### PR TITLE
feat(daemon): inject identity.md into systemContext every turn

### DIFF
--- a/packages/daemon/src/__tests__/system-context.test.ts
+++ b/packages/daemon/src/__tests__/system-context.test.ts
@@ -25,6 +25,10 @@ const { updateWorkingMemory, clearWorkingMemory } = await import(
 );
 const { ActivityTracker } = await import("../activity-tracker.js");
 const { createDaemonSystemContextBuilder } = await import("../system-context.js");
+const { ensureAgentWorkspace, agentWorkspaceDir } = await import(
+  "../agent-workspace.js"
+);
+const { writeFileSync } = await import("node:fs");
 
 function makeMessage(
   partial: Partial<GatewayInboundMessage> = {},
@@ -80,6 +84,54 @@ describe("createDaemonSystemContextBuilder", () => {
     expect(out).toContain("Goal: ship feature");
     expect(out).toContain("<section_notes>");
     expect(out).toContain("remember X");
+  });
+
+  it("injects the identity block from workspace/identity.md, placed before other blocks", () => {
+    ensureAgentWorkspace("ag_me", {
+      displayName: "Susan's Helper",
+      bio: "A friendly IM agent who tracks contacts.",
+      runtime: "claude-code",
+    });
+    updateWorkingMemory("ag_me", { goal: "ship feature" });
+
+    const builder = createDaemonSystemContextBuilder({ agentId: "ag_me" });
+    const out = builder(makeMessage()) as string;
+    expect(out).toContain("[BotCord Identity]");
+    expect(out).toContain("Susan's Helper");
+    expect(out).toContain("A friendly IM agent who tracks contacts.");
+    // Identity must precede working memory so it frames every other block.
+    expect(out.indexOf("[BotCord Identity]")).toBeLessThan(
+      out.indexOf("[BotCord Working Memory]"),
+    );
+  });
+
+  it("re-reads identity.md every turn so dashboard / agent edits take effect immediately", () => {
+    ensureAgentWorkspace("ag_me", { displayName: "Old Name" });
+    const builder = createDaemonSystemContextBuilder({ agentId: "ag_me" });
+    const first = builder(makeMessage()) as string;
+    expect(first).toContain("Old Name");
+
+    // Simulate an out-of-band edit (dashboard reconcile, user, control frame…).
+    writeFileSync(
+      path.join(agentWorkspaceDir("ag_me"), "identity.md"),
+      "# Identity\n\n- **Display name**: New Name\n",
+    );
+    const second = builder(makeMessage()) as string;
+    expect(second).toContain("New Name");
+    expect(second).not.toContain("Old Name");
+  });
+
+  it("skips the identity block cleanly when identity.md is missing", () => {
+    // No ensureAgentWorkspace — workspace never provisioned.
+    const builder = createDaemonSystemContextBuilder({ agentId: "ag_me" });
+    expect(builder(makeMessage())).toBeUndefined();
+  });
+
+  it("skips the identity block when identity.md is blank", () => {
+    ensureAgentWorkspace("ag_me", { displayName: "X" });
+    writeFileSync(path.join(agentWorkspaceDir("ag_me"), "identity.md"), "");
+    const builder = createDaemonSystemContextBuilder({ agentId: "ag_me" });
+    expect(builder(makeMessage())).toBeUndefined();
   });
 
   it("emits the 'memory is currently empty' notice when the memory file exists but is blank", () => {

--- a/packages/daemon/src/agent-workspace.ts
+++ b/packages/daemon/src/agent-workspace.ts
@@ -88,10 +88,14 @@ This directory is your persistent workspace. You run with \`cwd\` set here.
 
 ## How to use this
 
-You are **instructed** to skim \`identity.md\`, \`memory.md\`, \`task.md\` before each
-response and to write back what changed after meaningful turns. Nothing in the
-runtime enforces this — the daemon does not auto-load these files into your
-context. Treat AGENTS.md as a convention, not a mechanism.
+- \`identity.md\` is **auto-loaded** by the daemon and injected into every turn's
+  system context as the \`[BotCord Identity]\` block. Edits to this file (yours,
+  the dashboard's via \`applyAgentIdentity\`, or a hello-snapshot reapply) take
+  effect on the next turn — no restart needed.
+- \`memory.md\` and \`task.md\` are **convention, not mechanism**. The daemon does
+  not auto-load them; you are instructed to skim them before responding and to
+  write back what changed after meaningful turns. Keep them tight enough to be
+  worth re-reading.
 `;
 
 const MEMORY_MD = `# Memory
@@ -99,9 +103,9 @@ const MEMORY_MD = `# Memory
 <!--
 Long-lived facts about the user, past decisions, and preferences that should
 survive across conversations. Organize by topic. Keep entries short. Prune
-regularly — AGENTS.md instructs the runtime to consult this file before each
-response, but nothing loads it automatically; keep it short enough to be
-worth re-reading.
+regularly — AGENTS.md instructs you to consult this file before each
+response, but nothing loads it automatically (unlike identity.md); keep it
+short enough to be worth re-reading.
 -->
 `;
 
@@ -331,4 +335,26 @@ export function applyAgentIdentity(
 
   writeFileSync(file, text, { mode: 0o600 });
   return { changed: true };
+}
+
+/**
+ * Read the agent's `identity.md` verbatim, if it exists. Returns the raw
+ * contents (including the leading `# Identity` heading) so callers can
+ * splice it into the system context. Returns `null` when the workspace
+ * has not been provisioned yet, the file is empty, or the read fails.
+ *
+ * Each call hits disk — same contract as `readWorkingMemory`, so a
+ * dashboard-driven edit (`applyAgentIdentity` from a control frame, or
+ * a hello-snapshot reapply, or the agent's own self-edit) is visible
+ * on the very next turn without restarting the gateway.
+ */
+export function readIdentity(agentId: string): string | null {
+  assertSafeAgentId(agentId);
+  const file = path.join(agentWorkspaceDir(agentId), "identity.md");
+  try {
+    const raw = readFileSync(file, "utf8");
+    return raw.trim().length > 0 ? raw : null;
+  } catch {
+    return null;
+  }
 }

--- a/packages/daemon/src/system-context.ts
+++ b/packages/daemon/src/system-context.ts
@@ -6,10 +6,11 @@
  * `RuntimeRunOptions.systemContext`. This module composes the daemon's
  * system-context string from:
  *
- *   1. `[BotCord Scene: Owner Chat]` (owner-trust turns only)
- *   2. `[BotCord Working Memory]`
- *   3. `[BotCord Room Context]` (group rooms, via optional async fetcher)
- *   4. `[BotCord Cross-Room Awareness]` (optional activity tracker)
+ *   1. `[BotCord Identity]` (read fresh from workspace/identity.md each turn)
+ *   2. `[BotCord Scene: Owner Chat]` (owner-trust turns only)
+ *   3. `[BotCord Working Memory]`
+ *   4. `[BotCord Room Context]` (group rooms, via optional async fetcher)
+ *   5. `[BotCord Cross-Room Awareness]` (optional activity tracker)
  *
  * Behavior:
  *   - Working memory is loaded fresh per turn, so a `memory set` from another
@@ -26,6 +27,7 @@ import type { GatewayInboundMessage, SystemContextBuilder } from "./gateway/inde
 import type { ActivityTracker } from "./activity-tracker.js";
 import { buildCrossRoomDigest } from "./cross-room.js";
 import { buildWorkingMemoryPrompt, readWorkingMemory } from "./working-memory.js";
+import { readIdentity } from "./agent-workspace.js";
 import { classifyActivitySender } from "./sender-classify.js";
 import { log } from "./log.js";
 
@@ -87,6 +89,31 @@ function safeReadWorkingMemory(agentId: string) {
 }
 
 /**
+ * Read identity.md and wrap it as a system-context block. Placed before
+ * every other block so the agent answers "who are you" from this file
+ * rather than from the underlying CLI's default persona ("I am Claude
+ * Code"). Re-read every turn so dashboard reconcile (`applyAgentIdentity`)
+ * and self-edits take effect immediately, mirroring working-memory
+ * semantics.
+ */
+function buildIdentityPrompt(agentId: string): string | null {
+  let raw: string | null = null;
+  try {
+    raw = readIdentity(agentId);
+  } catch (err) {
+    log.warn("identity read failed", { agentId, err: String(err) });
+    return null;
+  }
+  if (!raw) return null;
+  return [
+    "[BotCord Identity]",
+    "Your persistent identity card. The fields below are the source of truth — when asked who you are, what you do, or what you will / will not do, answer from this block, not from the underlying CLI's default persona.",
+    "",
+    raw.trim(),
+  ].join("\n");
+}
+
+/**
  * Build a {@link SystemContextBuilder} for the gateway dispatcher.
  *
  * When `deps.roomContextBuilder` is provided the returned function is async
@@ -97,10 +124,13 @@ export function createDaemonSystemContextBuilder(
   deps: SystemContextDeps,
 ): (message: GatewayInboundMessage) => Promise<string | undefined> | string | undefined {
   const gatherSyncBlocks = (message: GatewayInboundMessage): {
+    identity: string | null;
     ownerScene: string | null;
     memory: string | null;
     digest: string | null;
   } => {
+    const identity = buildIdentityPrompt(deps.agentId);
+
     const ownerScene =
       classifyActivitySender(message).kind === "owner"
         ? buildOwnerChatSceneContext()
@@ -118,7 +148,7 @@ export function createDaemonSystemContextBuilder(
         }) || null
       : null;
 
-    return { ownerScene, memory, digest };
+    return { identity, ownerScene, memory, digest };
   };
 
   const assemble = (parts: Array<string | null | undefined>): string | undefined => {
@@ -144,11 +174,12 @@ export function createDaemonSystemContextBuilder(
 
   if (!deps.roomContextBuilder) {
     const syncBuilder = (message: GatewayInboundMessage): string | undefined => {
-      const { ownerScene, memory, digest } = gatherSyncBlocks(message);
+      const { identity, ownerScene, memory, digest } = gatherSyncBlocks(message);
       // Loop-risk sits at the end so its "reply NO_REPLY unless…" guidance
       // is the last thing the model sees before the user turn body.
+      // Identity sits at the very front so it frames every other block.
       const loopRisk = runLoopRisk(message);
-      return assemble([ownerScene, memory, digest, loopRisk]);
+      return assemble([identity, ownerScene, memory, digest, loopRisk]);
     };
     // Compile-time witness that the narrower sync signature still satisfies
     // `SystemContextBuilder` (which allows async). Prevents the two contracts
@@ -162,11 +193,12 @@ export function createDaemonSystemContextBuilder(
   const asyncBuilder = async (
     message: GatewayInboundMessage,
   ): Promise<string | undefined> => {
-    const { ownerScene, memory, digest } = gatherSyncBlocks(message);
+    const { identity, ownerScene, memory, digest } = gatherSyncBlocks(message);
     // Room context landing order: after owner-scene / memory, before digest —
     // "what room am I in" belongs with the session's own identity, while the
     // cross-room digest deliberately describes OTHER rooms and should stay
     // last so it doesn't get confused with the current room.
+    // Identity stays at the very front; see syncBuilder for rationale.
     let roomBlock: string | null = null;
     try {
       roomBlock = await roomBuilder(message);
@@ -178,7 +210,7 @@ export function createDaemonSystemContextBuilder(
       });
     }
     const loopRisk = runLoopRisk(message);
-    return assemble([ownerScene, memory, roomBlock, digest, loopRisk]);
+    return assemble([identity, ownerScene, memory, roomBlock, digest, loopRisk]);
   };
   const _typecheck: SystemContextBuilder = asyncBuilder;
   void _typecheck;


### PR DESCRIPTION
## Summary

- Promote `workspace/identity.md` from documentation file to a real
  context source: read fresh every turn and injected as a leading
  `[BotCord Identity]` block in the daemon's `systemContext`, so
  cc/codex actually see the agent's name, bio, role, and boundaries
  instead of falling back to "I'm Claude Code".
- Closes the missing half of #346: that PR taught the dashboard to
  reconcile `identity.md` (online via `update_agent` control frame,
  offline via hello-snapshot reapply); this PR makes the model actually
  read it.
- Refresh `AGENTS.md` / `memory.md` template wording so the
  "convention vs mechanism" line matches new behavior — `identity.md`
  is auto-loaded; `memory.md` and `task.md` remain convention-only.

## Why this is small

- `readIdentity(agentId)` mirrors `readWorkingMemory` (~12 LoC).
- `buildIdentityPrompt` mirrors the working-memory wrapper (~15 LoC).
- One extra block in the existing `gatherSyncBlocks` / `assemble`
  pipeline; identity is the first slot so it frames every later block.
- Returns `null` cleanly when the workspace isn't provisioned yet or
  the file is empty — existing "empty systemContext" behavior is
  preserved (see new `it("skips the identity block cleanly when…")`).

## Out of scope (left for later)

- System prompt **override** — `--append-system-prompt` and the codex
  `AGENTS.md` carrier still sit on top of cc/codex's built-in coding
  persona. This PR uses framing in the identity block ("answer from
  this block, not from the underlying CLI's default persona") as a
  soft prompt-level lever.
- Tool whitelisting (`--allowedTools`), model / temperature knobs,
  per-agent runtime selection — those are separate gaps.
- Migration of pre-existing workspaces' AGENTS.md wording —
  `writeIfMissing` semantics deliberately leave older agents alone.

## Test plan

- [x] `vitest run src/__tests__/system-context.test.ts src/__tests__/agent-workspace.test.ts` — 44/44 pass
- [x] Identity block appears before working memory and other blocks
- [x] Out-of-band edit to `identity.md` is visible on the next turn (no restart)
- [x] Missing / blank `identity.md` skips the block cleanly (no spurious empty section)
- [ ] Manual: provision a fresh agent, confirm cc/codex answers "what's your name" using the bio in `identity.md` rather than CLI default
- [ ] Manual: edit bio via dashboard (#346 path), confirm change visible to agent within one turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)