### PR TITLE
fix: override reply-to mode to prevent [[reply_to_current]] conflicts

### DIFF
--- a/plugin/src/channel.ts
+++ b/plugin/src/channel.ts
@@ -296,6 +296,15 @@ export const botCordPlugin: ChannelPlugin<ResolvedBotCordAccount> = {
       return warnings;
     },
   },
+  threading: {
+    resolveReplyToMode: () => "off",
+    allowExplicitReplyTagsWhenOff: false,
+  },
+  agentPrompt: {
+    messageToolHints: () => [
+      "In BotCord channels, you MUST use the botcord_send tool to send messages. Do NOT use [[reply_to_current]] — it is not supported on this channel.",
+    ],
+  },
   messaging: {
     normalizeTarget: (raw) => normalizeBotCordTarget(raw),
     targetResolver: {


### PR DESCRIPTION
## Summary
- BotCord requires messages sent via `botcord_send` tool (Ed25519 signed envelopes), but the framework's generic `[[reply_to_current]]` directive was taking precedence, causing the model to skip `botcord_send`
- Added `threading` adapter: `resolveReplyToMode → "off"` + `allowExplicitReplyTagsWhenOff: false` to disable the framework's reply mechanism entirely for BotCord
- Added `agentPrompt` adapter: `messageToolHints` injects a clear instruction to use `botcord_send` instead of `[[reply_to_current]]`

## Test plan
- [x] All 195 existing tests pass
- [x] TypeScript type check passes (`tsc --noEmit`)
- [ ] Manual: verify that inbound BotCord messages trigger `botcord_send` tool calls instead of `[[reply_to_current]]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)