### PR TITLE
ci(daemon): publish @botcord/daemon to npm via workflow

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -11,6 +11,7 @@ on:
           - plugin
           - cli
           - protocol-core
+          - daemon
       bump:
         description: "Version bump type"
         required: true
@@ -35,10 +36,10 @@ jobs:
       contents: write
     defaults:
       run:
-        working-directory: ${{ github.event.inputs.package == 'protocol-core' && 'packages/protocol-core' || github.event.inputs.package }}
+        working-directory: ${{ (github.event.inputs.package == 'protocol-core' || github.event.inputs.package == 'daemon') && format('packages/{0}', github.event.inputs.package) || github.event.inputs.package }}
     env:
       PKG: ${{ github.event.inputs.package }}
-      PKG_DIR: ${{ github.event.inputs.package == 'protocol-core' && 'packages/protocol-core' || github.event.inputs.package }}
+      PKG_DIR: ${{ (github.event.inputs.package == 'protocol-core' || github.event.inputs.package == 'daemon') && format('packages/{0}', github.event.inputs.package) || github.event.inputs.package }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -52,6 +53,7 @@ jobs:
             plugin) DISPLAY_NAME="Plugin" ;;
             cli) DISPLAY_NAME="CLI" ;;
             protocol-core) DISPLAY_NAME="Protocol Core" ;;
+            daemon) DISPLAY_NAME="Daemon" ;;
           esac
           echo "display_name=$DISPLAY_NAME" >> $GITHUB_OUTPUT
 
@@ -77,11 +79,11 @@ jobs:
           fi
 
       - name: Build
-        if: env.PKG == 'cli' || env.PKG == 'protocol-core'
+        if: env.PKG == 'cli' || env.PKG == 'protocol-core' || env.PKG == 'daemon'
         run: npm run build
 
       - name: Run tests
-        if: env.PKG == 'plugin'
+        if: env.PKG == 'plugin' || env.PKG == 'daemon'
         run: npm test
 
       - name: Configure git
@@ -173,6 +175,7 @@ jobs:
             plugin) TAG_PREFIX="" ;;
             cli) TAG_PREFIX="cli-" ;;
             protocol-core) TAG_PREFIX="protocol-core-" ;;
+            daemon) TAG_PREFIX="daemon-" ;;
           esac
           git commit -m "chore: release ${PKG} ${{ steps.bump.outputs.new_version }}"
           git tag "${TAG_PREFIX}${{ steps.bump.outputs.new_version }}"

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -9,8 +9,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
-    "prepublishOnly": "tsc",
+    "build": "tsc -p tsconfig.build.json",
+    "prepublishOnly": "tsc -p tsconfig.build.json",
     "test": "vitest run",
     "test:watch": "vitest"
   },


### PR DESCRIPTION
## Summary
- Adds `daemon` to the `publish-package.yml` workflow choices (stable + beta), matching cli/protocol-core
- Fixes `@botcord/daemon`'s `build`/`prepublishOnly` to use `tsconfig.build.json` so tests under `src/__tests__` don't get compiled into `dist/` (and so `prepublishOnly` actually succeeds — default `tsc` picks up a pre-existing type error in `runtime-discovery.test.ts`)

After merging, users can run `npx @botcord/daemon@latest start --hub <url>` for cold-start (once the first release has been triggered via Actions → Publish Package → daemon).

## Test plan
- [ ] Trigger workflow with `package=daemon`, `bump=patch`, `channel=beta` → expect a `0.1.1-beta.<ts>` on npm
- [ ] Verify `npx @botcord/daemon@beta start --foreground` runs device-code login
- [ ] Trigger workflow with `channel=stable` → expect `0.1.1` on npm, tagged `daemon-v0.1.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)