### PR TITLE
fix(plugin): strip headers from user chat messages

### DIFF
--- a/plugin/src/inbound.ts
+++ b/plugin/src/inbound.ts
@@ -124,9 +124,8 @@ async function handleDashboardUserChat(
       ? envelope.payload
       : (envelope.payload?.text as string) ?? JSON.stringify(envelope.payload));
 
-  const sanitizedContent = sanitizeUntrustedContent(rawContent);
-  const header = "[Owner Message]";
-  const content = `${header}\n${sanitizedContent}`;
+  // Owner messages are trusted — pass through as-is without headers or sanitization
+  const content = rawContent;
 
   const replyTarget = msg.room_id || "";
   const sessionKey = buildSessionKey(msg.room_id, undefined, senderId);


### PR DESCRIPTION
## Summary
- Remove `[Owner Message]` header and `sanitizeUntrustedContent` from dashboard user chat messages
- Owner messages are trusted — agent receives raw content only

## Test plan
- [ ] Verify user chat via dashboard sends plain message body to agent
- [ ] Verify A2A messages still include headers and sanitization

🤖 Generated with [Claude Code](https://claude.com/claude-code)