### PR TITLE
fix(ci): use highest beta base version, not just latest dist-tag

### DIFF
--- a/.github/workflows/publish-plugin.yml
+++ b/.github/workflows/publish-plugin.yml
@@ -56,13 +56,21 @@ jobs:
             # For beta: use the higher of package.json version and latest npm beta base
             LOCAL_VERSION=$(node -p "require('./package.json').version")
 
-            # Query npm for latest beta version, strip -beta.* suffix to get base
-            NPM_BETA=$(npm view @botcord/botcord dist-tags.beta 2>/dev/null || echo "")
-            if [ -n "$NPM_BETA" ]; then
-              NPM_BASE=$(echo "$NPM_BETA" | sed 's/-beta\..*//')
-            else
-              NPM_BASE="0.0.0"
-            fi
+            # Find highest base version among all published beta versions
+            # (dist-tags.beta only points to the most recently published, not the highest)
+            NPM_BASE=$(npm view @botcord/botcord versions --json 2>/dev/null | node -e "
+              const versions = JSON.parse(require('fs').readFileSync(0, 'utf8'));
+              const bases = versions
+                .filter(v => v.includes('-beta.'))
+                .map(v => v.replace(/-beta\..*/, ''));
+              if (bases.length === 0) { console.log('0.0.0'); process.exit(); }
+              bases.sort((a, b) => {
+                const [a1,a2,a3] = a.split('.').map(Number);
+                const [b1,b2,b3] = b.split('.').map(Number);
+                return (a1 - b1) || (a2 - b2) || (a3 - b3);
+              });
+              console.log(bases[bases.length - 1]);
+            " || echo "0.0.0")
 
             # Pick the higher version as the starting point
             HIGHER=$(node -e "


### PR DESCRIPTION
## Summary
- `dist-tags.beta` only points to the most recently published beta, not the highest version number
- This caused version regression: after publishing `0.2.1-beta`, a subsequent `patch` bump produced `0.1.4-beta` instead of `0.2.2-beta`
- Now queries all published versions, filters betas, and picks the highest base version

## Test plan
- [ ] Verify locally: `npm view @botcord/botcord versions --json` piped through the node script outputs `0.2.1`
- [ ] Trigger a beta `patch` publish — should produce `0.2.2-beta.xxx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)