### PR TITLE
fix(app): include source_type in user chat messages

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -941,6 +941,7 @@ async def get_room_messages(
             "topic_id": rec.topic_id,
             "topic_title": topic_info.get(rec.topic_id, {}).get("title") if rec.topic_id else None,
             "created_at": rec.created_at.isoformat() if rec.created_at else None,
+            "source_type": rec.source_type,
         }
         if is_member:
             msg["mentioned"] = rec.mentioned


### PR DESCRIPTION
## Summary
- App-layer `get_room_messages` endpoint was missing `source_type` field in the response dict
- Frontend `isOwnerMessage()` always returned `false`, causing all user-sent messages to display on the left (agent side) instead of the right
- Added `"source_type": rec.source_type` to the message response

## Test plan
- [ ] Open dashboard user chat, send a message — verify it appears on the right side
- [ ] Agent replies should still appear on the left side
- [ ] Existing room message views should be unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)