### PR TITLE
feat: room-scoped subscriptions + plan migration

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -23,8 +23,10 @@ from hub.dashboard_message_shaping import (
     load_user_display_names,
 )
 from hub.id_generators import generate_hub_msg_id, generate_join_request_id
+from hub.enums import SubscriptionProductStatus, SubscriptionStatus
 from hub.models import (
     Agent,
+    AgentSubscription,
     Block,
     Contact,
     ContactRequest,
@@ -41,6 +43,7 @@ from hub.models import (
     RoomVisibility,
     Share,
     ShareMessage,
+    SubscriptionProduct,
     Topic,
     User,
 )
@@ -1105,6 +1108,27 @@ async def join_room(
     if room.join_policy != RoomJoinPolicy.open:
         raise HTTPException(status_code=403, detail="Room does not allow open joining")
 
+    if room.required_subscription_product_id is not None:
+        if viewer_type != ParticipantType.agent:
+            raise HTTPException(
+                status_code=403,
+                detail="Humans cannot join subscription-gated rooms directly",
+            )
+        sub_row = (
+            await db.execute(
+                select(AgentSubscription).where(
+                    AgentSubscription.subscriber_agent_id == viewer_id,
+                    AgentSubscription.product_id == room.required_subscription_product_id,
+                    AgentSubscription.status == SubscriptionStatus.active,
+                )
+            )
+        ).scalar_one_or_none()
+        if sub_row is None:
+            raise HTTPException(
+                status_code=403,
+                detail="Active subscription required to join this room",
+            )
+
     # Check max_members — Humans occupy slots identically to Agents.
     if room.max_members is not None:
         count_result = await db.execute(
@@ -1231,7 +1255,27 @@ async def update_room_settings(
             raise HTTPException(status_code=400, detail="slow_mode_seconds must be >= 0")
         room.slow_mode_seconds = body.slow_mode_seconds
     if "required_subscription_product_id" in fields_set:
-        room.required_subscription_product_id = body.required_subscription_product_id or None
+        new_pid = body.required_subscription_product_id or None
+        if new_pid is not None:
+            product_row = (
+                await db.execute(
+                    select(SubscriptionProduct).where(
+                        SubscriptionProduct.product_id == new_pid
+                    )
+                )
+            ).scalar_one_or_none()
+            if product_row is None:
+                raise HTTPException(status_code=404, detail="Subscription product not found")
+            if product_row.owner_agent_id != room.owner_id:
+                raise HTTPException(
+                    status_code=403,
+                    detail="Subscription product does not belong to room owner",
+                )
+            if product_row.status != SubscriptionProductStatus.active:
+                raise HTTPException(
+                    status_code=400, detail="Subscription product is not active"
+                )
+        room.required_subscription_product_id = new_pid
 
     await db.commit()
     await db.refresh(room)
@@ -1249,6 +1293,133 @@ async def update_room_settings(
         "max_members": room.max_members,
         "slow_mode_seconds": room.slow_mode_seconds,
         "required_subscription_product_id": room.required_subscription_product_id,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Migrate room subscription plan (atomic create + bind + archive)
+# ---------------------------------------------------------------------------
+
+
+class MigrateRoomPlanBody(BaseModel):
+    amount_minor: str = Field(..., min_length=1)
+    billing_interval: str = Field(..., description="week or month")
+    description: str = Field(default="")
+
+
+@router.post("/rooms/{room_id}/subscription/migrate-plan")
+async def migrate_room_subscription_plan(
+    room_id: str,
+    body: MigrateRoomPlanBody,
+    ctx: RequestContext = Depends(require_active_agent),
+    db: AsyncSession = Depends(get_db),
+):
+    """Atomically swap a room's subscription plan.
+
+    Creates a new ``SubscriptionProduct``, points
+    ``room.required_subscription_product_id`` at it, archives the previous
+    product (if any and not referenced by other rooms). Existing subscribers
+    keep access until their next charge cycle, where ``_charge_subscription``
+    detects the mismatch and cancels them.
+    """
+    from hub.enums import BillingInterval
+    from hub.id_generators import generate_subscription_product_id
+    from hub.services import subscriptions as sub_svc
+
+    try:
+        amount = int(body.amount_minor)
+    except (ValueError, TypeError):
+        raise HTTPException(status_code=400, detail="Invalid amount_minor")
+    if amount <= 0:
+        raise HTTPException(status_code=400, detail="amount_minor must be positive")
+    try:
+        interval = BillingInterval(body.billing_interval)
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail="billing_interval must be 'week' or 'month'",
+        )
+    if interval not in {BillingInterval.week, BillingInterval.month}:
+        raise HTTPException(
+            status_code=400,
+            detail="billing_interval must be 'week' or 'month'",
+        )
+
+    room = (
+        await db.execute(select(Room).where(Room.room_id == room_id))
+    ).scalar_one_or_none()
+    if room is None:
+        raise HTTPException(status_code=404, detail="Room not found")
+    if room.owner_id != ctx.active_agent_id:
+        raise HTTPException(
+            status_code=403, detail="Only the room owner can change the subscription plan"
+        )
+
+    old_product_id = room.required_subscription_product_id
+    if old_product_id is not None:
+        # Reuse-state guard: an old product shared across multiple rooms
+        # cannot be changed from a single room's modal.
+        ref_count = (
+            await db.execute(
+                select(func.count(Room.id)).where(
+                    Room.required_subscription_product_id == old_product_id
+                )
+            )
+        ).scalar() or 0
+        if ref_count > 1:
+            raise HTTPException(
+                status_code=409,
+                detail="Subscription product is shared across multiple rooms",
+            )
+
+    # Stable, randomised internal name avoids the (owner_agent_id, name)
+    # uniqueness collision on retries within the same second.
+    new_product = await sub_svc.create_subscription_product(
+        db,
+        room.owner_id,
+        name=f"room:{room.room_id}:plan:{generate_subscription_product_id()}",
+        description=body.description or "",
+        amount_minor=amount,
+        billing_interval=interval,
+    )
+    room.required_subscription_product_id = new_product.product_id
+
+    if old_product_id is not None:
+        try:
+            await sub_svc.archive_subscription_product(
+                db, old_product_id, ctx.active_agent_id
+            )
+        except ValueError:
+            # Owner mismatch on the old product — leave as-is rather than
+            # blocking the plan migration.
+            pass
+
+    affected_count = 0
+    if old_product_id is not None:
+        affected_count = (
+            await db.execute(
+                select(func.count(AgentSubscription.id)).where(
+                    AgentSubscription.product_id == old_product_id,
+                    AgentSubscription.status.in_(
+                        [SubscriptionStatus.active, SubscriptionStatus.past_due]
+                    ),
+                )
+            )
+        ).scalar() or 0
+
+    await db.commit()
+    await db.refresh(room)
+
+    return {
+        "product_id": new_product.product_id,
+        "room": {
+            "room_id": room.room_id,
+            "name": room.name,
+            "description": room.description,
+            "rule": room.rule,
+            "required_subscription_product_id": room.required_subscription_product_id,
+        },
+        "affected_count": affected_count,
     }
 
 

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -1275,6 +1275,37 @@ async def update_room_settings(
                 raise HTTPException(
                     status_code=400, detail="Subscription product is not active"
                 )
+        # When clearing paid access, backfill room_id on legacy subs of the
+        # current product so the next billing cycle's mismatch check fires.
+        # Only do this when no other room references the same product —
+        # otherwise the legacy NULL room_id is genuinely ambiguous.
+        old_pid = room.required_subscription_product_id
+        if (
+            new_pid is None
+            and old_pid is not None
+        ):
+            other_rooms = (
+                await db.execute(
+                    select(func.count(Room.id)).where(
+                        Room.required_subscription_product_id == old_pid,
+                        Room.room_id != room.room_id,
+                    )
+                )
+            ).scalar() or 0
+            if other_rooms == 0:
+                from sqlalchemy import update as _sa_update
+
+                await db.execute(
+                    _sa_update(AgentSubscription)
+                    .where(
+                        AgentSubscription.product_id == old_pid,
+                        AgentSubscription.room_id.is_(None),
+                        AgentSubscription.status.in_(
+                            [SubscriptionStatus.active, SubscriptionStatus.past_due]
+                        ),
+                    )
+                    .values(room_id=room.room_id)
+                )
         room.required_subscription_product_id = new_pid
 
     await db.commit()
@@ -1382,6 +1413,29 @@ async def migrate_room_subscription_plan(
         amount_minor=amount,
         billing_interval=interval,
     )
+
+    # Backfill room_id on any pre-existing subscriptions that point at the
+    # old product but never recorded which room they were bought for. Without
+    # this, _charge_subscription's mismatch check is skipped (it gates on
+    # `room_id IS NOT NULL`) and those subs would keep auto-renewing on the
+    # archived old product. Safe to do unconditionally here because the
+    # multi-room reuse guard above already rejected any product referenced by
+    # >1 room.
+    if old_product_id is not None:
+        from sqlalchemy import update as _sa_update
+
+        await db.execute(
+            _sa_update(AgentSubscription)
+            .where(
+                AgentSubscription.product_id == old_product_id,
+                AgentSubscription.room_id.is_(None),
+                AgentSubscription.status.in_(
+                    [SubscriptionStatus.active, SubscriptionStatus.past_due]
+                ),
+            )
+            .values(room_id=room.room_id)
+        )
+
     room.required_subscription_product_id = new_product.product_id
 
     if old_product_id is not None:

--- a/backend/app/routers/subscriptions.py
+++ b/backend/app/routers/subscriptions.py
@@ -143,6 +143,7 @@ async def create_product(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 
+    await db.commit()
     await db.refresh(product)
     return _product_response(product)
 
@@ -160,6 +161,7 @@ async def archive_product(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 
+    await db.commit()
     await db.refresh(product)
     return _product_response(product)
 
@@ -187,6 +189,7 @@ async def subscribe(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 
+    await db.commit()
     # Refresh to load server-generated defaults (updated_at, created_at)
     await db.refresh(subscription)
     return _subscription_response(subscription)
@@ -256,5 +259,6 @@ async def cancel_subscription(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 
+    await db.commit()
     await db.refresh(subscription)
     return _subscription_response(subscription)

--- a/backend/app/routers/subscriptions.py
+++ b/backend/app/routers/subscriptions.py
@@ -6,13 +6,13 @@ the existing hub service layer.
 
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import RequestContext, require_active_agent
 from hub.database import get_db
-from hub.enums import BillingInterval
+from hub.enums import BillingInterval, SubscriptionStatus
 from hub.models import AgentSubscription
 from hub.services import subscriptions as sub_svc
 from hub.subscription_schemas import (
@@ -182,6 +182,7 @@ async def subscribe(
             product_id=product_id,
             subscriber_agent_id=ctx.active_agent_id,
             idempotency_key=body.idempotency_key if body else None,
+            room_id=body.room_id if body else None,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
@@ -194,6 +195,10 @@ async def subscribe(
 @router.get("/products/{product_id}/subscribers")
 async def list_subscribers(
     product_id: str,
+    status: str | None = Query(
+        default=None,
+        description="Comma-separated subscription statuses to filter by (e.g. 'active,past_due')",
+    ),
     ctx: RequestContext = Depends(require_active_agent),
     db: AsyncSession = Depends(get_db),
 ):
@@ -204,7 +209,23 @@ async def list_subscribers(
     if product.owner_agent_id != ctx.active_agent_id:
         raise HTTPException(status_code=403, detail="Not authorized to view subscribers")
 
-    subscribers = await sub_svc.list_product_subscribers(db, product_id)
+    statuses: list[SubscriptionStatus] | None = None
+    if status:
+        statuses = []
+        for raw in status.split(","):
+            token = raw.strip()
+            if not token:
+                continue
+            try:
+                statuses.append(SubscriptionStatus(token))
+            except ValueError:
+                raise HTTPException(
+                    status_code=400, detail=f"Invalid subscription status: {token}"
+                )
+
+    subscribers = await sub_svc.list_product_subscribers(
+        db, product_id, statuses=statuses
+    )
     return {"subscribers": [_subscription_response(s) for s in subscribers]}
 
 

--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -883,6 +883,12 @@ class AgentSubscription(Base):
     provider_agent_id: Mapped[str] = mapped_column(
         String(32), ForeignKey("agents.agent_id"), nullable=False, index=True
     )
+    room_id: Mapped[str | None] = mapped_column(
+        String(64),
+        ForeignKey("rooms.room_id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
     asset_code: Mapped[str] = mapped_column(String(16), nullable=False, default="COIN")
     amount_minor: Mapped[int] = mapped_column(BigInteger, nullable=False)
     billing_interval: Mapped[BillingInterval] = mapped_column(

--- a/backend/hub/routers/room.py
+++ b/backend/hub/routers/room.py
@@ -796,6 +796,29 @@ async def dissolve_room(
     if member.role != RoomRole.owner:
         raise I18nHTTPException(status_code=403, message_key="only_owner_can_dissolve")
 
+    # Pre-cancel any subscriptions bound to this room. The FK uses ON DELETE
+    # SET NULL, so without this step the active subscriptions become orphaned
+    # ("ghost" subs whose mismatch check can never trigger). No need to revoke
+    # room membership — the room itself is about to be deleted.
+    import datetime as _dt
+    bound_subs = (
+        await db.execute(
+            select(AgentSubscription).where(
+                AgentSubscription.room_id == room.room_id,
+                AgentSubscription.status.in_(
+                    [SubscriptionStatus.active, SubscriptionStatus.past_due]
+                ),
+            )
+        )
+    ).scalars().all()
+    if bound_subs:
+        now = _dt.datetime.now(_dt.timezone.utc)
+        for sub in bound_subs:
+            sub.status = SubscriptionStatus.cancelled
+            sub.cancelled_at = now
+            sub.cancel_at_period_end = False
+        await db.flush()
+
     await db.delete(room)
     await db.commit()
     return {"ok": True}

--- a/backend/hub/routers/subscriptions.py
+++ b/backend/hub/routers/subscriptions.py
@@ -162,6 +162,7 @@ async def subscribe(
             product_id=product_id,
             subscriber_agent_id=current_agent,
             idempotency_key=req.idempotency_key,
+            room_id=req.room_id,
         )
         await db.commit()
         await db.refresh(subscription)

--- a/backend/hub/services/subscriptions.py
+++ b/backend/hub/services/subscriptions.py
@@ -175,9 +175,15 @@ async def list_my_subscriptions(
 
 
 async def list_product_subscribers(
-    session: AsyncSession, product_id: str
+    session: AsyncSession,
+    product_id: str,
+    *,
+    statuses: list[SubscriptionStatus] | None = None,
 ) -> list[AgentSubscription]:
-    result = await session.execute(_subscription_query(product_id=product_id))
+    stmt = _subscription_query(product_id=product_id)
+    if statuses:
+        stmt = stmt.where(AgentSubscription.status.in_(statuses))
+    result = await session.execute(stmt)
     return list(result.scalars().all())
 
 
@@ -202,6 +208,7 @@ async def create_subscription(
     product_id: str,
     subscriber_agent_id: str,
     idempotency_key: str | None = None,
+    room_id: str | None = None,
 ) -> AgentSubscription:
     result = await session.execute(
         select(SubscriptionProduct).where(SubscriptionProduct.product_id == product_id)
@@ -214,6 +221,16 @@ async def create_subscription(
     if product.owner_agent_id == subscriber_agent_id:
         raise ValueError("Cannot subscribe to your own product")
 
+    if room_id is not None:
+        room_lookup = await session.execute(
+            select(Room).where(Room.room_id == room_id)
+        )
+        room_row = room_lookup.scalar_one_or_none()
+        if room_row is None:
+            raise ValueError("Room not found")
+        if room_row.required_subscription_product_id != product_id:
+            raise ValueError("Product does not match room's required subscription")
+
     existing = await session.execute(
         select(AgentSubscription).where(
             AgentSubscription.product_id == product_id,
@@ -225,8 +242,11 @@ async def create_subscription(
         if current.status == SubscriptionStatus.cancelled:
             # Reactivate cancelled subscription: charge and reset billing period
             return await _reactivate_subscription(
-                session, current, product, idempotency_key,
+                session, current, product, idempotency_key, room_id=room_id,
             )
+        if room_id is not None and current.room_id != room_id:
+            current.room_id = room_id
+            await session.flush()
         return current
 
     now = _utcnow()
@@ -256,6 +276,7 @@ async def create_subscription(
         product_id=product.product_id,
         subscriber_agent_id=subscriber_agent_id,
         provider_agent_id=product.owner_agent_id,
+        room_id=room_id,
         asset_code=product.asset_code,
         amount_minor=product.amount_minor,
         billing_interval=product.billing_interval,
@@ -293,6 +314,8 @@ async def _reactivate_subscription(
     subscription: AgentSubscription,
     product: SubscriptionProduct,
     idempotency_key: str | None,
+    *,
+    room_id: str | None = None,
 ) -> AgentSubscription:
     """Reactivate a cancelled subscription by charging and resetting the billing period."""
     now = _utcnow()
@@ -325,6 +348,8 @@ async def _reactivate_subscription(
     subscription.last_charged_at = now
     subscription.last_charge_tx_id = tx.tx_id
     subscription.consecutive_failed_attempts = 0
+    if room_id is not None:
+        subscription.room_id = room_id
     await session.flush()
 
     await _auto_join_subscription_rooms(session, subscription)
@@ -335,12 +360,24 @@ async def _auto_join_subscription_rooms(
     session: AsyncSession,
     subscription: AgentSubscription,
 ) -> None:
-    result = await session.execute(
-        select(Room).where(
-            Room.required_subscription_product_id == subscription.product_id
+    if subscription.room_id is not None:
+        # Room-scoped subscription: only consider its bound room, and only
+        # if the room's current required product still matches.
+        room_lookup = await session.execute(
+            select(Room).where(Room.room_id == subscription.room_id)
         )
-    )
-    rooms = list(result.scalars().all())
+        room = room_lookup.scalar_one_or_none()
+        if room is None or room.required_subscription_product_id != subscription.product_id:
+            return
+        rooms = [room]
+    else:
+        # Cross-room pass (future "subscription pass"): use product reverse-lookup.
+        result = await session.execute(
+            select(Room).where(
+                Room.required_subscription_product_id == subscription.product_id
+            )
+        )
+        rooms = list(result.scalars().all())
 
     for room in rooms:
         existing_result = await session.execute(
@@ -381,11 +418,44 @@ async def _revoke_subscription_room_access(
     session: AsyncSession,
     subscription: AgentSubscription,
 ) -> None:
+    if subscription.room_id is not None:
+        # Room-scoped revoke: only the bound room's membership.
+        result = await session.execute(
+            select(RoomMember).where(
+                RoomMember.room_id == subscription.room_id,
+                RoomMember.agent_id == subscription.subscriber_agent_id,
+            )
+        )
+    else:
+        # Cross-room revoke: every room currently requiring this product.
+        result = await session.execute(
+            select(RoomMember)
+            .join(Room, Room.room_id == RoomMember.room_id)
+            .where(
+                Room.required_subscription_product_id == subscription.product_id,
+                RoomMember.agent_id == subscription.subscriber_agent_id,
+            )
+        )
+    for membership in result.scalars().all():
+        await session.delete(membership)
+    await session.flush()
+
+
+async def _revoke_subscription_room_access_for_subscription(
+    session: AsyncSession,
+    subscription: AgentSubscription,
+) -> None:
+    """Revoke membership only for the room bound to ``subscription.room_id``.
+
+    Used by mismatch / plan-change cancellation: at that point the room no
+    longer references the old product, so the generic product reverse-lookup
+    in :func:`_revoke_subscription_room_access` would be a no-op.
+    """
+    if subscription.room_id is None:
+        return
     result = await session.execute(
-        select(RoomMember)
-        .join(Room, Room.room_id == RoomMember.room_id)
-        .where(
-            Room.required_subscription_product_id == subscription.product_id,
+        select(RoomMember).where(
+            RoomMember.room_id == subscription.room_id,
             RoomMember.agent_id == subscription.subscriber_agent_id,
         )
     )
@@ -467,6 +537,23 @@ async def _charge_subscription(
     due_at = _ensure_tz(subscription.next_charge_at)
     if due_at > now:
         return "skipped"
+
+    # Plan-change check: if the subscription is bound to a room and that room
+    # no longer requires this exact product (owner changed plan / unbound /
+    # room deleted), cancel without charging.
+    if subscription.room_id is not None:
+        room_lookup = await session.execute(
+            select(Room).where(Room.room_id == subscription.room_id)
+        )
+        room = room_lookup.scalar_one_or_none()
+        room_pid = room.required_subscription_product_id if room is not None else None
+        if room_pid != subscription.product_id:
+            subscription.status = SubscriptionStatus.cancelled
+            subscription.cancelled_at = now
+            subscription.cancel_at_period_end = False
+            await _revoke_subscription_room_access_for_subscription(session, subscription)
+            await session.flush()
+            return "cancelled_due_to_plan_change"
 
     billing_cycle_key = _billing_cycle_key(subscription)
     attempt_result = await session.execute(

--- a/backend/hub/subscription_schemas.py
+++ b/backend/hub/subscription_schemas.py
@@ -14,6 +14,7 @@ class SubscriptionProductCreateRequest(BaseModel):
 
 class SubscriptionCreateRequest(BaseModel):
     idempotency_key: str | None = None
+    room_id: str | None = None
 
 
 class SubscriptionProductResponse(BaseModel):

--- a/backend/migrations/030_agent_subscriptions_room_id.sql
+++ b/backend/migrations/030_agent_subscriptions_room_id.sql
@@ -1,0 +1,15 @@
+-- Migration: Add room_id to agent_subscriptions for room-scoped subscription tracking.
+--
+-- The new column lets the billing loop compare a subscription's bound room
+-- (`room_id`) against the room's current `required_subscription_product_id` and
+-- cancel mismatched subscriptions when a room owner changes the plan. The FK
+-- uses ON DELETE SET NULL so that existing audit/charge history is preserved
+-- even after a room is deleted; application paths must pre-cancel subscriptions
+-- before deletion (see hub services for room dissolve).
+
+ALTER TABLE agent_subscriptions
+    ADD COLUMN IF NOT EXISTS room_id VARCHAR(64)
+    REFERENCES rooms(room_id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS ix_agent_subscriptions_room_id
+    ON agent_subscriptions(room_id);

--- a/backend/migrations/030_agent_subscriptions_room_id.sql
+++ b/backend/migrations/030_agent_subscriptions_room_id.sql
@@ -13,3 +13,22 @@ ALTER TABLE agent_subscriptions
 
 CREATE INDEX IF NOT EXISTS ix_agent_subscriptions_room_id
     ON agent_subscriptions(room_id);
+
+-- Backfill room_id for legacy active/past_due subscriptions where exactly
+-- one room currently references their product. The plan-change cancel path
+-- in `_charge_subscription` gates on `room_id IS NOT NULL`; without this
+-- backfill, pre-existing subscriptions would keep auto-renewing on archived
+-- products after a migrate-plan or paid-access toggle-off. Subs whose product
+-- is referenced by zero or multiple rooms are left NULL (genuinely ambiguous).
+UPDATE agent_subscriptions AS s
+SET room_id = (
+    SELECT r.room_id
+    FROM rooms r
+    WHERE r.required_subscription_product_id = s.product_id
+)
+WHERE s.room_id IS NULL
+  AND s.status IN ('active', 'past_due')
+  AND (
+    SELECT COUNT(*) FROM rooms r
+    WHERE r.required_subscription_product_id = s.product_id
+  ) = 1;

--- a/backend/tests/test_subscription.py
+++ b/backend/tests/test_subscription.py
@@ -1024,3 +1024,92 @@ async def test_dissolve_room_pre_cancels_bound_subscriptions(
     ).scalar_one()
     assert sub.status == SubscriptionStatus.cancelled
     assert sub.cancelled_at is not None
+
+
+@pytest.mark.asyncio
+async def test_legacy_null_room_id_backfilled_then_cancelled_on_plan_change(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """Legacy product-scoped subs (room_id IS NULL, e.g. created before
+    migration 030) must still be cancellable when the room owner switches
+    plans — by backfilling room_id from the unique referencing room."""
+    from sqlalchemy import update as _sa_update
+
+    sk_provider, pub_provider = _make_keypair()
+    sk_subscriber, pub_subscriber = _make_keypair()
+    provider_id, provider_token = await _register_and_verify(
+        client, sk_provider, pub_provider, "Provider"
+    )
+    _, subscriber_token = await _register_and_verify(
+        client, sk_subscriber, pub_subscriber, "Subscriber"
+    )
+
+    old_product = await _create_product(
+        client, provider_token, name="LegacyOld", amount_minor=5000, billing_interval="week"
+    )
+    new_product = await _create_product(
+        client, provider_token, name="LegacyNew", amount_minor=8000, billing_interval="week"
+    )
+    await _set_subscription_room_policy(
+        client, provider_id, allowed_to_create=True, max_active_rooms=5
+    )
+    room = await _create_room(
+        client,
+        provider_token,
+        name="Gated",
+        required_subscription_product_id=old_product["product_id"],
+    )
+
+    await _fund_agent(client, subscriber_token, 30000)
+
+    # Subscribe WITHOUT room_id, mirroring a pre-PR record.
+    resp = await client.post(
+        f"/subscriptions/products/{old_product['product_id']}/subscribe",
+        json={},
+        headers=_auth(subscriber_token),
+    )
+    assert resp.status_code == 201, resp.text
+    sid = resp.json()["subscription_id"]
+
+    sub = (
+        await db_session.execute(
+            select(AgentSubscription).where(AgentSubscription.subscription_id == sid)
+        )
+    ).scalar_one()
+    assert sub.room_id is None  # legacy shape
+
+    # Apply the same backfill UPDATE that migrate-plan / clear-paid use.
+    await db_session.execute(
+        _sa_update(AgentSubscription)
+        .where(
+            AgentSubscription.product_id == old_product["product_id"],
+            AgentSubscription.room_id.is_(None),
+            AgentSubscription.status.in_(
+                [SubscriptionStatus.active, SubscriptionStatus.past_due]
+            ),
+        )
+        .values(room_id=room["room_id"])
+    )
+
+    # Owner swaps the room to the new plan.
+    from hub.models import Room as _Room
+
+    db_room = (
+        await db_session.execute(select(_Room).where(_Room.room_id == room["room_id"]))
+    ).scalar_one()
+    db_room.required_subscription_product_id = new_product["product_id"]
+    await db_session.commit()
+
+    # Force the subscription to be due now and run billing.
+    due_at = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(seconds=1)
+    await _set_subscription_due(db_session, sid, due_at, due_at)
+    resp = await client.post("/internal/subscriptions/run-billing")
+    assert resp.status_code == 200, resp.text
+
+    sub = (
+        await db_session.execute(
+            select(AgentSubscription).where(AgentSubscription.subscription_id == sid)
+        )
+    ).scalar_one()
+    assert sub.status == SubscriptionStatus.cancelled
+    assert sub.cancelled_at is not None

--- a/backend/tests/test_subscription.py
+++ b/backend/tests/test_subscription.py
@@ -833,3 +833,194 @@ async def test_subscription_gated_room_quota_enforced(client: AsyncClient):
     )
     assert resp.status_code == 403
     assert "quota exceeded" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Room-scoped subscriptions: room_id binding, plan-change cancellation,
+# and dissolve pre-cancel (added for room-subscription-redesign).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_subscribe_persists_room_id_and_validates_match(
+    client: AsyncClient, db_session: AsyncSession
+):
+    sk_provider, pub_provider = _make_keypair()
+    sk_subscriber, pub_subscriber = _make_keypair()
+    provider_id, provider_token = await _register_and_verify(
+        client, sk_provider, pub_provider, "Provider"
+    )
+    _, subscriber_token = await _register_and_verify(
+        client, sk_subscriber, pub_subscriber, "Subscriber"
+    )
+
+    product = await _create_product(
+        client, provider_token, name="P1", amount_minor=10000, billing_interval="week"
+    )
+    other_product = await _create_product(
+        client, provider_token, name="P2", amount_minor=10000, billing_interval="week"
+    )
+    await _set_subscription_room_policy(
+        client, provider_id, allowed_to_create=True, max_active_rooms=5
+    )
+    room = await _create_room(
+        client,
+        provider_token,
+        name="Gated",
+        required_subscription_product_id=product["product_id"],
+    )
+
+    await _fund_agent(client, subscriber_token, 30000)
+
+    # Mismatch: room requires P1 but caller passes P2.
+    resp = await client.post(
+        f"/subscriptions/products/{other_product['product_id']}/subscribe",
+        json={"room_id": room["room_id"]},
+        headers=_auth(subscriber_token),
+    )
+    assert resp.status_code == 400
+    assert "match" in resp.json()["detail"].lower()
+
+    # Happy path persists room_id on the subscription row.
+    resp = await client.post(
+        f"/subscriptions/products/{product['product_id']}/subscribe",
+        json={"room_id": room["room_id"]},
+        headers=_auth(subscriber_token),
+    )
+    assert resp.status_code == 201, resp.text
+    sid = resp.json()["subscription_id"]
+
+    sub = (
+        await db_session.execute(
+            select(AgentSubscription).where(AgentSubscription.subscription_id == sid)
+        )
+    ).scalar_one()
+    assert sub.room_id == room["room_id"]
+
+
+@pytest.mark.asyncio
+async def test_charge_subscription_cancels_on_plan_change(
+    client: AsyncClient, db_session: AsyncSession
+):
+    sk_provider, pub_provider = _make_keypair()
+    sk_subscriber, pub_subscriber = _make_keypair()
+    provider_id, provider_token = await _register_and_verify(
+        client, sk_provider, pub_provider, "Provider"
+    )
+    subscriber_id, subscriber_token = await _register_and_verify(
+        client, sk_subscriber, pub_subscriber, "Subscriber"
+    )
+
+    old_product = await _create_product(
+        client, provider_token, name="OldPlan", amount_minor=5000, billing_interval="week"
+    )
+    new_product = await _create_product(
+        client, provider_token, name="NewPlan", amount_minor=8000, billing_interval="week"
+    )
+    await _set_subscription_room_policy(
+        client, provider_id, allowed_to_create=True, max_active_rooms=5
+    )
+    room = await _create_room(
+        client,
+        provider_token,
+        name="Gated",
+        required_subscription_product_id=old_product["product_id"],
+    )
+
+    await _fund_agent(client, subscriber_token, 30000)
+
+    resp = await client.post(
+        f"/subscriptions/products/{old_product['product_id']}/subscribe",
+        json={"room_id": room["room_id"]},
+        headers=_auth(subscriber_token),
+    )
+    assert resp.status_code == 201, resp.text
+    sid = resp.json()["subscription_id"]
+
+    # Owner switches the room to a new product, simulating a plan change.
+    from hub.models import Room as _Room
+
+    db_room = (
+        await db_session.execute(select(_Room).where(_Room.room_id == room["room_id"]))
+    ).scalar_one()
+    db_room.required_subscription_product_id = new_product["product_id"]
+    await db_session.commit()
+
+    # Force the subscription to be due now.
+    due_at = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(seconds=1)
+    await _set_subscription_due(db_session, sid, due_at, due_at)
+
+    resp = await client.post("/internal/subscriptions/run-billing")
+    assert resp.status_code == 200, resp.text
+
+    sub = (
+        await db_session.execute(
+            select(AgentSubscription).where(AgentSubscription.subscription_id == sid)
+        )
+    ).scalar_one()
+    assert sub.status == SubscriptionStatus.cancelled
+    assert sub.cancelled_at is not None
+    assert sub.cancel_at_period_end is False
+
+    # Membership in the bound room is revoked.
+    from hub.models import RoomMember as _RM
+
+    membership = (
+        await db_session.execute(
+            select(_RM).where(
+                _RM.room_id == room["room_id"],
+                _RM.agent_id == subscriber_id,
+            )
+        )
+    ).scalar_one_or_none()
+    assert membership is None
+
+
+@pytest.mark.asyncio
+async def test_dissolve_room_pre_cancels_bound_subscriptions(
+    client: AsyncClient, db_session: AsyncSession
+):
+    sk_provider, pub_provider = _make_keypair()
+    sk_subscriber, pub_subscriber = _make_keypair()
+    provider_id, provider_token = await _register_and_verify(
+        client, sk_provider, pub_provider, "Provider"
+    )
+    _, subscriber_token = await _register_and_verify(
+        client, sk_subscriber, pub_subscriber, "Subscriber"
+    )
+
+    product = await _create_product(
+        client, provider_token, name="DissolvePlan", amount_minor=5000, billing_interval="week"
+    )
+    await _set_subscription_room_policy(
+        client, provider_id, allowed_to_create=True, max_active_rooms=5
+    )
+    room = await _create_room(
+        client,
+        provider_token,
+        name="Doomed",
+        required_subscription_product_id=product["product_id"],
+    )
+
+    await _fund_agent(client, subscriber_token, 20000)
+    resp = await client.post(
+        f"/subscriptions/products/{product['product_id']}/subscribe",
+        json={"room_id": room["room_id"]},
+        headers=_auth(subscriber_token),
+    )
+    assert resp.status_code == 201
+    sid = resp.json()["subscription_id"]
+
+    resp = await client.delete(
+        f"/hub/rooms/{room['room_id']}", headers=_auth(provider_token)
+    )
+    assert resp.status_code == 200, resp.text
+
+    db_session.expire_all()
+    sub = (
+        await db_session.execute(
+            select(AgentSubscription).where(AgentSubscription.subscription_id == sid)
+        )
+    ).scalar_one()
+    assert sub.status == SubscriptionStatus.cancelled
+    assert sub.cancelled_at is not None

--- a/docs/room-subscription-redesign.md
+++ b/docs/room-subscription-redesign.md
@@ -1,0 +1,490 @@
+# 房间订阅功能重设计 (路径 2)
+
+> 状态: 设计稿 / 已对齐评审反馈 v3
+> 范围: backend + frontend
+> 作者: 讨论沉淀
+> 日期: 2026-04-27 (最近修订: 同日 v3)
+
+## 修订记录
+
+**v4 (三轮评审反馈修复)**:
+- BFF join 路由 `POST /api/dashboard/rooms/{id}/join` (`backend/app/routers/dashboard.py:1079`) 当前**不检查** `required_subscription_product_id` —— 工单 A 必须修，否则付费 public/open 房可被免费加入，grandfather 设计前提就不成立
+- 移除「room_id NULL 兜底也能 cancel」的矛盾说法，统一只依赖 §5.4-bis 预 cancel 路径
+- `already_ending_count` 字段去掉 (本期不实现) — 现行 `cancel_subscription` 立即置 `cancelled` + revoke，不会出现 `active + cancel_at_period_end=true` 状态。等真要做 period-end cancel 再加
+- §5.3 明确**两个 subscribe 路由都要改** (前端走 `app/routers/subscriptions.py:172`，hub 路由 `hub/routers/subscriptions.py` 也要同步)
+- 自动产品 name 生成器换成 `f"room:{room_id}:plan:{generate_subscription_product_id()}"`，避开同秒重试碰撞
+- 文档头状态更新到 v3 (本次修订标 v4)
+
+**v3 (二轮评审反馈修复)**:
+- 路由认知更正：前端实际走 `app/routers/dashboard.py:1136`，**不是** `hub/routers/room.py`。BFF 路由对 `required_subscription_product_id` 完全没校验 → `_ensure_existing_members_match_subscription_requirement` 不在路径上，"绕过校验"叙述删除
+- migrate-plan 端点保留，定位从"绕过校验"调整为"原子事务封装 (create+bind+archive)"
+- dashboard PATCH 缺校验本身是 bug，工单 A 增加：product 必须存在 + active + 属于 room owner
+- `agent_subscriptions.room_id` FK 策略明确 `ON DELETE SET NULL`，并在房间解散路径显式预先 cancel
+- subscribe 端点带 room_id 时增加校验：room 存在 / product 与 room.required_subscription_product_id 匹配
+- 首次启用付费遇上"已有免费成员"采用 grandfather 策略 (老成员保留)
+- 订阅者数量口径统一：`affected_count` (active+past_due, cancel_at_period_end=False) + `already_ending_count` (cancel_at_period_end=True)
+- `/api/subscriptions/products/{product_id}/subscribers` 已存在 (`app/routers/subscriptions.py:194`)，工单改为"扩展 status filter 并接入前端"
+
+**v2 (一轮评审反馈修复)** — 解决 v1 的 7 个 blocker/high:
+- `cancel_at_period_end` 续费逻辑不读 → 改为 mismatch 时直接 cancel + revoke
+- `SubscriptionStatus` 没有 `expired` → 统一用 `cancelled`
+- 自动产品名撞 `(owner_agent_id, name)` 唯一约束 → 用稳定后缀
+- `room_id` 字段与现有 auto-join/revoke 冲突 → 显式分支处理
+- 前端缺 `listProductSubscribers` API → 补到工单 B
+- 后端文件路径错 → 改为 `backend/hub/services/subscriptions.py`
+
+## 1. 背景
+
+当前 BotCord 的订阅模型由三张表支撑：
+
+- `subscription_products` — 订阅产品 (name, amount_minor, billing_interval, owner_agent_id)
+- `agent_subscriptions` — 用户订阅记录 (subscriber_agent_id, product_id, amount_minor 快照)
+- `rooms.required_subscription_product_id` — 房间引用的产品
+
+前端目前**没有产品创建/编辑/管理 UI**，房主只能在 `RoomSettingsModal` 里把已存在的产品挂到房间上。产品本身只能通过后端 API 或 CLI 创建。
+
+## 2. 现状的问题
+
+### 2.1 房主无创建产品入口
+房主无法在 UI 上创建订阅产品 → 实际上「付费房间」功能在前端处于半残废状态。
+
+### 2.2 续订永久绑死老产品
+`backend/hub/subscription_billing.py:493-504` 续订时仅读 `agent_subscriptions` 行的字段（amount_minor / asset_code / provider_agent_id），**不查 product 也不查 room**。
+
+含义：
+
+- 房主把 `room.required_subscription_product_id` 切到新产品后，老订阅**永远卡在老产品上**
+- 老订阅者按老价格无限续费，房主想改价只能等老订阅自然 cancel
+- 一旦老订阅者真的失去房间访问权（依赖 `room.product_id == subscription.product_id` 的判断），还会出现「扣钱但没访问权」的负面体验
+
+### 2.3 概念过重
+对当前用户量（产品表基本为空），「Product」是一个用户感知不到、但前端要为它撑起 CRUD UI 的额外抽象。
+
+## 3. 设计目标
+
+| # | 目标 |
+|---|------|
+| G1 | 房主能在 UI 上创建/调整房间订阅价格 |
+| G2 | 改价后老订阅者本周期走完，下周期自然到期 (cancel_at_period_end)；想继续访问需按新价重新订 |
+| G3 | 不引入「产品 (Product)」这个心智概念到房主侧 UI |
+| G4 | Schema 保留 Product 抽象，为未来「跨房间通行证」(一次订阅进多个房间) 留扩展口 |
+| G5 | 改价不会偷偷涨价 — 订阅者权益受保护 (合规友好) |
+
+## 4. 总体方案
+
+### 4.1 一句话总结
+> Schema 为未来留口，UI 为当下做减法。后端续订增加房间-产品一致性检查，不一致则停止续订。
+
+### 4.2 用户视角
+
+**房主**：在 `RoomSettingsModal` 看到「价格 + 计费周期 + 启用开关」三件套，改价时弹确认框「将有 X 位订阅者本周期到期后失效」。
+
+**订阅者**：现有体验不变。改价发生后，本周期内继续有访问权；周期结束后订阅自然失效，UI 提示「订阅已过期，房间价格已变更为 $X，是否重新订阅」。
+
+### 4.3 系统行为
+
+| 房主动作 | 后端实际操作 |
+|---------|-------------|
+| 首次启用付费 | `POST /subscriptions/products` 创建产品 → `PATCH /api/dashboard/rooms/{id}` 绑定 product_id。**已存在的非 owner 成员被 grandfather** (作为 RoomMember 留下，无 subscription 记录，不参与 mismatch 检查；新加入者必须订阅 — 依赖 §5.9 修补 BFF join 路由) |
+| **改价** | 调用**新增**端点 `POST /api/dashboard/rooms/{id}/subscription/migrate-plan`，原子完成: 创建新产品 + 切换 `room.required_subscription_product_id` + 归档老产品。老订阅在本周期到期点被续订逻辑判定 mismatch → 直接 cancel + revoke 房间访问 |
+| 关闭付费 | `PATCH /api/dashboard/rooms/{id}` 清空 `required_subscription_product_id`。老订阅在本周期到期点 mismatch → cancel + revoke |
+
+**路由现状澄清**: 前端实际调用的是 `backend/app/routers/dashboard.py:1136` 的 BFF `PATCH /api/dashboard/rooms/{room_id}`。该路由 `:1208-1209` 直接赋值 `required_subscription_product_id`，**对该字段没有任何校验** —— 不验产品所有权、不验产品 active 状态、不验成员是否已订阅。`_ensure_existing_members_match_subscription_requirement` 仅在 `hub/routers/room.py` 的 agent JWT 路径上，前端用户路径走不到。这本身是一个独立的安全 bug，工单 A 必须补齐 (见 §5.7)。
+
+**为什么仍要 migrate-plan 端点**: 改价是"创建新产品 + 切换房间绑定 + 归档老产品"三步操作，前端串调三个 HTTP 中间任一步失败都会留下不一致状态 (产品建了但没绑 / 绑了但老的没归档)。migrate-plan 把三步封装成单 transaction，提供原子语义，前端只需一次调用并处理一种结果。
+
+## 5. 后端改造
+
+### 5.1 Schema 变更
+
+`agent_subscriptions` 表增加一个字段：
+
+```sql
+ALTER TABLE agent_subscriptions
+  ADD COLUMN room_id VARCHAR(64)
+    REFERENCES rooms(room_id) ON DELETE SET NULL;
+
+CREATE INDEX idx_agent_subscriptions_room_id ON agent_subscriptions(room_id);
+```
+
+**为什么需要**：续订时要根据 subscription 直接定位到「这条订阅原本是为哪个房间订的」，比较 `room.required_subscription_product_id` 是否还等于 `subscription.product_id`。如果靠 product_id 反查所有引用此产品的房间，在「跨房间通行证」场景下会模糊（一个产品挂多个房间）。
+
+**FK 策略 (`ON DELETE SET NULL`)**: 房间被解散时不直接级联删除订阅 (订阅有钱流/审计价值)，而是把 `room_id` 置空。但 SET NULL 后续费逻辑就丢失了 mismatch 信号 → 必须配套：**房间解散路径在删除 room 之前显式 cancel 所有 `room_id == this_room` 的活跃订阅** (见 §5.2 房间解散补偿)。
+
+为现有数据补 `room_id`：通过订阅时刻最近的 `rooms.required_subscription_product_id == subscription.product_id` 反查；若产品基本未启用，迁移时大部分行允许 `NULL`，新订阅强制写入。
+
+### 5.2 续订逻辑变更
+
+文件: `backend/hub/services/subscriptions.py` (实际续费逻辑在 `_charge_subscription` @ 459 / `process_due_subscription_billings` @ 534；`hub/subscription_billing.py` 只是 runner wrapper，不改)
+
+伪代码:
+
+```python
+async def _charge_subscription(session, subscription, now):
+    if subscription.status == SubscriptionStatus.cancelled:
+        return "skipped"
+
+    due_at = _ensure_tz(subscription.next_charge_at)
+    if due_at > now:
+        return "skipped"
+
+    # 新增: 到期点的 room ↔ product 一致性检查
+    if subscription.room_id:
+        room = await session.get(Room, subscription.room_id)
+        room_pid = room.required_subscription_product_id if room else None
+        if room_pid != subscription.product_id:
+            # 房间已改产品 / unbind / 房间被删 → 直接 cancel
+            subscription.status = SubscriptionStatus.cancelled
+            subscription.cancelled_at = now
+            subscription.cancel_at_period_end = False
+            await _revoke_subscription_room_access_for_subscription(session, subscription)
+            await session.flush()
+            return "cancelled_due_to_plan_change"
+
+    # 既有 charge 逻辑
+    ...
+```
+
+核心要点 (修订):
+
+- 续订前先查 room，比较 `room.required_subscription_product_id` vs `subscription.product_id`
+- mismatch 时**直接** `status = cancelled` + `cancelled_at = now` + revoke 房间访问，**不依赖 `cancel_at_period_end`**
+- 触发时机就是 `next_charge_at` (== 旧周期 `current_period_end`)，所以「本周期内仍可访问」由 `due_at > now` 守门自然满足，无需中间态
+- `expired` 不是合法 status (enum 只有 `active / past_due / cancelled` @ `backend/hub/enums.py:97`)，统一用 `cancelled`，前端展示时按 `cancelled_at` 文案区分「主动取消」vs「计划变更而到期」(可选: 加 `cancellation_reason` 字段做更精确归因，本期可不加)
+- `cancel_at_period_end` 字段保留 (主动取消场景仍用)，但本设计不依赖它做计划变更
+
+### 5.3 订阅创建逻辑变更
+
+**两个路由都要改**:
+- `backend/app/routers/subscriptions.py:172` — BFF 路径，**前端实际走的就是这个**
+- `backend/hub/routers/subscriptions.py` — agent JWT 路径
+- service 层在 `backend/hub/services/subscriptions.py`，service 改一次两边路由都享有
+
+`POST /subscriptions/products/{product_id}/subscribe` 两个路由都增加可选 `room_id` 入参：
+
+- 来自房间访问入口的订阅必须带 `room_id` (新写入 `agent_subscriptions.room_id`)
+- 来自直接订阅产品 (未来跨房间通行证) 可省略 → `room_id = NULL`
+
+**带 room_id 时的强校验**:
+
+```python
+if body.room_id:
+    room = await session.get(Room, body.room_id)
+    if room is None:
+        raise HTTPException(404, "Room not found")
+    if room.required_subscription_product_id != product_id:
+        # 不允许订阅一个 product 然后绑到「碰巧"也"有付费门槛但用别的产品」的房间
+        raise HTTPException(400, "Product does not match room's required subscription")
+    # product owner 必须是 room owner — 由 product_id 与 room.required_subscription_product_id
+    # 一致性间接保证 (因为 owner 设置 room.required_subscription_product_id 时, dashboard PATCH §5.7 会校验产品归属)
+```
+
+不校验则客户端可以 (a) 传任意 `room_id` 让自己被 auto-join 到无关房间 (`_auto_join_subscription_rooms` 的 product 反查会被绕开) 或 (b) 让 mismatch 检测到错误的房间错误地 cancel 真订阅。
+
+### 5.4 auto-join / revoke 逻辑分支
+
+`_auto_join_subscription_rooms` (services/subscriptions.py:334) 和 `_revoke_subscription_room_access` (:380) 当前按 product 反查所有引用此产品的房间。新增 `room_id` 后语义会和这个反查冲突，需要分支处理:
+
+```python
+async def _auto_join_subscription_rooms(session, subscription):
+    if subscription.room_id:
+        # 房间订阅 → 仅 join 该房间
+        rooms = [await session.get(Room, subscription.room_id)]
+        rooms = [r for r in rooms if r and r.required_subscription_product_id == subscription.product_id]
+    else:
+        # 跨房间通行证 → 沿用 product 反查 (未来扩展用)
+        rooms = await session.execute(
+            select(Room).where(Room.required_subscription_product_id == subscription.product_id)
+        )
+        rooms = list(rooms.scalars().all())
+    # ... 既有 join 逻辑
+```
+
+`_revoke_subscription_room_access` 同样分支。
+
+新增专用 helper `_revoke_subscription_room_access_for_subscription(session, subscription)` 给 §5.2 的 mismatch 路径用 — 仅根据 `subscription.room_id` 撤销该房间 membership (不能用旧的 product 反查，因为此时 product 已经不挂这个房间了)。
+
+### 5.4-bis 房间解散补偿
+
+文件: `backend/app/routers/dashboard.py` (room dissolve / leave 路径) + `backend/hub/routers/room.py` (DELETE /rooms/{id})
+
+由于 §5.1 用了 `ON DELETE SET NULL`，房间被解散时若不预先处理，订阅会变成 `room_id = NULL` 的"游魂订阅" — mismatch 检查永远不触发，会按老 product 一直续费但订阅者没有房间可进。
+
+**修复**: 在删除 room 前的事务里:
+
+```python
+# Cancel all subscriptions tied to this room
+result = await session.execute(
+    select(AgentSubscription).where(
+        AgentSubscription.room_id == room.room_id,
+        AgentSubscription.status == SubscriptionStatus.active,
+    )
+)
+for sub in result.scalars().all():
+    sub.status = SubscriptionStatus.cancelled
+    sub.cancelled_at = _utcnow()
+    sub.cancel_at_period_end = False
+    # revoke 不需要 — 房间马上要删了
+await session.flush()
+# 然后 await db.delete(room)
+```
+
+### 5.5 新增端点: 改价迁移
+
+```
+POST /api/dashboard/rooms/{room_id}/subscription/migrate-plan
+Body: { amount_minor: str, billing_interval: "week"|"month", description?: str }
+Response: { product_id, room: <updated>, affected_subscriptions: int }
+```
+
+文件: `backend/app/routers/dashboard.py` (或新文件 `dashboard_subscriptions.py`)
+
+逻辑 (单个事务):
+
+1. Auth: 必须是 room owner
+2. 计算新产品 name: `f"room:{room_id}:plan:{generate_subscription_product_id()}"` (内部识别用，含随机后缀避开 `(owner_agent_id, name)` 唯一约束 + 同秒重试碰撞)
+3. 创建新 product (status=active, owner_agent_id = room.owner_id)
+4. 记录老 product_id (room.required_subscription_product_id)
+5. `room.required_subscription_product_id = new_product_id`
+6. 老 product 调 archive (若不为 None 且无其他房间引用)
+7. 统计响应数据: `affected_count` 与 `already_ending_count` (口径见下)
+8. commit
+
+**响应**:
+
+```json
+{
+  "product_id": "sp_...",
+  "room": {...},
+  "affected_count": 12
+}
+```
+
+口径定义 (与 §6.4 严格一致):
+
+- `affected_count` = `status in (active, past_due)` 的订阅数 — **这些订阅会在下个续费点被本设计 cancel**
+
+(`already_ending_count` 不在本期实现，见 §6.4 注释)
+
+migrate-plan 端点检测当前 product 被多个房间引用 → 409 拒绝 (复用态保护，本期不支持从此入口修改)。
+
+### 5.6 现有 API 不删
+
+`POST /subscriptions/products` / `archive` / `products/me` 全部保留，前端继续用 (`POST /subscriptions/products` 仍是「无房间上下文」的产品创建路径，给未来通行证场景)。
+
+### 5.7 dashboard PATCH /rooms/{id} 校验补强 (修 bug)
+
+文件: `backend/app/routers/dashboard.py:1208-1209`
+
+当前直接赋值 `required_subscription_product_id` 无任何校验，是独立 bug。补:
+
+```python
+if "required_subscription_product_id" in fields_set:
+    new_pid = body.required_subscription_product_id or None
+    if new_pid is not None:
+        product = await sub_svc.get_subscription_product(db, new_pid)
+        if product is None:
+            raise HTTPException(404, "Subscription product not found")
+        if product.owner_agent_id != room.owner_id:
+            raise HTTPException(403, "Product does not belong to room owner")
+        if product.status != SubscriptionProductStatus.active:
+            raise HTTPException(400, "Subscription product is not active")
+    room.required_subscription_product_id = new_pid
+```
+
+**注意**: 这里不调用 `_ensure_existing_members_match_subscription_requirement` (那个校验是 hub agent JWT 路径的设计，不适用于 BFF user JWT 路径下房主自己改自己房间的场景)。本设计采用 grandfather 策略 (§4.3)，已有非 owner 成员保留，新成员走订阅。
+
+### 5.8-bis BFF join 路由订阅校验 (修 bug)
+
+文件: `backend/app/routers/dashboard.py:1079` (`POST /api/dashboard/rooms/{room_id}/join`)
+
+当前仅检查 `visibility=public` + `join_policy=open`，**不检查** `required_subscription_product_id`。这是个独立 bug：付费 public/open 房间可以被任何 viewer 免费加入，grandfather 设计就站不住脚。
+
+**修补**:
+
+```python
+if room.required_subscription_product_id is not None:
+    if viewer_type == ParticipantType.agent:
+        result = await db.execute(
+            select(AgentSubscription).where(
+                AgentSubscription.subscriber_agent_id == viewer_id,
+                AgentSubscription.product_id == room.required_subscription_product_id,
+                AgentSubscription.status == SubscriptionStatus.active,
+            )
+        )
+        if result.scalar_one_or_none() is None:
+            raise HTTPException(
+                status_code=403,
+                detail="Active subscription required to join this room",
+            )
+    else:  # human viewer
+        # 当前没有 human 订阅模型 — 直接拒绝
+        raise HTTPException(
+            status_code=403,
+            detail="Humans cannot join subscription-gated rooms directly",
+        )
+```
+
+未来要支持 human 订阅 (人买月票直接进房) 是独立设计，本期 out-of-scope。前端在房间 join 入口检测到 `required_subscription_product_id` 应该先引导 viewer 走订阅流程 (现有 `SubscriptionBadge` 已是这个语义)。
+
+### 5.8 `/products/{product_id}/subscribers` 扩展
+
+端点已存在 (`backend/app/routers/subscriptions.py:194`，owner 限定已实现)。**扩展**:
+
+- 新增可选 query param `?status=active,past_due` (逗号分隔)，默认返回所有 status (兼容现状)
+- service 层 `list_product_subscribers` 增加 status 过滤参数
+- 响应 schema 不变
+
+## 6. 前端改造
+
+### 6.1 新增 / 修改文件
+
+| 文件 | 改动 |
+|---|---|
+| `frontend/src/lib/api.ts` | 增加 `createSubscriptionProduct({name, amount_minor, billing_interval, description?})`、`archiveSubscriptionProduct(productId)`、`migrateRoomSubscriptionPlan(roomId, {amount_minor, billing_interval, description?})`、`listProductSubscribers(productId)` (统计活跃订阅者数量)；扩展 `subscribeToProduct(productId, {room_id?})` |
+| `frontend/src/store/useDashboardSubscriptionStore.ts` | 增加 `upsertRoomPlan(roomId, {amount_minor, billing_interval})` — 内部分支: 当 room 无既有 product → 走 create + PATCH room；当 room 已有 product → 走 §5.5 新端点 `migrateRoomSubscriptionPlan` |
+| `frontend/src/components/dashboard/RoomSettingsModal.tsx` | 重写订阅区 (现 692-775 行)，去掉「下拉选产品」概念，改为「价格 + 周期」两输入 + 启用开关 |
+| `frontend/src/components/dashboard/PlanChangeConfirmDialog.tsx` (新) | 改价时的二次确认对话框，展示「X 位订阅者本周期到期后失效」 |
+| `frontend/src/lib/i18n/translations/dashboard.ts` | 替换所有 product / 产品 文案为 plan / 套餐；新增改价确认文案 |
+
+### 6.2 房主侧 UI
+
+`RoomSettingsModal` 的 Payment & subscription 区域变更后:
+
+```
+┌─ Payment & subscription ──────────────┐
+│  [开关] 启用付费访问                    │
+│   订阅本房间的人可进入                  │
+│                                        │
+│  价格:    [9.99]   USDC                │
+│  计费周期: ( ) 每周  (•) 每月           │
+│                                        │
+│  当前订阅者: 12 人                     │
+│                                        │
+│  [保存]                                │
+└────────────────────────────────────────┘
+```
+
+不出现「产品」/「Product」字样。
+
+### 6.3 复用态保护 (重要)
+
+保存前先调 `getMySubscriptionProducts()` 拿到当前房间绑定的 product_id，再聚合统计该 product_id 被多少房间引用 (后端无聚合 API，前端遍历 `chatStore.rooms` 比对即可，N 较小可接受)。
+
+- 引用数 == 1 → 正常走「create 新产品 + bind + archive 老的」
+- 引用数 > 1 → **disable 保存按钮 + 提示**:
+  > 此订阅套餐被多个房间共用，无法在此修改。请前往「我的通行证」管理。
+
+「我的通行证」管理页本期不实现 — 复用态目前只有受限 (拿不到一个产品被多房间引用)，等真有用户撞到再做。MVP 阶段做防呆即可。
+
+### 6.4 订阅者数量统计 (确认弹窗用)
+
+端点已存在: `GET /api/subscriptions/products/{product_id}/subscribers` (`app/routers/subscriptions.py:194`)。工单 A §5.8 增加 `?status=active,past_due` 过滤；前端按以下**统一口径**做两个数:
+
+| 字段 | 定义 | 含义 |
+|---|---|---|
+| `affected_count` | `status in (active, past_due)` | 本次改价**会在下周期被 cancel** 的订阅数 — 弹窗主数字 |
+
+**注意**: 当前 `cancel_subscription` (`hub/services/subscriptions.py:397`) 是**立即** `status=cancelled` + revoke，不会留下 `active + cancel_at_period_end=true` 的中间态。所以本期不实现 `already_ending_count`。等未来真正引入「period-end cancel」语义 (订阅者点取消后本周期保留访问，到期再 cancel) 时再加。
+
+口径与 §5.5 migrate-plan 响应完全一致；弹窗里展示的预测值与迁移完成后回执对得上。
+
+### 6.5 改价确认对话框
+
+```
+┌─ 修改订阅价格 ────────────────────────────┐
+│                                          │
+│  当前: $4.99 / 月  →  新: $9.99 / 月     │
+│                                          │
+│  ⚠️ 12 位现有订阅者将本周期到期后失效，    │
+│  需按新价重新订阅。                       │
+│                                          │
+│  此操作不可撤销 — 老订阅套餐将归档。       │
+│                                          │
+│        [取消]      [确认修改]             │
+└──────────────────────────────────────────┘
+```
+
+文案要点：
+
+- 明确「不会立刻取消老订阅，本周期内仍可使用」
+- 明确订阅者数量
+- 明确「老套餐归档」(暗示订阅者要重订)
+
+### 6.6 订阅者侧
+
+现有 `SubscriptionBadge.tsx` 在订阅时调 `subscribeToProduct` 增加 `room_id` 参数 — 仅此一处改动。订阅者 UI 视觉不变。
+
+## 7. 边界情况
+
+| 场景 | 行为 |
+|---|---|
+| 房主改价时没有任何订阅者 | 跳过确认弹窗，直接调 migrate-plan |
+| **首次启用付费但房间已有非 owner 免费成员** | **Grandfather 策略**: 老成员保留为 `RoomMember` (无 subscription)，不参与 mismatch 检查；新加入者必须订阅。前端**不弹任何阻塞性确认** (但可 i18n 提示一行: "现有成员将免费保留访问权，新加入需订阅") |
+| 房主关闭付费 (清空 `required_subscription_product_id`) | 老产品保留 (不归档)，老订阅本周期到期后被 mismatch 检测 → cancel + revoke |
+| 房主重新启用付费但用回老产品 | UI 默认创建新产品 (内部 name 是房间 id + 时间戳，不会撞唯一约束)；高级路径 (未来通行证管理页) 再支持复用 |
+| 老订阅者本周期未到期，房主又改回老价 | 老订阅指向**第一个**老产品；房主"改回老价"实际是再造一个新产品 (内部 name 不同)，老订阅在 next_charge_at 时仍 mismatch → cancel。**这是符合预期的** (老订阅者同意的是某次具体计划) |
+| `room_id` NULL 的老订阅 (迁移期) | `_charge_subscription` mismatch 检查只在 `subscription.room_id is not None` 时启用；NULL 时沿用旧行为。auto-join/revoke 同样分支 (见 §5.4) |
+| 一个产品被同一房主的多个房间引用 (复用态) | UI disable 保存；后端允许 (不强制 product → room 1:1)。`migrate-plan` 端点应检测此情况返回 409 (产品被多房间引用，禁止从此入口修改) |
+| 房间被解散/删除 | §5.4-bis 在删除 room 前预先 cancel 所有 `room_id == this_room` 的活跃订阅。FK `ON DELETE SET NULL` 仅作为防御性兜底 (防止绕过应用层的直接 SQL 删除)。**应用层路径必须保证 pre-cancel** — 这是设计的硬性约束。游魂订阅 (room_id=NULL，product 仍 active) 在本期视为不应出现的状态；可加一个运维清理脚本/告警，但不依赖 mismatch 自动 cancel 它们。单测覆盖: 解散路径前后订阅状态 |
+| `name` 唯一约束 `(owner_agent_id, name)` | 自动生成的产品 name 用 `room:{room_id}:plan:{unix_ts}` 格式，物理上唯一；用户可见名展示 amount/interval (不展示 name)。`description` 字段保留给未来给用户起的"VIP Pass"等显示名 |
+
+## 8. 任务拆分
+
+### 工单 A — Backend
+- [ ] Schema migration: `agent_subscriptions.room_id VARCHAR(64)` (nullable, FK → `rooms.room_id` `ON DELETE SET NULL`) + index
+- [ ] **修 bug**: dashboard `PATCH /rooms/{id}` 补 `required_subscription_product_id` 校验 (产品存在 / active / 属于 room owner) — §5.7
+- [ ] **修 bug**: dashboard `POST /rooms/{room_id}/join` (`backend/app/routers/dashboard.py:1079`) 补订阅校验 — agent viewer 必须有 active subscription，human viewer 直接拒绝 (§5.8-bis)
+- [ ] `services/subscriptions.py::_charge_subscription` 在 due 时检查 `room_id` ↔ `product_id` 一致性，mismatch 直接 `status=cancelled` + `cancelled_at` + `_revoke_subscription_room_access_for_subscription`
+- [ ] `services/subscriptions.py::_auto_join_subscription_rooms` & `_revoke_subscription_room_access` 增加 `room_id` 分支 (§5.4)
+- [ ] 新增 helper `_revoke_subscription_room_access_for_subscription(session, subscription)` — 仅按 `subscription.room_id` revoke
+- [ ] `POST /subscriptions/products/{id}/subscribe` **两个路由都改** (`app/routers/subscriptions.py:172` + `hub/routers/subscriptions.py`)：接受可选 `room_id`，并校验 room 存在 + `room.required_subscription_product_id == product_id` (§5.3)
+- [ ] **新端点** `POST /api/dashboard/rooms/{room_id}/subscription/migrate-plan` (§5.5) — 原子 create + bind + archive，返回 `{product_id, room, affected_count, already_ending_count}`，多房间引用时 409
+- [ ] **房间解散补偿** (§5.4-bis): 删除 room 前预先 cancel `room_id == this_room` 的活跃订阅
+- [ ] **扩展端点** `GET /api/subscriptions/products/{product_id}/subscribers` 加 `?status=active,past_due` 过滤 — §5.8 (端点已存在，不是新建)
+- [ ] 自动产品 name 生成器: `f"room:{room_id}:plan:{generate_subscription_product_id()}"` (用 product id 后缀避免同秒重试碰撞 `(owner_agent_id, name)` 唯一约束)
+- [ ] 单测: mismatch 场景不扣费 + status=cancelled + revoke
+- [ ] 单测: 房间被删 (预 cancel 路径正确) / room_id NULL 沿用旧行为 / 产品被多房间引用 / subscribe 校验各分支 / BFF join 拒绝无订阅 viewer
+- [ ] 兼容分支: room_id NULL 时沿用旧 product 反查 auto-join/revoke 行为
+
+### 工单 B — Frontend (依赖 A 完成)
+- [ ] `lib/api.ts`: `createSubscriptionProduct` / `archiveSubscriptionProduct` / `migrateRoomSubscriptionPlan` / `listProductSubscribers`，扩展 `subscribeToProduct(roomId?)`
+- [ ] `useDashboardSubscriptionStore.upsertRoomPlan` (内部分支: 首启走 create+PATCH room；改价走 migrate-plan)
+- [ ] `RoomSettingsModal` 订阅区重写 (§6.2)
+- [ ] `PlanChangeConfirmDialog` 新组件 (§6.5)
+- [ ] 复用态检测 (§6.3) + 防呆
+- [ ] 改价前调 `listProductSubscribers` 获取订阅者数量 (§6.4)
+- [ ] i18n 文案更新 (含「老订阅本周期到期失效」「需重新订阅」等关键文案)
+- [ ] `SubscriptionBadge` 调 subscribe 时带 room_id 参数
+
+### 工单 C — 文档/通知
+- [ ] 用户文档: 房主改价对订阅者的影响说明
+- [ ] (可选) 改价后给老订阅者发系统消息提示「价格变更，本周期到期后需重订」
+
+## 9. 不在本期范围
+
+- 「我的通行证」管理页 (跨房间通行证产品的完整 CRUD)
+- `billing_interval = once` 一次性付费
+- 订阅者价格变更通知 (邮件/IM)
+- 订阅升降级 (proration)
+- 多币种 / 多 asset_code 切换
+
+## 10. 待决策
+
+- **是否给 `AgentSubscription` 加 `cancellation_reason` 字段** (区分 user_cancel / plan_changed / billing_failed) — 不加也能跑 (前端按 `cancelled_at` + 上下文猜测)，加上有助于客服与日志可读性。**倾向**: 本期可不加，留观察后补。
+- **migrate-plan 端点遇上「产品被多房间引用」**返回 409 → 前端文案怎么写、引导到哪 (现在没有通行证管理页) — 暂定: 提示「此订阅套餐被其他房间共用，暂不支持在此修改。请联系支持」。后续做通行证页时再优化。
+
+## 11. 参考
+
+- 后端续订逻辑: `backend/hub/services/subscriptions.py::_charge_subscription` (459 起) + `process_due_subscription_billings` (534)
+- 订阅状态枚举: `backend/hub/enums.py:97` (`active / past_due / cancelled`，**无 expired**)
+- auto-join / revoke: `backend/hub/services/subscriptions.py:334, 380`
+- **前端实际走的房间更新路由**: `backend/app/routers/dashboard.py:1136` (PATCH /rooms/{id})，`:1208-1209` 直接赋值无校验 — 工单 A 必须修
+- hub 路径成员校验 (前端不走): `backend/hub/routers/room.py:393` (`_ensure_existing_members_match_subscription_requirement`) + `:770` 调用点
+- 现有 subscribers 端点: `backend/app/routers/subscriptions.py:194` (owner 限定，已实现，仅缺 status filter)
+- 产品唯一约束: `backend/migrations/009_create_subscription_tables.sql:18` (`uq_subscription_product_owner_name`)
+- 订阅模型: `backend/hub/models.py:864-895`
+- 产品创建: `backend/hub/routers/subscriptions.py:79`
+- 房间字段: `frontend/db/schema/rooms.ts:37`
+- 前端订阅区现状: `frontend/src/components/dashboard/RoomSettingsModal.tsx:692-775`
+- 订阅 store: `frontend/src/store/useDashboardSubscriptionStore.ts:39-123`

--- a/frontend/src/components/dashboard/PlanChangeConfirmDialog.tsx
+++ b/frontend/src/components/dashboard/PlanChangeConfirmDialog.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { Loader2, X } from "lucide-react";
+import { useLanguage } from "@/lib/i18n";
+import { roomAdvancedSettings } from "@/lib/i18n/translations/dashboard";
+
+interface PlanChangeConfirmDialogProps {
+  fromLabel: string;
+  toLabel: string;
+  affectedCount: number;
+  loading?: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+export default function PlanChangeConfirmDialog({
+  fromLabel,
+  toLabel,
+  affectedCount,
+  loading = false,
+  onClose,
+  onConfirm,
+}: PlanChangeConfirmDialogProps) {
+  const locale = useLanguage();
+  const ta = roomAdvancedSettings[locale];
+
+  const fromTo = ta.planChangeFromTo
+    .replace("{from}", fromLabel)
+    .replace("{to}", toLabel);
+  const warning = ta.planChangeWarning.replace(
+    "{count}",
+    String(affectedCount),
+  );
+
+  return (
+    <div
+      className="fixed inset-0 z-[80] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="relative w-full max-w-md rounded-2xl border border-glass-border bg-deep-black-light p-5 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={loading}
+          className="absolute right-4 top-4 rounded-full p-1.5 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+          aria-label={ta.planChangeCancel}
+        >
+          <X className="h-5 w-5" />
+        </button>
+
+        <div className="pr-8">
+          <h3 className="text-xl font-bold text-text-primary">{ta.planChangeTitle}</h3>
+          <p className="mt-3 text-sm text-text-primary/90">{fromTo}</p>
+          {affectedCount > 0 ? (
+            <p className="mt-3 rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-xs text-yellow-200">
+              ⚠️ {warning}
+            </p>
+          ) : null}
+          <p className="mt-3 text-xs text-text-secondary">{ta.planChangeIrreversible}</p>
+        </div>
+
+        <div className="mt-5 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={loading}
+            className="rounded-lg border border-glass-border px-3 py-1.5 text-sm text-text-secondary transition-colors hover:bg-glass-bg disabled:opacity-50"
+          >
+            {ta.planChangeCancel}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={loading}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-1.5 text-sm font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20 disabled:opacity-50"
+          >
+            {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
+            {ta.planChangeConfirm}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/RoomSettingsModal.tsx
+++ b/frontend/src/components/dashboard/RoomSettingsModal.tsx
@@ -13,6 +13,7 @@ import {
 import type { PublicRoomMember, SubscriptionProduct } from "@/lib/types";
 import AddRoomMemberModal from "./AddRoomMemberModal";
 import MemberActionsMenu from "./MemberActionsMenu";
+import PlanChangeConfirmDialog from "./PlanChangeConfirmDialog";
 import TransferOwnershipDialog from "./TransferOwnershipDialog";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
@@ -166,6 +167,7 @@ export default function RoomSettingsModal({
   const getActiveSubscription = useDashboardSubscriptionStore((s) => s.getActiveSubscription);
   const ensureSubscriptions = useDashboardSubscriptionStore((s) => s.ensureSubscriptions);
   const cancelSubscription = useDashboardSubscriptionStore((s) => s.cancelSubscription);
+  const upsertRoomPlan = useDashboardSubscriptionStore((s) => s.upsertRoomPlan);
   const setFocusedRoomId = useDashboardUIStore((s) => s.setFocusedRoomId);
   const setOpenedRoomId = useDashboardUIStore((s) => s.setOpenedRoomId);
 
@@ -198,6 +200,13 @@ export default function RoomSettingsModal({
   const [ownedProducts, setOwnedProducts] = useState<SubscriptionProduct[]>([]);
   const [subscriptionProduct, setSubscriptionProduct] = useState<SubscriptionProduct | null>(null);
   const [subscriptionLoading, setSubscriptionLoading] = useState(false);
+  const [priceInput, setPriceInput] = useState("");
+  const [billingInterval, setBillingInterval] = useState<"week" | "month">("month");
+  const [subscriberCount, setSubscriberCount] = useState<number | null>(null);
+  const [multiRoomBlocked, setMultiRoomBlocked] = useState(false);
+  const [planChangeDialogOpen, setPlanChangeDialogOpen] = useState(false);
+  const [planChangeAffected, setPlanChangeAffected] = useState(0);
+  const [planChangeBusy, setPlanChangeBusy] = useState(false);
   const [members, setMembers] = useState<PublicRoomMember[]>([]);
   const [memberQuery, setMemberQuery] = useState("");
   const [membersLoading, setMembersLoading] = useState(false);
@@ -279,15 +288,52 @@ export default function RoomSettingsModal({
           ? (productsResult as { products: SubscriptionProduct[] }).products
           : [];
         setOwnedProducts(myProducts);
+        let product: SubscriptionProduct | null = null;
         if (productResult && "product" in (productResult as { product: SubscriptionProduct })) {
-          setSubscriptionProduct((productResult as { product: SubscriptionProduct }).product);
-        } else {
-          setSubscriptionProduct(null);
+          product = (productResult as { product: SubscriptionProduct }).product;
+        }
+        setSubscriptionProduct(product);
+        if (product) {
+          const major = Number(product.amount_minor) / 100;
+          setPriceInput(Number.isFinite(major) ? major.toFixed(2) : "");
+          if (product.billing_interval === "week" || product.billing_interval === "month") {
+            setBillingInterval(product.billing_interval);
+          }
+        }
+        // Multi-room reuse detection: count rooms whose
+        // `required_subscription_product_id` matches the current product.
+        if (product && isOwner) {
+          try {
+            const overview = await api.getOverview();
+            const refCount = (overview.rooms ?? []).filter(
+              (r) => r.required_subscription_product_id === product.product_id,
+            ).length;
+            if (!cancelled) setMultiRoomBlocked(refCount > 1);
+          } catch {
+            if (!cancelled) setMultiRoomBlocked(false);
+          }
+        } else if (!cancelled) {
+          setMultiRoomBlocked(false);
+        }
+        // Subscriber count for confirm dialog and current display.
+        if (product && isOwner) {
+          try {
+            const subs = await api.listProductSubscribers(product.product_id, {
+              status: "active,past_due",
+            });
+            if (!cancelled) setSubscriberCount(subs.subscribers.length);
+          } catch {
+            if (!cancelled) setSubscriberCount(null);
+          }
+        } else if (!cancelled) {
+          setSubscriberCount(null);
         }
       } catch {
         if (cancelled) return;
         setOwnedProducts([]);
         setSubscriptionProduct(null);
+        setSubscriberCount(null);
+        setMultiRoomBlocked(false);
       } finally {
         if (!cancelled) setSubscriptionLoading(false);
       }
@@ -334,17 +380,8 @@ export default function RoomSettingsModal({
         if (nextMax !== initialMaxMembers) patch.max_members = nextMax;
         const nextSlow = slowMode ? Number(slowMode) : null;
         if (nextSlow !== initialSlowModeSeconds) patch.slow_mode_seconds = nextSlow;
-        const nextSub = subscriptionEnabled
-          ? (subscriptionProductId.trim() || availableProduct?.product_id || null)
-          : null;
-        if (subscriptionEnabled && !nextSub) {
-          setError(ta.subscriptionNoPlan);
-          setSaving(false);
-          return;
-        }
-        if (nextSub !== initialSubscriptionProductId) {
-          patch.required_subscription_product_id = nextSub;
-        }
+        // Subscription handling is split into a separate write below, so the
+        // PATCH only carries non-subscription fields here.
       }
       if (Object.keys(patch).length > 0) {
         const updater = viewerMode === "human" ? humansApi.updateRoomSettings : api.updateRoomSettings;
@@ -354,6 +391,19 @@ export default function RoomSettingsModal({
           refreshHumanRooms(),
         ]);
       }
+
+      if (isOwner) {
+        const subscriptionResult = await applySubscriptionChange();
+        if (subscriptionResult === "deferred") {
+          // Plan change confirm dialog is open; keep modal mounted.
+          setSaving(false);
+          return;
+        }
+        if (subscriptionResult === "blocked") {
+          setSaving(false);
+          return;
+        }
+      }
       onClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : t.saveFailed);
@@ -361,6 +411,85 @@ export default function RoomSettingsModal({
       setSaving(false);
     }
   };
+
+  // Returns one of:
+  //   "noop"     — nothing changed
+  //   "applied"  — wrote the change immediately
+  //   "deferred" — opened the plan-change confirm dialog
+  //   "blocked"  — user-visible error already set
+  async function applySubscriptionChange(): Promise<
+    "noop" | "applied" | "deferred" | "blocked"
+  > {
+    if (!isOwner) return "noop";
+
+    // Toggle off → unbind product on the room (mismatch will cancel old subs).
+    if (!subscriptionEnabled) {
+      if (!initialSubscriptionProductId) return "noop";
+      await api.updateRoomSettings(roomId, {
+        required_subscription_product_id: null,
+      });
+      await refreshOverview({ reloadOpenedRoom: true });
+      return "applied";
+    }
+
+    if (multiRoomBlocked) {
+      setError(ta.subscriptionMultiRoomBlock);
+      return "blocked";
+    }
+
+    const priceMajor = Number(priceInput);
+    if (!Number.isFinite(priceMajor) || priceMajor <= 0) {
+      setError(ta.subscriptionPriceLabel);
+      return "blocked";
+    }
+    const amountMinor = String(Math.round(priceMajor * 100));
+
+    // First-time enable: no current product on the room → create + bind.
+    if (!initialSubscriptionProductId) {
+      await upsertRoomPlan(roomId, {
+        amount_minor: amountMinor,
+        billing_interval: billingInterval,
+      });
+      await refreshOverview({ reloadOpenedRoom: true });
+      return "applied";
+    }
+
+    // Same product, identical price + interval → noop.
+    const currentMinor = subscriptionProduct
+      ? Number(subscriptionProduct.amount_minor)
+      : NaN;
+    const sameAmount =
+      Number.isFinite(currentMinor) && Number(amountMinor) === currentMinor;
+    const sameInterval =
+      subscriptionProduct?.billing_interval === billingInterval;
+    if (sameAmount && sameInterval) return "noop";
+
+    // Plan change → defer to confirm dialog.
+    setPlanChangeAffected(subscriberCount ?? 0);
+    setPlanChangeDialogOpen(true);
+    return "deferred";
+  }
+
+  async function confirmPlanChange() {
+    setPlanChangeBusy(true);
+    setError(null);
+    try {
+      const priceMajor = Number(priceInput);
+      const amountMinor = String(Math.round(priceMajor * 100));
+      await upsertRoomPlan(roomId, {
+        amount_minor: amountMinor,
+        billing_interval: billingInterval,
+        currentProductId: initialSubscriptionProductId ?? undefined,
+      });
+      await refreshOverview({ reloadOpenedRoom: true });
+      setPlanChangeDialogOpen(false);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t.saveFailed);
+    } finally {
+      setPlanChangeBusy(false);
+    }
+  }
 
   const handleLeave = async () => {
     if (isOwner) return;
@@ -719,54 +848,77 @@ export default function RoomSettingsModal({
                     </div>
                     <button
                       type="button"
-                      disabled={!isOwner || (!subscriptionEnabled && !subscriptionProductId && !availableProduct)}
-                      onClick={() => {
-                        if (!subscriptionEnabled) {
-                          const nextProductId = subscriptionProductId || availableProduct?.product_id || "";
-                          if (!nextProductId) return;
-                          setSubscriptionProductId(nextProductId);
-                          if (!subscriptionProduct && availableProduct) {
-                            setSubscriptionProduct(availableProduct);
-                          }
-                          setSubscriptionEnabled(true);
-                          return;
-                        }
-                        setSubscriptionEnabled(false);
-                      }}
+                      disabled={!isOwner || multiRoomBlocked}
+                      onClick={() => setSubscriptionEnabled((v) => !v)}
                       className={`shrink-0 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${subscriptionEnabled ? "border-neon-cyan/40 bg-neon-cyan/10 text-neon-cyan" : "border-glass-border text-text-secondary hover:bg-glass-bg"}`}
                     >
                       {subscriptionEnabled ? ta.subscriptionToggleOn : ta.subscriptionToggleOff}
                     </button>
                   </div>
 
-                  {!subscriptionEnabled && isOwner && !subscriptionProductId && !availableProduct && (
-                    <p className="text-xs text-text-secondary/70">{ta.subscriptionNoPlan}</p>
+                  {multiRoomBlocked && (
+                    <p className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-xs text-yellow-200">
+                      {ta.subscriptionMultiRoomBlock}
+                    </p>
                   )}
 
-                  {!subscriptionEnabled && isOwner && availableProduct && (
-                    <p className="text-xs text-text-secondary/70">{ta.subscriptionAutoPick}</p>
-                  )}
-
-                  {subscriptionEnabled && (
-                    <div className="rounded-xl border border-glass-border bg-deep-black/40 px-4 py-3">
-                      <p className="text-sm font-medium text-text-primary">{ta.subscriptionCurrentPlan}</p>
-                      {subscriptionLoading ? (
-                        <p className="mt-2 text-xs text-text-secondary/70">{t.saving}</p>
-                      ) : subscriptionProduct || availableProduct ? (
-                        (() => {
-                          const product = subscriptionProduct ?? availableProduct;
-                          if (!product) return null;
-                          return (
-                            <div className="mt-2 space-y-1 text-xs text-text-secondary/80">
-                              <p className="text-sm font-medium text-text-primary">{product.name}</p>
-                              {product.description ? <p>{product.description}</p> : null}
-                              <p>{ta.subscriptionPriceLabel}: {typeof product.amount_minor === "number" ? (product.amount_minor / 100).toFixed(2) : String(Number(product.amount_minor) / 100)} {product.asset_code}</p>
-                              <p>{ta.subscriptionBillingLabel}: {product.billing_interval}</p>
-                            </div>
-                          );
-                        })()
-                      ) : (
-                        <p className="mt-2 text-xs text-text-secondary/70">{ta.subscriptionNone}</p>
+                  {subscriptionEnabled && isOwner && (
+                    <div className="space-y-3 rounded-xl border border-glass-border bg-deep-black/40 px-4 py-3">
+                      <div className="flex items-center gap-3">
+                        <label className="text-sm text-text-primary">
+                          {ta.subscriptionPriceLabel}
+                        </label>
+                        <input
+                          type="number"
+                          min="0"
+                          step="0.01"
+                          inputMode="decimal"
+                          disabled={multiRoomBlocked}
+                          placeholder={ta.subscriptionPricePlaceholder}
+                          value={priceInput}
+                          onChange={(e) => setPriceInput(e.target.value)}
+                          className="w-28 rounded-lg border border-glass-border bg-deep-black px-2 py-1 text-sm text-text-primary"
+                        />
+                        <span className="text-xs text-text-secondary/80">USDC</span>
+                      </div>
+                      <div className="flex items-center gap-4">
+                        <label className="text-sm text-text-primary">
+                          {ta.subscriptionBillingLabel}
+                        </label>
+                        <label className="flex items-center gap-1.5 text-sm text-text-secondary">
+                          <input
+                            type="radio"
+                            name="billing-interval"
+                            value="week"
+                            checked={billingInterval === "week"}
+                            onChange={() => setBillingInterval("week")}
+                            disabled={multiRoomBlocked}
+                            className="accent-neon-cyan"
+                          />
+                          {ta.subscriptionWeekly}
+                        </label>
+                        <label className="flex items-center gap-1.5 text-sm text-text-secondary">
+                          <input
+                            type="radio"
+                            name="billing-interval"
+                            value="month"
+                            checked={billingInterval === "month"}
+                            onChange={() => setBillingInterval("month")}
+                            disabled={multiRoomBlocked}
+                            className="accent-neon-cyan"
+                          />
+                          {ta.subscriptionMonthly}
+                        </label>
+                      </div>
+                      {subscriberCount !== null && (
+                        <p className="text-xs text-text-secondary/80">
+                          {ta.subscriptionCurrentSubscribers}: {subscriberCount}
+                        </p>
+                      )}
+                      {!initialSubscriptionProductId && (
+                        <p className="text-xs text-text-secondary/70">
+                          {ta.subscriptionGrandfatherHint}
+                        </p>
                       )}
                     </div>
                   )}
@@ -909,6 +1061,26 @@ export default function RoomSettingsModal({
           onClose={() => setLeaveDialogOpen(false)}
           onConfirm={() => {
             void handleLeave();
+          }}
+        />
+      )}
+
+      {planChangeDialogOpen && isOwner && (
+        <PlanChangeConfirmDialog
+          fromLabel={
+            subscriptionProduct
+              ? `${(Number(subscriptionProduct.amount_minor) / 100).toFixed(2)} ${subscriptionProduct.asset_code} / ${subscriptionProduct.billing_interval}`
+              : "—"
+          }
+          toLabel={`${Number(priceInput).toFixed(2)} USDC / ${billingInterval}`}
+          affectedCount={planChangeAffected}
+          loading={planChangeBusy}
+          onClose={() => {
+            if (planChangeBusy) return;
+            setPlanChangeDialogOpen(false);
+          }}
+          onConfirm={() => {
+            void confirmPlanChange();
           }}
         />
       )}

--- a/frontend/src/components/dashboard/SubscriptionBadge.tsx
+++ b/frontend/src/components/dashboard/SubscriptionBadge.tsx
@@ -185,7 +185,7 @@ export default function SubscriptionBadge({
     setErrorKind("generic");
     try {
       if (!alreadySubscribed) {
-        await subscribeToProduct(productId);
+        await subscribeToProduct(productId, roomId ? { roomId } : undefined);
       }
       if (roomId) {
         await joinRoom(roomId);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -45,6 +45,9 @@ import type {
   SubscriptionProductResponse,
   SubscriptionProductListResponse,
   MySubscriptionsResponse,
+  ProductSubscribersResponse,
+  MigrateRoomPlanResponse,
+  SubscriptionProduct,
   UserChatRoom,
   UserChatSendResponse,
   RoomHumanSendResponse,
@@ -615,14 +618,48 @@ export const api = {
   getMySubscriptionProducts() {
     return apiGet<SubscriptionProductListResponse>("/api/subscriptions/products/me");
   },
-  subscribeToProduct(productId: string) {
-    return apiPost<any>(`/api/subscriptions/products/${productId}/subscribe`);
+  subscribeToProduct(productId: string, opts?: { roomId?: string }) {
+    const body: Record<string, unknown> = {};
+    if (opts?.roomId) body.room_id = opts.roomId;
+    return apiPost<any>(`/api/subscriptions/products/${productId}/subscribe`, body);
   },
   cancelSubscription(subscriptionId: string) {
     return apiPost<{ subscription_id: string; status: string }>(`/api/subscriptions/${subscriptionId}/cancel`);
   },
   getMySubscriptions() {
     return apiGet<MySubscriptionsResponse>("/api/subscriptions/me");
+  },
+  createSubscriptionProduct(body: {
+    name: string;
+    amount_minor: string;
+    billing_interval: "week" | "month";
+    description?: string;
+  }) {
+    return apiPost<SubscriptionProduct>("/api/subscriptions/products", body);
+  },
+  archiveSubscriptionProduct(productId: string) {
+    return apiPost<SubscriptionProduct>(
+      `/api/subscriptions/products/${productId}/archive`,
+    );
+  },
+  listProductSubscribers(productId: string, opts?: { status?: string }) {
+    return apiGet<ProductSubscribersResponse>(
+      `/api/subscriptions/products/${productId}/subscribers`,
+      opts?.status ? { status: opts.status } : undefined,
+    );
+  },
+  migrateRoomSubscriptionPlan(
+    roomId: string,
+    body: {
+      amount_minor: string;
+      billing_interval: "week" | "month";
+      description?: string;
+    },
+  ) {
+    return apiPost<MigrateRoomPlanResponse>(
+      `/api/dashboard/rooms/${roomId}/subscription/migrate-plan`,
+      body,
+    );
   },
 
   // --- User Chat (owner-agent direct messaging) ---

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -2307,6 +2307,18 @@ export const roomAdvancedSettings: TranslationMap<{
   subscriptionProductLabel: string
   subscriptionNone: string
   ownerOnly: string
+  subscriptionWeekly: string
+  subscriptionMonthly: string
+  subscriptionPricePlaceholder: string
+  subscriptionCurrentSubscribers: string
+  subscriptionGrandfatherHint: string
+  subscriptionMultiRoomBlock: string
+  planChangeTitle: string
+  planChangeFromTo: string
+  planChangeWarning: string
+  planChangeIrreversible: string
+  planChangeConfirm: string
+  planChangeCancel: string
 }> = {
   en: {
     sectionTitle: 'Advanced',
@@ -2337,6 +2349,18 @@ export const roomAdvancedSettings: TranslationMap<{
     subscriptionProductLabel: 'Required subscription product ID',
     subscriptionNone: 'None',
     ownerOnly: 'Only the owner can change these.',
+    subscriptionWeekly: 'Weekly',
+    subscriptionMonthly: 'Monthly',
+    subscriptionPricePlaceholder: '0.00',
+    subscriptionCurrentSubscribers: 'Current subscribers',
+    subscriptionGrandfatherHint: 'Existing members keep free access; new joiners must subscribe.',
+    subscriptionMultiRoomBlock: 'This subscription plan is shared across multiple rooms and cannot be edited here.',
+    planChangeTitle: 'Change subscription price',
+    planChangeFromTo: 'Current: {from} → New: {to}',
+    planChangeWarning: '{count} existing subscribers will lose access at the end of their current cycle and need to resubscribe at the new price.',
+    planChangeIrreversible: 'This cannot be undone — the old plan will be archived.',
+    planChangeConfirm: 'Confirm change',
+    planChangeCancel: 'Cancel',
   },
   zh: {
     sectionTitle: '高级设置',
@@ -2367,6 +2391,18 @@ export const roomAdvancedSettings: TranslationMap<{
     subscriptionProductLabel: '必需订阅产品 ID',
     subscriptionNone: '无',
     ownerOnly: '仅群主可修改。',
+    subscriptionWeekly: '每周',
+    subscriptionMonthly: '每月',
+    subscriptionPricePlaceholder: '0.00',
+    subscriptionCurrentSubscribers: '当前订阅者',
+    subscriptionGrandfatherHint: '现有成员可继续免费使用；新加入者必须订阅。',
+    subscriptionMultiRoomBlock: '此订阅套餐被多个房间共用，无法在此修改。',
+    planChangeTitle: '修改订阅价格',
+    planChangeFromTo: '当前：{from} → 新：{to}',
+    planChangeWarning: '{count} 位现有订阅者将在本周期到期后失效，需要按新价重新订阅。',
+    planChangeIrreversible: '此操作不可撤销 — 老订阅套餐将归档。',
+    planChangeConfirm: '确认修改',
+    planChangeCancel: '取消',
   },
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -653,6 +653,22 @@ export interface MySubscriptionsResponse {
   subscriptions: AgentSubscription[];
 }
 
+export interface ProductSubscribersResponse {
+  subscribers: AgentSubscription[];
+}
+
+export interface MigrateRoomPlanResponse {
+  product_id: string;
+  room: {
+    room_id: string;
+    name: string;
+    description: string;
+    rule: string | null;
+    required_subscription_product_id: string | null;
+  };
+  affected_count: number;
+}
+
 // --- Wallet types ---
 
 export interface WalletSummary {

--- a/frontend/src/store/useDashboardSubscriptionStore.ts
+++ b/frontend/src/store/useDashboardSubscriptionStore.ts
@@ -20,8 +20,17 @@ interface DashboardSubscriptionState {
   getActiveSubscription: (productId: string) => AgentSubscription | null;
   ensureSubscriptions: () => Promise<AgentSubscription[]>;
   refreshSubscriptions: () => Promise<AgentSubscription[]>;
-  subscribeToProduct: (productId: string) => Promise<AgentSubscription | null>;
+  subscribeToProduct: (productId: string, opts?: { roomId?: string }) => Promise<AgentSubscription | null>;
   cancelSubscription: (subscriptionId: string) => Promise<AgentSubscription[]>;
+  upsertRoomPlan: (
+    roomId: string,
+    body: {
+      amount_minor: string;
+      billing_interval: "week" | "month";
+      description?: string;
+      currentProductId?: string | null;
+    },
+  ) => Promise<{ productId: string; affectedCount: number }>;
 }
 
 const initialSubscriptionState = {
@@ -108,8 +117,8 @@ export const useDashboardSubscriptionStore = create<DashboardSubscriptionState>(
     }
   },
 
-  subscribeToProduct: async (productId) => {
-    await api.subscribeToProduct(productId);
+  subscribeToProduct: async (productId, opts) => {
+    await api.subscribeToProduct(productId, opts);
     const subscriptions = await get().refreshSubscriptions();
     return subscriptions.find(
       (item) => item.product_id === productId && item.status === "active",
@@ -119,5 +128,29 @@ export const useDashboardSubscriptionStore = create<DashboardSubscriptionState>(
   cancelSubscription: async (subscriptionId) => {
     await api.cancelSubscription(subscriptionId);
     return get().refreshSubscriptions();
+  },
+
+  upsertRoomPlan: async (roomId, body) => {
+    // First-time enable: room has no product yet → create product, then bind
+    // it via the existing PATCH /rooms/{id} route.
+    if (!body.currentProductId) {
+      const product = await api.createSubscriptionProduct({
+        name: `room:${roomId}:plan:${Date.now()}`,
+        amount_minor: body.amount_minor,
+        billing_interval: body.billing_interval,
+        description: body.description,
+      });
+      await api.updateRoomSettings(roomId, {
+        required_subscription_product_id: product.product_id,
+      });
+      return { productId: product.product_id, affectedCount: 0 };
+    }
+    // Plan change: backend handles create + bind + archive atomically.
+    const result = await api.migrateRoomSubscriptionPlan(roomId, {
+      amount_minor: body.amount_minor,
+      billing_interval: body.billing_interval,
+      description: body.description,
+    });
+    return { productId: result.product_id, affectedCount: result.affected_count };
   },
 }));


### PR DESCRIPTION
## Summary

实现 `docs/room-subscription-redesign.md`：把订阅从「永久绑死老 product」改成「房间绑定 + 改价后老订阅本周期到期失效」。Schema 保留 Product 抽象给未来「跨房通行证」留口，UI 上去掉产品概念，房主只看到价格 + 周期。

### Backend (工单 A)
- Schema：`agent_subscriptions.room_id`（FK，`ON DELETE SET NULL`）+ index — migration `030`
- 续订逻辑：`_charge_subscription` 在 due 时比对 `room.required_subscription_product_id` ↔ `subscription.product_id`，mismatch → 直接 `cancelled` + `cancelled_at` + revoke 房间访问（不依赖 `cancel_at_period_end`）
- `_auto_join_subscription_rooms` / `_revoke_subscription_room_access`：按 `room_id` 分支（房间订阅 vs 通行证）；新增 `_revoke_subscription_room_access_for_subscription` helper 给 mismatch 路径用
- Subscribe 两个路由（`app/routers/subscriptions.py:172` BFF + `hub/routers/subscriptions.py`）都接受可选 `room_id` 并校验 room 存在 + product 与 `room.required_subscription_product_id` 匹配
- 新端点 `POST /api/dashboard/rooms/{id}/subscription/migrate-plan` — 原子 create + bind + archive；当老 product 被多房间引用时返回 409；返回 `affected_count`
- 修 bug：`PATCH /api/dashboard/rooms/{id}` 给 `required_subscription_product_id` 加校验（产品存在 / active / 属于 room owner）
- 修 bug：`POST /api/dashboard/rooms/{id}/join` agent viewer 必须持 active 订阅，human viewer 直接拒绝
- 房间解散预 cancel：`hub` 的 dissolve 路径在 `db.delete(room)` 前先 cancel 所有 `room_id == this_room` 的活跃订阅，避免 `ON DELETE SET NULL` 留下游魂订阅
- `GET /api/subscriptions/products/{id}/subscribers` 支持 `?status=active,past_due` 过滤

### Frontend (工单 B)
- `lib/api.ts`：`createSubscriptionProduct` / `archiveSubscriptionProduct` / `listProductSubscribers` / `migrateRoomSubscriptionPlan`，`subscribeToProduct(productId, { roomId })`
- `useDashboardSubscriptionStore.upsertRoomPlan`：首次启用走 create + PATCH，改价走 migrate-plan
- `RoomSettingsModal` 订阅区重写为「开关 + 价格 + 计费周期」+ 当前订阅者数。多房间复用态 disable 保存
- 新组件 `PlanChangeConfirmDialog` — 改价时显示 affected 订阅者数
- `SubscriptionBadge` 订阅时带 `roomId`
- i18n：新增 weekly/monthly/grandfather/multi-room/plan-change 文案（en + zh）

## Test plan

- [x] Backend: `uv run pytest tests/` — **907 passed / 31 skipped**（含 3 个新增）
  - `test_subscribe_persists_room_id_and_validates_match`
  - `test_charge_subscription_cancels_on_plan_change`
  - `test_dissolve_room_pre_cancels_bound_subscriptions`
- [x] Frontend: `pnpm exec tsc --noEmit` — 仅剩与本 PR 无关的既有 test 文件错误
- [ ] 手测（建议）：
  - [ ] 房主开启付费访问（首次）→ 房间能用，新成员需订阅
  - [ ] 改价 → 弹出 confirm 显示 affected 数量 → 确认后老订阅在下个 charge 周期被自动 cancel
  - [ ] 关闭付费 → 老订阅在下个 charge 周期被自动 cancel
  - [ ] 解散房间 → 绑定订阅立即 cancel，没有游魂订阅
  - [ ] 一个 product 被多个房间引用 → modal 提示无法在此修改

## Out of scope

「我的通行证」管理页（跨房通行证 CRUD）、`once` 一次性付费、订阅升降级 / proration、订阅者改价通知。

🤖 Generated with [Claude Code](https://claude.com/claude-code)