### PR TITLE
feat: bind-code install onboarding

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -273,6 +273,73 @@ async def _consume_bind_code(code: str) -> bool:
     return await _consume_short_code(code, "bind")
 
 
+async def _consume_bind_code_with_claim(code: str, agent_id: str) -> bool:
+    """Atomically consume a bind code AND stamp the resulting agent_id.
+
+    install-claim derives ``agent_id`` deterministically from the public
+    key before it ever touches the short_code row, so we can write
+    ``payload_json.claimed_agent_id`` in the same transaction that flips
+    ``consumed_at`` to non-null. Doing it as two separate writes left a
+    race window where ``GET /bind-ticket/{code}`` between the consume and
+    the metadata write saw a consumed row with no claimed_agent_id and
+    reported it as ``revoked`` — terminal-looking — even though the
+    agent was about to appear.
+
+    Returns True on first-use, False if the code was already consumed,
+    expired, or unknown (semantics identical to ``_consume_bind_code``).
+    """
+    async with _short_code_session_factory() as code_session:
+        now = _utc_now()
+        # Read the row first to merge the existing payload (so we keep
+        # bind_ticket / intended_name) with the new claim metadata. The
+        # WHERE clause on the UPDATE below still guarantees only one
+        # caller wins the consume, so the read is harmless to the
+        # uniqueness invariant.
+        select_result = await code_session.execute(
+            select(ShortCode.payload_json).where(
+                ShortCode.code == code,
+                ShortCode.kind == "bind",
+                ShortCode.consumed_at.is_(None),
+                ShortCode.use_count < ShortCode.max_uses,
+                ShortCode.expires_at > now,
+            )
+        )
+        existing_payload_json = select_result.scalar_one_or_none()
+        if existing_payload_json is None:
+            return False
+        try:
+            payload = json.loads(existing_payload_json)
+        except json.JSONDecodeError:
+            payload = {}
+        payload["claimed_agent_id"] = agent_id
+        payload["claimed_at"] = now.isoformat()
+        new_payload_json = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+
+        update_result = await code_session.execute(
+            update(ShortCode)
+            .where(
+                ShortCode.code == code,
+                ShortCode.kind == "bind",
+                ShortCode.consumed_at.is_(None),
+                ShortCode.use_count < ShortCode.max_uses,
+                ShortCode.expires_at > now,
+            )
+            .values(
+                use_count=ShortCode.use_count + 1,
+                consumed_at=case(
+                    (ShortCode.use_count + 1 >= ShortCode.max_uses, now),
+                    else_=ShortCode.consumed_at,
+                ),
+                payload_json=new_payload_json,
+            )
+        )
+        if update_result.rowcount == 0:
+            await code_session.rollback()
+            return False
+        await code_session.commit()
+        return True
+
+
 async def _peek_reset_code(code: str) -> str | None:
     return await _peek_short_code(code, "credential_reset", "reset_ticket")
 
@@ -1214,26 +1281,6 @@ def _generic_invalid_bind_code() -> HTTPException:
     return HTTPException(status_code=400, detail="INVALID_BIND_CODE")
 
 
-async def _record_claim_outcome(code: str, agent_id: str) -> None:
-    """Record claim metadata on the short_code so the dashboard owner can poll."""
-    now = _utc_now()
-    async with _short_code_session_factory() as code_session:
-        result = await code_session.execute(
-            select(ShortCode).where(ShortCode.code == code, ShortCode.kind == "bind")
-        )
-        row = result.scalar_one_or_none()
-        if row is None:
-            return
-        try:
-            payload = json.loads(row.payload_json) if row.payload_json else {}
-        except json.JSONDecodeError:
-            payload = {}
-        payload["claimed_agent_id"] = agent_id
-        payload["claimed_at"] = now.isoformat()
-        row.payload_json = json.dumps(payload, separators=(",", ":"), sort_keys=True)
-        await code_session.commit()
-
-
 @router.post("/me/agents/install-claim", status_code=201)
 async def install_claim(
     body: InstallClaimBody,
@@ -1326,9 +1373,11 @@ async def install_claim(
         )
     is_first = current_count == 0
 
-    # 10. Atomically consume the short_code (one-shot). If we lose the race,
+    # 10. Atomically consume the short_code AND stamp it with the
+    #     deterministic agent_id so polling never sees a "consumed but
+    #     no agent" intermediate state. If we lose the consume race,
     #     surface as INVALID_BIND_CODE.
-    if not await _consume_bind_code(body.bind_code):
+    if not await _consume_bind_code_with_claim(body.bind_code, agent_id):
         raise _generic_invalid_bind_code()
 
     # 11. Burn the JTI (separate connection, commits independently).
@@ -1379,8 +1428,9 @@ async def install_claim(
     await db.commit()
     await db.refresh(agent)
 
-    # 13. Record claim metadata on the short_code for owner polling.
-    await _record_claim_outcome(body.bind_code, agent_id)
+    # claimed_agent_id was already written into short_code.payload_json
+    # by _consume_bind_code_with_claim above, so dashboard polling sees
+    # a fully consistent state without a "revoked" intermediate read.
 
     return {
         "agent_id": agent_id,

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -11,6 +11,7 @@ import hashlib
 import hmac
 import json
 import logging
+import os
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -22,7 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.auth import RequestContext, require_user
 from hub import config as hub_config
 from hub.auth import create_agent_token, verify_agent_token
-from hub.config import BIND_PROOF_SECRET, JWT_SECRET
+from hub.config import BIND_PROOF_SECRET, HUB_PUBLIC_BASE_URL, JWT_SECRET
 from hub.routers.hub import is_agent_ws_online
 from hub.routers.daemon_control import is_daemon_online, send_control_frame
 from hub.crypto import verify_challenge_sig
@@ -36,6 +37,10 @@ from hub.services.wallet import get_or_create_wallet
 from hub.validators import parse_pubkey
 
 from nacl.signing import SigningKey as NaClSigningKey
+
+# Bind-code onboarding: short TTL + per-user active cap.
+BIND_TICKET_TTL_MINUTES = 10
+MAX_ACTIVE_BIND_CODES_PER_USER = 5
 
 _logger = logging.getLogger(__name__)
 
@@ -711,44 +716,206 @@ async def patch_agent(
 # ---------------------------------------------------------------------------
 
 
+class BindTicketBody(BaseModel):
+    intended_name: str | None = Field(default=None, max_length=128)
+
+
+def _build_install_command(bind_code: str, nonce: str) -> str:
+    base = HUB_PUBLIC_BASE_URL.rstrip("/")
+    return (
+        f"curl -fsSL {base}/openclaw/install.sh | bash -s -- "
+        f"--bind-code {bind_code} --bind-nonce {nonce}"
+    )
+
+
 @router.post("/me/agents/bind-ticket")
 async def create_bind_ticket(
+    body: BindTicketBody | None = None,
     ctx: RequestContext = Depends(require_user),
 ):
-    """Issue a one-time bind ticket for cryptographic agent binding."""
+    """Issue a one-time bind ticket for cryptographic agent binding.
+
+    Phase 1 onboarding: short TTL, per-user active-code cap, embeds
+    ``purpose=install_claim`` and a base64 32-byte nonce so the same code
+    can be redeemed by ``install-claim`` with an Ed25519 proof of possession.
+    """
+    intended_name = (body.intended_name.strip() if body and body.intended_name else None) or None
+
     now = _utc_now()
-    exp = now + datetime.timedelta(minutes=30)
-    nonce = uuid4().hex
+    exp = now + datetime.timedelta(minutes=BIND_TICKET_TTL_MINUTES)
+    # Base64 32-byte nonce so the install client can sign it as an Ed25519 challenge.
+    nonce = base64.b64encode(os.urandom(32)).decode()
     jti = uuid4().hex
     bind_code = f"bd_{uuid4().hex[:12]}"
 
-    payload = {
+    # Cap concurrently active install codes per user.
+    async with _short_code_session_factory() as code_session:
+        active_count_result = await code_session.execute(
+            select(sa_func.count())
+            .select_from(ShortCode)
+            .where(
+                ShortCode.kind == "bind",
+                ShortCode.owner_user_id == ctx.user_id,
+                ShortCode.consumed_at.is_(None),
+                ShortCode.expires_at > now,
+            )
+        )
+        active_count = active_count_result.scalar_one()
+        if active_count >= MAX_ACTIVE_BIND_CODES_PER_USER:
+            raise HTTPException(
+                status_code=429,
+                detail=(
+                    f"Too many active bind codes (max {MAX_ACTIVE_BIND_CODES_PER_USER}); "
+                    "revoke or wait for one to expire"
+                ),
+            )
+
+    ticket_payload = {
         "uid": str(ctx.user_id),
+        "purpose": "install_claim",
         "nonce": nonce,
         "iat": int(now.timestamp()),
         "exp": int(exp.timestamp()),
         "jti": jti,
     }
+    if intended_name:
+        ticket_payload["intended_name"] = intended_name
 
-    ticket = _build_signed_ticket(payload)
+    ticket = _build_signed_ticket(ticket_payload)
+
+    short_code_payload: dict = {"bind_ticket": ticket}
+    if intended_name:
+        short_code_payload["intended_name"] = intended_name
 
     short_code = ShortCode(
         code=bind_code,
         kind="bind",
         owner_user_id=ctx.user_id,
-        payload_json=json.dumps({"bind_ticket": ticket}, separators=(",", ":"), sort_keys=True),
+        payload_json=json.dumps(short_code_payload, separators=(",", ":"), sort_keys=True),
         expires_at=exp,
     )
     async with _short_code_session_factory() as code_session:
         code_session.add(short_code)
         await code_session.commit()
 
+    install_command = _build_install_command(bind_code, nonce)
+
     return {
         "bind_code": bind_code,
         "bind_ticket": ticket,
         "nonce": nonce,
         "expires_at": int(exp.timestamp()),
+        "install_command": install_command,
+        "intended_name": intended_name,
     }
+
+
+# ---------------------------------------------------------------------------
+# GET /api/users/me/agents/bind-ticket/{code}  (owner-only polling)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/me/agents/bind-ticket/{code}")
+async def get_bind_ticket_status(
+    code: str,
+    ctx: RequestContext = Depends(require_user),
+):
+    """Poll the status of a bind code issued by the current user.
+
+    Returns ``status`` ∈ {pending, claimed, expired} plus the resulting
+    ``agent_id`` once the install client has redeemed the code.
+    """
+    if not code.startswith("bd_"):
+        raise HTTPException(status_code=404, detail="Bind code not found")
+
+    async with _short_code_session_factory() as code_session:
+        result = await code_session.execute(
+            select(ShortCode).where(
+                ShortCode.code == code,
+                ShortCode.kind == "bind",
+                ShortCode.owner_user_id == ctx.user_id,
+            )
+        )
+        row = result.scalar_one_or_none()
+
+    if row is None:
+        raise HTTPException(status_code=404, detail="Bind code not found")
+
+    now = _utc_now()
+    expires_at = row.expires_at
+    if expires_at is not None and expires_at.tzinfo is None:
+        # SQLite stores naive datetimes; treat as UTC.
+        expires_at = expires_at.replace(tzinfo=datetime.timezone.utc)
+    expires_at_iso = expires_at.isoformat() if expires_at else None
+    expires_at_ts = int(expires_at.timestamp()) if expires_at else None
+
+    try:
+        payload = json.loads(row.payload_json) if row.payload_json else {}
+    except json.JSONDecodeError:
+        payload = {}
+
+    if row.consumed_at is not None:
+        return {
+            "bind_code": code,
+            "status": "claimed",
+            "agent_id": payload.get("claimed_agent_id"),
+            "claimed_at": row.consumed_at.isoformat(),
+            "expires_at": expires_at_iso,
+            "expires_at_ts": expires_at_ts,
+        }
+    if expires_at is not None and expires_at <= now:
+        return {
+            "bind_code": code,
+            "status": "expired",
+            "agent_id": None,
+            "expires_at": expires_at_iso,
+            "expires_at_ts": expires_at_ts,
+        }
+    return {
+        "bind_code": code,
+        "status": "pending",
+        "agent_id": None,
+        "expires_at": expires_at_iso,
+        "expires_at_ts": expires_at_ts,
+    }
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/users/me/agents/bind-ticket/{code}  (owner revoke)
+# ---------------------------------------------------------------------------
+
+
+@router.delete("/me/agents/bind-ticket/{code}")
+async def revoke_bind_ticket(
+    code: str,
+    ctx: RequestContext = Depends(require_user),
+):
+    """Revoke a pending bind code owned by the current user."""
+    if not code.startswith("bd_"):
+        raise HTTPException(status_code=404, detail="Bind code not found")
+
+    now = _utc_now()
+    async with _short_code_session_factory() as code_session:
+        upd = await code_session.execute(
+            update(ShortCode)
+            .where(
+                ShortCode.code == code,
+                ShortCode.kind == "bind",
+                ShortCode.owner_user_id == ctx.user_id,
+                ShortCode.consumed_at.is_(None),
+            )
+            .values(
+                consumed_at=now,
+                use_count=ShortCode.max_uses,
+            )
+        )
+        if upd.rowcount == 0:
+            await code_session.rollback()
+            # Either not found or already consumed/expired — surface 404 so the
+            # caller treats it as terminal in either case.
+            raise HTTPException(status_code=404, detail="Bind code not found or already consumed")
+        await code_session.commit()
+    return {"ok": True}
 
 
 @router.post(
@@ -1012,6 +1179,212 @@ async def agent_bind(
         db, user_id, body.agent_id, body.display_name, body.agent_token
     )
     return _agent_meta(agent)
+
+
+# ---------------------------------------------------------------------------
+# POST /api/users/me/agents/install-claim  (no JWT)
+# ---------------------------------------------------------------------------
+
+
+class InstallClaimProof(BaseModel):
+    nonce: str
+    sig: str
+
+
+class InstallClaimBody(BaseModel):
+    bind_code: str
+    pubkey: str
+    proof: InstallClaimProof
+    name: str | None = Field(default=None, max_length=128)
+
+
+def _generic_invalid_bind_code() -> HTTPException:
+    """Unauth claim path returns the same 400 for all bind-code-related failures.
+
+    Differentiating "not found" from "expired" from "already used" leaks
+    state to anyone holding a candidate code. Owner-visible state is
+    surfaced via the authenticated polling endpoint.
+    """
+    return HTTPException(status_code=400, detail="INVALID_BIND_CODE")
+
+
+async def _record_claim_outcome(code: str, agent_id: str) -> None:
+    """Record claim metadata on the short_code so the dashboard owner can poll."""
+    now = _utc_now()
+    async with _short_code_session_factory() as code_session:
+        result = await code_session.execute(
+            select(ShortCode).where(ShortCode.code == code, ShortCode.kind == "bind")
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            return
+        try:
+            payload = json.loads(row.payload_json) if row.payload_json else {}
+        except json.JSONDecodeError:
+            payload = {}
+        payload["claimed_agent_id"] = agent_id
+        payload["claimed_at"] = now.isoformat()
+        row.payload_json = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+        await code_session.commit()
+
+
+@router.post("/me/agents/install-claim", status_code=201)
+async def install_claim(
+    body: InstallClaimBody,
+    db: AsyncSession = Depends(get_db),
+):
+    """Redeem an install bind code with an Ed25519 proof of possession.
+
+    No user JWT — the bind code is a bearer credential issued from the
+    dashboard. The Ed25519 proof binds the redemption to the keypair that
+    the install client locally generated, so the server can never derive
+    the private key and a leaked bind code cannot be used to register a
+    pubkey the attacker does not control.
+    """
+    # 1. Shape check
+    if not body.bind_code.startswith("bd_"):
+        raise _generic_invalid_bind_code()
+
+    # 2. Peek the ticket without consuming
+    bind_ticket = await _peek_bind_code(body.bind_code)
+    if bind_ticket is None:
+        raise _generic_invalid_bind_code()
+
+    # 3. Verify ticket signature + expiry
+    ticket_payload = _verify_bind_ticket(bind_ticket)
+    if ticket_payload is None:
+        raise _generic_invalid_bind_code()
+
+    if ticket_payload.get("purpose") != "install_claim":
+        raise _generic_invalid_bind_code()
+
+    uid_str = ticket_payload.get("uid")
+    if not uid_str:
+        raise _generic_invalid_bind_code()
+    try:
+        user_id = UUID(uid_str)
+    except ValueError:
+        raise _generic_invalid_bind_code()
+
+    ticket_nonce = ticket_payload.get("nonce")
+    if not isinstance(ticket_nonce, str) or not ticket_nonce:
+        raise _generic_invalid_bind_code()
+
+    # 4. Proof: nonce must match the ticket's nonce
+    if body.proof.nonce != ticket_nonce:
+        raise HTTPException(status_code=401, detail="INVALID_PROOF")
+
+    # 5. Validate pubkey format ("ed25519:<base64-32-bytes>")
+    pubkey = body.pubkey.strip()
+    try:
+        pubkey_b64 = parse_pubkey(pubkey)
+    except HTTPException:
+        raise HTTPException(status_code=400, detail="INVALID_PUBKEY")
+
+    # 6. Verify Ed25519 proof of possession
+    if not verify_challenge_sig(pubkey_b64, ticket_nonce, body.proof.sig):
+        raise HTTPException(status_code=401, detail="INVALID_PROOF")
+
+    # 7. Derive agent_id from pubkey
+    agent_id = generate_agent_id(pubkey_b64)
+
+    # 8. Pre-check pubkey not already in use by any active/pending key
+    dup_key_result = await db.execute(
+        select(SigningKey).where(
+            SigningKey.pubkey == pubkey,
+            SigningKey.state.in_((KeyState.active, KeyState.pending)),
+        )
+    )
+    if dup_key_result.scalar_one_or_none() is not None:
+        raise HTTPException(status_code=409, detail="PUBKEY_ALREADY_REGISTERED")
+
+    # If an Agent row already exists for this deterministic agent_id, the
+    # pubkey was already claimed in a prior install. Surface as conflict.
+    dup_agent_result = await db.execute(select(Agent).where(Agent.agent_id == agent_id))
+    if dup_agent_result.scalar_one_or_none() is not None:
+        raise HTTPException(status_code=409, detail="PUBKEY_ALREADY_REGISTERED")
+
+    # 9. Quota check on owning user
+    user_result = await db.execute(select(User).where(User.id == user_id))
+    user = user_result.scalar_one_or_none()
+    if user is None:
+        raise _generic_invalid_bind_code()
+    count_result = await db.execute(
+        select(sa_func.count()).select_from(Agent).where(Agent.user_id == user_id)
+    )
+    current_count = count_result.scalar_one()
+    if current_count >= user.max_agents:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Agent quota exceeded (max {user.max_agents})",
+        )
+    is_first = current_count == 0
+
+    # 10. Atomically consume the short_code (one-shot). If we lose the race,
+    #     surface as INVALID_BIND_CODE.
+    if not await _consume_bind_code(body.bind_code):
+        raise _generic_invalid_bind_code()
+
+    # 11. Burn the JTI (separate connection, commits independently).
+    if not await _consume_bind_ticket_jti(ticket_payload["jti"]):
+        # Code is already burned at this point; nothing to roll back.
+        raise _generic_invalid_bind_code()
+
+    # 12. Insert Agent + active SigningKey atomically.
+    intended_name = ticket_payload.get("intended_name") if isinstance(ticket_payload.get("intended_name"), str) else None
+    requested_name = (body.name.strip() if body.name else None) or None
+    display_name = requested_name or intended_name or agent_id
+
+    now = _utc_now()
+    agent_token, expires_at_ts = create_agent_token(agent_id)
+    token_expires_at = datetime.datetime.fromtimestamp(
+        expires_at_ts, tz=datetime.timezone.utc
+    )
+
+    key_id = generate_key_id()
+    agent = Agent(
+        agent_id=agent_id,
+        display_name=display_name,
+        user_id=user_id,
+        agent_token=agent_token,
+        token_expires_at=token_expires_at,
+        is_default=is_first,
+        claimed_at=now,
+    )
+    signing_key = SigningKey(
+        agent_id=agent_id,
+        key_id=key_id,
+        pubkey=pubkey,
+        state=KeyState.active,
+    )
+    try:
+        async with db.begin_nested():
+            db.add(agent)
+            db.add(signing_key)
+    except IntegrityError:
+        # Another concurrent claim won. The bind code is already burned, so
+        # nothing further to do here — surface as conflict.
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="PUBKEY_ALREADY_REGISTERED")
+
+    await _ensure_agent_owner_role(db, user_id)
+    await _maybe_grant_claim_gift(db, agent)
+
+    await db.commit()
+    await db.refresh(agent)
+
+    # 13. Record claim metadata on the short_code for owner polling.
+    await _record_claim_outcome(body.bind_code, agent_id)
+
+    return {
+        "agent_id": agent_id,
+        "key_id": key_id,
+        "agent_token": agent_token,
+        "token_expires_at": expires_at_ts,
+        "hub_url": HUB_PUBLIC_BASE_URL,
+        "ws_url": HUB_PUBLIC_BASE_URL.replace("https://", "wss://").replace("http://", "ws://") + "/ws",
+        "display_name": display_name,
+    }
 
 
 @router.post(

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -855,10 +855,16 @@ async def get_bind_ticket_status(
         payload = {}
 
     if row.consumed_at is not None:
+        claimed_agent_id = payload.get("claimed_agent_id")
+        # A consumed row without a recorded claimed_agent_id was revoked
+        # (or the post-claim metadata write failed). Either way it is
+        # terminal — surface it as "revoked" so polling stops without
+        # claiming there is an agent we can navigate to.
+        status = "claimed" if claimed_agent_id else "revoked"
         return {
             "bind_code": code,
-            "status": "claimed",
-            "agent_id": payload.get("claimed_agent_id"),
+            "status": status,
+            "agent_id": claimed_agent_id,
             "claimed_at": row.consumed_at.isoformat(),
             "expires_at": expires_at_iso,
             "expires_at_ts": expires_at_ts,

--- a/backend/hub/main.py
+++ b/backend/hub/main.py
@@ -8,7 +8,7 @@ import sentry_sdk
 from fastapi import Depends, FastAPI, Request
 from fastapi.exceptions import HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
+from fastapi.responses import FileResponse, JSONResponse
 
 from hub.i18n import I18nHTTPException, detect_locale, get_hint, get_message
 
@@ -215,6 +215,25 @@ async def structured_http_exception_handler(request: Request, exc: HTTPException
 @app.get("/health", tags=["health"])
 async def health():
     return {"status": "ok"}
+
+
+_INSTALL_SH_PATH = _PROJECT_ROOT / "static" / "openclaw" / "install.sh"
+
+
+@app.get("/openclaw/install.sh", tags=["onboarding"])
+async def serve_install_script():
+    """Serve the BotCord plugin installer for the dashboard one-line command.
+
+    Cached briefly at the CDN; the dashboard always pairs it with a fresh
+    bind code in the bash arguments, so a stale script body remains safe.
+    """
+    if not _INSTALL_SH_PATH.is_file():
+        raise HTTPException(status_code=404, detail="install.sh not packaged")
+    return FileResponse(
+        _INSTALL_SH_PATH,
+        media_type="text/x-sh",
+        headers={"Cache-Control": "public, max-age=300"},
+    )
 
 
 app.include_router(registry_router)

--- a/backend/static/openclaw/install.sh
+++ b/backend/static/openclaw/install.sh
@@ -178,13 +178,21 @@ if [ "$SKIP_PLUGIN_INSTALL" != "true" ]; then
   require_cmd npm "Install npm (ships with Node.js)"
 fi
 
-# ── Step 1: Stage + install plugin ────────────────────────────────────────
+# ── Step 1: Stage + npm install (no live swap yet) ───────────────────────
+#
+# We deliberately do *not* touch $TARGET_DIR before the claim step. That
+# way a claim failure (expired bind code, server-side reject, network
+# blip) leaves the user's existing plugin install untouched. The atomic
+# swap into TARGET_DIR happens further down once we have credentials in
+# hand.
 
+WANT_PLUGIN_SWAP="false"
 if [ "$SKIP_PLUGIN_INSTALL" = "true" ]; then
   log "skipping plugin install (--skip-plugin-install)"
 elif [ -d "$TARGET_DIR" ] && [ "$FORCE_REINSTALL" != "true" ]; then
   log "plugin already installed at $TARGET_DIR (use --force-reinstall to replace)"
 else
+  WANT_PLUGIN_SWAP="true"
   STAGING_DIR="$(mktemp -d "${TMPDIR:-/tmp}/botcord-stage.XXXXXX")"
   log "staging plugin to $STAGING_DIR"
 
@@ -224,16 +232,6 @@ else
     log_error "npm install failed; see $RUN_LOG for details"
     exit 1
   }
-
-  mkdir -p -- "$(dirname "$TARGET_DIR")"
-  if [ -d "$TARGET_DIR" ]; then
-    BACKUP_DIR="${TARGET_DIR}.bak.${TS}"
-    log "moving existing $TARGET_DIR → $BACKUP_DIR"
-    mv -- "$TARGET_DIR" "$BACKUP_DIR"
-  fi
-  mv -- "$STAGING_DIR" "$TARGET_DIR"
-  STAGING_DIR=""  # ownership transferred; on_exit shouldn't rm the live install
-  log "plugin installed at $TARGET_DIR"
 fi
 
 # ── Step 2: Generate keypair, sign, claim ────────────────────────────────
@@ -353,7 +351,25 @@ log "  Display:     $DISPLAY_NAME"
 log "  Key ID:      $KEY_ID"
 log "  Credentials: $CRED_FILE"
 
-# ── Step 3: Configure openclaw.json ──────────────────────────────────────
+# ── Step 3: Atomic swap staged plugin into TARGET_DIR ─────────────────────
+#
+# Now (and only now) that the claim succeeded do we touch the live plugin
+# install. If we'd swapped earlier and the claim then failed, the user's
+# previous plugin would have been displaced for nothing.
+
+if [ "$WANT_PLUGIN_SWAP" = "true" ] && [ -n "$STAGING_DIR" ] && [ -d "$STAGING_DIR" ]; then
+  mkdir -p -- "$(dirname "$TARGET_DIR")"
+  if [ -d "$TARGET_DIR" ]; then
+    BACKUP_DIR="${TARGET_DIR}.bak.${TS}"
+    log "moving existing $TARGET_DIR → $BACKUP_DIR"
+    mv -- "$TARGET_DIR" "$BACKUP_DIR"
+  fi
+  mv -- "$STAGING_DIR" "$TARGET_DIR"
+  STAGING_DIR=""  # ownership transferred; on_exit shouldn't rm the live install
+  log "plugin installed at $TARGET_DIR"
+fi
+
+# ── Step 4: Configure openclaw.json ──────────────────────────────────────
 
 # Account-namespaced keys when --account is supplied; otherwise global keys.
 if [ -n "$ACCOUNT" ]; then
@@ -435,7 +451,7 @@ if [ "$CONFIG_OK" != "true" ]; then
   log_warn "  channels.botcord.deliveryMode = websocket"
 fi
 
-# ── Step 4: Restart gateway ───────────────────────────────────────────────
+# ── Step 5: Restart gateway ───────────────────────────────────────────────
 
 if [ "$SKIP_RESTART" = "true" ]; then
   log "skipping gateway restart (--skip-restart); restart it manually for the plugin to load"

--- a/backend/static/openclaw/install.sh
+++ b/backend/static/openclaw/install.sh
@@ -52,6 +52,13 @@ LOG_DIR="$HOME/.botcord/log"
 TS="$(date +%Y%m%d_%H%M%S)"
 RUN_LOG="${TMPDIR:-/tmp}/botcord-install-${TS}-$$.log"
 STAGING_DIR=""
+# Swap state for the post-claim plugin replacement. ``BACKUP_DIR`` names
+# the directory that holds the user's previous plugin while we move the
+# staged one into place. ``SWAP_DONE`` flips to ``true`` only after both
+# moves succeed; if the script dies between them, on_exit restores the
+# backup so the user is never left with a missing plugin.
+BACKUP_DIR=""
+SWAP_DONE="false"
 
 mkdir -p "$LOG_DIR" 2>/dev/null || true
 : > "$RUN_LOG" 2>/dev/null || RUN_LOG="/dev/null"
@@ -64,6 +71,18 @@ log_quiet() { printf "[botcord] %s\n" "$*" >> "$RUN_LOG"; }  # log only to file 
 on_exit() {
   local code=$?
   if [ "$code" -ne 0 ]; then
+    # Plugin-swap rollback: if we stashed the previous install but did
+    # not finish moving the staged one into place, restore the backup
+    # so the live target never ends up missing.
+    if [ "$SWAP_DONE" != "true" ] && [ -n "$BACKUP_DIR" ] && [ -d "$BACKUP_DIR" ]; then
+      log_error "rolling back plugin swap; restoring $BACKUP_DIR → $TARGET_DIR"
+      rm -rf -- "$TARGET_DIR" 2>/dev/null || true
+      if mv -- "$BACKUP_DIR" "$TARGET_DIR" 2>>"$RUN_LOG"; then
+        log_error "previous plugin restored at $TARGET_DIR"
+      else
+        log_error "rollback failed; previous plugin is at $BACKUP_DIR"
+      fi
+    fi
     if [ -d "${STAGING_DIR:-/nonexistent}" ]; then
       rm -rf -- "$STAGING_DIR" 2>/dev/null || true
     fi
@@ -363,9 +382,20 @@ if [ "$WANT_PLUGIN_SWAP" = "true" ] && [ -n "$STAGING_DIR" ] && [ -d "$STAGING_D
     BACKUP_DIR="${TARGET_DIR}.bak.${TS}"
     log "moving existing $TARGET_DIR → $BACKUP_DIR"
     mv -- "$TARGET_DIR" "$BACKUP_DIR"
+    # From here on, on_exit will restore BACKUP_DIR if the script dies
+    # before SWAP_DONE flips below.
+  fi
+  # Fault-injection hook for tests: if BOTCORD_INSTALL_FAULT=after-backup,
+  # exit between the two moves so the on_exit rollback path is exercised
+  # against a real filesystem state. Never fires in production unless the
+  # caller explicitly opts in with this env var.
+  if [ "${BOTCORD_INSTALL_FAULT:-}" = "after-backup" ]; then
+    log_error "BOTCORD_INSTALL_FAULT=after-backup; aborting before second mv"
+    exit 73
   fi
   mv -- "$STAGING_DIR" "$TARGET_DIR"
-  STAGING_DIR=""  # ownership transferred; on_exit shouldn't rm the live install
+  STAGING_DIR=""   # ownership transferred; on_exit shouldn't rm the live install
+  SWAP_DONE="true" # second move succeeded — disarm the rollback
   log "plugin installed at $TARGET_DIR"
 fi
 

--- a/backend/static/openclaw/install.sh
+++ b/backend/static/openclaw/install.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# BotCord OpenClaw plugin installer (Phase 1 placeholder)
+#
+# Real installer is implemented in Phase 2 of bind-code-onboarding-design.md.
+# Until then, this stub exists so the dashboard install command resolves and
+# users get an actionable message instead of a 404.
+set -euo pipefail
+
+cat <<'MSG'
+BotCord plugin installer is not yet generally available.
+
+The dashboard ships a one-time install command of the form:
+
+  curl -fsSL <hub>/openclaw/install.sh | bash -s -- \
+    --bind-code bd_xxxxxxxxxxxx \
+    --bind-nonce <base64-nonce>
+
+When Phase 2 lands this script will:
+  1. Download the @botcord/botcord plugin tarball
+  2. Run npm install --omit=dev into ~/.openclaw/extensions/botcord
+  3. Generate an Ed25519 keypair locally
+  4. Sign the bind nonce and POST /api/users/me/agents/install-claim
+  5. Write ~/.botcord/credentials/<agentId>.json (chmod 600)
+  6. Run `openclaw config set --batch-json` and restart the gateway
+
+For now, follow plugin/README.md to install manually.
+MSG
+
+exit 1

--- a/backend/static/openclaw/install.sh
+++ b/backend/static/openclaw/install.sh
@@ -1,29 +1,460 @@
 #!/usr/bin/env bash
-# BotCord OpenClaw plugin installer (Phase 1 placeholder)
+# --------------------------------------------------------------------------
+# BotCord OpenClaw plugin installer (bind-code onboarding)
 #
-# Real installer is implemented in Phase 2 of bind-code-onboarding-design.md.
-# Until then, this stub exists so the dashboard install command resolves and
-# users get an actionable message instead of a 404.
+# Issued by the dashboard; runs on a machine that already has OpenClaw +
+# Node.js + npm. The dashboard pre-fills --bind-code and --bind-nonce in
+# the install command.
+#
+# What it does, in order:
+#   1. Stages @botcord/botcord into ~/.openclaw/extensions/botcord
+#      (download tarball or clone source, npm install --omit=dev, atomic swap)
+#   2. Generates an Ed25519 keypair locally (private key never leaves disk)
+#   3. Signs the bind-nonce and POSTs /api/users/me/agents/install-claim
+#   4. Writes ~/.botcord/credentials/<agentId>.json with chmod 600
+#   5. Configures channels.botcord in openclaw.json (CLI or direct edit)
+#   6. Restarts the OpenClaw gateway (or prints a docker-restart hint)
+#
+# Invariants:
+#   - The bind code is single-use; if any pre-claim step fails the code
+#     remains pending so the user can retry.
+#   - The Ed25519 private key is never sent to the server. The server sees
+#     only the public key + a signature over the bind-nonce.
+#   - Trap on_exit archives the run log to ~/.botcord/log/install_fail_<ts>.log
+#     when the installer aborts non-zero.
+# --------------------------------------------------------------------------
 set -euo pipefail
 
-cat <<'MSG'
-BotCord plugin installer is not yet generally available.
+# ── Defaults ──────────────────────────────────────────────────────────────
 
-The dashboard ships a one-time install command of the form:
+SERVER_URL="${BOTCORD_SERVER_URL:-https://api.botcord.chat}"
+PLUGIN_PACKAGE="@botcord/botcord"
+PLUGIN_VERSION=""
+TGZ_URL=""
+TGZ_PATH=""
+FROM_SOURCE_DIR=""
+TARGET_DIR_DEFAULT="$HOME/.openclaw/extensions/botcord"
+TARGET_DIR="$TARGET_DIR_DEFAULT"
+ACCOUNT=""
+AGENT_NAME=""
+SKIP_PLUGIN_INSTALL="false"
+SKIP_RESTART="false"
+FORCE_REINSTALL="false"
+OPENCLAW_BIN="${OPENCLAW_BIN:-openclaw}"
+OPENCLAW_CONFIG_PATH="${OPENCLAW_CONFIG_PATH:-}"
 
-  curl -fsSL <hub>/openclaw/install.sh | bash -s -- \
-    --bind-code bd_xxxxxxxxxxxx \
-    --bind-nonce <base64-nonce>
+BIND_CODE=""
+BIND_NONCE=""
 
-When Phase 2 lands this script will:
-  1. Download the @botcord/botcord plugin tarball
-  2. Run npm install --omit=dev into ~/.openclaw/extensions/botcord
-  3. Generate an Ed25519 keypair locally
-  4. Sign the bind nonce and POST /api/users/me/agents/install-claim
-  5. Write ~/.botcord/credentials/<agentId>.json (chmod 600)
-  6. Run `openclaw config set --batch-json` and restart the gateway
+# ── Logging + cleanup ─────────────────────────────────────────────────────
 
-For now, follow plugin/README.md to install manually.
-MSG
+LOG_DIR="$HOME/.botcord/log"
+TS="$(date +%Y%m%d_%H%M%S)"
+RUN_LOG="${TMPDIR:-/tmp}/botcord-install-${TS}-$$.log"
+STAGING_DIR=""
 
-exit 1
+mkdir -p "$LOG_DIR" 2>/dev/null || true
+: > "$RUN_LOG" 2>/dev/null || RUN_LOG="/dev/null"
+
+log()       { printf "[botcord] %s\n" "$*" | tee -a "$RUN_LOG"; }
+log_warn()  { printf "[botcord] WARN: %s\n" "$*" | tee -a "$RUN_LOG"; }
+log_error() { printf "[botcord] ERROR: %s\n" "$*" | tee -a "$RUN_LOG" >&2; }
+log_quiet() { printf "[botcord] %s\n" "$*" >> "$RUN_LOG"; }  # log only to file (private)
+
+on_exit() {
+  local code=$?
+  if [ "$code" -ne 0 ]; then
+    if [ -d "${STAGING_DIR:-/nonexistent}" ]; then
+      rm -rf -- "$STAGING_DIR" 2>/dev/null || true
+    fi
+    if [ "$RUN_LOG" != "/dev/null" ] && [ -s "$RUN_LOG" ]; then
+      local archive="$LOG_DIR/install_fail_${TS}.log"
+      cp -- "$RUN_LOG" "$archive" 2>/dev/null && \
+        printf "[botcord] install failed; full log archived to %s\n" "$archive" >&2
+    fi
+  else
+    [ "$RUN_LOG" != "/dev/null" ] && rm -f -- "$RUN_LOG" 2>/dev/null || true
+  fi
+}
+trap on_exit EXIT
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+usage() {
+  cat <<USAGE
+Usage:
+  curl -fsSL <hub>/openclaw/install.sh | bash -s -- --bind-code <bd_xxx> --bind-nonce <nonce> [options]
+
+Required (issued by the dashboard):
+  --bind-code <bd_xxx>      One-time bind code from "Add Agent to OpenClaw"
+  --bind-nonce <base64>     Ticket nonce to sign with the local keypair
+
+Plugin source (mutually exclusive; default: npm registry):
+  --plugin-version <ver>    Pin a specific version of $PLUGIN_PACKAGE
+  --tgz-url <url>           Install plugin from a tarball URL
+  --tgz-path <path>         Install plugin from a local tarball
+  --from-source <dir>       Install plugin from a checked-out source dir
+
+Configuration:
+  --server-url <url>        BotCord hub URL (default: $SERVER_URL)
+  --account <id>            Multi-account namespace (channels.botcord.accounts.<id>)
+  --target-dir <path>       Plugin install dir (default: $TARGET_DIR_DEFAULT)
+  --name <name>             Override agent display name (otherwise dashboard's intended_name wins)
+  --force-reinstall         Replace any existing plugin install at target dir
+  --skip-plugin-install     Only do claim + credentials + config; assume plugin already installed
+  --skip-restart            Skip gateway restart (you'll restart manually)
+  -h, --help                Show this help
+
+Environment:
+  BOTCORD_SERVER_URL         Default for --server-url
+  OPENCLAW_BIN               Path to openclaw CLI (default: openclaw)
+  OPENCLAW_CONFIG_PATH       Direct openclaw.json path (skips CLI; useful in containers)
+USAGE
+}
+
+need_next_arg() {
+  local opt="$1" argc="$2"
+  if [ "$argc" -lt 2 ]; then
+    log_error "missing value for $opt"
+    exit 1
+  fi
+}
+
+require_cmd() {
+  local cmd="$1" hint="$2"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    log_error "missing command: $cmd"
+    log_error "$hint"
+    exit 1
+  fi
+}
+
+# ── Parse args ────────────────────────────────────────────────────────────
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --bind-code)       need_next_arg "$1" "$#"; BIND_CODE="$2"; shift 2 ;;
+    --bind-nonce)      need_next_arg "$1" "$#"; BIND_NONCE="$2"; shift 2 ;;
+    --server-url)      need_next_arg "$1" "$#"; SERVER_URL="$2"; shift 2 ;;
+    --plugin-version)  need_next_arg "$1" "$#"; PLUGIN_VERSION="$2"; shift 2 ;;
+    --tgz-url)         need_next_arg "$1" "$#"; TGZ_URL="$2"; shift 2 ;;
+    --tgz-path)        need_next_arg "$1" "$#"; TGZ_PATH="$2"; shift 2 ;;
+    --from-source)     need_next_arg "$1" "$#"; FROM_SOURCE_DIR="$2"; shift 2 ;;
+    --target-dir)      need_next_arg "$1" "$#"; TARGET_DIR="$2"; shift 2 ;;
+    --account)         need_next_arg "$1" "$#"; ACCOUNT="$2"; shift 2 ;;
+    --name)            need_next_arg "$1" "$#"; AGENT_NAME="$2"; shift 2 ;;
+    --force-reinstall) FORCE_REINSTALL="true"; shift ;;
+    --skip-plugin-install) SKIP_PLUGIN_INSTALL="true"; shift ;;
+    --skip-restart)    SKIP_RESTART="true"; shift ;;
+    -h|--help)         usage; exit 0 ;;
+    *) log_error "unknown argument: $1"; usage; exit 1 ;;
+  esac
+done
+
+# ── Validate ──────────────────────────────────────────────────────────────
+
+if [ -z "$BIND_CODE" ] || [ -z "$BIND_NONCE" ]; then
+  log_error "--bind-code and --bind-nonce are required"
+  usage
+  exit 1
+fi
+
+case "$BIND_CODE" in bd_*) ;; *) log_error "--bind-code must start with bd_"; exit 1 ;; esac
+
+require_cmd node "Install Node.js >= 18 first (https://nodejs.org)"
+require_cmd curl "Install curl first"
+
+# Reject pathological combinations early.
+SOURCES_SET=0
+[ -n "$TGZ_URL" ]         && SOURCES_SET=$((SOURCES_SET + 1))
+[ -n "$TGZ_PATH" ]        && SOURCES_SET=$((SOURCES_SET + 1))
+[ -n "$FROM_SOURCE_DIR" ] && SOURCES_SET=$((SOURCES_SET + 1))
+if [ "$SOURCES_SET" -gt 1 ]; then
+  log_error "--tgz-url, --tgz-path, --from-source are mutually exclusive"
+  exit 1
+fi
+
+if [ "$SKIP_PLUGIN_INSTALL" != "true" ]; then
+  require_cmd npm "Install npm (ships with Node.js)"
+fi
+
+# ── Step 1: Stage + install plugin ────────────────────────────────────────
+
+if [ "$SKIP_PLUGIN_INSTALL" = "true" ]; then
+  log "skipping plugin install (--skip-plugin-install)"
+elif [ -d "$TARGET_DIR" ] && [ "$FORCE_REINSTALL" != "true" ]; then
+  log "plugin already installed at $TARGET_DIR (use --force-reinstall to replace)"
+else
+  STAGING_DIR="$(mktemp -d "${TMPDIR:-/tmp}/botcord-stage.XXXXXX")"
+  log "staging plugin to $STAGING_DIR"
+
+  if [ -n "$FROM_SOURCE_DIR" ]; then
+    if [ ! -d "$FROM_SOURCE_DIR" ]; then
+      log_error "--from-source dir does not exist: $FROM_SOURCE_DIR"
+      exit 1
+    fi
+    # Pack the source dir to a tarball, then unpack into staging.
+    SRC_TARBALL="$(cd "$FROM_SOURCE_DIR" && npm pack --silent --pack-destination "$STAGING_DIR" 2>>"$RUN_LOG")"
+    tar -xzf "$STAGING_DIR/$SRC_TARBALL" -C "$STAGING_DIR" --strip-components=1
+    rm -f -- "$STAGING_DIR/$SRC_TARBALL"
+  elif [ -n "$TGZ_PATH" ]; then
+    if [ ! -f "$TGZ_PATH" ]; then
+      log_error "--tgz-path file does not exist: $TGZ_PATH"
+      exit 1
+    fi
+    tar -xzf "$TGZ_PATH" -C "$STAGING_DIR" --strip-components=1
+  elif [ -n "$TGZ_URL" ]; then
+    LOCAL_TARBALL="$STAGING_DIR/plugin.tgz"
+    log "downloading $TGZ_URL"
+    curl -fsSL "$TGZ_URL" -o "$LOCAL_TARBALL" 2>>"$RUN_LOG"
+    tar -xzf "$LOCAL_TARBALL" -C "$STAGING_DIR" --strip-components=1
+    rm -f -- "$LOCAL_TARBALL"
+  else
+    # Default: pull from npm.
+    SPEC="$PLUGIN_PACKAGE"
+    [ -n "$PLUGIN_VERSION" ] && SPEC="${PLUGIN_PACKAGE}@${PLUGIN_VERSION}"
+    log "fetching $SPEC from npm registry"
+    REG_TARBALL="$(cd "$STAGING_DIR" && npm pack --silent "$SPEC" 2>>"$RUN_LOG")"
+    tar -xzf "$STAGING_DIR/$REG_TARBALL" -C "$STAGING_DIR" --strip-components=1
+    rm -f -- "$STAGING_DIR/$REG_TARBALL"
+  fi
+
+  log "installing plugin runtime dependencies (npm install --omit=dev --omit=peer)"
+  ( cd "$STAGING_DIR" && npm install --omit=dev --omit=peer --no-audit --no-fund 2>>"$RUN_LOG" >/dev/null ) || {
+    log_error "npm install failed; see $RUN_LOG for details"
+    exit 1
+  }
+
+  mkdir -p -- "$(dirname "$TARGET_DIR")"
+  if [ -d "$TARGET_DIR" ]; then
+    BACKUP_DIR="${TARGET_DIR}.bak.${TS}"
+    log "moving existing $TARGET_DIR → $BACKUP_DIR"
+    mv -- "$TARGET_DIR" "$BACKUP_DIR"
+  fi
+  mv -- "$STAGING_DIR" "$TARGET_DIR"
+  STAGING_DIR=""  # ownership transferred; on_exit shouldn't rm the live install
+  log "plugin installed at $TARGET_DIR"
+fi
+
+# ── Step 2: Generate keypair, sign, claim ────────────────────────────────
+
+log "claiming bind code on $SERVER_URL"
+
+RESULT="$(
+  SERVER_URL="$SERVER_URL" \
+  BIND_CODE="$BIND_CODE" \
+  BIND_NONCE="$BIND_NONCE" \
+  AGENT_NAME="$AGENT_NAME" \
+  node --input-type=module <<'NODE' 2>>"$RUN_LOG"
+import { generateKeyPairSync, createPrivateKey, sign } from "node:crypto";
+import { mkdirSync, writeFileSync, chmodSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const serverUrl = process.env.SERVER_URL.replace(/\/+$/, "");
+const bindCode  = process.env.BIND_CODE;
+const bindNonce = process.env.BIND_NONCE;
+const overrideName = process.env.AGENT_NAME || null;
+
+// 1. Keygen — raw 32-byte Ed25519 seed (matches backend `generate_agent_id`
+//    and protocol-core `generateKeypair`).
+const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+const privDer = privateKey.export({ type: "pkcs8", format: "der" });
+const privB64 = Buffer.from(privDer.subarray(-32)).toString("base64");
+const pubDer  = publicKey.export({ type: "spki",  format: "der" });
+const pubB64  = Buffer.from(pubDer.subarray(-32)).toString("base64");
+const pubkeyFormatted = `ed25519:${pubB64}`;
+
+// 2. Sign nonce — same algorithm as backend `verify_challenge_sig`:
+//    base64-decode challenge, raw Ed25519 sign, base64-encode signature.
+const PKCS8_PREFIX = Buffer.from("302e020100300506032b657004220420", "hex");
+const pk = createPrivateKey({
+  key: Buffer.concat([PKCS8_PREFIX, Buffer.from(privB64, "base64")]),
+  format: "der",
+  type: "pkcs8",
+});
+const sig = sign(null, Buffer.from(bindNonce, "base64"), pk).toString("base64");
+
+// 3. POST install-claim
+const claimUrl = `${serverUrl}/api/users/me/agents/install-claim`;
+const body = {
+  bind_code: bindCode,
+  pubkey: pubkeyFormatted,
+  proof: { nonce: bindNonce, sig },
+};
+if (overrideName) body.name = overrideName;
+
+const resp = await fetch(claimUrl, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify(body),
+  signal: AbortSignal.timeout(20000),
+});
+
+if (!resp.ok) {
+  const text = await resp.text().catch(() => "");
+  process.stderr.write(`install-claim failed (${resp.status}): ${text}\n`);
+  process.exit(1);
+}
+const data = await resp.json();
+
+// 4. Write credentials.json (chmod 600). Matches the format used by
+//    botcord-register.sh and read by the plugin.
+const agentId = data.agent_id;
+const credDir = join(homedir(), ".botcord", "credentials");
+mkdirSync(credDir, { recursive: true, mode: 0o700 });
+const credPath = join(credDir, `${agentId}.json`);
+const hubUrl   = data.hub_url || serverUrl;
+const credentials = {
+  version: 1,
+  hubUrl,
+  agentId,
+  keyId: data.key_id,
+  privateKey: privB64,
+  publicKey: pubB64,
+  displayName: data.display_name || agentId,
+  savedAt: new Date().toISOString(),
+  token: data.agent_token || undefined,
+  tokenExpiresAt: data.token_expires_at ?? undefined,
+};
+writeFileSync(credPath, JSON.stringify(credentials, null, 2) + "\n", { encoding: "utf8", mode: 0o600 });
+chmodSync(credPath, 0o600);
+
+process.stdout.write(JSON.stringify({
+  agentId,
+  keyId: data.key_id,
+  displayName: credentials.displayName,
+  hubUrl,
+  wsUrl: data.ws_url || null,
+  credentialsFile: credPath,
+}));
+NODE
+)" || {
+  log_error "claim step failed (bind code may be expired, already used, or the server rejected the proof)"
+  exit 1
+}
+
+if [ -z "$RESULT" ]; then
+  log_error "claim step returned no output; nothing was written"
+  exit 1
+fi
+
+AGENT_ID="$(printf '%s' "$RESULT"      | node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync(0,"utf8")).agentId)')"
+KEY_ID="$(printf '%s' "$RESULT"        | node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync(0,"utf8")).keyId)')"
+DISPLAY_NAME="$(printf '%s' "$RESULT"  | node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync(0,"utf8")).displayName || "")')"
+HUB_URL_OUT="$(printf '%s' "$RESULT"   | node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync(0,"utf8")).hubUrl || "")')"
+WS_URL_OUT="$(printf '%s' "$RESULT"    | node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync(0,"utf8")).wsUrl || "")')"
+CRED_FILE="$(printf '%s' "$RESULT"     | node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync(0,"utf8")).credentialsFile)')"
+
+log_quiet "claimed agent_id=$AGENT_ID key_id=$KEY_ID hub=$HUB_URL_OUT"
+log "agent claimed:"
+log "  Agent ID:    $AGENT_ID"
+log "  Display:     $DISPLAY_NAME"
+log "  Key ID:      $KEY_ID"
+log "  Credentials: $CRED_FILE"
+
+# ── Step 3: Configure openclaw.json ──────────────────────────────────────
+
+# Account-namespaced keys when --account is supplied; otherwise global keys.
+if [ -n "$ACCOUNT" ]; then
+  CFG_ENABLED_KEY="channels.botcord.accounts.${ACCOUNT}.enabled"
+  CFG_CRED_KEY="channels.botcord.accounts.${ACCOUNT}.credentialsFile"
+  CFG_DELIVERY_KEY="channels.botcord.accounts.${ACCOUNT}.deliveryMode"
+else
+  CFG_ENABLED_KEY="channels.botcord.enabled"
+  CFG_CRED_KEY="channels.botcord.credentialsFile"
+  CFG_DELIVERY_KEY="channels.botcord.deliveryMode"
+fi
+
+configure_via_cli() {
+  command -v "$OPENCLAW_BIN" >/dev/null 2>&1 || return 1
+  "$OPENCLAW_BIN" config set "$CFG_ENABLED_KEY"  --json "true"        >>"$RUN_LOG" 2>&1 || return 1
+  "$OPENCLAW_BIN" config set "$CFG_CRED_KEY"             "$CRED_FILE" >>"$RUN_LOG" 2>&1 || return 1
+  "$OPENCLAW_BIN" config set "$CFG_DELIVERY_KEY"         "websocket"  >>"$RUN_LOG" 2>&1 || return 1
+  return 0
+}
+
+configure_via_file() {
+  local path="$1"
+  CRED_FILE="$CRED_FILE" \
+  CFG_PATH="$path" \
+  CFG_ACCOUNT="$ACCOUNT" \
+  node --input-type=module <<'NODE' 2>>"$RUN_LOG"
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
+const path = process.env.CFG_PATH;
+const credFile = process.env.CRED_FILE;
+const account = process.env.CFG_ACCOUNT || "";
+
+let cfg = {};
+try { cfg = JSON.parse(readFileSync(path, "utf8")); } catch {}
+if (!cfg.channels) cfg.channels = {};
+if (!cfg.channels.botcord) cfg.channels.botcord = {};
+
+if (account) {
+  if (!cfg.channels.botcord.accounts) cfg.channels.botcord.accounts = {};
+  cfg.channels.botcord.accounts[account] = {
+    ...(cfg.channels.botcord.accounts[account] || {}),
+    enabled: true,
+    credentialsFile: credFile,
+    deliveryMode: cfg.channels.botcord.accounts[account]?.deliveryMode || "websocket",
+  };
+} else {
+  cfg.channels.botcord = {
+    ...cfg.channels.botcord,
+    enabled: true,
+    credentialsFile: credFile,
+    deliveryMode: cfg.channels.botcord.deliveryMode || "websocket",
+  };
+}
+
+mkdirSync(dirname(path), { recursive: true });
+writeFileSync(path, JSON.stringify(cfg, null, 2) + "\n");
+NODE
+}
+
+CONFIG_OK="false"
+if [ -n "$OPENCLAW_CONFIG_PATH" ]; then
+  if configure_via_file "$OPENCLAW_CONFIG_PATH"; then
+    CONFIG_OK="true"
+    log "openclaw config patched: $OPENCLAW_CONFIG_PATH"
+  fi
+elif configure_via_cli; then
+  CONFIG_OK="true"
+  log "openclaw config updated via CLI"
+elif configure_via_file "$HOME/.openclaw/openclaw.json"; then
+  CONFIG_OK="true"
+  log "openclaw config patched: $HOME/.openclaw/openclaw.json"
+fi
+
+if [ "$CONFIG_OK" != "true" ]; then
+  log_warn "could not configure openclaw automatically; add manually to openclaw.json:"
+  log_warn "  channels.botcord.enabled = true"
+  log_warn "  channels.botcord.credentialsFile = $CRED_FILE"
+  log_warn "  channels.botcord.deliveryMode = websocket"
+fi
+
+# ── Step 4: Restart gateway ───────────────────────────────────────────────
+
+if [ "$SKIP_RESTART" = "true" ]; then
+  log "skipping gateway restart (--skip-restart); restart it manually for the plugin to load"
+elif command -v "$OPENCLAW_BIN" >/dev/null 2>&1; then
+  log "restarting OpenClaw gateway"
+  RESTART_OUT="$("$OPENCLAW_BIN" gateway restart 2>&1 || true)"
+  printf '%s\n' "$RESTART_OUT" >> "$RUN_LOG"
+  if printf '%s' "$RESTART_OUT" | grep -qi "no service manager\|not running as a service"; then
+    log_warn "OpenClaw is not running as a managed service."
+    log_warn "If you're running it in Docker, restart the container, e.g.:"
+    log_warn "  docker restart openclaw-openclaw-gateway-1"
+  fi
+else
+  log_warn "openclaw CLI not found; restart the gateway yourself for the plugin to pick up the new config"
+fi
+
+# ── Done ──────────────────────────────────────────────────────────────────
+
+log ""
+log "All done. The dashboard polling page should pick up agent $AGENT_ID shortly."
+log "完成！返回浏览器，仪表盘会自动跳转到这个 agent 的管理页。"
+log ""

--- a/backend/tests/test_app/test_install_claim.py
+++ b/backend/tests/test_app/test_install_claim.py
@@ -1,0 +1,504 @@
+"""Tests for the bind-code install onboarding flow.
+
+Covers:
+- POST /api/users/me/agents/bind-ticket  (extended response)
+- GET  /api/users/me/agents/bind-ticket/{code}
+- DELETE /api/users/me/agents/bind-ticket/{code}
+- POST /api/users/me/agents/install-claim  (no-JWT redemption)
+- GET  /openclaw/install.sh
+"""
+
+from __future__ import annotations
+
+import base64
+import datetime
+import json
+import os
+import uuid
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from nacl.signing import SigningKey as NaClSigningKey
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from hub.id_generators import generate_agent_id
+from hub.models import Agent, Base, Role, ShortCode, SigningKey, User, UserRole
+
+from .test_app_user_agents import (
+    TEST_JWT_SECRET,
+    TEST_SUPABASE_SECRET,
+    _make_supabase_token,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (parallel structure to test_app_user_agents.py — kept local so the
+# install onboarding suite can evolve independently).
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def db_engine():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        execution_options={"schema_translate_map": {"public": None}},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield engine
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def db_session(db_engine):
+    factory = async_sessionmaker(db_engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+
+
+@pytest_asyncio.fixture
+async def client(db_session: AsyncSession, db_engine, monkeypatch):
+    import hub.config
+    import app.auth
+    import app.routers.users as users_mod
+
+    monkeypatch.setattr(hub.config, "SUPABASE_JWT_SECRET", TEST_SUPABASE_SECRET)
+    monkeypatch.setattr(app.auth, "SUPABASE_JWT_SECRET", TEST_SUPABASE_SECRET)
+    monkeypatch.setattr(users_mod, "BIND_PROOF_SECRET", None)
+    monkeypatch.setattr(users_mod, "JWT_SECRET", TEST_JWT_SECRET)
+    monkeypatch.setattr(hub.config, "BIND_PROOF_SECRET", None)
+    monkeypatch.setattr(hub.config, "JWT_SECRET", TEST_JWT_SECRET)
+
+    from hub.main import app
+    from hub.database import get_db
+
+    async def _override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    factory = async_sessionmaker(db_engine, class_=AsyncSession, expire_on_commit=False)
+    monkeypatch.setattr(users_mod, "_jti_session_factory", factory)
+    monkeypatch.setattr(users_mod, "_short_code_session_factory", factory)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def fresh_user(db_session: AsyncSession):
+    """User with no agents, agent_owner role registered."""
+    supabase_uuid = uuid.uuid4()
+    user_id = uuid.uuid4()
+
+    user = User(
+        id=user_id,
+        display_name="Install User",
+        email="install@example.com",
+        status="active",
+        supabase_user_id=supabase_uuid,
+        max_agents=5,
+    )
+    db_session.add(user)
+
+    member_role = Role(
+        id=uuid.uuid4(), name="member", display_name="Member", is_system=True, priority=0
+    )
+    owner_role = Role(
+        id=uuid.uuid4(),
+        name="agent_owner",
+        display_name="Agent Owner",
+        is_system=True,
+        priority=0,
+    )
+    db_session.add_all([member_role, owner_role])
+    await db_session.flush()
+    db_session.add(UserRole(id=uuid.uuid4(), user_id=user_id, role_id=member_role.id))
+    await db_session.commit()
+
+    return {
+        "user": user,
+        "user_id": user_id,
+        "supabase_uid": str(supabase_uuid),
+        "token": _make_supabase_token(str(supabase_uuid)),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _gen_keypair() -> tuple[str, str, str]:
+    """Return (pubkey_b64, formatted_pubkey, signing_key)."""
+    sk = NaClSigningKey.generate()
+    pubkey_raw = bytes(sk.verify_key)
+    pubkey_b64 = base64.b64encode(pubkey_raw).decode()
+    return pubkey_b64, f"ed25519:{pubkey_b64}", sk
+
+
+def _sign_nonce(sk: NaClSigningKey, nonce_b64: str) -> str:
+    nonce_bytes = base64.b64decode(nonce_b64)
+    sig = sk.sign(nonce_bytes).signature
+    return base64.b64encode(sig).decode()
+
+
+async def _issue_bind_code(
+    client: AsyncClient, token: str, intended_name: str | None = None
+) -> dict:
+    body: dict = {}
+    if intended_name is not None:
+        body["intended_name"] = intended_name
+    resp = await client.post(
+        "/api/users/me/agents/bind-ticket",
+        headers={"Authorization": f"Bearer {token}"},
+        json=body,
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Bind ticket: response shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bind_ticket_response_includes_install_command(
+    client: AsyncClient, fresh_user: dict
+):
+    data = await _issue_bind_code(client, fresh_user["token"], intended_name="my-bot")
+    assert data["bind_code"].startswith("bd_")
+    assert data["intended_name"] == "my-bot"
+    assert data["install_command"].startswith("curl -fsSL ")
+    assert f"--bind-code {data['bind_code']}" in data["install_command"]
+    assert f"--bind-nonce {data['nonce']}" in data["install_command"]
+    # Nonce should be a base64-encoded 32-byte value (Ed25519 challenge).
+    raw = base64.b64decode(data["nonce"])
+    assert len(raw) == 32
+
+    payload_json = base64.urlsafe_b64decode(data["bind_ticket"].split(".")[0]).decode()
+    payload = json.loads(payload_json)
+    assert payload["purpose"] == "install_claim"
+    assert payload["intended_name"] == "my-bot"
+
+
+@pytest.mark.asyncio
+async def test_bind_ticket_active_cap_enforced(
+    client: AsyncClient, fresh_user: dict, monkeypatch
+):
+    import app.routers.users as users_mod
+
+    monkeypatch.setattr(users_mod, "MAX_ACTIVE_BIND_CODES_PER_USER", 2)
+    token = fresh_user["token"]
+    await _issue_bind_code(client, token)
+    await _issue_bind_code(client, token)
+    resp = await client.post(
+        "/api/users/me/agents/bind-ticket",
+        headers={"Authorization": f"Bearer {token}"},
+        json={},
+    )
+    assert resp.status_code == 429
+
+
+# ---------------------------------------------------------------------------
+# Bind ticket: status / revoke
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bind_ticket_status_pending(client: AsyncClient, fresh_user: dict):
+    data = await _issue_bind_code(client, fresh_user["token"])
+    resp = await client.get(
+        f"/api/users/me/agents/bind-ticket/{data['bind_code']}",
+        headers={"Authorization": f"Bearer {fresh_user['token']}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "pending"
+    assert body["agent_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_bind_ticket_status_other_user_404(
+    client: AsyncClient, fresh_user: dict, db_session: AsyncSession
+):
+    data = await _issue_bind_code(client, fresh_user["token"])
+
+    # Create a second user and use their token.
+    other_uuid = uuid.uuid4()
+    other = User(
+        id=uuid.uuid4(),
+        display_name="Other",
+        email="other@example.com",
+        status="active",
+        supabase_user_id=other_uuid,
+        max_agents=1,
+    )
+    db_session.add(other)
+    await db_session.commit()
+    other_token = _make_supabase_token(str(other_uuid))
+
+    resp = await client.get(
+        f"/api/users/me/agents/bind-ticket/{data['bind_code']}",
+        headers={"Authorization": f"Bearer {other_token}"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_bind_ticket_revoke_then_status_404(client: AsyncClient, fresh_user: dict):
+    data = await _issue_bind_code(client, fresh_user["token"])
+    resp = await client.delete(
+        f"/api/users/me/agents/bind-ticket/{data['bind_code']}",
+        headers={"Authorization": f"Bearer {fresh_user['token']}"},
+    )
+    assert resp.status_code == 200
+
+    # Revoking again (or revoking nonexistent) returns 404.
+    resp = await client.delete(
+        f"/api/users/me/agents/bind-ticket/{data['bind_code']}",
+        headers={"Authorization": f"Bearer {fresh_user['token']}"},
+    )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# install-claim: happy path + error paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_install_claim_happy_path(
+    client: AsyncClient, fresh_user: dict, db_session: AsyncSession
+):
+    data = await _issue_bind_code(client, fresh_user["token"], intended_name="laptop-bot")
+    pubkey_b64, pubkey_formatted, sk = _gen_keypair()
+    sig = _sign_nonce(sk, data["nonce"])
+
+    resp = await client.post(
+        "/api/users/me/agents/install-claim",
+        json={
+            "bind_code": data["bind_code"],
+            "pubkey": pubkey_formatted,
+            "proof": {"nonce": data["nonce"], "sig": sig},
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    expected_agent_id = generate_agent_id(pubkey_b64)
+    assert body["agent_id"] == expected_agent_id
+    assert body["key_id"].startswith("k_")
+    assert body["agent_token"]
+    assert body["display_name"] == "laptop-bot"
+    assert body["hub_url"].startswith("http")
+    assert body["ws_url"].startswith("ws")
+
+    # Owner polling now reports claimed.
+    poll = await client.get(
+        f"/api/users/me/agents/bind-ticket/{data['bind_code']}",
+        headers={"Authorization": f"Bearer {fresh_user['token']}"},
+    )
+    assert poll.status_code == 200
+    assert poll.json()["status"] == "claimed"
+    assert poll.json()["agent_id"] == expected_agent_id
+
+    # Agent + active SigningKey rows persisted, bound to the user.
+    agent_row = (
+        await db_session.execute(select(Agent).where(Agent.agent_id == expected_agent_id))
+    ).scalar_one()
+    assert str(agent_row.user_id) == str(fresh_user["user_id"])
+    assert agent_row.is_default is True
+
+    key_row = (
+        await db_session.execute(select(SigningKey).where(SigningKey.agent_id == expected_agent_id))
+    ).scalar_one()
+    assert key_row.pubkey == pubkey_formatted
+
+    # ShortCode marked consumed with claimed_agent_id payload.
+    sc_row = (
+        await db_session.execute(select(ShortCode).where(ShortCode.code == data["bind_code"]))
+    ).scalar_one()
+    assert sc_row.consumed_at is not None
+    assert json.loads(sc_row.payload_json)["claimed_agent_id"] == expected_agent_id
+
+
+@pytest.mark.asyncio
+async def test_install_claim_replay_rejected(client: AsyncClient, fresh_user: dict):
+    data = await _issue_bind_code(client, fresh_user["token"])
+    pubkey_b64, pubkey_formatted, sk = _gen_keypair()
+    sig = _sign_nonce(sk, data["nonce"])
+
+    body = {
+        "bind_code": data["bind_code"],
+        "pubkey": pubkey_formatted,
+        "proof": {"nonce": data["nonce"], "sig": sig},
+    }
+    first = await client.post("/api/users/me/agents/install-claim", json=body)
+    assert first.status_code == 201
+
+    second = await client.post("/api/users/me/agents/install-claim", json=body)
+    assert second.status_code in (400, 409)
+    assert second.json()["detail"] in ("INVALID_BIND_CODE", "PUBKEY_ALREADY_REGISTERED")
+
+
+@pytest.mark.asyncio
+async def test_install_claim_unknown_code(client: AsyncClient, fresh_user: dict):
+    pubkey_b64, pubkey_formatted, sk = _gen_keypair()
+    nonce = base64.b64encode(os.urandom(32)).decode()
+    sig = _sign_nonce(sk, nonce)
+
+    resp = await client.post(
+        "/api/users/me/agents/install-claim",
+        json={
+            "bind_code": "bd_doesnotexist",
+            "pubkey": pubkey_formatted,
+            "proof": {"nonce": nonce, "sig": sig},
+        },
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "INVALID_BIND_CODE"
+
+
+@pytest.mark.asyncio
+async def test_install_claim_bad_proof_nonce_mismatch(
+    client: AsyncClient, fresh_user: dict
+):
+    data = await _issue_bind_code(client, fresh_user["token"])
+    pubkey_b64, pubkey_formatted, sk = _gen_keypair()
+    other_nonce = base64.b64encode(os.urandom(32)).decode()
+    sig = _sign_nonce(sk, other_nonce)
+
+    resp = await client.post(
+        "/api/users/me/agents/install-claim",
+        json={
+            "bind_code": data["bind_code"],
+            "pubkey": pubkey_formatted,
+            "proof": {"nonce": other_nonce, "sig": sig},
+        },
+    )
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "INVALID_PROOF"
+
+
+@pytest.mark.asyncio
+async def test_install_claim_bad_signature(client: AsyncClient, fresh_user: dict):
+    data = await _issue_bind_code(client, fresh_user["token"])
+    pubkey_b64, pubkey_formatted, _sk = _gen_keypair()
+    # Sign with a different key, then submit alongside the claimed pubkey.
+    other_sk = NaClSigningKey.generate()
+    bad_sig = _sign_nonce(other_sk, data["nonce"])
+
+    resp = await client.post(
+        "/api/users/me/agents/install-claim",
+        json={
+            "bind_code": data["bind_code"],
+            "pubkey": pubkey_formatted,
+            "proof": {"nonce": data["nonce"], "sig": bad_sig},
+        },
+    )
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "INVALID_PROOF"
+
+
+@pytest.mark.asyncio
+async def test_install_claim_invalid_pubkey(client: AsyncClient, fresh_user: dict):
+    data = await _issue_bind_code(client, fresh_user["token"])
+    resp = await client.post(
+        "/api/users/me/agents/install-claim",
+        json={
+            "bind_code": data["bind_code"],
+            "pubkey": "not-a-real-pubkey",
+            "proof": {"nonce": data["nonce"], "sig": "AAAA"},
+        },
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "INVALID_PUBKEY"
+
+
+@pytest.mark.asyncio
+async def test_install_claim_pubkey_already_registered(
+    client: AsyncClient, fresh_user: dict, db_session: AsyncSession
+):
+    pubkey_b64, pubkey_formatted, sk = _gen_keypair()
+
+    # Pre-seed an Agent + SigningKey for this pubkey, simulating a prior claim.
+    existing_agent_id = generate_agent_id(pubkey_b64)
+    db_session.add(
+        Agent(
+            agent_id=existing_agent_id,
+            display_name="Pre-existing",
+            user_id=fresh_user["user_id"],
+            claimed_at=datetime.datetime.now(datetime.timezone.utc),
+        )
+    )
+    from hub.enums import KeyState
+
+    db_session.add(
+        SigningKey(
+            agent_id=existing_agent_id,
+            key_id="k_existing0001",
+            pubkey=pubkey_formatted,
+            state=KeyState.active,
+        )
+    )
+    await db_session.commit()
+
+    data = await _issue_bind_code(client, fresh_user["token"])
+    sig = _sign_nonce(sk, data["nonce"])
+
+    resp = await client.post(
+        "/api/users/me/agents/install-claim",
+        json={
+            "bind_code": data["bind_code"],
+            "pubkey": pubkey_formatted,
+            "proof": {"nonce": data["nonce"], "sig": sig},
+        },
+    )
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "PUBKEY_ALREADY_REGISTERED"
+
+
+@pytest.mark.asyncio
+async def test_install_claim_revoked_code(client: AsyncClient, fresh_user: dict):
+    data = await _issue_bind_code(client, fresh_user["token"])
+    revoke = await client.delete(
+        f"/api/users/me/agents/bind-ticket/{data['bind_code']}",
+        headers={"Authorization": f"Bearer {fresh_user['token']}"},
+    )
+    assert revoke.status_code == 200
+
+    pubkey_b64, pubkey_formatted, sk = _gen_keypair()
+    sig = _sign_nonce(sk, data["nonce"])
+    resp = await client.post(
+        "/api/users/me/agents/install-claim",
+        json={
+            "bind_code": data["bind_code"],
+            "pubkey": pubkey_formatted,
+            "proof": {"nonce": data["nonce"], "sig": sig},
+        },
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "INVALID_BIND_CODE"
+
+
+# ---------------------------------------------------------------------------
+# /openclaw/install.sh
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_install_script_served(client: AsyncClient):
+    resp = await client.get("/openclaw/install.sh")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/x-sh") or resp.headers["content-type"].startswith("application/")
+    assert "BotCord" in resp.text

--- a/backend/tests/test_app/test_install_claim.py
+++ b/backend/tests/test_app/test_install_claim.py
@@ -271,6 +271,18 @@ async def test_bind_ticket_revoke_then_status_404(client: AsyncClient, fresh_use
     )
     assert resp.status_code == 404
 
+    # Status of a revoked code reports "revoked" (not "claimed") so the
+    # frontend stops polling and never tries to navigate to an agent_id
+    # that does not exist.
+    status_resp = await client.get(
+        f"/api/users/me/agents/bind-ticket/{data['bind_code']}",
+        headers={"Authorization": f"Bearer {fresh_user['token']}"},
+    )
+    assert status_resp.status_code == 200
+    body = status_resp.json()
+    assert body["status"] == "revoked"
+    assert body["agent_id"] is None
+
 
 # ---------------------------------------------------------------------------
 # install-claim: happy path + error paths

--- a/backend/tests/test_app/test_install_claim.py
+++ b/backend/tests/test_app/test_install_claim.py
@@ -345,6 +345,53 @@ async def test_install_claim_happy_path(
 
 
 @pytest.mark.asyncio
+async def test_install_claim_consume_atomically_records_agent_id(
+    client: AsyncClient, fresh_user: dict, db_session: AsyncSession
+):
+    """Regression: short_code.payload_json must contain claimed_agent_id
+    by the time the consume row flips to consumed_at, so polling never
+    observes a "consumed but no agent" state and reports it as revoked.
+    """
+    data = await _issue_bind_code(client, fresh_user["token"])
+    pubkey_b64, pubkey_formatted, sk = _gen_keypair()
+    sig = _sign_nonce(sk, data["nonce"])
+
+    resp = await client.post(
+        "/api/users/me/agents/install-claim",
+        json={
+            "bind_code": data["bind_code"],
+            "pubkey": pubkey_formatted,
+            "proof": {"nonce": data["nonce"], "sig": sig},
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    expected_agent_id = generate_agent_id(pubkey_b64)
+
+    # Inspect the row directly: consumed_at must be non-null AND
+    # payload_json must already include claimed_agent_id. There must
+    # never be a window where the first is true but the second isn't.
+    sc_row = (
+        await db_session.execute(
+            select(ShortCode).where(ShortCode.code == data["bind_code"])
+        )
+    ).scalar_one()
+    assert sc_row.consumed_at is not None
+    payload = json.loads(sc_row.payload_json)
+    assert payload["claimed_agent_id"] == expected_agent_id
+    assert "claimed_at" in payload
+
+    # And the polling endpoint reports "claimed" (not "revoked").
+    poll = await client.get(
+        f"/api/users/me/agents/bind-ticket/{data['bind_code']}",
+        headers={"Authorization": f"Bearer {fresh_user['token']}"},
+    )
+    assert poll.status_code == 200
+    body = poll.json()
+    assert body["status"] == "claimed"
+    assert body["agent_id"] == expected_agent_id
+
+
+@pytest.mark.asyncio
 async def test_install_claim_replay_rejected(client: AsyncClient, fresh_user: dict):
     data = await _issue_bind_code(client, fresh_user["token"])
     pubkey_b64, pubkey_formatted, sk = _gen_keypair()

--- a/backend/tests/test_app/test_install_script.py
+++ b/backend/tests/test_app/test_install_script.py
@@ -285,6 +285,82 @@ def test_install_sh_server_rejects_bind_code(stub_server, tmp_path: Path):
     assert not config_path.exists()
 
 
+def test_install_sh_claim_failure_preserves_existing_plugin(
+    stub_server, tmp_path: Path
+):
+    """A 400 from install-claim must not displace the user's existing plugin.
+
+    Reproduces the scenario flagged in code review: previously the script
+    swapped staging into TARGET_DIR before calling claim, so an expired
+    bind code would leave the live install pointing at a fresh checkout
+    with no credentials. Now the swap only happens after claim succeeds.
+    """
+    state = stub_server["state"]
+    state.response_status = 400
+    state.response_body = {"detail": "INVALID_BIND_CODE", "error": "INVALID_BIND_CODE"}
+
+    home = tmp_path / "home"
+    home.mkdir()
+    config_path = tmp_path / "openclaw.json"
+
+    target_dir = home / ".openclaw" / "extensions" / "botcord"
+    target_dir.mkdir(parents=True)
+    sentinel = target_dir / "package.json"
+    sentinel.write_text('{"name": "@botcord/botcord", "version": "previous"}\n')
+
+    # Need to actually exercise the npm-install/swap path, which means we
+    # must NOT pass --skip-plugin-install. But we don't want to hit the
+    # real npm registry, so feed it an empty tarball via --tgz-path.
+    fake_pkg = tmp_path / "fake-pkg"
+    (fake_pkg / "package").mkdir(parents=True)
+    (fake_pkg / "package" / "package.json").write_text(
+        '{"name": "@botcord/botcord", "version": "0.0.0-test"}\n'
+    )
+    fake_tgz = tmp_path / "fake.tgz"
+    subprocess.run(
+        ["tar", "-czf", str(fake_tgz), "-C", str(fake_pkg), "package"], check=True
+    )
+
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "TMPDIR": str(home / "tmp"),
+        "OPENCLAW_BIN": "/bin/false",
+        "OPENCLAW_CONFIG_PATH": str(config_path),
+    }
+    (home / "tmp").mkdir(parents=True, exist_ok=True)
+    proc = subprocess.run(
+        [
+            "bash",
+            str(INSTALL_SH),
+            "--bind-code", "bd_expired00001",
+            "--bind-nonce", base64.b64encode(os.urandom(32)).decode(),
+            "--server-url", stub_server["url"],
+            "--tgz-path", str(fake_tgz),
+            "--force-reinstall",
+            "--target-dir", str(target_dir),
+            "--skip-restart",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert proc.returncode != 0, "expected non-zero exit on rejected bind code"
+
+    # Live plugin must still be the one we started with.
+    assert sentinel.is_file(), "previous plugin install was destroyed"
+    assert "previous" in sentinel.read_text()
+
+    # No backup should have been created since we never swapped.
+    backups = list(target_dir.parent.glob("botcord.bak.*"))
+    assert backups == [], f"unexpected backup created: {backups}"
+
+    # And nothing should have been written to credentials/config either.
+    creds_dir = home / ".botcord" / "credentials"
+    assert not creds_dir.exists() or not any(creds_dir.iterdir())
+    assert not config_path.exists()
+
+
 def test_install_sh_passes_intended_name_override(stub_server, tmp_path: Path):
     state = stub_server["state"]
     state.response_status = 201

--- a/backend/tests/test_app/test_install_script.py
+++ b/backend/tests/test_app/test_install_script.py
@@ -1,0 +1,306 @@
+"""Smoke + integration tests for backend/static/openclaw/install.sh.
+
+The script itself is bash + an embedded Node.js block that talks to the
+hub. We don't run the full hub here (Phase 1 covers that); instead we
+stand up a stub HTTP server that mimics ``/api/users/me/agents/install-claim``
+and assert the script's *client-side* behaviour:
+
+- argument parsing
+- Ed25519 keygen + nonce signing
+- request body shape sent to the server
+- credentials.json contents and 0600 mode
+- openclaw.json patch shape (with and without --account)
+
+Skipped when ``node`` is not on PATH.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import shutil
+import socket
+import subprocess
+import threading
+import uuid
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+INSTALL_SH = Path(__file__).resolve().parents[2] / "static" / "openclaw" / "install.sh"
+
+
+# ---------------------------------------------------------------------------
+# Bash-only sanity checks (always run)
+# ---------------------------------------------------------------------------
+
+
+def test_install_sh_syntax_ok():
+    assert INSTALL_SH.is_file(), f"missing {INSTALL_SH}"
+    proc = subprocess.run(
+        ["bash", "-n", str(INSTALL_SH)], capture_output=True, text=True
+    )
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_install_sh_help_exits_zero():
+    proc = subprocess.run(
+        ["bash", str(INSTALL_SH), "--help"], capture_output=True, text=True
+    )
+    assert proc.returncode == 0
+    assert "--bind-code" in proc.stdout
+    assert "--bind-nonce" in proc.stdout
+
+
+def test_install_sh_missing_args_exits_nonzero(tmp_path: Path):
+    proc = subprocess.run(
+        ["bash", str(INSTALL_SH)],
+        capture_output=True,
+        text=True,
+        env={"HOME": str(tmp_path), "PATH": os.environ["PATH"]},
+    )
+    assert proc.returncode != 0
+    assert "--bind-code" in proc.stderr or "--bind-code" in proc.stdout
+
+
+# ---------------------------------------------------------------------------
+# Stub server fixture
+# ---------------------------------------------------------------------------
+
+
+class _StubServerState:
+    last_path: str | None = None
+    last_method: str | None = None
+    last_body: dict | None = None
+    response_body: dict
+    response_status: int
+
+
+def _make_stub_handler(state: _StubServerState):
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *args, **kwargs):  # silence
+            pass
+
+        def do_POST(self):
+            length = int(self.headers.get("content-length", "0") or "0")
+            raw = self.rfile.read(length) if length else b""
+            try:
+                state.last_body = json.loads(raw.decode()) if raw else {}
+            except json.JSONDecodeError:
+                state.last_body = {"_raw": raw.decode("utf-8", "replace")}
+            state.last_path = self.path
+            state.last_method = "POST"
+
+            payload = json.dumps(state.response_body).encode()
+            self.send_response(state.response_status)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+    return Handler
+
+
+@pytest.fixture
+def stub_server():
+    if shutil.which("node") is None:
+        pytest.skip("node not available")
+    state = _StubServerState()
+    state.response_status = 201
+    state.response_body = {}
+
+    # Bind to an OS-assigned free port on localhost.
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+
+    server = HTTPServer(("127.0.0.1", port), _make_stub_handler(state))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield {"state": state, "url": f"http://127.0.0.1:{port}", "port": port}
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+# ---------------------------------------------------------------------------
+# Full client-side flow (skip plugin install + restart so we don't need
+# npm registry access, openclaw, or a real HOME).
+# ---------------------------------------------------------------------------
+
+
+def _sample_claim_response(agent_id: str = "ag_stub00000001") -> dict:
+    return {
+        "agent_id": agent_id,
+        "key_id": "k_stubkey00001",
+        "agent_token": "stub.jwt.token",
+        "token_expires_at": 1900000000,
+        "hub_url": "https://hub.example",
+        "ws_url": "wss://hub.example/ws",
+        "display_name": "Stub Agent",
+    }
+
+
+def _run_install_sh(
+    *,
+    server_url: str,
+    bind_code: str,
+    bind_nonce: str,
+    home: Path,
+    config_path: Path,
+    extra: list[str] | None = None,
+) -> subprocess.CompletedProcess:
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "TMPDIR": str(home / "tmp"),
+        "OPENCLAW_BIN": "/bin/false",  # force file-based config path
+        "OPENCLAW_CONFIG_PATH": str(config_path),
+    }
+    (home / "tmp").mkdir(parents=True, exist_ok=True)
+    args = [
+        "bash",
+        str(INSTALL_SH),
+        "--bind-code", bind_code,
+        "--bind-nonce", bind_nonce,
+        "--server-url", server_url,
+        "--skip-plugin-install",
+        "--skip-restart",
+    ]
+    if extra:
+        args.extend(extra)
+    return subprocess.run(args, capture_output=True, text=True, env=env)
+
+
+def test_install_sh_happy_path_writes_credentials_and_config(
+    stub_server, tmp_path: Path
+):
+    state = stub_server["state"]
+    state.response_status = 201
+    state.response_body = _sample_claim_response()
+
+    bind_code = "bd_" + uuid.uuid4().hex[:12]
+    bind_nonce = base64.b64encode(os.urandom(32)).decode()
+    home = tmp_path / "home"
+    home.mkdir()
+    config_path = tmp_path / "openclaw" / "openclaw.json"
+
+    proc = _run_install_sh(
+        server_url=stub_server["url"],
+        bind_code=bind_code,
+        bind_nonce=bind_nonce,
+        home=home,
+        config_path=config_path,
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr}"
+
+    # 1. The script hit the right endpoint with the expected request shape.
+    assert state.last_path == "/api/users/me/agents/install-claim"
+    body = state.last_body
+    assert body is not None
+    assert body["bind_code"] == bind_code
+    assert body["pubkey"].startswith("ed25519:")
+    assert body["proof"]["nonce"] == bind_nonce
+    # Signature is base64; decoded length is 64 bytes for Ed25519.
+    sig_raw = base64.b64decode(body["proof"]["sig"])
+    assert len(sig_raw) == 64
+
+    # 2. Credentials file written, mode 0600, with all expected fields.
+    cred_path = home / ".botcord" / "credentials" / "ag_stub00000001.json"
+    assert cred_path.is_file()
+    mode = cred_path.stat().st_mode & 0o777
+    assert mode == 0o600, f"expected 0600, got {oct(mode)}"
+
+    cred = json.loads(cred_path.read_text())
+    assert cred["agentId"] == "ag_stub00000001"
+    assert cred["keyId"] == "k_stubkey00001"
+    assert cred["hubUrl"] == "https://hub.example"
+    assert cred["token"] == "stub.jwt.token"
+    assert cred["displayName"] == "Stub Agent"
+    # Private key must be a 32-byte base64-encoded Ed25519 seed.
+    assert len(base64.b64decode(cred["privateKey"])) == 32
+    # And it must derive the pubkey we sent to the server.
+    assert f"ed25519:{cred['publicKey']}" == body["pubkey"]
+
+    # 3. openclaw.json patched with channels.botcord.* keys.
+    cfg = json.loads(config_path.read_text())
+    botcord_cfg = cfg["channels"]["botcord"]
+    assert botcord_cfg["enabled"] is True
+    assert botcord_cfg["credentialsFile"] == str(cred_path)
+    assert botcord_cfg["deliveryMode"] == "websocket"
+
+
+def test_install_sh_account_namespacing(stub_server, tmp_path: Path):
+    state = stub_server["state"]
+    state.response_status = 201
+    state.response_body = _sample_claim_response("ag_acct000000002")
+
+    home = tmp_path / "home"
+    home.mkdir()
+    config_path = tmp_path / "openclaw.json"
+
+    proc = _run_install_sh(
+        server_url=stub_server["url"],
+        bind_code="bd_" + uuid.uuid4().hex[:12],
+        bind_nonce=base64.b64encode(os.urandom(32)).decode(),
+        home=home,
+        config_path=config_path,
+        extra=["--account", "work"],
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr}"
+
+    cfg = json.loads(config_path.read_text())
+    work = cfg["channels"]["botcord"]["accounts"]["work"]
+    assert work["enabled"] is True
+    assert work["credentialsFile"].endswith("ag_acct000000002.json")
+    assert work["deliveryMode"] == "websocket"
+
+
+def test_install_sh_server_rejects_bind_code(stub_server, tmp_path: Path):
+    """When the hub returns 400 INVALID_BIND_CODE the script must abort."""
+    state = stub_server["state"]
+    state.response_status = 400
+    state.response_body = {"detail": "INVALID_BIND_CODE", "error": "INVALID_BIND_CODE"}
+
+    home = tmp_path / "home"
+    home.mkdir()
+    config_path = tmp_path / "openclaw.json"
+
+    proc = _run_install_sh(
+        server_url=stub_server["url"],
+        bind_code="bd_expired00001",
+        bind_nonce=base64.b64encode(os.urandom(32)).decode(),
+        home=home,
+        config_path=config_path,
+    )
+    assert proc.returncode != 0
+    # Nothing should have been written to disk.
+    assert not (home / ".botcord" / "credentials").exists() or not any(
+        (home / ".botcord" / "credentials").iterdir()
+    )
+    assert not config_path.exists()
+
+
+def test_install_sh_passes_intended_name_override(stub_server, tmp_path: Path):
+    state = stub_server["state"]
+    state.response_status = 201
+    state.response_body = _sample_claim_response()
+
+    home = tmp_path / "home"
+    home.mkdir()
+    config_path = tmp_path / "openclaw.json"
+
+    proc = _run_install_sh(
+        server_url=stub_server["url"],
+        bind_code="bd_" + uuid.uuid4().hex[:12],
+        bind_nonce=base64.b64encode(os.urandom(32)).decode(),
+        home=home,
+        config_path=config_path,
+        extra=["--name", "laptop-bot"],
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr}"
+    assert state.last_body["name"] == "laptop-bot"

--- a/backend/tests/test_app/test_install_script.py
+++ b/backend/tests/test_app/test_install_script.py
@@ -361,6 +361,78 @@ def test_install_sh_claim_failure_preserves_existing_plugin(
     assert not config_path.exists()
 
 
+def test_install_sh_swap_failure_restores_backup(stub_server, tmp_path: Path):
+    """If the second mv (staging → TARGET_DIR) fails, on_exit must
+    restore the backup so the user is never left with a missing plugin.
+
+    We trigger the failure with BOTCORD_INSTALL_FAULT=after-backup, a
+    test-only hook in install.sh that exits after stashing the existing
+    plugin into ``.bak.<ts>`` but before moving staging into place.
+    """
+    state = stub_server["state"]
+    state.response_status = 201
+    state.response_body = _sample_claim_response("ag_swapfail000001")
+
+    home = tmp_path / "home"
+    home.mkdir()
+    config_path = tmp_path / "openclaw.json"
+
+    # Pre-existing plugin install at TARGET_DIR with a sentinel so we
+    # can prove it survives.
+    target_dir = home / ".openclaw" / "extensions" / "botcord"
+    target_dir.mkdir(parents=True)
+    sentinel = target_dir / "package.json"
+    sentinel.write_text('{"name": "@botcord/botcord", "version": "previous"}\n')
+
+    # Build a tiny tarball so the script's plugin-install step succeeds.
+    fake_pkg = tmp_path / "fake-pkg"
+    (fake_pkg / "package").mkdir(parents=True)
+    (fake_pkg / "package" / "package.json").write_text(
+        '{"name": "@botcord/botcord", "version": "0.0.0-test"}\n'
+    )
+    fake_tgz = tmp_path / "fake.tgz"
+    subprocess.run(
+        ["tar", "-czf", str(fake_tgz), "-C", str(fake_pkg), "package"], check=True
+    )
+
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "TMPDIR": str(home / "tmp"),
+        "OPENCLAW_BIN": "/bin/false",
+        "OPENCLAW_CONFIG_PATH": str(config_path),
+        "BOTCORD_INSTALL_FAULT": "after-backup",
+    }
+    (home / "tmp").mkdir(parents=True, exist_ok=True)
+    proc = subprocess.run(
+        [
+            "bash",
+            str(INSTALL_SH),
+            "--bind-code", "bd_" + uuid.uuid4().hex[:12],
+            "--bind-nonce", base64.b64encode(os.urandom(32)).decode(),
+            "--server-url", stub_server["url"],
+            "--tgz-path", str(fake_tgz),
+            "--force-reinstall",
+            "--target-dir", str(target_dir),
+            "--skip-restart",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert proc.returncode != 0, "fault-injected install must exit non-zero"
+
+    # The user's previous plugin must be back at TARGET_DIR.
+    assert sentinel.is_file(), (
+        f"sentinel missing after rollback. stdout={proc.stdout}\nstderr={proc.stderr}"
+    )
+    assert "previous" in sentinel.read_text()
+
+    # And no leftover .bak.* should remain — the rollback moves it back.
+    backups = list(target_dir.parent.glob("botcord.bak.*"))
+    assert backups == [], f"backup not consumed by rollback: {backups}"
+
+
 def test_install_sh_passes_intended_name_override(stub_server, tmp_path: Path):
     state = stub_server["state"]
     state.response_status = 201

--- a/cli/README.md
+++ b/cli/README.md
@@ -10,6 +10,13 @@ npm install -g @botcord/cli
 
 Requires Node.js >= 18.
 
+> **Already running OpenClaw?** The fastest path is the dashboard
+> bind-code flow at [botcord.chat/agents/add](https://botcord.chat/agents/add) —
+> it issues a one-line `curl … | bash` that installs the BotCord
+> plugin, registers a fresh agent, writes credentials, and binds to
+> your dashboard account in one step. The CLI below is for headless /
+> scripted provisioning and managing existing agents.
+
 ## Quick Start
 
 ### 1. Register an agent

--- a/cli/skills/botcord-user-guide/SKILL.md
+++ b/cli/skills/botcord-user-guide/SKILL.md
@@ -235,6 +235,10 @@ Use this sequence when a user asks how to begin. It splits into **one-time insta
 
 ### A. One-time install
 
+The fastest path for users who already run OpenClaw is the dashboard install command — generate it at `botcord.chat/agents/add`, paste it on the OpenClaw machine, done. The plugin, an Ed25519 keypair, the credentials file, and the `openclaw.json` patch are all handled in one shot, and the Bot is automatically bound to the dashboard account when it appears. Recommend that flow first.
+
+Fall back to the CLI flow only when the user explicitly cannot use the dashboard (headless server, scripted provisioning, or pinning a fork):
+
 1. Install the CLI: `npm i -g @botcord/cli` — exposes the `botcord` command
 2. Register or import a Bot identity: `botcord register --name "..."`, or `botcord import --file <path>` for an existing credential
 3. Bind the Bot to the BotCord Web account: `botcord bind <code>` (the code comes from the dashboard bind flow), or claim via the dashboard directly

--- a/docs/bind-code-onboarding-design.md
+++ b/docs/bind-code-onboarding-design.md
@@ -1,0 +1,485 @@
+# Bind Code Onboarding 设计方案
+
+**Status**: Draft
+**Owner**: @susan
+**Date**: 2026-04-26
+**Related**: `botcord-register.sh`, `plugin/install.sh`(待建), Bloome `install.sh` 调研
+
+---
+
+## 1. 背景与动机
+
+### 1.1 现状
+
+botcord plugin 当前的安装链路（README）要求用户：
+
+1. `git clone` 仓库
+2. 手动编辑 `~/.openclaw/openclaw.json` 添加 `plugins.load.paths` / `plugins.entries`
+3. 跑 `botcord-register.sh` 走 challenge-response 注册新 agent
+4. 在 dashboard 用 `/botcord_bind` 流程把 agent 绑定到登录用户
+
+门槛高、步骤多，且对非工程用户不友好。
+
+### 1.2 对标：Bloome 的一键安装
+
+竞品 Bloome 走 `curl | bash` + `--agent-token` 模式，体验顺滑：
+
+```bash
+bash <(curl -fsSL https://bloome.im/openclaw/install.sh) \
+  --agent-token 89bf90...494b1
+```
+
+但其代价是**服务端持有 token → agent 的反查表**，意味着：
+
+- 服务端能冒充任意 agent
+- 消息出 Hub 后无法被第三方独立验证签名
+- 整个 a2a 协议的"密码学主体"假设被打破
+
+### 1.3 中间道路：bind code
+
+把"onboarding 凭据"和"长期身份"在生命周期上拆开：
+
+| | bind code | agent keypair |
+|---|---|---|
+| 谁生成 | 服务端 | 客户端（install.sh 本地） |
+| 寿命 | 一次性，10 分钟 TTL | 永久（直到 revoke） |
+| 作用 | 证明"登录用户授权这次安装" | a2a 消息签名身份 |
+| 服务端留存 | claim 后立即作废 | **只存 pubkey，私钥从不经手** |
+
+效果：onboarding UX 追平 Bloome；密码学身份保留。
+
+---
+
+## 2. 总体设计
+
+### 2.1 用户视角流程
+
+1. 用户登录 `dashboard.botcord.chat`，点击 **"Add Agent to OpenClaw"**
+2. Dashboard 调后端生成一次性 install code，前端展示一键复制的安装命令：
+
+   ```bash
+   curl -fsSL https://api.botcord.chat/openclaw/install.sh | bash -s -- \
+     --bind-code bd_a1b2c3d4e5f6 \
+     --bind-nonce QkRjSEFMTE5HRV8zMl9CWVRFU19FWGFtcGxlISE=
+   ```
+
+3. 用户在装有 OpenClaw 的机器上粘贴执行
+4. install.sh 自动完成：下载插件 → 装依赖 → 本地生成 keypair → 签名 proof-of-possession → 调 `/api/users/me/agents/install-claim` 兑换身份 → 写凭证 + 配置 → 重启 gateway
+5. 完成后 dashboard 实时跳转到该 agent 的管理页
+
+### 2.2 系统视角时序
+
+```
+┌────────┐         ┌──────────┐        ┌─────────┐         ┌─────────┐
+│Browser │         │Frontend  │        │Backend  │         │install  │
+│(user)  │         │(BFF)     │        │(Hub)    │         │.sh      │
+└───┬────┘         └────┬─────┘        └────┬────┘         └────┬────┘
+    │ 点 Add Agent      │                   │                   │
+    ├──────────────────►│                   │                   │
+    │                   │ POST /bind-ticket │                   │
+    │                   ├──────────────────►│                   │
+    │                   │                   │ 生成 bd_xxx       │
+    │                   │                   │ short_codes入库   │
+    │                   │◄──────────────────┤                   │
+    │ 展示命令+轮询     │                   │                   │
+    │◄──────────────────┤                   │                   │
+    │                                       │                   │
+    │ ── 用户复制命令到目标机器执行 ────────────────────────────►│
+    │                                       │                   │
+    │                                       │                   │ 1.下载 tgz
+    │                                       │                   │ 2.npm install
+    │                                       │                   │ 3.gen keypair
+    │                                       │                   │ 4.sign nonce
+    │                                       │ POST install-claim│
+    │                                       │◄──────────────────┤
+    │                                       │ 校验签名+派生ag_xxx│
+    │                                       │ 插入Agent/Key,消费code│
+    │                                       ├──────────────────►│
+    │                                       │                   │ 5.写credentials
+    │                                       │                   │ 6.config set
+    │                                       │                   │ 7.gateway restart
+    │ 轮询命中已 claim                      │                   │
+    │◄──────────────────┤◄──────────────────┤                   │
+    │ 跳转 agent 详情   │                   │                   │
+```
+
+---
+
+## 3. 数据模型
+
+### 3.1 复用现有 `short_codes`
+
+不新增 `bind_codes` 表。当前仓库已有 `short_codes` 表和 `used_bind_tickets` 表，已经覆盖“一次性短码 + HMAC ticket + JTI 防重放”的基础能力：
+
+- `short_codes.kind = "bind"`：存短码本体，`payload_json` 内放 `bind_ticket` 以及安装页需要的元数据。
+- `short_codes.owner_user_id`：绑定发码用户。
+- `short_codes.expires_at` / `max_uses` / `use_count` / `consumed_at`：表达 TTL 和一次性消费。
+- `used_bind_tickets.jti`：防止同一个 signed ticket 被重放。
+
+建议把当前 `POST /api/users/me/agents/bind-ticket` 扩展为 install onboarding 专用响应，而不是另建平行表。短码格式继续使用现有 `bd_<12 hex>`，TTL 可从现有 30 分钟收紧到 10 分钟；如果担心迁移成本，Phase 1 可先保留 30 分钟，UI 文案与测试按实际值走。
+
+### 3.2 `agents` / `signing_keys` 写入
+
+claim 流程必须同时写：
+
+- `agents.agent_id`：由 public key 派生。
+- `agents.display_name`：使用 claim 请求的 `name`，空则使用 ticket payload 的 `intended_name`，再空则用 `agent_id`。
+- `agents.user_id`：来自 bind ticket 的 `uid`。
+- `agents.agent_token` / `token_expires_at`：给本地 credentials 保存，后续由现有 refresh 流程轮换。
+- `agents.is_default` / `claimed_at`：沿用 `_bind_agent_to_user` 的规则。
+- `signing_keys.key_id`：`generate_key_id()` 生成并返回给安装脚本。
+- `signing_keys.pubkey`：`ed25519:<base64 raw 32 bytes>`。
+- `signing_keys.state`：直接写 `active`，前提是 claim 请求已经用对应私钥签过 server nonce。
+
+`signing_keys.pubkey` 目前没有全局唯一约束。实现时仍应查询是否已有 active/pending key 使用同一 pubkey；如果需要数据库兜底，应新增唯一索引或在迁移中显式说明兼容策略。
+
+---
+
+## 4. 后端 API
+
+### 4.1 `POST /api/users/me/agents/bind-ticket`
+
+**作用**：登录用户在 dashboard 触发，生成一次性 install code。该接口已有基础形态，需要扩展为返回安装命令和用于轮询的短码状态。
+
+**Auth**：Supabase JWT（现有 BFF 中间件）
+
+**Request**:
+```json
+{ "intendedName": "my-agent" }
+```
+
+**Response**:
+```json
+{
+  "bindCode": "bd_a1b2c3d4e5f6",
+  "nonce": "QkRjSEFMTE5HRV8zMl9CWVRFU19FWGFtcGxlISE=",
+  "expiresAt": "2026-04-26T12:34:56Z",
+  "installCommand": "curl -fsSL https://api.botcord.chat/openclaw/install.sh | bash -s -- --bind-code bd_a1b2c3d4e5f6 --bind-nonce QkRjSEFMTE5HRV8zMl9CWVRFU19FWGFtcGxlISE="
+}
+```
+
+**实现要点**：
+- 生成：沿用 `bd_` + 随机短码；真实授权材料放在 signed `bind_ticket` 里。
+- ticket payload 至少包含：`uid`、`nonce`、`iat`、`exp`、`jti`、`purpose: "install_claim"`，可选 `intended_name`。`nonce` 使用 32 字节随机数的 base64 字符串，直接兼容现有 `signChallenge` / `verify_challenge_sig`。
+- `payload_json` 存 `bind_ticket`，也可存 `claimed_agent_id` / `claimed_at` 供轮询展示。
+- 单用户活跃 code 数量限流（建议 <= 5），防滥用。
+- intendedName 不强制要求唯一，仅作为 claim 时的默认 display name 兜底。
+
+### 4.2 `GET /api/users/me/agents/bind-ticket/:code`
+
+**作用**：dashboard 轮询 bind code 状态，命中后跳转。
+
+**Auth**：Supabase JWT，且 `short_codes.owner_user_id == current_user.id`
+
+**Response**:
+```json
+{
+  "bindCode": "bd_a1b2c3d4e5f6",
+  "status": "pending" | "claimed" | "expired",
+  "agentId": "ag_xxx",   // status=claimed 时返回
+  "expiresAt": "..."
+}
+```
+
+轮询频率建议 3 秒；claim 成功后 dashboard 也可走 WebSocket 收 `agent.claimed` 事件取代轮询。
+
+### 4.3 `POST /api/users/me/agents/install-claim`
+
+**作用**：install.sh 本地生成 keypair 后，用短码和签名证明兑换身份。
+
+**Auth**：**无 JWT**。bindCode 是带宽外授权凭据，但必须叠加 Ed25519 proof-of-possession，证明调用方持有所提交 public key 对应的私钥。
+
+**Request**:
+```json
+{
+  "bindCode": "bd_a1b2c3d4e5f6",
+  "pubkey": "ed25519:base64-encoded-pubkey",
+  "proof": {
+    "nonce": "ticket-payload-nonce",
+    "sig": "base64-ed25519-signature"
+  },
+  "name": "my-agent"
+}
+```
+
+**Response**:
+```json
+{
+  "agentId": "ag_a1b2c3d4e5f6",
+  "keyId": "k_xxx",
+  "agentToken": "jwt...",
+  "tokenExpiresAt": 1770000000,
+  "hubUrl": "https://api.botcord.chat",
+  "wsUrl":  "wss://api.botcord.chat/ws"
+}
+```
+
+**校验逻辑**（按顺序短路）：
+1. bindCode 形状合法。
+2. 从 `short_codes` peek 出 `bind_ticket`，校验 kind、未过期、未消费。
+3. 验证 signed ticket：HMAC、`purpose == "install_claim"`、`exp`、`jti`、`uid`。
+4. pubkey 格式合法（Ed25519, 32 bytes raw）。
+5. 用 pubkey 验证 `proof.sig` 是否签过 ticket 中的 `nonce`。没有这一步会允许 public-key squatting。
+6. `agent_id = generate_agent_id(pubkey_b64)`（既有派生函数）。
+7. 检查同一 pubkey 未被其他 active/pending `signing_keys` 占用。
+8. **原子消费短码**：执行类似 `UPDATE short_codes SET use_count = use_count + 1, consumed_at = now() WHERE code = :code AND kind = 'bind' AND consumed_at IS NULL AND use_count < max_uses AND expires_at > now() RETURNING payload_json`。不要先查再改。
+9. 消费 `used_bind_tickets.jti`。如果 JTI 已用，拒绝。
+10. 同一事务内插入 `Agent` + active `SigningKey` + wallet/role/claim gift 等现有副作用。
+11. 更新 `short_codes.payload_json` 追加 `claimed_agent_id` / `claimed_at`，供 dashboard 轮询。
+12. 提交后发 `agent.claimed` 事件给该 user 的 WS 通道。
+
+**错误码**：
+- `400` `INVALID_BIND_CODE`
+- `400` `INVALID_PUBKEY`
+- `401` `INVALID_PROOF`
+- `409` `PUBKEY_ALREADY_REGISTERED`
+- `429` `TOO_MANY_REQUESTS`（建议按 IP 限流，10/min）
+
+**重要**：unauthenticated claim 对外统一返回 `INVALID_BIND_CODE`，不要区分不存在、过期、已用；细分原因只进服务端日志和 dashboard owner 可见状态。bindCode 一旦兑换成功立即作废；同一 code 二次提交即使 pubkey 一致也拒绝，不做幂等。
+
+### 4.4 `GET /openclaw/install.sh`
+
+**作用**：静态托管安装脚本。
+
+**实现**：FastAPI 用 `FileResponse` 返回 `static/openclaw/install.sh`，CDN 缓存 5 分钟。
+
+---
+
+## 5. install.sh 脚本
+
+### 5.1 整体借鉴 Bloome
+
+参考 `~/botcord/docs/` 同侧 Bloome `install.sh` 调研结论，**直接 fork** 那份脚本，改造点见 5.2。保留：
+
+- `set -euo pipefail` + `trap on_exit EXIT` 失败回滚 + 日志归档到 `~/.botcord/log/install_fail_<ts>.log`
+- 三种插件源：`--tgz-url` / `--tgz-path` / `--from-source`
+- 暂存目录 → `npm install --omit=dev` → 原子 swap 到 `~/.openclaw/extensions/botcord`
+- `openclaw config set --batch-json` 走非交互路径，避免 docker exec 卡 clack prompt
+- Docker 环境识别：grep `gateway restart` 输出，命中 "no service manager" 时打印 `docker restart openclaw-openclaw-gateway-1` 提示
+- peer dep `openclaw` 解析失败兜底（gateway 注入）
+
+### 5.2 botcord 特有改造
+
+#### 5.2.1 参数
+
+```bash
+# 主线：bind code
+--bind-code <bd_xxx>            # 必填（除非 --agent-id + --credentials-path 老路径）
+--bind-nonce <nonce>            # 必填；由 dashboard 命令一并带上，用于签名 proof
+
+# 兼容老用户：直接传现有凭证
+--agent-id <ag_xxx>             # 已存在 agent 时跳过 claim
+--credentials-path <path>       # 已有 ~/.botcord/credentials/<id>.json
+
+# 配置
+--server-url <url>              # 默认 https://api.botcord.chat
+--account <id>                  # 多账号命名空间，对应 channels.botcord.accounts.<id>.*
+
+# 通用
+--target-dir <path>             # 默认 ~/.openclaw/extensions/botcord
+--force-reinstall, --skip-restart, --tgz-url, --tgz-path, --from-source
+```
+
+#### 5.2.2 keypair 本地生成
+
+在脚本里嵌入一段 `node -e`，复用 plugin/protocol-core 自带的 crypto 模块（确保算法一致）：
+
+```bash
+export BIND_CODE BIND_NONCE
+KEYGEN_OUT="$(node --input-type=module -e "
+  const { generateKeypair, signChallenge } = await import('$STAGING/src/crypto.ts');
+  const kp = generateKeypair();
+  kp.proofSig = signChallenge(kp.privateKey, process.env.BIND_NONCE);
+  process.stdout.write(JSON.stringify(kp));
+")"
+PUBKEY="$(printf '%s' "$KEYGEN_OUT" | node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync(0)).publicKey)')"
+PRIVKEY="$(printf '%s' "$KEYGEN_OUT" | node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync(0)).privateKey)')"
+PUBKEY_FORMATTED="$(printf '%s' "$KEYGEN_OUT" | node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync(0)).pubkeyFormatted)')"
+PROOF_SIG="$(printf '%s' "$KEYGEN_OUT" | node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync(0)).proofSig)')"
+export PUBKEY PRIVKEY PUBKEY_FORMATTED PROOF_SIG
+```
+
+> 设计选择：**复用插件/protocol-core 而不是脚本里自己造轮子**，避免出现"安装时 keypair 用 A 算法、运行时用 B 算法"的脱节。代价是 keypair 生成必须在插件安装之后、写 credentials 之前。具体 import 路径要以打包后的插件产物为准；如果发布包不能直接执行 `.ts`，安装脚本应调用随包提供的 JS helper。
+
+#### 5.2.3 claim 调用
+
+```bash
+CLAIM_RESP="$(curl -fsSL -X POST "$SERVER_URL/api/users/me/agents/install-claim" \
+  -H 'content-type: application/json' \
+  -d "$(node -e '
+    const v = JSON.parse(process.argv[1]);
+    process.stdout.write(JSON.stringify({
+      bindCode: process.env.BIND_CODE,
+      pubkey: v.pubkeyFormatted,
+      proof: {
+        nonce: process.env.BIND_NONCE,
+        sig: v.proofSig
+      },
+      name: process.env.AGENT_NAME || null
+    }));
+  ' -- "$KEYGEN_OUT")")" || {
+  log_error "claim failed; bind code 可能已过期或已被使用"
+  exit 1
+}
+
+AGENT_ID="$(printf '%s' "$CLAIM_RESP" | node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync(0)).agentId)')"
+KEY_ID="$(printf '%s' "$CLAIM_RESP" | node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync(0)).keyId)')"
+AGENT_TOKEN="$(printf '%s' "$CLAIM_RESP" | node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync(0)).agentToken)')"
+TOKEN_EXPIRES_AT="$(printf '%s' "$CLAIM_RESP" | node -e 'process.stdout.write(String(JSON.parse(require("fs").readFileSync(0)).tokenExpiresAt || ""))')"
+HUB_URL="$(printf '%s' "$CLAIM_RESP" | node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync(0)).hubUrl)')"
+export AGENT_ID KEY_ID AGENT_TOKEN TOKEN_EXPIRES_AT HUB_URL
+```
+
+#### 5.2.4 写 credentials.json
+
+格式与现有 `botcord-register.sh` 产物保持一致：
+
+```bash
+mkdir -p "$HOME/.botcord/credentials"
+CRED_PATH="$HOME/.botcord/credentials/$AGENT_ID.json"
+node -e "
+  const fs = require('fs');
+  fs.writeFileSync('$CRED_PATH', JSON.stringify({
+    version: 1,
+    hubUrl: '$HUB_URL',
+    agentId: '$AGENT_ID',
+    keyId: '$KEY_ID',
+    privateKey: process.env.PRIVKEY,
+    publicKey: process.env.PUBKEY,
+    displayName: process.env.AGENT_NAME || '$AGENT_ID',
+    savedAt: new Date().toISOString(),
+    token: process.env.AGENT_TOKEN || undefined,
+    tokenExpiresAt: process.env.TOKEN_EXPIRES_AT ? Number(process.env.TOKEN_EXPIRES_AT) : undefined
+  }, null, 2), { mode: 0o600 });
+"
+chmod 600 "$CRED_PATH"
+```
+
+**关键安全点**：
+- `chmod 600`，仅当前用户可读
+- 中间变量 `KEYGEN_OUT` `PRIVKEY` 不写入任何 log；`tee` run log 时用 `--quiet` 段包裹这一步
+
+#### 5.2.5 写 OpenClaw 配置
+
+```bash
+write_plain_config_batch \
+  "channels.botcord.enabled" "true" \
+  "channels.botcord.credentialsFile" "$CRED_PATH"
+```
+
+注意：**只写 credentialsFile 路径，不写私钥到 OpenClaw config**。OpenClaw config 会落盘到 `~/.openclaw/openclaw.json`，理论上备份/同步工具可能扫到，分开存更稳妥。现有 plugin 会从 `credentialsFile` 读取 `hubUrl`、`agentId`、`keyId`、`privateKey`、`publicKey`。
+
+---
+
+## 6. Frontend 改动
+
+### 6.1 新增页面 `/dashboard/agents/add`
+
+- 顶部一个"生成安装命令"按钮 → 调 4.1 → 拿到 code 后展示带复制按钮的命令块
+- 倒计时显示 expiresAt 剩余时间
+- 下方"等待安装中..."loading，3 秒轮询 4.2，命中 `claimed` 后跳 `/dashboard/agents/<agentId>`
+- 提供"换一个 code"按钮（作废上一个 + 生成新的）
+
+### 6.2 现有 dashboard 主入口加引导卡片
+
+`/dashboard` 首页若用户无任何 agent，加一张"在 OpenClaw 里安装 botcord plugin"卡片，CTA 跳 6.1。
+
+---
+
+## 7. 安全模型分析
+
+### 7.1 攻击面与缓解
+
+| 威胁 | 缓解 |
+|---|---|
+| **bindCode 泄露**（用户复制时被旁观、终端历史、剪贴板劫持） | 10 分钟 TTL；一次性；claim 后立即作废；dashboard 可显示"已被兑换"让用户察觉异常。泄露者仍可抢先安装自己的 keypair，所以 bindCode 仍按 bearer secret 处理 |
+| **public-key squatting**（攻击者提交不属于自己的 pubkey 占住 agent_id） | claim 必须验证 `proof.sig = sign(privateKey, nonce)`，没有私钥不能注册该 pubkey |
+| **MITM 替换 install.sh** | 仅通过 HTTPS 分发；可选 SRI（脚本里嵌 plugin tgz 的 sha256 校验，bloome 没做，我们可以做） |
+| **服务端日志记下 pubkey 与 user 关系** | 可接受——pubkey 本来就是公开身份，no-op |
+| **服务端被攻破后伪造 agent** | 攻击者无法获得已存在 agent 的私钥；但能注册新 agent 冒充新用户。这是任何带服务端的系统都有的问题，不在本方案 scope |
+| **重放旧 bindCode** | 一次性 + 过期；DB 唯一约束兜底 |
+| **暴力枚举 bindCode** | 短码只作为 ticket lookup handle；ticket 本身 HMAC 签名且有 JTI；按 IP 限流 10/min；unauthenticated claim 对失败 code 统一返回 `INVALID_BIND_CODE` |
+
+### 7.2 与 Bloome 对比
+
+| 维度 | Bloome | 本方案 |
+|---|---|---|
+| 服务端能否冒充 agent | 能 | **不能** |
+| 消息端到端可验 | 否 | **是** |
+| 用户 onboarding UX | 一条命令 | **一条命令** ✅ |
+| 凭证轮换 | 服务端 revoke | 重新 claim（生成新 keypair） |
+| 多账号 | `--account` | 同上 |
+
+**结论**：UX 追平，安全模型不退让。
+
+---
+
+## 8. 兼容性与迁移
+
+### 8.1 老用户（已有 credentials.json）
+
+`install.sh` 的 `--agent-id + --credentials-path` 路径保留：跳过 claim，直接走原子 swap + config set。
+
+### 8.2 老 `botcord-register.sh`
+
+不下线，作为"高级用户/无 dashboard 场景"的 fallback。文档里把 install.sh + bind code 列为推荐路径。
+
+### 8.3 dashboard 现有 `/botcord_bind` skill
+
+短期保留；install onboarding 应复用同一套 bind ticket/short code primitives。长期看 install 流程跑顺后，再评估是否把 `/botcord_bind` 的用户入口合并到同一页面。
+
+---
+
+## 9. 落地拆分
+
+### 9.1 Phase 1（后端基建，1-2 天）
+
+- [ ] 扩展现有 `POST /api/users/me/agents/bind-ticket`：purpose、intendedName、安装命令、TTL/限流
+- [ ] 新增 `GET /api/users/me/agents/bind-ticket/:code`
+- [ ] 新增 `POST /api/users/me/agents/install-claim`
+- [ ] 静态托管 `/openclaw/install.sh`（先放一个占位脚本）
+- [ ] 后端测试：claim happy path、过期、已用、proof 签名错误、pubkey 冲突、短码/JTI 竞态、限流
+
+### 9.2 Phase 2（install.sh，2-3 天）
+
+- [ ] fork bloome 脚本，按 5.2 改造
+- [ ] 在 `botcord/plugin/test-docker-install.sh` 基础上扩 e2e：拉一个本地 hub + 模拟 dashboard 签发 code → 跑 install.sh → 校验 agent 上线
+- [ ] 把 `chmod 600` 和 privkey 不入 run log 的部分单测覆盖
+
+### 9.3 Phase 3（frontend UI，1-2 天）
+
+- [ ] `/dashboard/agents/add` 页面
+- [ ] 主入口卡片
+- [ ] WS 事件 `agent.claimed` 接入（可选，先轮询）
+
+### 9.4 Phase 4（文档 + 灰度，1 天）
+
+- [ ] plugin/README.md 把 git clone 段落降级，bind code 升为推荐路径
+- [ ] 给 onboarding skill 加一句话指引
+- [ ] 选 3-5 个 Ouraca 内部用户先验证
+
+**总工作量**：~7 工作日单人。
+
+---
+
+## 10. 开放问题
+
+1. **bindCode 是否需要绑定 IP？**
+   倾向不绑——用户可能在浏览器端生成、在终端机器粘贴。但可以在 `used_ip` 与"生成时的 IP"差异巨大时（跨国）发邮件提醒。
+
+2. **是否支持 dashboard 主动 revoke 未用 code？**
+   需要。Phase 1 加 `DELETE /api/users/me/agents/bind-ticket/:code`，只允许 owner 撤销自己的 pending code。
+
+3. **多账号 `--account` 是否 Phase 1 就支持？**
+   建议 Phase 1 不做；先把单账号跑通，多账号留 Phase 5。
+
+4. **install.sh 里 keypair 生成失败时如何回滚 bind code？**
+   keypair 生成在 claim 之前，生成失败直接 exit，bind code 还是 pending，TTL 自然过期或用户手动重试。无须特殊处理。
+
+---
+
+## 11. 参考
+
+- Bloome `install.sh` 反向分析（本仓库工作记录）
+- 现有 `botcord-register.sh` 与 challenge-response 流程
+- a2a/0.1 协议规范：`backend/CLAUDE.md`、`plugin/CLAUDE.md`

--- a/frontend/src/app/agents/add/page.tsx
+++ b/frontend/src/app/agents/add/page.tsx
@@ -1,0 +1,5 @@
+import AddAgentPage from "@/components/agents/AddAgentPage";
+
+export default function AgentsAddRoute() {
+  return <AddAgentPage />;
+}

--- a/frontend/src/components/agents/AddAgentPage.tsx
+++ b/frontend/src/components/agents/AddAgentPage.tsx
@@ -76,7 +76,25 @@ export default function AddAgentPage() {
     setIssuing(true);
     setStatus("issued");
     setClaimedAgentId(null);
+    // Stop any in-flight polling/countdown for the previous ticket so we
+    // don't race the revoke we're about to issue.
+    clearPollTimer();
+    clearTickTimer();
     try {
+      // Revoke the previously issued code first so each retry doesn't
+      // accumulate against the per-user active-code cap (5). 404 means
+      // somebody already burned it (revoked from another tab, or
+      // claimed) — that's fine.
+      const previous = ticket;
+      if (previous) {
+        try {
+          await userApi.revokeBindTicket(previous.bind_code);
+        } catch (err) {
+          if (!(err instanceof ApiError && err.status === 404)) {
+            throw err;
+          }
+        }
+      }
       const data = await userApi.issueBindTicket({
         intendedName: intendedName.trim() || null,
       });
@@ -89,7 +107,7 @@ export default function AddAgentPage() {
     } finally {
       setIssuing(false);
     }
-  }, [intendedName]);
+  }, [intendedName, ticket, clearPollTimer, clearTickTimer]);
 
   const revoke = useCallback(async () => {
     if (!ticket) return;
@@ -139,7 +157,9 @@ export default function AddAgentPage() {
           setClaimedAgentId(res.agent_id);
           clearPollTimer();
           clearTickTimer();
-        } else if (res.status === "expired") {
+        } else if (res.status === "expired" || res.status === "revoked") {
+          // "revoked" comes from a delete in another tab (or a botched
+          // post-claim metadata write); either way it is terminal.
           setStatus("expired");
           clearPollTimer();
           clearTickTimer();
@@ -282,15 +302,12 @@ export default function AddAgentPage() {
 
             <div className="flex flex-wrap gap-2">
               <button
-                onClick={() => {
-                  setTicket(null);
-                  setStatus("issued");
-                }}
-                className="inline-flex items-center gap-1.5 rounded-lg border border-glass-border px-3 py-2 text-sm font-medium text-text-primary hover:bg-glass-border/30"
+                onClick={issue}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-glass-border px-3 py-2 text-sm font-medium text-text-primary hover:bg-glass-border/30 disabled:opacity-60"
                 disabled={issuing || revoking}
               >
                 <RefreshCw className="h-4 w-4" />
-                Generate another
+                {issuing ? "Generating…" : "Generate another"}
               </button>
               {!showExpired && (
                 <button

--- a/frontend/src/components/agents/AddAgentPage.tsx
+++ b/frontend/src/components/agents/AddAgentPage.tsx
@@ -1,0 +1,326 @@
+"use client";
+
+/**
+ * [INPUT]: 依赖 userApi 的 issueBindTicket / getBindTicketStatus / revokeBindTicket，依赖 next 路由跳转新 agent
+ * [OUTPUT]: 对外提供 AddAgentPage，承接 dashboard "Add Agent to OpenClaw" 入口
+ * [POS]: /agents/add 落地页，展示一次性 install 命令并轮询 install-claim 完成态
+ * [PROTOCOL]: 变更时更新此头部
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Check, Copy, RefreshCw, Trash2 } from "lucide-react";
+import { setActiveAgentId, userApi, ApiError } from "@/lib/api";
+import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
+import type {
+  BindTicketResponse,
+  BindTicketStatusResponse,
+  BindTicketStatusValue,
+} from "@/lib/types";
+
+const POLL_INTERVAL_MS = 3000;
+
+function formatRemaining(secondsLeft: number): string {
+  if (secondsLeft <= 0) return "expired";
+  const m = Math.floor(secondsLeft / 60);
+  const s = secondsLeft % 60;
+  return m > 0 ? `${m}m ${s}s` : `${s}s`;
+}
+
+export default function AddAgentPage() {
+  const router = useRouter();
+  const setSessionActiveAgentId = useDashboardSessionStore(
+    (state) => state.setActiveAgentId,
+  );
+
+  const [intendedName, setIntendedName] = useState("");
+  const [issuing, setIssuing] = useState(false);
+  const [revoking, setRevoking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [ticket, setTicket] = useState<BindTicketResponse | null>(null);
+  const [status, setStatus] = useState<BindTicketStatusValue | "issued">("issued");
+  const [claimedAgentId, setClaimedAgentId] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [now, setNow] = useState(() => Math.floor(Date.now() / 1000));
+
+  const pollTimerRef = useRef<number | null>(null);
+  const tickTimerRef = useRef<number | null>(null);
+  const copyTimerRef = useRef<number | null>(null);
+
+  const clearPollTimer = useCallback(() => {
+    if (pollTimerRef.current !== null) {
+      window.clearInterval(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
+  }, []);
+
+  const clearTickTimer = useCallback(() => {
+    if (tickTimerRef.current !== null) {
+      window.clearInterval(tickTimerRef.current);
+      tickTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      clearPollTimer();
+      clearTickTimer();
+      if (copyTimerRef.current !== null) {
+        window.clearTimeout(copyTimerRef.current);
+      }
+    };
+  }, [clearPollTimer, clearTickTimer]);
+
+  const issue = useCallback(async () => {
+    setError(null);
+    setIssuing(true);
+    setStatus("issued");
+    setClaimedAgentId(null);
+    try {
+      const data = await userApi.issueBindTicket({
+        intendedName: intendedName.trim() || null,
+      });
+      setTicket(data);
+      setNow(Math.floor(Date.now() / 1000));
+      setStatus("pending");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to generate install command";
+      setError(msg);
+    } finally {
+      setIssuing(false);
+    }
+  }, [intendedName]);
+
+  const revoke = useCallback(async () => {
+    if (!ticket) return;
+    setRevoking(true);
+    setError(null);
+    try {
+      await userApi.revokeBindTicket(ticket.bind_code);
+      clearPollTimer();
+      clearTickTimer();
+      setTicket(null);
+      setStatus("issued");
+    } catch (err) {
+      // 404 from a stale code is fine — surface but allow retry.
+      const msg = err instanceof Error ? err.message : "Failed to revoke";
+      setError(msg);
+    } finally {
+      setRevoking(false);
+    }
+  }, [ticket, clearPollTimer, clearTickTimer]);
+
+  // Tick the countdown once per second.
+  useEffect(() => {
+    if (!ticket) {
+      clearTickTimer();
+      return;
+    }
+    setNow(Math.floor(Date.now() / 1000));
+    tickTimerRef.current = window.setInterval(() => {
+      setNow(Math.floor(Date.now() / 1000));
+    }, 1000);
+    return clearTickTimer;
+  }, [ticket, clearTickTimer]);
+
+  // Poll status every 3s.
+  useEffect(() => {
+    if (!ticket || status !== "pending") {
+      clearPollTimer();
+      return;
+    }
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const res: BindTicketStatusResponse = await userApi.getBindTicketStatus(ticket.bind_code);
+        if (cancelled) return;
+        if (res.status === "claimed" && res.agent_id) {
+          setStatus("claimed");
+          setClaimedAgentId(res.agent_id);
+          clearPollTimer();
+          clearTickTimer();
+        } else if (res.status === "expired") {
+          setStatus("expired");
+          clearPollTimer();
+          clearTickTimer();
+        }
+      } catch (err) {
+        if (cancelled) return;
+        // Stop polling if the code was revoked / 404'd; otherwise keep trying.
+        if (err instanceof ApiError && err.status === 404) {
+          setStatus("expired");
+          clearPollTimer();
+        }
+      }
+    };
+    pollTimerRef.current = window.setInterval(tick, POLL_INTERVAL_MS);
+    void tick();
+    return () => {
+      cancelled = true;
+      clearPollTimer();
+    };
+  }, [ticket, status, clearPollTimer, clearTickTimer]);
+
+  // Auto-jump to the new agent once it is claimed.
+  useEffect(() => {
+    if (status !== "claimed" || !claimedAgentId) return;
+    setActiveAgentId(claimedAgentId);
+    setSessionActiveAgentId(claimedAgentId);
+    const timeout = window.setTimeout(() => {
+      router.replace("/chats/messages/__user-chat__");
+    }, 1500);
+    return () => window.clearTimeout(timeout);
+  }, [status, claimedAgentId, router, setSessionActiveAgentId]);
+
+  const copy = useCallback(async () => {
+    if (!ticket?.install_command) return;
+    try {
+      await navigator.clipboard.writeText(ticket.install_command);
+      setCopied(true);
+      if (copyTimerRef.current !== null) window.clearTimeout(copyTimerRef.current);
+      copyTimerRef.current = window.setTimeout(() => setCopied(false), 1800);
+    } catch {
+      // Ignore — fall back to manual select.
+    }
+  }, [ticket]);
+
+  const remaining = ticket ? Math.max(0, ticket.expires_at - now) : 0;
+  const showPending = ticket && status === "pending";
+  const showExpired = ticket && status === "expired";
+  const showClaimed = status === "claimed";
+
+  return (
+    <div className="flex min-h-screen items-start justify-center bg-deep-black px-4 py-10">
+      <div className="w-full max-w-2xl rounded-3xl border border-glass-border bg-deep-black-light p-6 shadow-2xl sm:p-8">
+        <header className="flex items-start justify-between gap-3">
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight text-text-primary">
+              Add Agent to OpenClaw
+            </h1>
+            <p className="mt-1 text-sm text-text-secondary">
+              Generate a one-time install command, paste it on the machine where OpenClaw runs.
+              The plugin is downloaded, an Ed25519 keypair is generated locally, and the agent
+              registers itself — your private key never leaves the device.
+            </p>
+          </div>
+        </header>
+
+        {!ticket && !showClaimed && (
+          <section className="mt-6 space-y-4">
+            <label className="block">
+              <span className="block text-sm font-medium text-text-primary">
+                Display name (optional)
+              </span>
+              <input
+                type="text"
+                value={intendedName}
+                onChange={(e) => setIntendedName(e.target.value)}
+                placeholder="e.g. laptop-bot"
+                maxLength={128}
+                className="mt-2 w-full rounded-lg border border-glass-border bg-deep-black px-3 py-2 text-sm text-text-primary placeholder:text-text-secondary/60 focus:border-neon-cyan/60 focus:outline-none"
+              />
+              <span className="mt-1 block text-xs text-text-secondary/80">
+                Used as the agent name if you don&apos;t pass <code>--name</code> to the installer.
+              </span>
+            </label>
+            <button
+              onClick={issue}
+              disabled={issuing}
+              className="rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-4 py-2.5 text-sm font-semibold text-neon-cyan hover:bg-neon-cyan/20 disabled:opacity-60"
+            >
+              {issuing ? "Generating…" : "Generate install command"}
+            </button>
+          </section>
+        )}
+
+        {ticket && (
+          <section className="mt-6 space-y-4">
+            <div className="rounded-2xl border border-glass-border bg-deep-black p-4">
+              <div className="mb-2 flex items-center justify-between">
+                <span className="text-xs font-medium uppercase tracking-wider text-text-secondary">
+                  Install command
+                </span>
+                <button
+                  onClick={copy}
+                  className="inline-flex items-center gap-1.5 rounded-md border border-glass-border px-2.5 py-1 text-xs font-medium text-text-primary hover:bg-glass-border/30"
+                >
+                  {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+                  {copied ? "Copied" : "Copy"}
+                </button>
+              </div>
+              <pre className="overflow-x-auto whitespace-pre-wrap break-all rounded-md bg-black/60 px-3 py-2 font-mono text-xs leading-relaxed text-neon-cyan">
+                {ticket.install_command || "(install command unavailable — please regenerate)"}
+              </pre>
+              <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-text-secondary">
+                <span>
+                  Bind code: <span className="font-mono text-text-primary">{ticket.bind_code}</span>
+                </span>
+                <span>•</span>
+                <span>
+                  Expires in{" "}
+                  <span className={remaining <= 60 ? "font-semibold text-amber-300" : "text-text-primary"}>
+                    {formatRemaining(remaining)}
+                  </span>
+                </span>
+              </div>
+            </div>
+
+            {showPending && (
+              <div className="rounded-2xl border border-neon-cyan/30 bg-neon-cyan/5 p-4 text-sm text-neon-cyan">
+                Waiting for the install client to redeem this code…
+                <span className="ml-1 text-text-secondary">
+                  (we poll every {Math.round(POLL_INTERVAL_MS / 1000)}s)
+                </span>
+              </div>
+            )}
+
+            {showExpired && (
+              <div className="rounded-2xl border border-amber-500/40 bg-amber-500/10 p-4 text-sm text-amber-200">
+                This bind code has expired or was revoked. Generate a new one below.
+              </div>
+            )}
+
+            <div className="flex flex-wrap gap-2">
+              <button
+                onClick={() => {
+                  setTicket(null);
+                  setStatus("issued");
+                }}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-glass-border px-3 py-2 text-sm font-medium text-text-primary hover:bg-glass-border/30"
+                disabled={issuing || revoking}
+              >
+                <RefreshCw className="h-4 w-4" />
+                Generate another
+              </button>
+              {!showExpired && (
+                <button
+                  onClick={revoke}
+                  disabled={revoking}
+                  className="inline-flex items-center gap-1.5 rounded-lg border border-red-500/40 bg-red-500/5 px-3 py-2 text-sm font-medium text-red-200 hover:bg-red-500/15 disabled:opacity-60"
+                >
+                  <Trash2 className="h-4 w-4" />
+                  {revoking ? "Revoking…" : "Revoke this code"}
+                </button>
+              )}
+            </div>
+          </section>
+        )}
+
+        {showClaimed && claimedAgentId && (
+          <div className="mt-6 rounded-2xl border border-green-500/40 bg-green-500/10 p-4 text-sm text-green-200">
+            <p className="font-medium">Agent claimed</p>
+            <p className="mt-1 text-green-300/90">
+              {claimedAgentId} is now bound to your account. Redirecting…
+            </p>
+          </div>
+        )}
+
+        {error && (
+          <div className="mt-6 rounded-2xl border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-300">
+            {error}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/AgentGateModal.tsx
+++ b/frontend/src/components/dashboard/AgentGateModal.tsx
@@ -8,7 +8,8 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ChevronDown, Loader2, Link2, Plus } from "lucide-react";
+import Link from "next/link";
+import { ChevronDown, Download, Loader2, Link2, Plus } from "lucide-react";
 import { userApi } from "@/lib/api";
 import type { UserAgent } from "@/lib/types";
 import { useLanguage } from "@/lib/i18n";
@@ -112,7 +113,7 @@ export default function AgentGateModal({ onAgentReady }: AgentGateModalProps) {
             </button>
 
             {showOptions ? (
-              <div className="grid gap-4 md:grid-cols-2">
+              <div className="grid gap-4 md:grid-cols-3">
                 <button
                   onClick={() => setBindMode("create")}
                   disabled={isResolving}
@@ -122,6 +123,17 @@ export default function AgentGateModal({ onAgentReady }: AgentGateModalProps) {
                   <p className="mt-4 text-base font-semibold text-text-primary">{t.createAgent}</p>
                   <p className="mt-2 text-sm leading-6 text-text-secondary">{t.createDesc}</p>
                 </button>
+                <Link
+                  href="/agents/add"
+                  className={`block rounded-2xl border border-neon-cyan/30 bg-neon-cyan/5 p-5 text-left transition-all hover:bg-neon-cyan/10 ${
+                    isResolving ? "pointer-events-none opacity-60" : ""
+                  }`}
+                  aria-disabled={isResolving}
+                >
+                  <Download className="h-5 w-5 text-neon-cyan" />
+                  <p className="mt-4 text-base font-semibold text-text-primary">{t.installInOpenclaw}</p>
+                  <p className="mt-2 text-sm leading-6 text-text-secondary">{t.installInOpenclawDesc}</p>
+                </Link>
                 <button
                   onClick={() => setBindMode("link")}
                   disabled={isResolving}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,7 @@
 import type {
   Attachment,
   BindTicketResponse,
+  BindTicketStatusResponse,
   FileUploadResult,
   ResetTicketResponse,
   DashboardOverview,
@@ -707,8 +708,22 @@ const userApi = {
     return apiGet<{ agents: UserAgent[] }>("/api/users/me/agents");
   },
 
-  async issueBindTicket(): Promise<BindTicketResponse> {
-    return apiPost<BindTicketResponse>("/api/users/me/agents/bind-ticket");
+  async issueBindTicket(opts?: { intendedName?: string | null }): Promise<BindTicketResponse> {
+    const body: Record<string, unknown> = {};
+    if (opts?.intendedName) body.intended_name = opts.intendedName;
+    return apiPost<BindTicketResponse>("/api/users/me/agents/bind-ticket", body);
+  },
+
+  async getBindTicketStatus(code: string): Promise<BindTicketStatusResponse> {
+    return apiGet<BindTicketStatusResponse>(
+      `/api/users/me/agents/bind-ticket/${encodeURIComponent(code)}`,
+    );
+  },
+
+  async revokeBindTicket(code: string): Promise<{ ok: boolean }> {
+    return apiDelete<{ ok: boolean }>(
+      `/api/users/me/agents/bind-ticket/${encodeURIComponent(code)}`,
+    );
   },
 
   async issueCredentialResetTicket(agentId: string): Promise<ResetTicketResponse> {

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -1658,6 +1658,8 @@ export const agentGateModal: TranslationMap<{
   createDesc: string
   linkAgent: string
   linkDesc: string
+  installInOpenclaw: string
+  installInOpenclawDesc: string
   idleHint: string
   entering: string
   pollFailed: string
@@ -1674,6 +1676,8 @@ export const agentGateModal: TranslationMap<{
     createDesc: 'Use AI to create a brand-new BotCord Bot for this account.',
     linkAgent: 'Connect an existing Bot',
     linkDesc: 'Use AI to connect one of your existing BotCord Bots to this account.',
+    installInOpenclaw: 'Install in OpenClaw',
+    installInOpenclawDesc: 'One-line command for a machine that already runs OpenClaw — installs the BotCord plugin and registers a fresh Bot.',
     idleHint: 'Copy the connect prompt to continue. Once your Bot is connected, the chat app will continue automatically.',
     entering: 'Bot detected. Entering the chat app...',
     pollFailed: 'Failed to check Bot status',
@@ -1690,6 +1694,8 @@ export const agentGateModal: TranslationMap<{
     createDesc: '通过 AI 为当前账号创建一个全新的 BotCord Bot。',
     linkAgent: '连接已有 Bot',
     linkDesc: '通过 AI 把你已有的 BotCord Bot 连接到当前账号。',
+    installInOpenclaw: '在 OpenClaw 中安装',
+    installInOpenclawDesc: '一行命令，在已经运行 OpenClaw 的机器上自动安装 BotCord 插件并注册新 Bot。',
     idleHint: '复制连接 Prompt 继续。只要当前账号出现可用 Bot，系统就会自动进入应用。',
     entering: '已检测到 Bot，正在进入聊天应用...',
     pollFailed: '检查 Bot 状态失败',

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -418,6 +418,19 @@ export interface BindTicketResponse {
   bind_ticket: string;
   nonce: string;
   expires_at: number;
+  install_command?: string;
+  intended_name?: string | null;
+}
+
+export type BindTicketStatusValue = "pending" | "claimed" | "expired";
+
+export interface BindTicketStatusResponse {
+  bind_code: string;
+  status: BindTicketStatusValue;
+  agent_id: string | null;
+  expires_at: string | null;
+  expires_at_ts: number | null;
+  claimed_at?: string | null;
 }
 
 export interface ResetTicketResponse {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -422,7 +422,7 @@ export interface BindTicketResponse {
   intended_name?: string | null;
 }
 
-export type BindTicketStatusValue = "pending" | "claimed" | "expired";
+export type BindTicketStatusValue = "pending" | "claimed" | "expired" | "revoked";
 
 export interface BindTicketStatusResponse {
   bind_code: string;

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -14,38 +14,50 @@ Enables OpenClaw agents to send and receive messages over BotCord with **Ed25519
 
 ## Prerequisites
 
-1. A running [BotCord Hub](https://github.com/botlearn-ai/botcord) (or use `https://api.botcord.chat`)
-2. A registered agent identity (agent ID, keypair, key ID) — see [botcord](https://github.com/botlearn-ai/botcord) for CLI registration
+- A machine that already runs [OpenClaw](https://github.com/openclaw-ai/openclaw) with Node.js ≥ 18 and `npm`
+- A BotCord account at [botcord.chat](https://botcord.chat) (free)
+- Network access to a BotCord Hub (default: `https://api.botcord.chat`; self-host is also supported)
 
-## Installation
+## Installation (recommended: dashboard bind code)
+
+The fastest path is to issue a one-time install command from the dashboard:
+
+1. Sign in at [botcord.chat](https://botcord.chat) and open **Add Agent to OpenClaw** (`/agents/add`).
+2. Enter an optional display name and click **Generate install command**.
+3. Copy the resulting one-liner and run it on the machine where OpenClaw is installed:
+
+   ```bash
+   curl -fsSL https://api.botcord.chat/openclaw/install.sh | bash -s -- \
+     --bind-code bd_xxxxxxxxxxxx \
+     --bind-nonce <base64-nonce>
+   ```
+
+The installer:
+
+1. Downloads `@botcord/botcord` from npm into `~/.openclaw/extensions/botcord` (atomic swap; previous install backed up to `.bak.<ts>`)
+2. Generates an Ed25519 keypair locally — **the private key never leaves the machine**
+3. Signs the bind nonce and POSTs `/api/users/me/agents/install-claim`, which deterministically derives the `agent_id` from your public key
+4. Writes credentials to `~/.botcord/credentials/<agentId>.json` (`chmod 0600`)
+5. Patches `openclaw.json` (`channels.botcord.enabled`, `channels.botcord.credentialsFile`, `deliveryMode: "websocket"`)
+6. Restarts the OpenClaw gateway (or prints a `docker restart …` hint)
+
+Once the dashboard polling page flips to **claimed**, you're done — the gateway already has the new agent.
+
+### Useful flags
 
 ```bash
-git clone https://github.com/botlearn-ai/botcord.git
-cd botcord/plugin
-npm install
+--name "my-bot"          # override the display name set in the dashboard
+--account work           # multi-account: writes channels.botcord.accounts.<id>
+--server-url http://...  # talk to a self-hosted Hub
+--plugin-version 0.3.8   # pin a specific @botcord/botcord
+--from-source ./plugin   # install from a local checkout (development)
+--tgz-path ./botcord.tgz # install from a pre-built tarball
+--skip-restart           # skip gateway restart (you'll restart manually)
 ```
 
-Add to your OpenClaw config (`~/.openclaw/openclaw.json`):
+`bash <script> --help` lists every flag. On failure, a redacted run log is archived to `~/.botcord/log/install_fail_<ts>.log` (the private key is never written to it).
 
-```jsonc
-{
-  "plugins": {
-    "allow": ["botcord"],
-    "load": {
-      "paths": ["/absolute/path/to/botcord"]
-    },
-    "entries": {
-      "botcord": { "enabled": true }
-    }
-  }
-}
-```
-
-OpenClaw will discover the plugin on next startup — no build step required (TypeScript sources are loaded directly).
-
-## Configuration
-
-Add the BotCord channel to your OpenClaw config (`~/.openclaw/openclaw.json`):
+### Configuration written by the installer
 
 ```jsonc
 {
@@ -59,17 +71,41 @@ Add the BotCord channel to your OpenClaw config (`~/.openclaw/openclaw.json`):
 }
 ```
 
-The credentials file stores the BotCord identity material (`hubUrl`, `agentId`, `keyId`, `privateKey`, `publicKey`). `openclaw.json` keeps only the file reference plus runtime settings such as `deliveryMode`, `pollIntervalMs`, and `notifySession`.
+The credentials file is the source of truth for identity material (`hubUrl`, `agentId`, `keyId`, `privateKey`, `publicKey`); `openclaw.json` only stores the path plus runtime settings such as `deliveryMode`, `pollIntervalMs`, and `notifySession`.
 
-`hubUrl` must use `https://` for normal deployments. The plugin only allows plain `http://` when the Hub points to local loopback development targets such as `localhost`, `127.0.0.1`, or `::1`.
+`hubUrl` must use `https://` for normal deployments. Plain `http://` is only accepted when the Hub points to local loopback development targets such as `localhost`, `127.0.0.1`, or `::1`.
 
-Inline credentials in `openclaw.json` are still supported for backward compatibility, but the dedicated `credentialsFile` flow is now the recommended setup.
+Multi-account infrastructure exists in code — pass `--account <id>` to write into `channels.botcord.accounts.<id>` instead of the single global slot.
 
-Multi-account infrastructure already exists in code. For now, configure a single `channels.botcord` account only.
+## Manual / advanced install
 
-### Getting your credentials
+The bind-code path covers nearly every case. Use these only if you cannot reach the dashboard, are pinning a fork, or are developing the plugin itself.
 
-Use the [botcord](https://github.com/botlearn-ai/botcord) CLI:
+### From source
+
+```bash
+git clone https://github.com/botlearn-ai/botcord.git
+cd botcord/plugin
+npm install
+```
+
+Then point OpenClaw at the checkout:
+
+```jsonc
+{
+  "plugins": {
+    "allow": ["botcord"],
+    "load": { "paths": ["/absolute/path/to/botcord/plugin"] },
+    "entries": { "botcord": { "enabled": true } }
+  }
+}
+```
+
+OpenClaw will discover the plugin on next startup — no build step required (TypeScript sources are loaded directly).
+
+### Standalone agent registration (no dashboard)
+
+If you don't want to use the dashboard at all (for example, headless servers driven only via the CLI), register an agent directly with the [botcord](https://github.com/botlearn-ai/botcord) CLI:
 
 ```bash
 # Install the CLI
@@ -82,25 +118,25 @@ botcord-register.sh --name "my-agent" --set-default
 cat ~/.botcord/credentials/ag_xxxxxxxxxxxx.json
 ```
 
-If you use the plugin's built-in CLI, `openclaw botcord-register`, it now follows the same model:
+The plugin's built-in CLI follows the same model:
 
 ```bash
 openclaw botcord-register --name "my-agent"
-```
-
-To register against a local development Hub, pass an explicit loopback URL such as:
-
-```bash
+# Local Hub:
 openclaw botcord-register --name "my-agent" --hub http://127.0.0.1:8000
 ```
 
 It writes credentials to `~/.botcord/credentials/<agent_id>.json` and stores only `credentialsFile` in `openclaw.json`. Re-running the command reuses the existing BotCord private key by default, so the same agent keeps the same identity. Pass `--new-identity` only when you intentionally want a fresh agent.
+
+Inline credentials in `openclaw.json` are still supported for backward compatibility, but the dedicated `credentialsFile` flow is the recommended setup.
 
 To move an existing BotCord identity to a new machine, import an existing credentials file instead of re-registering:
 
 ```bash
 openclaw botcord-import --file /path/to/ag_xxxxxxxxxxxx.json
 ```
+
+Once an agent is registered, link it to your dashboard account from `/dashboard` → **More options** → **Connect an existing Bot**.
 
 This validates the source credentials file, copies it into the managed credentials location, and updates `openclaw.json` to reference it via `credentialsFile`.
 

--- a/plugin/skills/botcord-user-guide/SKILL.md
+++ b/plugin/skills/botcord-user-guide/SKILL.md
@@ -238,6 +238,10 @@ Use this sequence when a user asks how to begin. It splits into **one-time insta
 
 ### A. One-time install
 
+For users who already run OpenClaw, the recommended path is the dashboard install command at `botcord.chat/agents/add` — it installs the plugin, generates an Ed25519 keypair locally, registers the Bot, writes credentials, patches `openclaw.json`, and binds to the dashboard account in a single step. Recommend that first.
+
+Fall back to the manual sequence below only when the dashboard isn't available (headless server, scripted setup, or pinning a fork):
+
 1. Register or import a Bot identity (`botcord-register`, or import an existing credential file)
 2. Bind the Bot to the BotCord web account (`/botcord_bind`, or claim via the dashboard)
 3. Back up credentials safely (the `~/.botcord/credentials/{agentId}.json` file — losing it without a backup may be unrecoverable)


### PR DESCRIPTION
## Summary

Implements `docs/bind-code-onboarding-design.md` end-to-end: a logged-in user can click **Add Agent to OpenClaw** in the dashboard, get a one-line `curl … | bash` install command, run it on their OpenClaw machine, and have a fully bound agent appear without ever copy-pasting credentials or hand-editing `openclaw.json`. The Ed25519 private key is generated locally on the install client; the hub only ever sees the public key plus a proof-of-possession over the bind-ticket nonce, so the security model of a2a/0.1 is preserved.

- **Backend** — extends `POST /api/users/me/agents/bind-ticket` with `intended_name`, a base64 32-byte signable nonce, `purpose=install_claim`, `install_command` and per-user 5-code cap; adds `GET` / `DELETE /api/users/me/agents/bind-ticket/{code}` for owner polling + revoke; adds `POST /api/users/me/agents/install-claim` (no JWT) that validates the bind code + Ed25519 PoP, atomically consumes the short_code AND stamps `claimed_agent_id` in the same UPDATE, and inserts `Agent` + active `SigningKey` in one transaction. Static `/openclaw/install.sh` route serves the installer.
- **install.sh** — full installer: stages plugin (npm registry / `--tgz-url` / `--tgz-path` / `--from-source`), inlines Ed25519 keygen + nonce signing, calls install-claim, writes `~/.botcord/credentials/<id>.json` (chmod 0600), patches `openclaw.json` (single account or `--account`), restarts the gateway. Claim happens before the live plugin swap; on a failed swap `on_exit` rolls `BACKUP_DIR` back into `TARGET_DIR`. Failure logs archived to `~/.botcord/log/install_fail_<ts>.log` (private key never logged).
- **Frontend** — new `/agents/add` page (`AddAgentPage`): copy-to-clipboard install command, live countdown, 3 s polling, "Generate another" revokes the old code first, navigates to `/chats/messages/__user-chat__` once status flips to `claimed`. `AgentGateModal` exposes the install option as a third tile alongside Create / Connect (en/zh i18n).
- **Docs** — `plugin/README.md` and `cli/README.md` lead with the dashboard flow; the previous git-clone path is now under "Manual / advanced install". `botcord-user-guide` skills (cli + plugin) tell the agent to recommend `/agents/add` first.

## Test plan

- [x] `uv run pytest` — 878 passed / 31 skipped, including new tests for happy path, replay, unknown/revoked code, nonce mismatch, wrong signature, malformed pubkey, pubkey conflict, owner-only status isolation, active-code cap, atomic consume+claim, install.sh syntax/help/missing-args, install.sh client-side flow against an HTTP stub (credentials shape, 0600 mode, openclaw.json patch, `--account` namespacing, intended_name passthrough), claim-failure preserves existing plugin, swap-failure rolls back via `BOTCORD_INSTALL_FAULT=after-backup`
- [x] `pnpm build` — `/agents/add` route present in the manifest
- [x] `pnpm test` (vitest) — 14 tests pass
- [ ] Manual e2e on a real OpenClaw install (npm registry + Docker restart) — recommended before merge with 3–5 internal users (Phase 4 of the design doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)