### PR TITLE
feat: return claim_url in verify response

### DIFF
--- a/backend/hub/routers/registry.py
+++ b/backend/hub/routers/registry.py
@@ -194,9 +194,18 @@ async def verify_agent(agent_id: str, req: VerifyRequest, db: AsyncSession = Dep
 
     token, expires_at = create_agent_token(agent_id)
 
+    # Look up agent to get claim_code for claim_url
+    agent_result = await db.execute(
+        select(Agent).where(Agent.agent_id == agent_id)
+    )
+    agent = agent_result.scalar_one_or_none()
+    claim_url = None
+    if agent and agent.claim_code:
+        claim_url = f"{hub_config.FRONTEND_BASE_URL.rstrip('/')}/agents/claim/{agent.claim_code}"
+
     await db.commit()
 
-    return VerifyResponse(agent_token=token, expires_at=expires_at)
+    return VerifyResponse(agent_token=token, expires_at=expires_at, claim_url=claim_url)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/hub/schemas.py
+++ b/backend/hub/schemas.py
@@ -158,6 +158,7 @@ class TokenRefreshRequest(BaseModel):
 class VerifyResponse(BaseModel):
     agent_token: str
     expires_at: int
+    claim_url: str | None = None
 
 
 class ClaimContextResponse(BaseModel):

--- a/frontend/src/lib/templates/register.template.sh
+++ b/frontend/src/lib/templates/register.template.sh
@@ -172,6 +172,8 @@ if (!verifyResp.ok) {
   process.exit(1);
 }
 
+const verifyData = await verifyResp.json();
+
 // ── Step 3: Write credentials file ──────────────────────────────
 const credDir = join(homedir(), ".botcord", "credentials");
 mkdirSync(credDir, { recursive: true, mode: 0o700 });
@@ -198,6 +200,7 @@ process.stdout.write(JSON.stringify({
   displayName: name,
   hub: hubUrl,
   credentialsFile: credPath,
+  claimUrl: verifyData.claim_url || null,
 }));
 NODE
 )"
@@ -210,11 +213,15 @@ fi
 AGENT_ID="$(echo "$RESULT" | node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).agentId)")"
 KEY_ID="$(echo "$RESULT" | node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).keyId)")"
 CRED_FILE="$(echo "$RESULT" | node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).credentialsFile)")"
+CLAIM_URL="$(echo "$RESULT" | node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).claimUrl || '')")"
 
 log "agent registered!"
 log "  Agent ID:    $AGENT_ID"
 log "  Key ID:      $KEY_ID"
 log "  Credentials: $CRED_FILE"
+if [ -n "$CLAIM_URL" ]; then
+  log "  Claim URL:   $CLAIM_URL"
+fi
 
 # ── Configure openclaw.json channel ───────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `VerifyResponse` 新增可选字段 `claim_url`，注册验证后直接返回 claim 链接
- `register.sh` 脚本解析并展示 claim URL，方便用户一键绑定 agent

## Changes
- `backend/hub/schemas.py`: `VerifyResponse` 加 `claim_url: str | None = None`
- `backend/hub/routers/registry.py`: verify 端点查询 `claim_code` 并拼接 URL
- `frontend/src/lib/templates/register.template.sh`: 解析 verify 响应，输出 claim URL

## Test plan
- [ ] 注册新 agent 后 verify 返回包含 `claim_url`
- [ ] 已有 agent 重新 verify 也能拿到 `claim_url`
- [ ] `claim_url` 为 `null` 时不影响现有流程（向后兼容）

🤖 Generated with [Claude Code](https://claude.com/claude-code)