### PR TITLE
fix: update last_sender_name in realtime room hint

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -1653,6 +1653,7 @@ async def send_chat_message(
             hub_msg_id=hub_msg_id,
             created_at=record.created_at,
             payload=payload,
+            sender_name=agent_display_name,
         ),
     )
 

--- a/backend/hub/routers/dashboard_chat.py
+++ b/backend/hub/routers/dashboard_chat.py
@@ -233,6 +233,7 @@ async def send_chat_message(
             hub_msg_id=hub_msg_id,
             created_at=record.created_at,
             payload=payload,
+            sender_name=agent_display_name,
         ),
     )
 

--- a/backend/hub/routers/hub.py
+++ b/backend/hub/routers/hub.py
@@ -136,6 +136,7 @@ def build_message_realtime_event(
     topic_id: str | None = None,
     mentioned: bool = False,
     payload: dict[str, Any] | None = None,
+    sender_name: str | None = None,
 ) -> dict[str, Any]:
     return build_agent_realtime_event(
         type=type,
@@ -145,6 +146,7 @@ def build_message_realtime_event(
         created_at=created_at,
         ext={
             "sender_id": sender_id,
+            "sender_name": sender_name,
             "topic_id": topic_id,
             "preview": _message_preview(payload or {}),
             "mentioned": mentioned,
@@ -597,6 +599,12 @@ async def _send_direct_message(
 
     await db.commit()
 
+    # Resolve sender display name for realtime event
+    _sender_name_result = await db.execute(
+        select(Agent.display_name).where(Agent.agent_id == envelope.from_)
+    )
+    _sender_display_name = _sender_name_result.scalar_one_or_none()
+
     # Notify inbox listeners
     await notify_inbox(
         envelope.to,
@@ -611,6 +619,7 @@ async def _send_direct_message(
             topic_id=topic_id,
             mentioned=True,
             payload=envelope.payload,
+            sender_name=_sender_display_name,
         ),
     )
 
@@ -743,6 +752,12 @@ async def _send_room_message(
         if m.agent_id != envelope.from_ and not m.muted and m.agent_id not in blocked_by
     }
 
+    # Resolve sender display name for realtime events
+    _sender_name_result = await db.execute(
+        select(Agent.display_name).where(Agent.agent_id == envelope.from_)
+    )
+    _sender_display_name = _sender_name_result.scalar_one_or_none()
+
     # When the sender is the only member (or all others are muted/blocking),
     # receivers would be empty.  Create a self-delivery record so the message
     # appears in room history, but skip inbox notification to avoid the plugin
@@ -822,6 +837,7 @@ async def _send_room_message(
             topic_id=topic_id,
             mentioned=receiver_id in (envelope.mentions or []) or "@all" in (envelope.mentions or []),
             payload=envelope.payload,
+            sender_name=_sender_display_name,
         )
         if _self_delivery and receiver_id == envelope.from_:
             # Self-delivery: publish realtime event for the dashboard
@@ -844,6 +860,7 @@ async def _send_room_message(
             topic_id=topic_id,
             mentioned=False,
             payload=envelope.payload,
+            sender_name=_sender_display_name,
         )
         await _publish_agent_realtime_event(db, sender_rt_event)
 

--- a/frontend/src/store/useDashboardChatStore.ts
+++ b/frontend/src/store/useDashboardChatStore.ts
@@ -33,6 +33,7 @@ function applyRealtimeRoomHint<T extends {
   room_id: string;
   last_message_at: string | null;
   last_message_preview: string | null;
+  last_sender_name: string | null;
 }>(room: T, event: RealtimeMetaEvent): T {
   if (room.room_id !== event.room_id) return room;
 
@@ -40,10 +41,15 @@ function applyRealtimeRoomHint<T extends {
     ? event.ext.preview
     : room.last_message_preview;
 
+  const senderName = typeof event.ext.sender_name === "string"
+    ? event.ext.sender_name
+    : room.last_sender_name;
+
   return {
     ...room,
     last_message_at: event.created_at > (room.last_message_at ?? "") ? event.created_at : room.last_message_at,
     last_message_preview: preview,
+    last_sender_name: senderName,
   };
 }
 


### PR DESCRIPTION
## Summary
- Room list sidebar showed stale sender name when new realtime messages arrived
- Backend: added `sender_name` to realtime event `ext` payload in all send flows (DM, room fan-out, owner chat, user chat)
- Frontend: `applyRealtimeRoomHint` now updates `last_sender_name` from the event

## Test plan
- [ ] Send a message in a room from agent A, verify room list shows A's name
- [ ] Send a follow-up from agent B, verify room list updates to B's name immediately
- [ ] Verify DM and owner-chat flows also show correct sender name

🤖 Generated with [Claude Code](https://claude.com/claude-code)