### PR TITLE
feat: output claim URL after botcord-register

### DIFF
--- a/openclaw-setup_instruction.md
+++ b/openclaw-setup_instruction.md
@@ -89,9 +89,11 @@ Check the gateway log for successful connection:
 
 After an agent is registered, it must be claimed by a user account before chatting in the web dashboard.
 
+`openclaw botcord-register` now outputs the claim URL automatically after registration. Simply open the printed URL in your browser to claim the agent.
+
 ### Fixed claim URL (claim_code)
 
-Use a fixed claim URL format:
+If you need to find the claim URL later, use the fixed format:
 
 ```text
 https://botcord.chat/agents/claim/<claim_code>
@@ -105,7 +107,7 @@ https://botcord.chat/agents/claim/clm_9f3b2a8c7d6e5f4a3210
 
 ### User side: open link and claim
 
-1. Open `https://botcord.chat/agents/claim/<claim_code>`
+1. Open the claim URL printed by `botcord-register`, or navigate to `https://botcord.chat/agents/claim/<claim_code>`
 2. Log in or sign up
 3. Complete claim by `claim_code` (`POST /api/users/me/agents/claim/resolve`)
 5. Start chatting in `/chats`

--- a/plugin/src/commands/register.ts
+++ b/plugin/src/commands/register.ts
@@ -34,6 +34,7 @@ interface RegisterResult {
   displayName: string;
   hub: string;
   credentialsFile: string;
+  claimUrl?: string;
 }
 
 interface ImportResult {
@@ -246,7 +247,26 @@ export async function registerAgent(opts: {
     throw new Error(`Verification failed (${verifyResp.status}): ${body}`);
   }
 
-  // 5. Write credentials via OpenClaw's config API
+  const verifyData = (await verifyResp.json()) as { token: string };
+
+  // 5. Fetch claim URL (best-effort)
+  let claimUrl: string | undefined;
+  try {
+    const claimResp = await fetch(
+      `${normalizedHub}/registry/agents/${regData.agent_id}/claim-link`,
+      {
+        headers: { Authorization: `Bearer ${verifyData.token}` },
+      },
+    );
+    if (claimResp.ok) {
+      const claimData = (await claimResp.json()) as { claim_url: string };
+      claimUrl = claimData.claim_url;
+    }
+  } catch {
+    // Best-effort — claim URL fetch failure should not block registration.
+  }
+
+  // 6. Write credentials via OpenClaw's config API
   const credentialsFile = await persistCredentials({
     config,
     credentials: {
@@ -267,6 +287,7 @@ export async function registerAgent(opts: {
     displayName: name,
     hub: normalizedHub,
     credentialsFile,
+    claimUrl,
   };
 }
 
@@ -358,6 +379,9 @@ export function createRegisterCli() {
             ctx.logger.info(`  Display name: ${result.displayName}`);
             ctx.logger.info(`  Hub:          ${result.hub}`);
             ctx.logger.info(`  Credentials:  ${result.credentialsFile}`);
+            if (result.claimUrl) {
+              ctx.logger.info(`  Claim URL:    ${result.claimUrl}`);
+            }
             ctx.logger.info(``);
             ctx.logger.info(`Restart OpenClaw to activate: openclaw gateway restart`);
           } catch (err: any) {


### PR DESCRIPTION
## Summary
- `botcord-register` 注册成功后自动调 `/registry/agents/{id}/claim-link` 获取真实 claim URL 并输出
- Best-effort：claim URL 获取失败不阻塞注册流程
- 更新 `openclaw-setup_instruction.md` 说明注册后自动输出 claim URL

## Why
AI agent 注册后会编造假的 claim code（用 agent ID 后缀拼接），导致用户一直收到 "Invalid claim code"。根因是注册流程没有调 API 获取真实的 `clm_*` claim code。

## Test plan
- [x] 149 plugin tests pass（manifest version sync 是已有问题）
- [ ] 手动 `openclaw botcord-register` 验证 claim URL 输出
- [ ] 用输出的 URL 完成 claim 流程

🤖 Generated with [Claude Code](https://claude.com/claude-code)