### PR TITLE
feat(daemon): NDJSON transcript logging per design doc

### DIFF
--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -90,6 +90,20 @@ export interface DaemonConfig {
   routes: RouteRule[];
   /** If true, stream blocks (only meaningful for rm_oc_* rooms). */
   streamBlocks: boolean;
+  /**
+   * Persistent transcript-logging settings (design §3 / §6). Defaults to
+   * disabled — see `BOTCORD_TRANSCRIPT` for env-driven temporary overrides.
+   */
+  transcript?: TranscriptConfig;
+}
+
+/**
+ * Persistent transcript settings (design §6). Default-off — `botcord-daemon
+ * transcript enable` flips `enabled` and `transcript disable` flips it back.
+ * The env var `BOTCORD_TRANSCRIPT` can override at boot.
+ */
+export interface TranscriptConfig {
+  enabled?: boolean;
 }
 
 /**
@@ -223,6 +237,11 @@ export function loadConfig(): DaemonConfig {
     routes: routesRaw,
     streamBlocks: parsed.streamBlocks ?? true,
   };
+  if (parsed.transcript && typeof parsed.transcript === "object") {
+    const t: TranscriptConfig = {};
+    if (typeof parsed.transcript.enabled === "boolean") t.enabled = parsed.transcript.enabled;
+    out.transcript = t;
+  }
   if (hasAgents) out.agents = (parsed.agents as string[]).slice();
   if (hasLegacy) out.agentId = parsed.agentId;
   if (discovery && typeof discovery === "object") {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6,6 +6,7 @@ import {
 import {
   Gateway,
   createBotCordChannel,
+  resolveTranscriptEnabled,
   sanitizeUntrustedContent,
   type ChannelAdapter,
   type GatewayChannelConfig,
@@ -394,6 +395,10 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
     composeUserTurn: composeBotCordUserTurn,
     attentionGate,
     resolveHubUrl,
+    transcriptEnabled: resolveTranscriptEnabled(
+      process.env.BOTCORD_TRANSCRIPT,
+      opts.config.transcript?.enabled === true,
+    ),
   });
 
   logger.info("daemon starting", {

--- a/packages/daemon/src/gateway/__tests__/transcript.test.ts
+++ b/packages/daemon/src/gateway/__tests__/transcript.test.ts
@@ -1,0 +1,496 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { existsSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Dispatcher, type RuntimeFactory } from "../dispatcher.js";
+import { SessionStore } from "../session-store.js";
+import {
+  createTranscriptWriter,
+  resolveTranscriptEnabled,
+  TRANSCRIPT_TEXT_LIMIT,
+  truncateTextField,
+  type TranscriptRecord,
+} from "../transcript.js";
+import { safePathSegment, transcriptFilePath } from "../transcript-paths.js";
+import type {
+  ChannelAdapter,
+  ChannelSendContext,
+  ChannelSendResult,
+  GatewayConfig,
+  GatewayInboundEnvelope,
+  GatewayInboundMessage,
+  RuntimeAdapter,
+  RuntimeRunOptions,
+  RuntimeRunResult,
+} from "../types.js";
+import type { GatewayLogger } from "../log.js";
+
+function silentLogger(): GatewayLogger {
+  return { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+}
+
+class FakeChannel implements ChannelAdapter {
+  readonly id = "botcord";
+  readonly type = "fake";
+  readonly sends: ChannelSendContext[] = [];
+  sendImpl?: (ctx: ChannelSendContext) => Promise<ChannelSendResult> | ChannelSendResult;
+  async start(): Promise<void> {}
+  async send(ctx: ChannelSendContext): Promise<ChannelSendResult> {
+    this.sends.push(ctx);
+    if (this.sendImpl) return this.sendImpl(ctx);
+    return {};
+  }
+}
+
+interface FakeRuntimeOptions {
+  reply?: string;
+  newSessionId?: string;
+  delayMs?: number;
+  throwError?: Error | string;
+  hang?: boolean;
+}
+
+class FakeRuntime implements RuntimeAdapter {
+  readonly id = "claude-code";
+  constructor(private readonly opts: FakeRuntimeOptions = {}) {}
+  async run(options: RuntimeRunOptions): Promise<RuntimeRunResult> {
+    if (this.opts.hang) {
+      await new Promise<void>((_, reject) => {
+        options.signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+      });
+    }
+    if (this.opts.delayMs) {
+      await new Promise<void>((resolve, reject) => {
+        const t = setTimeout(resolve, this.opts.delayMs);
+        options.signal.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(t);
+            reject(new Error("aborted"));
+          },
+          { once: true },
+        );
+      });
+    }
+    if (this.opts.throwError) {
+      throw typeof this.opts.throwError === "string"
+        ? new Error(this.opts.throwError)
+        : this.opts.throwError;
+    }
+    return {
+      text: this.opts.reply ?? "hello",
+      newSessionId: this.opts.newSessionId ?? "sid-1",
+    };
+  }
+}
+
+function makeMessage(p: Partial<GatewayInboundMessage> = {}): GatewayInboundMessage {
+  return {
+    id: p.id ?? "msg_1",
+    channel: p.channel ?? "botcord",
+    accountId: p.accountId ?? "ag_me",
+    conversation: p.conversation ?? { id: "rm_oc_1", kind: "direct" },
+    sender: p.sender ?? { id: "ag_peer", kind: "user", name: "peer" },
+    text: p.text ?? "hello",
+    raw: p.raw ?? {},
+    replyTo: null,
+    receivedAt: Date.now(),
+    trace: p.trace,
+  };
+}
+
+function makeEnvelope(p: Partial<GatewayInboundMessage> = {}): GatewayInboundEnvelope {
+  return { message: makeMessage(p) };
+}
+
+function baseConfig(): GatewayConfig {
+  return {
+    channels: [{ id: "botcord", type: "botcord", accountId: "ag_me" }],
+    defaultRoute: { runtime: "claude-code", cwd: "/tmp/default" },
+    routes: [],
+  };
+}
+
+async function readRecords(file: string): Promise<TranscriptRecord[]> {
+  if (!existsSync(file)) return [];
+  const data = await readFile(file, "utf8");
+  return data
+    .split("\n")
+    .filter((l) => l.length > 0)
+    .map((l) => JSON.parse(l) as TranscriptRecord);
+}
+
+interface Scaffold {
+  dispatcher: Dispatcher;
+  channel: FakeChannel;
+  store: SessionStore;
+  rootDir: string;
+  recordsForRoom: (roomId: string, topicId?: string | null) => Promise<TranscriptRecord[]>;
+  cleanup: () => Promise<void>;
+}
+
+async function scaffold(opts: {
+  runtimeFactory?: RuntimeFactory;
+  turnTimeoutMs?: number;
+  attentionGate?: (msg: GatewayInboundMessage) => boolean | Promise<boolean>;
+  composeUserTurn?: (msg: GatewayInboundMessage) => string;
+  channel?: FakeChannel;
+  agentId?: string;
+} = {}): Promise<Scaffold> {
+  const tmp = await mkdtemp(path.join(tmpdir(), "transcript-test-"));
+  const sessionsPath = path.join(tmp, "sessions.json");
+  const store = new SessionStore({ path: sessionsPath });
+  await store.load();
+  const rootDir = path.join(tmp, "agents");
+  const channel = opts.channel ?? new FakeChannel();
+  const channels = new Map<string, ChannelAdapter>([[channel.id, channel]]);
+  const transcript = createTranscriptWriter({ rootDir, log: silentLogger(), enabled: true });
+  const dispatcher = new Dispatcher({
+    config: baseConfig(),
+    channels,
+    runtime: opts.runtimeFactory ?? (() => new FakeRuntime()),
+    sessionStore: store,
+    log: silentLogger(),
+    turnTimeoutMs: opts.turnTimeoutMs,
+    attentionGate: opts.attentionGate,
+    composeUserTurn: opts.composeUserTurn,
+    transcript,
+  });
+  return {
+    dispatcher,
+    channel,
+    store,
+    rootDir,
+    recordsForRoom: async (roomId: string, topicId: string | null = null) => {
+      const file = transcriptFilePath(rootDir, opts.agentId ?? "ag_me", roomId, topicId);
+      return readRecords(file);
+    },
+    cleanup: () => rm(tmp, { recursive: true, force: true }),
+  };
+}
+
+describe("safePathSegment", () => {
+  it("fast path for plain ids", () => {
+    expect(safePathSegment("rm_abc-123")).toBe("rm_abc-123");
+    expect(safePathSegment("ag_01HXYZ")).toBe("ag_01HXYZ");
+  });
+
+  it("invalid → _invalid_<sha256-8>", () => {
+    const dot = safePathSegment("..");
+    expect(dot).toMatch(/^_invalid_[0-9a-f]{8}$/);
+    expect(safePathSegment(".")).toMatch(/^_invalid_[0-9a-f]{8}$/);
+    expect(safePathSegment("")).toMatch(/^_invalid_[0-9a-f]{8}$/);
+    // Different inputs hash to different files.
+    expect(safePathSegment("..")).not.toBe(safePathSegment("."));
+  });
+
+  it("Windows reserved names take precedence over fast path", () => {
+    expect(safePathSegment("CON")).toBe("_win_CON");
+    expect(safePathSegment("con")).toBe("_win_con");
+    expect(safePathSegment("COM1")).toBe("_win_COM1");
+    expect(safePathSegment("LPT9")).toBe("_win_LPT9");
+  });
+
+  it("escapes path-bearing chars but keeps `%` literal", () => {
+    expect(safePathSegment("rm/with/slash")).toBe("rm%2Fwith%2Fslash");
+    // `a..b` falls out of fast path (`.` is not whitelisted) so dots get encoded.
+    expect(safePathSegment("a..b")).toBe("a%2E%2Eb");
+    // `%` itself is preserved literally.
+    expect(safePathSegment("100%pure")).toBe("100%pure");
+  });
+
+  it("truncates long escaped names without splitting %XX", () => {
+    const long = "%".repeat(0) + "a/".repeat(150); // long enough to need truncation after escape
+    const s = safePathSegment(long);
+    expect(s.length).toBeLessThanOrEqual(200);
+    // Ensure the result does not end mid-`%XX` (last 3 chars are either non-`%` block or `_<hash>`).
+    expect(s).toMatch(/_[0-9a-f]{8}$/);
+  });
+
+  it("different long inputs sharing prefix get different hashes", () => {
+    const a = "/".repeat(150) + "tail-A";
+    const b = "/".repeat(150) + "tail-B";
+    const sa = safePathSegment(a);
+    const sb = safePathSegment(b);
+    expect(sa).not.toBe(sb);
+    expect(sa.length).toBeLessThanOrEqual(200);
+    expect(sb.length).toBeLessThanOrEqual(200);
+  });
+});
+
+describe("resolveTranscriptEnabled", () => {
+  it("env=1 forces on", () => {
+    expect(resolveTranscriptEnabled("1", false)).toBe(true);
+    expect(resolveTranscriptEnabled("1", true)).toBe(true);
+  });
+  it("env=0 forces off", () => {
+    expect(resolveTranscriptEnabled("0", true)).toBe(false);
+    expect(resolveTranscriptEnabled("0", false)).toBe(false);
+  });
+  it("unset / other strings fall through to config", () => {
+    expect(resolveTranscriptEnabled(undefined, true)).toBe(true);
+    expect(resolveTranscriptEnabled(undefined, false)).toBe(false);
+    expect(resolveTranscriptEnabled("yes", true)).toBe(true);
+    expect(resolveTranscriptEnabled("yes", false)).toBe(false);
+  });
+});
+
+describe("truncateTextField", () => {
+  it("passes through short text", () => {
+    const r = truncateTextField("hi");
+    expect(r.text).toBe("hi");
+    expect(r.truncated).toBe(false);
+  });
+  it("truncates oversize", () => {
+    const big = "a".repeat(TRANSCRIPT_TEXT_LIMIT + 100);
+    const r = truncateTextField(big);
+    expect(r.truncated).toBe(true);
+    expect(r.text.length).toBe(TRANSCRIPT_TEXT_LIMIT);
+  });
+});
+
+describe("Dispatcher transcript integration", () => {
+  let cleanups: Array<() => Promise<void>>;
+  beforeEach(() => {
+    cleanups = [];
+  });
+  afterEach(async () => {
+    for (const c of cleanups) await c();
+  });
+
+  function track(s: Scaffold): Scaffold {
+    cleanups.push(s.cleanup);
+    return s;
+  }
+
+  it("happy path: inbound + dispatched + outbound{delivered}, all share turnId", async () => {
+    const s = track(await scaffold({ runtimeFactory: () => new FakeRuntime({ reply: "ok" }) }));
+    await s.dispatcher.handle(makeEnvelope({ conversation: { id: "rm_oc_1", kind: "direct" } }));
+    const recs = await s.recordsForRoom("rm_oc_1");
+    expect(recs.map((r) => r.kind)).toEqual(["inbound", "dispatched", "outbound"]);
+    expect(new Set(recs.map((r) => r.turnId)).size).toBe(1);
+    const out = recs[2] as Extract<TranscriptRecord, { kind: "outbound" }>;
+    expect(out.deliveryStatus).toBe("delivered");
+    expect(out.finalText).toBe("ok");
+  });
+
+  it("non-owner-chat: outbound{gated_non_owner_chat}, channel never sends", async () => {
+    const s = track(await scaffold({ runtimeFactory: () => new FakeRuntime({ reply: "ok" }) }));
+    await s.dispatcher.handle(
+      makeEnvelope({ conversation: { id: "rm_normal", kind: "group" } }),
+    );
+    const recs = await s.recordsForRoom("rm_normal");
+    const out = recs.find((r) => r.kind === "outbound") as Extract<TranscriptRecord, { kind: "outbound" }>;
+    expect(out.deliveryStatus).toBe("gated_non_owner_chat");
+    expect(s.channel.sends.length).toBe(0);
+  });
+
+  it("dashboard_user_chat raw.source_type → delivered even outside rm_oc_", async () => {
+    const s = track(await scaffold({ runtimeFactory: () => new FakeRuntime({ reply: "yo" }) }));
+    await s.dispatcher.handle(
+      makeEnvelope({
+        conversation: { id: "rm_dash", kind: "direct" },
+        raw: { source_type: "dashboard_user_chat" },
+      }),
+    );
+    const recs = await s.recordsForRoom("rm_dash");
+    const out = recs.find((r) => r.kind === "outbound") as Extract<TranscriptRecord, { kind: "outbound" }>;
+    expect(out.deliveryStatus).toBe("delivered");
+  });
+
+  it("empty runtime text → outbound{empty_text}", async () => {
+    const s = track(await scaffold({ runtimeFactory: () => new FakeRuntime({ reply: "   " }) }));
+    await s.dispatcher.handle(makeEnvelope());
+    const recs = await s.recordsForRoom("rm_oc_1");
+    const out = recs.find((r) => r.kind === "outbound") as Extract<TranscriptRecord, { kind: "outbound" }>;
+    expect(out.deliveryStatus).toBe("empty_text");
+    expect(s.channel.sends.length).toBe(0);
+  });
+
+  it("channel.send throws → outbound{send_failed} with deliveryReason", async () => {
+    const channel = new FakeChannel();
+    channel.sendImpl = () => {
+      throw new Error("boom");
+    };
+    const s = track(await scaffold({
+      runtimeFactory: () => new FakeRuntime({ reply: "ok" }),
+      channel,
+    }));
+    await s.dispatcher.handle(makeEnvelope());
+    const recs = await s.recordsForRoom("rm_oc_1");
+    const out = recs.find((r) => r.kind === "outbound") as Extract<TranscriptRecord, { kind: "outbound" }>;
+    expect(out.deliveryStatus).toBe("send_failed");
+    expect(out.deliveryReason).toBe("boom");
+  });
+
+  it("runtime throws → turn_error{phase:runtime}, no outbound", async () => {
+    const s = track(await scaffold({
+      runtimeFactory: () => new FakeRuntime({ throwError: "kaboom" }),
+    }));
+    await s.dispatcher.handle(makeEnvelope());
+    const recs = await s.recordsForRoom("rm_oc_1");
+    const kinds = recs.map((r) => r.kind);
+    expect(kinds).toContain("turn_error");
+    expect(kinds).not.toContain("outbound");
+    const err = recs.find((r) => r.kind === "turn_error") as Extract<TranscriptRecord, { kind: "turn_error" }>;
+    expect(err.phase).toBe("runtime");
+    expect(err.error).toBe("kaboom");
+  });
+
+  it("attention gate false → inbound + attention_skipped only", async () => {
+    const s = track(await scaffold({ attentionGate: () => false }));
+    await s.dispatcher.handle(makeEnvelope());
+    const recs = await s.recordsForRoom("rm_oc_1");
+    expect(recs.map((r) => r.kind)).toEqual(["inbound", "attention_skipped"]);
+    expect(new Set(recs.map((r) => r.turnId)).size).toBe(1);
+  });
+
+  it("compose_failed (cancel-previous mode) emits non-terminal record then proceeds", async () => {
+    const s = track(await scaffold({
+      composeUserTurn: () => {
+        throw new Error("compose boom");
+      },
+      runtimeFactory: () => new FakeRuntime({ reply: "ok" }),
+    }));
+    await s.dispatcher.handle(makeEnvelope({ conversation: { id: "rm_oc_1", kind: "direct" } }));
+    const recs = await s.recordsForRoom("rm_oc_1");
+    expect(recs.map((r) => r.kind)).toEqual([
+      "inbound",
+      "compose_failed",
+      "dispatched",
+      "outbound",
+    ]);
+  });
+
+  it("pre-skip branches do not write any record", async () => {
+    const s = track(await scaffold());
+    // empty text
+    await s.dispatcher.handle(makeEnvelope({ text: "   " }));
+    // own-agent echo
+    await s.dispatcher.handle(makeEnvelope({ sender: { id: "ag_me", kind: "agent" } }));
+    const recs = await s.recordsForRoom("rm_oc_1");
+    expect(recs).toEqual([]);
+  });
+
+  it("text/finalText truncation marks truncated.<field>", async () => {
+    const big = "X".repeat(TRANSCRIPT_TEXT_LIMIT + 50);
+    const s = track(await scaffold({
+      runtimeFactory: () => new FakeRuntime({ reply: big }),
+    }));
+    await s.dispatcher.handle(makeEnvelope({ text: big }));
+    const recs = await s.recordsForRoom("rm_oc_1");
+    const inbound = recs[0] as Extract<TranscriptRecord, { kind: "inbound" }>;
+    expect(inbound.truncated?.text).toBe(true);
+    expect(inbound.text.length).toBe(TRANSCRIPT_TEXT_LIMIT);
+    const outbound = recs[recs.length - 1] as Extract<TranscriptRecord, { kind: "outbound" }>;
+    expect(outbound.truncated?.finalText).toBe(true);
+  });
+
+  it("sender kind variants serialize correctly", async () => {
+    for (const kind of ["user", "agent", "system"] as const) {
+      const s = track(await scaffold({
+        runtimeFactory: () => new FakeRuntime({ reply: "ok" }),
+      }));
+      // for kind=agent we need a peer id to avoid own-echo skip
+      await s.dispatcher.handle(
+        makeEnvelope({ sender: { id: "ag_other", kind, name: "Bob" } }),
+      );
+      const recs = await s.recordsForRoom("rm_oc_1");
+      const inbound = recs[0] as Extract<TranscriptRecord, { kind: "inbound" }>;
+      expect(inbound.sender.kind).toBe(kind);
+      expect(inbound.sender.name).toBe("Bob");
+    }
+  });
+
+  it("file rotation when crossing maxFileBytes", async () => {
+    const tmp = await mkdtemp(path.join(tmpdir(), "transcript-rotate-"));
+    cleanups.push(() => rm(tmp, { recursive: true, force: true }));
+    const writer = createTranscriptWriter({
+      rootDir: tmp,
+      log: silentLogger(),
+      enabled: true,
+      maxFileBytes: 200, // tiny
+    });
+    const base = {
+      ts: new Date().toISOString(),
+      turnId: "tn_x",
+      agentId: "ag_me",
+      roomId: "rm_x",
+      topicId: null,
+    } as const;
+    for (let i = 0; i < 10; i++) {
+      writer.write({
+        ...base,
+        kind: "attention_skipped",
+        reason: "padding-" + i + "-" + "z".repeat(40),
+      });
+    }
+    const dir = path.join(tmp, "ag_me", "transcripts", "rm_x");
+    const { readdirSync } = await import("node:fs");
+    const files = readdirSync(dir);
+    // Should be at least one rotated (.YYYYMMDD-HHMMSS.jsonl) plus active
+    expect(files.length).toBeGreaterThan(1);
+    expect(files.some((f) => /_default\.\d{8}-\d{6}\.jsonl$/.test(f))).toBe(true);
+    expect(files).toContain("_default.jsonl");
+  });
+
+  it("disabled writer does not create files", async () => {
+    const tmp = await mkdtemp(path.join(tmpdir(), "transcript-off-"));
+    cleanups.push(() => rm(tmp, { recursive: true, force: true }));
+    const writer = createTranscriptWriter({ rootDir: tmp, log: silentLogger(), enabled: false });
+    expect(writer.enabled).toBe(false);
+    writer.write({
+      ts: new Date().toISOString(),
+      kind: "attention_skipped",
+      turnId: "tn_x",
+      agentId: "ag_me",
+      roomId: "rm_x",
+      topicId: null,
+      reason: "test",
+    });
+    expect(existsSync(path.join(tmp, "ag_me"))).toBe(false);
+  });
+
+  it("FsTranscriptWriter absorbs filesystem errors — turn still completes", async () => {
+    // Point the writer at a path inside a regular file (mkdir will fail).
+    const tmp = await mkdtemp(path.join(tmpdir(), "transcript-fail-"));
+    cleanups.push(() => rm(tmp, { recursive: true, force: true }));
+    const blocker = path.join(tmp, "blocker");
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(blocker, "x");
+    // rootDir below `blocker` (a file, not a dir) → mkdir/append fail every time.
+    const writer = createTranscriptWriter({
+      rootDir: path.join(blocker, "nope"),
+      log: silentLogger(),
+      enabled: true,
+    });
+    const sessionsPath = path.join(tmp, "sessions.json");
+    const store = new SessionStore({ path: sessionsPath });
+    await store.load();
+    const channel = new FakeChannel();
+    const channels = new Map<string, ChannelAdapter>([[channel.id, channel]]);
+    const dispatcher = new Dispatcher({
+      config: baseConfig(),
+      channels,
+      runtime: () => new FakeRuntime({ reply: "ok" }),
+      sessionStore: store,
+      log: silentLogger(),
+      transcript: writer,
+    });
+    await expect(dispatcher.handle(makeEnvelope())).resolves.not.toThrow();
+    expect(channel.sends.length).toBe(1);
+  });
+
+  it("CLI path helper resolves to the same file the writer used", async () => {
+    const s = track(await scaffold({ runtimeFactory: () => new FakeRuntime({ reply: "ok" }) }));
+    await s.dispatcher.handle(
+      makeEnvelope({
+        conversation: { id: "rm_oc_1", kind: "direct", threadId: "tp_ABC" },
+      }),
+    );
+    const file = transcriptFilePath(s.rootDir, "ag_me", "rm_oc_1", "tp_ABC");
+    expect(existsSync(file)).toBe(true);
+    expect(statSync(file).size).toBeGreaterThan(0);
+  });
+});

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -1,6 +1,14 @@
+import { randomUUID } from "node:crypto";
+
 import type { GatewayLogger } from "./log.js";
 import { resolveRoute } from "./router.js";
 import { sessionKey, type SessionStore } from "./session-store.js";
+import {
+  truncateTextField,
+  type DeliveryStatus,
+  type TranscriptBlockSummary,
+  type TranscriptWriter,
+} from "./transcript.js";
 import type {
   ChannelAdapter,
   GatewayConfig,
@@ -103,13 +111,43 @@ export interface DispatcherOptions {
    * unspecified and fall back to whatever the bundled CLI defaults to.
    */
   resolveHubUrl?: (accountId: string) => string | undefined;
+  /**
+   * Optional NDJSON transcript writer. When provided, dispatcher emits one
+   * inbound record + one path record + (for dispatched turns) one terminal
+   * record per `handle()` call. A noop writer is used by default so existing
+   * call sites keep working unchanged. See `docs/transcript-logging.md`.
+   */
+  transcript?: TranscriptWriter;
 }
 
+/**
+ * Reason carried on `AbortController.abort()` when a cancel-previous wave
+ * is taking over the slot. Distinguishing this from a timeout abort lets
+ * `runTurn`'s finalize know NOT to write a `turn_error` — the supersede
+ * path already wrote a `dropped` record for the old turnId before the abort.
+ */
+class TurnSupersededError extends Error {
+  constructor(public readonly supersededBy: string) {
+    super("turn superseded");
+    this.name = "TurnSupersededError";
+  }
+}
+
+const NOOP_TRANSCRIPT: TranscriptWriter = {
+  enabled: false,
+  rootDir: "",
+  write: () => {},
+};
+
 interface TurnSlot {
+  turnId: string;
   controller: AbortController;
   timedOut: boolean;
   snapshot: TurnStatusSnapshot;
   done: Promise<void>;
+  dispatchedAt: number;
+  /** Streamed block summaries flushed into the terminal `outbound` record. */
+  blocks: TranscriptBlockSummary[];
 }
 
 /**
@@ -121,6 +159,8 @@ interface BufferedSerialEntry {
   route: GatewayRoute;
   msg: GatewayInboundEnvelope["message"];
   channel: ChannelAdapter;
+  /** Per-arrival turnId; preserved through merge so transcript can record dropped/dispatched correctly. */
+  turnId: string;
 }
 
 interface QueueState {
@@ -172,6 +212,7 @@ export class Dispatcher {
     message: GatewayInboundMessage,
   ) => Promise<boolean> | boolean;
   private readonly resolveHubUrl?: (accountId: string) => string | undefined;
+  private readonly transcript: TranscriptWriter;
   private readonly queues: Map<string, QueueState> = new Map();
 
   constructor(opts: DispatcherOptions) {
@@ -188,21 +229,30 @@ export class Dispatcher {
     this.managedRoutes = opts.managedRoutes;
     this.attentionGate = opts.attentionGate;
     this.resolveHubUrl = opts.resolveHubUrl;
+    this.transcript = opts.transcript ?? NOOP_TRANSCRIPT;
   }
 
   /** Consume one inbound envelope, ack it once ownership is decided, then run its turn. */
   async handle(envelope: GatewayInboundEnvelope): Promise<void> {
     const msg = envelope.message;
 
-    // Skip rule: empty/whitespace text.
-    const rawText = typeof msg.text === "string" ? msg.text.trim() : "";
-    if (!rawText) {
-      this.log.debug("dispatcher skip: empty text", { messageId: msg.id });
+    // ---- Pre-skip branches: NEVER write a transcript record (design §3.2).
+    // Order matters: unknown channel → own echo → empty text. Each ack's the
+    // envelope (when applicable) and returns silently with only a debug/warn
+    // line in the daemon log.
+
+    // Pre-skip: unknown channel — configuration error, not a conversation event.
+    const channel = this.channels.get(msg.channel);
+    if (!channel) {
+      this.log.warn("dispatcher: unknown channel for outbound reply", {
+        channel: msg.channel,
+        messageId: msg.id,
+      });
       await this.safeAck(envelope);
       return;
     }
 
-    // Skip rule: echo from the agent itself (own agent output looped back).
+    // Pre-skip: echo from the agent itself (own agent output looped back).
     // Owner/human messages in dashboard rooms share the agent's id as sender.id
     // but carry sender.kind === "user", so we only skip when kind === "agent".
     if (msg.sender.id === msg.accountId && msg.sender.kind === "agent") {
@@ -210,6 +260,18 @@ export class Dispatcher {
       await this.safeAck(envelope);
       return;
     }
+
+    // Pre-skip: empty/whitespace text.
+    const rawText = typeof msg.text === "string" ? msg.text.trim() : "";
+    if (!rawText) {
+      this.log.debug("dispatcher skip: empty text", { messageId: msg.id });
+      await this.safeAck(envelope);
+      return;
+    }
+
+    // From here on, the inbound is a real conversation event — generate a
+    // turnId and write the inbound transcript record.
+    const turnId = randomUUID();
 
     const managed = this.managedRoutes ? Array.from(this.managedRoutes.values()) : undefined;
     const route = resolveRoute(msg, this.config, managed);
@@ -222,6 +284,7 @@ export class Dispatcher {
     // the full coalesced batch instead of any single arrival), so calling
     // the composer here would just be redundant work.
     let text = rawText;
+    let composeFailedError: string | undefined;
     if (mode === "cancel-previous" && this.composeUserTurn) {
       try {
         const composed = this.composeUserTurn(msg);
@@ -229,15 +292,20 @@ export class Dispatcher {
           text = composed;
         }
       } catch (err) {
+        composeFailedError = err instanceof Error ? err.message : String(err);
         this.log.warn("dispatcher: composeUserTurn threw — using raw text", {
           messageId: msg.id,
-          error: err instanceof Error ? err.message : String(err),
+          error: composeFailedError,
         });
       }
     }
 
     // Ack immediately: once the dispatcher has a route + queue key, ownership is decided.
     await this.safeAck(envelope);
+
+    // Inbound transcript record — always before observers / gates so we have a
+    // grounded turnId for any downstream attention_skipped / dropped / etc.
+    this.emitInbound(turnId, msg);
 
     // Notify the optional observer (activity tracking, metrics, etc.) as soon
     // as the dispatcher owns the message. Errors must not abort the turn.
@@ -274,23 +342,36 @@ export class Dispatcher {
           accountId: msg.accountId,
           conversationId: msg.conversation.id,
         });
+        this.transcript.write({
+          ts: nowIso(),
+          kind: "attention_skipped",
+          turnId,
+          agentId: msg.accountId,
+          roomId: msg.conversation.id,
+          topicId: msg.conversation.threadId ?? null,
+          reason: "attention_gate_false",
+        });
         return;
       }
     }
 
-    const channel = this.channels.get(msg.channel);
-    if (!channel) {
-      this.log.warn("dispatcher: unknown channel for outbound reply", {
-        channel: msg.channel,
-        messageId: msg.id,
+    if (composeFailedError) {
+      this.transcript.write({
+        ts: nowIso(),
+        kind: "compose_failed",
+        turnId,
+        agentId: msg.accountId,
+        roomId: msg.conversation.id,
+        topicId: msg.conversation.threadId ?? null,
+        error: composeFailedError,
+        fallback: "raw_text",
       });
-      return;
     }
 
     if (mode === "cancel-previous") {
-      await this.runCancelPrevious(queueKey, route, text, msg, channel);
+      await this.runCancelPrevious(queueKey, route, text, msg, channel, turnId);
     } else {
-      await this.runSerial(queueKey, route, text, msg, channel);
+      await this.runSerial(queueKey, route, text, msg, channel, turnId);
     }
   }
 
@@ -340,6 +421,7 @@ export class Dispatcher {
     text: string,
     msg: GatewayInboundEnvelope["message"],
     channel: ChannelAdapter,
+    turnId: string,
   ): Promise<void> {
     const q = this.getQueue(queueKey);
     // Bump the generation on every arrival. Older arrivals still awaiting
@@ -350,7 +432,19 @@ export class Dispatcher {
     const prev = q.current;
     if (prev) {
       this.log.info("dispatcher: cancelling previous turn", { queueKey });
-      prev.controller.abort();
+      // Record the supersede BEFORE aborting so the prev turn's finalize sees
+      // the abort reason (TurnSupersededError) and skips writing turn_error.
+      this.transcript.write({
+        ts: nowIso(),
+        kind: "dropped",
+        turnId: prev.turnId,
+        agentId: msg.accountId,
+        roomId: msg.conversation.id,
+        topicId: msg.conversation.threadId ?? null,
+        reason: "queue_cancel_previous",
+        supersededBy: turnId,
+      });
+      prev.controller.abort(new TurnSupersededError(turnId));
       // Wait for it to finish cleanup (it won't reply, won't persist).
       await prev.done.catch(() => undefined);
     }
@@ -359,9 +453,22 @@ export class Dispatcher {
     // drop out silently — the newest turn is the only one that should run.
     if (myGen !== q.cancelGen) {
       this.log.info("dispatcher: cancel-previous superseded", { queueKey });
+      // We didn't run the turn; emit dropped so the caller's inbound has a
+      // matching path record. supersededBy is unknown at this layer (newer
+      // arrival owns its own bump) — leave null.
+      this.transcript.write({
+        ts: nowIso(),
+        kind: "dropped",
+        turnId,
+        agentId: msg.accountId,
+        roomId: msg.conversation.id,
+        topicId: msg.conversation.threadId ?? null,
+        reason: "queue_cancel_previous",
+        supersededBy: null,
+      });
       return;
     }
-    await this.runTurn(queueKey, route, text, msg, channel);
+    await this.runTurn(queueKey, route, text, msg, channel, turnId, []);
   }
 
   /**
@@ -388,15 +495,26 @@ export class Dispatcher {
     _text: string,
     msg: GatewayInboundEnvelope["message"],
     channel: ChannelAdapter,
+    turnId: string,
   ): Promise<void> {
     const q = this.getQueue(queueKey);
-    q.serialBuffer.push({ route, msg, channel });
+    q.serialBuffer.push({ route, msg, channel, turnId });
     while (q.serialBuffer.length > MAX_BATCH_BUFFER_ENTRIES) {
       const dropped = q.serialBuffer.shift()!;
       this.log.warn("dispatcher: serial buffer overflow — dropped oldest entry", {
         queueKey,
         droppedMessageId: dropped.msg.id,
         bufferCap: MAX_BATCH_BUFFER_ENTRIES,
+      });
+      this.transcript.write({
+        ts: nowIso(),
+        kind: "dropped",
+        turnId: dropped.turnId,
+        agentId: dropped.msg.accountId,
+        roomId: dropped.msg.conversation.id,
+        topicId: dropped.msg.conversation.threadId ?? null,
+        reason: "queue_overflow",
+        supersededBy: null,
       });
     }
     if (q.serialWorkerActive) return;
@@ -406,12 +524,33 @@ export class Dispatcher {
         const drained = q.serialBuffer.splice(0, q.serialBuffer.length);
         const merged = this.mergeSerialBuffer(drained, queueKey);
         if (!merged) continue;
+        // Drained entries other than the winner get a `batch_merged` dropped
+        // record now (winner is always the last entry — see mergeSerialBuffer).
+        if (drained.length > 1) {
+          for (let i = 0; i < drained.length - 1; i++) {
+            const lost = drained[i]!;
+            this.transcript.write({
+              ts: nowIso(),
+              kind: "dropped",
+              turnId: lost.turnId,
+              agentId: lost.msg.accountId,
+              roomId: lost.msg.conversation.id,
+              topicId: lost.msg.conversation.threadId ?? null,
+              reason: "batch_merged",
+              supersededBy: merged.turnId,
+            });
+          }
+        }
+        const mergedFromTurnIds =
+          drained.length > 1 ? drained.slice(0, -1).map((e) => e.turnId) : [];
         await this.runTurn(
           queueKey,
           merged.route,
           merged.text,
           merged.msg,
           merged.channel,
+          merged.turnId,
+          mergedFromTurnIds,
         );
       }
     } finally {
@@ -436,6 +575,7 @@ export class Dispatcher {
     text: string;
     msg: GatewayInboundEnvelope["message"];
     channel: ChannelAdapter;
+    turnId: string;
   } | null {
     if (entries.length === 0) return null;
     if (entries.length === 1) {
@@ -445,6 +585,7 @@ export class Dispatcher {
         text: this.recomposeUserTurn(only.msg),
         msg: only.msg,
         channel: only.channel,
+        turnId: only.turnId,
       };
     }
 
@@ -500,6 +641,7 @@ export class Dispatcher {
       text: this.recomposeUserTurn(mergedMsg),
       msg: mergedMsg,
       channel: latest.channel,
+      turnId: latest.turnId,
     };
   }
 
@@ -530,6 +672,8 @@ export class Dispatcher {
     text: string,
     msg: GatewayInboundEnvelope["message"],
     channel: ChannelAdapter,
+    turnId: string,
+    mergedFromTurnIds: string[],
   ): Promise<void> {
     const q = this.getQueue(queueKey);
     const controller = new AbortController();
@@ -548,8 +692,34 @@ export class Dispatcher {
     const done = new Promise<void>((res) => {
       resolveDone = res;
     });
-    const slot: TurnSlot = { controller, timedOut: false, snapshot, done };
+    const slot: TurnSlot = {
+      turnId,
+      controller,
+      timedOut: false,
+      snapshot,
+      done,
+      dispatchedAt: startedAt,
+      blocks: [],
+    };
     q.current = slot;
+
+    // Dispatched record — marks "this turn entered runtime".
+    {
+      const composedField = truncateTextField(text);
+      const dispatched: import("./transcript.js").DispatchedTranscriptRecord = {
+        ts: nowIso(),
+        kind: "dispatched",
+        turnId,
+        agentId: msg.accountId,
+        roomId: msg.conversation.id,
+        topicId: msg.conversation.threadId ?? null,
+        composedText: composedField.text,
+        runtime: route.runtime,
+      };
+      if (mergedFromTurnIds.length > 0) dispatched.mergedFromTurnIds = mergedFromTurnIds;
+      if (composedField.truncated) dispatched.truncated = { composedText: true };
+      this.transcript.write(dispatched);
+    }
 
     // Hard-cap turn with a timeout.
     const timer = setTimeout(() => {
@@ -578,8 +748,18 @@ export class Dispatcher {
     const traceId = msg.trace?.id;
     const canStream =
       streamable && typeof traceId === "string" && typeof channel.streamBlock === "function";
+    const recordBlock = (block: StreamBlock): void => {
+      const summary: TranscriptBlockSummary = { type: block.kind };
+      const raw = block.raw as { text?: unknown; name?: unknown } | null | undefined;
+      if (raw && typeof raw === "object") {
+        if (typeof raw.text === "string") summary.chars = raw.text.length;
+        if (typeof raw.name === "string") summary.name = raw.name;
+      }
+      slot.blocks.push(summary);
+    };
     const onBlock = canStream
       ? (block: StreamBlock) => {
+          recordBlock(block);
           // Fire-and-forget: stream errors must not break the turn.
           channel
             .streamBlock!({
@@ -646,6 +826,11 @@ export class Dispatcher {
       // until after the reply lets the new arrival trip our abort signal, and
       // this check then drops us silently. Timed-out turns still fall through
       // to send their error reply.
+      //
+      // Note on transcript: the supersede path already wrote the `dropped`
+      // record from `runCancelPrevious` BEFORE aborting, so we MUST NOT also
+      // emit a `turn_error` here — that would violate the "exactly one
+      // terminal record per turnId" invariant.
       if (controller.signal.aborted && !slot.timedOut) {
         return;
       }
@@ -669,6 +854,17 @@ export class Dispatcher {
       const isOwnerChat = isOwnerChatRoom(msg);
 
       if (slot.timedOut) {
+        this.transcript.write({
+          ts: nowIso(),
+          kind: "turn_error",
+          turnId,
+          agentId: msg.accountId,
+          roomId: msg.conversation.id,
+          topicId: msg.conversation.threadId ?? null,
+          phase: "timeout",
+          error: `runtime timeout after ${this.turnTimeoutMs}ms`,
+          durationMs: Date.now() - slot.dispatchedAt,
+        });
         if (isOwnerChat) {
           await this.sendReply(channel, {
             channel: msg.channel,
@@ -690,19 +886,30 @@ export class Dispatcher {
       }
 
       if (threw) {
+        const errMsg = threw instanceof Error ? threw.message : String(threw);
         this.log.error("dispatcher: runtime threw", {
           queueKey,
           runtime: route.runtime,
-          error: threw instanceof Error ? threw.message : String(threw),
+          error: errMsg,
+        });
+        this.transcript.write({
+          ts: nowIso(),
+          kind: "turn_error",
+          turnId,
+          agentId: msg.accountId,
+          roomId: msg.conversation.id,
+          topicId: msg.conversation.threadId ?? null,
+          phase: "runtime",
+          error: errMsg,
+          durationMs: Date.now() - slot.dispatchedAt,
         });
         if (isOwnerChat) {
-          const shortMsg = threw instanceof Error ? threw.message : String(threw);
           await this.sendReply(channel, {
             channel: msg.channel,
             accountId: msg.accountId,
             conversationId: msg.conversation.id,
             threadId: msg.conversation.threadId ?? null,
-            text: `⚠️ Runtime error: ${truncate(shortMsg, 500)}`,
+            text: `⚠️ Runtime error: ${truncate(errMsg, 500)}`,
             replyTo: msg.id,
             traceId: msg.trace?.id ?? null,
           });
@@ -770,7 +977,23 @@ export class Dispatcher {
       }
 
       const replyText = (result.text || "").trim();
-      if (!replyText) return;
+      const finalTextField = truncateTextField(result.text || "");
+
+      if (!replyText) {
+        this.emitOutbound({
+          turnId,
+          msg,
+          runtime: route.runtime,
+          runtimeSessionId: result.newSessionId || null,
+          startedAt: slot.dispatchedAt,
+          costUsd: result.costUsd,
+          finalText: finalTextField,
+          deliveryStatus: "empty_text",
+          deliveryReason: null,
+          blocks: slot.blocks,
+        });
+        return;
+      }
 
       if (!isOwnerChat) {
         // Non-owner-chat rooms: result.text never goes out. The agent is
@@ -785,6 +1008,18 @@ export class Dispatcher {
             replyTextLen: replyText.length,
           },
         );
+        this.emitOutbound({
+          turnId,
+          msg,
+          runtime: route.runtime,
+          runtimeSessionId: result.newSessionId || null,
+          startedAt: slot.dispatchedAt,
+          costUsd: result.costUsd,
+          finalText: finalTextField,
+          deliveryStatus: "gated_non_owner_chat",
+          deliveryReason: null,
+          blocks: slot.blocks,
+        });
         return;
       }
 
@@ -795,7 +1030,7 @@ export class Dispatcher {
         return;
       }
 
-      await this.sendReply(channel, {
+      const sendResult = await this.sendReply(channel, {
         channel: msg.channel,
         accountId: msg.accountId,
         conversationId: msg.conversation.id,
@@ -803,6 +1038,18 @@ export class Dispatcher {
         text: replyText,
         replyTo: msg.id,
         traceId: msg.trace?.id ?? null,
+      });
+      this.emitOutbound({
+        turnId,
+        msg,
+        runtime: route.runtime,
+        runtimeSessionId: result.newSessionId || null,
+        startedAt: slot.dispatchedAt,
+        costUsd: result.costUsd,
+        finalText: finalTextField,
+        deliveryStatus: sendResult.ok ? "delivered" : "send_failed",
+        deliveryReason: sendResult.ok ? null : sendResult.error,
+        blocks: slot.blocks,
       });
     } finally {
       // Clear slot ownership AFTER the reply has been sent (or skipped).
@@ -818,16 +1065,17 @@ export class Dispatcher {
   private async sendReply(
     channel: ChannelAdapter,
     outbound: GatewayOutboundMessage,
-  ): Promise<void> {
+  ): Promise<{ ok: true } | { ok: false; error: string }> {
     try {
       await channel.send({ message: outbound, log: this.log });
     } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
       this.log.warn("dispatcher: channel.send failed", {
         channel: outbound.channel,
         conversationId: outbound.conversationId,
-        error: err instanceof Error ? err.message : String(err),
+        error,
       });
-      return;
+      return { ok: false, error };
     }
     if (this.onOutbound) {
       try {
@@ -839,7 +1087,73 @@ export class Dispatcher {
         });
       }
     }
+    return { ok: true };
   }
+
+  private emitInbound(turnId: string, msg: GatewayInboundEnvelope["message"]): void {
+    if (!this.transcript.enabled) return;
+    const rawText = typeof msg.text === "string" ? msg.text : "";
+    const tField = truncateTextField(rawText);
+    const raw = msg.raw as Record<string, unknown> | null | undefined;
+    const batch =
+      raw && typeof raw === "object" && Array.isArray((raw as { batch?: unknown }).batch)
+        ? (raw as { batch: unknown[] }).batch.length
+        : undefined;
+    const rec: import("./transcript.js").InboundTranscriptRecord = {
+      ts: nowIso(),
+      kind: "inbound",
+      turnId,
+      agentId: msg.accountId,
+      roomId: msg.conversation.id,
+      topicId: msg.conversation.threadId ?? null,
+      messageId: msg.id,
+      sender: { id: msg.sender.id, kind: msg.sender.kind, ...(msg.sender.name ? { name: msg.sender.name } : {}) },
+      text: tField.text,
+    };
+    if (batch !== undefined && batch > 1) rec.rawBatchEntries = batch;
+    if (msg.trace?.id) {
+      rec.trace = { id: msg.trace.id, ...(msg.trace.streamable ? { streamable: true } : {}) };
+    }
+    if (tField.truncated) rec.truncated = { text: true };
+    this.transcript.write(rec);
+  }
+
+  private emitOutbound(args: {
+    turnId: string;
+    msg: GatewayInboundEnvelope["message"];
+    runtime: string;
+    runtimeSessionId: string | null;
+    startedAt: number;
+    costUsd?: number;
+    finalText: { text: string; truncated: boolean };
+    deliveryStatus: DeliveryStatus;
+    deliveryReason: string | null;
+    blocks: TranscriptBlockSummary[];
+  }): void {
+    if (!this.transcript.enabled) return;
+    const rec: import("./transcript.js").OutboundTranscriptRecord = {
+      ts: nowIso(),
+      kind: "outbound",
+      turnId: args.turnId,
+      agentId: args.msg.accountId,
+      roomId: args.msg.conversation.id,
+      topicId: args.msg.conversation.threadId ?? null,
+      runtime: args.runtime,
+      runtimeSessionId: args.runtimeSessionId,
+      durationMs: Date.now() - args.startedAt,
+      finalText: args.finalText.text,
+      deliveryStatus: args.deliveryStatus,
+      deliveryReason: args.deliveryReason,
+    };
+    if (typeof args.costUsd === "number") rec.costUsd = args.costUsd;
+    if (args.blocks.length > 0) rec.blocks = args.blocks;
+    if (args.finalText.truncated) rec.truncated = { finalText: true };
+    this.transcript.write(rec);
+  }
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
 }
 
 function buildQueueKey(msg: GatewayInboundEnvelope["message"]): string {

--- a/packages/daemon/src/gateway/gateway.ts
+++ b/packages/daemon/src/gateway/gateway.ts
@@ -3,6 +3,11 @@ import { Dispatcher, type RuntimeFactory } from "./dispatcher.js";
 import { consoleLogger, type GatewayLogger } from "./log.js";
 import { createRuntime } from "./runtimes/registry.js";
 import { DEFAULT_SESSION_STORE_MAX_ENTRY_AGE_MS, SessionStore } from "./session-store.js";
+import {
+  createTranscriptWriter,
+  resolveTranscriptEnabled,
+  type TranscriptWriter,
+} from "./transcript.js";
 import type {
   ChannelAdapter,
   GatewayChannelConfig,
@@ -63,6 +68,21 @@ export interface GatewayBootOptions {
    * (`BOTCORD_HUB`) target the correct hub for the owning agent.
    */
   resolveHubUrl?: (accountId: string) => string | undefined;
+  /**
+   * Persistent NDJSON transcript writer (design §3 / §6). Optional — when
+   * omitted the dispatcher uses a noop writer. Pass `transcriptEnabled` plus
+   * `transcriptRootDir` to let the gateway construct one for you.
+   */
+  transcript?: TranscriptWriter;
+  /**
+   * Tri-state convenience: if `transcript` is not provided, the gateway
+   * constructs a writer using this flag plus `transcriptRootDir`. Use
+   * {@link resolveTranscriptEnabled} to combine `BOTCORD_TRANSCRIPT` env with
+   * the persistent daemon-config flag.
+   */
+  transcriptEnabled?: boolean;
+  /** Root directory for transcript files. Defaults to `~/.botcord/agents`. */
+  transcriptRootDir?: string;
 }
 
 /** Default runtime factory: delegates to the built-in registry; ignores extraArgs at construction. */
@@ -121,6 +141,14 @@ export class Gateway {
 
     const runtimeFactory = opts.createRuntime ?? defaultRuntimeFactory;
 
+    const transcript =
+      opts.transcript
+      ?? createTranscriptWriter({
+        log: this.log,
+        enabled: opts.transcriptEnabled === true,
+        rootDir: opts.transcriptRootDir,
+      });
+
     this.dispatcher = new Dispatcher({
       config: this.config,
       channels: this.channelMap,
@@ -135,6 +163,7 @@ export class Gateway {
       managedRoutes: this.managedRoutes,
       attentionGate: opts.attentionGate,
       resolveHubUrl: opts.resolveHubUrl,
+      transcript,
     });
 
     this.channelManager = new ChannelManager({

--- a/packages/daemon/src/gateway/index.ts
+++ b/packages/daemon/src/gateway/index.ts
@@ -9,6 +9,31 @@ export { ChannelManager, type ChannelManagerOptions, type ChannelBackoffOptions 
 export { Dispatcher, type DispatcherOptions, type RuntimeFactory } from "./dispatcher.js";
 export { Gateway, type GatewayBootOptions } from "./gateway.js";
 export {
+  createTranscriptWriter,
+  resolveTranscriptEnabled,
+  defaultTranscriptRoot,
+  truncateTextField,
+  TRANSCRIPT_TEXT_LIMIT,
+  TRANSCRIPT_FILE_LIMIT,
+  type TranscriptWriter,
+  type TranscriptRecord,
+  type InboundTranscriptRecord,
+  type DispatchedTranscriptRecord,
+  type ComposeFailedTranscriptRecord,
+  type OutboundTranscriptRecord,
+  type TurnErrorTranscriptRecord,
+  type AttentionSkippedTranscriptRecord,
+  type DroppedTranscriptRecord,
+  type DeliveryStatus,
+  type DroppedReason,
+} from "./transcript.js";
+export {
+  safePathSegment,
+  transcriptFilePath,
+  transcriptRoomDir,
+  transcriptAgentRoot,
+} from "./transcript-paths.js";
+export {
   ClaudeCodeAdapter,
   probeClaude,
   resolveClaudeCommand,

--- a/packages/daemon/src/gateway/transcript-paths.ts
+++ b/packages/daemon/src/gateway/transcript-paths.ts
@@ -1,0 +1,145 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+
+const FAST_PATH_RE = /^[A-Za-z0-9_-]{1,128}$/;
+const WIN_RESERVED = new Set([
+  "CON", "PRN", "AUX", "NUL",
+  "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+  "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+]);
+const MAX_LEN = 200;
+const TRUNCATE_PREFIX = 191;
+
+function sha256_8(raw: string): string {
+  return createHash("sha256").update(raw).digest("hex").slice(0, 8);
+}
+
+function isControlOrNul(ch: number): boolean {
+  return ch === 0 || ch < 0x20 || ch === 0x7f;
+}
+
+function isAllControl(raw: string): boolean {
+  for (let i = 0; i < raw.length; i++) {
+    if (!isControlOrNul(raw.charCodeAt(i))) return false;
+  }
+  return true;
+}
+
+function percentEncodeByte(byte: number): string {
+  return "%" + byte.toString(16).toUpperCase().padStart(2, "0");
+}
+
+function isWhitelistByte(byte: number): boolean {
+  // [A-Za-z0-9_-%] retained as literal
+  return (
+    (byte >= 0x30 && byte <= 0x39) || // 0-9
+    (byte >= 0x41 && byte <= 0x5a) || // A-Z
+    (byte >= 0x61 && byte <= 0x7a) || // a-z
+    byte === 0x5f || // _
+    byte === 0x2d || // -
+    byte === 0x25    // %  (kept literal — design §3.1)
+  );
+}
+
+function escapeRaw(raw: string): string {
+  const bytes = Buffer.from(raw, "utf8");
+  let out = "";
+  for (const b of bytes) {
+    out += isWhitelistByte(b) ? String.fromCharCode(b) : percentEncodeByte(b);
+  }
+  return out;
+}
+
+/**
+ * Truncate an escaped string to exactly MAX_LEN chars without splitting a `%XX`
+ * sequence. Keep first TRUNCATE_PREFIX chars (rolled back if mid-`%XX`), then
+ * `_` + sha256-8(raw) so the total is always ≤ MAX_LEN.
+ */
+function truncateEscaped(escaped: string, raw: string): string {
+  let cut = TRUNCATE_PREFIX;
+  // Roll back if cut sits inside a `%XX` sequence.
+  // A '%' at position cut-1 or cut-2 means the next 1 or 2 chars belong to it.
+  if (cut >= 1 && escaped[cut - 1] === "%") cut -= 1;
+  else if (cut >= 2 && escaped[cut - 2] === "%") cut -= 2;
+  const hash = sha256_8(raw);
+  return escaped.slice(0, cut) + "_" + hash;
+}
+
+/**
+ * Convert a raw ID into a filesystem-safe path segment.
+ *
+ * Order (must not be reordered — see design §3.1):
+ *   1. obviously invalid (empty / `.` / `..` / all control/NUL)
+ *      → `_invalid_<sha256-8>`
+ *   2. Windows reserved name (CON/PRN/AUX/NUL/COM1-9/LPT1-9, case-insensitive)
+ *      → `_win_<raw>`
+ *   3. fast path (`^[A-Za-z0-9_-]{1,128}$`) → return raw
+ *   4. percent-encode non-whitelist bytes; truncate at 200 chars without
+ *      splitting a `%XX` (191 prefix + `_` + sha256-8)
+ *
+ * The original ID is always written into the transcript record itself; this
+ * helper only sanitizes the on-disk filename.
+ */
+export function safePathSegment(raw: string): string {
+  // 1. obviously invalid
+  if (raw === "" || raw === "." || raw === ".." || isAllControl(raw)) {
+    return "_invalid_" + sha256_8(raw);
+  }
+
+  // 2. Windows reserved names — must run BEFORE fast path so `CON` is not
+  //    leaked unchanged on case-insensitive filesystems.
+  if (WIN_RESERVED.has(raw.toUpperCase())) {
+    return "_win_" + raw;
+  }
+
+  // 3. fast path
+  if (FAST_PATH_RE.test(raw)) return raw;
+
+  // 4. escape + maybe truncate
+  const escaped = escapeRaw(raw);
+  if (escaped.length <= MAX_LEN) return escaped;
+  return truncateEscaped(escaped, raw);
+}
+
+/**
+ * Resolve the on-disk transcript file for a given (agent, room, topic). Used
+ * by the writer AND the CLI subcommands so both look at the same file.
+ *
+ * Layout (design §3.1):
+ *   <rootDir>/<agentId>/transcripts/<roomId>/<topicId|_default>.jsonl
+ *
+ * Where <rootDir> is typically `~/.botcord/agents`.
+ */
+export function transcriptFilePath(
+  rootDir: string,
+  agentId: string,
+  roomId: string,
+  topicId: string | null,
+): string {
+  return path.join(
+    rootDir,
+    safePathSegment(agentId),
+    "transcripts",
+    safePathSegment(roomId),
+    (topicId === null ? "_default" : safePathSegment(topicId)) + ".jsonl",
+  );
+}
+
+/** Directory holding a (agent, room) pair's transcript files. */
+export function transcriptRoomDir(
+  rootDir: string,
+  agentId: string,
+  roomId: string,
+): string {
+  return path.join(
+    rootDir,
+    safePathSegment(agentId),
+    "transcripts",
+    safePathSegment(roomId),
+  );
+}
+
+/** Directory holding all transcript rooms for a single agent. */
+export function transcriptAgentRoot(rootDir: string, agentId: string): string {
+  return path.join(rootDir, safePathSegment(agentId), "transcripts");
+}

--- a/packages/daemon/src/gateway/transcript.ts
+++ b/packages/daemon/src/gateway/transcript.ts
@@ -1,0 +1,300 @@
+import { appendFileSync, mkdirSync, renameSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+import type { GatewayLogger } from "./log.js";
+import { transcriptFilePath } from "./transcript-paths.js";
+
+/**
+ * Soft cap on a single textual field (`text` / `composedText` / `finalText`).
+ * Anything longer is truncated and `truncated.<field>` set to `true`.
+ */
+export const TRANSCRIPT_TEXT_LIMIT = 32 * 1024;
+
+/** Soft cap on a single transcript file before rotation. */
+export const TRANSCRIPT_FILE_LIMIT = 8 * 1024 * 1024;
+
+/** Default root directory for per-agent transcript trees. */
+export function defaultTranscriptRoot(): string {
+  return path.join(homedir(), ".botcord", "agents");
+}
+
+// ---------------------------------------------------------------------------
+// Record types — see design §3.2
+// ---------------------------------------------------------------------------
+
+export type TranscriptRecordKind =
+  | "inbound"
+  | "dispatched"
+  | "compose_failed"
+  | "outbound"
+  | "turn_error"
+  | "attention_skipped"
+  | "dropped";
+
+export interface TranscriptRecordBase {
+  ts: string;
+  kind: TranscriptRecordKind;
+  turnId: string;
+  agentId: string;
+  roomId: string;
+  topicId: string | null;
+}
+
+export interface TranscriptSenderInfo {
+  id: string;
+  kind: "user" | "agent" | "system";
+  name?: string;
+}
+
+export interface InboundTranscriptRecord extends TranscriptRecordBase {
+  kind: "inbound";
+  messageId: string;
+  sender: TranscriptSenderInfo;
+  text: string;
+  rawBatchEntries?: number;
+  trace?: { id: string; streamable?: boolean };
+  truncated?: { text?: true };
+}
+
+export interface DispatchedTranscriptRecord extends TranscriptRecordBase {
+  kind: "dispatched";
+  composedText: string;
+  mergedFromTurnIds?: string[];
+  runtime: string;
+  truncated?: { composedText?: true };
+}
+
+export interface ComposeFailedTranscriptRecord extends TranscriptRecordBase {
+  kind: "compose_failed";
+  error: string;
+  fallback: "raw_text";
+}
+
+export type DeliveryStatus =
+  | "delivered"
+  | "gated_non_owner_chat"
+  | "empty_text"
+  | "send_failed";
+
+export interface TranscriptBlockSummary {
+  type: string;
+  chars?: number;
+  name?: string;
+}
+
+export interface OutboundTranscriptRecord extends TranscriptRecordBase {
+  kind: "outbound";
+  runtime: string;
+  runtimeSessionId?: string | null;
+  durationMs: number;
+  costUsd?: number;
+  finalText: string;
+  deliveryStatus: DeliveryStatus;
+  deliveryReason?: string | null;
+  blocks?: TranscriptBlockSummary[];
+  truncated?: { finalText?: true };
+}
+
+export interface TurnErrorTranscriptRecord extends TranscriptRecordBase {
+  kind: "turn_error";
+  phase: "runtime" | "timeout";
+  error: string;
+  durationMs: number;
+}
+
+export interface AttentionSkippedTranscriptRecord extends TranscriptRecordBase {
+  kind: "attention_skipped";
+  reason: string;
+}
+
+export type DroppedReason =
+  | "batch_merged"
+  | "queue_cancel_previous"
+  | "queue_overflow";
+
+export interface DroppedTranscriptRecord extends TranscriptRecordBase {
+  kind: "dropped";
+  reason: DroppedReason;
+  supersededBy?: string | null;
+}
+
+export type TranscriptRecord =
+  | InboundTranscriptRecord
+  | DispatchedTranscriptRecord
+  | ComposeFailedTranscriptRecord
+  | OutboundTranscriptRecord
+  | TurnErrorTranscriptRecord
+  | AttentionSkippedTranscriptRecord
+  | DroppedTranscriptRecord;
+
+// ---------------------------------------------------------------------------
+// Truncation helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Truncate `value` to TRANSCRIPT_TEXT_LIMIT chars. Returns the (possibly
+ * truncated) text and whether truncation occurred. Surrogate-pair aware: if
+ * the cut would split a pair, step back one char.
+ */
+export function truncateTextField(value: string): { text: string; truncated: boolean } {
+  if (value.length <= TRANSCRIPT_TEXT_LIMIT) return { text: value, truncated: false };
+  let cut = TRANSCRIPT_TEXT_LIMIT;
+  const code = value.charCodeAt(cut - 1);
+  if (code >= 0xd800 && code <= 0xdbff) cut -= 1; // mid-surrogate
+  return { text: value.slice(0, cut), truncated: true };
+}
+
+// ---------------------------------------------------------------------------
+// Writer
+// ---------------------------------------------------------------------------
+
+export interface TranscriptWriter {
+  /** Append a record. Failures are logged and swallowed. */
+  write(rec: TranscriptRecord): void;
+  /** Whether persistence is on. CLI / tests may read this. */
+  readonly enabled: boolean;
+  /** Root directory used for path resolution. */
+  readonly rootDir: string;
+}
+
+export interface CreateTranscriptWriterOptions {
+  /** Defaults to `~/.botcord/agents`. */
+  rootDir?: string;
+  log: GatewayLogger;
+  /** Defaults to `false` — see design §6 (default-off). */
+  enabled?: boolean;
+  /** Override file rotation threshold (bytes). Defaults to TRANSCRIPT_FILE_LIMIT. */
+  maxFileBytes?: number;
+}
+
+interface FileMeta {
+  size: number;
+}
+
+class NoopTranscriptWriter implements TranscriptWriter {
+  readonly enabled = false;
+  readonly rootDir: string;
+  constructor(rootDir: string) {
+    this.rootDir = rootDir;
+  }
+  write(_rec: TranscriptRecord): void {
+    // intentionally empty
+  }
+}
+
+class FsTranscriptWriter implements TranscriptWriter {
+  readonly enabled = true;
+  readonly rootDir: string;
+  private readonly log: GatewayLogger;
+  private readonly maxFileBytes: number;
+  private readonly fileMeta = new Map<string, FileMeta>();
+  private firstWriteAnnounced = false;
+
+  constructor(rootDir: string, log: GatewayLogger, maxFileBytes: number) {
+    this.rootDir = rootDir;
+    this.log = log;
+    this.maxFileBytes = maxFileBytes;
+  }
+
+  write(rec: TranscriptRecord): void {
+    try {
+      const file = transcriptFilePath(this.rootDir, rec.agentId, rec.roomId, rec.topicId);
+      const dir = path.dirname(file);
+      try {
+        mkdirSync(dir, { recursive: true, mode: 0o700 });
+      } catch {
+        // best-effort — appendFileSync below will surface a real error
+      }
+
+      const line = JSON.stringify(rec) + "\n";
+      const bytes = Buffer.byteLength(line, "utf8");
+
+      // Rotate before appending if the existing file would exceed the cap.
+      const meta = this.statFile(file);
+      if (meta.size > 0 && meta.size + bytes > this.maxFileBytes) {
+        this.rotate(file);
+        this.fileMeta.delete(file);
+      }
+
+      appendFileSync(file, line, { mode: 0o600 });
+      const cur = this.fileMeta.get(file) ?? { size: meta.size };
+      cur.size = (cur.size || 0) + bytes;
+      this.fileMeta.set(file, cur);
+
+      if (!this.firstWriteAnnounced) {
+        this.firstWriteAnnounced = true;
+        this.log.info("transcript enabled", { dir: this.rootDir });
+      }
+    } catch (err) {
+      this.log.warn("transcript: write failed", {
+        kind: rec.kind,
+        turnId: rec.turnId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  private statFile(file: string): FileMeta {
+    const cached = this.fileMeta.get(file);
+    if (cached) return cached;
+    try {
+      const st = statSync(file);
+      const meta = { size: st.size };
+      this.fileMeta.set(file, meta);
+      return meta;
+    } catch {
+      const meta = { size: 0 };
+      this.fileMeta.set(file, meta);
+      return meta;
+    }
+  }
+
+  private rotate(file: string): void {
+    const stamp = formatStamp(new Date());
+    const ext = ".jsonl";
+    const base = file.endsWith(ext) ? file.slice(0, -ext.length) : file;
+    const rotated = `${base}.${stamp}${ext}`;
+    try {
+      renameSync(file, rotated);
+    } catch (err) {
+      this.log.warn("transcript: rotate failed", {
+        file,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}
+
+export function createTranscriptWriter(
+  opts: CreateTranscriptWriterOptions,
+): TranscriptWriter {
+  const rootDir = opts.rootDir ?? defaultTranscriptRoot();
+  const enabled = opts.enabled ?? false;
+  if (!enabled) return new NoopTranscriptWriter(rootDir);
+  const maxBytes = opts.maxFileBytes ?? TRANSCRIPT_FILE_LIMIT;
+  return new FsTranscriptWriter(rootDir, opts.log, maxBytes);
+}
+
+/**
+ * Resolve the tri-state enable flag (env wins; otherwise config). See design §5.
+ *  - env === "1" → true (force on)
+ *  - env === "0" → false (force off)
+ *  - any other / unset → fall back to `configEnabled`
+ */
+export function resolveTranscriptEnabled(
+  envVal: string | undefined,
+  configEnabled: boolean,
+): boolean {
+  if (envVal === "1") return true;
+  if (envVal === "0") return false;
+  return configEnabled;
+}
+
+function formatStamp(d: Date): string {
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return (
+    `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}` +
+    `-${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}${pad(d.getUTCSeconds())}`
+  );
+}

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, unlinkSync, readdirSync, statSync, rmSync } from "node:fs";
 import { homedir, hostname } from "node:os";
 import path from "node:path";
 import {
@@ -17,6 +17,12 @@ import {
   type RouteRuleMatch,
 } from "./config.js";
 import { resolveBootAgents } from "./agent-discovery.js";
+import {
+  defaultTranscriptRoot,
+  resolveTranscriptEnabled,
+  transcriptAgentRoot,
+  transcriptFilePath,
+} from "./gateway/index.js";
 import { startDaemon } from "./daemon.js";
 import { log, LOG_FILE_PATH } from "./log.js";
 import { detectRuntimes, getAdapterModule, listAdapterIds } from "./adapters/runtimes.js";
@@ -94,6 +100,15 @@ Commands:
   stop                                    Stop the running daemon (SIGTERM)
   status                                  Print daemon status (pid, agent)
   logs [-f]                               Print log tail (use -f to follow)
+  transcript enable|disable|status        Toggle persistent transcript logging
+  transcript list --agent <ag_xxx>        List rooms with transcripts for an agent
+  transcript tail --agent <ag_xxx> --room <rm_xxx> [--topic <tp>] [-n 50] [-f]
+                                          Tail recent transcript records (NDJSON)
+  transcript dump --agent <ag_xxx> --room <rm_xxx> [--topic <tp>]
+                                          Print full transcript file to stdout
+  transcript prune --agent <ag_xxx> [--older-than 30d] [--all]
+                                          Remove rotated transcript files (or all
+                                          for the agent with --all --yes)
   route add [match flags] --adapter <${ADAPTER_LIST}> --cwd <path>
       match flags (first match wins; at least one conversation/sender selector required):
         --conversation-id <rm_xxx>        (alias: --room <rm_xxx>)
@@ -597,6 +612,225 @@ async function cmdLogs(args: ParsedArgs): Promise<void> {
   console.log(lines.slice(-100).join("\n"));
 }
 
+// ---------------------------------------------------------------------------
+// transcript subcommands (design §5)
+// ---------------------------------------------------------------------------
+
+function transcriptStringFlag(args: ParsedArgs, name: string): string | null {
+  const v = args.flags[name];
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+function parseDurationToMs(s: string): number | null {
+  const m = /^(\d+)\s*([smhd])?$/.exec(s.trim());
+  if (!m) return null;
+  const n = Number(m[1]);
+  const unit = m[2] ?? "d";
+  const mult: Record<string, number> = {
+    s: 1000,
+    m: 60_000,
+    h: 3_600_000,
+    d: 86_400_000,
+  };
+  return n * mult[unit];
+}
+
+async function cmdTranscript(args: ParsedArgs): Promise<void> {
+  switch (args.sub) {
+    case "enable":
+      return cmdTranscriptToggle(true);
+    case "disable":
+      return cmdTranscriptToggle(false);
+    case "status":
+      return cmdTranscriptStatus();
+    case "list":
+      return cmdTranscriptList(args);
+    case "tail":
+      return cmdTranscriptTail(args);
+    case "dump":
+      return cmdTranscriptDump(args);
+    case "prune":
+      return cmdTranscriptPrune(args);
+    default:
+      console.error("usage: botcord-daemon transcript <enable|disable|status|list|tail|dump|prune>");
+      process.exit(1);
+  }
+}
+
+function cmdTranscriptToggle(enable: boolean): void {
+  let cfg: DaemonConfig;
+  try {
+    cfg = loadConfig();
+  } catch (err) {
+    const e = err as Error & { code?: string };
+    if (e.code === CONFIG_MISSING) {
+      console.error(
+        `daemon config not found — run \`botcord-daemon start\` once to initialize, then retry`,
+      );
+      process.exit(1);
+    }
+    throw err;
+  }
+  cfg.transcript = { ...(cfg.transcript ?? {}), enabled: enable };
+  saveConfig(cfg);
+  console.log(
+    `transcript persistence ${enable ? "enabled" : "disabled"} (next daemon start)`,
+  );
+}
+
+function cmdTranscriptStatus(): void {
+  let cfg: DaemonConfig | null = null;
+  try {
+    cfg = loadConfig();
+  } catch (err) {
+    const e = err as Error & { code?: string };
+    if (e.code !== CONFIG_MISSING) throw err;
+  }
+  const configEnabled = cfg?.transcript?.enabled === true;
+  const env = process.env.BOTCORD_TRANSCRIPT;
+  const effective = resolveTranscriptEnabled(env, configEnabled);
+  let source: string;
+  if (env === "1" || env === "0") source = `env BOTCORD_TRANSCRIPT=${env}`;
+  else if (configEnabled) source = "config (transcript.enabled=true)";
+  else source = "default-off";
+  console.log(`enabled: ${effective}`);
+  console.log(`source: ${source}`);
+  console.log(`root: ${defaultTranscriptRoot()}`);
+}
+
+function cmdTranscriptList(args: ParsedArgs): void {
+  const agent = transcriptStringFlag(args, "agent");
+  if (!agent) {
+    console.error("transcript list requires --agent <ag_xxx>");
+    process.exit(1);
+  }
+  const root = transcriptAgentRoot(defaultTranscriptRoot(), agent);
+  if (!existsSync(root)) {
+    return; // no rooms → empty output
+  }
+  for (const entry of readdirSync(root)) {
+    const dir = path.join(root, entry);
+    let st;
+    try {
+      st = statSync(dir);
+    } catch {
+      continue;
+    }
+    if (!st.isDirectory()) continue;
+    console.log(entry);
+  }
+}
+
+function cmdTranscriptTail(args: ParsedArgs): Promise<void> | void {
+  const agent = transcriptStringFlag(args, "agent");
+  const room = transcriptStringFlag(args, "room");
+  if (!agent || !room) {
+    console.error("transcript tail requires --agent <ag_xxx> --room <rm_xxx>");
+    process.exit(1);
+  }
+  const topic = transcriptStringFlag(args, "topic");
+  const file = transcriptFilePath(defaultTranscriptRoot(), agent, room, topic);
+  if (!existsSync(file)) {
+    console.error(`no transcript at ${file}`);
+    process.exit(1);
+  }
+  const follow = args.flags.f === true || args.flags.follow === true;
+  const nFlag = transcriptStringFlag(args, "n");
+  const n = nFlag && /^\d+$/.test(nFlag) ? Number(nFlag) : 50;
+  if (follow) {
+    const child = spawn("tail", ["-n", String(n), "-f", file], { stdio: "inherit" });
+    process.on("SIGINT", () => child.kill("SIGINT"));
+    return new Promise<void>((resolve) => {
+      child.on("close", () => resolve());
+    });
+  }
+  const data = readFileSync(file, "utf8");
+  const lines = data.split("\n").filter((l) => l.length > 0);
+  console.log(lines.slice(-n).join("\n"));
+}
+
+function cmdTranscriptDump(args: ParsedArgs): void {
+  const agent = transcriptStringFlag(args, "agent");
+  const room = transcriptStringFlag(args, "room");
+  if (!agent || !room) {
+    console.error("transcript dump requires --agent <ag_xxx> --room <rm_xxx>");
+    process.exit(1);
+  }
+  const topic = transcriptStringFlag(args, "topic");
+  const file = transcriptFilePath(defaultTranscriptRoot(), agent, room, topic);
+  if (!existsSync(file)) {
+    console.error(`no transcript at ${file}`);
+    process.exit(1);
+  }
+  process.stdout.write(readFileSync(file, "utf8"));
+}
+
+function cmdTranscriptPrune(args: ParsedArgs): void {
+  const agent = transcriptStringFlag(args, "agent");
+  if (!agent) {
+    console.error("transcript prune requires --agent <ag_xxx>");
+    process.exit(1);
+  }
+  const all = args.flags.all === true;
+  const olderThanFlag = transcriptStringFlag(args, "older-than");
+  const yes = args.flags.yes === true;
+  const root = transcriptAgentRoot(defaultTranscriptRoot(), agent);
+  if (!existsSync(root)) return;
+
+  if (all) {
+    if (!yes) {
+      console.error(
+        `transcript prune --all will delete every transcript under ${root}; rerun with --yes to confirm`,
+      );
+      process.exit(1);
+    }
+    rmSync(root, { recursive: true, force: true });
+    console.log(`removed ${root}`);
+    return;
+  }
+
+  // Default and --older-than: prune rotated files only (the "{topic}.STAMP.jsonl" form).
+  // Active files (`{topic}.jsonl` / `_default.jsonl`) are never touched.
+  const cutoffMs = olderThanFlag ? parseDurationToMs(olderThanFlag) : null;
+  if (olderThanFlag && cutoffMs === null) {
+    console.error(`transcript prune --older-than: invalid duration "${olderThanFlag}" (use 30d / 12h / 30m / 60s)`);
+    process.exit(1);
+  }
+  const cutoff = cutoffMs !== null ? Date.now() - cutoffMs : null;
+
+  let removed = 0;
+  for (const roomEntry of readdirSync(root)) {
+    const dir = path.join(root, roomEntry);
+    let st;
+    try {
+      st = statSync(dir);
+    } catch {
+      continue;
+    }
+    if (!st.isDirectory()) continue;
+    for (const f of readdirSync(dir)) {
+      // rotated files: <topic>.<YYYYMMDD-HHMMSS>.jsonl — must contain a stamp segment
+      if (!/^.+\.\d{8}-\d{6}\.jsonl$/.test(f)) continue;
+      const full = path.join(dir, f);
+      if (cutoff !== null) {
+        try {
+          const fst = statSync(full);
+          if (fst.mtimeMs >= cutoff) continue;
+        } catch {
+          continue;
+        }
+      }
+      try {
+        unlinkSync(full);
+        removed += 1;
+      } catch (err) {
+        console.error(`failed to remove ${full}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+  }
+  console.log(`removed ${removed} rotated transcript file(s)`);
+}
+
 function formatRouteMatch(m: RouteRuleMatch): string {
   const parts: string[] = [];
   if (m.channel) parts.push(`channel=${m.channel}`);
@@ -954,6 +1188,9 @@ async function main(): Promise<void> {
         break;
       case "logs":
         await cmdLogs(args);
+        break;
+      case "transcript":
+        await cmdTranscript(args);
         break;
       case "route":
         await cmdRoute(args);


### PR DESCRIPTION
## Summary
- Implements `packages/daemon/docs/transcript-logging.md`: per-(agent, room, topic) NDJSON transcripts at `~/.botcord/agents/{agentId}/transcripts/{roomId}/{topicId|_default}.jsonl`, with one `inbound` + one path record (`dispatched`/`dropped`/`attention_skipped`) + one terminal (`outbound`/`turn_error`) per dispatcher `handle()`.
- New `transcript-paths.ts` (4-step `safePathSegment` shared by writer & CLI) and `transcript.ts` (record union, `FsTranscriptWriter` with 8 MiB rotation + 32 KiB field truncation, tri-state `resolveTranscriptEnabled`).
- Dispatcher gains `turnId` per turn, `TurnSupersededError` to distinguish cancel-previous from timeout abort, serial-buffer/cancel-previous/queue-overflow → `dropped` records, `deliveryStatus` state machine (`delivered` / `gated_non_owner_chat` / `empty_text` / `send_failed`).
- New `botcord-daemon transcript {enable|disable|status|list|tail|dump|prune}` subcommands; `transcript.enabled` added to daemon config; `BOTCORD_TRANSCRIPT` env overrides config (`1` force on, `0` force off).
- Default-off per design §6 (only opt in via env or `transcript enable`).

## Test plan
- [x] `vitest run src/gateway/__tests__/transcript.test.ts` — 26 new tests pass (state machine, owner-chat dual gate, attention/compose paths, truncation, rotation, fs-error resilience, `safePathSegment` ordering incl. `CON`/`..`/long IDs, CLI/writer path parity)
- [x] Full gateway suite — 222 tests, all pass (`vitest run src/gateway/__tests__/`)
- [ ] Manual: `BOTCORD_TRANSCRIPT=1 npx botcord-daemon start`, send a message, verify file appears under `~/.botcord/agents/.../transcripts/`
- [ ] Manual: `botcord-daemon transcript status` reflects env vs config source correctly
- [ ] Manual: `botcord-daemon transcript prune --agent <ag> --older-than 30d` removes only rotated `*.YYYYMMDD-HHMMSS.jsonl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)