### PR TITLE
fix: remove 500-char text truncation in dashboard messages

### DIFF
--- a/backend/app/helpers.py
+++ b/backend/app/helpers.py
@@ -21,7 +21,7 @@ def extract_text_from_envelope(envelope_json: str | None) -> dict:
         text = payload.get("message", "")
     return {
         "sender_id": sender_id,
-        "text": text[:500] if text else None,
+        "text": text or None,
         "type": msg_type,
         "payload": payload,
     }

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -1215,6 +1215,7 @@ async def get_room_messages(
             "sender_display_name": sender_names.get(rec.sender_id),
             "text": parsed["text"],
             "type": parsed["type"],
+            "payload": parsed["payload"],
             "topic": rec.topic,
             "topic_id": rec.topic_id,
             "topic_title": topic_info.get(rec.topic_id, {}).get("title") if rec.topic_id else None,

--- a/plugin/src/ws-client.ts
+++ b/plugin/src/ws-client.ts
@@ -27,14 +27,19 @@ interface WsClientOptions {
   };
 }
 
-const activeWsClients = new Map<string, { stop: () => void }>();
+// Use lazy initialization to avoid TDZ errors when jiti resolves
+// the dynamic import("./ws-client.js") before the module body completes.
+let _activeWsClients: Map<string, { stop: () => void }> | undefined;
+function getActiveWsClients() {
+  return (_activeWsClients ??= new Map());
+}
 
 // Reconnect backoff: 1s, 2s, 4s, 8s, 16s, 30s max
 const RECONNECT_BACKOFF = [1000, 2000, 4000, 8000, 16000, 30000];
 
 export function startWsClient(opts: WsClientOptions): { stop: () => void } {
   // Stop any existing client for this account before creating a new one
-  const existing = activeWsClients.get(opts.accountId);
+  const existing = getActiveWsClients().get(opts.accountId);
   if (existing) existing.stop();
 
   const { client, accountId, cfg, abortSignal, log } = opts;
@@ -167,14 +172,14 @@ export function startWsClient(opts: WsClientOptions): { stop: () => void } {
       }
       ws = null;
     }
-    activeWsClients.delete(accountId);
+    getActiveWsClients().delete(accountId);
   }
 
   // Start connection
   connect();
 
   const entry = { stop };
-  activeWsClients.set(accountId, entry);
+  getActiveWsClients().set(accountId, entry);
 
   abortSignal?.addEventListener("abort", stop, { once: true });
 
@@ -182,6 +187,6 @@ export function startWsClient(opts: WsClientOptions): { stop: () => void } {
 }
 
 export function stopWsClient(accountId: string): void {
-  const entry = activeWsClients.get(accountId);
+  const entry = getActiveWsClients().get(accountId);
   if (entry) entry.stop();
 }


### PR DESCRIPTION
## Summary
- Remove the arbitrary 500-character truncation on message text in `app/helpers.py:extract_text_from_envelope`, which was causing long messages (e.g. JSON configs) to be cut off in the chat UI
- Add `payload` field to the app-layer dashboard message response, matching the hub-layer behavior and giving the frontend access to the full message content
- Fix a TDZ (Temporal Dead Zone) error in `plugin/src/ws-client.ts` by using lazy initialization for the module-level `activeWsClients` map

## Test plan
- [x] `pytest tests/test_app/test_app_dashboard.py` — 21 passed
- [ ] Verify long messages display fully in the dashboard chat UI
- [ ] Verify room list previews still show truncated previews (separate 200-char limit, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)