### PR TITLE
feat(frontend): hide agent gate modal for users without an agent

### DIFF
--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -88,10 +88,7 @@ export default function DashboardApp() {
   const shouldShowBootstrapSkeleton = !sessionStore.authResolved || sessionStore.authBootstrapping;
   const fallbackAgent =
     sessionStore.ownedAgents.find((agent) => agent.is_default) ?? sessionStore.ownedAgents[0] ?? null;
-  const shouldShowAgentGate =
-    sessionStore.authResolved
-    && sessionStore.sessionMode === "authed-no-agent"
-    && sessionStore.ownedAgents.length === 0;
+  const shouldShowAgentGate = false;
   const realtimeTopic = sessionStore.activeAgentId ? `agent:${sessionStore.activeAgentId}` : null;
   const continueTarget = searchParams.get("next");
   const continueHandledRef = useRef<string | null>(null);


### PR DESCRIPTION
## Summary
- Bypass `AgentGateModal` so newly registered users aren't blocked by the "Connect your Bot to enter the chat app" prompt.
- Sets `shouldShowAgentGate = false` in `DashboardApp.tsx`; the existing gating logic is kept in git history for when we restore it.

## Notes
- Frontend-only hide. Downstream chat surfaces still depend on `activeAgentId`, so users without an agent may land on empty states. A follow-up non-blocking onboarding nudge is the intended replacement.

## Test plan
- [ ] `pnpm build` in `frontend/`
- [ ] Log in as a user with no bound agent → `/chats` no longer shows the gate modal
- [ ] Log in as a user with an agent → no regression in normal chat flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)