### PR TITLE
feat: add agent unbind lifecycle phase

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -13,9 +13,9 @@ import json
 import logging
 from uuid import UUID, uuid4
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from pydantic import BaseModel, Field
-from sqlalchemy import case, func as sa_func, select, update
+from sqlalchemy import delete, case, func as sa_func, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -27,9 +27,32 @@ from hub.routers.hub import is_agent_ws_online
 from hub.routers.daemon_control import is_daemon_online, send_control_frame
 from hub.crypto import verify_challenge_sig
 from hub.database import async_session as _default_session_factory, get_db
-from hub.models import Agent, DaemonInstance, Role, ShortCode, SigningKey, User, UserRole
+from hub.models import (
+    Agent,
+    AgentSubscription,
+    DaemonInstance,
+    Role,
+    ShortCode,
+    SigningKey,
+    SubscriptionChargeAttempt,
+    SubscriptionProduct,
+    TopupRequest,
+    User,
+    UserRole,
+    WalletAccount,
+    WalletTransaction,
+    WithdrawalRequest,
+)
 from hub.id_generators import generate_agent_id, generate_key_id
-from hub.enums import KeyState
+from hub.enums import (
+    KeyState,
+    SubscriptionChargeAttemptStatus,
+    SubscriptionProductStatus,
+    SubscriptionStatus,
+    TopupStatus,
+    TxStatus,
+    WithdrawalStatus,
+)
 from hub.schemas import ResetCredentialResponse
 from hub.services import wallet as wallet_svc
 from hub.services.wallet import get_or_create_wallet
@@ -182,6 +205,178 @@ async def _ensure_agent_owner_role(
     )
     if existing_ur.scalar_one_or_none() is None:
         db.add(UserRole(user_id=user_id, role_id=agent_owner_role.id))
+
+
+async def _maybe_remove_agent_owner_role(db: AsyncSession, user_id: UUID) -> None:
+    """Remove global agent_owner role only after the user owns no active agents."""
+    remaining_result = await db.execute(
+        select(sa_func.count())
+        .select_from(Agent)
+        .where(
+            Agent.user_id == user_id,
+            Agent.status == "active",
+        )
+    )
+    if (remaining_result.scalar_one() or 0) > 0:
+        return
+
+    role_result = await db.execute(select(Role).where(Role.name == "agent_owner"))
+    agent_owner_role = role_result.scalar_one_or_none()
+    if agent_owner_role is None:
+        return
+
+    await db.execute(
+        delete(UserRole).where(
+            UserRole.user_id == user_id,
+            UserRole.role_id == agent_owner_role.id,
+        )
+    )
+
+
+async def _ensure_agent_unbind_allowed(db: AsyncSession, agent_id: str) -> None:
+    wallet_result = await db.execute(
+        select(WalletAccount.id)
+        .where(
+            WalletAccount.owner_id == agent_id,
+            (WalletAccount.available_balance_minor != 0)
+            | (WalletAccount.locked_balance_minor != 0),
+        )
+        .limit(1)
+    )
+    if wallet_result.scalar_one_or_none() is not None:
+        raise HTTPException(status_code=409, detail="wallet_not_empty")
+
+    active_owner_products = (
+        select(SubscriptionProduct.product_id)
+        .where(
+            SubscriptionProduct.owner_agent_id == agent_id,
+            SubscriptionProduct.status == SubscriptionProductStatus.active,
+        )
+        .subquery()
+    )
+    subscriber_result = await db.execute(
+        select(AgentSubscription.id)
+        .where(
+            AgentSubscription.product_id.in_(select(active_owner_products.c.product_id)),
+            AgentSubscription.status == SubscriptionStatus.active,
+        )
+        .limit(1)
+    )
+    if subscriber_result.scalar_one_or_none() is not None:
+        raise HTTPException(status_code=409, detail="product_has_subscribers")
+
+    pending_tx_result = await db.execute(
+        select(WalletTransaction.id)
+        .where(
+            (
+                (WalletTransaction.from_owner_id == agent_id)
+                | (WalletTransaction.to_owner_id == agent_id)
+                | (WalletTransaction.initiator_owner_id == agent_id)
+            ),
+            WalletTransaction.status.in_([TxStatus.pending, TxStatus.processing]),
+        )
+        .limit(1)
+    )
+    if pending_tx_result.scalar_one_or_none() is not None:
+        raise HTTPException(status_code=409, detail="pending_obligations")
+
+    pending_topup_result = await db.execute(
+        select(TopupRequest.id)
+        .where(TopupRequest.owner_id == agent_id, TopupRequest.status == TopupStatus.pending)
+        .limit(1)
+    )
+    pending_withdrawal_result = await db.execute(
+        select(WithdrawalRequest.id)
+        .where(
+            WithdrawalRequest.owner_id == agent_id,
+            WithdrawalRequest.status.in_([WithdrawalStatus.pending, WithdrawalStatus.approved]),
+        )
+        .limit(1)
+    )
+    pending_charge_result = await db.execute(
+        select(SubscriptionChargeAttempt.id)
+        .join(
+            AgentSubscription,
+            AgentSubscription.subscription_id == SubscriptionChargeAttempt.subscription_id,
+        )
+        .where(
+            (
+                (AgentSubscription.subscriber_agent_id == agent_id)
+                | (AgentSubscription.provider_agent_id == agent_id)
+            ),
+            SubscriptionChargeAttempt.status == SubscriptionChargeAttemptStatus.pending,
+        )
+        .limit(1)
+    )
+    if (
+        pending_topup_result.scalar_one_or_none() is not None
+        or pending_withdrawal_result.scalar_one_or_none() is not None
+        or pending_charge_result.scalar_one_or_none() is not None
+    ):
+        raise HTTPException(status_code=409, detail="pending_obligations")
+
+
+async def _cancel_agent_subscriptions(db: AsyncSession, agent_id: str, now: datetime.datetime) -> None:
+    result = await db.execute(
+        select(AgentSubscription).where(
+            AgentSubscription.subscriber_agent_id == agent_id,
+            AgentSubscription.status == SubscriptionStatus.active,
+        )
+    )
+    for subscription in result.scalars().all():
+        subscription.status = SubscriptionStatus.cancelled
+        subscription.cancelled_at = now
+        subscription.cancel_at_period_end = False
+
+
+async def _promote_next_default_agent(db: AsyncSession, user_id: UUID, agent_id: str) -> None:
+    next_result = await db.execute(
+        select(Agent)
+        .where(
+            Agent.user_id == user_id,
+            Agent.agent_id != agent_id,
+            Agent.status == "active",
+        )
+        .order_by(Agent.created_at)
+        .limit(1)
+    )
+    next_agent = next_result.scalar_one_or_none()
+    if next_agent is not None:
+        next_agent.is_default = True
+
+
+async def _unbind_agent_from_user(db: AsyncSession, agent_id: str, user_id: UUID) -> dict:
+    result = await db.execute(
+        select(Agent).where(
+            Agent.agent_id == agent_id,
+            Agent.user_id == user_id,
+            Agent.status == "active",
+        )
+    )
+    agent = result.scalar_one_or_none()
+    if agent is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+    await _ensure_agent_unbind_allowed(db, agent_id)
+
+    now = _utc_now()
+    was_default = agent.is_default
+
+    await _cancel_agent_subscriptions(db, agent_id, now)
+
+    agent.user_id = None
+    agent.claimed_at = None
+    agent.is_default = False
+    agent.agent_token = None
+    agent.token_expires_at = None
+    agent.claim_code = f"clm_{uuid4().hex}"
+
+    if was_default:
+        await _promote_next_default_agent(db, user_id, agent_id)
+
+    await _maybe_remove_agent_owner_role(db, user_id)
+    await db.flush()
+    return {"agent_id": agent_id, "unbound_at": now.isoformat()}
 
 
 async def _maybe_grant_claim_gift(
@@ -424,7 +619,9 @@ async def _bind_agent_to_user(
         raise HTTPException(status_code=404, detail="User not found")
 
     count_result = await db.execute(
-        select(sa_func.count()).select_from(Agent).where(Agent.user_id == user_id)
+        select(sa_func.count())
+        .select_from(Agent)
+        .where(Agent.user_id == user_id, Agent.status == "active")
     )
     current_count = count_result.scalar_one()
 
@@ -440,6 +637,8 @@ async def _bind_agent_to_user(
     # Find existing agent
     result = await db.execute(select(Agent).where(Agent.agent_id == agent_id))
     agent = result.scalar_one_or_none()
+    if agent is not None and agent.status != "active":
+        raise HTTPException(status_code=410, detail="agent_deleted")
 
     if agent is None:
         # Agent not in DB yet — try insert inside a savepoint; if a concurrent
@@ -467,7 +666,11 @@ async def _bind_agent_to_user(
             # Fall through to conditional update below
             upd_result = await db.execute(
                 update(Agent)
-                .where(Agent.agent_id == agent_id, Agent.user_id.is_(None))
+                .where(
+                    Agent.agent_id == agent_id,
+                    Agent.user_id.is_(None),
+                    Agent.status == "active",
+                )
                 .values(
                     user_id=user_id,
                     display_name=display_name,
@@ -486,7 +689,11 @@ async def _bind_agent_to_user(
         # Atomic conditional update: only bind if user_id is still NULL
         upd_result = await db.execute(
             update(Agent)
-            .where(Agent.agent_id == agent_id, Agent.user_id.is_(None))
+            .where(
+                Agent.agent_id == agent_id,
+                Agent.user_id.is_(None),
+                Agent.status == "active",
+            )
             .values(
                 user_id=user_id,
                 display_name=display_name,
@@ -537,7 +744,9 @@ async def get_me(
 
     # Load agents belonging to this user
     agent_result = await db.execute(
-        select(Agent).where(Agent.user_id == user.id).order_by(Agent.created_at)
+        select(Agent)
+        .where(Agent.user_id == user.id, Agent.status == "active")
+        .order_by(Agent.created_at)
     )
     agents = agent_result.scalars().all()
 
@@ -567,12 +776,16 @@ async def get_me(
 
 @router.get("/me/agents")
 async def get_my_agents(
+    include_deleted: bool = Query(default=False),
     ctx: RequestContext = Depends(require_user),
     db: AsyncSession = Depends(get_db),
 ):
     """Return list of agents belonging to the authenticated user."""
+    stmt = select(Agent).where(Agent.user_id == ctx.user_id)
+    if not include_deleted:
+        stmt = stmt.where(Agent.status == "active")
     agent_result = await db.execute(
-        select(Agent).where(Agent.user_id == ctx.user_id).order_by(Agent.created_at)
+        stmt.order_by(Agent.created_at)
     )
     agents = agent_result.scalars().all()
 
@@ -585,6 +798,8 @@ async def get_my_agents(
                 "message_policy": a.message_policy.value if a.message_policy else None,
                 "is_default": a.is_default,
                 "claimed_at": a.claimed_at.isoformat() if a.claimed_at else None,
+                "status": a.status,
+                "deleted_at": a.deleted_at.isoformat() if a.deleted_at else None,
                 "ws_online": is_agent_ws_online(a.agent_id),
             }
             for a in agents
@@ -605,7 +820,11 @@ async def get_agent_identity(
 ):
     """Return agent_id and agent_token for the specified agent owned by the user."""
     result = await db.execute(
-        select(Agent).where(Agent.agent_id == agent_id, Agent.user_id == ctx.user_id)
+        select(Agent).where(
+            Agent.agent_id == agent_id,
+            Agent.user_id == ctx.user_id,
+            Agent.status == "active",
+        )
     )
     agent = result.scalar_one_or_none()
     if agent is None:
@@ -618,47 +837,35 @@ async def get_agent_identity(
 
 
 # ---------------------------------------------------------------------------
-# DELETE /api/users/me/agents/{agent_id}
+# DELETE /api/users/me/agents/{agent_id}/binding
 # ---------------------------------------------------------------------------
+
+
+@router.delete("/me/agents/{agent_id}/binding")
+async def unbind_agent_binding(
+    agent_id: str,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Unbind an active agent from the current user."""
+    payload = await _unbind_agent_from_user(db, agent_id, ctx.user_id)
+    await db.commit()
+    return payload
 
 
 @router.delete("/me/agents/{agent_id}")
 async def delete_agent(
     agent_id: str,
+    response: Response,
     ctx: RequestContext = Depends(require_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Unbind an agent from the current user."""
-    result = await db.execute(
-        select(Agent).where(Agent.agent_id == agent_id, Agent.user_id == ctx.user_id)
-    )
-    agent = result.scalar_one_or_none()
-    if agent is None:
-        raise HTTPException(status_code=404, detail="Agent not found")
-
-    was_default = agent.is_default
-
-    # Unbind agent
-    agent.user_id = None
-    agent.claimed_at = None
-    agent.is_default = False
-    agent.agent_token = None
-    agent.token_expires_at = None
-
-    # If the deleted agent was default, promote the next agent by earliest created_at
-    if was_default:
-        next_result = await db.execute(
-            select(Agent)
-            .where(Agent.user_id == ctx.user_id, Agent.agent_id != agent_id)
-            .order_by(Agent.created_at)
-            .limit(1)
-        )
-        next_agent = next_result.scalar_one_or_none()
-        if next_agent is not None:
-            next_agent.is_default = True
-
+    """Deprecated alias for unbinding an agent from the current user."""
+    payload = await _unbind_agent_from_user(db, agent_id, ctx.user_id)
     await db.commit()
-    return {"ok": True}
+    response.headers["Deprecation"] = "true"
+    response.headers["Link"] = f'</api/users/me/agents/{agent_id}/binding>; rel="successor-version"'
+    return {"ok": True, "deprecated": True, **payload}
 
 
 # ---------------------------------------------------------------------------
@@ -675,7 +882,11 @@ async def patch_agent(
 ):
     """Update agent attributes (is_default, display_name, bio)."""
     result = await db.execute(
-        select(Agent).where(Agent.agent_id == agent_id, Agent.user_id == ctx.user_id)
+        select(Agent).where(
+            Agent.agent_id == agent_id,
+            Agent.user_id == ctx.user_id,
+            Agent.status == "active",
+        )
     )
     agent = result.scalar_one_or_none()
     if agent is None:
@@ -685,7 +896,11 @@ async def patch_agent(
         # Unset default on all other agents for this user
         await db.execute(
             update(Agent)
-            .where(Agent.user_id == ctx.user_id, Agent.agent_id != agent_id)
+            .where(
+                Agent.user_id == ctx.user_id,
+                Agent.agent_id != agent_id,
+                Agent.status == "active",
+            )
             .values(is_default=False)
         )
         agent.is_default = True
@@ -762,7 +977,11 @@ async def create_credential_reset_ticket(
 ):
     """Issue a one-time credential reset ticket for an owned agent."""
     result = await db.execute(
-        select(Agent).where(Agent.agent_id == agent_id, Agent.user_id == ctx.user_id)
+        select(Agent).where(
+            Agent.agent_id == agent_id,
+            Agent.user_id == ctx.user_id,
+            Agent.status == "active",
+        )
     )
     agent = result.scalar_one_or_none()
     if agent is None:
@@ -822,7 +1041,7 @@ async def claim_resolve(
 
     # Look up the agent
     result = await db.execute(
-        select(Agent).where(Agent.claim_code == claim_code)
+        select(Agent).where(Agent.claim_code == claim_code, Agent.status == "active")
     )
     agent = result.scalar_one_or_none()
     if agent is None:
@@ -836,7 +1055,9 @@ async def claim_resolve(
     user = user_result.scalar_one()
 
     count_result = await db.execute(
-        select(sa_func.count()).select_from(Agent).where(Agent.user_id == ctx.user_id)
+        select(sa_func.count())
+        .select_from(Agent)
+        .where(Agent.user_id == ctx.user_id, Agent.status == "active")
     )
     current_count = count_result.scalar_one()
 
@@ -1051,7 +1272,11 @@ async def reset_agent_credential(
         raise HTTPException(status_code=401, detail="Reset ticket has invalid uid")
 
     result = await db.execute(
-        select(Agent).where(Agent.agent_id == body.agent_id, Agent.user_id == user_id)
+        select(Agent).where(
+            Agent.agent_id == body.agent_id,
+            Agent.user_id == user_id,
+            Agent.status == "active",
+        )
     )
     agent = result.scalar_one_or_none()
     if agent is None:
@@ -1202,7 +1427,9 @@ async def provision_agent(
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
     count_result = await db.execute(
-        select(sa_func.count()).select_from(Agent).where(Agent.user_id == ctx.user_id)
+        select(sa_func.count())
+        .select_from(Agent)
+        .where(Agent.user_id == ctx.user_id, Agent.status == "active")
     )
     current_count = count_result.scalar_one()
     if current_count >= user.max_agents:
@@ -1238,6 +1465,8 @@ async def provision_agent(
         is_default=is_first,
         claimed_at=now,
         runtime=runtime,
+        daemon_instance_id=body.daemon_instance_id,
+        hosting_kind="daemon",
     )
     db.add(agent)
     db.add(

--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -63,6 +63,12 @@ class Base(DeclarativeBase):
 
 class Agent(Base):
     __tablename__ = "agents"
+    __table_args__ = (
+        CheckConstraint(
+            "hosting_kind IS NULL OR hosting_kind IN ('daemon', 'plugin', 'cli')",
+            name="ck_agents_hosting_kind",
+        ),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     agent_id: Mapped[str] = mapped_column(String(32), unique=True, nullable=False, index=True)
@@ -77,15 +83,21 @@ class Agent(Base):
     user_id: Mapped[_uuid.UUID | None] = mapped_column(Uuid, nullable=True, index=True)
     agent_token: Mapped[str | None] = mapped_column(Text, nullable=True)
     token_expires_at: Mapped[datetime.datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
-    claim_code: Mapped[str] = mapped_column(
+    claim_code: Mapped[str | None] = mapped_column(
         String(64),
-        nullable=False,
+        nullable=True,
         unique=True,
         index=True,
         default=lambda: f"clm_{_uuid.uuid4().hex}",
     )
     is_default: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
     claimed_at: Mapped[datetime.datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default="active", server_default="active")
+    deleted_at: Mapped[datetime.datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    daemon_instance_id: Mapped[str | None] = mapped_column(
+        String(32), ForeignKey("daemon_instances.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    hosting_kind: Mapped[str | None] = mapped_column(String(16), nullable=True)
     # Runtime selected at creation (claude-code / codex / gemini / ...).
     # Null for agents created via bind_code.
     runtime: Mapped[str | None] = mapped_column(String(32), nullable=True)
@@ -94,6 +106,14 @@ class Agent(Base):
     challenges: Mapped[list["Challenge"]] = relationship(back_populates="agent")
     used_nonces: Mapped[list["UsedNonce"]] = relationship(back_populates="agent")
     endpoints: Mapped[list["Endpoint"]] = relationship(back_populates="agent")
+
+    @property
+    def is_active(self) -> bool:
+        return self.status == "active"
+
+    @property
+    def is_deletable(self) -> bool:
+        return self.status == "active" and self.user_id is not None
 
 
 class SigningKey(Base):

--- a/backend/hub/validators.py
+++ b/backend/hub/validators.py
@@ -7,7 +7,6 @@ import re
 from urllib.parse import urlparse
 
 import httpx
-from fastapi import HTTPException
 
 from hub.config import (
     ALLOW_PRIVATE_ENDPOINTS,

--- a/backend/migrations/028_agent_lifecycle.sql
+++ b/backend/migrations/028_agent_lifecycle.sql
@@ -1,0 +1,49 @@
+-- Agent lifecycle columns for the Phase A unbind rollout.
+--
+-- This migration only introduces the lifecycle shape needed by the compatible
+-- /binding route. PR1 writes daemon_instance_id/hosting_kind from provision_agent
+-- so later delete/outbox work can route daemon revocation frames without another
+-- backfill. Hard delete behavior and deprovision_outbox are intentionally left
+-- to follow-up phases.
+
+ALTER TABLE agents
+  ADD COLUMN IF NOT EXISTS status VARCHAR(16) NOT NULL DEFAULT 'active';
+
+ALTER TABLE agents
+  ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+
+ALTER TABLE agents
+  ADD COLUMN IF NOT EXISTS daemon_instance_id VARCHAR(32)
+    REFERENCES daemon_instances(id) ON DELETE SET NULL;
+
+ALTER TABLE agents
+  ADD COLUMN IF NOT EXISTS hosting_kind VARCHAR(16);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'ck_agents_hosting_kind'
+  ) THEN
+    ALTER TABLE agents
+      ADD CONSTRAINT ck_agents_hosting_kind
+      CHECK (hosting_kind IS NULL OR hosting_kind IN ('daemon', 'plugin', 'cli'))
+      NOT VALID;
+  END IF;
+END $$;
+
+ALTER TABLE agents
+  ALTER COLUMN claim_code DROP NOT NULL;
+
+CREATE INDEX IF NOT EXISTS ix_agents_status_active
+  ON agents(status)
+  WHERE status = 'active';
+
+CREATE INDEX IF NOT EXISTS ix_agents_status_deleted
+  ON agents(status)
+  WHERE status = 'deleted';
+
+CREATE INDEX IF NOT EXISTS ix_agents_daemon_instance
+  ON agents(daemon_instance_id)
+  WHERE daemon_instance_id IS NOT NULL;

--- a/backend/tests/test_app/test_app_user_agents.py
+++ b/backend/tests/test_app/test_app_user_agents.py
@@ -17,8 +17,27 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from sqlalchemy.pool import StaticPool
 from unittest.mock import AsyncMock, patch
 
-from hub.enums import TxType
-from hub.models import Agent, Base, KeyState, MessagePolicy, Role, SigningKey, User, UserRole, WalletTransaction
+from hub.enums import (
+    BillingInterval,
+    SubscriptionProductStatus,
+    SubscriptionStatus,
+    TxStatus,
+    TxType,
+)
+from hub.models import (
+    Agent,
+    AgentSubscription,
+    Base,
+    KeyState,
+    MessagePolicy,
+    Role,
+    SigningKey,
+    SubscriptionProduct,
+    User,
+    UserRole,
+    WalletAccount,
+    WalletTransaction,
+)
 
 TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
 TEST_SUPABASE_SECRET = "test-supabase-jwt-secret-for-unit-tests"
@@ -134,6 +153,8 @@ async def seed_user(db_session: AsyncSession):
 
     user_role = UserRole(id=uuid.uuid4(), user_id=user_id, role_id=role.id)
     db_session.add(user_role)
+    owner_user_role = UserRole(id=uuid.uuid4(), user_id=user_id, role_id=agent_owner_role.id)
+    db_session.add(owner_user_role)
 
     now = datetime.datetime.now(datetime.timezone.utc)
 
@@ -173,21 +194,62 @@ async def seed_user(db_session: AsyncSession):
 
 
 # ---------------------------------------------------------------------------
-# DELETE /api/users/me/agents/{agent_id}
+# GET /api/users/me/agents
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_delete_agent(client: AsyncClient, seed_user: dict):
+async def test_get_my_agents_hides_deleted_by_default_and_can_include_them(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    seed_user: dict,
+):
+    deleted_at = datetime.datetime.now(datetime.timezone.utc)
+    seed_user["agent2"].status = "deleted"
+    seed_user["agent2"].deleted_at = deleted_at
+    await db_session.commit()
+
+    default_resp = await client.get(
+        "/api/users/me/agents",
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert default_resp.status_code == 200
+    default_agents = default_resp.json()["agents"]
+    assert [agent["agent_id"] for agent in default_agents] == ["ag_agent001"]
+
+    include_resp = await client.get(
+        "/api/users/me/agents?include_deleted=true",
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert include_resp.status_code == 200
+    agents_by_id = {
+        agent["agent_id"]: agent
+        for agent in include_resp.json()["agents"]
+    }
+    assert set(agents_by_id) == {"ag_agent001", "ag_agent002"}
+    assert agents_by_id["ag_agent002"]["status"] == "deleted"
+    assert agents_by_id["ag_agent002"]["deleted_at"] == deleted_at.isoformat()
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/users/me/agents/{agent_id}/binding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unbind_agent_binding(client: AsyncClient, db_session: AsyncSession, seed_user: dict):
     """Unbinding the default agent promotes the next one."""
     token = seed_user["token"]
+    original_claim_code = seed_user["agent1"].claim_code
 
     resp = await client.delete(
-        "/api/users/me/agents/ag_agent001",
+        "/api/users/me/agents/ag_agent001/binding",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 200
-    assert resp.json() == {"ok": True}
+    body = resp.json()
+    assert body["agent_id"] == "ag_agent001"
+    assert body["unbound_at"]
 
     # Verify agent2 became default
     agents_resp = await client.get(
@@ -198,16 +260,271 @@ async def test_delete_agent(client: AsyncClient, seed_user: dict):
     assert len(agents) == 1
     assert agents[0]["agent_id"] == "ag_agent002"
     assert agents[0]["is_default"] is True
+    assert agents[0]["status"] == "active"
+
+    agent_result = await db_session.execute(select(Agent).where(Agent.agent_id == "ag_agent001"))
+    agent = agent_result.scalar_one()
+    assert agent.user_id is None
+    assert agent.claimed_at is None
+    assert agent.is_default is False
+    assert agent.agent_token is None
+    assert agent.token_expires_at is None
+    assert agent.claim_code is not None
+    assert agent.claim_code != original_claim_code
+
+    role_result = await db_session.execute(
+        select(UserRole)
+        .where(
+            UserRole.user_id == seed_user["user_id"],
+            UserRole.role_id == seed_user["agent_owner_role"].id,
+        )
+    )
+    assert role_result.scalar_one_or_none() is not None
 
 
 @pytest.mark.asyncio
-async def test_delete_agent_not_found(client: AsyncClient, seed_user: dict):
+async def test_legacy_delete_route_is_deprecated_unbind(client: AsyncClient, seed_user: dict):
     token = seed_user["token"]
     resp = await client.delete(
-        "/api/users/me/agents/ag_nonexistent",
+        "/api/users/me/agents/ag_agent002",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.headers["deprecation"] == "true"
+    body = resp.json()
+    assert body["deprecated"] is True
+    assert body["ok"] is True
+    assert body["agent_id"] == "ag_agent002"
+    assert body["unbound_at"]
+
+
+@pytest.mark.asyncio
+async def test_unbind_agent_not_found(client: AsyncClient, seed_user: dict):
+    token = seed_user["token"]
+    resp = await client.delete(
+        "/api/users/me/agents/ag_nonexistent/binding",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_unbind_agent_second_time_404(client: AsyncClient, seed_user: dict):
+    token = seed_user["token"]
+    first = await client.delete(
+        "/api/users/me/agents/ag_agent002/binding",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert first.status_code == 200
+
+    second = await client.delete(
+        "/api/users/me/agents/ag_agent002/binding",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert second.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_unbind_agent_cross_user_404(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    seed_user: dict,
+):
+    other_supabase_uuid = uuid.uuid4()
+    other_user_id = uuid.uuid4()
+    db_session.add(
+        User(
+            id=other_user_id,
+            display_name="Other User",
+            status="active",
+            supabase_user_id=other_supabase_uuid,
+            max_agents=10,
+        )
+    )
+    await db_session.commit()
+
+    resp = await client.delete(
+        "/api/users/me/agents/ag_agent001/binding",
+        headers={"Authorization": f"Bearer {_make_supabase_token(str(other_supabase_uuid))}"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_unbind_last_agent_removes_agent_owner_role(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    seed_user: dict,
+):
+    seed_user["agent2"].user_id = None
+    seed_user["agent2"].claimed_at = None
+    await db_session.commit()
+
+    resp = await client.delete(
+        "/api/users/me/agents/ag_agent001/binding",
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert resp.status_code == 200
+
+    role_result = await db_session.execute(
+        select(UserRole)
+        .where(
+            UserRole.user_id == seed_user["user_id"],
+            UserRole.role_id == seed_user["agent_owner_role"].id,
+        )
+    )
+    assert role_result.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_unbind_agent_rejects_non_empty_wallet(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    seed_user: dict,
+):
+    db_session.add(
+        WalletAccount(
+            owner_id="ag_agent001",
+            asset_code="COIN",
+            available_balance_minor=1,
+            locked_balance_minor=0,
+        )
+    )
+    await db_session.commit()
+
+    resp = await client.delete(
+        "/api/users/me/agents/ag_agent001/binding",
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "wallet_not_empty"
+
+
+@pytest.mark.asyncio
+async def test_unbind_agent_rejects_product_with_active_subscribers(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    seed_user: dict,
+):
+    now = datetime.datetime.now(datetime.timezone.utc)
+    db_session.add(
+        SubscriptionProduct(
+            product_id="sp_test001",
+            owner_agent_id="ag_agent001",
+            name="Paid Room",
+            amount_minor=100,
+            billing_interval=BillingInterval.month,
+            status=SubscriptionProductStatus.active,
+        )
+    )
+    db_session.add(
+        AgentSubscription(
+            subscription_id="sub_test001",
+            product_id="sp_test001",
+            subscriber_agent_id="ag_agent002",
+            provider_agent_id="ag_agent001",
+            amount_minor=100,
+            billing_interval=BillingInterval.month,
+            status=SubscriptionStatus.active,
+            current_period_start=now,
+            current_period_end=now + datetime.timedelta(days=30),
+            next_charge_at=now + datetime.timedelta(days=30),
+        )
+    )
+    await db_session.commit()
+
+    resp = await client.delete(
+        "/api/users/me/agents/ag_agent001/binding",
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "product_has_subscribers"
+
+
+@pytest.mark.asyncio
+async def test_unbind_agent_cancels_subscriber_subscriptions(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    seed_user: dict,
+):
+    now = datetime.datetime.now(datetime.timezone.utc)
+    db_session.add(
+        Agent(
+            agent_id="ag_provider",
+            display_name="Provider",
+            message_policy=MessagePolicy.contacts_only,
+            is_default=False,
+            claimed_at=now,
+        )
+    )
+    db_session.add(
+        SubscriptionProduct(
+            product_id="sp_provider",
+            owner_agent_id="ag_provider",
+            name="Provider Plan",
+            amount_minor=100,
+            billing_interval=BillingInterval.month,
+            status=SubscriptionProductStatus.active,
+        )
+    )
+    db_session.add(
+        AgentSubscription(
+            subscription_id="sub_agent001",
+            product_id="sp_provider",
+            subscriber_agent_id="ag_agent001",
+            provider_agent_id="ag_provider",
+            amount_minor=100,
+            billing_interval=BillingInterval.month,
+            status=SubscriptionStatus.active,
+            current_period_start=now,
+            current_period_end=now + datetime.timedelta(days=30),
+            next_charge_at=now + datetime.timedelta(days=30),
+        )
+    )
+    await db_session.commit()
+
+    resp = await client.delete(
+        "/api/users/me/agents/ag_agent001/binding",
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert resp.status_code == 200
+
+    sub_result = await db_session.execute(
+        select(AgentSubscription).where(AgentSubscription.subscription_id == "sub_agent001")
+    )
+    subscription = sub_result.scalar_one()
+    assert subscription.status == SubscriptionStatus.cancelled
+    assert subscription.cancelled_at is not None
+
+
+@pytest.mark.asyncio
+async def test_unbind_agent_rejects_pending_payment(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    seed_user: dict,
+):
+    db_session.add(
+        WalletTransaction(
+            tx_id="tx_pending001",
+            type=TxType.transfer,
+            status=TxStatus.pending,
+            asset_code="COIN",
+            amount_minor=10,
+            fee_minor=0,
+            from_owner_id="ag_agent001",
+            to_owner_id="ag_agent002",
+            initiator_owner_id="ag_agent001",
+            idempotency_key="pending-unbind-test",
+        )
+    )
+    await db_session.commit()
+
+    resp = await client.delete(
+        "/api/users/me/agents/ag_agent001/binding",
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "pending_obligations"
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/db/schema/agents.ts
+++ b/frontend/db/schema/agents.ts
@@ -1,5 +1,5 @@
 import { sql } from "drizzle-orm";
-import { pgTable, serial, uuid, varchar, text, boolean, timestamp, index, uniqueIndex } from "drizzle-orm/pg-core";
+import { pgTable, serial, uuid, varchar, text, boolean, timestamp, index, uniqueIndex, check } from "drizzle-orm/pg-core";
 import { users } from "./users";
 
 export const agents = pgTable(
@@ -15,13 +15,18 @@ export const agents = pgTable(
     agentToken: text("agent_token"),
     tokenExpiresAt: timestamp("token_expires_at", { withTimezone: true }),
     claimCode: varchar("claim_code", { length: 64 })
-      .default(sql`('clm_' || replace(gen_random_uuid()::text, '-', ''))`)
-      .notNull(),
+      .default(sql`('clm_' || replace(gen_random_uuid()::text, '-', ''))`),
     isDefault: boolean("is_default").default(false).notNull(),
     claimedAt: timestamp("claimed_at", { withTimezone: true }),
+    status: varchar("status", { length: 16 }).default("active").notNull(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+    daemonInstanceId: varchar("daemon_instance_id", { length: 32 }),
+    hostingKind: varchar("hosting_kind", { length: 16 }),
   },
   (table) => [
     index("agents_user_id_idx").on(table.userId),
+    index("ix_agents_daemon_instance").on(table.daemonInstanceId),
     uniqueIndex("agents_claim_code_unique").on(table.claimCode).where(sql`"claim_code" IS NOT NULL`),
+    check("ck_agents_hosting_kind", sql`${table.hostingKind} IS NULL OR ${table.hostingKind} IN ('daemon', 'plugin', 'cli')`),
   ],
 );


### PR DESCRIPTION
## Summary
- add Phase A agent lifecycle schema fields and migration
- add explicit /api/users/me/agents/{agent_id}/binding unbind route while keeping legacy DELETE route as deprecated alias
- add unbind guards for wallet balances, active product subscribers, pending obligations, claim_code rotation, default promotion, and conditional agent_owner role cleanup
- update frontend Drizzle agents schema and expand user-agent endpoint tests

## Tests
- git diff --check
- env UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_app/test_app_user_agents.py -q
- env UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_app/test_app_subscriptions.py tests/test_wallet.py -q