### PR TITLE
feat: show bot-only rooms for humans

### DIFF
--- a/backend/app/routers/humans.py
+++ b/backend/app/routers/humans.py
@@ -24,6 +24,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import RequestContext, require_user
+from app.routers.dashboard import _build_rooms_from_sql
 from hub.database import get_db
 from hub.enums import (
     ApprovalKind,
@@ -83,6 +84,34 @@ class HumanRoomSummary(BaseModel):
 
 class HumanRoomListResponse(BaseModel):
     rooms: list[HumanRoomSummary]
+
+
+class HumanAgentRoomBot(BaseModel):
+    agent_id: str
+    display_name: str
+    role: str
+
+
+class HumanAgentRoomSummary(BaseModel):
+    room_id: str
+    name: str
+    description: str | None
+    rule: str | None = None
+    owner_id: str
+    visibility: str
+    join_policy: str | None = None
+    member_count: int
+    created_at: str | None = None
+    required_subscription_product_id: str | None = None
+    last_message_preview: str | None = None
+    last_message_at: str | None = None
+    last_sender_name: str | None = None
+    allow_human_send: bool | None = None
+    bots: list[HumanAgentRoomBot]
+
+
+class HumanAgentRoomListResponse(BaseModel):
+    rooms: list[HumanAgentRoomSummary]
 
 
 class CreateHumanRoomBody(BaseModel):
@@ -416,6 +445,88 @@ async def list_human_rooms(
             )
         )
     return HumanRoomListResponse(rooms=rooms)
+
+
+@router.get("/me/agent-rooms", response_model=HumanAgentRoomListResponse)
+async def list_owned_agent_only_rooms(
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Rooms joined by the user's Agents, excluding rooms joined/owned by the Human."""
+    user = await _load_human(db, ctx)
+    human_id = user.human_id
+
+    agent_result = await db.execute(
+        select(Agent.agent_id, Agent.display_name)
+        .where(Agent.user_id == ctx.user_id)
+        .order_by(Agent.created_at)
+    )
+    owned_agents = agent_result.all()
+    if not owned_agents:
+        return HumanAgentRoomListResponse(rooms=[])
+
+    agent_names = {agent_id: display_name for agent_id, display_name in owned_agents}
+    rooms_by_id: dict[str, dict] = {}
+    bots_by_room: dict[str, dict[str, HumanAgentRoomBot]] = {}
+
+    for agent_id, display_name in owned_agents:
+        previews = await _build_rooms_from_sql(agent_id, db)
+        for preview in previews:
+            room_id = preview.get("room_id")
+            if not isinstance(room_id, str) or not room_id:
+                continue
+            rooms_by_id.setdefault(room_id, preview)
+            role = preview.get("my_role") or "member"
+            bots_by_room.setdefault(room_id, {})[agent_id] = HumanAgentRoomBot(
+                agent_id=agent_id,
+                display_name=display_name or agent_id,
+                role=str(role),
+            )
+
+    if not rooms_by_id:
+        return HumanAgentRoomListResponse(rooms=[])
+
+    room_ids = list(rooms_by_id.keys())
+    human_membership_result = await db.execute(
+        select(RoomMember.room_id)
+        .where(
+            RoomMember.room_id.in_(room_ids),
+            RoomMember.agent_id == human_id,
+            RoomMember.participant_type == ParticipantType.human,
+        )
+    )
+    human_member_room_ids = {row[0] for row in human_membership_result.all()}
+
+    response_rooms: list[HumanAgentRoomSummary] = []
+    for room_id, preview in rooms_by_id.items():
+        owner_id = str(preview.get("owner_id") or "")
+        if room_id in human_member_room_ids or owner_id == human_id:
+            continue
+        bots = list(bots_by_room.get(room_id, {}).values())
+        if not bots:
+            continue
+        response_rooms.append(
+            HumanAgentRoomSummary(
+                room_id=room_id,
+                name=str(preview.get("name") or room_id),
+                description=preview.get("description"),
+                rule=preview.get("rule"),
+                owner_id=owner_id,
+                visibility=str(preview.get("visibility") or ""),
+                join_policy=preview.get("join_policy"),
+                member_count=int(preview.get("member_count") or 0),
+                created_at=preview.get("created_at"),
+                required_subscription_product_id=preview.get("required_subscription_product_id"),
+                last_message_preview=preview.get("last_message_preview"),
+                last_message_at=preview.get("last_message_at"),
+                last_sender_name=preview.get("last_sender_name"),
+                allow_human_send=preview.get("allow_human_send"),
+                bots=sorted(bots, key=lambda bot: agent_names.get(bot.agent_id) or bot.agent_id),
+            )
+        )
+
+    response_rooms.sort(key=lambda room: room.last_message_at or room.created_at or "", reverse=True)
+    return HumanAgentRoomListResponse(rooms=response_rooms)
 
 
 @router.post("/me/rooms", response_model=HumanRoomSummary, status_code=201)

--- a/backend/tests/test_app/test_app_humans.py
+++ b/backend/tests/test_app/test_app_humans.py
@@ -187,6 +187,85 @@ async def test_human_creates_and_lists_room(client, seed, db_session: AsyncSessi
     assert "Human HQ" in names
 
 
+@pytest.mark.asyncio
+async def test_list_owned_agent_rooms_excludes_current_human_rooms(
+    client, seed, db_session: AsyncSession
+):
+    agent = Agent(
+        agent_id="ag_alice00001",
+        display_name="Alice Bot",
+        message_policy=MessagePolicy.open,
+        user_id=seed["user_id"],
+    )
+    included = Room(
+        room_id="rm_bot_only",
+        name="Bot Only",
+        description="agent present, human absent",
+        owner_id="ag_other00001",
+        owner_type=ParticipantType.agent,
+        visibility=RoomVisibility.private,
+        join_policy=RoomJoinPolicy.invite_only,
+    )
+    human_member = Room(
+        room_id="rm_human_member",
+        name="Human Member",
+        description="excluded because human is a member",
+        owner_id="ag_other00001",
+        owner_type=ParticipantType.agent,
+        visibility=RoomVisibility.private,
+        join_policy=RoomJoinPolicy.invite_only,
+    )
+    human_owner = Room(
+        room_id="rm_human_owner",
+        name="Human Owner",
+        description="excluded because human owns it",
+        owner_id=seed["human_id"],
+        owner_type=ParticipantType.human,
+        visibility=RoomVisibility.private,
+        join_policy=RoomJoinPolicy.invite_only,
+    )
+    db_session.add_all([agent, included, human_member, human_owner])
+    await db_session.flush()
+    db_session.add_all([
+        RoomMember(
+            room_id="rm_bot_only",
+            agent_id="ag_alice00001",
+            participant_type=ParticipantType.agent,
+            role=RoomRole.member,
+        ),
+        RoomMember(
+            room_id="rm_human_member",
+            agent_id="ag_alice00001",
+            participant_type=ParticipantType.agent,
+            role=RoomRole.member,
+        ),
+        RoomMember(
+            room_id="rm_human_member",
+            agent_id=seed["human_id"],
+            participant_type=ParticipantType.human,
+            role=RoomRole.member,
+        ),
+        RoomMember(
+            room_id="rm_human_owner",
+            agent_id="ag_alice00001",
+            participant_type=ParticipantType.agent,
+            role=RoomRole.member,
+        ),
+    ])
+    await db_session.commit()
+
+    resp = await client.get(
+        "/api/humans/me/agent-rooms",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+    )
+    assert resp.status_code == 200, resp.text
+    rooms = resp.json()["rooms"]
+    assert [room["room_id"] for room in rooms] == ["rm_bot_only"]
+    assert rooms[0]["bots"] == [
+        {"agent_id": "ag_alice00001", "display_name": "Alice Bot", "role": "member"}
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Contact request → Agent (claimed)
 # ---------------------------------------------------------------------------

--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -586,17 +586,28 @@ export default function DashboardApp() {
     if (!chatStore.publicHumansLoaded && !chatStore.publicHumansLoading) {
       void chatStore.loadPublicHumans();
     }
+    if (
+      sessionStore.activeIdentity?.type === "human"
+      && !chatStore.ownedAgentRoomsLoaded
+      && !chatStore.ownedAgentRoomsLoading
+    ) {
+      void chatStore.loadOwnedAgentRooms();
+    }
   }, [
     sessionStore.authResolved,
+    sessionStore.activeIdentity?.type,
     chatStore.publicRoomsLoaded,
     chatStore.publicRoomsLoading,
     chatStore.publicAgentsLoaded,
     chatStore.publicAgentsLoading,
     chatStore.publicHumansLoaded,
     chatStore.publicHumansLoading,
+    chatStore.ownedAgentRoomsLoaded,
+    chatStore.ownedAgentRoomsLoading,
     chatStore.loadPublicRooms,
     chatStore.loadPublicAgents,
     chatStore.loadPublicHumans,
+    chatStore.loadOwnedAgentRooms,
   ]);
 
   useEffect(() => {

--- a/frontend/src/components/dashboard/RoomList.tsx
+++ b/frontend/src/components/dashboard/RoomList.tsx
@@ -49,6 +49,8 @@ interface RoomListProps {
   rooms?: DashboardRoom[];
   loading?: boolean;
   searchQuery?: string;
+  includeUserChat?: boolean;
+  roomMeta?: Record<string, string>;
 }
 
 const USER_CHAT_PATH = "/chats/messages/__user-chat__";
@@ -80,7 +82,13 @@ function formatLastMessageTime(isoTime: string | null): string {
     : date.toLocaleDateString();
 }
 
-export default function RoomList({ rooms: propsRooms, loading = false, searchQuery = "" }: RoomListProps) {
+export default function RoomList({
+  rooms: propsRooms,
+  loading = false,
+  searchQuery = "",
+  includeUserChat = true,
+  roomMeta,
+}: RoomListProps) {
   const router = useRouter();
   const locale = useLanguage();
   const t = roomList[locale];
@@ -117,7 +125,7 @@ export default function RoomList({ rooms: propsRooms, loading = false, searchQue
       .map(humanRoomToDashboardRoom);
     return [...agentRooms, ...extras];
   })();
-  const showUserChatEntry = Boolean(activeAgentId) && (
+  const showUserChatEntry = includeUserChat && Boolean(activeAgentId) && (
     !normalizedSearchQuery ||
     [t.userChatTitle, t.userChatPreview, t.userChatTooltip, activeAgentId]
       .join("\n")
@@ -255,6 +263,7 @@ export default function RoomList({ rooms: propsRooms, loading = false, searchQue
           previewSender = "";
         }
         const previewLine = previewSender ? `${previewSender}: ${previewText}` : previewText;
+        const metaLine = roomMeta?.[room.room_id] ?? null;
         const messageTime = formatLastMessageTime(room.last_message_at);
         const avatarLabel = buildRoomAvatarLabel(room.name);
         const avatarTone = buildAvatarTone(room.room_id);
@@ -305,6 +314,11 @@ export default function RoomList({ rooms: propsRooms, loading = false, searchQue
                     {previewLine}
                   </p>
                 </div>
+                {metaLine && (
+                  <p className="mt-1 truncate text-[10px] text-neon-cyan/70">
+                    {metaLine}
+                  </p>
+                )}
               </div>
             </div>
           </div>

--- a/frontend/src/components/dashboard/Sidebar.tsx
+++ b/frontend/src/components/dashboard/Sidebar.tsx
@@ -23,10 +23,10 @@ import CreateRoomModal from "./CreateRoomModal";
 import CreateAgentDialog from "./CreateAgentDialog";
 import RoomZeroState from "./RoomZeroState";
 import SearchBar from "./SearchBar";
-import { UserPlus, MessageSquarePlus, Users, LogIn, Bot, Plus } from "lucide-react";
+import { UserPlus, MessageSquarePlus, Users, LogIn, Bot, Plus, ChevronDown } from "lucide-react";
 import { messagesHeader } from "@/lib/i18n/translations/dashboard";
 import { createClient } from "@/lib/supabase/client";
-import { useDashboardChatStore } from "@/store/useDashboardChatStore";
+import { mapOwnedAgentRoomToDashboardRoom, useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import { useDashboardUnreadStore } from "@/store/useDashboardUnreadStore";
@@ -224,6 +224,8 @@ export default function Sidebar() {
     overview: state.overview,
     messages: state.messages,
     recentVisitedRooms: state.recentVisitedRooms,
+    ownedAgentRooms: state.ownedAgentRooms,
+    ownedAgentRoomsLoading: state.ownedAgentRoomsLoading,
     switchActiveAgent: state.switchActiveAgent,
   })));
   const optimisticUnreadRoomIds = useDashboardUnreadStore((state) => state.optimisticUnreadRoomIds);
@@ -235,6 +237,7 @@ export default function Sidebar() {
   const [showAddFriend, setShowAddFriend] = useState(false);
   const [showCreateRoom, setShowCreateRoom] = useState(false);
   const [showCreateBot, setShowCreateBot] = useState(false);
+  const [agentRoomsOpen, setAgentRoomsOpen] = useState(true);
   const [messageQuery, setMessageQuery] = useState("");
   const tMsgHeader = messagesHeader[locale];
   const showLoginModal = () => router.push("/login");
@@ -332,6 +335,38 @@ export default function Sidebar() {
       return searchHaystack.includes(normalizedMessageQuery);
     });
   }, [chatStore.messages, normalizedMessageQuery, visibleMessageRooms]);
+  const filteredOwnedAgentRooms = useMemo(() => {
+    const rooms = chatStore.ownedAgentRooms.map(mapOwnedAgentRoomToDashboardRoom);
+    if (!normalizedMessageQuery) return rooms;
+    return rooms.filter((room) => {
+      const source = chatStore.ownedAgentRooms.find((item) => item.room_id === room.room_id);
+      const searchHaystack = [
+        room.name,
+        room.room_id,
+        room.description,
+        room.last_message_preview,
+        room.last_sender_name,
+        ...(source?.bots.map((bot) => `${bot.display_name} ${bot.agent_id}`) ?? []),
+      ]
+        .filter(Boolean)
+        .join("\n")
+        .toLowerCase();
+      return searchHaystack.includes(normalizedMessageQuery);
+    });
+  }, [chatStore.ownedAgentRooms, normalizedMessageQuery]);
+  const ownedAgentRoomMeta = useMemo(
+    () => Object.fromEntries(
+      chatStore.ownedAgentRooms.map((room) => [
+        room.room_id,
+        room.bots.map((bot) => bot.display_name || bot.agent_id).join(", "),
+      ]),
+    ),
+    [chatStore.ownedAgentRooms],
+  );
+  const showOwnedAgentRoomsSection =
+    sessionStore.viewMode === "human"
+    && !isGuest
+    && (chatStore.ownedAgentRoomsLoading || filteredOwnedAgentRooms.length > 0);
   const showOverviewSkeleton =
     sessionStore.sessionMode === "authed-ready" && !chatStore.overview && uiStore.sidebarTab === "messages";
   const hasUnreadMessages = optimisticUnreadRoomIds.length > 0 || visibleMessageRooms.some((room) => room.has_unread);
@@ -642,14 +677,45 @@ export default function Sidebar() {
               <div className="border-b border-glass-border px-3 pb-3">
                 <SearchBar onSearch={setMessageQuery} placeholder={t.searchMessages} />
               </div>
-              {visibleMessageRooms.length === 0 && !sessionStore.activeAgentId ? (
+              {visibleMessageRooms.length === 0 && !sessionStore.activeAgentId && !showOwnedAgentRoomsSection ? (
                 <RoomZeroState compact />
-              ) : !showOverviewSkeleton && filteredMessageRooms.length === 0 && !sessionStore.activeAgentId ? (
+              ) : !showOverviewSkeleton && filteredMessageRooms.length === 0 && !sessionStore.activeAgentId && !showOwnedAgentRoomsSection ? (
                 <div className="px-4 py-6 text-center text-xs text-text-secondary">
                   {t.noMessages}
                 </div>
               ) : (
-                <RoomList rooms={filteredMessageRooms} loading={showOverviewSkeleton} searchQuery={messageQuery} />
+                <>
+                  <RoomList rooms={filteredMessageRooms} loading={showOverviewSkeleton} searchQuery={messageQuery} />
+                  {showOwnedAgentRoomsSection && (
+                    <div className="border-t border-glass-border/70 pt-1">
+                      <button
+                        type="button"
+                        onClick={() => setAgentRoomsOpen((open) => !open)}
+                        className="flex w-full items-center justify-between px-4 py-2 text-left text-[11px] font-semibold uppercase tracking-[0.14em] text-text-secondary/75 transition-colors hover:text-text-primary"
+                      >
+                        <span>
+                          {locale === "zh" ? "我的 Bots 所在群" : "Bot rooms"}
+                          {filteredOwnedAgentRooms.length > 0 ? ` · ${filteredOwnedAgentRooms.length}` : ""}
+                        </span>
+                        <ChevronDown
+                          className={`h-3.5 w-3.5 transition-transform ${agentRoomsOpen ? "rotate-180" : ""}`}
+                        />
+                      </button>
+                      {agentRoomsOpen && (
+                        chatStore.ownedAgentRoomsLoading ? (
+                          <RoomList rooms={[]} loading includeUserChat={false} />
+                        ) : (
+                          <RoomList
+                            rooms={filteredOwnedAgentRooms}
+                            searchQuery={messageQuery}
+                            includeUserChat={false}
+                            roomMeta={ownedAgentRoomMeta}
+                          />
+                        )
+                      )}
+                    </div>
+                  )}
+                </>
               )}
             </div>
           )}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -54,6 +54,7 @@ import type {
   RoomResponse,
   UpdateRoomBody,
   HumanInfo,
+  HumanAgentRoomListResponse,
   HumanRoomSummary,
   HumanRoomListResponse,
   HumanContactListResponse,
@@ -831,6 +832,10 @@ const humansApi = {
 
   listRooms(): Promise<HumanRoomListResponse> {
     return apiGet<HumanRoomListResponse>("/api/humans/me/rooms");
+  },
+
+  listAgentRooms(): Promise<HumanAgentRoomListResponse> {
+    return apiGet<HumanAgentRoomListResponse>("/api/humans/me/agent-rooms");
   },
 
   /** Human self-joins a public+open room. */

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -845,6 +845,34 @@ export interface HumanRoomListResponse {
   rooms: HumanRoomSummary[];
 }
 
+export interface HumanAgentRoomBot {
+  agent_id: string;
+  display_name: string;
+  role: string;
+}
+
+export interface HumanAgentRoomSummary {
+  room_id: string;
+  name: string;
+  description: string | null;
+  rule: string | null;
+  owner_id: string;
+  visibility: string;
+  join_policy?: string | null;
+  member_count: number;
+  created_at?: string | null;
+  required_subscription_product_id?: string | null;
+  last_message_preview: string | null;
+  last_message_at: string | null;
+  last_sender_name: string | null;
+  allow_human_send?: boolean | null;
+  bots: HumanAgentRoomBot[];
+}
+
+export interface HumanAgentRoomListResponse {
+  rooms: HumanAgentRoomSummary[];
+}
+
 export interface HumanContactSummary {
   peer_id: string;
   peer_type: ParticipantType;

--- a/frontend/src/store/useDashboardChatStore.ts
+++ b/frontend/src/store/useDashboardChatStore.ts
@@ -13,11 +13,12 @@ import type {
   DashboardOverview,
   DashboardRoom,
   DiscoverRoom,
+  HumanAgentRoomSummary,
   PublicHumanProfile,
   PublicRoom,
   RealtimeMetaEvent,
 } from "@/lib/types";
-import { api } from "@/lib/api";
+import { api, humansApi } from "@/lib/api";
 import {
   buildVisibleMessageRooms,
   roomMessagesInFlight,
@@ -59,6 +60,33 @@ function applyRealtimeRoomHint<T extends {
   };
 }
 
+function ownedAgentRoomToDashboardRoom(room: HumanAgentRoomSummary): DashboardRoom {
+  return {
+    room_id: room.room_id,
+    name: room.name,
+    description: room.description ?? "",
+    owner_id: room.owner_id,
+    visibility: room.visibility,
+    join_policy: room.join_policy ?? undefined,
+    can_invite: undefined,
+    member_count: room.member_count,
+    my_role: room.bots[0]?.role ?? "member",
+    created_at: room.created_at ?? null,
+    rule: room.rule,
+    required_subscription_product_id: room.required_subscription_product_id ?? null,
+    last_viewed_at: null,
+    has_unread: false,
+    last_message_preview: room.last_message_preview,
+    last_message_at: room.last_message_at,
+    last_sender_name: room.last_sender_name,
+    allow_human_send: room.allow_human_send ?? undefined,
+  };
+}
+
+export function mapOwnedAgentRoomToDashboardRoom(room: HumanAgentRoomSummary): DashboardRoom {
+  return ownedAgentRoomToDashboardRoom(room);
+}
+
 interface DashboardChatState {
   boundAgentId: string | null;
   overviewRefreshing: boolean;
@@ -89,6 +117,9 @@ interface DashboardChatState {
   publicHumansLoading: boolean;
   publicHumansLoaded: boolean;
   recentVisitedRooms: PublicRoom[];
+  ownedAgentRooms: HumanAgentRoomSummary[];
+  ownedAgentRoomsLoading: boolean;
+  ownedAgentRoomsLoaded: boolean;
 
   setError: (error: string | null) => void;
   addRecentPublicRoom: (room: PublicRoom) => void;
@@ -117,6 +148,7 @@ interface DashboardChatState {
   loadPublicRoomDetail: (roomId: string) => Promise<PublicRoom | null>;
   loadPublicAgents: (q?: string) => Promise<void>;
   loadPublicHumans: (q?: string) => Promise<void>;
+  loadOwnedAgentRooms: () => Promise<void>;
   switchActiveAgent: (agentId: string) => Promise<void>;
 }
 
@@ -150,6 +182,9 @@ const initialChatState = {
   publicHumansLoading: false,
   publicHumansLoaded: false,
   recentVisitedRooms: [],
+  ownedAgentRooms: [],
+  ownedAgentRoomsLoading: false,
+  ownedAgentRoomsLoaded: false,
 };
 
 function hasTransientChatState(state: DashboardChatState): boolean {
@@ -173,6 +208,7 @@ function hasTransientChatState(state: DashboardChatState): boolean {
     || state.leavingRoomId !== null
     || state.publicRoomsLoading
     || state.publicAgentsLoading
+    || state.ownedAgentRoomsLoading
   );
 }
 
@@ -257,7 +293,9 @@ export const useDashboardChatStore = create<DashboardChatState>()(
         const publicRoom = state.publicRooms.find((room) => room.room_id === roomId) || state.publicRoomDetails[roomId];
         if (publicRoom) return toRoomSummary(publicRoom);
         const recentRoom = state.recentVisitedRooms.find((room) => room.room_id === roomId);
-        return recentRoom ? toRoomSummary(recentRoom) : null;
+        if (recentRoom) return toRoomSummary(recentRoom);
+        const ownedAgentRoom = state.ownedAgentRooms.find((room) => room.room_id === roomId);
+        return ownedAgentRoom ? ownedAgentRoomToDashboardRoom(ownedAgentRoom) : null;
       },
 
       getVisibleMessageRooms: () =>
@@ -298,6 +336,9 @@ export const useDashboardChatStore = create<DashboardChatState>()(
           recentVisitedRooms: event.room_id
             ? state.recentVisitedRooms.map((room) => applyRealtimeRoomHint(room, event))
             : state.recentVisitedRooms,
+          ownedAgentRooms: event.room_id
+            ? state.ownedAgentRooms.map((room) => applyRealtimeRoomHint(room, event))
+            : state.ownedAgentRooms,
         })),
 
       replaceOverview: (overview) => {
@@ -588,6 +629,29 @@ export const useDashboardChatStore = create<DashboardChatState>()(
         } catch {
           if (requestId !== publicHumansRequestSeq) return;
           set({ publicHumansLoading: false, publicHumansLoaded: true });
+        }
+      },
+
+      loadOwnedAgentRooms: async () => {
+        const { token, activeIdentity } = useDashboardSessionStore.getState();
+        if (!token || activeIdentity?.type !== "human") {
+          set({ ownedAgentRooms: [], ownedAgentRoomsLoading: false, ownedAgentRoomsLoaded: true });
+          return;
+        }
+        set({ ownedAgentRoomsLoading: true });
+        try {
+          const result = await humansApi.listAgentRooms();
+          set({
+            ownedAgentRooms: result.rooms,
+            ownedAgentRoomsLoading: false,
+            ownedAgentRoomsLoaded: true,
+          });
+        } catch (error) {
+          set({
+            ownedAgentRoomsLoading: false,
+            ownedAgentRoomsLoaded: true,
+          });
+          get().setError(error instanceof Error ? error.message : "Failed to load bot rooms");
         }
       },
 


### PR DESCRIPTION
## Summary
- add a Human BFF endpoint for rooms where owned Agents are members but the current Human is not a member or owner
- load those rooms in Human mode and render them in a collapsible Messages sidebar section
- show which owned Bots are present in each bot-only room

## Tests
- UV_CACHE_DIR=/tmp/botcord-uv-cache uv run pytest tests/test_app/test_app_humans.py -q
- npx tsc --noEmit (fails on existing missing modules/legacy test imports: remark-breaks, tests/api route imports, require-agent/wallet imports)