### PR TITLE
fix(frontend): sync viewMode on auth bootstrap & include own agent in mentions

### DIFF
--- a/frontend/src/components/dashboard/RoomHumanComposer.tsx
+++ b/frontend/src/components/dashboard/RoomHumanComposer.tsx
@@ -59,10 +59,11 @@ export default function RoomHumanComposer({ roomId }: RoomHumanComposerProps) {
 
   const mentionCandidates = useMemo<MentionCandidate[]>(() => {
     if (isOwnerChat) return [];
+    const selfId = viewMode === "agent" ? activeAgentId : human?.human_id;
     return members
-      .filter((m) => m.agent_id !== activeAgentId)
+      .filter((m) => m.agent_id !== selfId)
       .map((m) => ({ agent_id: m.agent_id, display_name: m.display_name }));
-  }, [members, activeAgentId, isOwnerChat]);
+  }, [members, activeAgentId, human?.human_id, viewMode, isOwnerChat]);
 
   const handleSend = useCallback(async (text: string, _files: File[], mentions?: string[]) => {
     if (!text) return;

--- a/frontend/src/store/useDashboardSessionStore.ts
+++ b/frontend/src/store/useDashboardSessionStore.ts
@@ -124,6 +124,7 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
       token,
       activeAgentId,
       activeIdentity,
+      viewMode: activeIdentity?.type === "agent" ? "agent" : "human",
       sessionMode: resolveSessionMode(token, activeAgentId),
     });
   },
@@ -240,6 +241,7 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
         ownedAgents: user.agents,
         activeAgentId: activeId,
         activeIdentity,
+        viewMode: activeIdentity?.type === "agent" ? "agent" : "human",
         sessionMode: resolveSessionMode(token, activeId),
       });
     } catch (err: any) {


### PR DESCRIPTION
## Summary
- Sync `viewMode` from the restored `activeIdentity` in `initAuth` and `setToken`. `viewMode` isn't persisted, so after the full page reload triggered by `switchActiveAgent` it reverted to the default `"human"` and the account menu showed Human as checked even when an agent was active.
- Include the user's own agent in @mention candidates when in human view (prior commit on this branch).

## Test plan
- [ ] `pnpm dev`, log in, click left-bottom account menu → switch to an agent → after reload the agent (not Human) is checked.
- [ ] In human view, verify own agent appears in @mention candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)