### PR TITLE
fix(frontend): correct room sidebar preview showing wrong sender

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -60,20 +60,24 @@ class CreateShareBody(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-def _extract_text_preview(envelope_json: str) -> tuple[str, str | None]:
-    """Extract (sender_id, text_preview) from an envelope JSON string."""
+_RECEIPT_TYPES = frozenset({"ack", "result", "error"})
+
+
+def _extract_text_preview(envelope_json: str) -> tuple[str, str | None, str]:
+    """Extract (sender_id, text_preview, msg_type) from an envelope JSON string."""
     try:
         data = json.loads(envelope_json)
     except (json.JSONDecodeError, TypeError):
-        return ("", None)
+        return ("", None, "message")
     sender_id = data.get("from", "")
+    msg_type = data.get("type", "message")
     payload = data.get("payload", {})
     if not isinstance(payload, dict):
         payload = {}
     text_val = payload.get("text") or payload.get("body") or payload.get("message") or ""
     if text_val and not isinstance(text_val, str):
         text_val = str(text_val)
-    return sender_id, (text_val[:200] if text_val else None)
+    return sender_id, (text_val[:200] if text_val else None), str(msg_type)
 
 
 async def _build_rooms_from_sql(
@@ -194,9 +198,40 @@ async def _build_rooms_from_membership(
         .where(MessageRecord.id.in_(select(latest_sub.c.record_id)))
     )
     last_messages: dict[str, MessageRecord] = {}
+    receipt_room_ids: list[str] = []
     for rec in last_msg_result.scalars().all():
-        if rec.room_id:
+        if not rec.room_id:
+            continue
+        _, _, msg_type = _extract_text_preview(rec.envelope_json)
+        if msg_type in _RECEIPT_TYPES:
+            receipt_room_ids.append(rec.room_id)
+        else:
             last_messages[rec.room_id] = rec
+
+    # Second pass: for rooms whose latest record was a receipt, walk back to
+    # find the most recent real message (single batch query).
+    if receipt_room_ids:
+        fallback_dedup = (
+            select(
+                MessageRecord.room_id,
+                MessageRecord.msg_id,
+                func.min(MessageRecord.id).label("min_id"),
+            )
+            .where(MessageRecord.room_id.in_(receipt_room_ids))
+            .group_by(MessageRecord.room_id, MessageRecord.msg_id)
+            .subquery()
+        )
+        fallback_result = await db.execute(
+            select(MessageRecord)
+            .where(MessageRecord.id.in_(select(fallback_dedup.c.min_id)))
+            .order_by(MessageRecord.id.desc())
+        )
+        for rec in fallback_result.scalars().all():
+            rid = rec.room_id
+            if rid and rid not in last_messages:
+                _, _, mt = _extract_text_preview(rec.envelope_json)
+                if mt not in _RECEIPT_TYPES:
+                    last_messages[rid] = rec
 
     sender_ids = {rec.sender_id for rec in last_messages.values()}
     sender_names: dict[str, str] = {}
@@ -217,7 +252,7 @@ async def _build_rooms_from_membership(
         last_at = None
         last_sender = None
         if last_rec:
-            sid, preview = _extract_text_preview(last_rec.envelope_json)
+            sid, preview, _mt = _extract_text_preview(last_rec.envelope_json)
             last_preview = preview
             last_at = last_rec.created_at
             if last_at is not None and last_at.tzinfo is None:

--- a/frontend/db/functions/001_get_agent_room_previews.sql
+++ b/frontend/db/functions/001_get_agent_room_previews.sql
@@ -94,6 +94,7 @@ as $$
     from message_records mr
     left join agents a on a.agent_id = mr.sender_id
     where mr.room_id in (select room_id from member_rooms)
+      and coalesce(mr.envelope_json::jsonb ->> 'type', 'message') not in ('ack', 'result', 'error')
   ),
   latest_message as (
     select

--- a/frontend/db/functions/002_get_public_room_previews.sql
+++ b/frontend/db/functions/002_get_public_room_previews.sql
@@ -82,6 +82,7 @@ as $$
     from message_records mr
     left join agents a on a.agent_id = mr.sender_id
     where mr.room_id in (select room_id from filtered_rooms)
+      and coalesce(mr.envelope_json::jsonb ->> 'type', 'message') not in ('ack', 'result', 'error')
   ),
   latest_message as (
     select

--- a/frontend/src/components/dashboard/AccountMenu.tsx
+++ b/frontend/src/components/dashboard/AccountMenu.tsx
@@ -11,8 +11,9 @@ import { useMemo, useState } from "react";
 import type { UserAgent, UserProfile } from "@/lib/types";
 import AgentBindDialog from "./AgentBindDialog";
 import CredentialResetDialog from "./CredentialResetDialog";
+import UnbindAgentDialog from "./UnbindAgentDialog";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
-import { Check, KeyRound, LogOut, Plus, RefreshCw, Settings, User } from "lucide-react";
+import { Check, KeyRound, LogOut, Plus, RefreshCw, Settings, Unlink, User } from "lucide-react";
 import { useLanguage } from "@/lib/i18n";
 import { accountMenu, bindDialog } from "@/lib/i18n/translations/dashboard";
 import { common } from "@/lib/i18n/translations/common";
@@ -25,6 +26,7 @@ interface AccountMenuProps {
   onSwitchAgent: (agentId: string) => Promise<void> | void;
   onLogout: () => void;
   onAgentBound: (agentId: string) => Promise<void> | void;
+  onAgentUnbound: (agentId: string) => Promise<void> | void;
   onRefreshStatus?: () => Promise<void> | void;
 }
 
@@ -41,11 +43,13 @@ export default function AccountMenu({
   onSwitchAgent,
   onLogout,
   onAgentBound,
+  onAgentUnbound,
   onRefreshStatus,
 }: AccountMenuProps) {
   const [open, setOpen] = useState(false);
   const [showBindDialog, setShowBindDialog] = useState(false);
   const [showResetDialog, setShowResetDialog] = useState(false);
+  const [showUnbindDialog, setShowUnbindDialog] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const locale = useLanguage();
   const t = accountMenu[locale];
@@ -162,6 +166,15 @@ export default function AccountMenu({
               <span>{activeAgentId ? t.resetCredential : t.resetCredentialDisabled}</span>
             </DropdownMenu.Item>
 
+            <DropdownMenu.Item
+              disabled={!activeAgent}
+              onClick={() => activeAgent && setShowUnbindDialog(true)}
+              className="relative flex cursor-pointer select-none items-center rounded-md px-2 py-1.5 text-sm outline-none transition-colors text-red-400 focus:bg-red-400/10 focus:text-red-400 data-[disabled]:cursor-not-allowed data-[disabled]:text-text-secondary/50"
+            >
+              <Unlink className="mr-2 h-4 w-4" />
+              <span>{activeAgent ? t.unbindAgent : t.unbindAgentDisabled}</span>
+            </DropdownMenu.Item>
+
             {user?.beta_admin && (
               <>
                 <DropdownMenu.Separator className="my-1 h-px bg-glass-border" />
@@ -198,6 +211,14 @@ export default function AccountMenu({
         <CredentialResetDialog
           agentId={activeAgentId}
           onClose={() => setShowResetDialog(false)}
+        />
+      ) : null}
+      {showUnbindDialog && activeAgentId && activeAgent ? (
+        <UnbindAgentDialog
+          agentId={activeAgentId}
+          agentName={activeAgent.display_name}
+          onClose={() => setShowUnbindDialog(false)}
+          onUnbound={onAgentUnbound}
         />
       ) : null}
     </>

--- a/frontend/src/components/dashboard/RoomList.tsx
+++ b/frontend/src/components/dashboard/RoomList.tsx
@@ -171,9 +171,23 @@ export default function RoomList({ rooms: propsRooms, loading = false }: RoomLis
       {!loading && rooms.map((room) => {
         const isSelected = messagesPane === "room" && focusedRoomId === room.room_id;
         const roomMessages = messages[room.room_id] || [];
-        const cachedLatestMessage = roomMessages[roomMessages.length - 1];
-        const previewText = room.last_message_preview || cachedLatestMessage?.text || t.noMessagesYet;
-        const previewSender = room.last_sender_name || cachedLatestMessage?.sender_name || "";
+        // Find the latest real message (skip ack/result/error receipts)
+        const cachedLatestMessage = roomMessages.findLast(
+          (m) => m.type !== "ack" && m.type !== "result" && m.type !== "error",
+        );
+        // Preview text and sender must come from the same source to stay consistent
+        let previewText: string;
+        let previewSender: string;
+        if (room.last_message_preview != null || room.last_sender_name != null) {
+          previewText = room.last_message_preview ?? t.noMessagesYet;
+          previewSender = room.last_sender_name ?? "";
+        } else if (cachedLatestMessage) {
+          previewText = cachedLatestMessage.text || t.noMessagesYet;
+          previewSender = cachedLatestMessage.sender_name || "";
+        } else {
+          previewText = t.noMessagesYet;
+          previewSender = "";
+        }
         const previewLine = previewSender ? `${previewSender}: ${previewText}` : previewText;
         const messageTime = formatLastMessageTime(room.last_message_at);
         const avatarLabel = buildRoomAvatarLabel(room.name);

--- a/frontend/src/components/dashboard/Sidebar.tsx
+++ b/frontend/src/components/dashboard/Sidebar.tsx
@@ -481,9 +481,9 @@ export default function Sidebar() {
                   await sessionStore.refreshUserProfile();
                   await chatStore.switchActiveAgent(agentId);
                 }}
-                onAgentUnbound={(agentId) => {
+                onAgentUnbound={async (agentId) => {
                   sessionStore.removeAgent(agentId);
-                  sessionStore.refreshUserProfile();
+                  await sessionStore.refreshUserProfile();
                 }}
                 onRefreshStatus={() => sessionStore.refreshUserProfile()}
               />

--- a/frontend/src/components/dashboard/Sidebar.tsx
+++ b/frontend/src/components/dashboard/Sidebar.tsx
@@ -180,6 +180,7 @@ export default function Sidebar() {
     sessionMode: state.sessionMode,
     token: state.token,
     refreshUserProfile: state.refreshUserProfile,
+    removeAgent: state.removeAgent,
     logout: state.logout,
   })));
   const uiStore = useDashboardUIStore(useShallow((state) => ({
@@ -479,6 +480,10 @@ export default function Sidebar() {
                 onAgentBound={async (agentId) => {
                   await sessionStore.refreshUserProfile();
                   await chatStore.switchActiveAgent(agentId);
+                }}
+                onAgentUnbound={(agentId) => {
+                  sessionStore.removeAgent(agentId);
+                  sessionStore.refreshUserProfile();
                 }}
                 onRefreshStatus={() => sessionStore.refreshUserProfile()}
               />

--- a/frontend/src/components/dashboard/UnbindAgentDialog.tsx
+++ b/frontend/src/components/dashboard/UnbindAgentDialog.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState } from "react";
+import { userApi } from "@/lib/api";
+import { useLanguage } from "@/lib/i18n";
+import { unbindAgentDialog } from "@/lib/i18n/translations/dashboard";
+import { AlertTriangle, Loader2, Unlink, X } from "lucide-react";
+
+interface UnbindAgentDialogProps {
+  agentId: string;
+  agentName: string;
+  onClose: () => void;
+  onUnbound: (agentId: string) => Promise<void> | void;
+}
+
+export default function UnbindAgentDialog({
+  agentId,
+  agentName,
+  onClose,
+  onUnbound,
+}: UnbindAgentDialogProps) {
+  const locale = useLanguage();
+  const t = unbindAgentDialog[locale];
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleUnbind() {
+    setLoading(true);
+    setError(null);
+    try {
+      await userApi.unbindAgent(agentId);
+      await onUnbound(agentId);
+      onClose();
+    } catch (err: any) {
+      setError(err?.message || t.failed);
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-[110] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm">
+      <div className="relative w-full max-w-md rounded-2xl border border-glass-border bg-deep-black-light p-5 shadow-2xl">
+        <button
+          onClick={onClose}
+          disabled={loading}
+          className="absolute right-4 top-4 rounded-full p-1.5 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+        >
+          <X className="h-5 w-5" />
+        </button>
+
+        <div className="mb-5 pr-8">
+          <h3 className="flex items-center gap-2 text-xl font-bold text-text-primary">
+            <Unlink className="h-5 w-5 text-red-400" />
+            {t.title}
+          </h3>
+          <p className="mt-2 text-sm text-text-secondary">{t.description}</p>
+        </div>
+
+        <div className="rounded-xl border border-amber-400/20 bg-amber-400/5 p-3">
+          <div className="flex items-start gap-2">
+            <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-400" />
+            <p className="text-xs text-amber-300">{t.warning}</p>
+          </div>
+        </div>
+
+        <p className="mt-4 text-xs text-text-secondary">
+          {t.targetAgent}
+          <span className="font-mono text-text-primary">{agentName}</span>
+          <span className="ml-1 text-text-secondary/50">({agentId})</span>
+        </p>
+
+        {error && (
+          <p className="mt-4 rounded-lg border border-red-400/20 bg-red-400/10 p-2 text-xs text-red-400">
+            {error}
+          </p>
+        )}
+
+        <div className="mt-6 flex items-center justify-end gap-3">
+          <button
+            onClick={onClose}
+            disabled={loading}
+            className="rounded-xl border border-glass-border px-4 py-2.5 text-sm font-medium text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+          >
+            {t.cancel}
+          </button>
+          <button
+            onClick={handleUnbind}
+            disabled={loading}
+            className="flex items-center gap-2 rounded-xl border border-red-400/50 bg-red-500/10 px-4 py-2.5 text-sm font-bold text-red-400 transition-all hover:bg-red-500/20 disabled:opacity-60"
+          >
+            {loading ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                {t.unbinding}
+              </>
+            ) : (
+              t.confirm
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -259,7 +259,10 @@ export default function UserChatPane() {
     const filesToUpload = [...pendingFiles];
     setInputText("");
     setPendingFiles([]);
-    if (inputRef.current) inputRef.current.value = "";
+    if (inputRef.current) {
+      inputRef.current.value = "";
+      inputRef.current.style.height = "auto";
+    }
     for (const pf of filesToUpload) { if (pf.preview) URL.revokeObjectURL(pf.preview); }
 
     const clientId = crypto.randomUUID();
@@ -311,6 +314,13 @@ export default function UserChatPane() {
       handleSend();
     }
   };
+
+  const autoResize = useCallback(() => {
+    const el = inputRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 120)}px`;
+  }, []);
 
   const handleDrop = useCallback((e: React.DragEvent) => {
     e.preventDefault();
@@ -590,10 +600,10 @@ export default function UserChatPane() {
           </button>
           <textarea
             ref={inputRef}
-            className="flex-1 bg-zinc-900 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-200 placeholder-zinc-500 resize-none focus:outline-none focus:border-cyan-500/50 min-h-[40px] max-h-[120px]"
+            className="flex-1 bg-zinc-900 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-200 placeholder-zinc-500 resize-none focus:outline-none focus:border-cyan-500/50"
             placeholder="Type a message..."
             value={inputText}
-            onChange={(e) => setInputText(e.target.value)}
+            onChange={(e) => { setInputText(e.target.value); autoResize(); }}
             onKeyDown={handleKeyDown}
             rows={1}
           />

--- a/frontend/src/hooks/useOwnerChatWs.ts
+++ b/frontend/src/hooks/useOwnerChatWs.ts
@@ -160,6 +160,8 @@ export function useOwnerChatWs({
       onStatusChange: (connected) => {
         if (connected) {
           store.getState().setWsConnected(true);
+          // Reconcile failed/partial messages against server state after reconnect
+          void store.getState().reconcileAfterReconnect();
         } else {
           store.getState().onDisconnect();
         }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -159,6 +159,17 @@ async function apiPost<T>(path: string, body?: unknown): Promise<T> {
   return res.json();
 }
 
+async function apiDelete<T>(path: string): Promise<T> {
+  const headers = await buildAuthHeaders();
+  const url = new URL(path, API_BASE);
+  const res = await fetch(url.toString(), { method: "DELETE", headers });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({ error: res.statusText }));
+    throw new ApiError(res.status, extractErrorMessage(data, res.statusText));
+  }
+  return res.json();
+}
+
 export const api = {
   // --- Dashboard APIs ---
 
@@ -500,6 +511,15 @@ const userApi = {
 
   getAgentIdentity(agentId: string): Promise<{ agent_id: string; agent_token: string | null }> {
     return apiGet<{ agent_id: string; agent_token: string | null }>(`/api/users/me/agents/${agentId}/identity`);
+  },
+
+  async unbindAgent(agentId: string): Promise<{ ok: boolean }> {
+    const result = await apiDelete<{ ok: boolean }>(`/api/users/me/agents/${agentId}`);
+    invalidateMeCache();
+    if (getActiveAgentId() === agentId) {
+      setActiveAgentId(null);
+    }
+    return result;
   },
 };
 

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -1010,6 +1010,8 @@ export const accountMenu: TranslationMap<{
   createAgent: string
   resetCredential: string
   resetCredentialDisabled: string
+  unbindAgent: string
+  unbindAgentDisabled: string
   wsOnline: string
   wsOffline: string
   refreshStatus: string
@@ -1024,6 +1026,8 @@ export const accountMenu: TranslationMap<{
     createAgent: 'Create Bot',
     resetCredential: 'Reset Bot Credential',
     resetCredentialDisabled: 'Select a Bot first',
+    unbindAgent: 'Unbind Bot',
+    unbindAgentDisabled: 'Select a Bot first',
     wsOnline: 'Online',
     wsOffline: 'Offline',
     refreshStatus: 'Refresh status',
@@ -1038,6 +1042,8 @@ export const accountMenu: TranslationMap<{
     createAgent: '创建 Bot',
     resetCredential: '重置 Bot Credential',
     resetCredentialDisabled: '请先选择一个 Bot',
+    unbindAgent: '解绑 Bot',
+    unbindAgentDisabled: '请先选择一个 Bot',
     wsOnline: '在线',
     wsOffline: '离线',
     refreshStatus: '刷新状态',
@@ -1138,6 +1144,38 @@ export const credentialResetDialog: TranslationMap<{
     copyPromptFailed: '复制 Prompt 失败，请手动复制。',
     ticketExpiresAt: '重置口令过期时间：',
     targetAgent: '目标 Bot：',
+  },
+}
+
+export const unbindAgentDialog: TranslationMap<{
+  title: string
+  description: string
+  warning: string
+  targetAgent: string
+  confirm: string
+  cancel: string
+  unbinding: string
+  failed: string
+}> = {
+  en: {
+    title: 'Unbind Bot',
+    description: 'This will remove the Bot from your account. The Bot identity will still exist on the network, but it will no longer be associated with your account.',
+    warning: 'This action cannot be undone easily. You will need to re-bind the Bot if you want to manage it again.',
+    targetAgent: 'Bot to unbind: ',
+    confirm: 'Confirm Unbind',
+    cancel: 'Cancel',
+    unbinding: 'Unbinding...',
+    failed: 'Failed to unbind Bot',
+  },
+  zh: {
+    title: '解绑 Bot',
+    description: '这将把该 Bot 从你的账户中移除。Bot 身份仍会存在于网络上，但不再与你的账户关联。',
+    warning: '此操作不易撤销。如果你想重新管理该 Bot，需要重新绑定。',
+    targetAgent: '即将解绑：',
+    confirm: '确认解绑',
+    cancel: '取消',
+    unbinding: '解绑中...',
+    failed: '解绑 Bot 失败',
   },
 }
 

--- a/frontend/src/store/useDashboardSessionStore.ts
+++ b/frontend/src/store/useDashboardSessionStore.ts
@@ -27,6 +27,7 @@ interface DashboardSessionState {
   resetSessionState: () => void;
   initAuth: (token: string) => Promise<void>;
   refreshUserProfile: () => Promise<void>;
+  removeAgent: (agentId: string) => void;
   switchActiveAgent: (agentId: string) => Promise<void>;
   logout: () => void;
 }
@@ -170,6 +171,20 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
     } catch (err) {
       console.error("[SessionStore] Failed to refresh user profile:", err);
     }
+  },
+
+  removeAgent: (agentId: string) => {
+    const { ownedAgents, activeAgentId, token } = get();
+    const remaining = ownedAgents.filter((a) => a.agent_id !== agentId);
+    const newActiveId = agentId === activeAgentId
+      ? (remaining.find((a) => a.is_default) || remaining[0])?.agent_id ?? null
+      : activeAgentId;
+    setActiveAgentId(newActiveId);
+    set({
+      ownedAgents: remaining,
+      activeAgentId: newActiveId,
+      sessionMode: resolveSessionMode(token, newActiveId),
+    });
   },
 
   switchActiveAgent: async (agentId: string) => {

--- a/frontend/src/store/useOwnerChatStore.ts
+++ b/frontend/src/store/useOwnerChatStore.ts
@@ -85,6 +85,7 @@ export interface OwnerChatState {
   setWsConnected: (connected: boolean) => void;
   setAgentTyping: (typing: boolean) => void;
   onDisconnect: () => void;
+  reconcileAfterReconnect: () => Promise<void>;
   reset: () => void;
 }
 
@@ -307,9 +308,43 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
       const existingIds = new Set(
         state.messages.filter((m) => m.hubMsgId).map((m) => m.hubMsgId!)
       );
-      const deduped = converted.filter((m) => m.hubMsgId && !existingIds.has(m.hubMsgId));
-      if (deduped.length === 0) return state;
-      return { messages: [...state.messages, ...deduped] };
+
+      // Reconcile: if a server message matches a failed optimistic message, confirm it
+      const failedUserMsgs = state.messages.filter(
+        (m) => m.status === "failed" && m.sender === "user" && m.error === "Connection lost"
+      );
+      let reconciled = state.messages;
+      const reconciledServerIds = new Set<string>();
+
+      if (failedUserMsgs.length > 0) {
+        const serverUserMsgs = converted.filter((m) => m.sender === "user");
+        reconciled = state.messages.map((m) => {
+          if (m.status !== "failed" || m.sender !== "user" || m.error !== "Connection lost") return m;
+          const sendText = m.sendText || m.text;
+          const match = serverUserMsgs.find(
+            (sm) => sm.text === sendText && sm.hubMsgId && !reconciledServerIds.has(sm.hubMsgId)
+          );
+          if (match && match.hubMsgId) {
+            reconciledServerIds.add(match.hubMsgId);
+            return {
+              ...m,
+              hubMsgId: match.hubMsgId,
+              status: "confirmed" as const,
+              createdAt: match.createdAt,
+              error: undefined,
+              sendText: undefined,
+              retryFiles: undefined,
+            };
+          }
+          return m;
+        });
+      }
+
+      const deduped = converted.filter(
+        (m) => m.hubMsgId && !existingIds.has(m.hubMsgId) && !reconciledServerIds.has(m.hubMsgId)
+      );
+      if (deduped.length === 0 && reconciled === state.messages) return state;
+      return { messages: deduped.length > 0 ? [...reconciled, ...deduped] : reconciled };
     });
   },
 
@@ -434,16 +469,100 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
       wsConnected: false,
       agentTyping: false,
       activeTraceId: null,
-      messages: state.messages
-        // Fail all optimistic messages
-        .map((m) =>
-          m.status === "optimistic"
-            ? { ...m, status: "failed" as const, error: "Connection lost" }
-            : m
-        )
-        // Remove streaming messages (cannot be recovered)
-        .filter((m) => m.status !== "streaming"),
+      messages: state.messages.map((m) => {
+        if (m.status === "optimistic") {
+          // Mark as failed but flag for reconnect reconciliation
+          return { ...m, status: "failed" as const, error: "Connection lost" };
+        }
+        if (m.status === "streaming") {
+          // Preserve partial streamed content instead of dropping
+          const partialText = m.text || extractAssistantText(m.streamBlocks);
+          if (!partialText && m.streamBlocks.length === 0) {
+            // Empty streaming placeholder — safe to drop
+            return null;
+          }
+          return {
+            ...m,
+            text: partialText,
+            status: "delivered" as const,
+            // Keep streamBlocks for display (execution blocks, etc.)
+            streamBlocks: m.streamBlocks.filter((b) => b.block.kind !== "assistant"),
+          };
+        }
+        return m;
+      }).filter((m): m is OwnerChatMessage => m !== null),
     })),
+
+  reconcileAfterReconnect: async () => {
+    const { roomId, messages, agentName } = get();
+    if (!roomId) return;
+
+    // Find failed user messages that were caused by disconnect (candidates for reconciliation)
+    const failedMsgs = messages.filter(
+      (m) => m.status === "failed" && m.sender === "user" && m.error === "Connection lost"
+    );
+    if (failedMsgs.length === 0) return;
+
+    try {
+      // Fetch recent messages from server to check if any "failed" sends actually went through
+      const newest = [...messages].reverse().find((m) => m.hubMsgId && m.status !== "failed");
+      const result = newest?.hubMsgId
+        ? await api.getRoomMessages(roomId, { after: newest.hubMsgId, limit: 50 })
+        : await api.getRoomMessages(roomId, { limit: 50 });
+
+      if (result.messages.length === 0) return;
+
+      const serverMsgs = result.messages.map((m) => dashboardMsgToOwnerChat(m, agentName));
+      const serverTexts = new Set(serverMsgs.map((m) => m.text));
+
+      set((state) => {
+        const existingHubIds = new Set(
+          state.messages.filter((m) => m.hubMsgId).map((m) => m.hubMsgId!)
+        );
+
+        const updatedMessages = state.messages.map((m) => {
+          // Only reconcile disconnect-failed user messages
+          if (m.status !== "failed" || m.sender !== "user" || m.error !== "Connection lost") {
+            return m;
+          }
+
+          // Check if server received this message (match by text content)
+          const sendText = m.sendText || m.text;
+          const serverMatch = serverMsgs.find(
+            (sm) => sm.sender === "user" && sm.text === sendText
+          );
+          if (serverMatch) {
+            return {
+              ...m,
+              hubMsgId: serverMatch.hubMsgId,
+              status: "confirmed" as const,
+              createdAt: serverMatch.createdAt,
+              error: undefined,
+              sendText: undefined,
+              retryFiles: undefined,
+            };
+          }
+
+          return m;
+        });
+
+        // Append any new server messages not already in our list
+        const newServerMsgs = serverMsgs.filter(
+          (sm) => sm.hubMsgId && !existingHubIds.has(sm.hubMsgId)
+            // Skip messages we just reconciled above
+            && !updatedMessages.some((m) => m.hubMsgId === sm.hubMsgId)
+        );
+
+        return {
+          messages: newServerMsgs.length > 0
+            ? [...updatedMessages, ...newServerMsgs]
+            : updatedMessages,
+        };
+      });
+    } catch (err) {
+      console.error("[OwnerChatStore] Failed to reconcile after reconnect:", err);
+    }
+  },
 
   reset: () => {
     loadInFlight = false;


### PR DESCRIPTION
## Summary
- SQL functions (`get_agent_room_previews`, `get_public_room_previews`) now filter out receipt records (ack/result/error) before windowing, so the sidebar preview always shows the actual last message sender
- ORM fallback uses a two-pass query to walk back past receipts and find the latest real message
- `RoomList.tsx` preview logic refactored: sender name and text are now sourced atomically from the same data origin (server overview OR cached messages, never mixed); cached messages also skip receipt types via `findLast`

## Test plan
- [x] Backend dashboard tests pass (`tests/test_app/test_app_dashboard.py` — 7/7)
- [x] Frontend TypeScript compiles successfully
- [ ] Deploy SQL functions to production DB (`pnpm db:functions`)
- [ ] Verify sidebar previews show correct sender in rooms with active agent receipts

🤖 Generated with [Claude Code](https://claude.com/claude-code)