### PR TITLE
feat(frontend): upgrade onboarding to spotlight overlay

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -67,6 +67,16 @@ body {
   animation: dashboard-skeleton-breathe 1.8s ease-in-out infinite;
 }
 
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes scale-in {
+  from { opacity: 0; transform: scale(0.92) translateY(12px); }
+  to { opacity: 1; transform: scale(1) translateY(0); }
+}
+
 @keyframes pulse-border {
   0%,
   100% {

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -372,9 +372,87 @@ export default function UserChatPane() {
   }
 
   const hasStreamingMsg = messages.some((m) => m.status === "streaming");
+  const showOnboarding = messages.length === 0;
+
+  const sendSuggestion = useCallback((text: string) => {
+    const clientId = crypto.randomUUID();
+    const optimisticMsg: OwnerChatMessage = {
+      clientId,
+      hubMsgId: null,
+      sender: "user",
+      text,
+      streamBlocks: [],
+      status: "optimistic",
+      createdAt: new Date().toISOString(),
+      senderName: "You",
+      type: "message",
+      sendText: text,
+    };
+    useOwnerChatStore.getState().addOptimistic(optimisticMsg);
+    scrollToBottom();
+    void sendMessage(text, clientId);
+  }, [scrollToBottom, sendMessage]);
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="relative flex flex-col h-full">
+      {/* ===== Spotlight onboarding overlay ===== */}
+      {showOnboarding && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center animate-[fade-in_0.3s_ease-out]">
+          {/* Dark backdrop */}
+          <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" />
+
+          {/* Centered card */}
+          <div className="relative z-10 flex flex-col items-center gap-6 rounded-3xl border border-cyan-500/30 bg-zinc-900/95 px-8 py-10 shadow-[0_0_60px_rgba(0,240,255,0.12)] max-w-lg mx-4 animate-[scale-in_0.3s_ease-out]">
+            {/* Glowing icon */}
+            <div className="relative">
+              <div className="absolute inset-0 rounded-2xl bg-cyan-500/25 blur-2xl animate-pulse" />
+              <div className="relative flex h-20 w-20 items-center justify-center rounded-2xl border border-cyan-500/40 bg-cyan-500/10">
+                <MessageSquare className="h-10 w-10 text-cyan-400" />
+              </div>
+            </div>
+
+            {/* Welcome text */}
+            <div className="text-center">
+              <h2 className="text-xl font-bold text-white">
+                {chatRoomName ? `${chatRoomName} is ready!` : "Your Bot is ready!"}
+              </h2>
+              <p className="mt-2 text-sm text-zinc-400 max-w-sm leading-relaxed">
+                Choose a conversation starter, or type your own message below.
+              </p>
+            </div>
+
+            {/* Suggestion chips */}
+            <div className="flex flex-col gap-2.5 w-full">
+              {[
+                { emoji: "👋", text: "Hey! What can you do?" },
+                { emoji: "💡", text: "Tell me about yourself" },
+                { emoji: "🚀", text: "Let's get started!" },
+              ].map((suggestion) => (
+                <button
+                  key={suggestion.text}
+                  onClick={() => sendSuggestion(suggestion.text)}
+                  className="group flex items-center gap-3 rounded-xl border border-zinc-700/80 bg-zinc-800/60 px-4 py-3 text-left text-sm text-zinc-200 transition-all hover:border-cyan-500/50 hover:bg-cyan-500/10 hover:text-cyan-200 hover:shadow-[0_0_16px_rgba(0,240,255,0.12)]"
+                >
+                  <span className="text-lg">{suggestion.emoji}</span>
+                  <span className="flex-1">{suggestion.text}</span>
+                  <Send className="h-3.5 w-3.5 text-zinc-600 transition-colors group-hover:text-cyan-400" />
+                </button>
+              ))}
+            </div>
+
+            {/* Divider + hint */}
+            <div className="flex items-center gap-3 w-full">
+              <div className="flex-1 h-px bg-zinc-700" />
+              <span className="text-xs text-zinc-500 shrink-0">or type below</span>
+              <div className="flex-1 h-px bg-zinc-700" />
+            </div>
+
+            {/* Bouncing arrow */}
+            <ChevronDown className="h-6 w-6 text-cyan-400 animate-bounce" />
+          </div>
+        </div>
+      )}
+
       {/* Header */}
       <div className="flex items-center gap-2 px-4 py-3 border-b border-zinc-800">
         <MessageSquare className="w-4 h-4 text-cyan-400" />
@@ -391,68 +469,6 @@ export default function UserChatPane() {
         {hasMore && (
           <div className="mb-1 text-center text-xs text-zinc-500 animate-pulse">
             Scroll up for older messages
-          </div>
-        )}
-        {messages.length === 0 && (
-          <div className="flex flex-col items-center justify-center h-full gap-4 px-6">
-            {/* Glowing avatar */}
-            <div className="relative">
-              <div className="absolute inset-0 rounded-2xl bg-cyan-500/20 blur-xl animate-pulse" />
-              <div className="relative flex h-16 w-16 items-center justify-center rounded-2xl border border-cyan-500/40 bg-cyan-500/10">
-                <MessageSquare className="h-8 w-8 text-cyan-400" />
-              </div>
-            </div>
-
-            {/* Welcome text */}
-            <div className="text-center">
-              <p className="text-base font-semibold text-zinc-100">
-                {chatRoomName ? `${chatRoomName} is ready!` : "Your Bot is ready!"}
-              </p>
-              <p className="mt-1.5 text-sm text-zinc-400 max-w-sm">
-                Send your first message to start the conversation.
-              </p>
-            </div>
-
-            {/* Suggestion chips */}
-            <div className="flex flex-wrap justify-center gap-2 max-w-md">
-              {[
-                { emoji: "👋", text: "Hey! What can you do?" },
-                { emoji: "💡", text: "Tell me about yourself" },
-                { emoji: "🚀", text: "Let's get started!" },
-              ].map((suggestion) => (
-                <button
-                  key={suggestion.text}
-                  onClick={() => {
-                    const clientId = crypto.randomUUID();
-                    const optimisticMsg: OwnerChatMessage = {
-                      clientId,
-                      hubMsgId: null,
-                      sender: "user",
-                      text: suggestion.text,
-                      streamBlocks: [],
-                      status: "optimistic",
-                      createdAt: new Date().toISOString(),
-                      senderName: "You",
-                      type: "message",
-                      sendText: suggestion.text,
-                    };
-                    useOwnerChatStore.getState().addOptimistic(optimisticMsg);
-                    scrollToBottom();
-                    void sendMessage(suggestion.text, clientId);
-                  }}
-                  className="group flex items-center gap-1.5 rounded-xl border border-zinc-700 bg-zinc-800/80 px-3.5 py-2 text-sm text-zinc-300 transition-all hover:border-cyan-500/50 hover:bg-cyan-500/10 hover:text-cyan-300 hover:shadow-[0_0_12px_rgba(0,240,255,0.15)]"
-                >
-                  <span>{suggestion.emoji}</span>
-                  <span>{suggestion.text}</span>
-                </button>
-              ))}
-            </div>
-
-            {/* Bouncing arrow pointing to input */}
-            <div className="mt-2 flex flex-col items-center gap-1 text-zinc-500">
-              <span className="text-xs">or type your own message</span>
-              <ChevronDown className="h-5 w-5 animate-bounce" />
-            </div>
           </div>
         )}
 
@@ -633,8 +649,8 @@ export default function UserChatPane() {
         <div />
       </div>
 
-      {/* Input */}
-      <div className={`border-t px-4 py-3 transition-colors ${messages.length === 0 ? "border-cyan-500/30 bg-cyan-500/[0.03]" : "border-zinc-800"}`} onDrop={handleDrop} onDragOver={handleDragOver}>
+      {/* Input — elevated above spotlight overlay so user can type */}
+      <div className={`border-t px-4 py-3 transition-colors ${showOnboarding ? "relative z-50 border-cyan-500/30 bg-zinc-900" : "border-zinc-800"}`} onDrop={handleDrop} onDragOver={handleDragOver}>
         {pendingFiles.length > 0 && (
           <div className="flex flex-wrap gap-2 mb-2">
             {pendingFiles.map((pf, idx) => (


### PR DESCRIPTION
## Summary
- 将 owner-chat 空状态引导从内联提示升级为 **全屏 spotlight 遮罩**
- 黑色半透明蒙层 + backdrop-blur 覆盖整个页面（包括 sidebar）
- 居中浮动卡片：发光图标、欢迎文案、3 个全宽 suggestion 按钮、分割线 + 弹跳箭头
- 输入区域通过 z-50 穿透遮罩，用户可直接在底部打字
- 发送第一条消息后遮罩自动消失
- 新增 fade-in / scale-in CSS 入场动画

Follows up on #252 (已合并).

## Test plan
- [ ] 进入空 owner-chat，确认全屏遮罩覆盖包括 sidebar
- [ ] 点击 suggestion 按钮，确认消息发送且遮罩立即消失
- [ ] 在底部输入框直接打字发送，确认遮罩消失
- [ ] 已有消息的 owner-chat 不显示遮罩
- [ ] 遮罩入场动画流畅（fade-in + scale-in）

🤖 Generated with [Claude Code](https://claude.com/claude-code)