### PR TITLE
feat(plugin): release channel for prod/test env separation

### DIFF
--- a/.github/workflows/publish-plugin.yml
+++ b/.github/workflows/publish-plugin.yml
@@ -11,6 +11,14 @@ on:
           - patch
           - minor
           - major
+      channel:
+        description: "Release channel (stable → latest, beta → test hub)"
+        required: true
+        type: choice
+        options:
+          - stable
+          - beta
+        default: stable
 
 jobs:
   publish:
@@ -45,6 +53,13 @@ jobs:
         id: bump
         run: |
           NEW_VERSION=$(npm version ${{ github.event.inputs.bump }} --no-git-tag-version)
+          if [ "${{ github.event.inputs.channel }}" = "beta" ]; then
+            # Append -beta.<timestamp> prerelease suffix
+            BASE="${NEW_VERSION#v}"
+            BETA_VERSION="${BASE}-beta.$(date +%Y%m%d%H%M%S)"
+            npm version "$BETA_VERSION" --no-git-tag-version --allow-same-version
+            NEW_VERSION="v${BETA_VERSION}"
+          fi
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Sync version to openclaw.plugin.json
@@ -53,12 +68,23 @@ jobs:
           VERSION="${VERSION#v}"
           jq --arg v "$VERSION" '.version = $v' openclaw.plugin.json > tmp.json && mv tmp.json openclaw.plugin.json
 
+      - name: Set release channel in source
+        if: github.event.inputs.channel == 'beta'
+        run: |
+          sed -i 's/RELEASE_CHANNEL: ReleaseChannel = "stable"/RELEASE_CHANNEL: ReleaseChannel = "beta"/' src/constants.ts
+
       - name: Publish to npm
-        run: npm publish --access public
+        run: |
+          if [ "${{ github.event.inputs.channel }}" = "beta" ]; then
+            npm publish --access public --tag beta
+          else
+            npm publish --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Commit and tag
+        if: github.event.inputs.channel == 'stable'
         run: |
           git add package.json package-lock.json openclaw.plugin.json
           git commit -m "chore: release ${{ steps.bump.outputs.new_version }}"
@@ -93,6 +119,7 @@ jobs:
               {"label": "状态", "value": "${{ steps.notify-data.outputs.status_desc }}"},
               {"label": "版本", "value": "${{ steps.bump.outputs.new_version }}"},
               {"label": "Bump 类型", "value": "${{ github.event.inputs.bump }}"},
+              {"label": "渠道", "value": "${{ github.event.inputs.channel }}"},
               {"label": "触发者", "value": "${{ github.actor }}"}
             ]
           buttons: |

--- a/plugin/src/commands/register.ts
+++ b/plugin/src/commands/register.ts
@@ -25,8 +25,7 @@ import {
 } from "../config.js";
 import { normalizeAndValidateHubUrl } from "../hub-url.js";
 import { getBotCordRuntime } from "../runtime.js";
-
-const DEFAULT_HUB = "https://api.botcord.chat";
+import { DEFAULT_HUB } from "../constants.js";
 
 interface RegisterResult {
   agentId: string;

--- a/plugin/src/constants.ts
+++ b/plugin/src/constants.ts
@@ -1,0 +1,19 @@
+/**
+ * Release channel and environment-dependent defaults.
+ *
+ * In the stable (production) build this file ships as-is.
+ * The CI pipeline replaces the RELEASE_CHANNEL value with "beta"
+ * before publishing to the `beta` npm dist-tag, so that beta
+ * installations automatically point at the test hub.
+ */
+
+export type ReleaseChannel = "stable" | "beta";
+
+export const RELEASE_CHANNEL: ReleaseChannel = "stable";
+
+const HUB_URLS: Record<ReleaseChannel, string> = {
+  stable: "https://api.botcord.chat",
+  beta: "https://test.botcord.chat",
+};
+
+export const DEFAULT_HUB = HUB_URLS[RELEASE_CHANNEL];


### PR DESCRIPTION
## Summary
- Add `plugin/src/constants.ts` with `RELEASE_CHANNEL` → `DEFAULT_HUB` mapping (`stable` → prod, `beta` → test hub)
- Refactor `register.ts` to import `DEFAULT_HUB` from constants instead of hardcoding
- Extend `publish-plugin.yml` with `channel` input: beta publishes use `-beta.<ts>` version suffix, `--tag beta` dist-tag, and swap `RELEASE_CHANNEL` to `"beta"` via sed before publish

## How it works
- **Stable publish**: identical to current behavior, no changes
- **Beta publish**: CI replaces `RELEASE_CHANNEL` in source → all hub requests point to `https://test.botcord.chat` → published with `npm --tag beta` so `latest` is unaffected
- Test users install via `npm install @botcord/botcord@beta`, zero config needed

## Test plan
- [x] All 177 plugin tests pass
- [ ] Manual: trigger workflow with `channel=beta`, verify published package has `test.botcord.chat` as default hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)