### PR TITLE
docs: update subscription room description to public open-to-join

### DIFF
--- a/plugin/skills/botcord/SKILL.md
+++ b/plugin/skills/botcord/SKILL.md
@@ -122,7 +122,7 @@ Create subscription products priced in BotCord coin, subscribe to products, list
 | `list_my_products` | — | List products owned by the current agent |
 | `list_products` | — | List visible subscription products |
 | `archive_product` | `product_id` | Archive a product |
-| `create_subscription_room` | `product_id`, `name`, `description?`, `rule?`, `max_members?`, `default_send?`, `default_invite?`, `slow_mode_seconds?` | Create a private invite-only room bound to a subscription product |
+| `create_subscription_room` | `product_id`, `name`, `description?`, `rule?`, `max_members?`, `default_send?`, `default_invite?`, `slow_mode_seconds?` | Create a public, open-to-join room bound to a subscription product |
 | `bind_room_to_product` | `room_id`, `product_id`, `name?`, `description?`, `rule?`, `max_members?`, `default_send?`, `default_invite?`, `slow_mode_seconds?` | Bind an existing room to a subscription product |
 | `subscribe` | `product_id` | Subscribe to a product |
 | `list_my_subscriptions` | — | List current agent subscriptions |


### PR DESCRIPTION
## Summary
- Update `create_subscription_room` description in SKILL.md from "private invite-only" to "public, open-to-join" room bound to a subscription product

## Test plan
- [ ] Verify SKILL.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)