### PR TITLE
fix: show agent name and id in chat messages

### DIFF
--- a/frontend/src/components/dashboard/MessageBubble.tsx
+++ b/frontend/src/components/dashboard/MessageBubble.tsx
@@ -109,18 +109,18 @@ export default function MessageBubble({ message, isOwn }: MessageBubbleProps) {
             : "border border-glass-border bg-glass-bg"
         }`}
       >
-        {!isOwn && (
-          <div
-            role="button"
-            tabIndex={0}
-            onClick={(e) => { e.stopPropagation(); handleSelectSender(); }}
-            onKeyDown={handleSelectSenderByKey}
-            className="mb-0.5 flex items-center gap-1.5 rounded px-1 -ml-1 transition-colors hover:bg-glass-bg"
-          >
-            <span className="text-xs font-medium text-neon-purple hover:underline">{message.sender_name}</span>
-            <CopyableId value={message.sender_id} />
-          </div>
-        )}
+        <div
+          role="button"
+          tabIndex={0}
+          onClick={(e) => { e.stopPropagation(); handleSelectSender(); }}
+          onKeyDown={handleSelectSenderByKey}
+          className={`mb-0.5 flex items-center gap-1.5 rounded px-1 transition-colors hover:bg-glass-bg ${isOwn ? "justify-end" : "-ml-1"}`}
+        >
+          <span className="text-xs font-medium text-neon-purple hover:underline">
+            {message.sender_name || message.sender_id}
+          </span>
+          <CopyableId value={message.sender_id} />
+        </div>
 
         {/* Goal badge */}
         {message.goal && (

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -16,6 +16,7 @@ import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import DashboardMessagePaneSkeleton from "./DashboardMessagePaneSkeleton";
 import MarkdownContent from "@/components/ui/MarkdownContent";
+import CopyableId from "@/components/ui/CopyableId";
 import { useShallow } from "zustand/react/shallow";
 
 interface PendingMessage {
@@ -273,11 +274,12 @@ export default function UserChatPane() {
                     : "bg-zinc-800 text-zinc-200 border border-zinc-700"
                 }`}
               >
-                {!isOwner && (
-                  <div className="text-xs text-zinc-400 mb-1 font-medium">
-                    {msg.sender_name}
-                  </div>
-                )}
+                <div className={`mb-1 flex items-center gap-1.5 ${isOwner ? "justify-end" : ""}`}>
+                  <span className="text-xs font-medium text-zinc-300">
+                    {msg.sender_name || msg.sender_id}
+                  </span>
+                  <CopyableId value={msg.sender_id} className="text-zinc-500 hover:text-zinc-300" />
+                </div>
                 {!isOwner && !animatedRef.current.has(msg.hub_msg_id) ? (
                   <TypewriterText
                     text={msg.text || ""}


### PR DESCRIPTION
## Summary
- show both sender name and sender id in dashboard room message bubbles
- align the user-chat pane with the same sender header format
- keep sender id copy affordance visible in both views

## Testing
- npm run build