### PR TITLE
feat(daemon): bundle @botcord/cli with version-locked hub/agent env injection

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botcord/cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "BotCord CLI — register agents, send signed messages, manage rooms and contacts",
   "type": "module",
   "bin": {
@@ -30,7 +30,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@botcord/protocol-core": "^0.1.0"
+    "@botcord/protocol-core": "^0.2.0"
   },
   "devDependencies": {
     "typescript": "^5.4.0",

--- a/cli/pnpm-lock.yaml
+++ b/cli/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@botcord/protocol-core':
-        specifier: ^0.1.0
-        version: 0.1.1
+        specifier: ^0.2.0
+        version: 0.2.0
     devDependencies:
       '@types/node':
         specifier: ^20.0.0
@@ -21,8 +21,8 @@ importers:
 
 packages:
 
-  '@botcord/protocol-core@0.1.1':
-    resolution: {integrity: sha512-qxbiavALKS7ecxw/DG3kXNxEgknvw7th+TUvapxKVuI87PCbGRnPL6kEOdNesJwj9h0lGyDtDnv3LIBfz9Y3Gw==}
+  '@botcord/protocol-core@0.2.0':
+    resolution: {integrity: sha512-n2W2/1lXGQRIncrRE5MafYiGIsSt+o3ChqxP43TdEc1b/LOmX6Ghw/du7gMVLpvRaZW6xTlUkmvsxNwWQkuYyQ==}
     engines: {node: '>=18'}
 
   '@types/node@20.19.39':
@@ -38,7 +38,7 @@ packages:
 
 snapshots:
 
-  '@botcord/protocol-core@0.1.1': {}
+  '@botcord/protocol-core@0.2.0': {}
 
   '@types/node@20.19.39':
     dependencies:

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -62,13 +62,17 @@ Global options:
   --help, -h        Show help
 
 Environment:
-  BOTCORD_HUB       Default hub URL override`;
+  BOTCORD_HUB       Default hub URL override
+  BOTCORD_AGENT_ID  Default agent id (used when --agent is not passed)`;
 
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
 
   // Global options
-  const globalAgent = typeof args.flags["agent"] === "string" ? args.flags["agent"] : undefined;
+  const globalAgent =
+    (typeof args.flags["agent"] === "string" ? args.flags["agent"] : undefined)
+    || process.env.BOTCORD_AGENT_ID
+    || undefined;
   const globalHub = typeof args.flags["hub"] === "string"
     ? args.flags["hub"]
     : (process.env.BOTCORD_HUB || undefined);

--- a/docs/daemon-cli-distribution-design.md
+++ b/docs/daemon-cli-distribution-design.md
@@ -1,0 +1,190 @@
+# Daemon 内嵌 CLI 分发策略
+
+## 背景
+
+当用户通过以下命令启动 daemon：
+
+```bash
+npx -y -p @botcord/daemon@latest botcord-daemon start --hub https://api.preview.botcord.chat
+```
+
+daemon 会为每个 agent 在 `~/.botcord/agents/{agentId}/` 下拉起 runtime（Claude Code / Codex / Gemini）。这些 runtime 经常需要在自己的 workspace 里调用 `botcord` CLI 完成发消息、查房间、管理联系人等操作。
+
+当前问题：
+
+- `@botcord/daemon` 的 `dependencies`（`packages/daemon/package.json:30`）没有 `@botcord/cli`——`npx -p @botcord/daemon` 不会附带 CLI。
+- 即使用户全局 `npm i -g @botcord/cli`，runtime 子进程虽然能通过继承的 `PATH` 找到 `botcord`，但会出现：
+  - **版本漂移**：daemon 与 CLI 各自 `latest`，`@botcord/protocol-core` 可能不一致（daemon 当前 `^0.2.0`，CLI 当前 `^0.1.0`，npm 会同时装两份），签名/控制帧不兼容。
+  - **Hub 错配**：CLI 默认 hub 不一定与 daemon 启动时 `--hub` 对齐。
+  - **agent 误用**：所有 agent 共用 `~/.botcord/credentials/`，runtime 调 CLI 时若不显式传 `--agent` 会落到 `~/.botcord/default.json`。
+
+## 目标
+
+让 runtime 在自己的 workspace 中调用 `botcord` CLI 时：
+
+1. 拿到与 daemon **版本绑定**的 CLI；
+2. **自动**使用该 agent 对应的 hub URL；
+3. **自动**作用于 workspace 所属的 agent，避免误操作他人凭证；
+4. 用户**零额外安装步骤**——`npx -p @botcord/daemon@latest` 一条命令就够。
+
+## 方案：依赖内嵌 + bin 解析 + Env 注入
+
+四步缺一不可。
+
+### 1. 先对齐 protocol-core 版本，再把 CLI 加进 daemon 依赖
+
+**前置**：把 `cli/package.json` 里 `"@botcord/protocol-core": "^0.1.0"` 升到 `^0.2.0`，与 daemon 对齐，避免 npm 同时安装两份不兼容版本。后续在 release 流程里加一道校验：daemon 与 CLI 的 protocol-core 范围必须一致。
+
+然后 `packages/daemon/package.json`：
+
+```json
+{
+  "dependencies": {
+    "@botcord/cli": "^0.1.7",
+    "@botcord/protocol-core": "^0.2.0",
+    "ws": "^8.18.0"
+  }
+}
+```
+
+> 包名是 `@botcord/cli`（CLI 的 `bin` 才叫 `botcord`），不是 `botcord`——npm 上没有 `botcord` 包。
+>
+> 版本下限**必须指向 protocol-core 已升级到 `^0.2.0` 的那个新版**。当前 npm 上的 `@botcord/cli@0.1.6` 仍依赖 `protocol-core@^0.1.0`（`cli/package.json:32`），且已发布的版本不可变。所以落地顺序是：先发 CLI 新版本（例如 `0.1.7` 或 `0.2.0`，把 protocol-core 升到 `^0.2.0`），然后 daemon 才能依赖那个新版。文档里的 `^0.1.7` 是占位，发版时按实际新版号填。
+
+效果：
+
+- `npx -y -p @botcord/daemon@latest` 拉取 daemon 时，npm 会把 `@botcord/cli` 与其依赖一并放到临时安装根；
+- 两边共享同一份 `@botcord/protocol-core`，签名算法、会话密钥派生、控制帧 schema 一致。
+
+### 2. 用 `createRequire` 解析 CLI bin 的真实路径
+
+不能假设 `daemonPackageDir/node_modules/.bin/botcord` 存在。npm 通常会把依赖**提升**到顶层（`<install-root>/node_modules/@botcord/cli`），bin 落在 `<install-root>/node_modules/.bin/botcord`，而非 daemon 子目录下。最稳妥的做法是用 `createRequire` 解析包路径，再读 `bin` 字段。
+
+在 daemon 里加一个辅助：
+
+```ts
+// packages/daemon/src/gateway/cli-resolver.ts
+import { createRequire } from "node:module";
+import path from "node:path";
+import fs from "node:fs";
+
+const require = createRequire(import.meta.url);
+
+let cached: { binDir: string; binPath: string } | null = null;
+
+export function resolveBundledCliBin(): { binDir: string; binPath: string } | null {
+  if (cached) return cached;
+  try {
+    const pkgJsonPath = require.resolve("@botcord/cli/package.json");
+    const pkgRoot = path.dirname(pkgJsonPath);
+    const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8"));
+    const binRel = typeof pkg.bin === "string" ? pkg.bin : pkg.bin?.botcord;
+    if (!binRel) return null;
+    const binPath = path.resolve(pkgRoot, binRel);
+    // PATH 注入要指向 install root 的 node_modules/.bin（npm 在那里建 botcord
+    // 软链），而不是 CLI 包内部的 dist/。pkgRoot 形如
+    //   <install-root>/node_modules/@botcord/cli
+    // 上溯两级到 <install-root>/node_modules，再 + .bin。
+    const binDir = path.resolve(pkgRoot, "..", "..", ".bin");
+    cached = { binDir, binPath };
+    return cached;
+  } catch {
+    return null; // CLI 未安装时优雅降级
+  }
+}
+```
+
+注意：
+
+- `binPath` 用于 daemon 自己**直接 spawn** CLI 入口（不依赖 `.bin` 软链是否存在，最可靠）；
+- `binDir` 用于注入 PATH，覆盖"runtime 在 shell 里手敲 `botcord`"的场景；
+- 不能用 `path.dirname(binPath)`——那会指向 `@botcord/cli/dist/`，PATH 里没有名为 `botcord` 的可执行文件。
+
+### 3. 把 per-agent hubUrl 透传到 runtime，再注入 PATH 和环境变量
+
+当前 `RuntimeRunOptions`（`packages/daemon/src/gateway/types.ts:260`）和 dispatcher 的 `runtime.run(...)` 调用（`packages/daemon/src/gateway/dispatcher.ts:572`）只带 `accountId`，没有 `hubUrl`。
+
+正确的 per-agent hub 来源是**凭证文件本身**：每张 agent 凭证记录了它注册时所连的 hub，由 `agent-discovery.ts` 在 boot 时读出。`DiscoveredAgentCredential.hubUrl`（`packages/daemon/src/agent-discovery.ts:28`、`:162`）是权威来源——**不是** daemon 用户控制面登录用的 `record.hubUrl`（`packages/daemon/src/index.ts:294`，那个是登录 hub，与 agent 凭证 hub 可以不同）。
+
+需要补：
+
+1. `RuntimeRunOptions` 增加 `hubUrl: string`；
+2. `startDaemon` 从 `boot.agents` 构建 `hubUrlByAgentId: Map<string, string>`，注入到 dispatcher / route 上下文；
+3. dispatcher 在 `runtime.run(...)` 调用处按 `msg.accountId` 查表，把 `hubUrl` 一起传下去；找不到时按 daemon 启动的 `--hub` 兜底（也只是兜底，正常路径不会用到）；
+4. `NdjsonStreamAdapter.spawnEnv`（`packages/daemon/src/gateway/runtimes/ndjson-stream.ts:77`）改成：
+
+```ts
+protected spawnEnv(opts: RuntimeRunOptions): NodeJS.ProcessEnv {
+  const cli = resolveBundledCliBin();
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    BOTCORD_HUB: opts.hubUrl,
+    BOTCORD_AGENT_ID: opts.accountId,
+  };
+  if (cli) {
+    env.PATH = `${cli.binDir}${path.delimiter}${process.env.PATH ?? ""}`;
+  }
+  return env;
+}
+```
+
+`cli` 解析失败时只做 env 注入（让用户的全局 CLI 仍可用），不阻塞 runtime 启动。
+
+### 4. CLI 端补齐 env fallback
+
+`cli/src/index.ts:71` 当前只读 `--agent`，需要加 `BOTCORD_AGENT_ID` fallback：
+
+```ts
+const globalAgent =
+  (typeof args.flags["agent"] === "string" ? args.flags["agent"] : undefined)
+  ?? process.env.BOTCORD_AGENT_ID
+  ?? undefined;
+```
+
+`BOTCORD_HUB` 已在 `cli/src/index.ts:74` 读过，保持不变。同时把 HELP 文本里的 Environment 段补上 `BOTCORD_AGENT_ID`。
+
+runtime 在 workspace 里直接：
+
+```bash
+botcord room list           # 自动用对的 hub + 对的 agent
+botcord send --to rm_xxx --text "hi"
+```
+
+完全不需要手动传参。
+
+## 方案对比
+
+| 维度 | 全局安装 (`npm i -g @botcord/cli`) | 每次 `npx -y @botcord/cli` | **依赖内嵌（本方案）** |
+|------|-------------------------------------|------------------------------|------------------------|
+| 版本与 daemon 对齐 | 漂移 | 各自 latest | 锁定 |
+| 调用延迟 | 低 | 每次拉包 | 仅 daemon 启动一次 |
+| 用户安装步骤 | 多一步 | 无 | 无 |
+| Hub 环境一致 | 手动 `--hub` | 手动 `--hub` | 自动（per-agent） |
+| agent 误用风险 | 高 | 高 | env 兜底 |
+
+## 边界与非目标
+
+- **凭证目录仍共享** `~/.botcord/credentials/`。设计如此（一台机器多 agent 共存）；`BOTCORD_AGENT_ID` 用于"默认作用域"，**不是安全隔离层**。如未来需要强隔离，再引入 per-agent HOME。
+- **用户在自己终端**手敲 `botcord ...` 仍走全局安装路径，与 daemon 无关。两条调用链并存。
+- 不改变 plugin / OpenClaw 路径下 `botcord_*` agent tool 的行为——那是另一条独立的工具注入链路。
+
+## 落地步骤
+
+1. **对齐 protocol-core 并发版 CLI**：把 `cli/package.json` 的 `@botcord/protocol-core` 升到 `^0.2.0`，跑 CLI 单测确认无回归，**发布新版本**（如 `0.1.7` 或 `0.2.0`）到 npm；旧 `0.1.6` 不可变，必须以新版为准；
+2. **加 daemon 依赖**：`packages/daemon/package.json` 加 `"@botcord/cli": "^<新版本>"`（指向第 1 步发布的版本）；
+3. **新增 `cli-resolver.ts`**：用 `createRequire` 解析 CLI 包根，`binDir = <install-root>/node_modules/.bin`，`binPath = pkgRoot + bin.botcord`；
+4. **plumb per-agent hubUrl**：扩展 `RuntimeRunOptions` 加 `hubUrl: string`；`startDaemon` 从 `boot.agents`（`agent-discovery.ts:28,162`）构建 `hubUrlByAgentId`，dispatcher 在 `runtime.run(...)`（`dispatcher.ts:572`）按 `msg.accountId` 查表填入；
+5. **改 `spawnEnv`**：在 `ndjson-stream.ts:77` 注入 PATH + `BOTCORD_HUB` + `BOTCORD_AGENT_ID`；
+6. **改 CLI**：`cli/src/index.ts:71` 加 `BOTCORD_AGENT_ID` fallback，HELP 同步更新；
+7. **release 流程校验**：CI 检查 daemon/cli 的 `@botcord/protocol-core` 范围一致；
+8. **e2e 验证**：
+   - `npx -y -p @botcord/daemon@latest botcord-daemon start --hub <preview>` 起 daemon；
+   - 让 runtime shell 执行 `botcord room list`，确认请求打到 preview hub，且作用于 workspace 对应的 agent；
+   - 切换 agent workspace 重复一遍，验证身份与 hub 都按 per-agent 解析；
+   - 卸载/未安装 `@botcord/cli` 的退化路径：daemon 仍能起，runtime fallback 到全局 `botcord`（若有）或报"command not found"。
+
+## 风险
+
+- **daemon 包体积**变大（多一份 CLI 及其依赖）。CLI 体量小，可接受。
+- **CLI 升级耦合 daemon 发版**。利大于弊：通过统一发版避免协议层面的版本漂移。如需独立修 CLI bug，照常发 patch 版本，daemon 下次发版自动跟进。
+- **`createRequire` 解析依赖 npm 实际拓扑**。已在第 2 步用 try/catch 优雅降级；CI 里需要至少一个 e2e 真跑 `npx -p @botcord/daemon`，确保解析路径在真实安装结构下成立。

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -27,7 +27,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@botcord/cli": "^0.1.7",
+    "@botcord/cli": "0.1.7",
     "@botcord/protocol-core": "^0.2.0",
     "ws": "^8.18.0"
   },

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -27,6 +27,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@botcord/cli": "^0.1.7",
     "@botcord/protocol-core": "^0.2.0",
     "ws": "^8.18.0"
   },

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -228,6 +228,18 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
 
   const gwConfig = toGatewayConfig(opts.config, { agentIds, agentRuntimes });
 
+  // Per-agent hub URL — read from each credential file at boot. Used to
+  // populate `BOTCORD_HUB` for runtime CLI subprocesses so the bundled
+  // `botcord` CLI talks to the same hub the agent is registered against,
+  // even when a single daemon hosts agents from different hubs.
+  const hubUrlByAgentId = new Map<string, string>();
+  for (const a of boot.agents) {
+    if (a.hubUrl) hubUrlByAgentId.set(a.agentId, a.hubUrl);
+  }
+  const fallbackHubUrl = opts.hubBaseUrl;
+  const resolveHubUrl = (accountId: string): string | undefined =>
+    hubUrlByAgentId.get(accountId) ?? fallbackHubUrl;
+
   // ActivityTracker lives at the daemon layer (not the gateway core). We
   // expose it to the gateway via (a) the `buildSystemContext` hook so the
   // cross-room digest reflects current activity, and (b) the `onInbound`
@@ -381,6 +393,7 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
     onOutbound,
     composeUserTurn: composeBotCordUserTurn,
     attentionGate,
+    resolveHubUrl,
   });
 
   logger.info("daemon starting", {

--- a/packages/daemon/src/gateway/cli-resolver.ts
+++ b/packages/daemon/src/gateway/cli-resolver.ts
@@ -1,0 +1,92 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+import fs from "node:fs";
+import { consoleLogger } from "./log.js";
+
+const require = createRequire(import.meta.url);
+
+// Tri-state cache: `undefined` means "not yet attempted"; `null` means
+// "attempted and unavailable" (don't retry, don't re-log).
+let cached: { binDir: string; binPath: string } | null | undefined;
+
+export interface BundledCliBin {
+  /** Directory containing the `botcord` symlink — safe to prepend to PATH. */
+  binDir: string;
+  /** Absolute path to the CLI's JS entry — for direct spawn (not via PATH). */
+  binPath: string;
+}
+
+/**
+ * Resolve the bundled `@botcord/cli` package and return both the
+ * `<install-root>/node_modules/.bin` directory (for PATH injection so
+ * `botcord` shows up to runtimes) and the absolute JS entry (for callers
+ * that want to spawn the CLI directly without depending on the symlink).
+ *
+ * Returns `null` when `@botcord/cli` is not installed alongside the daemon
+ * — callers should fall back to whatever `botcord` is on the user's PATH.
+ */
+export function resolveBundledCliBin(): BundledCliBin | null {
+  if (cached !== undefined) return cached;
+  try {
+    const pkgJsonPath = require.resolve("@botcord/cli/package.json");
+    const pkgRoot = path.dirname(pkgJsonPath);
+    const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8")) as {
+      bin?: string | Record<string, string>;
+    };
+    const binRel =
+      typeof pkg.bin === "string" ? pkg.bin : pkg.bin?.botcord;
+    if (!binRel) {
+      consoleLogger.warn("cli-resolver: @botcord/cli has no bin.botcord entry");
+      cached = null;
+      return null;
+    }
+    const binPath = path.resolve(pkgRoot, binRel);
+    // PATH must point at `<install-root>/node_modules/.bin` (where npm puts
+    // the `botcord` shim), not the package's own `dist/` — there is no
+    // executable named `botcord` inside the package directory.
+    const binDir = path.resolve(pkgRoot, "..", "..", ".bin");
+    cached = { binDir, binPath };
+    return cached;
+  } catch (err) {
+    consoleLogger.warn(
+      "cli-resolver: bundled @botcord/cli not resolvable; runtimes will fall back to PATH",
+      { error: err instanceof Error ? err.message : String(err) },
+    );
+    cached = null;
+    return null;
+  }
+}
+
+/** Test-only: clear the cached resolution. */
+export function __resetBundledCliBinCache(): void {
+  cached = undefined;
+}
+
+/**
+ * Return env additions that point a runtime CLI subprocess at the right
+ * BotCord identity:
+ *   - `BOTCORD_HUB`      — hub URL the agent is registered against
+ *   - `BOTCORD_AGENT_ID` — default `--agent` for `botcord ...` invocations
+ *   - `PATH`             — prepended with the bundled CLI's `.bin` dir so
+ *                          `botcord` resolves to the version daemon shipped
+ *                          with (avoiding protocol-core drift). Falls
+ *                          through to whatever the user already has on PATH
+ *                          when the bundled CLI can't be resolved.
+ */
+export function buildCliEnv(opts: {
+  hubUrl?: string;
+  accountId?: string;
+  basePath?: string | undefined;
+}): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  if (opts.hubUrl) env.BOTCORD_HUB = opts.hubUrl;
+  if (opts.accountId) env.BOTCORD_AGENT_ID = opts.accountId;
+  const cli = resolveBundledCliBin();
+  if (cli) {
+    const existing = opts.basePath ?? "";
+    env.PATH = existing
+      ? `${cli.binDir}${path.delimiter}${existing}`
+      : cli.binDir;
+  }
+  return env;
+}

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -96,6 +96,13 @@ export interface DispatcherOptions {
   attentionGate?: (
     message: GatewayInboundMessage,
   ) => Promise<boolean> | boolean;
+  /**
+   * Resolve the hub URL the inbound message's agent is registered against.
+   * Threaded into `RuntimeRunOptions.hubUrl` so spawned CLI subprocesses
+   * target the correct hub. If unset, runtimes leave `BOTCORD_HUB`
+   * unspecified and fall back to whatever the bundled CLI defaults to.
+   */
+  resolveHubUrl?: (accountId: string) => string | undefined;
 }
 
 interface TurnSlot {
@@ -164,6 +171,7 @@ export class Dispatcher {
   private readonly attentionGate?: (
     message: GatewayInboundMessage,
   ) => Promise<boolean> | boolean;
+  private readonly resolveHubUrl?: (accountId: string) => string | undefined;
   private readonly queues: Map<string, QueueState> = new Map();
 
   constructor(opts: DispatcherOptions) {
@@ -179,6 +187,7 @@ export class Dispatcher {
     this.composeUserTurn = opts.composeUserTurn;
     this.managedRoutes = opts.managedRoutes;
     this.attentionGate = opts.attentionGate;
+    this.resolveHubUrl = opts.resolveHubUrl;
   }
 
   /** Consume one inbound envelope, ack it once ownership is decided, then run its turn. */
@@ -617,6 +626,7 @@ export class Dispatcher {
           sessionId,
           cwd: route.cwd,
           accountId: msg.accountId,
+          hubUrl: this.resolveHubUrl?.(msg.accountId),
           extraArgs: route.extraArgs,
           signal: controller.signal,
           trustLevel,

--- a/packages/daemon/src/gateway/gateway.ts
+++ b/packages/daemon/src/gateway/gateway.ts
@@ -57,6 +57,12 @@ export interface GatewayBootOptions {
   attentionGate?: (
     message: GatewayInboundMessage,
   ) => Promise<boolean> | boolean;
+  /**
+   * Resolve the per-agent hub URL for an inbound message. Forwarded to the
+   * dispatcher as `RuntimeRunOptions.hubUrl` so spawned CLI subprocesses
+   * (`BOTCORD_HUB`) target the correct hub for the owning agent.
+   */
+  resolveHubUrl?: (accountId: string) => string | undefined;
 }
 
 /** Default runtime factory: delegates to the built-in registry; ignores extraArgs at construction. */
@@ -128,6 +134,7 @@ export class Gateway {
       onOutbound: opts.onOutbound,
       managedRoutes: this.managedRoutes,
       attentionGate: opts.attentionGate,
+      resolveHubUrl: opts.resolveHubUrl,
     });
 
     this.channelManager = new ChannelManager({

--- a/packages/daemon/src/gateway/runtimes/codex.ts
+++ b/packages/daemon/src/gateway/runtimes/codex.ts
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, renameSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { agentCodexHomeDir, ensureAgentCodexHome } from "../../agent-workspace.js";
+import { buildCliEnv } from "../cli-resolver.js";
 import { NdjsonStreamAdapter, type NdjsonEventCtx } from "./ndjson-stream.js";
 import {
   firstExistingPath,
@@ -214,8 +215,14 @@ export class CodexAdapter extends NdjsonStreamAdapter {
   }
 
   protected spawnEnv(opts: RuntimeRunOptions): NodeJS.ProcessEnv {
+    const cliEnv = buildCliEnv({
+      hubUrl: opts.hubUrl,
+      accountId: opts.accountId,
+      basePath: process.env.PATH,
+    });
     const env: NodeJS.ProcessEnv = {
       ...process.env,
+      ...cliEnv,
       // Keep JSONL free of ANSI codes regardless of user terminal settings.
       FORCE_COLOR: "0",
       NO_COLOR: "1",

--- a/packages/daemon/src/gateway/runtimes/ndjson-stream.ts
+++ b/packages/daemon/src/gateway/runtimes/ndjson-stream.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { buildCliEnv } from "../cli-resolver.js";
 import { consoleLogger } from "../log.js";
 import type {
   RuntimeAdapter,
@@ -73,9 +74,21 @@ export abstract class NdjsonStreamAdapter implements RuntimeAdapter {
   protected abstract buildArgs(opts: RuntimeRunOptions): string[];
   protected abstract handleEvent(obj: unknown, ctx: NdjsonEventCtx): void;
 
-  /** Override to tweak env (FORCE_COLOR=0, NO_COLOR=1, etc). */
-  protected spawnEnv(_opts: RuntimeRunOptions): NodeJS.ProcessEnv {
-    return process.env;
+  /**
+   * Override to tweak env (FORCE_COLOR=0, NO_COLOR=1, etc). Subclasses that
+   * override should compose with the bundled-CLI env helper so spawned
+   * `botcord` invocations stay scoped to the right hub/agent — see
+   * {@link buildCliEnv}.
+   */
+  protected spawnEnv(opts: RuntimeRunOptions): NodeJS.ProcessEnv {
+    return {
+      ...process.env,
+      ...buildCliEnv({
+        hubUrl: opts.hubUrl,
+        accountId: opts.accountId,
+        basePath: process.env.PATH,
+      }),
+    };
   }
 
   async run(opts: RuntimeRunOptions): Promise<RuntimeRunResult> {

--- a/packages/daemon/src/gateway/types.ts
+++ b/packages/daemon/src/gateway/types.ts
@@ -268,6 +268,15 @@ export interface RuntimeRunOptions {
    * per-agent `CODEX_HOME` carrying the AGENTS.md that injects systemContext.
    */
   accountId: string;
+  /**
+   * Hub URL the owning agent is registered against. Forwarded to runtimes
+   * so spawned CLI subprocesses can target the correct hub via
+   * `BOTCORD_HUB` (see `cli-resolver.buildCliEnv`). Optional because the
+   * dispatcher cannot always resolve a per-agent hub (e.g. for agents
+   * provisioned after boot); when unset, runtimes leave `BOTCORD_HUB`
+   * unspecified and the bundled CLI falls back to its own default.
+   */
+  hubUrl?: string;
   signal: AbortSignal;
   extraArgs?: string[];
   trustLevel: TrustLevel;


### PR DESCRIPTION
## Summary

- Bundle `@botcord/cli` as a daemon dependency so runtime subprocesses (Claude Code / Codex / Gemini) get a `botcord` CLI on PATH that's version-locked against the daemon — no protocol-core drift.
- Thread per-agent `hubUrl` from each credential file through `RuntimeRunOptions` and inject `BOTCORD_HUB` + `BOTCORD_AGENT_ID` into spawned CLI subprocesses, so \`botcord room list\` in a workspace auto-targets the right hub + right agent with zero flags.
- New \`cli-resolver.ts\` uses \`createRequire\` to resolve the bundled CLI's bin and the install-root \`.bin\` dir; fails soft with a one-shot warn when not installed.

Design: [docs/daemon-cli-distribution-design.md](./docs/daemon-cli-distribution-design.md)

## Changes

- \`cli\`: 0.1.6 → 0.1.7, \`@botcord/protocol-core\` ^0.1.0 → ^0.2.0; \`BOTCORD_AGENT_ID\` env fallback (using \`||\` like \`BOTCORD_HUB\`)
- \`packages/daemon\`: depends on \`@botcord/cli@^0.1.7\`; \`RuntimeRunOptions.hubUrl?: string\`; \`Dispatcher\` / \`Gateway\` accept a \`resolveHubUrl(accountId)\` resolver; \`startDaemon\` builds \`hubUrlByAgentId\` from \`boot.agents\`
- \`spawnEnv\` (base + Codex override) prepends bundled CLI's \`.bin\` to PATH and sets \`BOTCORD_HUB\` / \`BOTCORD_AGENT_ID\`; \`CODEX_HOME\` ordering preserved

## Release ordering

This PR depends on \`@botcord/cli@0.1.7\` being published first (since 0.1.6 still pins \`protocol-core@^0.1.0\`). After CLI 0.1.7 is on npm, \`@botcord/daemon\` can be released and the bundling works end-to-end via a single \`npx -p @botcord/daemon@latest\`.

## Known follow-ups (not in this PR)

- \`hubUrlByAgentId\` is snapshotted at boot — agents added later via control-plane \`provision_agent\` fall through to the daemon's startup hub. Wire a setter into the provisioner once needed.
- CI guard: enforce daemon and CLI ranges of \`@botcord/protocol-core\` stay aligned.
- pnpm / npm-link layouts may not produce \`<root>/node_modules/.bin/botcord\`; \`createRequire\` fails soft and warns, but real e2e validation is on the rollout checklist.

## Test plan

- [x] \`npm run build\` clean for both \`cli\` and \`packages/daemon\`
- [x] \`npm test\` in \`packages/daemon\` — 454/454 pass
- [ ] Manual e2e: \`npx -p @botcord/daemon@<rc> botcord-daemon start --hub <preview>\` then \`botcord room list\` inside a runtime workspace; verify request hits preview hub with correct agent
- [ ] Repeat across two agents bound to different hubs to confirm per-agent resolution
- [ ] Smoke-check \`@botcord/cli\` not installed: daemon still starts, runtimes fall back to user's global \`botcord\` (or report \`command not found\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)