### PR TITLE
fix: prevent WebSocket message loss with two-phase ack

### DIFF
--- a/backend/hub/enums.py
+++ b/backend/hub/enums.py
@@ -23,6 +23,7 @@ class MessagePolicy(str, enum.Enum):
 
 class MessageState(str, enum.Enum):
     queued = "queued"
+    processing = "processing"  # Claimed by a consumer, pending explicit ack
     delivered = "delivered"
     acked = "acked"
     done = "done"

--- a/backend/hub/expiry.py
+++ b/backend/hub/expiry.py
@@ -51,6 +51,56 @@ def _build_ttl_error_envelope(record: MessageRecord) -> dict | None:
     }
 
 
+async def _reclaim_stale_processing() -> None:
+    """Revert messages stuck in 'processing' state back to 'queued'.
+
+    This handles the case where a consumer polled with ack=false (marking
+    messages as 'processing') but crashed before calling POST /hub/inbox/ack.
+    The poll endpoint sets next_retry_at to the processing timeout deadline.
+
+    After reclaiming, notifies affected agents so WS/long-poll consumers
+    re-fetch immediately instead of waiting for the next new message.
+    """
+    from hub.routers.hub import notify_inbox
+    from sqlalchemy import select, update
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    async with async_session() as session:
+        # First, find which agents are affected so we can notify them
+        affected_stmt = (
+            select(MessageRecord.receiver_id)
+            .where(
+                MessageRecord.state == MessageState.processing,
+                MessageRecord.next_retry_at <= now,
+            )
+            .distinct()
+        )
+        affected_result = await session.execute(affected_stmt)
+        affected_agents = [row[0] for row in affected_result.all()]
+
+        if not affected_agents:
+            return
+
+        # Bulk revert
+        stmt = (
+            update(MessageRecord)
+            .where(
+                MessageRecord.state == MessageState.processing,
+                MessageRecord.next_retry_at <= now,
+            )
+            .values(state=MessageState.queued, next_retry_at=None)
+        )
+        result = await session.execute(stmt)
+        await session.commit()
+
+        logger.info("Reclaimed %d stale processing messages back to queued", result.rowcount)
+
+        # Notify affected agents so they re-poll
+        for agent_id in affected_agents:
+            await notify_inbox(agent_id)
+
+
 async def _expire_batch() -> None:
     """Scan for queued messages past their TTL and expire them."""
     from hub.routers.hub import notify_inbox
@@ -128,9 +178,10 @@ async def _expire_batch() -> None:
 
 
 async def message_expiry_loop() -> None:
-    """Background loop that expires queued messages past their TTL."""
+    """Background loop that expires queued messages past their TTL and reclaims stale processing."""
     while True:
         try:
+            await _reclaim_stale_processing()
             await _expire_batch()
         except asyncio.CancelledError:
             raise

--- a/backend/hub/routers/hub.py
+++ b/backend/hub/routers/hub.py
@@ -50,6 +50,8 @@ from hub.prompt_guard import scan_content, InjectionRisk
 from hub.schemas import (
     HistoryMessage,
     HistoryResponse,
+    InboxAckRequest,
+    InboxAckResponse,
     InboxMessage,
     InboxPollResponse,
     MessageEnvelope,
@@ -239,8 +241,21 @@ async def notify_inbox(
         for ws in list(ws_set):
             try:
                 await ws.send_json({"type": "inbox_update"})
-            except Exception:
+            except (WebSocketDisconnect, RuntimeError) as exc:
+                # Permanent disconnect — mark connection as dead
+                logger.debug(
+                    "WS send failed (disconnect) for agent=%s: %s",
+                    agent_id,
+                    exc,
+                )
                 dead.append(ws)
+            except Exception as exc:
+                # Transient or unknown error — log warning but keep connection alive
+                logger.warning(
+                    "WS send failed (transient) for agent=%s: %s",
+                    agent_id,
+                    exc,
+                )
         for ws in dead:
             ws_set.discard(ws)
         if not ws_set:
@@ -1093,7 +1108,11 @@ def _build_delivery_note(last_error: str | None) -> str | None:
 async def _fetch_queued_messages(
     db: AsyncSession, agent_id: str, limit: int, room_id: str | None = None
 ) -> list[MessageRecord]:
-    """Return up to *limit* queued messages for *agent_id*, ordered oldest first."""
+    """Return up to *limit* queued messages for *agent_id*, ordered oldest first.
+
+    Uses FOR UPDATE SKIP LOCKED on PostgreSQL to prevent concurrent polls from
+    claiming the same rows. Falls back to a plain SELECT on SQLite (tests).
+    """
     stmt = (
         select(MessageRecord)
         .where(
@@ -1105,6 +1124,10 @@ async def _fetch_queued_messages(
     )
     if room_id is not None:
         stmt = stmt.where(MessageRecord.room_id == room_id)
+    # Atomic claim: skip rows already locked by a concurrent poll
+    dialect = db.bind.dialect.name if db.bind else ""
+    if dialect == "postgresql":
+        stmt = stmt.with_for_update(skip_locked=True)
     result = await db.execute(stmt)
     return list(result.scalars().all())
 
@@ -1258,8 +1281,14 @@ async def poll_inbox(
             rec.state = MessageState.delivered
             rec.delivered_at = now
             rec.next_retry_at = None  # prevent retry loop from picking it up
+        else:
+            # Two-phase ack: mark as processing so concurrent polls skip them.
+            # Set next_retry_at as the processing timeout — the expiry loop will
+            # revert stale processing records back to queued after this time.
+            rec.state = MessageState.processing
+            rec.next_retry_at = now + datetime.timedelta(seconds=120)
 
-    if ack and messages:
+    if messages:
         await db.commit()
 
     return InboxPollResponse(
@@ -1267,6 +1296,52 @@ async def poll_inbox(
         count=len(messages),
         has_more=has_more,
     )
+
+
+# ---------------------------------------------------------------------------
+# POST /hub/inbox/ack — explicit message acknowledgement
+# ---------------------------------------------------------------------------
+
+
+@router.post("/inbox/ack", response_model=InboxAckResponse)
+async def ack_inbox_messages(
+    body: InboxAckRequest,
+    db: AsyncSession = Depends(get_db),
+    current_agent: str = Depends(get_dashboard_claimed_agent),
+):
+    """Acknowledge specific messages by ID, marking them as delivered."""
+    if not body.message_ids:
+        return InboxAckResponse(acked=0)
+
+    # Fetch processing (two-phase ack) or queued messages belonging to the agent
+    stmt = (
+        select(MessageRecord)
+        .where(
+            MessageRecord.receiver_id == current_agent,
+            MessageRecord.hub_msg_id.in_(body.message_ids),
+            MessageRecord.state.in_([MessageState.processing, MessageState.queued]),
+        )
+    )
+    result = await db.execute(stmt)
+    rows = list(result.scalars().all())
+
+    if not rows:
+        return InboxAckResponse(acked=0)
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    for rec in rows:
+        rec.state = MessageState.delivered
+        rec.delivered_at = now
+        rec.next_retry_at = None
+
+    await db.commit()
+    logger.info(
+        "Acked %d messages for agent=%s (requested %d)",
+        len(rows),
+        current_agent,
+        len(body.message_ids),
+    )
+    return InboxAckResponse(acked=len(rows))
 
 
 # ---------------------------------------------------------------------------

--- a/backend/hub/schemas.py
+++ b/backend/hub/schemas.py
@@ -335,6 +335,14 @@ class InboxPollResponse(BaseModel):
     has_more: bool
 
 
+class InboxAckRequest(BaseModel):
+    message_ids: list[str]
+
+
+class InboxAckResponse(BaseModel):
+    acked: int
+
+
 # --- History schemas ---
 
 

--- a/plugin/src/client.ts
+++ b/plugin/src/client.ts
@@ -59,8 +59,8 @@ export class BotCordClient {
 
   // ── Token management ──────────────────────────────────────────
 
-  async ensureToken(): Promise<string> {
-    if (this.jwtToken && Date.now() / 1000 < this.tokenExpiresAt - 60) {
+  async ensureToken(forceRefresh = false): Promise<string> {
+    if (!forceRefresh && this.jwtToken && Date.now() / 1000 < this.tokenExpiresAt - 60) {
       return this.jwtToken;
     }
     return this.refreshToken();
@@ -300,6 +300,14 @@ export class BotCordClient {
 
     const resp = await this.hubFetch(`/hub/inbox?${params.toString()}`);
     return (await resp.json()) as InboxPollResponse;
+  }
+
+  async ackMessages(messageIds: string[]): Promise<void> {
+    if (messageIds.length === 0) return;
+    await this.hubFetch("/hub/inbox/ack", {
+      method: "POST",
+      body: JSON.stringify({ message_ids: messageIds }),
+    });
   }
 
   async getHistory(options?: {

--- a/plugin/src/poller.ts
+++ b/plugin/src/poller.ts
@@ -27,14 +27,24 @@ export function startPoller(opts: PollerOptions): { stop: () => void } {
     if (!running || abortSignal?.aborted) return;
 
     try {
-      const resp = await client.pollInbox({ limit: 20, ack: true });
+      const resp = await client.pollInbox({ limit: 20, ack: false });
       const messages = resp.messages || [];
+      const ackedIds: string[] = [];
 
       for (const msg of messages) {
         try {
           await handleInboxMessage(msg, accountId, cfg);
+          ackedIds.push(msg.hub_msg_id);
         } catch (err: any) {
           log?.error(`[${dp}] failed to dispatch message ${msg.hub_msg_id}: ${err.message}`);
+        }
+      }
+
+      if (ackedIds.length > 0) {
+        try {
+          await client.ackMessages(ackedIds);
+        } catch (err: any) {
+          log?.error(`[${dp}] ack error: ${err.message}`);
         }
       }
     } catch (err: any) {

--- a/plugin/src/ws-client.ts
+++ b/plugin/src/ws-client.ts
@@ -48,6 +48,8 @@ export function startWsClient(opts: WsClientOptions): { stop: () => void } {
   let ws: WebSocket | null = null;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   let reconnectAttempt = 0;
+  let consecutiveAuthFailures = 0;
+  const MAX_AUTH_FAILURES = 5;
   let processing = false;
   let keepaliveTimer: ReturnType<typeof setInterval> | null = null;
   const KEEPALIVE_INTERVAL = 20_000; // 20s — well under Caddy/proxy 30s timeout
@@ -56,13 +58,22 @@ export function startWsClient(opts: WsClientOptions): { stop: () => void } {
     if (processing) return;
     processing = true;
     try {
-      const resp = await client.pollInbox({ limit: 20, ack: true });
+      const resp = await client.pollInbox({ limit: 20, ack: false });
       const messages = resp.messages || [];
+      const ackedIds: string[] = [];
       for (const msg of messages) {
         try {
           await handleInboxMessage(msg, accountId, cfg);
+          ackedIds.push(msg.hub_msg_id);
         } catch (err: any) {
           log?.error(`[${dp}] ws dispatch error for ${msg.hub_msg_id}: ${err.message}`);
+        }
+      }
+      if (ackedIds.length > 0) {
+        try {
+          await client.ackMessages(ackedIds);
+        } catch (err: any) {
+          log?.error(`[${dp}] ws ack error: ${err.message}`);
         }
       }
     } catch (err: any) {
@@ -96,6 +107,7 @@ export function startWsClient(opts: WsClientOptions): { stop: () => void } {
             case "auth_ok":
               log?.info(`[${dp}] WebSocket authenticated as ${msg.agent_id}`);
               reconnectAttempt = 0; // Reset backoff on successful auth
+              consecutiveAuthFailures = 0; // Reset auth failure counter
               // Start client-side keepalive to survive proxies/Caddy timeouts
               if (keepaliveTimer) clearInterval(keepaliveTimer);
               keepaliveTimer = setInterval(() => {
@@ -103,6 +115,8 @@ export function startWsClient(opts: WsClientOptions): { stop: () => void } {
                   ws.send(JSON.stringify({ type: "ping" }));
                 }
               }, KEEPALIVE_INTERVAL);
+              // Catch up on messages missed during disconnect
+              fetchAndDispatch();
               break;
 
             case "inbox_update":
@@ -127,15 +141,25 @@ export function startWsClient(opts: WsClientOptions): { stop: () => void } {
         }
       });
 
-      ws.on("close", (code: number, reason: Buffer) => {
+      ws.on("close", async (code: number, reason: Buffer) => {
         const reasonStr = reason.toString();
         log?.info(`[${dp}] WebSocket closed: code=${code} reason=${reasonStr}`);
         ws = null;
         if (keepaliveTimer) { clearInterval(keepaliveTimer); keepaliveTimer = null; }
 
         if (code === 4001) {
-          // Auth failure — don't reconnect immediately, token may need refresh
-          log?.warn(`[${dp}] WebSocket auth failed, will retry with fresh token`);
+          consecutiveAuthFailures++;
+          if (consecutiveAuthFailures >= MAX_AUTH_FAILURES) {
+            log?.error(`[${dp}] WebSocket auth failed ${consecutiveAuthFailures} times consecutively, stopping reconnect`);
+            return;
+          }
+          log?.warn(`[${dp}] WebSocket auth failed (${consecutiveAuthFailures}/${MAX_AUTH_FAILURES}), force-refreshing token before reconnect`);
+          // Await token refresh so the next connect() picks up the new token
+          try {
+            await client.ensureToken(true);
+          } catch (err: any) {
+            log?.error(`[${dp}] Token force-refresh failed: ${err.message}`);
+          }
         }
 
         scheduleReconnect();


### PR DESCRIPTION
## Summary
- Add `processing` message state + `POST /hub/inbox/ack` for two-phase delivery (poll claims with `FOR UPDATE SKIP LOCKED`, ack after dispatch, expiry reclaims stale + notifies agents)
- Await token force-refresh on WS 4001 with circuit breaker (5 max failures)
- Pull inbox on WS `auth_ok` to recover missed messages during disconnect
- Distinguish transient vs permanent errors in `notify_inbox` WS send

## Test plan
- [ ] Backend: 130 tests pass (pre-existing SQLite schema error in contact_requests unrelated)
- [ ] Plugin: 193/193 tests pass
- [ ] Verify two-phase ack: poll returns messages, concurrent poll skips them, ack confirms delivery
- [ ] Verify stale processing reclaim: unacked messages revert to queued after 2min timeout
- [ ] Verify WS reconnect pulls inbox immediately on auth_ok
- [ ] Verify 4001 auth loop breaks after 5 consecutive failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)