### PR TITLE
fix(backend): remove orphan registry claim endpoints

### DIFF
--- a/backend/hub/routers/registry.py
+++ b/backend/hub/routers/registry.py
@@ -27,7 +27,6 @@ from hub.schemas import (
     AgentSummary,
     ClaimContextResponse,
     ClaimLinkResponse,
-    ClaimStatusResponse,
     EndpointHealthStatus,
     EndpointProbeReport,
     EndpointResponse,
@@ -637,51 +636,6 @@ async def get_claim_link(
         display_name=agent.display_name,
         claim_code=agent.claim_code,
         claim_url=f"{hub_config.FRONTEND_BASE_URL.rstrip('/')}/agents/claim/{agent.claim_code}",
-    )
-
-
-@router.get(
-    "/agents/{agent_id}/claim-status",
-    response_model=ClaimStatusResponse,
-)
-async def get_claim_status(
-    agent_id: str,
-    db: AsyncSession = Depends(get_db),
-):
-    result = await db.execute(select(Agent).where(Agent.agent_id == agent_id))
-    agent = result.scalar_one_or_none()
-    if agent is None:
-        raise I18nHTTPException(status_code=404, message_key="agent_not_found")
-
-    return ClaimStatusResponse(
-        agent_id=agent_id,
-        claimed=agent.claimed_at is not None,
-        claimed_at=agent.claimed_at,
-    )
-
-
-@router.post(
-    "/agents/{agent_id}/claim",
-    response_model=ClaimStatusResponse,
-)
-async def claim_agent(
-    agent_id: str,
-    db: AsyncSession = Depends(get_db),
-    current_agent: str = Depends(get_current_agent),
-):
-    check_agent_ownership(agent_id, current_agent)
-    result = await db.execute(select(Agent).where(Agent.agent_id == agent_id))
-    agent = result.scalar_one_or_none()
-    if agent is None:
-        raise I18nHTTPException(status_code=404, message_key="agent_not_found")
-    if agent.claimed_at is None:
-        agent.claimed_at = datetime.datetime.now(datetime.timezone.utc)
-        await db.commit()
-        await db.refresh(agent)
-    return ClaimStatusResponse(
-        agent_id=agent_id,
-        claimed=True,
-        claimed_at=agent.claimed_at,
     )
 
 

--- a/backend/hub/schemas.py
+++ b/backend/hub/schemas.py
@@ -179,12 +179,6 @@ class ClaimLinkResponse(BaseModel):
     claim_url: str
 
 
-class ClaimStatusResponse(BaseModel):
-    agent_id: str
-    claimed: bool
-    claimed_at: datetime.datetime | None = None
-
-
 # --- Endpoint schemas ---
 
 

--- a/backend/tests/test_m2_registry.py
+++ b/backend/tests/test_m2_registry.py
@@ -1618,27 +1618,3 @@ async def test_get_claim_link_forbidden_when_not_owner(client: AsyncClient):
     assert resp.status_code == 403
 
 
-@pytest.mark.asyncio
-async def test_claim_status_and_claim_endpoint(client: AsyncClient):
-    sk, pubkey = _make_keypair()
-    agent_id, _, token = await _register_and_verify(client, sk, pubkey, display_name="Claimable Agent")
-
-    status_before = await client.get(f"/registry/agents/{agent_id}/claim-status")
-    assert status_before.status_code == 200
-    assert status_before.json()["claimed"] is False
-    assert status_before.json()["claimed_at"] is None
-
-    claim_resp = await client.post(
-        f"/registry/agents/{agent_id}/claim",
-        headers=_auth_header(token),
-    )
-    assert claim_resp.status_code == 200
-    claim_data = claim_resp.json()
-    assert claim_data["agent_id"] == agent_id
-    assert claim_data["claimed"] is True
-    assert claim_data["claimed_at"] is not None
-
-    status_after = await client.get(f"/registry/agents/{agent_id}/claim-status")
-    assert status_after.status_code == 200
-    assert status_after.json()["claimed"] is True
-    assert status_after.json()["claimed_at"] is not None


### PR DESCRIPTION
## Summary
- Remove `POST /registry/agents/{id}/claim` and `GET /registry/agents/{id}/claim-status` — these only set `claimed_at` without binding `user_id`, creating a "claimed but unbound" ghost state
- No production caller exists (plugin/CLI only use `GET /claim-link`; real claim goes through `POST /api/users/me/agents/claim/resolve`)
- Remove associated `ClaimStatusResponse` schema and test

## Test plan
- [ ] Verify `GET /registry/agents/{id}/claim-link` and `GET /registry/agents/{id}/claim-context` still work (not removed)
- [ ] Verify `POST /api/users/me/agents/claim/resolve` (app-layer claim) still works
- [ ] Confirm no 404s in plugin registration flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)