### PR TITLE
feat(cli): add @botcord/cli TypeScript CLI package

### DIFF
--- a/cli/dist/args.d.ts
+++ b/cli/dist/args.d.ts
@@ -1,0 +1,7 @@
+export type ParsedArgs = {
+    command: string;
+    subcommand?: string;
+    positionals: string[];
+    flags: Record<string, string | boolean>;
+};
+export declare function parseArgs(argv: string[]): ParsedArgs;

--- a/cli/dist/args.js
+++ b/cli/dist/args.js
@@ -1,0 +1,51 @@
+export function parseArgs(argv) {
+    const flags = {};
+    const positionals = [];
+    let i = 0;
+    while (i < argv.length) {
+        const arg = argv[i];
+        if (arg === "--") {
+            positionals.push(...argv.slice(i + 1));
+            break;
+        }
+        if (arg.startsWith("--")) {
+            const eqIdx = arg.indexOf("=");
+            if (eqIdx !== -1) {
+                flags[arg.slice(2, eqIdx)] = arg.slice(eqIdx + 1);
+            }
+            else {
+                const next = argv[i + 1];
+                if (next !== undefined && !next.startsWith("-")) {
+                    flags[arg.slice(2)] = next;
+                    i++;
+                }
+                else {
+                    flags[arg.slice(2)] = true;
+                }
+            }
+        }
+        else if (arg === "-h") {
+            flags["help"] = true;
+        }
+        else if (arg.startsWith("-") && arg.length === 2) {
+            const next = argv[i + 1];
+            if (next !== undefined && !next.startsWith("-")) {
+                flags[arg.slice(1)] = next;
+                i++;
+            }
+            else {
+                flags[arg.slice(1)] = true;
+            }
+        }
+        else {
+            positionals.push(arg);
+        }
+        i++;
+    }
+    const command = positionals.shift() || "";
+    let subcommand;
+    if (positionals.length > 0 && !positionals[0].startsWith("-")) {
+        subcommand = positionals.shift();
+    }
+    return { command, subcommand, positionals, flags };
+}

--- a/cli/dist/client.d.ts
+++ b/cli/dist/client.d.ts
@@ -1,0 +1,144 @@
+import type { InboxPollResponse, SendResponse, RoomInfo, AgentInfo, ContactInfo, ContactRequestInfo, FileUploadResponse, MessageAttachment, WalletSummary, WalletTransaction, WalletLedgerResponse, TopupResponse, WithdrawalResponse } from "./types.js";
+export interface BotCordClientConfig {
+    hubUrl: string;
+    agentId: string;
+    keyId: string;
+    privateKey: string;
+    token?: string;
+    tokenExpiresAt?: number;
+}
+export declare class BotCordClient {
+    private hubUrl;
+    private agentId;
+    private keyId;
+    private privateKey;
+    private jwtToken;
+    private tokenExpiresAt;
+    /** Called after a token refresh so credentials can be persisted. */
+    onTokenRefresh?: (token: string, expiresAt: number) => void;
+    constructor(config: BotCordClientConfig);
+    ensureToken(): Promise<string>;
+    refreshToken(): Promise<string>;
+    getToken(): string | null;
+    getTokenExpiresAt(): number;
+    private hubFetch;
+    uploadFile(filePath: string, filename: string, contentType?: string): Promise<FileUploadResponse>;
+    sendMessage(to: string, text: string, options?: {
+        replyTo?: string;
+        topic?: string;
+        goal?: string;
+        ttlSec?: number;
+        attachments?: MessageAttachment[];
+        mentions?: string[];
+    }): Promise<SendResponse>;
+    pollInbox(options?: {
+        limit?: number;
+        ack?: boolean;
+        roomId?: string;
+    }): Promise<InboxPollResponse>;
+    getHistory(options?: {
+        peer?: string;
+        roomId?: string;
+        topic?: string;
+        topicId?: string;
+        before?: string;
+        after?: string;
+        limit?: number;
+    }): Promise<unknown>;
+    resolve(agentId: string): Promise<AgentInfo>;
+    getPolicy(agentId?: string): Promise<{
+        message_policy: string;
+    }>;
+    setPolicy(policy: "open" | "contacts_only"): Promise<void>;
+    updateProfile(params: {
+        display_name?: string;
+        bio?: string;
+    }): Promise<void>;
+    getMessageStatus(msgId: string): Promise<unknown>;
+    sendContactRequest(to: string, message?: string): Promise<SendResponse>;
+    listContacts(): Promise<ContactInfo[]>;
+    removeContact(contactAgentId: string): Promise<void>;
+    blockAgent(blockedId: string): Promise<void>;
+    unblockAgent(blockedId: string): Promise<void>;
+    listBlocks(): Promise<unknown[]>;
+    listReceivedRequests(state?: string): Promise<ContactRequestInfo[]>;
+    listSentRequests(state?: string): Promise<ContactRequestInfo[]>;
+    acceptRequest(requestId: string): Promise<void>;
+    rejectRequest(requestId: string): Promise<void>;
+    createRoom(params: {
+        name: string;
+        description?: string;
+        rule?: string;
+        visibility?: "private" | "public";
+        join_policy?: "invite_only" | "open";
+        max_members?: number;
+        member_ids?: string[];
+    }): Promise<RoomInfo>;
+    listMyRooms(): Promise<RoomInfo[]>;
+    getRoomInfo(roomId: string): Promise<RoomInfo>;
+    joinRoom(roomId: string): Promise<void>;
+    leaveRoom(roomId: string): Promise<void>;
+    inviteToRoom(roomId: string, agentId: string): Promise<void>;
+    discoverRooms(name?: string): Promise<RoomInfo[]>;
+    updateRoom(roomId: string, params: {
+        name?: string;
+        description?: string;
+        visibility?: string;
+        join_policy?: string;
+        max_members?: number | null;
+    }): Promise<RoomInfo>;
+    removeMember(roomId: string, agentId: string): Promise<void>;
+    promoteMember(roomId: string, agentId: string, role: "admin" | "member"): Promise<void>;
+    transferOwnership(roomId: string, newOwnerId: string): Promise<void>;
+    dissolveRoom(roomId: string): Promise<void>;
+    setMemberPermissions(roomId: string, agentId: string, permissions: {
+        can_send?: boolean;
+        can_invite?: boolean;
+    }): Promise<void>;
+    muteRoom(roomId: string, muted: boolean): Promise<void>;
+    createTopic(roomId: string, params: {
+        title: string;
+        description?: string;
+        goal?: string;
+    }): Promise<unknown>;
+    listTopics(roomId: string, status?: string): Promise<unknown[]>;
+    getTopic(roomId: string, topicId: string): Promise<unknown>;
+    updateTopic(roomId: string, topicId: string, params: {
+        title?: string;
+        description?: string;
+        status?: string;
+        goal?: string;
+    }): Promise<unknown>;
+    deleteTopic(roomId: string, topicId: string): Promise<void>;
+    getWallet(): Promise<WalletSummary>;
+    getWalletLedger(opts?: {
+        cursor?: string;
+        limit?: number;
+        type?: string;
+    }): Promise<WalletLedgerResponse>;
+    createTransfer(params: {
+        to_agent_id: string;
+        amount_minor: string;
+        memo?: string;
+    }): Promise<WalletTransaction>;
+    createTopup(params: {
+        amount_minor: string;
+    }): Promise<TopupResponse>;
+    createWithdrawal(params: {
+        amount_minor: string;
+    }): Promise<WithdrawalResponse>;
+    getWalletTransaction(txId: string): Promise<WalletTransaction>;
+    cancelWithdrawal(withdrawalId: string): Promise<WithdrawalResponse>;
+    registerEndpoint(url: string, webhookToken: string): Promise<unknown>;
+    getAgentId(): string;
+    getHubUrl(): string;
+    static register(hubUrl: string, name: string, bio?: string): Promise<{
+        agentId: string;
+        keyId: string;
+        privateKey: string;
+        publicKey: string;
+        token: string;
+        expiresAt: number;
+        hubUrl: string;
+    }>;
+}

--- a/cli/dist/client.js
+++ b/cli/dist/client.js
@@ -1,0 +1,498 @@
+/**
+ * HTTP client for BotCord Hub REST API.
+ * Handles JWT token lifecycle and request signing.
+ */
+import { randomBytes } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { buildSignedEnvelope, generateKeypair, signChallenge } from "./crypto.js";
+import { normalizeAndValidateHubUrl } from "./hub-url.js";
+const MAX_RETRIES = 2;
+const RETRY_BASE_MS = 1000;
+export class BotCordClient {
+    hubUrl;
+    agentId;
+    keyId;
+    privateKey;
+    jwtToken = null;
+    tokenExpiresAt = 0;
+    /** Called after a token refresh so credentials can be persisted. */
+    onTokenRefresh;
+    constructor(config) {
+        if (!config.hubUrl || !config.agentId || !config.keyId || !config.privateKey) {
+            throw new Error("BotCord client requires hubUrl, agentId, keyId, and privateKey");
+        }
+        this.hubUrl = normalizeAndValidateHubUrl(config.hubUrl);
+        this.agentId = config.agentId;
+        this.keyId = config.keyId;
+        this.privateKey = config.privateKey;
+        if (config.token) {
+            this.jwtToken = config.token;
+            this.tokenExpiresAt = config.tokenExpiresAt ?? 0;
+        }
+    }
+    // ── Token management ──────────────────────────────────────────
+    async ensureToken() {
+        if (this.jwtToken && Date.now() / 1000 < this.tokenExpiresAt - 60) {
+            return this.jwtToken;
+        }
+        return this.refreshToken();
+    }
+    async refreshToken() {
+        const nonce = randomBytes(32).toString("base64");
+        const sig = signChallenge(this.privateKey, nonce);
+        const resp = await fetch(`${this.hubUrl}/registry/agents/${this.agentId}/token/refresh`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                key_id: this.keyId,
+                nonce,
+                sig,
+            }),
+            signal: AbortSignal.timeout(10000),
+        });
+        if (!resp.ok) {
+            const body = await resp.text().catch(() => "");
+            throw new Error(`Token refresh failed: ${resp.status} ${body}`);
+        }
+        const data = (await resp.json());
+        this.jwtToken = data.agent_token || data.token;
+        this.tokenExpiresAt = data.expires_at ?? Date.now() / 1000 + 86400;
+        this.onTokenRefresh?.(this.jwtToken, this.tokenExpiresAt);
+        return this.jwtToken;
+    }
+    getToken() {
+        return this.jwtToken;
+    }
+    getTokenExpiresAt() {
+        return this.tokenExpiresAt;
+    }
+    // ── Authenticated fetch with rate-limit retry ─────────────────
+    async hubFetch(path, init = {}) {
+        const token = await this.ensureToken();
+        for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+            const headers = {
+                Authorization: `Bearer ${token}`,
+                ...(init.headers ?? {}),
+            };
+            if (init.body && typeof init.body === "string") {
+                headers["Content-Type"] = "application/json";
+            }
+            const resp = await fetch(`${this.hubUrl}${path}`, {
+                ...init,
+                headers,
+                signal: AbortSignal.timeout(30000),
+            });
+            if (resp.ok)
+                return resp;
+            if (resp.status === 401 && attempt === 0) {
+                await this.refreshToken();
+                continue;
+            }
+            if (resp.status === 429 && attempt < MAX_RETRIES) {
+                const retryAfter = parseInt(resp.headers.get("Retry-After") || "", 10);
+                const delayMs = retryAfter > 0 ? retryAfter * 1000 : RETRY_BASE_MS * (attempt + 1);
+                await new Promise((r) => setTimeout(r, delayMs));
+                continue;
+            }
+            const body = await resp.text().catch(() => "");
+            const err = new Error(`BotCord ${path} failed: ${resp.status} ${body}`);
+            err.status = resp.status;
+            throw err;
+        }
+        throw new Error(`BotCord ${path} failed: exhausted retries`);
+    }
+    // ── File upload ──────────────────────────────────────────────
+    async uploadFile(filePath, filename, contentType) {
+        const fileData = readFileSync(filePath);
+        const token = await this.ensureToken();
+        const formData = new FormData();
+        const blob = new Blob([fileData], { type: contentType || "application/octet-stream" });
+        formData.append("file", blob, filename);
+        const resp = await fetch(`${this.hubUrl}/hub/upload`, {
+            method: "POST",
+            headers: { Authorization: `Bearer ${token}` },
+            body: formData,
+            signal: AbortSignal.timeout(30000),
+        });
+        if (!resp.ok) {
+            const body = await resp.text().catch(() => "");
+            throw new Error(`File upload failed: ${resp.status} ${body}`);
+        }
+        const data = (await resp.json());
+        if (data.url && !data.url.startsWith("http")) {
+            data.url = `${this.hubUrl}${data.url}`;
+        }
+        return data;
+    }
+    // ── Messaging ─────────────────────────────────────────────────
+    async sendMessage(to, text, options) {
+        const payload = { text };
+        if (options?.attachments && options.attachments.length > 0) {
+            payload.attachments = options.attachments;
+        }
+        const envelope = buildSignedEnvelope({
+            from: this.agentId,
+            to,
+            type: "message",
+            payload,
+            privateKey: this.privateKey,
+            keyId: this.keyId,
+            replyTo: options?.replyTo,
+            ttlSec: options?.ttlSec,
+            topic: options?.topic,
+            goal: options?.goal,
+        });
+        const body = { ...envelope };
+        if (options?.mentions && options.mentions.length > 0) {
+            body.mentions = options.mentions;
+        }
+        const topicQuery = options?.topic ? `?topic=${encodeURIComponent(options.topic)}` : "";
+        const resp = await this.hubFetch(`/hub/send${topicQuery}`, {
+            method: "POST",
+            body: JSON.stringify(body),
+        });
+        return (await resp.json());
+    }
+    // ── Inbox ─────────────────────────────────────────────────────
+    async pollInbox(options) {
+        const params = new URLSearchParams();
+        if (options?.limit)
+            params.set("limit", String(options.limit));
+        if (options?.ack)
+            params.set("ack", "true");
+        if (options?.roomId)
+            params.set("room_id", options.roomId);
+        const resp = await this.hubFetch(`/hub/inbox?${params.toString()}`);
+        return (await resp.json());
+    }
+    async getHistory(options) {
+        const params = new URLSearchParams();
+        if (options?.peer)
+            params.set("peer", options.peer);
+        if (options?.roomId)
+            params.set("room_id", options.roomId);
+        if (options?.topic)
+            params.set("topic", options.topic);
+        if (options?.topicId)
+            params.set("topic_id", options.topicId);
+        if (options?.before)
+            params.set("before", options.before);
+        if (options?.after)
+            params.set("after", options.after);
+        if (options?.limit)
+            params.set("limit", String(options.limit));
+        const resp = await this.hubFetch(`/hub/history?${params.toString()}`);
+        return await resp.json();
+    }
+    // ── Registry ──────────────────────────────────────────────────
+    async resolve(agentId) {
+        const resp = await this.hubFetch(`/registry/resolve/${agentId}`);
+        return (await resp.json());
+    }
+    // ── Policy ───────────────────────────────────────────────────
+    async getPolicy(agentId) {
+        const id = agentId || this.agentId;
+        const resp = await this.hubFetch(`/registry/agents/${id}/policy`);
+        return (await resp.json());
+    }
+    async setPolicy(policy) {
+        await this.hubFetch(`/registry/agents/${this.agentId}/policy`, {
+            method: "PATCH",
+            body: JSON.stringify({ message_policy: policy }),
+        });
+    }
+    // ── Profile ─────────────────────────────────────────────────
+    async updateProfile(params) {
+        await this.hubFetch(`/registry/agents/${this.agentId}/profile`, {
+            method: "PATCH",
+            body: JSON.stringify(params),
+        });
+    }
+    // ── Message status ──────────────────────────────────────────
+    async getMessageStatus(msgId) {
+        const resp = await this.hubFetch(`/hub/status/${msgId}`);
+        return await resp.json();
+    }
+    // ── Contact requests (send) ─────────────────────────────────
+    async sendContactRequest(to, message) {
+        const payload = message ? { text: message } : {};
+        const envelope = buildSignedEnvelope({
+            from: this.agentId,
+            to,
+            type: "contact_request",
+            payload,
+            privateKey: this.privateKey,
+            keyId: this.keyId,
+        });
+        const resp = await this.hubFetch("/hub/send", {
+            method: "POST",
+            body: JSON.stringify(envelope),
+        });
+        return (await resp.json());
+    }
+    // ── Contacts ──────────────────────────────────────────────────
+    async listContacts() {
+        const resp = await this.hubFetch(`/registry/agents/${this.agentId}/contacts`);
+        const body = await resp.json();
+        return (body.contacts ?? body);
+    }
+    async removeContact(contactAgentId) {
+        await this.hubFetch(`/registry/agents/${this.agentId}/contacts/${contactAgentId}`, {
+            method: "DELETE",
+        });
+    }
+    async blockAgent(blockedId) {
+        await this.hubFetch(`/registry/agents/${this.agentId}/blocks`, {
+            method: "POST",
+            body: JSON.stringify({ blocked_agent_id: blockedId }),
+        });
+    }
+    async unblockAgent(blockedId) {
+        await this.hubFetch(`/registry/agents/${this.agentId}/blocks/${blockedId}`, {
+            method: "DELETE",
+        });
+    }
+    async listBlocks() {
+        const resp = await this.hubFetch(`/registry/agents/${this.agentId}/blocks`);
+        return await resp.json();
+    }
+    // ── Contact requests ──────────────────────────────────────────
+    async listReceivedRequests(state) {
+        const q = state ? `?state=${state}` : "";
+        const resp = await this.hubFetch(`/registry/agents/${this.agentId}/contact-requests/received${q}`);
+        return (await resp.json());
+    }
+    async listSentRequests(state) {
+        const q = state ? `?state=${state}` : "";
+        const resp = await this.hubFetch(`/registry/agents/${this.agentId}/contact-requests/sent${q}`);
+        return (await resp.json());
+    }
+    async acceptRequest(requestId) {
+        await this.hubFetch(`/registry/agents/${this.agentId}/contact-requests/${requestId}/accept`, {
+            method: "POST",
+        });
+    }
+    async rejectRequest(requestId) {
+        await this.hubFetch(`/registry/agents/${this.agentId}/contact-requests/${requestId}/reject`, {
+            method: "POST",
+        });
+    }
+    // ── Rooms ─────────────────────────────────────────────────────
+    async createRoom(params) {
+        const resp = await this.hubFetch("/hub/rooms", {
+            method: "POST",
+            body: JSON.stringify(params),
+        });
+        return (await resp.json());
+    }
+    async listMyRooms() {
+        const resp = await this.hubFetch("/hub/rooms/me");
+        return (await resp.json());
+    }
+    async getRoomInfo(roomId) {
+        const resp = await this.hubFetch(`/hub/rooms/${roomId}`);
+        return (await resp.json());
+    }
+    async joinRoom(roomId) {
+        await this.hubFetch(`/hub/rooms/${roomId}/members`, {
+            method: "POST",
+            body: JSON.stringify({ agent_id: this.agentId }),
+        });
+    }
+    async leaveRoom(roomId) {
+        await this.hubFetch(`/hub/rooms/${roomId}/leave`, { method: "POST" });
+    }
+    async inviteToRoom(roomId, agentId) {
+        await this.hubFetch(`/hub/rooms/${roomId}/members`, {
+            method: "POST",
+            body: JSON.stringify({ agent_id: agentId }),
+        });
+    }
+    async discoverRooms(name) {
+        const q = name ? `?name=${encodeURIComponent(name)}` : "";
+        const resp = await this.hubFetch(`/hub/rooms${q}`);
+        return (await resp.json());
+    }
+    async updateRoom(roomId, params) {
+        const resp = await this.hubFetch(`/hub/rooms/${roomId}`, {
+            method: "PATCH",
+            body: JSON.stringify(params),
+        });
+        return (await resp.json());
+    }
+    async removeMember(roomId, agentId) {
+        await this.hubFetch(`/hub/rooms/${roomId}/members/${agentId}`, {
+            method: "DELETE",
+        });
+    }
+    async promoteMember(roomId, agentId, role) {
+        await this.hubFetch(`/hub/rooms/${roomId}/promote`, {
+            method: "POST",
+            body: JSON.stringify({ agent_id: agentId, role }),
+        });
+    }
+    async transferOwnership(roomId, newOwnerId) {
+        await this.hubFetch(`/hub/rooms/${roomId}/transfer`, {
+            method: "POST",
+            body: JSON.stringify({ new_owner_id: newOwnerId }),
+        });
+    }
+    async dissolveRoom(roomId) {
+        await this.hubFetch(`/hub/rooms/${roomId}`, {
+            method: "DELETE",
+        });
+    }
+    async setMemberPermissions(roomId, agentId, permissions) {
+        await this.hubFetch(`/hub/rooms/${roomId}/permissions`, {
+            method: "POST",
+            body: JSON.stringify({ agent_id: agentId, ...permissions }),
+        });
+    }
+    async muteRoom(roomId, muted) {
+        await this.hubFetch(`/hub/rooms/${roomId}/mute`, {
+            method: "POST",
+            body: JSON.stringify({ muted }),
+        });
+    }
+    // ── Room Topics ────────────────────────────────────────────────
+    async createTopic(roomId, params) {
+        const resp = await this.hubFetch(`/hub/rooms/${roomId}/topics`, {
+            method: "POST",
+            body: JSON.stringify(params),
+        });
+        return await resp.json();
+    }
+    async listTopics(roomId, status) {
+        const q = status ? `?status=${status}` : "";
+        const resp = await this.hubFetch(`/hub/rooms/${roomId}/topics${q}`);
+        return await resp.json();
+    }
+    async getTopic(roomId, topicId) {
+        const resp = await this.hubFetch(`/hub/rooms/${roomId}/topics/${topicId}`);
+        return await resp.json();
+    }
+    async updateTopic(roomId, topicId, params) {
+        const resp = await this.hubFetch(`/hub/rooms/${roomId}/topics/${topicId}`, {
+            method: "PATCH",
+            body: JSON.stringify(params),
+        });
+        return await resp.json();
+    }
+    async deleteTopic(roomId, topicId) {
+        await this.hubFetch(`/hub/rooms/${roomId}/topics/${topicId}`, {
+            method: "DELETE",
+        });
+    }
+    // ── Wallet ──────────────────────────────────────────────────
+    async getWallet() {
+        const resp = await this.hubFetch("/wallet/me");
+        return (await resp.json());
+    }
+    async getWalletLedger(opts) {
+        const params = new URLSearchParams();
+        if (opts?.cursor)
+            params.set("cursor", opts.cursor);
+        if (opts?.limit)
+            params.set("limit", String(opts.limit));
+        if (opts?.type)
+            params.set("type", opts.type);
+        const q = params.toString();
+        const resp = await this.hubFetch(`/wallet/ledger${q ? `?${q}` : ""}`);
+        return (await resp.json());
+    }
+    async createTransfer(params) {
+        const resp = await this.hubFetch("/wallet/transfers", {
+            method: "POST",
+            body: JSON.stringify(params),
+        });
+        return (await resp.json());
+    }
+    async createTopup(params) {
+        const resp = await this.hubFetch("/wallet/topups", {
+            method: "POST",
+            body: JSON.stringify(params),
+        });
+        return (await resp.json());
+    }
+    async createWithdrawal(params) {
+        const resp = await this.hubFetch("/wallet/withdrawals", {
+            method: "POST",
+            body: JSON.stringify(params),
+        });
+        return (await resp.json());
+    }
+    async getWalletTransaction(txId) {
+        const resp = await this.hubFetch(`/wallet/transactions/${txId}`);
+        return (await resp.json());
+    }
+    async cancelWithdrawal(withdrawalId) {
+        const resp = await this.hubFetch(`/wallet/withdrawals/${withdrawalId}/cancel`, {
+            method: "POST",
+        });
+        return (await resp.json());
+    }
+    // ── Endpoint registration ─────────────────────────────────────
+    async registerEndpoint(url, webhookToken) {
+        const resp = await this.hubFetch(`/registry/agents/${this.agentId}/endpoints`, {
+            method: "POST",
+            body: JSON.stringify({ url, webhook_token: webhookToken }),
+        });
+        return await resp.json();
+    }
+    // ── Accessors ─────────────────────────────────────────────────
+    getAgentId() {
+        return this.agentId;
+    }
+    getHubUrl() {
+        return this.hubUrl;
+    }
+    // ── Static factory: register a brand-new agent ────────────────
+    static async register(hubUrl, name, bio) {
+        const normalizedHub = normalizeAndValidateHubUrl(hubUrl);
+        const keypair = generateKeypair();
+        // Step 1: POST /registry/agents
+        const regResp = await fetch(`${normalizedHub}/registry/agents`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                display_name: name,
+                pubkey: keypair.pubkeyFormatted,
+                bio: bio || "",
+            }),
+            signal: AbortSignal.timeout(10000),
+        });
+        if (!regResp.ok) {
+            const body = await regResp.text().catch(() => "");
+            throw new Error(`Agent registration failed: ${regResp.status} ${body}`);
+        }
+        const regData = (await regResp.json());
+        // Step 2: Sign challenge and verify
+        const sig = signChallenge(keypair.privateKey, regData.challenge);
+        const verifyResp = await fetch(`${normalizedHub}/registry/agents/${regData.agent_id}/verify`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                key_id: regData.key_id,
+                challenge: regData.challenge,
+                sig,
+            }),
+            signal: AbortSignal.timeout(10000),
+        });
+        if (!verifyResp.ok) {
+            const body = await verifyResp.text().catch(() => "");
+            throw new Error(`Agent verification failed: ${verifyResp.status} ${body}`);
+        }
+        const verifyData = (await verifyResp.json());
+        const token = verifyData.agent_token || verifyData.token;
+        const expiresAt = verifyData.expires_at ?? Date.now() / 1000 + 86400;
+        return {
+            agentId: regData.agent_id,
+            keyId: regData.key_id,
+            privateKey: keypair.privateKey,
+            publicKey: keypair.publicKey,
+            token,
+            expiresAt,
+            hubUrl: normalizedHub,
+        };
+    }
+}

--- a/cli/dist/commands/block.d.ts
+++ b/cli/dist/commands/block.d.ts
@@ -1,0 +1,2 @@
+import type { ParsedArgs } from "../args.js";
+export declare function blockCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void>;

--- a/cli/dist/commands/block.js
+++ b/cli/dist/commands/block.js
@@ -1,0 +1,52 @@
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials } from "../credentials.js";
+import { outputJson, outputError } from "../output.js";
+export async function blockCommand(args, globalHub, globalAgent) {
+    const sub = args.subcommand;
+    if (args.flags["help"] || !sub) {
+        console.log(`Usage: botcord block <subcommand> [options]
+
+Subcommands:
+  add    --id <agent_id>    Block an agent
+  list                      List blocked agents
+  remove --id <agent_id>    Unblock an agent`);
+        if (!sub && !args.flags["help"])
+            process.exit(1);
+        return;
+    }
+    const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+    const hubUrl = globalHub || creds.hubUrl;
+    const client = new BotCordClient({
+        hubUrl,
+        agentId: creds.agentId,
+        keyId: creds.keyId,
+        privateKey: creds.privateKey,
+        token: creds.token,
+        tokenExpiresAt: creds.tokenExpiresAt,
+    });
+    switch (sub) {
+        case "add": {
+            const id = args.flags["id"];
+            if (!id || typeof id !== "string")
+                outputError("--id is required");
+            await client.blockAgent(id);
+            outputJson({ blocked: true, agent_id: id });
+            break;
+        }
+        case "list": {
+            const result = await client.listBlocks();
+            outputJson(result);
+            break;
+        }
+        case "remove": {
+            const id = args.flags["id"];
+            if (!id || typeof id !== "string")
+                outputError("--id is required");
+            await client.unblockAgent(id);
+            outputJson({ unblocked: true, agent_id: id });
+            break;
+        }
+        default:
+            outputError(`unknown subcommand: ${sub}. Use "add", "list", or "remove"`);
+    }
+}

--- a/cli/dist/commands/contact-request.d.ts
+++ b/cli/dist/commands/contact-request.d.ts
@@ -1,0 +1,2 @@
+import type { ParsedArgs } from "../args.js";
+export declare function contactRequestCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void>;

--- a/cli/dist/commands/contact-request.js
+++ b/cli/dist/commands/contact-request.js
@@ -1,0 +1,70 @@
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials } from "../credentials.js";
+import { outputJson, outputError } from "../output.js";
+export async function contactRequestCommand(args, globalHub, globalAgent) {
+    const sub = args.subcommand;
+    if (args.flags["help"] || !sub) {
+        console.log(`Usage: botcord contact-request <subcommand> [options]
+
+Subcommands:
+  send      --to <agent_id> [--message <text>]
+  received  [--state pending|accepted|rejected]
+  sent      [--state pending|accepted|rejected]
+  accept    --id <request_id>
+  reject    --id <request_id>`);
+        if (!sub && !args.flags["help"])
+            process.exit(1);
+        return;
+    }
+    const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+    const hubUrl = globalHub || creds.hubUrl;
+    const client = new BotCordClient({
+        hubUrl,
+        agentId: creds.agentId,
+        keyId: creds.keyId,
+        privateKey: creds.privateKey,
+        token: creds.token,
+        tokenExpiresAt: creds.tokenExpiresAt,
+    });
+    switch (sub) {
+        case "send": {
+            const to = args.flags["to"];
+            if (!to || typeof to !== "string")
+                outputError("--to is required");
+            const message = typeof args.flags["message"] === "string" ? args.flags["message"] : undefined;
+            const result = await client.sendContactRequest(to, message);
+            outputJson(result);
+            break;
+        }
+        case "received": {
+            const state = typeof args.flags["state"] === "string" ? args.flags["state"] : undefined;
+            const result = await client.listReceivedRequests(state);
+            outputJson(result);
+            break;
+        }
+        case "sent": {
+            const state = typeof args.flags["state"] === "string" ? args.flags["state"] : undefined;
+            const result = await client.listSentRequests(state);
+            outputJson(result);
+            break;
+        }
+        case "accept": {
+            const id = args.flags["id"];
+            if (!id || typeof id !== "string")
+                outputError("--id is required");
+            await client.acceptRequest(id);
+            outputJson({ accepted: true, request_id: id });
+            break;
+        }
+        case "reject": {
+            const id = args.flags["id"];
+            if (!id || typeof id !== "string")
+                outputError("--id is required");
+            await client.rejectRequest(id);
+            outputJson({ rejected: true, request_id: id });
+            break;
+        }
+        default:
+            outputError(`unknown subcommand: ${sub}`);
+    }
+}

--- a/cli/dist/commands/contact.d.ts
+++ b/cli/dist/commands/contact.d.ts
@@ -1,0 +1,2 @@
+import type { ParsedArgs } from "../args.js";
+export declare function contactCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void>;

--- a/cli/dist/commands/contact.js
+++ b/cli/dist/commands/contact.js
@@ -1,0 +1,43 @@
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials } from "../credentials.js";
+import { outputJson, outputError } from "../output.js";
+export async function contactCommand(args, globalHub, globalAgent) {
+    const sub = args.subcommand;
+    if (args.flags["help"] || !sub) {
+        console.log(`Usage: botcord contact <subcommand> [options]
+
+Subcommands:
+  list              List all contacts
+  remove --id <id>  Remove a contact`);
+        if (!sub && !args.flags["help"])
+            process.exit(1);
+        return;
+    }
+    const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+    const hubUrl = globalHub || creds.hubUrl;
+    const client = new BotCordClient({
+        hubUrl,
+        agentId: creds.agentId,
+        keyId: creds.keyId,
+        privateKey: creds.privateKey,
+        token: creds.token,
+        tokenExpiresAt: creds.tokenExpiresAt,
+    });
+    switch (sub) {
+        case "list": {
+            const result = await client.listContacts();
+            outputJson(result);
+            break;
+        }
+        case "remove": {
+            const id = args.flags["id"];
+            if (!id || typeof id !== "string")
+                outputError("--id is required");
+            await client.removeContact(id);
+            outputJson({ removed: true, agent_id: id });
+            break;
+        }
+        default:
+            outputError(`unknown subcommand: ${sub}. Use "list" or "remove"`);
+    }
+}

--- a/cli/dist/commands/endpoint.d.ts
+++ b/cli/dist/commands/endpoint.d.ts
@@ -1,0 +1,2 @@
+import type { ParsedArgs } from "../args.js";
+export declare function endpointCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void>;

--- a/cli/dist/commands/endpoint.js
+++ b/cli/dist/commands/endpoint.js
@@ -1,0 +1,33 @@
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials } from "../credentials.js";
+import { outputJson, outputError } from "../output.js";
+export async function endpointCommand(args, globalHub, globalAgent) {
+    if (args.flags["help"]) {
+        console.log(`Usage: botcord endpoint --url <inbox_url> --webhook-token <token>
+
+Register a webhook endpoint for message delivery.
+
+Options:
+  --url <inbox_url>          Webhook URL (required)
+  --webhook-token <token>    Webhook authentication token (required)`);
+        return;
+    }
+    const url = args.flags["url"];
+    const webhookToken = args.flags["webhook-token"];
+    if (!url || typeof url !== "string")
+        outputError("--url is required");
+    if (!webhookToken || typeof webhookToken !== "string")
+        outputError("--webhook-token is required");
+    const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+    const hubUrl = globalHub || creds.hubUrl;
+    const client = new BotCordClient({
+        hubUrl,
+        agentId: creds.agentId,
+        keyId: creds.keyId,
+        privateKey: creds.privateKey,
+        token: creds.token,
+        tokenExpiresAt: creds.tokenExpiresAt,
+    });
+    const result = await client.registerEndpoint(url, webhookToken);
+    outputJson(result);
+}

--- a/cli/dist/commands/inbox.d.ts
+++ b/cli/dist/commands/inbox.d.ts
@@ -1,0 +1,2 @@
+import type { ParsedArgs } from "../args.js";
+export declare function inboxCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void>;

--- a/cli/dist/commands/inbox.js
+++ b/cli/dist/commands/inbox.js
@@ -1,0 +1,31 @@
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials } from "../credentials.js";
+import { outputJson } from "../output.js";
+export async function inboxCommand(args, globalHub, globalAgent) {
+    if (args.flags["help"]) {
+        console.log(`Usage: botcord inbox [options]
+
+Poll inbox for new messages.
+
+Options:
+  --limit <n>       Maximum number of messages to return
+  --ack             Acknowledge messages after retrieval
+  --room <room_id>  Filter by room ID`);
+        return;
+    }
+    const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+    const hubUrl = globalHub || creds.hubUrl;
+    const client = new BotCordClient({
+        hubUrl,
+        agentId: creds.agentId,
+        keyId: creds.keyId,
+        privateKey: creds.privateKey,
+        token: creds.token,
+        tokenExpiresAt: creds.tokenExpiresAt,
+    });
+    const limit = typeof args.flags["limit"] === "string" ? parseInt(args.flags["limit"], 10) : undefined;
+    const ack = args.flags["ack"] === true;
+    const roomId = typeof args.flags["room"] === "string" ? args.flags["room"] : undefined;
+    const result = await client.pollInbox({ limit, ack, roomId });
+    outputJson(result);
+}

--- a/cli/dist/commands/policy.d.ts
+++ b/cli/dist/commands/policy.d.ts
@@ -1,0 +1,2 @@
+import type { ParsedArgs } from "../args.js";
+export declare function policyCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void>;

--- a/cli/dist/commands/policy.js
+++ b/cli/dist/commands/policy.js
@@ -1,0 +1,85 @@
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials } from "../credentials.js";
+import { normalizeAndValidateHubUrl } from "../hub-url.js";
+import { outputJson, outputError } from "../output.js";
+const DEFAULT_HUB = "https://api.botcord.chat";
+export async function policyCommand(args, globalHub, globalAgent) {
+    const sub = args.subcommand;
+    if (args.flags["help"] || !sub) {
+        if (!sub) {
+            console.log(`Usage: botcord policy <get|set> [options]
+
+Subcommands:
+  get [<agent_id>]            Get message policy (own or another agent's)
+  set --policy <open|contacts_only>   Set own message policy`);
+            if (!args.flags["help"])
+                process.exit(1);
+            return;
+        }
+    }
+    if (sub === "get") {
+        const targetId = args.positionals[0];
+        // If querying another agent's policy, can work without auth
+        if (targetId) {
+            let hubUrl;
+            if (globalHub) {
+                hubUrl = normalizeAndValidateHubUrl(globalHub);
+            }
+            else if (process.env.BOTCORD_HUB) {
+                hubUrl = normalizeAndValidateHubUrl(process.env.BOTCORD_HUB);
+            }
+            else {
+                try {
+                    const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+                    hubUrl = creds.hubUrl;
+                }
+                catch {
+                    hubUrl = DEFAULT_HUB;
+                }
+            }
+            const resp = await fetch(`${hubUrl}/registry/agents/${targetId}/policy`, {
+                signal: AbortSignal.timeout(10000),
+            });
+            if (!resp.ok) {
+                const body = await resp.text().catch(() => "");
+                outputError(`policy get failed: ${resp.status} ${body}`);
+            }
+            outputJson(await resp.json());
+            return;
+        }
+        // Own policy — needs auth
+        const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+        const hubUrl = globalHub || creds.hubUrl;
+        const client = new BotCordClient({
+            hubUrl,
+            agentId: creds.agentId,
+            keyId: creds.keyId,
+            privateKey: creds.privateKey,
+            token: creds.token,
+            tokenExpiresAt: creds.tokenExpiresAt,
+        });
+        const result = await client.getPolicy();
+        outputJson(result);
+    }
+    else if (sub === "set") {
+        const policy = args.flags["policy"];
+        if (policy !== "open" && policy !== "contacts_only") {
+            outputError("--policy must be 'open' or 'contacts_only'");
+        }
+        const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+        const hubUrl = globalHub || creds.hubUrl;
+        const client = new BotCordClient({
+            hubUrl,
+            agentId: creds.agentId,
+            keyId: creds.keyId,
+            privateKey: creds.privateKey,
+            token: creds.token,
+            tokenExpiresAt: creds.tokenExpiresAt,
+        });
+        await client.setPolicy(policy);
+        outputJson({ updated: true, message_policy: policy });
+    }
+    else {
+        outputError(`unknown subcommand: ${sub}. Use "get" or "set"`);
+    }
+}

--- a/cli/dist/commands/profile.d.ts
+++ b/cli/dist/commands/profile.d.ts
@@ -1,0 +1,2 @@
+import type { ParsedArgs } from "../args.js";
+export declare function profileCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void>;

--- a/cli/dist/commands/profile.js
+++ b/cli/dist/commands/profile.js
@@ -1,0 +1,51 @@
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials } from "../credentials.js";
+import { outputJson, outputError } from "../output.js";
+export async function profileCommand(args, globalHub, globalAgent) {
+    const sub = args.subcommand;
+    if (args.flags["help"] || (!sub && !args.flags["help"])) {
+        if (!sub) {
+            console.log(`Usage: botcord profile <get|set> [options]
+
+Subcommands:
+  get       Get current agent profile
+  set       Update agent profile
+
+Options for set:
+  --name <display_name>   New display name
+  --bio <bio>             New bio`);
+            if (!args.flags["help"])
+                process.exit(1);
+            return;
+        }
+    }
+    const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+    const hubUrl = globalHub || creds.hubUrl;
+    const client = new BotCordClient({
+        hubUrl,
+        agentId: creds.agentId,
+        keyId: creds.keyId,
+        privateKey: creds.privateKey,
+        token: creds.token,
+        tokenExpiresAt: creds.tokenExpiresAt,
+    });
+    if (sub === "get") {
+        const info = await client.resolve(creds.agentId);
+        outputJson(info);
+    }
+    else if (sub === "set") {
+        const params = {};
+        if (typeof args.flags["name"] === "string")
+            params.display_name = args.flags["name"];
+        if (typeof args.flags["bio"] === "string")
+            params.bio = args.flags["bio"];
+        if (!params.display_name && !params.bio) {
+            outputError("at least one of --name or --bio is required");
+        }
+        await client.updateProfile(params);
+        outputJson({ updated: true, ...params });
+    }
+    else {
+        outputError(`unknown subcommand: ${sub}. Use "get" or "set"`);
+    }
+}

--- a/cli/dist/commands/refresh.d.ts
+++ b/cli/dist/commands/refresh.d.ts
@@ -1,0 +1,2 @@
+import type { ParsedArgs } from "../args.js";
+export declare function refreshCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void>;

--- a/cli/dist/commands/refresh.js
+++ b/cli/dist/commands/refresh.js
@@ -1,0 +1,33 @@
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials, writeCredentialsFile, defaultCredentialsFile } from "../credentials.js";
+import { outputJson } from "../output.js";
+export async function refreshCommand(args, globalHub, globalAgent) {
+    if (args.flags["help"]) {
+        console.log(`Usage: botcord refresh
+
+Refresh the JWT token for the current agent.`);
+        return;
+    }
+    const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+    const hubUrl = globalHub || creds.hubUrl;
+    const client = new BotCordClient({
+        hubUrl,
+        agentId: creds.agentId,
+        keyId: creds.keyId,
+        privateKey: creds.privateKey,
+    });
+    const token = await client.refreshToken();
+    const expiresAt = client.getTokenExpiresAt();
+    // Persist the new token
+    const credPath = defaultCredentialsFile(creds.agentId);
+    writeCredentialsFile(credPath, {
+        ...creds,
+        token,
+        tokenExpiresAt: expiresAt,
+    });
+    outputJson({
+        agent_id: creds.agentId,
+        token_refreshed: true,
+        expires_at: expiresAt,
+    });
+}

--- a/cli/dist/commands/register.d.ts
+++ b/cli/dist/commands/register.d.ts
@@ -1,0 +1,2 @@
+import type { ParsedArgs } from "../args.js";
+export declare function registerCommand(args: ParsedArgs): Promise<void>;

--- a/cli/dist/commands/register.js
+++ b/cli/dist/commands/register.js
@@ -1,0 +1,52 @@
+import { BotCordClient } from "../client.js";
+import { defaultCredentialsFile, writeCredentialsFile, setDefaultAgent } from "../credentials.js";
+import { outputJson, outputError } from "../output.js";
+const DEFAULT_HUB = "https://api.botcord.chat";
+export async function registerCommand(args) {
+    if (args.flags["help"]) {
+        console.log(`Usage: botcord register --name <name> --bio <bio> [--hub <url>] [--set-default]
+
+Register a new agent on the BotCord network.
+
+Options:
+  --name <name>     Agent display name (required)
+  --bio <bio>       Agent bio/description
+  --hub <url>       Hub URL (default: ${DEFAULT_HUB})
+  --set-default     Set as default agent`);
+        return;
+    }
+    const name = args.flags["name"];
+    if (!name || typeof name !== "string") {
+        outputError("--name is required");
+    }
+    const bio = typeof args.flags["bio"] === "string" ? args.flags["bio"] : undefined;
+    const hubUrl = (typeof args.flags["hub"] === "string" ? args.flags["hub"] : null)
+        || process.env.BOTCORD_HUB
+        || DEFAULT_HUB;
+    const result = await BotCordClient.register(hubUrl, name, bio);
+    const credPath = defaultCredentialsFile(result.agentId);
+    writeCredentialsFile(credPath, {
+        version: 1,
+        hubUrl: result.hubUrl,
+        agentId: result.agentId,
+        keyId: result.keyId,
+        privateKey: result.privateKey,
+        publicKey: result.publicKey,
+        displayName: name,
+        savedAt: new Date().toISOString(),
+        token: result.token,
+        tokenExpiresAt: result.expiresAt,
+    });
+    const setDefault = args.flags["set-default"] === true;
+    if (setDefault) {
+        setDefaultAgent(result.agentId);
+    }
+    outputJson({
+        agent_id: result.agentId,
+        key_id: result.keyId,
+        display_name: name,
+        hub: result.hubUrl,
+        credentials_file: credPath,
+        set_default: setDefault,
+    });
+}

--- a/cli/dist/commands/resolve.d.ts
+++ b/cli/dist/commands/resolve.d.ts
@@ -1,0 +1,2 @@
+import type { ParsedArgs } from "../args.js";
+export declare function resolveCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void>;

--- a/cli/dist/commands/resolve.js
+++ b/cli/dist/commands/resolve.js
@@ -1,0 +1,41 @@
+import { normalizeAndValidateHubUrl } from "../hub-url.js";
+import { outputJson, outputError } from "../output.js";
+const DEFAULT_HUB = "https://api.botcord.chat";
+export async function resolveCommand(args, globalHub, globalAgent) {
+    if (args.flags["help"]) {
+        console.log(`Usage: botcord resolve <agent_id>
+
+Resolve public info for an agent. Works without authentication.`);
+        return;
+    }
+    const agentId = args.subcommand || args.positionals[0];
+    if (!agentId)
+        outputError("agent_id is required");
+    // Try to load credentials for hub URL, but fall back to defaults
+    let hubUrl;
+    if (globalHub) {
+        hubUrl = normalizeAndValidateHubUrl(globalHub);
+    }
+    else if (process.env.BOTCORD_HUB) {
+        hubUrl = normalizeAndValidateHubUrl(process.env.BOTCORD_HUB);
+    }
+    else {
+        try {
+            const { loadDefaultCredentials } = await import("../credentials.js");
+            const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+            hubUrl = creds.hubUrl;
+        }
+        catch {
+            hubUrl = DEFAULT_HUB;
+        }
+    }
+    const resp = await fetch(`${hubUrl}/registry/resolve/${agentId}`, {
+        signal: AbortSignal.timeout(10000),
+    });
+    if (!resp.ok) {
+        const body = await resp.text().catch(() => "");
+        outputError(`resolve failed: ${resp.status} ${body}`);
+    }
+    const data = await resp.json();
+    outputJson(data);
+}

--- a/cli/dist/commands/room.d.ts
+++ b/cli/dist/commands/room.d.ts
@@ -1,0 +1,2 @@
+import type { ParsedArgs } from "../args.js";
+export declare function roomCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void>;

--- a/cli/dist/commands/room.js
+++ b/cli/dist/commands/room.js
@@ -1,0 +1,278 @@
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials } from "../credentials.js";
+import { outputJson, outputError } from "../output.js";
+function makeClient(globalHub, globalAgent) {
+    const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+    return new BotCordClient({
+        hubUrl: globalHub || creds.hubUrl,
+        agentId: creds.agentId,
+        keyId: creds.keyId,
+        privateKey: creds.privateKey,
+        token: creds.token,
+        tokenExpiresAt: creds.tokenExpiresAt,
+    });
+}
+export async function roomCommand(args, globalHub, globalAgent) {
+    const sub = args.subcommand;
+    if (args.flags["help"] || !sub) {
+        console.log(`Usage: botcord room <subcommand> [options]
+
+Subcommands:
+  create        Create a new room
+  get <id>      Get room info
+  list          List my rooms
+  discover      Discover public rooms
+  update        Update room settings
+  dissolve      Dissolve a room
+  join          Join a room
+  leave         Leave a room
+  add-member    Add a member to a room
+  remove-member Remove a member
+  transfer      Transfer room ownership
+  promote       Change member role
+  mute          Mute/unmute room
+  permissions   Set member permissions
+  topic         Manage room topics`);
+        if (!sub && !args.flags["help"])
+            process.exit(1);
+        return;
+    }
+    // Handle topic subcommand tree
+    if (sub === "topic") {
+        await topicSubcommand(args, globalHub, globalAgent);
+        return;
+    }
+    const client = makeClient(globalHub, globalAgent);
+    switch (sub) {
+        case "create": {
+            const name = args.flags["name"];
+            if (!name || typeof name !== "string")
+                outputError("--name is required");
+            const params = { name };
+            if (typeof args.flags["description"] === "string")
+                params.description = args.flags["description"];
+            if (typeof args.flags["visibility"] === "string")
+                params.visibility = args.flags["visibility"];
+            if (typeof args.flags["join-policy"] === "string")
+                params.join_policy = args.flags["join-policy"];
+            if (typeof args.flags["max-members"] === "string")
+                params.max_members = parseInt(args.flags["max-members"], 10);
+            if (typeof args.flags["members"] === "string")
+                params.member_ids = args.flags["members"].split(",");
+            const result = await client.createRoom(params);
+            outputJson(result);
+            break;
+        }
+        case "get": {
+            const roomId = args.positionals[0] || args.flags["room"];
+            if (!roomId || typeof roomId !== "string")
+                outputError("room_id is required");
+            const result = await client.getRoomInfo(roomId);
+            outputJson(result);
+            break;
+        }
+        case "list": {
+            const result = await client.listMyRooms();
+            outputJson(result);
+            break;
+        }
+        case "discover": {
+            const name = typeof args.flags["name"] === "string" ? args.flags["name"] : undefined;
+            const result = await client.discoverRooms(name);
+            outputJson(result);
+            break;
+        }
+        case "update": {
+            const roomId = args.flags["room"];
+            if (!roomId || typeof roomId !== "string")
+                outputError("--room is required");
+            const params = {};
+            if (typeof args.flags["name"] === "string")
+                params.name = args.flags["name"];
+            if (typeof args.flags["description"] === "string")
+                params.description = args.flags["description"];
+            if (typeof args.flags["visibility"] === "string")
+                params.visibility = args.flags["visibility"];
+            if (typeof args.flags["join-policy"] === "string")
+                params.join_policy = args.flags["join-policy"];
+            const result = await client.updateRoom(roomId, params);
+            outputJson(result);
+            break;
+        }
+        case "dissolve": {
+            const roomId = args.flags["room"];
+            if (!roomId || typeof roomId !== "string")
+                outputError("--room is required");
+            await client.dissolveRoom(roomId);
+            outputJson({ dissolved: true, room_id: roomId });
+            break;
+        }
+        case "join": {
+            const roomId = args.flags["room"];
+            if (!roomId || typeof roomId !== "string")
+                outputError("--room is required");
+            await client.joinRoom(roomId);
+            outputJson({ joined: true, room_id: roomId });
+            break;
+        }
+        case "leave": {
+            const roomId = args.flags["room"];
+            if (!roomId || typeof roomId !== "string")
+                outputError("--room is required");
+            await client.leaveRoom(roomId);
+            outputJson({ left: true, room_id: roomId });
+            break;
+        }
+        case "add-member": {
+            const roomId = args.flags["room"];
+            const agentId = args.flags["id"];
+            if (!roomId || typeof roomId !== "string")
+                outputError("--room is required");
+            if (!agentId || typeof agentId !== "string")
+                outputError("--id is required");
+            await client.inviteToRoom(roomId, agentId);
+            outputJson({ added: true, room_id: roomId, agent_id: agentId });
+            break;
+        }
+        case "remove-member": {
+            const roomId = args.flags["room"];
+            const agentId = args.flags["id"];
+            if (!roomId || typeof roomId !== "string")
+                outputError("--room is required");
+            if (!agentId || typeof agentId !== "string")
+                outputError("--id is required");
+            await client.removeMember(roomId, agentId);
+            outputJson({ removed: true, room_id: roomId, agent_id: agentId });
+            break;
+        }
+        case "transfer": {
+            const roomId = args.flags["room"];
+            const newOwner = args.flags["id"];
+            if (!roomId || typeof roomId !== "string")
+                outputError("--room is required");
+            if (!newOwner || typeof newOwner !== "string")
+                outputError("--id is required");
+            await client.transferOwnership(roomId, newOwner);
+            outputJson({ transferred: true, room_id: roomId, new_owner: newOwner });
+            break;
+        }
+        case "promote": {
+            const roomId = args.flags["room"];
+            const agentId = args.flags["id"];
+            const role = args.flags["role"];
+            if (!roomId || typeof roomId !== "string")
+                outputError("--room is required");
+            if (!agentId || typeof agentId !== "string")
+                outputError("--id is required");
+            if (role !== "admin" && role !== "member")
+                outputError("--role must be 'admin' or 'member'");
+            await client.promoteMember(roomId, agentId, role);
+            outputJson({ promoted: true, room_id: roomId, agent_id: agentId, role });
+            break;
+        }
+        case "mute": {
+            const roomId = args.flags["room"];
+            if (!roomId || typeof roomId !== "string")
+                outputError("--room is required");
+            const muted = args.flags["muted"] !== "false";
+            await client.muteRoom(roomId, muted);
+            outputJson({ room_id: roomId, muted });
+            break;
+        }
+        case "permissions": {
+            const roomId = args.flags["room"];
+            const agentId = args.flags["id"];
+            if (!roomId || typeof roomId !== "string")
+                outputError("--room is required");
+            if (!agentId || typeof agentId !== "string")
+                outputError("--id is required");
+            const permissions = {};
+            if (typeof args.flags["can-send"] === "string")
+                permissions.can_send = args.flags["can-send"] === "true";
+            if (typeof args.flags["can-invite"] === "string")
+                permissions.can_invite = args.flags["can-invite"] === "true";
+            await client.setMemberPermissions(roomId, agentId, permissions);
+            outputJson({ updated: true, room_id: roomId, agent_id: agentId, ...permissions });
+            break;
+        }
+        default:
+            outputError(`unknown subcommand: ${sub}`);
+    }
+}
+async function topicSubcommand(args, globalHub, globalAgent) {
+    // The topic action is the first positional after "topic" was consumed as subcommand
+    const action = args.positionals[0];
+    if (args.flags["help"] || !action) {
+        console.log(`Usage: botcord room topic <action> [options]
+
+Actions:
+  list      --room <id> [--status <status>]
+  create    --room <id> --title <title> [--description <text>] [--goal <text>]
+  get       --room <id> --topic-id <id>
+  update    --room <id> --topic-id <id> [--title ...] [--status ...] [--goal ...]
+  delete    --room <id> --topic-id <id>`);
+        if (!action && !args.flags["help"])
+            process.exit(1);
+        return;
+    }
+    const client = makeClient(globalHub, globalAgent);
+    const roomId = args.flags["room"];
+    if (!roomId || typeof roomId !== "string")
+        outputError("--room is required");
+    switch (action) {
+        case "list": {
+            const status = typeof args.flags["status"] === "string" ? args.flags["status"] : undefined;
+            const result = await client.listTopics(roomId, status);
+            outputJson(result);
+            break;
+        }
+        case "create": {
+            const title = args.flags["title"];
+            if (!title || typeof title !== "string")
+                outputError("--title is required");
+            const params = { title };
+            if (typeof args.flags["description"] === "string")
+                params.description = args.flags["description"];
+            if (typeof args.flags["goal"] === "string")
+                params.goal = args.flags["goal"];
+            const result = await client.createTopic(roomId, params);
+            outputJson(result);
+            break;
+        }
+        case "get": {
+            const topicId = args.flags["topic-id"];
+            if (!topicId || typeof topicId !== "string")
+                outputError("--topic-id is required");
+            const result = await client.getTopic(roomId, topicId);
+            outputJson(result);
+            break;
+        }
+        case "update": {
+            const topicId = args.flags["topic-id"];
+            if (!topicId || typeof topicId !== "string")
+                outputError("--topic-id is required");
+            const params = {};
+            if (typeof args.flags["title"] === "string")
+                params.title = args.flags["title"];
+            if (typeof args.flags["description"] === "string")
+                params.description = args.flags["description"];
+            if (typeof args.flags["status"] === "string")
+                params.status = args.flags["status"];
+            if (typeof args.flags["goal"] === "string")
+                params.goal = args.flags["goal"];
+            const result = await client.updateTopic(roomId, topicId, params);
+            outputJson(result);
+            break;
+        }
+        case "delete": {
+            const topicId = args.flags["topic-id"];
+            if (!topicId || typeof topicId !== "string")
+                outputError("--topic-id is required");
+            await client.deleteTopic(roomId, topicId);
+            outputJson({ deleted: true, room_id: roomId, topic_id: topicId });
+            break;
+        }
+        default:
+            outputError(`unknown topic action: ${action}`);
+    }
+}

--- a/cli/dist/commands/send.d.ts
+++ b/cli/dist/commands/send.d.ts
@@ -1,0 +1,2 @@
+import type { ParsedArgs } from "../args.js";
+export declare function sendCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void>;

--- a/cli/dist/commands/send.js
+++ b/cli/dist/commands/send.js
@@ -1,0 +1,86 @@
+import path from "node:path";
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials } from "../credentials.js";
+import { outputJson, outputError } from "../output.js";
+export async function sendCommand(args, globalHub, globalAgent) {
+    if (args.flags["help"]) {
+        console.log(`Usage: botcord send --to <id> --text <msg> [options]
+
+Send a signed message to an agent or room.
+
+Options:
+  --to <id>           Recipient agent or room ID (required)
+  --text <msg>        Message text (required)
+  --reply-to <id>     Reply to a specific message ID
+  --topic <topic>     Topic name
+  --goal <goal>       Goal description
+  --ttl <sec>         Message TTL in seconds (default: 3600)
+  --file <path>       Attach a file (can be repeated)
+  --mention <id>      Mention an agent or @all (can be repeated)`);
+        return;
+    }
+    const to = args.flags["to"];
+    const text = args.flags["text"];
+    if (!to || typeof to !== "string")
+        outputError("--to is required");
+    if (!text || typeof text !== "string")
+        outputError("--text is required");
+    const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+    const hubUrl = globalHub || creds.hubUrl;
+    const client = new BotCordClient({
+        hubUrl,
+        agentId: creds.agentId,
+        keyId: creds.keyId,
+        privateKey: creds.privateKey,
+        token: creds.token,
+        tokenExpiresAt: creds.tokenExpiresAt,
+    });
+    // Collect --file flags (may appear multiple times in positionals/raw argv)
+    const files = [];
+    const rawArgv = process.argv.slice(2);
+    for (let i = 0; i < rawArgv.length; i++) {
+        if (rawArgv[i] === "--file" && rawArgv[i + 1]) {
+            files.push(rawArgv[i + 1]);
+            i++;
+        }
+        else if (rawArgv[i].startsWith("--file=")) {
+            files.push(rawArgv[i].slice(7));
+        }
+    }
+    // Collect --mention flags
+    const mentions = [];
+    for (let i = 0; i < rawArgv.length; i++) {
+        if (rawArgv[i] === "--mention" && rawArgv[i + 1]) {
+            mentions.push(rawArgv[i + 1]);
+            i++;
+        }
+        else if (rawArgv[i].startsWith("--mention=")) {
+            mentions.push(rawArgv[i].slice(10));
+        }
+    }
+    // Upload files
+    const attachments = [];
+    for (const filePath of files) {
+        const filename = path.basename(filePath);
+        const uploaded = await client.uploadFile(filePath, filename);
+        attachments.push({
+            filename: uploaded.original_filename,
+            url: uploaded.url,
+            content_type: uploaded.content_type,
+            size_bytes: uploaded.size_bytes,
+        });
+    }
+    const replyTo = typeof args.flags["reply-to"] === "string" ? args.flags["reply-to"] : undefined;
+    const topic = typeof args.flags["topic"] === "string" ? args.flags["topic"] : undefined;
+    const goal = typeof args.flags["goal"] === "string" ? args.flags["goal"] : undefined;
+    const ttl = typeof args.flags["ttl"] === "string" ? parseInt(args.flags["ttl"], 10) : undefined;
+    const result = await client.sendMessage(to, text, {
+        replyTo,
+        topic,
+        goal,
+        ttlSec: ttl,
+        attachments: attachments.length > 0 ? attachments : undefined,
+        mentions: mentions.length > 0 ? mentions : undefined,
+    });
+    outputJson(result);
+}

--- a/cli/dist/commands/status.d.ts
+++ b/cli/dist/commands/status.d.ts
@@ -1,0 +1,2 @@
+import type { ParsedArgs } from "../args.js";
+export declare function statusCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void>;

--- a/cli/dist/commands/status.js
+++ b/cli/dist/commands/status.js
@@ -1,0 +1,26 @@
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials } from "../credentials.js";
+import { outputJson, outputError } from "../output.js";
+export async function statusCommand(args, globalHub, globalAgent) {
+    if (args.flags["help"]) {
+        console.log(`Usage: botcord status <msg_id>
+
+Query the delivery status of a message.`);
+        return;
+    }
+    const msgId = args.subcommand || args.positionals[0];
+    if (!msgId)
+        outputError("msg_id is required");
+    const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+    const hubUrl = globalHub || creds.hubUrl;
+    const client = new BotCordClient({
+        hubUrl,
+        agentId: creds.agentId,
+        keyId: creds.keyId,
+        privateKey: creds.privateKey,
+        token: creds.token,
+        tokenExpiresAt: creds.tokenExpiresAt,
+    });
+    const result = await client.getMessageStatus(msgId);
+    outputJson(result);
+}

--- a/cli/dist/commands/wallet.d.ts
+++ b/cli/dist/commands/wallet.d.ts
@@ -1,0 +1,2 @@
+import type { ParsedArgs } from "../args.js";
+export declare function walletCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void>;

--- a/cli/dist/commands/wallet.js
+++ b/cli/dist/commands/wallet.js
@@ -1,0 +1,78 @@
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials } from "../credentials.js";
+import { outputJson, outputError } from "../output.js";
+export async function walletCommand(args, globalHub, globalAgent) {
+    const sub = args.subcommand;
+    if (args.flags["help"] || !sub) {
+        console.log(`Usage: botcord wallet <subcommand> [options]
+
+Subcommands:
+  balance                          Show wallet balance
+  ledger [--limit <n>] [--cursor <c>] [--type <type>]  Show ledger entries
+  transfer --to <id> --amount <n> [--memo <text>]       Transfer funds
+  topup --amount <n>               Request a topup
+  withdraw --amount <n>            Request a withdrawal`);
+        if (!sub && !args.flags["help"])
+            process.exit(1);
+        return;
+    }
+    const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+    const hubUrl = globalHub || creds.hubUrl;
+    const client = new BotCordClient({
+        hubUrl,
+        agentId: creds.agentId,
+        keyId: creds.keyId,
+        privateKey: creds.privateKey,
+        token: creds.token,
+        tokenExpiresAt: creds.tokenExpiresAt,
+    });
+    switch (sub) {
+        case "balance": {
+            const result = await client.getWallet();
+            outputJson(result);
+            break;
+        }
+        case "ledger": {
+            const limit = typeof args.flags["limit"] === "string" ? parseInt(args.flags["limit"], 10) : undefined;
+            const cursor = typeof args.flags["cursor"] === "string" ? args.flags["cursor"] : undefined;
+            const type = typeof args.flags["type"] === "string" ? args.flags["type"] : undefined;
+            const result = await client.getWalletLedger({ limit, cursor, type });
+            outputJson(result);
+            break;
+        }
+        case "transfer": {
+            const to = args.flags["to"];
+            const amount = args.flags["amount"];
+            if (!to || typeof to !== "string")
+                outputError("--to is required");
+            if (!amount || typeof amount !== "string")
+                outputError("--amount is required");
+            const memo = typeof args.flags["memo"] === "string" ? args.flags["memo"] : undefined;
+            const result = await client.createTransfer({
+                to_agent_id: to,
+                amount_minor: amount,
+                memo,
+            });
+            outputJson(result);
+            break;
+        }
+        case "topup": {
+            const amount = args.flags["amount"];
+            if (!amount || typeof amount !== "string")
+                outputError("--amount is required");
+            const result = await client.createTopup({ amount_minor: amount });
+            outputJson(result);
+            break;
+        }
+        case "withdraw": {
+            const amount = args.flags["amount"];
+            if (!amount || typeof amount !== "string")
+                outputError("--amount is required");
+            const result = await client.createWithdrawal({ amount_minor: amount });
+            outputJson(result);
+            break;
+        }
+        default:
+            outputError(`unknown subcommand: ${sub}`);
+    }
+}

--- a/cli/dist/credentials.d.ts
+++ b/cli/dist/credentials.d.ts
@@ -1,0 +1,18 @@
+export interface StoredBotCordCredentials {
+    version: 1;
+    hubUrl: string;
+    agentId: string;
+    keyId: string;
+    privateKey: string;
+    publicKey: string;
+    displayName?: string;
+    savedAt: string;
+    token?: string;
+    tokenExpiresAt?: number;
+}
+export declare function resolveCredentialsFilePath(credentialsFile: string): string;
+export declare function defaultCredentialsFile(agentId: string): string;
+export declare function loadStoredCredentials(credentialsFile: string): StoredBotCordCredentials;
+export declare function writeCredentialsFile(credentialsFile: string, credentials: StoredBotCordCredentials): string;
+export declare function loadDefaultCredentials(agentId?: string): StoredBotCordCredentials;
+export declare function setDefaultAgent(agentId: string): void;

--- a/cli/dist/credentials.js
+++ b/cli/dist/credentials.js
@@ -1,0 +1,114 @@
+import { chmodSync, mkdirSync, readFileSync, writeFileSync, symlinkSync, unlinkSync, existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { derivePublicKey } from "./crypto.js";
+import { normalizeAndValidateHubUrl } from "./hub-url.js";
+function normalizeCredentialValue(raw, keys) {
+    for (const key of keys) {
+        const value = raw[key];
+        if (typeof value === "string" && value.trim())
+            return value;
+    }
+    return undefined;
+}
+export function resolveCredentialsFilePath(credentialsFile) {
+    if (credentialsFile === "~")
+        return os.homedir();
+    if (credentialsFile.startsWith("~/")) {
+        return path.join(os.homedir(), credentialsFile.slice(2));
+    }
+    return path.isAbsolute(credentialsFile)
+        ? credentialsFile
+        : path.resolve(credentialsFile);
+}
+export function defaultCredentialsFile(agentId) {
+    return path.join(os.homedir(), ".botcord", "credentials", `${agentId}.json`);
+}
+export function loadStoredCredentials(credentialsFile) {
+    const resolved = resolveCredentialsFilePath(credentialsFile);
+    let raw;
+    try {
+        raw = JSON.parse(readFileSync(resolved, "utf8"));
+    }
+    catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(`Unable to read BotCord credentials file "${resolved}": ${msg}`);
+    }
+    const hubUrl = normalizeCredentialValue(raw, ["hubUrl", "hub_url", "hub"]);
+    const agentId = normalizeCredentialValue(raw, ["agentId", "agent_id"]);
+    const keyId = normalizeCredentialValue(raw, ["keyId", "key_id"]);
+    const privateKey = normalizeCredentialValue(raw, ["privateKey", "private_key"]);
+    const publicKey = normalizeCredentialValue(raw, ["publicKey", "public_key"]);
+    const displayName = normalizeCredentialValue(raw, ["displayName", "display_name"]);
+    const savedAt = normalizeCredentialValue(raw, ["savedAt", "saved_at"]);
+    const token = normalizeCredentialValue(raw, ["token"]);
+    const tokenExpiresAt = typeof raw.tokenExpiresAt === "number" ? raw.tokenExpiresAt : undefined;
+    if (!hubUrl)
+        throw new Error(`BotCord credentials file "${resolved}" is missing hubUrl`);
+    if (!agentId)
+        throw new Error(`BotCord credentials file "${resolved}" is missing agentId`);
+    if (!keyId)
+        throw new Error(`BotCord credentials file "${resolved}" is missing keyId`);
+    if (!privateKey)
+        throw new Error(`BotCord credentials file "${resolved}" is missing privateKey`);
+    const derivedPublicKey = derivePublicKey(privateKey);
+    if (publicKey && publicKey !== derivedPublicKey) {
+        throw new Error(`BotCord credentials file "${resolved}" has a publicKey that does not match privateKey`);
+    }
+    let normalizedHubUrl;
+    try {
+        normalizedHubUrl = normalizeAndValidateHubUrl(hubUrl);
+    }
+    catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(`BotCord credentials file "${resolved}" has an invalid hubUrl: ${msg}`);
+    }
+    return {
+        version: 1,
+        hubUrl: normalizedHubUrl,
+        agentId,
+        keyId,
+        privateKey,
+        publicKey: publicKey || derivedPublicKey,
+        displayName,
+        savedAt: savedAt || new Date().toISOString(),
+        token,
+        tokenExpiresAt,
+    };
+}
+export function writeCredentialsFile(credentialsFile, credentials) {
+    const resolved = resolveCredentialsFilePath(credentialsFile);
+    const normalizedCredentials = {
+        ...credentials,
+        hubUrl: normalizeAndValidateHubUrl(credentials.hubUrl),
+    };
+    mkdirSync(path.dirname(resolved), { recursive: true, mode: 0o700 });
+    writeFileSync(resolved, JSON.stringify(normalizedCredentials, null, 2) + "\n", {
+        encoding: "utf8",
+        mode: 0o600,
+    });
+    chmodSync(resolved, 0o600);
+    return resolved;
+}
+const DEFAULT_LINK = path.join(os.homedir(), ".botcord", "default.json");
+export function loadDefaultCredentials(agentId) {
+    if (agentId) {
+        return loadStoredCredentials(defaultCredentialsFile(agentId));
+    }
+    if (!existsSync(DEFAULT_LINK)) {
+        throw new Error("No default agent configured. Use --agent <id> or run: botcord register --set-default");
+    }
+    return loadStoredCredentials(DEFAULT_LINK);
+}
+export function setDefaultAgent(agentId) {
+    const target = defaultCredentialsFile(agentId);
+    if (!existsSync(target)) {
+        throw new Error(`Credentials file not found: ${target}`);
+    }
+    const linkDir = path.dirname(DEFAULT_LINK);
+    mkdirSync(linkDir, { recursive: true, mode: 0o700 });
+    if (existsSync(DEFAULT_LINK)) {
+        unlinkSync(DEFAULT_LINK);
+    }
+    symlinkSync(target, DEFAULT_LINK);
+}

--- a/cli/dist/crypto.d.ts
+++ b/cli/dist/crypto.d.ts
@@ -1,0 +1,22 @@
+import type { BotCordMessageEnvelope, MessageType } from "./types.js";
+export declare function jcsCanonicalize(value: unknown): string | undefined;
+export declare function computePayloadHash(payload: Record<string, unknown>): string;
+export declare function signChallenge(privateKeyB64: string, challengeB64: string): string;
+export declare function derivePublicKey(privateKeyB64: string): string;
+export declare function buildSignedEnvelope(params: {
+    from: string;
+    to: string;
+    type: MessageType;
+    payload: Record<string, unknown>;
+    privateKey: string;
+    keyId: string;
+    replyTo?: string | null;
+    ttlSec?: number;
+    topic?: string | null;
+    goal?: string | null;
+}): BotCordMessageEnvelope;
+export declare function generateKeypair(): {
+    privateKey: string;
+    publicKey: string;
+    pubkeyFormatted: string;
+};

--- a/cli/dist/crypto.js
+++ b/cli/dist/crypto.js
@@ -1,0 +1,113 @@
+/**
+ * Ed25519 signing for BotCord protocol.
+ * Zero npm dependencies — uses Node.js built-in crypto module.
+ * Ported from botcord-skill/skill/botcord-crypto.mjs.
+ */
+import { createHash, createPublicKey, createPrivateKey, generateKeyPairSync, sign, randomUUID, } from "node:crypto";
+// ── JCS (RFC 8785) canonicalization ─────────────────────────────
+export function jcsCanonicalize(value) {
+    if (value === null || typeof value === "boolean")
+        return JSON.stringify(value);
+    if (typeof value === "number") {
+        if (Object.is(value, -0))
+            return "0";
+        return JSON.stringify(value);
+    }
+    if (typeof value === "string")
+        return JSON.stringify(value);
+    if (Array.isArray(value))
+        return "[" + value.map((v) => jcsCanonicalize(v)).join(",") + "]";
+    if (typeof value === "object") {
+        const keys = Object.keys(value).sort();
+        const parts = [];
+        for (const k of keys) {
+            const v = value[k];
+            if (v === undefined)
+                continue;
+            parts.push(JSON.stringify(k) + ":" + jcsCanonicalize(v));
+        }
+        return "{" + parts.join(",") + "}";
+    }
+    return undefined;
+}
+// ── Build Node.js KeyObject from raw 32-byte seed ───────────────
+function privateKeyFromSeed(seed) {
+    const prefix = Buffer.from("302e020100300506032b657004220420", "hex");
+    return createPrivateKey({
+        key: Buffer.concat([prefix, seed]),
+        format: "der",
+        type: "pkcs8",
+    });
+}
+// ── Payload hash ────────────────────────────────────────────────
+export function computePayloadHash(payload) {
+    const canonical = jcsCanonicalize(payload);
+    const digest = createHash("sha256").update(canonical).digest("hex");
+    return `sha256:${digest}`;
+}
+// ── Sign challenge ──────────────────────────────────────────────
+export function signChallenge(privateKeyB64, challengeB64) {
+    const pk = privateKeyFromSeed(Buffer.from(privateKeyB64, "base64"));
+    const sig = sign(null, Buffer.from(challengeB64, "base64"), pk);
+    return sig.toString("base64");
+}
+export function derivePublicKey(privateKeyB64) {
+    const privateKey = privateKeyFromSeed(Buffer.from(privateKeyB64, "base64"));
+    const publicKey = createPublicKey(privateKey);
+    const pubDer = publicKey.export({ type: "spki", format: "der" });
+    return Buffer.from(pubDer.subarray(-32)).toString("base64");
+}
+// ── Build and sign a full message envelope ──────────────────────
+export function buildSignedEnvelope(params) {
+    const { from, to, type, payload, privateKey, keyId, replyTo = null, ttlSec = 3600, topic = null, goal = null, } = params;
+    const msgId = randomUUID();
+    const ts = Math.floor(Date.now() / 1000);
+    const payloadHash = computePayloadHash(payload);
+    // Build signing input (newline-joined fields)
+    const parts = [
+        "a2a/0.1",
+        msgId,
+        String(ts),
+        from,
+        to,
+        String(type),
+        replyTo || "",
+        String(ttlSec),
+        payloadHash,
+    ];
+    const pk = privateKeyFromSeed(Buffer.from(privateKey, "base64"));
+    const sigValue = sign(null, Buffer.from(parts.join("\n")), pk);
+    const sig = {
+        alg: "ed25519",
+        key_id: keyId,
+        value: sigValue.toString("base64"),
+    };
+    return {
+        v: "a2a/0.1",
+        msg_id: msgId,
+        ts,
+        from,
+        to,
+        type,
+        reply_to: replyTo,
+        ttl_sec: ttlSec,
+        topic,
+        goal,
+        payload,
+        payload_hash: payloadHash,
+        sig,
+    };
+}
+// ── Keygen ──────────────────────────────────────────────────────
+export function generateKeypair() {
+    const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+    const privDer = privateKey.export({ type: "pkcs8", format: "der" });
+    const privB64 = Buffer.from(privDer.subarray(-32)).toString("base64");
+    const pubDer = publicKey.export({ type: "spki", format: "der" });
+    const pubB64 = Buffer.from(pubDer.subarray(-32)).toString("base64");
+    return {
+        privateKey: privB64,
+        publicKey: pubB64,
+        pubkeyFormatted: `ed25519:${pubB64}`,
+    };
+}

--- a/cli/dist/hub-url.d.ts
+++ b/cli/dist/hub-url.d.ts
@@ -1,0 +1,1 @@
+export declare function normalizeAndValidateHubUrl(hubUrl: string): string;

--- a/cli/dist/hub-url.js
+++ b/cli/dist/hub-url.js
@@ -1,0 +1,25 @@
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+function isLoopbackHost(hostname) {
+    const normalized = hostname.toLowerCase().replace(/^\[(.*)\]$/, "$1");
+    return LOOPBACK_HOSTS.has(normalized) || normalized.endsWith(".localhost");
+}
+export function normalizeAndValidateHubUrl(hubUrl) {
+    const trimmed = hubUrl.trim();
+    if (!trimmed) {
+        throw new Error("BotCord hubUrl is required");
+    }
+    let parsed;
+    try {
+        parsed = new URL(trimmed);
+    }
+    catch {
+        throw new Error(`BotCord hubUrl must be a valid absolute URL: ${hubUrl}`);
+    }
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+        throw new Error("BotCord hubUrl must use http:// or https://");
+    }
+    if (parsed.protocol === "http:" && !isLoopbackHost(parsed.hostname)) {
+        throw new Error("BotCord hubUrl must use https:// unless it targets localhost, 127.0.0.1, or ::1 for local development");
+    }
+    return trimmed.replace(/\/$/, "");
+}

--- a/cli/dist/index.d.ts
+++ b/cli/dist/index.d.ts
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+export {};

--- a/cli/dist/index.js
+++ b/cli/dist/index.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+import { parseArgs } from "./args.js";
+import { outputError } from "./output.js";
+import { registerCommand } from "./commands/register.js";
+import { sendCommand } from "./commands/send.js";
+import { refreshCommand } from "./commands/refresh.js";
+import { resolveCommand } from "./commands/resolve.js";
+import { statusCommand } from "./commands/status.js";
+import { profileCommand } from "./commands/profile.js";
+import { policyCommand } from "./commands/policy.js";
+import { endpointCommand } from "./commands/endpoint.js";
+import { roomCommand } from "./commands/room.js";
+import { contactCommand } from "./commands/contact.js";
+import { contactRequestCommand } from "./commands/contact-request.js";
+import { blockCommand } from "./commands/block.js";
+import { inboxCommand } from "./commands/inbox.js";
+import { walletCommand } from "./commands/wallet.js";
+const VERSION = "0.1.0";
+const HELP = `botcord — BotCord CLI v${VERSION}
+
+Usage: botcord <command> [options]
+
+Commands:
+  register          Register a new agent
+  send              Send a signed message
+  inbox             Poll inbox for new messages
+  status            Query message delivery status
+  room              Manage rooms
+  contact           Manage contacts
+  contact-request   Manage contact requests
+  block             Manage blocked agents
+  profile           Get or update agent profile
+  policy            Get or set message policy
+  endpoint          Register webhook endpoint
+  resolve           Resolve agent info
+  refresh           Refresh JWT token
+  wallet            Wallet operations
+
+Global options:
+  --agent <id>      Use specific agent credentials
+  --hub <url>       Override hub URL
+  --help, -h        Show help
+
+Environment:
+  BOTCORD_HUB       Default hub URL override`;
+async function main() {
+    const args = parseArgs(process.argv.slice(2));
+    // Global options
+    const globalAgent = typeof args.flags["agent"] === "string" ? args.flags["agent"] : undefined;
+    const globalHub = typeof args.flags["hub"] === "string"
+        ? args.flags["hub"]
+        : (process.env.BOTCORD_HUB || undefined);
+    if (!args.command || args.flags["help"] === true) {
+        if (!args.command) {
+            console.log(HELP);
+            process.exit(args.flags["help"] ? 0 : 1);
+        }
+    }
+    try {
+        switch (args.command) {
+            case "register":
+                await registerCommand(args);
+                break;
+            case "send":
+                await sendCommand(args, globalHub, globalAgent);
+                break;
+            case "inbox":
+                await inboxCommand(args, globalHub, globalAgent);
+                break;
+            case "status":
+                await statusCommand(args, globalHub, globalAgent);
+                break;
+            case "room":
+                await roomCommand(args, globalHub, globalAgent);
+                break;
+            case "contact":
+                await contactCommand(args, globalHub, globalAgent);
+                break;
+            case "contact-request":
+                await contactRequestCommand(args, globalHub, globalAgent);
+                break;
+            case "block":
+                await blockCommand(args, globalHub, globalAgent);
+                break;
+            case "profile":
+                await profileCommand(args, globalHub, globalAgent);
+                break;
+            case "policy":
+                await policyCommand(args, globalHub, globalAgent);
+                break;
+            case "endpoint":
+                await endpointCommand(args, globalHub, globalAgent);
+                break;
+            case "resolve":
+                await resolveCommand(args, globalHub, globalAgent);
+                break;
+            case "refresh":
+                await refreshCommand(args, globalHub, globalAgent);
+                break;
+            case "wallet":
+                await walletCommand(args, globalHub, globalAgent);
+                break;
+            default:
+                outputError(`unknown command: ${args.command}. Run "botcord --help" for usage.`);
+        }
+    }
+    catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        outputError(message);
+    }
+}
+main();

--- a/cli/dist/output.d.ts
+++ b/cli/dist/output.d.ts
@@ -1,0 +1,2 @@
+export declare function outputJson(data: unknown): void;
+export declare function outputError(message: string): never;

--- a/cli/dist/output.js
+++ b/cli/dist/output.js
@@ -1,0 +1,7 @@
+export function outputJson(data) {
+    console.log(JSON.stringify(data, null, 2));
+}
+export function outputError(message) {
+    console.error(JSON.stringify({ error: message }));
+    process.exit(1);
+}

--- a/cli/dist/types.d.ts
+++ b/cli/dist/types.d.ts
@@ -1,0 +1,201 @@
+export type BotCordSignature = {
+    alg: "ed25519";
+    key_id: string;
+    value: string;
+};
+export type MessageType = "message" | "ack" | "result" | "error" | "contact_request" | "contact_request_response" | "contact_removed" | "system";
+export type BotCordMessageEnvelope = {
+    v: string;
+    msg_id: string;
+    ts: number;
+    from: string;
+    to: string;
+    type: MessageType;
+    reply_to: string | null;
+    ttl_sec: number;
+    topic?: string | null;
+    goal?: string | null;
+    payload: Record<string, unknown>;
+    payload_hash: string;
+    sig: BotCordSignature;
+    mentions?: string[] | null;
+};
+export type InboxMessage = {
+    hub_msg_id: string;
+    envelope: BotCordMessageEnvelope;
+    text?: string;
+    room_id?: string;
+    room_name?: string;
+    room_rule?: string | null;
+    room_member_count?: number;
+    room_member_names?: string[];
+    my_role?: string;
+    my_can_send?: boolean;
+    topic?: string;
+    topic_id?: string;
+    goal?: string;
+    mentioned?: boolean;
+    source_type?: string;
+    source_user_id?: string | null;
+    source_session_kind?: string | null;
+};
+export type InboxPollResponse = {
+    messages: InboxMessage[];
+    count: number;
+    has_more: boolean;
+};
+export type SendResponse = {
+    queued: boolean;
+    hub_msg_id: string;
+    status: string;
+    topic_id?: string;
+};
+export type RoomInfo = {
+    room_id: string;
+    name: string;
+    description?: string;
+    rule?: string | null;
+    visibility: "private" | "public";
+    join_policy: "invite_only" | "open";
+    required_subscription_product_id?: string | null;
+    max_members?: number | null;
+    default_send: boolean;
+    default_invite?: boolean;
+    slow_mode_seconds?: number | null;
+    member_count: number;
+    created_at: string;
+};
+export type AgentInfo = {
+    agent_id: string;
+    display_name?: string;
+    bio?: string;
+    message_policy: string;
+    endpoints: Array<{
+        url: string;
+        state: string;
+    }>;
+};
+export type ContactInfo = {
+    contact_agent_id: string;
+    display_name?: string;
+    created_at: string;
+};
+export type ContactRequestInfo = {
+    request_id: string;
+    from_agent_id: string;
+    to_agent_id: string;
+    state: "pending" | "accepted" | "rejected";
+    created_at: string;
+};
+export type FileUploadResponse = {
+    file_id: string;
+    url: string;
+    original_filename: string;
+    content_type: string;
+    size_bytes: number;
+    expires_at: string;
+};
+export type MessageAttachment = {
+    filename: string;
+    url: string;
+    content_type?: string;
+    size_bytes?: number;
+};
+export type WalletSummary = {
+    agent_id: string;
+    asset_code: string;
+    available_balance_minor: string;
+    locked_balance_minor: string;
+    total_balance_minor: string;
+    updated_at: string;
+};
+export type WalletTransaction = {
+    tx_id: string;
+    type: "topup" | "withdrawal" | "transfer";
+    status: "pending" | "processing" | "completed" | "failed" | "cancelled";
+    asset_code: string;
+    amount_minor: string;
+    fee_minor: string;
+    from_agent_id: string | null;
+    to_agent_id: string | null;
+    reference_type: string | null;
+    reference_id: string | null;
+    idempotency_key: string | null;
+    metadata_json: string | null;
+    created_at: string;
+    updated_at: string;
+    completed_at: string | null;
+};
+export type WalletLedgerEntry = {
+    entry_id: string;
+    tx_id: string;
+    agent_id: string;
+    asset_code: string;
+    direction: "debit" | "credit";
+    amount_minor: string;
+    balance_after_minor: string;
+    created_at: string;
+};
+export type WalletLedgerResponse = {
+    entries: WalletLedgerEntry[];
+    next_cursor: string | null;
+    has_more: boolean;
+};
+export type TopupResponse = {
+    topup_id: string;
+    tx_id: string | null;
+    agent_id: string;
+    asset_code: string;
+    amount_minor: string;
+    status: string;
+    channel: string;
+    created_at: string;
+    completed_at: string | null;
+};
+export type WithdrawalResponse = {
+    withdrawal_id: string;
+    tx_id: string | null;
+    agent_id: string;
+    asset_code: string;
+    amount_minor: string;
+    fee_minor: string;
+    status: string;
+    destination_type: string | null;
+    review_note: string | null;
+    created_at: string;
+    reviewed_at: string | null;
+    completed_at: string | null;
+};
+export type SubscriptionProduct = {
+    product_id: string;
+    owner_agent_id: string;
+    name: string;
+    description: string;
+    asset_code: string;
+    amount_minor: string;
+    billing_interval: "week" | "month";
+    status: "active" | "archived";
+    created_at: string;
+    updated_at: string;
+    archived_at: string | null;
+};
+export type Subscription = {
+    subscription_id: string;
+    product_id: string;
+    subscriber_agent_id: string;
+    provider_agent_id: string;
+    asset_code: string;
+    amount_minor: string;
+    billing_interval: "week" | "month";
+    status: "active" | "past_due" | "cancelled";
+    current_period_start: string;
+    current_period_end: string;
+    next_charge_at: string;
+    cancel_at_period_end: boolean;
+    cancelled_at: string | null;
+    last_charged_at: string | null;
+    last_charge_tx_id: string | null;
+    consecutive_failed_attempts: number;
+    created_at: string;
+    updated_at: string;
+};

--- a/cli/dist/types.js
+++ b/cli/dist/types.js
@@ -1,0 +1,2 @@
+// BotCord protocol types (mirrors hub/schemas.py)
+export {};

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@botcord/cli",
+  "version": "0.1.0",
+  "description": "BotCord CLI — register agents, send signed messages, manage rooms and contacts",
+  "type": "module",
+  "bin": {
+    "botcord": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "prepublishOnly": "tsc"
+  },
+  "files": ["dist", "README.md"],
+  "engines": { "node": ">=18" },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/botlearn-ai/botcord",
+    "directory": "cli"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "@types/node": "^20.0.0"
+  }
+}

--- a/cli/src/args.ts
+++ b/cli/src/args.ts
@@ -1,0 +1,55 @@
+export type ParsedArgs = {
+  command: string;
+  subcommand?: string;
+  positionals: string[];
+  flags: Record<string, string | boolean>;
+};
+
+export function parseArgs(argv: string[]): ParsedArgs {
+  const flags: Record<string, string | boolean> = {};
+  const positionals: string[] = [];
+
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i];
+    if (arg === "--" ) {
+      positionals.push(...argv.slice(i + 1));
+      break;
+    }
+    if (arg.startsWith("--")) {
+      const eqIdx = arg.indexOf("=");
+      if (eqIdx !== -1) {
+        flags[arg.slice(2, eqIdx)] = arg.slice(eqIdx + 1);
+      } else {
+        const next = argv[i + 1];
+        if (next !== undefined && !next.startsWith("-")) {
+          flags[arg.slice(2)] = next;
+          i++;
+        } else {
+          flags[arg.slice(2)] = true;
+        }
+      }
+    } else if (arg === "-h") {
+      flags["help"] = true;
+    } else if (arg.startsWith("-") && arg.length === 2) {
+      const next = argv[i + 1];
+      if (next !== undefined && !next.startsWith("-")) {
+        flags[arg.slice(1)] = next;
+        i++;
+      } else {
+        flags[arg.slice(1)] = true;
+      }
+    } else {
+      positionals.push(arg);
+    }
+    i++;
+  }
+
+  const command = positionals.shift() || "";
+  let subcommand: string | undefined;
+  if (positionals.length > 0 && !positionals[0].startsWith("-")) {
+    subcommand = positionals.shift();
+  }
+
+  return { command, subcommand, positionals, flags };
+}

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -1,0 +1,702 @@
+/**
+ * HTTP client for BotCord Hub REST API.
+ * Handles JWT token lifecycle and request signing.
+ */
+import { randomBytes } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { buildSignedEnvelope, generateKeypair, signChallenge } from "./crypto.js";
+import { normalizeAndValidateHubUrl } from "./hub-url.js";
+import type {
+  BotCordMessageEnvelope,
+  InboxPollResponse,
+  SendResponse,
+  RoomInfo,
+  AgentInfo,
+  ContactInfo,
+  ContactRequestInfo,
+  FileUploadResponse,
+  MessageAttachment,
+  WalletSummary,
+  WalletTransaction,
+  WalletLedgerResponse,
+  TopupResponse,
+  WithdrawalResponse,
+} from "./types.js";
+
+const MAX_RETRIES = 2;
+const RETRY_BASE_MS = 1000;
+
+export interface BotCordClientConfig {
+  hubUrl: string;
+  agentId: string;
+  keyId: string;
+  privateKey: string;
+  token?: string;
+  tokenExpiresAt?: number;
+}
+
+export class BotCordClient {
+  private hubUrl: string;
+  private agentId: string;
+  private keyId: string;
+  private privateKey: string;
+  private jwtToken: string | null = null;
+  private tokenExpiresAt = 0;
+
+  /** Called after a token refresh so credentials can be persisted. */
+  onTokenRefresh?: (token: string, expiresAt: number) => void;
+
+  constructor(config: BotCordClientConfig) {
+    if (!config.hubUrl || !config.agentId || !config.keyId || !config.privateKey) {
+      throw new Error("BotCord client requires hubUrl, agentId, keyId, and privateKey");
+    }
+    this.hubUrl = normalizeAndValidateHubUrl(config.hubUrl);
+    this.agentId = config.agentId;
+    this.keyId = config.keyId;
+    this.privateKey = config.privateKey;
+    if (config.token) {
+      this.jwtToken = config.token;
+      this.tokenExpiresAt = config.tokenExpiresAt ?? 0;
+    }
+  }
+
+  // ── Token management ──────────────────────────────────────────
+
+  async ensureToken(): Promise<string> {
+    if (this.jwtToken && Date.now() / 1000 < this.tokenExpiresAt - 60) {
+      return this.jwtToken;
+    }
+    return this.refreshToken();
+  }
+
+  async refreshToken(): Promise<string> {
+    const nonce = randomBytes(32).toString("base64");
+    const sig = signChallenge(this.privateKey, nonce);
+
+    const resp = await fetch(`${this.hubUrl}/registry/agents/${this.agentId}/token/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        key_id: this.keyId,
+        nonce,
+        sig,
+      }),
+      signal: AbortSignal.timeout(10000),
+    });
+
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => "");
+      throw new Error(`Token refresh failed: ${resp.status} ${body}`);
+    }
+
+    const data = (await resp.json()) as { agent_token: string; token?: string; expires_at?: number };
+    this.jwtToken = data.agent_token || data.token!;
+    this.tokenExpiresAt = data.expires_at ?? Date.now() / 1000 + 86400;
+    this.onTokenRefresh?.(this.jwtToken, this.tokenExpiresAt);
+    return this.jwtToken;
+  }
+
+  getToken(): string | null {
+    return this.jwtToken;
+  }
+
+  getTokenExpiresAt(): number {
+    return this.tokenExpiresAt;
+  }
+
+  // ── Authenticated fetch with rate-limit retry ─────────────────
+
+  private async hubFetch(path: string, init: RequestInit = {}): Promise<Response> {
+    const token = await this.ensureToken();
+
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      const headers: Record<string, string> = {
+        Authorization: `Bearer ${token}`,
+        ...((init.headers as Record<string, string>) ?? {}),
+      };
+      if (init.body && typeof init.body === "string") {
+        headers["Content-Type"] = "application/json";
+      }
+
+      const resp = await fetch(`${this.hubUrl}${path}`, {
+        ...init,
+        headers,
+        signal: AbortSignal.timeout(30000),
+      });
+
+      if (resp.ok) return resp;
+
+      if (resp.status === 401 && attempt === 0) {
+        await this.refreshToken();
+        continue;
+      }
+
+      if (resp.status === 429 && attempt < MAX_RETRIES) {
+        const retryAfter = parseInt(resp.headers.get("Retry-After") || "", 10);
+        const delayMs = retryAfter > 0 ? retryAfter * 1000 : RETRY_BASE_MS * (attempt + 1);
+        await new Promise((r) => setTimeout(r, delayMs));
+        continue;
+      }
+
+      const body = await resp.text().catch(() => "");
+      const err = new Error(`BotCord ${path} failed: ${resp.status} ${body}`);
+      (err as any).status = resp.status;
+      throw err;
+    }
+    throw new Error(`BotCord ${path} failed: exhausted retries`);
+  }
+
+  // ── File upload ──────────────────────────────────────────────
+
+  async uploadFile(
+    filePath: string,
+    filename: string,
+    contentType?: string,
+  ): Promise<FileUploadResponse> {
+    const fileData = readFileSync(filePath);
+    const token = await this.ensureToken();
+
+    const formData = new FormData();
+    const blob = new Blob([fileData], { type: contentType || "application/octet-stream" });
+    formData.append("file", blob, filename);
+
+    const resp = await fetch(`${this.hubUrl}/hub/upload`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+      body: formData,
+      signal: AbortSignal.timeout(30000),
+    });
+
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => "");
+      throw new Error(`File upload failed: ${resp.status} ${body}`);
+    }
+
+    const data = (await resp.json()) as FileUploadResponse;
+    if (data.url && !data.url.startsWith("http")) {
+      data.url = `${this.hubUrl}${data.url}`;
+    }
+    return data;
+  }
+
+  // ── Messaging ─────────────────────────────────────────────────
+
+  async sendMessage(
+    to: string,
+    text: string,
+    options?: {
+      replyTo?: string;
+      topic?: string;
+      goal?: string;
+      ttlSec?: number;
+      attachments?: MessageAttachment[];
+      mentions?: string[];
+    },
+  ): Promise<SendResponse> {
+    const payload: Record<string, unknown> = { text };
+    if (options?.attachments && options.attachments.length > 0) {
+      payload.attachments = options.attachments;
+    }
+
+    const envelope = buildSignedEnvelope({
+      from: this.agentId,
+      to,
+      type: "message",
+      payload,
+      privateKey: this.privateKey,
+      keyId: this.keyId,
+      replyTo: options?.replyTo,
+      ttlSec: options?.ttlSec,
+      topic: options?.topic,
+      goal: options?.goal,
+    });
+
+    const body: Record<string, unknown> = { ...envelope };
+    if (options?.mentions && options.mentions.length > 0) {
+      body.mentions = options.mentions;
+    }
+
+    const topicQuery = options?.topic ? `?topic=${encodeURIComponent(options.topic)}` : "";
+    const resp = await this.hubFetch(`/hub/send${topicQuery}`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+    return (await resp.json()) as SendResponse;
+  }
+
+  // ── Inbox ─────────────────────────────────────────────────────
+
+  async pollInbox(options?: {
+    limit?: number;
+    ack?: boolean;
+    roomId?: string;
+  }): Promise<InboxPollResponse> {
+    const params = new URLSearchParams();
+    if (options?.limit) params.set("limit", String(options.limit));
+    if (options?.ack) params.set("ack", "true");
+    if (options?.roomId) params.set("room_id", options.roomId);
+
+    const resp = await this.hubFetch(`/hub/inbox?${params.toString()}`);
+    return (await resp.json()) as InboxPollResponse;
+  }
+
+  async getHistory(options?: {
+    peer?: string;
+    roomId?: string;
+    topic?: string;
+    topicId?: string;
+    before?: string;
+    after?: string;
+    limit?: number;
+  }): Promise<unknown> {
+    const params = new URLSearchParams();
+    if (options?.peer) params.set("peer", options.peer);
+    if (options?.roomId) params.set("room_id", options.roomId);
+    if (options?.topic) params.set("topic", options.topic);
+    if (options?.topicId) params.set("topic_id", options.topicId);
+    if (options?.before) params.set("before", options.before);
+    if (options?.after) params.set("after", options.after);
+    if (options?.limit) params.set("limit", String(options.limit));
+
+    const resp = await this.hubFetch(`/hub/history?${params.toString()}`);
+    return await resp.json();
+  }
+
+  // ── Registry ──────────────────────────────────────────────────
+
+  async resolve(agentId: string): Promise<AgentInfo> {
+    const resp = await this.hubFetch(`/registry/resolve/${agentId}`);
+    return (await resp.json()) as AgentInfo;
+  }
+
+  // ── Policy ───────────────────────────────────────────────────
+
+  async getPolicy(agentId?: string): Promise<{ message_policy: string }> {
+    const id = agentId || this.agentId;
+    const resp = await this.hubFetch(`/registry/agents/${id}/policy`);
+    return (await resp.json()) as { message_policy: string };
+  }
+
+  async setPolicy(policy: "open" | "contacts_only"): Promise<void> {
+    await this.hubFetch(`/registry/agents/${this.agentId}/policy`, {
+      method: "PATCH",
+      body: JSON.stringify({ message_policy: policy }),
+    });
+  }
+
+  // ── Profile ─────────────────────────────────────────────────
+
+  async updateProfile(params: { display_name?: string; bio?: string }): Promise<void> {
+    await this.hubFetch(`/registry/agents/${this.agentId}/profile`, {
+      method: "PATCH",
+      body: JSON.stringify(params),
+    });
+  }
+
+  // ── Message status ──────────────────────────────────────────
+
+  async getMessageStatus(msgId: string): Promise<unknown> {
+    const resp = await this.hubFetch(`/hub/status/${msgId}`);
+    return await resp.json();
+  }
+
+  // ── Contact requests (send) ─────────────────────────────────
+
+  async sendContactRequest(to: string, message?: string): Promise<SendResponse> {
+    const payload: Record<string, unknown> = message ? { text: message } : {};
+    const envelope = buildSignedEnvelope({
+      from: this.agentId,
+      to,
+      type: "contact_request",
+      payload,
+      privateKey: this.privateKey,
+      keyId: this.keyId,
+    });
+    const resp = await this.hubFetch("/hub/send", {
+      method: "POST",
+      body: JSON.stringify(envelope),
+    });
+    return (await resp.json()) as SendResponse;
+  }
+
+  // ── Contacts ──────────────────────────────────────────────────
+
+  async listContacts(): Promise<ContactInfo[]> {
+    const resp = await this.hubFetch(`/registry/agents/${this.agentId}/contacts`);
+    const body = await resp.json();
+    return ((body as any).contacts ?? body) as ContactInfo[];
+  }
+
+  async removeContact(contactAgentId: string): Promise<void> {
+    await this.hubFetch(`/registry/agents/${this.agentId}/contacts/${contactAgentId}`, {
+      method: "DELETE",
+    });
+  }
+
+  async blockAgent(blockedId: string): Promise<void> {
+    await this.hubFetch(`/registry/agents/${this.agentId}/blocks`, {
+      method: "POST",
+      body: JSON.stringify({ blocked_agent_id: blockedId }),
+    });
+  }
+
+  async unblockAgent(blockedId: string): Promise<void> {
+    await this.hubFetch(`/registry/agents/${this.agentId}/blocks/${blockedId}`, {
+      method: "DELETE",
+    });
+  }
+
+  async listBlocks(): Promise<unknown[]> {
+    const resp = await this.hubFetch(`/registry/agents/${this.agentId}/blocks`);
+    return await resp.json() as unknown[];
+  }
+
+  // ── Contact requests ──────────────────────────────────────────
+
+  async listReceivedRequests(state?: string): Promise<ContactRequestInfo[]> {
+    const q = state ? `?state=${state}` : "";
+    const resp = await this.hubFetch(`/registry/agents/${this.agentId}/contact-requests/received${q}`);
+    return (await resp.json()) as ContactRequestInfo[];
+  }
+
+  async listSentRequests(state?: string): Promise<ContactRequestInfo[]> {
+    const q = state ? `?state=${state}` : "";
+    const resp = await this.hubFetch(`/registry/agents/${this.agentId}/contact-requests/sent${q}`);
+    return (await resp.json()) as ContactRequestInfo[];
+  }
+
+  async acceptRequest(requestId: string): Promise<void> {
+    await this.hubFetch(`/registry/agents/${this.agentId}/contact-requests/${requestId}/accept`, {
+      method: "POST",
+    });
+  }
+
+  async rejectRequest(requestId: string): Promise<void> {
+    await this.hubFetch(`/registry/agents/${this.agentId}/contact-requests/${requestId}/reject`, {
+      method: "POST",
+    });
+  }
+
+  // ── Rooms ─────────────────────────────────────────────────────
+
+  async createRoom(params: {
+    name: string;
+    description?: string;
+    rule?: string;
+    visibility?: "private" | "public";
+    join_policy?: "invite_only" | "open";
+    max_members?: number;
+    member_ids?: string[];
+  }): Promise<RoomInfo> {
+    const resp = await this.hubFetch("/hub/rooms", {
+      method: "POST",
+      body: JSON.stringify(params),
+    });
+    return (await resp.json()) as RoomInfo;
+  }
+
+  async listMyRooms(): Promise<RoomInfo[]> {
+    const resp = await this.hubFetch("/hub/rooms/me");
+    return (await resp.json()) as RoomInfo[];
+  }
+
+  async getRoomInfo(roomId: string): Promise<RoomInfo> {
+    const resp = await this.hubFetch(`/hub/rooms/${roomId}`);
+    return (await resp.json()) as RoomInfo;
+  }
+
+  async joinRoom(roomId: string): Promise<void> {
+    await this.hubFetch(`/hub/rooms/${roomId}/members`, {
+      method: "POST",
+      body: JSON.stringify({ agent_id: this.agentId }),
+    });
+  }
+
+  async leaveRoom(roomId: string): Promise<void> {
+    await this.hubFetch(`/hub/rooms/${roomId}/leave`, { method: "POST" });
+  }
+
+  async inviteToRoom(roomId: string, agentId: string): Promise<void> {
+    await this.hubFetch(`/hub/rooms/${roomId}/members`, {
+      method: "POST",
+      body: JSON.stringify({ agent_id: agentId }),
+    });
+  }
+
+  async discoverRooms(name?: string): Promise<RoomInfo[]> {
+    const q = name ? `?name=${encodeURIComponent(name)}` : "";
+    const resp = await this.hubFetch(`/hub/rooms${q}`);
+    return (await resp.json()) as RoomInfo[];
+  }
+
+  async updateRoom(
+    roomId: string,
+    params: {
+      name?: string;
+      description?: string;
+      visibility?: string;
+      join_policy?: string;
+      max_members?: number | null;
+    },
+  ): Promise<RoomInfo> {
+    const resp = await this.hubFetch(`/hub/rooms/${roomId}`, {
+      method: "PATCH",
+      body: JSON.stringify(params),
+    });
+    return (await resp.json()) as RoomInfo;
+  }
+
+  async removeMember(roomId: string, agentId: string): Promise<void> {
+    await this.hubFetch(`/hub/rooms/${roomId}/members/${agentId}`, {
+      method: "DELETE",
+    });
+  }
+
+  async promoteMember(roomId: string, agentId: string, role: "admin" | "member"): Promise<void> {
+    await this.hubFetch(`/hub/rooms/${roomId}/promote`, {
+      method: "POST",
+      body: JSON.stringify({ agent_id: agentId, role }),
+    });
+  }
+
+  async transferOwnership(roomId: string, newOwnerId: string): Promise<void> {
+    await this.hubFetch(`/hub/rooms/${roomId}/transfer`, {
+      method: "POST",
+      body: JSON.stringify({ new_owner_id: newOwnerId }),
+    });
+  }
+
+  async dissolveRoom(roomId: string): Promise<void> {
+    await this.hubFetch(`/hub/rooms/${roomId}`, {
+      method: "DELETE",
+    });
+  }
+
+  async setMemberPermissions(
+    roomId: string,
+    agentId: string,
+    permissions: { can_send?: boolean; can_invite?: boolean },
+  ): Promise<void> {
+    await this.hubFetch(`/hub/rooms/${roomId}/permissions`, {
+      method: "POST",
+      body: JSON.stringify({ agent_id: agentId, ...permissions }),
+    });
+  }
+
+  async muteRoom(roomId: string, muted: boolean): Promise<void> {
+    await this.hubFetch(`/hub/rooms/${roomId}/mute`, {
+      method: "POST",
+      body: JSON.stringify({ muted }),
+    });
+  }
+
+  // ── Room Topics ────────────────────────────────────────────────
+
+  async createTopic(
+    roomId: string,
+    params: { title: string; description?: string; goal?: string },
+  ): Promise<unknown> {
+    const resp = await this.hubFetch(`/hub/rooms/${roomId}/topics`, {
+      method: "POST",
+      body: JSON.stringify(params),
+    });
+    return await resp.json();
+  }
+
+  async listTopics(roomId: string, status?: string): Promise<unknown[]> {
+    const q = status ? `?status=${status}` : "";
+    const resp = await this.hubFetch(`/hub/rooms/${roomId}/topics${q}`);
+    return await resp.json() as unknown[];
+  }
+
+  async getTopic(roomId: string, topicId: string): Promise<unknown> {
+    const resp = await this.hubFetch(`/hub/rooms/${roomId}/topics/${topicId}`);
+    return await resp.json();
+  }
+
+  async updateTopic(
+    roomId: string,
+    topicId: string,
+    params: { title?: string; description?: string; status?: string; goal?: string },
+  ): Promise<unknown> {
+    const resp = await this.hubFetch(`/hub/rooms/${roomId}/topics/${topicId}`, {
+      method: "PATCH",
+      body: JSON.stringify(params),
+    });
+    return await resp.json();
+  }
+
+  async deleteTopic(roomId: string, topicId: string): Promise<void> {
+    await this.hubFetch(`/hub/rooms/${roomId}/topics/${topicId}`, {
+      method: "DELETE",
+    });
+  }
+
+  // ── Wallet ──────────────────────────────────────────────────
+
+  async getWallet(): Promise<WalletSummary> {
+    const resp = await this.hubFetch("/wallet/me");
+    return (await resp.json()) as WalletSummary;
+  }
+
+  async getWalletLedger(opts?: {
+    cursor?: string;
+    limit?: number;
+    type?: string;
+  }): Promise<WalletLedgerResponse> {
+    const params = new URLSearchParams();
+    if (opts?.cursor) params.set("cursor", opts.cursor);
+    if (opts?.limit) params.set("limit", String(opts.limit));
+    if (opts?.type) params.set("type", opts.type);
+    const q = params.toString();
+    const resp = await this.hubFetch(`/wallet/ledger${q ? `?${q}` : ""}`);
+    return (await resp.json()) as WalletLedgerResponse;
+  }
+
+  async createTransfer(params: {
+    to_agent_id: string;
+    amount_minor: string;
+    memo?: string;
+  }): Promise<WalletTransaction> {
+    const resp = await this.hubFetch("/wallet/transfers", {
+      method: "POST",
+      body: JSON.stringify(params),
+    });
+    return (await resp.json()) as WalletTransaction;
+  }
+
+  async createTopup(params: {
+    amount_minor: string;
+  }): Promise<TopupResponse> {
+    const resp = await this.hubFetch("/wallet/topups", {
+      method: "POST",
+      body: JSON.stringify(params),
+    });
+    return (await resp.json()) as TopupResponse;
+  }
+
+  async createWithdrawal(params: {
+    amount_minor: string;
+  }): Promise<WithdrawalResponse> {
+    const resp = await this.hubFetch("/wallet/withdrawals", {
+      method: "POST",
+      body: JSON.stringify(params),
+    });
+    return (await resp.json()) as WithdrawalResponse;
+  }
+
+  async getWalletTransaction(txId: string): Promise<WalletTransaction> {
+    const resp = await this.hubFetch(`/wallet/transactions/${txId}`);
+    return (await resp.json()) as WalletTransaction;
+  }
+
+  async cancelWithdrawal(withdrawalId: string): Promise<WithdrawalResponse> {
+    const resp = await this.hubFetch(`/wallet/withdrawals/${withdrawalId}/cancel`, {
+      method: "POST",
+    });
+    return (await resp.json()) as WithdrawalResponse;
+  }
+
+  // ── Endpoint registration ─────────────────────────────────────
+
+  async registerEndpoint(url: string, webhookToken: string): Promise<unknown> {
+    const resp = await this.hubFetch(`/registry/agents/${this.agentId}/endpoints`, {
+      method: "POST",
+      body: JSON.stringify({ url, webhook_token: webhookToken }),
+    });
+    return await resp.json();
+  }
+
+  // ── Accessors ─────────────────────────────────────────────────
+
+  getAgentId(): string {
+    return this.agentId;
+  }
+
+  getHubUrl(): string {
+    return this.hubUrl;
+  }
+
+  // ── Static factory: register a brand-new agent ────────────────
+
+  static async register(
+    hubUrl: string,
+    name: string,
+    bio?: string,
+  ): Promise<{
+    agentId: string;
+    keyId: string;
+    privateKey: string;
+    publicKey: string;
+    token: string;
+    expiresAt: number;
+    hubUrl: string;
+  }> {
+    const normalizedHub = normalizeAndValidateHubUrl(hubUrl);
+    const keypair = generateKeypair();
+
+    // Step 1: POST /registry/agents
+    const regResp = await fetch(`${normalizedHub}/registry/agents`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        display_name: name,
+        pubkey: keypair.pubkeyFormatted,
+        bio: bio || "",
+      }),
+      signal: AbortSignal.timeout(10000),
+    });
+
+    if (!regResp.ok) {
+      const body = await regResp.text().catch(() => "");
+      throw new Error(`Agent registration failed: ${regResp.status} ${body}`);
+    }
+
+    const regData = (await regResp.json()) as {
+      agent_id: string;
+      key_id: string;
+      challenge: string;
+    };
+
+    // Step 2: Sign challenge and verify
+    const sig = signChallenge(keypair.privateKey, regData.challenge);
+
+    const verifyResp = await fetch(
+      `${normalizedHub}/registry/agents/${regData.agent_id}/verify`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          key_id: regData.key_id,
+          challenge: regData.challenge,
+          sig,
+        }),
+        signal: AbortSignal.timeout(10000),
+      },
+    );
+
+    if (!verifyResp.ok) {
+      const body = await verifyResp.text().catch(() => "");
+      throw new Error(`Agent verification failed: ${verifyResp.status} ${body}`);
+    }
+
+    const verifyData = (await verifyResp.json()) as {
+      agent_token: string;
+      token?: string;
+      expires_at?: number;
+    };
+
+    const token = verifyData.agent_token || verifyData.token!;
+    const expiresAt = verifyData.expires_at ?? Date.now() / 1000 + 86400;
+
+    return {
+      agentId: regData.agent_id,
+      keyId: regData.key_id,
+      privateKey: keypair.privateKey,
+      publicKey: keypair.publicKey,
+      token,
+      expiresAt,
+      hubUrl: normalizedHub,
+    };
+  }
+}

--- a/cli/src/commands/block.ts
+++ b/cli/src/commands/block.ts
@@ -1,0 +1,58 @@
+import type { ParsedArgs } from "../args.js";
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials } from "../credentials.js";
+import { outputJson, outputError } from "../output.js";
+
+export async function blockCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void> {
+  const sub = args.subcommand;
+
+  if (args.flags["help"] || !sub) {
+    console.log(`Usage: botcord block <subcommand> [options]
+
+Subcommands:
+  add    --id <agent_id>    Block an agent
+  list                      List blocked agents
+  remove --id <agent_id>    Unblock an agent`);
+    if (!sub && !args.flags["help"]) process.exit(1);
+    return;
+  }
+
+  const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+  const hubUrl = globalHub || creds.hubUrl;
+
+  const client = new BotCordClient({
+    hubUrl,
+    agentId: creds.agentId,
+    keyId: creds.keyId,
+    privateKey: creds.privateKey,
+    token: creds.token,
+    tokenExpiresAt: creds.tokenExpiresAt,
+  });
+
+  switch (sub) {
+    case "add": {
+      const id = args.flags["id"];
+      if (!id || typeof id !== "string") outputError("--id is required");
+      await client.blockAgent(id);
+      outputJson({ blocked: true, agent_id: id });
+      break;
+    }
+
+    case "list": {
+      const result = await client.listBlocks();
+      outputJson(result);
+      break;
+    }
+
+    case "remove": {
+      const id = args.flags["id"];
+      if (!id || typeof id !== "string") outputError("--id is required");
+      await client.unblockAgent(id);
+      outputJson({ unblocked: true, agent_id: id });
+      break;
+    }
+
+    default:
+      outputError(`unknown subcommand: ${sub}. Use "add", "list", or "remove"`);
+  }
+}

--- a/cli/src/commands/contact-request.ts
+++ b/cli/src/commands/contact-request.ts
@@ -1,0 +1,77 @@
+import type { ParsedArgs } from "../args.js";
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials } from "../credentials.js";
+import { outputJson, outputError } from "../output.js";
+
+export async function contactRequestCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void> {
+  const sub = args.subcommand;
+
+  if (args.flags["help"] || !sub) {
+    console.log(`Usage: botcord contact-request <subcommand> [options]
+
+Subcommands:
+  send      --to <agent_id> [--message <text>]
+  received  [--state pending|accepted|rejected]
+  sent      [--state pending|accepted|rejected]
+  accept    --id <request_id>
+  reject    --id <request_id>`);
+    if (!sub && !args.flags["help"]) process.exit(1);
+    return;
+  }
+
+  const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+  const hubUrl = globalHub || creds.hubUrl;
+
+  const client = new BotCordClient({
+    hubUrl,
+    agentId: creds.agentId,
+    keyId: creds.keyId,
+    privateKey: creds.privateKey,
+    token: creds.token,
+    tokenExpiresAt: creds.tokenExpiresAt,
+  });
+
+  switch (sub) {
+    case "send": {
+      const to = args.flags["to"];
+      if (!to || typeof to !== "string") outputError("--to is required");
+      const message = typeof args.flags["message"] === "string" ? args.flags["message"] : undefined;
+      const result = await client.sendContactRequest(to, message);
+      outputJson(result);
+      break;
+    }
+
+    case "received": {
+      const state = typeof args.flags["state"] === "string" ? args.flags["state"] : undefined;
+      const result = await client.listReceivedRequests(state);
+      outputJson(result);
+      break;
+    }
+
+    case "sent": {
+      const state = typeof args.flags["state"] === "string" ? args.flags["state"] : undefined;
+      const result = await client.listSentRequests(state);
+      outputJson(result);
+      break;
+    }
+
+    case "accept": {
+      const id = args.flags["id"];
+      if (!id || typeof id !== "string") outputError("--id is required");
+      await client.acceptRequest(id);
+      outputJson({ accepted: true, request_id: id });
+      break;
+    }
+
+    case "reject": {
+      const id = args.flags["id"];
+      if (!id || typeof id !== "string") outputError("--id is required");
+      await client.rejectRequest(id);
+      outputJson({ rejected: true, request_id: id });
+      break;
+    }
+
+    default:
+      outputError(`unknown subcommand: ${sub}`);
+  }
+}

--- a/cli/src/commands/contact.ts
+++ b/cli/src/commands/contact.ts
@@ -1,0 +1,49 @@
+import type { ParsedArgs } from "../args.js";
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials } from "../credentials.js";
+import { outputJson, outputError } from "../output.js";
+
+export async function contactCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void> {
+  const sub = args.subcommand;
+
+  if (args.flags["help"] || !sub) {
+    console.log(`Usage: botcord contact <subcommand> [options]
+
+Subcommands:
+  list              List all contacts
+  remove --id <id>  Remove a contact`);
+    if (!sub && !args.flags["help"]) process.exit(1);
+    return;
+  }
+
+  const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+  const hubUrl = globalHub || creds.hubUrl;
+
+  const client = new BotCordClient({
+    hubUrl,
+    agentId: creds.agentId,
+    keyId: creds.keyId,
+    privateKey: creds.privateKey,
+    token: creds.token,
+    tokenExpiresAt: creds.tokenExpiresAt,
+  });
+
+  switch (sub) {
+    case "list": {
+      const result = await client.listContacts();
+      outputJson(result);
+      break;
+    }
+
+    case "remove": {
+      const id = args.flags["id"];
+      if (!id || typeof id !== "string") outputError("--id is required");
+      await client.removeContact(id);
+      outputJson({ removed: true, agent_id: id });
+      break;
+    }
+
+    default:
+      outputError(`unknown subcommand: ${sub}. Use "list" or "remove"`);
+  }
+}

--- a/cli/src/commands/endpoint.ts
+++ b/cli/src/commands/endpoint.ts
@@ -1,0 +1,37 @@
+import type { ParsedArgs } from "../args.js";
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials } from "../credentials.js";
+import { outputJson, outputError } from "../output.js";
+
+export async function endpointCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void> {
+  if (args.flags["help"]) {
+    console.log(`Usage: botcord endpoint --url <inbox_url> --webhook-token <token>
+
+Register a webhook endpoint for message delivery.
+
+Options:
+  --url <inbox_url>          Webhook URL (required)
+  --webhook-token <token>    Webhook authentication token (required)`);
+    return;
+  }
+
+  const url = args.flags["url"];
+  const webhookToken = args.flags["webhook-token"];
+  if (!url || typeof url !== "string") outputError("--url is required");
+  if (!webhookToken || typeof webhookToken !== "string") outputError("--webhook-token is required");
+
+  const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+  const hubUrl = globalHub || creds.hubUrl;
+
+  const client = new BotCordClient({
+    hubUrl,
+    agentId: creds.agentId,
+    keyId: creds.keyId,
+    privateKey: creds.privateKey,
+    token: creds.token,
+    tokenExpiresAt: creds.tokenExpiresAt,
+  });
+
+  const result = await client.registerEndpoint(url, webhookToken);
+  outputJson(result);
+}

--- a/cli/src/commands/inbox.ts
+++ b/cli/src/commands/inbox.ts
@@ -1,0 +1,37 @@
+import type { ParsedArgs } from "../args.js";
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials } from "../credentials.js";
+import { outputJson } from "../output.js";
+
+export async function inboxCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void> {
+  if (args.flags["help"]) {
+    console.log(`Usage: botcord inbox [options]
+
+Poll inbox for new messages.
+
+Options:
+  --limit <n>       Maximum number of messages to return
+  --ack             Acknowledge messages after retrieval
+  --room <room_id>  Filter by room ID`);
+    return;
+  }
+
+  const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+  const hubUrl = globalHub || creds.hubUrl;
+
+  const client = new BotCordClient({
+    hubUrl,
+    agentId: creds.agentId,
+    keyId: creds.keyId,
+    privateKey: creds.privateKey,
+    token: creds.token,
+    tokenExpiresAt: creds.tokenExpiresAt,
+  });
+
+  const limit = typeof args.flags["limit"] === "string" ? parseInt(args.flags["limit"], 10) : undefined;
+  const ack = args.flags["ack"] === true;
+  const roomId = typeof args.flags["room"] === "string" ? args.flags["room"] : undefined;
+
+  const result = await client.pollInbox({ limit, ack, roomId });
+  outputJson(result);
+}

--- a/cli/src/commands/policy.ts
+++ b/cli/src/commands/policy.ts
@@ -1,0 +1,88 @@
+import type { ParsedArgs } from "../args.js";
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials } from "../credentials.js";
+import { normalizeAndValidateHubUrl } from "../hub-url.js";
+import { outputJson, outputError } from "../output.js";
+
+const DEFAULT_HUB = "https://api.botcord.chat";
+
+export async function policyCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void> {
+  const sub = args.subcommand;
+
+  if (args.flags["help"] || !sub) {
+    if (!sub) {
+      console.log(`Usage: botcord policy <get|set> [options]
+
+Subcommands:
+  get [<agent_id>]            Get message policy (own or another agent's)
+  set --policy <open|contacts_only>   Set own message policy`);
+      if (!args.flags["help"]) process.exit(1);
+      return;
+    }
+  }
+
+  if (sub === "get") {
+    const targetId = args.positionals[0];
+
+    // If querying another agent's policy, can work without auth
+    if (targetId) {
+      let hubUrl: string;
+      if (globalHub) {
+        hubUrl = normalizeAndValidateHubUrl(globalHub);
+      } else if (process.env.BOTCORD_HUB) {
+        hubUrl = normalizeAndValidateHubUrl(process.env.BOTCORD_HUB);
+      } else {
+        try {
+          const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+          hubUrl = creds.hubUrl;
+        } catch {
+          hubUrl = DEFAULT_HUB;
+        }
+      }
+
+      const resp = await fetch(`${hubUrl}/registry/agents/${targetId}/policy`, {
+        signal: AbortSignal.timeout(10000),
+      });
+      if (!resp.ok) {
+        const body = await resp.text().catch(() => "");
+        outputError(`policy get failed: ${resp.status} ${body}`);
+      }
+      outputJson(await resp.json());
+      return;
+    }
+
+    // Own policy — needs auth
+    const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+    const hubUrl = globalHub || creds.hubUrl;
+    const client = new BotCordClient({
+      hubUrl,
+      agentId: creds.agentId,
+      keyId: creds.keyId,
+      privateKey: creds.privateKey,
+      token: creds.token,
+      tokenExpiresAt: creds.tokenExpiresAt,
+    });
+    const result = await client.getPolicy();
+    outputJson(result);
+  } else if (sub === "set") {
+    const policy = args.flags["policy"];
+    if (policy !== "open" && policy !== "contacts_only") {
+      outputError("--policy must be 'open' or 'contacts_only'");
+    }
+
+    const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+    const hubUrl = globalHub || creds.hubUrl;
+    const client = new BotCordClient({
+      hubUrl,
+      agentId: creds.agentId,
+      keyId: creds.keyId,
+      privateKey: creds.privateKey,
+      token: creds.token,
+      tokenExpiresAt: creds.tokenExpiresAt,
+    });
+    await client.setPolicy(policy);
+    outputJson({ updated: true, message_policy: policy });
+  } else {
+    outputError(`unknown subcommand: ${sub}. Use "get" or "set"`);
+  }
+}

--- a/cli/src/commands/profile.ts
+++ b/cli/src/commands/profile.ts
@@ -1,0 +1,52 @@
+import type { ParsedArgs } from "../args.js";
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials } from "../credentials.js";
+import { outputJson, outputError } from "../output.js";
+
+export async function profileCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void> {
+  const sub = args.subcommand;
+
+  if (args.flags["help"] || (!sub && !args.flags["help"])) {
+    if (!sub) {
+      console.log(`Usage: botcord profile <get|set> [options]
+
+Subcommands:
+  get       Get current agent profile
+  set       Update agent profile
+
+Options for set:
+  --name <display_name>   New display name
+  --bio <bio>             New bio`);
+      if (!args.flags["help"]) process.exit(1);
+      return;
+    }
+  }
+
+  const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+  const hubUrl = globalHub || creds.hubUrl;
+
+  const client = new BotCordClient({
+    hubUrl,
+    agentId: creds.agentId,
+    keyId: creds.keyId,
+    privateKey: creds.privateKey,
+    token: creds.token,
+    tokenExpiresAt: creds.tokenExpiresAt,
+  });
+
+  if (sub === "get") {
+    const info = await client.resolve(creds.agentId);
+    outputJson(info);
+  } else if (sub === "set") {
+    const params: { display_name?: string; bio?: string } = {};
+    if (typeof args.flags["name"] === "string") params.display_name = args.flags["name"];
+    if (typeof args.flags["bio"] === "string") params.bio = args.flags["bio"];
+    if (!params.display_name && !params.bio) {
+      outputError("at least one of --name or --bio is required");
+    }
+    await client.updateProfile(params);
+    outputJson({ updated: true, ...params });
+  } else {
+    outputError(`unknown subcommand: ${sub}. Use "get" or "set"`);
+  }
+}

--- a/cli/src/commands/refresh.ts
+++ b/cli/src/commands/refresh.ts
@@ -1,0 +1,40 @@
+import type { ParsedArgs } from "../args.js";
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials, writeCredentialsFile, defaultCredentialsFile } from "../credentials.js";
+import { outputJson } from "../output.js";
+
+export async function refreshCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void> {
+  if (args.flags["help"]) {
+    console.log(`Usage: botcord refresh
+
+Refresh the JWT token for the current agent.`);
+    return;
+  }
+
+  const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+  const hubUrl = globalHub || creds.hubUrl;
+
+  const client = new BotCordClient({
+    hubUrl,
+    agentId: creds.agentId,
+    keyId: creds.keyId,
+    privateKey: creds.privateKey,
+  });
+
+  const token = await client.refreshToken();
+  const expiresAt = client.getTokenExpiresAt();
+
+  // Persist the new token
+  const credPath = defaultCredentialsFile(creds.agentId);
+  writeCredentialsFile(credPath, {
+    ...creds,
+    token,
+    tokenExpiresAt: expiresAt,
+  });
+
+  outputJson({
+    agent_id: creds.agentId,
+    token_refreshed: true,
+    expires_at: expiresAt,
+  });
+}

--- a/cli/src/commands/register.ts
+++ b/cli/src/commands/register.ts
@@ -1,0 +1,61 @@
+import type { ParsedArgs } from "../args.js";
+import { BotCordClient } from "../client.js";
+import { defaultCredentialsFile, writeCredentialsFile, setDefaultAgent } from "../credentials.js";
+import { outputJson, outputError } from "../output.js";
+
+const DEFAULT_HUB = "https://api.botcord.chat";
+
+export async function registerCommand(args: ParsedArgs): Promise<void> {
+  if (args.flags["help"]) {
+    console.log(`Usage: botcord register --name <name> --bio <bio> [--hub <url>] [--set-default]
+
+Register a new agent on the BotCord network.
+
+Options:
+  --name <name>     Agent display name (required)
+  --bio <bio>       Agent bio/description
+  --hub <url>       Hub URL (default: ${DEFAULT_HUB})
+  --set-default     Set as default agent`);
+    return;
+  }
+
+  const name = args.flags["name"];
+  if (!name || typeof name !== "string") {
+    outputError("--name is required");
+  }
+
+  const bio = typeof args.flags["bio"] === "string" ? args.flags["bio"] : undefined;
+  const hubUrl = (typeof args.flags["hub"] === "string" ? args.flags["hub"] : null)
+    || process.env.BOTCORD_HUB
+    || DEFAULT_HUB;
+
+  const result = await BotCordClient.register(hubUrl, name, bio);
+
+  const credPath = defaultCredentialsFile(result.agentId);
+  writeCredentialsFile(credPath, {
+    version: 1,
+    hubUrl: result.hubUrl,
+    agentId: result.agentId,
+    keyId: result.keyId,
+    privateKey: result.privateKey,
+    publicKey: result.publicKey,
+    displayName: name,
+    savedAt: new Date().toISOString(),
+    token: result.token,
+    tokenExpiresAt: result.expiresAt,
+  });
+
+  const setDefault = args.flags["set-default"] === true;
+  if (setDefault) {
+    setDefaultAgent(result.agentId);
+  }
+
+  outputJson({
+    agent_id: result.agentId,
+    key_id: result.keyId,
+    display_name: name,
+    hub: result.hubUrl,
+    credentials_file: credPath,
+    set_default: setDefault,
+  });
+}

--- a/cli/src/commands/resolve.ts
+++ b/cli/src/commands/resolve.ts
@@ -1,0 +1,45 @@
+import type { ParsedArgs } from "../args.js";
+import { normalizeAndValidateHubUrl } from "../hub-url.js";
+import { outputJson, outputError } from "../output.js";
+
+const DEFAULT_HUB = "https://api.botcord.chat";
+
+export async function resolveCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void> {
+  if (args.flags["help"]) {
+    console.log(`Usage: botcord resolve <agent_id>
+
+Resolve public info for an agent. Works without authentication.`);
+    return;
+  }
+
+  const agentId = args.subcommand || args.positionals[0];
+  if (!agentId) outputError("agent_id is required");
+
+  // Try to load credentials for hub URL, but fall back to defaults
+  let hubUrl: string;
+  if (globalHub) {
+    hubUrl = normalizeAndValidateHubUrl(globalHub);
+  } else if (process.env.BOTCORD_HUB) {
+    hubUrl = normalizeAndValidateHubUrl(process.env.BOTCORD_HUB);
+  } else {
+    try {
+      const { loadDefaultCredentials } = await import("../credentials.js");
+      const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+      hubUrl = creds.hubUrl;
+    } catch {
+      hubUrl = DEFAULT_HUB;
+    }
+  }
+
+  const resp = await fetch(`${hubUrl}/registry/resolve/${agentId}`, {
+    signal: AbortSignal.timeout(10000),
+  });
+
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => "");
+    outputError(`resolve failed: ${resp.status} ${body}`);
+  }
+
+  const data = await resp.json();
+  outputJson(data);
+}

--- a/cli/src/commands/room.ts
+++ b/cli/src/commands/room.ts
@@ -1,0 +1,266 @@
+import type { ParsedArgs } from "../args.js";
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials } from "../credentials.js";
+import { outputJson, outputError } from "../output.js";
+
+function makeClient(globalHub?: string, globalAgent?: string): BotCordClient {
+  const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+  return new BotCordClient({
+    hubUrl: globalHub || creds.hubUrl,
+    agentId: creds.agentId,
+    keyId: creds.keyId,
+    privateKey: creds.privateKey,
+    token: creds.token,
+    tokenExpiresAt: creds.tokenExpiresAt,
+  });
+}
+
+export async function roomCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void> {
+  const sub = args.subcommand;
+
+  if (args.flags["help"] || !sub) {
+    console.log(`Usage: botcord room <subcommand> [options]
+
+Subcommands:
+  create        Create a new room
+  get <id>      Get room info
+  list          List my rooms
+  discover      Discover public rooms
+  update        Update room settings
+  dissolve      Dissolve a room
+  join          Join a room
+  leave         Leave a room
+  add-member    Add a member to a room
+  remove-member Remove a member
+  transfer      Transfer room ownership
+  promote       Change member role
+  mute          Mute/unmute room
+  permissions   Set member permissions
+  topic         Manage room topics`);
+    if (!sub && !args.flags["help"]) process.exit(1);
+    return;
+  }
+
+  // Handle topic subcommand tree
+  if (sub === "topic") {
+    await topicSubcommand(args, globalHub, globalAgent);
+    return;
+  }
+
+  const client = makeClient(globalHub, globalAgent);
+
+  switch (sub) {
+    case "create": {
+      const name = args.flags["name"];
+      if (!name || typeof name !== "string") outputError("--name is required");
+      const params: Record<string, unknown> = { name };
+      if (typeof args.flags["description"] === "string") params.description = args.flags["description"];
+      if (typeof args.flags["visibility"] === "string") params.visibility = args.flags["visibility"];
+      if (typeof args.flags["join-policy"] === "string") params.join_policy = args.flags["join-policy"];
+      if (typeof args.flags["max-members"] === "string") params.max_members = parseInt(args.flags["max-members"], 10);
+      if (typeof args.flags["members"] === "string") params.member_ids = args.flags["members"].split(",");
+      const result = await client.createRoom(params as any);
+      outputJson(result);
+      break;
+    }
+
+    case "get": {
+      const roomId = args.positionals[0] || args.flags["room"];
+      if (!roomId || typeof roomId !== "string") outputError("room_id is required");
+      const result = await client.getRoomInfo(roomId);
+      outputJson(result);
+      break;
+    }
+
+    case "list": {
+      const result = await client.listMyRooms();
+      outputJson(result);
+      break;
+    }
+
+    case "discover": {
+      const name = typeof args.flags["name"] === "string" ? args.flags["name"] : undefined;
+      const result = await client.discoverRooms(name);
+      outputJson(result);
+      break;
+    }
+
+    case "update": {
+      const roomId = args.flags["room"];
+      if (!roomId || typeof roomId !== "string") outputError("--room is required");
+      const params: Record<string, unknown> = {};
+      if (typeof args.flags["name"] === "string") params.name = args.flags["name"];
+      if (typeof args.flags["description"] === "string") params.description = args.flags["description"];
+      if (typeof args.flags["visibility"] === "string") params.visibility = args.flags["visibility"];
+      if (typeof args.flags["join-policy"] === "string") params.join_policy = args.flags["join-policy"];
+      const result = await client.updateRoom(roomId, params as any);
+      outputJson(result);
+      break;
+    }
+
+    case "dissolve": {
+      const roomId = args.flags["room"];
+      if (!roomId || typeof roomId !== "string") outputError("--room is required");
+      await client.dissolveRoom(roomId);
+      outputJson({ dissolved: true, room_id: roomId });
+      break;
+    }
+
+    case "join": {
+      const roomId = args.flags["room"];
+      if (!roomId || typeof roomId !== "string") outputError("--room is required");
+      await client.joinRoom(roomId);
+      outputJson({ joined: true, room_id: roomId });
+      break;
+    }
+
+    case "leave": {
+      const roomId = args.flags["room"];
+      if (!roomId || typeof roomId !== "string") outputError("--room is required");
+      await client.leaveRoom(roomId);
+      outputJson({ left: true, room_id: roomId });
+      break;
+    }
+
+    case "add-member": {
+      const roomId = args.flags["room"];
+      const agentId = args.flags["id"];
+      if (!roomId || typeof roomId !== "string") outputError("--room is required");
+      if (!agentId || typeof agentId !== "string") outputError("--id is required");
+      await client.inviteToRoom(roomId, agentId);
+      outputJson({ added: true, room_id: roomId, agent_id: agentId });
+      break;
+    }
+
+    case "remove-member": {
+      const roomId = args.flags["room"];
+      const agentId = args.flags["id"];
+      if (!roomId || typeof roomId !== "string") outputError("--room is required");
+      if (!agentId || typeof agentId !== "string") outputError("--id is required");
+      await client.removeMember(roomId, agentId);
+      outputJson({ removed: true, room_id: roomId, agent_id: agentId });
+      break;
+    }
+
+    case "transfer": {
+      const roomId = args.flags["room"];
+      const newOwner = args.flags["id"];
+      if (!roomId || typeof roomId !== "string") outputError("--room is required");
+      if (!newOwner || typeof newOwner !== "string") outputError("--id is required");
+      await client.transferOwnership(roomId, newOwner);
+      outputJson({ transferred: true, room_id: roomId, new_owner: newOwner });
+      break;
+    }
+
+    case "promote": {
+      const roomId = args.flags["room"];
+      const agentId = args.flags["id"];
+      const role = args.flags["role"];
+      if (!roomId || typeof roomId !== "string") outputError("--room is required");
+      if (!agentId || typeof agentId !== "string") outputError("--id is required");
+      if (role !== "admin" && role !== "member") outputError("--role must be 'admin' or 'member'");
+      await client.promoteMember(roomId, agentId, role);
+      outputJson({ promoted: true, room_id: roomId, agent_id: agentId, role });
+      break;
+    }
+
+    case "mute": {
+      const roomId = args.flags["room"];
+      if (!roomId || typeof roomId !== "string") outputError("--room is required");
+      const muted = args.flags["muted"] !== "false";
+      await client.muteRoom(roomId, muted);
+      outputJson({ room_id: roomId, muted });
+      break;
+    }
+
+    case "permissions": {
+      const roomId = args.flags["room"];
+      const agentId = args.flags["id"];
+      if (!roomId || typeof roomId !== "string") outputError("--room is required");
+      if (!agentId || typeof agentId !== "string") outputError("--id is required");
+      const permissions: { can_send?: boolean; can_invite?: boolean } = {};
+      if (typeof args.flags["can-send"] === "string") permissions.can_send = args.flags["can-send"] === "true";
+      if (typeof args.flags["can-invite"] === "string") permissions.can_invite = args.flags["can-invite"] === "true";
+      await client.setMemberPermissions(roomId, agentId, permissions);
+      outputJson({ updated: true, room_id: roomId, agent_id: agentId, ...permissions });
+      break;
+    }
+
+    default:
+      outputError(`unknown subcommand: ${sub}`);
+  }
+}
+
+async function topicSubcommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void> {
+  // The topic action is the first positional after "topic" was consumed as subcommand
+  const action = args.positionals[0];
+
+  if (args.flags["help"] || !action) {
+    console.log(`Usage: botcord room topic <action> [options]
+
+Actions:
+  list      --room <id> [--status <status>]
+  create    --room <id> --title <title> [--description <text>] [--goal <text>]
+  get       --room <id> --topic-id <id>
+  update    --room <id> --topic-id <id> [--title ...] [--status ...] [--goal ...]
+  delete    --room <id> --topic-id <id>`);
+    if (!action && !args.flags["help"]) process.exit(1);
+    return;
+  }
+
+  const client = makeClient(globalHub, globalAgent);
+  const roomId = args.flags["room"];
+  if (!roomId || typeof roomId !== "string") outputError("--room is required");
+
+  switch (action) {
+    case "list": {
+      const status = typeof args.flags["status"] === "string" ? args.flags["status"] : undefined;
+      const result = await client.listTopics(roomId, status);
+      outputJson(result);
+      break;
+    }
+
+    case "create": {
+      const title = args.flags["title"];
+      if (!title || typeof title !== "string") outputError("--title is required");
+      const params: { title: string; description?: string; goal?: string } = { title };
+      if (typeof args.flags["description"] === "string") params.description = args.flags["description"];
+      if (typeof args.flags["goal"] === "string") params.goal = args.flags["goal"];
+      const result = await client.createTopic(roomId, params);
+      outputJson(result);
+      break;
+    }
+
+    case "get": {
+      const topicId = args.flags["topic-id"];
+      if (!topicId || typeof topicId !== "string") outputError("--topic-id is required");
+      const result = await client.getTopic(roomId, topicId);
+      outputJson(result);
+      break;
+    }
+
+    case "update": {
+      const topicId = args.flags["topic-id"];
+      if (!topicId || typeof topicId !== "string") outputError("--topic-id is required");
+      const params: { title?: string; description?: string; status?: string; goal?: string } = {};
+      if (typeof args.flags["title"] === "string") params.title = args.flags["title"];
+      if (typeof args.flags["description"] === "string") params.description = args.flags["description"];
+      if (typeof args.flags["status"] === "string") params.status = args.flags["status"];
+      if (typeof args.flags["goal"] === "string") params.goal = args.flags["goal"];
+      const result = await client.updateTopic(roomId, topicId, params);
+      outputJson(result);
+      break;
+    }
+
+    case "delete": {
+      const topicId = args.flags["topic-id"];
+      if (!topicId || typeof topicId !== "string") outputError("--topic-id is required");
+      await client.deleteTopic(roomId, topicId);
+      outputJson({ deleted: true, room_id: roomId, topic_id: topicId });
+      break;
+    }
+
+    default:
+      outputError(`unknown topic action: ${action}`);
+  }
+}

--- a/cli/src/commands/send.ts
+++ b/cli/src/commands/send.ts
@@ -1,0 +1,94 @@
+import path from "node:path";
+import type { ParsedArgs } from "../args.js";
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials } from "../credentials.js";
+import { outputJson, outputError } from "../output.js";
+import type { MessageAttachment } from "../types.js";
+
+export async function sendCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void> {
+  if (args.flags["help"]) {
+    console.log(`Usage: botcord send --to <id> --text <msg> [options]
+
+Send a signed message to an agent or room.
+
+Options:
+  --to <id>           Recipient agent or room ID (required)
+  --text <msg>        Message text (required)
+  --reply-to <id>     Reply to a specific message ID
+  --topic <topic>     Topic name
+  --goal <goal>       Goal description
+  --ttl <sec>         Message TTL in seconds (default: 3600)
+  --file <path>       Attach a file (can be repeated)
+  --mention <id>      Mention an agent or @all (can be repeated)`);
+    return;
+  }
+
+  const to = args.flags["to"];
+  const text = args.flags["text"];
+  if (!to || typeof to !== "string") outputError("--to is required");
+  if (!text || typeof text !== "string") outputError("--text is required");
+
+  const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+  const hubUrl = globalHub || creds.hubUrl;
+
+  const client = new BotCordClient({
+    hubUrl,
+    agentId: creds.agentId,
+    keyId: creds.keyId,
+    privateKey: creds.privateKey,
+    token: creds.token,
+    tokenExpiresAt: creds.tokenExpiresAt,
+  });
+
+  // Collect --file flags (may appear multiple times in positionals/raw argv)
+  const files: string[] = [];
+  const rawArgv = process.argv.slice(2);
+  for (let i = 0; i < rawArgv.length; i++) {
+    if (rawArgv[i] === "--file" && rawArgv[i + 1]) {
+      files.push(rawArgv[i + 1]);
+      i++;
+    } else if (rawArgv[i].startsWith("--file=")) {
+      files.push(rawArgv[i].slice(7));
+    }
+  }
+
+  // Collect --mention flags
+  const mentions: string[] = [];
+  for (let i = 0; i < rawArgv.length; i++) {
+    if (rawArgv[i] === "--mention" && rawArgv[i + 1]) {
+      mentions.push(rawArgv[i + 1]);
+      i++;
+    } else if (rawArgv[i].startsWith("--mention=")) {
+      mentions.push(rawArgv[i].slice(10));
+    }
+  }
+
+  // Upload files
+  const attachments: MessageAttachment[] = [];
+  for (const filePath of files) {
+    const filename = path.basename(filePath);
+    const uploaded = await client.uploadFile(filePath, filename);
+    attachments.push({
+      filename: uploaded.original_filename,
+      url: uploaded.url,
+      content_type: uploaded.content_type,
+      size_bytes: uploaded.size_bytes,
+    });
+  }
+
+  const replyTo = typeof args.flags["reply-to"] === "string" ? args.flags["reply-to"] : undefined;
+  const topic = typeof args.flags["topic"] === "string" ? args.flags["topic"] : undefined;
+  const goal = typeof args.flags["goal"] === "string" ? args.flags["goal"] : undefined;
+  const ttl = typeof args.flags["ttl"] === "string" ? parseInt(args.flags["ttl"], 10) : undefined;
+
+  const result = await client.sendMessage(to, text, {
+    replyTo,
+    topic,
+    goal,
+    ttlSec: ttl,
+    attachments: attachments.length > 0 ? attachments : undefined,
+    mentions: mentions.length > 0 ? mentions : undefined,
+  });
+
+  outputJson(result);
+}

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -1,0 +1,31 @@
+import type { ParsedArgs } from "../args.js";
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials } from "../credentials.js";
+import { outputJson, outputError } from "../output.js";
+
+export async function statusCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void> {
+  if (args.flags["help"]) {
+    console.log(`Usage: botcord status <msg_id>
+
+Query the delivery status of a message.`);
+    return;
+  }
+
+  const msgId = args.subcommand || args.positionals[0];
+  if (!msgId) outputError("msg_id is required");
+
+  const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+  const hubUrl = globalHub || creds.hubUrl;
+
+  const client = new BotCordClient({
+    hubUrl,
+    agentId: creds.agentId,
+    keyId: creds.keyId,
+    privateKey: creds.privateKey,
+    token: creds.token,
+    tokenExpiresAt: creds.tokenExpiresAt,
+  });
+
+  const result = await client.getMessageStatus(msgId);
+  outputJson(result);
+}

--- a/cli/src/commands/wallet.ts
+++ b/cli/src/commands/wallet.ts
@@ -1,0 +1,84 @@
+import type { ParsedArgs } from "../args.js";
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials } from "../credentials.js";
+import { outputJson, outputError } from "../output.js";
+
+export async function walletCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void> {
+  const sub = args.subcommand;
+
+  if (args.flags["help"] || !sub) {
+    console.log(`Usage: botcord wallet <subcommand> [options]
+
+Subcommands:
+  balance                          Show wallet balance
+  ledger [--limit <n>] [--cursor <c>] [--type <type>]  Show ledger entries
+  transfer --to <id> --amount <n> [--memo <text>]       Transfer funds
+  topup --amount <n>               Request a topup
+  withdraw --amount <n>            Request a withdrawal`);
+    if (!sub && !args.flags["help"]) process.exit(1);
+    return;
+  }
+
+  const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+  const hubUrl = globalHub || creds.hubUrl;
+
+  const client = new BotCordClient({
+    hubUrl,
+    agentId: creds.agentId,
+    keyId: creds.keyId,
+    privateKey: creds.privateKey,
+    token: creds.token,
+    tokenExpiresAt: creds.tokenExpiresAt,
+  });
+
+  switch (sub) {
+    case "balance": {
+      const result = await client.getWallet();
+      outputJson(result);
+      break;
+    }
+
+    case "ledger": {
+      const limit = typeof args.flags["limit"] === "string" ? parseInt(args.flags["limit"], 10) : undefined;
+      const cursor = typeof args.flags["cursor"] === "string" ? args.flags["cursor"] : undefined;
+      const type = typeof args.flags["type"] === "string" ? args.flags["type"] : undefined;
+      const result = await client.getWalletLedger({ limit, cursor, type });
+      outputJson(result);
+      break;
+    }
+
+    case "transfer": {
+      const to = args.flags["to"];
+      const amount = args.flags["amount"];
+      if (!to || typeof to !== "string") outputError("--to is required");
+      if (!amount || typeof amount !== "string") outputError("--amount is required");
+      const memo = typeof args.flags["memo"] === "string" ? args.flags["memo"] : undefined;
+      const result = await client.createTransfer({
+        to_agent_id: to,
+        amount_minor: amount,
+        memo,
+      });
+      outputJson(result);
+      break;
+    }
+
+    case "topup": {
+      const amount = args.flags["amount"];
+      if (!amount || typeof amount !== "string") outputError("--amount is required");
+      const result = await client.createTopup({ amount_minor: amount });
+      outputJson(result);
+      break;
+    }
+
+    case "withdraw": {
+      const amount = args.flags["amount"];
+      if (!amount || typeof amount !== "string") outputError("--amount is required");
+      const result = await client.createWithdrawal({ amount_minor: amount });
+      outputJson(result);
+      break;
+    }
+
+    default:
+      outputError(`unknown subcommand: ${sub}`);
+  }
+}

--- a/cli/src/credentials.ts
+++ b/cli/src/credentials.ts
@@ -1,0 +1,137 @@
+import { chmodSync, mkdirSync, readFileSync, writeFileSync, symlinkSync, unlinkSync, existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { derivePublicKey } from "./crypto.js";
+import { normalizeAndValidateHubUrl } from "./hub-url.js";
+
+export interface StoredBotCordCredentials {
+  version: 1;
+  hubUrl: string;
+  agentId: string;
+  keyId: string;
+  privateKey: string;
+  publicKey: string;
+  displayName?: string;
+  savedAt: string;
+  token?: string;
+  tokenExpiresAt?: number;
+}
+
+function normalizeCredentialValue(raw: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = raw[key];
+    if (typeof value === "string" && value.trim()) return value;
+  }
+  return undefined;
+}
+
+export function resolveCredentialsFilePath(credentialsFile: string): string {
+  if (credentialsFile === "~") return os.homedir();
+  if (credentialsFile.startsWith("~/")) {
+    return path.join(os.homedir(), credentialsFile.slice(2));
+  }
+  return path.isAbsolute(credentialsFile)
+    ? credentialsFile
+    : path.resolve(credentialsFile);
+}
+
+export function defaultCredentialsFile(agentId: string): string {
+  return path.join(os.homedir(), ".botcord", "credentials", `${agentId}.json`);
+}
+
+export function loadStoredCredentials(credentialsFile: string): StoredBotCordCredentials {
+  const resolved = resolveCredentialsFilePath(credentialsFile);
+  let raw: Record<string, unknown>;
+  try {
+    raw = JSON.parse(readFileSync(resolved, "utf8")) as Record<string, unknown>;
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`Unable to read BotCord credentials file "${resolved}": ${msg}`);
+  }
+
+  const hubUrl = normalizeCredentialValue(raw, ["hubUrl", "hub_url", "hub"]);
+  const agentId = normalizeCredentialValue(raw, ["agentId", "agent_id"]);
+  const keyId = normalizeCredentialValue(raw, ["keyId", "key_id"]);
+  const privateKey = normalizeCredentialValue(raw, ["privateKey", "private_key"]);
+  const publicKey = normalizeCredentialValue(raw, ["publicKey", "public_key"]);
+  const displayName = normalizeCredentialValue(raw, ["displayName", "display_name"]);
+  const savedAt = normalizeCredentialValue(raw, ["savedAt", "saved_at"]);
+  const token = normalizeCredentialValue(raw, ["token"]);
+  const tokenExpiresAt = typeof raw.tokenExpiresAt === "number" ? raw.tokenExpiresAt : undefined;
+
+  if (!hubUrl) throw new Error(`BotCord credentials file "${resolved}" is missing hubUrl`);
+  if (!agentId) throw new Error(`BotCord credentials file "${resolved}" is missing agentId`);
+  if (!keyId) throw new Error(`BotCord credentials file "${resolved}" is missing keyId`);
+  if (!privateKey) throw new Error(`BotCord credentials file "${resolved}" is missing privateKey`);
+
+  const derivedPublicKey = derivePublicKey(privateKey);
+  if (publicKey && publicKey !== derivedPublicKey) {
+    throw new Error(
+      `BotCord credentials file "${resolved}" has a publicKey that does not match privateKey`,
+    );
+  }
+
+  let normalizedHubUrl: string;
+  try {
+    normalizedHubUrl = normalizeAndValidateHubUrl(hubUrl);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`BotCord credentials file "${resolved}" has an invalid hubUrl: ${msg}`);
+  }
+
+  return {
+    version: 1,
+    hubUrl: normalizedHubUrl,
+    agentId,
+    keyId,
+    privateKey,
+    publicKey: publicKey || derivedPublicKey,
+    displayName,
+    savedAt: savedAt || new Date().toISOString(),
+    token,
+    tokenExpiresAt,
+  };
+}
+
+export function writeCredentialsFile(
+  credentialsFile: string,
+  credentials: StoredBotCordCredentials,
+): string {
+  const resolved = resolveCredentialsFilePath(credentialsFile);
+  const normalizedCredentials = {
+    ...credentials,
+    hubUrl: normalizeAndValidateHubUrl(credentials.hubUrl),
+  };
+  mkdirSync(path.dirname(resolved), { recursive: true, mode: 0o700 });
+  writeFileSync(resolved, JSON.stringify(normalizedCredentials, null, 2) + "\n", {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  chmodSync(resolved, 0o600);
+  return resolved;
+}
+
+const DEFAULT_LINK = path.join(os.homedir(), ".botcord", "default.json");
+
+export function loadDefaultCredentials(agentId?: string): StoredBotCordCredentials {
+  if (agentId) {
+    return loadStoredCredentials(defaultCredentialsFile(agentId));
+  }
+  if (!existsSync(DEFAULT_LINK)) {
+    throw new Error("No default agent configured. Use --agent <id> or run: botcord register --set-default");
+  }
+  return loadStoredCredentials(DEFAULT_LINK);
+}
+
+export function setDefaultAgent(agentId: string): void {
+  const target = defaultCredentialsFile(agentId);
+  if (!existsSync(target)) {
+    throw new Error(`Credentials file not found: ${target}`);
+  }
+  const linkDir = path.dirname(DEFAULT_LINK);
+  mkdirSync(linkDir, { recursive: true, mode: 0o700 });
+  if (existsSync(DEFAULT_LINK)) {
+    unlinkSync(DEFAULT_LINK);
+  }
+  symlinkSync(target, DEFAULT_LINK);
+}

--- a/cli/src/crypto.ts
+++ b/cli/src/crypto.ts
@@ -1,0 +1,155 @@
+/**
+ * Ed25519 signing for BotCord protocol.
+ * Zero npm dependencies — uses Node.js built-in crypto module.
+ * Ported from botcord-skill/skill/botcord-crypto.mjs.
+ */
+import {
+  createHash,
+  createPublicKey,
+  createPrivateKey,
+  generateKeyPairSync,
+  sign,
+  randomUUID,
+} from "node:crypto";
+import type { BotCordMessageEnvelope, BotCordSignature, MessageType } from "./types.js";
+
+// ── JCS (RFC 8785) canonicalization ─────────────────────────────
+export function jcsCanonicalize(value: unknown): string | undefined {
+  if (value === null || typeof value === "boolean") return JSON.stringify(value);
+  if (typeof value === "number") {
+    if (Object.is(value, -0)) return "0";
+    return JSON.stringify(value);
+  }
+  if (typeof value === "string") return JSON.stringify(value);
+  if (Array.isArray(value))
+    return "[" + value.map((v) => jcsCanonicalize(v)).join(",") + "]";
+  if (typeof value === "object") {
+    const keys = Object.keys(value as Record<string, unknown>).sort();
+    const parts: string[] = [];
+    for (const k of keys) {
+      const v = (value as Record<string, unknown>)[k];
+      if (v === undefined) continue;
+      parts.push(JSON.stringify(k) + ":" + jcsCanonicalize(v));
+    }
+    return "{" + parts.join(",") + "}";
+  }
+  return undefined;
+}
+
+// ── Build Node.js KeyObject from raw 32-byte seed ───────────────
+function privateKeyFromSeed(seed: Buffer): ReturnType<typeof createPrivateKey> {
+  const prefix = Buffer.from("302e020100300506032b657004220420", "hex");
+  return createPrivateKey({
+    key: Buffer.concat([prefix, seed]),
+    format: "der",
+    type: "pkcs8",
+  });
+}
+
+// ── Payload hash ────────────────────────────────────────────────
+export function computePayloadHash(payload: Record<string, unknown>): string {
+  const canonical = jcsCanonicalize(payload)!;
+  const digest = createHash("sha256").update(canonical).digest("hex");
+  return `sha256:${digest}`;
+}
+
+// ── Sign challenge ──────────────────────────────────────────────
+export function signChallenge(privateKeyB64: string, challengeB64: string): string {
+  const pk = privateKeyFromSeed(Buffer.from(privateKeyB64, "base64"));
+  const sig = sign(null, Buffer.from(challengeB64, "base64"), pk);
+  return sig.toString("base64");
+}
+
+export function derivePublicKey(privateKeyB64: string): string {
+  const privateKey = privateKeyFromSeed(Buffer.from(privateKeyB64, "base64"));
+  const publicKey = createPublicKey(privateKey);
+  const pubDer = publicKey.export({ type: "spki", format: "der" });
+  return Buffer.from(pubDer.subarray(-32)).toString("base64");
+}
+
+// ── Build and sign a full message envelope ──────────────────────
+export function buildSignedEnvelope(params: {
+  from: string;
+  to: string;
+  type: MessageType;
+  payload: Record<string, unknown>;
+  privateKey: string; // base64 Ed25519 seed
+  keyId: string;
+  replyTo?: string | null;
+  ttlSec?: number;
+  topic?: string | null;
+  goal?: string | null;
+}): BotCordMessageEnvelope {
+  const {
+    from,
+    to,
+    type,
+    payload,
+    privateKey,
+    keyId,
+    replyTo = null,
+    ttlSec = 3600,
+    topic = null,
+    goal = null,
+  } = params;
+
+  const msgId = randomUUID();
+  const ts = Math.floor(Date.now() / 1000);
+  const payloadHash = computePayloadHash(payload);
+
+  // Build signing input (newline-joined fields)
+  const parts = [
+    "a2a/0.1",
+    msgId,
+    String(ts),
+    from,
+    to,
+    String(type),
+    replyTo || "",
+    String(ttlSec),
+    payloadHash,
+  ];
+
+  const pk = privateKeyFromSeed(Buffer.from(privateKey, "base64"));
+  const sigValue = sign(null, Buffer.from(parts.join("\n")), pk);
+
+  const sig: BotCordSignature = {
+    alg: "ed25519",
+    key_id: keyId,
+    value: sigValue.toString("base64"),
+  };
+
+  return {
+    v: "a2a/0.1",
+    msg_id: msgId,
+    ts,
+    from,
+    to,
+    type,
+    reply_to: replyTo,
+    ttl_sec: ttlSec,
+    topic,
+    goal,
+    payload,
+    payload_hash: payloadHash,
+    sig,
+  };
+}
+
+// ── Keygen ──────────────────────────────────────────────────────
+export function generateKeypair(): {
+  privateKey: string;
+  publicKey: string;
+  pubkeyFormatted: string;
+} {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const privDer = privateKey.export({ type: "pkcs8", format: "der" });
+  const privB64 = Buffer.from(privDer.subarray(-32)).toString("base64");
+  const pubDer = publicKey.export({ type: "spki", format: "der" });
+  const pubB64 = Buffer.from(pubDer.subarray(-32)).toString("base64");
+  return {
+    privateKey: privB64,
+    publicKey: pubB64,
+    pubkeyFormatted: `ed25519:${pubB64}`,
+  };
+}

--- a/cli/src/hub-url.ts
+++ b/cli/src/hub-url.ts
@@ -1,0 +1,32 @@
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+
+function isLoopbackHost(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/^\[(.*)\]$/, "$1");
+  return LOOPBACK_HOSTS.has(normalized) || normalized.endsWith(".localhost");
+}
+
+export function normalizeAndValidateHubUrl(hubUrl: string): string {
+  const trimmed = hubUrl.trim();
+  if (!trimmed) {
+    throw new Error("BotCord hubUrl is required");
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error(`BotCord hubUrl must be a valid absolute URL: ${hubUrl}`);
+  }
+
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new Error("BotCord hubUrl must use http:// or https://");
+  }
+
+  if (parsed.protocol === "http:" && !isLoopbackHost(parsed.hostname)) {
+    throw new Error(
+      "BotCord hubUrl must use https:// unless it targets localhost, 127.0.0.1, or ::1 for local development",
+    );
+  }
+
+  return trimmed.replace(/\/$/, "");
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+import { parseArgs } from "./args.js";
+import { outputError } from "./output.js";
+import { registerCommand } from "./commands/register.js";
+import { sendCommand } from "./commands/send.js";
+import { refreshCommand } from "./commands/refresh.js";
+import { resolveCommand } from "./commands/resolve.js";
+import { statusCommand } from "./commands/status.js";
+import { profileCommand } from "./commands/profile.js";
+import { policyCommand } from "./commands/policy.js";
+import { endpointCommand } from "./commands/endpoint.js";
+import { roomCommand } from "./commands/room.js";
+import { contactCommand } from "./commands/contact.js";
+import { contactRequestCommand } from "./commands/contact-request.js";
+import { blockCommand } from "./commands/block.js";
+import { inboxCommand } from "./commands/inbox.js";
+import { walletCommand } from "./commands/wallet.js";
+
+const VERSION = "0.1.0";
+
+const HELP = `botcord — BotCord CLI v${VERSION}
+
+Usage: botcord <command> [options]
+
+Commands:
+  register          Register a new agent
+  send              Send a signed message
+  inbox             Poll inbox for new messages
+  status            Query message delivery status
+  room              Manage rooms
+  contact           Manage contacts
+  contact-request   Manage contact requests
+  block             Manage blocked agents
+  profile           Get or update agent profile
+  policy            Get or set message policy
+  endpoint          Register webhook endpoint
+  resolve           Resolve agent info
+  refresh           Refresh JWT token
+  wallet            Wallet operations
+
+Global options:
+  --agent <id>      Use specific agent credentials
+  --hub <url>       Override hub URL
+  --help, -h        Show help
+
+Environment:
+  BOTCORD_HUB       Default hub URL override`;
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+
+  // Global options
+  const globalAgent = typeof args.flags["agent"] === "string" ? args.flags["agent"] : undefined;
+  const globalHub = typeof args.flags["hub"] === "string"
+    ? args.flags["hub"]
+    : (process.env.BOTCORD_HUB || undefined);
+
+  if (!args.command || args.flags["help"] === true) {
+    if (!args.command) {
+      console.log(HELP);
+      process.exit(args.flags["help"] ? 0 : 1);
+    }
+  }
+
+  try {
+    switch (args.command) {
+      case "register":
+        await registerCommand(args);
+        break;
+      case "send":
+        await sendCommand(args, globalHub, globalAgent);
+        break;
+      case "inbox":
+        await inboxCommand(args, globalHub, globalAgent);
+        break;
+      case "status":
+        await statusCommand(args, globalHub, globalAgent);
+        break;
+      case "room":
+        await roomCommand(args, globalHub, globalAgent);
+        break;
+      case "contact":
+        await contactCommand(args, globalHub, globalAgent);
+        break;
+      case "contact-request":
+        await contactRequestCommand(args, globalHub, globalAgent);
+        break;
+      case "block":
+        await blockCommand(args, globalHub, globalAgent);
+        break;
+      case "profile":
+        await profileCommand(args, globalHub, globalAgent);
+        break;
+      case "policy":
+        await policyCommand(args, globalHub, globalAgent);
+        break;
+      case "endpoint":
+        await endpointCommand(args, globalHub, globalAgent);
+        break;
+      case "resolve":
+        await resolveCommand(args, globalHub, globalAgent);
+        break;
+      case "refresh":
+        await refreshCommand(args, globalHub, globalAgent);
+        break;
+      case "wallet":
+        await walletCommand(args, globalHub, globalAgent);
+        break;
+      default:
+        outputError(`unknown command: ${args.command}. Run "botcord --help" for usage.`);
+    }
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    outputError(message);
+  }
+}
+
+main();

--- a/cli/src/output.ts
+++ b/cli/src/output.ts
@@ -1,0 +1,8 @@
+export function outputJson(data: unknown): void {
+  console.log(JSON.stringify(data, null, 2));
+}
+
+export function outputError(message: string): never {
+  console.error(JSON.stringify({ error: message }));
+  process.exit(1);
+}

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -1,0 +1,232 @@
+// BotCord protocol types (mirrors hub/schemas.py)
+
+export type BotCordSignature = {
+  alg: "ed25519";
+  key_id: string;
+  value: string; // base64
+};
+
+export type MessageType =
+  | "message"
+  | "ack"
+  | "result"
+  | "error"
+  | "contact_request"
+  | "contact_request_response"
+  | "contact_removed"
+  | "system";
+
+export type BotCordMessageEnvelope = {
+  v: string;
+  msg_id: string;
+  ts: number;
+  from: string;
+  to: string;
+  type: MessageType;
+  reply_to: string | null;
+  ttl_sec: number;
+  topic?: string | null;
+  goal?: string | null;
+  payload: Record<string, unknown>;
+  payload_hash: string;
+  sig: BotCordSignature;
+  mentions?: string[] | null;
+};
+
+// Inbox poll response
+export type InboxMessage = {
+  hub_msg_id: string;
+  envelope: BotCordMessageEnvelope;
+  text?: string;
+  room_id?: string;
+  room_name?: string;
+  room_rule?: string | null;
+  room_member_count?: number;
+  room_member_names?: string[];
+  my_role?: string;
+  my_can_send?: boolean;
+  topic?: string;
+  topic_id?: string;
+  goal?: string;
+  mentioned?: boolean;
+  source_type?: string;
+  source_user_id?: string | null;
+  source_session_kind?: string | null;
+};
+
+export type InboxPollResponse = {
+  messages: InboxMessage[];
+  count: number;
+  has_more: boolean;
+};
+
+// Hub API response types
+export type SendResponse = {
+  queued: boolean;
+  hub_msg_id: string;
+  status: string;
+  topic_id?: string;
+};
+
+export type RoomInfo = {
+  room_id: string;
+  name: string;
+  description?: string;
+  rule?: string | null;
+  visibility: "private" | "public";
+  join_policy: "invite_only" | "open";
+  required_subscription_product_id?: string | null;
+  max_members?: number | null;
+  default_send: boolean;
+  default_invite?: boolean;
+  slow_mode_seconds?: number | null;
+  member_count: number;
+  created_at: string;
+};
+
+export type AgentInfo = {
+  agent_id: string;
+  display_name?: string;
+  bio?: string;
+  message_policy: string;
+  endpoints: Array<{ url: string; state: string }>;
+};
+
+export type ContactInfo = {
+  contact_agent_id: string;
+  display_name?: string;
+  created_at: string;
+};
+
+export type ContactRequestInfo = {
+  request_id: string;
+  from_agent_id: string;
+  to_agent_id: string;
+  state: "pending" | "accepted" | "rejected";
+  created_at: string;
+};
+
+// File upload response
+export type FileUploadResponse = {
+  file_id: string;
+  url: string;
+  original_filename: string;
+  content_type: string;
+  size_bytes: number;
+  expires_at: string;
+};
+
+// Attachment metadata included in message payloads
+export type MessageAttachment = {
+  filename: string;
+  url: string;
+  content_type?: string;
+  size_bytes?: number;
+};
+
+// Wallet types
+export type WalletSummary = {
+  agent_id: string;
+  asset_code: string;
+  available_balance_minor: string;
+  locked_balance_minor: string;
+  total_balance_minor: string;
+  updated_at: string;
+};
+
+export type WalletTransaction = {
+  tx_id: string;
+  type: "topup" | "withdrawal" | "transfer";
+  status: "pending" | "processing" | "completed" | "failed" | "cancelled";
+  asset_code: string;
+  amount_minor: string;
+  fee_minor: string;
+  from_agent_id: string | null;
+  to_agent_id: string | null;
+  reference_type: string | null;
+  reference_id: string | null;
+  idempotency_key: string | null;
+  metadata_json: string | null;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+};
+
+export type WalletLedgerEntry = {
+  entry_id: string;
+  tx_id: string;
+  agent_id: string;
+  asset_code: string;
+  direction: "debit" | "credit";
+  amount_minor: string;
+  balance_after_minor: string;
+  created_at: string;
+};
+
+export type WalletLedgerResponse = {
+  entries: WalletLedgerEntry[];
+  next_cursor: string | null;
+  has_more: boolean;
+};
+
+export type TopupResponse = {
+  topup_id: string;
+  tx_id: string | null;
+  agent_id: string;
+  asset_code: string;
+  amount_minor: string;
+  status: string;
+  channel: string;
+  created_at: string;
+  completed_at: string | null;
+};
+
+export type WithdrawalResponse = {
+  withdrawal_id: string;
+  tx_id: string | null;
+  agent_id: string;
+  asset_code: string;
+  amount_minor: string;
+  fee_minor: string;
+  status: string;
+  destination_type: string | null;
+  review_note: string | null;
+  created_at: string;
+  reviewed_at: string | null;
+  completed_at: string | null;
+};
+
+export type SubscriptionProduct = {
+  product_id: string;
+  owner_agent_id: string;
+  name: string;
+  description: string;
+  asset_code: string;
+  amount_minor: string;
+  billing_interval: "week" | "month";
+  status: "active" | "archived";
+  created_at: string;
+  updated_at: string;
+  archived_at: string | null;
+};
+
+export type Subscription = {
+  subscription_id: string;
+  product_id: string;
+  subscriber_agent_id: string;
+  provider_agent_id: string;
+  asset_code: string;
+  amount_minor: string;
+  billing_interval: "week" | "month";
+  status: "active" | "past_due" | "cancelled";
+  current_period_start: string;
+  current_period_end: string;
+  next_charge_at: string;
+  cancel_at_period_end: boolean;
+  cancelled_at: string | null;
+  last_charged_at: string | null;
+  last_charge_tx_id: string | null;
+  consecutive_failed_attempts: number;
+  created_at: string;
+  updated_at: string;
+};

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "sourceMap": false,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- Add `cli/` package (`@botcord/cli`) — a zero-dependency TypeScript CLI for the BotCord a2a/0.1 protocol
- Single entry point (`botcord <command>`) with 14 subcommands: register, send, inbox, status, room, contact, contact-request, block, profile, policy, endpoint, resolve, refresh, wallet
- Crypto logic reused from `plugin/src/crypto.ts` (Ed25519 JCS signing), credentials compatible with `~/.botcord/credentials/` format
- All output is JSON for scriptability; requires Node.js 18+; publishable as `npm install -g @botcord/cli`

## Test plan
- [x] `tsc` compiles with zero errors
- [x] `botcord --help` displays command list
- [x] `botcord register --help`, `botcord send --help`, `botcord room --help` show correct usage
- [ ] End-to-end: `botcord register` → `botcord send` → `botcord inbox` against test hub
- [ ] Verify credential file permissions (0o600)

🤖 Generated with [Claude Code](https://claude.com/claude-code)