### PR TITLE
feat(plugin): add safe uninstall command and recovery script

### DIFF
--- a/frontend/src/app/api/public-docs/[slug]/route.ts
+++ b/frontend/src/app/api/public-docs/[slug]/route.ts
@@ -53,6 +53,10 @@ const TEMPLATES: Record<string, TemplateEntry> = {
     file: "register-beta.template.sh",
     contentType: "text/x-shellscript; charset=utf-8",
   },
+  "uninstall.sh": {
+    file: "uninstall.template.sh",
+    contentType: "text/x-shellscript; charset=utf-8",
+  },
 };
 
 function getBaseUrl(): string {

--- a/frontend/src/lib/templates/uninstall.template.sh
+++ b/frontend/src/lib/templates/uninstall.template.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# --------------------------------------------------------------------------
+# BotCord Plugin Uninstaller
+#
+# One-liner:
+#   bash <(curl -fsSL {{BASE_URL}}/uninstall.sh)
+#
+# What it does:
+#   1. Disables the BotCord plugin via OpenClaw CLI
+#   2. Removes plugin files from ~/.openclaw/extensions/botcord/
+#   3. Cleans up channel config from openclaw.json (safely via node, with backup)
+#   4. Preserves credentials in ~/.botcord/ (use --purge to delete them)
+#
+# This script is the recovery path when OpenClaw is broken due to a
+# corrupted openclaw.json. It does NOT require a working OpenClaw install.
+# --------------------------------------------------------------------------
+set -euo pipefail
+
+# ── Defaults ──────────────────────────────────────────────────────────────
+
+OPENCLAW_BIN="${OPENCLAW_BIN:-openclaw}"
+TARGET_DIR="${TARGET_DIR:-$HOME/.openclaw/extensions/botcord}"
+PURGE="0"
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+log()       { printf "[botcord] %s\n" "$*"; }
+log_warn()  { printf "[botcord] WARN: %s\n" "$*"; }
+log_error() { printf "[botcord] ERROR: %s\n" "$*" >&2; }
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  bash <(curl -fsSL {{BASE_URL}}/uninstall.sh) [options]
+
+Options:
+  --purge               Also delete credentials from ~/.botcord/
+  --target-dir <path>   Plugin directory (default: ~/.openclaw/extensions/botcord)
+  -h, --help            Show this help
+USAGE
+}
+
+need_next_arg() {
+  local opt="$1"
+  local argc="$2"
+  if [ "$argc" -lt 2 ]; then
+    log_error "missing value for $opt"
+    exit 1
+  fi
+}
+
+# ── Parse args ────────────────────────────────────────────────────────────
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --purge)
+      PURGE="1"
+      shift
+      ;;
+    --target-dir)
+      need_next_arg "$1" "$#"
+      TARGET_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      log_error "unknown argument: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+# ── Step 1: Disable plugin via OpenClaw CLI (best-effort) ────────────────
+
+if command -v "$OPENCLAW_BIN" >/dev/null 2>&1; then
+  log "disabling BotCord plugin ..."
+  "$OPENCLAW_BIN" plugins disable botcord >/dev/null 2>&1 && log "  plugin disabled" || log_warn "  could not disable (may already be disabled or OpenClaw is broken)"
+else
+  log_warn "openclaw CLI not found — skipping plugin disable"
+fi
+
+# ── Step 2: Remove plugin files ──────────────────────────────────────────
+
+if [ -d "$TARGET_DIR" ]; then
+  log "removing plugin files from $TARGET_DIR ..."
+  rm -rf "$TARGET_DIR"
+  log "  done"
+else
+  log "no plugin files found at $TARGET_DIR"
+fi
+
+# Also clean up any leftover backups from failed installs
+shopt -s nullglob
+for old_backup in "${TARGET_DIR}".bak.*; do
+  log "  cleaning up backup: $(basename "$old_backup")"
+  rm -rf "$old_backup"
+done
+shopt -u nullglob
+
+# ── Step 3: Clean openclaw.json safely ───────────────────────────────────
+# This is the critical part — uses Node.js to safely parse/modify JSON
+# with a backup, so a crash here can't corrupt the config.
+
+OPENCLAW_JSON=""
+if [ -n "${OPENCLAW_CONFIG_PATH:-}" ] && [ -f "$OPENCLAW_CONFIG_PATH" ]; then
+  OPENCLAW_JSON="$OPENCLAW_CONFIG_PATH"
+elif command -v "$OPENCLAW_BIN" >/dev/null 2>&1; then
+  OPENCLAW_JSON="$("$OPENCLAW_BIN" config file 2>/dev/null || true)"
+  if [ -n "$OPENCLAW_JSON" ] && [ ! -f "$OPENCLAW_JSON" ]; then
+    OPENCLAW_JSON=""
+  fi
+fi
+if [ -z "$OPENCLAW_JSON" ]; then
+  for candidate in "$HOME/.openclaw/openclaw.json" "./openclaw.json"; do
+    if [ -f "$candidate" ]; then
+      OPENCLAW_JSON="$candidate"
+      break
+    fi
+  done
+fi
+
+if [ -n "$OPENCLAW_JSON" ] && command -v node >/dev/null 2>&1; then
+  log "cleaning BotCord entries from $(basename "$OPENCLAW_JSON") ..."
+  OPENCLAW_JSON="$OPENCLAW_JSON" TARGET_DIR="$TARGET_DIR" node --input-type=module <<'NODE' || true
+import { readFileSync, writeFileSync, copyFileSync } from "node:fs";
+
+const configPath = process.env.OPENCLAW_JSON;
+let raw, config;
+try {
+  raw = readFileSync(configPath, "utf8");
+  config = JSON.parse(raw);
+} catch (err) {
+  console.log(`[botcord] WARN: could not parse ${configPath}: ${err.message}`);
+  console.log("[botcord] WARN: config file may already be corrupted — attempting repair");
+
+  // Try to fix common JSON corruption: trailing commas only.
+  // We intentionally do NOT regex-remove nested objects (e.g. "botcord": {...})
+  // because that regex can't handle nested braces and would corrupt the file.
+  // If trailing-comma fix succeeds, the delete below will remove botcord cleanly.
+  try {
+    let fixed = raw.replace(/,\s*([\]}])/g, "$1");
+    config = JSON.parse(fixed);
+    console.log("[botcord] repair succeeded (trailing comma fix) — will write cleaned config");
+  } catch {
+    console.log("[botcord] WARN: could not repair config — skipping JSON cleanup");
+    console.log("[botcord] HINT: manually check " + configPath);
+    process.exit(0);
+  }
+}
+
+let changed = false;
+
+// Remove channels.botcord
+if (config?.channels?.botcord) {
+  delete config.channels.botcord;
+  if (Object.keys(config.channels).length === 0) delete config.channels;
+  changed = true;
+  console.log("[botcord]   removed channels.botcord");
+}
+
+// Remove plugin load path entries pointing to botcord
+const loadPaths = config?.plugins?.load?.paths;
+if (Array.isArray(loadPaths)) {
+  const before = loadPaths.length;
+  const targetDir = process.env.TARGET_DIR;
+  config.plugins.load.paths = loadPaths.filter(
+    (p) => !p.includes("botcord") && p !== targetDir
+  );
+  if (config.plugins.load.paths.length < before) {
+    changed = true;
+    console.log("[botcord]   removed botcord from plugins.load.paths");
+  }
+  if (config.plugins.load.paths.length === 0) {
+    delete config.plugins.load.paths;
+    if (Object.keys(config.plugins.load).length === 0) delete config.plugins.load;
+  }
+}
+
+// Remove plugin entries.botcord
+if (config?.plugins?.entries?.botcord) {
+  delete config.plugins.entries.botcord;
+  if (Object.keys(config.plugins.entries).length === 0) delete config.plugins.entries;
+  changed = true;
+  console.log("[botcord]   removed plugins.entries.botcord");
+}
+
+// Remove from plugins.allow
+const allowList = config?.plugins?.allow;
+if (Array.isArray(allowList)) {
+  const idx = allowList.indexOf("botcord");
+  if (idx !== -1) {
+    allowList.splice(idx, 1);
+    changed = true;
+    console.log("[botcord]   removed botcord from plugins.allow");
+  }
+}
+
+// Clean up empty plugins object
+if (config?.plugins && Object.keys(config.plugins).length === 0) {
+  delete config.plugins;
+}
+
+if (changed) {
+  // Backup before writing
+  const backupPath = configPath + ".bak." + Date.now();
+  copyFileSync(configPath, backupPath);
+  console.log("[botcord]   backed up to " + backupPath);
+
+  writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  console.log("[botcord]   config updated");
+} else {
+  console.log("[botcord]   no BotCord entries found in config");
+}
+NODE
+elif [ -n "$OPENCLAW_JSON" ]; then
+  log_warn "node not found — cannot clean openclaw.json automatically"
+  log_warn "manually remove 'channels.botcord' and botcord plugin entries from $OPENCLAW_JSON"
+fi
+
+# ── Step 4: Handle credentials ───────────────────────────────────────────
+
+CRED_DIR="$HOME/.botcord/credentials"
+
+if [ "$PURGE" = "1" ]; then
+  if [ -d "$CRED_DIR" ]; then
+    shopt -s nullglob
+    CRED_FILES=("$CRED_DIR"/*.json)
+    shopt -u nullglob
+    if [ "${#CRED_FILES[@]}" -gt 0 ]; then
+      log "deleting ${#CRED_FILES[@]} credential file(s) ..."
+      for cf in "${CRED_FILES[@]}"; do
+        rm -f "$cf"
+        log "  deleted $(basename "$cf")"
+      done
+    fi
+    # Remove empty dirs
+    rmdir "$CRED_DIR" 2>/dev/null || true
+    rmdir "$HOME/.botcord" 2>/dev/null || true
+  fi
+else
+  if [ -d "$CRED_DIR" ]; then
+    shopt -s nullglob
+    CRED_FILES=("$CRED_DIR"/*.json)
+    shopt -u nullglob
+    if [ "${#CRED_FILES[@]}" -gt 0 ]; then
+      log "credentials preserved in $CRED_DIR (${#CRED_FILES[@]} file(s))"
+      log "  use --purge to also delete credentials"
+      log "  to reinstall later: bash <(curl -fsSL {{BASE_URL}}/install.sh)"
+    fi
+  fi
+fi
+
+# ── Done ──────────────────────────────────────────────────────────────────
+
+log ""
+log "BotCord plugin uninstalled."
+if command -v "$OPENCLAW_BIN" >/dev/null 2>&1; then
+  log "Restart OpenClaw to apply: openclaw gateway restart"
+fi
+log ""

--- a/frontend/src/lib/templates/uninstall.template.sh
+++ b/frontend/src/lib/templates/uninstall.template.sh
@@ -109,7 +109,7 @@ OPENCLAW_JSON=""
 if [ -n "${OPENCLAW_CONFIG_PATH:-}" ] && [ -f "$OPENCLAW_CONFIG_PATH" ]; then
   OPENCLAW_JSON="$OPENCLAW_CONFIG_PATH"
 elif command -v "$OPENCLAW_BIN" >/dev/null 2>&1; then
-  OPENCLAW_JSON="$("$OPENCLAW_BIN" config file 2>/dev/null || true)"
+  OPENCLAW_JSON="$("$OPENCLAW_BIN" config path 2>/dev/null || true)"
   if [ -n "$OPENCLAW_JSON" ] && [ ! -f "$OPENCLAW_JSON" ]; then
     OPENCLAW_JSON=""
   fi
@@ -168,7 +168,7 @@ if (Array.isArray(loadPaths)) {
   const before = loadPaths.length;
   const targetDir = process.env.TARGET_DIR;
   config.plugins.load.paths = loadPaths.filter(
-    (p) => !p.includes("botcord") && p !== targetDir
+    (p) => p !== targetDir && !p.endsWith("/botcord")
   );
   if (config.plugins.load.paths.length < before) {
     changed = true;

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -22,6 +22,7 @@ import { createTokenCommand } from "./src/commands/token.js";
 import { createBindCommand } from "./src/commands/bind.js";
 import { createEnvCommand } from "./src/commands/env.js";
 import { createResetCredentialCommand } from "./src/commands/reset-credential.js";
+import { createUninstallCli } from "./src/commands/uninstall.js";
 import {
   clearBotCordLoopRiskSession,
   didBotCordSendSucceed,
@@ -161,6 +162,9 @@ export default {
     api.registerCommand(createBindCommand());
     api.registerCommand(createResetCredentialCommand());
     api.registerCommand(createEnvCommand());
+
+    const uninstallCli = createUninstallCli();
+    api.registerCli(uninstallCli.setup, { commands: uninstallCli.commands });
 
   },
 };

--- a/plugin/src/commands/uninstall.ts
+++ b/plugin/src/commands/uninstall.ts
@@ -1,0 +1,129 @@
+/**
+ * CLI: `openclaw botcord-uninstall`
+ *
+ * Safe uninstall that uses OpenClaw's plugin API instead of editing JSON directly.
+ * Prevents the common failure mode where AI agents corrupt openclaw.json.
+ */
+
+export function createUninstallCli() {
+  return {
+    setup: (ctx: any) => {
+      ctx.program
+        .command("botcord-uninstall")
+        .description("Safely uninstall the BotCord plugin")
+        .option("--purge", "Also delete credentials from ~/.botcord/", false)
+        .option("--keep-channel", "Keep channel config in openclaw.json", false)
+        .option("--profile <name>", "OpenClaw profile to target")
+        .option("--dev", "Target the dev profile")
+        .action(async (options: { purge?: boolean; keepChannel?: boolean; profile?: string; dev?: boolean }) => {
+          const { existsSync, rmSync, readdirSync } = await import("node:fs");
+          const { join } = await import("node:path");
+          const { spawnSync } = await import("node:child_process");
+          const { homedir } = await import("node:os");
+
+          const home = homedir();
+          const credDir = join(home, ".botcord", "credentials");
+
+          // Build profile args to forward to openclaw CLI (as array, never shell-interpolated)
+          const profileArgs: string[] = [];
+          if (options.dev) profileArgs.push("--dev");
+          else if (options.profile) {
+            // Validate profile name to prevent injection via spawn args
+            if (!/^[a-zA-Z0-9._-]+$/.test(options.profile)) {
+              ctx.logger.error("Invalid profile name — only alphanumeric, dots, hyphens, and underscores are allowed");
+              return;
+            }
+            profileArgs.push("--profile", options.profile);
+          }
+
+          // Helper: run openclaw CLI safely via spawnSync (no shell interpolation)
+          const oc = (cmdArgs: string[]) =>
+            spawnSync("openclaw", [...profileArgs, ...cmdArgs], { stdio: "pipe", encoding: "utf8" });
+
+          // Resolve extension dir from openclaw CLI if possible, else default
+          let extensionDir = join(home, ".openclaw", "extensions", "botcord");
+          try {
+            const result = oc(["config", "file"]);
+            const configFile = (result.stdout || "").trim();
+            if (configFile) {
+              const configDir = join(configFile, "..");
+              extensionDir = join(configDir, "extensions", "botcord");
+            }
+          } catch {
+            // fall back to default path
+          }
+
+          // Step 1: Disable plugin via OpenClaw CLI (safe — no JSON editing)
+          ctx.logger.info("Disabling BotCord plugin ...");
+          try {
+            const result = oc(["plugins", "disable", "botcord"]);
+            if (result.status === 0) {
+              ctx.logger.info("  Plugin disabled");
+            } else {
+              ctx.logger.warn("  Plugin was not enabled (or already disabled)");
+            }
+          } catch {
+            ctx.logger.warn("  Plugin was not enabled (or already disabled)");
+          }
+
+          // Step 2: Remove channel config via OpenClaw CLI if available
+          if (!options.keepChannel) {
+            ctx.logger.info("Removing channel configuration ...");
+            try {
+              const result = oc(["config", "unset", "channels.botcord"]);
+              if (result.status === 0) {
+                ctx.logger.info("  Channel config removed");
+              } else {
+                ctx.logger.warn("  Could not remove channel config via CLI — may need manual cleanup");
+                ctx.logger.warn("  If needed, remove 'channels.botcord' from openclaw.json");
+              }
+            } catch {
+              ctx.logger.warn("  Could not remove channel config via CLI — may need manual cleanup");
+              ctx.logger.warn("  If needed, remove 'channels.botcord' from openclaw.json");
+            }
+          } else {
+            ctx.logger.info("Keeping channel configuration (--keep-channel)");
+          }
+
+          // Step 3: Remove plugin files
+          if (existsSync(extensionDir)) {
+            ctx.logger.info(`Removing plugin files from ${extensionDir} ...`);
+            rmSync(extensionDir, { recursive: true, force: true });
+            ctx.logger.info("  Plugin files removed");
+          } else {
+            ctx.logger.info("  No plugin files found (already removed)");
+          }
+
+          // Step 4: Optionally purge credentials
+          if (options.purge) {
+            if (existsSync(credDir)) {
+              const files = readdirSync(credDir).filter((f: string) => f.endsWith(".json"));
+              if (files.length > 0) {
+                ctx.logger.info(`Deleting ${files.length} credential file(s) from ${credDir} ...`);
+                for (const f of files) {
+                  rmSync(join(credDir, f), { force: true });
+                  ctx.logger.info(`  Deleted ${f}`);
+                }
+              }
+            } else {
+              ctx.logger.info("  No credentials directory found");
+            }
+          } else {
+            // Show what's preserved
+            if (existsSync(credDir)) {
+              const files = readdirSync(credDir).filter((f: string) => f.endsWith(".json"));
+              if (files.length > 0) {
+                ctx.logger.info(`Credentials preserved in ${credDir} (${files.length} file(s))`);
+                ctx.logger.info("  Use --purge to also delete credentials");
+              }
+            }
+          }
+
+          ctx.logger.info("");
+          ctx.logger.info("BotCord plugin uninstalled.");
+          ctx.logger.info("Restart OpenClaw to apply: openclaw gateway restart");
+        });
+    },
+    commands: ["botcord-uninstall"],
+  };
+}

--- a/plugin/src/commands/uninstall.ts
+++ b/plugin/src/commands/uninstall.ts
@@ -43,7 +43,7 @@ export function createUninstallCli() {
           // Resolve extension dir from openclaw CLI if possible, else default
           let extensionDir = join(home, ".openclaw", "extensions", "botcord");
           try {
-            const result = oc(["config", "file"]);
+            const result = oc(["config", "path"]);
             const configFile = (result.stdout || "").trim();
             if (configFile) {
               const configDir = join(configFile, "..");


### PR DESCRIPTION
## Summary
- Add `openclaw botcord-uninstall` CLI command using OpenClaw plugin API
- Add external recovery shell script (`uninstall.sh`) for broken installations
- Uses spawnSync (not execSync) to prevent shell injection via --profile flag
- Supports --purge and --keep-channel flags

Extracted from #121.

## Test plan
- [ ] Test `openclaw botcord-uninstall` with default flags
- [ ] Test `openclaw botcord-uninstall --purge` deletes credentials
- [ ] Test `openclaw botcord-uninstall --keep-channel` preserves config
- [ ] Verify uninstall.sh template renders via public-docs API

🤖 Generated with [Claude Code](https://claude.com/claude-code)