### PR TITLE
feat(plugin,backend,cli): COIN unit params + one-time billing

### DIFF
--- a/backend/hub/enums.py
+++ b/backend/hub/enums.py
@@ -86,6 +86,7 @@ class TxType(str, enum.Enum):
 class BillingInterval(str, enum.Enum):
     week = "week"
     month = "month"
+    once = "once"
 
 
 class SubscriptionProductStatus(str, enum.Enum):

--- a/backend/hub/i18n.py
+++ b/backend/hub/i18n.py
@@ -460,8 +460,8 @@ ERROR_MESSAGES: dict[str, dict[Locale, str]] = {
     # Subscriptions (subscriptions.py)
     # -----------------------------------------------------------------------
     "billing_interval_invalid": {
-        Locale.EN: "billing_interval must be week or month",
-        Locale.ZH: "billing_interval 必须为 week 或 month",
+        Locale.EN: "billing_interval must be week, month, or once",
+        Locale.ZH: "billing_interval 必须为 week、month 或 once",
     },
     "subscription_product_not_found": {
         Locale.EN: "Subscription product not found",

--- a/backend/hub/services/subscriptions.py
+++ b/backend/hub/services/subscriptions.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 
 MAX_FAILED_BILLING_ATTEMPTS = 3
 RETRY_DELAY = datetime.timedelta(hours=24)
+_NEVER = datetime.datetime(9999, 12, 31, tzinfo=datetime.timezone.utc)
 
 
 def _utcnow() -> datetime.datetime:
@@ -49,6 +50,8 @@ def _ensure_tz(dt: datetime.datetime) -> datetime.datetime:
 
 def _advance_period(anchor: datetime.datetime, interval: BillingInterval) -> datetime.datetime:
     anchor = _ensure_tz(anchor)
+    if interval == BillingInterval.once:
+        return _NEVER
     if interval == BillingInterval.week:
         return anchor + datetime.timedelta(days=7)
 
@@ -92,8 +95,8 @@ async def create_subscription_product(
 ) -> SubscriptionProduct:
     if amount_minor <= 0:
         raise ValueError("Amount must be positive")
-    if billing_interval not in {BillingInterval.week, BillingInterval.month}:
-        raise ValueError("billing_interval must be week or month")
+    if billing_interval not in {BillingInterval.week, BillingInterval.month, BillingInterval.once}:
+        raise ValueError("billing_interval must be week, month, or once")
 
     product = SubscriptionProduct(
         product_id=generate_subscription_product_id(),

--- a/backend/hub/subscription_schemas.py
+++ b/backend/hub/subscription_schemas.py
@@ -9,7 +9,7 @@ class SubscriptionProductCreateRequest(BaseModel):
     name: str = Field(..., min_length=1, max_length=128)
     description: str = Field(default="")
     amount_minor: str = Field(..., min_length=1)
-    billing_interval: str = Field(..., description="week or month")
+    billing_interval: str = Field(..., description="week, month, or once")
 
 
 class SubscriptionCreateRequest(BaseModel):

--- a/cli/src/client.ts
+++ b/cli/src/client.ts
@@ -697,7 +697,7 @@ export class BotCordClient {
     name: string;
     description?: string;
     amount_minor: string;
-    billing_interval: "week" | "month";
+    billing_interval: "week" | "month" | "once";
     asset_code?: string;
   }): Promise<SubscriptionProduct> {
     const resp = await this.hubFetch("/subscriptions/products", {

--- a/cli/src/commands/subscription.ts
+++ b/cli/src/commands/subscription.ts
@@ -11,7 +11,7 @@ export async function subscriptionCommand(args: ParsedArgs, globalHub?: string, 
 
 Subcommands:
   create-product    Create a subscription product
-                      --name <name> --amount <minor> --interval <week|month>
+                      --name <name> --amount <minor> --interval <week|month|once>
                       [--description <text>] [--asset-code <code>]
   list-products     List your own subscription products
   list-all-products List all available subscription products
@@ -44,7 +44,7 @@ Subcommands:
       const interval = args.flags["interval"];
       if (!name || typeof name !== "string") outputError("--name is required");
       if (!amount || typeof amount !== "string") outputError("--amount is required");
-      if (interval !== "week" && interval !== "month") outputError("--interval must be 'week' or 'month'");
+      if (interval !== "week" && interval !== "month" && interval !== "once") outputError("--interval must be 'week', 'month', or 'once'");
       const description = typeof args.flags["description"] === "string" ? args.flags["description"] : undefined;
       const assetCode = typeof args.flags["asset-code"] === "string" ? args.flags["asset-code"] : undefined;
       const result = await client.createSubscriptionProduct({

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -196,7 +196,7 @@ export type WithdrawalResponse = {
   completed_at: string | null;
 };
 
-export type BillingInterval = "week" | "month";
+export type BillingInterval = "week" | "month" | "once";
 
 export type SubscriptionProductStatus = "active" | "archived";
 

--- a/plugin/.gitignore
+++ b/plugin/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 .DS_Store
+*.tgz

--- a/plugin/skills/botcord/SKILL.md
+++ b/plugin/skills/botcord/SKILL.md
@@ -118,7 +118,7 @@ Create subscription products priced in BotCord coin, subscribe to products, list
 
 | Action | Parameters | Description |
 |--------|------------|-------------|
-| `create_product` | `name`, `description?`, `amount`, `billing_interval`, `asset_code?` | Create a subscription product. `amount` is in COIN (e.g. `"10"` or `"9.50"`) |
+| `create_product` | `name`, `description?`, `amount`, `billing_interval`, `asset_code?` | Create a subscription product. `amount` is in COIN (e.g. `"10"` or `"9.50"`). `billing_interval`: `"week"`, `"month"`, or `"once"` (one-time payment, no recurring charges) |
 | `list_my_products` | — | List products owned by the current agent |
 | `list_products` | — | List visible subscription products |
 | `archive_product` | `product_id` | Archive a product |

--- a/plugin/skills/botcord/SKILL.md
+++ b/plugin/skills/botcord/SKILL.md
@@ -106,9 +106,9 @@ Unified payment entry point for BotCord coin flows. Use this tool for recipient 
 | `recipient_verify` | `agent_id` | Verify that a recipient agent exists before sending payment |
 | `balance` | — | View wallet balance (available, locked, total) |
 | `ledger` | `cursor?`, `limit?`, `type?` | Query payment ledger entries |
-| `transfer` | `to_agent_id`, `amount_minor`, `memo?`, `reference_type?`, `reference_id?`, `metadata?`, `idempotency_key?` | Send coin payment to another agent |
-| `topup` | `amount_minor`, `channel?`, `metadata?`, `idempotency_key?` | Create a topup request |
-| `withdraw` | `amount_minor`, `fee_minor?`, `destination_type?`, `destination?`, `idempotency_key?` | Create a withdrawal request |
+| `transfer` | `to_agent_id`, `amount`, `memo?`, `reference_type?`, `reference_id?`, `metadata?`, `idempotency_key?` | Send coin payment to another agent. `amount` is in COIN (e.g. `"10"` or `"9.50"`) |
+| `topup` | `amount`, `channel?`, `metadata?`, `idempotency_key?` | Create a topup request. `amount` is in COIN |
+| `withdraw` | `amount`, `fee?`, `destination_type?`, `destination?`, `idempotency_key?` | Create a withdrawal request. `amount` and `fee` are in COIN |
 | `cancel_withdrawal` | `withdrawal_id` | Cancel a pending withdrawal |
 | `tx_status` | `tx_id` | Query a single transaction by ID |
 
@@ -118,7 +118,7 @@ Create subscription products priced in BotCord coin, subscribe to products, list
 
 | Action | Parameters | Description |
 |--------|------------|-------------|
-| `create_product` | `name`, `description?`, `amount_minor`, `billing_interval`, `asset_code?` | Create a subscription product |
+| `create_product` | `name`, `description?`, `amount`, `billing_interval`, `asset_code?` | Create a subscription product. `amount` is in COIN (e.g. `"10"` or `"9.50"`) |
 | `list_my_products` | — | List products owned by the current agent |
 | `list_products` | — | List visible subscription products |
 | `archive_product` | `product_id` | Archive a product |

--- a/plugin/src/__tests__/coin-format.test.ts
+++ b/plugin/src/__tests__/coin-format.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { parseCoinToMinor, formatCoinAmount } from "../tools/coin-format.js";
+
+describe("parseCoinToMinor", () => {
+  it("converts whole COIN to minor units", () => {
+    expect(parseCoinToMinor("10")).toBe("1000");
+    expect(parseCoinToMinor("0")).toBe("0");
+    expect(parseCoinToMinor("1")).toBe("100");
+  });
+
+  it("converts 1-decimal COIN to minor units", () => {
+    expect(parseCoinToMinor("9.5")).toBe("950");
+    expect(parseCoinToMinor("0.1")).toBe("10");
+  });
+
+  it("converts 2-decimal COIN to minor units", () => {
+    expect(parseCoinToMinor("9.50")).toBe("950");
+    expect(parseCoinToMinor("0.01")).toBe("1");
+    expect(parseCoinToMinor("99.99")).toBe("9999");
+  });
+
+  it("rejects 3+ decimal places", () => {
+    expect(parseCoinToMinor("1.234")).toBeNull();
+    expect(parseCoinToMinor("0.005")).toBeNull();
+    expect(parseCoinToMinor("10.999")).toBeNull();
+  });
+
+  it("rejects negative values", () => {
+    expect(parseCoinToMinor("-1")).toBeNull();
+    expect(parseCoinToMinor("-0.50")).toBeNull();
+  });
+
+  it("rejects non-numeric strings", () => {
+    expect(parseCoinToMinor("abc")).toBeNull();
+    expect(parseCoinToMinor("1abc")).toBeNull();
+    expect(parseCoinToMinor("1.2.3")).toBeNull();
+    expect(parseCoinToMinor("$10")).toBeNull();
+    expect(parseCoinToMinor("10 COIN")).toBeNull();
+  });
+
+  it("rejects leading zeros", () => {
+    expect(parseCoinToMinor("007")).toBeNull();
+    expect(parseCoinToMinor("00.50")).toBeNull();
+    expect(parseCoinToMinor("01")).toBeNull();
+  });
+
+  it("rejects empty and null", () => {
+    expect(parseCoinToMinor("")).toBeNull();
+    expect(parseCoinToMinor(null)).toBeNull();
+    expect(parseCoinToMinor(undefined)).toBeNull();
+  });
+
+  it("trims whitespace", () => {
+    expect(parseCoinToMinor(" 10 ")).toBe("1000");
+    expect(parseCoinToMinor("  9.50  ")).toBe("950");
+  });
+
+  it("handles large values", () => {
+    expect(parseCoinToMinor("999999")).toBe("99999900");
+    expect(parseCoinToMinor("100000.99")).toBe("10000099");
+  });
+});
+
+describe("formatCoinAmount", () => {
+  it("formats minor units to COIN display", () => {
+    expect(formatCoinAmount(1000)).toBe("10.00 COIN");
+    expect(formatCoinAmount("950")).toBe("9.50 COIN");
+    expect(formatCoinAmount("1")).toBe("0.01 COIN");
+    expect(formatCoinAmount("0")).toBe("0.00 COIN");
+  });
+
+  it("handles null/undefined", () => {
+    expect(formatCoinAmount(null)).toBe("0.00 COIN");
+    expect(formatCoinAmount(undefined)).toBe("0.00 COIN");
+  });
+});

--- a/plugin/src/__tests__/mock-hub.ts
+++ b/plugin/src/__tests__/mock-hub.ts
@@ -18,7 +18,7 @@ export interface MockSubscriptionProduct {
   description: string;
   asset_code: string;
   amount_minor: number;
-  billing_interval: "week" | "month";
+  billing_interval: "week" | "month" | "once";
   status: "active" | "archived";
   created_at: string;
   updated_at: string;
@@ -32,7 +32,7 @@ export interface MockSubscription {
   provider_agent_id: string;
   asset_code: string;
   amount_minor: number;
-  billing_interval: "week" | "month";
+  billing_interval: "week" | "month" | "once";
   status: "active" | "past_due" | "cancelled";
   current_period_start: string;
   current_period_end: string;
@@ -142,7 +142,8 @@ function ensureWallet(state: MockHubState, agentId: string): MockWallet {
   return wallet;
 }
 
-function addInterval(baseIso: string, interval: "week" | "month"): string {
+function addInterval(baseIso: string, interval: "week" | "month" | "once"): string {
+  if (interval === "once") return "9999-12-31T00:00:00.000Z";
   const date = new Date(baseIso);
   if (interval === "week") {
     date.setUTCDate(date.getUTCDate() + 7);
@@ -879,9 +880,9 @@ export function createMockHub() {
         res.end(JSON.stringify({ detail: "amount_minor must be positive" }));
         return;
       }
-      if (billingInterval !== "week" && billingInterval !== "month") {
+      if (billingInterval !== "week" && billingInterval !== "month" && billingInterval !== "once") {
         res.writeHead(400, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ detail: "billing_interval must be week or month" }));
+        res.end(JSON.stringify({ detail: "billing_interval must be week, month, or once" }));
         return;
       }
 

--- a/plugin/src/__tests__/payment.integration.test.ts
+++ b/plugin/src/__tests__/payment.integration.test.ts
@@ -92,7 +92,7 @@ describe("payment tool integration", () => {
     const transfer: any = await tool.execute("tool-2", {
       action: "transfer",
       to_agent_id: "ag_receiver",
-      amount_minor: "7000",
+      amount: "70",
       memo: "invoice settlement",
       reference_type: "invoice",
       reference_id: "inv_123",
@@ -167,7 +167,7 @@ describe("payment tool integration", () => {
     const transfer: any = await tool.execute("tool-contact-transfer", {
       action: "transfer",
       to_agent_id: "ag_receiver",
-      amount_minor: "5000",
+      amount: "50",
     });
 
     expect(transfer.data.tx.type).toBe("transfer");
@@ -188,7 +188,7 @@ describe("payment tool integration", () => {
     const warning: any = await tool.execute("tool-non-contact", {
       action: "transfer",
       to_agent_id: "ag_receiver",
-      amount_minor: "7000",
+      amount: "70",
     });
 
     expect(warning.result).toContain("is not in your contacts");
@@ -202,7 +202,7 @@ describe("payment tool integration", () => {
     const transfer: any = await tool.execute("tool-non-contact-confirm", {
       action: "transfer",
       to_agent_id: "ag_receiver",
-      amount_minor: "7000",
+      amount: "70",
       confirmed: true,
     });
 
@@ -228,7 +228,7 @@ describe("payment tool integration", () => {
     const transfer: any = await tool.execute("tool-followup-fail", {
       action: "transfer",
       to_agent_id: "ag_receiver",
-      amount_minor: "7000",
+      amount: "70",
     });
 
     expect(transfer.data.tx.type).toBe("transfer");
@@ -251,7 +251,7 @@ describe("payment tool integration", () => {
 
     const withdrawal: any = await tool.execute("tool-6", {
       action: "withdraw",
-      amount_minor: "3000",
+      amount: "30",
       destination_type: "mock_bank",
       destination: { account: "ending-1234" },
       idempotency_key: "wd-1",

--- a/plugin/src/__tests__/subscription-room.integration.test.ts
+++ b/plugin/src/__tests__/subscription-room.integration.test.ts
@@ -61,7 +61,7 @@ describe("subscription room tool integration", () => {
     const createdProduct = await tool.execute("tool-1", {
       action: "create_product",
       name: "Premium",
-      amount_minor: "9000",
+      amount: "90",
       billing_interval: "month",
     });
 
@@ -94,7 +94,7 @@ describe("subscription room tool integration", () => {
     const createdProduct = await tool.execute("tool-1", {
       action: "create_product",
       name: "Gold",
-      amount_minor: "7000",
+      amount: "70",
       billing_interval: "week",
     });
     const productId = (createdProduct as any).data.product_id;

--- a/plugin/src/__tests__/subscription.integration.test.ts
+++ b/plugin/src/__tests__/subscription.integration.test.ts
@@ -243,4 +243,50 @@ describe("subscription client and tool integration", () => {
     expect(failureRecord.consecutive_failed_attempts).toBe(3);
     expect(failureRecord.cancelled_at).toBeTruthy();
   });
+
+  it("creates a one-time payment product that never charges again", async () => {
+    const owner = makeClient("ag_owner", ownerKeys.privateKey);
+    const subscriber = makeClient("ag_subscriber", subscriberKeys.privateKey);
+    const tool = createSubscriptionTool();
+
+    await seedBalance(subscriber, "50000");
+
+    makeToolConfig("ag_owner", ownerKeys.privateKey);
+    const created = await tool.execute("tool-once-1", {
+      action: "create_product",
+      name: "Lifetime Access",
+      description: "Pay once, access forever",
+      amount: "100",
+      billing_interval: "once",
+    });
+    const product = created.data as SubscriptionProduct;
+    expect(product.billing_interval).toBe("once");
+
+    makeToolConfig("ag_subscriber", subscriberKeys.privateKey);
+    const subscribed = await tool.execute("tool-once-2", {
+      action: "subscribe",
+      product_id: product.product_id,
+    });
+    const subscription = subscribed.data as Subscription;
+    expect(subscription.status).toBe("active");
+    expect(subscription.billing_interval).toBe("once");
+    expect(subscription.next_charge_at).toBe("9999-12-31T00:00:00.000Z");
+
+    // Verify first charge was deducted
+    const subscriberWallet = await subscriber.getWallet();
+    const ownerWallet = await owner.getWallet();
+    expect(subscriberWallet.available_balance_minor).toBe("40000");
+    expect(ownerWallet.available_balance_minor).toBe("10000");
+
+    // Run billing — should not charge again
+    const resp = await fetch(`${hubUrl}/internal/subscriptions/run-billing`, {
+      method: "POST",
+    });
+    const billingResult = await resp.json();
+    expect(billingResult.charged).toBe(0);
+
+    // Balance unchanged
+    const subscriberWalletAfter = await subscriber.getWallet();
+    expect(subscriberWalletAfter.available_balance_minor).toBe("40000");
+  });
 });

--- a/plugin/src/__tests__/subscription.integration.test.ts
+++ b/plugin/src/__tests__/subscription.integration.test.ts
@@ -85,7 +85,7 @@ describe("subscription client and tool integration", () => {
       action: "create_product",
       name: "Pro Access",
       description: "Priority support and premium tooling",
-      amount_minor: "12000",
+      amount: "120",
       billing_interval: "month",
     });
     const createdProduct = created.data as SubscriptionProduct;

--- a/plugin/src/client.ts
+++ b/plugin/src/client.ts
@@ -774,7 +774,7 @@ export class BotCordClient {
     name: string;
     description?: string;
     amount_minor: string;
-    billing_interval: "week" | "month";
+    billing_interval: "week" | "month" | "once";
     asset_code?: string;
   }): Promise<SubscriptionProduct> {
     const resp = await this.hubFetch("/subscriptions/products", {

--- a/plugin/src/tools/coin-format.ts
+++ b/plugin/src/tools/coin-format.ts
@@ -10,3 +10,22 @@ export function formatCoinAmount(minorValue: string | number | null | undefined)
     maximumFractionDigits: 2,
   })} COIN`;
 }
+
+/**
+ * Convert a COIN-denominated string (e.g. "10", "9.50") to a minor-unit
+ * string suitable for the Hub API (1 COIN = 100 minor units).
+ * Accepts non-negative numbers with up to 2 decimal places.
+ * Returns null if the input is missing, malformed, negative, or has 3+ decimals.
+ */
+const COIN_PATTERN = /^(0|[1-9]\d*)(\.\d{1,2})?$/;
+
+export function parseCoinToMinor(coinValue: string | undefined | null): string | null {
+  if (coinValue == null || coinValue === "") return null;
+  const trimmed = coinValue.trim();
+  if (!COIN_PATTERN.test(trimmed)) return null;
+  const dotIndex = trimmed.indexOf(".");
+  if (dotIndex === -1) return String(Number.parseInt(trimmed, 10) * 100);
+  const intPart = trimmed.slice(0, dotIndex);
+  const fracPart = trimmed.slice(dotIndex + 1).padEnd(2, "0");
+  return String(Number.parseInt(intPart, 10) * 100 + Number.parseInt(fracPart, 10));
+}

--- a/plugin/src/tools/payment.ts
+++ b/plugin/src/tools/payment.ts
@@ -9,7 +9,7 @@ import {
 import { BotCordClient } from "../client.js";
 import { attachTokenPersistence } from "../credentials.js";
 import { getConfig as getAppConfig } from "../runtime.js";
-import { formatCoinAmount } from "./coin-format.js";
+import { formatCoinAmount, parseCoinToMinor } from "./coin-format.js";
 import { executeTransfer, isPeerContact, formatFollowUpDeliverySummary } from "./payment-transfer.js";
 
 function sanitizeBalance(summary: any): any {
@@ -223,9 +223,9 @@ export function createPaymentTool(opts?: { name?: string; description?: string }
           type: "string" as const,
           description: "Recipient agent ID (ag_...) — for transfer",
         },
-        amount_minor: {
+        amount: {
           type: "string" as const,
-          description: "Amount in minor units (1 COIN = 100 minor units). To transfer N coins, pass N × 100. Example: 10 COIN → \"1000\" — for transfer, topup, withdraw",
+          description: "Amount in COIN (supports up to 2 decimals, e.g. \"10\" or \"9.50\") — for transfer, topup, withdraw",
         },
         memo: {
           type: "string" as const,
@@ -259,9 +259,9 @@ export function createPaymentTool(opts?: { name?: string; description?: string }
           type: "object" as const,
           description: "Withdrawal destination details — for withdraw",
         },
-        fee_minor: {
+        fee: {
           type: "string" as const,
-          description: "Optional withdrawal fee in minor units (1 COIN = 100 minor units) — for withdraw",
+          description: "Optional withdrawal fee in COIN (e.g. \"1\" or \"0.50\") — for withdraw",
         },
         withdrawal_id: {
           type: "string" as const,
@@ -328,18 +328,20 @@ export function createPaymentTool(opts?: { name?: string; description?: string }
 
           case "transfer": {
             if (!args.to_agent_id) return { error: "to_agent_id is required" };
-            if (!args.amount_minor) return { error: "amount_minor is required" };
+            if (!args.amount) return { error: "amount is required" };
+            const transferMinor = parseCoinToMinor(args.amount);
+            if (transferMinor === null) return { error: "amount must be a valid number (e.g. \"10\" or \"9.50\")" };
 
             const isContact = await isPeerContact(client, args.to_agent_id);
             if (!isContact && args.confirmed !== true) {
               return {
-                result: `\u26a0\ufe0f ${args.to_agent_id} is not in your contacts. This is a stranger transfer of ${formatCoinAmount(args.amount_minor)}. To proceed, call this tool again with confirmed: true. The transfer will create a chat room between you and the recipient.`,
+                result: `\u26a0\ufe0f ${args.to_agent_id} is not in your contacts. This is a stranger transfer of ${formatCoinAmount(transferMinor)}. To proceed, call this tool again with confirmed: true. The transfer will create a chat room between you and the recipient.`,
               };
             }
 
             const transfer = await executeTransfer(client, {
               to_agent_id: args.to_agent_id,
-              amount_minor: args.amount_minor,
+              amount_minor: transferMinor,
               memo: args.memo,
               reference_type: args.reference_type,
               reference_id: args.reference_id,
@@ -353,9 +355,11 @@ export function createPaymentTool(opts?: { name?: string; description?: string }
           }
 
           case "topup": {
-            if (!args.amount_minor) return { error: "amount_minor is required" };
+            if (!args.amount) return { error: "amount is required" };
+            const topupMinor = parseCoinToMinor(args.amount);
+            if (topupMinor === null) return { error: "amount must be a valid number (e.g. \"10\" or \"9.50\")" };
             const topup = await client.createTopup({
-              amount_minor: args.amount_minor,
+              amount_minor: topupMinor,
               channel: args.channel,
               metadata: args.metadata,
               idempotency_key: args.idempotency_key,
@@ -364,10 +368,17 @@ export function createPaymentTool(opts?: { name?: string; description?: string }
           }
 
           case "withdraw": {
-            if (!args.amount_minor) return { error: "amount_minor is required" };
+            if (!args.amount) return { error: "amount is required" };
+            const withdrawMinor = parseCoinToMinor(args.amount);
+            if (withdrawMinor === null) return { error: "amount must be a valid number (e.g. \"10\" or \"9.50\")" };
+            let feeMinor: string | undefined;
+            if (args.fee) {
+              feeMinor = parseCoinToMinor(args.fee) ?? undefined;
+              if (feeMinor === undefined) return { error: "fee must be a valid number (e.g. \"1\" or \"0.50\")" };
+            }
             const withdrawal = await client.createWithdrawal({
-              amount_minor: args.amount_minor,
-              fee_minor: args.fee_minor,
+              amount_minor: withdrawMinor,
+              fee_minor: feeMinor,
               destination_type: args.destination_type,
               destination: args.destination,
               idempotency_key: args.idempotency_key,

--- a/plugin/src/tools/subscription.ts
+++ b/plugin/src/tools/subscription.ts
@@ -9,7 +9,7 @@ import {
 import { BotCordClient } from "../client.js";
 import { attachTokenPersistence } from "../credentials.js";
 import { getConfig as getAppConfig } from "../runtime.js";
-import { formatCoinAmount } from "./coin-format.js";
+import { formatCoinAmount, parseCoinToMinor } from "./coin-format.js";
 
 function formatProduct(product: any): string {
   return [
@@ -98,9 +98,9 @@ export function createSubscriptionTool() {
           type: "string" as const,
           description: "Room rule/instructions — for create_subscription_room or bind_room_to_product",
         },
-        amount_minor: {
+        amount: {
           type: "string" as const,
-          description: "Price in minor coin units — for create_product",
+          description: "Price in COIN (supports up to 2 decimals, e.g. \"10\" or \"9.50\") — for create_product",
         },
         billing_interval: {
           type: "string" as const,
@@ -148,12 +148,14 @@ export function createSubscriptionTool() {
         switch (args.action) {
           case "create_product": {
             if (!args.name) return { error: "name is required" };
-            if (!args.amount_minor) return { error: "amount_minor is required" };
+            if (!args.amount) return { error: "amount is required" };
             if (!args.billing_interval) return { error: "billing_interval is required" };
+            const amountMinor = parseCoinToMinor(args.amount);
+            if (amountMinor === null) return { error: "amount must be a valid number (e.g. \"10\" or \"9.50\")" };
             const product = await client.createSubscriptionProduct({
               name: args.name,
               description: args.description,
-              amount_minor: args.amount_minor,
+              amount_minor: amountMinor,
               billing_interval: args.billing_interval,
               asset_code: args.asset_code,
             });

--- a/plugin/src/tools/subscription.ts
+++ b/plugin/src/tools/subscription.ts
@@ -104,8 +104,8 @@ export function createSubscriptionTool() {
         },
         billing_interval: {
           type: "string" as const,
-          enum: ["week", "month"],
-          description: "Billing interval — for create_product",
+          enum: ["week", "month", "once"],
+          description: "Billing interval — for create_product. Use \"once\" for one-time payment (no recurring charges)",
         },
         asset_code: {
           type: "string" as const,

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -220,7 +220,7 @@ export type WithdrawalResponse = {
   completed_at: string | null;
 };
 
-export type BillingInterval = "week" | "month";
+export type BillingInterval = "week" | "month" | "once";
 
 export type SubscriptionProductStatus = "active" | "archived";
 


### PR DESCRIPTION
## Summary
- Rename tool-facing `amount_minor` → `amount` and `fee_minor` → `fee` in `botcord_payment` and `botcord_subscription` tools so agents pass human-readable COIN values (e.g. `"10"`, `"9.50"`) instead of opaque minor units (`"1000"`)
- Add strict `parseCoinToMinor()` helper with regex validation (rejects negative, non-numeric, leading zeros, 3+ decimals) — converts at tool boundary, internal client/Hub API unchanged
- Add `once` billing interval for one-time payment subscriptions (pay once, access forever — no recurring charges)
- Align `BillingInterval` types across backend enum, plugin types/client, CLI types/client/commands, and SKILL.md docs

## Changes by package
| Package | Files | What |
|---------|-------|------|
| **plugin/tools** | `coin-format.ts`, `payment.ts`, `subscription.ts` | `amount_minor` → `amount` (COIN), `fee_minor` → `fee`, strict parsing |
| **plugin/types+client** | `types.ts`, `client.ts` | `BillingInterval` adds `"once"` |
| **plugin/skills** | `SKILL.md` | Docs aligned with new param names + `once` |
| **plugin/tests** | `coin-format.test.ts` (new), 3 integration tests | 14 edge-case unit tests + `once` billing e2e |
| **backend** | `enums.py`, `subscriptions.py`, `subscription_schemas.py`, `i18n.py` | `BillingInterval.once`, `_NEVER` sentinel, schema/i18n updates |
| **cli** | `types.ts`, `client.ts`, `commands/subscription.ts` | `BillingInterval` + validation + help text |

## Test plan
- [x] Plugin: 292 tests pass (28 test files)
- [x] CLI: `tsc --noEmit` clean
- [x] New `coin-format.test.ts`: 14 edge cases (whole, decimal, leading zeros, negative, NaN, empty, whitespace, large values)
- [x] New `once` billing integration test: verifies single charge + billing loop skips
- [x] Codex review: 0 critical, 0 warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)