### PR TITLE
feat(frontend): small dashboard fixes + bot picker in CreateRoomModal

### DIFF
--- a/frontend/src/components/dashboard/CreateRoomModal.tsx
+++ b/frontend/src/components/dashboard/CreateRoomModal.tsx
@@ -31,6 +31,7 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
   const viewMode = useDashboardSessionStore((s) => s.viewMode);
   const human = useDashboardSessionStore((s) => s.human);
   const activeAgentId = useDashboardSessionStore((s) => s.activeAgentId);
+  const ownedAgents = useDashboardSessionStore((s) => s.ownedAgents);
   const identityReady = viewMode === "human" ? Boolean(human) : Boolean(activeAgentId);
 
   const [name, setName] = useState("");
@@ -57,6 +58,15 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
       (c.alias ?? "").toLowerCase().includes(q),
     );
   }, [contacts, memberQuery]);
+
+  const filteredBots = useMemo(() => {
+    const q = memberQuery.trim().toLowerCase();
+    if (!q) return ownedAgents;
+    return ownedAgents.filter((a) =>
+      a.display_name.toLowerCase().includes(q) ||
+      a.agent_id.toLowerCase().includes(q),
+    );
+  }, [ownedAgents, memberQuery]);
 
   function toggleMember(id: string) {
     setSelected((prev) => {
@@ -181,7 +191,7 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
                 </span>
               </div>
               <p className="mb-2 text-[11px] text-text-secondary/70">{t.membersHint}</p>
-              {contacts.length === 0 ? (
+              {contacts.length === 0 && ownedAgents.length === 0 ? (
                 <p className="rounded border border-dashed border-glass-border px-3 py-3 text-xs text-text-secondary/70">
                   {t.noContacts}
                 </p>
@@ -192,36 +202,90 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
                     <input
                       value={memberQuery}
                       onChange={(e) => setMemberQuery(e.target.value)}
-                      placeholder={t.searchContacts}
+                      placeholder={t.searchMembers}
                       className="w-full bg-transparent py-1.5 text-xs text-text-primary outline-none"
                     />
                   </div>
-                  <div className="max-h-40 overflow-y-auto rounded border border-glass-border">
-                    {filteredContacts.map((c: ContactInfo) => {
-                      const checked = selected.has(c.contact_agent_id);
-                      return (
-                        <label
-                          key={c.contact_agent_id}
-                          className={`flex cursor-pointer items-center gap-2 border-b border-glass-border/60 px-3 py-2 text-xs last:border-b-0 ${
-                            checked ? "bg-neon-cyan/10" : "hover:bg-glass-bg"
-                          }`}
-                        >
-                          <input
-                            type="checkbox"
-                            checked={checked}
-                            onChange={() => toggleMember(c.contact_agent_id)}
-                            className="accent-neon-cyan"
-                          />
-                          <span className="flex-1 truncate text-text-primary">
-                            {c.alias || c.display_name}
-                          </span>
-                          <span className="font-mono text-[10px] text-text-secondary/70">
-                            {c.contact_agent_id}
-                          </span>
-                        </label>
-                      );
-                    })}
-                  </div>
+
+                  {ownedAgents.length > 0 && (
+                    <div className="mb-2">
+                      <p className="mb-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-text-secondary/60">
+                        {t.myBotsLabel}
+                      </p>
+                      <div className="max-h-40 overflow-y-auto rounded border border-glass-border">
+                        {filteredBots.length === 0 ? (
+                          <p className="px-3 py-2 text-[11px] text-text-secondary/60">
+                            {t.noBotsMatch}
+                          </p>
+                        ) : (
+                          filteredBots.map((a) => {
+                            const checked = selected.has(a.agent_id);
+                            return (
+                              <label
+                                key={a.agent_id}
+                                className={`flex cursor-pointer items-center gap-2 border-b border-glass-border/60 px-3 py-2 text-xs last:border-b-0 ${
+                                  checked ? "bg-neon-cyan/10" : "hover:bg-glass-bg"
+                                }`}
+                              >
+                                <input
+                                  type="checkbox"
+                                  checked={checked}
+                                  onChange={() => toggleMember(a.agent_id)}
+                                  className="accent-neon-cyan"
+                                />
+                                <span className="flex-1 truncate text-text-primary">
+                                  {a.display_name}
+                                </span>
+                                <span className="font-mono text-[10px] text-text-secondary/70">
+                                  {a.agent_id}
+                                </span>
+                              </label>
+                            );
+                          })
+                        )}
+                      </div>
+                    </div>
+                  )}
+
+                  {contacts.length > 0 && (
+                    <div>
+                      <p className="mb-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-text-secondary/60">
+                        {t.contactsLabel}
+                      </p>
+                      <div className="max-h-40 overflow-y-auto rounded border border-glass-border">
+                        {filteredContacts.length === 0 ? (
+                          <p className="px-3 py-2 text-[11px] text-text-secondary/60">
+                            {t.noContactsMatch}
+                          </p>
+                        ) : (
+                          filteredContacts.map((c: ContactInfo) => {
+                            const checked = selected.has(c.contact_agent_id);
+                            return (
+                              <label
+                                key={c.contact_agent_id}
+                                className={`flex cursor-pointer items-center gap-2 border-b border-glass-border/60 px-3 py-2 text-xs last:border-b-0 ${
+                                  checked ? "bg-neon-cyan/10" : "hover:bg-glass-bg"
+                                }`}
+                              >
+                                <input
+                                  type="checkbox"
+                                  checked={checked}
+                                  onChange={() => toggleMember(c.contact_agent_id)}
+                                  className="accent-neon-cyan"
+                                />
+                                <span className="flex-1 truncate text-text-primary">
+                                  {c.alias || c.display_name}
+                                </span>
+                                <span className="font-mono text-[10px] text-text-secondary/70">
+                                  {c.contact_agent_id}
+                                </span>
+                              </label>
+                            );
+                          })
+                        )}
+                      </div>
+                    </div>
+                  )}
                 </>
               )}
             </div>

--- a/frontend/src/components/dashboard/RoomHeader.tsx
+++ b/frontend/src/components/dashboard/RoomHeader.tsx
@@ -457,6 +457,7 @@ export default function RoomHeader() {
           initialVisibility={room.visibility}
           initialJoinPolicy={room.join_policy}
           initialSubscriptionProductId={room.required_subscription_product_id ?? null}
+          initialAllowHumanSend={authRoom?.allow_human_send !== false}
           isOwner={authRoom?.my_role === "owner"}
           onClose={() => setShowSettingsModal(false)}
         />

--- a/frontend/src/components/dashboard/RoomHumanComposer.tsx
+++ b/frontend/src/components/dashboard/RoomHumanComposer.tsx
@@ -59,10 +59,11 @@ export default function RoomHumanComposer({ roomId }: RoomHumanComposerProps) {
 
   const mentionCandidates = useMemo<MentionCandidate[]>(() => {
     if (isOwnerChat) return [];
+    const selfId = viewMode === "agent" ? activeAgentId : human?.human_id;
     return members
-      .filter((m) => m.agent_id !== activeAgentId)
+      .filter((m) => m.agent_id !== selfId)
       .map((m) => ({ agent_id: m.agent_id, display_name: m.display_name }));
-  }, [members, activeAgentId, isOwnerChat]);
+  }, [members, activeAgentId, human?.human_id, viewMode, isOwnerChat]);
 
   const handleSend = useCallback(async (text: string, _files: File[], mentions?: string[]) => {
     if (!text) return;

--- a/frontend/src/components/dashboard/RoomSettingsModal.tsx
+++ b/frontend/src/components/dashboard/RoomSettingsModal.tsx
@@ -16,6 +16,7 @@ interface RoomSettingsModalProps {
   initialJoinPolicy?: string;
   initialDefaultSend?: boolean;
   initialDefaultInvite?: boolean;
+  initialAllowHumanSend?: boolean;
   initialMaxMembers?: number | null;
   initialSlowModeSeconds?: number | null;
   initialSubscriptionProductId?: string | null;
@@ -32,6 +33,7 @@ export default function RoomSettingsModal({
   initialJoinPolicy = "invite_only",
   initialDefaultSend = true,
   initialDefaultInvite = false,
+  initialAllowHumanSend = true,
   initialMaxMembers = null,
   initialSlowModeSeconds = null,
   initialSubscriptionProductId = null,
@@ -50,6 +52,7 @@ export default function RoomSettingsModal({
   const [joinPolicy, setJoinPolicy] = useState(initialJoinPolicy);
   const [defaultSend, setDefaultSend] = useState(initialDefaultSend);
   const [defaultInvite, setDefaultInvite] = useState(initialDefaultInvite);
+  const [allowHumanSend, setAllowHumanSend] = useState(initialAllowHumanSend);
   const [maxMembers, setMaxMembers] = useState(
     initialMaxMembers == null ? "" : String(initialMaxMembers),
   );
@@ -82,6 +85,7 @@ export default function RoomSettingsModal({
         if (joinPolicy !== initialJoinPolicy) patch.join_policy = joinPolicy as "open" | "invite_only";
         if (defaultSend !== initialDefaultSend) patch.default_send = defaultSend;
         if (defaultInvite !== initialDefaultInvite) patch.default_invite = defaultInvite;
+        if (allowHumanSend !== initialAllowHumanSend) patch.allow_human_send = allowHumanSend;
         const nextMax = maxMembers ? Number(maxMembers) : null;
         if (nextMax !== initialMaxMembers) patch.max_members = nextMax;
         const nextSlow = slowMode ? Number(slowMode) : null;
@@ -225,6 +229,16 @@ export default function RoomSettingsModal({
                     className="accent-neon-cyan"
                   />
                   {ta.defaultInviteLabel}
+                </label>
+                <label className="flex items-center gap-2 text-xs text-text-secondary">
+                  <input
+                    type="checkbox"
+                    disabled={!isOwner}
+                    checked={allowHumanSend}
+                    onChange={(e) => setAllowHumanSend(e.target.checked)}
+                    className="accent-neon-cyan"
+                  />
+                  {ta.allowHumanSendLabel}
                 </label>
                 <div className="grid grid-cols-2 gap-3">
                   <label className="block">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -339,6 +339,7 @@ export const api = {
       join_policy?: "open" | "invite_only";
       default_send?: boolean;
       default_invite?: boolean;
+      allow_human_send?: boolean;
       max_members?: number | null;
       slow_mode_seconds?: number | null;
       required_subscription_product_id?: string | null;
@@ -353,6 +354,7 @@ export const api = {
       join_policy?: string;
       default_send?: boolean;
       default_invite?: boolean;
+      allow_human_send?: boolean;
       max_members?: number | null;
       slow_mode_seconds?: number | null;
       required_subscription_product_id?: string | null;

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -2020,6 +2020,11 @@ export const createRoomModal: TranslationMap<{
   membersHint: string
   noContacts: string
   searchContacts: string
+  searchMembers: string
+  myBotsLabel: string
+  contactsLabel: string
+  noBotsMatch: string
+  noContactsMatch: string
   visibilityLabel: string
   visibilityPublic: string
   visibilityPrivate: string
@@ -2051,9 +2056,14 @@ export const createRoomModal: TranslationMap<{
     ruleLabel: 'Rule / announcement',
     rulePlaceholder: 'Ground rules shown to members.',
     membersLabel: 'Initial members',
-    membersHint: 'Pick from your contacts. You can invite more after the group is created.',
-    noContacts: 'No contacts yet — you can create an empty group and invite later.',
+    membersHint: 'Pick your bots or contacts. You can invite more after the group is created.',
+    noContacts: 'No bots or contacts yet — you can create an empty group and invite later.',
     searchContacts: 'Search contacts',
+    searchMembers: 'Search bots or contacts',
+    myBotsLabel: 'My bots',
+    contactsLabel: 'Contacts',
+    noBotsMatch: 'No bots match the search.',
+    noContactsMatch: 'No contacts match the search.',
     visibilityLabel: 'Visibility',
     visibilityPublic: 'Public (discoverable)',
     visibilityPrivate: 'Private (invite-only)',
@@ -2085,9 +2095,14 @@ export const createRoomModal: TranslationMap<{
     ruleLabel: '群公告 / 规则',
     rulePlaceholder: '给成员看的群内基本规则。',
     membersLabel: '初始成员',
-    membersHint: '从联系人中勾选，创建后也能继续邀请其他人。',
-    noContacts: '还没有联系人 — 你可以先创建空群，之后再邀请。',
+    membersHint: '从自己的 Bot 或联系人中勾选，创建后也能继续邀请。',
+    noContacts: '还没有 Bot 或联系人 — 你可以先创建空群，之后再邀请。',
     searchContacts: '搜索联系人',
+    searchMembers: '搜索 Bot 或联系人',
+    myBotsLabel: '我的 Bot',
+    contactsLabel: '联系人',
+    noBotsMatch: '没有匹配的 Bot。',
+    noContactsMatch: '没有匹配的联系人。',
     visibilityLabel: '可见性',
     visibilityPublic: '公开（可被发现）',
     visibilityPrivate: '私有（仅限邀请）',

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -2214,6 +2214,7 @@ export const roomAdvancedSettings: TranslationMap<{
   joinPolicyInviteOnly: string
   defaultSendLabel: string
   defaultInviteLabel: string
+  allowHumanSendLabel: string
   maxMembersLabel: string
   slowModeLabel: string
   subscriptionSection: string
@@ -2233,6 +2234,7 @@ export const roomAdvancedSettings: TranslationMap<{
     joinPolicyInviteOnly: 'Invite-only',
     defaultSendLabel: 'Members can send messages',
     defaultInviteLabel: 'Members can invite others',
+    allowHumanSendLabel: 'Humans can send messages',
     maxMembersLabel: 'Max members',
     slowModeLabel: 'Slow mode (seconds)',
     subscriptionSection: 'Payment & subscription',
@@ -2252,6 +2254,7 @@ export const roomAdvancedSettings: TranslationMap<{
     joinPolicyInviteOnly: '仅限邀请',
     defaultSendLabel: '默认允许成员发言',
     defaultInviteLabel: '默认允许成员邀请他人',
+    allowHumanSendLabel: '允许真人在此房间发言',
     maxMembersLabel: '人数上限',
     slowModeLabel: '慢速模式（秒）',
     subscriptionSection: '支付与订阅',

--- a/frontend/src/store/useDashboardSessionStore.ts
+++ b/frontend/src/store/useDashboardSessionStore.ts
@@ -124,6 +124,7 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
       token,
       activeAgentId,
       activeIdentity,
+      viewMode: activeIdentity?.type === "agent" ? "agent" : "human",
       sessionMode: resolveSessionMode(token, activeAgentId),
     });
   },
@@ -240,6 +241,7 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
         ownedAgents: user.agents,
         activeAgentId: activeId,
         activeIdentity,
+        viewMode: activeIdentity?.type === "agent" ? "agent" : "human",
         sessionMode: resolveSessionMode(token, activeId),
       });
     } catch (err: any) {


### PR DESCRIPTION
## Summary
- Create-group modal now lists the current user's own bots as a separate section alongside contacts, so owners can pull their bots into a new group without first adding them as contacts (ag_* ids flow through the existing member_ids field that already accepts both ag_* and hu_*).
- Bundles a few related frontend fixes already on this branch: sync viewMode from activeIdentity on auth bootstrap; include own agent in @mention candidates in human view; expose allow_human_send in RoomSettingsModal.

## Test plan
- [ ] Open Create group modal as a human with owned bots → verify "My bots" section renders with checkboxes
- [ ] Search box filters both bots and contacts
- [ ] Select a bot + a contact, create group → verify both appear as members
- [ ] Modal falls back to "no bots or contacts" empty state when both lists are empty
- [ ] Smoke-test the other bundled fixes (viewMode bootstrap, @mention own agent, allow_human_send toggle)

Generated with Claude Code