### PR TITLE
fix(dashboard): hide join/share controls in owner-chat rooms

### DIFF
--- a/frontend/src/components/dashboard/RoomHeader.tsx
+++ b/frontend/src/components/dashboard/RoomHeader.tsx
@@ -73,6 +73,10 @@ export default function RoomHeader() {
 
   // DM room detection: room_id prefix "rm_dm_"
   const isDMRoom = Boolean(openedRoomId?.startsWith("rm_dm_"));
+  // Owner-chat room: deterministic container between a user and their own agent.
+  // The user is not stored as a RoomMember (only the agent is), so generic
+  // join/invite logic would mistakenly treat the user as an outsider.
+  const isOwnerChatRoom = Boolean(openedRoomId?.startsWith("rm_oc_"));
   // For DM rooms, figure out the partner agent by filtering activeAgentId from the room ID parts
   const dmPartnerAgentId = isDMRoom && openedRoomId && activeAgentId
     ? openedRoomId.replace("rm_dm_", "").split("_ag_")
@@ -170,7 +174,7 @@ export default function RoomHeader() {
   if (!room) return null;
 
   const renderJoinButton = () => {
-    if (isJoined) return null;
+    if (isJoined || isOwnerChatRoom) return null;
 
     if (room.required_subscription_product_id) {
       return (
@@ -325,7 +329,7 @@ export default function RoomHeader() {
               {t.guest}
             </span>
           )}
-          {isJoined && !isDMRoom && (
+          {isJoined && !isDMRoom && !isOwnerChatRoom && (
             <span className="group relative">
               <button
                 onClick={() => setShowShareModal(true)}
@@ -337,7 +341,7 @@ export default function RoomHeader() {
               <span className={tooltipCls}>{t.shareRoom}</span>
             </span>
           )}
-          {isAuthedReady && (isJoined || isDMRoom) && (
+          {isAuthedReady && (isJoined || isDMRoom) && !isOwnerChatRoom && (
             <span className="group relative">
               <button
                 onClick={() => setShowSettingsModal(true)}
@@ -349,7 +353,7 @@ export default function RoomHeader() {
               <span className={tooltipCls}>{t.roomSettings}</span>
             </span>
           )}
-          {!isDMRoom && (
+          {!isDMRoom && !isOwnerChatRoom && (
             <span className="group relative">
               <button
                 onClick={handleOpenMembersPanel}


### PR DESCRIPTION
## Summary
- Owner-chat rooms (`rm_oc_*`) are 1:1 containers between a user and their own agent. The user is not a `RoomMember` (only the agent is), so the generic `isJoined` check fell through and the room's `invite_only` join policy surfaced a misleading "Request to Join" button in the header.
- Detect the `rm_oc_` prefix (analogous to the existing `rm_dm_` handling), short-circuit `renderJoinButton`, and hide the share / settings / members buttons that have no semantic in this context.

## Test plan
- [ ] Open an owner-chat room from the dashboard sidebar; confirm the top-right no longer shows "Request to Join", Share, Settings, or Members.
- [ ] Open a regular invite-only room you are not in; confirm "Request to Join" still renders.
- [ ] Open a DM (`rm_dm_*`); confirm existing DM behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)