### PR TITLE
feat(human-first): Human-viewer across chats dashboard + moderator UI + realtime

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -37,6 +37,12 @@ class RequestContext:
     supabase_user_id: str
     roles: list[str] = field(default_factory=list)
     active_agent_id: str | None = None
+    # The social identity id of the User (``hu_*``). Available whenever the
+    # request carries a valid Supabase JWT, regardless of whether an active
+    # Agent is selected — Human-first routes use this as the viewer anchor.
+    human_id: str | None = None
+    # The User's display name, convenience for building viewer descriptors.
+    user_display_name: str | None = None
 
 
 def _get_jwks_client(issuer: str) -> PyJWKClient:
@@ -243,6 +249,8 @@ async def require_active_agent(
         supabase_user_id=supabase_user_id,
         roles=roles,
         active_agent_id=x_active_agent,
+        human_id=user.human_id,
+        user_display_name=user.display_name,
     )
 
 
@@ -285,4 +293,6 @@ async def require_user_with_optional_agent(
         supabase_user_id=supabase_user_id,
         roles=roles,
         active_agent_id=active_agent_id,
+        human_id=user.human_id,
+        user_display_name=user.display_name,
     )

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -344,33 +344,54 @@ async def _build_rooms_from_membership(
 
 @router.get("/overview")
 async def get_overview(
-    ctx: RequestContext = Depends(require_active_agent),
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
     db: AsyncSession = Depends(get_db),
 ):
-    """Return dashboard overview for the active agent."""
-    agent_id = ctx.active_agent_id
+    """Return dashboard overview for the current viewer.
 
-    result = await db.execute(
-        select(Agent).where(Agent.agent_id == agent_id)
-    )
-    agent = result.scalar_one_or_none()
-    if agent is None:
-        raise HTTPException(status_code=404, detail="Agent not found")
+    Viewer is either the active Agent (when ``X-Active-Agent`` is supplied)
+    or the Human (``hu_*``) derived from the Supabase JWT. In Human mode
+    the ``agent`` field is ``None`` and a ``viewer`` descriptor identifies
+    the Human viewer.
+    """
+    agent_data: dict | None = None
+    viewer_id: str
+    viewer_type: ParticipantType
+    viewer_display_name: str | None
 
-    agent_data = {
-        "agent_id": agent.agent_id,
-        "display_name": agent.display_name,
-        "bio": agent.bio,
-        "message_policy": agent.message_policy.value if hasattr(agent.message_policy, "value") else str(agent.message_policy),
-        "created_at": agent.created_at.isoformat() if agent.created_at else None,
-    }
+    if ctx.active_agent_id is not None:
+        result = await db.execute(
+            select(Agent).where(Agent.agent_id == ctx.active_agent_id)
+        )
+        agent = result.scalar_one_or_none()
+        if agent is None:
+            raise HTTPException(status_code=404, detail="Agent not found")
+        agent_data = {
+            "agent_id": agent.agent_id,
+            "display_name": agent.display_name,
+            "bio": agent.bio,
+            "message_policy": agent.message_policy.value if hasattr(agent.message_policy, "value") else str(agent.message_policy),
+            "created_at": agent.created_at.isoformat() if agent.created_at else None,
+        }
+        viewer_id = agent.agent_id
+        viewer_type = ParticipantType.agent
+        viewer_display_name = agent.display_name
+    else:
+        if not ctx.human_id:
+            raise HTTPException(status_code=500, detail="Missing human_id for viewer")
+        viewer_id = ctx.human_id
+        viewer_type = ParticipantType.human
+        viewer_display_name = ctx.user_display_name
 
-    rooms = await _build_rooms_from_sql(agent_id, db)
+    rooms = await _build_rooms_from_sql(viewer_id, db)
 
     contact_result = await db.execute(
         select(Contact, Agent.display_name)
         .outerjoin(Agent, Agent.agent_id == Contact.contact_agent_id)
-        .where(Contact.owner_id == agent_id)
+        .where(
+            Contact.owner_id == viewer_id,
+            Contact.owner_type == viewer_type,
+        )
     )
     contacts = [
         {
@@ -386,7 +407,8 @@ async def get_overview(
         select(func.count())
         .select_from(ContactRequest)
         .where(
-            ContactRequest.to_agent_id == agent_id,
+            ContactRequest.to_agent_id == viewer_id,
+            ContactRequest.to_type == viewer_type,
             ContactRequest.state == ContactRequestState.pending,
         )
     )
@@ -394,6 +416,11 @@ async def get_overview(
 
     return {
         "agent": agent_data,
+        "viewer": {
+            "type": viewer_type.value,
+            "id": viewer_id,
+            "display_name": viewer_display_name,
+        },
         "rooms": rooms,
         "contacts": contacts,
         "pending_requests": pending_count,
@@ -594,20 +621,26 @@ async def _resolve_display_names(
 @router.get("/contact-requests/received")
 async def list_received_requests(
     state: str | None = Query(default=None),
-    ctx: RequestContext = Depends(require_active_agent),
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
     db: AsyncSession = Depends(get_db),
 ):
-    """List contact requests received by the active agent.
+    """List contact requests received by the current viewer.
 
-    The active agent only ever appears as an ``agent`` counterparty, so
-    ``to_type`` is always ``agent`` for rows returned here. The ``from``
-    side may be either an agent (legacy A→A) or a human (H→A).
+    Viewer is either the active Agent or the Human derived from the
+    Supabase JWT. The ``from`` side may independently be Agent or Human.
     """
-    agent_id = ctx.active_agent_id
+    if ctx.active_agent_id is not None:
+        viewer_id = ctx.active_agent_id
+        viewer_type = ParticipantType.agent
+    else:
+        if not ctx.human_id:
+            raise HTTPException(status_code=500, detail="Missing human_id for viewer")
+        viewer_id = ctx.human_id
+        viewer_type = ParticipantType.human
 
     stmt = select(ContactRequest).where(
-        ContactRequest.to_agent_id == agent_id,
-        ContactRequest.to_type == ParticipantType.agent,
+        ContactRequest.to_agent_id == viewer_id,
+        ContactRequest.to_type == viewer_type,
     )
     if state:
         stmt = stmt.where(ContactRequest.state == state)
@@ -638,18 +671,26 @@ async def list_received_requests(
 @router.get("/contact-requests/sent")
 async def list_sent_requests(
     state: str | None = Query(default=None),
-    ctx: RequestContext = Depends(require_active_agent),
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
     db: AsyncSession = Depends(get_db),
 ):
-    """List contact requests sent by the active agent.
+    """List contact requests sent by the current viewer.
 
-    ``from_type`` is always ``agent``. ``to_type`` may be agent or human.
+    Viewer is either the active Agent or the Human derived from the
+    Supabase JWT. ``to_type`` may independently be Agent or Human.
     """
-    agent_id = ctx.active_agent_id
+    if ctx.active_agent_id is not None:
+        viewer_id = ctx.active_agent_id
+        viewer_type = ParticipantType.agent
+    else:
+        if not ctx.human_id:
+            raise HTTPException(status_code=500, detail="Missing human_id for viewer")
+        viewer_id = ctx.human_id
+        viewer_type = ParticipantType.human
 
     stmt = select(ContactRequest).where(
-        ContactRequest.from_agent_id == agent_id,
-        ContactRequest.from_type == ParticipantType.agent,
+        ContactRequest.from_agent_id == viewer_id,
+        ContactRequest.from_type == viewer_type,
     )
     if state:
         stmt = stmt.where(ContactRequest.state == state)
@@ -958,11 +999,20 @@ async def discover_rooms(
 @router.post("/rooms/{room_id}/join", status_code=201)
 async def join_room(
     room_id: str,
-    ctx: RequestContext = Depends(require_active_agent),
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
     db: AsyncSession = Depends(get_db),
 ):
-    """Join a public room with open join policy."""
-    agent_id = ctx.active_agent_id
+    """Join a public room with open join policy. Viewer is the active Agent
+    or the Human derived from the Supabase JWT — Humans occupy member slots
+    identically to Agents."""
+    if ctx.active_agent_id is not None:
+        viewer_id = ctx.active_agent_id
+        viewer_type = ParticipantType.agent
+    else:
+        if not ctx.human_id:
+            raise HTTPException(status_code=500, detail="Missing human_id for viewer")
+        viewer_id = ctx.human_id
+        viewer_type = ParticipantType.human
 
     result = await db.execute(
         select(Room).where(Room.room_id == room_id)
@@ -975,7 +1025,7 @@ async def join_room(
     if room.join_policy != RoomJoinPolicy.open:
         raise HTTPException(status_code=403, detail="Room does not allow open joining")
 
-    # Check max_members
+    # Check max_members — Humans occupy slots identically to Agents.
     if room.max_members is not None:
         count_result = await db.execute(
             select(func.count(RoomMember.id)).where(RoomMember.room_id == room_id)
@@ -984,11 +1034,11 @@ async def join_room(
         if current_count >= room.max_members:
             raise HTTPException(status_code=409, detail="Room is full")
 
-    # Check not already member
     existing = await db.execute(
         select(RoomMember).where(
             RoomMember.room_id == room_id,
-            RoomMember.agent_id == agent_id,
+            RoomMember.agent_id == viewer_id,
+            RoomMember.participant_type == viewer_type,
         )
     )
     if existing.scalar_one_or_none() is not None:
@@ -996,7 +1046,8 @@ async def join_room(
 
     member = RoomMember(
         room_id=room_id,
-        agent_id=agent_id,
+        agent_id=viewer_id,
+        participant_type=viewer_type,
         role=RoomRole.member,
     )
     db.add(member)
@@ -1129,16 +1180,25 @@ async def update_room_settings(
 @router.post("/rooms/{room_id}/leave")
 async def leave_room(
     room_id: str,
-    ctx: RequestContext = Depends(require_active_agent),
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
     db: AsyncSession = Depends(get_db),
 ):
-    """Leave a room. Owner cannot leave."""
-    agent_id = ctx.active_agent_id
+    """Leave a room. Owner cannot leave. Works for both Agent and Human
+    viewers — membership is keyed on (agent_id, participant_type)."""
+    if ctx.active_agent_id is not None:
+        viewer_id = ctx.active_agent_id
+        viewer_type = ParticipantType.agent
+    else:
+        if not ctx.human_id:
+            raise HTTPException(status_code=500, detail="Missing human_id for viewer")
+        viewer_id = ctx.human_id
+        viewer_type = ParticipantType.human
 
     result = await db.execute(
         select(RoomMember).where(
             RoomMember.room_id == room_id,
-            RoomMember.agent_id == agent_id,
+            RoomMember.agent_id == viewer_id,
+            RoomMember.participant_type == viewer_type,
         )
     )
     member = result.scalar_one_or_none()
@@ -1166,11 +1226,20 @@ class _JoinRequestBody(BaseModel):
 async def create_join_request(
     room_id: str,
     body: _JoinRequestBody | None = None,
-    ctx: RequestContext = Depends(require_active_agent),
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
     db: AsyncSession = Depends(get_db),
 ):
-    """Submit a join request for an invite-only public room."""
-    agent_id = ctx.active_agent_id
+    """Submit a join request for an invite-only public room. Works for
+    Agent or Human viewers — the request is keyed on
+    (room_id, requester_id, participant_type)."""
+    if ctx.active_agent_id is not None:
+        viewer_id = ctx.active_agent_id
+        viewer_type = ParticipantType.agent
+    else:
+        if not ctx.human_id:
+            raise HTTPException(status_code=500, detail="Missing human_id for viewer")
+        viewer_id = ctx.human_id
+        viewer_type = ParticipantType.human
 
     room_result = await db.execute(select(Room).where(Room.room_id == room_id))
     room = room_result.scalar_one_or_none()
@@ -1182,7 +1251,11 @@ async def create_join_request(
         raise HTTPException(status_code=400, detail="Room is open — use the join endpoint instead")
 
     existing_member = await db.execute(
-        select(RoomMember).where(RoomMember.room_id == room_id, RoomMember.agent_id == agent_id)
+        select(RoomMember).where(
+            RoomMember.room_id == room_id,
+            RoomMember.agent_id == viewer_id,
+            RoomMember.participant_type == viewer_type,
+        )
     )
     if existing_member.scalar_one_or_none() is not None:
         raise HTTPException(status_code=409, detail="Already a member")
@@ -1190,7 +1263,8 @@ async def create_join_request(
     existing_pending = await db.execute(
         select(RoomJoinRequest).where(
             RoomJoinRequest.room_id == room_id,
-            RoomJoinRequest.agent_id == agent_id,
+            RoomJoinRequest.agent_id == viewer_id,
+            RoomJoinRequest.participant_type == viewer_type,
             RoomJoinRequest.status == RoomJoinRequestStatus.pending,
         )
     )
@@ -1200,7 +1274,8 @@ async def create_join_request(
     req = RoomJoinRequest(
         request_id=generate_join_request_id(),
         room_id=room_id,
-        agent_id=agent_id,
+        agent_id=viewer_id,
+        participant_type=viewer_type,
         message=body.message if body else None,
         status=RoomJoinRequestStatus.pending,
     )
@@ -1210,7 +1285,8 @@ async def create_join_request(
     return {
         "request_id": req.request_id,
         "room_id": room_id,
-        "agent_id": agent_id,
+        "agent_id": viewer_id,
+        "participant_type": viewer_type.value,
         "status": "pending",
         "message": req.message,
         "created_at": req.created_at.isoformat() if req.created_at else None,
@@ -1221,22 +1297,39 @@ async def create_join_request(
 async def list_join_requests(
     room_id: str,
     status: str | None = Query(default=None),
-    ctx: RequestContext = Depends(require_active_agent),
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
     db: AsyncSession = Depends(get_db),
 ):
-    """List join requests for a room. Owner/admin only."""
-    agent_id = ctx.active_agent_id
+    """List join requests for a room. Owner/admin only. Viewer can be Agent
+    or Human — both roles are first-class moderators."""
+    if ctx.active_agent_id is not None:
+        viewer_id = ctx.active_agent_id
+        viewer_type = ParticipantType.agent
+    else:
+        if not ctx.human_id:
+            raise HTTPException(status_code=500, detail="Missing human_id for viewer")
+        viewer_id = ctx.human_id
+        viewer_type = ParticipantType.human
 
     member_result = await db.execute(
-        select(RoomMember).where(RoomMember.room_id == room_id, RoomMember.agent_id == agent_id)
+        select(RoomMember).where(
+            RoomMember.room_id == room_id,
+            RoomMember.agent_id == viewer_id,
+            RoomMember.participant_type == viewer_type,
+        )
     )
     member = member_result.scalar_one_or_none()
     if member is None or member.role not in (RoomRole.owner, RoomRole.admin):
         raise HTTPException(status_code=403, detail="Owner or admin required")
 
+    # Resolve requester display name against both agents and users (by human_id).
     stmt = (
-        select(RoomJoinRequest, Agent.display_name)
+        select(
+            RoomJoinRequest,
+            func.coalesce(Agent.display_name, User.display_name).label("display_name"),
+        )
         .outerjoin(Agent, Agent.agent_id == RoomJoinRequest.agent_id)
+        .outerjoin(User, User.human_id == RoomJoinRequest.agent_id)
         .where(RoomJoinRequest.room_id == room_id)
     )
     if status:
@@ -1254,6 +1347,11 @@ async def list_join_requests(
                 "request_id": jr.request_id,
                 "room_id": jr.room_id,
                 "agent_id": jr.agent_id,
+                "participant_type": (
+                    jr.participant_type.value
+                    if hasattr(jr.participant_type, "value")
+                    else str(jr.participant_type)
+                ),
                 "agent_display_name": display_name,
                 "message": jr.message,
                 "status": jr.status.value if hasattr(jr.status, "value") else str(jr.status),
@@ -1268,14 +1366,25 @@ async def list_join_requests(
 async def accept_join_request(
     room_id: str,
     request_id: str,
-    ctx: RequestContext = Depends(require_active_agent),
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
     db: AsyncSession = Depends(get_db),
 ):
-    """Accept a join request. Owner/admin only."""
-    agent_id = ctx.active_agent_id
+    """Accept a join request. Owner/admin only (Agent or Human)."""
+    if ctx.active_agent_id is not None:
+        viewer_id = ctx.active_agent_id
+        viewer_type = ParticipantType.agent
+    else:
+        if not ctx.human_id:
+            raise HTTPException(status_code=500, detail="Missing human_id for viewer")
+        viewer_id = ctx.human_id
+        viewer_type = ParticipantType.human
 
     member_result = await db.execute(
-        select(RoomMember).where(RoomMember.room_id == room_id, RoomMember.agent_id == agent_id)
+        select(RoomMember).where(
+            RoomMember.room_id == room_id,
+            RoomMember.agent_id == viewer_id,
+            RoomMember.participant_type == viewer_type,
+        )
     )
     member = member_result.scalar_one_or_none()
     if member is None or member.role not in (RoomRole.owner, RoomRole.admin):
@@ -1303,12 +1412,13 @@ async def accept_join_request(
             raise HTTPException(status_code=409, detail="Room is full")
 
     jr.status = RoomJoinRequestStatus.accepted
-    jr.responded_by = agent_id
+    jr.responded_by = viewer_id
     jr.resolved_at = func.now()
 
     new_member = RoomMember(
         room_id=room_id,
         agent_id=jr.agent_id,
+        participant_type=jr.participant_type,
         role=RoomRole.member,
     )
     db.add(new_member)
@@ -1318,6 +1428,11 @@ async def accept_join_request(
         "request_id": request_id,
         "room_id": room_id,
         "agent_id": jr.agent_id,
+        "participant_type": (
+            jr.participant_type.value
+            if hasattr(jr.participant_type, "value")
+            else str(jr.participant_type)
+        ),
         "status": "accepted",
     }
 
@@ -1326,14 +1441,25 @@ async def accept_join_request(
 async def reject_join_request(
     room_id: str,
     request_id: str,
-    ctx: RequestContext = Depends(require_active_agent),
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
     db: AsyncSession = Depends(get_db),
 ):
-    """Reject a join request. Owner/admin only."""
-    agent_id = ctx.active_agent_id
+    """Reject a join request. Owner/admin only (Agent or Human)."""
+    if ctx.active_agent_id is not None:
+        viewer_id = ctx.active_agent_id
+        viewer_type = ParticipantType.agent
+    else:
+        if not ctx.human_id:
+            raise HTTPException(status_code=500, detail="Missing human_id for viewer")
+        viewer_id = ctx.human_id
+        viewer_type = ParticipantType.human
 
     member_result = await db.execute(
-        select(RoomMember).where(RoomMember.room_id == room_id, RoomMember.agent_id == agent_id)
+        select(RoomMember).where(
+            RoomMember.room_id == room_id,
+            RoomMember.agent_id == viewer_id,
+            RoomMember.participant_type == viewer_type,
+        )
     )
     member = member_result.scalar_one_or_none()
     if member is None or member.role not in (RoomRole.owner, RoomRole.admin):
@@ -1352,7 +1478,7 @@ async def reject_join_request(
         raise HTTPException(status_code=409, detail="Request already resolved")
 
     jr.status = RoomJoinRequestStatus.rejected
-    jr.responded_by = agent_id
+    jr.responded_by = viewer_id
     jr.resolved_at = func.now()
     await db.commit()
 
@@ -1360,6 +1486,11 @@ async def reject_join_request(
         "request_id": request_id,
         "room_id": room_id,
         "agent_id": jr.agent_id,
+        "participant_type": (
+            jr.participant_type.value
+            if hasattr(jr.participant_type, "value")
+            else str(jr.participant_type)
+        ),
         "status": "rejected",
     }
 
@@ -1367,15 +1498,24 @@ async def reject_join_request(
 @router.get("/rooms/{room_id}/my-join-request")
 async def get_my_join_request(
     room_id: str,
-    ctx: RequestContext = Depends(require_active_agent),
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
     db: AsyncSession = Depends(get_db),
 ):
-    """Check if the current agent has a pending join request for this room."""
-    agent_id = ctx.active_agent_id
+    """Check if the current viewer (Agent or Human) has a recent join request."""
+    if ctx.active_agent_id is not None:
+        viewer_id = ctx.active_agent_id
+        viewer_type = ParticipantType.agent
+    else:
+        if not ctx.human_id:
+            raise HTTPException(status_code=500, detail="Missing human_id for viewer")
+        viewer_id = ctx.human_id
+        viewer_type = ParticipantType.human
+
     result = await db.execute(
         select(RoomJoinRequest).where(
             RoomJoinRequest.room_id == room_id,
-            RoomJoinRequest.agent_id == agent_id,
+            RoomJoinRequest.agent_id == viewer_id,
+            RoomJoinRequest.participant_type == viewer_type,
         ).order_by(RoomJoinRequest.created_at.desc()).limit(1)
     )
     jr = result.scalar_one_or_none()
@@ -1399,16 +1539,24 @@ async def get_my_join_request(
 @router.post("/rooms/{room_id}/read")
 async def mark_room_read(
     room_id: str,
-    ctx: RequestContext = Depends(require_active_agent),
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
     db: AsyncSession = Depends(get_db),
 ):
-    """Update last_viewed_at for the active agent in this room."""
-    agent_id = ctx.active_agent_id
+    """Update last_viewed_at for the current viewer (Agent or Human)."""
+    if ctx.active_agent_id is not None:
+        viewer_id = ctx.active_agent_id
+        viewer_type = ParticipantType.agent
+    else:
+        if not ctx.human_id:
+            raise HTTPException(status_code=500, detail="Missing human_id for viewer")
+        viewer_id = ctx.human_id
+        viewer_type = ParticipantType.human
 
     result = await db.execute(
         select(RoomMember).where(
             RoomMember.room_id == room_id,
-            RoomMember.agent_id == agent_id,
+            RoomMember.agent_id == viewer_id,
+            RoomMember.participant_type == viewer_type,
         )
     )
     member = result.scalar_one_or_none()
@@ -1454,33 +1602,49 @@ async def get_room_messages(
     is_member = False
     viewer_agent_id = None
     viewer_user_id: str | None = None
+    viewer_human_id: str | None = None
 
-    # Try to resolve authenticated user and verify agent ownership
-    if authorization and authorization.startswith("Bearer ") and x_active_agent:
+    # Try to resolve authenticated user. With X-Active-Agent the viewer is
+    # the active Agent; without it the Human (``user.human_id``) is the
+    # viewer and room membership is checked against that id.
+    if authorization and authorization.startswith("Bearer "):
         token = authorization[len("Bearer "):]
         try:
             jwt_payload = _decode_supabase_token(token)
             supabase_uid = jwt_payload["sub"]
             user, _roles = await _load_user_and_roles(supabase_uid, db, jwt_payload=jwt_payload)
             viewer_user_id = str(user.id)
-            # Verify agent belongs to authenticated user
-            agent_check = await db.execute(
-                select(Agent).where(
-                    Agent.agent_id == x_active_agent,
-                    Agent.user_id == user.id,
+            viewer_human_id = user.human_id
+
+            if x_active_agent:
+                # Agent viewer: require agent ownership + membership.
+                agent_check = await db.execute(
+                    select(Agent).where(
+                        Agent.agent_id == x_active_agent,
+                        Agent.user_id == user.id,
+                    )
                 )
-            )
-            if agent_check.scalar_one_or_none() is not None:
-                # Now check room membership
+                if agent_check.scalar_one_or_none() is not None:
+                    member_result = await db.execute(
+                        select(RoomMember).where(
+                            RoomMember.room_id == room_id,
+                            RoomMember.agent_id == x_active_agent,
+                        )
+                    )
+                    if member_result.scalar_one_or_none() is not None:
+                        is_member = True
+                        viewer_agent_id = x_active_agent
+            else:
+                # Human viewer: membership row stores ``hu_*`` in agent_id.
                 member_result = await db.execute(
                     select(RoomMember).where(
                         RoomMember.room_id == room_id,
-                        RoomMember.agent_id == x_active_agent,
+                        RoomMember.agent_id == user.human_id,
+                        RoomMember.participant_type == ParticipantType.human,
                     )
                 )
                 if member_result.scalar_one_or_none() is not None:
                     is_member = True
-                    viewer_agent_id = x_active_agent
         except HTTPException:
             pass  # Invalid token — fall through to public view
 
@@ -1853,21 +2017,35 @@ async def get_room_members(
         raise HTTPException(status_code=404, detail="Room not found")
 
     is_member = False
-    if authorization and authorization.startswith("Bearer ") and x_active_agent:
+    if authorization and authorization.startswith("Bearer "):
         token = authorization[len("Bearer "):]
         try:
             jwt_payload = _decode_supabase_token(token)
             supabase_uid = jwt_payload["sub"]
             user, _ = await _load_user_and_roles(supabase_uid, db, jwt_payload=jwt_payload)
-            agent_result = await db.execute(
-                select(Agent).where(Agent.agent_id == x_active_agent)
-            )
-            agent = agent_result.scalar_one_or_none()
-            if agent and str(agent.user_id) == str(user.id):
+
+            if x_active_agent:
+                agent_result = await db.execute(
+                    select(Agent).where(Agent.agent_id == x_active_agent)
+                )
+                agent = agent_result.scalar_one_or_none()
+                if agent and str(agent.user_id) == str(user.id):
+                    mem = await db.execute(
+                        select(RoomMember).where(
+                            RoomMember.room_id == room_id,
+                            RoomMember.agent_id == x_active_agent,
+                            RoomMember.participant_type == ParticipantType.agent,
+                        )
+                    )
+                    if mem.scalar_one_or_none() is not None:
+                        is_member = True
+            else:
+                # Human viewer: membership row stores ``hu_*``.
                 mem = await db.execute(
                     select(RoomMember).where(
                         RoomMember.room_id == room_id,
-                        RoomMember.agent_id == x_active_agent,
+                        RoomMember.agent_id == user.human_id,
+                        RoomMember.participant_type == ParticipantType.human,
                     )
                 )
                 if mem.scalar_one_or_none() is not None:
@@ -1878,25 +2056,45 @@ async def get_room_members(
     if not is_member and room.visibility != RoomVisibility.public:
         raise HTTPException(status_code=404, detail="Room not found")
 
+    # Left-join against both ``agents`` and ``users`` so Human members expose a
+    # resolvable display_name. ``Agent``/``User`` are joined on the polymorphic
+    # ``RoomMember.agent_id`` column (ag_* or hu_*) — exactly one side matches
+    # per row, so coalesce picks whichever is non-null.
     result = await db.execute(
-        select(RoomMember, Agent)
+        select(RoomMember, Agent, User)
         .outerjoin(Agent, Agent.agent_id == RoomMember.agent_id)
+        .outerjoin(User, User.human_id == RoomMember.agent_id)
         .where(RoomMember.room_id == room_id)
     )
     rows = result.all()
 
-    members = [
-        {
+    members = []
+    for m, a, u in rows:
+        ptype = (
+            m.participant_type.value
+            if hasattr(m.participant_type, "value")
+            else str(m.participant_type)
+        )
+        display_name = (a.display_name if a else None) or (u.display_name if u else None) or m.agent_id
+        members.append({
             "agent_id": m.agent_id,
-            "display_name": a.display_name if a else m.agent_id,
+            "participant_type": ptype,
+            "display_name": display_name,
             "bio": a.bio if a else None,
-            "message_policy": (a.message_policy.value if hasattr(a.message_policy, "value") else str(a.message_policy)) if a else None,
-            "created_at": a.created_at.isoformat() if a and a.created_at else None,
+            "message_policy": (
+                (a.message_policy.value if hasattr(a.message_policy, "value") else str(a.message_policy))
+                if a else None
+            ),
+            "created_at": (a.created_at.isoformat() if a and a.created_at else None),
             "role": m.role.value if hasattr(m.role, "value") else str(m.role),
+            "muted": bool(m.muted),
+            # ``None`` == use room default; explicit bool == per-member override.
+            # The frontend permissions dialog prefills from these, so "Save"
+            # with no edits keeps the existing state instead of wiping it.
+            "can_send": m.can_send,
+            "can_invite": m.can_invite,
             "joined_at": m.joined_at.isoformat() if m.joined_at else None,
-        }
-        for m, a in rows
-    ]
+        })
     return {"room_id": room_id, "members": members, "total": len(members)}
 
 
@@ -2044,10 +2242,10 @@ async def get_inbox(
     timeout: int = Query(default=0, ge=0, le=30),
     ack: bool = Query(default=True),
     room_id: str | None = Query(default=None),
-    ctx: RequestContext = Depends(require_active_agent),
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
     db: AsyncSession = Depends(get_db),
 ):
-    """Poll for queued messages for the active agent.
+    """Poll for queued messages for the current viewer (Agent or Human).
 
     Supports long-polling: when *timeout* > 0 and no messages are available,
     blocks until a message arrives or the timeout elapses — reusing the hub's
@@ -2057,24 +2255,29 @@ async def get_inbox(
     from hub.models import MessageState
     from hub.routers.hub import _inbox_conditions
 
-    agent_id = ctx.active_agent_id
+    if ctx.active_agent_id is not None:
+        receiver_id = ctx.active_agent_id
+    else:
+        if not ctx.human_id:
+            raise HTTPException(status_code=500, detail="Missing human_id for viewer")
+        receiver_id = ctx.human_id
 
-    records = await _fetch_inbox(db, agent_id, limit + 1, room_id)
+    records = await _fetch_inbox(db, receiver_id, limit + 1, room_id)
 
     # Long-poll: if nothing found and timeout > 0, wait for notification
     if not records and timeout > 0:
-        cond = _inbox_conditions.get(agent_id)
+        cond = _inbox_conditions.get(receiver_id)
         if cond is None:
             cond = asyncio.Condition()
-            _inbox_conditions[agent_id] = cond
+            _inbox_conditions[receiver_id] = cond
         try:
             async with cond:
                 await asyncio.wait_for(cond.wait(), timeout=timeout)
         except asyncio.TimeoutError:
             pass
-        _inbox_conditions.pop(agent_id, None)
+        _inbox_conditions.pop(receiver_id, None)
         # Re-query after wakeup / timeout
-        records = await _fetch_inbox(db, agent_id, limit + 1, room_id)
+        records = await _fetch_inbox(db, receiver_id, limit + 1, room_id)
 
     has_more = len(records) > limit
     records = records[:limit]

--- a/backend/app/routers/humans.py
+++ b/backend/app/routers/humans.py
@@ -117,6 +117,57 @@ class HumanRoomMemberResponse(BaseModel):
     joined_at: int
 
 
+class TransferRoomOwnerBody(BaseModel):
+    new_owner_id: str = Field(..., min_length=1, max_length=32)
+
+
+class HumanRoomTransferResponse(BaseModel):
+    room_id: str
+    new_owner_id: str
+    new_owner_type: Literal["agent", "human"]
+
+
+class PromoteMemberBody(BaseModel):
+    participant_id: str = Field(..., min_length=1, max_length=32)
+    role: Literal["admin", "member"]
+
+
+class HumanRoomRoleChangeResponse(BaseModel):
+    room_id: str
+    participant_id: str
+    participant_type: Literal["agent", "human"]
+    role: Literal["owner", "admin", "member"]
+
+
+class HumanRoomRemoveMemberResponse(BaseModel):
+    room_id: str
+    participant_id: str
+    removed: bool
+
+
+class MuteRoomBody(BaseModel):
+    muted: bool
+
+
+class HumanRoomMuteResponse(BaseModel):
+    room_id: str
+    muted: bool
+
+
+class SetMemberPermissionsBody(BaseModel):
+    participant_id: str = Field(..., min_length=1, max_length=32)
+    can_send: bool | None = None
+    can_invite: bool | None = None
+
+
+class HumanRoomPermissionsResponse(BaseModel):
+    room_id: str
+    participant_id: str
+    participant_type: Literal["agent", "human"]
+    can_send: bool | None
+    can_invite: bool | None
+
+
 class HumanContactRequestSummary(BaseModel):
     id: str
     from_participant_id: str
@@ -619,6 +670,264 @@ async def invite_room_member_as_human(
         else str(new_member.participant_type),
         role=new_member.role.value if hasattr(new_member.role, "value") else str(new_member.role),
         joined_at=_ts(new_member.joined_at),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Room moderator actions (Human-side counterparts to hub/routers/room.py).
+#
+# The hub-layer endpoints live behind an Agent JWT and `_reject_human_id`
+# guards on every body parameter — they are deliberately agent-only. These
+# Human counterparts expose the same capabilities to the Supabase-auth'd
+# owner/admin and accept polymorphic participant ids (``ag_*`` or ``hu_*``)
+# so a Human moderator can operate on either kind of member.
+# ---------------------------------------------------------------------------
+
+
+async def _load_room_member_as_caller(
+    db: AsyncSession, room_id: str, human_id: str, *, lock: bool = False
+) -> tuple[Room, RoomMember]:
+    """Fetch (room, caller_membership) for a Human acting on a room.
+
+    Raises 404 if the room doesn't exist or the Human isn't a member.
+    With ``lock=True`` the row is selected FOR UPDATE so the caller can
+    serialize write-heavy operations (transfer, promote, member ops).
+    """
+    room_stmt = select(Room).where(Room.room_id == room_id)
+    if lock:
+        room_stmt = room_stmt.with_for_update()
+    room = (await db.execute(room_stmt)).scalar_one_or_none()
+    if room is None:
+        raise HTTPException(status_code=404, detail="Room not found")
+
+    caller = (
+        await db.execute(
+            select(RoomMember).where(
+                RoomMember.room_id == room_id,
+                RoomMember.agent_id == human_id,
+                RoomMember.participant_type == ParticipantType.human,
+            )
+        )
+    ).scalar_one_or_none()
+    if caller is None:
+        raise HTTPException(status_code=404, detail="Not a member of this room")
+    return room, caller
+
+
+async def _find_room_member(
+    db: AsyncSession, room_id: str, participant_id: str
+) -> RoomMember | None:
+    """Fetch a RoomMember by room_id + polymorphic participant id."""
+    return (
+        await db.execute(
+            select(RoomMember).where(
+                RoomMember.room_id == room_id,
+                RoomMember.agent_id == participant_id,
+            )
+        )
+    ).scalar_one_or_none()
+
+
+@router.post("/me/rooms/{room_id}/transfer", response_model=HumanRoomTransferResponse)
+async def transfer_room_ownership_as_human(
+    room_id: str,
+    body: TransferRoomOwnerBody,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Transfer room ownership to another member. Human owner only.
+
+    The new owner may be an Agent (``ag_*``) or a Human (``hu_*``) — both are
+    first-class participants. Subscription-gated rooms keep the hub's
+    ``required_subscription_product_id`` check for Agent targets only;
+    Humans are admitted by being current members (see invite flow).
+    """
+    user = await _load_human(db, ctx)
+    me = user.human_id
+    room, caller = await _load_room_member_as_caller(db, room_id, me, lock=True)
+    if caller.role != RoomRole.owner:
+        raise HTTPException(status_code=403, detail="Only the room owner can transfer ownership")
+
+    new_owner_id = body.new_owner_id
+    new_owner_type = _split_prefix(new_owner_id)
+    if new_owner_type == ParticipantType.human and new_owner_id == me:
+        raise HTTPException(status_code=400, detail="Cannot transfer to self")
+
+    new_owner_member = await _find_room_member(db, room_id, new_owner_id)
+    if new_owner_member is None or new_owner_member.participant_type != new_owner_type:
+        raise HTTPException(status_code=404, detail="Target must already be a member")
+
+    # Subscription gating: for Agent targets we mirror the hub's check. For
+    # Human targets there is no user-side subscription model yet, so they are
+    # admitted purely on existing-membership.
+    if room.required_subscription_product_id and new_owner_type == ParticipantType.agent:
+        sub_row = await db.execute(
+            select(AgentSubscription).where(
+                AgentSubscription.product_id == room.required_subscription_product_id,
+                AgentSubscription.subscriber_agent_id == new_owner_id,
+                AgentSubscription.status == SubscriptionStatus.active,
+            )
+        )
+        if sub_row.scalar_one_or_none() is None:
+            raise HTTPException(
+                status_code=403,
+                detail="Target must hold an active subscription to own this room",
+            )
+
+    caller.role = RoomRole.member
+    new_owner_member.role = RoomRole.owner
+    room.owner_id = new_owner_id
+    room.owner_type = new_owner_type
+    await db.commit()
+
+    return HumanRoomTransferResponse(
+        room_id=room_id,
+        new_owner_id=new_owner_id,
+        new_owner_type=new_owner_type.value,
+    )
+
+
+@router.post("/me/rooms/{room_id}/promote", response_model=HumanRoomRoleChangeResponse)
+async def promote_member_as_human(
+    room_id: str,
+    body: PromoteMemberBody,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Promote/demote a member. Human owner only. Matches hub's `promote`."""
+    user = await _load_human(db, ctx)
+    _, caller = await _load_room_member_as_caller(db, room_id, user.human_id, lock=True)
+    if caller.role != RoomRole.owner:
+        raise HTTPException(status_code=403, detail="Only the room owner can promote or demote")
+
+    target_type = _split_prefix(body.participant_id)
+    target = await _find_room_member(db, room_id, body.participant_id)
+    if target is None or target.participant_type != target_type:
+        raise HTTPException(status_code=404, detail="Member not found in room")
+    if target.role == RoomRole.owner:
+        raise HTTPException(status_code=400, detail="Cannot change the owner's role")
+
+    target.role = RoomRole(body.role)
+    await db.commit()
+
+    return HumanRoomRoleChangeResponse(
+        room_id=room_id,
+        participant_id=target.agent_id,
+        participant_type=target.participant_type.value
+        if hasattr(target.participant_type, "value")
+        else str(target.participant_type),
+        role=target.role.value if hasattr(target.role, "value") else str(target.role),
+    )
+
+
+@router.delete(
+    "/me/rooms/{room_id}/members/{participant_id}",
+    response_model=HumanRoomRemoveMemberResponse,
+)
+async def remove_member_as_human(
+    room_id: str,
+    participant_id: str,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Remove a member. Human owner/admin only. Mirrors hub's remove_member,
+    but accepts both ``ag_*`` and ``hu_*`` targets."""
+    user = await _load_human(db, ctx)
+    _, caller = await _load_room_member_as_caller(db, room_id, user.human_id, lock=True)
+    if caller.role not in (RoomRole.owner, RoomRole.admin):
+        raise HTTPException(status_code=403, detail="Owner or admin required")
+
+    target_type = _split_prefix(participant_id)
+    target = await _find_room_member(db, room_id, participant_id)
+    if target is None or target.participant_type != target_type:
+        raise HTTPException(status_code=404, detail="Member not found in room")
+    if target.role == RoomRole.owner:
+        raise HTTPException(status_code=400, detail="Cannot remove the room owner")
+    if target.role == RoomRole.admin and caller.role != RoomRole.owner:
+        raise HTTPException(status_code=403, detail="Only the owner can remove admins")
+
+    removed_id = target.agent_id
+    await db.delete(target)
+    await db.commit()
+
+    try:
+        from hub.routers.room import _notify_room_member_change
+
+        remaining = (
+            await db.execute(
+                select(RoomMember.agent_id).where(RoomMember.room_id == room_id)
+            )
+        ).all()
+        remaining_ids = [row[0] for row in remaining]
+        await _notify_room_member_change(
+            db,
+            event_type="room_member_removed",
+            room_id=room_id,
+            changed_agent_id=removed_id,
+            notify_agent_ids=[removed_id] + remaining_ids,
+        )
+    except Exception:  # pragma: no cover — notification must not break the HTTP response
+        _logger.exception("room_member_removed broadcast failed for %s", room_id)
+
+    return HumanRoomRemoveMemberResponse(
+        room_id=room_id,
+        participant_id=removed_id,
+        removed=True,
+    )
+
+
+@router.post("/me/rooms/{room_id}/mute", response_model=HumanRoomMuteResponse)
+async def mute_room_as_human(
+    room_id: str,
+    body: MuteRoomBody,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Toggle mute on the caller's own Human membership."""
+    user = await _load_human(db, ctx)
+    _, caller = await _load_room_member_as_caller(db, room_id, user.human_id)
+    caller.muted = body.muted
+    await db.commit()
+    return HumanRoomMuteResponse(room_id=room_id, muted=caller.muted)
+
+
+@router.post(
+    "/me/rooms/{room_id}/permissions",
+    response_model=HumanRoomPermissionsResponse,
+)
+async def set_member_permissions_as_human(
+    room_id: str,
+    body: SetMemberPermissionsBody,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Set per-member permission overrides. Human owner/admin only."""
+    user = await _load_human(db, ctx)
+    _, caller = await _load_room_member_as_caller(db, room_id, user.human_id, lock=True)
+    if caller.role not in (RoomRole.owner, RoomRole.admin):
+        raise HTTPException(status_code=403, detail="Owner or admin required")
+
+    target_type = _split_prefix(body.participant_id)
+    target = await _find_room_member(db, room_id, body.participant_id)
+    if target is None or target.participant_type != target_type:
+        raise HTTPException(status_code=404, detail="Member not found in room")
+    if target.role == RoomRole.owner:
+        raise HTTPException(status_code=400, detail="Cannot modify the owner's permissions")
+    if target.role == RoomRole.admin and caller.role != RoomRole.owner:
+        raise HTTPException(status_code=403, detail="Only the owner can modify admin permissions")
+
+    target.can_send = body.can_send
+    target.can_invite = body.can_invite
+    await db.commit()
+
+    return HumanRoomPermissionsResponse(
+        room_id=room_id,
+        participant_id=target.agent_id,
+        participant_type=target.participant_type.value
+        if hasattr(target.participant_type, "value")
+        else str(target.participant_type),
+        can_send=target.can_send,
+        can_invite=target.can_invite,
     )
 
 

--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -333,7 +333,10 @@ class RoomMember(Base):
 class RoomJoinRequest(Base):
     __tablename__ = "room_join_requests"
     __table_args__ = (
-        UniqueConstraint("room_id", "agent_id", "status", name="uq_room_join_request_pending"),
+        UniqueConstraint(
+            "room_id", "agent_id", "participant_type", "status",
+            name="uq_room_join_request_pending",
+        ),
         Index("ix_room_join_requests_room_status", "room_id", "status"),
     )
 
@@ -342,8 +345,17 @@ class RoomJoinRequest(Base):
     room_id: Mapped[str] = mapped_column(
         String(64), ForeignKey("rooms.room_id"), nullable=False, index=True
     )
+    # Polymorphic requester id (ag_* or hu_*). Column name kept for
+    # compatibility; ``participant_type`` is the discriminator. FK to agents
+    # was dropped so Human requesters are legal.
     agent_id: Mapped[str] = mapped_column(
-        String(32), ForeignKey("agents.agent_id"), nullable=False, index=True
+        String(32), nullable=False, index=True
+    )
+    participant_type: Mapped[ParticipantType] = mapped_column(
+        Enum(ParticipantType, name="participanttype"),
+        nullable=False,
+        default=ParticipantType.agent,
+        server_default=ParticipantType.agent.value,
     )
     message: Mapped[str | None] = mapped_column(Text, nullable=True)
     status: Mapped[RoomJoinRequestStatus] = mapped_column(

--- a/backend/hub/routers/hub.py
+++ b/backend/hub/routers/hub.py
@@ -110,8 +110,19 @@ def is_agent_ws_online(agent_id: str) -> bool:
     return bool(ws_set)
 
 
-def build_agent_realtime_topic(agent_id: str) -> str:
-    return f"agent:{agent_id}"
+def build_agent_realtime_topic(participant_id: str) -> str:
+    """Return the Supabase realtime topic for a polymorphic participant id.
+
+    - ``ag_*`` → ``agent:<ag_*>``  (legacy, gated by can_access_agent_realtime)
+    - ``hu_*`` → ``human:<hu_*>``  (gated by can_access_human_realtime)
+
+    Every existing publisher already passes the recipient's id to this helper,
+    so routing to Human subscribers is automatic once the id stored in
+    membership/contact/message tables is ``hu_*``.
+    """
+    if participant_id.startswith("hu_"):
+        return f"human:{participant_id}"
+    return f"agent:{participant_id}"
 
 
 def build_agent_realtime_event(
@@ -249,10 +260,16 @@ async def _publish_agent_realtime_event(
 async def _collect_presence_observers(
     db: AsyncSession, agent_id: str
 ) -> set[str]:
-    """Return agent_ids who should be notified when `agent_id` goes on/offline.
+    """Return participant ids who should be notified when ``agent_id`` goes
+    on/offline.
 
-    Observers = contacts (owners who have this agent as contact) + co-members
-    of any shared room. The agent itself is excluded.
+    Polymorphic: ``agent_id`` may be ``ag_*`` or ``hu_*``. Observer queries run
+    against the polymorphic ``Contact.contact_agent_id`` /
+    ``Contact.owner_id`` / ``RoomMember.agent_id`` columns, so Human
+    participants are included as both subjects and observers.
+
+    Observers = contacts (owners who have this participant as contact) +
+    co-members of any shared room. The subject itself is excluded.
     """
     observers: set[str] = set()
 
@@ -272,7 +289,12 @@ async def _collect_presence_observers(
 
 
 async def broadcast_presence(agent_id: str, online: bool) -> None:
-    """Fan out a presence event to the agent + all observers (contacts, co-members)."""
+    """Fan out a presence event to the subject + all observers.
+
+    ``agent_id`` is polymorphic (``ag_*`` or ``hu_*``). Each target receives the
+    event on their own realtime topic — routing (``agent:`` vs ``human:``) is
+    handled by ``build_agent_realtime_topic`` which dispatches by id prefix.
+    """
     from hub.database import async_session
 
     event_time = datetime.datetime.now(datetime.timezone.utc)

--- a/backend/migrations/026_human_room_join_requests.sql
+++ b/backend/migrations/026_human_room_join_requests.sql
@@ -1,0 +1,57 @@
+-- Human-as-first-class: polymorphic room_join_requests.
+--
+-- 1. Drops the FK on room_join_requests.agent_id so Human requesters (hu_*)
+--    are legal (the agent_id column remains as the legacy column name; it now
+--    stores any participant id — same pattern as room_members.agent_id).
+-- 2. Adds participant_type discriminator column (default 'agent') so existing
+--    rows keep their A→Room semantics.
+-- 3. Replaces the (room_id, agent_id, status) unique constraint with one that
+--    also covers participant_type — a Human and an Agent with accidentally
+--    colliding ids (shouldn't happen, but be safe) get distinct pending rows.
+--
+-- Postgres-specific. SQLite (tests) builds the same shape from the SQLAlchemy
+-- model so no migration is run there.
+
+-- ---------------------------------------------------------------------------
+-- 1. Drop the FK to agents.agent_id
+-- ---------------------------------------------------------------------------
+
+DO $$
+DECLARE
+    fk_name text;
+BEGIN
+    SELECT conname INTO fk_name
+    FROM pg_constraint
+    WHERE contype = 'f'
+      AND conrelid = 'room_join_requests'::regclass
+      AND confrelid = 'agents'::regclass;
+    IF fk_name IS NOT NULL THEN
+        EXECUTE format('ALTER TABLE room_join_requests DROP CONSTRAINT %I', fk_name);
+    END IF;
+END$$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Add participant_type column (reuses enum created in 024_human_participant)
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE room_join_requests
+    ADD COLUMN IF NOT EXISTS participant_type participanttype NOT NULL DEFAULT 'agent';
+
+-- ---------------------------------------------------------------------------
+-- 3. Replace unique constraint to include participant_type
+-- ---------------------------------------------------------------------------
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'uq_room_join_request_pending'
+          AND conrelid = 'room_join_requests'::regclass
+    ) THEN
+        ALTER TABLE room_join_requests DROP CONSTRAINT uq_room_join_request_pending;
+    END IF;
+END$$;
+
+ALTER TABLE room_join_requests
+    ADD CONSTRAINT uq_room_join_request_pending
+    UNIQUE (room_id, agent_id, participant_type, status);

--- a/backend/tests/contract/schema.py
+++ b/backend/tests/contract/schema.py
@@ -94,8 +94,17 @@ CONTACT_REQUEST_ITEM = {
     "to_display_name?": "str",
 }
 
+VIEWER_DESCRIPTOR = {
+    "type": "str",
+    "id": "str",
+    "display_name?": "str",
+}
+
 DASHBOARD_OVERVIEW = {
-    "agent": AGENT_PROFILE,
+    # ``agent`` is null in Human-viewer mode; the nested schema applies
+    # only when present and non-null (validator treats None as OK).
+    "agent?": AGENT_PROFILE,
+    "viewer": VIEWER_DESCRIPTOR,
     "rooms": [DASHBOARD_ROOM],
     "contacts": [CONTACT_INFO],
     "pending_requests": "int",

--- a/backend/tests/test_app/test_app_dashboard.py
+++ b/backend/tests/test_app/test_app_dashboard.py
@@ -194,6 +194,11 @@ async def test_dashboard_overview(client: AsyncClient, seed_data: dict):
     assert data["agent"]["agent_id"] == "ag_dashtest001"
     assert data["agent"]["display_name"] == "Dashboard Agent"
 
+    # Viewer descriptor (Agent mode)
+    assert data["viewer"]["type"] == "agent"
+    assert data["viewer"]["id"] == "ag_dashtest001"
+    assert data["viewer"]["display_name"] == "Dashboard Agent"
+
     # Rooms
     assert len(data["rooms"]) == 1
     assert data["rooms"][0]["room_id"] == "rm_testroom001"
@@ -210,16 +215,31 @@ async def test_dashboard_overview(client: AsyncClient, seed_data: dict):
 
 
 @pytest.mark.asyncio
-async def test_dashboard_overview_missing_agent_header(
+async def test_dashboard_overview_human_mode(
     client: AsyncClient, seed_data: dict
 ):
-    """Should return 400 when X-Active-Agent header is missing."""
+    """Without X-Active-Agent the overview returns the Human viewer."""
     token = seed_data["token"]
     resp = await client.get(
         "/api/dashboard/overview",
         headers={"Authorization": f"Bearer {token}"},
     )
-    assert resp.status_code == 400
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # In Human mode, ``agent`` is None and a ``viewer`` descriptor identifies
+    # the Human viewer via ``human_id``.
+    assert data["agent"] is None
+    assert data["viewer"]["type"] == "human"
+    assert data["viewer"]["id"].startswith("hu_")
+    assert data["viewer"]["display_name"] == "Dashboard User"
+
+    # Seed data puts the Agent (not the Human) in room/contact/request rows,
+    # so Human mode sees empty lists for now — Phase 2 will migrate those
+    # call sites once Humans can be full participants everywhere.
+    assert data["rooms"] == []
+    assert data["contacts"] == []
+    assert data["pending_requests"] == 0
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_app/test_app_dashboard_rooms.py
+++ b/backend/tests/test_app/test_app_dashboard_rooms.py
@@ -206,6 +206,70 @@ async def test_join_private_room_fails(client: AsyncClient, seed: dict):
 
 
 @pytest.mark.asyncio
+async def test_join_and_leave_as_human(client: AsyncClient, seed: dict, db_session: AsyncSession):
+    """Human viewer (no X-Active-Agent) can self-join and leave a public+open
+    room. Membership row uses the Human's ``hu_*`` id with participant_type=human."""
+    from sqlalchemy import select
+    from hub.models import ParticipantType, User
+
+    # Resolve seed Joiner's human_id (auto-assigned default).
+    joiner = (
+        await db_session.execute(
+            select(User).where(User.email == "j@x.com")
+        )
+    ).scalar_one()
+    human_id = joiner.human_id
+    assert human_id and human_id.startswith("hu_")
+
+    # Join — no X-Active-Agent header.
+    join_resp = await client.post(
+        "/api/dashboard/rooms/rm_pubopen01/join",
+        headers={"Authorization": f"Bearer {seed['token2']}"},
+    )
+    assert join_resp.status_code == 201, join_resp.text
+    assert join_resp.json()["my_role"] == "member"
+
+    # Membership row stores hu_* + participant_type=human.
+    from hub.models import RoomMember
+    mrow = (
+        await db_session.execute(
+            select(RoomMember).where(
+                RoomMember.room_id == "rm_pubopen01",
+                RoomMember.agent_id == human_id,
+            )
+        )
+    ).scalar_one()
+    assert mrow.participant_type == ParticipantType.human
+    assert mrow.role == RoomRole.member
+
+    # Re-join must 409.
+    dup = await client.post(
+        "/api/dashboard/rooms/rm_pubopen01/join",
+        headers={"Authorization": f"Bearer {seed['token2']}"},
+    )
+    assert dup.status_code == 409
+
+    # Leave.
+    leave_resp = await client.post(
+        "/api/dashboard/rooms/rm_pubopen01/leave",
+        headers={"Authorization": f"Bearer {seed['token2']}"},
+    )
+    assert leave_resp.status_code == 200
+    assert leave_resp.json() == {"room_id": "rm_pubopen01", "left": True}
+
+    # Membership gone.
+    gone = (
+        await db_session.execute(
+            select(RoomMember).where(
+                RoomMember.room_id == "rm_pubopen01",
+                RoomMember.agent_id == human_id,
+            )
+        )
+    ).scalar_one_or_none()
+    assert gone is None
+
+
+@pytest.mark.asyncio
 async def test_room_messages_as_member(client: AsyncClient, seed: dict):
     resp = await client.get(
         "/api/dashboard/rooms/rm_pubopen01/messages",

--- a/backend/tests/test_app/test_app_humans.py
+++ b/backend/tests/test_app/test_app_humans.py
@@ -28,6 +28,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from hub.enums import RoomJoinPolicy, RoomVisibility
 from hub.models import (
     Agent,
     AgentApprovalQueue,
@@ -872,6 +873,189 @@ async def test_non_recipient_cannot_accept_request(
         headers={"Authorization": f"Bearer {carol_token}"},
     )
     assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# W-R2-1: Symmetric duplicate-check semantics on /me/contacts/request
+# (parity with app/routers/dashboard.py::send_contact_request)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_h2h_resend_after_reject_reuses_row(
+    client, seed, db_session: AsyncSession
+):
+    """After Bob rejects Alice's H2H request, Alice can resend and the same
+    ContactRequest row flips back to ``pending`` (no duplicate row)."""
+    _, bob_human_id, bob_token = await _seed_second_human(db_session, "Bob")
+    alice_headers = {"Authorization": f"Bearer {seed['token']}"}
+
+    # 1) Alice → Bob
+    r1 = await client.post(
+        "/api/humans/me/contacts/request",
+        headers=alice_headers,
+        json={"peer_id": bob_human_id, "message": "first try"},
+    )
+    assert r1.status_code == 202
+    assert r1.json()["status"] == "requested"
+
+    # 2) Bob rejects.
+    received = await client.get(
+        "/api/humans/me/contact-requests/received",
+        headers={"Authorization": f"Bearer {bob_token}"},
+    )
+    req_id = received.json()["requests"][0]["id"]
+    rej = await client.post(
+        f"/api/humans/me/contact-requests/{req_id}/reject",
+        headers={"Authorization": f"Bearer {bob_token}"},
+    )
+    assert rej.status_code == 200
+
+    # 3) Alice resends — must succeed with the same underlying row.
+    r2 = await client.post(
+        "/api/humans/me/contacts/request",
+        headers=alice_headers,
+        json={"peer_id": bob_human_id, "message": "second try"},
+    )
+    assert r2.status_code == 202, r2.text
+    assert r2.json()["status"] == "requested"
+    assert r2.json()["request_id"] == req_id
+
+    # Exactly one ContactRequest row exists, now pending again with
+    # the latest message attached.
+    rows = list((await db_session.execute(select(ContactRequest))).scalars().all())
+    assert len(rows) == 1
+    assert rows[0].state == ContactRequestState.pending
+    assert rows[0].message == "second try"
+
+
+@pytest.mark.asyncio
+async def test_h2h_reverse_pending_hints_accept_incoming(
+    client, seed, db_session: AsyncSession
+):
+    """If Bob has already sent Alice a pending H2H request, Alice sending
+    the mirror request back must 409 with the 'accept incoming' hint
+    instead of silently creating a second row."""
+    _, bob_human_id, bob_token = await _seed_second_human(db_session, "Bob")
+
+    # Bob → Alice first.
+    r1 = await client.post(
+        "/api/humans/me/contacts/request",
+        headers={"Authorization": f"Bearer {bob_token}"},
+        json={"peer_id": seed["human_id"]},
+    )
+    assert r1.status_code == 202
+    assert r1.json()["status"] == "requested"
+
+    # Alice → Bob should now hit the reverse-pending branch.
+    r2 = await client.post(
+        "/api/humans/me/contacts/request",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+        json={"peer_id": bob_human_id},
+    )
+    assert r2.status_code == 409, r2.text
+    assert "accept" in r2.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_h2h_duplicate_pending_returns_already_requested(
+    client, seed, db_session: AsyncSession
+):
+    """Alice → Bob twice in a row while the first is still pending must
+    short-circuit with ``already_requested`` (no IntegrityError path)."""
+    _, bob_human_id, _ = await _seed_second_human(db_session, "Bob")
+    alice_headers = {"Authorization": f"Bearer {seed['token']}"}
+
+    r1 = await client.post(
+        "/api/humans/me/contacts/request",
+        headers=alice_headers,
+        json={"peer_id": bob_human_id},
+    )
+    assert r1.status_code == 202
+    assert r1.json()["status"] == "requested"
+
+    r2 = await client.post(
+        "/api/humans/me/contacts/request",
+        headers=alice_headers,
+        json={"peer_id": bob_human_id},
+    )
+    assert r2.status_code == 202
+    assert r2.json()["status"] == "already_requested"
+
+    rows = list((await db_session.execute(select(ContactRequest))).scalars().all())
+    assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# W-R2-2: Subscription-gated room admits the Human owner
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sub_gated_room_admits_human_owner_exempt(
+    client, seed, db_session: AsyncSession
+):
+    """In a Human-owned sub-gated room, the owner is exempt from the
+    subscription check. Other Humans are still blocked with a clear
+    'humans not yet supported' 403.
+
+    Construction: Alice owns a sub-gated room; Bob is a co-admin. Bob tries
+    to re-add Alice (the owner) to the room — this is the only realistic
+    path to exercise the owner-exempt branch without the earlier self-invite
+    short-circuit. We first remove Alice's member row to simulate an edge
+    re-entry scenario; the sub-gate check must let her back in.
+    """
+    alice_human_id = seed["human_id"]
+    _, bob_human_id, bob_token = await _seed_second_human(db_session, "Bob")
+
+    room_id = "rm_subgate0001"
+    db_session.add(
+        Room(
+            room_id=room_id,
+            name="Sub Gate",
+            description="",
+            owner_id=alice_human_id,
+            owner_type=ParticipantType.human,
+            visibility=RoomVisibility.private,
+            join_policy=RoomJoinPolicy.invite_only,
+            required_subscription_product_id="sp_fakeproduct",
+        )
+    )
+    db_session.add(
+        RoomMember(
+            room_id=room_id,
+            agent_id=bob_human_id,
+            participant_type=ParticipantType.human,
+            role=RoomRole.admin,
+        )
+    )
+    await db_session.commit()
+
+    bob_headers = {"Authorization": f"Bearer {bob_token}"}
+
+    # Case A: Bob (admin) tries to invite a third Human → blocked by sub-gate
+    # with the human-limitation message.
+    _, carol_human_id, _ = await _seed_second_human(db_session, "Carol")
+    bad = await client.post(
+        f"/api/humans/me/rooms/{room_id}/members",
+        headers=bob_headers,
+        json={"participant_id": carol_human_id},
+    )
+    assert bad.status_code == 403, bad.text
+    assert "subscription" in bad.json()["detail"].lower()
+
+    # Case B: Bob invites Alice (the room's Human owner). She has no
+    # AgentSubscription row, but the owner-exempt branch must let her
+    # through the sub-gate and succeed with 201.
+    ok = await client.post(
+        f"/api/humans/me/rooms/{room_id}/members",
+        headers=bob_headers,
+        json={"participant_id": alice_human_id},
+    )
+    assert ok.status_code == 201, ok.text
+    body = ok.json()
+    assert body["participant_id"] == alice_human_id
+    assert body["participant_type"] == "human"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_app/test_app_humans.py
+++ b/backend/tests/test_app/test_app_humans.py
@@ -649,6 +649,185 @@ async def test_invite_members_endpoint_409_on_duplicate(
 
 
 # ---------------------------------------------------------------------------
+# Phase 4 moderator endpoints: transfer / promote / remove / mute / permissions
+# ---------------------------------------------------------------------------
+
+
+async def _seat_human_as(
+    db_session: AsyncSession, room_id: str, human_id: str, role: RoomRole
+) -> None:
+    db_session.add(
+        RoomMember(
+            room_id=room_id,
+            agent_id=human_id,
+            participant_type=ParticipantType.human,
+            role=role,
+        )
+    )
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_moderator_transfer_ownership_to_human(
+    client, seed, db_session: AsyncSession
+):
+    """Owner can transfer to another Human member; roles swap atomically."""
+    _, bob_human_id, _ = await _seed_second_human(db_session, "Bob")
+    room_id = await _create_room_as(client, seed["token"], "Transferable")
+    await _seat_human_as(db_session, room_id, bob_human_id, RoomRole.member)
+
+    resp = await client.post(
+        f"/api/humans/me/rooms/{room_id}/transfer",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+        json={"new_owner_id": bob_human_id},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["new_owner_id"] == bob_human_id
+    assert body["new_owner_type"] == "human"
+
+    room = (await db_session.execute(select(Room).where(Room.room_id == room_id))).scalar_one()
+    assert room.owner_id == bob_human_id
+    assert room.owner_type == ParticipantType.human
+
+    members = (
+        await db_session.execute(
+            select(RoomMember).where(RoomMember.room_id == room_id)
+        )
+    ).scalars().all()
+    roles = {m.agent_id: m.role for m in members}
+    assert roles[seed["human_id"]] == RoomRole.member
+    assert roles[bob_human_id] == RoomRole.owner
+
+
+@pytest.mark.asyncio
+async def test_moderator_promote_demote(client, seed, db_session: AsyncSession):
+    """Owner can promote a Human member to admin, then demote back."""
+    _, bob_human_id, _ = await _seed_second_human(db_session, "Bob")
+    room_id = await _create_room_as(client, seed["token"])
+    await _seat_human_as(db_session, room_id, bob_human_id, RoomRole.member)
+
+    promote = await client.post(
+        f"/api/humans/me/rooms/{room_id}/promote",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+        json={"participant_id": bob_human_id, "role": "admin"},
+    )
+    assert promote.status_code == 200, promote.text
+    assert promote.json()["role"] == "admin"
+
+    demote = await client.post(
+        f"/api/humans/me/rooms/{room_id}/promote",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+        json={"participant_id": bob_human_id, "role": "member"},
+    )
+    assert demote.status_code == 200
+    assert demote.json()["role"] == "member"
+
+
+@pytest.mark.asyncio
+async def test_moderator_remove_member(client, seed, db_session: AsyncSession):
+    """Owner can remove a member; owner cannot be removed."""
+    _, bob_human_id, _ = await _seed_second_human(db_session, "Bob")
+    room_id = await _create_room_as(client, seed["token"])
+    await _seat_human_as(db_session, room_id, bob_human_id, RoomRole.member)
+
+    # Remove bob
+    resp = await client.delete(
+        f"/api/humans/me/rooms/{room_id}/members/{bob_human_id}",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["removed"] is True
+
+    gone = (
+        await db_session.execute(
+            select(RoomMember).where(
+                RoomMember.room_id == room_id,
+                RoomMember.agent_id == bob_human_id,
+            )
+        )
+    ).scalar_one_or_none()
+    assert gone is None
+
+    # Owner (seed user) cannot be removed.
+    owner_del = await client.delete(
+        f"/api/humans/me/rooms/{room_id}/members/{seed['human_id']}",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+    )
+    assert owner_del.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_moderator_mute(client, seed, db_session: AsyncSession):
+    """Caller toggles mute on their own Human membership."""
+    room_id = await _create_room_as(client, seed["token"])
+
+    on = await client.post(
+        f"/api/humans/me/rooms/{room_id}/mute",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+        json={"muted": True},
+    )
+    assert on.status_code == 200
+    assert on.json() == {"room_id": room_id, "muted": True}
+
+    row = (
+        await db_session.execute(
+            select(RoomMember).where(
+                RoomMember.room_id == room_id,
+                RoomMember.agent_id == seed["human_id"],
+            )
+        )
+    ).scalar_one()
+    assert row.muted is True
+
+
+@pytest.mark.asyncio
+async def test_moderator_permissions(client, seed, db_session: AsyncSession):
+    """Owner can set can_send/can_invite overrides on a member."""
+    _, bob_human_id, _ = await _seed_second_human(db_session, "Bob")
+    room_id = await _create_room_as(client, seed["token"])
+    await _seat_human_as(db_session, room_id, bob_human_id, RoomRole.member)
+
+    resp = await client.post(
+        f"/api/humans/me/rooms/{room_id}/permissions",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+        json={"participant_id": bob_human_id, "can_send": False, "can_invite": True},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["can_send"] is False
+    assert body["can_invite"] is True
+
+    row = (
+        await db_session.execute(
+            select(RoomMember).where(
+                RoomMember.room_id == room_id,
+                RoomMember.agent_id == bob_human_id,
+            )
+        )
+    ).scalar_one()
+    assert row.can_send is False
+    assert row.can_invite is True
+
+
+@pytest.mark.asyncio
+async def test_moderator_non_owner_cannot_transfer(
+    client, seed, db_session: AsyncSession
+):
+    """A Human admin is not owner, so they cannot transfer ownership."""
+    _, bob_human_id, bob_token = await _seed_second_human(db_session, "Bob")
+    room_id = await _create_room_as(client, seed["token"])
+    await _seat_human_as(db_session, room_id, bob_human_id, RoomRole.admin)
+
+    resp = await client.post(
+        f"/api/humans/me/rooms/{room_id}/transfer",
+        headers={"Authorization": f"Bearer {bob_token}"},
+        json={"new_owner_id": bob_human_id},
+    )
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
 # Contact requests (Human-side accept/reject + listings)
 # ---------------------------------------------------------------------------
 

--- a/frontend/db/functions/001_get_agent_room_previews.sql
+++ b/frontend/db/functions/001_get_agent_room_previews.sql
@@ -1,5 +1,5 @@
 /*
- * [INPUT]: 依赖 rooms/room_members/message_records/agents 表，按已加入房间聚合成员数与最近消息摘要
+ * [INPUT]: 依赖 rooms/room_members/message_records/agents/users 表，按已加入房间聚合成员数与最近消息摘要；支持以 hu_* 作为 viewer（room_members.agent_id 可能是 ag_* 或 hu_*），通过 left join users.human_id 解析 Human 发送者 display_name
  * [OUTPUT]: 对外提供 public.get_agent_room_previews(agent_id) SQL 函数，返回最近消息预览与 room 级未读状态
  * [POS]: frontend 登录态房间预览聚合层，为 /api/dashboard/overview 的会话列表提供单一数据源
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
@@ -78,7 +78,7 @@ as $$
       mr.room_id,
       mr.id,
       mr.sender_id as last_sender_id,
-      a.display_name as last_sender_name,
+      coalesce(a.display_name, u.display_name) as last_sender_name,
       mr.created_at as last_message_at,
       left(
         coalesce(
@@ -95,6 +95,7 @@ as $$
       ) as rn
     from message_records mr
     left join agents a on a.agent_id = mr.sender_id
+    left join users u on u.human_id = mr.sender_id
     where mr.room_id in (select room_id from member_rooms)
       and coalesce(mr.envelope_json::jsonb ->> 'type', 'message') not in ('ack', 'result', 'error')
   ),

--- a/frontend/db/functions/005_setup_human_realtime_auth_function.sql
+++ b/frontend/db/functions/005_setup_human_realtime_auth_function.sql
@@ -1,0 +1,44 @@
+/*
+ * [INPUT]: 依赖 public.users 与 Supabase 的 realtime.messages 表，按 human topic 建立稳定的 private broadcast 授权函数
+ * [OUTPUT]: 对外提供 public.can_access_human_realtime(topic) 与基于该函数的 realtime.messages 订阅策略
+ * [POS]: frontend realtime 授权稳定层，Human 分支；和 004 的 Agent 分支对称，收敛跨表 policy 判断到 security definer 函数
+ * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
+ */
+
+create or replace function public.can_access_human_realtime(requested_topic text)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.users as u
+    where u.supabase_user_id = auth.uid()
+      and u.human_id is not null
+      and (
+        requested_topic = ('human:' || u.human_id)
+        or requested_topic = ('realtime:human:' || u.human_id)
+      )
+  );
+$$;
+
+revoke all on function public.can_access_human_realtime(text) from public;
+grant execute on function public.can_access_human_realtime(text) to authenticated;
+
+-- Merge the Human condition into the existing realtime.messages SELECT policy
+-- so a single row-level check covers both agent and human subscribers. The
+-- Agent policy (004) narrowed SELECT to agent-topic rows; we widen it here to
+-- "agent OR human". Dropping and recreating is idempotent.
+drop policy if exists "authenticated can receive agent broadcast" on "realtime"."messages";
+drop policy if exists "authenticated can receive human broadcast" on "realtime"."messages";
+
+create policy "authenticated can receive agent or human broadcast"
+  on "realtime"."messages"
+  for select
+  to authenticated
+  using (
+    public.can_access_agent_realtime(realtime.topic())
+    or public.can_access_human_realtime(realtime.topic())
+  );

--- a/frontend/src/components/dashboard/AgentBrowser.tsx
+++ b/frontend/src/components/dashboard/AgentBrowser.tsx
@@ -15,7 +15,7 @@ import SearchBar from "./SearchBar";
 import CopyableId from "@/components/ui/CopyableId";
 import { useRouter } from "nextjs-toploader/app";
 import { useShallow } from "zustand/react/shallow";
-import { api } from "@/lib/api";
+import { api, humansApi } from "@/lib/api";
 import type { PublicRoomMember } from "@/lib/types";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
@@ -24,6 +24,8 @@ import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import { usePresenceStore } from "@/store/usePresenceStore";
 import { PresenceDot } from "./PresenceDot";
 import JoinRequestsPanel from "./JoinRequestsPanel";
+import MemberActionsMenu from "./MemberActionsMenu";
+import TransferOwnershipDialog from "./TransferOwnershipDialog";
 import { roomList as roomListI18n } from "@/lib/i18n/translations/dashboard";
 
 export default function AgentBrowser() {
@@ -31,6 +33,8 @@ export default function AgentBrowser() {
   const locale = useLanguage();
   const t = agentBrowser[locale];
   const sessionMode = useDashboardSessionStore((state) => state.sessionMode);
+  const activeIdentity = useDashboardSessionStore((state) => state.activeIdentity);
+  const humanId = useDashboardSessionStore((state) => state.human?.human_id ?? null);
   const {
     focusedRoomId,
     toggleRightPanel,
@@ -78,6 +82,10 @@ export default function AgentBrowser() {
   })));
   const [roomMembers, setRoomMembers] = useState<PublicRoomMember[]>([]);
   const [roomMembersLoading, setRoomMembersLoading] = useState(false);
+  const [memberRefetchTick, setMemberRefetchTick] = useState(0);
+  const [mutingRoom, setMutingRoom] = useState(false);
+  const [transferDialogOpen, setTransferDialogOpen] = useState(false);
+  const refetchMembers = () => setMemberRefetchTick((t) => t + 1);
   const [roomMembersError, setRoomMembersError] = useState<string | null>(null);
   const [roomActionError, setRoomActionError] = useState<string | null>(null);
   const [cancellingSubscriptionId, setCancellingSubscriptionId] = useState<string | null>(null);
@@ -121,7 +129,7 @@ export default function AgentBrowser() {
     return () => {
       cancelled = true;
     };
-  }, [focusedRoomId]);
+  }, [focusedRoomId, memberRefetchTick]);
 
   useEffect(() => {
     if (!isAuthedReady || !currentRoom?.required_subscription_product_id) {
@@ -203,32 +211,58 @@ export default function AgentBrowser() {
               <p className="text-xs text-text-secondary/60">{t.noMembers}</p>
             ) : (
               <div className="space-y-1">
-                {roomMembers.map((member) => (
-                  <div
-                    key={member.agent_id}
-                    className="flex items-center justify-between rounded-lg px-2 py-1.5 transition-colors hover:bg-glass-bg"
-                  >
-                    <button
-                      onClick={() => selectAgent(member.agent_id)}
-                      className="min-w-0 flex-1 text-left"
+                {roomMembers.map((member) => {
+                  const ptype: "human" | "agent" = member.participant_type
+                    ?? (member.agent_id.startsWith("hu_") ? "human" : "agent");
+                  const isHumanViewer = activeIdentity?.type === "human";
+                  const viewerIsModerator = joinedRoom?.my_role === "owner" || joinedRoom?.my_role === "admin";
+                  const isSelf = isHumanViewer ? member.agent_id === humanId : false;
+                  return (
+                    <div
+                      key={member.agent_id}
+                      className="flex items-center justify-between rounded-lg px-2 py-1.5 transition-colors hover:bg-glass-bg"
                     >
-                      <div className="flex items-center gap-1.5 truncate text-xs font-medium text-text-primary">
-                        <PresenceDot agentId={member.agent_id} fallback={member.online} size="xs" />
-                        <span className="truncate">{member.display_name}</span>
-                      </div>
-                    </button>
-                    <CopyableId value={member.agent_id} className="mt-0.5" />
-                    <span className={`ml-2 shrink-0 rounded border px-1.5 py-px text-[9px] font-medium ${
-                      member.role === "owner"
-                        ? "border-neon-cyan/30 text-neon-cyan"
-                        : member.role === "admin"
-                          ? "border-neon-purple/30 text-neon-purple"
-                          : "border-glass-border text-text-secondary"
-                    }`}>
-                      {member.role}
-                    </span>
-                  </div>
-                ))}
+                      <button
+                        onClick={() => selectAgent(member.agent_id)}
+                        className="min-w-0 flex-1 text-left"
+                      >
+                        <div className="flex items-center gap-1.5 truncate text-xs font-medium text-text-primary">
+                          <PresenceDot agentId={member.agent_id} fallback={member.online} size="xs" />
+                          <span className="truncate">{member.display_name}</span>
+                          <span
+                            title={ptype === "human" ? t.participantHuman : t.participantAgent}
+                            className={`shrink-0 rounded px-1 py-px text-[9px] font-medium leading-3 ${
+                              ptype === "human"
+                                ? "bg-neon-green/10 text-neon-green"
+                                : "bg-neon-cyan/10 text-neon-cyan"
+                            }`}
+                          >
+                            {ptype === "human" ? "H" : "A"}
+                          </span>
+                        </div>
+                      </button>
+                      <CopyableId value={member.agent_id} className="mt-0.5" />
+                      <span className={`ml-2 shrink-0 rounded border px-1.5 py-px text-[9px] font-medium ${
+                        member.role === "owner"
+                          ? "border-neon-cyan/30 text-neon-cyan"
+                          : member.role === "admin"
+                            ? "border-neon-purple/30 text-neon-purple"
+                            : "border-glass-border text-text-secondary"
+                      }`}>
+                        {member.role}
+                      </span>
+                      {isHumanViewer && viewerIsModerator && !isSelf && currentRoom?.room_id && (
+                        <MemberActionsMenu
+                          roomId={currentRoom.room_id}
+                          member={member}
+                          viewerRole={joinedRoom?.my_role ?? "member"}
+                          onMutated={refetchMembers}
+                          onError={(msg) => setRoomActionError(msg)}
+                        />
+                      )}
+                    </div>
+                  );
+                })}
               </div>
             )}
             {joinedRoom && (joinedRoom.my_role === "owner" || joinedRoom.my_role === "admin") && currentRoom?.join_policy === "invite_only" && (
@@ -266,6 +300,42 @@ export default function AgentBrowser() {
                         : t.cancelSubscription}
                     </button>
                   ) : null}
+                  {activeIdentity?.type === "human" && currentRoom?.room_id && (() => {
+                    const selfRow = roomMembers.find((m) => m.agent_id === humanId);
+                    const isMuted = Boolean((selfRow as any)?.muted);
+                    return (
+                      <button
+                        onClick={async () => {
+                          if (mutingRoom || !currentRoom.room_id) return;
+                          setMutingRoom(true);
+                          setRoomActionError(null);
+                          try {
+                            await humansApi.setRoomMute(currentRoom.room_id, !isMuted);
+                            refetchMembers();
+                          } catch (err: any) {
+                            setRoomActionError(err?.message || t.muteFailed);
+                          } finally {
+                            setMutingRoom(false);
+                          }
+                        }}
+                        disabled={mutingRoom}
+                        className="w-full rounded border border-glass-border bg-glass-bg px-3 py-2 text-xs font-medium text-text-secondary transition-colors hover:text-text-primary disabled:opacity-50"
+                      >
+                        {isMuted ? t.unmuteRoom : t.muteRoom}
+                      </button>
+                    );
+                  })()}
+                  {activeIdentity?.type === "human" && joinedRoom.my_role === "owner" && currentRoom?.room_id && (
+                    <button
+                      onClick={() => {
+                        setRoomActionError(null);
+                        setTransferDialogOpen(true);
+                      }}
+                      className="w-full rounded border border-neon-purple/35 bg-neon-purple/10 px-3 py-2 text-xs font-medium text-neon-purple transition-colors hover:bg-neon-purple/15"
+                    >
+                      {t.transferOwnership}
+                    </button>
+                  )}
                 </div>
                 {joinedRoom.my_role === "owner" ? (
                   <p className="mt-2 text-[11px] leading-5 text-text-secondary/70">
@@ -273,6 +343,17 @@ export default function AgentBrowser() {
                   </p>
                 ) : null}
               </div>
+            )}
+            {transferDialogOpen && currentRoom?.room_id && humanId && (
+              <TransferOwnershipDialog
+                roomId={currentRoom.room_id}
+                roomName={currentRoom.name}
+                viewerHumanId={humanId}
+                members={roomMembers}
+                onClose={() => setTransferDialogOpen(false)}
+                onSuccess={refetchMembers}
+                onError={(msg) => setRoomActionError(msg)}
+              />
             )}
           </div>
         )}

--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -311,6 +311,25 @@ export default function DashboardApp() {
   ]);
 
   useEffect(() => {
+    // Human-first: when the user is authenticated but has no active Agent
+    // (Human viewer mode), skip the agent-specific binding/reset cycle and
+    // let refreshOverview() run on the Human anchor. Only drop back into the
+    // full reset branch for truly pre-auth states.
+    if (sessionStore.sessionMode === "authed-no-agent") {
+      walletBoundAgentRef.current = null;
+      contactBoundAgentRef.current = null;
+      subscriptionBoundAgentRef.current = null;
+      if (
+        !chatStore.overview
+        && !chatStore.overviewRefreshing
+        && !chatStore.overviewErrored
+        && uiStore.sidebarTab !== "wallet"
+      ) {
+        void chatStore.refreshOverview();
+      }
+      return;
+    }
+
     if (sessionStore.sessionMode !== "authed-ready" || !sessionStore.activeAgentId) {
       walletBoundAgentRef.current = null;
       contactBoundAgentRef.current = null;
@@ -369,7 +388,15 @@ export default function DashboardApp() {
   ]);
 
   useEffect(() => {
-    if (!sessionStore.authResolved || sessionStore.sessionMode !== "authed-ready") return;
+    if (!sessionStore.authResolved) return;
+    // Human-first: fire for both Agent viewer (authed-ready) and Human
+    // viewer (authed-no-agent). Only stay idle for guest sessions.
+    if (
+      sessionStore.sessionMode !== "authed-ready"
+      && sessionStore.sessionMode !== "authed-no-agent"
+    ) {
+      return;
+    }
     if (uiStore.sidebarTab === "wallet" || uiStore.sidebarTab === "activity") return;
     if (chatStore.overview || chatStore.overviewRefreshing || chatStore.overviewErrored) return;
     void chatStore.refreshOverview();
@@ -396,16 +423,27 @@ export default function DashboardApp() {
   }, [sessionStore.sessionMode, sessionStore.activeAgentId, uiStore.setUserChatRoomId]);
 
   useEffect(() => {
-    if (
-      !sessionStore.authResolved
-      || sessionStore.sessionMode !== "authed-ready"
-      || !sessionStore.activeAgentId
-    ) {
+    // Phase 6 Human-first: pick the realtime anchor from activeIdentity.
+    // Agent viewer → ``agent:<ag_*>``; Human viewer → ``human:<hu_*>``.
+    // Guest / unresolved → idle.
+    const anchor = (() => {
+      if (!sessionStore.authResolved) return null;
+      if (sessionStore.activeIdentity?.type === "agent") {
+        return { kind: "agent" as const, id: sessionStore.activeIdentity.id };
+      }
+      if (sessionStore.activeIdentity?.type === "human" && sessionStore.human?.human_id) {
+        return { kind: "human" as const, id: sessionStore.human.human_id };
+      }
+      return null;
+    })();
+
+    if (!anchor) {
       realtimeStore.setRealtimeStatus("idle");
       return;
     }
 
-    const topic = `agent:${sessionStore.activeAgentId}`;
+    const topic = `${anchor.kind}:${anchor.id}`;
+    const anchorId = anchor.id;
     let cancelled = false;
     let channel: ReturnType<typeof supabase.channel> | null = null;
 
@@ -428,7 +466,8 @@ export default function DashboardApp() {
       realtimeStore.setRealtimeStatus("connecting");
       console.info("[BotCord][Realtime] subscribing", {
         topic,
-        activeAgentId: sessionStore.activeAgentId,
+        anchorKind: anchor.kind,
+        anchorId,
         sessionMode: sessionStore.sessionMode,
       });
 
@@ -436,7 +475,11 @@ export default function DashboardApp() {
         .channel(topic, { config: { private: true } })
         .on("broadcast", { event: "*" }, ({ payload }) => {
           const realtimeEvent = payload as RealtimeMetaEvent;
-          if (!realtimeEvent?.type || realtimeEvent.agent_id !== sessionStore.activeAgentId) {
+          // Backend populates ``agent_id`` with the recipient participant id
+          // (``ag_*`` OR ``hu_*``) — topic dispatch in the backend already
+          // narrows delivery per subscriber, so this check is a belt-and-
+          // suspenders filter.
+          if (!realtimeEvent?.type || realtimeEvent.agent_id !== anchorId) {
             return;
           }
           const currentUIState = useDashboardUIStore.getState();
@@ -501,6 +544,8 @@ export default function DashboardApp() {
     sessionStore.authResolved,
     sessionStore.sessionMode,
     sessionStore.activeAgentId,
+    sessionStore.activeIdentity,
+    sessionStore.human?.human_id,
     chatStore.applyRealtimeEventHint,
     unreadStore.applyRealtimeEvent,
     realtimeStore.setRealtimeStatus,

--- a/frontend/src/components/dashboard/MemberActionsMenu.tsx
+++ b/frontend/src/components/dashboard/MemberActionsMenu.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+/**
+ * [INPUT]: 接收当前房间、目标成员、调用者角色，依赖 humansApi 调用 Phase 4 moderator endpoints
+ * [OUTPUT]: 对外提供 MemberActionsMenu — 成员行上的 Promote/Demote/Permissions/Remove 入口
+ * [POS]: AgentBrowser 成员列表的右侧交互层，Phase 7 将 Phase 4 的 moderator wrappers 收拢到单点 UI
+ * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
+ */
+
+import { useState } from "react";
+import type { PublicRoomMember } from "@/lib/types";
+import { humansApi } from "@/lib/api";
+import { useLanguage } from "@/lib/i18n";
+import { agentBrowser } from "@/lib/i18n/translations/dashboard";
+
+interface Props {
+  roomId: string;
+  member: PublicRoomMember;
+  viewerRole: "owner" | "admin" | "member" | string;
+  /** Fired on any successful mutation so the parent can refetch the list. */
+  onMutated: () => void;
+  /** Fired on errors — parent shows them in a shared banner. */
+  onError: (msg: string) => void;
+}
+
+export default function MemberActionsMenu({
+  roomId, member, viewerRole, onMutated, onError,
+}: Props) {
+  const locale = useLanguage();
+  const t = agentBrowser[locale];
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [permOpen, setPermOpen] = useState(false);
+
+  const isOwner = viewerRole === "owner";
+  const isOwnerTarget = member.role === "owner";
+  const isAdminTarget = member.role === "admin";
+
+  const canPromoteDemote = isOwner && !isOwnerTarget;
+  // Admin can edit perms for plain members; owner can edit perms for non-owner.
+  const canEditPerms = !isOwnerTarget && (isOwner || (viewerRole === "admin" && !isAdminTarget));
+  // Already surfaced by the outer ✕ — this menu focuses on role + perms;
+  // include Remove here too for a single unified surface.
+  const canRemove = !isOwnerTarget && (isOwner || (viewerRole === "admin" && !isAdminTarget));
+
+  if (!canPromoteDemote && !canEditPerms && !canRemove) return null;
+
+  const guard = async (fn: () => Promise<void>) => {
+    if (busy) return;
+    setBusy(true);
+    try { await fn(); } finally { setBusy(false); setOpen(false); }
+  };
+
+  const toggleRole = () => guard(async () => {
+    const next = member.role === "admin" ? "member" : "admin";
+    try {
+      await humansApi.promoteRoomMember(roomId, member.agent_id, next);
+      onMutated();
+    } catch (e: any) {
+      onError(e?.message || t.promoteFailed);
+    }
+  });
+
+  const doRemove = () => guard(async () => {
+    if (!window.confirm(t.removeMemberConfirm)) return;
+    try {
+      await humansApi.removeRoomMember(roomId, member.agent_id);
+      onMutated();
+    } catch (e: any) {
+      onError(e?.message || t.removeMemberFailed);
+    }
+  });
+
+  return (
+    <div className="relative ml-1 shrink-0">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        disabled={busy}
+        title={t.memberActions}
+        className="rounded px-1 py-0.5 text-[12px] leading-none text-text-secondary/70 transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-40"
+      >
+        ⋯
+      </button>
+      {open && (
+        <div className="absolute right-0 z-20 mt-1 min-w-[140px] rounded-md border border-glass-border bg-deep-black-light p-1 shadow-lg">
+          {canPromoteDemote && (
+            <button
+              onClick={toggleRole}
+              className="block w-full rounded px-2 py-1.5 text-left text-[11px] text-text-primary hover:bg-glass-bg"
+            >
+              {member.role === "admin" ? t.demoteToMember : t.promoteToAdmin}
+            </button>
+          )}
+          {canEditPerms && (
+            <button
+              onClick={() => { setPermOpen(true); setOpen(false); }}
+              className="block w-full rounded px-2 py-1.5 text-left text-[11px] text-text-primary hover:bg-glass-bg"
+            >
+              {t.editPermissions}
+            </button>
+          )}
+          {canRemove && (
+            <button
+              onClick={doRemove}
+              className="block w-full rounded px-2 py-1.5 text-left text-[11px] text-red-300 hover:bg-red-500/10"
+            >
+              {t.removeMember}
+            </button>
+          )}
+        </div>
+      )}
+      {permOpen && (
+        <PermissionsDialog
+          roomId={roomId}
+          member={member}
+          onClose={() => setPermOpen(false)}
+          onSaved={onMutated}
+          onError={onError}
+        />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Inline permissions dialog. Tri-state per field: null (default), true, false.
+// ---------------------------------------------------------------------------
+
+function PermissionsDialog({
+  roomId, member, onClose, onSaved, onError,
+}: {
+  roomId: string;
+  member: PublicRoomMember;
+  onClose: () => void;
+  onSaved: () => void;
+  onError: (msg: string) => void;
+}) {
+  const locale = useLanguage();
+  const t = agentBrowser[locale];
+  // Prefill from the server's current override state so Save-without-edits
+  // is a no-op, not an accidental wipe. Missing fields fall back to ``null``
+  // ("use room default").
+  const [canSend, setCanSend] = useState<boolean | null>(member.can_send ?? null);
+  const [canInvite, setCanInvite] = useState<boolean | null>(member.can_invite ?? null);
+  const [saving, setSaving] = useState(false);
+
+  const save = async () => {
+    if (saving) return;
+    setSaving(true);
+    try {
+      await humansApi.setRoomMemberPermissions(roomId, member.agent_id, {
+        can_send: canSend,
+        can_invite: canInvite,
+      });
+      onSaved();
+      onClose();
+    } catch (e: any) {
+      onError(e?.message || t.permSaveFailed);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-30 flex items-center justify-center bg-black/60"
+      onClick={onClose}
+    >
+      <div
+        className="w-[320px] rounded-lg border border-glass-border bg-deep-black-light p-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="mb-3 text-sm font-semibold text-text-primary">
+          {t.permissionsTitle} — {member.display_name}
+        </h3>
+        <TriToggle label={t.permCanSend} value={canSend} onChange={setCanSend} t={t} />
+        <TriToggle label={t.permCanInvite} value={canInvite} onChange={setCanInvite} t={t} />
+        <div className="mt-4 flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            disabled={saving}
+            className="rounded border border-glass-border px-3 py-1.5 text-[11px] text-text-secondary hover:bg-glass-bg"
+          >
+            {t.permCancel}
+          </button>
+          <button
+            onClick={save}
+            disabled={saving}
+            className="rounded border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-1.5 text-[11px] text-neon-cyan hover:bg-neon-cyan/20 disabled:opacity-50"
+          >
+            {saving ? "…" : t.permSave}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TriToggle({
+  label, value, onChange, t,
+}: {
+  label: string;
+  value: boolean | null;
+  onChange: (v: boolean | null) => void;
+  t: { permUseDefault: string; permAllow: string; permDeny: string };
+}) {
+  const base = "px-2 py-1 text-[10px] rounded border transition-colors";
+  const sel = "border-neon-cyan/40 bg-neon-cyan/10 text-neon-cyan";
+  const off = "border-glass-border text-text-secondary hover:bg-glass-bg";
+  return (
+    <div className="mb-3">
+      <p className="mb-1 text-[11px] text-text-secondary">{label}</p>
+      <div className="flex gap-1">
+        <button className={`${base} ${value === null ? sel : off}`} onClick={() => onChange(null)}>
+          {t.permUseDefault}
+        </button>
+        <button className={`${base} ${value === true ? sel : off}`} onClick={() => onChange(true)}>
+          {t.permAllow}
+        </button>
+        <button className={`${base} ${value === false ? sel : off}`} onClick={() => onChange(false)}>
+          {t.permDeny}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/RoomZeroState.tsx
+++ b/frontend/src/components/dashboard/RoomZeroState.tsx
@@ -22,11 +22,18 @@ export default function RoomZeroState({ compact = false }: RoomZeroStateProps) {
   const router = useRouter();
   const sessionMode = useDashboardSessionStore((state) => state.sessionMode);
   const human = useDashboardSessionStore((state) => state.human);
+  const ownedAgents = useDashboardSessionStore((state) => state.ownedAgents);
   const locale = useLanguage();
   const t = roomZeroState[locale];
   const [showCreateRoom, setShowCreateRoom] = useState(false);
   const isGuest = sessionMode === "guest";
   const showLoginModal = () => router.push("/login");
+  // Human-first onboarding: brand-new users (have a Human identity but zero
+  // Agents) get a friendlier "welcome, start a room" framing that reassures
+  // them an Agent is optional.
+  const isHumanFirstTime = !isGuest && human && ownedAgents.length === 0;
+  const titleCopy = isHumanFirstTime ? t.humanTitle : t.title;
+  const descCopy = isHumanFirstTime ? t.humanDescription : t.description;
 
   const containerClassName = compact
     ? "m-3 rounded-2xl border border-dashed border-glass-border bg-glass-bg/30 p-4"
@@ -35,8 +42,8 @@ export default function RoomZeroState({ compact = false }: RoomZeroStateProps) {
   return (
     <div className={containerClassName}>
       <div className={compact ? "" : "max-w-md"}>
-        <p className="text-sm font-semibold text-text-primary">{t.title}</p>
-        <p className="mt-2 text-xs leading-6 text-text-secondary">{t.description}</p>
+        <p className="text-sm font-semibold text-text-primary">{titleCopy}</p>
+        <p className="mt-2 text-xs leading-6 text-text-secondary">{descCopy}</p>
       </div>
 
       <div className={`mt-4 flex ${compact ? "flex-col" : "flex-wrap justify-center"} gap-3`}>

--- a/frontend/src/components/dashboard/TransferDialog.tsx
+++ b/frontend/src/components/dashboard/TransferDialog.tsx
@@ -16,7 +16,7 @@ interface TransferDialogProps {
 export default function TransferDialog({ onClose, onSuccess }: TransferDialogProps) {
   const locale = useLanguage();
   const t = transferDialog[locale];
-  const myAgentId = useDashboardChatStore((state) => state.overview?.agent.agent_id ?? "");
+  const myAgentId = useDashboardChatStore((state) => state.overview?.agent?.agent_id ?? "");
   const isAuthedReady = useDashboardSessionStore((state) => state.sessionMode === "authed-ready");
   const [recipientId, setRecipientId] = useState("");
   const [amount, setAmount] = useState("");

--- a/frontend/src/components/dashboard/TransferOwnershipDialog.tsx
+++ b/frontend/src/components/dashboard/TransferOwnershipDialog.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+/**
+ * [INPUT]: 接收当前房间、候选成员列表与关闭回调，依赖 humansApi.transferRoomOwnership 执行转让
+ * [OUTPUT]: 对外提供 TransferOwnershipDialog — 下拉选择 + 二次文字确认的转让房主弹窗
+ * [POS]: AgentBrowser 房间操作区，取代 window.prompt，Phase 8 P0 的转让安全网
+ * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
+ */
+
+import { useMemo, useState } from "react";
+import type { PublicRoomMember } from "@/lib/types";
+import { humansApi } from "@/lib/api";
+import { useLanguage } from "@/lib/i18n";
+import { agentBrowser } from "@/lib/i18n/translations/dashboard";
+
+interface Props {
+  roomId: string;
+  roomName: string;
+  viewerHumanId: string;
+  members: PublicRoomMember[];
+  onClose: () => void;
+  onSuccess: () => void;
+  onError: (msg: string) => void;
+}
+
+export default function TransferOwnershipDialog({
+  roomId, roomName, viewerHumanId, members, onClose, onSuccess, onError,
+}: Props) {
+  const locale = useLanguage();
+  const t = agentBrowser[locale];
+
+  // Candidates = every member except the caller and the current owner (who
+  // is the caller, given we only render this for owners). Sorted admins
+  // first so the "most natural successor" floats up.
+  const candidates = useMemo(
+    () => members
+      .filter((m) => m.agent_id !== viewerHumanId && m.role !== "owner")
+      .sort((a, b) => (a.role === "admin" ? -1 : 1) - (b.role === "admin" ? -1 : 1)),
+    [members, viewerHumanId],
+  );
+
+  const [selectedId, setSelectedId] = useState<string>(candidates[0]?.agent_id ?? "");
+  const [confirmText, setConfirmText] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const selected = candidates.find((c) => c.agent_id === selectedId);
+  // Require the user to type the room name exactly — this is a
+  // non-reversible action and the blast radius is losing ownership.
+  const confirmArmed = confirmText.trim() === roomName.trim();
+
+  const submit = async () => {
+    if (!selected || !confirmArmed || submitting) return;
+    setSubmitting(true);
+    try {
+      await humansApi.transferRoomOwnership(roomId, selected.agent_id);
+      onSuccess();
+      onClose();
+    } catch (e: any) {
+      onError(e?.message || t.transferFailed);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-30 flex items-center justify-center bg-black/60"
+      onClick={onClose}
+    >
+      <div
+        className="w-[360px] rounded-lg border border-glass-border bg-deep-black-light p-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="mb-3 text-sm font-semibold text-text-primary">
+          {t.transferOwnership}
+        </h3>
+
+        {candidates.length === 0 ? (
+          <p className="text-xs text-text-secondary">{t.transferPromptNoCandidate}</p>
+        ) : (
+          <>
+            <label className="mb-3 block">
+              <span className="mb-1 block text-[11px] text-text-secondary">
+                {t.transferSelectLabel}
+              </span>
+              <select
+                value={selectedId}
+                onChange={(e) => setSelectedId(e.target.value)}
+                className="w-full rounded border border-glass-border bg-deep-black px-2 py-1.5 text-xs text-text-primary"
+              >
+                {candidates.map((c) => (
+                  <option key={c.agent_id} value={c.agent_id}>
+                    {c.display_name} · {c.agent_id.startsWith("hu_") ? "H" : "A"} · {c.role}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="mb-3 block">
+              <span className="mb-1 block text-[11px] text-text-secondary">
+                {t.transferConfirmLabel.replace("{room}", roomName)}
+              </span>
+              <input
+                type="text"
+                value={confirmText}
+                onChange={(e) => setConfirmText(e.target.value)}
+                placeholder={roomName}
+                className="w-full rounded border border-glass-border bg-deep-black px-2 py-1.5 text-xs text-text-primary placeholder:text-text-secondary/40"
+              />
+            </label>
+
+            <p className="mb-3 text-[11px] leading-5 text-yellow-300/80">
+              {t.transferWarning}
+            </p>
+          </>
+        )}
+
+        <div className="mt-1 flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            disabled={submitting}
+            className="rounded border border-glass-border px-3 py-1.5 text-[11px] text-text-secondary hover:bg-glass-bg"
+          >
+            {t.permCancel}
+          </button>
+          {candidates.length > 0 && (
+            <button
+              onClick={submit}
+              disabled={!confirmArmed || !selected || submitting}
+              className="rounded border border-neon-purple/40 bg-neon-purple/10 px-3 py-1.5 text-[11px] text-neon-purple hover:bg-neon-purple/20 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {submitting ? "…" : t.transferOwnership}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/api.remove-member.test.ts
+++ b/frontend/src/lib/api.remove-member.test.ts
@@ -1,0 +1,68 @@
+/**
+ * [INPUT]: 依赖 vitest 的 mock 注入 supabase 客户端与 global.fetch，验证 humansApi 对 Phase 4 moderator endpoints 的契约
+ * [OUTPUT]: 对外提供 humansApi.removeRoomMember 的契约回归测试，锁定 URL / HTTP method / Authorization 头
+ * [POS]: frontend/lib 的 moderator 调用契约护栏，防止 AgentBrowser Remove 路径因 URL / method 漂移而静默失效
+ * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    auth: {
+      getSession: async () => ({
+        data: { session: { access_token: "test-access-token" } },
+      }),
+    },
+  }),
+}));
+
+// Environment for API_BASE resolution.
+process.env.NEXT_PUBLIC_HUB_BASE_URL = "https://api.example.test";
+
+describe("humansApi.removeRoomMember", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ room_id: "rm_x", participant_id: "hu_abc", removed: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("issues a DELETE to /api/humans/me/rooms/{room_id}/members/{participant_id} with the Supabase bearer", async () => {
+    const { humansApi } = await import("./api");
+    const result = await humansApi.removeRoomMember("rm_testroom", "hu_target01");
+
+    expect(result).toEqual({ room_id: "rm_x", participant_id: "hu_abc", removed: true });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.example.test/api/humans/me/rooms/rm_testroom/members/hu_target01");
+    expect(init.method).toBe("DELETE");
+    const headers = new Headers(init.headers);
+    expect(headers.get("Authorization")).toBe("Bearer test-access-token");
+    // Human mode: no X-Active-Agent header — moderator actions authenticate as
+    // the logged-in Human, identified server-side via the Supabase JWT.
+    expect(headers.get("X-Active-Agent")).toBeNull();
+  });
+
+  it("surfaces non-2xx responses as ApiError with the response status", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ detail: "Owner or admin required" }), {
+        status: 403,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const { humansApi, ApiError } = await import("./api");
+    await expect(humansApi.removeRoomMember("rm_x", "hu_x")).rejects.toBeInstanceOf(ApiError);
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -60,6 +60,11 @@ import type {
   HumanRoomMemberResponse,
   HumanContactRequestListResponse,
   HumanContactRequestResolveResponse,
+  HumanRoomTransferResponse,
+  HumanRoomRoleChangeResponse,
+  HumanRoomRemoveMemberResponse,
+  HumanRoomMuteResponse,
+  HumanRoomPermissionsResponse,
 } from "./types";
 
 import { createClient } from "@/lib/supabase/client";
@@ -863,6 +868,66 @@ const humansApi = {
   ): Promise<HumanContactRequestResolveResponse> {
     return apiPost<HumanContactRequestResolveResponse>(
       `/api/humans/me/contact-requests/${requestId}/reject`,
+    );
+  },
+
+  // -------------------------------------------------------------------------
+  // Phase 4 — Human moderator actions on a room. Caller must be a Human
+  // owner/admin of the target room. All accept polymorphic participant ids
+  // (``ag_*`` or ``hu_*``). Writes do NOT send the ``X-Active-Agent`` header;
+  // the backend treats the authenticated Human as the moderator.
+  // -------------------------------------------------------------------------
+
+  /** Transfer room ownership to another member. Owner only. */
+  transferRoomOwnership(
+    roomId: string,
+    newOwnerId: string,
+  ): Promise<HumanRoomTransferResponse> {
+    return apiPost<HumanRoomTransferResponse>(
+      `/api/humans/me/rooms/${roomId}/transfer`,
+      { new_owner_id: newOwnerId },
+    );
+  },
+
+  /** Promote/demote a member between admin and member. Owner only. */
+  promoteRoomMember(
+    roomId: string,
+    participantId: string,
+    role: "admin" | "member",
+  ): Promise<HumanRoomRoleChangeResponse> {
+    return apiPost<HumanRoomRoleChangeResponse>(
+      `/api/humans/me/rooms/${roomId}/promote`,
+      { participant_id: participantId, role },
+    );
+  },
+
+  /** Remove a member. Owner/admin only; owner cannot be removed. */
+  removeRoomMember(
+    roomId: string,
+    participantId: string,
+  ): Promise<HumanRoomRemoveMemberResponse> {
+    return apiDelete<HumanRoomRemoveMemberResponse>(
+      `/api/humans/me/rooms/${roomId}/members/${participantId}`,
+    );
+  },
+
+  /** Toggle mute for the caller's own Human membership. */
+  setRoomMute(roomId: string, muted: boolean): Promise<HumanRoomMuteResponse> {
+    return apiPost<HumanRoomMuteResponse>(
+      `/api/humans/me/rooms/${roomId}/mute`,
+      { muted },
+    );
+  },
+
+  /** Set per-member permission overrides. Owner/admin only. */
+  setRoomMemberPermissions(
+    roomId: string,
+    participantId: string,
+    body: { can_send?: boolean | null; can_invite?: boolean | null },
+  ): Promise<HumanRoomPermissionsResponse> {
+    return apiPost<HumanRoomPermissionsResponse>(
+      `/api/humans/me/rooms/${roomId}/permissions`,
+      { participant_id: participantId, ...body },
     );
   },
 };

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -109,6 +109,8 @@ export const roomZeroState: TranslationMap<{
   openExplore: string
   loginToCreate: string
   promptLabel: string
+  humanTitle: string
+  humanDescription: string
 }> = {
   en: {
     title: 'No groups yet',
@@ -117,6 +119,8 @@ export const roomZeroState: TranslationMap<{
     openExplore: 'Browse groups',
     loginToCreate: 'Log in to create a room',
     promptLabel: 'Prompt for your Bot',
+    humanTitle: 'Welcome — start your first room',
+    humanDescription: 'You are signed in as a Human. Create a room to host a conversation, or browse public groups to join the network. An Agent is optional.',
   },
   zh: {
     title: '还没有可切换的群',
@@ -125,6 +129,8 @@ export const roomZeroState: TranslationMap<{
     openExplore: '去发现页选群',
     loginToCreate: '登录后创建房间',
     promptLabel: '给 Bot 的 Prompt',
+    humanTitle: '欢迎 — 先建一个群试试',
+    humanDescription: '你已以人类身份登录。你可以直接创建房间当房主，或去发现页加入一个现有的公开群。创建 Agent 是可选项，随时再说。',
   },
 }
 
@@ -403,6 +409,35 @@ export const agentBrowser: TranslationMap<{
   loadMembersFailed: string
   leaveRoomFailed: string
   cancelSubscriptionFailed: string
+  participantHuman: string
+  participantAgent: string
+  removeMember: string
+  removeMemberConfirm: string
+  removeMemberFailed: string
+  memberActions: string
+  promoteToAdmin: string
+  demoteToMember: string
+  promoteFailed: string
+  editPermissions: string
+  permissionsTitle: string
+  permCanSend: string
+  permCanInvite: string
+  permUseDefault: string
+  permAllow: string
+  permDeny: string
+  permSave: string
+  permCancel: string
+  permSaveFailed: string
+  muteRoom: string
+  unmuteRoom: string
+  muteFailed: string
+  transferOwnership: string
+  transferPromptPrefix: string
+  transferPromptNoCandidate: string
+  transferFailed: string
+  transferSelectLabel: string
+  transferConfirmLabel: string
+  transferWarning: string
 }> = {
   en: {
     agents: 'Bots',
@@ -425,6 +460,35 @@ export const agentBrowser: TranslationMap<{
     loadMembersFailed: 'Failed to load members',
     leaveRoomFailed: 'Failed to leave group',
     cancelSubscriptionFailed: 'Failed to cancel subscription',
+    participantHuman: 'Human member',
+    participantAgent: 'Agent member',
+    removeMember: 'Remove from group',
+    removeMemberConfirm: 'Remove this member from the group?',
+    removeMemberFailed: 'Failed to remove member',
+    memberActions: 'More actions',
+    promoteToAdmin: 'Promote to admin',
+    demoteToMember: 'Demote to member',
+    promoteFailed: 'Failed to change role',
+    editPermissions: 'Permissions…',
+    permissionsTitle: 'Member permissions',
+    permCanSend: 'Can send messages',
+    permCanInvite: 'Can invite members',
+    permUseDefault: 'Default',
+    permAllow: 'Allow',
+    permDeny: 'Deny',
+    permSave: 'Save',
+    permCancel: 'Cancel',
+    permSaveFailed: 'Failed to save permissions',
+    muteRoom: 'Mute',
+    unmuteRoom: 'Unmute',
+    muteFailed: 'Failed to update mute',
+    transferOwnership: 'Transfer ownership',
+    transferPromptPrefix: 'Transfer ownership to (enter a member id, ag_ or hu_):',
+    transferPromptNoCandidate: 'No other member to transfer to.',
+    transferFailed: 'Transfer failed',
+    transferSelectLabel: 'New owner',
+    transferConfirmLabel: 'Type the room name "{room}" to confirm',
+    transferWarning: 'This is irreversible. You will become a regular member and lose owner rights.',
   },
   zh: {
     agents: 'Bot',
@@ -447,6 +511,35 @@ export const agentBrowser: TranslationMap<{
     loadMembersFailed: '加载成员失败',
     leaveRoomFailed: '退出群失败',
     cancelSubscriptionFailed: '取消订阅失败',
+    participantHuman: '人类成员',
+    participantAgent: 'Agent 成员',
+    removeMember: '将此成员移出群',
+    removeMemberConfirm: '确认将此成员移出群？',
+    removeMemberFailed: '移出成员失败',
+    memberActions: '更多操作',
+    promoteToAdmin: '提升为管理员',
+    demoteToMember: '降为普通成员',
+    promoteFailed: '修改角色失败',
+    editPermissions: '权限设置…',
+    permissionsTitle: '成员权限',
+    permCanSend: '可发送消息',
+    permCanInvite: '可邀请成员',
+    permUseDefault: '默认',
+    permAllow: '允许',
+    permDeny: '禁止',
+    permSave: '保存',
+    permCancel: '取消',
+    permSaveFailed: '保存权限失败',
+    muteRoom: '静音',
+    unmuteRoom: '取消静音',
+    muteFailed: '修改静音状态失败',
+    transferOwnership: '转让群主',
+    transferPromptPrefix: '转让给哪位成员（输入成员 id，ag_ 或 hu_）：',
+    transferPromptNoCandidate: '当前群里没有其他成员可转让。',
+    transferFailed: '转让失败',
+    transferSelectLabel: '新群主',
+    transferConfirmLabel: '输入群名 "{room}" 以确认',
+    transferWarning: '此操作不可撤销。转让后你会变成普通成员，不再拥有群主权限。',
   },
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -84,8 +84,17 @@ export interface ContactRequestListResponse {
   requests: ContactRequestItem[];
 }
 
+export interface DashboardViewer {
+  type: "agent" | "human";
+  id: string;
+  display_name: string | null;
+}
+
 export interface DashboardOverview {
-  agent: AgentProfile;
+  /** Null when the viewer is a Human (no ``X-Active-Agent`` header supplied). */
+  agent: AgentProfile | null;
+  /** Identity used to scope this overview — always present. */
+  viewer: DashboardViewer;
   rooms: DashboardRoom[];
   contacts: ContactInfo[];
   pending_requests: number;
@@ -537,13 +546,22 @@ export interface PublicOverview {
 
 export interface PublicRoomMember {
   agent_id: string;
+  /** "agent" (ag_*) or "human" (hu_*). Authenticated /members endpoint
+   * always sets this; the public variant (unauth) may omit it for agents. */
+  participant_type?: ParticipantType;
   display_name: string;
   bio: string | null;
-  message_policy: string;
-  created_at: string;
+  message_policy: string | null;
+  created_at: string | null;
   role: string;
   joined_at: string;
   online?: boolean;
+  /** Mute flag — only meaningful for the authenticated viewer's own row. */
+  muted?: boolean;
+  /** Per-member permission override. ``null`` = use room default. */
+  can_send?: boolean | null;
+  /** Per-member permission override. ``null`` = use room default. */
+  can_invite?: boolean | null;
 }
 
 export interface PublicRoomMembersResponse {
@@ -868,6 +886,44 @@ export interface HumanRoomMemberResponse {
   participant_type: ParticipantType;
   role: "owner" | "admin" | "member";
   joined_at: number;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 4 Human moderator endpoints
+// (POST /api/humans/me/rooms/{id}/transfer | /promote | /mute | /permissions,
+//  DELETE /api/humans/me/rooms/{id}/members/{participant_id})
+// ---------------------------------------------------------------------------
+
+export interface HumanRoomTransferResponse {
+  room_id: string;
+  new_owner_id: string;
+  new_owner_type: ParticipantType;
+}
+
+export interface HumanRoomRoleChangeResponse {
+  room_id: string;
+  participant_id: string;
+  participant_type: ParticipantType;
+  role: "owner" | "admin" | "member";
+}
+
+export interface HumanRoomRemoveMemberResponse {
+  room_id: string;
+  participant_id: string;
+  removed: boolean;
+}
+
+export interface HumanRoomMuteResponse {
+  room_id: string;
+  muted: boolean;
+}
+
+export interface HumanRoomPermissionsResponse {
+  room_id: string;
+  participant_id: string;
+  participant_type: ParticipantType;
+  can_send: boolean | null;
+  can_invite: boolean | null;
 }
 
 export interface HumanContactRequestSummary {

--- a/frontend/src/store/useDashboardChatStore.ts
+++ b/frontend/src/store/useDashboardChatStore.ts
@@ -19,7 +19,6 @@ import type {
 import { api } from "@/lib/api";
 import {
   buildVisibleMessageRooms,
-  hasReadyActiveAgent,
   roomMessagesInFlight,
   roomPollInFlight,
   toRoomSummary,
@@ -453,7 +452,7 @@ export const useDashboardChatStore = create<DashboardChatState>()(
       },
 
       refreshOverview: async (opts) => {
-        const { token, activeAgentId } = useDashboardSessionStore.getState();
+        const { token } = useDashboardSessionStore.getState();
         const openedRoomId = opts?.reloadOpenedRoom
           ? useDashboardUIStore.getState().openedRoomId
           : null;
@@ -462,10 +461,9 @@ export const useDashboardChatStore = create<DashboardChatState>()(
           await Promise.all([get().loadPublicRooms(), get().loadPublicAgents()]);
           return;
         }
-        if (!hasReadyActiveAgent(token, activeAgentId)) {
-          set({ overview: null, overviewRefreshing: false, overviewErrored: false });
-          return;
-        }
+        // Human-first: /overview works for both Agent viewer (X-Active-Agent
+        // header) and Human viewer (derived from Supabase JWT). The backend
+        // decides; we just need a valid token.
 
         set({ overviewRefreshing: true, overviewErrored: false });
         try {

--- a/frontend/src/store/useDashboardRealtimeStore.ts
+++ b/frontend/src/store/useDashboardRealtimeStore.ts
@@ -8,7 +8,6 @@
 import { create } from "zustand";
 import type { RealtimeMetaEvent } from "@/lib/types";
 import { api } from "@/lib/api";
-import { hasReadyActiveAgent } from "@/store/dashboard-shared";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardContactStore } from "@/store/useDashboardContactStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
@@ -63,8 +62,10 @@ export const useDashboardRealtimeStore = create<DashboardRealtimeState>()((set) 
     )),
 
   syncRealtimeEvent: async (event) => {
-    const { token, activeAgentId } = useDashboardSessionStore.getState();
-    if (!hasReadyActiveAgent(token, activeAgentId)) return;
+    const { token, activeIdentity } = useDashboardSessionStore.getState();
+    // Human-first: accept both Agent and Human viewer; only bail when we
+    // have no token or no resolved identity to anchor on.
+    if (!token || !activeIdentity) return;
 
     if (realtimeSyncInFlight) {
       queuedRealtimeEvent = event || queuedRealtimeEvent;


### PR DESCRIPTION
## Summary

Migrates the `/app/dashboard/*` BFF from agent-only to a polymorphic viewer model (Agent or Human), unblocks the chats home in Human mode, and ships the full Human moderator UI with realtime delivery.

## What changes

### Backend — viewer-polymorphic BFF (`app/routers/*`)
- `RequestContext` gains `human_id` + `user_display_name`; every dashboard endpoint resolves the viewer from Supabase JWT when no `X-Active-Agent` header is supplied.
- Endpoints migrated: `/overview`, `/contact-requests/{received,sent}`, `/rooms/{id}/{messages,read,send,join,leave,members}`, `/rooms/{id}/join-requests` CRUD, `/inbox`.
- `/overview` response: `agent` becomes nullable; new `viewer: {type, id, display_name}` descriptor always present.
- `GET /members` now returns `participant_type`, `muted`, `can_send`, `can_invite` — powers the permissions dialog prefill.

### Backend — schema
- Migration `026_human_room_join_requests.sql`: drop FK on `room_join_requests.agent_id`, add `participant_type` column, widen unique constraint.
- `RoomJoinRequest` model updated accordingly.

### Backend — Human moderator endpoints (`app/routers/humans.py`)
- New: `POST /api/humans/me/rooms/{id}/transfer` · `/promote` · `/mute` · `/permissions`; `DELETE /.../members/{participant_id}`.
- All accept polymorphic (`ag_*` or `hu_*`) participant ids. Admin-vs-admin protection matches hub-layer semantics.

### Backend — realtime topic dispatch
- `build_agent_realtime_topic` picks `agent:<ag_*>` vs `human:<hu_*>` by id prefix — every existing publish site routes to Human subscribers automatically. Presence helpers documented as polymorphic.

### Frontend — session / wrappers / UI
- `DashboardOverview.viewer` threaded through types + session store. Chats home loads in Human mode; `refreshOverview` no longer short-circuits on missing active agent; Effect #2 in `DashboardApp` gains a Human-mode branch that skips agent-bound resets.
- `humansApi` wrappers for all 6 moderator actions.
- `MemberActionsMenu` (new): per-row ⋯ menu with Promote/Demote/Permissions/Remove; `PermissionsDialog` prefills from server values so Save-no-edits is a no-op.
- `TransferOwnershipDialog` (new): dropdown selector + typed-name confirmation, replaces the previous `window.prompt` flow.
- H/A participant-type badge in member rows; room-level Mute toggle.
- `RoomZeroState` shows Human-first onboarding copy for users with zero agents.

### Frontend — realtime
- Subscription picks anchor from `activeIdentity`; Human viewer subscribes to `human:<hu_*>`.
- New SQL function `005_setup_human_realtime_auth_function.sql` adds `can_access_human_realtime` and merges the `realtime.messages` SELECT policy to cover both topic families.

## Test plan

Automated:
- [x] Backend: `uv run pytest tests/` — **836 passed / 31 skipped**. +6 moderator tests + human join/leave happy path + human-mode overview assertion.
- [x] Frontend: `node_modules/.bin/tsc --noEmit` — 0 src errors (pre-existing `tests/api/*` errors unchanged).
- [x] Frontend: `vitest run` — new `api.remove-member.test.ts` contract test passes.

Manual verification needed after deploy:
- [ ] Sign in as a brand-new user (no agents) → chats home loads, Human onboarding copy visible, Create-room works.
- [ ] Create a room as Human, invite an Agent + another Human → H/A badges render correctly.
- [ ] As Human owner: open member ⋯ menu → Promote, Demote, Permissions (prefill shows current state), Remove.
- [ ] Mute/Unmute toggles self membership; preview reflects immediately after refetch.
- [ ] Transfer dialog: select member → must type room name → button enables → transfer succeeds, roles swap.
- [ ] Human-mode realtime: send a message in another browser tab → receives via `human:<hu_*>` topic.

## Deployment checklist

- [ ] `make migrate` → applies `026_human_room_join_requests.sql`.
- [ ] `pnpm db:functions` on Supabase → re-applies `001_get_agent_room_previews.sql` (updated) + `005_setup_human_realtime_auth_function.sql` (new). **Order matters: 005 drops the 004 policy and recreates it OR-merged; both must be deployed together.**
- [ ] Backend image redeploy (contains realtime topic dispatch + /members response shape).
- [ ] Frontend deploy.

## Follow-ups (not in this PR)

- Human presence heartbeat (backend has polymorphic plumbing; missing the online-signal source for Humans).
- Vitest coverage for Promote/Transfer/Mute/Permissions wrappers (Remove covered here; others have backend e2e coverage).
- Agent-viewer moderator UI (needs agent-JWT signing in the dashboard, out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)