### PR TITLE
feat: three-tier prompt instructions + Hub invite endpoints

### DIFF
--- a/backend/app/routers/invites.py
+++ b/backend/app/routers/invites.py
@@ -11,13 +11,13 @@ import uuid as _uuid
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy import func, select
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import RequestContext, require_active_agent
 from hub.config import FRONTEND_BASE_URL
 from hub.database import get_db
 from hub.enums import RoomRole, RoomVisibility, SubscriptionStatus
+from hub.invite_ops import preview_invite, redeem_invite_for_agent
 from hub.models import Agent, AgentSubscription, Contact, Invite, InviteRedemption, Room, RoomMember
 from hub.share_payloads import frontend_url, room_continue_url, room_entry_type
 
@@ -30,14 +30,6 @@ class CreateInviteBody(BaseModel):
 
 def _utc_now() -> datetime.datetime:
     return datetime.datetime.now(datetime.timezone.utc)
-
-
-def _continue_url_for_invite(invite: Invite, room: Room | None = None) -> str:
-    if invite.kind == "friend":
-        return frontend_url("/chats/contacts/agents")
-    if room is None or invite.room_id is None:
-        return frontend_url("/chats/messages")
-    return room_continue_url(invite.room_id)
 
 
 def _invite_url(code: str) -> str:
@@ -70,6 +62,24 @@ def _serialize_invite_preview(invite: Invite, creator: Agent, room: Room | None,
             "member_count": member_count,
         },
     }
+
+
+def _continue_url_for_invite(invite: Invite, room: Room | None = None) -> str:
+    if invite.kind == "friend":
+        return frontend_url("/chats/contacts/agents")
+    if room is None or invite.room_id is None:
+        return frontend_url("/chats/messages")
+    return room_continue_url(invite.room_id)
+
+
+def _can_invite(room: Room, member: RoomMember) -> bool:
+    if member.role == RoomRole.owner:
+        return True
+    if member.can_invite is not None:
+        return member.can_invite
+    if member.role == RoomRole.admin:
+        return True
+    return room.default_invite
 
 
 async def _load_invite_or_404(code: str, db: AsyncSession) -> Invite:
@@ -111,44 +121,6 @@ async def _load_membership(room_id: str, agent_id: str, db: AsyncSession) -> Roo
     if member is None:
         raise HTTPException(status_code=403, detail="Not a member of this room")
     return member
-
-
-def _can_invite(room: Room, member: RoomMember) -> bool:
-    if member.role == RoomRole.owner:
-        return True
-    if member.can_invite is not None:
-        return member.can_invite
-    if member.role == RoomRole.admin:
-        return True
-    return room.default_invite
-
-
-async def _ensure_subscription_access(room: Room, agent_id: str, db: AsyncSession) -> None:
-    if not room.required_subscription_product_id or room.owner_id == agent_id:
-        return
-    result = await db.execute(
-        select(AgentSubscription).where(
-            AgentSubscription.product_id == room.required_subscription_product_id,
-            AgentSubscription.subscriber_agent_id == agent_id,
-            AgentSubscription.status == SubscriptionStatus.active,
-        )
-    )
-    if result.scalar_one_or_none() is None:
-        raise HTTPException(status_code=403, detail="Active subscription required to join this room")
-
-
-async def _record_redemption(invite: Invite, redeemer_agent_id: str, db: AsyncSession) -> bool:
-    db.add(InviteRedemption(code=invite.code, redeemer_agent_id=redeemer_agent_id))
-    try:
-        await db.flush()
-    except IntegrityError:
-        await db.rollback()
-        refreshed = await _load_invite_or_404(invite.code, db)
-        invite.use_count = refreshed.use_count
-        return False
-    invite.use_count += 1
-    await db.flush()
-    return True
 
 
 @router.post("/friends", status_code=201)
@@ -205,22 +177,7 @@ async def get_invite(
     code: str,
     db: AsyncSession = Depends(get_db),
 ):
-    invite = await _load_invite_or_404(code, db)
-    _ensure_invite_active(invite)
-
-    creator = await db.scalar(select(Agent).where(Agent.agent_id == invite.creator_agent_id))
-    if creator is None:
-        raise HTTPException(status_code=404, detail="Invite creator not found")
-
-    room = None
-    member_count = 0
-    if invite.room_id:
-        room = await _load_room_or_404(invite.room_id, db)
-        member_count = await db.scalar(
-            select(func.count(RoomMember.id)).where(RoomMember.room_id == invite.room_id)
-        ) or 0
-
-    return _serialize_invite_preview(invite, creator=creator, room=room, member_count=member_count)
+    return await preview_invite(code, db)
 
 
 @router.post("/{code}/redeem")
@@ -229,80 +186,7 @@ async def redeem_invite(
     ctx: RequestContext = Depends(require_active_agent),
     db: AsyncSession = Depends(get_db),
 ):
-    invite = await _load_invite_or_404(code, db)
-
-    if invite.kind == "friend":
-        existing = await db.execute(
-            select(Contact).where(
-                Contact.owner_id == ctx.active_agent_id,
-                Contact.contact_agent_id == invite.creator_agent_id,
-            )
-        )
-        if existing.scalar_one_or_none() is not None:
-            return {
-                "status": "already_connected",
-                "kind": "friend",
-                "target_type": "friend",
-                "target_id": invite.creator_agent_id,
-                "continue_url": _continue_url_for_invite(invite),
-            }
-        if invite.creator_agent_id == ctx.active_agent_id:
-            raise HTTPException(status_code=400, detail="You cannot use your own friend invite")
-        _ensure_invite_active(invite)
-        db.add(Contact(owner_id=ctx.active_agent_id, contact_agent_id=invite.creator_agent_id))
-        db.add(Contact(owner_id=invite.creator_agent_id, contact_agent_id=ctx.active_agent_id))
-        await _record_redemption(invite, ctx.active_agent_id, db)
-        await db.commit()
-        return {
-            "status": "redeemed",
-            "kind": "friend",
-            "target_type": "friend",
-            "target_id": invite.creator_agent_id,
-            "continue_url": _continue_url_for_invite(invite),
-        }
-
-    room = await _load_room_or_404(invite.room_id or "", db)
-    existing_member = await db.execute(
-        select(RoomMember).where(
-            RoomMember.room_id == room.room_id,
-            RoomMember.agent_id == ctx.active_agent_id,
-        )
-    )
-    if existing_member.scalar_one_or_none() is not None:
-        return {
-            "status": "already_joined",
-            "kind": "room",
-            "target_type": "room",
-            "target_id": room.room_id,
-            "continue_url": _continue_url_for_invite(invite, room),
-        }
-
-    _ensure_invite_active(invite)
-    await _ensure_subscription_access(room, ctx.active_agent_id, db)
-
-    if room.max_members is not None:
-        member_count = await db.scalar(
-            select(func.count(RoomMember.id)).where(RoomMember.room_id == room.room_id)
-        ) or 0
-        if member_count >= room.max_members:
-            raise HTTPException(status_code=409, detail="Room is full")
-
-    db.add(
-        RoomMember(
-            room_id=room.room_id,
-            agent_id=ctx.active_agent_id,
-            role=RoomRole.member,
-        )
-    )
-    await _record_redemption(invite, ctx.active_agent_id, db)
-    await db.commit()
-    return {
-        "status": "redeemed",
-        "kind": "room",
-        "target_type": "room",
-        "target_id": room.room_id,
-        "continue_url": _continue_url_for_invite(invite, room),
-    }
+    return await redeem_invite_for_agent(code, ctx.active_agent_id, db)
 
 
 @router.delete("/{code}")
@@ -314,6 +198,7 @@ async def revoke_invite(
     invite = await _load_invite_or_404(code, db)
     if invite.creator_agent_id != ctx.active_agent_id:
         raise HTTPException(status_code=403, detail="You cannot revoke this invite")
+    _ensure_invite_active(invite)
     invite.revoked_at = _utc_now()
     await db.commit()
     return {"code": invite.code, "revoked": True}

--- a/backend/hub/invite_ops.py
+++ b/backend/hub/invite_ops.py
@@ -1,0 +1,221 @@
+"""
+[INPUT]: SQLAlchemy 会话与邀请/联系人/房间模型
+[OUTPUT]: 邀请预览与兑换核心逻辑，供 Hub 层和 BFF 层共享
+[POS]: 邀请领域服务层，收敛 invite 校验、兑换、计数等操作
+[PROTOCOL]: 变更时更新此头部，然后检查 README.md
+"""
+
+import datetime
+
+from fastapi import HTTPException
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from hub.enums import RoomRole, SubscriptionStatus
+from hub.models import Agent, AgentSubscription, Contact, Invite, InviteRedemption, Room, RoomMember
+from hub.share_payloads import frontend_url, room_continue_url, room_entry_type
+
+
+def _utc_now() -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def _continue_url_for_invite(invite: Invite, room: Room | None = None) -> str:
+    if invite.kind == "friend":
+        return frontend_url("/chats/contacts/agents")
+    if room is None or invite.room_id is None:
+        return frontend_url("/chats/messages")
+    return room_continue_url(invite.room_id)
+
+
+def _invite_url(code: str) -> str:
+    return frontend_url(f"/i/{code}")
+
+
+def _serialize_invite_preview(invite: Invite, creator: Agent, room: Room | None, member_count: int = 0) -> dict:
+    return {
+        "code": invite.code,
+        "kind": invite.kind,
+        "entry_type": "friend_invite" if invite.kind == "friend" else room_entry_type(room).replace("private_room", "private_invite") if room else "private_invite",
+        "target_type": "friend" if invite.kind == "friend" else "room",
+        "target_id": creator.agent_id if invite.kind == "friend" else invite.room_id,
+        "invite_url": _invite_url(invite.code),
+        "continue_url": _continue_url_for_invite(invite, room),
+        "expires_at": invite.expires_at.isoformat() if invite.expires_at else None,
+        "max_uses": invite.max_uses,
+        "use_count": invite.use_count,
+        "creator": {
+            "agent_id": creator.agent_id,
+            "display_name": creator.display_name,
+        },
+        "room": None if room is None else {
+            "room_id": room.room_id,
+            "name": room.name,
+            "description": room.description,
+            "visibility": room.visibility.value,
+            "join_mode": room.join_policy.value,
+            "requires_payment": bool(room.required_subscription_product_id),
+            "member_count": member_count,
+        },
+    }
+
+
+async def _load_invite_or_404(code: str, db: AsyncSession) -> Invite:
+    result = await db.execute(select(Invite).where(Invite.code == code))
+    invite = result.scalar_one_or_none()
+    if invite is None:
+        raise HTTPException(status_code=404, detail="Invite not found")
+    return invite
+
+
+def _ensure_invite_active(invite: Invite) -> None:
+    if invite.revoked_at is not None:
+        raise HTTPException(status_code=410, detail="Invite has been revoked")
+    expires_at = invite.expires_at
+    if expires_at is not None and expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=datetime.timezone.utc)
+    if expires_at is not None and _utc_now() > expires_at:
+        raise HTTPException(status_code=410, detail="Invite has expired")
+    if invite.use_count >= invite.max_uses:
+        raise HTTPException(status_code=410, detail="Invite is no longer available")
+
+
+async def _load_room_or_404(room_id: str, db: AsyncSession) -> Room:
+    result = await db.execute(select(Room).where(Room.room_id == room_id))
+    room = result.scalar_one_or_none()
+    if room is None:
+        raise HTTPException(status_code=404, detail="Room not found")
+    return room
+
+
+async def _ensure_subscription_access(room: Room, agent_id: str, db: AsyncSession) -> None:
+    if not room.required_subscription_product_id or room.owner_id == agent_id:
+        return
+    result = await db.execute(
+        select(AgentSubscription).where(
+            AgentSubscription.product_id == room.required_subscription_product_id,
+            AgentSubscription.subscriber_agent_id == agent_id,
+            AgentSubscription.status == SubscriptionStatus.active,
+        )
+    )
+    if result.scalar_one_or_none() is None:
+        raise HTTPException(status_code=403, detail="Active subscription required to join this room")
+
+
+async def _record_redemption(invite: Invite, redeemer_agent_id: str, db: AsyncSession) -> bool:
+    db.add(InviteRedemption(code=invite.code, redeemer_agent_id=redeemer_agent_id))
+    try:
+        await db.flush()
+    except IntegrityError:
+        await db.rollback()
+        refreshed = await _load_invite_or_404(invite.code, db)
+        invite.use_count = refreshed.use_count
+        return False
+    invite.use_count += 1
+    await db.flush()
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def preview_invite(code: str, db: AsyncSession) -> dict:
+    """Load and serialize an invite preview (no auth required)."""
+    invite = await _load_invite_or_404(code, db)
+    _ensure_invite_active(invite)
+
+    creator = await db.scalar(select(Agent).where(Agent.agent_id == invite.creator_agent_id))
+    if creator is None:
+        raise HTTPException(status_code=404, detail="Invite creator not found")
+
+    room = None
+    member_count = 0
+    if invite.room_id:
+        room = await _load_room_or_404(invite.room_id, db)
+        member_count = await db.scalar(
+            select(func.count(RoomMember.id)).where(RoomMember.room_id == invite.room_id)
+        ) or 0
+
+    return _serialize_invite_preview(invite, creator=creator, room=room, member_count=member_count)
+
+
+async def redeem_invite_for_agent(code: str, agent_id: str, db: AsyncSession) -> dict:
+    """Core invite redemption logic shared by Hub and BFF layers."""
+    invite = await _load_invite_or_404(code, db)
+
+    if invite.kind == "friend":
+        existing = await db.execute(
+            select(Contact).where(
+                Contact.owner_id == agent_id,
+                Contact.contact_agent_id == invite.creator_agent_id,
+            )
+        )
+        if existing.scalar_one_or_none() is not None:
+            return {
+                "status": "already_connected",
+                "kind": "friend",
+                "target_type": "friend",
+                "target_id": invite.creator_agent_id,
+                "continue_url": _continue_url_for_invite(invite),
+            }
+        if invite.creator_agent_id == agent_id:
+            raise HTTPException(status_code=400, detail="You cannot use your own friend invite")
+        _ensure_invite_active(invite)
+        db.add(Contact(owner_id=agent_id, contact_agent_id=invite.creator_agent_id))
+        db.add(Contact(owner_id=invite.creator_agent_id, contact_agent_id=agent_id))
+        await _record_redemption(invite, agent_id, db)
+        await db.commit()
+        return {
+            "status": "redeemed",
+            "kind": "friend",
+            "target_type": "friend",
+            "target_id": invite.creator_agent_id,
+            "continue_url": _continue_url_for_invite(invite),
+        }
+
+    # Room invite
+    room = await _load_room_or_404(invite.room_id or "", db)
+    existing_member = await db.execute(
+        select(RoomMember).where(
+            RoomMember.room_id == room.room_id,
+            RoomMember.agent_id == agent_id,
+        )
+    )
+    if existing_member.scalar_one_or_none() is not None:
+        return {
+            "status": "already_joined",
+            "kind": "room",
+            "target_type": "room",
+            "target_id": room.room_id,
+            "continue_url": _continue_url_for_invite(invite, room),
+        }
+
+    _ensure_invite_active(invite)
+    await _ensure_subscription_access(room, agent_id, db)
+
+    if room.max_members is not None:
+        member_count = await db.scalar(
+            select(func.count(RoomMember.id)).where(RoomMember.room_id == room.room_id)
+        ) or 0
+        if member_count >= room.max_members:
+            raise HTTPException(status_code=409, detail="Room is full")
+
+    db.add(
+        RoomMember(
+            room_id=room.room_id,
+            agent_id=agent_id,
+            role=RoomRole.member,
+        )
+    )
+    await _record_redemption(invite, agent_id, db)
+    await db.commit()
+    return {
+        "status": "redeemed",
+        "kind": "room",
+        "target_type": "room",
+        "target_id": room.room_id,
+        "continue_url": _continue_url_for_invite(invite, room),
+    }

--- a/backend/hub/main.py
+++ b/backend/hub/main.py
@@ -28,6 +28,7 @@ from hub.routers.dashboard import share_public_router
 from hub.routers.dashboard_chat import router as dashboard_chat_router
 from hub.routers.files import router as files_router
 from hub.routers.hub import router as hub_router
+from hub.routers.invites import router as hub_invites_router
 from hub.routers.registry import router as registry_router
 from hub.routers.public import router as public_router
 from hub.routers.room import internal_router as room_internal_router
@@ -192,6 +193,7 @@ app.include_router(registry_router)
 app.include_router(contacts_router)
 app.include_router(contact_requests_router)
 app.include_router(hub_router)
+app.include_router(hub_invites_router)
 app.include_router(room_router)
 app.include_router(room_internal_router)
 app.include_router(topics_router)

--- a/backend/hub/routers/invites.py
+++ b/backend/hub/routers/invites.py
@@ -1,0 +1,32 @@
+"""
+[INPUT]: 依赖 hub.auth 的 agent JWT 上下文与 invite_ops 共享逻辑完成邀请兑换
+[OUTPUT]: 对外提供 /hub/invites Hub 级路由，让 Plugin/CLI/HTTP 通过 agent token 兑换邀请
+[POS]: hub 层邀请端点，与 app/routers/invites.py（BFF 层）共享核心逻辑
+[PROTOCOL]: 变更时更新此头部，然后检查 README.md
+"""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from hub.auth import get_current_claimed_agent
+from hub.database import get_db
+from hub.invite_ops import preview_invite, redeem_invite_for_agent
+
+router = APIRouter(prefix="/hub/invites", tags=["hub-invites"])
+
+
+@router.get("/{code}")
+async def get_invite(
+    code: str,
+    db: AsyncSession = Depends(get_db),
+):
+    return await preview_invite(code, db)
+
+
+@router.post("/{code}/redeem")
+async def redeem_invite(
+    code: str,
+    current_agent: str = Depends(get_current_claimed_agent),
+    db: AsyncSession = Depends(get_db),
+):
+    return await redeem_invite_for_agent(code, current_agent, db)

--- a/frontend/src/lib/onboarding.ts
+++ b/frontend/src/lib/onboarding.ts
@@ -3,6 +3,8 @@
  * [OUTPUT]: 对外提供连接 Bot、真实邀请链接与建群动作的统一 Prompt 模板
  * [POS]: frontend onboarding 提示词模板层，负责把用户动作语言与内部实现细节隔离开，并禁止把内部页面路由伪装成对外入口
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
+ *
+ * Prompt 三级优先级：Plugin > CLI > HTTP
  */
 
 function trimTrailingSlash(value: string): string {
@@ -15,51 +17,9 @@ function resolveLocale(locale?: PromptLocale): PromptLocale {
   return locale === "en" ? "en" : "zh";
 }
 
-function buildHttpRequestParamLines(
-  locale: PromptLocale,
-  options?: {
-    headers?: string;
-    jsonParams?: string;
-  },
-): string[] {
-  if (locale === "en") {
-    return [
-      `Required headers: ${options?.headers || "none"}`,
-      `JSON params: ${options?.jsonParams || "none"}`,
-    ];
-  }
-
-  return [
-    `请求头参数：${options?.headers || "无"}`,
-    `JSON 参数：${options?.jsonParams || "无"}`,
-  ];
-}
-
-function buildInviteRedeemRequestLines(
-  redeemUrl: string,
-  locale: PromptLocale,
-  options?: { requiresPayment?: boolean },
-): string[] {
-  if (locale === "en") {
-    return [
-      options?.requiresPayment
-        ? `Accept the invite (payment may be required): POST ${redeemUrl}`
-        : `Accept the invite: POST ${redeemUrl}`,
-      ...buildHttpRequestParamLines(locale, {
-        headers: "Authorization: Bearer <BotCord access token>, X-Active-Agent: <current_bot_agent_id>",
-      }),
-    ];
-  }
-
-  return [
-    options?.requiresPayment
-      ? `接受邀请（可能需要付费）：POST ${redeemUrl}`
-      : `接受邀请：POST ${redeemUrl}`,
-    ...buildHttpRequestParamLines(locale, {
-      headers: "Authorization: Bearer <BotCord access token>, X-Active-Agent: <当前 Bot 的 agent_id>",
-    }),
-  ];
-}
+// ---------------------------------------------------------------------------
+// URL helpers
+// ---------------------------------------------------------------------------
 
 export function getBotcordWebAppUrl(): string {
   const envUrl = process.env.NEXT_PUBLIC_APP_URL;
@@ -97,6 +57,61 @@ export function rebaseToCurrentOrigin(url: string): string {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Three-tier instruction builder
+// ---------------------------------------------------------------------------
+
+interface TierInstructions {
+  plugin?: string[];
+  cli?: string[];
+  http?: string[];
+}
+
+function buildTieredBlock(locale: PromptLocale, tiers: TierInstructions): string[] {
+  const lines: string[] = [];
+  const hasMultiple = [tiers.plugin, tiers.cli, tiers.http].filter(Boolean).length > 1;
+
+  if (locale === "en") {
+    if (tiers.plugin?.length) {
+      if (hasMultiple) lines.push("If BotCord Plugin (OpenClaw) is installed:");
+      for (const l of tiers.plugin) lines.push(hasMultiple ? `  ${l}` : l);
+    }
+    if (tiers.cli?.length) {
+      if (hasMultiple) lines.push("If BotCord CLI is installed:");
+      for (const l of tiers.cli) lines.push(hasMultiple ? `  ${l}` : l);
+    }
+    if (tiers.http?.length) {
+      if (hasMultiple) lines.push("If neither is installed, use HTTP API directly:");
+      for (const l of tiers.http) lines.push(hasMultiple ? `  ${l}` : l);
+    }
+  } else {
+    if (tiers.plugin?.length) {
+      if (hasMultiple) lines.push("如果已安装 BotCord Plugin（OpenClaw 插件）：");
+      for (const l of tiers.plugin) lines.push(hasMultiple ? `  ${l}` : l);
+    }
+    if (tiers.cli?.length) {
+      if (hasMultiple) lines.push("如果已安装 BotCord CLI（botcord 命令行）：");
+      for (const l of tiers.cli) lines.push(hasMultiple ? `  ${l}` : l);
+    }
+    if (tiers.http?.length) {
+      if (hasMultiple) lines.push("如果都没安装，通过 HTTP 请求完成：");
+      for (const l of tiers.http) lines.push(hasMultiple ? `  ${l}` : l);
+    }
+  }
+  return lines;
+}
+
+function httpTokenHint(locale: PromptLocale, hubUrl: string): string {
+  if (locale === "en") {
+    return `Agent JWT token can be obtained via: POST ${hubUrl}/registry/agents/{agent_id}/token/refresh (requires Ed25519 signed challenge)`;
+  }
+  return `Agent JWT token 可通过 POST ${hubUrl}/registry/agents/{agent_id}/token/refresh 获取（需要 Ed25519 签名 challenge）`;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Connect Bot (bind agent to dashboard)
+// ---------------------------------------------------------------------------
+
 type ConnectPromptMode = "auto" | "create" | "link";
 
 export function buildConnectBotPrompt(options: {
@@ -118,37 +133,72 @@ export function buildConnectBotPrompt(options: {
         ? "If I already have a Bot, connect the existing one first and do not create a new one."
         : "If I already have a Bot, connect the existing one first. If not, create a new one for me.";
 
-    const lines = ["Help me start using BotCord."];
-    lines.push(
-      `If BotCord is not installed yet, follow this setup guide first: ${installGuideUrl}`,
+    const lines = [
+      "Help me start using BotCord.",
       modeLine,
       "After setup, connect this Bot to my BotCord account.",
-      options.connectionCode
-        ? `Use the botcord_bind tool with bind_ticket "${options.connectionCode}" to complete the binding.`
-        : (options.connectionInstruction || "If you need my confirmation during the connection flow, I will confirm it in this chat."),
+    ];
+
+    if (options.connectionCode) {
+      lines.push(
+        "",
+        ...buildTieredBlock(locale, {
+          plugin: [`Use the botcord_bind tool with bind_ticket "${options.connectionCode}".`],
+          cli: [`Run: botcord bind ${options.connectionCode}`],
+        }),
+      );
+    } else {
+      lines.push(
+        options.connectionInstruction || "If you need my confirmation during the connection flow, I will confirm it in this chat.",
+      );
+    }
+
+    lines.push(
+      "",
+      `If BotCord is not installed yet, follow this setup guide first: ${installGuideUrl}`,
       "Do not explain internal technical details. Just tell me when it is done.",
     );
     return lines.join("\n");
   }
 
+  // Chinese
   const modeLine = mode === "create"
     ? "如果我还没有 Bot，请为我创建一个新的 Bot。"
     : mode === "link"
       ? "如果我已经有 Bot，请优先连接已有的 Bot，不要创建新的。"
       : "如果我已经有 Bot，请优先连接已有的；如果还没有，再为我创建新的。";
 
-  const lines = ["帮我开始使用 BotCord。"];
-  lines.push(
-    `如果还没安装，请按这个说明完成安装：${installGuideUrl}`,
+  const lines = [
+    "帮我开始使用 BotCord。",
     modeLine,
     "安装完成后，把这个 Bot 连接到我的 BotCord 账号。",
-    options.connectionCode
-      ? `使用 botcord_bind 工具，传入 bind_ticket "${options.connectionCode}" 完成绑定。`
-      : (options.connectionInstruction || "如果连接过程中需要我确认，我会在当前对话里配合。"),
+  ];
+
+  if (options.connectionCode) {
+    lines.push(
+      "",
+      ...buildTieredBlock(locale, {
+        plugin: [`使用 botcord_bind 工具，传入 bind_ticket "${options.connectionCode}" 完成绑定。`],
+        cli: [`执行命令：botcord bind ${options.connectionCode}`],
+      }),
+    );
+  } else {
+    lines.push(
+      options.connectionInstruction || "如果连接过程中需要我确认，我会在当前对话里配合。",
+    );
+  }
+
+  lines.push(
+    "",
+    `如果还没安装，请按这个说明完成安装：${installGuideUrl}`,
     "不要向我解释内部技术细节；完成后直接告诉我结果。",
   );
   return lines.join("\n");
 }
+
+// ---------------------------------------------------------------------------
+// 2. Reset Credential
+// ---------------------------------------------------------------------------
 
 export function buildResetCredentialPrompt(options: {
   agentId: string;
@@ -165,10 +215,19 @@ export function buildResetCredentialPrompt(options: {
       "Reset the BotCord credential for my existing Bot.",
       `Target agent_id: ${options.agentId}`,
       `Hub URL: ${hubUrl}`,
-      `Use reset code: ${options.resetCode}`,
-      `If BotCord is not installed yet, follow this setup guide first: ${installGuideUrl}`,
-      `Run the botcord_reset_credential command with agent_id "${options.agentId}" and reset code "${options.resetCode}".`,
+      `Reset code: ${options.resetCode}`,
+      "",
+      ...buildTieredBlock(locale, {
+        plugin: [
+          `Use the botcord_reset_credential tool with agent_id "${options.agentId}" and reset code "${options.resetCode}".`,
+        ],
+        cli: [
+          `Run: botcord bind ${options.resetCode} (CLI will detect this is a reset ticket and handle credential rotation).`,
+        ],
+      }),
+      "",
       "Generate a fresh local credential, save it as the active BotCord credential, and tell me when the reset is done.",
+      `If BotCord is not installed yet, follow this setup guide first: ${installGuideUrl}`,
       "Do not explain internal technical details. Just tell me the result.",
     ].join("\n");
   }
@@ -177,13 +236,26 @@ export function buildResetCredentialPrompt(options: {
     "帮我重置这个已有 Bot 的 BotCord credential。",
     `目标 agent_id：${options.agentId}`,
     `Hub URL：${hubUrl}`,
-    `使用 reset code：${options.resetCode}`,
-    `如果还没安装 BotCord，请先按这个说明完成安装：${installGuideUrl}`,
-    `请执行 botcord_reset_credential 命令，传入 agent_id "${options.agentId}" 和 reset code "${options.resetCode}"。`,
+    `Reset code：${options.resetCode}`,
+    "",
+    ...buildTieredBlock(locale, {
+      plugin: [
+        `使用 botcord_reset_credential 工具，传入 agent_id "${options.agentId}" 和 reset code "${options.resetCode}"。`,
+      ],
+      cli: [
+        `执行命令：botcord bind ${options.resetCode}（CLI 会检测到这是 reset ticket 并自动处理 credential 轮换）。`,
+      ],
+    }),
+    "",
     "为这个 Bot 生成新的本地 credential，保存为当前生效的 BotCord credential，完成后直接告诉我结果。",
+    `如果还没安装 BotCord，请先按这个说明完成安装：${installGuideUrl}`,
     "不要解释内部技术细节。",
   ].join("\n");
 }
+
+// ---------------------------------------------------------------------------
+// 3. Share / Invite to Room
+// ---------------------------------------------------------------------------
 
 export function buildSharePrompt(options: {
   shareId?: string;
@@ -206,24 +278,51 @@ export function buildSharePrompt(options: {
     ];
 
     if (options.inviteCode) {
-      const previewUrl = `${hubApiBaseUrl}/api/invites/${options.inviteCode}`;
-      const redeemUrl = `${hubApiBaseUrl}/api/invites/${options.inviteCode}/redeem`;
+      const previewUrl = `${hubApiBaseUrl}/hub/invites/${options.inviteCode}`;
+      const redeemUrl = `${hubApiBaseUrl}/hub/invites/${options.inviteCode}/redeem`;
       lines.push(
         `Preview invite details: GET ${previewUrl}`,
-        ...buildHttpRequestParamLines(locale),
       );
       if (!options.isReadOnly) {
-        lines.push(...buildInviteRedeemRequestLines(redeemUrl, locale, {
-          requiresPayment: options.requiresPayment,
-        }));
+        lines.push(
+          "",
+          ...buildTieredBlock(locale, {
+            plugin: [
+              `Use the botcord_rooms tool with action "join" and the room_id from the invite preview.`,
+            ],
+            cli: [
+              `Run: botcord room join --room <room_id> (get room_id from the invite preview above).`,
+            ],
+            http: [
+              `Accept the invite: POST ${redeemUrl}`,
+              `Headers: Authorization: Bearer <agent_jwt_token>`,
+              httpTokenHint(locale, hubApiBaseUrl),
+            ],
+          }),
+        );
+        if (options.requiresPayment) {
+          lines.push("Note: this group requires a paid subscription. Complete the subscription before joining.");
+        }
       }
     } else if (options.roomId) {
       const joinUrl = `${hubApiBaseUrl}/hub/rooms/${options.roomId}/members`;
-      lines.push(`Join the group: POST ${joinUrl}`);
-      lines.push(...buildHttpRequestParamLines(locale, {
-        headers: "Authorization: Bearer <current_bot_agent_token>",
-        jsonParams: "{\"agent_id\":\"<current_bot_agent_id>\"}",
-      }));
+      lines.push(
+        "",
+        ...buildTieredBlock(locale, {
+          plugin: [
+            `Use the botcord_rooms tool with action "join" and room_id "${options.roomId}".`,
+          ],
+          cli: [
+            `Run: botcord room join --room ${options.roomId}`,
+          ],
+          http: [
+            `Join the group: POST ${joinUrl}`,
+            `Headers: Authorization: Bearer <agent_jwt_token>`,
+            `JSON body: {"agent_id":"<your_agent_id>"}`,
+            httpTokenHint(locale, hubApiBaseUrl),
+          ],
+        }),
+      );
       if (options.requiresPayment) {
         lines.push("Note: this group requires a paid subscription. Complete the subscription before joining.");
       }
@@ -231,40 +330,83 @@ export function buildSharePrompt(options: {
       const shareInfoUrl = `${hubApiBaseUrl}/api/share/${options.shareId}`;
       lines.push(
         `View share details and find room_id: GET ${shareInfoUrl}`,
-        ...buildHttpRequestParamLines(locale),
+        "",
+        ...buildTieredBlock(locale, {
+          plugin: [
+            `Use the botcord_rooms tool with action "join" and the room_id from the share details.`,
+          ],
+          cli: [
+            `Run: botcord room join --room <room_id> (get room_id from the share details above).`,
+          ],
+          http: [
+            `Join the group: POST ${hubApiBaseUrl}/hub/rooms/<room_id>/members`,
+            `Headers: Authorization: Bearer <agent_jwt_token>`,
+            `JSON body: {"agent_id":"<your_agent_id>"}`,
+            httpTokenHint(locale, hubApiBaseUrl),
+          ],
+        }),
       );
     }
 
     lines.push(
+      "",
       `If BotCord is not installed yet, follow this setup guide first: ${installGuideUrl}`,
       "Do not explain internal technical details. Just tell me when it is done.",
     );
     return lines.join("\n");
   }
 
+  // Chinese
   const lines: string[] = [
     `这是一个 BotCord 群邀请：${options.roomName}`,
   ];
 
   if (options.inviteCode) {
-    const previewUrl = `${hubApiBaseUrl}/api/invites/${options.inviteCode}`;
-    const redeemUrl = `${hubApiBaseUrl}/api/invites/${options.inviteCode}/redeem`;
+    const previewUrl = `${hubApiBaseUrl}/hub/invites/${options.inviteCode}`;
+    const redeemUrl = `${hubApiBaseUrl}/hub/invites/${options.inviteCode}/redeem`;
     lines.push(
       `查看邀请详情：GET ${previewUrl}`,
-      ...buildHttpRequestParamLines(locale),
     );
     if (!options.isReadOnly) {
-      lines.push(...buildInviteRedeemRequestLines(redeemUrl, locale, {
-        requiresPayment: options.requiresPayment,
-      }));
+      lines.push(
+        "",
+        ...buildTieredBlock(locale, {
+          plugin: [
+            `使用 botcord_rooms 工具，action 为 "join"，room_id 从上面的邀请详情中获取。`,
+          ],
+          cli: [
+            `执行命令：botcord room join --room <room_id>（room_id 从上面的邀请详情中获取）。`,
+          ],
+          http: [
+            `接受邀请：POST ${redeemUrl}`,
+            `请求头：Authorization: Bearer <agent_jwt_token>`,
+            httpTokenHint(locale, hubApiBaseUrl),
+          ],
+        }),
+      );
+      if (options.requiresPayment) {
+        lines.push("注意：该群需要付费订阅，请先完成订阅再加入。");
+      }
     }
   } else if (options.roomId) {
     const joinUrl = `${hubApiBaseUrl}/hub/rooms/${options.roomId}/members`;
-    lines.push(`加入群：POST ${joinUrl}`);
-    lines.push(...buildHttpRequestParamLines(locale, {
-      headers: "Authorization: Bearer <当前 Bot 的 agent token>",
-      jsonParams: "{\"agent_id\":\"<当前 Bot 的 agent_id>\"}",
-    }));
+    lines.push(
+      "",
+      ...buildTieredBlock(locale, {
+        plugin: [
+          `使用 botcord_rooms 工具，action 为 "join"，room_id 为 "${options.roomId}"。`,
+        ],
+        cli: [
+          `执行命令：botcord room join --room ${options.roomId}`,
+        ],
+        http: [
+          `加入群：POST ${joinUrl}`,
+          `请求头：Authorization: Bearer <agent_jwt_token>`,
+          `JSON 参数：{"agent_id":"<你的 agent_id>"}`,
+          httpTokenHint(locale, hubApiBaseUrl),
+        ],
+      }),
+    );
     if (options.requiresPayment) {
       lines.push("注意：该群需要付费订阅，请先完成订阅再加入。");
     }
@@ -272,16 +414,35 @@ export function buildSharePrompt(options: {
     const shareInfoUrl = `${hubApiBaseUrl}/api/share/${options.shareId}`;
     lines.push(
       `查看分享详情并获取 room_id：GET ${shareInfoUrl}`,
-      ...buildHttpRequestParamLines(locale),
+      "",
+      ...buildTieredBlock(locale, {
+        plugin: [
+          `使用 botcord_rooms 工具，action 为 "join"，room_id 从分享详情中获取。`,
+        ],
+        cli: [
+          `执行命令：botcord room join --room <room_id>（room_id 从上面的分享详情中获取）。`,
+        ],
+        http: [
+          `加入群：POST ${hubApiBaseUrl}/hub/rooms/<room_id>/members`,
+          `请求头：Authorization: Bearer <agent_jwt_token>`,
+          `JSON 参数：{"agent_id":"<你的 agent_id>"}`,
+          httpTokenHint(locale, hubApiBaseUrl),
+        ],
+      }),
     );
   }
 
   lines.push(
+    "",
     `如果还没安装 BotCord，请先按这个说明完成安装：${installGuideUrl}`,
     "不要向我解释内部技术细节；完成后直接告诉我结果。",
   );
   return lines.join("\n");
 }
+
+// ---------------------------------------------------------------------------
+// 4. Friend Invite
+// ---------------------------------------------------------------------------
 
 export function buildFriendInvitePrompt(options: {
   inviteCode: string;
@@ -292,15 +453,30 @@ export function buildFriendInvitePrompt(options: {
   const hubApiBaseUrl = options.hubApiBaseUrl || getHubApiBaseUrl();
   const installGuideUrl = options.installGuideUrl || getBotcordInstallGuideUrl();
   const locale = resolveLocale(options.locale);
-  const previewApiUrl = `${hubApiBaseUrl}/api/invites/${options.inviteCode}`;
-  const redeemApiUrl = `${hubApiBaseUrl}/api/invites/${options.inviteCode}/redeem`;
+  const previewApiUrl = `${hubApiBaseUrl}/hub/invites/${options.inviteCode}`;
+  const redeemApiUrl = `${hubApiBaseUrl}/hub/invites/${options.inviteCode}/redeem`;
 
   if (locale === "en") {
     return [
       "This is a BotCord friend invite.",
       `Preview invite details: GET ${previewApiUrl}`,
-      ...buildHttpRequestParamLines(locale),
-      ...buildInviteRedeemRequestLines(redeemApiUrl, locale),
+      "",
+      ...buildTieredBlock(locale, {
+        plugin: [
+          `Use the botcord_contacts tool with action "accept_request" and the request details from the invite preview.`,
+          `Or redeem directly: POST ${redeemApiUrl}`,
+        ],
+        cli: [
+          `If the preview shows a contact request, accept it: botcord contact-request accept --id <request_id>`,
+          `Or redeem directly: POST ${redeemApiUrl}`,
+        ],
+        http: [
+          `Accept the invite: POST ${redeemApiUrl}`,
+          `Headers: Authorization: Bearer <agent_jwt_token>`,
+          httpTokenHint(locale, hubApiBaseUrl),
+        ],
+      }),
+      "",
       `If BotCord is not installed yet, follow this setup guide first: ${installGuideUrl}`,
       "After accepting, just confirm it is done. Do not explain internal technical details.",
     ].join("\n");
@@ -309,12 +485,31 @@ export function buildFriendInvitePrompt(options: {
   return [
     "这是一个 BotCord 好友邀请。",
     `查看邀请详情：GET ${previewApiUrl}`,
-    ...buildHttpRequestParamLines(locale),
-    ...buildInviteRedeemRequestLines(redeemApiUrl, locale),
+    "",
+    ...buildTieredBlock(locale, {
+      plugin: [
+        `使用 botcord_contacts 工具，action 为 "accept_request"，根据邀请详情中的请求信息完成操作。`,
+        `或直接 redeem：POST ${redeemApiUrl}`,
+      ],
+      cli: [
+        `如果预览显示为好友请求，执行：botcord contact-request accept --id <request_id>`,
+        `或直接 redeem：POST ${redeemApiUrl}`,
+      ],
+      http: [
+        `接受邀请：POST ${redeemApiUrl}`,
+        `请求头：Authorization: Bearer <agent_jwt_token>`,
+        httpTokenHint(locale, hubApiBaseUrl),
+      ],
+    }),
+    "",
     `如果还没安装 BotCord，请先按这个说明完成安装：${installGuideUrl}`,
     "接受后直接告诉我结果，不要解释内部技术细节。",
   ].join("\n");
 }
+
+// ---------------------------------------------------------------------------
+// 5. Self Join (own bot joins a room)
+// ---------------------------------------------------------------------------
 
 export function buildSelfJoinPrompt(options: {
   roomId: string;
@@ -331,38 +526,81 @@ export function buildSelfJoinPrompt(options: {
   if (locale === "en") {
     return [
       `Help me join this BotCord group: ${options.roomName}`,
-      `If BotCord is not installed yet, follow this setup guide first: ${installGuideUrl}`,
-      `Join the group: POST ${joinUrl}`,
-      ...buildHttpRequestParamLines(locale, {
-        headers: "Authorization: Bearer <current_bot_agent_token>",
-        jsonParams: "{\"agent_id\":\"<current_bot_agent_id>\"}",
+      "",
+      ...buildTieredBlock(locale, {
+        plugin: [
+          `Use the botcord_rooms tool with action "join" and room_id "${options.roomId}".`,
+        ],
+        cli: [
+          `Run: botcord room join --room ${options.roomId}`,
+        ],
+        http: [
+          `Join the group: POST ${joinUrl}`,
+          `Headers: Authorization: Bearer <agent_jwt_token>`,
+          `JSON body: {"agent_id":"<your_agent_id>"}`,
+          httpTokenHint(locale, hubApiBaseUrl),
+        ],
       }),
+      "",
+      `If BotCord is not installed yet, follow this setup guide first: ${installGuideUrl}`,
       "Do not explain internal technical details. Just tell me when it is done.",
     ].join("\n");
   }
 
   return [
     `帮我加入这个 BotCord 群：${options.roomName}`,
-    `如果还没安装 BotCord，请先按这个说明完成安装：${installGuideUrl}`,
-    `加入群：POST ${joinUrl}`,
-    ...buildHttpRequestParamLines(locale, {
-      headers: "Authorization: Bearer <当前 Bot 的 agent token>",
-      jsonParams: "{\"agent_id\":\"<当前 Bot 的 agent_id>\"}",
+    "",
+    ...buildTieredBlock(locale, {
+      plugin: [
+        `使用 botcord_rooms 工具，action 为 "join"，room_id 为 "${options.roomId}"。`,
+      ],
+      cli: [
+        `执行命令：botcord room join --room ${options.roomId}`,
+      ],
+      http: [
+        `加入群：POST ${joinUrl}`,
+        `请求头：Authorization: Bearer <agent_jwt_token>`,
+        `JSON 参数：{"agent_id":"<你的 agent_id>"}`,
+        httpTokenHint(locale, hubApiBaseUrl),
+      ],
     }),
+    "",
+    `如果还没安装 BotCord，请先按这个说明完成安装：${installGuideUrl}`,
     "不要向我解释内部技术细节；完成后直接告诉我结果。",
   ].join("\n");
 }
+
+// ---------------------------------------------------------------------------
+// 6. Create Room
+// ---------------------------------------------------------------------------
 
 export function buildCreateRoomPrompt(options?: {
   locale?: PromptLocale;
 }): string {
   const locale = resolveLocale(options?.locale);
+  const hubApiBaseUrl = getHubApiBaseUrl();
 
   if (locale === "en") {
     return [
       "Help me create a new BotCord group.",
       "First ask only for the missing information: the group name, its purpose, whether it should be public, and who should be invited.",
       "If I do not specify anything else, choose the safer defaults: private group, invite-only access, members can send messages, and regular members cannot invite others.",
+      "",
+      ...buildTieredBlock(locale, {
+        plugin: [
+          `Use the botcord_rooms tool with action "create".`,
+        ],
+        cli: [
+          `Run: botcord room create --name <name> [--visibility private] [--join-policy invite_only]`,
+        ],
+        http: [
+          `Create the group: POST ${hubApiBaseUrl}/hub/rooms`,
+          `Headers: Authorization: Bearer <agent_jwt_token>`,
+          `JSON body: {"name":"<name>","visibility":"private","join_policy":"invite_only","default_send":true,"default_invite":false}`,
+          httpTokenHint(locale, hubApiBaseUrl),
+        ],
+      }),
+      "",
       "When it is done, do not explain internal technical fields. Just tell me the group is ready and which key settings you applied.",
     ].join("\n");
   }
@@ -371,6 +609,22 @@ export function buildCreateRoomPrompt(options?: {
     "帮我创建一个新的 BotCord 群。",
     "先只问我缺少的信息：群名称、用途、是否公开，以及需要邀请谁。",
     "如果我没有特别说明，默认用更稳妥的方式创建：私有群、需要邀请才能加入、成员可以发言、普通成员不能继续拉人。",
+    "",
+    ...buildTieredBlock(locale, {
+      plugin: [
+        `使用 botcord_rooms 工具，action 为 "create"。`,
+      ],
+      cli: [
+        `执行命令：botcord room create --name <群名> [--visibility private] [--join-policy invite_only]`,
+      ],
+      http: [
+        `创建群：POST ${hubApiBaseUrl}/hub/rooms`,
+        `请求头：Authorization: Bearer <agent_jwt_token>`,
+        `JSON 参数：{"name":"<群名>","visibility":"private","join_policy":"invite_only","default_send":true,"default_invite":false}`,
+        httpTokenHint(locale, hubApiBaseUrl),
+      ],
+    }),
+    "",
     "创建完成后，不要向我解释内部技术字段；只告诉我这个群已经可以开始使用，以及你替我做了哪些关键设置。",
   ].join("\n");
 }


### PR DESCRIPTION
## Summary
- Restructure all 6 onboarding prompt builders in `frontend/src/lib/onboarding.ts` to provide **Plugin > CLI > HTTP** three-tier fallback instructions, so agents can use whichever integration is available
- Add Hub-level invite endpoints (`GET/POST /hub/invites/{code}`) with agent JWT auth, removing the dependency on Supabase user JWT for invite preview/redeem
- Extract shared invite logic into `backend/hub/invite_ops.py`, used by both Hub and BFF layers

## Test plan
- [x] Frontend build passes (`pnpm build`)
- [x] Backend invite tests pass (`pytest tests/test_app/test_app_invites.py`)
- [x] Full app test suite passes (131 passed, 2 pre-existing Stripe failures)
- [ ] Manual: verify prompt copy-paste flows in dashboard (bind, reset, share, friend invite, self-join, create room)
- [ ] Manual: test `POST /hub/invites/{code}/redeem` with agent JWT token

🤖 Generated with [Claude Code](https://claude.com/claude-code)