### PR TITLE
feat(plugin): allow stranger transfers with confirmation step

### DIFF
--- a/plugin/src/__tests__/payment.integration.test.ts
+++ b/plugin/src/__tests__/payment.integration.test.ts
@@ -171,22 +171,64 @@ describe("payment tool integration", () => {
     expect(balance.result).toContain("Available: 180.00 COIN");
   });
 
-  it("rejects transfers to non-contacts", async () => {
+  it("transfers to contacts without requiring confirmation", async () => {
+    const sender = makeClient("ag_sender", senderKeys.privateKey);
+    const tool = createPaymentTool();
+
+    await seedBalance(sender, "25000");
+    hub.state.contacts = [
+      { contact_agent_id: "ag_receiver", display_name: "Receiver", created_at: new Date().toISOString() },
+    ];
+    makeToolConfig("ag_sender", senderKeys.privateKey);
+
+    // No confirmed param needed — recipient is a contact
+    const transfer: any = await tool.execute("tool-contact-transfer", {
+      action: "transfer",
+      to_agent_id: "ag_receiver",
+      amount_minor: "5000",
+    });
+
+    expect(transfer.data.tx.type).toBe("transfer");
+    expect(transfer.data.tx.to_agent_id).toBe("ag_receiver");
+    expect(transfer.result).not.toContain("is not in your contacts");
+    expect(transfer.data.transfer_record_message.sent).toBe(true);
+    expect(transfer.data.notifications.payer.sent).toBe(true);
+    expect(transfer.data.notifications.payee.sent).toBe(true);
+    expect(hub.state.messages).toHaveLength(3);
+  });
+
+  it("requires confirmation for stranger transfers", async () => {
     const sender = makeClient("ag_sender", senderKeys.privateKey);
     const tool = createPaymentTool();
 
     await seedBalance(sender, "25000");
     makeToolConfig("ag_sender", senderKeys.privateKey);
 
-    const transfer: any = await tool.execute("tool-non-contact", {
+    // First call without confirmed — should return a warning, no transfer executed
+    const warning: any = await tool.execute("tool-non-contact", {
       action: "transfer",
       to_agent_id: "ag_receiver",
       amount_minor: "7000",
     });
 
-    expect(transfer.error).toContain("only allowed between contacts");
-    expect(hub.state.walletTransactions).toHaveLength(1);
+    expect(warning.result).toContain("is not in your contacts");
+    expect(warning.result).toContain("stranger transfer");
+    expect(warning.result).toContain("confirmed: true");
+    expect(warning.data).toBeUndefined();
+    expect(hub.state.walletTransactions).toHaveLength(1); // only the topup
     expect(hub.state.messages).toHaveLength(0);
+
+    // Second call with confirmed: true — should proceed
+    const transfer: any = await tool.execute("tool-non-contact-confirm", {
+      action: "transfer",
+      to_agent_id: "ag_receiver",
+      amount_minor: "7000",
+      confirmed: true,
+    });
+
+    expect(transfer.data.tx.type).toBe("transfer");
+    expect(transfer.data.tx.to_agent_id).toBe("ag_receiver");
+    expect(hub.state.messages).toHaveLength(3); // record + 2 notifications
   });
 
   it("keeps transfer successful when follow-up messages fail", async () => {

--- a/plugin/src/tools/payment-transfer.ts
+++ b/plugin/src/tools/payment-transfer.ts
@@ -9,7 +9,7 @@ type FollowUpDeliveryResult = {
   error?: string;
 };
 
-export type ContactOnlyTransferResult = {
+export type TransferResult = {
   tx: WalletTransaction;
   transfer_record_message: FollowUpDeliveryResult;
   notifications: {
@@ -17,6 +17,7 @@ export type ContactOnlyTransferResult = {
     payee: FollowUpDeliveryResult;
   };
 };
+
 
 function extractTransferMetadata(tx: WalletTransaction): Record<string, unknown> | null {
   if (!tx.metadata_json) return null;
@@ -33,13 +34,11 @@ function formatOptionalLine(label: string, value: string | null | undefined): st
   return value ? `${label}: ${value}` : null;
 }
 
-export async function assertTransferPeerIsContact(client: BotCordClient, toAgentId: string): Promise<void> {
+export async function isPeerContact(client: BotCordClient, toAgentId: string): Promise<boolean> {
   const contacts = await client.listContacts();
-  const isContact = contacts.some((contact) => contact.contact_agent_id === toAgentId);
-  if (!isContact) {
-    throw new Error("Transfer is only allowed between contacts. Please add this agent as a contact first.");
-  }
+  return contacts.some((contact) => contact.contact_agent_id === toAgentId);
 }
+
 
 export function buildTransferRecordMessage(tx: WalletTransaction): string {
   const metadata = extractTransferMetadata(tx);
@@ -68,7 +67,7 @@ export function buildTransferNotificationMessage(
   return `[BotCord Notice] Payment received: ${formatCoinAmount(tx.amount_minor)} from ${tx.from_agent_id} (tx: ${tx.tx_id})`;
 }
 
-export function formatFollowUpDeliverySummary(result: ContactOnlyTransferResult): string {
+export function formatFollowUpDeliverySummary(result: TransferResult): string {
   const lines = [
     `Transfer record message: ${result.transfer_record_message.sent ? "sent" : "failed"}`,
     `Payer notification: ${result.notifications.payer.sent ? "sent" : "failed"}`,
@@ -121,7 +120,7 @@ async function sendNotification(
   }
 }
 
-export async function executeContactOnlyTransfer(
+export async function executeTransfer(
   client: BotCordClient,
   params: {
     to_agent_id: string;
@@ -132,9 +131,7 @@ export async function executeContactOnlyTransfer(
     metadata?: Record<string, unknown>;
     idempotency_key?: string;
   },
-): Promise<ContactOnlyTransferResult> {
-  await assertTransferPeerIsContact(client, params.to_agent_id);
-
+): Promise<TransferResult> {
   const tx = await client.createTransfer(params);
   const [recordMessage, payerNotification, payeeNotification] = await Promise.all([
     sendRecordMessage(client, tx),

--- a/plugin/src/tools/payment.ts
+++ b/plugin/src/tools/payment.ts
@@ -9,7 +9,7 @@ import {
 import { BotCordClient } from "../client.js";
 import { getConfig as getAppConfig } from "../runtime.js";
 import { formatCoinAmount } from "./coin-format.js";
-import { executeContactOnlyTransfer, formatFollowUpDeliverySummary } from "./payment-transfer.js";
+import { executeTransfer, isPeerContact, formatFollowUpDeliverySummary } from "./payment-transfer.js";
 
 function sanitizeBalance(summary: any): any {
   return {
@@ -275,6 +275,10 @@ export function createPaymentTool(opts?: { name?: string; description?: string }
           type: "string" as const,
           description: "Pagination cursor — for ledger",
         },
+        confirmed: {
+          type: "boolean" as const,
+          description: "Set to true to confirm a stranger transfer (recipient not in contacts) — for transfer",
+        },
         limit: {
           type: "number" as const,
           description: "Max entries to return — for ledger",
@@ -324,7 +328,15 @@ export function createPaymentTool(opts?: { name?: string; description?: string }
           case "transfer": {
             if (!args.to_agent_id) return { error: "to_agent_id is required" };
             if (!args.amount_minor) return { error: "amount_minor is required" };
-            const transfer = await executeContactOnlyTransfer(client, {
+
+            const isContact = await isPeerContact(client, args.to_agent_id);
+            if (!isContact && args.confirmed !== true) {
+              return {
+                result: `\u26a0\ufe0f ${args.to_agent_id} is not in your contacts. This is a stranger transfer of ${formatCoinAmount(args.amount_minor)}. To proceed, call this tool again with confirmed: true. The transfer will create a chat room between you and the recipient.`,
+              };
+            }
+
+            const transfer = await executeTransfer(client, {
               to_agent_id: args.to_agent_id,
               amount_minor: args.amount_minor,
               memo: args.memo,


### PR DESCRIPTION
## Summary
- Remove contact-only restriction on wallet transfers — strangers can now transfer coins
- When recipient is not a contact, returns a confirmation prompt; AI must re-call with `confirmed: true` to proceed
- After a successful stranger transfer, the follow-up record message auto-creates a DM room between the two parties

## Changes
- `payment-transfer.ts`: `assertTransferPeerIsContact` → `isPeerContact` (bool), `executeContactOnlyTransfer` → `executeTransfer` (no contact check), removed deprecated aliases
- `payment.ts`: Added `confirmed` parameter to transfer action with stranger detection logic
- `payment.integration.test.ts`: Added tests for stranger confirmation flow and contact direct-transfer path

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — all 178 tests pass
- [x] Stranger transfer returns confirmation prompt without `confirmed`
- [x] Stranger transfer succeeds with `confirmed: true`
- [x] Contact transfer succeeds without `confirmed` parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)