### PR TITLE
fix: use agent_token field from verify response for claim-link request

### DIFF
--- a/plugin/src/commands/register.ts
+++ b/plugin/src/commands/register.ts
@@ -247,7 +247,7 @@ export async function registerAgent(opts: {
     throw new Error(`Verification failed (${verifyResp.status}): ${body}`);
   }
 
-  const verifyData = (await verifyResp.json()) as { token: string };
+  const verifyData = (await verifyResp.json()) as { agent_token: string };
 
   // 5. Fetch claim URL (best-effort)
   let claimUrl: string | undefined;
@@ -255,7 +255,7 @@ export async function registerAgent(opts: {
     const claimResp = await fetch(
       `${normalizedHub}/registry/agents/${regData.agent_id}/claim-link`,
       {
-        headers: { Authorization: `Bearer ${verifyData.token}` },
+        headers: { Authorization: `Bearer ${verifyData.agent_token}` },
       },
     );
     if (claimResp.ok) {


### PR DESCRIPTION
## 问题

注册完成后，`claim-link` 请求始终静默失败，导致用户无法获取认领链接（相关 issue #43）。

根本原因：插件将 `/registry/agents/{id}/verify` 的响应 cast 为 `{ token: string }`，但后端实际返回的字段名是 `agent_token`（见 `VerifyResponse` schema）。导致 `Authorization: Bearer undefined` 被发出，服务端鉴权失败。

## 修复

```ts
// 修复前
const verifyData = (await verifyResp.json()) as { token: string };
headers: { Authorization: `Bearer ${verifyData.token}` }

// 修复后
const verifyData = (await verifyResp.json()) as { agent_token: string };
headers: { Authorization: `Bearer ${verifyData.agent_token}` }
```

## 验证

- `npx tsc --noEmit` 通过
- `npm test`：18 个测试文件，176 个测试，全部通过