### PR TITLE
feat(profile): edit agent and human profile from dashboard

### DIFF
--- a/backend/app/routers/humans.py
+++ b/backend/app/routers/humans.py
@@ -70,6 +70,11 @@ class HumanInfo(BaseModel):
     email: str | None
 
 
+class PatchHumanBody(BaseModel):
+    display_name: str | None = Field(default=None, min_length=1, max_length=128)
+    avatar_url: str | None = Field(default=None, max_length=2048)
+
+
 class HumanRoomSummary(BaseModel):
     room_id: str
     name: str
@@ -370,6 +375,35 @@ async def get_human(
 ):
     user = await _load_human(db, ctx)
     await db.commit()
+    return HumanInfo(
+        human_id=user.human_id,
+        display_name=user.display_name,
+        avatar_url=user.avatar_url,
+        email=user.email,
+    )
+
+
+@router.patch("/me", response_model=HumanInfo)
+async def patch_human(
+    body: PatchHumanBody,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Update the authed user's Human profile (display_name, avatar_url)."""
+    user = await _load_human(db, ctx)
+
+    if body.display_name is not None:
+        name = body.display_name.strip()
+        if not name:
+            raise HTTPException(status_code=400, detail="display_name must not be empty")
+        user.display_name = name
+
+    if body.avatar_url is not None:
+        url = body.avatar_url.strip()
+        user.avatar_url = url or None
+
+    await db.commit()
+    await db.refresh(user)
     return HumanInfo(
         human_id=user.human_id,
         display_name=user.display_name,

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -14,7 +14,7 @@ import logging
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import case, func as sa_func, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -55,6 +55,8 @@ router = APIRouter(prefix="/api/users", tags=["app-users"])
 
 class PatchAgentBody(BaseModel):
     is_default: bool | None = None
+    display_name: str | None = Field(default=None, min_length=1, max_length=128)
+    bio: str | None = Field(default=None, max_length=4000)
 
 
 class ClaimResolveBody(BaseModel):
@@ -100,6 +102,7 @@ def _agent_meta(agent: Agent) -> dict:
     return {
         "agent_id": agent.agent_id,
         "display_name": agent.display_name,
+        "bio": agent.bio,
         "is_default": agent.is_default,
         "claimed_at": agent.claimed_at.isoformat() if agent.claimed_at else None,
     }
@@ -552,6 +555,7 @@ async def get_me(
             {
                 "agent_id": a.agent_id,
                 "display_name": a.display_name,
+                "bio": a.bio,
                 "is_default": a.is_default,
                 "claimed_at": a.claimed_at.isoformat() if a.claimed_at else None,
                 "ws_online": is_agent_ws_online(a.agent_id),
@@ -669,7 +673,7 @@ async def patch_agent(
     ctx: RequestContext = Depends(require_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Update agent attributes (currently only is_default)."""
+    """Update agent attributes (is_default, display_name, bio)."""
     result = await db.execute(
         select(Agent).where(Agent.agent_id == agent_id, Agent.user_id == ctx.user_id)
     )
@@ -685,6 +689,17 @@ async def patch_agent(
             .values(is_default=False)
         )
         agent.is_default = True
+
+    if body.display_name is not None:
+        name = body.display_name.strip()
+        if not name:
+            raise HTTPException(status_code=400, detail="display_name must not be empty")
+        agent.display_name = name
+
+    if body.bio is not None:
+        # Normalise empty string to NULL so it reads as "no bio" downstream.
+        bio = body.bio.strip()
+        agent.bio = bio or None
 
     await db.commit()
     await db.refresh(agent)

--- a/frontend/src/components/dashboard/AccountMenu.tsx
+++ b/frontend/src/components/dashboard/AccountMenu.tsx
@@ -10,7 +10,8 @@
 import { useState } from "react";
 import type { UserAgent, UserProfile } from "@/lib/types";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
-import { Bot, Check, LogOut, Plus, Settings } from "lucide-react";
+import { Bot, Check, LogOut, Pencil, Plus, Settings } from "lucide-react";
+import HumanProfileEditModal from "./HumanProfileEditModal";
 import { useLanguage } from "@/lib/i18n";
 import { accountMenu } from "@/lib/i18n/translations/dashboard";
 import { common } from "@/lib/i18n/translations/common";
@@ -47,6 +48,7 @@ export default function AccountMenu({
   onLogout,
 }: AccountMenuProps) {
   const [open, setOpen] = useState(false);
+  const [editProfileOpen, setEditProfileOpen] = useState(false);
   const locale = useLanguage();
   const t = accountMenu[locale];
   const tc = common[locale];
@@ -205,6 +207,19 @@ export default function AccountMenu({
               </DropdownMenu.Group>
             ) : null}
 
+            {human && (
+              <>
+                <DropdownMenu.Separator className="my-1 h-px bg-glass-border" />
+                <DropdownMenu.Item
+                  onClick={() => setEditProfileOpen(true)}
+                  className="relative flex cursor-pointer select-none items-center rounded-md px-2 py-1.5 text-sm outline-none transition-colors text-text-primary focus:bg-neon-purple/10"
+                >
+                  <Pencil className="mr-2 h-4 w-4 text-neon-purple" />
+                  <span>{locale === "zh" ? "编辑个人资料" : "Edit profile"}</span>
+                </DropdownMenu.Item>
+              </>
+            )}
+
             {user?.beta_admin && (
               <>
                 <DropdownMenu.Separator className="my-1 h-px bg-glass-border" />
@@ -230,6 +245,10 @@ export default function AccountMenu({
           </DropdownMenu.Content>
         </DropdownMenu.Portal>
       </DropdownMenu.Root>
+
+      {editProfileOpen && (
+        <HumanProfileEditModal onClose={() => setEditProfileOpen(false)} />
+      )}
     </>
   );
 }

--- a/frontend/src/components/dashboard/AgentProfileEditModal.tsx
+++ b/frontend/src/components/dashboard/AgentProfileEditModal.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Loader2, Settings, X } from "lucide-react";
+import { userApi } from "@/lib/api";
+import { useLanguage } from "@/lib/i18n";
+import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
+
+interface AgentProfileEditModalProps {
+  agentId: string;
+  initialDisplayName: string;
+  initialBio?: string | null;
+  onClose: () => void;
+  onSaved?: () => void;
+}
+
+export default function AgentProfileEditModal({
+  agentId,
+  initialDisplayName,
+  initialBio,
+  onClose,
+  onSaved,
+}: AgentProfileEditModalProps) {
+  const locale = useLanguage();
+  const refreshUserProfile = useDashboardSessionStore((s) => s.refreshUserProfile);
+
+  const [displayName, setDisplayName] = useState(initialDisplayName);
+  const [bio, setBio] = useState(initialBio ?? "");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setDisplayName(initialDisplayName);
+    setBio(initialBio ?? "");
+  }, [initialDisplayName, initialBio]);
+
+  const trimmedName = displayName.trim();
+  const nameChanged = trimmedName !== initialDisplayName.trim();
+  const bioChanged = (bio ?? "").trim() !== (initialBio ?? "").trim();
+  const canSave = !saving && trimmedName.length > 0 && (nameChanged || bioChanged);
+
+  async function handleSave() {
+    if (!canSave) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const patch: { display_name?: string; bio?: string | null } = {};
+      if (nameChanged) patch.display_name = trimmedName;
+      if (bioChanged) patch.bio = bio.trim() || null;
+      await userApi.updateAgent(agentId, patch);
+      await refreshUserProfile();
+      onSaved?.();
+      onClose();
+    } catch (err: any) {
+      setError(err?.message || (locale === "zh" ? "保存失败" : "Failed to save"));
+      setSaving(false);
+    }
+  }
+
+  const tTitle = locale === "zh" ? "编辑 Bot 资料" : "Edit Bot Profile";
+  const tDesc = locale === "zh" ? "更新该 Bot 的显示名称与简介。" : "Update this bot's display name and bio.";
+  const tNameLabel = locale === "zh" ? "显示名称" : "Display name";
+  const tBioLabel = locale === "zh" ? "简介" : "Bio";
+  const tBioPlaceholder = locale === "zh" ? "介绍这个 Bot（可选）" : "Introduce this bot (optional)";
+  const tCancel = locale === "zh" ? "取消" : "Cancel";
+  const tSave = locale === "zh" ? "保存" : "Save";
+  const tSaving = locale === "zh" ? "保存中..." : "Saving...";
+
+  return (
+    <div className="fixed inset-0 z-[110] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm">
+      <div className="relative w-full max-w-md rounded-2xl border border-glass-border bg-deep-black-light p-5 shadow-2xl">
+        <button
+          onClick={onClose}
+          disabled={saving}
+          className="absolute right-4 top-4 rounded-full p-1.5 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+        >
+          <X className="h-5 w-5" />
+        </button>
+
+        <div className="mb-5 pr-8">
+          <h3 className="flex items-center gap-2 text-xl font-bold text-text-primary">
+            <Settings className="h-5 w-5 text-neon-cyan" />
+            {tTitle}
+          </h3>
+          <p className="mt-2 text-sm text-text-secondary">{tDesc}</p>
+          <p className="mt-1 font-mono text-[10px] text-text-secondary/60">{agentId}</p>
+        </div>
+
+        <label className="mb-3 block">
+          <span className="mb-1 block text-xs font-medium text-text-secondary">{tNameLabel}</span>
+          <input
+            type="text"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            disabled={saving}
+            maxLength={128}
+            className="w-full rounded-lg border border-glass-border bg-glass-bg px-3 py-2 text-sm text-text-primary outline-none transition-colors focus:border-neon-cyan/50 disabled:opacity-60"
+          />
+        </label>
+
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-text-secondary">{tBioLabel}</span>
+          <textarea
+            value={bio}
+            onChange={(e) => setBio(e.target.value)}
+            disabled={saving}
+            rows={4}
+            maxLength={4000}
+            placeholder={tBioPlaceholder}
+            className="w-full resize-none rounded-lg border border-glass-border bg-glass-bg px-3 py-2 text-sm text-text-primary outline-none transition-colors focus:border-neon-cyan/50 disabled:opacity-60"
+          />
+        </label>
+
+        {error && (
+          <p className="mt-3 rounded-lg border border-red-400/20 bg-red-400/10 p-2 text-xs text-red-400">
+            {error}
+          </p>
+        )}
+
+        <div className="mt-6 flex items-center justify-end gap-3">
+          <button
+            onClick={onClose}
+            disabled={saving}
+            className="rounded-xl border border-glass-border px-4 py-2.5 text-sm font-medium text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+          >
+            {tCancel}
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={!canSave}
+            className="flex items-center gap-2 rounded-xl border border-neon-cyan/40 bg-neon-cyan/10 px-4 py-2.5 text-sm font-bold text-neon-cyan transition-all hover:bg-neon-cyan/20 disabled:opacity-60"
+          >
+            {saving ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                {tSaving}
+              </>
+            ) : (
+              tSave
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/HumanProfileEditModal.tsx
+++ b/frontend/src/components/dashboard/HumanProfileEditModal.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Loader2, UserRound, X } from "lucide-react";
+import { humansApi } from "@/lib/api";
+import { useLanguage } from "@/lib/i18n";
+import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
+
+interface HumanProfileEditModalProps {
+  onClose: () => void;
+}
+
+export default function HumanProfileEditModal({ onClose }: HumanProfileEditModalProps) {
+  const locale = useLanguage();
+  const human = useDashboardSessionStore((s) => s.human);
+  const setHuman = useDashboardSessionStore((s) => s.setHuman);
+
+  const [displayName, setDisplayName] = useState(human?.display_name ?? "");
+  const [avatarUrl, setAvatarUrl] = useState(human?.avatar_url ?? "");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setDisplayName(human?.display_name ?? "");
+    setAvatarUrl(human?.avatar_url ?? "");
+  }, [human]);
+
+  const trimmedName = displayName.trim();
+  const trimmedAvatar = avatarUrl.trim();
+  const nameChanged = trimmedName !== (human?.display_name ?? "").trim();
+  const avatarChanged = trimmedAvatar !== (human?.avatar_url ?? "").trim();
+  const canSave = !saving && trimmedName.length > 0 && (nameChanged || avatarChanged);
+
+  async function handleSave() {
+    if (!canSave) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const patch: { display_name?: string; avatar_url?: string | null } = {};
+      if (nameChanged) patch.display_name = trimmedName;
+      if (avatarChanged) patch.avatar_url = trimmedAvatar || null;
+      const updated = await humansApi.updateProfile(patch);
+      setHuman(updated);
+      onClose();
+    } catch (err: any) {
+      setError(err?.message || (locale === "zh" ? "保存失败" : "Failed to save"));
+      setSaving(false);
+    }
+  }
+
+  const tTitle = locale === "zh" ? "编辑个人资料" : "Edit Profile";
+  const tDesc = locale === "zh" ? "更新你的显示名称和头像。" : "Update your display name and avatar.";
+  const tNameLabel = locale === "zh" ? "显示名称" : "Display name";
+  const tAvatarLabel = locale === "zh" ? "头像链接" : "Avatar URL";
+  const tAvatarPlaceholder = locale === "zh" ? "https://... （可选）" : "https://... (optional)";
+  const tCancel = locale === "zh" ? "取消" : "Cancel";
+  const tSave = locale === "zh" ? "保存" : "Save";
+  const tSaving = locale === "zh" ? "保存中..." : "Saving...";
+
+  return (
+    <div className="fixed inset-0 z-[110] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm">
+      <div className="relative w-full max-w-md rounded-2xl border border-glass-border bg-deep-black-light p-5 shadow-2xl">
+        <button
+          onClick={onClose}
+          disabled={saving}
+          className="absolute right-4 top-4 rounded-full p-1.5 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+        >
+          <X className="h-5 w-5" />
+        </button>
+
+        <div className="mb-5 pr-8">
+          <h3 className="flex items-center gap-2 text-xl font-bold text-text-primary">
+            <UserRound className="h-5 w-5 text-neon-purple" />
+            {tTitle}
+          </h3>
+          <p className="mt-2 text-sm text-text-secondary">{tDesc}</p>
+          {human && (
+            <p className="mt-1 font-mono text-[10px] text-text-secondary/60">{human.human_id}</p>
+          )}
+        </div>
+
+        <label className="mb-3 block">
+          <span className="mb-1 block text-xs font-medium text-text-secondary">{tNameLabel}</span>
+          <input
+            type="text"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            disabled={saving}
+            maxLength={128}
+            className="w-full rounded-lg border border-glass-border bg-glass-bg px-3 py-2 text-sm text-text-primary outline-none transition-colors focus:border-neon-purple/50 disabled:opacity-60"
+          />
+        </label>
+
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-text-secondary">{tAvatarLabel}</span>
+          <input
+            type="url"
+            value={avatarUrl}
+            onChange={(e) => setAvatarUrl(e.target.value)}
+            disabled={saving}
+            maxLength={2048}
+            placeholder={tAvatarPlaceholder}
+            className="w-full rounded-lg border border-glass-border bg-glass-bg px-3 py-2 text-sm text-text-primary outline-none transition-colors focus:border-neon-purple/50 disabled:opacity-60"
+          />
+        </label>
+
+        {trimmedAvatar && (
+          <div className="mt-3 flex items-center gap-2 rounded-lg border border-glass-border bg-glass-bg p-2">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={trimmedAvatar}
+              alt="Avatar preview"
+              className="h-10 w-10 rounded-full border border-white/10 object-cover"
+              onError={(e) => {
+                (e.currentTarget as HTMLImageElement).style.display = "none";
+              }}
+            />
+            <span className="truncate text-[11px] text-text-secondary">{trimmedAvatar}</span>
+          </div>
+        )}
+
+        {error && (
+          <p className="mt-3 rounded-lg border border-red-400/20 bg-red-400/10 p-2 text-xs text-red-400">
+            {error}
+          </p>
+        )}
+
+        <div className="mt-6 flex items-center justify-end gap-3">
+          <button
+            onClick={onClose}
+            disabled={saving}
+            className="rounded-xl border border-glass-border px-4 py-2.5 text-sm font-medium text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+          >
+            {tCancel}
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={!canSave}
+            className="flex items-center gap-2 rounded-xl border border-neon-purple/40 bg-neon-purple/10 px-4 py-2.5 text-sm font-bold text-neon-purple transition-all hover:bg-neon-purple/20 disabled:opacity-60"
+          >
+            {saving ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                {tSaving}
+              </>
+            ) : (
+              tSave
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import { Loader2, MessageSquare, AlertCircle, RotateCcw, Bell, FileText } from "lucide-react";
+import { Loader2, MessageSquare, AlertCircle, RotateCcw, Bell, FileText, Settings } from "lucide-react";
 import { api } from "@/lib/api";
 import type { Attachment, OwnerChatMessage } from "@/lib/types";
 import type { WsAttachment } from "@/lib/owner-chat-ws";
@@ -23,6 +23,7 @@ import MarkdownContent from "@/components/ui/MarkdownContent";
 import StreamBlocksView from "./StreamBlocksView";
 import CopyableId from "@/components/ui/CopyableId";
 import MessageComposer from "./MessageComposer";
+import AgentProfileEditModal from "./AgentProfileEditModal";
 
 const HUB_BASE_URL =
   process.env.NEXT_PUBLIC_HUB_BASE_URL ||
@@ -65,9 +66,14 @@ function TypewriterText({
 
 export default function UserChatPane({ agentId }: { agentId?: string | null }) {
   const { activeAgentId, activeIdentity } = useDashboardSessionStore();
+  const ownedAgents = useDashboardSessionStore((s) => s.ownedAgents);
   const isAgentMode = activeIdentity?.type === "agent" && !!activeAgentId;
   const chatAgentId = agentId || (isAgentMode ? activeAgentId : null);
   const { setUserChatRoomId } = useDashboardUIStore();
+  const [editOpen, setEditOpen] = useState(false);
+  const ownedAgent = chatAgentId
+    ? ownedAgents.find((a) => a.agent_id === chatAgentId) ?? null
+    : null;
 
   // Owner-chat store
   const messages = useOwnerChatStore((s) => s.messages);
@@ -296,10 +302,31 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
         <h2 className="text-sm font-medium text-zinc-200">
           {chatRoomName || "Chat with Agent"}
         </h2>
-        {wsConnected && (
-          <span className="ml-auto w-1.5 h-1.5 rounded-full bg-emerald-400" title="Live" />
-        )}
+        <div className="ml-auto flex items-center gap-2">
+          {wsConnected && (
+            <span className="w-1.5 h-1.5 rounded-full bg-emerald-400" title="Live" />
+          )}
+          {ownedAgent && (
+            <button
+              type="button"
+              onClick={() => setEditOpen(true)}
+              title="Edit bot profile"
+              className="rounded-md border border-transparent p-1 text-text-secondary transition-colors hover:border-glass-border hover:text-neon-cyan"
+            >
+              <Settings className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
       </div>
+
+      {editOpen && ownedAgent && (
+        <AgentProfileEditModal
+          agentId={ownedAgent.agent_id}
+          initialDisplayName={ownedAgent.display_name}
+          initialBio={ownedAgent.bio ?? null}
+          onClose={() => setEditOpen(false)}
+        />
+      )}
 
       {/* Messages */}
       <div ref={scrollContainerRef} onScroll={handleScroll} className="flex-1 overflow-y-auto px-4 py-3 space-y-3">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -734,6 +734,27 @@ const userApi = {
     return apiGet<{ agent_id: string; agent_token: string | null }>(`/api/users/me/agents/${agentId}/identity`);
   },
 
+  async updateAgent(
+    agentId: string,
+    patch: { display_name?: string; bio?: string | null; is_default?: boolean },
+  ): Promise<{
+    agent_id: string;
+    display_name: string;
+    bio: string | null;
+    is_default: boolean;
+    claimed_at: string | null;
+  }> {
+    const result = await apiPatch<{
+      agent_id: string;
+      display_name: string;
+      bio: string | null;
+      is_default: boolean;
+      claimed_at: string | null;
+    }>(`/api/users/me/agents/${agentId}`, patch);
+    invalidateMeCache();
+    return result;
+  },
+
   async unbindAgent(agentId: string): Promise<{ ok: boolean }> {
     const result = await apiDelete<{ ok: boolean }>(`/api/users/me/agents/${agentId}`);
     invalidateMeCache();
@@ -829,6 +850,12 @@ const humansApi = {
 
   getMe(): Promise<HumanInfo> {
     return apiGet<HumanInfo>("/api/humans/me");
+  },
+
+  async updateProfile(
+    patch: { display_name?: string; avatar_url?: string | null },
+  ): Promise<HumanInfo> {
+    return apiPatch<HumanInfo>("/api/humans/me", patch);
   },
 
   listRooms(): Promise<HumanRoomListResponse> {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -776,6 +776,7 @@ export interface UserProfile {
 export interface UserAgent {
   agent_id: string;
   display_name: string;
+  bio?: string | null;
   is_default: boolean;
   claimed_at: string;
   ws_online: boolean;

--- a/frontend/src/store/useDashboardSessionStore.ts
+++ b/frontend/src/store/useDashboardSessionStore.ts
@@ -47,6 +47,7 @@ interface DashboardSessionState {
    */
   activeIdentity: ActiveIdentity | null;
 
+  setHuman: (human: HumanInfo) => void;
   setAuthResolved: (resolved: boolean) => void;
   setToken: (token: string | null) => void;
   setUser: (user: UserProfile) => void;
@@ -134,6 +135,12 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
       user,
       ownedAgents: user.agents,
       sessionMode: resolveSessionMode(state.token, state.activeAgentId),
+    })),
+
+  setHuman: (human) =>
+    set((state) => ({
+      human,
+      user: state.user ? { ...state.user, display_name: human.display_name, avatar_url: human.avatar_url } : state.user,
     })),
 
   setActiveAgentId: (agentId) =>


### PR DESCRIPTION
## Summary
- Extend `PATCH /api/users/me/agents/{id}` to accept `display_name` / `bio` (was previously only `is_default`); include `bio` in `_agent_meta` and `/me` responses.
- Add `PATCH /api/humans/me` for the authed user's own `display_name` / `avatar_url`.
- Frontend: add `userApi.updateAgent` and `humansApi.updateProfile` wrappers; new `AgentProfileEditModal` (opened from a settings icon in the owner-chat header for owned bots) and `HumanProfileEditModal` (opened from an "Edit profile" entry in AccountMenu).

## Test plan
- [ ] Open a bot from **My Bots**, click the gear icon in the chat header, edit display name + bio, save, and verify the sidebar refreshes with the new name.
- [ ] Open the account dropdown, click **Edit profile**, update display name / avatar URL, save, and verify the avatar/name in the dropdown and sidebar update immediately.
- [ ] Backend: `PATCH /api/users/me/agents/{id}` with empty `display_name` returns 400; `bio: ""` clears the bio (stored as NULL).
- [ ] Backend: `PATCH /api/humans/me` with empty `avatar_url` clears the avatar.
- [ ] `pnpm build` / `tsc --noEmit` clean for source (pre-existing `tests/api/*` errors referring to removed routes are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)