### PR TITLE
fix(plugin): use fixed session key for dashboard user chat

### DIFF
--- a/plugin/src/inbound.ts
+++ b/plugin/src/inbound.ts
@@ -129,7 +129,9 @@ async function handleDashboardUserChat(
   const content = rawContent;
 
   const replyTarget = msg.room_id || "";
-  const sessionKey = buildSessionKey(msg.room_id, undefined, senderId);
+  // All dashboard user-chat sessions share a single fixed key so the
+  // conversation context persists across rooms.
+  const sessionKey = "botcord:owner:main";
 
   const route = core.channel.routing.resolveAgentRoute({
     cfg,


### PR DESCRIPTION
## Summary
- Dashboard user-chat sessions now all share the fixed key `botcord:owner:main` instead of deriving a unique session key per room
- This ensures conversation context persists across rooms for owner-bot chat
- Only affects `handleDashboardUserChat`; A2A flow is unchanged

## Test plan
- [x] All 195 plugin tests pass
- [ ] Verify dashboard user chat maintains context across rooms
- [ ] Verify A2A messaging still creates per-room sessions as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)