### PR TITLE
chore(daemon): bump to 0.2.0 and require protocol-core ^0.2.0

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botcord/daemon",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "BotCord local daemon — bridges Hub inbox push to local Claude Code / Codex / Gemini CLIs",
   "type": "module",
   "bin": {
@@ -27,7 +27,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@botcord/protocol-core": "^0.1.1",
+    "@botcord/protocol-core": "^0.2.0",
     "ws": "^8.18.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Bump `@botcord/daemon` from 0.1.1 → 0.2.0
- Update its `@botcord/protocol-core` dependency from `^0.1.1` → `^0.2.0`

## Why
Running `npx -y -p @botcord/daemon botcord-daemon start ...` fails at import:

```
SyntaxError: The requested module '@botcord/protocol-core' does not provide an export named 'BotCordClient'
```

The published `@botcord/daemon@0.1.1` declares `^0.1.1` on `@botcord/protocol-core`, which resolves to the old 0.1.1 dist that does not include `client.ts` / `daemon-client.ts` / `control-frame.ts` (where `BotCordClient`, `buildHubWebSocketUrl`, etc. live). protocol-core has since been bumped to 0.2.0 with those exports, so the daemon needs to require the matching major.

## Test plan
- [ ] After publish: `npx -y -p @botcord/daemon@0.2.0 botcord-daemon start --hub https://api.preview.botcord.chat` starts without the SyntaxError