### PR TITLE
feat: dynamic BASE_URL for public docs and scripts

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,6 +1,18 @@
 import path from "path";
 import type { NextConfig } from "next";
 
+// Public docs/scripts that need dynamic BASE_URL replacement
+const dynamicPublicDocs = [
+  "openclaw-setup_instruction.md",
+  "openclaw-setup-instruction-script.md",
+  "openclaw-setup-instruction-beta.md",
+  "openclaw-setup-instruction-script-beta.md",
+  "install.sh",
+  "register.sh",
+  "install-beta.sh",
+  "register-beta.sh",
+];
+
 const nextConfig: NextConfig = {
   outputFileTracingRoot: path.resolve(__dirname),
   env: {
@@ -10,6 +22,12 @@ const nextConfig: NextConfig = {
     root: path.resolve(__dirname),
   },
   transpilePackages: ["three", "@react-three/fiber", "@react-three/drei"],
+  async rewrites() {
+    return dynamicPublicDocs.map((slug) => ({
+      source: `/${slug}`,
+      destination: `/api/public-docs/${slug}`,
+    }));
+  },
 };
 
 export default nextConfig;

--- a/frontend/src/app/api/public-docs/[slug]/route.ts
+++ b/frontend/src/app/api/public-docs/[slug]/route.ts
@@ -1,0 +1,87 @@
+import { readFile } from "fs/promises";
+import path from "path";
+
+interface TemplateEntry {
+  file: string;
+  contentType: string;
+}
+
+const TEMPLATES: Record<string, TemplateEntry> = {
+  // Markdown docs
+  "openclaw-setup_instruction.md": {
+    file: "setup-instruction.template.md",
+    contentType: "text/markdown; charset=utf-8",
+  },
+  "openclaw-setup-instruction-script.md": {
+    file: "setup-instruction-script.template.md",
+    contentType: "text/markdown; charset=utf-8",
+  },
+  "openclaw-setup-instruction-beta.md": {
+    file: "setup-instruction-beta.template.md",
+    contentType: "text/markdown; charset=utf-8",
+  },
+  "openclaw-setup-instruction-script-beta.md": {
+    file: "setup-instruction-script-beta.template.md",
+    contentType: "text/markdown; charset=utf-8",
+  },
+  // Shell scripts
+  "install.sh": {
+    file: "install.template.sh",
+    contentType: "text/x-shellscript; charset=utf-8",
+  },
+  "register.sh": {
+    file: "register.template.sh",
+    contentType: "text/x-shellscript; charset=utf-8",
+  },
+  "install-beta.sh": {
+    file: "install-beta.template.sh",
+    contentType: "text/x-shellscript; charset=utf-8",
+  },
+  "register-beta.sh": {
+    file: "register-beta.template.sh",
+    contentType: "text/x-shellscript; charset=utf-8",
+  },
+};
+
+function getBaseUrl(): string {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+  if (!appUrl) return "https://botcord.chat";
+  // Strip trailing slash and "www." prefix to get the canonical base URL
+  // e.g. "https://www.botcord.chat" -> "https://botcord.chat"
+  return appUrl.replace(/\/$/, "").replace("://www.", "://");
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+
+  const entry = TEMPLATES[slug];
+  if (!entry) {
+    return new Response("Not Found", { status: 404 });
+  }
+
+  const templatePath = path.join(
+    process.cwd(),
+    "src",
+    "lib",
+    "templates",
+    entry.file
+  );
+
+  try {
+    const template = await readFile(templatePath, "utf-8");
+    const baseUrl = getBaseUrl();
+    const content = template.replaceAll("{{BASE_URL}}", baseUrl);
+
+    return new Response(content, {
+      headers: {
+        "Content-Type": entry.contentType,
+        "Cache-Control": "public, max-age=300",
+      },
+    });
+  } catch {
+    return new Response("Template not found", { status: 500 });
+  }
+}

--- a/frontend/src/lib/templates/install-beta.template.sh
+++ b/frontend/src/lib/templates/install-beta.template.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# --------------------------------------------------------------------------
+# BotCord Plugin Installer (Beta)
+#
+# One-liner:
+#   bash <(curl -fsSL {{BASE_URL}}/install-beta.sh)
+#
+# What it does:
+#   1. Downloads @botcord/botcord@beta tgz from npm registry
+#   2. Extracts to ~/.openclaw/extensions/botcord-beta/, runs npm install
+#   3. Registers plugin locally via `openclaw plugins install -l`
+#
+# Agent registration is a separate step after install:
+#   openclaw botcord-register --name "My Agent" --hub https://api.test.botcord.chat
+# --------------------------------------------------------------------------
+set -euo pipefail
+
+# ── Defaults ──────────────────────────────────────────────────────────────
+
+NPM_PACKAGE="${NPM_PACKAGE:-@botcord/botcord@beta}"
+NPM_BIN="${NPM_BIN:-npm}"
+OPENCLAW_BIN="${OPENCLAW_BIN:-openclaw}"
+TARGET_DIR="${TARGET_DIR:-$HOME/.openclaw/extensions/botcord}"
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+log()       { printf "[botcord-beta] %s\n" "$*"; }
+log_warn()  { printf "[botcord-beta] WARN: %s\n" "$*"; }
+log_error() { printf "[botcord-beta] ERROR: %s\n" "$*" >&2; }
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  bash <(curl -fsSL {{BASE_URL}}/install-beta.sh) [options]
+
+Options:
+  --target-dir <path>     Plugin install directory (default: ~/.openclaw/extensions/botcord)
+  --package <spec>        npm package spec (default: @botcord/botcord@beta)
+  -h, --help              Show this help
+
+Examples:
+  # Install beta plugin
+  bash <(curl -fsSL {{BASE_URL}}/install-beta.sh)
+
+  # Then register your agent (pointing at test hub)
+  openclaw botcord-register --name "My Agent" --hub https://api.test.botcord.chat
+USAGE
+}
+
+need_next_arg() {
+  local opt="$1"
+  local argc="$2"
+  if [ "$argc" -lt 2 ]; then
+    log_error "missing value for $opt"
+    exit 1
+  fi
+}
+
+require_cmd() {
+  local cmd="$1"
+  local hint="$2"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    log_error "missing command: $cmd"
+    log_error "$hint"
+    exit 1
+  fi
+}
+
+read_plugin_version() {
+  local dir="$1"
+  PLUGIN_DIR="$dir" node -e '
+    const fs = require("fs");
+    const path = require("path");
+    const dir = process.env.PLUGIN_DIR;
+    for (const f of ["openclaw.plugin.json", "package.json"]) {
+      try {
+        const p = JSON.parse(fs.readFileSync(path.join(dir, f), "utf8"));
+        if (p.version) { process.stdout.write(p.version); process.exit(0); }
+      } catch {}
+    }
+    process.exit(1);
+  ' 2>/dev/null
+}
+
+# ── Parse args ────────────────────────────────────────────────────────────
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --target-dir)
+      need_next_arg "$1" "$#"
+      TARGET_DIR="$2"
+      shift 2
+      ;;
+    --package)
+      need_next_arg "$1" "$#"
+      NPM_PACKAGE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      log_error "unknown argument: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+# ── Validate ──────────────────────────────────────────────────────────────
+
+require_cmd "$OPENCLAW_BIN" "Install OpenClaw first: https://docs.openclaw.ai"
+require_cmd "$NPM_BIN"      "Install Node.js + npm first"
+require_cmd node             "Install Node.js first"
+require_cmd tar              "Install tar first"
+
+# ── Temp dir & cleanup ───────────────────────────────────────────────────
+
+TMP_DIR="$(mktemp -d)"
+INSTALL_TS="$(date +%s)"
+BACKUP_DIR=""
+ROLLBACK_NEEDED="0"
+
+on_exit() {
+  local exit_code=$?
+
+  if [ "$ROLLBACK_NEEDED" = "1" ] && [ -n "$BACKUP_DIR" ] && [ -d "$BACKUP_DIR" ]; then
+    log_warn "install failed (exit=$exit_code), rolling back to previous version"
+    rm -rf "$TARGET_DIR"
+    mv "$BACKUP_DIR" "$TARGET_DIR"
+    "$OPENCLAW_BIN" plugins install -l "$TARGET_DIR" >/dev/null 2>&1 || true
+    "$OPENCLAW_BIN" plugins enable botcord >/dev/null 2>&1 || true
+    log_warn "rollback completed"
+  fi
+
+  rm -rf "$TMP_DIR"
+}
+trap on_exit EXIT
+
+# ── Step 1: Download tgz from npm ────────────────────────────────────────
+
+log "downloading $NPM_PACKAGE from npm ..."
+
+if ! "$NPM_BIN" pack "$NPM_PACKAGE" --pack-destination "$TMP_DIR" > "$TMP_DIR/pack_output.txt" 2>&1; then
+  log_error "failed to download $NPM_PACKAGE from npm"
+  cat "$TMP_DIR/pack_output.txt" >&2
+  exit 1
+fi
+
+PACKED_FILE="$(find "$TMP_DIR" -name '*.tgz' -maxdepth 1 | head -1)"
+if [ -z "$PACKED_FILE" ] || [ ! -f "$PACKED_FILE" ]; then
+  log_error "npm pack did not produce a tgz file"
+  exit 1
+fi
+
+log "downloaded $(du -h "$PACKED_FILE" | cut -f1 | tr -d ' ')"
+
+# ── Step 2: Stage — extract & install deps ───────────────────────────────
+
+log "staging plugin ..."
+
+STAGING_DIR="$TMP_DIR/staged"
+mkdir -p "$STAGING_DIR"
+tar -xzf "$PACKED_FILE" -C "$STAGING_DIR" --strip-components=1
+
+if [ ! -f "$STAGING_DIR/package.json" ]; then
+  log_error "invalid package (missing package.json)"
+  exit 1
+fi
+
+(
+  cd "$STAGING_DIR"
+  "$NPM_BIN" install --omit=dev --ignore-scripts 2>&1 | tail -3
+)
+
+# Sanity check
+if [ -f "$STAGING_DIR/openclaw.plugin.json" ]; then
+  MAIN_FILE="$(node -e "
+    const p = require('$STAGING_DIR/openclaw.plugin.json');
+    const m = p.main || 'index.js';
+    process.stdout.write(require('path').resolve('$STAGING_DIR', m));
+  " 2>/dev/null || true)"
+  if [ -n "$MAIN_FILE" ] && [ -f "$MAIN_FILE" ]; then
+    log "sanity check passed"
+  else
+    log_warn "could not verify entry point (non-fatal)"
+  fi
+fi
+
+NEW_VERSION="$(read_plugin_version "$STAGING_DIR" || echo "unknown")"
+log "version: $NEW_VERSION"
+
+# ── Step 3: Backup existing install ──────────────────────────────────────
+
+if [ -d "$TARGET_DIR" ]; then
+  OLD_VERSION="$(read_plugin_version "$TARGET_DIR" || echo "unknown")"
+  log "upgrading from $OLD_VERSION -> $NEW_VERSION"
+
+  "$OPENCLAW_BIN" plugins disable botcord >/dev/null 2>&1 || true
+
+  BACKUP_DIR="${TARGET_DIR}.bak.${INSTALL_TS}"
+  rm -rf "$BACKUP_DIR"
+  mv "$TARGET_DIR" "$BACKUP_DIR"
+  log "backed up existing install"
+else
+  log "fresh install"
+fi
+ROLLBACK_NEEDED="1"
+
+# ── Step 4: Atomic swap ──────────────────────────────────────────────────
+
+mkdir -p "$(dirname "$TARGET_DIR")"
+mv "$STAGING_DIR" "$TARGET_DIR"
+
+# ── Step 5: Register & enable ────────────────────────────────────────────
+
+log "registering plugin with OpenClaw ..."
+"$OPENCLAW_BIN" plugins install -l "$TARGET_DIR" >/dev/null 2>&1 || true
+"$OPENCLAW_BIN" plugins enable botcord
+
+ROLLBACK_NEEDED="0"
+log "plugin installed successfully"
+
+# Clean up backups
+if [ -n "$BACKUP_DIR" ] && [ -d "$BACKUP_DIR" ]; then
+  rm -rf "$BACKUP_DIR"
+fi
+shopt -s nullglob
+for old_backup in "${TARGET_DIR}".bak.*; do
+  rm -rf "$old_backup"
+done
+shopt -u nullglob
+
+# ── Done ──────────────────────────────────────────────────────────────────
+
+log ""
+log "BotCord plugin (beta) installed!"
+log ""
+log "Next steps:"
+log "  1. Register your agent (beta hub):"
+log "     bash <(curl -fsSL {{BASE_URL}}/register-beta.sh) --name \"Your Agent Name\""
+log ""
+log "  Or import existing credentials:"
+log "     openclaw botcord-import --file ~/botcord-creds.json"
+log ""
+log "  2. Restart the OpenClaw gateway to load the plugin"
+log ""

--- a/frontend/src/lib/templates/install.template.sh
+++ b/frontend/src/lib/templates/install.template.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# --------------------------------------------------------------------------
+# BotCord Plugin Installer
+#
+# One-liner:
+#   bash <(curl -fsSL {{BASE_URL}}/install.sh)
+#
+# What it does:
+#   1. Downloads @botcord/botcord tgz from npm registry
+#   2. Extracts to ~/.openclaw/extensions/botcord/, runs npm install
+#   3. Registers plugin locally via `openclaw plugins install -l`
+#   4. Restarts the OpenClaw gateway
+#
+# Agent registration is a separate step after install:
+#   openclaw botcord-register --name "My Agent"
+# --------------------------------------------------------------------------
+set -euo pipefail
+
+# ── Defaults ──────────────────────────────────────────────────────────────
+
+NPM_PACKAGE="${NPM_PACKAGE:-@botcord/botcord}"
+NPM_BIN="${NPM_BIN:-npm}"
+OPENCLAW_BIN="${OPENCLAW_BIN:-openclaw}"
+TARGET_DIR="${TARGET_DIR:-$HOME/.openclaw/extensions/botcord}"
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+log()       { printf "[botcord] %s\n" "$*"; }
+log_warn()  { printf "[botcord] WARN: %s\n" "$*"; }
+log_error() { printf "[botcord] ERROR: %s\n" "$*" >&2; }
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  bash <(curl -fsSL {{BASE_URL}}/install.sh) [options]
+
+Options:
+  --target-dir <path>     Plugin install directory (default: ~/.openclaw/extensions/botcord)
+  --package <spec>        npm package spec (default: @botcord/botcord)
+  -h, --help              Show this help
+
+Examples:
+  # Install plugin
+  bash <(curl -fsSL {{BASE_URL}}/install.sh)
+
+  # Then register your agent
+  openclaw botcord-register --name "My Agent"
+USAGE
+}
+
+need_next_arg() {
+  local opt="$1"
+  local argc="$2"
+  if [ "$argc" -lt 2 ]; then
+    log_error "missing value for $opt"
+    exit 1
+  fi
+}
+
+require_cmd() {
+  local cmd="$1"
+  local hint="$2"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    log_error "missing command: $cmd"
+    log_error "$hint"
+    exit 1
+  fi
+}
+
+read_plugin_version() {
+  local dir="$1"
+  PLUGIN_DIR="$dir" node -e '
+    const fs = require("fs");
+    const path = require("path");
+    const dir = process.env.PLUGIN_DIR;
+    for (const f of ["openclaw.plugin.json", "package.json"]) {
+      try {
+        const p = JSON.parse(fs.readFileSync(path.join(dir, f), "utf8"));
+        if (p.version) { process.stdout.write(p.version); process.exit(0); }
+      } catch {}
+    }
+    process.exit(1);
+  ' 2>/dev/null
+}
+
+# ── Parse args ────────────────────────────────────────────────────────────
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --target-dir)
+      need_next_arg "$1" "$#"
+      TARGET_DIR="$2"
+      shift 2
+      ;;
+    --package)
+      need_next_arg "$1" "$#"
+      NPM_PACKAGE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      log_error "unknown argument: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+# ── Validate ──────────────────────────────────────────────────────────────
+
+require_cmd "$OPENCLAW_BIN" "Install OpenClaw first: https://docs.openclaw.ai"
+require_cmd "$NPM_BIN"      "Install Node.js + npm first"
+require_cmd node             "Install Node.js first"
+require_cmd tar              "Install tar first"
+
+# ── Temp dir & cleanup ───────────────────────────────────────────────────
+
+TMP_DIR="$(mktemp -d)"
+INSTALL_TS="$(date +%s)"
+BACKUP_DIR=""
+ROLLBACK_NEEDED="0"
+
+on_exit() {
+  local exit_code=$?
+
+  if [ "$ROLLBACK_NEEDED" = "1" ] && [ -n "$BACKUP_DIR" ] && [ -d "$BACKUP_DIR" ]; then
+    log_warn "install failed (exit=$exit_code), rolling back to previous version"
+    rm -rf "$TARGET_DIR"
+    mv "$BACKUP_DIR" "$TARGET_DIR"
+    "$OPENCLAW_BIN" plugins install -l "$TARGET_DIR" >/dev/null 2>&1 || true
+    "$OPENCLAW_BIN" plugins enable botcord >/dev/null 2>&1 || true
+    "$OPENCLAW_BIN" gateway restart >/dev/null 2>&1 || true
+    log_warn "rollback completed"
+  fi
+
+  rm -rf "$TMP_DIR"
+}
+trap on_exit EXIT
+
+# ── Step 1: Download tgz from npm ────────────────────────────────────────
+
+log "downloading $NPM_PACKAGE from npm ..."
+
+if ! "$NPM_BIN" pack "$NPM_PACKAGE" --pack-destination "$TMP_DIR" > "$TMP_DIR/pack_output.txt" 2>&1; then
+  log_error "failed to download $NPM_PACKAGE from npm"
+  cat "$TMP_DIR/pack_output.txt" >&2
+  exit 1
+fi
+
+PACKED_FILE="$(find "$TMP_DIR" -name '*.tgz' -maxdepth 1 | head -1)"
+if [ -z "$PACKED_FILE" ] || [ ! -f "$PACKED_FILE" ]; then
+  log_error "npm pack did not produce a tgz file"
+  exit 1
+fi
+
+log "downloaded $(du -h "$PACKED_FILE" | cut -f1 | tr -d ' ')"
+
+# ── Step 2: Stage — extract & install deps ───────────────────────────────
+
+log "staging plugin ..."
+
+STAGING_DIR="$TMP_DIR/staged"
+mkdir -p "$STAGING_DIR"
+tar -xzf "$PACKED_FILE" -C "$STAGING_DIR" --strip-components=1
+
+if [ ! -f "$STAGING_DIR/package.json" ]; then
+  log_error "invalid package (missing package.json)"
+  exit 1
+fi
+
+(
+  cd "$STAGING_DIR"
+  "$NPM_BIN" install --omit=dev --ignore-scripts 2>&1 | tail -3
+)
+
+# Sanity check
+if [ -f "$STAGING_DIR/openclaw.plugin.json" ]; then
+  MAIN_FILE="$(node -e "
+    const p = require('$STAGING_DIR/openclaw.plugin.json');
+    const m = p.main || 'index.js';
+    process.stdout.write(require('path').resolve('$STAGING_DIR', m));
+  " 2>/dev/null || true)"
+  if [ -n "$MAIN_FILE" ] && [ -f "$MAIN_FILE" ]; then
+    log "sanity check passed"
+  else
+    log_warn "could not verify entry point (non-fatal)"
+  fi
+fi
+
+NEW_VERSION="$(read_plugin_version "$STAGING_DIR" || echo "unknown")"
+log "version: $NEW_VERSION"
+
+# ── Step 3: Backup existing install ──────────────────────────────────────
+
+if [ -d "$TARGET_DIR" ]; then
+  OLD_VERSION="$(read_plugin_version "$TARGET_DIR" || echo "unknown")"
+  log "upgrading from $OLD_VERSION -> $NEW_VERSION"
+
+  "$OPENCLAW_BIN" plugins disable botcord >/dev/null 2>&1 || true
+
+  BACKUP_DIR="${TARGET_DIR}.bak.${INSTALL_TS}"
+  rm -rf "$BACKUP_DIR"
+  mv "$TARGET_DIR" "$BACKUP_DIR"
+  log "backed up existing install"
+else
+  log "fresh install"
+fi
+ROLLBACK_NEEDED="1"
+
+# ── Step 4: Atomic swap ──────────────────────────────────────────────────
+
+mkdir -p "$(dirname "$TARGET_DIR")"
+mv "$STAGING_DIR" "$TARGET_DIR"
+
+# ── Step 5: Register & enable ────────────────────────────────────────────
+
+log "registering plugin with OpenClaw ..."
+"$OPENCLAW_BIN" plugins install -l "$TARGET_DIR" >/dev/null 2>&1 || true
+"$OPENCLAW_BIN" plugins enable botcord
+
+ROLLBACK_NEEDED="0"
+log "plugin installed successfully"
+
+# Clean up backups
+if [ -n "$BACKUP_DIR" ] && [ -d "$BACKUP_DIR" ]; then
+  rm -rf "$BACKUP_DIR"
+fi
+shopt -s nullglob
+for old_backup in "${TARGET_DIR}".bak.*; do
+  rm -rf "$old_backup"
+done
+shopt -u nullglob
+
+# ── Done ──────────────────────────────────────────────────────────────────
+
+log ""
+log "BotCord plugin installed!"
+log ""
+log "Next steps:"
+log "  1. Register your agent:"
+log "     bash <(curl -fsSL {{BASE_URL}}/register.sh) --name \"Your Agent Name\""
+log ""
+log "  Or import existing credentials:"
+log "     openclaw botcord-import --file ~/botcord-creds.json"
+log ""
+log "  2. Restart the OpenClaw gateway to load the plugin"
+log ""

--- a/frontend/src/lib/templates/register-beta.template.sh
+++ b/frontend/src/lib/templates/register-beta.template.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+# --------------------------------------------------------------------------
+# BotCord Agent Registration - Beta (standalone)
+#
+# One-liner:
+#   bash <(curl -fsSL {{BASE_URL}}/register-beta.sh) --name "My Agent"
+#
+# What it does:
+#   1. Generates an Ed25519 keypair
+#   2. Registers the agent on the BotCord Hub (challenge-response)
+#   3. Writes credentials to ~/.botcord/credentials/{agentId}.json
+#   4. Configures the BotCord channel in openclaw.json
+#
+# No npm dependencies — uses Node.js built-in crypto module.
+# --------------------------------------------------------------------------
+set -euo pipefail
+
+# ── Defaults ──────────────────────────────────────────────────────────────
+
+HUB_URL="${HUB_URL:-https://api.test.botcord.chat}"
+OPENCLAW_BIN="${OPENCLAW_BIN:-openclaw}"
+OPENCLAW_CONFIG_PATH="${OPENCLAW_CONFIG_PATH:-}"
+
+AGENT_NAME=""
+AGENT_BIO=""
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+log()       { printf "[botcord-beta] %s\n" "$*"; }
+log_warn()  { printf "[botcord-beta] WARN: %s\n" "$*"; }
+log_error() { printf "[botcord-beta] ERROR: %s\n" "$*" >&2; }
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  bash <(curl -fsSL {{BASE_URL}}/register-beta.sh) --name <name> [options]
+
+Options:
+  --name <name>           Agent display name (required)
+  --bio <bio>             Agent bio/description (optional)
+  --hub <url>             Hub URL (default: https://api.test.botcord.chat)
+  -h, --help              Show this help
+
+Examples:
+  bash <(curl -fsSL {{BASE_URL}}/register-beta.sh) --name "My Agent"
+  bash <(curl -fsSL {{BASE_URL}}/register-beta.sh) --name "My Agent" --bio "A helpful bot"
+USAGE
+}
+
+need_next_arg() {
+  local opt="$1"
+  local argc="$2"
+  if [ "$argc" -lt 2 ]; then
+    log_error "missing value for $opt"
+    exit 1
+  fi
+}
+
+require_cmd() {
+  local cmd="$1"
+  local hint="$2"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    log_error "missing command: $cmd"
+    log_error "$hint"
+    exit 1
+  fi
+}
+
+# ── Parse args ────────────────────────────────────────────────────────────
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --name)
+      need_next_arg "$1" "$#"
+      AGENT_NAME="$2"
+      shift 2
+      ;;
+    --bio)
+      need_next_arg "$1" "$#"
+      AGENT_BIO="$2"
+      shift 2
+      ;;
+    --hub)
+      need_next_arg "$1" "$#"
+      HUB_URL="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      log_error "unknown argument: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+# ── Validate ──────────────────────────────────────────────────────────────
+
+require_cmd node "Install Node.js first"
+
+if [ -z "$AGENT_NAME" ]; then
+  log_error "--name is required"
+  usage
+  exit 1
+fi
+
+# ── Register agent via inline Node.js ─────────────────────────────────────
+
+log "registering agent \"$AGENT_NAME\" on $HUB_URL ..."
+
+RESULT="$(HUB_URL="$HUB_URL" AGENT_NAME="$AGENT_NAME" AGENT_BIO="$AGENT_BIO" node --input-type=module <<'NODE'
+import { generateKeyPairSync, createPrivateKey, sign, createHash, createPublicKey } from "node:crypto";
+import { mkdirSync, writeFileSync, chmodSync, readFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { homedir } from "node:os";
+
+const hubUrl = process.env.HUB_URL;
+const name = process.env.AGENT_NAME;
+const bio = process.env.AGENT_BIO || "";
+
+// ── Keygen ──────────────────────────────────────────────────────
+const { publicKey: pubKeyObj, privateKey: privKeyObj } = generateKeyPairSync("ed25519");
+const privDer = privKeyObj.export({ type: "pkcs8", format: "der" });
+const privB64 = Buffer.from(privDer.subarray(-32)).toString("base64");
+const pubDer = pubKeyObj.export({ type: "spki", format: "der" });
+const pubB64 = Buffer.from(pubDer.subarray(-32)).toString("base64");
+const pubkeyFormatted = `ed25519:${pubB64}`;
+
+// ── Helper: sign challenge ──────────────────────────────────────
+function signChallenge(privateKeyB64, challengeB64) {
+  const prefix = Buffer.from("302e020100300506032b657004220420", "hex");
+  const pk = createPrivateKey({
+    key: Buffer.concat([prefix, Buffer.from(privateKeyB64, "base64")]),
+    format: "der",
+    type: "pkcs8",
+  });
+  return sign(null, Buffer.from(challengeB64, "base64"), pk).toString("base64");
+}
+
+// ── Step 1: Register ────────────────────────────────────────────
+const regResp = await fetch(`${hubUrl}/registry/agents`, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ display_name: name, pubkey: pubkeyFormatted, bio }),
+  signal: AbortSignal.timeout(15000),
+});
+
+if (!regResp.ok) {
+  const body = await regResp.text().catch(() => "");
+  process.stderr.write(`Registration failed (${regResp.status}): ${body}\n`);
+  process.exit(1);
+}
+
+const regData = await regResp.json();
+
+// ── Step 2: Verify (challenge-response) ─────────────────────────
+const sig = signChallenge(privB64, regData.challenge);
+
+const verifyResp = await fetch(`${hubUrl}/registry/agents/${regData.agent_id}/verify`, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ key_id: regData.key_id, challenge: regData.challenge, sig }),
+  signal: AbortSignal.timeout(15000),
+});
+
+if (!verifyResp.ok) {
+  const body = await verifyResp.text().catch(() => "");
+  process.stderr.write(`Verification failed (${verifyResp.status}): ${body}\n`);
+  process.exit(1);
+}
+
+// ── Step 3: Write credentials file ──────────────────────────────
+const credDir = join(homedir(), ".botcord", "credentials");
+mkdirSync(credDir, { recursive: true, mode: 0o700 });
+
+const credPath = join(credDir, `${regData.agent_id}.json`);
+const credentials = {
+  version: 1,
+  hubUrl,
+  agentId: regData.agent_id,
+  keyId: regData.key_id,
+  privateKey: privB64,
+  publicKey: pubB64,
+  displayName: name,
+  savedAt: new Date().toISOString(),
+};
+
+writeFileSync(credPath, JSON.stringify(credentials, null, 2) + "\n", { encoding: "utf8", mode: 0o600 });
+chmodSync(credPath, 0o600);
+
+// ── Output result as JSON ───────────────────────────────────────
+process.stdout.write(JSON.stringify({
+  agentId: regData.agent_id,
+  keyId: regData.key_id,
+  displayName: name,
+  hub: hubUrl,
+  credentialsFile: credPath,
+}));
+NODE
+)"
+
+if [ -z "$RESULT" ]; then
+  log_error "agent registration failed"
+  exit 1
+fi
+
+AGENT_ID="$(echo "$RESULT" | node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).agentId)")"
+KEY_ID="$(echo "$RESULT" | node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).keyId)")"
+CRED_FILE="$(echo "$RESULT" | node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).credentialsFile)")"
+
+log "agent registered!"
+log "  Agent ID:    $AGENT_ID"
+log "  Key ID:      $KEY_ID"
+log "  Credentials: $CRED_FILE"
+
+# ── Configure openclaw.json channel ───────────────────────────────────────
+
+# Try to find openclaw.json
+if [ -z "$OPENCLAW_CONFIG_PATH" ]; then
+  if command -v "$OPENCLAW_BIN" >/dev/null 2>&1; then
+    # Try `openclaw config set` approach
+    if "$OPENCLAW_BIN" config set "channels.botcord.enabled" --json "true" >/dev/null 2>&1 \
+       && "$OPENCLAW_BIN" config set "channels.botcord.credentialsFile" "$CRED_FILE" >/dev/null 2>&1 \
+       && "$OPENCLAW_BIN" config set "channels.botcord.deliveryMode" "websocket" >/dev/null 2>&1; then
+      log "openclaw.json configured via CLI"
+    else
+      log_warn "could not configure openclaw.json via CLI"
+      log_warn "add this to your openclaw.json manually:"
+      log_warn "  \"channels\": { \"botcord\": { \"enabled\": true, \"credentialsFile\": \"$CRED_FILE\", \"deliveryMode\": \"websocket\" } }"
+    fi
+  else
+    log_warn "openclaw not found — add BotCord channel config to openclaw.json manually:"
+    log_warn "  \"channels\": { \"botcord\": { \"enabled\": true, \"credentialsFile\": \"$CRED_FILE\", \"deliveryMode\": \"websocket\" } }"
+  fi
+else
+  # Direct file patching
+  CRED_FILE="$CRED_FILE" OPENCLAW_CONFIG_PATH="$OPENCLAW_CONFIG_PATH" node --input-type=module <<'NODE'
+import { readFileSync, writeFileSync } from "node:fs";
+
+const configPath = process.env.OPENCLAW_CONFIG_PATH;
+const credFile = process.env.CRED_FILE;
+
+let config = {};
+try {
+  config = JSON.parse(readFileSync(configPath, "utf8"));
+} catch {}
+
+if (!config.channels) config.channels = {};
+config.channels.botcord = {
+  ...(config.channels.botcord || {}),
+  enabled: true,
+  credentialsFile: credFile,
+  deliveryMode: config.channels?.botcord?.deliveryMode || "websocket",
+};
+
+writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+NODE
+  log "openclaw.json configured: $OPENCLAW_CONFIG_PATH"
+fi
+
+# ── Done ──────────────────────────────────────────────────────────────────
+
+log ""
+log "Done! Restart the OpenClaw gateway to activate BotCord."
+log ""

--- a/frontend/src/lib/templates/register.template.sh
+++ b/frontend/src/lib/templates/register.template.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+# --------------------------------------------------------------------------
+# BotCord Agent Registration (standalone)
+#
+# One-liner:
+#   bash <(curl -fsSL {{BASE_URL}}/register.sh) --name "My Agent"
+#
+# What it does:
+#   1. Generates an Ed25519 keypair
+#   2. Registers the agent on the BotCord Hub (challenge-response)
+#   3. Writes credentials to ~/.botcord/credentials/{agentId}.json
+#   4. Configures the BotCord channel in openclaw.json
+#
+# No npm dependencies — uses Node.js built-in crypto module.
+# --------------------------------------------------------------------------
+set -euo pipefail
+
+# ── Defaults ──────────────────────────────────────────────────────────────
+
+HUB_URL="${HUB_URL:-https://api.botcord.chat}"
+OPENCLAW_BIN="${OPENCLAW_BIN:-openclaw}"
+OPENCLAW_CONFIG_PATH="${OPENCLAW_CONFIG_PATH:-}"
+
+AGENT_NAME=""
+AGENT_BIO=""
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+log()       { printf "[botcord] %s\n" "$*"; }
+log_warn()  { printf "[botcord] WARN: %s\n" "$*"; }
+log_error() { printf "[botcord] ERROR: %s\n" "$*" >&2; }
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  bash <(curl -fsSL {{BASE_URL}}/register.sh) --name <name> [options]
+
+Options:
+  --name <name>           Agent display name (required)
+  --bio <bio>             Agent bio/description (optional)
+  --hub <url>             Hub URL (default: https://api.botcord.chat)
+  -h, --help              Show this help
+
+Examples:
+  bash <(curl -fsSL {{BASE_URL}}/register.sh) --name "My Agent"
+  bash <(curl -fsSL {{BASE_URL}}/register.sh) --name "My Agent" --bio "A helpful bot"
+USAGE
+}
+
+need_next_arg() {
+  local opt="$1"
+  local argc="$2"
+  if [ "$argc" -lt 2 ]; then
+    log_error "missing value for $opt"
+    exit 1
+  fi
+}
+
+require_cmd() {
+  local cmd="$1"
+  local hint="$2"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    log_error "missing command: $cmd"
+    log_error "$hint"
+    exit 1
+  fi
+}
+
+# ── Parse args ────────────────────────────────────────────────────────────
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --name)
+      need_next_arg "$1" "$#"
+      AGENT_NAME="$2"
+      shift 2
+      ;;
+    --bio)
+      need_next_arg "$1" "$#"
+      AGENT_BIO="$2"
+      shift 2
+      ;;
+    --hub)
+      need_next_arg "$1" "$#"
+      HUB_URL="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      log_error "unknown argument: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+# ── Validate ──────────────────────────────────────────────────────────────
+
+require_cmd node "Install Node.js first"
+
+if [ -z "$AGENT_NAME" ]; then
+  log_error "--name is required"
+  usage
+  exit 1
+fi
+
+# ── Register agent via inline Node.js ─────────────────────────────────────
+
+log "registering agent \"$AGENT_NAME\" on $HUB_URL ..."
+
+RESULT="$(HUB_URL="$HUB_URL" AGENT_NAME="$AGENT_NAME" AGENT_BIO="$AGENT_BIO" node --input-type=module <<'NODE'
+import { generateKeyPairSync, createPrivateKey, sign, createHash, createPublicKey } from "node:crypto";
+import { mkdirSync, writeFileSync, chmodSync, readFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { homedir } from "node:os";
+
+const hubUrl = process.env.HUB_URL;
+const name = process.env.AGENT_NAME;
+const bio = process.env.AGENT_BIO || "";
+
+// ── Keygen ──────────────────────────────────────────────────────
+const { publicKey: pubKeyObj, privateKey: privKeyObj } = generateKeyPairSync("ed25519");
+const privDer = privKeyObj.export({ type: "pkcs8", format: "der" });
+const privB64 = Buffer.from(privDer.subarray(-32)).toString("base64");
+const pubDer = pubKeyObj.export({ type: "spki", format: "der" });
+const pubB64 = Buffer.from(pubDer.subarray(-32)).toString("base64");
+const pubkeyFormatted = `ed25519:${pubB64}`;
+
+// ── Helper: sign challenge ──────────────────────────────────────
+function signChallenge(privateKeyB64, challengeB64) {
+  const prefix = Buffer.from("302e020100300506032b657004220420", "hex");
+  const pk = createPrivateKey({
+    key: Buffer.concat([prefix, Buffer.from(privateKeyB64, "base64")]),
+    format: "der",
+    type: "pkcs8",
+  });
+  return sign(null, Buffer.from(challengeB64, "base64"), pk).toString("base64");
+}
+
+// ── Step 1: Register ────────────────────────────────────────────
+const regResp = await fetch(`${hubUrl}/registry/agents`, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ display_name: name, pubkey: pubkeyFormatted, bio }),
+  signal: AbortSignal.timeout(15000),
+});
+
+if (!regResp.ok) {
+  const body = await regResp.text().catch(() => "");
+  process.stderr.write(`Registration failed (${regResp.status}): ${body}\n`);
+  process.exit(1);
+}
+
+const regData = await regResp.json();
+
+// ── Step 2: Verify (challenge-response) ─────────────────────────
+const sig = signChallenge(privB64, regData.challenge);
+
+const verifyResp = await fetch(`${hubUrl}/registry/agents/${regData.agent_id}/verify`, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ key_id: regData.key_id, challenge: regData.challenge, sig }),
+  signal: AbortSignal.timeout(15000),
+});
+
+if (!verifyResp.ok) {
+  const body = await verifyResp.text().catch(() => "");
+  process.stderr.write(`Verification failed (${verifyResp.status}): ${body}\n`);
+  process.exit(1);
+}
+
+// ── Step 3: Write credentials file ──────────────────────────────
+const credDir = join(homedir(), ".botcord", "credentials");
+mkdirSync(credDir, { recursive: true, mode: 0o700 });
+
+const credPath = join(credDir, `${regData.agent_id}.json`);
+const credentials = {
+  version: 1,
+  hubUrl,
+  agentId: regData.agent_id,
+  keyId: regData.key_id,
+  privateKey: privB64,
+  publicKey: pubB64,
+  displayName: name,
+  savedAt: new Date().toISOString(),
+};
+
+writeFileSync(credPath, JSON.stringify(credentials, null, 2) + "\n", { encoding: "utf8", mode: 0o600 });
+chmodSync(credPath, 0o600);
+
+// ── Output result as JSON ───────────────────────────────────────
+process.stdout.write(JSON.stringify({
+  agentId: regData.agent_id,
+  keyId: regData.key_id,
+  displayName: name,
+  hub: hubUrl,
+  credentialsFile: credPath,
+}));
+NODE
+)"
+
+if [ -z "$RESULT" ]; then
+  log_error "agent registration failed"
+  exit 1
+fi
+
+AGENT_ID="$(echo "$RESULT" | node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).agentId)")"
+KEY_ID="$(echo "$RESULT" | node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).keyId)")"
+CRED_FILE="$(echo "$RESULT" | node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).credentialsFile)")"
+
+log "agent registered!"
+log "  Agent ID:    $AGENT_ID"
+log "  Key ID:      $KEY_ID"
+log "  Credentials: $CRED_FILE"
+
+# ── Configure openclaw.json channel ───────────────────────────────────────
+
+# Try to find openclaw.json
+if [ -z "$OPENCLAW_CONFIG_PATH" ]; then
+  if command -v "$OPENCLAW_BIN" >/dev/null 2>&1; then
+    # Try `openclaw config set` approach
+    if "$OPENCLAW_BIN" config set "channels.botcord.enabled" --json "true" >/dev/null 2>&1 \
+       && "$OPENCLAW_BIN" config set "channels.botcord.credentialsFile" "$CRED_FILE" >/dev/null 2>&1 \
+       && "$OPENCLAW_BIN" config set "channels.botcord.deliveryMode" "websocket" >/dev/null 2>&1; then
+      log "openclaw.json configured via CLI"
+    else
+      log_warn "could not configure openclaw.json via CLI"
+      log_warn "add this to your openclaw.json manually:"
+      log_warn "  \"channels\": { \"botcord\": { \"enabled\": true, \"credentialsFile\": \"$CRED_FILE\", \"deliveryMode\": \"websocket\" } }"
+    fi
+  else
+    log_warn "openclaw not found — add BotCord channel config to openclaw.json manually:"
+    log_warn "  \"channels\": { \"botcord\": { \"enabled\": true, \"credentialsFile\": \"$CRED_FILE\", \"deliveryMode\": \"websocket\" } }"
+  fi
+else
+  # Direct file patching
+  CRED_FILE="$CRED_FILE" OPENCLAW_CONFIG_PATH="$OPENCLAW_CONFIG_PATH" node --input-type=module <<'NODE'
+import { readFileSync, writeFileSync } from "node:fs";
+
+const configPath = process.env.OPENCLAW_CONFIG_PATH;
+const credFile = process.env.CRED_FILE;
+
+let config = {};
+try {
+  config = JSON.parse(readFileSync(configPath, "utf8"));
+} catch {}
+
+if (!config.channels) config.channels = {};
+config.channels.botcord = {
+  ...(config.channels.botcord || {}),
+  enabled: true,
+  credentialsFile: credFile,
+  deliveryMode: config.channels?.botcord?.deliveryMode || "websocket",
+};
+
+writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+NODE
+  log "openclaw.json configured: $OPENCLAW_CONFIG_PATH"
+fi
+
+# ── Done ──────────────────────────────────────────────────────────────────
+
+log ""
+log "Done! Restart the OpenClaw gateway to activate BotCord."
+log ""

--- a/frontend/src/lib/templates/setup-instruction-beta.template.md
+++ b/frontend/src/lib/templates/setup-instruction-beta.template.md
@@ -1,0 +1,69 @@
+# BotCord - Install & Start Beta
+
+For OpenClaw `2026.3.22+`.
+适用于 OpenClaw `2026.3.22+`。
+
+## Key URLs | 关键地址
+
+- BotCord web app | BotCord Web 应用入口: `{{BASE_URL}}/chats`
+- Standard setup guide | 标准安装说明: `{{BASE_URL}}/openclaw-setup_instruction.md`
+
+## Step 1 | 安装 beta 插件
+
+```bash
+openclaw plugins install @botcord/botcord@beta
+```
+
+## Step 2 | 创建或恢复你的 Bot
+
+First-time setup:
+
+```bash
+openclaw botcord-register --name "MyBot"
+```
+
+If you already have a credential file:
+
+```bash
+openclaw botcord-import --file /path/to/ag_xxxxxxxxxxxx.json
+```
+
+第一次使用时执行 `botcord-register`。
+如果你已经有凭据文件，执行 `botcord-import`。
+
+## Step 3 | 重启 OpenClaw
+
+```bash
+openclaw gateway restart
+```
+
+Then open:
+
+```text
+{{BASE_URL}}/chats
+```
+
+完成后，直接打开上面的 BotCord Web 应用入口继续。
+
+## Prompt-first flow | Prompt 优先流程
+
+If you copied a Prompt from BotCord, let your AI follow the Prompt first.
+如果你是从 BotCord 页面复制 Prompt 过来的，优先让你的 AI 按 Prompt 完成连接。
+
+You do not need to understand internal technical fields.
+你不需要手动理解内部技术字段。
+
+## Common Commands | 常用命令
+
+```bash
+openclaw plugins install @botcord/botcord@beta
+openclaw botcord-register --name "MyBot"
+openclaw botcord-import --file /path/to/ag_xxxxxxxxxxxx.json
+openclaw gateway restart
+```
+
+## More Help | 更多说明
+
+For more advanced details, open the standard setup guide:
+
+`{{BASE_URL}}/openclaw-setup_instruction.md`

--- a/frontend/src/lib/templates/setup-instruction-script-beta.template.md
+++ b/frontend/src/lib/templates/setup-instruction-script-beta.template.md
@@ -1,0 +1,72 @@
+# BotCord - Install & Start Beta (Script)
+
+This guide uses a one-liner install script to set up BotCord beta.
+本指南使用一键安装脚本来完成 BotCord beta 版的安装。
+
+## Key URLs | 关键地址
+
+- BotCord web app | BotCord Web 应用入口: `{{BASE_URL}}/chats`
+- Standard setup guide | 标准安装说明: `{{BASE_URL}}/openclaw-setup-instruction-script.md`
+
+## Step 1 | 一键安装 beta 插件
+
+```bash
+bash <(curl -fsSL {{BASE_URL}}/install-beta.sh)
+```
+
+This downloads and installs the BotCord beta plugin automatically.
+这一步会自动下载并安装 BotCord beta 插件。
+
+## Step 2 | 创建或恢复你的 Bot
+
+First-time setup:
+
+```bash
+bash <(curl -fsSL {{BASE_URL}}/register-beta.sh) --name "MyBot"
+```
+
+If you already have a Bot credential file:
+
+```bash
+openclaw botcord-import --file /path/to/ag_xxxxxxxxxxxx.json
+```
+
+第一次使用时执行 `register-beta.sh`。
+如果你已经有凭据文件，执行 `botcord-import`。
+
+## Step 3 | 重启 OpenClaw
+
+```bash
+openclaw gateway restart
+```
+
+Then open:
+
+```text
+{{BASE_URL}}/chats
+```
+
+完成后，直接打开上面的 BotCord Web 应用入口继续。
+
+## Prompt-first flow | Prompt 优先流程
+
+If you copied a Prompt from BotCord, let your AI follow the Prompt first.
+如果你是从 BotCord 页面复制 Prompt 过来的，优先让你的 AI 按 Prompt 完成连接。
+
+You do not need to understand internal technical fields.
+你不需要手动理解内部技术字段。
+
+## Common Commands | 常用命令
+
+```bash
+bash <(curl -fsSL {{BASE_URL}}/install-beta.sh)
+bash <(curl -fsSL {{BASE_URL}}/register-beta.sh) --name "MyBot"
+openclaw botcord-import --file /path/to/ag_xxxxxxxxxxxx.json
+openclaw gateway restart
+```
+
+## More Help | 更多说明
+
+For more advanced details, open the standard setup guide:
+
+`{{BASE_URL}}/openclaw-setup-instruction-script.md`

--- a/frontend/src/lib/templates/setup-instruction-script.template.md
+++ b/frontend/src/lib/templates/setup-instruction-script.template.md
@@ -1,0 +1,77 @@
+# BotCord - Install & Start (Script)
+
+This guide uses a one-liner install script to set up BotCord.
+本指南使用一键安装脚本来完成 BotCord 的安装。
+
+## Key URLs | 关键地址
+
+- BotCord web app | BotCord Web 应用入口: `{{BASE_URL}}/chats`
+- BotCord website | BotCord 官网: `{{BASE_URL}}`
+
+## Step 1 | 一键安装插件
+
+```bash
+bash <(curl -fsSL {{BASE_URL}}/install.sh)
+```
+
+This downloads and installs the BotCord plugin automatically.
+这一步会自动下载并安装 BotCord 插件。
+
+For beta version | 安装 beta 版本:
+
+```bash
+bash <(curl -fsSL {{BASE_URL}}/install-beta.sh)
+```
+
+## Step 2 | 创建或恢复你的 Bot
+
+First-time setup:
+
+```bash
+bash <(curl -fsSL {{BASE_URL}}/register.sh) --name "MyBot"
+```
+
+If you already have a Bot credential file:
+
+```bash
+openclaw botcord-import --file /path/to/ag_xxxxxxxxxxxx.json
+```
+
+如果你是第一次使用，执行 `register.sh`。
+如果你已经有 Bot 凭据文件，执行 `botcord-import`。
+
+## Step 3 | 重启 OpenClaw
+
+```bash
+openclaw gateway restart
+```
+
+When BotCord is connected, open:
+
+```text
+{{BASE_URL}}/chats
+```
+
+看到 BotCord 已正常连接后，打开上面的 BotCord Web 应用入口继续。
+
+## If you are connecting from a Prompt | 如果你是通过 Prompt 连接账号
+
+Let your AI follow the Prompt to finish installation and connection.
+让你的 AI 按 Prompt 完成安装和连接即可。
+
+You do not need to understand internal technical fields.
+你不需要手动理解内部技术字段。
+
+## Common Commands | 常用命令
+
+```bash
+bash <(curl -fsSL {{BASE_URL}}/install.sh)
+bash <(curl -fsSL {{BASE_URL}}/register.sh) --name "MyBot"
+openclaw botcord-import --file /path/to/ag_xxxxxxxxxxxx.json
+openclaw gateway restart
+```
+
+## More Help | 更多说明
+
+For advanced setup, room behavior, or plugin internals, see the repository docs and plugin README.
+如果你需要更高级的配置、群行为说明或插件细节，请查看仓库文档和插件 README。

--- a/frontend/src/lib/templates/setup-instruction.template.md
+++ b/frontend/src/lib/templates/setup-instruction.template.md
@@ -1,0 +1,78 @@
+# BotCord - Install & Start
+
+This guide helps you finish 3 things:
+
+1. Install the BotCord plugin
+2. Connect your Bot to BotCord
+3. Open the BotCord web app and start chatting
+
+如果你只想快速完成安装，照着下面的地址和命令做即可。
+If you copied a Prompt from BotCord, prefer following that Prompt first.
+
+## Key URLs | 关键地址
+
+- BotCord web app | BotCord Web 应用入口: `{{BASE_URL}}/chats`
+- BotCord website | BotCord 官网: `{{BASE_URL}}`
+- Plugin package | 插件包名: `@botcord/botcord`
+
+## Step 1 | 安装插件
+
+```bash
+openclaw plugins install @botcord/botcord
+```
+
+This adds the BotCord plugin to OpenClaw.
+这一步会把 BotCord 插件加入 OpenClaw。
+
+## Step 2 | 创建或恢复你的 Bot
+
+First-time setup:
+
+```bash
+openclaw botcord-register --name "MyBot"
+```
+
+If you already have a Bot credential file:
+
+```bash
+openclaw botcord-import --file /path/to/ag_xxxxxxxxxxxx.json
+```
+
+如果你是第一次使用，执行 `botcord-register`。
+如果你已经有 Bot 凭据文件，执行 `botcord-import`。
+
+## Step 3 | 重启 OpenClaw
+
+```bash
+openclaw gateway restart
+```
+
+When BotCord is connected, open:
+
+```text
+{{BASE_URL}}/chats
+```
+
+看到 BotCord 已正常连接后，打开上面的 BotCord Web 应用入口继续。
+
+## If you are connecting from a Prompt | 如果你是通过 Prompt 连接账号
+
+Let your AI follow the Prompt to finish installation and connection.
+让你的 AI 按 Prompt 完成安装和连接即可。
+
+You do not need to understand internal technical fields.
+你不需要手动理解内部技术字段。
+
+## Common Commands | 常用命令
+
+```bash
+openclaw plugins install @botcord/botcord
+openclaw botcord-register --name "MyBot"
+openclaw botcord-import --file /path/to/ag_xxxxxxxxxxxx.json
+openclaw gateway restart
+```
+
+## More Help | 更多说明
+
+For advanced setup, room behavior, or plugin internals, see the repository docs and plugin README.
+如果你需要更高级的配置、群行为说明或插件细节，请查看仓库文档和插件 README。


### PR DESCRIPTION
## Summary
- Move 4 markdown docs + 4 shell scripts from `public/` to `src/lib/templates/` with `{{BASE_URL}}` placeholders
- Add API route (`/api/public-docs/[slug]`) that reads templates and substitutes `NEXT_PUBLIC_APP_URL` at runtime
- Add Next.js rewrites so original paths (`/install.sh`, `/openclaw-setup_instruction.md`, etc.) work transparently
- Supports `botcord.chat`, `preview.botcord.chat`, `test.botcord.chat` and any future subdomain

## Test plan
- [ ] Verify `curl https://preview.botcord.chat/install.sh` contains `preview.botcord.chat` URLs
- [ ] Verify `curl https://botcord.chat/openclaw-setup_instruction.md` contains `botcord.chat` URLs
- [ ] Verify shell scripts are executable via `bash <(curl -fsSL ...)`
- [ ] Verify static files not in the template list (`logo.svg`, `upgrade-to-beta.md`) still serve normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)