### PR TITLE
feat(daemon): return verification_uri_complete with pre-filled user_code

### DIFF
--- a/backend/hub/routers/daemon_control.py
+++ b/backend/hub/routers/daemon_control.py
@@ -25,6 +25,7 @@ import logging
 import secrets
 import uuid as _uuid
 from dataclasses import dataclass
+from urllib.parse import quote
 from typing import Any
 
 import jcs
@@ -252,6 +253,7 @@ class _DeviceCodeResponse(BaseModel):
     device_code: str
     user_code: str
     verification_uri: str
+    verification_uri_complete: str
     expires_in: int
     interval: int
 
@@ -281,10 +283,12 @@ async def issue_device_code(db: AsyncSession = Depends(get_db)) -> _DeviceCodeRe
     await db.commit()
 
     verification_uri = f"{FRONTEND_BASE_URL.rstrip('/')}/activate"
+    verification_uri_complete = f"{verification_uri}?code={quote(user_code, safe='')}"
     return _DeviceCodeResponse(
         device_code=device_code,
         user_code=user_code,
         verification_uri=verification_uri,
+        verification_uri_complete=verification_uri_complete,
         expires_in=DAEMON_DEVICE_CODE_TTL_SECONDS,
         interval=DAEMON_DEVICE_CODE_INTERVAL_SECONDS,
     )


### PR DESCRIPTION
## Summary
- Backend `POST /daemon/auth/device-code` now returns `verification_uri_complete` (e.g. `https://preview.botcord.chat/activate?code=ZCW3-N6YV`) alongside the bare `verification_uri`
- The daemon CLI already prefers `verificationUriComplete` when displaying the activation URL (`packages/daemon/src/index.ts:253`), and the `/activate` page already reads `?code=` from the query string (`frontend/src/components/daemon/ActivatePage.tsx:34`) — so no CLI/frontend changes are needed
- Users can now click the printed URL directly instead of visiting `/activate` and copy-pasting the code

## Test plan
- [x] `uv run pytest tests/test_app/test_daemon_control.py::test_device_code_happy_path` passes
- [ ] After deploy, run `node dist/index.js start --hub <hub>` and verify the printed URL contains `?code=XXXX-XXXX`
- [ ] Click the URL and confirm the `/activate` page pre-fills the code field

🤖 Generated with [Claude Code](https://claude.com/claude-code)