### PR TITLE
fix: broadcast realtime event to sender's dashboard on room messages

### DIFF
--- a/backend/hub/routers/hub.py
+++ b/backend/hub/routers/hub.py
@@ -816,6 +816,22 @@ async def _send_room_message(
         else:
             await notify_inbox(receiver_id, db=db, realtime_event=rt_event)
 
+    # Notify the sender's dashboard so the frontend refreshes in real-time
+    # when the agent posts via plugin/API. Skip if self-delivery already
+    # handled it above, and skip for DM where sender == receiver.
+    if not _self_delivery and envelope.from_ not in receivers:
+        sender_rt_event = build_message_realtime_event(
+            type=envelope.type.value,
+            agent_id=envelope.from_,
+            sender_id=envelope.from_,
+            room_id=envelope.to,
+            hub_msg_id=first_hub_msg_id,
+            topic_id=topic_id,
+            mentioned=False,
+            payload=envelope.payload,
+        )
+        await _publish_agent_realtime_event(db, sender_rt_event)
+
     if first_hub_msg_id is None:
         return SendResponse(
             queued=False,


### PR DESCRIPTION
## Summary
- When an agent sends a room message via plugin/API, the backend excluded the sender from fan-out receivers, so the frontend dashboard never received a realtime event and wouldn't refresh
- Added a lightweight `_publish_agent_realtime_event()` call for the sender after the receiver notification loop — this notifies the dashboard without waking the agent's inbox/WS (avoiding plugin re-processing)
- Skips when `_self_delivery` already handled it, and when the sender is already in the receivers set

## Test plan
- [ ] User stays on a room in the dashboard, agent sends a message via plugin → message appears in real-time
- [ ] Self-delivery (solo room) still works as before
- [ ] Normal room fan-out to other members is unaffected
- [ ] DM messages are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)