### PR TITLE
feat(frontend): guide user to owner-chat after claim

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -67,6 +67,19 @@ body {
   animation: dashboard-skeleton-breathe 1.8s ease-in-out infinite;
 }
 
+@keyframes pulse-border {
+  0%,
+  100% {
+    border-color: rgba(0, 240, 255, 0.25);
+    box-shadow: 0 0 6px rgba(0, 240, 255, 0.05);
+  }
+
+  50% {
+    border-color: rgba(0, 240, 255, 0.55);
+    box-shadow: 0 0 14px rgba(0, 240, 255, 0.15);
+  }
+}
+
 @keyframes dashboard-skeleton-breathe {
   0%,
   100% {

--- a/frontend/src/components/claim/ClaimAgentPage.tsx
+++ b/frontend/src/components/claim/ClaimAgentPage.tsx
@@ -26,7 +26,7 @@ interface ClaimedAgent {
 export default function ClaimAgentPage({ claimCode }: ClaimAgentPageProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const continuePath = searchParams.get("next") || "/chats/messages";
+  const continuePath = searchParams.get("next") || "/chats/messages/__user-chat__";
   const setSessionActiveAgentId = useDashboardSessionStore((state) => state.setActiveAgentId);
 
   const [loading, setLoading] = useState(false);

--- a/frontend/src/components/dashboard/RoomList.tsx
+++ b/frontend/src/components/dashboard/RoomList.tsx
@@ -17,6 +17,7 @@ import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import { useDashboardUnreadStore } from "@/store/useDashboardUnreadStore";
+import { useOwnerChatStore } from "@/store/useOwnerChatStore";
 import SubscriptionBadge from "./SubscriptionBadge";
 
 interface RoomListProps {
@@ -71,8 +72,14 @@ export default function RoomList({ rooms: propsRooms, loading = false }: RoomLis
   })));
   const activeAgentId = useDashboardSessionStore((state) => state.activeAgentId);
   const isRoomUnread = useDashboardUnreadStore((state) => state.isRoomUnread);
+  const ownerChatMessages = useOwnerChatStore((state) => state.messages);
+  const ownerChatLoading = useOwnerChatStore((state) => state.loading);
+  const ownerChatRoomId = useOwnerChatStore((state) => state.roomId);
   const rooms = propsRooms || overview?.rooms || [];
   const showUserChatEntry = Boolean(activeAgentId);
+  // Only show onboarding state when the owner-chat store has been initialized
+  // (roomId is set), to avoid false positives when store is in default empty state.
+  const isOwnerChatEmpty = showUserChatEntry && Boolean(ownerChatRoomId) && !ownerChatLoading && ownerChatMessages.length === 0;
 
   const handleSelect = (roomId: string) => {
     setMessagesPane("room");
@@ -125,15 +132,22 @@ export default function RoomList({ rooms: propsRooms, loading = false }: RoomLis
           title={t.userChatTooltip}
           onClick={handleSelectUserChat}
           onKeyDown={handleUserChatKeyDown}
-          className={`w-full border-l-2 px-4 py-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-cyan/60 ${
+          className={`relative w-full border-l-2 px-4 py-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-cyan/60 ${
             messagesPane === "user-chat"
               ? "border-neon-cyan bg-neon-cyan/10"
-              : "border-transparent hover:bg-glass-bg"
+              : isOwnerChatEmpty
+                ? "border-neon-cyan/50 bg-neon-cyan/[0.06] animate-[pulse-border_2s_ease-in-out_infinite]"
+                : "border-transparent hover:bg-glass-bg"
           }`}
         >
           <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-neon-cyan/30 bg-neon-cyan/10 text-neon-cyan">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" className="h-5 w-5">
+            <div className={`relative flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border text-neon-cyan ${
+              isOwnerChatEmpty ? "border-neon-cyan/50 bg-neon-cyan/15" : "border-neon-cyan/30 bg-neon-cyan/10"
+            }`}>
+              {isOwnerChatEmpty && (
+                <div className="absolute inset-0 rounded-xl bg-neon-cyan/20 blur-md animate-pulse" />
+              )}
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" className="relative h-5 w-5">
                 <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z" />
               </svg>
             </div>
@@ -144,10 +158,15 @@ export default function RoomList({ rooms: propsRooms, loading = false }: RoomLis
                   <span className="rounded-full border border-neon-cyan/35 bg-neon-cyan/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-neon-cyan">
                     {t.userChatBadge}
                   </span>
+                  {isOwnerChatEmpty && (
+                    <span className="rounded-full bg-neon-green/20 border border-neon-green/40 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-neon-green animate-pulse">
+                      {t.userChatOnboardingBadge}
+                    </span>
+                  )}
                 </span>
               </div>
-              <p className="mt-0.5 truncate text-xs text-text-secondary">
-                {t.userChatPreview}
+              <p className={`mt-0.5 truncate text-xs ${isOwnerChatEmpty ? "text-neon-cyan/70" : "text-text-secondary"}`}>
+                {isOwnerChatEmpty ? t.userChatOnboardingPreview : t.userChatPreview}
               </p>
             </div>
           </div>

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import { Send, Loader2, MessageSquare, AlertCircle, RotateCcw, Bell, Paperclip, X, FileText } from "lucide-react";
+import { Send, Loader2, MessageSquare, AlertCircle, RotateCcw, Bell, Paperclip, X, FileText, ChevronDown } from "lucide-react";
 import { api } from "@/lib/api";
 import type { Attachment, OwnerChatMessage } from "@/lib/types";
 import type { WsAttachment } from "@/lib/owner-chat-ws";
@@ -148,6 +148,15 @@ export default function UserChatPane() {
       });
     }
   }, [loading, messages]);
+
+  // ------ Auto-focus input when empty (onboarding) ------
+  useEffect(() => {
+    if (!loading && messages.length === 0 && inputRef.current) {
+      // Small delay so the welcome UI renders first
+      const timer = setTimeout(() => inputRef.current?.focus(), 300);
+      return () => clearTimeout(timer);
+    }
+  }, [loading, messages.length]);
 
   // ------ Scroll helpers ------
 
@@ -385,8 +394,65 @@ export default function UserChatPane() {
           </div>
         )}
         {messages.length === 0 && (
-          <div className="flex items-center justify-center h-full text-zinc-500 text-sm">
-            <p>Send a message to start the conversation</p>
+          <div className="flex flex-col items-center justify-center h-full gap-4 px-6">
+            {/* Glowing avatar */}
+            <div className="relative">
+              <div className="absolute inset-0 rounded-2xl bg-cyan-500/20 blur-xl animate-pulse" />
+              <div className="relative flex h-16 w-16 items-center justify-center rounded-2xl border border-cyan-500/40 bg-cyan-500/10">
+                <MessageSquare className="h-8 w-8 text-cyan-400" />
+              </div>
+            </div>
+
+            {/* Welcome text */}
+            <div className="text-center">
+              <p className="text-base font-semibold text-zinc-100">
+                {chatRoomName ? `${chatRoomName} is ready!` : "Your Bot is ready!"}
+              </p>
+              <p className="mt-1.5 text-sm text-zinc-400 max-w-sm">
+                Send your first message to start the conversation.
+              </p>
+            </div>
+
+            {/* Suggestion chips */}
+            <div className="flex flex-wrap justify-center gap-2 max-w-md">
+              {[
+                { emoji: "👋", text: "Hey! What can you do?" },
+                { emoji: "💡", text: "Tell me about yourself" },
+                { emoji: "🚀", text: "Let's get started!" },
+              ].map((suggestion) => (
+                <button
+                  key={suggestion.text}
+                  onClick={() => {
+                    const clientId = crypto.randomUUID();
+                    const optimisticMsg: OwnerChatMessage = {
+                      clientId,
+                      hubMsgId: null,
+                      sender: "user",
+                      text: suggestion.text,
+                      streamBlocks: [],
+                      status: "optimistic",
+                      createdAt: new Date().toISOString(),
+                      senderName: "You",
+                      type: "message",
+                      sendText: suggestion.text,
+                    };
+                    useOwnerChatStore.getState().addOptimistic(optimisticMsg);
+                    scrollToBottom();
+                    void sendMessage(suggestion.text, clientId);
+                  }}
+                  className="group flex items-center gap-1.5 rounded-xl border border-zinc-700 bg-zinc-800/80 px-3.5 py-2 text-sm text-zinc-300 transition-all hover:border-cyan-500/50 hover:bg-cyan-500/10 hover:text-cyan-300 hover:shadow-[0_0_12px_rgba(0,240,255,0.15)]"
+                >
+                  <span>{suggestion.emoji}</span>
+                  <span>{suggestion.text}</span>
+                </button>
+              ))}
+            </div>
+
+            {/* Bouncing arrow pointing to input */}
+            <div className="mt-2 flex flex-col items-center gap-1 text-zinc-500">
+              <span className="text-xs">or type your own message</span>
+              <ChevronDown className="h-5 w-5 animate-bounce" />
+            </div>
           </div>
         )}
 
@@ -559,7 +625,7 @@ export default function UserChatPane() {
       </div>
 
       {/* Input */}
-      <div className="border-t border-zinc-800 px-4 py-3" onDrop={handleDrop} onDragOver={handleDragOver}>
+      <div className={`border-t px-4 py-3 transition-colors ${messages.length === 0 ? "border-cyan-500/30 bg-cyan-500/[0.03]" : "border-zinc-800"}`} onDrop={handleDrop} onDragOver={handleDragOver}>
         {pendingFiles.length > 0 && (
           <div className="flex flex-wrap gap-2 mb-2">
             {pendingFiles.map((pf, idx) => (
@@ -600,8 +666,12 @@ export default function UserChatPane() {
           </button>
           <textarea
             ref={inputRef}
-            className="flex-1 bg-zinc-900 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-200 placeholder-zinc-500 resize-none focus:outline-none focus:border-cyan-500/50"
-            placeholder="Type a message..."
+            className={`flex-1 bg-zinc-900 border rounded-lg px-3 py-2 text-sm text-zinc-200 placeholder-zinc-500 resize-none focus:outline-none focus:border-cyan-500/50 transition-all ${
+              messages.length === 0
+                ? "border-cyan-500/40 shadow-[0_0_8px_rgba(0,240,255,0.1)] animate-[pulse-border_2s_ease-in-out_infinite]"
+                : "border-zinc-700"
+            }`}
+            placeholder={messages.length === 0 ? "Say something to your Bot..." : "Type a message..."}
             value={inputText}
             onChange={(e) => { setInputText(e.target.value); autoResize(); }}
             onKeyDown={handleKeyDown}

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -243,6 +243,8 @@ export const roomList: TranslationMap<{
   userChatPreview: string
   userChatTooltip: string
   userChatAriaLabel: string
+  userChatOnboardingBadge: string
+  userChatOnboardingPreview: string
   joinFailed: string
   joinRequests: string
   noJoinRequests: string
@@ -274,6 +276,8 @@ export const roomList: TranslationMap<{
     userChatPreview: 'Private 1:1 entry for chatting with your current Bot.',
     userChatTooltip: 'Open the private chat between you and your current active Bot.',
     userChatAriaLabel: 'Open private chat between you and your current active Bot',
+    userChatOnboardingBadge: 'Start',
+    userChatOnboardingPreview: 'Send your first message!',
     joinFailed: 'Failed to join group',
     joinRequests: 'Join Requests',
     noJoinRequests: 'No pending requests',
@@ -306,6 +310,8 @@ export const roomList: TranslationMap<{
     userChatPreview: '你和当前 Bot 的一对一聊天入口。',
     userChatTooltip: '打开你与当前 Bot 的私聊，用于直接给自己的 Bot 发消息。',
     userChatAriaLabel: '打开你与当前 Bot 的私聊入口',
+    userChatOnboardingBadge: '开始',
+    userChatOnboardingPreview: '发送你的第一条消息！',
     joinRequests: '入群申请',
     noJoinRequests: '暂无待处理申请',
     accept: '通过',


### PR DESCRIPTION
## Summary
- Claim 成功后直接跳转到 `/chats/messages/__user-chat__`，用户直接进入和 Bot 的 1:1 私聊
- UserChatPane 空消息状态增加强引导：发光头像、欢迎文案、3 个可点击 suggestion chips（点击即发送）、向下弹跳箭头、输入框脉冲发光边框
- Sidebar RoomList 的 "Me & My Bot" 入口在空聊天时显示脉冲动画 + 绿色 "Start" badge
- 新增 `pulse-border` CSS keyframe 动画，i18n 支持 (en/zh)
- `isOwnerChatEmpty` 使用 `ownerChatRoomId` 守卫防止 store 未初始化时误判

## Test plan
- [ ] 用 claim URL 认领一个新 agent，确认跳转到 owner-chat 而非空 room 列表
- [ ] 验证 UserChatPane 空状态展示：发光图标、欢迎文案、3 个 suggestion chips、弹跳箭头
- [ ] 点击 suggestion chip，确认消息立即发送并显示在聊天中
- [ ] 验证 sidebar "Me & My Bot" 入口在空聊天时显示 START badge 和脉冲动画
- [ ] 发送第一条消息后，所有 onboarding 指示自动消失
- [ ] 切换到其他 tab 再回来，确认已有消息的用户不会看到 onboarding 状态
- [ ] 中文 locale 下确认 i18n 文案正确（"开始" / "发送你的第一条消息！"）

🤖 Generated with [Claude Code](https://claude.com/claude-code)