### PR TITLE
ci: use local protocol-core build when publishing daemon/plugin/cli

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -42,7 +42,7 @@ jobs:
       PKG_DIR: ${{ (github.event.inputs.package == 'protocol-core' || github.event.inputs.package == 'daemon') && format('packages/{0}', github.event.inputs.package) || github.event.inputs.package }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Resolve npm package name
         id: meta
@@ -58,7 +58,7 @@ jobs:
           echo "display_name=$DISPLAY_NAME" >> $GITHUB_OUTPUT
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
@@ -77,6 +77,20 @@ jobs:
           else
             npm install
           fi
+
+      - name: Override @botcord/protocol-core with local build
+        if: env.PKG == 'daemon' || env.PKG == 'plugin' || env.PKG == 'cli'
+        run: |
+          rm -rf node_modules/@botcord/protocol-core
+          mkdir -p node_modules/@botcord
+          # daemon lives in packages/daemon → ../protocol-core
+          # plugin/cli live at repo root → ../packages/protocol-core
+          if [ -d ../protocol-core/dist ]; then
+            cp -R ../protocol-core node_modules/@botcord/protocol-core
+          else
+            cp -R ../packages/protocol-core node_modules/@botcord/protocol-core
+          fi
+          ls node_modules/@botcord/protocol-core/dist | head -5
 
       - name: Build
         if: env.PKG == 'cli' || env.PKG == 'protocol-core' || env.PKG == 'daemon'


### PR DESCRIPTION
## Summary

- daemon publish CI was failing with \`Module '@botcord/protocol-core' has no exported member 'CONTROL_FRAME_TYPES'\` (and siblings for \`buildDaemonWebSocketUrl\`, \`runtime\`, \`cwd\`). Root cause: daemon's \`npm install\` pulls \`@botcord/protocol-core@^0.1.1\` from the npm registry, which lags the monorepo — the new exports/fields only exist in \`packages/protocol-core/src\`.
- After \`npm install\`, overwrite \`node_modules/@botcord/protocol-core\` with the locally built copy. Applies to daemon / plugin / cli (all three consume protocol-core; plugin & cli were already doing this via explicit \`npm install ../packages/protocol-core\` in ci.yml — this makes publish-package.yml consistent).
- Bumps \`actions/checkout@v4\` → \`v6\` and \`actions/setup-node@v4\` → \`v6\` to clear the Node 20 deprecation warning and match \`ci.yml\`.

## Test plan

- [ ] Manually trigger \`Publish Package\` with \`package=daemon\`, \`bump=patch\`, \`channel=beta\` → tsc builds green against locally built protocol-core.
- [ ] Re-run \`package=protocol-core\` publish to confirm no regression there.
- [ ] Confirm the deprecation warning on Node 20 actions is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)