### PR TITLE
feat: persist hub uploads in supabase storage

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,5 +13,17 @@ ENDPOINT_PROBE_TIMEOUT_SECONDS=5
 # Inbox long-polling
 INBOX_POLL_MAX_TIMEOUT=30
 
+# File upload
+FILE_STORAGE_BACKEND=disk
+FILE_UPLOAD_DIR=/tmp/botcord/uploads
+FILE_MAX_SIZE_BYTES=10485760
+FILE_TTL_HOURS=1
+FILE_CLEANUP_INTERVAL_SECONDS=300
+
+# Supabase Storage (required when FILE_STORAGE_BACKEND=supabase)
+SUPABASE_URL=
+SUPABASE_SERVICE_ROLE_KEY=
+SUPABASE_STORAGE_BUCKET=botcord-files
+
 # Set to true to allow private/localhost endpoint URLs (dev only)
 ALLOW_PRIVATE_ENDPOINTS=false

--- a/backend/README.md
+++ b/backend/README.md
@@ -134,6 +134,7 @@ botcord-register.sh --name "my-agent" --set-default
 - [ ] Enable TLS via reverse proxy
 - [ ] Set up database backups (`pg_dump`)
 - [ ] Configure log rotation
+- [ ] Configure file storage: either mount `FILE_UPLOAD_DIR` or set `FILE_STORAGE_BACKEND=supabase`
 
 ---
 

--- a/backend/doc/doc.md
+++ b/backend/doc/doc.md
@@ -1409,7 +1409,7 @@ Response 404: 文件不存在或已过期
 **文件生命周期：**
 
 ```
-上传 → 存储（磁盘 + DB 记录）→ 通过 URL 访问 → TTL 到期 → 后台清理（删除磁盘文件 + DB 记录）
+上传 → 存储（disk 或 Supabase Storage + DB 记录）→ 通过 URL 访问 → TTL 到期 → 后台清理（删除对象 + DB 记录）
 ```
 
 - 文件默认 TTL 为 **1 小时**（`FILE_TTL_HOURS`），可通过环境变量配置
@@ -1420,10 +1420,14 @@ Response 404: 文件不存在或已过期
 
 | 环境变量 | 默认值 | 说明 |
 |----------|--------|------|
+| `FILE_STORAGE_BACKEND` | `disk` | 文件存储后端，`disk` 或 `supabase` |
 | `FILE_UPLOAD_DIR` | `/data/botcord/uploads` | 文件存储目录 |
 | `FILE_MAX_SIZE_BYTES` | `10485760`（10 MB） | 单文件最大字节数 |
 | `FILE_TTL_HOURS` | `1` | 文件过期时间（小时） |
 | `FILE_CLEANUP_INTERVAL_SECONDS` | `300` | 清理循环间隔（秒） |
+| `SUPABASE_URL` | 空 | Supabase 项目 URL，`FILE_STORAGE_BACKEND=supabase` 时必填 |
+| `SUPABASE_SERVICE_ROLE_KEY` | 空 | Supabase Service Role Key，`FILE_STORAGE_BACKEND=supabase` 时必填 |
+| `SUPABASE_STORAGE_BUCKET` | `botcord-files` | Supabase Storage bucket 名称 |
 
 **数据模型（FileRecord）：**
 
@@ -1434,7 +1438,10 @@ Response 404: 文件不存在或已过期
 | `original_filename` | string(256) | 原始文件名（清理后） |
 | `content_type` | string(128) | MIME 类型 |
 | `size_bytes` | integer | 文件大小（字节） |
-| `disk_path` | text | 磁盘存储路径 |
+| `storage_backend` | string(32) | 存储后端，`disk` 或 `supabase` |
+| `disk_path` | text/null | 磁盘存储路径（仅 `disk` 后端） |
+| `storage_bucket` | string(128)/null | 对象存储 bucket（仅 `supabase` 后端） |
+| `storage_object_key` | text/null | 对象存储 key（仅 `supabase` 后端） |
 | `expires_at` | datetime(tz) | 过期时间，有索引（供清理循环查询） |
 | `created_at` | datetime(tz) | 创建时间 |
 

--- a/backend/hub/cleanup.py
+++ b/backend/hub/cleanup.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 import asyncio
 import datetime
 import logging
-import os
 
 from sqlalchemy import select
 
 from hub import config as hub_config
 from hub.database import async_session
 from hub.models import FileRecord
+from hub.storage import delete_file
 
 logger = logging.getLogger(__name__)
 
@@ -40,13 +40,12 @@ async def _cleanup_expired_files() -> int:
         )
         records = list(result.scalars().all())
         for record in records:
-            # Delete disk file first (non-blocking)
             try:
-                await asyncio.to_thread(os.remove, record.disk_path)
+                await delete_file(record)
             except FileNotFoundError:
                 pass
             except OSError as exc:
-                logger.warning("Failed to delete file %s: %s", record.disk_path, exc)
+                logger.warning("Failed to delete file for %s: %s", record.file_id, exc)
             await session.delete(record)
             deleted += 1
         if records:

--- a/backend/hub/config.py
+++ b/backend/hub/config.py
@@ -75,10 +75,19 @@ INBOX_POLL_MAX_TIMEOUT: int = int(os.getenv("INBOX_POLL_MAX_TIMEOUT", "30"))
 JOIN_RATE_LIMIT_PER_MINUTE: int = int(os.getenv("JOIN_RATE_LIMIT_PER_MINUTE", "10"))
 
 # File upload settings
+FILE_STORAGE_BACKEND: str = os.getenv("FILE_STORAGE_BACKEND", "disk").strip().lower()
+if FILE_STORAGE_BACKEND not in {"disk", "supabase"}:
+    raise ValueError(
+        "FILE_STORAGE_BACKEND must be either 'disk' or 'supabase', "
+        f"got: {FILE_STORAGE_BACKEND!r}"
+    )
 FILE_UPLOAD_DIR: str = os.getenv("FILE_UPLOAD_DIR", "/tmp/botcord/uploads")
 FILE_MAX_SIZE_BYTES: int = int(os.getenv("FILE_MAX_SIZE_BYTES", str(10 * 1024 * 1024)))  # 10 MB
 FILE_TTL_HOURS: int = int(os.getenv("FILE_TTL_HOURS", "1"))  # 1 hour
 FILE_CLEANUP_INTERVAL_SECONDS: float = float(os.getenv("FILE_CLEANUP_INTERVAL_SECONDS", "300"))  # 5 min
+SUPABASE_URL: str | None = os.getenv("SUPABASE_URL")
+SUPABASE_SERVICE_ROLE_KEY: str | None = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+SUPABASE_STORAGE_BUCKET: str | None = os.getenv("SUPABASE_STORAGE_BUCKET")
 
 # ---------------------------------------------------------------------------
 # Stripe integration

--- a/backend/hub/main.py
+++ b/backend/hub/main.py
@@ -37,6 +37,7 @@ from hub.routers.topics import router as topics_router
 from hub.routers.stripe import router as stripe_router
 from hub.routers.wallet import internal_router as wallet_internal_router
 from hub.routers.wallet import router as wallet_router
+from hub.storage import storage_requires_local_disk
 
 logging.basicConfig(level=logging.INFO)
 
@@ -73,9 +74,10 @@ async def lifespan(app: FastAPI):
     if not hasattr(app.state, "http_client"):
         app.state.http_client = None
 
-    # Ensure upload directory exists
-    import os
-    os.makedirs(hub_config.FILE_UPLOAD_DIR, exist_ok=True)
+    if storage_requires_local_disk():
+        # Ensure upload directory exists for local-disk storage mode.
+        import os
+        os.makedirs(hub_config.FILE_UPLOAD_DIR, exist_ok=True)
 
     expiry_task = None
     cleanup_task = None

--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -411,7 +411,10 @@ class FileRecord(Base):
     original_filename: Mapped[str] = mapped_column(String(256), nullable=False)
     content_type: Mapped[str] = mapped_column(String(128), nullable=False)
     size_bytes: Mapped[int] = mapped_column(Integer, nullable=False)
-    disk_path: Mapped[str] = mapped_column(Text, nullable=False)
+    storage_backend: Mapped[str] = mapped_column(String(32), nullable=False, default="disk", index=True)
+    disk_path: Mapped[str | None] = mapped_column(Text, nullable=True)
+    storage_bucket: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    storage_object_key: Mapped[str | None] = mapped_column(Text, nullable=True)
     expires_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, index=True
     )

--- a/backend/hub/routers/files.py
+++ b/backend/hub/routers/files.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-import asyncio
 import datetime
 import logging
 import os
+from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, UploadFile
 from hub.i18n import I18nHTTPException
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -19,6 +19,7 @@ from hub.database import get_db
 from hub.id_generators import generate_file_id
 from hub.models import FileRecord
 from hub.schemas import FileUploadResponse
+from hub.storage import load_file, store_file
 
 logger = logging.getLogger(__name__)
 
@@ -75,25 +76,29 @@ async def upload_file(
     if total_size == 0:
         raise I18nHTTPException(status_code=400, message_key="empty_file")
 
-    data = b"".join(chunks)
-    file_id = generate_file_id()
-    disk_path = os.path.join(hub_config.FILE_UPLOAD_DIR, file_id)
-    now = datetime.datetime.now(datetime.timezone.utc)
-    expires_at = now + datetime.timedelta(hours=hub_config.FILE_TTL_HOURS)
-
-    # Write to disk (non-blocking)
-    await asyncio.to_thread(_write_file, disk_path, data)
-
     # Sanitize filename: strip path separators and limit length
     raw_name = file.filename or "upload"
     original_filename = os.path.basename(raw_name).strip()[:200] or "upload"
+    data = b"".join(chunks)
+    file_id = generate_file_id()
+    now = datetime.datetime.now(datetime.timezone.utc)
+    expires_at = now + datetime.timedelta(hours=hub_config.FILE_TTL_HOURS)
+    location = await store_file(
+        file_id=file_id,
+        original_filename=original_filename,
+        content_type=content_type,
+        data=data,
+    )
     record = FileRecord(
         file_id=file_id,
         uploader_id=agent_id,
         original_filename=original_filename,
         content_type=content_type,
         size_bytes=total_size,
-        disk_path=disk_path,
+        storage_backend=location.storage_backend,
+        disk_path=location.disk_path,
+        storage_bucket=location.storage_bucket,
+        storage_object_key=location.storage_object_key,
         expires_at=expires_at,
     )
     db.add(record)
@@ -112,12 +117,6 @@ async def upload_file(
         size_bytes=total_size,
         expires_at=expires_at.isoformat(),
     )
-
-
-def _write_file(path: str, data: bytes) -> None:
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "wb") as f:
-        f.write(data)
 
 
 @router.get("/files/{file_id}")
@@ -140,11 +139,29 @@ async def download_file(
     if datetime.datetime.now(datetime.timezone.utc) >= expires:
         raise I18nHTTPException(status_code=404, message_key="file_expired")
 
-    if not os.path.isfile(record.disk_path):
+    if record.storage_backend == "disk" and record.disk_path:
+        if not os.path.isfile(record.disk_path):
+            raise I18nHTTPException(status_code=404, message_key="file_not_found_on_disk")
+        return FileResponse(
+            path=record.disk_path,
+            media_type=record.content_type,
+            filename=record.original_filename,
+        )
+
+    try:
+        data = await load_file(record)
+    except FileNotFoundError:
         raise I18nHTTPException(status_code=404, message_key="file_not_found_on_disk")
 
-    return FileResponse(
-        path=record.disk_path,
+    return Response(
+        content=data,
         media_type=record.content_type,
-        filename=record.original_filename,
+        headers={
+            "Content-Disposition": _build_content_disposition(record.original_filename),
+        },
     )
+
+
+def _build_content_disposition(filename: str) -> str:
+    quoted = quote(filename, safe="")
+    return f'attachment; filename="{filename}"; filename*=UTF-8\'\'{quoted}'

--- a/backend/hub/storage.py
+++ b/backend/hub/storage.py
@@ -1,0 +1,186 @@
+"""Storage helpers for uploaded files."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+from fastapi import HTTPException
+
+from hub import config as hub_config
+from hub.models import FileRecord
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class StoredFileLocation:
+    storage_backend: str
+    disk_path: str | None = None
+    storage_bucket: str | None = None
+    storage_object_key: str | None = None
+
+
+def storage_requires_local_disk() -> bool:
+    return hub_config.FILE_STORAGE_BACKEND == "disk"
+
+
+async def store_file(
+    *,
+    file_id: str,
+    original_filename: str,
+    content_type: str,
+    data: bytes,
+) -> StoredFileLocation:
+    if hub_config.FILE_STORAGE_BACKEND == "disk":
+        disk_path = os.path.join(hub_config.FILE_UPLOAD_DIR, file_id)
+        await asyncio.to_thread(_write_file, disk_path, data)
+        return StoredFileLocation(storage_backend="disk", disk_path=disk_path)
+
+    if hub_config.FILE_STORAGE_BACKEND == "supabase":
+        _validate_supabase_config()
+        object_key = f"{file_id}/{original_filename}"
+        await _supabase_request(
+            "POST",
+            f"/storage/v1/object/{_quoted_bucket_and_key(hub_config.SUPABASE_STORAGE_BUCKET, object_key)}",
+            content=data,
+            headers={
+                "Content-Type": content_type,
+                "x-upsert": "false",
+            },
+            expected_statuses={200, 201},
+        )
+        return StoredFileLocation(
+            storage_backend="supabase",
+            storage_bucket=hub_config.SUPABASE_STORAGE_BUCKET,
+            storage_object_key=object_key,
+        )
+
+    raise RuntimeError(f"Unsupported FILE_STORAGE_BACKEND: {hub_config.FILE_STORAGE_BACKEND}")
+
+
+async def load_file(record: FileRecord) -> bytes:
+    backend = _record_backend(record)
+    if backend == "disk":
+        if not record.disk_path or not os.path.isfile(record.disk_path):
+            raise FileNotFoundError(record.disk_path or "<missing disk_path>")
+        return await asyncio.to_thread(_read_file, record.disk_path)
+
+    if backend == "supabase":
+        bucket = record.storage_bucket or hub_config.SUPABASE_STORAGE_BUCKET
+        if not bucket or not record.storage_object_key:
+            raise FileNotFoundError("Missing Supabase storage coordinates")
+        response = await _supabase_request(
+            "GET",
+            f"/storage/v1/object/{_quoted_bucket_and_key(bucket, record.storage_object_key)}",
+            expected_statuses={200},
+        )
+        return response.content
+
+    raise FileNotFoundError(f"Unsupported storage backend: {backend}")
+
+
+async def delete_file(record: FileRecord) -> None:
+    backend = _record_backend(record)
+    if backend == "disk":
+        if record.disk_path:
+            await asyncio.to_thread(os.remove, record.disk_path)
+        return
+
+    if backend == "supabase":
+        bucket = record.storage_bucket or hub_config.SUPABASE_STORAGE_BUCKET
+        if not bucket or not record.storage_object_key:
+            return
+        await _supabase_request(
+            "DELETE",
+            "/storage/v1/object/{bucket}".format(bucket=quote(bucket, safe="")),
+            json={"prefixes": [record.storage_object_key]},
+            expected_statuses={200},
+        )
+        return
+
+    logger.warning("Skipping delete for unsupported storage backend %s", backend)
+
+
+def _record_backend(record: FileRecord) -> str:
+    return record.storage_backend or ("disk" if record.disk_path else "supabase")
+
+
+def _write_file(path: str, data: bytes) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as f:
+        f.write(data)
+
+
+def _read_file(path: str) -> bytes:
+    with open(path, "rb") as f:
+        return f.read()
+
+
+def _validate_supabase_config() -> None:
+    missing = [
+        name
+        for name, value in (
+            ("SUPABASE_URL", hub_config.SUPABASE_URL),
+            ("SUPABASE_SERVICE_ROLE_KEY", hub_config.SUPABASE_SERVICE_ROLE_KEY),
+            ("SUPABASE_STORAGE_BUCKET", hub_config.SUPABASE_STORAGE_BUCKET),
+        )
+        if not value
+    ]
+    if missing:
+        raise RuntimeError(
+            "Supabase storage is enabled but required settings are missing: "
+            + ", ".join(missing)
+        )
+
+
+def _quoted_bucket_and_key(bucket: str | None, object_key: str) -> str:
+    if not bucket:
+        raise RuntimeError("SUPABASE_STORAGE_BUCKET is required")
+    quoted_key = "/".join(quote(part, safe="") for part in object_key.split("/"))
+    return f"{quote(bucket, safe='')}/{quoted_key}"
+
+
+async def _supabase_request(
+    method: str,
+    path: str,
+    *,
+    headers: dict[str, str] | None = None,
+    expected_statuses: set[int] | None = None,
+    **kwargs: Any,
+) -> httpx.Response:
+    _validate_supabase_config()
+    request_headers = {
+        "Authorization": f"Bearer {hub_config.SUPABASE_SERVICE_ROLE_KEY}",
+        "apikey": hub_config.SUPABASE_SERVICE_ROLE_KEY,
+        **(headers or {}),
+    }
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.request(
+            method,
+            f"{hub_config.SUPABASE_URL}{path}",
+            headers=request_headers,
+            **kwargs,
+        )
+
+    allowed = expected_statuses or {200}
+    if response.status_code in allowed:
+        return response
+
+    detail = response.text.strip()
+    logger.error(
+        "Supabase storage request failed: %s %s -> %s %s",
+        method,
+        path,
+        response.status_code,
+        detail,
+    )
+    raise HTTPException(
+        status_code=502,
+        detail=f"Supabase storage request failed: {response.status_code}",
+    )

--- a/backend/migrations/012_add_file_storage_backend.sql
+++ b/backend/migrations/012_add_file_storage_backend.sql
@@ -1,0 +1,70 @@
+-- Migration 012: add storage backend metadata for uploaded files
+-- Run against PostgreSQL 16
+
+ALTER TABLE file_records
+    ALTER COLUMN disk_path DROP NOT NULL;
+
+ALTER TABLE file_records
+    ADD COLUMN IF NOT EXISTS storage_backend VARCHAR(32) DEFAULT 'disk',
+    ADD COLUMN IF NOT EXISTS storage_bucket VARCHAR(128),
+    ADD COLUMN IF NOT EXISTS storage_object_key TEXT;
+
+UPDATE file_records
+SET storage_backend = 'disk'
+WHERE storage_backend IS NULL;
+
+ALTER TABLE file_records
+    ALTER COLUMN storage_backend SET DEFAULT 'disk';
+
+ALTER TABLE file_records
+    ALTER COLUMN storage_backend SET NOT NULL;
+
+UPDATE file_records
+SET
+    storage_backend = 'disk',
+    storage_bucket = NULL,
+    storage_object_key = NULL
+WHERE storage_backend = 'disk'
+  AND disk_path IS NOT NULL
+  AND (storage_bucket IS NOT NULL OR storage_object_key IS NOT NULL);
+
+ALTER TABLE file_records
+    DROP CONSTRAINT IF EXISTS ck_file_records_storage_backend;
+
+ALTER TABLE file_records
+    DROP CONSTRAINT IF EXISTS ck_file_records_storage_location;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'ck_file_records_storage_backend'
+          AND conrelid = 'file_records'::regclass
+    ) THEN
+        ALTER TABLE file_records
+            ADD CONSTRAINT ck_file_records_storage_backend
+            CHECK (storage_backend IN ('disk', 'supabase'));
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'ck_file_records_storage_location'
+          AND conrelid = 'file_records'::regclass
+    ) THEN
+        ALTER TABLE file_records
+            ADD CONSTRAINT ck_file_records_storage_location
+            CHECK (
+                (storage_backend = 'disk' AND disk_path IS NOT NULL AND storage_bucket IS NULL AND storage_object_key IS NULL)
+                OR
+                (storage_backend = 'supabase' AND disk_path IS NULL AND storage_bucket IS NOT NULL AND storage_object_key IS NOT NULL)
+            );
+    END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS ix_file_records_storage_backend
+    ON file_records(storage_backend);

--- a/backend/tests/test_files.py
+++ b/backend/tests/test_files.py
@@ -6,13 +6,15 @@ import io
 import os
 import time
 import uuid
+from contextlib import asynccontextmanager
 
 import pytest
 import pytest_asyncio
+import httpx
 from httpx import ASGITransport, AsyncClient
 from nacl.signing import SigningKey
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 from hub.models import Base, FileRecord
 
@@ -36,9 +38,17 @@ async def db_session():
 async def client(db_session: AsyncSession, tmp_path):
     from hub import config
 
-    # Override upload dir BEFORE importing app (lifespan uses it)
+    # Override upload settings BEFORE importing app (lifespan uses them)
     original_dir = config.FILE_UPLOAD_DIR
+    original_backend = config.FILE_STORAGE_BACKEND
+    original_supabase_url = config.SUPABASE_URL
+    original_supabase_service_role_key = config.SUPABASE_SERVICE_ROLE_KEY
+    original_supabase_bucket = config.SUPABASE_STORAGE_BUCKET
     config.FILE_UPLOAD_DIR = str(tmp_path / "uploads")
+    config.FILE_STORAGE_BACKEND = "disk"
+    config.SUPABASE_URL = None
+    config.SUPABASE_SERVICE_ROLE_KEY = None
+    config.SUPABASE_STORAGE_BUCKET = None
     os.makedirs(config.FILE_UPLOAD_DIR, exist_ok=True)
 
     from hub.main import app
@@ -55,6 +65,10 @@ async def client(db_session: AsyncSession, tmp_path):
         yield c
     app.dependency_overrides.clear()
     config.FILE_UPLOAD_DIR = original_dir
+    config.FILE_STORAGE_BACKEND = original_backend
+    config.SUPABASE_URL = original_supabase_url
+    config.SUPABASE_SERVICE_ROLE_KEY = original_supabase_service_role_key
+    config.SUPABASE_STORAGE_BUCKET = original_supabase_bucket
 
 
 # ---------------------------------------------------------------------------
@@ -95,6 +109,25 @@ async def _register_and_verify(
 
 def _auth_header(token: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
+
+
+def _enable_supabase_storage():
+    from hub import config
+
+    config.FILE_STORAGE_BACKEND = "supabase"
+    config.SUPABASE_URL = "https://project.supabase.co"
+    config.SUPABASE_SERVICE_ROLE_KEY = "service-role-key"
+    config.SUPABASE_STORAGE_BUCKET = "botcord-files"
+
+
+def _supabase_response(
+    status_code: int = 200,
+    *,
+    content: bytes = b"",
+    text: str = "",
+) -> httpx.Response:
+    request = httpx.Request("GET", "https://project.supabase.co/storage/v1/object")
+    return httpx.Response(status_code, request=request, content=content or text.encode())
 
 
 # ===========================================================================
@@ -230,6 +263,36 @@ async def test_upload_sanitizes_filename(client: AsyncClient):
     assert resp.json()["original_filename"] == "passwd"
 
 
+@pytest.mark.asyncio
+async def test_upload_success_supabase(client: AsyncClient, db_session: AsyncSession):
+    from sqlalchemy import select as sa_select
+
+    _enable_supabase_storage()
+    sk, pubkey = _make_keypair()
+    _, _, token = await _register_and_verify(client, sk, pubkey)
+
+    with patch("hub.storage._supabase_request", new=AsyncMock(return_value=_supabase_response())) as mock_request:
+        resp = await client.post(
+            "/hub/upload",
+            headers=_auth_header(token),
+            files={"file": ("report.pdf", io.BytesIO(b"%PDF-1.4"), "application/pdf")},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["original_filename"] == "report.pdf"
+    mock_request.assert_awaited_once()
+
+    result = await db_session.execute(
+        sa_select(FileRecord).where(FileRecord.file_id == data["file_id"])
+    )
+    record = result.scalar_one()
+    assert record.storage_backend == "supabase"
+    assert record.disk_path is None
+    assert record.storage_bucket == "botcord-files"
+    assert record.storage_object_key == f"{data['file_id']}/report.pdf"
+
+
 # ===========================================================================
 # Download tests
 # ===========================================================================
@@ -337,6 +400,37 @@ async def test_download_disk_file_missing(client: AsyncClient, db_session: Async
     assert "disk" in dl_resp.json()["detail"].lower()
 
 
+@pytest.mark.asyncio
+async def test_download_success_supabase(client: AsyncClient):
+    _enable_supabase_storage()
+    sk, pubkey = _make_keypair()
+    _, _, token = await _register_and_verify(client, sk, pubkey)
+
+    with patch(
+        "hub.storage._supabase_request",
+        new=AsyncMock(
+            side_effect=[
+                _supabase_response(),
+                _supabase_response(content=b"supabase bytes"),
+            ]
+        ),
+    ):
+        upload_resp = await client.post(
+            "/hub/upload",
+            headers=_auth_header(token),
+            files={"file": ("report.pdf", io.BytesIO(b"%PDF-1.4"), "application/pdf")},
+        )
+        assert upload_resp.status_code == 200
+        file_id = upload_resp.json()["file_id"]
+
+        dl_resp = await client.get(f"/hub/files/{file_id}")
+
+    assert dl_resp.status_code == 200
+    assert dl_resp.content == b"supabase bytes"
+    assert "application/pdf" in dl_resp.headers.get("content-type", "")
+    assert "report.pdf" in dl_resp.headers.get("content-disposition", "")
+
+
 # ===========================================================================
 # Cleanup tests
 # ===========================================================================
@@ -398,6 +492,47 @@ async def test_cleanup_removes_expired_files(client: AsyncClient, db_session: As
 
     # Verify disk file and DB record are gone
     assert not os.path.isfile(disk_path)
+    result = await db_session.execute(
+        sa_select(FileRecord).where(FileRecord.file_id == file_id)
+    )
+    assert result.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_removes_expired_supabase_files(client: AsyncClient, db_session: AsyncSession):
+    from sqlalchemy import select as sa_select
+    from sqlalchemy import update
+    from hub import cleanup as hub_cleanup
+
+    _enable_supabase_storage()
+    sk, pubkey = _make_keypair()
+    _, _, token = await _register_and_verify(client, sk, pubkey)
+
+    @asynccontextmanager
+    async def _test_async_session():
+        yield db_session
+
+    with patch("hub.storage._supabase_request", new=AsyncMock(return_value=_supabase_response())) as mock_request:
+        with patch.object(hub_cleanup, "async_session", _test_async_session):
+            upload_resp = await client.post(
+                "/hub/upload",
+                headers=_auth_header(token),
+                files={"file": ("cleanup.txt", io.BytesIO(b"cleanup"), "text/plain")},
+            )
+            assert upload_resp.status_code == 200
+            file_id = upload_resp.json()["file_id"]
+
+            await db_session.execute(
+                update(FileRecord)
+                .where(FileRecord.file_id == file_id)
+                .values(expires_at=datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc))
+            )
+            await db_session.commit()
+
+            deleted = await hub_cleanup._cleanup_expired_files()
+
+    assert deleted == 1
+    assert mock_request.await_count == 2
     result = await db_session.execute(
         sa_select(FileRecord).where(FileRecord.file_id == file_id)
     )


### PR DESCRIPTION
## Summary

This PR adds Supabase-backed persistence for Hub file uploads while keeping the existing  and  API contract unchanged.

## What Changed

- added a storage abstraction for uploaded files
- added Supabase CLI 2.39.2

Usage:
  supabase [command]

Quick Start:
  bootstrap            Bootstrap a Supabase project from a starter template

Local Development:
  db                   Manage Postgres databases
  gen                  Run code generation tools
  init                 Initialize a local project
  inspect              Tools to inspect your Supabase project
  link                 Link to a Supabase project
  login                Authenticate using an access token
  logout               Log out and delete access tokens locally
  migration            Manage database migration scripts
  seed                 Seed a Supabase project from supabase/config.toml
  services             Show versions of all Supabase services
  start                Start containers for Supabase local development
  status               Show status of local Supabase containers
  stop                 Stop all local Supabase containers
  test                 Run tests on local Supabase containers
  unlink               Unlink a Supabase project

Management APIs:
  backups              Manage Supabase physical backups
  branches             Manage Supabase preview branches
  config               Manage Supabase project configurations
  domains              Manage custom domain names for Supabase projects
  encryption           Manage encryption keys of Supabase projects
  functions            Manage Supabase Edge functions
  network-bans         Manage network bans
  network-restrictions Manage network restrictions
  orgs                 Manage Supabase organizations
  postgres-config      Manage Postgres database config
  projects             Manage Supabase projects
  secrets              Manage Supabase secrets
  snippets             Manage Supabase SQL snippets
  ssl-enforcement      Manage SSL enforcement configuration
  sso                  Manage Single Sign-On (SSO) authentication for projects
  storage              Manage Supabase Storage objects
  vanity-subdomains    Manage vanity subdomains for Supabase projects

Additional Commands:
  completion           Generate the autocompletion script for the specified shell
  help                 Help about any command

Flags:
      --create-ticket                                  create a support ticket for any CLI error
      --debug                                          output debug logs to stderr
      --dns-resolver [ native | https ]                lookup domain names using the specified resolver (default native)
      --experimental                                   enable experimental features
  -h, --help                                           help for supabase
      --network-id string                              use the specified docker network instead of a generated one
  -o, --output [ env | pretty | json | toml | yaml ]   output format of status variables (default pretty)
      --profile string                                 use a specific profile for connecting to Supabase API (default "supabase")
  -v, --version                                        version for supabase
      --workdir string                                 path to a Supabase project directory
      --yes                                            answer yes to all prompts

Use "supabase [command] --help" for more information about a command. as a configurable file storage backend
- kept  as the default fallback for local/dev usage
- updated file upload flow to store object metadata in 
- updated file download flow so Hub can proxy files from Supabase Storage
- updated cleanup logic to delete expired objects from the configured backend
- added a migration for , , and 
- updated backend env docs and upload/storage documentation
- added test coverage for disk mode and Supabase mode

## Config

When using Supabase storage, set:

- 
- 
- 
- 

## Migration

Run:



## Verification

Ran:

============================= test session starts ==============================
platform darwin -- Python 3.12.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /private/tmp/botcord-supabase-file-persistence/backend
configfile: pyproject.toml
plugins: anyio-4.12.1, asyncio-1.3.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 23 items

tests/test_files.py .......................                              [100%]

=============================== warnings summary ===============================
tests/test_files.py: 15 warnings
  /private/tmp/botcord-supabase-file-persistence/backend/.venv/lib/python3.12/site-packages/jwt/api_jwt.py:153: InsecureKeyLengthWarning: The HMAC key is 23 bytes long, which is below the minimum recommended length of 32 bytes for SHA256. See RFC 7518 Section 3.2.
    return self._jws.encode(

tests/test_files.py: 17 warnings
  /private/tmp/botcord-supabase-file-persistence/backend/.venv/lib/python3.12/site-packages/jwt/api_jwt.py:371: InsecureKeyLengthWarning: The HMAC key is 23 bytes long, which is below the minimum recommended length of 32 bytes for SHA256. See RFC 7518 Section 3.2.
    decoded = self.decode_complete(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================= 23 passed, 32 warnings in 3.31s ========================

## Notes

- bucket can remain private; downloads still go through Hub
- current implementation uses the Supabase service role key on the backend only
- existing file records are backfilled to 
