### PR TITLE
feat(daemon): redirect to /settings/daemons after device-code auth

### DIFF
--- a/frontend/src/components/daemon/ActivatePage.tsx
+++ b/frontend/src/components/daemon/ActivatePage.tsx
@@ -20,6 +20,21 @@ function formatUserCode(raw: string): string {
   return `${cleaned.slice(0, 4)}-${cleaned.slice(4)}`;
 }
 
+export const ACTIVATE_DEFAULT_NEXT = "/settings/daemons";
+
+/**
+ * Sanitize the post-auth `?next=…` redirect target. Only same-origin
+ * relative paths are allowed — protocol-relative (`//evil.com`), absolute
+ * (`http://...`), and pseudo-URL (`javascript:`) values are rejected to
+ * prevent open-redirect abuse. Anything invalid falls back to the daemon
+ * settings page.
+ */
+export function sanitizeNextPath(raw: string | null | undefined): string {
+  if (!raw) return ACTIVATE_DEFAULT_NEXT;
+  if (!raw.startsWith("/") || raw.startsWith("//")) return ACTIVATE_DEFAULT_NEXT;
+  return raw;
+}
+
 export default function ActivatePage() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -32,6 +47,12 @@ export default function ActivatePage() {
   // the user is unauthenticated. `formatUserCode` normalizes to the canonical
   // XXXX-XXXX shape before we drop it into the form.
   const urlCode = searchParams?.get("code") ?? null;
+
+  // Optional `?next=…` redirect target. Restricted to same-origin relative
+  // paths to prevent open-redirect abuse — anything else falls back to the
+  // daemon settings page, which is the natural destination after authorizing.
+  const rawNext = searchParams?.get("next") ?? null;
+  const safeNext = useMemo(() => sanitizeNextPath(rawNext), [rawNext]);
 
   const [userCode, setUserCode] = useState("");
   const [label, setLabel] = useState("");
@@ -46,11 +67,13 @@ export default function ActivatePage() {
       const { data: { session } } = await supabase.auth.getSession();
       if (cancelled) return;
       if (!session) {
-        // Preserve the original `?code=…` across the login round-trip so the
-        // user lands back on this page with the prefill intact (plan §6.1).
-        const nextPath = urlCode
-          ? `/activate?code=${encodeURIComponent(urlCode)}`
-          : "/activate";
+        // Preserve the original `?code=…` and `?next=…` across the login
+        // round-trip so the user lands back on this page with the prefill
+        // and post-auth redirect target intact (plan §6.1).
+        const qs = new URLSearchParams();
+        if (urlCode) qs.set("code", urlCode);
+        if (rawNext) qs.set("next", rawNext);
+        const nextPath = qs.toString() ? `/activate?${qs.toString()}` : "/activate";
         const next = encodeURIComponent(nextPath);
         router.replace(`/login?next=${next}`);
         return;
@@ -62,7 +85,7 @@ export default function ActivatePage() {
     return () => {
       cancelled = true;
     };
-  }, [router, supabase, urlCode]);
+  }, [router, supabase, urlCode, rawNext]);
 
   // Plan §6.1: URL-borne `code` prefill is *convenience only* — still gated
   // behind Supabase auth + explicit Authorize click. We only hydrate the
@@ -122,6 +145,9 @@ export default function ActivatePage() {
       setApproveOk(true);
       setUserCode("");
       setLabel("");
+      // Brief pause so the user sees the success banner, then send them to
+      // the page they actually need (daemon list by default).
+      setTimeout(() => router.replace(safeNext), 1200);
     } catch (err) {
       setApproveError(
         err instanceof Error ? err.message : "Network error",

--- a/frontend/tests/activate-next.test.ts
+++ b/frontend/tests/activate-next.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  ACTIVATE_DEFAULT_NEXT,
+  sanitizeNextPath,
+} from "@/components/daemon/ActivatePage";
+
+describe("sanitizeNextPath", () => {
+  it("returns the default when next is null/undefined/empty", () => {
+    expect(sanitizeNextPath(null)).toBe(ACTIVATE_DEFAULT_NEXT);
+    expect(sanitizeNextPath(undefined)).toBe(ACTIVATE_DEFAULT_NEXT);
+    expect(sanitizeNextPath("")).toBe(ACTIVATE_DEFAULT_NEXT);
+  });
+
+  it("accepts same-origin relative paths", () => {
+    expect(sanitizeNextPath("/chats/messages")).toBe("/chats/messages");
+    expect(sanitizeNextPath("/settings/daemons")).toBe("/settings/daemons");
+    expect(sanitizeNextPath("/")).toBe("/");
+  });
+
+  it("rejects protocol-relative URLs (open-redirect vector)", () => {
+    expect(sanitizeNextPath("//evil.com")).toBe(ACTIVATE_DEFAULT_NEXT);
+    expect(sanitizeNextPath("//evil.com/path")).toBe(ACTIVATE_DEFAULT_NEXT);
+  });
+
+  it("rejects absolute URLs", () => {
+    expect(sanitizeNextPath("http://evil.com")).toBe(ACTIVATE_DEFAULT_NEXT);
+    expect(sanitizeNextPath("https://evil.com/x")).toBe(ACTIVATE_DEFAULT_NEXT);
+  });
+
+  it("rejects pseudo-URL schemes", () => {
+    expect(sanitizeNextPath("javascript:alert(1)")).toBe(ACTIVATE_DEFAULT_NEXT);
+    expect(sanitizeNextPath("data:text/html,foo")).toBe(ACTIVATE_DEFAULT_NEXT);
+  });
+
+  it("rejects relative paths without a leading slash", () => {
+    expect(sanitizeNextPath("settings/daemons")).toBe(ACTIVATE_DEFAULT_NEXT);
+    expect(sanitizeNextPath("../etc/passwd")).toBe(ACTIVATE_DEFAULT_NEXT);
+  });
+});

--- a/packages/daemon/src/__tests__/url-utils.test.ts
+++ b/packages/daemon/src/__tests__/url-utils.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { appendNextParam } from "../url-utils.js";
+
+describe("appendNextParam", () => {
+  it("appends next to a URL with no existing query string", () => {
+    const out = appendNextParam(
+      "https://app.botcord.chat/activate",
+      "/settings/daemons",
+    );
+    expect(out).toBe("https://app.botcord.chat/activate?next=%2Fsettings%2Fdaemons");
+  });
+
+  it("preserves existing query params (e.g. ?code=...)", () => {
+    const out = appendNextParam(
+      "https://app.botcord.chat/activate?code=ABCD-EFGH",
+      "/settings/daemons",
+    );
+    const u = new URL(out);
+    expect(u.searchParams.get("code")).toBe("ABCD-EFGH");
+    expect(u.searchParams.get("next")).toBe("/settings/daemons");
+  });
+
+  it("overwrites an existing next param rather than duplicating it", () => {
+    const out = appendNextParam(
+      "https://app.botcord.chat/activate?next=/old",
+      "/settings/daemons",
+    );
+    const u = new URL(out);
+    // searchParams.getAll guards against ?next=/old&next=/new style duplicates
+    expect(u.searchParams.getAll("next")).toEqual(["/settings/daemons"]);
+  });
+
+  it("returns the original string when the URL cannot be parsed", () => {
+    const out = appendNextParam("not a url", "/settings/daemons");
+    expect(out).toBe("not a url");
+  });
+});

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -35,6 +35,7 @@ import {
   type UserAuthRecord,
 } from "./user-auth.js";
 import { renderStatus, type StatusRenderInput } from "./status-render.js";
+import { appendNextParam } from "./url-utils.js";
 import {
   channelsFromDaemonConfig,
   defaultHttpFetcher,
@@ -274,10 +275,15 @@ async function runDeviceCodeFlow(opts: {
     opts.hubUrl,
     opts.label ? { label: opts.label } : undefined,
   );
-  const display = dc.verificationUriComplete ?? dc.verificationUri;
+  const base = dc.verificationUriComplete ?? dc.verificationUri;
+  const display = appendNextParam(base, "/settings/daemons");
   console.log("");
-  console.log(`Visit ${display}`);
-  console.log(`Code: ${dc.userCode}`);
+  console.log("Open this URL in a browser where you're signed in to BotCord");
+  console.log("(typically your laptop, NOT this machine):");
+  console.log("");
+  console.log(`  ${display}`);
+  console.log("");
+  console.log(`Or enter this code at ${dc.verificationUri}: ${dc.userCode}`);
   console.log("Waiting for authorization (Ctrl-C to abort)...");
 
   const expiresAt = Date.now() + dc.expiresIn * 1000;

--- a/packages/daemon/src/url-utils.ts
+++ b/packages/daemon/src/url-utils.ts
@@ -1,0 +1,17 @@
+/**
+ * Append a `next` query param to a URL. Used by the device-code flow to
+ * encode a post-auth redirect target into the Hub-issued verification URL,
+ * so the dashboard knows where to send the user after they click Authorize.
+ *
+ * Falls back to returning the original URL string if parsing fails — the
+ * device-code flow keeps working, just without the redirect convenience.
+ */
+export function appendNextParam(url: string, next: string): string {
+  try {
+    const u = new URL(url);
+    u.searchParams.set("next", next);
+    return u.toString();
+  } catch {
+    return url;
+  }
+}


### PR DESCRIPTION
## Summary
- daemon `start` now appends `?next=/settings/daemons` to the printed verification URL and reworks the wording to make clear the URL should be opened on the **user's** signed-in browser, not on the daemon host
- `ActivatePage` reads `?next=…`, sanitizes it as a same-origin relative path (rejects `//evil.com`, `http://…`, `javascript:`, …), and `router.replace()`s the user there 1.2s after a successful Authorize
- both `code` and `next` are now preserved across the `/login` round-trip

Fixes the dead-end where, after authorizing, the user just saw a green "Done" banner on `/activate` with no way forward.

## Why
Today the user sees `Visit https://app.botcord.chat/activate?code=ABCD-EFGH` from a daemon running on a remote/headless machine, has to figure out it should be opened on their laptop, then after clicking Authorize stays on `/activate` instead of landing on the daemon list to verify the daemon came online.

## Design notes
- URL augmentation lives **daemon-side** (`appendNextParam` in `packages/daemon/src/url-utils.ts`) so the Hub device-code protocol is unchanged — old daemon ↔ new Hub and vice versa stay compatible.
- `next` defaults to `/settings/daemons` if missing/invalid, so older daemons (no `next`) automatically benefit from the post-auth redirect once the frontend ships.
- Open-redirect hardening: only paths matching `^/[^/]` are accepted; protocol-relative `//`, absolute schemes, and pseudo-URLs all fall back to the default.

## Test plan
- [x] `packages/daemon` — new `url-utils.test.ts` covers append + preserve-existing-query + overwrite-duplicate + parse-failure (4 cases passing)
- [x] `packages/daemon` — existing `device-code.test.ts` still green (9 cases)
- [x] `frontend` — new `tests/activate-next.test.ts` covers default / valid / protocol-relative / absolute / pseudo-scheme / no-leading-slash (6 cases passing)
- [x] daemon `tsc --noEmit` clean on touched files
- [x] frontend `tsc --noEmit` clean on touched files
- [ ] manual: run `botcord-daemon start` on a remote box, open the URL on a laptop signed in to dashboard, confirm post-Authorize redirect lands on `/settings/daemons` with the new daemon listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)