### PR TITLE
fix(backend): serialize SQL datetime fields in agent-rooms previews

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -133,6 +133,7 @@ async def _build_rooms_from_sql(
         "room_created_at": "created_at",
     }
     _DROP_COLS = {"last_sender_id"}
+    _DATETIME_KEYS = {"created_at", "last_message_at"}
 
     sql_room_ids: set[str] = set()
 
@@ -149,6 +150,10 @@ async def _build_rooms_from_sql(
                 if k in _DROP_COLS:
                     continue
                 key = _SQL_TO_API.get(k, k)
+                if key in _DATETIME_KEYS and isinstance(v, datetime.datetime):
+                    if v.tzinfo is None:
+                        v = v.replace(tzinfo=datetime.timezone.utc)
+                    v = v.isoformat()
                 item[key] = v
             if "member_count" in item:
                 item["member_count"] = int(item["member_count"] or 0)


### PR DESCRIPTION
## Summary
- `/api/humans/me/agent-rooms` returned 500 on owner-chat refresh in preview/prod.
- Root cause: `_build_rooms_from_sql` PostgreSQL branch returned raw `datetime` for `created_at`/`last_message_at`, but `HumanAgentRoomSummary` declares them as `str | None`. Pydantic v2 rejected the values. SQLite/ORM fallback already isoformatted, which is why the test suite (#320) passed.
- Fix: isoformat datetime fields in the SQL branch so both code paths produce the same shape.

## Test plan
- [x] `uv run pytest tests/test_app/test_app_humans.py` passes
- [ ] After deploy, refresh owner-chat on preview and confirm 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)