### PR TITLE
feat(frontend): My Bots / human-view polish

### DIFF
--- a/frontend/src/components/dashboard/CreateRoomModal.tsx
+++ b/frontend/src/components/dashboard/CreateRoomModal.tsx
@@ -31,6 +31,7 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
   const viewMode = useDashboardSessionStore((s) => s.viewMode);
   const human = useDashboardSessionStore((s) => s.human);
   const activeAgentId = useDashboardSessionStore((s) => s.activeAgentId);
+  const ownedAgents = useDashboardSessionStore((s) => s.ownedAgents);
   const identityReady = viewMode === "human" ? Boolean(human) : Boolean(activeAgentId);
 
   const [name, setName] = useState("");
@@ -57,6 +58,15 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
       (c.alias ?? "").toLowerCase().includes(q),
     );
   }, [contacts, memberQuery]);
+
+  const filteredBots = useMemo(() => {
+    const q = memberQuery.trim().toLowerCase();
+    if (!q) return ownedAgents;
+    return ownedAgents.filter((a) =>
+      a.display_name.toLowerCase().includes(q) ||
+      a.agent_id.toLowerCase().includes(q),
+    );
+  }, [ownedAgents, memberQuery]);
 
   function toggleMember(id: string) {
     setSelected((prev) => {
@@ -181,7 +191,7 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
                 </span>
               </div>
               <p className="mb-2 text-[11px] text-text-secondary/70">{t.membersHint}</p>
-              {contacts.length === 0 ? (
+              {contacts.length === 0 && ownedAgents.length === 0 ? (
                 <p className="rounded border border-dashed border-glass-border px-3 py-3 text-xs text-text-secondary/70">
                   {t.noContacts}
                 </p>
@@ -192,36 +202,90 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
                     <input
                       value={memberQuery}
                       onChange={(e) => setMemberQuery(e.target.value)}
-                      placeholder={t.searchContacts}
+                      placeholder={t.searchMembers}
                       className="w-full bg-transparent py-1.5 text-xs text-text-primary outline-none"
                     />
                   </div>
-                  <div className="max-h-40 overflow-y-auto rounded border border-glass-border">
-                    {filteredContacts.map((c: ContactInfo) => {
-                      const checked = selected.has(c.contact_agent_id);
-                      return (
-                        <label
-                          key={c.contact_agent_id}
-                          className={`flex cursor-pointer items-center gap-2 border-b border-glass-border/60 px-3 py-2 text-xs last:border-b-0 ${
-                            checked ? "bg-neon-cyan/10" : "hover:bg-glass-bg"
-                          }`}
-                        >
-                          <input
-                            type="checkbox"
-                            checked={checked}
-                            onChange={() => toggleMember(c.contact_agent_id)}
-                            className="accent-neon-cyan"
-                          />
-                          <span className="flex-1 truncate text-text-primary">
-                            {c.alias || c.display_name}
-                          </span>
-                          <span className="font-mono text-[10px] text-text-secondary/70">
-                            {c.contact_agent_id}
-                          </span>
-                        </label>
-                      );
-                    })}
-                  </div>
+
+                  {ownedAgents.length > 0 && (
+                    <div className="mb-2">
+                      <p className="mb-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-text-secondary/60">
+                        {t.myBotsLabel}
+                      </p>
+                      <div className="max-h-40 overflow-y-auto rounded border border-glass-border">
+                        {filteredBots.length === 0 ? (
+                          <p className="px-3 py-2 text-[11px] text-text-secondary/60">
+                            {t.noBotsMatch}
+                          </p>
+                        ) : (
+                          filteredBots.map((a) => {
+                            const checked = selected.has(a.agent_id);
+                            return (
+                              <label
+                                key={a.agent_id}
+                                className={`flex cursor-pointer items-center gap-2 border-b border-glass-border/60 px-3 py-2 text-xs last:border-b-0 ${
+                                  checked ? "bg-neon-cyan/10" : "hover:bg-glass-bg"
+                                }`}
+                              >
+                                <input
+                                  type="checkbox"
+                                  checked={checked}
+                                  onChange={() => toggleMember(a.agent_id)}
+                                  className="accent-neon-cyan"
+                                />
+                                <span className="flex-1 truncate text-text-primary">
+                                  {a.display_name}
+                                </span>
+                                <span className="font-mono text-[10px] text-text-secondary/70">
+                                  {a.agent_id}
+                                </span>
+                              </label>
+                            );
+                          })
+                        )}
+                      </div>
+                    </div>
+                  )}
+
+                  {contacts.length > 0 && (
+                    <div>
+                      <p className="mb-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-text-secondary/60">
+                        {t.contactsLabel}
+                      </p>
+                      <div className="max-h-40 overflow-y-auto rounded border border-glass-border">
+                        {filteredContacts.length === 0 ? (
+                          <p className="px-3 py-2 text-[11px] text-text-secondary/60">
+                            {t.noContactsMatch}
+                          </p>
+                        ) : (
+                          filteredContacts.map((c: ContactInfo) => {
+                            const checked = selected.has(c.contact_agent_id);
+                            return (
+                              <label
+                                key={c.contact_agent_id}
+                                className={`flex cursor-pointer items-center gap-2 border-b border-glass-border/60 px-3 py-2 text-xs last:border-b-0 ${
+                                  checked ? "bg-neon-cyan/10" : "hover:bg-glass-bg"
+                                }`}
+                              >
+                                <input
+                                  type="checkbox"
+                                  checked={checked}
+                                  onChange={() => toggleMember(c.contact_agent_id)}
+                                  className="accent-neon-cyan"
+                                />
+                                <span className="flex-1 truncate text-text-primary">
+                                  {c.alias || c.display_name}
+                                </span>
+                                <span className="font-mono text-[10px] text-text-secondary/70">
+                                  {c.contact_agent_id}
+                                </span>
+                              </label>
+                            );
+                          })
+                        )}
+                      </div>
+                    </div>
+                  )}
                 </>
               )}
             </div>

--- a/frontend/src/components/dashboard/RoomHeader.tsx
+++ b/frontend/src/components/dashboard/RoomHeader.tsx
@@ -457,6 +457,7 @@ export default function RoomHeader() {
           initialVisibility={room.visibility}
           initialJoinPolicy={room.join_policy}
           initialSubscriptionProductId={room.required_subscription_product_id ?? null}
+          initialAllowHumanSend={authRoom?.allow_human_send !== false}
           isOwner={authRoom?.my_role === "owner"}
           onClose={() => setShowSettingsModal(false)}
         />

--- a/frontend/src/components/dashboard/RoomHumanComposer.tsx
+++ b/frontend/src/components/dashboard/RoomHumanComposer.tsx
@@ -59,10 +59,11 @@ export default function RoomHumanComposer({ roomId }: RoomHumanComposerProps) {
 
   const mentionCandidates = useMemo<MentionCandidate[]>(() => {
     if (isOwnerChat) return [];
+    const selfId = viewMode === "agent" ? activeAgentId : human?.human_id;
     return members
-      .filter((m) => m.agent_id !== activeAgentId)
+      .filter((m) => m.agent_id !== selfId)
       .map((m) => ({ agent_id: m.agent_id, display_name: m.display_name }));
-  }, [members, activeAgentId, isOwnerChat]);
+  }, [members, activeAgentId, human?.human_id, viewMode, isOwnerChat]);
 
   const handleSend = useCallback(async (text: string, _files: File[], mentions?: string[]) => {
     if (!text) return;

--- a/frontend/src/components/dashboard/RoomSettingsModal.tsx
+++ b/frontend/src/components/dashboard/RoomSettingsModal.tsx
@@ -16,6 +16,7 @@ interface RoomSettingsModalProps {
   initialJoinPolicy?: string;
   initialDefaultSend?: boolean;
   initialDefaultInvite?: boolean;
+  initialAllowHumanSend?: boolean;
   initialMaxMembers?: number | null;
   initialSlowModeSeconds?: number | null;
   initialSubscriptionProductId?: string | null;
@@ -32,6 +33,7 @@ export default function RoomSettingsModal({
   initialJoinPolicy = "invite_only",
   initialDefaultSend = true,
   initialDefaultInvite = false,
+  initialAllowHumanSend = true,
   initialMaxMembers = null,
   initialSlowModeSeconds = null,
   initialSubscriptionProductId = null,
@@ -50,6 +52,7 @@ export default function RoomSettingsModal({
   const [joinPolicy, setJoinPolicy] = useState(initialJoinPolicy);
   const [defaultSend, setDefaultSend] = useState(initialDefaultSend);
   const [defaultInvite, setDefaultInvite] = useState(initialDefaultInvite);
+  const [allowHumanSend, setAllowHumanSend] = useState(initialAllowHumanSend);
   const [maxMembers, setMaxMembers] = useState(
     initialMaxMembers == null ? "" : String(initialMaxMembers),
   );
@@ -82,6 +85,7 @@ export default function RoomSettingsModal({
         if (joinPolicy !== initialJoinPolicy) patch.join_policy = joinPolicy as "open" | "invite_only";
         if (defaultSend !== initialDefaultSend) patch.default_send = defaultSend;
         if (defaultInvite !== initialDefaultInvite) patch.default_invite = defaultInvite;
+        if (allowHumanSend !== initialAllowHumanSend) patch.allow_human_send = allowHumanSend;
         const nextMax = maxMembers ? Number(maxMembers) : null;
         if (nextMax !== initialMaxMembers) patch.max_members = nextMax;
         const nextSlow = slowMode ? Number(slowMode) : null;
@@ -225,6 +229,16 @@ export default function RoomSettingsModal({
                     className="accent-neon-cyan"
                   />
                   {ta.defaultInviteLabel}
+                </label>
+                <label className="flex items-center gap-2 text-xs text-text-secondary">
+                  <input
+                    type="checkbox"
+                    disabled={!isOwner}
+                    checked={allowHumanSend}
+                    onChange={(e) => setAllowHumanSend(e.target.checked)}
+                    className="accent-neon-cyan"
+                  />
+                  {ta.allowHumanSendLabel}
                 </label>
                 <div className="grid grid-cols-2 gap-3">
                   <label className="block">

--- a/frontend/src/components/dashboard/Sidebar.tsx
+++ b/frontend/src/components/dashboard/Sidebar.tsx
@@ -23,7 +23,7 @@ import CreateRoomModal from "./CreateRoomModal";
 import CreateAgentDialog from "./CreateAgentDialog";
 import RoomZeroState from "./RoomZeroState";
 import SearchBar from "./SearchBar";
-import { UserPlus, MessageSquarePlus, Users, LogIn, Bot, Plus } from "lucide-react";
+import { UserPlus, MessageSquarePlus, Users, LogIn, Bot, Plus, RefreshCw } from "lucide-react";
 import { messagesHeader } from "@/lib/i18n/translations/dashboard";
 import { createClient } from "@/lib/supabase/client";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
@@ -236,6 +236,7 @@ export default function Sidebar() {
   const [showCreateRoom, setShowCreateRoom] = useState(false);
   const [showCreateBot, setShowCreateBot] = useState(false);
   const [messageQuery, setMessageQuery] = useState("");
+  const [refreshingBots, setRefreshingBots] = useState(false);
   const tMsgHeader = messagesHeader[locale];
   const showLoginModal = () => router.push("/login");
 
@@ -656,6 +657,28 @@ export default function Sidebar() {
 
           {uiStore.sidebarTab === "bots" && (
             <div className="p-2">
+              {sessionStore.ownedAgents.length > 0 && (
+                <div className="mb-2 flex items-center justify-end px-1">
+                  <button
+                    type="button"
+                    disabled={refreshingBots}
+                    onClick={async () => {
+                      if (refreshingBots) return;
+                      setRefreshingBots(true);
+                      try {
+                        await sessionStore.refreshUserProfile();
+                      } finally {
+                        setRefreshingBots(false);
+                      }
+                    }}
+                    title="Refresh status"
+                    className="inline-flex items-center gap-1 rounded-md border border-glass-border px-2 py-1 text-[10px] text-text-secondary transition-colors hover:border-neon-cyan/40 hover:text-neon-cyan disabled:opacity-50"
+                  >
+                    <RefreshCw className={`h-3 w-3 ${refreshingBots ? "animate-spin" : ""}`} />
+                    <span>Refresh</span>
+                  </button>
+                </div>
+              )}
               {sessionStore.ownedAgents.length === 0 ? (
                 <div className="rounded-lg border border-dashed border-glass-border px-3 py-6 text-center">
                   <p className="text-xs text-text-secondary/70">{t.myBotsEmpty}</p>

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import { Send, Loader2, MessageSquare, AlertCircle, RotateCcw, Bell, FileText, ChevronDown } from "lucide-react";
+import { Loader2, MessageSquare, AlertCircle, RotateCcw, Bell, FileText } from "lucide-react";
 import { api } from "@/lib/api";
 import type { Attachment, OwnerChatMessage } from "@/lib/types";
 import type { WsAttachment } from "@/lib/owner-chat-ws";
@@ -255,25 +255,6 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
     }
   }, [sendMessage, uploadFiles]);
 
-  const sendSuggestion = useCallback((text: string) => {
-    const clientId = crypto.randomUUID();
-    const optimisticMsg: OwnerChatMessage = {
-      clientId,
-      hubMsgId: null,
-      sender: "user",
-      text,
-      streamBlocks: [],
-      status: "optimistic",
-      createdAt: new Date().toISOString(),
-      senderName: "You",
-      type: "message",
-      sendText: text,
-    };
-    useOwnerChatStore.getState().addOptimistic(optimisticMsg);
-    scrollToBottom();
-    void sendMessage(text, clientId);
-  }, [scrollToBottom, sendMessage]);
-
   // ------ Render guards ------
 
   if (!chatAgentId) {
@@ -306,68 +287,9 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
   }
 
   const hasStreamingMsg = messages.some((m) => m.status === "streaming");
-  const showOnboarding = messages.length === 0;
 
   return (
     <div className="relative flex flex-col h-full">
-      {/* ===== Spotlight onboarding overlay ===== */}
-      {showOnboarding && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center animate-[fade-in_0.3s_ease-out]">
-          {/* Dark backdrop */}
-          <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" />
-
-          {/* Centered card */}
-          <div className="relative z-10 flex flex-col items-center gap-6 rounded-3xl border border-cyan-500/30 bg-zinc-900/95 px-8 py-10 shadow-[0_0_60px_rgba(0,240,255,0.12)] max-w-lg mx-4 animate-[scale-in_0.3s_ease-out]">
-            {/* Glowing icon */}
-            <div className="relative">
-              <div className="absolute inset-0 rounded-2xl bg-cyan-500/25 blur-2xl animate-pulse" />
-              <div className="relative flex h-20 w-20 items-center justify-center rounded-2xl border border-cyan-500/40 bg-cyan-500/10">
-                <MessageSquare className="h-10 w-10 text-cyan-400" />
-              </div>
-            </div>
-
-            {/* Welcome text */}
-            <div className="text-center">
-              <h2 className="text-xl font-bold text-white">
-                {chatRoomName ? `${chatRoomName} is ready!` : "Your Bot is ready!"}
-              </h2>
-              <p className="mt-2 text-sm text-zinc-400 max-w-sm leading-relaxed">
-                Choose a conversation starter, or type your own message below.
-              </p>
-            </div>
-
-            {/* Suggestion chips */}
-            <div className="flex flex-col gap-2.5 w-full">
-              {[
-                { emoji: "👋", text: "Hey! What can you do?" },
-                { emoji: "💡", text: "Tell me about yourself" },
-                { emoji: "🚀", text: "Let's get started!" },
-              ].map((suggestion) => (
-                <button
-                  key={suggestion.text}
-                  onClick={() => sendSuggestion(suggestion.text)}
-                  className="group flex items-center gap-3 rounded-xl border border-zinc-700/80 bg-zinc-800/60 px-4 py-3 text-left text-sm text-zinc-200 transition-all hover:border-cyan-500/50 hover:bg-cyan-500/10 hover:text-cyan-200 hover:shadow-[0_0_16px_rgba(0,240,255,0.12)]"
-                >
-                  <span className="text-lg">{suggestion.emoji}</span>
-                  <span className="flex-1">{suggestion.text}</span>
-                  <Send className="h-3.5 w-3.5 text-zinc-600 transition-colors group-hover:text-cyan-400" />
-                </button>
-              ))}
-            </div>
-
-            {/* Divider + hint */}
-            <div className="flex items-center gap-3 w-full">
-              <div className="flex-1 h-px bg-zinc-700" />
-              <span className="text-xs text-zinc-500 shrink-0">or type below</span>
-              <div className="flex-1 h-px bg-zinc-700" />
-            </div>
-
-            {/* Bouncing arrow */}
-            <ChevronDown className="h-6 w-6 text-cyan-400 animate-bounce" />
-          </div>
-        </div>
-      )}
-
       {/* Header */}
       <div className="flex items-center gap-2 px-4 py-3 border-b border-zinc-800">
         <MessageSquare className="w-4 h-4 text-cyan-400" />
@@ -564,18 +486,12 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
         <div />
       </div>
 
-      {/* Input — elevated above spotlight overlay so user can type */}
-      <div
-        className={`border-t px-4 py-3 transition-colors ${
-          showOnboarding ? "relative z-50 border-cyan-500/30 bg-zinc-900" : "border-zinc-800"
-        }`}
-      >
+      {/* Input */}
+      <div className="border-t border-zinc-800 px-4 py-3">
         <MessageComposer
           onSend={handleSend}
           allowAttachments
-          autoFocus={showOnboarding}
-          emptyState={showOnboarding}
-          placeholder={showOnboarding ? "Say something to your Bot..." : "Type a message..."}
+          placeholder="Type a message..."
         />
       </div>
     </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -339,6 +339,7 @@ export const api = {
       join_policy?: "open" | "invite_only";
       default_send?: boolean;
       default_invite?: boolean;
+      allow_human_send?: boolean;
       max_members?: number | null;
       slow_mode_seconds?: number | null;
       required_subscription_product_id?: string | null;
@@ -353,6 +354,7 @@ export const api = {
       join_policy?: string;
       default_send?: boolean;
       default_invite?: boolean;
+      allow_human_send?: boolean;
       max_members?: number | null;
       slow_mode_seconds?: number | null;
       required_subscription_product_id?: string | null;

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -2020,6 +2020,11 @@ export const createRoomModal: TranslationMap<{
   membersHint: string
   noContacts: string
   searchContacts: string
+  searchMembers: string
+  myBotsLabel: string
+  contactsLabel: string
+  noBotsMatch: string
+  noContactsMatch: string
   visibilityLabel: string
   visibilityPublic: string
   visibilityPrivate: string
@@ -2051,9 +2056,14 @@ export const createRoomModal: TranslationMap<{
     ruleLabel: 'Rule / announcement',
     rulePlaceholder: 'Ground rules shown to members.',
     membersLabel: 'Initial members',
-    membersHint: 'Pick from your contacts. You can invite more after the group is created.',
-    noContacts: 'No contacts yet — you can create an empty group and invite later.',
+    membersHint: 'Pick your bots or contacts. You can invite more after the group is created.',
+    noContacts: 'No bots or contacts yet — you can create an empty group and invite later.',
     searchContacts: 'Search contacts',
+    searchMembers: 'Search bots or contacts',
+    myBotsLabel: 'My bots',
+    contactsLabel: 'Contacts',
+    noBotsMatch: 'No bots match the search.',
+    noContactsMatch: 'No contacts match the search.',
     visibilityLabel: 'Visibility',
     visibilityPublic: 'Public (discoverable)',
     visibilityPrivate: 'Private (invite-only)',
@@ -2085,9 +2095,14 @@ export const createRoomModal: TranslationMap<{
     ruleLabel: '群公告 / 规则',
     rulePlaceholder: '给成员看的群内基本规则。',
     membersLabel: '初始成员',
-    membersHint: '从联系人中勾选，创建后也能继续邀请其他人。',
-    noContacts: '还没有联系人 — 你可以先创建空群，之后再邀请。',
+    membersHint: '从自己的 Bot 或联系人中勾选，创建后也能继续邀请。',
+    noContacts: '还没有 Bot 或联系人 — 你可以先创建空群，之后再邀请。',
     searchContacts: '搜索联系人',
+    searchMembers: '搜索 Bot 或联系人',
+    myBotsLabel: '我的 Bot',
+    contactsLabel: '联系人',
+    noBotsMatch: '没有匹配的 Bot。',
+    noContactsMatch: '没有匹配的联系人。',
     visibilityLabel: '可见性',
     visibilityPublic: '公开（可被发现）',
     visibilityPrivate: '私有（仅限邀请）',

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -2214,6 +2214,7 @@ export const roomAdvancedSettings: TranslationMap<{
   joinPolicyInviteOnly: string
   defaultSendLabel: string
   defaultInviteLabel: string
+  allowHumanSendLabel: string
   maxMembersLabel: string
   slowModeLabel: string
   subscriptionSection: string
@@ -2233,6 +2234,7 @@ export const roomAdvancedSettings: TranslationMap<{
     joinPolicyInviteOnly: 'Invite-only',
     defaultSendLabel: 'Members can send messages',
     defaultInviteLabel: 'Members can invite others',
+    allowHumanSendLabel: 'Humans can send messages',
     maxMembersLabel: 'Max members',
     slowModeLabel: 'Slow mode (seconds)',
     subscriptionSection: 'Payment & subscription',
@@ -2252,6 +2254,7 @@ export const roomAdvancedSettings: TranslationMap<{
     joinPolicyInviteOnly: '仅限邀请',
     defaultSendLabel: '默认允许成员发言',
     defaultInviteLabel: '默认允许成员邀请他人',
+    allowHumanSendLabel: '允许真人在此房间发言',
     maxMembersLabel: '人数上限',
     slowModeLabel: '慢速模式（秒）',
     subscriptionSection: '支付与订阅',

--- a/frontend/src/store/useDashboardSessionStore.ts
+++ b/frontend/src/store/useDashboardSessionStore.ts
@@ -124,6 +124,7 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
       token,
       activeAgentId,
       activeIdentity,
+      viewMode: activeIdentity?.type === "agent" ? "agent" : "human",
       sessionMode: resolveSessionMode(token, activeAgentId),
     });
   },
@@ -240,6 +241,7 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
         ownedAgents: user.agents,
         activeAgentId: activeId,
         activeIdentity,
+        viewMode: activeIdentity?.type === "agent" ? "agent" : "human",
         sessionMode: resolveSessionMode(token, activeId),
       });
     } catch (err: any) {


### PR DESCRIPTION
## Summary
- Polish My Bots tab: remove the spotlight onboarding overlay on first open; add a Refresh button to re-pull bot status
- Split own bots into a dedicated section in CreateRoomModal
- Expose \`allow_human_send\` in RoomSettingsModal
- Sync \`viewMode\` from \`activeIdentity\` on auth bootstrap
- Include own agent in @mention candidates in human view

## Test plan
- [ ] Open a bot from My Bots — no onboarding overlay, chat composer is ready
- [ ] Click Refresh on My Bots list — online dot updates
- [ ] Create a room — own bots appear as a separate group
- [ ] Toggle \`allow_human_send\` in Room Settings and verify it persists
- [ ] After login reload, human/agent viewMode matches active identity
- [ ] @mention in human view includes own agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)