### PR TITLE
fix: BFF subscription room join bypass and auto-enter

### DIFF
--- a/frontend/src/app/api/dashboard/rooms/[roomId]/join/route.ts
+++ b/frontend/src/app/api/dashboard/rooms/[roomId]/join/route.ts
@@ -54,14 +54,8 @@ export async function POST(
     return NextResponse.json({ error: "Room not found" }, { status: 404 });
   }
 
-  if (room.visibility !== "public") {
-    return NextResponse.json({ error: "Room is not public" }, { status: 403 });
-  }
-
-  if (room.joinPolicy !== "open") {
-    return NextResponse.json({ error: "Room does not allow open join" }, { status: 403 });
-  }
-
+  // Check subscription access first — active subscribers bypass visibility/joinPolicy
+  let hasSubscriptionAccess = false;
   if (room.requiredSubscriptionProductId) {
     const [subscription] = await backendDb
       .select({ id: agentSubscriptions.id })
@@ -75,11 +69,23 @@ export async function POST(
       )
       .limit(1);
 
-    if (!subscription) {
+    if (subscription) {
+      hasSubscriptionAccess = true;
+    } else {
       return NextResponse.json(
         { error: "Active subscription required before joining this room" },
         { status: 403 },
       );
+    }
+  }
+
+  if (!hasSubscriptionAccess) {
+    if (room.visibility !== "public") {
+      return NextResponse.json({ error: "Room is not public" }, { status: 403 });
+    }
+
+    if (room.joinPolicy !== "open") {
+      return NextResponse.json({ error: "Room does not allow open join" }, { status: 403 });
     }
   }
 
@@ -91,7 +97,15 @@ export async function POST(
     .limit(1);
 
   if (existing) {
-    return NextResponse.json({ error: "Already a member of this room" }, { status: 409 });
+    // Backend auto-join may have already added the member during subscription;
+    // treat as success so the frontend flow completes cleanly.
+    return NextResponse.json({
+      room_id: roomId,
+      agent_id: agentId,
+      role: "member",
+      joined: true,
+      already_member: true,
+    });
   }
 
   // Check max_members

--- a/frontend/src/components/dashboard/SubscriptionBadge.tsx
+++ b/frontend/src/components/dashboard/SubscriptionBadge.tsx
@@ -8,12 +8,14 @@
  */
 
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { api } from "@/lib/api";
 import type { SubscriptionProduct } from "@/lib/types";
 import { useShallow } from "zustand/react/shallow";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardSubscriptionStore } from "@/store/useDashboardSubscriptionStore";
+import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 
 interface SubscriptionBadgeProps {
   productId?: string | null;
@@ -34,6 +36,7 @@ export default function SubscriptionBadge({
   triggerLabel,
   loginHref,
 }: SubscriptionBadgeProps) {
+  const router = useRouter();
   const [showModal, setShowModal] = useState(false);
   const [loading, setLoading] = useState(false);
   const [productData, setProductData] = useState<SubscriptionProduct | null>(null);
@@ -46,7 +49,15 @@ export default function SubscriptionBadge({
     activeAgentId: state.activeAgentId,
     sessionMode: state.sessionMode,
   })));
-  const joinRoom = useDashboardChatStore((state) => state.joinRoom);
+  const { joinRoom, loadRoomMessages } = useDashboardChatStore(useShallow((state) => ({
+    joinRoom: state.joinRoom,
+    loadRoomMessages: state.loadRoomMessages,
+  })));
+  const { setOpenedRoomId, setFocusedRoomId, setSidebarTab } = useDashboardUIStore(useShallow((state) => ({
+    setOpenedRoomId: state.setOpenedRoomId,
+    setFocusedRoomId: state.setFocusedRoomId,
+    setSidebarTab: state.setSidebarTab,
+  })));
   const {
     getActiveSubscription,
     ensureSubscriptions,
@@ -132,6 +143,12 @@ export default function SubscriptionBadge({
       }
       if (roomId) {
         await joinRoom(roomId);
+        // Navigate into the room immediately
+        setFocusedRoomId(roomId);
+        setOpenedRoomId(roomId);
+        setSidebarTab("messages");
+        loadRoomMessages(roomId);
+        router.push(`/chats/messages/${encodeURIComponent(roomId)}`);
       }
       setShowModal(false);
     } catch (err) {


### PR DESCRIPTION
## Summary
- **BFF join route**: subscription-gated rooms (private/invite_only) were blocked by visibility/joinPolicy checks that ran before the subscription check. Now active subscribers bypass those checks, matching the backend hub behavior.
- **Already-member handling**: returns 200 instead of 409 when the backend auto-join already added the member during subscription.
- **Auto-enter room**: SubscriptionBadge now navigates directly into the room after subscribe + join, removing the extra manual step.

## Test plan
- [ ] Subscribe to a product with a gated private room → should auto-enter the room
- [ ] Re-subscribe (already member) → should still succeed and navigate into room
- [ ] Join a public/open room without subscription → should still work as before
- [ ] Try joining a subscription room without subscribing → should get 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)