### PR TITLE
feat(plugin): support multiple notifySession targets

### DIFF
--- a/openclaw-setup_instruction.md
+++ b/openclaw-setup_instruction.md
@@ -64,9 +64,9 @@ Notes:
 
 ### `notifySession` configuration
 
-`notifySession` lives under `channels.botcord` in `~/.openclaw/openclaw.json`. It tells OpenClaw which local session should receive the BotCord inbound notification.
+`notifySession` lives under `channels.botcord` in `~/.openclaw/openclaw.json`. It tells OpenClaw which local session(s) should receive BotCord inbound notifications. It accepts a single string or an array of strings to notify multiple sessions.
 
-Example:
+Example (single session):
 
 ```jsonc
 {
@@ -78,7 +78,22 @@ Example:
       "enabled": true,
       "credentialsFile": "/Users/yourname/.botcord/credentials/ag_xxxxxxxxxxxx.json",
       "deliveryMode": "websocket",
-      "notifySession": "agent:pm:telegram:direct:1234567890"
+      "notifySession": "botcord:owner:main"
+    }
+  }
+}
+```
+
+Example (multiple sessions):
+
+```jsonc
+{
+  "channels": {
+    "botcord": {
+      "enabled": true,
+      "credentialsFile": "/Users/yourname/.botcord/credentials/ag_xxxxxxxxxxxx.json",
+      "deliveryMode": "websocket",
+      "notifySession": ["botcord:owner:main", "agent:pm:telegram:direct:1234567890"]
     }
   }
 }
@@ -86,9 +101,9 @@ Example:
 
 What this means:
 
-- `notifySession` should be an existing OpenClaw session key.
-- In a setup like the example above, inbound BotCord notifications are forwarded into the `pm` agent's Telegram direct-message session.
-- If you use `openclaw botcord-register`, this value is usually written for you automatically. You only need to edit it manually if you want notifications to go to a different session.
+- `notifySession` should be an existing OpenClaw session key (or an array of them).
+- In a setup like the example above, inbound BotCord notifications are forwarded into the specified session(s).
+- If you use `openclaw botcord-register`, this value is usually written for you automatically (default: `botcord:owner:main`). You only need to edit it manually if you want notifications to go to a different session.
 - If `notifySession` points to the wrong session, BotCord messages may still arrive at the gateway but will not be routed to the place you expect.
 
 ### 3. Restart and verify

--- a/plugin/skills/botcord/SKILL.md
+++ b/plugin/skills/botcord/SKILL.md
@@ -420,7 +420,7 @@ BotCord channel config lives in `openclaw.json` under `channels.botcord`:
       "enabled": true,
       "credentialsFile": "~/.botcord/credentials/ag_xxxxxxxxxxxx.json",
       "deliveryMode": "websocket",   // "websocket" (recommended) or "polling"
-      "notifySession": "agent:pm:telegram:direct:7904063707"
+      "notifySession": "botcord:owner:main"
     }
   }
 }
@@ -428,7 +428,9 @@ BotCord channel config lives in `openclaw.json` under `channels.botcord`:
 
 ### `notifySession`
 
-When BotCord receives notification-type messages (contact requests, contact responses, contact removals), the plugin sends a push notification directly to the channel specified by this session key — **without triggering an agent turn**. This lets the owner see incoming events in real time on their preferred messaging app.
+When BotCord receives notification-type messages (contact requests, contact responses, contact removals), the plugin sends a push notification directly to the channel(s) specified by this session key — **without triggering an agent turn**. This lets the owner see incoming events in real time on their preferred messaging app.
+
+`notifySession` accepts a single string or an array of strings to notify multiple sessions simultaneously.
 
 **Format:** `agent:<agentName>:<channel>:<chatType>:<peerId>`
 

--- a/plugin/src/channel.ts
+++ b/plugin/src/channel.ts
@@ -149,8 +149,11 @@ const botCordConfigSchema = {
       items: { type: "string" as const },
     },
     notifySession: {
-      type: "string" as const,
-      description: "Session key to notify when inbound messages arrive (e.g. agent:main:main)",
+      oneOf: [
+        { type: "string" as const },
+        { type: "array" as const, items: { type: "string" as const } },
+      ],
+      description: "Session key(s) to notify when inbound messages arrive (e.g. botcord:owner:main)",
     },
     accounts: {
       type: "object" as const,

--- a/plugin/src/commands/register.ts
+++ b/plugin/src/commands/register.ts
@@ -95,7 +95,7 @@ function buildNextConfig(
             : "websocket",
         notifySession:
           currentBotcord.notifySession ||
-          "agent:main:main",
+          "botcord:owner:main",
       },
     },
     session: {

--- a/plugin/src/inbound.ts
+++ b/plugin/src/inbound.ts
@@ -25,6 +25,12 @@ import { BotCordClient } from "./client.js";
 import { createBotCordReplyDispatcher } from "./reply-dispatcher.js";
 import type { InboxMessage, MessageType } from "./types.js";
 
+/** Normalize notifySession (string | string[] | undefined) to a flat array. */
+export function normalizeNotifySessions(ns?: string | string[]): string[] {
+  if (!ns) return [];
+  return Array.isArray(ns) ? ns : [ns];
+}
+
 // Envelope types that count as notifications rather than normal messages
 const NOTIFICATION_TYPES: ReadonlySet<string> = new Set([
   "contact_request",
@@ -356,21 +362,20 @@ export async function dispatchInbound(params: InboundParams): Promise<void> {
   const messageType = params.messageType;
   if (messageType && NOTIFICATION_TYPES.has(messageType)) {
     const acct = resolveAccountConfig(cfg, accountId);
-    const notifySession = acct.notifySession;
-    if (notifySession) {
-      const childSessionKey = route.sessionKey || sessionKey;
-      if (childSessionKey !== notifySession) {
-        const topicLabel = topic ? ` (topic: ${topic})` : "";
-        const notification =
-          `[BotCord ${messageType}] from ${senderName}${topicLabel}\n` +
-          `Session: ${childSessionKey}\n` +
-          `Preview: ${(params.content || "").slice(0, 200)}`;
+    const sessions = normalizeNotifySessions(acct.notifySession);
+    const childSessionKey = route.sessionKey || sessionKey;
+    for (const ns of sessions) {
+      if (ns === childSessionKey) continue;
+      const topicLabel = topic ? ` (topic: ${topic})` : "";
+      const notification =
+        `[BotCord ${messageType}] from ${senderName}${topicLabel}\n` +
+        `Session: ${childSessionKey}\n` +
+        `Preview: ${(params.content || "").slice(0, 200)}`;
 
-        try {
-          await deliverNotification(core, cfg, notifySession, notification);
-        } catch (err: any) {
-          console.error(`[botcord] auto-notify failed:`, err?.message ?? err);
-        }
+      try {
+        await deliverNotification(core, cfg, ns, notification);
+      } catch (err: any) {
+        console.error(`[botcord] auto-notify failed:`, err?.message ?? err);
       }
     }
   }

--- a/plugin/src/reset-credential.ts
+++ b/plugin/src/reset-credential.ts
@@ -47,7 +47,7 @@ function buildNextConfig(config: Record<string, any>, credentialsFile: string): 
         enabled: true,
         credentialsFile,
         deliveryMode: currentBotcord.deliveryMode === "polling" ? "polling" : "websocket",
-        notifySession: currentBotcord.notifySession || "agent:main:main",
+        notifySession: currentBotcord.notifySession || "botcord:owner:main",
       },
     },
     session: {

--- a/plugin/src/tools/notify.ts
+++ b/plugin/src/tools/notify.ts
@@ -6,7 +6,7 @@
 import { getBotCordRuntime } from "../runtime.js";
 import { getConfig as getAppConfig } from "../runtime.js";
 import { getSingleAccountModeError, resolveAccountConfig } from "../config.js";
-import { deliverNotification } from "../inbound.js";
+import { deliverNotification, normalizeNotifySessions } from "../inbound.js";
 
 export function createNotifyTool() {
   return {
@@ -34,8 +34,8 @@ export function createNotifyTool() {
       if (singleAccountError) return { error: singleAccountError };
 
       const acct = resolveAccountConfig(cfg);
-      const notifySession = acct.notifySession;
-      if (!notifySession) {
+      const sessions = normalizeNotifySessions(acct.notifySession);
+      if (sessions.length === 0) {
         return { error: "notifySession is not configured in channels.botcord" };
       }
 
@@ -45,12 +45,23 @@ export function createNotifyTool() {
         return { error: "text is required" };
       }
 
-      try {
-        await deliverNotification(core, cfg, notifySession, text);
-        return { ok: true, notifySession };
-      } catch (err: any) {
-        return { error: `notify failed: ${err?.message ?? err}` };
+      const errors: string[] = [];
+      for (const ns of sessions) {
+        try {
+          await deliverNotification(core, cfg, ns, text);
+        } catch (err: any) {
+          errors.push(`${ns}: ${err?.message ?? err}`);
+        }
       }
+
+      if (errors.length > 0) {
+        return {
+          ok: errors.length < sessions.length,
+          notifySessions: sessions,
+          errors,
+        };
+      }
+      return { ok: true, notifySessions: sessions };
     },
   };
 }

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -47,7 +47,7 @@ export type BotCordAccountConfig = {
   deliveryMode?: "polling" | "websocket";
   pollIntervalMs?: number;
   allowFrom?: string[];
-  notifySession?: string;
+  notifySession?: string | string[];
   accounts?: Record<string, BotCordAccountConfig>;
 };
 


### PR DESCRIPTION
## Summary
- `notifySession` now accepts `string | string[]` — notifications are delivered to all configured sessions
- Default value changed from `agent:main:main` to `botcord:owner:main`
- Updated setup instruction, SKILL.md, and channel schema docs

## Test plan
- [x] All 195 plugin tests pass
- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] Verify single-string config still works (backward compatible)
- [ ] Verify array config delivers to multiple sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)