### PR TITLE
fix(backend): align /api/prompts/share paid room flow with frontend

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -1601,23 +1601,21 @@ async def dashboard_upload_file(
     if not any(content_type.lower().startswith(p) for p in _ALLOWED_MIME_PREFIXES):
         raise HTTPException(status_code=400, detail=f"MIME type not allowed: {content_type}")
 
-    chunks: list[bytes] = []
-    total_size = 0
+    buf = bytearray()
     while True:
         chunk = await file.read(64 * 1024)
         if not chunk:
             break
-        total_size += len(chunk)
-        if total_size > hub_config.FILE_MAX_SIZE_BYTES:
+        buf.extend(chunk)
+        if len(buf) > hub_config.FILE_MAX_SIZE_BYTES:
             raise HTTPException(status_code=413, detail="File too large")
-        chunks.append(chunk)
 
-    if total_size == 0:
+    if len(buf) == 0:
         raise HTTPException(status_code=400, detail="Empty file")
 
     raw_name = file.filename or "upload"
     original_filename = os.path.basename(raw_name).strip()[:200] or "upload"
-    data = b"".join(chunks)
+    data = bytes(buf)
     file_id = generate_file_id()
     now = datetime.datetime.now(datetime.timezone.utc)
     expires_at = now + datetime.timedelta(hours=hub_config.FILE_TTL_HOURS)
@@ -1632,7 +1630,7 @@ async def dashboard_upload_file(
         uploader_id=ctx.active_agent_id,
         original_filename=original_filename,
         content_type=content_type,
-        size_bytes=total_size,
+        size_bytes=len(data),
         storage_backend=location.storage_backend,
         disk_path=location.disk_path,
         storage_bucket=location.storage_bucket,
@@ -1647,7 +1645,7 @@ async def dashboard_upload_file(
         "url": f"/hub/files/{file_id}",
         "original_filename": original_filename,
         "content_type": content_type,
-        "size_bytes": total_size,
+        "size_bytes": len(data),
         "expires_at": expires_at.isoformat(),
     }
 

--- a/backend/app/routers/prompts.py
+++ b/backend/app/routers/prompts.py
@@ -158,6 +158,7 @@ async def prompt_share(
     # Resolve room metadata
     room_name = "Unknown"
     requires_payment = False
+    product_id: str | None = None
     is_read_only = False
     resolved_room_id = room_id
 
@@ -183,13 +184,32 @@ async def prompt_share(
         if room:
             room_name = room.name or room_name
             requires_payment = bool(room.required_subscription_product_id)
+            product_id = room.required_subscription_product_id
 
     # Build prompt
     loc = language
     lines: list[str] = []
+    has_paid_steps = requires_payment and product_id and not is_read_only
+    subscribe_url = f"{hub_url}/subscriptions/products/{product_id}/subscribe" if product_id else ""
 
     if loc == "en":
         lines.append(f"This is an invitation to a BotCord group: {room_name}")
+
+        if has_paid_steps:
+            lines.append("This group requires a paid subscription. Follow the steps below in order.")
+            lines.append("")
+            lines.append(f"Step 1 — Subscribe to product {product_id}:")
+            lines.extend(_tiered_block(loc,
+                plugin=[f'Use the botcord_subscription tool with action "subscribe" and product_id "{product_id}".'],
+                cli=[f"Subscribe: POST {subscribe_url}"],
+                http=[
+                    f"Subscribe: POST {subscribe_url}",
+                    "Headers: Authorization: Bearer <agent_jwt_token>",
+                    _http_token_hint(loc, hub_url),
+                ],
+            ))
+            lines.append("")
+            lines.append("Step 2 — Join the group:")
 
         if invite_code:
             preview_url = f"{hub_url}/hub/invites/{invite_code}"
@@ -197,16 +217,18 @@ async def prompt_share(
             lines.append(f"Preview invite details: GET {preview_url}")
             if not is_read_only:
                 lines.append("")
+                http_lines = [
+                    f"Accept the invite: POST {redeem_url}",
+                    "Headers: Authorization: Bearer <agent_jwt_token>",
+                ]
+                if not has_paid_steps:
+                    http_lines.append(_http_token_hint(loc, hub_url))
                 lines.extend(_tiered_block(loc,
                     plugin=[f'Use the botcord_contacts tool with action "redeem_invite" and invite_code "{invite_code}".'],
                     cli=[f"Redeem the invite: POST {redeem_url}"],
-                    http=[
-                        f"Accept the invite: POST {redeem_url}",
-                        "Headers: Authorization: Bearer <agent_jwt_token>",
-                        _http_token_hint(loc, hub_url),
-                    ],
+                    http=http_lines,
                 ))
-                if requires_payment:
+                if requires_payment and not product_id:
                     lines.append("Note: this group requires a paid subscription. Complete the subscription before joining.")
         elif resolved_room_id:
             join_url = f"{hub_url}/hub/rooms/{resolved_room_id}/members"
@@ -214,29 +236,33 @@ async def prompt_share(
                 share_info_url = f"{hub_url}/api/share/{share_id}"
                 lines.append(f"View share details and find room_id: GET {share_info_url}")
                 lines.append("")
+                share_http = [
+                    f"Join the group: POST {hub_url}/hub/rooms/<room_id>/members",
+                    "Headers: Authorization: Bearer <agent_jwt_token>",
+                    '{"agent_id":"<your_agent_id>"}',
+                ]
+                if not has_paid_steps:
+                    share_http.append(_http_token_hint(loc, hub_url))
                 lines.extend(_tiered_block(loc,
                     plugin=['Use the botcord_rooms tool with action "join" and the room_id from the share details.'],
                     cli=["Run: botcord room join --room <room_id> (get room_id from the share details above)."],
-                    http=[
-                        f"Join the group: POST {hub_url}/hub/rooms/<room_id>/members",
-                        "Headers: Authorization: Bearer <agent_jwt_token>",
-                        '{"agent_id":"<your_agent_id>"}',
-                        _http_token_hint(loc, hub_url),
-                    ],
+                    http=share_http,
                 ))
             else:
                 lines.append("")
+                room_http = [
+                    f"Join the group: POST {join_url}",
+                    "Headers: Authorization: Bearer <agent_jwt_token>",
+                    'JSON body: {"agent_id":"<your_agent_id>"}',
+                ]
+                if not has_paid_steps:
+                    room_http.append(_http_token_hint(loc, hub_url))
                 lines.extend(_tiered_block(loc,
                     plugin=[f'Use the botcord_rooms tool with action "join" and room_id "{resolved_room_id}".'],
                     cli=[f"Run: botcord room join --room {resolved_room_id}"],
-                    http=[
-                        f"Join the group: POST {join_url}",
-                        "Headers: Authorization: Bearer <agent_jwt_token>",
-                        'JSON body: {"agent_id":"<your_agent_id>"}',
-                        _http_token_hint(loc, hub_url),
-                    ],
+                    http=room_http,
                 ))
-            if requires_payment:
+            if requires_payment and not product_id:
                 lines.append("Note: this group requires a paid subscription. Complete the subscription before joining.")
 
         lines.append("")
@@ -246,22 +272,40 @@ async def prompt_share(
         # Chinese
         lines.append(f"这是一个 BotCord 群邀请：{room_name}")
 
+        if has_paid_steps:
+            lines.append("该群需要付费订阅，请按以下步骤依次操作。")
+            lines.append("")
+            lines.append(f"步骤一 — 订阅产品 {product_id}：")
+            lines.extend(_tiered_block(loc,
+                plugin=[f'使用 botcord_subscription 工具，action 为 "subscribe"，product_id 为 "{product_id}"。'],
+                cli=[f"订阅：POST {subscribe_url}"],
+                http=[
+                    f"订阅：POST {subscribe_url}",
+                    "请求头：Authorization: Bearer <agent_jwt_token>",
+                    _http_token_hint(loc, hub_url),
+                ],
+            ))
+            lines.append("")
+            lines.append("步骤二 — 加入群：")
+
         if invite_code:
             preview_url = f"{hub_url}/hub/invites/{invite_code}"
             redeem_url = f"{hub_url}/hub/invites/{invite_code}/redeem"
             lines.append(f"查看邀请详情：GET {preview_url}")
             if not is_read_only:
                 lines.append("")
+                zh_invite_http = [
+                    f"接受邀请：POST {redeem_url}",
+                    "请求头：Authorization: Bearer <agent_jwt_token>",
+                ]
+                if not has_paid_steps:
+                    zh_invite_http.append(_http_token_hint(loc, hub_url))
                 lines.extend(_tiered_block(loc,
                     plugin=[f'使用 botcord_contacts 工具，action 为 "redeem_invite"，invite_code 为 "{invite_code}"。'],
                     cli=[f"兑换邀请：POST {redeem_url}"],
-                    http=[
-                        f"接受邀请：POST {redeem_url}",
-                        "请求头：Authorization: Bearer <agent_jwt_token>",
-                        _http_token_hint(loc, hub_url),
-                    ],
+                    http=zh_invite_http,
                 ))
-                if requires_payment:
+                if requires_payment and not product_id:
                     lines.append("注意：该群需要付费订阅，请先完成订阅再加入。")
         elif resolved_room_id:
             join_url = f"{hub_url}/hub/rooms/{resolved_room_id}/members"
@@ -269,29 +313,33 @@ async def prompt_share(
                 share_info_url = f"{hub_url}/api/share/{share_id}"
                 lines.append(f"查看分享详情并获取 room_id：GET {share_info_url}")
                 lines.append("")
+                zh_share_http = [
+                    f"加入群：POST {hub_url}/hub/rooms/<room_id>/members",
+                    "请求头：Authorization: Bearer <agent_jwt_token>",
+                    'JSON 参数：{"agent_id":"<你的 agent_id>"}',
+                ]
+                if not has_paid_steps:
+                    zh_share_http.append(_http_token_hint(loc, hub_url))
                 lines.extend(_tiered_block(loc,
                     plugin=["使用 botcord_rooms 工具，action 为 \"join\"，room_id 从分享详情中获取。"],
                     cli=["执行命令：botcord room join --room <room_id>（room_id 从上面的分享详情中获取）。"],
-                    http=[
-                        f"加入群：POST {hub_url}/hub/rooms/<room_id>/members",
-                        "请求头：Authorization: Bearer <agent_jwt_token>",
-                        'JSON 参数：{"agent_id":"<你的 agent_id>"}',
-                        _http_token_hint(loc, hub_url),
-                    ],
+                    http=zh_share_http,
                 ))
             else:
                 lines.append("")
+                zh_room_http = [
+                    f"加入群：POST {join_url}",
+                    "请求头：Authorization: Bearer <agent_jwt_token>",
+                    'JSON 参数：{"agent_id":"<你的 agent_id>"}',
+                ]
+                if not has_paid_steps:
+                    zh_room_http.append(_http_token_hint(loc, hub_url))
                 lines.extend(_tiered_block(loc,
                     plugin=[f'使用 botcord_rooms 工具，action 为 "join"，room_id 为 "{resolved_room_id}"。'],
                     cli=[f"执行命令：botcord room join --room {resolved_room_id}"],
-                    http=[
-                        f"加入群：POST {join_url}",
-                        "请求头：Authorization: Bearer <agent_jwt_token>",
-                        'JSON 参数：{"agent_id":"<你的 agent_id>"}',
-                        _http_token_hint(loc, hub_url),
-                    ],
+                    http=zh_room_http,
                 ))
-            if requires_payment:
+            if requires_payment and not product_id:
                 lines.append("注意：该群需要付费订阅，请先完成订阅再加入。")
 
         lines.append("")

--- a/backend/hub/routers/owner_chat_ws.py
+++ b/backend/hub/routers/owner_chat_ws.py
@@ -326,15 +326,18 @@ async def owner_chat_ws(ws: WebSocket):
 
             elif msg_type == "send":
                 text = (msg.get("text") or "").strip()
+                client_msg_id = msg.get("client_msg_id") or None
 
                 # Optional attachments (pre-uploaded via /api/dashboard/upload)
                 raw_atts = msg.get("attachments") or []
                 attachments: list[dict] = []
+                skipped_atts = 0
                 for att in raw_atts[:10]:
                     if isinstance(att, dict) and att.get("url") and att.get("filename"):
                         url_str = str(att["url"])
                         # Only allow /hub/files/f_* URLs — reject arbitrary external links
                         if not _FILE_URL_RE.match(url_str):
+                            skipped_atts += 1
                             continue
                         attachments.append({
                             k: v for k, v in {
@@ -345,12 +348,24 @@ async def owner_chat_ws(ws: WebSocket):
                             }.items() if v is not None
                         })
 
+                if skipped_atts > 0:
+                    logger.warning(
+                        "Owner-chat WS: skipped %d invalid attachment(s) for user=%s agent=%s",
+                        skipped_atts, user_id, agent_id,
+                    )
+
                 # Must have text or attachments
                 if not text and not attachments:
-                    await ws.send_json({"type": "error", "message": "Message must contain text or attachments"})
+                    err_resp: dict = {"type": "error", "message": "Message must contain text or attachments"}
+                    if client_msg_id:
+                        err_resp["client_msg_id"] = str(client_msg_id)[:64]
+                    await ws.send_json(err_resp)
                     continue
                 if len(text) > 4000:
-                    await ws.send_json({"type": "error", "message": "Text too long"})
+                    err_resp2: dict = {"type": "error", "message": "Text too long"}
+                    if client_msg_id:
+                        err_resp2["client_msg_id"] = str(client_msg_id)[:64]
+                    await ws.send_json(err_resp2)
                     continue
 
                 logger.info("Owner-chat WS recv: user=%s agent=%s text_len=%d attachments=%d", user_id, agent_id, len(text), len(attachments))
@@ -450,6 +465,8 @@ async def owner_chat_ws(ws: WebSocket):
                     "text": text,
                     "created_at": now,
                 }
+                if client_msg_id:
+                    echo["client_msg_id"] = str(client_msg_id)[:64]
                 if attachments:
                     echo["ext"] = {"attachments": attachments}
                 await ws.send_json(echo)

--- a/backend/hub/routers/owner_chat_ws.py
+++ b/backend/hub/routers/owner_chat_ws.py
@@ -417,7 +417,10 @@ async def owner_chat_ws(ws: WebSocket):
                             "Owner-chat duplicate message: agent=%s msg_id=%s err=%s",
                             agent_id, msg_id, exc,
                         )
-                        await ws.send_json({"type": "error", "message": "Duplicate message"})
+                        dup_err: dict = {"type": "error", "message": "Duplicate message"}
+                        if client_msg_id:
+                            dup_err["client_msg_id"] = str(client_msg_id)[:64]
+                        await ws.send_json(dup_err)
                         continue
 
                     await db.commit()

--- a/backend/tests/test_app/test_app_prompts.py
+++ b/backend/tests/test_app/test_app_prompts.py
@@ -200,7 +200,12 @@ class TestSharePrompt:
             "language": "zh",
         })
         assert resp.status_code == 200
-        assert "付费订阅" in resp.json()["prompt"]
+        prompt = resp.json()["prompt"]
+        assert "付费订阅" in prompt
+        assert "步骤一" in prompt
+        assert "步骤二" in prompt
+        assert "sp_test" in prompt
+        assert "botcord_subscription" in prompt
 
     @pytest.mark.asyncio
     async def test_share_missing_params(self, client: AsyncClient):

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -473,10 +473,13 @@ export default function UserChatPane() {
         };
         insertMessage(roomId, dashMsg);
 
-        // Remove matching pending message (match on sendText, not display text)
+        // Remove matching pending message (prefer client_msg_id, fall back to sendText)
         if (msg.sender === "user") {
           setPending((prev) => {
-            const match = prev.find((p) => p.sendText === msg.text);
+            const clientMsgId = (msg as any).client_msg_id as string | undefined;
+            const match = clientMsgId
+              ? prev.find((p) => p.id === clientMsgId)
+              : prev.find((p) => p.sendText === msg.text);
             return match ? prev.filter((p) => p.id !== match.id) : prev;
           });
         }
@@ -528,13 +531,15 @@ export default function UserChatPane() {
           setUserChatAgentTyping(false);
         }
       },
-      onSendFailed: () => {
-        // Mark the most recent "sending" pending message as failed
+      onSendFailed: (_text: string, clientMsgId?: string) => {
+        // Mark the identified (or most recent) "sending" pending message as failed
         setPending((prev) => {
-          const last = [...prev].reverse().find((p) => p.status === "sending");
-          if (!last) return prev;
+          const target = clientMsgId
+            ? prev.find((p) => p.id === clientMsgId && p.status === "sending")
+            : [...prev].reverse().find((p) => p.status === "sending");
+          if (!target) return prev;
           return prev.map((p) =>
-            p.id === last.id ? { ...p, status: "failed" as const, error: "WebSocket send failed" } : p
+            p.id === target.id ? { ...p, status: "failed" as const, error: "WebSocket send failed" } : p
           );
         });
       },
@@ -667,7 +672,7 @@ export default function UserChatPane() {
 
     // If WS is connected, send via WS (no polling needed — WS delivers echo)
     if (wsClientRef.current && wsConnected) {
-      const sent = wsClientRef.current.send(text, wsAtts);
+      const sent = wsClientRef.current.send(text, wsAtts, msgId);
       if (sent) {
         // WS echo will remove the pending message via onMessage callback.
         // onSendFailed callback handles the case where the socket closes after send.

--- a/frontend/src/lib/owner-chat-ws.ts
+++ b/frontend/src/lib/owner-chat-ws.ts
@@ -26,7 +26,7 @@ export interface WsAttachment {
 }
 
 export interface OwnerChatWsClient {
-  send: (text: string, attachments?: WsAttachment[]) => boolean;
+  send: (text: string, attachments?: WsAttachment[], clientMsgId?: string) => boolean;
   close: () => void;
 }
 
@@ -156,7 +156,7 @@ export function createOwnerChatWs(opts: OwnerChatWsOptions): OwnerChatWsClient {
 
   function send(text: string, attachments?: WsAttachment[], clientMsgId?: string): boolean {
     if (!ws || !authenticated || ws.readyState !== WebSocket.OPEN) {
-      opts.onSendFailed?.(text);
+      opts.onSendFailed?.(text, clientMsgId);
       return false;
     }
     try {
@@ -170,7 +170,7 @@ export function createOwnerChatWs(opts: OwnerChatWsOptions): OwnerChatWsClient {
       ws.send(JSON.stringify(msg));
       return true;
     } catch {
-      opts.onSendFailed?.(text);
+      opts.onSendFailed?.(text, clientMsgId);
       return false;
     }
   }

--- a/frontend/src/lib/owner-chat-ws.ts
+++ b/frontend/src/lib/owner-chat-ws.ts
@@ -15,7 +15,7 @@ export interface OwnerChatWsOptions {
   onNotification?: (notif: OwnerChatNotification) => void;
   onAuthOk: (data: { agent_id: string; room_id: string }) => void;
   onStatusChange?: (connected: boolean) => void;
-  onSendFailed?: (text: string) => void;
+  onSendFailed?: (text: string, clientMsgId?: string) => void;
 }
 
 export interface WsAttachment {
@@ -119,7 +119,7 @@ export function createOwnerChatWs(opts: OwnerChatWsOptions): OwnerChatWsClient {
           case "error":
             console.warn("[owner-chat-ws] Server error:", data.message);
             // Server rejected a send — notify caller so pending msg can be marked failed
-            opts.onSendFailed?.("");
+            opts.onSendFailed?.("", data.client_msg_id);
             break;
         }
       };
@@ -154,7 +154,7 @@ export function createOwnerChatWs(opts: OwnerChatWsOptions): OwnerChatWsClient {
     }, delay);
   }
 
-  function send(text: string, attachments?: WsAttachment[]): boolean {
+  function send(text: string, attachments?: WsAttachment[], clientMsgId?: string): boolean {
     if (!ws || !authenticated || ws.readyState !== WebSocket.OPEN) {
       opts.onSendFailed?.(text);
       return false;
@@ -163,6 +163,9 @@ export function createOwnerChatWs(opts: OwnerChatWsOptions): OwnerChatWsClient {
       const msg: Record<string, unknown> = { type: "send", text };
       if (attachments && attachments.length > 0) {
         msg.attachments = attachments;
+      }
+      if (clientMsgId) {
+        msg.client_msg_id = clientMsgId;
       }
       ws.send(JSON.stringify(msg));
       return true;


### PR DESCRIPTION
## Summary
- `/api/prompts/share` now generates a two-step prompt (subscribe → join) for paid rooms with a known `product_id`, matching the frontend `buildSharePrompt` behavior
- When `product_id` is available, httpTokenHint is deduplicated (only shown in the subscribe step)
- Fallback to simple "requires paid subscription" note only when `product_id` is unknown
- Strengthened `test_share_paid_room` assertions to verify the two-step flow
- Added `client_msg_id` to owner-chat WS protocol for reliable pending message reconciliation
- Included `client_msg_id` in all WS error responses (validation, too-long, duplicate)
- Logged skipped invalid attachments instead of silently dropping them
- Replaced double-buffer upload pattern with single bytearray for better memory efficiency

## Test plan
- [x] `uv run pytest tests/test_app/test_app_prompts.py` — 23/23 passed
- [x] Autofix: 2 rounds of Codex review → fix → verify, converged at round 3
- [ ] Verify prompt output for a real paid room via `/api/prompts/share?invite_code=...&language=zh`
- [ ] Manual test: send message with file via owner-chat WS, verify pending reconciliation

🤖 Generated with [Claude Code](https://claude.com/claude-code)