### PR TITLE
fix: coerce postgres:// URL to postgresql+asyncpg:// for async engine

### DIFF
--- a/backend/hub/config.py
+++ b/backend/hub/config.py
@@ -20,6 +20,12 @@ def _build_database_url() -> str:
     """Build DATABASE_URL from env, supporting both a single URL and individual components."""
     url = os.getenv("DATABASE_URL")
     if url:
+        # Platforms (Vercel, Railway, Supabase) often provide postgres:// or postgresql://
+        # which resolves to psycopg2 (sync).  Force asyncpg for SQLAlchemy async engine.
+        for sync_prefix in ("postgresql+psycopg2://", "postgres://", "postgresql://"):
+            if url.startswith(sync_prefix):
+                url = "postgresql+asyncpg://" + url[len(sync_prefix):]
+                break
         return url
     # Fall back to individual DB_* variables (e.g. Vercel environment)
     user = os.getenv("DB_USER")


### PR DESCRIPTION
## Summary

- Platforms like Vercel, Railway, and Supabase provide `DATABASE_URL` as `postgres://` or `postgresql://`, which SQLAlchemy resolves to the synchronous `psycopg2` driver.
- `create_async_engine` requires an async driver; loading `psycopg2` caused an immediate startup crash (`InvalidRequestError: The loaded 'psycopg2' is not async`).
- `_build_database_url()` in `hub/config.py` now rewrites any of the three sync-driver URL prefixes to `postgresql+asyncpg://` before the URL is used, so the environment variable never needs to be changed manually.

## Test plan

- [ ] Deploy to the test environment and confirm the Hub starts without the `InvalidRequestError` crash.
- [ ] Verify existing backend unit tests pass (`uv run pytest tests/`).