### PR TITLE
fix(cli): align CLI commands with plugin tool capabilities

### DIFF
--- a/cli/dist/client.d.ts
+++ b/cli/dist/client.d.ts
@@ -1,4 +1,4 @@
-import type { InboxPollResponse, SendResponse, RoomInfo, AgentInfo, ContactInfo, ContactRequestInfo, FileUploadResponse, MessageAttachment, WalletSummary, WalletTransaction, WalletLedgerResponse, TopupResponse, WithdrawalResponse } from "./types.js";
+import type { InboxPollResponse, SendResponse, RoomInfo, AgentInfo, ContactInfo, ContactRequestInfo, FileUploadResponse, MessageAttachment, WalletSummary, WalletTransaction, WalletLedgerResponse, TopupResponse, WithdrawalResponse, SubscriptionProduct, Subscription } from "./types.js";
 export interface BotCordClientConfig {
     hubUrl: string;
     agentId: string;
@@ -31,9 +31,18 @@ export declare class BotCordClient {
         attachments?: MessageAttachment[];
         mentions?: string[];
     }): Promise<SendResponse>;
+    sendTypedMessage(to: string, type: "result" | "error", text: string, options?: {
+        replyTo?: string;
+        topic?: string;
+        attachments?: MessageAttachment[];
+    }): Promise<SendResponse>;
+    sendSystemMessage(to: string, text: string, payload?: Record<string, unknown>, options?: {
+        topic?: string;
+    }): Promise<SendResponse>;
     pollInbox(options?: {
         limit?: number;
         ack?: boolean;
+        timeout?: number;
         roomId?: string;
     }): Promise<InboxPollResponse>;
     getHistory(options?: {
@@ -71,21 +80,36 @@ export declare class BotCordClient {
         rule?: string;
         visibility?: "private" | "public";
         join_policy?: "invite_only" | "open";
+        required_subscription_product_id?: string;
         max_members?: number;
+        default_send?: boolean;
+        default_invite?: boolean;
+        slow_mode_seconds?: number;
         member_ids?: string[];
     }): Promise<RoomInfo>;
     listMyRooms(): Promise<RoomInfo[]>;
     getRoomInfo(roomId: string): Promise<RoomInfo>;
-    joinRoom(roomId: string): Promise<void>;
+    joinRoom(roomId: string, options?: {
+        can_send?: boolean;
+        can_invite?: boolean;
+    }): Promise<void>;
     leaveRoom(roomId: string): Promise<void>;
-    inviteToRoom(roomId: string, agentId: string): Promise<void>;
+    inviteToRoom(roomId: string, agentId: string, options?: {
+        can_send?: boolean;
+        can_invite?: boolean;
+    }): Promise<void>;
     discoverRooms(name?: string): Promise<RoomInfo[]>;
     updateRoom(roomId: string, params: {
         name?: string;
         description?: string;
+        rule?: string | null;
         visibility?: string;
         join_policy?: string;
+        required_subscription_product_id?: string | null;
         max_members?: number | null;
+        default_send?: boolean;
+        default_invite?: boolean;
+        slow_mode_seconds?: number | null;
     }): Promise<RoomInfo>;
     removeMember(roomId: string, agentId: string): Promise<void>;
     promoteMember(roomId: string, agentId: string, role: "admin" | "member"): Promise<void>;
@@ -120,15 +144,40 @@ export declare class BotCordClient {
         to_agent_id: string;
         amount_minor: string;
         memo?: string;
+        reference_type?: string;
+        reference_id?: string;
+        metadata?: Record<string, unknown>;
+        idempotency_key?: string;
     }): Promise<WalletTransaction>;
     createTopup(params: {
         amount_minor: string;
+        channel?: string;
+        metadata?: Record<string, unknown>;
+        idempotency_key?: string;
     }): Promise<TopupResponse>;
     createWithdrawal(params: {
         amount_minor: string;
+        fee_minor?: string;
+        destination_type?: string;
+        destination?: Record<string, unknown>;
+        idempotency_key?: string;
     }): Promise<WithdrawalResponse>;
     getWalletTransaction(txId: string): Promise<WalletTransaction>;
     cancelWithdrawal(withdrawalId: string): Promise<WithdrawalResponse>;
+    createSubscriptionProduct(params: {
+        name: string;
+        description?: string;
+        amount_minor: string;
+        billing_interval: "week" | "month";
+        asset_code?: string;
+    }): Promise<SubscriptionProduct>;
+    listMySubscriptionProducts(): Promise<SubscriptionProduct[]>;
+    listSubscriptionProducts(): Promise<SubscriptionProduct[]>;
+    archiveSubscriptionProduct(productId: string): Promise<SubscriptionProduct>;
+    subscribeToProduct(productId: string, idempotencyKey?: string): Promise<Subscription>;
+    listMySubscriptions(): Promise<Subscription[]>;
+    listProductSubscribers(productId: string): Promise<Subscription[]>;
+    cancelSubscription(subscriptionId: string): Promise<Subscription>;
     registerEndpoint(url: string, webhookToken: string): Promise<unknown>;
     getAgentId(): string;
     getHubUrl(): string;

--- a/cli/dist/client.js
+++ b/cli/dist/client.js
@@ -153,6 +153,48 @@ export class BotCordClient {
         });
         return (await resp.json());
     }
+    async sendTypedMessage(to, type, text, options) {
+        const payload = type === "error" ? { error: { code: "agent_error", message: text } } : { text };
+        if (options?.attachments && options.attachments.length > 0) {
+            payload.attachments = options.attachments;
+        }
+        const envelope = buildSignedEnvelope({
+            from: this.agentId,
+            to,
+            type,
+            payload,
+            privateKey: this.privateKey,
+            keyId: this.keyId,
+            replyTo: options?.replyTo,
+            topic: options?.topic,
+        });
+        const topicQuery = options?.topic ? `?topic=${encodeURIComponent(options.topic)}` : "";
+        const resp = await this.hubFetch(`/hub/send${topicQuery}`, {
+            method: "POST",
+            body: JSON.stringify(envelope),
+        });
+        return (await resp.json());
+    }
+    async sendSystemMessage(to, text, payload, options) {
+        const envelope = buildSignedEnvelope({
+            from: this.agentId,
+            to,
+            type: "system",
+            payload: {
+                text,
+                ...(payload || {}),
+            },
+            privateKey: this.privateKey,
+            keyId: this.keyId,
+            topic: options?.topic,
+        });
+        const topicQuery = options?.topic ? `?topic=${encodeURIComponent(options.topic)}` : "";
+        const resp = await this.hubFetch(`/hub/send${topicQuery}`, {
+            method: "POST",
+            body: JSON.stringify(envelope),
+        });
+        return (await resp.json());
+    }
     // ── Inbox ─────────────────────────────────────────────────────
     async pollInbox(options) {
         const params = new URLSearchParams();
@@ -160,6 +202,8 @@ export class BotCordClient {
             params.set("limit", String(options.limit));
         if (options?.ack)
             params.set("ack", "true");
+        if (options?.timeout)
+            params.set("timeout", String(options.timeout));
         if (options?.roomId)
             params.set("room_id", options.roomId);
         const resp = await this.hubFetch(`/hub/inbox?${params.toString()}`);
@@ -293,19 +337,19 @@ export class BotCordClient {
         const resp = await this.hubFetch(`/hub/rooms/${roomId}`);
         return (await resp.json());
     }
-    async joinRoom(roomId) {
+    async joinRoom(roomId, options) {
         await this.hubFetch(`/hub/rooms/${roomId}/members`, {
             method: "POST",
-            body: JSON.stringify({ agent_id: this.agentId }),
+            body: JSON.stringify({ agent_id: this.agentId, ...options }),
         });
     }
     async leaveRoom(roomId) {
         await this.hubFetch(`/hub/rooms/${roomId}/leave`, { method: "POST" });
     }
-    async inviteToRoom(roomId, agentId) {
+    async inviteToRoom(roomId, agentId, options) {
         await this.hubFetch(`/hub/rooms/${roomId}/members`, {
             method: "POST",
-            body: JSON.stringify({ agent_id: agentId }),
+            body: JSON.stringify({ agent_id: agentId, ...options }),
         });
     }
     async discoverRooms(name) {
@@ -427,6 +471,56 @@ export class BotCordClient {
     }
     async cancelWithdrawal(withdrawalId) {
         const resp = await this.hubFetch(`/wallet/withdrawals/${withdrawalId}/cancel`, {
+            method: "POST",
+        });
+        return (await resp.json());
+    }
+    // ── Subscriptions ───────────────────────────────────────────
+    async createSubscriptionProduct(params) {
+        const resp = await this.hubFetch("/subscriptions/products", {
+            method: "POST",
+            body: JSON.stringify(params),
+        });
+        return (await resp.json());
+    }
+    async listMySubscriptionProducts() {
+        const resp = await this.hubFetch("/subscriptions/products/me");
+        const body = await resp.json();
+        return body.products;
+    }
+    async listSubscriptionProducts() {
+        const resp = await this.hubFetch("/subscriptions/products");
+        const body = await resp.json();
+        return body.products;
+    }
+    async archiveSubscriptionProduct(productId) {
+        const resp = await this.hubFetch(`/subscriptions/products/${productId}/archive`, {
+            method: "POST",
+        });
+        return (await resp.json());
+    }
+    async subscribeToProduct(productId, idempotencyKey) {
+        const body = {};
+        if (idempotencyKey)
+            body.idempotency_key = idempotencyKey;
+        const resp = await this.hubFetch(`/subscriptions/products/${productId}/subscribe`, {
+            method: "POST",
+            body: JSON.stringify(body),
+        });
+        return (await resp.json());
+    }
+    async listMySubscriptions() {
+        const resp = await this.hubFetch("/subscriptions/me");
+        const body = await resp.json();
+        return body.subscriptions;
+    }
+    async listProductSubscribers(productId) {
+        const resp = await this.hubFetch(`/subscriptions/products/${productId}/subscribers`);
+        const body = await resp.json();
+        return body.subscriptions;
+    }
+    async cancelSubscription(subscriptionId) {
+        const resp = await this.hubFetch(`/subscriptions/${subscriptionId}/cancel`, {
             method: "POST",
         });
         return (await resp.json());

--- a/cli/dist/commands/inbox.js
+++ b/cli/dist/commands/inbox.js
@@ -10,7 +10,8 @@ Poll inbox for new messages.
 Options:
   --limit <n>       Maximum number of messages to return
   --ack             Acknowledge messages after retrieval
-  --room <room_id>  Filter by room ID`);
+  --room <room_id>  Filter by room ID
+  --timeout <sec>   Long-poll timeout in seconds`);
         return;
     }
     const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
@@ -26,6 +27,7 @@ Options:
     const limit = typeof args.flags["limit"] === "string" ? parseInt(args.flags["limit"], 10) : undefined;
     const ack = args.flags["ack"] === true;
     const roomId = typeof args.flags["room"] === "string" ? args.flags["room"] : undefined;
-    const result = await client.pollInbox({ limit, ack, roomId });
+    const timeout = typeof args.flags["timeout"] === "string" ? parseInt(args.flags["timeout"], 10) : undefined;
+    const result = await client.pollInbox({ limit, ack, roomId, timeout });
     outputJson(result);
 }

--- a/cli/dist/commands/room.js
+++ b/cli/dist/commands/room.js
@@ -19,14 +19,24 @@ export async function roomCommand(args, globalHub, globalAgent) {
 
 Subcommands:
   create        Create a new room
+                  --name <name> [--description <text>] [--rule <text>]
+                  [--visibility <private|public>] [--join-policy <invite_only|open>]
+                  [--max-members <n>] [--members <id1,id2>]
+                  [--default-send <true|false>] [--default-invite <true|false>]
+                  [--slow-mode <seconds>] [--subscription-product <product_id>]
   get <id>      Get room info
   list          List my rooms
   discover      Discover public rooms
   update        Update room settings
+                  --room <id> [--name <name>] [--description <text>] [--rule <text>]
+                  [--visibility <private|public>] [--join-policy <invite_only|open>]
+                  [--max-members <n>] [--default-send <true|false>]
+                  [--default-invite <true|false>] [--slow-mode <seconds>]
+                  [--subscription-product <product_id>]
   dissolve      Dissolve a room
-  join          Join a room
+  join          Join a room --room <id> [--can-send <true|false>] [--can-invite <true|false>]
   leave         Leave a room
-  add-member    Add a member to a room
+  add-member    Add a member --room <id> --id <agent_id> [--can-send <true|false>] [--can-invite <true|false>]
   remove-member Remove a member
   transfer      Transfer room ownership
   promote       Change member role
@@ -51,12 +61,22 @@ Subcommands:
             const params = { name };
             if (typeof args.flags["description"] === "string")
                 params.description = args.flags["description"];
+            if (typeof args.flags["rule"] === "string")
+                params.rule = args.flags["rule"];
             if (typeof args.flags["visibility"] === "string")
                 params.visibility = args.flags["visibility"];
             if (typeof args.flags["join-policy"] === "string")
                 params.join_policy = args.flags["join-policy"];
+            if (typeof args.flags["subscription-product"] === "string")
+                params.required_subscription_product_id = args.flags["subscription-product"];
             if (typeof args.flags["max-members"] === "string")
                 params.max_members = parseInt(args.flags["max-members"], 10);
+            if (typeof args.flags["default-send"] === "string")
+                params.default_send = args.flags["default-send"] === "true";
+            if (typeof args.flags["default-invite"] === "string")
+                params.default_invite = args.flags["default-invite"] === "true";
+            if (typeof args.flags["slow-mode"] === "string")
+                params.slow_mode_seconds = parseInt(args.flags["slow-mode"], 10);
             if (typeof args.flags["members"] === "string")
                 params.member_ids = args.flags["members"].split(",");
             const result = await client.createRoom(params);
@@ -91,10 +111,22 @@ Subcommands:
                 params.name = args.flags["name"];
             if (typeof args.flags["description"] === "string")
                 params.description = args.flags["description"];
+            if (typeof args.flags["rule"] === "string")
+                params.rule = args.flags["rule"];
             if (typeof args.flags["visibility"] === "string")
                 params.visibility = args.flags["visibility"];
             if (typeof args.flags["join-policy"] === "string")
                 params.join_policy = args.flags["join-policy"];
+            if (typeof args.flags["subscription-product"] === "string")
+                params.required_subscription_product_id = args.flags["subscription-product"];
+            if (typeof args.flags["max-members"] === "string")
+                params.max_members = parseInt(args.flags["max-members"], 10);
+            if (typeof args.flags["default-send"] === "string")
+                params.default_send = args.flags["default-send"] === "true";
+            if (typeof args.flags["default-invite"] === "string")
+                params.default_invite = args.flags["default-invite"] === "true";
+            if (typeof args.flags["slow-mode"] === "string")
+                params.slow_mode_seconds = parseInt(args.flags["slow-mode"], 10);
             const result = await client.updateRoom(roomId, params);
             outputJson(result);
             break;
@@ -111,7 +143,12 @@ Subcommands:
             const roomId = args.flags["room"];
             if (!roomId || typeof roomId !== "string")
                 outputError("--room is required");
-            await client.joinRoom(roomId);
+            const joinOpts = {};
+            if (typeof args.flags["can-send"] === "string")
+                joinOpts.can_send = args.flags["can-send"] === "true";
+            if (typeof args.flags["can-invite"] === "string")
+                joinOpts.can_invite = args.flags["can-invite"] === "true";
+            await client.joinRoom(roomId, Object.keys(joinOpts).length > 0 ? joinOpts : undefined);
             outputJson({ joined: true, room_id: roomId });
             break;
         }
@@ -130,7 +167,12 @@ Subcommands:
                 outputError("--room is required");
             if (!agentId || typeof agentId !== "string")
                 outputError("--id is required");
-            await client.inviteToRoom(roomId, agentId);
+            const inviteOpts = {};
+            if (typeof args.flags["can-send"] === "string")
+                inviteOpts.can_send = args.flags["can-send"] === "true";
+            if (typeof args.flags["can-invite"] === "string")
+                inviteOpts.can_invite = args.flags["can-invite"] === "true";
+            await client.inviteToRoom(roomId, agentId, Object.keys(inviteOpts).length > 0 ? inviteOpts : undefined);
             outputJson({ added: true, room_id: roomId, agent_id: agentId });
             break;
         }

--- a/cli/dist/commands/send.js
+++ b/cli/dist/commands/send.js
@@ -11,6 +11,7 @@ Send a signed message to an agent or room.
 Options:
   --to <id>           Recipient agent or room ID (required)
   --text <msg>        Message text (required)
+  --type <type>       Message type: message, result, or error (default: message)
   --reply-to <id>     Reply to a specific message ID
   --topic <topic>     Topic name
   --goal <goal>       Goal description
@@ -74,13 +75,24 @@ Options:
     const topic = typeof args.flags["topic"] === "string" ? args.flags["topic"] : undefined;
     const goal = typeof args.flags["goal"] === "string" ? args.flags["goal"] : undefined;
     const ttl = typeof args.flags["ttl"] === "string" ? parseInt(args.flags["ttl"], 10) : undefined;
-    const result = await client.sendMessage(to, text, {
-        replyTo,
-        topic,
-        goal,
-        ttlSec: ttl,
-        attachments: attachments.length > 0 ? attachments : undefined,
-        mentions: mentions.length > 0 ? mentions : undefined,
-    });
+    const msgType = typeof args.flags["type"] === "string" ? args.flags["type"] : "message";
+    let result;
+    if (msgType === "result" || msgType === "error") {
+        result = await client.sendTypedMessage(to, msgType, text, {
+            replyTo,
+            topic,
+            attachments: attachments.length > 0 ? attachments : undefined,
+        });
+    }
+    else {
+        result = await client.sendMessage(to, text, {
+            replyTo,
+            topic,
+            goal,
+            ttlSec: ttl,
+            attachments: attachments.length > 0 ? attachments : undefined,
+            mentions: mentions.length > 0 ? mentions : undefined,
+        });
+    }
     outputJson(result);
 }

--- a/cli/dist/commands/subscription.d.ts
+++ b/cli/dist/commands/subscription.d.ts
@@ -1,0 +1,2 @@
+import type { ParsedArgs } from "../args.js";
+export declare function subscriptionCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void>;

--- a/cli/dist/commands/subscription.js
+++ b/cli/dist/commands/subscription.js
@@ -1,0 +1,109 @@
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials } from "../credentials.js";
+import { outputJson, outputError } from "../output.js";
+export async function subscriptionCommand(args, globalHub, globalAgent) {
+    const sub = args.subcommand;
+    if (args.flags["help"] || !sub) {
+        console.log(`Usage: botcord subscription <subcommand> [options]
+
+Subcommands:
+  create-product    Create a subscription product
+                      --name <name> --amount <minor> --interval <week|month>
+                      [--description <text>] [--asset-code <code>]
+  list-products     List your own subscription products
+  list-all-products List all available subscription products
+  archive-product   Archive a subscription product --id <product_id>
+  subscribe         Subscribe to a product --product <product_id>
+                      [--idempotency-key <key>]
+  list              List your active subscriptions
+  subscribers       List subscribers of a product --product <product_id>
+  cancel            Cancel a subscription --id <subscription_id>`);
+        if (!sub && !args.flags["help"])
+            process.exit(1);
+        return;
+    }
+    const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+    const hubUrl = globalHub || creds.hubUrl;
+    const client = new BotCordClient({
+        hubUrl,
+        agentId: creds.agentId,
+        keyId: creds.keyId,
+        privateKey: creds.privateKey,
+        token: creds.token,
+        tokenExpiresAt: creds.tokenExpiresAt,
+    });
+    switch (sub) {
+        case "create-product": {
+            const name = args.flags["name"];
+            const amount = args.flags["amount"];
+            const interval = args.flags["interval"];
+            if (!name || typeof name !== "string")
+                outputError("--name is required");
+            if (!amount || typeof amount !== "string")
+                outputError("--amount is required");
+            if (interval !== "week" && interval !== "month")
+                outputError("--interval must be 'week' or 'month'");
+            const description = typeof args.flags["description"] === "string" ? args.flags["description"] : undefined;
+            const assetCode = typeof args.flags["asset-code"] === "string" ? args.flags["asset-code"] : undefined;
+            const result = await client.createSubscriptionProduct({
+                name,
+                amount_minor: amount,
+                billing_interval: interval,
+                description,
+                asset_code: assetCode,
+            });
+            outputJson(result);
+            break;
+        }
+        case "list-products": {
+            const result = await client.listMySubscriptionProducts();
+            outputJson(result);
+            break;
+        }
+        case "list-all-products": {
+            const result = await client.listSubscriptionProducts();
+            outputJson(result);
+            break;
+        }
+        case "archive-product": {
+            const id = args.flags["id"];
+            if (!id || typeof id !== "string")
+                outputError("--id is required");
+            const result = await client.archiveSubscriptionProduct(id);
+            outputJson(result);
+            break;
+        }
+        case "subscribe": {
+            const productId = args.flags["product"];
+            if (!productId || typeof productId !== "string")
+                outputError("--product is required");
+            const idempotencyKey = typeof args.flags["idempotency-key"] === "string" ? args.flags["idempotency-key"] : undefined;
+            const result = await client.subscribeToProduct(productId, idempotencyKey);
+            outputJson(result);
+            break;
+        }
+        case "list": {
+            const result = await client.listMySubscriptions();
+            outputJson(result);
+            break;
+        }
+        case "subscribers": {
+            const productId = args.flags["product"];
+            if (!productId || typeof productId !== "string")
+                outputError("--product is required");
+            const result = await client.listProductSubscribers(productId);
+            outputJson(result);
+            break;
+        }
+        case "cancel": {
+            const id = args.flags["id"];
+            if (!id || typeof id !== "string")
+                outputError("--id is required");
+            const result = await client.cancelSubscription(id);
+            outputJson(result);
+            break;
+        }
+        default:
+            outputError(`unknown subcommand: ${sub}`);
+    }
+}

--- a/cli/dist/commands/wallet.js
+++ b/cli/dist/commands/wallet.js
@@ -10,8 +10,13 @@ Subcommands:
   balance                          Show wallet balance
   ledger [--limit <n>] [--cursor <c>] [--type <type>]  Show ledger entries
   transfer --to <id> --amount <n> [--memo <text>]       Transfer funds
+           [--reference-type <type>] [--reference-id <id>]
+           [--metadata <json>] [--idempotency-key <key>]
   topup --amount <n>               Request a topup
-  withdraw --amount <n>            Request a withdrawal`);
+        [--channel <channel>] [--metadata <json>] [--idempotency-key <key>]
+  withdraw --amount <n>            Request a withdrawal
+           [--fee <minor>] [--destination-type <type>]
+           [--destination <json>] [--idempotency-key <key>]`);
         if (!sub && !args.flags["help"])
             process.exit(1);
         return;
@@ -48,10 +53,18 @@ Subcommands:
             if (!amount || typeof amount !== "string")
                 outputError("--amount is required");
             const memo = typeof args.flags["memo"] === "string" ? args.flags["memo"] : undefined;
+            const referenceType = typeof args.flags["reference-type"] === "string" ? args.flags["reference-type"] : undefined;
+            const referenceId = typeof args.flags["reference-id"] === "string" ? args.flags["reference-id"] : undefined;
+            const metadata = typeof args.flags["metadata"] === "string" ? JSON.parse(args.flags["metadata"]) : undefined;
+            const idempotencyKey = typeof args.flags["idempotency-key"] === "string" ? args.flags["idempotency-key"] : undefined;
             const result = await client.createTransfer({
                 to_agent_id: to,
                 amount_minor: amount,
                 memo,
+                reference_type: referenceType,
+                reference_id: referenceId,
+                metadata,
+                idempotency_key: idempotencyKey,
             });
             outputJson(result);
             break;
@@ -60,7 +73,15 @@ Subcommands:
             const amount = args.flags["amount"];
             if (!amount || typeof amount !== "string")
                 outputError("--amount is required");
-            const result = await client.createTopup({ amount_minor: amount });
+            const channel = typeof args.flags["channel"] === "string" ? args.flags["channel"] : undefined;
+            const metadata = typeof args.flags["metadata"] === "string" ? JSON.parse(args.flags["metadata"]) : undefined;
+            const idempotencyKey = typeof args.flags["idempotency-key"] === "string" ? args.flags["idempotency-key"] : undefined;
+            const result = await client.createTopup({
+                amount_minor: amount,
+                channel,
+                metadata,
+                idempotency_key: idempotencyKey,
+            });
             outputJson(result);
             break;
         }
@@ -68,7 +89,17 @@ Subcommands:
             const amount = args.flags["amount"];
             if (!amount || typeof amount !== "string")
                 outputError("--amount is required");
-            const result = await client.createWithdrawal({ amount_minor: amount });
+            const feeminor = typeof args.flags["fee"] === "string" ? args.flags["fee"] : undefined;
+            const destinationType = typeof args.flags["destination-type"] === "string" ? args.flags["destination-type"] : undefined;
+            const destination = typeof args.flags["destination"] === "string" ? JSON.parse(args.flags["destination"]) : undefined;
+            const idempotencyKey = typeof args.flags["idempotency-key"] === "string" ? args.flags["idempotency-key"] : undefined;
+            const result = await client.createWithdrawal({
+                amount_minor: amount,
+                fee_minor: feeminor,
+                destination_type: destinationType,
+                destination,
+                idempotency_key: idempotencyKey,
+            });
             outputJson(result);
             break;
         }

--- a/cli/dist/index.js
+++ b/cli/dist/index.js
@@ -15,6 +15,7 @@ import { contactRequestCommand } from "./commands/contact-request.js";
 import { blockCommand } from "./commands/block.js";
 import { inboxCommand } from "./commands/inbox.js";
 import { walletCommand } from "./commands/wallet.js";
+import { subscriptionCommand } from "./commands/subscription.js";
 const VERSION = "0.1.0";
 const HELP = `botcord — BotCord CLI v${VERSION}
 
@@ -35,6 +36,7 @@ Commands:
   resolve           Resolve agent info
   refresh           Refresh JWT token
   wallet            Wallet operations
+  subscription      Manage subscriptions
 
 Global options:
   --agent <id>      Use specific agent credentials
@@ -99,6 +101,9 @@ async function main() {
                 break;
             case "wallet":
                 await walletCommand(args, globalHub, globalAgent);
+                break;
+            case "subscription":
+                await subscriptionCommand(args, globalHub, globalAgent);
                 break;
             default:
                 outputError(`unknown command: ${args.command}. Run "botcord --help" for usage.`);

--- a/cli/dist/types.d.ts
+++ b/cli/dist/types.d.ts
@@ -166,6 +166,21 @@ export type WithdrawalResponse = {
     reviewed_at: string | null;
     completed_at: string | null;
 };
+export type BillingInterval = "week" | "month";
+export type SubscriptionProductStatus = "active" | "archived";
+export type SubscriptionStatus = "active" | "past_due" | "cancelled";
+export type SubscriptionChargeAttemptStatus = "pending" | "succeeded" | "failed";
+export type SubscriptionChargeAttempt = {
+    attempt_id: string;
+    subscription_id: string;
+    billing_cycle_key: string;
+    status: SubscriptionChargeAttemptStatus;
+    scheduled_at: string;
+    attempted_at: string | null;
+    tx_id: string | null;
+    failure_reason: string | null;
+    created_at: string;
+};
 export type SubscriptionProduct = {
     product_id: string;
     owner_agent_id: string;
@@ -173,8 +188,8 @@ export type SubscriptionProduct = {
     description: string;
     asset_code: string;
     amount_minor: string;
-    billing_interval: "week" | "month";
-    status: "active" | "archived";
+    billing_interval: BillingInterval;
+    status: SubscriptionProductStatus;
     created_at: string;
     updated_at: string;
     archived_at: string | null;
@@ -186,8 +201,8 @@ export type Subscription = {
     provider_agent_id: string;
     asset_code: string;
     amount_minor: string;
-    billing_interval: "week" | "month";
-    status: "active" | "past_due" | "cancelled";
+    billing_interval: BillingInterval;
+    status: SubscriptionStatus;
     current_period_start: string;
     current_period_end: string;
     next_charge_at: string;

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -21,6 +21,8 @@ import type {
   WalletLedgerResponse,
   TopupResponse,
   WithdrawalResponse,
+  SubscriptionProduct,
+  Subscription,
 } from "./types.js";
 
 const MAX_RETRIES = 2;
@@ -224,16 +226,75 @@ export class BotCordClient {
     return (await resp.json()) as SendResponse;
   }
 
+  async sendTypedMessage(
+    to: string,
+    type: "result" | "error",
+    text: string,
+    options?: { replyTo?: string; topic?: string; attachments?: MessageAttachment[] },
+  ): Promise<SendResponse> {
+    const payload: Record<string, unknown> =
+      type === "error" ? { error: { code: "agent_error", message: text } } : { text };
+    if (options?.attachments && options.attachments.length > 0) {
+      payload.attachments = options.attachments;
+    }
+
+    const envelope = buildSignedEnvelope({
+      from: this.agentId,
+      to,
+      type,
+      payload,
+      privateKey: this.privateKey,
+      keyId: this.keyId,
+      replyTo: options?.replyTo,
+      topic: options?.topic,
+    });
+
+    const topicQuery = options?.topic ? `?topic=${encodeURIComponent(options.topic)}` : "";
+    const resp = await this.hubFetch(`/hub/send${topicQuery}`, {
+      method: "POST",
+      body: JSON.stringify(envelope),
+    });
+    return (await resp.json()) as SendResponse;
+  }
+
+  async sendSystemMessage(
+    to: string,
+    text: string,
+    payload?: Record<string, unknown>,
+    options?: { topic?: string },
+  ): Promise<SendResponse> {
+    const envelope = buildSignedEnvelope({
+      from: this.agentId,
+      to,
+      type: "system",
+      payload: {
+        text,
+        ...(payload || {}),
+      },
+      privateKey: this.privateKey,
+      keyId: this.keyId,
+      topic: options?.topic,
+    });
+    const topicQuery = options?.topic ? `?topic=${encodeURIComponent(options.topic)}` : "";
+    const resp = await this.hubFetch(`/hub/send${topicQuery}`, {
+      method: "POST",
+      body: JSON.stringify(envelope),
+    });
+    return (await resp.json()) as SendResponse;
+  }
+
   // ── Inbox ─────────────────────────────────────────────────────
 
   async pollInbox(options?: {
     limit?: number;
     ack?: boolean;
+    timeout?: number;
     roomId?: string;
   }): Promise<InboxPollResponse> {
     const params = new URLSearchParams();
     if (options?.limit) params.set("limit", String(options.limit));
     if (options?.ack) params.set("ack", "true");
+    if (options?.timeout) params.set("timeout", String(options.timeout));
     if (options?.roomId) params.set("room_id", options.roomId);
 
     const resp = await this.hubFetch(`/hub/inbox?${params.toString()}`);
@@ -385,7 +446,11 @@ export class BotCordClient {
     rule?: string;
     visibility?: "private" | "public";
     join_policy?: "invite_only" | "open";
+    required_subscription_product_id?: string;
     max_members?: number;
+    default_send?: boolean;
+    default_invite?: boolean;
+    slow_mode_seconds?: number;
     member_ids?: string[];
   }): Promise<RoomInfo> {
     const resp = await this.hubFetch("/hub/rooms", {
@@ -405,10 +470,13 @@ export class BotCordClient {
     return (await resp.json()) as RoomInfo;
   }
 
-  async joinRoom(roomId: string): Promise<void> {
+  async joinRoom(
+    roomId: string,
+    options?: { can_send?: boolean; can_invite?: boolean },
+  ): Promise<void> {
     await this.hubFetch(`/hub/rooms/${roomId}/members`, {
       method: "POST",
-      body: JSON.stringify({ agent_id: this.agentId }),
+      body: JSON.stringify({ agent_id: this.agentId, ...options }),
     });
   }
 
@@ -416,10 +484,14 @@ export class BotCordClient {
     await this.hubFetch(`/hub/rooms/${roomId}/leave`, { method: "POST" });
   }
 
-  async inviteToRoom(roomId: string, agentId: string): Promise<void> {
+  async inviteToRoom(
+    roomId: string,
+    agentId: string,
+    options?: { can_send?: boolean; can_invite?: boolean },
+  ): Promise<void> {
     await this.hubFetch(`/hub/rooms/${roomId}/members`, {
       method: "POST",
-      body: JSON.stringify({ agent_id: agentId }),
+      body: JSON.stringify({ agent_id: agentId, ...options }),
     });
   }
 
@@ -434,9 +506,14 @@ export class BotCordClient {
     params: {
       name?: string;
       description?: string;
+      rule?: string | null;
       visibility?: string;
       join_policy?: string;
+      required_subscription_product_id?: string | null;
       max_members?: number | null;
+      default_send?: boolean;
+      default_invite?: boolean;
+      slow_mode_seconds?: number | null;
     },
   ): Promise<RoomInfo> {
     const resp = await this.hubFetch(`/hub/rooms/${roomId}`, {
@@ -557,6 +634,10 @@ export class BotCordClient {
     to_agent_id: string;
     amount_minor: string;
     memo?: string;
+    reference_type?: string;
+    reference_id?: string;
+    metadata?: Record<string, unknown>;
+    idempotency_key?: string;
   }): Promise<WalletTransaction> {
     const resp = await this.hubFetch("/wallet/transfers", {
       method: "POST",
@@ -567,6 +648,9 @@ export class BotCordClient {
 
   async createTopup(params: {
     amount_minor: string;
+    channel?: string;
+    metadata?: Record<string, unknown>;
+    idempotency_key?: string;
   }): Promise<TopupResponse> {
     const resp = await this.hubFetch("/wallet/topups", {
       method: "POST",
@@ -577,6 +661,10 @@ export class BotCordClient {
 
   async createWithdrawal(params: {
     amount_minor: string;
+    fee_minor?: string;
+    destination_type?: string;
+    destination?: Record<string, unknown>;
+    idempotency_key?: string;
   }): Promise<WithdrawalResponse> {
     const resp = await this.hubFetch("/wallet/withdrawals", {
       method: "POST",
@@ -595,6 +683,70 @@ export class BotCordClient {
       method: "POST",
     });
     return (await resp.json()) as WithdrawalResponse;
+  }
+
+  // ── Subscriptions ───────────────────────────────────────────
+
+  async createSubscriptionProduct(params: {
+    name: string;
+    description?: string;
+    amount_minor: string;
+    billing_interval: "week" | "month";
+    asset_code?: string;
+  }): Promise<SubscriptionProduct> {
+    const resp = await this.hubFetch("/subscriptions/products", {
+      method: "POST",
+      body: JSON.stringify(params),
+    });
+    return (await resp.json()) as SubscriptionProduct;
+  }
+
+  async listMySubscriptionProducts(): Promise<SubscriptionProduct[]> {
+    const resp = await this.hubFetch("/subscriptions/products/me");
+    const body = await resp.json();
+    return (body as any).products as SubscriptionProduct[];
+  }
+
+  async listSubscriptionProducts(): Promise<SubscriptionProduct[]> {
+    const resp = await this.hubFetch("/subscriptions/products");
+    const body = await resp.json();
+    return (body as any).products as SubscriptionProduct[];
+  }
+
+  async archiveSubscriptionProduct(productId: string): Promise<SubscriptionProduct> {
+    const resp = await this.hubFetch(`/subscriptions/products/${productId}/archive`, {
+      method: "POST",
+    });
+    return (await resp.json()) as SubscriptionProduct;
+  }
+
+  async subscribeToProduct(productId: string, idempotencyKey?: string): Promise<Subscription> {
+    const body: Record<string, string> = {};
+    if (idempotencyKey) body.idempotency_key = idempotencyKey;
+    const resp = await this.hubFetch(`/subscriptions/products/${productId}/subscribe`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+    return (await resp.json()) as Subscription;
+  }
+
+  async listMySubscriptions(): Promise<Subscription[]> {
+    const resp = await this.hubFetch("/subscriptions/me");
+    const body = await resp.json();
+    return (body as any).subscriptions as Subscription[];
+  }
+
+  async listProductSubscribers(productId: string): Promise<Subscription[]> {
+    const resp = await this.hubFetch(`/subscriptions/products/${productId}/subscribers`);
+    const body = await resp.json();
+    return (body as any).subscriptions as Subscription[];
+  }
+
+  async cancelSubscription(subscriptionId: string): Promise<Subscription> {
+    const resp = await this.hubFetch(`/subscriptions/${subscriptionId}/cancel`, {
+      method: "POST",
+    });
+    return (await resp.json()) as Subscription;
   }
 
   // ── Endpoint registration ─────────────────────────────────────

--- a/cli/src/commands/inbox.ts
+++ b/cli/src/commands/inbox.ts
@@ -12,7 +12,8 @@ Poll inbox for new messages.
 Options:
   --limit <n>       Maximum number of messages to return
   --ack             Acknowledge messages after retrieval
-  --room <room_id>  Filter by room ID`);
+  --room <room_id>  Filter by room ID
+  --timeout <sec>   Long-poll timeout in seconds`);
     return;
   }
 
@@ -31,7 +32,8 @@ Options:
   const limit = typeof args.flags["limit"] === "string" ? parseInt(args.flags["limit"], 10) : undefined;
   const ack = args.flags["ack"] === true;
   const roomId = typeof args.flags["room"] === "string" ? args.flags["room"] : undefined;
+  const timeout = typeof args.flags["timeout"] === "string" ? parseInt(args.flags["timeout"], 10) : undefined;
 
-  const result = await client.pollInbox({ limit, ack, roomId });
+  const result = await client.pollInbox({ limit, ack, roomId, timeout });
   outputJson(result);
 }

--- a/cli/src/commands/room.ts
+++ b/cli/src/commands/room.ts
@@ -23,14 +23,24 @@ export async function roomCommand(args: ParsedArgs, globalHub?: string, globalAg
 
 Subcommands:
   create        Create a new room
+                  --name <name> [--description <text>] [--rule <text>]
+                  [--visibility <private|public>] [--join-policy <invite_only|open>]
+                  [--max-members <n>] [--members <id1,id2>]
+                  [--default-send <true|false>] [--default-invite <true|false>]
+                  [--slow-mode <seconds>] [--subscription-product <product_id>]
   get <id>      Get room info
   list          List my rooms
   discover      Discover public rooms
   update        Update room settings
+                  --room <id> [--name <name>] [--description <text>] [--rule <text>]
+                  [--visibility <private|public>] [--join-policy <invite_only|open>]
+                  [--max-members <n>] [--default-send <true|false>]
+                  [--default-invite <true|false>] [--slow-mode <seconds>]
+                  [--subscription-product <product_id>]
   dissolve      Dissolve a room
-  join          Join a room
+  join          Join a room --room <id> [--can-send <true|false>] [--can-invite <true|false>]
   leave         Leave a room
-  add-member    Add a member to a room
+  add-member    Add a member --room <id> --id <agent_id> [--can-send <true|false>] [--can-invite <true|false>]
   remove-member Remove a member
   transfer      Transfer room ownership
   promote       Change member role
@@ -55,9 +65,14 @@ Subcommands:
       if (!name || typeof name !== "string") outputError("--name is required");
       const params: Record<string, unknown> = { name };
       if (typeof args.flags["description"] === "string") params.description = args.flags["description"];
+      if (typeof args.flags["rule"] === "string") params.rule = args.flags["rule"];
       if (typeof args.flags["visibility"] === "string") params.visibility = args.flags["visibility"];
       if (typeof args.flags["join-policy"] === "string") params.join_policy = args.flags["join-policy"];
+      if (typeof args.flags["subscription-product"] === "string") params.required_subscription_product_id = args.flags["subscription-product"];
       if (typeof args.flags["max-members"] === "string") params.max_members = parseInt(args.flags["max-members"], 10);
+      if (typeof args.flags["default-send"] === "string") params.default_send = args.flags["default-send"] === "true";
+      if (typeof args.flags["default-invite"] === "string") params.default_invite = args.flags["default-invite"] === "true";
+      if (typeof args.flags["slow-mode"] === "string") params.slow_mode_seconds = parseInt(args.flags["slow-mode"], 10);
       if (typeof args.flags["members"] === "string") params.member_ids = args.flags["members"].split(",");
       const result = await client.createRoom(params as any);
       outputJson(result);
@@ -91,8 +106,14 @@ Subcommands:
       const params: Record<string, unknown> = {};
       if (typeof args.flags["name"] === "string") params.name = args.flags["name"];
       if (typeof args.flags["description"] === "string") params.description = args.flags["description"];
+      if (typeof args.flags["rule"] === "string") params.rule = args.flags["rule"];
       if (typeof args.flags["visibility"] === "string") params.visibility = args.flags["visibility"];
       if (typeof args.flags["join-policy"] === "string") params.join_policy = args.flags["join-policy"];
+      if (typeof args.flags["subscription-product"] === "string") params.required_subscription_product_id = args.flags["subscription-product"];
+      if (typeof args.flags["max-members"] === "string") params.max_members = parseInt(args.flags["max-members"], 10);
+      if (typeof args.flags["default-send"] === "string") params.default_send = args.flags["default-send"] === "true";
+      if (typeof args.flags["default-invite"] === "string") params.default_invite = args.flags["default-invite"] === "true";
+      if (typeof args.flags["slow-mode"] === "string") params.slow_mode_seconds = parseInt(args.flags["slow-mode"], 10);
       const result = await client.updateRoom(roomId, params as any);
       outputJson(result);
       break;
@@ -109,7 +130,10 @@ Subcommands:
     case "join": {
       const roomId = args.flags["room"];
       if (!roomId || typeof roomId !== "string") outputError("--room is required");
-      await client.joinRoom(roomId);
+      const joinOpts: { can_send?: boolean; can_invite?: boolean } = {};
+      if (typeof args.flags["can-send"] === "string") joinOpts.can_send = args.flags["can-send"] === "true";
+      if (typeof args.flags["can-invite"] === "string") joinOpts.can_invite = args.flags["can-invite"] === "true";
+      await client.joinRoom(roomId, Object.keys(joinOpts).length > 0 ? joinOpts : undefined);
       outputJson({ joined: true, room_id: roomId });
       break;
     }
@@ -127,7 +151,10 @@ Subcommands:
       const agentId = args.flags["id"];
       if (!roomId || typeof roomId !== "string") outputError("--room is required");
       if (!agentId || typeof agentId !== "string") outputError("--id is required");
-      await client.inviteToRoom(roomId, agentId);
+      const inviteOpts: { can_send?: boolean; can_invite?: boolean } = {};
+      if (typeof args.flags["can-send"] === "string") inviteOpts.can_send = args.flags["can-send"] === "true";
+      if (typeof args.flags["can-invite"] === "string") inviteOpts.can_invite = args.flags["can-invite"] === "true";
+      await client.inviteToRoom(roomId, agentId, Object.keys(inviteOpts).length > 0 ? inviteOpts : undefined);
       outputJson({ added: true, room_id: roomId, agent_id: agentId });
       break;
     }

--- a/cli/src/commands/send.ts
+++ b/cli/src/commands/send.ts
@@ -14,6 +14,7 @@ Send a signed message to an agent or room.
 Options:
   --to <id>           Recipient agent or room ID (required)
   --text <msg>        Message text (required)
+  --type <type>       Message type: message, result, or error (default: message)
   --reply-to <id>     Reply to a specific message ID
   --topic <topic>     Topic name
   --goal <goal>       Goal description
@@ -80,15 +81,25 @@ Options:
   const topic = typeof args.flags["topic"] === "string" ? args.flags["topic"] : undefined;
   const goal = typeof args.flags["goal"] === "string" ? args.flags["goal"] : undefined;
   const ttl = typeof args.flags["ttl"] === "string" ? parseInt(args.flags["ttl"], 10) : undefined;
+  const msgType = typeof args.flags["type"] === "string" ? args.flags["type"] : "message";
 
-  const result = await client.sendMessage(to, text, {
-    replyTo,
-    topic,
-    goal,
-    ttlSec: ttl,
-    attachments: attachments.length > 0 ? attachments : undefined,
-    mentions: mentions.length > 0 ? mentions : undefined,
-  });
+  let result;
+  if (msgType === "result" || msgType === "error") {
+    result = await client.sendTypedMessage(to, msgType, text, {
+      replyTo,
+      topic,
+      attachments: attachments.length > 0 ? attachments : undefined,
+    });
+  } else {
+    result = await client.sendMessage(to, text, {
+      replyTo,
+      topic,
+      goal,
+      ttlSec: ttl,
+      attachments: attachments.length > 0 ? attachments : undefined,
+      mentions: mentions.length > 0 ? mentions : undefined,
+    });
+  }
 
   outputJson(result);
 }

--- a/cli/src/commands/subscription.ts
+++ b/cli/src/commands/subscription.ts
@@ -1,0 +1,115 @@
+import type { ParsedArgs } from "../args.js";
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials } from "../credentials.js";
+import { outputJson, outputError } from "../output.js";
+
+export async function subscriptionCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void> {
+  const sub = args.subcommand;
+
+  if (args.flags["help"] || !sub) {
+    console.log(`Usage: botcord subscription <subcommand> [options]
+
+Subcommands:
+  create-product    Create a subscription product
+                      --name <name> --amount <minor> --interval <week|month>
+                      [--description <text>] [--asset-code <code>]
+  list-products     List your own subscription products
+  list-all-products List all available subscription products
+  archive-product   Archive a subscription product --id <product_id>
+  subscribe         Subscribe to a product --product <product_id>
+                      [--idempotency-key <key>]
+  list              List your active subscriptions
+  subscribers       List subscribers of a product --product <product_id>
+  cancel            Cancel a subscription --id <subscription_id>`);
+    if (!sub && !args.flags["help"]) process.exit(1);
+    return;
+  }
+
+  const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+  const hubUrl = globalHub || creds.hubUrl;
+
+  const client = new BotCordClient({
+    hubUrl,
+    agentId: creds.agentId,
+    keyId: creds.keyId,
+    privateKey: creds.privateKey,
+    token: creds.token,
+    tokenExpiresAt: creds.tokenExpiresAt,
+  });
+
+  switch (sub) {
+    case "create-product": {
+      const name = args.flags["name"];
+      const amount = args.flags["amount"];
+      const interval = args.flags["interval"];
+      if (!name || typeof name !== "string") outputError("--name is required");
+      if (!amount || typeof amount !== "string") outputError("--amount is required");
+      if (interval !== "week" && interval !== "month") outputError("--interval must be 'week' or 'month'");
+      const description = typeof args.flags["description"] === "string" ? args.flags["description"] : undefined;
+      const assetCode = typeof args.flags["asset-code"] === "string" ? args.flags["asset-code"] : undefined;
+      const result = await client.createSubscriptionProduct({
+        name,
+        amount_minor: amount,
+        billing_interval: interval,
+        description,
+        asset_code: assetCode,
+      });
+      outputJson(result);
+      break;
+    }
+
+    case "list-products": {
+      const result = await client.listMySubscriptionProducts();
+      outputJson(result);
+      break;
+    }
+
+    case "list-all-products": {
+      const result = await client.listSubscriptionProducts();
+      outputJson(result);
+      break;
+    }
+
+    case "archive-product": {
+      const id = args.flags["id"];
+      if (!id || typeof id !== "string") outputError("--id is required");
+      const result = await client.archiveSubscriptionProduct(id);
+      outputJson(result);
+      break;
+    }
+
+    case "subscribe": {
+      const productId = args.flags["product"];
+      if (!productId || typeof productId !== "string") outputError("--product is required");
+      const idempotencyKey = typeof args.flags["idempotency-key"] === "string" ? args.flags["idempotency-key"] : undefined;
+      const result = await client.subscribeToProduct(productId, idempotencyKey);
+      outputJson(result);
+      break;
+    }
+
+    case "list": {
+      const result = await client.listMySubscriptions();
+      outputJson(result);
+      break;
+    }
+
+    case "subscribers": {
+      const productId = args.flags["product"];
+      if (!productId || typeof productId !== "string") outputError("--product is required");
+      const result = await client.listProductSubscribers(productId);
+      outputJson(result);
+      break;
+    }
+
+    case "cancel": {
+      const id = args.flags["id"];
+      if (!id || typeof id !== "string") outputError("--id is required");
+      const result = await client.cancelSubscription(id);
+      outputJson(result);
+      break;
+    }
+
+    default:
+      outputError(`unknown subcommand: ${sub}`);
+  }
+}

--- a/cli/src/commands/wallet.ts
+++ b/cli/src/commands/wallet.ts
@@ -13,8 +13,13 @@ Subcommands:
   balance                          Show wallet balance
   ledger [--limit <n>] [--cursor <c>] [--type <type>]  Show ledger entries
   transfer --to <id> --amount <n> [--memo <text>]       Transfer funds
+           [--reference-type <type>] [--reference-id <id>]
+           [--metadata <json>] [--idempotency-key <key>]
   topup --amount <n>               Request a topup
-  withdraw --amount <n>            Request a withdrawal`);
+        [--channel <channel>] [--metadata <json>] [--idempotency-key <key>]
+  withdraw --amount <n>            Request a withdrawal
+           [--fee <minor>] [--destination-type <type>]
+           [--destination <json>] [--idempotency-key <key>]`);
     if (!sub && !args.flags["help"]) process.exit(1);
     return;
   }
@@ -53,10 +58,18 @@ Subcommands:
       if (!to || typeof to !== "string") outputError("--to is required");
       if (!amount || typeof amount !== "string") outputError("--amount is required");
       const memo = typeof args.flags["memo"] === "string" ? args.flags["memo"] : undefined;
+      const referenceType = typeof args.flags["reference-type"] === "string" ? args.flags["reference-type"] : undefined;
+      const referenceId = typeof args.flags["reference-id"] === "string" ? args.flags["reference-id"] : undefined;
+      const metadata = typeof args.flags["metadata"] === "string" ? JSON.parse(args.flags["metadata"]) : undefined;
+      const idempotencyKey = typeof args.flags["idempotency-key"] === "string" ? args.flags["idempotency-key"] : undefined;
       const result = await client.createTransfer({
         to_agent_id: to,
         amount_minor: amount,
         memo,
+        reference_type: referenceType,
+        reference_id: referenceId,
+        metadata,
+        idempotency_key: idempotencyKey,
       });
       outputJson(result);
       break;
@@ -65,7 +78,15 @@ Subcommands:
     case "topup": {
       const amount = args.flags["amount"];
       if (!amount || typeof amount !== "string") outputError("--amount is required");
-      const result = await client.createTopup({ amount_minor: amount });
+      const channel = typeof args.flags["channel"] === "string" ? args.flags["channel"] : undefined;
+      const metadata = typeof args.flags["metadata"] === "string" ? JSON.parse(args.flags["metadata"]) : undefined;
+      const idempotencyKey = typeof args.flags["idempotency-key"] === "string" ? args.flags["idempotency-key"] : undefined;
+      const result = await client.createTopup({
+        amount_minor: amount,
+        channel,
+        metadata,
+        idempotency_key: idempotencyKey,
+      });
       outputJson(result);
       break;
     }
@@ -73,7 +94,17 @@ Subcommands:
     case "withdraw": {
       const amount = args.flags["amount"];
       if (!amount || typeof amount !== "string") outputError("--amount is required");
-      const result = await client.createWithdrawal({ amount_minor: amount });
+      const feeminor = typeof args.flags["fee"] === "string" ? args.flags["fee"] : undefined;
+      const destinationType = typeof args.flags["destination-type"] === "string" ? args.flags["destination-type"] : undefined;
+      const destination = typeof args.flags["destination"] === "string" ? JSON.parse(args.flags["destination"]) : undefined;
+      const idempotencyKey = typeof args.flags["idempotency-key"] === "string" ? args.flags["idempotency-key"] : undefined;
+      const result = await client.createWithdrawal({
+        amount_minor: amount,
+        fee_minor: feeminor,
+        destination_type: destinationType,
+        destination,
+        idempotency_key: idempotencyKey,
+      });
       outputJson(result);
       break;
     }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -15,6 +15,7 @@ import { contactRequestCommand } from "./commands/contact-request.js";
 import { blockCommand } from "./commands/block.js";
 import { inboxCommand } from "./commands/inbox.js";
 import { walletCommand } from "./commands/wallet.js";
+import { subscriptionCommand } from "./commands/subscription.js";
 
 const VERSION = "0.1.0";
 
@@ -37,6 +38,7 @@ Commands:
   resolve           Resolve agent info
   refresh           Refresh JWT token
   wallet            Wallet operations
+  subscription      Manage subscriptions
 
 Global options:
   --agent <id>      Use specific agent credentials
@@ -105,6 +107,9 @@ async function main(): Promise<void> {
         break;
       case "wallet":
         await walletCommand(args, globalHub, globalAgent);
+        break;
+      case "subscription":
+        await subscriptionCommand(args, globalHub, globalAgent);
         break;
       default:
         outputError(`unknown command: ${args.command}. Run "botcord --help" for usage.`);

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -196,6 +196,26 @@ export type WithdrawalResponse = {
   completed_at: string | null;
 };
 
+export type BillingInterval = "week" | "month";
+
+export type SubscriptionProductStatus = "active" | "archived";
+
+export type SubscriptionStatus = "active" | "past_due" | "cancelled";
+
+export type SubscriptionChargeAttemptStatus = "pending" | "succeeded" | "failed";
+
+export type SubscriptionChargeAttempt = {
+  attempt_id: string;
+  subscription_id: string;
+  billing_cycle_key: string;
+  status: SubscriptionChargeAttemptStatus;
+  scheduled_at: string;
+  attempted_at: string | null;
+  tx_id: string | null;
+  failure_reason: string | null;
+  created_at: string;
+};
+
 export type SubscriptionProduct = {
   product_id: string;
   owner_agent_id: string;
@@ -203,8 +223,8 @@ export type SubscriptionProduct = {
   description: string;
   asset_code: string;
   amount_minor: string;
-  billing_interval: "week" | "month";
-  status: "active" | "archived";
+  billing_interval: BillingInterval;
+  status: SubscriptionProductStatus;
   created_at: string;
   updated_at: string;
   archived_at: string | null;
@@ -217,8 +237,8 @@ export type Subscription = {
   provider_agent_id: string;
   asset_code: string;
   amount_minor: string;
-  billing_interval: "week" | "month";
-  status: "active" | "past_due" | "cancelled";
+  billing_interval: BillingInterval;
+  status: SubscriptionStatus;
   current_period_start: string;
   current_period_end: string;
   next_charge_at: string;


### PR DESCRIPTION
## Summary
- Align all CLI commands with plugin tool capabilities (plugin is source of truth)
- **room**: add `--rule`, `--default-send`, `--default-invite`, `--slow-mode`, `--subscription-product` to create/update; `--can-send`/`--can-invite` to join/add-member
- **send**: add `--type <message|result|error>` for topic completion signaling
- **wallet**: add `--reference-type`, `--reference-id`, `--metadata`, `--idempotency-key` to transfer; `--channel` to topup; `--fee`, `--destination-type`, `--destination` to withdraw
- **inbox**: add `--timeout` for long-polling
- **subscription**: new command with create-product, list-products, archive-product, subscribe, list, subscribers, cancel
- **client**: add `sendTypedMessage`, `sendSystemMessage`, all subscription methods; fix `joinRoom`/`inviteToRoom` to accept permission options

Follow-up to #68 — the fix commit was pushed after the PR was merged.

## Test plan
- [x] `tsc` compiles with zero errors
- [ ] Verify `botcord subscription --help` shows all subcommands
- [ ] Verify `botcord send --type result` routes to `sendTypedMessage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)