### PR TITLE
feat(frontend): transfer card display for wallet messages

### DIFF
--- a/frontend/src/components/dashboard/MessageBubble.tsx
+++ b/frontend/src/components/dashboard/MessageBubble.tsx
@@ -7,6 +7,7 @@ import { messageBubble } from '@/lib/i18n/translations/dashboard';
 import AttachmentItem from "@/components/ui/AttachmentItem";
 import CopyableId from "@/components/ui/CopyableId";
 import MarkdownContent from "@/components/ui/MarkdownContent";
+import TransferCard, { parseTransferText, parseTransferNotice } from "@/components/dashboard/TransferCard";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 
 interface MessageBubbleProps {
@@ -79,6 +80,10 @@ export default function MessageBubble({ message, isOwn }: MessageBubbleProps) {
   const textContent = message.payload?.text || message.payload?.body || message.payload?.message;
   const displayText = typeof textContent === "string" ? textContent : message.text;
 
+  const transferInfo = displayText
+    ? parseTransferText(displayText) ?? parseTransferNotice(displayText, message.payload)
+    : null;
+
   const attachments = Array.isArray(message.payload?.attachments)
     ? (message.payload.attachments as Attachment[])
     : [];
@@ -125,7 +130,11 @@ export default function MessageBubble({ message, isOwn }: MessageBubbleProps) {
           </div>
         )}
 
-        {displayText && <MarkdownContent content={displayText} />}
+        {transferInfo ? (
+          <TransferCard info={transferInfo} isNotice={displayText?.startsWith("[BotCord Notice]")} />
+        ) : (
+          displayText && <MarkdownContent content={displayText} />
+        )}
 
         {attachments.length > 0 && (
           <div className="mt-1.5 flex flex-col gap-1.5">

--- a/frontend/src/components/dashboard/TransferCard.tsx
+++ b/frontend/src/components/dashboard/TransferCard.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import CopyableId from "@/components/ui/CopyableId";
+
+interface TransferInfo {
+  status: string;
+  tx_id: string;
+  amount: string;
+  asset: string;
+  from: string;
+  to: string;
+  memo?: string;
+  created_at?: string;
+}
+
+/**
+ * Parse a "[BotCord Transfer]" plain-text message into structured fields.
+ * Returns null if the text is not a transfer record.
+ */
+export function parseTransferText(text: string): TransferInfo | null {
+  if (!text.startsWith("[BotCord Transfer]")) return null;
+
+  const get = (label: string): string => {
+    const re = new RegExp(`^${label}:\\s*(.+)`, "m");
+    return re.exec(text)?.[1]?.trim() ?? "";
+  };
+
+  const amount = get("Amount");
+  const asset = get("Asset");
+  if (!amount) return null;
+
+  return {
+    status: get("Status"),
+    tx_id: get("Transaction"),
+    amount,
+    asset,
+    from: get("From"),
+    to: get("To"),
+    memo: get("Memo") || undefined,
+    created_at: get("Created") || undefined,
+  };
+}
+
+/**
+ * Parse a "[BotCord Notice]" system message into structured fields.
+ * Also accepts payload with structured event data.
+ */
+export function parseTransferNotice(
+  text: string,
+  payload?: Record<string, unknown>,
+): TransferInfo | null {
+  // Prefer structured payload
+  if (payload?.event === "wallet_transfer_notice") {
+    const amountMinor = parseInt(String(payload.amount_minor ?? "0"), 10);
+    const major = isNaN(amountMinor) ? "0.00" : (amountMinor / 100).toFixed(2);
+    return {
+      status: "completed",
+      tx_id: String(payload.tx_id ?? ""),
+      amount: `${major} ${payload.asset_code ?? "COIN"}`,
+      asset: String(payload.asset_code ?? "COIN"),
+      from: String(payload.from_agent_id ?? ""),
+      to: String(payload.to_agent_id ?? ""),
+    };
+  }
+
+  if (!text.startsWith("[BotCord Notice]")) return null;
+
+  // "[BotCord Notice] Transfer sent: 10.00 COIN to ag_xxx (tx: tx_xxx)"
+  // "[BotCord Notice] Payment received: 10.00 COIN from ag_xxx (tx: tx_xxx)"
+  const sent = /Transfer sent:\s*([\d.]+\s*\w+)\s+to\s+(ag_\w+)\s*\(tx:\s*(\w+)\)/.exec(text);
+  if (sent) {
+    return {
+      status: "completed",
+      tx_id: sent[3],
+      amount: sent[1],
+      asset: sent[1].split(/\s+/)[1] ?? "COIN",
+      from: "",
+      to: sent[2],
+    };
+  }
+
+  const received = /Payment received:\s*([\d.]+\s*\w+)\s+from\s+(ag_\w+)\s*\(tx:\s*(\w+)\)/.exec(text);
+  if (received) {
+    return {
+      status: "completed",
+      tx_id: received[3],
+      amount: received[1],
+      asset: received[1].split(/\s+/)[1] ?? "COIN",
+      from: received[2],
+      to: "",
+    };
+  }
+
+  return null;
+}
+
+const statusStyles: Record<string, string> = {
+  completed: "text-neon-green bg-neon-green/10 border-neon-green/30",
+  pending: "text-yellow-400 bg-yellow-400/10 border-yellow-400/30",
+  failed: "text-red-400 bg-red-400/10 border-red-400/30",
+};
+
+export default function TransferCard({ info, isNotice }: { info: TransferInfo; isNotice?: boolean }) {
+  const amountNum = parseFloat(info.amount);
+  const amountDisplay = isNaN(amountNum) ? info.amount : `${amountNum.toFixed(2)} ${info.asset}`;
+  const sc = statusStyles[info.status] ?? statusStyles.completed;
+
+  return (
+    <div className="w-full min-w-[240px] rounded-lg border border-neon-cyan/20 bg-gradient-to-br from-neon-cyan/5 to-transparent p-3">
+      {/* Header */}
+      <div className="mb-2 flex items-center justify-between">
+        <div className="flex items-center gap-1.5">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="h-4 w-4 text-neon-cyan">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
+          </svg>
+          <span className="text-xs font-medium text-neon-cyan">
+            {isNotice ? "Transfer Notice" : "Transfer Record"}
+          </span>
+        </div>
+        <span className={`rounded-full border px-1.5 py-px text-[10px] font-medium ${sc}`}>
+          {info.status}
+        </span>
+      </div>
+
+      {/* Amount */}
+      <div className="mb-2.5 text-center">
+        <span className="font-mono text-xl font-bold text-text-primary">{amountDisplay}</span>
+      </div>
+
+      {/* Details grid */}
+      <div className="space-y-1.5 text-xs">
+        {info.from && (
+          <div className="flex items-center justify-between gap-2">
+            <span className="shrink-0 text-text-secondary/60">From</span>
+            <CopyableId value={info.from} />
+          </div>
+        )}
+        {info.to && (
+          <div className="flex items-center justify-between gap-2">
+            <span className="shrink-0 text-text-secondary/60">To</span>
+            <CopyableId value={info.to} />
+          </div>
+        )}
+        {info.memo && (
+          <div className="flex items-center justify-between gap-2">
+            <span className="shrink-0 text-text-secondary/60">Memo</span>
+            <span className="truncate text-text-primary/80">{info.memo}</span>
+          </div>
+        )}
+        {info.tx_id && (
+          <div className="flex items-center justify-between gap-2">
+            <span className="shrink-0 text-text-secondary/60">Tx</span>
+            <CopyableId value={info.tx_id} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/share/SharedMessageBubble.tsx
+++ b/frontend/src/components/share/SharedMessageBubble.tsx
@@ -3,6 +3,7 @@
 import type { SharedMessage, Attachment } from "@/lib/types";
 import AttachmentItem from "@/components/ui/AttachmentItem";
 import MarkdownContent from "@/components/ui/MarkdownContent";
+import TransferCard, { parseTransferText, parseTransferNotice } from "@/components/dashboard/TransferCard";
 
 interface SharedMessageBubbleProps {
   message: SharedMessage;
@@ -11,6 +12,10 @@ interface SharedMessageBubbleProps {
 export default function SharedMessageBubble({ message }: SharedMessageBubbleProps) {
   const textContent = message.payload?.text || message.payload?.body || message.payload?.message;
   const displayText = typeof textContent === "string" ? textContent : message.text;
+
+  const transferInfo = displayText
+    ? parseTransferText(displayText) ?? parseTransferNotice(displayText, message.payload)
+    : null;
 
   const attachments = Array.isArray(message.payload?.attachments)
     ? (message.payload.attachments as Attachment[])
@@ -23,7 +28,11 @@ export default function SharedMessageBubble({ message }: SharedMessageBubbleProp
           <span className="text-xs font-medium text-neon-purple">{message.sender_name}</span>
           <span className="font-mono text-[10px] text-text-secondary/50">{message.sender_id}</span>
         </div>
-        {displayText && <MarkdownContent content={displayText} />}
+        {transferInfo ? (
+          <TransferCard info={transferInfo} isNotice={displayText?.startsWith("[BotCord Notice]")} />
+        ) : (
+          displayText && <MarkdownContent content={displayText} />
+        )}
         {attachments.length > 0 && (
           <div className="mt-1.5 flex flex-col gap-1.5">
             {attachments.map((att, i) => (


### PR DESCRIPTION
## Summary
- Add `TransferCard` component that parses `[BotCord Transfer]` and `[BotCord Notice]` messages into structured card UI
- Displays amount, status badge, from/to agent IDs (copyable), memo, and tx ID
- Applied to both `MessageBubble` and `SharedMessageBubble`

## Test plan
- [x] `pnpm build` passes
- [ ] Verify `[BotCord Transfer]` messages render as card in chat
- [ ] Verify `[BotCord Notice]` system messages render as card
- [ ] Verify normal messages still render as markdown text

🤖 Generated with [Claude Code](https://claude.com/claude-code)