### PR TITLE
fix: support ES256 JWKS for Supabase JWT verification

### DIFF
--- a/backend/hub/auth.py
+++ b/backend/hub/auth.py
@@ -1,14 +1,23 @@
 import datetime
+import logging
 
 import jwt
 from fastapi import Depends, Header, HTTPException
+from jwt import PyJWKClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from hub.config import JWT_ALGORITHM, JWT_EXPIRE_HOURS, JWT_SECRET, SUPABASE_JWT_SECRET
+from hub.config import JWT_ALGORITHM, JWT_EXPIRE_HOURS, JWT_SECRET, SUPABASE_JWT_SECRET, SUPABASE_JWT_JWKS_URL
 from hub.database import get_db
 from hub.i18n import I18nHTTPException
 from hub.models import Agent
+
+_logger = logging.getLogger(__name__)
+
+# Lazily initialised JWKS client (cached keys, thread-safe)
+_jwks_client: PyJWKClient | None = None
+if SUPABASE_JWT_JWKS_URL:
+    _jwks_client = PyJWKClient(SUPABASE_JWT_JWKS_URL, cache_keys=True)
 
 
 def create_agent_token(agent_id: str) -> tuple[str, int]:
@@ -99,12 +108,24 @@ def _parse_dashboard_token(
         pass
 
     # Slow path: Supabase JWT — need X-Active-Agent + ownership check later.
-    if not SUPABASE_JWT_SECRET:
+    if not SUPABASE_JWT_SECRET and not _jwks_client:
         raise I18nHTTPException(status_code=401, message_key="user_auth_not_configured")
+
     try:
-        payload = jwt.decode(
-            token, SUPABASE_JWT_SECRET, algorithms=["HS256"], audience="authenticated",
-        )
+        if _jwks_client:
+            # ES256 / RS256 via JWKS endpoint
+            signing_key = _jwks_client.get_signing_key_from_jwt(token)
+            payload = jwt.decode(
+                token,
+                signing_key.key,
+                algorithms=["ES256", "RS256"],
+                audience="authenticated",
+            )
+        else:
+            # Legacy HS256 via symmetric secret
+            payload = jwt.decode(
+                token, SUPABASE_JWT_SECRET, algorithms=["HS256"], audience="authenticated",
+            )
     except jwt.InvalidTokenError:
         raise I18nHTTPException(status_code=401, message_key="invalid_token")
 

--- a/backend/hub/config.py
+++ b/backend/hub/config.py
@@ -60,8 +60,12 @@ if ALLOW_PRIVATE_ENDPOINTS and not INTERNAL_API_SECRET:
         "Set INTERNAL_API_SECRET to a strong random value in production."
     )
 
-# Supabase JWT secret for dashboard user auth (optional)
+# Supabase JWT verification (optional — set ONE of these)
+# Option 1: symmetric HS256 secret (legacy Supabase projects)
 SUPABASE_JWT_SECRET: str | None = os.getenv("SUPABASE_JWT_SECRET")
+# Option 2: JWKS URL for ES256/RS256 (modern Supabase projects)
+# e.g. https://<ref>.supabase.co/auth/v1/.well-known/jwks.json
+SUPABASE_JWT_JWKS_URL: str | None = os.getenv("SUPABASE_JWT_JWKS_URL")
 
 RATE_LIMIT_PER_MINUTE: int = 20
 PAIR_RATE_LIMIT_PER_MINUTE: int = int(os.getenv("PAIR_RATE_LIMIT_PER_MINUTE", "10"))


### PR DESCRIPTION
## Summary

- Modern Supabase projects use ECC P-256 (ES256) instead of HS256 for JWT signing
- Add `SUPABASE_JWT_JWKS_URL` config option to fetch public keys from JWKS endpoint
- `PyJWKClient` handles key caching and rotation automatically
- Backward compatible: `SUPABASE_JWT_SECRET` (HS256) still works for legacy projects

### Production config

```
SUPABASE_JWT_JWKS_URL=https://czgzvulavmtexfqagccy.supabase.co/auth/v1/.well-known/jwks.json
```

## Test plan
- [x] Existing dashboard chat tests pass (pre-existing SQLite schema issue unrelated)
- [x] `PyJWKClient` import verified available in current PyJWT

🤖 Generated with [Claude Code](https://claude.com/claude-code)