### PR TITLE
fix(frontend): discover rooms not loading on page load

### DIFF
--- a/frontend/src/store/useDashboardChatStore.ts
+++ b/frontend/src/store/useDashboardChatStore.ts
@@ -453,8 +453,6 @@ export const useDashboardChatStore = create<DashboardChatState>()(
       },
 
       loadDiscoverRooms: async () => {
-        const { token } = useDashboardSessionStore.getState();
-        if (!token) return;
         set({ discoverLoading: true });
         try {
           const result = await api.discoverRooms();


### PR DESCRIPTION
## Summary
- Remove redundant Zustand session store token guard in `loadDiscoverRooms`
- `api.discoverRooms()` fetches its auth token directly from the Supabase client (restored from cookies), but the store action was checking `useDashboardSessionStore.token` which initializes asynchronously — causing the request to be silently skipped on first load

## Test plan
- [ ] Open `/chats/explore/rooms` — verify discover rooms load on first page load
- [ ] Check Network tab for `GET /api/dashboard/rooms/discover` request
- [ ] Verify the refresh button still works
- [ ] Verify join/leave room still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)