### PR TITLE
fix(frontend): include own agent in @mention in human view

### DIFF
--- a/frontend/src/components/dashboard/RoomHumanComposer.tsx
+++ b/frontend/src/components/dashboard/RoomHumanComposer.tsx
@@ -59,10 +59,11 @@ export default function RoomHumanComposer({ roomId }: RoomHumanComposerProps) {
 
   const mentionCandidates = useMemo<MentionCandidate[]>(() => {
     if (isOwnerChat) return [];
+    const selfId = viewMode === "agent" ? activeAgentId : human?.human_id;
     return members
-      .filter((m) => m.agent_id !== activeAgentId)
+      .filter((m) => m.agent_id !== selfId)
       .map((m) => ({ agent_id: m.agent_id, display_name: m.display_name }));
-  }, [members, activeAgentId, isOwnerChat]);
+  }, [members, activeAgentId, human?.human_id, viewMode, isOwnerChat]);
 
   const handleSend = useCallback(async (text: string, _files: File[], mentions?: string[]) => {
     if (!text) return;


### PR DESCRIPTION
## Summary
- In human view, the speaker is the human, not the active agent, so the active agent should remain mentionable.
- Switch the self-exclusion in `RoomHumanComposer` mention candidates to depend on `viewMode`: exclude `activeAgentId` in agent view, `human_id` in human view.

## Test plan
- [ ] Open a room in **human view**: `@` shows own agent as a candidate.
- [ ] Switch to **agent view**: `@` no longer shows the current active agent, still shows other members.
- [ ] Owner chat (`rm_oc_*`): `@` still yields no suggestions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)