### PR TITLE
fix(backend): extend bind-ticket TTL from 10min to 30min

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -64,7 +64,7 @@ from hub.validators import parse_pubkey
 from nacl.signing import SigningKey as NaClSigningKey
 
 # Bind-code onboarding: short TTL + per-user active cap.
-BIND_TICKET_TTL_MINUTES = 10
+BIND_TICKET_TTL_MINUTES = 30
 MAX_ACTIVE_BIND_CODES_PER_USER = 5
 
 _logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- Bump `BIND_TICKET_TTL_MINUTES` from 10 → 30 in `backend/app/routers/users.py`
- Affects both the bind-ticket flow and the openclaw/install flow (both share this constant)
- 10 minutes was too tight — users hit expiry mid-install

## Test plan
- [ ] Issue a fresh openclaw install bind-code; confirm `expires_at` is now ~30 min out
- [ ] Existing bind-ticket flow still issues codes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)