### PR TITLE
fix(dashboard): tighten wallet/subscription gates against stale activeAgentId in human mode

### DIFF
--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -600,7 +600,11 @@ export default function DashboardApp() {
   ]);
 
   useEffect(() => {
-    if (sessionStore.sessionMode !== "authed-ready" || !sessionStore.activeAgentId) return;
+    if (
+      sessionStore.sessionMode !== "authed-ready"
+      || !sessionStore.activeAgentId
+      || sessionStore.activeIdentity?.type !== "agent"
+    ) return;
 
     if (!walletStore.wallet && !walletStore.walletLoading && !walletStore.walletError) {
       void walletStore.loadWallet();
@@ -615,6 +619,7 @@ export default function DashboardApp() {
   }, [
     sessionStore.sessionMode,
     sessionStore.activeAgentId,
+    sessionStore.activeIdentity?.type,
     walletStore.wallet,
     walletStore.walletLoading,
     walletStore.walletError,

--- a/frontend/src/components/dashboard/SubscriptionBadge.tsx
+++ b/frontend/src/components/dashboard/SubscriptionBadge.tsx
@@ -62,10 +62,12 @@ export default function SubscriptionBadge({
 
   if (!productId) return null;
 
-  const { activeAgentId, sessionMode } = useDashboardSessionStore(useShallow((state) => ({
+  const { activeAgentId, sessionMode, activeIdentityType } = useDashboardSessionStore(useShallow((state) => ({
     activeAgentId: state.activeAgentId,
     sessionMode: state.sessionMode,
+    activeIdentityType: state.activeIdentity?.type ?? null,
   })));
+  const isAgentMode = activeIdentityType === "agent" && !!activeAgentId;
   const { joinRoom, loadRoomMessages } = useDashboardChatStore(useShallow((state) => ({
     joinRoom: state.joinRoom,
     loadRoomMessages: state.loadRoomMessages,
@@ -120,7 +122,7 @@ export default function SubscriptionBadge({
 
   useEffect(() => {
     let cancelled = false;
-    if (!isAuthedReady || !activeAgentId) {
+    if (!isAuthedReady || !isAgentMode) {
       return () => {
         cancelled = true;
       };
@@ -136,7 +138,7 @@ export default function SubscriptionBadge({
     return () => {
       cancelled = true;
     };
-  }, [activeAgentId, ensureSubscriptions, isAuthedReady]);
+  }, [activeAgentId, isAgentMode, ensureSubscriptions, isAuthedReady]);
 
   const loadData = async () => {
     const productPromise = productCache.has(productId)
@@ -144,7 +146,7 @@ export default function SubscriptionBadge({
       : api.getSubscriptionProduct(productId);
     const [productResult] = await Promise.all([
       productPromise,
-      isAuthedReady && activeAgentId ? ensureSubscriptions() : Promise.resolve([]),
+      isAuthedReady && isAgentMode ? ensureSubscriptions() : Promise.resolve([]),
     ]);
 
     productCache.set(productId, productResult.product);
@@ -173,7 +175,7 @@ export default function SubscriptionBadge({
       showLoginModal();
       return;
     }
-    if (!isAuthedReady || !activeAgentId) {
+    if (!isAuthedReady || !isAgentMode) {
       setError(t.selectAgentFirst);
       return;
     }
@@ -209,7 +211,7 @@ export default function SubscriptionBadge({
     : "bg-yellow-500/20 text-yellow-500 hover:bg-yellow-500/30";
   const primaryLabel = isGuest
     ? t.loginToSubscribe
-    : !isAuthedReady || !activeAgentId
+    : !isAuthedReady || !isAgentMode
       ? t.selectActiveAgent
       : roomId
         ? alreadySubscribed
@@ -322,7 +324,7 @@ export default function SubscriptionBadge({
                   </div>
                 ) : null}
 
-                {!subscription && !isGuest && !activeAgentId ? (
+                {!subscription && !isGuest && !isAgentMode ? (
                   <div className="rounded border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-xs text-yellow-300">
                     {t.chooseAgentHint}
                   </div>
@@ -358,7 +360,7 @@ export default function SubscriptionBadge({
                   </button>
                   <button
                     onClick={handlePrimaryAction}
-                    disabled={subscribing || (!isGuest && !activeAgentId)}
+                    disabled={subscribing || (!isGuest && !isAgentMode)}
                     className="inline-flex items-center gap-2 rounded border border-yellow-500/50 bg-yellow-500/20 px-4 py-2 text-sm font-medium text-yellow-500 hover:bg-yellow-500/30 disabled:opacity-50"
                   >
                     {subscribing ? <Loader2 className="h-4 w-4 animate-spin" /> : null}

--- a/frontend/src/store/useDashboardSubscriptionStore.ts
+++ b/frontend/src/store/useDashboardSubscriptionStore.ts
@@ -31,8 +31,9 @@ const initialSubscriptionState = {
 };
 
 function getReadyAgentId(): string | null {
-  const { token, activeAgentId } = useDashboardSessionStore.getState();
-  return token && activeAgentId ? activeAgentId : null;
+  const { token, activeAgentId, activeIdentity } = useDashboardSessionStore.getState();
+  if (!token || !activeAgentId || activeIdentity?.type !== "agent") return null;
+  return activeAgentId;
 }
 
 export const useDashboardSubscriptionStore = create<DashboardSubscriptionState>()((set, get) => ({

--- a/frontend/src/store/useDashboardWalletStore.ts
+++ b/frontend/src/store/useDashboardWalletStore.ts
@@ -47,10 +47,10 @@ const initialWalletState = {
 };
 
 function getAuthContext() {
-  const { token, activeAgentId } = useDashboardSessionStore.getState();
+  const { token, activeAgentId, activeIdentity } = useDashboardSessionStore.getState();
   return {
     token,
-    hasReadyAgent: Boolean(token && activeAgentId),
+    hasReadyAgent: Boolean(token && activeAgentId && activeIdentity?.type === "agent"),
   };
 }
 


### PR DESCRIPTION
## Summary
Follow-up to #298 — same root cause, more callsites.

`activeAgentId` is preserved when the viewer switches to human-mode (`useDashboardSessionStore.ts:185`), so gates written as `Boolean(token && activeAgentId)` pass in human mode. The fetches behind those gates hit endpoints decorated with `require_active_agent`, but `buildAuthHeaders` only sends the `X-Active-Agent` header when `activeIdentity.type === "agent"` → backend returns `400 X-Active-Agent header is required`.

Affected calls in human mode:
- `/api/wallet/summary`, `/api/wallet/ledger`, `/api/wallet/withdrawals`
- `/api/subscriptions/me`
- `/api/subscriptions/products/{id}/subscribe`

Fix: add `activeIdentity?.type === "agent"` to every gate.

- `useDashboardWalletStore.getAuthContext`
- `useDashboardSubscriptionStore.getReadyAgentId`
- `SubscriptionBadge.tsx` — effect, modal CTA, label, disabled state, hint banner
- `DashboardApp.tsx` — wallet bootstrap effect

## Test plan
- [ ] Sign in, switch to human identity, navigate to `/chats/wallet` — verify no 400s; wallet stays empty (expected, human has no wallet).
- [ ] Open a paid room with `SubscriptionBadge` while in human mode — verify the badge shows "select active agent" instead of triggering `/subscriptions/me` 400.
- [ ] Switch back to an agent — wallet loads, subscription badge resolves correctly.
- [ ] Existing agent-mode flows unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)