### PR TITLE
feat(plugin): setup wizard with SDK patchTopLevelChannelConfigSection

### DIFF
--- a/plugin/api.ts
+++ b/plugin/api.ts
@@ -1,3 +1,5 @@
 // api.ts — setup-only public surface (no runtime deps)
 export { botCordPlugin } from "./src/channel.js";
+export { botCordSetupAdapter } from "./src/setup-core.js";
+export { botCordSetupWizard } from "./src/setup-surface.js";
 export type { BotCordChannelConfig, BotCordAccountConfig } from "./src/types.js";

--- a/plugin/setup-entry.ts
+++ b/plugin/setup-entry.ts
@@ -1,5 +1,5 @@
 // setup-entry.ts — lightweight entry for onboarding/config (no heavy deps like ws)
+import { defineSetupPluginEntry } from "openclaw/plugin-sdk/core";
 import { botCordPlugin } from "./src/channel.js";
 
-// Inline replacement for defineSetupPluginEntry (just returns { plugin }).
-export default { plugin: botCordPlugin };
+export default defineSetupPluginEntry(botCordPlugin);

--- a/plugin/src/channel.ts
+++ b/plugin/src/channel.ts
@@ -39,6 +39,8 @@ import {
   isAccountConfigured,
   displayPrefix,
 } from "./config.js";
+import { botCordSetupAdapter } from "./setup-core.js";
+import { botCordSetupWizard } from "./setup-surface.js";
 import type {
   BotCordAccountConfig,
   BotCordChannelConfig,
@@ -192,6 +194,8 @@ export const botCordPlugin: ChannelPlugin<ResolvedBotCordAccount> = {
   configSchema: {
     schema: botCordConfigSchema,
   },
+  setup: botCordSetupAdapter,
+  setupWizard: botCordSetupWizard,
   config: {
     listAccountIds: (cfg) => listBotCordAccountIds(cfg as CoreConfig),
     resolveAccount: (cfg, accountId) =>

--- a/plugin/src/setup-core.ts
+++ b/plugin/src/setup-core.ts
@@ -1,0 +1,42 @@
+import {
+  DEFAULT_ACCOUNT_ID,
+  type ChannelSetupAdapter,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/setup";
+import type { BotCordChannelConfig } from "./types.js";
+
+export const botCordSetupAdapter: ChannelSetupAdapter = {
+  resolveAccountId: () => DEFAULT_ACCOUNT_ID,
+  applyAccountConfig: ({ cfg, accountId }) => {
+    const isDefault = !accountId || accountId === DEFAULT_ACCOUNT_ID;
+    if (isDefault) {
+      return {
+        ...cfg,
+        channels: {
+          ...cfg.channels,
+          botcord: {
+            ...cfg.channels?.botcord,
+            enabled: true,
+          },
+        },
+      };
+    }
+    const botcordCfg = cfg.channels?.botcord as BotCordChannelConfig | undefined;
+    return {
+      ...cfg,
+      channels: {
+        ...cfg.channels,
+        botcord: {
+          ...botcordCfg,
+          accounts: {
+            ...botcordCfg?.accounts,
+            [accountId]: {
+              ...botcordCfg?.accounts?.[accountId],
+              enabled: true,
+            },
+          },
+        },
+      },
+    };
+  },
+};

--- a/plugin/src/setup-surface.ts
+++ b/plugin/src/setup-surface.ts
@@ -1,0 +1,305 @@
+import {
+  DEFAULT_ACCOUNT_ID,
+  formatDocsLink,
+  patchTopLevelChannelConfigSection,
+  type ChannelSetupWizard,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/setup";
+import { isAccountConfigured, resolveChannelConfig } from "./config.js";
+import { botCordSetupAdapter } from "./setup-core.js";
+import type { BotCordChannelConfig } from "./types.js";
+
+const channel = "botcord" as const;
+
+// ── Configured check ──────────────────────────────────────────
+
+function isCredentialsFileLoadable(filePath: string): boolean {
+  try {
+    const { readCredentialFileData } = require("./credentials.js") as typeof import("./credentials.js");
+    const data = readCredentialFileData(filePath);
+    return !!(data.hubUrl && data.agentId && data.keyId && data.privateKey);
+  } catch {
+    return false;
+  }
+}
+
+function isBotCordConfigured(cfg: OpenClawConfig): boolean {
+  const channelCfg = resolveChannelConfig(cfg);
+  // Check top-level inline credentials
+  if (isAccountConfigured(channelCfg)) return true;
+  // Check credentialsFile at top level — verify it's actually loadable
+  if (channelCfg.credentialsFile && isCredentialsFileLoadable(channelCfg.credentialsFile)) {
+    return true;
+  }
+  // Check accounts
+  for (const acct of Object.values(channelCfg.accounts ?? {})) {
+    if (isAccountConfigured(acct)) return true;
+    if (acct.credentialsFile && isCredentialsFileLoadable(acct.credentialsFile)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// ── Hub probe (lazy import to avoid pulling ws at setup time) ─
+
+async function probeBotCordHub(config: {
+  hubUrl: string;
+  agentId: string;
+  keyId: string;
+  privateKey: string;
+}): Promise<{ ok: boolean; displayName?: string; error?: string }> {
+  try {
+    const { BotCordClient } = await import("./client.js");
+    const client = new BotCordClient(config);
+    const info = await client.resolve(config.agentId);
+    return { ok: true, displayName: info.display_name || info.agent_id };
+  } catch (err: any) {
+    return { ok: false, error: err.message ?? String(err) };
+  }
+}
+
+// ── Credential help note ──────────────────────────────────────
+
+async function noteBotCordCredentialHelp(
+  prompter: Parameters<NonNullable<ChannelSetupWizard["finalize"]>>[0]["prompter"],
+): Promise<void> {
+  await prompter.note(
+    [
+      "BotCord requires Ed25519 credentials to sign messages.",
+      "",
+      "Easiest: run `openclaw botcord-register` to generate and register a new keypair.",
+      "Or: import an existing credentials file (~/.botcord/credentials/<agentId>.json).",
+      "",
+      `Docs: ${formatDocsLink("/channels/botcord", "botcord")}`,
+    ].join("\n"),
+    "BotCord credentials",
+  );
+}
+
+// ── Setup wizard ──────────────────────────────────────────────
+
+export { botCordSetupAdapter } from "./setup-core.js";
+
+export const botCordSetupWizard: ChannelSetupWizard = {
+  channel,
+  resolveAccountIdForConfigure: () => DEFAULT_ACCOUNT_ID,
+  resolveShouldPromptAccountIds: () => false,
+  status: {
+    configuredLabel: "configured",
+    unconfiguredLabel: "needs credentials",
+    configuredHint: "configured",
+    unconfiguredHint: "needs credentials",
+    configuredScore: 2,
+    unconfiguredScore: 0,
+    resolveConfigured: ({ cfg }) => isBotCordConfigured(cfg),
+    resolveStatusLines: async ({ cfg, configured }) => {
+      if (!configured) return ["BotCord: needs credentials"];
+      const channelCfg = resolveChannelConfig(cfg);
+      if (channelCfg.agentId) {
+        try {
+          const probe = await probeBotCordHub({
+            hubUrl: channelCfg.hubUrl!,
+            agentId: channelCfg.agentId!,
+            keyId: channelCfg.keyId!,
+            privateKey: channelCfg.privateKey!,
+          });
+          if (probe.ok) {
+            return [`BotCord: connected as ${probe.displayName ?? channelCfg.agentId}`];
+          }
+        } catch {}
+      }
+      return ["BotCord: configured (connection not verified)"];
+    },
+  },
+  credentials: [],
+  finalize: async ({ cfg, prompter }) => {
+    const channelCfg = resolveChannelConfig(cfg);
+    const alreadyConfigured = isBotCordConfigured(cfg);
+
+    let next = cfg;
+
+    // If already configured, ask whether to keep or reconfigure
+    if (alreadyConfigured) {
+      const keep = await prompter.select({
+        message: "BotCord credentials already configured. What would you like to do?",
+        options: [
+          { value: "keep", label: "Keep current credentials" },
+          { value: "reconfigure", label: "Reconfigure credentials" },
+        ],
+        initialValue: "keep",
+      });
+      if (keep === "keep") {
+        next = patchTopLevelChannelConfigSection({
+          cfg: next,
+          channel,
+          enabled: true,
+          patch: {},
+        }) as OpenClawConfig;
+
+        // Still ask about delivery mode and allowFrom
+        next = await promptDeliveryMode(next, prompter);
+        return { cfg: next };
+      }
+    }
+
+    // Show help for unconfigured users
+    if (!alreadyConfigured) {
+      await noteBotCordCredentialHelp(prompter);
+    }
+
+    // Ask how to provide credentials
+    const credentialMethod = await prompter.select({
+      message: "How would you like to provide BotCord credentials?",
+      options: [
+        { value: "file", label: "Import from credentials file (recommended)" },
+        { value: "manual", label: "Enter credentials manually" },
+      ],
+      initialValue: "file",
+    });
+
+    if (credentialMethod === "file") {
+      const filePath = String(
+        await prompter.text({
+          message: "Path to BotCord credentials file",
+          placeholder: "~/.botcord/credentials/ag_xxxxxxxxxxxx.json",
+          initialValue: channelCfg.credentialsFile,
+          validate: (value) => (value?.trim() ? undefined : "Required"),
+        }),
+      ).trim();
+
+      next = patchTopLevelChannelConfigSection({
+        cfg: next,
+        channel,
+        enabled: true,
+        clearFields: ["hubUrl", "agentId", "keyId", "privateKey", "publicKey"],
+        patch: { credentialsFile: filePath },
+      }) as OpenClawConfig;
+
+      // Probe to verify the credentials file works
+      try {
+        const { loadStoredCredentials } = await import("./credentials.js");
+        const creds = loadStoredCredentials(filePath);
+        const probe = await probeBotCordHub({
+          hubUrl: creds.hubUrl,
+          agentId: creds.agentId,
+          keyId: creds.keyId,
+          privateKey: creds.privateKey,
+        });
+        if (probe.ok) {
+          await prompter.note(
+            `Connected as ${probe.displayName ?? creds.agentId}`,
+            "BotCord connection test",
+          );
+        } else {
+          await prompter.note(
+            `Connection failed: ${probe.error ?? "unknown error"}`,
+            "BotCord connection test",
+          );
+        }
+      } catch (err: any) {
+        await prompter.note(
+          `Could not load credentials file: ${err.message ?? String(err)}`,
+          "BotCord connection test",
+        );
+      }
+    } else {
+      // Manual entry
+      const hubUrl = String(
+        await prompter.text({
+          message: "BotCord Hub URL",
+          initialValue: channelCfg.hubUrl ?? "https://api.botcord.chat",
+          validate: (value) => (value?.trim() ? undefined : "Required"),
+        }),
+      ).trim();
+
+      const agentId = String(
+        await prompter.text({
+          message: "Agent ID (ag_...)",
+          initialValue: channelCfg.agentId,
+          validate: (value) =>
+            value?.trim()?.startsWith("ag_") ? undefined : "Must start with ag_",
+        }),
+      ).trim();
+
+      const keyId = String(
+        await prompter.text({
+          message: "Key ID",
+          initialValue: channelCfg.keyId,
+          validate: (value) => (value?.trim() ? undefined : "Required"),
+        }),
+      ).trim();
+
+      const privateKey = String(
+        await prompter.text({
+          message: "Ed25519 private key (base64)",
+          initialValue: channelCfg.privateKey,
+          validate: (value) => (value?.trim() ? undefined : "Required"),
+        }),
+      ).trim();
+
+      next = patchTopLevelChannelConfigSection({
+        cfg: next,
+        channel,
+        enabled: true,
+        clearFields: ["credentialsFile"],
+        patch: { hubUrl, agentId, keyId, privateKey },
+      }) as OpenClawConfig;
+
+      // Probe to verify
+      try {
+        const probe = await probeBotCordHub({ hubUrl, agentId, keyId, privateKey });
+        if (probe.ok) {
+          await prompter.note(
+            `Connected as ${probe.displayName ?? agentId}`,
+            "BotCord connection test",
+          );
+        } else {
+          await prompter.note(
+            `Connection failed: ${probe.error ?? "unknown error"}`,
+            "BotCord connection test",
+          );
+        }
+      } catch (err: any) {
+        await prompter.note(
+          `Connection test failed: ${String(err)}`,
+          "BotCord connection test",
+        );
+      }
+    }
+
+    // Delivery mode
+    next = await promptDeliveryMode(next, prompter);
+
+    return { cfg: next };
+  },
+  disable: (cfg) =>
+    patchTopLevelChannelConfigSection({
+      cfg,
+      channel,
+      patch: { enabled: false },
+    }),
+};
+
+// ── Delivery mode prompt ──────────────────────────────────────
+
+async function promptDeliveryMode(
+  cfg: OpenClawConfig,
+  prompter: Parameters<NonNullable<ChannelSetupWizard["finalize"]>>[0]["prompter"],
+): Promise<OpenClawConfig> {
+  const currentMode =
+    (cfg.channels?.botcord as BotCordChannelConfig | undefined)?.deliveryMode ?? "websocket";
+  const deliveryMode = (await prompter.select({
+    message: "BotCord delivery mode",
+    options: [
+      { value: "websocket", label: "WebSocket (recommended, real-time)" },
+      { value: "polling", label: "Polling (works everywhere)" },
+    ],
+    initialValue: currentMode,
+  })) as "websocket" | "polling";
+  return patchTopLevelChannelConfigSection({
+    cfg,
+    channel,
+    patch: { deliveryMode },
+  }) as OpenClawConfig;
+}

--- a/plugin/test-docker-install.sh
+++ b/plugin/test-docker-install.sh
@@ -1,0 +1,215 @@
+#!/bin/bash
+# ============================================================
+# Local Docker verification: npm pack → install tarball in
+# OpenClaw container → verify plugin loads without errors.
+#
+# This simulates the real user flow: `npm install @botcord/botcord`
+# by packing a tarball locally and installing it inside the container.
+#
+# Usage: cd plugin && bash test-docker-install.sh
+# ============================================================
+set -euo pipefail
+
+OPENCLAW_IMAGE="${OPENCLAW_IMAGE:-alpine/openclaw:latest}"
+CONTAINER_NAME="botcord-plugin-test"
+PLUGIN_DIR="$(cd "$(dirname "$0")" && pwd)"
+TEST_DIR=$(mktemp -d)
+
+cleanup() {
+  echo ">>> Cleaning up..."
+  docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+  # Docker may have created files as root inside the mounted volume
+  docker run --rm -v "$TEST_DIR:/cleanup" alpine sh -c 'rm -rf /cleanup/*' 2>/dev/null || true
+  rm -rf "$TEST_DIR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "=== BotCord Plugin Docker Install Test ==="
+echo "Image:  $OPENCLAW_IMAGE"
+echo "Plugin: $PLUGIN_DIR"
+echo "TmpDir: $TEST_DIR"
+echo ""
+
+# ── 1. npm pack to produce a tarball ──────────────────────────
+echo ">>> Step 1: Packing plugin tarball..."
+TARBALL=$(cd "$PLUGIN_DIR" && npm pack --pack-destination "$TEST_DIR" 2>/dev/null)
+TARBALL_PATH="$TEST_DIR/$TARBALL"
+
+if [ ! -f "$TARBALL_PATH" ]; then
+  echo "FAIL: npm pack did not produce a tarball"
+  exit 1
+fi
+echo "    Tarball: $TARBALL ($(du -h "$TARBALL_PATH" | cut -f1))"
+
+# ── 2. Prepare .openclaw with minimal config (no botcord yet) ─
+mkdir -p "$TEST_DIR/.openclaw/workspace"
+
+# Start with a clean config — no botcord references yet, so the
+# gateway can boot without validation errors before the plugin exists.
+cat > "$TEST_DIR/.openclaw/openclaw.json" <<'JSONEOF'
+{
+  "gateway": {
+    "mode": "local",
+    "controlUi": {
+      "dangerouslyAllowHostHeaderOriginFallback": true,
+      "allowInsecureAuth": true,
+      "dangerouslyDisableDeviceAuth": true
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": "google-vertex/gemini-3-flash-preview"
+    }
+  }
+}
+JSONEOF
+
+chmod 700 "$TEST_DIR/.openclaw"
+chmod 600 "$TEST_DIR/.openclaw/openclaw.json"
+
+echo ">>> Step 2: Config prepared (minimal, no plugin references)"
+
+# ── 3. Start container ────────────────────────────────────────
+GATEWAY_TOKEN="test$(openssl rand -hex 10)"
+docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+
+docker run -d \
+  --name "$CONTAINER_NAME" \
+  -e HOME=/home/node \
+  -e TERM=xterm-256color \
+  -e OPENCLAW_GATEWAY_TOKEN="$GATEWAY_TOKEN" \
+  -v "$TEST_DIR/.openclaw:/home/node/.openclaw" \
+  -v "$TEST_DIR/.openclaw/workspace:/home/node/.openclaw/workspace" \
+  -p 0:18789 \
+  --init \
+  "$OPENCLAW_IMAGE" \
+  node dist/index.js gateway --bind lan --port 18789 --allow-unconfigured
+
+echo ">>> Step 3: Container started"
+
+# ── 4. Copy tarball into container and npm install ────────────
+echo ">>> Step 4: Installing plugin from tarball..."
+
+docker cp "$TARBALL_PATH" "$CONTAINER_NAME:/tmp/$TARBALL"
+
+# Extract tarball into extensions dir, then install runtime deps only.
+# The openclaw peer dep is provided by the host runtime — skip it.
+# This mirrors what `openclaw plugins install @botcord/botcord` does.
+docker exec "$CONTAINER_NAME" sh -c "
+  mkdir -p /home/node/.openclaw/extensions/botcord && \
+  tar xzf /tmp/$TARBALL -C /home/node/.openclaw/extensions/botcord --strip-components=1 && \
+  cd /home/node/.openclaw/extensions/botcord && \
+  npm install --omit=dev --omit=peer 2>&1
+" || {
+  echo "FAIL: npm install from tarball failed"
+  docker logs "$CONTAINER_NAME" 2>&1 | tail -30
+  exit 1
+}
+
+echo ">>> Step 4: Plugin installed from tarball"
+
+# ── 5. Verify installed package contents ──────────────────────
+echo ">>> Step 5: Checking installed package files..."
+docker exec "$CONTAINER_NAME" sh -c \
+  'ls /home/node/.openclaw/extensions/botcord/' || true
+echo ""
+
+# ── 6. Write full config with plugin references, then restart ─
+echo ">>> Step 6: Writing config with plugin + restarting..."
+
+# Now write the real config pointing to the installed plugin path.
+cat > "$TEST_DIR/.openclaw/openclaw.json" <<'JSONEOF'
+{
+  "gateway": {
+    "mode": "local",
+    "controlUi": {
+      "dangerouslyAllowHostHeaderOriginFallback": true,
+      "allowInsecureAuth": true,
+      "dangerouslyDisableDeviceAuth": true
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": "google-vertex/gemini-3-flash-preview"
+    }
+  },
+  "channels": {
+    "botcord": {
+      "enabled": false
+    }
+  },
+  "plugins": {
+    "load": {
+      "paths": ["/home/node/.openclaw/extensions/botcord"]
+    },
+    "entries": {
+      "botcord": {
+        "enabled": true
+      }
+    }
+  }
+}
+JSONEOF
+
+chmod 600 "$TEST_DIR/.openclaw/openclaw.json"
+
+docker restart "$CONTAINER_NAME"
+
+# Wait for gateway to fully boot after restart.
+echo ">>> Waiting for gateway startup after restart..."
+sleep 3
+for i in $(seq 1 45); do
+  if docker logs --since 30s "$CONTAINER_NAME" 2>&1 | grep -q "listening on"; then
+    break
+  fi
+  # Check if container died
+  if ! docker ps -q -f "name=$CONTAINER_NAME" | grep -q .; then
+    echo "WARN: Container exited during restart"
+    echo "=== Exit logs ==="
+    docker logs --tail 30 "$CONTAINER_NAME" 2>&1
+    break
+  fi
+  sleep 1
+done
+
+# ── 7. Check logs for plugin load success/failure ─────────────
+echo ""
+echo "=== Container Status ==="
+docker ps -a -f "name=$CONTAINER_NAME" --format "{{.Status}}"
+echo ""
+echo "=== Container Logs (full) ==="
+docker logs "$CONTAINER_NAME" 2>&1 | tail -60
+echo ""
+
+LOGS=$(docker logs "$CONTAINER_NAME" 2>&1)
+
+if echo "$LOGS" | grep -qi "error.*botcord\|failed.*botcord\|cannot find.*botcord"; then
+  echo ""
+  echo "FAIL: BotCord plugin load errors detected!"
+  exit 1
+fi
+
+if echo "$LOGS" | grep -qi "botcord"; then
+  echo ""
+  echo "PASS: BotCord plugin loaded (found references in logs)"
+else
+  echo ""
+  echo "WARN: No BotCord references found in logs (plugin may not have been loaded yet)"
+  echo "      Check the full logs above for details."
+fi
+
+# ── 8. Test gateway health endpoint ──────────────────────────
+MAPPED_PORT=$(docker port "$CONTAINER_NAME" 18789/tcp 2>/dev/null | head -1 | cut -d: -f2)
+if [ -n "$MAPPED_PORT" ]; then
+  echo ""
+  echo ">>> Gateway port: $MAPPED_PORT"
+  HEALTH=$(curl -sf "http://localhost:$MAPPED_PORT/" 2>/dev/null || echo "unreachable")
+  if [ "$HEALTH" != "unreachable" ]; then
+    echo "PASS: Gateway is responding on port $MAPPED_PORT"
+  else
+    echo "INFO: Gateway not yet responding (may still be starting)"
+  fi
+fi
+
+echo ""
+echo "=== Test Complete ==="


### PR DESCRIPTION
## Summary
- Migrate plugin setup from manual `openclaw.json` editing to OpenClaw SDK's interactive setup wizard pattern (aligned with feishu extension)
- Add `ChannelSetupAdapter` and `ChannelSetupWizard` with credential file import, manual entry, Hub connection probe, and delivery mode selection
- Use `patchTopLevelChannelConfigSection` for all config mutations — framework handles persistence and schema validation
- Add Docker-based install verification script (`test-docker-install.sh`: npm pack → tarball → container install → gateway load)
- Requires `openclaw >= 2026.3.22` (`plugin-sdk/setup` subpath)

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 177 tests pass
- [x] Docker install test passes on `alpine/openclaw:latest` (v2026.3.24)
- [ ] Manual: run `openclaw configure` and verify BotCord setup wizard flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)