### PR TITLE
feat(daemon): OpenClaw ACP as fourth runtime

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1991,7 +1991,7 @@ async def provision_agent(
         raise HTTPException(status_code=409, detail="daemon_revoked")
     if not is_daemon_online(body.daemon_instance_id):
         raise HTTPException(status_code=409, detail="daemon_offline")
-    if not _daemon_lists_runtime(instance, runtime):
+    if not _daemon_lists_runtime(instance, runtime, body.openclaw_gateway):
         raise HTTPException(status_code=409, detail="runtime_unavailable")
 
     # --- Quota check ---------------------------------------------------

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1914,13 +1914,23 @@ class ProvisionAgentResponse(BaseModel):
     is_default: bool
 
 
-def _daemon_lists_runtime(instance: DaemonInstance, runtime: str) -> bool:
+def _daemon_lists_runtime(
+    instance: DaemonInstance,
+    runtime: str,
+    openclaw_gateway: str | None = None,
+) -> bool:
     """Check that the daemon's last runtime probe lists `runtime` as available.
 
     Empty / missing snapshots are treated permissively: the daemon may not
     have completed its first probe yet, and rejecting here would deadlock
     provisioning on a freshly-connected daemon. The daemon will still reject
     unknown runtimes in `provision.ts` at the handler boundary.
+
+    For `runtime == "openclaw-acp"`, RFC §3.8.2 requires an additional check:
+    when `openclaw_gateway` is given, the matching `endpoints[]` entry must
+    be reachable. Without this, a daemon with the OpenClaw CLI installed but
+    a misconfigured / unreachable gateway would still pass the gate and only
+    fail at first turn.
     """
     snap = instance.runtimes_json
     if not isinstance(snap, list) or not snap:
@@ -1928,8 +1938,21 @@ def _daemon_lists_runtime(instance: DaemonInstance, runtime: str) -> bool:
     for entry in snap:
         if not isinstance(entry, dict):
             continue
-        if entry.get("id") == runtime and entry.get("available") is True:
-            return True
+        if entry.get("id") != runtime:
+            continue
+        if entry.get("available") is not True:
+            return False
+        if runtime == "openclaw-acp" and openclaw_gateway:
+            endpoints = entry.get("endpoints")
+            if not isinstance(endpoints, list):
+                return False
+            for ep in endpoints:
+                if not isinstance(ep, dict):
+                    continue
+                if ep.get("name") == openclaw_gateway and ep.get("reachable") is True:
+                    return True
+            return False
+        return True
     return False
 
 

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1899,6 +1899,11 @@ class ProvisionAgentBody(BaseModel):
     runtime: str
     cwd: str | None = None
     bio: str | None = None
+    # Optional OpenClaw routing selection. Only meaningful when
+    # `runtime == "openclaw-acp"` — daemon writes these to credentials so the
+    # synthesized managed route can resolve a `ResolvedOpenclawGateway`.
+    openclaw_gateway: str | None = None
+    openclaw_agent: str | None = None
 
 
 class ProvisionAgentResponse(BaseModel):
@@ -2056,6 +2061,17 @@ async def provision_agent(
         frame_params["credentials"]["cwd"] = body.cwd
     if body.bio:
         frame_params["bio"] = body.bio
+    if body.openclaw_gateway:
+        # Top-level nested form (RFC §3.9.2).
+        oc: dict[str, str] = {"gateway": body.openclaw_gateway}
+        if body.openclaw_agent:
+            oc["agent"] = body.openclaw_agent
+        frame_params["openclaw"] = oc
+        # Mirror onto the flat credentials envelope so daemon's offline reload
+        # path picks the same gateway without seeing the top-level field.
+        frame_params["credentials"]["openclawGateway"] = body.openclaw_gateway
+        if body.openclaw_agent:
+            frame_params["credentials"]["openclawAgent"] = body.openclaw_agent
 
     # Seed the daemon's policyResolver with the agent's default attention so
     # it has a real policy from message zero (no first-message refetch race).

--- a/backend/hub/routers/daemon_control.py
+++ b/backend/hub/routers/daemon_control.py
@@ -849,9 +849,18 @@ def _parse_runtime_snapshot_params(
     if len(runtimes) > 64:
         return None
     # Each entry must be a dict — beyond that we trust the daemon's schema.
+    # The one schema-aware check we run is on the optional nested
+    # ``endpoints[]`` (RFC §3.8.2): a misconfigured daemon could otherwise
+    # ship thousands of OpenClaw gateway entries inside the jsonb column.
+    # Cap at 32 (matches RUNTIME_ENDPOINTS_CAP on the daemon side); silently
+    # truncate rather than reject so a transient overflow doesn't drop the
+    # whole snapshot.
     for entry in runtimes:
         if not isinstance(entry, dict):
             return None
+        endpoints = entry.get("endpoints")
+        if isinstance(endpoints, list) and len(endpoints) > 32:
+            entry["endpoints"] = endpoints[:32]
     if not isinstance(probed_at, (int, float)) or isinstance(probed_at, bool):
         return None
     if probed_at <= 0:

--- a/frontend/src/components/dashboard/CreateAgentDialog.tsx
+++ b/frontend/src/components/dashboard/CreateAgentDialog.tsx
@@ -704,12 +704,16 @@ function OpenclawGatewayPicker({
             className="w-full rounded-xl border border-glass-border bg-deep-black px-3 py-2 text-sm text-text-primary"
           >
             <option value="">(use gateway defaultAgent)</option>
-            {agents.map((a) => (
-              <option key={a.name} value={a.name}>
-                {a.name}
-                {a.model ? ` — ${a.model}` : ""}
-              </option>
-            ))}
+            {agents.map((a) => {
+              const label =
+                (a.name && a.name !== a.id ? `${a.name} (${a.id})` : a.id) +
+                (a.model?.name ? ` — ${a.model.name}` : "");
+              return (
+                <option key={a.id} value={a.id}>
+                  {label}
+                </option>
+              );
+            })}
           </select>
         )}
       </div>

--- a/frontend/src/components/dashboard/CreateAgentDialog.tsx
+++ b/frontend/src/components/dashboard/CreateAgentDialog.tsx
@@ -77,6 +77,8 @@ export default function CreateAgentDialog({
   const [hostKind, setHostKind] = useState<"daemon" | "openclaw">("daemon");
   const [selectedDaemonId, setSelectedDaemonId] = useState<string | null>(null);
   const [selectedRuntimeId, setSelectedRuntimeId] = useState<string | null>(null);
+  const [selectedGateway, setSelectedGateway] = useState<string | null>(null);
+  const [selectedOpenclawAgent, setSelectedOpenclawAgent] = useState<string | null>(null);
   const [name, setName] = useState("");
   const [bio, setBio] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -127,6 +129,23 @@ export default function CreateAgentDialog({
     setSelectedRuntimeId(firstAvailable?.id ?? null);
   }, [selectedDaemon, selectedRuntimeId]);
 
+  // Reset OpenClaw selections when leaving the openclaw-acp runtime.
+  const selectedRuntime = useMemo(
+    () => selectedDaemon?.runtimes?.find((r) => r.id === selectedRuntimeId) ?? null,
+    [selectedDaemon, selectedRuntimeId],
+  );
+  useEffect(() => {
+    if (selectedRuntimeId !== "openclaw-acp") {
+      setSelectedGateway(null);
+      setSelectedOpenclawAgent(null);
+      return;
+    }
+    const reachable = (selectedRuntime?.endpoints ?? []).filter((e) => e.reachable);
+    if (selectedGateway && reachable.some((e) => e.name === selectedGateway)) return;
+    setSelectedGateway(reachable[0]?.name ?? null);
+    setSelectedOpenclawAgent(null);
+  }, [selectedRuntime, selectedRuntimeId, selectedGateway]);
+
   async function handleCopy(): Promise<void> {
     try {
       await navigator.clipboard.writeText(buildStartCommand());
@@ -172,6 +191,12 @@ export default function CreateAgentDialog({
         name: name.trim() || undefined,
         bio: bio.trim() || undefined,
         runtime: selectedRuntimeId,
+        ...(selectedRuntimeId === "openclaw-acp" && selectedGateway
+          ? {
+              openclawGateway: selectedGateway,
+              ...(selectedOpenclawAgent ? { openclawAgent: selectedOpenclawAgent } : {}),
+            }
+          : {}),
       });
       await onSuccess(res.agentId);
       onClose();
@@ -183,8 +208,12 @@ export default function CreateAgentDialog({
   }
 
   const showEmptyState = loaded && onlineDaemons.length === 0;
+  const needsOpenclawGateway = selectedRuntimeId === "openclaw-acp";
   const canSubmit =
-    !!selectedDaemonId && !!selectedRuntimeId && !submitting;
+    !!selectedDaemonId &&
+    !!selectedRuntimeId &&
+    (!needsOpenclawGateway || !!selectedGateway) &&
+    !submitting;
 
   return (
     <div className="fixed inset-0 z-[110] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm">
@@ -312,6 +341,20 @@ export default function CreateAgentDialog({
               }}
               disabled={submitting}
             />
+
+            {needsOpenclawGateway && (
+              <OpenclawGatewayPicker
+                runtime={selectedRuntime}
+                selectedGateway={selectedGateway}
+                onSelectGateway={(g) => {
+                  setSelectedGateway(g);
+                  setSelectedOpenclawAgent(null);
+                }}
+                selectedAgent={selectedOpenclawAgent}
+                onSelectAgent={setSelectedOpenclawAgent}
+                disabled={submitting}
+              />
+            )}
 
             <div>
               <label className="mb-1.5 block text-xs font-semibold uppercase tracking-wider text-text-secondary">
@@ -582,6 +625,95 @@ function RuntimeCard({
         <Check className="h-4 w-4 flex-shrink-0 text-neon-cyan" />
       )}
     </button>
+  );
+}
+
+function OpenclawGatewayPicker({
+  runtime,
+  selectedGateway,
+  onSelectGateway,
+  selectedAgent,
+  onSelectAgent,
+  disabled,
+}: {
+  runtime: DaemonRuntime | null;
+  selectedGateway: string | null;
+  onSelectGateway: (name: string | null) => void;
+  selectedAgent: string | null;
+  onSelectAgent: (name: string | null) => void;
+  disabled: boolean;
+}) {
+  const endpoints = runtime?.endpoints ?? [];
+  const reachable = endpoints.filter((e) => e.reachable);
+  const current = endpoints.find((e) => e.name === selectedGateway) ?? null;
+  const agents = current?.agents ?? [];
+  if (endpoints.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-glass-border bg-glass-bg/40 px-3 py-3 text-xs text-text-secondary">
+        No OpenClaw gateways configured on this daemon. Add an entry to
+        <code className="mx-1 font-mono">openclawGateways</code>
+        in the daemon config and refresh.
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-2">
+      <div>
+        <label className="mb-1.5 block text-xs font-semibold uppercase tracking-wider text-text-secondary">
+          Gateway
+        </label>
+        <select
+          disabled={disabled}
+          value={selectedGateway ?? ""}
+          onChange={(e) => onSelectGateway(e.target.value || null)}
+          className="w-full rounded-xl border border-glass-border bg-deep-black px-3 py-2 text-sm text-text-primary"
+        >
+          <option value="" disabled>
+            Select a gateway
+          </option>
+          {endpoints.map((e) => (
+            <option key={e.name} value={e.name} disabled={!e.reachable}>
+              {e.name} — {e.url} {e.reachable ? `(${e.version ?? "ok"})` : `✗ ${e.error ?? "unreachable"}`}
+            </option>
+          ))}
+        </select>
+        {reachable.length === 0 && (
+          <p className="mt-1 text-[11px] text-orange-400">
+            No reachable gateways. Check tokens, daemon network access, or refresh runtimes.
+          </p>
+        )}
+      </div>
+      <div>
+        <label className="mb-1.5 block text-xs font-semibold uppercase tracking-wider text-text-secondary">
+          Agent profile (optional)
+        </label>
+        {agents.length === 0 ? (
+          <input
+            disabled={disabled || !selectedGateway}
+            type="text"
+            value={selectedAgent ?? ""}
+            placeholder="leave blank to use the gateway's defaultAgent"
+            onChange={(e) => onSelectAgent(e.target.value.trim() || null)}
+            className="w-full rounded-xl border border-glass-border bg-deep-black px-3 py-2 text-sm text-text-primary"
+          />
+        ) : (
+          <select
+            disabled={disabled || !selectedGateway}
+            value={selectedAgent ?? ""}
+            onChange={(e) => onSelectAgent(e.target.value || null)}
+            className="w-full rounded-xl border border-glass-border bg-deep-black px-3 py-2 text-sm text-text-primary"
+          >
+            <option value="">(use gateway defaultAgent)</option>
+            {agents.map((a) => (
+              <option key={a.name} value={a.name}>
+                {a.name}
+                {a.model ? ` — ${a.model}` : ""}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+    </div>
   );
 }
 

--- a/frontend/src/store/useDaemonStore.ts
+++ b/frontend/src/store/useDaemonStore.ts
@@ -17,12 +17,23 @@
 import { create } from "zustand";
 import { useDashboardSessionStore } from "./useDashboardSessionStore";
 
+export interface DaemonRuntimeEndpoint {
+  name: string;
+  url: string;
+  reachable: boolean;
+  version?: string;
+  error?: string;
+  agents?: Array<{ name: string; model?: string }>;
+}
+
 export interface DaemonRuntime {
   id: string;
   available: boolean;
   version?: string;
   path?: string;
   error?: string;
+  /** OpenClaw-style runtimes carry per-gateway endpoint probe results. */
+  endpoints?: DaemonRuntimeEndpoint[];
 }
 
 export interface DaemonInstance {
@@ -41,6 +52,10 @@ export interface ProvisionAgentInput {
   bio?: string;
   runtime?: string;
   cwd?: string;
+  /** OpenClaw gateway profile name (only when runtime === "openclaw-acp"). */
+  openclawGateway?: string;
+  /** OpenClaw agent profile override. */
+  openclawAgent?: string;
 }
 
 export interface ProvisionAgentResult {
@@ -135,12 +150,45 @@ function normalizeRuntimes(raw: unknown): DaemonRuntime[] | null | undefined {
     const r = entry as Record<string, unknown>;
     const id = typeof r.id === "string" ? r.id : null;
     if (!id) continue;
+    const endpoints = Array.isArray(r.endpoints)
+      ? (r.endpoints as unknown[])
+          .map((rawEp) => {
+            if (!rawEp || typeof rawEp !== "object") return null;
+            const ep = rawEp as Record<string, unknown>;
+            const epName = typeof ep.name === "string" ? ep.name : null;
+            const epUrl = typeof ep.url === "string" ? ep.url : null;
+            if (!epName || !epUrl) return null;
+            return {
+              name: epName,
+              url: epUrl,
+              reachable: ep.reachable === true,
+              version: typeof ep.version === "string" ? ep.version : undefined,
+              error: typeof ep.error === "string" ? ep.error : undefined,
+              agents: Array.isArray(ep.agents)
+                ? ((ep.agents as unknown[])
+                    .map((a) => {
+                      if (!a || typeof a !== "object") return null;
+                      const ax = a as Record<string, unknown>;
+                      const an = typeof ax.name === "string" ? ax.name : null;
+                      if (!an) return null;
+                      return {
+                        name: an,
+                        model: typeof ax.model === "string" ? ax.model : undefined,
+                      };
+                    })
+                    .filter(Boolean) as Array<{ name: string; model?: string }>)
+                : undefined,
+            } as DaemonRuntimeEndpoint;
+          })
+          .filter(Boolean) as DaemonRuntimeEndpoint[]
+      : undefined;
     out.push({
       id,
       available: r.available === true,
       version: typeof r.version === "string" ? r.version : undefined,
       path: typeof r.path === "string" ? r.path : undefined,
       error: typeof r.error === "string" ? r.error : undefined,
+      endpoints,
     });
   }
   return out;
@@ -355,6 +403,8 @@ export const useDaemonStore = create<DaemonState>()((set, get) => ({
     if (input.runtime) body.runtime = input.runtime;
     if (input.cwd) body.cwd = input.cwd;
     if (input.bio) body.bio = input.bio;
+    if (input.openclawGateway) body.openclaw_gateway = input.openclawGateway;
+    if (input.openclawAgent) body.openclaw_agent = input.openclawAgent;
 
     const res = await fetch("/api/users/me/agents/provision", {
       method: "POST",

--- a/frontend/src/store/useDaemonStore.ts
+++ b/frontend/src/store/useDaemonStore.ts
@@ -23,7 +23,12 @@ export interface DaemonRuntimeEndpoint {
   reachable: boolean;
   version?: string;
   error?: string;
-  agents?: Array<{ name: string; model?: string }>;
+  agents?: Array<{
+    id: string;
+    name?: string;
+    workspace?: string;
+    model?: { name?: string; provider?: string };
+  }>;
 }
 
 export interface DaemonRuntime {
@@ -169,14 +174,30 @@ function normalizeRuntimes(raw: unknown): DaemonRuntime[] | null | undefined {
                     .map((a) => {
                       if (!a || typeof a !== "object") return null;
                       const ax = a as Record<string, unknown>;
-                      const an = typeof ax.name === "string" ? ax.name : null;
-                      if (!an) return null;
+                      const id = typeof ax.id === "string" ? ax.id : null;
+                      if (!id) return null;
+                      const model =
+                        ax.model && typeof ax.model === "object"
+                          ? {
+                              name:
+                                typeof (ax.model as any).name === "string"
+                                  ? (ax.model as any).name
+                                  : undefined,
+                              provider:
+                                typeof (ax.model as any).provider === "string"
+                                  ? (ax.model as any).provider
+                                  : undefined,
+                            }
+                          : undefined;
                       return {
-                        name: an,
-                        model: typeof ax.model === "string" ? ax.model : undefined,
+                        id,
+                        name: typeof ax.name === "string" ? ax.name : undefined,
+                        workspace:
+                          typeof ax.workspace === "string" ? ax.workspace : undefined,
+                        model,
                       };
                     })
-                    .filter(Boolean) as Array<{ name: string; model?: string }>)
+                    .filter(Boolean) as DaemonRuntimeEndpoint["agents"])
                 : undefined,
             } as DaemonRuntimeEndpoint;
           })

--- a/packages/daemon/src/__tests__/daemon-config-map.test.ts
+++ b/packages/daemon/src/__tests__/daemon-config-map.test.ts
@@ -414,3 +414,61 @@ describe("buildManagedRoutes", () => {
     expect(map.size).toBe(0);
   });
 });
+
+describe("openclawGateways resolution", () => {
+  it("resolves a route gateway profile name into ResolvedOpenclawGateway", () => {
+    const cfg = baseConfig({
+      defaultRoute: { adapter: "claude-code", cwd: "/home/alice" },
+      openclawGateways: [
+        { name: "local", url: "ws://127.0.0.1:1", token: "t1", defaultAgent: "main" },
+      ],
+      routes: [
+        { match: { conversationId: "rm_x" }, adapter: "openclaw-acp", cwd: "/home/alice", gateway: "local" },
+      ],
+    });
+    const gw = toGatewayConfig(cfg);
+    expect(gw.routes[0].gateway).toEqual({
+      name: "local",
+      url: "ws://127.0.0.1:1",
+      token: "t1",
+      openclawAgent: "main",
+    });
+  });
+
+  it("route.openclawAgent overrides profile.defaultAgent", () => {
+    const cfg = baseConfig({
+      openclawGateways: [{ name: "p1", url: "ws://x", defaultAgent: "main" }],
+      routes: [{ match: {}, adapter: "openclaw-acp", cwd: "/home/alice", gateway: "p1", openclawAgent: "design" }],
+    });
+    const gw = toGatewayConfig(cfg);
+    expect(gw.routes[0].gateway?.openclawAgent).toBe("design");
+  });
+
+  it("buildManagedRoutes uses credentials openclawGateway / openclawAgent", () => {
+    const cfg = baseConfig({
+      agents: ["ag_one"],
+      openclawGateways: [{ name: "p1", url: "ws://x", defaultAgent: "main" }],
+    });
+    const gw = toGatewayConfig(cfg, {
+      agentIds: ["ag_one"],
+      agentRuntimes: { ag_one: { runtime: "openclaw-acp", openclawGateway: "p1", openclawAgent: "qa" } },
+    });
+    const managed = gw.managedRoutes?.find((r) => r.match?.accountId === "ag_one");
+    expect(managed?.runtime).toBe("openclaw-acp");
+    expect(managed?.gateway?.name).toBe("p1");
+    expect(managed?.gateway?.openclawAgent).toBe("qa");
+  });
+
+  it("buildManagedRoutes skips an openclaw-acp managed route when its gateway is unknown", () => {
+    const cfg = baseConfig({
+      agents: ["ag_one"],
+      openclawGateways: [{ name: "p1", url: "ws://x" }],
+    });
+    const gw = toGatewayConfig(cfg, {
+      agentIds: ["ag_one"],
+      agentRuntimes: { ag_one: { runtime: "openclaw-acp", openclawGateway: "missing" } },
+    });
+    expect(gw.managedRoutes).toEqual([]);
+  });
+});
+

--- a/packages/daemon/src/__tests__/openclaw-acp.test.ts
+++ b/packages/daemon/src/__tests__/openclaw-acp.test.ts
@@ -148,6 +148,53 @@ describe("OpenclawAcpAdapter.run", () => {
     expect(spawnFn.mock.calls[0][1]).toEqual(["acp", "--url", "ws://127.0.0.1:1"]);
   });
 
+  it("respawns the pooled child when gateway.url or gateway.token changes under the same name", async () => {
+    function newChild(): FakeChild {
+      const c = new FakeChild();
+      c.stdin.on("data", (chunk: Buffer) => {
+        for (const line of chunk.toString("utf8").split("\n").filter(Boolean)) {
+          const frame = JSON.parse(line);
+          if (frame.method === "initialize") {
+            c.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: {} }) + "\n");
+          } else if (frame.method === "session/new") {
+            c.stdout.write(
+              JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { sessionId: "s" } }) + "\n",
+            );
+          } else if (frame.method === "session/prompt") {
+            c.stdout.write(
+              JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { text: "ok" } }) + "\n",
+            );
+          }
+        }
+      });
+      return c;
+    }
+    const children = [newChild(), newChild(), newChild()];
+    const spawnFn = vi.fn().mockImplementation(() => children.shift()! as any);
+    const adapter = new OpenclawAcpAdapter({ spawnFn: spawnFn as any });
+    const baseOpts = {
+      text: "hi",
+      sessionId: null,
+      cwd: "/tmp",
+      accountId: "ag_alice",
+      signal: new AbortController().signal,
+      trustLevel: "owner" as const,
+    };
+    await adapter.run({
+      ...baseOpts,
+      gateway: { name: "p1", url: "ws://a", token: "t1", openclawAgent: "main" },
+    });
+    await adapter.run({
+      ...baseOpts,
+      gateway: { name: "p1", url: "ws://b", token: "t1", openclawAgent: "main" },
+    });
+    await adapter.run({
+      ...baseOpts,
+      gateway: { name: "p1", url: "ws://b", token: "t2", openclawAgent: "main" },
+    });
+    expect(spawnFn).toHaveBeenCalledTimes(3);
+  });
+
   it("reuses the pooled child for the same (accountId, gateway)", async () => {
     const child = new FakeChild();
     const spawnFn = vi.fn().mockReturnValue(child);

--- a/packages/daemon/src/__tests__/openclaw-acp.test.ts
+++ b/packages/daemon/src/__tests__/openclaw-acp.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import {
+  OpenclawAcpAdapter,
+  __resetOpenclawAcpPoolForTests,
+  buildAcpSessionKey,
+} from "../gateway/runtimes/openclaw-acp.js";
+import type { ResolvedOpenclawGateway } from "../gateway/types.js";
+
+class FakeChild extends EventEmitter {
+  stdin = new PassThrough();
+  stdout = new PassThrough();
+  stderr = new PassThrough();
+  killed = false;
+  kill(): void {
+    this.killed = true;
+  }
+}
+
+function makeSpawn(child: FakeChild): any {
+  return () => child as unknown as ReturnType<typeof import("node:child_process").spawn>;
+}
+
+function readFrames(child: FakeChild): Promise<any[]> {
+  return new Promise((resolve) => {
+    const frames: any[] = [];
+    child.stdin.on("data", (chunk: Buffer) => {
+      const lines = chunk.toString("utf8").split("\n").filter(Boolean);
+      for (const line of lines) frames.push(JSON.parse(line));
+    });
+    setTimeout(() => resolve(frames), 50);
+  });
+}
+
+afterEach(() => {
+  __resetOpenclawAcpPoolForTests();
+});
+
+describe("buildAcpSessionKey", () => {
+  it("includes accountId so two daemon agents can't collide on a gateway key", () => {
+    const a = buildAcpSessionKey({
+      openclawAgent: "main",
+      accountId: "ag_alice",
+      conversationKey: "rm_x",
+    });
+    const b = buildAcpSessionKey({
+      openclawAgent: "main",
+      accountId: "ag_bob",
+      conversationKey: "rm_x",
+    });
+    expect(a).not.toBe(b);
+    expect(a).toContain("ag_alice");
+    expect(b).toContain("ag_bob");
+  });
+});
+
+describe("OpenclawAcpAdapter.run", () => {
+  it("fails fast when gateway is not provided", async () => {
+    const adapter = new OpenclawAcpAdapter({ spawnFn: makeSpawn(new FakeChild()) });
+    const res = await adapter.run({
+      text: "hi",
+      sessionId: null,
+      cwd: "/tmp",
+      accountId: "ag_alice",
+      signal: new AbortController().signal,
+      trustLevel: "owner",
+    });
+    expect(res.error).toMatch(/missing gateway/);
+  });
+
+  it("fails when gateway has no openclawAgent resolved", async () => {
+    const adapter = new OpenclawAcpAdapter({ spawnFn: makeSpawn(new FakeChild()) });
+    const gateway: ResolvedOpenclawGateway = {
+      name: "local",
+      url: "ws://127.0.0.1:1",
+    };
+    const res = await adapter.run({
+      text: "hi",
+      sessionId: null,
+      cwd: "/tmp",
+      accountId: "ag_alice",
+      signal: new AbortController().signal,
+      trustLevel: "owner",
+      gateway,
+    });
+    expect(res.error).toMatch(/openclawAgent/);
+  });
+
+  it("performs initialize → newSession → prompt and returns final text", async () => {
+    const child = new FakeChild();
+    const spawnFn = vi.fn().mockReturnValue(child);
+    const adapter = new OpenclawAcpAdapter({ spawnFn: spawnFn as any });
+    const gateway: ResolvedOpenclawGateway = {
+      name: "local",
+      url: "ws://127.0.0.1:1",
+      openclawAgent: "main",
+    };
+
+    // Seed the child stdout with replies as soon as stdin is written.
+    let nextSessionId = "acp-uuid-1";
+    let promptId: number | null = null;
+    child.stdin.on("data", (chunk: Buffer) => {
+      for (const line of chunk.toString("utf8").split("\n").filter(Boolean)) {
+        const frame = JSON.parse(line);
+        if (frame.method === "initialize") {
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { protocolVersion: 1 } }) + "\n");
+        } else if (frame.method === "session/new") {
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { sessionId: nextSessionId } }) + "\n");
+        } else if (frame.method === "session/prompt") {
+          promptId = frame.id;
+          // Stream a chunk then resolve.
+          child.stdout.write(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              method: "session/update",
+              params: {
+                sessionId: nextSessionId,
+                update: { sessionUpdate: "agent_message_chunk", content: { text: "hello world" } },
+              },
+            }) + "\n",
+          );
+          setTimeout(() => {
+            child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: promptId, result: { text: "hello world" } }) + "\n");
+          }, 5);
+        }
+      }
+    });
+
+    const blocks: any[] = [];
+    const res = await adapter.run({
+      text: "hi",
+      sessionId: null,
+      cwd: "/tmp",
+      accountId: "ag_alice",
+      signal: new AbortController().signal,
+      trustLevel: "owner",
+      gateway,
+      onBlock: (b) => blocks.push(b),
+    });
+
+    expect(res.error).toBeUndefined();
+    expect(res.text).toBe("hello world");
+    expect(res.newSessionId).toBe("acp-uuid-1");
+    expect(blocks.length).toBeGreaterThan(0);
+    expect(blocks[0].kind).toBe("assistant_text");
+    expect(spawnFn).toHaveBeenCalledTimes(1);
+    expect(spawnFn.mock.calls[0][1]).toEqual(["acp", "--url", "ws://127.0.0.1:1"]);
+  });
+
+  it("reuses the pooled child for the same (accountId, gateway)", async () => {
+    const child = new FakeChild();
+    const spawnFn = vi.fn().mockReturnValue(child);
+    const adapter = new OpenclawAcpAdapter({ spawnFn: spawnFn as any });
+    const gateway: ResolvedOpenclawGateway = {
+      name: "local",
+      url: "ws://127.0.0.1:1",
+      openclawAgent: "main",
+    };
+
+    child.stdin.on("data", (chunk: Buffer) => {
+      for (const line of chunk.toString("utf8").split("\n").filter(Boolean)) {
+        const frame = JSON.parse(line);
+        if (frame.method === "initialize") {
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { protocolVersion: 1 } }) + "\n");
+        } else if (frame.method === "session/new") {
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { sessionId: "s1" } }) + "\n");
+        } else if (frame.method === "session/prompt") {
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { text: "ok" } }) + "\n");
+        }
+      }
+    });
+
+    const opts = {
+      text: "hi",
+      sessionId: null,
+      cwd: "/tmp",
+      accountId: "ag_alice",
+      signal: new AbortController().signal,
+      trustLevel: "owner" as const,
+      gateway,
+    };
+    await adapter.run(opts);
+    await adapter.run({ ...opts, sessionId: "s1" });
+    expect(spawnFn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/daemon/src/agent-discovery.ts
+++ b/packages/daemon/src/agent-discovery.ts
@@ -38,6 +38,10 @@ export interface DiscoveredAgentCredential {
   runtime?: string;
   /** Working directory cached alongside `runtime`. */
   cwd?: string;
+  /** OpenClaw gateway profile name from credentials (only meaningful for openclaw-acp). */
+  openclawGateway?: string;
+  /** OpenClaw agent profile override from credentials. */
+  openclawAgent?: string;
   /** Key id from the credentials file — surfaced so boot-time workspace
    * seeding (see daemon-agent-workspace-plan.md §9) can render identity.md
    * without re-reading the file. */
@@ -164,6 +168,8 @@ export function discoverAgentCredentials(
     if (creds.displayName) entry.displayName = creds.displayName;
     if (creds.runtime) entry.runtime = creds.runtime;
     if (creds.cwd) entry.cwd = creds.cwd;
+    if (creds.openclawGateway) entry.openclawGateway = creds.openclawGateway;
+    if (creds.openclawAgent) entry.openclawAgent = creds.openclawAgent;
     if (creds.keyId) entry.keyId = creds.keyId;
     if (creds.savedAt) entry.savedAt = creds.savedAt;
     agents.push(entry);
@@ -236,6 +242,8 @@ export function resolveBootAgents(
         if (creds.displayName) entry.displayName = creds.displayName;
         if (creds.runtime) entry.runtime = creds.runtime;
         if (creds.cwd) entry.cwd = creds.cwd;
+        if (creds.openclawGateway) entry.openclawGateway = creds.openclawGateway;
+        if (creds.openclawAgent) entry.openclawAgent = creds.openclawAgent;
         if (creds.keyId) entry.keyId = creds.keyId;
         if (creds.savedAt) entry.savedAt = creds.savedAt;
       } catch (err) {

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -13,7 +13,24 @@ export const SNAPSHOT_PATH = path.join(DAEMON_DIR, "snapshot.json");
  * Adapter ids. Built-in adapters are enumerated for editor hints; any string
  * accepted by the registry is valid at runtime.
  */
-export type AdapterName = "claude-code" | "codex" | "gemini" | (string & {});
+export type AdapterName = "claude-code" | "codex" | "gemini" | "openclaw-acp" | (string & {});
+
+/**
+ * One OpenClaw gateway profile. Referenced by `RouteRule.gateway` and
+ * `DaemonRouteDefault.gateway` (and `StoredBotCordCredentials.openclawGateway`)
+ * via `name`. `tokenFile` is `~`-expanded and read at `toGatewayConfig` time;
+ * read failures do not block boot — the gateway becomes unusable but other
+ * gateways still work.
+ */
+export interface OpenclawGatewayProfile {
+  name: string;
+  url: string;
+  /** Bearer token; mutually-exclusive priority is `token > tokenFile`. */
+  token?: string;
+  tokenFile?: string;
+  /** Default OpenClaw agent profile name when a route does not pin one. */
+  defaultAgent?: string;
+}
 
 /**
  * Predicates selecting messages for a route. `roomId` / `roomPrefix` are
@@ -41,12 +58,23 @@ export interface RouteRule {
   cwd: string;
   /** Extra CLI flags appended to the adapter invocation. */
   extraArgs?: string[];
+  /**
+   * Required when `adapter === "openclaw-acp"`: name of an entry in
+   * `DaemonConfig.openclawGateways[]`.
+   */
+  gateway?: string;
+  /** Overrides `OpenclawGatewayProfile.defaultAgent` when set. */
+  openclawAgent?: string;
 }
 
 export interface DaemonRouteDefault {
   adapter: AdapterName;
   cwd: string;
   extraArgs?: string[];
+  /** Same semantics as `RouteRule.gateway`. */
+  gateway?: string;
+  /** Same semantics as `RouteRule.openclawAgent`. */
+  openclawAgent?: string;
 }
 
 /**
@@ -90,6 +118,14 @@ export interface DaemonConfig {
   routes: RouteRule[];
   /** If true, stream blocks (only meaningful for rm_oc_* rooms). */
   streamBlocks: boolean;
+
+  /**
+   * Optional registry of OpenClaw gateway endpoints. Routes / managed routes
+   * with `adapter === "openclaw-acp"` reference these by `name`. Resolution
+   * to {@link ResolvedOpenclawGateway} happens eagerly in `toGatewayConfig`
+   * so the dispatcher never re-queries this list.
+   */
+  openclawGateways?: OpenclawGatewayProfile[];
 }
 
 /**
@@ -200,6 +236,65 @@ export function loadConfig(): DaemonConfig {
   }
   validateAdapter(parsed.defaultRoute.adapter, "defaultRoute.adapter");
 
+  const gatewaysRaw = (parsed as Partial<DaemonConfig>).openclawGateways;
+  const gatewayNames = new Set<string>();
+  if (gatewaysRaw !== undefined) {
+    if (!Array.isArray(gatewaysRaw)) {
+      throw new Error(
+        `daemon config "openclawGateways" must be an array (${CONFIG_PATH})`,
+      );
+    }
+    for (const [i, g] of gatewaysRaw.entries()) {
+      if (!g || typeof g !== "object") {
+        throw new Error(
+          `daemon config openclawGateways[${i}] is not an object (${CONFIG_PATH})`,
+        );
+      }
+      const gg = g as Partial<OpenclawGatewayProfile>;
+      if (typeof gg.name !== "string" || gg.name.length === 0) {
+        throw new Error(
+          `daemon config openclawGateways[${i}].name must be a non-empty string (${CONFIG_PATH})`,
+        );
+      }
+      if (typeof gg.url !== "string" || gg.url.length === 0) {
+        throw new Error(
+          `daemon config openclawGateways[${i}].url must be a non-empty string (${CONFIG_PATH})`,
+        );
+      }
+      if (gatewayNames.has(gg.name)) {
+        throw new Error(
+          `daemon config openclawGateways[${i}].name "${gg.name}" duplicated (${CONFIG_PATH})`,
+        );
+      }
+      gatewayNames.add(gg.name);
+    }
+  }
+
+  const validateGatewayRef = (
+    adapter: string,
+    gateway: unknown,
+    where: string,
+  ): void => {
+    if (adapter === "openclaw-acp") {
+      if (typeof gateway !== "string" || gateway.length === 0) {
+        throw new Error(
+          `daemon config ${where} adapter "openclaw-acp" requires a "gateway" name (${CONFIG_PATH})`,
+        );
+      }
+      if (!gatewayNames.has(gateway)) {
+        throw new Error(
+          `daemon config ${where}.gateway "${gateway}" not in openclawGateways (${CONFIG_PATH})`,
+        );
+      }
+    }
+  };
+
+  validateGatewayRef(
+    parsed.defaultRoute.adapter,
+    (parsed.defaultRoute as DaemonRouteDefault).gateway,
+    "defaultRoute",
+  );
+
   const routesRaw = parsed.routes ?? [];
   if (!Array.isArray(routesRaw)) {
     throw new Error(`daemon config "routes" must be an array (${CONFIG_PATH})`);
@@ -214,6 +309,7 @@ export function loadConfig(): DaemonConfig {
       );
     }
     validateAdapter(r.adapter, `routes[${i}].adapter`);
+    validateGatewayRef(r.adapter, (r as RouteRule).gateway, `routes[${i}]`);
   }
   // Preserve the on-disk shape as-is so `config` prints what the user wrote.
   // Resolution of agents vs agentId happens at the consumption boundary
@@ -223,6 +319,15 @@ export function loadConfig(): DaemonConfig {
     routes: routesRaw,
     streamBlocks: parsed.streamBlocks ?? true,
   };
+  if (gatewaysRaw && Array.isArray(gatewaysRaw)) {
+    out.openclawGateways = (gatewaysRaw as OpenclawGatewayProfile[]).map((g) => {
+      const copy: OpenclawGatewayProfile = { name: g.name, url: g.url };
+      if (typeof g.token === "string") copy.token = g.token;
+      if (typeof g.tokenFile === "string") copy.tokenFile = g.tokenFile;
+      if (typeof g.defaultAgent === "string") copy.defaultAgent = g.defaultAgent;
+      return copy;
+    });
+  }
   if (hasAgents) out.agents = (parsed.agents as string[]).slice();
   if (hasLegacy) out.agentId = parsed.agentId;
   if (discovery && typeof discovery === "object") {

--- a/packages/daemon/src/daemon-config-map.ts
+++ b/packages/daemon/src/daemon-config-map.ts
@@ -1,14 +1,98 @@
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
 import type {
   GatewayChannelConfig,
   GatewayConfig,
   GatewayRoute,
+  ResolvedOpenclawGateway,
   RouteMatch,
   TrustLevel as GatewayTrustLevel,
 } from "./gateway/index.js";
-import type { DaemonConfig, RouteRule } from "./config.js";
+import type {
+  DaemonConfig,
+  DaemonRouteDefault,
+  OpenclawGatewayProfile,
+  RouteRule,
+} from "./config.js";
 import { resolveAgentIds } from "./config.js";
 import { agentWorkspaceDir } from "./agent-workspace.js";
 import { log as daemonLog } from "./log.js";
+
+/** Per-agent metadata cached from credentials, used by `buildManagedRoutes`. */
+export interface AgentRuntimeMeta {
+  runtime?: string;
+  cwd?: string;
+  /** OpenClaw gateway profile name to lookup in the registry. */
+  openclawGateway?: string;
+  /** Optional override of the OpenClaw agent profile within the gateway. */
+  openclawAgent?: string;
+}
+
+/** Internal: profile + tokenFile-resolved bearer token. */
+interface PreparedGatewayProfile extends OpenclawGatewayProfile {
+  /** Token actually usable at dispatch time; empty when load failed. */
+  resolvedToken?: string;
+  /** Reason `resolvedToken` is empty, for logs. */
+  tokenError?: string;
+}
+
+function expandHome(p: string): string {
+  if (p === "~") return homedir();
+  if (p.startsWith("~/")) return path.join(homedir(), p.slice(2));
+  return p;
+}
+
+function prepareGatewayProfiles(
+  profiles: OpenclawGatewayProfile[] | undefined,
+): Map<string, PreparedGatewayProfile> {
+  const out = new Map<string, PreparedGatewayProfile>();
+  if (!profiles) return out;
+  for (const p of profiles) {
+    const prepared: PreparedGatewayProfile = { ...p };
+    if (p.token && p.token.length > 0) {
+      prepared.resolvedToken = p.token;
+    } else if (p.tokenFile && p.tokenFile.length > 0) {
+      try {
+        prepared.resolvedToken = readFileSync(expandHome(p.tokenFile), "utf8").trim();
+      } catch (err: any) {
+        prepared.tokenError = err?.message ?? String(err);
+        daemonLog.warn("daemon.config.openclaw.tokenfile_failed", {
+          gateway: p.name,
+          tokenFile: p.tokenFile,
+          error: prepared.tokenError,
+        });
+      }
+    }
+    out.set(p.name, prepared);
+  }
+  return out;
+}
+
+function resolveGateway(
+  profiles: Map<string, PreparedGatewayProfile>,
+  gatewayName: string | undefined,
+  agentOverride: string | undefined,
+  where: string,
+): ResolvedOpenclawGateway | undefined {
+  if (!gatewayName) {
+    daemonLog.warn("daemon.config.openclaw.missing_gateway", { where });
+    return undefined;
+  }
+  const profile = profiles.get(gatewayName);
+  if (!profile) {
+    daemonLog.warn("daemon.config.openclaw.unknown_gateway", { where, gateway: gatewayName });
+    return undefined;
+  }
+  const resolved: ResolvedOpenclawGateway = {
+    name: profile.name,
+    url: profile.url,
+  };
+  if (profile.resolvedToken) resolved.token = profile.resolvedToken;
+  const agent = agentOverride ?? profile.defaultAgent;
+  if (agent) resolved.openclawAgent = agent;
+  return resolved;
+}
 
 /** Options accepted by {@link toGatewayConfig}. */
 export interface ToGatewayConfigOptions {
@@ -24,7 +108,7 @@ export interface ToGatewayConfigOptions {
    * turns to its runtime. Explicit `cfg.routes` entries still win because
    * synthesized routes are appended after them.
    */
-  agentRuntimes?: Record<string, { runtime?: string; cwd?: string }>;
+  agentRuntimes?: Record<string, AgentRuntimeMeta>;
 }
 
 /**
@@ -59,7 +143,11 @@ function mapTrustLevel(
  * legacy alias and its canonical field are present, the canonical field
  * wins and a warning is logged.
  */
-function mapRoute(r: RouteRule): GatewayRoute {
+function mapRoute(
+  r: RouteRule,
+  profiles: Map<string, PreparedGatewayProfile>,
+  index: number,
+): GatewayRoute {
   const match: RouteMatch = {};
   if (r.match.channel) match.channel = r.match.channel;
   if (r.match.accountId) match.accountId = r.match.accountId;
@@ -95,13 +183,22 @@ function mapRoute(r: RouteRule): GatewayRoute {
   if (typeof r.match.mentioned === "boolean") match.mentioned = r.match.mentioned;
 
   const rawTrust = (r as { trustLevel?: "owner" | "untrusted" }).trustLevel;
-  return {
+  const out: GatewayRoute = {
     match,
     runtime: r.adapter,
     cwd: r.cwd,
     extraArgs: r.extraArgs,
     trustLevel: mapTrustLevel(rawTrust),
   };
+  if (r.adapter === "openclaw-acp") {
+    out.gateway = resolveGateway(
+      profiles,
+      r.gateway,
+      r.openclawAgent,
+      `routes[${index}]`,
+    );
+  }
+  return out;
 }
 
 /**
@@ -134,6 +231,8 @@ export function toGatewayConfig(
 
   // DaemonConfig's typed surface doesn't carry `trustLevel`, but we read it
   // defensively so future config extensions can propagate without a shape bump.
+  const profiles = prepareGatewayProfiles(cfg.openclawGateways);
+
   const rawDefaultTrust = (cfg.defaultRoute as { trustLevel?: "owner" | "untrusted" })
     .trustLevel;
   const defaultRoute: GatewayRoute = {
@@ -144,8 +243,17 @@ export function toGatewayConfig(
     // (direct → cancel-previous, group → serial).
     trustLevel: mapTrustLevel(rawDefaultTrust),
   };
+  if (cfg.defaultRoute.adapter === "openclaw-acp") {
+    const dr = cfg.defaultRoute as DaemonRouteDefault;
+    defaultRoute.gateway = resolveGateway(
+      profiles,
+      dr.gateway,
+      dr.openclawAgent,
+      "defaultRoute",
+    );
+  }
 
-  const routes: GatewayRoute[] = (cfg.routes ?? []).map(mapRoute);
+  const routes: GatewayRoute[] = (cfg.routes ?? []).map((r, i) => mapRoute(r, profiles, i));
 
   // Synthesize a per-agent route for every bound agent and hand it to the
   // gateway via the managed-routes bucket (plan §10.1). User-authored
@@ -157,6 +265,7 @@ export function toGatewayConfig(
     agentIds,
     opts.agentRuntimes ?? {},
     defaultRoute,
+    profiles,
   );
 
   return {
@@ -184,17 +293,39 @@ export function toGatewayConfig(
  */
 export function buildManagedRoutes(
   agentIds: string[],
-  agentRuntimes: Record<string, { runtime?: string; cwd?: string }>,
+  agentRuntimes: Record<string, AgentRuntimeMeta>,
   defaultRoute: GatewayRoute,
+  openclawProfiles?: Map<string, PreparedGatewayProfile>,
 ): Map<string, GatewayRoute> {
   const out = new Map<string, GatewayRoute>();
+  // Lazy-build profile map when caller didn't pass one (legacy callers).
+  const profiles = openclawProfiles ?? new Map<string, PreparedGatewayProfile>();
   for (const agentId of agentIds) {
     const meta = agentRuntimes[agentId] ?? {};
-    out.set(agentId, {
+    const runtime = meta.runtime ?? defaultRoute.runtime;
+    const route: GatewayRoute = {
       match: { accountId: agentId },
-      runtime: meta.runtime ?? defaultRoute.runtime,
+      runtime,
       cwd: meta.cwd || agentWorkspaceDir(agentId),
-    });
+    };
+    if (runtime === "openclaw-acp") {
+      // Per RFC §3.4: prefer credentials, fall back to defaultRoute.gateway.
+      const gatewayName = meta.openclawGateway ?? defaultRoute.gateway?.name;
+      const agentOverride = meta.openclawAgent;
+      const resolved = gatewayName
+        ? resolveGateway(profiles, gatewayName, agentOverride, `managedRoute[${agentId}]`)
+        : defaultRoute.gateway;
+      if (!resolved) {
+        // No usable gateway — skip the managed route so defaultRoute can take over.
+        daemonLog.warn("daemon.config.openclaw.managed_route_skipped", {
+          agentId,
+          gatewayName,
+        });
+        continue;
+      }
+      route.gateway = resolved;
+    }
+    out.set(agentId, route);
   }
   return out;
 }

--- a/packages/daemon/src/daemon-config-map.ts
+++ b/packages/daemon/src/daemon-config-map.ts
@@ -29,8 +29,10 @@ export interface AgentRuntimeMeta {
   openclawAgent?: string;
 }
 
-/** Internal: profile + tokenFile-resolved bearer token. */
-interface PreparedGatewayProfile extends OpenclawGatewayProfile {
+/** Profile + tokenFile-resolved bearer token. Exported so other module-boundary
+ *  paths (runtime probing, post-provision hot-add) reuse the same resolver
+ *  instead of duplicating tokenFile semantics. */
+export interface PreparedGatewayProfile extends OpenclawGatewayProfile {
   /** Token actually usable at dispatch time; empty when load failed. */
   resolvedToken?: string;
   /** Reason `resolvedToken` is empty, for logs. */
@@ -43,29 +45,37 @@ function expandHome(p: string): string {
   return p;
 }
 
-function prepareGatewayProfiles(
+/** Resolve one profile's token (inline > tokenFile). Failures are swallowed
+ *  into `tokenError`; `resolvedToken` is left undefined. Logs at warn for ops
+ *  visibility. */
+export function prepareGatewayProfile(
+  p: OpenclawGatewayProfile,
+): PreparedGatewayProfile {
+  const prepared: PreparedGatewayProfile = { ...p };
+  if (p.token && p.token.length > 0) {
+    prepared.resolvedToken = p.token;
+  } else if (p.tokenFile && p.tokenFile.length > 0) {
+    try {
+      prepared.resolvedToken = readFileSync(expandHome(p.tokenFile), "utf8").trim();
+    } catch (err: any) {
+      prepared.tokenError = err?.message ?? String(err);
+      daemonLog.warn("daemon.config.openclaw.tokenfile_failed", {
+        gateway: p.name,
+        tokenFile: p.tokenFile,
+        error: prepared.tokenError,
+      });
+    }
+  }
+  return prepared;
+}
+
+/** Build a name → prepared-profile map for a config's gateway registry. */
+export function prepareGatewayProfiles(
   profiles: OpenclawGatewayProfile[] | undefined,
 ): Map<string, PreparedGatewayProfile> {
   const out = new Map<string, PreparedGatewayProfile>();
   if (!profiles) return out;
-  for (const p of profiles) {
-    const prepared: PreparedGatewayProfile = { ...p };
-    if (p.token && p.token.length > 0) {
-      prepared.resolvedToken = p.token;
-    } else if (p.tokenFile && p.tokenFile.length > 0) {
-      try {
-        prepared.resolvedToken = readFileSync(expandHome(p.tokenFile), "utf8").trim();
-      } catch (err: any) {
-        prepared.tokenError = err?.message ?? String(err);
-        daemonLog.warn("daemon.config.openclaw.tokenfile_failed", {
-          gateway: p.name,
-          tokenFile: p.tokenFile,
-          error: prepared.tokenError,
-        });
-      }
-    }
-    out.set(p.name, prepared);
-  }
+  for (const p of profiles) out.set(p.name, prepareGatewayProfile(p));
   return out;
 }
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -497,7 +497,7 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
  */
 export interface BootBackfillResult {
   credentialPathByAgentId: Map<string, string>;
-  agentRuntimes: Record<string, { runtime?: string; cwd?: string }>;
+  agentRuntimes: Record<string, { runtime?: string; cwd?: string; openclawGateway?: string; openclawAgent?: string }>;
 }
 
 /**
@@ -520,10 +520,12 @@ export function backfillBootAgents(
   const failed: string[] = [];
   for (const a of agents) {
     if (a.credentialsFile) credentialPathByAgentId.set(a.agentId, a.credentialsFile);
-    if (a.runtime || a.cwd) {
+    if (a.runtime || a.cwd || a.openclawGateway || a.openclawAgent) {
       agentRuntimes[a.agentId] = {
         ...(a.runtime ? { runtime: a.runtime } : {}),
         ...(a.cwd ? { cwd: a.cwd } : {}),
+        ...(a.openclawGateway ? { openclawGateway: a.openclawGateway } : {}),
+        ...(a.openclawAgent ? { openclawAgent: a.openclawAgent } : {}),
       };
     }
     // Seed files are written only when missing (see `ensureAgentWorkspace`),

--- a/packages/daemon/src/doctor.ts
+++ b/packages/daemon/src/doctor.ts
@@ -31,9 +31,29 @@ export interface DoctorHttpResult {
   error?: string;
 }
 
+/** One endpoint probe entry, mirrored from `RuntimeEndpointProbe`. */
+export interface DoctorRuntimeEndpoint {
+  name: string;
+  url: string;
+  reachable: boolean;
+  version?: string;
+  error?: string;
+  agents?: Array<{ name: string; model?: string }>;
+  /**
+   * Optional warning surfaced by the doctor: e.g. botcord plugin loaded on
+   * the gateway (would form a daemon → openclaw → botcord → Hub loop).
+   */
+  warnings?: string[];
+}
+
+/** Augmented runtime entry that may carry endpoint probe results. */
+export interface DoctorRuntimeEntry extends RuntimeProbeEntry {
+  endpoints?: DoctorRuntimeEndpoint[];
+}
+
 /** Input for the rendered doctor output. */
 export interface DoctorInput {
-  runtimes: RuntimeProbeEntry[];
+  runtimes: DoctorRuntimeEntry[];
   channels: ChannelProbeResult[];
 }
 
@@ -226,10 +246,27 @@ export function renderDoctor(input: DoctorInput): string {
   lines.push(
     `${pad("RUNTIME", widths.runtime)}  ${pad("NAME", widths.name)}  ${pad("STATUS", widths.status)}  ${pad("VERSION", widths.version)}  PATH`,
   );
-  for (const r of rows) {
+  for (let i = 0; i < rows.length; i += 1) {
+    const r = rows[i];
+    const e = input.runtimes[i];
     lines.push(
       `${pad(r.runtime, widths.runtime)}  ${pad(r.name, widths.name)}  ${pad(r.status, widths.status)}  ${pad(r.version, widths.version)}  ${r.path}`,
     );
+    if (e.endpoints && e.endpoints.length > 0) {
+      for (const ep of e.endpoints) {
+        const mark = ep.reachable ? "✓" : "✗";
+        const detail = ep.reachable
+          ? ep.version ?? "ok"
+          : ep.error ?? "unreachable";
+        lines.push(`    gateway ${pad(`"${ep.name}"`, 16)} ${pad(ep.url, 40)} ${mark} ${detail}`);
+        if (ep.agents && ep.agents.length > 0) {
+          lines.push(`      agents: ${ep.agents.map((a) => a.name).join(", ")}`);
+        }
+        if (ep.warnings) {
+          for (const w of ep.warnings) lines.push(`      WARN: ${w}`);
+        }
+      }
+    }
   }
   const available = input.runtimes.filter((e) => e.result.available).length;
   lines.push(`\n${available}/${input.runtimes.length} runtimes available`);

--- a/packages/daemon/src/doctor.ts
+++ b/packages/daemon/src/doctor.ts
@@ -38,7 +38,12 @@ export interface DoctorRuntimeEndpoint {
   reachable: boolean;
   version?: string;
   error?: string;
-  agents?: Array<{ name: string; model?: string }>;
+  agents?: Array<{
+    id: string;
+    name?: string;
+    workspace?: string;
+    model?: { name?: string; provider?: string };
+  }>;
   /**
    * Optional warning surfaced by the doctor: e.g. botcord plugin loaded on
    * the gateway (would form a daemon → openclaw → botcord → Hub loop).
@@ -260,7 +265,12 @@ export function renderDoctor(input: DoctorInput): string {
           : ep.error ?? "unreachable";
         lines.push(`    gateway ${pad(`"${ep.name}"`, 16)} ${pad(ep.url, 40)} ${mark} ${detail}`);
         if (ep.agents && ep.agents.length > 0) {
-          lines.push(`      agents: ${ep.agents.map((a) => a.name).join(", ")}`);
+          // RFC §3.8.4: list by `id` (stable key); show display name when distinct.
+          lines.push(
+            `      agents (id): ${ep.agents
+              .map((a) => (a.name && a.name !== a.id ? `${a.id} (${a.name})` : a.id))
+              .join(", ")}`,
+          );
         }
         if (ep.warnings) {
           for (const w of ep.warnings) lines.push(`      WARN: ${w}`);

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -632,6 +632,7 @@ export class Dispatcher {
           trustLevel,
           systemContext,
           onBlock,
+          gateway: route.gateway,
         });
       } catch (err) {
         threw = err;

--- a/packages/daemon/src/gateway/runtimes/openclaw-acp.ts
+++ b/packages/daemon/src/gateway/runtimes/openclaw-acp.ts
@@ -1,0 +1,580 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import {
+  readCommandVersion,
+  resolveCommandOnPath,
+  type ProbeDeps,
+} from "./probe.js";
+import { consoleLogger } from "../log.js";
+import type {
+  RuntimeAdapter,
+  RuntimeProbeResult,
+  RuntimeRunOptions,
+  RuntimeRunResult,
+  StreamBlock,
+} from "../types.js";
+
+const log = consoleLogger;
+
+const ACP_PROTOCOL_VERSION = 1;
+/** How long an idle (no in-flight prompt) ACP child process is kept alive. */
+const ACP_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+/** Cap for streamed assistant text per turn. */
+const ASSISTANT_TEXT_CAP = 1 * 1024 * 1024;
+
+// ---------------------------------------------------------------------------
+// Module-level process pool — survives across adapter instances. The
+// dispatcher creates a new `OpenclawAcpAdapter` per turn (see
+// `runtimeFactory`), so adapter-instance state cannot hold a long-lived child.
+// Pool key includes accountId so different daemon agents never share an ACP
+// child even when they target the same gateway profile.
+// ---------------------------------------------------------------------------
+
+interface AcpProcessHandle {
+  child: ChildProcessWithoutNullStreams;
+  /** Pending JSON-RPC requests keyed by id. */
+  pending: Map<number, PendingCall>;
+  /** Per-ACP-sessionId notification subscribers. */
+  subscribers: Map<string, (note: AcpNotification) => void>;
+  nextId: number;
+  buffer: string;
+  initialized: boolean;
+  initializePromise?: Promise<void>;
+  idleTimer?: NodeJS.Timeout;
+  inFlight: number;
+  closed: boolean;
+  exitReason?: string;
+}
+
+interface PendingCall {
+  resolve: (value: unknown) => void;
+  reject: (err: Error) => void;
+  method: string;
+}
+
+interface AcpNotification {
+  method: string;
+  params: any;
+}
+
+const ACP_POOL = new Map<string, AcpProcessHandle>();
+
+function poolKey(accountId: string, gatewayName: string): string {
+  return `${accountId}::${gatewayName}`;
+}
+
+function resetIdle(h: AcpProcessHandle, key: string): void {
+  if (h.idleTimer) clearTimeout(h.idleTimer);
+  if (h.inFlight > 0) return;
+  h.idleTimer = setTimeout(() => {
+    if (h.inFlight === 0 && !h.closed) {
+      log.info("openclaw-acp.idle-timeout", { key });
+      shutdownHandle(h, "idle-timeout");
+      ACP_POOL.delete(key);
+    }
+  }, ACP_IDLE_TIMEOUT_MS);
+  h.idleTimer.unref?.();
+}
+
+function shutdownHandle(h: AcpProcessHandle, reason: string): void {
+  if (h.closed) return;
+  h.closed = true;
+  h.exitReason = reason;
+  if (h.idleTimer) clearTimeout(h.idleTimer);
+  for (const p of h.pending.values()) {
+    p.reject(new Error(`openclaw acp child closed: ${reason}`));
+  }
+  h.pending.clear();
+  h.subscribers.clear();
+  try {
+    h.child.kill("SIGTERM");
+  } catch {
+    // already dead
+  }
+}
+
+/** Test-only: drop all cached child processes. */
+export function __resetOpenclawAcpPoolForTests(): void {
+  for (const [key, h] of ACP_POOL.entries()) {
+    shutdownHandle(h, "test-reset");
+    ACP_POOL.delete(key);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Probe
+// ---------------------------------------------------------------------------
+
+function resolveOpenclawCommand(deps: ProbeDeps = {}): string | null {
+  const explicit = (deps.env ?? process.env).BOTCORD_OPENCLAW_BIN;
+  if (explicit && explicit.length > 0) return explicit;
+  return resolveCommandOnPath("openclaw", deps);
+}
+
+export function probeOpenclaw(deps: ProbeDeps = {}): RuntimeProbeResult {
+  const command = resolveOpenclawCommand(deps);
+  if (!command) return { available: false };
+  return {
+    available: true,
+    path: command,
+    version: readCommandVersion(command, [], deps) ?? undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
+interface SpawnDeps {
+  spawnFn?: typeof spawn;
+}
+
+/**
+ * OpenClaw ACP runtime adapter.
+ *
+ * Spawns `openclaw acp --url <gateway> [--token <token>]` per
+ * `(accountId, gatewayName)` pair and reuses the process across turns. The
+ * child speaks JSON-RPC over stdio; we send `initialize` once, then
+ * `newSession` (with `_meta.sessionKey`) when the daemon has no persisted
+ * runtime session id, and `prompt` for each turn. Streaming `session/update`
+ * notifications are relayed to `onBlock`.
+ *
+ * Process-pool lifetime + abort/cancel semantics live at module scope; see
+ * `ACP_POOL` and `shutdownHandle` above.
+ */
+export class OpenclawAcpAdapter implements RuntimeAdapter {
+  readonly id = "openclaw-acp" as const;
+
+  private readonly spawnFn: typeof spawn;
+
+  constructor(deps: SpawnDeps = {}) {
+    this.spawnFn = deps.spawnFn ?? spawn;
+  }
+
+  probe(): RuntimeProbeResult {
+    return probeOpenclaw();
+  }
+
+  async run(opts: RuntimeRunOptions): Promise<RuntimeRunResult> {
+    const gateway = opts.gateway;
+    if (!gateway) {
+      return failResult(
+        opts.sessionId ?? "",
+        "openclaw-acp: missing gateway endpoint (route.gateway not resolved)",
+      );
+    }
+    if (!gateway.openclawAgent) {
+      return failResult(
+        opts.sessionId ?? "",
+        `openclaw-acp: gateway "${gateway.name}" did not resolve an openclawAgent (set defaultAgent on the profile or openclawAgent on the route)`,
+      );
+    }
+    const sessionKey = buildAcpSessionKey({
+      openclawAgent: gateway.openclawAgent,
+      accountId: opts.accountId,
+      // The dispatcher passes `context.conversationKey` in for routing;
+      // fall back to a stable per-accountId key when it's not present (e.g.
+      // synthetic test calls).
+      conversationKey: stringField(opts.context, "conversationKey") ?? "default",
+    });
+
+    const key = poolKey(opts.accountId, gateway.name);
+    let handle: AcpProcessHandle;
+    try {
+      handle = await this.acquireHandle(key, opts, gateway);
+    } catch (err) {
+      return failResult(opts.sessionId ?? "", `openclaw-acp: ${(err as Error).message}`);
+    }
+
+    handle.inFlight += 1;
+    if (handle.idleTimer) clearTimeout(handle.idleTimer);
+
+    let acpSessionId = opts.sessionId ?? "";
+    let seq = 0;
+    let assistantText = "";
+    let assistantBytes = 0;
+    let capped = false;
+    let finalText = "";
+
+    const emitBlock = (block: StreamBlock): void => {
+      try {
+        opts.onBlock?.(block);
+      } catch (err) {
+        log.warn("openclaw-acp.onBlock-threw", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    };
+
+    const onNotification = (note: AcpNotification): void => {
+      seq += 1;
+      // Forward raw notification as a stream block for downstream visibility.
+      const kind = classifyAcpUpdate(note);
+      emitBlock({ raw: note, kind, seq });
+
+      const update = note.params?.update;
+      if (update?.sessionUpdate === "agent_message_chunk") {
+        const text = extractText(update.content);
+        if (text && !capped) {
+          const bytes = Buffer.byteLength(text, "utf8");
+          if (assistantBytes + bytes > ASSISTANT_TEXT_CAP) {
+            capped = true;
+          } else {
+            assistantText += text;
+            assistantBytes += bytes;
+          }
+        }
+      }
+    };
+
+    let abortListener: (() => void) | undefined;
+    try {
+      // Ensure we have an ACP session id. When the dispatcher doesn't carry
+      // one, ask the child to create or rebind one for our sessionKey.
+      if (!acpSessionId) {
+        try {
+          acpSessionId = await this.newSession(handle, {
+            cwd: opts.cwd,
+            sessionKey,
+          });
+        } catch (err) {
+          throw new Error(`newSession failed: ${(err as Error).message}`);
+        }
+      }
+      handle.subscribers.set(acpSessionId, onNotification);
+
+      if (opts.signal?.aborted) {
+        return failResult(acpSessionId, "openclaw-acp: aborted before prompt");
+      }
+
+      abortListener = () => {
+        // Best-effort cancel; ACP `cancel` is a notification (fire-and-forget).
+        sendNotification(handle, "session/cancel", { sessionId: acpSessionId });
+      };
+      opts.signal?.addEventListener("abort", abortListener);
+
+      let promptResult: any;
+      try {
+        promptResult = await this.prompt(handle, {
+          sessionId: acpSessionId,
+          text: opts.text,
+        });
+      } catch (err) {
+        const msg = (err as Error).message ?? "prompt failed";
+        // If the child says the session is gone (process restart, GC),
+        // recreate it so the next turn doesn't hard-fail.
+        if (/session not found|unknown session/i.test(msg)) {
+          try {
+            const fresh = await this.newSession(handle, {
+              cwd: opts.cwd,
+              sessionKey,
+            });
+            handle.subscribers.delete(acpSessionId);
+            acpSessionId = fresh;
+            handle.subscribers.set(acpSessionId, onNotification);
+            promptResult = await this.prompt(handle, {
+              sessionId: acpSessionId,
+              text: opts.text,
+            });
+          } catch (err2) {
+            throw new Error(`prompt failed after session reset: ${(err2 as Error).message}`);
+          }
+        } else {
+          throw err;
+        }
+      }
+
+      // OpenClaw's prompt response shape isn't strictly fixed; pull a final
+      // text out of common locations and otherwise fall back to the streamed
+      // chunks accumulated above.
+      finalText = pickFinalText(promptResult) ?? assistantText;
+
+      if (capped) {
+        log.warn("openclaw-acp.assistant-text-capped", { sessionId: acpSessionId });
+      }
+
+      return {
+        text: finalText,
+        newSessionId: acpSessionId,
+      };
+    } catch (err) {
+      return failResult(acpSessionId, `openclaw-acp: ${(err as Error).message}`);
+    } finally {
+      if (abortListener && opts.signal) {
+        try {
+          opts.signal.removeEventListener("abort", abortListener);
+        } catch {
+          // ignore
+        }
+      }
+      handle.subscribers.delete(acpSessionId);
+      handle.inFlight = Math.max(0, handle.inFlight - 1);
+      resetIdle(handle, key);
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Process management
+  // ---------------------------------------------------------------------
+
+  private async acquireHandle(
+    key: string,
+    opts: RuntimeRunOptions,
+    gateway: NonNullable<RuntimeRunOptions["gateway"]>,
+  ): Promise<AcpProcessHandle> {
+    let handle = ACP_POOL.get(key);
+    if (handle && handle.closed) {
+      ACP_POOL.delete(key);
+      handle = undefined;
+    }
+    if (!handle) {
+      handle = this.spawnAcpProcess(key, gateway);
+      ACP_POOL.set(key, handle);
+    }
+    if (!handle.initialized) {
+      if (!handle.initializePromise) {
+        handle.initializePromise = sendRequest(handle, "initialize", {
+          protocolVersion: ACP_PROTOCOL_VERSION,
+          clientCapabilities: {},
+        }).then(() => {
+          handle!.initialized = true;
+        });
+      }
+      await handle.initializePromise;
+    }
+    return handle;
+  }
+
+  private spawnAcpProcess(
+    key: string,
+    gateway: NonNullable<RuntimeRunOptions["gateway"]>,
+  ): AcpProcessHandle {
+    const command = resolveOpenclawCommand() ?? "openclaw";
+    const args = ["acp", "--url", gateway.url];
+    if (gateway.token) args.push("--token", gateway.token);
+
+    const child = this.spawnFn(command, args, {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env },
+    }) as ChildProcessWithoutNullStreams;
+
+    const handle: AcpProcessHandle = {
+      child,
+      pending: new Map(),
+      subscribers: new Map(),
+      nextId: 1,
+      buffer: "",
+      initialized: false,
+      inFlight: 0,
+      closed: false,
+    };
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => onStdoutChunk(handle, chunk));
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      log.debug("openclaw-acp.stderr", { key, chunk: chunk.slice(0, 500) });
+    });
+    child.on("exit", (code, signal) => {
+      shutdownHandle(handle, `exit code=${code ?? "null"} signal=${signal ?? "null"}`);
+      ACP_POOL.delete(key);
+    });
+    child.on("error", (err) => {
+      log.warn("openclaw-acp.child-error", {
+        key,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      shutdownHandle(handle, `error: ${(err as Error).message}`);
+      ACP_POOL.delete(key);
+    });
+
+    return handle;
+  }
+
+  private async newSession(
+    handle: AcpProcessHandle,
+    args: { cwd: string; sessionKey: string },
+  ): Promise<string> {
+    const result = (await sendRequest(handle, "session/new", {
+      cwd: args.cwd,
+      mcpServers: [],
+      _meta: { sessionKey: args.sessionKey },
+    })) as { sessionId?: string };
+    if (!result?.sessionId || typeof result.sessionId !== "string") {
+      throw new Error("newSession returned no sessionId");
+    }
+    return result.sessionId;
+  }
+
+  private async prompt(
+    handle: AcpProcessHandle,
+    args: { sessionId: string; text: string },
+  ): Promise<any> {
+    return sendRequest(handle, "session/prompt", {
+      sessionId: args.sessionId,
+      prompt: [{ type: "text", text: args.text }],
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// JSON-RPC stdio plumbing
+// ---------------------------------------------------------------------------
+
+function onStdoutChunk(handle: AcpProcessHandle, chunk: string): void {
+  handle.buffer += chunk;
+  let idx: number;
+  while ((idx = handle.buffer.indexOf("\n")) !== -1) {
+    const line = handle.buffer.slice(0, idx).trim();
+    handle.buffer = handle.buffer.slice(idx + 1);
+    if (!line) continue;
+    let msg: any;
+    try {
+      msg = JSON.parse(line);
+    } catch (err) {
+      log.warn("openclaw-acp.parse-error", {
+        error: err instanceof Error ? err.message : String(err),
+        line: line.slice(0, 200),
+      });
+      continue;
+    }
+    routeMessage(handle, msg);
+  }
+}
+
+function routeMessage(handle: AcpProcessHandle, msg: any): void {
+  if (msg && typeof msg === "object" && "id" in msg && ("result" in msg || "error" in msg)) {
+    const id = typeof msg.id === "number" ? msg.id : Number(msg.id);
+    const pending = handle.pending.get(id);
+    if (!pending) return;
+    handle.pending.delete(id);
+    if (msg.error) {
+      const message = typeof msg.error?.message === "string" ? msg.error.message : "rpc error";
+      pending.reject(new Error(message));
+    } else {
+      pending.resolve(msg.result);
+    }
+    return;
+  }
+  // Notification.
+  if (msg?.method && msg?.params) {
+    const sid = msg.params?.sessionId;
+    if (typeof sid === "string") {
+      const sub = handle.subscribers.get(sid);
+      if (sub) {
+        try {
+          sub({ method: msg.method, params: msg.params });
+        } catch (err) {
+          log.warn("openclaw-acp.subscriber-threw", {
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+    }
+  }
+}
+
+function sendRequest(
+  handle: AcpProcessHandle,
+  method: string,
+  params: any,
+): Promise<unknown> {
+  if (handle.closed) return Promise.reject(new Error("acp child closed"));
+  return new Promise((resolve, reject) => {
+    const id = handle.nextId++;
+    handle.pending.set(id, { resolve, reject, method });
+    const frame = JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n";
+    try {
+      handle.child.stdin.write(frame);
+    } catch (err) {
+      handle.pending.delete(id);
+      reject(err as Error);
+    }
+  });
+}
+
+function sendNotification(
+  handle: AcpProcessHandle,
+  method: string,
+  params: any,
+): void {
+  if (handle.closed) return;
+  const frame = JSON.stringify({ jsonrpc: "2.0", method, params }) + "\n";
+  try {
+    handle.child.stdin.write(frame);
+  } catch {
+    // best-effort fire-and-forget
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function failResult(sessionId: string, error: string): RuntimeRunResult {
+  return {
+    text: "",
+    newSessionId: sessionId,
+    error,
+  };
+}
+
+function classifyAcpUpdate(note: AcpNotification): StreamBlock["kind"] {
+  const update = note.params?.update;
+  const kind: string | undefined = update?.sessionUpdate;
+  switch (kind) {
+    case "agent_message_chunk":
+      return "assistant_text";
+    case "tool_call":
+      return "tool_use";
+    case "tool_call_update":
+      return "tool_result";
+    case "session_info_update":
+    case "available_commands_update":
+    case "usage_update":
+      return "system";
+    default:
+      return "other";
+  }
+}
+
+function extractText(content: unknown): string {
+  if (!content) return "";
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content.map(extractText).join("");
+  }
+  if (typeof content === "object") {
+    const c = content as Record<string, unknown>;
+    if (typeof c.text === "string") return c.text;
+    if (typeof c.content === "string") return c.content;
+    if (Array.isArray(c.content)) return extractText(c.content);
+  }
+  return "";
+}
+
+function pickFinalText(result: unknown): string | undefined {
+  if (!result || typeof result !== "object") return undefined;
+  const r = result as Record<string, unknown>;
+  if (typeof r.text === "string" && r.text.length > 0) return r.text;
+  if (typeof r.message === "string" && r.message.length > 0) return r.message;
+  return undefined;
+}
+
+function stringField(bag: Record<string, unknown> | undefined, key: string): string | undefined {
+  if (!bag) return undefined;
+  const v = bag[key];
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+/**
+ * Build the OpenClaw ACP `sessionKey` for a daemon turn. `accountId` is
+ * always included to prevent two daemon agents from colliding on the same
+ * gateway-side key (RFC §3.5.2 串号 防御).
+ */
+export function buildAcpSessionKey(args: {
+  openclawAgent: string;
+  accountId: string;
+  conversationKey: string;
+}): string {
+  return `agent:${args.openclawAgent}:${args.accountId}:${args.conversationKey}`;
+}

--- a/packages/daemon/src/gateway/runtimes/openclaw-acp.ts
+++ b/packages/daemon/src/gateway/runtimes/openclaw-acp.ts
@@ -43,6 +43,13 @@ interface AcpProcessHandle {
   inFlight: number;
   closed: boolean;
   exitReason?: string;
+  /**
+   * URL + token the child was spawned with. We compare against the live
+   * `route.gateway` on every `acquireHandle` so a config-reload/token-rotation
+   * under the same gateway name doesn't keep using a stale child.
+   */
+  spawnedUrl: string;
+  spawnedToken: string | undefined;
 }
 
 interface PendingCall {
@@ -326,6 +333,23 @@ export class OpenclawAcpAdapter implements RuntimeAdapter {
       ACP_POOL.delete(key);
       handle = undefined;
     }
+    // Invalidate the cached child if its spawn args drifted from the live
+    // gateway endpoint — config reload / token rotation under the same
+    // profile name must not keep talking to the old --url / --token.
+    if (
+      handle &&
+      (handle.spawnedUrl !== gateway.url || handle.spawnedToken !== gateway.token)
+    ) {
+      log.info("openclaw-acp.gateway-args-changed", {
+        key,
+        oldUrl: handle.spawnedUrl,
+        newUrl: gateway.url,
+        tokenChanged: handle.spawnedToken !== gateway.token,
+      });
+      shutdownHandle(handle, "gateway-args-changed");
+      ACP_POOL.delete(key);
+      handle = undefined;
+    }
     if (!handle) {
       handle = this.spawnAcpProcess(key, gateway);
       ACP_POOL.set(key, handle);
@@ -366,6 +390,8 @@ export class OpenclawAcpAdapter implements RuntimeAdapter {
       initialized: false,
       inFlight: 0,
       closed: false,
+      spawnedUrl: gateway.url,
+      spawnedToken: gateway.token,
     };
 
     child.stdout.setEncoding("utf8");

--- a/packages/daemon/src/gateway/runtimes/registry.ts
+++ b/packages/daemon/src/gateway/runtimes/registry.ts
@@ -1,6 +1,7 @@
 import { ClaudeCodeAdapter, probeClaude } from "./claude-code.js";
 import { CodexAdapter, probeCodex } from "./codex.js";
 import { GeminiAdapter, probeGemini } from "./gemini.js";
+import { OpenclawAcpAdapter, probeOpenclaw } from "./openclaw-acp.js";
 import type { RuntimeAdapter, RuntimeProbeResult } from "../types.js";
 
 /**
@@ -58,6 +59,16 @@ export const geminiModule: RuntimeModule = {
   supportsRun: false,
 };
 
+/** Built-in runtime module entry for OpenClaw (ACP). */
+export const openclawAcpModule: RuntimeModule = {
+  id: "openclaw-acp",
+  displayName: "OpenClaw (ACP)",
+  binary: "openclaw",
+  envVar: "BOTCORD_OPENCLAW_BIN",
+  probe: () => probeOpenclaw(),
+  create: () => new OpenclawAcpAdapter(),
+};
+
 /**
  * Built-in runtime modules. To add a new runtime:
  *   1. Create `runtimes/<name>.ts` extending `NdjsonStreamAdapter` (or
@@ -68,6 +79,7 @@ export const RUNTIME_MODULES: readonly RuntimeModule[] = [
   claudeCodeModule,
   codexModule,
   geminiModule,
+  openclawAcpModule,
 ];
 
 const BY_ID = new Map<string, RuntimeModule>(

--- a/packages/daemon/src/gateway/types.ts
+++ b/packages/daemon/src/gateway/types.ts
@@ -21,6 +21,20 @@ export type QueueMode = "serial" | "cancel-previous";
 /** Source-based trust tier used by runtimes to pick default permission flags. */
 export type TrustLevel = "owner" | "trusted" | "public";
 
+/**
+ * Resolved OpenClaw gateway endpoint for a route. Built eagerly in
+ * `toGatewayConfig` from the `DaemonConfig.openclawGateways` registry plus the
+ * `RouteRule.gateway` / `openclawAgent` choice — the dispatcher never needs
+ * to re-query the registry. `name` is preserved purely for logging/snapshot.
+ */
+export interface ResolvedOpenclawGateway {
+  name: string;
+  url: string;
+  token?: string;
+  /** OpenClaw agent profile, with the route override already applied. */
+  openclawAgent?: string;
+}
+
 /** Declarative route entry selecting the runtime and execution flags for matched messages. */
 export interface GatewayRoute {
   match?: RouteMatch;
@@ -29,6 +43,8 @@ export interface GatewayRoute {
   extraArgs?: string[];
   queueMode?: QueueMode;
   trustLevel?: TrustLevel;
+  /** Required when `runtime === "openclaw-acp"`. Resolved at config-load time. */
+  gateway?: ResolvedOpenclawGateway;
 }
 
 // ---------------------------------------------------------------------------
@@ -286,6 +302,13 @@ export interface RuntimeRunOptions {
   context?: Record<string, unknown>;
   /** Called for every parsed block while the turn is in progress. */
   onBlock?: (block: StreamBlock) => void;
+  /**
+   * External service endpoint required by some runtimes (first user:
+   * openclaw-acp). Resolved at config-load time and passed through here per
+   * call — runtime factories do not see it. Mirrors the `hubUrl` precedent of
+   * lifting service URLs out of `extraArgs` into typed first-class fields.
+   */
+  gateway?: ResolvedOpenclawGateway;
 }
 
 /** Result returned by a runtime adapter after a turn completes. */

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -907,15 +907,26 @@ const fsFileReader: DoctorFileReader = {
 };
 
 async function cmdDoctor(args: ParsedArgs): Promise<void> {
-  const entries = detectRuntimes();
+  const entries: import("./doctor.js").DoctorRuntimeEntry[] = detectRuntimes();
   // Doctor should not hard-fail when no config exists yet; channel probes
   // simply produce an empty list in that case.
   let channels: ReturnType<typeof channelsFromDaemonConfig> = [];
+  let cfgForEndpoints: import("./config.js").DaemonConfig | null = null;
   try {
     const cfg = loadConfig();
+    cfgForEndpoints = cfg;
     channels = channelsFromDaemonConfig(cfg);
   } catch {
     channels = [];
+  }
+  if (cfgForEndpoints?.openclawGateways && cfgForEndpoints.openclawGateways.length > 0) {
+    const { collectRuntimeSnapshotAsync } = await import("./provision.js");
+    const snap = await collectRuntimeSnapshotAsync({ cfg: cfgForEndpoints });
+    const byId = new Map(snap.runtimes.map((r) => [r.id, r]));
+    for (const e of entries) {
+      const r = byId.get(e.id);
+      if (r?.endpoints) e.endpoints = r.endpoints;
+    }
   }
 
   const credentialsPath = (accountId: string) =>

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -41,7 +41,11 @@ import {
   type RouteRule,
   type RouteRuleMatch,
 } from "./config.js";
-import { BOTCORD_CHANNEL_TYPE, buildManagedRoutes } from "./daemon-config-map.js";
+import {
+  BOTCORD_CHANNEL_TYPE,
+  buildManagedRoutes,
+  prepareGatewayProfile,
+} from "./daemon-config-map.js";
 import {
   agentHomeDir,
   agentStateDir,
@@ -368,14 +372,18 @@ async function provisionAgent(
         (g) => g.name === credentials.openclawGateway,
       );
       if (profile) {
+        // Run the same tokenFile-aware resolver `toGatewayConfig` uses so the
+        // first turn after provisioning doesn't auth-fail when the gateway
+        // ships its bearer via `tokenFile` instead of an inline `token`.
+        const prepared = prepareGatewayProfile(profile);
         synthRoute.gateway = {
-          name: profile.name,
-          url: profile.url,
-          ...(profile.token ? { token: profile.token } : {}),
+          name: prepared.name,
+          url: prepared.url,
+          ...(prepared.resolvedToken ? { token: prepared.resolvedToken } : {}),
           ...(credentials.openclawAgent
             ? { openclawAgent: credentials.openclawAgent }
-            : profile.defaultAgent
-              ? { openclawAgent: profile.defaultAgent }
+            : prepared.defaultAgent
+              ? { openclawAgent: prepared.defaultAgent }
               : {}),
         };
       }
@@ -723,7 +731,7 @@ export function collectRuntimeSnapshot(): ListRuntimesResult {
 /** Maximum number of `endpoints[]` entries persisted per runtime (RFC §3.8.2). */
 export const RUNTIME_ENDPOINTS_CAP = 32;
 
-/** Injection seam for L2 endpoint probes — kept testable + side-effect-free. */
+/** Injection seam for L2 + L3 endpoint probes — kept testable + side-effect-free. */
 export type WsEndpointProbeFn = (args: {
   url: string;
   token?: string;
@@ -731,11 +739,31 @@ export type WsEndpointProbeFn = (args: {
 }) => Promise<{
   ok: boolean;
   version?: string;
-  agents?: Array<{ name: string; model?: string }>;
+  /**
+   * L3 — populated when `agents.list` succeeds. `id` is the stable key
+   * consumed by route lookups / `openclawAgent`; `name` is display-only.
+   */
+  agents?: Array<{
+    id: string;
+    name?: string;
+    workspace?: string;
+    model?: { name?: string; provider?: string };
+  }>;
   error?: string;
 }>;
 
-/** Default L2 probe — best-effort WS handshake against the OpenClaw gateway. */
+/**
+ * Default L2 + L3 probe — opens a WS handshake against the OpenClaw gateway
+ * and, when the connection is up, issues a JSON-RPC `agents.list` request to
+ * enumerate configured agent profiles. Best-effort: a successful WS open with
+ * a failed `agents.list` still reports `ok: true` (just without `agents`),
+ * matching the RFC's "agents populated only when listing succeeded" rule.
+ *
+ * Method name and result shape follow OpenClaw:
+ *   `~/claws/openclaw/src/gateway/server-methods/agents.ts:416` and
+ *   `~/claws/openclaw/src/gateway/session-utils.ts:783` —
+ *   `{ defaultId, mainKey, scope, agents: [{ id, name?, identity?, workspace, model? }] }`.
+ */
 async function defaultWsProbe(args: {
   url: string;
   token?: string;
@@ -743,28 +771,42 @@ async function defaultWsProbe(args: {
 }): Promise<{
   ok: boolean;
   version?: string;
-  agents?: Array<{ name: string; model?: string }>;
+  agents?: Array<{
+    id: string;
+    name?: string;
+    workspace?: string;
+    model?: { name?: string; provider?: string };
+  }>;
   error?: string;
 }> {
+  type AgentRow = {
+    id: string;
+    name?: string;
+    workspace?: string;
+    model?: { name?: string; provider?: string };
+  };
+  type ProbeResult = {
+    ok: boolean;
+    version?: string;
+    agents?: AgentRow[];
+    error?: string;
+  };
   const { default: WebSocket } = await import("ws");
-  return new Promise((resolve) => {
+  return new Promise<ProbeResult>((resolve) => {
     let settled = false;
-    const settle = (v: {
-      ok: boolean;
-      version?: string;
-      agents?: Array<{ name: string; model?: string }>;
-      error?: string;
-    }): void => {
+    let ws: any;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const settle = (v: ProbeResult): void => {
       if (settled) return;
       settled = true;
+      if (timer) clearTimeout(timer);
       try {
-        ws.terminate();
+        ws?.terminate();
       } catch {
         // ignore
       }
       resolve(v);
     };
-    let ws: any;
     try {
       const headers: Record<string, string> = {};
       if (args.token) headers["Authorization"] = `Bearer ${args.token}`;
@@ -773,14 +815,59 @@ async function defaultWsProbe(args: {
       resolve({ ok: false, error: (err as Error).message });
       return;
     }
-    const timer = setTimeout(() => settle({ ok: false, error: "timeout" }), args.timeoutMs);
+    timer = setTimeout(() => settle({ ok: false, error: "timeout" }), args.timeoutMs);
+    const requestId = "probe-agents-list";
     ws.on("open", () => {
-      clearTimeout(timer);
-      settle({ ok: true });
+      // L3: enumerate agent profiles. We don't fail the L2 result if this
+      // call fails — the gateway is reachable either way.
+      try {
+        ws.send(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: requestId,
+            method: "agents.list",
+            params: {},
+          }),
+        );
+      } catch (err) {
+        settle({ ok: true, error: `agents.list send failed: ${(err as Error).message}` });
+      }
+    });
+    ws.on("message", (raw: Buffer | string) => {
+      try {
+        const msg = JSON.parse(typeof raw === "string" ? raw : raw.toString("utf8"));
+        if (msg?.id !== requestId) return; // ignore unrelated frames
+        if (msg.error) {
+          settle({ ok: true, error: String(msg.error?.message ?? "agents.list error") });
+          return;
+        }
+        const list = Array.isArray(msg.result?.agents) ? msg.result.agents : [];
+        const agents: AgentRow[] = [];
+        for (const a of list) {
+          if (!a || typeof a.id !== "string" || a.id.length === 0) continue;
+          const row: AgentRow = { id: a.id };
+          if (typeof a.name === "string") row.name = a.name;
+          if (typeof a.workspace === "string") row.workspace = a.workspace;
+          if (a.model && typeof a.model === "object") {
+            const model: { name?: string; provider?: string } = {};
+            if (typeof a.model.name === "string") model.name = a.model.name;
+            if (typeof a.model.provider === "string") model.provider = a.model.provider;
+            if (model.name || model.provider) row.model = model;
+          }
+          agents.push(row);
+        }
+        settle({ ok: true, agents });
+      } catch (err) {
+        settle({ ok: true, error: `agents.list parse failed: ${(err as Error).message}` });
+      }
     });
     ws.on("error", (err: Error) => {
-      clearTimeout(timer);
       settle({ ok: false, error: err.message });
+    });
+    ws.on("close", () => {
+      // If the socket closes before `agents.list` resolved we still treat
+      // L2 as ok (open fired) and emit no agents.
+      settle({ ok: true });
     });
   });
 }
@@ -803,13 +890,18 @@ export async function collectRuntimeSnapshotAsync(opts: {
   const gateways = opts.cfg?.openclawGateways ?? [];
   if (gateways.length === 0) return base;
   const probe = opts.wsProbe ?? defaultWsProbe;
-  const timeoutMs = opts.timeoutMs ?? 5000;
+  // Default daemon-side budget is 3s — it must stay below the Hub's
+  // `list_runtimes` ack wait (5s, see backend/hub/routers/daemon_control.py)
+  // so a single slow gateway can't blow the whole snapshot to a 504.
+  const timeoutMs = opts.timeoutMs ?? 3000;
   const capped = gateways.slice(0, RUNTIME_ENDPOINTS_CAP);
   const endpoints = await Promise.all(
     capped.map(async (g) => {
-      const token = g.token; // tokenFile resolution lives in toGatewayConfig; if a caller hands us only tokenFile we skip auth.
+      // Resolve `tokenFile` here so token-file-only profiles probe with auth
+      // and aren't falsely marked unreachable in the dashboard.
+      const prepared = prepareGatewayProfile(g);
       try {
-        const res = await probe({ url: g.url, token, timeoutMs });
+        const res = await probe({ url: g.url, token: prepared.resolvedToken, timeoutMs });
         const entry: any = { name: g.name, url: g.url, reachable: res.ok };
         if (res.version) entry.version = res.version;
         if (res.error) entry.error = res.error;

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -226,7 +226,15 @@ export function createProvisioner(opts: ProvisionerOptions): (
       }
 
       case CONTROL_FRAME_TYPES.LIST_RUNTIMES: {
-        const snapshot = collectRuntimeSnapshot();
+        // Async path so the openclaw-acp endpoints get probed inline; gateway
+        // / WS errors are swallowed inside `collectRuntimeSnapshotAsync`.
+        let cfgForProbe: { openclawGateways?: any[] } | undefined;
+        try {
+          cfgForProbe = loadConfig();
+        } catch {
+          cfgForProbe = undefined;
+        }
+        const snapshot = await collectRuntimeSnapshotAsync({ cfg: cfgForProbe });
         daemonLog.debug("list_runtimes", { count: snapshot.runtimes.length });
         return { ok: true, result: snapshot };
       }
@@ -346,11 +354,33 @@ async function provisionAgent(
   // Hot-add the synthesized per-agent managed route so the next turn picks
   // the agent's runtime + workspace cwd without waiting for reload_config.
   try {
-    ctx.gateway.upsertManagedRoute(credentials.agentId, {
+    const synthRoute: import("./gateway/index.js").GatewayRoute = {
       match: { accountId: credentials.agentId },
       runtime: credentials.runtime ?? cfg.defaultRoute.adapter,
       cwd: credentials.cwd ?? agentWorkspaceDir(credentials.agentId),
-    });
+    };
+    if (synthRoute.runtime === "openclaw-acp") {
+      // Resolve gateway from the freshly written credentials + the live
+      // openclawGateways registry. A missing/unknown gateway here yields a
+      // disabled route (set_route style); next turn for this agent falls
+      // back to defaultRoute. Caller already validated via reload semantics.
+      const profile = (cfg.openclawGateways ?? []).find(
+        (g) => g.name === credentials.openclawGateway,
+      );
+      if (profile) {
+        synthRoute.gateway = {
+          name: profile.name,
+          url: profile.url,
+          ...(profile.token ? { token: profile.token } : {}),
+          ...(credentials.openclawAgent
+            ? { openclawAgent: credentials.openclawAgent }
+            : profile.defaultAgent
+              ? { openclawAgent: profile.defaultAgent }
+              : {}),
+        };
+      }
+    }
+    ctx.gateway.upsertManagedRoute(credentials.agentId, synthRoute);
   } catch (err) {
     // Rollback the channel + config + credentials on managed-route failure
     // (shouldn't happen — pure map op — but keeps the invariant tight).
@@ -432,6 +462,9 @@ async function materializeCredentials(
     if (typeof c.tokenExpiresAt === "number") record.tokenExpiresAt = c.tokenExpiresAt;
     if (runtime) record.runtime = runtime;
     record.cwd = cwd;
+    const openclawSel = pickOpenclawSelection(params);
+    if (openclawSel.gateway) record.openclawGateway = openclawSel.gateway;
+    if (openclawSel.agent) record.openclawAgent = openclawSel.agent;
     return record;
   }
 
@@ -461,7 +494,39 @@ async function materializeCredentials(
   };
   if (runtime) record.runtime = runtime;
   record.cwd = cwd;
+  const openclawSel = pickOpenclawSelection(params);
+  if (openclawSel.gateway) record.openclawGateway = openclawSel.gateway;
+  if (openclawSel.agent) record.openclawAgent = openclawSel.agent;
   return record;
+}
+
+/**
+ * Resolve OpenClaw routing selection from a `provision_agent` frame. Top-level
+ * `params.openclaw` (nested) wins over the flat `credentials.openclaw*` mirror.
+ * Returning `{}` is fine — only meaningful when the agent's runtime is
+ * `openclaw-acp`, and `buildManagedRoutes` falls back to defaultRoute.gateway
+ * when both are missing.
+ */
+function pickOpenclawSelection(
+  params: ProvisionAgentParams,
+): { gateway?: string; agent?: string } {
+  const out: { gateway?: string; agent?: string } = {};
+  const top = params.openclaw;
+  if (top && typeof top.gateway === "string" && top.gateway.length > 0) {
+    out.gateway = top.gateway;
+    if (typeof top.agent === "string" && top.agent.length > 0) out.agent = top.agent;
+    return out;
+  }
+  const flat = params.credentials;
+  if (flat) {
+    if (typeof flat.openclawGateway === "string" && flat.openclawGateway.length > 0) {
+      out.gateway = flat.openclawGateway;
+    }
+    if (typeof flat.openclawAgent === "string" && flat.openclawAgent.length > 0) {
+      out.agent = flat.openclawAgent;
+    }
+  }
+  return out;
 }
 
 async function revokeAgent(
@@ -655,6 +720,118 @@ export function collectRuntimeSnapshot(): ListRuntimesResult {
   return { runtimes, probedAt: Date.now() };
 }
 
+/** Maximum number of `endpoints[]` entries persisted per runtime (RFC §3.8.2). */
+export const RUNTIME_ENDPOINTS_CAP = 32;
+
+/** Injection seam for L2 endpoint probes — kept testable + side-effect-free. */
+export type WsEndpointProbeFn = (args: {
+  url: string;
+  token?: string;
+  timeoutMs: number;
+}) => Promise<{
+  ok: boolean;
+  version?: string;
+  agents?: Array<{ name: string; model?: string }>;
+  error?: string;
+}>;
+
+/** Default L2 probe — best-effort WS handshake against the OpenClaw gateway. */
+async function defaultWsProbe(args: {
+  url: string;
+  token?: string;
+  timeoutMs: number;
+}): Promise<{
+  ok: boolean;
+  version?: string;
+  agents?: Array<{ name: string; model?: string }>;
+  error?: string;
+}> {
+  const { default: WebSocket } = await import("ws");
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (v: {
+      ok: boolean;
+      version?: string;
+      agents?: Array<{ name: string; model?: string }>;
+      error?: string;
+    }): void => {
+      if (settled) return;
+      settled = true;
+      try {
+        ws.terminate();
+      } catch {
+        // ignore
+      }
+      resolve(v);
+    };
+    let ws: any;
+    try {
+      const headers: Record<string, string> = {};
+      if (args.token) headers["Authorization"] = `Bearer ${args.token}`;
+      ws = new WebSocket(args.url, { headers });
+    } catch (err) {
+      resolve({ ok: false, error: (err as Error).message });
+      return;
+    }
+    const timer = setTimeout(() => settle({ ok: false, error: "timeout" }), args.timeoutMs);
+    ws.on("open", () => {
+      clearTimeout(timer);
+      settle({ ok: true });
+    });
+    ws.on("error", (err: Error) => {
+      clearTimeout(timer);
+      settle({ ok: false, error: err.message });
+    });
+  });
+}
+
+/**
+ * Async variant that includes L2 (gateway reachability) and L3 (agent listing)
+ * probes for runtimes that talk to external services. Used by the production
+ * `list_runtimes` and first-connect snapshot paths.
+ *
+ * `cfg` is optional so existing callers without a loaded config (e.g. tests)
+ * can keep using the sync `collectRuntimeSnapshot()` — when absent, the result
+ * is identical to that function.
+ */
+export async function collectRuntimeSnapshotAsync(opts: {
+  cfg?: { openclawGateways?: Array<{ name: string; url: string; token?: string; tokenFile?: string }> };
+  wsProbe?: WsEndpointProbeFn;
+  timeoutMs?: number;
+} = {}): Promise<ListRuntimesResult> {
+  const base = collectRuntimeSnapshot();
+  const gateways = opts.cfg?.openclawGateways ?? [];
+  if (gateways.length === 0) return base;
+  const probe = opts.wsProbe ?? defaultWsProbe;
+  const timeoutMs = opts.timeoutMs ?? 5000;
+  const capped = gateways.slice(0, RUNTIME_ENDPOINTS_CAP);
+  const endpoints = await Promise.all(
+    capped.map(async (g) => {
+      const token = g.token; // tokenFile resolution lives in toGatewayConfig; if a caller hands us only tokenFile we skip auth.
+      try {
+        const res = await probe({ url: g.url, token, timeoutMs });
+        const entry: any = { name: g.name, url: g.url, reachable: res.ok };
+        if (res.version) entry.version = res.version;
+        if (res.error) entry.error = res.error;
+        if (res.agents) entry.agents = res.agents;
+        return entry;
+      } catch (err) {
+        return {
+          name: g.name,
+          url: g.url,
+          reachable: false,
+          error: (err as Error).message,
+        };
+      }
+    }),
+  );
+  const out: ListRuntimesResult = { ...base };
+  out.runtimes = base.runtimes.map((r) =>
+    r.id === "openclaw-acp" ? { ...r, endpoints } : r,
+  );
+  return out;
+}
+
 // ---------------------------------------------------------------------------
 // hello agents snapshot (lightweight identity sync)
 // ---------------------------------------------------------------------------
@@ -789,17 +966,19 @@ export async function reloadConfig(ctx: { gateway: Gateway }): Promise<ReloadRes
  */
 function readAgentRuntimesFromCredentials(
   agentIds: string[],
-): Record<string, { runtime?: string; cwd?: string }> {
-  const out: Record<string, { runtime?: string; cwd?: string }> = {};
+): Record<string, { runtime?: string; cwd?: string; openclawGateway?: string; openclawAgent?: string }> {
+  const out: Record<string, { runtime?: string; cwd?: string; openclawGateway?: string; openclawAgent?: string }> = {};
   for (const id of agentIds) {
     const file = defaultCredentialsFile(id);
     try {
       if (!existsSync(file)) continue;
       const creds = loadStoredCredentials(file);
-      const entry: { runtime?: string; cwd?: string } = {};
+      const entry: { runtime?: string; cwd?: string; openclawGateway?: string; openclawAgent?: string } = {};
       if (creds.runtime) entry.runtime = creds.runtime;
       if (creds.cwd) entry.cwd = creds.cwd;
-      if (entry.runtime || entry.cwd) out[id] = entry;
+      if (creds.openclawGateway) entry.openclawGateway = creds.openclawGateway;
+      if (creds.openclawAgent) entry.openclawAgent = creds.openclawAgent;
+      if (entry.runtime || entry.cwd || entry.openclawGateway || entry.openclawAgent) out[id] = entry;
     } catch {
       // best-effort — skip agents with unreadable credentials
     }

--- a/packages/protocol-core/package.json
+++ b/packages/protocol-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botcord/protocol-core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Shared protocol primitives for BotCord — Ed25519 signing, credentials I/O, session key derivation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/protocol-core/src/control-frame.ts
+++ b/packages/protocol-core/src/control-frame.ts
@@ -316,8 +316,18 @@ export interface RuntimeEndpointProbe {
   version?: string;
   /** Failure reason when `reachable === false`. */
   error?: string;
-  /** Listing of agent profiles, only set when `reachable` and the listing RPC succeeded. */
-  agents?: Array<{ name: string; model?: string }>;
+  /**
+   * Listing of agent profiles, only set when `reachable` and the listing RPC
+   * (`agents.list`) succeeded. Shape mirrors OpenClaw's
+   * `gateway/session-utils.ts` — `id` is the stable key (used by daemon
+   * routes / `openclawAgent`), `name` is display-only.
+   */
+  agents?: Array<{
+    id: string;
+    name?: string;
+    workspace?: string;
+    model?: { name?: string; provider?: string };
+  }>;
 }
 
 /**

--- a/packages/protocol-core/src/control-frame.ts
+++ b/packages/protocol-core/src/control-frame.ts
@@ -133,6 +133,27 @@ export interface ProvisionAgentParams {
     runtime?: string;
     /** Working directory cached alongside the runtime, for route synthesis. */
     cwd?: string;
+    /**
+     * OpenClaw gateway profile name to bind to this agent. Only meaningful
+     * when `runtime === "openclaw-acp"`. Flat naming chosen to match the
+     * existing flat shape of the `credentials` envelope.
+     */
+    openclawGateway?: string;
+    /** Optional OpenClaw agent profile override for this agent. */
+    openclawAgent?: string;
+  };
+  /**
+   * OpenClaw runtime parameters. When `runtime === "openclaw-acp"` the daemon
+   * routes this agent's turns through the named gateway profile (must exist in
+   * `DaemonConfig.openclawGateways[].name`). Top-level nesting groups the
+   * fields as a runtime cluster; the duplicate flat fields under `credentials`
+   * exist because the credentials envelope is intentionally flat.
+   */
+  openclaw?: {
+    /** References `DaemonConfig.openclawGateways[].name` on the daemon side. */
+    gateway: string;
+    /** Overrides `OpenclawGatewayProfile.defaultAgent` for this agent. */
+    agent?: string;
   };
   /**
    * Optional initial attention policy seed. When the Hub already knows the
@@ -267,6 +288,36 @@ export interface RuntimeProbeResult {
   path?: string;
   /** Human-readable reason the probe failed (only when `available === false`). */
   error?: string;
+  /**
+   * Optional per-endpoint probe results. Populated by runtimes that talk to
+   * external services (the openclaw-acp runtime uses one entry per
+   * `DaemonConfig.openclawGateways` profile). Length is capped (32) by the
+   * daemon before send and by the Hub on ingest. Older Hub builds that don't
+   * recognize this field simply pass it through inside the opaque
+   * `runtimes_json` blob.
+   */
+  endpoints?: RuntimeEndpointProbe[];
+}
+
+/**
+ * One endpoint probe entry attached to a `RuntimeProbeResult`. For the
+ * openclaw-acp runtime, each entry is a configured gateway profile and
+ * carries the WS reachability outcome (L2) plus, when reachable, the list of
+ * agent profiles available on that gateway (L3).
+ */
+export interface RuntimeEndpointProbe {
+  /** Gateway profile name (`DaemonConfig.openclawGateways[].name`). */
+  name: string;
+  /** Endpoint URL (e.g. `wss://gw.example:18789`). */
+  url: string;
+  /** True when the gateway responded successfully within the timeout. */
+  reachable: boolean;
+  /** Gateway-reported version, when available. */
+  version?: string;
+  /** Failure reason when `reachable === false`. */
+  error?: string;
+  /** Listing of agent profiles, only set when `reachable` and the listing RPC succeeded. */
+  agents?: Array<{ name: string; model?: string }>;
 }
 
 /**

--- a/packages/protocol-core/src/credentials.ts
+++ b/packages/protocol-core/src/credentials.ts
@@ -25,6 +25,18 @@ export interface StoredBotCordCredentials {
   runtime?: string;
   /** Working directory pinned for this agent, cached alongside runtime. */
   cwd?: string;
+  /**
+   * Name of the OpenClaw gateway profile (`DaemonConfig.openclawGateways[].name`)
+   * to route this agent's turns through. Only meaningful when `runtime ===
+   * "openclaw-acp"`. Read by `buildManagedRoutes` to lookup the resolved
+   * gateway endpoint at config-load time.
+   */
+  openclawGateway?: string;
+  /**
+   * Optional override of the OpenClaw agent profile to use within the gateway,
+   * falling back to `OpenclawGatewayProfile.defaultAgent` when absent.
+   */
+  openclawAgent?: string;
 }
 
 function normalizeCredentialValue(raw: any, keys: string[]): string | undefined {
@@ -97,6 +109,8 @@ export function loadStoredCredentials(credentialsFile: string): StoredBotCordCre
   const onboardedAt = normalizeCredentialValue(raw, ["onboardedAt", "onboarded_at"]);
   const runtime = normalizeCredentialValue(raw, ["runtime"]);
   const cwd = normalizeCredentialValue(raw, ["cwd"]);
+  const openclawGateway = normalizeCredentialValue(raw, ["openclawGateway", "openclaw_gateway"]);
+  const openclawAgent = normalizeCredentialValue(raw, ["openclawAgent", "openclaw_agent"]);
 
   return {
     version: 1,
@@ -112,6 +126,8 @@ export function loadStoredCredentials(credentialsFile: string): StoredBotCordCre
     onboardedAt,
     runtime,
     cwd,
+    openclawGateway,
+    openclawAgent,
   };
 }
 


### PR DESCRIPTION
## Summary

Implements [docs/daemon-openclaw-runtime-rfc.md](../blob/feat/openclaw-runtime/docs/daemon-openclaw-runtime-rfc.md). Adds `openclaw-acp` as a fourth daemon runtime alongside `claude-code` / `codex` / `gemini`, talking ACP (Agent Client Protocol) over stdio to a long-lived OpenClaw Gateway.

- **protocol-core (additive):** `RuntimeProbeResult.endpoints` + `RuntimeEndpointProbe`; `ProvisionAgentParams.openclaw` + `credentials.openclaw{Gateway,Agent}`; `StoredBotCordCredentials.openclaw{Gateway,Agent}`.
- **daemon:** new `DaemonConfig.openclawGateways` registry; `RouteRule.gateway` / `openclawAgent`; eager `profile name → ResolvedOpenclawGateway` resolution in `toGatewayConfig` (with `tokenFile` expansion); `agent-discovery` + `buildManagedRoutes` propagate openclaw fields from credentials; dispatcher passes `route.gateway` through to `runtime.run`. New `OpenclawAcpAdapter` with module-level `(accountId, gatewayName)` process pool, JSON-RPC over stdio, ACP double-id (sessionId / sessionKey) handling, idle GC, accountId-bearing sessionKey for 串号 防御. `collectRuntimeSnapshotAsync` adds L2/L3 probes with `endpoints[]` capped at 32. Doctor renders the new gateway / agents tier. `provisionAgent` persists openclaw fields to credentials and hot-adds the managed route with the resolved gateway.
- **backend:** `_parse_runtime_snapshot_params` truncates `endpoints[]` to 32 (independent of daemon-side cap); `/me/agents/provision` accepts and forwards `openclaw_{gateway,agent}`.
- **frontend:** `DaemonRuntime.endpoints` and `ProvisionAgentInput.openclaw*` plumbed through `useDaemonStore`; `CreateAgentDialog` shows a two-level Gateway → Agent picker when `runtime === "openclaw-acp"`.

Verification:
- protocol-core build clean.
- daemon build clean; **483 tests passed (+9 new)** — config-map gateway resolution, managed-route credentials path, adapter stdio happy path + pool reuse + missing-gateway/agent guards, sessionKey accountId mixing.

## Test plan

- [ ] `cd packages/protocol-core && npm run build`
- [ ] `cd packages/daemon && npm run build && npm test`
- [ ] Boot daemon with two gateways (local + remote), verify dashboard runtime card shows endpoints with reachability + agent list, and that the create-agent dialog gates submission on a chosen gateway.
- [ ] Provision an agent against `runtime: openclaw-acp` and confirm credentials file has `openclawGateway` / `openclawAgent` and a turn round-trips through `openclaw acp` stdio.
- [ ] Confirm `daemon doctor` prints the per-gateway tier and that an unreachable gateway does not break the others.
- [ ] Inject 1000-element `endpoints[]` from a misconfigured daemon and verify backend persists exactly 32.

## Out of scope (RFC §7)

- Loop-detection RPC method name on the gateway side (`plugins.list` / `plugins.status`) — pending PoC against `~/claws/openclaw/src/gateway/`.
- Frontend i18n strings for the new picker (uses hardcoded English).

🤖 Generated with [Claude Code](https://claude.com/claude-code)