### PR TITLE
fix(daemon): prioritize per-agent managedRoutes over broad user routes

### DIFF
--- a/packages/daemon/src/daemon-config-map.ts
+++ b/packages/daemon/src/daemon-config-map.ts
@@ -150,9 +150,10 @@ export function toGatewayConfig(
 
   // Synthesize a per-agent route for every bound agent and hand it to the
   // gateway via the managed-routes bucket (plan §10.1). User-authored
-  // `cfg.routes[]` stay untouched so an explicit operator override still
-  // wins on conflict — the gateway matches `routes[] → managedRoutes →
-  // defaultRoute` in that order.
+  // `cfg.routes[]` stay untouched. Match priority (see router.ts):
+  // `routes[] with explicit accountId → managedRoutes → other routes[] →
+  // defaultRoute`. Broad prefix/kind rules no longer clobber the agent's
+  // chosen runtime — only routes that name the agent by `accountId` do.
   const managedMap = buildManagedRoutes(
     agentIds,
     opts.agentRuntimes ?? {},

--- a/packages/daemon/src/gateway/__tests__/router.test.ts
+++ b/packages/daemon/src/gateway/__tests__/router.test.ts
@@ -78,11 +78,37 @@ describe("resolveRoute", () => {
   });
 
   describe("managedRoutes", () => {
-    it("user cfg.routes match wins over managed for same accountId", () => {
+    it("user route with explicit accountId wins over managed for same agent", () => {
       const user = makeRoute({ runtime: "user", match: { accountId: "ag_1" } });
       const managed = makeRoute({ runtime: "managed", match: { accountId: "ag_1" } });
       const msg = makeMessage({ accountId: "ag_1" });
       expect(resolveRoute(msg, { defaultRoute, routes: [user] }, [managed])).toBe(user);
+    });
+
+    it("broad user route (no accountId) does NOT override managed per-agent route", () => {
+      const broad = makeRoute({
+        runtime: "broad",
+        match: { conversationPrefix: "rm_oc_" },
+      });
+      const managed = makeRoute({ runtime: "managed", match: { accountId: "ag_1" } });
+      const msg = makeMessage({
+        accountId: "ag_1",
+        conversation: { id: "rm_oc_abc", kind: "group" },
+      });
+      expect(resolveRoute(msg, { defaultRoute, routes: [broad] }, [managed])).toBe(managed);
+    });
+
+    it("broad user route applies when no managed route matches the agent", () => {
+      const broad = makeRoute({
+        runtime: "broad",
+        match: { conversationPrefix: "rm_oc_" },
+      });
+      const managed = makeRoute({ runtime: "managed", match: { accountId: "ag_other" } });
+      const msg = makeMessage({
+        accountId: "ag_1",
+        conversation: { id: "rm_oc_abc", kind: "group" },
+      });
+      expect(resolveRoute(msg, { defaultRoute, routes: [broad] }, [managed])).toBe(broad);
     });
 
     it("no user match + managed match → managed wins", () => {

--- a/packages/daemon/src/gateway/router.ts
+++ b/packages/daemon/src/gateway/router.ts
@@ -38,9 +38,14 @@ export function matchesRoute(
 
 /**
  * Picks the first matching route in priority order:
- *   1. `config.routes[]` (user-authored)
- *   2. `managedRoutes` (daemon-synthesized per-agent)
- *   3. `config.defaultRoute`
+ *   1. `config.routes[]` entries whose `match.accountId` names this message's
+ *      accountId — explicit operator override for a specific agent.
+ *   2. `managedRoutes` (daemon-synthesized per-agent, reflects the runtime
+ *      the user picked when provisioning the agent). Broad user routes do
+ *      NOT clobber this, because the agent's runtime is itself an explicit
+ *      user choice — a catch-all prefix rule shouldn't silently downgrade it.
+ *   3. Remaining `config.routes[]` (broad prefix/kind/channel rules).
+ *   4. `config.defaultRoute`.
  */
 export function resolveRoute(
   message: GatewayInboundMessage,
@@ -48,13 +53,22 @@ export function resolveRoute(
   managedRoutes?: readonly GatewayRoute[],
 ): GatewayRoute {
   const routes = config.routes ?? [];
+
   for (const route of routes) {
-    if (matchesRoute(message, route.match)) return route;
+    if (route.match?.accountId === message.accountId && matchesRoute(message, route.match)) {
+      return route;
+    }
   }
+
   if (managedRoutes) {
     for (const route of managedRoutes) {
       if (matchesRoute(message, route.match)) return route;
     }
   }
+
+  for (const route of routes) {
+    if (matchesRoute(message, route.match)) return route;
+  }
+
   return config.defaultRoute;
 }


### PR DESCRIPTION
## Summary
- Per-agent runtime selected in the dashboard CreateAgentDialog was being silently overridden by broad user routes in `~/.botcord/daemon/config.json` (e.g. `{ roomPrefix: "rm_oc_", adapter: "claude-code" }`). Codex agents kept spawning as claude-code whenever they spoke in matching rooms.
- Reorder `resolveRoute` so the agent's own runtime wins over broad prefix/kind/channel rules. Operators can still override a specific agent by matching on `accountId`.

## New priority
1. `routes[]` whose `match.accountId` equals the message's accountId (explicit per-agent operator override)
2. `managedRoutes` (per-agent, reflects the runtime picked in UI at provision time)
3. Remaining `routes[]` (broad prefix/kind/channel rules)
4. `defaultRoute`

## Repro (before)
`~/.botcord/daemon/config.json`:
```json
"routes": [{ "match": { "roomPrefix": "rm_oc_" }, "adapter": "claude-code" }]
```
Provision a new agent with `runtime: "codex"` via the dashboard. Daemon logs `"runtime":"codex"` and writes `"runtime": "codex"` to the credentials file, but turns in any `rm_oc_*` room still spawn claude-code.

## Test plan
- [x] `vitest run` — 383/383 pass, including two new `router.test.ts` cases:
  - broad user route (no accountId) does NOT override managed per-agent route
  - broad user route still applies when no managed route matches the agent
- [x] Existing "user route with explicit accountId wins over managed for same agent" case still passes
- [ ] Manual: restart daemon, send a message to a codex agent in an `rm_oc_` room, confirm codex adapter spawns

🤖 Generated with [Claude Code](https://claude.com/claude-code)