### PR TITLE
feat(frontend): add system message notice UI

### DIFF
--- a/frontend/src/components/dashboard/MessageBubble.tsx
+++ b/frontend/src/components/dashboard/MessageBubble.tsx
@@ -8,6 +8,7 @@ import { messageBubble } from '@/lib/i18n/translations/dashboard';
 import AttachmentItem from "@/components/ui/AttachmentItem";
 import CopyableId from "@/components/ui/CopyableId";
 import MarkdownContent from "@/components/ui/MarkdownContent";
+import SystemMessageNotice from "@/components/ui/SystemMessageNotice";
 import TransferCard, { parseTransferText, parseTransferNotice } from "@/components/dashboard/TransferCard";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { PresenceDot } from "./PresenceDot";
@@ -105,6 +106,10 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
   const isOwn = typeof message.is_mine === "boolean" ? message.is_mine : isOwnProp;
   const isHuman = message.sender_kind === "human";
   const senderDisplayName = message.display_sender_name || message.sender_name || message.sender_id;
+
+  if (message.type === "system") {
+    return <SystemMessageNotice text={displayText || "System update"} timestamp={timestampLabel} />;
+  }
 
   const transferInfo = displayText
     ? parseTransferText(displayText) ?? parseTransferNotice(displayText, message.payload)

--- a/frontend/src/components/share/SharedMessageBubble.tsx
+++ b/frontend/src/components/share/SharedMessageBubble.tsx
@@ -3,6 +3,7 @@
 import type { SharedMessage, Attachment } from "@/lib/types";
 import AttachmentItem from "@/components/ui/AttachmentItem";
 import MarkdownContent from "@/components/ui/MarkdownContent";
+import SystemMessageNotice from "@/components/ui/SystemMessageNotice";
 import TransferCard, { parseTransferText, parseTransferNotice } from "@/components/dashboard/TransferCard";
 
 interface SharedMessageBubbleProps {
@@ -12,6 +13,11 @@ interface SharedMessageBubbleProps {
 export default function SharedMessageBubble({ message }: SharedMessageBubbleProps) {
   const textContent = message.payload?.text || message.payload?.body || message.payload?.message;
   const displayText = typeof textContent === "string" ? textContent : message.text;
+  const timestampLabel = new Date(message.created_at).toLocaleTimeString();
+
+  if (message.type === "system") {
+    return <SystemMessageNotice text={displayText || "System update"} timestamp={timestampLabel} />;
+  }
 
   const transferInfo = displayText
     ? parseTransferText(displayText) ?? parseTransferNotice(displayText, message.payload)

--- a/frontend/src/components/ui/SystemMessageNotice.tsx
+++ b/frontend/src/components/ui/SystemMessageNotice.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+interface SystemMessageNoticeProps {
+  text: string;
+  timestamp?: string;
+}
+
+export default function SystemMessageNotice({ text, timestamp }: SystemMessageNoticeProps) {
+  return (
+    <div className="my-3 flex justify-center px-3">
+      <div className="max-w-[82%] rounded-full border border-glass-border/60 bg-glass-bg/70 px-3 py-1.5 text-center text-xs leading-relaxed text-text-secondary shadow-sm">
+        <span className="break-words">{text || "System update"}</span>
+        {timestamp && (
+          <span className="ml-2 whitespace-nowrap font-mono text-[10px] text-text-secondary/45">
+            {timestamp}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -327,6 +327,7 @@ export type RealtimeMetaEventType =
   | "ack"
   | "result"
   | "error"
+  | "system"
   | "typing"
   | "presence";
 

--- a/frontend/src/store/useDashboardRealtimeStore.ts
+++ b/frontend/src/store/useDashboardRealtimeStore.ts
@@ -25,7 +25,7 @@ function isContactRealtimeEvent(type: RealtimeMetaEvent["type"]): boolean {
 }
 
 function isMessageRealtimeEvent(type: RealtimeMetaEvent["type"]): boolean {
-  return type === "message" || type === "ack" || type === "result" || type === "error";
+  return type === "message" || type === "ack" || type === "result" || type === "error" || type === "system";
 }
 
 function isTypingRealtimeEvent(type: RealtimeMetaEvent["type"]): boolean {


### PR DESCRIPTION
## Summary
- render system messages as centered notice rows instead of normal chat bubbles
- reuse the notice renderer in shared room snapshots
- include system in dashboard realtime message event handling

## Testing
- npm run build (compile/TypeScript stage passed; full build blocked by missing Supabase env during /admin/codes prerender)
- npx tsc --noEmit (blocked by existing tests/api module resolution and type errors)