### PR TITLE
fix(frontend): React hooks order violation in ExploreMainPane

### DIFF
--- a/frontend/src/components/dashboard/ChatPane.tsx
+++ b/frontend/src/components/dashboard/ChatPane.tsx
@@ -351,11 +351,6 @@ function ExploreMainPane() {
   })));
   const [query, setQuery] = useState("");
   const [page, setPage] = useState(1);
-
-  if (exploreView === "templates") {
-    return <PromptTemplates />;
-  }
-
   const isRoomsView = exploreView === "rooms";
 
   useEffect(() => {
@@ -426,6 +421,10 @@ function ExploreMainPane() {
   const end = start + EXPLORE_PAGE_SIZE;
   const pagedRooms = filteredRooms.slice(start, end);
   const pagedAgents = filteredAgents.slice(start, end);
+
+  if (exploreView === "templates") {
+    return <PromptTemplates />;
+  }
 
   return (
     <div className="relative flex flex-1 flex-col overflow-hidden bg-deep-black">


### PR DESCRIPTION
## Summary
- Fix React error #300 ("Rendered more hooks than during the previous render") when switching to/from the templates view
- The `if (exploreView === "templates") return` was placed between `useState` and `useEffect`/`useMemo`, violating Rules of Hooks
- Moved the early return after all hooks, before the JSX return

## Test plan
- [ ] Navigate to `/chats/explore/templates` — no React error in console
- [ ] Switch between Rooms / Bots / Templates tabs — no crash
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)