### PR TITLE
chore(frontend): pin daemon install command to @latest

### DIFF
--- a/frontend/src/components/dashboard/CreateAgentDialog.tsx
+++ b/frontend/src/components/dashboard/CreateAgentDialog.tsx
@@ -40,7 +40,7 @@ const HUB_BASE_URL =
     : "https://api.botcord.chat");
 
 function buildStartCommand(): string {
-  return `npx -y -p @botcord/daemon botcord-daemon start --hub ${HUB_BASE_URL}`;
+  return `npx -y -p @botcord/daemon@latest botcord-daemon start --hub ${HUB_BASE_URL}`;
 }
 
 function firstOnline(daemons: DaemonInstance[]): DaemonInstance | null {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botcord/daemon",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "BotCord local daemon — bridges Hub inbox push to local Claude Code / Codex / Gemini CLIs",
   "type": "module",
   "bin": {
@@ -27,7 +27,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@botcord/protocol-core": "^0.1.1",
+    "@botcord/protocol-core": "^0.2.0",
     "ws": "^8.18.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Dashboard's copyable daemon start command now uses `@botcord/daemon@latest` so npx always pulls the newest version instead of a stale cached one.

## Test plan
- [ ] Open create-agent dialog, copy command, verify it contains `@botcord/daemon@latest`
- [ ] Run the copied command and confirm daemon starts against the configured hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)