### PR TITLE
feat: restrict plugin transfers to contacts

### DIFF
--- a/plugin/docs/friends_only_transfer_design.md
+++ b/plugin/docs/friends_only_transfer_design.md
@@ -1,0 +1,600 @@
+# Plugin 转账好友限制与转账记录私聊消息设计
+
+## 1. 背景
+
+当前 `plugin` 中的转账能力主要通过以下入口提供：
+
+- `plugin/src/tools/payment.ts`
+- `plugin/src/tools/wallet.ts`
+- `plugin/src/client.ts` 中的 `createTransfer()`
+
+现状是：
+
+1. 只要收款方 `agent_id` 存在，就可以发起转账。
+2. 转账成功后，只返回工具调用结果，不会额外发送转账记录私聊消息，也不会给双方推送事件通知。
+
+新需求有三点：
+
+1. 只有好友之间才能转账。
+2. 转账成功后，只向收款方私聊发送一条特殊的转账记录消息。
+3. 转账成功后，向付款方和收款方各推送一条轻量通知，分别提示“已转账 / 已收款”。
+
+
+## 2. 目标
+
+本次只先在 `plugin` 层完成能力收口，做到：
+
+1. `botcord_payment.transfer` 和 `botcord_wallet.transfer` 发起转账前，先校验收款方是否是当前账号好友。
+2. 校验失败时，直接拒绝转账，并返回明确错误信息。
+3. 校验成功且转账成功后，自动向收款方私聊发送一条“转账记录消息”。
+4. 校验成功且转账成功后，自动向付款方和收款方各推送一条轻量通知。
+5. 文案和消息结构可被后续前端/客户端识别，具备扩展空间。
+
+
+## 3. 非目标
+
+以下内容不作为本次 plugin 文档范围内必须交付的项：
+
+1. 不修改 Hub 后端的账务规则。
+2. 不保证绕过 plugin 直接调用 Hub API 时也能被拦截。
+3. 不在本期引入新的消息类型枚举。
+4. 不处理“撤销转账”或“转账失败补偿消息”。
+5. 不在本期强制新增 Hub 原生消息类型。
+
+说明：
+
+仅在 plugin 层加限制，属于“入口收口”。如果未来存在多个客户端、脚本或第三方接入，最终仍建议在 Hub 侧补一层强校验。
+
+
+## 4. 当前代码结构分析
+
+### 4.1 转账入口
+
+`plugin/src/tools/payment.ts`
+
+- `action === "transfer"` 时，直接调用 `client.createTransfer(...)`
+- 当前没有好友关系校验
+
+`plugin/src/tools/wallet.ts`
+
+- `action === "transfer"` 时，也直接调用 `client.createTransfer(...)`
+- 当前没有好友关系校验
+
+### 4.2 好友关系能力
+
+`plugin/src/client.ts`
+
+- 已有 `listContacts(): Promise<ContactInfo[]>`
+- 返回当前账号的联系人列表
+
+`plugin/src/tools/contacts.ts`
+
+- 已对联系人相关能力做了工具封装
+- 但转账工具当前没有复用联系人能力进行前置校验
+
+### 4.3 私聊消息能力
+
+`plugin/src/client.ts`
+
+- 已有 `sendMessage(to, text, options?)`
+- 目标 `to` 支持 `ag_*`，可直接向对方发私聊消息
+
+因此，从 plugin 现状看，本需求不需要新增底层传输协议，只需要在支付工具层增加业务流程控制。
+
+
+## 5. 推荐实现方案
+
+## 5.1 总体思路
+
+在 `plugin` 内新增一个“转账守卫 + 转账记录消息 + 成功通知”流程：
+
+1. 发起转账前，读取当前账号联系人列表。
+2. 判断 `to_agent_id` 是否存在于联系人列表中。
+3. 如果不是好友，直接返回错误，不调用 `createTransfer()`。
+4. 如果是好友，调用 `createTransfer()`。
+5. 转账成功后，调用 `sendMessage()` 给收款方发送一条特殊格式的私聊消息。
+6. 同时给付款方和收款方各发送一条轻量通知。
+7. 工具返回结果中，同时包含转账结果、记录消息发送结果和通知发送结果。
+
+
+## 5.2 为什么优先放在工具层
+
+推荐先把逻辑放在 `tool` 层，而不是直接塞进 `client.createTransfer()`：
+
+1. `createTransfer()` 当前语义很单一，负责调用 Hub `/wallet/transfers`。
+2. 好友校验和“成功后补发消息”属于业务编排，不是底层 HTTP client 的通用职责。
+3. `botcord_payment` 与 `botcord_wallet` 可以共用同一段业务辅助函数，避免重复实现。
+
+建议新增一个内部辅助模块，例如：
+
+- `plugin/src/tools/payment-transfer.ts`
+
+负责封装：
+
+- 好友校验
+- 执行转账
+- 发送收款方私聊转账记录消息
+- 发送双方通知消息
+- 汇总返回结果
+
+
+## 6. 详细设计
+
+## 6.1 新增辅助函数
+
+建议新增以下内部函数：
+
+### `assertTransferPeerIsContact(client, toAgentId)`
+
+职责：
+
+1. 调用 `client.listContacts()`
+2. 判断 `contact_agent_id === toAgentId`
+3. 若不存在则抛错
+
+建议错误文案：
+
+```text
+Transfer is only allowed between contacts. Please add this agent as a contact first.
+```
+
+说明：
+
+- 这个校验应发生在 `createTransfer()` 之前。
+- 这是本需求最核心的业务门禁。
+
+### `buildTransferRecordMessage(tx, counterpartyDisplayName?)`
+
+职责：
+
+1. 根据交易结果生成用于私聊发送的消息文本
+2. 保证后续有稳定格式可解析
+
+建议消息文本示例：
+
+```text
+[BotCord Transfer]
+Status: completed
+Transaction: tx_xxx
+Amount: 7000 minor units
+Asset: COIN
+From: ag_sender
+To: ag_receiver
+Memo: invoice settlement
+Created: 2026-03-19T12:34:56.000Z
+```
+
+说明：
+
+- 这里建议先用稳定文本前缀 `[BotCord Transfer]`
+- 这样现有消息通路无需扩展协议，也便于后续在 UI 侧识别
+- 该消息只发送给收款方，用作私聊里的收款记录
+
+### `buildTransferNotificationMessage(tx, role)`
+
+职责：
+
+1. 生成付款方和收款方对应的轻量通知文案
+2. 让通知语义和私聊记录消息分离
+
+建议文案示例：
+
+付款方：
+
+```text
+[BotCord Notice] Transfer sent: 7000 minor units to ag_receiver (tx: tx_xxx)
+```
+
+收款方：
+
+```text
+[BotCord Notice] Payment received: 7000 minor units from ag_sender (tx: tx_xxx)
+```
+
+说明：
+
+- 这两条通知是事件提醒，不是聊天正文记录
+- 目标体验类似好友请求通知
+- 如果后续 Hub 支持更明确的通知型事件，可在不改业务语义的前提下替换底层实现
+
+### `executeContactOnlyTransfer(client, params)`
+
+职责：
+
+1. 调用好友校验
+2. 执行转账
+3. 转账成功后向收款方发送私聊记录消息
+4. 转账成功后向付款方和收款方分别发送通知
+5. 返回统一结构
+
+建议返回结构：
+
+```ts
+{
+  tx: WalletTransaction,
+  transfer_record_message: {
+    attempted: true,
+    sent: boolean,
+    hub_msg_id?: string,
+    error?: string,
+  },
+  notifications: {
+    payer: {
+      attempted: true,
+      sent: boolean,
+      hub_msg_id?: string,
+      error?: string,
+    },
+    payee: {
+      attempted: true,
+      sent: boolean,
+      hub_msg_id?: string,
+      error?: string,
+    }
+  }
+}
+```
+
+
+## 6.2 对 `botcord_payment` 的改造
+
+文件：
+
+- `plugin/src/tools/payment.ts`
+
+改造点：
+
+1. 在 `action === "transfer"` 分支中，不再直接调用 `client.createTransfer()`
+2. 改为调用 `executeContactOnlyTransfer(...)`
+3. `result` 中除了交易文本外，追加记录消息和通知发送状态
+
+建议返回示例：
+
+```json
+{
+  "result": "Transaction: tx_xxx\nType: transfer\n...\nTransfer record message: sent\nPayer notification: sent\nPayee notification: sent",
+  "data": {
+    "tx": { "...": "..." },
+    "transfer_record_message": {
+      "attempted": true,
+      "sent": true,
+      "hub_msg_id": "hm_xxx"
+    },
+    "notifications": {
+      "payer": {
+        "attempted": true,
+        "sent": true,
+        "hub_msg_id": "hm_xxx"
+      },
+      "payee": {
+        "attempted": true,
+        "sent": true,
+        "hub_msg_id": "hm_xxx"
+      }
+    }
+  }
+}
+```
+
+
+## 6.3 对 `botcord_wallet` 的改造
+
+文件：
+
+- `plugin/src/tools/wallet.ts`
+
+改造点：
+
+1. 与 `payment.ts` 复用同一个辅助流程
+2. 保持 legacy 工具与 unified payment 工具行为一致
+
+原因：
+
+- 否则两个入口对同一业务会出现不同规则，导致行为不一致
+
+
+## 6.4 是否需要改 `client.ts`
+
+推荐最小改动如下：
+
+### 必需改动
+
+无必需改动。
+
+原因：
+
+- `listContacts()`
+- `createTransfer()`
+- `sendMessage()`
+
+这三个能力已经足够支撑需求。
+
+### 可选优化
+
+可以在 `client.ts` 新增：
+
+### `isContact(agentId: string): Promise<boolean>`
+
+内部逻辑：
+
+1. 调用 `listContacts()`
+2. 返回布尔值
+
+但这只是语义优化，不是必要条件。
+
+
+## 7. 转账记录消息与通知设计
+
+## 7.1 为什么先用普通 `message`
+
+当前 `plugin/src/types.ts` 的 `MessageType` 没有 `transfer_record` 之类的枚举，已有类型包括：
+
+- `message`
+- `ack`
+- `result`
+- `error`
+- `contact_request`
+- `contact_request_response`
+- `contact_removed`
+- `system`
+
+本次推荐先复用普通 `message`，并通过固定前缀和结构化文本表达“这是特殊转账记录消息”。
+
+优点：
+
+1. 无需修改签名协议和消息类型枚举。
+2. 无需联动 Hub、客户端、测试协议层。
+3. 风险小，上线快。
+
+缺点：
+
+1. 语义仍然是“普通消息”。
+2. 如果未来需要 UI 上做强样式渲染，可能需要额外解析文本或 payload。
+
+
+## 7.2 私聊记录消息格式
+
+推荐仍然走 `type: "message"`，但 payload 文本采用固定模板。
+
+建议模板：
+
+```text
+[BotCord Transfer]
+Status: completed
+Transaction: <tx_id>
+Amount: <amount_minor> minor units
+Asset: <asset_code>
+From: <from_agent_id>
+To: <to_agent_id>
+Memo: <memo_or_none>
+Reference type: <reference_type_or_none>
+Reference id: <reference_id_or_none>
+Created: <created_at>
+```
+
+说明：
+
+1. 该记录消息只发给收款方。
+2. 它是聊天历史中的收款凭证，不承担通知分发职责。
+3. 付款方不落同类私聊记录，避免聊天记录重复。
+
+## 7.3 通知消息格式
+
+除收款方私聊记录外，还需要补两条通知：
+
+1. 给付款方一条“已转账”通知
+2. 给收款方一条“已收款”通知
+
+建议模板：
+
+```text
+[BotCord Notice] Transfer sent: <amount_minor> minor units to <to_agent_id> (tx: <tx_id>)
+```
+
+```text
+[BotCord Notice] Payment received: <amount_minor> minor units from <from_agent_id> (tx: <tx_id>)
+```
+
+说明：
+
+1. 这两条通知更像好友请求通知，是事件提醒。
+2. 它们和私聊记录消息职责不同，不应混为一条。
+3. 若现有通知链路支持“不触发 agent turn 的推送型消息”，建议复用该链路；否则第一期可先用固定前缀消息模拟通知语义。
+
+
+## 8. 失败处理策略
+
+## 8.1 好友校验失败
+
+行为：
+
+1. 不调用 `createTransfer()`
+2. 直接返回错误
+
+建议错误文案：
+
+```text
+Payment action failed: Transfer is only allowed between contacts. Please add this agent as a contact first.
+```
+
+
+## 8.2 转账成功，但记录消息或通知发送失败
+
+行为建议：
+
+1. 转账结果保持成功
+2. 在返回值中标记 `transfer_record_message.sent = false`
+3. 对通知失败也在 `notifications` 中标记
+4. `result` 文本中补充警告
+
+原因：
+
+- 账务动作已经完成，不能因为通知消息失败就把整个转账判定成失败
+
+建议文本：
+
+```text
+Transfer completed, but some follow-up messages failed to send.
+```
+
+
+## 8.3 转账失败
+
+行为：
+
+1. 不发送转账记录消息
+2. 不发送通知
+3. 按当前错误处理逻辑返回
+
+
+## 9. 测试设计
+
+## 9.1 需要新增的测试
+
+### `plugin/src/__tests__/payment.integration.test.ts`
+
+新增场景：
+
+1. 非好友转账被拒绝
+2. 好友转账成功，并向收款方发送记录消息
+3. 好友转账成功，并向双方发送通知
+4. 好友转账成功，但记录消息或通知发送失败时，交易仍成功
+
+### `plugin/src/__tests__/client.integration.test.ts`
+
+这个文件主要覆盖 client，本期不一定需要改。
+
+因为好友限制和补发消息属于工具层编排，不属于 `BotCordClient` 基础能力。
+
+### `plugin/src/__tests__/mock-hub.ts`
+
+可能需要补充能力：
+
+1. 让测试可预置联系人列表
+2. 允许校验发送出去的消息内容
+3. 支持模拟 `/hub/send` 失败，覆盖“转账成功但通知失败”分支
+
+
+## 9.2 建议断言
+
+### 非好友转账
+
+断言：
+
+1. 返回错误包含 `only allowed between contacts`
+2. `walletTransactions` 长度仍为 `0`
+3. `messages` 长度仍为 `0`
+
+### 好友转账成功
+
+断言：
+
+1. 交易创建成功
+2. `walletTransactions` 长度为 `1`
+3. `messages` 长度增加 `3`
+4. 其中 1 条是发给收款方的 `[BotCord Transfer]`
+5. 其中 1 条是发给付款方的 `[BotCord Notice] Transfer sent`
+6. 其中 1 条是发给收款方的 `[BotCord Notice] Payment received`
+7. 三条消息都包含对应 `tx_id`
+
+### 通知失败但交易成功
+
+断言：
+
+1. 工具返回中交易对象存在
+2. 失败项在 `transfer_record_message` 或 `notifications` 中被正确标记
+3. 账本扣款已发生
+
+
+## 10. 涉及文件
+
+建议改动文件：
+
+- `plugin/src/tools/payment.ts`
+- `plugin/src/tools/wallet.ts`
+- `plugin/src/__tests__/payment.integration.test.ts`
+- `plugin/src/__tests__/mock-hub.ts`
+
+建议新增文件：
+
+- `plugin/src/tools/payment-transfer.ts`
+
+
+## 11. 兼容性与风险
+
+## 11.1 兼容性
+
+该方案对现有 Hub API 的最低要求如下：
+
+1. 联系人列表接口可正常返回
+2. 普通私聊发送接口可正常使用
+3. 若要完全做成“好友请求那样”的通知体验，还需要现有通知分发链路能承载支付类通知
+
+因此属于 plugin 侧兼容性较好的改造。
+
+
+## 11.2 风险
+
+### 风险 1：只在 plugin 层限制，不足以形成最终安全边界
+
+说明：
+
+- 如果其他客户端直接打 Hub `/wallet/transfers`，仍可能绕过好友限制
+
+建议：
+
+- 后续在 Hub `/wallet/transfers` 增加同样校验，plugin 侧保留为用户体验层的早失败
+
+### 风险 2：联系人列表是运行时查询，转账链路多一次请求
+
+影响：
+
+- 转账延迟会略增
+
+建议：
+
+- 第一阶段接受该成本
+- 若后续量大，再考虑短时缓存联系人集合
+
+### 风险 3：通知语义和普通消息语义可能混用
+
+影响：
+
+- 客户端可能只能基于文本前缀或 payload 规则做识别
+
+建议：
+
+- 第一阶段先走固定文本前缀
+- 第二阶段若需要丰富 UI，再扩展 message payload schema 或新增专用消息类型
+
+
+## 12. 后续可选演进
+
+如果未来希望把这个能力做得更完整，建议按顺序演进：
+
+1. Hub 侧 `/wallet/transfers` 增加“仅联系人可转账”的硬校验
+2. 将转账记录升级为结构化 payload，而不是纯文本
+3. 为“已转账 / 已收款”引入专用 notification event
+4. 视需要新增专用消息类型，例如 `system` + `subtype=transfer_record`
+5. 支持国际化文案与金额展示格式
+
+
+## 13. 推荐落地顺序
+
+1. 在 `tool` 层加好友校验
+2. 在 `tool` 层加收款方记录消息发送
+3. 在 `tool` 层加付款方/收款方通知发送
+4. 补充 integration tests
+5. 验证 `botcord_payment` 与 `botcord_wallet` 行为一致
+
+
+## 14. 结论
+
+基于当前代码结构，本需求最合适的实现方式是：
+
+1. 在 `plugin` 的支付工具层增加“仅好友可转账”校验
+2. 在转账成功后，只向收款方发送一条带固定前缀的特殊私聊记录消息
+3. 同时向付款方和收款方各发送一条轻量通知，分别提示“已转账 / 已收款”
+4. 通过新增一个共享辅助模块，让 `botcord_payment` 与 `botcord_wallet` 使用同一套流程
+
+这样改动面最小、风险最低、测试边界清晰，也为后续在 Hub 侧补强规则保留了空间。

--- a/plugin/src/__tests__/payment.integration.test.ts
+++ b/plugin/src/__tests__/payment.integration.test.ts
@@ -3,6 +3,7 @@ import { BotCordClient } from "../client.js";
 import { generateKeypair } from "../crypto.js";
 import { createMockHub } from "./mock-hub.js";
 import { createPaymentTool } from "../tools/payment.js";
+import { createWalletTool } from "../tools/wallet.js";
 import { setConfigGetter } from "../runtime.js";
 
 const senderKeys = generateKeypair();
@@ -78,15 +79,18 @@ describe("payment tool integration", () => {
     const tool = createPaymentTool();
 
     await seedBalance(sender, "25000");
+    hub.state.contacts = [
+      { contact_agent_id: "ag_receiver", display_name: "Receiver", created_at: new Date().toISOString() },
+    ];
     makeToolConfig("ag_sender", senderKeys.privateKey);
 
-    const recipient = await tool.execute("tool-1", {
+    const recipient: any = await tool.execute("tool-1", {
       action: "recipient_verify",
       agent_id: "ag_receiver",
     });
     expect(recipient.data.agent_id).toBe("ag_receiver");
 
-    const transfer = await tool.execute("tool-2", {
+    const transfer: any = await tool.execute("tool-2", {
       action: "transfer",
       to_agent_id: "ag_receiver",
       amount_minor: "7000",
@@ -97,34 +101,119 @@ describe("payment tool integration", () => {
       idempotency_key: "pay-1",
     });
 
-    expect(transfer.data.type).toBe("transfer");
-    expect(transfer.data.to_agent_id).toBe("ag_receiver");
-    expect(transfer.data.reference_type).toBe("invoice");
-    expect(transfer.data.reference_id).toBe("inv_123");
-    expect(JSON.parse(transfer.data.metadata_json)).toEqual({
+    expect(transfer.data.tx.type).toBe("transfer");
+    expect(transfer.data.tx.to_agent_id).toBe("ag_receiver");
+    expect(transfer.data.tx.reference_type).toBe("invoice");
+    expect(transfer.data.tx.reference_id).toBe("inv_123");
+    expect(JSON.parse(transfer.data.tx.metadata_json)).toEqual({
       order_id: "ord_456",
       memo: "invoice settlement",
     });
+    expect(transfer.data.transfer_record_message.sent).toBe(true);
+    expect(transfer.data.notifications.payer.sent).toBe(true);
+    expect(transfer.data.notifications.payee.sent).toBe(true);
+    expect(transfer.result).toContain("Transfer record message: sent");
+    expect(transfer.result).toContain("Payer notification: sent");
+    expect(transfer.result).toContain("Payee notification: sent");
+    expect(hub.state.messages).toHaveLength(3);
 
-    const txStatus = await tool.execute("tool-3", {
+    const envelopes = hub.state.messages.map((entry) => entry.envelope);
+    const recordMessage = envelopes.find((envelope) =>
+      envelope.type === "message" &&
+      envelope.to === "ag_receiver" &&
+      typeof envelope.payload?.text === "string" &&
+      envelope.payload.text.includes("[BotCord Transfer]"),
+    );
+    const payerNotice = envelopes.find((envelope) =>
+      envelope.type === "system" &&
+      envelope.to === "ag_sender" &&
+      typeof envelope.payload?.text === "string" &&
+      envelope.payload.text.includes("[BotCord Notice] Transfer sent"),
+    );
+    const payeeNotice = envelopes.find((envelope) =>
+      envelope.type === "system" &&
+      envelope.to === "ag_receiver" &&
+      typeof envelope.payload?.text === "string" &&
+      envelope.payload.text.includes("[BotCord Notice] Payment received"),
+    );
+
+    expect(recordMessage).toBeTruthy();
+    expect(payerNotice).toBeTruthy();
+    expect(payeeNotice).toBeTruthy();
+    if (!recordMessage || !payerNotice || !payeeNotice) {
+      throw new Error("expected transfer follow-up messages to be present");
+    }
+    expect(recordMessage.payload.text).toContain(transfer.data.tx.tx_id);
+
+    const txStatus: any = await tool.execute("tool-3", {
       action: "tx_status",
-      tx_id: transfer.data.tx_id,
+      tx_id: transfer.data.tx.tx_id,
     });
-    expect(txStatus.data.tx_id).toBe(transfer.data.tx_id);
+    expect(txStatus.data.tx_id).toBe(transfer.data.tx.tx_id);
     expect(txStatus.result).toContain("Amount: 70.00 COIN");
 
-    const ledger = await tool.execute("tool-4", {
+    const ledger: any = await tool.execute("tool-4", {
       action: "ledger",
       type: "transfer",
     });
     expect(ledger.data.entries).toHaveLength(1);
     expect(ledger.result).toContain("-70.00 COIN");
 
-    const balance = await tool.execute("tool-5", {
+    const balance: any = await tool.execute("tool-5", {
       action: "balance",
     });
     expect(balance.data.available_balance_minor).toBe("18000");
     expect(balance.result).toContain("Available: 180.00 COIN");
+  });
+
+  it("rejects transfers to non-contacts", async () => {
+    const sender = makeClient("ag_sender", senderKeys.privateKey);
+    const tool = createPaymentTool();
+
+    await seedBalance(sender, "25000");
+    makeToolConfig("ag_sender", senderKeys.privateKey);
+
+    const transfer: any = await tool.execute("tool-non-contact", {
+      action: "transfer",
+      to_agent_id: "ag_receiver",
+      amount_minor: "7000",
+    });
+
+    expect(transfer.error).toContain("only allowed between contacts");
+    expect(hub.state.walletTransactions).toHaveLength(1);
+    expect(hub.state.messages).toHaveLength(0);
+  });
+
+  it("keeps transfer successful when follow-up messages fail", async () => {
+    const sender = makeClient("ag_sender", senderKeys.privateKey);
+    const tool = createPaymentTool();
+
+    await seedBalance(sender, "25000");
+    hub.state.contacts = [
+      { contact_agent_id: "ag_receiver", display_name: "Receiver", created_at: new Date().toISOString() },
+    ];
+    hub.state.overrides.set("/hub/send", {
+      status: 500,
+      body: { error: "send failed" },
+    });
+    makeToolConfig("ag_sender", senderKeys.privateKey);
+
+    const transfer: any = await tool.execute("tool-followup-fail", {
+      action: "transfer",
+      to_agent_id: "ag_receiver",
+      amount_minor: "7000",
+    });
+
+    expect(transfer.data.tx.type).toBe("transfer");
+    expect(transfer.data.transfer_record_message.sent).toBe(false);
+    expect(transfer.data.notifications.payer.sent).toBe(false);
+    expect(transfer.data.notifications.payee.sent).toBe(false);
+    expect(transfer.result).toContain("Warning: some follow-up messages failed to send.");
+
+    const balance: any = await tool.execute("tool-followup-fail-balance", {
+      action: "balance",
+    });
+    expect(balance.data.available_balance_minor).toBe("18000");
   });
 
   it("creates and cancels withdrawals through the unified payment tool", async () => {
@@ -134,7 +223,7 @@ describe("payment tool integration", () => {
     await seedBalance(sender, "10000");
     makeToolConfig("ag_sender", senderKeys.privateKey);
 
-    const withdrawal = await tool.execute("tool-6", {
+    const withdrawal: any = await tool.execute("tool-6", {
       action: "withdraw",
       amount_minor: "3000",
       destination_type: "mock_bank",
@@ -144,18 +233,44 @@ describe("payment tool integration", () => {
     expect(withdrawal.data.status).toBe("pending");
     expect(withdrawal.result).toContain("Amount: 30.00 COIN");
 
-    const cancelled = await tool.execute("tool-7", {
+    const cancelled: any = await tool.execute("tool-7", {
       action: "cancel_withdrawal",
       withdrawal_id: withdrawal.data.withdrawal_id,
     });
     expect(cancelled.data.status).toBe("cancelled");
     expect(cancelled.result).toContain("Amount: 30.00 COIN");
 
-    const balance = await tool.execute("tool-8", {
+    const balance: any = await tool.execute("tool-8", {
       action: "balance",
     });
     expect(balance.data.available_balance_minor).toBe("10000");
     expect(balance.data.locked_balance_minor).toBe("0");
     expect(balance.result).toContain("Available: 100.00 COIN");
+  });
+});
+
+describe("wallet tool integration", () => {
+  it("applies the same contact-only transfer policy and follow-up messages", async () => {
+    const sender = makeClient("ag_sender", senderKeys.privateKey);
+    const tool = createWalletTool();
+
+    await seedBalance(sender, "15000");
+    hub.state.contacts = [
+      { contact_agent_id: "ag_receiver", display_name: "Receiver", created_at: new Date().toISOString() },
+    ];
+    makeToolConfig("ag_sender", senderKeys.privateKey);
+
+    const transfer: any = await tool.execute("wallet-tool-1", {
+      action: "transfer",
+      to_agent_id: "ag_receiver",
+      amount_minor: "5000",
+      memo: "legacy wallet",
+    });
+
+    expect(transfer.data.tx.amount_minor).toBe("5000");
+    expect(transfer.data.transfer_record_message.sent).toBe(true);
+    expect(transfer.data.notifications.payer.sent).toBe(true);
+    expect(transfer.data.notifications.payee.sent).toBe(true);
+    expect(hub.state.messages).toHaveLength(3);
   });
 });

--- a/plugin/src/client.ts
+++ b/plugin/src/client.ts
@@ -233,6 +233,32 @@ export class BotCordClient {
     return (await resp.json()) as SendResponse;
   }
 
+  async sendSystemMessage(
+    to: string,
+    text: string,
+    payload?: Record<string, unknown>,
+    options?: { topic?: string },
+  ): Promise<SendResponse> {
+    const envelope = buildSignedEnvelope({
+      from: this.agentId,
+      to,
+      type: "system",
+      payload: {
+        text,
+        ...(payload || {}),
+      },
+      privateKey: this.privateKey,
+      keyId: this.keyId,
+      topic: options?.topic,
+    });
+    const topicQuery = options?.topic ? `?topic=${encodeURIComponent(options.topic)}` : "";
+    const resp = await this.hubFetch(`/hub/send${topicQuery}`, {
+      method: "POST",
+      body: JSON.stringify(envelope),
+    });
+    return (await resp.json()) as SendResponse;
+  }
+
   async sendEnvelope(envelope: BotCordMessageEnvelope, topic?: string): Promise<SendResponse> {
     const topicQuery = topic ? `?topic=${encodeURIComponent(topic)}` : "";
     const resp = await this.hubFetch(`/hub/send${topicQuery}`, {

--- a/plugin/src/tools/payment-transfer.ts
+++ b/plugin/src/tools/payment-transfer.ts
@@ -1,0 +1,153 @@
+import type { BotCordClient } from "../client.js";
+import type { WalletTransaction } from "../types.js";
+import { formatCoinAmount } from "./coin-format.js";
+
+type FollowUpDeliveryResult = {
+  attempted: true;
+  sent: boolean;
+  hub_msg_id?: string;
+  error?: string;
+};
+
+export type ContactOnlyTransferResult = {
+  tx: WalletTransaction;
+  transfer_record_message: FollowUpDeliveryResult;
+  notifications: {
+    payer: FollowUpDeliveryResult;
+    payee: FollowUpDeliveryResult;
+  };
+};
+
+function extractTransferMetadata(tx: WalletTransaction): Record<string, unknown> | null {
+  if (!tx.metadata_json) return null;
+  try {
+    return typeof tx.metadata_json === "string"
+      ? JSON.parse(tx.metadata_json)
+      : tx.metadata_json;
+  } catch {
+    return null;
+  }
+}
+
+function formatOptionalLine(label: string, value: string | null | undefined): string | null {
+  return value ? `${label}: ${value}` : null;
+}
+
+export async function assertTransferPeerIsContact(client: BotCordClient, toAgentId: string): Promise<void> {
+  const contacts = await client.listContacts();
+  const isContact = contacts.some((contact) => contact.contact_agent_id === toAgentId);
+  if (!isContact) {
+    throw new Error("Transfer is only allowed between contacts. Please add this agent as a contact first.");
+  }
+}
+
+export function buildTransferRecordMessage(tx: WalletTransaction): string {
+  const metadata = extractTransferMetadata(tx);
+  return [
+    "[BotCord Transfer]",
+    `Status: ${tx.status}`,
+    `Transaction: ${tx.tx_id}`,
+    `Amount: ${formatCoinAmount(tx.amount_minor)}`,
+    `Asset: ${tx.asset_code}`,
+    formatOptionalLine("From", tx.from_agent_id),
+    formatOptionalLine("To", tx.to_agent_id),
+    formatOptionalLine("Memo", typeof metadata?.memo === "string" ? metadata.memo : undefined),
+    formatOptionalLine("Reference type", tx.reference_type),
+    formatOptionalLine("Reference id", tx.reference_id),
+    `Created: ${tx.created_at}`,
+  ].filter(Boolean).join("\n");
+}
+
+export function buildTransferNotificationMessage(
+  tx: WalletTransaction,
+  role: "payer" | "payee",
+): string {
+  if (role === "payer") {
+    return `[BotCord Notice] Transfer sent: ${formatCoinAmount(tx.amount_minor)} to ${tx.to_agent_id} (tx: ${tx.tx_id})`;
+  }
+  return `[BotCord Notice] Payment received: ${formatCoinAmount(tx.amount_minor)} from ${tx.from_agent_id} (tx: ${tx.tx_id})`;
+}
+
+export function formatFollowUpDeliverySummary(result: ContactOnlyTransferResult): string {
+  const lines = [
+    `Transfer record message: ${result.transfer_record_message.sent ? "sent" : "failed"}`,
+    `Payer notification: ${result.notifications.payer.sent ? "sent" : "failed"}`,
+    `Payee notification: ${result.notifications.payee.sent ? "sent" : "failed"}`,
+  ];
+  const failures = [
+    result.transfer_record_message.error,
+    result.notifications.payer.error,
+    result.notifications.payee.error,
+  ].filter(Boolean);
+  if (failures.length > 0) {
+    lines.push("Warning: some follow-up messages failed to send.");
+  }
+  return lines.join("\n");
+}
+
+async function sendRecordMessage(
+  client: BotCordClient,
+  tx: WalletTransaction,
+): Promise<FollowUpDeliveryResult> {
+  try {
+    const response = await client.sendMessage(tx.to_agent_id || "", buildTransferRecordMessage(tx));
+    return { attempted: true, sent: true, hub_msg_id: response.hub_msg_id };
+  } catch (err: any) {
+    return { attempted: true, sent: false, error: err?.message ?? String(err) };
+  }
+}
+
+async function sendNotification(
+  client: BotCordClient,
+  to: string,
+  tx: WalletTransaction,
+  role: "payer" | "payee",
+): Promise<FollowUpDeliveryResult> {
+  try {
+    const response = await client.sendSystemMessage(to, buildTransferNotificationMessage(tx, role), {
+      event: "wallet_transfer_notice",
+      role,
+      tx_id: tx.tx_id,
+      amount_minor: tx.amount_minor,
+      asset_code: tx.asset_code,
+      from_agent_id: tx.from_agent_id,
+      to_agent_id: tx.to_agent_id,
+      reference_type: tx.reference_type,
+      reference_id: tx.reference_id,
+    });
+    return { attempted: true, sent: true, hub_msg_id: response.hub_msg_id };
+  } catch (err: any) {
+    return { attempted: true, sent: false, error: err?.message ?? String(err) };
+  }
+}
+
+export async function executeContactOnlyTransfer(
+  client: BotCordClient,
+  params: {
+    to_agent_id: string;
+    amount_minor: string;
+    memo?: string;
+    reference_type?: string;
+    reference_id?: string;
+    metadata?: Record<string, unknown>;
+    idempotency_key?: string;
+  },
+): Promise<ContactOnlyTransferResult> {
+  await assertTransferPeerIsContact(client, params.to_agent_id);
+
+  const tx = await client.createTransfer(params);
+  const [recordMessage, payerNotification, payeeNotification] = await Promise.all([
+    sendRecordMessage(client, tx),
+    sendNotification(client, client.getAgentId(), tx, "payer"),
+    sendNotification(client, params.to_agent_id, tx, "payee"),
+  ]);
+
+  return {
+    tx,
+    transfer_record_message: recordMessage,
+    notifications: {
+      payer: payerNotification,
+      payee: payeeNotification,
+    },
+  };
+}

--- a/plugin/src/tools/payment.ts
+++ b/plugin/src/tools/payment.ts
@@ -9,6 +9,7 @@ import {
 import { BotCordClient } from "../client.js";
 import { getConfig as getAppConfig } from "../runtime.js";
 import { formatCoinAmount } from "./coin-format.js";
+import { executeContactOnlyTransfer, formatFollowUpDeliverySummary } from "./payment-transfer.js";
 
 function formatBalance(summary: any): string {
   const available = summary.available_balance_minor ?? "0";
@@ -233,7 +234,7 @@ export function createPaymentTool() {
           case "transfer": {
             if (!args.to_agent_id) return { error: "to_agent_id is required" };
             if (!args.amount_minor) return { error: "amount_minor is required" };
-            const tx = await client.createTransfer({
+            const transfer = await executeContactOnlyTransfer(client, {
               to_agent_id: args.to_agent_id,
               amount_minor: args.amount_minor,
               memo: args.memo,
@@ -242,7 +243,10 @@ export function createPaymentTool() {
               metadata: args.metadata,
               idempotency_key: args.idempotency_key,
             });
-            return { result: formatTransaction(tx), data: tx };
+            return {
+              result: `${formatTransaction(transfer.tx)}\n${formatFollowUpDeliverySummary(transfer)}`,
+              data: transfer,
+            };
           }
 
           case "topup": {

--- a/plugin/src/tools/wallet.ts
+++ b/plugin/src/tools/wallet.ts
@@ -9,6 +9,7 @@ import {
 import { BotCordClient } from "../client.js";
 import { getConfig as getAppConfig } from "../runtime.js";
 import { formatCoinAmount } from "./coin-format.js";
+import { executeContactOnlyTransfer, formatFollowUpDeliverySummary } from "./payment-transfer.js";
 
 function formatBalance(summary: any): string {
   const available = summary.available_balance_minor ?? "0";
@@ -159,13 +160,16 @@ export function createWalletTool() {
           case "transfer": {
             if (!args.to_agent_id) return { error: "to_agent_id is required" };
             if (!args.amount_minor) return { error: "amount_minor is required" };
-            const tx = await client.createTransfer({
+            const transfer = await executeContactOnlyTransfer(client, {
               to_agent_id: args.to_agent_id,
               amount_minor: args.amount_minor,
               memo: args.memo,
               idempotency_key: args.idempotency_key,
             });
-            return { result: formatTransaction(tx), data: tx };
+            return {
+              result: `${formatTransaction(transfer.tx)}\n${formatFollowUpDeliverySummary(transfer)}`,
+              data: transfer,
+            };
           }
 
           case "topup": {


### PR DESCRIPTION
## Summary
- restrict plugin transfer flows to BotCord contacts only
- send a transfer record DM to the payee and system notifications to both payer and payee after successful transfers
- document the design and add integration coverage for payment and wallet transfer flows

## Testing
- cd plugin && npm test
- cd plugin && npx tsc --noEmit