### PR TITLE
fix: defer bind_code and jti consumption until all validations pass

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -136,8 +136,32 @@ def _utc_now() -> datetime.datetime:
     return datetime.datetime.now(datetime.timezone.utc)
 
 
-async def _consume_bind_code(code: str) -> str | None:
-    """Burn a bind short code and return its mapped bind ticket."""
+async def _peek_bind_code(code: str) -> str | None:
+    """Validate a bind short code and return its bind_ticket WITHOUT consuming it."""
+    async with _short_code_session_factory() as code_session:
+        now = _utc_now()
+        result = await code_session.execute(
+            select(ShortCode.payload_json).where(
+                ShortCode.code == code,
+                ShortCode.kind == "bind",
+                ShortCode.consumed_at.is_(None),
+                ShortCode.use_count < ShortCode.max_uses,
+                ShortCode.expires_at > now,
+            )
+        )
+        payload_json = result.scalar_one_or_none()
+        if payload_json is None:
+            return None
+        try:
+            payload = json.loads(payload_json)
+        except json.JSONDecodeError:
+            return None
+        bind_ticket = payload.get("bind_ticket")
+        return bind_ticket if isinstance(bind_ticket, str) else None
+
+
+async def _consume_bind_code(code: str) -> bool:
+    """Atomically consume a bind short code. Returns True on success."""
     async with _short_code_session_factory() as code_session:
         now = _utc_now()
         result = await code_session.execute(
@@ -156,19 +180,12 @@ async def _consume_bind_code(code: str) -> str | None:
                     else_=ShortCode.consumed_at,
                 ),
             )
-            .returning(ShortCode.payload_json)
         )
-        payload_json = result.scalar_one_or_none()
-        if payload_json is None:
+        if result.rowcount == 0:
             await code_session.rollback()
-            return None
+            return False
         await code_session.commit()
-        try:
-            payload = json.loads(payload_json)
-        except json.JSONDecodeError:
-            return None
-        bind_ticket = payload.get("bind_ticket")
-        return bind_ticket if isinstance(bind_ticket, str) else None
+        return True
 
 
 async def _consume_bind_ticket_jti(jti: str) -> bool:
@@ -796,10 +813,11 @@ async def agent_bind(
     if not body.display_name:
         raise HTTPException(status_code=400, detail="display_name is required")
 
-    # --- resolve bind credential to real bind_ticket ---
+    # --- resolve bind credential to real bind_ticket (peek, don't consume yet) ---
     bind_ticket = body.bind_ticket
-    if body.bind_code:
-        bind_ticket = await _consume_bind_code(body.bind_code)
+    has_bind_code = bool(body.bind_code)
+    if has_bind_code:
+        bind_ticket = await _peek_bind_code(body.bind_code)
         if bind_ticket is None:
             raise HTTPException(
                 status_code=401, detail="Invalid or expired bind code"
@@ -825,16 +843,25 @@ async def agent_bind(
     except ValueError:
         raise HTTPException(status_code=401, detail="Bind ticket has invalid uid")
 
-    # Consume jti (one-time use, DB-backed)
-    if not await _consume_bind_ticket_jti(ticket_payload["jti"]):
-        raise HTTPException(
-            status_code=401, detail="Bind ticket already used"
-        )
-
     # --- verify agent_token directly via hub JWT verification ---
     if not _verify_agent_control(body.agent_id, body.agent_token):
         raise HTTPException(
             status_code=401, detail="Agent token verification failed"
+        )
+
+    # --- All validations passed, now consume the one-time credentials ---
+
+    # Consume bind_code (atomic UPDATE)
+    if has_bind_code:
+        if not await _consume_bind_code(body.bind_code):
+            raise HTTPException(
+                status_code=401, detail="Bind code already consumed (race condition)"
+            )
+
+    # Consume jti (one-time use, DB-backed)
+    if not await _consume_bind_ticket_jti(ticket_payload["jti"]):
+        raise HTTPException(
+            status_code=401, detail="Bind ticket already used"
         )
 
     # Bind agent to user (shared logic)

--- a/backend/tests/test_app/test_app_user_agents.py
+++ b/backend/tests/test_app/test_app_user_agents.py
@@ -737,9 +737,10 @@ async def test_agent_bind_invalid_bind_code(
 
 
 @pytest.mark.asyncio
-async def test_agent_bind_code_burned_on_first_use(
+async def test_agent_bind_code_survives_failed_attempt(
     client: AsyncClient, seed_user_for_claim: dict
 ):
+    """bind_code should NOT be burned when a later verification step fails."""
     token = seed_user_for_claim["token"]
     issue = await client.post(
         "/api/users/me/agents/bind-ticket",
@@ -747,6 +748,7 @@ async def test_agent_bind_code_burned_on_first_use(
     )
     bind_code = issue.json()["bind_code"]
 
+    # First attempt: agent_token verification fails → 401, but bind_code survives
     with _mock_verify_agent_control(False):
         first = await client.post(
             "/api/users/me/agents/bind",
@@ -759,6 +761,7 @@ async def test_agent_bind_code_burned_on_first_use(
         )
     assert first.status_code == 401
 
+    # Second attempt: same bind_code with valid token → should succeed
     with _mock_verify_agent_control(True):
         second = await client.post(
             "/api/users/me/agents/bind",
@@ -769,8 +772,21 @@ async def test_agent_bind_code_burned_on_first_use(
                 "bind_code": bind_code,
             },
         )
-    assert second.status_code == 401
-    assert "bind code" in second.json()["detail"].lower()
+    assert second.status_code == 201
+
+    # Third attempt: bind_code now consumed → 401
+    with _mock_verify_agent_control(True):
+        third = await client.post(
+            "/api/users/me/agents/bind",
+            json={
+                "agent_id": "ag_bindcodeburn2",
+                "display_name": "Burn Code 2",
+                "agent_token": "tok_valid",
+                "bind_code": bind_code,
+            },
+        )
+    assert third.status_code == 401
+    assert "bind code" in third.json()["detail"].lower() or "consumed" in third.json()["detail"].lower()
 
 
 @pytest.mark.asyncio
@@ -809,20 +825,18 @@ async def test_agent_bind_ticket_replay_rejected(
 
 
 @pytest.mark.asyncio
-async def test_agent_bind_ticket_burned_on_failure(
+async def test_agent_bind_ticket_survives_failed_attempt(
     client: AsyncClient, seed_user_for_claim: dict
 ):
-    """A ticket is consumed even when the bind fails (e.g. bad agent_token).
+    """bind_ticket jti should NOT be consumed when agent_token verification fails.
 
-    After the first attempt fails (jti consumed but agent_token rejected),
-    the same ticket must not be accepted on a second attempt, even with a
-    valid agent_token. This verifies the independent-transaction jti burn.
+    After the first attempt fails (bad agent_token), the same ticket should
+    still be usable on a second attempt with a valid agent_token.
     """
     user_id = str(seed_user_for_claim["user_id"])
     ticket = _make_bind_ticket(user_id)
 
-    # First attempt: ticket is valid but agent_token verification fails.
-    # The jti should still be burned.
+    # First attempt: agent_token verification fails → 401, but ticket survives
     with _mock_verify_agent_control(False):
         resp1 = await client.post(
             "/api/users/me/agents/bind",
@@ -836,8 +850,7 @@ async def test_agent_bind_ticket_burned_on_failure(
     assert resp1.status_code == 401
     assert "token" in resp1.json()["detail"].lower()
 
-    # Second attempt: same ticket, now with valid token. Should still be rejected
-    # because the jti was already consumed in the first (failed) attempt.
+    # Second attempt: same ticket with valid token → should succeed
     with _mock_verify_agent_control(True):
         resp2 = await client.post(
             "/api/users/me/agents/bind",
@@ -848,8 +861,21 @@ async def test_agent_bind_ticket_burned_on_failure(
                 "bind_ticket": ticket,
             },
         )
-    assert resp2.status_code == 401
-    assert "already used" in resp2.json()["detail"].lower()
+    assert resp2.status_code == 201
+
+    # Third attempt: ticket now consumed → 401
+    with _mock_verify_agent_control(True):
+        resp3 = await client.post(
+            "/api/users/me/agents/bind",
+            json={
+                "agent_id": "ag_burntest0002",
+                "display_name": "Burn Test 2",
+                "agent_token": "tok_valid",
+                "bind_ticket": ticket,
+            },
+        )
+    assert resp3.status_code == 401
+    assert "already used" in resp3.json()["detail"].lower()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `bind_code` and `bind_ticket` jti were consumed in independent transactions **before** `agent_token` verification. If `_verify_agent_control` failed, the one-time credentials were already burned — agents could not retry with a corrected token.
- Split `_consume_bind_code` into `_peek_bind_code` (read-only) + `_consume_bind_code` (atomic consume). Move all credential consumption to **after** all validations pass.
- Root cause introduced in `710117d` ("Onboarding 场景优化").

## Test plan
- [x] `test_agent_bind_code_survives_failed_attempt` — bind_code reusable after agent_token failure, consumed after success
- [x] `test_agent_bind_ticket_survives_failed_attempt` — same for bind_ticket jti
- [x] All 21 agent bind tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)