### PR TITLE
docs: add agent API hint design spec

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@
 
 成员清单
 
+- `agent-api-hint-design.md`: Agent API 中 `hint` 字段的统一设计规范，定义适用边界、场景优先级与接口级建议。
 - `onboarding-optimization-prd.md`: Onboarding 收敛方案，统一新用户进入 BotCord 的主路径。
 - `press_release_zh.md`: 中文对外发布稿，沉淀产品叙事与传播话术。
 - `community-cold-start-seed-plan.md`: 群冷启动策略文档，定义 seed 群型、内容引擎与首月运营节奏。

--- a/docs/agent-api-hint-design.md
+++ b/docs/agent-api-hint-design.md
@@ -1,0 +1,716 @@
+<!--
+- [INPUT]: 依赖 world.coze.site/skill.md 的 agent API 文档分析结论，依赖 backend/hub/routers 下现有 BotCord agent-facing API 设计现状。
+- [OUTPUT]: 对外提供 BotCord 中 `hint` 字段的统一设计规范，定义字段语义、适用边界、场景优先级与接口级建议。
+- [POS]: docs 共享协议设计文档，供产品、后端、插件与前端在新增或改造 agent API 时复用。
+- [PROTOCOL]: 变更时同步检查 docs/README.md 与相关 API 文档是否需要补入口。
+-->
+
+# BotCord Agent API Hint 设计规范
+
+## 1. 文档定位
+
+本文用于收敛 BotCord 在 agent-facing API 中如何使用 `hint` 字段。
+
+目标不是把所有响应都塞进自然语言，而是定义一套稳定边界：
+
+- 哪些接口需要 `hint`
+- `hint` 该承担什么职责
+- 哪些信息必须结构化返回，不能只放在 `hint`
+- 成功场景与失败场景分别应该如何设计
+
+一句话目标：**让 BotCord 的 API 不只可调用，还能主动引导 Agent 完成下一步。**
+
+---
+
+## 2. 背景与判断
+
+在 Agent 系统里，API 返回值面对的通常不是传统前端，而是：
+
+- LLM 驱动的 Agent
+- 会自动串联多步调用的插件
+- 半自动化的 workflow 执行器
+
+这类调用方有一个共同问题：
+
+- 能理解结构化字段
+- 但不一定知道“下一步最合理的动作是什么”
+- 也不一定知道“失败后应该如何恢复”
+
+因此，`hint` 的价值不在于替代结构化字段，而在于补足两个缺口：
+
+1. 恢复提示：接口失败后，告诉 Agent 如何修复或绕开问题
+2. 下一步提示：接口成功后，告诉 Agent 接下来最值得调用什么
+
+对比统一身份类 Agent 平台文档，`hint` 并不是必须字段，但在 BotCord 这种多步协作平台里，它是非常高价值的辅助协议字段。
+
+---
+
+## 3. 设计目标
+
+### 3.1 核心目标
+
+1. 降低 Agent 对 BotCord API 的使用路径搜索成本
+2. 提高多步流程的成功率，减少“停在半路”的情况
+3. 将推荐路径显式化，而不是让客户端靠猜
+4. 在不破坏 API 结构稳定性的前提下提升可恢复性
+
+### 3.2 非目标
+
+1. 不让客户端依赖 `hint` 决定核心业务逻辑
+2. 不把错误码、状态机或权限语义迁移到自然语言里
+3. 不要求所有接口都返回 `hint`
+
+---
+
+## 4. `hint` 的定义
+
+### 4.1 字段语义
+
+`hint` 是一个面向 Agent 的短文本建议字段，用于说明：
+
+- 成功后推荐的下一步动作
+- 失败后推荐的恢复动作
+- 当前接口所处的迁移路径或最佳实践
+
+BotCord 的成功响应直接返回业务模型 JSON（无 `success` / `data` 包装），
+因此 `hint` 作为可选字段直接附加在现有响应体上：
+
+```json
+{
+  "room_id": "rm_abc",
+  "name": "Design Review",
+  "members": ["ag_alice", "ag_bob"],
+  "hint": "Call GET /hub/rooms/rm_abc to inspect room rules and active topics."
+}
+```
+
+错误响应已通过 `I18nHTTPException` + `HINT_MESSAGES` 统一返回 recovery hint：
+
+```json
+{
+  "detail": "Not a member of this room",
+  "code": "not_a_member",
+  "hint": "Join the room first, or ask an admin to add you.",
+  "retryable": false
+}
+```
+
+### 4.2 类型划分
+
+BotCord 中的 `hint` 只建议分成两类：
+
+1. `recovery hint`（已实现）
+- 用于失败场景
+- 目标是让 Agent 能自动恢复或至少知道如何人工介入
+- 实现方式：`hub/i18n.py` 的 `HINT_MESSAGES` 目录，通过 exception handler 自动注入到错误响应
+
+2. `next-action hint`（待实现）
+- 用于成功场景
+- 目标是降低下一步动作选择成本
+- 实现方式：需要在各端点的 response schema 中添加可选 `hint` 字段
+
+### 4.3 不可替代的结构化信息
+
+以下信息不能只放在 `hint`，必须保留结构化字段：
+
+- 权限判断，例如 `default_send`、`can_send` override
+- 身份状态，例如 token 是否过期、key 是否 active
+- 资源标识，例如 `room_id`、`topic_id`、`agent_id`
+- 错误类别，例如状态码、错误码、`last_error`
+- 资源状态，例如 topic open/completed/failed
+- 下一步调用所需参数
+
+规则是：
+
+- 结构化字段负责“事实”
+- `hint` 负责“建议”
+
+---
+
+## 5. 何时应该返回 `hint`
+
+### 5.1 应该返回 `hint` 的判定条件
+
+满足任一条件即可考虑返回：
+
+1. 下一步动作对 Agent 来说不明显
+2. 失败场景存在明确的恢复路径
+3. 接口处于产品推荐路径或迁移路径
+4. 资源具备明显的上下文跳转关系
+5. 成功只是流程中的一步，不是最终目标
+
+### 5.2 不必强行返回 `hint` 的场景
+
+以下接口优先保持简洁：
+
+- 纯读取且下一步非常直观
+- 简单资源详情查询
+- 低歧义、低状态成本的幂等接口
+- 客户端已有稳定调用链、不会在此停住的接口
+
+例如：
+
+- `GET /registry/agents/{agent_id}/keys/{key_id}`
+- `GET /wallet/me`
+- 普通 `GET /registry/resolve/{agent_id}`
+
+这些接口不是绝对不能返回 `hint`，而是默认优先级低。
+
+---
+
+## 6. 文案规则
+
+### 6.1 文案约束
+
+1. 一条 `hint` 只表达一个主建议
+2. 优先使用明确 API 路径，而不是模糊描述
+3. 明确前置条件，例如 `if default_send is true`
+4. 避免长解释，重点是动作导向
+5. 避免抽象措辞，例如“你可以继续探索系统能力”
+
+### 6.2 推荐句式
+
+成功场景：
+
+- `Call GET /hub/rooms/{room_id} next to inspect room context.`
+- `Poll GET /hub/inbox next to consume queued messages.`
+- `Use POST /hub/send to reply in this room if default_send is true or you have a can_send override.`
+
+失败场景：
+
+- `Refresh your token via POST /registry/agents/{agent_id}/token/refresh and retry.`
+- `Direct messaging is restricted by the target agent's policy. Send a contact request first or interact in a shared room.`
+- `The hub uses inbox-only delivery. Prefer /hub/ws for realtime notifications and GET /hub/inbox for message retrieval.`
+
+### 6.3 不推荐句式
+
+- `Please fix your configuration`
+- `Something went wrong`
+- `Try again later`
+- `You may do some next actions`
+
+问题在于这些文案没有给出明确动作。
+
+---
+
+## 7. BotCord 场景分层
+
+BotCord 当前的 agent-facing API 大致可分为六层：
+
+1. 身份层：注册、验证、token refresh、profile、claim
+2. 传输层：send、receipt、status、inbox、ack、ws
+3. 协作层：rooms、topics、room context、search
+4. 关系层：contacts、contact requests、blocks、policy
+5. 交易层：wallet、subscriptions
+6. 迁移兼容层：deprecated webhook endpoint 系列
+
+其中最适合先引入 `hint` 的，不是所有层，而是以下三层：
+
+1. 传输层（send / inbox / status — 调用最频繁，下一步最不明显）
+2. 协作层（rooms / topics — 多步流程入口，上下文跳转密集）
+3. 身份层（register / verify / token refresh — onboarding 关键路径）
+
+原因是：
+
+- 这些层最容易让 Agent 不知道下一步
+- 这些层的失败恢复路径最明确
+- 这些层对多步任务成功率影响最大
+
+---
+
+## 8. 接口级建议
+
+以下为 BotCord 当前最值得引入 `hint` 的接口清单。
+
+### 8.1 身份层
+
+#### `POST /registry/agents`
+
+作用：
+
+- 注册 Agent
+- 返回 `agent_id`、`key_id`、`challenge`
+
+建议：
+
+- 成功后返回 next-action hint
+
+推荐 hint：
+
+- `Sign the returned challenge with your private key, then call POST /registry/agents/{agent_id}/verify to activate this key.`
+
+适用原因：
+
+- 注册本身不是终点，验证才是完成 onboarding 的关键一步。
+
+#### `POST /registry/agents/{agent_id}/verify`
+
+作用：
+
+- 验证签名
+- 激活 key
+- 返回 `agent_token`
+
+建议：
+
+- 成功后返回 next-action hint
+- 失败时根据失败原因补 recovery hint
+
+推荐 hint：
+
+- 成功：`Store the returned agent_token, then use POST /registry/agents/{agent_id}/token/refresh for future renewal. If claim_url is present, complete owner binding there.`
+- 失败：`Ensure the signature was generated from the exact challenge and the matching private key, then retry before the challenge expires.`
+
+#### `POST /registry/agents/{agent_id}/token/refresh`
+
+作用：
+
+- 通过 nonce 签名刷新 token
+
+建议：
+
+- 失败时强烈建议返回 recovery hint
+
+推荐 hint：
+
+- `Ensure the key is active, the nonce has not been reused, and the request is signed by the matching private key.`
+- 插件版本过低时：`Upgrade the BotCord plugin before retrying token refresh.`
+
+#### `PATCH /registry/agents/{agent_id}/profile`
+
+作用：
+
+- 更新 display_name / bio
+
+建议：
+
+- 可选返回轻量 next-action hint
+
+推荐 hint：
+
+- `Call GET /registry/resolve/{agent_id} if you need the refreshed public profile view.`
+
+### 8.2 Endpoint 层
+
+#### `POST /registry/agents/{agent_id}/endpoints`
+#### `POST /registry/agents/{agent_id}/endpoints/test`
+#### `GET /registry/agents/{agent_id}/endpoints/status`
+
+作用：
+
+- 注册 agent 的 webhook endpoint URL
+- 测试 endpoint 可达性
+- 查询 endpoint 健康状态
+
+> 注意：Endpoint 注册本身**未废弃**——它仍用于 endpoint 健康检查和连接元数据。
+> 但 **webhook 主动推送已废弃**：当前架构为 inbox-only，消息通过
+> `GET /hub/inbox` 轮询或 `/hub/ws` WebSocket 获取，不会主动推送到 endpoint。
+
+建议：
+
+- 注册成功后返回 next-action hint，引导到消息接收的正确路径
+- probe 失败时返回 recovery hint
+
+推荐 hint：
+
+- 注册成功：`Endpoint registered. Note: the hub uses inbox-only delivery. Use /hub/ws for realtime notifications or GET /hub/inbox for message retrieval.`
+- probe 失败时补充原因：
+  - `Ensure the endpoint URL is publicly reachable and responds to POST requests with 2xx.`
+
+适用原因：
+
+- 新用户容易误以为注册 endpoint 后消息会自动推送过来，需要引导到正确的消息接收路径。
+
+### 8.3 传输层
+
+#### `POST /hub/send`
+
+作用：
+
+- 发送 DM、room message、contact request、result、error
+
+建议：
+
+- 成功和失败都推荐返回 `hint`
+
+推荐 hint：
+
+- 成功：
+  - DM：`Track delivery via GET /hub/status/{msg_id}, and expect the receiver to consume it from GET /hub/inbox.`
+  - 房间：`Call GET /hub/rooms/{room_id} if you need room context, or GET /hub/status/{msg_id} to inspect delivery state.`
+  - contact request：`The target agent can review this request from its received contact requests list or consume the notification from GET /hub/inbox.`
+- 失败：
+  - `Ensure envelope.from matches the authenticated agent and the envelope signature is valid.`
+  - `If direct messaging is blocked by policy, send a contact request first or use a shared room.`
+
+#### `POST /hub/receipt`
+
+作用：
+
+- 接收 ack/result/error 回执
+
+建议：
+
+- 成功时可返回轻量 next-action hint
+- 失败时应返回 recovery hint
+
+推荐 hint：
+
+- 成功：`The original sender can consume this receipt from GET /hub/inbox or inspect state via GET /hub/status/{reply_to}.`
+- 失败：`Ensure reply_to references the original message msg_id and the receipt signature is valid.`
+
+#### `GET /hub/status/{msg_id}`
+
+作用：
+
+- 查询消息投递状态
+
+建议：
+
+- 当 state 为失败态或未完成态时返回 `hint`
+
+推荐 hint：
+
+- `The receiver has not acknowledged this message yet. Retry later or inspect whether the receiver is polling GET /hub/inbox.`
+- `Delivery failed. Check last_error and recover based on transport mode or target policy.`
+
+#### `GET /hub/inbox`
+
+作用：
+
+- 拉取消息
+- 支持长轮询
+- 可选自动 ack
+
+建议：
+
+- 最适合做 next-action hint
+- 响应级可以有总 hint，消息级未来可扩展 `message_hint`
+
+推荐 hint：
+
+- 有消息：
+  - `Process returned messages in order. If ack mode is not enabled, poll again with ack=true to mark them as delivered.`
+- 空结果：
+  - `No queued messages were found. Continue polling GET /hub/inbox or establish /hub/ws for realtime wake-ups.`
+- 房间消息存在时：
+  - `For room messages, call GET /hub/rooms/{room_id} to inspect room rules, topics, and membership context.`
+
+> 注意：BotCord 没有独立的 `POST /hub/inbox/ack` 端点。消息确认通过
+> `GET /hub/inbox?ack=true` 查询参数实现（拉取时同时确认）。
+
+### 8.4 协作层
+
+#### `POST /hub/rooms`
+
+作用：
+
+- 创建房间
+
+建议：
+
+- 成功后应该返回 `hint`
+
+推荐 hint：
+
+- `Call GET /hub/rooms/{room_id} to inspect membership and room context before sending messages.`
+
+#### 房间加入相关接口
+
+包括：
+
+- `POST /hub/rooms/{room_id}/members`
+- dashboard/BFF 的 join 入口
+
+建议：
+
+- 这是最该加 next-action hint 的成功场景
+
+推荐 hint：
+
+- `Joined room successfully. Call GET /hub/rooms/{room_id} next to inspect room rules and active topics, then GET /hub/history?room_id={room_id} for recent context. If default_send is true or you have a can_send override, you can reply via POST /hub/send.`
+
+#### `GET /hub/rooms/me`
+
+作用：
+
+- 列出当前 agent 已加入的所有房间
+
+建议：
+
+- 可返回轻量 next-action hint
+
+推荐 hint：
+
+- `Pick a room_id from the list and call GET /hub/rooms/{room_id} for detailed context.`
+
+#### `GET /hub/rooms/{room_id}`
+
+作用：
+
+- 获取房间详情（成员列表、权限、规则、Topic 等）
+
+建议：
+
+- 成功后返回 next-action hint
+
+推荐 hint：
+
+- `Use GET /hub/history?room_id={room_id} for message history, or POST /hub/send to participate if your room permissions allow it.`
+
+#### `GET /hub/history`
+
+作用：
+
+- 查询聊天历史（支持按 `room_id`、`peer`、`topic_id` 过滤，cursor 分页）
+
+建议：
+
+- 默认不强制返回
+- 当携带 topic_id 或结果为空时可考虑加 hint
+
+推荐 hint：
+
+- `If you need higher-level context, call GET /hub/rooms/{room_id} for room details.`
+- `If you need topic-focused history, filter by topic_id or inspect topic metadata via GET /hub/rooms/{room_id}/topics/{topic_id}.`
+
+#### 消息搜索
+
+> 注意：当前 agent-facing 协议层没有独立的搜索端点。消息过滤通过
+> `GET /hub/history` 的 `peer`、`room_id`、`topic_id` 参数实现。
+> Dashboard 层（`app/routers/dashboard.py`）有搜索功能，但面向用户而非 agent。
+>
+> 如果未来新增 agent-facing 搜索端点，适合按以下模式返回 hint：
+
+建议：
+
+- 有结果时返回下一步建议
+- 无结果时返回恢复式建议
+
+推荐 hint：
+
+- 有结果：`Use returned room_id and topic_id to fetch full context via GET /hub/rooms/{room_id} or GET /hub/history.`
+- 无结果：`Try broader keywords or remove topic/peer filters in GET /hub/history.`
+
+### 8.5 Topic 生命周期
+
+#### `POST /hub/rooms/{room_id}/topics`
+
+作用：
+
+- 创建 topic
+
+建议：
+
+- 必须返回 next-action hint
+
+推荐 hint：
+
+- `Send follow-up room messages with this topic context, and use result or error message types to close the topic lifecycle when work is complete.`
+
+#### `PATCH /hub/rooms/{room_id}/topics/{topic_id}`
+
+作用：
+
+- 更新 topic
+
+建议：
+
+- 状态变化时返回 hint
+
+推荐 hint：
+
+- `If the topic remains open, continue discussion in the room with the same topic context. If it is completed or failed, create a new topic for follow-up work.`
+
+#### `GET /hub/rooms/{room_id}/topics/{topic_id}`
+
+作用：
+
+- topic 详情查询
+
+建议：
+
+- 可返回轻量 next-action hint
+
+推荐 hint：
+
+- `Use GET /hub/history?room_id={room_id}&topic_id={topic_id} to inspect the message trail for this topic.`
+
+### 8.6 关系层
+
+#### 联系人与好友申请
+
+包括：
+
+- 发送 contact request
+- 接受 request
+- 拒绝 request
+- 删除 contact
+
+建议：
+
+- 成功后非常适合返回 next-action hint
+
+推荐 hint：
+
+- 发送申请成功：`The target agent can review this request from contact requests or consume the notification from GET /hub/inbox.`
+- 接受成功：`You can now send direct messages to this contact or invite them to a shared room.`
+- 删除联系人：`Direct messaging may now depend on each agent's current message policy or shared room membership.`
+
+#### `PATCH /registry/agents/{agent_id}/policy`
+
+作用：
+
+- 更新消息策略
+
+建议：
+
+- 成功后返回策略生效提示
+
+推荐 hint：
+
+- `This policy affects future direct messages. Agents outside your contacts may need to send a contact request first.`
+
+#### block / unblock
+
+建议：
+
+- 成功后返回约束说明
+
+推荐 hint：
+
+- `Blocked agents should no longer interact directly with you through supported direct channels.`
+
+### 8.7 交易层
+
+#### `POST /wallet/transfers`
+#### `POST /wallet/topups`
+#### `POST /wallet/withdrawals`
+#### 订阅购买相关接口
+
+建议：
+
+- 失败恢复优先级高于成功引导
+
+推荐 hint：
+
+- 转账余额不足：`Top up your wallet first, then retry this transfer.`
+- topup 创建成功：`Track settlement via the returned topup state or related transaction endpoint.`
+- 订阅成功：`You can now access subscription-gated rooms or services linked to this product.`
+
+---
+
+## 9. 优先级排序
+
+### P0：必须先做
+
+1. `POST /hub/send`（成功后 next-action hint）
+2. `GET /hub/inbox`（有消息/无消息不同 hint）
+3. 房间加入成功（`POST /hub/rooms/{room_id}/members`）
+4. `GET /hub/rooms/{room_id}`（房间详情后的下一步引导）
+5. `POST /registry/agents/{agent_id}/token/refresh`（失败恢复 — 影响所有后续调用）
+
+原因：
+
+- 调用最频繁
+- 卡住成本最高
+- 下一步最不明显
+
+### P1：应尽快补齐
+
+1. register / verify（onboarding 流程引导）
+2. topic create / update / detail
+3. contact request / accept / policy
+4. `GET /hub/status/{msg_id}`
+5. endpoint 注册（引导到 inbox-only 消息接收路径）
+
+### P2：可按业务节奏跟进
+
+1. wallet
+2. subscriptions
+3. 低歧义只读接口
+
+---
+
+## 10. 返回结构建议
+
+### 10.1 错误响应（已实现）
+
+错误响应通过 `I18nHTTPException` 统一返回，`hint` 字段已在 exception handler 中自动注入：
+
+```json
+{
+  "detail": "Insufficient balance",
+  "code": "wallet_service_error",
+  "hint": "Top up your wallet before retrying, or reduce the amount.",
+  "retryable": false
+}
+```
+
+- `hint` 来自 `hub/i18n.py` 的 `HINT_MESSAGES` 目录（EN/ZH 双语）
+- 动态错误（如 wallet service error）通过 `hint_key` + `resolve_service_error_hint()` 匹配精确 hint
+- 无 hint 时返回 `null`
+
+### 10.2 成功响应（待实现）
+
+在既有 Pydantic response model 中新增可选 `hint` 字段：
+
+```json
+{
+  "room_id": "rm_abc",
+  "name": "Design Review",
+  "members": [...],
+  "hint": "Call GET /hub/rooms/rm_abc to inspect room context before sending messages."
+}
+```
+
+实现方式：给需要 hint 的 response schema 添加 `hint: str | None = None`。
+
+约束：
+
+- `hint` 是单个字符串，只表达最关键的一条建议
+- 对 LLM agent 来说，一条明确的 hint 比多条建议更有效——减少决策成本
+- 如果需要传达多个信息，写在一条 hint 中用分号或逗号连接即可
+- `hint` 可空，不强制所有分支返回
+
+---
+
+## 11. 实施原则
+
+### 11.1 后端
+
+1. 先在最关键接口的 response schema 中加入可选 `hint`
+2. 保持 `hint` 可空，不强制所有分支返回
+3. 根据明确分支生成文案，不做大而全的模板拼装
+4. 错误分支优先根据错误码映射 recovery hint
+
+### 11.2 插件 / Agent SDK
+
+1. 可展示 `hint`，但不能依赖它做核心逻辑判断
+2. 若具备自动编排能力，可把 `hint` 当作下一步建议输入给 LLM
+3. 仍应优先读取结构化字段做确定性分支
+
+### 11.3 前端 / Dashboard
+
+1. BFF 返回给 Web 的时候可选择透传或裁剪 `hint`
+2. 对用户界面不应机械展示所有 hint
+3. `hint` 优先服务 Agent、插件、workflow，不是给普通用户看的主文案
+
+---
+
+## 12. 最终结论
+
+在 BotCord 中，`hint` 最适合扮演的不是“错误附注”，而是“面向 Agent 的动作引导层”。
+
+因此它的最佳落点不是所有接口，而是：
+
+- 多步流程入口
+- 迁移兼容接口
+- 高状态成本接口
+- 上下文跳转密集接口
+
+最重要的落地原则只有一句：
+
+**结构化字段负责真实状态，`hint` 负责推荐动作。**
+
+如果后续继续推进，可按本文的 P0/P1 顺序逐步把 `hint` 收敛进 BotCord 的 agent API 契约中。


### PR DESCRIPTION
## Summary
- Add design spec for the unified `hint` field in BotCord agent-facing APIs
- Covers both recovery hints (errors, already implemented in botlearn-ai/botcord#214) and next-action hints (success responses, to be implemented)
- Defines when to return hint, response format, per-endpoint recommendations, and P0/P1/P2 priorities

## Test plan
- [x] Endpoint paths verified against actual code in hub/routers/
- [x] Response format aligned with actual Pydantic model conventions
- [x] Cross-referenced with already-implemented error hint system

🤖 Generated with [Claude Code](https://claude.com/claude-code)