### PR TITLE
fix: reject contact request from human to their own agent

### DIFF
--- a/backend/app/routers/humans.py
+++ b/backend/app/routers/humans.py
@@ -1501,6 +1501,12 @@ async def send_contact_request(
         if agent is None:
             raise HTTPException(status_code=404, detail="Agent not found")
 
+        if agent.user_id == user.id:
+            raise HTTPException(
+                status_code=400,
+                detail="Cannot send contact request to your own agent",
+            )
+
         if agent.user_id is not None:
             # Claimed agent: queue for owner's approval.
             payload = {

--- a/backend/tests/test_app/test_app_humans.py
+++ b/backend/tests/test_app/test_app_humans.py
@@ -475,6 +475,33 @@ async def test_self_contact_rejected(client, seed):
 
 
 @pytest.mark.asyncio
+async def test_contact_request_to_own_agent_rejected(
+    client, seed, db_session: AsyncSession
+):
+    db_session.add(
+        Agent(
+            agent_id="ag_alice0000001",
+            display_name="Alice's Agent",
+            message_policy=MessagePolicy.contacts_only,
+            user_id=seed["user_id"],
+            claimed_at=datetime.datetime.now(datetime.timezone.utc),
+        )
+    )
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/humans/me/contacts/request",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+        json={"peer_id": "ag_alice0000001"},
+    )
+    assert resp.status_code == 400, resp.text
+    assert "own agent" in resp.json()["detail"].lower()
+
+    queue_rows = await db_session.execute(select(AgentApprovalQueue))
+    assert list(queue_rows.scalars().all()) == []
+
+
+@pytest.mark.asyncio
 async def test_bad_peer_prefix_rejected(client, seed):
     resp = await client.post(
         "/api/humans/me/contacts/request",


### PR DESCRIPTION
## Summary
- Human → owned-agent friend request now returns 400 instead of queuing into `AgentApprovalQueue` (which let the same user auto-approve a self-loop contact)
- Check added in `app/routers/humans.py` send_contact_request: short-circuit when `agent.user_id == user.id`
- Agent → agent across same owner is unaffected — they remain independent a2a identities

## Test plan
- [x] `uv run pytest backend/tests/test_app/test_app_humans.py::test_contact_request_to_own_agent_rejected` passes
- [x] Existing `test_contact_request_to_claimed_agent_queues_approval` and `test_self_contact_rejected` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)