### PR TITLE
feat(backend): add hint field to API error responses

### DIFF
--- a/backend/hub/i18n.py
+++ b/backend/hub/i18n.py
@@ -541,6 +541,672 @@ ERROR_MESSAGES: dict[str, dict[Locale, str]] = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Hint message catalog
+# ---------------------------------------------------------------------------
+# Each key maps to {Locale.EN: "...", Locale.ZH: "..."}.
+# Hints explain *why* the error happened and *how* to fix or avoid it.
+# Keys match ERROR_MESSAGES where possible; extra keys (prefixed ``hint_``)
+# are used for dynamic-detail errors like ``wallet_service_error``.
+# ---------------------------------------------------------------------------
+
+HINT_MESSAGES: dict[str, dict[Locale, str]] = {
+    # -----------------------------------------------------------------------
+    # Registry
+    # -----------------------------------------------------------------------
+    "agent_id_collision": {
+        Locale.EN: "Use your existing agent or generate a new keypair to register a different agent.",
+        Locale.ZH: "请使用已有的 Agent，或生成新的密钥对来注册一个新 Agent。",
+    },
+    "challenge_not_found": {
+        Locale.EN: "Start the registration flow again to obtain a new challenge.",
+        Locale.ZH: "请重新开始注册流程以获取新的 Challenge。",
+    },
+    "challenge_already_used": {
+        Locale.EN: "Each challenge can only be used once. Register again to get a fresh challenge.",
+        Locale.ZH: "每个 Challenge 仅可使用一次，请重新注册以获取新的 Challenge。",
+    },
+    "challenge_expired": {
+        Locale.EN: "Challenges expire after a short time. Register again to get a fresh challenge.",
+        Locale.ZH: "Challenge 已超时，请重新注册以获取新的 Challenge。",
+    },
+    "key_not_found": {
+        Locale.EN: "Check the key_id. It should start with 'k_'.",
+        Locale.ZH: "请检查 key_id 是否正确，key_id 以 'k_' 开头。",
+    },
+    "signature_verification_failed": {
+        Locale.EN: "Ensure you are signing with the correct private key matching the registered public key.",
+        Locale.ZH: "请确认使用了与已注册公钥对应的正确私钥进行签名。",
+    },
+    "agent_not_found": {
+        Locale.EN: "Check the agent_id. Agent IDs start with 'ag_'.",
+        Locale.ZH: "请检查 agent_id 是否正确，Agent ID 以 'ag_' 开头。",
+    },
+    "agent_not_claimed": {
+        Locale.EN: "Visit the claim URL to bind this agent to your account before using it.",
+        Locale.ZH: "请访问 claim 链接将该 Agent 绑定到您的账号后再使用。",
+    },
+    "agent_not_claimed_generic": {
+        Locale.EN: "Claim this agent via the dashboard or the /botcord_bind command first.",
+        Locale.ZH: "请先通过 Dashboard 或 /botcord_bind 命令完成 Agent 认领。",
+    },
+    "agent_not_owned_by_user": {
+        Locale.EN: "Switch to an agent you own, or claim this agent first.",
+        Locale.ZH: "请切换到您拥有的 Agent，或先认领该 Agent。",
+    },
+    "no_endpoint_registered": {
+        Locale.EN: "Register an endpoint URL via POST /registry/agents/{{agent_id}}/endpoints.",
+        Locale.ZH: "请通过 POST /registry/agents/{{agent_id}}/endpoints 注册 Endpoint URL。",
+    },
+    "agent_discovery_disabled": {
+        Locale.EN: "Agent discovery is turned off on this hub. Use /registry/resolve/{{agent_id}} to look up specific agents.",
+        Locale.ZH: "此 Hub 已关闭 Agent 发现功能，请使用 /registry/resolve/{{agent_id}} 查询特定 Agent。",
+    },
+    "key_already_revoked": {
+        Locale.EN: "This key is already revoked. No further action needed.",
+        Locale.ZH: "该密钥已被撤销，无需再次操作。",
+    },
+    "cannot_revoke_last_active_key": {
+        Locale.EN: "Add a new signing key before revoking the last one.",
+        Locale.ZH: "请先添加新的签名密钥，再撤销最后一个活跃密钥。",
+    },
+    "key_not_active": {
+        Locale.EN: "This key must be verified and active before it can be used. Complete the challenge-response flow.",
+        Locale.ZH: "该密钥需要完成验证才能使用，请完成 Challenge-Response 流程。",
+    },
+    "nonce_already_used": {
+        Locale.EN: "Generate a new random nonce for each token refresh request.",
+        Locale.ZH: "请为每次 token 刷新请求生成一个新的随机 nonce。",
+    },
+
+    # -----------------------------------------------------------------------
+    # Validators
+    # -----------------------------------------------------------------------
+    "agent_id_mismatch": {
+        Locale.EN: "The agent_id in the URL must match the agent_id in the JWT token.",
+        Locale.ZH: "URL 中的 agent_id 必须与 JWT 令牌中的 agent_id 一致。",
+    },
+    "pubkey_must_start_with_ed25519": {
+        Locale.EN: "Format the public key as 'ed25519:<base64-encoded-key>'.",
+        Locale.ZH: "请将公钥格式化为 'ed25519:<base64编码的密钥>'。",
+    },
+    "pubkey_base64_invalid": {
+        Locale.EN: "Re-encode the public key using standard base64.",
+        Locale.ZH: "请使用标准 base64 重新编码公钥。",
+    },
+    "pubkey_must_be_32_bytes": {
+        Locale.EN: "Ensure you are using an Ed25519 public key (exactly 32 bytes after decoding).",
+        Locale.ZH: "请确认使用的是 Ed25519 公钥（解码后恰好 32 字节）。",
+    },
+    "url_must_use_http_or_https": {
+        Locale.EN: "Provide a URL starting with http:// or https://.",
+        Locale.ZH: "请提供以 http:// 或 https:// 开头的 URL。",
+    },
+    "url_must_have_hostname": {
+        Locale.EN: "Include a valid hostname in the URL (e.g. https://example.com/webhook).",
+        Locale.ZH: "请在 URL 中包含有效的主机名（如 https://example.com/webhook）。",
+    },
+    "private_hostnames_not_allowed": {
+        Locale.EN: "Use a publicly reachable hostname. localhost, .local, and .internal are not allowed.",
+        Locale.ZH: "请使用可公开访问的主机名，不允许 localhost、.local 和 .internal。",
+    },
+    "private_ips_not_allowed": {
+        Locale.EN: "Use a public IP address. Private ranges (10.x, 172.16-31.x, 192.168.x) are not allowed.",
+        Locale.ZH: "请使用公网 IP 地址，不允许私有地址段（10.x、172.16-31.x、192.168.x）。",
+    },
+    "endpoint_probe_failed": {
+        Locale.EN: "Ensure your endpoint is reachable and responds to POST requests with 2xx.",
+        Locale.ZH: "请确保您的 Endpoint 可达并对 POST 请求返回 2xx 状态码。",
+    },
+    "endpoint_probe_failed_detail": {
+        Locale.EN: "Check that the endpoint URL is correct and the server is running.",
+        Locale.ZH: "请确认 Endpoint URL 正确且服务已启动。",
+    },
+
+    # -----------------------------------------------------------------------
+    # Hub / messaging
+    # -----------------------------------------------------------------------
+    "rate_limit_exceeded": {
+        Locale.EN: "Wait a moment and retry. The limit resets every minute.",
+        Locale.ZH: "请稍后重试，速率限制每分钟重置。",
+    },
+    "conversation_rate_limit_exceeded": {
+        Locale.EN: "Slow down messages to this recipient. The per-conversation limit resets every minute.",
+        Locale.ZH: "请降低向该对话发送消息的频率，每分钟限制会重置。",
+    },
+    "timestamp_out_of_range": {
+        Locale.EN: "Sync your system clock. The message timestamp must be within ±5 minutes of the server time.",
+        Locale.ZH: "请同步系统时钟，消息时间戳必须在服务器时间 ±5 分钟以内。",
+    },
+    "payload_hash_mismatch": {
+        Locale.EN: "Recompute the payload_hash using JCS canonicalization + SHA-256.",
+        Locale.ZH: "请使用 JCS 规范化 + SHA-256 重新计算 payload_hash。",
+    },
+    "signing_key_not_found_or_inactive": {
+        Locale.EN: "Check the key_id in the envelope. The key must be verified and active.",
+        Locale.ZH: "请检查信封中的 key_id，密钥必须已验证且处于活跃状态。",
+    },
+    "key_does_not_belong_to_sender": {
+        Locale.EN: "Use a signing key that belongs to the 'from' agent in the envelope.",
+        Locale.ZH: "请使用属于信封中 'from' Agent 的签名密钥。",
+    },
+    "unknown_agent": {
+        Locale.EN: "The recipient agent_id does not exist. Verify the ID or register the agent first.",
+        Locale.ZH: "收件人 agent_id 不存在，请确认 ID 或先注册该 Agent。",
+    },
+    "blocked": {
+        Locale.EN: "The recipient has blocked you. You cannot send messages to this agent.",
+        Locale.ZH: "对方已将您屏蔽，无法向该 Agent 发送消息。",
+    },
+    "not_in_contacts": {
+        Locale.EN: "The recipient's policy requires you to be in their contacts. Send a contact request first.",
+        Locale.ZH: "对方设置了仅联系人策略，请先发送联系人请求。",
+    },
+    "cannot_send_contact_request_to_self": {
+        Locale.EN: "You cannot add yourself as a contact.",
+        Locale.ZH: "不能将自己添加为联系人。",
+    },
+    "already_in_contacts": {
+        Locale.EN: "This agent is already in your contacts. No action needed.",
+        Locale.ZH: "该 Agent 已在您的联系人列表中，无需操作。",
+    },
+    "contact_request_already_pending": {
+        Locale.EN: "A contact request is already waiting for the recipient's response.",
+        Locale.ZH: "已有一个联系人请求等待对方回应。",
+    },
+    "contact_request_already_accepted": {
+        Locale.EN: "The contact request was already accepted. You are already contacts.",
+        Locale.ZH: "该联系人请求已被接受，你们已经是联系人。",
+    },
+    "slow_mode_wait": {
+        Locale.EN: "This room has slow mode enabled. Wait for the cooldown period to pass.",
+        Locale.ZH: "该房间启用了慢速模式，请等待冷却时间结束。",
+    },
+    "duplicate_content": {
+        Locale.EN: "Modify your message before resending — consecutive identical messages are blocked.",
+        Locale.ZH: "请修改消息内容后再发送——不允许连续发送完全相同的消息。",
+    },
+    "sender_does_not_match_token": {
+        Locale.EN: "The 'from' field in the envelope must match the agent_id in your JWT token.",
+        Locale.ZH: "信封中的 'from' 字段必须与 JWT 令牌中的 agent_id 一致。",
+    },
+    "send_invalid_type": {
+        Locale.EN: "Use /hub/send for 'message', 'contact_request', 'result', or 'error' types. Use /hub/receipt for ack/result/error.",
+        Locale.ZH: "请通过 /hub/send 发送 'message'、'contact_request'、'result' 或 'error' 类型，使用 /hub/receipt 发送 ack/result/error。",
+    },
+    "receipt_invalid_type": {
+        Locale.EN: "Only ack, result, and error types are accepted on /hub/receipt.",
+        Locale.ZH: "/hub/receipt 仅接受 ack、result 和 error 类型。",
+    },
+    "receipt_must_have_reply_to": {
+        Locale.EN: "Set the reply_to field to the msg_id of the message you are acknowledging.",
+        Locale.ZH: "请在 reply_to 字段中设置您要确认的消息的 msg_id。",
+    },
+    "original_message_not_found": {
+        Locale.EN: "The message referenced by reply_to does not exist. Check the msg_id.",
+        Locale.ZH: "reply_to 引用的消息不存在，请检查 msg_id。",
+    },
+    "message_not_found": {
+        Locale.EN: "Check the msg_id. Message IDs start with 'h_'.",
+        Locale.ZH: "请检查 msg_id 是否正确，消息 ID 以 'h_' 开头。",
+    },
+    "not_the_sender": {
+        Locale.EN: "You can only check the delivery status of messages you sent.",
+        Locale.ZH: "您只能查看自己发送的消息的投递状态。",
+    },
+    "invalid_cursor": {
+        Locale.EN: "The cursor references a message that no longer exists. Start pagination from the beginning.",
+        Locale.ZH: "游标引用的消息已不存在，请从头开始分页。",
+    },
+
+    # -----------------------------------------------------------------------
+    # Room
+    # -----------------------------------------------------------------------
+    "room_not_found": {
+        Locale.EN: "Check the room_id. Room IDs start with 'rm_'.",
+        Locale.ZH: "请检查 room_id 是否正确，房间 ID 以 'rm_' 开头。",
+    },
+    "not_a_member": {
+        Locale.EN: "Join the room first, or ask an admin to add you.",
+        Locale.ZH: "请先加入房间，或联系管理员将您添加。",
+    },
+    "admin_or_owner_required": {
+        Locale.EN: "This action requires admin or owner role. Ask the room owner to promote you.",
+        Locale.ZH: "此操作需要管理员或所有者角色，请联系房间所有者提升您的角色。",
+    },
+    "member_ids_not_found": {
+        Locale.EN: "Verify all member agent_ids exist and start with 'ag_'.",
+        Locale.ZH: "请确认所有成员的 agent_id 存在且以 'ag_' 开头。",
+    },
+    "admission_denied_contacts_only": {
+        Locale.EN: "Some agents have contacts_only policy. Add them as contacts first before inviting.",
+        Locale.ZH: "部分 Agent 设置了仅联系人策略，请先添加为联系人再邀请。",
+    },
+    "initial_members_exceed_max": {
+        Locale.EN: "Reduce the number of initial members or increase max_members for the room.",
+        Locale.ZH: "请减少初始成员数量，或增大房间的 max_members 限制。",
+    },
+    "join_rate_limit_exceeded": {
+        Locale.EN: "Too many agents are joining this room. Wait a moment and try again.",
+        Locale.ZH: "该房间的加入频率过高，请稍后重试。",
+    },
+    "self_join_public_open_only": {
+        Locale.EN: "This room is not public or does not allow open joining. Ask an admin to invite you.",
+        Locale.ZH: "该房间不是公开房间或不允许自由加入，请联系管理员邀请您。",
+    },
+    "no_invite_permission": {
+        Locale.EN: "The room's default_invite is disabled and you don't have an override. Ask an admin.",
+        Locale.ZH: "房间的 default_invite 已禁用且您没有覆盖权限，请联系管理员。",
+    },
+    "admission_denied_target_contacts_only": {
+        Locale.EN: "The target agent's policy requires you to be in their contacts first.",
+        Locale.ZH: "目标 Agent 设置了仅联系人策略，请先添加为联系人。",
+    },
+    "room_is_full": {
+        Locale.EN: "The room has reached its member limit. Ask the owner to increase max_members.",
+        Locale.ZH: "房间已达成员上限，请联系所有者增大 max_members。",
+    },
+    "agent_already_member_or_not_exist": {
+        Locale.EN: "The agent is already in the room, or the agent_id does not exist.",
+        Locale.ZH: "该 Agent 已在房间中，或 agent_id 不存在。",
+    },
+    "member_not_found_in_room": {
+        Locale.EN: "Check the agent_id. This agent is not a member of the room.",
+        Locale.ZH: "请检查 agent_id，该 Agent 不是此房间的成员。",
+    },
+    "cannot_remove_room_owner": {
+        Locale.EN: "Transfer ownership to another member before removing the owner.",
+        Locale.ZH: "请先将所有权转移给其他成员，再移除所有者。",
+    },
+    "only_owner_can_remove_admins": {
+        Locale.EN: "Only the room owner can remove admins. Contact the owner.",
+        Locale.ZH: "只有房间所有者可以移除管理员，请联系所有者。",
+    },
+    "owner_cannot_leave": {
+        Locale.EN: "Transfer ownership to another member first, then you can leave.",
+        Locale.ZH: "请先将所有权转移给其他成员，然后再离开房间。",
+    },
+    "only_owner_can_dissolve": {
+        Locale.EN: "Only the room owner can dissolve the room.",
+        Locale.ZH: "只有房间所有者可以解散房间。",
+    },
+    "only_owner_can_transfer": {
+        Locale.EN: "Only the current owner can transfer ownership.",
+        Locale.ZH: "只有当前所有者可以转让所有权。",
+    },
+    "cannot_transfer_to_self": {
+        Locale.EN: "You are already the owner. Transfer to a different member.",
+        Locale.ZH: "您已经是所有者，请转让给其他成员。",
+    },
+    "new_owner_not_member": {
+        Locale.EN: "The target agent must be a member of the room before receiving ownership.",
+        Locale.ZH: "目标 Agent 必须是房间成员才能接受所有权。",
+    },
+    "only_owner_can_promote": {
+        Locale.EN: "Only the room owner can promote or demote members.",
+        Locale.ZH: "只有房间所有者可以提升或降级成员角色。",
+    },
+    "cannot_change_owner_role": {
+        Locale.EN: "Use the transfer endpoint to change ownership instead.",
+        Locale.ZH: "请使用转让端点来更改所有权。",
+    },
+    "cannot_modify_owner_permissions": {
+        Locale.EN: "Owner permissions cannot be modified.",
+        Locale.ZH: "所有者权限不可修改。",
+    },
+    "only_owner_can_modify_admin_permissions": {
+        Locale.EN: "Only the room owner can modify admin permissions.",
+        Locale.ZH: "只有房间所有者可以修改管理员权限。",
+    },
+    "only_owner_admin_can_post": {
+        Locale.EN: "This room has default_send disabled. Ask an admin to grant you send permission.",
+        Locale.ZH: "该房间已禁用 default_send，请联系管理员授予您发送权限。",
+    },
+
+    # -----------------------------------------------------------------------
+    # Topics
+    # -----------------------------------------------------------------------
+    "topic_not_found": {
+        Locale.EN: "Check the topic_id. Topic IDs start with 'tp_'.",
+        Locale.ZH: "请检查 topic_id 是否正确，Topic ID 以 'tp_' 开头。",
+    },
+    "topic_title_duplicate": {
+        Locale.EN: "Choose a different title — a topic with this name already exists in the room.",
+        Locale.ZH: "请选择不同的标题——该房间中已存在同名 Topic。",
+    },
+    "topic_update_title_desc_forbidden": {
+        Locale.EN: "Only the topic creator, a room admin, or the owner can edit the title and description.",
+        Locale.ZH: "只有 Topic 创建者、管理员或所有者可以修改标题和描述。",
+    },
+    "topic_reactivation_requires_goal": {
+        Locale.EN: "Provide a new 'goal' to reactivate a completed, failed, or expired topic.",
+        Locale.ZH: "请提供新的 'goal' 来重新激活已终止的 Topic。",
+    },
+    "only_owner_admin_can_delete_topics": {
+        Locale.EN: "Only the room owner or admin can delete topics.",
+        Locale.ZH: "只有房间所有者或管理员可以删除 Topic。",
+    },
+
+    # -----------------------------------------------------------------------
+    # Files
+    # -----------------------------------------------------------------------
+    "mime_type_not_allowed": {
+        Locale.EN: "Allowed types: text/*, image/*, audio/*, video/*, and common application types (pdf, json, zip).",
+        Locale.ZH: "允许的类型：text/*、image/*、audio/*、video/* 以及常见应用类型（pdf、json、zip）。",
+    },
+    "file_too_large": {
+        Locale.EN: "Reduce the file size or split it into smaller parts.",
+        Locale.ZH: "请缩小文件大小或拆分为多个较小的部分。",
+    },
+    "empty_file": {
+        Locale.EN: "Upload a file with actual content.",
+        Locale.ZH: "请上传有实际内容的文件。",
+    },
+    "file_not_found": {
+        Locale.EN: "The file_id does not exist. File IDs start with 'f_'.",
+        Locale.ZH: "该 file_id 不存在，文件 ID 以 'f_' 开头。",
+    },
+    "file_expired": {
+        Locale.EN: "This file has expired and been deleted. Upload it again if needed.",
+        Locale.ZH: "该文件已过期并被删除，如需使用请重新上传。",
+    },
+    "file_not_found_on_disk": {
+        Locale.EN: "The file record exists but the actual file is missing. Re-upload the file.",
+        Locale.ZH: "文件记录存在但实际文件丢失，请重新上传。",
+    },
+
+    # -----------------------------------------------------------------------
+    # Wallet
+    # -----------------------------------------------------------------------
+    "subscription_product_creation_not_allowed": {
+        Locale.EN: "Your agent does not have permission to create subscription products. Contact the hub admin.",
+        Locale.ZH: "您的 Agent 没有创建订阅产品的权限，请联系 Hub 管理员。",
+    },
+    "amount_minor_must_be_numeric": {
+        Locale.EN: "Provide amount_minor as a numeric string (e.g. \"1000\").",
+        Locale.ZH: "请将 amount_minor 提供为数字字符串（如 \"1000\"）。",
+    },
+    "amount_fee_must_be_numeric": {
+        Locale.EN: "Provide amount and fee as numeric strings.",
+        Locale.ZH: "请将 amount 和 fee 提供为数字字符串。",
+    },
+    "fee_must_be_non_negative": {
+        Locale.EN: "Set fee_minor to 0 or a positive value.",
+        Locale.ZH: "请将 fee_minor 设为 0 或正数。",
+    },
+    "transaction_not_found": {
+        Locale.EN: "Check the tx_id. Transaction IDs start with 'tx_'.",
+        Locale.ZH: "请检查 tx_id 是否正确，交易 ID 以 'tx_' 开头。",
+    },
+    "not_authorized": {
+        Locale.EN: "You are not authorized to perform this action.",
+        Locale.ZH: "您没有执行此操作的权限。",
+    },
+    "internal_endpoints_disabled": {
+        Locale.EN: "Set ALLOW_PRIVATE_ENDPOINTS=true in the server configuration to enable internal endpoints.",
+        Locale.ZH: "请在服务器配置中设置 ALLOW_PRIVATE_ENDPOINTS=true 以启用内部端点。",
+    },
+    "missing_internal_api_secret": {
+        Locale.EN: "Provide a Bearer token in the Authorization header.",
+        Locale.ZH: "请在 Authorization 请求头中提供 Bearer 令牌。",
+    },
+    "invalid_internal_api_secret": {
+        Locale.EN: "The provided API secret does not match. Check INTERNAL_API_SECRET configuration.",
+        Locale.ZH: "提供的 API 密钥不匹配，请检查 INTERNAL_API_SECRET 配置。",
+    },
+    "wallet_service_error": {
+        Locale.EN: "Check the request parameters and try again.",
+        Locale.ZH: "请检查请求参数后重试。",
+    },
+
+    # -----------------------------------------------------------------------
+    # Contacts
+    # -----------------------------------------------------------------------
+    "contact_not_found": {
+        Locale.EN: "Check the contact agent_id. You may not have this agent in your contacts.",
+        Locale.ZH: "请检查联系人 agent_id，该 Agent 可能不在您的联系人列表中。",
+    },
+    "cannot_block_yourself": {
+        Locale.EN: "You cannot block yourself.",
+        Locale.ZH: "不能屏蔽自己。",
+    },
+    "target_agent_not_found": {
+        Locale.EN: "The target agent_id does not exist. Verify the ID.",
+        Locale.ZH: "目标 agent_id 不存在，请确认 ID。",
+    },
+    "agent_already_blocked": {
+        Locale.EN: "This agent is already blocked. No further action needed.",
+        Locale.ZH: "该 Agent 已被屏蔽，无需再次操作。",
+    },
+    "block_not_found": {
+        Locale.EN: "You have not blocked this agent.",
+        Locale.ZH: "您未屏蔽该 Agent。",
+    },
+
+    # -----------------------------------------------------------------------
+    # Contact Requests
+    # -----------------------------------------------------------------------
+    "contact_request_not_found": {
+        Locale.EN: "Check the request_id. The contact request may have been deleted.",
+        Locale.ZH: "请检查 request_id，该联系人请求可能已被删除。",
+    },
+    "contact_request_already_resolved": {
+        Locale.EN: "This contact request has already been processed. No further action is possible.",
+        Locale.ZH: "该联系人请求已被处理，无法再次操作。",
+    },
+
+    # -----------------------------------------------------------------------
+    # Subscriptions
+    # -----------------------------------------------------------------------
+    "billing_interval_invalid": {
+        Locale.EN: "Set billing_interval to 'week', 'month', or 'once'.",
+        Locale.ZH: "请将 billing_interval 设置为 'week'、'month' 或 'once'。",
+    },
+    "subscription_product_not_found": {
+        Locale.EN: "Check the product_id. Subscription product IDs start with 'sp_'.",
+        Locale.ZH: "请检查 product_id 是否正确，订阅产品 ID 以 'sp_' 开头。",
+    },
+
+    # -----------------------------------------------------------------------
+    # Dashboard
+    # -----------------------------------------------------------------------
+    "before_after_exclusive": {
+        Locale.EN: "Use either 'before' or 'after' for pagination, not both at the same time.",
+        Locale.ZH: "分页时请只使用 'before' 或 'after' 中的一个，不能同时使用。",
+    },
+    "share_not_found": {
+        Locale.EN: "The share link may have been deleted or the share_id is incorrect.",
+        Locale.ZH: "分享链接可能已被删除或 share_id 不正确。",
+    },
+    "share_expired": {
+        Locale.EN: "This share link has expired. Ask the room member to create a new one.",
+        Locale.ZH: "该分享链接已过期，请联系房间成员创建新的分享。",
+    },
+    "already_a_member": {
+        Locale.EN: "You are already a member of this room. No action needed.",
+        Locale.ZH: "您已是此房间的成员，无需操作。",
+    },
+
+    # -----------------------------------------------------------------------
+    # Auth
+    # -----------------------------------------------------------------------
+    "invalid_authorization_header": {
+        Locale.EN: "Provide a valid 'Bearer <token>' in the Authorization header.",
+        Locale.ZH: "请在 Authorization 请求头中提供有效的 'Bearer <token>'。",
+    },
+    "token_expired": {
+        Locale.EN: "Refresh your token via POST /registry/agents/{{agent_id}}/token/refresh.",
+        Locale.ZH: "请通过 POST /registry/agents/{{agent_id}}/token/refresh 刷新令牌。",
+    },
+    "invalid_token": {
+        Locale.EN: "The token is malformed or signed with a different secret. Obtain a new token.",
+        Locale.ZH: "令牌格式错误或使用了不同的密钥签发，请获取新的令牌。",
+    },
+    "user_auth_not_configured": {
+        Locale.EN: "The hub admin needs to configure SUPABASE_JWT_SECRET or SUPABASE_JWT_JWKS_URL.",
+        Locale.ZH: "Hub 管理员需要配置 SUPABASE_JWT_SECRET 或 SUPABASE_JWT_JWKS_URL。",
+    },
+    "active_agent_header_required": {
+        Locale.EN: "Include X-Active-Agent header with the agent_id you want to act as.",
+        Locale.ZH: "请在请求头中包含 X-Active-Agent，值为您要操作的 agent_id。",
+    },
+
+    # -----------------------------------------------------------------------
+    # Dashboard chat
+    # -----------------------------------------------------------------------
+    "user_id_required_for_chat": {
+        Locale.EN: "Log in to the dashboard to use the chat feature.",
+        Locale.ZH: "请登录 Dashboard 以使用聊天功能。",
+    },
+    "duplicate_message": {
+        Locale.EN: "This message was already sent. Use a different msg_id.",
+        Locale.ZH: "该消息已发送过，请使用不同的 msg_id。",
+    },
+
+    # -----------------------------------------------------------------------
+    # Wallet/Subscription service-layer error hints (used via hint_key)
+    # -----------------------------------------------------------------------
+    "hint_insufficient_balance": {
+        Locale.EN: "Top up your wallet before retrying, or reduce the amount.",
+        Locale.ZH: "请先充值钱包后重试，或减少金额。",
+    },
+    "hint_amount_must_be_positive": {
+        Locale.EN: "Specify a positive amount greater than zero.",
+        Locale.ZH: "请指定大于零的正数金额。",
+    },
+    "hint_recipient_not_found": {
+        Locale.EN: "Check the recipient agent_id. It should start with 'ag_'.",
+        Locale.ZH: "请检查收款方 agent_id，应以 'ag_' 开头。",
+    },
+    "hint_cannot_transfer_to_self": {
+        Locale.EN: "Transfer to a different agent, not yourself.",
+        Locale.ZH: "请转账给其他 Agent，不能转给自己。",
+    },
+    "hint_idempotency_conflict": {
+        Locale.EN: "This operation was already processed. Use a new idempotency key if you intend a separate transaction.",
+        Locale.ZH: "此操作已被处理过，如需新交易请使用新的幂等键。",
+    },
+    "hint_request_not_found": {
+        Locale.EN: "Check the request ID. The request may have already been processed or does not exist.",
+        Locale.ZH: "请检查请求 ID，该请求可能已被处理或不存在。",
+    },
+    "hint_request_wrong_status": {
+        Locale.EN: "This request is no longer in the expected state. Check its current status.",
+        Locale.ZH: "该请求已不在预期状态，请检查其当前状态。",
+    },
+    "hint_fee_must_be_non_negative": {
+        Locale.EN: "Set the fee to 0 or a positive value.",
+        Locale.ZH: "请将手续费设为 0 或正数。",
+    },
+    "hint_stripe_not_configured": {
+        Locale.EN: "The hub admin needs to configure Stripe API keys.",
+        Locale.ZH: "Hub 管理员需要配置 Stripe API 密钥。",
+    },
+    "hint_subscription_product_exists": {
+        Locale.EN: "A product with this name already exists. Use a different name.",
+        Locale.ZH: "同名产品已存在，请使用不同的名称。",
+    },
+    "hint_subscription_product_archived": {
+        Locale.EN: "This product has been archived and no longer accepts new subscriptions.",
+        Locale.ZH: "该产品已归档，不再接受新的订阅。",
+    },
+    "hint_cannot_subscribe_own_product": {
+        Locale.EN: "You cannot subscribe to a product you own.",
+        Locale.ZH: "不能订阅自己拥有的产品。",
+    },
+    "hint_subscription_already_exists": {
+        Locale.EN: "You already have an active subscription to this product.",
+        Locale.ZH: "您已经订阅了该产品。",
+    },
+    "hint_not_authorized_cancel": {
+        Locale.EN: "Only the subscriber can cancel their subscription.",
+        Locale.ZH: "只有订阅者本人可以取消订阅。",
+    },
+    "hint_not_authorized_archive": {
+        Locale.EN: "Only the product owner can archive it.",
+        Locale.ZH: "只有产品所有者可以归档该产品。",
+    },
+    "hint_not_authorized_generic": {
+        Locale.EN: "You do not have permission for this operation.",
+        Locale.ZH: "您没有执行此操作的权限。",
+    },
+    "hint_subscription_product_not_found": {
+        Locale.EN: "Check the product_id. Subscription product IDs start with 'sp_'.",
+        Locale.ZH: "请检查 product_id，订阅产品 ID 以 'sp_' 开头。",
+    },
+    "hint_subscription_not_found": {
+        Locale.EN: "Check the subscription_id. Subscription IDs start with 'sub_'.",
+        Locale.ZH: "请检查 subscription_id，订阅 ID 以 'sub_' 开头。",
+    },
+    "hint_subscription_room_full": {
+        Locale.EN: "The subscription room has reached its member limit. Ask the room owner to increase max_members.",
+        Locale.ZH: "订阅房间已达成员上限，请联系房间所有者增大 max_members。",
+    },
+    "hint_subscription_room_join_failed": {
+        Locale.EN: "Auto-join to the subscription room failed. The subscriber may already be a member, or there was a conflict.",
+        Locale.ZH: "自动加入订阅房间失败，订阅者可能已是成员或发生了冲突。",
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Helper: resolve service-layer ValueError messages to hint keys
+# ---------------------------------------------------------------------------
+# IMPORTANT: Rules are matched top-to-bottom (first match wins).
+# Place more specific patterns BEFORE generic catch-all patterns.
+# ---------------------------------------------------------------------------
+
+_SERVICE_ERROR_HINT_MAP: list[tuple[str, str]] = [
+    # -- Specific patterns first --
+    ("Insufficient balance", "hint_insufficient_balance"),
+    ("Amount must be positive", "hint_amount_must_be_positive"),
+    ("Fee must be non-negative", "hint_fee_must_be_non_negative"),
+    ("Recipient agent not found", "hint_recipient_not_found"),
+    ("Cannot transfer to yourself", "hint_cannot_transfer_to_self"),
+    ("Cannot subscribe to your own", "hint_cannot_subscribe_own_product"),
+    ("Idempotency conflict", "hint_idempotency_conflict"),
+    ("Stripe is not configured", "hint_stripe_not_configured"),
+    ("is archived", "hint_subscription_product_archived"),
+    # -- Subscription-specific patterns --
+    ("Failed to auto-join subscription room", "hint_subscription_room_join_failed"),
+    ("Subscription room", "hint_subscription_room_full"),
+    ("Subscription product already exists", "hint_subscription_product_exists"),
+    ("Subscription already exists", "hint_subscription_already_exists"),
+    ("Subscription product not found", "hint_subscription_product_not_found"),
+    ("Subscription not found", "hint_subscription_not_found"),
+    ("Not authorized to archive", "hint_not_authorized_archive"),
+    ("Not authorized to cancel", "hint_not_authorized_cancel"),
+    # -- Generic catch-all patterns (must be last) --
+    ("not found", "hint_request_not_found"),
+    ("not pending", "hint_request_wrong_status"),
+    ("not approved", "hint_request_wrong_status"),
+    ("already exists", "hint_subscription_product_exists"),
+    ("Not authorized", "hint_not_authorized_generic"),
+]
+
+
+def resolve_service_error_hint(error_msg: str) -> str | None:
+    """Find the best hint_key for a service-layer ValueError message."""
+    for pattern, hint_key in _SERVICE_ERROR_HINT_MAP:
+        if pattern in error_msg:
+            return hint_key
+    return None
+
+
+def get_hint(key: str, locale: Locale = Locale.EN, **kwargs: object) -> str | None:
+    """Get a translated hint by key.
+
+    Returns ``None`` if no hint is defined for the key.
+    """
+    msgs = HINT_MESSAGES.get(key)
+    if msgs is None:
+        return None
+    msg = msgs.get(locale, msgs.get(Locale.EN))
+    if msg is None:
+        return None
+    return msg.format(**kwargs) if kwargs else msg
+
+
 def get_message(key: str, locale: Locale = Locale.EN, **kwargs: object) -> str:
     """Get a translated error message by key.
 
@@ -572,15 +1238,22 @@ class I18nHTTPException(HTTPException):
     ``message_key`` that maps to an entry in ``ERROR_MESSAGES``.  The
     exception handler in ``main.py`` resolves the key to a translated
     string based on the request's ``Accept-Language`` header.
+
+    An optional ``hint_key`` overrides which key is used to look up
+    the hint message (useful for generic wrappers like
+    ``wallet_service_error`` that need error-specific hints).
     """
 
     def __init__(
         self,
         status_code: int,
         message_key: str,
+        *,
+        hint_key: str | None = None,
         **kwargs: object,
     ) -> None:
         self.message_key = message_key
+        self.hint_key = hint_key
         self.message_kwargs = kwargs
         # Use the key as the detail so FastAPI's default handler still
         # produces something meaningful if our custom handler is bypassed.

--- a/backend/hub/main.py
+++ b/backend/hub/main.py
@@ -10,7 +10,7 @@ from fastapi.exceptions import HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
-from hub.i18n import I18nHTTPException, detect_locale, get_message
+from hub.i18n import I18nHTTPException, detect_locale, get_hint, get_message
 
 from sqlalchemy import text
 
@@ -170,9 +170,12 @@ async def i18n_http_exception_handler(request: Request, exc: I18nHTTPException):
     """Return structured error with translated message based on Accept-Language."""
     locale = detect_locale(request.headers.get("accept-language"))
     detail = get_message(exc.message_key, locale, **exc.message_kwargs)
+    hint_lookup_key = exc.hint_key or exc.message_key
+    hint = get_hint(hint_lookup_key, locale, **exc.message_kwargs)
     content: dict = {
         "detail": detail,
         "code": exc.message_key,
+        "hint": hint,
         "retryable": exc.status_code >= 500,
     }
     if exc.message_kwargs.get("claim_url"):
@@ -198,6 +201,7 @@ async def structured_http_exception_handler(request: Request, exc: HTTPException
         content={
             "detail": exc.detail,
             "error": exc.detail,
+            "hint": None,
             "retryable": exc.status_code >= 500,
         },
     )

--- a/backend/hub/routers/subscriptions.py
+++ b/backend/hub/routers/subscriptions.py
@@ -1,7 +1,7 @@
 """Subscription product and billing API router."""
 
 from fastapi import APIRouter, Depends, Header, Query
-from hub.i18n import I18nHTTPException
+from hub.i18n import I18nHTTPException, resolve_service_error_hint
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -106,7 +106,7 @@ async def create_product(
         await db.commit()
         await db.refresh(product)
     except ValueError as err:
-        raise I18nHTTPException(status_code=400, message_key="wallet_service_error", detail=str(err))
+        raise I18nHTTPException(status_code=400, message_key="wallet_service_error", hint_key=resolve_service_error_hint(str(err)), detail=str(err))
 
     return _product_response(product)
 
@@ -145,7 +145,7 @@ async def archive_product(
         await db.commit()
         await db.refresh(product)
     except ValueError as err:
-        raise I18nHTTPException(status_code=400, message_key="wallet_service_error", detail=str(err))
+        raise I18nHTTPException(status_code=400, message_key="wallet_service_error", hint_key=resolve_service_error_hint(str(err)), detail=str(err))
     return _product_response(product)
 
 
@@ -166,7 +166,7 @@ async def subscribe(
         await db.commit()
         await db.refresh(subscription)
     except ValueError as err:
-        raise I18nHTTPException(status_code=400, message_key="wallet_service_error", detail=str(err))
+        raise I18nHTTPException(status_code=400, message_key="wallet_service_error", hint_key=resolve_service_error_hint(str(err)), detail=str(err))
     return _subscription_response(subscription)
 
 
@@ -212,7 +212,7 @@ async def cancel_subscription(
         await db.commit()
         await db.refresh(subscription)
     except ValueError as err:
-        raise I18nHTTPException(status_code=400, message_key="wallet_service_error", detail=str(err))
+        raise I18nHTTPException(status_code=400, message_key="wallet_service_error", hint_key=resolve_service_error_hint(str(err)), detail=str(err))
     return _subscription_response(subscription)
 
 
@@ -227,6 +227,6 @@ async def run_billing(
         result = await subscription_svc.process_due_subscription_billings(db, limit=limit)
         await db.commit()
     except ValueError as err:
-        raise I18nHTTPException(status_code=400, message_key="wallet_service_error", detail=str(err))
+        raise I18nHTTPException(status_code=400, message_key="wallet_service_error", hint_key=resolve_service_error_hint(str(err)), detail=str(err))
 
     return SubscriptionBillingResponse(**result)

--- a/backend/hub/routers/wallet.py
+++ b/backend/hub/routers/wallet.py
@@ -4,7 +4,7 @@ import json
 import logging
 
 from fastapi import APIRouter, Depends, Header, Query
-from hub.i18n import I18nHTTPException
+from hub.i18n import I18nHTTPException, resolve_service_error_hint
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from hub.auth import get_current_claimed_agent
@@ -111,7 +111,7 @@ async def create_transfer(
         )
         await db.commit()
     except ValueError as e:
-        raise I18nHTTPException(status_code=400, message_key="wallet_service_error", detail=str(e))
+        raise I18nHTTPException(status_code=400, message_key="wallet_service_error", hint_key=resolve_service_error_hint(str(e)), detail=str(e))
 
     return _tx_response(tx)
 
@@ -135,7 +135,7 @@ async def create_topup(
         )
         await db.commit()
     except ValueError as e:
-        raise I18nHTTPException(status_code=400, message_key="wallet_service_error", detail=str(e))
+        raise I18nHTTPException(status_code=400, message_key="wallet_service_error", hint_key=resolve_service_error_hint(str(e)), detail=str(e))
 
     return TopupResponse(
         topup_id=topup.topup_id,
@@ -180,7 +180,7 @@ async def create_withdrawal(
         )
         await db.commit()
     except ValueError as e:
-        raise I18nHTTPException(status_code=400, message_key="wallet_service_error", detail=str(e))
+        raise I18nHTTPException(status_code=400, message_key="wallet_service_error", hint_key=resolve_service_error_hint(str(e)), detail=str(e))
 
     return _wd_response(wd)
 
@@ -212,7 +212,7 @@ async def cancel_withdrawal(
         wd = await wallet_svc.cancel_withdrawal_request(db, withdrawal_id, current_agent)
         await db.commit()
     except ValueError as e:
-        raise I18nHTTPException(status_code=400, message_key="wallet_service_error", detail=str(e))
+        raise I18nHTTPException(status_code=400, message_key="wallet_service_error", hint_key=resolve_service_error_hint(str(e)), detail=str(e))
     return _wd_response(wd)
 
 
@@ -255,7 +255,7 @@ async def internal_complete_topup(
         topup, tx = await wallet_svc.complete_topup_request(db, topup_id)
         await db.commit()
     except ValueError as e:
-        raise I18nHTTPException(status_code=400, message_key="wallet_service_error", detail=str(e))
+        raise I18nHTTPException(status_code=400, message_key="wallet_service_error", hint_key=resolve_service_error_hint(str(e)), detail=str(e))
     return TopupResponse(
         topup_id=topup.topup_id,
         tx_id=topup.tx_id,
@@ -281,7 +281,7 @@ async def internal_fail_topup(
         topup = await wallet_svc.fail_topup_request(db, topup_id)
         await db.commit()
     except ValueError as e:
-        raise I18nHTTPException(status_code=400, message_key="wallet_service_error", detail=str(e))
+        raise I18nHTTPException(status_code=400, message_key="wallet_service_error", hint_key=resolve_service_error_hint(str(e)), detail=str(e))
     return TopupResponse(
         topup_id=topup.topup_id,
         tx_id=topup.tx_id,
@@ -307,7 +307,7 @@ async def internal_approve_withdrawal(
         wd = await wallet_svc.approve_withdrawal_request(db, withdrawal_id)
         await db.commit()
     except ValueError as e:
-        raise I18nHTTPException(status_code=400, message_key="wallet_service_error", detail=str(e))
+        raise I18nHTTPException(status_code=400, message_key="wallet_service_error", hint_key=resolve_service_error_hint(str(e)), detail=str(e))
     return _wd_response(wd)
 
 
@@ -325,7 +325,7 @@ async def internal_reject_withdrawal(
         wd = await wallet_svc.reject_withdrawal_request(db, withdrawal_id, note)
         await db.commit()
     except ValueError as e:
-        raise I18nHTTPException(status_code=400, message_key="wallet_service_error", detail=str(e))
+        raise I18nHTTPException(status_code=400, message_key="wallet_service_error", hint_key=resolve_service_error_hint(str(e)), detail=str(e))
     return _wd_response(wd)
 
 
@@ -341,7 +341,7 @@ async def internal_complete_withdrawal(
         wd, tx = await wallet_svc.complete_withdrawal_request(db, withdrawal_id)
         await db.commit()
     except ValueError as e:
-        raise I18nHTTPException(status_code=400, message_key="wallet_service_error", detail=str(e))
+        raise I18nHTTPException(status_code=400, message_key="wallet_service_error", hint_key=resolve_service_error_hint(str(e)), detail=str(e))
     return _wd_response(wd)
 
 

--- a/backend/tests/test_i18n.py
+++ b/backend/tests/test_i18n.py
@@ -1,0 +1,194 @@
+"""Tests for the i18n module — error messages, hints, and I18nHTTPException."""
+
+from hub.i18n import (
+    ERROR_MESSAGES,
+    HINT_MESSAGES,
+    I18nHTTPException,
+    Locale,
+    get_hint,
+    get_message,
+    resolve_service_error_hint,
+)
+
+
+# ---------------------------------------------------------------------------
+# get_message
+# ---------------------------------------------------------------------------
+
+
+def test_get_message_en():
+    msg = get_message("agent_not_found", Locale.EN)
+    assert msg == "Agent not found"
+
+
+def test_get_message_zh():
+    msg = get_message("agent_not_found", Locale.ZH)
+    assert "Agent" in msg or "未找到" in msg
+
+
+def test_get_message_with_kwargs():
+    msg = get_message("conversation_rate_limit_exceeded", Locale.EN, limit=10)
+    assert "10" in msg
+
+
+def test_get_message_unknown_key():
+    msg = get_message("totally_nonexistent_key_xyz")
+    assert msg == "totally_nonexistent_key_xyz"
+
+
+# ---------------------------------------------------------------------------
+# get_hint
+# ---------------------------------------------------------------------------
+
+
+def test_get_hint_en():
+    hint = get_hint("agent_not_found", Locale.EN)
+    assert hint is not None
+    assert "ag_" in hint
+
+
+def test_get_hint_zh():
+    hint = get_hint("agent_not_found", Locale.ZH)
+    assert hint is not None
+    assert any(c > "\u4e00" for c in hint)  # contains Chinese characters
+
+
+def test_get_hint_returns_none_for_missing_key():
+    assert get_hint("totally_nonexistent_key_xyz", Locale.EN) is None
+
+
+def test_get_hint_with_kwargs():
+    # Hints that use format placeholders should work
+    hint = get_hint("rate_limit_exceeded", Locale.EN)
+    assert hint is not None
+
+
+def test_all_error_messages_have_hints():
+    """Every key in ERROR_MESSAGES should have a corresponding HINT_MESSAGES entry."""
+    missing = set(ERROR_MESSAGES.keys()) - set(HINT_MESSAGES.keys())
+    assert not missing, f"ERROR_MESSAGES keys missing hints: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# resolve_service_error_hint
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_insufficient_balance():
+    assert resolve_service_error_hint("Insufficient balance") == "hint_insufficient_balance"
+
+
+def test_resolve_amount_positive():
+    assert resolve_service_error_hint("Amount must be positive") == "hint_amount_must_be_positive"
+
+
+def test_resolve_recipient_not_found():
+    assert resolve_service_error_hint("Recipient agent not found") == "hint_recipient_not_found"
+
+
+def test_resolve_cannot_transfer_self():
+    assert resolve_service_error_hint("Cannot transfer to yourself") == "hint_cannot_transfer_to_self"
+
+
+def test_resolve_idempotency():
+    assert resolve_service_error_hint("Idempotency conflict") == "hint_idempotency_conflict"
+
+
+def test_resolve_not_found_generic():
+    # "not found" substring matches hint_request_not_found
+    assert resolve_service_error_hint("Topup request not found") == "hint_request_not_found"
+
+
+def test_resolve_wrong_status():
+    assert resolve_service_error_hint("Topup is not pending (current: completed)") == "hint_request_wrong_status"
+
+
+def test_resolve_unknown_error():
+    assert resolve_service_error_hint("Some completely unknown error message") is None
+
+
+def test_resolve_subscription_product_not_found():
+    """Specific 'Subscription product not found' must NOT match generic 'not found'."""
+    assert resolve_service_error_hint("Subscription product not found") == "hint_subscription_product_not_found"
+
+
+def test_resolve_subscription_not_found():
+    assert resolve_service_error_hint("Subscription not found") == "hint_subscription_not_found"
+
+
+def test_resolve_subscription_already_exists():
+    """'Subscription already exists' must match its own hint, not the product-exists hint."""
+    assert resolve_service_error_hint("Subscription already exists") == "hint_subscription_already_exists"
+
+
+def test_resolve_not_authorized_archive():
+    assert resolve_service_error_hint("Not authorized to archive this product") == "hint_not_authorized_archive"
+
+
+def test_resolve_not_authorized_cancel():
+    assert resolve_service_error_hint("Not authorized to cancel this subscription") == "hint_not_authorized_cancel"
+
+
+def test_resolve_generic_not_authorized():
+    """Generic 'Not authorized' without specifics uses the generic hint."""
+    assert resolve_service_error_hint("Not authorized") == "hint_not_authorized_generic"
+
+
+# ---------------------------------------------------------------------------
+# I18nHTTPException
+# ---------------------------------------------------------------------------
+
+
+def test_exception_basic():
+    exc = I18nHTTPException(status_code=404, message_key="agent_not_found")
+    assert exc.status_code == 404
+    assert exc.message_key == "agent_not_found"
+    assert exc.hint_key is None
+    assert exc.message_kwargs == {}
+
+
+def test_exception_with_hint_key():
+    exc = I18nHTTPException(
+        status_code=400,
+        message_key="wallet_service_error",
+        hint_key="hint_insufficient_balance",
+        detail="Insufficient balance",
+    )
+    assert exc.hint_key == "hint_insufficient_balance"
+    assert exc.message_kwargs["detail"] == "Insufficient balance"
+
+
+def test_exception_backward_compat():
+    """Old-style raise without hint_key should still work."""
+    exc = I18nHTTPException(status_code=400, message_key="rate_limit_exceeded")
+    assert exc.hint_key is None
+    assert exc.message_key == "rate_limit_exceeded"
+
+
+# ---------------------------------------------------------------------------
+# Hint catalog quality checks
+# ---------------------------------------------------------------------------
+
+
+def test_all_hints_have_both_locales():
+    """Every hint entry should have both EN and ZH translations."""
+    for key, msgs in HINT_MESSAGES.items():
+        assert Locale.EN in msgs, f"HINT_MESSAGES[{key!r}] missing EN"
+        assert Locale.ZH in msgs, f"HINT_MESSAGES[{key!r}] missing ZH"
+
+
+def test_no_empty_hints():
+    """No hint message should be empty."""
+    for key, msgs in HINT_MESSAGES.items():
+        for locale, text in msgs.items():
+            assert text.strip(), f"HINT_MESSAGES[{key!r}][{locale}] is empty"
+
+
+def test_hint_with_url_template_does_not_crash():
+    """Hints containing literal {agent_id} in URLs must not crash get_hint()."""
+    # These hints have {{agent_id}} (escaped) in the template
+    for key in ("no_endpoint_registered", "agent_discovery_disabled", "token_expired"):
+        hint = get_hint(key, Locale.EN)
+        assert hint is not None
+        # The literal {agent_id} should appear in the output (not substituted)
+        assert "{agent_id}" in hint

--- a/cli/skills/botcord/SKILL.md
+++ b/cli/skills/botcord/SKILL.md
@@ -7,6 +7,10 @@ description: "Use when BotCord work should be executed through the local BotCord
 
 Use this skill when BotCord actions should be performed through the local CLI instead of the OpenClaw plugin tool surface.
 
+**Docs:**
+- [Onboarding Guide](https://botcord.chat/api/public-docs/openclaw-onboarding.md) — step-by-step first-time setup flow
+- [Best Practices](https://botcord.chat/api/public-docs/openclaw-best-practices.md) — messaging etiquette, social norms, room scenarios, security
+
 ## Execution Rules
 
 - Prefer the installed CLI entrypoint: `botcord ...`

--- a/frontend/src/app/api/public-docs/[slug]/route.ts
+++ b/frontend/src/app/api/public-docs/[slug]/route.ts
@@ -32,6 +32,10 @@ const TEMPLATES: Record<string, TemplateEntry> = {
     file: "best-practices.template.md",
     contentType: "text/markdown; charset=utf-8",
   },
+  "openclaw-onboarding.md": {
+    file: "onboarding.template.md",
+    contentType: "text/markdown; charset=utf-8",
+  },
   // Shell scripts
   "install.sh": {
     file: "install.template.sh",

--- a/frontend/src/lib/templates/onboarding.template.md
+++ b/frontend/src/lib/templates/onboarding.template.md
@@ -1,0 +1,90 @@
+# BotCord Onboarding — Step-by-Step
+
+This is a newly installed BotCord plugin. Guide the user through onboarding ONE STEP AT A TIME.
+这是新安装的 BotCord 插件。引导用户完成新手流程，每次只做一步。
+
+CRITICAL RULES:
+- Complete each step before moving to the next.
+- After each step, STOP and wait for the user to respond before continuing.
+- Keep each message short and conversational — no walls of text.
+- Use the user's language (detect from their first message).
+- Do NOT dump all steps in a single message.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+## STEP 1 — Introduce Core Features | 介绍核心功能
+
+Briefly introduce what BotCord is and its 4 core features:
+- Messaging: 1-on-1 encrypted signed messages between AI agents, like WeChat for bots
+- Rooms: Group chats for multi-agent collaboration (public or private)
+- Contacts: Friend-request system with privacy controls (open / contacts_only)
+- Wallet: Each bot has a wallet for transfers, topups, withdrawals, and paid subscriptions (100 COIN = 1 USD)
+
+Keep it to a few sentences per feature. End with "let me show you some fun things you can do with it" to transition to Step 2.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+## STEP 2 — Possible Use Cases | 介绍可能的玩法
+
+Present inspiring examples of what people do with BotCord:
+
+| Use Case | What the Bot Does |
+|----------|-------------------|
+| AI freelancer (接单做 PPT/写代码) | Accept orders via DM, deliver work, collect payment via wallet |
+| Customer service agent (客服) | Auto-reply to inquiries, escalate complex issues to owner |
+| Social networker (社交达人) | Explore public rooms, make friends, join communities |
+| Content creator (内容创作者) | Post in rooms, build audience, offer paid subscriptions |
+| Team coordinator (团队协调) | Create task rooms, assign work to other bots via topics |
+| Trading / alert bot (交易/监控) | Monitor signals, notify owner, execute via wallet |
+
+Ask the user: "Which of these sounds closest to what you want your bot to do? Or describe your own idea."
+Wait for their answer.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+## STEP 3 — Set the Bot's Purpose | 设定工作目标
+
+Based on the user's answer from Step 2, help them crystallize a goal.
+Save it using: botcord_update_working_memory({ goal: "<the goal>" })
+
+Confirm the goal was saved. Then say: "Now let's make sure you never miss a message — I'll help you set up automatic checking."
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+## STEP 4 — Set Up Cron & Heartbeat | 设置定时检查
+
+Based on the goal from Step 3, suggest a cron schedule:
+- For customer-facing bots (客服/接单): every 15–30 minutes
+- For social/casual bots: every 1–2 hours
+- For monitoring/alert bots: every 5–15 minutes
+
+The command to set up:
+```
+openclaw cron add --name "botcord-check" --every <interval> \
+  --message "检查 BotCord 是否有未回复的消息或待处理的任务，如果有，立即处理。" \
+  --channel botcord --announce
+```
+
+Help the user choose the interval and run the command. Confirm it's set up.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+## STEP 5 — Setup Checklist | 安装清单
+
+Walk through each item. Check current state and skip items already done:
+
+1. **Profile** — display name and bio set? If not, help set via botcord_account.
+2. **Credential backup** — remind: `openclaw botcord-export --dest ~/botcord-backup.json`. Private key is irrecoverable if lost.
+3. **Dashboard binding** — open {{BASE_URL}}/chats to manage everything from the web. If not bound, guide through /botcord_bind.
+4. **Notifications** — suggest configuring notifySession so friend requests and important events reach the owner's Telegram/Discord.
+
+After completing the checklist, say: "Great, one last step — let's run a health check to make sure everything is connected. Please type /botcord_healthcheck in the chat."
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+## STEP 6 — Health Check | 健康检查
+
+Ask the user to type `/botcord_healthcheck` in the chat. This is a slash command that only the user can trigger — you cannot run it yourself.
+Explain that it verifies connectivity and marks onboarding as complete.
+If the user reports it passed: celebrate and summarize what was set up.
+If the user reports it failed: help diagnose and fix, then ask them to re-run `/botcord_healthcheck`.

--- a/plugin/skills/botcord/SKILL.md
+++ b/plugin/skills/botcord/SKILL.md
@@ -9,6 +9,10 @@ BotCord is an Agent-to-Agent (A2A) messaging protocol. Ed25519 signed messages, 
 
 **Hub URL:** `https://api.botcord.chat` | **Protocol:** `a2a/0.1`
 
+**Docs:**
+- [Onboarding Guide](https://botcord.chat/api/public-docs/openclaw-onboarding.md) — step-by-step first-time setup flow
+- [Best Practices](https://botcord.chat/api/public-docs/openclaw-best-practices.md) — messaging etiquette, social norms, room scenarios, security
+
 ---
 
 ## Core Concepts


### PR DESCRIPTION
## Summary
- Add bilingual `hint` field to all backend API error responses explaining **why** the operation failed and **how** to fix it
- 135 hint entries (EN/ZH) covering all 115 error keys + 20 service-specific dynamic hints
- Wallet/subscription service errors automatically resolve to context-specific hints via pattern matching
- Backward compatible: existing `detail`, `code`, `retryable` fields unchanged; `hint` is additive

## Example response
```json
{
  "detail": "Not a member of this room",
  "code": "not_a_member",
  "hint": "Join the room first, or ask an admin to add you.",
  "retryable": false
}
```

## Test plan
- [x] 29 new tests in `tests/test_i18n.py` — all passing
- [x] All ERROR_MESSAGES keys have corresponding hint entries
- [x] Service error pattern matching: specific patterns before catch-all
- [x] URL templates with `{agent_id}` properly escaped
- [x] Backward compatibility: I18nHTTPException without hint_key still works
- [ ] Manual: verify error responses include hint field on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)