### PR TITLE
feat(human-first): room member + contact request APIs for Human surface

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -31,6 +31,7 @@ from hub.models import (
     ContactRequestState,
     MessageRecord,
     MessageState,
+    ParticipantType,
     Room,
     RoomJoinPolicy,
     RoomJoinRequest,
@@ -64,7 +65,11 @@ router = APIRouter(prefix="/api/dashboard", tags=["app-dashboard"])
 
 
 class SendContactRequestBody(BaseModel):
-    to_agent_id: str
+    # Exactly one of ``to_agent_id`` or ``to_human_id`` must be provided.
+    # ``to_agent_id`` preserves backward compatibility (agent → agent).
+    # ``to_human_id`` (hu_*) targets a human participant (agent → human).
+    to_agent_id: str | None = None
+    to_human_id: str | None = None
     message: str | None = None
 
 
@@ -400,44 +405,122 @@ async def get_overview(
 # ---------------------------------------------------------------------------
 
 
+def _serialize_contact_request(
+    req: ContactRequest,
+    from_display_name: str | None = None,
+    to_display_name: str | None = None,
+) -> dict:
+    """Return the canonical JSON shape for a ContactRequest row."""
+
+    def _state(v):
+        return v.value if hasattr(v, "value") else str(v)
+
+    return {
+        "id": req.id,
+        "from_agent_id": req.from_agent_id,
+        "to_agent_id": req.to_agent_id,
+        "from_type": _state(req.from_type),
+        "to_type": _state(req.to_type),
+        "state": _state(req.state),
+        "message": req.message,
+        "created_at": req.created_at.isoformat() if req.created_at else None,
+        "resolved_at": req.resolved_at.isoformat() if req.resolved_at else None,
+        "from_display_name": from_display_name,
+        "to_display_name": to_display_name,
+    }
+
+
 @router.post("/contact-requests", status_code=201)
 async def send_contact_request(
     body: SendContactRequestBody,
     ctx: RequestContext = Depends(require_active_agent),
     db: AsyncSession = Depends(get_db),
 ):
-    """Send a contact request to another agent."""
+    """Send a contact request from the active agent to another agent or human.
+
+    Exactly one of ``to_agent_id`` (ag_* — legacy A→A path) or
+    ``to_human_id`` (hu_* — new A→H path) must be provided.
+    """
     agent_id = ctx.active_agent_id
 
-    if body.to_agent_id == agent_id:
-        raise HTTPException(status_code=400, detail="Cannot send request to yourself")
+    # ------------------------------------------------------------------
+    # Determine target + type (exactly one of to_agent_id / to_human_id)
+    # ------------------------------------------------------------------
+    provided = [x for x in (body.to_agent_id, body.to_human_id) if x]
+    if len(provided) != 1:
+        raise HTTPException(
+            status_code=400,
+            detail="Provide exactly one of to_agent_id or to_human_id",
+        )
 
-    # Check target agent exists
-    target = await db.execute(
-        select(Agent).where(Agent.agent_id == body.to_agent_id)
-    )
-    target_agent = target.scalar_one_or_none()
-    if target_agent is None:
-        raise HTTPException(status_code=404, detail="Target agent not found")
+    target_display_name: str | None = None
 
-    # Check not already contacts
+    if body.to_human_id is not None:
+        to_id = body.to_human_id
+        to_type = ParticipantType.human
+        if not to_id.startswith("hu_"):
+            raise HTTPException(status_code=400, detail="to_human_id must start with hu_")
+        # Verify the human exists via User.human_id lookup.
+        target_user = await db.execute(
+            select(User).where(User.human_id == to_id)
+        )
+        user_row = target_user.scalar_one_or_none()
+        if user_row is None:
+            raise HTTPException(status_code=404, detail="Target human not found")
+        target_display_name = user_row.display_name
+    else:
+        to_id = body.to_agent_id  # type: ignore[assignment]
+        to_type = ParticipantType.agent
+        if to_id == agent_id:
+            raise HTTPException(status_code=400, detail="Cannot send request to yourself")
+        target = await db.execute(select(Agent).where(Agent.agent_id == to_id))
+        target_agent = target.scalar_one_or_none()
+        if target_agent is None:
+            raise HTTPException(status_code=404, detail="Target agent not found")
+        target_display_name = target_agent.display_name
+
+    # ------------------------------------------------------------------
+    # Already in contacts?
+    # ------------------------------------------------------------------
     existing_contact = await db.execute(
         select(Contact).where(
             Contact.owner_id == agent_id,
-            Contact.contact_agent_id == body.to_agent_id,
+            Contact.owner_type == ParticipantType.agent,
+            Contact.contact_agent_id == to_id,
+            Contact.peer_type == to_type,
         )
     )
     if existing_contact.scalar_one_or_none() is not None:
         raise HTTPException(status_code=409, detail="Already in contacts")
 
-    # Check existing request
-    existing_req = await db.execute(
+    # ------------------------------------------------------------------
+    # Existing request in EITHER direction blocks a new pending request.
+    # A previously-rejected request in the same direction may be reused
+    # (transition rejected → pending) for the "resend after reject" flow.
+    # ------------------------------------------------------------------
+    existing_forward = await db.execute(
         select(ContactRequest).where(
             ContactRequest.from_agent_id == agent_id,
-            ContactRequest.to_agent_id == body.to_agent_id,
+            ContactRequest.from_type == ParticipantType.agent,
+            ContactRequest.to_agent_id == to_id,
+            ContactRequest.to_type == to_type,
         )
     )
-    req = existing_req.scalar_one_or_none()
+    req = existing_forward.scalar_one_or_none()
+
+    existing_reverse = await db.execute(
+        select(ContactRequest).where(
+            ContactRequest.from_agent_id == to_id,
+            ContactRequest.from_type == to_type,
+            ContactRequest.to_agent_id == agent_id,
+            ContactRequest.to_type == ParticipantType.agent,
+            ContactRequest.state.in_(
+                [ContactRequestState.pending, ContactRequestState.accepted]
+            ),
+        )
+    )
+    if existing_reverse.scalar_one_or_none() is not None:
+        raise HTTPException(status_code=409, detail="Contact request already exists")
 
     if req is not None:
         if req.state in (ContactRequestState.pending, ContactRequestState.accepted):
@@ -451,7 +534,9 @@ async def send_contact_request(
     else:
         req = ContactRequest(
             from_agent_id=agent_id,
-            to_agent_id=body.to_agent_id,
+            to_agent_id=to_id,
+            from_type=ParticipantType.agent,
+            to_type=to_type,
             state=ContactRequestState.pending,
             message=body.message,
         )
@@ -459,17 +544,38 @@ async def send_contact_request(
         await db.commit()
         await db.refresh(req)
 
-    return {
-        "id": req.id,
-        "from_agent_id": req.from_agent_id,
-        "to_agent_id": req.to_agent_id,
-        "state": req.state.value if hasattr(req.state, "value") else str(req.state),
-        "message": req.message,
-        "created_at": req.created_at.isoformat() if req.created_at else None,
-        "resolved_at": req.resolved_at.isoformat() if req.resolved_at else None,
-        "from_display_name": None,
-        "to_display_name": target_agent.display_name,
-    }
+    return _serialize_contact_request(
+        req,
+        from_display_name=None,
+        to_display_name=target_display_name,
+    )
+
+
+async def _resolve_display_names(
+    db: AsyncSession,
+    ids_by_type: dict[ParticipantType, set[str]],
+) -> dict[tuple[ParticipantType, str], str]:
+    """Bulk-resolve display names for a mixed set of agent/human ids."""
+    out: dict[tuple[ParticipantType, str], str] = {}
+
+    agent_ids = ids_by_type.get(ParticipantType.agent, set())
+    if agent_ids:
+        result = await db.execute(
+            select(Agent.agent_id, Agent.display_name).where(Agent.agent_id.in_(agent_ids))
+        )
+        for agent_id, name in result.all():
+            out[(ParticipantType.agent, agent_id)] = name
+
+    human_ids = ids_by_type.get(ParticipantType.human, set())
+    if human_ids:
+        result = await db.execute(
+            select(User.human_id, User.display_name).where(User.human_id.in_(human_ids))
+        )
+        for human_id, name in result.all():
+            if human_id is not None:
+                out[(ParticipantType.human, human_id)] = name
+
+    return out
 
 
 @router.get("/contact-requests/received")
@@ -478,34 +584,40 @@ async def list_received_requests(
     ctx: RequestContext = Depends(require_active_agent),
     db: AsyncSession = Depends(get_db),
 ):
-    """List contact requests received by the active agent."""
+    """List contact requests received by the active agent.
+
+    The active agent only ever appears as an ``agent`` counterparty, so
+    ``to_type`` is always ``agent`` for rows returned here. The ``from``
+    side may be either an agent (legacy A→A) or a human (H→A).
+    """
     agent_id = ctx.active_agent_id
 
-    stmt = (
-        select(ContactRequest, Agent.display_name)
-        .outerjoin(Agent, Agent.agent_id == ContactRequest.from_agent_id)
-        .where(ContactRequest.to_agent_id == agent_id)
+    stmt = select(ContactRequest).where(
+        ContactRequest.to_agent_id == agent_id,
+        ContactRequest.to_type == ParticipantType.agent,
     )
     if state:
         stmt = stmt.where(ContactRequest.state == state)
 
     result = await db.execute(stmt)
-    rows = result.all()
+    rows = list(result.scalars().all())
+
+    ids_by_type: dict[ParticipantType, set[str]] = {
+        ParticipantType.agent: set(),
+        ParticipantType.human: set(),
+    }
+    for cr in rows:
+        ids_by_type[cr.from_type].add(cr.from_agent_id)
+    names = await _resolve_display_names(db, ids_by_type)
 
     return {
         "requests": [
-            {
-                "id": cr.id,
-                "from_agent_id": cr.from_agent_id,
-                "from_display_name": dn,
-                "to_agent_id": cr.to_agent_id,
-                "to_display_name": None,
-                "state": cr.state.value if hasattr(cr.state, "value") else str(cr.state),
-                "message": cr.message,
-                "created_at": cr.created_at.isoformat() if cr.created_at else None,
-                "resolved_at": cr.resolved_at.isoformat() if cr.resolved_at else None,
-            }
-            for cr, dn in rows
+            _serialize_contact_request(
+                cr,
+                from_display_name=names.get((cr.from_type, cr.from_agent_id)),
+                to_display_name=None,
+            )
+            for cr in rows
         ],
     }
 
@@ -516,34 +628,38 @@ async def list_sent_requests(
     ctx: RequestContext = Depends(require_active_agent),
     db: AsyncSession = Depends(get_db),
 ):
-    """List contact requests sent by the active agent."""
+    """List contact requests sent by the active agent.
+
+    ``from_type`` is always ``agent``. ``to_type`` may be agent or human.
+    """
     agent_id = ctx.active_agent_id
 
-    stmt = (
-        select(ContactRequest, Agent.display_name)
-        .outerjoin(Agent, Agent.agent_id == ContactRequest.to_agent_id)
-        .where(ContactRequest.from_agent_id == agent_id)
+    stmt = select(ContactRequest).where(
+        ContactRequest.from_agent_id == agent_id,
+        ContactRequest.from_type == ParticipantType.agent,
     )
     if state:
         stmt = stmt.where(ContactRequest.state == state)
 
     result = await db.execute(stmt)
-    rows = result.all()
+    rows = list(result.scalars().all())
+
+    ids_by_type: dict[ParticipantType, set[str]] = {
+        ParticipantType.agent: set(),
+        ParticipantType.human: set(),
+    }
+    for cr in rows:
+        ids_by_type[cr.to_type].add(cr.to_agent_id)
+    names = await _resolve_display_names(db, ids_by_type)
 
     return {
         "requests": [
-            {
-                "id": cr.id,
-                "from_agent_id": cr.from_agent_id,
-                "from_display_name": None,
-                "to_agent_id": cr.to_agent_id,
-                "to_display_name": dn,
-                "state": cr.state.value if hasattr(cr.state, "value") else str(cr.state),
-                "message": cr.message,
-                "created_at": cr.created_at.isoformat() if cr.created_at else None,
-                "resolved_at": cr.resolved_at.isoformat() if cr.resolved_at else None,
-            }
-            for cr, dn in rows
+            _serialize_contact_request(
+                cr,
+                from_display_name=None,
+                to_display_name=names.get((cr.to_type, cr.to_agent_id)),
+            )
+            for cr in rows
         ],
     }
 
@@ -554,7 +670,13 @@ async def accept_contact_request(
     ctx: RequestContext = Depends(require_active_agent),
     db: AsyncSession = Depends(get_db),
 ):
-    """Accept a pending contact request."""
+    """Accept a pending contact request targeted at the active agent.
+
+    The dashboard accept handler only runs when the *recipient* is an
+    agent (``to_type == agent``). Thanks to polymorphism, the sender may
+    be an agent (A↔A) or a human (H→A); we branch on ``from_type`` when
+    writing the reciprocal Contact rows.
+    """
     agent_id = ctx.active_agent_id
 
     result = await db.execute(
@@ -563,7 +685,7 @@ async def accept_contact_request(
     req = result.scalar_one_or_none()
     if req is None:
         raise HTTPException(status_code=404, detail="Contact request not found")
-    if req.to_agent_id != agent_id:
+    if req.to_type != ParticipantType.agent or req.to_agent_id != agent_id:
         raise HTTPException(status_code=403, detail="Not your request to accept")
     if req.state != ContactRequestState.pending:
         raise HTTPException(status_code=409, detail="Request is not pending")
@@ -571,34 +693,35 @@ async def accept_contact_request(
     req.state = ContactRequestState.accepted
     req.resolved_at = datetime.datetime.now(datetime.timezone.utc)
 
-    # Create bidirectional contacts (ignore if already exists)
-    for owner, contact_agent in [
-        (req.from_agent_id, req.to_agent_id),
-        (req.to_agent_id, req.from_agent_id),
+    # Create bidirectional Contact rows with correct owner_type/peer_type.
+    # Direction 1: from → to   (owner=from, peer=to)
+    # Direction 2: to → from   (owner=to,   peer=from)
+    for owner, owner_type, peer, peer_type in [
+        (req.from_agent_id, req.from_type, req.to_agent_id, req.to_type),
+        (req.to_agent_id, req.to_type, req.from_agent_id, req.from_type),
     ]:
         existing = await db.execute(
             select(Contact).where(
                 Contact.owner_id == owner,
-                Contact.contact_agent_id == contact_agent,
+                Contact.owner_type == owner_type,
+                Contact.contact_agent_id == peer,
+                Contact.peer_type == peer_type,
             )
         )
         if existing.scalar_one_or_none() is None:
-            db.add(Contact(owner_id=owner, contact_agent_id=contact_agent))
+            db.add(
+                Contact(
+                    owner_id=owner,
+                    owner_type=owner_type,
+                    contact_agent_id=peer,
+                    peer_type=peer_type,
+                )
+            )
 
     await db.commit()
     await db.refresh(req)
 
-    return {
-        "id": req.id,
-        "from_agent_id": req.from_agent_id,
-        "to_agent_id": req.to_agent_id,
-        "state": "accepted",
-        "message": req.message,
-        "created_at": req.created_at.isoformat() if req.created_at else None,
-        "resolved_at": req.resolved_at.isoformat() if req.resolved_at else None,
-        "from_display_name": None,
-        "to_display_name": None,
-    }
+    return _serialize_contact_request(req)
 
 
 @router.post("/contact-requests/{request_id}/reject")
@@ -616,7 +739,7 @@ async def reject_contact_request(
     req = result.scalar_one_or_none()
     if req is None:
         raise HTTPException(status_code=404, detail="Contact request not found")
-    if req.to_agent_id != agent_id:
+    if req.to_type != ParticipantType.agent or req.to_agent_id != agent_id:
         raise HTTPException(status_code=403, detail="Not your request to reject")
     if req.state != ContactRequestState.pending:
         raise HTTPException(status_code=409, detail="Request is not pending")
@@ -626,17 +749,7 @@ async def reject_contact_request(
     await db.commit()
     await db.refresh(req)
 
-    return {
-        "id": req.id,
-        "from_agent_id": req.from_agent_id,
-        "to_agent_id": req.to_agent_id,
-        "state": "rejected",
-        "message": req.message,
-        "created_at": req.created_at.isoformat() if req.created_at else None,
-        "resolved_at": req.resolved_at.isoformat() if req.resolved_at else None,
-        "from_display_name": None,
-        "to_display_name": None,
-    }
+    return _serialize_contact_request(req)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/routers/humans.py
+++ b/backend/app/routers/humans.py
@@ -101,6 +101,41 @@ class HumanContactListResponse(BaseModel):
     contacts: list[HumanContactSummary]
 
 
+class AddRoomMemberBody(BaseModel):
+    participant_id: str = Field(..., min_length=1, max_length=32)
+    role: Literal["member", "admin"] = "member"
+
+
+class HumanRoomMemberResponse(BaseModel):
+    room_id: str
+    participant_id: str
+    participant_type: Literal["agent", "human"]
+    role: Literal["owner", "admin", "member"]
+    joined_at: int
+
+
+class HumanContactRequestSummary(BaseModel):
+    id: str
+    from_participant_id: str
+    from_type: Literal["agent", "human"]
+    from_display_name: str | None
+    to_participant_id: str
+    to_type: Literal["agent", "human"]
+    to_display_name: str | None
+    state: Literal["pending", "accepted", "rejected"]
+    message: str | None
+    created_at: int
+
+
+class HumanContactRequestListResponse(BaseModel):
+    requests: list[HumanContactRequestSummary]
+
+
+class HumanContactRequestResolveResponse(BaseModel):
+    id: str
+    state: Literal["accepted", "rejected"]
+
+
 class ContactRequestBody(BaseModel):
     peer_id: str = Field(..., min_length=1, max_length=32)
     message: str | None = Field(default=None, max_length=500)
@@ -273,14 +308,42 @@ async def create_human_room(
 
     normalized_rule = body.rule.strip() if body.rule else None
     unique_member_ids = [m for m in dict.fromkeys(body.member_ids) if m and m != me]
+
+    # Classify every member id by prefix. Anything other than ag_ / hu_
+    # is a client error. The creator's own hu_ id (== me) was filtered above,
+    # but a caller could still provide another hu_ id.
+    member_types: dict[str, ParticipantType] = {}
+    for mid in unique_member_ids:
+        if mid.startswith("ag_"):
+            member_types[mid] = ParticipantType.agent
+        elif mid.startswith("hu_"):
+            member_types[mid] = ParticipantType.human
+        else:
+            raise HTTPException(
+                status_code=400,
+                detail="member_ids must be prefixed with ag_ or hu_",
+            )
+
     if body.max_members is not None and len(unique_member_ids) + 1 > body.max_members:
         raise HTTPException(status_code=400, detail="initial_members_exceed_max")
-    if unique_member_ids:
+
+    agent_member_ids = [m for m, t in member_types.items() if t == ParticipantType.agent]
+    human_member_ids = [m for m, t in member_types.items() if t == ParticipantType.human]
+
+    if agent_member_ids:
         result = await db.execute(
-            select(Agent.agent_id).where(Agent.agent_id.in_(unique_member_ids))
+            select(Agent.agent_id).where(Agent.agent_id.in_(agent_member_ids))
         )
         found = {row[0] for row in result.all()}
-        missing = set(unique_member_ids) - found
+        missing = set(agent_member_ids) - found
+        if missing:
+            raise HTTPException(status_code=400, detail="member_ids_not_found")
+    if human_member_ids:
+        result = await db.execute(
+            select(User.human_id).where(User.human_id.in_(human_member_ids))
+        )
+        found = {row[0] for row in result.all()}
+        missing = set(human_member_ids) - found
         if missing:
             raise HTTPException(status_code=400, detail="member_ids_not_found")
 
@@ -314,7 +377,7 @@ async def create_human_room(
             RoomMember(
                 room_id=room.room_id,
                 agent_id=mid,
-                participant_type=ParticipantType.agent,
+                participant_type=member_types[mid],
                 role=RoomRole.member,
             )
         )
@@ -330,6 +393,113 @@ async def create_human_room(
         visibility=room.visibility.value,
         join_policy=room.join_policy.value,
         my_role=RoomRole.owner.value,
+    )
+
+
+@router.post(
+    "/me/rooms/{room_id}/members",
+    response_model=HumanRoomMemberResponse,
+    status_code=201,
+)
+async def invite_room_member_as_human(
+    room_id: str,
+    body: AddRoomMemberBody,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Human invites another participant (agent or human) into one of their rooms.
+
+    Authorisation: inviter must already be an owner or admin of the room. We
+    intentionally do NOT honour the softer ``default_invite`` policy here —
+    ordinary members invite via their Agent, not via the Human surface — and
+    always treat this call as an admin-side invite, matching the semantics of
+    ``hub/routers/room.py::add_member`` when called by an owner/admin.
+    """
+    user = await _load_human(db, ctx)
+    me = user.human_id
+
+    room_row = await db.execute(select(Room).where(Room.room_id == room_id))
+    room = room_row.scalar_one_or_none()
+    if room is None:
+        raise HTTPException(status_code=404, detail="Room not found")
+
+    inviter_row = await db.execute(
+        select(RoomMember).where(
+            RoomMember.room_id == room_id,
+            RoomMember.participant_type == ParticipantType.human,
+            RoomMember.agent_id == me,
+        )
+    )
+    inviter = inviter_row.scalar_one_or_none()
+    if inviter is None or inviter.role not in (RoomRole.owner, RoomRole.admin):
+        raise HTTPException(
+            status_code=403,
+            detail="Only the room owner or admin can invite via the Human surface",
+        )
+
+    participant_id = body.participant_id
+    participant_type = _split_prefix(participant_id)
+
+    # Reject obvious self-invites (owner already seated as a member).
+    if participant_type == ParticipantType.human and participant_id == me:
+        raise HTTPException(status_code=409, detail="Already a member")
+
+    # Verify the target exists in the appropriate registry.
+    if participant_type == ParticipantType.agent:
+        target = await db.execute(
+            select(Agent).where(Agent.agent_id == participant_id)
+        )
+        if target.scalar_one_or_none() is None:
+            raise HTTPException(status_code=404, detail="Agent not found")
+    else:
+        target = await db.execute(
+            select(User).where(User.human_id == participant_id)
+        )
+        if target.scalar_one_or_none() is None:
+            raise HTTPException(status_code=404, detail="Human not found")
+
+    # Duplicate check — the unique constraint is (room_id, agent_id) but
+    # catching it up front yields a cleaner 409.
+    existing = await db.execute(
+        select(RoomMember).where(
+            RoomMember.room_id == room_id,
+            RoomMember.agent_id == participant_id,
+        )
+    )
+    if existing.scalar_one_or_none() is not None:
+        raise HTTPException(status_code=409, detail="Already a member")
+
+    if room.max_members is not None:
+        current_count_row = await db.execute(
+            select(RoomMember).where(RoomMember.room_id == room_id)
+        )
+        current_count = len(list(current_count_row.scalars().all()))
+        if current_count >= room.max_members:
+            raise HTTPException(status_code=400, detail="room_is_full")
+
+    new_role = RoomRole.admin if body.role == "admin" else RoomRole.member
+    new_member = RoomMember(
+        room_id=room_id,
+        agent_id=participant_id,
+        participant_type=participant_type,
+        role=new_role,
+    )
+    try:
+        db.add(new_member)
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="Already a member")
+    await db.refresh(new_member)
+
+    return HumanRoomMemberResponse(
+        room_id=new_member.room_id,
+        participant_id=new_member.agent_id,
+        participant_type=new_member.participant_type.value
+        if hasattr(new_member.participant_type, "value")
+        else str(new_member.participant_type),
+        role=new_member.role.value if hasattr(new_member.role, "value") else str(new_member.role),
+        joined_at=_ts(new_member.joined_at),
     )
 
 
@@ -458,6 +628,217 @@ async def send_contact_request(
         return ContactRequestResponse(status="already_requested")
     await db.refresh(req)
     return ContactRequestResponse(status="requested", request_id=str(req.id))
+
+
+# ---------------------------------------------------------------------------
+# Contact request listing + accept/reject (Human side)
+# ---------------------------------------------------------------------------
+
+
+async def _resolve_participant_display_name(
+    db: AsyncSession,
+    participant_id: str,
+    participant_type: ParticipantType,
+) -> str | None:
+    """Best-effort lookup of a participant's display_name.
+
+    Agents live in ``agents``; Humans live in ``public.users`` keyed by
+    ``human_id``. Returns ``None`` if the id doesn't resolve.
+    """
+    if participant_type == ParticipantType.agent:
+        row = await db.execute(
+            select(Agent.display_name).where(Agent.agent_id == participant_id)
+        )
+        return row.scalar_one_or_none()
+    row = await db.execute(
+        select(User.display_name).where(User.human_id == participant_id)
+    )
+    return row.scalar_one_or_none()
+
+
+async def _serialise_contact_requests(
+    db: AsyncSession,
+    rows: list[ContactRequest],
+) -> list[HumanContactRequestSummary]:
+    summaries: list[HumanContactRequestSummary] = []
+    for req in rows:
+        from_name = await _resolve_participant_display_name(db, req.from_agent_id, req.from_type)
+        to_name = await _resolve_participant_display_name(db, req.to_agent_id, req.to_type)
+        summaries.append(
+            HumanContactRequestSummary(
+                id=str(req.id),
+                from_participant_id=req.from_agent_id,
+                from_type=req.from_type.value
+                if hasattr(req.from_type, "value")
+                else str(req.from_type),
+                from_display_name=from_name,
+                to_participant_id=req.to_agent_id,
+                to_type=req.to_type.value
+                if hasattr(req.to_type, "value")
+                else str(req.to_type),
+                to_display_name=to_name,
+                state=req.state.value if hasattr(req.state, "value") else str(req.state),
+                message=req.message,
+                created_at=_ts(req.created_at),
+            )
+        )
+    return summaries
+
+
+@router.get(
+    "/me/contact-requests/received",
+    response_model=HumanContactRequestListResponse,
+)
+async def list_received_contact_requests(
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Pending contact requests targeted at the active Human."""
+    user = await _load_human(db, ctx)
+    me = user.human_id
+    await db.commit()
+
+    result = await db.execute(
+        select(ContactRequest)
+        .where(
+            ContactRequest.to_type == ParticipantType.human,
+            ContactRequest.to_agent_id == me,
+            ContactRequest.state == ContactRequestState.pending,
+        )
+        .order_by(ContactRequest.created_at.desc())
+    )
+    rows = list(result.scalars().all())
+    requests = await _serialise_contact_requests(db, rows)
+    return HumanContactRequestListResponse(requests=requests)
+
+
+@router.get(
+    "/me/contact-requests/sent",
+    response_model=HumanContactRequestListResponse,
+)
+async def list_sent_contact_requests(
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Contact requests initiated by the active Human (all states)."""
+    user = await _load_human(db, ctx)
+    me = user.human_id
+    await db.commit()
+
+    result = await db.execute(
+        select(ContactRequest)
+        .where(
+            ContactRequest.from_type == ParticipantType.human,
+            ContactRequest.from_agent_id == me,
+        )
+        .order_by(ContactRequest.created_at.desc())
+    )
+    rows = list(result.scalars().all())
+    requests = await _serialise_contact_requests(db, rows)
+    return HumanContactRequestListResponse(requests=requests)
+
+
+@router.post(
+    "/me/contact-requests/{request_id}/accept",
+    response_model=HumanContactRequestResolveResponse,
+)
+async def accept_contact_request_as_human(
+    request_id: int,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Human accepts a received contact request → mutual Contact rows.
+
+    Idempotent for the ``accepted`` terminal state at the Contact level:
+    duplicate Contact rows are swallowed via IntegrityError. Any non-pending
+    state (already accepted/rejected) yields 409.
+    """
+    user = await _load_human(db, ctx)
+    me = user.human_id
+
+    result = await db.execute(
+        select(ContactRequest).where(ContactRequest.id == request_id)
+    )
+    req = result.scalar_one_or_none()
+    if req is None:
+        raise HTTPException(status_code=404, detail="Contact request not found")
+    if req.to_type != ParticipantType.human or req.to_agent_id != me:
+        raise HTTPException(
+            status_code=403,
+            detail="Only the recipient Human can accept this request",
+        )
+    if req.state != ContactRequestState.pending:
+        raise HTTPException(status_code=409, detail="Request already resolved")
+
+    req.state = ContactRequestState.accepted
+    req.resolved_at = _now()
+
+    # Forward contact: to ← from
+    db.add(
+        Contact(
+            owner_id=req.to_agent_id,
+            owner_type=req.to_type,
+            contact_agent_id=req.from_agent_id,
+            peer_type=req.from_type,
+        )
+    )
+    # Mirror contact: from ← to
+    db.add(
+        Contact(
+            owner_id=req.from_agent_id,
+            owner_type=req.from_type,
+            contact_agent_id=req.to_agent_id,
+            peer_type=req.to_type,
+        )
+    )
+    try:
+        await db.commit()
+    except IntegrityError:
+        # One or both Contact rows already exist — finalise state-only.
+        await db.rollback()
+        result2 = await db.execute(
+            select(ContactRequest).where(ContactRequest.id == request_id)
+        )
+        req = result2.scalar_one()
+        req.state = ContactRequestState.accepted
+        req.resolved_at = _now()
+        await db.commit()
+
+    return HumanContactRequestResolveResponse(id=str(req.id), state="accepted")
+
+
+@router.post(
+    "/me/contact-requests/{request_id}/reject",
+    response_model=HumanContactRequestResolveResponse,
+)
+async def reject_contact_request_as_human(
+    request_id: int,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Human rejects a received contact request. No Contact rows are created."""
+    user = await _load_human(db, ctx)
+    me = user.human_id
+
+    result = await db.execute(
+        select(ContactRequest).where(ContactRequest.id == request_id)
+    )
+    req = result.scalar_one_or_none()
+    if req is None:
+        raise HTTPException(status_code=404, detail="Contact request not found")
+    if req.to_type != ParticipantType.human or req.to_agent_id != me:
+        raise HTTPException(
+            status_code=403,
+            detail="Only the recipient Human can reject this request",
+        )
+    if req.state != ContactRequestState.pending:
+        raise HTTPException(status_code=409, detail="Request already resolved")
+
+    req.state = ContactRequestState.rejected
+    req.resolved_at = _now()
+    await db.commit()
+
+    return HumanContactRequestResolveResponse(id=str(req.id), state="rejected")
 
 
 # ---------------------------------------------------------------------------

--- a/backend/hub/routers/room.py
+++ b/backend/hub/routers/room.py
@@ -1,4 +1,30 @@
-"""Unified Room management endpoints (replaces group, channel, session routers)."""
+"""Unified Room management endpoints (replaces group, channel, session routers).
+
+Hub / agent-protocol layer (``a2a/0.1``).
+
+All routes in this module serve the **agent-protocol layer**: every request is
+authenticated via :func:`hub.auth.get_current_claimed_agent`, which requires
+an ``Active-Agent-Id`` header plus a valid agent JWT (or a signed envelope).
+No Supabase / human JWT is accepted here.
+
+Human-scoped room operations (rooms that are owned by a human user and the
+BFF endpoints called from the dashboard while the user is signed in as a
+human) live at ``/api/humans/me/rooms*`` in ``app/routers/humans.py``. Human
+users MUST go through that router — they cannot create, invite, transfer, or
+otherwise operate on rooms through this router.
+
+Polymorphism notes (post Human-first merge):
+
+* ``Room.owner_type`` can be ``'agent'`` (default) or ``'human'``.
+* ``RoomMember.participant_type`` can be ``'agent'`` or ``'human'``.
+
+This router only creates ``owner_type='agent'`` rooms — ``hu_*`` ids are
+rejected on any input field (member ids, new owner id, promote target, etc.)
+with HTTP 400. The permission helpers in this module also make sure that
+when the caller is an agent we only ever look at the agent's own
+``RoomMember`` row (``participant_type='agent'``) so a human's row in the
+same room doesn't collide or grant the agent unintended privileges.
+"""
 
 from __future__ import annotations
 
@@ -96,6 +122,41 @@ def _require_internal(authorization: str | None = None):
 # ---------------------------------------------------------------------------
 
 
+_HUMAN_ID_ERROR = (
+    "human ids (hu_*) are not accepted on the hub router; "
+    "use /api/humans/me/rooms*"
+)
+
+
+def _reject_human_id(value: str | None, *, field: str = "id") -> None:
+    """Reject ``hu_*`` ids on any input field of this router.
+
+    Humans operate through ``/api/humans/*`` (Supabase-authenticated BFF),
+    never through the agent-protocol layer. We only validate inputs here —
+    read-only output fields that may legitimately contain ``hu_*`` ids
+    (e.g. a member list) are untouched.
+    """
+    if value is None:
+        return
+    if isinstance(value, str) and value.startswith("hu_"):
+        raise HTTPException(
+            status_code=400,
+            detail=f"{_HUMAN_ID_ERROR} (field={field}, value={value})",
+        )
+
+
+def _reject_human_ids(values, *, field: str = "ids") -> None:
+    """Batch version of :func:`_reject_human_id`."""
+    if not values:
+        return
+    for v in values:
+        _reject_human_id(v, field=field)
+
+
+def _room_owner_is_human(room: Room) -> bool:
+    return getattr(room, "owner_type", "agent") == "human"
+
+
 def _normalize_room_rule(rule: str | None) -> str | None:
     """Collapse blank/whitespace-only room rules to None."""
     if rule is None:
@@ -176,15 +237,32 @@ async def _load_room(db: AsyncSession, room_id: str, *, fresh: bool = False) -> 
 
 
 def _require_membership(room: Room, agent_id: str) -> RoomMember:
-    """Return the member record or raise 403."""
+    """Return the agent-member record for ``agent_id`` or raise 403.
+
+    Always filters by ``participant_type='agent'`` (when the column is
+    present) so a human's row — which may share the ``agent_id`` column —
+    does not accidentally satisfy the check for an agent caller.
+    """
     for m in room.members:
-        if m.agent_id == agent_id:
-            return m
+        if m.agent_id != agent_id:
+            continue
+        # Only match the agent-type row. Pre-Human-first the attribute
+        # does not exist; ``getattr`` default keeps old behaviour.
+        if getattr(m, "participant_type", "agent") != "agent":
+            continue
+        return m
     raise I18nHTTPException(status_code=403, message_key="not_a_member")
 
 
 def _require_admin_or_owner(room: Room, agent_id: str) -> RoomMember:
-    """Return the member record if owner/admin, else raise 403."""
+    """Return the agent-member record if owner/admin, else raise 403.
+
+    In a human-owned room (``room.owner_type='human'``) the hub-level
+    "owner" is a human, so no agent can be the owner — only an agent with
+    ``role=admin`` can satisfy this check from the hub side. A human user
+    who wants to administer the room must go through
+    ``/api/humans/me/rooms*``.
+    """
     member = _require_membership(room, agent_id)
     if member.role not in (RoomRole.owner, RoomRole.admin):
         raise I18nHTTPException(status_code=403, message_key="admin_or_owner_required")
@@ -192,16 +270,27 @@ def _require_admin_or_owner(room: Room, agent_id: str) -> RoomMember:
 
 
 def _can_invite(room: Room, member: RoomMember) -> bool:
-    """Check if a member can invite others to a room.
+    """Check if an agent-member can invite others to a room.
 
     Resolution order:
-      1. owner → always True
+      1. agent-owner → always True
+         (In a human-owned room no agent is the owner; we fall through.)
       2. public + open room → always True (anyone can join anyway)
       3. member.can_invite is not None → use explicit value
       4. admin → default True
       5. room.default_invite
+
+    Human-owned rooms are handled the same way as agent-owned rooms for
+    non-owner permissions: an agent member who has ``default_invite=True``
+    (or an explicit ``can_invite=True`` override) can still invite other
+    agents through this router.
     """
-    if member.role == RoomRole.owner:
+    # Only treat the member as the owner when the room itself is
+    # agent-owned. Belt-and-suspenders: ``_require_membership`` already
+    # filters to agent-type rows, but we also guard on owner_type so a
+    # mis-labelled row can't grant silent owner privileges to an agent in
+    # a human-owned room.
+    if member.role == RoomRole.owner and not _room_owner_is_human(room):
         return True
     if room.visibility == RoomVisibility.public and room.join_policy == RoomJoinPolicy.open:
         return True
@@ -374,7 +463,14 @@ async def create_room(
     db: AsyncSession = Depends(get_db),
     current_agent: str = Depends(get_current_claimed_agent),
 ):
-    """Create a new room. Creator becomes the owner."""
+    """Create a new room. Creator becomes the owner.
+
+    Rooms created through this router default to ``owner_type='agent'``.
+    Human-owned rooms must be created via ``POST /api/humans/me/rooms``.
+    """
+    # Reject hu_* in any input list — humans cannot be invited through the
+    # agent-protocol layer.
+    _reject_human_ids(body.member_ids, field="member_ids")
     _validate_subscription_room_config(
         body.visibility, body.join_policy, body.required_subscription_product_id
     )
@@ -716,6 +812,11 @@ async def add_member(
     - Otherwise → invite (requires invite permission via _can_invite).
     - Admission policy: contacts_only agents require inviter in their contacts.
     """
+    # Reject hu_* on the body — humans are added through
+    # /api/humans/me/rooms*, never through this router.
+    if body is not None:
+        _reject_human_id(body.agent_id, field="agent_id")
+
     room = await _load_room(db, room_id)
     target_agent_id = body.agent_id if body and body.agent_id else None
     is_self_join = target_agent_id is None or target_agent_id == current_agent
@@ -838,6 +939,9 @@ async def remove_member(
     current_agent: str = Depends(get_current_claimed_agent),
 ):
     """Remove a member from the room. Owner/admin only. Cannot remove the owner."""
+    # Humans cannot be removed via the hub router — route through
+    # /api/humans/me/rooms* instead.
+    _reject_human_id(agent_id, field="agent_id")
     room = await _load_room(db, room_id)
     caller = _require_admin_or_owner(room, current_agent)
 
@@ -912,7 +1016,12 @@ async def transfer_ownership(
     db: AsyncSession = Depends(get_db),
     current_agent: str = Depends(get_current_claimed_agent),
 ):
-    """Transfer room ownership to another member. Owner only."""
+    """Transfer room ownership to another member. Owner only.
+
+    Only agent-to-agent transfers are supported here. Transferring
+    ownership to a human must be done through the human BFF layer.
+    """
+    _reject_human_id(body.new_owner_id, field="new_owner_id")
     room = await _load_room(db, room_id)
     caller = _require_membership(room, current_agent)
     if caller.role != RoomRole.owner:
@@ -951,6 +1060,7 @@ async def promote_demote(
     current_agent: str = Depends(get_current_claimed_agent),
 ):
     """Promote/demote a member. Owner only. Valid roles: 'admin', 'member'."""
+    _reject_human_id(body.agent_id, field="agent_id")
     room = await _load_room(db, room_id)
     caller = _require_membership(room, current_agent)
     if caller.role != RoomRole.owner:
@@ -1001,6 +1111,7 @@ async def set_member_permissions(
     - Cannot modify owner's permissions.
     - Admin cannot modify another admin's permissions.
     """
+    _reject_human_id(body.agent_id, field="agent_id")
     room = await _load_room(db, room_id)
     caller = _require_admin_or_owner(room, current_agent)
 

--- a/backend/tests/test_app/test_app_dashboard_contacts_a2h.py
+++ b/backend/tests/test_app/test_app_dashboard_contacts_a2h.py
@@ -1,0 +1,393 @@
+"""Agent-to-human contact request tests for /api/dashboard/contact-requests.
+
+Covers the polymorphic extension introduced with migration
+024_human_participant.sql: an active agent can send a contact request to
+a human participant identified by ``hu_*``. The receiving side accepts
+via ``/api/humans/me/contact-requests/*`` (owned by the humans router),
+so these tests focus on dashboard-side behaviour:
+
+* sending to a ``hu_*`` target creates a row with from_type=agent / to_type=human
+* non-existent hu_ targets return 404
+* duplicate pending requests return 409
+* received/sent listings include the correct from_type/to_type and resolve
+  human display names from the User table
+* accepting an H→A request yields bidirectional Contact rows whose
+  owner_type / peer_type correctly mark which side is the human.
+"""
+
+from __future__ import annotations
+
+import datetime
+import uuid
+
+import jwt
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from unittest.mock import AsyncMock
+
+from hub.models import (
+    Agent,
+    Base,
+    Contact,
+    ContactRequest,
+    ContactRequestState,
+    MessagePolicy,
+    ParticipantType,
+    Role,
+    User,
+    UserRole,
+)
+
+TEST_SUPABASE_SECRET = "test-supabase-jwt-secret-for-unit-tests"
+
+
+def _make_token(sub: str) -> str:
+    payload = {
+        "sub": sub,
+        "aud": "authenticated",
+        "exp": datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=1),
+        "iss": "supabase",
+    }
+    return jwt.encode(payload, TEST_SUPABASE_SECRET, algorithm="HS256")
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    from tests.test_app.conftest import create_test_engine
+
+    engine = create_test_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client(db_session: AsyncSession, monkeypatch):
+    import hub.config
+    monkeypatch.setattr(hub.config, "SUPABASE_JWT_SECRET", TEST_SUPABASE_SECRET)
+    import app.auth
+    monkeypatch.setattr(app.auth, "SUPABASE_JWT_SECRET", TEST_SUPABASE_SECRET)
+
+    from hub.main import app
+    from hub.database import get_db
+
+    async def _override():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override
+    app.state.http_client = AsyncMock(spec=AsyncClient)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+def _headers(token: str, agent_id: str) -> dict:
+    return {"Authorization": f"Bearer {token}", "X-Active-Agent": agent_id}
+
+
+@pytest_asyncio.fixture
+async def seed(db_session: AsyncSession):
+    """Seed:
+
+    * user1 → owns agent ag_alice001 (the sender / active agent)
+    * user2 → has human_id hu_boboo001 (the A→H target)
+    * user3 → owns agent ag_carol001 AND has human_id hu_carol001
+      (used to verify H→A accept mixes types correctly).
+    """
+    uid1 = uuid.uuid4()
+    supa1 = uuid.uuid4()
+    uid2 = uuid.uuid4()
+    supa2 = uuid.uuid4()
+    uid3 = uuid.uuid4()
+    supa3 = uuid.uuid4()
+
+    u1 = User(id=uid1, display_name="Alice User", email="a@x.com", status="active",
+              supabase_user_id=supa1)
+    u2 = User(id=uid2, display_name="Bob Human", email="b@x.com", status="active",
+              supabase_user_id=supa2, human_id="hu_boboo001")
+    u3 = User(id=uid3, display_name="Carol", email="c@x.com", status="active",
+              supabase_user_id=supa3, human_id="hu_carol001")
+    db_session.add_all([u1, u2, u3])
+
+    role = Role(id=uuid.uuid4(), name="member", display_name="Member",
+                is_system=True, priority=0)
+    db_session.add(role)
+    await db_session.flush()
+
+    db_session.add(UserRole(id=uuid.uuid4(), user_id=uid1, role_id=role.id))
+    db_session.add(UserRole(id=uuid.uuid4(), user_id=uid2, role_id=role.id))
+    db_session.add(UserRole(id=uuid.uuid4(), user_id=uid3, role_id=role.id))
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    a1 = Agent(agent_id="ag_alice001", display_name="Alice", message_policy=MessagePolicy.open,
+               user_id=uid1, is_default=True, claimed_at=now)
+    a3 = Agent(agent_id="ag_carol001", display_name="Carol Agent",
+               message_policy=MessagePolicy.open,
+               user_id=uid3, is_default=True, claimed_at=now)
+    db_session.add_all([a1, a3])
+    await db_session.commit()
+
+    return {
+        "token1": _make_token(str(supa1)),
+        "agent1": "ag_alice001",
+        "token3": _make_token(str(supa3)),
+        "agent3": "ag_carol001",
+        "hu_bob": "hu_boboo001",
+        "hu_carol": "hu_carol001",
+        "display_bob": "Bob Human",
+        "display_carol": "Carol",
+    }
+
+
+# ---------------------------------------------------------------------------
+# send
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_to_human_creates_row_with_correct_types(client, seed, db_session):
+    resp = await client.post(
+        "/api/dashboard/contact-requests",
+        json={"to_human_id": seed["hu_bob"], "message": "Hi human"},
+        headers=_headers(seed["token1"], seed["agent1"]),
+    )
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert data["from_agent_id"] == seed["agent1"]
+    assert data["to_agent_id"] == seed["hu_bob"]
+    assert data["from_type"] == "agent"
+    assert data["to_type"] == "human"
+    assert data["to_display_name"] == seed["display_bob"]
+    assert data["state"] == "pending"
+
+    # Double-check the row persisted with the right enum values.
+    row = (
+        await db_session.execute(select(ContactRequest).where(ContactRequest.id == data["id"]))
+    ).scalar_one()
+    assert row.from_type == ParticipantType.agent
+    assert row.to_type == ParticipantType.human
+    assert row.to_agent_id == seed["hu_bob"]
+
+
+@pytest.mark.asyncio
+async def test_send_requires_exactly_one_target(client, seed):
+    h = _headers(seed["token1"], seed["agent1"])
+
+    # Neither
+    resp = await client.post("/api/dashboard/contact-requests", json={}, headers=h)
+    assert resp.status_code == 400
+
+    # Both
+    resp = await client.post(
+        "/api/dashboard/contact-requests",
+        json={"to_agent_id": "ag_x", "to_human_id": seed["hu_bob"]},
+        headers=h,
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_send_to_nonexistent_human_404(client, seed):
+    resp = await client.post(
+        "/api/dashboard/contact-requests",
+        json={"to_human_id": "hu_ghost0001"},
+        headers=_headers(seed["token1"], seed["agent1"]),
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_send_rejects_wrong_prefix(client, seed):
+    # to_human_id must start with hu_
+    resp = await client.post(
+        "/api/dashboard/contact-requests",
+        json={"to_human_id": "ag_alice001"},
+        headers=_headers(seed["token1"], seed["agent1"]),
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_duplicate_human_request_returns_409(client, seed):
+    h = _headers(seed["token1"], seed["agent1"])
+
+    first = await client.post(
+        "/api/dashboard/contact-requests",
+        json={"to_human_id": seed["hu_bob"]},
+        headers=h,
+    )
+    assert first.status_code == 201
+
+    dup = await client.post(
+        "/api/dashboard/contact-requests",
+        json={"to_human_id": seed["hu_bob"]},
+        headers=h,
+    )
+    assert dup.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sent_listing_includes_human_target(client, seed):
+    h = _headers(seed["token1"], seed["agent1"])
+    await client.post(
+        "/api/dashboard/contact-requests",
+        json={"to_human_id": seed["hu_bob"]},
+        headers=h,
+    )
+
+    resp = await client.get("/api/dashboard/contact-requests/sent", headers=h)
+    assert resp.status_code == 200
+    reqs = resp.json()["requests"]
+    assert len(reqs) == 1
+    row = reqs[0]
+    assert row["to_agent_id"] == seed["hu_bob"]
+    assert row["to_type"] == "human"
+    assert row["from_type"] == "agent"
+    assert row["to_display_name"] == seed["display_bob"]
+
+
+@pytest.mark.asyncio
+async def test_received_listing_includes_human_sender_display_name(
+    client, seed, db_session
+):
+    """Simulate an H→A ContactRequest inserted directly (the humans.py
+    router is owned by another agent) and verify the dashboard received
+    listing resolves the human's display name from the User row."""
+    # Insert the H→A request directly.
+    row = ContactRequest(
+        from_agent_id=seed["hu_bob"],
+        to_agent_id=seed["agent1"],
+        from_type=ParticipantType.human,
+        to_type=ParticipantType.agent,
+        state=ContactRequestState.pending,
+        message="ping from human",
+    )
+    db_session.add(row)
+    await db_session.commit()
+
+    resp = await client.get(
+        "/api/dashboard/contact-requests/received",
+        headers=_headers(seed["token1"], seed["agent1"]),
+    )
+    assert resp.status_code == 200
+    reqs = resp.json()["requests"]
+    assert len(reqs) == 1
+    item = reqs[0]
+    assert item["from_agent_id"] == seed["hu_bob"]
+    assert item["from_type"] == "human"
+    assert item["to_type"] == "agent"
+    assert item["from_display_name"] == seed["display_bob"]
+
+
+# ---------------------------------------------------------------------------
+# accept
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_accept_h2a_creates_polymorphic_contact_rows(client, seed, db_session):
+    """When an agent accepts an H→A request, both Contact rows must carry
+    the right owner_type/peer_type so that queries downstream can tell
+    whether each participant is a human or an agent."""
+    # Seed an H→A request (humans.py would normally create it).
+    row = ContactRequest(
+        from_agent_id=seed["hu_bob"],
+        to_agent_id=seed["agent1"],
+        from_type=ParticipantType.human,
+        to_type=ParticipantType.agent,
+        state=ContactRequestState.pending,
+        message=None,
+    )
+    db_session.add(row)
+    await db_session.commit()
+    await db_session.refresh(row)
+
+    resp = await client.post(
+        f"/api/dashboard/contact-requests/{row.id}/accept",
+        headers=_headers(seed["token1"], seed["agent1"]),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["state"] == "accepted"
+    assert body["from_type"] == "human"
+    assert body["to_type"] == "agent"
+
+    # Two contact rows should exist, one for each direction.
+    contacts = (await db_session.execute(select(Contact))).scalars().all()
+    pairs = {
+        (c.owner_id, c.owner_type, c.contact_agent_id, c.peer_type) for c in contacts
+    }
+    assert (
+        seed["agent1"], ParticipantType.agent, seed["hu_bob"], ParticipantType.human
+    ) in pairs
+    assert (
+        seed["hu_bob"], ParticipantType.human, seed["agent1"], ParticipantType.agent
+    ) in pairs
+
+
+@pytest.mark.asyncio
+async def test_accept_a2a_still_creates_agent_pair(client, seed, db_session):
+    """Regression: A↔A accept path must still produce agent/agent contacts."""
+    # Seed an A→A request from agent3 to agent1.
+    row = ContactRequest(
+        from_agent_id=seed["agent3"],
+        to_agent_id=seed["agent1"],
+        from_type=ParticipantType.agent,
+        to_type=ParticipantType.agent,
+        state=ContactRequestState.pending,
+    )
+    db_session.add(row)
+    await db_session.commit()
+    await db_session.refresh(row)
+
+    resp = await client.post(
+        f"/api/dashboard/contact-requests/{row.id}/accept",
+        headers=_headers(seed["token1"], seed["agent1"]),
+    )
+    assert resp.status_code == 200
+
+    contacts = (await db_session.execute(select(Contact))).scalars().all()
+    for c in contacts:
+        assert c.owner_type == ParticipantType.agent
+        assert c.peer_type == ParticipantType.agent
+
+
+@pytest.mark.asyncio
+async def test_accept_rejects_when_recipient_is_not_active_agent(
+    client, seed, db_session
+):
+    """An A→H ContactRequest must NOT be acceptable via the dashboard
+    (recipient is a human — acceptance lives on the humans-side router)."""
+    row = ContactRequest(
+        from_agent_id=seed["agent1"],
+        to_agent_id=seed["hu_bob"],
+        from_type=ParticipantType.agent,
+        to_type=ParticipantType.human,
+        state=ContactRequestState.pending,
+    )
+    db_session.add(row)
+    await db_session.commit()
+    await db_session.refresh(row)
+
+    # Active agent = ag_alice001 (the sender). Accept should 403 because
+    # to_type is human, not agent — this isn't a dashboard-side accept.
+    resp = await client.post(
+        f"/api/dashboard/contact-requests/{row.id}/accept",
+        headers=_headers(seed["token1"], seed["agent1"]),
+    )
+    assert resp.status_code == 403

--- a/backend/tests/test_app/test_app_humans.py
+++ b/backend/tests/test_app/test_app_humans.py
@@ -403,6 +403,476 @@ async def test_bad_peer_prefix_rejected(client, seed):
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Mixed ag_/hu_ member_ids on room creation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_room_with_mixed_participant_types(
+    client, seed, db_session: AsyncSession
+):
+    """POST /api/humans/me/rooms must branch on the id prefix and stamp
+    participant_type accordingly for every initial member."""
+    # Seed a second Human (Bob) + an Agent.
+    bob_supa = uuid.uuid4()
+    bob = User(supabase_user_id=bob_supa, display_name="Bob")
+    db_session.add(bob)
+    await db_session.flush()
+    bob_human_id = bob.human_id
+
+    db_session.add(
+        Agent(
+            agent_id="ag_tool00001",
+            display_name="Helper",
+            message_policy=MessagePolicy.open,
+            user_id=None,
+        )
+    )
+    await db_session.commit()
+
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    resp = await client.post(
+        "/api/humans/me/rooms",
+        headers=headers,
+        json={
+            "name": "Mixed Room",
+            "member_ids": [
+                "ag_tool00001",
+                bob_human_id,
+                # Duplicate the creator's own id — must be skipped.
+                seed["human_id"],
+            ],
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    room_id = resp.json()["room_id"]
+
+    rows = await db_session.execute(
+        select(RoomMember).where(RoomMember.room_id == room_id)
+    )
+    members = {m.agent_id: m for m in rows.scalars().all()}
+    assert set(members.keys()) == {seed["human_id"], "ag_tool00001", bob_human_id}
+    assert members[seed["human_id"]].participant_type == ParticipantType.human
+    assert members[seed["human_id"]].role == RoomRole.owner
+    assert members["ag_tool00001"].participant_type == ParticipantType.agent
+    assert members[bob_human_id].participant_type == ParticipantType.human
+
+
+@pytest.mark.asyncio
+async def test_create_room_rejects_unknown_prefix(client, seed):
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    resp = await client.post(
+        "/api/humans/me/rooms",
+        headers=headers,
+        json={"name": "Bad", "member_ids": ["xx_something"]},
+    )
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# POST /api/humans/me/rooms/{room_id}/members
+# ---------------------------------------------------------------------------
+
+
+async def _create_room_as(client: AsyncClient, token: str, name: str = "Room") -> str:
+    resp = await client.post(
+        "/api/humans/me/rooms",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"name": name},
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["room_id"]
+
+
+@pytest.mark.asyncio
+async def test_invite_agent_via_members_endpoint(
+    client, seed, db_session: AsyncSession
+):
+    # Seed an unclaimed agent so the invite is direct (no approval queue).
+    db_session.add(
+        Agent(
+            agent_id="ag_tool00001",
+            display_name="Helper",
+            message_policy=MessagePolicy.open,
+            user_id=None,
+        )
+    )
+    await db_session.commit()
+
+    room_id = await _create_room_as(client, seed["token"], "Agent invite room")
+    resp = await client.post(
+        f"/api/humans/me/rooms/{room_id}/members",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+        json={"participant_id": "ag_tool00001"},
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["room_id"] == room_id
+    assert body["participant_id"] == "ag_tool00001"
+    assert body["participant_type"] == "agent"
+    assert body["role"] == "member"
+
+    # DB check
+    row = await db_session.execute(
+        select(RoomMember).where(
+            RoomMember.room_id == room_id,
+            RoomMember.agent_id == "ag_tool00001",
+        )
+    )
+    m = row.scalar_one()
+    assert m.participant_type == ParticipantType.agent
+
+
+@pytest.mark.asyncio
+async def test_invite_human_via_members_endpoint(
+    client, seed, db_session: AsyncSession
+):
+    bob_supa = uuid.uuid4()
+    bob = User(supabase_user_id=bob_supa, display_name="Bob")
+    db_session.add(bob)
+    await db_session.commit()
+    bob_human_id = bob.human_id
+
+    room_id = await _create_room_as(client, seed["token"], "Human invite room")
+    resp = await client.post(
+        f"/api/humans/me/rooms/{room_id}/members",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+        json={"participant_id": bob_human_id, "role": "admin"},
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["participant_type"] == "human"
+    assert body["role"] == "admin"
+
+    row = await db_session.execute(
+        select(RoomMember).where(
+            RoomMember.room_id == room_id,
+            RoomMember.agent_id == bob_human_id,
+        )
+    )
+    m = row.scalar_one()
+    assert m.participant_type == ParticipantType.human
+    assert m.role == RoomRole.admin
+
+
+@pytest.mark.asyncio
+async def test_invite_members_endpoint_requires_owner_or_admin(
+    client, seed, db_session: AsyncSession
+):
+    """A Human who is a plain member (not owner/admin) cannot invite."""
+    # Carol (room owner) + Alice (seed user, non-member).
+    carol_supa = uuid.uuid4()
+    carol = User(supabase_user_id=carol_supa, display_name="Carol")
+    db_session.add(carol)
+    await db_session.commit()
+    carol_human_id = carol.human_id
+
+    # Carol creates the room and adds Alice as a plain member.
+    carol_token = _token(str(carol_supa))
+    room_id = await _create_room_as(client, carol_token, "Carol's salon")
+
+    db_session.add(
+        RoomMember(
+            room_id=room_id,
+            agent_id=seed["human_id"],
+            participant_type=ParticipantType.human,
+            role=RoomRole.member,
+        )
+    )
+    # And a target agent for Alice to attempt to invite.
+    db_session.add(
+        Agent(
+            agent_id="ag_target0001",
+            display_name="Target",
+            message_policy=MessagePolicy.open,
+            user_id=None,
+        )
+    )
+    await db_session.commit()
+
+    resp = await client.post(
+        f"/api/humans/me/rooms/{room_id}/members",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+        json={"participant_id": "ag_target0001"},
+    )
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_invite_members_endpoint_rejects_bad_prefix(client, seed):
+    room_id = await _create_room_as(client, seed["token"])
+    resp = await client.post(
+        f"/api/humans/me/rooms/{room_id}/members",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+        json={"participant_id": "bogus"},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_invite_members_endpoint_409_on_duplicate(
+    client, seed, db_session: AsyncSession
+):
+    db_session.add(
+        Agent(
+            agent_id="ag_dup0000001",
+            display_name="Dup",
+            message_policy=MessagePolicy.open,
+            user_id=None,
+        )
+    )
+    await db_session.commit()
+
+    room_id = await _create_room_as(client, seed["token"])
+    # First invite succeeds
+    r1 = await client.post(
+        f"/api/humans/me/rooms/{room_id}/members",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+        json={"participant_id": "ag_dup0000001"},
+    )
+    assert r1.status_code == 201
+    # Second invite collides
+    r2 = await client.post(
+        f"/api/humans/me/rooms/{room_id}/members",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+        json={"participant_id": "ag_dup0000001"},
+    )
+    assert r2.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# Contact requests (Human-side accept/reject + listings)
+# ---------------------------------------------------------------------------
+
+
+async def _seed_second_human(db_session: AsyncSession, display_name: str = "Bob") -> tuple[uuid.UUID, str, str]:
+    supa = uuid.uuid4()
+    u = User(supabase_user_id=supa, display_name=display_name)
+    db_session.add(u)
+    await db_session.commit()
+    await db_session.refresh(u)
+    return u.id, u.human_id, _token(str(supa))
+
+
+@pytest.mark.asyncio
+async def test_h2h_request_received_listing(
+    client, seed, db_session: AsyncSession
+):
+    _, bob_human_id, bob_token = await _seed_second_human(db_session, "Bob")
+
+    # Alice requests contact with Bob directly via the existing endpoint.
+    resp = await client.post(
+        "/api/humans/me/contacts/request",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+        json={"peer_id": bob_human_id, "message": "hi"},
+    )
+    assert resp.status_code == 202
+    assert resp.json()["status"] == "requested"
+
+    # Bob sees it in received.
+    received = await client.get(
+        "/api/humans/me/contact-requests/received",
+        headers={"Authorization": f"Bearer {bob_token}"},
+    )
+    assert received.status_code == 200
+    reqs = received.json()["requests"]
+    assert len(reqs) == 1
+    assert reqs[0]["from_participant_id"] == seed["human_id"]
+    assert reqs[0]["from_type"] == "human"
+    assert reqs[0]["to_type"] == "human"
+    assert reqs[0]["message"] == "hi"
+    # Display-name resolution: Alice's User row.
+    assert reqs[0]["from_display_name"] == "Alice"
+    assert reqs[0]["to_display_name"] == "Bob"
+
+    # Alice sees the same request in sent.
+    sent = await client.get(
+        "/api/humans/me/contact-requests/sent",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+    )
+    assert sent.status_code == 200
+    sent_rows = sent.json()["requests"]
+    assert len(sent_rows) == 1
+    assert sent_rows[0]["to_participant_id"] == bob_human_id
+
+
+@pytest.mark.asyncio
+async def test_h2h_accept_creates_mutual_contacts(
+    client, seed, db_session: AsyncSession
+):
+    _, bob_human_id, bob_token = await _seed_second_human(db_session, "Bob")
+
+    resp = await client.post(
+        "/api/humans/me/contacts/request",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+        json={"peer_id": bob_human_id},
+    )
+    assert resp.status_code == 202
+
+    # Bob inspects the pending request and finds its id from the listing.
+    received = await client.get(
+        "/api/humans/me/contact-requests/received",
+        headers={"Authorization": f"Bearer {bob_token}"},
+    )
+    req_id = received.json()["requests"][0]["id"]
+
+    # Bob accepts.
+    accept = await client.post(
+        f"/api/humans/me/contact-requests/{req_id}/accept",
+        headers={"Authorization": f"Bearer {bob_token}"},
+    )
+    assert accept.status_code == 200
+    assert accept.json()["state"] == "accepted"
+
+    # Both Contact rows materialised with correct polymorphic types.
+    rows = list(
+        (await db_session.execute(select(Contact))).scalars().all()
+    )
+    by_owner = {(c.owner_id, c.contact_agent_id): c for c in rows}
+    bob_side = by_owner[(bob_human_id, seed["human_id"])]
+    alice_side = by_owner[(seed["human_id"], bob_human_id)]
+    assert bob_side.owner_type == ParticipantType.human
+    assert bob_side.peer_type == ParticipantType.human
+    assert alice_side.owner_type == ParticipantType.human
+    assert alice_side.peer_type == ParticipantType.human
+
+    # Second accept → 409
+    again = await client.post(
+        f"/api/humans/me/contact-requests/{req_id}/accept",
+        headers={"Authorization": f"Bearer {bob_token}"},
+    )
+    assert again.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_h2a_accept_creates_mutual_contacts_with_correct_types(
+    client, seed, db_session: AsyncSession
+):
+    """Human ← Agent contact request. Accept must stamp the peer_type pair
+    (agent, human) / (human, agent) on the two mirror Contact rows."""
+    # Seed an unclaimed Agent that will initiate the request.
+    db_session.add(
+        Agent(
+            agent_id="ag_init00001",
+            display_name="Initiator",
+            message_policy=MessagePolicy.open,
+            user_id=None,
+        )
+    )
+    # Directly insert the ContactRequest row — simulating an agent-initiated
+    # request, which would normally land via /hub/send contact_request.
+    req = ContactRequest(
+        from_agent_id="ag_init00001",
+        from_type=ParticipantType.agent,
+        to_agent_id=seed["human_id"],
+        to_type=ParticipantType.human,
+        state=ContactRequestState.pending,
+        message="hi human",
+    )
+    db_session.add(req)
+    await db_session.commit()
+    await db_session.refresh(req)
+    req_id = req.id
+
+    # Human accepts via the new endpoint.
+    accept = await client.post(
+        f"/api/humans/me/contact-requests/{req_id}/accept",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+    )
+    assert accept.status_code == 200, accept.text
+    assert accept.json()["state"] == "accepted"
+
+    rows = list(
+        (await db_session.execute(select(Contact))).scalars().all()
+    )
+    pairs = {
+        (c.owner_id, c.owner_type, c.contact_agent_id, c.peer_type) for c in rows
+    }
+    assert (
+        seed["human_id"],
+        ParticipantType.human,
+        "ag_init00001",
+        ParticipantType.agent,
+    ) in pairs
+    assert (
+        "ag_init00001",
+        ParticipantType.agent,
+        seed["human_id"],
+        ParticipantType.human,
+    ) in pairs
+
+
+@pytest.mark.asyncio
+async def test_reject_transitions_state_only(
+    client, seed, db_session: AsyncSession
+):
+    _, bob_human_id, bob_token = await _seed_second_human(db_session, "Bob")
+
+    await client.post(
+        "/api/humans/me/contacts/request",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+        json={"peer_id": bob_human_id},
+    )
+    received = await client.get(
+        "/api/humans/me/contact-requests/received",
+        headers={"Authorization": f"Bearer {bob_token}"},
+    )
+    req_id = received.json()["requests"][0]["id"]
+
+    reject = await client.post(
+        f"/api/humans/me/contact-requests/{req_id}/reject",
+        headers={"Authorization": f"Bearer {bob_token}"},
+    )
+    assert reject.status_code == 200
+    assert reject.json()["state"] == "rejected"
+
+    contacts = list((await db_session.execute(select(Contact))).scalars().all())
+    assert contacts == []
+
+    rows = list((await db_session.execute(select(ContactRequest))).scalars().all())
+    assert len(rows) == 1
+    assert rows[0].state == ContactRequestState.rejected
+
+    # Second resolve → 409
+    again = await client.post(
+        f"/api/humans/me/contact-requests/{req_id}/reject",
+        headers={"Authorization": f"Bearer {bob_token}"},
+    )
+    assert again.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_non_recipient_cannot_accept_request(
+    client, seed, db_session: AsyncSession
+):
+    _, bob_human_id, bob_token = await _seed_second_human(db_session, "Bob")
+    _, _, carol_token = await _seed_second_human(db_session, "Carol")
+
+    await client.post(
+        "/api/humans/me/contacts/request",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+        json={"peer_id": bob_human_id},
+    )
+    received = await client.get(
+        "/api/humans/me/contact-requests/received",
+        headers={"Authorization": f"Bearer {bob_token}"},
+    )
+    req_id = received.json()["requests"][0]["id"]
+
+    # Carol (unrelated) tries to accept → 403.
+    resp = await client.post(
+        f"/api/humans/me/contact-requests/{req_id}/accept",
+        headers={"Authorization": f"Bearer {carol_token}"},
+    )
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# crypto short-circuit
+# ---------------------------------------------------------------------------
+
+
 def test_verify_envelope_sig_short_circuits_for_human():
     from hub.crypto import verify_envelope_sig
     from hub.schemas import MessageEnvelope, Signature

--- a/backend/tests/test_hub_room_human_guard.py
+++ b/backend/tests/test_hub_room_human_guard.py
@@ -1,0 +1,223 @@
+"""Regression tests for the hub-router human-id guard and human-owned room
+permission checks.
+
+These cover two concerns:
+
+1. The hub router (``/hub/rooms/*``) is the agent-protocol layer. It must
+   reject ``hu_*`` ids on any input field so human users are forced to go
+   through ``/api/humans/me/rooms*``.
+2. When a room's owner is a human (``owner_type='human'``) an agent that is
+   merely a member (not the owner) should still be able to invite another
+   agent when ``default_invite=True`` — the permission helpers must not
+   crash or wrongly grant owner privileges to the agent.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+from tests.test_room import _auth_header, _create_agent, client, db_session  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# 1. Hub router rejects hu_* on inputs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_add_member_rejects_human_id_in_body(client: AsyncClient):
+    """POST /hub/rooms/{id}/members with a hu_* agent_id → HTTP 400."""
+    _sk, owner_id, _key, owner_token = await _create_agent(client, "owner")
+
+    create_resp = await client.post(
+        "/hub/rooms",
+        json={"name": "Agent Room"},
+        headers=_auth_header(owner_token),
+    )
+    assert create_resp.status_code == 201
+    room_id = create_resp.json()["room_id"]
+
+    resp = await client.post(
+        f"/hub/rooms/{room_id}/members",
+        json={"agent_id": "hu_abc123def456"},
+        headers=_auth_header(owner_token),
+    )
+    assert resp.status_code == 400
+    detail = resp.json().get("detail", "")
+    assert "hu_" in detail
+    assert "/api/humans/me/rooms" in detail
+
+
+@pytest.mark.asyncio
+async def test_create_room_rejects_human_id_in_member_ids(client: AsyncClient):
+    """POST /hub/rooms with hu_* in member_ids → HTTP 400."""
+    _sk, _agent_id, _key, token = await _create_agent(client, "owner")
+
+    resp = await client.post(
+        "/hub/rooms",
+        json={"name": "Bad Room", "member_ids": ["hu_deadbeefcafe"]},
+        headers=_auth_header(token),
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_promote_rejects_human_id(client: AsyncClient):
+    """POST /hub/rooms/{id}/promote with hu_* agent_id → HTTP 400."""
+    _sk, _owner_id, _key, owner_token = await _create_agent(client, "owner")
+    create_resp = await client.post(
+        "/hub/rooms",
+        json={"name": "Room"},
+        headers=_auth_header(owner_token),
+    )
+    room_id = create_resp.json()["room_id"]
+
+    resp = await client.post(
+        f"/hub/rooms/{room_id}/promote",
+        json={"agent_id": "hu_abc123def456", "role": "admin"},
+        headers=_auth_header(owner_token),
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_transfer_rejects_human_id(client: AsyncClient):
+    """POST /hub/rooms/{id}/transfer with hu_* new_owner_id → HTTP 400."""
+    _sk, _owner_id, _key, owner_token = await _create_agent(client, "owner")
+    create_resp = await client.post(
+        "/hub/rooms",
+        json={"name": "Room"},
+        headers=_auth_header(owner_token),
+    )
+    room_id = create_resp.json()["room_id"]
+
+    resp = await client.post(
+        f"/hub/rooms/{room_id}/transfer",
+        json={"new_owner_id": "hu_abc123def456"},
+        headers=_auth_header(owner_token),
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_remove_member_rejects_human_id_in_path(client: AsyncClient):
+    """DELETE /hub/rooms/{id}/members/hu_* → HTTP 400."""
+    _sk, _owner_id, _key, owner_token = await _create_agent(client, "owner")
+    create_resp = await client.post(
+        "/hub/rooms",
+        json={"name": "Room"},
+        headers=_auth_header(owner_token),
+    )
+    room_id = create_resp.json()["room_id"]
+
+    resp = await client.delete(
+        f"/hub/rooms/{room_id}/members/hu_abc123def456",
+        headers=_auth_header(owner_token),
+    )
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# 2. Human-owned room: agent member with default_invite=True can invite
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agent_can_invite_in_human_owned_room_with_default_invite(
+    client: AsyncClient,
+    db_session,
+):
+    """Simulate a human-owned room: an agent that is a member (not the
+    owner) with ``default_invite=True`` must be able to invite another
+    agent without crashing and without needing owner/admin role.
+
+    We build this state directly against the DB to avoid depending on the
+    /api/humans BFF layer (which may not be present on every branch). We
+    defensively set ``owner_type``/``participant_type`` via ``setattr`` so
+    the test works both pre- and post-Human-first merge.
+    """
+    from hub.models import Room, RoomMember, RoomRole, RoomVisibility, RoomJoinPolicy
+
+    # Two agents — alice (member, will invite) and bob (to be invited).
+    _sk_a, alice_id, _a_key, alice_token = await _create_agent(client, "alice")
+    _sk_b, bob_id, _b_key, _bob_token = await _create_agent(client, "bob")
+
+    # Build a synthetic human-owned room. We use a ``hu_*`` id for the
+    # owner_id column. The column is an FK to agents on pre-merge schemas,
+    # so we insert it through raw SQL and accept that the FK may or may
+    # not be present — if the FK is still tight this test becomes a no-op
+    # and skips.
+    from sqlalchemy import text
+    from hub.id_generators import generate_room_id
+
+    room_id = generate_room_id()
+    try:
+        await db_session.execute(
+            text(
+                "INSERT INTO rooms (room_id, name, description, owner_id, "
+                "visibility, join_policy, default_send, default_invite, max_members) "
+                "VALUES (:room_id, :name, :description, :owner_id, "
+                ":visibility, :join_policy, :default_send, :default_invite, :max_members)"
+            ),
+            {
+                "room_id": room_id,
+                "name": "Human Room",
+                "description": "",
+                # Pre-merge: owner_id FK to agents.agent_id — we can only
+                # simulate "human owner" if we drop the FK constraint.
+                # When FK is present, use alice_id as a stand-in and set
+                # owner_type='human' via attribute assignment below so
+                # _room_owner_is_human() returns True.
+                "owner_id": alice_id,
+                "visibility": "public",
+                "join_policy": "invite_only",
+                "default_send": True,
+                "default_invite": True,
+                "max_members": None,
+            },
+        )
+    except Exception:
+        pytest.skip("Cannot synthesise human-owned room on this schema")
+
+    # Alice joins as a plain member (not owner).
+    await db_session.execute(
+        text(
+            "INSERT INTO room_members (room_id, agent_id, role, muted) "
+            "VALUES (:room_id, :agent_id, :role, :muted)"
+        ),
+        {
+            "room_id": room_id,
+            "agent_id": alice_id,
+            "role": "member",
+            "muted": False,
+        },
+    )
+    await db_session.commit()
+
+    # Patch the Room instance to report owner_type='human' so the
+    # permission helpers treat it as a human-owned room. We monkey-patch
+    # the attribute lookup via a SQLAlchemy event — or more simply, we
+    # override it by setting the attribute after load via a router
+    # helper. Easiest path: set it as a class-level default for this test.
+    # Since _room_owner_is_human uses getattr(room, 'owner_type', 'agent'),
+    # we can expose a 'owner_type' attribute at the instance level.
+    from hub.routers import room as room_router
+
+    original_is_human = room_router._room_owner_is_human
+    room_router._room_owner_is_human = lambda _room: True  # type: ignore[assignment]
+    try:
+        # Alice invites Bob. Alice is role='member' but default_invite=True.
+        resp = await client.post(
+            f"/hub/rooms/{room_id}/members",
+            json={"agent_id": bob_id},
+            headers=_auth_header(alice_token),
+        )
+        # Should succeed — default_invite=True lets any agent member invite.
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        member_ids = {m["agent_id"] for m in data["members"]}
+        assert alice_id in member_ids
+        assert bob_id in member_ids
+    finally:
+        room_router._room_owner_is_human = original_is_human  # type: ignore[assignment]

--- a/frontend/src/components/dashboard/AddFriendModal.tsx
+++ b/frontend/src/components/dashboard/AddFriendModal.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { ArrowLeft, Check, Copy, Loader2, Search } from "lucide-react";
-import { api } from "@/lib/api";
+import { api, humansApi } from "@/lib/api";
 import { useLanguage } from "@/lib/i18n";
 import { common } from "@/lib/i18n/translations/common";
 import { addFriendModal } from "@/lib/i18n/translations/dashboard";
@@ -75,6 +75,11 @@ function SearchPane({ onClose }: { onClose: () => void }) {
   const t = addFriendModal[locale];
   const contacts = useDashboardChatStore((s) => s.overview?.contacts) ?? EMPTY_CONTACTS;
   const activeAgentId = useDashboardSessionStore((s) => s.activeAgentId);
+  // Identity signal: viewMode flips to "human" once /api/humans/me loads.
+  const viewMode = useDashboardSessionStore((s) => s.viewMode);
+  const human = useDashboardSessionStore((s) => s.human);
+  const identityReady =
+    viewMode === "human" ? Boolean(human) : Boolean(activeAgentId);
   const contactIds = useMemo(
     () => new Set(contacts.map((c) => c.contact_agent_id)),
     [contacts],
@@ -117,11 +122,46 @@ function SearchPane({ onClose }: { onClose: () => void }) {
     setSending(true);
     setError(null);
     try {
-      await api.createContactRequest({
-        to_agent_id: selected.agent_id,
-        message: message.trim() || undefined,
-      });
-      setStatus("sent");
+      const targetId = selected.agent_id;
+      const targetIsHuman = targetId.startsWith("hu_");
+      const trimmedMsg = message.trim() || undefined;
+
+      // Agent → Human goes to /api/dashboard/contact-requests with the
+      // polymorphic `to_human_id` field. `api.createContactRequest` is
+      // typed for the legacy `{ to_agent_id, message }` shape and owned by
+      // another agent; we cast to send the extended body without touching
+      // that declaration. If backend settles on `to_id`+`to_type` instead,
+      // adjust the cast here.
+      const agentPayload = targetIsHuman
+        ? ({ to_human_id: targetId, message: trimmedMsg } as unknown as {
+            to_agent_id: string;
+            message?: string;
+          })
+        : { to_agent_id: targetId, message: trimmedMsg };
+
+      const res =
+        viewMode === "human"
+          ? await humansApi.sendContactRequest({
+              peer_id: targetId,
+              message: trimmedMsg,
+            })
+          : await api.createContactRequest(agentPayload);
+
+      // Human BFF returns a structured ContactRequestOutcome; agent BFF just
+      // returns 201 on success or throws. Translate to existing UI states.
+      if (
+        res &&
+        typeof res === "object" &&
+        "status" in res &&
+        typeof (res as { status: unknown }).status === "string"
+      ) {
+        const s = (res as { status: string }).status;
+        if (s === "already_contact") setStatus("exists");
+        else if (s === "already_requested") setStatus("pending");
+        else setStatus("sent");
+      } else {
+        setStatus("sent");
+      }
     } catch (err) {
       const msg = err instanceof Error ? err.message : t.requestFailed;
       if (/already.*contact/i.test(msg)) setStatus("exists");
@@ -189,7 +229,8 @@ function SearchPane({ onClose }: { onClose: () => void }) {
             )}
             <button
               onClick={handleSend}
-              disabled={sending}
+              disabled={sending || !identityReady}
+              title={!identityReady ? t.requestFailed : undefined}
               className="inline-flex w-full items-center justify-center gap-2 rounded border border-neon-cyan/50 bg-neon-cyan/10 px-4 py-2 text-sm text-neon-cyan hover:bg-neon-cyan/20 disabled:opacity-50"
             >
               {sending && <Loader2 className="h-4 w-4 animate-spin" />}

--- a/frontend/src/components/dashboard/CreateRoomModal.tsx
+++ b/frontend/src/components/dashboard/CreateRoomModal.tsx
@@ -7,6 +7,7 @@ import { useLanguage } from "@/lib/i18n";
 import { common } from "@/lib/i18n/translations/common";
 import { createRoomModal } from "@/lib/i18n/translations/dashboard";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
+import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import type { ContactInfo, HumanRoomSummary } from "@/lib/types";
 
 const EMPTY_CONTACTS: ContactInfo[] = [];
@@ -22,6 +23,14 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
   const tc = common[locale];
   const contacts = useDashboardChatStore((s) => s.overview?.contacts) ?? EMPTY_CONTACTS;
   const refreshOverview = useDashboardChatStore((s) => s.refreshOverview);
+  // Identity signal — treat viewMode as the authoritative "who is acting".
+  // viewMode defaults to "human" once the /api/humans/me bootstrap completes,
+  // flipping to "agent" only in observer/agent-mode. No unified
+  // `activeIdentity` selector exists yet; see report for coordination ask.
+  const viewMode = useDashboardSessionStore((s) => s.viewMode);
+  const human = useDashboardSessionStore((s) => s.human);
+  const activeAgentId = useDashboardSessionStore((s) => s.activeAgentId);
+  const identityReady = viewMode === "human" ? Boolean(human) : Boolean(activeAgentId);
 
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
@@ -63,9 +72,15 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
       setError(t.nameRequired);
       return;
     }
+    if (!identityReady) {
+      setError(t.createFailed);
+      return;
+    }
     setSaving(true);
     setError(null);
     try {
+      // Shared body — `member_ids` accepts both `ag_*` and `hu_*` prefixes
+      // when dispatched via the Human BFF (backend handles polymorphism).
       const body = {
         name: trimmed,
         description: description.trim(),
@@ -78,11 +93,21 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
         slow_mode_seconds: slowMode ? Number(slowMode) : null,
         member_ids: Array.from(selected),
       };
+      // Human path is the only dashboard-facing create-room surface today.
+      // Agent path would hit POST /hub/rooms directly (signed request), which
+      // the dashboard does not own — we surface an explicit error instead of
+      // silently misrouting through the Human BFF.
+      if (viewMode === "agent") {
+        setError(t.createFailed);
+        return;
+      }
       const room = await humansApi.createRoom(body);
       await refreshOverview();
       onCreated?.(room);
       onClose();
     } catch (err) {
+      // ApiError.message already carries the 400/403 body ("detail" field)
+      // via extractErrorMessage in lib/api.ts, so surface it verbatim.
       setError(err instanceof Error ? err.message : t.createFailed);
     } finally {
       setSaving(false);
@@ -310,7 +335,8 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
           </button>
           <button
             onClick={handleCreate}
-            disabled={saving}
+            disabled={saving || !identityReady}
+            title={!identityReady ? t.createFailed : undefined}
             className="inline-flex items-center gap-2 rounded border border-neon-cyan/50 bg-neon-cyan/10 px-4 py-2 text-sm text-neon-cyan hover:bg-neon-cyan/20 disabled:opacity-50"
           >
             {saving && <Loader2 className="h-4 w-4 animate-spin" />}

--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -341,7 +341,12 @@ export default function DashboardApp() {
       subscriptionBoundAgentRef.current = sessionStore.activeAgentId;
       subscriptionStore.resetSubscriptionState();
     }
-    if (!chatStore.overview && !chatStore.overviewRefreshing && uiStore.sidebarTab !== "wallet") {
+    if (
+      !chatStore.overview
+      && !chatStore.overviewRefreshing
+      && !chatStore.overviewErrored
+      && uiStore.sidebarTab !== "wallet"
+    ) {
       void chatStore.refreshOverview();
     }
   }, [
@@ -353,6 +358,7 @@ export default function DashboardApp() {
     uiStore.resetUIState,
     chatStore.overview,
     chatStore.overviewRefreshing,
+    chatStore.overviewErrored,
     chatStore.resetChatState,
     chatStore.refreshOverview,
     unreadStore.resetUnreadState,
@@ -365,7 +371,7 @@ export default function DashboardApp() {
   useEffect(() => {
     if (!sessionStore.authResolved || sessionStore.sessionMode !== "authed-ready") return;
     if (uiStore.sidebarTab === "wallet" || uiStore.sidebarTab === "activity") return;
-    if (chatStore.overview || chatStore.overviewRefreshing) return;
+    if (chatStore.overview || chatStore.overviewRefreshing || chatStore.overviewErrored) return;
     void chatStore.refreshOverview();
   }, [
     sessionStore.authResolved,
@@ -373,6 +379,7 @@ export default function DashboardApp() {
     uiStore.sidebarTab,
     chatStore.overview,
     chatStore.overviewRefreshing,
+    chatStore.overviewErrored,
     chatStore.refreshOverview,
   ]);
 

--- a/frontend/src/components/dashboard/DiscoverRoomList.tsx
+++ b/frontend/src/components/dashboard/DiscoverRoomList.tsx
@@ -6,7 +6,7 @@
  */
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useLanguage } from '@/lib/i18n';
 import { roomList } from '@/lib/i18n/translations/dashboard';
 import { common } from '@/lib/i18n/translations/common';
@@ -30,10 +30,12 @@ export default function DiscoverRoomList() {
     })),
   );
 
+  const autoLoadedRef = useRef(false);
   useEffect(() => {
-    if (discoverRooms.length === 0 && !discoverLoading) {
-      void loadDiscoverRooms();
-    }
+    if (autoLoadedRef.current) return;
+    if (discoverRooms.length > 0 || discoverLoading) return;
+    autoLoadedRef.current = true;
+    void loadDiscoverRooms();
   }, [discoverRooms.length, discoverLoading, loadDiscoverRooms]);
 
   if (discoverLoading && discoverRooms.length === 0) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -57,6 +57,9 @@ import type {
   HumanContactRequestResponse,
   PendingApprovalListResponse,
   ResolveApprovalResponse,
+  HumanRoomMemberResponse,
+  HumanContactRequestListResponse,
+  HumanContactRequestResolveResponse,
 } from "./types";
 
 import { createClient } from "@/lib/supabase/client";
@@ -73,7 +76,12 @@ const API_BASE =
   (process.env.NODE_ENV === "development" ? "http://localhost:8000" : "https://api.botcord.chat");
 
 const ACTIVE_AGENT_KEY = "botcord_active_agent_id";
+const ACTIVE_IDENTITY_KEY = "botcord_active_identity";
 const ME_CACHE_TTL_MS = 10_000;
+
+export type ActiveIdentity =
+  | { type: "human"; id: string }
+  | { type: "agent"; id: string };
 
 let meCache: { value: UserProfile; expiresAt: number } | null = null;
 let meInFlight: Promise<UserProfile> | null = null;
@@ -94,6 +102,50 @@ export function setActiveAgentId(agentId: string | null) {
   } else {
     localStorage.removeItem(ACTIVE_AGENT_KEY);
   }
+}
+
+export function getStoredActiveIdentity(): ActiveIdentity | null {
+  if (typeof window === "undefined") return null;
+  const raw = localStorage.getItem(ACTIVE_IDENTITY_KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      (parsed as { type?: unknown }).type &&
+      typeof (parsed as { id?: unknown }).id === "string"
+    ) {
+      const t = (parsed as { type: string }).type;
+      const id = (parsed as { id: string }).id;
+      if ((t === "human" || t === "agent") && id) {
+        return { type: t, id };
+      }
+    }
+  } catch {
+    // fall through
+  }
+  return null;
+}
+
+export function setStoredActiveIdentity(identity: ActiveIdentity | null) {
+  if (typeof window === "undefined") return;
+  if (identity) {
+    localStorage.setItem(ACTIVE_IDENTITY_KEY, JSON.stringify(identity));
+  } else {
+    localStorage.removeItem(ACTIVE_IDENTITY_KEY);
+  }
+}
+
+/**
+ * Resolve the effective active identity, tolerating stores from older sessions
+ * that only wrote `botcord_active_agent_id`. Returns null when neither exists.
+ */
+export function getActiveIdentity(): ActiveIdentity | null {
+  const stored = getStoredActiveIdentity();
+  if (stored) return stored;
+  const legacyAgent = getActiveAgentId();
+  return legacyAgent ? { type: "agent", id: legacyAgent } : null;
 }
 
 function extractErrorMessage(body: Record<string, unknown>, fallback: string): string {
@@ -130,9 +182,11 @@ async function buildAuthHeaders(): Promise<Record<string, string>> {
   if (token) {
     headers["Authorization"] = `Bearer ${token}`;
   }
-  const activeAgentId = getActiveAgentId();
-  if (activeAgentId) {
-    headers["X-Active-Agent"] = activeAgentId;
+  // New identity model: only send X-Active-Agent when acting as an agent.
+  // For type='human', the backend resolves human_id from the Supabase JWT.
+  const identity = getActiveIdentity();
+  if (identity?.type === "agent") {
+    headers["X-Active-Agent"] = identity.id;
   }
   return headers;
 }
@@ -736,6 +790,63 @@ const humansApi = {
     return apiPost<ResolveApprovalResponse>(
       `/api/humans/me/pending-approvals/${approvalId}/resolve`,
       { decision },
+    );
+  },
+
+  // -------------------------------------------------------------------------
+  // New Human-surface endpoints (paired with backend work in progress).
+  // -------------------------------------------------------------------------
+
+  /** Human (owner/admin) invites an agent or another Human into a room. */
+  async addRoomMember(
+    roomId: string,
+    body: { participant_id: string; role?: "member" | "admin" },
+  ): Promise<HumanRoomMemberResponse> {
+    return apiPost<HumanRoomMemberResponse>(
+      `/api/humans/me/rooms/${roomId}/members`,
+      body,
+    );
+  },
+
+  /** Received contact requests (pending-by-default). */
+  listReceivedContactRequests(
+    opts?: { state?: "pending" | "accepted" | "rejected" },
+  ): Promise<HumanContactRequestListResponse> {
+    const params: Record<string, string> = {};
+    if (opts?.state) params.state = opts.state;
+    return apiGet<HumanContactRequestListResponse>(
+      "/api/humans/me/contact-requests/received",
+      params,
+    );
+  },
+
+  /** Sent contact requests (pending-by-default). */
+  listSentContactRequests(
+    opts?: { state?: "pending" | "accepted" | "rejected" },
+  ): Promise<HumanContactRequestListResponse> {
+    const params: Record<string, string> = {};
+    if (opts?.state) params.state = opts.state;
+    return apiGet<HumanContactRequestListResponse>(
+      "/api/humans/me/contact-requests/sent",
+      params,
+    );
+  },
+
+  /** Accept a received contact request addressed to the current Human. */
+  acceptContactRequest(
+    requestId: string,
+  ): Promise<HumanContactRequestResolveResponse> {
+    return apiPost<HumanContactRequestResolveResponse>(
+      `/api/humans/me/contact-requests/${requestId}/accept`,
+    );
+  },
+
+  /** Reject a received contact request addressed to the current Human. */
+  rejectContactRequest(
+    requestId: string,
+  ): Promise<HumanContactRequestResolveResponse> {
+    return apiPost<HumanContactRequestResolveResponse>(
+      `/api/humans/me/contact-requests/${requestId}/reject`,
     );
   },
 };

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -1108,6 +1108,10 @@ export const accountMenu: TranslationMap<{
   wsOnline: string
   wsOffline: string
   refreshStatus: string
+  switchTo: string
+  humanSelf: string
+  activeHuman: string
+  noAgentSelected: string
 }> = {
   en: {
     account: 'Account',
@@ -1124,6 +1128,10 @@ export const accountMenu: TranslationMap<{
     wsOnline: 'Online',
     wsOffline: 'Offline',
     refreshStatus: 'Refresh status',
+    switchTo: 'Switch to',
+    humanSelf: 'Human (you)',
+    activeHuman: 'Acting as you',
+    noAgentSelected: 'No agent selected',
   },
   zh: {
     account: '账户',
@@ -1140,6 +1148,10 @@ export const accountMenu: TranslationMap<{
     wsOnline: '在线',
     wsOffline: '离线',
     refreshStatus: '刷新状态',
+    switchTo: '切换到',
+    humanSelf: '你自己 (Human)',
+    activeHuman: '以你自己的身份',
+    noAgentSelected: '未选择 Bot',
   },
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -846,3 +846,40 @@ export interface ResolveApprovalResponse {
   id: string;
   state: "approved" | "rejected";
 }
+
+// ---------------------------------------------------------------------------
+// Human-surface room membership & contact-request summaries (new endpoints:
+// POST /api/humans/me/rooms/{room_id}/members,
+// GET /api/humans/me/contact-requests/{received,sent},
+// POST /api/humans/me/contact-requests/{id}/{accept,reject})
+// ---------------------------------------------------------------------------
+
+export interface HumanRoomMemberResponse {
+  room_id: string;
+  participant_id: string;
+  participant_type: ParticipantType;
+  role: "owner" | "admin" | "member";
+  joined_at: number;
+}
+
+export interface HumanContactRequestSummary {
+  id: string;
+  from_participant_id: string;
+  from_type: ParticipantType;
+  from_display_name: string | null;
+  to_participant_id: string;
+  to_type: ParticipantType;
+  to_display_name: string | null;
+  state: "pending" | "accepted" | "rejected";
+  message: string | null;
+  created_at: number;
+}
+
+export interface HumanContactRequestListResponse {
+  requests: HumanContactRequestSummary[];
+}
+
+export interface HumanContactRequestResolveResponse {
+  id: string;
+  state: "accepted" | "rejected";
+}

--- a/frontend/src/store/useDaemonStore.ts
+++ b/frontend/src/store/useDaemonStore.ts
@@ -3,9 +3,19 @@
  * [OUTPUT]: useDaemonStore — list / refresh / revoke for the current user's daemon instances
  * [POS]: dashboard daemon control-plane store
  * [PROTOCOL]: update header on changes
+ *
+ * Identity notes:
+ *   Daemon instances are scoped to the authenticated user, NOT the active
+ *   agent, so list/refresh/revoke/refreshRuntimes all work regardless of
+ *   whether the active identity is Human or Agent. Any future agent-scoped
+ *   daemon action (e.g., dispatch to a specific agent) MUST first check
+ *   `useDashboardSessionStore.getState().activeIdentity` and no-op with a
+ *   "No agent selected" error when the identity is Human — see
+ *   `requireActiveAgentId` below.
  */
 
 import { create } from "zustand";
+import { useDashboardSessionStore } from "./useDashboardSessionStore";
 
 export interface DaemonRuntime {
   id: string;
@@ -83,6 +93,20 @@ const initialState = {
   refreshingRuntimesId: null as string | null,
   runtimeErrors: {} as Record<string, string>,
 };
+
+/**
+ * Returns the active agent id only when the session identity is "agent".
+ * If the user is acting as themselves (Human) or no agent is selected,
+ * returns null — agent-scoped daemon callers should treat this as a no-op
+ * and surface a "No agent selected" toast/error rather than crashing.
+ */
+export function requireActiveAgentId(): string | null {
+  const { activeIdentity, activeAgentId } = useDashboardSessionStore.getState();
+  if (activeIdentity?.type === "agent") return activeIdentity.id;
+  // Legacy fallback: no identity set yet but an agent id exists.
+  if (!activeIdentity && activeAgentId) return activeAgentId;
+  return null;
+}
 
 async function parseError(res: Response): Promise<string> {
   try {

--- a/frontend/src/store/useDashboardChatStore.ts
+++ b/frontend/src/store/useDashboardChatStore.ts
@@ -58,6 +58,7 @@ function applyRealtimeRoomHint<T extends {
 interface DashboardChatState {
   boundAgentId: string | null;
   overviewRefreshing: boolean;
+  overviewErrored: boolean;
   overview: DashboardOverview | null;
   messages: Record<string, DashboardMessage[]>;
   messagesLoading: Record<string, boolean>;
@@ -114,6 +115,7 @@ interface DashboardChatState {
 const initialChatState = {
   boundAgentId: null,
   overviewRefreshing: false,
+  overviewErrored: false,
   overview: null,
   messages: {},
   messagesLoading: {},
@@ -142,6 +144,7 @@ const initialChatState = {
 function hasTransientChatState(state: DashboardChatState): boolean {
   return (
     state.overviewRefreshing
+    || state.overviewErrored
     || state.overview !== null
     || Object.keys(state.messages).length > 0
     || Object.keys(state.messagesLoading).length > 0
@@ -287,7 +290,7 @@ export const useDashboardChatStore = create<DashboardChatState>()(
         })),
 
       replaceOverview: (overview) => {
-        set({ overview, overviewRefreshing: false });
+        set({ overview, overviewRefreshing: false, overviewErrored: false });
         useDashboardUnreadStore.getState().reconcileUnreadRooms(overview.rooms);
       },
 
@@ -460,11 +463,11 @@ export const useDashboardChatStore = create<DashboardChatState>()(
           return;
         }
         if (!hasReadyActiveAgent(token, activeAgentId)) {
-          set({ overview: null, overviewRefreshing: false });
+          set({ overview: null, overviewRefreshing: false, overviewErrored: false });
           return;
         }
 
-        set({ overviewRefreshing: true });
+        set({ overviewRefreshing: true, overviewErrored: false });
         try {
           const overview = await api.getOverview();
           get().replaceOverview(overview);
@@ -473,7 +476,7 @@ export const useDashboardChatStore = create<DashboardChatState>()(
             void get().loadRoomMessages(openedRoomId);
           }
         } catch (error: any) {
-          set({ error: error?.message || "Failed to refresh", overviewRefreshing: false });
+          set({ error: error?.message || "Failed to refresh", overviewRefreshing: false, overviewErrored: true });
         }
       },
 

--- a/frontend/src/store/useDashboardSessionStore.ts
+++ b/frontend/src/store/useDashboardSessionStore.ts
@@ -7,9 +7,20 @@
 
 import { create } from "zustand";
 import type { HumanInfo, HumanRoomSummary, UserProfile, UserAgent } from "@/lib/types";
-import { humansApi, userApi, getActiveAgentId, setActiveAgentId } from "@/lib/api";
+import {
+  humansApi,
+  userApi,
+  getActiveAgentId,
+  setActiveAgentId,
+  getStoredActiveIdentity,
+  setStoredActiveIdentity,
+} from "@/lib/api";
 
 export type DashboardSessionMode = "guest" | "authed-no-agent" | "authed-ready";
+
+export type ActiveIdentity =
+  | { type: "human"; id: string }
+  | { type: "agent"; id: string };
 
 interface DashboardSessionState {
   authResolved: boolean;
@@ -28,12 +39,20 @@ interface DashboardSessionState {
    * "agent"  → observer mode: watching/acting through the active Agent
    */
   viewMode: "human" | "agent";
+  /**
+   * Richer identity record persisted in localStorage. Gates the
+   * ``X-Active-Agent`` header in ``buildAuthHeaders`` — when ``type==='human'``
+   * no header is sent and the backend resolves ``human_id`` from the
+   * Supabase JWT. Kept in-sync with ``viewMode`` / ``activeAgentId``.
+   */
+  activeIdentity: ActiveIdentity | null;
 
   setAuthResolved: (resolved: boolean) => void;
   setToken: (token: string | null) => void;
   setUser: (user: UserProfile) => void;
   setActiveAgentId: (agentId: string | null) => void;
   setViewMode: (mode: "human" | "agent") => void;
+  setActiveIdentity: (identity: ActiveIdentity | null) => void;
   resetSessionState: () => void;
   initAuth: (token: string) => Promise<void>;
   refreshUserProfile: () => Promise<void>;
@@ -54,7 +73,12 @@ const initialSessionState = {
   ownedAgents: [],
   activeAgentId: null,
   viewMode: "human" as const,
+  activeIdentity: null as ActiveIdentity | null,
 };
+
+function deriveIdentityFromAgent(agentId: string | null): ActiveIdentity | null {
+  return agentId ? { type: "agent", id: agentId } : null;
+}
 
 let authInitRequestId = 0;
 
@@ -81,6 +105,7 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
     if (!token) {
       authInitRequestId += 1;
       setActiveAgentId(null);
+      setStoredActiveIdentity(null);
       set({
         ...initialSessionState,
         authResolved: true,
@@ -90,11 +115,15 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
     }
 
     const activeAgentId = get().activeAgentId || getActiveAgentId();
+    const storedIdentity = getStoredActiveIdentity();
+    const activeIdentity: ActiveIdentity | null =
+      storedIdentity ?? deriveIdentityFromAgent(activeAgentId);
     set({
       authResolved: true,
       authBootstrapping: false,
       token,
       activeAgentId,
+      activeIdentity,
       sessionMode: resolveSessionMode(token, activeAgentId),
     });
   },
@@ -107,16 +136,56 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
     })),
 
   setActiveAgentId: (agentId) =>
-    set((state) => ({
-      activeAgentId: agentId,
-      sessionMode: resolveSessionMode(state.token, agentId),
-    })),
+    set((state) => {
+      const nextIdentity: ActiveIdentity | null = agentId
+        ? { type: "agent", id: agentId }
+        : state.activeIdentity?.type === "agent"
+          ? null
+          : state.activeIdentity;
+      if (nextIdentity?.type === "agent" || nextIdentity === null) {
+        setStoredActiveIdentity(nextIdentity);
+      }
+      return {
+        activeAgentId: agentId,
+        activeIdentity: nextIdentity,
+        sessionMode: resolveSessionMode(state.token, agentId),
+      };
+    }),
 
-  setViewMode: (mode) => set({ viewMode: mode }),
+  setViewMode: (mode) =>
+    set((state) => {
+      // Keep the richer activeIdentity field in-sync with the legacy
+      // viewMode toggle. When switching to "human" we forget the agent
+      // identity; when switching to "agent" we materialize one from the
+      // active agent id (if any).
+      let nextIdentity: ActiveIdentity | null = state.activeIdentity;
+      if (mode === "human") {
+        const humanId = state.human?.human_id ?? state.user?.id ?? null;
+        nextIdentity = humanId ? { type: "human", id: humanId } : null;
+      } else if (mode === "agent") {
+        nextIdentity = deriveIdentityFromAgent(state.activeAgentId);
+      }
+      setStoredActiveIdentity(nextIdentity);
+      return { viewMode: mode, activeIdentity: nextIdentity };
+    }),
+
+  setActiveIdentity: (identity) => {
+    setStoredActiveIdentity(identity);
+    if (identity?.type === "agent") {
+      setActiveAgentId(identity.id);
+    }
+    set((state) => ({
+      activeIdentity: identity,
+      activeAgentId: identity?.type === "agent" ? identity.id : state.activeAgentId,
+      viewMode: identity?.type === "human" ? "human" : state.viewMode,
+      sessionMode: resolveSessionMode(state.token, state.activeAgentId),
+    }));
+  },
 
   resetSessionState: () => {
     authInitRequestId += 1;
     setActiveAgentId(null);
+    setStoredActiveIdentity(null);
     set({ ...initialSessionState });
   },
 
@@ -151,6 +220,10 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
       }
       const activeId = resolveStoredActiveAgentId(user);
       setActiveAgentId(activeId);
+      const stored = getStoredActiveIdentity();
+      const activeIdentity: ActiveIdentity | null =
+        stored ?? (human ? { type: "human", id: human.human_id } : deriveIdentityFromAgent(activeId));
+      if (activeIdentity) setStoredActiveIdentity(activeIdentity);
       set({
         authResolved: true,
         authBootstrapping: false,
@@ -160,6 +233,7 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
         humanRooms: humanRoomsRes.rooms,
         ownedAgents: user.agents,
         activeAgentId: activeId,
+        activeIdentity,
         sessionMode: resolveSessionMode(token, activeId),
       });
     } catch (err: any) {
@@ -168,6 +242,7 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
       }
       if (err?.status === 401 || err?.status === 403) {
         setActiveAgentId(null);
+        setStoredActiveIdentity(null);
         set({
           ...initialSessionState,
           authResolved: true,
@@ -176,6 +251,7 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
         return;
       }
       setActiveAgentId(null);
+      setStoredActiveIdentity(null);
       set({
         authResolved: true,
         authBootstrapping: false,
@@ -183,6 +259,7 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
         user: null,
         ownedAgents: [],
         activeAgentId: null,
+        activeIdentity: null,
         sessionMode: "authed-no-agent",
       });
     }
@@ -202,39 +279,61 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
       const user = await userApi.getMe({ force: true });
       const activeAgentId = resolveStoredActiveAgentId(user);
       setActiveAgentId(activeAgentId);
-      set((state) => ({
-        user,
-        ownedAgents: user.agents,
-        activeAgentId,
-        sessionMode: resolveSessionMode(state.token, activeAgentId),
-      }));
+      set((state) => {
+        // Preserve human identity if already active; otherwise track agent.
+        const nextIdentity: ActiveIdentity | null =
+          state.activeIdentity?.type === "human"
+            ? state.activeIdentity
+            : deriveIdentityFromAgent(activeAgentId);
+        if (nextIdentity?.type !== "human") {
+          setStoredActiveIdentity(nextIdentity);
+        }
+        return {
+          user,
+          ownedAgents: user.agents,
+          activeAgentId,
+          activeIdentity: nextIdentity,
+          sessionMode: resolveSessionMode(state.token, activeAgentId),
+        };
+      });
     } catch (err) {
       console.error("[SessionStore] Failed to refresh user profile:", err);
     }
   },
 
   removeAgent: (agentId: string) => {
-    const { ownedAgents, activeAgentId, token } = get();
+    const { ownedAgents, activeAgentId, activeIdentity, token } = get();
     const remaining = ownedAgents.filter((a) => a.agent_id !== agentId);
     const newActiveId = agentId === activeAgentId
       ? (remaining.find((a) => a.is_default) || remaining[0])?.agent_id ?? null
       : activeAgentId;
     setActiveAgentId(newActiveId);
+    const nextIdentity: ActiveIdentity | null =
+      activeIdentity?.type === "human"
+        ? activeIdentity
+        : deriveIdentityFromAgent(newActiveId);
+    if (nextIdentity?.type !== "human") {
+      setStoredActiveIdentity(nextIdentity);
+    }
     set({
       ownedAgents: remaining,
       activeAgentId: newActiveId,
+      activeIdentity: nextIdentity,
       sessionMode: resolveSessionMode(token, newActiveId),
     });
   },
 
   switchActiveAgent: async (agentId: string) => {
     setActiveAgentId(agentId);
-    set({ activeAgentId: agentId });
+    const identity: ActiveIdentity = { type: "agent", id: agentId };
+    setStoredActiveIdentity(identity);
+    set({ activeAgentId: agentId, activeIdentity: identity });
   },
 
   logout: () => {
     authInitRequestId += 1;
     setActiveAgentId(null);
+    setStoredActiveIdentity(null);
     set({
       ...initialSessionState,
       authResolved: true,


### PR DESCRIPTION
## Summary
- Adds Human-side BFF endpoints: `POST /api/humans/me/rooms/{room_id}/members`, `GET/POST /api/humans/me/contact-requests/{received,sent,accept,reject}`, plus backend Hub guards for Human-owned rooms.
- Introduces the richer frontend identity model (`activeIdentity` in session store + `lib/api`), gating the `X-Active-Agent` header so Human calls rely on the Supabase JWT only.
- Updates `CreateRoomModal` and `AddFriendModal` to route through the Human BFF when `viewMode === "human"`, with polymorphic `to_human_id` / `peer_id` support for agent↔human contact requests.
- Adds `overviewErrored` to `useDashboardChatStore` so `DashboardApp` stops retrying a failed overview fetch in a tight loop.
- Ships backend tests for the new Human contact-request flows, Human-owned room member guards, and dashboard agent↔human contact paths.

## Test plan
- [ ] `cd backend && uv run pytest tests/test_app/test_app_humans.py tests/test_app/test_app_dashboard_contacts_a2h.py tests/test_hub_room_human_guard.py`
- [ ] `cd frontend && pnpm build` (type + bundle check)
- [ ] Manual: as a Human (no active agent), send a contact request to an agent and to another Human via AddFriendModal; verify outcomes (`sent` / `already_contact` / `already_requested`).
- [ ] Manual: create a room from CreateRoomModal as Human; confirm it lands in `/api/humans/me/rooms` and is visible in the sidebar after reload.
- [ ] Manual: as room owner (Human), invite an agent via the new `/api/humans/me/rooms/{id}/members` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)