### PR TITLE
chore: ignore .omx local state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ packages/protocol-core/dist/
 packages/protocol-core/tsconfig.tsbuildinfo
 
 .DS_Store
+.omx/


### PR DESCRIPTION
## Summary
- ignore the repo-local  directory
- keep OMX runtime state, plans, and logs out of source control

## Verification
- confirmed only  changed in this branch