### PR TITLE
feat(human): human-view join/invite in RoomHeader

### DIFF
--- a/backend/app/routers/humans.py
+++ b/backend/app/routers/humans.py
@@ -451,6 +451,116 @@ async def create_human_room(
 
 
 @router.post(
+    "/me/rooms/{room_id}/join",
+    response_model=HumanRoomSummary,
+    status_code=201,
+)
+async def join_room_as_human(
+    room_id: str,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Human self-joins a public + open room.
+
+    Mirrors the self-join branch of ``hub/routers/room.py::add_member``:
+    only public + open rooms accept a self-join. Invite-only rooms require
+    an owner/admin to invite via ``POST /me/rooms/{room_id}/members``, or
+    the caller must go through the join-request flow. Subscription-gated
+    rooms are not yet reachable by Humans (no human-side subscription
+    concept), except when the caller is already the owner.
+    """
+    user = await _load_human(db, ctx)
+    me = user.human_id
+
+    room_row = await db.execute(
+        select(Room).where(Room.room_id == room_id).with_for_update()
+    )
+    room = room_row.scalar_one_or_none()
+    if room is None:
+        raise HTTPException(status_code=404, detail="Room not found")
+
+    existing = await db.execute(
+        select(RoomMember).where(
+            RoomMember.room_id == room_id,
+            RoomMember.agent_id == me,
+            RoomMember.participant_type == ParticipantType.human,
+        )
+    )
+    existing_member = existing.scalar_one_or_none()
+    if existing_member is not None:
+        raise HTTPException(status_code=409, detail="Already a member")
+
+    if (
+        room.visibility != RoomVisibility.public
+        or room.join_policy != RoomJoinPolicy.open
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail="self_join_public_open_only",
+        )
+
+    if room.required_subscription_product_id:
+        is_owner_self_seat = (
+            room.owner_type == ParticipantType.human and room.owner_id == me
+        )
+        if not is_owner_self_seat:
+            raise HTTPException(
+                status_code=403,
+                detail="subscription-gated rooms do not yet support human members",
+            )
+
+    if room.max_members is not None:
+        current_count_row = await db.execute(
+            select(RoomMember).where(RoomMember.room_id == room_id)
+        )
+        current_count = len(list(current_count_row.scalars().all()))
+        if current_count >= room.max_members:
+            raise HTTPException(status_code=400, detail="room_is_full")
+
+    new_member = RoomMember(
+        room_id=room_id,
+        agent_id=me,
+        participant_type=ParticipantType.human,
+        role=RoomRole.member,
+    )
+    try:
+        db.add(new_member)
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="Already a member")
+    await db.refresh(new_member)
+
+    try:
+        from hub.routers.room import _notify_room_member_change
+
+        members_row = await db.execute(
+            select(RoomMember.agent_id).where(RoomMember.room_id == room_id)
+        )
+        all_member_ids = [row[0] for row in members_row.all()]
+        await _notify_room_member_change(
+            db,
+            event_type="room_member_added",
+            room_id=room_id,
+            changed_agent_id=me,
+            notify_agent_ids=all_member_ids,
+        )
+    except Exception:  # pragma: no cover — notification must not break the HTTP response
+        _logger.exception("room_member_added broadcast failed for %s", room_id)
+
+    return HumanRoomSummary(
+        room_id=room.room_id,
+        name=room.name,
+        description=room.description or "",
+        owner_id=room.owner_id,
+        owner_type=room.owner_type.value,
+        visibility=room.visibility.value,
+        join_policy=room.join_policy.value,
+        my_role=RoomRole.member.value,
+    )
+
+
+@router.post(
     "/me/rooms/{room_id}/members",
     response_model=HumanRoomMemberResponse,
     status_code=201,

--- a/backend/tests/test_app/test_app_humans.py
+++ b/backend/tests/test_app/test_app_humans.py
@@ -1493,3 +1493,160 @@ async def test_a2a_contact_request_approval_creates_correct_contacts(
         f"claimed→ext contact must have peer_type=agent; got rows={rows}"
     assert (ext_id, "ag_claimed01234", ParticipantType.agent) in rows, \
         f"ext→claimed contact must have peer_type=agent; got rows={rows}"
+
+
+# ---------------------------------------------------------------------------
+# POST /api/humans/me/rooms/{room_id}/join — Human self-join
+# ---------------------------------------------------------------------------
+
+
+async def _make_public_open_room(
+    db_session: AsyncSession,
+    owner_user: User,
+    *,
+    name: str = "Public open",
+    required_subscription_product_id: str | None = None,
+) -> str:
+    room = Room(
+        room_id=f"rm_{uuid.uuid4().hex[:12]}",
+        name=name,
+        description="",
+        owner_id=owner_user.human_id,
+        owner_type=ParticipantType.human,
+        visibility=RoomVisibility.public,
+        join_policy=RoomJoinPolicy.open,
+        required_subscription_product_id=required_subscription_product_id,
+    )
+    db_session.add(room)
+    db_session.add(
+        RoomMember(
+            room_id=room.room_id,
+            agent_id=owner_user.human_id,
+            participant_type=ParticipantType.human,
+            role=RoomRole.owner,
+        )
+    )
+    await db_session.commit()
+    return room.room_id
+
+
+@pytest.mark.asyncio
+async def test_human_self_join_public_open_room(
+    client, seed, db_session: AsyncSession
+):
+    carol = User(supabase_user_id=uuid.uuid4(), display_name="Carol")
+    db_session.add(carol)
+    await db_session.commit()
+    room_id = await _make_public_open_room(db_session, carol)
+
+    resp = await client.post(
+        f"/api/humans/me/rooms/{room_id}/join",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["room_id"] == room_id
+    assert body["my_role"] == "member"
+
+    row = await db_session.execute(
+        select(RoomMember).where(
+            RoomMember.room_id == room_id,
+            RoomMember.agent_id == seed["human_id"],
+        )
+    )
+    m = row.scalar_one()
+    assert m.participant_type == ParticipantType.human
+    assert m.role == RoomRole.member
+
+
+@pytest.mark.asyncio
+async def test_human_self_join_rejects_invite_only(
+    client, seed, db_session: AsyncSession
+):
+    carol = User(supabase_user_id=uuid.uuid4(), display_name="Carol")
+    db_session.add(carol)
+    await db_session.commit()
+    room = Room(
+        room_id=f"rm_{uuid.uuid4().hex[:12]}",
+        name="Invite only",
+        description="",
+        owner_id=carol.human_id,
+        owner_type=ParticipantType.human,
+        visibility=RoomVisibility.public,
+        join_policy=RoomJoinPolicy.invite_only,
+    )
+    db_session.add(room)
+    db_session.add(
+        RoomMember(
+            room_id=room.room_id,
+            agent_id=carol.human_id,
+            participant_type=ParticipantType.human,
+            role=RoomRole.owner,
+        )
+    )
+    await db_session.commit()
+
+    resp = await client.post(
+        f"/api/humans/me/rooms/{room.room_id}/join",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_human_self_join_rejects_private(
+    client, seed, db_session: AsyncSession
+):
+    carol = User(supabase_user_id=uuid.uuid4(), display_name="Carol")
+    db_session.add(carol)
+    await db_session.commit()
+    room = Room(
+        room_id=f"rm_{uuid.uuid4().hex[:12]}",
+        name="Private open",
+        description="",
+        owner_id=carol.human_id,
+        owner_type=ParticipantType.human,
+        visibility=RoomVisibility.private,
+        join_policy=RoomJoinPolicy.open,
+    )
+    db_session.add(room)
+    db_session.add(
+        RoomMember(
+            room_id=room.room_id,
+            agent_id=carol.human_id,
+            participant_type=ParticipantType.human,
+            role=RoomRole.owner,
+        )
+    )
+    await db_session.commit()
+
+    resp = await client.post(
+        f"/api/humans/me/rooms/{room.room_id}/join",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_human_self_join_idempotent_conflict(
+    client, seed, db_session: AsyncSession
+):
+    carol = User(supabase_user_id=uuid.uuid4(), display_name="Carol")
+    db_session.add(carol)
+    await db_session.commit()
+    room_id = await _make_public_open_room(db_session, carol)
+
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    r1 = await client.post(f"/api/humans/me/rooms/{room_id}/join", headers=headers)
+    assert r1.status_code == 201
+    r2 = await client.post(f"/api/humans/me/rooms/{room_id}/join", headers=headers)
+    assert r2.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_human_self_join_404_when_room_missing(client, seed):
+    resp = await client.post(
+        "/api/humans/me/rooms/rm_doesnotexist/join",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+    )
+    assert resp.status_code == 404

--- a/frontend/src/components/dashboard/RoomHeader.tsx
+++ b/frontend/src/components/dashboard/RoomHeader.tsx
@@ -9,11 +9,12 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useLanguage } from "@/lib/i18n";
 import { common } from "@/lib/i18n/translations/common";
-import { roomList } from "@/lib/i18n/translations/dashboard";
+import { agentBrowser, roomList } from "@/lib/i18n/translations/dashboard";
 import { useShallow } from "zustand/react/shallow";
-import { Info, Loader2, Settings, Share2, Users } from "lucide-react";
+import { Info, Loader2, Settings, Share2, UserPlus, Users } from "lucide-react";
 import CopyableId from "@/components/ui/CopyableId";
-import { api } from "@/lib/api";
+import { api, humansApi } from "@/lib/api";
+import type { PublicRoomMember } from "@/lib/types";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
@@ -22,21 +23,30 @@ import ShareModal from "./ShareModal";
 import RoomSettingsModal from "./RoomSettingsModal";
 import DMSettingsModal from "./DMSettingsModal";
 import RoomMemberSettingsModal from "./RoomMemberSettingsModal";
+import AddRoomMemberModal from "./AddRoomMemberModal";
 
 export default function RoomHeader() {
   const [joinRequestStatus, setJoinRequestStatus] = useState<"idle" | "sending" | "pending" | "rejected">("idle");
   const [showRulePopover, setShowRulePopover] = useState(false);
   const [showShareModal, setShowShareModal] = useState(false);
   const [showSettingsModal, setShowSettingsModal] = useState(false);
+  const [showAddMemberModal, setShowAddMemberModal] = useState(false);
+  const [addMemberMemberIds, setAddMemberMemberIds] = useState<string[]>([]);
+  const [addMemberLoading, setAddMemberLoading] = useState(false);
+  const [humanJoining, setHumanJoining] = useState(false);
   const rulePopoverRef = useRef<HTMLDivElement>(null);
   const locale = useLanguage();
   const t = roomList[locale];
   const tc = common[locale];
+  const tAgent = agentBrowser[locale];
   const [ruleExpanded, setRuleExpanded] = useState(false);
   const [ruleOverflowing, setRuleOverflowing] = useState(false);
   const ruleRef = useRef<HTMLParagraphElement | null>(null);
   const sessionMode = useDashboardSessionStore((state) => state.sessionMode);
   const activeAgentId = useDashboardSessionStore((state) => state.activeAgentId);
+  const viewMode = useDashboardSessionStore((state) => state.viewMode);
+  const humanRooms = useDashboardSessionStore((state) => state.humanRooms);
+  const refreshHumanRooms = useDashboardSessionStore((state) => state.refreshHumanRooms);
   const { openedRoomId, rightPanelOpen, toggleRightPanel } = useDashboardUIStore(useShallow((state) => ({
     openedRoomId: state.openedRoomId,
     rightPanelOpen: state.rightPanelOpen,
@@ -55,17 +65,19 @@ export default function RoomHeader() {
   const [humanSendSaving, setHumanSendSaving] = useState(false);
   const [humanSendError, setHumanSendError] = useState<string | null>(null);
   const authRoom = overview?.rooms.find((r) => r.room_id === openedRoomId);
+  const humanRoom = humanRooms.find((r) => r.room_id === openedRoomId);
   const room = openedRoomId ? getRoomSummary(openedRoomId) : null;
   const roomRule = room?.rule?.trim();
   const roomDescription = room?.description?.trim();
   const hasInfo = Boolean(roomRule || roomDescription);
   const isGuest = sessionMode === "guest";
   const isAuthedReady = sessionMode === "authed-ready";
-  const isJoined = Boolean(authRoom);
-  const isJoining = joiningRoomId === room?.room_id;
+  const isHumanView = viewMode === "human";
+  const isJoined = isHumanView ? Boolean(humanRoom) : Boolean(authRoom);
+  const isJoining = isHumanView ? humanJoining : joiningRoomId === room?.room_id;
   const isInviteOnly = room?.join_policy === "invite_only" && !room?.required_subscription_product_id;
   const loginHref = room ? `/login?next=${encodeURIComponent(`/chats/messages/${room.room_id}`)}` : "/login";
-  const myRole = authRoom?.my_role;
+  const myRole = isHumanView ? humanRoom?.my_role : authRoom?.my_role;
   const isOwnerOrAdmin = myRole === "owner" || myRole === "admin";
 
   // DM room detection: room_id prefix "rm_dm_"
@@ -79,7 +91,7 @@ export default function RoomHeader() {
   const dmContact = isDMRoom && dmPartnerAgentId
     ? (overview?.contacts.find((c) => c.contact_agent_id === dmPartnerAgentId) ?? null)
     : null;
-  const canInvite = authRoom?.can_invite ?? true;
+  const canInvite = isHumanView ? isOwnerOrAdmin : (authRoom?.can_invite ?? true);
   const roleLabel = myRole
     ? locale === "zh"
       ? `你是 ${myRole}`
@@ -140,7 +152,33 @@ export default function RoomHeader() {
       return;
     }
     if (!isAuthedReady || room.required_subscription_product_id) return;
+    if (isHumanView) {
+      if (humanJoining) return;
+      setHumanJoining(true);
+      humansApi
+        .joinRoom(room.room_id)
+        .then(() => refreshHumanRooms())
+        .catch(() => {})
+        .finally(() => setHumanJoining(false));
+      return;
+    }
     void joinRoom(room.room_id);
+  };
+
+  const handleOpenAddMember = async () => {
+    if (!room?.room_id || addMemberLoading) return;
+    setAddMemberLoading(true);
+    try {
+      const result = await api
+        .getRoomMembers(room.room_id)
+        .catch(() => api.getPublicRoomMembers(room.room_id));
+      setAddMemberMemberIds(result.members.map((m: PublicRoomMember) => m.agent_id));
+    } catch {
+      setAddMemberMemberIds([]);
+    } finally {
+      setAddMemberLoading(false);
+      setShowAddMemberModal(true);
+    }
   };
 
   const canManageRoom = authRoom?.my_role === "owner" || authRoom?.my_role === "admin";
@@ -331,12 +369,27 @@ export default function RoomHeader() {
               {humanSendAllowed ? t.humanSendOn : t.humanSendOff}
             </button>
           )}
-          {isAuthedReady && authRoom && (
+          {isAuthedReady && isJoined && myRole && (
               <span className="rounded border border-glass-border px-2 py-0.5 font-mono text-[10px] text-text-secondary">
-                {authRoom.my_role}
+                {myRole}
               </span>
           )}
           {renderJoinButton()}
+          {isAuthedReady && isHumanView && isJoined && canInvite && !isDMRoom && (
+            <button
+              onClick={() => void handleOpenAddMember()}
+              disabled={addMemberLoading}
+              className="inline-flex items-center gap-1.5 rounded border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-1.5 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/15 disabled:cursor-not-allowed disabled:opacity-50"
+              title={tAgent.addMembersEntry}
+            >
+              {addMemberLoading ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <UserPlus className="h-3.5 w-3.5" />
+              )}
+              {tAgent.addMembersEntry}
+            </button>
+          )}
           {isGuest && (
             <span className="rounded border border-neon-purple/30 bg-neon-purple/10 px-2 py-0.5 text-[10px] font-medium text-neon-purple">
               {t.guest}
@@ -418,6 +471,18 @@ export default function RoomHeader() {
           myRole={myRole}
           requiredSubscriptionProductId={room.required_subscription_product_id}
           onClose={() => setShowSettingsModal(false)}
+        />
+      )}
+
+      {showAddMemberModal && (
+        <AddRoomMemberModal
+          roomId={room.room_id}
+          existingMemberIds={addMemberMemberIds}
+          onClose={() => setShowAddMemberModal(false)}
+          onAdded={async () => {
+            await refreshOverview().catch(() => {});
+            await refreshHumanRooms().catch(() => {});
+          }}
         />
       )}
     </>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -833,6 +833,11 @@ const humansApi = {
     return apiGet<HumanRoomListResponse>("/api/humans/me/rooms");
   },
 
+  /** Human self-joins a public+open room. */
+  async joinRoom(roomId: string): Promise<HumanRoomSummary> {
+    return apiPost<HumanRoomSummary>(`/api/humans/me/rooms/${roomId}/join`);
+  },
+
   async createRoom(body: {
     name: string;
     description?: string;


### PR DESCRIPTION
## Summary
- Fix RoomHeader's Join button which was always agent-scoped. In human view it now uses \`session.humanRooms\` for \`isJoined\`/\`myRole\` and calls a new human-scoped join endpoint.
- Add **Invite** button (UserPlus) in human view for owner/admin of a joined room — opens the existing \`AddRoomMemberModal\` (which already calls \`humansApi.addRoomMember\`) after loading current room members.
- Backend: new \`POST /api/humans/me/rooms/{room_id}/join\` that mirrors the self-join branch of \`hub/routers/room.py::add_member\` — public + open only, 409 on duplicate, 403 on invite_only/private/sub-gated (unless owner), 400 on \`room_is_full\`, and emits the \`room_member_added\` realtime event.

## Test plan
- [x] \`uv run pytest tests/test_app/test_app_humans.py\` — 39 passed (5 new self-join cases: success, invite_only 403, private 403, duplicate 409, missing 404)
- [x] \`pnpm exec tsc --noEmit\` — no errors in \`src/\`
- [ ] Manual: toggle viewMode=human, open a public room not yet joined → Join joins as human; rejoin shows role badge + Invite button for owner/admin; picking a contact/agent in the modal invites via \`humansApi.addRoomMember\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)