### PR TITLE
fix: clarify coin amount_minor description to prevent AI misuse

### DIFF
--- a/plugin/src/__tests__/payment.integration.test.ts
+++ b/plugin/src/__tests__/payment.integration.test.ts
@@ -110,12 +110,8 @@ describe("payment tool integration", () => {
       memo: "invoice settlement",
     });
     expect(transfer.data.transfer_record_message.sent).toBe(true);
-    expect(transfer.data.notifications.payer.sent).toBe(true);
-    expect(transfer.data.notifications.payee.sent).toBe(true);
     expect(transfer.result).toContain("Transfer record message: sent");
-    expect(transfer.result).toContain("Payer notification: sent");
-    expect(transfer.result).toContain("Payee notification: sent");
-    expect(hub.state.messages).toHaveLength(3);
+    expect(hub.state.messages).toHaveLength(1);
 
     const envelopes = hub.state.messages.map((entry) => entry.envelope);
     const recordMessage = envelopes.find((envelope) =>
@@ -124,24 +120,10 @@ describe("payment tool integration", () => {
       typeof envelope.payload?.text === "string" &&
       envelope.payload.text.includes("[BotCord Transfer]"),
     );
-    const payerNotice = envelopes.find((envelope) =>
-      envelope.type === "system" &&
-      envelope.to === "ag_sender" &&
-      typeof envelope.payload?.text === "string" &&
-      envelope.payload.text.includes("[BotCord Notice] Transfer sent"),
-    );
-    const payeeNotice = envelopes.find((envelope) =>
-      envelope.type === "system" &&
-      envelope.to === "ag_receiver" &&
-      typeof envelope.payload?.text === "string" &&
-      envelope.payload.text.includes("[BotCord Notice] Payment received"),
-    );
 
     expect(recordMessage).toBeTruthy();
-    expect(payerNotice).toBeTruthy();
-    expect(payeeNotice).toBeTruthy();
-    if (!recordMessage || !payerNotice || !payeeNotice) {
-      throw new Error("expected transfer follow-up messages to be present");
+    if (!recordMessage) {
+      throw new Error("expected transfer record message to be present");
     }
     expect(recordMessage.payload.text).toContain(transfer.data.tx.tx_id);
 
@@ -192,9 +174,7 @@ describe("payment tool integration", () => {
     expect(transfer.data.tx.to_agent_id).toBe("ag_receiver");
     expect(transfer.result).not.toContain("is not in your contacts");
     expect(transfer.data.transfer_record_message.sent).toBe(true);
-    expect(transfer.data.notifications.payer.sent).toBe(true);
-    expect(transfer.data.notifications.payee.sent).toBe(true);
-    expect(hub.state.messages).toHaveLength(3);
+    expect(hub.state.messages).toHaveLength(1);
   });
 
   it("requires confirmation for stranger transfers", async () => {
@@ -228,7 +208,7 @@ describe("payment tool integration", () => {
 
     expect(transfer.data.tx.type).toBe("transfer");
     expect(transfer.data.tx.to_agent_id).toBe("ag_receiver");
-    expect(hub.state.messages).toHaveLength(3); // record + 2 notifications
+    expect(hub.state.messages).toHaveLength(1);
   });
 
   it("keeps transfer successful when follow-up messages fail", async () => {
@@ -253,9 +233,7 @@ describe("payment tool integration", () => {
 
     expect(transfer.data.tx.type).toBe("transfer");
     expect(transfer.data.transfer_record_message.sent).toBe(false);
-    expect(transfer.data.notifications.payer.sent).toBe(false);
-    expect(transfer.data.notifications.payee.sent).toBe(false);
-    expect(transfer.result).toContain("Warning: some follow-up messages failed to send.");
+    expect(transfer.result).toContain("Transfer record message: failed");
 
     const balance: any = await tool.execute("tool-followup-fail-balance", {
       action: "balance",

--- a/plugin/src/tools/payment-transfer.ts
+++ b/plugin/src/tools/payment-transfer.ts
@@ -12,10 +12,6 @@ type FollowUpDeliveryResult = {
 export type TransferResult = {
   tx: WalletTransaction;
   transfer_record_message: FollowUpDeliveryResult;
-  notifications: {
-    payer: FollowUpDeliveryResult;
-    payee: FollowUpDeliveryResult;
-  };
 };
 
 
@@ -57,31 +53,10 @@ export function buildTransferRecordMessage(tx: WalletTransaction): string {
   ].filter(Boolean).join("\n");
 }
 
-export function buildTransferNotificationMessage(
-  tx: WalletTransaction,
-  role: "payer" | "payee",
-): string {
-  if (role === "payer") {
-    return `[BotCord Notice] Transfer sent: ${formatCoinAmount(tx.amount_minor)} to ${tx.to_agent_id} (tx: ${tx.tx_id})`;
-  }
-  return `[BotCord Notice] Payment received: ${formatCoinAmount(tx.amount_minor)} from ${tx.from_agent_id} (tx: ${tx.tx_id})`;
-}
-
 export function formatFollowUpDeliverySummary(result: TransferResult): string {
-  const lines = [
-    `Transfer record message: ${result.transfer_record_message.sent ? "sent" : "failed"}`,
-    `Payer notification: ${result.notifications.payer.sent ? "sent" : "failed"}`,
-    `Payee notification: ${result.notifications.payee.sent ? "sent" : "failed"}`,
-  ];
-  const failures = [
-    result.transfer_record_message.error,
-    result.notifications.payer.error,
-    result.notifications.payee.error,
-  ].filter(Boolean);
-  if (failures.length > 0) {
-    lines.push("Warning: some follow-up messages failed to send.");
-  }
-  return lines.join("\n");
+  return `Transfer record message: ${result.transfer_record_message.sent ? "sent" : "failed"}${
+    result.transfer_record_message.error ? ` (${result.transfer_record_message.error})` : ""
+  }`;
 }
 
 async function sendRecordMessage(
@@ -90,30 +65,6 @@ async function sendRecordMessage(
 ): Promise<FollowUpDeliveryResult> {
   try {
     const response = await client.sendMessage(tx.to_agent_id || "", buildTransferRecordMessage(tx));
-    return { attempted: true, sent: true, hub_msg_id: response.hub_msg_id };
-  } catch (err: any) {
-    return { attempted: true, sent: false, error: err?.message ?? String(err) };
-  }
-}
-
-async function sendNotification(
-  client: BotCordClient,
-  to: string,
-  tx: WalletTransaction,
-  role: "payer" | "payee",
-): Promise<FollowUpDeliveryResult> {
-  try {
-    const response = await client.sendSystemMessage(to, buildTransferNotificationMessage(tx, role), {
-      event: "wallet_transfer_notice",
-      role,
-      tx_id: tx.tx_id,
-      amount_minor: tx.amount_minor,
-      asset_code: tx.asset_code,
-      from_agent_id: tx.from_agent_id,
-      to_agent_id: tx.to_agent_id,
-      reference_type: tx.reference_type,
-      reference_id: tx.reference_id,
-    });
     return { attempted: true, sent: true, hub_msg_id: response.hub_msg_id };
   } catch (err: any) {
     return { attempted: true, sent: false, error: err?.message ?? String(err) };
@@ -133,18 +84,10 @@ export async function executeTransfer(
   },
 ): Promise<TransferResult> {
   const tx = await client.createTransfer(params);
-  const [recordMessage, payerNotification, payeeNotification] = await Promise.all([
-    sendRecordMessage(client, tx),
-    sendNotification(client, client.getAgentId(), tx, "payer"),
-    sendNotification(client, params.to_agent_id, tx, "payee"),
-  ]);
+  const recordMessage = await sendRecordMessage(client, tx);
 
   return {
     tx,
     transfer_record_message: recordMessage,
-    notifications: {
-      payer: payerNotification,
-      payee: payeeNotification,
-    },
   };
 }

--- a/plugin/src/tools/payment.ts
+++ b/plugin/src/tools/payment.ts
@@ -81,7 +81,6 @@ function sanitizeTransferResult(transfer: any): any {
   return {
     tx: sanitizeTransaction(transfer.tx),
     transfer_record_message: transfer.transfer_record_message,
-    notifications: transfer.notifications,
   };
 }
 
@@ -226,7 +225,7 @@ export function createPaymentTool(opts?: { name?: string; description?: string }
         },
         amount_minor: {
           type: "string" as const,
-          description: "Amount in minor units (string) — for transfer, topup, withdraw",
+          description: "Amount in minor units (1 COIN = 100 minor units). To transfer N coins, pass N × 100. Example: 10 COIN → \"1000\" — for transfer, topup, withdraw",
         },
         memo: {
           type: "string" as const,
@@ -262,7 +261,7 @@ export function createPaymentTool(opts?: { name?: string; description?: string }
         },
         fee_minor: {
           type: "string" as const,
-          description: "Optional withdrawal fee in minor units — for withdraw",
+          description: "Optional withdrawal fee in minor units (1 COIN = 100 minor units) — for withdraw",
         },
         withdrawal_id: {
           type: "string" as const,


### PR DESCRIPTION
## Summary
- Clarified `amount_minor` and `fee_minor` parameter descriptions to include conversion ratio (`1 COIN = 100 minor units`) with example, preventing AI models from passing raw coin values (e.g. `"10"` instead of `"1000"` for 10 COIN)
- Removed redundant payer/payee transfer notification messages, keeping only the transfer record message

## Test plan
- [ ] Verify `npm test` passes in plugin/
- [ ] Test AI agent transfer flow: ask to "transfer 10 COIN" and confirm `amount_minor` is `"1000"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)