### PR TITLE
Harden OAuth user provisioning against schema drift

### DIFF
--- a/frontend/drizzle/0003_repair_users_defaults.sql
+++ b/frontend/drizzle/0003_repair_users_defaults.sql
@@ -1,0 +1,36 @@
+ALTER TABLE "users"
+  ADD COLUMN IF NOT EXISTS "beta_access" boolean,
+  ADD COLUMN IF NOT EXISTS "beta_admin" boolean;
+--> statement-breakpoint
+ALTER TABLE "users"
+  ALTER COLUMN "id" SET DEFAULT gen_random_uuid(),
+  ALTER COLUMN "status" SET DEFAULT 'active',
+  ALTER COLUMN "max_agents" SET DEFAULT 10,
+  ALTER COLUMN "created_at" SET DEFAULT now(),
+  ALTER COLUMN "updated_at" SET DEFAULT now(),
+  ALTER COLUMN "beta_access" SET DEFAULT false,
+  ALTER COLUMN "beta_admin" SET DEFAULT false;
+--> statement-breakpoint
+UPDATE "users"
+SET
+  "status" = COALESCE("status", 'active'),
+  "max_agents" = COALESCE("max_agents", 10),
+  "created_at" = COALESCE("created_at", now()),
+  "updated_at" = COALESCE("updated_at", now()),
+  "beta_access" = COALESCE("beta_access", false),
+  "beta_admin" = COALESCE("beta_admin", false)
+WHERE
+  "status" IS NULL OR
+  "max_agents" IS NULL OR
+  "created_at" IS NULL OR
+  "updated_at" IS NULL OR
+  "beta_access" IS NULL OR
+  "beta_admin" IS NULL;
+--> statement-breakpoint
+ALTER TABLE "users"
+  ALTER COLUMN "status" SET NOT NULL,
+  ALTER COLUMN "max_agents" SET NOT NULL,
+  ALTER COLUMN "created_at" SET NOT NULL,
+  ALTER COLUMN "updated_at" SET NOT NULL,
+  ALTER COLUMN "beta_access" SET NOT NULL,
+  ALTER COLUMN "beta_admin" SET NOT NULL;

--- a/frontend/drizzle/meta/_journal.json
+++ b/frontend/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1774003200000,
       "tag": "0002_add_claim_code_to_agents",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1774003201000,
+      "tag": "0003_repair_users_defaults",
+      "breakpoints": true
     }
   ]
 }

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -2,6 +2,7 @@ import { createClient } from "@/lib/supabase/server";
 import { db } from "@/../db";
 import { users, agents, userRoles, roles, rolePermissions, permissions } from "@/../db/schema";
 import { eq, and } from "drizzle-orm";
+import { randomUUID } from "crypto";
 
 export interface AuthenticatedUser {
   id: string;
@@ -156,15 +157,24 @@ export async function findOrCreateUser(supabaseUser: {
     supabaseUser.email?.split("@")[0] ||
     "User";
   const avatarUrl = (metadata.avatar_url as string) || (metadata.picture as string) || null;
+  const now = new Date();
+  const userId = randomUUID();
 
   const [newUser] = await db
     .insert(users)
     .values({
+      id: userId,
       displayName,
       email: supabaseUser.email || null,
       avatarUrl,
+      status: "active",
       supabaseUserId: supabaseUser.id,
-      lastLoginAt: new Date(),
+      maxAgents: 10,
+      createdAt: now,
+      updatedAt: now,
+      lastLoginAt: now,
+      betaAccess: false,
+      betaAdmin: false,
     })
     .returning({ id: users.id });
 

--- a/frontend/tests/auth.test.ts
+++ b/frontend/tests/auth.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockDb = vi.hoisted(() => {
+  const state = {
+    selectResults: [] as unknown[][],
+    insertPayloads: [] as unknown[],
+    updatePayloads: [] as unknown[],
+  };
+
+  const select = vi.fn(() => ({
+    from: vi.fn(() => ({
+      where: vi.fn(() => ({
+        limit: vi.fn(async () => state.selectResults.shift() ?? []),
+      })),
+    })),
+  }));
+
+  const update = vi.fn(() => ({
+    set: vi.fn((payload: unknown) => {
+      state.updatePayloads.push(payload);
+      return {
+        where: vi.fn(async () => undefined),
+      };
+    }),
+  }));
+
+  const insert = vi.fn(() => {
+    const callIndex = state.insertPayloads.length;
+    return {
+      values: vi.fn((payload: unknown) => {
+        state.insertPayloads.push(payload);
+
+        if (callIndex === 0) {
+          return {
+            returning: vi.fn(async () => [{ id: (payload as { id: string }).id }]),
+          };
+        }
+
+        return Promise.resolve();
+      }),
+    };
+  });
+
+  return { state, select, update, insert };
+});
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock("@/../db", () => ({
+  db: {
+    select: mockDb.select,
+    update: mockDb.update,
+    insert: mockDb.insert,
+  },
+}));
+
+import { findOrCreateUser } from "@/lib/auth";
+
+describe("findOrCreateUser", () => {
+  beforeEach(() => {
+    mockDb.state.selectResults.length = 0;
+    mockDb.state.insertPayloads.length = 0;
+    mockDb.state.updatePayloads.length = 0;
+    mockDb.select.mockClear();
+    mockDb.update.mockClear();
+    mockDb.insert.mockClear();
+  });
+
+  it("inserts an explicit user row instead of relying on database defaults", async () => {
+    mockDb.state.selectResults.push([], [{ id: "member-role-id" }]);
+
+    const userId = await findOrCreateUser({
+      id: "supabase-user-id",
+      email: "asoisox@gmail.com",
+      user_metadata: {
+        full_name: "Asoiso Lee",
+        avatar_url: "https://example.com/avatar.png",
+      },
+    });
+
+    expect(mockDb.insert).toHaveBeenCalledTimes(2);
+
+    const insertedUser = mockDb.state.insertPayloads[0] as {
+      id: string;
+      displayName: string;
+      email: string | null;
+      avatarUrl: string | null;
+      status: string;
+      supabaseUserId: string;
+      maxAgents: number;
+      createdAt: Date;
+      updatedAt: Date;
+      lastLoginAt: Date;
+      betaAccess: boolean;
+      betaAdmin: boolean;
+    };
+
+    expect(userId).toBe(insertedUser.id);
+    expect(insertedUser).toMatchObject({
+      displayName: "Asoiso Lee",
+      email: "asoisox@gmail.com",
+      avatarUrl: "https://example.com/avatar.png",
+      status: "active",
+      supabaseUserId: "supabase-user-id",
+      maxAgents: 10,
+      betaAccess: false,
+      betaAdmin: false,
+    });
+    expect(insertedUser.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+    expect(insertedUser.createdAt).toBeInstanceOf(Date);
+    expect(insertedUser.updatedAt).toBeInstanceOf(Date);
+    expect(insertedUser.lastLoginAt).toBeInstanceOf(Date);
+    expect(insertedUser.createdAt).toEqual(insertedUser.updatedAt);
+    expect(insertedUser.updatedAt).toEqual(insertedUser.lastLoginAt);
+    expect(mockDb.state.insertPayloads[1]).toEqual({
+      userId: insertedUser.id,
+      roleId: "member-role-id",
+    });
+  });
+
+  it("updates last login for an existing user", async () => {
+    mockDb.state.selectResults.push([{ id: "existing-user-id" }]);
+
+    const userId = await findOrCreateUser({
+      id: "supabase-user-id",
+      email: "asoisox@gmail.com",
+    });
+
+    expect(userId).toBe("existing-user-id");
+    expect(mockDb.insert).not.toHaveBeenCalled();
+    expect(mockDb.update).toHaveBeenCalledTimes(1);
+    expect(mockDb.state.updatePayloads[0]).toMatchObject({
+      lastLoginAt: expect.any(Date),
+      updatedAt: expect.any(Date),
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- stop `findOrCreateUser()` from relying on `users` table defaults during OAuth signup
- add a regression test covering explicit user creation payloads and existing-user login updates
- add a repair migration to restore/backfill `users` defaults in drifted environments

## Verification
- `pnpm exec vitest run tests/auth.test.ts`

## Known pre-existing issues
- `pnpm exec tsc --noEmit` fails in unrelated `frontend/tests/api/*` files due to missing route/module imports
- `pnpm build` fails after compile with `Cannot find module 'next/types.js'`
