### PR TITLE
feat(plugin): enable onboarding from any channel

### DIFF
--- a/backend/hub/dashboard_schemas.py
+++ b/backend/hub/dashboard_schemas.py
@@ -24,6 +24,7 @@ class DashboardRoom(BaseModel):
     last_message_preview: str | None = None
     last_message_at: datetime.datetime | None = None
     last_sender_name: str | None = None
+    url: str
 
 
 class DashboardContactInfo(BaseModel):
@@ -136,6 +137,7 @@ class DiscoverRoom(BaseModel):
     visibility: str
     member_count: int
     required_subscription_product_id: str | None = None
+    url: str
 
 
 class DiscoverRoomsResponse(BaseModel):
@@ -152,6 +154,7 @@ class JoinRoomResponse(BaseModel):
     visibility: str
     member_count: int
     my_role: str
+    url: str
 
 
 # ---------------------------------------------------------------------------

--- a/backend/hub/routers/dashboard.py
+++ b/backend/hub/routers/dashboard.py
@@ -47,7 +47,7 @@ from hub.models import (
     Share,
     ShareMessage,
 )
-from hub.share_payloads import room_entry_type, share_create_payload, share_public_payload
+from hub.share_payloads import frontend_url, room_entry_type, share_create_payload, share_public_payload
 
 router = APIRouter(prefix="/dashboard", tags=["dashboard"])
 
@@ -185,6 +185,7 @@ async def _build_dashboard_rooms(
                 last_message_preview=last_preview,
                 last_message_at=last_at,
                 last_sender_name=last_sender,
+                url=frontend_url(f"/chats/messages/{room.room_id}"),
             )
         )
     dashboard_rooms.sort(
@@ -711,6 +712,7 @@ async def discover_rooms(
             visibility=room.visibility.value if hasattr(room.visibility, "value") else str(room.visibility),
             member_count=count or 0,
             required_subscription_product_id=room.required_subscription_product_id,
+            url=frontend_url(f"/chats/messages/{room.room_id}"),
         )
         for room, count in rows
     ]
@@ -793,6 +795,7 @@ async def join_room(
         visibility=room.visibility.value if hasattr(room.visibility, "value") else str(room.visibility),
         member_count=updated_count,
         my_role="member",
+        url=frontend_url(f"/chats/messages/{room.room_id}"),
     )
 
 

--- a/backend/hub/routers/room.py
+++ b/backend/hub/routers/room.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import selectinload
 from hub.auth import get_current_claimed_agent
 from hub import config as hub_config
 from hub.config import JOIN_RATE_LIMIT_PER_MINUTE
+from hub.share_payloads import frontend_url
 from hub.database import get_db
 from hub.id_generators import generate_room_id
 from hub.enums import SubscriptionProductStatus, SubscriptionStatus
@@ -99,6 +100,10 @@ def _normalize_room_rule(rule: str | None) -> str | None:
     return normalized or None
 
 
+def _room_url(room_id: str) -> str:
+    return frontend_url(f"/chats/messages/{room_id}")
+
+
 def _build_room_response(room: Room) -> RoomResponse:
     return RoomResponse(
         room_id=room.room_id,
@@ -126,6 +131,7 @@ def _build_room_response(room: Room) -> RoomResponse:
             for m in room.members
         ],
         created_at=room.created_at,
+        url=_room_url(room.room_id),
     )
 
 
@@ -142,6 +148,7 @@ def _build_room_public_response(room: Room) -> RoomPublicResponse:
         slow_mode_seconds=room.slow_mode_seconds,
         member_count=len(room.members),
         created_at=room.created_at,
+        url=_room_url(room.room_id),
     )
 
 

--- a/backend/hub/schemas.py
+++ b/backend/hub/schemas.py
@@ -516,6 +516,7 @@ class RoomResponse(BaseModel):
     member_count: int
     members: list[RoomMemberResponse]
     created_at: datetime.datetime
+    url: str
 
 
 class RoomPublicResponse(BaseModel):
@@ -530,6 +531,7 @@ class RoomPublicResponse(BaseModel):
     slow_mode_seconds: int | None = None
     member_count: int
     created_at: datetime.datetime
+    url: str
 
 
 class RoomDiscoveryResponse(BaseModel):
@@ -583,6 +585,7 @@ class DashboardRoom(BaseModel):
     last_message_preview: str | None = None
     last_message_at: datetime.datetime | None = None
     last_sender_name: str | None = None
+    url: str
 
 
 class DashboardContactInfo(BaseModel):

--- a/cli/skills/botcord/SKILL.md
+++ b/cli/skills/botcord/SKILL.md
@@ -21,7 +21,10 @@ Use this skill when BotCord actions should be performed through the local CLI in
 
 ## Quick Entry | 快速入口
 
-首次使用时，先运行 `botcord memory`。如果包含 `onboarding` section，按其中的步骤指引操作，用下方 Command Map 查找对应命令。CLI 无内置定时任务，Step 4 可用系统 crontab 或 Claude Code `/schedule` 配置。
+- **首次使用 / `botcord memory` 显示 `onboarding` section 仍存在** → 参见 [onboarding_instruction](./onboarding_instruction.md)，按判定流程继续或开始 onboarding
+- **日常操作** → 用下方 Command Map 查找对应命令
+
+> CLI 无内置定时任务，onboarding STEP 4 可用系统 crontab 或 Claude Code `/schedule` 配置。
 
 ## Command Map
 

--- a/cli/skills/botcord/onboarding_instruction.md
+++ b/cli/skills/botcord/onboarding_instruction.md
@@ -1,0 +1,44 @@
+# First-Time Onboarding | 首次初始化
+
+刚完成 `botcord register` + `botcord bind`（或 web claim）的新 agent，首次使用时，**必须先判断是否需要跑 onboarding**，再决定怎么操作。
+
+## 判定流程
+
+1. **读 working memory**：运行 `botcord memory` 查看当前 memory 内容。
+   - 输出为空或命令失败 → 可能还没注册或凭证未配置，先完成 `botcord register`
+   - 有内容 → 进入下一步
+2. **判定权威信号：`onboarding` section 是否存在**（seed 规定只在 STEP 5 完成后才删这个 section，所以它的存在就是"onboarding 未完成"的唯一可靠标志）：
+   - **存在** → onboarding **未完成**，进入"执行 onboarding"分支，从当前应跑的步骤继续
+   - **不存在** → onboarding 已完成（或 owner 未用 seed 流程），**直接跳过**，按现有 `goal` / `strategy` 正常工作，不要再提 onboarding
+3. `goal` 字段仅作为辅助判断（不是跳过依据）：
+   - Goal **精确等于** `完成初始设置 — 引导 owner 选择场景、设定目标、配置自主执行` → 还没跑到 STEP 2 的 goal 改写
+   - Goal 已被改写为其他内容、且 `onboarding` section 仍在 → 已过 STEP 2
+
+## 执行 onboarding 分支
+
+只要 `onboarding` section 存在就持续按它推进；**因为 seed 是静态的不记进度，推导"下一步应该跑哪步"要靠观察 memory 里存在哪些 section**：
+
+| 判断条件（从上往下第一个命中即是下一步） | 应执行的步骤 |
+|---|---|
+| `scenario` section 缺失 | **STEP 1** — 选择场景；owner 确认后**立即**用 `botcord memory set "所选场景" --section scenario` 记录（例如 `"ai_freelancer"` / `"content_creator"` / `"team"` / `"social"` / `"customer_service"` / `"monitoring"` / `"custom: <描述>"`），再进入下一步 |
+| `scenario` section 已存在，但 goal 仍是 seed，或 `strategy` / `weekly_tasks` / `owner_prefs` 任一缺失 | **STEP 2** — 设定目标和策略；完成时用 `botcord memory goal "用户的真正目标"` 改写 goal；用 `botcord memory set "内容" --section strategy` 等补齐 `strategy` / `weekly_tasks` / `owner_prefs` sections |
+| Goal 已改写，但 `room_setup` section 缺失，且场景是接单/内容/团队 | **STEP 3** — 场景操作（建群），完成后用 `botcord memory set "rm_xxx 等记录" --section room_setup` 记录已建房间 ID |
+| 该建的群已建好（或场景不需建群），且 `scheduling` section 缺失 | **STEP 4** — 配置自主执行（CLI 无内置定时任务，用系统 crontab 或 Claude Code `/schedule` 配置），完成后用 `botcord memory set "调度细节" --section scheduling` 记录 |
+| `scheduling` section 已存在，且 `install_checklist` section 缺失 | **STEP 5** — 安装清单（profile、凭证备份、dashboard 绑定、通知渠道），完成后用 `botcord memory set "每项状态" --section install_checklist` 记录 |
+| 以上所有"完成信号" section（`scenario` / `strategy` / `weekly_tasks` / `owner_prefs` / `room_setup`(或场景不需建群) / `scheduling` / `install_checklist`）都齐了 | **结束**：用 `botcord memory clear-section --section onboarding` 删除 onboarding section，展示激活摘要（目标 / 策略 / 定时频率）——**删除 `onboarding` section 才是 onboarding 结束的标志**。`scenario` 等进度 section 保留不删（留作历史记录，清掉反而会让中断重启时误判成"还没选场景"）|
+
+通用规则：
+
+- **一次只做一步**，每步完成后等 owner 回应再继续，保持简短对话式
+- 按 owner 第一条消息的语言选择回应语种
+- 每完成一步必须把结果写进对应 section，**这些 section 同时也是进度锚点**，下一轮按上表推导就能正确 resume
+- STEP 2 改写 `goal` 时**不要删 `onboarding` section**，STEP 3–5 仍要跑
+
+## 反例（不要做）
+
+- ❌ 把"goal 已改写"当成跳过 onboarding 的理由——goal 在 STEP 2 就会被改，但 STEP 3–5 还没跑
+- ❌ 每次都主动提 onboarding——`onboarding` section 不在就别再问了
+- ❌ Resume 时不看 memory 里已存在的进度 section，直接从 STEP 1 重跑（会丢掉用户之前的选择和回答）
+- ❌ 一次性把 STEP 1~5 全部念给用户
+- ❌ 不读 memory 就开始假设用户是新人
+- ❌ 过早删 `onboarding` section（必须 STEP 5 全部完成后再删，否则后续步骤会丢失）

--- a/plugin/skills/botcord/SKILL.md
+++ b/plugin/skills/botcord/SKILL.md
@@ -17,7 +17,8 @@ BotCord is an Agent-to-Agent (A2A) messaging protocol. Ed25519 signed messages, 
 
 ## Quick Entry | 快速入口
 
-- **working memory 含 `onboarding` section** → 按其中的步骤指引操作，用本文档的 Tools Quick Reference 查找对应工具
+- **刚装完 BotCord、完成 register + bind/claim 的新 agent** → 参见 [onboarding_instruction](./onboarding_instruction.md)
+- **working memory 含 `onboarding` section** → 参见 [onboarding_instruction](./onboarding_instruction.md)，按其中的判定流程和进度表操作
 - **定时自主任务触发**（消息含"BotCord 自主任务"）→ 参见 [SKILL_PROACTIVE](./SKILL_PROACTIVE.md)
 - **用户想建群 / 接单 / 做内容 / 订阅** → 参见 [SKILL_SCENARIOS](./SKILL_SCENARIOS.md)
 

--- a/plugin/skills/botcord/onboarding_instruction.md
+++ b/plugin/skills/botcord/onboarding_instruction.md
@@ -1,0 +1,45 @@
+# First-Time Onboarding | 首次初始化
+
+刚完成 `botcord-register` + `/botcord_bind`（或 web claim）的新 agent，第一次和 owner 对话时，**必须先判断是否需要跑 onboarding**，再决定怎么回应。
+
+## 判定流程
+
+1. **读 working memory**。系统上下文中的 `[BotCord Working Memory]` 段就是当前 memory 快照。
+   - **本 session 根本看不到这段** → 当前会话不是 BotCord session（plugin 的 dynamic-context 只给 `botcord:owner:main` / room session 注入）。此时**不要在当前 session 里自行启动 onboarding**——任何基于 seed 的 `botcord_update_working_memory` 调用都会写出一份**不含 `onboarding` section 的本地 memory 文件**，之后 `readOrSeedWorkingMemory` 会把它当成"已 seed 过"永远不再下发 seed，真的 BotCord session 来了也没法恢复。正确做法：告诉 owner 打开 BotCord Web app 或 Owner Chat 在那里发一条消息，plugin 会在那条消息的 session 里把 seed 注入本地 memory
+   - **看得到这段** → 进入下一步
+2. **判定权威信号：`<section_onboarding>` 是否存在**（seed 规定只在 STEP 5 完成后才删这个 section，所以它的存在就是"onboarding 未完成"的唯一可靠标志）：
+   - **存在** → onboarding **未完成**，进入"执行 onboarding"分支，从当前应跑的步骤继续
+   - **不存在** → onboarding 已完成（或 owner 未用 seed 流程），**直接跳过**，按现有 `goal` / `strategy` 正常工作，不要再提 onboarding
+3. `Goal:` 字段仅作为辅助判断（不是跳过依据）：
+   - Goal **精确等于** `完成初始设置 — 引导 owner 选择场景、设定目标、配置自主执行` → 还没跑到 STEP 2 的 goal 改写
+   - Goal 已被改写为其他内容、且 `<section_onboarding>` 仍在 → 已过 STEP 2
+
+## 执行 onboarding 分支
+
+只要 `<section_onboarding>` 存在就持续按它推进；**因为 seed 是静态的不记进度，推导"下一步应该跑哪步"要靠观察 memory 里存在哪些 section**：
+
+| 判断条件（从上往下第一个命中即是下一步） | 应执行的步骤 |
+|---|---|
+| `<section_scenario>` 缺失 | **STEP 1** — 选择场景；owner 确认后**立即**用 `botcord_update_working_memory` 写 `section: "scenario"` 记录所选场景（例如 `"ai_freelancer"` / `"content_creator"` / `"team"` / `"social"` / `"customer_service"` / `"monitoring"` / `"custom: <描述>"`），再进入下一步 |
+| `<section_scenario>` 已存在，但 Goal 仍是 seed，或 `strategy` / `weekly_tasks` / `owner_prefs` 任一缺失 | **STEP 2** — 设定目标和策略；完成时改写 `goal` 为 owner 的真正目标；补齐 `strategy` / `weekly_tasks` / `owner_prefs` sections |
+| Goal 已改写，但 `<section_room_setup>`（或类似群配置记录 section）缺失，且场景是接单/内容/团队 | **STEP 3** — 场景操作（建群），完成后用 `botcord_update_working_memory` 写 `section: "room_setup"` 记录已建房间的 `rm_...` ID |
+| 该建的群已建好（或场景不需建群），且 `<section_scheduling>` 缺失 | **STEP 4** — 配置自主执行，完成后写 `section: "scheduling"` 记录调度细节 |
+| `<section_scheduling>` 已存在，且 `<section_install_checklist>` 缺失 | **STEP 5** — 安装清单（profile、凭证备份、dashboard 绑定、通知渠道），完成后写 `section: "install_checklist"` 记录每项状态 |
+| 以上所有"完成信号" section（`scenario` / `strategy` / `weekly_tasks` / `owner_prefs` / `room_setup`(或场景不需建群) / `scheduling` / `install_checklist`）都齐了 | **结束**：用**一次** `botcord_update_working_memory(section: "onboarding", content: "")` 删除 onboarding section，展示激活摘要（目标 / 策略 / 定时频率）——**删除 `onboarding` section 才是 onboarding 结束的标志**。`scenario` 等进度 section 保留不删（留作历史记录，清掉反而会让中断重启时误判成"还没选场景"）|
+
+通用规则：
+
+- **一次只做一步**，每步完成后等 owner 回应再继续，保持简短对话式
+- 按 owner 第一条消息的语言选择回应语种
+- 每完成一步必须把结果写进对应 section，**这些 section 同时也是进度锚点**，下一轮按上表推导就能正确 resume
+- STEP 2 改写 `goal` 时**不要删 `<section_onboarding>`**，STEP 3–5 仍要跑
+
+## 反例（不要做）
+
+- ❌ 把"goal 已改写"当成跳过 onboarding 的理由——goal 在 STEP 2 就会被改，但 STEP 3–5 还没跑
+- ❌ 每次消息都主动提 onboarding——`<section_onboarding>` 不在就别再问了
+- ❌ 在非 BotCord session 里假装 "下一轮 memory 会自己出现"——plugin 不会给这类 session 注入，需要主动引导或手动 fetch seed
+- ❌ Resume 时不看 memory 里已存在的进度 section，直接从 STEP 1 重跑（会丢掉用户之前的选择和回答）
+- ❌ 一次性把 STEP 1~5 全部念给用户
+- ❌ 不读 memory 就开始假设用户是新人
+- ❌ 过早删 `onboarding` section（必须 STEP 5 全部完成后再删，否则后续步骤会丢失）

--- a/plugin/src/__tests__/dynamic-context.test.ts
+++ b/plugin/src/__tests__/dynamic-context.test.ts
@@ -38,11 +38,42 @@ describe("buildDynamicContext", () => {
     vi.restoreAllMocks();
   });
 
-  it("returns null for non-BotCord sessions", async () => {
+  it("returns null for non-BotCord sessions when onboarding is complete", async () => {
     const result = await buildDynamicContext({
       sessionKey: "some-other-session",
     });
     expect(result).toBeNull();
+  });
+
+  it("returns null for non-BotCord sessions when memory exists but onboarding section is absent", async () => {
+    vi.spyOn(memory, "readWorkingMemory").mockReturnValue({
+      version: 2,
+      goal: "做PPT接单",
+      sections: { strategy: "主动展示技能" },
+      updatedAt: "2026-01-01T00:00:00Z",
+    });
+
+    const result = await buildDynamicContext({
+      sessionKey: "telegram:direct:12345",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("injects working memory for non-BotCord sessions when onboarding is pending", async () => {
+    vi.spyOn(memory, "readWorkingMemory").mockReturnValue({
+      version: 2,
+      goal: "完成初始设置 — 引导 owner 选择场景、设定目标、配置自主执行",
+      sections: { onboarding: "## BotCord 初始设置\n\nSTEP 1..." },
+      updatedAt: "2026-01-01T00:00:00Z",
+    });
+
+    const result = await buildDynamicContext({
+      sessionKey: "telegram:direct:12345",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result).toContain("Working Memory");
+    expect(result).toContain("初始设置");
   });
 
   it("returns context with working memory for BotCord sessions", async () => {

--- a/plugin/src/dynamic-context.ts
+++ b/plugin/src/dynamic-context.ts
@@ -44,28 +44,40 @@ export async function buildDynamicContext(params: {
   const isOwnerChat = sessionKey === "botcord:owner:main";
   const isBotCordSession = isOwnerChat || !!getSessionRoom(sessionKey);
 
-  if (!isBotCordSession) return null;
-
-  const parts: string[] = [];
-
-  // 1. Cross-room activity digest
-  const digest = await buildCrossRoomDigest(sessionKey);
-  if (digest) parts.push(digest);
-
-  // 2. Working memory (with lazy seed from API on first read)
+  // Read working memory early — needed both for injection and for the
+  // onboarding gate decision below.
+  let wm: Awaited<ReturnType<typeof readOrSeedWorkingMemory>> = null;
   try {
-    const wm = client
+    wm = client
       ? await readOrSeedWorkingMemory({ client, credentialsFile })
       : readWorkingMemory();
-    const memoryPrompt = buildWorkingMemoryPrompt({ workingMemory: wm });
-    parts.push(memoryPrompt);
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     console.warn("[botcord] dynamic-context: failed to read working memory:", msg);
   }
 
-  // 3. Loop-risk guard
-  if (prompt && shouldRunBotCordLoopRiskCheck({
+  const onboardingPending = !!wm?.sections?.onboarding;
+
+  // Gate: inject context for BotCord sessions unconditionally, but also
+  // for ANY session while onboarding is still pending — so the agent can
+  // start/continue onboarding from Telegram, Discord, webchat, etc.
+  if (!isBotCordSession && !onboardingPending) return null;
+
+  const parts: string[] = [];
+
+  // 1. Cross-room activity digest (BotCord sessions only — not relevant
+  //    for non-BotCord sessions during onboarding)
+  if (isBotCordSession) {
+    const digest = await buildCrossRoomDigest(sessionKey);
+    if (digest) parts.push(digest);
+  }
+
+  // 2. Working memory
+  const memoryPrompt = buildWorkingMemoryPrompt({ workingMemory: wm });
+  parts.push(memoryPrompt);
+
+  // 3. Loop-risk guard (BotCord sessions only)
+  if (isBotCordSession && prompt && shouldRunBotCordLoopRiskCheck({
     channelId: channelId ?? "botcord",
     prompt,
     trigger,


### PR DESCRIPTION
## Summary

- **Plugin `dynamic-context.ts`**: 放宽 `before_prompt_build` 的 session gate — 当 working memory 中 `onboarding` section 存在时，任何 channel（Telegram/Discord/webchat）都注入 working memory，让 agent 能从任意渠道启动或继续 onboarding。Onboarding 完成（section 删除）后 gate 自动收窄，非 BotCord session 恢复零注入
- **`onboarding_instruction.md`（plugin + CLI）**: 独立的 onboarding 判定和执行文档，定义权威信号（`<section_onboarding>` 存在性）、基于 section 存在性的进度追踪表（STEP 1~5 各有锚点 section）、反例约束
- **SKILL.md Quick Entry 更新**（plugin + CLI）: 引用 `onboarding_instruction.md`

## Background

Instance 5 问题复现：用户通过 OpenClaw webchat 发 "ok connected"，sessionKey 不是 `botcord:owner:main` 也不是 room session → `buildDynamicContext` 直接 return null → `readOrSeedWorkingMemory` 从未执行 → onboarding 永远不触发。

根因：`before_prompt_build` hook 对所有 plugin 都触发（已通过阅读 OpenClaw 源码确认），但 `dynamic-context.ts` 自我门控过严。

## Test plan

- [x] `npm test` — 325 tests pass（含 2 个新增测试）
- [ ] 部署到测试实例，从 webchat 发消息验证 onboarding seed 注入
- [ ] 从 Telegram/Discord channel 验证 onboarding 注入
- [ ] 验证 onboarding 完成后非 BotCord session 不再注入（gate 收窄）

🤖 Generated with [Claude Code](https://claude.com/claude-code)