### PR TITLE
fix(dashboard): gate UserChatPane on agent identity in human mode

### DIFF
--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -424,7 +424,11 @@ export default function DashboardApp() {
 
   // Eagerly register userChatRoomId so realtime events are always routed to the user-chat pane
   useEffect(() => {
-    if (sessionStore.sessionMode !== "authed-ready" || !sessionStore.activeAgentId) return;
+    if (
+      sessionStore.sessionMode !== "authed-ready"
+      || !sessionStore.activeAgentId
+      || sessionStore.activeIdentity?.type !== "agent"
+    ) return;
 
     let cancelled = false;
     api.getUserChatRoom().then((room) => {
@@ -432,7 +436,12 @@ export default function DashboardApp() {
     }).catch(() => { /* ignore — UserChatPane will retry on mount */ });
 
     return () => { cancelled = true; };
-  }, [sessionStore.sessionMode, sessionStore.activeAgentId, uiStore.setUserChatRoomId]);
+  }, [
+    sessionStore.sessionMode,
+    sessionStore.activeAgentId,
+    sessionStore.activeIdentity?.type,
+    uiStore.setUserChatRoomId,
+  ]);
 
   useEffect(() => {
     // Phase 6 Human-first: pick the realtime anchor from activeIdentity.

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -64,7 +64,8 @@ function TypewriterText({
 // ---------------------------------------------------------------------------
 
 export default function UserChatPane() {
-  const { activeAgentId } = useDashboardSessionStore();
+  const { activeAgentId, activeIdentity } = useDashboardSessionStore();
+  const isAgentMode = activeIdentity?.type === "agent" && !!activeAgentId;
   const { setUserChatRoomId } = useDashboardUIStore();
 
   // Owner-chat store
@@ -88,16 +89,16 @@ export default function UserChatPane() {
   const wasNearBottomRef = useRef(true);
   const [, forceRender] = useState(0);
 
-  // WS hook
+  // WS hook — only when acting as an agent; human-mode keeps the hook idle.
   const { wsClientRef, streamedTraceIds } = useOwnerChatWs({
-    activeAgentId,
+    activeAgentId: isAgentMode ? activeAgentId : null,
     roomId,
     agentName: chatRoomName || activeAgentId || "",
   });
 
   // ------ Initialize chat room and load messages ------
   useEffect(() => {
-    if (!activeAgentId) return;
+    if (!isAgentMode) return;
     let cancelled = false;
 
     // Reset store for fresh agent
@@ -118,7 +119,7 @@ export default function UserChatPane() {
 
     return () => { cancelled = true; };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeAgentId]);
+  }, [activeAgentId, isAgentMode]);
 
   // ------ Mark initial load messages as already animated ------
   useEffect(() => {
@@ -268,10 +269,10 @@ export default function UserChatPane() {
 
   // ------ Render guards ------
 
-  if (!activeAgentId) {
+  if (!isAgentMode) {
     return (
       <div className="flex items-center justify-center h-full text-zinc-500">
-        <p>Select an agent to start chatting</p>
+        <p>Switch to an agent identity to start chatting</p>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- In human-viewer mode `activeAgentId` is preserved (see `useDashboardSessionStore.ts:185`), so the previous `if (!activeAgentId) return` guard in `UserChatPane` and `DashboardApp` failed to short-circuit. Result: `/api/dashboard/chat/room` and `/api/dashboard/chat/send` fired without the `X-Active-Agent` header and the backend (which uses `require_active_agent`) returned `400 X-Active-Agent header is required`.
- Gate on `activeIdentity?.type === "agent"` instead, both for the eager preload in `DashboardApp` and the init effect / WS hook / render guard in `UserChatPane`.
- Render a "Switch to an agent identity to start chatting" placeholder for human viewers in `UserChatPane`.

## Test plan
- [ ] Sign in, switch identity to human, navigate to `/chats` — verify no `/api/dashboard/chat/*` requests fire and no 400s in the console.
- [ ] Switch identity back to an agent — verify owner-agent chat loads and messages send.
- [ ] In human mode open the "My Bots" tab without selecting a bot, then with a bot — placeholder shows in human mode; chat works after switching back to that agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)