### PR TITLE
fix(frontend): skip typewriter animation for historical owner-chat messages

### DIFF
--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -117,30 +117,35 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
     animatedRef.current.clear();
     useOwnerChatStore.getState().reset();
 
-    api.getUserChatRoom(chatAgentId)
-      .then((room) => {
+    (async () => {
+      try {
+        const room = await api.getUserChatRoom(chatAgentId);
         if (cancelled) return;
         setChatRoomName(room.name);
         setUserChatRoomId(room.room_id);
         useOwnerChatStore.getState().setRoom(room.room_id, room.name || chatAgentId);
-        return useOwnerChatStore.getState().loadInitial(room.room_id);
-      })
-      .catch((err) => {
+        await useOwnerChatStore.getState().loadInitial(room.room_id);
+        if (cancelled) return;
+        // Historical messages must not replay the typewriter animation. Populate
+        // animatedRef synchronously here so the first render that sees them
+        // already considers them animated.
+        for (const msg of useOwnerChatStore.getState().messages) {
+          animatedRef.current.add(msg.clientId);
+        }
+        initialLoadRef.current = false;
+      } catch (err: any) {
         if (cancelled) return;
         setInitError(err?.message || "Failed to initialize chat");
-      });
+      }
+    })();
 
     return () => { cancelled = true; };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chatAgentId]);
 
-  // ------ Mark initial load messages as already animated ------
+  // ------ Scroll to bottom once initial messages render ------
   useEffect(() => {
-    if (!loading && initialLoadRef.current && messages.length > 0) {
-      for (const msg of messages) {
-        animatedRef.current.add(msg.clientId);
-      }
-      initialLoadRef.current = false;
+    if (!loading && messages.length > 0 && prevLengthRef.current === 0) {
       requestAnimationFrame(() => {
         const el = scrollContainerRef.current;
         if (el) el.scrollTop = el.scrollHeight;
@@ -441,7 +446,7 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
                       animatedRef.current.add(msg.clientId);
                       streamedTraceIds.current.delete(msg.traceId!);
                     }
-                    const skipTypewriter = isUser || animatedRef.current.has(msg.clientId);
+                    const skipTypewriter = isUser || initialLoadRef.current || animatedRef.current.has(msg.clientId);
                     if (skipTypewriter) {
                       return <MarkdownContent content={msg.text || ""} />;
                     }


### PR DESCRIPTION
## Summary
- 进入或刷新 owner-chat 时，历史消息每次都会重新走打字机动画 — 修复这个不合理的行为
- 根因：`animatedRef` 在 useEffect 里异步标记，晚于首次渲染；首次渲染已经挂好 `TypewriterText`，之后 parent 重渲染也不会让它停下
- 改为在 `loadInitial()` await 完成后同步写入 `animatedRef` 并翻转 `initialLoadRef`；渲染处加 `initialLoadRef.current` 作为保险，async 初始化期间一律走 `MarkdownContent`

行为变化：
- 历史消息：静态渲染，不再打字机
- WS 新到的非流式消息：仍然走打字机
- 流式消息：仍走 `StreamBlocksView` + `finalizeStream`，不受影响

## Test plan
- [ ] 进入 owner-chat，历史消息应直接显示，没有打字机动画
- [ ] 刷新页面，历史消息仍直接显示
- [ ] 切换到另一个 agent 再切回来，历史消息直接显示
- [ ] 发送一条消息，对方 agent 通过非流式路径回复时仍有打字机效果
- [ ] 发送一条消息，对方 agent 通过 streaming 路径回复时正常显示 stream blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)