### PR TITLE
fix(plugin): inline openclaw/plugin-sdk imports for 3.22+ compatibility

### DIFF
--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -1,7 +1,6 @@
 /**
  * @botcord/botcord — OpenClaw plugin for BotCord A2A messaging protocol.
  */
-import { defineChannelPluginEntry } from "openclaw/plugin-sdk/core";
 import { botCordPlugin } from "./src/channel.js";
 import { setBotCordRuntime, setConfigGetter } from "./src/runtime.js";
 import { createMessagingTool, createUploadTool } from "./src/tools/messaging.js";
@@ -26,17 +25,18 @@ import {
   shouldRunBotCordLoopRiskCheck,
 } from "./src/loop-risk.js";
 
-export default defineChannelPluginEntry({
+// Inline replacement for defineChannelPluginEntry from openclaw/plugin-sdk/core.
+// Avoids missing dist artifacts in npm-installed openclaw (see openclaw#53685).
+export default {
   id: "botcord",
   name: "BotCord",
   description: "BotCord A2A messaging protocol — secure agent-to-agent communication with Ed25519 signing",
-  plugin: botCordPlugin,
+  register(api: any) {
+    setBotCordRuntime(api.runtime);
+    api.registerChannel({ plugin: botCordPlugin });
 
-  setRuntime(runtime) {
-    setBotCordRuntime(runtime);
-  },
+    if (api.registrationMode !== "full") return;
 
-  registerFull(api) {
     setConfigGetter(() => api.config);
 
     // Agent tools — `as any` needed until tool execute() return types are
@@ -54,7 +54,7 @@ export default defineChannelPluginEntry({
     api.registerTool(createBindTool() as any);
 
     // Hooks
-    api.on("after_tool_call", async (event, ctx) => {
+    api.on("after_tool_call", async (event: any, ctx: any) => {
       if (ctx.toolName !== "botcord_send") return;
       if (!didBotCordSendSucceed(event.result, event.error)) return;
       recordBotCordOutboundText({
@@ -63,7 +63,7 @@ export default defineChannelPluginEntry({
       });
     });
 
-    api.on("before_prompt_build", async (event, ctx) => {
+    api.on("before_prompt_build", async (event: any, ctx: any) => {
       if (!shouldRunBotCordLoopRiskCheck({
         channelId: ctx.channelId,
         prompt: event.prompt,
@@ -82,7 +82,7 @@ export default defineChannelPluginEntry({
       return { prependContext };
     }, { priority: 10 });
 
-    api.on("session_end", async (_event, ctx) => {
+    api.on("session_end", async (_event: any, ctx: any) => {
       clearBotCordLoopRiskSession(ctx.sessionKey);
     });
 
@@ -95,7 +95,7 @@ export default defineChannelPluginEntry({
     const registerCli = createRegisterCli();
     api.registerCli(registerCli.setup, { commands: registerCli.commands });
   },
-});
+};
 
 export { TopicTracker } from "./src/topic-tracker.js";
 export type { TopicState, TopicInfo } from "./src/topic-tracker.js";

--- a/plugin/setup-entry.ts
+++ b/plugin/setup-entry.ts
@@ -1,5 +1,5 @@
 // setup-entry.ts — lightweight entry for onboarding/config (no heavy deps like ws)
-import { defineSetupPluginEntry } from "openclaw/plugin-sdk/core";
 import { botCordPlugin } from "./src/channel.js";
 
-export default defineSetupPluginEntry(botCordPlugin);
+// Inline replacement for defineSetupPluginEntry (just returns { plugin }).
+export default { plugin: botCordPlugin };

--- a/plugin/src/channel.ts
+++ b/plugin/src/channel.ts
@@ -4,11 +4,35 @@
  * security, messaging, and status adapters.
  */
 import type { ChannelPlugin, OpenClawConfig as ClawdbotConfig } from "openclaw/plugin-sdk/core";
-import {
-  buildBaseChannelStatusSummary,
-  createDefaultChannelRuntimeState,
-} from "openclaw/plugin-sdk/status-helpers";
-import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
+// Inlined from openclaw/plugin-sdk/status-helpers and account-id to avoid
+// missing dist artifacts in npm-installed openclaw (see openclaw#53685).
+const DEFAULT_ACCOUNT_ID = "default";
+
+function createDefaultChannelRuntimeState(accountId: string) {
+  return {
+    accountId,
+    running: false as const,
+    lastStartAt: null,
+    lastStopAt: null,
+    lastError: null,
+  };
+}
+
+function buildBaseChannelStatusSummary(snapshot: {
+  configured?: boolean | null;
+  running?: boolean | null;
+  lastStartAt?: number | null;
+  lastStopAt?: number | null;
+  lastError?: string | null;
+}) {
+  return {
+    configured: snapshot.configured ?? false,
+    running: snapshot.running ?? false,
+    lastStartAt: snapshot.lastStartAt ?? null,
+    lastStopAt: snapshot.lastStopAt ?? null,
+    lastError: snapshot.lastError ?? null,
+  };
+}
 import {
   resolveChannelConfig,
   resolveAccounts,

--- a/plugin/src/inbound.ts
+++ b/plugin/src/inbound.ts
@@ -5,7 +5,20 @@
 import { getBotCordRuntime } from "./runtime.js";
 import { resolveAccountConfig } from "./config.js";
 import { buildSessionKey } from "./session-key.js";
-import { loadSessionStore } from "openclaw/plugin-sdk/mattermost";
+import { readFileSync } from "node:fs";
+
+// Simplified inline replacement for loadSessionStore from openclaw/plugin-sdk/mattermost.
+// Avoids missing dist artifacts in npm-installed openclaw (see openclaw#53685).
+function loadSessionStore(storePath: string): Record<string, any> {
+  try {
+    const raw = readFileSync(storePath, "utf-8");
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
 import { sanitizeUntrustedContent, sanitizeSenderName } from "./sanitize.js";
 import { BotCordClient } from "./client.js";
 import { createBotCordReplyDispatcher } from "./reply-dispatcher.js";


### PR DESCRIPTION
## Summary

- Inline all runtime imports from `openclaw/plugin-sdk` to fix plugin loading on OpenClaw 3.22+
- Workaround for two upstream bugs:
  1. **jiti alias resolution failure** — third-party plugins installed to `~/.openclaw/extensions/` can't resolve `openclaw/plugin-sdk/*` because the alias walker starts from the plugin directory instead of the loader's own location (openclaw#53685, #53403, #53002)
  2. **Missing dist artifacts** — npm-published openclaw package declares 103 `plugin-sdk/*` subpath exports but only ships dist files for ~50 of them; `status-helpers`, `mattermost`, etc. are missing

### Changes
| Original import | Replacement |
|----------------|-------------|
| `defineChannelPluginEntry` from `core` | Direct `{ id, name, register }` export |
| `defineSetupPluginEntry` from `core` | Direct `{ plugin }` export |
| `createDefaultChannelRuntimeState` from `status-helpers` | Inlined function |
| `buildBaseChannelStatusSummary` from `status-helpers` | Inlined function |
| `DEFAULT_ACCOUNT_ID` from `account-id` | Inlined constant `"default"` |
| `loadSessionStore` from `mattermost` | Simplified local implementation |

Only `import type` (erased at runtime) remains from `openclaw/plugin-sdk/core`.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 177 tests pass
- [x] Verified locally: `openclaw plugins install` → status `loaded` → channel `ON / OK / configured` on OpenClaw 2026.3.23-2


🤖 Generated with [Claude Code](https://claude.com/claude-code)