### PR TITLE
feat(daemon): port loop-risk guard (P2.1)

### DIFF
--- a/packages/daemon/src/__tests__/loop-risk.test.ts
+++ b/packages/daemon/src/__tests__/loop-risk.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildLoopRiskPrompt,
+  clearLoopRiskSession,
+  evaluateLoopRisk,
+  loopRiskSessionKey,
+  recordInboundText,
+  recordOutboundText,
+  resetLoopRiskStateForTests,
+  stripBotCordPromptScaffolding,
+} from "../loop-risk.js";
+
+afterEach(() => {
+  resetLoopRiskStateForTests();
+});
+
+describe("stripBotCordPromptScaffolding", () => {
+  it("removes headers, hints, and wrapper tags but keeps the actual body", () => {
+    const wrapped = [
+      "[BotCord Message] | from: ag_alice | to: ag_me | room: Team",
+      '<agent-message sender="ag_alice" sender_kind="agent">',
+      "hello world",
+      "</agent-message>",
+      "",
+      '[In group chats, do NOT reply unless you are explicitly mentioned or addressed. If no response is needed, reply with exactly "NO_REPLY" and nothing else.]',
+    ].join("\n");
+    expect(stripBotCordPromptScaffolding(wrapped)).toBe("hello world");
+  });
+
+  it("leaves plain text untouched", () => {
+    expect(stripBotCordPromptScaffolding("just a line")).toBe("just a line");
+  });
+});
+
+describe("evaluateLoopRisk", () => {
+  const key = "ag_me:rm_team:";
+
+  it("returns no reasons for an unknown session", () => {
+    expect(evaluateLoopRisk({ sessionKey: "unknown" })).toEqual({ reasons: [] });
+  });
+
+  it("flags short_ack_tail when the last two inbound messages are both acks", () => {
+    const now = 1_700_000_000_000;
+    recordInboundText({ sessionKey: key, text: "Let's ship it", timestamp: now - 3000 });
+    recordInboundText({ sessionKey: key, text: "Thanks!", timestamp: now - 2000 });
+    recordInboundText({ sessionKey: key, text: "好的", timestamp: now - 1000 });
+    const out = evaluateLoopRisk({ sessionKey: key, now });
+    expect(out.reasons.some((r) => r.id === "short_ack_tail")).toBe(true);
+  });
+
+  it("does NOT flag short_ack_tail when only one message is an ack", () => {
+    const now = 1_700_000_000_000;
+    recordInboundText({ sessionKey: key, text: "Can you help with X?", timestamp: now - 2000 });
+    recordInboundText({ sessionKey: key, text: "OK", timestamp: now - 1000 });
+    const out = evaluateLoopRisk({ sessionKey: key, now });
+    expect(out.reasons.some((r) => r.id === "short_ack_tail")).toBe(false);
+  });
+
+  it("flags repeated_outbound when the last outbound reply matches the previous one exactly", () => {
+    const now = 1_700_000_000_000;
+    recordOutboundText({ sessionKey: key, text: "Got it, thanks!", timestamp: now - 2000 });
+    recordOutboundText({ sessionKey: key, text: "Got it, thanks!", timestamp: now - 1000 });
+    const out = evaluateLoopRisk({ sessionKey: key, now });
+    expect(out.reasons.some((r) => r.id === "repeated_outbound")).toBe(true);
+  });
+
+  it("flags repeated_outbound on high trigram similarity (>= 0.88)", () => {
+    const now = 1_700_000_000_000;
+    const a = "Sounds good, I'll take care of that shortly.";
+    const b = "Sounds good, I'll take care of that shortly!";
+    const c = "Sounds good, I'll take care of that shortly :)";
+    recordOutboundText({ sessionKey: key, text: a, timestamp: now - 3000 });
+    recordOutboundText({ sessionKey: key, text: b, timestamp: now - 2000 });
+    recordOutboundText({ sessionKey: key, text: c, timestamp: now - 1000 });
+    const out = evaluateLoopRisk({ sessionKey: key, now });
+    expect(out.reasons.some((r) => r.id === "repeated_outbound")).toBe(true);
+  });
+
+  it("flags high_turn_rate on rapid user↔assistant alternation", () => {
+    const now = 1_700_000_000_000;
+    // 8 turns over the last 60s, tightly alternating.
+    const base = now - 60_000;
+    for (let i = 0; i < 4; i++) {
+      recordInboundText({
+        sessionKey: key,
+        text: `inbound ${i}`,
+        timestamp: base + i * 14_000,
+      });
+      recordOutboundText({
+        sessionKey: key,
+        text: `outbound ${i}`,
+        timestamp: base + i * 14_000 + 7_000,
+      });
+    }
+    const out = evaluateLoopRisk({ sessionKey: key, now });
+    expect(out.reasons.some((r) => r.id === "high_turn_rate")).toBe(true);
+  });
+
+  it("does NOT flag high_turn_rate when the turns are spread out beyond the 2-minute window", () => {
+    const now = 1_700_000_000_000;
+    const base = now - 5 * 60_000;
+    for (let i = 0; i < 4; i++) {
+      recordInboundText({
+        sessionKey: key,
+        text: `in ${i}`,
+        timestamp: base + i * 30_000,
+      });
+      recordOutboundText({
+        sessionKey: key,
+        text: `out ${i}`,
+        timestamp: base + i * 30_000 + 1000,
+      });
+    }
+    const out = evaluateLoopRisk({ sessionKey: key, now });
+    expect(out.reasons.some((r) => r.id === "high_turn_rate")).toBe(false);
+  });
+
+  it("prunes samples older than the 10-minute max age", () => {
+    const now = 1_700_000_000_000;
+    recordOutboundText({ sessionKey: key, text: "ancient", timestamp: now - 20 * 60_000 });
+    recordOutboundText({ sessionKey: key, text: "ancient", timestamp: now - 15 * 60_000 });
+    // Same text immediately before now would trigger repeated_outbound if the
+    // old samples survived; they should be pruned, so no flag fires.
+    recordOutboundText({ sessionKey: key, text: "ancient", timestamp: now });
+    const out = evaluateLoopRisk({ sessionKey: key, now });
+    expect(out.reasons.some((r) => r.id === "repeated_outbound")).toBe(false);
+  });
+
+  it("clearLoopRiskSession drops all state for the given key", () => {
+    const now = 1_700_000_000_000;
+    recordOutboundText({ sessionKey: key, text: "same", timestamp: now - 1000 });
+    recordOutboundText({ sessionKey: key, text: "same", timestamp: now });
+    clearLoopRiskSession(key);
+    expect(evaluateLoopRisk({ sessionKey: key, now }).reasons).toEqual([]);
+  });
+});
+
+describe("buildLoopRiskPrompt", () => {
+  const key = "ag_me:rm_x:";
+
+  it("returns null when no risk is detected", () => {
+    expect(buildLoopRiskPrompt({ sessionKey: key })).toBeNull();
+  });
+
+  it("renders the full prompt block when a risk fires", () => {
+    const now = 1_700_000_000_000;
+    recordOutboundText({ sessionKey: key, text: "same outbound", timestamp: now - 1000 });
+    recordOutboundText({ sessionKey: key, text: "same outbound", timestamp: now });
+    const out = buildLoopRiskPrompt({ sessionKey: key, now });
+    expect(out).toContain("[BotCord loop-risk check]");
+    expect(out).toContain("Observed signals:");
+    expect(out).toContain("recent outbound texts in this session are highly similar");
+    expect(out).toContain('reply with exactly "NO_REPLY"');
+  });
+});
+
+describe("loopRiskSessionKey", () => {
+  it("includes threadId when present", () => {
+    expect(
+      loopRiskSessionKey({ accountId: "ag_me", conversationId: "rm_1", threadId: "tp_a" }),
+    ).toBe("ag_me:rm_1:tp_a");
+  });
+
+  it("uses empty string for threadId when null/undefined", () => {
+    expect(loopRiskSessionKey({ accountId: "ag_me", conversationId: "rm_1" })).toBe(
+      "ag_me:rm_1:",
+    );
+    expect(
+      loopRiskSessionKey({ accountId: "ag_me", conversationId: "rm_1", threadId: null }),
+    ).toBe("ag_me:rm_1:");
+  });
+});

--- a/packages/daemon/src/__tests__/system-context.test.ts
+++ b/packages/daemon/src/__tests__/system-context.test.ts
@@ -288,6 +288,41 @@ describe("createDaemonSystemContextBuilder", () => {
     expect(out).toBeUndefined();
   });
 
+  it("appends loopRiskBuilder output at the end of the system context", async () => {
+    const builder = createDaemonSystemContextBuilder({
+      agentId: "ag_me",
+      roomContextBuilder: async () => null,
+      loopRiskBuilder: () => "[BotCord loop-risk check]\nObserved signals:\n- x",
+    });
+    const out = await builder(
+      makeMessage({ conversation: { id: "rm_team", kind: "group" } }),
+    );
+    expect(typeof out).toBe("string");
+    expect(out).toContain("[BotCord loop-risk check]");
+  });
+
+  it("also injects loopRiskBuilder in the sync (no roomContextBuilder) branch", () => {
+    const builder = createDaemonSystemContextBuilder({
+      agentId: "ag_me",
+      loopRiskBuilder: () => "[BotCord loop-risk check]\nObserved signals:\n- y",
+    });
+    const out = builder(makeMessage()) as string | undefined;
+    expect(typeof out).toBe("string");
+    expect(out).toContain("[BotCord loop-risk check]");
+  });
+
+  it("skips loopRiskBuilder gracefully when it throws", async () => {
+    const builder = createDaemonSystemContextBuilder({
+      agentId: "ag_me",
+      roomContextBuilder: async () => null,
+      loopRiskBuilder: () => {
+        throw new Error("oops");
+      },
+    });
+    const out = await builder(makeMessage());
+    expect(out).toBeUndefined();
+  });
+
   it("translates GatewayInboundMessage.conversation.id → old `room_id` for the digest exclude key", () => {
     const tracker = new ActivityTracker({
       filePath: path.join(tmpDir, "activity.json"),

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6,6 +6,7 @@ import {
   type ChannelAdapter,
   type GatewayChannelConfig,
   type GatewayInboundMessage,
+  type GatewayOutboundMessage,
   type GatewayLogger,
   type GatewayRuntimeSnapshot,
 } from "./gateway/index.js";
@@ -22,6 +23,12 @@ import { SnapshotWriter } from "./snapshot-writer.js";
 import { createDaemonSystemContextBuilder } from "./system-context.js";
 import { createRoomStaticContextBuilder } from "./room-context.js";
 import { createRoomContextFetcher } from "./room-context-fetcher.js";
+import {
+  buildLoopRiskPrompt,
+  loopRiskSessionKey,
+  recordInboundText as recordLoopRiskInbound,
+  recordOutboundText as recordLoopRiskOutbound,
+} from "./loop-risk.js";
 import { composeBotCordUserTurn } from "./turn-text.js";
 import { UserAuthManager } from "./user-auth.js";
 
@@ -245,6 +252,14 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
     msg: GatewayInboundMessage,
   ) => Promise<string | undefined> | string | undefined;
   const scBuilders = new Map<string, PerAgentBuilder>();
+  const loopRiskBuilder = (msg: GatewayInboundMessage): string | null =>
+    buildLoopRiskPrompt({
+      sessionKey: loopRiskSessionKey({
+        accountId: msg.accountId,
+        conversationId: msg.conversation.id,
+        threadId: msg.conversation.threadId ?? null,
+      }),
+    });
   for (const aid of agentIds) {
     scBuilders.set(
       aid,
@@ -252,6 +267,7 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
         agentId: aid,
         activityTracker,
         roomContextBuilder,
+        loopRiskBuilder,
       }),
     );
   }
@@ -274,10 +290,34 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
   // outside the system-context builder (option A) means the builder stays
   // pure — a cleaner contract the gateway can also expose to non-daemon
   // callers in the future.
-  const onInbound = createActivityRecorder({
+  const recordActivity = createActivityRecorder({
     activityTracker,
     ...(agentIds[0] ? { fallbackAgentId: agentIds[0] } : {}),
   });
+  const onInbound = (msg: GatewayInboundMessage): void => {
+    recordActivity(msg);
+    // Feed the loop-risk tracker with the sanitized inbound text so
+    // detectShortAckTail + detectHighTurnRate have a timeline.
+    recordLoopRiskInbound({
+      sessionKey: loopRiskSessionKey({
+        accountId: msg.accountId,
+        conversationId: msg.conversation.id,
+        threadId: msg.conversation.threadId ?? null,
+      }),
+      text: msg.text,
+      timestamp: msg.receivedAt,
+    });
+  };
+  const onOutbound = (out: GatewayOutboundMessage): void => {
+    recordLoopRiskOutbound({
+      sessionKey: loopRiskSessionKey({
+        accountId: out.accountId,
+        conversationId: out.conversationId,
+        threadId: out.threadId ?? null,
+      }),
+      text: out.text,
+    });
+  };
 
   const gateway = new Gateway({
     config: gwConfig,
@@ -298,6 +338,7 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
     turnTimeoutMs: DEFAULT_TURN_TIMEOUT_MS,
     buildSystemContext,
     onInbound,
+    onOutbound,
     composeUserTurn: composeBotCordUserTurn,
   });
 

--- a/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
+++ b/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
@@ -350,6 +350,46 @@ describe("Dispatcher", () => {
     expect(runtime.calls[0].text).toBe("hello");
   });
 
+  it("fires onOutbound after a reply is dispatched", async () => {
+    const runtime = new FakeRuntime({ reply: "hello back", newSessionId: "sid-1" });
+    const { store, dir } = await makeStore();
+    tempDirs.push(dir);
+    const channel = new FakeChannel();
+    const outbound: string[] = [];
+    const dispatcher = new Dispatcher({
+      config: baseConfig(),
+      channels: new Map<string, ChannelAdapter>([[channel.id, channel]]),
+      runtime: () => runtime,
+      sessionStore: store,
+      log: silentLogger(),
+      onOutbound: (msg) => {
+        outbound.push(msg.text);
+      },
+    });
+    await dispatcher.handle(makeEnvelope({ id: "msg_1", text: "hi" }));
+    expect(outbound).toEqual(["hello back"]);
+  });
+
+  it("does not crash when onOutbound throws", async () => {
+    const runtime = new FakeRuntime({ reply: "hello back", newSessionId: "sid-1" });
+    const { store, dir } = await makeStore();
+    tempDirs.push(dir);
+    const channel = new FakeChannel();
+    const dispatcher = new Dispatcher({
+      config: baseConfig(),
+      channels: new Map<string, ChannelAdapter>([[channel.id, channel]]),
+      runtime: () => runtime,
+      sessionStore: store,
+      log: silentLogger(),
+      onOutbound: () => {
+        throw new Error("boom");
+      },
+    });
+    await dispatcher.handle(makeEnvelope({ id: "msg_1", text: "hi" }));
+    // Reply still went out; no assertion needed beyond the absence of a throw.
+    expect(channel.sends.length).toBe(1);
+  });
+
   it("does not crash when an errored turn has no prior session entry", async () => {
     const runtime = new FakeRuntime({ newSessionId: "", errorText: "boom" });
     const { dispatcher, store } = await scaffold({ runtimeFactory: () => runtime });

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -9,6 +9,7 @@ import type {
   GatewayRoute,
   GatewaySessionEntry,
   InboundObserver,
+  OutboundObserver,
   QueueMode,
   RuntimeAdapter,
   StreamBlock,
@@ -58,6 +59,12 @@ export interface DispatcherOptions {
    * a fallback so a buggy composer cannot drop turns.
    */
   composeUserTurn?: UserTurnBuilder;
+  /**
+   * Optional observer fired after each reply is dispatched. Intended for
+   * outbound bookkeeping such as loop-risk tracking. Errors are logged
+   * and suppressed so observer failures never break the turn.
+   */
+  onOutbound?: OutboundObserver;
 }
 
 interface TurnSlot {
@@ -102,6 +109,7 @@ export class Dispatcher {
   private readonly turnTimeoutMs: number;
   private readonly buildSystemContext?: SystemContextBuilder;
   private readonly onInbound?: InboundObserver;
+  private readonly onOutbound?: OutboundObserver;
   private readonly composeUserTurn?: UserTurnBuilder;
   private readonly managedRoutes?: Map<string, GatewayRoute>;
   private readonly queues: Map<string, QueueState> = new Map();
@@ -115,6 +123,7 @@ export class Dispatcher {
     this.turnTimeoutMs = opts.turnTimeoutMs ?? DEFAULT_TURN_TIMEOUT_MS;
     this.buildSystemContext = opts.buildSystemContext;
     this.onInbound = opts.onInbound;
+    this.onOutbound = opts.onOutbound;
     this.composeUserTurn = opts.composeUserTurn;
     this.managedRoutes = opts.managedRoutes;
   }
@@ -532,6 +541,17 @@ export class Dispatcher {
         conversationId: outbound.conversationId,
         error: err instanceof Error ? err.message : String(err),
       });
+      return;
+    }
+    if (this.onOutbound) {
+      try {
+        await this.onOutbound(outbound);
+      } catch (err) {
+        this.log.warn("dispatcher: onOutbound threw — continuing", {
+          conversationId: outbound.conversationId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
   }
 }

--- a/packages/daemon/src/gateway/gateway.ts
+++ b/packages/daemon/src/gateway/gateway.ts
@@ -10,6 +10,7 @@ import type {
   GatewayRoute,
   GatewayRuntimeSnapshot,
   InboundObserver,
+  OutboundObserver,
   SystemContextBuilder,
   UserTurnBuilder,
 } from "./types.js";
@@ -42,6 +43,11 @@ export interface GatewayBootOptions {
    * to the runtime. Forwarded to the dispatcher; see {@link UserTurnBuilder}.
    */
   composeUserTurn?: UserTurnBuilder;
+  /**
+   * Optional observer fired after each reply is sent. Intended for outbound
+   * bookkeeping like loop-risk tracking.
+   */
+  onOutbound?: OutboundObserver;
 }
 
 /** Default runtime factory: delegates to the built-in registry; ignores extraArgs at construction. */
@@ -110,6 +116,7 @@ export class Gateway {
       buildSystemContext: opts.buildSystemContext,
       onInbound: opts.onInbound,
       composeUserTurn: opts.composeUserTurn,
+      onOutbound: opts.onOutbound,
       managedRoutes: this.managedRoutes,
     });
 

--- a/packages/daemon/src/gateway/types.ts
+++ b/packages/daemon/src/gateway/types.ts
@@ -138,6 +138,15 @@ export type InboundObserver = (
  */
 export type UserTurnBuilder = (message: GatewayInboundMessage) => string;
 
+/**
+ * Optional hook fired after the dispatcher dispatches a reply to a channel.
+ * Intended for outbound bookkeeping (loop-risk tracking, metrics). Errors
+ * are caught and logged so observer failures never break the turn.
+ */
+export type OutboundObserver = (
+  message: GatewayOutboundMessage,
+) => Promise<void> | void;
+
 /** Outbound reply payload passed to `ChannelAdapter.send()`. */
 export interface GatewayOutboundMessage {
   channel: string;

--- a/packages/daemon/src/loop-risk.ts
+++ b/packages/daemon/src/loop-risk.ts
@@ -1,0 +1,322 @@
+/**
+ * Loop-risk guard — detects patterns that suggest two daemon-hosted agents
+ * are stuck echoing each other (or that a conversation has naturally
+ * wound down but both sides keep sending courtesy acks). When triggered,
+ * `buildLoopRiskPrompt()` returns an injected hint that encourages the
+ * agent to reply with `NO_REPLY` unless it has something substantive to
+ * add.
+ *
+ * Ported from `plugin/src/loop-risk.ts` with one structural change: plugin
+ * has OpenClaw's message transcript available (`messages: unknown[]`) so
+ * it can reconstruct historical user turns on demand. Daemon does not —
+ * Claude Code owns the transcript, not daemon. So daemon records inbound
+ * texts in a module-level map the same way plugin records outbound ones.
+ *
+ * Detectors:
+ *   - high_turn_rate  — many user↔assistant alternations in a short window
+ *   - short_ack_tail  — the last two inbound texts are acks / closure phrases
+ *   - repeated_outbound — recent outbound replies are highly similar
+ */
+
+interface Sample {
+  text: string;
+  normalized: string;
+  timestamp: number;
+}
+
+export type LoopRiskReason = {
+  id: "high_turn_rate" | "short_ack_tail" | "repeated_outbound";
+  summary: string;
+};
+
+export interface LoopRiskEvaluation {
+  reasons: LoopRiskReason[];
+}
+
+// Module-level state. Keys are caller-supplied session identifiers
+// (daemon uses `${accountId}:${conversationId}:${threadId ?? ""}`).
+const inboundBySession = new Map<string, Sample[]>();
+const outboundBySession = new Map<string, Sample[]>();
+
+// --- Tunables ---------------------------------------------------------
+
+const TURN_WINDOW_MS = 2 * 60_000;
+const TURN_THRESHOLD = 8;
+const ALTERNATION_THRESHOLD = 6;
+const MIN_TURNS_PER_SIDE = 3;
+
+const SAMPLE_MAX_AGE_MS = 10 * 60_000;
+const MAX_TRACKED_PER_SIDE = 6;
+
+const SHORT_ACK_MAX_CHARS = 48;
+const MIN_REPEAT_TEXT_CHARS = 6;
+const OUTBOUND_SIMILARITY_THRESHOLD = 0.88;
+
+// --- Ack / closure phrase lists (mirrors plugin) ----------------------
+
+const ENGLISH_ACK_OR_CLOSURE = new Set([
+  "ok", "okay", "got it", "thanks", "thank you", "noted", "understood",
+  "sounds good", "sgtm", "roger", "copy", "will do", "all good",
+  "no worries", "bye", "goodbye", "see you", "talk later",
+]);
+
+const CHINESE_ACK_OR_CLOSURE = new Set([
+  "收到", "好的", "好", "行", "嗯", "嗯嗯", "明白", "明白了", "知道了",
+  "谢谢", "谢谢你", "感谢", "辛苦了", "先这样", "回头聊", "有需要再说",
+  "没问题", "了解", "好嘞",
+]);
+
+// --- Text normalization -----------------------------------------------
+
+/**
+ * Strip the `[BotCord Message] | …` header and `<agent-message>` / hint
+ * wrappers the user-turn composer adds around the raw inbound text. Leaves
+ * the plain body so similarity / ack detection operates on actual content.
+ * Kept in sync with `turn-text.ts` output shape.
+ */
+export function stripBotCordPromptScaffolding(text: string): string {
+  const filtered = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => {
+      if (!line) return false;
+      if (line.startsWith("[BotCord Message]")) return false;
+      if (line.startsWith("[BotCord Notification]")) return false;
+      if (line.startsWith("[Room Rule]")) return false;
+      if (line.startsWith("[In group chats, do NOT reply")) return false;
+      if (line.startsWith("[If the conversation has naturally concluded")) return false;
+      if (line.startsWith("[You received a contact request")) return false;
+      if (line.includes('reply with exactly "NO_REPLY"')) return false;
+      if (line.startsWith("<agent-message")) return false;
+      if (line === "</agent-message>") return false;
+      if (line.startsWith("<human-message")) return false;
+      if (line === "</human-message>") return false;
+      return true;
+    });
+  return filtered.join("\n").trim();
+}
+
+export function normalizeLoopText(text: string): string {
+  return stripBotCordPromptScaffolding(text)
+    .toLowerCase()
+    .replace(/https?:\/\/\S+/gu, " ")
+    .replace(/[^\p{L}\p{N}\s]/gu, " ")
+    .replace(/\s+/gu, " ")
+    .trim();
+}
+
+function isShortAckOrClosure(text: string): boolean {
+  const n = normalizeLoopText(text);
+  if (!n || n.length > SHORT_ACK_MAX_CHARS) return false;
+  return ENGLISH_ACK_OR_CLOSURE.has(n) || CHINESE_ACK_OR_CLOSURE.has(n);
+}
+
+// --- Similarity -------------------------------------------------------
+
+function trigramSet(text: string): Set<string> {
+  if (text.length <= 3) return new Set([text]);
+  const grams = new Set<string>();
+  for (let i = 0; i <= text.length - 3; i++) grams.add(text.slice(i, i + 3));
+  return grams;
+}
+
+function jaccardSimilarity(a: string, b: string): number {
+  if (!a || !b) return 0;
+  if (a === b) return 1;
+  const A = trigramSet(a);
+  const B = trigramSet(b);
+  let inter = 0;
+  for (const g of A) if (B.has(g)) inter++;
+  const union = A.size + B.size - inter;
+  return union === 0 ? 0 : inter / union;
+}
+
+function areOutboundTextsHighlySimilar(a: string, b: string): boolean {
+  if (!a || !b) return false;
+  if (a === b) return true;
+  if (a.length < MIN_REPEAT_TEXT_CHARS || b.length < MIN_REPEAT_TEXT_CHARS) return false;
+  return jaccardSimilarity(a, b) >= OUTBOUND_SIMILARITY_THRESHOLD;
+}
+
+// --- Sample store -----------------------------------------------------
+
+function prune(map: Map<string, Sample[]>, sessionKey: string, now: number): Sample[] {
+  const existing = map.get(sessionKey) ?? [];
+  const next = existing.filter((s) => now - s.timestamp <= SAMPLE_MAX_AGE_MS);
+  if (next.length === 0) {
+    map.delete(sessionKey);
+    return [];
+  }
+  map.set(sessionKey, next);
+  return next;
+}
+
+function record(
+  map: Map<string, Sample[]>,
+  sessionKey: string,
+  sample: Sample,
+): void {
+  const kept = prune(map, sessionKey, sample.timestamp);
+  const next = [...kept, sample].slice(-MAX_TRACKED_PER_SIDE);
+  map.set(sessionKey, next);
+}
+
+export function recordInboundText(params: {
+  sessionKey?: string;
+  text?: unknown;
+  timestamp?: number;
+}): void {
+  const sessionKey = params.sessionKey?.trim();
+  const raw = typeof params.text === "string" ? params.text.trim() : "";
+  if (!sessionKey || !raw) return;
+  const normalized = normalizeLoopText(raw);
+  if (!normalized) return;
+  record(inboundBySession, sessionKey, {
+    text: raw,
+    normalized,
+    timestamp: params.timestamp ?? Date.now(),
+  });
+}
+
+export function recordOutboundText(params: {
+  sessionKey?: string;
+  text?: unknown;
+  timestamp?: number;
+}): void {
+  const sessionKey = params.sessionKey?.trim();
+  const raw = typeof params.text === "string" ? params.text.trim() : "";
+  if (!sessionKey || !raw) return;
+  const normalized = normalizeLoopText(raw);
+  if (!normalized) return;
+  record(outboundBySession, sessionKey, {
+    text: raw,
+    normalized,
+    timestamp: params.timestamp ?? Date.now(),
+  });
+}
+
+export function clearLoopRiskSession(sessionKey?: string): void {
+  if (!sessionKey) return;
+  inboundBySession.delete(sessionKey);
+  outboundBySession.delete(sessionKey);
+}
+
+export function resetLoopRiskStateForTests(): void {
+  inboundBySession.clear();
+  outboundBySession.clear();
+}
+
+// --- Detectors --------------------------------------------------------
+
+function detectHighTurnRate(inbound: Sample[], outbound: Sample[], now: number):
+  LoopRiskReason | undefined {
+  const timeline: Array<{ role: "user" | "assistant"; timestamp: number }> = [];
+  for (const s of inbound) {
+    if (now - s.timestamp <= TURN_WINDOW_MS) timeline.push({ role: "user", timestamp: s.timestamp });
+  }
+  for (const s of outbound) {
+    if (now - s.timestamp <= TURN_WINDOW_MS) timeline.push({ role: "assistant", timestamp: s.timestamp });
+  }
+  if (timeline.length < TURN_THRESHOLD) return undefined;
+  timeline.sort((a, b) => a.timestamp - b.timestamp);
+
+  let userTurns = 0;
+  let assistantTurns = 0;
+  let alternations = 0;
+  for (let i = 0; i < timeline.length; i++) {
+    if (timeline[i]!.role === "user") userTurns++;
+    else assistantTurns++;
+    if (i > 0 && timeline[i]!.role !== timeline[i - 1]!.role) alternations++;
+  }
+
+  if (
+    userTurns >= MIN_TURNS_PER_SIDE &&
+    assistantTurns >= MIN_TURNS_PER_SIDE &&
+    alternations >= ALTERNATION_THRESHOLD
+  ) {
+    return {
+      id: "high_turn_rate",
+      summary: `same session shows ${timeline.length} user/assistant turns within ${Math.round(TURN_WINDOW_MS / 1000)}s`,
+    };
+  }
+  return undefined;
+}
+
+function detectShortAckTail(inbound: Sample[]): LoopRiskReason | undefined {
+  const tail = inbound.slice(-2);
+  if (tail.length < 2) return undefined;
+  if (tail.every((s) => isShortAckOrClosure(s.text))) {
+    return {
+      id: "short_ack_tail",
+      summary: "the last two inbound user messages are short acknowledgements or closure phrases",
+    };
+  }
+  return undefined;
+}
+
+function detectRepeatedOutbound(outbound: Sample[]): LoopRiskReason | undefined {
+  const recent = outbound.slice(-3);
+  if (recent.length < 2) return undefined;
+  const last = recent[recent.length - 1];
+  if (!last) return undefined;
+  const previous = recent.slice(0, -1);
+  const exact = previous.filter((s) => s.normalized === last.normalized).length;
+  const similar = previous.filter((s) =>
+    areOutboundTextsHighlySimilar(s.normalized, last.normalized),
+  ).length;
+  if (exact >= 1 || (recent.length >= 3 && similar >= 2)) {
+    return {
+      id: "repeated_outbound",
+      summary: "recent outbound texts in this session are highly similar",
+    };
+  }
+  return undefined;
+}
+
+export function evaluateLoopRisk(params: {
+  sessionKey?: string;
+  now?: number;
+}): LoopRiskEvaluation {
+  const now = params.now ?? Date.now();
+  if (!params.sessionKey) return { reasons: [] };
+  const inbound = prune(inboundBySession, params.sessionKey, now);
+  const outbound = prune(outboundBySession, params.sessionKey, now);
+  const reasons = [
+    detectHighTurnRate(inbound, outbound, now),
+    detectShortAckTail(inbound),
+    detectRepeatedOutbound(outbound),
+  ].filter((r): r is LoopRiskReason => Boolean(r));
+  return { reasons };
+}
+
+/** Build the injected system-context hint, or `null` if no risk detected. */
+export function buildLoopRiskPrompt(params: {
+  sessionKey?: string;
+  now?: number;
+}): string | null {
+  const evaluation = evaluateLoopRisk(params);
+  if (evaluation.reasons.length === 0) return null;
+  return [
+    "[BotCord loop-risk check]",
+    "Observed signals:",
+    ...evaluation.reasons.map((r) => `- ${r.summary}`),
+    "",
+    "Before sending any BotCord reply, verify that it adds new information, concrete progress, a blocking question, or a final result/error.",
+    'If it does not, reply with exactly "NO_REPLY" and nothing else.',
+    "Do not send courtesy-only acknowledgements or mirrored sign-offs.",
+  ].join("\n");
+}
+
+/**
+ * Derive a loop-risk session key from a gateway inbound message or
+ * outbound reply. Keyed on (accountId, conversationId, threadId) so a
+ * DM and a group thread under the same agent don't share state.
+ */
+export function loopRiskSessionKey(params: {
+  accountId: string;
+  conversationId: string;
+  threadId?: string | null;
+}): string {
+  const thread = params.threadId ?? "";
+  return `${params.accountId}:${params.conversationId}:${thread}`;
+}

--- a/packages/daemon/src/system-context.ts
+++ b/packages/daemon/src/system-context.ts
@@ -69,6 +69,12 @@ export interface SystemContextDeps {
    * is skipped.
    */
   roomContextBuilder?: RoomStaticContextBuilder;
+  /**
+   * Optional per-turn loop-risk check. Returns a warning block when the
+   * session shows signs of agent-to-agent echo or courtesy loops. Sync
+   * + cheap — consulted every turn even when roomContextBuilder is absent.
+   */
+  loopRiskBuilder?: (message: GatewayInboundMessage) => string | null;
 }
 
 function safeReadWorkingMemory(agentId: string) {
@@ -122,10 +128,27 @@ export function createDaemonSystemContextBuilder(
     return filtered.length > 0 ? filtered.join("\n\n") : undefined;
   };
 
+  const runLoopRisk = (message: GatewayInboundMessage): string | null => {
+    if (!deps.loopRiskBuilder) return null;
+    try {
+      return deps.loopRiskBuilder(message);
+    } catch (err) {
+      log.warn("system-context: loopRiskBuilder threw — skipping loop-risk block", {
+        agentId: deps.agentId,
+        roomId: message.conversation.id,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
+  };
+
   if (!deps.roomContextBuilder) {
     const syncBuilder = (message: GatewayInboundMessage): string | undefined => {
       const { ownerScene, memory, digest } = gatherSyncBlocks(message);
-      return assemble([ownerScene, memory, digest]);
+      // Loop-risk sits at the end so its "reply NO_REPLY unless…" guidance
+      // is the last thing the model sees before the user turn body.
+      const loopRisk = runLoopRisk(message);
+      return assemble([ownerScene, memory, digest, loopRisk]);
     };
     // Compile-time witness that the narrower sync signature still satisfies
     // `SystemContextBuilder` (which allows async). Prevents the two contracts
@@ -154,7 +177,8 @@ export function createDaemonSystemContextBuilder(
         err: err instanceof Error ? err.message : String(err),
       });
     }
-    return assemble([ownerScene, memory, roomBlock, digest]);
+    const loopRisk = runLoopRisk(message);
+    return assemble([ownerScene, memory, roomBlock, digest, loopRisk]);
   };
   const _typecheck: SystemContextBuilder = asyncBuilder;
   void _typecheck;


### PR DESCRIPTION
P2.1 of the prompt-scaffolding plan. Ports plugin's `loop-risk.ts` into daemon so Claude Code stops emitting courtesy acknowledgements / mirrored sign-offs when the conversation has wound down, and notices when two agents are stuck echoing each other.

## Detectors
- **high_turn_rate** — ≥8 alternating user/assistant turns in 2 min (≥6 alternations, ≥3 per side)
- **short_ack_tail** — last two inbound texts are short acks / closures (en + zh)
- **repeated_outbound** — recent outbound replies are exact or trigram-Jaccard ≥0.88 similar

## Key structural change vs. plugin
Daemon doesn't have OpenClaw's `messages: unknown[]` transcript, so we track inbound samples per session alongside outbound ones. Both pruned at 10-min max age, capped at 6 per side.

## Changes
- `loop-risk.ts` (new): record/evaluate/build APIs + session-key helper + test-only reset.
- `gateway/types.ts` + `dispatcher.ts` + `gateway.ts`: new `OutboundObserver` hook fires after `channel.send`. Errors caught + logged.
- `system-context.ts`: new optional `loopRiskBuilder` dep. Runs every turn, appends block last so the "reply NO_REPLY unless…" guidance is the final thing the model reads. Throws swallowed.
- `daemon.ts`: wires inbound recorder into existing `onInbound`, new `onOutbound` recorder, passes `loopRiskBuilder` per agent.

## Tests
+20 cases (424/424 green). Covers each detector independently, TTL pruning, session clearing, prompt block rendering, system-context slot ordering (sync + async branches), throw-tolerance, dispatcher onOutbound fire + throw fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)