### PR TITLE
fix(frontend): Human 建房后新房间立即出现在 Sidebar

### DIFF
--- a/frontend/src/components/dashboard/CreateRoomModal.tsx
+++ b/frontend/src/components/dashboard/CreateRoomModal.tsx
@@ -7,6 +7,7 @@ import { useLanguage } from "@/lib/i18n";
 import { common } from "@/lib/i18n/translations/common";
 import { createRoomModal } from "@/lib/i18n/translations/dashboard";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
+import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import type { ContactInfo, HumanRoomSummary } from "@/lib/types";
 
 const EMPTY_CONTACTS: ContactInfo[] = [];
@@ -22,6 +23,7 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
   const tc = common[locale];
   const contacts = useDashboardChatStore((s) => s.overview?.contacts) ?? EMPTY_CONTACTS;
   const refreshOverview = useDashboardChatStore((s) => s.refreshOverview);
+  const refreshHumanRooms = useDashboardSessionStore((s) => s.refreshHumanRooms);
 
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
@@ -79,7 +81,7 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
         member_ids: Array.from(selected),
       };
       const room = await humansApi.createRoom(body);
-      await refreshOverview();
+      await Promise.all([refreshOverview(), refreshHumanRooms()]);
       onCreated?.(room);
       onClose();
     } catch (err) {

--- a/frontend/src/components/dashboard/Sidebar.tsx
+++ b/frontend/src/components/dashboard/Sidebar.tsx
@@ -189,6 +189,7 @@ export default function Sidebar() {
     activeAgentId: state.activeAgentId,
     sessionMode: state.sessionMode,
     token: state.token,
+    humanRooms: state.humanRooms,
     refreshUserProfile: state.refreshUserProfile,
     removeAgent: state.removeAgent,
     logout: state.logout,
@@ -282,8 +283,9 @@ export default function Sidebar() {
       overview: chatStore.overview,
       recentVisitedRooms: chatStore.recentVisitedRooms,
       token: sessionStore.token,
+      humanRooms: sessionStore.humanRooms,
     }),
-    [chatStore.overview, chatStore.recentVisitedRooms, sessionStore.token],
+    [chatStore.overview, chatStore.recentVisitedRooms, sessionStore.token, sessionStore.humanRooms],
   );
   const showOverviewSkeleton =
     sessionStore.sessionMode === "authed-ready" && !chatStore.overview && uiStore.sidebarTab === "messages";

--- a/frontend/src/store/dashboard-shared.ts
+++ b/frontend/src/store/dashboard-shared.ts
@@ -9,6 +9,7 @@ import type {
   DashboardMessage,
   DashboardOverview,
   DashboardRoom,
+  HumanRoomSummary,
   PublicRoom,
 } from "@/lib/types";
 import { getActiveAgentId } from "@/lib/api";
@@ -51,17 +52,41 @@ function isOwnerChatRoom(roomId: string): boolean {
   return roomId.startsWith("rm_oc_");
 }
 
+export function humanRoomToDashboardRoom(r: HumanRoomSummary): DashboardRoom {
+  return {
+    room_id: r.room_id,
+    name: r.name,
+    description: r.description,
+    owner_id: r.owner_id,
+    visibility: r.visibility,
+    join_policy: r.join_policy,
+    member_count: 0,
+    my_role: r.my_role,
+    rule: null,
+    required_subscription_product_id: null,
+    last_viewed_at: null,
+    has_unread: false,
+    last_message_preview: null,
+    last_message_at: null,
+    last_sender_name: null,
+  };
+}
+
 export function buildVisibleMessageRooms(state: {
   overview: DashboardOverview | null;
   recentVisitedRooms: PublicRoom[];
   token: string | null;
+  humanRooms?: HumanRoomSummary[];
 }): DashboardRoom[] {
   const joinedRooms = (state.overview?.rooms || []).filter((room) => !isOwnerChatRoom(room.room_id));
   const joinedRoomIds = new Set(joinedRooms.map((room) => room.room_id));
   const recentUnjoinedRooms = state.recentVisitedRooms
     .filter((room) => !joinedRoomIds.has(room.room_id) && !isOwnerChatRoom(room.room_id))
     .map(toRoomSummary);
-  const mergedRooms = [...joinedRooms, ...recentUnjoinedRooms].sort((a, b) => {
+  const humanOnlyRooms = (state.humanRooms || [])
+    .filter((r) => !joinedRoomIds.has(r.room_id) && !isOwnerChatRoom(r.room_id))
+    .map(humanRoomToDashboardRoom);
+  const mergedRooms = [...joinedRooms, ...recentUnjoinedRooms, ...humanOnlyRooms].sort((a, b) => {
     const aTs = a.last_message_at ? Date.parse(a.last_message_at) : 0;
     const bTs = b.last_message_at ? Date.parse(b.last_message_at) : 0;
     return bTs - aTs;


### PR DESCRIPTION
## 问题

PR #271 合并后，Human 通过 `CreateRoomModal` 建房成功，但新房间不出现在 Sidebar。

**根本原因**：`buildVisibleMessageRooms` 只读 Agent 侧的 `overview.rooms`，完全不包含 `sessionStore.humanRooms`；建房回调也只调用了 `refreshOverview()`，没有刷新 `humanRooms`。

## 修复

| 文件 | 改动 |
|------|------|
| `frontend/src/store/dashboard-shared.ts` | 新增 `humanRoomToDashboardRoom` 转换函数；`buildVisibleMessageRooms` 增加可选 `humanRooms` 参数，去重后合并进结果列表 |
| `frontend/src/components/dashboard/Sidebar.tsx` | sessionStore selector 加入 `humanRooms`；传给 `buildVisibleMessageRooms` 并加入 `useMemo` 依赖 |
| `frontend/src/components/dashboard/CreateRoomModal.tsx` | 建房成功后 `await Promise.all([refreshOverview(), refreshHumanRooms()])` 同时刷新两侧数据 |

## 行为保证

- Agent 侧房间（已在 `overview.rooms`）不会重复出现，按 `room_id` 去重
- `humanRooms` 参数为可选，未传时行为与原来完全一致
- TypeScript 编译无新增错误

## 测试步骤

1. 登录（有 Agent 的用户）
2. 点击「建群」→ 填写名称 → 创建
3. 验证新房间立即出现在 Sidebar 房间列表中，无需刷新页面

Closes: follow-up from #271