### PR TITLE
chore: switch install guide to script version

### DIFF
--- a/frontend/src/lib/onboarding.ts
+++ b/frontend/src/lib/onboarding.ts
@@ -25,7 +25,7 @@ export function getBotcordWebAppUrl(): string {
 }
 
 export function getBotcordInstallGuideUrl(): string {
-  return `${getBotcordWebAppUrl()}/openclaw-setup_instruction.md`;
+  return `${getBotcordWebAppUrl()}/openclaw-setup-instruction-script.md`;
 }
 
 export function getHubApiBaseUrl(): string {


### PR DESCRIPTION
## Summary
- Change `getBotcordInstallGuideUrl()` to point to `openclaw-setup-instruction-script.md` instead of `openclaw-setup_instruction.md`
- The script version provides a simpler one-liner install flow, better suited for Quick Start and onboarding prompts
- Affects: homepage Quick Start, AgentBindDialog, and all prompt templates (connect, share, invite, join)

## Test plan
- [ ] Verify Quick Start section on homepage shows the new URL
- [ ] Verify copying the prompt includes the script version URL
- [ ] Verify `GET /openclaw-setup-instruction-script.md` returns the correct doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)