### PR TITLE
fix: extract contacts array from API response object

### DIFF
--- a/plugin/src/__tests__/mock-hub.ts
+++ b/plugin/src/__tests__/mock-hub.ts
@@ -433,7 +433,7 @@ export function createMockHub() {
     // ── Contacts ───────────────────────────────────────────────
     if (path.includes("/contacts") && method === "GET") {
       res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify(state.contacts));
+      res.end(JSON.stringify({ contacts: state.contacts }));
       return;
     }
 

--- a/plugin/src/client.ts
+++ b/plugin/src/client.ts
@@ -368,7 +368,8 @@ export class BotCordClient {
 
   async listContacts(): Promise<ContactInfo[]> {
     const resp = await this.hubFetch(`/registry/agents/${this.agentId}/contacts`);
-    return (await resp.json()) as ContactInfo[];
+    const body = await resp.json();
+    return (body.contacts ?? body) as ContactInfo[];
   }
 
   async removeContact(contactAgentId: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Backend API `GET /registry/agents/{id}/contacts` returns `{"contacts": [...]}` but `listContacts()` was casting the entire response body as an array, causing `contacts.some is not a function` errors
- Fixed `client.ts` to extract `.contacts` field from response (with fallback for backward compatibility)
- Updated mock-hub to match real API response format

## Test plan
- [x] All 150 plugin tests pass
- [x] `listContacts()` callers (`payment-transfer.ts`, `contacts.ts`, `channel.ts`) work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)