### PR TITLE
fix(frontend): log auth callback error for OAuth preview failures

### DIFF
--- a/frontend/src/app/auth/callback/route.ts
+++ b/frontend/src/app/auth/callback/route.ts
@@ -10,6 +10,9 @@ export async function GET(request: Request) {
   if (code) {
     const supabase = await createClient();
     const { error } = await supabase.auth.exchangeCodeForSession(code);
+    if (error) {
+      console.error("[auth/callback] exchangeCodeForSession failed:", error.message, "| status:", error.status);
+    }
     if (!error) {
       // Ensure users table has a record for this Supabase user
       const {


### PR DESCRIPTION
## Summary

- Adds `console.error` logging in `/auth/callback` when `exchangeCodeForSession` fails, surfacing the Supabase error message and HTTP status to Vercel function logs
- Enables diagnosis of OAuth failures in preview deployments where the redirect URL is not in the Supabase allowed list

## Root Cause (Context)

Google OAuth login fails on preview deployments (`*-ouraca.vercel.app`) with `auth_callback_failed`. The error occurs at `exchangeCodeForSession` because Supabase validates the `redirect_uri` against its allowlist at exchange time. The production URL is allowlisted; preview URLs are not.

**Required Supabase config fix** (outside this PR): Add `https://**-ouraca.vercel.app/**` to Supabase Auth → URL Configuration → Additional Redirect URLs.

## Test plan

- [ ] Deploy to a preview environment and attempt Google OAuth login
- [ ] Confirm error detail appears in Vercel function logs under `/auth/callback`
- [ ] After adding preview URL to Supabase allowlist, confirm login succeeds end-to-end