### PR TITLE
ci: remap deploy environments — PR→test, main→preview, release→prod

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -3,8 +3,6 @@ name: Deploy Backend
 on:
   push:
     branches: ["main", "release"]
-    paths:
-      - "backend/**"
   pull_request:
     branches: ["main"]
     paths:


### PR DESCRIPTION
## Summary

- PR to main → build `test` image + restart service
- Push to main → build `preview` image + restart service
- Push to release → build `prod` image only (no restart)

Previously main push built prod and preview branch built preview. Now release branch controls prod builds, and main controls preview.

## Test plan

- [ ] Verify PR triggers build with `env_name=test`
- [ ] Verify main push triggers build with `env_name=preview`
- [ ] Verify release push triggers build with `env_name=prod` and skips restart