### PR TITLE
feat: add Activity panel with observability dashboard

### DIFF
--- a/backend/app/routers/activity.py
+++ b/backend/app/routers/activity.py
@@ -1,0 +1,363 @@
+"""Activity / observability API routes under /api/dashboard/activity."""
+
+import datetime
+import logging
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import distinct, func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import RequestContext, require_active_agent
+from hub.database import get_db
+from hub.models import (
+    Agent,
+    MessageRecord,
+    MessageState,
+    Room,
+    Topic,
+    TopicStatus,
+)
+
+_logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/dashboard", tags=["app-activity"])
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _period_start(period: str) -> datetime.datetime:
+    """Return the UTC start time for the given period string."""
+    now = datetime.datetime.now(datetime.timezone.utc)
+    if period == "7d":
+        return now - datetime.timedelta(days=7)
+    if period == "30d":
+        return now - datetime.timedelta(days=30)
+    # Default: "today" — start of current UTC day
+    return now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+# ---------------------------------------------------------------------------
+# 1. GET /api/dashboard/activity/stats
+# ---------------------------------------------------------------------------
+
+
+@router.get("/activity/stats")
+async def get_activity_stats(
+    period: str = Query(default="today", pattern="^(today|7d|30d)$"),
+    ctx: RequestContext = Depends(require_active_agent),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return overview statistics cards for the active agent."""
+    agent_id = ctx.active_agent_id
+    start = _period_start(period)
+
+    # --- messages_sent (deduplicated by msg_id) ---
+    sent_result = await db.execute(
+        select(func.count(distinct(MessageRecord.msg_id))).where(
+            MessageRecord.sender_id == agent_id,
+            MessageRecord.created_at >= start,
+        )
+    )
+    messages_sent = sent_result.scalar() or 0
+
+    # --- messages_received ---
+    received_result = await db.execute(
+        select(func.count()).select_from(MessageRecord).where(
+            MessageRecord.receiver_id == agent_id,
+            MessageRecord.created_at >= start,
+        )
+    )
+    messages_received = received_result.scalar() or 0
+
+    # --- topics: find topic_ids where agent participates and updated within period ---
+    # Agent participates if they are creator_id OR have sent/received messages with that topic_id.
+    msg_topic_sub = (
+        select(distinct(MessageRecord.topic_id))
+        .where(
+            MessageRecord.topic_id.isnot(None),
+            or_(
+                MessageRecord.sender_id == agent_id,
+                MessageRecord.receiver_id == agent_id,
+            ),
+        )
+        .subquery()
+    )
+
+    topic_counts_result = await db.execute(
+        select(
+            Topic.status,
+            func.count().label("cnt"),
+        )
+        .where(
+            Topic.updated_at >= start,
+            or_(
+                Topic.creator_id == agent_id,
+                Topic.topic_id.in_(select(msg_topic_sub)),
+            ),
+        )
+        .group_by(Topic.status)
+    )
+    topic_counts: dict[str, int] = {}
+    for row in topic_counts_result.all():
+        status_val = row[0].value if hasattr(row[0], "value") else str(row[0])
+        topic_counts[status_val] = row[1]
+
+    topics_open = topic_counts.get("open", 0)
+    topics_completed = topic_counts.get("completed", 0)
+    topics_failed = topic_counts.get("failed", 0)
+
+    # --- delivery_success_rate & failed_messages ---
+    # Count by state for messages sent by this agent within the period (deduplicated).
+    # We use a subquery to first pick min(id) per msg_id for deduplication.
+    dedup_sent = (
+        select(
+            MessageRecord.msg_id,
+            func.min(MessageRecord.id).label("min_id"),
+        )
+        .where(
+            MessageRecord.sender_id == agent_id,
+            MessageRecord.created_at >= start,
+        )
+        .group_by(MessageRecord.msg_id)
+        .subquery()
+    )
+
+    state_counts_result = await db.execute(
+        select(
+            MessageRecord.state,
+            func.count().label("cnt"),
+        )
+        .where(MessageRecord.id.in_(select(dedup_sent.c.min_id)))
+        .group_by(MessageRecord.state)
+    )
+    state_counts: dict[str, int] = {}
+    for row in state_counts_result.all():
+        state_val = row[0].value if hasattr(row[0], "value") else str(row[0])
+        state_counts[state_val] = row[1]
+
+    total_sent_records = sum(state_counts.values())
+    success_states = state_counts.get("delivered", 0) + state_counts.get("acked", 0) + state_counts.get("done", 0)
+    delivery_success_rate = round(success_states / total_sent_records, 3) if total_sent_records > 0 else 1.0
+    failed_messages = state_counts.get("failed", 0)
+
+    # --- active_rooms ---
+    active_rooms_result = await db.execute(
+        select(func.count(distinct(MessageRecord.room_id))).where(
+            MessageRecord.room_id.isnot(None),
+            MessageRecord.created_at >= start,
+            or_(
+                MessageRecord.sender_id == agent_id,
+                MessageRecord.receiver_id == agent_id,
+            ),
+        )
+    )
+    active_rooms = active_rooms_result.scalar() or 0
+
+    return {
+        "messages_sent": messages_sent,
+        "messages_received": messages_received,
+        "topics_open": topics_open,
+        "topics_completed": topics_completed,
+        "topics_failed": topics_failed,
+        "delivery_success_rate": delivery_success_rate,
+        "failed_messages": failed_messages,
+        "active_rooms": active_rooms,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 2. GET /api/dashboard/activity/topics
+# ---------------------------------------------------------------------------
+
+
+@router.get("/activity/topics")
+async def get_activity_topics(
+    status: str | None = Query(default=None, pattern="^(open|completed|failed|expired)$"),
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+    ctx: RequestContext = Depends(require_active_agent),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return recent topics the active agent participates in."""
+    agent_id = ctx.active_agent_id
+
+    # Subquery: topic_ids where the agent has sent/received messages
+    msg_topic_sub = (
+        select(distinct(MessageRecord.topic_id))
+        .where(
+            MessageRecord.topic_id.isnot(None),
+            or_(
+                MessageRecord.sender_id == agent_id,
+                MessageRecord.receiver_id == agent_id,
+            ),
+        )
+        .subquery()
+    )
+
+    # Base filter: agent is creator OR has messages in the topic
+    base_filter = or_(
+        Topic.creator_id == agent_id,
+        Topic.topic_id.in_(select(msg_topic_sub)),
+    )
+
+    # Count total
+    count_stmt = select(func.count()).select_from(Topic).where(base_filter)
+    if status:
+        count_stmt = count_stmt.where(Topic.status == status)
+    total_result = await db.execute(count_stmt)
+    total = total_result.scalar() or 0
+
+    # Fetch topics with room name
+    stmt = (
+        select(Topic, Room.name.label("room_name"))
+        .outerjoin(Room, Room.room_id == Topic.room_id)
+        .where(base_filter)
+    )
+    if status:
+        stmt = stmt.where(Topic.status == status)
+    stmt = stmt.order_by(Topic.updated_at.desc()).offset(offset).limit(limit)
+
+    result = await db.execute(stmt)
+    rows = result.all()
+
+    topics = []
+    for t, room_name in rows:
+        topics.append({
+            "topic_id": t.topic_id,
+            "title": t.title,
+            "status": t.status.value if hasattr(t.status, "value") else str(t.status),
+            "room_id": t.room_id,
+            "room_name": room_name,
+            "goal": t.goal,
+            "message_count": t.message_count,
+            "creator_id": t.creator_id,
+            "created_at": t.created_at.isoformat() if t.created_at else None,
+            "updated_at": t.updated_at.isoformat() if t.updated_at else None,
+            "closed_at": t.closed_at.isoformat() if t.closed_at else None,
+        })
+
+    return {"topics": topics, "total": total}
+
+
+# ---------------------------------------------------------------------------
+# 3. GET /api/dashboard/activity/issues
+# ---------------------------------------------------------------------------
+
+
+@router.get("/activity/issues")
+async def get_activity_issues(
+    ctx: RequestContext = Depends(require_active_agent),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return anomalies/issues that need attention for the active agent."""
+    agent_id = ctx.active_agent_id
+    now = datetime.datetime.now(datetime.timezone.utc)
+    seven_days_ago = now - datetime.timedelta(days=7)
+    one_hour_ago = now - datetime.timedelta(hours=1)
+
+    # --- failed_messages: last 7 days, limit 50 ---
+    # Join Agent for receiver_name, join Room for room_name
+    ReceiverAgent = Agent.__table__.alias("receiver_agent")
+
+    failed_stmt = (
+        select(
+            MessageRecord.hub_msg_id,
+            MessageRecord.receiver_id,
+            ReceiverAgent.c.display_name.label("receiver_name"),
+            MessageRecord.room_id,
+            Room.name.label("room_name"),
+            MessageRecord.last_error,
+            MessageRecord.retry_count,
+            MessageRecord.created_at,
+        )
+        .outerjoin(ReceiverAgent, ReceiverAgent.c.agent_id == MessageRecord.receiver_id)
+        .outerjoin(Room, Room.room_id == MessageRecord.room_id)
+        .where(
+            MessageRecord.sender_id == agent_id,
+            MessageRecord.state == MessageState.failed,
+            MessageRecord.created_at >= seven_days_ago,
+        )
+        .order_by(MessageRecord.created_at.desc())
+        .limit(50)
+    )
+    failed_result = await db.execute(failed_stmt)
+    failed_rows = failed_result.all()
+
+    failed_messages = [
+        {
+            "hub_msg_id": row.hub_msg_id,
+            "receiver_id": row.receiver_id,
+            "receiver_name": row.receiver_name,
+            "room_id": row.room_id,
+            "room_name": row.room_name,
+            "last_error": row.last_error,
+            "retry_count": row.retry_count,
+            "created_at": row.created_at.isoformat() if row.created_at else None,
+        }
+        for row in failed_rows
+    ]
+
+    # --- stale_topics: open topics where agent participates, updated > 1 hour ago ---
+    msg_topic_sub = (
+        select(distinct(MessageRecord.topic_id))
+        .where(
+            MessageRecord.topic_id.isnot(None),
+            or_(
+                MessageRecord.sender_id == agent_id,
+                MessageRecord.receiver_id == agent_id,
+            ),
+        )
+        .subquery()
+    )
+
+    stale_stmt = (
+        select(
+            Topic.topic_id,
+            Topic.title,
+            Room.name.label("room_name"),
+            Topic.status,
+            Topic.message_count,
+            Topic.updated_at,
+        )
+        .outerjoin(Room, Room.room_id == Topic.room_id)
+        .where(
+            Topic.status == TopicStatus.open,
+            Topic.updated_at < one_hour_ago,
+            or_(
+                Topic.creator_id == agent_id,
+                Topic.topic_id.in_(select(msg_topic_sub)),
+            ),
+        )
+        .order_by(Topic.updated_at.asc())
+        .limit(50)
+    )
+    stale_result = await db.execute(stale_stmt)
+    stale_rows = stale_result.all()
+
+    stale_topics = []
+    for row in stale_rows:
+        updated_at = row.updated_at
+        hours_since = 0
+        if updated_at:
+            if updated_at.tzinfo is None:
+                updated_at = updated_at.replace(tzinfo=datetime.timezone.utc)
+            delta = now - updated_at
+            hours_since = round(delta.total_seconds() / 3600, 1)
+
+        stale_topics.append({
+            "topic_id": row.topic_id,
+            "title": row.title,
+            "room_name": row.room_name,
+            "status": row.status.value if hasattr(row.status, "value") else str(row.status),
+            "message_count": row.message_count,
+            "updated_at": row.updated_at.isoformat() if row.updated_at else None,
+            "hours_since_update": hours_since,
+        })
+
+    return {
+        "failed_messages": failed_messages,
+        "stale_topics": stale_topics,
+    }

--- a/backend/hub/main.py
+++ b/backend/hub/main.py
@@ -57,6 +57,7 @@ from app.routers.wallet import router as app_wallet_router
 from app.routers.subscriptions import router as app_subscriptions_router
 from app.routers.beta import router as app_beta_router
 from app.routers.admin_beta import router as app_admin_beta_router
+from app.routers.activity import router as app_activity_router
 from app.routers.prompts import router as app_prompts_router
 from app.auth import require_beta_user
 
@@ -239,6 +240,7 @@ app.include_router(share_public_router)
 app.include_router(app_users_router)
 # Product routers: gated by beta_access
 _beta_gate = [Depends(require_beta_user)]
+app.include_router(app_activity_router, dependencies=_beta_gate)
 app.include_router(app_dashboard_router, dependencies=_beta_gate)
 app.include_router(app_invites_router)
 app.include_router(app_public_router)

--- a/frontend/src/components/dashboard/ActivityPanel.tsx
+++ b/frontend/src/components/dashboard/ActivityPanel.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { api } from "@/lib/api";
+import type { ActivityStats, ActivityTopic, ActivityIssues } from "@/lib/types";
+import { useLanguage } from "@/lib/i18n";
+import { sidebar } from "@/lib/i18n/translations/dashboard";
+
+type Period = "today" | "7d" | "30d";
+type TopicFilter = "" | "open" | "completed" | "failed" | "expired";
+
+// ---------------------------------------------------------------------------
+// Stat card
+// ---------------------------------------------------------------------------
+
+function StatCard({
+  label,
+  value,
+  sub,
+  tone = "cyan",
+}: {
+  label: string;
+  value: string | number;
+  sub?: string;
+  tone?: "cyan" | "green" | "red" | "purple";
+}) {
+  const toneMap = {
+    cyan: "text-neon-cyan",
+    green: "text-neon-green",
+    red: "text-red-400",
+    purple: "text-neon-purple",
+  };
+  return (
+    <div className="rounded-xl border border-glass-border bg-glass-bg p-4">
+      <p className="mb-1 text-[10px] font-medium uppercase tracking-wider text-text-secondary">
+        {label}
+      </p>
+      <p className={`font-mono text-lg font-semibold ${toneMap[tone]}`}>{value}</p>
+      {sub && <p className="mt-0.5 text-[10px] text-text-secondary">{sub}</p>}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Topic status badge
+// ---------------------------------------------------------------------------
+
+function TopicBadge({ status }: { status: string }) {
+  const map: Record<string, { bg: string; text: string; label: string }> = {
+    open: { bg: "bg-neon-cyan/15", text: "text-neon-cyan", label: "Open" },
+    completed: { bg: "bg-neon-green/15", text: "text-neon-green", label: "Done" },
+    failed: { bg: "bg-red-500/15", text: "text-red-400", label: "Failed" },
+    expired: { bg: "bg-yellow-500/15", text: "text-yellow-400", label: "Expired" },
+  };
+  const s = map[status] ?? map.open;
+  return (
+    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold ${s.bg} ${s.text}`}>
+      {s.label}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Time ago helper
+// ---------------------------------------------------------------------------
+
+function timeAgo(iso: string | null): string {
+  if (!iso) return "";
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
+// ---------------------------------------------------------------------------
+// Main panel
+// ---------------------------------------------------------------------------
+
+export default function ActivityPanel() {
+  const locale = useLanguage();
+  const t = sidebar[locale];
+
+  const [period, setPeriod] = useState<Period>("today");
+  const [topicFilter, setTopicFilter] = useState<TopicFilter>("");
+  const [stats, setStats] = useState<ActivityStats | null>(null);
+  const [topics, setTopics] = useState<ActivityTopic[]>([]);
+  const [topicsTotal, setTopicsTotal] = useState(0);
+  const [issues, setIssues] = useState<ActivityIssues | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadData = useCallback(async (p: Period, tf: TopicFilter) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [statsRes, topicsRes, issuesRes] = await Promise.all([
+        api.getActivityStats(p),
+        api.getActivityTopics({ status: tf || undefined, limit: 20 }),
+        api.getActivityIssues(),
+      ]);
+      setStats(statsRes);
+      setTopics(topicsRes.topics);
+      setTopicsTotal(topicsRes.total);
+      setIssues(issuesRes);
+    } catch (err: any) {
+      setError(err?.message ?? "Failed to load activity data");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadData(period, topicFilter);
+  }, [period, topicFilter, loadData]);
+
+  const periodLabels: Record<Period, string> = {
+    today: locale === "zh" ? "今日" : "Today",
+    "7d": locale === "zh" ? "近7天" : "7 Days",
+    "30d": locale === "zh" ? "近30天" : "30 Days",
+  };
+
+  const filterLabels: Record<TopicFilter, string> = {
+    "": locale === "zh" ? "全部" : "All",
+    open: "Open",
+    completed: locale === "zh" ? "已完成" : "Done",
+    failed: locale === "zh" ? "失败" : "Failed",
+    expired: locale === "zh" ? "过期" : "Expired",
+  };
+
+  const hasIssues = issues && (issues.failed_messages.length > 0 || issues.stale_topics.length > 0);
+
+  return (
+    <div className="flex flex-1 flex-col overflow-hidden bg-deep-black">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-glass-border px-6 py-4">
+        <h1 className="text-base font-semibold text-text-primary">{t.activity}</h1>
+        {/* Period selector */}
+        <div className="flex gap-1 rounded-lg border border-glass-border bg-glass-bg p-0.5">
+          {(["today", "7d", "30d"] as Period[]).map((p) => (
+            <button
+              key={p}
+              onClick={() => setPeriod(p)}
+              className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
+                period === p
+                  ? "bg-neon-cyan/15 text-neon-cyan"
+                  : "text-text-secondary hover:text-text-primary"
+              }`}
+            >
+              {periodLabels[p]}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Scrollable body */}
+      <div className="flex-1 overflow-y-auto px-6 py-5 space-y-6">
+        {error ? (
+          <div className="flex flex-col items-center gap-3 py-12">
+            <p className="text-sm text-red-400">{error}</p>
+            <button
+              onClick={() => loadData(period, topicFilter)}
+              className="rounded-lg border border-glass-border px-4 py-1.5 text-xs text-text-secondary hover:text-text-primary transition-colors"
+            >
+              {locale === "zh" ? "重试" : "Retry"}
+            </button>
+          </div>
+        ) : loading && !stats ? (
+          <div className="flex items-center justify-center py-16">
+            <div className="h-6 w-6 animate-spin rounded-full border-2 border-glass-border border-t-neon-cyan" />
+          </div>
+        ) : (
+          <>
+            {/* Stats cards */}
+            {stats && (
+              <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+                <StatCard
+                  label={locale === "zh" ? "消息" : "Messages"}
+                  value={`${stats.messages_sent} / ${stats.messages_received}`}
+                  sub={locale === "zh" ? "发送 / 接收" : "Sent / Received"}
+                />
+                <StatCard
+                  label={locale === "zh" ? "活跃对话" : "Active Topics"}
+                  value={stats.topics_open}
+                  sub={`${stats.topics_completed} ${locale === "zh" ? "已完成" : "done"}, ${stats.topics_failed} ${locale === "zh" ? "失败" : "failed"}`}
+                  tone="purple"
+                />
+                <StatCard
+                  label={locale === "zh" ? "投递成功率" : "Delivery Rate"}
+                  value={`${(stats.delivery_success_rate * 100).toFixed(1)}%`}
+                  tone={stats.delivery_success_rate >= 0.95 ? "green" : "red"}
+                />
+                <StatCard
+                  label={locale === "zh" ? "活跃房间" : "Active Rooms"}
+                  value={stats.active_rooms}
+                  tone="cyan"
+                />
+              </div>
+            )}
+
+            {/* Issues banner */}
+            {hasIssues && (
+              <div className="rounded-xl border border-red-500/30 bg-red-500/5 p-4">
+                <h3 className="mb-2 text-xs font-semibold text-red-400">
+                  {locale === "zh" ? "需要关注" : "Needs Attention"}
+                </h3>
+                {issues!.failed_messages.length > 0 && (
+                  <div className="mb-2">
+                    <p className="text-[11px] text-text-secondary">
+                      {issues!.failed_messages.length} {locale === "zh" ? "条消息发送失败" : "failed message(s)"}
+                    </p>
+                    <div className="mt-1 space-y-1">
+                      {issues!.failed_messages.slice(0, 3).map((m) => (
+                        <div key={m.hub_msg_id} className="flex items-center gap-2 text-[10px] text-text-secondary">
+                          <span className="text-red-400">x</span>
+                          <span className="truncate">{m.receiver_name ?? m.receiver_id}</span>
+                          {m.room_name && <span className="text-text-secondary/50">in {m.room_name}</span>}
+                          <span className="ml-auto shrink-0 text-text-secondary/50">{m.last_error}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {issues!.stale_topics.length > 0 && (
+                  <div>
+                    <p className="text-[11px] text-text-secondary">
+                      {issues!.stale_topics.length} {locale === "zh" ? "个对话可能卡住了" : "stale topic(s)"}
+                    </p>
+                    <div className="mt-1 space-y-1">
+                      {issues!.stale_topics.slice(0, 3).map((st) => (
+                        <div key={st.topic_id} className="flex items-center gap-2 text-[10px] text-text-secondary">
+                          <span className="text-yellow-400">!</span>
+                          <span className="truncate">{st.title}</span>
+                          <span className="ml-auto shrink-0 text-text-secondary/50">
+                            {st.hours_since_update}h {locale === "zh" ? "无更新" : "idle"}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Topics section */}
+            <div>
+              <div className="mb-3 flex items-center justify-between">
+                <h2 className="text-sm font-semibold text-text-primary">
+                  {locale === "zh" ? "最近对话" : "Recent Topics"}
+                  <span className="ml-2 text-xs font-normal text-text-secondary">({topicsTotal})</span>
+                </h2>
+                {/* Status filter */}
+                <div className="flex gap-1">
+                  {(["", "open", "completed", "failed"] as TopicFilter[]).map((f) => (
+                    <button
+                      key={f}
+                      onClick={() => setTopicFilter(f)}
+                      className={`rounded-md px-2 py-0.5 text-[10px] font-medium transition-colors ${
+                        topicFilter === f
+                          ? "bg-neon-cyan/15 text-neon-cyan"
+                          : "text-text-secondary hover:text-text-primary"
+                      }`}
+                    >
+                      {filterLabels[f]}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {topics.length === 0 ? (
+                <div className="rounded-xl border border-glass-border bg-glass-bg p-8 text-center">
+                  <p className="text-xs text-text-secondary">
+                    {locale === "zh" ? "暂无对话记录" : "No topics found"}
+                  </p>
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  {topics.map((topic) => (
+                    <div
+                      key={topic.topic_id}
+                      className="rounded-xl border border-glass-border bg-glass-bg p-3 transition-colors hover:border-glass-border/80"
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-2">
+                            <TopicBadge status={topic.status} />
+                            <span className="truncate text-sm font-medium text-text-primary">
+                              {topic.title}
+                            </span>
+                          </div>
+                          {topic.goal && (
+                            <p className="mt-1 truncate text-[11px] text-text-secondary">{topic.goal}</p>
+                          )}
+                          <div className="mt-1.5 flex items-center gap-3 text-[10px] text-text-secondary">
+                            {topic.room_name && (
+                              <span className="flex items-center gap-1">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-3 w-3">
+                                  <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
+                                </svg>
+                                {topic.room_name}
+                              </span>
+                            )}
+                            <span>{topic.message_count} msg</span>
+                          </div>
+                        </div>
+                        <span className="shrink-0 text-[10px] text-text-secondary">
+                          {timeAgo(topic.updated_at)}
+                        </span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -30,6 +30,7 @@ import Sidebar from "./Sidebar";
 import StripeReturnBanner from "./StripeReturnBanner";
 import UserChatPane from "./UserChatPane";
 import WalletPanel from "./WalletPanel";
+import ActivityPanel from "./ActivityPanel";
 
 const USER_CHAT_SUBTAB = "__user-chat__";
 
@@ -206,7 +207,7 @@ export default function DashboardApp() {
     const normalizedTab =
       tab === "dm" || tab === "rooms"
         ? "messages"
-        : tab === "messages" || tab === "contacts" || tab === "explore" || tab === "wallet" || tab === "user-chat"
+        : tab === "messages" || tab === "contacts" || tab === "explore" || tab === "wallet" || tab === "activity" || tab === "user-chat"
           ? tab
           : null;
 
@@ -361,7 +362,7 @@ export default function DashboardApp() {
 
   useEffect(() => {
     if (!sessionStore.authResolved || sessionStore.sessionMode !== "authed-ready") return;
-    if (uiStore.sidebarTab === "wallet") return;
+    if (uiStore.sidebarTab === "wallet" || uiStore.sidebarTab === "activity") return;
     if (chatStore.overview || chatStore.overviewRefreshing) return;
     void chatStore.refreshOverview();
   }, [
@@ -578,7 +579,9 @@ export default function DashboardApp() {
   return (
     <div className="relative flex h-screen overflow-hidden">
       <Sidebar />
-      {uiStore.sidebarTab === "wallet" ? (
+      {uiStore.sidebarTab === "activity" ? (
+        <ActivityPanel />
+      ) : uiStore.sidebarTab === "wallet" ? (
         <WalletPanel />
       ) : uiStore.sidebarTab === "messages" && uiStore.messagesPane === "user-chat" ? (
         <div className="flex-1 min-w-0">

--- a/frontend/src/components/dashboard/Sidebar.tsx
+++ b/frontend/src/components/dashboard/Sidebar.tsx
@@ -76,6 +76,15 @@ const authNavItems = [
       </svg>
     ),
   },
+  {
+    key: "activity" as const,
+    label: "Activity",
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-5 w-5">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
+      </svg>
+    ),
+  },
 ] as const;
 
 interface PrimaryNavButtonProps {
@@ -277,6 +286,7 @@ export default function Sidebar() {
     contacts: t.contacts,
     explore: t.discover,
     wallet: t.wallet,
+    activity: t.activity,
   };
 
   const navItems = authNavItems;
@@ -306,10 +316,11 @@ export default function Sidebar() {
     prefetch(`/chats/contacts/${uiStore.contactsView}`);
     prefetch(`/chats/explore/${uiStore.exploreView}`);
     prefetch("/chats/wallet");
+    prefetch("/chats/activity");
   }, [router, uiStore.contactsView, uiStore.exploreView]);
 
-  const navigatePrimaryTab = (tab: "messages" | "contacts" | "explore" | "wallet") => {
-    if (isGuest && tab === "contacts") {
+  const navigatePrimaryTab = (tab: "messages" | "contacts" | "explore" | "wallet" | "activity") => {
+    if (isGuest && (tab === "contacts" || tab === "activity")) {
       showLoginModal();
       return;
     }
@@ -323,6 +334,7 @@ export default function Sidebar() {
       contacts: `/chats/contacts/${uiStore.contactsView}`,
       explore: `/chats/explore/${uiStore.exploreView}`,
       wallet: "/chats/wallet",
+      activity: "/chats/activity",
     };
     uiStore.setSidebarTab(tab);
     if (tab === "messages" && !uiStore.openedRoomId && uiStore.messagesPane !== "user-chat") {
@@ -349,7 +361,7 @@ export default function Sidebar() {
           {navItems.map((item) => {
             const isActive = uiStore.sidebarTab === item.key;
             const isExplore = item.key === "explore";
-            const requiresLogin = isGuest && item.key === "contacts";
+            const requiresLogin = isGuest && (item.key === "contacts" || item.key === "activity");
             let badge: ReactNode = null;
             if (item.key === "messages" && hasUnreadMessages && !requiresLogin) {
               badge = (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -45,6 +45,9 @@ import type {
   CreateJoinRequestResponse,
   JoinRequestListResponse,
   MyJoinRequestResponse,
+  ActivityStats,
+  ActivityTopicsResponse,
+  ActivityIssues,
 } from "./types";
 
 import { createClient } from "@/lib/supabase/client";
@@ -452,6 +455,24 @@ export const api = {
       throw new ApiError(res.status, extractErrorMessage(data, res.statusText));
     }
     return res.json();
+  },
+
+  // --- Activity / Observability ---
+
+  getActivityStats(period: "today" | "7d" | "30d" = "today") {
+    return apiGet<ActivityStats>("/api/dashboard/activity/stats", { period });
+  },
+
+  getActivityTopics(opts?: { status?: string; limit?: number; offset?: number }) {
+    const params: Record<string, string> = {};
+    if (opts?.status) params.status = opts.status;
+    if (opts?.limit) params.limit = String(opts.limit);
+    if (opts?.offset) params.offset = String(opts.offset);
+    return apiGet<ActivityTopicsResponse>("/api/dashboard/activity/topics", params);
+  },
+
+  getActivityIssues() {
+    return apiGet<ActivityIssues>("/api/dashboard/activity/issues");
   },
 };
 

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -33,6 +33,7 @@ export const sidebar: TranslationMap<{
   copyAgentIdentityLoading: string
   copyAgentIdentityCopied: string
   promptTemplates: string
+  activity: string
 }> = {
   en: {
     messages: 'Messages',
@@ -60,6 +61,7 @@ export const sidebar: TranslationMap<{
     copyAgentIdentityLoading: 'Loading...',
     copyAgentIdentityCopied: 'Copied!',
     promptTemplates: 'Templates',
+    activity: 'Activity',
   },
   zh: {
     messages: '消息',
@@ -87,6 +89,7 @@ export const sidebar: TranslationMap<{
     copyAgentIdentityLoading: '加载中...',
     copyAgentIdentityCopied: '已复制!',
     promptTemplates: '场景模板',
+    activity: '动态',
   },
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -699,3 +699,61 @@ export interface UserAgent {
   claimed_at: string;
   ws_online: boolean;
 }
+
+// --- Activity / Observability types ---
+
+export interface ActivityStats {
+  messages_sent: number;
+  messages_received: number;
+  topics_open: number;
+  topics_completed: number;
+  topics_failed: number;
+  delivery_success_rate: number;
+  failed_messages: number;
+  active_rooms: number;
+}
+
+export interface ActivityTopic {
+  topic_id: string;
+  title: string;
+  status: "open" | "completed" | "failed" | "expired";
+  room_id: string;
+  room_name: string | null;
+  goal: string | null;
+  message_count: number;
+  creator_id: string;
+  created_at: string | null;
+  updated_at: string | null;
+  closed_at: string | null;
+}
+
+export interface ActivityTopicsResponse {
+  topics: ActivityTopic[];
+  total: number;
+}
+
+export interface ActivityFailedMessage {
+  hub_msg_id: string;
+  receiver_id: string;
+  receiver_name: string | null;
+  room_id: string | null;
+  room_name: string | null;
+  last_error: string | null;
+  retry_count: number;
+  created_at: string | null;
+}
+
+export interface ActivityStaleTopic {
+  topic_id: string;
+  title: string;
+  room_name: string | null;
+  status: string;
+  message_count: number;
+  updated_at: string | null;
+  hours_since_update: number;
+}
+
+export interface ActivityIssues {
+  failed_messages: ActivityFailedMessage[];
+  stale_topics: ActivityStaleTopic[];
+}

--- a/frontend/src/store/useDashboardUIStore.ts
+++ b/frontend/src/store/useDashboardUIStore.ts
@@ -14,7 +14,7 @@ export interface DashboardUIState {
   userChatRoomId: string | null;
   rightPanelOpen: boolean;
   agentCardOpen: boolean;
-  sidebarTab: "messages" | "contacts" | "explore" | "wallet";
+  sidebarTab: "messages" | "contacts" | "explore" | "wallet" | "activity";
   /** Distinguish the fixed user-chat entry from ordinary message rooms. */
   messagesPane: "room" | "user-chat";
   exploreView: "rooms" | "agents" | "templates";


### PR DESCRIPTION
## Summary
- **Backend**: 3 new API endpoints (`/api/dashboard/activity/stats`, `/topics`, `/issues`) providing message volume stats, topic listing with status filters, and anomaly detection (failed messages + stale open topics)
- **Frontend**: Full `ActivityPanel` component with stat cards, period selector (today/7d/30d), issue alert banner, and filterable topic list, integrated into dashboard sidebar as a new "Activity" tab
- **Infra**: i18n support (en/zh), type definitions, API client methods, UI store + routing wired up

## Test plan
- [ ] Verify `GET /api/dashboard/activity/stats?period=today` returns correct counts
- [ ] Verify `GET /api/dashboard/activity/topics?status=open` filters correctly
- [ ] Verify `GET /api/dashboard/activity/issues` returns failed messages and stale topics
- [ ] Click Activity tab in sidebar → panel renders with stat cards
- [ ] Switch period selector (Today / 7d / 30d) → stats refresh
- [ ] Filter topics by status → list updates
- [ ] Guest user cannot access Activity tab (redirects to login)
- [ ] `pnpm build` passes in frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)