### PR TITLE
feat(frontend): add Settings link to account menu

### DIFF
--- a/frontend/src/components/dashboard/AccountMenu.tsx
+++ b/frontend/src/components/dashboard/AccountMenu.tsx
@@ -220,6 +220,15 @@ export default function AccountMenu({
               </>
             )}
 
+            <DropdownMenu.Separator className="my-1 h-px bg-glass-border" />
+            <DropdownMenu.Item
+              onClick={() => { window.location.href = "/settings/daemons"; }}
+              className="relative flex cursor-pointer select-none items-center rounded-md px-2 py-1.5 text-sm outline-none transition-colors text-text-primary focus:bg-neon-cyan/10 focus:text-neon-cyan"
+            >
+              <Settings className="mr-2 h-4 w-4 text-neon-cyan" />
+              <span>{locale === "zh" ? "设置" : "Settings"}</span>
+            </DropdownMenu.Item>
+
             {user?.beta_admin && (
               <>
                 <DropdownMenu.Separator className="my-1 h-px bg-glass-border" />


### PR DESCRIPTION
## Summary
- Adds a "Settings" entry in the dashboard account dropdown menu, linking to `/settings/daemons`
- Previously the daemon management page was only reachable by typing the URL manually
- Visible to all signed-in users (sits between "Edit profile" and the admin-only "Admin" entry)

## Test plan
- [ ] Open the dashboard, click the user avatar — verify "Settings / 设置" appears
- [ ] Click it — lands on `/settings/daemons`
- [ ] Verify daemon rename (pencil icon) still works on that page

🤖 Generated with [Claude Code](https://claude.com/claude-code)