### PR TITLE
feat(daemon): default owner trust to --permission-mode bypassPermissions

### DIFF
--- a/packages/daemon/src/gateway/__tests__/claude-code-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/claude-code-adapter.test.ts
@@ -211,7 +211,7 @@ process.stdout.write(JSON.stringify({type:"result", subtype:"success", session_i
 `,
       );
 
-    it("owner → --permission-mode acceptEdits", async () => {
+    it("owner → --permission-mode bypassPermissions", async () => {
       const adapter = new ClaudeCodeAdapter({ binary: echoScript() });
       const ctrl = new AbortController();
       const res = await adapter.run({
@@ -225,7 +225,7 @@ process.stdout.write(JSON.stringify({type:"result", subtype:"success", session_i
       const argv = JSON.parse(res.text) as string[];
       const modeIdx = argv.indexOf("--permission-mode");
       expect(modeIdx).toBeGreaterThanOrEqual(0);
-      expect(argv[modeIdx + 1]).toBe("acceptEdits");
+      expect(argv[modeIdx + 1]).toBe("bypassPermissions");
     });
 
     it("public → --permission-mode default", async () => {

--- a/packages/daemon/src/gateway/runtimes/claude-code.ts
+++ b/packages/daemon/src/gateway/runtimes/claude-code.ts
@@ -107,12 +107,18 @@ export class ClaudeCodeAdapter extends NdjsonStreamAdapter {
       args.push("--resume", opts.sessionId);
     }
     // Permission-mode policy:
-    //  - owner: acceptEdits (owner trusts their own agent).
-    //  - non-owner (trusted/public): default (let Claude Code prompt / reject edits per its own rules).
+    //  - owner: bypassPermissions (owner fully trusts their own agent; daemon
+    //    has no authorization-relay UI yet, so any other mode causes Bash /
+    //    WebFetch / MCP tool calls to deadlock waiting for a prompt that
+    //    never reaches the user — see issue #332 for the planned MCP-bridge
+    //    relay that will let us tighten this back up).
+    //  - non-owner (trusted/public): default (let Claude Code prompt / reject
+    //    per its own rules — we must NOT auto-bypass for agents the operator
+    //    doesn't own).
     // `extraArgs` still wins — operators who know what they're doing can override either.
     if (!opts.extraArgs?.some((a) => a.startsWith("--permission-mode"))) {
       if (opts.trustLevel === "owner") {
-        args.push("--permission-mode", "acceptEdits");
+        args.push("--permission-mode", "bypassPermissions");
       } else {
         args.push("--permission-mode", "default");
       }


### PR DESCRIPTION
## Summary

- Owner-trust agents previously got `acceptEdits`, which still gated `Bash` / `WebFetch` / MCP tool calls behind a permission prompt. The daemon's headless `claude -p` runtime has no way to surface that prompt, so every such call deadlocked — the agent ended up telling the user to "approve in the popup" that never appeared. The only workaround was hand-editing each route's `extraArgs`.
- This switches owner default to `bypassPermissions` so owned agents can actually use their tools end-to-end without operator intervention.
- Non-owner trust (`trusted` / `public`) stays on `default` — the daemon must not auto-approve tools for agents the operator doesn't own.
- `extraArgs` override still wins, so anyone needing tighter policy per-route can opt back in.

Issue #332 tracks the proper MCP-bridge authorization relay that will let us tighten this back up while surfacing real prompts to the dashboard.

## Test plan

- [x] `vitest run` (full daemon suite, 431 tests passing) — updated the one assertion that pinned `acceptEdits`; trusted / public / `extraArgs` override branches all stay green.
- [ ] Smoke: start daemon against a real owned agent, ask it to run a Bash-backed skill (e.g. `botcord room list`), verify it executes without an authorization prompt.
- [ ] Verify a non-owner agent (if available) still gets `--permission-mode default`.