### PR TITLE
feat(frontend): collapsible long text for room rule and invite prompt

### DIFF
--- a/frontend/src/components/dashboard/InviteOthersGuide.tsx
+++ b/frontend/src/components/dashboard/InviteOthersGuide.tsx
@@ -7,7 +7,7 @@
 
 "use client";
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { api } from "@/lib/api";
 import { useLanguage } from "@/lib/i18n";
 import { common } from "@/lib/i18n/translations/common";
@@ -30,6 +30,10 @@ export default function InviteOthersGuide({ roomId, roomName, visibility, canInv
   const [shareData, setShareData] = useState<CreateShareResponse | InvitePreviewResponse | null>(null);
   const [promptError, setPromptError] = useState<string | null>(null);
   const [isPreparingPrompt, setIsPreparingPrompt] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+  const promptRef = useRef<HTMLDivElement | null>(null);
+  const COLLAPSED_MAX_PX = 120;
 
   const needsInviteLink = visibility === "private";
 
@@ -90,6 +94,12 @@ export default function InviteOthersGuide({ roomId, roomName, visibility, canInv
     });
   }, [isPreparingPrompt, locale, promptError, roomName, shareData, t.preparingPrompt, t.promptUnavailable]);
 
+  useLayoutEffect(() => {
+    const el = promptRef.current;
+    if (!el) return;
+    setIsOverflowing(el.scrollHeight > COLLAPSED_MAX_PX + 1);
+  }, [combinedPrompt]);
+
   const handleCopy = () => {
     if (!shareData || typeof navigator === "undefined" || !navigator.clipboard) return;
     navigator.clipboard.writeText(combinedPrompt).then(() => {
@@ -148,10 +158,28 @@ export default function InviteOthersGuide({ roomId, roomName, visibility, canInv
       </div>
 
       <div className="group relative overflow-hidden rounded border border-glass-border/50 bg-deep-black-light/50">
-        <div className="bg-deep-black/30 p-2.5 font-mono text-[10px] leading-relaxed text-text-secondary/80 whitespace-pre-wrap break-all">
+        <div
+          ref={promptRef}
+          className="overflow-hidden bg-deep-black/30 p-2.5 font-mono text-[10px] leading-relaxed text-text-secondary/80 whitespace-pre-wrap break-all transition-[max-height] duration-200"
+          style={{ maxHeight: !expanded && isOverflowing ? `${COLLAPSED_MAX_PX}px` : "none" }}
+        >
           <span className="text-text-primary/90">{combinedPrompt}</span>
         </div>
+        {isOverflowing && !expanded && (
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-t from-deep-black/80 to-transparent" />
+        )}
       </div>
+      {isOverflowing && (
+        <div className="mt-1.5 flex justify-end">
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            className="text-[10px] font-medium text-neon-cyan/80 transition-colors hover:text-neon-cyan"
+          >
+            {expanded ? tc.showLess : tc.showMore}
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/dashboard/RoomHeader.tsx
+++ b/frontend/src/components/dashboard/RoomHeader.tsx
@@ -6,8 +6,9 @@
  */
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useLanguage } from "@/lib/i18n";
+import { common } from "@/lib/i18n/translations/common";
 import { roomList } from "@/lib/i18n/translations/dashboard";
 import { useShallow } from "zustand/react/shallow";
 import { Loader2 } from "lucide-react";
@@ -22,6 +23,10 @@ export default function RoomHeader() {
   const [joinRequestStatus, setJoinRequestStatus] = useState<"idle" | "sending" | "pending" | "rejected">("idle");
   const locale = useLanguage();
   const t = roomList[locale];
+  const tc = common[locale];
+  const [ruleExpanded, setRuleExpanded] = useState(false);
+  const [ruleOverflowing, setRuleOverflowing] = useState(false);
+  const ruleRef = useRef<HTMLParagraphElement | null>(null);
   const sessionMode = useDashboardSessionStore((state) => state.sessionMode);
   const { openedRoomId, rightPanelOpen, toggleRightPanel } = useDashboardUIStore(useShallow((state) => ({
     openedRoomId: state.openedRoomId,
@@ -59,6 +64,19 @@ export default function RoomHeader() {
     }).catch(() => {});
     return () => { cancelled = true; };
   }, [isAuthedReady, room?.room_id, isJoined, isInviteOnly]);
+
+  useLayoutEffect(() => {
+    const el = ruleRef.current;
+    if (!el) {
+      setRuleOverflowing(false);
+      return;
+    }
+    setRuleOverflowing(el.scrollHeight > el.clientHeight + 1);
+  }, [roomRule, ruleExpanded]);
+
+  useEffect(() => {
+    setRuleExpanded(false);
+  }, [openedRoomId]);
 
   const handleOpenMembersPanel = () => {
     if (!rightPanelOpen) {
@@ -167,9 +185,23 @@ export default function RoomHeader() {
             {room.description && <span className="ml-2 text-text-secondary/60">· {room.description}</span>}
           </div>
           {roomRule && (
-            <p className="mt-1 text-xs leading-5 text-text-secondary">
-              <span className="font-medium text-neon-cyan">{t.rule}</span> {roomRule}
-            </p>
+            <div className="mt-1">
+              <p
+                ref={ruleRef}
+                className={`text-xs leading-5 text-text-secondary ${ruleExpanded ? "" : "line-clamp-2"}`}
+              >
+                <span className="font-medium text-neon-cyan">{t.rule}</span> {roomRule}
+              </p>
+              {(ruleOverflowing || ruleExpanded) && (
+                <button
+                  type="button"
+                  onClick={() => setRuleExpanded((v) => !v)}
+                  className="mt-0.5 text-[10px] font-medium text-neon-cyan/80 transition-colors hover:text-neon-cyan"
+                >
+                  {ruleExpanded ? tc.showLess : tc.showMore}
+                </button>
+              )}
+            </div>
           )}
         </div>
         <div className="flex items-center gap-2 self-start py-0.5">

--- a/frontend/src/lib/i18n/translations/common.ts
+++ b/frontend/src/lib/i18n/translations/common.ts
@@ -57,6 +57,8 @@ export const common: TranslationMap<{
   logout: string
   refresh: string
   or: string
+  showMore: string
+  showLess: string
 }> = {
   en: {
     copy: 'Copy',
@@ -70,6 +72,8 @@ export const common: TranslationMap<{
     logout: 'Logout',
     refresh: 'Refresh',
     or: 'or',
+    showMore: 'Show more',
+    showLess: 'Show less',
   },
   zh: {
     copy: '复制',
@@ -83,5 +87,7 @@ export const common: TranslationMap<{
     logout: '退出登录',
     refresh: '刷新',
     or: '或',
+    showMore: '展开',
+    showLess: '收起',
   },
 }


### PR DESCRIPTION
## Summary
- Truncate long room rules to 2 lines in `RoomHeader` with a show more / show less toggle, auto-reset on room switch.
- Cap the invite guide prompt at 120px with a gradient fade, expanding on demand in `InviteOthersGuide`.
- Add shared `showMore` / `showLess` i18n keys (en + zh) in `common.ts`.

Both components detect real overflow via `useLayoutEffect` + `scrollHeight` so the toggle only appears when needed.

## Test plan
- [ ] Open a room with a long rule — verify it clamps to 2 lines and the toggle works.
- [ ] Open a room with a short rule — verify no toggle appears.
- [ ] Open invite guide with a long prompt — verify 120px cap, fade, and expand/collapse.
- [ ] Switch between rooms — verify rule collapses back to clamped state.
- [ ] Check both EN and ZH locales render the right labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)