### PR TITLE
feat(daemon): coalesce serial turns and gate replies to owner-chat

### DIFF
--- a/backend/hub/routers/daemon_control.py
+++ b/backend/hub/routers/daemon_control.py
@@ -478,6 +478,34 @@ async def _load_owned_instance(
     return instance
 
 
+class _RenameInstanceRequest(BaseModel):
+    label: str | None = Field(default=None, max_length=64)
+
+
+@router.patch("/daemon/instances/{daemon_instance_id}", response_model=_InstanceView)
+async def rename_instance(
+    daemon_instance_id: str,
+    body: _RenameInstanceRequest,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+) -> _InstanceView:
+    instance = await _load_owned_instance(db, ctx.user_id, daemon_instance_id)
+    new_label = body.label.strip() if isinstance(body.label, str) else None
+    instance.label = new_label or None
+    await db.commit()
+    await db.refresh(instance)
+    return _InstanceView(
+        id=instance.id,
+        label=instance.label,
+        created_at=instance.created_at,
+        last_seen_at=instance.last_seen_at,
+        revoked_at=instance.revoked_at,
+        online=_REGISTRY.is_online(instance.id),
+        runtimes=instance.runtimes_json if instance.runtimes_json else None,
+        runtimes_probed_at=instance.runtimes_probed_at,
+    )
+
+
 @router.post("/daemon/instances/{daemon_instance_id}/revoke")
 async def revoke_instance(
     daemon_instance_id: str,

--- a/backend/tests/test_app/test_daemon_control.py
+++ b/backend/tests/test_app/test_daemon_control.py
@@ -301,6 +301,103 @@ async def test_list_instances(client: AsyncClient, seed_user):
 
 
 # ---------------------------------------------------------------------------
+# Rename (label update)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rename_instance_updates_label(client: AsyncClient, seed_user):
+    bundle = await _provision_instance_via_device_code(
+        client, seed_user, label="old"
+    )
+    instance_id = bundle["daemon_instance_id"]
+
+    r = await client.patch(
+        f"/daemon/instances/{instance_id}",
+        json={"label": "  My MacBook  "},
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["label"] == "My MacBook"
+
+    r = await client.get(
+        "/daemon/instances",
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert r.json()["instances"][0]["label"] == "My MacBook"
+
+
+@pytest.mark.asyncio
+async def test_rename_instance_clears_label(client: AsyncClient, seed_user):
+    bundle = await _provision_instance_via_device_code(
+        client, seed_user, label="old"
+    )
+    instance_id = bundle["daemon_instance_id"]
+
+    # Empty string normalizes to null.
+    r = await client.patch(
+        f"/daemon/instances/{instance_id}",
+        json={"label": "   "},
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["label"] is None
+
+    # Explicit null also clears.
+    r = await client.patch(
+        f"/daemon/instances/{instance_id}",
+        json={"label": None},
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert r.status_code == 200
+    assert r.json()["label"] is None
+
+
+@pytest.mark.asyncio
+async def test_rename_instance_rejects_oversized_label(
+    client: AsyncClient, seed_user
+):
+    bundle = await _provision_instance_via_device_code(client, seed_user)
+    instance_id = bundle["daemon_instance_id"]
+
+    r = await client.patch(
+        f"/daemon/instances/{instance_id}",
+        json={"label": "x" * 65},
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_rename_instance_owned_by_other_user_returns_404(
+    client: AsyncClient, seed_user, db_session: AsyncSession
+):
+    bundle = await _provision_instance_via_device_code(client, seed_user)
+    instance_id = bundle["daemon_instance_id"]
+
+    # Create a second, unrelated user and use their token.
+    other_supabase_uuid = uuid.uuid4()
+    other_user = User(
+        id=uuid.uuid4(),
+        display_name="Other",
+        email="other@example.com",
+        status="active",
+        supabase_user_id=other_supabase_uuid,
+        max_agents=10,
+    )
+    db_session.add(other_user)
+    await db_session.commit()
+    other_token = _make_supabase_token(str(other_supabase_uuid))
+
+    r = await client.patch(
+        f"/daemon/instances/{instance_id}",
+        json={"label": "stolen"},
+        headers={"Authorization": f"Bearer {other_token}"},
+    )
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
 # Dispatch (frame send) against a fake daemon connection
 # ---------------------------------------------------------------------------
 

--- a/frontend/src/app/api/daemon/_lib/proxy.ts
+++ b/frontend/src/app/api/daemon/_lib/proxy.ts
@@ -24,7 +24,7 @@ export async function getSupabaseAccessToken(): Promise<string | null> {
 
 export async function proxyDaemon(
   path: string,
-  init: { method: "GET" | "POST" | "DELETE"; body?: unknown },
+  init: { method: "GET" | "POST" | "DELETE" | "PATCH"; body?: unknown },
 ): Promise<NextResponse> {
   const token = await getSupabaseAccessToken();
   if (!token) {

--- a/frontend/src/app/api/daemon/instances/[id]/route.ts
+++ b/frontend/src/app/api/daemon/instances/[id]/route.ts
@@ -1,0 +1,29 @@
+/**
+ * [INPUT]: Supabase user session, daemon instance id from path, JSON body { label }
+ * [OUTPUT]: PATCH /api/daemon/instances/[id] — update daemon label
+ * [POS]: BFF endpoint for the per-row rename action on /settings/daemons
+ * [PROTOCOL]: update header on changes
+ */
+
+import { NextResponse } from "next/server";
+import { proxyDaemon } from "../../_lib/proxy";
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  if (!id) {
+    return NextResponse.json({ error: "missing_id" }, { status: 400 });
+  }
+  let body: unknown = {};
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  return proxyDaemon(`/daemon/instances/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    body,
+  });
+}

--- a/frontend/src/components/daemon/DaemonsSettingsPage.tsx
+++ b/frontend/src/components/daemon/DaemonsSettingsPage.tsx
@@ -11,9 +11,12 @@ import { Fragment, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import {
   AlertTriangle,
+  Check,
   Loader2,
+  Pencil,
   RefreshCcw,
   Server,
+  X,
   XCircle,
 } from "lucide-react";
 import {
@@ -192,21 +195,119 @@ function RuntimesBlock({
   );
 }
 
+function LabelCell({
+  daemon,
+  editing,
+  pending,
+  errorMsg,
+  onStartEdit,
+  onSubmit,
+  onCancel,
+}: {
+  daemon: DaemonInstance;
+  editing: boolean;
+  pending: boolean;
+  errorMsg: string | undefined;
+  onStartEdit: () => void;
+  onSubmit: (next: string) => void;
+  onCancel: () => void;
+}) {
+  const [draft, setDraft] = useState(daemon.label ?? "");
+
+  useEffect(() => {
+    if (editing) setDraft(daemon.label ?? "");
+  }, [editing, daemon.label]);
+
+  if (!editing) {
+    const canEdit = daemon.status !== "revoked";
+    return (
+      <div className="flex items-center gap-2">
+        <span className="text-text-primary">
+          {daemon.label || (
+            <span className="text-text-tertiary">unnamed</span>
+          )}
+        </span>
+        {canEdit && (
+          <button
+            type="button"
+            onClick={onStartEdit}
+            className="rounded p-1 text-text-tertiary transition-colors hover:bg-glass-bg hover:text-text-primary"
+            title="Rename"
+          >
+            <Pencil className="h-3 w-3" />
+          </button>
+        )}
+        {errorMsg ? (
+          <span className="text-[11px] text-red-300">{errorMsg}</span>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <input
+        type="text"
+        value={draft}
+        autoFocus
+        maxLength={64}
+        disabled={pending}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") onSubmit(draft);
+          if (e.key === "Escape") onCancel();
+        }}
+        placeholder="Label (optional)"
+        className="w-40 rounded-md border border-glass-border bg-deep-black-light px-2 py-1 text-sm text-text-primary outline-none focus:border-neon-cyan/50 disabled:opacity-50"
+      />
+      <button
+        type="button"
+        onClick={() => onSubmit(draft)}
+        disabled={pending}
+        className="rounded p-1 text-neon-green transition-colors hover:bg-glass-bg disabled:opacity-50"
+        title="Save"
+      >
+        {pending ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        ) : (
+          <Check className="h-3.5 w-3.5" />
+        )}
+      </button>
+      <button
+        type="button"
+        onClick={onCancel}
+        disabled={pending}
+        className="rounded p-1 text-text-tertiary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+        title="Cancel"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+      {errorMsg ? (
+        <span className="text-[11px] text-red-300">{errorMsg}</span>
+      ) : null}
+    </div>
+  );
+}
+
 export default function DaemonsSettingsPage() {
   const daemons = useDaemonStore((s) => s.daemons);
   const loading = useDaemonStore((s) => s.loading);
   const loaded = useDaemonStore((s) => s.loaded);
   const error = useDaemonStore((s) => s.error);
   const revokingId = useDaemonStore((s) => s.revokingId);
+  const renamingId = useDaemonStore((s) => s.renamingId);
+  const renameErrors = useDaemonStore((s) => s.renameErrors);
   const refreshingRuntimesId = useDaemonStore((s) => s.refreshingRuntimesId);
   const runtimeErrors = useDaemonStore((s) => s.runtimeErrors);
   const refresh = useDaemonStore((s) => s.refresh);
   const revoke = useDaemonStore((s) => s.revoke);
+  const rename = useDaemonStore((s) => s.rename);
   const refreshRuntimes = useDaemonStore((s) => s.refreshRuntimes);
 
   const [confirmTarget, setConfirmTarget] = useState<DaemonInstance | null>(
     null,
   );
+  const [editingId, setEditingId] = useState<string | null>(null);
 
   useEffect(() => {
     void refresh();
@@ -300,10 +401,19 @@ export default function DaemonsSettingsPage() {
                 sorted.map((d) => (
                   <Fragment key={d.id}>
                     <tr className="border-b border-glass-border/30">
-                      <td className="px-4 pt-3 text-text-primary">
-                        {d.label || (
-                          <span className="text-text-tertiary">unnamed</span>
-                        )}
+                      <td className="px-4 pt-3">
+                        <LabelCell
+                          daemon={d}
+                          editing={editingId === d.id}
+                          pending={renamingId === d.id}
+                          errorMsg={renameErrors[d.id]}
+                          onStartEdit={() => setEditingId(d.id)}
+                          onSubmit={async (next) => {
+                            const ok = await rename(d.id, next);
+                            if (ok) setEditingId(null);
+                          }}
+                          onCancel={() => setEditingId(null)}
+                        />
                       </td>
                       <td className="px-4 pt-3 font-mono text-xs text-text-secondary" title={d.id}>
                         {truncateId(d.id)}

--- a/frontend/src/store/useDaemonStore.ts
+++ b/frontend/src/store/useDaemonStore.ts
@@ -71,11 +71,14 @@ interface DaemonState {
   loaded: boolean;
   error: string | null;
   revokingId: string | null;
+  renamingId: string | null;
   refreshingRuntimesId: string | null;
   runtimeErrors: Record<string, string>;
+  renameErrors: Record<string, string>;
 
   refresh: () => Promise<void>;
   revoke: (id: string) => Promise<void>;
+  rename: (id: string, label: string | null) => Promise<boolean>;
   refreshRuntimes: (id: string) => Promise<void>;
   provisionAgent: (
     daemonId: string,
@@ -90,8 +93,10 @@ const initialState = {
   loaded: false,
   error: null as string | null,
   revokingId: null as string | null,
+  renamingId: null as string | null,
   refreshingRuntimesId: null as string | null,
   runtimeErrors: {} as Record<string, string>,
+  renameErrors: {} as Record<string, string>,
 };
 
 /**
@@ -233,6 +238,57 @@ export const useDaemonStore = create<DaemonState>()((set, get) => ({
         revokingId: null,
         error: err instanceof Error ? err.message : "Failed to revoke",
       });
+    }
+  },
+
+  rename: async (id: string, label: string | null) => {
+    const trimmed = label?.trim() || null;
+    if (trimmed && trimmed.length > 64) {
+      set((state) => ({
+        renameErrors: { ...state.renameErrors, [id]: "Label must be 64 chars or fewer" },
+      }));
+      return false;
+    }
+    set((state) => {
+      const next = { ...state.renameErrors };
+      delete next[id];
+      return { renamingId: id, renameErrors: next };
+    });
+    try {
+      const res = await fetch(`/api/daemon/instances/${encodeURIComponent(id)}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ label: trimmed }),
+      });
+      if (!res.ok) {
+        const msg = await parseError(res);
+        set((state) => ({
+          renamingId: null,
+          renameErrors: { ...state.renameErrors, [id]: msg },
+        }));
+        return false;
+      }
+      const data = (await res.json().catch(() => null)) as
+        | Record<string, unknown>
+        | null;
+      const newLabel =
+        data && typeof data.label === "string"
+          ? (data.label as string)
+          : trimmed;
+      set({
+        daemons: get().daemons.map((d) =>
+          d.id === id ? { ...d, label: newLabel } : d,
+        ),
+        renamingId: null,
+      });
+      return true;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to rename";
+      set((state) => ({
+        renamingId: null,
+        renameErrors: { ...state.renameErrors, [id]: msg },
+      }));
+      return false;
     }
   },
 

--- a/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
+++ b/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
@@ -459,16 +459,19 @@ describe("Dispatcher", () => {
     });
     const { dispatcher, channel } = await scaffold({ config, runtimeFactory });
 
+    // Use an `rm_oc_` room so the dispatcher's reply gating does not drop
+    // the runtime text — non-owner-chat rooms intentionally suppress
+    // result.text since the agent is expected to use `botcord_send`.
     const p1 = dispatcher.handle(
       makeEnvelope({
         id: "m1",
-        conversation: { id: "rm_g1", kind: "group" },
+        conversation: { id: "rm_oc_g1", kind: "group" },
       }),
     );
     const p2 = dispatcher.handle(
       makeEnvelope({
         id: "m2",
-        conversation: { id: "rm_g1", kind: "group" },
+        conversation: { id: "rm_oc_g1", kind: "group" },
       }),
     );
     await Promise.all([p1, p2]);
@@ -1195,5 +1198,375 @@ describe("Dispatcher", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Owner-chat reply gating
+  // ─────────────────────────────────────────────────────────────────────
+
+  it("non-owner-chat room: discards result.text, agent must use botcord_send", async () => {
+    const runtime = new FakeRuntime({ reply: "would-be-reply", newSessionId: "sid-1" });
+    const { dispatcher, channel, store } = await scaffold({
+      runtimeFactory: () => runtime,
+    });
+
+    await dispatcher.handle(
+      makeEnvelope({
+        id: "msg_1",
+        conversation: { id: "rm_g_other", kind: "group" },
+      }),
+    );
+
+    expect(runtime.calls.length).toBe(1);
+    // Session is still persisted — only the channel send is gated.
+    expect(store.all().length).toBe(1);
+    expect(channel.sends.length).toBe(0);
+  });
+
+  it("non-owner-chat room: timeout reply is suppressed (logged only)", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtime = new FakeRuntime({ hang: true });
+      const { dispatcher, channel } = await scaffold({
+        runtimeFactory: () => runtime,
+        turnTimeoutMs: 500,
+      });
+      const p = dispatcher.handle(
+        makeEnvelope({
+          id: "m_to",
+          conversation: { id: "rm_g_other", kind: "group" },
+        }),
+      );
+      await vi.advanceTimersByTimeAsync(501);
+      await p;
+      expect(runtime.calls[0].signal.aborted).toBe(true);
+      expect(channel.sends.length).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("non-owner-chat room: runtime error reply is suppressed", async () => {
+    const runtime = new FakeRuntime({ throwError: "boom" });
+    const { dispatcher, channel } = await scaffold({
+      runtimeFactory: () => runtime,
+    });
+    await dispatcher.handle(
+      makeEnvelope({
+        id: "m_err",
+        conversation: { id: "rm_g_other", kind: "group" },
+      }),
+    );
+    expect(channel.sends.length).toBe(0);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Serial coalesce-on-drain
+  // ─────────────────────────────────────────────────────────────────────
+
+  it("serial coalesce: messages arriving during a slow turn fold into ONE next turn", async () => {
+    let callNo = 0;
+    const runtimeFactory: RuntimeFactory = () => {
+      callNo += 1;
+      const tag = `r${callNo}`;
+      return new FakeRuntime({
+        id: "claude-code",
+        reply: tag,
+        delayMs: 30,
+        newSessionId: `sid-${callNo}`,
+      });
+    };
+    // Capture composer input so we can inspect what each turn was asked to render.
+    const composeCalls: Array<{ id: string; batchSize: number }> = [];
+    const { store, dir } = await makeStore();
+    tempDirs.push(dir);
+    const channel = new FakeChannel();
+    const dispatcher = new Dispatcher({
+      config: baseConfig({
+        defaultRoute: { runtime: "claude-code", cwd: "/tmp/d", queueMode: "serial" },
+      }),
+      channels: new Map<string, ChannelAdapter>([[channel.id, channel]]),
+      runtime: runtimeFactory,
+      sessionStore: store,
+      log: silentLogger(),
+      composeUserTurn: (msg) => {
+        const raw = msg.raw as { batch?: unknown[] } | null | undefined;
+        const batch = Array.isArray(raw?.batch) ? raw!.batch : null;
+        composeCalls.push({ id: msg.id, batchSize: batch ? batch.length : 1 });
+        return msg.text ?? "";
+      },
+    });
+
+    // m1 arrives → triggers immediate turn.
+    const p1 = dispatcher.handle(
+      makeEnvelope({
+        id: "m1",
+        text: "hello",
+        raw: { hub_msg_id: "m1", text: "hello" },
+        conversation: { id: "rm_grp_x", kind: "group" },
+      }),
+    );
+    // Let the worker start runtime.run for m1.
+    await Promise.resolve();
+    await Promise.resolve();
+    // m2 + m3 arrive while m1 is in flight → buffered, must coalesce.
+    const p2 = dispatcher.handle(
+      makeEnvelope({
+        id: "m2",
+        text: "second",
+        raw: { hub_msg_id: "m2", text: "second" },
+        conversation: { id: "rm_grp_x", kind: "group" },
+      }),
+    );
+    const p3 = dispatcher.handle(
+      makeEnvelope({
+        id: "m3",
+        text: "third",
+        raw: { hub_msg_id: "m3", text: "third" },
+        conversation: { id: "rm_grp_x", kind: "group" },
+      }),
+    );
+    await Promise.all([p1, p2, p3]);
+
+    // Exactly two runtime turns: m1 alone, then a single coalesced turn merging m2+m3.
+    expect(callNo).toBe(2);
+    expect(composeCalls.length).toBe(2);
+    expect(composeCalls[0]).toEqual({ id: "m1", batchSize: 1 });
+    // Anchor of merged turn is the latest entry (m3); raw.batch holds both.
+    expect(composeCalls[1].id).toBe("m3");
+    expect(composeCalls[1].batchSize).toBe(2);
+    // Sends gated for non-owner-chat room.
+    expect(channel.sends.length).toBe(0);
+  });
+
+  it("serial coalesce: mentioned is OR'd across the merged batch", async () => {
+    let captured: { mentioned?: boolean } = {};
+    const runtimeFactory: RuntimeFactory = () =>
+      new FakeRuntime({ reply: "ok", delayMs: 20, newSessionId: "sid" });
+    const { store, dir } = await makeStore();
+    tempDirs.push(dir);
+    const channel = new FakeChannel();
+    const dispatcher = new Dispatcher({
+      config: baseConfig({
+        defaultRoute: { runtime: "claude-code", cwd: "/tmp/d", queueMode: "serial" },
+      }),
+      channels: new Map<string, ChannelAdapter>([[channel.id, channel]]),
+      runtime: runtimeFactory,
+      sessionStore: store,
+      log: silentLogger(),
+      composeUserTurn: (msg) => {
+        if (msg.id === "m_b") captured = { mentioned: msg.mentioned };
+        return msg.text ?? "";
+      },
+    });
+
+    const p1 = dispatcher.handle(
+      makeEnvelope({
+        id: "m_a",
+        text: "a",
+        mentioned: false,
+        conversation: { id: "rm_grp_y", kind: "group" },
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    // Two new entries arrive during turn 1; one of them is mentioned.
+    const p2 = dispatcher.handle(
+      makeEnvelope({
+        id: "m_a2",
+        text: "a2",
+        mentioned: true,
+        conversation: { id: "rm_grp_y", kind: "group" },
+      }),
+    );
+    const p3 = dispatcher.handle(
+      makeEnvelope({
+        id: "m_b",
+        text: "b",
+        mentioned: false,
+        conversation: { id: "rm_grp_y", kind: "group" },
+      }),
+    );
+    await Promise.all([p1, p2, p3]);
+    expect(captured.mentioned).toBe(true);
+  });
+
+  it("serial coalesce: buffer overflow drops oldest entries (>40 backlog)", async () => {
+    let firstTurnDone!: () => void;
+    const firstTurnGate = new Promise<void>((resolve) => {
+      firstTurnDone = resolve;
+    });
+    let callNo = 0;
+    const runtimeFactory: RuntimeFactory = () => {
+      callNo += 1;
+      const tag = `r${callNo}`;
+      // Turn 1 hangs until firstTurnGate is resolved, so we can pile up the
+      // overflowing backlog while it's in flight. Turns 2+ just complete.
+      if (callNo === 1) {
+        return new FakeRuntime({
+          reply: tag,
+          newSessionId: `sid-${callNo}`,
+          observeRun: () => {
+            void firstTurnGate.then(() => undefined);
+          },
+        });
+      }
+      return new FakeRuntime({
+        reply: tag,
+        newSessionId: `sid-${callNo}`,
+        delayMs: 0,
+      });
+    };
+    const composedIds: string[][] = [];
+    const { store, dir } = await makeStore();
+    tempDirs.push(dir);
+    const channel = new FakeChannel();
+    const dispatcher = new Dispatcher({
+      config: baseConfig({
+        defaultRoute: { runtime: "claude-code", cwd: "/tmp/d", queueMode: "serial" },
+      }),
+      channels: new Map<string, ChannelAdapter>([[channel.id, channel]]),
+      runtime: runtimeFactory,
+      sessionStore: store,
+      log: silentLogger(),
+      composeUserTurn: (msg) => {
+        const raw = msg.raw as { batch?: Array<{ hub_msg_id?: string }> } | null;
+        const ids = Array.isArray(raw?.batch)
+          ? raw!.batch!.map((b) => b.hub_msg_id ?? "?")
+          : [msg.id];
+        composedIds.push(ids);
+        return msg.text ?? "";
+      },
+    });
+    // Use a slow-runtime trigger that only resolves once we've enqueued
+    // enough overflow. Easier path: switch to delayMs and use timers.
+    // Simplification: just push 50 messages serially via Promise.all so that
+    // arrivals 2-50 buffer while arrival 1 is mid-run.
+    const arrivals: Array<Promise<void>> = [];
+    arrivals.push(
+      dispatcher.handle(
+        makeEnvelope({
+          id: "m_first",
+          text: "first",
+          raw: { hub_msg_id: "m_first", text: "first" },
+          conversation: { id: "rm_grp_overflow", kind: "group" },
+        }),
+      ),
+    );
+    // Yield twice so the worker observes the first entry and starts runtime.
+    await Promise.resolve();
+    await Promise.resolve();
+    // Push 50 more — backlog cap is 40, so the oldest 10 must be dropped.
+    for (let i = 0; i < 50; i++) {
+      arrivals.push(
+        dispatcher.handle(
+          makeEnvelope({
+            id: `m_${i}`,
+            text: `msg-${i}`,
+            raw: { hub_msg_id: `m_${i}`, text: `msg-${i}` },
+            conversation: { id: "rm_grp_overflow", kind: "group" },
+          }),
+        ),
+      );
+    }
+    // Release turn 1 so the worker drains the (capped) backlog.
+    firstTurnDone();
+    await Promise.all(arrivals);
+
+    // Two compose calls: first turn (m_first), second turn (40 surviving
+    // backlog entries — m_10 through m_49 if drop-oldest was applied).
+    expect(composedIds.length).toBe(2);
+    expect(composedIds[0]).toEqual(["m_first"]);
+    expect(composedIds[1].length).toBe(40);
+    expect(composedIds[1][0]).toBe("m_10");
+    expect(composedIds[1][39]).toBe("m_49");
+  });
+
+  it("serial coalesce: char-cap drops oldest individual messages from merged batch", async () => {
+    let callNo = 0;
+    const runtimeFactory: RuntimeFactory = () => {
+      callNo += 1;
+      const tag = `r${callNo}`;
+      return new FakeRuntime({
+        reply: tag,
+        newSessionId: `sid-${callNo}`,
+        // Turn 1 holds until released so turns 2-N pile up.
+        delayMs: callNo === 1 ? 50 : 0,
+      });
+    };
+    const composedItemCounts: number[] = [];
+    const { store, dir } = await makeStore();
+    tempDirs.push(dir);
+    const channel = new FakeChannel();
+    const dispatcher = new Dispatcher({
+      config: baseConfig({
+        defaultRoute: { runtime: "claude-code", cwd: "/tmp/d", queueMode: "serial" },
+      }),
+      channels: new Map<string, ChannelAdapter>([[channel.id, channel]]),
+      runtime: runtimeFactory,
+      sessionStore: store,
+      log: silentLogger(),
+      composeUserTurn: (msg) => {
+        const raw = msg.raw as { batch?: unknown[] } | null;
+        const items = Array.isArray(raw?.batch) ? raw!.batch!.length : 1;
+        composedItemCounts.push(items);
+        return msg.text ?? "";
+      },
+    });
+    // Each pile-up message carries ~2000 chars; 20 messages = ~40000 chars,
+    // well over the 16000 cap. The merger must drop oldest until ≤16000.
+    const big = "x".repeat(2000);
+    const p0 = dispatcher.handle(
+      makeEnvelope({
+        id: "m_lead",
+        text: "lead",
+        raw: { hub_msg_id: "m_lead", text: "lead" },
+        conversation: { id: "rm_grp_chars", kind: "group" },
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    const arrivals: Array<Promise<void>> = [p0];
+    for (let i = 0; i < 20; i++) {
+      arrivals.push(
+        dispatcher.handle(
+          makeEnvelope({
+            id: `mb_${i}`,
+            text: big,
+            raw: { hub_msg_id: `mb_${i}`, text: big },
+            conversation: { id: "rm_grp_chars", kind: "group" },
+          }),
+        ),
+      );
+    }
+    await Promise.all(arrivals);
+
+    // Two composer calls. The second is the merged drain — it must contain
+    // strictly fewer than 20 items because oldest were dropped to fit cap.
+    expect(composedItemCounts.length).toBe(2);
+    expect(composedItemCounts[0]).toBe(1);
+    expect(composedItemCounts[1]).toBeGreaterThan(0);
+    expect(composedItemCounts[1]).toBeLessThan(20);
+    // Cap is 16000 chars; each item is 2000 → at most 8 items survive.
+    expect(composedItemCounts[1]).toBeLessThanOrEqual(8);
+  });
+
+  it("owner-chat detection: dashboard_user_chat in non-rm_oc room still sends reply", async () => {
+    const runtime = new FakeRuntime({ reply: "ok", newSessionId: "sid-1" });
+    const { dispatcher, channel } = await scaffold({
+      runtimeFactory: () => runtime,
+    });
+    await dispatcher.handle(
+      makeEnvelope({
+        id: "m_dash",
+        // Note: room id does NOT start with rm_oc_ but raw.source_type marks
+        // this as a dashboard user chat — must be treated as owner-chat by
+        // the gating predicate.
+        conversation: { id: "rm_dashroom", kind: "direct" },
+        raw: { source_type: "dashboard_user_chat" },
+      }),
+    );
+    expect(channel.sends.length).toBe(1);
+    expect(channel.sends[0].message.text).toBe("ok");
   });
 });

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -20,6 +20,24 @@ import type {
 
 const DEFAULT_TURN_TIMEOUT_MS = 10 * 60 * 1000;
 
+/**
+ * Owner-chat room prefix. Reply-text gating: only rooms with this prefix get
+ * `result.text` forwarded to the channel; in every other room the runtime's
+ * plain text output is discarded — agents must use the `botcord_send` tool
+ * (or `botcord send` CLI via Bash) to actually deliver replies.
+ */
+const OWNER_CHAT_ROOM_PREFIX = "rm_oc_";
+
+/** Maximum number of buffered serial entries per queue. Excess entries drop oldest. */
+const MAX_BATCH_BUFFER_ENTRIES = 40;
+
+/**
+ * Soft cap on the total characters across raw.batch members in a merged
+ * turn. When exceeded, oldest entries are dropped (with a warn log) so the
+ * runtime prompt stays bounded even if the channel-side batch was huge.
+ */
+const MAX_BATCH_BUFFER_CHARS = 16000;
+
 /** Factory signature for building a runtime adapter at turn dispatch time. */
 export type RuntimeFactory = (
   runtimeId: string,
@@ -74,11 +92,20 @@ interface TurnSlot {
   done: Promise<void>;
 }
 
+/**
+ * One entry buffered for serial-mode coalescing. Each successful `runSerial`
+ * call pushes one entry; the worker drains the entire buffer on the next
+ * turn boundary and merges them into a single dispatch.
+ */
+interface BufferedSerialEntry {
+  route: GatewayRoute;
+  msg: GatewayInboundEnvelope["message"];
+  channel: ChannelAdapter;
+}
+
 interface QueueState {
   /** The currently executing turn on this queue key, if any. */
   current: TurnSlot | null;
-  /** Tail of the serial-mode queue — chained via promises; replaced each append. */
-  tail: Promise<void>;
   /**
    * Generation counter bumped every time a cancel-previous turn arrives.
    * Any in-flight cancel-previous arrival captures the value at entry; if a
@@ -88,6 +115,15 @@ interface QueueState {
    * `current === null` after an abort and run concurrently.
    */
   cancelGen: number;
+  /**
+   * Serial-mode coalescing buffer. Messages pushed here while a turn is in
+   * flight are drained — and merged into a single user turn — on the next
+   * iteration of the worker loop. First message in an idle queue triggers a
+   * turn immediately; subsequent arrivals fold into the next batch.
+   */
+  serialBuffer: BufferedSerialEntry[];
+  /** True when the serial-drain worker is actively running (or about to). */
+  serialWorkerActive: boolean;
 }
 
 /**
@@ -149,12 +185,18 @@ export class Dispatcher {
       return;
     }
 
-    // Compose the final user-turn text. The composer can enrich the raw
-    // message with sender label, room header, NO_REPLY hint, etc. — anything
-    // that should land in the runtime transcript. Failures fall back to the
-    // raw trimmed text so a buggy composer cannot drop turns.
+    const managed = this.managedRoutes ? Array.from(this.managedRoutes.values()) : undefined;
+    const route = resolveRoute(msg, this.config, managed);
+    const mode = resolveQueueMode(route, msg.conversation.kind);
+    const queueKey = buildQueueKey(msg);
+
+    // Compose the final user-turn text only for cancel-previous mode, where
+    // the dispatcher consumes the pre-composed text directly. Serial mode
+    // re-runs the composer at drain time on the merged message (so it sees
+    // the full coalesced batch instead of any single arrival), so calling
+    // the composer here would just be redundant work.
     let text = rawText;
-    if (this.composeUserTurn) {
+    if (mode === "cancel-previous" && this.composeUserTurn) {
       try {
         const composed = this.composeUserTurn(msg);
         if (typeof composed === "string" && composed.length > 0) {
@@ -167,11 +209,6 @@ export class Dispatcher {
         });
       }
     }
-
-    const managed = this.managedRoutes ? Array.from(this.managedRoutes.values()) : undefined;
-    const route = resolveRoute(msg, this.config, managed);
-    const mode = resolveQueueMode(route, msg.conversation.kind);
-    const queueKey = buildQueueKey(msg);
 
     // Ack immediately: once the dispatcher has a route + queue key, ownership is decided.
     await this.safeAck(envelope);
@@ -236,8 +273,9 @@ export class Dispatcher {
     if (!q) {
       q = {
         current: null,
-        tail: Promise.resolve(),
         cancelGen: 0,
+        serialBuffer: [],
+        serialWorkerActive: false,
       };
       this.queues.set(key, q);
     }
@@ -274,18 +312,164 @@ export class Dispatcher {
     await this.runTurn(queueKey, route, text, msg, channel);
   }
 
+  /**
+   * Serial mode with coalesce-on-drain semantics:
+   *
+   *   1. First arrival on an idle queue boots the worker, which dispatches a
+   *      single-message turn immediately (no batching delay).
+   *   2. Arrivals during an in-flight turn append to `serialBuffer`; when the
+   *      worker finishes the current turn it drains the entire buffer and
+   *      merges all pending entries into ONE next turn (folded into a single
+   *      `raw.batch` so the composer renders them as multi-block input).
+   *   3. Buffer caps: at most `MAX_BATCH_BUFFER_ENTRIES` entries are retained
+   *      (drop oldest) and merged turns are further trimmed to fit
+   *      `MAX_BATCH_BUFFER_CHARS` of total raw text.
+   *
+   * Note: the pre-composed `text` from `handle()` is intentionally discarded
+   * here — at drain time the worker re-invokes `composeUserTurn` on the
+   * merged message so the runtime sees a single coherent prompt covering all
+   * coalesced messages.
+   */
   private async runSerial(
     queueKey: string,
     route: GatewayRoute,
-    text: string,
+    _text: string,
     msg: GatewayInboundEnvelope["message"],
     channel: ChannelAdapter,
   ): Promise<void> {
     const q = this.getQueue(queueKey);
-    const prev = q.tail;
-    const next = prev.then(() => this.runTurn(queueKey, route, text, msg, channel));
-    q.tail = next.catch(() => undefined);
-    return next;
+    q.serialBuffer.push({ route, msg, channel });
+    while (q.serialBuffer.length > MAX_BATCH_BUFFER_ENTRIES) {
+      const dropped = q.serialBuffer.shift()!;
+      this.log.warn("dispatcher: serial buffer overflow — dropped oldest entry", {
+        queueKey,
+        droppedMessageId: dropped.msg.id,
+        bufferCap: MAX_BATCH_BUFFER_ENTRIES,
+      });
+    }
+    if (q.serialWorkerActive) return;
+    q.serialWorkerActive = true;
+    try {
+      while (q.serialBuffer.length > 0) {
+        const drained = q.serialBuffer.splice(0, q.serialBuffer.length);
+        const merged = this.mergeSerialBuffer(drained, queueKey);
+        if (!merged) continue;
+        await this.runTurn(
+          queueKey,
+          merged.route,
+          merged.text,
+          merged.msg,
+          merged.channel,
+        );
+      }
+    } finally {
+      q.serialWorkerActive = false;
+    }
+  }
+
+  /**
+   * Merge buffered serial entries into a single dispatchable unit. With one
+   * entry the call is a near no-op (just recompose). With ≥2 entries this
+   * flattens any per-entry `raw.batch` (the BotCord channel already groups
+   * one inbox-poll's worth of same-room/topic messages into a `raw.batch`),
+   * applies the `MAX_BATCH_BUFFER_CHARS` cap by dropping oldest individual
+   * messages, and then synthesizes a merged inbound message anchored on the
+   * latest entry's metadata (mentioned = OR across all entries).
+   */
+  private mergeSerialBuffer(
+    entries: BufferedSerialEntry[],
+    queueKey: string,
+  ): {
+    route: GatewayRoute;
+    text: string;
+    msg: GatewayInboundEnvelope["message"];
+    channel: ChannelAdapter;
+  } | null {
+    if (entries.length === 0) return null;
+    if (entries.length === 1) {
+      const only = entries[0]!;
+      return {
+        route: only.route,
+        text: this.recomposeUserTurn(only.msg),
+        msg: only.msg,
+        channel: only.channel,
+      };
+    }
+
+    // Flatten: each entry's raw may already be a BatchedInboxRaw with
+    // `.batch`; otherwise it's a single InboxMessage we treat as a 1-element
+    // batch. Insertion order preserves chronology.
+    const items: Array<Record<string, unknown>> = [];
+    for (const e of entries) {
+      const raw = e.msg.raw as Record<string, unknown> | null | undefined;
+      const batch = raw && Array.isArray((raw as { batch?: unknown }).batch)
+        ? ((raw as { batch: Array<Record<string, unknown>> }).batch)
+        : null;
+      if (batch) {
+        for (const m of batch) items.push(m);
+      } else if (raw) {
+        items.push(raw);
+      }
+    }
+
+    // Char-cap: drop oldest until we fit. Reserve at least one item so we
+    // never produce an empty merged batch.
+    let totalChars = items.reduce(
+      (acc, m) => acc + (typeof m?.text === "string" ? (m.text as string).length : 0),
+      0,
+    );
+    let droppedCount = 0;
+    while (totalChars > MAX_BATCH_BUFFER_CHARS && items.length > 1) {
+      const removed = items.shift()!;
+      totalChars -= typeof removed?.text === "string" ? (removed.text as string).length : 0;
+      droppedCount += 1;
+    }
+    if (droppedCount > 0) {
+      this.log.warn("dispatcher: merged batch exceeded char cap — dropped oldest", {
+        queueKey,
+        droppedCount,
+        remaining: items.length,
+        totalChars,
+        charCap: MAX_BATCH_BUFFER_CHARS,
+      });
+    }
+
+    const latest = entries[entries.length - 1]!;
+    const latestRaw = (latest.msg.raw as Record<string, unknown> | null | undefined) ?? {};
+    const mergedRaw = { ...latestRaw, batch: items };
+    const anyMentioned = entries.some((e) => e.msg.mentioned === true);
+    const mergedMsg: GatewayInboundEnvelope["message"] = {
+      ...latest.msg,
+      mentioned: anyMentioned,
+      raw: mergedRaw,
+    };
+    return {
+      route: latest.route,
+      text: this.recomposeUserTurn(mergedMsg),
+      msg: mergedMsg,
+      channel: latest.channel,
+    };
+  }
+
+  /**
+   * Re-run the user-turn composer at drain time. Mirrors the logic in
+   * `handle()` but operates on the (possibly merged) message. Falls back to
+   * raw trimmed text on composer failure so a buggy composer never drops a
+   * turn.
+   */
+  private recomposeUserTurn(msg: GatewayInboundEnvelope["message"]): string {
+    const rawText = typeof msg.text === "string" ? msg.text.trim() : "";
+    if (!this.composeUserTurn) return rawText;
+    try {
+      const composed = this.composeUserTurn(msg);
+      if (typeof composed === "string" && composed.length > 0) return composed;
+    } catch (err) {
+      this.log.warn("dispatcher: composeUserTurn (drain) threw — using raw text", {
+        messageId: msg.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    return rawText;
   }
 
   private async runTurn(
@@ -413,16 +597,42 @@ export class Dispatcher {
         return;
       }
 
+      // Reply gating: only owner-chat rooms accept the runtime's plain text
+      // output as a delivered message. Every other room expects the agent to
+      // call the `botcord_send` tool (or `botcord send` CLI via Bash)
+      // explicitly; runtime text in those rooms is logged and dropped,
+      // including timeout / error notifications.
+      //
+      // Owner-chat is identified by either the `rm_oc_` room prefix OR
+      // `source_type === "dashboard_user_chat"` on the raw envelope — the
+      // same dual check used by `sender-classify.ts:classifyActivitySender`,
+      // so the dispatcher's reply gating stays in lock-step with the
+      // composer's owner-bypass.
+      //
+      // Side effect: `onOutbound` (loop-risk tracking) only fires when a
+      // reply actually leaves the dispatcher. In non-owner-chat rooms the
+      // expectation is that the agent's `botcord_send` tool calls do their
+      // own loop-risk accounting downstream.
+      const isOwnerChat = isOwnerChatRoom(msg);
+
       if (slot.timedOut) {
-        await this.sendReply(channel, {
-          channel: msg.channel,
-          accountId: msg.accountId,
-          conversationId: msg.conversation.id,
-          threadId: msg.conversation.threadId ?? null,
-          text: `⚠️ Runtime timeout after ${Math.round(this.turnTimeoutMs / 60000)} minute(s); aborted`,
-          replyTo: msg.id,
-          traceId: msg.trace?.id ?? null,
-        });
+        if (isOwnerChat) {
+          await this.sendReply(channel, {
+            channel: msg.channel,
+            accountId: msg.accountId,
+            conversationId: msg.conversation.id,
+            threadId: msg.conversation.threadId ?? null,
+            text: `⚠️ Runtime timeout after ${Math.round(this.turnTimeoutMs / 60000)} minute(s); aborted`,
+            replyTo: msg.id,
+            traceId: msg.trace?.id ?? null,
+          });
+        } else {
+          this.log.warn("dispatcher: timeout in non-owner-chat room — error reply suppressed", {
+            queueKey,
+            conversationId: msg.conversation.id,
+            timeoutMs: this.turnTimeoutMs,
+          });
+        }
         return;
       }
 
@@ -432,16 +642,23 @@ export class Dispatcher {
           runtime: route.runtime,
           error: threw instanceof Error ? threw.message : String(threw),
         });
-        const shortMsg = threw instanceof Error ? threw.message : String(threw);
-        await this.sendReply(channel, {
-          channel: msg.channel,
-          accountId: msg.accountId,
-          conversationId: msg.conversation.id,
-          threadId: msg.conversation.threadId ?? null,
-          text: `⚠️ Runtime error: ${truncate(shortMsg, 500)}`,
-          replyTo: msg.id,
-          traceId: msg.trace?.id ?? null,
-        });
+        if (isOwnerChat) {
+          const shortMsg = threw instanceof Error ? threw.message : String(threw);
+          await this.sendReply(channel, {
+            channel: msg.channel,
+            accountId: msg.accountId,
+            conversationId: msg.conversation.id,
+            threadId: msg.conversation.threadId ?? null,
+            text: `⚠️ Runtime error: ${truncate(shortMsg, 500)}`,
+            replyTo: msg.id,
+            traceId: msg.trace?.id ?? null,
+          });
+        } else {
+          this.log.warn("dispatcher: runtime error in non-owner-chat room — error reply suppressed", {
+            queueKey,
+            conversationId: msg.conversation.id,
+          });
+        }
         return;
       }
 
@@ -502,6 +719,22 @@ export class Dispatcher {
       const replyText = (result.text || "").trim();
       if (!replyText) return;
 
+      if (!isOwnerChat) {
+        // Non-owner-chat rooms: result.text never goes out. The agent is
+        // expected to have used the `botcord_send` tool / `botcord send` CLI
+        // already; whatever it left in the runtime's final assistant text is
+        // discarded so it doesn't leak into the room.
+        this.log.debug(
+          "dispatcher: non-owner-chat — discarding result.text (agent must use botcord_send)",
+          {
+            queueKey,
+            conversationId: msg.conversation.id,
+            replyTextLen: replyText.length,
+          },
+        );
+        return;
+      }
+
       // One last abort check immediately before the send. Narrows the window
       // in which a cancel-previous arriving during session-store.set could
       // still slip a stale reply past us.
@@ -559,6 +792,28 @@ export class Dispatcher {
 function buildQueueKey(msg: GatewayInboundEnvelope["message"]): string {
   const thread = msg.conversation.threadId ?? "";
   return `${msg.channel}:${msg.accountId}:${msg.conversation.id}:${thread}`;
+}
+
+/**
+ * Owner-chat predicate used by the dispatcher's reply gating. Matches the
+ * dual check in `sender-classify.ts:classifyActivitySender` so the
+ * dispatcher's gate stays consistent with the composer's owner-bypass:
+ *
+ *   1. `rm_oc_*` room id, OR
+ *   2. `source_type === "dashboard_user_chat"` on the raw envelope.
+ *
+ * The latter exists because the dashboard's user-chat surface can route
+ * messages through non-`rm_oc_` rooms in some flows; treating them as
+ * owner-trust here keeps the agent's plain reply text reachable.
+ */
+function isOwnerChatRoom(msg: GatewayInboundEnvelope["message"]): boolean {
+  if (msg.conversation.id.startsWith(OWNER_CHAT_ROOM_PREFIX)) return true;
+  const raw = msg.raw;
+  if (raw && typeof raw === "object") {
+    const sourceType = (raw as { source_type?: unknown }).source_type;
+    if (sourceType === "dashboard_user_chat") return true;
+  }
+  return false;
 }
 
 function resolveQueueMode(

--- a/packages/daemon/src/turn-text.ts
+++ b/packages/daemon/src/turn-text.ts
@@ -35,6 +35,18 @@ const DIRECT_HINT =
   'reply with exactly "NO_REPLY" and nothing else.]';
 
 /**
+ * Reminder appended to every wrapped (non-owner-chat) inbound message. The
+ * dispatcher discards `result.text` for any room that is not `rm_oc_*`, so
+ * the agent must call the `botcord_send` tool (or the `botcord send` CLI
+ * via Bash) to actually deliver a reply. Plain assistant text in those
+ * rooms is logged and dropped.
+ */
+const NON_OWNER_REPLY_HINT =
+  "[This room is NOT owner-chat. Plain text output WILL NOT be sent. " +
+  "To reply, call the `botcord_send` tool, or run " +
+  '`botcord send --room <room_id> --text "..."` via Bash.]';
+
+/**
  * Read the BotCord envelope type from a raw inbound message. Returns
  * `undefined` when the message didn't come from the BotCord channel or the
  * raw shape is unexpected — callers treat that the same as "message".
@@ -169,6 +181,8 @@ export function composeBotCordUserTurn(msg: GatewayInboundMessage): string {
     `</${tag}>`,
     "",
     hint,
+    "",
+    NON_OWNER_REPLY_HINT,
   ];
   if (contactRequestHint) {
     lines.push("", contactRequestHint);
@@ -223,7 +237,14 @@ function composeBatchedTurn(
   }
 
   const hint = isGroup ? GROUP_HINT : DIRECT_HINT;
-  const lines: string[] = [header.join(" | "), blocks.join("\n"), "", hint];
+  const lines: string[] = [
+    header.join(" | "),
+    blocks.join("\n"),
+    "",
+    hint,
+    "",
+    NON_OWNER_REPLY_HINT,
+  ];
 
   if (contactRequestSenders.length > 0) {
     // Dedup + list — multiple distinct senders show as "A, B".


### PR DESCRIPTION
## Summary

- **Coalesce-on-drain serial worker**: in group rooms, the first arrival triggers a turn immediately; any messages that arrive while the turn is in flight buffer up and fold into the *next* turn as one merged batch, instead of spawning N back-to-back turns. Caps: **40 entries / 16 000 chars**, drop-oldest. This is the dispatcher fix for the "3 s in / 10 s out" backlog blow-up.
- **Reply gating to owner-chat**: only `rm_oc_*` rooms (or `source_type === "dashboard_user_chat"`) accept the runtime's plain text output as a reply. In every other room the agent must use the `botcord_send` tool (or `botcord send` CLI via Bash) — plain text, timeout banners and error replies are logged and dropped.
- **Composer hint**: the wrapped user-turn now appends a one-liner reminding the agent that plain text won't be delivered in non-owner-chat rooms.

## Design notes

- The owner-chat predicate (`isOwnerChatRoom`) mirrors `sender-classify.ts:classifyActivitySender` so the dispatcher's gate stays in lock-step with the composer's owner-bypass — no path can have one side say "owner" and the other say "non-owner".
- Composer is now invoked at *drain time* for serial mode (instead of in `handle()`), so it sees the merged message and can render the full batch in a single user turn. Cancel-previous mode keeps the eager pre-compose path.
- `onOutbound`/loop-risk observers no longer fire in non-owner-chat rooms since no reply leaves the dispatcher there; the agent's own `botcord_send` calls do their loop-risk accounting downstream.

## Test plan

- [x] `vitest run` — full daemon suite: **439 passed (was 431, +8 new)**
- [x] `tsc --noEmit` — clean (the 2 pre-existing `runtime-discovery.test.ts` errors are unrelated)
- [x] New tests cover: coalesce-on-drain folding m2+m3 into one turn; `mentioned` OR across merged batch; buffer overflow drops oldest 10 / keeps newest 40; char-cap drops oldest by 2 KB chunks; `dashboard_user_chat` in non-`rm_oc_` rooms still sends a reply; non-owner-chat rooms suppress text / timeout / error replies
- [ ] Smoke test against a live daemon + group room (recommend before rolling out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)