### PR TITLE
refactor(plugin): migrate all tools to withClient + structured errors + dry-run

### DIFF
--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -17,6 +17,7 @@ import { createBindTool } from "./src/tools/bind.js";
 import { createRegisterTool } from "./src/tools/register.js";
 import { createResetCredentialTool } from "./src/tools/reset-credential.js";
 import { createWorkingMemoryTool } from "./src/tools/working-memory.js";
+import { createApiTool } from "./src/tools/api.js";
 import { createHealthcheckCommand } from "./src/commands/healthcheck.js";
 import { createTokenCommand } from "./src/commands/token.js";
 import { createBindCommand } from "./src/commands/bind.js";
@@ -63,6 +64,7 @@ export default {
     api.registerTool(createRegisterTool() as any);
     api.registerTool(createResetCredentialTool() as any);
     api.registerTool(createWorkingMemoryTool() as any);
+    api.registerTool(createApiTool() as any);
 
     // Hooks
     api.on("after_tool_call", async (event: any, ctx: any) => {

--- a/plugin/src/__tests__/api-tool.test.ts
+++ b/plugin/src/__tests__/api-tool.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { createApiTool } from "../tools/api.js";
+
+// Mock withClient to isolate tool validation logic from actual Hub calls
+const mockWithClient = vi.fn();
+vi.mock("../tools/with-client.js", () => ({
+  withClient: (...args: any[]) => mockWithClient(...args),
+}));
+
+describe("botcord_api tool", () => {
+  let tool: ReturnType<typeof createApiTool>;
+
+  beforeEach(() => {
+    tool = createApiTool();
+    mockWithClient.mockReset();
+    // Default: withClient invokes the callback with a mock client
+    mockWithClient.mockImplementation(async (fn: any) => {
+      const mockClient = {
+        request: vi.fn().mockResolvedValue({ ok: true }),
+      };
+      return fn(mockClient, {});
+    });
+  });
+
+  // ── Confirm gate ────────────────────────────────────────────
+
+  it("rejects write operations without confirm=true", async () => {
+    const result: any = await tool.execute("t1", {
+      method: "POST",
+      path: "/hub/send",
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error.code).toBe("confirmation_required");
+  });
+
+  it("allows write operations with confirm=true", async () => {
+    const result: any = await tool.execute("t1", {
+      method: "POST",
+      path: "/hub/send",
+      confirm: true,
+    });
+    expect(result.ok).not.toBe(false);
+  });
+
+  it("allows GET without confirm", async () => {
+    const result: any = await tool.execute("t1", {
+      method: "GET",
+      path: "/hub/inbox",
+    });
+    expect(result.ok).not.toBe(false);
+  });
+
+  // ── Disallowed prefixes ─────────────────────────────────────
+
+  it("rejects paths not starting with allowed prefixes", async () => {
+    const result: any = await tool.execute("t1", {
+      method: "GET",
+      path: "/admin/users",
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error.code).toBe("INVALID_INPUT");
+  });
+
+  it("rejects absolute external URLs", async () => {
+    const result: any = await tool.execute("t1", {
+      method: "GET",
+      path: "https://evil.com/hub/inbox",
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error.code).toBe("INVALID_INPUT");
+  });
+
+  it("rejects ftp:// scheme URLs", async () => {
+    const result: any = await tool.execute("t1", {
+      method: "GET",
+      path: "ftp://evil.com/hub/inbox",
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  // ── Query string in path ─────────────────────────────────────
+
+  it("rejects query string embedded in path", async () => {
+    const result: any = await tool.execute("t1", {
+      method: "GET",
+      path: "/hub/search?q=deploy",
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error.code).toBe("INVALID_INPUT");
+    expect(result.error.hint).toContain("query");
+  });
+
+  it("rejects path with query string even when query field is also provided", async () => {
+    const result: any = await tool.execute("t1", {
+      method: "GET",
+      path: "/hub/search?q=deploy",
+      query: { limit: "10" },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  // ── Encoded path traversal ─────────────────────────────────
+
+  it("rejects percent-encoded path traversal escaping to disallowed prefix", async () => {
+    // /hub/%2e%2e/admin/secret resolves to /admin/secret — not in allowed list
+    const result: any = await tool.execute("t1", {
+      method: "GET",
+      path: "/hub/%2e%2e/admin/secret",
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error.code).toBe("INVALID_INPUT");
+  });
+
+  it("rejects literal path traversal (..)", async () => {
+    const result: any = await tool.execute("t1", {
+      method: "GET",
+      path: "/hub/../admin/secret",
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects traversal even when resolved path lands on allowed prefix", async () => {
+    // /hub/%2e%2e/registry/agents/ag_x resolves to /registry/agents/ag_x
+    // This technically resolves to an allowed prefix, but the traversal
+    // means the user is trying to escape /hub/ — the resolved path check
+    // catches the prefix change. Since /registry/ is allowed, this passes
+    // — which is acceptable because the resolved path IS within bounds.
+    const result: any = await tool.execute("t1", {
+      method: "GET",
+      path: "/hub/%2e%2e/registry/agents/ag_x",
+    });
+    // This is OK — resolved path /registry/agents/ag_x is an allowed prefix
+    expect(result).toBeDefined();
+  });
+
+  it("rejects double-encoded traversal to disallowed path", async () => {
+    // /hub/%2e%2e/internal/ resolves via URL to /internal/ — not allowed
+    const result: any = await tool.execute("t1", {
+      method: "GET",
+      path: "/hub/%2e%2e/internal/config",
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  // ── Valid paths ─────────────────────────────────────────────
+
+  it("accepts valid /hub/ path", async () => {
+    const result: any = await tool.execute("t1", {
+      method: "GET",
+      path: "/hub/inbox",
+    });
+    expect(result.ok).not.toBe(false);
+  });
+
+  it("accepts valid /registry/ path", async () => {
+    const result: any = await tool.execute("t1", {
+      method: "GET",
+      path: "/registry/agents/ag_123",
+    });
+    expect(result.ok).not.toBe(false);
+  });
+
+  it("accepts valid /wallet/ path", async () => {
+    const result: any = await tool.execute("t1", {
+      method: "GET",
+      path: "/wallet/balance",
+    });
+    expect(result.ok).not.toBe(false);
+  });
+
+  // ── Normalized path forwarding ───────────────────────────────
+
+  it("forwards normalized path to client.request, not raw input", async () => {
+    let requestedPath: string | undefined;
+    mockWithClient.mockImplementation(async (fn: any) => {
+      const mockClient = {
+        request: vi.fn(async (_method: string, path: string) => {
+          requestedPath = path;
+          return { ok: true };
+        }),
+      };
+      return fn(mockClient, {});
+    });
+
+    // Path with duplicate slashes — should be collapsed
+    await tool.execute("t1", {
+      method: "GET",
+      path: "/hub///inbox",
+    });
+    expect(requestedPath).toBe("/hub/inbox");
+  });
+
+  // ── Missing required params ─────────────────────────────────
+
+  it("rejects missing method", async () => {
+    const result: any = await tool.execute("t1", { path: "/hub/inbox" });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects missing path", async () => {
+    const result: any = await tool.execute("t1", { method: "GET" });
+    expect(result.ok).toBe(false);
+  });
+});

--- a/plugin/src/__tests__/client-request.test.ts
+++ b/plugin/src/__tests__/client-request.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { BotCordClient } from "../client.js";
+
+// Capture the path passed to hubFetch
+let capturedPath: string;
+
+vi.mock("../runtime.js", () => ({
+  getBotCordRuntime: vi.fn(() => ({})),
+  getConfig: vi.fn(() => null),
+}));
+
+describe("BotCordClient.request() query serialization", () => {
+  let client: BotCordClient;
+
+  beforeEach(() => {
+    client = new BotCordClient({
+      hubUrl: "https://hub.test",
+      agentId: "ag_test",
+      keyId: "k_test",
+      privateKey: "deadbeef",
+    } as any);
+
+    // Stub hubFetch to capture the path
+    (client as any).hubFetch = vi.fn(async (path: string, _init: RequestInit) => {
+      capturedPath = path;
+      return {
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ ok: true }),
+      };
+    });
+  });
+
+  it("serializes repeated query parameters", async () => {
+    await client.request("GET", "/hub/search", {
+      query: { q: ["deploy", "release"] as any },
+    });
+    // Should produce q=deploy&q=release, not q=deploy%2Crelease
+    expect(capturedPath).toBe("/hub/search?q=deploy&q=release");
+  });
+
+  it("serializes single string query parameters", async () => {
+    await client.request("GET", "/hub/rooms", {
+      query: { limit: "10", offset: "0" },
+    });
+    expect(capturedPath).toBe("/hub/rooms?limit=10&offset=0");
+  });
+
+  it("merges query params when path already has a query string", async () => {
+    await client.request("GET", "/hub/rooms?type=public", {
+      query: { limit: "10" },
+    });
+    // Should use & separator, not ?
+    expect(capturedPath).toBe("/hub/rooms?type=public&limit=10");
+  });
+
+  it("handles no query params", async () => {
+    await client.request("GET", "/hub/inbox");
+    expect(capturedPath).toBe("/hub/inbox");
+  });
+});

--- a/plugin/src/__tests__/directory.integration.test.ts
+++ b/plugin/src/__tests__/directory.integration.test.ts
@@ -70,7 +70,7 @@ describe("directory tool integration", () => {
       limit: 15,
     });
 
-    expect((result as any).messages).toEqual([]);
+    expect((result as any).history).toEqual({ messages: [] });
     expect(hub.state.lastHistoryQuery).toEqual({
       peer: "ag_peer",
       room_id: "rm_room",

--- a/plugin/src/client.ts
+++ b/plugin/src/client.ts
@@ -222,12 +222,20 @@ export class BotCordClient {
   async request(
     method: string,
     path: string,
-    options?: { body?: unknown; query?: Record<string, string> },
+    options?: { body?: unknown; query?: Record<string, string | string[]> },
   ): Promise<unknown> {
     let fullPath = path;
     if (options?.query) {
-      const params = new URLSearchParams(options.query);
-      fullPath = `${path}?${params}`;
+      const params = new URLSearchParams();
+      for (const [key, val] of Object.entries(options.query)) {
+        if (Array.isArray(val)) {
+          for (const v of val) params.append(key, v);
+        } else {
+          params.append(key, val);
+        }
+      }
+      const sep = path.includes("?") ? "&" : "?";
+      fullPath = `${path}${sep}${params}`;
     }
     const init: RequestInit = { method };
     if (options?.body !== undefined) {

--- a/plugin/src/client.ts
+++ b/plugin/src/client.ts
@@ -30,6 +30,36 @@ import type {
 const MAX_RETRIES = 2;
 const RETRY_BASE_MS = 1000;
 
+/**
+ * Typed error thrown by BotCordClient for non-ok HTTP responses.
+ * Carries the HTTP status and an optional error code parsed from the response body.
+ */
+export class HubApiError extends Error {
+  readonly status: number;
+  readonly code: string | undefined;
+
+  constructor(status: number, body: string, path: string) {
+    super(`BotCord ${path} failed: ${status} ${body}`);
+    this.name = "HubApiError";
+    this.status = status;
+    this.code = HubApiError.parseCode(body);
+  }
+
+  private static parseCode(body: string): string | undefined {
+    try {
+      const parsed = JSON.parse(body);
+      // Hub returns { "detail": "BLOCKED" } or { "code": "NOT_IN_CONTACTS" }
+      if (typeof parsed.code === "string") return parsed.code;
+      if (typeof parsed.detail === "string" && /^[A-Z_]+$/.test(parsed.detail)) return parsed.detail;
+    } catch {
+      // Not JSON — try to extract an all-caps code from the raw body
+      const match = body.match(/\b([A-Z][A-Z_]{2,})\b/);
+      if (match) return match[1];
+    }
+    return undefined;
+  }
+}
+
 export class BotCordClient {
   private hubUrl: string;
   private agentId: string;
@@ -178,11 +208,47 @@ export class BotCordClient {
       }
 
       const body = await resp.text().catch(() => "");
-      const err = new Error(`BotCord ${path} failed: ${resp.status} ${body}`);
-      (err as any).status = resp.status;
-      throw err;
+      throw new HubApiError(resp.status, body, path);
     }
     throw new Error(`BotCord ${path} failed: exhausted retries`);
+  }
+
+  // ── Raw API access ──────────────────────────────────────────
+
+  /**
+   * Execute an arbitrary authenticated request against the Hub API.
+   * Returns the parsed JSON response body.
+   */
+  async request(
+    method: string,
+    path: string,
+    options?: { body?: unknown; query?: Record<string, string> },
+  ): Promise<unknown> {
+    let fullPath = path;
+    if (options?.query) {
+      const params = new URLSearchParams(options.query);
+      fullPath = `${path}?${params}`;
+    }
+    const init: RequestInit = { method };
+    if (options?.body !== undefined) {
+      init.body = JSON.stringify(options.body);
+    }
+    const resp = await this.hubFetch(fullPath, init);
+    const text = await resp.text();
+    // Guard against unexpectedly large responses (1MB cap for raw API use)
+    const MAX_RESPONSE_SIZE = 1024 * 1024;
+    if (text.length > MAX_RESPONSE_SIZE) {
+      throw new HubApiError(
+        resp.status,
+        `Response too large (${(text.length / 1024).toFixed(0)}KB > 1MB limit)`,
+        fullPath,
+      );
+    }
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
   }
 
   // ── File upload ──────────────────────────────────────────────

--- a/plugin/src/commands/bind.ts
+++ b/plugin/src/commands/bind.ts
@@ -19,10 +19,11 @@ export function createBindCommand() {
         return { text: "[FAIL] Usage: /botcord_bind <bind_code_or_bind_ticket>" };
       }
 
-      const result = await executeBind(bindCredential);
+      const result = await executeBind(bindCredential) as Record<string, unknown>;
 
-      if ("error" in result) {
-        return { text: `[FAIL] ${result.error}` };
+      if (!result.ok) {
+        const err = (result.error as { message?: string })?.message || "Unknown error";
+        return { text: `[FAIL] ${err}` };
       }
 
       const agentId = result.agent_id || "unknown";

--- a/plugin/src/tools/account.ts
+++ b/plugin/src/tools/account.ts
@@ -1,14 +1,8 @@
 /**
  * botcord_account — Manage the agent's own identity, profile, and settings.
  */
-import {
-  getSingleAccountModeError,
-  resolveAccountConfig,
-  isAccountConfigured,
-} from "../config.js";
-import { BotCordClient } from "../client.js";
-import { attachTokenPersistence } from "../credentials.js";
-import { getConfig as getAppConfig } from "../runtime.js";
+import { withClient } from "./with-client.js";
+import { validationError, dryRunResult } from "./tool-result.js";
 
 export function createAccountTool() {
   return {
@@ -41,35 +35,25 @@ export function createAccountTool() {
           type: "string" as const,
           description: "Message ID — for message_status",
         },
+        dry_run: {
+          type: "boolean" as const,
+          description: "Preview the request without executing. Returns the API call that would be made.",
+        },
       },
       required: ["action"],
     },
     execute: async (toolCallId: any, args: any, signal?: any, onUpdate?: any) => {
-      const cfg = getAppConfig();
-      if (!cfg) return { error: "No configuration available" };
-      const singleAccountError = getSingleAccountModeError(cfg);
-      if (singleAccountError) return { error: singleAccountError };
-
-      const acct = resolveAccountConfig(cfg);
-      if (!isAccountConfigured(acct)) {
-        return { error: "BotCord is not configured." };
-      }
-
-      const client = new BotCordClient(acct);
-      attachTokenPersistence(client, acct);
-
-      try {
+      return withClient(async (client) => {
         switch (args.action) {
           case "whoami":
             return await client.resolve(client.getAgentId());
 
           case "update_profile": {
-            if (!args.display_name && !args.bio) {
-              return { error: "At least one of display_name or bio is required" };
-            }
+            if (!args.display_name && !args.bio) return validationError("At least one of display_name or bio is required");
             const params: { display_name?: string; bio?: string } = {};
             if (args.display_name) params.display_name = args.display_name;
             if (args.bio) params.bio = args.bio;
+            if (args.dry_run) return dryRunResult("PATCH", `/registry/agents/${client.getAgentId()}/profile`, params);
             await client.updateProfile(params);
             return { ok: true, updated: params };
           }
@@ -77,21 +61,21 @@ export function createAccountTool() {
           case "get_policy":
             return await client.getPolicy();
 
-          case "set_policy":
-            if (!args.policy) return { error: "policy is required (open or contacts_only)" };
+          case "set_policy": {
+            if (!args.policy) return validationError("policy is required (open or contacts_only)");
+            if (args.dry_run) return dryRunResult("PATCH", `/registry/agents/${client.getAgentId()}/policy`, { message_policy: args.policy });
             await client.setPolicy(args.policy);
             return { ok: true, policy: args.policy };
+          }
 
           case "message_status":
-            if (!args.msg_id) return { error: "msg_id is required" };
+            if (!args.msg_id) return validationError("msg_id is required");
             return await client.getMessageStatus(args.msg_id);
 
           default:
-            return { error: `Unknown action: ${args.action}` };
+            return validationError(`Unknown action: ${args.action}`);
         }
-      } catch (err: any) {
-        return { error: `Account action failed: ${err.message}` };
-      }
+      });
     },
   };
 }

--- a/plugin/src/tools/api.ts
+++ b/plugin/src/tools/api.ts
@@ -1,0 +1,112 @@
+/**
+ * botcord_api — Raw Hub API access for advanced use cases.
+ *
+ * This is the "escape hatch" tool: when the structured tools don't cover
+ * a particular endpoint, agents can call the Hub API directly.
+ */
+import { withClient } from "./with-client.js";
+import { validationError } from "./tool-result.js";
+
+export function createApiTool() {
+  return {
+    name: "botcord_api",
+    label: "Raw API",
+    description:
+      "Execute a raw authenticated request against the BotCord Hub API. " +
+      "Use this when the structured tools (botcord_send, botcord_rooms, etc.) " +
+      "don't cover the endpoint you need. The request is automatically authenticated with your agent's JWT.",
+    parameters: {
+      type: "object" as const,
+      properties: {
+        method: {
+          type: "string" as const,
+          enum: ["GET", "POST", "PUT", "PATCH", "DELETE"],
+          description: "HTTP method",
+        },
+        path: {
+          type: "string" as const,
+          description: "API path (e.g. /hub/inbox, /registry/agents/ag_xxx)",
+        },
+        query: {
+          type: "object" as const,
+          description: "Query parameters as key-value pairs",
+        },
+        data: {
+          type: "object" as const,
+          description: "Request body (for POST/PUT/PATCH)",
+        },
+        confirm: {
+          type: "boolean" as const,
+          description: "Must be true for write operations (POST/PUT/PATCH/DELETE). Safety gate to prevent unintended mutations.",
+        },
+      },
+      required: ["method", "path"],
+    },
+    execute: async (toolCallId: any, args: any, signal?: any, onUpdate?: any) => {
+      if (!args.method) return validationError("method is required");
+      if (!args.path) return validationError("path is required");
+
+      const method = (args.method as string).toUpperCase();
+      const path = args.path as string;
+
+      // Validate path to prevent SSRF / path traversal.
+      const ALLOWED_PREFIXES = ["/hub/", "/registry/", "/wallet/", "/subscriptions/", "/app/"];
+
+      // Reject absolute URLs (scheme://...) — path must be relative to Hub
+      if (/^[a-z][a-z0-9+.-]*:/i.test(path)) {
+        return validationError(
+          "Absolute URLs are not allowed — provide a path like /hub/inbox",
+          "Path traversal and arbitrary URLs are not allowed.",
+        );
+      }
+
+      // Reject query strings embedded in path — callers must use the query field.
+      // URL normalization strips ?… from path, so silently accepting them would
+      // drop parameters the caller intended to send.
+      if (path.includes("?")) {
+        return validationError(
+          "Query strings in path are not allowed — use the query parameter instead",
+          'e.g. path: "/hub/search", query: { q: "deploy" }',
+        );
+      }
+
+      // Resolve against dummy base to normalize percent-encoded traversal
+      // (e.g. /%2e%2e/ → /../ → resolved away by URL constructor)
+      let resolvedPath: string;
+      try {
+        resolvedPath = new URL(path, "http://localhost").pathname;
+      } catch {
+        return validationError("Invalid path", "Could not parse the provided path as a URL.");
+      }
+      const normalized = resolvedPath.replace(/\/+/g, "/"); // collapse duplicate slashes
+      if (normalized.includes("..") || !ALLOWED_PREFIXES.some((p) => normalized.startsWith(p))) {
+        return validationError(
+          `path must start with one of: ${ALLOWED_PREFIXES.join(", ")}`,
+          "Path traversal and arbitrary URLs are not allowed.",
+        );
+      }
+
+      // Write operations require explicit confirmation via confirm param
+      if (method !== "GET" && !args.confirm) {
+        return {
+          ok: false,
+          error: {
+            type: "validation" as const,
+            code: "confirmation_required",
+            message: `${method} ${path} is a write operation — set confirm: true to proceed`,
+            hint: "Raw API write operations bypass structured tool safeguards. Review the request carefully before confirming.",
+          },
+        };
+      }
+
+      return withClient(async (client) => {
+        // Use the normalized path so the request matches what was validated
+        const result = await client.request(method, normalized, {
+          body: args.data,
+          query: args.query,
+        });
+        return { response: result };
+      });
+    },
+  };
+}

--- a/plugin/src/tools/bind.ts
+++ b/plugin/src/tools/bind.ts
@@ -4,44 +4,26 @@
  * [POS]: plugin dashboard 认领执行器，把命令行参数翻译成稳定的绑定请求
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
-import {
-  getSingleAccountModeError,
-  resolveAccountConfig,
-  isAccountConfigured,
-} from "../config.js";
-import { BotCordClient } from "../client.js";
-import { attachTokenPersistence } from "../credentials.js";
-import { getConfig as getAppConfig } from "../runtime.js";
+import { withClient } from "./with-client.js";
+import { validationError } from "./tool-result.js";
+import { HubApiError } from "../client.js";
 
 /**
  * Shared bind logic used by both the tool and the command.
  */
 export async function executeBind(
   bindCredential: string,
-): Promise<{ ok: true; [key: string]: unknown } | { error: string }> {
-  const cfg = getAppConfig();
-  if (!cfg) return { error: "No configuration available" };
-  const singleAccountError = getSingleAccountModeError(cfg);
-  if (singleAccountError) return { error: singleAccountError };
-
-  const acct = resolveAccountConfig(cfg);
-  if (!isAccountConfigured(acct)) {
-    return { error: "BotCord is not configured." };
-  }
-
-  const client = new BotCordClient(acct);
-  attachTokenPersistence(client, acct);
-
-  try {
+) {
+  return withClient(async (client) => {
     const agentToken = await client.ensureToken();
     const agentId = client.getAgentId();
 
     const resolved = (await client.resolve(agentId)) as Record<string, unknown>;
     const displayName = (resolved.display_name as string) || agentId;
 
-    const hubUrl = client.getHubUrl();
+    const baseUrl = client.getHubUrl().replace(/\/+$/, "");
 
-    const res = await fetch(`${hubUrl}/api/users/me/agents/bind`, {
+    const res = await fetch(`${baseUrl}/api/users/me/agents/bind`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -59,13 +41,11 @@ export async function executeBind(
 
     if (!res.ok) {
       const msg = body?.error || body?.detail || body?.message || res.statusText;
-      return { error: `Bind failed (${res.status}): ${msg}` };
+      throw new HubApiError(res.status, JSON.stringify({ detail: msg }), "/api/users/me/agents/bind");
     }
 
     return { ok: true, ...body };
-  } catch (err: any) {
-    return { error: `Bind failed: ${err.message}` };
-  }
+  });
 }
 
 export function createBindTool() {
@@ -86,7 +66,7 @@ export function createBindTool() {
     },
     execute: async (toolCallId: any, args: any, signal?: any, onUpdate?: any) => {
       if (!args.bind_ticket) {
-        return { error: "bind_ticket is required" };
+        return validationError("bind_ticket is required");
       }
       return executeBind(args.bind_ticket);
     },

--- a/plugin/src/tools/contacts.ts
+++ b/plugin/src/tools/contacts.ts
@@ -1,14 +1,8 @@
 /**
  * botcord_contacts — Manage social relationships: contacts, requests, blocks.
  */
-import {
-  getSingleAccountModeError,
-  resolveAccountConfig,
-  isAccountConfigured,
-} from "../config.js";
-import { BotCordClient } from "../client.js";
-import { attachTokenPersistence } from "../credentials.js";
-import { getConfig as getAppConfig } from "../runtime.js";
+import { withClient } from "./with-client.js";
+import { validationError, dryRunResult } from "./tool-result.js";
 
 export function createContactsTool() {
   return {
@@ -56,69 +50,66 @@ export function createContactsTool() {
           enum: ["pending", "accepted", "rejected"],
           description: "Filter by state — for received_requests, sent_requests",
         },
+        dry_run: {
+          type: "boolean" as const,
+          description: "Preview the request without executing. Returns the API call that would be made.",
+        },
       },
       required: ["action"],
     },
     execute: async (toolCallId: any, args: any, signal?: any, onUpdate?: any) => {
-      const cfg = getAppConfig();
-      if (!cfg) return { error: "No configuration available" };
-      const singleAccountError = getSingleAccountModeError(cfg);
-      if (singleAccountError) return { error: singleAccountError };
-
-      const acct = resolveAccountConfig(cfg);
-      if (!isAccountConfigured(acct)) {
-        return { error: "BotCord is not configured." };
-      }
-
-      const client = new BotCordClient(acct);
-      attachTokenPersistence(client, acct);
-
-      try {
+      return withClient(async (client) => {
         switch (args.action) {
           case "list":
-            return await client.listContacts();
+            return { contacts: await client.listContacts() };
 
           case "remove":
-            if (!args.agent_id) return { error: "agent_id is required" };
+            if (!args.agent_id) return validationError("agent_id is required");
+            if (args.dry_run) return dryRunResult("DELETE", `/registry/agents/{self}/contacts/${args.agent_id}`);
             await client.removeContact(args.agent_id);
             return { ok: true, removed: args.agent_id };
 
           case "send_request":
-            if (!args.agent_id) return { error: "agent_id is required" };
+            if (!args.agent_id) return validationError("agent_id is required");
+            if (args.dry_run) return dryRunResult("POST", "/hub/send", { to: args.agent_id, type: "contact_request", payload: args.message ? { text: args.message } : {} });
             await client.sendContactRequest(args.agent_id, args.message);
             return { ok: true, sent_to: args.agent_id };
 
           case "received_requests":
-            return await client.listReceivedRequests(args.state);
+            return { requests: await client.listReceivedRequests(args.state) };
 
           case "sent_requests":
-            return await client.listSentRequests(args.state);
+            return { requests: await client.listSentRequests(args.state) };
 
           case "accept_request":
-            if (!args.request_id) return { error: "request_id is required" };
+            if (!args.request_id) return validationError("request_id is required");
+            if (args.dry_run) return dryRunResult("POST", `/registry/agents/{self}/contact-requests/${args.request_id}/accept`);
             await client.acceptRequest(args.request_id);
             return { ok: true, accepted: args.request_id };
 
           case "reject_request":
-            if (!args.request_id) return { error: "request_id is required" };
+            if (!args.request_id) return validationError("request_id is required");
+            if (args.dry_run) return dryRunResult("POST", `/registry/agents/{self}/contact-requests/${args.request_id}/reject`);
             await client.rejectRequest(args.request_id);
             return { ok: true, rejected: args.request_id };
 
           case "block":
-            if (!args.agent_id) return { error: "agent_id is required" };
+            if (!args.agent_id) return validationError("agent_id is required");
+            if (args.dry_run) return dryRunResult("POST", `/registry/agents/{self}/blocks`, { blocked_agent_id: args.agent_id });
             await client.blockAgent(args.agent_id);
             return { ok: true, blocked: args.agent_id };
 
           case "unblock":
-            if (!args.agent_id) return { error: "agent_id is required" };
+            if (!args.agent_id) return validationError("agent_id is required");
+            if (args.dry_run) return dryRunResult("DELETE", `/registry/agents/{self}/blocks/${args.agent_id}`);
             await client.unblockAgent(args.agent_id);
             return { ok: true, unblocked: args.agent_id };
 
           case "list_blocks":
-            return await client.listBlocks();
+            return { blocks: await client.listBlocks() };
 
           case "redeem_invite": {
-            if (!args.invite_code) return { error: "invite_code is required" };
+            if (!args.invite_code) return validationError("invite_code is required");
             // Extract code from full URL if needed (e.g. .../invites/iv_xxx/redeem or /i/iv_xxx)
             const raw = args.invite_code as string;
             const match = raw.match(/\b(iv_[a-zA-Z0-9]+)/);
@@ -127,11 +118,9 @@ export function createContactsTool() {
           }
 
           default:
-            return { error: `Unknown action: ${args.action}` };
+            return validationError(`Unknown action: ${args.action}`);
         }
-      } catch (err: any) {
-        return { error: `Contact action failed: ${err.message}` };
-      }
+      });
     },
   };
 }

--- a/plugin/src/tools/contacts.ts
+++ b/plugin/src/tools/contacts.ts
@@ -71,7 +71,7 @@ export function createContactsTool() {
 
           case "send_request":
             if (!args.agent_id) return validationError("agent_id is required");
-            if (args.dry_run) return dryRunResult("POST", "/hub/send", { to: args.agent_id, type: "contact_request", payload: args.message ? { text: args.message } : {} });
+            if (args.dry_run) return dryRunResult("POST", "/hub/send", { to: args.agent_id, type: "contact_request", payload: args.message ? { text: args.message } : {} }, { note: "The actual body is a signed envelope (JCS + Ed25519), not the raw fields shown here." });
             await client.sendContactRequest(args.agent_id, args.message);
             return { ok: true, sent_to: args.agent_id };
 

--- a/plugin/src/tools/directory.ts
+++ b/plugin/src/tools/directory.ts
@@ -64,7 +64,7 @@ export function createDirectoryTool() {
             return await client.resolve(args.agent_id);
 
           case "discover_rooms":
-            return { rooms: await client.discoverRooms(args.room_name) };
+            return await client.discoverPublicRooms(args.room_name);
 
           case "history":
             return { history: await client.getHistory({

--- a/plugin/src/tools/directory.ts
+++ b/plugin/src/tools/directory.ts
@@ -1,14 +1,8 @@
 /**
  * botcord_directory — Read-only queries: resolve agents, discover rooms, message history.
  */
-import {
-  getSingleAccountModeError,
-  resolveAccountConfig,
-  isAccountConfigured,
-} from "../config.js";
-import { BotCordClient } from "../client.js";
-import { attachTokenPersistence } from "../credentials.js";
-import { getConfig as getAppConfig } from "../runtime.js";
+import { withClient } from "./with-client.js";
+import { validationError } from "./tool-result.js";
 
 export function createDirectoryTool() {
   return {
@@ -63,30 +57,17 @@ export function createDirectoryTool() {
       required: ["action"],
     },
     execute: async (toolCallId: any, args: any, signal?: any, onUpdate?: any) => {
-      const cfg = getAppConfig();
-      if (!cfg) return { error: "No configuration available" };
-      const singleAccountError = getSingleAccountModeError(cfg);
-      if (singleAccountError) return { error: singleAccountError };
-
-      const acct = resolveAccountConfig(cfg);
-      if (!isAccountConfigured(acct)) {
-        return { error: "BotCord is not configured." };
-      }
-
-      const client = new BotCordClient(acct);
-      attachTokenPersistence(client, acct);
-
-      try {
+      return withClient(async (client) => {
         switch (args.action) {
           case "resolve":
-            if (!args.agent_id) return { error: "agent_id is required" };
+            if (!args.agent_id) return validationError("agent_id is required");
             return await client.resolve(args.agent_id);
 
           case "discover_rooms":
-            return await client.discoverPublicRooms(args.room_name);
+            return { rooms: await client.discoverRooms(args.room_name) };
 
           case "history":
-            return await client.getHistory({
+            return { history: await client.getHistory({
               peer: args.peer,
               roomId: args.room_id,
               topic: args.topic,
@@ -94,14 +75,12 @@ export function createDirectoryTool() {
               before: args.before,
               after: args.after,
               limit: args.limit || 20,
-            });
+            }) };
 
           default:
-            return { error: `Unknown action: ${args.action}` };
+            return validationError(`Unknown action: ${args.action}`);
         }
-      } catch (err: any) {
-        return { error: `Directory action failed: ${err.message}` };
-      }
+      });
     },
   };
 }

--- a/plugin/src/tools/messaging.ts
+++ b/plugin/src/tools/messaging.ts
@@ -138,7 +138,10 @@ export function createMessagingTool() {
         if (args.mentions) body.mentions = args.mentions;
         if (args.file_paths) body.file_paths = args.file_paths;
         if (args.file_urls) body.file_urls = args.file_urls;
-        return dryRunResult("POST", "/hub/send", body);
+        const notes: string[] = [];
+        if (args.file_paths?.length) notes.push("Local files will be uploaded via POST /hub/upload before sending.");
+        notes.push("The actual body is a signed envelope (JCS + Ed25519), not the raw fields shown here.");
+        return dryRunResult("POST", "/hub/send", body, { note: notes.join(" ") });
       }
 
       return withClient(async (client) => {

--- a/plugin/src/tools/messaging.ts
+++ b/plugin/src/tools/messaging.ts
@@ -3,15 +3,9 @@
  */
 import { readFile } from "node:fs/promises";
 import { basename } from "node:path";
-import { lookup } from "node:dns";
-import {
-  getSingleAccountModeError,
-  resolveAccountConfig,
-  isAccountConfigured,
-} from "../config.js";
-import { BotCordClient } from "../client.js";
-import { attachTokenPersistence } from "../credentials.js";
-import { getConfig as getAppConfig } from "../runtime.js";
+import { withClient } from "./with-client.js";
+import { validationError, dryRunResult } from "./tool-result.js";
+import type { BotCordClient } from "../client.js";
 import type { MessageAttachment } from "../types.js";
 
 /** Extract clean filename from a URL, stripping query string and hash. */
@@ -127,23 +121,27 @@ export function createMessagingTool() {
           items: { type: "string" as const },
           description: "URLs of already-hosted files to attach to the message",
         },
+        dry_run: {
+          type: "boolean" as const,
+          description: "Preview the request without sending. Returns the API call that would be made.",
+        },
       },
       required: ["to", "text"],
     },
     execute: async (toolCallId: any, args: any, signal?: any, onUpdate?: any) => {
-      const cfg = getAppConfig();
-      if (!cfg) return { error: "No configuration available" };
-      const singleAccountError = getSingleAccountModeError(cfg);
-      if (singleAccountError) return { error: singleAccountError };
-
-      const acct = resolveAccountConfig(cfg);
-      if (!isAccountConfigured(acct)) {
-        return { error: "BotCord is not configured. Set hubUrl, agentId, keyId, and privateKey." };
+      if (args.dry_run) {
+        const msgType = args.type || "message";
+        const body: Record<string, unknown> = { to: args.to, text: args.text, type: msgType };
+        if (args.topic) body.topic = args.topic;
+        if (args.goal) body.goal = args.goal;
+        if (args.reply_to) body.reply_to = args.reply_to;
+        if (args.mentions) body.mentions = args.mentions;
+        if (args.file_paths) body.file_paths = args.file_paths;
+        if (args.file_urls) body.file_urls = args.file_urls;
+        return dryRunResult("POST", "/hub/send", body);
       }
 
-      try {
-        const client = new BotCordClient(acct);
-        attachTokenPersistence(client, acct);
+      return withClient(async (client) => {
         const msgType = args.type || "message";
 
         // Collect attachments from both file_paths (upload first) and file_urls
@@ -182,9 +180,7 @@ export function createMessagingTool() {
           attachments: finalAttachments,
         });
         return { ok: true, hub_msg_id: result.hub_msg_id, to: args.to, type: msgType, attachments: finalAttachments };
-      } catch (err: any) {
-        return { error: `Failed to send: ${err.message}` };
-      }
+      });
     },
   };
 }
@@ -212,28 +208,14 @@ export function createUploadTool() {
       required: ["file_paths"],
     },
     execute: async (toolCallId: any, args: any, signal?: any, onUpdate?: any) => {
-      const cfg = getAppConfig();
-      if (!cfg) return { error: "No configuration available" };
-      const singleAccountError = getSingleAccountModeError(cfg);
-      if (singleAccountError) return { error: singleAccountError };
-
-      const acct = resolveAccountConfig(cfg);
-      if (!isAccountConfigured(acct)) {
-        return { error: "BotCord is not configured. Set hubUrl, agentId, keyId, and privateKey." };
-      }
-
       if (!args.file_paths || args.file_paths.length === 0) {
-        return { error: "file_paths is required and must not be empty" };
+        return validationError("file_paths is required and must not be empty");
       }
 
-      try {
-        const client = new BotCordClient(acct);
-        attachTokenPersistence(client, acct);
+      return withClient(async (client) => {
         const uploaded = await uploadLocalFiles(client, args.file_paths);
         return { ok: true, files: uploaded };
-      } catch (err: any) {
-        return { error: `Upload failed: ${err.message}` };
-      }
+      });
     },
   };
 }

--- a/plugin/src/tools/payment.ts
+++ b/plugin/src/tools/payment.ts
@@ -1,14 +1,8 @@
 /**
  * botcord_payment — Unified payment and transaction tool for BotCord coin flows.
  */
-import {
-  getSingleAccountModeError,
-  resolveAccountConfig,
-  isAccountConfigured,
-} from "../config.js";
-import { BotCordClient } from "../client.js";
-import { attachTokenPersistence } from "../credentials.js";
-import { getConfig as getAppConfig } from "../runtime.js";
+import { withClient } from "./with-client.js";
+import { validationError, dryRunResult } from "./tool-result.js";
 import { formatCoinAmount, parseCoinToMinor } from "./coin-format.js";
 import { executeTransfer, isPeerContact, formatFollowUpDeliverySummary } from "./payment-transfer.js";
 
@@ -287,27 +281,18 @@ export function createPaymentTool(opts?: { name?: string; description?: string }
           type: "string" as const,
           description: "Filter by transaction type — for ledger",
         },
+        dry_run: {
+          type: "boolean" as const,
+          description: "Preview the request without executing. Returns the API call that would be made.",
+        },
       },
       required: ["action"],
     },
     execute: async (_toolCallId: any, args: any) => {
-      const cfg = getAppConfig();
-      if (!cfg) return { error: "No configuration available" };
-      const singleAccountError = getSingleAccountModeError(cfg);
-      if (singleAccountError) return { error: singleAccountError };
-
-      const acct = resolveAccountConfig(cfg);
-      if (!isAccountConfigured(acct)) {
-        return { error: "BotCord is not configured." };
-      }
-
-      const client = new BotCordClient(acct);
-      attachTokenPersistence(client, acct);
-
-      try {
+      return withClient(async (client) => {
         switch (args.action) {
           case "recipient_verify": {
-            if (!args.agent_id) return { error: "agent_id is required" };
+            if (!args.agent_id) return validationError("agent_id is required");
             const agent = await client.resolve(args.agent_id);
             return { result: formatRecipient(agent), data: agent };
           }
@@ -327,10 +312,11 @@ export function createPaymentTool(opts?: { name?: string; description?: string }
           }
 
           case "transfer": {
-            if (!args.to_agent_id) return { error: "to_agent_id is required" };
-            if (!args.amount) return { error: "amount is required" };
+            if (!args.to_agent_id) return validationError("to_agent_id is required");
+            if (!args.amount) return validationError("amount is required");
             const transferMinor = parseCoinToMinor(args.amount);
-            if (transferMinor === null) return { error: "amount must be a valid number (e.g. \"10\" or \"9.50\")" };
+            if (transferMinor === null) return validationError("amount must be a valid number (e.g. \"10\" or \"9.50\")");
+            if (args.dry_run) return dryRunResult("POST", "/wallet/transfers", { to_agent_id: args.to_agent_id, amount_minor: transferMinor, memo: args.memo });
 
             const isContact = await isPeerContact(client, args.to_agent_id);
             if (!isContact && args.confirmed !== true) {
@@ -355,9 +341,11 @@ export function createPaymentTool(opts?: { name?: string; description?: string }
           }
 
           case "topup": {
-            if (!args.amount) return { error: "amount is required" };
+            if (!args.amount) return validationError("amount is required");
             const topupMinor = parseCoinToMinor(args.amount);
-            if (topupMinor === null) return { error: "amount must be a valid number (e.g. \"10\" or \"9.50\")" };
+            if (topupMinor === null) return validationError("amount must be a valid number (e.g. \"10\" or \"9.50\")");
+            if (args.dry_run) return dryRunResult("POST", "/wallet/topups", { amount_minor: topupMinor, channel: args.channel });
+
             const topup = await client.createTopup({
               amount_minor: topupMinor,
               channel: args.channel,
@@ -368,14 +356,16 @@ export function createPaymentTool(opts?: { name?: string; description?: string }
           }
 
           case "withdraw": {
-            if (!args.amount) return { error: "amount is required" };
+            if (!args.amount) return validationError("amount is required");
             const withdrawMinor = parseCoinToMinor(args.amount);
-            if (withdrawMinor === null) return { error: "amount must be a valid number (e.g. \"10\" or \"9.50\")" };
+            if (withdrawMinor === null) return validationError("amount must be a valid number (e.g. \"10\" or \"9.50\")");
             let feeMinor: string | undefined;
             if (args.fee) {
               feeMinor = parseCoinToMinor(args.fee) ?? undefined;
-              if (feeMinor === undefined) return { error: "fee must be a valid number (e.g. \"1\" or \"0.50\")" };
+              if (feeMinor === undefined) return validationError("fee must be a valid number (e.g. \"1\" or \"0.50\")");
             }
+            if (args.dry_run) return dryRunResult("POST", "/wallet/withdrawals", { amount_minor: withdrawMinor, destination_type: args.destination_type });
+
             const withdrawal = await client.createWithdrawal({
               amount_minor: withdrawMinor,
               fee_minor: feeMinor,
@@ -387,23 +377,23 @@ export function createPaymentTool(opts?: { name?: string; description?: string }
           }
 
           case "cancel_withdrawal": {
-            if (!args.withdrawal_id) return { error: "withdrawal_id is required" };
+            if (!args.withdrawal_id) return validationError("withdrawal_id is required");
+            if (args.dry_run) return dryRunResult("POST", `/wallet/withdrawals/${args.withdrawal_id}/cancel`);
+
             const withdrawal = await client.cancelWithdrawal(args.withdrawal_id);
             return { result: formatWithdrawal(withdrawal), data: sanitizeWithdrawal(withdrawal) };
           }
 
           case "tx_status": {
-            if (!args.tx_id) return { error: "tx_id is required" };
+            if (!args.tx_id) return validationError("tx_id is required");
             const tx = await client.getWalletTransaction(args.tx_id);
             return { result: formatTransaction(tx), data: sanitizeTransaction(tx) };
           }
 
           default:
-            return { error: `Unknown action: ${args.action}` };
+            return validationError(`Unknown action: ${args.action}`);
         }
-      } catch (err: any) {
-        return { error: `Payment action failed: ${err.message}` };
-      }
+      });
     },
   };
 }

--- a/plugin/src/tools/register.ts
+++ b/plugin/src/tools/register.ts
@@ -4,6 +4,7 @@
 import { registerAgent } from "../commands/register.js";
 import { getConfig as getAppConfig } from "../runtime.js";
 import { DEFAULT_HUB } from "../constants.js";
+import { validationError, configError, classifyError } from "./tool-result.js";
 
 export function createRegisterTool() {
   return {
@@ -35,11 +36,11 @@ export function createRegisterTool() {
     },
     execute: async (toolCallId: any, args: any, signal?: any, onUpdate?: any) => {
       if (!args.name) {
-        return { error: "name is required" };
+        return validationError("name is required");
       }
 
       const cfg = getAppConfig();
-      if (!cfg) return { error: "No configuration available" };
+      if (!cfg) return configError("No configuration available");
 
       try {
         const result = await registerAgent({
@@ -59,8 +60,8 @@ export function createRegisterTool() {
           claim_url: result.claimUrl,
           note: "Restart OpenClaw to activate: openclaw gateway restart",
         };
-      } catch (err: any) {
-        return { error: `Registration failed: ${err.message}` };
+      } catch (err: unknown) {
+        return classifyError(err);
       }
     },
   };

--- a/plugin/src/tools/reset-credential.ts
+++ b/plugin/src/tools/reset-credential.ts
@@ -3,6 +3,7 @@
  */
 import { getConfig as getAppConfig } from "../runtime.js";
 import { resetCredential } from "../reset-credential.js";
+import { validationError, configError, classifyError } from "./tool-result.js";
 
 export function createResetCredentialTool() {
   return {
@@ -30,9 +31,9 @@ export function createResetCredentialTool() {
     },
     execute: async (_toolCallId: any, args: any) => {
       const cfg = getAppConfig();
-      if (!cfg) return { error: "No configuration available" };
-      if (!args.agent_id) return { error: "agent_id is required" };
-      if (!args.reset_code) return { error: "reset_code is required" };
+      if (!cfg) return configError("No configuration available");
+      if (!args.agent_id) return validationError("agent_id is required");
+      if (!args.reset_code) return validationError("reset_code is required");
 
       try {
         const result = await resetCredential({
@@ -50,8 +51,8 @@ export function createResetCredentialTool() {
           credentials_file: result.credentialsFile,
           note: "Restart OpenClaw to activate: openclaw gateway restart",
         };
-      } catch (err: any) {
-        return { error: err.message };
+      } catch (err: unknown) {
+        return classifyError(err);
       }
     },
   };

--- a/plugin/src/tools/room-context.ts
+++ b/plugin/src/tools/room-context.ts
@@ -2,14 +2,8 @@
  * botcord_room_context — Inspect room context, recent messages, and search
  * message history within one room or across all joined rooms.
  */
-import {
-  getSingleAccountModeError,
-  resolveAccountConfig,
-  isAccountConfigured,
-} from "../config.js";
-import { BotCordClient } from "../client.js";
-import { attachTokenPersistence } from "../credentials.js";
-import { getConfig as getAppConfig } from "../runtime.js";
+import { withClient } from "./with-client.js";
+import { validationError } from "./tool-result.js";
 
 /** Normalize query input: accept a string or string[] from the LLM. */
 function _normalizeQuery(raw: unknown): string | string[] | null {
@@ -89,28 +83,15 @@ export function createRoomContextTool() {
       required: ["action"],
     },
     execute: async (toolCallId: any, args: any, signal?: any, onUpdate?: any) => {
-      const cfg = getAppConfig();
-      if (!cfg) return { error: "No configuration available" };
-      const singleAccountError = getSingleAccountModeError(cfg);
-      if (singleAccountError) return { error: singleAccountError };
-
-      const acct = resolveAccountConfig(cfg);
-      if (!isAccountConfigured(acct)) {
-        return { error: "BotCord is not configured." };
-      }
-
-      const client = new BotCordClient(acct);
-      attachTokenPersistence(client, acct);
-
-      try {
+      return withClient(async (client) => {
         switch (args.action) {
           case "room_summary": {
-            if (!args.room_id) return { error: "room_id is required for room_summary" };
+            if (!args.room_id) return validationError("room_id is required for room_summary");
             return await client.roomSummary(args.room_id, args.limit);
           }
 
           case "room_messages": {
-            if (!args.room_id) return { error: "room_id is required for room_messages" };
+            if (!args.room_id) return validationError("room_id is required for room_messages");
             return await client.roomMessages(args.room_id, {
               limit: args.limit,
               before: args.before,
@@ -121,9 +102,9 @@ export function createRoomContextTool() {
           }
 
           case "room_search": {
-            if (!args.room_id) return { error: "room_id is required for room_search" };
+            if (!args.room_id) return validationError("room_id is required for room_search");
             const rsQuery = _normalizeQuery(args.query);
-            if (!rsQuery) return { error: "query is required for room_search" };
+            if (!rsQuery) return validationError("query is required for room_search");
             return await client.roomSearch(args.room_id, rsQuery, {
               limit: args.limit,
               before: args.before,
@@ -138,7 +119,7 @@ export function createRoomContextTool() {
 
           case "global_search": {
             const gsQuery = _normalizeQuery(args.query);
-            if (!gsQuery) return { error: "query is required for global_search" };
+            if (!gsQuery) return validationError("query is required for global_search");
             return await client.globalSearch(gsQuery, {
               limit: args.limit,
               roomId: args.room_id,
@@ -149,11 +130,9 @@ export function createRoomContextTool() {
           }
 
           default:
-            return { error: `Unknown action: ${args.action}` };
+            return validationError(`Unknown action: ${args.action}`);
         }
-      } catch (err: any) {
-        return { error: `Room context action failed: ${err.message}` };
-      }
+      });
     },
   };
 }

--- a/plugin/src/tools/rooms.ts
+++ b/plugin/src/tools/rooms.ts
@@ -147,7 +147,7 @@ export function createRoomsTool() {
             });
 
           case "discover":
-            return { rooms: await client.discoverRooms(args.name) };
+            return await client.discoverPublicRooms(args.name);
 
           case "join":
             if (!args.room_id) return validationError("room_id is required");

--- a/plugin/src/tools/rooms.ts
+++ b/plugin/src/tools/rooms.ts
@@ -1,14 +1,8 @@
 /**
  * botcord_rooms — Room lifecycle and membership management.
  */
-import {
-  getSingleAccountModeError,
-  resolveAccountConfig,
-  isAccountConfigured,
-} from "../config.js";
-import { BotCordClient } from "../client.js";
-import { attachTokenPersistence } from "../credentials.js";
-import { getConfig as getAppConfig } from "../runtime.js";
+import { withClient } from "./with-client.js";
+import { validationError, dryRunResult } from "./tool-result.js";
 
 export function createRoomsTool() {
   return {
@@ -102,27 +96,19 @@ export function createRoomsTool() {
           type: "boolean" as const,
           description: "Mute or unmute the current member in a room — for mute",
         },
+        dry_run: {
+          type: "boolean" as const,
+          description: "Preview the request without executing. Returns the API call that would be made.",
+        },
       },
       required: ["action"],
     },
     execute: async (toolCallId: any, args: any, signal?: any, onUpdate?: any) => {
-      const cfg = getAppConfig();
-      if (!cfg) return { error: "No configuration available" };
-      const singleAccountError = getSingleAccountModeError(cfg);
-      if (singleAccountError) return { error: singleAccountError };
-
-      const acct = resolveAccountConfig(cfg);
-      if (!isAccountConfigured(acct)) {
-        return { error: "BotCord is not configured." };
-      }
-
-      const client = new BotCordClient(acct);
-      attachTokenPersistence(client, acct);
-
-      try {
+      return withClient(async (client) => {
         switch (args.action) {
           case "create":
-            if (!args.name) return { error: "name is required" };
+            if (!args.name) return validationError("name is required");
+            if (args.dry_run) return dryRunResult("POST", "/hub/rooms", { name: args.name, visibility: args.visibility || "private", join_policy: args.join_policy, member_ids: args.member_ids });
             return await client.createRoom({
               name: args.name,
               description: args.description,
@@ -138,14 +124,15 @@ export function createRoomsTool() {
             });
 
           case "list":
-            return await client.listMyRooms();
+            return { rooms: await client.listMyRooms() };
 
           case "info":
-            if (!args.room_id) return { error: "room_id is required" };
+            if (!args.room_id) return validationError("room_id is required");
             return await client.getRoomInfo(args.room_id);
 
           case "update":
-            if (!args.room_id) return { error: "room_id is required" };
+            if (!args.room_id) return validationError("room_id is required");
+            if (args.dry_run) return dryRunResult("PATCH", `/hub/rooms/${args.room_id}`, { name: args.name, description: args.description, rule: args.rule, visibility: args.visibility, join_policy: args.join_policy, required_subscription_product_id: args.required_subscription_product_id, max_members: args.max_members, default_send: args.default_send, default_invite: args.default_invite, slow_mode_seconds: args.slow_mode_seconds });
             return await client.updateRoom(args.room_id, {
               name: args.name,
               description: args.description,
@@ -160,10 +147,11 @@ export function createRoomsTool() {
             });
 
           case "discover":
-            return await client.discoverPublicRooms(args.name);
+            return { rooms: await client.discoverRooms(args.name) };
 
           case "join":
-            if (!args.room_id) return { error: "room_id is required" };
+            if (!args.room_id) return validationError("room_id is required");
+            if (args.dry_run) return dryRunResult("POST", `/hub/rooms/${args.room_id}/members`, { agent_id: "{self}" });
             await client.joinRoom(args.room_id, {
               can_send: args.can_send,
               can_invite: args.can_invite,
@@ -171,21 +159,24 @@ export function createRoomsTool() {
             return { ok: true, joined: args.room_id };
 
           case "leave":
-            if (!args.room_id) return { error: "room_id is required" };
+            if (!args.room_id) return validationError("room_id is required");
+            if (args.dry_run) return dryRunResult("POST", `/hub/rooms/${args.room_id}/leave`);
             await client.leaveRoom(args.room_id);
             return { ok: true, left: args.room_id };
 
           case "dissolve":
-            if (!args.room_id) return { error: "room_id is required" };
+            if (!args.room_id) return validationError("room_id is required");
+            if (args.dry_run) return dryRunResult("DELETE", `/hub/rooms/${args.room_id}`);
             await client.dissolveRoom(args.room_id);
             return { ok: true, dissolved: args.room_id };
 
           case "members":
-            if (!args.room_id) return { error: "room_id is required" };
-            return await client.getRoomMembers(args.room_id);
+            if (!args.room_id) return validationError("room_id is required");
+            return { members: await client.getRoomMembers(args.room_id) };
 
           case "invite":
-            if (!args.room_id || !args.agent_id) return { error: "room_id and agent_id are required" };
+            if (!args.room_id || !args.agent_id) return validationError("room_id and agent_id are required");
+            if (args.dry_run) return dryRunResult("POST", `/hub/rooms/${args.room_id}/members`, { agent_id: args.agent_id, can_send: args.can_send, can_invite: args.can_invite });
             await client.inviteToRoom(args.room_id, args.agent_id, {
               can_send: args.can_send,
               can_invite: args.can_invite,
@@ -193,22 +184,26 @@ export function createRoomsTool() {
             return { ok: true, invited: args.agent_id, room: args.room_id };
 
           case "remove_member":
-            if (!args.room_id || !args.agent_id) return { error: "room_id and agent_id are required" };
+            if (!args.room_id || !args.agent_id) return validationError("room_id and agent_id are required");
+            if (args.dry_run) return dryRunResult("DELETE", `/hub/rooms/${args.room_id}/members/${args.agent_id}`);
             await client.removeMember(args.room_id, args.agent_id);
             return { ok: true, removed: args.agent_id, room: args.room_id };
 
           case "promote":
-            if (!args.room_id || !args.agent_id) return { error: "room_id and agent_id are required" };
+            if (!args.room_id || !args.agent_id) return validationError("room_id and agent_id are required");
+            if (args.dry_run) return dryRunResult("POST", `/hub/rooms/${args.room_id}/promote`, { agent_id: args.agent_id, role: args.role || "admin" });
             await client.promoteMember(args.room_id, args.agent_id, args.role || "admin");
             return { ok: true, promoted: args.agent_id, role: args.role || "admin", room: args.room_id };
 
           case "transfer":
-            if (!args.room_id || !args.agent_id) return { error: "room_id and agent_id are required" };
+            if (!args.room_id || !args.agent_id) return validationError("room_id and agent_id are required");
+            if (args.dry_run) return dryRunResult("POST", `/hub/rooms/${args.room_id}/transfer`, { new_owner_id: args.agent_id });
             await client.transferOwnership(args.room_id, args.agent_id);
             return { ok: true, new_owner: args.agent_id, room: args.room_id };
 
           case "permissions":
-            if (!args.room_id || !args.agent_id) return { error: "room_id and agent_id are required" };
+            if (!args.room_id || !args.agent_id) return validationError("room_id and agent_id are required");
+            if (args.dry_run) return dryRunResult("POST", `/hub/rooms/${args.room_id}/permissions`, { agent_id: args.agent_id, can_send: args.can_send, can_invite: args.can_invite });
             await client.setMemberPermissions(args.room_id, args.agent_id, {
               can_send: args.can_send,
               can_invite: args.can_invite,
@@ -216,16 +211,15 @@ export function createRoomsTool() {
             return { ok: true, agent: args.agent_id, room: args.room_id };
 
           case "mute":
-            if (!args.room_id) return { error: "room_id is required" };
+            if (!args.room_id) return validationError("room_id is required");
+            if (args.dry_run) return dryRunResult("POST", `/hub/rooms/${args.room_id}/mute`, { muted: args.muted ?? true });
             await client.muteRoom(args.room_id, args.muted ?? true);
             return { ok: true, room: args.room_id, muted: args.muted ?? true };
 
           default:
-            return { error: `Unknown action: ${args.action}` };
+            return validationError(`Unknown action: ${args.action}`);
         }
-      } catch (err: any) {
-        return { error: `Room action failed: ${err.message}` };
-      }
+      });
     },
   };
 }

--- a/plugin/src/tools/subscription.ts
+++ b/plugin/src/tools/subscription.ts
@@ -1,14 +1,8 @@
 /**
  * botcord_subscription — Create and manage coin-priced subscription products.
  */
-import {
-  getSingleAccountModeError,
-  resolveAccountConfig,
-  isAccountConfigured,
-} from "../config.js";
-import { BotCordClient } from "../client.js";
-import { attachTokenPersistence } from "../credentials.js";
-import { getConfig as getAppConfig } from "../runtime.js";
+import { withClient } from "./with-client.js";
+import { validationError, dryRunResult } from "./tool-result.js";
 import { formatCoinAmount, parseCoinToMinor } from "./coin-format.js";
 
 function formatProduct(product: any): string {
@@ -127,31 +121,23 @@ export function createSubscriptionTool() {
           type: "number" as const,
           description: "Slow mode interval in seconds — for create_subscription_room or bind_room_to_product",
         },
+        dry_run: {
+          type: "boolean" as const,
+          description: "Preview the request without executing. Returns the API call that would be made.",
+        },
       },
       required: ["action"],
     },
     execute: async (toolCallId: any, args: any, signal?: any, onUpdate?: any) => {
-      const cfg = getAppConfig();
-      if (!cfg) return { error: "No configuration available" };
-      const singleAccountError = getSingleAccountModeError(cfg);
-      if (singleAccountError) return { error: singleAccountError };
-
-      const acct = resolveAccountConfig(cfg);
-      if (!isAccountConfigured(acct)) {
-        return { error: "BotCord is not configured." };
-      }
-
-      const client = new BotCordClient(acct);
-      attachTokenPersistence(client, acct);
-
-      try {
+      return withClient(async (client) => {
         switch (args.action) {
           case "create_product": {
-            if (!args.name) return { error: "name is required" };
-            if (!args.amount) return { error: "amount is required" };
-            if (!args.billing_interval) return { error: "billing_interval is required" };
+            if (!args.name) return validationError("name is required");
+            if (!args.amount) return validationError("amount is required");
+            if (!args.billing_interval) return validationError("billing_interval is required");
             const amountMinor = parseCoinToMinor(args.amount);
-            if (amountMinor === null) return { error: "amount must be a valid number (e.g. \"10\" or \"9.50\")" };
+            if (amountMinor === null) return validationError("amount must be a valid number (e.g. \"10\" or \"9.50\")");
+            if (args.dry_run) return dryRunResult("POST", "/subscriptions/products", { name: args.name, amount_minor: amountMinor, billing_interval: args.billing_interval });
             const product = await client.createSubscriptionProduct({
               name: args.name,
               description: args.description,
@@ -173,14 +159,16 @@ export function createSubscriptionTool() {
           }
 
           case "archive_product": {
-            if (!args.product_id) return { error: "product_id is required" };
+            if (!args.product_id) return validationError("product_id is required");
+            if (args.dry_run) return dryRunResult("POST", `/subscriptions/products/${args.product_id}/archive`);
             const product = await client.archiveSubscriptionProduct(args.product_id);
             return { result: formatProduct(product), data: product };
           }
 
           case "create_subscription_room": {
-            if (!args.product_id) return { error: "product_id is required" };
-            if (!args.name) return { error: "name is required" };
+            if (!args.product_id) return validationError("product_id is required");
+            if (!args.name) return validationError("name is required");
+            if (args.dry_run) return dryRunResult("POST", "/hub/rooms", { name: args.name, description: args.description, visibility: "public", join_policy: "open", required_subscription_product_id: args.product_id });
             const room = await client.createRoom({
               name: args.name,
               description: args.description,
@@ -200,8 +188,9 @@ export function createSubscriptionTool() {
           }
 
           case "bind_room_to_product": {
-            if (!args.room_id) return { error: "room_id is required" };
-            if (!args.product_id) return { error: "product_id is required" };
+            if (!args.room_id) return validationError("room_id is required");
+            if (!args.product_id) return validationError("product_id is required");
+            if (args.dry_run) return dryRunResult("PATCH", `/hub/rooms/${args.room_id}`, { visibility: "public", join_policy: "open", required_subscription_product_id: args.product_id });
             const room = await client.updateRoom(args.room_id, {
               name: args.name,
               description: args.description,
@@ -221,7 +210,8 @@ export function createSubscriptionTool() {
           }
 
           case "subscribe": {
-            if (!args.product_id) return { error: "product_id is required" };
+            if (!args.product_id) return validationError("product_id is required");
+            if (args.dry_run) return dryRunResult("POST", `/subscriptions/products/${args.product_id}/subscribe`);
             const subscription = await client.subscribeToProduct(args.product_id, args.idempotency_key);
             return { result: formatSubscription(subscription), data: subscription };
           }
@@ -232,23 +222,22 @@ export function createSubscriptionTool() {
           }
 
           case "list_subscribers": {
-            if (!args.product_id) return { error: "product_id is required" };
+            if (!args.product_id) return validationError("product_id is required");
             const subscriptions = await client.listProductSubscribers(args.product_id);
             return { result: formatSubscriptionList(subscriptions), data: subscriptions };
           }
 
           case "cancel": {
-            if (!args.subscription_id) return { error: "subscription_id is required" };
+            if (!args.subscription_id) return validationError("subscription_id is required");
+            if (args.dry_run) return dryRunResult("POST", `/subscriptions/${args.subscription_id}/cancel`);
             const subscription = await client.cancelSubscription(args.subscription_id);
             return { result: formatSubscription(subscription), data: subscription };
           }
 
           default:
-            return { error: `Unknown action: ${args.action}` };
+            return validationError(`Unknown action: ${args.action}`);
         }
-      } catch (err: any) {
-        return { error: `Subscription action failed: ${err.message}` };
-      }
+      });
     },
   };
 }

--- a/plugin/src/tools/tool-result.ts
+++ b/plugin/src/tools/tool-result.ts
@@ -28,7 +28,7 @@ export interface DryRunRequest {
   method: string;
   path: string;
   body?: unknown;
-  query?: Record<string, string>;
+  query?: Record<string, string | string[]>;
 }
 
 export type DryRunResult = { ok: true; dry_run: true; request: DryRunRequest };
@@ -60,7 +60,7 @@ export function apiError(code: string, message: string, hint?: string): ToolFail
   return fail("api", code, message, hint);
 }
 
-export function dryRunResult(method: string, path: string, body?: unknown, query?: Record<string, string>): DryRunResult {
+export function dryRunResult(method: string, path: string, body?: unknown, query?: Record<string, string | string[]>): DryRunResult {
   return {
     ok: true,
     dry_run: true,

--- a/plugin/src/tools/tool-result.ts
+++ b/plugin/src/tools/tool-result.ts
@@ -29,6 +29,7 @@ export interface DryRunRequest {
   path: string;
   body?: unknown;
   query?: Record<string, string | string[]>;
+  note?: string;
 }
 
 export type DryRunResult = { ok: true; dry_run: true; request: DryRunRequest };
@@ -60,11 +61,17 @@ export function apiError(code: string, message: string, hint?: string): ToolFail
   return fail("api", code, message, hint);
 }
 
-export function dryRunResult(method: string, path: string, body?: unknown, query?: Record<string, string | string[]>): DryRunResult {
+export function dryRunResult(method: string, path: string, body?: unknown, options?: { query?: Record<string, string | string[]>; note?: string }): DryRunResult {
   return {
     ok: true,
     dry_run: true,
-    request: { method, path, ...(body !== undefined ? { body } : {}), ...(query ? { query } : {}) },
+    request: {
+      method,
+      path,
+      ...(body !== undefined ? { body } : {}),
+      ...(options?.query ? { query: options.query } : {}),
+      ...(options?.note ? { note: options.note } : {}),
+    },
   };
 }
 

--- a/plugin/src/tools/topics.ts
+++ b/plugin/src/tools/topics.ts
@@ -1,14 +1,8 @@
 /**
  * botcord_topics — Topic lifecycle management within rooms.
  */
-import {
-  getSingleAccountModeError,
-  resolveAccountConfig,
-  isAccountConfigured,
-} from "../config.js";
-import { BotCordClient } from "../client.js";
-import { attachTokenPersistence } from "../credentials.js";
-import { getConfig as getAppConfig } from "../runtime.js";
+import { withClient } from "./with-client.js";
+import { validationError, dryRunResult } from "./tool-result.js";
 
 export function createTopicsTool() {
   return {
@@ -50,27 +44,19 @@ export function createTopicsTool() {
           enum: ["open", "completed", "failed", "expired"],
           description: "Topic status — for list (filter) or update (transition)",
         },
+        dry_run: {
+          type: "boolean" as const,
+          description: "Preview the request without executing. Returns the API call that would be made.",
+        },
       },
       required: ["action", "room_id"],
     },
     execute: async (toolCallId: any, args: any, signal?: any, onUpdate?: any) => {
-      const cfg = getAppConfig();
-      if (!cfg) return { error: "No configuration available" };
-      const singleAccountError = getSingleAccountModeError(cfg);
-      if (singleAccountError) return { error: singleAccountError };
-
-      const acct = resolveAccountConfig(cfg);
-      if (!isAccountConfigured(acct)) {
-        return { error: "BotCord is not configured." };
-      }
-
-      const client = new BotCordClient(acct);
-      attachTokenPersistence(client, acct);
-
-      try {
+      return withClient(async (client) => {
         switch (args.action) {
           case "create":
-            if (!args.title) return { error: "title is required" };
+            if (!args.title) return validationError("title is required");
+            if (args.dry_run) return dryRunResult("POST", `/hub/rooms/${args.room_id}/topics`, { title: args.title, description: args.description, goal: args.goal });
             return await client.createTopic(args.room_id, {
               title: args.title,
               description: args.description,
@@ -78,14 +64,15 @@ export function createTopicsTool() {
             });
 
           case "list":
-            return await client.listTopics(args.room_id, args.status);
+            return { topics: await client.listTopics(args.room_id, args.status) };
 
           case "get":
-            if (!args.topic_id) return { error: "topic_id is required" };
+            if (!args.topic_id) return validationError("topic_id is required");
             return await client.getTopic(args.room_id, args.topic_id);
 
           case "update":
-            if (!args.topic_id) return { error: "topic_id is required" };
+            if (!args.topic_id) return validationError("topic_id is required");
+            if (args.dry_run) return dryRunResult("PATCH", `/hub/rooms/${args.room_id}/topics/${args.topic_id}`, { title: args.title, status: args.status, goal: args.goal });
             return await client.updateTopic(args.room_id, args.topic_id, {
               title: args.title,
               description: args.description,
@@ -94,16 +81,15 @@ export function createTopicsTool() {
             });
 
           case "delete":
-            if (!args.topic_id) return { error: "topic_id is required" };
+            if (!args.topic_id) return validationError("topic_id is required");
+            if (args.dry_run) return dryRunResult("DELETE", `/hub/rooms/${args.room_id}/topics/${args.topic_id}`);
             await client.deleteTopic(args.room_id, args.topic_id);
             return { ok: true, deleted: args.topic_id, room: args.room_id };
 
           default:
-            return { error: `Unknown action: ${args.action}` };
+            return validationError(`Unknown action: ${args.action}`);
         }
-      } catch (err: any) {
-        return { error: `Topic action failed: ${err.message}` };
-      }
+      });
     },
   };
 }


### PR DESCRIPTION
## Summary
- Add `HubApiError` typed class to `client.ts` — replaces `(err as any).status` pattern
- Add `client.request()` raw API method with 1MB response cap
- Migrate all 13 tool files from manual config/client boilerplate to `withClient`/`withConfig` wrapper
- Replace `{ error: "..." }` with typed `validationError()` across all tools
- Add `dry_run` parameter to 7 write-operation tools (send, rooms, contacts, account, topics, payment, subscription)
- Wrap read-only returns in named objects for consistent `{ ok: true, ... }` envelope

This fixes the dead `HubApiError` import in `tool-result.ts` (which was added earlier but never had its dependency in `client.ts`).

Extracted from #121. Preserves COIN unit params from #197 and OR search from #195.

## Test plan
- [x] All 292 plugin tests pass
- [ ] Verify dry-run returns correct API paths for each tool
- [ ] Verify HubApiError classifies 401/403/404/429 correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)