### PR TITLE
fix: keep My Bots clicks in owner chat

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -1688,6 +1688,20 @@ async def get_room_messages(
                 )
                 if human_member_result.scalar_one_or_none() is not None:
                     is_member = True
+
+            # Owner-chat rooms intentionally only store the agent as a member.
+            # Let the owning user read history even when they are not currently
+            # acting as that agent.
+            if not is_member and room_id.startswith("rm_oc_") and room.owner_id:
+                owner_agent_result = await db.execute(
+                    select(Agent).where(
+                        Agent.agent_id == room.owner_id,
+                        Agent.user_id == user.id,
+                    )
+                )
+                if owner_agent_result.scalar_one_or_none() is not None:
+                    is_member = True
+                    viewer_agent_id = room.owner_id
         except HTTPException:
             pass  # Invalid token — fall through to public view
 
@@ -2375,29 +2389,43 @@ class ChatAttachment(BaseModel):
 
 class ChatSendBody(BaseModel):
     text: str = ""
+    agent_id: str | None = Field(default=None, max_length=64)
     attachments: list[ChatAttachment] | None = Field(default=None, max_length=10)
+
+
+async def _resolve_owner_chat_agent(
+    db: AsyncSession,
+    ctx: RequestContext,
+    requested_agent_id: str | None,
+) -> tuple[str, str]:
+    agent_id = (requested_agent_id or ctx.active_agent_id or "").strip()
+    if not agent_id:
+        raise HTTPException(status_code=400, detail="agent_id is required")
+
+    result = await db.execute(select(Agent).where(Agent.agent_id == agent_id))
+    agent = result.scalar_one_or_none()
+    if agent is None or agent.claimed_at is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    if str(agent.user_id) != str(ctx.user_id):
+        raise HTTPException(status_code=403, detail="Agent not owned by user")
+    return agent_id, (agent.display_name or agent_id)
 
 
 @router.get("/chat/room")
 async def get_chat_room(
-    ctx: RequestContext = Depends(require_active_agent),
+    agent_id: str | None = Query(default=None),
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
     db: AsyncSession = Depends(get_db),
 ):
     """Return (or create) the owner-agent chat room for the authenticated user."""
     from hub.routers.dashboard_chat import _ensure_owner_chat_room
 
-    agent_id = ctx.active_agent_id
+    chat_agent_id, display_name = await _resolve_owner_chat_agent(db, ctx, agent_id)
 
-    # Fetch agent display name
-    result = await db.execute(
-        select(Agent.display_name).where(Agent.agent_id == agent_id)
-    )
-    display_name = result.scalar_one_or_none() or agent_id
-
-    room_id = await _ensure_owner_chat_room(db, str(ctx.user_id), agent_id, display_name)
+    room_id = await _ensure_owner_chat_room(db, str(ctx.user_id), chat_agent_id, display_name)
     await db.commit()
 
-    return {"room_id": room_id, "name": f"Chat with {display_name}", "agent_id": agent_id}
+    return {"room_id": room_id, "name": f"Chat with {display_name}", "agent_id": chat_agent_id}
 
 
 # Allowed MIME type prefixes (mirrors hub/routers/files.py)
@@ -2411,7 +2439,8 @@ _ALLOWED_MIME_PREFIXES = (
 @router.post("/upload")
 async def dashboard_upload_file(
     file: UploadFile,
-    ctx: RequestContext = Depends(require_active_agent),
+    agent_id: str | None = Query(default=None),
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
     db: AsyncSession = Depends(get_db),
 ):
     """Upload a file via dashboard auth. Reuses hub file storage."""
@@ -2436,6 +2465,8 @@ async def dashboard_upload_file(
     if len(buf) == 0:
         raise HTTPException(status_code=400, detail="Empty file")
 
+    uploader_agent_id, _display_name = await _resolve_owner_chat_agent(db, ctx, agent_id)
+
     raw_name = file.filename or "upload"
     original_filename = os.path.basename(raw_name).strip()[:200] or "upload"
     data = bytes(buf)
@@ -2450,7 +2481,7 @@ async def dashboard_upload_file(
     )
     record = FileRecord(
         file_id=file_id,
-        uploader_id=ctx.active_agent_id,
+        uploader_id=uploader_agent_id,
         original_filename=original_filename,
         content_type=content_type,
         size_bytes=len(data),
@@ -2477,7 +2508,7 @@ async def dashboard_upload_file(
 async def send_chat_message(
     body: ChatSendBody,
     request: Request,
-    ctx: RequestContext = Depends(require_active_agent),
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
     db: AsyncSession = Depends(get_db),
 ):
     """Send a message from the dashboard user to their own agent.
@@ -2497,8 +2528,8 @@ async def send_chat_message(
         notify_inbox,
     )
 
-    agent_id = ctx.active_agent_id
     user_id = str(ctx.user_id)
+    agent_id, agent_display_name = await _resolve_owner_chat_agent(db, ctx, body.agent_id)
 
     text = (body.text or "").strip()
     has_attachments = bool(body.attachments)
@@ -2517,12 +2548,6 @@ async def send_chat_message(
             dumped = att.model_dump(exclude_none=True)
             dumped["url"] = normalized
             normalized_attachments.append(dumped)
-
-    # Fetch agent display name
-    agent_result = await db.execute(
-        select(Agent.display_name).where(Agent.agent_id == agent_id)
-    )
-    agent_display_name = agent_result.scalar_one_or_none() or agent_id
 
     # Ensure room exists
     room_id = await _ensure_owner_chat_room(db, user_id, agent_id, agent_display_name)

--- a/backend/tests/test_app/test_app_dashboard.py
+++ b/backend/tests/test_app/test_app_dashboard.py
@@ -322,6 +322,56 @@ async def test_chat_room_idempotent(
     assert room_id_1 == room_id_2
 
 
+@pytest.mark.asyncio
+async def test_chat_room_for_explicit_owned_agent_without_active_agent(
+    client: AsyncClient, seed_data: dict, db_session: AsyncSession, monkeypatch
+):
+    """Owner-chat can target an owned bot without switching X-Active-Agent."""
+    token = seed_data["token"]
+    user_id = seed_data["user_id"]
+    db_session.add(
+        Agent(
+            agent_id="ag_secondbot01",
+            display_name="Second Bot",
+            message_policy=MessagePolicy.contacts_only,
+            user_id=user_id,
+            claimed_at=datetime.datetime.now(datetime.timezone.utc),
+        )
+    )
+    await db_session.commit()
+
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.get(
+        "/api/dashboard/chat/room",
+        params={"agent_id": "ag_secondbot01"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["agent_id"] == "ag_secondbot01"
+    assert data["name"] == "Chat with Second Bot"
+
+    from hub.routers import hub as hub_router
+
+    monkeypatch.setattr(hub_router, "notify_inbox", AsyncMock())
+    monkeypatch.setattr(hub_router, "_publish_agent_realtime_event", AsyncMock())
+
+    send_resp = await client.post(
+        "/api/dashboard/chat/send",
+        json={"agent_id": "ag_secondbot01", "text": "hello second bot"},
+        headers=headers,
+    )
+    assert send_resp.status_code == 202
+    assert send_resp.json()["room_id"] == data["room_id"]
+
+    messages_resp = await client.get(
+        f"/api/dashboard/rooms/{data['room_id']}/messages",
+        headers=headers,
+    )
+    assert messages_resp.status_code == 200
+    assert len(messages_resp.json()["messages"]) == 1
+
+
 # ---------------------------------------------------------------------------
 # POST /api/dashboard/chat/send
 # ---------------------------------------------------------------------------

--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -682,7 +682,7 @@ export default function DashboardApp() {
       ) : uiStore.sidebarTab === "bots" ? (
         <div className="flex-1 min-w-0">
           {uiStore.selectedBotAgentId ? (
-            <UserChatPane />
+            <UserChatPane agentId={uiStore.selectedBotAgentId} />
           ) : (
             <div className="flex h-full items-center justify-center px-6 text-center text-sm text-text-secondary/70">
               {/* Prompt rendered by DashboardApp to keep sidebar lean */}

--- a/frontend/src/components/dashboard/Sidebar.tsx
+++ b/frontend/src/components/dashboard/Sidebar.tsx
@@ -642,7 +642,6 @@ export default function Sidebar() {
                         <button
                           onClick={() => {
                             uiStore.setSelectedBotAgentId(bot.agent_id);
-                            void chatStore.switchActiveAgent(bot.agent_id);
                             startTransition(() => {
                               router.push(`/chats/bots/${encodeURIComponent(bot.agent_id)}`);
                             });

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -63,9 +63,10 @@ function TypewriterText({
 // Main component
 // ---------------------------------------------------------------------------
 
-export default function UserChatPane() {
+export default function UserChatPane({ agentId }: { agentId?: string | null }) {
   const { activeAgentId, activeIdentity } = useDashboardSessionStore();
   const isAgentMode = activeIdentity?.type === "agent" && !!activeAgentId;
+  const chatAgentId = agentId || (isAgentMode ? activeAgentId : null);
   const { setUserChatRoomId } = useDashboardUIStore();
 
   // Owner-chat store
@@ -89,27 +90,33 @@ export default function UserChatPane() {
   const wasNearBottomRef = useRef(true);
   const [, forceRender] = useState(0);
 
-  // WS hook — only when acting as an agent; human-mode keeps the hook idle.
+  // WS hook authenticates the selected owner-chat target explicitly. The plain
+  // user-chat route still stays idle unless the user is acting as an agent.
   const { wsClientRef, streamedTraceIds } = useOwnerChatWs({
-    activeAgentId: isAgentMode ? activeAgentId : null,
+    activeAgentId: chatAgentId,
     roomId,
-    agentName: chatRoomName || activeAgentId || "",
+    agentName: chatRoomName || chatAgentId || "",
   });
 
   // ------ Initialize chat room and load messages ------
   useEffect(() => {
-    if (!isAgentMode) return;
+    if (!chatAgentId) return;
     let cancelled = false;
 
     // Reset store for fresh agent
+    setInitError(null);
+    setChatRoomName("");
+    initialLoadRef.current = true;
+    prevLengthRef.current = 0;
+    animatedRef.current.clear();
     useOwnerChatStore.getState().reset();
 
-    api.getUserChatRoom()
+    api.getUserChatRoom(chatAgentId)
       .then((room) => {
         if (cancelled) return;
         setChatRoomName(room.name);
         setUserChatRoomId(room.room_id);
-        useOwnerChatStore.getState().setRoom(room.room_id, room.name || activeAgentId);
+        useOwnerChatStore.getState().setRoom(room.room_id, room.name || chatAgentId);
         return useOwnerChatStore.getState().loadInitial(room.room_id);
       })
       .catch((err) => {
@@ -119,7 +126,7 @@ export default function UserChatPane() {
 
     return () => { cancelled = true; };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeAgentId, isAgentMode]);
+  }, [chatAgentId]);
 
   // ------ Mark initial load messages as already animated ------
   useEffect(() => {
@@ -172,7 +179,7 @@ export default function UserChatPane() {
   const uploadFiles = useCallback(async (rawFiles: File[]): Promise<Attachment[]> => {
     const results: Attachment[] = [];
     for (const file of rawFiles) {
-      const res = await api.uploadFile(file);
+      const res = await api.uploadFile(file, chatAgentId);
       results.push({
         filename: res.original_filename,
         url: res.url,
@@ -181,7 +188,7 @@ export default function UserChatPane() {
       });
     }
     return results;
-  }, []);
+  }, [chatAgentId]);
 
   // ------ Send message ------
 
@@ -198,12 +205,12 @@ export default function UserChatPane() {
 
     // HTTP fallback
     try {
-      const result = await api.sendUserChatMessage(text, attachments);
+      const result = await api.sendUserChatMessage(text, attachments, chatAgentId || undefined);
       useOwnerChatStore.getState().confirmOptimistic(clientId, result.hub_msg_id, new Date().toISOString(), attachments);
     } catch (err: any) {
       useOwnerChatStore.getState().failOptimistic(clientId, err?.message || "Failed to send");
     }
-  }, [wsClientRef, wsConnected]);
+  }, [wsClientRef, wsConnected, chatAgentId]);
 
   const handleSend = useCallback(async (text: string, rawFiles: File[]) => {
     if ((!text && rawFiles.length === 0) || !roomId) return;
@@ -269,7 +276,7 @@ export default function UserChatPane() {
 
   // ------ Render guards ------
 
-  if (!isAgentMode) {
+  if (!chatAgentId) {
     return (
       <div className="flex items-center justify-center h-full text-zinc-500">
         <p>Switch to an agent identity to start chatting</p>
@@ -472,8 +479,8 @@ export default function UserChatPane() {
                       <span className="text-xs font-medium text-zinc-300">
                         {msg.senderName}
                       </span>
-                      {activeAgentId && (
-                        <CopyableId value={activeAgentId} className="text-zinc-500 hover:text-zinc-300" />
+                      {chatAgentId && (
+                        <CopyableId value={chatAgentId} className="text-zinc-500 hover:text-zinc-300" />
                       )}
                     </div>
                   )}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -576,12 +576,18 @@ export const api = {
 
   // --- User Chat (owner-agent direct messaging) ---
 
-  getUserChatRoom() {
-    return apiGet<UserChatRoom>("/api/dashboard/chat/room");
+  getUserChatRoom(agentId?: string | null) {
+    return apiGet<UserChatRoom>(
+      "/api/dashboard/chat/room",
+      agentId ? { agent_id: agentId } : undefined,
+    );
   },
 
-  sendUserChatMessage(text: string, attachments?: Attachment[]) {
+  sendUserChatMessage(text: string, attachments?: Attachment[], agentId?: string | null) {
     const body: Record<string, unknown> = { text };
+    if (agentId) {
+      body.agent_id = agentId;
+    }
     if (attachments && attachments.length > 0) {
       body.attachments = attachments;
     }
@@ -594,11 +600,14 @@ export const api = {
     return apiPost<RoomHumanSendResponse>(`/api/dashboard/rooms/${roomId}/send`, body);
   },
 
-  async uploadFile(file: File): Promise<FileUploadResult> {
+  async uploadFile(file: File, agentId?: string | null): Promise<FileUploadResult> {
     const headers = await buildAuthHeaders();
     const formData = new FormData();
     formData.append("file", file);
     const url = new URL("/api/dashboard/upload", API_BASE);
+    if (agentId) {
+      url.searchParams.set("agent_id", agentId);
+    }
     const res = await fetch(url.toString(), {
       method: "POST",
       headers,


### PR DESCRIPTION
## Summary
- keep My Bots list clicks from switching the global active agent identity
- pass the selected bot id into owner-chat room/send/upload calls
- allow owner-chat HTTP endpoints and history reads to target an explicitly owned bot

## Tests
- env UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_app/test_app_dashboard.py -q
- npx tsc --noEmit (fails on existing missing frontend API route/type modules in tests/api/*)