### PR TITLE
fix: hide misleading sender info on user messages in UserChatPane

### DIFF
--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -325,12 +325,14 @@ export default function UserChatPane() {
                     : "bg-zinc-800 text-zinc-200 border border-zinc-700"
                 }`}
               >
-                <div className={`mb-1 flex items-center gap-1.5 ${isOwner ? "justify-end" : ""}`}>
-                  <span className="text-xs font-medium text-zinc-300">
-                    {msg.sender_name || msg.sender_id}
-                  </span>
-                  <CopyableId value={msg.sender_id} className="text-zinc-500 hover:text-zinc-300" />
-                </div>
+                {!isOwner && (
+                  <div className="mb-1 flex items-center gap-1.5">
+                    <span className="text-xs font-medium text-zinc-300">
+                      {msg.sender_name || msg.sender_id}
+                    </span>
+                    <CopyableId value={msg.sender_id} className="text-zinc-500 hover:text-zinc-300" />
+                  </div>
+                )}
                 {!isOwner && !animatedRef.current.has(msg.hub_msg_id) ? (
                   <TypewriterText
                     text={msg.text || ""}


### PR DESCRIPTION
## Summary
- User-sent messages in UserChatPane incorrectly displayed the target agent's name and ID as the sender, because the backend `sender_id` FK constraint requires an `agent_id` value
- Hide the sender info row (name + copyable ID) for owner messages — only agent replies show sender identity

## Test plan
- [x] `pnpm build` passes
- [ ] Manual: open UserChatPane, send a message — user bubble should have no sender name/ID row
- [ ] Manual: agent reply bubble should still show agent name and copyable ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)