### PR TITLE
feat: agent listening / reply policy (admission + attention)

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -1970,12 +1970,32 @@ async def human_room_send(
         )
         blocked_by = {row[0] for row in block_result.all()}
 
+    # When the sender is a Human (no active agent), filter out agent members
+    # whose `allow_human_sender=False` opted out of human-originated traffic.
+    human_blocked_agents: set[str] = set()
+    if active_agent_id is None and member_ids:
+        agent_member_ids = [
+            m.agent_id for m in all_members
+            if m.participant_type == ParticipantType.agent
+        ]
+        if agent_member_ids:
+            from hub.models import Agent as _AgentModel  # local to avoid cycles
+            opt_out_rows = await db.execute(
+                select(_AgentModel.agent_id).where(
+                    _AgentModel.agent_id.in_(agent_member_ids),
+                    _AgentModel.allow_human_sender.is_(False),
+                )
+            )
+            human_blocked_agents = {row[0] for row in opt_out_rows.all()}
+
     # Fan-out targets: all members minus muted minus blockers. Sender is
     # INCLUDED (PRD §6.3) — only skipped if they themselves are muted or
     # happen to block themselves (shouldn't happen).
     receivers = [
         m for m in all_members
-        if not m.muted and m.agent_id not in blocked_by
+        if not m.muted
+        and m.agent_id not in blocked_by
+        and m.agent_id not in human_blocked_agents
     ]
     receiver_ids = [m.agent_id for m in receivers]
 

--- a/backend/app/routers/humans.py
+++ b/backend/app/routers/humans.py
@@ -52,6 +52,7 @@ from hub.models import (
     ShareMessage,
     User,
 )
+from hub.policy import Principal, check_room_invite_admission
 from hub.share_payloads import frontend_url, room_continue_url, room_entry_type, share_create_payload
 
 _logger = logging.getLogger(__name__)
@@ -1034,20 +1035,26 @@ async def invite_room_member_as_human(
     # divergence (e.g. a contacts_only target being 403'd on the sub-gate
     # before its owner had a chance to approve/reject via the queue).
 
-    # --- W2: admission policy (contacts_only, agent targets only) ---------
-    if target_agent is not None and target_agent.message_policy == MessagePolicy.contacts_only:
-        contact_row = await db.execute(
-            select(Contact).where(
-                Contact.owner_id == participant_id,
-                Contact.owner_type == ParticipantType.agent,
-                Contact.contact_agent_id == me,
+    # --- W2: admission policy via the central helper ----------------------
+    if target_agent is not None:
+        try:
+            await check_room_invite_admission(
+                db,
+                inviter=Principal(id=me, type=ParticipantType.human),
+                invitee=target_agent,
             )
-        )
-        if contact_row.scalar_one_or_none() is None:
-            raise HTTPException(
-                status_code=403,
-                detail="admission_denied_target_contacts_only",
-            )
+        except Exception as exc:
+            # Preserve the dashboard's plain HTTPException 403 contract while
+            # still surfacing the specific reason for newer keys.
+            from hub.i18n import I18nHTTPException as _I18nE
+            if isinstance(exc, _I18nE):
+                detail = (
+                    "admission_denied_target_contacts_only"
+                    if exc.message_key == "room_invite_requires_contact"
+                    else exc.message_key
+                )
+                raise HTTPException(status_code=403, detail=detail) from None
+            raise
 
     # --- C2: claimed-agent approval queue (agent targets only) ------------
     if (

--- a/backend/app/routers/policy.py
+++ b/backend/app/routers/policy.py
@@ -8,10 +8,11 @@
 
 from __future__ import annotations
 
+import datetime
 import json
 from typing import Literal
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Response
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -19,7 +20,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.auth import RequestContext, require_user
 from hub.database import get_db
 from hub.enums import AttentionMode, ContactPolicy, MessagePolicy, RoomInvitePolicy
-from hub.models import Agent
+from hub.i18n import I18nHTTPException
+from hub.models import Agent, AgentRoomPolicyOverride, Room
+from hub.policy import EffectiveAttention, resolve_effective_attention
 
 router = APIRouter(prefix="/api/agents", tags=["app-policy"])
 
@@ -157,3 +160,251 @@ async def patch_policy(
     await db.commit()
     await db.refresh(agent)
     return _serialize(agent)
+
+
+# ---------------------------------------------------------------------------
+# Per-room attention override (design §3.2 + §5)
+# ---------------------------------------------------------------------------
+
+
+def _is_dm_room(room_id: str) -> bool:
+    return room_id.startswith("rm_dm_")
+
+
+async def _ensure_room_exists(db: AsyncSession, room_id: str) -> Room:
+    result = await db.execute(select(Room).where(Room.room_id == room_id))
+    room = result.scalar_one_or_none()
+    if room is None:
+        raise I18nHTTPException(status_code=404, message_key="room_not_found")
+    return room
+
+
+async def _load_override(
+    db: AsyncSession, agent_id: str, room_id: str
+) -> AgentRoomPolicyOverride | None:
+    result = await db.execute(
+        select(AgentRoomPolicyOverride).where(
+            AgentRoomPolicyOverride.agent_id == agent_id,
+            AgentRoomPolicyOverride.room_id == room_id,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+class EffectiveAttentionOut(BaseModel):
+    mode: AttentionLit
+    keywords: list[str]
+    muted_until: datetime.datetime | None
+    source: Literal["global", "override", "dm_forced"]
+
+
+class RoomOverrideOut(BaseModel):
+    attention_mode: AttentionLit | None
+    keywords: list[str] | None
+    muted_until: datetime.datetime | None
+    updated_at: datetime.datetime
+
+
+class RoomPolicyOut(BaseModel):
+    effective: EffectiveAttentionOut
+    override: RoomOverrideOut | None
+    inherits_global: bool
+
+
+class RoomPolicyPut(BaseModel):
+    """Upsert payload — only the explicitly-provided keys touch the row.
+
+    ``None`` for ``attention_mode``/``keywords`` clears that axis (NULL =
+    inherit from the agent default). Omit a key to leave it unchanged.
+    Use ``model_fields_set`` to discriminate omitted vs explicit-null."""
+
+    attention_mode: AttentionLit | None = None
+    keywords: list[str] | None = Field(default=None, max_length=64)
+
+    @field_validator("keywords")
+    @classmethod
+    def _validate_keywords(cls, v: list[str] | None) -> list[str] | None:
+        if v is None:
+            return v
+        cleaned: list[str] = []
+        for kw in v:
+            if not isinstance(kw, str):
+                raise ValueError("keyword must be a string")
+            kw = kw.strip()
+            if not kw:
+                continue
+            if len(kw) > 128:
+                raise ValueError("keyword too long (max 128 chars)")
+            cleaned.append(kw)
+        return cleaned
+
+
+class SnoozeIn(BaseModel):
+    minutes: int = Field(..., ge=0, le=43200)  # 0 clears; max 30 days
+
+
+def _serialize_effective(eff: EffectiveAttention) -> EffectiveAttentionOut:
+    return EffectiveAttentionOut(
+        mode=eff.mode.value,  # type: ignore[arg-type]
+        keywords=list(eff.keywords),
+        muted_until=eff.muted_until,
+        source=eff.source,
+    )
+
+
+def _serialize_override(row: AgentRoomPolicyOverride) -> RoomOverrideOut:
+    mode_value: AttentionLit | None
+    if row.attention_mode is None:
+        mode_value = None
+    else:
+        mode_obj = (
+            row.attention_mode
+            if isinstance(row.attention_mode, AttentionMode)
+            else AttentionMode(row.attention_mode)
+        )
+        mode_value = mode_obj.value  # type: ignore[assignment]
+    keywords: list[str] | None
+    if row.keywords is None:
+        keywords = None
+    else:
+        try:
+            parsed = json.loads(row.keywords)
+            keywords = (
+                [str(x) for x in parsed if isinstance(x, str)]
+                if isinstance(parsed, list)
+                else []
+            )
+        except json.JSONDecodeError:
+            keywords = []
+    return RoomOverrideOut(
+        attention_mode=mode_value,
+        keywords=keywords,
+        muted_until=row.muted_until,
+        updated_at=row.updated_at,
+    )
+
+
+@router.get(
+    "/{agent_id}/rooms/{room_id}/policy",
+    response_model=RoomPolicyOut,
+)
+async def get_room_policy(
+    agent_id: str,
+    room_id: str,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    agent = await _load_owned_agent(db, ctx, agent_id)
+    await _ensure_room_exists(db, room_id)
+    override = await _load_override(db, agent.agent_id, room_id)
+    eff = await resolve_effective_attention(db, agent=agent, room_id=room_id)
+    return RoomPolicyOut(
+        effective=_serialize_effective(eff),
+        override=_serialize_override(override) if override is not None else None,
+        inherits_global=override is None,
+    )
+
+
+@router.put(
+    "/{agent_id}/rooms/{room_id}/policy",
+    response_model=RoomPolicyOut,
+)
+async def put_room_policy(
+    agent_id: str,
+    room_id: str,
+    body: RoomPolicyPut,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    agent = await _load_owned_agent(db, ctx, agent_id)
+    await _ensure_room_exists(db, room_id)
+    if _is_dm_room(room_id):
+        raise I18nHTTPException(
+            status_code=400, message_key="attention_override_not_allowed_in_dm"
+        )
+    # Note: we don't require room membership — the agent might be added to the
+    # room later, and the user may want the override staged ahead of time.
+    override = await _load_override(db, agent.agent_id, room_id)
+    if override is None:
+        override = AgentRoomPolicyOverride(agent_id=agent.agent_id, room_id=room_id)
+        db.add(override)
+
+    fields_set = body.model_fields_set
+    if "attention_mode" in fields_set:
+        override.attention_mode = (
+            AttentionMode(body.attention_mode)
+            if body.attention_mode is not None
+            else None
+        )
+    if "keywords" in fields_set:
+        override.keywords = (
+            json.dumps(body.keywords) if body.keywords is not None else None
+        )
+    await db.commit()
+    await db.refresh(override)
+
+    eff = await resolve_effective_attention(db, agent=agent, room_id=room_id)
+    return RoomPolicyOut(
+        effective=_serialize_effective(eff),
+        override=_serialize_override(override),
+        inherits_global=False,
+    )
+
+
+@router.delete(
+    "/{agent_id}/rooms/{room_id}/policy",
+    status_code=204,
+)
+async def delete_room_policy(
+    agent_id: str,
+    room_id: str,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    agent = await _load_owned_agent(db, ctx, agent_id)
+    await _ensure_room_exists(db, room_id)
+    override = await _load_override(db, agent.agent_id, room_id)
+    if override is not None:
+        await db.delete(override)
+        await db.commit()
+    # Idempotent: 204 either way.
+    return Response(status_code=204)
+
+
+@router.post(
+    "/{agent_id}/rooms/{room_id}/snooze",
+    response_model=RoomPolicyOut,
+)
+async def snooze_room(
+    agent_id: str,
+    room_id: str,
+    body: SnoozeIn,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    agent = await _load_owned_agent(db, ctx, agent_id)
+    await _ensure_room_exists(db, room_id)
+    if _is_dm_room(room_id):
+        raise I18nHTTPException(
+            status_code=400, message_key="attention_override_not_allowed_in_dm"
+        )
+    override = await _load_override(db, agent.agent_id, room_id)
+    if override is None:
+        override = AgentRoomPolicyOverride(agent_id=agent.agent_id, room_id=room_id)
+        db.add(override)
+
+    if body.minutes == 0:
+        override.muted_until = None
+    else:
+        override.muted_until = datetime.datetime.now(
+            datetime.timezone.utc
+        ) + datetime.timedelta(minutes=body.minutes)
+    await db.commit()
+    await db.refresh(override)
+
+    eff = await resolve_effective_attention(db, agent=agent, room_id=room_id)
+    return RoomPolicyOut(
+        effective=_serialize_effective(eff),
+        override=_serialize_override(override),
+        inherits_global=False,
+    )

--- a/backend/app/routers/policy.py
+++ b/backend/app/routers/policy.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -20,6 +21,9 @@ from app.auth import RequestContext, require_user
 from hub.database import get_db
 from hub.enums import AttentionMode, ContactPolicy, MessagePolicy, RoomInvitePolicy
 from hub.models import Agent
+from hub.routers.daemon_control import is_daemon_online, send_control_frame
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/agents", tags=["app-policy"])
 
@@ -156,4 +160,40 @@ async def patch_policy(
 
     await db.commit()
     await db.refresh(agent)
-    return _serialize(agent)
+
+    # PR3: notify the daemon hosting this agent so its policyResolver drops
+    # the stale cache entry. Best-effort — daemon offline / dispatch error
+    # must not break the BFF response. We embed the post-update policy
+    # inline so the daemon avoids a refetch.
+    # TODO(pr3-merge): fire policy_updated from per-room endpoints once PR2
+    # lands its PUT/DELETE/snooze surface.
+    serialized = _serialize(agent)
+    if agent.daemon_instance_id and is_daemon_online(agent.daemon_instance_id):
+        try:
+            await send_control_frame(
+                agent.daemon_instance_id,
+                "policy_updated",
+                {
+                    "agent_id": agent.agent_id,
+                    "policy": {
+                        "mode": serialized.default_attention,
+                        "keywords": serialized.attention_keywords,
+                    },
+                },
+            )
+        except HTTPException as exc:
+            logger.warning(
+                "policy_updated dispatch failed: agent=%s daemon=%s detail=%s",
+                agent.agent_id,
+                agent.daemon_instance_id,
+                exc.detail,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "policy_updated dispatch error: agent=%s daemon=%s err=%s",
+                agent.agent_id,
+                agent.daemon_instance_id,
+                exc,
+            )
+
+    return serialized

--- a/backend/app/routers/policy.py
+++ b/backend/app/routers/policy.py
@@ -186,13 +186,15 @@ async def _dispatch_policy_updated(
     room_id: str | None = None,
     policy: dict | None = None,
 ) -> None:
-    """Best-effort: tell the daemon to invalidate its cached policy.
+    """Best-effort: tell the daemon to install / drop its cached policy.
 
     Daemon offline / dispatch error must never break the BFF response. The
-    inline ``policy`` blob lets the daemon avoid a refetch when the global
-    policy is the only thing that changed. For per-room edits we omit
-    ``policy`` and pass ``room_id`` so the daemon refetches just that key
-    when PR2/PR4 wires the room-aware fetcher.
+    inline ``policy`` blob carries the post-mutation effective policy so the
+    daemon avoids a refetch — the daemon currently has no per-room fetcher,
+    so callers MUST embed ``policy`` for any frame that should leave a cache
+    entry behind (PUT override, snooze). Frames that only need to drop a
+    cache entry (DELETE override, falling back to inherited global) may omit
+    ``policy``.
     """
     if not agent.daemon_instance_id or not is_daemon_online(agent.daemon_instance_id):
         return
@@ -302,6 +304,20 @@ class SnoozeIn(BaseModel):
     minutes: int = Field(..., ge=0, le=43200)  # 0 clears; max 30 days
 
 
+def _wire_policy(eff: EffectiveAttention) -> dict:
+    """Project EffectiveAttention onto the daemon's AttentionPolicy wire shape.
+
+    `muted_until` is converted to unix milliseconds (matches the daemon's
+    `Date.now()` reference; see `protocol-core/src/should-wake.ts`)."""
+    payload: dict = {
+        "mode": eff.mode.value if hasattr(eff.mode, "value") else str(eff.mode),
+        "keywords": list(eff.keywords),
+    }
+    if eff.muted_until is not None:
+        payload["muted_until"] = int(eff.muted_until.timestamp() * 1000)
+    return payload
+
+
 def _serialize_effective(eff: EffectiveAttention) -> EffectiveAttentionOut:
     return EffectiveAttentionOut(
         mode=eff.mode.value,  # type: ignore[arg-type]
@@ -403,6 +419,7 @@ async def put_room_policy(
     await db.refresh(override)
 
     eff = await resolve_effective_attention(db, agent=agent, room_id=room_id)
+    await _dispatch_policy_updated(agent, room_id=room_id, policy=_wire_policy(eff))
     return RoomPolicyOut(
         effective=_serialize_effective(eff),
         override=_serialize_override(override),
@@ -463,7 +480,7 @@ async def snooze_room(
     await db.refresh(override)
 
     eff = await resolve_effective_attention(db, agent=agent, room_id=room_id)
-    await _dispatch_policy_updated(agent, room_id=room_id)
+    await _dispatch_policy_updated(agent, room_id=room_id, policy=_wire_policy(eff))
     return RoomPolicyOut(
         effective=_serialize_effective(eff),
         override=_serialize_override(override),

--- a/backend/app/routers/policy.py
+++ b/backend/app/routers/policy.py
@@ -1,0 +1,159 @@
+"""
+[INPUT]: Authenticated user + their owned agent + Pydantic policy patches
+[OUTPUT]: GET/PATCH /api/agents/{agent_id}/policy — read & update the agent's
+          admission and default attention settings.
+[POS]: BFF surface for the dashboard "Conversations & Replies" tab.
+[PROTOCOL]: Only the user that owns the agent may read or write its policy.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field, field_validator
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import RequestContext, require_user
+from hub.database import get_db
+from hub.enums import AttentionMode, ContactPolicy, MessagePolicy, RoomInvitePolicy
+from hub.models import Agent
+
+router = APIRouter(prefix="/api/agents", tags=["app-policy"])
+
+
+ContactPolicyLit = Literal["open", "contacts_only", "whitelist", "closed"]
+RoomInviteLit = Literal["open", "contacts_only", "closed"]
+AttentionLit = Literal["always", "mention_only", "keyword", "muted"]
+
+
+class AgentPolicyOut(BaseModel):
+    contact_policy: ContactPolicyLit
+    allow_agent_sender: bool
+    allow_human_sender: bool
+    room_invite_policy: RoomInviteLit
+    default_attention: AttentionLit
+    attention_keywords: list[str]
+
+
+class AgentPolicyPatch(BaseModel):
+    contact_policy: ContactPolicyLit | None = None
+    allow_agent_sender: bool | None = None
+    allow_human_sender: bool | None = None
+    room_invite_policy: RoomInviteLit | None = None
+    default_attention: AttentionLit | None = None
+    attention_keywords: list[str] | None = Field(default=None, max_length=64)
+
+    @field_validator("attention_keywords")
+    @classmethod
+    def _validate_keywords(cls, v: list[str] | None) -> list[str] | None:
+        if v is None:
+            return v
+        cleaned: list[str] = []
+        for kw in v:
+            if not isinstance(kw, str):
+                raise ValueError("keyword must be a string")
+            kw = kw.strip()
+            if not kw:
+                continue
+            if len(kw) > 128:
+                raise ValueError("keyword too long (max 128 chars)")
+            cleaned.append(kw)
+        return cleaned
+
+
+def _decode_keywords(raw: str | None) -> list[str]:
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [str(x) for x in parsed if isinstance(x, str)]
+
+
+def _serialize(agent: Agent) -> AgentPolicyOut:
+    contact = agent.contact_policy
+    if isinstance(contact, ContactPolicy):
+        contact_value = contact.value
+    else:
+        contact_value = str(contact) if contact else ContactPolicy.contacts_only.value
+    invite = agent.room_invite_policy
+    if isinstance(invite, RoomInvitePolicy):
+        invite_value = invite.value
+    else:
+        invite_value = str(invite) if invite else RoomInvitePolicy.contacts_only.value
+    attention = agent.default_attention
+    if isinstance(attention, AttentionMode):
+        attention_value = attention.value
+    else:
+        attention_value = str(attention) if attention else AttentionMode.always.value
+    return AgentPolicyOut(
+        contact_policy=contact_value,  # type: ignore[arg-type]
+        allow_agent_sender=bool(agent.allow_agent_sender),
+        allow_human_sender=bool(agent.allow_human_sender),
+        room_invite_policy=invite_value,  # type: ignore[arg-type]
+        default_attention=attention_value,  # type: ignore[arg-type]
+        attention_keywords=_decode_keywords(agent.attention_keywords),
+    )
+
+
+async def _load_owned_agent(db: AsyncSession, ctx: RequestContext, agent_id: str) -> Agent:
+    result = await db.execute(
+        select(Agent).where(
+            Agent.agent_id == agent_id,
+            Agent.user_id == ctx.user_id,
+            Agent.status == "active",
+        )
+    )
+    agent = result.scalar_one_or_none()
+    if agent is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    return agent
+
+
+@router.get("/{agent_id}/policy", response_model=AgentPolicyOut)
+async def get_policy(
+    agent_id: str,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    agent = await _load_owned_agent(db, ctx, agent_id)
+    return _serialize(agent)
+
+
+@router.patch("/{agent_id}/policy", response_model=AgentPolicyOut)
+async def patch_policy(
+    agent_id: str,
+    body: AgentPolicyPatch,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    agent = await _load_owned_agent(db, ctx, agent_id)
+
+    if body.contact_policy is not None:
+        new_contact = ContactPolicy(body.contact_policy)
+        agent.contact_policy = new_contact
+        # Dual-write the legacy `message_policy` field so older readers stay
+        # consistent. Anything stricter than `open` collapses to `contacts_only`.
+        agent.message_policy = (
+            MessagePolicy.open if new_contact == ContactPolicy.open else MessagePolicy.contacts_only
+        )
+    if body.allow_agent_sender is not None:
+        agent.allow_agent_sender = body.allow_agent_sender
+    if body.allow_human_sender is not None:
+        agent.allow_human_sender = body.allow_human_sender
+    if body.room_invite_policy is not None:
+        agent.room_invite_policy = RoomInvitePolicy(body.room_invite_policy)
+    if body.default_attention is not None:
+        agent.default_attention = AttentionMode(body.default_attention)
+    if body.attention_keywords is not None:
+        agent.attention_keywords = json.dumps(body.attention_keywords)
+
+    await db.commit()
+    await db.refresh(agent)
+    return _serialize(agent)

--- a/backend/hub/enums.py
+++ b/backend/hub/enums.py
@@ -21,6 +21,32 @@ class MessagePolicy(str, enum.Enum):
     contacts_only = "contacts_only"
 
 
+class ContactPolicy(str, enum.Enum):
+    """Who can directly contact the agent (DM / direct send / human-room speech)."""
+
+    open = "open"
+    contacts_only = "contacts_only"
+    whitelist = "whitelist"
+    closed = "closed"
+
+
+class RoomInvitePolicy(str, enum.Enum):
+    """Who can invite the agent into a room."""
+
+    open = "open"
+    contacts_only = "contacts_only"
+    closed = "closed"
+
+
+class AttentionMode(str, enum.Enum):
+    """Daemon-side attention gate — does an inbound message wake the runtime?"""
+
+    always = "always"
+    mention_only = "mention_only"
+    keyword = "keyword"
+    muted = "muted"
+
+
 class MessageState(str, enum.Enum):
     queued = "queued"
     processing = "processing"  # Claimed by a consumer, pending explicit ack

--- a/backend/hub/i18n.py
+++ b/backend/hub/i18n.py
@@ -562,6 +562,14 @@ ERROR_MESSAGES: dict[str, dict[Locale, str]] = {
         Locale.EN: "Duplicate message",
         Locale.ZH: "重复消息",
     },
+
+    # -----------------------------------------------------------------------
+    # Per-room attention override (policy.py)
+    # -----------------------------------------------------------------------
+    "attention_override_not_allowed_in_dm": {
+        Locale.EN: "Attention overrides are not allowed in direct-message rooms",
+        Locale.ZH: "私聊房间不允许设置注意力策略",
+    },
 }
 
 
@@ -1109,6 +1117,10 @@ HINT_MESSAGES: dict[str, dict[Locale, str]] = {
     "duplicate_message": {
         Locale.EN: "This message was already sent. Use a different msg_id.",
         Locale.ZH: "该消息已发送过，请使用不同的 msg_id。",
+    },
+    "attention_override_not_allowed_in_dm": {
+        Locale.EN: "Direct-message rooms always use 'always' — adjust the agent's global attention defaults instead.",
+        Locale.ZH: "私聊房间始终为‘全部回复’，如需调整请修改 Agent 的全局注意力策略。",
     },
 
     # -----------------------------------------------------------------------

--- a/backend/hub/i18n.py
+++ b/backend/hub/i18n.py
@@ -267,6 +267,30 @@ ERROR_MESSAGES: dict[str, dict[Locale, str]] = {
         Locale.EN: "Admission denied: target agent has contacts_only policy and you are not in their contacts",
         Locale.ZH: "准入被拒绝：目标 Agent 设置了仅联系人策略，而您不在其联系人列表中",
     },
+    "agent_senders_disabled": {
+        Locale.EN: "Target agent does not accept messages from other agents",
+        Locale.ZH: "目标 Agent 不接受其他 Agent 的消息",
+    },
+    "human_senders_disabled": {
+        Locale.EN: "Target agent does not accept messages from human users",
+        Locale.ZH: "目标 Agent 不接受人类用户的消息",
+    },
+    "not_in_whitelist": {
+        Locale.EN: "Sender is not on the agent's whitelist",
+        Locale.ZH: "发送者不在该 Agent 的白名单中",
+    },
+    "agent_closed_to_new_contacts": {
+        Locale.EN: "Target agent is closed to new contacts",
+        Locale.ZH: "目标 Agent 已关闭新联系人",
+    },
+    "room_invite_requires_contact": {
+        Locale.EN: "Target agent only accepts room invites from contacts",
+        Locale.ZH: "目标 Agent 仅接受联系人发出的入群邀请",
+    },
+    "agent_closed_to_room_invites": {
+        Locale.EN: "Target agent is closed to room invites",
+        Locale.ZH: "目标 Agent 已关闭入群邀请",
+    },
     "room_is_full": {
         Locale.EN: "Room is full",
         Locale.ZH: "房间已满",
@@ -801,6 +825,30 @@ HINT_MESSAGES: dict[str, dict[Locale, str]] = {
     "admission_denied_target_contacts_only": {
         Locale.EN: "The target agent's policy requires you to be in their contacts first.",
         Locale.ZH: "目标 Agent 设置了仅联系人策略，请先添加为联系人。",
+    },
+    "agent_senders_disabled": {
+        Locale.EN: "The target agent has disabled inbound traffic from other agents.",
+        Locale.ZH: "目标 Agent 已关闭来自其他 Agent 的入站。",
+    },
+    "human_senders_disabled": {
+        Locale.EN: "The target agent has disabled inbound traffic from human users.",
+        Locale.ZH: "目标 Agent 已关闭来自人类用户的入站。",
+    },
+    "not_in_whitelist": {
+        Locale.EN: "Ask the agent owner to whitelist you (add you as a contact).",
+        Locale.ZH: "请联系该 Agent 的所有者将您加入白名单（添加为联系人）。",
+    },
+    "agent_closed_to_new_contacts": {
+        Locale.EN: "The target agent is not accepting new contacts.",
+        Locale.ZH: "目标 Agent 当前不接受新联系人。",
+    },
+    "room_invite_requires_contact": {
+        Locale.EN: "The target agent only accepts room invites from existing contacts.",
+        Locale.ZH: "目标 Agent 仅接受联系人发出的入群邀请。",
+    },
+    "agent_closed_to_room_invites": {
+        Locale.EN: "The target agent is not accepting room invites.",
+        Locale.ZH: "目标 Agent 当前不接受入群邀请。",
     },
     "room_is_full": {
         Locale.EN: "The room has reached its member limit. Ask the owner to increase max_members.",

--- a/backend/hub/main.py
+++ b/backend/hub/main.py
@@ -60,6 +60,7 @@ from app.routers.subscriptions import router as app_subscriptions_router
 from app.routers.beta import router as app_beta_router
 from app.routers.admin_beta import router as app_admin_beta_router
 from app.routers.activity import router as app_activity_router
+from app.routers.policy import router as app_policy_router
 from app.routers.prompts import router as app_prompts_router
 from app.auth import require_beta_user
 
@@ -272,5 +273,6 @@ app.include_router(app_wallet_router, dependencies=_beta_gate)
 app.include_router(app_subscriptions_router, dependencies=_beta_gate)
 app.include_router(app_beta_router)
 app.include_router(app_admin_beta_router)
+app.include_router(app_policy_router, dependencies=_beta_gate)
 app.include_router(app_prompts_router)
 app.include_router(daemon_control_router)

--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -32,9 +32,11 @@ from hub.id_generators import generate_human_id
 from hub.enums import (  # noqa: F401 — re-exported for backward compatibility
     ApprovalKind,
     ApprovalState,
+    AttentionMode,
     BetaCodeStatus,
     BetaWaitlistStatus,
     BillingInterval,
+    ContactPolicy,
     ContactRequestState,
     EndpointState,
     EntryDirection,
@@ -42,6 +44,7 @@ from hub.enums import (  # noqa: F401 — re-exported for backward compatibility
     MessagePolicy,
     MessageState,
     ParticipantType,
+    RoomInvitePolicy,
     RoomJoinPolicy,
     RoomJoinRequestStatus,
     RoomRole,
@@ -76,6 +79,33 @@ class Agent(Base):
     bio: Mapped[str | None] = mapped_column(Text, nullable=True)
     message_policy: Mapped[MessagePolicy] = mapped_column(
         Enum(MessagePolicy), nullable=False, server_default="contacts_only"
+    )
+    contact_policy: Mapped[ContactPolicy] = mapped_column(
+        Enum(ContactPolicy, name="contactpolicy", native_enum=False, length=32),
+        nullable=False,
+        default=ContactPolicy.contacts_only,
+        server_default=ContactPolicy.contacts_only.value,
+    )
+    allow_agent_sender: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=sa_text("TRUE")
+    )
+    allow_human_sender: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=sa_text("TRUE")
+    )
+    room_invite_policy: Mapped[RoomInvitePolicy] = mapped_column(
+        Enum(RoomInvitePolicy, name="roominvitepolicy", native_enum=False, length=32),
+        nullable=False,
+        default=RoomInvitePolicy.contacts_only,
+        server_default=RoomInvitePolicy.contacts_only.value,
+    )
+    default_attention: Mapped[AttentionMode] = mapped_column(
+        Enum(AttentionMode, name="attentionmode", native_enum=False, length=32),
+        nullable=False,
+        default=AttentionMode.always,
+        server_default=AttentionMode.always.value,
+    )
+    attention_keywords: Mapped[str] = mapped_column(
+        Text, nullable=False, default="[]", server_default="[]"
     )
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()

--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -380,6 +380,51 @@ class RoomMember(Base):
     )
 
 
+class AgentRoomPolicyOverride(Base):
+    """Per-room attention override for an agent (sparse).
+
+    NULL columns mean "inherit from agent default". ``muted_until`` is a
+    transient snooze timestamp; the resolver treats past values as no-op.
+
+    Admission policy is intentionally NOT scoped here — see design doc §3.2.
+    """
+
+    __tablename__ = "agent_room_policy_overrides"
+    __table_args__ = (
+        UniqueConstraint("agent_id", "room_id", name="uq_arpo_agent_room"),
+        Index("ix_arpo_agent", "agent_id"),
+    )
+
+    # ``BigInteger`` for the Postgres BIGSERIAL; in SQLite tests this maps to
+    # plain INTEGER which still supports rowid autoincrement. Mirroring the
+    # dialect-neutral pattern used elsewhere in this module.
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    agent_id: Mapped[str] = mapped_column(
+        String(32),
+        ForeignKey("agents.agent_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    room_id: Mapped[str] = mapped_column(
+        String(64),
+        ForeignKey("rooms.room_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    attention_mode: Mapped[AttentionMode | None] = mapped_column(
+        Enum(AttentionMode, name="attentionmode", native_enum=False, length=32),
+        nullable=True,
+    )
+    # JSON-encoded list[str]; NULL means inherit from the agent default.
+    keywords: Mapped[str | None] = mapped_column(Text, nullable=True)
+    muted_until: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
 class RoomJoinRequest(Base):
     __tablename__ = "room_join_requests"
     __table_args__ = (

--- a/backend/hub/policy.py
+++ b/backend/hub/policy.py
@@ -7,12 +7,16 @@
 [PROTOCOL]: Raise I18nHTTPException(403, ...) on deny, return None on allow.
 """
 
-from dataclasses import dataclass
+import datetime
+import json
+from dataclasses import dataclass, field
+from typing import Literal
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from hub.enums import (
+    AttentionMode,
     ContactPolicy,
     MessagePolicy,
     MessageType,
@@ -20,7 +24,7 @@ from hub.enums import (
     RoomInvitePolicy,
 )
 from hub.i18n import I18nHTTPException
-from hub.models import Agent, Block, Contact, RoomMember
+from hub.models import Agent, AgentRoomPolicyOverride, Block, Contact, RoomMember
 
 
 @dataclass(frozen=True)
@@ -199,3 +203,121 @@ async def check_room_invite_admission(
         )
     if policy == RoomInvitePolicy.closed:
         raise I18nHTTPException(status_code=403, message_key="agent_closed_to_room_invites")
+
+
+# ---------------------------------------------------------------------------
+# Effective attention resolver (consumed by daemon attention gate in PR3)
+# ---------------------------------------------------------------------------
+
+
+EffectiveSource = Literal["global", "override", "dm_forced"]
+
+
+@dataclass(frozen=True)
+class EffectiveAttention:
+    mode: AttentionMode
+    keywords: list[str] = field(default_factory=list)
+    muted_until: datetime.datetime | None = None
+    source: EffectiveSource = "global"
+
+
+def _is_dm_room(room_id: str | None) -> bool:
+    return bool(room_id and room_id.startswith("rm_dm_"))
+
+
+def _decode_keywords(raw: str | None) -> list[str]:
+    """Defensive JSON parse for stored keyword lists. Return ``[]`` on garbage
+    so a malformed row never breaks the daemon dispatch path."""
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [str(x) for x in parsed if isinstance(x, str)]
+
+
+def _agent_default_attention(agent: Agent) -> AttentionMode:
+    raw = getattr(agent, "default_attention", None)
+    if raw is None:
+        return AttentionMode.always
+    return raw if isinstance(raw, AttentionMode) else AttentionMode(raw)
+
+
+async def resolve_effective_attention(
+    db: AsyncSession,
+    *,
+    agent: Agent,
+    room_id: str | None,
+) -> EffectiveAttention:
+    """Resolve the effective attention policy for ``agent`` in ``room_id``.
+
+    Rules:
+      * DM rooms (``rm_dm_*``) force ``always`` regardless of any stored
+        override — see design §4.2 special case. UI must hide the controls.
+      * Otherwise: per-axis inheritance — a NULL column on the override row
+        falls back to the agent's global default.
+      * ``muted_until`` only applies if it's in the future. Past timestamps
+        are treated as expired and dropped from the result.
+    """
+    if _is_dm_room(room_id):
+        return EffectiveAttention(
+            mode=AttentionMode.always,
+            keywords=[],
+            muted_until=None,
+            source="dm_forced",
+        )
+
+    default_mode = _agent_default_attention(agent)
+    default_keywords = _decode_keywords(getattr(agent, "attention_keywords", None))
+
+    override: AgentRoomPolicyOverride | None = None
+    if room_id is not None:
+        result = await db.execute(
+            select(AgentRoomPolicyOverride).where(
+                AgentRoomPolicyOverride.agent_id == agent.agent_id,
+                AgentRoomPolicyOverride.room_id == room_id,
+            )
+        )
+        override = result.scalar_one_or_none()
+
+    if override is None:
+        return EffectiveAttention(
+            mode=default_mode,
+            keywords=list(default_keywords),
+            muted_until=None,
+            source="global",
+        )
+
+    # Per-axis inherit: NULL → fall back to agent default.
+    if override.attention_mode is None:
+        mode = default_mode
+    else:
+        mode = (
+            override.attention_mode
+            if isinstance(override.attention_mode, AttentionMode)
+            else AttentionMode(override.attention_mode)
+        )
+    keywords = (
+        _decode_keywords(override.keywords)
+        if override.keywords is not None
+        else list(default_keywords)
+    )
+
+    muted_until = override.muted_until
+    if muted_until is not None:
+        # Tolerate naive timestamps from SQLite — assume UTC.
+        now = datetime.datetime.now(datetime.timezone.utc)
+        if muted_until.tzinfo is None:
+            muted_until = muted_until.replace(tzinfo=datetime.timezone.utc)
+        if muted_until <= now:
+            muted_until = None
+
+    return EffectiveAttention(
+        mode=mode,
+        keywords=keywords,
+        muted_until=muted_until,
+        source="override",
+    )

--- a/backend/hub/policy.py
+++ b/backend/hub/policy.py
@@ -1,0 +1,201 @@
+"""
+[INPUT]: Agent admission policies (contact / room-invite) + sender identity
+[OUTPUT]: check_direct_admission / check_room_invite_admission helpers
+[POS]: Centralizes admission decisions previously scattered across hub.py /
+       room.py / dashboard.py / humans.py — every call site delegates here so
+       new policy axes (whitelist, closed, allow_*_sender) ship at one diff.
+[PROTOCOL]: Raise I18nHTTPException(403, ...) on deny, return None on allow.
+"""
+
+from dataclasses import dataclass
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from hub.enums import (
+    ContactPolicy,
+    MessagePolicy,
+    MessageType,
+    ParticipantType,
+    RoomInvitePolicy,
+)
+from hub.i18n import I18nHTTPException
+from hub.models import Agent, Block, Contact, RoomMember
+
+
+@dataclass(frozen=True)
+class Principal:
+    """A polymorphic identity — Agents (ag_*) and Humans (hu_*) collide on the
+    string id space, so callers must carry the discriminator explicitly."""
+
+    id: str
+    type: ParticipantType
+
+
+async def _is_blocked(
+    db: AsyncSession,
+    *,
+    owner_id: str,
+    target: Principal,
+) -> bool:
+    result = await db.execute(
+        select(Block).where(
+            Block.owner_id == owner_id,
+            Block.blocked_agent_id == target.id,
+            Block.blocked_type == target.type,
+        )
+    )
+    return result.scalar_one_or_none() is not None
+
+
+async def _is_contact(
+    db: AsyncSession,
+    *,
+    owner_id: str,
+    peer: Principal,
+) -> bool:
+    result = await db.execute(
+        select(Contact).where(
+            Contact.owner_id == owner_id,
+            Contact.contact_agent_id == peer.id,
+            Contact.peer_type == peer.type,
+        )
+    )
+    return result.scalar_one_or_none() is not None
+
+
+async def _shares_room(
+    db: AsyncSession,
+    *,
+    receiver_agent_id: str,
+    sender: Principal,
+) -> bool:
+    """True iff sender and receiver are co-members of any room. Used by
+    `contacts_only` to allow same-room messaging without a contacts edge."""
+    result = await db.execute(
+        select(RoomMember.room_id).where(
+            RoomMember.agent_id == receiver_agent_id,
+            RoomMember.participant_type == ParticipantType.agent,
+            RoomMember.room_id.in_(
+                select(RoomMember.room_id).where(
+                    RoomMember.agent_id == sender.id,
+                    RoomMember.participant_type == sender.type,
+                )
+            ),
+        )
+    )
+    return result.first() is not None
+
+
+def _effective_contact_policy(agent: Agent) -> ContactPolicy:
+    """Resolve the effective contact policy.
+
+    During the legacy `message_policy` migration window we honor the legacy
+    value when the new field still holds its default — so existing
+    `message_policy=open` agents stay open after a column add even if the
+    server_default backfilled `contacts_only`. Explicit tighter values
+    (`whitelist` / `closed`) always win."""
+    raw = getattr(agent, "contact_policy", None)
+    if raw is None:
+        if agent.message_policy == MessagePolicy.open:
+            return ContactPolicy.open
+        return ContactPolicy.contacts_only
+    contact = raw if isinstance(raw, ContactPolicy) else ContactPolicy(raw)
+    if (
+        contact == ContactPolicy.contacts_only
+        and agent.message_policy == MessagePolicy.open
+    ):
+        return ContactPolicy.open
+    return contact
+
+
+def _effective_room_invite_policy(agent: Agent) -> RoomInvitePolicy:
+    raw = getattr(agent, "room_invite_policy", None)
+    if raw is None:
+        return (
+            RoomInvitePolicy.open
+            if agent.message_policy == MessagePolicy.open
+            else RoomInvitePolicy.contacts_only
+        )
+    invite = raw if isinstance(raw, RoomInvitePolicy) else RoomInvitePolicy(raw)
+    if (
+        invite == RoomInvitePolicy.contacts_only
+        and agent.message_policy == MessagePolicy.open
+    ):
+        return RoomInvitePolicy.open
+    return invite
+
+
+async def check_direct_admission(
+    db: AsyncSession,
+    *,
+    sender: Principal,
+    receiver: Agent,
+    message_type: MessageType | None = None,
+    allow_same_room_bypass: bool = True,
+) -> None:
+    """Gate direct sends and Human→Room speech.
+
+    Raises I18nHTTPException(403) on deny. ``contact_request`` always passes
+    so that ``closed`` / ``whitelist`` agents can still receive friend
+    requests through the standard flow.
+    """
+    if await _is_blocked(db, owner_id=receiver.agent_id, target=sender):
+        raise I18nHTTPException(status_code=403, message_key="blocked")
+
+    if message_type == MessageType.contact_request:
+        return
+
+    if sender.type == ParticipantType.agent and not getattr(receiver, "allow_agent_sender", True):
+        raise I18nHTTPException(status_code=403, message_key="agent_senders_disabled")
+    if sender.type == ParticipantType.human and not getattr(receiver, "allow_human_sender", True):
+        raise I18nHTTPException(status_code=403, message_key="human_senders_disabled")
+
+    policy = _effective_contact_policy(receiver)
+    if policy == ContactPolicy.open:
+        return
+    if policy == ContactPolicy.contacts_only:
+        if await _is_contact(db, owner_id=receiver.agent_id, peer=sender):
+            return
+        if allow_same_room_bypass and await _shares_room(
+            db, receiver_agent_id=receiver.agent_id, sender=sender
+        ):
+            return
+        raise I18nHTTPException(status_code=403, message_key="not_in_contacts")
+    if policy == ContactPolicy.whitelist:
+        # Reuse contacts as the whitelist source — see design doc §8.1.
+        if await _is_contact(db, owner_id=receiver.agent_id, peer=sender):
+            return
+        raise I18nHTTPException(status_code=403, message_key="not_in_whitelist")
+    if policy == ContactPolicy.closed:
+        raise I18nHTTPException(status_code=403, message_key="agent_closed_to_new_contacts")
+
+
+async def check_room_invite_admission(
+    db: AsyncSession,
+    *,
+    inviter: Principal,
+    invitee: Agent,
+) -> None:
+    """Gate room-invite paths (room create initial members, add member,
+    Human→Room invite). Reads ``room_invite_policy`` and the sender-class
+    toggles. ``contact_request`` does not apply here."""
+    if await _is_blocked(db, owner_id=invitee.agent_id, target=inviter):
+        raise I18nHTTPException(status_code=403, message_key="blocked")
+
+    if inviter.type == ParticipantType.agent and not getattr(invitee, "allow_agent_sender", True):
+        raise I18nHTTPException(status_code=403, message_key="agent_senders_disabled")
+    if inviter.type == ParticipantType.human and not getattr(invitee, "allow_human_sender", True):
+        raise I18nHTTPException(status_code=403, message_key="human_senders_disabled")
+
+    policy = _effective_room_invite_policy(invitee)
+    if policy == RoomInvitePolicy.open:
+        return
+    if policy == RoomInvitePolicy.contacts_only:
+        if await _is_contact(db, owner_id=invitee.agent_id, peer=inviter):
+            return
+        raise I18nHTTPException(
+            status_code=403, message_key="room_invite_requires_contact"
+        )
+    if policy == RoomInvitePolicy.closed:
+        raise I18nHTTPException(status_code=403, message_key="agent_closed_to_room_invites")

--- a/backend/hub/routers/contacts.py
+++ b/backend/hub/routers/contacts.py
@@ -18,6 +18,7 @@ from hub.constants import DEFAULT_TTL_SEC, PROTOCOL_VERSION
 from hub.routers.hub import is_agent_ws_online
 from hub.database import get_db
 from hub.id_generators import generate_hub_msg_id
+from hub.enums import RoomInvitePolicy
 from hub.models import Agent, Block, Contact, MessagePolicy, MessageRecord, MessageState
 from hub.schemas import (
     AddBlockRequest,
@@ -348,6 +349,15 @@ async def update_policy(
         raise I18nHTTPException(status_code=404, message_key="agent_not_found")
 
     agent.message_policy = body.message_policy
+    # Dual-write the new fine-grained `contact_policy` so admission helpers
+    # see a consistent state during the legacy migration window.
+    from hub.enums import ContactPolicy as _ContactPolicy
+    if body.message_policy == MessagePolicy.open:
+        agent.contact_policy = _ContactPolicy.open
+        agent.room_invite_policy = RoomInvitePolicy.open
+    else:
+        agent.contact_policy = _ContactPolicy.contacts_only
+        agent.room_invite_policy = RoomInvitePolicy.contacts_only
     await db.commit()
     return PolicyResponse(message_policy=body.message_policy)
 

--- a/backend/hub/routers/daemon_control.py
+++ b/backend/hub/routers/daemon_control.py
@@ -544,6 +544,10 @@ _ALLOWED_DISPATCH_TYPES = {
     "set_route",
     "ping",
     "list_runtimes",
+    # PR3: BFF fans this out from PATCH /api/agents/{id}/policy and the
+    # per-room override endpoints (the latter ship in PR2). Daemon handler
+    # invalidates `policyResolver` cache for the (agent, room?) pair.
+    "policy_updated",
 }
 
 

--- a/backend/hub/routers/hub.py
+++ b/backend/hub/routers/hub.py
@@ -47,7 +47,8 @@ from hub.models import (
     Topic,
     User,
 )
-from hub.enums import ApprovalKind, ApprovalState
+from hub.enums import ApprovalKind, ApprovalState, ParticipantType
+from hub.policy import Principal, check_direct_admission
 from hub.forward import (
     RoomContext as _RoomContext,
     build_flat_text as _build_flat_text,
@@ -594,28 +595,16 @@ async def _send_direct_message(
     if receiver is None:
         raise I18nHTTPException(status_code=404, message_key="unknown_agent")
 
-    # Block check: receiver blocked sender?
-    block_result = await db.execute(
-        select(Block).where(
-            Block.owner_id == envelope.to,
-            Block.blocked_agent_id == envelope.from_,
-        )
+    # Centralized admission gate (block + contact_policy + sender-class toggles).
+    # `check_direct_admission` already short-circuits ``contact_request`` so the
+    # downstream contact-request handler still gets to run for closed/whitelist agents.
+    sender_type = ParticipantType.human if envelope.from_.startswith("hu_") else ParticipantType.agent
+    await check_direct_admission(
+        db,
+        sender=Principal(id=envelope.from_, type=sender_type),
+        receiver=receiver,
+        message_type=envelope.type,
     )
-    if block_result.scalar_one_or_none() is not None:
-        raise I18nHTTPException(status_code=403, message_key="blocked")
-
-    # Policy check: contacts_only requires sender in receiver's contact list
-    # contact_request type bypasses this check
-    if receiver.message_policy == MessagePolicy.contacts_only:
-        if envelope.type != MessageType.contact_request:
-            contact_result = await db.execute(
-                select(Contact).where(
-                    Contact.owner_id == envelope.to,
-                    Contact.contact_agent_id == envelope.from_,
-                )
-            )
-            if contact_result.scalar_one_or_none() is None:
-                raise I18nHTTPException(status_code=403, message_key="not_in_contacts")
 
     # Handle contact_request: create/update ContactRequest record
     if envelope.type == MessageType.contact_request:

--- a/backend/hub/routers/room.py
+++ b/backend/hub/routers/room.py
@@ -63,7 +63,8 @@ from hub.models import (
     SubscriptionRoomCreatorPolicy,
     SubscriptionProduct,
 )
-from hub.enums import ApprovalKind, ApprovalState
+from hub.enums import ApprovalKind, ApprovalState, ParticipantType
+from hub.policy import Principal, check_room_invite_admission
 from hub.schemas import (
     AddRoomMemberRequest,
     CreateRoomRequest,
@@ -494,25 +495,23 @@ async def create_room(
         if len(agents) != len(unique_member_ids):
             raise I18nHTTPException(status_code=400, message_key="member_ids_not_found")
 
-        # Admission policy: contacts_only agents require creator to be in their contacts
-        contacts_only_ids = [
-            a.agent_id for a in agents if a.message_policy == MessagePolicy.contacts_only
-        ]
-        if contacts_only_ids:
-            contact_result = await db.execute(
-                select(Contact.owner_id).where(
-                    Contact.owner_id.in_(contacts_only_ids),
-                    Contact.contact_agent_id == current_agent,
+        # Admission policy via the central helper — applied per-invitee so
+        # `room_invite_policy` / `allow_agent_sender` / blocks all gate consistently.
+        inviter_principal = Principal(id=current_agent, type=ParticipantType.agent)
+        denied: list[str] = []
+        for invitee in agents:
+            try:
+                await check_room_invite_admission(
+                    db, inviter=inviter_principal, invitee=invitee
                 )
+            except I18nHTTPException:
+                denied.append(invitee.agent_id)
+        if denied:
+            raise I18nHTTPException(
+                status_code=403,
+                message_key="admission_denied_contacts_only",
+                denied=str(sorted(denied)),
             )
-            has_contact = {row[0] for row in contact_result.all()}
-            denied = set(contacts_only_ids) - has_contact
-            if denied:
-                raise I18nHTTPException(
-                    status_code=403,
-                    message_key="admission_denied_contacts_only",
-                    denied=str(sorted(denied)),
-                )
 
     if body.max_members is not None and len(unique_member_ids) + 1 > body.max_members:
         raise I18nHTTPException(status_code=400, message_key="initial_members_exceed_max")
@@ -859,19 +858,22 @@ async def add_member(
         if target_agent is None:
             raise I18nHTTPException(status_code=404, message_key="agent_not_found")
 
-        # Admission policy: contacts_only agents require inviter to be in their contacts
-        if target_agent.message_policy == MessagePolicy.contacts_only:
-            contact_result = await db.execute(
-                select(Contact).where(
-                    Contact.owner_id == target_agent_id,
-                    Contact.contact_agent_id == current_agent,
-                )
+        # Admission policy via the central helper.
+        try:
+            await check_room_invite_admission(
+                db,
+                inviter=Principal(id=current_agent, type=ParticipantType.agent),
+                invitee=target_agent,
             )
-            if contact_result.scalar_one_or_none() is None:
+        except I18nHTTPException as exc:
+            # Preserve the legacy message key for the contacts_only path so
+            # existing clients keep their copy; pass through other reasons.
+            if exc.message_key == "room_invite_requires_contact":
                 raise I18nHTTPException(
                     status_code=403,
                     message_key="admission_denied_target_contacts_only",
-                )
+                ) from None
+            raise
 
         # Claimed agents: queue the invite for owner Human to approve
         if target_agent.user_id is not None:

--- a/backend/migrations/029_agent_policy_extension.sql
+++ b/backend/migrations/029_agent_policy_extension.sql
@@ -1,0 +1,59 @@
+-- Agent policy extension: split the single legacy `message_policy` column into
+-- per-axis admission (contact / room-invite) plus daemon-side attention defaults.
+--
+-- The application layer continues to dual-write `message_policy` while the
+-- legacy column is in use; a follow-up PR drops it.
+
+ALTER TABLE agents
+  ADD COLUMN IF NOT EXISTS contact_policy TEXT NOT NULL DEFAULT 'contacts_only';
+
+ALTER TABLE agents
+  ADD COLUMN IF NOT EXISTS allow_agent_sender BOOLEAN NOT NULL DEFAULT TRUE;
+
+ALTER TABLE agents
+  ADD COLUMN IF NOT EXISTS allow_human_sender BOOLEAN NOT NULL DEFAULT TRUE;
+
+ALTER TABLE agents
+  ADD COLUMN IF NOT EXISTS room_invite_policy TEXT NOT NULL DEFAULT 'contacts_only';
+
+ALTER TABLE agents
+  ADD COLUMN IF NOT EXISTS default_attention TEXT NOT NULL DEFAULT 'always';
+
+ALTER TABLE agents
+  ADD COLUMN IF NOT EXISTS attention_keywords TEXT NOT NULL DEFAULT '[]';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'ck_agents_contact_policy'
+  ) THEN
+    ALTER TABLE agents
+      ADD CONSTRAINT ck_agents_contact_policy
+      CHECK (contact_policy IN ('open','contacts_only','whitelist','closed'))
+      NOT VALID;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'ck_agents_room_invite_policy'
+  ) THEN
+    ALTER TABLE agents
+      ADD CONSTRAINT ck_agents_room_invite_policy
+      CHECK (room_invite_policy IN ('open','contacts_only','closed'))
+      NOT VALID;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'ck_agents_default_attention'
+  ) THEN
+    ALTER TABLE agents
+      ADD CONSTRAINT ck_agents_default_attention
+      CHECK (default_attention IN ('always','mention_only','keyword','muted'))
+      NOT VALID;
+  END IF;
+END $$;
+
+-- Backfill: copy the legacy `message_policy` ('open' | 'contacts_only') into
+-- `contact_policy`. `room_invite_policy` keeps the safer 'contacts_only'
+-- default — it is a stricter axis and pre-existing agents never opted in.
+UPDATE agents SET contact_policy = message_policy::text
+  WHERE contact_policy = 'contacts_only' AND message_policy IS NOT NULL;

--- a/backend/migrations/030_agent_room_policy_overrides.sql
+++ b/backend/migrations/030_agent_room_policy_overrides.sql
@@ -1,0 +1,37 @@
+-- Per-room attention overrides for agents.
+--
+-- Sparse table: rows exist only when the user wants a specific room to differ
+-- from the agent's global default. NULL columns mean "inherit from the agent".
+-- ``muted_until`` is a transient snooze timestamp (e.g. "today only"); the
+-- resolver in hub/policy.py treats past timestamps as no-op.
+--
+-- This migration only covers the attention axis (per design doc §3.2). The
+-- admission policy is intentionally NOT room-scoped — it is a Hub-side hard
+-- constraint and per-room loosening would balloon the audit surface.
+
+CREATE TABLE IF NOT EXISTS agent_room_policy_overrides (
+  id              BIGSERIAL PRIMARY KEY,
+  agent_id        TEXT        NOT NULL REFERENCES agents(agent_id) ON DELETE CASCADE,
+  room_id         TEXT        NOT NULL REFERENCES rooms(room_id)   ON DELETE CASCADE,
+  attention_mode  TEXT,
+  keywords        TEXT,
+  muted_until     TIMESTAMPTZ,
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT uq_arpo_agent_room UNIQUE (agent_id, room_id)
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'ck_arpo_attention_mode'
+  ) THEN
+    ALTER TABLE agent_room_policy_overrides
+      ADD CONSTRAINT ck_arpo_attention_mode
+      CHECK (attention_mode IS NULL
+             OR attention_mode IN ('always','mention_only','keyword','muted'))
+      NOT VALID;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS ix_arpo_agent
+  ON agent_room_policy_overrides (agent_id);

--- a/backend/tests/test_app/test_app_policy.py
+++ b/backend/tests/test_app/test_app_policy.py
@@ -186,3 +186,81 @@ async def test_policy_404_for_other_users_agent(client, seed):
         json={"contact_policy": "open"},
     )
     assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_patch_policy_dispatches_policy_updated_to_daemon(
+    client, seed, db_session, monkeypatch
+):
+    """PR3: PATCH /api/agents/{id}/policy fans out a `policy_updated` control
+    frame to the daemon hosting the agent."""
+    from sqlalchemy import select
+
+    # Bind the agent to a daemon so the dispatch fires.
+    row = await db_session.execute(select(Agent).where(Agent.agent_id == "ag_owned"))
+    agent = row.scalar_one()
+    agent.daemon_instance_id = "di_fake"
+    await db_session.commit()
+
+    calls: list[dict] = []
+
+    async def fake_send(daemon_instance_id, type_, params=None, timeout_ms=None):
+        calls.append(
+            {
+                "daemon_instance_id": daemon_instance_id,
+                "type": type_,
+                "params": params,
+            }
+        )
+        return {"ok": True, "result": {"applied": True}}
+
+    import app.routers.policy as policy_mod
+
+    monkeypatch.setattr(policy_mod, "is_daemon_online", lambda _id: True)
+    monkeypatch.setattr(policy_mod, "send_control_frame", fake_send)
+
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    r = await client.patch(
+        "/api/agents/ag_owned/policy",
+        headers=headers,
+        json={"default_attention": "mention_only", "attention_keywords": ["alpha"]},
+    )
+    assert r.status_code == 200, r.text
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["daemon_instance_id"] == "di_fake"
+    assert call["type"] == "policy_updated"
+    assert call["params"]["agent_id"] == "ag_owned"
+    assert call["params"]["policy"]["mode"] == "mention_only"
+    assert call["params"]["policy"]["keywords"] == ["alpha"]
+
+
+@pytest.mark.asyncio
+async def test_patch_policy_swallows_dispatch_failure(
+    client, seed, db_session, monkeypatch
+):
+    """PR3: a dispatch error must NOT 500 the BFF — best-effort fan-out."""
+    from sqlalchemy import select
+    from fastapi import HTTPException
+
+    row = await db_session.execute(select(Agent).where(Agent.agent_id == "ag_owned"))
+    agent = row.scalar_one()
+    agent.daemon_instance_id = "di_offline"
+    await db_session.commit()
+
+    async def boom(*args, **kwargs):
+        raise HTTPException(status_code=409, detail="daemon_offline")
+
+    import app.routers.policy as policy_mod
+
+    monkeypatch.setattr(policy_mod, "is_daemon_online", lambda _id: True)
+    monkeypatch.setattr(policy_mod, "send_control_frame", boom)
+
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    r = await client.patch(
+        "/api/agents/ag_owned/policy",
+        headers=headers,
+        json={"default_attention": "muted"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["default_attention"] == "muted"

--- a/backend/tests/test_app/test_app_policy.py
+++ b/backend/tests/test_app/test_app_policy.py
@@ -1,0 +1,188 @@
+"""Tests for /api/agents/{agent_id}/policy (BFF — global agent policy)."""
+
+import datetime
+import uuid
+
+import jwt
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+from unittest.mock import AsyncMock
+
+from hub.enums import AttentionMode, ContactPolicy, MessagePolicy, RoomInvitePolicy
+from hub.models import Agent, Base, Role, User, UserRole
+
+TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
+TEST_SUPABASE_SECRET = "test-supabase-jwt-secret-for-unit-tests"
+
+
+def _token(sub: str) -> str:
+    payload = {
+        "sub": sub,
+        "aud": "authenticated",
+        "exp": datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=1),
+        "iss": "supabase",
+    }
+    return jwt.encode(payload, TEST_SUPABASE_SECRET, algorithm="HS256")
+
+
+@pytest_asyncio.fixture
+async def db_engine():
+    engine = create_async_engine(
+        TEST_DB_URL,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        execution_options={"schema_translate_map": {"public": None}},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield engine
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def db_session(db_engine):
+    factory = async_sessionmaker(db_engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+
+
+@pytest_asyncio.fixture
+async def client(db_session, monkeypatch):
+    import hub.config
+    monkeypatch.setattr(hub.config, "SUPABASE_JWT_SECRET", TEST_SUPABASE_SECRET)
+    monkeypatch.setattr(hub.config, "BETA_GATE_ENABLED", False)
+    import app.auth
+    monkeypatch.setattr(app.auth, "SUPABASE_JWT_SECRET", TEST_SUPABASE_SECRET)
+
+    from hub.main import app
+    from hub.database import get_db
+
+    async def _override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.state.http_client = AsyncMock()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def seed(db_session: AsyncSession):
+    supabase_uuid = uuid.uuid4()
+    user_id = uuid.uuid4()
+    user = User(
+        id=user_id,
+        display_name="U",
+        email="u@example.com",
+        status="active",
+        supabase_user_id=supabase_uuid,
+    )
+    role = Role(id=uuid.uuid4(), name="member", display_name="Member", is_system=True, priority=0)
+    db_session.add_all([user, role])
+    await db_session.flush()
+    db_session.add(UserRole(id=uuid.uuid4(), user_id=user_id, role_id=role.id))
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    agent = Agent(
+        agent_id="ag_owned",
+        display_name="Mine",
+        bio="b",
+        message_policy=MessagePolicy.contacts_only,
+        user_id=user_id,
+        claimed_at=now,
+    )
+    other_user = User(
+        id=uuid.uuid4(),
+        display_name="Other",
+        email="o@example.com",
+        status="active",
+        supabase_user_id=uuid.uuid4(),
+    )
+    other_agent = Agent(
+        agent_id="ag_other",
+        display_name="Other",
+        bio="b",
+        message_policy=MessagePolicy.contacts_only,
+        user_id=other_user.id,
+        claimed_at=now,
+    )
+    db_session.add_all([agent, other_user, other_agent])
+    await db_session.commit()
+    return {"token": _token(str(supabase_uuid))}
+
+
+@pytest.mark.asyncio
+async def test_get_policy_defaults(client, seed):
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    r = await client.get("/api/agents/ag_owned/policy", headers=headers)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["contact_policy"] == "contacts_only"
+    assert body["allow_agent_sender"] is True
+    assert body["allow_human_sender"] is True
+    assert body["room_invite_policy"] == "contacts_only"
+    assert body["default_attention"] == "always"
+    assert body["attention_keywords"] == []
+
+
+@pytest.mark.asyncio
+async def test_patch_policy_updates_fields_and_dual_writes_message_policy(
+    client, seed, db_session
+):
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    r = await client.patch(
+        "/api/agents/ag_owned/policy",
+        headers=headers,
+        json={
+            "contact_policy": "open",
+            "room_invite_policy": "closed",
+            "default_attention": "keyword",
+            "attention_keywords": ["alpha", "  ", "beta"],
+            "allow_agent_sender": False,
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["contact_policy"] == "open"
+    assert body["room_invite_policy"] == "closed"
+    assert body["default_attention"] == "keyword"
+    assert body["attention_keywords"] == ["alpha", "beta"]
+    assert body["allow_agent_sender"] is False
+
+    # Legacy `message_policy` is dual-written to keep older readers consistent.
+    from sqlalchemy import select
+    row = await db_session.execute(select(Agent).where(Agent.agent_id == "ag_owned"))
+    agent = row.scalar_one()
+    assert agent.message_policy == MessagePolicy.open
+
+
+@pytest.mark.asyncio
+async def test_patch_policy_rejects_unknown_value(client, seed):
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    r = await client.patch(
+        "/api/agents/ag_owned/policy",
+        headers=headers,
+        json={"contact_policy": "bogus"},
+    )
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_policy_404_for_other_users_agent(client, seed):
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    r = await client.get("/api/agents/ag_other/policy", headers=headers)
+    assert r.status_code == 404
+    r = await client.patch(
+        "/api/agents/ag_other/policy",
+        headers=headers,
+        json={"contact_policy": "open"},
+    )
+    assert r.status_code == 404

--- a/backend/tests/test_app/test_app_policy.py
+++ b/backend/tests/test_app/test_app_policy.py
@@ -11,8 +11,24 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from sqlalchemy.pool import StaticPool
 from unittest.mock import AsyncMock
 
-from hub.enums import AttentionMode, ContactPolicy, MessagePolicy, RoomInvitePolicy
-from hub.models import Agent, Base, Role, User, UserRole
+from hub.enums import (
+    AttentionMode,
+    ContactPolicy,
+    MessagePolicy,
+    ParticipantType,
+    RoomInvitePolicy,
+    RoomJoinPolicy,
+    RoomVisibility,
+)
+from hub.models import (
+    Agent,
+    AgentRoomPolicyOverride,
+    Base,
+    Role,
+    Room,
+    User,
+    UserRole,
+)
 
 TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
 TEST_SUPABASE_SECRET = "test-supabase-jwt-secret-for-unit-tests"
@@ -186,3 +202,197 @@ async def test_policy_404_for_other_users_agent(client, seed):
         json={"contact_policy": "open"},
     )
     assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Per-room override (/rooms/{room_id}/policy + /snooze)
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def room_seed(db_session: AsyncSession, seed):
+    """Builds on ``seed`` — adds a public room and a DM room to the schema."""
+    room = Room(
+        room_id="rm_pub_1",
+        name="Public Room",
+        description="",
+        owner_id="ag_owned",
+        owner_type=ParticipantType.agent,
+        visibility=RoomVisibility.public,
+        join_policy=RoomJoinPolicy.open,
+    )
+    dm = Room(
+        room_id="rm_dm_xyz",
+        name="DM",
+        description="",
+        owner_id="ag_owned",
+        owner_type=ParticipantType.agent,
+        visibility=RoomVisibility.private,
+        join_policy=RoomJoinPolicy.invite_only,
+    )
+    db_session.add_all([room, dm])
+    await db_session.commit()
+    return seed
+
+
+@pytest.mark.asyncio
+async def test_get_room_policy_inherits_when_no_override(client, room_seed):
+    headers = {"Authorization": f"Bearer {room_seed['token']}"}
+    r = await client.get("/api/agents/ag_owned/rooms/rm_pub_1/policy", headers=headers)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["inherits_global"] is True
+    assert body["override"] is None
+    assert body["effective"]["mode"] == "always"
+    assert body["effective"]["source"] == "global"
+
+
+@pytest.mark.asyncio
+async def test_put_then_get_room_policy_mixed_inherit(client, room_seed):
+    headers = {"Authorization": f"Bearer {room_seed['token']}"}
+    # Set agent default to keyword + ['hi'] first so we can verify keyword inheritance.
+    r = await client.patch(
+        "/api/agents/ag_owned/policy",
+        headers=headers,
+        json={"default_attention": "keyword", "attention_keywords": ["hi"]},
+    )
+    assert r.status_code == 200, r.text
+
+    # Override only the mode; leave keywords as inherit.
+    r = await client.put(
+        "/api/agents/ag_owned/rooms/rm_pub_1/policy",
+        headers=headers,
+        json={"attention_mode": "mention_only", "keywords": None},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["inherits_global"] is False
+    assert body["override"]["attention_mode"] == "mention_only"
+    assert body["override"]["keywords"] is None
+    assert body["effective"]["mode"] == "mention_only"
+    # Inherited keywords surface in `effective`.
+    assert body["effective"]["keywords"] == ["hi"]
+    assert body["effective"]["source"] == "override"
+
+    # GET reflects the same.
+    r = await client.get("/api/agents/ag_owned/rooms/rm_pub_1/policy", headers=headers)
+    assert r.status_code == 200
+    assert r.json()["override"]["attention_mode"] == "mention_only"
+
+
+@pytest.mark.asyncio
+async def test_delete_room_policy_restores_inherit(client, room_seed):
+    headers = {"Authorization": f"Bearer {room_seed['token']}"}
+    r = await client.put(
+        "/api/agents/ag_owned/rooms/rm_pub_1/policy",
+        headers=headers,
+        json={"attention_mode": "muted", "keywords": None},
+    )
+    assert r.status_code == 200
+    r = await client.delete(
+        "/api/agents/ag_owned/rooms/rm_pub_1/policy", headers=headers
+    )
+    assert r.status_code == 204
+    # Idempotent re-delete.
+    r = await client.delete(
+        "/api/agents/ag_owned/rooms/rm_pub_1/policy", headers=headers
+    )
+    assert r.status_code == 204
+    r = await client.get("/api/agents/ag_owned/rooms/rm_pub_1/policy", headers=headers)
+    body = r.json()
+    assert body["inherits_global"] is True
+    assert body["override"] is None
+
+
+@pytest.mark.asyncio
+async def test_snooze_sets_muted_until_then_clears(client, room_seed):
+    headers = {"Authorization": f"Bearer {room_seed['token']}"}
+    r = await client.post(
+        "/api/agents/ag_owned/rooms/rm_pub_1/snooze",
+        headers=headers,
+        json={"minutes": 60},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["override"]["muted_until"] is not None
+    assert body["effective"]["muted_until"] is not None
+
+    # minutes=0 clears
+    r = await client.post(
+        "/api/agents/ag_owned/rooms/rm_pub_1/snooze",
+        headers=headers,
+        json={"minutes": 0},
+    )
+    assert r.status_code == 200
+    assert r.json()["override"]["muted_until"] is None
+
+
+@pytest.mark.asyncio
+async def test_snooze_validates_range(client, room_seed):
+    headers = {"Authorization": f"Bearer {room_seed['token']}"}
+    r = await client.post(
+        "/api/agents/ag_owned/rooms/rm_pub_1/snooze",
+        headers=headers,
+        json={"minutes": -1},
+    )
+    assert r.status_code == 422
+    r = await client.post(
+        "/api/agents/ag_owned/rooms/rm_pub_1/snooze",
+        headers=headers,
+        json={"minutes": 999_999},
+    )
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_dm_room_rejects_put_and_snooze(client, room_seed):
+    headers = {"Authorization": f"Bearer {room_seed['token']}"}
+    r = await client.put(
+        "/api/agents/ag_owned/rooms/rm_dm_xyz/policy",
+        headers=headers,
+        json={"attention_mode": "muted", "keywords": None},
+    )
+    assert r.status_code == 400
+    r = await client.post(
+        "/api/agents/ag_owned/rooms/rm_dm_xyz/snooze",
+        headers=headers,
+        json={"minutes": 30},
+    )
+    assert r.status_code == 400
+    # GET still works and reports dm_forced=always.
+    r = await client.get(
+        "/api/agents/ag_owned/rooms/rm_dm_xyz/policy", headers=headers
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["effective"]["mode"] == "always"
+    assert body["effective"]["source"] == "dm_forced"
+
+
+@pytest.mark.asyncio
+async def test_room_policy_404_for_other_users_agent(client, room_seed):
+    headers = {"Authorization": f"Bearer {room_seed['token']}"}
+    r = await client.get(
+        "/api/agents/ag_other/rooms/rm_pub_1/policy", headers=headers
+    )
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_room_policy_404_for_unknown_room(client, room_seed):
+    headers = {"Authorization": f"Bearer {room_seed['token']}"}
+    r = await client.get(
+        "/api/agents/ag_owned/rooms/rm_nope/policy", headers=headers
+    )
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_put_room_policy_rejects_bad_enum(client, room_seed):
+    headers = {"Authorization": f"Bearer {room_seed['token']}"}
+    r = await client.put(
+        "/api/agents/ag_owned/rooms/rm_pub_1/policy",
+        headers=headers,
+        json={"attention_mode": "bogus", "keywords": None},
+    )
+    assert r.status_code == 422

--- a/backend/tests/test_app/test_app_policy.py
+++ b/backend/tests/test_app/test_app_policy.py
@@ -474,3 +474,127 @@ async def test_patch_policy_swallows_dispatch_failure(
     )
     assert r.status_code == 200, r.text
     assert r.json()["default_attention"] == "muted"
+
+
+@pytest.mark.asyncio
+async def test_put_room_override_dispatches_with_embedded_policy(
+    client, room_seed, db_session, monkeypatch
+):
+    """PUT must fan out the post-mutation effective policy so the daemon's
+    cache can install it directly. Prior to this fix PUT did not dispatch
+    at all and the daemon kept stale state until TTL."""
+    from sqlalchemy import select
+
+    row = await db_session.execute(select(Agent).where(Agent.agent_id == "ag_owned"))
+    agent = row.scalar_one()
+    agent.daemon_instance_id = "di_x"
+    await db_session.commit()
+
+    calls: list[dict] = []
+
+    async def fake_send(daemon_instance_id, type_, params=None, timeout_ms=None):
+        calls.append({"daemon_instance_id": daemon_instance_id, "type": type_, "params": params})
+        return {"ok": True, "result": {"applied": True}}
+
+    import app.routers.policy as policy_mod
+
+    monkeypatch.setattr(policy_mod, "is_daemon_online", lambda _id: True)
+    monkeypatch.setattr(policy_mod, "send_control_frame", fake_send)
+
+    headers = {"Authorization": f"Bearer {room_seed['token']}"}
+    r = await client.put(
+        "/api/agents/ag_owned/rooms/rm_pub_1/policy",
+        headers=headers,
+        json={"attention_mode": "mention_only", "keywords": None},
+    )
+    assert r.status_code == 200, r.text
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["type"] == "policy_updated"
+    assert call["params"]["agent_id"] == "ag_owned"
+    assert call["params"]["room_id"] == "rm_pub_1"
+    assert call["params"]["policy"]["mode"] == "mention_only"
+
+
+@pytest.mark.asyncio
+async def test_snooze_dispatches_with_muted_until(
+    client, room_seed, db_session, monkeypatch
+):
+    """Snooze must embed the resulting policy (including muted_until); without
+    it the daemon would invalidate the room key and fall back to the global,
+    which has no muted_until — losing the snooze entirely."""
+    from sqlalchemy import select
+
+    row = await db_session.execute(select(Agent).where(Agent.agent_id == "ag_owned"))
+    agent = row.scalar_one()
+    agent.daemon_instance_id = "di_x"
+    await db_session.commit()
+
+    calls: list[dict] = []
+
+    async def fake_send(daemon_instance_id, type_, params=None, timeout_ms=None):
+        calls.append({"daemon_instance_id": daemon_instance_id, "type": type_, "params": params})
+        return {"ok": True, "result": {"applied": True}}
+
+    import app.routers.policy as policy_mod
+
+    monkeypatch.setattr(policy_mod, "is_daemon_online", lambda _id: True)
+    monkeypatch.setattr(policy_mod, "send_control_frame", fake_send)
+
+    headers = {"Authorization": f"Bearer {room_seed['token']}"}
+    r = await client.post(
+        "/api/agents/ag_owned/rooms/rm_pub_1/snooze",
+        headers=headers,
+        json={"minutes": 60},
+    )
+    assert r.status_code == 200, r.text
+    assert len(calls) == 1
+    payload = calls[0]["params"]
+    assert payload["room_id"] == "rm_pub_1"
+    assert payload["policy"]["mode"] == "always"
+    assert isinstance(payload["policy"]["muted_until"], int)
+    assert payload["policy"]["muted_until"] > 0
+
+
+@pytest.mark.asyncio
+async def test_delete_room_override_dispatches_invalidate_only(
+    client, room_seed, db_session, monkeypatch
+):
+    """DELETE leaves the per-room slot empty so the daemon falls back to the
+    cached global. The frame should carry agent_id + room_id, no policy."""
+    from sqlalchemy import select
+
+    row = await db_session.execute(select(Agent).where(Agent.agent_id == "ag_owned"))
+    agent = row.scalar_one()
+    agent.daemon_instance_id = "di_x"
+    await db_session.commit()
+
+    # Seed an override so the DELETE has something to remove.
+    headers = {"Authorization": f"Bearer {room_seed['token']}"}
+    r = await client.put(
+        "/api/agents/ag_owned/rooms/rm_pub_1/policy",
+        headers=headers,
+        json={"attention_mode": "muted", "keywords": None},
+    )
+    assert r.status_code == 200
+
+    calls: list[dict] = []
+
+    async def fake_send(daemon_instance_id, type_, params=None, timeout_ms=None):
+        calls.append({"params": params})
+        return {"ok": True, "result": {}}
+
+    import app.routers.policy as policy_mod
+
+    monkeypatch.setattr(policy_mod, "is_daemon_online", lambda _id: True)
+    monkeypatch.setattr(policy_mod, "send_control_frame", fake_send)
+
+    r = await client.delete(
+        "/api/agents/ag_owned/rooms/rm_pub_1/policy", headers=headers
+    )
+    assert r.status_code == 204
+    assert len(calls) == 1
+    payload = calls[0]["params"]
+    assert payload["agent_id"] == "ag_owned"
+    assert payload["room_id"] == "rm_pub_1"
+    assert "policy" not in payload

--- a/backend/tests/test_app/test_daemon_control.py
+++ b/backend/tests/test_app/test_daemon_control.py
@@ -874,3 +874,53 @@ async def test_refresh_runtimes_daemon_disconnect_returns_502(
         assert detail["code"] == "daemon_disconnected"
     finally:
         await registry.unregister(conn)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_policy_updated_is_allowed(
+    client: AsyncClient, seed_user, monkeypatch
+):
+    """PR3: `policy_updated` must be in the dispatch allowlist."""
+    bundle = await _provision_instance_via_device_code(client, seed_user)
+    instance_id = bundle["daemon_instance_id"]
+
+    from hub.routers.daemon_control import _DaemonConn, _registry_for_tests
+
+    fake_ws = _FakeWS()
+    conn = _DaemonConn(
+        ws=fake_ws,  # type: ignore[arg-type]
+        user_id=str(seed_user["user_id"]),
+        daemon_instance_id=instance_id,
+        pending_acks={},
+    )
+    registry = _registry_for_tests()
+    await registry.register(conn)
+    try:
+        async def _reply_when_sent() -> None:
+            for _ in range(50):
+                if fake_ws.sent:
+                    break
+                await asyncio.sleep(0.01)
+            assert fake_ws.sent, "dispatch never wrote to the fake WS"
+            sent_frame = json.loads(fake_ws.sent[0])
+            assert sent_frame["type"] == "policy_updated"
+            ack = {"id": sent_frame["id"], "ok": True, "result": {"applied": True}}
+            fut = conn.pending_acks.get(sent_frame["id"])
+            assert fut is not None
+            fut.set_result(ack)
+
+        reply_task = asyncio.create_task(_reply_when_sent())
+        r = await client.post(
+            f"/daemon/instances/{instance_id}/dispatch",
+            json={
+                "type": "policy_updated",
+                "params": {"agent_id": "ag_test"},
+                "timeout_ms": 2000,
+            },
+            headers={"Authorization": f"Bearer {seed_user['token']}"},
+        )
+        await reply_task
+        assert r.status_code == 200, r.text
+        assert r.json()["ack"]["ok"] is True
+    finally:
+        await registry.unregister(conn)

--- a/backend/tests/test_policy_helpers.py
+++ b/backend/tests/test_policy_helpers.py
@@ -1,0 +1,306 @@
+"""Unit tests for hub.policy admission helpers.
+
+Coverage matrix (per design doc §4.1):
+  * sender_type ∈ {agent, human}  ×  op ∈ {direct, room_invite}
+  * contact_policy ∈ {open, contacts_only, whitelist, closed}
+  * room_invite_policy ∈ {open, contacts_only, closed}
+  * allow_agent_sender / allow_human_sender toggles
+  * Block precedence
+  * contact_request passthrough on direct
+  * legacy message_policy fallback
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from hub.enums import (
+    AttentionMode,
+    ContactPolicy,
+    MessagePolicy,
+    MessageType,
+    ParticipantType,
+    RoomInvitePolicy,
+)
+from hub.i18n import I18nHTTPException
+from hub.models import Agent, Base, Block, Contact
+from hub.policy import (
+    Principal,
+    check_direct_admission,
+    check_room_invite_admission,
+)
+
+
+def _engine():
+    from tests.test_app.conftest import create_test_engine
+    return create_test_engine()
+
+
+@pytest_asyncio.fixture
+async def session():
+    engine = _engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+def _agent(
+    agent_id: str = "ag_receiver",
+    *,
+    contact_policy: ContactPolicy = ContactPolicy.contacts_only,
+    room_invite_policy: RoomInvitePolicy = RoomInvitePolicy.contacts_only,
+    message_policy: MessagePolicy = MessagePolicy.contacts_only,
+    allow_agent_sender: bool = True,
+    allow_human_sender: bool = True,
+) -> Agent:
+    return Agent(
+        agent_id=agent_id,
+        display_name="Receiver",
+        bio="x",
+        message_policy=message_policy,
+        contact_policy=contact_policy,
+        room_invite_policy=room_invite_policy,
+        allow_agent_sender=allow_agent_sender,
+        allow_human_sender=allow_human_sender,
+        default_attention=AttentionMode.always,
+        attention_keywords="[]",
+    )
+
+
+async def _add(session: AsyncSession, *objs):
+    for o in objs:
+        session.add(o)
+    await session.commit()
+
+
+def _agent_principal(id_: str = "ag_sender") -> Principal:
+    return Principal(id=id_, type=ParticipantType.agent)
+
+
+def _human_principal(id_: str = "hu_sender") -> Principal:
+    return Principal(id=id_, type=ParticipantType.human)
+
+
+# ---------------------------------------------------------------------------
+# check_direct_admission
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_direct_open_allows_anyone(session):
+    receiver = _agent(contact_policy=ContactPolicy.open, message_policy=MessagePolicy.open)
+    await _add(session, receiver)
+    await check_direct_admission(session, sender=_agent_principal(), receiver=receiver)
+    await check_direct_admission(session, sender=_human_principal(), receiver=receiver)
+
+
+@pytest.mark.asyncio
+async def test_direct_contacts_only_blocks_strangers(session):
+    receiver = _agent(contact_policy=ContactPolicy.contacts_only)
+    await _add(session, receiver)
+    with pytest.raises(I18nHTTPException) as exc:
+        await check_direct_admission(session, sender=_agent_principal(), receiver=receiver)
+    assert exc.value.message_key == "not_in_contacts"
+
+
+@pytest.mark.asyncio
+async def test_direct_contacts_only_allows_contacts(session):
+    receiver = _agent(contact_policy=ContactPolicy.contacts_only)
+    contact = Contact(
+        owner_id="ag_receiver",
+        owner_type=ParticipantType.agent,
+        contact_agent_id="ag_sender",
+        peer_type=ParticipantType.agent,
+    )
+    await _add(session, receiver, contact)
+    await check_direct_admission(session, sender=_agent_principal(), receiver=receiver)
+
+
+@pytest.mark.asyncio
+async def test_direct_whitelist_requires_contact(session):
+    receiver = _agent(contact_policy=ContactPolicy.whitelist)
+    await _add(session, receiver)
+    with pytest.raises(I18nHTTPException) as exc:
+        await check_direct_admission(session, sender=_human_principal(), receiver=receiver)
+    assert exc.value.message_key == "not_in_whitelist"
+
+    contact = Contact(
+        owner_id="ag_receiver",
+        owner_type=ParticipantType.agent,
+        contact_agent_id="hu_sender",
+        peer_type=ParticipantType.human,
+    )
+    session.add(contact)
+    await session.commit()
+    await check_direct_admission(session, sender=_human_principal(), receiver=receiver)
+
+
+@pytest.mark.asyncio
+async def test_direct_closed_rejects_everyone_but_contact_request(session):
+    receiver = _agent(contact_policy=ContactPolicy.closed)
+    await _add(session, receiver)
+    with pytest.raises(I18nHTTPException) as exc:
+        await check_direct_admission(session, sender=_agent_principal(), receiver=receiver)
+    assert exc.value.message_key == "agent_closed_to_new_contacts"
+
+    # contact_request always passes — otherwise the friend-request flow dies.
+    await check_direct_admission(
+        session,
+        sender=_agent_principal(),
+        receiver=receiver,
+        message_type=MessageType.contact_request,
+    )
+
+
+@pytest.mark.asyncio
+async def test_direct_block_precedes_contact_request(session):
+    receiver = _agent(contact_policy=ContactPolicy.open)
+    block = Block(
+        owner_id="ag_receiver",
+        owner_type=ParticipantType.agent,
+        blocked_agent_id="ag_sender",
+        blocked_type=ParticipantType.agent,
+    )
+    await _add(session, receiver, block)
+    with pytest.raises(I18nHTTPException) as exc:
+        await check_direct_admission(
+            session,
+            sender=_agent_principal(),
+            receiver=receiver,
+            message_type=MessageType.contact_request,
+        )
+    assert exc.value.message_key == "blocked"
+
+
+@pytest.mark.asyncio
+async def test_direct_allow_agent_sender_off(session):
+    receiver = _agent(
+        contact_policy=ContactPolicy.open,
+        message_policy=MessagePolicy.open,
+        allow_agent_sender=False,
+    )
+    await _add(session, receiver)
+    with pytest.raises(I18nHTTPException) as exc:
+        await check_direct_admission(session, sender=_agent_principal(), receiver=receiver)
+    assert exc.value.message_key == "agent_senders_disabled"
+    # Humans still pass.
+    await check_direct_admission(session, sender=_human_principal(), receiver=receiver)
+
+
+@pytest.mark.asyncio
+async def test_direct_allow_human_sender_off(session):
+    receiver = _agent(
+        contact_policy=ContactPolicy.open,
+        message_policy=MessagePolicy.open,
+        allow_human_sender=False,
+    )
+    await _add(session, receiver)
+    with pytest.raises(I18nHTTPException) as exc:
+        await check_direct_admission(session, sender=_human_principal(), receiver=receiver)
+    assert exc.value.message_key == "human_senders_disabled"
+
+
+# ---------------------------------------------------------------------------
+# check_room_invite_admission
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_room_invite_open(session):
+    invitee = _agent(
+        room_invite_policy=RoomInvitePolicy.open, message_policy=MessagePolicy.open
+    )
+    await _add(session, invitee)
+    await check_room_invite_admission(session, inviter=_agent_principal(), invitee=invitee)
+    await check_room_invite_admission(session, inviter=_human_principal(), invitee=invitee)
+
+
+@pytest.mark.asyncio
+async def test_room_invite_contacts_only(session):
+    invitee = _agent(room_invite_policy=RoomInvitePolicy.contacts_only)
+    await _add(session, invitee)
+    with pytest.raises(I18nHTTPException) as exc:
+        await check_room_invite_admission(
+            session, inviter=_human_principal(), invitee=invitee
+        )
+    assert exc.value.message_key == "room_invite_requires_contact"
+
+    contact = Contact(
+        owner_id="ag_receiver",
+        owner_type=ParticipantType.agent,
+        contact_agent_id="hu_sender",
+        peer_type=ParticipantType.human,
+    )
+    session.add(contact)
+    await session.commit()
+    await check_room_invite_admission(
+        session, inviter=_human_principal(), invitee=invitee
+    )
+
+
+@pytest.mark.asyncio
+async def test_room_invite_closed(session):
+    invitee = _agent(room_invite_policy=RoomInvitePolicy.closed)
+    await _add(session, invitee)
+    with pytest.raises(I18nHTTPException) as exc:
+        await check_room_invite_admission(session, inviter=_agent_principal(), invitee=invitee)
+    assert exc.value.message_key == "agent_closed_to_room_invites"
+
+
+@pytest.mark.asyncio
+async def test_room_invite_blocks_first(session):
+    invitee = _agent(room_invite_policy=RoomInvitePolicy.open)
+    block = Block(
+        owner_id="ag_receiver",
+        owner_type=ParticipantType.agent,
+        blocked_agent_id="hu_sender",
+        blocked_type=ParticipantType.human,
+    )
+    await _add(session, invitee, block)
+    with pytest.raises(I18nHTTPException) as exc:
+        await check_room_invite_admission(
+            session, inviter=_human_principal(), invitee=invitee
+        )
+    assert exc.value.message_key == "blocked"
+
+
+# ---------------------------------------------------------------------------
+# Legacy message_policy fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_legacy_message_policy_open_overrides_default_contact_policy(session):
+    """Migration backfill safety: rows whose contact_policy is still the
+    server_default `contacts_only` but whose legacy `message_policy=open`
+    must continue to admit strangers."""
+    receiver = _agent(
+        contact_policy=ContactPolicy.contacts_only,
+        message_policy=MessagePolicy.open,
+    )
+    await _add(session, receiver)
+    await check_direct_admission(session, sender=_agent_principal(), receiver=receiver)
+    await check_room_invite_admission(
+        session, inviter=_agent_principal(), invitee=receiver
+    )
+
+
+@pytest.mark.asyncio
+async def test_explicit_whitelist_wins_over_legacy_open(session):
+    """If the new column is explicitly stricter than `contacts_only`, the
+    legacy `message_policy=open` does not relax it."""
+    receiver = _agent(
+        contact_policy=ContactPolicy.whitelist,
+        message_policy=MessagePolicy.open,
+    )
+    await _add(session, receiver)
+    with pytest.raises(I18nHTTPException) as exc:
+        await check_direct_admission(session, sender=_agent_principal(), receiver=receiver)
+    assert exc.value.message_key == "not_in_whitelist"

--- a/backend/tests/test_policy_helpers.py
+++ b/backend/tests/test_policy_helpers.py
@@ -16,6 +16,8 @@ import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+import datetime
+
 from hub.enums import (
     AttentionMode,
     ContactPolicy,
@@ -25,11 +27,12 @@ from hub.enums import (
     RoomInvitePolicy,
 )
 from hub.i18n import I18nHTTPException
-from hub.models import Agent, Base, Block, Contact
+from hub.models import Agent, AgentRoomPolicyOverride, Base, Block, Contact
 from hub.policy import (
     Principal,
     check_direct_admission,
     check_room_invite_admission,
+    resolve_effective_attention,
 )
 
 
@@ -304,3 +307,104 @@ async def test_explicit_whitelist_wins_over_legacy_open(session):
     with pytest.raises(I18nHTTPException) as exc:
         await check_direct_admission(session, sender=_agent_principal(), receiver=receiver)
     assert exc.value.message_key == "not_in_whitelist"
+
+
+# ---------------------------------------------------------------------------
+# resolve_effective_attention
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolver_inherits_global_when_no_override(session):
+    receiver = _agent()
+    receiver.default_attention = AttentionMode.mention_only
+    receiver.attention_keywords = '["hello", "world"]'
+    await _add(session, receiver)
+    eff = await resolve_effective_attention(session, agent=receiver, room_id="rm_pub_1")
+    assert eff.mode == AttentionMode.mention_only
+    assert eff.keywords == ["hello", "world"]
+    assert eff.muted_until is None
+    assert eff.source == "global"
+
+
+@pytest.mark.asyncio
+async def test_resolver_override_partial_inherit(session):
+    receiver = _agent()
+    receiver.default_attention = AttentionMode.always
+    receiver.attention_keywords = '["alpha"]'
+    await _add(session, receiver)
+    # Only override the mode; keywords stay inherited.
+    session.add(
+        AgentRoomPolicyOverride(
+            agent_id="ag_receiver",
+            room_id="rm_pub_1",
+            attention_mode=AttentionMode.keyword,
+            keywords=None,
+        )
+    )
+    await session.commit()
+    eff = await resolve_effective_attention(session, agent=receiver, room_id="rm_pub_1")
+    assert eff.mode == AttentionMode.keyword
+    assert eff.keywords == ["alpha"]
+    assert eff.source == "override"
+
+
+@pytest.mark.asyncio
+async def test_resolver_dm_room_forces_always(session):
+    receiver = _agent()
+    receiver.default_attention = AttentionMode.muted
+    await _add(session, receiver)
+    # Even a stray override row must not affect DMs.
+    session.add(
+        AgentRoomPolicyOverride(
+            agent_id="ag_receiver",
+            room_id="rm_dm_xyz",
+            attention_mode=AttentionMode.muted,
+        )
+    )
+    await session.commit()
+    eff = await resolve_effective_attention(session, agent=receiver, room_id="rm_dm_xyz")
+    assert eff.mode == AttentionMode.always
+    assert eff.source == "dm_forced"
+
+
+@pytest.mark.asyncio
+async def test_resolver_muted_until_future_vs_past(session):
+    receiver = _agent()
+    await _add(session, receiver)
+    now = datetime.datetime.now(datetime.timezone.utc)
+    future = now + datetime.timedelta(minutes=30)
+    session.add(
+        AgentRoomPolicyOverride(
+            agent_id="ag_receiver",
+            room_id="rm_pub_1",
+            muted_until=future,
+        )
+    )
+    await session.commit()
+    eff = await resolve_effective_attention(session, agent=receiver, room_id="rm_pub_1")
+    assert eff.muted_until is not None
+    assert eff.source == "override"
+
+    # Replace with a past timestamp — should be dropped.
+    row = (
+        await session.execute(
+            __import__("sqlalchemy").select(AgentRoomPolicyOverride).where(
+                AgentRoomPolicyOverride.agent_id == "ag_receiver",
+                AgentRoomPolicyOverride.room_id == "rm_pub_1",
+            )
+        )
+    ).scalar_one()
+    row.muted_until = now - datetime.timedelta(minutes=1)
+    await session.commit()
+    eff2 = await resolve_effective_attention(session, agent=receiver, room_id="rm_pub_1")
+    assert eff2.muted_until is None
+
+
+@pytest.mark.asyncio
+async def test_resolver_garbled_keywords_returns_empty(session):
+    receiver = _agent()
+    receiver.attention_keywords = "not-json-at-all"
+    await _add(session, receiver)
+    eff = await resolve_effective_attention(session, agent=receiver, room_id="rm_pub_1")
+    assert eff.keywords == []

--- a/frontend/src/app/(dashboard)/settings/layout.tsx
+++ b/frontend/src/app/(dashboard)/settings/layout.tsx
@@ -10,7 +10,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import Link from "next/link";
-import { ArrowLeft, Loader2, Server } from "lucide-react";
+import { ArrowLeft, Loader2, MessageSquare, Server } from "lucide-react";
 import { createClient } from "@/lib/supabase/client";
 
 function SettingsNavLink({
@@ -85,6 +85,12 @@ export default function SettingsLayout({
             icon={<Server className="h-4 w-4" />}
           >
             Daemons
+          </SettingsNavLink>
+          <SettingsNavLink
+            href="/settings/policy"
+            icon={<MessageSquare className="h-4 w-4" />}
+          >
+            对话与回复
           </SettingsNavLink>
         </nav>
         <div className="border-t border-glass-border px-3 py-3">

--- a/frontend/src/app/(dashboard)/settings/policy/PolicySettingsClient.tsx
+++ b/frontend/src/app/(dashboard)/settings/policy/PolicySettingsClient.tsx
@@ -1,0 +1,490 @@
+"use client";
+
+/**
+ * [INPUT]: userApi.getMyAgents for the agent picker; usePolicyStore for policy state
+ * [OUTPUT]: PolicySettingsClient — global admission + default-attention policy form
+ * [POS]: dashboard /settings/policy ("对话与回复") content
+ * [PROTOCOL]: update header on changes
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Loader2, MessageSquare, X } from "lucide-react";
+import { userApi } from "@/lib/api";
+import type { UserAgent } from "@/lib/types";
+import {
+  usePolicyStore,
+  type AgentPolicy,
+  type AgentPolicyPatch,
+  type AttentionMode,
+  type ContactPolicy,
+  type RoomInvitePolicy,
+} from "@/store/usePolicyStore";
+
+const CONTACT_OPTIONS: { value: ContactPolicy; label: string; hint: string }[] = [
+  { value: "open", label: "公开", hint: "任何人都可以联系我" },
+  { value: "contacts_only", label: "仅联系人", hint: "联系人或同房间成员" },
+  { value: "whitelist", label: "白名单", hint: "仅联系人（严格）" },
+  { value: "closed", label: "关闭", hint: "拒绝所有新对话（联系人申请仍可发起）" },
+];
+
+const ROOM_INVITE_OPTIONS: { value: RoomInvitePolicy; label: string }[] = [
+  { value: "open", label: "公开" },
+  { value: "contacts_only", label: "仅联系人" },
+  { value: "closed", label: "关闭" },
+];
+
+const ATTENTION_OPTIONS: { value: AttentionMode; label: string; hint: string }[] = [
+  { value: "always", label: "全部", hint: "群聊里收到任何消息都唤醒回复" },
+  { value: "mention_only", label: "仅被@", hint: "只在被 @ 时唤醒" },
+  { value: "keyword", label: "关键词", hint: "命中关键词才唤醒" },
+  { value: "muted", label: "静音", hint: "群聊不主动回复" },
+];
+
+function Card({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="mb-6 rounded-2xl border border-glass-border bg-glass-bg/40 p-6">
+      <header className="mb-4">
+        <h2 className="text-base font-semibold text-text-primary">{title}</h2>
+        {description ? (
+          <p className="mt-1 text-xs text-text-secondary">{description}</p>
+        ) : null}
+      </header>
+      {children}
+    </section>
+  );
+}
+
+function RadioGroup<T extends string>({
+  name,
+  value,
+  options,
+  onChange,
+  disabled,
+}: {
+  name: string;
+  value: T;
+  options: { value: T; label: string; hint?: string }[];
+  onChange: (next: T) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      {options.map((opt) => {
+        const selected = value === opt.value;
+        return (
+          <label
+            key={opt.value}
+            className={`flex cursor-pointer items-start gap-3 rounded-xl border px-3 py-2 transition-colors ${
+              selected
+                ? "border-neon-cyan/40 bg-neon-cyan/5"
+                : "border-glass-border bg-transparent hover:bg-glass-bg/60"
+            } ${disabled ? "pointer-events-none opacity-50" : ""}`}
+          >
+            <input
+              type="radio"
+              name={name}
+              value={opt.value}
+              checked={selected}
+              onChange={() => onChange(opt.value)}
+              className="mt-1 accent-neon-cyan"
+              disabled={disabled}
+            />
+            <div className="flex-1">
+              <div className="text-sm text-text-primary">{opt.label}</div>
+              {opt.hint ? (
+                <div className="text-xs text-text-secondary">{opt.hint}</div>
+              ) : null}
+            </div>
+          </label>
+        );
+      })}
+    </div>
+  );
+}
+
+function KeywordChips({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: string[];
+  onChange: (next: string[]) => void;
+  disabled?: boolean;
+}) {
+  const [draft, setDraft] = useState("");
+
+  const add = useCallback(
+    (raw: string) => {
+      const trimmed = raw.trim();
+      if (!trimmed) return;
+      if (value.includes(trimmed)) return;
+      onChange([...value, trimmed]);
+      setDraft("");
+    },
+    [onChange, value],
+  );
+
+  const remove = useCallback(
+    (kw: string) => {
+      onChange(value.filter((v) => v !== kw));
+    },
+    [onChange, value],
+  );
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap gap-1.5">
+        {value.length === 0 ? (
+          <span className="text-xs text-text-tertiary">尚未配置关键词</span>
+        ) : (
+          value.map((kw) => (
+            <span
+              key={kw}
+              className="inline-flex items-center gap-1 rounded-full border border-neon-cyan/30 bg-neon-cyan/5 px-2 py-0.5 text-xs text-neon-cyan"
+            >
+              {kw}
+              <button
+                type="button"
+                onClick={() => remove(kw)}
+                disabled={disabled}
+                className="rounded-full p-0.5 hover:bg-neon-cyan/10 disabled:opacity-50"
+                aria-label={`移除关键词 ${kw}`}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </span>
+          ))
+        )}
+      </div>
+      <input
+        type="text"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === ",") {
+            e.preventDefault();
+            add(draft);
+          }
+        }}
+        onBlur={() => add(draft)}
+        disabled={disabled}
+        placeholder="输入关键词后按回车添加"
+        className="rounded-xl border border-glass-border bg-deep-black/40 px-3 py-2 text-sm text-text-primary placeholder:text-text-tertiary focus:border-neon-cyan/40 focus:outline-none disabled:opacity-50"
+      />
+    </div>
+  );
+}
+
+export default function PolicySettingsClient() {
+  const [agents, setAgents] = useState<UserAgent[] | null>(null);
+  const [agentsError, setAgentsError] = useState<string | null>(null);
+  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const policy = usePolicyStore((s) =>
+    selectedAgentId ? s.globalByAgent[selectedAgentId] : undefined,
+  );
+  const loadingPolicy = usePolicyStore((s) =>
+    selectedAgentId ? Boolean(s.globalLoading[selectedAgentId]) : false,
+  );
+  const loadGlobal = usePolicyStore((s) => s.loadGlobal);
+  const patchGlobal = usePolicyStore((s) => s.patchGlobal);
+
+  const fetchAgents = useCallback(async () => {
+    setAgentsError(null);
+    try {
+      const res = await userApi.getMyAgents();
+      setAgents(res.agents);
+      if (res.agents.length > 0 && !selectedAgentId) {
+        const def =
+          res.agents.find((a) => a.is_default) ?? res.agents[0];
+        setSelectedAgentId(def.agent_id);
+      }
+    } catch (err) {
+      setAgentsError(err instanceof Error ? err.message : String(err));
+    }
+  }, [selectedAgentId]);
+
+  useEffect(() => {
+    void fetchAgents();
+  }, [fetchAgents]);
+
+  const reloadPolicy = useCallback(async () => {
+    if (!selectedAgentId) return;
+    setLoadError(null);
+    try {
+      await loadGlobal(selectedAgentId);
+    } catch (err) {
+      setLoadError(err instanceof Error ? err.message : String(err));
+    }
+  }, [loadGlobal, selectedAgentId]);
+
+  useEffect(() => {
+    void reloadPolicy();
+  }, [reloadPolicy]);
+
+  const apply = useCallback(
+    async (patch: AgentPolicyPatch) => {
+      if (!selectedAgentId) return;
+      setSaving(true);
+      setSaveError(null);
+      try {
+        await patchGlobal(selectedAgentId, patch);
+      } catch (err) {
+        setSaveError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setSaving(false);
+      }
+    },
+    [patchGlobal, selectedAgentId],
+  );
+
+  const headerNode = useMemo(() => {
+    if (!agents) return null;
+    if (agents.length <= 1) {
+      const a = agents[0];
+      return (
+        <div className="text-sm text-text-secondary">
+          当前 Agent：
+          <span className="ml-1 text-text-primary">
+            {a ? a.display_name : "—"}
+          </span>
+        </div>
+      );
+    }
+    return (
+      <label className="flex items-center gap-2 text-sm text-text-secondary">
+        Agent
+        <select
+          value={selectedAgentId ?? ""}
+          onChange={(e) => setSelectedAgentId(e.target.value || null)}
+          className="rounded-lg border border-glass-border bg-deep-black/40 px-2 py-1 text-text-primary"
+        >
+          {agents.map((a) => (
+            <option key={a.agent_id} value={a.agent_id}>
+              {a.display_name}
+            </option>
+          ))}
+        </select>
+      </label>
+    );
+  }, [agents, selectedAgentId]);
+
+  if (agentsError) {
+    return (
+      <div className="max-w-3xl">
+        <Header />
+        <div className="rounded-2xl border border-red-400/20 bg-red-400/5 p-4 text-sm text-red-300">
+          加载 Agent 列表失败：{agentsError}
+          <button
+            type="button"
+            onClick={() => void fetchAgents()}
+            className="ml-3 rounded border border-red-400/40 px-2 py-0.5 text-xs text-red-200 hover:bg-red-400/10"
+          >
+            重试
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!agents) {
+    return (
+      <div className="max-w-3xl">
+        <Header />
+        <SkeletonCard />
+        <SkeletonCard />
+      </div>
+    );
+  }
+
+  if (agents.length === 0) {
+    return (
+      <div className="max-w-3xl">
+        <Header />
+        <div className="rounded-2xl border border-glass-border bg-glass-bg/40 p-6 text-sm text-text-secondary">
+          你还没有任何 Agent，先去创建一个吧。
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-3xl">
+      <Header right={headerNode} />
+
+      {loadError ? (
+        <div className="mb-4 rounded-xl border border-red-400/20 bg-red-400/5 px-4 py-3 text-sm text-red-300">
+          加载策略失败：{loadError}
+          <button
+            type="button"
+            onClick={() => void reloadPolicy()}
+            className="ml-3 rounded border border-red-400/40 px-2 py-0.5 text-xs text-red-200 hover:bg-red-400/10"
+          >
+            重试
+          </button>
+        </div>
+      ) : null}
+
+      {saveError ? (
+        <div className="mb-4 rounded-xl border border-red-400/20 bg-red-400/5 px-4 py-3 text-sm text-red-300">
+          保存失败：{saveError}
+        </div>
+      ) : null}
+
+      {!policy || loadingPolicy ? (
+        <>
+          <SkeletonCard />
+          <SkeletonCard />
+        </>
+      ) : (
+        <PolicyForm policy={policy} saving={saving} onPatch={apply} />
+      )}
+    </div>
+  );
+}
+
+function Header({ right }: { right?: React.ReactNode }) {
+  return (
+    <header className="mb-6 flex items-center justify-between">
+      <div className="flex items-center gap-2">
+        <MessageSquare className="h-5 w-5 text-neon-cyan" />
+        <div>
+          <h1 className="text-lg font-semibold text-text-primary">对话与回复</h1>
+          <p className="text-xs text-text-secondary">
+            控制谁能联系你的 Agent，以及 Agent 在群聊中的默认回复策略。
+          </p>
+        </div>
+      </div>
+      {right}
+    </header>
+  );
+}
+
+function SkeletonCard() {
+  return (
+    <section className="mb-6 animate-pulse rounded-2xl border border-glass-border bg-glass-bg/40 p-6">
+      <div className="mb-4 h-4 w-32 rounded bg-glass-bg" />
+      <div className="space-y-2">
+        <div className="h-10 rounded bg-glass-bg/70" />
+        <div className="h-10 rounded bg-glass-bg/70" />
+        <div className="h-10 rounded bg-glass-bg/70" />
+      </div>
+    </section>
+  );
+}
+
+function PolicyForm({
+  policy,
+  saving,
+  onPatch,
+}: {
+  policy: AgentPolicy;
+  saving: boolean;
+  onPatch: (patch: AgentPolicyPatch) => void;
+}) {
+  return (
+    <>
+      <Card
+        title="谁能联系我"
+        description="Hub 准入：是否接受来自其他 Agent 或人类用户的对话与入群邀请。"
+      >
+        <RadioGroup
+          name="contact_policy"
+          value={policy.contact_policy}
+          options={CONTACT_OPTIONS}
+          onChange={(v) => onPatch({ contact_policy: v })}
+          disabled={saving}
+        />
+
+        <div className="mt-4 flex flex-col gap-2">
+          <label className="flex cursor-pointer items-center gap-2 text-sm text-text-primary">
+            <input
+              type="checkbox"
+              checked={policy.allow_agent_sender}
+              onChange={(e) => onPatch({ allow_agent_sender: e.target.checked })}
+              disabled={saving}
+              className="accent-neon-cyan"
+            />
+            接受其他 agent 直接对话
+          </label>
+          <label className="flex cursor-pointer items-center gap-2 text-sm text-text-primary">
+            <input
+              type="checkbox"
+              checked={policy.allow_human_sender}
+              onChange={(e) => onPatch({ allow_human_sender: e.target.checked })}
+              disabled={saving}
+              className="accent-neon-cyan"
+            />
+            接受人类用户对话
+          </label>
+        </div>
+
+        <div className="mt-4">
+          <label className="flex items-center gap-2 text-sm text-text-secondary">
+            入群邀请
+            <select
+              value={policy.room_invite_policy}
+              onChange={(e) =>
+                onPatch({ room_invite_policy: e.target.value as RoomInvitePolicy })
+              }
+              disabled={saving}
+              className="rounded-lg border border-glass-border bg-deep-black/40 px-2 py-1 text-text-primary"
+            >
+              {ROOM_INVITE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </Card>
+
+      <Card
+        title="默认回复策略"
+        description="Daemon 注意力：群聊里收到消息后是否唤醒 LLM。私聊不受此设置影响，始终回复。"
+      >
+        <RadioGroup
+          name="default_attention"
+          value={policy.default_attention}
+          options={ATTENTION_OPTIONS}
+          onChange={(v) => onPatch({ default_attention: v })}
+          disabled={saving}
+        />
+
+        {policy.default_attention === "keyword" ? (
+          <div className="mt-4">
+            <div className="mb-2 text-xs text-text-secondary">关键词</div>
+            <KeywordChips
+              value={policy.attention_keywords}
+              onChange={(next) => onPatch({ attention_keywords: next })}
+              disabled={saving}
+            />
+          </div>
+        ) : null}
+
+        <p className="mt-4 inline-flex items-center gap-2 rounded-lg border border-glass-border/60 bg-glass-bg/40 px-3 py-2 text-xs text-text-secondary">
+          ⓘ 私聊不受此设置影响，始终回复
+        </p>
+      </Card>
+
+      {saving ? (
+        <div className="mb-2 flex items-center gap-2 text-xs text-text-secondary">
+          <Loader2 className="h-3 w-3 animate-spin" />
+          保存中…
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/frontend/src/app/(dashboard)/settings/policy/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/policy/page.tsx
@@ -1,0 +1,14 @@
+/**
+ * [INPUT]: SettingsLayout shell + PolicySettingsClient client component
+ * [OUTPUT]: /settings/policy route — global per-agent admission/attention policy form
+ * [POS]: dashboard "对话与回复" settings page
+ * [PROTOCOL]: update header on changes
+ */
+
+import PolicySettingsClient from "./PolicySettingsClient";
+
+export const dynamic = "force-dynamic";
+
+export default function Page() {
+  return <PolicySettingsClient />;
+}

--- a/frontend/src/app/api/_lib/proxy-hub.ts
+++ b/frontend/src/app/api/_lib/proxy-hub.ts
@@ -1,0 +1,83 @@
+/**
+ * [INPUT]: Supabase server client for forwarding bearer token
+ * [OUTPUT]: proxyHub — forwards an arbitrary path to the backend Hub, preserving
+ *          status code and JSON/empty bodies; sibling of daemon/_lib/proxy.ts
+ *          but supports the full set of HTTP verbs used by /api/agents/* routes.
+ * [POS]: shared BFF helper for non-daemon Hub-backed routes
+ * [PROTOCOL]: update header on changes
+ */
+
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+const HUB_BASE_URL =
+  process.env.NEXT_PUBLIC_HUB_BASE_URL ||
+  (process.env.NODE_ENV === "development"
+    ? "http://localhost:8000"
+    : "https://api.botcord.chat");
+
+export type HubMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+async function getSupabaseAccessToken(): Promise<string | null> {
+  const supabase = await createClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  return session?.access_token ?? null;
+}
+
+export async function proxyHub(
+  path: string,
+  init: { method: HubMethod; body?: unknown },
+): Promise<NextResponse> {
+  const token = await getSupabaseAccessToken();
+  if (!token) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+  };
+  let body: BodyInit | undefined;
+  if (init.body !== undefined) {
+    headers["Content-Type"] = "application/json";
+    body = JSON.stringify(init.body);
+  }
+
+  const url = new URL(path, HUB_BASE_URL).toString();
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: init.method,
+      headers,
+      body,
+      cache: "no-store",
+    });
+  } catch (err) {
+    return NextResponse.json(
+      {
+        error: "upstream_unreachable",
+        message: err instanceof Error ? err.message : String(err),
+      },
+      { status: 502 },
+    );
+  }
+
+  if (res.status === 204) {
+    return new NextResponse(null, { status: 204 });
+  }
+
+  const text = await res.text();
+  if (!text) {
+    return new NextResponse(null, { status: res.status });
+  }
+  try {
+    const json = JSON.parse(text);
+    return NextResponse.json(json, { status: res.status });
+  } catch {
+    return new NextResponse(text, {
+      status: res.status,
+      headers: { "Content-Type": res.headers.get("Content-Type") || "text/plain" },
+    });
+  }
+}

--- a/frontend/src/app/api/agents/[agentId]/policy/route.ts
+++ b/frontend/src/app/api/agents/[agentId]/policy/route.ts
@@ -1,0 +1,42 @@
+/**
+ * [INPUT]: agentId from path; PATCH body is a partial AgentPolicy
+ * [OUTPUT]: GET/PATCH /api/agents/[agentId]/policy — proxies to Hub /api/agents/{id}/policy
+ * [POS]: BFF endpoints for the global per-agent policy form
+ * [PROTOCOL]: update header on changes
+ */
+
+import { NextResponse } from "next/server";
+import { proxyHub } from "../../../_lib/proxy-hub";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ agentId: string }> },
+) {
+  const { agentId } = await params;
+  if (!agentId) {
+    return NextResponse.json({ error: "missing_agent_id" }, { status: 400 });
+  }
+  return proxyHub(`/api/agents/${encodeURIComponent(agentId)}/policy`, {
+    method: "GET",
+  });
+}
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ agentId: string }> },
+) {
+  const { agentId } = await params;
+  if (!agentId) {
+    return NextResponse.json({ error: "missing_agent_id" }, { status: 400 });
+  }
+  let body: unknown = {};
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  return proxyHub(`/api/agents/${encodeURIComponent(agentId)}/policy`, {
+    method: "PATCH",
+    body,
+  });
+}

--- a/frontend/src/app/api/agents/[agentId]/rooms/[roomId]/policy/route.ts
+++ b/frontend/src/app/api/agents/[agentId]/rooms/[roomId]/policy/route.ts
@@ -1,0 +1,45 @@
+/**
+ * [INPUT]: agentId + roomId from path; PUT body is a partial RoomPolicyOverride
+ * [OUTPUT]: GET/PUT/DELETE /api/agents/[agentId]/rooms/[roomId]/policy — proxies to Hub
+ * [POS]: BFF endpoints for the per-room attention override card
+ * [PROTOCOL]: update header on changes
+ */
+
+import { NextResponse } from "next/server";
+import { proxyHub } from "../../../../../_lib/proxy-hub";
+
+type Params = { params: Promise<{ agentId: string; roomId: string }> };
+
+function path(agentId: string, roomId: string): string {
+  return `/api/agents/${encodeURIComponent(agentId)}/rooms/${encodeURIComponent(roomId)}/policy`;
+}
+
+export async function GET(_req: Request, { params }: Params) {
+  const { agentId, roomId } = await params;
+  if (!agentId || !roomId) {
+    return NextResponse.json({ error: "missing_param" }, { status: 400 });
+  }
+  return proxyHub(path(agentId, roomId), { method: "GET" });
+}
+
+export async function PUT(req: Request, { params }: Params) {
+  const { agentId, roomId } = await params;
+  if (!agentId || !roomId) {
+    return NextResponse.json({ error: "missing_param" }, { status: 400 });
+  }
+  let body: unknown = {};
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  return proxyHub(path(agentId, roomId), { method: "PUT", body });
+}
+
+export async function DELETE(_req: Request, { params }: Params) {
+  const { agentId, roomId } = await params;
+  if (!agentId || !roomId) {
+    return NextResponse.json({ error: "missing_param" }, { status: 400 });
+  }
+  return proxyHub(path(agentId, roomId), { method: "DELETE" });
+}

--- a/frontend/src/app/api/agents/[agentId]/rooms/[roomId]/snooze/route.ts
+++ b/frontend/src/app/api/agents/[agentId]/rooms/[roomId]/snooze/route.ts
@@ -1,0 +1,28 @@
+/**
+ * [INPUT]: agentId + roomId from path; POST body { minutes: 0..43200 }
+ * [OUTPUT]: POST /api/agents/[agentId]/rooms/[roomId]/snooze — proxies to Hub
+ * [POS]: BFF endpoint for quick-snooze buttons in the per-room policy card
+ * [PROTOCOL]: update header on changes
+ */
+
+import { NextResponse } from "next/server";
+import { proxyHub } from "../../../../../_lib/proxy-hub";
+
+type Params = { params: Promise<{ agentId: string; roomId: string }> };
+
+export async function POST(req: Request, { params }: Params) {
+  const { agentId, roomId } = await params;
+  if (!agentId || !roomId) {
+    return NextResponse.json({ error: "missing_param" }, { status: 400 });
+  }
+  let body: unknown = {};
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  return proxyHub(
+    `/api/agents/${encodeURIComponent(agentId)}/rooms/${encodeURIComponent(roomId)}/snooze`,
+    { method: "POST", body },
+  );
+}

--- a/frontend/src/components/dashboard/RoomHeader.tsx
+++ b/frontend/src/components/dashboard/RoomHeader.tsx
@@ -11,7 +11,7 @@ import { useLanguage } from "@/lib/i18n";
 import { common } from "@/lib/i18n/translations/common";
 import { roomList } from "@/lib/i18n/translations/dashboard";
 import { useShallow } from "zustand/react/shallow";
-import { Info, Loader2, Settings, Share2, Users } from "lucide-react";
+import { Bell, Info, Loader2, Settings, Share2, Users } from "lucide-react";
 import CopyableId from "@/components/ui/CopyableId";
 import { api, humansApi } from "@/lib/api";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
@@ -22,12 +22,14 @@ import ShareModal from "./ShareModal";
 import RoomSettingsModal from "./RoomSettingsModal";
 import DMSettingsModal from "./DMSettingsModal";
 import RoomMemberSettingsModal from "./RoomMemberSettingsModal";
+import RoomPolicyModal from "./RoomPolicyModal";
 
 export default function RoomHeader() {
   const [joinRequestStatus, setJoinRequestStatus] = useState<"idle" | "sending" | "pending" | "rejected">("idle");
   const [showRulePopover, setShowRulePopover] = useState(false);
   const [showShareModal, setShowShareModal] = useState(false);
   const [showSettingsModal, setShowSettingsModal] = useState(false);
+  const [showPolicyModal, setShowPolicyModal] = useState(false);
   const [humanJoining, setHumanJoining] = useState(false);
   const rulePopoverRef = useRef<HTMLDivElement>(null);
   const locale = useLanguage();
@@ -341,6 +343,18 @@ export default function RoomHeader() {
               <span className={tooltipCls}>{t.shareRoom}</span>
             </span>
           )}
+          {isAuthedReady && activeAgentId && !isHumanView && isJoined && !isOwnerChatRoom && (
+            <span className="group relative">
+              <button
+                onClick={() => setShowPolicyModal(true)}
+                className={iconBtn}
+                aria-label="我的回复策略"
+              >
+                <Bell className="h-4 w-4" />
+              </button>
+              <span className={tooltipCls}>我的回复策略</span>
+            </span>
+          )}
           {isAuthedReady && (isJoined || isDMRoom) && !isOwnerChatRoom && (
             <span className="group relative">
               <button
@@ -400,6 +414,14 @@ export default function RoomHeader() {
           initialAllowHumanSend={authRoom?.allow_human_send !== false}
           isOwner={authRoom?.my_role === "owner"}
           onClose={() => setShowSettingsModal(false)}
+        />
+      )}
+
+      {showPolicyModal && activeAgentId && openedRoomId && (
+        <RoomPolicyModal
+          agentId={activeAgentId}
+          roomId={openedRoomId}
+          onClose={() => setShowPolicyModal(false)}
         />
       )}
 

--- a/frontend/src/components/dashboard/RoomPolicyModal.tsx
+++ b/frontend/src/components/dashboard/RoomPolicyModal.tsx
@@ -1,0 +1,409 @@
+"use client";
+
+/**
+ * [INPUT]: agentId + roomId; usePolicyStore for effective + override state
+ * [OUTPUT]: RoomPolicyModal — per-room "我的回复策略" card. Shows the effective
+ *          attention policy with inherits/override badge, lets the user expand
+ *          a per-room override (radio + keyword input), exposes quick snooze
+ *          buttons (1h / today / forever), and a "恢复默认" reset.
+ *
+ *          DM rooms ("rm_dm_*") only show the effective state — controls hide.
+ *
+ * [POS]: Mounted from RoomHeader as a modal (the dashboard has no permanent
+ *        right-side info drawer; the design doc's "right-side drawer card" is
+ *        approximated by an overlay popover here. Revisit when a true room
+ *        info drawer lands.)
+ * [PROTOCOL]: update header on changes
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Loader2, X } from "lucide-react";
+import {
+  usePolicyStore,
+  type AttentionMode,
+  type RoomPolicyEffective,
+} from "@/store/usePolicyStore";
+
+const ATTENTION_OPTIONS: { value: AttentionMode; label: string }[] = [
+  { value: "always", label: "全部回复" },
+  { value: "mention_only", label: "仅被@" },
+  { value: "keyword", label: "关键词" },
+  { value: "muted", label: "静音" },
+];
+
+function modeLabel(mode: AttentionMode): string {
+  return ATTENTION_OPTIONS.find((o) => o.value === mode)?.label ?? mode;
+}
+
+function snoozeMinutesUntilMidnight(): number {
+  const now = new Date();
+  const next = new Date(now);
+  next.setHours(24, 0, 0, 0);
+  const diffMs = next.getTime() - now.getTime();
+  const minutes = Math.max(1, Math.round(diffMs / 60000));
+  // Backend caps at 43200 (30 days); midnight is always within range.
+  return Math.min(minutes, 43200);
+}
+
+export default function RoomPolicyModal({
+  agentId,
+  roomId,
+  onClose,
+}: {
+  agentId: string;
+  roomId: string;
+  onClose: () => void;
+}) {
+  const isDM = roomId.startsWith("rm_dm_");
+  const key = `${agentId}:${roomId}`;
+
+  const data = usePolicyStore((s) => s.roomEffectiveByKey[key]);
+  const loading = usePolicyStore((s) => Boolean(s.roomLoading[key]));
+  const loadRoomPolicy = usePolicyStore((s) => s.loadRoomPolicy);
+  const putRoomOverride = usePolicyStore((s) => s.putRoomOverride);
+  const deleteRoomOverride = usePolicyStore((s) => s.deleteRoomOverride);
+  const snoozeRoom = usePolicyStore((s) => s.snoozeRoom);
+
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setError(null);
+    void (async () => {
+      try {
+        await loadRoomPolicy(agentId, roomId);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [agentId, roomId, loadRoomPolicy]);
+
+  const effective: RoomPolicyEffective | null = data?.effective ?? null;
+  const hasOverride = data?.override != null;
+
+  useEffect(() => {
+    if (hasOverride) setExpanded(true);
+  }, [hasOverride]);
+
+  const draftKeywords = useMemo(() => {
+    if (data?.override?.keywords) return data.override.keywords;
+    if (effective?.keywords) return effective.keywords;
+    return [];
+  }, [data?.override?.keywords, effective?.keywords]);
+
+  const apply = useCallback(
+    async (action: () => Promise<unknown>) => {
+      setBusy(true);
+      setError(null);
+      try {
+        await action();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setBusy(false);
+      }
+    },
+    [],
+  );
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4 backdrop-blur">
+      <div className="w-full max-w-md rounded-2xl border border-glass-border bg-deep-black-light p-5 shadow-2xl">
+        <div className="mb-4 flex items-start justify-between">
+          <div>
+            <h2 className="text-base font-semibold text-text-primary">我的回复策略</h2>
+            <p className="mt-0.5 text-xs text-text-secondary">
+              控制此 Agent 在该房间内的注意力（是否唤醒回复）。
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded p-1 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
+            aria-label="关闭"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {loading && !data ? (
+          <div className="flex items-center gap-2 rounded-xl border border-glass-border bg-glass-bg/40 px-3 py-3 text-sm text-text-secondary">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            加载中…
+          </div>
+        ) : error && !data ? (
+          <div className="rounded-xl border border-red-400/20 bg-red-400/5 px-3 py-3 text-sm text-red-300">
+            加载失败：{error}
+          </div>
+        ) : data && effective ? (
+          isDM ? (
+            <div className="rounded-xl border border-glass-border bg-glass-bg/40 px-3 py-3 text-sm text-text-secondary">
+              一对一始终回复
+            </div>
+          ) : (
+            <>
+              <EffectiveBadge effective={effective} hasOverride={hasOverride} />
+
+              <div className="mt-4 flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={() =>
+                    void apply(() => snoozeRoom(agentId, roomId, 60))
+                  }
+                  disabled={busy}
+                  className="rounded-lg border border-glass-border bg-glass-bg/40 px-3 py-1.5 text-xs text-text-primary transition-colors hover:bg-glass-bg disabled:opacity-50"
+                >
+                  静音 1 小时
+                </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    void apply(() =>
+                      snoozeRoom(agentId, roomId, snoozeMinutesUntilMidnight()),
+                    )
+                  }
+                  disabled={busy}
+                  className="rounded-lg border border-glass-border bg-glass-bg/40 px-3 py-1.5 text-xs text-text-primary transition-colors hover:bg-glass-bg disabled:opacity-50"
+                >
+                  静音到今天结束
+                </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    void apply(() =>
+                      putRoomOverride(agentId, roomId, { attention_mode: "muted" }),
+                    )
+                  }
+                  disabled={busy}
+                  className="rounded-lg border border-glass-border bg-glass-bg/40 px-3 py-1.5 text-xs text-text-primary transition-colors hover:bg-glass-bg disabled:opacity-50"
+                >
+                  永久静音
+                </button>
+              </div>
+
+              <div className="mt-4 rounded-xl border border-glass-border bg-glass-bg/30 p-3">
+                <button
+                  type="button"
+                  onClick={() => setExpanded((v) => !v)}
+                  className="text-sm text-neon-cyan transition-colors hover:text-neon-cyan/80"
+                >
+                  {expanded ? "▾ 改为本群专属" : "▸ 改为本群专属"}
+                </button>
+
+                {expanded ? (
+                  <OverrideForm
+                    currentMode={data.override?.attention_mode ?? effective.mode}
+                    currentKeywords={draftKeywords}
+                    busy={busy}
+                    onApply={(mode, keywords) =>
+                      void apply(() =>
+                        putRoomOverride(agentId, roomId, {
+                          attention_mode: mode,
+                          keywords: mode === "keyword" ? keywords : null,
+                        }),
+                      )
+                    }
+                  />
+                ) : null}
+              </div>
+
+              {hasOverride ? (
+                <div className="mt-4">
+                  <button
+                    type="button"
+                    onClick={() =>
+                      void apply(() => deleteRoomOverride(agentId, roomId)).then(
+                        () => {
+                          // re-load to refresh effective view after override removed
+                          void loadRoomPolicy(agentId, roomId);
+                        },
+                      )
+                    }
+                    disabled={busy}
+                    className="rounded-lg border border-glass-border px-3 py-1.5 text-xs text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+                  >
+                    恢复默认（继承全局）
+                  </button>
+                </div>
+              ) : null}
+
+              {error ? (
+                <p className="mt-3 text-xs text-red-300">{error}</p>
+              ) : null}
+            </>
+          )
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function EffectiveBadge({
+  effective,
+  hasOverride,
+}: {
+  effective: RoomPolicyEffective;
+  hasOverride: boolean;
+}) {
+  const mutedActive =
+    effective.muted_until && new Date(effective.muted_until).getTime() > Date.now();
+  const sourceText =
+    effective.source === "dm_forced"
+      ? "私聊（强制）"
+      : effective.source === "override" || hasOverride
+        ? "本群专属"
+        : "继承全局";
+  return (
+    <div className="rounded-xl border border-glass-border bg-glass-bg/40 px-3 py-3">
+      <div className="text-xs text-text-secondary">当前</div>
+      <div className="mt-1 flex flex-wrap items-center gap-2">
+        <span className="text-sm font-medium text-text-primary">
+          {modeLabel(effective.mode)}
+        </span>
+        <span
+          className={`rounded-full border px-2 py-0.5 text-[10px] ${
+            effective.source === "override"
+              ? "border-neon-cyan/30 bg-neon-cyan/5 text-neon-cyan"
+              : "border-glass-border bg-glass-bg text-text-secondary"
+          }`}
+        >
+          {sourceText}
+        </span>
+        {mutedActive ? (
+          <span className="rounded-full border border-yellow-400/30 bg-yellow-400/5 px-2 py-0.5 text-[10px] text-yellow-300">
+            静音至 {new Date(effective.muted_until!).toLocaleString()}
+          </span>
+        ) : null}
+      </div>
+      {effective.mode === "keyword" && effective.keywords.length > 0 ? (
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {effective.keywords.map((k) => (
+            <span
+              key={k}
+              className="rounded-full border border-glass-border bg-glass-bg px-2 py-0.5 text-[10px] text-text-secondary"
+            >
+              {k}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function OverrideForm({
+  currentMode,
+  currentKeywords,
+  busy,
+  onApply,
+}: {
+  currentMode: AttentionMode;
+  currentKeywords: string[];
+  busy: boolean;
+  onApply: (mode: AttentionMode, keywords: string[]) => void;
+}) {
+  const [mode, setMode] = useState<AttentionMode>(currentMode);
+  const [keywords, setKeywords] = useState<string[]>(currentKeywords);
+  const [draft, setDraft] = useState("");
+
+  useEffect(() => {
+    setMode(currentMode);
+  }, [currentMode]);
+  useEffect(() => {
+    setKeywords(currentKeywords);
+  }, [currentKeywords]);
+
+  const addKeyword = () => {
+    const trimmed = draft.trim();
+    if (!trimmed || keywords.includes(trimmed)) {
+      setDraft("");
+      return;
+    }
+    setKeywords((prev) => [...prev, trimmed]);
+    setDraft("");
+  };
+
+  return (
+    <div className="mt-3">
+      <div className="flex flex-col gap-1.5">
+        {ATTENTION_OPTIONS.map((opt) => (
+          <label
+            key={opt.value}
+            className="flex cursor-pointer items-center gap-2 text-sm text-text-primary"
+          >
+            <input
+              type="radio"
+              name="room_attention"
+              value={opt.value}
+              checked={mode === opt.value}
+              onChange={() => setMode(opt.value)}
+              className="accent-neon-cyan"
+              disabled={busy}
+            />
+            {opt.label}
+          </label>
+        ))}
+      </div>
+
+      {mode === "keyword" ? (
+        <div className="mt-3 flex flex-col gap-2">
+          <div className="flex flex-wrap gap-1.5">
+            {keywords.length === 0 ? (
+              <span className="text-xs text-text-tertiary">尚未配置关键词</span>
+            ) : (
+              keywords.map((k) => (
+                <span
+                  key={k}
+                  className="inline-flex items-center gap-1 rounded-full border border-neon-cyan/30 bg-neon-cyan/5 px-2 py-0.5 text-xs text-neon-cyan"
+                >
+                  {k}
+                  <button
+                    type="button"
+                    onClick={() => setKeywords((prev) => prev.filter((v) => v !== k))}
+                    className="rounded-full p-0.5 hover:bg-neon-cyan/10"
+                    aria-label={`移除关键词 ${k}`}
+                    disabled={busy}
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </span>
+              ))
+            )}
+          </div>
+          <input
+            type="text"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === ",") {
+                e.preventDefault();
+                addKeyword();
+              }
+            }}
+            onBlur={addKeyword}
+            disabled={busy}
+            placeholder="输入关键词后按回车添加"
+            className="rounded-xl border border-glass-border bg-deep-black/40 px-3 py-2 text-sm text-text-primary placeholder:text-text-tertiary focus:border-neon-cyan/40 focus:outline-none disabled:opacity-50"
+          />
+        </div>
+      ) : null}
+
+      <div className="mt-3 flex justify-end">
+        <button
+          type="button"
+          onClick={() => onApply(mode, keywords)}
+          disabled={busy}
+          className="inline-flex items-center gap-1.5 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-1.5 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/15 disabled:opacity-50"
+        >
+          {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
+          应用到本群
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/store/usePolicyStore.ts
+++ b/frontend/src/store/usePolicyStore.ts
@@ -1,0 +1,274 @@
+/**
+ * [INPUT]: zustand store; BFF /api/agents/[agentId]/policy and per-room policy/snooze routes
+ * [OUTPUT]: usePolicyStore — global per-agent admission/attention policy + per-room overrides
+ * [POS]: dashboard policy state for /settings/policy and the room policy card
+ * [PROTOCOL]: update header on changes
+ */
+
+import { create } from "zustand";
+
+// TODO(realtime): subscribe to policy_updated to invalidate cache once the
+// daemon control frame is wired into the dashboard realtime channel.
+
+export type ContactPolicy = "open" | "contacts_only" | "whitelist" | "closed";
+export type RoomInvitePolicy = "open" | "contacts_only" | "closed";
+export type AttentionMode = "always" | "mention_only" | "keyword" | "muted";
+export type PolicySource = "global" | "override" | "dm_forced";
+
+export interface AgentPolicy {
+  contact_policy: ContactPolicy;
+  allow_agent_sender: boolean;
+  allow_human_sender: boolean;
+  room_invite_policy: RoomInvitePolicy;
+  default_attention: AttentionMode;
+  attention_keywords: string[];
+}
+
+export interface AgentPolicyPatch {
+  contact_policy?: ContactPolicy;
+  allow_agent_sender?: boolean;
+  allow_human_sender?: boolean;
+  room_invite_policy?: RoomInvitePolicy;
+  default_attention?: AttentionMode;
+  attention_keywords?: string[];
+}
+
+export interface RoomPolicyOverride {
+  attention_mode: AttentionMode | null;
+  keywords: string[] | null;
+  muted_until: string | null;
+  updated_at: string;
+}
+
+export interface RoomPolicyEffective {
+  mode: AttentionMode;
+  keywords: string[];
+  muted_until: string | null;
+  source: PolicySource;
+}
+
+export interface RoomPolicyResponse {
+  effective: RoomPolicyEffective;
+  override: RoomPolicyOverride | null;
+  inherits_global: boolean;
+}
+
+export interface RoomOverridePatch {
+  // Omit a key to leave unchanged; explicit null clears (= inherit).
+  attention_mode?: AttentionMode | null;
+  keywords?: string[] | null;
+}
+
+interface PolicyState {
+  globalByAgent: Record<string, AgentPolicy>;
+  globalLoading: Record<string, boolean>;
+  roomEffectiveByKey: Record<string, RoomPolicyResponse>;
+  roomLoading: Record<string, boolean>;
+
+  loadGlobal: (agentId: string) => Promise<AgentPolicy>;
+  patchGlobal: (agentId: string, patch: AgentPolicyPatch) => Promise<AgentPolicy>;
+  loadRoomPolicy: (agentId: string, roomId: string) => Promise<RoomPolicyResponse>;
+  putRoomOverride: (
+    agentId: string,
+    roomId: string,
+    body: RoomOverridePatch,
+  ) => Promise<RoomPolicyResponse>;
+  deleteRoomOverride: (agentId: string, roomId: string) => Promise<void>;
+  snoozeRoom: (
+    agentId: string,
+    roomId: string,
+    minutes: number,
+  ) => Promise<RoomPolicyResponse>;
+  invalidate: (agentId: string, roomId?: string) => void;
+}
+
+function roomKey(agentId: string, roomId: string): string {
+  return `${agentId}:${roomId}`;
+}
+
+async function readErr(res: Response): Promise<Error> {
+  const text = await res.text().catch(() => "");
+  let detail: string | undefined;
+  let messageKey: string | undefined;
+  try {
+    const json = JSON.parse(text) as { detail?: unknown; message_key?: unknown };
+    if (typeof json.detail === "string") detail = json.detail;
+    if (typeof json.message_key === "string") messageKey = json.message_key;
+  } catch {
+    // fall through
+  }
+  const err = new Error(detail || messageKey || `HTTP ${res.status}`);
+  (err as Error & { status?: number; messageKey?: string }).status = res.status;
+  if (messageKey) {
+    (err as Error & { status?: number; messageKey?: string }).messageKey = messageKey;
+  }
+  return err;
+}
+
+export const usePolicyStore = create<PolicyState>((set, get) => ({
+  globalByAgent: {},
+  globalLoading: {},
+  roomEffectiveByKey: {},
+  roomLoading: {},
+
+  async loadGlobal(agentId) {
+    set((s) => ({ globalLoading: { ...s.globalLoading, [agentId]: true } }));
+    try {
+      const res = await fetch(`/api/agents/${encodeURIComponent(agentId)}/policy`, {
+        cache: "no-store",
+      });
+      if (!res.ok) throw await readErr(res);
+      const policy = (await res.json()) as AgentPolicy;
+      set((s) => ({
+        globalByAgent: { ...s.globalByAgent, [agentId]: policy },
+      }));
+      return policy;
+    } finally {
+      set((s) => {
+        const next = { ...s.globalLoading };
+        delete next[agentId];
+        return { globalLoading: next };
+      });
+    }
+  },
+
+  async patchGlobal(agentId, patch) {
+    const prev = get().globalByAgent[agentId];
+    const optimistic: AgentPolicy | undefined = prev
+      ? { ...prev, ...patch }
+      : undefined;
+    if (optimistic) {
+      set((s) => ({ globalByAgent: { ...s.globalByAgent, [agentId]: optimistic } }));
+    }
+    try {
+      const res = await fetch(`/api/agents/${encodeURIComponent(agentId)}/policy`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(patch),
+      });
+      if (!res.ok) throw await readErr(res);
+      const policy = (await res.json()) as AgentPolicy;
+      set((s) => ({ globalByAgent: { ...s.globalByAgent, [agentId]: policy } }));
+      return policy;
+    } catch (err) {
+      // rollback
+      if (prev) {
+        set((s) => ({ globalByAgent: { ...s.globalByAgent, [agentId]: prev } }));
+      }
+      throw err;
+    }
+  },
+
+  async loadRoomPolicy(agentId, roomId) {
+    const key = roomKey(agentId, roomId);
+    set((s) => ({ roomLoading: { ...s.roomLoading, [key]: true } }));
+    try {
+      const res = await fetch(
+        `/api/agents/${encodeURIComponent(agentId)}/rooms/${encodeURIComponent(roomId)}/policy`,
+        { cache: "no-store" },
+      );
+      if (!res.ok) throw await readErr(res);
+      const data = (await res.json()) as RoomPolicyResponse;
+      set((s) => ({ roomEffectiveByKey: { ...s.roomEffectiveByKey, [key]: data } }));
+      return data;
+    } finally {
+      set((s) => {
+        const next = { ...s.roomLoading };
+        delete next[key];
+        return { roomLoading: next };
+      });
+    }
+  },
+
+  async putRoomOverride(agentId, roomId, body) {
+    const key = roomKey(agentId, roomId);
+    const prev = get().roomEffectiveByKey[key];
+    try {
+      const res = await fetch(
+        `/api/agents/${encodeURIComponent(agentId)}/rooms/${encodeURIComponent(roomId)}/policy`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        },
+      );
+      if (!res.ok) throw await readErr(res);
+      const data = (await res.json()) as RoomPolicyResponse;
+      set((s) => ({ roomEffectiveByKey: { ...s.roomEffectiveByKey, [key]: data } }));
+      return data;
+    } catch (err) {
+      if (prev) {
+        set((s) => ({ roomEffectiveByKey: { ...s.roomEffectiveByKey, [key]: prev } }));
+      }
+      throw err;
+    }
+  },
+
+  async deleteRoomOverride(agentId, roomId) {
+    const key = roomKey(agentId, roomId);
+    const prev = get().roomEffectiveByKey[key];
+    set((s) => {
+      const next = { ...s.roomEffectiveByKey };
+      delete next[key];
+      return { roomEffectiveByKey: next };
+    });
+    try {
+      const res = await fetch(
+        `/api/agents/${encodeURIComponent(agentId)}/rooms/${encodeURIComponent(roomId)}/policy`,
+        { method: "DELETE" },
+      );
+      if (!res.ok && res.status !== 204) throw await readErr(res);
+    } catch (err) {
+      if (prev) {
+        set((s) => ({ roomEffectiveByKey: { ...s.roomEffectiveByKey, [key]: prev } }));
+      }
+      throw err;
+    }
+  },
+
+  async snoozeRoom(agentId, roomId, minutes) {
+    const key = roomKey(agentId, roomId);
+    const prev = get().roomEffectiveByKey[key];
+    try {
+      const res = await fetch(
+        `/api/agents/${encodeURIComponent(agentId)}/rooms/${encodeURIComponent(roomId)}/snooze`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ minutes }),
+        },
+      );
+      if (!res.ok) throw await readErr(res);
+      const data = (await res.json()) as RoomPolicyResponse;
+      set((s) => ({ roomEffectiveByKey: { ...s.roomEffectiveByKey, [key]: data } }));
+      return data;
+    } catch (err) {
+      if (prev) {
+        set((s) => ({ roomEffectiveByKey: { ...s.roomEffectiveByKey, [key]: prev } }));
+      }
+      throw err;
+    }
+  },
+
+  invalidate(agentId, roomId) {
+    if (roomId) {
+      const key = roomKey(agentId, roomId);
+      set((s) => {
+        const next = { ...s.roomEffectiveByKey };
+        delete next[key];
+        return { roomEffectiveByKey: next };
+      });
+      return;
+    }
+    set((s) => {
+      const nextGlobal = { ...s.globalByAgent };
+      delete nextGlobal[agentId];
+      const nextRooms = { ...s.roomEffectiveByKey };
+      const prefix = `${agentId}:`;
+      for (const k of Object.keys(nextRooms)) {
+        if (k.startsWith(prefix)) delete nextRooms[k];
+      }
+      return { globalByAgent: nextGlobal, roomEffectiveByKey: nextRooms };
+    });
+  },
+}));

--- a/frontend/tests/usePolicyStore.test.ts
+++ b/frontend/tests/usePolicyStore.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  usePolicyStore,
+  type AgentPolicy,
+  type RoomPolicyResponse,
+} from "@/store/usePolicyStore";
+
+const baseGlobal: AgentPolicy = {
+  contact_policy: "contacts_only",
+  allow_agent_sender: true,
+  allow_human_sender: true,
+  room_invite_policy: "contacts_only",
+  default_attention: "always",
+  attention_keywords: [],
+};
+
+const baseRoom: RoomPolicyResponse = {
+  effective: {
+    mode: "always",
+    keywords: [],
+    muted_until: null,
+    source: "global",
+  },
+  override: null,
+  inherits_global: true,
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function noContent(): Response {
+  return new Response(null, { status: 204 });
+}
+
+describe("usePolicyStore", () => {
+  beforeEach(() => {
+    usePolicyStore.setState({
+      globalByAgent: {},
+      globalLoading: {},
+      roomEffectiveByKey: {},
+      roomLoading: {},
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("loadGlobal fetches and stores agent policy", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse(baseGlobal));
+
+    const result = await usePolicyStore.getState().loadGlobal("ag_alice");
+
+    expect(result).toEqual(baseGlobal);
+    expect(usePolicyStore.getState().globalByAgent["ag_alice"]).toEqual(baseGlobal);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/agents/ag_alice/policy",
+      expect.objectContaining({ cache: "no-store" }),
+    );
+  });
+
+  it("patchGlobal PATCHes and updates state with server response", async () => {
+    usePolicyStore.setState({ globalByAgent: { ag_alice: baseGlobal } });
+    const updated: AgentPolicy = { ...baseGlobal, contact_policy: "open" };
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse(updated));
+
+    const result = await usePolicyStore
+      .getState()
+      .patchGlobal("ag_alice", { contact_policy: "open" });
+
+    expect(result).toEqual(updated);
+    expect(usePolicyStore.getState().globalByAgent["ag_alice"]).toEqual(updated);
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(init?.method).toBe("PATCH");
+    expect(JSON.parse((init?.body as string) ?? "{}")).toEqual({
+      contact_policy: "open",
+    });
+  });
+
+  it("patchGlobal rolls back on failure", async () => {
+    usePolicyStore.setState({ globalByAgent: { ag_alice: baseGlobal } });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({ detail: "boom" }, 400),
+    );
+
+    await expect(
+      usePolicyStore
+        .getState()
+        .patchGlobal("ag_alice", { contact_policy: "open" }),
+    ).rejects.toThrow("boom");
+
+    expect(usePolicyStore.getState().globalByAgent["ag_alice"]).toEqual(baseGlobal);
+  });
+
+  it("loadRoomPolicy stores effective response keyed by agent+room", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(baseRoom));
+
+    await usePolicyStore.getState().loadRoomPolicy("ag_alice", "rm_x");
+
+    expect(
+      usePolicyStore.getState().roomEffectiveByKey["ag_alice:rm_x"],
+    ).toEqual(baseRoom);
+  });
+
+  it("deleteRoomOverride removes the cached entry", async () => {
+    usePolicyStore.setState({
+      roomEffectiveByKey: { "ag_alice:rm_x": baseRoom },
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(noContent());
+
+    await usePolicyStore.getState().deleteRoomOverride("ag_alice", "rm_x");
+
+    expect(
+      usePolicyStore.getState().roomEffectiveByKey["ag_alice:rm_x"],
+    ).toBeUndefined();
+  });
+
+  it("invalidate clears the targeted room key", () => {
+    usePolicyStore.setState({
+      globalByAgent: { ag_alice: baseGlobal },
+      roomEffectiveByKey: {
+        "ag_alice:rm_x": baseRoom,
+        "ag_alice:rm_y": baseRoom,
+        "ag_bob:rm_x": baseRoom,
+      },
+    });
+
+    usePolicyStore.getState().invalidate("ag_alice", "rm_x");
+    const after = usePolicyStore.getState();
+    expect(after.roomEffectiveByKey["ag_alice:rm_x"]).toBeUndefined();
+    expect(after.roomEffectiveByKey["ag_alice:rm_y"]).toEqual(baseRoom);
+    expect(after.globalByAgent["ag_alice"]).toEqual(baseGlobal);
+  });
+
+  it("invalidate without roomId clears all entries for the agent", () => {
+    usePolicyStore.setState({
+      globalByAgent: { ag_alice: baseGlobal, ag_bob: baseGlobal },
+      roomEffectiveByKey: {
+        "ag_alice:rm_x": baseRoom,
+        "ag_bob:rm_x": baseRoom,
+      },
+    });
+
+    usePolicyStore.getState().invalidate("ag_alice");
+    const after = usePolicyStore.getState();
+    expect(after.globalByAgent["ag_alice"]).toBeUndefined();
+    expect(after.globalByAgent["ag_bob"]).toEqual(baseGlobal);
+    expect(after.roomEffectiveByKey["ag_alice:rm_x"]).toBeUndefined();
+    expect(after.roomEffectiveByKey["ag_bob:rm_x"]).toEqual(baseRoom);
+  });
+});

--- a/packages/daemon/src/__tests__/policy-resolver.test.ts
+++ b/packages/daemon/src/__tests__/policy-resolver.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import { PolicyResolver } from "../gateway/policy-resolver.js";
+import type { AttentionPolicy } from "@botcord/protocol-core";
+
+describe("PolicyResolver", () => {
+  it("returns default policy when fetchGlobal returns undefined", async () => {
+    const resolver = new PolicyResolver({ fetchGlobal: async () => undefined });
+    const p = await resolver.resolve("ag_a", null);
+    expect(p.mode).toBe("always");
+    expect(p.keywords).toEqual([]);
+  });
+
+  it("caches the global fetch result and reuses on the next resolve", async () => {
+    const fetchGlobal = vi.fn(async () => ({ mode: "muted", keywords: [] }) as AttentionPolicy);
+    const resolver = new PolicyResolver({ fetchGlobal });
+    await resolver.resolve("ag_a", null);
+    await resolver.resolve("ag_a", null);
+    expect(fetchGlobal).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidate(agent) drops all entries for that agent", async () => {
+    const fetchGlobal = vi.fn(async () => ({ mode: "always", keywords: [] }) as AttentionPolicy);
+    const resolver = new PolicyResolver({ fetchGlobal });
+    await resolver.resolve("ag_a", null);
+    await resolver.resolve("ag_a", null);
+    expect(fetchGlobal).toHaveBeenCalledTimes(1);
+    resolver.invalidate("ag_a");
+    await resolver.resolve("ag_a", null);
+    expect(fetchGlobal).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidate(agent, room) only drops the matching room entry", async () => {
+    const policy: AttentionPolicy = { mode: "always", keywords: [] };
+    const fetchGlobal = vi.fn(async () => policy);
+    const fetchEffective = vi.fn(async () => policy);
+    const resolver = new PolicyResolver({ fetchGlobal, fetchEffective });
+
+    await resolver.resolve("ag_a", null);
+    await resolver.resolve("ag_a", "rm_1");
+    await resolver.resolve("ag_a", "rm_2");
+    expect(fetchGlobal).toHaveBeenCalledTimes(1);
+    expect(fetchEffective).toHaveBeenCalledTimes(2);
+
+    resolver.invalidate("ag_a", "rm_1");
+    await resolver.resolve("ag_a", null); // still cached
+    await resolver.resolve("ag_a", "rm_2"); // still cached
+    await resolver.resolve("ag_a", "rm_1"); // refetched
+    expect(fetchGlobal).toHaveBeenCalledTimes(1);
+    expect(fetchEffective).toHaveBeenCalledTimes(3);
+  });
+
+  it("put() installs a policy without going through fetch", async () => {
+    const fetchGlobal = vi.fn(async () => undefined);
+    const resolver = new PolicyResolver({ fetchGlobal });
+    resolver.put("ag_a", null, { mode: "muted", keywords: [] });
+    const p = await resolver.resolve("ag_a", null);
+    expect(p.mode).toBe("muted");
+    expect(fetchGlobal).not.toHaveBeenCalled();
+  });
+
+  it("forces DM rooms (rm_dm_*) to mode=always even if cached muted", async () => {
+    const resolver = new PolicyResolver({ fetchGlobal: async () => undefined });
+    resolver.put("ag_a", "rm_dm_xyz", { mode: "muted", keywords: [] });
+    const p = await resolver.resolve("ag_a", "rm_dm_xyz");
+    expect(p.mode).toBe("always");
+  });
+
+  it("falls back to defaults when fetch throws", async () => {
+    const resolver = new PolicyResolver({
+      fetchGlobal: async () => {
+        throw new Error("boom");
+      },
+    });
+    const p = await resolver.resolve("ag_a", null);
+    expect(p.mode).toBe("always");
+  });
+
+  it("expires cached entries after ttlMs", async () => {
+    const fetchGlobal = vi.fn(async () => ({ mode: "muted", keywords: [] }) as AttentionPolicy);
+    const resolver = new PolicyResolver({ fetchGlobal, ttlMs: 1 });
+    await resolver.resolve("ag_a", null);
+    await new Promise((r) => setTimeout(r, 5));
+    await resolver.resolve("ag_a", null);
+    expect(fetchGlobal).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/daemon/src/__tests__/policy-resolver.test.ts
+++ b/packages/daemon/src/__tests__/policy-resolver.test.ts
@@ -75,6 +75,44 @@ describe("PolicyResolver", () => {
     expect(p.mode).toBe("always");
   });
 
+  it("falls back to the cached global when resolving a room with no override", async () => {
+    // Regression: prior to the room→global fallback, group messages
+    // collapsed to mode=always whenever the daemon had no fetchEffective
+    // wired (the default state), silently breaking global mention_only/muted.
+    const resolver = new PolicyResolver({ fetchGlobal: async () => undefined });
+    resolver.put("ag_a", null, { mode: "mention_only", keywords: [] });
+    const p = await resolver.resolve("ag_a", "rm_1");
+    expect(p.mode).toBe("mention_only");
+  });
+
+  it("per-room override wins over the cached global", async () => {
+    const resolver = new PolicyResolver({ fetchGlobal: async () => undefined });
+    resolver.put("ag_a", null, { mode: "always", keywords: [] });
+    resolver.put("ag_a", "rm_1", { mode: "muted", keywords: [] });
+    const p = await resolver.resolve("ag_a", "rm_1");
+    expect(p.mode).toBe("muted");
+    // Other rooms still inherit the global.
+    expect((await resolver.resolve("ag_a", "rm_2")).mode).toBe("always");
+  });
+
+  it("invalidate(agent, room) drops the override and falls back to the cached global", async () => {
+    const resolver = new PolicyResolver({ fetchGlobal: async () => undefined });
+    resolver.put("ag_a", null, { mode: "mention_only", keywords: [] });
+    resolver.put("ag_a", "rm_1", { mode: "muted", keywords: [] });
+    expect((await resolver.resolve("ag_a", "rm_1")).mode).toBe("muted");
+    resolver.invalidate("ag_a", "rm_1");
+    expect((await resolver.resolve("ag_a", "rm_1")).mode).toBe("mention_only");
+  });
+
+  it("global update via put propagates to inheriting rooms without invalidation", async () => {
+    const resolver = new PolicyResolver({ fetchGlobal: async () => undefined });
+    resolver.put("ag_a", null, { mode: "always", keywords: [] });
+    expect((await resolver.resolve("ag_a", "rm_1")).mode).toBe("always");
+    // Hub fires policy_updated with new global policy → daemon does put().
+    resolver.put("ag_a", null, { mode: "muted", keywords: [] });
+    expect((await resolver.resolve("ag_a", "rm_1")).mode).toBe("muted");
+  });
+
   it("expires cached entries after ttlMs", async () => {
     const fetchGlobal = vi.fn(async () => ({ mode: "muted", keywords: [] }) as AttentionPolicy);
     const resolver = new PolicyResolver({ fetchGlobal, ttlMs: 1 });

--- a/packages/daemon/src/__tests__/policy-updated-handler.test.ts
+++ b/packages/daemon/src/__tests__/policy-updated-handler.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = {
+  cfg: {
+    defaultRoute: { adapter: "claude-code", cwd: "/tmp" },
+    routes: [],
+    streamBlocks: true,
+  } as Record<string, unknown>,
+  saved: [] as Array<Record<string, unknown>>,
+};
+
+vi.mock("../config.js", async () => {
+  const actual = await vi.importActual<typeof import("../config.js")>("../config.js");
+  return {
+    ...actual,
+    loadConfig: () => JSON.parse(JSON.stringify(mockState.cfg)) as Record<string, unknown>,
+    saveConfig: (next: Record<string, unknown>) => {
+      mockState.cfg = JSON.parse(JSON.stringify(next)) as Record<string, unknown>;
+      mockState.saved.push(JSON.parse(JSON.stringify(next)) as Record<string, unknown>);
+    },
+  };
+});
+
+const { createProvisioner } = await import("../provision.js");
+const { CONTROL_FRAME_TYPES } = await import("@botcord/protocol-core");
+import type { GatewayRoute, GatewayRuntimeSnapshot } from "../gateway/index.js";
+import type { PolicyResolverLike } from "../gateway/policy-resolver.js";
+
+beforeEach(() => {
+  mockState.cfg = {
+    defaultRoute: { adapter: "claude-code", cwd: "/tmp" },
+    routes: [],
+    streamBlocks: true,
+  };
+  mockState.saved = [];
+});
+
+function makeFakeGateway(): unknown {
+  const snap: GatewayRuntimeSnapshot = { channels: {}, turns: {} };
+  return {
+    addChannel: vi.fn(async () => {}),
+    removeChannel: vi.fn(async () => {}),
+    upsertManagedRoute: vi.fn(),
+    removeManagedRoute: vi.fn(),
+    replaceManagedRoutes: vi.fn(),
+    listManagedRoutes: () => [] as GatewayRoute[],
+    snapshot: () => snap,
+  };
+}
+
+function makeFakeResolver(): PolicyResolverLike & {
+  invalidate: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  resolve: ReturnType<typeof vi.fn>;
+} {
+  return {
+    resolve: vi.fn(async () => ({ mode: "always", keywords: [] })),
+    invalidate: vi.fn(),
+    put: vi.fn(),
+  };
+}
+
+describe("policy_updated control-frame handler", () => {
+  it("invalidates the resolver cache for the agent when payload has no policy", async () => {
+    const gw = makeFakeGateway();
+    const resolver = makeFakeResolver();
+    const provisioner = createProvisioner({
+      gateway: gw as Parameters<typeof createProvisioner>[0]["gateway"],
+      policyResolver: resolver,
+    });
+    const ack = await provisioner({
+      id: "f1",
+      type: CONTROL_FRAME_TYPES.POLICY_UPDATED,
+      params: { agent_id: "ag_a" },
+    });
+    expect(ack.ok).toBe(true);
+    expect(resolver.invalidate).toHaveBeenCalledWith("ag_a", undefined);
+    expect(resolver.put).not.toHaveBeenCalled();
+  });
+
+  it("invalidates only the per-room slot when room_id is present", async () => {
+    const resolver = makeFakeResolver();
+    const provisioner = createProvisioner({
+      gateway: makeFakeGateway() as Parameters<typeof createProvisioner>[0]["gateway"],
+      policyResolver: resolver,
+    });
+    await provisioner({
+      id: "f2",
+      type: CONTROL_FRAME_TYPES.POLICY_UPDATED,
+      params: { agent_id: "ag_a", room_id: "rm_1" },
+    });
+    expect(resolver.invalidate).toHaveBeenCalledWith("ag_a", "rm_1");
+  });
+
+  it("calls put() with the embedded policy when payload carries one", async () => {
+    const resolver = makeFakeResolver();
+    const provisioner = createProvisioner({
+      gateway: makeFakeGateway() as Parameters<typeof createProvisioner>[0]["gateway"],
+      policyResolver: resolver,
+    });
+    const ack = await provisioner({
+      id: "f3",
+      type: CONTROL_FRAME_TYPES.POLICY_UPDATED,
+      params: {
+        agent_id: "ag_a",
+        policy: { mode: "keyword", keywords: ["foo", "bar"], muted_until: 123 },
+      },
+    });
+    expect(ack.ok).toBe(true);
+    expect(resolver.put).toHaveBeenCalledWith("ag_a", null, {
+      mode: "keyword",
+      keywords: ["foo", "bar"],
+      muted_until: 123,
+    });
+    expect(resolver.invalidate).not.toHaveBeenCalled();
+  });
+
+  it("rejects payloads missing agent_id with bad_params", async () => {
+    const resolver = makeFakeResolver();
+    const provisioner = createProvisioner({
+      gateway: makeFakeGateway() as Parameters<typeof createProvisioner>[0]["gateway"],
+      policyResolver: resolver,
+    });
+    const ack = await provisioner({
+      id: "f4",
+      type: CONTROL_FRAME_TYPES.POLICY_UPDATED,
+      params: {},
+    });
+    expect(ack.ok).toBe(false);
+    expect(ack.error?.code).toBe("bad_params");
+  });
+
+  it("succeeds quietly when no resolver is wired", async () => {
+    const provisioner = createProvisioner({
+      gateway: makeFakeGateway() as Parameters<typeof createProvisioner>[0]["gateway"],
+    });
+    const ack = await provisioner({
+      id: "f5",
+      type: CONTROL_FRAME_TYPES.POLICY_UPDATED,
+      params: { agent_id: "ag_a" },
+    });
+    expect(ack.ok).toBe(true);
+  });
+});

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -1,4 +1,8 @@
-import { CONTROL_FRAME_TYPES } from "@botcord/protocol-core";
+import {
+  CONTROL_FRAME_TYPES,
+  shouldWake,
+  type AttentionPolicy,
+} from "@botcord/protocol-core";
 import {
   Gateway,
   createBotCordChannel,
@@ -31,6 +35,8 @@ import {
 } from "./loop-risk.js";
 import { composeBotCordUserTurn } from "./turn-text.js";
 import { UserAuthManager } from "./user-auth.js";
+import { PolicyResolver } from "./gateway/policy-resolver.js";
+import { scanMention } from "./mention-scan.js";
 
 /**
  * Matches the 10-minute turn timeout the legacy daemon dispatcher used, so
@@ -319,6 +325,40 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
     });
   };
 
+  // Per-agent attention policy cache (PR3, design §4.2 / §5). Seeded from
+  // the optional `defaultAttention` / `attentionKeywords` carried by
+  // `provision_agent`, refreshed in-place by the `policy_updated` control
+  // frame. PR2 will plug per-room overrides into `fetchEffective`; PR3
+  // leaves it absent so the resolver collapses to per-agent state.
+  const policyResolver = new PolicyResolver({
+    fetchGlobal: async (_agentId: string) => undefined,
+  });
+
+  // Display-name lookup for the mention text-fallback. Populated from boot
+  // credentials; multi-agent daemons can reuse the same map via accountId.
+  const displayNameByAgent = new Map<string, string>();
+  for (const a of boot.agents) {
+    if (a.displayName) displayNameByAgent.set(a.agentId, a.displayName);
+  }
+
+  // Attention gate: compose `messages.mentioned` (sender-supplied — distrust)
+  // with a local `@<display_name>` / `@<agent_id>` text scan, resolve the
+  // effective policy, then defer to the protocol-core `shouldWake` decision.
+  const attentionGate = async (msg: GatewayInboundMessage): Promise<boolean> => {
+    const policy: AttentionPolicy = await policyResolver.resolve(
+      msg.accountId,
+      msg.conversation.id,
+    );
+    const localMention = scanMention(msg.text, {
+      agentId: msg.accountId,
+      displayName: displayNameByAgent.get(msg.accountId),
+    });
+    return shouldWake(policy, {
+      mentioned: msg.mentioned === true || localMention,
+      text: msg.text,
+    });
+  };
+
   const gateway = new Gateway({
     config: gwConfig,
     sessionStorePath: opts.sessionStorePath ?? SESSIONS_PATH,
@@ -340,6 +380,7 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
     onInbound,
     onOutbound,
     composeUserTurn: composeBotCordUserTurn,
+    attentionGate,
   });
 
   logger.info("daemon starting", {
@@ -376,7 +417,7 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
       userId: userAuth.current.userId,
       hubUrl: userAuth.current.hubUrl,
     });
-    const provisioner = createProvisioner({ gateway });
+    const provisioner = createProvisioner({ gateway, policyResolver });
     controlChannel = new ControlChannel({
       auth: userAuth,
       handle: provisioner,

--- a/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
+++ b/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
@@ -1551,6 +1551,71 @@ describe("Dispatcher", () => {
     expect(composedItemCounts[1]).toBeLessThanOrEqual(8);
   });
 
+  it("attentionGate=false skips the runtime turn but still acks and runs onInbound (PR3)", async () => {
+    const runtime = new FakeRuntime();
+    const { store, dir } = await makeStore();
+    tempDirs.push(dir);
+    const channel = new FakeChannel();
+    const channels = new Map<string, ChannelAdapter>([[channel.id, channel]]);
+    const accept = vi.fn(async () => {});
+    const onInbound = vi.fn();
+    const attentionGate = vi.fn(async () => false);
+    const dispatcher = new Dispatcher({
+      config: baseConfig(),
+      channels,
+      runtime: () => runtime,
+      sessionStore: store,
+      log: silentLogger(),
+      onInbound,
+      attentionGate,
+    });
+    await dispatcher.handle(makeEnvelope({ id: "m_gated", text: "hello" }, { accept }));
+    expect(accept).toHaveBeenCalledTimes(1);
+    expect(onInbound).toHaveBeenCalledTimes(1);
+    expect(attentionGate).toHaveBeenCalledTimes(1);
+    expect(runtime.calls.length).toBe(0);
+    expect(channel.sends.length).toBe(0);
+  });
+
+  it("attentionGate=true wakes the runtime as usual (PR3)", async () => {
+    const runtime = new FakeRuntime({ reply: "ok", newSessionId: "sid-1" });
+    const { store, dir } = await makeStore();
+    tempDirs.push(dir);
+    const channel = new FakeChannel();
+    const channels = new Map<string, ChannelAdapter>([[channel.id, channel]]);
+    const dispatcher = new Dispatcher({
+      config: baseConfig(),
+      channels,
+      runtime: () => runtime,
+      sessionStore: store,
+      log: silentLogger(),
+      attentionGate: () => true,
+    });
+    await dispatcher.handle(makeEnvelope({ id: "m_wake" }));
+    expect(runtime.calls.length).toBe(1);
+    expect(channel.sends.length).toBe(1);
+  });
+
+  it("attentionGate throwing fails open and runs the turn (PR3)", async () => {
+    const runtime = new FakeRuntime({ reply: "ok", newSessionId: "sid-1" });
+    const { store, dir } = await makeStore();
+    tempDirs.push(dir);
+    const channel = new FakeChannel();
+    const channels = new Map<string, ChannelAdapter>([[channel.id, channel]]);
+    const dispatcher = new Dispatcher({
+      config: baseConfig(),
+      channels,
+      runtime: () => runtime,
+      sessionStore: store,
+      log: silentLogger(),
+      attentionGate: () => {
+        throw new Error("boom");
+      },
+    });
+    await dispatcher.handle(makeEnvelope({ id: "m_wake_throw" }));
+    expect(runtime.calls.length).toBe(1);
+  });
+
   it("owner-chat detection: dashboard_user_chat in non-rm_oc room still sends reply", async () => {
     const runtime = new FakeRuntime({ reply: "ok", newSessionId: "sid-1" });
     const { dispatcher, channel } = await scaffold({

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -5,6 +5,7 @@ import type {
   ChannelAdapter,
   GatewayConfig,
   GatewayInboundEnvelope,
+  GatewayInboundMessage,
   GatewayOutboundMessage,
   GatewayRoute,
   GatewaySessionEntry,
@@ -83,6 +84,18 @@ export interface DispatcherOptions {
    * and suppressed so observer failures never break the turn.
    */
   onOutbound?: OutboundObserver;
+  /**
+   * Optional attention gate (PR3, design §4.2). Resolved AFTER `onInbound`
+   * runs and BEFORE the runtime turn enqueues, so working memory / activity
+   * tracking still observe the message even when the gate skips the wake.
+   *
+   * Return `true` to wake the runtime, `false` to skip the turn. Errors are
+   * logged and treated as `true` (fail-open) so a buggy gate cannot silence
+   * the agent.
+   */
+  attentionGate?: (
+    message: GatewayInboundMessage,
+  ) => Promise<boolean> | boolean;
 }
 
 interface TurnSlot {
@@ -148,6 +161,9 @@ export class Dispatcher {
   private readonly onOutbound?: OutboundObserver;
   private readonly composeUserTurn?: UserTurnBuilder;
   private readonly managedRoutes?: Map<string, GatewayRoute>;
+  private readonly attentionGate?: (
+    message: GatewayInboundMessage,
+  ) => Promise<boolean> | boolean;
   private readonly queues: Map<string, QueueState> = new Map();
 
   constructor(opts: DispatcherOptions) {
@@ -162,6 +178,7 @@ export class Dispatcher {
     this.onOutbound = opts.onOutbound;
     this.composeUserTurn = opts.composeUserTurn;
     this.managedRoutes = opts.managedRoutes;
+    this.attentionGate = opts.attentionGate;
   }
 
   /** Consume one inbound envelope, ack it once ownership is decided, then run its turn. */
@@ -223,6 +240,32 @@ export class Dispatcher {
           messageId: msg.id,
           error: err instanceof Error ? err.message : String(err),
         });
+      }
+    }
+
+    // Attention gate (PR3, design §4.2). Inserted AFTER `onInbound` so the
+    // working-memory append + activity tracking still see the message — only
+    // the runtime turn is suppressed. Errors are treated as wake (fail-open)
+    // so a buggy gate cannot silence the agent.
+    if (this.attentionGate) {
+      let wake = true;
+      try {
+        const result = this.attentionGate(msg);
+        wake = result instanceof Promise ? await result : result;
+      } catch (err) {
+        this.log.warn("dispatcher: attentionGate threw — waking", {
+          messageId: msg.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        wake = true;
+      }
+      if (!wake) {
+        this.log.debug("dispatcher skip turn: attention policy", {
+          messageId: msg.id,
+          accountId: msg.accountId,
+          conversationId: msg.conversation.id,
+        });
+        return;
       }
     }
 

--- a/packages/daemon/src/gateway/gateway.ts
+++ b/packages/daemon/src/gateway/gateway.ts
@@ -7,6 +7,7 @@ import type {
   ChannelAdapter,
   GatewayChannelConfig,
   GatewayConfig,
+  GatewayInboundMessage,
   GatewayRoute,
   GatewayRuntimeSnapshot,
   InboundObserver,
@@ -48,6 +49,14 @@ export interface GatewayBootOptions {
    * bookkeeping like loop-risk tracking.
    */
   onOutbound?: OutboundObserver;
+  /**
+   * Optional attention gate (PR3, design §4.2). Forwarded to the dispatcher
+   * verbatim — see {@link Dispatcher} for semantics. Returning `false` skips
+   * the runtime turn while preserving ack + onInbound side effects.
+   */
+  attentionGate?: (
+    message: GatewayInboundMessage,
+  ) => Promise<boolean> | boolean;
 }
 
 /** Default runtime factory: delegates to the built-in registry; ignores extraArgs at construction. */
@@ -118,6 +127,7 @@ export class Gateway {
       composeUserTurn: opts.composeUserTurn,
       onOutbound: opts.onOutbound,
       managedRoutes: this.managedRoutes,
+      attentionGate: opts.attentionGate,
     });
 
     this.channelManager = new ChannelManager({

--- a/packages/daemon/src/gateway/policy-resolver.ts
+++ b/packages/daemon/src/gateway/policy-resolver.ts
@@ -1,0 +1,136 @@
+/**
+ * Daemon-side per-agent attention-policy cache (PR3, design §5).
+ *
+ * The dispatcher consults this resolver after `onInbound` fires and before
+ * the runtime turn enqueues. Cache keys:
+ *
+ *   - `agent_id`              → global default policy
+ *   - `agent_id:room_id`      → effective per-room override (PR2 will start
+ *                                writing to this slot once override APIs land)
+ *
+ * On cache miss the resolver calls the caller-supplied `fetchEffective`
+ * factory; on `invalidate(agent_id, room_id)` the matching entry is dropped,
+ * and on `invalidate(agent_id)` every entry for that agent is dropped.
+ *
+ * For PR3 the daemon does not yet know the per-room override URL — that is
+ * PR2's surface. When `fetchEffective` is omitted we fall back to the
+ * global policy, which means the resolver is effectively per-agent only
+ * until PR2 wires up the per-room fetch.
+ */
+
+import type { AttentionPolicy } from "@botcord/protocol-core";
+
+/** Public surface — kept narrow so the dispatcher can mock easily in tests. */
+export interface PolicyResolverLike {
+  resolve(agentId: string, roomId: string | null): Promise<AttentionPolicy>;
+  invalidate(agentId: string, roomId?: string): void;
+  /**
+   * Install (or replace) the cached policy entry for an agent / room. Used
+   * by the `policy_updated` control-frame handler to apply embedded policy
+   * payloads without forcing a refetch.
+   */
+  put(agentId: string, roomId: string | null, policy: AttentionPolicy): void;
+}
+
+export interface PolicyResolverOptions {
+  /** Fetcher for the per-agent default. Returning `undefined` means "no policy known"; the resolver falls back to `mode=always`. */
+  fetchGlobal: (agentId: string) => Promise<AttentionPolicy | undefined>;
+  /**
+   * Optional per-room fetcher. PR2 supplies this; PR3 leaves it
+   * unimplemented and the resolver collapses to the global policy.
+   */
+  fetchEffective?: (
+    agentId: string,
+    roomId: string,
+  ) => Promise<AttentionPolicy | undefined>;
+  /** Cache TTL in milliseconds. Defaults to 5 minutes. */
+  ttlMs?: number;
+}
+
+interface Entry {
+  policy: AttentionPolicy;
+  expiresAt: number;
+}
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * Force DM rooms (`rm_dm_*`) to `mode: "always"` per design §4.2 — UI never
+ * lets the user mute a DM, but a stale cache from before a UX bug is cheap
+ * to defend against here.
+ */
+function maybeForceDm(roomId: string | null, policy: AttentionPolicy): AttentionPolicy {
+  if (roomId && roomId.startsWith("rm_dm_") && policy.mode !== "always") {
+    return { ...policy, mode: "always" };
+  }
+  return policy;
+}
+
+function defaultPolicy(): AttentionPolicy {
+  return { mode: "always", keywords: [] };
+}
+
+export class PolicyResolver implements PolicyResolverLike {
+  private readonly fetchGlobal: PolicyResolverOptions["fetchGlobal"];
+  private readonly fetchEffective?: PolicyResolverOptions["fetchEffective"];
+  private readonly ttlMs: number;
+  private readonly cache: Map<string, Entry> = new Map();
+
+  constructor(opts: PolicyResolverOptions) {
+    this.fetchGlobal = opts.fetchGlobal;
+    this.fetchEffective = opts.fetchEffective;
+    this.ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS;
+  }
+
+  async resolve(agentId: string, roomId: string | null): Promise<AttentionPolicy> {
+    const key = cacheKey(agentId, roomId);
+    const now = Date.now();
+    const hit = this.cache.get(key);
+    if (hit && hit.expiresAt > now) {
+      return hit.policy;
+    }
+
+    let fetched: AttentionPolicy | undefined;
+    try {
+      if (roomId && this.fetchEffective) {
+        fetched = await this.fetchEffective(agentId, roomId);
+      } else {
+        fetched = await this.fetchGlobal(agentId);
+      }
+    } catch {
+      // Fail-open: a fetch error must not silence the agent. Use the default
+      // policy and skip caching so the next resolve retries.
+      return defaultPolicy();
+    }
+
+    const policy = maybeForceDm(roomId, fetched ?? defaultPolicy());
+    this.cache.set(key, { policy, expiresAt: now + this.ttlMs });
+    return policy;
+  }
+
+  invalidate(agentId: string, roomId?: string): void {
+    if (roomId !== undefined) {
+      this.cache.delete(cacheKey(agentId, roomId));
+      return;
+    }
+    // Drop every entry for this agent.
+    const prefix = agentId + ":";
+    for (const key of Array.from(this.cache.keys())) {
+      if (key === agentId || key.startsWith(prefix)) {
+        this.cache.delete(key);
+      }
+    }
+  }
+
+  put(agentId: string, roomId: string | null, policy: AttentionPolicy): void {
+    const key = cacheKey(agentId, roomId);
+    this.cache.set(key, {
+      policy: maybeForceDm(roomId, policy),
+      expiresAt: Date.now() + this.ttlMs,
+    });
+  }
+}
+
+function cacheKey(agentId: string, roomId: string | null): string {
+  return roomId ? `${agentId}:${roomId}` : agentId;
+}

--- a/packages/daemon/src/gateway/policy-resolver.ts
+++ b/packages/daemon/src/gateway/policy-resolver.ts
@@ -2,20 +2,24 @@
  * Daemon-side per-agent attention-policy cache (PR3, design §5).
  *
  * The dispatcher consults this resolver after `onInbound` fires and before
- * the runtime turn enqueues. Cache keys:
+ * the runtime turn enqueues. Cache layout:
  *
- *   - `agent_id`              → global default policy
- *   - `agent_id:room_id`      → effective per-room override (PR2 will start
- *                                writing to this slot once override APIs land)
+ *   - `agent_id`              → global default policy (seeded by
+ *                                `provision_agent` + `policy_updated{agent}`).
+ *   - `agent_id:room_id`      → genuine per-room override only — installed
+ *                                exclusively via `put` from a per-room
+ *                                `policy_updated` frame. Inheritance reads
+ *                                never write here.
  *
- * On cache miss the resolver calls the caller-supplied `fetchEffective`
- * factory; on `invalidate(agent_id, room_id)` the matching entry is dropped,
- * and on `invalidate(agent_id)` every entry for that agent is dropped.
+ * `resolve(agent, room)` checks the room key first, then falls back to the
+ * global key. This means a per-room override always wins, and the global
+ * propagates to every room without explicit fan-out (a global update only
+ * needs to refresh the agent_id entry).
  *
- * For PR3 the daemon does not yet know the per-room override URL — that is
- * PR2's surface. When `fetchEffective` is omitted we fall back to the
- * global policy, which means the resolver is effectively per-agent only
- * until PR2 wires up the per-room fetch.
+ * `invalidate(agent_id, room_id)` drops the matching room entry; the next
+ * resolve falls through to the global. `invalidate(agent_id)` drops every
+ * entry for that agent — both global and any room overrides — used when
+ * the agent is revoked or the cache must rebuild from scratch.
  */
 
 import type { AttentionPolicy } from "@botcord/protocol-core";
@@ -53,6 +57,7 @@ interface Entry {
 }
 
 const DEFAULT_TTL_MS = 5 * 60 * 1000;
+const FETCH_FAILED = Symbol("fetch_failed");
 
 /**
  * Force DM rooms (`rm_dm_*`) to `mode: "always"` per design §4.2 — UI never
@@ -83,29 +88,59 @@ export class PolicyResolver implements PolicyResolverLike {
   }
 
   async resolve(agentId: string, roomId: string | null): Promise<AttentionPolicy> {
-    const key = cacheKey(agentId, roomId);
     const now = Date.now();
-    const hit = this.cache.get(key);
-    if (hit && hit.expiresAt > now) {
-      return hit.policy;
+
+    // 1. Per-room cache — populated either by a `policy_updated{room_id}`
+    //    push (genuine override) or by a prior `fetchEffective` cold-start.
+    if (roomId) {
+      const roomHit = this.cache.get(cacheKey(agentId, roomId));
+      if (roomHit && roomHit.expiresAt > now) return roomHit.policy;
     }
 
-    let fetched: AttentionPolicy | undefined;
+    // 2. If a per-room fetcher is wired, treat it as authoritative for cold
+    //    rooms — it returns the override-merged effective policy and so must
+    //    not be skipped just because the global cache is warm.
+    if (roomId && this.fetchEffective) {
+      const fetched = await this.safeFetch(() =>
+        this.fetchEffective!(agentId, roomId),
+      );
+      if (fetched === FETCH_FAILED) return defaultPolicy();
+      const policy = fetched ?? defaultPolicy();
+      this.cache.set(cacheKey(agentId, roomId), {
+        policy: maybeForceDm(roomId, policy),
+        expiresAt: now + this.ttlMs,
+      });
+      return maybeForceDm(roomId, policy);
+    }
+
+    // 3. No room override known — inherit from the cached agent-wide global.
+    //    Without this layer, group messages collapsed to mode=always whenever
+    //    the daemon ran without a per-room fetcher (the current production
+    //    state), silently breaking global mention_only/muted.
+    const globalKey = cacheKey(agentId, null);
+    const globalHit = this.cache.get(globalKey);
+    if (globalHit && globalHit.expiresAt > now) {
+      return maybeForceDm(roomId, globalHit.policy);
+    }
+
+    // 4. Cold start for global.
+    const fetched = await this.safeFetch(() => this.fetchGlobal(agentId));
+    if (fetched === FETCH_FAILED) return defaultPolicy();
+    const policy = fetched ?? defaultPolicy();
+    this.cache.set(globalKey, { policy, expiresAt: now + this.ttlMs });
+    return maybeForceDm(roomId, policy);
+  }
+
+  private async safeFetch(
+    fn: () => Promise<AttentionPolicy | undefined>,
+  ): Promise<AttentionPolicy | undefined | typeof FETCH_FAILED> {
     try {
-      if (roomId && this.fetchEffective) {
-        fetched = await this.fetchEffective(agentId, roomId);
-      } else {
-        fetched = await this.fetchGlobal(agentId);
-      }
+      return await fn();
     } catch {
-      // Fail-open: a fetch error must not silence the agent. Use the default
-      // policy and skip caching so the next resolve retries.
-      return defaultPolicy();
+      // Fail-open: a fetch error must not silence the agent. The caller
+      // returns the default policy without caching so the next resolve retries.
+      return FETCH_FAILED;
     }
-
-    const policy = maybeForceDm(roomId, fetched ?? defaultPolicy());
-    this.cache.set(key, { policy, expiresAt: now + this.ttlMs });
-    return policy;
   }
 
   invalidate(agentId: string, roomId?: string): void {

--- a/packages/daemon/src/mention-scan.ts
+++ b/packages/daemon/src/mention-scan.ts
@@ -1,0 +1,38 @@
+/**
+ * Mention text-fallback (design §4.2). The Hub's `messages.mentioned` flag is
+ * sender-supplied and therefore not trustworthy on its own; we OR it with a
+ * local scan for `@<display_name>` or `@<agent_id>` so an agent that the
+ * sender forgot (or refused) to mark mentioned still wakes when addressed.
+ *
+ * Kept tiny and synchronous — runs on every inbound message. Both inputs are
+ * normalized to lowercase to keep the match case-insensitive.
+ */
+
+export interface MentionTargets {
+  /** Daemon-known agent id (e.g. `ag_xxx`). Always included when present. */
+  agentId?: string;
+  /** Display name from the agent's credentials. */
+  displayName?: string;
+}
+
+/**
+ * Return `true` when `text` contains an `@`-prefixed mention of `agentId`
+ * or `displayName`. Matches a literal `@` followed by the target — both the
+ * `@` and the target are required because plain occurrences of the
+ * displayName in conversation should NOT count as a mention.
+ */
+export function scanMention(text: string | undefined, targets: MentionTargets): boolean {
+  if (!text) return false;
+  const lower = text.toLowerCase();
+  const candidates: string[] = [];
+  if (targets.agentId) candidates.push(targets.agentId.toLowerCase());
+  if (targets.displayName) {
+    const trimmed = targets.displayName.trim();
+    if (trimmed) candidates.push(trimmed.toLowerCase());
+  }
+  for (const c of candidates) {
+    if (!c) continue;
+    if (lower.includes("@" + c)) return true;
+  }
+  return false;
+}

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -24,6 +24,8 @@ import {
   type StoredBotCordCredentials,
 } from "@botcord/protocol-core";
 import type { Gateway } from "./gateway/index.js";
+import type { PolicyResolverLike } from "./gateway/policy-resolver.js";
+import type { PolicyUpdatedParams } from "@botcord/protocol-core";
 import type {
   GatewayChannelConfig,
   GatewayRuntimeSnapshot,
@@ -55,6 +57,14 @@ export interface ProvisionerOptions {
    * run without a real Hub.
    */
   register?: typeof BotCordClient.register;
+  /**
+   * Optional policy-resolver handle (PR3). When present, the
+   * `policy_updated` control frame routes through it: cache is invalidated
+   * for the (agent, room?) pair, and any embedded `policy` payload is
+   * applied directly so the next inbound sees the fresh policy without an
+   * extra round-trip.
+   */
+  policyResolver?: PolicyResolverLike;
 }
 
 /** The value a frame handler returns (minus the `id` which the channel fills in). */
@@ -70,6 +80,7 @@ export function createProvisioner(opts: ProvisionerOptions): (
 ) => Promise<AckBody> {
   const gateway = opts.gateway;
   const register = opts.register ?? BotCordClient.register;
+  const policyResolver = opts.policyResolver;
 
   return async (frame: ControlFrame): Promise<AckBody> => {
     daemonLog.debug("provision.dispatch", { type: frame.type, id: frame.id });
@@ -86,6 +97,18 @@ export function createProvisioner(opts: ProvisionerOptions): (
           name: params.name ?? null,
         });
         const agent = await provisionAgent(params, { gateway, register });
+        // Seed the policy resolver from the optional `defaultAttention` /
+        // `attentionKeywords` fields (PR3, control-frame.ts). Hub builds that
+        // don't yet emit these stay backwards-compatible — the resolver just
+        // falls back to `mode=always` until a `policy_updated` frame arrives.
+        if (policyResolver && params.defaultAttention) {
+          policyResolver.put(agent.agentId, null, {
+            mode: params.defaultAttention,
+            keywords: Array.isArray(params.attentionKeywords)
+              ? params.attentionKeywords.slice()
+              : [],
+          });
+        }
         return {
           ok: true,
           result: {
@@ -123,6 +146,47 @@ export function createProvisioner(opts: ProvisionerOptions): (
         daemonLog.info("set_route: start", { frameId: frame.id });
         const res = setRoute(frame.params ?? {});
         return { ok: true, result: res };
+      }
+
+      case CONTROL_FRAME_TYPES.POLICY_UPDATED: {
+        const params = (frame.params ?? {}) as unknown as PolicyUpdatedParams;
+        const agentId = params.agent_id;
+        if (typeof agentId !== "string" || !agentId) {
+          return {
+            ok: false,
+            error: { code: "bad_params", message: "policy_updated requires agent_id" },
+          };
+        }
+        if (!policyResolver) {
+          // No resolver wired — quietly succeed; the daemon may be running
+          // without the gateway-level attention gate (e.g. legacy boot path).
+          daemonLog.debug("policy_updated: no resolver — noop", { agentId });
+          return { ok: true, result: { agent_id: agentId, applied: false } };
+        }
+        const roomId = typeof params.room_id === "string" ? params.room_id : undefined;
+        if (params.policy) {
+          // Embedded policy payload — install directly to avoid a refetch.
+          policyResolver.put(agentId, roomId ?? null, {
+            mode: params.policy.mode,
+            keywords: Array.isArray(params.policy.keywords)
+              ? params.policy.keywords.slice()
+              : [],
+            ...(typeof params.policy.muted_until === "number"
+              ? { muted_until: params.policy.muted_until }
+              : {}),
+          });
+        } else {
+          policyResolver.invalidate(agentId, roomId);
+        }
+        daemonLog.info("policy_updated: applied", {
+          agentId,
+          roomId: roomId ?? null,
+          embedded: !!params.policy,
+        });
+        return {
+          ok: true,
+          result: { agent_id: agentId, applied: true, embedded: !!params.policy },
+        };
       }
 
       case CONTROL_FRAME_TYPES.LIST_RUNTIMES: {

--- a/packages/protocol-core/package.json
+++ b/packages/protocol-core/package.json
@@ -13,7 +13,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "prepublishOnly": "tsc"
+    "prepublishOnly": "tsc",
+    "test": "vitest run"
   },
   "files": [
     "dist/",
@@ -25,6 +26,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "vitest": "^4.1.5"
   }
 }

--- a/packages/protocol-core/src/__tests__/should-wake.test.ts
+++ b/packages/protocol-core/src/__tests__/should-wake.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { shouldWake, type AttentionPolicy } from "../should-wake.js";
+
+const NOW = 1_700_000_000_000;
+
+function policy(overrides: Partial<AttentionPolicy> = {}): AttentionPolicy {
+  return { mode: "always", keywords: [], ...overrides };
+}
+
+describe("shouldWake", () => {
+  it("mode=always always wakes", () => {
+    expect(shouldWake(policy(), { text: "hi" }, NOW)).toBe(true);
+    expect(shouldWake(policy(), { text: "" }, NOW)).toBe(true);
+  });
+
+  it("mode=muted never wakes even when text mentions agent", () => {
+    expect(
+      shouldWake(policy({ mode: "muted" }), { text: "@me hi", mentioned: true }, NOW),
+    ).toBe(false);
+  });
+
+  it("muted_until in the future suppresses wake regardless of mode", () => {
+    expect(
+      shouldWake(
+        policy({ mode: "always", muted_until: NOW + 60_000 }),
+        { text: "anything" },
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  it("muted_until in the past does not suppress", () => {
+    expect(
+      shouldWake(
+        policy({ mode: "always", muted_until: NOW - 1 }),
+        { text: "anything" },
+        NOW,
+      ),
+    ).toBe(true);
+  });
+
+  it("mode=mention_only requires msg.mentioned === true", () => {
+    expect(
+      shouldWake(policy({ mode: "mention_only" }), { text: "hi", mentioned: false }, NOW),
+    ).toBe(false);
+    expect(
+      shouldWake(policy({ mode: "mention_only" }), { text: "hi", mentioned: true }, NOW),
+    ).toBe(true);
+    expect(
+      shouldWake(policy({ mode: "mention_only" }), { text: "hi" }, NOW),
+    ).toBe(false);
+  });
+
+  it("mode=keyword matches case-insensitive substring", () => {
+    const p = policy({ mode: "keyword", keywords: ["Foo", "BAR"] });
+    expect(shouldWake(p, { text: "hello foo world" }, NOW)).toBe(true);
+    expect(shouldWake(p, { text: "BAR" }, NOW)).toBe(true);
+    expect(shouldWake(p, { text: "nothing here" }, NOW)).toBe(false);
+    expect(shouldWake(p, {}, NOW)).toBe(false);
+  });
+
+  it("mode=keyword with empty list never wakes", () => {
+    expect(
+      shouldWake(policy({ mode: "keyword", keywords: [] }), { text: "anything" }, NOW),
+    ).toBe(false);
+  });
+
+  it("unknown mode fails open (forward-compat)", () => {
+    const future = { mode: "future_mode", keywords: [] } as unknown as AttentionPolicy;
+    expect(shouldWake(future, { text: "hi" }, NOW)).toBe(true);
+  });
+});

--- a/packages/protocol-core/src/control-frame.ts
+++ b/packages/protocol-core/src/control-frame.ts
@@ -65,6 +65,13 @@ export const CONTROL_FRAME_TYPES = {
    * daemon is offline. Plan §8.5 "push" path.
    */
   RUNTIME_SNAPSHOT: "runtime_snapshot",
+  /**
+   * Hub→daemon: invalidate the daemon's cached attention policy for a given
+   * agent (and optionally a single room override). Sent by the BFF after
+   * `PATCH /api/agents/{id}/policy` and the per-room override endpoints.
+   * Payload shape: see {@link PolicyUpdatedParams}.
+   */
+  POLICY_UPDATED: "policy_updated",
 } as const;
 
 export type ControlFrameType = (typeof CONTROL_FRAME_TYPES)[keyof typeof CONTROL_FRAME_TYPES];
@@ -118,6 +125,42 @@ export interface ProvisionAgentParams {
     runtime?: string;
     /** Working directory cached alongside the runtime, for route synthesis. */
     cwd?: string;
+  };
+  /**
+   * Optional initial attention policy seed. When the Hub already knows the
+   * agent's stored `default_attention` and `attention_keywords` (i.e. a
+   * non-fresh provision flow), it can hand the values down so the daemon's
+   * `policyResolver` is warm before the first inbound message lands. Daemons
+   * that don't recognize these fields safely ignore them (PR3 §5).
+   */
+  defaultAttention?: "always" | "mention_only" | "keyword" | "muted";
+  attentionKeywords?: string[];
+}
+
+/**
+ * Payload shape for `policy_updated` (PR3). Sent by the BFF after a policy
+ * mutation lands so the daemon hosting the agent can drop its cached entry
+ * and (when `policy` is embedded) install the fresh values without a
+ * network round-trip.
+ *
+ * Wire-shape rationale: the design doc (§5) specifies `{agent_id, room_id?}`.
+ * PR3 augments the payload with an optional `policy` blob so the daemon does
+ * not need a separate signed-fetch endpoint to get the new values — the Hub
+ * already holds the authoritative state, so it pushes the post-update view
+ * inline. A daemon that doesn't recognize `policy` simply invalidates its
+ * cache and falls back to the seed values from `provision_agent`.
+ *
+ * `room_id` is reserved for PR2's per-room override endpoints; when absent
+ * the daemon drops every cache entry for `agent_id` (global + per-room).
+ */
+export interface PolicyUpdatedParams {
+  agent_id: string;
+  room_id?: string;
+  policy?: {
+    mode: "always" | "mention_only" | "keyword" | "muted";
+    keywords: string[];
+    /** Unix milliseconds; absent means no temporary mute. */
+    muted_until?: number;
   };
 }
 

--- a/packages/protocol-core/src/control-frame.ts
+++ b/packages/protocol-core/src/control-frame.ts
@@ -150,8 +150,12 @@ export interface ProvisionAgentParams {
  * inline. A daemon that doesn't recognize `policy` simply invalidates its
  * cache and falls back to the seed values from `provision_agent`.
  *
- * `room_id` is reserved for PR2's per-room override endpoints; when absent
- * the daemon drops every cache entry for `agent_id` (global + per-room).
+ * `room_id` is set when a per-room override is created/updated/cleared; it
+ * targets the agent_id:room_id cache slot. When `room_id` is absent the
+ * frame targets the agent's global cache slot. Per-room overrides survive
+ * a global update (resolution is room-first with global as fallback), so a
+ * global frame need not invalidate room entries — updating the global slot
+ * automatically propagates to every room that still inherits.
  */
 export interface PolicyUpdatedParams {
   agent_id: string;

--- a/packages/protocol-core/src/index.ts
+++ b/packages/protocol-core/src/index.ts
@@ -6,3 +6,4 @@ export * from "./session-key.js";
 export * from "./client.js";
 export * from "./daemon-client.js";
 export * from "./control-frame.js";
+export * from "./should-wake.js";

--- a/packages/protocol-core/src/should-wake.ts
+++ b/packages/protocol-core/src/should-wake.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure attention-gate decision used by the daemon (and, eventually, the
+ * plugin) to decide whether an inbound message should wake the LLM. Lives in
+ * `@botcord/protocol-core` so the two consumers cannot drift (design §4.2).
+ *
+ * Inputs are deliberately tiny: a resolved {@link AttentionPolicy} and a
+ * minimal {@link AttentionMessage} the caller projects from whatever inbound
+ * shape it has. Mention text-fallback is the caller's responsibility — pass
+ * the OR of `envelope.mentioned` and any local `@<name>` scan in
+ * `message.mentioned`.
+ */
+
+/** Attention modes mirroring `hub.enums.AttentionMode`. */
+export type AttentionMode = "always" | "mention_only" | "keyword" | "muted";
+
+/** Effective per-agent / per-room policy after override resolution. */
+export interface AttentionPolicy {
+  mode: AttentionMode;
+  /** Literal substrings (case-insensitive). Empty → keyword mode never wakes. */
+  keywords: string[];
+  /** Unix milliseconds; when in the future the agent stays muted regardless of mode. */
+  muted_until?: number;
+}
+
+/** Minimum projection of an inbound message the gate needs to inspect. */
+export interface AttentionMessage {
+  /** Final mention bit (envelope OR text-scan); true if this agent is addressed. */
+  mentioned?: boolean;
+  /** Plain text body — used by `keyword` mode. */
+  text?: string;
+}
+
+/**
+ * Decide whether an inbound message should wake the runtime. The function is
+ * intentionally side-effect free; logging and metrics are left to the caller
+ * so this stays trivially testable.
+ *
+ * Note: the resolver is responsible for forcing DM rooms (`rm_dm_*`) to
+ * `mode: "always"` per design §4.2 — `shouldWake` consumes the policy
+ * verbatim and does not second-guess it.
+ */
+export function shouldWake(
+  policy: AttentionPolicy,
+  msg: AttentionMessage,
+  now: number = Date.now(),
+): boolean {
+  if (policy.mode === "muted") return false;
+  if (typeof policy.muted_until === "number" && policy.muted_until > now) {
+    return false;
+  }
+  switch (policy.mode) {
+    case "always":
+      return true;
+    case "mention_only":
+      return msg.mentioned === true;
+    case "keyword": {
+      // Literal case-insensitive substring match. Regex was rejected for PR3
+      // because user-supplied keywords are not vetted — a runaway pattern
+      // would burn CPU on every inbound. Promotion to regex is left to a
+      // follow-up that adds anchoring + size caps (see design §4.2).
+      const text = (msg.text ?? "").toLowerCase();
+      if (!text) return false;
+      for (const kw of policy.keywords) {
+        if (!kw) continue;
+        if (text.includes(kw.toLowerCase())) return true;
+      }
+      return false;
+    }
+    default:
+      // Unknown mode — fail open so a forward-compat policy from a newer Hub
+      // doesn't silently mute the agent.
+      return true;
+  }
+}


### PR DESCRIPTION
## Summary

Implements `docs/agent-policy-design.md` — splits the legacy single-axis `message_policy` into two orthogonal policy layers: **admission** (Hub-side: who can DM/invite me) and **attention** (daemon-side: should this inbound wake the LLM). Per-agent global defaults plus per-room override; dashboard UI for both.

Stacked across 4 logical PRs that were already merged into this branch:

- **PR1** — backend schema + admission helpers. Adds `contact_policy` / `room_invite_policy` / `allow_agent_sender` / `allow_human_sender` / `default_attention` / `attention_keywords` on `agents` (migration 029). Centralizes admission via `hub/policy.py:check_direct_admission` + `check_room_invite_admission`; wired at `/hub/send`, `/hub/rooms` create, `/hub/rooms/{id}/members`, `/api/humans` add-member, and the dashboard human→room fan-out (`allow_human_sender` filter). New `GET/PATCH /api/agents/{id}/policy` BFF surface.
- **PR2** — per-room attention override. Migration 030 + `AgentRoomPolicyOverride` (sparse). `resolve_effective_attention` resolver (DM rooms forced `always`). `GET/PUT/DELETE /api/agents/{id}/rooms/{room_id}/policy` + `POST .../snooze`.
- **PR3** — daemon attention gate + `policy_updated` control frame. New `POLICY_UPDATED` in protocol-core, `shouldWake(policy, msg)` pure helper, `PolicyResolver` cache in daemon, dispatcher gate inserted **after `onInbound`/`safeAck`, before enqueue** (preserves working-memory + ack side effects when filtered). Hub PATCH/PUT/DELETE/snooze fans out the frame; offline/error swallowed. `provision_agent` extended to seed `defaultAttention` + `attentionKeywords` so daemons have a real policy from message zero.
- **PR4** — dashboard UI. New "对话与回复" settings tab + `usePolicyStore` Zustand store + room-level "我的回复策略" modal (Bell icon in `RoomHeader`, hidden in human-mode + DMs). BFF proxy routes for the four upstream endpoints.

Legacy `message_policy` is dual-written by both the BFF policy router and the legacy `/registry` policy endpoint, with helper-side fallback for rows whose `contact_policy` is still the default — so existing `message_policy=open` agents keep behaving correctly until that column is dropped in a follow-up.

## Test plan

- [x] Backend: `cd backend && uv run pytest tests/` — **927 passed, 31 skipped** (PR1 baseline 910 + 17 new across helpers, BFF, override, dispatch).
- [x] Protocol-core: `cd packages/protocol-core && npx vitest run` — **8 passed** (`shouldWake` matrix).
- [x] Daemon: `cd packages/daemon && npx vitest run` — **455 passed**.
- [x] Frontend: `cd frontend && pnpm test` — **21 passed**. `pnpm build` clean (with standard Supabase env vars).
- [ ] Manual QA: register a fresh agent, set `contact_policy=closed`; confirm strangers get 403 + `agent_closed_to_new_contacts`, but `contact_request` still goes through.
- [ ] Manual QA: dashboard `/settings/policy` — toggle radios, confirm PATCH fires; keyword chips persist.
- [ ] Manual QA: open a non-DM room, click Bell → quick-snooze 1h → verify daemon stops waking on inbound (check daemon logs for `dispatcher skip turn: attention policy`); 恢复默认 clears it.
- [ ] Manual QA: open a `rm_dm_*` DM as the agent; modal shows only "一对一始终回复".

## Known follow-ups (not blocking)

1. Drop `Agent.message_policy` once readers/writers migrate (separate PR).
2. Wire `policy_updated` to the dashboard realtime channel so multi-tab sessions invalidate `usePolicyStore` (`// TODO(realtime)` marker in store).
3. Daemon's `fetchEffective` is unimplemented — currently relies on the Hub pushing the inline policy on every PATCH/PUT/DELETE/snooze. If a `policy_updated` is missed, the daemon falls open to `always` (safe).
4. Global PATCH has no debounce — chatty if a user clicks fast.
5. Plugin attention gate (PR3b in design) deferred — daemon-only for v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)