### PR TITLE
feat: support renaming daemon instances from dashboard

### DIFF
--- a/backend/hub/routers/daemon_control.py
+++ b/backend/hub/routers/daemon_control.py
@@ -478,6 +478,34 @@ async def _load_owned_instance(
     return instance
 
 
+class _RenameInstanceRequest(BaseModel):
+    label: str | None = Field(default=None, max_length=64)
+
+
+@router.patch("/daemon/instances/{daemon_instance_id}", response_model=_InstanceView)
+async def rename_instance(
+    daemon_instance_id: str,
+    body: _RenameInstanceRequest,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+) -> _InstanceView:
+    instance = await _load_owned_instance(db, ctx.user_id, daemon_instance_id)
+    new_label = body.label.strip() if isinstance(body.label, str) else None
+    instance.label = new_label or None
+    await db.commit()
+    await db.refresh(instance)
+    return _InstanceView(
+        id=instance.id,
+        label=instance.label,
+        created_at=instance.created_at,
+        last_seen_at=instance.last_seen_at,
+        revoked_at=instance.revoked_at,
+        online=_REGISTRY.is_online(instance.id),
+        runtimes=instance.runtimes_json if instance.runtimes_json else None,
+        runtimes_probed_at=instance.runtimes_probed_at,
+    )
+
+
 @router.post("/daemon/instances/{daemon_instance_id}/revoke")
 async def revoke_instance(
     daemon_instance_id: str,

--- a/backend/tests/test_app/test_daemon_control.py
+++ b/backend/tests/test_app/test_daemon_control.py
@@ -301,6 +301,103 @@ async def test_list_instances(client: AsyncClient, seed_user):
 
 
 # ---------------------------------------------------------------------------
+# Rename (label update)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rename_instance_updates_label(client: AsyncClient, seed_user):
+    bundle = await _provision_instance_via_device_code(
+        client, seed_user, label="old"
+    )
+    instance_id = bundle["daemon_instance_id"]
+
+    r = await client.patch(
+        f"/daemon/instances/{instance_id}",
+        json={"label": "  My MacBook  "},
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["label"] == "My MacBook"
+
+    r = await client.get(
+        "/daemon/instances",
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert r.json()["instances"][0]["label"] == "My MacBook"
+
+
+@pytest.mark.asyncio
+async def test_rename_instance_clears_label(client: AsyncClient, seed_user):
+    bundle = await _provision_instance_via_device_code(
+        client, seed_user, label="old"
+    )
+    instance_id = bundle["daemon_instance_id"]
+
+    # Empty string normalizes to null.
+    r = await client.patch(
+        f"/daemon/instances/{instance_id}",
+        json={"label": "   "},
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["label"] is None
+
+    # Explicit null also clears.
+    r = await client.patch(
+        f"/daemon/instances/{instance_id}",
+        json={"label": None},
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert r.status_code == 200
+    assert r.json()["label"] is None
+
+
+@pytest.mark.asyncio
+async def test_rename_instance_rejects_oversized_label(
+    client: AsyncClient, seed_user
+):
+    bundle = await _provision_instance_via_device_code(client, seed_user)
+    instance_id = bundle["daemon_instance_id"]
+
+    r = await client.patch(
+        f"/daemon/instances/{instance_id}",
+        json={"label": "x" * 65},
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_rename_instance_owned_by_other_user_returns_404(
+    client: AsyncClient, seed_user, db_session: AsyncSession
+):
+    bundle = await _provision_instance_via_device_code(client, seed_user)
+    instance_id = bundle["daemon_instance_id"]
+
+    # Create a second, unrelated user and use their token.
+    other_supabase_uuid = uuid.uuid4()
+    other_user = User(
+        id=uuid.uuid4(),
+        display_name="Other",
+        email="other@example.com",
+        status="active",
+        supabase_user_id=other_supabase_uuid,
+        max_agents=10,
+    )
+    db_session.add(other_user)
+    await db_session.commit()
+    other_token = _make_supabase_token(str(other_supabase_uuid))
+
+    r = await client.patch(
+        f"/daemon/instances/{instance_id}",
+        json={"label": "stolen"},
+        headers={"Authorization": f"Bearer {other_token}"},
+    )
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
 # Dispatch (frame send) against a fake daemon connection
 # ---------------------------------------------------------------------------
 

--- a/frontend/src/app/api/daemon/_lib/proxy.ts
+++ b/frontend/src/app/api/daemon/_lib/proxy.ts
@@ -24,7 +24,7 @@ export async function getSupabaseAccessToken(): Promise<string | null> {
 
 export async function proxyDaemon(
   path: string,
-  init: { method: "GET" | "POST" | "DELETE"; body?: unknown },
+  init: { method: "GET" | "POST" | "DELETE" | "PATCH"; body?: unknown },
 ): Promise<NextResponse> {
   const token = await getSupabaseAccessToken();
   if (!token) {

--- a/frontend/src/app/api/daemon/instances/[id]/route.ts
+++ b/frontend/src/app/api/daemon/instances/[id]/route.ts
@@ -1,0 +1,29 @@
+/**
+ * [INPUT]: Supabase user session, daemon instance id from path, JSON body { label }
+ * [OUTPUT]: PATCH /api/daemon/instances/[id] — update daemon label
+ * [POS]: BFF endpoint for the per-row rename action on /settings/daemons
+ * [PROTOCOL]: update header on changes
+ */
+
+import { NextResponse } from "next/server";
+import { proxyDaemon } from "../../_lib/proxy";
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  if (!id) {
+    return NextResponse.json({ error: "missing_id" }, { status: 400 });
+  }
+  let body: unknown = {};
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  return proxyDaemon(`/daemon/instances/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    body,
+  });
+}

--- a/frontend/src/components/daemon/DaemonsSettingsPage.tsx
+++ b/frontend/src/components/daemon/DaemonsSettingsPage.tsx
@@ -11,9 +11,12 @@ import { Fragment, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import {
   AlertTriangle,
+  Check,
   Loader2,
+  Pencil,
   RefreshCcw,
   Server,
+  X,
   XCircle,
 } from "lucide-react";
 import {
@@ -192,21 +195,119 @@ function RuntimesBlock({
   );
 }
 
+function LabelCell({
+  daemon,
+  editing,
+  pending,
+  errorMsg,
+  onStartEdit,
+  onSubmit,
+  onCancel,
+}: {
+  daemon: DaemonInstance;
+  editing: boolean;
+  pending: boolean;
+  errorMsg: string | undefined;
+  onStartEdit: () => void;
+  onSubmit: (next: string) => void;
+  onCancel: () => void;
+}) {
+  const [draft, setDraft] = useState(daemon.label ?? "");
+
+  useEffect(() => {
+    if (editing) setDraft(daemon.label ?? "");
+  }, [editing, daemon.label]);
+
+  if (!editing) {
+    const canEdit = daemon.status !== "revoked";
+    return (
+      <div className="flex items-center gap-2">
+        <span className="text-text-primary">
+          {daemon.label || (
+            <span className="text-text-tertiary">unnamed</span>
+          )}
+        </span>
+        {canEdit && (
+          <button
+            type="button"
+            onClick={onStartEdit}
+            className="rounded p-1 text-text-tertiary transition-colors hover:bg-glass-bg hover:text-text-primary"
+            title="Rename"
+          >
+            <Pencil className="h-3 w-3" />
+          </button>
+        )}
+        {errorMsg ? (
+          <span className="text-[11px] text-red-300">{errorMsg}</span>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <input
+        type="text"
+        value={draft}
+        autoFocus
+        maxLength={64}
+        disabled={pending}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") onSubmit(draft);
+          if (e.key === "Escape") onCancel();
+        }}
+        placeholder="Label (optional)"
+        className="w-40 rounded-md border border-glass-border bg-deep-black-light px-2 py-1 text-sm text-text-primary outline-none focus:border-neon-cyan/50 disabled:opacity-50"
+      />
+      <button
+        type="button"
+        onClick={() => onSubmit(draft)}
+        disabled={pending}
+        className="rounded p-1 text-neon-green transition-colors hover:bg-glass-bg disabled:opacity-50"
+        title="Save"
+      >
+        {pending ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        ) : (
+          <Check className="h-3.5 w-3.5" />
+        )}
+      </button>
+      <button
+        type="button"
+        onClick={onCancel}
+        disabled={pending}
+        className="rounded p-1 text-text-tertiary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+        title="Cancel"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+      {errorMsg ? (
+        <span className="text-[11px] text-red-300">{errorMsg}</span>
+      ) : null}
+    </div>
+  );
+}
+
 export default function DaemonsSettingsPage() {
   const daemons = useDaemonStore((s) => s.daemons);
   const loading = useDaemonStore((s) => s.loading);
   const loaded = useDaemonStore((s) => s.loaded);
   const error = useDaemonStore((s) => s.error);
   const revokingId = useDaemonStore((s) => s.revokingId);
+  const renamingId = useDaemonStore((s) => s.renamingId);
+  const renameErrors = useDaemonStore((s) => s.renameErrors);
   const refreshingRuntimesId = useDaemonStore((s) => s.refreshingRuntimesId);
   const runtimeErrors = useDaemonStore((s) => s.runtimeErrors);
   const refresh = useDaemonStore((s) => s.refresh);
   const revoke = useDaemonStore((s) => s.revoke);
+  const rename = useDaemonStore((s) => s.rename);
   const refreshRuntimes = useDaemonStore((s) => s.refreshRuntimes);
 
   const [confirmTarget, setConfirmTarget] = useState<DaemonInstance | null>(
     null,
   );
+  const [editingId, setEditingId] = useState<string | null>(null);
 
   useEffect(() => {
     void refresh();
@@ -300,10 +401,19 @@ export default function DaemonsSettingsPage() {
                 sorted.map((d) => (
                   <Fragment key={d.id}>
                     <tr className="border-b border-glass-border/30">
-                      <td className="px-4 pt-3 text-text-primary">
-                        {d.label || (
-                          <span className="text-text-tertiary">unnamed</span>
-                        )}
+                      <td className="px-4 pt-3">
+                        <LabelCell
+                          daemon={d}
+                          editing={editingId === d.id}
+                          pending={renamingId === d.id}
+                          errorMsg={renameErrors[d.id]}
+                          onStartEdit={() => setEditingId(d.id)}
+                          onSubmit={async (next) => {
+                            const ok = await rename(d.id, next);
+                            if (ok) setEditingId(null);
+                          }}
+                          onCancel={() => setEditingId(null)}
+                        />
                       </td>
                       <td className="px-4 pt-3 font-mono text-xs text-text-secondary" title={d.id}>
                         {truncateId(d.id)}

--- a/frontend/src/store/useDaemonStore.ts
+++ b/frontend/src/store/useDaemonStore.ts
@@ -71,11 +71,14 @@ interface DaemonState {
   loaded: boolean;
   error: string | null;
   revokingId: string | null;
+  renamingId: string | null;
   refreshingRuntimesId: string | null;
   runtimeErrors: Record<string, string>;
+  renameErrors: Record<string, string>;
 
   refresh: () => Promise<void>;
   revoke: (id: string) => Promise<void>;
+  rename: (id: string, label: string | null) => Promise<boolean>;
   refreshRuntimes: (id: string) => Promise<void>;
   provisionAgent: (
     daemonId: string,
@@ -90,8 +93,10 @@ const initialState = {
   loaded: false,
   error: null as string | null,
   revokingId: null as string | null,
+  renamingId: null as string | null,
   refreshingRuntimesId: null as string | null,
   runtimeErrors: {} as Record<string, string>,
+  renameErrors: {} as Record<string, string>,
 };
 
 /**
@@ -233,6 +238,57 @@ export const useDaemonStore = create<DaemonState>()((set, get) => ({
         revokingId: null,
         error: err instanceof Error ? err.message : "Failed to revoke",
       });
+    }
+  },
+
+  rename: async (id: string, label: string | null) => {
+    const trimmed = label?.trim() || null;
+    if (trimmed && trimmed.length > 64) {
+      set((state) => ({
+        renameErrors: { ...state.renameErrors, [id]: "Label must be 64 chars or fewer" },
+      }));
+      return false;
+    }
+    set((state) => {
+      const next = { ...state.renameErrors };
+      delete next[id];
+      return { renamingId: id, renameErrors: next };
+    });
+    try {
+      const res = await fetch(`/api/daemon/instances/${encodeURIComponent(id)}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ label: trimmed }),
+      });
+      if (!res.ok) {
+        const msg = await parseError(res);
+        set((state) => ({
+          renamingId: null,
+          renameErrors: { ...state.renameErrors, [id]: msg },
+        }));
+        return false;
+      }
+      const data = (await res.json().catch(() => null)) as
+        | Record<string, unknown>
+        | null;
+      const newLabel =
+        data && typeof data.label === "string"
+          ? (data.label as string)
+          : trimmed;
+      set({
+        daemons: get().daemons.map((d) =>
+          d.id === id ? { ...d, label: newLabel } : d,
+        ),
+        renamingId: null,
+      });
+      return true;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to rename";
+      set((state) => ({
+        renamingId: null,
+        renameErrors: { ...state.renameErrors, [id]: msg },
+      }));
+      return false;
     }
   },
 


### PR DESCRIPTION
## Summary
- Adds `PATCH /daemon/instances/{id}` on the Hub control plane to update a daemon's `label` (display-only; identity, JWT claims, and control-plane routing are unaffected).
- Wires up an inline rename UI on `/settings/daemons` (pencil icon → input → save/cancel; Enter/Esc supported; revoked daemons not editable).
- Validates user ownership (`_load_owned_instance` → 404 on mismatch), trims input, treats empty as `null`, enforces ≤64 chars.

## Test plan
- [x] `uv run pytest backend/tests/test_app/test_daemon_control.py -k rename` — 4 new tests (happy path / clear / >64 chars 422 / cross-user 404) pass.
- [ ] Manual: rename, clear, attempt overflow, attempt rename of someone else's daemon (should 404), confirm UI does not allow editing revoked rows.
- [ ] `cd frontend && pnpm install && pnpm build` to verify the Next.js build (not run locally — this worktree has no `node_modules`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)