### PR TITLE
fix(frontend): preserve streamed assistant text on owner-chat finalize

### DIFF
--- a/frontend/src/store/useOwnerChatStore.ts
+++ b/frontend/src/store/useOwnerChatStore.ts
@@ -437,15 +437,29 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
 
       // Upgrade streaming placeholder to delivered
       const existing = state.messages[idx];
+      // Preserve the streamed assistant text if it is richer than the final
+      // `message` text (e.g. Codex streams long intermediate reasoning/answer
+      // segments but only sends a short summary via botcord_send).
+      const streamedText = extractAssistantText(existing.streamBlocks);
+      const finalText = finalData.text || "";
+      let mergedText: string;
+      if (streamedText.length > finalText.length) {
+        mergedText =
+          finalText && !streamedText.includes(finalText)
+            ? `${streamedText}\n\n${finalText}`
+            : streamedText;
+      } else {
+        mergedText = finalText;
+      }
       const finalizedMsg: OwnerChatMessage = {
         ...existing,
         hubMsgId: finalData.hubMsgId,
-        text: finalData.text,
+        text: mergedText,
         senderName: finalData.senderName,
         createdAt: finalData.createdAt,
         attachments: finalData.attachments,
         status: "delivered",
-        // Keep only execution blocks (strip assistant text — now in the final message text)
+        // Keep only execution blocks (assistant text now lives in `text`)
         streamBlocks: existing.streamBlocks.filter((b) => b.block.kind !== "assistant"),
       };
 


### PR DESCRIPTION
## Summary
- Fix owner-chat bubble collapsing to a tiny final message (e.g. `"Hi."`) after an agent streams a long assistant response.
- `finalizeStream` now keeps the longer of the accumulated streamed text vs. `finalData.text`, appending `finalText` as a suffix only when it isn't already contained.

## Why
Plugin's buffered block dispatcher posts every assistant chunk as a `stream_block` (`kind:"assistant"`) and also delivers each via `botcord_send`. For agents like Codex that interleave reasoning + tool calls + short final answers, the last hub `message.text` is much shorter than the already-streamed text. The previous code replaced the streaming placeholder's `text` with `finalData.text`, making the UI "lose" most of what the user just watched stream in.

Claude typically streams one full block equal to the final message, so its behavior is unchanged.

## Test plan
- [ ] Chat with a Codex owner-agent, send `hi` — confirm the streamed multi-block response remains visible after finalize instead of collapsing to the short final message.
- [ ] Chat with a Claude owner-agent — confirm normal single-block replies still render unchanged.
- [ ] Disconnect mid-stream — partial streamed text is still preserved (unchanged path in `onDisconnect`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)