### PR TITLE
feat(daemon): accept contact_request + append notify-owner hint (P2.2)

### DIFF
--- a/packages/daemon/src/__tests__/turn-text.test.ts
+++ b/packages/daemon/src/__tests__/turn-text.test.ts
@@ -99,6 +99,38 @@ describe("composeBotCordUserTurn", () => {
     expect(out).toBe("");
   });
 
+  it("appends the contact-request notify-owner hint when envelope.type is contact_request", () => {
+    const out = composeBotCordUserTurn(
+      makeMessage({
+        text: "Hi, please add me",
+        sender: { id: "ag_stranger", kind: "agent" },
+        conversation: { id: "rm_dm_x", kind: "direct" },
+        raw: { envelope: { type: "contact_request" } },
+      }),
+    );
+    expect(out).toContain("contact request from ag_stranger");
+    expect(out).toContain("botcord_notify tool");
+    // Base direct-chat hint should still appear above the contact-request hint.
+    expect(out).toContain("naturally concluded");
+    const baseIdx = out.indexOf("naturally concluded");
+    const crIdx = out.indexOf("contact request from");
+    expect(crIdx).toBeGreaterThan(baseIdx);
+  });
+
+  it("does NOT append the contact-request hint for a plain message envelope", () => {
+    const out = composeBotCordUserTurn(
+      makeMessage({
+        raw: { envelope: { type: "message" } },
+      }),
+    );
+    expect(out).not.toContain("contact request from");
+  });
+
+  it("does NOT append the contact-request hint when msg.raw has no envelope", () => {
+    const out = composeBotCordUserTurn(makeMessage({ raw: {} }));
+    expect(out).not.toContain("contact request from");
+  });
+
   it("sanitizes room names so newline-based injection can't reshape the header", () => {
     const out = composeBotCordUserTurn(
       makeMessage({

--- a/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
+++ b/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
@@ -255,6 +255,32 @@ describe("createBotCordChannel — inbox normalization", () => {
     }
   });
 
+  it("lets contact_request envelopes through so the composer can add the notify-owner hint", async () => {
+    const { emits, server } = await startWithInbox([
+      makeInbox({
+        hub_msg_id: "m_cr",
+        room_id: "rm_dm_peer",
+        text: "Hi, please add me",
+        envelope: {
+          type: "contact_request",
+          from: "ag_stranger",
+          payload: { text: "Hi, please add me" },
+        } as unknown as InboxMessage["envelope"],
+      }),
+    ]);
+    try {
+      expect(emits).toHaveLength(1);
+      const env = emits[0].message;
+      expect(env.sender.id).toBe("ag_stranger");
+      expect(env.text).toBe("Hi, please add me");
+      // Raw preserves envelope so turn-text can detect the type.
+      const raw = env.raw as { envelope?: { type?: string } };
+      expect(raw?.envelope?.type).toBe("contact_request");
+    } finally {
+      await server.close();
+    }
+  });
+
   it("sanitizes prompt-injection markers in untrusted text but not in owner-chat", async () => {
     const { emits, server } = await startWithInbox([
       makeInbox({

--- a/packages/daemon/src/gateway/channels/botcord.ts
+++ b/packages/daemon/src/gateway/channels/botcord.ts
@@ -147,7 +147,13 @@ function normalizeInbox(
 ): GatewayInboundMessage | null {
   const env = msg.envelope;
   if (!env) return null;
-  if (env.type !== "message") return null;
+  // `message` is the normal conversational envelope; `contact_request` is
+  // a lightweight inbound asking the agent to notify its owner (the
+  // composer appends the notify-owner hint). All other envelope types
+  // (notification, system, contact_added/removed, …) are still filtered
+  // out here — they belong in a separate push-notification path that
+  // daemon does not yet implement.
+  if (env.type !== "message" && env.type !== "contact_request") return null;
   if (!msg.room_id) return null;
 
   const rawText =

--- a/packages/daemon/src/turn-text.ts
+++ b/packages/daemon/src/turn-text.ts
@@ -35,6 +35,19 @@ const DIRECT_HINT =
   'reply with exactly "NO_REPLY" and nothing else.]';
 
 /**
+ * Read the BotCord envelope type from a raw inbound message. Returns
+ * `undefined` when the message didn't come from the BotCord channel or the
+ * raw shape is unexpected — callers treat that the same as "message".
+ */
+function readEnvelopeType(raw: unknown): string | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const env = (raw as { envelope?: unknown }).envelope;
+  if (!env || typeof env !== "object") return undefined;
+  const t = (env as { type?: unknown }).type;
+  return typeof t === "string" ? t : undefined;
+}
+
+/**
  * Compose the user-turn text for a BotCord inbound message.
  *
  * Contract (from `UserTurnBuilder`):
@@ -82,12 +95,29 @@ export function composeBotCordUserTurn(msg: GatewayInboundMessage): string {
 
   const hint = isGroup ? GROUP_HINT : DIRECT_HINT;
 
-  return [
+  // Contact-request envelopes travel through the same "inbound message"
+  // path as regular messages, but carry an additional expectation: the
+  // agent should surface the request to its owner rather than auto-accept
+  // or auto-reject. Mirrors `plugin/src/inbound.ts` §handleA2ASingle.
+  const isContactRequest = readEnvelopeType(msg.raw) === "contact_request";
+  const contactRequestHint = isContactRequest
+    ? "[You received a contact request from " +
+      sanitizedSenderLabel +
+      ". Use the botcord_notify tool to inform your owner about this request so " +
+      "they can decide whether to accept or reject it. Include the sender's " +
+      "agent ID and any message they attached.]"
+    : null;
+
+  const lines: string[] = [
     headerFields.join(" | "),
     `<${tag} sender="${sanitizedSenderLabel}" sender_kind="${senderKindAttr}">`,
     trimmed,
     `</${tag}>`,
     "",
     hint,
-  ].join("\n");
+  ];
+  if (contactRequestHint) {
+    lines.push("", contactRequestHint);
+  }
+  return lines.join("\n");
 }


### PR DESCRIPTION
P2.2 of the prompt-scaffolding plan. Mirrors plugin's `contact_request` handling so Claude Code in daemon-mode sees the same "tell your owner, don't auto-decide" framing that plugin agents receive.

## Changes
- **gateway/channels/botcord.ts**: relax the envelope-type filter in `normalizeInbox` so `contact_request` flows through alongside `message`. All other non-message types (notification, system, contact_added/removed, …) still drop here; they belong in a push-notification path daemon does not yet implement.
- **turn-text.ts**: when `msg.raw.envelope.type === "contact_request"`, append the plugin's exact notify-owner hint after the base NO_REPLY hint.

## Tests
+4 cases (404/404 green):
- channel-level passthrough for contact_request envelopes
- composer hint emission + ordering (after the base hint)
- no hint on plain `message`
- no hint on raw shapes that don't carry `envelope.type`

🤖 Generated with [Claude Code](https://claude.com/claude-code)