### PR TITLE
fix(frontend): route CreateAgentDialog through /me/agents/provision BFF

### DIFF
--- a/frontend/src/app/api/users/me/agents/provision/route.ts
+++ b/frontend/src/app/api/users/me/agents/provision/route.ts
@@ -1,0 +1,23 @@
+/**
+ * [INPUT]: Supabase user session, provision body {daemon_instance_id, label, runtime, cwd?, bio?}
+ * [OUTPUT]: POST /api/users/me/agents/provision — forwards to backend /api/users/me/agents/provision
+ * [POS]: BFF endpoint backing CreateAgentDialog — creates a user-owned Agent row on the Hub and
+ *        ships the Hub-generated credentials to the daemon via the provision_agent control frame.
+ * [PROTOCOL]: update header on changes
+ */
+
+import { NextResponse } from "next/server";
+import { proxyDaemon } from "../../../../daemon/_lib/proxy";
+
+export async function POST(req: Request): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+  return proxyDaemon("/api/users/me/agents/provision", {
+    method: "POST",
+    body,
+  });
+}

--- a/frontend/src/store/useDaemonStore.ts
+++ b/frontend/src/store/useDaemonStore.ts
@@ -286,42 +286,47 @@ export const useDaemonStore = create<DaemonState>()((set, get) => ({
   },
 
   provisionAgent: async (daemonId, input) => {
-    const params: Record<string, unknown> = {};
-    if (input.name) params.name = input.name;
-    if (input.bio) params.bio = input.bio;
-    if (input.runtime) params.runtime = input.runtime;
-    if (input.cwd) params.cwd = input.cwd;
+    // Hub owns keypair generation + DB insert; the backend ships the
+    // credential envelope to the daemon via the provision_agent control
+    // frame. The raw /dispatch path cannot be used here because it
+    // bypasses the Agent/SigningKey insert and leaves the new identity
+    // unclaimed in the registry.
+    const label = (input.name ?? "").trim() || `agent-${Date.now()}`;
+    const body: Record<string, unknown> = {
+      daemon_instance_id: daemonId,
+      label,
+    };
+    if (input.runtime) body.runtime = input.runtime;
+    if (input.cwd) body.cwd = input.cwd;
+    if (input.bio) body.bio = input.bio;
 
-    const res = await fetch(
-      `/api/daemon/instances/${encodeURIComponent(daemonId)}/dispatch`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ type: "provision_agent", params }),
-      },
-    );
+    const res = await fetch("/api/users/me/agents/provision", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
     if (!res.ok) {
+      const detail = await parseError(res);
       if (res.status === 409) {
-        throw new ProvisionAgentError("daemon_offline");
+        if (detail === "daemon_offline") {
+          throw new ProvisionAgentError("daemon_offline");
+        }
+        throw new ProvisionAgentError("http_error", detail);
       }
       if (res.status === 504) {
         throw new ProvisionAgentError("daemon_timeout");
       }
-      throw new ProvisionAgentError("http_error", await parseError(res));
+      if (res.status === 502) {
+        throw new ProvisionAgentError("daemon_failed", detail);
+      }
+      throw new ProvisionAgentError("http_error", detail);
     }
-    const data = await res.json().catch(() => null);
-    const ack = data?.ack as { ok?: boolean; result?: unknown; error?: { message?: string } } | undefined;
-    if (!ack || ack.ok !== true) {
-      const detail =
-        typeof ack?.error?.message === "string" ? ack.error.message : undefined;
-      throw new ProvisionAgentError("daemon_failed", detail);
-    }
-    const result = (ack.result ?? {}) as Record<string, unknown>;
+    const data = (await res.json().catch(() => null)) as Record<string, unknown> | null;
     const agentId =
-      typeof result.agentId === "string"
-        ? result.agentId
-        : typeof result.agent_id === "string"
-          ? (result.agent_id as string)
+      typeof data?.agent_id === "string"
+        ? (data.agent_id as string)
+        : typeof data?.agentId === "string"
+          ? (data.agentId as string)
           : null;
     if (!agentId) {
       throw new ProvisionAgentError("missing_agent_id");


### PR DESCRIPTION
## Summary

- `CreateAgentDialog` 之前通过 `useDaemonStore.provisionAgent` 打 `/api/daemon/instances/{id}/dispatch`，后端这条路径只是把 `provision_agent` 控制帧透传给 daemon，**完全不写 DB**。
- daemon 收到不带 `credentials` 字段的帧后，回退到 `/registry/agents` 匿名注册：DB 里生成的 Agent 行 `user_id=NULL`，只有 `claim_code`，所以"我的 agent"里查不到——表现为"本地身份建好了但 DB 里没有"。
- 本 PR 切到正确的 BFF `/api/users/me/agents/provision`：Hub 生成 keypair、插入 `Agent(user_id=ctx.user_id)` + `SigningKey` + wallet + role，再把完整 credentials envelope 通过 `provision_agent` 帧交给 daemon 落盘；daemon ack 失败时后端 `db.rollback()` 不留孤儿行。

## Changes

- 新增 `frontend/src/app/api/users/me/agents/provision/route.ts` —— 前端 BFF，转发到后端 `/api/users/me/agents/provision`。
- `frontend/src/store/useDaemonStore.ts` —— `provisionAgent` 改走新路由；请求体对齐后端 `ProvisionAgentBody { daemon_instance_id, label, runtime, cwd?, bio? }`；`409 / 502 / 504` 分别映射到 `daemon_offline / daemon_failed / daemon_timeout`。
- `CreateAgentDialog.tsx` 不需要动，store 的对外契约 `{agentId}` 不变。
- 旧的 `/api/daemon/instances/[id]/dispatch` 保留给未来其它 control-plane 场景。

## Test plan

- [ ] Dashboard → Create Agent：选在线 daemon + runtime，输入名字，提交
- [ ] 后端 `agents` 表新行：`user_id = 当前用户`、`display_name = label`、对应的 `signing_keys` 行 `state = active`
- [ ] daemon `~/.botcord/credentials/ag_*.json` 落盘，新 agent 立即出现在用户 agent 列表
- [ ] 错误路径：daemon 离线 → `daemon_offline` 提示；ack 失败 → DB 不残留 Agent 行
- [ ] 已有的匿名遗留身份（`he` / `test cc` / `12`）不受影响，可按需单独清理

🤖 Generated with [Claude Code](https://claude.com/claude-code)