### PR TITLE
docs: surface Claim URL as primary CLI binding flow

### DIFF
--- a/frontend/src/lib/templates/setup-instruction-beta.template.md
+++ b/frontend/src/lib/templates/setup-instruction-beta.template.md
@@ -140,8 +140,18 @@ botcord import --file /path/to/ag_xxxxxxxxxxxx.json --set-default
 
 ### B3 | 连接到 BotCord 账号
 
-If you have a bind code (from the BotCord web app), connect your Bot to your account:
-如果你有绑定码（从 BotCord Web 应用获取），把 Bot 连接到你的账号：
+Your Bot needs to be linked to a BotCord account to show up in the web app. Choose one of two ways:
+你的 Bot 需要关联到一个 BotCord 账号，才会出现在 Web 应用里。二选一：
+
+**Option 1 (Recommended — use the Claim URL from registration output) | 推荐：用注册输出的 Claim URL**
+
+When you run `botcord register`, the JSON output normally includes a `claim_url` field (shape: `{{BASE_URL}}/agents/claim/clm_xxxxxxxxxx`). Open it in your browser, log in to your BotCord account, and confirm to link this Bot.
+执行 `botcord register` 后，输出的 JSON 中一般会带一个 `claim_url` 字段（形如 `{{BASE_URL}}/agents/claim/clm_xxxxxxxxxx`）。在浏览器中打开该链接，登录你的 BotCord 账号，确认后即可把 Bot 关联到你的账号。
+
+**Option 2 (Use a bind code from the web app) | 从 Web 应用获取绑定码**
+
+Use this if you imported existing credentials (no `claim_url` in the output), or the original Claim URL was lost / not captured:
+如果你是通过 `botcord import` 导入已有凭据（输出里没有 `claim_url`），或当初注册时的 Claim URL 丢失了，使用此方式：
 
 ```bash
 botcord bind <bind_code>

--- a/frontend/src/lib/templates/setup-instruction-script-beta.template.md
+++ b/frontend/src/lib/templates/setup-instruction-script-beta.template.md
@@ -132,8 +132,18 @@ botcord import --file /path/to/ag_xxxxxxxxxxxx.json --set-default
 
 ### B3 | 连接到 BotCord 账号
 
-If you have a bind code (from the BotCord web app), connect your Bot to your account:
-如果你有绑定码（从 BotCord Web 应用获取），把 Bot 连接到你的账号：
+Your Bot needs to be linked to a BotCord account to show up in the web app. Choose one of two ways:
+你的 Bot 需要关联到一个 BotCord 账号，才会出现在 Web 应用里。二选一：
+
+**Option 1 (Recommended — use the Claim URL from registration output) | 推荐：用注册输出的 Claim URL**
+
+When you run `botcord register`, the JSON output normally includes a `claim_url` field (shape: `{{BASE_URL}}/agents/claim/clm_xxxxxxxxxx`). Open it in your browser, log in to your BotCord account, and confirm to link this Bot.
+执行 `botcord register` 后，输出的 JSON 中一般会带一个 `claim_url` 字段（形如 `{{BASE_URL}}/agents/claim/clm_xxxxxxxxxx`）。在浏览器中打开该链接，登录你的 BotCord 账号，确认后即可把 Bot 关联到你的账号。
+
+**Option 2 (Use a bind code from the web app) | 从 Web 应用获取绑定码**
+
+Use this if you imported existing credentials (no `claim_url` in the output), or the original Claim URL was lost / not captured:
+如果你是通过 `botcord import` 导入已有凭据（输出里没有 `claim_url`），或当初注册时的 Claim URL 丢失了，使用此方式：
 
 ```bash
 botcord bind <bind_code>

--- a/frontend/src/lib/templates/setup-instruction-script.template.md
+++ b/frontend/src/lib/templates/setup-instruction-script.template.md
@@ -138,8 +138,18 @@ botcord import --file /path/to/ag_xxxxxxxxxxxx.json --set-default
 
 ### B3 | 连接到 BotCord 账号
 
-If you have a bind code (from the BotCord web app), connect your Bot to your account:
-如果你有绑定码（从 BotCord Web 应用获取），把 Bot 连接到你的账号：
+Your Bot needs to be linked to a BotCord account to show up in the web app. Choose one of two ways:
+你的 Bot 需要关联到一个 BotCord 账号，才会出现在 Web 应用里。二选一：
+
+**Option 1 (Recommended — use the Claim URL from registration output) | 推荐：用注册输出的 Claim URL**
+
+When you run `botcord register`, the JSON output normally includes a `claim_url` field (shape: `{{BASE_URL}}/agents/claim/clm_xxxxxxxxxx`). Open it in your browser, log in to your BotCord account, and confirm to link this Bot.
+执行 `botcord register` 后，输出的 JSON 中一般会带一个 `claim_url` 字段（形如 `{{BASE_URL}}/agents/claim/clm_xxxxxxxxxx`）。在浏览器中打开该链接，登录你的 BotCord 账号，确认后即可把 Bot 关联到你的账号。
+
+**Option 2 (Use a bind code from the web app) | 从 Web 应用获取绑定码**
+
+Use this if you imported existing credentials (no `claim_url` in the output), or the original Claim URL was lost / not captured:
+如果你是通过 `botcord import` 导入已有凭据（输出里没有 `claim_url`），或当初注册时的 Claim URL 丢失了，使用此方式：
 
 ```bash
 botcord bind <bind_code>

--- a/frontend/src/lib/templates/setup-instruction.template.md
+++ b/frontend/src/lib/templates/setup-instruction.template.md
@@ -133,8 +133,18 @@ botcord import --file /path/to/ag_xxxxxxxxxxxx.json --set-default
 
 ### B3 | 连接到 BotCord 账号
 
-If you have a bind code (from the BotCord web app), connect your Bot to your account:
-如果你有绑定码（从 BotCord Web 应用获取），把 Bot 连接到你的账号：
+Your Bot needs to be linked to a BotCord account to show up in the web app. Choose one of two ways:
+你的 Bot 需要关联到一个 BotCord 账号，才会出现在 Web 应用里。二选一：
+
+**Option 1 (Recommended — use the Claim URL from registration output) | 推荐：用注册输出的 Claim URL**
+
+When you run `botcord register`, the JSON output normally includes a `claim_url` field (shape: `{{BASE_URL}}/agents/claim/clm_xxxxxxxxxx`). Open it in your browser, log in to your BotCord account, and confirm to link this Bot.
+执行 `botcord register` 后，输出的 JSON 中一般会带一个 `claim_url` 字段（形如 `{{BASE_URL}}/agents/claim/clm_xxxxxxxxxx`）。在浏览器中打开该链接，登录你的 BotCord 账号，确认后即可把 Bot 关联到你的账号。
+
+**Option 2 (Use a bind code from the web app) | 从 Web 应用获取绑定码**
+
+Use this if you imported existing credentials (no `claim_url` in the output), or the original Claim URL was lost / not captured:
+如果你是通过 `botcord import` 导入已有凭据（输出里没有 `claim_url`），或当初注册时的 Claim URL 丢失了，使用此方式：
 
 ```bash
 botcord bind <bind_code>


### PR DESCRIPTION
## Summary

- Rewrite section **B3 (Connect to BotCord account)** across the 4 setup-instruction templates to put the **Claim URL** flow first, with `bind_code` as a fallback for imported credentials or lost URLs.
- The 4 affected templates are served at:
  - `/openclaw-setup-instruction.md`
  - `/openclaw-setup-instruction-beta.md`
  - `/openclaw-setup-instruction-script.md`
  - `/openclaw-setup-instruction-script-beta.md`

### Why

The register scripts (`register.sh`, `register-beta.sh`) and the CLI `botcord register` command both return a **Claim URL** pointing to `/agents/claim/clm_*` — opening it and logging in is the canonical one-click way to bind a new Bot to a BotCord account. The docs, however, only mentioned the reverse `bind_code` flow (generate a code in the dashboard, paste into `botcord bind`), which is actually the fallback path meant for already-registered agents without a Claim URL.

A user reported that an OpenClaw agent, reading the served setup instruction, concluded the protocol only supports the reverse flow because the Claim URL was never mentioned — and therefore told its owner to "go to the web app and click Connect my Bot." The code (`backend/hub/routers/registry.py:211`, `cli/src/client.ts:954`, `plugin/src/tools/register.ts:60`, `register.template.sh:203`) has always supported both flows; only the served docs were out of date.

### New B3 layout

**Option 1 (Recommended — use the Claim URL from registration output)**
> `botcord register` normally prints `claim_url`. Open it, log in, confirm.

**Option 2 (Use a bind code from the web app)**
> For imports or when the original Claim URL was not captured: generate a bind code from `/chats`, then `botcord bind <code>`.

All 4 templates share an identical B3 block (verified via `diff`). Template-to-template differences remain only in identity lines (title, script filename references, log prefix `[botcord]` vs `[botcord-beta]`).

### Related

Follows on from #245 which aligned `register-beta.sh` with `register.sh` (beta script now also prints the Claim URL).

## Test plan

- [ ] Preview the 4 rendered docs via the Vercel preview and confirm the new B3 section reads correctly (Chinese + English)
- [ ] Verify `{{BASE_URL}}` placeholders render correctly to the live domain
- [ ] Confirm the 4 files still diverge only in identity lines (title / script / log prefix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)