### PR TITLE
fix: user chat sender_id VARCHAR(32) + FK constraint violation

### DIFF
--- a/backend/hub/routers/dashboard_chat.py
+++ b/backend/hub/routers/dashboard_chat.py
@@ -181,7 +181,7 @@ async def send_chat_message(
         "v": "a2a/0.1",
         "msg_id": msg_id,
         "ts": ts,
-        "from": f"user:{user_id}",
+        "from": agent_id,
         "to": agent_id,
         "type": "message",
         "reply_to": None,
@@ -193,10 +193,13 @@ async def send_chat_message(
     envelope_json = json.dumps(envelope_data)
 
     hub_msg_id = generate_hub_msg_id()
+    # sender_id must be a valid agents.agent_id (FK constraint + VARCHAR(32)).
+    # The real user identity is captured in source_user_id; sender_id uses
+    # the agent_id so the record satisfies the FK and column-width constraints.
     record = MessageRecord(
         hub_msg_id=hub_msg_id,
         msg_id=msg_id,
-        sender_id=f"user:{user_id}",
+        sender_id=agent_id,
         receiver_id=agent_id,
         room_id=room_id,
         state=MessageState.queued,
@@ -225,7 +228,7 @@ async def send_chat_message(
         realtime_event=build_message_realtime_event(
             type="message",
             agent_id=agent_id,
-            sender_id=f"user:{user_id}",
+            sender_id=agent_id,
             room_id=room_id,
             hub_msg_id=hub_msg_id,
             created_at=record.created_at,

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -46,7 +46,7 @@ function TypewriterText({
 }
 
 function isOwnerMessage(msg: DashboardMessage): boolean {
-  return msg.source_type === "dashboard_user_chat" || msg.sender_id.startsWith("user:");
+  return msg.source_type === "dashboard_user_chat";
 }
 
 export default function UserChatPane() {


### PR DESCRIPTION
## Summary

- Fix 500 error on `POST /dashboard/chat/send` caused by `sender_id` using `"user:{uuid}"` (42 chars) which exceeds the `VARCHAR(32)` column limit and violates the FK constraint to `agents.agent_id`
- Use `agent_id` as `sender_id` instead — the real user identity is already captured in `source_type` + `source_user_id` fields
- Update frontend `isOwnerMessage()` to rely solely on `source_type === "dashboard_user_chat"` instead of `sender_id.startsWith("user:")`

## Test plan
- [x] `cd backend && uv run pytest tests/test_dashboard_chat.py -v` — 5 passed
- [x] `cd frontend && npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)