### PR TITLE
feat(daemon): sync dashboard agent name/bio edits to identity.md

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -5,6 +5,7 @@
 [PROTOCOL]: 变更时更新此头部，然后检查 README.md
 """
 
+import asyncio
 import base64
 import datetime
 import hashlib
@@ -977,20 +978,68 @@ async def patch_agent(
         )
         agent.is_default = True
 
+    identity_changed = False
     if body.display_name is not None:
         name = body.display_name.strip()
         if not name:
             raise HTTPException(status_code=400, detail="display_name must not be empty")
-        agent.display_name = name
+        if agent.display_name != name:
+            agent.display_name = name
+            identity_changed = True
 
     if body.bio is not None:
         # Normalise empty string to NULL so it reads as "no bio" downstream.
-        bio = body.bio.strip()
-        agent.bio = bio or None
+        bio = body.bio.strip() or None
+        if agent.bio != bio:
+            agent.bio = bio
+            identity_changed = True
 
     await db.commit()
     await db.refresh(agent)
+
+    # Best-effort live push to the daemon — fire-and-forget so a slow or
+    # half-open daemon WS can never inflate this PATCH's latency. Offline
+    # daemons reconcile via the `hello.agents` snapshot on next reconnect.
+    if identity_changed and agent.daemon_instance_id and is_daemon_online(agent.daemon_instance_id):
+        params: dict[str, object | None] = {"agentId": agent.agent_id}
+        if body.display_name is not None:
+            params["displayName"] = agent.display_name
+        if body.bio is not None:
+            params["bio"] = agent.bio
+        task = asyncio.create_task(
+            _push_update_agent_frame(agent.daemon_instance_id, agent.agent_id, params)
+        )
+        # Keep a strong reference until completion — without this, the
+        # asyncio event loop only weakly tracks tasks and GC can collect
+        # the coroutine mid-flight (documented CPython behaviour).
+        _BACKGROUND_TASKS.add(task)
+        task.add_done_callback(_BACKGROUND_TASKS.discard)
+
     return _agent_meta(agent)
+
+
+# Strong-reference set keeping fire-and-forget background tasks alive until
+# they complete. See the matching `add` / `discard` calls in `patch_agent`.
+_BACKGROUND_TASKS: set[asyncio.Task] = set()
+
+
+async def _push_update_agent_frame(
+    daemon_instance_id: str, agent_id: str, params: dict[str, object | None]
+) -> None:
+    """Best-effort `update_agent` dispatch — never raises, only logs."""
+    try:
+        await send_control_frame(daemon_instance_id, "update_agent", params)
+    except HTTPException as exc:
+        _logger.info(
+            "update_agent push skipped: agent=%s status=%s detail=%s",
+            agent_id,
+            exc.status_code,
+            exc.detail,
+        )
+    except Exception as exc:  # noqa: BLE001
+        _logger.warning(
+            "update_agent push failed: agent=%s err=%s", agent_id, exc
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/hub/routers/daemon_control.py
+++ b/backend/hub/routers/daemon_control.py
@@ -60,7 +60,7 @@ from hub.id_generators import (
     generate_daemon_instance_id,
     generate_daemon_user_code,
 )
-from hub.models import DaemonDeviceCode, DaemonInstance
+from hub.models import Agent, DaemonDeviceCode, DaemonInstance
 
 logger = logging.getLogger(__name__)
 
@@ -767,10 +767,16 @@ async def daemon_control_ws(ws: WebSocket) -> None:
         except Exception:
             pass
 
-    # Send the hello frame straight away.
+    # Send the hello frame straight away. The `agents` snapshot lets the
+    # daemon reconcile each provisioned agent's on-disk `identity.md` against
+    # the dashboard-edited truth — offline edits land here on next reconnect.
+    agents_snapshot = await _load_agent_identity_snapshot(daemon_instance_id)
     hello = _build_signed_frame(
         "hello",
-        {"server_time": int(_now().timestamp() * 1000)},
+        {
+            "server_time": int(_now().timestamp() * 1000),
+            "agents": agents_snapshot,
+        },
     )
     try:
         await ws.send_text(json.dumps(hello))
@@ -877,6 +883,45 @@ async def _persist_runtime_snapshot(
     instance.runtimes_json = runtimes
     instance.runtimes_probed_at = probed_dt
     return runtimes, probed_dt
+
+
+async def _load_agent_identity_snapshot(
+    daemon_instance_id: str,
+) -> list[dict[str, Any]]:
+    """Return the identity snapshot for every active agent bound to this daemon.
+
+    Embedded in the `hello` frame so the daemon can rewrite each agent's
+    on-disk `identity.md` whenever the dashboard mutated it while the daemon
+    was offline. Failures are logged and yield an empty list — losing the
+    snapshot is preferable to refusing the connection.
+    """
+    try:
+        async with async_session() as db:
+            result = await db.execute(
+                select(Agent).where(
+                    Agent.daemon_instance_id == daemon_instance_id,
+                    Agent.status == "active",
+                )
+            )
+            rows = result.scalars().all()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "hello agents snapshot load failed: instance=%s err=%s",
+            daemon_instance_id,
+            exc,
+        )
+        return []
+    # Only fields the daemon's `applyAgentIdentity` actually consumes ship
+    # on the wire — runtime is already cached locally in the credentials
+    # file and re-sending it here would just bloat the hello payload.
+    return [
+        {
+            "agentId": row.agent_id,
+            "displayName": row.display_name,
+            "bio": row.bio,
+        }
+        for row in rows
+    ]
 
 
 async def _handle_daemon_event(conn: _DaemonConn, msg: dict[str, Any]) -> None:

--- a/backend/tests/test_app/test_app_user_agents.py
+++ b/backend/tests/test_app/test_app_user_agents.py
@@ -557,6 +557,103 @@ async def test_patch_agent_set_default(client: AsyncClient, seed_user: dict):
     assert agents["ag_agent002"]["is_default"] is True
 
 
+@pytest.mark.asyncio
+async def test_patch_agent_pushes_update_when_daemon_online(
+    client: AsyncClient, db_session: AsyncSession, seed_user: dict, monkeypatch
+):
+    """When the agent is bound to a connected daemon, PATCH dispatches an
+    `update_agent` control frame so identity.md is rewritten without waiting
+    for the next reconnect."""
+    # Wire the agent to a (fake) daemon instance and pretend it's online.
+    seed_user["agent1"].daemon_instance_id = "di_test"
+    await db_session.commit()
+
+    import app.routers.users as users_mod
+
+    monkeypatch.setattr(users_mod, "is_daemon_online", lambda _id: True)
+    import asyncio as _asyncio
+
+    captured: dict = {}
+    sent = _asyncio.Event()
+
+    async def fake_send(daemon_id, type_, params, timeout_ms=None):
+        captured["daemon_id"] = daemon_id
+        captured["type"] = type_
+        captured["params"] = params
+        sent.set()
+        return {"id": "x", "ok": True}
+
+    monkeypatch.setattr(users_mod, "send_control_frame", fake_send)
+
+    resp = await client.patch(
+        "/api/users/me/agents/ag_agent001",
+        json={"display_name": "Renamed", "bio": "Fresh bio"},
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert resp.status_code == 200, resp.text
+    # Push is fire-and-forget — wait for the background task to land.
+    await _asyncio.wait_for(sent.wait(), timeout=2.0)
+    assert captured["daemon_id"] == "di_test"
+    assert captured["type"] == "update_agent"
+    assert captured["params"]["agentId"] == "ag_agent001"
+    assert captured["params"]["displayName"] == "Renamed"
+    assert captured["params"]["bio"] == "Fresh bio"
+
+
+@pytest.mark.asyncio
+async def test_patch_agent_swallows_push_error_when_online(
+    client: AsyncClient, db_session: AsyncSession, seed_user: dict, monkeypatch
+):
+    """Even if the daemon is online but the dispatch raises (timeout, 502),
+    the PATCH must still succeed — eventual consistency via hello snapshot."""
+    seed_user["agent1"].daemon_instance_id = "di_flaky"
+    await db_session.commit()
+
+    import app.routers.users as users_mod
+    from fastapi import HTTPException
+
+    monkeypatch.setattr(users_mod, "is_daemon_online", lambda _id: True)
+
+    async def boom(*_a, **_kw):
+        raise HTTPException(504, detail="daemon_ack_timeout")
+
+    monkeypatch.setattr(users_mod, "send_control_frame", boom)
+
+    resp = await client.patch(
+        "/api/users/me/agents/ag_agent001",
+        json={"bio": "Anything"},
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_patch_agent_swallows_offline_daemon(
+    client: AsyncClient, db_session: AsyncSession, seed_user: dict, monkeypatch
+):
+    """Offline daemon must not break the PATCH — eventual consistency is via
+    the next hello snapshot."""
+    seed_user["agent1"].daemon_instance_id = "di_offline"
+    await db_session.commit()
+
+    import app.routers.users as users_mod
+    from fastapi import HTTPException
+
+    monkeypatch.setattr(users_mod, "is_daemon_online", lambda _id: False)
+
+    async def boom(*_a, **_kw):  # pragma: no cover - should never run
+        raise HTTPException(409, detail="daemon_offline")
+
+    monkeypatch.setattr(users_mod, "send_control_frame", boom)
+
+    resp = await client.patch(
+        "/api/users/me/agents/ag_agent001",
+        json={"display_name": "Whatever"},
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert resp.status_code == 200
+
+
 # ---------------------------------------------------------------------------
 # POST /api/users/me/agents/bind-ticket
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_app/test_daemon_control.py
+++ b/backend/tests/test_app/test_daemon_control.py
@@ -18,7 +18,8 @@ import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from hub.models import Base, DaemonDeviceCode, DaemonInstance, Role, User, UserRole
+from hub.enums import MessagePolicy
+from hub.models import Agent, Base, DaemonDeviceCode, DaemonInstance, Role, User, UserRole
 
 TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
 TEST_SUPABASE_SECRET = "test-supabase-jwt-secret-for-daemon-control"
@@ -874,3 +875,69 @@ async def test_refresh_runtimes_daemon_disconnect_returns_502(
         assert detail["code"] == "daemon_disconnected"
     finally:
         await registry.unregister(conn)
+
+
+@pytest.mark.asyncio
+async def test_load_agent_identity_snapshot_returns_active_bound_agents(
+    client: AsyncClient, seed_user, db_session: AsyncSession
+):
+    """The hello frame's agents snapshot must list every active agent bound
+    to the daemon — that's what lets the daemon reconcile identity.md on
+    reconnect after the dashboard mutated it offline."""
+    from hub.routers.daemon_control import _load_agent_identity_snapshot
+
+    bundle = await _provision_instance_via_device_code(client, seed_user)
+    instance_id = bundle["daemon_instance_id"]
+
+    # Two active agents bound to this daemon, one bound but soft-deleted, one
+    # active but bound to a different daemon — only the first two should appear.
+    db_session.add_all(
+        [
+            Agent(
+                agent_id="ag_keep1",
+                display_name="Keep One",
+                bio="Bio one",
+                runtime="claude-code",
+                user_id=seed_user["user_id"],
+                daemon_instance_id=instance_id,
+                message_policy=MessagePolicy.contacts_only,
+                status="active",
+            ),
+            Agent(
+                agent_id="ag_keep2",
+                display_name="Keep Two",
+                bio=None,
+                runtime="codex",
+                user_id=seed_user["user_id"],
+                daemon_instance_id=instance_id,
+                message_policy=MessagePolicy.contacts_only,
+                status="active",
+            ),
+            Agent(
+                agent_id="ag_deleted",
+                display_name="Gone",
+                user_id=seed_user["user_id"],
+                daemon_instance_id=instance_id,
+                message_policy=MessagePolicy.contacts_only,
+                status="deleted",
+            ),
+            Agent(
+                agent_id="ag_other_daemon",
+                display_name="Elsewhere",
+                user_id=seed_user["user_id"],
+                daemon_instance_id="di_other",
+                message_policy=MessagePolicy.contacts_only,
+                status="active",
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    snapshot = await _load_agent_identity_snapshot(instance_id)
+    by_id = {entry["agentId"]: entry for entry in snapshot}
+    assert set(by_id) == {"ag_keep1", "ag_keep2"}
+    assert by_id["ag_keep1"]["displayName"] == "Keep One"
+    assert by_id["ag_keep1"]["bio"] == "Bio one"
+    assert by_id["ag_keep2"]["bio"] is None
+    # runtime is intentionally not on the wire — it's cached locally on the daemon.
+    assert "runtime" not in by_id["ag_keep1"]

--- a/packages/daemon/src/__tests__/agent-workspace.test.ts
+++ b/packages/daemon/src/__tests__/agent-workspace.test.ts
@@ -15,6 +15,7 @@ import {
   agentHomeDir,
   agentStateDir,
   agentWorkspaceDir,
+  applyAgentIdentity,
   ensureAgentWorkspace,
 } from "../agent-workspace.js";
 
@@ -131,6 +132,98 @@ describe("ensureAgentWorkspace", () => {
       for (const ok of ["ag_abc123", "ag_XYZ_9", "ag-dash-ok", "A1", "ag_0"]) {
         expect(() => agentHomeDir(ok)).not.toThrow();
       }
+    });
+  });
+
+  describe("applyAgentIdentity", () => {
+    it("rewrites display name + bio while preserving Role/Boundaries", () => {
+      ensureAgentWorkspace("ag_edit", {
+        displayName: "Old",
+        bio: "Old bio",
+        runtime: "claude-code",
+      });
+      const identityPath = path.join(agentWorkspaceDir("ag_edit"), "identity.md");
+      const original = readFileSync(identityPath, "utf8");
+      // User personalises Role/Boundaries — must survive identity sync.
+      const customised = original
+        .replace("_(Describe what you do and for whom. Edit this section.)_", "I write poetry.")
+        .replace("_(What you will and will not do. Edit this section.)_", "No financial advice.");
+      writeFileSync(identityPath, customised);
+
+      const result = applyAgentIdentity("ag_edit", {
+        displayName: "New Name",
+        bio: "Refreshed bio.",
+      });
+      expect(result.changed).toBe(true);
+
+      const updated = readFileSync(identityPath, "utf8");
+      expect(updated).toContain("- **Display name**: New Name");
+      expect(updated).toContain("Refreshed bio.");
+      expect(updated).not.toContain("Old bio");
+      expect(updated).toContain("I write poetry.");
+      expect(updated).toContain("No financial advice.");
+    });
+
+    it("clears bio back to placeholder when null is passed", () => {
+      ensureAgentWorkspace("ag_clearbio", { bio: "Some bio" });
+      const result = applyAgentIdentity("ag_clearbio", { bio: null });
+      expect(result.changed).toBe(true);
+      const updated = readFileSync(
+        path.join(agentWorkspaceDir("ag_clearbio"), "identity.md"),
+        "utf8",
+      );
+      expect(updated).not.toContain("Some bio");
+      expect(updated).toContain("_(none provided at provision time");
+    });
+
+    it("returns no-change when patch matches current values", () => {
+      ensureAgentWorkspace("ag_idempotent", { displayName: "Same", bio: "Same bio" });
+      const result = applyAgentIdentity("ag_idempotent", {
+        displayName: "Same",
+        bio: "Same bio",
+      });
+      expect(result.changed).toBe(false);
+      expect(result.skipped).toBe("no-change");
+    });
+
+    it("skips when identity.md is missing", () => {
+      const result = applyAgentIdentity("ag_missing", { displayName: "X" });
+      expect(result.changed).toBe(false);
+      expect(result.skipped).toBe("missing-file");
+    });
+
+    it("rewrites correctly when identity.md has no trailing sections after Bio", () => {
+      ensureAgentWorkspace("ag_eofbio", { displayName: "Old", bio: "Old bio" });
+      const identityPath = path.join(agentWorkspaceDir("ag_eofbio"), "identity.md");
+      // Strip everything after `## Bio` so the Bio section runs to EOF.
+      const truncated =
+        readFileSync(identityPath, "utf8").replace(/(## Bio\n\nOld bio)[\s\S]*$/, "$1\n");
+      writeFileSync(identityPath, truncated);
+
+      const result = applyAgentIdentity("ag_eofbio", { bio: "New bio" });
+      expect(result.changed).toBe(true);
+      const updated = readFileSync(identityPath, "utf8");
+      expect(updated).toContain("New bio");
+      expect(updated).not.toContain("Old bio");
+    });
+
+    it("returns unparseable when the canonical metadata header is missing", () => {
+      ensureAgentWorkspace("ag_corrupt", {});
+      const identityPath = path.join(agentWorkspaceDir("ag_corrupt"), "identity.md");
+      writeFileSync(identityPath, "# Identity\n\nThis file was rewritten by a user.\n");
+
+      const result = applyAgentIdentity("ag_corrupt", { displayName: "X" });
+      expect(result.changed).toBe(false);
+      expect(result.skipped).toBe("unparseable");
+    });
+
+    it("treats display names containing regex specials literally", () => {
+      ensureAgentWorkspace("ag_specials", { displayName: "old" });
+      const identityPath = path.join(agentWorkspaceDir("ag_specials"), "identity.md");
+      const result = applyAgentIdentity("ag_specials", { displayName: "$1 backref $&" });
+      expect(result.changed).toBe(true);
+      const updated = readFileSync(identityPath, "utf8");
+      expect(updated).toContain("- **Display name**: $1 backref $&");
     });
   });
 

--- a/packages/daemon/src/__tests__/provision.test.ts
+++ b/packages/daemon/src/__tests__/provision.test.ts
@@ -920,3 +920,111 @@ describe("revoke_agent respects deleteState / deleteWorkspace flags", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// hello + update_agent identity sync (lightweight reconcile path)
+// ---------------------------------------------------------------------------
+
+describe("hello identity snapshot", () => {
+  it("rewrites identity.md for every agent in the snapshot", async () => {
+    await withSandboxHome(async ({ tmp, fs, path: nodePath }) => {
+      const { ensureAgentWorkspace } = await import("../agent-workspace.js");
+      ensureAgentWorkspace("ag_h1", { displayName: "Old1", bio: "Old bio 1" });
+      ensureAgentWorkspace("ag_h2", { displayName: "Old2", bio: "Old bio 2" });
+      void tmp;
+
+      const gw = makeFakeGateway();
+      const provisioner = createProvisioner({
+        gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+      });
+
+      const ack = await provisioner({
+        id: "req_hello",
+        type: CONTROL_FRAME_TYPES.HELLO,
+        params: {
+          server_time: Date.now(),
+          agents: [
+            { agentId: "ag_h1", displayName: "Fresh1", bio: "Fresh bio 1" },
+            { agentId: "ag_h2", displayName: "Fresh2", bio: null },
+            { agentId: "ag_missing", displayName: "Nope", bio: "Nope" },
+          ],
+        },
+      });
+      expect(ack.ok).toBe(true);
+      const result = ack.result as { updated: number; skipped: number };
+      expect(result.updated).toBe(2);
+      expect(result.skipped).toBe(1);
+
+      const id1 = fs.readFileSync(
+        nodePath.join(tmp, ".botcord", "agents", "ag_h1", "workspace", "identity.md"),
+        "utf8",
+      );
+      expect(id1).toContain("Fresh1");
+      expect(id1).toContain("Fresh bio 1");
+      expect(id1).not.toContain("Old1");
+
+      const id2 = fs.readFileSync(
+        nodePath.join(tmp, ".botcord", "agents", "ag_h2", "workspace", "identity.md"),
+        "utf8",
+      );
+      expect(id2).toContain("Fresh2");
+      // bio cleared → placeholder
+      expect(id2).toContain("_(none provided at provision time");
+    });
+  });
+
+  it("tolerates a hello frame with no agents array", async () => {
+    const gw = makeFakeGateway();
+    const provisioner = createProvisioner({
+      gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+    });
+    const ack = await provisioner({
+      id: "req_hello_empty",
+      type: CONTROL_FRAME_TYPES.HELLO,
+      params: { server_time: Date.now() },
+    });
+    expect(ack.ok).toBe(true);
+  });
+});
+
+describe("update_agent handler", () => {
+  it("rewrites identity.md for the targeted agent", async () => {
+    await withSandboxHome(async ({ tmp, fs, path: nodePath }) => {
+      const { ensureAgentWorkspace } = await import("../agent-workspace.js");
+      ensureAgentWorkspace("ag_u1", { displayName: "Before", bio: "Before bio" });
+
+      const gw = makeFakeGateway();
+      const provisioner = createProvisioner({
+        gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+      });
+      const ack = await provisioner({
+        id: "req_update",
+        type: CONTROL_FRAME_TYPES.UPDATE_AGENT,
+        params: { agentId: "ag_u1", displayName: "After", bio: "After bio" },
+      });
+      expect(ack.ok).toBe(true);
+      expect((ack.result as { changed: boolean }).changed).toBe(true);
+
+      const md = fs.readFileSync(
+        nodePath.join(tmp, ".botcord", "agents", "ag_u1", "workspace", "identity.md"),
+        "utf8",
+      );
+      expect(md).toContain("After");
+      expect(md).toContain("After bio");
+    });
+  });
+
+  it("rejects update_agent without agentId", async () => {
+    const gw = makeFakeGateway();
+    const provisioner = createProvisioner({
+      gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+    });
+    const ack = await provisioner({
+      id: "req_update_bad",
+      type: CONTROL_FRAME_TYPES.UPDATE_AGENT,
+      params: {},
+    });
+    expect(ack.ok).toBe(false);
+    expect(ack.error?.code).toBe("bad_params");
+  });
+});

--- a/packages/daemon/src/agent-workspace.ts
+++ b/packages/daemon/src/agent-workspace.ts
@@ -14,6 +14,7 @@ import {
   existsSync,
   lstatSync,
   mkdirSync,
+  readFileSync,
   readlinkSync,
   symlinkSync,
   unlinkSync,
@@ -242,4 +243,92 @@ export function ensureAgentWorkspace(agentId: string, seed: WorkspaceSeed): void
   writeIfMissing(path.join(workspace, "memory.md"), MEMORY_MD);
   writeIfMissing(path.join(workspace, "task.md"), TASK_MD);
   writeIfMissing(path.join(notes, ".gitkeep"), "");
+}
+
+/** Patch fields accepted by {@link applyAgentIdentity}. `bio = null` clears it. */
+export interface AgentIdentityPatch {
+  displayName?: string;
+  bio?: string | null;
+}
+
+/**
+ * Result of applying an identity patch. `changed` is true only when the
+ * file was rewritten on disk; `skipped` reports why (no-op vs. unable).
+ */
+export interface AgentIdentityApplyResult {
+  changed: boolean;
+  skipped?: "missing-file" | "no-change" | "unparseable";
+}
+
+const DISPLAY_NAME_LINE = /^- \*\*Display name\*\*: .*$/m;
+// Match the Bio section's body. Anchor on the next `##` heading when one
+// exists, otherwise consume to end-of-file — keeps the rewrite working when
+// the user has stripped Role/Boundaries sections.
+const BIO_SECTION = /(## Bio\n\n)([\s\S]*?)(\n+##\s|$)/;
+
+/**
+ * Surgically rewrite the `Display name` and `Bio` fields inside an existing
+ * `identity.md`, preserving anything the user has authored elsewhere
+ * (Role / Boundaries / arbitrary new sections). No-op when the file is
+ * missing — provisioning will create it with the correct values, and
+ * subsequent hello snapshots simply reapply the dashboard truth.
+ *
+ * The identity.md template carries `Role` / `Boundaries` headings after
+ * `## Bio`; we anchor the Bio rewrite on "next `##`" so user-added
+ * paragraphs inside Bio are replaced wholesale (the dashboard is the
+ * source of truth) without disturbing siblings.
+ */
+export function applyAgentIdentity(
+  agentId: string,
+  patch: AgentIdentityPatch,
+): AgentIdentityApplyResult {
+  assertSafeAgentId(agentId);
+  const file = path.join(agentWorkspaceDir(agentId), "identity.md");
+  if (!existsSync(file)) {
+    return { changed: false, skipped: "missing-file" };
+  }
+
+  let text: string;
+  try {
+    text = readFileSync(file, "utf8");
+  } catch {
+    return { changed: false, skipped: "missing-file" };
+  }
+
+  const original = text;
+  let touched = false;
+
+  if (typeof patch.displayName === "string") {
+    const value = patch.displayName.length > 0 ? patch.displayName : FIELD_PLACEHOLDER;
+    if (DISPLAY_NAME_LINE.test(text)) {
+      // Use a function replacer so `$1`, `$&` etc. inside the value are
+      // treated literally rather than as backreferences.
+      text = text.replace(DISPLAY_NAME_LINE, () => `- **Display name**: ${value}`);
+      touched = true;
+    } else {
+      // Heavily-edited file without the canonical metadata block — bail
+      // out rather than guess where to splice.
+      return { changed: false, skipped: "unparseable" };
+    }
+  }
+
+  if (patch.bio !== undefined) {
+    const bioText =
+      patch.bio !== null && patch.bio.trim().length > 0
+        ? patch.bio.trim()
+        : BIO_PLACEHOLDER;
+    if (BIO_SECTION.test(text)) {
+      text = text.replace(BIO_SECTION, (_match, head, _body, tail) => `${head}${bioText}${tail}`);
+      touched = true;
+    } else {
+      return { changed: false, skipped: "unparseable" };
+    }
+  }
+
+  if (!touched || text === original) {
+    return { changed: false, skipped: "no-change" };
+  }
+
+  writeFileSync(file, text, { mode: 0o600 });
+  return { changed: true };
 }

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -14,14 +14,17 @@ import {
   derivePublicKey,
   loadStoredCredentials,
   writeCredentialsFile,
+  type AgentIdentitySnapshot,
   type ControlAck,
   type ControlFrame,
+  type HelloParams,
   type ListRuntimesResult,
   type ProvisionAgentParams,
   type RevokeAgentParams,
   type RevokeAgentResult,
   type RuntimeProbeResult,
   type StoredBotCordCredentials,
+  type UpdateAgentParams,
 } from "@botcord/protocol-core";
 import type { Gateway } from "./gateway/index.js";
 import type {
@@ -41,6 +44,7 @@ import {
   agentHomeDir,
   agentStateDir,
   agentWorkspaceDir,
+  applyAgentIdentity,
   ensureAgentWorkspace,
 } from "./agent-workspace.js";
 import { detectRuntimes, getAdapterModule } from "./adapters/runtimes.js";
@@ -76,6 +80,38 @@ export function createProvisioner(opts: ProvisionerOptions): (
     switch (frame.type) {
       case CONTROL_FRAME_TYPES.PING:
         return { ok: true, result: { pong: true, ts: Date.now() } };
+
+      case CONTROL_FRAME_TYPES.HELLO: {
+        const params = (frame.params ?? {}) as unknown as HelloParams;
+        const result = applyHelloIdentitySnapshot(params.agents);
+        daemonLog.debug("hello: identity snapshot applied", {
+          frameId: frame.id,
+          received: params.agents?.length ?? 0,
+          updated: result.updated,
+          skipped: result.skipped,
+        });
+        return { ok: true, result };
+      }
+
+      case CONTROL_FRAME_TYPES.UPDATE_AGENT: {
+        const params = (frame.params ?? {}) as unknown as UpdateAgentParams;
+        if (!params.agentId) {
+          return {
+            ok: false,
+            error: { code: "bad_params", message: "update_agent requires params.agentId" },
+          };
+        }
+        const result = applyAgentIdentity(params.agentId, {
+          displayName: params.displayName,
+          bio: params.bio,
+        });
+        daemonLog.info("update_agent applied", {
+          agentId: params.agentId,
+          changed: result.changed,
+          skipped: result.skipped ?? null,
+        });
+        return { ok: true, result };
+      }
 
       case CONTROL_FRAME_TYPES.PROVISION_AGENT: {
         const params = (frame.params ?? {}) as unknown as ProvisionAgentParams;
@@ -553,6 +589,54 @@ export function collectRuntimeSnapshot(): ListRuntimesResult {
     return record;
   });
   return { runtimes, probedAt: Date.now() };
+}
+
+// ---------------------------------------------------------------------------
+// hello agents snapshot (lightweight identity sync)
+// ---------------------------------------------------------------------------
+
+interface HelloIdentityResult {
+  updated: number;
+  skipped: number;
+}
+
+/**
+ * Reconcile every agent identity carried by the `hello.agents` snapshot
+ * against the on-disk `identity.md`. Best-effort: a malformed entry or a
+ * file-system error for one agent never aborts the rest.
+ *
+ * Identity-snapshot semantics intentionally only touch the metadata
+ * line + Bio body — Role/Boundaries paragraphs the user authored locally
+ * are preserved (see `applyAgentIdentity`). Missing identity.md files
+ * (agent provisioned on a different daemon, or workspace cleared) are
+ * silently skipped.
+ */
+export function applyHelloIdentitySnapshot(
+  snapshot: AgentIdentitySnapshot[] | undefined,
+): HelloIdentityResult {
+  const out: HelloIdentityResult = { updated: 0, skipped: 0 };
+  if (!Array.isArray(snapshot)) return out;
+  for (const entry of snapshot) {
+    if (!entry || typeof entry.agentId !== "string") {
+      out.skipped += 1;
+      continue;
+    }
+    try {
+      const result = applyAgentIdentity(entry.agentId, {
+        displayName: entry.displayName,
+        bio: entry.bio,
+      });
+      if (result.changed) out.updated += 1;
+      else out.skipped += 1;
+    } catch (err) {
+      out.skipped += 1;
+      daemonLog.warn("hello.identity apply failed", {
+        agentId: entry.agentId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return out;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/protocol-core/src/control-frame.ts
+++ b/packages/protocol-core/src/control-frame.ts
@@ -51,6 +51,14 @@ export const CONTROL_FRAME_TYPES = {
   AGENT_REVOKED: "agent_revoked",
   CONFIG_RELOADED: "config_reloaded",
   /**
+   * Hub→daemon: identity metadata (display name / bio) for an existing agent
+   * has changed on the dashboard. Daemon rewrites the on-disk
+   * `identity.md` for that agent. Sent best-effort while the daemon is
+   * connected; offline daemons catch up via the `agents` snapshot embedded
+   * on the next `hello` frame.
+   */
+  UPDATE_AGENT: "update_agent",
+  /**
    * Hub→daemon: ask the daemon to re-probe locally installed AI CLI
    * runtimes (claude-code, codex, gemini, …) and return the current
    * snapshot. Used by the dashboard "refresh runtimes" button. Plan §8.5
@@ -120,6 +128,43 @@ export interface ProvisionAgentParams {
     cwd?: string;
   };
 }
+
+/**
+ * Identity metadata snapshot for one agent bound to the daemon. Used both
+ * inside the `hello` frame `agents` array (full snapshot on connect) and as
+ * the basis for the single-agent `update_agent` frame.
+ *
+ * `bio` is `null` when the dashboard cleared it, distinct from `undefined`
+ * which means "no value sent" — daemon writes a placeholder for the former
+ * and skips the field for the latter.
+ */
+export interface AgentIdentitySnapshot {
+  agentId: string;
+  displayName?: string;
+  bio?: string | null;
+  runtime?: string | null;
+}
+
+/**
+ * Payload shape for the Hub-issued `hello` frame. The `server_time` field
+ * is snake_case to match the Hub's pre-existing wire shape (every other
+ * runtime/snapshot frame uses camelCase, but hello shipped first with
+ * snake_case and renaming would break older daemons). `agents` was added
+ * so the daemon can reconcile each provisioned agent's on-disk
+ * `identity.md` against the dashboard-edited truth on every (re)connect.
+ */
+export interface HelloParams {
+  server_time?: number;
+  agents?: AgentIdentitySnapshot[];
+}
+
+/**
+ * Payload shape for `update_agent`. Sent best-effort from the Hub right
+ * after a dashboard PATCH, when the target daemon is currently online.
+ * Offline daemons rely on the `hello.agents` snapshot for eventual
+ * consistency, so this frame is fire-and-forget.
+ */
+export type UpdateAgentParams = AgentIdentitySnapshot;
 
 /** Payload shape for `revoke_agent`. */
 export interface RevokeAgentParams {


### PR DESCRIPTION
## Summary

Dashboard PATCH on `display_name` / `bio` previously only updated the Hub DB; the daemon's on-disk `~/.botcord/agents/{id}/workspace/identity.md` was written once at provisioning and never refreshed, so CLIs read a stale identity.

This adds two reconcile paths:

- **Online** — backend dispatches a new `update_agent` control frame as a fire-and-forget background task (strong-ref'd to dodge the `asyncio.create_task` GC weak-ref gotcha). PATCH never blocks on the daemon ack.
- **Offline** — `hello` frame now embeds an `agents` snapshot of every active agent bound to the daemon; on every (re)connect the daemon re-applies it surgically — the canonical metadata header + Bio body get rewritten while user-authored Role/Boundaries paragraphs are preserved.

Display names containing regex specials (`\$1`, `\$&`) are handled literally via a function replacer.

## Test plan

- [x] Daemon unit tests (`vitest`): 450/450 incl. new cases — surgical rewrite, regex-special display names, missing-file/unparseable skip paths, hello batch snapshot, update_agent dispatch
- [x] Backend pytest: 896 passed / 31 skipped incl. new cases — patch_agent online push (with sentinel `asyncio.Event` to wait on the fire-and-forget task), patch_agent offline daemon swallow, patch_agent online-but-push-raises swallow, `_load_agent_identity_snapshot` filters by daemon + status
- [x] Type-check (`tsc --noEmit`) clean across protocol-core + daemon

## Out of scope

- The `runtime` field is intentionally NOT shipped on the wire — it's already cached locally in each agent's credentials file. Documented inline.