### PR TITLE
feat(backend): include member display_name in room list responses

### DIFF
--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -291,6 +291,13 @@ class RoomMember(Base):
     )
 
     room: Mapped["Room"] = relationship(back_populates="members")
+    agent: Mapped["Agent"] = relationship(
+        "Agent",
+        primaryjoin="RoomMember.agent_id == Agent.agent_id",
+        foreign_keys=[agent_id],
+        viewonly=True,
+        lazy="select",
+    )
 
 
 class RoomJoinRequest(Base):

--- a/backend/hub/routers/room.py
+++ b/backend/hub/routers/room.py
@@ -122,6 +122,7 @@ def _build_room_response(room: Room) -> RoomResponse:
         members=[
             RoomMemberResponse(
                 agent_id=m.agent_id,
+                display_name=m.agent.display_name if m.agent is not None else None,
                 role=m.role.value,
                 muted=m.muted,
                 can_send=m.can_send,
@@ -159,7 +160,7 @@ async def _load_room(db: AsyncSession, room_id: str, *, fresh: bool = False) -> 
     result = await db.execute(
         select(Room)
         .where(Room.room_id == room_id)
-        .options(selectinload(Room.members))
+        .options(selectinload(Room.members).selectinload(RoomMember.agent))
     )
     room = result.scalar_one_or_none()
     if room is None:
@@ -586,7 +587,7 @@ async def list_my_rooms(
         select(Room)
         .join(RoomMember, RoomMember.room_id == Room.room_id)
         .where(RoomMember.agent_id == current_agent)
-        .options(selectinload(Room.members))
+        .options(selectinload(Room.members).selectinload(RoomMember.agent))
         .order_by(Room.created_at.desc())
         .limit(limit)
         .offset(offset)

--- a/backend/hub/schemas.py
+++ b/backend/hub/schemas.py
@@ -493,6 +493,7 @@ class SetMemberPermissionsRequest(BaseModel):
 
 class RoomMemberResponse(BaseModel):
     agent_id: str
+    display_name: str | None = None
     role: str
     muted: bool
     can_send: bool | None = None


### PR DESCRIPTION
## Summary
- `RoomMemberResponse` now carries `display_name` so `botcord_rooms list` (and all other room endpoints) returns each member's name in one shot, no extra directory lookup.
- Added a viewonly `RoomMember.agent` relationship and eager-loaded it in `_load_room` / `list_my_rooms` to avoid async lazy loads.

## Test plan
- [ ] `uv run pytest tests/test_room.py` (note: pre-existing `public.users` sqlite schema issue on main is unrelated)
- [ ] Manual: call `GET /hub/rooms/me` and verify each `members[*].display_name` is populated
- [ ] Manual: agent tool `botcord_rooms` with `action=list` returns member display names

🤖 Generated with [Claude Code](https://claude.com/claude-code)