### PR TITLE
chore(daemon): add logs across control-plane, provisioning, user-auth, discovery

### DIFF
--- a/packages/daemon/src/agent-discovery.ts
+++ b/packages/daemon/src/agent-discovery.ts
@@ -8,6 +8,7 @@ import {
 } from "@botcord/protocol-core";
 import type { DaemonConfig } from "./config.js";
 import { resolveConfiguredAgentIds } from "./config.js";
+import { log as daemonLog } from "./log.js";
 
 /**
  * Default location daemon looks at when discovering BotCord credentials at
@@ -83,11 +84,13 @@ export function discoverAgentCredentials(
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
     if (code === "ENOENT") {
+      daemonLog.debug("credentials dir missing", { dir });
       return { agents: [], warnings };
     }
     warnings.push(`credentials dir unreadable (${dir}): ${errMsg(err)}`);
     return { agents: [], warnings };
   }
+  daemonLog.debug("credentials dir scan", { dir, entryCount: entries.length });
 
   // Sort filenames lexically so the duplicate tie-breaker is deterministic
   // regardless of filesystem ordering.
@@ -159,6 +162,11 @@ export function discoverAgentCredentials(
   }
   // Stable order for downstream channel creation / logs.
   agents.sort((a, b) => a.agentId.localeCompare(b.agentId));
+  daemonLog.debug("credentials discovery done", {
+    dir,
+    agentCount: agents.length,
+    warningCount: warnings.length,
+  });
   return { agents, warnings };
 }
 
@@ -196,6 +204,11 @@ export function resolveBootAgents(
     opts.credentialsDir ?? cfg.agentDiscovery?.credentialsDir ?? DEFAULT_CREDENTIALS_DIR;
 
   const explicit = resolveConfiguredAgentIds(cfg);
+  daemonLog.debug("resolveBootAgents", {
+    credentialsDir,
+    source: explicit ? "config" : "credentials",
+    explicitCount: explicit?.length ?? 0,
+  });
   if (explicit) {
     // Best-effort enrich with runtime/cwd cached in credentials. A missing
     // or unreadable file is not fatal — the gateway channel will surface the

--- a/packages/daemon/src/control-channel.ts
+++ b/packages/daemon/src/control-channel.ts
@@ -136,6 +136,13 @@ export class ControlChannel {
     }
     if (this.connectInflight) return this.connectInflight;
     this.stopRequested = false;
+    daemonLog.info("control-channel starting", {
+      userId: this.auth.current.userId,
+      hubUrl: this.auth.current.hubUrl,
+      path: this.path,
+      label: this.label ?? null,
+      hubKeyConfigured: !!this.hubPublicKey,
+    });
     this.connectInflight = this.connect().catch((err) => {
       // Initial connect failure surfaces to the caller; subsequent
       // reconnects are handled opaquely inside onClose.
@@ -151,6 +158,9 @@ export class ControlChannel {
 
   /** Close the WS and stop reconnecting. Idempotent. */
   async stop(): Promise<void> {
+    if (!this.stopRequested) {
+      daemonLog.info("control-channel stopping", { wasConnected: this.connected });
+    }
     this.stopRequested = true;
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
@@ -172,9 +182,17 @@ export class ControlChannel {
   /** Actively send a frame (used for event reports like `agent_provisioned`). */
   send(frame: ControlFrame): boolean {
     const ws = this.ws;
-    if (!ws || ws.readyState !== WebSocket.OPEN) return false;
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      daemonLog.debug("control-channel.send skipped (not open)", {
+        type: frame.type,
+        id: frame.id,
+        readyState: ws?.readyState ?? null,
+      });
+      return false;
+    }
     try {
       ws.send(JSON.stringify(frame));
+      daemonLog.debug("control-channel.send", { type: frame.type, id: frame.id });
       return true;
     } catch (err) {
       daemonLog.warn("control-channel.send failed", {
@@ -308,6 +326,11 @@ export class ControlChannel {
     if (typeof frame.ts === "number") {
       const skewMs = Math.abs(Date.now() - frame.ts);
       if (skewMs > 5 * 60 * 1000) {
+        daemonLog.warn("control-channel: rejecting frame with stale ts", {
+          type: frame.type,
+          id: frame.id,
+          skewMs,
+        });
         this.sendAck({
           id: frame.id,
           ok: false,
@@ -360,6 +383,10 @@ export class ControlChannel {
     // provisioner itself is the authoritative dedupe boundary for
     // stateful operations.
     if (this.seenFrameIds.includes(frame.id)) {
+      daemonLog.debug("control-channel: duplicate frame, acking as no-op", {
+        type: frame.type,
+        id: frame.id,
+      });
       this.sendAck({ id: frame.id, ok: true, result: { duplicate: true } });
       return;
     }
@@ -367,6 +394,11 @@ export class ControlChannel {
     if (this.seenFrameIds.length > REPLAY_DEDUPE_CAP) {
       this.seenFrameIds.splice(0, this.seenFrameIds.length - REPLAY_DEDUPE_CAP);
     }
+
+    daemonLog.debug("control-channel frame received", {
+      type: frame.type,
+      id: frame.id,
+    });
 
     // Plan §6.3 — instance-level revoke: write the expired flag, ack, and
     // tear down the control plane. Agent gateway stays up so existing
@@ -388,6 +420,11 @@ export class ControlChannel {
       const ack: ControlAck = result
         ? { id: frame.id, ...result }
         : { id: frame.id, ok: true };
+      daemonLog.debug("control-channel handler done", {
+        type: frame.type,
+        id: frame.id,
+        ok: ack.ok !== false,
+      });
       this.sendAck(ack);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -345,6 +345,10 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
       ? tryLoadUserAuth(logger)
       : opts.userAuth;
   if (userAuth?.current && !opts.disableControlChannel) {
+    logger.info("control-channel: enabling", {
+      userId: userAuth.current.userId,
+      hubUrl: userAuth.current.hubUrl,
+    });
     const provisioner = createProvisioner({ gateway });
     controlChannel = new ControlChannel({
       auth: userAuth,
@@ -355,7 +359,10 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
       // Plan §8.5 P0 — push one runtime snapshot immediately after connect
       // so Hub's `daemon_instances.runtimes_json` is populated for the
       // dashboard even before any user action. No periodic refresh in P0.
-      pushRuntimeSnapshot(controlChannel);
+      const pushed = pushRuntimeSnapshot(controlChannel);
+      logger.info("control-channel: initial runtime_snapshot push", {
+        ok: pushed,
+      });
     } catch (err) {
       logger.warn("control-channel failed to start; continuing without it", {
         error: err instanceof Error ? err.message : String(err),

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -206,6 +206,7 @@ async function cmdInit(args: ParsedArgs): Promise<void> {
   const agents = args.lists.agent ?? [];
   const cwd =
     typeof args.flags.cwd === "string" ? path.resolve(args.flags.cwd) : homedir();
+  log.info("cmd init", { agents, cwd });
   const cfg = initDefaultConfig(agents, cwd);
   saveConfig(cfg);
   console.log(`wrote ${CONFIG_FILE_PATH}`);
@@ -246,6 +247,10 @@ async function runDeviceCodeFlow(opts: {
   hubUrl: string;
   label?: string;
 }): Promise<UserAuthRecord> {
+  log.info("device-code flow: requesting code", {
+    hubUrl: opts.hubUrl,
+    label: opts.label ?? null,
+  });
   const dc: DeviceCodeResponse = await requestDeviceCode(
     opts.hubUrl,
     opts.label ? { label: opts.label } : undefined,
@@ -284,9 +289,17 @@ async function runDeviceCodeFlow(opts: {
     const record = userAuthFromTokenResponse(res, opts.label ? { label: opts.label } : undefined);
     saveUserAuth(record);
     clearAuthExpiredFlag();
+    log.info("device-code flow: authorized", {
+      userId: record.userId,
+      hubUrl: record.hubUrl,
+      label: opts.label ?? null,
+    });
     console.log(`Logged in as ${record.userId}`);
     return record;
   }
+  log.warn("device-code flow: expired without authorization", {
+    hubUrl: opts.hubUrl,
+  });
   throw new Error("device-code expired without authorization");
 }
 
@@ -351,6 +364,11 @@ async function ensureUserAuthForStart(args: ParsedArgs): Promise<UserAuthRecord 
 async function cmdStart(args: ParsedArgs): Promise<void> {
   const cfg = loadConfig();
   const foreground = args.flags.foreground === true;
+  log.info("cmd start", {
+    foreground,
+    relogin: args.flags.relogin === true,
+    child: process.env.BOTCORD_DAEMON_CHILD === "1",
+  });
 
   const existing = readPid();
   if (existing && pidAlive(existing)) {
@@ -421,6 +439,7 @@ async function cmdStart(args: ParsedArgs): Promise<void> {
 
 async function cmdStop(): Promise<void> {
   const pid = readPid();
+  log.info("cmd stop", { pid });
   if (!pid) {
     console.error("no pid file found");
     process.exit(1);

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -67,12 +67,19 @@ export function createProvisioner(opts: ProvisionerOptions): (
   const register = opts.register ?? BotCordClient.register;
 
   return async (frame: ControlFrame): Promise<AckBody> => {
+    daemonLog.debug("provision.dispatch", { type: frame.type, id: frame.id });
     switch (frame.type) {
       case CONTROL_FRAME_TYPES.PING:
         return { ok: true, result: { pong: true, ts: Date.now() } };
 
       case CONTROL_FRAME_TYPES.PROVISION_AGENT: {
         const params = (frame.params ?? {}) as unknown as ProvisionAgentParams;
+        daemonLog.info("provision_agent: start", {
+          frameId: frame.id,
+          hasCredentials: !!params.credentials,
+          runtime: pickRuntime(params) ?? null,
+          name: params.name ?? null,
+        });
         const agent = await provisionAgent(params, { gateway, register });
         return {
           ok: true,
@@ -86,31 +93,44 @@ export function createProvisioner(opts: ProvisionerOptions): (
 
       case CONTROL_FRAME_TYPES.REVOKE_AGENT: {
         const params = (frame.params ?? {}) as unknown as RevokeAgentParams;
+        daemonLog.info("revoke_agent: start", {
+          frameId: frame.id,
+          agentId: params.agentId,
+          deleteCredentials: params.deleteCredentials !== false,
+        });
         const res = await revokeAgent(params, { gateway });
         return { ok: true, result: res };
       }
 
       case CONTROL_FRAME_TYPES.LIST_AGENTS: {
         const agents = listAgentsFromGateway(gateway);
+        daemonLog.debug("list_agents", { count: agents.length });
         return { ok: true, result: { agents } };
       }
 
       case CONTROL_FRAME_TYPES.RELOAD_CONFIG: {
+        daemonLog.info("reload_config: start", { frameId: frame.id });
         const res = await reloadConfig({ gateway });
         return { ok: true, result: res };
       }
 
       case CONTROL_FRAME_TYPES.SET_ROUTE: {
+        daemonLog.info("set_route: start", { frameId: frame.id });
         const res = setRoute(frame.params ?? {});
         return { ok: true, result: res };
       }
 
       case CONTROL_FRAME_TYPES.LIST_RUNTIMES: {
         const snapshot = collectRuntimeSnapshot();
+        daemonLog.debug("list_runtimes", { count: snapshot.runtimes.length });
         return { ok: true, result: snapshot };
       }
 
       default:
+        daemonLog.warn("provision.dispatch: unknown frame type", {
+          type: frame.type,
+          id: frame.id,
+        });
         return {
           ok: false,
           error: { code: "unknown_type", message: `unknown control frame type "${frame.type}"` },
@@ -138,6 +158,12 @@ async function provisionAgent(
 
   const cfg = loadConfig();
   const credentials = await materializeCredentials(params, cfg, ctx);
+  daemonLog.debug("provision: credentials materialized", {
+    agentId: credentials.agentId,
+    hubUrl: credentials.hubUrl,
+    runtime: credentials.runtime ?? null,
+    source: params.credentials ? "hub-supplied" : "registered",
+  });
 
   const credentialsFile = writeCredentialsFile(
     defaultCredentialsFile(credentials.agentId),

--- a/packages/daemon/src/user-auth.ts
+++ b/packages/daemon/src/user-auth.ts
@@ -24,6 +24,7 @@ import {
   type DaemonTokenResponse,
 } from "@botcord/protocol-core";
 import { DAEMON_DIR_PATH } from "./config.js";
+import { log as daemonLog } from "./log.js";
 
 export const USER_AUTH_PATH = path.join(DAEMON_DIR_PATH, "user-auth.json");
 export const AUTH_EXPIRED_FLAG_PATH = path.join(DAEMON_DIR_PATH, "auth-expired.flag");
@@ -126,12 +127,18 @@ export function saveUserAuth(
   chmodSync(tmp, 0o600);
   renameSync(tmp, file);
   chmodSync(file, 0o600);
+  daemonLog.debug("user-auth saved", {
+    file,
+    userId: record.userId,
+    expiresAt: record.expiresAt,
+  });
 }
 
 /** Remove user-auth (e.g. after a hard revoke). Safe on missing file. */
 export function clearUserAuth(file: string = USER_AUTH_PATH): void {
   try {
     unlinkSync(file);
+    daemonLog.info("user-auth cleared", { file });
   } catch {
     // ignore
   }
@@ -165,12 +172,14 @@ export function writeAuthExpiredFlag(file: string = AUTH_EXPIRED_FLAG_PATH): voi
   writeFileSync(file, JSON.stringify({ expiredAt: new Date().toISOString() }), {
     mode: 0o600,
   });
+  daemonLog.warn("user-auth expired flag written", { file });
 }
 
 /** Remove the auth-expired flag (e.g. after a successful re-login). */
 export function clearAuthExpiredFlag(file: string = AUTH_EXPIRED_FLAG_PATH): void {
   try {
     unlinkSync(file);
+    daemonLog.debug("user-auth expired flag cleared", { file });
   } catch {
     // ignore
   }
@@ -232,6 +241,11 @@ export class UserAuthManager {
     }
     if (this.refreshInflight) return this.refreshInflight;
     const current = this.record;
+    daemonLog.info("user-auth refresh: start", {
+      userId: current.userId,
+      hubUrl: current.hubUrl,
+      expiresInMs: current.expiresAt - Date.now(),
+    });
     this.refreshInflight = (async () => {
       const tok = await refreshDaemonToken(current.hubUrl, current.refreshToken);
       const next: UserAuthRecord = {
@@ -243,8 +257,18 @@ export class UserAuthManager {
       };
       saveUserAuth(next, this.file);
       this.record = next;
+      daemonLog.info("user-auth refresh: ok", {
+        userId: next.userId,
+        expiresAt: next.expiresAt,
+      });
       return next;
-    })().finally(() => {
+    })().catch((err) => {
+      daemonLog.warn("user-auth refresh: failed", {
+        userId: current.userId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      throw err;
+    }).finally(() => {
       this.refreshInflight = null;
     });
     return this.refreshInflight;
@@ -255,11 +279,17 @@ export class UserAuthManager {
     saveUserAuth(record, this.file);
     this.record = record;
     clearAuthExpiredFlag();
+    daemonLog.info("user-auth replaced", {
+      userId: record.userId,
+      hubUrl: record.hubUrl,
+    });
   }
 
   /** Drop the record from memory + disk (e.g. after a hard revoke). */
   clear(): void {
+    const prevUserId = this.record?.userId ?? null;
     clearUserAuth(this.file);
     this.record = null;
+    daemonLog.info("user-auth manager cleared", { userId: prevUserId });
   }
 }


### PR DESCRIPTION
## Summary
- Fill log gaps in daemon modules that were previously near-silent (control-channel, provision, user-auth, agent-discovery, daemon.ts lifecycle, index.ts CLI entry)
- Info/warn on state changes and errors; debug (gated by `BOTCORD_DAEMON_DEBUG`) for per-frame traffic
- Debugging "daemon is running but behavior is off" should stop being a black box

## Test plan
- [x] `vitest run` — 303/303 passing
- [x] Verified sample log output in test runs (control-channel start/stop, provision_agent start, route set, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)