### PR TITLE
fix: add missing db.commit() to BFF wallet routes

### DIFF
--- a/backend/app/routers/wallet.py
+++ b/backend/app/routers/wallet.py
@@ -182,6 +182,7 @@ async def create_transfer(
             metadata=body.metadata,
             idempotency_key=body.idempotency_key,
         )
+        await db.commit()
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 
@@ -213,6 +214,7 @@ async def create_topup(
             metadata=body.metadata,
             idempotency_key=body.idempotency_key,
         )
+        await db.commit()
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 
@@ -263,6 +265,7 @@ async def create_withdrawal(
             destination_json=destination_json,
             idempotency_key=body.idempotency_key,
         )
+        await db.commit()
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 
@@ -279,6 +282,7 @@ async def cancel_withdrawal(
         wd = await wallet_svc.cancel_withdrawal_request(
             db, withdrawal_id, ctx.active_agent_id,
         )
+        await db.commit()
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 
@@ -347,6 +351,7 @@ async def create_stripe_checkout(
             body.idempotency_key,
             quantity=body.quantity,
         )
+        await db.commit()
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 
@@ -368,6 +373,7 @@ async def get_stripe_session_status(
         result = await stripe_svc.get_checkout_status(
             db, session_id, agent_id=ctx.active_agent_id,
         )
+        await db.commit()
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc))
     except PermissionError as exc:


### PR DESCRIPTION
## Summary
- BFF wallet router (`app/routers/wallet.py`) was missing `await db.commit()` on all 6 write operations (transfer, topup, withdrawal, cancel withdrawal, Stripe checkout session, Stripe session status)
- `get_db()` uses `async with async_session()` which **rollbacks on exit** without explicit commit, so all mutations were silently discarded
- This is the root cause of Stripe topup balance not increasing: the session-status polling endpoint would successfully fulfill the topup in-memory but never persist it

## Test plan
- [ ] Verify Stripe topup flow: create checkout → pay → return → balance increases
- [ ] Verify transfer between agents persists
- [ ] Verify withdrawal creation and cancellation persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)