### PR TITLE
feat(plugin): use public API for room discovery

### DIFF
--- a/plugin/src/client.ts
+++ b/plugin/src/client.ts
@@ -24,6 +24,7 @@ import type {
   WithdrawalResponse,
   SubscriptionProduct,
   Subscription,
+  PublicRoomsResponse,
 } from "./types.js";
 
 const MAX_RETRIES = 2;
@@ -582,6 +583,20 @@ export class BotCordClient {
     const q = name ? `?name=${encodeURIComponent(name)}` : "";
     const resp = await this.hubFetch(`/hub/rooms${q}`);
     return (await resp.json()) as RoomInfo[];
+  }
+
+  async discoverPublicRooms(q?: string): Promise<PublicRoomsResponse> {
+    const params = new URLSearchParams();
+    if (q) params.set("q", q);
+    const qs = params.toString();
+    const resp = await fetch(`${this.hubUrl}/public/rooms${qs ? `?${qs}` : ""}`, {
+      signal: AbortSignal.timeout(30000),
+    });
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => "");
+      throw new Error(`BotCord /public/rooms failed: ${resp.status} ${body}`);
+    }
+    return (await resp.json()) as PublicRoomsResponse;
   }
 
   async updateRoom(

--- a/plugin/src/tools/directory.ts
+++ b/plugin/src/tools/directory.ts
@@ -83,7 +83,7 @@ export function createDirectoryTool() {
             return await client.resolve(args.agent_id);
 
           case "discover_rooms":
-            return await client.discoverRooms(args.room_name);
+            return await client.discoverPublicRooms(args.room_name);
 
           case "history":
             return await client.getHistory({

--- a/plugin/src/tools/rooms.ts
+++ b/plugin/src/tools/rooms.ts
@@ -160,7 +160,7 @@ export function createRoomsTool() {
             });
 
           case "discover":
-            return await client.discoverRooms(args.name);
+            return await client.discoverPublicRooms(args.name);
 
           case "join":
             if (!args.room_id) return { error: "room_id is required" };

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -107,6 +107,33 @@ export type RoomInfo = {
   created_at: string;
 };
 
+export type PublicSubscriptionProduct = {
+  product_id: string;
+  name: string;
+  description: string;
+  amount_minor: string;
+  billing_interval: string;
+};
+
+export type PublicRoom = {
+  room_id: string;
+  name: string;
+  description: string;
+  owner_id: string;
+  visibility: string;
+  member_count: number;
+  required_subscription_product_id?: string | null;
+  subscription_product?: PublicSubscriptionProduct | null;
+  last_message_preview?: string | null;
+  last_message_at?: string | null;
+  last_sender_name?: string | null;
+};
+
+export type PublicRoomsResponse = {
+  rooms: PublicRoom[];
+  total: number;
+};
+
 export type AgentInfo = {
   agent_id: string;
   display_name?: string;


### PR DESCRIPTION
## Summary
- Switch `botcord_rooms` discover and `botcord_directory` discover_rooms actions from `GET /hub/rooms` (auth-required, only returns joined rooms) to `GET /public/rooms` (unauthenticated, searches all public rooms by name/description)
- Add `PublicRoom`, `PublicSubscriptionProduct`, `PublicRoomsResponse` types to `types.ts`
- Add `discoverPublicRooms()` method to `BotCordClient` using unauthenticated fetch (no JWT needed)

## Test plan
- [x] All 231 unit tests pass
- [x] TypeScript type check passes (no new errors)
- [ ] Manual test: agent uses `botcord_rooms discover` to find public rooms it hasn't joined
- [ ] Manual test: agent uses `botcord_directory discover_rooms` with search query

🤖 Generated with [Claude Code](https://claude.com/claude-code)