### PR TITLE
feat: gate subscription room creators with policy

### DIFF
--- a/backend/hub/main.py
+++ b/backend/hub/main.py
@@ -29,6 +29,7 @@ from hub.routers.files import router as files_router
 from hub.routers.hub import router as hub_router
 from hub.routers.registry import router as registry_router
 from hub.routers.public import router as public_router
+from hub.routers.room import internal_router as room_internal_router
 from hub.routers.room import router as room_router
 from hub.routers.subscriptions import internal_router as subscriptions_internal_router
 from hub.routers.subscriptions import router as subscriptions_router
@@ -156,6 +157,7 @@ app.include_router(contacts_router)
 app.include_router(contact_requests_router)
 app.include_router(hub_router)
 app.include_router(room_router)
+app.include_router(room_internal_router)
 app.include_router(topics_router)
 app.include_router(files_router)
 app.include_router(wallet_router)

--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -177,6 +177,28 @@ class Room(Base):
     )
 
 
+class SubscriptionRoomCreatorPolicy(Base):
+    __tablename__ = "subscription_room_creator_policies"
+    __table_args__ = (
+        UniqueConstraint("agent_id", name="uq_subscription_room_creator_policy_agent"),
+        CheckConstraint("max_active_rooms >= 0", name="ck_subscription_room_creator_policy_nonneg"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    agent_id: Mapped[str] = mapped_column(
+        String(32), ForeignKey("agents.agent_id"), nullable=False, index=True
+    )
+    allowed_to_create: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    max_active_rooms: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    note: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+
 class RoomMember(Base):
     __tablename__ = "room_members"
     __table_args__ = (UniqueConstraint("room_id", "agent_id"),)

--- a/backend/hub/routers/room.py
+++ b/backend/hub/routers/room.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import time
 from collections import defaultdict, deque
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from hub.i18n import I18nHTTPException
 from sqlalchemy import select, func as sa_func
 from sqlalchemy.exc import IntegrityError
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from hub.auth import get_current_agent
+from hub import config as hub_config
 from hub.config import JOIN_RATE_LIMIT_PER_MINUTE
 from hub.database import get_db
 from hub.id_generators import generate_room_id
@@ -27,6 +28,7 @@ from hub.models import (
     RoomMember,
     RoomRole,
     RoomVisibility,
+    SubscriptionRoomCreatorPolicy,
     SubscriptionProduct,
 )
 from hub.schemas import (
@@ -39,12 +41,16 @@ from hub.schemas import (
     RoomMemberResponse,
     RoomPublicResponse,
     RoomResponse,
+    SubscriptionRoomCreatorPolicyListResponse,
+    SubscriptionRoomCreatorPolicyResponse,
+    SubscriptionRoomCreatorPolicyUpsertRequest,
     SetMemberPermissionsRequest,
     TransferRoomOwnerRequest,
     UpdateRoomRequest,
 )
 
 router = APIRouter(prefix="/hub/rooms", tags=["rooms"])
+internal_router = APIRouter(prefix="/internal/rooms", tags=["rooms-internal"])
 
 # ---------------------------------------------------------------------------
 # In-memory join rate-limit state: room_id → deque of timestamps
@@ -61,6 +67,19 @@ def _check_join_rate_limit(room_id: str) -> None:
     if len(window) >= JOIN_RATE_LIMIT_PER_MINUTE:
         raise I18nHTTPException(status_code=429, message_key="join_rate_limit_exceeded")
     window.append(now)
+
+
+def _require_internal(authorization: str | None = None):
+    if not hub_config.ALLOW_PRIVATE_ENDPOINTS:
+        raise HTTPException(status_code=403, detail="Internal endpoints are disabled")
+
+    expected = hub_config.INTERNAL_API_SECRET
+    if expected:
+        if not authorization or not authorization.startswith("Bearer "):
+            raise HTTPException(status_code=401, detail="Missing internal API secret")
+        provided = authorization.removeprefix("Bearer ").strip()
+        if provided != expected:
+            raise HTTPException(status_code=401, detail="Invalid internal API secret")
 
 
 # ---------------------------------------------------------------------------
@@ -237,6 +256,56 @@ async def _ensure_subscription_room_access(
         )
 
 
+def _subscription_room_creator_policy_response(
+    policy: SubscriptionRoomCreatorPolicy,
+) -> SubscriptionRoomCreatorPolicyResponse:
+    return SubscriptionRoomCreatorPolicyResponse(
+        agent_id=policy.agent_id,
+        allowed_to_create=policy.allowed_to_create,
+        max_active_rooms=policy.max_active_rooms,
+        note=policy.note,
+        created_at=policy.created_at,
+        updated_at=policy.updated_at,
+    )
+
+
+async def _enforce_subscription_room_creator_policy(
+    db: AsyncSession,
+    agent_id: str,
+    required_subscription_product_id: str | None,
+    *,
+    exclude_room_id: str | None = None,
+) -> None:
+    if not required_subscription_product_id:
+        return
+
+    result = await db.execute(
+        select(SubscriptionRoomCreatorPolicy).where(
+            SubscriptionRoomCreatorPolicy.agent_id == agent_id
+        )
+    )
+    policy = result.scalar_one_or_none()
+    if policy is None or not policy.allowed_to_create:
+        raise HTTPException(
+            status_code=403,
+            detail="Agent is not allowed to create subscription-gated rooms",
+        )
+
+    stmt = select(sa_func.count(Room.id)).where(
+        Room.owner_id == agent_id,
+        Room.required_subscription_product_id.is_not(None),
+    )
+    if exclude_room_id is not None:
+        stmt = stmt.where(Room.room_id != exclude_room_id)
+    room_count_result = await db.execute(stmt)
+    active_room_count = room_count_result.scalar() or 0
+    if active_room_count >= policy.max_active_rooms:
+        raise HTTPException(
+            status_code=403,
+            detail="Subscription-gated room quota exceeded",
+        )
+
+
 async def _ensure_existing_members_match_subscription_requirement(
     db: AsyncSession,
     room: Room,
@@ -283,6 +352,9 @@ async def create_room(
     """Create a new room. Creator becomes the owner."""
     _validate_subscription_room_config(
         body.visibility, body.join_policy, body.required_subscription_product_id
+    )
+    await _enforce_subscription_room_creator_policy(
+        db, current_agent, body.required_subscription_product_id
     )
     await _ensure_room_subscription_product(
         db, current_agent, body.required_subscription_product_id
@@ -371,6 +443,92 @@ async def create_room(
 
     room = await _load_room(db, room.room_id, fresh=True)
     return _build_room_response(room)
+
+
+@internal_router.put(
+    "/subscription-room-policies/{agent_id}",
+    response_model=SubscriptionRoomCreatorPolicyResponse,
+)
+async def upsert_subscription_room_creator_policy(
+    agent_id: str,
+    body: SubscriptionRoomCreatorPolicyUpsertRequest,
+    db: AsyncSession = Depends(get_db),
+    authorization: str | None = Header(default=None),
+):
+    _require_internal(authorization)
+
+    result = await db.execute(select(Agent).where(Agent.agent_id == agent_id))
+    if result.scalar_one_or_none() is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+    result = await db.execute(
+        select(SubscriptionRoomCreatorPolicy).where(
+            SubscriptionRoomCreatorPolicy.agent_id == agent_id
+        )
+    )
+    policy = result.scalar_one_or_none()
+    if policy is None:
+        policy = SubscriptionRoomCreatorPolicy(
+            agent_id=agent_id,
+            allowed_to_create=body.allowed_to_create,
+            max_active_rooms=body.max_active_rooms,
+            note=body.note,
+        )
+        db.add(policy)
+    else:
+        policy.allowed_to_create = body.allowed_to_create
+        policy.max_active_rooms = body.max_active_rooms
+        policy.note = body.note
+
+    await db.commit()
+    await db.refresh(policy)
+    return _subscription_room_creator_policy_response(policy)
+
+
+@internal_router.get(
+    "/subscription-room-policies/{agent_id}",
+    response_model=SubscriptionRoomCreatorPolicyResponse,
+)
+async def get_subscription_room_creator_policy(
+    agent_id: str,
+    db: AsyncSession = Depends(get_db),
+    authorization: str | None = Header(default=None),
+):
+    _require_internal(authorization)
+
+    result = await db.execute(
+        select(SubscriptionRoomCreatorPolicy).where(
+            SubscriptionRoomCreatorPolicy.agent_id == agent_id
+        )
+    )
+    policy = result.scalar_one_or_none()
+    if policy is None:
+        raise HTTPException(status_code=404, detail="Subscription room creator policy not found")
+    return _subscription_room_creator_policy_response(policy)
+
+
+@internal_router.get(
+    "/subscription-room-policies",
+    response_model=SubscriptionRoomCreatorPolicyListResponse,
+)
+async def list_subscription_room_creator_policies(
+    db: AsyncSession = Depends(get_db),
+    authorization: str | None = Header(default=None),
+):
+    _require_internal(authorization)
+
+    result = await db.execute(
+        select(SubscriptionRoomCreatorPolicy).order_by(
+            SubscriptionRoomCreatorPolicy.created_at.desc()
+        )
+    )
+    policies = list(result.scalars().all())
+    return SubscriptionRoomCreatorPolicyListResponse(
+        policies=[
+            _subscription_room_creator_policy_response(policy)
+            for policy in policies
+        ]
+    )
 
 
 @router.get("", response_model=RoomDiscoveryResponse)
@@ -472,6 +630,12 @@ async def update_room(
 
         _validate_subscription_room_config(
             room.visibility, room.join_policy, room.required_subscription_product_id
+        )
+        await _enforce_subscription_room_creator_policy(
+            db,
+            room.owner_id,
+            room.required_subscription_product_id,
+            exclude_room_id=room.room_id,
         )
         await _ensure_room_subscription_product(
             db, room.owner_id, room.required_subscription_product_id

--- a/backend/hub/schemas.py
+++ b/backend/hub/schemas.py
@@ -479,6 +479,25 @@ class RoomListResponse(BaseModel):
     rooms: list[RoomResponse]
 
 
+class SubscriptionRoomCreatorPolicyUpsertRequest(BaseModel):
+    allowed_to_create: bool = False
+    max_active_rooms: int = Field(..., ge=0)
+    note: str | None = None
+
+
+class SubscriptionRoomCreatorPolicyResponse(BaseModel):
+    agent_id: str
+    allowed_to_create: bool
+    max_active_rooms: int
+    note: str | None = None
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+
+
+class SubscriptionRoomCreatorPolicyListResponse(BaseModel):
+    policies: list[SubscriptionRoomCreatorPolicyResponse]
+
+
 # --- Dashboard schemas ---
 
 

--- a/backend/migrations/011_create_subscription_room_creator_policies.sql
+++ b/backend/migrations/011_create_subscription_room_creator_policies.sql
@@ -1,0 +1,16 @@
+-- Migration: subscription-gated room creator whitelist and quota policy
+
+CREATE TABLE IF NOT EXISTS subscription_room_creator_policies (
+    id SERIAL PRIMARY KEY,
+    agent_id VARCHAR(32) NOT NULL REFERENCES agents(agent_id),
+    allowed_to_create BOOLEAN NOT NULL DEFAULT FALSE,
+    max_active_rooms INTEGER NOT NULL DEFAULT 0,
+    note TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    CONSTRAINT uq_subscription_room_creator_policy_agent UNIQUE (agent_id),
+    CONSTRAINT ck_subscription_room_creator_policy_nonneg CHECK (max_active_rooms >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS ix_subscription_room_creator_policies_agent_id
+    ON subscription_room_creator_policies(agent_id);

--- a/backend/tests/test_subscription.py
+++ b/backend/tests/test_subscription.py
@@ -113,6 +113,27 @@ async def _set_open_policy(client: AsyncClient, agent_id: str, token: str):
     assert resp.status_code == 200
 
 
+async def _set_subscription_room_policy(
+    client: AsyncClient,
+    agent_id: str,
+    *,
+    allowed_to_create: bool,
+    max_active_rooms: int,
+    note: str | None = None,
+):
+    payload = {
+        "allowed_to_create": allowed_to_create,
+        "max_active_rooms": max_active_rooms,
+        "note": note,
+    }
+    resp = await client.put(
+        f"/internal/rooms/subscription-room-policies/{agent_id}",
+        json=payload,
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
 async def _create_product(
     client: AsyncClient,
     token: str,
@@ -213,7 +234,7 @@ async def test_create_product_and_list(client: AsyncClient):
 async def test_subscribe_charges_first_period_immediately(client: AsyncClient):
     sk_provider, pub_provider = _make_keypair()
     sk_subscriber, pub_subscriber = _make_keypair()
-    _, provider_token = await _register_and_verify(client, sk_provider, pub_provider, "Provider")
+    provider_id, provider_token = await _register_and_verify(client, sk_provider, pub_provider, "Provider")
     subscriber_id, subscriber_token = await _register_and_verify(client, sk_subscriber, pub_subscriber, "Subscriber")
 
     product = await _create_product(
@@ -478,6 +499,9 @@ async def test_subscribe_auto_joins_bound_private_room(client: AsyncClient):
         amount_minor=10000,
         billing_interval="week",
     )
+    await _set_subscription_room_policy(
+        client, provider_id, allowed_to_create=True, max_active_rooms=5
+    )
     room = await _create_room(
         client,
         provider_token,
@@ -500,7 +524,7 @@ async def test_subscribe_auto_joins_bound_private_room(client: AsyncClient):
 async def test_cancel_subscription_revokes_gated_room_access(client: AsyncClient):
     sk_provider, pub_provider = _make_keypair()
     sk_subscriber, pub_subscriber = _make_keypair()
-    _, provider_token = await _register_and_verify(client, sk_provider, pub_provider, "Provider")
+    provider_id, provider_token = await _register_and_verify(client, sk_provider, pub_provider, "Provider")
     _, subscriber_token = await _register_and_verify(client, sk_subscriber, pub_subscriber, "Subscriber")
 
     product = await _create_product(
@@ -509,6 +533,9 @@ async def test_cancel_subscription_revokes_gated_room_access(client: AsyncClient
         name="Cancelable Room Access",
         amount_minor=10000,
         billing_interval="week",
+    )
+    await _set_subscription_room_policy(
+        client, provider_id, allowed_to_create=True, max_active_rooms=5
     )
     room = await _create_room(
         client,
@@ -547,6 +574,9 @@ async def test_subscription_gated_room_blocks_unsubscribed_invite(client: AsyncC
         name="Invite Gated Access",
         amount_minor=5000,
         billing_interval="week",
+    )
+    await _set_subscription_room_policy(
+        client, provider_id, allowed_to_create=True, max_active_rooms=5
     )
     room = await _create_room(
         client,
@@ -588,6 +618,9 @@ async def test_update_room_rejects_enabling_subscription_gate_with_unsubscribed_
         amount_minor=5000,
         billing_interval="week",
     )
+    await _set_subscription_room_policy(
+        client, provider_id, allowed_to_create=True, max_active_rooms=5
+    )
     room = await _create_room(
         client,
         provider_token,
@@ -628,6 +661,9 @@ async def test_gated_room_transfer_ownership_requires_product_owner(client: Asyn
         amount_minor=5000,
         billing_interval="week",
     )
+    await _set_subscription_room_policy(
+        client, provider_id, allowed_to_create=True, max_active_rooms=5
+    )
     room = await _create_room(
         client,
         provider_token,
@@ -652,8 +688,8 @@ async def test_gated_room_transfer_ownership_requires_product_owner(client: Asyn
 async def test_room_owner_must_own_required_subscription_product(client: AsyncClient):
     sk_provider, pub_provider = _make_keypair()
     sk_other, pub_other = _make_keypair()
-    _, provider_token = await _register_and_verify(client, sk_provider, pub_provider, "Provider")
-    _, other_token = await _register_and_verify(client, sk_other, pub_other, "Other")
+    provider_id, provider_token = await _register_and_verify(client, sk_provider, pub_provider, "Provider")
+    other_id, other_token = await _register_and_verify(client, sk_other, pub_other, "Other")
 
     product = await _create_product(
         client,
@@ -661,6 +697,12 @@ async def test_room_owner_must_own_required_subscription_product(client: AsyncCl
         name="Owner Scoped Product",
         amount_minor=5000,
         billing_interval="week",
+    )
+    await _set_subscription_room_policy(
+        client, provider_id, allowed_to_create=True, max_active_rooms=5
+    )
+    await _set_subscription_room_policy(
+        client, other_id, allowed_to_create=True, max_active_rooms=5
     )
 
     resp = await client.post(
@@ -673,3 +715,118 @@ async def test_room_owner_must_own_required_subscription_product(client: AsyncCl
     )
     assert resp.status_code == 403
     assert "must own" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_internal_subscription_room_policy_upsert_and_list(client: AsyncClient):
+    sk_provider, pub_provider = _make_keypair()
+    provider_id, _provider_token = await _register_and_verify(client, sk_provider, pub_provider, "Provider")
+
+    resp = await client.put(
+        f"/internal/rooms/subscription-room-policies/{provider_id}",
+        json={
+            "allowed_to_create": True,
+            "max_active_rooms": 3,
+            "note": "pilot allowlist",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["agent_id"] == provider_id
+    assert resp.json()["allowed_to_create"] is True
+    assert resp.json()["max_active_rooms"] == 3
+
+    resp = await client.get(f"/internal/rooms/subscription-room-policies/{provider_id}")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["note"] == "pilot allowlist"
+
+    resp = await client.get("/internal/rooms/subscription-room-policies")
+    assert resp.status_code == 200, resp.text
+    assert any(policy["agent_id"] == provider_id for policy in resp.json()["policies"])
+
+
+@pytest.mark.asyncio
+async def test_subscription_gated_room_requires_creator_policy(client: AsyncClient):
+    sk_provider, pub_provider = _make_keypair()
+    provider_id, provider_token = await _register_and_verify(client, sk_provider, pub_provider, "Provider")
+
+    product = await _create_product(
+        client,
+        provider_token,
+        name="Policy Required Product",
+        amount_minor=5000,
+        billing_interval="week",
+    )
+
+    resp = await client.post(
+        "/hub/rooms",
+        json={
+            "name": "Blocked Premium Room",
+            "required_subscription_product_id": product["product_id"],
+        },
+        headers=_auth(provider_token),
+    )
+    assert resp.status_code == 403
+    assert "not allowed" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_update_room_to_subscription_gate_requires_creator_policy(client: AsyncClient):
+    sk_provider, pub_provider = _make_keypair()
+    provider_id, provider_token = await _register_and_verify(client, sk_provider, pub_provider, "Provider")
+
+    product = await _create_product(
+        client,
+        provider_token,
+        name="Policy Required Update Product",
+        amount_minor=5000,
+        billing_interval="week",
+    )
+    room = await _create_room(
+        client,
+        provider_token,
+        name="Plain Private Room",
+    )
+
+    resp = await client.patch(
+        f"/hub/rooms/{room['room_id']}",
+        json={"required_subscription_product_id": product["product_id"]},
+        headers=_auth(provider_token),
+    )
+    assert resp.status_code == 403
+    assert "not allowed" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_subscription_gated_room_quota_enforced(client: AsyncClient):
+    sk_provider, pub_provider = _make_keypair()
+    provider_id, provider_token = await _register_and_verify(client, sk_provider, pub_provider, "Provider")
+
+    product = await _create_product(
+        client,
+        provider_token,
+        name="Quota Product",
+        amount_minor=5000,
+        billing_interval="week",
+    )
+    await _set_subscription_room_policy(
+        client, provider_id, allowed_to_create=True, max_active_rooms=1
+    )
+
+    room_one = await _create_room(
+        client,
+        provider_token,
+        name="First Gated Room",
+        required_subscription_product_id=product["product_id"],
+    )
+    assert room_one["required_subscription_product_id"] == product["product_id"]
+
+    resp = await client.post(
+        "/hub/rooms",
+        json={
+            "name": "Second Gated Room",
+            "required_subscription_product_id": product["product_id"],
+        },
+        headers=_auth(provider_token),
+    )
+    assert resp.status_code == 403
+    assert "quota exceeded" in resp.json()["detail"]


### PR DESCRIPTION
## Summary

- add a whitelist/quota policy table for subscription-gated room creators
- enforce creator policy on gated room create and update flows
- expose internal policy management endpoints for upsert/get/list
- add migration SQL and regression tests for allowlist and quota behavior

## Testing

- `uv run pytest tests/test_subscription.py -q`
- `uv run pytest tests/test_room.py -q`
