### PR TITLE
fix(frontend): render daemon-gateway stream blocks (assistant_text/tool_use)

### DIFF
--- a/frontend/src/components/dashboard/StreamBlocksView.tsx
+++ b/frontend/src/components/dashboard/StreamBlocksView.tsx
@@ -41,30 +41,134 @@ function summarizeResult(result: string): string {
   return result.length > 120 ? result.slice(0, 120) + "..." : result;
 }
 
-function StreamBlockItem({ block }: { block: StreamBlockEntry }) {
-  const { kind, payload } = block.block;
-  const [resultExpanded, setResultExpanded] = useState(false);
-  const resultStr = kind === "tool_result" ? String(payload?.result ?? "") : "";
+/** Normalize a stream block into a displayable view-model, handling both the
+ *  legacy plugin shape (`payload`) and the daemon-gateway shape (`raw`). */
+interface BlockView {
+  kind: "tool_call" | "tool_result" | "reasoning" | "system" | "unknown";
+  toolName?: string;
+  paramHint?: string | null;
+  resultStr?: string;
+  reasoningText?: string;
+  rawKind: string;
+}
 
+function normalizeBlock(block: StreamBlockEntry["block"]): BlockView {
+  const { kind, payload, raw } = block;
+  const rawAny = raw as any;
+
+  // Legacy shape ------------------------------------------------------------
   if (kind === "tool_call") {
-    const name = (payload?.name as string) || "tool";
-    const params = payload?.params as Record<string, unknown> | undefined;
-    const paramHint = summarizeParams(params);
+    return {
+      kind: "tool_call",
+      toolName: (payload?.name as string) || "tool",
+      paramHint: summarizeParams(payload?.params as Record<string, unknown> | undefined),
+      rawKind: kind,
+    };
+  }
+  if (kind === "tool_result" && payload) {
+    return {
+      kind: "tool_result",
+      toolName: (payload.name as string) || "tool",
+      resultStr: String(payload.result ?? ""),
+      rawKind: kind,
+    };
+  }
+  if (kind === "reasoning") {
+    return {
+      kind: "reasoning",
+      reasoningText: (payload?.text as string) || "",
+      rawKind: kind,
+    };
+  }
+
+  // Daemon-gateway shape (Codex / Claude-code) ------------------------------
+  if (kind === "tool_use") {
+    // Claude-code: raw.message.content[*] where type === "tool_use"
+    const contents = rawAny?.message?.content;
+    if (Array.isArray(contents)) {
+      const tu = contents.find((c: any) => c?.type === "tool_use");
+      if (tu) {
+        return {
+          kind: "tool_call",
+          toolName: (tu.name as string) || "tool",
+          paramHint: summarizeParams((tu.input || tu.arguments) as Record<string, unknown> | undefined),
+          rawKind: kind,
+        };
+      }
+    }
+    // Codex: raw.item.type is the concrete tool kind
+    const item = rawAny?.item;
+    if (item) {
+      const name = (item.type as string) || "tool";
+      const hint =
+        typeof item.command === "string" ? item.command
+        : typeof item.path === "string" ? item.path
+        : typeof item.query === "string" ? item.query
+        : summarizeParams(item as Record<string, unknown>);
+      return {
+        kind: "tool_call",
+        toolName: name,
+        paramHint: typeof hint === "string" && hint.length > 60 ? hint.slice(0, 60) + "..." : hint ?? null,
+        rawKind: kind,
+      };
+    }
+    return { kind: "tool_call", toolName: "tool", rawKind: kind };
+  }
+
+  if (kind === "tool_result") {
+    // Claude-code: raw.message.content[*] where type === "tool_result"
+    const contents = rawAny?.message?.content;
+    if (Array.isArray(contents)) {
+      const tr = contents.find((c: any) => c?.type === "tool_result");
+      if (tr) {
+        const content = tr.content;
+        let resultStr = "";
+        if (typeof content === "string") resultStr = content;
+        else if (Array.isArray(content)) {
+          resultStr = content.map((c: any) => c?.text ?? "").filter(Boolean).join("\n");
+        }
+        return {
+          kind: "tool_result",
+          toolName: "tool",
+          resultStr,
+          rawKind: kind,
+        };
+      }
+    }
+    return { kind: "tool_result", toolName: "tool", resultStr: "", rawKind: kind };
+  }
+
+  if (kind === "system") {
+    // Codex thread.started / turn.started etc — usually noise; keep a terse label.
+    const type = rawAny?.type as string | undefined;
+    return { kind: "system", rawKind: type || "system" };
+  }
+
+  return { kind: "unknown", rawKind: kind };
+}
+
+function StreamBlockItem({ block }: { block: StreamBlockEntry }) {
+  const view = normalizeBlock(block.block);
+  const [resultExpanded, setResultExpanded] = useState(false);
+
+  if (view.kind === "tool_call") {
+    const name = view.toolName || "tool";
     return (
       <div className="flex items-start gap-2 py-1">
         <ToolCallIcon name={name} />
         <div className="min-w-0">
           <span className="text-xs font-mono text-cyan-400">{name}</span>
-          {paramHint && (
-            <p className="text-[10px] text-zinc-500 truncate mt-0.5">{paramHint}</p>
+          {view.paramHint && (
+            <p className="text-[10px] text-zinc-500 truncate mt-0.5">{view.paramHint}</p>
           )}
         </div>
       </div>
     );
   }
 
-  if (kind === "tool_result") {
-    const name = (payload?.name as string) || "tool";
+  if (view.kind === "tool_result") {
+    const name = view.toolName || "tool";
+    const resultStr = view.resultStr || "";
     return (
       <div className="py-1">
         <button
@@ -92,13 +196,12 @@ function StreamBlockItem({ block }: { block: StreamBlockEntry }) {
     );
   }
 
-  if (kind === "reasoning") {
-    const text = (payload?.text as string) || "";
+  if (view.kind === "reasoning") {
     return (
       <div className="flex items-start gap-2 py-1">
         <Brain className="w-3 h-3 text-purple-400 shrink-0 mt-0.5" />
         <p className="text-xs text-purple-300/70 italic leading-relaxed line-clamp-3">
-          {text}
+          {view.reasoningText || ""}
         </p>
       </div>
     );
@@ -107,7 +210,7 @@ function StreamBlockItem({ block }: { block: StreamBlockEntry }) {
   return (
     <div className="flex items-center gap-2 py-1">
       <HelpCircle className="w-3 h-3 text-zinc-500 shrink-0" />
-      <span className="text-xs text-zinc-500 font-mono">{kind}</span>
+      <span className="text-xs text-zinc-500 font-mono">{view.rawKind}</span>
     </div>
   );
 }
@@ -123,10 +226,13 @@ export default function StreamBlocksView({
 }) {
   const [expanded, setExpanded] = useState(defaultExpanded ?? false);
 
-  const executionBlocks = blocks.filter((b) => b.block.kind !== "assistant");
-  const assistantBlocks = blocks.filter((b) => b.block.kind === "assistant");
+  const isAssistant = (k: string) => k === "assistant" || k === "assistant_text";
+  const executionBlocks = blocks.filter((b) => !isAssistant(b.block.kind));
+  const assistantBlocks = blocks.filter((b) => isAssistant(b.block.kind));
 
-  const toolCallCount = executionBlocks.filter((b) => b.block.kind === "tool_call").length;
+  const toolCallCount = executionBlocks.filter(
+    (b) => b.block.kind === "tool_call" || b.block.kind === "tool_use",
+  ).length;
   const reasoningCount = executionBlocks.filter((b) => b.block.kind === "reasoning").length;
 
   useEffect(() => {
@@ -176,7 +282,22 @@ export default function StreamBlocksView({
             <MarkdownContent
               content={
                 assistantBlocks
-                  .map((b) => (b.block.payload?.text as string) || "")
+                  .map((b) => {
+                    if (b.block.kind === "assistant") {
+                      return (b.block.payload?.text as string) || "";
+                    }
+                    // assistant_text (daemon gateway)
+                    const raw = b.block.raw as any;
+                    if (typeof raw?.item?.text === "string") return raw.item.text;
+                    const contents = raw?.message?.content;
+                    if (Array.isArray(contents)) {
+                      return contents
+                        .filter((c: any) => c?.type === "text" && typeof c.text === "string")
+                        .map((c: any) => c.text as string)
+                        .join("");
+                    }
+                    return "";
+                  })
                   .join("")
               }
             />

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -177,7 +177,10 @@ export interface StreamBlockEntry {
   seq: number;
   block: {
     kind: string;
-    payload: Record<string, unknown>;
+    /** Legacy shape (plugin-driven): structured payload. */
+    payload?: Record<string, unknown>;
+    /** Current shape (daemon gateway): raw runtime event object. */
+    raw?: unknown;
   };
   created_at: string;
 }

--- a/frontend/src/store/useOwnerChatStore.ts
+++ b/frontend/src/store/useOwnerChatStore.ts
@@ -27,12 +27,37 @@ const MAX_BLOCKS_PER_TRACE = 200;
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Extract streamed assistant text from stream blocks. */
+/** Extract streamed assistant text from stream blocks.
+ *  Supports two shapes:
+ *   - legacy plugin: `{ kind: "assistant", payload: { text } }`
+ *   - daemon gateway: `{ kind: "assistant_text", raw: <runtime event> }` where
+ *     raw is either Codex's `item.completed` (`raw.item.text`) or Claude-code's
+ *     `assistant` event (`raw.message.content[*].text`). */
 function extractAssistantText(blocks: StreamBlockEntry[]): string {
-  return blocks
-    .filter((b) => b.block.kind === "assistant")
-    .map((b) => (b.block.payload?.text as string) || "")
-    .join("");
+  const parts: string[] = [];
+  for (const b of blocks) {
+    const kind = b.block.kind;
+    if (kind === "assistant") {
+      parts.push((b.block.payload?.text as string) || "");
+      continue;
+    }
+    if (kind === "assistant_text") {
+      const raw = b.block.raw as any;
+      // Codex: raw.item.text
+      if (typeof raw?.item?.text === "string") {
+        parts.push(raw.item.text);
+        continue;
+      }
+      // Claude-code: raw.message.content[*].text where type === "text"
+      const contents = raw?.message?.content;
+      if (Array.isArray(contents)) {
+        for (const c of contents) {
+          if (c?.type === "text" && typeof c.text === "string") parts.push(c.text);
+        }
+      }
+    }
+  }
+  return parts.join("");
 }
 
 /** In-flight guard + request token to prevent stale loadInitial responses. */
@@ -460,7 +485,7 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
         attachments: finalData.attachments,
         status: "delivered",
         // Keep only execution blocks (assistant text now lives in `text`)
-        streamBlocks: existing.streamBlocks.filter((b) => b.block.kind !== "assistant"),
+        streamBlocks: existing.streamBlocks.filter((b) => b.block.kind !== "assistant" && b.block.kind !== "assistant_text"),
       };
 
       const newMessages = [...state.messages];
@@ -500,7 +525,7 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
             text: partialText,
             status: "delivered" as const,
             // Keep streamBlocks for display (execution blocks, etc.)
-            streamBlocks: m.streamBlocks.filter((b) => b.block.kind !== "assistant"),
+            streamBlocks: m.streamBlocks.filter((b) => b.block.kind !== "assistant" && b.block.kind !== "assistant_text"),
           };
         }
         return m;


### PR DESCRIPTION
## Summary
Follow-up to #326. Owner-chat step list was still showing only kind labels (\`system\`, \`tool_use\`, \`assistant_text\`) with no content, and the streamed assistant bubble stayed empty before collapsing to the final short message.

## Root cause
The daemon gateway (\`packages/daemon/src/gateway/runtimes/{codex,claude-code}.ts\`) emits stream blocks shaped as \`{ raw, kind, seq }\` with kinds \`assistant_text | tool_use | tool_result | system | other\`, and the content lives on \`raw\` (e.g. \`raw.item.text\` for Codex, \`raw.message.content[*]\` for Claude-code).

The frontend \`StreamBlocksView\` was written for the **older plugin shape** (\`payload.*\` with kinds \`assistant | tool_call | tool_result | reasoning\`), so every Codex/Claude-code block fell into the \`HelpCircle\` fallback with just the kind name. \`extractAssistantText\` filtered on \`kind === \"assistant\"\`, so streamedText was always empty and the 'keep longer text' logic in #326 couldn't actually trigger for Codex.

## Changes
- \`frontend/src/lib/types.ts\`: \`block\` now accepts either \`payload\` (legacy) or \`raw\` (daemon gateway).
- \`frontend/src/components/dashboard/StreamBlocksView.tsx\`: added \`normalizeBlock()\` that maps both shapes into a single view-model; \`tool_use\` / \`tool_result\` / \`assistant_text\` / \`system\` now render with real tool names, param hints, and result content. The Composing... bubble reads text from both shapes.
- \`frontend/src/store/useOwnerChatStore.ts\`: \`extractAssistantText\` now reads from \`assistant_text.raw\` (Codex and Claude-code) plus legacy \`assistant.payload\`. \`finalizeStream\` / \`onDisconnect\` strip both \`assistant\` and \`assistant_text\` from the retained execution blocks.

## Test plan
- [ ] Chat with Codex owner-agent; expand the steps panel — each \`tool_use\` row shows the tool type and a param/command hint, \`assistant_text\` contributes to the streamed bubble.
- [ ] Chat with Claude-code owner-agent; \`tool_use\` shows tool name + input, \`tool_result\` is expandable with content.
- [ ] Legacy plugin-sourced agents (if any still on \`payload\` shape) still render tool_call / tool_result / reasoning / assistant correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)