### PR TITLE
feat(backend): add url field to all room response schemas

### DIFF
--- a/backend/hub/dashboard_schemas.py
+++ b/backend/hub/dashboard_schemas.py
@@ -24,6 +24,7 @@ class DashboardRoom(BaseModel):
     last_message_preview: str | None = None
     last_message_at: datetime.datetime | None = None
     last_sender_name: str | None = None
+    url: str
 
 
 class DashboardContactInfo(BaseModel):
@@ -136,6 +137,7 @@ class DiscoverRoom(BaseModel):
     visibility: str
     member_count: int
     required_subscription_product_id: str | None = None
+    url: str
 
 
 class DiscoverRoomsResponse(BaseModel):
@@ -152,6 +154,7 @@ class JoinRoomResponse(BaseModel):
     visibility: str
     member_count: int
     my_role: str
+    url: str
 
 
 # ---------------------------------------------------------------------------

--- a/backend/hub/routers/dashboard.py
+++ b/backend/hub/routers/dashboard.py
@@ -47,7 +47,7 @@ from hub.models import (
     Share,
     ShareMessage,
 )
-from hub.share_payloads import room_entry_type, share_create_payload, share_public_payload
+from hub.share_payloads import frontend_url, room_entry_type, share_create_payload, share_public_payload
 
 router = APIRouter(prefix="/dashboard", tags=["dashboard"])
 
@@ -185,6 +185,7 @@ async def _build_dashboard_rooms(
                 last_message_preview=last_preview,
                 last_message_at=last_at,
                 last_sender_name=last_sender,
+                url=frontend_url(f"/chats/messages/{room.room_id}"),
             )
         )
     dashboard_rooms.sort(
@@ -711,6 +712,7 @@ async def discover_rooms(
             visibility=room.visibility.value if hasattr(room.visibility, "value") else str(room.visibility),
             member_count=count or 0,
             required_subscription_product_id=room.required_subscription_product_id,
+            url=frontend_url(f"/chats/messages/{room.room_id}"),
         )
         for room, count in rows
     ]
@@ -793,6 +795,7 @@ async def join_room(
         visibility=room.visibility.value if hasattr(room.visibility, "value") else str(room.visibility),
         member_count=updated_count,
         my_role="member",
+        url=frontend_url(f"/chats/messages/{room.room_id}"),
     )
 
 

--- a/backend/hub/routers/room.py
+++ b/backend/hub/routers/room.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import selectinload
 from hub.auth import get_current_claimed_agent
 from hub import config as hub_config
 from hub.config import JOIN_RATE_LIMIT_PER_MINUTE
+from hub.share_payloads import frontend_url
 from hub.database import get_db
 from hub.id_generators import generate_room_id
 from hub.enums import SubscriptionProductStatus, SubscriptionStatus
@@ -99,6 +100,10 @@ def _normalize_room_rule(rule: str | None) -> str | None:
     return normalized or None
 
 
+def _room_url(room_id: str) -> str:
+    return frontend_url(f"/chats/messages/{room_id}")
+
+
 def _build_room_response(room: Room) -> RoomResponse:
     return RoomResponse(
         room_id=room.room_id,
@@ -126,6 +131,7 @@ def _build_room_response(room: Room) -> RoomResponse:
             for m in room.members
         ],
         created_at=room.created_at,
+        url=_room_url(room.room_id),
     )
 
 
@@ -142,6 +148,7 @@ def _build_room_public_response(room: Room) -> RoomPublicResponse:
         slow_mode_seconds=room.slow_mode_seconds,
         member_count=len(room.members),
         created_at=room.created_at,
+        url=_room_url(room.room_id),
     )
 
 

--- a/backend/hub/schemas.py
+++ b/backend/hub/schemas.py
@@ -516,6 +516,7 @@ class RoomResponse(BaseModel):
     member_count: int
     members: list[RoomMemberResponse]
     created_at: datetime.datetime
+    url: str
 
 
 class RoomPublicResponse(BaseModel):
@@ -530,6 +531,7 @@ class RoomPublicResponse(BaseModel):
     slow_mode_seconds: int | None = None
     member_count: int
     created_at: datetime.datetime
+    url: str
 
 
 class RoomDiscoveryResponse(BaseModel):
@@ -583,6 +585,7 @@ class DashboardRoom(BaseModel):
     last_message_preview: str | None = None
     last_message_at: datetime.datetime | None = None
     last_sender_name: str | None = None
+    url: str
 
 
 class DashboardContactInfo(BaseModel):


### PR DESCRIPTION
## Summary
- All room-related API responses now include a `url` field with the frontend chat page link (`FRONTEND_BASE_URL/chats/messages/{room_id}`)
- Covers 6 response schemas: `RoomResponse`, `RoomPublicResponse`, `DashboardRoom` (×2), `DiscoverRoom`, `JoinRoomResponse`
- Uses existing `frontend_url()` helper from `share_payloads.py` for consistency

## Test plan
- [ ] Verify `POST /hub/rooms` response includes `url` field
- [ ] Verify `GET /hub/rooms/{room_id}` response includes `url` field
- [ ] Verify `GET /dashboard/overview` rooms list items include `url` field
- [ ] Verify `GET /dashboard/rooms/discover` items include `url` field
- [ ] Verify `POST /dashboard/rooms/{room_id}/join` response includes `url` field
- [ ] Verify public room discovery responses include `url` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)