### PR TITLE
feat(daemon): per-agent on-disk workspace at ~/.botcord/agents/{id}/

### DIFF
--- a/docs/daemon-agent-workspace-plan.md
+++ b/docs/daemon-agent-workspace-plan.md
@@ -1,0 +1,574 @@
+# Daemon Agent Workspace Plan
+
+**Status**: Draft
+**Date**: 2026-04-23
+**Scope**: Give every BotCord agent its own on-disk workspace directory, generate it at provision time, and default the runtime `cwd` to that workspace instead of the daemon's shared `defaultRoute.cwd`.
+
+---
+
+## 1. Background
+
+Today `provisionAgent` (`packages/daemon/src/provision.ts:133`) only writes one thing to disk per new agent: `~/.botcord/credentials/{agentId}.json`. The `cwd` that actually gets handed to Claude Code / Codex at turn time comes from `config.defaultRoute.cwd` (falling back to `homedir()` in `initDefaultConfig`, `config.ts:264`), unless an operator has manually set a route.
+
+Consequences:
+
+- Every agent on one daemon shares the same cwd by default — usually `$HOME`. Runtime sandboxes (`codex -s workspace-write`) end up scoped to the whole home directory, and agents can read/write each other's files.
+- There is no designated place for an agent to keep its own long-lived Markdown state (identity, memory, task list). Runtime-side memory (working-memory.json) is daemon-owned JSON that the LLM can't naturally edit.
+- Users who want per-agent isolation have to hand-craft `config.routes` entries before the first turn.
+
+This plan gives every agent a dedicated, self-contained directory and makes that directory the default `cwd`.
+
+## 2. Goals
+
+- Each provisioned agent gets `~/.botcord/agents/{agentId}/workspace/` with a small set of seed Markdown files.
+- Provisioning without an explicit `cwd` defaults to that workspace; explicit `cwd` still wins.
+- Existing daemons and already-provisioned agents work unchanged; workspaces are backfilled lazily on next boot.
+- Working-memory state moves under the agent directory so everything per-agent lives in one tree.
+- Revoking an agent does not delete user-authored workspace content by default.
+
+## 3. Non-goals
+
+- Moving `~/.botcord/credentials/{agentId}.json` into the agent directory. Credentials are shared with `protocol-core`, plugin, and CLI; migrating them is a separate follow-up.
+- Changing `system-context.ts` injection behavior. Workspace Markdown is additive — the systemContext path stays as-is in v1.
+- User-customizable templates. v1 ships one built-in template set; overrides come later if requested.
+
+---
+
+## 4. Directory layout
+
+```
+~/.botcord/
+  credentials/
+    {agentId}.json              # unchanged in v1
+  daemon/
+    config.json                 # unchanged
+    sessions.json               # unchanged
+    snapshot.json               # unchanged
+  agents/
+    {agentId}/
+      workspace/                # runtime cwd
+        AGENTS.md               # runtime-facing rules entry
+        CLAUDE.md               # duplicate of AGENTS.md content (NOT a symlink)
+        identity.md             # rendered from provision params
+        memory.md               # long-lived notes, LLM-owned
+        task.md                 # current task / plan, LLM-owned
+        notes/                  # free-form, LLM-owned
+      state/
+        working-memory.json     # moved from ~/.botcord/daemon/memory/{id}/
+```
+
+Files inside `workspace/` are considered **user/LLM-owned** once they exist. `state/` is **daemon-owned** — the daemon may rewrite it freely.
+
+### Trade-off when the operator overrides `cwd`
+
+§7 lets an explicit `cwd` (e.g. a real project directory) win over the per-agent workspace. When that happens, the runtime starts inside the project tree and **does not see** `identity.md` / `memory.md` / `task.md` — those files still exist under `~/.botcord/agents/{id}/workspace/` but are outside the runtime's cwd, so `AGENTS.md` conventions there are invisible.
+
+v1 accepts this trade-off: operators who override `cwd` are assumed to manage their own context surface in the project dir (project's own `AGENTS.md`, `CLAUDE.md`, etc.). The daemon does **not**:
+
+- copy seed files into the project dir (would pollute a user-owned tree),
+- symlink them in (banned — see "Why CLAUDE.md is a separate file" above),
+- merge workspace markdown into `systemContext` (§3 explicitly keeps `system-context.ts` untouched in v1).
+
+If per-agent memory needs to follow the agent into project cwds, that's a v2 feature — likely via optional `systemContext` injection of `identity.md` / `memory.md`. Call it out in release notes so operators know what they lose by overriding `cwd`.
+
+### Why CLAUDE.md is a separate file, not a symlink
+
+- Symlinks break on Windows without developer mode, and `mklink` requires elevation.
+- Tarballs, `rsync`, cloud sync tools (Dropbox/iCloud), and some editors follow or mangle symlinks inconsistently.
+- The cost of a duplicate file is negligible (a few KB of static text).
+
+Both files get written with identical content at `ensureAgentWorkspace` time. They are written **only if missing** (see §6), so users who edit one are not forced to keep the other in sync — divergence is their choice.
+
+---
+
+## 5. Template contents
+
+All templates live in code as template literals exported from `agent-workspace.ts`. No external template files in v1.
+
+### 5.1 AGENTS.md / CLAUDE.md (same content)
+
+```markdown
+# Agent Workspace
+
+This directory is your persistent workspace. You run with `cwd` set here.
+
+## Files you own
+
+- `identity.md` — who you are, your role, your boundaries. Read before responding.
+- `memory.md` — long-lived facts, user preferences, past decisions. Update when
+  you learn something durable. Prune when it grows stale.
+- `task.md` — current task and plan. Update as you make progress. Clear when done.
+- `notes/` — free-form scratch space.
+
+## Boundaries
+
+- Do not modify files outside this workspace unless the user explicitly asks.
+- `../state/` (sibling directory, outside this workspace) is managed by the
+  daemon — do not read or edit it directly.
+
+## How to use this
+
+You are **instructed** to skim `identity.md`, `memory.md`, `task.md` before each
+response and to write back what changed after meaningful turns. Nothing in the
+runtime enforces this — the daemon does not auto-load these files into your
+context. Treat AGENTS.md as a convention, not a mechanism.
+```
+
+### 5.2 identity.md (rendered from provision params)
+
+```markdown
+# Identity
+
+- **Agent ID**: {{agentId}}
+- **Display name**: {{displayName}}
+- **Runtime**: {{runtime}}
+- **Key ID**: {{keyId}}
+- **Created**: {{savedAt}}
+
+## Bio
+
+{{bio or "_(none provided at provision time — edit this section)_"}}
+
+## Role
+
+_(Describe what you do and for whom. Edit this section.)_
+
+## Boundaries
+
+_(What you will and will not do. Edit this section.)_
+```
+
+Interpolation is plain string replacement; no template engine. Empty `bio` renders the parenthetical hint.
+
+### 5.3 memory.md
+
+```markdown
+# Memory
+
+<!--
+Long-lived facts about the user, past decisions, and preferences that should
+survive across conversations. Organize by topic. Keep entries short. Prune
+regularly — AGENTS.md instructs the runtime to consult this file before each
+response, but nothing loads it automatically; keep it short enough to be
+worth re-reading.
+-->
+```
+
+### 5.4 task.md
+
+```markdown
+# Current Task
+
+<!--
+What are you working on right now? What is the plan? What is blocked?
+Clear this file when the task is done.
+-->
+```
+
+`notes/` is created as an empty directory with a `.gitkeep` (empty file) so it survives clean checkouts if the user versions the workspace.
+
+---
+
+## 6. Module: `agent-workspace.ts`
+
+New file at `packages/daemon/src/agent-workspace.ts`. Exports:
+
+```ts
+export function agentHomeDir(agentId: string): string;
+export function agentWorkspaceDir(agentId: string): string;
+export function agentStateDir(agentId: string): string;
+
+export interface WorkspaceSeed {
+  displayName?: string;
+  bio?: string;
+  runtime?: string;
+  keyId?: string;
+  savedAt?: string; // ISO timestamp
+}
+
+export function ensureAgentWorkspace(
+  agentId: string,
+  seed: WorkspaceSeed,
+): void;
+```
+
+`ensureAgentWorkspace` semantics:
+
+1. `mkdirSync` the three directories (`agentHomeDir`, `workspace`, `workspace/notes`, `state`) with mode `0700`, `recursive: true`. Never throws on already-exists.
+2. For each of `AGENTS.md`, `CLAUDE.md`, `identity.md`, `memory.md`, `task.md`: **if the file does not exist**, write the rendered template. If it exists, leave it alone (including modification time).
+3. Ensure `workspace/notes/.gitkeep` exists.
+4. No writes to `state/` — that is §8's job.
+
+Failures: any error other than `EEXIST` on directory creation or file write propagates. Callers in provision wrap in the existing rollback (§7).
+
+Idempotency is load-bearing: boot-time backfill (§9) calls this for every discovered credential on every start.
+
+---
+
+## 7. Wire into `provisionAgent`
+
+File: `packages/daemon/src/provision.ts:133`.
+
+`materializeCredentials` has two branches: a **fast path** when `params.credentials` is provided by Hub (agentId comes from `c.agentId`) and a **slow path** where the daemon calls `register()` and agentId comes from `reg.agentId`. The default-cwd logic must sit in both branches with the correct id source.
+
+Changes:
+
+1. **Validate explicit cwd up front**. Replace the current `assertSafeCwd(params.cwd)` at `provision.ts:137` with:
+
+   ```ts
+   const explicitCwd = params.credentials?.cwd ?? params.cwd;
+   assertSafeCwd(explicitCwd);
+   ```
+
+   This closes a pre-existing hole: today `params.credentials.cwd` is never validated and can smuggle an arbitrary path (e.g. `/etc`) into the credentials file. The check moves once, catches both sources.
+
+2. **Default cwd in `materializeCredentials`**. Drop the `const cwd = ...` line at 212. In each branch, after the agentId is known, compute:
+
+   - Fast path (after line 216 validates `c.agentId`):
+
+     ```ts
+     const cwd = explicitCwd ?? agentWorkspaceDir(c.agentId);
+     ```
+
+   - Slow path (after line 257's `reg = await ctx.register(...)`):
+
+     ```ts
+     const cwd = explicitCwd ?? agentWorkspaceDir(reg.agentId);
+     ```
+
+   Threading `explicitCwd` into `materializeCredentials` is simplest via a second parameter; alternatively compute it twice from the same `params` object. Pick whichever produces the smaller diff.
+
+   `record.cwd` is now always set. Downstream code (`toGatewayConfig`, dispatcher) can treat it as required when present on disk.
+
+3. **Create workspace** after `writeCredentialsFile` succeeds and before `addChannel`:
+
+   ```ts
+   ensureAgentWorkspace(credentials.agentId, {
+     displayName: credentials.displayName,
+     bio: params.bio,
+     runtime: credentials.runtime,
+     keyId: credentials.keyId,
+     savedAt: credentials.savedAt,
+   });
+   ```
+
+4. **Rollback extension**: if `ensureAgentWorkspace` throws, unlink the credentials file and re-throw. Do **not** `rm -rf` the agent directory on rollback — partial contents might be from a pre-existing workspace we shouldn't have touched. Leaving orphaned seed files is cheap; the next provision attempt with the same id is idempotent.
+
+5. `assertKnownRuntime` already runs before credentials are written; no change.
+
+---
+
+## 8. Move working-memory under agent dir
+
+File: `packages/daemon/src/working-memory.ts`.
+
+- Old path: `~/.botcord/daemon/memory/{agentId}/working-memory.json`
+- New path: `~/.botcord/agents/{agentId}/state/working-memory.json`
+
+Implementation:
+
+1. Path constants come from `agent-workspace.ts` (`agentStateDir`).
+2. **Read path resolution** — before every read:
+   - If `newPath` exists → read `newPath`. Do nothing with `oldPath` even if it exists (new wins).
+   - Else if `oldPath` exists → `renameSync(oldPath, newPath)` then read `newPath`. `ensureAgentWorkspace` already created `state/`, so the destination directory exists.
+   - Else → return empty / initial state as today.
+3. **Write path** — always write to `newPath`. Never write to `oldPath`.
+4. **Conflict case** (both paths exist — shouldn't happen if §9 runs, but defensive): new wins, old is left in place, emit a `daemonLog.warn({ agentId, oldPath, newPath })` once per process so it's visible but not disruptive.
+5. Wrap the rename in try/catch. On rename failure, log a warning and fall back to reading `oldPath` directly — don't error. The next write will land in `newPath` and fix state naturally.
+6. Delete the migration branch (steps 2's "else if" and step 4) one release after the change ships.
+
+No change to JSON schema or public API of the working-memory module.
+
+---
+
+## 9. Startup backfill for existing agents
+
+File: `packages/daemon/src/daemon.ts` — inside the `startDaemon` boot flow, immediately after `resolveBootAgents()` (around line 238) and **before** the `toGatewayConfig(...)` call at line 255.
+
+`agent-discovery.ts` is deliberately kept side-effect-lean (path resolution and credential parsing only). Workspace creation is a boot-flow concern — the `daemon.ts` site has the logger, the full boot agent list, and the `agentRuntimes` map under construction, so the same iteration that populates `agentRuntimes` also calls `ensureAgentWorkspace`:
+
+```ts
+const agentRuntimes: Record<string, { runtime?: string; cwd?: string }> = {};
+for (const a of boot.agents) {
+  if (a.runtime || a.cwd) {
+    agentRuntimes[a.agentId] = { runtime: a.runtime, cwd: a.cwd };
+  }
+  try {
+    ensureAgentWorkspace(a.agentId, {
+      displayName: a.displayName,
+      runtime: a.runtime,
+      keyId: a.keyId,
+      savedAt: a.savedAt,
+      // `bio` is not in BootAgent today; leave undefined — template renders placeholder.
+    });
+  } catch (err) {
+    daemonLog.warn("ensureAgentWorkspace failed at boot; continuing", {
+      agentId: a.agentId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+```
+
+**Failure policy: warn-and-continue.** One agent's broken workspace (permission denied, filesystem full, etc.) must not block the other agents from starting. The agent still gets a gateway channel; runtime turns will fail with a clearer error if the workspace is truly unusable.
+
+**No credential mutation.** If an existing credential file has no `cwd`, the daemon does not rewrite it — `toGatewayConfig` (§10) supplies the workspace fallback dynamically. Rationale: credentials are co-owned with plugin and CLI; daemon should not silently mutate them during boot.
+
+**BootAgent shape.** If `resolveBootAgents()` today doesn't surface `displayName` / `keyId` / `savedAt` on each entry, extend its return type to include them (they're already read from the credentials file during discovery — just not exposed). This is a local change to `agent-discovery.ts`, not a scope bump.
+
+---
+
+## 10. Per-agent route via `toGatewayConfig`
+
+File: `packages/daemon/src/daemon-config-map.ts:117` (`toGatewayConfig`). **Do not touch** `gateway/router.ts` — the router stays a pure function of `GatewayConfig`.
+
+The daemon already synthesizes a per-agent terminal route for agents whose credentials carry a `runtime` field (current code at lines 155–166). Two targeted changes make that route the universal per-agent default:
+
+1. **Always synthesize, not only when runtime is present.** Change the guard from `if (!meta?.runtime) continue` to "synthesize for every agent in `agentIds`". Agents without a cached runtime inherit `defaultRoute.runtime`.
+2. **Workspace-based cwd fallback**:
+
+   ```ts
+   for (const agentId of agentIds) {
+     const meta = agentRuntimes[agentId] ?? {};
+     routes.push({
+       match: { accountId: agentId },
+       runtime: meta.runtime ?? defaultRoute.runtime,
+       cwd: meta.cwd || agentWorkspaceDir(agentId),
+     });
+   }
+   ```
+
+   `meta.cwd` comes from the credentials file (populated by §7 for new agents, absent for legacy agents). When absent, the route pins the agent to its own workspace directory. `config.defaultRoute.cwd` is no longer the end of the line for per-agent turns — it only applies to hypothetical messages that match no `accountId`, which in practice doesn't happen (channels are all agent-scoped).
+
+Ordering inside `config.routes` is unchanged: user-authored `cfg.routes[]` are mapped first (line 148), then the synthesized per-agent routes are appended. First match wins, so explicit operator routes still override the per-agent default.
+
+### 10.1 Managed routes vs. user routes
+
+Per-agent workspace routes are **synthesized** by the daemon and must be owned separately from user-authored `cfg.routes[]`. Today `GatewayRoute` has no `source`/`managed` marker, and `gateway.config.routes` is a flat array: a naive "remove all routes with `match.accountId === id`" on revoke would blow away an operator's explicit route.
+
+Solution: keep synthesized per-agent routes in a **separate bucket** inside the gateway, never inside `cfg.routes`.
+
+- Extend `Gateway` with an internal `managedRoutes: Map<accountId, GatewayRoute>` (keyed by accountId to make add/remove O(1) and unambiguous — each agent gets exactly one synthesized route).
+- Extend `GatewayConfig` with a **read-only** `managedRoutes?: GatewayRoute[]` field populated from that map (for snapshot/debug purposes), but route matching reads it directly from the map.
+- Router matching order (new): `cfg.routes[] → managedRoutes → cfg.defaultRoute`. User routes always win; synthesized routes only apply when nothing user-authored matches. `resolveRoute`'s signature takes the extra `managedRoutes` input (simple array parameter, no `Map` in the pure function).
+
+`toGatewayConfig` populates `managedRoutes` instead of appending to `routes` — move lines 155–166 of the current impl into the managed bucket. User `cfg.routes[]` stays untouched.
+
+### 10.2 Gateway API surface
+
+Add three methods on `Gateway`:
+
+```ts
+/** Replace all managed routes atomically. Used by reload_config. */
+replaceManagedRoutes(routes: Map<string, GatewayRoute>): void;
+
+/** Add or update one managed route. Used by provision hot-add. */
+upsertManagedRoute(accountId: string, route: GatewayRoute): void;
+
+/** Drop one managed route. Used by revoke / removeChannel. */
+removeManagedRoute(accountId: string): void;
+```
+
+These are pure in-memory ops. The dispatcher reads the current map on every `resolveRoute` call, so the next turn picks up the change.
+
+### 10.3 Provision hot-add
+
+In `provisionAgent`, after `addChannel` succeeds:
+
+```ts
+await ctx.gateway.addChannel({ ... });
+ctx.gateway.upsertManagedRoute(credentials.agentId, {
+  match: { accountId: credentials.agentId },
+  runtime: credentials.runtime ?? defaultRoute.runtime,
+  cwd: credentials.cwd ?? agentWorkspaceDir(credentials.agentId),
+});
+```
+
+Rollback: if `upsertManagedRoute` fails (it shouldn't — pure map op), or if a later step fails, `removeManagedRoute(agentId)` runs alongside the existing config/credentials rollback.
+
+### 10.4 Revoke + channel removal
+
+In `revokeAgent` and anywhere `removeChannel` is called, follow up with `removeManagedRoute(agentId)`. Because the map is keyed by accountId, there's no ambiguity — user routes with the same accountId are safe because they live in `cfg.routes[]`, a different bucket.
+
+### 10.5 `reload_config` rebuilds managed routes
+
+Current `reloadConfig()` at `provision.ts:455` only reconciles channels. Comment at line 585 (`setRoute`) already admits "changes apply at next `reload_config` — it does not mutate the live router immediately", and today `reload_config` doesn't actually rebuild routes either. Fix that here:
+
+After the existing channel reconcile loop, re-run the managed-route synthesis:
+
+```ts
+const freshCfg = loadConfig();
+const freshAgents = resolveConfiguredAgentIds(freshCfg) ?? [];
+const agentRuntimes = readAgentRuntimesFromCredentials(freshAgents);
+const managed = buildManagedRoutes(freshAgents, agentRuntimes, freshCfg.defaultRoute);
+ctx.gateway.replaceManagedRoutes(managed);
+```
+
+`buildManagedRoutes` is the same logic extracted from `toGatewayConfig` — share it. After this change, `set_route` + `reload_config` becomes a functional flow (writes to `cfg.routes[]`, then reload rebuilds both user-route-derived gateway state **and** re-synthesizes managed routes).
+
+**Properties:**
+
+- New agents use their own workspace (credentials.cwd is set by §7).
+- Legacy agents with no credentials.cwd also land in their own workspace (path helper).
+- Operator `config.routes` entries still win — and are never touched by add/remove/reload bookkeeping.
+- `set_route` + `reload_config` now actually applies without a restart.
+- Router stays a pure function; dispatcher signature extended by one parameter.
+
+**Properties:**
+
+- New agents use their own workspace (credentials.cwd is set by §7).
+- Legacy agents with no credentials.cwd also land in their own workspace (path helper).
+- Operator `config.routes` entries still win.
+- Router stays a pure function; no dispatcher signature change.
+
+---
+
+## 11. Revoke policy (cross-package change)
+
+Revoke touches three packages; the wire contract has to land in lockstep or the new flags will be silently dropped.
+
+### 11.1 `packages/protocol-core`
+
+Extend `RevokeAgentParams` with:
+
+```ts
+export interface RevokeAgentParams {
+  agentId: string;
+  deleteCredentials?: boolean;   // existing
+  deleteState?: boolean;         // NEW — default = value of deleteCredentials
+  deleteWorkspace?: boolean;     // NEW — default = false
+}
+```
+
+Extend the ack result type (whatever `RevokeAgentResult` is called today — the shape returned via `ControlAck.result` from `revoke_agent`):
+
+```ts
+export interface RevokeAgentResult {
+  agentId: string;
+  removed: boolean;
+  credentialsDeleted: boolean;   // existing
+  stateDeleted: boolean;         // NEW
+  workspaceDeleted: boolean;     // NEW
+}
+```
+
+### 11.2 Hub control-frame validation
+
+If Hub validates `revoke_agent` params against an allowlist / schema before forwarding to the daemon (check `backend/hub/` — control-plane plan §5.3 is the relevant section), add `deleteState` and `deleteWorkspace` to that allowlist. Unknown fields must not be stripped silently. Same for whatever Hub-side test contract exists for the frame shape.
+
+### 11.3 `packages/daemon/src/provision.ts:281` (`revokeAgent`)
+
+- Always leave `agents/{id}/workspace/` alone by default. User-authored memory/notes are precious.
+- `deleteState` (default = `deleteCredentials`): when true, `rm -rf ~/.botcord/agents/{id}/state/` after credentials cleanup. Keeps the revoke-but-preserve-notes case ergonomic — revoking typically wants state gone too, but not necessarily the workspace.
+- `deleteWorkspace` (default **false**): when true, `rm -rf ~/.botcord/agents/{id}/` entirely (subsumes state deletion). Requires explicit opt-in from the caller.
+- **Managed-route cleanup**: after `gateway.removeChannel(agentId)`, call `gateway.removeManagedRoute(agentId)`. This runs unconditionally — whether or not credentials are deleted — because the channel is gone and the synthesized per-agent route is now dangling. User-authored `cfg.routes[]` entries with the same accountId are a different bucket and are not touched (see §10.1).
+- Execution order: `removeChannel` → `removeManagedRoute` → credentials → state → workspace. Each disk step is independent and best-effort; a failure at one step logs a warning and does not prevent the next (matches the existing `deleteCredentials` pattern). The two in-memory gateway ops run first so the running turn (if any) is aborted before disk state goes away.
+- Return `{ ...existing, stateDeleted, workspaceDeleted }`.
+
+### 11.4 Tests / contracts
+
+- Update daemon `provision.test.ts` revoke cases: default flags preserve workspace + state; `deleteState` alone preserves workspace; `deleteWorkspace` removes everything.
+- Update any control-plane contract fixtures under `docs/daemon-control-plane-api-contract.md` / related test files so the new fields appear in the example payloads.
+- If Hub has request/response snapshot tests for `revoke_agent`, regenerate them.
+
+---
+
+## 12. Codex sandbox implication (documentation-only)
+
+Codex non-owner turns use `-s workspace-write` (`codex.ts:155`), scoped to `cwd`. Before this plan, `cwd` was typically `$HOME` and the sandbox was nearly useless. After this plan, `cwd` is `~/.botcord/agents/{id}/workspace/` by default, and Codex can only write inside that directory.
+
+Users who want an agent to edit project code must set an explicit route:
+
+```jsonc
+// ~/.botcord/daemon/config.json
+{
+  "routes": [
+    {
+      "match": { "accountId": "ag_..." },
+      "adapter": "codex",
+      "cwd": "/Users/me/code/myproject"
+    }
+  ]
+}
+```
+
+Call this out in the daemon README + release notes when the change ships. Not a code change — but load-bearing for user expectations.
+
+---
+
+## 13. Testing
+
+New tests in `packages/daemon/src/__tests__/`:
+
+- `agent-workspace.test.ts`:
+  - Creates all directories + seed files from a clean slate.
+  - Second call does not overwrite a modified `memory.md`.
+  - `notes/.gitkeep` is present.
+  - `identity.md` interpolation handles missing `bio` / `runtime`.
+
+- Extend `provision.test.ts`:
+  - Provisioning without `cwd` (slow path) → credentials.cwd equals `agentWorkspaceDir(reg.agentId)`, workspace dir and 5 seed files exist.
+  - Provisioning without `cwd` (fast path, Hub supplies `credentials`) → credentials.cwd equals `agentWorkspaceDir(c.agentId)`.
+  - Provisioning with explicit `params.cwd` → credentials.cwd honors the override; workspace still gets built.
+  - Provisioning with explicit `params.credentials.cwd` pointing outside `$HOME` → `assertSafeCwd` rejects **before** any disk write.
+  - Rollback: if `ensureAgentWorkspace` throws, credentials file is unlinked.
+
+- Extend daemon boot test (whichever file covers `startDaemon` / the boot flow):
+  - Legacy discovered agent without workspace → `ensureAgentWorkspace` runs, credentials file is not mutated.
+  - `ensureAgentWorkspace` throwing for one agent does not abort boot; other agents still come up.
+
+- Extend `daemon-config-map.test.ts` (covering `toGatewayConfig` + `buildManagedRoutes`):
+  - Agent with `agentRuntimes[id].cwd` set → synthesized managed route uses that cwd.
+  - Agent with no `cwd` in its meta → synthesized managed route cwd equals `agentWorkspaceDir(id)`.
+  - Agent with no `runtime` in its meta → synthesized managed route runtime falls back to `defaultRoute.runtime` (behavior change from the pre-plan guard).
+  - Managed routes land in `GatewayConfig.managedRoutes` (or its map equivalent), **not** in `GatewayConfig.routes`.
+  - `cfg.routes[]` is passed through to `GatewayConfig.routes` unchanged.
+
+- New `router.test.ts` cases for the extra parameter:
+  - User `cfg.routes[]` match wins over a managed route for the same `accountId`.
+  - No user match + managed match → managed wins.
+  - No user match + no managed match → `defaultRoute` wins.
+
+- New gateway tests for managed-route API:
+  - `upsertManagedRoute` adds a route; next `resolveRoute` picks it up without restart.
+  - `upsertManagedRoute` on an existing accountId replaces the prior entry (not duplicate).
+  - `removeManagedRoute` drops the entry; `cfg.routes[]` with the same accountId is untouched.
+  - `replaceManagedRoutes(new Map())` wipes synthesized routes without touching `cfg.routes[]`.
+
+- Extend provision test for hot-add:
+  - After `provisionAgent`, `gateway.snapshot()` (or a managed-route accessor) shows exactly one managed route for the new agent pointing at its workspace.
+  - `provisionAgent` rollback path also removes the managed route if a later step fails.
+  - After `revokeAgent`, that managed route is removed — and an operator-authored `cfg.routes[]` entry with the same accountId still exists.
+
+- New `reload_config` test:
+  - Edit `config.json` routes + add a new agent discoverable on disk → `reload_config` adds the channel, rebuilds managed routes, and does not duplicate user routes.
+
+- Extend `provision.test.ts` for revoke (defaults follow §11.3: `deleteCredentials` defaults true, `deleteState` defaults to whatever `deleteCredentials` resolves to, `deleteWorkspace` defaults false):
+  - Default flags (vanilla revoke) → **credentials deleted, state deleted, workspace preserved**.
+  - `deleteCredentials: false` (explicit opt-out) → credentials kept, state kept (mirrors `deleteCredentials`), workspace kept.
+  - `deleteWorkspace: true` → entire `~/.botcord/agents/{id}/` directory removed (subsumes state).
+  - `deleteState: false, deleteCredentials: true` → credentials gone, state + workspace preserved.
+  - `removeManagedRoute` is called in every case, including when `deleteCredentials: false` — the channel is revoked regardless of whether disk state survives.
+
+- `working-memory.test.ts`:
+  - New-path read/write (new exists) → reads new, ignores old even if present.
+  - Only old path exists → one-shot `renameSync`, subsequent read comes from new.
+  - Neither exists → returns empty state.
+  - Rename failure → falls back to reading old path and logs warning (doesn't throw).
+
+---
+
+## 14. Rollout
+
+- **Land order matters** because of §11's cross-package change:
+  1. `protocol-core` type extensions for `RevokeAgentParams` / `RevokeAgentResult` land first (backward-compatible — new fields are optional).
+  2. Daemon changes (§§6–10) land next, behind no flag — boot backfill makes it safe for existing installs.
+  3. Hub control-frame allowlist update lands last (or together with daemon, since Hub is the caller).
+- One release later, delete the working-memory migration branch (§8 steps 2's "else if" and step 4).
+- Credentials relocation (into `agents/{id}/credentials.json`) is a separate plan; not bundled here.
+
+## 15. Open questions
+
+- Should the daemon track per-file mtimes in `state/` and offer the runtime a "what changed since last turn" diff? (Out of scope for this plan.)
+- Should `ensureAgentWorkspace` write a `.botcord-agent` sentinel file for future tooling to detect agent-owned directories? Probably yes, but first version can skip.
+- Windows paths: `homedir()` already handles them; `0700` permissions degrade to best-effort on NTFS — acceptable.

--- a/docs/daemon-agent-workspace-release-notes.md
+++ b/docs/daemon-agent-workspace-release-notes.md
@@ -1,0 +1,69 @@
+# Daemon agent workspace — release notes (draft)
+
+Ship alongside the per-agent workspace feature.
+
+## What changed
+
+Every provisioned agent now gets its own directory at
+`~/.botcord/agents/{agentId}/` with:
+
+- `workspace/` — runtime `cwd`, seeded with `AGENTS.md`, `CLAUDE.md`,
+  `identity.md`, `memory.md`, `task.md`, and an empty `notes/` folder. LLM-owned
+  once it exists; the daemon will not overwrite these files.
+- `state/working-memory.json` — daemon-owned runtime state. Moved here from
+  `~/.botcord/daemon/memory/{agentId}/` (auto-migrated on first boot).
+
+Provisioning without an explicit `cwd` now defaults to the per-agent workspace.
+Existing agents are backfilled on daemon startup; credentials files are not
+rewritten.
+
+## Breaking behavior — Codex `workspace-write`
+
+Codex non-owner turns run with `-s workspace-write`, which is scoped to the
+turn's `cwd`. Before this change the daemon's `cwd` default was `$HOME`, so the
+sandbox was effectively unlocked. After this change the default is
+`~/.botcord/agents/{id}/workspace/`, and Codex can no longer write outside that
+directory by default.
+
+If you want a Codex agent to edit project code, set an explicit route in
+`~/.botcord/daemon/config.json`:
+
+```jsonc
+{
+  "routes": [
+    {
+      "match": { "accountId": "ag_..." },
+      "adapter": "codex",
+      "cwd": "/path/to/your/project"
+    }
+  ]
+}
+```
+
+User-authored routes always win over the synthesized per-agent workspace
+route.
+
+## `revoke_agent` flag changes
+
+`RevokeAgentParams` gains two optional fields:
+
+- `deleteState` — default: same as `deleteCredentials`. Removes
+  `~/.botcord/agents/{id}/state/`.
+- `deleteWorkspace` — default: `false`. Requires explicit opt-in; removes the
+  entire `~/.botcord/agents/{id}/` directory, including user-authored memory
+  and notes.
+
+Vanilla `revoke_agent` (no flags) now preserves `workspace/` by default. This
+is a deliberate change — previously `revoke` only wiped credentials; now it
+wipes credentials + runtime state but keeps LLM-authored workspace content.
+
+`RevokeAgentResult` gains `stateDeleted` and `workspaceDeleted` booleans.
+
+## Override trade-off
+
+When an operator sets an explicit `cwd` (project directory, not the per-agent
+workspace), the runtime starts in the project tree and **does not see**
+`identity.md` / `memory.md` / `task.md`. Those files still exist under
+`~/.botcord/agents/{id}/workspace/` but are outside the runtime's `cwd`. This
+is an accepted trade-off for v1; operators are expected to manage their own
+context surface (project `AGENTS.md`, `CLAUDE.md`, etc.) in overridden cwds.

--- a/packages/daemon/src/__tests__/agent-discovery.test.ts
+++ b/packages/daemon/src/__tests__/agent-discovery.test.ts
@@ -39,11 +39,13 @@ describe("discoverAgentCredentials", () => {
   });
 
   it("loads valid credential files and returns the internal agentId (not the filename)", () => {
+    const savedAt = "2025-01-01T00:00:00.000Z";
     const res = discoverAgentCredentials({
       credentialsDir: "/creds",
       readDir: () => ["wrong-name.json"],
       stat: () => fakeStat(100),
-      loadCredentials: () => fakeCreds("ag_internal", { displayName: "Alice" }),
+      loadCredentials: () =>
+        fakeCreds("ag_internal", { displayName: "Alice", savedAt }),
     });
     expect(res.agents).toEqual([
       {
@@ -51,9 +53,25 @@ describe("discoverAgentCredentials", () => {
         credentialsFile: "/creds/wrong-name.json",
         hubUrl: "https://hub.example.com",
         displayName: "Alice",
+        keyId: "k_1",
+        savedAt,
       },
     ]);
     expect(res.warnings).toEqual([]);
+  });
+
+  it("surfaces keyId and savedAt from the credentials file (plan §9 BootAgent shape)", () => {
+    const savedAt = "2026-04-23T12:00:00.000Z";
+    const res = discoverAgentCredentials({
+      credentialsDir: "/creds",
+      readDir: () => ["ag.json"],
+      stat: () => fakeStat(1),
+      loadCredentials: () =>
+        fakeCreds("ag_one", { keyId: "k_42", savedAt }),
+    });
+    expect(res.agents).toHaveLength(1);
+    expect(res.agents[0].keyId).toBe("k_42");
+    expect(res.agents[0].savedAt).toBe(savedAt);
   });
 
   it("ignores non-JSON files silently", () => {

--- a/packages/daemon/src/__tests__/agent-workspace.test.ts
+++ b/packages/daemon/src/__tests__/agent-workspace.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  agentHomeDir,
+  agentStateDir,
+  agentWorkspaceDir,
+  ensureAgentWorkspace,
+} from "../agent-workspace.js";
+
+let tmpHome = "";
+let prevHome: string | undefined;
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(path.join(os.tmpdir(), "daemon-workspace-"));
+  prevHome = process.env.HOME;
+  process.env.HOME = tmpHome;
+});
+
+afterEach(() => {
+  if (prevHome === undefined) delete process.env.HOME;
+  else process.env.HOME = prevHome;
+  if (tmpHome) rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe("ensureAgentWorkspace", () => {
+  it("creates the full tree + seed files from a clean slate", () => {
+    ensureAgentWorkspace("ag_fresh", {
+      displayName: "Writer",
+      bio: "A careful assistant.",
+      runtime: "claude-code",
+      keyId: "k_abc",
+      savedAt: "2026-04-23T00:00:00Z",
+    });
+
+    const home = agentHomeDir("ag_fresh");
+    const workspace = agentWorkspaceDir("ag_fresh");
+    const state = agentStateDir("ag_fresh");
+
+    expect(home.startsWith(tmpHome)).toBe(true);
+    expect(existsSync(home)).toBe(true);
+    expect(statSync(home).isDirectory()).toBe(true);
+    expect(existsSync(workspace)).toBe(true);
+    expect(existsSync(state)).toBe(true);
+    expect(existsSync(path.join(workspace, "notes"))).toBe(true);
+
+    for (const name of ["AGENTS.md", "CLAUDE.md", "identity.md", "memory.md", "task.md"]) {
+      expect(existsSync(path.join(workspace, name))).toBe(true);
+    }
+
+    const agentsMd = readFileSync(path.join(workspace, "AGENTS.md"), "utf8");
+    const claudeMd = readFileSync(path.join(workspace, "CLAUDE.md"), "utf8");
+    expect(agentsMd).toBe(claudeMd);
+    expect(agentsMd).toContain("# Agent Workspace");
+
+    const identity = readFileSync(path.join(workspace, "identity.md"), "utf8");
+    expect(identity).toContain("ag_fresh");
+    expect(identity).toContain("Writer");
+    expect(identity).toContain("claude-code");
+    expect(identity).toContain("k_abc");
+    expect(identity).toContain("2026-04-23T00:00:00Z");
+    expect(identity).toContain("A careful assistant.");
+  });
+
+  it("places .gitkeep inside notes/", () => {
+    ensureAgentWorkspace("ag_notes", {});
+    expect(existsSync(path.join(agentWorkspaceDir("ag_notes"), "notes", ".gitkeep"))).toBe(true);
+  });
+
+  it("does not overwrite a user-modified memory.md on a second call", () => {
+    ensureAgentWorkspace("ag_keep", {});
+    const memoryPath = path.join(agentWorkspaceDir("ag_keep"), "memory.md");
+    writeFileSync(memoryPath, "my custom notes\n");
+
+    ensureAgentWorkspace("ag_keep", {});
+
+    expect(readFileSync(memoryPath, "utf8")).toBe("my custom notes\n");
+  });
+
+  it("identity.md renders the bio placeholder when bio is missing", () => {
+    ensureAgentWorkspace("ag_nobio", { displayName: "Nameless" });
+    const identity = readFileSync(path.join(agentWorkspaceDir("ag_nobio"), "identity.md"), "utf8");
+    expect(identity).toContain("_(none provided at provision time");
+    expect(identity).toContain("## Bio");
+  });
+
+  it("identity.md degrades gracefully when runtime/keyId/savedAt are absent", () => {
+    ensureAgentWorkspace("ag_sparse", {});
+    const identity = readFileSync(path.join(agentWorkspaceDir("ag_sparse"), "identity.md"), "utf8");
+    expect(identity).toContain("ag_sparse");
+    // Placeholder used for every missing scalar field.
+    expect(identity).toContain("_(not set)_");
+    expect(identity).toContain("_(none provided at provision time");
+  });
+
+  describe("agentId safety", () => {
+    // Defence-in-depth: if a malformed/hostile agentId reached these path
+    // builders, `revokeAgent(deleteWorkspace:true)`'s `rmSync(home, {recursive:true})`
+    // would happily wipe data outside ~/.botcord/agents/.
+    const hostile = [
+      "../escape",
+      "../../etc",
+      "foo/bar",
+      "..",
+      ".",
+      "",
+      "has spaces",
+      "a\0b",
+      "foo/../bar",
+    ];
+    for (const id of hostile) {
+      it(`rejects unsafe agentId ${JSON.stringify(id)}`, () => {
+        expect(() => agentHomeDir(id)).toThrow();
+        expect(() => agentWorkspaceDir(id)).toThrow();
+        expect(() => agentStateDir(id)).toThrow();
+        expect(() => ensureAgentWorkspace(id, {})).toThrow();
+      });
+    }
+
+    it("accepts realistic agent ids", () => {
+      for (const ok of ["ag_abc123", "ag_XYZ_9", "ag-dash-ok", "A1", "ag_0"]) {
+        expect(() => agentHomeDir(ok)).not.toThrow();
+      }
+    });
+  });
+
+  it("tightens perms on a pre-existing agent home with looser mode", () => {
+    // Simulate a home dir created by an older daemon with mode 0o755.
+    const home = agentHomeDir("ag_upgrade");
+    // Creation goes via ensureAgentWorkspace's recursive mkdir, which wouldn't
+    // override an existing mode — that's precisely the bug we fix.
+    mkdirSync(home, { recursive: true, mode: 0o755 });
+    ensureAgentWorkspace("ag_upgrade", {});
+    const mode = statSync(home).mode & 0o777;
+    expect(mode).toBe(0o700);
+  });
+});

--- a/packages/daemon/src/__tests__/daemon-config-map.test.ts
+++ b/packages/daemon/src/__tests__/daemon-config-map.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 import type { DaemonConfig } from "../config.js";
 import {
   BOTCORD_CHANNEL_TYPE,
+  buildManagedRoutes,
   toGatewayConfig,
 } from "../daemon-config-map.js";
+import { agentWorkspaceDir } from "../agent-workspace.js";
+import type { GatewayRoute } from "../gateway/index.js";
 
 function baseConfig(partial: Partial<DaemonConfig> = {}): DaemonConfig {
   return {
@@ -304,43 +307,110 @@ describe("toGatewayConfig", () => {
     expect(gw.channels).toEqual([]);
   });
 
-  it("synthesizes a per-agent route from agentRuntimes, appended after explicit routes", () => {
+  it("routes user-authored cfg.routes[] through to GatewayConfig.routes unchanged", () => {
     const cfg = baseConfig({
       agentId: undefined,
-      agents: ["ag_one", "ag_two"],
+      agents: ["ag_one"],
       routes: [
         { match: { roomPrefix: "rm_oc_" }, adapter: "claude-code", cwd: "/work" },
       ],
     });
     const gw = toGatewayConfig(cfg, {
+      agentIds: ["ag_one"],
+      agentRuntimes: { ag_one: { runtime: "codex", cwd: "/home/alice/ag_one" } },
+    });
+    // User route stays in `routes[]` exactly as translated from `cfg.routes`.
+    expect(gw.routes).toHaveLength(1);
+    expect(gw.routes![0].match).toEqual({ conversationPrefix: "rm_oc_" });
+    // Synthesized per-agent route lives in `managedRoutes`, not `routes`.
+    expect(gw.managedRoutes).toEqual([
+      {
+        match: { accountId: "ag_one" },
+        runtime: "codex",
+        cwd: "/home/alice/ag_one",
+      },
+    ]);
+  });
+
+  it("synthesizes managed routes into GatewayConfig.managedRoutes, not GatewayConfig.routes", () => {
+    const cfg = baseConfig({
+      agentId: undefined,
+      agents: ["ag_one", "ag_two"],
+    });
+    const gw = toGatewayConfig(cfg, {
       agentIds: ["ag_one", "ag_two"],
       agentRuntimes: {
         ag_one: { runtime: "codex", cwd: "/home/alice/ag_one" },
-        // ag_two deliberately missing — it should fall back to defaultRoute
+        // ag_two deliberately missing — should still get a managed route.
       },
     });
-    expect(gw.routes).toHaveLength(2);
-    // Explicit route stays first (match-first-wins).
-    expect(gw.routes![0].match).toEqual({ conversationPrefix: "rm_oc_" });
-    // Synthesized per-agent route appended after, pinning by accountId.
-    expect(gw.routes![1]).toEqual({
+    expect(gw.routes).toEqual([]);
+    expect(gw.managedRoutes).toHaveLength(2);
+    expect(gw.managedRoutes![0]).toEqual({
       match: { accountId: "ag_one" },
       runtime: "codex",
       cwd: "/home/alice/ag_one",
     });
-  });
-
-  it("inherits defaultRoute.cwd when agentRuntimes omits cwd for an agent", () => {
-    const cfg = baseConfig({ agentId: undefined, agents: ["ag_one"] });
-    const gw = toGatewayConfig(cfg, {
-      agentIds: ["ag_one"],
-      agentRuntimes: { ag_one: { runtime: "codex" } },
+    expect(gw.managedRoutes![1]).toEqual({
+      match: { accountId: "ag_two" },
+      runtime: "claude-code",
+      cwd: agentWorkspaceDir("ag_two"),
     });
-    expect(gw.routes).toHaveLength(1);
-    expect(gw.routes![0]).toEqual({
+  });
+});
+
+describe("buildManagedRoutes", () => {
+  const defaultRoute: GatewayRoute = {
+    runtime: "claude-code",
+    cwd: "/home/default",
+  };
+
+  it("uses agentRuntimes[id].cwd when set", () => {
+    const map = buildManagedRoutes(
+      ["ag_one"],
+      { ag_one: { runtime: "codex", cwd: "/custom/ag_one" } },
+      defaultRoute,
+    );
+    expect(map.get("ag_one")).toEqual({
       match: { accountId: "ag_one" },
       runtime: "codex",
-      cwd: "/home/alice",
+      cwd: "/custom/ag_one",
     });
+  });
+
+  it("falls back to agentWorkspaceDir(id) when meta has no cwd", () => {
+    const map = buildManagedRoutes(
+      ["ag_one"],
+      { ag_one: { runtime: "codex" } },
+      defaultRoute,
+    );
+    expect(map.get("ag_one")?.cwd).toBe(agentWorkspaceDir("ag_one"));
+  });
+
+  it("falls back to defaultRoute.runtime when meta has no runtime (behavior change from pre-plan guard)", () => {
+    // Previously the synthesized route was only emitted when meta.runtime
+    // was truthy; agents without a cached runtime were silently skipped.
+    // Plan §10 makes the synthesis universal so every agent lands in its
+    // own workspace by default.
+    const map = buildManagedRoutes(["ag_one"], {}, defaultRoute);
+    expect(map.get("ag_one")).toEqual({
+      match: { accountId: "ag_one" },
+      runtime: "claude-code",
+      cwd: agentWorkspaceDir("ag_one"),
+    });
+  });
+
+  it("preserves agentIds insertion order in the returned map", () => {
+    const map = buildManagedRoutes(
+      ["ag_b", "ag_a", "ag_c"],
+      {},
+      defaultRoute,
+    );
+    expect(Array.from(map.keys())).toEqual(["ag_b", "ag_a", "ag_c"]);
+  });
+
+  it("emits an empty map when agentIds is empty", () => {
+    const map = buildManagedRoutes([], {}, defaultRoute);
+    expect(map.size).toBe(0);
   });
 });

--- a/packages/daemon/src/__tests__/daemon.test.ts
+++ b/packages/daemon/src/__tests__/daemon.test.ts
@@ -1,6 +1,21 @@
-import { describe, expect, it, vi } from "vitest";
-import type { GatewayInboundMessage } from "../gateway/index.js";
-import { classifyActivitySender, createActivityRecorder } from "../daemon.js";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayInboundMessage, GatewayLogger } from "../gateway/index.js";
+import {
+  backfillBootAgents,
+  classifyActivitySender,
+  createActivityRecorder,
+} from "../daemon.js";
+import type { DiscoveredAgentCredential } from "../agent-discovery.js";
+import { agentWorkspaceDir } from "../agent-workspace.js";
 
 function makeMsg(overrides: {
   conversationId?: string;
@@ -168,5 +183,118 @@ describe("createActivityRecorder", () => {
     });
     expect(record.mock.calls[0][0].lastInboundPreview).toBe("raw owner text");
     expect(record.mock.calls[0][0].lastSenderKind).toBe("owner");
+  });
+});
+
+function silentLogger(): GatewayLogger {
+  return {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  };
+}
+
+function bootAgent(
+  agentId: string,
+  extra: Partial<DiscoveredAgentCredential> = {},
+): DiscoveredAgentCredential {
+  return {
+    agentId,
+    credentialsFile: `/fake/${agentId}.json`,
+    hubUrl: "https://hub.example.com",
+    ...extra,
+  };
+}
+
+describe("backfillBootAgents", () => {
+  let tmpHome: string;
+  let origHome: string | undefined;
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(path.join(os.tmpdir(), "botcord-daemon-boot-"));
+    origHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    if (origHome === undefined) delete process.env.HOME;
+    else process.env.HOME = origHome;
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("creates the per-agent workspace for a legacy discovered agent that has none", () => {
+    // Simulates plan §9's primary use case: an agent was provisioned before
+    // the workspace feature existed, so `~/.botcord/agents/{id}/` doesn't
+    // exist yet. Boot backfill should materialize it — but leave the
+    // credentials file alone (no-credential-mutation invariant).
+    const res = backfillBootAgents(
+      [
+        bootAgent("ag_legacy", {
+          displayName: "Legacy",
+          keyId: "k_42",
+          savedAt: "2026-04-23T00:00:00.000Z",
+        }),
+      ],
+      { logger: silentLogger() },
+    );
+    const ws = agentWorkspaceDir("ag_legacy");
+    expect(existsSync(path.join(ws, "AGENTS.md"))).toBe(true);
+    expect(existsSync(path.join(ws, "identity.md"))).toBe(true);
+    const identity = readFileSync(path.join(ws, "identity.md"), "utf8");
+    expect(identity).toContain("ag_legacy");
+    expect(identity).toContain("Legacy");
+    expect(identity).toContain("k_42");
+    // Maps still populated for downstream `toGatewayConfig` consumption.
+    expect(res.credentialPathByAgentId.get("ag_legacy")).toBe(
+      "/fake/ag_legacy.json",
+    );
+    // No runtime/cwd on the boot agent → no entry in the runtimes map.
+    expect(res.agentRuntimes.ag_legacy).toBeUndefined();
+  });
+
+  it("is idempotent: a second call leaves user-edited files alone", () => {
+    backfillBootAgents([bootAgent("ag_one")], { logger: silentLogger() });
+    const memoryPath = path.join(agentWorkspaceDir("ag_one"), "memory.md");
+    const edited = "# My notes\n\nremembered thing\n";
+    // Simulate the LLM/user editing memory.md.
+    writeFileSync(memoryPath, edited);
+    backfillBootAgents([bootAgent("ag_one")], { logger: silentLogger() });
+    expect(readFileSync(memoryPath, "utf8")).toBe(edited);
+  });
+
+  it("warns and continues when ensureAgentWorkspace throws for one agent", () => {
+    // One agent's broken workspace (permission denied, full disk, etc.)
+    // must not block the other agents from being brought up.
+    const warn = vi.fn();
+    const ensure = vi.fn((agentId: string) => {
+      if (agentId === "ag_bad") throw new Error("EACCES");
+    });
+    const logger: GatewayLogger = { ...silentLogger(), warn };
+    const res = backfillBootAgents(
+      [bootAgent("ag_bad"), bootAgent("ag_good", { runtime: "codex" })],
+      { logger, ensure },
+    );
+    expect(ensure).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledWith(
+      "ensureAgentWorkspace failed at boot; continuing",
+      expect.objectContaining({ agentId: "ag_bad" }),
+    );
+    // Both agents are still plumbed into the downstream caches — the peer
+    // agent's channel and route are not taken down by the sibling's error.
+    expect(res.credentialPathByAgentId.has("ag_bad")).toBe(true);
+    expect(res.credentialPathByAgentId.has("ag_good")).toBe(true);
+    expect(res.agentRuntimes.ag_good).toEqual({ runtime: "codex" });
+  });
+
+  it("does not touch credential files (no-credential-mutation invariant)", () => {
+    // §9 "No credential mutation": boot backfill writes to the agent's
+    // workspace dir only; the credential file passed in via `credentialsFile`
+    // is not opened. We verify by using a path that doesn't exist on disk —
+    // if the backfill tried to read or rewrite it, we'd see an ENOENT.
+    expect(() =>
+      backfillBootAgents([bootAgent("ag_one")], { logger: silentLogger() }),
+    ).not.toThrow();
+    expect(existsSync("/fake/ag_one.json")).toBe(false);
   });
 });

--- a/packages/daemon/src/__tests__/provision.test.ts
+++ b/packages/daemon/src/__tests__/provision.test.ts
@@ -33,7 +33,11 @@ const {
 } = await import("../provision.js");
 const { CONTROL_FRAME_TYPES } = await import("@botcord/protocol-core");
 import type { DaemonConfig } from "../config.js";
-import type { GatewayChannelConfig, GatewayRuntimeSnapshot } from "../gateway/index.js";
+import type {
+  GatewayChannelConfig,
+  GatewayRoute,
+  GatewayRuntimeSnapshot,
+} from "../gateway/index.js";
 
 beforeEach(() => {
   mockState.cfg = {
@@ -94,11 +98,16 @@ describe("addAgentToConfig / removeAgentFromConfig", () => {
 interface FakeGateway {
   addChannel: ReturnType<typeof vi.fn>;
   removeChannel: ReturnType<typeof vi.fn>;
+  upsertManagedRoute: ReturnType<typeof vi.fn>;
+  removeManagedRoute: ReturnType<typeof vi.fn>;
+  replaceManagedRoutes: ReturnType<typeof vi.fn>;
+  listManagedRoutes: () => GatewayRoute[];
   snapshot: () => GatewayRuntimeSnapshot;
 }
 
 function makeFakeGateway(initialChannelIds: string[] = []): FakeGateway {
   const channels = new Set(initialChannelIds);
+  const managed = new Map<string, GatewayRoute>();
   return {
     addChannel: vi.fn(async (cfg: GatewayChannelConfig) => {
       channels.add(cfg.id);
@@ -106,6 +115,17 @@ function makeFakeGateway(initialChannelIds: string[] = []): FakeGateway {
     removeChannel: vi.fn(async (id: string) => {
       channels.delete(id);
     }),
+    upsertManagedRoute: vi.fn((accountId: string, route: GatewayRoute) => {
+      managed.set(accountId, route);
+    }),
+    removeManagedRoute: vi.fn((accountId: string) => {
+      managed.delete(accountId);
+    }),
+    replaceManagedRoutes: vi.fn((routes: Map<string, GatewayRoute>) => {
+      managed.clear();
+      for (const [id, route] of routes) managed.set(id, route);
+    }),
+    listManagedRoutes: (): GatewayRoute[] => Array.from(managed.values()),
     snapshot: (): GatewayRuntimeSnapshot => ({
       channels: Object.fromEntries(
         [...channels].map((id) => [
@@ -166,6 +186,64 @@ describe("reload_config handler", () => {
     const gw = makeFakeGateway(["ag_a"]);
     const res = await reloadConfig({ gateway: gw as unknown as Parameters<typeof reloadConfig>[0]["gateway"] });
     expect(res).toEqual({ reloaded: true, added: [], removed: [] });
+  });
+
+  it("rebuilds managed routes — legacy credential without cwd gets workspace fallback", async () => {
+    const os = await import("node:os");
+    const fs = await import("node:fs");
+    const nodePath = await import("node:path");
+    const { agentWorkspaceDir } = await import("../agent-workspace.js");
+
+    const tmp = fs.mkdtempSync(nodePath.join(os.tmpdir(), "daemon-reload-"));
+    const prevHome = process.env.HOME;
+    process.env.HOME = tmp;
+    try {
+      // Plant a legacy credentials file with NO `cwd` field — mimics an
+      // agent provisioned before the per-agent-workspace feature shipped.
+      const credDir = nodePath.join(tmp, ".botcord", "credentials");
+      fs.mkdirSync(credDir, { recursive: true });
+      fs.writeFileSync(
+        nodePath.join(credDir, "ag_legacy.json"),
+        JSON.stringify({
+          agentId: "ag_legacy",
+          keyId: "k_legacy",
+          privateKey: Buffer.alloc(32, 3).toString("base64"),
+          hubUrl: "https://hub.example",
+          // Deliberately omit `runtime` + `cwd` — the fallback path is
+          // what we're exercising.
+        }),
+      );
+
+      mockState.cfg = {
+        defaultRoute: { adapter: "claude-code", cwd: "/tmp" },
+        routes: [
+          // Operator-authored route for a different accountId — must
+          // survive reload untouched (plan §10.5 property).
+          { match: { accountId: "ag_user_pinned" }, adapter: "codex", cwd: "/src" },
+        ],
+        streamBlocks: true,
+        agents: ["ag_legacy"],
+      };
+      const gw = makeFakeGateway(["ag_legacy"]);
+      const res = await reloadConfig({
+        gateway: gw as unknown as Parameters<typeof reloadConfig>[0]["gateway"],
+      });
+      expect(res.reloaded).toBe(true);
+
+      expect(gw.replaceManagedRoutes).toHaveBeenCalledOnce();
+      const passed = gw.replaceManagedRoutes.mock.calls[0][0] as Map<string, GatewayRoute>;
+      const legacy = passed.get("ag_legacy");
+      expect(legacy).toBeDefined();
+      expect(legacy!.cwd).toBe(agentWorkspaceDir("ag_legacy"));
+      expect(legacy!.runtime).toBe("claude-code"); // falls back to defaultRoute.runtime
+      // The user-authored route still lives in cfg.routes[] — not duplicated
+      // into the managed bucket even if accountIds overlapped.
+      expect(passed.has("ag_user_pinned")).toBe(false);
+    } finally {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });
 
@@ -382,5 +460,463 @@ describe("provision_agent handler writes runtime + cwd", () => {
       else process.env.HOME = prevHome;
       fs.rmSync(tmp, { recursive: true, force: true });
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// provision_agent workspace seeding + managed-route hot-add (plan §7, §10.3)
+// ---------------------------------------------------------------------------
+
+interface SandboxFixture {
+  tmp: string;
+  prevHome: string | undefined;
+  fs: typeof import("node:fs");
+  path: typeof import("node:path");
+}
+
+async function withSandboxHome<T>(run: (sbx: SandboxFixture) => Promise<T>): Promise<T> {
+  const os = await import("node:os");
+  const fs = await import("node:fs");
+  const nodePath = await import("node:path");
+  const tmp = fs.mkdtempSync(nodePath.join(os.tmpdir(), "daemon-provision-"));
+  const prevHome = process.env.HOME;
+  process.env.HOME = tmp;
+  try {
+    return await run({ tmp, prevHome, fs, path: nodePath });
+  } finally {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+const SEED_FILES = ["AGENTS.md", "CLAUDE.md", "identity.md", "memory.md", "task.md"];
+
+describe("provision_agent seeds workspace + hot-adds managed route", () => {
+  it("defaults cwd to agentWorkspaceDir on the fast path (Hub-supplied credentials)", async () => {
+    await withSandboxHome(async ({ tmp, fs, path: nodePath }) => {
+      const gw = makeFakeGateway();
+      const provisioner = createProvisioner({
+        gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+      });
+      const privateKey = Buffer.alloc(32, 13).toString("base64");
+      const ack = await provisioner({
+        id: "req_fast",
+        type: CONTROL_FRAME_TYPES.PROVISION_AGENT,
+        params: {
+          credentials: {
+            agentId: "ag_fast",
+            keyId: "k_fast",
+            privateKey,
+            hubUrl: "https://hub.example",
+          },
+        },
+      });
+      expect(ack.ok).toBe(true);
+      const expectedCwd = nodePath.join(tmp, ".botcord", "agents", "ag_fast", "workspace");
+      const credFile = nodePath.join(tmp, ".botcord", "credentials", "ag_fast.json");
+      const saved = JSON.parse(fs.readFileSync(credFile, "utf8")) as Record<string, unknown>;
+      expect(saved.cwd).toBe(expectedCwd);
+      expect(fs.existsSync(expectedCwd)).toBe(true);
+      for (const f of SEED_FILES) {
+        expect(fs.existsSync(nodePath.join(expectedCwd, f))).toBe(true);
+      }
+      // State dir and notes/.gitkeep also created.
+      expect(fs.existsSync(nodePath.join(tmp, ".botcord", "agents", "ag_fast", "state"))).toBe(true);
+      expect(fs.existsSync(nodePath.join(expectedCwd, "notes", ".gitkeep"))).toBe(true);
+      // Managed route hot-added.
+      const routes = gw.listManagedRoutes();
+      expect(routes).toHaveLength(1);
+      expect(routes[0].match?.accountId).toBe("ag_fast");
+      expect(routes[0].cwd).toBe(expectedCwd);
+    });
+  });
+
+  it("defaults cwd to agentWorkspaceDir on the slow path (daemon register)", async () => {
+    await withSandboxHome(async ({ tmp, fs, path: nodePath }) => {
+      // Seed an existing credential so `inferHubUrl` finds a hubUrl.
+      // Omit publicKey — loadStoredCredentials derives it and cross-checks
+      // when present. Supplying a mismatched pair would make inferHubUrl
+      // silently skip the file.
+      const existingCreds = {
+        version: 1,
+        hubUrl: "https://hub.example",
+        agentId: "ag_existing",
+        keyId: "k_e",
+        privateKey: Buffer.alloc(32, 3).toString("base64"),
+        savedAt: new Date().toISOString(),
+      };
+      const credDir = nodePath.join(tmp, ".botcord", "credentials");
+      fs.mkdirSync(credDir, { recursive: true });
+      fs.writeFileSync(
+        nodePath.join(credDir, "ag_existing.json"),
+        JSON.stringify(existingCreds),
+      );
+      mockState.cfg = {
+        defaultRoute: { adapter: "claude-code", cwd: "/tmp" },
+        routes: [],
+        streamBlocks: true,
+        agents: ["ag_existing"],
+      };
+
+      const registered = {
+        agentId: "ag_slow",
+        keyId: "k_slow",
+        privateKey: Buffer.alloc(32, 21).toString("base64"),
+        publicKey: Buffer.alloc(32, 22).toString("base64"),
+        hubUrl: "https://hub.example",
+        token: "tok",
+        expiresAt: Date.now() + 60_000,
+      };
+      const register = vi.fn(async () => registered);
+
+      const gw = makeFakeGateway();
+      const provisioner = createProvisioner({
+        gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+        register: register as unknown as Parameters<typeof createProvisioner>[0]["register"],
+      });
+      const ack = await provisioner({
+        id: "req_slow",
+        type: CONTROL_FRAME_TYPES.PROVISION_AGENT,
+        params: { name: "slow-agent" },
+      });
+      expect(ack.ok).toBe(true);
+      const expectedCwd = nodePath.join(tmp, ".botcord", "agents", "ag_slow", "workspace");
+      const credFile = nodePath.join(tmp, ".botcord", "credentials", "ag_slow.json");
+      const saved = JSON.parse(fs.readFileSync(credFile, "utf8")) as Record<string, unknown>;
+      expect(saved.cwd).toBe(expectedCwd);
+      for (const f of SEED_FILES) {
+        expect(fs.existsSync(nodePath.join(expectedCwd, f))).toBe(true);
+      }
+      const routes = gw.listManagedRoutes();
+      expect(routes).toHaveLength(1);
+      expect(routes[0].cwd).toBe(expectedCwd);
+    });
+  });
+
+  it("honors an explicit params.cwd override while still seeding the workspace", async () => {
+    await withSandboxHome(async ({ tmp, fs, path: nodePath }) => {
+      const override = nodePath.join(tmp, "project-dir");
+      fs.mkdirSync(override, { recursive: true });
+      const gw = makeFakeGateway();
+      const provisioner = createProvisioner({
+        gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+      });
+      const privateKey = Buffer.alloc(32, 17).toString("base64");
+      const ack = await provisioner({
+        id: "req_override",
+        type: CONTROL_FRAME_TYPES.PROVISION_AGENT,
+        params: {
+          cwd: override,
+          credentials: {
+            agentId: "ag_override",
+            keyId: "k_o",
+            privateKey,
+            hubUrl: "https://hub.example",
+          },
+        },
+      });
+      expect(ack.ok).toBe(true);
+      const credFile = nodePath.join(tmp, ".botcord", "credentials", "ag_override.json");
+      const saved = JSON.parse(fs.readFileSync(credFile, "utf8")) as Record<string, unknown>;
+      expect(saved.cwd).toBe(override);
+      // Workspace still exists even when runtime cwd points elsewhere.
+      const wsDir = nodePath.join(tmp, ".botcord", "agents", "ag_override", "workspace");
+      for (const f of SEED_FILES) {
+        expect(fs.existsSync(nodePath.join(wsDir, f))).toBe(true);
+      }
+      const routes = gw.listManagedRoutes();
+      expect(routes[0].cwd).toBe(override);
+    });
+  });
+
+  it("rejects params.credentials.cwd outside $HOME before any disk write", async () => {
+    await withSandboxHome(async ({ tmp, fs, path: nodePath }) => {
+      const gw = makeFakeGateway();
+      const provisioner = createProvisioner({
+        gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+      });
+      const privateKey = Buffer.alloc(32, 19).toString("base64");
+      await expect(
+        provisioner({
+          id: "req_smuggle",
+          type: CONTROL_FRAME_TYPES.PROVISION_AGENT,
+          params: {
+            credentials: {
+              agentId: "ag_smuggle",
+              keyId: "k_s",
+              privateKey,
+              hubUrl: "https://hub.example",
+              cwd: "/etc",
+            },
+          },
+        }),
+      ).rejects.toThrow(/outside the user home/);
+      // Credentials file must not have been written.
+      const credFile = nodePath.join(tmp, ".botcord", "credentials", "ag_smuggle.json");
+      expect(fs.existsSync(credFile)).toBe(false);
+      expect(gw.addChannel).not.toHaveBeenCalled();
+      expect(gw.listManagedRoutes()).toHaveLength(0);
+    });
+  });
+
+  it("unlinks the credentials file when ensureAgentWorkspace fails", async () => {
+    await withSandboxHome(async ({ tmp, fs, path: nodePath }) => {
+      // Pre-create a FILE at the workspace dir path so mkdirSync(recursive)
+      // throws ENOTDIR — forcing ensureAgentWorkspace to propagate.
+      const agentDir = nodePath.join(tmp, ".botcord", "agents", "ag_blocked");
+      fs.mkdirSync(agentDir, { recursive: true });
+      fs.writeFileSync(nodePath.join(agentDir, "workspace"), "blocker");
+
+      const gw = makeFakeGateway();
+      const provisioner = createProvisioner({
+        gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+      });
+      const privateKey = Buffer.alloc(32, 23).toString("base64");
+      await expect(
+        provisioner({
+          id: "req_rollback",
+          type: CONTROL_FRAME_TYPES.PROVISION_AGENT,
+          params: {
+            credentials: {
+              agentId: "ag_blocked",
+              keyId: "k_b",
+              privateKey,
+              hubUrl: "https://hub.example",
+            },
+          },
+        }),
+      ).rejects.toThrow();
+      const credFile = nodePath.join(tmp, ".botcord", "credentials", "ag_blocked.json");
+      expect(fs.existsSync(credFile)).toBe(false);
+      expect(gw.addChannel).not.toHaveBeenCalled();
+      expect(gw.listManagedRoutes()).toHaveLength(0);
+    });
+  });
+
+  it("rolls back the managed route when addChannel fails", async () => {
+    await withSandboxHome(async ({ tmp, fs, path: nodePath }) => {
+      const gw = makeFakeGateway();
+      gw.addChannel.mockImplementationOnce(async () => {
+        throw new Error("channel boom");
+      });
+      const provisioner = createProvisioner({
+        gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+      });
+      const privateKey = Buffer.alloc(32, 29).toString("base64");
+      await expect(
+        provisioner({
+          id: "req_ch_fail",
+          type: CONTROL_FRAME_TYPES.PROVISION_AGENT,
+          params: {
+            credentials: {
+              agentId: "ag_chfail",
+              keyId: "k_c",
+              privateKey,
+              hubUrl: "https://hub.example",
+            },
+          },
+        }),
+      ).rejects.toThrow(/channel boom/);
+      // Credentials unlinked; managed route never added (addChannel threw
+      // before the upsert step).
+      const credFile = nodePath.join(tmp, ".botcord", "credentials", "ag_chfail.json");
+      expect(fs.existsSync(credFile)).toBe(false);
+      expect(gw.listManagedRoutes()).toHaveLength(0);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// revoke_agent — new flag semantics (plan §11.3)
+// ---------------------------------------------------------------------------
+
+function seedAgentOnDisk(
+  fs: typeof import("node:fs"),
+  nodePath: typeof import("node:path"),
+  tmp: string,
+  agentId: string,
+): { credFile: string; workspaceDir: string; stateDir: string; homeDir: string } {
+  const credDir = nodePath.join(tmp, ".botcord", "credentials");
+  const homeDir = nodePath.join(tmp, ".botcord", "agents", agentId);
+  const workspaceDir = nodePath.join(homeDir, "workspace");
+  const stateDir = nodePath.join(homeDir, "state");
+  fs.mkdirSync(credDir, { recursive: true });
+  fs.mkdirSync(workspaceDir, { recursive: true });
+  fs.mkdirSync(stateDir, { recursive: true });
+  const credFile = nodePath.join(credDir, `${agentId}.json`);
+  fs.writeFileSync(
+    credFile,
+    JSON.stringify({
+      version: 1,
+      hubUrl: "https://hub.example",
+      agentId,
+      keyId: `k_${agentId}`,
+      privateKey: Buffer.alloc(32, 41).toString("base64"),
+      publicKey: Buffer.alloc(32, 42).toString("base64"),
+      savedAt: new Date().toISOString(),
+    }),
+  );
+  fs.writeFileSync(nodePath.join(workspaceDir, "memory.md"), "# Memory\nprecious\n");
+  fs.writeFileSync(nodePath.join(stateDir, "working-memory.json"), "{}");
+  return { credFile, workspaceDir, stateDir, homeDir };
+}
+
+describe("revoke_agent respects deleteState / deleteWorkspace flags", () => {
+  it("default flags: credentials deleted, state deleted, workspace preserved", async () => {
+    await withSandboxHome(async ({ tmp, fs, path: nodePath }) => {
+      const { credFile, workspaceDir, stateDir } = seedAgentOnDisk(
+        fs,
+        nodePath,
+        tmp,
+        "ag_default",
+      );
+      const gw = makeFakeGateway(["ag_default"]);
+      const provisioner = createProvisioner({
+        gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+      });
+      const ack = await provisioner({
+        id: "req_rev_default",
+        type: CONTROL_FRAME_TYPES.REVOKE_AGENT,
+        params: { agentId: "ag_default" },
+      });
+      expect(ack.ok).toBe(true);
+      const result = ack.result as {
+        agentId: string;
+        credentialsDeleted: boolean;
+        stateDeleted: boolean;
+        workspaceDeleted: boolean;
+      };
+      expect(result.credentialsDeleted).toBe(true);
+      expect(result.stateDeleted).toBe(true);
+      expect(result.workspaceDeleted).toBe(false);
+      expect(fs.existsSync(credFile)).toBe(false);
+      expect(fs.existsSync(stateDir)).toBe(false);
+      expect(fs.existsSync(workspaceDir)).toBe(true);
+      expect(gw.removeManagedRoute).toHaveBeenCalledWith("ag_default");
+    });
+  });
+
+  it("deleteCredentials:false keeps everything on disk but still revokes the channel + managed route", async () => {
+    await withSandboxHome(async ({ tmp, fs, path: nodePath }) => {
+      const { credFile, workspaceDir, stateDir } = seedAgentOnDisk(
+        fs,
+        nodePath,
+        tmp,
+        "ag_keep",
+      );
+      const gw = makeFakeGateway(["ag_keep"]);
+      const provisioner = createProvisioner({
+        gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+      });
+      const ack = await provisioner({
+        id: "req_rev_keep",
+        type: CONTROL_FRAME_TYPES.REVOKE_AGENT,
+        params: { agentId: "ag_keep", deleteCredentials: false },
+      });
+      expect(ack.ok).toBe(true);
+      const result = ack.result as {
+        credentialsDeleted: boolean;
+        stateDeleted: boolean;
+        workspaceDeleted: boolean;
+      };
+      expect(result.credentialsDeleted).toBe(false);
+      expect(result.stateDeleted).toBe(false);
+      expect(result.workspaceDeleted).toBe(false);
+      expect(fs.existsSync(credFile)).toBe(true);
+      expect(fs.existsSync(stateDir)).toBe(true);
+      expect(fs.existsSync(workspaceDir)).toBe(true);
+      // Channel + managed route cleanup still runs unconditionally.
+      expect(gw.removeChannel).toHaveBeenCalledWith("ag_keep", "revoked by hub");
+      expect(gw.removeManagedRoute).toHaveBeenCalledWith("ag_keep");
+    });
+  });
+
+  it("deleteWorkspace:true removes the entire agent home (subsumes state)", async () => {
+    await withSandboxHome(async ({ tmp, fs, path: nodePath }) => {
+      const { credFile, homeDir } = seedAgentOnDisk(fs, nodePath, tmp, "ag_wipe");
+      const gw = makeFakeGateway(["ag_wipe"]);
+      const provisioner = createProvisioner({
+        gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+      });
+      const ack = await provisioner({
+        id: "req_rev_wipe",
+        type: CONTROL_FRAME_TYPES.REVOKE_AGENT,
+        params: { agentId: "ag_wipe", deleteWorkspace: true },
+      });
+      expect(ack.ok).toBe(true);
+      const result = ack.result as {
+        credentialsDeleted: boolean;
+        stateDeleted: boolean;
+        workspaceDeleted: boolean;
+      };
+      expect(result.credentialsDeleted).toBe(true);
+      expect(result.stateDeleted).toBe(true);
+      expect(result.workspaceDeleted).toBe(true);
+      expect(fs.existsSync(credFile)).toBe(false);
+      expect(fs.existsSync(homeDir)).toBe(false);
+    });
+  });
+
+  it("deleteState:false with deleteCredentials:true keeps state + workspace", async () => {
+    await withSandboxHome(async ({ tmp, fs, path: nodePath }) => {
+      const { credFile, workspaceDir, stateDir } = seedAgentOnDisk(
+        fs,
+        nodePath,
+        tmp,
+        "ag_keepstate",
+      );
+      const gw = makeFakeGateway(["ag_keepstate"]);
+      const provisioner = createProvisioner({
+        gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+      });
+      const ack = await provisioner({
+        id: "req_rev_keepstate",
+        type: CONTROL_FRAME_TYPES.REVOKE_AGENT,
+        params: { agentId: "ag_keepstate", deleteCredentials: true, deleteState: false },
+      });
+      expect(ack.ok).toBe(true);
+      const result = ack.result as {
+        credentialsDeleted: boolean;
+        stateDeleted: boolean;
+        workspaceDeleted: boolean;
+      };
+      expect(result.credentialsDeleted).toBe(true);
+      expect(result.stateDeleted).toBe(false);
+      expect(result.workspaceDeleted).toBe(false);
+      expect(fs.existsSync(credFile)).toBe(false);
+      expect(fs.existsSync(stateDir)).toBe(true);
+      expect(fs.existsSync(workspaceDir)).toBe(true);
+    });
+  });
+
+  it("preserves an operator-authored cfg.routes[] entry with the same accountId", async () => {
+    await withSandboxHome(async ({ tmp, fs, path: nodePath }) => {
+      seedAgentOnDisk(fs, nodePath, tmp, "ag_opkept");
+      mockState.cfg = {
+        defaultRoute: { adapter: "claude-code", cwd: tmp },
+        routes: [
+          {
+            match: { accountId: "ag_opkept" },
+            adapter: "claude-code",
+            cwd: tmp,
+          },
+        ],
+        streamBlocks: true,
+        agents: ["ag_opkept"],
+      };
+      const gw = makeFakeGateway(["ag_opkept"]);
+      const provisioner = createProvisioner({
+        gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+      });
+      await provisioner({
+        id: "req_rev_op",
+        type: CONTROL_FRAME_TYPES.REVOKE_AGENT,
+        params: { agentId: "ag_opkept" },
+      });
+      const saved = mockState.saved[mockState.saved.length - 1] as unknown as DaemonConfig;
+      expect(saved.routes).toHaveLength(1);
+      expect(saved.routes[0].match.accountId).toBe("ag_opkept");
+    });
   });
 });

--- a/packages/daemon/src/__tests__/system-context.test.ts
+++ b/packages/daemon/src/__tests__/system-context.test.ts
@@ -4,16 +4,16 @@ import os from "node:os";
 import path from "node:path";
 import type { GatewayInboundMessage } from "../gateway/index.js";
 
-// Shared tempdir used for both working-memory (via DAEMON_DIR_PATH) and the
-// activity tracker file. Working memory resolves its base path at read time
-// via `get DAEMON_DIR_PATH()`, so re-assigning the `let` before each test
-// gives us per-test isolation.
+// Shared tempdir used for both working-memory (resolved via $HOME since the
+// §8 migration) and the activity tracker file. Each test gets a fresh HOME
+// so `~/.botcord/agents/<id>/state/working-memory.json` is isolated.
 let tmpDir = "";
+let prevHome: string | undefined;
 
 vi.mock("../config.js", () => {
   return {
     get DAEMON_DIR_PATH() {
-      return tmpDir;
+      return path.join(tmpDir, ".botcord", "daemon");
     },
   };
 });
@@ -43,8 +43,12 @@ function makeMessage(
 
 beforeEach(() => {
   tmpDir = mkdtempSync(path.join(os.tmpdir(), "daemon-sc-"));
+  prevHome = process.env.HOME;
+  process.env.HOME = tmpDir;
 });
 afterEach(() => {
+  if (prevHome === undefined) delete process.env.HOME;
+  else process.env.HOME = prevHome;
   if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
 });
 

--- a/packages/daemon/src/__tests__/working-memory.test.ts
+++ b/packages/daemon/src/__tests__/working-memory.test.ts
@@ -1,27 +1,65 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-let tmpDir = "";
+let tmpHome = "";
+let prevHome: string | undefined;
 
-// Point the shared DAEMON_DIR_PATH at an isolated tempdir so the real
-// ~/.botcord/daemon is never touched.
+// The legacy location lives under `<DAEMON_DIR_PATH>/memory/<agentId>`. The
+// mock keeps it inside our per-test tmp HOME so the migration read path can
+// see an old file without touching the real `~/.botcord/daemon`.
 vi.mock("../config.js", () => {
   return {
     get DAEMON_DIR_PATH() {
-      return tmpDir;
+      return path.join(tmpHome, ".botcord", "daemon");
     },
   };
 });
 
+const warnSpy = vi.fn();
+vi.mock("../log.js", () => ({
+  log: {
+    info: vi.fn(),
+    warn: (msg: string, fields?: Record<string, unknown>) => warnSpy(msg, fields),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
 const wm = await import("../working-memory.js");
+const { agentStateDir } = await import("../agent-workspace.js");
+
+function newPathFor(agentId: string): string {
+  return path.join(agentStateDir(agentId), "working-memory.json");
+}
+
+function legacyPathFor(agentId: string): string {
+  return path.join(tmpHome, ".botcord", "daemon", "memory", agentId, "working-memory.json");
+}
+
+function writeLegacy(agentId: string, body: unknown): void {
+  const p = legacyPathFor(agentId);
+  mkdirSync(path.dirname(p), { recursive: true });
+  writeFileSync(p, JSON.stringify(body));
+}
+
+function writeNew(agentId: string, body: unknown): void {
+  const p = newPathFor(agentId);
+  mkdirSync(path.dirname(p), { recursive: true });
+  writeFileSync(p, JSON.stringify(body));
+}
 
 beforeEach(() => {
-  tmpDir = mkdtempSync(path.join(os.tmpdir(), "daemon-wm-"));
+  tmpHome = mkdtempSync(path.join(os.tmpdir(), "daemon-wm-"));
+  prevHome = process.env.HOME;
+  process.env.HOME = tmpHome;
+  warnSpy.mockClear();
 });
 afterEach(() => {
-  if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+  if (prevHome === undefined) delete process.env.HOME;
+  else process.env.HOME = prevHome;
+  if (tmpHome) rmSync(tmpHome, { recursive: true, force: true });
 });
 
 describe("working-memory I/O", () => {
@@ -41,11 +79,16 @@ describe("working-memory I/O", () => {
     expect(got?.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 
+  it("writes land in the new state dir", () => {
+    wm.updateWorkingMemory("ag_new", { goal: "g" });
+    expect(existsSync(newPathFor("ag_new"))).toBe(true);
+    expect(existsSync(legacyPathFor("ag_new"))).toBe(false);
+  });
+
   it("migrates v1 on read", () => {
     const dir = wm.resolveMemoryDir("ag_v1");
-    const fs = require("node:fs");
-    fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
       path.join(dir, "working-memory.json"),
       JSON.stringify({ version: 1, content: "old notes", updatedAt: "2024-01-01" }),
     );
@@ -93,6 +136,70 @@ describe("working-memory I/O", () => {
   });
 });
 
+describe("working-memory migration (§8)", () => {
+  it("reads from new path when present and ignores legacy", () => {
+    writeNew("ag_mig", { version: 2, sections: { notes: "fresh" }, updatedAt: "2026-01-01" });
+    writeLegacy("ag_mig", { version: 2, sections: { notes: "stale" }, updatedAt: "2024-01-01" });
+
+    const got = wm.readWorkingMemory("ag_mig");
+    expect(got?.sections.notes).toBe("fresh");
+    // Legacy is left in place when new wins; warning is emitted once.
+    expect(existsSync(legacyPathFor("ag_mig"))).toBe(true);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("renames legacy → new on first read when only legacy exists", () => {
+    writeLegacy("ag_onlyold", {
+      version: 2,
+      sections: { notes: "old notes" },
+      updatedAt: "2024-01-01",
+    });
+    expect(existsSync(newPathFor("ag_onlyold"))).toBe(false);
+
+    const got = wm.readWorkingMemory("ag_onlyold");
+    expect(got?.sections.notes).toBe("old notes");
+
+    // Legacy moved away; new path now holds the data.
+    expect(existsSync(legacyPathFor("ag_onlyold"))).toBe(false);
+    expect(existsSync(newPathFor("ag_onlyold"))).toBe(true);
+
+    // Subsequent reads come from new path — delete legacy dir tree to
+    // prove no re-read falls through to it.
+    const got2 = wm.readWorkingMemory("ag_onlyold");
+    expect(got2?.sections.notes).toBe("old notes");
+  });
+
+  it("returns null when neither path exists", () => {
+    expect(wm.readWorkingMemory("ag_none")).toBeNull();
+  });
+
+  it("falls back to reading legacy path and logs warning on rename failure", () => {
+    writeLegacy("ag_renamefail", {
+      version: 2,
+      sections: { notes: "still readable" },
+      updatedAt: "2024-01-01",
+    });
+
+    // Plant a regular file where the new state *directory* would live, so
+    // mkdirSync+renameSync inside the migration branch fails with ENOTDIR
+    // (the agent home's `state` path already exists as a file). The
+    // migration path must log and fall back to reading the legacy file.
+    const home = path.join(tmpHome, ".botcord", "agents", "ag_renamefail");
+    mkdirSync(home, { recursive: true });
+    writeFileSync(path.join(home, "state"), "not a dir");
+
+    const got = wm.readWorkingMemory("ag_renamefail");
+    expect(got?.sections.notes).toBe("still readable");
+    // Legacy file remains untouched after a failed rename.
+    expect(existsSync(legacyPathFor("ag_renamefail"))).toBe(true);
+    expect(warnSpy).toHaveBeenCalled();
+    const warnArgs = warnSpy.mock.calls.find((c) =>
+      String(c[0]).includes("migration rename failed"),
+    );
+    expect(warnArgs).toBeDefined();
+  });
+});
+
 describe("buildWorkingMemoryPrompt", () => {
   it("returns a helpful empty-state block when memory is null", () => {
     const p = wm.buildWorkingMemoryPrompt({ workingMemory: null });
@@ -130,3 +237,4 @@ describe("buildWorkingMemoryPrompt", () => {
     expect(p).toContain("‹current_memory›");
   });
 });
+

--- a/packages/daemon/src/agent-discovery.ts
+++ b/packages/daemon/src/agent-discovery.ts
@@ -38,6 +38,12 @@ export interface DiscoveredAgentCredential {
   runtime?: string;
   /** Working directory cached alongside `runtime`. */
   cwd?: string;
+  /** Key id from the credentials file — surfaced so boot-time workspace
+   * seeding (see daemon-agent-workspace-plan.md §9) can render identity.md
+   * without re-reading the file. */
+  keyId?: string;
+  /** ISO timestamp of when the credentials file was written. */
+  savedAt?: string;
 }
 
 /** Result of one discovery pass — explicit about what was dropped and why. */
@@ -158,6 +164,8 @@ export function discoverAgentCredentials(
     if (creds.displayName) entry.displayName = creds.displayName;
     if (creds.runtime) entry.runtime = creds.runtime;
     if (creds.cwd) entry.cwd = creds.cwd;
+    if (creds.keyId) entry.keyId = creds.keyId;
+    if (creds.savedAt) entry.savedAt = creds.savedAt;
     agents.push(entry);
   }
   // Stable order for downstream channel creation / logs.
@@ -228,6 +236,8 @@ export function resolveBootAgents(
         if (creds.displayName) entry.displayName = creds.displayName;
         if (creds.runtime) entry.runtime = creds.runtime;
         if (creds.cwd) entry.cwd = creds.cwd;
+        if (creds.keyId) entry.keyId = creds.keyId;
+        if (creds.savedAt) entry.savedAt = creds.savedAt;
       } catch (err) {
         // Silent on any read failure: the file may not exist yet (it gets
         // written by provision flows or legacy CLI) and the gateway channel

--- a/packages/daemon/src/agent-workspace.ts
+++ b/packages/daemon/src/agent-workspace.ts
@@ -1,0 +1,170 @@
+/**
+ * Per-agent on-disk workspace. Each provisioned agent gets a dedicated
+ * directory tree under `~/.botcord/agents/{agentId}/`:
+ *
+ *   workspace/  — runtime cwd; seed Markdown files live here (LLM-owned)
+ *   state/      — daemon-owned JSON (e.g. working-memory.json)
+ *
+ * See docs/daemon-agent-workspace-plan.md §4 for the full layout rationale.
+ */
+import { chmodSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+// Accepted agent id pattern. Enforced at every path-builder entry so a
+// malicious / malformed agentId (e.g. "../../etc") cannot escape
+// ~/.botcord/agents/ and end up under `rmSync(..., { recursive: true })`
+// in revokeAgent(deleteWorkspace: true).
+const AGENT_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
+
+function assertSafeAgentId(agentId: string): void {
+  if (!agentId) throw new Error("agentId is required");
+  if (!AGENT_ID_PATTERN.test(agentId)) {
+    throw new Error(`unsafe agentId: ${JSON.stringify(agentId)}`);
+  }
+}
+
+export function agentHomeDir(agentId: string): string {
+  assertSafeAgentId(agentId);
+  return path.join(homedir(), ".botcord", "agents", agentId);
+}
+
+export function agentWorkspaceDir(agentId: string): string {
+  return path.join(agentHomeDir(agentId), "workspace");
+}
+
+export function agentStateDir(agentId: string): string {
+  return path.join(agentHomeDir(agentId), "state");
+}
+
+export interface WorkspaceSeed {
+  displayName?: string;
+  bio?: string;
+  runtime?: string;
+  keyId?: string;
+  /** ISO timestamp. */
+  savedAt?: string;
+}
+
+const AGENTS_MD = `# Agent Workspace
+
+This directory is your persistent workspace. You run with \`cwd\` set here.
+
+## Files you own
+
+- \`identity.md\` — who you are, your role, your boundaries. Read before responding.
+- \`memory.md\` — long-lived facts, user preferences, past decisions. Update when
+  you learn something durable. Prune when it grows stale.
+- \`task.md\` — current task and plan. Update as you make progress. Clear when done.
+- \`notes/\` — free-form scratch space.
+
+## Boundaries
+
+- Do not modify files outside this workspace unless the user explicitly asks.
+- \`../state/\` (sibling directory, outside this workspace) is managed by the
+  daemon — do not read or edit it directly.
+
+## How to use this
+
+You are **instructed** to skim \`identity.md\`, \`memory.md\`, \`task.md\` before each
+response and to write back what changed after meaningful turns. Nothing in the
+runtime enforces this — the daemon does not auto-load these files into your
+context. Treat AGENTS.md as a convention, not a mechanism.
+`;
+
+const MEMORY_MD = `# Memory
+
+<!--
+Long-lived facts about the user, past decisions, and preferences that should
+survive across conversations. Organize by topic. Keep entries short. Prune
+regularly — AGENTS.md instructs the runtime to consult this file before each
+response, but nothing loads it automatically; keep it short enough to be
+worth re-reading.
+-->
+`;
+
+const TASK_MD = `# Current Task
+
+<!--
+What are you working on right now? What is the plan? What is blocked?
+Clear this file when the task is done.
+-->
+`;
+
+const BIO_PLACEHOLDER = "_(none provided at provision time — edit this section)_";
+const FIELD_PLACEHOLDER = "_(not set)_";
+
+function renderIdentity(agentId: string, seed: WorkspaceSeed): string {
+  const bio = seed.bio && seed.bio.trim().length > 0 ? seed.bio : BIO_PLACEHOLDER;
+  return `# Identity
+
+- **Agent ID**: ${agentId}
+- **Display name**: ${seed.displayName ?? FIELD_PLACEHOLDER}
+- **Runtime**: ${seed.runtime ?? FIELD_PLACEHOLDER}
+- **Key ID**: ${seed.keyId ?? FIELD_PLACEHOLDER}
+- **Created**: ${seed.savedAt ?? FIELD_PLACEHOLDER}
+
+## Bio
+
+${bio}
+
+## Role
+
+_(Describe what you do and for whom. Edit this section.)_
+
+## Boundaries
+
+_(What you will and will not do. Edit this section.)_
+`;
+}
+
+function mkdirTolerant(dir: string): void {
+  try {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+  }
+  // mkdirSync with `recursive: true` only applies `mode` to directories it
+  // creates. If the agent home / workspace / state already existed with
+  // looser perms (a very common case on upgrades), tighten them now.
+  // Best-effort: some filesystems (e.g. certain Windows / SMB mounts) reject
+  // chmod and that is acceptable.
+  try {
+    chmodSync(dir, 0o700);
+  } catch {
+    /* best-effort */
+  }
+}
+
+function writeIfMissing(filePath: string, content: string): void {
+  if (existsSync(filePath)) return;
+  writeFileSync(filePath, content, { mode: 0o600 });
+}
+
+/**
+ * Idempotently create the agent's home / workspace / state directories and
+ * seed the workspace Markdown files. Existing files are never overwritten —
+ * users' edits to AGENTS.md, memory.md, etc. are preserved across calls.
+ * State files are not touched here; working-memory.ts owns `state/`.
+ */
+export function ensureAgentWorkspace(agentId: string, seed: WorkspaceSeed): void {
+  if (!agentId) throw new Error("ensureAgentWorkspace: agentId is required");
+  const home = agentHomeDir(agentId);
+  const workspace = agentWorkspaceDir(agentId);
+  const notes = path.join(workspace, "notes");
+  const state = agentStateDir(agentId);
+
+  mkdirTolerant(home);
+  mkdirTolerant(workspace);
+  mkdirTolerant(notes);
+  mkdirTolerant(state);
+
+  const agentsMdPath = path.join(workspace, "AGENTS.md");
+  const claudeMdPath = path.join(workspace, "CLAUDE.md");
+  writeIfMissing(agentsMdPath, AGENTS_MD);
+  writeIfMissing(claudeMdPath, AGENTS_MD);
+  writeIfMissing(path.join(workspace, "identity.md"), renderIdentity(agentId, seed));
+  writeIfMissing(path.join(workspace, "memory.md"), MEMORY_MD);
+  writeIfMissing(path.join(workspace, "task.md"), TASK_MD);
+  writeIfMissing(path.join(notes, ".gitkeep"), "");
+}

--- a/packages/daemon/src/daemon-config-map.ts
+++ b/packages/daemon/src/daemon-config-map.ts
@@ -7,6 +7,7 @@ import type {
 } from "./gateway/index.js";
 import type { DaemonConfig, RouteRule } from "./config.js";
 import { resolveAgentIds } from "./config.js";
+import { agentWorkspaceDir } from "./agent-workspace.js";
 import { log as daemonLog } from "./log.js";
 
 /** Options accepted by {@link toGatewayConfig}. */
@@ -147,28 +148,53 @@ export function toGatewayConfig(
 
   const routes: GatewayRoute[] = (cfg.routes ?? []).map(mapRoute);
 
-  // Synthesize a per-agent terminal route for every agent that has a cached
-  // runtime in its credentials. Appended after the user's explicit routes so
-  // `cfg.routes` still wins on conflict, but ahead of the `defaultRoute`
-  // fallback so the agent's own runtime takes precedence over the daemon-wide
-  // default (docs/agent-runtime-property-plan.md §4.3).
-  const agentRuntimes = opts.agentRuntimes ?? {};
-  for (const agentId of agentIds) {
-    const meta = agentRuntimes[agentId];
-    if (!meta?.runtime) continue;
-    routes.push({
-      match: { accountId: agentId },
-      runtime: meta.runtime,
-      cwd: meta.cwd || defaultRoute.cwd,
-      // Inherit defaults for the rest. `extraArgs`/`queueMode`/`trustLevel`
-      // stay unset so the gateway's own defaults apply.
-    });
-  }
+  // Synthesize a per-agent route for every bound agent and hand it to the
+  // gateway via the managed-routes bucket (plan §10.1). User-authored
+  // `cfg.routes[]` stay untouched so an explicit operator override still
+  // wins on conflict — the gateway matches `routes[] → managedRoutes →
+  // defaultRoute` in that order.
+  const managedMap = buildManagedRoutes(
+    agentIds,
+    opts.agentRuntimes ?? {},
+    defaultRoute,
+  );
 
   return {
     channels,
     defaultRoute,
     routes,
+    managedRoutes: Array.from(managedMap.values()),
     streamBlocks: cfg.streamBlocks,
   };
+}
+
+/**
+ * Build the daemon's managed per-agent routes. Emits exactly one route per
+ * `agentId`, keyed by `accountId`. `runtime` comes from the agent's cached
+ * metadata when present (credentials file), otherwise falls back to
+ * `defaultRoute.runtime`. `cwd` prefers the cached value but falls back to
+ * the agent's workspace directory (see plan §10) so every agent runs inside
+ * its own dedicated tree by default.
+ *
+ * Iteration order of `agentIds` is preserved in the resulting Map for test
+ * determinism; the gateway router does not depend on map order.
+ *
+ * Exported so `reload_config` and `provisionAgent` hot-add can share the
+ * same synthesis logic (plan §10.5).
+ */
+export function buildManagedRoutes(
+  agentIds: string[],
+  agentRuntimes: Record<string, { runtime?: string; cwd?: string }>,
+  defaultRoute: GatewayRoute,
+): Map<string, GatewayRoute> {
+  const out = new Map<string, GatewayRoute>();
+  for (const agentId of agentIds) {
+    const meta = agentRuntimes[agentId] ?? {};
+    out.set(agentId, {
+      match: { accountId: agentId },
+      runtime: meta.runtime ?? defaultRoute.runtime,
+      cwd: meta.cwd || agentWorkspaceDir(agentId),
+    });
+  }
+  return out;
 }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -13,6 +13,7 @@ import { ActivityTracker } from "./activity-tracker.js";
 import type { DaemonConfig } from "./config.js";
 import { SESSIONS_PATH, SNAPSHOT_PATH } from "./config.js";
 import { resolveBootAgents, type BootAgentsResult } from "./agent-discovery.js";
+import { ensureAgentWorkspace } from "./agent-workspace.js";
 import { ControlChannel } from "./control-channel.js";
 import { toGatewayConfig } from "./daemon-config-map.js";
 import { log as daemonLog } from "./log.js";
@@ -240,17 +241,10 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
     logger.warn("daemon.discovery.warning", { message: w });
   }
   const agentIds = boot.agents.map((a) => a.agentId);
-  const credentialPathByAgentId = new Map<string, string>();
-  const agentRuntimes: Record<string, { runtime?: string; cwd?: string }> = {};
-  for (const a of boot.agents) {
-    if (a.credentialsFile) credentialPathByAgentId.set(a.agentId, a.credentialsFile);
-    if (a.runtime || a.cwd) {
-      agentRuntimes[a.agentId] = {
-        ...(a.runtime ? { runtime: a.runtime } : {}),
-        ...(a.cwd ? { cwd: a.cwd } : {}),
-      };
-    }
-  }
+  const { credentialPathByAgentId, agentRuntimes } = backfillBootAgents(
+    boot.agents,
+    { logger },
+  );
 
   const gwConfig = toGatewayConfig(opts.config, { agentIds, agentRuntimes });
 
@@ -408,6 +402,70 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
     stop,
     snapshot: () => gateway.snapshot(),
   };
+}
+
+/**
+ * Result of {@link backfillBootAgents}: the maps the boot flow needs to
+ * plumb into `toGatewayConfig` + the channel factory.
+ */
+export interface BootBackfillResult {
+  credentialPathByAgentId: Map<string, string>;
+  agentRuntimes: Record<string, { runtime?: string; cwd?: string }>;
+}
+
+/**
+ * Walk the boot-agent list and (a) populate the credential-path + runtime
+ * caches used downstream, and (b) idempotently create each agent's on-disk
+ * workspace tree (plan §9). One agent's failing workspace must not block
+ * the others — errors are warned and swallowed per agent. Exported for
+ * unit tests; `startDaemon` calls this inline.
+ */
+export function backfillBootAgents(
+  agents: BootAgentsResult["agents"],
+  opts: {
+    logger: GatewayLogger;
+    ensure?: typeof ensureAgentWorkspace;
+  },
+): BootBackfillResult {
+  const ensure = opts.ensure ?? ensureAgentWorkspace;
+  const credentialPathByAgentId = new Map<string, string>();
+  const agentRuntimes: Record<string, { runtime?: string; cwd?: string }> = {};
+  const failed: string[] = [];
+  for (const a of agents) {
+    if (a.credentialsFile) credentialPathByAgentId.set(a.agentId, a.credentialsFile);
+    if (a.runtime || a.cwd) {
+      agentRuntimes[a.agentId] = {
+        ...(a.runtime ? { runtime: a.runtime } : {}),
+        ...(a.cwd ? { cwd: a.cwd } : {}),
+      };
+    }
+    // Seed files are written only when missing (see `ensureAgentWorkspace`),
+    // so a legacy agent whose workspace dir doesn't exist yet gets one on
+    // the next boot — with zero risk of overwriting the user's edits.
+    try {
+      ensure(a.agentId, {
+        ...(a.displayName ? { displayName: a.displayName } : {}),
+        ...(a.runtime ? { runtime: a.runtime } : {}),
+        ...(a.keyId ? { keyId: a.keyId } : {}),
+        ...(a.savedAt ? { savedAt: a.savedAt } : {}),
+        // `bio` is not surfaced on BootAgent — identity.md renders a
+        // placeholder the user can fill in.
+      });
+    } catch (err) {
+      failed.push(a.agentId);
+      opts.logger.warn("ensureAgentWorkspace failed at boot; continuing", {
+        agentId: a.agentId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  if (failed.length > 0) {
+    opts.logger.warn("ensureAgentWorkspace: boot backfill incomplete", {
+      count: failed.length,
+      agentIds: failed,
+    });
+  }
+  return { credentialPathByAgentId, agentRuntimes };
 }
 
 /**

--- a/packages/daemon/src/gateway/__tests__/gateway-managed-routes.test.ts
+++ b/packages/daemon/src/gateway/__tests__/gateway-managed-routes.test.ts
@@ -1,0 +1,181 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Gateway } from "../gateway.js";
+import { resolveRoute } from "../router.js";
+import type {
+  ChannelAdapter,
+  ChannelSendContext,
+  ChannelSendResult,
+  ChannelStartContext,
+  ChannelStopContext,
+  GatewayChannelConfig,
+  GatewayInboundMessage,
+  GatewayRoute,
+} from "../types.js";
+import type { GatewayLogger } from "../log.js";
+
+function silentLogger(): GatewayLogger {
+  return { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+}
+
+class StubChannel implements ChannelAdapter {
+  readonly type = "stub";
+  constructor(public readonly id: string, public readonly accountId: string) {}
+  async start(ctx: ChannelStartContext): Promise<void> {
+    await new Promise<void>((resolve) => {
+      ctx.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+    });
+  }
+  async stop(_ctx: ChannelStopContext): Promise<void> {}
+  async send(_ctx: ChannelSendContext): Promise<ChannelSendResult> {
+    return {};
+  }
+}
+
+function makeMessage(overrides: Partial<GatewayInboundMessage> = {}): GatewayInboundMessage {
+  return {
+    id: "m_1",
+    channel: "botcord",
+    accountId: "ag_1",
+    conversation: { id: "rm_1", kind: "group" },
+    sender: { id: "ag_sender", kind: "agent" },
+    text: "hi",
+    raw: {},
+    receivedAt: 0,
+    ...overrides,
+  };
+}
+
+function makeRoute(overrides: Partial<GatewayRoute> = {}): GatewayRoute {
+  return { runtime: "claude-code", cwd: "/tmp", ...overrides };
+}
+
+describe("Gateway managed-route API", () => {
+  const defaultRoute: GatewayRoute = makeRoute({ runtime: "default", cwd: "/default" });
+  let dirs: string[] = [];
+  let gateway: Gateway | null = null;
+
+  beforeEach(() => {
+    dirs = [];
+    gateway = null;
+  });
+
+  afterEach(async () => {
+    if (gateway) await gateway.stop("test");
+    for (const d of dirs) await rm(d, { recursive: true, force: true });
+  });
+
+  async function makeGateway(
+    channels: GatewayChannelConfig[] = [],
+    userRoutes: GatewayRoute[] = [],
+  ): Promise<Gateway> {
+    const dir = await mkdtemp(path.join(tmpdir(), "gw-mr-"));
+    dirs.push(dir);
+    const gw = new Gateway({
+      config: { channels, defaultRoute, routes: userRoutes },
+      sessionStorePath: path.join(dir, "sessions.json"),
+      createChannel: (cfg) => new StubChannel(cfg.id, cfg.accountId),
+      log: silentLogger(),
+    });
+    gateway = gw;
+    return gw;
+  }
+
+  it("upsertManagedRoute adds a route and listManagedRoutes reflects it", async () => {
+    const gw = await makeGateway();
+    const route = makeRoute({ runtime: "r1", cwd: "/ws/ag_1", match: { accountId: "ag_1" } });
+    gw.upsertManagedRoute("ag_1", route);
+    expect(gw.listManagedRoutes()).toEqual([route]);
+  });
+
+  it("upsertManagedRoute on existing accountId replaces (no duplicate)", async () => {
+    const gw = await makeGateway();
+    const first = makeRoute({ runtime: "r1", match: { accountId: "ag_1" } });
+    const second = makeRoute({ runtime: "r2", match: { accountId: "ag_1" } });
+    gw.upsertManagedRoute("ag_1", first);
+    gw.upsertManagedRoute("ag_1", second);
+    expect(gw.listManagedRoutes()).toEqual([second]);
+  });
+
+  it("removeManagedRoute drops the entry; cfg.routes with same accountId untouched", async () => {
+    const user = makeRoute({ runtime: "user", match: { accountId: "ag_1" } });
+    const gw = await makeGateway([], [user]);
+    gw.upsertManagedRoute("ag_1", makeRoute({ runtime: "managed", match: { accountId: "ag_1" } }));
+    gw.removeManagedRoute("ag_1");
+    expect(gw.listManagedRoutes()).toEqual([]);
+
+    const msg = makeMessage({ accountId: "ag_1" });
+    expect(resolveRoute(msg, { defaultRoute, routes: [user] }, gw.listManagedRoutes())).toBe(user);
+  });
+
+  it("removeManagedRoute on unknown accountId is a no-op", async () => {
+    const gw = await makeGateway();
+    expect(() => gw.removeManagedRoute("ag_missing")).not.toThrow();
+    expect(gw.listManagedRoutes()).toEqual([]);
+  });
+
+  it("replaceManagedRoutes(new Map()) wipes synthesized without touching cfg.routes", async () => {
+    const user = makeRoute({ runtime: "user", match: { accountId: "ag_2" } });
+    const gw = await makeGateway([], [user]);
+    gw.upsertManagedRoute("ag_1", makeRoute({ runtime: "m1" }));
+    gw.upsertManagedRoute("ag_9", makeRoute({ runtime: "m2" }));
+    gw.replaceManagedRoutes(new Map());
+    expect(gw.listManagedRoutes()).toEqual([]);
+
+    const msg = makeMessage({ accountId: "ag_2" });
+    expect(resolveRoute(msg, { defaultRoute, routes: [user] }, gw.listManagedRoutes())).toBe(user);
+  });
+
+  it("replaceManagedRoutes swaps contents atomically", async () => {
+    const gw = await makeGateway();
+    gw.upsertManagedRoute("ag_old", makeRoute({ runtime: "old" }));
+    const next = new Map<string, GatewayRoute>();
+    const newRoute = makeRoute({ runtime: "new", match: { accountId: "ag_new" } });
+    next.set("ag_new", newRoute);
+    gw.replaceManagedRoutes(next);
+    expect(gw.listManagedRoutes()).toEqual([newRoute]);
+  });
+
+  it("replaceManagedRoutes decouples from the caller's Map", async () => {
+    const gw = await makeGateway();
+    const src = new Map<string, GatewayRoute>();
+    src.set("ag_1", makeRoute({ runtime: "m1" }));
+    gw.replaceManagedRoutes(src);
+    src.clear();
+    expect(gw.listManagedRoutes()).toHaveLength(1);
+  });
+
+  it("ctor logs (not silently drops) seed managed routes missing accountId", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "gw-mr-bad-"));
+    dirs.push(dir);
+    const warnCalls: unknown[][] = [];
+    const log: GatewayLogger = {
+      info: () => {},
+      warn: (...args: unknown[]) => warnCalls.push(args),
+      error: () => {},
+      debug: () => {},
+    };
+    const gw = new Gateway({
+      config: {
+        channels: [],
+        defaultRoute,
+        routes: [],
+        managedRoutes: [
+          { match: { accountId: "ag_ok" }, runtime: "r", cwd: "/w/ok" },
+          // match.accountId missing — must not crash, must log
+          { match: {}, runtime: "r", cwd: "/w/bad" },
+          // match undefined — same
+          { runtime: "r", cwd: "/w/bad2" },
+        ],
+      },
+      sessionStorePath: path.join(dir, "sessions.json"),
+      createChannel: (cfg) => new StubChannel(cfg.id, cfg.accountId),
+      log,
+    });
+    gateway = gw;
+    expect(gw.listManagedRoutes()).toHaveLength(1);
+    expect(warnCalls.length).toBe(2);
+  });
+});

--- a/packages/daemon/src/gateway/__tests__/router.test.ts
+++ b/packages/daemon/src/gateway/__tests__/router.test.ts
@@ -76,6 +76,46 @@ describe("resolveRoute", () => {
     const msg = makeMessage({ channel: "botcord" });
     expect(resolveRoute(msg, { defaultRoute, routes: [skip, hit] })).toBe(hit);
   });
+
+  describe("managedRoutes", () => {
+    it("user cfg.routes match wins over managed for same accountId", () => {
+      const user = makeRoute({ runtime: "user", match: { accountId: "ag_1" } });
+      const managed = makeRoute({ runtime: "managed", match: { accountId: "ag_1" } });
+      const msg = makeMessage({ accountId: "ag_1" });
+      expect(resolveRoute(msg, { defaultRoute, routes: [user] }, [managed])).toBe(user);
+    });
+
+    it("no user match + managed match → managed wins", () => {
+      const managed = makeRoute({ runtime: "managed", match: { accountId: "ag_1" } });
+      const msg = makeMessage({ accountId: "ag_1" });
+      expect(resolveRoute(msg, { defaultRoute, routes: [] }, [managed])).toBe(managed);
+    });
+
+    it("no user match + no managed match → defaultRoute wins", () => {
+      const user = makeRoute({ runtime: "user", match: { accountId: "ag_2" } });
+      const managed = makeRoute({ runtime: "managed", match: { accountId: "ag_3" } });
+      const msg = makeMessage({ accountId: "ag_1" });
+      expect(resolveRoute(msg, { defaultRoute, routes: [user] }, [managed])).toBe(defaultRoute);
+    });
+
+    it("no user routes defined + managed match → managed wins", () => {
+      const managed = makeRoute({ runtime: "managed", match: { accountId: "ag_1" } });
+      const msg = makeMessage({ accountId: "ag_1" });
+      expect(resolveRoute(msg, { defaultRoute }, [managed])).toBe(managed);
+    });
+
+    it("managed routes undefined behaves like no managed routes", () => {
+      const msg = makeMessage();
+      expect(resolveRoute(msg, { defaultRoute }, undefined)).toBe(defaultRoute);
+    });
+
+    it("first matching managed route wins when multiple match", () => {
+      const first = makeRoute({ runtime: "mfirst", match: { accountId: "ag_1" } });
+      const second = makeRoute({ runtime: "msecond", match: { accountId: "ag_1" } });
+      const msg = makeMessage({ accountId: "ag_1" });
+      expect(resolveRoute(msg, { defaultRoute, routes: [] }, [first, second])).toBe(first);
+    });
+  });
 });
 
 describe("matchesRoute", () => {

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -33,6 +33,12 @@ export interface DispatcherOptions {
   log: GatewayLogger;
   turnTimeoutMs?: number;
   /**
+   * Live reference to the Gateway's managed-route map. Dispatcher reads
+   * `values()` on every `resolveRoute` call so hot-add/remove take effect
+   * without restart.
+   */
+  managedRoutes?: Map<string, GatewayRoute>;
+  /**
    * Optional hook producing a `systemContext` string for each turn. Result is
    * forwarded to the runtime as `RuntimeRunOptions.systemContext`. Errors are
    * swallowed and logged — they never abort the turn.
@@ -88,6 +94,7 @@ export class Dispatcher {
   private readonly turnTimeoutMs: number;
   private readonly buildSystemContext?: SystemContextBuilder;
   private readonly onInbound?: InboundObserver;
+  private readonly managedRoutes?: Map<string, GatewayRoute>;
   private readonly queues: Map<string, QueueState> = new Map();
 
   constructor(opts: DispatcherOptions) {
@@ -99,6 +106,7 @@ export class Dispatcher {
     this.turnTimeoutMs = opts.turnTimeoutMs ?? DEFAULT_TURN_TIMEOUT_MS;
     this.buildSystemContext = opts.buildSystemContext;
     this.onInbound = opts.onInbound;
+    this.managedRoutes = opts.managedRoutes;
   }
 
   /** Consume one inbound envelope, ack it once ownership is decided, then run its turn. */
@@ -122,7 +130,8 @@ export class Dispatcher {
       return;
     }
 
-    const route = resolveRoute(msg, this.config);
+    const managed = this.managedRoutes ? Array.from(this.managedRoutes.values()) : undefined;
+    const route = resolveRoute(msg, this.config, managed);
     const mode = resolveQueueMode(route, msg.conversation.kind);
     const queueKey = buildQueueKey(msg);
 

--- a/packages/daemon/src/gateway/gateway.ts
+++ b/packages/daemon/src/gateway/gateway.ts
@@ -7,6 +7,7 @@ import type {
   ChannelAdapter,
   GatewayChannelConfig,
   GatewayConfig,
+  GatewayRoute,
   GatewayRuntimeSnapshot,
   InboundObserver,
   SystemContextBuilder,
@@ -50,6 +51,7 @@ export class Gateway {
   private readonly channelManager: ChannelManager;
   private readonly channelMap: Map<string, ChannelAdapter>;
   private readonly createChannelFn: (cfg: GatewayChannelConfig) => ChannelAdapter;
+  private readonly managedRoutes: Map<string, GatewayRoute> = new Map();
   private started = false;
   private stopped = false;
 
@@ -64,6 +66,21 @@ export class Gateway {
       const adapter = opts.createChannel(cfg);
       this.channelMap.set(adapter.id, adapter);
       channelList.push(adapter);
+    }
+
+    for (const route of opts.config.managedRoutes ?? []) {
+      const id = route.match?.accountId;
+      if (typeof id === "string") {
+        this.managedRoutes.set(id, route);
+      } else {
+        // Defensive: buildManagedRoutes always sets match.accountId, so
+        // reaching here means a caller constructed GatewayConfig directly
+        // with a malformed entry. Log so it's not silently dropped.
+        this.log.warn("gateway: dropping seed managed route with no accountId", {
+          runtime: route.runtime,
+          cwd: route.cwd,
+        });
+      }
     }
 
     this.sessionStore = new SessionStore({
@@ -82,6 +99,7 @@ export class Gateway {
       turnTimeoutMs: opts.turnTimeoutMs,
       buildSystemContext: opts.buildSystemContext,
       onInbound: opts.onInbound,
+      managedRoutes: this.managedRoutes,
     });
 
     this.channelManager = new ChannelManager({
@@ -114,6 +132,32 @@ export class Gateway {
       channels: this.channelManager.status(),
       turns: this.dispatcher.turns(),
     };
+  }
+
+  /**
+   * Read-only view of the synthesized per-agent routes. Exposed for
+   * snapshot/debug callers and tests; matching reads the live internal map.
+   */
+  listManagedRoutes(): GatewayRoute[] {
+    return Array.from(this.managedRoutes.values());
+  }
+
+  /** Replace all managed routes atomically. Used by `reload_config`. */
+  replaceManagedRoutes(routes: Map<string, GatewayRoute>): void {
+    this.managedRoutes.clear();
+    for (const [id, route] of routes) {
+      this.managedRoutes.set(id, route);
+    }
+  }
+
+  /** Add or update one managed route. Used by provision hot-add. */
+  upsertManagedRoute(accountId: string, route: GatewayRoute): void {
+    this.managedRoutes.set(accountId, route);
+  }
+
+  /** Drop one managed route. Used by revoke / removeChannel. */
+  removeManagedRoute(accountId: string): void {
+    this.managedRoutes.delete(accountId);
   }
 
   /**

--- a/packages/daemon/src/gateway/router.ts
+++ b/packages/daemon/src/gateway/router.ts
@@ -36,14 +36,25 @@ export function matchesRoute(
   return true;
 }
 
-/** Picks the first matching route from config.routes; falls back to config.defaultRoute. */
+/**
+ * Picks the first matching route in priority order:
+ *   1. `config.routes[]` (user-authored)
+ *   2. `managedRoutes` (daemon-synthesized per-agent)
+ *   3. `config.defaultRoute`
+ */
 export function resolveRoute(
   message: GatewayInboundMessage,
   config: Pick<GatewayConfig, "defaultRoute" | "routes">,
+  managedRoutes?: readonly GatewayRoute[],
 ): GatewayRoute {
   const routes = config.routes ?? [];
   for (const route of routes) {
     if (matchesRoute(message, route.match)) return route;
+  }
+  if (managedRoutes) {
+    for (const route of managedRoutes) {
+      if (matchesRoute(message, route.match)) return route;
+    }
   }
   return config.defaultRoute;
 }

--- a/packages/daemon/src/gateway/types.ts
+++ b/packages/daemon/src/gateway/types.ts
@@ -52,6 +52,12 @@ export interface GatewayConfig {
   channels: GatewayChannelConfig[];
   defaultRoute: GatewayRoute;
   routes?: GatewayRoute[];
+  /**
+   * Daemon-synthesized per-agent routes. Snapshot/debug-only surface —
+   * `resolveRoute` reads the live map on the Gateway, not this array.
+   * Matched after `routes[]` and before `defaultRoute`.
+   */
+  managedRoutes?: GatewayRoute[];
   streamBlocks?: boolean;
 }
 

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -6,7 +6,7 @@
  *
  * See `docs/daemon-control-plane-plan.md` §4.3, §5.3, §8.
  */
-import { existsSync, unlinkSync } from "node:fs";
+import { existsSync, rmSync, unlinkSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import {
@@ -21,6 +21,7 @@ import {
   type ListRuntimesResult,
   type ProvisionAgentParams,
   type RevokeAgentParams,
+  type RevokeAgentResult,
   type RuntimeProbeResult,
   type StoredBotCordCredentials,
 } from "@botcord/protocol-core";
@@ -37,7 +38,13 @@ import {
   type RouteRule,
   type RouteRuleMatch,
 } from "./config.js";
-import { BOTCORD_CHANNEL_TYPE } from "./daemon-config-map.js";
+import { BOTCORD_CHANNEL_TYPE, buildManagedRoutes } from "./daemon-config-map.js";
+import {
+  agentHomeDir,
+  agentStateDir,
+  agentWorkspaceDir,
+  ensureAgentWorkspace,
+} from "./agent-workspace.js";
 import { detectRuntimes, getAdapterModule } from "./adapters/runtimes.js";
 import { log as daemonLog } from "./log.js";
 
@@ -154,10 +161,15 @@ async function provisionAgent(
   params: ProvisionAgentParams,
   ctx: ProvisionCtx,
 ): Promise<ProvisionedAgent> {
-  assertSafeCwd(params.cwd);
+  // Validate both caller-supplied cwd sources up front. Previously only
+  // `params.cwd` was checked, so `params.credentials.cwd` could smuggle an
+  // arbitrary path (e.g. `/etc`) into the credentials file; plan §7 closes
+  // that hole by moving the check to the union of both.
+  const explicitCwd = params.credentials?.cwd ?? params.cwd;
+  assertSafeCwd(explicitCwd);
 
   const cfg = loadConfig();
-  const credentials = await materializeCredentials(params, cfg, ctx);
+  const credentials = await materializeCredentials(params, cfg, ctx, explicitCwd);
   daemonLog.debug("provision: credentials materialized", {
     agentId: credentials.agentId,
     hubUrl: credentials.hubUrl,
@@ -169,6 +181,26 @@ async function provisionAgent(
     defaultCredentialsFile(credentials.agentId),
     credentials,
   );
+
+  // Seed the per-agent workspace directory. On failure, unlink the fresh
+  // credentials file but do NOT `rm -rf` the agent dir — partial contents
+  // may belong to a pre-existing workspace we must not touch.
+  try {
+    ensureAgentWorkspace(credentials.agentId, {
+      displayName: credentials.displayName,
+      bio: params.bio,
+      runtime: credentials.runtime,
+      keyId: credentials.keyId,
+      savedAt: credentials.savedAt,
+    });
+  } catch (err) {
+    try {
+      unlinkSync(credentialsFile);
+    } catch {
+      // best-effort
+    }
+    throw err;
+  }
 
   try {
     const updated = addAgentToConfig(cfg, credentials.agentId);
@@ -213,6 +245,40 @@ async function provisionAgent(
     throw err;
   }
 
+  // Hot-add the synthesized per-agent managed route so the next turn picks
+  // the agent's runtime + workspace cwd without waiting for reload_config.
+  try {
+    ctx.gateway.upsertManagedRoute(credentials.agentId, {
+      match: { accountId: credentials.agentId },
+      runtime: credentials.runtime ?? cfg.defaultRoute.adapter,
+      cwd: credentials.cwd ?? agentWorkspaceDir(credentials.agentId),
+    });
+  } catch (err) {
+    // Rollback the channel + config + credentials on managed-route failure
+    // (shouldn't happen — pure map op — but keeps the invariant tight).
+    daemonLog.error("provision.upsertManagedRoute failed, rolling back", {
+      agentId: credentials.agentId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    try {
+      await ctx.gateway.removeChannel(credentials.agentId, "provision rollback");
+    } catch {
+      // ignore
+    }
+    try {
+      const revertCfg = removeAgentFromConfig(loadConfig(), credentials.agentId);
+      if (revertCfg) saveConfig(revertCfg);
+    } catch {
+      // ignore
+    }
+    try {
+      unlinkSync(credentialsFile);
+    } catch {
+      // ignore
+    }
+    throw err;
+  }
+
   daemonLog.info("agent provisioned", {
     agentId: credentials.agentId,
     credentialsFile,
@@ -229,13 +295,13 @@ async function materializeCredentials(
   params: ProvisionAgentParams,
   cfg: DaemonConfig,
   ctx: ProvisionCtx,
+  explicitCwd: string | undefined,
 ): Promise<StoredBotCordCredentials> {
   // Runtime is an agent property (docs/agent-runtime-property-plan.md §4.1).
   // Hub is authoritative; top-level `runtime` wins, `adapter` is a one-release
   // alias, and `credentials.runtime` is the per-agent cached copy.
   const runtime = pickRuntime(params);
   if (runtime) assertKnownRuntime(runtime);
-  const cwd = params.credentials?.cwd ?? params.cwd;
 
   // Fast path: Hub handed us the credential envelope directly.
   if (params.credentials) {
@@ -253,6 +319,7 @@ async function materializeCredentials(
     if (!hubUrl) {
       throw new Error("provision_agent.credentials missing hubUrl");
     }
+    const cwd = explicitCwd ?? agentWorkspaceDir(c.agentId);
     const record: StoredBotCordCredentials = {
       version: 1,
       hubUrl,
@@ -266,7 +333,7 @@ async function materializeCredentials(
     if (c.token) record.token = c.token;
     if (typeof c.tokenExpiresAt === "number") record.tokenExpiresAt = c.tokenExpiresAt;
     if (runtime) record.runtime = runtime;
-    if (cwd) record.cwd = cwd;
+    record.cwd = cwd;
     return record;
   }
 
@@ -281,6 +348,7 @@ async function materializeCredentials(
   }
   const name = params.name || `agent-${Date.now()}`;
   const reg = await ctx.register(hubUrl, name, params.bio);
+  const cwd = explicitCwd ?? agentWorkspaceDir(reg.agentId);
   const record: StoredBotCordCredentials = {
     version: 1,
     hubUrl: reg.hubUrl,
@@ -294,30 +362,42 @@ async function materializeCredentials(
     tokenExpiresAt: reg.expiresAt,
   };
   if (runtime) record.runtime = runtime;
-  if (cwd) record.cwd = cwd;
+  record.cwd = cwd;
   return record;
-}
-
-interface RevokeResult {
-  agentId: string;
-  removed: boolean;
-  credentialsDeleted: boolean;
 }
 
 async function revokeAgent(
   params: RevokeAgentParams,
   ctx: { gateway: Gateway },
-): Promise<RevokeResult> {
+): Promise<RevokeAgentResult> {
   if (!params.agentId) {
     throw new Error("revoke_agent requires params.agentId");
   }
   const agentId = params.agentId;
   const deleteCreds = params.deleteCredentials !== false;
+  // `deleteState` defaults to whatever `deleteCredentials` resolves to —
+  // vanilla revoke wipes runtime state, but explicit `deleteCredentials:false`
+  // (keep-creds) also implies keep-state unless the caller says otherwise.
+  const deleteState = params.deleteState ?? deleteCreds;
+  // Workspace is precious (user-authored memory/notes); require explicit opt-in.
+  const deleteWorkspace = params.deleteWorkspace === true;
 
+  // In-memory gateway ops run first so any in-flight turn is aborted before
+  // disk state changes. Both run unconditionally — the channel is revoked
+  // regardless of whether disk state survives, and the synthesized managed
+  // route is now dangling.
   try {
     await ctx.gateway.removeChannel(agentId, "revoked by hub");
   } catch (err) {
     daemonLog.warn("revoke.removeChannel failed", {
+      agentId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+  try {
+    ctx.gateway.removeManagedRoute(agentId);
+  } catch (err) {
+    daemonLog.warn("revoke.removeManagedRoute failed", {
       agentId,
       error: err instanceof Error ? err.message : String(err),
     });
@@ -355,8 +435,50 @@ async function revokeAgent(
     }
   }
 
-  daemonLog.info("agent revoked", { agentId, removed, credentialsDeleted });
-  return { agentId, removed, credentialsDeleted };
+  // Disk steps are independent and best-effort: a failure at one step logs a
+  // warning but does not prevent the next (matches `deleteCredentials`).
+  let stateDeleted = false;
+  let workspaceDeleted = false;
+  if (deleteWorkspace) {
+    // Workspace deletion subsumes state — remove the whole agent home.
+    const home = agentHomeDir(agentId);
+    try {
+      if (existsSync(home)) {
+        rmSync(home, { recursive: true, force: true });
+        workspaceDeleted = true;
+        stateDeleted = true;
+      }
+    } catch (err) {
+      daemonLog.warn("revoke.rmWorkspace failed", {
+        agentId,
+        path: home,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  } else if (deleteState) {
+    const state = agentStateDir(agentId);
+    try {
+      if (existsSync(state)) {
+        rmSync(state, { recursive: true, force: true });
+        stateDeleted = true;
+      }
+    } catch (err) {
+      daemonLog.warn("revoke.rmState failed", {
+        agentId,
+        path: state,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  daemonLog.info("agent revoked", {
+    agentId,
+    removed,
+    credentialsDeleted,
+    stateDeleted,
+    workspaceDeleted,
+  });
+  return { agentId, removed, credentialsDeleted, stateDeleted, workspaceDeleted };
 }
 
 /** Reject paths outside the operator's home directory (plan §8.3). */
@@ -491,8 +613,52 @@ export async function reloadConfig(ctx: { gateway: Gateway }): Promise<ReloadRes
     }
   }
 
+  // Re-synthesize managed routes so `set_route` + `reload_config` actually
+  // applies at runtime (plan §10.5). User-authored `cfg.routes[]` lives in a
+  // different bucket and is unaffected.
+  try {
+    const freshCfg = loadConfig();
+    const freshAgents = resolveConfiguredAgentIds(freshCfg) ?? [];
+    const agentRuntimes = readAgentRuntimesFromCredentials(freshAgents);
+    const freshDefault = {
+      runtime: freshCfg.defaultRoute.adapter,
+      cwd: freshCfg.defaultRoute.cwd,
+    };
+    const managed = buildManagedRoutes(freshAgents, agentRuntimes, freshDefault);
+    ctx.gateway.replaceManagedRoutes(managed);
+  } catch (err) {
+    daemonLog.warn("reload_config.replaceManagedRoutes failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
   daemonLog.info("config reloaded", { added, removed });
   return { reloaded: true, added, removed };
+}
+
+/**
+ * Read cached `runtime`/`cwd` from each agent's credentials file. Missing
+ * files or malformed entries are skipped silently — callers fall back to
+ * the daemon's `defaultRoute` for those agents.
+ */
+function readAgentRuntimesFromCredentials(
+  agentIds: string[],
+): Record<string, { runtime?: string; cwd?: string }> {
+  const out: Record<string, { runtime?: string; cwd?: string }> = {};
+  for (const id of agentIds) {
+    const file = defaultCredentialsFile(id);
+    try {
+      if (!existsSync(file)) continue;
+      const creds = loadStoredCredentials(file);
+      const entry: { runtime?: string; cwd?: string } = {};
+      if (creds.runtime) entry.runtime = creds.runtime;
+      if (creds.cwd) entry.cwd = creds.cwd;
+      if (entry.runtime || entry.cwd) out[id] = entry;
+    } catch {
+      // best-effort — skip agents with unreadable credentials
+    }
+  }
+  return out;
 }
 
 /**

--- a/packages/daemon/src/working-memory.ts
+++ b/packages/daemon/src/working-memory.ts
@@ -1,16 +1,25 @@
 /**
  * Working memory — persistent, account-scoped notes injected into every turn.
  *
- * Stored at `~/.botcord/daemon/memory/{agentId}/working-memory.json`. A distinct
- * directory from the plugin's `~/.botcord/memory/{agentId}/` so daemon and
- * plugin don't step on each other — share later if we decide the semantics match.
+ * Stored at `~/.botcord/agents/{agentId}/state/working-memory.json` (the
+ * per-agent state dir owned by the daemon; see docs/daemon-agent-workspace-plan.md §8).
  *
  * Ported from plugin/src/memory.ts (dropping workspace + OpenClaw runtime
  * branches) and plugin/src/memory-protocol.ts (prompt builder).
  */
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
+import { agentStateDir } from "./agent-workspace.js";
 import { DAEMON_DIR_PATH } from "./config.js";
+import { log as daemonLog } from "./log.js";
 
 export interface WorkingMemory {
   version: 2;
@@ -40,14 +49,92 @@ const RESERVED_TAGS_RE = /<\/?(?:current_memory|section_\w+)\b[^>]*>/gi;
 
 // ── Path resolution ────────────────────────────────────────────────
 
-/** Base directory: `<DAEMON_DIR_PATH>/memory/<agentId>`. */
+/**
+ * Canonical per-agent state directory. Returns the new location
+ * (`~/.botcord/agents/{agentId}/state`). The legacy location under
+ * `~/.botcord/daemon/memory/{agentId}` is migrated lazily on first read —
+ * see §8 of the daemon-agent-workspace plan.
+ */
 export function resolveMemoryDir(agentId: string): string {
   if (!agentId) throw new Error("resolveMemoryDir: agentId is required");
+  return agentStateDir(agentId);
+}
+
+/** Legacy location retained for one-shot migration on read. */
+function legacyMemoryDir(agentId: string): string {
   return path.join(DAEMON_DIR_PATH, "memory", agentId);
 }
 
 function workingMemoryPath(agentId: string): string {
   return path.join(resolveMemoryDir(agentId), "working-memory.json");
+}
+
+function legacyWorkingMemoryPath(agentId: string): string {
+  return path.join(legacyMemoryDir(agentId), "working-memory.json");
+}
+
+// Migration conflict warnings are emitted at most once per agent per
+// process. Reset only by daemon restart — good enough for a one-release
+// transitional branch that gets removed later.
+const warnedMigrationConflict = new Set<string>();
+
+/**
+ * Resolve the path to read from, migrating from the legacy location if
+ * necessary. Returns the path the caller should read, or `null` when no
+ * memory file exists anywhere.
+ *
+ * Migration branch (the `else if` on `legacyExists` below) is meant to be
+ * deleted one release after this change ships; see plan §8 step 6.
+ */
+function resolveReadPath(agentId: string): string | null {
+  const newPath = workingMemoryPath(agentId);
+  const oldPath = legacyWorkingMemoryPath(agentId);
+  const newExists = existsSync(newPath);
+  const oldExists = existsSync(oldPath);
+
+  if (newExists) {
+    if (oldExists && !warnedMigrationConflict.has(agentId)) {
+      warnedMigrationConflict.add(agentId);
+      daemonLog.warn("working-memory: both new and legacy paths exist; using new", {
+        agentId,
+        oldPath,
+        newPath,
+      });
+    }
+    return newPath;
+  }
+  if (oldExists) {
+    try {
+      mkdirSync(path.dirname(newPath), { recursive: true, mode: 0o700 });
+      try {
+        renameSync(oldPath, newPath);
+      } catch (err) {
+        // EXDEV = legacy and new paths live on different filesystems
+        // (bind mounts, tmpfs overlays). `renameSync` cannot cross fs
+        // boundaries, so fall back to copy + unlink. Without this, the
+        // next write would go to newPath while legacy still has the old
+        // payload — silent divergence the reviewer of §8 flagged.
+        if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+          copyFileSync(oldPath, newPath);
+          unlinkSync(oldPath);
+        } else {
+          throw err;
+        }
+      }
+      return newPath;
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      daemonLog.warn("working-memory: migration rename failed; reading legacy path", {
+        agentId,
+        oldPath,
+        newPath,
+        code: e.code,
+        error: e.message ?? String(err),
+      });
+      return oldPath;
+    }
+  }
+  return null;
 }
 
 // ── File I/O ───────────────────────────────────────────────────────
@@ -100,8 +187,8 @@ function normalize(raw: unknown): WorkingMemory | null {
 }
 
 export function readWorkingMemory(agentId: string): WorkingMemory | null {
-  const p = workingMemoryPath(agentId);
-  if (!existsSync(p)) return null;
+  const p = resolveReadPath(agentId);
+  if (!p) return null;
   return normalize(readJson<unknown>(p));
 }
 

--- a/packages/protocol-core/src/control-frame.ts
+++ b/packages/protocol-core/src/control-frame.ts
@@ -126,6 +126,33 @@ export interface RevokeAgentParams {
   agentId: string;
   /** When true, the credentials file on disk is deleted (default: true). */
   deleteCredentials?: boolean;
+  /**
+   * When true, the per-agent state directory (`~/.botcord/agents/{id}/state/`)
+   * is removed after credentials cleanup. Default semantics = value of
+   * `deleteCredentials` (default applied by the daemon, not here).
+   */
+  deleteState?: boolean;
+  /**
+   * When true, the per-agent workspace directory
+   * (`~/.botcord/agents/{id}/workspace/`) is removed. Default false
+   * (applied by the daemon). User-authored memory/notes are preserved
+   * by default and require explicit opt-in to delete.
+   */
+  deleteWorkspace?: boolean;
+}
+
+/**
+ * Result shape returned via `ControlAck.result` from a `revoke_agent`
+ * frame. Each `*Deleted` flag reflects whether the corresponding disk
+ * step actually completed — best-effort cleanup, so a `false` may mean
+ * "not requested" or "failed and logged". See plan §11.3.
+ */
+export interface RevokeAgentResult {
+  agentId: string;
+  removed: boolean;
+  credentialsDeleted: boolean;
+  stateDeleted: boolean;
+  workspaceDeleted: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Every provisioned agent now has a dedicated `~/.botcord/agents/{agentId}/` tree (`workspace/` seeded with `AGENTS.md` / `CLAUDE.md` / `identity.md` / `memory.md` / `task.md` / `notes/`; `state/working-memory.json` owned by the daemon, migrated from `~/.botcord/daemon/memory/`).
- Runtime `cwd` now defaults to the per-agent workspace. Operators who want project-tree editing must set an explicit `cfg.routes[]` entry.
- Synthesized per-agent routes moved out of `cfg.routes[]` into a daemon-managed `managedRoutes` bucket on the Gateway — user routes are never touched by add/remove/reload bookkeeping. Router order: `cfg.routes → managedRoutes → defaultRoute`.
- `revoke_agent` gains `deleteState` / `deleteWorkspace` flags; vanilla revoke preserves LLM-authored workspace content by default.

Implementation follows `docs/daemon-agent-workspace-plan.md` sections §6 – §12. Release-notes draft at `docs/daemon-agent-workspace-release-notes.md` (Codex `-s workspace-write` sandbox surface shrinks from `$HOME` to the per-agent workspace — worth flagging in the changelog).

Security hardening landed alongside: `agentId` is regex-validated at every path builder (prevents `revoke_agent(deleteWorkspace:true)` from `rm -rf`-ing outside `agents/`); `mkdirTolerant` re-applies `0o700` to pre-existing dirs; working-memory migration handles `EXDEV` via copy+unlink so bind-mount setups don't silently diverge.

## Test plan

- [x] `cd packages/daemon && npm test` — **360 passed / 28 files** (baseline was 303)
- [x] `cd packages/daemon && npm run build` — production `tsc` clean
- [x] `npx tsc --noEmit` — only pre-existing error in `runtime-discovery.test.ts` (present on `main`)
- [ ] Smoke test: `botcord-daemon` boot on a machine with existing legacy agents → verify `~/.botcord/agents/{id}/workspace/` is seeded without touching credentials, and `~/.botcord/agents/{id}/state/working-memory.json` appears on next memory write (migrated from legacy path)
- [ ] Smoke test: provision a fresh agent without `cwd` → verify credentials.cwd is the workspace dir; run a turn → verify cwd is respected
- [ ] Smoke test: `revoke_agent` with no flags → credentials + state deleted, workspace preserved; `deleteWorkspace:true` → entire agent home gone
- [ ] Hub-side follow-up: add `deleteState` / `deleteWorkspace` to the `revoke_agent` allowlist (§11.2 — not in this repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)