### PR TITLE
fix: align owner-chat agent replies to the left in dashboard

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -1787,12 +1787,19 @@ async def get_room_messages(
         for t in topic_result.scalars().all():
             topic_info[t.topic_id] = {"title": t.title}
 
-    # Resolve human sender user display names (only for human room rows)
+    # Resolve human sender user display names (human-room + owner-chat rows)
     human_user_ids = {
         r.source_user_id for r in records
-        if (r.source_type or "") == "dashboard_human_room" and r.source_user_id
+        if (r.source_type or "") in ("dashboard_human_room", "dashboard_user_chat")
+        and r.source_user_id
     }
     user_name_map = await load_user_display_names(db, human_user_ids)
+
+    # Owner-chat rooms (rm_oc_*) are always viewed as the human owner — both
+    # user-typed messages and the agent's replies share sender_id=agent_id, so
+    # anchoring the viewer to the agent would mark every message as "mine".
+    if room_id.startswith("rm_oc_"):
+        viewer_agent_id = None
 
     messages = []
     for rec in records:

--- a/backend/hub/dashboard_message_shaping.py
+++ b/backend/hub/dashboard_message_shaping.py
@@ -18,10 +18,12 @@ from hub.models import Agent, MessageRecord, User
 _logger = logging.getLogger(__name__)
 
 HUMAN_ROOM_SOURCE_TYPE = "dashboard_human_room"
+USER_CHAT_SOURCE_TYPE = "dashboard_user_chat"
+HUMAN_SOURCE_TYPES = frozenset({HUMAN_ROOM_SOURCE_TYPE, USER_CHAT_SOURCE_TYPE})
 
 
 def sender_kind_for(source_type: str | None) -> str:
-    return "human" if source_type == HUMAN_ROOM_SOURCE_TYPE else "agent"
+    return "human" if source_type in HUMAN_SOURCE_TYPES else "agent"
 
 
 async def load_user_display_names(


### PR DESCRIPTION
## Summary
- In `rm_oc_*` (owner-chat) rooms both user-typed messages and the agent's replies share `sender_id=agent_id`. Anchoring `viewer_agent_id` to that agent made every message render as `is_mine=true` (right side).
- Treat `dashboard_user_chat` rows as human-sourced in `derive_sender_fields`, include them in the user display-name lookup, and force `viewer_agent_id=None` for `rm_oc_*` rooms so the human owner is always the viewer.
- Frontend already prefers `message.is_mine` (`MessageBubble.tsx:106`), so no UI change required.

## Test plan
- [x] `uv run pytest tests/test_dashboard_chat.py tests/test_dashboard.py tests/test_dashboard_rooms_human_send.py`
- [ ] Manual: open an owner-chat room in the dashboard — agent replies render on the left, user messages on the right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)