### PR TITLE
feat(frontend): make sidebar secondary panel resizable

### DIFF
--- a/frontend/src/components/dashboard/Sidebar.tsx
+++ b/frontend/src/components/dashboard/Sidebar.tsx
@@ -7,7 +7,7 @@
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
 
-import { startTransition, useEffect, useMemo, useState } from "react";
+import { startTransition, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import Link from "next/link";
 import { useRouter } from "nextjs-toploader/app";
@@ -188,10 +188,12 @@ export default function Sidebar() {
     exploreView: state.exploreView,
     openedRoomId: state.openedRoomId,
     messagesPane: state.messagesPane,
+    sidebarWidth: state.sidebarWidth,
     setSidebarTab: state.setSidebarTab,
     setMessagesPane: state.setMessagesPane,
     setExploreView: state.setExploreView,
     setContactsView: state.setContactsView,
+    setSidebarWidth: state.setSidebarWidth,
   })));
   const chatStore = useDashboardChatStore(useShallow((state) => ({
     overview: state.overview,
@@ -207,6 +209,37 @@ export default function Sidebar() {
   const [showFriendInvite, setShowFriendInvite] = useState(false);
   const [identityState, setIdentityState] = useState<"idle" | "loading" | "copied">("idle");
   const showLoginModal = () => router.push("/login");
+
+  const SIDEBAR_MIN = 200;
+  const SIDEBAR_MAX = 480;
+  const isResizing = useRef(false);
+  const startX = useRef(0);
+  const startWidth = useRef(uiStore.sidebarWidth);
+
+  const handleResizeStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    isResizing.current = true;
+    startX.current = e.clientX;
+    startWidth.current = uiStore.sidebarWidth;
+
+    const onMouseMove = (ev: MouseEvent) => {
+      if (!isResizing.current) return;
+      const delta = ev.clientX - startX.current;
+      const next = Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, startWidth.current + delta));
+      uiStore.setSidebarWidth(next);
+    };
+    const onMouseUp = () => {
+      isResizing.current = false;
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+  }, [uiStore.sidebarWidth, uiStore.setSidebarWidth]);
 
   const handleCopyAgentIdentity = async () => {
     if (!sessionStore.activeAgentId || identityState === "loading") return;
@@ -457,7 +490,12 @@ export default function Sidebar() {
       {showFriendInvite && <FriendInviteModal onClose={() => setShowFriendInvite(false)} />}
 
       {/* Secondary panel */}
-      <div className="flex h-full w-[260px] min-w-[260px] flex-col border-r border-glass-border bg-deep-black-light">
+      <div className="relative flex h-full flex-col border-r border-glass-border bg-deep-black-light" style={{ width: uiStore.sidebarWidth, minWidth: SIDEBAR_MIN }}>
+        {/* Resize handle */}
+        <div
+          onMouseDown={handleResizeStart}
+          className="absolute right-0 top-0 z-10 h-full w-1 cursor-col-resize transition-colors hover:bg-neon-cyan/30 active:bg-neon-cyan/50"
+        />
         {/* Panel header */}
         <div className="flex min-h-14 items-center justify-between border-b border-glass-border px-4 py-3">
           <div className="min-w-0">

--- a/frontend/src/store/useDashboardUIStore.ts
+++ b/frontend/src/store/useDashboardUIStore.ts
@@ -33,6 +33,8 @@ export interface DashboardUIState {
   toggleRightPanel: () => void;
   openAgentCard: () => void;
   closeAgentCard: () => void;
+  sidebarWidth: number;
+  setSidebarWidth: (width: number) => void;
   resetUIState: () => void;
   logout: () => void;
 }
@@ -48,6 +50,7 @@ const initialUIState = {
   messagesPane: "room" as const,
   exploreView: "rooms" as const,
   contactsView: "agents" as const,
+  sidebarWidth: 260,
 };
 
 export const useDashboardUIStore = create<DashboardUIState>()((set) => ({
@@ -69,6 +72,8 @@ export const useDashboardUIStore = create<DashboardUIState>()((set) => ({
     set((state) => (state.exploreView === exploreView ? state : { exploreView })),
   setContactsView: (contactsView) =>
     set((state) => (state.contactsView === contactsView ? state : { contactsView })),
+  setSidebarWidth: (sidebarWidth) =>
+    set((state) => (state.sidebarWidth === sidebarWidth ? state : { sidebarWidth })),
   toggleRightPanel: () => set((state) => ({ rightPanelOpen: !state.rightPanelOpen })),
   openAgentCard: () => set({ agentCardOpen: true }),
   closeAgentCard: () => set({ agentCardOpen: false }),


### PR DESCRIPTION
## Summary
- Add a draggable resize handle on the right edge of the sidebar's secondary panel (room list / contacts / explore / wallet)
- Users can drag to adjust width between 200px and 480px
- Width is stored in the UI store and persists during the session

## Test plan
- [ ] Hover over the right edge of the sidebar — cursor changes to col-resize
- [ ] Drag to resize the panel — width updates smoothly
- [ ] Width clamps between 200px and 480px
- [ ] Room names / content reflow correctly at different widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)