### PR TITLE
fix(daemon): load project skills in headless Claude Code runs

### DIFF
--- a/packages/daemon/src/gateway/runtimes/claude-code.ts
+++ b/packages/daemon/src/gateway/runtimes/claude-code.ts
@@ -96,6 +96,12 @@ export class ClaudeCodeAdapter extends NdjsonStreamAdapter {
 
   protected buildArgs(opts: RuntimeRunOptions): string[] {
     const args = ["-p", opts.text, "--output-format", "stream-json", "--verbose"];
+    // Headless `-p` mode does not load project `.claude/` by default, so
+    // per-agent skills seeded at `<workspace>/.claude/skills/` are invisible
+    // unless we opt in. `extraArgs` wins so operators can still override.
+    if (!opts.extraArgs?.some((a) => a.startsWith("--setting-sources"))) {
+      args.push("--setting-sources", "project");
+    }
     if (opts.sessionId) {
       if (!isValidClaudeSessionId(opts.sessionId)) throw new Error(invalidClaudeSessionIdError());
       args.push("--resume", opts.sessionId);


### PR DESCRIPTION
## Summary
- Pass `--setting-sources project` in the daemon's `claude-code` adapter so skills seeded at `<agent-workspace>/.claude/skills/` are loaded by headless `claude -p`.
- Without this flag, Claude Code's `-p` mode skips project-level `.claude/` entirely, so the pre-installed `botcord` CLI skill never appears in the runtime's skill list.
- `extraArgs` still wins, so operators can override to `user,project,local` when needed.

## Test plan
- [x] `pnpm test` in `packages/daemon` — 431/431 passing
- [x] Manually ran `claude -p "..." --output-format stream-json --verbose --setting-sources project` with cwd set to a seeded agent workspace; `init` event's `skills` array now contains `botcord`, model invokes it correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)