### PR TITLE
fix: allow all members to invite in public open-to-join rooms

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -222,7 +222,13 @@ async def _build_rooms_from_membership(
         my_role = role_val.value if hasattr(role_val, "value") else str(role_val) if role_val else "member"
 
         member_can_invite = invite_overrides.get(rid)
+        is_public_open = (
+            room.visibility == RoomVisibility.public
+            and room.join_policy == RoomJoinPolicy.open
+        )
         if my_role == "owner":
+            computed_can_invite = True
+        elif is_public_open:
             computed_can_invite = True
         elif member_can_invite is not None:
             computed_can_invite = member_can_invite

--- a/backend/app/routers/invites.py
+++ b/backend/app/routers/invites.py
@@ -16,7 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.auth import RequestContext, require_active_agent
 from hub.config import FRONTEND_BASE_URL
 from hub.database import get_db
-from hub.enums import RoomRole, RoomVisibility, SubscriptionStatus
+from hub.enums import RoomJoinPolicy, RoomRole, RoomVisibility, SubscriptionStatus
 from hub.invite_ops import preview_invite, redeem_invite_for_agent
 from hub.models import Agent, AgentSubscription, Contact, Invite, InviteRedemption, Room, RoomMember
 from hub.share_payloads import frontend_url, room_continue_url, room_entry_type
@@ -74,6 +74,8 @@ def _continue_url_for_invite(invite: Invite, room: Room | None = None) -> str:
 
 def _can_invite(room: Room, member: RoomMember) -> bool:
     if member.role == RoomRole.owner:
+        return True
+    if room.visibility == RoomVisibility.public and room.join_policy == RoomJoinPolicy.open:
         return True
     if member.can_invite is not None:
         return member.can_invite

--- a/backend/hub/routers/room.py
+++ b/backend/hub/routers/room.py
@@ -181,11 +181,14 @@ def _can_invite(room: Room, member: RoomMember) -> bool:
 
     Resolution order:
       1. owner → always True
-      2. member.can_invite is not None → use explicit value
-      3. admin → default True
-      4. room.default_invite
+      2. public + open room → always True (anyone can join anyway)
+      3. member.can_invite is not None → use explicit value
+      4. admin → default True
+      5. room.default_invite
     """
     if member.role == RoomRole.owner:
+        return True
+    if room.visibility == RoomVisibility.public and room.join_policy == RoomJoinPolicy.open:
         return True
     if member.can_invite is not None:
         return member.can_invite


### PR DESCRIPTION
## Summary
- Public + open-to-join rooms are joinable by anyone, so invite permission should not be restricted for members
- Updated `_can_invite` logic in all three locations to return `True` when room is `public` + `open`:
  - `hub/routers/room.py` — protocol layer
  - `app/routers/invites.py` — BFF invite layer (+ added `RoomJoinPolicy` import)
  - `app/routers/dashboard.py` — dashboard overview `computed_can_invite`

## Test plan
- [ ] As a regular member in a public + open room, verify the invite prompt is shown (not the 🔒 no-permission state)
- [ ] As a regular member in a private room with `default_invite=False`, verify invite is still blocked
- [ ] As a regular member in a public + invite_only room with `default_invite=False`, verify invite is still blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)