### PR TITLE
fix(plugin): remove duplicate room rule injection

### DIFF
--- a/plugin/src/__tests__/inbound.rule.test.ts
+++ b/plugin/src/__tests__/inbound.rule.test.ts
@@ -25,12 +25,12 @@ vi.mock("../runtime.js", () => ({
 
 import { handleInboxMessage } from "../inbound.js";
 
-describe("handleInboxMessage room rule injection", () => {
+describe("handleInboxMessage room rule injection removed", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("injects room rule for group rooms", async () => {
+  it("does not inject room rule into message body for group rooms (handled by static context)", async () => {
     await handleInboxMessage(
       {
         hub_msg_id: "h1",
@@ -58,8 +58,8 @@ describe("handleInboxMessage room rule injection", () => {
 
     expect(mockDispatchReply).toHaveBeenCalledTimes(1);
     const dispatchArg = mockDispatchReply.mock.calls[0][0];
-    expect(dispatchArg.ctx.BodyForAgent).toContain("[Room Rule] <room-rule>Keep it focused</room-rule>");
-    expect(dispatchArg.ctx.RawBody).toContain("[Room Rule] <room-rule>Keep it focused</room-rule>");
+    expect(dispatchArg.ctx.BodyForAgent).not.toContain("[Room Rule]");
+    expect(dispatchArg.ctx.RawBody).not.toContain("[Room Rule]");
   });
 
   it("does not inject room rule for direct rooms", async () => {

--- a/plugin/src/inbound.ts
+++ b/plugin/src/inbound.ts
@@ -69,13 +69,6 @@ function buildInboundHeader(params: {
   return parts.join(" | ");
 }
 
-function appendRoomRule(content: string, roomRule?: string | null): string {
-  const normalizedRule = roomRule?.trim();
-  if (!normalizedRule) return content;
-  const sanitizedRule = sanitizeUntrustedContent(normalizedRule);
-  return `${content}\n[Room Rule] <room-rule>${sanitizedRule}</room-rule>`;
-}
-
 export interface InboundParams {
   cfg: any;
   accountId: string;
@@ -363,14 +356,13 @@ async function handleA2AMessage(
 
   const sanitizedContent = sanitizeUntrustedContent(rawContent);
   const content = `${header}\n<agent-message sender="${sanitizedSender}">\n${sanitizedContent}\n</agent-message>${silentHint}${notifyOwnerHint}`;
-  const contentWithRule = isGroupRoom ? appendRoomRule(content, msg.room_rule) : content;
 
   await dispatchInbound({
     cfg,
     accountId,
     senderName: senderId,
     senderId,
-    content: contentWithRule,
+    content,
     messageId: envelope.msg_id,
     messageType: envelope.type,
     chatType,
@@ -441,7 +433,6 @@ async function handleA2AMessageBatch(
     : "";
 
   const content = `${header}\n${messageBlocks.join("\n")}${silentHint}${notifyOwnerHint}`;
-  const contentWithRule = isGroupRoom ? appendRoomRule(content, first.room_rule) : content;
 
   // Use the last message's metadata for dispatch (most recent)
   const last = msgs[msgs.length - 1];


### PR DESCRIPTION
## Summary
- Remove `appendRoomRule()` which injected room rule into every inbound group message body
- Room rule is already provided via `buildRoomStaticContext()` (priority 60 `appendSystemContext` hook), making the per-message injection redundant
- Update test assertions to verify rule no longer appears in message body

## Test plan
- [x] All 292 plugin tests pass
- [ ] Verify room rule still visible to agent in group room conversations (via static context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)