### PR TITLE
fix: proxy subscribe endpoint to backend and support reactivation

### DIFF
--- a/backend/hub/routers/subscriptions.py
+++ b/backend/hub/routers/subscriptions.py
@@ -6,7 +6,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from hub import config as hub_config
-from hub.auth import get_current_claimed_agent
+from hub.auth import get_current_claimed_agent, get_dashboard_claimed_agent
 from hub.database import get_db
 from hub.models import SubscriptionRoomCreatorPolicy
 from hub.services import subscriptions as subscription_svc
@@ -153,7 +153,7 @@ async def archive_product(
 async def subscribe(
     product_id: str,
     req: SubscriptionCreateRequest,
-    current_agent: str = Depends(get_current_claimed_agent),
+    current_agent: str = Depends(get_dashboard_claimed_agent),
     db: AsyncSession = Depends(get_db),
 ):
     try:

--- a/backend/hub/services/subscriptions.py
+++ b/backend/hub/services/subscriptions.py
@@ -205,7 +205,10 @@ async def create_subscription(
     current = existing.scalar_one_or_none()
     if current is not None:
         if current.status == SubscriptionStatus.cancelled:
-            raise ValueError("Subscription already cancelled")
+            # Reactivate cancelled subscription: charge and reset billing period
+            return await _reactivate_subscription(
+                session, current, product, idempotency_key,
+            )
         return current
 
     now = _utcnow()
@@ -262,6 +265,49 @@ async def create_subscription(
         if current is not None:
             return current
         raise ValueError("Subscription already exists")
+
+    await _auto_join_subscription_rooms(session, subscription)
+    return subscription
+
+
+async def _reactivate_subscription(
+    session: AsyncSession,
+    subscription: AgentSubscription,
+    product: SubscriptionProduct,
+    idempotency_key: str | None,
+) -> AgentSubscription:
+    """Reactivate a cancelled subscription by charging and resetting the billing period."""
+    now = _utcnow()
+    current_period_end = _advance_period(now, product.billing_interval)
+
+    metadata = {
+        "kind": "subscription_charge",
+        "product_id": product.product_id,
+        "subscription_id": subscription.subscription_id,
+        "billing_cycle_key": now.isoformat(),
+    }
+    tx = await create_transfer(
+        session,
+        from_agent_id=subscription.subscriber_agent_id,
+        to_agent_id=product.owner_agent_id,
+        amount_minor=product.amount_minor,
+        idempotency_key=idempotency_key or f"subscription:reactivate:{subscription.subscription_id}:{now.isoformat()}",
+        reference_type="subscription_charge",
+        reference_id=subscription.subscription_id,
+        metadata=metadata,
+        asset_code=product.asset_code,
+    )
+
+    subscription.status = SubscriptionStatus.active
+    subscription.current_period_start = now
+    subscription.current_period_end = current_period_end
+    subscription.next_charge_at = current_period_end
+    subscription.cancel_at_period_end = False
+    subscription.cancelled_at = None
+    subscription.last_charged_at = now
+    subscription.last_charge_tx_id = tx.tx_id
+    subscription.consecutive_failed_attempts = 0
+    await session.flush()
 
     await _auto_join_subscription_rooms(session, subscription)
     return subscription

--- a/frontend/src/app/api/subscriptions/products/[productId]/subscribe/route.ts
+++ b/frontend/src/app/api/subscriptions/products/[productId]/subscribe/route.ts
@@ -1,38 +1,40 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireAgent } from "@/lib/require-agent";
-import {
-  createSubscription,
-  SubscriptionError,
-} from "@/lib/services/subscriptions";
-import { TransferError } from "@/lib/services/wallet";
+import { getBoundAgentToken } from "@/app/api/_hub-proxy";
+
+const API_BASE =
+  process.env.NEXT_PUBLIC_HUB_BASE_URL ||
+  (process.env.NODE_ENV === "development" ? "http://localhost:8000" : "https://api.botcord.chat");
 
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ productId: string }> },
 ) {
-  const { agentId, error } = await requireAgent();
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: error.status });
-  }
+  const bound = await getBoundAgentToken();
+  if (bound.error) return bound.error;
 
   const { productId } = await params;
   const body = await request.json().catch(() => ({}));
-  const { idempotency_key } = body as { idempotency_key?: string };
 
-  try {
-    const result = await createSubscription(
-      productId,
-      agentId,
-      idempotency_key,
-    );
-    return NextResponse.json(result, { status: 201 });
-  } catch (err) {
-    if (err instanceof SubscriptionError) {
-      return NextResponse.json({ error: err.message }, { status: err.status });
-    }
-    if (err instanceof TransferError) {
-      return NextResponse.json({ error: err.message }, { status: err.status });
-    }
-    throw err;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${bound.token}`,
+  };
+  if (bound.agentId) {
+    headers["X-Active-Agent"] = bound.agentId;
   }
+
+  const upstream = await fetch(
+    `${API_BASE}/subscriptions/products/${encodeURIComponent(productId)}/subscribe`,
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    },
+  );
+
+  const text = await upstream.text();
+  return new NextResponse(text, {
+    status: upstream.status,
+    headers: { "content-type": upstream.headers.get("content-type") || "application/json" },
+  });
 }


### PR DESCRIPTION
## Summary
- Frontend subscribe API route was directly operating the DB without a transaction, causing 500 errors on race conditions (transfer succeeds but subscription insert fails)
- Changed frontend to proxy to backend `POST /subscriptions/products/{productId}/subscribe`, consistent with other proxied endpoints (chat/send, inbox, etc.)
- Backend subscribe auth switched to `get_dashboard_claimed_agent` for Supabase JWT + X-Active-Agent compatibility
- Added `_reactivate_subscription` in backend to support re-subscribing after cancellation (previously raised `ValueError`)

## Test plan
- [ ] Subscribe to a product → verify subscription created and coins deducted
- [ ] Subscribe again to same product → verify idempotent return
- [ ] Cancel subscription then re-subscribe → verify reactivation works
- [ ] Verify insufficient balance returns 400 not 500
- [ ] Confirm no DB migration needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)