### PR TITLE
feat(human-first): contact-request state filters + invite concurrency + subscription gate

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -494,38 +494,51 @@ async def send_contact_request(
         raise HTTPException(status_code=409, detail="Already in contacts")
 
     # ------------------------------------------------------------------
-    # Existing request in EITHER direction blocks a new pending request.
-    # A previously-rejected request in the same direction may be reused
-    # (transition rejected → pending) for the "resend after reject" flow.
+    # Explicit state filters (W4):
+    #   * Forward (me→target) where state != rejected → 409
+    #   * Reverse (target→me) pending → 409 with "accept incoming" hint
+    #   * Forward (me→target) rejected → reuse row (resend)
     # ------------------------------------------------------------------
-    existing_forward = await db.execute(
-        select(ContactRequest).where(
-            ContactRequest.from_agent_id == agent_id,
-            ContactRequest.from_type == ParticipantType.agent,
-            ContactRequest.to_agent_id == to_id,
-            ContactRequest.to_type == to_type,
-        )
-    )
-    req = existing_forward.scalar_one_or_none()
-
     existing_reverse = await db.execute(
         select(ContactRequest).where(
             ContactRequest.from_agent_id == to_id,
             ContactRequest.from_type == to_type,
             ContactRequest.to_agent_id == agent_id,
             ContactRequest.to_type == ParticipantType.agent,
-            ContactRequest.state.in_(
-                [ContactRequestState.pending, ContactRequestState.accepted]
-            ),
+            ContactRequest.state == ContactRequestState.pending,
         )
     )
     if existing_reverse.scalar_one_or_none() is not None:
+        raise HTTPException(
+            status_code=409,
+            detail="Incoming contact request exists — accept it instead",
+        )
+
+    existing_forward_active = await db.execute(
+        select(ContactRequest).where(
+            ContactRequest.from_agent_id == agent_id,
+            ContactRequest.from_type == ParticipantType.agent,
+            ContactRequest.to_agent_id == to_id,
+            ContactRequest.to_type == to_type,
+            ContactRequest.state != ContactRequestState.rejected,
+        )
+    )
+    if existing_forward_active.scalar_one_or_none() is not None:
         raise HTTPException(status_code=409, detail="Contact request already exists")
 
+    existing_forward_rejected = await db.execute(
+        select(ContactRequest).where(
+            ContactRequest.from_agent_id == agent_id,
+            ContactRequest.from_type == ParticipantType.agent,
+            ContactRequest.to_agent_id == to_id,
+            ContactRequest.to_type == to_type,
+            ContactRequest.state == ContactRequestState.rejected,
+        )
+    )
+    req = existing_forward_rejected.scalar_one_or_none()
+
     if req is not None:
-        if req.state in (ContactRequestState.pending, ContactRequestState.accepted):
-            raise HTTPException(status_code=409, detail="Contact request already exists")
-        # Rejected — allow resend
+        # Resend after reject — reuse the existing row.
         req.state = ContactRequestState.pending
         req.message = body.message
         req.resolved_at = None

--- a/backend/app/routers/humans.py
+++ b/backend/app/routers/humans.py
@@ -29,15 +29,18 @@ from hub.enums import (
     ApprovalKind,
     ApprovalState,
     ContactRequestState,
+    MessagePolicy,
     ParticipantType,
     RoomJoinPolicy,
     RoomRole,
     RoomVisibility,
+    SubscriptionStatus,
 )
 from hub.id_generators import generate_human_id, generate_room_id
 from hub.models import (
     Agent,
     AgentApprovalQueue,
+    AgentSubscription,
     Contact,
     ContactRequest,
     Room,
@@ -418,7 +421,14 @@ async def invite_room_member_as_human(
     user = await _load_human(db, ctx)
     me = user.human_id
 
-    room_row = await db.execute(select(Room).where(Room.room_id == room_id))
+    # Serialize concurrent invites for this room (C4): lock the room row
+    # up front so counting + inserting cannot race against a sibling call.
+    # On SQLite this with_for_update() is a no-op (no row-level locks), so
+    # we still rely on the unique (room_id, agent_id) constraint as a
+    # correctness backstop via IntegrityError below.
+    room_row = await db.execute(
+        select(Room).where(Room.room_id == room_id).with_for_update()
+    )
     room = room_row.scalar_one_or_none()
     if room is None:
         raise HTTPException(status_code=404, detail="Room not found")
@@ -445,17 +455,19 @@ async def invite_room_member_as_human(
         raise HTTPException(status_code=409, detail="Already a member")
 
     # Verify the target exists in the appropriate registry.
+    target_agent: Agent | None = None
     if participant_type == ParticipantType.agent:
-        target = await db.execute(
+        target_row = await db.execute(
             select(Agent).where(Agent.agent_id == participant_id)
         )
-        if target.scalar_one_or_none() is None:
+        target_agent = target_row.scalar_one_or_none()
+        if target_agent is None:
             raise HTTPException(status_code=404, detail="Agent not found")
     else:
-        target = await db.execute(
+        target_user_row = await db.execute(
             select(User).where(User.human_id == participant_id)
         )
-        if target.scalar_one_or_none() is None:
+        if target_user_row.scalar_one_or_none() is None:
             raise HTTPException(status_code=404, detail="Human not found")
 
     # Duplicate check — the unique constraint is (room_id, agent_id) but
@@ -469,6 +481,95 @@ async def invite_room_member_as_human(
     if existing.scalar_one_or_none() is not None:
         raise HTTPException(status_code=409, detail="Already a member")
 
+    # Order of checks mirrors hub/routers/room.py::add_member exactly:
+    # 1) contacts_only admission  2) claimed-agent approval queue
+    # 3) subscription gate        4) max_members  5) insert
+    # Keeping these in the same order as the hub router prevents subtle
+    # divergence (e.g. a contacts_only target being 403'd on the sub-gate
+    # before its owner had a chance to approve/reject via the queue).
+
+    # --- W2: admission policy (contacts_only, agent targets only) ---------
+    if target_agent is not None and target_agent.message_policy == MessagePolicy.contacts_only:
+        contact_row = await db.execute(
+            select(Contact).where(
+                Contact.owner_id == participant_id,
+                Contact.owner_type == ParticipantType.agent,
+                Contact.contact_agent_id == me,
+            )
+        )
+        if contact_row.scalar_one_or_none() is None:
+            raise HTTPException(
+                status_code=403,
+                detail="admission_denied_target_contacts_only",
+            )
+
+    # --- C2: claimed-agent approval queue (agent targets only) ------------
+    if (
+        target_agent is not None
+        and target_agent.user_id is not None
+        and target_agent.user_id != ctx.user_id
+    ):
+        from fastapi.responses import JSONResponse
+
+        entry = AgentApprovalQueue(
+            agent_id=participant_id,
+            owner_user_id=target_agent.user_id,
+            kind=ApprovalKind.room_invite,
+            payload_json=json.dumps(
+                {
+                    "room_id": room_id,
+                    "invited_by": me,
+                    "invited_by_type": ParticipantType.human.value,
+                    "role": body.role,
+                }
+            ),
+            state=ApprovalState.pending,
+        )
+        db.add(entry)
+        await db.commit()
+        await db.refresh(entry)
+        return JSONResponse(
+            {"status": "pending_approval", "approval_id": str(entry.id)},
+            status_code=202,
+        )
+
+    # --- W3: subscription gate (applies to both agent and human invitees) -
+    # Limitation: there is no human-side subscription concept yet, so a
+    # Human invitee can only enter a sub-gated room when they are the
+    # room's own owner (which is always admitted).
+    if room.required_subscription_product_id:
+        if participant_type == ParticipantType.agent:
+            # Owner of the room (if this agent happens to be the owner_id)
+            # bypasses — matches hub's _ensure_subscription_room_access.
+            if participant_id != room.owner_id:
+                sub_row = await db.execute(
+                    select(AgentSubscription).where(
+                        AgentSubscription.product_id == room.required_subscription_product_id,
+                        AgentSubscription.subscriber_agent_id == participant_id,
+                        AgentSubscription.status == SubscriptionStatus.active,
+                    )
+                )
+                if sub_row.scalar_one_or_none() is None:
+                    raise HTTPException(
+                        status_code=403,
+                        detail="Active subscription required to join this room",
+                    )
+        else:
+            # Human invitee: the owning Human of a sub-gated room is always
+            # admitted (they created the gate, they are not expected to pay
+            # themselves). All other Humans are blocked until a human-side
+            # subscription model exists.
+            is_owner_self_seat = (
+                room.owner_type == ParticipantType.human
+                and participant_id == room.owner_id
+            )
+            if not is_owner_self_seat:
+                raise HTTPException(
+                    status_code=403,
+                    detail="subscription-gated rooms do not yet support human members",
+                )
+
+    # --- C4: max_members check now runs under the row lock ----------------
     if room.max_members is not None:
         current_count_row = await db.execute(
             select(RoomMember).where(RoomMember.room_id == room_id)
@@ -491,6 +592,24 @@ async def invite_room_member_as_human(
         await db.rollback()
         raise HTTPException(status_code=409, detail="Already a member")
     await db.refresh(new_member)
+
+    # --- W4: realtime broadcast (mirror hub's add_member) -----------------
+    try:
+        from hub.routers.room import _notify_room_member_change
+
+        members_row = await db.execute(
+            select(RoomMember.agent_id).where(RoomMember.room_id == room_id)
+        )
+        all_member_ids = [row[0] for row in members_row.all()]
+        await _notify_room_member_change(
+            db,
+            event_type="room_member_added",
+            room_id=room_id,
+            changed_agent_id=participant_id,
+            notify_agent_ids=all_member_ids,
+        )
+    except Exception:  # pragma: no cover — notification must not break the HTTP response
+        _logger.exception("room_member_added broadcast failed for %s", room_id)
 
     return HumanRoomMemberResponse(
         room_id=new_member.room_id,
@@ -602,15 +721,60 @@ async def send_contact_request(
             )
 
     # Fall-through: unclaimed Agent or peer Human → plain ContactRequest.
-    dup_req = await db.execute(
+    #
+    # Mirror the three-branch state-machine from
+    # ``app/routers/dashboard.py::send_contact_request``:
+    #   (a) reverse-pending (target→me AND pending) → 409 hint to accept incoming
+    #   (b) forward-active (me→target AND state != rejected) → already_requested
+    #   (c) forward-rejected (me→target AND state == rejected) → resend by
+    #       flipping the existing row back to pending
+    # TODO: share with dashboard.py — logic duplicated intentionally to keep
+    # this patch narrow; extract into _contact_utils.py when touched again.
+    reverse_pending = await db.execute(
         select(ContactRequest).where(
-            ContactRequest.from_agent_id == me,
-            ContactRequest.to_agent_id == peer_id,
+            ContactRequest.from_agent_id == peer_id,
+            ContactRequest.from_type == peer_type,
+            ContactRequest.to_agent_id == me,
+            ContactRequest.to_type == ParticipantType.human,
             ContactRequest.state == ContactRequestState.pending,
         )
     )
-    if dup_req.scalar_one_or_none() is not None:
+    if reverse_pending.scalar_one_or_none() is not None:
+        raise HTTPException(
+            status_code=409,
+            detail="Incoming contact request exists — accept it instead",
+        )
+
+    forward_active = await db.execute(
+        select(ContactRequest).where(
+            ContactRequest.from_agent_id == me,
+            ContactRequest.from_type == ParticipantType.human,
+            ContactRequest.to_agent_id == peer_id,
+            ContactRequest.to_type == peer_type,
+            ContactRequest.state != ContactRequestState.rejected,
+        )
+    )
+    if forward_active.scalar_one_or_none() is not None:
         return ContactRequestResponse(status="already_requested")
+
+    forward_rejected = await db.execute(
+        select(ContactRequest).where(
+            ContactRequest.from_agent_id == me,
+            ContactRequest.from_type == ParticipantType.human,
+            ContactRequest.to_agent_id == peer_id,
+            ContactRequest.to_type == peer_type,
+            ContactRequest.state == ContactRequestState.rejected,
+        )
+    )
+    req = forward_rejected.scalar_one_or_none()
+    if req is not None:
+        # Resend after reject — reuse the existing row.
+        req.state = ContactRequestState.pending
+        req.message = body.message
+        req.resolved_at = None
+        await db.commit()
+        await db.refresh(req)
+        return ContactRequestResponse(status="requested", request_id=str(req.id))
 
     req = ContactRequest(
         from_agent_id=me,
@@ -660,10 +824,40 @@ async def _serialise_contact_requests(
     db: AsyncSession,
     rows: list[ContactRequest],
 ) -> list[HumanContactRequestSummary]:
+    # Batch display-name resolution: collect unique (type, id) pairs across
+    # every row, issue one query per participant type, then serialise via a
+    # lookup dict. Mirrors ``app/routers/dashboard.py::_resolve_display_names``.
+    agent_ids: set[str] = set()
+    human_ids: set[str] = set()
+    for req in rows:
+        if req.from_type == ParticipantType.agent:
+            agent_ids.add(req.from_agent_id)
+        else:
+            human_ids.add(req.from_agent_id)
+        if req.to_type == ParticipantType.agent:
+            agent_ids.add(req.to_agent_id)
+        else:
+            human_ids.add(req.to_agent_id)
+
+    name_lookup: dict[tuple[ParticipantType, str], str | None] = {}
+    if agent_ids:
+        agent_rows = await db.execute(
+            select(Agent.agent_id, Agent.display_name).where(Agent.agent_id.in_(agent_ids))
+        )
+        for aid, name in agent_rows.all():
+            name_lookup[(ParticipantType.agent, aid)] = name
+    if human_ids:
+        human_rows = await db.execute(
+            select(User.human_id, User.display_name).where(User.human_id.in_(human_ids))
+        )
+        for hid, name in human_rows.all():
+            if hid is not None:
+                name_lookup[(ParticipantType.human, hid)] = name
+
     summaries: list[HumanContactRequestSummary] = []
     for req in rows:
-        from_name = await _resolve_participant_display_name(db, req.from_agent_id, req.from_type)
-        to_name = await _resolve_participant_display_name(db, req.to_agent_id, req.to_type)
+        from_name = name_lookup.get((req.from_type, req.from_agent_id))
+        to_name = name_lookup.get((req.to_type, req.to_agent_id))
         summaries.append(
             HumanContactRequestSummary(
                 id=str(req.id),
@@ -772,37 +966,31 @@ async def accept_contact_request_as_human(
 
     req.state = ContactRequestState.accepted
     req.resolved_at = _now()
+    await db.flush()
 
-    # Forward contact: to ← from
-    db.add(
-        Contact(
-            owner_id=req.to_agent_id,
-            owner_type=req.to_type,
-            contact_agent_id=req.from_agent_id,
-            peer_type=req.from_type,
-        )
-    )
-    # Mirror contact: from ← to
-    db.add(
-        Contact(
-            owner_id=req.from_agent_id,
-            owner_type=req.from_type,
-            contact_agent_id=req.to_agent_id,
-            peer_type=req.to_type,
-        )
-    )
-    try:
-        await db.commit()
-    except IntegrityError:
-        # One or both Contact rows already exist — finalise state-only.
-        await db.rollback()
-        result2 = await db.execute(
-            select(ContactRequest).where(ContactRequest.id == request_id)
-        )
-        req = result2.scalar_one()
-        req.state = ContactRequestState.accepted
-        req.resolved_at = _now()
-        await db.commit()
+    # Insert each direction in its own savepoint so a collision on one side
+    # does not erase the other (C3). Pattern mirrored from
+    # hub/routers/contact_requests.py::accept flow.
+    for owner_id, owner_type, contact_id, peer_type in (
+        (req.to_agent_id, req.to_type, req.from_agent_id, req.from_type),
+        (req.from_agent_id, req.from_type, req.to_agent_id, req.to_type),
+    ):
+        try:
+            async with db.begin_nested():
+                db.add(
+                    Contact(
+                        owner_id=owner_id,
+                        owner_type=owner_type,
+                        contact_agent_id=contact_id,
+                        peer_type=peer_type,
+                    )
+                )
+                await db.flush()
+        except IntegrityError:
+            # Row already exists — keep the other direction intact.
+            pass
+
+    await db.commit()
 
     return HumanContactRequestResolveResponse(id=str(req.id), state="accepted")
 

--- a/backend/hub/routers/room.py
+++ b/backend/hub/routers/room.py
@@ -246,9 +246,12 @@ def _require_membership(room: Room, agent_id: str) -> RoomMember:
     for m in room.members:
         if m.agent_id != agent_id:
             continue
-        # Only match the agent-type row. Pre-Human-first the attribute
-        # does not exist; ``getattr`` default keeps old behaviour.
-        if getattr(m, "participant_type", "agent") != "agent":
+        # Only match the agent-type row. Pre-Human-first the attribute is
+        # absent; legacy rows (and tests that bypass model defaults) can
+        # also leave ``participant_type`` NULL — both count as 'agent'.
+        # Explicit 'human' is still excluded.
+        ptype = getattr(m, "participant_type", None)
+        if ptype is not None and ptype != "agent" and getattr(ptype, "value", None) != "agent":
             continue
         return m
     raise I18nHTTPException(status_code=403, message_key="not_a_member")

--- a/backend/tests/test_hub_room_human_guard.py
+++ b/backend/tests/test_hub_room_human_guard.py
@@ -128,96 +128,84 @@ async def test_agent_can_invite_in_human_owned_room_with_default_invite(
     client: AsyncClient,
     db_session,
 ):
-    """Simulate a human-owned room: an agent that is a member (not the
-    owner) with ``default_invite=True`` must be able to invite another
-    agent without crashing and without needing owner/admin role.
+    """Human-owned room: an agent member (not owner) with ``default_invite=True``
+    must be able to invite another agent — no monkey-patching.
 
-    We build this state directly against the DB to avoid depending on the
-    /api/humans BFF layer (which may not be present on every branch). We
-    defensively set ``owner_type``/``participant_type`` via ``setattr`` so
-    the test works both pre- and post-Human-first merge.
+    We build the state directly: create a User with a ``human_id``, a Room
+    with ``owner_type='human'`` and ``owner_id=<hu_*>``, and seat alice as
+    a plain agent-type member.
     """
-    from hub.models import Room, RoomMember, RoomRole, RoomVisibility, RoomJoinPolicy
+    import uuid
+
+    from hub.models import (
+        ParticipantType,
+        Room,
+        RoomJoinPolicy,
+        RoomMember,
+        RoomRole,
+        RoomVisibility,
+        User,
+    )
+    from hub.id_generators import generate_human_id, generate_room_id
 
     # Two agents — alice (member, will invite) and bob (to be invited).
     _sk_a, alice_id, _a_key, alice_token = await _create_agent(client, "alice")
     _sk_b, bob_id, _b_key, _bob_token = await _create_agent(client, "bob")
 
-    # Build a synthetic human-owned room. We use a ``hu_*`` id for the
-    # owner_id column. The column is an FK to agents on pre-merge schemas,
-    # so we insert it through raw SQL and accept that the FK may or may
-    # not be present — if the FK is still tight this test becomes a no-op
-    # and skips.
-    from sqlalchemy import text
-    from hub.id_generators import generate_room_id
-
-    room_id = generate_room_id()
+    # Create a real human owner (User row + hu_* id). Skip if the schema
+    # cannot accept a human-owned room (e.g. pre-merge FK still tight).
+    human_id = generate_human_id()
     try:
-        await db_session.execute(
-            text(
-                "INSERT INTO rooms (room_id, name, description, owner_id, "
-                "visibility, join_policy, default_send, default_invite, max_members) "
-                "VALUES (:room_id, :name, :description, :owner_id, "
-                ":visibility, :join_policy, :default_send, :default_invite, :max_members)"
-            ),
-            {
-                "room_id": room_id,
-                "name": "Human Room",
-                "description": "",
-                # Pre-merge: owner_id FK to agents.agent_id — we can only
-                # simulate "human owner" if we drop the FK constraint.
-                # When FK is present, use alice_id as a stand-in and set
-                # owner_type='human' via attribute assignment below so
-                # _room_owner_is_human() returns True.
-                "owner_id": alice_id,
-                "visibility": "public",
-                "join_policy": "invite_only",
-                "default_send": True,
-                "default_invite": True,
-                "max_members": None,
-            },
+        owner_user = User(
+            id=uuid.uuid4(),
+            supabase_user_id=uuid.uuid4(),
+            email=f"owner-{human_id}@example.com",
+            display_name="Room Owner",
+            status="active",
+            human_id=human_id,
         )
+        db_session.add(owner_user)
+        await db_session.flush()
+
+        room = Room(
+            room_id=generate_room_id(),
+            name="Human Room",
+            description="",
+            owner_id=human_id,
+            owner_type=ParticipantType.human,
+            visibility=RoomVisibility.public,
+            join_policy=RoomJoinPolicy.invite_only,
+            default_send=True,
+            default_invite=True,
+        )
+        db_session.add(room)
+        await db_session.flush()
     except Exception:
+        await db_session.rollback()
         pytest.skip("Cannot synthesise human-owned room on this schema")
 
-    # Alice joins as a plain member (not owner).
-    await db_session.execute(
-        text(
-            "INSERT INTO room_members (room_id, agent_id, role, muted) "
-            "VALUES (:room_id, :agent_id, :role, :muted)"
-        ),
-        {
-            "room_id": room_id,
-            "agent_id": alice_id,
-            "role": "member",
-            "muted": False,
-        },
+    # Alice joins as a plain agent-type member (not owner).
+    db_session.add(
+        RoomMember(
+            room_id=room.room_id,
+            agent_id=alice_id,
+            participant_type=ParticipantType.agent,
+            role=RoomRole.member,
+        )
     )
     await db_session.commit()
 
-    # Patch the Room instance to report owner_type='human' so the
-    # permission helpers treat it as a human-owned room. We monkey-patch
-    # the attribute lookup via a SQLAlchemy event — or more simply, we
-    # override it by setting the attribute after load via a router
-    # helper. Easiest path: set it as a class-level default for this test.
-    # Since _room_owner_is_human uses getattr(room, 'owner_type', 'agent'),
-    # we can expose a 'owner_type' attribute at the instance level.
-    from hub.routers import room as room_router
+    room_id = room.room_id
 
-    original_is_human = room_router._room_owner_is_human
-    room_router._room_owner_is_human = lambda _room: True  # type: ignore[assignment]
-    try:
-        # Alice invites Bob. Alice is role='member' but default_invite=True.
-        resp = await client.post(
-            f"/hub/rooms/{room_id}/members",
-            json={"agent_id": bob_id},
-            headers=_auth_header(alice_token),
-        )
-        # Should succeed — default_invite=True lets any agent member invite.
-        assert resp.status_code == 201, resp.text
-        data = resp.json()
-        member_ids = {m["agent_id"] for m in data["members"]}
-        assert alice_id in member_ids
-        assert bob_id in member_ids
-    finally:
-        room_router._room_owner_is_human = original_is_human  # type: ignore[assignment]
+    # Alice invites Bob. Alice is role='member' but default_invite=True,
+    # and the real owner_type='human' drives _room_owner_is_human() natively.
+    resp = await client.post(
+        f"/hub/rooms/{room_id}/members",
+        json={"agent_id": bob_id},
+        headers=_auth_header(alice_token),
+    )
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    member_ids = {m["agent_id"] for m in data["members"]}
+    assert alice_id in member_ids
+    assert bob_id in member_ids

--- a/frontend/src/components/dashboard/AddFriendModal.tsx
+++ b/frontend/src/components/dashboard/AddFriendModal.tsx
@@ -127,16 +127,10 @@ function SearchPane({ onClose }: { onClose: () => void }) {
       const trimmedMsg = message.trim() || undefined;
 
       // Agent → Human goes to /api/dashboard/contact-requests with the
-      // polymorphic `to_human_id` field. `api.createContactRequest` is
-      // typed for the legacy `{ to_agent_id, message }` shape and owned by
-      // another agent; we cast to send the extended body without touching
-      // that declaration. If backend settles on `to_id`+`to_type` instead,
-      // adjust the cast here.
+      // polymorphic `to_human_id` field; A→A keeps `to_agent_id`.
+      // `createContactRequest` accepts the tagged-union body directly.
       const agentPayload = targetIsHuman
-        ? ({ to_human_id: targetId, message: trimmedMsg } as unknown as {
-            to_agent_id: string;
-            message?: string;
-          })
+        ? { to_human_id: targetId, message: trimmedMsg }
         : { to_agent_id: targetId, message: trimmedMsg };
 
       const res =

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -464,7 +464,23 @@ export const api = {
     return apiGet<ContactRequestListResponse>("/api/dashboard/contact-requests/sent", params);
   },
 
-  createContactRequest(payload: { to_agent_id: string; message?: string }) {
+  createContactRequest(
+    payload:
+      | { to_agent_id: string; to_human_id?: undefined; message?: string }
+      | { to_human_id: string; to_agent_id?: undefined; message?: string },
+  ) {
+    // Runtime guard: exactly one of to_agent_id / to_human_id must be set.
+    const hasAgent = Boolean(
+      (payload as { to_agent_id?: string }).to_agent_id,
+    );
+    const hasHuman = Boolean(
+      (payload as { to_human_id?: string }).to_human_id,
+    );
+    if (hasAgent === hasHuman) {
+      throw new Error(
+        "createContactRequest: provide exactly one of to_agent_id or to_human_id",
+      );
+    }
     return apiPost<ContactRequestItem>("/api/dashboard/contact-requests", payload);
   },
 

--- a/frontend/src/store/useDashboardSessionStore.ts
+++ b/frontend/src/store/useDashboardSessionStore.ts
@@ -154,14 +154,20 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
 
   setViewMode: (mode) =>
     set((state) => {
-      // Keep the richer activeIdentity field in-sync with the legacy
-      // viewMode toggle. When switching to "human" we forget the agent
-      // identity; when switching to "agent" we materialize one from the
-      // active agent id (if any).
+      // W1: when switching to "human" without a loaded hu_* id, refuse to
+      // change mode (previously fell back to Supabase UUID, which broke any
+      // hu_*-aware check downstream). Caller should await humansApi.createOrGet()
+      // first. Agent-direction is unchanged.
       let nextIdentity: ActiveIdentity | null = state.activeIdentity;
       if (mode === "human") {
-        const humanId = state.human?.human_id ?? state.user?.id ?? null;
-        nextIdentity = humanId ? { type: "human", id: humanId } : null;
+        const humanId = state.human?.human_id ?? null;
+        if (!humanId) {
+          console.warn(
+            "[SessionStore] setViewMode('human') ignored — no human.human_id loaded yet",
+          );
+          return {};
+        }
+        nextIdentity = { type: "human", id: humanId };
       } else if (mode === "agent") {
         nextIdentity = deriveIdentityFromAgent(state.activeAgentId);
       }


### PR DESCRIPTION
## Summary
- dashboard `send_contact_request`: split existing-request detection into explicit W4 state filters — reverse pending 409 with "accept incoming" hint, forward non-rejected 409, forward rejected reused for resend flow
- humans `invite_room_member_as_human`: serialize concurrent invites via row-level `SELECT ... FOR UPDATE` on the room (C4), resolve target agent up front for subscription gating, tighten guards
- hub room router + `test_hub_room_human_guard` updates to match
- Frontend wiring: AddFriendModal, `lib/api.ts`, `useDashboardSessionStore`

Builds on #289 (Human-first room/contact APIs) and `f301deeb2` (optional-agent dependency). Recovered from a local multi-file WIP stash and rebased cleanly onto current main (no conflicts).

## Test plan
- [ ] `cd backend && uv run pytest tests/test_app/test_app_humans.py tests/test_hub_room_human_guard.py tests/test_app/test_app_dashboard_contacts_a2h.py`
- [ ] Manual: send a contact request in both directions (new → 409 accept-incoming hint; resend after reject → succeeds)
- [ ] Manual: invite a paid-subscription-gated agent into a Human-owned room
- [ ] Frontend: Add Friend modal still works from Human mode without an active agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)