### PR TITLE
feat(wallet): support user-scoped (human) wallets

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -191,7 +191,7 @@ async def _maybe_grant_claim_gift(
 
     await wallet_svc.create_grant(
         db,
-        agent_id=agent.agent_id,
+        owner_id=agent.agent_id,
         amount_minor=hub_config.CLAIM_GIFT_AMOUNT_MINOR,
         asset_code=hub_config.CLAIM_GIFT_ASSET_CODE,
         idempotency_key="claim-cold-start-gift-v1",

--- a/backend/app/routers/wallet.py
+++ b/backend/app/routers/wallet.py
@@ -1,7 +1,9 @@
 """Wallet, topup, withdrawal, and Stripe routes under /api/wallet.
 
-Uses Supabase JWT auth via ``require_active_agent`` and delegates to
-the existing hub service layer.
+Auth uses Supabase JWT via ``require_user_with_optional_agent``; each
+route accepts ``?as=agent|human`` (default ``agent``) to pick whose
+wallet to operate on. ``as=agent`` still requires the
+``X-Active-Agent`` header; ``as=human`` uses ``ctx.human_id``.
 """
 
 import json
@@ -11,7 +13,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth import RequestContext, require_active_agent
+from app.auth import RequestContext, require_user_with_optional_agent
 from hub import config as hub_config
 from hub.database import get_db
 from hub.models import WithdrawalRequest
@@ -42,6 +44,22 @@ router = APIRouter(prefix="/api/wallet", tags=["app-wallet"])
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _resolve_owner(ctx: RequestContext, as_: str) -> str:
+    """Resolve owner id based on `?as=agent|human` query parameter."""
+    if as_ == "human":
+        if not ctx.human_id:
+            raise HTTPException(status_code=400, detail="User has no human_id")
+        return ctx.human_id
+    if as_ == "agent":
+        if not ctx.active_agent_id:
+            raise HTTPException(
+                status_code=400,
+                detail="X-Active-Agent header is required when as=agent",
+            )
+        return ctx.active_agent_id
+    raise HTTPException(status_code=400, detail=f"Invalid `as` value: {as_!r}")
 
 
 def _wallet_summary(wallet) -> dict:
@@ -114,10 +132,12 @@ def _withdrawal_response(wd) -> dict:
 
 @router.get("/summary")
 async def get_wallet_summary(
-    ctx: RequestContext = Depends(require_active_agent),
+    as_: str = Query(default="agent", alias="as"),
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
     db: AsyncSession = Depends(get_db),
 ):
-    wallet = await wallet_svc.get_or_create_wallet(db, ctx.active_agent_id)
+    owner_id = _resolve_owner(ctx, as_)
+    wallet = await wallet_svc.get_or_create_wallet(db, owner_id)
     return _wallet_summary(wallet)
 
 
@@ -131,11 +151,13 @@ async def get_wallet_ledger(
     cursor: str | None = Query(default=None),
     limit: int = Query(default=50, ge=1, le=100),
     type: str | None = Query(default=None),
-    ctx: RequestContext = Depends(require_active_agent),
+    as_: str = Query(default="agent", alias="as"),
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
     db: AsyncSession = Depends(get_db),
 ):
+    owner_id = _resolve_owner(ctx, as_)
     entries, next_cursor, has_more = await wallet_svc.list_wallet_ledger(
-        db, ctx.active_agent_id, cursor=cursor, limit=limit, tx_type=type,
+        db, owner_id, cursor=cursor, limit=limit, tx_type=type,
     )
     return {
         "entries": [
@@ -165,7 +187,8 @@ async def get_wallet_ledger(
 @router.post("/transfers", status_code=201)
 async def create_transfer(
     body: TransferRequest,
-    ctx: RequestContext = Depends(require_active_agent),
+    as_: str = Query(default="agent", alias="as"),
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
     db: AsyncSession = Depends(get_db),
 ):
     try:
@@ -173,10 +196,12 @@ async def create_transfer(
     except (ValueError, TypeError):
         raise HTTPException(status_code=400, detail="Invalid amount_minor")
 
+    from_owner_id = _resolve_owner(ctx, as_)
+
     try:
         tx = await wallet_svc.create_transfer(
             db,
-            from_owner_id=ctx.active_agent_id,
+            from_owner_id=from_owner_id,
             to_owner_id=body.to_agent_id,
             amount_minor=amount,
             memo=body.memo,
@@ -200,7 +225,8 @@ async def create_transfer(
 @router.post("/topups", status_code=201)
 async def create_topup(
     body: TopupCreateRequest,
-    ctx: RequestContext = Depends(require_active_agent),
+    as_: str = Query(default="agent", alias="as"),
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
     db: AsyncSession = Depends(get_db),
 ):
     try:
@@ -208,10 +234,12 @@ async def create_topup(
     except (ValueError, TypeError):
         raise HTTPException(status_code=400, detail="Invalid amount_minor")
 
+    owner_id = _resolve_owner(ctx, as_)
+
     try:
         topup, tx = await wallet_svc.create_topup_request(
             db,
-            ctx.active_agent_id,
+            owner_id,
             amount,
             channel=body.channel,
             metadata=body.metadata,
@@ -231,12 +259,14 @@ async def create_topup(
 
 @router.get("/withdrawals")
 async def list_withdrawals(
-    ctx: RequestContext = Depends(require_active_agent),
+    as_: str = Query(default="agent", alias="as"),
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
     db: AsyncSession = Depends(get_db),
 ):
+    owner_id = _resolve_owner(ctx, as_)
     result = await db.execute(
         select(WithdrawalRequest)
-        .where(WithdrawalRequest.owner_id == ctx.active_agent_id)
+        .where(WithdrawalRequest.owner_id == owner_id)
         .order_by(WithdrawalRequest.created_at.desc())
         .limit(20)
     )
@@ -247,7 +277,8 @@ async def list_withdrawals(
 @router.post("/withdrawals", status_code=201)
 async def create_withdrawal(
     body: WithdrawalCreateRequest,
-    ctx: RequestContext = Depends(require_active_agent),
+    as_: str = Query(default="agent", alias="as"),
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
     db: AsyncSession = Depends(get_db),
 ):
     try:
@@ -258,10 +289,12 @@ async def create_withdrawal(
 
     destination_json = json.dumps(body.destination) if body.destination else None
 
+    owner_id = _resolve_owner(ctx, as_)
+
     try:
         wd, _tx = await wallet_svc.create_withdrawal_request(
             db,
-            ctx.active_agent_id,
+            owner_id,
             amount,
             fee_minor=fee,
             destination_type=body.destination_type,
@@ -278,12 +311,14 @@ async def create_withdrawal(
 @router.post("/withdrawals/{withdrawal_id}/cancel")
 async def cancel_withdrawal(
     withdrawal_id: str,
-    ctx: RequestContext = Depends(require_active_agent),
+    as_: str = Query(default="agent", alias="as"),
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
     db: AsyncSession = Depends(get_db),
 ):
+    owner_id = _resolve_owner(ctx, as_)
     try:
         wd = await wallet_svc.cancel_withdrawal_request(
-            db, withdrawal_id, ctx.active_agent_id,
+            db, withdrawal_id, owner_id,
         )
         await db.commit()
     except ValueError as exc:
@@ -300,15 +335,17 @@ async def cancel_withdrawal(
 @router.get("/transactions/{tx_id}")
 async def get_transaction(
     tx_id: str,
-    ctx: RequestContext = Depends(require_active_agent),
+    as_: str = Query(default="agent", alias="as"),
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
     db: AsyncSession = Depends(get_db),
 ):
     tx = await wallet_svc.get_transaction(db, tx_id)
     if tx is None:
         raise HTTPException(status_code=404, detail="Transaction not found")
 
-    # Authorization: agent must be sender or receiver
-    if ctx.active_agent_id not in (tx.from_owner_id, tx.to_owner_id):
+    owner_id = _resolve_owner(ctx, as_)
+    # Authorization: owner must be sender or receiver
+    if owner_id not in (tx.from_owner_id, tx.to_owner_id):
         raise HTTPException(status_code=403, detail="Not authorized to view this transaction")
 
     return _tx_response(tx)
@@ -343,13 +380,15 @@ async def list_stripe_packages():
 @router.post("/stripe/checkout-session", status_code=201)
 async def create_stripe_checkout(
     body: StripeCheckoutRequest,
-    ctx: RequestContext = Depends(require_active_agent),
+    as_: str = Query(default="agent", alias="as"),
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
     db: AsyncSession = Depends(get_db),
 ):
+    owner_id = _resolve_owner(ctx, as_)
     try:
         result = await stripe_svc.create_checkout_session(
             db,
-            ctx.active_agent_id,
+            owner_id,
             body.package_code,
             body.idempotency_key,
             quantity=body.quantity,
@@ -369,12 +408,14 @@ async def create_stripe_checkout(
 @router.get("/stripe/session-status")
 async def get_stripe_session_status(
     session_id: str = Query(...),
-    ctx: RequestContext = Depends(require_active_agent),
+    as_: str = Query(default="agent", alias="as"),
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
     db: AsyncSession = Depends(get_db),
 ):
+    owner_id = _resolve_owner(ctx, as_)
     try:
         result = await stripe_svc.get_checkout_status(
-            db, session_id, agent_id=ctx.active_agent_id,
+            db, session_id, agent_id=owner_id,
         )
         await db.commit()
     except ValueError as exc:

--- a/backend/app/routers/wallet.py
+++ b/backend/app/routers/wallet.py
@@ -47,7 +47,7 @@ router = APIRouter(prefix="/api/wallet", tags=["app-wallet"])
 def _wallet_summary(wallet) -> dict:
     total = wallet.available_balance_minor + wallet.locked_balance_minor
     return {
-        "agent_id": wallet.agent_id,
+        "agent_id": wallet.owner_id,
         "asset_code": wallet.asset_code,
         "available_balance_minor": str(wallet.available_balance_minor),
         "locked_balance_minor": str(wallet.locked_balance_minor),
@@ -64,8 +64,8 @@ def _tx_response(tx) -> dict:
         "asset_code": tx.asset_code,
         "amount_minor": str(tx.amount_minor),
         "fee_minor": str(tx.fee_minor),
-        "from_agent_id": tx.from_agent_id,
-        "to_agent_id": tx.to_agent_id,
+        "from_agent_id": tx.from_owner_id,
+        "to_agent_id": tx.to_owner_id,
         "reference_type": tx.reference_type,
         "reference_id": tx.reference_id,
         "idempotency_key": tx.idempotency_key,
@@ -80,7 +80,7 @@ def _topup_response(topup, tx) -> dict:
     return {
         "topup_id": topup.topup_id,
         "tx_id": tx.tx_id if tx else topup.tx_id,
-        "agent_id": topup.agent_id,
+        "agent_id": topup.owner_id,
         "asset_code": topup.asset_code,
         "amount_minor": str(topup.amount_minor),
         "status": topup.status.value if hasattr(topup.status, "value") else str(topup.status),
@@ -94,7 +94,7 @@ def _withdrawal_response(wd) -> dict:
     return {
         "withdrawal_id": wd.withdrawal_id,
         "tx_id": wd.tx_id,
-        "agent_id": wd.agent_id,
+        "agent_id": wd.owner_id,
         "asset_code": wd.asset_code,
         "amount_minor": str(wd.amount_minor),
         "fee_minor": str(wd.fee_minor),
@@ -176,8 +176,8 @@ async def create_transfer(
     try:
         tx = await wallet_svc.create_transfer(
             db,
-            from_agent_id=ctx.active_agent_id,
-            to_agent_id=body.to_agent_id,
+            from_owner_id=ctx.active_agent_id,
+            to_owner_id=body.to_agent_id,
             amount_minor=amount,
             memo=body.memo,
             reference_type=body.reference_type,
@@ -236,7 +236,7 @@ async def list_withdrawals(
 ):
     result = await db.execute(
         select(WithdrawalRequest)
-        .where(WithdrawalRequest.agent_id == ctx.active_agent_id)
+        .where(WithdrawalRequest.owner_id == ctx.active_agent_id)
         .order_by(WithdrawalRequest.created_at.desc())
         .limit(20)
     )
@@ -308,7 +308,7 @@ async def get_transaction(
         raise HTTPException(status_code=404, detail="Transaction not found")
 
     # Authorization: agent must be sender or receiver
-    if ctx.active_agent_id not in (tx.from_agent_id, tx.to_agent_id):
+    if ctx.active_agent_id not in (tx.from_owner_id, tx.to_owner_id):
         raise HTTPException(status_code=403, detail="Not authorized to view this transaction")
 
     return _tx_response(tx)

--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -680,15 +680,15 @@ class FileRecord(Base):
 class WalletAccount(Base):
     __tablename__ = "wallet_accounts"
     __table_args__ = (
-        UniqueConstraint("agent_id", "asset_code", name="uq_wallet_agent_asset"),
+        UniqueConstraint("owner_id", "asset_code", name="uq_wallet_owner_asset"),
         CheckConstraint("available_balance_minor >= 0", name="ck_wallet_available_nonneg"),
         CheckConstraint("locked_balance_minor >= 0", name="ck_wallet_locked_nonneg"),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    agent_id: Mapped[str] = mapped_column(
-        String(32), ForeignKey("agents.agent_id"), nullable=False, index=True
-    )
+    # Owner may be an agent (`ag_*`) or a human user (`hu_*`). No FK — the
+    # target table depends on prefix; validated in the service layer.
+    owner_id: Mapped[str] = mapped_column(String(32), nullable=False, index=True)
     asset_code: Mapped[str] = mapped_column(String(16), nullable=False, default="COIN")
     available_balance_minor: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
     locked_balance_minor: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
@@ -704,10 +704,9 @@ class WalletAccount(Base):
 class WalletTransaction(Base):
     __tablename__ = "wallet_transactions"
     __table_args__ = (
-        # Idempotency: scoped to (type, initiator_agent_id, idempotency_key).
-        # initiator_agent_id is from_agent_id for transfer/withdrawal, to_agent_id for topup.
-        # We use a computed-style approach: store the initiator in a dedicated column.
-        UniqueConstraint("type", "initiator_agent_id", "idempotency_key", name="uq_tx_idem"),
+        # Idempotency: scoped to (type, initiator_owner_id, idempotency_key).
+        # initiator_owner_id is from_owner_id for transfer/withdrawal, to_owner_id for topup.
+        UniqueConstraint("type", "initiator_owner_id", "idempotency_key", name="uq_tx_idem"),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
@@ -717,11 +716,11 @@ class WalletTransaction(Base):
     asset_code: Mapped[str] = mapped_column(String(16), nullable=False, default="COIN")
     amount_minor: Mapped[int] = mapped_column(BigInteger, nullable=False)
     fee_minor: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
-    from_agent_id: Mapped[str | None] = mapped_column(String(32), nullable=True, index=True)
-    to_agent_id: Mapped[str | None] = mapped_column(String(32), nullable=True, index=True)
-    initiator_agent_id: Mapped[str | None] = mapped_column(
+    from_owner_id: Mapped[str | None] = mapped_column(String(32), nullable=True, index=True)
+    to_owner_id: Mapped[str | None] = mapped_column(String(32), nullable=True, index=True)
+    initiator_owner_id: Mapped[str | None] = mapped_column(
         String(32), nullable=True, index=True,
-        doc="The agent who initiated the tx: from_agent_id for transfer/withdrawal, to_agent_id for topup"
+        doc="The owner who initiated the tx: from_owner_id for transfer/withdrawal, to_owner_id for topup"
     )
     reference_type: Mapped[str | None] = mapped_column(String(32), nullable=True)
     reference_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
@@ -746,9 +745,7 @@ class WalletEntry(Base):
     tx_id: Mapped[str] = mapped_column(
         String(64), ForeignKey("wallet_transactions.tx_id"), nullable=False, index=True
     )
-    agent_id: Mapped[str] = mapped_column(
-        String(32), ForeignKey("agents.agent_id"), nullable=False, index=True
-    )
+    owner_id: Mapped[str] = mapped_column(String(32), nullable=False, index=True)
     asset_code: Mapped[str] = mapped_column(String(16), nullable=False, default="COIN")
     direction: Mapped[EntryDirection] = mapped_column(Enum(EntryDirection), nullable=False)
     amount_minor: Mapped[int] = mapped_column(BigInteger, nullable=False)
@@ -763,9 +760,7 @@ class TopupRequest(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     topup_id: Mapped[str] = mapped_column(String(64), unique=True, nullable=False, index=True)
-    agent_id: Mapped[str] = mapped_column(
-        String(32), ForeignKey("agents.agent_id"), nullable=False, index=True
-    )
+    owner_id: Mapped[str] = mapped_column(String(32), nullable=False, index=True)
     asset_code: Mapped[str] = mapped_column(String(16), nullable=False, default="COIN")
     amount_minor: Mapped[int] = mapped_column(BigInteger, nullable=False)
     status: Mapped[TopupStatus] = mapped_column(
@@ -790,9 +785,7 @@ class WithdrawalRequest(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     withdrawal_id: Mapped[str] = mapped_column(String(64), unique=True, nullable=False, index=True)
-    agent_id: Mapped[str] = mapped_column(
-        String(32), ForeignKey("agents.agent_id"), nullable=False, index=True
-    )
+    owner_id: Mapped[str] = mapped_column(String(32), nullable=False, index=True)
     asset_code: Mapped[str] = mapped_column(String(16), nullable=False, default="COIN")
     amount_minor: Mapped[int] = mapped_column(BigInteger, nullable=False)
     fee_minor: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)

--- a/backend/hub/routers/wallet.py
+++ b/backend/hub/routers/wallet.py
@@ -42,7 +42,7 @@ async def wallet_summary(
     wallet = await wallet_svc.get_wallet_summary(db, current_agent)
     total = wallet.available_balance_minor + wallet.locked_balance_minor
     return WalletSummaryResponse(
-        agent_id=wallet.agent_id,
+        agent_id=wallet.owner_id,
         asset_code=wallet.asset_code,
         available_balance_minor=str(wallet.available_balance_minor),
         locked_balance_minor=str(wallet.locked_balance_minor),
@@ -68,7 +68,7 @@ async def wallet_ledger(
             LedgerEntryResponse(
                 entry_id=entry.entry_id,
                 tx_id=entry.tx_id,
-                agent_id=entry.agent_id,
+                agent_id=entry.owner_id,
                 asset_code=entry.asset_code,
                 direction=entry.direction.value,
                 tx_type=tx.type.value if tx is not None and hasattr(tx.type, "value") else (str(tx.type) if tx is not None else None),
@@ -100,8 +100,8 @@ async def create_transfer(
     try:
         tx = await wallet_svc.create_transfer(
             db,
-            from_agent_id=current_agent,
-            to_agent_id=req.to_agent_id,
+            from_owner_id=current_agent,
+            to_owner_id=req.to_agent_id,
             amount_minor=amount,
             idempotency_key=req.idempotency_key,
             memo=req.memo,
@@ -140,7 +140,7 @@ async def create_topup(
     return TopupResponse(
         topup_id=topup.topup_id,
         tx_id=topup.tx_id,
-        agent_id=topup.agent_id,
+        agent_id=topup.owner_id,
         asset_code=topup.asset_code,
         amount_minor=str(topup.amount_minor),
         status=topup.status.value,
@@ -196,7 +196,7 @@ async def get_transaction(
     if tx is None:
         raise I18nHTTPException(status_code=404, message_key="transaction_not_found")
     # Authorization: agent must be sender or receiver
-    if tx.from_agent_id != current_agent and tx.to_agent_id != current_agent:
+    if tx.from_owner_id != current_agent and tx.to_owner_id != current_agent:
         raise I18nHTTPException(status_code=403, message_key="not_authorized")
     return _tx_response(tx)
 
@@ -259,7 +259,7 @@ async def internal_complete_topup(
     return TopupResponse(
         topup_id=topup.topup_id,
         tx_id=topup.tx_id,
-        agent_id=topup.agent_id,
+        agent_id=topup.owner_id,
         asset_code=topup.asset_code,
         amount_minor=str(topup.amount_minor),
         status=topup.status.value,
@@ -285,7 +285,7 @@ async def internal_fail_topup(
     return TopupResponse(
         topup_id=topup.topup_id,
         tx_id=topup.tx_id,
-        agent_id=topup.agent_id,
+        agent_id=topup.owner_id,
         asset_code=topup.asset_code,
         amount_minor=str(topup.amount_minor),
         status=topup.status.value,
@@ -358,8 +358,8 @@ def _tx_response(tx) -> TransactionResponse:
         asset_code=tx.asset_code,
         amount_minor=str(tx.amount_minor),
         fee_minor=str(tx.fee_minor),
-        from_agent_id=tx.from_agent_id,
-        to_agent_id=tx.to_agent_id,
+        from_agent_id=tx.from_owner_id,
+        to_agent_id=tx.to_owner_id,
         reference_type=tx.reference_type,
         reference_id=tx.reference_id,
         idempotency_key=tx.idempotency_key,
@@ -374,7 +374,7 @@ def _wd_response(wd) -> WithdrawalResponse:
     return WithdrawalResponse(
         withdrawal_id=wd.withdrawal_id,
         tx_id=wd.tx_id,
-        agent_id=wd.agent_id,
+        agent_id=wd.owner_id,
         asset_code=wd.asset_code,
         amount_minor=str(wd.amount_minor),
         fee_minor=str(wd.fee_minor),

--- a/backend/hub/services/stripe_topup.py
+++ b/backend/hub/services/stripe_topup.py
@@ -66,7 +66,7 @@ async def create_checkout_session(
     # --- Idempotency: look for an existing topup with the same key ----------
     existing = await session.execute(
         select(TopupRequest).where(
-            TopupRequest.agent_id == agent_id,
+            TopupRequest.owner_id == agent_id,
             TopupRequest.channel == "stripe",
             TopupRequest.metadata_json.isnot(None),
         )
@@ -318,7 +318,7 @@ async def get_checkout_status(
         raise ValueError("Checkout session not found")
 
     # Ownership check
-    if topup.agent_id != agent_id:
+    if topup.owner_id != agent_id:
         raise PermissionError("Not authorized to view this topup")
 
     # Attempt fulfillment as compensation

--- a/backend/hub/services/subscriptions.py
+++ b/backend/hub/services/subscriptions.py
@@ -241,8 +241,8 @@ async def create_subscription(
     }
     tx = await create_transfer(
         session,
-        from_agent_id=subscriber_agent_id,
-        to_agent_id=product.owner_agent_id,
+        from_owner_id=subscriber_agent_id,
+        to_owner_id=product.owner_agent_id,
         amount_minor=product.amount_minor,
         idempotency_key=idempotency_key or f"subscription:first:{subscription_id}",
         reference_type="subscription_charge",
@@ -306,8 +306,8 @@ async def _reactivate_subscription(
     }
     tx = await create_transfer(
         session,
-        from_agent_id=subscription.subscriber_agent_id,
-        to_agent_id=product.owner_agent_id,
+        from_owner_id=subscription.subscriber_agent_id,
+        to_owner_id=product.owner_agent_id,
         amount_minor=product.amount_minor,
         idempotency_key=idempotency_key or f"subscription:reactivate:{subscription.subscription_id}:{now.isoformat()}",
         reference_type="subscription_charge",
@@ -493,8 +493,8 @@ async def _charge_subscription(
     try:
         tx = await create_transfer(
             session,
-            from_agent_id=subscription.subscriber_agent_id,
-            to_agent_id=subscription.provider_agent_id,
+            from_owner_id=subscription.subscriber_agent_id,
+            to_owner_id=subscription.provider_agent_id,
             amount_minor=subscription.amount_minor,
             idempotency_key=f"subscription:charge:{subscription.subscription_id}:{billing_cycle_key}",
             reference_type="subscription_charge",

--- a/backend/hub/services/wallet.py
+++ b/backend/hub/services/wallet.py
@@ -9,7 +9,7 @@ import datetime
 import json
 import logging
 
-from sqlalchemy import select, update
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -44,19 +44,19 @@ logger = logging.getLogger(__name__)
 
 
 async def get_or_create_wallet(
-    session: AsyncSession, agent_id: str, asset_code: str = "COIN"
+    session: AsyncSession, owner_id: str, asset_code: str = "COIN"
 ) -> WalletAccount:
     """Return existing wallet or create a zero-balance wallet."""
     result = await session.execute(
         select(WalletAccount).where(
-            WalletAccount.agent_id == agent_id,
+            WalletAccount.owner_id == owner_id,
             WalletAccount.asset_code == asset_code,
         )
     )
     wallet = result.scalar_one_or_none()
     if wallet is not None:
         return wallet
-    wallet = WalletAccount(agent_id=agent_id, asset_code=asset_code)
+    wallet = WalletAccount(owner_id=owner_id, asset_code=asset_code)
     session.add(wallet)
     await session.flush()
     return wallet
@@ -67,7 +67,7 @@ def _is_sqlite(session: AsyncSession) -> bool:
 
 
 async def _lock_wallet(
-    session: AsyncSession, agent_id: str, asset_code: str = "COIN"
+    session: AsyncSession, owner_id: str, asset_code: str = "COIN"
 ) -> WalletAccount:
     """SELECT ... FOR UPDATE on the wallet row. Creates wallet if missing.
 
@@ -77,7 +77,7 @@ async def _lock_wallet(
     sqlite = _is_sqlite(session)
 
     stmt = select(WalletAccount).where(
-        WalletAccount.agent_id == agent_id,
+        WalletAccount.owner_id == owner_id,
         WalletAccount.asset_code == asset_code,
     )
     if not sqlite:
@@ -86,7 +86,7 @@ async def _lock_wallet(
     result = await session.execute(stmt)
     wallet = result.scalar_one_or_none()
     if wallet is None:
-        wallet = WalletAccount(agent_id=agent_id, asset_code=asset_code)
+        wallet = WalletAccount(owner_id=owner_id, asset_code=asset_code)
         session.add(wallet)
         await session.flush()
         # Re-lock after creation (for PG)
@@ -94,7 +94,7 @@ async def _lock_wallet(
             result = await session.execute(
                 select(WalletAccount)
                 .where(
-                    WalletAccount.agent_id == agent_id,
+                    WalletAccount.owner_id == owner_id,
                     WalletAccount.asset_code == asset_code,
                 )
                 .with_for_update()
@@ -106,7 +106,7 @@ async def _lock_wallet(
 def _write_entry(
     session: AsyncSession,
     tx_id: str,
-    agent_id: str,
+    owner_id: str,
     asset_code: str,
     direction: EntryDirection,
     amount_minor: int,
@@ -115,7 +115,7 @@ def _write_entry(
     entry = WalletEntry(
         entry_id=generate_wallet_entry_id(),
         tx_id=tx_id,
-        agent_id=agent_id,
+        owner_id=owner_id,
         asset_code=asset_code,
         direction=direction,
         amount_minor=amount_minor,
@@ -131,22 +131,22 @@ def _write_entry(
 
 
 async def get_wallet_summary(
-    session: AsyncSession, agent_id: str, asset_code: str = "COIN"
+    session: AsyncSession, owner_id: str, asset_code: str = "COIN"
 ) -> WalletAccount:
     """Return wallet summary (creates a zero-balance wallet if none exists)."""
-    return await get_or_create_wallet(session, agent_id, asset_code)
+    return await get_or_create_wallet(session, owner_id, asset_code)
 
 
 async def list_wallet_ledger(
     session: AsyncSession,
-    agent_id: str,
+    owner_id: str,
     *,
     asset_code: str = "COIN",
     tx_type: str | None = None,
     cursor: str | None = None,
     limit: int = 50,
 ) -> tuple[list[tuple[WalletEntry, WalletTransaction | None]], str | None, bool]:
-    """Return paginated ledger entries for an agent.
+    """Return paginated ledger entries for an owner.
 
     Returns (entries, next_cursor, has_more).
     """
@@ -156,7 +156,7 @@ async def list_wallet_ledger(
         select(WalletEntry, WalletTransaction)
         .outerjoin(WalletTransaction, WalletEntry.tx_id == WalletTransaction.tx_id)
         .where(
-            WalletEntry.agent_id == agent_id,
+            WalletEntry.owner_id == owner_id,
             WalletEntry.asset_code == asset_code,
         )
         .order_by(WalletEntry.id.desc())
@@ -203,7 +203,7 @@ async def get_transaction(
 
 async def create_grant(
     session: AsyncSession,
-    agent_id: str,
+    owner_id: str,
     amount_minor: int,
     *,
     idempotency_key: str | None = None,
@@ -213,14 +213,14 @@ async def create_grant(
     metadata: dict | None = None,
     asset_code: str = "COIN",
 ) -> WalletTransaction:
-    """Credit an agent directly from the system treasury."""
+    """Credit an owner directly from the system treasury."""
 
     if idempotency_key:
         existing = await session.execute(
             select(WalletTransaction).where(
                 WalletTransaction.idempotency_key == idempotency_key,
                 WalletTransaction.type == TxType.grant,
-                WalletTransaction.initiator_agent_id == agent_id,
+                WalletTransaction.initiator_owner_id == owner_id,
             )
         )
         tx = existing.scalar_one_or_none()
@@ -230,11 +230,11 @@ async def create_grant(
     if amount_minor <= 0:
         raise ValueError("Amount must be positive")
 
-    recipient = await session.execute(select(Agent).where(Agent.agent_id == agent_id))
+    recipient = await session.execute(select(Agent).where(Agent.agent_id == owner_id))
     if recipient.scalar_one_or_none() is None:
         raise ValueError("Recipient agent not found")
 
-    wallet = await _lock_wallet(session, agent_id, asset_code)
+    wallet = await _lock_wallet(session, owner_id, asset_code)
     now = datetime.datetime.now(datetime.timezone.utc)
     tx_id = generate_tx_id()
     metadata_obj = dict(metadata or {})
@@ -252,9 +252,9 @@ async def create_grant(
         asset_code=asset_code,
         amount_minor=amount_minor,
         fee_minor=0,
-        from_agent_id=None,
-        to_agent_id=agent_id,
-        initiator_agent_id=agent_id,
+        from_owner_id=None,
+        to_owner_id=owner_id,
+        initiator_owner_id=owner_id,
         idempotency_key=idempotency_key,
         reference_type=reference_type,
         reference_id=reference_id,
@@ -270,7 +270,7 @@ async def create_grant(
             select(WalletTransaction).where(
                 WalletTransaction.idempotency_key == idempotency_key,
                 WalletTransaction.type == TxType.grant,
-                WalletTransaction.initiator_agent_id == agent_id,
+                WalletTransaction.initiator_owner_id == owner_id,
             )
         )
         tx = existing.scalar_one_or_none()
@@ -283,7 +283,7 @@ async def create_grant(
     _write_entry(
         session,
         tx_id,
-        agent_id,
+        owner_id,
         asset_code,
         EntryDirection.credit,
         amount_minor,
@@ -299,8 +299,8 @@ async def create_grant(
 
 async def create_transfer(
     session: AsyncSession,
-    from_agent_id: str,
-    to_agent_id: str,
+    from_owner_id: str,
+    to_owner_id: str,
     amount_minor: int,
     *,
     idempotency_key: str | None = None,
@@ -318,7 +318,7 @@ async def create_transfer(
             select(WalletTransaction).where(
                 WalletTransaction.idempotency_key == idempotency_key,
                 WalletTransaction.type == TxType.transfer,
-                WalletTransaction.initiator_agent_id == from_agent_id,
+                WalletTransaction.initiator_owner_id == from_owner_id,
             )
         )
         tx = existing.scalar_one_or_none()
@@ -326,26 +326,26 @@ async def create_transfer(
             return tx
 
     # Validations
-    if from_agent_id == to_agent_id:
+    if from_owner_id == to_owner_id:
         raise ValueError("Cannot transfer to yourself")
     if amount_minor <= 0:
         raise ValueError("Amount must be positive")
 
     # Verify recipient exists
     recipient = await session.execute(
-        select(Agent).where(Agent.agent_id == to_agent_id)
+        select(Agent).where(Agent.agent_id == to_owner_id)
     )
     if recipient.scalar_one_or_none() is None:
         raise ValueError("Recipient agent not found")
 
     # Lock wallets (consistent ordering to avoid deadlock)
-    ids_sorted = sorted([from_agent_id, to_agent_id])
+    ids_sorted = sorted([from_owner_id, to_owner_id])
     wallets = {}
-    for aid in ids_sorted:
-        wallets[aid] = await _lock_wallet(session, aid, asset_code)
+    for oid in ids_sorted:
+        wallets[oid] = await _lock_wallet(session, oid, asset_code)
 
-    sender_wallet = wallets[from_agent_id]
-    receiver_wallet = wallets[to_agent_id]
+    sender_wallet = wallets[from_owner_id]
+    receiver_wallet = wallets[to_owner_id]
 
     if sender_wallet.available_balance_minor < amount_minor:
         raise ValueError("Insufficient balance")
@@ -368,9 +368,9 @@ async def create_transfer(
         asset_code=asset_code,
         amount_minor=amount_minor,
         fee_minor=0,
-        from_agent_id=from_agent_id,
-        to_agent_id=to_agent_id,
-        initiator_agent_id=from_agent_id,
+        from_owner_id=from_owner_id,
+        to_owner_id=to_owner_id,
+        initiator_owner_id=from_owner_id,
         idempotency_key=idempotency_key,
         reference_type=reference_type,
         reference_id=reference_id,
@@ -387,7 +387,7 @@ async def create_transfer(
             select(WalletTransaction).where(
                 WalletTransaction.idempotency_key == idempotency_key,
                 WalletTransaction.type == TxType.transfer,
-                WalletTransaction.initiator_agent_id == from_agent_id,
+                WalletTransaction.initiator_owner_id == from_owner_id,
             )
         )
         tx = existing.scalar_one_or_none()
@@ -399,7 +399,7 @@ async def create_transfer(
     sender_wallet.available_balance_minor -= amount_minor
     sender_wallet.version += 1
     _write_entry(
-        session, tx_id, from_agent_id, asset_code,
+        session, tx_id, from_owner_id, asset_code,
         EntryDirection.debit, amount_minor,
         sender_wallet.available_balance_minor + sender_wallet.locked_balance_minor,
     )
@@ -408,7 +408,7 @@ async def create_transfer(
     receiver_wallet.available_balance_minor += amount_minor
     receiver_wallet.version += 1
     _write_entry(
-        session, tx_id, to_agent_id, asset_code,
+        session, tx_id, to_owner_id, asset_code,
         EntryDirection.credit, amount_minor,
         receiver_wallet.available_balance_minor + receiver_wallet.locked_balance_minor,
     )
@@ -424,7 +424,7 @@ async def create_transfer(
 
 async def create_topup_request(
     session: AsyncSession,
-    agent_id: str,
+    owner_id: str,
     amount_minor: int,
     *,
     channel: str = "mock",
@@ -442,7 +442,7 @@ async def create_topup_request(
             select(WalletTransaction).where(
                 WalletTransaction.idempotency_key == idempotency_key,
                 WalletTransaction.type == TxType.topup,
-                WalletTransaction.initiator_agent_id == agent_id,
+                WalletTransaction.initiator_owner_id == owner_id,
             )
         )
         tx = existing.scalar_one_or_none()
@@ -464,8 +464,8 @@ async def create_topup_request(
         asset_code=asset_code,
         amount_minor=amount_minor,
         fee_minor=0,
-        to_agent_id=agent_id,
-        initiator_agent_id=agent_id,
+        to_owner_id=owner_id,
+        initiator_owner_id=owner_id,
         idempotency_key=idempotency_key,
         metadata_json=json.dumps(metadata) if metadata else None,
     )
@@ -478,7 +478,7 @@ async def create_topup_request(
             select(WalletTransaction).where(
                 WalletTransaction.idempotency_key == idempotency_key,
                 WalletTransaction.type == TxType.topup,
-                WalletTransaction.initiator_agent_id == agent_id,
+                WalletTransaction.initiator_owner_id == owner_id,
             )
         )
         tx = existing.scalar_one_or_none()
@@ -493,7 +493,7 @@ async def create_topup_request(
 
     topup = TopupRequest(
         topup_id=topup_id,
-        agent_id=agent_id,
+        owner_id=owner_id,
         asset_code=asset_code,
         amount_minor=amount_minor,
         status=TopupStatus.pending,
@@ -523,7 +523,7 @@ async def complete_topup_request(
         raise ValueError(f"Topup is not pending (current: {topup.status.value})")
 
     # Lock wallet and credit
-    wallet = await _lock_wallet(session, topup.agent_id, topup.asset_code)
+    wallet = await _lock_wallet(session, topup.owner_id, topup.asset_code)
     wallet.available_balance_minor += topup.amount_minor
     wallet.version += 1
 
@@ -541,7 +541,7 @@ async def complete_topup_request(
 
     # Write ledger entry
     _write_entry(
-        session, tx.tx_id, topup.agent_id, topup.asset_code,
+        session, tx.tx_id, topup.owner_id, topup.asset_code,
         EntryDirection.credit, topup.amount_minor,
         wallet.available_balance_minor + wallet.locked_balance_minor,
     )
@@ -585,7 +585,7 @@ async def fail_topup_request(
 
 async def create_withdrawal_request(
     session: AsyncSession,
-    agent_id: str,
+    owner_id: str,
     amount_minor: int,
     *,
     fee_minor: int = 0,
@@ -608,7 +608,7 @@ async def create_withdrawal_request(
             select(WalletTransaction).where(
                 WalletTransaction.idempotency_key == idempotency_key,
                 WalletTransaction.type == TxType.withdrawal,
-                WalletTransaction.initiator_agent_id == agent_id,
+                WalletTransaction.initiator_owner_id == owner_id,
             )
         )
         tx = existing.scalar_one_or_none()
@@ -623,7 +623,7 @@ async def create_withdrawal_request(
                 return wd, tx
 
     # Lock wallet
-    wallet = await _lock_wallet(session, agent_id, asset_code)
+    wallet = await _lock_wallet(session, owner_id, asset_code)
     if wallet.available_balance_minor < total:
         raise ValueError("Insufficient balance")
 
@@ -642,8 +642,8 @@ async def create_withdrawal_request(
         asset_code=asset_code,
         amount_minor=amount_minor,
         fee_minor=fee_minor,
-        from_agent_id=agent_id,
-        initiator_agent_id=agent_id,
+        from_owner_id=owner_id,
+        initiator_owner_id=owner_id,
         idempotency_key=idempotency_key,
     )
     session.add(tx)
@@ -655,7 +655,7 @@ async def create_withdrawal_request(
             select(WalletTransaction).where(
                 WalletTransaction.idempotency_key == idempotency_key,
                 WalletTransaction.type == TxType.withdrawal,
-                WalletTransaction.initiator_agent_id == agent_id,
+                WalletTransaction.initiator_owner_id == owner_id,
             )
         )
         tx = existing.scalar_one_or_none()
@@ -672,7 +672,7 @@ async def create_withdrawal_request(
 
     wd = WithdrawalRequest(
         withdrawal_id=withdrawal_id,
-        agent_id=agent_id,
+        owner_id=owner_id,
         asset_code=asset_code,
         amount_minor=amount_minor,
         fee_minor=fee_minor,
@@ -739,7 +739,7 @@ async def reject_withdrawal_request(
     total = wd.amount_minor + wd.fee_minor
 
     # Unlock balance
-    wallet = await _lock_wallet(session, wd.agent_id, wd.asset_code)
+    wallet = await _lock_wallet(session, wd.owner_id, wd.asset_code)
     wallet.locked_balance_minor -= total
     wallet.available_balance_minor += total
     wallet.version += 1
@@ -780,7 +780,7 @@ async def complete_withdrawal_request(
     total = wd.amount_minor + wd.fee_minor
 
     # Deduct locked balance
-    wallet = await _lock_wallet(session, wd.agent_id, wd.asset_code)
+    wallet = await _lock_wallet(session, wd.owner_id, wd.asset_code)
     wallet.locked_balance_minor -= total
     wallet.version += 1
 
@@ -798,7 +798,7 @@ async def complete_withdrawal_request(
 
     # Write ledger entry
     _write_entry(
-        session, tx.tx_id, wd.agent_id, wd.asset_code,
+        session, tx.tx_id, wd.owner_id, wd.asset_code,
         EntryDirection.debit, total,
         wallet.available_balance_minor + wallet.locked_balance_minor,
     )
@@ -808,9 +808,9 @@ async def complete_withdrawal_request(
 
 
 async def cancel_withdrawal_request(
-    session: AsyncSession, withdrawal_id: str, agent_id: str
+    session: AsyncSession, withdrawal_id: str, owner_id: str
 ) -> WithdrawalRequest:
-    """Cancel a pending withdrawal — unlock balance. Only the requesting agent can cancel."""
+    """Cancel a pending withdrawal — unlock balance. Only the requesting owner can cancel."""
     sqlite = _is_sqlite(session)
     stmt = select(WithdrawalRequest).where(
         WithdrawalRequest.withdrawal_id == withdrawal_id
@@ -821,7 +821,7 @@ async def cancel_withdrawal_request(
     wd = result.scalar_one_or_none()
     if wd is None:
         raise ValueError("Withdrawal request not found")
-    if wd.agent_id != agent_id:
+    if wd.owner_id != owner_id:
         raise ValueError("Not authorized to cancel this withdrawal")
     if wd.status != WithdrawalStatus.pending:
         raise ValueError(f"Withdrawal is not pending (current: {wd.status.value})")
@@ -829,7 +829,7 @@ async def cancel_withdrawal_request(
     total = wd.amount_minor + wd.fee_minor
 
     # Unlock balance
-    wallet = await _lock_wallet(session, wd.agent_id, wd.asset_code)
+    wallet = await _lock_wallet(session, wd.owner_id, wd.asset_code)
     wallet.locked_balance_minor -= total
     wallet.available_balance_minor += total
     wallet.version += 1

--- a/backend/hub/services/wallet.py
+++ b/backend/hub/services/wallet.py
@@ -29,6 +29,7 @@ from hub.id_generators import (
 from hub.models import (
     Agent,
     TopupRequest,
+    User,
     WalletAccount,
     WalletEntry,
     WalletTransaction,
@@ -41,6 +42,25 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+async def _assert_owner_exists(session: AsyncSession, owner_id: str) -> None:
+    """Validate an owner id refers to a real agent or human user.
+
+    `ag_*` → agents.agent_id; `hu_*` → users.human_id. Any other shape is an
+    immediate programming error.
+    """
+    if owner_id.startswith("ag_"):
+        result = await session.execute(select(Agent).where(Agent.agent_id == owner_id))
+        if result.scalar_one_or_none() is None:
+            raise ValueError("Recipient agent not found")
+        return
+    if owner_id.startswith("hu_"):
+        result = await session.execute(select(User).where(User.human_id == owner_id))
+        if result.scalar_one_or_none() is None:
+            raise ValueError("Recipient human not found")
+        return
+    raise ValueError(f"Unsupported owner id prefix: {owner_id!r}")
 
 
 async def get_or_create_wallet(
@@ -230,9 +250,7 @@ async def create_grant(
     if amount_minor <= 0:
         raise ValueError("Amount must be positive")
 
-    recipient = await session.execute(select(Agent).where(Agent.agent_id == owner_id))
-    if recipient.scalar_one_or_none() is None:
-        raise ValueError("Recipient agent not found")
+    await _assert_owner_exists(session, owner_id)
 
     wallet = await _lock_wallet(session, owner_id, asset_code)
     now = datetime.datetime.now(datetime.timezone.utc)
@@ -331,12 +349,10 @@ async def create_transfer(
     if amount_minor <= 0:
         raise ValueError("Amount must be positive")
 
-    # Verify recipient exists
-    recipient = await session.execute(
-        select(Agent).where(Agent.agent_id == to_owner_id)
-    )
-    if recipient.scalar_one_or_none() is None:
-        raise ValueError("Recipient agent not found")
+    # Verify both parties exist. Sender is normally the caller (already
+    # authenticated), but we validate anyway to catch malformed ids.
+    await _assert_owner_exists(session, from_owner_id)
+    await _assert_owner_exists(session, to_owner_id)
 
     # Lock wallets (consistent ordering to avoid deadlock)
     ids_sorted = sorted([from_owner_id, to_owner_id])
@@ -435,6 +451,8 @@ async def create_topup_request(
     """Create a pending topup request and associated transaction."""
     if amount_minor <= 0:
         raise ValueError("Amount must be positive")
+
+    await _assert_owner_exists(session, owner_id)
 
     # Idempotency check — scoped to (type, initiator, key)
     if idempotency_key:
@@ -599,6 +617,8 @@ async def create_withdrawal_request(
         raise ValueError("Amount must be positive")
     if fee_minor < 0:
         raise ValueError("Fee must be non-negative")
+
+    await _assert_owner_exists(session, owner_id)
 
     total = amount_minor + fee_minor
 

--- a/backend/migrations/027_wallet_owner_id.sql
+++ b/backend/migrations/027_wallet_owner_id.sql
@@ -1,0 +1,37 @@
+-- Migration: Rename wallet ownership columns from agent_id -> owner_id
+--
+-- Owner id may be an agent (`ag_*`) or a human (`hu_*`). The FKs to agents
+-- are dropped; existence is validated in the service layer based on prefix.
+-- Column shapes (VARCHAR(32)) are unchanged — ag_/hu_ prefixes share one
+-- namespace.
+
+-- wallet_accounts ------------------------------------------------------------
+ALTER TABLE wallet_accounts DROP CONSTRAINT IF EXISTS wallet_accounts_agent_id_fkey;
+ALTER TABLE wallet_accounts RENAME COLUMN agent_id TO owner_id;
+ALTER TABLE wallet_accounts RENAME CONSTRAINT uq_wallet_agent_asset TO uq_wallet_owner_asset;
+ALTER INDEX IF EXISTS ix_wallet_accounts_agent_id RENAME TO ix_wallet_accounts_owner_id;
+
+-- wallet_entries -------------------------------------------------------------
+ALTER TABLE wallet_entries DROP CONSTRAINT IF EXISTS wallet_entries_agent_id_fkey;
+ALTER TABLE wallet_entries RENAME COLUMN agent_id TO owner_id;
+ALTER INDEX IF EXISTS ix_wallet_entries_agent_id RENAME TO ix_wallet_entries_owner_id;
+
+-- wallet_transactions --------------------------------------------------------
+ALTER TABLE wallet_transactions RENAME COLUMN from_agent_id TO from_owner_id;
+ALTER TABLE wallet_transactions RENAME COLUMN to_agent_id TO to_owner_id;
+ALTER TABLE wallet_transactions RENAME COLUMN initiator_agent_id TO initiator_owner_id;
+ALTER INDEX IF EXISTS ix_wallet_transactions_from_agent_id RENAME TO ix_wallet_transactions_from_owner_id;
+ALTER INDEX IF EXISTS ix_wallet_transactions_to_agent_id RENAME TO ix_wallet_transactions_to_owner_id;
+ALTER INDEX IF EXISTS ix_wallet_transactions_initiator_agent_id RENAME TO ix_wallet_transactions_initiator_owner_id;
+-- uq_tx_idem references initiator column: Postgres tracks the column by OID,
+-- so the unique constraint follows the rename automatically.
+
+-- topup_requests -------------------------------------------------------------
+ALTER TABLE topup_requests DROP CONSTRAINT IF EXISTS topup_requests_agent_id_fkey;
+ALTER TABLE topup_requests RENAME COLUMN agent_id TO owner_id;
+ALTER INDEX IF EXISTS ix_topup_requests_agent_id RENAME TO ix_topup_requests_owner_id;
+
+-- withdrawal_requests --------------------------------------------------------
+ALTER TABLE withdrawal_requests DROP CONSTRAINT IF EXISTS withdrawal_requests_agent_id_fkey;
+ALTER TABLE withdrawal_requests RENAME COLUMN agent_id TO owner_id;
+ALTER INDEX IF EXISTS ix_withdrawal_requests_agent_id RENAME TO ix_withdrawal_requests_owner_id;

--- a/backend/tests/test_app/test_app_subscriptions.py
+++ b/backend/tests/test_app/test_app_subscriptions.py
@@ -136,7 +136,7 @@ async def seed_data(db_session: AsyncSession):
 
     # Give subscriber a balance for subscription charges
     wallet = WalletAccount(
-        agent_id="ag_subscriber001",
+        owner_id="ag_subscriber001",
         asset_code="COIN",
         available_balance_minor=50000,
         locked_balance_minor=0,

--- a/backend/tests/test_app/test_app_user_agents.py
+++ b/backend/tests/test_app/test_app_user_agents.py
@@ -367,7 +367,7 @@ async def test_claim_resolve_success(client: AsyncClient, seed_user: dict, db_se
 
     grant_result = await db_session.execute(
         select(WalletTransaction).where(
-            WalletTransaction.to_agent_id == "ag_unclaimed01",
+            WalletTransaction.to_owner_id == "ag_unclaimed01",
             WalletTransaction.type == TxType.grant,
         )
     )
@@ -586,7 +586,7 @@ async def test_claim_gift_skips_after_window(
     assert resp.status_code == 201
     tx_count = await db_session.execute(
         select(func.count()).select_from(WalletTransaction).where(
-            WalletTransaction.to_agent_id == "ag_windowclosed1",
+            WalletTransaction.to_owner_id == "ag_windowclosed1",
             WalletTransaction.type == TxType.grant,
         )
     )

--- a/backend/tests/test_app/test_app_wallet.py
+++ b/backend/tests/test_app/test_app_wallet.py
@@ -138,7 +138,7 @@ async def seed_data(db_session: AsyncSession):
 
     # Give agent1 some balance
     wallet = WalletAccount(
-        agent_id="ag_wallet001",
+        owner_id="ag_wallet001",
         asset_code="COIN",
         available_balance_minor=10000,
         locked_balance_minor=0,

--- a/backend/tests/test_app/test_app_wallet_human.py
+++ b/backend/tests/test_app/test_app_wallet_human.py
@@ -1,0 +1,312 @@
+"""Tests for /api/wallet endpoints invoked with `?as=human`.
+
+Covers: human wallet summary/ledger, agent→human and human→agent transfers,
+and human-side topups. PR2 semantics: `ctx.human_id` is resolved from the
+Supabase-authenticated user; no X-Active-Agent header is required for human
+mode.
+"""
+
+import datetime
+import uuid
+
+import jwt
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from unittest.mock import AsyncMock
+
+from hub.models import (
+    Agent,
+    Base,
+    MessagePolicy,
+    Role,
+    User,
+    UserRole,
+    WalletAccount,
+)
+
+TEST_SUPABASE_SECRET = "test-supabase-jwt-secret-for-unit-tests"
+
+
+def _make_token(sub: str, secret: str = TEST_SUPABASE_SECRET) -> str:
+    payload = {
+        "sub": sub,
+        "aud": "authenticated",
+        "exp": datetime.datetime.now(datetime.timezone.utc)
+        + datetime.timedelta(hours=1),
+        "iss": "supabase",
+    }
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    from tests.test_app.conftest import create_test_engine
+    engine = create_test_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+    async with session_factory() as session:
+        yield session
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client(db_session: AsyncSession, monkeypatch):
+    import hub.config
+    monkeypatch.setattr(hub.config, "SUPABASE_JWT_SECRET", TEST_SUPABASE_SECRET)
+    import app.auth
+    monkeypatch.setattr(app.auth, "SUPABASE_JWT_SECRET", TEST_SUPABASE_SECRET)
+
+    from hub.main import app
+    from hub.database import get_db
+
+    async def _override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.state.http_client = AsyncMock(spec=AsyncClient)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def seed(db_session: AsyncSession):
+    """User with an agent. User has an auto-generated human_id."""
+    supabase_uuid = uuid.uuid4()
+    user_id = uuid.uuid4()
+    user = User(
+        id=user_id,
+        display_name="Human Wallet User",
+        email="human@example.com",
+        status="active",
+        supabase_user_id=supabase_uuid,
+    )
+    db_session.add(user)
+
+    role = Role(
+        id=uuid.uuid4(), name="member", display_name="Member",
+        is_system=True, priority=0,
+    )
+    db_session.add(role)
+    await db_session.flush()
+
+    db_session.add(UserRole(id=uuid.uuid4(), user_id=user_id, role_id=role.id))
+
+    agent = Agent(
+        agent_id="ag_humanwal01",
+        display_name="Human's Agent",
+        message_policy=MessagePolicy.contacts_only,
+        user_id=user_id,
+        is_default=True,
+        claimed_at=datetime.datetime.now(datetime.timezone.utc),
+    )
+    db_session.add(agent)
+
+    # Seed a pre-funded agent wallet so we can transfer agent → human
+    db_session.add(WalletAccount(
+        owner_id="ag_humanwal01",
+        asset_code="COIN",
+        available_balance_minor=5000,
+        locked_balance_minor=0,
+    ))
+
+    await db_session.commit()
+    await db_session.refresh(user)
+
+    return {
+        "token": _make_token(str(supabase_uuid)),
+        "agent_id": "ag_humanwal01",
+        "human_id": user.human_id,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Summary / lazy-create
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_human_summary_lazy_creates_wallet(client, seed):
+    """First GET with ?as=human creates a zero-balance human wallet."""
+    resp = await client.get(
+        "/api/wallet/summary?as=human",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["agent_id"] == seed["human_id"]
+    assert data["available_balance_minor"] == "0"
+    assert data["locked_balance_minor"] == "0"
+
+
+@pytest.mark.asyncio
+async def test_invalid_as_value_rejected(client, seed):
+    resp = await client.get(
+        "/api/wallet/summary?as=bogus",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_as_agent_without_header_rejected(client, seed):
+    """as=agent still requires X-Active-Agent."""
+    resp = await client.get(
+        "/api/wallet/summary?as=agent",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+    )
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Transfer agent ↔ human
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agent_to_human_transfer(client, seed):
+    """Agent wallet (5000) → human wallet. Balances shift accordingly."""
+    resp = await client.post(
+        "/api/wallet/transfers?as=agent",
+        headers={
+            "Authorization": f"Bearer {seed['token']}",
+            "X-Active-Agent": seed["agent_id"],
+        },
+        json={"to_agent_id": seed["human_id"], "amount_minor": "1500"},
+    )
+    assert resp.status_code == 201, resp.text
+    tx = resp.json()
+    assert tx["from_agent_id"] == seed["agent_id"]
+    assert tx["to_agent_id"] == seed["human_id"]
+
+    # Human summary reflects the credit
+    resp = await client.get(
+        "/api/wallet/summary?as=human",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+    )
+    assert resp.json()["available_balance_minor"] == "1500"
+
+    # Agent summary reflects the debit
+    resp = await client.get(
+        "/api/wallet/summary?as=agent",
+        headers={
+            "Authorization": f"Bearer {seed['token']}",
+            "X-Active-Agent": seed["agent_id"],
+        },
+    )
+    assert resp.json()["available_balance_minor"] == "3500"
+
+
+@pytest.mark.asyncio
+async def test_human_to_agent_transfer(client, seed):
+    """Seed human wallet then transfer human → agent with ?as=human."""
+    # Fund human wallet first via agent → human
+    await client.post(
+        "/api/wallet/transfers?as=agent",
+        headers={
+            "Authorization": f"Bearer {seed['token']}",
+            "X-Active-Agent": seed["agent_id"],
+        },
+        json={"to_agent_id": seed["human_id"], "amount_minor": "2000"},
+    )
+
+    # Now human → agent
+    resp = await client.post(
+        "/api/wallet/transfers?as=human",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+        json={"to_agent_id": seed["agent_id"], "amount_minor": "500"},
+    )
+    assert resp.status_code == 201, resp.text
+    tx = resp.json()
+    assert tx["from_agent_id"] == seed["human_id"]
+    assert tx["to_agent_id"] == seed["agent_id"]
+
+    # Human balance: 2000 - 500 = 1500
+    resp = await client.get(
+        "/api/wallet/summary?as=human",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+    )
+    assert resp.json()["available_balance_minor"] == "1500"
+
+
+@pytest.mark.asyncio
+async def test_transfer_to_nonexistent_human_rejected(client, seed):
+    resp = await client.post(
+        "/api/wallet/transfers?as=agent",
+        headers={
+            "Authorization": f"Bearer {seed['token']}",
+            "X-Active-Agent": seed["agent_id"],
+        },
+        json={"to_agent_id": "hu_doesnotexist", "amount_minor": "100"},
+    )
+    assert resp.status_code == 400
+    assert "human" in resp.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Topup as human (mock channel)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_human_topup_creates_pending(client, seed):
+    resp = await client.post(
+        "/api/wallet/topups?as=human",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+        json={"amount_minor": "800", "channel": "mock"},
+    )
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert data["agent_id"] == seed["human_id"]
+    assert data["status"] == "pending"
+    assert data["amount_minor"] == "800"
+
+
+# ---------------------------------------------------------------------------
+# Ledger isolation: agent ledger ≠ human ledger
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ledger_scoped_to_owner(client, seed):
+    # Transfer agent → human
+    await client.post(
+        "/api/wallet/transfers?as=agent",
+        headers={
+            "Authorization": f"Bearer {seed['token']}",
+            "X-Active-Agent": seed["agent_id"],
+        },
+        json={"to_agent_id": seed["human_id"], "amount_minor": "700"},
+    )
+
+    # Agent ledger: one debit entry
+    resp = await client.get(
+        "/api/wallet/ledger?as=agent",
+        headers={
+            "Authorization": f"Bearer {seed['token']}",
+            "X-Active-Agent": seed["agent_id"],
+        },
+    )
+    agent_entries = resp.json()["entries"]
+    assert any(e["direction"] == "debit" and e["amount_minor"] == "700" for e in agent_entries)
+
+    # Human ledger: one credit entry
+    resp = await client.get(
+        "/api/wallet/ledger?as=human",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+    )
+    human_entries = resp.json()["entries"]
+    assert any(e["direction"] == "credit" and e["amount_minor"] == "700" for e in human_entries)
+    # And no debit — the human only received
+    assert all(e["direction"] == "credit" for e in human_entries)

--- a/backend/tests/test_stripe_topup.py
+++ b/backend/tests/test_stripe_topup.py
@@ -287,7 +287,7 @@ async def test_create_checkout_stripe_failure_marks_topup_failed(client, db_sess
     from sqlalchemy import select
     result = await db_session.execute(
         select(TopupRequestModel).where(
-            TopupRequestModel.agent_id == agent_id,
+            TopupRequestModel.owner_id == agent_id,
             TopupRequestModel.channel == "stripe",
         )
     )


### PR DESCRIPTION
## Summary

Lets a user have their own wallet (keyed on their ``hu_*`` human_id)
alongside agent wallets. Ships in two commits:

- **refactor(wallet): rename agent_id columns to owner_id** — pure
  DB/ORM rename. wallet_accounts / wallet_entries / wallet_transactions
  / topup_requests / withdrawal_requests now use a generic ``owner_id``
  column (no FK to agents). Public API schemas keep their existing
  ``agent_id`` / ``from_agent_id`` / ``to_agent_id`` field names, so
  frontend/CLI are unaffected.
- **feat(wallet): support human owners (hu_*) alongside agents** —
  adds ``_assert_owner_exists`` in the service layer (validates
  ``ag_*`` via agents, ``hu_*`` via users.human_id) and a
  ``?as=agent|human`` query parameter across all ``/api/wallet/*``
  BFF routes (default ``agent``, fully back-compat). ``as=human``
  uses ``ctx.human_id`` and no longer requires ``X-Active-Agent``.

### Why

Previously wallets were strictly agent-scoped, so a user with multiple
agents had multiple unrelated balances and no way to hold funds as
themselves. The dashboard store already gated the wallet UI on
``activeIdentity.type === "agent"`` — this PR unblocks a human
identity path.

### Migration

``backend/migrations/027_wallet_owner_id.sql`` renames columns and
drops FKs to ``agents.agent_id``. Column shape unchanged
(``VARCHAR(32)``), so Postgres rename is metadata-only. No data
migration needed — existing ``ag_*`` values are valid owner ids.

## Test plan

- [x] ``uv run pytest tests/`` — 853 passed, 31 skipped, 0 failed
- [x] 8 new tests in ``test_app_wallet_human.py`` covering lazy
  wallet creation, agent↔human transfers, topup as human, ledger
  scoping, and validation errors
- [ ] Manual verification on staging that ``/api/wallet/summary`` and
  ``/api/wallet/summary?as=human`` both work with a logged-in user
- [ ] Run the migration on a staging DB and verify
  ``wallet_accounts.owner_id`` is queryable, FKs dropped
- [ ] Frontend follow-up (separate PR): relax ``useDashboardWalletStore``
  guard to accept ``human`` identity and add ``?as=`` to the API
  client

## Out of scope

- Subscription tables (``subscription_products.owner_agent_id``,
  ``agent_subscriptions.subscriber_agent_id/provider_agent_id``) —
  still agent-only. Will be migrated when humans need to
  subscribe/sell.
- Stripe webhook metadata key ``agent_id`` is still written as-is;
  human topups work via the normal pending → complete path but the
  webhook display path isn't revisited here.
- Frontend store / API client changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)