### PR TITLE
fix(daemon): inherit defaultRoute.extraArgs in synthesized + provisioned routes

### DIFF
--- a/packages/daemon/src/__tests__/daemon-config-map.test.ts
+++ b/packages/daemon/src/__tests__/daemon-config-map.test.ts
@@ -400,6 +400,27 @@ describe("buildManagedRoutes", () => {
     });
   });
 
+  it("inherits defaultRoute.extraArgs (e.g. --permission-mode bypassPermissions)", () => {
+    const withExtraArgs: GatewayRoute = {
+      runtime: "claude-code",
+      cwd: "/home/default",
+      extraArgs: ["--permission-mode", "bypassPermissions"],
+    };
+    const map = buildManagedRoutes(["ag_one"], {}, withExtraArgs);
+    expect(map.get("ag_one")?.extraArgs).toEqual([
+      "--permission-mode",
+      "bypassPermissions",
+    ]);
+    // Ensure it's a copy, not the same reference — caller should not be able
+    // to mutate the defaultRoute by editing a managed route's extraArgs.
+    expect(map.get("ag_one")?.extraArgs).not.toBe(withExtraArgs.extraArgs);
+  });
+
+  it("omits extraArgs when defaultRoute has none", () => {
+    const map = buildManagedRoutes(["ag_one"], {}, defaultRoute);
+    expect(map.get("ag_one")).not.toHaveProperty("extraArgs");
+  });
+
   it("preserves agentIds insertion order in the returned map", () => {
     const map = buildManagedRoutes(
       ["ag_b", "ag_a", "ag_c"],

--- a/packages/daemon/src/__tests__/provision.test.ts
+++ b/packages/daemon/src/__tests__/provision.test.ts
@@ -298,6 +298,58 @@ describe("set_route handler", () => {
     expect(saved.routes[0].extraArgs).toEqual(["--debug"]);
   });
 
+  it("inherits defaultRoute.extraArgs when caller omits them (mirrors adapter/cwd fallback)", () => {
+    mockState.cfg = {
+      defaultRoute: {
+        adapter: "claude-code",
+        cwd: process.env.HOME ?? "/tmp",
+        extraArgs: ["--permission-mode", "bypassPermissions"],
+      },
+      routes: [],
+      streamBlocks: true,
+    };
+    setRoute({ agentId: "ag_new", pattern: "rm_oc_" });
+    const saved = mockState.saved[mockState.saved.length - 1] as unknown as DaemonConfig;
+    expect(saved.routes[0].extraArgs).toEqual([
+      "--permission-mode",
+      "bypassPermissions",
+    ]);
+    // Mutating the saved route must not bleed back into defaultRoute.
+    saved.routes[0].extraArgs!.push("--mutated");
+    expect(mockState.cfg.defaultRoute).toEqual({
+      adapter: "claude-code",
+      cwd: process.env.HOME ?? "/tmp",
+      extraArgs: ["--permission-mode", "bypassPermissions"],
+    });
+  });
+
+  it("explicit extraArgs override defaultRoute.extraArgs", () => {
+    mockState.cfg = {
+      defaultRoute: {
+        adapter: "claude-code",
+        cwd: process.env.HOME ?? "/tmp",
+        extraArgs: ["--permission-mode", "bypassPermissions"],
+      },
+      routes: [],
+      streamBlocks: true,
+    };
+    setRoute({
+      agentId: "ag_new",
+      route: { adapter: "claude-code", cwd: process.env.HOME ?? "/tmp", extraArgs: ["--debug"] },
+    });
+    const saved = mockState.saved[mockState.saved.length - 1] as unknown as DaemonConfig;
+    expect(saved.routes[0].extraArgs).toEqual(["--debug"]);
+  });
+
+  it("omits extraArgs when neither route nor defaultRoute provide them", () => {
+    setRoute({
+      agentId: "ag_new",
+      route: { adapter: "claude-code", cwd: process.env.HOME ?? "/tmp" },
+    });
+    const saved = mockState.saved[mockState.saved.length - 1] as unknown as DaemonConfig;
+    expect(saved.routes[0]).not.toHaveProperty("extraArgs");
+  });
+
   it("forces match.accountId to the agentId even when callers omit it", () => {
     setRoute({
       agentId: "ag_x",

--- a/packages/daemon/src/daemon-config-map.ts
+++ b/packages/daemon/src/daemon-config-map.ts
@@ -194,6 +194,10 @@ export function buildManagedRoutes(
       match: { accountId: agentId },
       runtime: meta.runtime ?? defaultRoute.runtime,
       cwd: meta.cwd || agentWorkspaceDir(agentId),
+      // Inherit defaultRoute's extraArgs so synthesized per-agent routes
+      // pick up operator-wide flags (e.g. `--permission-mode bypassPermissions`)
+      // that would otherwise apply only to agents listed in `cfg.routes[]`.
+      ...(defaultRoute.extraArgs ? { extraArgs: defaultRoute.extraArgs.slice() } : {}),
     });
   }
   return out;

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -930,11 +930,21 @@ export function setRoute(params: unknown): SetRouteResult {
     match.conversationPrefix = p.pattern;
   }
 
+  // Fall back to defaultRoute.extraArgs (mirrors adapter/cwd inheritance
+  // above) so dashboard-driven `set_route` calls that only carry agentId +
+  // pattern still pick up operator-wide flags like `--permission-mode
+  // bypassPermissions`. Without this, every newly provisioned agent lost
+  // those flags and Bash/MCP tool calls would deadlock on permission prompts.
+  const extraArgs = Array.isArray(route?.extraArgs)
+    ? route!.extraArgs!.slice()
+    : Array.isArray(cfg.defaultRoute.extraArgs)
+      ? cfg.defaultRoute.extraArgs.slice()
+      : undefined;
   const newRule: RouteRule = {
     match,
     adapter,
     cwd,
-    ...(Array.isArray(route?.extraArgs) ? { extraArgs: route!.extraArgs!.slice() } : {}),
+    ...(extraArgs ? { extraArgs } : {}),
   };
 
   const routes = Array.isArray(cfg.routes) ? cfg.routes.slice() : [];


### PR DESCRIPTION
## Summary

Two symmetric bugs caused newly provisioned/discovered agents to silently lose operator-wide flags from `defaultRoute.extraArgs` (most notably `--permission-mode bypassPermissions`):

1. **`buildManagedRoutes`** (`packages/daemon/src/daemon-config-map.ts`) — synthesizes a per-agent route for every agent not in `cfg.routes[]`. It inherited `runtime` and `cwd` from `defaultRoute` but **never copied `extraArgs`**.
2. **`setRoute`** (`packages/daemon/src/provision.ts`) — invoked by the dashboard's `set_route` control frame after `provision_agent`. `adapter` and `cwd` had a fallback to `cfg.defaultRoute`, but **`extraArgs` did not**.

### Symptom in the wild

A freshly provisioned `claude-code` agent received room messages, drafted a reply, and tried to run `Bash` to send it. claude-code refused with "This command requires approval" — there was no `--permission-mode bypassPermissions` on the spawn args because the synthesized/dashboard-written route had no `extraArgs`. The runtime aborted; the agent appeared unresponsive in the room. Pre-existing agents listed in `cfg.routes[]` with explicit `extraArgs` worked fine, so the bug looked like a per-agent quirk rather than a config-inheritance gap.

### Fix

Both call sites now fall back to `defaultRoute.extraArgs` (sliced to avoid mutation aliasing) when the per-route value is not provided. Explicit per-route `extraArgs` still wins.

## Test plan

- [x] Added 2 tests to `daemon-config-map.test.ts` covering managed-route inheritance (with and without `defaultRoute.extraArgs`).
- [x] Added 3 tests to `provision.test.ts` covering `setRoute` fallback, explicit-override precedence, and the no-args case.
- [x] Affected test files: 67/67 passing locally.
- [x] Pre-existing failures in `policy-updated-handler.test.ts` and stale `provision.ts` tsc errors against `@botcord/protocol-core` reproduce on `main` and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)