### PR TITLE
fix(ci): replace setup-python with setup-uv for ARM64 compatibility

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -46,11 +46,9 @@ jobs:
         working-directory: backend
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v6
         with:
           python-version: '3.12'
-      - name: Install uv
-        run: pip install uv
       - name: Install deps
         run: uv sync
       - name: Run SQL migrations
@@ -71,11 +69,9 @@ jobs:
         working-directory: backend
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v6
         with:
           python-version: '3.12'
-      - name: Install uv
-        run: pip install uv
       - name: Install deps
         run: uv sync
       - name: Run SQL migrations


### PR DESCRIPTION
## 问题

self-hosted runner 为 ARM64 架构，`actions/setup-python@v5` 找不到该架构下 Python 3.12 的预编译二进制，导致 Database Migration workflow 失败。

## 修复

- 移除 `actions/setup-python@v5`（不支持 ARM64 预编译）
- 移除冗余的 `pip install uv` 步骤
- 改用 `astral-sh/setup-uv@v6`，原生支持 ARM64 并自动管理 Python 版本

同时修复 preview 和 production 两个 migration job。