### PR TITLE
feat: OpenClaw runtime onboarding (host control plane + dashboard branch)

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -2510,15 +2510,25 @@ async def openclaw_provision(
             },
         )
 
+    # Trust check: a buggy or compromised host could ack with someone
+    # else's agent_id. Only return success if the row was actually
+    # produced by *this* provision (correct owner + same host instance).
+    # Note we deliberately don't fall through to a different "wrong agent"
+    # error code — leaking that an unrelated agent_id exists is itself a
+    # disclosure.
     agent_q = await db.execute(select(Agent).where(Agent.agent_id == agent_id))
     agent = agent_q.scalar_one_or_none()
-    if agent is None:
+    if (
+        agent is None
+        or str(agent.user_id) != str(ctx.user_id)
+        or agent.openclaw_host_id != instance.id
+    ):
         await _burn_provision_code()
         raise HTTPException(
             status_code=502,
             detail={
                 "code": "openclaw_provision_failed",
-                "host_message": "agent row not found post-claim",
+                "host_message": "agent row not found or not bound to this host",
             },
         )
 

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -469,22 +469,32 @@ async def _consume_bind_code(code: str) -> bool:
     return await _consume_short_code(code, "bind")
 
 
-async def _revert_short_code_claim(code: str, kind: str) -> None:
-    """Best-effort: re-open a short_code that was consumed-with-claim.
+async def _revert_short_code_claim(
+    code: str, kind: str, *, reopen: bool = False
+) -> None:
+    """Best-effort: roll back a ``claimed_agent_id`` stamp on a short_code.
 
-    Used when the downstream insert (Agent / SigningKey / etc.) fails after
-    :func:`_consume_short_code_with_claim` has already stamped
-    ``claimed_agent_id`` and bumped ``use_count``. We re-set ``use_count``
-    to 0 / ``consumed_at`` to NULL and strip the claim metadata so polling
-    readers don't observe a "claimed but agent missing" state. The
-    underlying ticket (signed JWT-style payload) and ``jti`` are *not*
-    re-issued — replay is still impossible because the JTI burn is
-    independent.
+    Used when the downstream insert (Agent / SigningKey / etc.) fails
+    after :func:`_consume_short_code_with_claim` already stamped the
+    short_code. The claim metadata is always stripped so polling never
+    reports a phantom "claimed but agent missing" state.
+
+    ``reopen`` controls what happens to the consumed bookkeeping:
+
+    - ``False`` (default, **safe for bind tickets**): leave ``consumed_at``
+      and ``use_count`` set. The row stays terminal — polling reports the
+      bind code as no longer pending and the user must request a fresh one.
+      This avoids a phantom-pending state when the ``jti`` was burned by
+      :func:`_consume_bind_ticket_jti` (one-shot, irreversible) and the
+      ticket can therefore never be redeemed again even if reopened.
+
+    - ``True``: also reset ``consumed_at = None`` and ``use_count = 0`` so
+      the code can be re-redeemed. Only safe for short_code kinds whose
+      consume path is *not* JTI-gated (e.g. ``openclaw_provision``).
 
     Failures are swallowed: if the revert can't run (DB down, transaction
-    poisoned), the consumer is left in the consumed state, which is the
-    safe direction for credential issuance — the user can simply request
-    a new bind code.
+    poisoned), the row is left consumed-with-stamp, which is the
+    fail-closed direction for credential issuance.
     """
     try:
         async with _short_code_session_factory() as code_session:
@@ -504,14 +514,14 @@ async def _revert_short_code_claim(code: str, kind: str) -> None:
             payload.pop("claimed_agent_id", None)
             payload.pop("claimed_at", None)
             new_payload_json = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+            values: dict = {"payload_json": new_payload_json}
+            if reopen:
+                values["consumed_at"] = None
+                values["use_count"] = 0
             await code_session.execute(
                 update(ShortCode)
                 .where(ShortCode.code == code, ShortCode.kind == kind)
-                .values(
-                    consumed_at=None,
-                    use_count=0,
-                    payload_json=new_payload_json,
-                )
+                .values(**values)
             )
             await code_session.commit()
     except Exception:  # noqa: BLE001
@@ -2438,29 +2448,39 @@ async def openclaw_provision(
         "owner_user_id": str(ctx.user_id),
     }
 
-    try:
-        ack = await send_host_control_frame(
-            instance.id, "provision_agent", frame_params
-        )
-    except HTTPException:
-        # Best-effort revoke the unconsumed short code so it can't be
-        # racey-redeemed later.
+    async def _burn_provision_code() -> None:
+        # Best-effort: stamp consumed_at on the unredeemed provision code so
+        # a late host claim can't sneak through after we've already returned
+        # an error to the dashboard. Failures here are intentionally
+        # swallowed — the TTL provides a hard ceiling either way.
         try:
             async with _short_code_session_factory() as code_session:
                 await code_session.execute(
                     update(ShortCode)
-                    .where(ShortCode.code == provision_id)
+                    .where(
+                        ShortCode.code == provision_id,
+                        ShortCode.kind == "openclaw_provision",
+                        ShortCode.consumed_at.is_(None),
+                    )
                     .values(consumed_at=_utc_now())
                 )
                 await code_session.commit()
         except Exception:  # noqa: BLE001
             pass
+
+    try:
+        ack = await send_host_control_frame(
+            instance.id, "provision_agent", frame_params
+        )
+    except HTTPException:
+        await _burn_provision_code()
         raise
 
     if not isinstance(ack, dict) or not ack.get("ok"):
         err = ack.get("error") if isinstance(ack, dict) else None
         code = (err or {}).get("code") if isinstance(err, dict) else None
         message = (err or {}).get("message") if isinstance(err, dict) else None
+        await _burn_provision_code()
         raise HTTPException(
             status_code=502,
             detail={
@@ -2473,6 +2493,7 @@ async def openclaw_provision(
     result = ack.get("result") if isinstance(ack.get("result"), dict) else None
     agent_id = (result or {}).get("agent_id")
     if not isinstance(agent_id, str):
+        await _burn_provision_code()
         raise HTTPException(
             status_code=502,
             detail={
@@ -2484,6 +2505,7 @@ async def openclaw_provision(
     agent_q = await db.execute(select(Agent).where(Agent.agent_id == agent_id))
     agent = agent_q.scalar_one_or_none()
     if agent is None:
+        await _burn_provision_code()
         raise HTTPException(
             status_code=502,
             detail={

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -469,6 +469,55 @@ async def _consume_bind_code(code: str) -> bool:
     return await _consume_short_code(code, "bind")
 
 
+async def _revert_short_code_claim(code: str, kind: str) -> None:
+    """Best-effort: re-open a short_code that was consumed-with-claim.
+
+    Used when the downstream insert (Agent / SigningKey / etc.) fails after
+    :func:`_consume_short_code_with_claim` has already stamped
+    ``claimed_agent_id`` and bumped ``use_count``. We re-set ``use_count``
+    to 0 / ``consumed_at`` to NULL and strip the claim metadata so polling
+    readers don't observe a "claimed but agent missing" state. The
+    underlying ticket (signed JWT-style payload) and ``jti`` are *not*
+    re-issued — replay is still impossible because the JTI burn is
+    independent.
+
+    Failures are swallowed: if the revert can't run (DB down, transaction
+    poisoned), the consumer is left in the consumed state, which is the
+    safe direction for credential issuance — the user can simply request
+    a new bind code.
+    """
+    try:
+        async with _short_code_session_factory() as code_session:
+            select_result = await code_session.execute(
+                select(ShortCode.payload_json).where(
+                    ShortCode.code == code,
+                    ShortCode.kind == kind,
+                )
+            )
+            existing = select_result.scalar_one_or_none()
+            if existing is None:
+                return
+            try:
+                payload = json.loads(existing)
+            except json.JSONDecodeError:
+                payload = {}
+            payload.pop("claimed_agent_id", None)
+            payload.pop("claimed_at", None)
+            new_payload_json = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+            await code_session.execute(
+                update(ShortCode)
+                .where(ShortCode.code == code, ShortCode.kind == kind)
+                .values(
+                    consumed_at=None,
+                    use_count=0,
+                    payload_json=new_payload_json,
+                )
+            )
+            await code_session.commit()
+    except Exception:  # noqa: BLE001
+        pass
+
+
 async def _consume_short_code_with_claim(code: str, kind: str, agent_id: str) -> bool:
     """Generalized variant of :func:`_consume_bind_code_with_claim`.
 
@@ -2079,7 +2128,11 @@ async def openclaw_install(
         code_session.add(short_code)
         await code_session.commit()
 
-    install_command = _build_install_command(bind_code, nonce)
+    base = HUB_PUBLIC_BASE_URL.rstrip("/")
+    install_command = (
+        f"curl -fsSL {base}/openclaw/install.sh | bash -s -- "
+        f"--purpose openclaw_install --bind-code {bind_code} --bind-nonce {nonce}"
+    )
 
     return OpenclawInstallResponse(
         bind_code=bind_code,
@@ -2236,13 +2289,16 @@ async def delete_openclaw_host(
             )
         )
     ).scalars().all()
+    revoked_ids = {a.agent_id for a in rows}
+    any_was_default = False
     for agent in rows:
         try:
             await _ensure_agent_unbind_allowed(db, agent.agent_id)
         except HTTPException:
             await db.rollback()
             raise
-        was_default = agent.is_default
+        if agent.is_default:
+            any_was_default = True
         await _cancel_agent_subscriptions(db, agent.agent_id, now)
         agent.user_id = None
         agent.claimed_at = None
@@ -2251,8 +2307,25 @@ async def delete_openclaw_host(
         agent.token_expires_at = None
         agent.openclaw_host_id = None
         agent.claim_code = f"clm_{uuid4().hex}"
-        if was_default:
-            await _promote_next_default_agent(db, ctx.user_id, agent.agent_id)
+
+    # Promote a single replacement default *after* every host agent has been
+    # detached, so the helper can't pick another agent that is still in
+    # ``rows`` but not yet processed.
+    if any_was_default:
+        next_q = await db.execute(
+            select(Agent)
+            .where(
+                Agent.user_id == ctx.user_id,
+                Agent.agent_id.notin_(revoked_ids) if revoked_ids else True,
+                Agent.status == "active",
+            )
+            .order_by(Agent.created_at)
+            .limit(1)
+        )
+        next_agent = next_q.scalar_one_or_none()
+        if next_agent is not None:
+            next_agent.is_default = True
+
     if rows:
         await _maybe_remove_agent_owner_role(db, ctx.user_id)
 

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -2366,6 +2366,14 @@ class OpenclawProvisionResponse(BaseModel):
     display_name: str
     openclaw_host_id: str
     is_default: bool
+    # Forwarded from the host's provision-claim ack so the dashboard can
+    # surface a "manually attach this agent in your OpenClaw config" warning
+    # when the plugin couldn't update ``~/.openclaw/openclaw.json`` itself
+    # (multi-account guard, IO error, etc.). ``True`` means the new agent
+    # will auto-load on the host's next plugin reload; ``False`` means the
+    # user (or follow-up automation) must take an action.
+    config_patched: bool = True
+    config_skip_reason: str | None = None
 
 
 @router.post(
@@ -2514,10 +2522,14 @@ async def openclaw_provision(
             },
         )
 
+    config_patched_raw = (result or {}).get("config_patched")
+    config_skip_reason = (result or {}).get("config_skip_reason")
     return OpenclawProvisionResponse(
         agent_id=agent.agent_id,
         display_name=agent.display_name,
         openclaw_host_id=instance.id,
         is_default=agent.is_default,
+        config_patched=bool(config_patched_raw) if config_patched_raw is not None else True,
+        config_skip_reason=config_skip_reason if isinstance(config_skip_reason, str) else None,
     )
 

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -32,6 +32,7 @@ from hub.models import (
     Agent,
     AgentSubscription,
     DaemonInstance,
+    OpenclawHostInstance,
     Role,
     ShortCode,
     SigningKey,
@@ -468,32 +469,21 @@ async def _consume_bind_code(code: str) -> bool:
     return await _consume_short_code(code, "bind")
 
 
-async def _consume_bind_code_with_claim(code: str, agent_id: str) -> bool:
-    """Atomically consume a bind code AND stamp the resulting agent_id.
+async def _consume_short_code_with_claim(code: str, kind: str, agent_id: str) -> bool:
+    """Generalized variant of :func:`_consume_bind_code_with_claim`.
 
-    install-claim derives ``agent_id`` deterministically from the public
-    key before it ever touches the short_code row, so we can write
-    ``payload_json.claimed_agent_id`` in the same transaction that flips
-    ``consumed_at`` to non-null. Doing it as two separate writes left a
-    race window where ``GET /bind-ticket/{code}`` between the consume and
-    the metadata write saw a consumed row with no claimed_agent_id and
-    reported it as ``revoked`` — terminal-looking — even though the
-    agent was about to appear.
-
-    Returns True on first-use, False if the code was already consumed,
-    expired, or unknown (semantics identical to ``_consume_bind_code``).
+    Atomically consumes any ``ShortCode`` row by ``(code, kind)`` and
+    stamps ``payload_json.claimed_agent_id`` in the same transaction so
+    polling readers never observe a "consumed but no agent" intermediate
+    state. Used by both the bind-ticket install path and the OpenClaw
+    install / provision claim paths.
     """
     async with _short_code_session_factory() as code_session:
         now = _utc_now()
-        # Read the row first to merge the existing payload (so we keep
-        # bind_ticket / intended_name) with the new claim metadata. The
-        # WHERE clause on the UPDATE below still guarantees only one
-        # caller wins the consume, so the read is harmless to the
-        # uniqueness invariant.
         select_result = await code_session.execute(
             select(ShortCode.payload_json).where(
                 ShortCode.code == code,
-                ShortCode.kind == "bind",
+                ShortCode.kind == kind,
                 ShortCode.consumed_at.is_(None),
                 ShortCode.use_count < ShortCode.max_uses,
                 ShortCode.expires_at > now,
@@ -514,7 +504,7 @@ async def _consume_bind_code_with_claim(code: str, agent_id: str) -> bool:
             update(ShortCode)
             .where(
                 ShortCode.code == code,
-                ShortCode.kind == "bind",
+                ShortCode.kind == kind,
                 ShortCode.consumed_at.is_(None),
                 ShortCode.use_count < ShortCode.max_uses,
                 ShortCode.expires_at > now,
@@ -533,6 +523,24 @@ async def _consume_bind_code_with_claim(code: str, agent_id: str) -> bool:
             return False
         await code_session.commit()
         return True
+
+
+async def _consume_bind_code_with_claim(code: str, agent_id: str) -> bool:
+    """Atomically consume a bind code AND stamp the resulting agent_id.
+
+    install-claim derives ``agent_id`` deterministically from the public
+    key before it ever touches the short_code row, so we can write
+    ``payload_json.claimed_agent_id`` in the same transaction that flips
+    ``consumed_at`` to non-null. Doing it as two separate writes left a
+    race window where ``GET /bind-ticket/{code}`` between the consume and
+    the metadata write saw a consumed row with no claimed_agent_id and
+    reported it as ``revoked`` — terminal-looking — even though the
+    agent was about to appear.
+
+    Returns True on first-use, False if the code was already consumed,
+    expired, or unknown (semantics identical to ``_consume_bind_code``).
+    """
+    return await _consume_short_code_with_claim(code, "bind", agent_id)
 
 
 async def _peek_reset_code(code: str) -> str | None:
@@ -1976,3 +1984,445 @@ async def provision_agent(
         daemon_instance_id=body.daemon_instance_id,
         is_default=agent.is_default,
     )
+
+
+# ---------------------------------------------------------------------------
+# OpenClaw onboarding — BFF routes
+# ---------------------------------------------------------------------------
+#
+# The user-authenticated entry points for the OpenClaw flow.  The
+# unauthenticated counterparts (``/openclaw/install-claim``,
+# ``/openclaw/host/provision-claim``, ``/openclaw/auth/refresh``,
+# ``WS /openclaw/control``) live in ``hub.routers.openclaw_control``.
+
+
+class OpenclawInstallBody(BaseModel):
+    name: str = Field(..., min_length=1, max_length=128)
+    bio: str | None = Field(default=None, max_length=4000)
+
+
+class OpenclawInstallResponse(BaseModel):
+    bind_code: str
+    bind_ticket: str
+    nonce: str
+    expires_at: int
+    install_command: str
+
+
+@router.post("/me/agents/openclaw/install", response_model=OpenclawInstallResponse)
+async def openclaw_install(
+    body: OpenclawInstallBody,
+    ctx: RequestContext = Depends(require_user),
+) -> OpenclawInstallResponse:
+    """Issue a bind ticket for the OpenClaw one-line install command."""
+    intended_name = body.name.strip()
+    if not intended_name:
+        raise HTTPException(status_code=400, detail="name is required")
+    intended_bio = (body.bio.strip() if body.bio else None) or None
+
+    now = _utc_now()
+    exp = now + datetime.timedelta(minutes=BIND_TICKET_TTL_MINUTES)
+    nonce = base64.b64encode(os.urandom(32)).decode()
+    jti = uuid4().hex
+    bind_code = f"bd_{uuid4().hex[:12]}"
+
+    async with _short_code_session_factory() as code_session:
+        active_count_result = await code_session.execute(
+            select(sa_func.count())
+            .select_from(ShortCode)
+            .where(
+                ShortCode.kind == "bind",
+                ShortCode.owner_user_id == ctx.user_id,
+                ShortCode.consumed_at.is_(None),
+                ShortCode.expires_at > now,
+            )
+        )
+        active_count = active_count_result.scalar_one()
+        if active_count >= MAX_ACTIVE_BIND_CODES_PER_USER:
+            raise HTTPException(
+                status_code=429,
+                detail=(
+                    f"Too many active bind codes (max {MAX_ACTIVE_BIND_CODES_PER_USER}); "
+                    "revoke or wait for one to expire"
+                ),
+            )
+
+    ticket_payload = {
+        "uid": str(ctx.user_id),
+        "purpose": "openclaw_install",
+        "nonce": nonce,
+        "iat": int(now.timestamp()),
+        "exp": int(exp.timestamp()),
+        "jti": jti,
+        "intended_name": intended_name,
+    }
+    if intended_bio:
+        ticket_payload["intended_bio"] = intended_bio
+
+    ticket = _build_signed_ticket(ticket_payload)
+
+    short_code_payload: dict = {
+        "bind_ticket": ticket,
+        "intended_name": intended_name,
+    }
+    if intended_bio:
+        short_code_payload["intended_bio"] = intended_bio
+
+    short_code = ShortCode(
+        code=bind_code,
+        kind="bind",
+        owner_user_id=ctx.user_id,
+        payload_json=json.dumps(short_code_payload, separators=(",", ":"), sort_keys=True),
+        expires_at=exp,
+    )
+    async with _short_code_session_factory() as code_session:
+        code_session.add(short_code)
+        await code_session.commit()
+
+    install_command = _build_install_command(bind_code, nonce)
+
+    return OpenclawInstallResponse(
+        bind_code=bind_code,
+        bind_ticket=ticket,
+        nonce=nonce,
+        expires_at=int(exp.timestamp()),
+        install_command=install_command,
+    )
+
+
+# ---- hosts CRUD -----------------------------------------------------------
+
+
+class OpenclawHostView(BaseModel):
+    id: str
+    label: str | None = None
+    online: bool
+    last_seen_at: datetime.datetime | None = None
+    revoked_at: datetime.datetime | None = None
+    agent_count: int
+    created_at: datetime.datetime
+
+
+class OpenclawHostsResponse(BaseModel):
+    hosts: list[OpenclawHostView]
+
+
+@router.get(
+    "/me/agents/openclaw/hosts",
+    response_model=OpenclawHostsResponse,
+)
+async def list_openclaw_hosts(
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+) -> OpenclawHostsResponse:
+    from hub.routers.openclaw_control import is_openclaw_host_online
+
+    rows = (
+        await db.execute(
+            select(OpenclawHostInstance)
+            .where(OpenclawHostInstance.owner_user_id == ctx.user_id)
+            .order_by(OpenclawHostInstance.created_at.desc())
+        )
+    ).scalars().all()
+
+    hosts: list[OpenclawHostView] = []
+    for row in rows:
+        count_result = await db.execute(
+            select(sa_func.count())
+            .select_from(Agent)
+            .where(
+                Agent.user_id == ctx.user_id,
+                Agent.openclaw_host_id == row.id,
+                Agent.status == "active",
+            )
+        )
+        agent_count = count_result.scalar_one() or 0
+        hosts.append(
+            OpenclawHostView(
+                id=row.id,
+                label=row.label,
+                online=row.revoked_at is None and is_openclaw_host_online(row.id),
+                last_seen_at=row.last_seen_at,
+                revoked_at=row.revoked_at,
+                agent_count=agent_count,
+                created_at=row.created_at,
+            )
+        )
+    return OpenclawHostsResponse(hosts=hosts)
+
+
+async def _load_owned_openclaw_host(
+    db: AsyncSession, user_id: UUID, host_id: str
+) -> OpenclawHostInstance:
+    result = await db.execute(
+        select(OpenclawHostInstance).where(OpenclawHostInstance.id == host_id)
+    )
+    instance = result.scalar_one_or_none()
+    if instance is None or str(instance.owner_user_id) != str(user_id):
+        raise HTTPException(status_code=404, detail="openclaw_host_not_found")
+    return instance
+
+
+class OpenclawHostPatchBody(BaseModel):
+    label: str | None = Field(default=None, max_length=64)
+
+
+@router.patch(
+    "/me/agents/openclaw/hosts/{host_id}",
+    response_model=OpenclawHostView,
+)
+async def patch_openclaw_host(
+    host_id: str,
+    body: OpenclawHostPatchBody,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+) -> OpenclawHostView:
+    from hub.routers.openclaw_control import is_openclaw_host_online
+
+    instance = await _load_owned_openclaw_host(db, ctx.user_id, host_id)
+    new_label = body.label.strip() if isinstance(body.label, str) else None
+    instance.label = new_label or None
+    await db.commit()
+    await db.refresh(instance)
+
+    count_result = await db.execute(
+        select(sa_func.count())
+        .select_from(Agent)
+        .where(
+            Agent.user_id == ctx.user_id,
+            Agent.openclaw_host_id == instance.id,
+            Agent.status == "active",
+        )
+    )
+    return OpenclawHostView(
+        id=instance.id,
+        label=instance.label,
+        online=instance.revoked_at is None and is_openclaw_host_online(instance.id),
+        last_seen_at=instance.last_seen_at,
+        revoked_at=instance.revoked_at,
+        agent_count=count_result.scalar_one() or 0,
+        created_at=instance.created_at,
+    )
+
+
+@router.delete("/me/agents/openclaw/hosts/{host_id}")
+async def delete_openclaw_host(
+    host_id: str,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Revoke an OpenClaw host and unbind all of its agents.
+
+    Mirrors the existing per-agent unbind semantics (``user_id`` /
+    ``claimed_at`` / ``agent_token`` are cleared) so the agent rows
+    remain reusable after the user re-installs on the host.
+    """
+    from hub.routers.openclaw_control import _REGISTRY as _HOST_REGISTRY
+
+    instance = await _load_owned_openclaw_host(db, ctx.user_id, host_id)
+
+    now = _utc_now()
+    if instance.revoked_at is None:
+        instance.revoked_at = now
+    instance.refresh_token_hash = None
+    instance.refresh_token_expires_at = None
+
+    rows = (
+        await db.execute(
+            select(Agent).where(
+                Agent.user_id == ctx.user_id,
+                Agent.openclaw_host_id == host_id,
+                Agent.status == "active",
+            )
+        )
+    ).scalars().all()
+    for agent in rows:
+        try:
+            await _ensure_agent_unbind_allowed(db, agent.agent_id)
+        except HTTPException:
+            await db.rollback()
+            raise
+        was_default = agent.is_default
+        await _cancel_agent_subscriptions(db, agent.agent_id, now)
+        agent.user_id = None
+        agent.claimed_at = None
+        agent.is_default = False
+        agent.agent_token = None
+        agent.token_expires_at = None
+        agent.openclaw_host_id = None
+        agent.claim_code = f"clm_{uuid4().hex}"
+        if was_default:
+            await _promote_next_default_agent(db, ctx.user_id, agent.agent_id)
+    if rows:
+        await _maybe_remove_agent_owner_role(db, ctx.user_id)
+
+    await db.commit()
+
+    conn = _HOST_REGISTRY.get(host_id)
+    if conn is not None:
+        try:
+            await conn.ws.close(code=4403, reason="host revoked")
+        except Exception:
+            pass
+        await _HOST_REGISTRY.unregister(conn)
+
+    return {"ok": True, "revoked_agents": [a.agent_id for a in rows]}
+
+
+# ---- provision (host-authorized) ------------------------------------------
+
+
+class OpenclawProvisionBody(BaseModel):
+    openclaw_host_id: str
+    name: str = Field(..., min_length=1, max_length=128)
+    bio: str | None = Field(default=None, max_length=4000)
+
+
+class OpenclawProvisionResponse(BaseModel):
+    agent_id: str
+    display_name: str
+    openclaw_host_id: str
+    is_default: bool
+
+
+@router.post(
+    "/me/agents/openclaw/provision",
+    status_code=201,
+    response_model=OpenclawProvisionResponse,
+)
+async def openclaw_provision(
+    body: OpenclawProvisionBody,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+) -> OpenclawProvisionResponse:
+    """Create an agent on an already-registered OpenClaw host.
+
+    Allocates a one-time provision short-code, dispatches a signed
+    ``provision_agent`` frame over the host control WS, and waits for
+    the host's ack — which fires only after the host has called
+    ``POST /openclaw/host/provision-claim`` to materialise the agent.
+    """
+    from hub.config import OPENCLAW_PROVISION_TICKET_TTL_SECONDS
+    from hub.routers.openclaw_control import (
+        is_openclaw_host_online,
+        send_host_control_frame,
+    )
+
+    name = body.name.strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="name is required")
+    bio = (body.bio.strip() if body.bio else None) or None
+
+    instance = await _load_owned_openclaw_host(db, ctx.user_id, body.openclaw_host_id)
+    if instance.revoked_at is not None:
+        raise HTTPException(status_code=409, detail="host_revoked")
+    if not is_openclaw_host_online(instance.id):
+        raise HTTPException(status_code=409, detail="host_offline")
+
+    user_result = await db.execute(select(User).where(User.id == ctx.user_id))
+    user = user_result.scalar_one_or_none()
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    count_result = await db.execute(
+        select(sa_func.count())
+        .select_from(Agent)
+        .where(Agent.user_id == ctx.user_id, Agent.status == "active")
+    )
+    if count_result.scalar_one() >= user.max_agents:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Agent quota exceeded (max {user.max_agents})",
+        )
+
+    now = _utc_now()
+    provision_id = f"prv_{uuid4().hex[:16]}"
+    nonce = base64.b64encode(os.urandom(32)).decode()
+    expires_at = now + datetime.timedelta(seconds=OPENCLAW_PROVISION_TICKET_TTL_SECONDS)
+
+    sc_payload = {
+        "owner_user_id": str(ctx.user_id),
+        "openclaw_host_id": instance.id,
+        "intended_name": name,
+        "nonce": nonce,
+    }
+    if bio:
+        sc_payload["intended_bio"] = bio
+
+    short_code = ShortCode(
+        code=provision_id,
+        kind="openclaw_provision",
+        owner_user_id=ctx.user_id,
+        payload_json=json.dumps(sc_payload, separators=(",", ":"), sort_keys=True),
+        expires_at=expires_at,
+    )
+    async with _short_code_session_factory() as code_session:
+        code_session.add(short_code)
+        await code_session.commit()
+
+    frame_params: dict = {
+        "provision_id": provision_id,
+        "nonce": nonce,
+        "owner_user_id": str(ctx.user_id),
+    }
+
+    try:
+        ack = await send_host_control_frame(
+            instance.id, "provision_agent", frame_params
+        )
+    except HTTPException:
+        # Best-effort revoke the unconsumed short code so it can't be
+        # racey-redeemed later.
+        try:
+            async with _short_code_session_factory() as code_session:
+                await code_session.execute(
+                    update(ShortCode)
+                    .where(ShortCode.code == provision_id)
+                    .values(consumed_at=_utc_now())
+                )
+                await code_session.commit()
+        except Exception:  # noqa: BLE001
+            pass
+        raise
+
+    if not isinstance(ack, dict) or not ack.get("ok"):
+        err = ack.get("error") if isinstance(ack, dict) else None
+        code = (err or {}).get("code") if isinstance(err, dict) else None
+        message = (err or {}).get("message") if isinstance(err, dict) else None
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "code": "openclaw_provision_failed",
+                "host_code": code,
+                "host_message": message,
+            },
+        )
+
+    result = ack.get("result") if isinstance(ack.get("result"), dict) else None
+    agent_id = (result or {}).get("agent_id")
+    if not isinstance(agent_id, str):
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "code": "openclaw_provision_failed",
+                "host_message": "host ack missing agent_id",
+            },
+        )
+
+    agent_q = await db.execute(select(Agent).where(Agent.agent_id == agent_id))
+    agent = agent_q.scalar_one_or_none()
+    if agent is None:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "code": "openclaw_provision_failed",
+                "host_message": "agent row not found post-claim",
+            },
+        )
+
+    return OpenclawProvisionResponse(
+        agent_id=agent.agent_id,
+        display_name=agent.display_name,
+        openclaw_host_id=instance.id,
+        is_default=agent.is_default,
+    )
+

--- a/backend/hub/config.py
+++ b/backend/hub/config.py
@@ -186,6 +186,17 @@ DAEMON_DISPATCH_MAX_TIMEOUT_MS: int = int(
     os.getenv("DAEMON_DISPATCH_MAX_TIMEOUT_MS", "60000")
 )
 
+# OpenClaw host (plugin) control plane — mirrors daemon's defaults.
+OPENCLAW_ACCESS_TOKEN_EXPIRE_SECONDS: int = int(
+    os.getenv("OPENCLAW_ACCESS_TOKEN_EXPIRE_SECONDS", "3600")
+)
+OPENCLAW_REFRESH_TOKEN_TTL_SECONDS: int = int(
+    os.getenv("OPENCLAW_REFRESH_TOKEN_TTL_SECONDS", str(60 * 60 * 24 * 30))
+)
+OPENCLAW_PROVISION_TICKET_TTL_SECONDS: int = int(
+    os.getenv("OPENCLAW_PROVISION_TICKET_TTL_SECONDS", "300")
+)
+
 # ---------------------------------------------------------------------------
 # Cold-start claim gift
 # 固定窗口: 2026-04-07 00:00:00 +08:00 <= now < 2026-07-08 00:00:00 +08:00

--- a/backend/hub/id_generators.py
+++ b/backend/hub/id_generators.py
@@ -103,6 +103,16 @@ def generate_daemon_instance_id() -> str:
     return "dm_" + secrets.token_hex(6)
 
 
+def generate_openclaw_host_id_from_pubkey(pubkey_b64: str) -> str:
+    """Derive openclaw host id deterministically from the host pubkey.
+
+    Same pattern as :func:`generate_agent_id` so a re-install with the same
+    keypair maps back to the same host row.
+    """
+    digest = hashlib.sha256(pubkey_b64.encode()).hexdigest()
+    return "oc_" + digest[:12]
+
+
 def generate_daemon_device_code() -> str:
     """Generate device-code secret: 'dc_' + 32 random hex chars."""
     return "dc_" + secrets.token_hex(16)

--- a/backend/hub/main.py
+++ b/backend/hub/main.py
@@ -25,6 +25,7 @@ from hub.subscription_billing import subscription_billing_loop
 from hub.version_poll import version_poll_loop
 from hub.routers.contact_requests import router as contact_requests_router
 from hub.routers.daemon_control import router as daemon_control_router
+from hub.routers.openclaw_control import router as openclaw_control_router
 from hub.routers.contacts import router as contacts_router
 from hub.routers.dashboard import router as dashboard_router
 from hub.routers.dashboard import share_public_router
@@ -274,3 +275,4 @@ app.include_router(app_beta_router)
 app.include_router(app_admin_beta_router)
 app.include_router(app_prompts_router)
 app.include_router(daemon_control_router)
+app.include_router(openclaw_control_router)

--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -97,6 +97,9 @@ class Agent(Base):
     daemon_instance_id: Mapped[str | None] = mapped_column(
         String(32), ForeignKey("daemon_instances.id", ondelete="SET NULL"), nullable=True, index=True
     )
+    openclaw_host_id: Mapped[str | None] = mapped_column(
+        String(32), ForeignKey("openclaw_host_instances.id", ondelete="SET NULL"), nullable=True, index=True
+    )
     hosting_kind: Mapped[str | None] = mapped_column(String(16), nullable=True)
     # Runtime selected at creation (claude-code / codex / gemini / ...).
     # Null for agents created via bind_code.
@@ -1152,6 +1155,38 @@ class DaemonInstance(Base):
     runtimes_json: Mapped[list | None] = mapped_column(JSON, nullable=True)
     runtimes_probed_at: Mapped[datetime.datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
+    )
+
+
+class OpenclawHostInstance(Base):
+    """An OpenClaw VM/container hosting the BotCord plugin.
+
+    Mirrors :class:`DaemonInstance` semantics — long-lived control-plane
+    row with refresh-token rotation. ``host_pubkey`` is the Ed25519 public
+    key the plugin generated locally during install-claim; the matching
+    private key never leaves the host.
+    """
+
+    __tablename__ = "openclaw_host_instances"
+
+    id: Mapped[str] = mapped_column(String(32), primary_key=True)  # oc_<12 hex>
+    owner_user_id: Mapped[_uuid.UUID] = mapped_column(Uuid, nullable=False, index=True)
+    host_pubkey: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
+    label: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    refresh_token_hash: Mapped[str | None] = mapped_column(
+        String(128), nullable=True, index=True
+    )
+    refresh_token_expires_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_seen_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    revoked_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
     )
 
 

--- a/backend/hub/routers/openclaw_control.py
+++ b/backend/hub/routers/openclaw_control.py
@@ -1,0 +1,841 @@
+"""OpenClaw host control-plane HTTP + WebSocket endpoints.
+
+Implements the ``/openclaw/*`` surface used by the BotCord plugin running
+inside an OpenClaw VM/container:
+
+- ``POST /openclaw/install-claim`` — first-install flow. Plugin submits
+  host + agent pubkeys with Ed25519 proof-of-possession against the
+  bind-ticket nonce; Hub atomically creates the host instance, agent row
+  + active key, and returns host JWT pair + agent JWT.
+- ``POST /openclaw/auth/refresh`` — host refresh-token rotation (mirror of
+  ``/daemon/auth/refresh``).
+- ``POST /openclaw/host/provision-claim`` — used by an already-online host
+  in response to a server-pushed ``provision_agent`` frame, to atomically
+  create a new agent + active key and obtain its JWT.
+- ``WS  /openclaw/control`` — long-lived control channel. Same Bearer JWT
+  + Hub Ed25519 signed-frame contract as the daemon control WS.
+
+The signing key is shared with the daemon control plane (single Hub
+identity) — see :data:`hub.routers.daemon_control.HUB_CONTROL_PUBLIC_KEY_B64`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import datetime
+import hashlib
+import json
+import logging
+import secrets
+import uuid as _uuid
+from dataclasses import dataclass
+from typing import Any
+
+import jwt as pyjwt
+from fastapi import (
+    APIRouter,
+    Depends,
+    HTTPException,
+    Request,
+    WebSocket,
+    WebSocketDisconnect,
+)
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from hub.config import (
+    HUB_PUBLIC_BASE_URL,
+    JWT_ALGORITHM,
+    JWT_SECRET,
+    OPENCLAW_ACCESS_TOKEN_EXPIRE_SECONDS,
+    OPENCLAW_REFRESH_TOKEN_TTL_SECONDS,
+)
+from hub.crypto import verify_challenge_sig
+from hub.database import async_session, get_db
+from hub.id_generators import (
+    generate_agent_id,
+    generate_key_id,
+    generate_openclaw_host_id_from_pubkey,
+)
+from hub.models import Agent, OpenclawHostInstance, ShortCode, SigningKey
+from hub.enums import KeyState
+from hub.routers.daemon_control import _build_signed_frame
+from hub.validators import parse_pubkey
+from hub.auth import create_agent_token
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["openclaw-control"])
+
+
+# ---------------------------------------------------------------------------
+# Time + token helpers
+# ---------------------------------------------------------------------------
+
+
+def _now() -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def _hash_refresh_token(raw: str) -> str:
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _generate_refresh_token() -> str:
+    return "ort_" + secrets.token_urlsafe(48)
+
+
+def _create_host_access_token(host_instance_id: str, owner_user_id: str) -> tuple[str, int]:
+    expires_at = _now() + datetime.timedelta(seconds=OPENCLAW_ACCESS_TOKEN_EXPIRE_SECONDS)
+    payload = {
+        "sub": host_instance_id,
+        "user_id": str(owner_user_id),
+        "openclaw_host_id": host_instance_id,
+        "kind": "openclaw-host-access",
+        "exp": expires_at,
+        "iss": "botcord-openclaw",
+    }
+    token = pyjwt.encode(payload, JWT_SECRET, algorithm=JWT_ALGORITHM)
+    return token, OPENCLAW_ACCESS_TOKEN_EXPIRE_SECONDS
+
+
+def _verify_host_access_token(token: str) -> dict[str, Any]:
+    try:
+        payload = pyjwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
+    except pyjwt.ExpiredSignatureError:
+        raise HTTPException(status_code=401, detail="Token expired")
+    except pyjwt.InvalidTokenError:
+        raise HTTPException(status_code=401, detail="Invalid token")
+    if payload.get("kind") != "openclaw-host-access":
+        raise HTTPException(status_code=401, detail="Invalid token kind")
+    if payload.get("iss") != "botcord-openclaw":
+        raise HTTPException(status_code=401, detail="Invalid token issuer")
+    if not payload.get("openclaw_host_id"):
+        raise HTTPException(status_code=401, detail="Missing openclaw_host_id claim")
+    return payload
+
+
+def _issue_host_token_bundle(
+    instance: OpenclawHostInstance,
+) -> tuple[dict[str, Any], str]:
+    """Mint (access, refresh) for the host. Caller persists ``refresh_token_hash``."""
+    access_token, expires_in = _create_host_access_token(instance.id, str(instance.owner_user_id))
+    refresh_token = _generate_refresh_token()
+    access_expires_at = _now() + datetime.timedelta(seconds=expires_in)
+    refresh_expires_at = _now() + datetime.timedelta(seconds=OPENCLAW_REFRESH_TOKEN_TTL_SECONDS)
+    bundle = {
+        "host_instance_id": instance.id,
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "access_expires_at": int(access_expires_at.timestamp()),
+        "refresh_expires_at": int(refresh_expires_at.timestamp()),
+    }
+    return bundle, refresh_token
+
+
+# ---------------------------------------------------------------------------
+# In-memory host WS registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _HostConn:
+    ws: WebSocket
+    owner_user_id: str
+    host_instance_id: str
+    pending_acks: dict[str, asyncio.Future]
+
+
+class _HostRegistry:
+    def __init__(self) -> None:
+        self._by_instance: dict[str, _HostConn] = {}
+        self._lock = asyncio.Lock()
+
+    async def register(self, conn: _HostConn) -> _HostConn | None:
+        async with self._lock:
+            previous = self._by_instance.get(conn.host_instance_id)
+            self._by_instance[conn.host_instance_id] = conn
+            return previous
+
+    async def unregister(self, conn: _HostConn) -> None:
+        async with self._lock:
+            current = self._by_instance.get(conn.host_instance_id)
+            if current is conn:
+                self._by_instance.pop(conn.host_instance_id, None)
+
+    def get(self, host_instance_id: str) -> _HostConn | None:
+        return self._by_instance.get(host_instance_id)
+
+    def is_online(self, host_instance_id: str) -> bool:
+        return host_instance_id in self._by_instance
+
+
+_REGISTRY = _HostRegistry()
+
+
+def is_openclaw_host_online(host_instance_id: str) -> bool:
+    return _REGISTRY.is_online(host_instance_id)
+
+
+_DEFAULT_DISPATCH_TIMEOUT_MS = 30000
+
+
+async def send_host_control_frame(
+    host_instance_id: str,
+    type_: str,
+    params: dict[str, Any] | None = None,
+    timeout_ms: int | None = None,
+) -> dict[str, Any]:
+    """Dispatch a signed control frame to a host and await its ack.
+
+    Mirrors :func:`hub.routers.daemon_control.send_control_frame` semantics.
+    Raises ``HTTPException(409 host_offline | 502 host_send_failed | 504
+    host_ack_timeout)``; resolution comes back as the ack dict.
+    """
+    conn = _REGISTRY.get(host_instance_id)
+    if conn is None:
+        raise HTTPException(status_code=409, detail="host_offline")
+
+    frame = _build_signed_frame(type_, params or {})
+    fut: asyncio.Future = asyncio.get_running_loop().create_future()
+    conn.pending_acks[frame["id"]] = fut
+
+    timeout = timeout_ms or _DEFAULT_DISPATCH_TIMEOUT_MS
+    try:
+        await conn.ws.send_text(json.dumps(frame))
+    except Exception as exc:  # noqa: BLE001
+        conn.pending_acks.pop(frame["id"], None)
+        raise HTTPException(status_code=502, detail=f"host_send_failed: {exc}")
+
+    try:
+        ack = await asyncio.wait_for(fut, timeout=timeout / 1000)
+    except asyncio.TimeoutError:
+        conn.pending_acks.pop(frame["id"], None)
+        raise HTTPException(status_code=504, detail="host_ack_timeout")
+    except RuntimeError as exc:
+        conn.pending_acks.pop(frame["id"], None)
+        raise HTTPException(
+            status_code=502,
+            detail={"code": "host_disconnected", "host_message": str(exc)},
+        )
+    return ack
+
+
+# ---------------------------------------------------------------------------
+# install-claim — first-install flow
+# ---------------------------------------------------------------------------
+
+
+def _generic_invalid_bind_code() -> HTTPException:
+    return HTTPException(status_code=400, detail="INVALID_BIND_CODE")
+
+
+class _ProofModel(BaseModel):
+    nonce: str
+    sig: str
+
+
+class _PubkeyAndProof(BaseModel):
+    pubkey: str
+    proof: _ProofModel
+
+
+class InstallClaimBody(BaseModel):
+    bind_code: str
+    host: _PubkeyAndProof
+    agent: _PubkeyAndProof
+
+
+@router.post("/openclaw/install-claim", status_code=201)
+async def openclaw_install_claim(
+    body: InstallClaimBody,
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Redeem an ``openclaw_install`` bind code with two Ed25519 PoPs.
+
+    Atomic: consume bind code (stamping ``claimed_agent_id``) → burn JTI →
+    create ``OpenclawHostInstance`` + ``Agent`` + active ``SigningKey`` →
+    issue host JWT pair + agent JWT.
+    """
+    # Late-import the shared bind-ticket helpers from the BFF module to
+    # avoid duplicating crypto/replay logic. The reverse import direction
+    # would be circular at module load.
+    from app.routers.users import (
+        _consume_bind_code_with_claim,
+        _consume_bind_ticket_jti,
+        _ensure_agent_owner_role,
+        _peek_bind_code,
+        _utc_now,
+        _verify_bind_ticket,
+    )
+    from hub.models import User
+
+    if not body.bind_code.startswith("bd_"):
+        raise _generic_invalid_bind_code()
+
+    bind_ticket = await _peek_bind_code(body.bind_code)
+    if bind_ticket is None:
+        raise _generic_invalid_bind_code()
+
+    payload = _verify_bind_ticket(bind_ticket)
+    if payload is None or payload.get("purpose") != "openclaw_install":
+        raise _generic_invalid_bind_code()
+
+    uid_str = payload.get("uid")
+    if not uid_str:
+        raise _generic_invalid_bind_code()
+    try:
+        owner_user_id = _uuid.UUID(uid_str)
+    except ValueError:
+        raise _generic_invalid_bind_code()
+
+    ticket_nonce = payload.get("nonce")
+    if not isinstance(ticket_nonce, str) or not ticket_nonce:
+        raise _generic_invalid_bind_code()
+
+    if body.host.proof.nonce != ticket_nonce or body.agent.proof.nonce != ticket_nonce:
+        raise HTTPException(status_code=401, detail="INVALID_PROOF")
+
+    # Validate pubkeys + verify both signatures.
+    try:
+        host_pubkey_b64 = parse_pubkey(body.host.pubkey.strip())
+        agent_pubkey_b64 = parse_pubkey(body.agent.pubkey.strip())
+    except HTTPException:
+        raise HTTPException(status_code=400, detail="INVALID_PUBKEY")
+
+    if not verify_challenge_sig(host_pubkey_b64, ticket_nonce, body.host.proof.sig):
+        raise HTTPException(status_code=401, detail="INVALID_PROOF")
+    if not verify_challenge_sig(agent_pubkey_b64, ticket_nonce, body.agent.proof.sig):
+        raise HTTPException(status_code=401, detail="INVALID_PROOF")
+
+    if host_pubkey_b64 == agent_pubkey_b64:
+        # The two PoPs must come from distinct keypairs — otherwise the
+        # agent identity would equal the host identity, which is not a
+        # supported topology.
+        raise HTTPException(status_code=400, detail="INVALID_PUBKEY")
+
+    agent_id = generate_agent_id(agent_pubkey_b64)
+    host_id = generate_openclaw_host_id_from_pubkey(host_pubkey_b64)
+
+    # Pubkey collisions: refuse if either is already registered.
+    dup_key_q = await db.execute(
+        select(SigningKey).where(
+            SigningKey.pubkey == f"ed25519:{agent_pubkey_b64}",
+            SigningKey.state.in_((KeyState.active, KeyState.pending)),
+        )
+    )
+    if dup_key_q.scalar_one_or_none() is not None:
+        raise HTTPException(status_code=409, detail="PUBKEY_ALREADY_REGISTERED")
+    dup_agent_q = await db.execute(select(Agent).where(Agent.agent_id == agent_id))
+    if dup_agent_q.scalar_one_or_none() is not None:
+        raise HTTPException(status_code=409, detail="PUBKEY_ALREADY_REGISTERED")
+    dup_host_q = await db.execute(
+        select(OpenclawHostInstance).where(
+            (OpenclawHostInstance.host_pubkey == host_pubkey_b64)
+            | (OpenclawHostInstance.id == host_id)
+        )
+    )
+    if dup_host_q.scalar_one_or_none() is not None:
+        raise HTTPException(status_code=409, detail="PUBKEY_ALREADY_REGISTERED")
+
+    # Owner quota check.
+    user_q = await db.execute(select(User).where(User.id == owner_user_id))
+    user = user_q.scalar_one_or_none()
+    if user is None:
+        raise _generic_invalid_bind_code()
+    from sqlalchemy import func as sa_func
+
+    count_q = await db.execute(
+        select(sa_func.count())
+        .select_from(Agent)
+        .where(Agent.user_id == owner_user_id, Agent.status == "active")
+    )
+    current_count = count_q.scalar_one()
+    if current_count >= user.max_agents:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Agent quota exceeded (max {user.max_agents})",
+        )
+    is_first = current_count == 0
+
+    # Atomic consume bind code + stamp claimed_agent_id.
+    if not await _consume_bind_code_with_claim(body.bind_code, agent_id):
+        raise _generic_invalid_bind_code()
+    if not await _consume_bind_ticket_jti(payload["jti"]):
+        raise _generic_invalid_bind_code()
+
+    # Insert host instance + agent + active key in one transaction.
+    intended_name = (
+        payload.get("intended_name")
+        if isinstance(payload.get("intended_name"), str)
+        else None
+    )
+    intended_bio = (
+        payload.get("intended_bio")
+        if isinstance(payload.get("intended_bio"), str)
+        else None
+    )
+    display_name = intended_name or agent_id
+
+    now = _utc_now()
+    agent_token, expires_at_ts = create_agent_token(agent_id)
+    token_expires_at = datetime.datetime.fromtimestamp(
+        expires_at_ts, tz=datetime.timezone.utc
+    )
+
+    instance = OpenclawHostInstance(
+        id=host_id,
+        owner_user_id=owner_user_id,
+        host_pubkey=host_pubkey_b64,
+        label=intended_name or None,
+        last_seen_at=now,
+    )
+    bundle, refresh_token = _issue_host_token_bundle(instance)
+    instance.refresh_token_hash = _hash_refresh_token(refresh_token)
+    instance.refresh_token_expires_at = datetime.datetime.fromtimestamp(
+        bundle["refresh_expires_at"], tz=datetime.timezone.utc
+    )
+
+    key_id = generate_key_id()
+    agent = Agent(
+        agent_id=agent_id,
+        display_name=display_name,
+        bio=intended_bio,
+        user_id=owner_user_id,
+        agent_token=agent_token,
+        token_expires_at=token_expires_at,
+        is_default=is_first,
+        claimed_at=now,
+        hosting_kind="plugin",
+        openclaw_host_id=host_id,
+    )
+    signing_key = SigningKey(
+        agent_id=agent_id,
+        key_id=key_id,
+        pubkey=f"ed25519:{agent_pubkey_b64}",
+        state=KeyState.active,
+    )
+    try:
+        async with db.begin_nested():
+            db.add(instance)
+            db.add(agent)
+            db.add(signing_key)
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="PUBKEY_ALREADY_REGISTERED")
+
+    await _ensure_agent_owner_role(db, owner_user_id)
+    await db.commit()
+    await db.refresh(agent)
+
+    control_ws_url = (
+        HUB_PUBLIC_BASE_URL.replace("https://", "wss://").replace("http://", "ws://")
+        + "/openclaw/control"
+    )
+
+    return {
+        "agent": {
+            "id": agent.agent_id,
+            "key_id": key_id,
+            "token": agent_token,
+            "token_expires_at": expires_at_ts,
+            "display_name": agent.display_name,
+            "bio": agent.bio,
+        },
+        "host": {
+            **bundle,
+            "control_ws_url": control_ws_url,
+        },
+        "hub_url": HUB_PUBLIC_BASE_URL,
+    }
+
+
+# ---------------------------------------------------------------------------
+# /openclaw/auth/refresh
+# ---------------------------------------------------------------------------
+
+
+class _RefreshRequest(BaseModel):
+    refresh_token: str = Field(..., min_length=8, max_length=256)
+
+
+@router.post("/openclaw/auth/refresh")
+async def openclaw_refresh_token(
+    body: _RefreshRequest,
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    refresh_hash = _hash_refresh_token(body.refresh_token)
+    result = await db.execute(
+        select(OpenclawHostInstance).where(
+            OpenclawHostInstance.refresh_token_hash == refresh_hash
+        )
+    )
+    instance = result.scalar_one_or_none()
+    if instance is None:
+        raise HTTPException(status_code=401, detail="invalid_refresh_token")
+    if instance.revoked_at is not None:
+        raise HTTPException(status_code=401, detail="host_revoked")
+    expires_at = instance.refresh_token_expires_at
+    if expires_at is not None and expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=datetime.timezone.utc)
+    if expires_at is not None and expires_at < _now():
+        raise HTTPException(status_code=401, detail="invalid_refresh_token")
+
+    bundle, new_refresh = _issue_host_token_bundle(instance)
+    instance.refresh_token_hash = _hash_refresh_token(new_refresh)
+    instance.refresh_token_expires_at = datetime.datetime.fromtimestamp(
+        bundle["refresh_expires_at"], tz=datetime.timezone.utc
+    )
+    instance.last_seen_at = _now()
+    await db.commit()
+    return bundle
+
+
+# ---------------------------------------------------------------------------
+# /openclaw/host/provision-claim
+# ---------------------------------------------------------------------------
+
+
+class ProvisionClaimBody(BaseModel):
+    provision_id: str
+    nonce: str
+    agent: _PubkeyAndProof
+
+
+def _require_host_bearer(request: Request) -> dict[str, Any]:
+    auth_header = request.headers.get("authorization") or request.headers.get(
+        "Authorization"
+    )
+    if not auth_header or not auth_header.lower().startswith("bearer "):
+        raise HTTPException(status_code=401, detail="missing_bearer")
+    token = auth_header[len("Bearer ") :]
+    return _verify_host_access_token(token)
+
+
+@router.post("/openclaw/host/provision-claim", status_code=201)
+async def openclaw_provision_claim(
+    body: ProvisionClaimBody,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Plugin-side claim of a ``provision_agent`` frame: create the agent.
+
+    Atomic: consume provision short-code → create ``Agent`` + active key →
+    return the agent JWT. Caller must also ack the original WS frame so
+    the BFF future resolves; this endpoint does *not* notify the BFF.
+    """
+    from app.routers.users import (
+        _consume_short_code_with_claim,
+        _ensure_agent_owner_role,
+        _utc_now,
+    )
+    from hub.models import User
+
+    claims = _require_host_bearer(request)
+    host_instance_id = claims["openclaw_host_id"]
+    host_owner_user_id = claims["user_id"]
+
+    # 1. Verify the host instance is still alive + un-revoked.
+    inst_q = await db.execute(
+        select(OpenclawHostInstance).where(
+            OpenclawHostInstance.id == host_instance_id
+        )
+    )
+    instance = inst_q.scalar_one_or_none()
+    if instance is None or instance.revoked_at is not None:
+        raise HTTPException(status_code=401, detail="host_revoked_or_unknown")
+    if str(instance.owner_user_id) != str(host_owner_user_id):
+        raise HTTPException(status_code=401, detail="host_owner_mismatch")
+
+    # 2. Look up the provision short code.
+    sc_q = await db.execute(
+        select(ShortCode).where(
+            ShortCode.code == body.provision_id,
+            ShortCode.kind == "openclaw_provision",
+        )
+    )
+    short_code = sc_q.scalar_one_or_none()
+    if short_code is None:
+        raise HTTPException(status_code=400, detail="INVALID_PROVISION")
+    expires_at = short_code.expires_at
+    if expires_at is not None and expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=datetime.timezone.utc)
+    if (
+        short_code.consumed_at is not None
+        or (expires_at is not None and expires_at < _now())
+        or short_code.use_count >= short_code.max_uses
+    ):
+        raise HTTPException(status_code=400, detail="INVALID_PROVISION")
+
+    try:
+        sc_payload = json.loads(short_code.payload_json)
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=400, detail="INVALID_PROVISION")
+
+    if sc_payload.get("nonce") != body.nonce:
+        raise HTTPException(status_code=401, detail="INVALID_PROOF")
+    if sc_payload.get("openclaw_host_id") != host_instance_id:
+        raise HTTPException(status_code=403, detail="host_mismatch")
+    if str(sc_payload.get("owner_user_id")) != str(host_owner_user_id):
+        raise HTTPException(status_code=403, detail="owner_mismatch")
+
+    # 3. Verify the agent PoP signs the provision nonce.
+    if body.agent.proof.nonce != body.nonce:
+        raise HTTPException(status_code=401, detail="INVALID_PROOF")
+    try:
+        agent_pubkey_b64 = parse_pubkey(body.agent.pubkey.strip())
+    except HTTPException:
+        raise HTTPException(status_code=400, detail="INVALID_PUBKEY")
+    if not verify_challenge_sig(agent_pubkey_b64, body.nonce, body.agent.proof.sig):
+        raise HTTPException(status_code=401, detail="INVALID_PROOF")
+
+    agent_id = generate_agent_id(agent_pubkey_b64)
+
+    # 4. Pubkey + agent_id collisions, owner quota.
+    dup_key_q = await db.execute(
+        select(SigningKey).where(
+            SigningKey.pubkey == f"ed25519:{agent_pubkey_b64}",
+            SigningKey.state.in_((KeyState.active, KeyState.pending)),
+        )
+    )
+    if dup_key_q.scalar_one_or_none() is not None:
+        raise HTTPException(status_code=409, detail="PUBKEY_ALREADY_REGISTERED")
+    dup_agent_q = await db.execute(select(Agent).where(Agent.agent_id == agent_id))
+    if dup_agent_q.scalar_one_or_none() is not None:
+        raise HTTPException(status_code=409, detail="PUBKEY_ALREADY_REGISTERED")
+
+    owner_user_id = _uuid.UUID(str(host_owner_user_id))
+    user_q = await db.execute(select(User).where(User.id == owner_user_id))
+    user = user_q.scalar_one_or_none()
+    if user is None:
+        raise HTTPException(status_code=400, detail="owner_not_found")
+    from sqlalchemy import func as sa_func
+
+    count_q = await db.execute(
+        select(sa_func.count())
+        .select_from(Agent)
+        .where(Agent.user_id == owner_user_id, Agent.status == "active")
+    )
+    current_count = count_q.scalar_one()
+    if current_count >= user.max_agents:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Agent quota exceeded (max {user.max_agents})",
+        )
+    is_first = current_count == 0
+
+    # 5. Atomic consume of the short code.
+    if not await _consume_short_code_with_claim(
+        body.provision_id, "openclaw_provision", agent_id
+    ):
+        raise HTTPException(status_code=400, detail="INVALID_PROVISION")
+
+    # 6. Insert agent + active key.
+    intended_name = (
+        sc_payload.get("intended_name")
+        if isinstance(sc_payload.get("intended_name"), str)
+        else None
+    )
+    intended_bio = (
+        sc_payload.get("intended_bio")
+        if isinstance(sc_payload.get("intended_bio"), str)
+        else None
+    )
+    display_name = intended_name or agent_id
+
+    now = _utc_now()
+    agent_token, expires_at_ts = create_agent_token(agent_id)
+    token_expires_at = datetime.datetime.fromtimestamp(
+        expires_at_ts, tz=datetime.timezone.utc
+    )
+    key_id = generate_key_id()
+    agent = Agent(
+        agent_id=agent_id,
+        display_name=display_name,
+        bio=intended_bio,
+        user_id=owner_user_id,
+        agent_token=agent_token,
+        token_expires_at=token_expires_at,
+        is_default=is_first,
+        claimed_at=now,
+        hosting_kind="plugin",
+        openclaw_host_id=host_instance_id,
+    )
+    signing_key = SigningKey(
+        agent_id=agent_id,
+        key_id=key_id,
+        pubkey=f"ed25519:{agent_pubkey_b64}",
+        state=KeyState.active,
+    )
+    try:
+        async with db.begin_nested():
+            db.add(agent)
+            db.add(signing_key)
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="PUBKEY_ALREADY_REGISTERED")
+
+    await _ensure_agent_owner_role(db, owner_user_id)
+    await db.commit()
+    await db.refresh(agent)
+
+    return {
+        "agent_id": agent.agent_id,
+        "key_id": key_id,
+        "token": agent_token,
+        "token_expires_at": expires_at_ts,
+        "display_name": agent.display_name,
+        "bio": agent.bio,
+    }
+
+
+# ---------------------------------------------------------------------------
+# WS /openclaw/control
+# ---------------------------------------------------------------------------
+
+
+_HOST_INITIATED_TYPES = {"heartbeat", "pong"}
+
+
+@router.websocket("/openclaw/control")
+async def openclaw_control_ws(ws: WebSocket) -> None:
+    """Long-lived host control channel.
+
+    Auth: ``Authorization: Bearer <openclaw host access JWT>``. Each frame
+    pushed by Hub is signed with the same Ed25519 key used for daemons.
+    """
+    auth_header = ws.headers.get("authorization") or ws.headers.get("Authorization")
+    if not auth_header or not auth_header.lower().startswith("bearer "):
+        await ws.close(code=4401, reason="missing bearer")
+        return
+    token = auth_header[len("Bearer ") :]
+    try:
+        claims = _verify_host_access_token(token)
+    except HTTPException as exc:
+        await ws.close(code=4401, reason=exc.detail or "auth")
+        return
+
+    host_instance_id = claims["openclaw_host_id"]
+    owner_user_id = claims.get("user_id") or ""
+
+    async with async_session() as db:
+        result = await db.execute(
+            select(OpenclawHostInstance).where(
+                OpenclawHostInstance.id == host_instance_id
+            )
+        )
+        instance = result.scalar_one_or_none()
+        if instance is None:
+            await ws.close(code=4401, reason="instance not found")
+            return
+        if instance.revoked_at is not None:
+            await ws.close(code=4403, reason="instance revoked")
+            return
+        instance.last_seen_at = _now()
+        await db.commit()
+
+    await ws.accept()
+
+    conn = _HostConn(
+        ws=ws,
+        owner_user_id=owner_user_id,
+        host_instance_id=host_instance_id,
+        pending_acks={},
+    )
+    previous = await _REGISTRY.register(conn)
+    if previous is not None:
+        try:
+            await previous.ws.close(code=4001, reason="displaced by new connection")
+        except Exception:
+            pass
+
+    hello = _build_signed_frame(
+        "hello",
+        {"server_time": int(_now().timestamp() * 1000)},
+    )
+    try:
+        await ws.send_text(json.dumps(hello))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("openclaw hello send failed: %s", exc)
+
+    try:
+        while True:
+            raw = await ws.receive_text()
+            try:
+                msg = json.loads(raw)
+            except json.JSONDecodeError:
+                logger.warning("openclaw WS: non-JSON frame, dropping")
+                continue
+            if not isinstance(msg, dict):
+                continue
+
+            # Ack of a Hub-issued dispatch.
+            if "ok" in msg and isinstance(msg.get("id"), str) and "type" not in msg:
+                fut = conn.pending_acks.pop(msg["id"], None)
+                if fut is not None and not fut.done():
+                    fut.set_result(msg)
+                continue
+
+            # Host-initiated event (heartbeat, pong).
+            await _handle_host_event(conn, msg)
+
+    except WebSocketDisconnect:
+        logger.info("openclaw WS disconnect: instance=%s", host_instance_id)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("openclaw WS error: instance=%s err=%s", host_instance_id, exc)
+    finally:
+        await _REGISTRY.unregister(conn)
+        for fut in conn.pending_acks.values():
+            if not fut.done():
+                fut.set_exception(RuntimeError("host disconnected"))
+
+
+async def _handle_host_event(conn: _HostConn, msg: dict[str, Any]) -> None:
+    msg_id = msg.get("id")
+    msg_type = msg.get("type")
+    if not isinstance(msg_id, str) or not isinstance(msg_type, str):
+        return
+
+    if msg_type not in _HOST_INITIATED_TYPES:
+        ack = {
+            "id": msg_id,
+            "ok": False,
+            "error": {"code": "unknown_type", "message": f"unknown host event type: {msg_type}"},
+        }
+        try:
+            await conn.ws.send_text(json.dumps(ack))
+        except Exception:
+            pass
+        return
+
+    try:
+        async with async_session() as db:
+            result = await db.execute(
+                select(OpenclawHostInstance).where(
+                    OpenclawHostInstance.id == conn.host_instance_id
+                )
+            )
+            instance = result.scalar_one_or_none()
+            if instance is not None:
+                instance.last_seen_at = _now()
+                await db.commit()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("openclaw event persist failed: %s", exc)
+
+    ack = {"id": msg_id, "ok": True}
+    try:
+        await conn.ws.send_text(json.dumps(ack))
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _registry_for_tests() -> _HostRegistry:
+    return _REGISTRY

--- a/backend/hub/routers/openclaw_control.py
+++ b/backend/hub/routers/openclaw_control.py
@@ -688,7 +688,9 @@ async def openclaw_provision_claim(
             db.add(signing_key)
     except IntegrityError:
         await db.rollback()
-        await _revert_short_code_claim(body.provision_id, "openclaw_provision")
+        await _revert_short_code_claim(
+            body.provision_id, "openclaw_provision", reopen=True
+        )
         raise HTTPException(status_code=409, detail="PUBKEY_ALREADY_REGISTERED")
 
     try:
@@ -696,7 +698,9 @@ async def openclaw_provision_claim(
         await db.commit()
     except Exception:
         await db.rollback()
-        await _revert_short_code_claim(body.provision_id, "openclaw_provision")
+        await _revert_short_code_claim(
+            body.provision_id, "openclaw_provision", reopen=True
+        )
         raise
     await db.refresh(agent)
 

--- a/backend/hub/routers/openclaw_control.py
+++ b/backend/hub/routers/openclaw_control.py
@@ -268,6 +268,7 @@ async def openclaw_install_claim(
         _consume_bind_ticket_jti,
         _ensure_agent_owner_role,
         _peek_bind_code,
+        _revert_short_code_claim,
         _utc_now,
         _verify_bind_ticket,
     )
@@ -425,10 +426,20 @@ async def openclaw_install_claim(
             db.add(signing_key)
     except IntegrityError:
         await db.rollback()
+        # The bind code was already stamped + the JTI burned. The agent
+        # row never landed; revert the short_code so polling readers don't
+        # see a phantom "claimed" state. The JTI stays burned (replay
+        # safety > the user redoing this exact flow).
+        await _revert_short_code_claim(body.bind_code, "bind")
         raise HTTPException(status_code=409, detail="PUBKEY_ALREADY_REGISTERED")
 
-    await _ensure_agent_owner_role(db, owner_user_id)
-    await db.commit()
+    try:
+        await _ensure_agent_owner_role(db, owner_user_id)
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        await _revert_short_code_claim(body.bind_code, "bind")
+        raise
     await db.refresh(agent)
 
     control_ws_url = (
@@ -530,6 +541,7 @@ async def openclaw_provision_claim(
     from app.routers.users import (
         _consume_short_code_with_claim,
         _ensure_agent_owner_role,
+        _revert_short_code_claim,
         _utc_now,
     )
     from hub.models import User
@@ -676,10 +688,16 @@ async def openclaw_provision_claim(
             db.add(signing_key)
     except IntegrityError:
         await db.rollback()
+        await _revert_short_code_claim(body.provision_id, "openclaw_provision")
         raise HTTPException(status_code=409, detail="PUBKEY_ALREADY_REGISTERED")
 
-    await _ensure_agent_owner_role(db, owner_user_id)
-    await db.commit()
+    try:
+        await _ensure_agent_owner_role(db, owner_user_id)
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        await _revert_short_code_claim(body.provision_id, "openclaw_provision")
+        raise
     await db.refresh(agent)
 
     return {

--- a/backend/migrations/029_openclaw_host_instances.sql
+++ b/backend/migrations/029_openclaw_host_instances.sql
@@ -1,0 +1,30 @@
+-- OpenClaw host instances: a host is the OpenClaw VM/container that runs
+-- the BotCord plugin. Mirrors `daemon_instances` shape — long-lived control
+-- plane row with refresh-token rotation; agents owned by this host link via
+-- `agents.openclaw_host_id`.
+
+CREATE TABLE IF NOT EXISTS openclaw_host_instances (
+    id                       VARCHAR(32)  PRIMARY KEY,                  -- oc_<12 hex>
+    owner_user_id            UUID         NOT NULL,
+    host_pubkey              TEXT         NOT NULL UNIQUE,
+    label                    VARCHAR(64)  NULL,
+    refresh_token_hash       VARCHAR(128) NULL,                          -- nullable so revoke can blank it
+    refresh_token_expires_at TIMESTAMPTZ  NULL,
+    last_seen_at             TIMESTAMPTZ  NULL,
+    revoked_at               TIMESTAMPTZ  NULL,
+    created_at               TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS ix_openclaw_host_instances_owner
+  ON openclaw_host_instances (owner_user_id);
+
+CREATE INDEX IF NOT EXISTS ix_openclaw_host_instances_refresh_hash
+  ON openclaw_host_instances (refresh_token_hash);
+
+ALTER TABLE agents
+  ADD COLUMN IF NOT EXISTS openclaw_host_id VARCHAR(32)
+    REFERENCES openclaw_host_instances(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS ix_agents_openclaw_host
+  ON agents(openclaw_host_id)
+  WHERE openclaw_host_id IS NOT NULL;

--- a/backend/static/openclaw/install.sh
+++ b/backend/static/openclaw/install.sh
@@ -45,6 +45,7 @@ OPENCLAW_CONFIG_PATH="${OPENCLAW_CONFIG_PATH:-}"
 
 BIND_CODE=""
 BIND_NONCE=""
+PURPOSE="install_claim"
 
 # ── Logging + cleanup ─────────────────────────────────────────────────────
 
@@ -107,6 +108,8 @@ Usage:
 Required (issued by the dashboard):
   --bind-code <bd_xxx>      One-time bind code from "Add Agent to OpenClaw"
   --bind-nonce <base64>     Ticket nonce to sign with the local keypair
+  --purpose <kind>          install_claim (default; agent-only legacy flow)
+                            or openclaw_install (host + agent first-install)
 
 Plugin source (mutually exclusive; default: npm registry):
   --plugin-version <ver>    Pin a specific version of $PLUGIN_PACKAGE
@@ -154,6 +157,7 @@ while [ "$#" -gt 0 ]; do
   case "$1" in
     --bind-code)       need_next_arg "$1" "$#"; BIND_CODE="$2"; shift 2 ;;
     --bind-nonce)      need_next_arg "$1" "$#"; BIND_NONCE="$2"; shift 2 ;;
+    --purpose)         need_next_arg "$1" "$#"; PURPOSE="$2"; shift 2 ;;
     --server-url)      need_next_arg "$1" "$#"; SERVER_URL="$2"; shift 2 ;;
     --plugin-version)  need_next_arg "$1" "$#"; PLUGIN_VERSION="$2"; shift 2 ;;
     --tgz-url)         need_next_arg "$1" "$#"; TGZ_URL="$2"; shift 2 ;;
@@ -179,6 +183,10 @@ if [ -z "$BIND_CODE" ] || [ -z "$BIND_NONCE" ]; then
 fi
 
 case "$BIND_CODE" in bd_*) ;; *) log_error "--bind-code must start with bd_"; exit 1 ;; esac
+case "$PURPOSE" in
+  install_claim|openclaw_install) ;;
+  *) log_error "--purpose must be 'install_claim' or 'openclaw_install'"; exit 1 ;;
+esac
 
 require_cmd node "Install Node.js >= 18 first (https://nodejs.org)"
 require_cmd curl "Install curl first"
@@ -255,8 +263,129 @@ fi
 
 # ── Step 2: Generate keypair, sign, claim ────────────────────────────────
 
-log "claiming bind code on $SERVER_URL"
+log "claiming bind code on $SERVER_URL (purpose=$PURPOSE)"
 
+if [ "$PURPOSE" = "openclaw_install" ]; then
+  RESULT="$(
+    SERVER_URL="$SERVER_URL" \
+    BIND_CODE="$BIND_CODE" \
+    BIND_NONCE="$BIND_NONCE" \
+    node --input-type=module <<'NODE' 2>>"$RUN_LOG"
+import { generateKeyPairSync, createPrivateKey, sign } from "node:crypto";
+import { mkdirSync, writeFileSync, chmodSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const serverUrl = process.env.SERVER_URL.replace(/\/+$/, "");
+const bindCode  = process.env.BIND_CODE;
+const bindNonce = process.env.BIND_NONCE;
+
+const PKCS8_PREFIX = Buffer.from("302e020100300506032b657004220420", "hex");
+
+function generateKeypair() {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const privDer = privateKey.export({ type: "pkcs8", format: "der" });
+  const privB64 = Buffer.from(privDer.subarray(-32)).toString("base64");
+  const pubDer  = publicKey.export({ type: "spki",  format: "der" });
+  const pubB64  = Buffer.from(pubDer.subarray(-32)).toString("base64");
+  return { privB64, pubB64 };
+}
+
+function signNonce(privB64, nonce) {
+  const pk = createPrivateKey({
+    key: Buffer.concat([PKCS8_PREFIX, Buffer.from(privB64, "base64")]),
+    format: "der",
+    type: "pkcs8",
+  });
+  return sign(null, Buffer.from(nonce, "base64"), pk).toString("base64");
+}
+
+const host  = generateKeypair();
+const agent = generateKeypair();
+
+const claimUrl = `${serverUrl}/openclaw/install-claim`;
+const body = {
+  bind_code: bindCode,
+  host: {
+    pubkey: `ed25519:${host.pubB64}`,
+    proof:  { nonce: bindNonce, sig: signNonce(host.privB64,  bindNonce) },
+  },
+  agent: {
+    pubkey: `ed25519:${agent.pubB64}`,
+    proof:  { nonce: bindNonce, sig: signNonce(agent.privB64, bindNonce) },
+  },
+};
+
+const resp = await fetch(claimUrl, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify(body),
+  signal: AbortSignal.timeout(20000),
+});
+if (!resp.ok) {
+  const text = await resp.text().catch(() => "");
+  process.stderr.write(`openclaw install-claim failed (${resp.status}): ${text}\n`);
+  process.exit(1);
+}
+const data = await resp.json();
+
+const agentId = data.agent.id;
+const hostId  = data.host.host_instance_id;
+const hubUrl  = data.hub_url || serverUrl;
+
+const credDir = join(homedir(), ".botcord", "credentials");
+mkdirSync(credDir, { recursive: true, mode: 0o700 });
+const credPath = join(credDir, `${agentId}.json`);
+writeFileSync(credPath, JSON.stringify({
+  version: 1,
+  hubUrl,
+  agentId,
+  keyId: data.agent.key_id,
+  privateKey: agent.privB64,
+  publicKey:  agent.pubB64,
+  displayName: data.agent.display_name || agentId,
+  bio: data.agent.bio || null,
+  savedAt: new Date().toISOString(),
+  token: data.agent.token || undefined,
+  tokenExpiresAt: data.agent.token_expires_at ?? undefined,
+  openclawHostId: hostId,
+}, null, 2) + "\n", { encoding: "utf8", mode: 0o600 });
+chmodSync(credPath, 0o600);
+
+const hostDir = join(homedir(), ".botcord", "openclaw");
+mkdirSync(hostDir, { recursive: true, mode: 0o700 });
+const hostPath = join(hostDir, "host.json");
+writeFileSync(hostPath, JSON.stringify({
+  version: 1,
+  hubUrl,
+  hostInstanceId: hostId,
+  privateKey: host.privB64,
+  publicKey:  host.pubB64,
+  accessToken: data.host.access_token,
+  refreshToken: data.host.refresh_token,
+  accessExpiresAt: data.host.access_expires_at,
+  refreshExpiresAt: data.host.refresh_expires_at,
+  controlWsUrl: data.host.control_ws_url,
+  savedAt: new Date().toISOString(),
+}, null, 2) + "\n", { encoding: "utf8", mode: 0o600 });
+chmodSync(hostPath, 0o600);
+
+process.stdout.write(JSON.stringify({
+  agentId,
+  keyId: data.agent.key_id,
+  displayName: data.agent.display_name || agentId,
+  hubUrl,
+  wsUrl: null,
+  credentialsFile: credPath,
+  hostFile: hostPath,
+  openclawHostId: hostId,
+}));
+NODE
+  )" || {
+    log_error "openclaw install-claim failed (bind code may be expired, already used, or proof rejected)"
+    exit 1
+  }
+else
 RESULT="$(
   SERVER_URL="$SERVER_URL" \
   BIND_CODE="$BIND_CODE" \
@@ -350,6 +479,7 @@ NODE
   log_error "claim step failed (bind code may be expired, already used, or the server rejected the proof)"
   exit 1
 }
+fi
 
 if [ -z "$RESULT" ]; then
   log_error "claim step returned no output; nothing was written"

--- a/backend/tests/test_app/test_openclaw_onboarding.py
+++ b/backend/tests/test_app/test_openclaw_onboarding.py
@@ -359,6 +359,53 @@ async def test_openclaw_install_endpoint_rejects_anon(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_openclaw_provision_rejects_wrong_agent_in_ack(
+    client: AsyncClient, fresh_user: dict, db_session: AsyncSession, monkeypatch
+):
+    """A buggy/compromised host that acks with someone else's agent_id
+    must not be reported as success — the BFF has to verify ownership +
+    host binding before returning to the dashboard.
+    """
+    issued = await _issue_install(client, fresh_user["token"], name="A")
+    claim = (await _claim(client, issued["bind_code"], issued["nonce"])).json()
+    host_id = claim["host"]["host_instance_id"]
+
+    # Pretend an unrelated user owns a different agent on a different host.
+    stranger_id = uuid.uuid4()
+    other_agent = Agent(
+        agent_id="ag_stranger12",
+        display_name="stranger",
+        user_id=stranger_id,
+        is_default=False,
+        hosting_kind="plugin",
+        openclaw_host_id=None,
+        status="active",
+    )
+    db_session.add(other_agent)
+    await db_session.commit()
+
+    # Stub the registry + control frame send so the BFF thinks the host
+    # is online and the host's "ack" returns the stranger's agent_id.
+    from hub.routers import openclaw_control as oc_mod
+
+    monkeypatch.setattr(oc_mod, "is_openclaw_host_online", lambda _hid: True)
+
+    async def fake_send_control_frame(_hid, _type, _params, *_a, **_kw):
+        return {"ok": True, "result": {"agent_id": "ag_stranger12"}}
+
+    monkeypatch.setattr(oc_mod, "send_host_control_frame", fake_send_control_frame)
+
+    resp = await client.post(
+        "/api/users/me/agents/openclaw/provision",
+        json={"openclaw_host_id": host_id, "name": "should-fail"},
+        headers={"Authorization": f"Bearer {fresh_user['token']}"},
+    )
+    assert resp.status_code == 502
+    body = resp.json()
+    assert body["detail"]["code"] == "openclaw_provision_failed"
+
+
+@pytest.mark.asyncio
 async def test_openclaw_hosts_list_returns_owned_only(
     client: AsyncClient, fresh_user: dict
 ):

--- a/backend/tests/test_app/test_openclaw_onboarding.py
+++ b/backend/tests/test_app/test_openclaw_onboarding.py
@@ -1,0 +1,379 @@
+"""Tests for the OpenClaw host onboarding flow.
+
+Covers:
+- POST /api/users/me/agents/openclaw/install (issues bind ticket)
+- POST /openclaw/install-claim (host + agent dual-PoP)
+- POST /openclaw/auth/refresh (refresh-token rotation)
+- DELETE /api/users/me/agents/openclaw/hosts/{id} (batch unbind +
+  single default promotion)
+- replay rejection of consumed bind code
+"""
+
+from __future__ import annotations
+
+import base64
+import uuid
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from nacl.signing import SigningKey as NaClSigningKey
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from hub.models import (
+    Agent,
+    Base,
+    OpenclawHostInstance,
+    Role,
+    User,
+    UserRole,
+)
+
+from .test_app_user_agents import (
+    TEST_JWT_SECRET,
+    TEST_SUPABASE_SECRET,
+    _make_supabase_token,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def db_engine():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        execution_options={"schema_translate_map": {"public": None}},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield engine
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def db_session(db_engine):
+    factory = async_sessionmaker(db_engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+
+
+@pytest_asyncio.fixture
+async def client(db_session: AsyncSession, db_engine, monkeypatch):
+    import hub.config
+    import app.auth
+    import app.routers.users as users_mod
+
+    monkeypatch.setattr(hub.config, "SUPABASE_JWT_SECRET", TEST_SUPABASE_SECRET)
+    monkeypatch.setattr(app.auth, "SUPABASE_JWT_SECRET", TEST_SUPABASE_SECRET)
+    monkeypatch.setattr(users_mod, "BIND_PROOF_SECRET", None)
+    monkeypatch.setattr(users_mod, "JWT_SECRET", TEST_JWT_SECRET)
+    monkeypatch.setattr(hub.config, "BIND_PROOF_SECRET", None)
+    monkeypatch.setattr(hub.config, "JWT_SECRET", TEST_JWT_SECRET)
+
+    from hub.main import app
+    from hub.database import get_db
+
+    async def _override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    factory = async_sessionmaker(db_engine, class_=AsyncSession, expire_on_commit=False)
+    monkeypatch.setattr(users_mod, "_jti_session_factory", factory)
+    monkeypatch.setattr(users_mod, "_short_code_session_factory", factory)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def fresh_user(db_session: AsyncSession):
+    supabase_uuid = uuid.uuid4()
+    user_id = uuid.uuid4()
+    user = User(
+        id=user_id,
+        display_name="Install User",
+        email="oc@example.com",
+        status="active",
+        supabase_user_id=supabase_uuid,
+        max_agents=5,
+    )
+    db_session.add(user)
+    member_role = Role(
+        id=uuid.uuid4(), name="member", display_name="Member", is_system=True, priority=0
+    )
+    owner_role = Role(
+        id=uuid.uuid4(),
+        name="agent_owner",
+        display_name="Agent Owner",
+        is_system=True,
+        priority=0,
+    )
+    db_session.add_all([member_role, owner_role])
+    await db_session.flush()
+    db_session.add(UserRole(id=uuid.uuid4(), user_id=user_id, role_id=member_role.id))
+    await db_session.commit()
+    return {
+        "user_id": user_id,
+        "token": _make_supabase_token(str(supabase_uuid)),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _gen_keypair() -> tuple[str, NaClSigningKey]:
+    sk = NaClSigningKey.generate()
+    return base64.b64encode(bytes(sk.verify_key)).decode(), sk
+
+
+def _sign_nonce(sk: NaClSigningKey, nonce_b64: str) -> str:
+    return base64.b64encode(sk.sign(base64.b64decode(nonce_b64)).signature).decode()
+
+
+async def _issue_install(client: AsyncClient, token: str, name: str = "vm-bot") -> dict:
+    resp = await client.post(
+        "/api/users/me/agents/openclaw/install",
+        json={"name": name, "bio": "hello"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+async def _claim(client: AsyncClient, bind_code: str, nonce: str) -> dict:
+    host_pub, host_sk = _gen_keypair()
+    agent_pub, agent_sk = _gen_keypair()
+    body = {
+        "bind_code": bind_code,
+        "host": {
+            "pubkey": f"ed25519:{host_pub}",
+            "proof": {"nonce": nonce, "sig": _sign_nonce(host_sk, nonce)},
+        },
+        "agent": {
+            "pubkey": f"ed25519:{agent_pub}",
+            "proof": {"nonce": nonce, "sig": _sign_nonce(agent_sk, nonce)},
+        },
+    }
+    resp = await client.post("/openclaw/install-claim", json=body)
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_openclaw_install_claim_happy_path(
+    client: AsyncClient, fresh_user: dict, db_session: AsyncSession
+):
+    issued = await _issue_install(client, fresh_user["token"], name="laptop-bot")
+    assert issued["bind_code"].startswith("bd_")
+    assert "openclaw_install" in issued["install_command"]
+    assert "/openclaw/install.sh" in issued["install_command"]
+
+    resp = await _claim(client, issued["bind_code"], issued["nonce"])
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["agent"]["id"].startswith("ag_")
+    assert body["agent"]["display_name"] == "laptop-bot"
+    assert body["agent"]["bio"] == "hello"
+    assert body["host"]["host_instance_id"].startswith("oc_")
+    assert body["host"]["access_token"]
+    assert body["host"]["refresh_token"].startswith("ort_")
+    assert body["host"]["control_ws_url"].endswith("/openclaw/control")
+
+    # Agent + host rows persisted with the right linkage.
+    agent = (
+        await db_session.execute(select(Agent).where(Agent.agent_id == body["agent"]["id"]))
+    ).scalar_one()
+    assert agent.hosting_kind == "plugin"
+    assert agent.openclaw_host_id == body["host"]["host_instance_id"]
+    assert agent.user_id == fresh_user["user_id"]
+    assert agent.is_default is True  # first agent for the user
+
+    instance = (
+        await db_session.execute(
+            select(OpenclawHostInstance).where(
+                OpenclawHostInstance.id == body["host"]["host_instance_id"]
+            )
+        )
+    ).scalar_one()
+    assert str(instance.owner_user_id) == str(fresh_user["user_id"])
+
+
+@pytest.mark.asyncio
+async def test_openclaw_install_claim_replay_rejected(
+    client: AsyncClient, fresh_user: dict
+):
+    issued = await _issue_install(client, fresh_user["token"])
+    first = await _claim(client, issued["bind_code"], issued["nonce"])
+    assert first.status_code == 201
+
+    # Same bind code, fresh keypairs — must be rejected.
+    second = await _claim(client, issued["bind_code"], issued["nonce"])
+    assert second.status_code == 400
+    assert second.json()["detail"] == "INVALID_BIND_CODE"
+
+
+@pytest.mark.asyncio
+async def test_openclaw_install_claim_bad_proof_rejected(
+    client: AsyncClient, fresh_user: dict
+):
+    issued = await _issue_install(client, fresh_user["token"])
+    host_pub, _ = _gen_keypair()
+    agent_pub, agent_sk = _gen_keypair()
+    body = {
+        "bind_code": issued["bind_code"],
+        "host": {
+            "pubkey": f"ed25519:{host_pub}",
+            "proof": {"nonce": issued["nonce"], "sig": "AA" * 32},
+        },
+        "agent": {
+            "pubkey": f"ed25519:{agent_pub}",
+            "proof": {"nonce": issued["nonce"], "sig": _sign_nonce(agent_sk, issued["nonce"])},
+        },
+    }
+    resp = await client.post("/openclaw/install-claim", json=body)
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "INVALID_PROOF"
+
+
+@pytest.mark.asyncio
+async def test_openclaw_refresh_token_rotation(
+    client: AsyncClient, fresh_user: dict
+):
+    issued = await _issue_install(client, fresh_user["token"])
+    claim = (await _claim(client, issued["bind_code"], issued["nonce"])).json()
+    refresh = claim["host"]["refresh_token"]
+    access = claim["host"]["access_token"]
+
+    resp = await client.post("/openclaw/auth/refresh", json={"refresh_token": refresh})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["host_instance_id"] == claim["host"]["host_instance_id"]
+    assert body["access_token"]
+    # Refresh token MUST rotate (one-time use); access token may be byte-equal
+    # if minted within the same `exp` second, which is a fine no-op.
+    assert body["refresh_token"] and body["refresh_token"] != refresh
+    _ = access  # keep reference; we tolerate same-second identical access JWT
+
+    # Old refresh must now be invalid.
+    repeat = await client.post("/openclaw/auth/refresh", json={"refresh_token": refresh})
+    assert repeat.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_openclaw_host_revoke_unbinds_all_agents_and_promotes_one_default(
+    client: AsyncClient, fresh_user: dict, db_session: AsyncSession
+):
+    # Onboard a host (creates default agent A).
+    issued = await _issue_install(client, fresh_user["token"], name="A")
+    claim_a = (await _claim(client, issued["bind_code"], issued["nonce"])).json()
+    host_id = claim_a["host"]["host_instance_id"]
+    agent_a_id = claim_a["agent"]["id"]
+
+    # Manually attach a second agent (B) to the same host so we can verify
+    # batched unbind + single default promotion. This avoids needing a
+    # live host WS to drive provision-claim through HTTP.
+    agent_b = Agent(
+        agent_id="ag_" + uuid.uuid4().hex[:12],
+        display_name="B",
+        user_id=fresh_user["user_id"],
+        is_default=False,
+        hosting_kind="plugin",
+        openclaw_host_id=host_id,
+        status="active",
+    )
+    db_session.add(agent_b)
+    # And an unrelated agent C on no host — should be the promoted default
+    # after the host is revoked.
+    agent_c = Agent(
+        agent_id="ag_" + uuid.uuid4().hex[:12],
+        display_name="C",
+        user_id=fresh_user["user_id"],
+        is_default=False,
+        hosting_kind=None,
+        openclaw_host_id=None,
+        status="active",
+    )
+    db_session.add(agent_c)
+    await db_session.commit()
+
+    resp = await client.delete(
+        f"/api/users/me/agents/openclaw/hosts/{host_id}",
+        headers={"Authorization": f"Bearer {fresh_user['token']}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body["revoked_agents"]) == {agent_a_id, agent_b.agent_id}
+
+    # Re-read with fresh queries — Agent rows captured before commit are stale.
+    a = (
+        await db_session.execute(select(Agent).where(Agent.agent_id == agent_a_id))
+    ).scalar_one()
+    b = (
+        await db_session.execute(select(Agent).where(Agent.agent_id == agent_b.agent_id))
+    ).scalar_one()
+    c = (
+        await db_session.execute(select(Agent).where(Agent.agent_id == agent_c.agent_id))
+    ).scalar_one()
+
+    assert a.user_id is None and a.openclaw_host_id is None and not a.is_default
+    assert b.user_id is None and b.openclaw_host_id is None and not b.is_default
+    # Exactly one promoted default — the unrelated agent C — even though
+    # the previous default lived on the revoked host.
+    assert c.is_default is True
+    assert c.user_id == fresh_user["user_id"]
+
+    instance = (
+        await db_session.execute(
+            select(OpenclawHostInstance).where(OpenclawHostInstance.id == host_id)
+        )
+    ).scalar_one()
+    assert instance.revoked_at is not None
+    assert instance.refresh_token_hash is None
+
+
+@pytest.mark.asyncio
+async def test_openclaw_install_endpoint_rejects_anon(client: AsyncClient):
+    resp = await client.post(
+        "/api/users/me/agents/openclaw/install",
+        json={"name": "x"},
+    )
+    assert resp.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_openclaw_hosts_list_returns_owned_only(
+    client: AsyncClient, fresh_user: dict
+):
+    issued = await _issue_install(client, fresh_user["token"], name="vm-1")
+    await _claim(client, issued["bind_code"], issued["nonce"])
+
+    resp = await client.get(
+        "/api/users/me/agents/openclaw/hosts",
+        headers={"Authorization": f"Bearer {fresh_user['token']}"},
+    )
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert len(payload["hosts"]) == 1
+    host = payload["hosts"][0]
+    assert host["id"].startswith("oc_")
+    assert host["agent_count"] == 1
+    # Not online — no live WS in the test harness.
+    assert host["online"] is False

--- a/frontend/src/app/api/users/me/agents/openclaw/hosts/[hostId]/route.ts
+++ b/frontend/src/app/api/users/me/agents/openclaw/hosts/[hostId]/route.ts
@@ -1,0 +1,34 @@
+/**
+ * [INPUT]: Supabase user session, optional patch body {label?}
+ * [OUTPUT]: PATCH /rename, DELETE /revoke for a single OpenClaw host instance
+ * [POS]: BFF endpoint for managing registered OpenClaw hosts
+ * [PROTOCOL]: update header on changes
+ */
+
+import { NextResponse } from "next/server";
+import { proxyDaemon } from "../../../../../../daemon/_lib/proxy";
+
+interface Ctx {
+  params: Promise<{ hostId: string }>;
+}
+
+export async function PATCH(req: Request, ctx: Ctx): Promise<NextResponse> {
+  const { hostId } = await ctx.params;
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  return proxyDaemon(`/api/users/me/agents/openclaw/hosts/${hostId}`, {
+    method: "PATCH",
+    body,
+  });
+}
+
+export async function DELETE(_req: Request, ctx: Ctx): Promise<NextResponse> {
+  const { hostId } = await ctx.params;
+  return proxyDaemon(`/api/users/me/agents/openclaw/hosts/${hostId}`, {
+    method: "DELETE",
+  });
+}

--- a/frontend/src/app/api/users/me/agents/openclaw/hosts/route.ts
+++ b/frontend/src/app/api/users/me/agents/openclaw/hosts/route.ts
@@ -1,0 +1,12 @@
+/**
+ * [INPUT]: Supabase user session
+ * [OUTPUT]: GET /api/users/me/agents/openclaw/hosts — current user's OpenClaw hosts
+ * [POS]: BFF endpoint backing the OpenClaw HostPicker
+ * [PROTOCOL]: update header on changes
+ */
+
+import { proxyDaemon } from "../../../../../daemon/_lib/proxy";
+
+export async function GET() {
+  return proxyDaemon("/api/users/me/agents/openclaw/hosts", { method: "GET" });
+}

--- a/frontend/src/app/api/users/me/agents/openclaw/install/route.ts
+++ b/frontend/src/app/api/users/me/agents/openclaw/install/route.ts
@@ -1,0 +1,22 @@
+/**
+ * [INPUT]: Supabase user session, install body {name, bio?}
+ * [OUTPUT]: POST /api/users/me/agents/openclaw/install — issues an OpenClaw bind ticket
+ * [POS]: BFF endpoint backing the OpenClaw branch of CreateAgentDialog
+ * [PROTOCOL]: update header on changes
+ */
+
+import { NextResponse } from "next/server";
+import { proxyDaemon } from "../../../../../daemon/_lib/proxy";
+
+export async function POST(req: Request): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+  return proxyDaemon("/api/users/me/agents/openclaw/install", {
+    method: "POST",
+    body,
+  });
+}

--- a/frontend/src/app/api/users/me/agents/openclaw/provision/route.ts
+++ b/frontend/src/app/api/users/me/agents/openclaw/provision/route.ts
@@ -1,0 +1,22 @@
+/**
+ * [INPUT]: Supabase user session, provision body {openclaw_host_id, name, bio?}
+ * [OUTPUT]: POST /api/users/me/agents/openclaw/provision — provisions an agent on a registered OpenClaw host
+ * [POS]: BFF endpoint backing the OpenClaw branch of CreateAgentDialog
+ * [PROTOCOL]: update header on changes
+ */
+
+import { NextResponse } from "next/server";
+import { proxyDaemon } from "../../../../../daemon/_lib/proxy";
+
+export async function POST(req: Request): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+  return proxyDaemon("/api/users/me/agents/openclaw/provision", {
+    method: "POST",
+    body,
+  });
+}

--- a/frontend/src/components/dashboard/CreateAgentDialog.tsx
+++ b/frontend/src/components/dashboard/CreateAgentDialog.tsx
@@ -27,6 +27,13 @@ import {
   type DaemonInstance,
   type DaemonRuntime,
 } from "@/store/useDaemonStore";
+import {
+  useOpenclawHostStore,
+  OpenclawProvisionError,
+  type OpenclawHost,
+  type OpenclawInstallTicket,
+} from "@/store/useOpenclawHostStore";
+import InstallCommandPanel from "./InstallCommandPanel";
 
 interface CreateAgentDialogProps {
   onClose: () => void;
@@ -67,6 +74,7 @@ export default function CreateAgentDialog({
     [daemons],
   );
 
+  const [hostKind, setHostKind] = useState<"daemon" | "openclaw">("daemon");
   const [selectedDaemonId, setSelectedDaemonId] = useState<string | null>(null);
   const [selectedRuntimeId, setSelectedRuntimeId] = useState<string | null>(null);
   const [name, setName] = useState("");
@@ -197,7 +205,42 @@ export default function CreateAgentDialog({
           <p className="mt-2 text-sm text-text-secondary">{t.description}</p>
         </div>
 
-        {!loaded && loading ? (
+        <div className="mb-4 inline-flex rounded-xl border border-glass-border bg-glass-bg/40 p-0.5 text-xs">
+          <button
+            type="button"
+            onClick={() => {
+              setHostKind("daemon");
+              setError(null);
+            }}
+            disabled={submitting}
+            className={`rounded-lg px-3 py-1.5 transition-colors ${
+              hostKind === "daemon"
+                ? "bg-neon-cyan/20 text-neon-cyan"
+                : "text-text-secondary hover:text-text-primary"
+            }`}
+          >
+            Local daemon
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setHostKind("openclaw");
+              setError(null);
+            }}
+            disabled={submitting}
+            className={`rounded-lg px-3 py-1.5 transition-colors ${
+              hostKind === "openclaw"
+                ? "bg-neon-cyan/20 text-neon-cyan"
+                : "text-text-secondary hover:text-text-primary"
+            }`}
+          >
+            OpenClaw host
+          </button>
+        </div>
+
+        {hostKind === "openclaw" ? (
+          <OpenclawBranch onSuccess={onSuccess} onClose={onClose} />
+        ) : !loaded && loading ? (
           <div className="flex items-center justify-center py-10 text-text-secondary">
             <Loader2 className="h-5 w-5 animate-spin" />
           </div>
@@ -541,3 +584,235 @@ function RuntimeCard({
     </button>
   );
 }
+
+// ── OpenClaw branch ─────────────────────────────────────────────────────────
+
+interface OpenclawBranchProps {
+  onSuccess: (agentId: string) => Promise<void> | void;
+  onClose: () => void;
+}
+
+type OpenclawTarget = { kind: "host"; hostId: string } | { kind: "new" };
+
+function OpenclawBranch({ onSuccess, onClose }: OpenclawBranchProps) {
+  const hosts = useOpenclawHostStore((s) => s.hosts);
+  const loaded = useOpenclawHostStore((s) => s.loaded);
+  const refresh = useOpenclawHostStore((s) => s.refresh);
+  const issueInstall = useOpenclawHostStore((s) => s.issueInstall);
+  const provisionOnHost = useOpenclawHostStore((s) => s.provisionOnHost);
+
+  const [target, setTarget] = useState<OpenclawTarget>({ kind: "new" });
+  const [name, setName] = useState("");
+  const [bio, setBio] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [ticket, setTicket] = useState<OpenclawInstallTicket | null>(null);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  // Default to a registered online host if any exist.
+  useEffect(() => {
+    if (target.kind === "host") return;
+    const onlineHost = hosts.find((h) => h.online && !h.revoked_at);
+    if (onlineHost) setTarget({ kind: "host", hostId: onlineHost.id });
+  }, [hosts, target.kind]);
+
+  function describeError(err: unknown): string {
+    if (err instanceof OpenclawProvisionError) {
+      return err.detail || err.message;
+    }
+    return err instanceof Error ? err.message : "Failed";
+  }
+
+  async function handleSubmit() {
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setError("Name is required");
+      return;
+    }
+    setError(null);
+    setSubmitting(true);
+    try {
+      if (target.kind === "host") {
+        const res = await provisionOnHost(target.hostId, {
+          name: trimmedName,
+          bio: bio.trim() || undefined,
+        });
+        await onSuccess(res.agentId);
+        onClose();
+      } else {
+        const t = await issueInstall({
+          name: trimmedName,
+          bio: bio.trim() || undefined,
+        });
+        setTicket(t);
+      }
+    } catch (err) {
+      setError(describeError(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (ticket) {
+    return (
+      <InstallCommandPanel
+        ticket={ticket}
+        onClaimed={async (agentId) => {
+          await onSuccess(agentId);
+          onClose();
+        }}
+        onCancel={() => setTicket(null)}
+      />
+    );
+  }
+
+  const visibleHosts = hosts.filter((h) => !h.revoked_at);
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="mb-1.5 block text-xs font-semibold uppercase tracking-wider text-text-secondary">
+          OpenClaw host
+        </label>
+        <div className="grid grid-cols-1 gap-2">
+          {visibleHosts.map((h) => (
+            <HostCard
+              key={h.id}
+              host={h}
+              selected={target.kind === "host" && target.hostId === h.id}
+              onSelect={() => setTarget({ kind: "host", hostId: h.id })}
+              disabled={submitting}
+            />
+          ))}
+          <button
+            type="button"
+            onClick={() => setTarget({ kind: "new" })}
+            disabled={submitting}
+            className={`flex items-center justify-between gap-2 rounded-xl border px-3 py-2 text-left text-sm transition-colors ${
+              target.kind === "new"
+                ? "border-neon-cyan/60 bg-neon-cyan/10 text-text-primary"
+                : "border-glass-border text-text-secondary hover:bg-glass-bg hover:text-text-primary"
+            }`}
+          >
+            <span className="flex items-center gap-2">
+              <Server className="h-4 w-4" />
+              Add a new OpenClaw host
+            </span>
+            {target.kind === "new" && <Check className="h-4 w-4 text-neon-cyan" />}
+          </button>
+        </div>
+        {!loaded && (
+          <p className="mt-2 text-[11px] text-text-tertiary">Loading registered hosts…</p>
+        )}
+      </div>
+
+      <div>
+        <label className="mb-1.5 block text-xs font-semibold uppercase tracking-wider text-text-secondary">
+          Agent name
+        </label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. research-bot"
+          disabled={submitting}
+          className="w-full rounded-xl border border-glass-border bg-deep-black px-3 py-2 text-sm text-text-primary placeholder-text-tertiary focus:border-neon-cyan focus:outline-none focus:ring-1 focus:ring-neon-cyan/50 disabled:opacity-50"
+          maxLength={64}
+        />
+      </div>
+
+      <div>
+        <label className="mb-1.5 block text-xs font-semibold uppercase tracking-wider text-text-secondary">
+          Bio (optional)
+        </label>
+        <textarea
+          value={bio}
+          onChange={(e) => setBio(e.target.value)}
+          placeholder="What this bot is for"
+          disabled={submitting}
+          rows={2}
+          className="w-full resize-none rounded-xl border border-glass-border bg-deep-black px-3 py-2 text-sm text-text-primary placeholder-text-tertiary focus:border-neon-cyan focus:outline-none focus:ring-1 focus:ring-neon-cyan/50 disabled:opacity-50"
+          maxLength={240}
+        />
+      </div>
+
+      {error && (
+        <p className="rounded-lg border border-red-400/20 bg-red-400/10 p-2 text-xs text-red-400">
+          {error}
+        </p>
+      )}
+
+      <div className="flex items-center justify-end gap-3">
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={submitting}
+          className="rounded-xl border border-glass-border px-4 py-2.5 text-sm font-medium text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={() => void handleSubmit()}
+          disabled={submitting || !name.trim()}
+          className="flex items-center gap-2 rounded-xl border border-neon-cyan/50 bg-neon-cyan/10 px-4 py-2.5 text-sm font-bold text-neon-cyan transition-all hover:bg-neon-cyan/20 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {submitting ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Working…
+            </>
+          ) : target.kind === "new" ? (
+            "Get install command"
+          ) : (
+            "Create"
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function HostCard({
+  host,
+  selected,
+  onSelect,
+  disabled,
+}: {
+  host: OpenclawHost;
+  selected: boolean;
+  onSelect: () => void;
+  disabled: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      disabled={disabled || !host.online}
+      className={`flex items-center justify-between gap-2 rounded-xl border px-3 py-2 text-left text-sm transition-colors ${
+        selected
+          ? "border-neon-cyan/60 bg-neon-cyan/10 text-text-primary"
+          : "border-glass-border text-text-secondary hover:bg-glass-bg hover:text-text-primary"
+      } ${!host.online ? "cursor-not-allowed opacity-60" : ""}`}
+    >
+      <span className="flex items-center gap-2">
+        <Server className="h-4 w-4 text-neon-cyan" />
+        <span className="text-text-primary">{host.label || host.id}</span>
+        {host.online ? (
+          <span className="ml-1 inline-flex h-1.5 w-1.5 rounded-full bg-neon-green" />
+        ) : (
+          <span className="ml-1 text-[10px] uppercase tracking-wider text-text-tertiary">
+            offline
+          </span>
+        )}
+      </span>
+      <span className="text-[11px] text-text-tertiary">
+        {host.agent_count} agent{host.agent_count === 1 ? "" : "s"}
+      </span>
+    </button>
+  );
+}
+

--- a/frontend/src/components/dashboard/CreateAgentDialog.tsx
+++ b/frontend/src/components/dashboard/CreateAgentDialog.tsx
@@ -641,6 +641,16 @@ function OpenclawBranch({ onSuccess, onClose }: OpenclawBranchProps) {
           bio: bio.trim() || undefined,
         });
         await onSuccess(res.agentId);
+        if (!res.configPatched) {
+          // Hub created the agent + the host wrote credentials, but the
+          // host couldn't auto-attach (multi-account guard or IO error).
+          // Warn loudly via console so the dashboard at least surfaces a
+          // signal until the toast plumbing carries it. Closing the
+          // dialog still happens — the agent IS created.
+          console.warn(
+            `[botcord] agent ${res.agentId} created but openclaw config not auto-patched (${res.configSkipReason || "unknown"}). Manually edit ~/.openclaw/openclaw.json on the host.`,
+          );
+        }
         onClose();
       } else {
         const t = await issueInstall({

--- a/frontend/src/components/dashboard/CreateAgentDialog.tsx
+++ b/frontend/src/components/dashboard/CreateAgentDialog.tsx
@@ -351,7 +351,7 @@ export default function CreateAgentDialog({
           </p>
         )}
 
-        {!showEmptyState && loaded && (
+        {hostKind === "daemon" && !showEmptyState && loaded && (
           <div className="mt-6 flex items-center justify-end gap-3">
             <button
               onClick={onClose}
@@ -607,6 +607,10 @@ function OpenclawBranch({ onSuccess, onClose }: OpenclawBranchProps) {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [ticket, setTicket] = useState<OpenclawInstallTicket | null>(null);
+  const [manualAttachNotice, setManualAttachNotice] = useState<{
+    agentId: string;
+    reason: string | null;
+  } | null>(null);
 
   useEffect(() => {
     void refresh();
@@ -642,14 +646,16 @@ function OpenclawBranch({ onSuccess, onClose }: OpenclawBranchProps) {
         });
         await onSuccess(res.agentId);
         if (!res.configPatched) {
-          // Hub created the agent + the host wrote credentials, but the
-          // host couldn't auto-attach (multi-account guard or IO error).
-          // Warn loudly via console so the dashboard at least surfaces a
-          // signal until the toast plumbing carries it. Closing the
-          // dialog still happens — the agent IS created.
-          console.warn(
-            `[botcord] agent ${res.agentId} created but openclaw config not auto-patched (${res.configSkipReason || "unknown"}). Manually edit ~/.openclaw/openclaw.json on the host.`,
-          );
+          // Agent IS created on Hub and credentials landed on disk,
+          // but the host couldn't auto-attach (multi-account guard or
+          // IO error). Don't auto-close — render a visible notice so
+          // the user knows a manual config edit is required before the
+          // agent will actually start sending/receiving.
+          setManualAttachNotice({
+            agentId: res.agentId,
+            reason: res.configSkipReason,
+          });
+          return;
         }
         onClose();
       } else {
@@ -664,6 +670,38 @@ function OpenclawBranch({ onSuccess, onClose }: OpenclawBranchProps) {
     } finally {
       setSubmitting(false);
     }
+  }
+
+  if (manualAttachNotice) {
+    const reasonText =
+      manualAttachNotice.reason === "multi_account_guard"
+        ? "BotCord currently supports only one configured agent per OpenClaw host. The new credentials are on disk but you'll need to swap them into ~/.openclaw/openclaw.json (or run the install command for the new agent on a separate host)."
+        : manualAttachNotice.reason === "io_error"
+          ? "The plugin couldn't write to ~/.openclaw/openclaw.json — check permissions on the host."
+          : "The plugin couldn't auto-register this agent in ~/.openclaw/openclaw.json.";
+    return (
+      <div className="space-y-4">
+        <div className="rounded-xl border border-amber-400/40 bg-amber-400/10 p-3 text-sm text-amber-200">
+          <p className="font-semibold">Agent created — manual attach required</p>
+          <p className="mt-1 text-xs leading-relaxed text-amber-100/80">
+            <span className="font-mono">{manualAttachNotice.agentId}</span> was
+            registered on the Hub and its credentials were written on the host,
+            but it will not start sending or receiving messages until you update
+            the OpenClaw config and reload the plugin.
+          </p>
+          <p className="mt-2 text-xs text-amber-100/70">{reasonText}</p>
+        </div>
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-xl border border-glass-border px-4 py-2 text-sm font-medium text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
+          >
+            Got it
+          </button>
+        </div>
+      </div>
+    );
   }
 
   if (ticket) {

--- a/frontend/src/components/dashboard/InstallCommandPanel.tsx
+++ b/frontend/src/components/dashboard/InstallCommandPanel.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+/**
+ * [INPUT]: ticket {bindCode, installCommand, expiresAt}; status polling via useOpenclawHostStore
+ * [OUTPUT]: InstallCommandPanel — copy-able install command, TTL countdown, claim status polling
+ * [POS]: rendered inside CreateAgentDialog after the user picks "+ Add OpenClaw host"
+ * [PROTOCOL]: update header on changes
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { Check, Copy, Loader2 } from "lucide-react";
+import { useOpenclawHostStore, type OpenclawInstallTicket } from "@/store/useOpenclawHostStore";
+
+interface Props {
+  ticket: OpenclawInstallTicket;
+  onClaimed: (agentId: string) => void | Promise<void>;
+  onCancel: () => void;
+}
+
+const POLL_INTERVAL_MS = 3_000;
+
+function formatRemaining(seconds: number): string {
+  if (seconds <= 0) return "0:00";
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+export default function InstallCommandPanel({ ticket, onClaimed, onCancel }: Props) {
+  const pollBindCode = useOpenclawHostStore((s) => s.pollBindCode);
+  const revokeBindCode = useOpenclawHostStore((s) => s.revokeBindCode);
+
+  const [copied, setCopied] = useState(false);
+  const [secondsLeft, setSecondsLeft] = useState(() =>
+    Math.max(0, ticket.expiresAt - Math.floor(Date.now() / 1000)),
+  );
+  const [statusMessage, setStatusMessage] = useState<string>("Waiting for host to register…");
+  const claimedRef = useRef(false);
+
+  // Countdown ticker.
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      setSecondsLeft((prev) => {
+        const next = ticket.expiresAt - Math.floor(Date.now() / 1000);
+        return Math.max(0, next);
+      });
+    }, 1_000);
+    return () => window.clearInterval(id);
+  }, [ticket.expiresAt]);
+
+  // Claim polling.
+  useEffect(() => {
+    let cancelled = false;
+    const poll = async () => {
+      if (cancelled || claimedRef.current) return;
+      try {
+        const status = await pollBindCode(ticket.bindCode);
+        if (cancelled) return;
+        if (status.status === "claimed" && status.agentId) {
+          claimedRef.current = true;
+          setStatusMessage("Host registered — finalizing…");
+          await onClaimed(status.agentId);
+        } else if (status.status === "expired") {
+          setStatusMessage("Bind code expired. Cancel and request a new one.");
+        } else if (status.status === "revoked") {
+          setStatusMessage("Bind code revoked.");
+        }
+      } catch {
+        /* ignore — next tick will retry */
+      }
+    };
+    void poll();
+    const id = window.setInterval(() => void poll(), POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [ticket.bindCode, pollBindCode, onClaimed]);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(ticket.installCommand);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  async function handleCancel() {
+    if (!claimedRef.current) {
+      await revokeBindCode(ticket.bindCode);
+    }
+    onCancel();
+  }
+
+  const expired = secondsLeft <= 0;
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl border border-glass-border bg-glass-bg/40 p-3">
+        <p className="mb-2 text-xs text-text-secondary">
+          Run this on your OpenClaw host (one-line install + bind):
+        </p>
+        <div className="flex items-stretch gap-2">
+          <code className="flex-1 overflow-x-auto whitespace-nowrap rounded-lg border border-glass-border bg-deep-black px-3 py-2 font-mono text-xs text-text-primary">
+            {ticket.installCommand}
+          </code>
+          <button
+            type="button"
+            onClick={() => void handleCopy()}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-glass-border px-3 py-2 text-xs text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
+          >
+            {copied ? (
+              <>
+                <Check className="h-3.5 w-3.5 text-neon-green" />
+                Copied
+              </>
+            ) : (
+              <>
+                <Copy className="h-3.5 w-3.5" />
+                Copy
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between rounded-xl border border-glass-border bg-deep-black px-3 py-2 text-xs">
+        <span className="flex items-center gap-2 text-text-secondary">
+          {!expired && <Loader2 className="h-3.5 w-3.5 animate-spin text-neon-cyan" />}
+          {statusMessage}
+        </span>
+        <span className={`font-mono ${expired ? "text-red-400" : "text-text-primary"}`}>
+          {formatRemaining(secondsLeft)}
+        </span>
+      </div>
+
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={() => void handleCancel()}
+          className="rounded-xl border border-glass-border px-4 py-2 text-sm font-medium text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/store/useOpenclawHostStore.ts
+++ b/frontend/src/store/useOpenclawHostStore.ts
@@ -1,0 +1,185 @@
+/**
+ * [INPUT]: BFF endpoints under /api/users/me/agents/openclaw/*
+ * [OUTPUT]: useOpenclawHostStore — list registered OpenClaw hosts, issue
+ *           install tickets, poll bind-code status, provision agents on
+ *           an already-online host
+ * [POS]: dashboard store backing the OpenClaw branch of CreateAgentDialog
+ * [PROTOCOL]: update header on changes
+ */
+
+import { create } from "zustand";
+
+export interface OpenclawHost {
+  id: string;
+  label: string | null;
+  online: boolean;
+  last_seen_at: string | null;
+  revoked_at: string | null;
+  agent_count: number;
+  created_at: string;
+}
+
+export interface OpenclawInstallTicket {
+  bindCode: string;
+  bindTicket: string;
+  nonce: string;
+  expiresAt: number; // unix seconds
+  installCommand: string;
+}
+
+export interface BindCodeStatus {
+  status: "pending" | "claimed" | "revoked" | "expired";
+  agentId?: string;
+}
+
+export class OpenclawProvisionError extends Error {
+  constructor(public code: string, message: string, public detail?: string) {
+    super(message);
+    this.name = "OpenclawProvisionError";
+  }
+}
+
+interface State {
+  hosts: OpenclawHost[];
+  loaded: boolean;
+  loading: boolean;
+}
+
+interface Actions {
+  refresh: () => Promise<void>;
+  issueInstall: (input: { name: string; bio?: string }) => Promise<OpenclawInstallTicket>;
+  pollBindCode: (bindCode: string) => Promise<BindCodeStatus>;
+  revokeBindCode: (bindCode: string) => Promise<void>;
+  provisionOnHost: (
+    hostId: string,
+    input: { name: string; bio?: string },
+  ) => Promise<{ agentId: string }>;
+  renameHost: (hostId: string, label: string | null) => Promise<void>;
+  revokeHost: (hostId: string) => Promise<void>;
+}
+
+const initialState: State = {
+  hosts: [],
+  loaded: false,
+  loading: false,
+};
+
+async function readError(res: Response): Promise<{ code: string; detail?: string }> {
+  try {
+    const body = await res.json();
+    if (typeof body?.detail === "string") return { code: body.detail };
+    if (body?.detail && typeof body.detail.code === "string") {
+      return { code: body.detail.code, detail: body.detail.host_message };
+    }
+    if (typeof body?.error === "string") return { code: body.error };
+  } catch {
+    /* ignore */
+  }
+  return { code: `http_${res.status}` };
+}
+
+export const useOpenclawHostStore = create<State & Actions>()((set, get) => ({
+  ...initialState,
+
+  async refresh() {
+    if (get().loading) return;
+    set({ loading: true });
+    try {
+      const res = await fetch("/api/users/me/agents/openclaw/hosts", {
+        cache: "no-store",
+      });
+      if (!res.ok) {
+        set({ loading: false });
+        return;
+      }
+      const data = (await res.json()) as { hosts: OpenclawHost[] };
+      set({ hosts: data.hosts ?? [], loaded: true, loading: false });
+    } catch {
+      set({ loading: false });
+    }
+  },
+
+  async issueInstall(input) {
+    const res = await fetch("/api/users/me/agents/openclaw/install", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: input.name, bio: input.bio }),
+    });
+    if (!res.ok) {
+      const err = await readError(res);
+      throw new OpenclawProvisionError(err.code, err.detail || err.code);
+    }
+    const data = await res.json();
+    return {
+      bindCode: data.bind_code,
+      bindTicket: data.bind_ticket,
+      nonce: data.nonce,
+      expiresAt: data.expires_at,
+      installCommand: data.install_command,
+    };
+  },
+
+  async pollBindCode(bindCode) {
+    const res = await fetch(
+      `/api/users/me/agents/bind-ticket/${encodeURIComponent(bindCode)}`,
+      { cache: "no-store" },
+    );
+    if (res.status === 404) return { status: "expired" };
+    if (!res.ok) return { status: "pending" };
+    const data = await res.json();
+    if (data.status === "claimed" && typeof data.agent_id === "string") {
+      return { status: "claimed", agentId: data.agent_id };
+    }
+    if (data.status === "expired") return { status: "expired" };
+    if (data.status === "revoked") return { status: "revoked" };
+    return { status: "pending" };
+  },
+
+  async revokeBindCode(bindCode) {
+    await fetch(
+      `/api/users/me/agents/bind-ticket/${encodeURIComponent(bindCode)}`,
+      { method: "DELETE" },
+    ).catch(() => {});
+  },
+
+  async provisionOnHost(hostId, input) {
+    const res = await fetch("/api/users/me/agents/openclaw/provision", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        openclaw_host_id: hostId,
+        name: input.name,
+        bio: input.bio,
+      }),
+    });
+    if (!res.ok) {
+      const err = await readError(res);
+      throw new OpenclawProvisionError(err.code, err.detail || err.code, err.detail);
+    }
+    const data = await res.json();
+    if (typeof data.agent_id !== "string") {
+      throw new OpenclawProvisionError("missing_agent_id", "missing agent_id in response");
+    }
+    return { agentId: data.agent_id };
+  },
+
+  async renameHost(hostId, label) {
+    await fetch(
+      `/api/users/me/agents/openclaw/hosts/${encodeURIComponent(hostId)}`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ label }),
+      },
+    );
+    await get().refresh();
+  },
+
+  async revokeHost(hostId) {
+    await fetch(
+      `/api/users/me/agents/openclaw/hosts/${encodeURIComponent(hostId)}`,
+      { method: "DELETE" },
+    );
+    await get().refresh();
+  },
+}));

--- a/frontend/src/store/useOpenclawHostStore.ts
+++ b/frontend/src/store/useOpenclawHostStore.ts
@@ -53,7 +53,11 @@ interface Actions {
   provisionOnHost: (
     hostId: string,
     input: { name: string; bio?: string },
-  ) => Promise<{ agentId: string }>;
+  ) => Promise<{
+    agentId: string;
+    configPatched: boolean;
+    configSkipReason: string | null;
+  }>;
   renameHost: (hostId: string, label: string | null) => Promise<void>;
   revokeHost: (hostId: string) => Promise<void>;
 }
@@ -160,7 +164,15 @@ export const useOpenclawHostStore = create<State & Actions>()((set, get) => ({
     if (typeof data.agent_id !== "string") {
       throw new OpenclawProvisionError("missing_agent_id", "missing agent_id in response");
     }
-    return { agentId: data.agent_id };
+    return {
+      agentId: data.agent_id,
+      configPatched:
+        typeof data.config_patched === "boolean" ? data.config_patched : true,
+      configSkipReason:
+        typeof data.config_skip_reason === "string"
+          ? data.config_skip_reason
+          : null,
+    };
   },
 
   async renameHost(hostId, label) {

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -36,6 +36,9 @@ import { BotCordClient } from "./src/client.js";
 import { getConfig } from "./src/runtime.js";
 import { resolveAccountConfig, isAccountConfigured } from "./src/config.js";
 import { attachTokenPersistence } from "./src/credentials.js";
+import { startOpenclawHostControl, type HostControlHandle } from "./src/host-control.js";
+
+let _openclawHostControl: HostControlHandle | null = null;
 
 // Inline replacement for defineChannelPluginEntry from openclaw/plugin-sdk/core.
 // Avoids missing dist artifacts in npm-installed openclaw (see openclaw#53685).
@@ -183,6 +186,16 @@ export default {
     const uninstallCli = createUninstallCli();
     api.registerCli(uninstallCli.setup, { commands: uninstallCli.commands });
 
+    // Start the OpenClaw host control loop once per process. Returns null
+    // (no-op) when the host hasn't been onboarded yet (no host.json on
+    // disk) — keeps the plugin runnable in pure per-agent setups.
+    if (!_openclawHostControl) {
+      try {
+        _openclawHostControl = startOpenclawHostControl();
+      } catch (err) {
+        console.warn("[botcord] failed to start openclaw host control:", err);
+      }
+    }
   },
 };
 

--- a/plugin/src/__tests__/host-control.test.ts
+++ b/plugin/src/__tests__/host-control.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   handleControlFrame,
+  patchOpenclawConfigForAgent,
   provisionAgentLocal,
 } from "../host-control.js";
 
@@ -75,6 +76,16 @@ describe("provisionAgentLocal", () => {
     expect(written.token).toBe("agent-token-xyz");
     expect(written.openclawHostId).toBe("oc_aaaaaaaaaaaa");
     expect(written.privateKey).toBe(res.privateKey);
+
+    // openclaw.json must now reference the new agent account.
+    expect(res.configPatched).toBe(true);
+    const cfgPath = join(tmpHome, ".openclaw", "openclaw.json");
+    const cfg = JSON.parse(readFileSync(cfgPath, "utf8"));
+    expect(cfg.channels.botcord.accounts["ag_provtest1234"]).toEqual({
+      enabled: true,
+      credentialsFile: credPath,
+      deliveryMode: "websocket",
+    });
   });
 
   it("throws on non-2xx response", async () => {
@@ -89,6 +100,67 @@ describe("provisionAgentLocal", () => {
         fetchImpl: fetchImpl as unknown as typeof fetch,
       }),
     ).rejects.toThrow(/provision-claim failed: 400/);
+  });
+});
+
+describe("patchOpenclawConfigForAgent", () => {
+  it("creates accounts map on a fresh config", () => {
+    const cfgPath = join(tmpHome, ".openclaw", "openclaw.json");
+    const ok = patchOpenclawConfigForAgent({
+      agentId: "ag_new1",
+      credentialsFile: "/tmp/creds.json",
+      configPath: cfgPath,
+    });
+    expect(ok).toBe(true);
+    const cfg = JSON.parse(readFileSync(cfgPath, "utf8"));
+    expect(cfg.channels.botcord.enabled).toBe(true);
+    expect(cfg.channels.botcord.accounts.ag_new1.credentialsFile).toBe("/tmp/creds.json");
+  });
+
+  it("promotes a single-account legacy shape into the accounts map", () => {
+    const cfgPath = join(tmpHome, ".openclaw", "openclaw.json");
+    mkdirSync(join(tmpHome, ".openclaw"), { recursive: true });
+    writeFileSync(
+      cfgPath,
+      JSON.stringify({
+        channels: {
+          botcord: {
+            enabled: true,
+            credentialsFile: "/legacy/creds.json",
+            deliveryMode: "polling",
+          },
+        },
+      }),
+    );
+    const ok = patchOpenclawConfigForAgent({
+      agentId: "ag_new2",
+      credentialsFile: "/tmp/new.json",
+      configPath: cfgPath,
+    });
+    expect(ok).toBe(true);
+    const cfg = JSON.parse(readFileSync(cfgPath, "utf8"));
+    expect(cfg.channels.botcord.credentialsFile).toBeUndefined();
+    expect(cfg.channels.botcord.accounts.default.credentialsFile).toBe(
+      "/legacy/creds.json",
+    );
+    expect(cfg.channels.botcord.accounts.default.deliveryMode).toBe("polling");
+    expect(cfg.channels.botcord.accounts.ag_new2.credentialsFile).toBe("/tmp/new.json");
+  });
+
+  it("is idempotent on repeated patch", () => {
+    const cfgPath = join(tmpHome, ".openclaw", "openclaw.json");
+    patchOpenclawConfigForAgent({
+      agentId: "ag_x",
+      credentialsFile: "/c1",
+      configPath: cfgPath,
+    });
+    patchOpenclawConfigForAgent({
+      agentId: "ag_x",
+      credentialsFile: "/c1",
+      configPath: cfgPath,
+    });
+    const cfg = JSON.parse(readFileSync(cfgPath, "utf8"));
+    expect(Object.keys(cfg.channels.botcord.accounts)).toEqual(["ag_x"]);
   });
 });
 

--- a/plugin/src/__tests__/host-control.test.ts
+++ b/plugin/src/__tests__/host-control.test.ts
@@ -77,15 +77,19 @@ describe("provisionAgentLocal", () => {
     expect(written.openclawHostId).toBe("oc_aaaaaaaaaaaa");
     expect(written.privateKey).toBe(res.privateKey);
 
-    // openclaw.json must now reference the new agent account.
-    expect(res.configPatched).toBe(true);
+    // Fresh install → accounts shape with the new agent registered.
+    // The multi-account guard only kicks in when *adding* to an
+    // already-configured account.
+    expect(res.config.applied).toBe(true);
+    if (res.config.applied) {
+      expect(res.config.reason).toBe("fresh");
+    }
     const cfgPath = join(tmpHome, ".openclaw", "openclaw.json");
     const cfg = JSON.parse(readFileSync(cfgPath, "utf8"));
-    expect(cfg.channels.botcord.accounts["ag_provtest1234"]).toEqual({
-      enabled: true,
-      credentialsFile: credPath,
-      deliveryMode: "websocket",
-    });
+    expect(cfg.channels.botcord.accounts["ag_provtest1234"].credentialsFile).toBe(
+      credPath,
+    );
+    expect(cfg.channels.botcord.enabled).toBe(true);
   });
 
   it("throws on non-2xx response", async () => {
@@ -104,20 +108,22 @@ describe("provisionAgentLocal", () => {
 });
 
 describe("patchOpenclawConfigForAgent", () => {
-  it("creates accounts map on a fresh config", () => {
+  it("writes a fresh accounts-shaped config", () => {
     const cfgPath = join(tmpHome, ".openclaw", "openclaw.json");
-    const ok = patchOpenclawConfigForAgent({
+    const r = patchOpenclawConfigForAgent({
       agentId: "ag_new1",
       credentialsFile: "/tmp/creds.json",
       configPath: cfgPath,
     });
-    expect(ok).toBe(true);
+    expect(r).toEqual({ applied: true, reason: "fresh" });
     const cfg = JSON.parse(readFileSync(cfgPath, "utf8"));
     expect(cfg.channels.botcord.enabled).toBe(true);
-    expect(cfg.channels.botcord.accounts.ag_new1.credentialsFile).toBe("/tmp/creds.json");
+    expect(cfg.channels.botcord.accounts.ag_new1.credentialsFile).toBe(
+      "/tmp/creds.json",
+    );
   });
 
-  it("promotes a single-account legacy shape into the accounts map", () => {
+  it("refuses to push an existing single-account config to multi-account", () => {
     const cfgPath = join(tmpHome, ".openclaw", "openclaw.json");
     mkdirSync(join(tmpHome, ".openclaw"), { recursive: true });
     writeFileSync(
@@ -132,35 +138,57 @@ describe("patchOpenclawConfigForAgent", () => {
         },
       }),
     );
-    const ok = patchOpenclawConfigForAgent({
+    const r = patchOpenclawConfigForAgent({
       agentId: "ag_new2",
       credentialsFile: "/tmp/new.json",
       configPath: cfgPath,
     });
-    expect(ok).toBe(true);
+    expect(r.applied).toBe(false);
+    if (r.applied === false) {
+      expect(r.reason).toBe("multi_account_guard");
+    }
+    // Legacy config must remain intact — adding a second account would
+    // trigger the SINGLE_ACCOUNT_ONLY guard and break botcord_send.
     const cfg = JSON.parse(readFileSync(cfgPath, "utf8"));
-    expect(cfg.channels.botcord.credentialsFile).toBeUndefined();
-    expect(cfg.channels.botcord.accounts.default.credentialsFile).toBe(
-      "/legacy/creds.json",
-    );
-    expect(cfg.channels.botcord.accounts.default.deliveryMode).toBe("polling");
-    expect(cfg.channels.botcord.accounts.ag_new2.credentialsFile).toBe("/tmp/new.json");
+    expect(cfg.channels.botcord.credentialsFile).toBe("/legacy/creds.json");
+    expect(cfg.channels.botcord.accounts).toBeUndefined();
   });
 
-  it("is idempotent on repeated patch", () => {
+  it("rewires legacy single-account when re-attaching the same agent", () => {
+    const cfgPath = join(tmpHome, ".openclaw", "openclaw.json");
+    mkdirSync(join(tmpHome, ".openclaw"), { recursive: true });
+    writeFileSync(
+      cfgPath,
+      JSON.stringify({
+        channels: {
+          botcord: {
+            enabled: true,
+            credentialsFile: "/old/creds.json",
+          },
+        },
+      }),
+    );
+    const r = patchOpenclawConfigForAgent({
+      agentId: "ag_same",
+      credentialsFile: "/old/creds.json",
+      configPath: cfgPath,
+    });
+    expect(r).toEqual({ applied: true, reason: "rewired_existing" });
+  });
+
+  it("is idempotent when re-patching an unchanged account", () => {
     const cfgPath = join(tmpHome, ".openclaw", "openclaw.json");
     patchOpenclawConfigForAgent({
       agentId: "ag_x",
       credentialsFile: "/c1",
       configPath: cfgPath,
     });
-    patchOpenclawConfigForAgent({
+    const r = patchOpenclawConfigForAgent({
       agentId: "ag_x",
       credentialsFile: "/c1",
       configPath: cfgPath,
     });
-    const cfg = JSON.parse(readFileSync(cfgPath, "utf8"));
-    expect(Object.keys(cfg.channels.botcord.accounts)).toEqual(["ag_x"]);
+    expect(r).toEqual({ applied: false, reason: "already_present" });
   });
 });
 

--- a/plugin/src/__tests__/host-control.test.ts
+++ b/plugin/src/__tests__/host-control.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  handleControlFrame,
+  provisionAgentLocal,
+} from "../host-control.js";
+
+const fakeHost = {
+  version: 1 as const,
+  hubUrl: "http://hub.test",
+  hostInstanceId: "oc_aaaaaaaaaaaa",
+  privateKey: "Z".repeat(43) + "=", // unused in these tests
+  publicKey: "Z".repeat(43) + "=",
+  accessToken: "host-access-token",
+  refreshToken: "host-refresh-token",
+  accessExpiresAt: Math.floor(Date.now() / 1000) + 3600,
+  refreshExpiresAt: Math.floor(Date.now() / 1000) + 86_400,
+  controlWsUrl: "ws://hub.test/openclaw/control",
+};
+
+let tmpHome: string;
+let originalHome: string | undefined;
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), "botcord-host-"));
+  originalHome = process.env.HOME;
+  process.env.HOME = tmpHome;
+});
+
+afterEach(() => {
+  if (originalHome !== undefined) process.env.HOME = originalHome;
+  else delete process.env.HOME;
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe("provisionAgentLocal", () => {
+  it("posts host bearer + signed nonce, writes credentials, returns agent_id", async () => {
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(url).toBe("http://hub.test/openclaw/host/provision-claim");
+      const body = JSON.parse((init!.body as string) ?? "{}");
+      expect(body.provision_id).toBe("prv_test");
+      expect(body.nonce).toBe(Buffer.from("nonce-bytes-32-chars-long-padding").toString("base64"));
+      expect(body.agent.pubkey.startsWith("ed25519:")).toBe(true);
+      expect(body.agent.proof.nonce).toBe(body.nonce);
+      expect(typeof body.agent.proof.sig).toBe("string");
+      const headers = init!.headers as Record<string, string>;
+      expect(headers.Authorization).toBe("Bearer host-access-token");
+
+      return new Response(
+        JSON.stringify({
+          agent_id: "ag_provtest1234",
+          key_id: "k_provtest123",
+          token: "agent-token-xyz",
+          token_expires_at: Math.floor(Date.now() / 1000) + 3600,
+          display_name: "Provisioned Agent",
+          bio: null,
+        }),
+        { status: 201, headers: { "Content-Type": "application/json" } },
+      );
+    });
+
+    const res = await provisionAgentLocal({
+      host: fakeHost,
+      provisionId: "prv_test",
+      nonce: Buffer.from("nonce-bytes-32-chars-long-padding").toString("base64"),
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(res.result.agent_id).toBe("ag_provtest1234");
+    const credPath = join(tmpHome, ".botcord", "credentials", "ag_provtest1234.json");
+    const written = JSON.parse(readFileSync(credPath, "utf8"));
+    expect(written.agentId).toBe("ag_provtest1234");
+    expect(written.token).toBe("agent-token-xyz");
+    expect(written.openclawHostId).toBe("oc_aaaaaaaaaaaa");
+    expect(written.privateKey).toBe(res.privateKey);
+  });
+
+  it("throws on non-2xx response", async () => {
+    const fetchImpl = vi.fn(
+      async () => new Response("INVALID_PROVISION", { status: 400 }),
+    );
+    await expect(
+      provisionAgentLocal({
+        host: fakeHost,
+        provisionId: "prv_x",
+        nonce: "AAAA",
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow(/provision-claim failed: 400/);
+  });
+});
+
+describe("handleControlFrame", () => {
+  const baseCtx = {
+    host: fakeHost,
+    log: () => {},
+  };
+
+  it("acks hello + ping", async () => {
+    expect(await handleControlFrame({ id: "1", type: "hello" }, baseCtx)).toEqual({
+      ok: true,
+    });
+    const pong = await handleControlFrame({ id: "2", type: "ping" }, baseCtx);
+    expect(pong).toEqual({ ok: true, result: { pong: true } });
+  });
+
+  it("rejects provision_agent missing params", async () => {
+    const ack = await handleControlFrame(
+      { id: "3", type: "provision_agent", params: {} },
+      baseCtx,
+    );
+    expect(ack).toEqual({
+      ok: false,
+      error: { code: "bad_params", message: "provision_id and nonce required" },
+    });
+  });
+
+  it("returns unknown_type for unrecognised frames", async () => {
+    const ack = await handleControlFrame(
+      { id: "4", type: "frobnicate" },
+      baseCtx,
+    );
+    expect(ack).toEqual({
+      ok: false,
+      error: {
+        code: "unknown_type",
+        message: "unknown frame type: frobnicate",
+      },
+    });
+  });
+});

--- a/plugin/src/host-control.ts
+++ b/plugin/src/host-control.ts
@@ -1,0 +1,539 @@
+/**
+ * OpenClaw host control-plane WebSocket client.
+ *
+ * Bootstraps from `~/.botcord/openclaw/host.json` (written by the install
+ * script) and runs the long-lived control channel to the Hub:
+ *
+ *   1. Open `wss://<hub>/openclaw/control` with `Authorization: Bearer <host JWT>`.
+ *   2. Verify Hub-signed control frames (Ed25519 over JCS-canonicalised
+ *      `{id,type,params,ts}`) — same scheme as the daemon control channel.
+ *   3. On `provision_agent`: generate a fresh agent keypair locally, sign
+ *      the provision nonce, POST `/openclaw/host/provision-claim` with the
+ *      host bearer JWT, write the resulting credentials to
+ *      `~/.botcord/credentials/{agentId}.json`, then ack the original
+ *      frame with `{agent_id}`.
+ *   4. Refresh the host access token via `/openclaw/auth/refresh` shortly
+ *      before expiry; persist the rotated tokens back to `host.json`.
+ *
+ * The host control loop is idempotent — on plugin reload it re-reads
+ * `host.json` and reconnects. New agents land as files on disk; the
+ * plugin picks them up on next config reload (per-agent hot-attach is
+ * a follow-up; see TODO at bottom of the file).
+ */
+import WebSocket from "ws";
+import { writeFileSync, mkdirSync, readFileSync, chmodSync, existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createPublicKey, verify as nodeVerify } from "node:crypto";
+import {
+  generateKeypair,
+  jcsCanonicalize,
+  signChallenge,
+} from "@botcord/protocol-core";
+
+// Inline minimal types + helpers — the published `@botcord/protocol-core`
+// (v0.1.x) doesn't yet ship the control-frame schemas; this duplicates
+// just what host-control needs so the plugin can build standalone.
+
+interface ControlFrame {
+  id: string;
+  type: string;
+  params?: Record<string, unknown>;
+  sig?: string;
+  ts?: number;
+}
+
+interface ControlAck {
+  id: string;
+  ok: boolean;
+  result?: unknown;
+  error?: { code: string; message: string };
+}
+
+/** Hub control-plane Ed25519 public key (raw 32-byte, base64). */
+const DEFAULT_HUB_CONTROL_PUBLIC_KEY = "H8lKtrtJclp+M69dh0n0avdia/kN8fy1tYUSrQFpDxY=";
+
+function resolveHubControlPublicKey(): string {
+  const env = (globalThis as { process?: { env?: Record<string, string> } }).process?.env;
+  const override = env?.BOTCORD_HUB_CONTROL_PUBLIC_KEY;
+  return override && override.length > 0 ? override : DEFAULT_HUB_CONTROL_PUBLIC_KEY;
+}
+
+const SPKI_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+
+function verifyEd25519(pubkeyB64: string, message: string, sigB64: string): boolean {
+  try {
+    const pkRaw = Buffer.from(pubkeyB64, "base64");
+    if (pkRaw.length !== 32) return false;
+    const spki = Buffer.concat([SPKI_PREFIX, pkRaw]);
+    const pk = createPublicKey({ key: spki, format: "der", type: "spki" });
+    return nodeVerify(null, Buffer.from(message), pk, Buffer.from(sigB64, "base64"));
+  } catch {
+    return false;
+  }
+}
+
+// ── Disk layout ─────────────────────────────────────────────────────────────
+
+function botcordHome(): string {
+  // Re-resolve each call so tests can monkey-patch `HOME`.
+  return process.env.HOME ?? homedir();
+}
+function hostDir(): string {
+  return join(botcordHome(), ".botcord", "openclaw");
+}
+function hostFile(): string {
+  return join(hostDir(), "host.json");
+}
+function credDir(): string {
+  return join(botcordHome(), ".botcord", "credentials");
+}
+
+interface HostFile {
+  version: 1;
+  hubUrl: string;
+  hostInstanceId: string;
+  privateKey: string;
+  publicKey: string;
+  accessToken: string;
+  refreshToken: string;
+  /** Unix seconds. */
+  accessExpiresAt: number;
+  /** Unix seconds. */
+  refreshExpiresAt: number;
+  /** `wss://<hub>/openclaw/control` */
+  controlWsUrl: string;
+  savedAt?: string;
+}
+
+export function readHostFile(path: string = hostFile()): HostFile | null {
+  if (!existsSync(path)) return null;
+  try {
+    const raw = readFileSync(path, "utf8");
+    return JSON.parse(raw) as HostFile;
+  } catch {
+    return null;
+  }
+}
+
+function writeHostFile(host: HostFile, path: string = hostFile()): void {
+  mkdirSync(hostDir(), { recursive: true, mode: 0o700 });
+  writeFileSync(path, JSON.stringify(host, null, 2) + "\n", {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  chmodSync(path, 0o600);
+}
+
+function writeAgentCredentials(args: {
+  agentId: string;
+  keyId: string;
+  privateKey: string;
+  publicKey: string;
+  hubUrl: string;
+  displayName?: string | null;
+  bio?: string | null;
+  token?: string;
+  tokenExpiresAt?: number;
+  openclawHostId: string;
+}): string {
+  const dir = credDir();
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const path = join(dir, `${args.agentId}.json`);
+  const body = {
+    version: 1,
+    hubUrl: args.hubUrl,
+    agentId: args.agentId,
+    keyId: args.keyId,
+    privateKey: args.privateKey,
+    publicKey: args.publicKey,
+    displayName: args.displayName || args.agentId,
+    bio: args.bio || null,
+    savedAt: new Date().toISOString(),
+    token: args.token,
+    tokenExpiresAt: args.tokenExpiresAt,
+    openclawHostId: args.openclawHostId,
+  };
+  writeFileSync(path, JSON.stringify(body, null, 2) + "\n", {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  chmodSync(path, 0o600);
+  return path;
+}
+
+// ── Frame signature verification ────────────────────────────────────────────
+
+function controlSigningInput(frame: ControlFrame): string {
+  return (
+    jcsCanonicalize({
+      id: frame.id,
+      type: frame.type,
+      params: (frame.params ?? {}) as Record<string, unknown>,
+      ts: typeof frame.ts === "number" ? frame.ts : 0,
+    }) ?? "{}"
+  );
+}
+
+function frameSignatureValid(frame: ControlFrame, hubPublicKey: string | null): boolean {
+  if (!hubPublicKey) return false;
+  if (typeof frame.sig !== "string" || frame.sig.length === 0) return false;
+  return verifyEd25519(hubPublicKey, controlSigningInput(frame), frame.sig);
+}
+
+// ── HTTP helpers ────────────────────────────────────────────────────────────
+
+async function refreshHostToken(host: HostFile): Promise<HostFile> {
+  const url = `${host.hubUrl.replace(/\/+$/, "")}/openclaw/auth/refresh`;
+  const resp = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ refresh_token: host.refreshToken }),
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!resp.ok) {
+    throw new Error(`openclaw refresh failed: ${resp.status} ${await resp.text()}`);
+  }
+  const body = (await resp.json()) as {
+    host_instance_id: string;
+    access_token: string;
+    refresh_token: string;
+    access_expires_at: number;
+    refresh_expires_at: number;
+  };
+  const next: HostFile = {
+    ...host,
+    accessToken: body.access_token,
+    refreshToken: body.refresh_token,
+    accessExpiresAt: body.access_expires_at,
+    refreshExpiresAt: body.refresh_expires_at,
+    savedAt: new Date().toISOString(),
+  };
+  writeHostFile(next);
+  return next;
+}
+
+interface ProvisionClaimResult {
+  agent_id: string;
+  key_id: string;
+  token: string;
+  token_expires_at: number;
+  display_name: string;
+  bio: string | null;
+}
+
+export async function provisionAgentLocal(args: {
+  host: HostFile;
+  provisionId: string;
+  nonce: string;
+  fetchImpl?: typeof fetch;
+}): Promise<{
+  result: ProvisionClaimResult;
+  privateKey: string;
+  publicKey: string;
+  credentialsFile: string;
+}> {
+  const fetchFn = args.fetchImpl ?? fetch;
+  const kp = generateKeypair();
+  const sig = signChallenge(kp.privateKey, args.nonce);
+  const url = `${args.host.hubUrl.replace(/\/+$/, "")}/openclaw/host/provision-claim`;
+
+  const resp = await fetchFn(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${args.host.accessToken}`,
+    },
+    body: JSON.stringify({
+      provision_id: args.provisionId,
+      nonce: args.nonce,
+      agent: {
+        pubkey: kp.pubkeyFormatted,
+        proof: { nonce: args.nonce, sig },
+      },
+    }),
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!resp.ok) {
+    throw new Error(
+      `provision-claim failed: ${resp.status} ${await resp.text().catch(() => "")}`,
+    );
+  }
+  const result = (await resp.json()) as ProvisionClaimResult;
+  const credPath = writeAgentCredentials({
+    agentId: result.agent_id,
+    keyId: result.key_id,
+    privateKey: kp.privateKey,
+    publicKey: kp.publicKey,
+    hubUrl: args.host.hubUrl,
+    displayName: result.display_name,
+    bio: result.bio,
+    token: result.token,
+    tokenExpiresAt: result.token_expires_at,
+    openclawHostId: args.host.hostInstanceId,
+  });
+  return {
+    result,
+    privateKey: kp.privateKey,
+    publicKey: kp.publicKey,
+    credentialsFile: credPath,
+  };
+}
+
+// ── Frame handler ───────────────────────────────────────────────────────────
+
+interface FrameHandlerCtx {
+  host: HostFile;
+  log: (level: "info" | "warn" | "error", msg: string) => void;
+  /** Hook fired after a new agent's credentials have been written. */
+  onAgentProvisioned?: (info: {
+    agentId: string;
+    credentialsFile: string;
+  }) => void | Promise<void>;
+}
+
+export async function handleControlFrame(
+  frame: ControlFrame,
+  ctx: FrameHandlerCtx,
+): Promise<Omit<ControlAck, "id"> | void> {
+  switch (frame.type) {
+    case "hello":
+      return { ok: true };
+    case "ping":
+      return { ok: true, result: { pong: true } };
+    case "provision_agent": {
+      const params = (frame.params ?? {}) as {
+        provision_id?: string;
+        nonce?: string;
+        owner_user_id?: string;
+      };
+      if (!params.provision_id || !params.nonce) {
+        return {
+          ok: false,
+          error: { code: "bad_params", message: "provision_id and nonce required" },
+        };
+      }
+      try {
+        const { result, credentialsFile } = await provisionAgentLocal({
+          host: ctx.host,
+          provisionId: params.provision_id,
+          nonce: params.nonce,
+        });
+        ctx.log("info", `provisioned agent ${result.agent_id} → ${credentialsFile}`);
+        if (ctx.onAgentProvisioned) {
+          await ctx.onAgentProvisioned({
+            agentId: result.agent_id,
+            credentialsFile,
+          });
+        }
+        return { ok: true, result: { agent_id: result.agent_id } };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        ctx.log("warn", `provision_agent failed: ${message}`);
+        return { ok: false, error: { code: "provision_failed", message } };
+      }
+    }
+    case "revoke_agent": {
+      // Best-effort: agent credentials cleanup is left to the user /
+      // dashboard for now; the host just acks so Hub doesn't retry.
+      return { ok: true };
+    }
+    case "set_route":
+      return { ok: true };
+    default:
+      return {
+        ok: false,
+        error: { code: "unknown_type", message: `unknown frame type: ${frame.type}` },
+      };
+  }
+}
+
+// ── Long-lived WS loop ──────────────────────────────────────────────────────
+
+const RECONNECT_BACKOFF_MS = [1000, 2000, 4000, 8000, 16000, 30000];
+const REFRESH_LEEWAY_SECONDS = 5 * 60; // refresh ~5 min before expiry
+const KEEPALIVE_INTERVAL_MS = 25_000;
+
+export interface HostControlOptions {
+  /** Override the host file (default: `~/.botcord/openclaw/host.json`). */
+  hostFilePath?: string;
+  /** Override the embedded Hub control public key. */
+  hubPublicKey?: string | null;
+  /** Test hook — inject a WebSocket constructor. */
+  webSocketCtor?: typeof WebSocket;
+  log?: (level: "info" | "warn" | "error", msg: string) => void;
+  onAgentProvisioned?: FrameHandlerCtx["onAgentProvisioned"];
+}
+
+export interface HostControlHandle {
+  stop: () => void;
+  isConnected: () => boolean;
+}
+
+export function startOpenclawHostControl(
+  opts: HostControlOptions = {},
+): HostControlHandle | null {
+  const hostFilePath = opts.hostFilePath ?? hostFile();
+  let host = readHostFile(hostFilePath);
+  if (!host) return null; // not onboarded as an OpenClaw host
+
+  const log =
+    opts.log ??
+    ((level, msg) => {
+      const fn = level === "error" ? console.error : level === "warn" ? console.warn : console.log;
+      fn(`[botcord:openclaw-host] ${msg}`);
+    });
+
+  const hubPublicKey = opts.hubPublicKey ?? resolveHubControlPublicKey();
+  const WSCtor = opts.webSocketCtor ?? WebSocket;
+
+  let stopped = false;
+  let ws: WebSocket | null = null;
+  let attempt = 0;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let refreshTimer: ReturnType<typeof setTimeout> | null = null;
+  let keepaliveTimer: ReturnType<typeof setInterval> | null = null;
+  let connected = false;
+
+  function clearTimers() {
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
+    if (refreshTimer) {
+      clearTimeout(refreshTimer);
+      refreshTimer = null;
+    }
+    if (keepaliveTimer) {
+      clearInterval(keepaliveTimer);
+      keepaliveTimer = null;
+    }
+  }
+
+  function scheduleRefresh() {
+    if (!host) return;
+    if (refreshTimer) clearTimeout(refreshTimer);
+    const nowSec = Math.floor(Date.now() / 1000);
+    const fireInMs = Math.max(
+      30_000,
+      (host.accessExpiresAt - nowSec - REFRESH_LEEWAY_SECONDS) * 1000,
+    );
+    refreshTimer = setTimeout(async () => {
+      if (stopped || !host) return;
+      try {
+        host = await refreshHostToken(host);
+        log("info", "refreshed host access token");
+        scheduleRefresh();
+      } catch (err) {
+        log("warn", `host token refresh failed: ${(err as Error).message}`);
+        // Reschedule a near-term retry; if refresh keeps failing the
+        // WS will eventually 401 and force reconnect with the stale
+        // token (caller-visible failure).
+        refreshTimer = setTimeout(scheduleRefresh, 60_000);
+      }
+    }, fireInMs);
+  }
+
+  function connect() {
+    if (stopped || !host) return;
+    const url = host.controlWsUrl;
+    log("info", `connecting ${url}`);
+    const sock = new WSCtor(url, {
+      headers: { Authorization: `Bearer ${host.accessToken}` },
+    });
+    ws = sock;
+
+    sock.on("open", () => {
+      connected = true;
+      attempt = 0;
+      log("info", "connected");
+      scheduleRefresh();
+      keepaliveTimer = setInterval(() => {
+        try {
+          sock.ping();
+        } catch {
+          /* ignore */
+        }
+      }, KEEPALIVE_INTERVAL_MS);
+    });
+
+    sock.on("message", async (raw) => {
+      let frame: ControlFrame;
+      try {
+        frame = JSON.parse(raw.toString()) as ControlFrame;
+      } catch {
+        return;
+      }
+
+      // Acks of host-initiated frames go nowhere today (we don't push).
+      if ("ok" in frame && typeof frame.id === "string" && !frame.type) return;
+
+      if (typeof frame.id !== "string" || typeof frame.type !== "string") return;
+
+      // Hub-signed frames must verify. Hello/heartbeat use the same scheme.
+      if (!frameSignatureValid(frame, hubPublicKey)) {
+        log("warn", `dropping unsigned/invalid frame type=${frame.type}`);
+        try {
+          sock.send(
+            JSON.stringify({
+              id: frame.id,
+              ok: false,
+              error: { code: "bad_signature", message: "hub signature did not verify" },
+            }),
+          );
+        } catch {
+          /* ignore */
+        }
+        return;
+      }
+
+      const ack = await handleControlFrame(frame, {
+        host: host!,
+        log,
+        onAgentProvisioned: opts.onAgentProvisioned,
+      });
+      if (!ack) return;
+      try {
+        sock.send(JSON.stringify({ id: frame.id, ...ack }));
+      } catch (err) {
+        log("warn", `ack send failed: ${(err as Error).message}`);
+      }
+    });
+
+    sock.on("close", (code, reason) => {
+      connected = false;
+      clearTimers();
+      log(
+        "warn",
+        `closed code=${code} reason=${reason?.toString() || ""} — reconnecting`,
+      );
+      if (stopped) return;
+      const delay = RECONNECT_BACKOFF_MS[Math.min(attempt, RECONNECT_BACKOFF_MS.length - 1)];
+      attempt += 1;
+      reconnectTimer = setTimeout(connect, delay);
+    });
+
+    sock.on("error", (err) => {
+      log("warn", `ws error: ${(err as Error).message}`);
+    });
+  }
+
+  connect();
+
+  return {
+    stop: () => {
+      stopped = true;
+      clearTimers();
+      try {
+        ws?.close();
+      } catch {
+        /* ignore */
+      }
+    },
+    isConnected: () => connected,
+  };
+}
+
+// TODO(plugin): hot-attach a freshly-provisioned agent into the running
+// channel without requiring an OpenClaw config reload. Today the
+// credentials file lands on disk and is picked up on next plugin restart.

--- a/plugin/src/host-control.ts
+++ b/plugin/src/host-control.ts
@@ -163,22 +163,41 @@ function writeAgentCredentials(args: {
 }
 
 /**
+ * Possible outcomes of :func:`patchOpenclawConfigForAgent`. ``applied`` is
+ * the only one that means the new agent will be picked up on next plugin
+ * load — the rest require the user (or the dashboard) to take a follow-up
+ * action.
+ */
+export type ConfigPatchResult =
+  /** Patch landed; account is registered under channels.botcord.accounts. */
+  | { applied: true; reason: "fresh" | "rewired_existing" }
+  /** Account already references this exact credentials file — no-op. */
+  | { applied: false; reason: "already_present" }
+  /**
+   * Skipped because patching would push BotCord above one configured
+   * account, which the per-tool ``with-client`` guard currently refuses
+   * to handle (`SINGLE_ACCOUNT_ONLY_MESSAGE`). Without this skip, adding
+   * a second agent on a host would *break* botcord_send et al for the
+   * existing agent. Tracked as a follow-up — once the tool layer is
+   * session-aware (session→accountId resolution), drop this guard.
+   */
+  | { applied: false; reason: "multi_account_guard"; existingAccountIds: string[] }
+  /** File-system / write failure. */
+  | { applied: false; reason: "io_error"; error: string };
+
+/**
  * Patch ``~/.openclaw/openclaw.json`` to register a freshly-provisioned
  * agent under ``channels.botcord.accounts.{agentId}``. Mirrors the
  * single-account → multi-account upgrade path used by
- * ``backend/static/openclaw/install.sh``.
- *
- * Returns ``true`` when the patch was applied, ``false`` when the config
- * file is missing or unwritable. The OpenClaw plugin SDK exposes no
- * runtime-reload hook today, so the new account becomes active on the
- * next plugin load — but the patch ensures the account *will* be picked
- * up automatically rather than requiring the user to edit JSON by hand.
+ * ``backend/static/openclaw/install.sh``, but refuses to push the
+ * configuration over one active account because the BotCord tool layer
+ * still hard-fails on multi-account configs.
  */
 export function patchOpenclawConfigForAgent(args: {
   agentId: string;
   credentialsFile: string;
   configPath?: string;
-}): boolean {
+}): ConfigPatchResult {
   const path =
     args.configPath ??
     process.env.OPENCLAW_CONFIG_PATH ??
@@ -197,44 +216,84 @@ export function patchOpenclawConfigForAgent(args: {
   if (!channels.botcord || typeof channels.botcord !== "object") channels.botcord = {};
   const botcord = channels.botcord as Record<string, any>;
 
-  // Promote single-account legacy shape into multi-account when needed:
-  // if the channel currently carries a top-level credentialsFile and we
-  // are about to add a *second* account, fold the existing one into the
-  // accounts map under the explicit account id "default".
-  if (!botcord.accounts || typeof botcord.accounts !== "object") {
-    botcord.accounts = {};
-  }
-  const accounts = botcord.accounts as Record<string, any>;
-  if (
+  // Discover existing accounts (legacy flat shape counts as one).
+  const accountsObj =
+    botcord.accounts && typeof botcord.accounts === "object"
+      ? (botcord.accounts as Record<string, any>)
+      : {};
+  const existingMultiIds = Object.keys(accountsObj);
+  const hasLegacySingle =
     typeof botcord.credentialsFile === "string" &&
-    !accounts.default &&
-    botcord.credentialsFile !== args.credentialsFile
+    botcord.credentialsFile.length > 0 &&
+    existingMultiIds.length === 0;
+  const existingIds = hasLegacySingle ? ["default"] : existingMultiIds;
+
+  // Idempotent re-patch of the same agent → no-op.
+  const existingForAgent = accountsObj[args.agentId];
+  if (
+    existingForAgent &&
+    existingForAgent.credentialsFile === args.credentialsFile &&
+    existingForAgent.enabled !== false
   ) {
-    accounts.default = {
-      enabled: botcord.enabled !== false,
-      credentialsFile: botcord.credentialsFile,
-      deliveryMode: botcord.deliveryMode || "websocket",
-    };
-    delete botcord.credentialsFile;
-    delete botcord.enabled;
-    delete botcord.deliveryMode;
+    return { applied: false, reason: "already_present" };
   }
 
-  accounts[args.agentId] = {
-    ...(accounts[args.agentId] || {}),
-    enabled: true,
-    credentialsFile: args.credentialsFile,
-    deliveryMode: accounts[args.agentId]?.deliveryMode || "websocket",
-  };
-  // Keep the channel itself enabled when we have at least one account.
-  if (botcord.enabled === undefined) botcord.enabled = true;
+  // Multi-account guard: refuse to push above one configured account.
+  // Re-attaching the same agentId, or rewiring a legacy single-account
+  // entry that happens to point at this agent's credentials file, is
+  // still allowed because the resulting config stays single-account.
+  const wouldBeIds = new Set(existingIds);
+  wouldBeIds.add(args.agentId);
+  if (hasLegacySingle && botcord.credentialsFile === args.credentialsFile) {
+    // legacy single → keep as single (will overwrite below)
+  } else if (wouldBeIds.size > 1) {
+    return {
+      applied: false,
+      reason: "multi_account_guard",
+      existingAccountIds: existingIds,
+    };
+  }
+
+  // Apply the patch. Two shapes depending on whether we're staying
+  // single-account or migrating from legacy → multi (only possible when
+  // the legacy entry already points at this same credentialsFile, see
+  // above; otherwise we'd have bailed with multi_account_guard).
+  let reason: "fresh" | "rewired_existing";
+  if (existingIds.length === 0) {
+    reason = "fresh";
+  } else {
+    reason = "rewired_existing";
+  }
+
+  if (hasLegacySingle) {
+    // Stay in legacy flat shape — overwrite to point at the new agent.
+    botcord.credentialsFile = args.credentialsFile;
+    if (botcord.enabled === undefined) botcord.enabled = true;
+    if (!botcord.deliveryMode) botcord.deliveryMode = "websocket";
+  } else {
+    if (!botcord.accounts || typeof botcord.accounts !== "object") {
+      botcord.accounts = {};
+    }
+    const accounts = botcord.accounts as Record<string, any>;
+    accounts[args.agentId] = {
+      ...(accounts[args.agentId] || {}),
+      enabled: true,
+      credentialsFile: args.credentialsFile,
+      deliveryMode: accounts[args.agentId]?.deliveryMode || "websocket",
+    };
+    if (botcord.enabled === undefined) botcord.enabled = true;
+  }
 
   try {
     mkdirSync(join(botcordHome(), ".openclaw"), { recursive: true });
     writeFileSync(path, JSON.stringify(cfg, null, 2) + "\n", { encoding: "utf8" });
-    return true;
-  } catch {
-    return false;
+    return { applied: true, reason };
+  } catch (err) {
+    return {
+      applied: false,
+      reason: "io_error",
+      error: err instanceof Error ? err.message : String(err),
+    };
   }
 }
 
@@ -308,7 +367,7 @@ export async function provisionAgentLocal(args: {
   privateKey: string;
   publicKey: string;
   credentialsFile: string;
-  configPatched: boolean;
+  config: ConfigPatchResult;
 }> {
   const fetchFn = args.fetchImpl ?? fetch;
   const kp = generateKeypair();
@@ -351,8 +410,11 @@ export async function provisionAgentLocal(args: {
   });
   // Register the new agent in OpenClaw's config so it actually gets loaded
   // (next plugin reload). Without this the credentials file is on disk but
-  // unreferenced and OpenClaw never spawns a channel for it.
-  const configPatched = patchOpenclawConfigForAgent({
+  // unreferenced and OpenClaw never spawns a channel for it. The patch is
+  // best-effort: when it can't be applied (e.g. multi-account guard, IO
+  // error), the structured `config` result is propagated up to the
+  // provision-claim ack so the dashboard can warn the user.
+  const config = patchOpenclawConfigForAgent({
     agentId: result.agent_id,
     credentialsFile: credPath,
   });
@@ -361,7 +423,7 @@ export async function provisionAgentLocal(args: {
     privateKey: kp.privateKey,
     publicKey: kp.publicKey,
     credentialsFile: credPath,
-    configPatched,
+    config,
   };
 }
 
@@ -399,19 +461,32 @@ export async function handleControlFrame(
         };
       }
       try {
-        const { result, credentialsFile } = await provisionAgentLocal({
+        const { result, credentialsFile, config } = await provisionAgentLocal({
           host: ctx.host,
           provisionId: params.provision_id,
           nonce: params.nonce,
         });
         ctx.log("info", `provisioned agent ${result.agent_id} → ${credentialsFile}`);
+        if (!config.applied) {
+          ctx.log(
+            "warn",
+            `openclaw config not patched (${config.reason}); agent ${result.agent_id} will not auto-load`,
+          );
+        }
         if (ctx.onAgentProvisioned) {
           await ctx.onAgentProvisioned({
             agentId: result.agent_id,
             credentialsFile,
           });
         }
-        return { ok: true, result: { agent_id: result.agent_id } };
+        return {
+          ok: true,
+          result: {
+            agent_id: result.agent_id,
+            config_patched: config.applied,
+            config_skip_reason: config.applied ? undefined : config.reason,
+          },
+        };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         ctx.log("warn", `provision_agent failed: ${message}`);

--- a/plugin/src/host-control.ts
+++ b/plugin/src/host-control.ts
@@ -162,6 +162,82 @@ function writeAgentCredentials(args: {
   return path;
 }
 
+/**
+ * Patch ``~/.openclaw/openclaw.json`` to register a freshly-provisioned
+ * agent under ``channels.botcord.accounts.{agentId}``. Mirrors the
+ * single-account → multi-account upgrade path used by
+ * ``backend/static/openclaw/install.sh``.
+ *
+ * Returns ``true`` when the patch was applied, ``false`` when the config
+ * file is missing or unwritable. The OpenClaw plugin SDK exposes no
+ * runtime-reload hook today, so the new account becomes active on the
+ * next plugin load — but the patch ensures the account *will* be picked
+ * up automatically rather than requiring the user to edit JSON by hand.
+ */
+export function patchOpenclawConfigForAgent(args: {
+  agentId: string;
+  credentialsFile: string;
+  configPath?: string;
+}): boolean {
+  const path =
+    args.configPath ??
+    process.env.OPENCLAW_CONFIG_PATH ??
+    join(botcordHome(), ".openclaw", "openclaw.json");
+
+  let cfg: Record<string, any> = {};
+  try {
+    cfg = JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    // Missing/empty file — start fresh.
+  }
+
+  if (typeof cfg !== "object" || cfg === null) cfg = {};
+  if (!cfg.channels || typeof cfg.channels !== "object") cfg.channels = {};
+  const channels = cfg.channels as Record<string, any>;
+  if (!channels.botcord || typeof channels.botcord !== "object") channels.botcord = {};
+  const botcord = channels.botcord as Record<string, any>;
+
+  // Promote single-account legacy shape into multi-account when needed:
+  // if the channel currently carries a top-level credentialsFile and we
+  // are about to add a *second* account, fold the existing one into the
+  // accounts map under the explicit account id "default".
+  if (!botcord.accounts || typeof botcord.accounts !== "object") {
+    botcord.accounts = {};
+  }
+  const accounts = botcord.accounts as Record<string, any>;
+  if (
+    typeof botcord.credentialsFile === "string" &&
+    !accounts.default &&
+    botcord.credentialsFile !== args.credentialsFile
+  ) {
+    accounts.default = {
+      enabled: botcord.enabled !== false,
+      credentialsFile: botcord.credentialsFile,
+      deliveryMode: botcord.deliveryMode || "websocket",
+    };
+    delete botcord.credentialsFile;
+    delete botcord.enabled;
+    delete botcord.deliveryMode;
+  }
+
+  accounts[args.agentId] = {
+    ...(accounts[args.agentId] || {}),
+    enabled: true,
+    credentialsFile: args.credentialsFile,
+    deliveryMode: accounts[args.agentId]?.deliveryMode || "websocket",
+  };
+  // Keep the channel itself enabled when we have at least one account.
+  if (botcord.enabled === undefined) botcord.enabled = true;
+
+  try {
+    mkdirSync(join(botcordHome(), ".openclaw"), { recursive: true });
+    writeFileSync(path, JSON.stringify(cfg, null, 2) + "\n", { encoding: "utf8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // ── Frame signature verification ────────────────────────────────────────────
 
 function controlSigningInput(frame: ControlFrame): string {
@@ -232,6 +308,7 @@ export async function provisionAgentLocal(args: {
   privateKey: string;
   publicKey: string;
   credentialsFile: string;
+  configPatched: boolean;
 }> {
   const fetchFn = args.fetchImpl ?? fetch;
   const kp = generateKeypair();
@@ -272,11 +349,19 @@ export async function provisionAgentLocal(args: {
     tokenExpiresAt: result.token_expires_at,
     openclawHostId: args.host.hostInstanceId,
   });
+  // Register the new agent in OpenClaw's config so it actually gets loaded
+  // (next plugin reload). Without this the credentials file is on disk but
+  // unreferenced and OpenClaw never spawns a channel for it.
+  const configPatched = patchOpenclawConfigForAgent({
+    agentId: result.agent_id,
+    credentialsFile: credPath,
+  });
   return {
     result,
     privateKey: kp.privateKey,
     publicKey: kp.publicKey,
     credentialsFile: credPath,
+    configPatched,
   };
 }
 
@@ -534,6 +619,10 @@ export function startOpenclawHostControl(
   };
 }
 
-// TODO(plugin): hot-attach a freshly-provisioned agent into the running
-// channel without requiring an OpenClaw config reload. Today the
-// credentials file lands on disk and is picked up on next plugin restart.
+// NOTE: provisionAgentLocal patches `~/.openclaw/openclaw.json` to register
+// the new agent under `channels.botcord.accounts.<agentId>`, mirroring the
+// install.sh flow. The OpenClaw plugin SDK currently exposes no in-process
+// reload hook, so the new account becomes active on the *next* plugin load.
+// True hot-attach (zero-downtime add of a running channel) would need an
+// SDK-side `runtime.reloadChannel(...)` API or a SIGHUP-style protocol —
+// tracked separately.


### PR DESCRIPTION
## Summary

Implements `docs/openclaw-runtime-onboarding-design.md`: BotCord can now treat **OpenClaw** as a first-class agent host alongside `daemon`, with a single dashboard flow that covers both first-install (host + agent in one shot) and subsequent agent provisioning on an already-registered host. Six commits, four review rounds.

- **Backend (Hub):** new `OpenclawHostInstance` model + migration `029`, `/openclaw/{install-claim, auth/refresh, host/provision-claim, control}` router (mirrors daemon control-plane: shared Hub Ed25519 frame signing, host JWT bearer, refresh-token rotation, in-memory WS registry), plus BFF routes `POST /api/users/me/agents/openclaw/{install,provision}` and `GET/PATCH/DELETE /hosts*`. Generalized `_consume_short_code_with_claim` so install / openclaw_install / openclaw_provision all share the same race-safe consume semantics.
- **Plugin:** `src/host-control.ts` runs a long-lived WS to `/openclaw/control`, verifies Hub-signed `provision_agent` frames, generates a fresh agent keypair locally, POSTs `/openclaw/host/provision-claim`, writes `~/.botcord/credentials/{agentId}.json`, and patches `~/.openclaw/openclaw.json` so OpenClaw picks the new agent up on next plugin load. Auto-starts from `index.ts` once per process when `host.json` exists.
- **Frontend:** Next BFF proxies the four new endpoints; `CreateAgentDialog` gains a "Local daemon | OpenClaw host" toggle; `OpenclawBranch` lists registered hosts and an "Add a new OpenClaw host" card; `InstallCommandPanel` renders the one-line install command with TTL countdown + claim polling; new `useOpenclawHostStore` Zustand store.
- **install.sh:** new `--purpose openclaw_install` branch generates host + agent keypairs and POSTs the new endpoint; legacy `install_claim` flow unchanged.

### Review-driven fixes

- Atomic `claim` paths: revert short_code claim stamp on insert failure (no phantom "claimed but agent missing" polls). For bind tickets, leave the row consumed (terminal) because the JTI is already burned — reopening would produce a permanently-pending poll state.
- Host revoke: collect default flag across all host agents, then promote a single replacement from the surviving non-host agents (was per-agent, could pick another about-to-be-unbound agent).
- `openclaw_provision` burns the unredeemed short_code on every terminal failure path (host `{ok:false}`, malformed ack, missing agent_id, agent row not found post-claim) — not only on send failures.
- `patchOpenclawConfigForAgent` returns a structured `ConfigPatchResult` and refuses to push the openclaw config above one configured account, which would otherwise trip the existing `SINGLE_ACCOUNT_ONLY` guard in `tools/with-client.ts` and break `botcord_send` for both agents. The ack now carries `config_patched` + `config_skip_reason` end-to-end so the dashboard can warn instead of showing false success.

## Test plan

- [x] Backend `uv run pytest -q` — **899 passed, 31 skipped** (7 new tests in `tests/test_app/test_openclaw_onboarding.py`: install-claim happy path / replay / bad-proof / refresh rotation / host revoke + single-default promotion / hosts list / anon rejection).
- [x] Plugin `npx vitest run` — **348 passed** (9 new in `host-control.test.ts`: provisionAgentLocal request shape + credentials + config patch outcomes; handleControlFrame routing; patchOpenclawConfigForAgent fresh / multi_account_guard / rewire / idempotent).
- [x] Frontend `tsc --noEmit` clean for `src/`. `pnpm build` Compile + TypeScript ✓ (the `/admin/codes` prerender failure is a pre-existing missing-Supabase-env issue, not from this branch).
- [ ] E2E scenario `e2e/scenarios/openclaw-onboarding.test.ts` — left as follow-up (design §6 step 8); the unit + integration coverage above hits each control-plane edge.
- [ ] Manual smoke on a fresh OpenClaw VM end-to-end (claim → host WS up → provision second agent → openclaw.json patched → next reload picks it up).

## Known follow-ups

- Tools/`with-client.ts` is still single-account; the multi-account guard in `patchOpenclawConfigForAgent` is what keeps existing users safe until tools become session→accountId aware. Documented inline.
- True hot-attach (zero-downtime add of a running channel) needs an OpenClaw SDK reload hook.
- Daemon provision path could later migrate to client-side keypair generation for parity with OpenClaw's PoP install-claim flow (design defers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)