### PR TITLE
feat: human-as-owner subscription products + polymorphic room admin

### DIFF
--- a/backend/app/auth_room.py
+++ b/backend/app/auth_room.py
@@ -1,0 +1,118 @@
+"""Room-scoped capability helpers used by the dashboard BFF.
+
+After PR #352 made rooms polymorphic (owner_id / owner_type can be ag_* or
+hu_*), authorization for owner-only operations is no longer "active_agent ==
+room.owner_id". The viewer's user might own the bot that owns the room, or
+the room's owner might be the viewer's own human identity. These helpers
+collapse those cases.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import RequestContext
+from hub.enums import ParticipantType, RoomRole
+from hub.models import Agent, Room, RoomMember
+
+
+RoomCapability = Literal["owner", "admin"]
+
+
+async def viewer_can_admin_room(
+    db: AsyncSession,
+    ctx: RequestContext,
+    room: Room,
+) -> RoomCapability | None:
+    """Return the strongest capability the JWT viewer has on ``room``.
+
+    - ``"owner"`` — viewer can perform owner-only operations
+      (visibility, join_policy, plan, dissolve, ...). Cases:
+        * room is agent-owned and viewer's active agent IS the owner agent;
+        * room is agent-owned and the owner agent's ``user_id`` ==
+          ``ctx.user_id`` (transitive — viewer's user owns the bot);
+        * room is human-owned and ``ctx.human_id`` matches ``room.owner_id``.
+        * RoomMember.role == owner under the viewer's active agent.
+    - ``"admin"`` — viewer is a RoomMember with role admin under their
+      active agent (humans don't get admin-via-membership today).
+    - ``None`` — no capability.
+    """
+    if room.owner_type == ParticipantType.agent:
+        if ctx.active_agent_id and ctx.active_agent_id == room.owner_id:
+            return "owner"
+        owner_agent = (
+            await db.execute(
+                select(Agent).where(Agent.agent_id == room.owner_id)
+            )
+        ).scalar_one_or_none()
+        if owner_agent is not None and ctx.user_id is not None and owner_agent.user_id == ctx.user_id:
+            return "owner"
+    elif room.owner_type == ParticipantType.human:
+        if ctx.human_id and ctx.human_id == room.owner_id:
+            return "owner"
+
+    # Admin-via-RoomMember — explicitly filter participant_type=agent so we
+    # don't depend on ID prefixes as a discriminator inside auth code.
+    if ctx.active_agent_id:
+        member = (
+            await db.execute(
+                select(RoomMember).where(
+                    RoomMember.room_id == room.room_id,
+                    RoomMember.agent_id == ctx.active_agent_id,
+                    RoomMember.participant_type == ParticipantType.agent,
+                )
+            )
+        ).scalar_one_or_none()
+        if member is not None and member.role in (RoomRole.owner, RoomRole.admin):
+            return "owner" if member.role == RoomRole.owner else "admin"
+
+    return None
+
+
+async def resolve_provider_agent_for_room(
+    db: AsyncSession,
+    ctx: RequestContext,
+    room: Room,
+    *,
+    requested_provider_agent_id: str | None,
+) -> str:
+    """Pick the agent that should receive subscription payments for ``room``.
+
+    - Agent-owned room → the owner agent (request body field is ignored).
+    - Human-owned room → ``requested_provider_agent_id`` is required, must
+      belong to ``ctx.user_id``, and must be active. We deliberately do NOT
+      fall back to ``X-Active-Agent`` because the human dashboard path does
+      not send it.
+    """
+    if room.owner_type == ParticipantType.agent:
+        return room.owner_id
+
+    if not requested_provider_agent_id:
+        raise HTTPException(
+            status_code=400,
+            detail="provider_agent_id is required for human-owned rooms",
+        )
+    agent = (
+        await db.execute(
+            select(Agent).where(Agent.agent_id == requested_provider_agent_id)
+        )
+    ).scalar_one_or_none()
+    if agent is None or ctx.user_id is None or agent.user_id != ctx.user_id:
+        raise HTTPException(
+            status_code=403,
+            detail="Provider agent does not belong to this user",
+        )
+    # `Agent.status` is a string in the schema; treat anything other than
+    # "active" as ineligible. If the column is missing on a row (legacy data),
+    # don't block here — the wallet transfer path will surface real failures.
+    status = getattr(agent, "status", None)
+    if status is not None and str(status) != "active":
+        raise HTTPException(
+            status_code=400,
+            detail="Provider agent is not active",
+        )
+    return requested_provider_agent_id

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -15,6 +15,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import RequestContext, require_active_agent, require_user_with_optional_agent
+from app.auth_room import resolve_provider_agent_for_room, viewer_can_admin_room
 from app.helpers import escape_like, extract_text_from_envelope
 from hub.database import get_db
 from hub.dashboard_message_shaping import (
@@ -351,6 +352,7 @@ async def _build_rooms_from_membership(
             "rule": room.rule,
             "required_subscription_product_id": room.required_subscription_product_id,
             "owner_id": room.owner_id,
+            "owner_type": room.owner_type.value if hasattr(room.owner_type, "value") else str(room.owner_type),
             "visibility": room.visibility.value if hasattr(room.visibility, "value") else str(room.visibility),
             "join_policy": room.join_policy.value if hasattr(room.join_policy, "value") else str(room.join_policy),
             "member_count": member_counts.get(rid, 0),
@@ -1186,25 +1188,18 @@ async def join_room(
 async def update_room_settings(
     room_id: str,
     body: UpdateRoomSettingsBody,
-    ctx: RequestContext = Depends(require_active_agent),
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
     db: AsyncSession = Depends(get_db),
 ):
-    """Update room name/description/rule. Owner/admin only."""
-    agent_id = ctx.active_agent_id
-
+    """Update room settings. Basic fields require admin; advanced fields
+    require owner. Works for human-as-owner viewers too — capability is
+    derived via ``viewer_can_admin_room``."""
     room = (await db.execute(select(Room).where(Room.room_id == room_id))).scalar_one_or_none()
     if room is None:
         raise HTTPException(status_code=404, detail="Room not found")
 
-    member = (
-        await db.execute(
-            select(RoomMember).where(
-                RoomMember.room_id == room_id,
-                RoomMember.agent_id == agent_id,
-            )
-        )
-    ).scalar_one_or_none()
-    if member is None or member.role not in (RoomRole.owner, RoomRole.admin):
+    cap = await viewer_can_admin_room(db, ctx, room)
+    if cap is None:
         raise HTTPException(status_code=403, detail="Only owner or admin can update room settings")
 
     fields_set = body.model_fields_set
@@ -1217,7 +1212,7 @@ async def update_room_settings(
         "slow_mode_seconds",
         "required_subscription_product_id",
     }
-    if fields_set & owner_only_fields and member.role != RoomRole.owner:
+    if fields_set & owner_only_fields and cap != "owner":
         raise HTTPException(status_code=403, detail="Only the owner can change advanced settings")
 
     if "name" in fields_set:
@@ -1266,7 +1261,10 @@ async def update_room_settings(
             ).scalar_one_or_none()
             if product_row is None:
                 raise HTTPException(status_code=404, detail="Subscription product not found")
-            if product_row.owner_agent_id != room.owner_id:
+            if (
+                product_row.owner_id != room.owner_id
+                or product_row.owner_type != room.owner_type
+            ):
                 raise HTTPException(
                     status_code=403,
                     detail="Subscription product does not belong to room owner",
@@ -1336,13 +1334,15 @@ class MigrateRoomPlanBody(BaseModel):
     amount_minor: str = Field(..., min_length=1)
     billing_interval: str = Field(..., description="week or month")
     description: str = Field(default="")
+    # Required when the room is human-owned. Ignored for agent-owned rooms.
+    provider_agent_id: str | None = None
 
 
 @router.post("/rooms/{room_id}/subscription/migrate-plan")
 async def migrate_room_subscription_plan(
     room_id: str,
     body: MigrateRoomPlanBody,
-    ctx: RequestContext = Depends(require_active_agent),
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
     db: AsyncSession = Depends(get_db),
 ):
     """Atomically swap a room's subscription plan.
@@ -1381,10 +1381,15 @@ async def migrate_room_subscription_plan(
     ).scalar_one_or_none()
     if room is None:
         raise HTTPException(status_code=404, detail="Room not found")
-    if room.owner_id != ctx.active_agent_id:
+    cap = await viewer_can_admin_room(db, ctx, room)
+    if cap != "owner":
         raise HTTPException(
             status_code=403, detail="Only the room owner can change the subscription plan"
         )
+
+    provider_agent_id = await resolve_provider_agent_for_room(
+        db, ctx, room, requested_provider_agent_id=body.provider_agent_id,
+    )
 
     old_product_id = room.required_subscription_product_id
     if old_product_id is not None:
@@ -1403,11 +1408,13 @@ async def migrate_room_subscription_plan(
                 detail="Subscription product is shared across multiple rooms",
             )
 
-    # Stable, randomised internal name avoids the (owner_agent_id, name)
+    # Stable, randomised internal name avoids the (owner_id, owner_type, name)
     # uniqueness collision on retries within the same second.
     new_product = await sub_svc.create_subscription_product(
         db,
-        room.owner_id,
+        owner_id=room.owner_id,
+        owner_type=room.owner_type,
+        provider_agent_id=provider_agent_id,
         name=f"room:{room.room_id}:plan:{generate_subscription_product_id()}",
         description=body.description or "",
         amount_minor=amount,
@@ -1441,7 +1448,10 @@ async def migrate_room_subscription_plan(
     if old_product_id is not None:
         try:
             await sub_svc.archive_subscription_product(
-                db, old_product_id, ctx.active_agent_id
+                db,
+                old_product_id,
+                owner_id=room.owner_id,
+                owner_type=room.owner_type,
             )
         except ValueError:
             # Owner mismatch on the old product — leave as-is rather than
@@ -1475,6 +1485,54 @@ async def migrate_room_subscription_plan(
         },
         "affected_count": affected_count,
     }
+
+
+# ---------------------------------------------------------------------------
+# Dissolve room (BFF — supports both human-owned and agent-owned rooms)
+# ---------------------------------------------------------------------------
+
+
+@router.delete("/rooms/{room_id}")
+async def dissolve_room(
+    room_id: str,
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
+    db: AsyncSession = Depends(get_db),
+):
+    """Dissolve a room. Owner-capability required (per
+    ``viewer_can_admin_room``). Pre-cancels any subscriptions bound to the
+    room before deletion (mirrors the hub agent-JWT route in
+    ``hub/routers/room.py``)."""
+    room = (
+        await db.execute(select(Room).where(Room.room_id == room_id))
+    ).scalar_one_or_none()
+    if room is None:
+        raise HTTPException(status_code=404, detail="Room not found")
+
+    cap = await viewer_can_admin_room(db, ctx, room)
+    if cap != "owner":
+        raise HTTPException(status_code=403, detail="Only the room owner can dissolve the room")
+
+    bound_subs = (
+        await db.execute(
+            select(AgentSubscription).where(
+                AgentSubscription.room_id == room.room_id,
+                AgentSubscription.status.in_(
+                    [SubscriptionStatus.active, SubscriptionStatus.past_due]
+                ),
+            )
+        )
+    ).scalars().all()
+    if bound_subs:
+        now = datetime.datetime.now(datetime.timezone.utc)
+        for sub in bound_subs:
+            sub.status = SubscriptionStatus.cancelled
+            sub.cancelled_at = now
+            sub.cancel_at_period_end = False
+        await db.flush()
+
+    await db.delete(room)
+    await db.commit()
+    return {"ok": True}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/routers/humans.py
+++ b/backend/app/routers/humans.py
@@ -35,6 +35,7 @@ from hub.enums import (
     RoomJoinPolicy,
     RoomRole,
     RoomVisibility,
+    SubscriptionProductStatus,
     SubscriptionStatus,
 )
 from hub.id_generators import generate_human_id, generate_room_id
@@ -50,6 +51,7 @@ from hub.models import (
     RoomMember,
     Share,
     ShareMessage,
+    SubscriptionProduct,
     User,
 )
 from hub.policy import Principal, check_room_invite_admission
@@ -1325,7 +1327,57 @@ async def update_room_settings_as_human(
     if "slow_mode_seconds" in fields_set:
         room.slow_mode_seconds = body.slow_mode_seconds
     if "required_subscription_product_id" in fields_set:
-        room.required_subscription_product_id = body.required_subscription_product_id or None
+        new_pid = body.required_subscription_product_id or None
+        if new_pid is not None:
+            product_row = (
+                await db.execute(
+                    select(SubscriptionProduct).where(
+                        SubscriptionProduct.product_id == new_pid
+                    )
+                )
+            ).scalar_one_or_none()
+            if product_row is None:
+                raise HTTPException(status_code=404, detail="Subscription product not found")
+            if (
+                product_row.owner_id != room.owner_id
+                or product_row.owner_type != room.owner_type
+            ):
+                raise HTTPException(
+                    status_code=403,
+                    detail="Subscription product does not belong to room owner",
+                )
+            if product_row.status != SubscriptionProductStatus.active:
+                raise HTTPException(
+                    status_code=400, detail="Subscription product is not active"
+                )
+        # Mirrors dashboard PATCH (§3.6 of design): on clear-paid, backfill
+        # legacy NULL room_id on the old product's active subs so the next
+        # billing cycle's plan-mismatch check fires.
+        old_pid = room.required_subscription_product_id
+        if new_pid is None and old_pid is not None:
+            other_rooms = (
+                await db.execute(
+                    select(func.count(Room.id)).where(
+                        Room.required_subscription_product_id == old_pid,
+                        Room.room_id != room.room_id,
+                    )
+                )
+            ).scalar() or 0
+            if other_rooms == 0:
+                from sqlalchemy import update as _sa_update
+
+                await db.execute(
+                    _sa_update(AgentSubscription)
+                    .where(
+                        AgentSubscription.product_id == old_pid,
+                        AgentSubscription.room_id.is_(None),
+                        AgentSubscription.status.in_(
+                            [SubscriptionStatus.active, SubscriptionStatus.past_due]
+                        ),
+                    )
+                    .values(room_id=room.room_id)
+                )
+        room.required_subscription_product_id = new_pid
 
     await db.commit()
     await db.refresh(room)
@@ -1347,6 +1399,25 @@ async def dissolve_room_as_human(
     room, caller = await _load_room_member_as_caller(db, room_id, user.human_id, lock=True)
     if caller.role != RoomRole.owner:
         raise HTTPException(status_code=403, detail="Only the room owner can dissolve this room")
+
+    # Pre-cancel subscriptions bound to this room — see hub dissolve route.
+    bound_subs = (
+        await db.execute(
+            select(AgentSubscription).where(
+                AgentSubscription.room_id == room.room_id,
+                AgentSubscription.status.in_(
+                    [SubscriptionStatus.active, SubscriptionStatus.past_due]
+                ),
+            )
+        )
+    ).scalars().all()
+    if bound_subs:
+        now = datetime.datetime.now(datetime.timezone.utc)
+        for sub in bound_subs:
+            sub.status = SubscriptionStatus.cancelled
+            sub.cancelled_at = now
+            sub.cancel_at_period_end = False
+        await db.flush()
 
     await db.delete(room)
     await db.commit()

--- a/backend/app/routers/subscriptions.py
+++ b/backend/app/routers/subscriptions.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import RequestContext, require_active_agent
 from hub.database import get_db
-from hub.enums import BillingInterval, SubscriptionStatus
+from hub.enums import BillingInterval, ParticipantType, SubscriptionStatus
 from hub.models import AgentSubscription
 from hub.services import subscriptions as sub_svc
 from hub.subscription_schemas import (
@@ -33,7 +33,9 @@ router = APIRouter(prefix="/api/subscriptions", tags=["app-subscriptions"])
 def _product_response(p) -> dict:
     return {
         "product_id": p.product_id,
-        "owner_agent_id": p.owner_agent_id,
+        "owner_id": p.owner_id,
+        "owner_type": p.owner_type.value if hasattr(p.owner_type, "value") else str(p.owner_type),
+        "provider_agent_id": p.provider_agent_id,
         "name": p.name,
         "description": p.description,
         "asset_code": p.asset_code,
@@ -88,7 +90,10 @@ async def list_my_products(
     db: AsyncSession = Depends(get_db),
 ):
     products = await sub_svc.list_subscription_products(
-        db, owner_agent_id=ctx.active_agent_id, include_archived=True,
+        db,
+        owner_id=ctx.active_agent_id,
+        owner_type=ParticipantType.agent,
+        include_archived=True,
     )
     return {"products": [_product_response(p) for p in products]}
 
@@ -134,7 +139,9 @@ async def create_product(
     try:
         product = await sub_svc.create_subscription_product(
             db,
-            ctx.active_agent_id,
+            owner_id=ctx.active_agent_id,
+            owner_type=ParticipantType.agent,
+            provider_agent_id=ctx.active_agent_id,
             name=body.name,
             description=body.description,
             amount_minor=amount,
@@ -156,7 +163,10 @@ async def archive_product(
 ):
     try:
         product = await sub_svc.archive_subscription_product(
-            db, product_id, ctx.active_agent_id,
+            db,
+            product_id,
+            owner_id=ctx.active_agent_id,
+            owner_type=ParticipantType.agent,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
@@ -209,7 +219,10 @@ async def list_subscribers(
     product = await sub_svc.get_subscription_product(db, product_id)
     if product is None:
         raise HTTPException(status_code=404, detail="Subscription product not found")
-    if product.owner_agent_id != ctx.active_agent_id:
+    if not (
+        product.owner_type == ParticipantType.agent
+        and product.owner_id == ctx.active_agent_id
+    ):
         raise HTTPException(status_code=403, detail="Not authorized to view subscribers")
 
     statuses: list[SubscriptionStatus] | None = None

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -253,10 +253,14 @@ async def _ensure_agent_unbind_allowed(db: AsyncSession, agent_id: str) -> None:
     if wallet_result.scalar_one_or_none() is not None:
         raise HTTPException(status_code=409, detail="wallet_not_empty")
 
+    # An agent being decommissioned could be either the owner of an
+    # agent-owned product OR the provider for a human-owned product. Block
+    # decommission while either kind has active subscribers.
     active_owner_products = (
         select(SubscriptionProduct.product_id)
         .where(
-            SubscriptionProduct.owner_agent_id == agent_id,
+            (SubscriptionProduct.owner_id == agent_id)
+            | (SubscriptionProduct.provider_agent_id == agent_id),
             SubscriptionProduct.status == SubscriptionProductStatus.active,
         )
         .subquery()

--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -910,12 +910,25 @@ class WithdrawalRequest(Base):
 class SubscriptionProduct(Base):
     __tablename__ = "subscription_products"
     __table_args__ = (
-        UniqueConstraint("owner_agent_id", "name", name="uq_subscription_product_owner_name"),
+        UniqueConstraint("owner_id", "owner_type", "name", name="uq_subscription_product_owner_name"),
+        Index("ix_subscription_products_owner", "owner_id", "owner_type"),
+        Index("ix_subscription_products_provider", "provider_agent_id"),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     product_id: Mapped[str] = mapped_column(String(64), unique=True, nullable=False, index=True)
-    owner_agent_id: Mapped[str] = mapped_column(
+    # Polymorphic owner — `owner_type` is the discriminator. Can be ag_* or hu_*.
+    owner_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    owner_type: Mapped[ParticipantType] = mapped_column(
+        Enum(ParticipantType, name="participanttype"),
+        nullable=False,
+        default=ParticipantType.agent,
+        server_default=ParticipantType.agent.value,
+    )
+    # Wallet receiver for charges — always an agent. Equals owner_id for
+    # agent-owned products; for human-owned products the human picks one of
+    # their bound bots.
+    provider_agent_id: Mapped[str] = mapped_column(
         String(32), ForeignKey("agents.agent_id"), nullable=False, index=True
     )
     name: Mapped[str] = mapped_column(String(128), nullable=False)

--- a/backend/hub/routers/room.py
+++ b/backend/hub/routers/room.py
@@ -331,7 +331,11 @@ async def _ensure_room_subscription_product(
     product = result.scalar_one_or_none()
     if product is None:
         raise HTTPException(status_code=400, detail="Subscription product not found")
-    if product.owner_agent_id != owner_id:
+    # Hub create-room path is agent-only — owner_id is always an agent here.
+    if not (
+        product.owner_type == ParticipantType.agent
+        and product.owner_id == owner_id
+    ):
         raise HTTPException(
             status_code=403,
             detail="Room owner must own the required subscription product",

--- a/backend/hub/routers/subscriptions.py
+++ b/backend/hub/routers/subscriptions.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from hub import config as hub_config
 from hub.auth import get_current_claimed_agent, get_dashboard_claimed_agent
 from hub.database import get_db
+from hub.enums import ParticipantType
 from hub.models import SubscriptionRoomCreatorPolicy
 from hub.services import subscriptions as subscription_svc
 from hub.subscription_schemas import (
@@ -40,7 +41,9 @@ def _require_internal(authorization: str | None = None):
 def _product_response(product) -> SubscriptionProductResponse:
     return SubscriptionProductResponse(
         product_id=product.product_id,
-        owner_agent_id=product.owner_agent_id,
+        owner_id=product.owner_id,
+        owner_type=product.owner_type.value,
+        provider_agent_id=product.provider_agent_id,
         name=product.name,
         description=product.description,
         asset_code=product.asset_code,
@@ -97,7 +100,9 @@ async def create_product(
     try:
         product = await subscription_svc.create_subscription_product(
             db,
-            current_agent,
+            owner_id=current_agent,
+            owner_type=ParticipantType.agent,
+            provider_agent_id=current_agent,
             name=req.name,
             description=req.description,
             amount_minor=amount,
@@ -125,7 +130,10 @@ async def list_my_products(
     db: AsyncSession = Depends(get_db),
 ):
     products = await subscription_svc.list_subscription_products(
-        db, owner_agent_id=current_agent, include_archived=True
+        db,
+        owner_id=current_agent,
+        owner_type=ParticipantType.agent,
+        include_archived=True,
     )
     return SubscriptionProductListResponse(
         products=[_product_response(product) for product in products]
@@ -140,7 +148,10 @@ async def archive_product(
 ):
     try:
         product = await subscription_svc.archive_subscription_product(
-            db, product_id, current_agent
+            db,
+            product_id,
+            owner_id=current_agent,
+            owner_type=ParticipantType.agent,
         )
         await db.commit()
         await db.refresh(product)
@@ -191,7 +202,12 @@ async def list_subscribers(
     product = await subscription_svc.get_subscription_product(db, product_id)
     if product is None:
         raise I18nHTTPException(status_code=404, message_key="subscription_product_not_found")
-    if product.owner_agent_id != current_agent:
+    # The hub list-subscribers route is agent-JWT — only agent-owned products
+    # are reachable here (human-owned manage via dashboard BFF).
+    if not (
+        product.owner_type == ParticipantType.agent
+        and product.owner_id == current_agent
+    ):
         raise I18nHTTPException(status_code=403, message_key="not_authorized")
 
     subscriptions = await subscription_svc.list_product_subscribers(db, product_id)

--- a/backend/hub/services/subscriptions.py
+++ b/backend/hub/services/subscriptions.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from hub.enums import (
     BillingInterval,
+    ParticipantType,
     SubscriptionChargeAttemptStatus,
     SubscriptionProductStatus,
     SubscriptionStatus,
@@ -65,10 +66,16 @@ def _billing_cycle_key(subscription: AgentSubscription) -> str:
     return _ensure_tz(subscription.current_period_end).isoformat()
 
 
-def _product_query(owner_agent_id: str | None = None, include_archived: bool = False):
+def _product_query(
+    owner_id: str | None = None,
+    owner_type: ParticipantType | None = None,
+    include_archived: bool = False,
+):
     stmt = select(SubscriptionProduct)
-    if owner_agent_id is not None:
-        stmt = stmt.where(SubscriptionProduct.owner_agent_id == owner_agent_id)
+    if owner_id is not None:
+        stmt = stmt.where(SubscriptionProduct.owner_id == owner_id)
+    if owner_type is not None:
+        stmt = stmt.where(SubscriptionProduct.owner_type == owner_type)
     if not include_archived:
         stmt = stmt.where(SubscriptionProduct.status == SubscriptionProductStatus.active)
     return stmt.order_by(SubscriptionProduct.created_at.desc())
@@ -85,8 +92,10 @@ def _subscription_query(agent_id: str | None = None, product_id: str | None = No
 
 async def create_subscription_product(
     session: AsyncSession,
-    owner_agent_id: str,
     *,
+    owner_id: str,
+    owner_type: ParticipantType,
+    provider_agent_id: str,
     name: str,
     description: str = "",
     amount_minor: int,
@@ -97,10 +106,17 @@ async def create_subscription_product(
         raise ValueError("Amount must be positive")
     if billing_interval not in {BillingInterval.week, BillingInterval.month, BillingInterval.once}:
         raise ValueError("billing_interval must be week, month, or once")
+    if not provider_agent_id:
+        raise ValueError("provider_agent_id is required")
+    if owner_type == ParticipantType.agent and provider_agent_id != owner_id:
+        # Invariant: an agent-owned product's wallet is the owner agent.
+        raise ValueError("Agent-owned product provider must be the owner agent")
 
     product = SubscriptionProduct(
         product_id=generate_subscription_product_id(),
-        owner_agent_id=owner_agent_id,
+        owner_id=owner_id,
+        owner_type=owner_type,
+        provider_agent_id=provider_agent_id,
         name=name,
         description=description or "",
         asset_code=asset_code,
@@ -120,17 +136,22 @@ async def create_subscription_product(
 async def list_subscription_products(
     session: AsyncSession,
     *,
-    owner_agent_id: str | None = None,
+    owner_id: str | None = None,
+    owner_type: ParticipantType | None = None,
     include_archived: bool = False,
 ) -> list[SubscriptionProduct]:
-    result = await session.execute(_product_query(owner_agent_id, include_archived))
+    result = await session.execute(
+        _product_query(owner_id=owner_id, owner_type=owner_type, include_archived=include_archived)
+    )
     return list(result.scalars().all())
 
 
 async def archive_subscription_product(
     session: AsyncSession,
     product_id: str,
-    current_agent: str,
+    *,
+    owner_id: str,
+    owner_type: ParticipantType,
 ) -> SubscriptionProduct:
     result = await session.execute(
         select(SubscriptionProduct).where(SubscriptionProduct.product_id == product_id)
@@ -138,7 +159,7 @@ async def archive_subscription_product(
     product = result.scalar_one_or_none()
     if product is None:
         raise ValueError("Subscription product not found")
-    if product.owner_agent_id != current_agent:
+    if product.owner_id != owner_id or product.owner_type != owner_type:
         raise ValueError("Not authorized to archive this product")
     if product.status == SubscriptionProductStatus.archived:
         return product
@@ -218,7 +239,11 @@ async def create_subscription(
         raise ValueError("Subscription product not found")
     if product.status != SubscriptionProductStatus.active:
         raise ValueError("Subscription product is archived")
-    if product.owner_agent_id == subscriber_agent_id:
+    # Self-subscription prevention: an agent can't subscribe to a product it
+    # owns (or that pays into its own wallet).
+    if product.owner_type == ParticipantType.agent and product.owner_id == subscriber_agent_id:
+        raise ValueError("Cannot subscribe to your own product")
+    if product.provider_agent_id == subscriber_agent_id:
         raise ValueError("Cannot subscribe to your own product")
 
     if room_id is not None:
@@ -262,7 +287,7 @@ async def create_subscription(
     tx = await create_transfer(
         session,
         from_owner_id=subscriber_agent_id,
-        to_owner_id=product.owner_agent_id,
+        to_owner_id=product.provider_agent_id,
         amount_minor=product.amount_minor,
         idempotency_key=idempotency_key or f"subscription:first:{subscription_id}",
         reference_type="subscription_charge",
@@ -275,7 +300,7 @@ async def create_subscription(
         subscription_id=subscription_id,
         product_id=product.product_id,
         subscriber_agent_id=subscriber_agent_id,
-        provider_agent_id=product.owner_agent_id,
+        provider_agent_id=product.provider_agent_id,
         room_id=room_id,
         asset_code=product.asset_code,
         amount_minor=product.amount_minor,
@@ -330,7 +355,7 @@ async def _reactivate_subscription(
     tx = await create_transfer(
         session,
         from_owner_id=subscription.subscriber_agent_id,
-        to_owner_id=product.owner_agent_id,
+        to_owner_id=product.provider_agent_id,
         amount_minor=product.amount_minor,
         idempotency_key=idempotency_key or f"subscription:reactivate:{subscription.subscription_id}:{now.isoformat()}",
         reference_type="subscription_charge",

--- a/backend/hub/subscription_schemas.py
+++ b/backend/hub/subscription_schemas.py
@@ -19,7 +19,9 @@ class SubscriptionCreateRequest(BaseModel):
 
 class SubscriptionProductResponse(BaseModel):
     product_id: str
-    owner_agent_id: str
+    owner_id: str
+    owner_type: str
+    provider_agent_id: str
     name: str
     description: str
     asset_code: str

--- a/backend/migrations/031_subscription_products_polymorphic_owner.sql
+++ b/backend/migrations/031_subscription_products_polymorphic_owner.sql
@@ -1,0 +1,75 @@
+-- Migration: Polymorphic owner for subscription_products + provider_agent_id.
+--
+-- Background: PR #352 made rooms polymorphic (owner_id + owner_type can be
+-- ag_* or hu_*) but subscription_products is still agent-only via
+-- owner_agent_id. The dashboard "create product" path 400s for human-owned
+-- rooms because there is no X-Active-Agent header. This migration:
+--
+--   1. Adds owner_id + owner_type to subscription_products, reusing the
+--      existing `participanttype` Postgres enum from migration 024 to stay
+--      consistent with rooms.owner_type.
+--   2. Adds provider_agent_id — the agent wallet that receives subscription
+--      payments. Always an agent. For agent-owned products this equals the
+--      owner; for human-owned products the human picks one of their bots.
+--   3. Backfills agent-owned rows: owner_id = owner_agent_id, owner_type =
+--      'agent', provider_agent_id = owner_agent_id.
+--   4. Replaces the (owner_agent_id, name) uniqueness with a polymorphic
+--      (owner_id, owner_type, name) constraint.
+--   5. Keeps owner_agent_id as a NULLable deprecated mirror so old code
+--      that still reads it on agent-owned products keeps working during
+--      rollout. PR C drops it.
+
+-- ---------------------------------------------------------------------------
+-- 1. Add new columns (nullable initially so backfill can run)
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE subscription_products
+    ADD COLUMN IF NOT EXISTS owner_id VARCHAR(64);
+
+ALTER TABLE subscription_products
+    ADD COLUMN IF NOT EXISTS owner_type participanttype;
+
+ALTER TABLE subscription_products
+    ADD COLUMN IF NOT EXISTS provider_agent_id VARCHAR(32)
+    REFERENCES agents(agent_id);
+
+-- ---------------------------------------------------------------------------
+-- 2. Backfill: every existing product is agent-owned
+-- ---------------------------------------------------------------------------
+
+UPDATE subscription_products
+SET owner_id = owner_agent_id,
+    owner_type = 'agent',
+    provider_agent_id = owner_agent_id
+WHERE owner_id IS NULL;
+
+-- ---------------------------------------------------------------------------
+-- 3. Tighten constraints
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE subscription_products
+    ALTER COLUMN owner_id SET NOT NULL,
+    ALTER COLUMN owner_type SET NOT NULL,
+    ALTER COLUMN provider_agent_id SET NOT NULL;
+
+-- owner_agent_id retained as deprecated read-only mirror — make NULLable so
+-- future human-owned inserts can leave it blank.
+ALTER TABLE subscription_products
+    ALTER COLUMN owner_agent_id DROP NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- 4. Swap uniqueness constraint
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE subscription_products
+    DROP CONSTRAINT IF EXISTS uq_subscription_product_owner_name;
+
+ALTER TABLE subscription_products
+    ADD CONSTRAINT uq_subscription_product_owner_name
+    UNIQUE (owner_id, owner_type, name);
+
+CREATE INDEX IF NOT EXISTS ix_subscription_products_owner
+    ON subscription_products(owner_id, owner_type);
+
+CREATE INDEX IF NOT EXISTS ix_subscription_products_provider
+    ON subscription_products(provider_agent_id);

--- a/backend/migrations/032_drop_subscription_products_owner_agent_id.sql
+++ b/backend/migrations/032_drop_subscription_products_owner_agent_id.sql
@@ -1,0 +1,9 @@
+-- Migration: Drop the deprecated subscription_products.owner_agent_id mirror.
+--
+-- Migration 031 added polymorphic (owner_id, owner_type) + provider_agent_id
+-- and kept owner_agent_id as a NULLable read-only mirror to ease rollout.
+-- All application code now reads owner_id / owner_type. This migration
+-- removes the mirror column.
+
+ALTER TABLE subscription_products
+    DROP COLUMN IF EXISTS owner_agent_id;

--- a/backend/tests/test_app/test_app_subscriptions.py
+++ b/backend/tests/test_app/test_app_subscriptions.py
@@ -179,7 +179,9 @@ async def test_create_product(client, seed_data):
     assert data["amount_minor"] == "1000"
     assert data["billing_interval"] == "month"
     assert data["status"] == "active"
-    assert data["owner_agent_id"] == seed_data["owner_agent_id"]
+    assert data["owner_id"] == seed_data["owner_agent_id"]
+    assert data["owner_type"] == "agent"
+    assert data["provider_agent_id"] == seed_data["owner_agent_id"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_app/test_app_user_agents.py
+++ b/backend/tests/test_app/test_app_user_agents.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock, patch
 
 from hub.enums import (
     BillingInterval,
+    ParticipantType,
     SubscriptionProductStatus,
     SubscriptionStatus,
     TxStatus,
@@ -410,7 +411,9 @@ async def test_unbind_agent_rejects_product_with_active_subscribers(
     db_session.add(
         SubscriptionProduct(
             product_id="sp_test001",
-            owner_agent_id="ag_agent001",
+            owner_id="ag_agent001",
+            owner_type=ParticipantType.agent,
+            provider_agent_id="ag_agent001",
             name="Paid Room",
             amount_minor=100,
             billing_interval=BillingInterval.month,
@@ -460,7 +463,9 @@ async def test_unbind_agent_cancels_subscriber_subscriptions(
     db_session.add(
         SubscriptionProduct(
             product_id="sp_provider",
-            owner_agent_id="ag_provider",
+            owner_id="ag_provider",
+            owner_type=ParticipantType.agent,
+            provider_agent_id="ag_provider",
             name="Provider Plan",
             amount_minor=100,
             billing_interval=BillingInterval.month,

--- a/backend/tests/test_app/test_human_owner_subscription.py
+++ b/backend/tests/test_app/test_human_owner_subscription.py
@@ -1,0 +1,381 @@
+"""Tests for human-as-owner subscription product / migrate-plan flows.
+
+Covers the cases enumerated in
+``docs/human-owner-subscription-redesign.md`` §5 (PR A unit tests):
+
+- human-owned room: human directly changes plan (no identity switch) → 200
+- agent-owned room: human-as-bound-user changes plan (no identity switch) → 200
+- agent-owned room: cross-user actor changes plan → 403
+- human-owned room: migrate-plan without ``provider_agent_id`` → 400
+- human-owned room: ``provider_agent_id`` not owned by ctx.user → 403
+- humans BFF PATCH with invalid product_id → 404; non-owner product → 403
+- humans BFF dissolve pre-cancels bound subscriptions
+"""
+
+from __future__ import annotations
+
+import datetime
+import uuid
+from unittest.mock import AsyncMock
+
+import jwt
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from hub.enums import (
+    BillingInterval,
+    MessagePolicy,
+    ParticipantType,
+    RoomJoinPolicy,
+    RoomRole,
+    RoomVisibility,
+    SubscriptionProductStatus,
+    SubscriptionStatus,
+)
+from hub.models import (
+    Agent,
+    AgentSubscription,
+    Base,
+    Role,
+    Room,
+    RoomMember,
+    SubscriptionProduct,
+    User,
+    UserRole,
+)
+
+TEST_SUPABASE_SECRET = "test-supabase-jwt-secret-for-unit-tests"
+
+
+def _token(sub: str) -> str:
+    payload = {
+        "sub": sub,
+        "aud": "authenticated",
+        "exp": datetime.datetime.now(datetime.timezone.utc)
+        + datetime.timedelta(hours=1),
+        "iss": "supabase",
+    }
+    return jwt.encode(payload, TEST_SUPABASE_SECRET, algorithm="HS256")
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    from tests.test_app.conftest import create_test_engine
+
+    engine = create_test_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client(db_session: AsyncSession, monkeypatch):
+    import hub.config
+    monkeypatch.setattr(hub.config, "SUPABASE_JWT_SECRET", TEST_SUPABASE_SECRET)
+    monkeypatch.setattr(hub.config, "BETA_GATE_ENABLED", False)
+    import app.auth
+    monkeypatch.setattr(app.auth, "SUPABASE_JWT_SECRET", TEST_SUPABASE_SECRET)
+
+    from hub.database import get_db
+    from hub.main import app
+
+    async def _override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.state.http_client = AsyncMock()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def world(db_session: AsyncSession):
+    """Two users, each with one bound active agent.
+
+    user_a owns ag_a01 (bound), and is the human owner for one human-owned
+    room and the agent-owner-via-bot for one agent-owned room.
+    user_b owns ag_b01 (bound), unrelated.
+    """
+    role = Role(name="member", display_name="Member")
+    db_session.add(role)
+    await db_session.flush()
+
+    user_a = User(supabase_user_id=uuid.uuid4(), display_name="Alice", email="a@x.com")
+    user_b = User(supabase_user_id=uuid.uuid4(), display_name="Bob", email="b@x.com")
+    db_session.add_all([user_a, user_b])
+    await db_session.flush()
+    db_session.add_all([
+        UserRole(user_id=user_a.id, role_id=role.id),
+        UserRole(user_id=user_b.id, role_id=role.id),
+    ])
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    ag_a = Agent(
+        agent_id="ag_a01",
+        display_name="Alice Bot",
+        message_policy=MessagePolicy.open,
+        user_id=user_a.id,
+        is_default=True,
+        claimed_at=now,
+        status="active",
+    )
+    ag_b = Agent(
+        agent_id="ag_b01",
+        display_name="Bob Bot",
+        message_policy=MessagePolicy.open,
+        user_id=user_b.id,
+        is_default=True,
+        claimed_at=now,
+        status="active",
+    )
+    db_session.add_all([ag_a, ag_b])
+    await db_session.flush()
+
+    # Human-owned room: alice (hu_*) is the owner.
+    human_room = Room(
+        room_id="rm_human01",
+        name="Alice's Human Room",
+        description="",
+        owner_id=user_a.human_id,
+        owner_type=ParticipantType.human,
+        visibility=RoomVisibility.public,
+        join_policy=RoomJoinPolicy.open,
+    )
+    # Agent-owned room: ag_a01 is the owner. Alice can manage as bound user.
+    agent_room = Room(
+        room_id="rm_agent01",
+        name="Alice Bot's Agent Room",
+        description="",
+        owner_id="ag_a01",
+        owner_type=ParticipantType.agent,
+        visibility=RoomVisibility.public,
+        join_policy=RoomJoinPolicy.open,
+    )
+    db_session.add_all([human_room, agent_room])
+    await db_session.flush()
+
+    db_session.add_all([
+        RoomMember(
+            room_id="rm_human01",
+            agent_id=user_a.human_id,
+            participant_type=ParticipantType.human,
+            role=RoomRole.owner,
+        ),
+        RoomMember(
+            room_id="rm_agent01",
+            agent_id="ag_a01",
+            participant_type=ParticipantType.agent,
+            role=RoomRole.owner,
+        ),
+    ])
+    await db_session.commit()
+    await db_session.refresh(user_a)
+    await db_session.refresh(user_b)
+
+    return {
+        "user_a": user_a,
+        "user_b": user_b,
+        "human_id_a": user_a.human_id,
+        "ag_a": "ag_a01",
+        "ag_b": "ag_b01",
+        "token_a": _token(str(user_a.supabase_user_id)),
+        "token_b": _token(str(user_b.supabase_user_id)),
+        "human_room": "rm_human01",
+        "agent_room": "rm_agent01",
+    }
+
+
+def _h(token: str, agent_id: str | None = None) -> dict:
+    headers = {"Authorization": f"Bearer {token}"}
+    if agent_id:
+        headers["X-Active-Agent"] = agent_id
+    return headers
+
+
+# ---------------------------------------------------------------------------
+# migrate-plan
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_human_owned_room_human_can_migrate_plan(client: AsyncClient, world: dict):
+    """Human-owned room: viewer is the human owner with no X-Active-Agent.
+    Must succeed when ``provider_agent_id`` points to one of their bound bots."""
+    resp = await client.post(
+        f"/api/dashboard/rooms/{world['human_room']}/subscription/migrate-plan",
+        headers=_h(world["token_a"]),  # no X-Active-Agent
+        json={
+            "amount_minor": "1000",
+            "billing_interval": "week",
+            "provider_agent_id": world["ag_a"],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["product_id"].startswith("sp_")
+    assert body["room"]["required_subscription_product_id"] == body["product_id"]
+
+
+@pytest.mark.asyncio
+async def test_agent_owned_room_bound_user_can_migrate_plan_without_x_active_agent(
+    client: AsyncClient, world: dict, db_session: AsyncSession,
+):
+    """Agent-owned room: viewer doesn't switch to the owner agent — they're
+    still that agent's bound user, so capability resolves to owner."""
+    resp = await client.post(
+        f"/api/dashboard/rooms/{world['agent_room']}/subscription/migrate-plan",
+        headers=_h(world["token_a"]),  # no X-Active-Agent
+        json={"amount_minor": "500", "billing_interval": "month"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # Provider for an agent-owned room is forced to the owner agent.
+    new_pid = body["product_id"]
+    product = (
+        await db_session.execute(
+            select(SubscriptionProduct).where(SubscriptionProduct.product_id == new_pid)
+        )
+    ).scalar_one()
+    assert product.owner_id == world["ag_a"]
+    assert product.owner_type == ParticipantType.agent
+    assert product.provider_agent_id == world["ag_a"]
+
+
+@pytest.mark.asyncio
+async def test_agent_owned_room_other_user_forbidden(client: AsyncClient, world: dict):
+    """Agent-owned room: a different user (who doesn't own the bot) → 403."""
+    resp = await client.post(
+        f"/api/dashboard/rooms/{world['agent_room']}/subscription/migrate-plan",
+        headers=_h(world["token_b"]),
+        json={"amount_minor": "500", "billing_interval": "month"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_human_owned_room_missing_provider_agent_id(client: AsyncClient, world: dict):
+    """Human-owned room: must reject migrate-plan without ``provider_agent_id``."""
+    resp = await client.post(
+        f"/api/dashboard/rooms/{world['human_room']}/subscription/migrate-plan",
+        headers=_h(world["token_a"]),
+        json={"amount_minor": "1000", "billing_interval": "week"},
+    )
+    assert resp.status_code == 400
+    assert "provider_agent_id" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_human_owned_room_provider_agent_not_owned(client: AsyncClient, world: dict):
+    """Human-owned room: ``provider_agent_id`` belongs to a different user → 403."""
+    resp = await client.post(
+        f"/api/dashboard/rooms/{world['human_room']}/subscription/migrate-plan",
+        headers=_h(world["token_a"]),
+        json={
+            "amount_minor": "1000",
+            "billing_interval": "week",
+            "provider_agent_id": world["ag_b"],  # owned by user_b
+        },
+    )
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Human BFF PATCH /api/humans/me/rooms/{id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_humans_patch_required_product_404_for_unknown(client: AsyncClient, world: dict):
+    resp = await client.patch(
+        f"/api/humans/me/rooms/{world['human_room']}",
+        headers=_h(world["token_a"]),
+        json={"required_subscription_product_id": "sp_doesnotexist"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_humans_patch_required_product_403_when_owner_mismatch(
+    client: AsyncClient, world: dict, db_session: AsyncSession,
+):
+    """A product owned by ag_b cannot be attached to alice's human-owned room."""
+    db_session.add(
+        SubscriptionProduct(
+            product_id="sp_othersown",
+            owner_id=world["ag_b"],
+            owner_type=ParticipantType.agent,
+            provider_agent_id=world["ag_b"],
+            name="Bob Plan",
+            amount_minor=100,
+            billing_interval=BillingInterval.month,
+            status=SubscriptionProductStatus.active,
+        )
+    )
+    await db_session.commit()
+    resp = await client.patch(
+        f"/api/humans/me/rooms/{world['human_room']}",
+        headers=_h(world["token_a"]),
+        json={"required_subscription_product_id": "sp_othersown"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_humans_dissolve_precancels_bound_subscriptions(
+    client: AsyncClient, world: dict, db_session: AsyncSession,
+):
+    """Dissolving a human-owned room via /api/humans/me/rooms/{id} should
+    pre-cancel any bound subscriptions before the FK SET NULL kicks in."""
+    now = datetime.datetime.now(datetime.timezone.utc)
+    db_session.add(
+        SubscriptionProduct(
+            product_id="sp_paid",
+            owner_id=world["human_id_a"],
+            owner_type=ParticipantType.human,
+            provider_agent_id=world["ag_a"],
+            name="Alice Paid",
+            amount_minor=1000,
+            billing_interval=BillingInterval.week,
+            status=SubscriptionProductStatus.active,
+        )
+    )
+    db_session.add(
+        AgentSubscription(
+            subscription_id="sub_active",
+            product_id="sp_paid",
+            subscriber_agent_id=world["ag_b"],
+            provider_agent_id=world["ag_a"],
+            room_id=world["human_room"],
+            amount_minor=1000,
+            billing_interval=BillingInterval.week,
+            status=SubscriptionStatus.active,
+            current_period_start=now,
+            current_period_end=now + datetime.timedelta(days=7),
+            next_charge_at=now + datetime.timedelta(days=7),
+        )
+    )
+    await db_session.commit()
+
+    resp = await client.delete(
+        f"/api/humans/me/rooms/{world['human_room']}",
+        headers=_h(world["token_a"]),
+    )
+    assert resp.status_code == 200, resp.text
+
+    sub = (
+        await db_session.execute(
+            select(AgentSubscription).where(AgentSubscription.subscription_id == "sub_active")
+        )
+    ).scalar_one()
+    assert sub.status == SubscriptionStatus.cancelled
+    assert sub.cancelled_at is not None

--- a/backend/tests/test_subscription.py
+++ b/backend/tests/test_subscription.py
@@ -217,7 +217,9 @@ async def test_create_product_and_list(client: AsyncClient):
         amount_minor=10000,
         billing_interval="week",
     )
-    assert product["owner_agent_id"] == agent_id
+    assert product["owner_id"] == agent_id
+    assert product["owner_type"] == "agent"
+    assert product["provider_agent_id"] == agent_id
     assert product["status"] == "active"
     assert product["billing_interval"] == "week"
 

--- a/docs/human-owner-subscription-redesign.md
+++ b/docs/human-owner-subscription-redesign.md
@@ -1,0 +1,342 @@
+# Human-as-owner: subscription products + room admin
+
+> 状态: 设计稿 v2.1 (评审反馈收敛)
+> 范围: backend (schema + service + auth) + frontend (RoomSettingsModal)
+> 前置: `docs/room-subscription-redesign.md` (PR #352, 已合并)
+> 日期: 2026-04-27
+
+## 修订记录
+
+**v2.1 (二轮评审反馈修复)**:
+- migration 031 `owner_type` 从 `VARCHAR(16)` 改为复用既有 `participanttype` Postgres enum (与 migration 024 / `Room.owner_type` 一致；DB 层有合法值约束) — §3.2.1
+- `viewer_can_admin_room` 的 `RoomMember` admin fallback 显式加 `participant_type == ParticipantType.agent` 过滤，不再仅靠 ID 前缀做区分 — §3.4
+
+**v2 (一轮评审反馈修复)** — 解决 v1 的 6 个问题：
+1. `provider_agent_id` 不再依赖 `X-Active-Agent` (human 路径根本不发) — 改成 body 必填 + `Agent.user_id == ctx.user_id` 校验 (§3.4 / §3.5 / §7)
+2. `PATCH /api/dashboard/rooms/{id}` 不能只换 owner-only 鉴权：路由前置 `RoomMember.agent_id == active_agent` 会先把 human 挡掉。改成切 `require_user_with_optional_agent` + `viewer_can_admin_room` 返回 `"owner"|"admin"|None` 分级 (§3.4 / §3.5)
+3. `PATCH /api/humans/me/rooms/{id}` (humans BFF) 也直接赋值 `required_subscription_product_id` 无校验 — 同 PR #352 §5.7 的安全洞，PR A 必须一起堵 (§3.5 / PR A scope)
+4. `DELETE /hub/rooms/{id}` 是 agent claim auth，没有 `ctx.user_id` — 不能 "同上" 复用 helper。新增 `DELETE /api/dashboard/rooms/{id}` BFF 路由，hub 路由保留 agent-only (§3.5)
+5. `subscription_products.owner_agent_id` 不能 "兼容留一阵" — `list_*` / `archive_*` / `_product_response` / dashboard 校验都读它，human-owned 产品会瞬间不可管理。PR A 必须把所有读路径切到 `(owner_id, owner_type)` (§5 PR A scope)
+6. `RoomSettingsModal` 没有 `room.owner_id` / `owner_type` props，没法决定显示「收款 bot」下拉 — PR B 要补 props + 所有调用点 (§3.6 / PR B scope)
+
+## 1. 背景与问题
+
+PR #352 落地后暴露两个 UX/权限问题：
+
+1. **`POST /api/subscriptions/products` 强制 `X-Active-Agent`**
+   订阅产品 schema 是 agent-only (`subscription_products.owner_agent_id` 是 agent 外键)，但 dashboard 里很多场景下用户是以 Human 身份操作 (e.g. 自己创建的房间，owner 是 hu_*)，浏览器请求没带 `X-Active-Agent`，直接 400。
+
+2. **`migrate-plan` / room owner 校验只认 `active_agent_id == room.owner_id`**
+   `room.owner_id` 在 migration 024 后已经是 polymorphic (`ag_*` 或 `hu_*`)。一个 human 用户可以拥有多个 agent，那些 agent 当 room owner 的房间，human 在不切到那个 agent 的情况下应该也能改设置 (它们终归是这个用户的资产)。当前实现要求 viewer 严格切到 owner agent，UX 很别扭。
+
+## 2. 设计目标
+
+| # | 目标 |
+|---|------|
+| G1 | Human 可以创建/拥有订阅产品 |
+| G2 | Human 可以管理 (改价 / 关停 / 解散) 自己 bot 当 owner 的房间，不需要切身份 |
+| G3 | 钱流暂不变 — 转账 from/to 仍只支持 agent-as-recipient (人钱包通路本期不做) |
+| G4 | Schema 改动一次到位，避免反复 migration |
+| G5 | 既有 agent-owned 数据零迁移成本 |
+
+## 3. 设计
+
+### 3.1 一句话
+
+> Subscription product 加 polymorphic owner，钱流仍走 agent；room owner 鉴权改为「viewer 是 room.owner_id 本人 OR viewer 是 room.owner agent 的所属 user」。
+
+### 3.2 Schema 改动 (migration 031)
+
+#### 3.2.1 `subscription_products`
+
+参照 `rooms` (migration 024) 的 polymorphic 写法：
+
+```sql
+-- owner_type reuses the existing `participanttype` Postgres enum created
+-- by migration 024 (rooms / contacts / blocks). Stay consistent with
+-- Room.owner_type so SQLAlchemy `Enum(ParticipantType, name="participanttype")`
+-- maps cleanly, and the DB enforces legal values at the column level.
+ALTER TABLE subscription_products
+    ADD COLUMN owner_id VARCHAR(64),
+    ADD COLUMN owner_type participanttype,
+    ADD COLUMN provider_agent_id VARCHAR(32) REFERENCES agents(agent_id);
+
+-- Backfill: agent-owned products' owner_agent_id remains the source of truth
+UPDATE subscription_products
+SET owner_id = owner_agent_id,
+    owner_type = 'agent',
+    provider_agent_id = owner_agent_id
+WHERE owner_id IS NULL;
+
+ALTER TABLE subscription_products
+    ALTER COLUMN owner_id SET NOT NULL,
+    ALTER COLUMN owner_type SET NOT NULL,
+    ALTER COLUMN provider_agent_id SET NOT NULL;
+
+-- Drop the old uniqueness constraint, add a polymorphic version
+ALTER TABLE subscription_products DROP CONSTRAINT uq_subscription_product_owner_name;
+ALTER TABLE subscription_products
+    ADD CONSTRAINT uq_subscription_product_owner_name UNIQUE (owner_id, owner_type, name);
+
+CREATE INDEX ix_subscription_products_owner ON subscription_products(owner_id, owner_type);
+CREATE INDEX ix_subscription_products_provider ON subscription_products(provider_agent_id);
+
+-- owner_agent_id retained as a deprecated read-only mirror (NULLable from now on)
+-- to keep old code paths reading agents-only products non-broken during rollout.
+ALTER TABLE subscription_products ALTER COLUMN owner_agent_id DROP NOT NULL;
+```
+
+**字段含义**:
+
+| 列 | 语义 |
+|---|---|
+| `owner_id` + `owner_type` | 谁能管理这个产品 (改价 / 归档)。可以是 hu_* 或 ag_* |
+| `provider_agent_id` | 钱打到哪个 agent 的钱包。**永远是 agent**。当 owner 是 human 时，前端创建产品时必须指定 (一般是该 human 的某个 bound agent) |
+| `owner_agent_id` (deprecated) | 兼容旧代码用，新代码读 `owner_id`/`owner_type` |
+
+#### 3.2.2 `agent_subscriptions` 不动
+
+`provider_agent_id` 已经是 agent (= `subscription_products.provider_agent_id` 的快照)。继续。
+
+`subscriber_agent_id` 不动 — 订阅者本期仍只支持 agent (human 订阅是另一个独立设计 §6)。
+
+### 3.3 Service 层
+
+```python
+# backend/hub/services/subscriptions.py
+
+async def create_subscription_product(
+    session,
+    *,
+    owner_id: str,
+    owner_type: ParticipantType,
+    provider_agent_id: str,  # 新增必填
+    name: str,
+    description: str = "",
+    amount_minor: int,
+    billing_interval: BillingInterval,
+    asset_code: str = "COIN",
+) -> SubscriptionProduct:
+    if owner_type == ParticipantType.human and provider_agent_id is None:
+        raise ValueError("Human-owned products must specify a provider_agent_id")
+    if owner_type == ParticipantType.agent and provider_agent_id != owner_id:
+        # invariant: agent-owned products always have themselves as provider
+        raise ValueError("Agent-owned product provider must be the owner agent")
+    ...
+```
+
+`_charge_subscription` 已经按 `subscription.provider_agent_id` 转账，不需要改。
+
+### 3.4 鉴权 helper
+
+新加 `app/auth_room.py`:
+
+```python
+async def viewer_can_admin_room(
+    db: AsyncSession,
+    ctx: RequestContext,
+    room: Room,
+) -> Literal["owner", "admin", None]:
+    """Return the strongest capability the JWT viewer has on this room.
+
+    "owner" — viewer can do owner-only ops (visibility, plan, dissolve, ...)
+    "admin" — viewer is a RoomMember with role admin (can edit basics only)
+    None    — no admin/owner capability
+
+    Owner-cap cases:
+    - viewer is acting AS the owner agent (X-Active-Agent == room.owner_id)
+    - room is human-owned and viewer.human_id == room.owner_id
+    - room is agent-owned and that agent's user_id == ctx.user_id
+      (transitive — viewer's user owns the bot that owns the room)
+
+    Admin-cap: the legacy RoomMember.role == 'admin' check, scoped to the
+    viewer's active agent. Humans don't get admin via membership today.
+    """
+    # Owner cases first
+    if room.owner_type == ParticipantType.agent:
+        if ctx.active_agent_id and ctx.active_agent_id == room.owner_id:
+            return "owner"
+        agent = (await db.execute(
+            select(Agent).where(Agent.agent_id == room.owner_id)
+        )).scalar_one_or_none()
+        if agent is not None and agent.user_id == ctx.user_id:
+            return "owner"
+    elif room.owner_type == ParticipantType.human:
+        if ctx.human_id and ctx.human_id == room.owner_id:
+            return "owner"
+
+    # Admin via RoomMember (agent path only — preserve current behavior).
+    # Filter on participant_type=agent explicitly: RoomMember is polymorphic
+    # since migration 024, and ID prefixes alone shouldn't be relied on as
+    # a discriminator inside auth code.
+    if ctx.active_agent_id:
+        member = (await db.execute(
+            select(RoomMember).where(
+                RoomMember.room_id == room.room_id,
+                RoomMember.agent_id == ctx.active_agent_id,
+                RoomMember.participant_type == ParticipantType.agent,
+            )
+        )).scalar_one_or_none()
+        if member and member.role in (RoomRole.owner, RoomRole.admin):
+            return "owner" if member.role == RoomRole.owner else "admin"
+
+    return None
+
+
+async def resolve_provider_agent_for_room(
+    db: AsyncSession,
+    ctx: RequestContext,
+    room: Room,
+    *,
+    requested_provider_agent_id: str | None,
+) -> str:
+    """Pick the agent that should receive subscription payments for this room.
+
+    - room is agent-owned → the owner agent (request body field is ignored)
+    - room is human-owned → REQUIRES request body to specify
+      `provider_agent_id`, which must be an active agent owned by ctx.user.
+      We do NOT fall back to X-Active-Agent — the human path doesn't send it.
+    """
+    if room.owner_type == ParticipantType.agent:
+        return room.owner_id
+    if not requested_provider_agent_id:
+        raise HTTPException(
+            status_code=400,
+            detail="provider_agent_id is required for human-owned rooms",
+        )
+    agent = (await db.execute(
+        select(Agent).where(Agent.agent_id == requested_provider_agent_id)
+    )).scalar_one_or_none()
+    if agent is None or agent.user_id != ctx.user_id:
+        raise HTTPException(
+            status_code=403,
+            detail="Provider agent does not belong to this user",
+        )
+    if agent.status != "active":
+        raise HTTPException(status_code=400, detail="Provider agent is not active")
+    return requested_provider_agent_id
+```
+
+### 3.5 端点改动
+
+**鉴权依赖一律切到 `require_user_with_optional_agent`** (Supabase JWT 必填，
+`X-Active-Agent` 可选)，再用 `viewer_can_admin_room` 做能力分级。这样
+human identity 下 (没发 `X-Active-Agent`) 也能通过 `room.owner_type=='human'` 或
+`agent.user_id == ctx.user_id` 这两条路径拿到 `owner` 能力。
+
+| 端点 | 改动 |
+|---|---|
+| `POST /api/subscriptions/products` | 仍 require_active_agent — 跨房间通行证 self-serve 路径，agent 视角创建 |
+| `POST /api/dashboard/rooms/{id}/subscription/migrate-plan` | 切到 `require_user_with_optional_agent`；要 `viewer_can_admin_room == "owner"`；body 新增可选 `provider_agent_id`；human-owned room 必填，按 `resolve_provider_agent_for_room` 校验；agent-owned 忽略 |
+| `PATCH /api/dashboard/rooms/{id}` (dashboard.py) | 切到 `require_user_with_optional_agent`；先算 `cap = viewer_can_admin_room`；fields 分两组：基础字段 (`name/description/rule`) 要 `cap in {owner, admin}`，owner-only 字段 (`visibility / join_policy / default_send / default_invite / max_members / slow_mode_seconds / required_subscription_product_id`) 要 `cap == "owner"`。**特别**：`required_subscription_product_id` 仍要走 §5.7 PR #352 的产品有效性 + ownership 校验，但 ownership 改成 `product.owner_id == room.owner_id AND product.owner_type == room.owner_type` |
+| `PATCH /api/humans/me/rooms/{id}` (humans.py BFF) | **新增同样的校验**：(a) 沿用既有 human-as-owner 鉴权；(b) `required_subscription_product_id` 字段加产品存在 / active / ownership 校验，并在 clear 时做 §3.6 的 legacy `room_id` backfill (与 dashboard PATCH 一致)。这是 PR #352 的同类型缺口，必须一起堵 |
+| `DELETE /api/dashboard/rooms/{id}` (新增 BFF) | 新建 BFF dissolve 路由，复用 `viewer_can_admin_room == "owner"` 鉴权 + PR #352 已落地的 pre-cancel 订阅逻辑。前端从此调这个，不再调 hub |
+| `DELETE /hub/rooms/{id}` (hub agent JWT) | 保持不变 — agent claim auth，agent-token 持有人 == 当前 owner agent 才能解散；human 通路走新增的 BFF 端点 |
+| `POST /api/dashboard/rooms/{id}/leave` 等 member-only | 不变 |
+
+### 3.6 Frontend
+
+**`RoomSettingsModal`**:
+
+- **加 props**：调用方必须传 `roomOwnerId: string` 和 `roomOwnerType: "human" | "agent"`，否则没法决定要不要显示 provider agent 下拉。所有调用点都要补 (chat 列表 / discover / explore card / 其它能打开 modal 的位置)。备选：如果 props 改动面太大，modal mount 时 fetch 一次 `GET /api/dashboard/rooms/{id}` 拿 owner metadata。**倾向 props**，已有数据复用避免多一次请求
+- **删 first-time-enable 两步分支** (`createSubscriptionProduct + PATCH room`) — 一律 `migrate-plan`，原子，没有 `X-Active-Agent` 歧义
+- **human-owned 房间**：订阅区出现「收款 bot」下拉
+  - 数据：`api.getMyAgents()`，过滤 `status == "active"`
+  - 默认值：viewer 当前 active_agent (若属于此 user)，否则首个 active agent
+  - 选中后 `migrateRoomSubscriptionPlan` body 带 `provider_agent_id`
+- **agent-owned 但 viewer 没切到该 agent**：订阅区可编辑 (新鉴权放行)，不再硬要求切身份
+- **dissolve 按钮**：human 模式下也调用新的 `DELETE /api/dashboard/rooms/{id}` (不再依赖 hub agent JWT 路径)
+
+`migrate-plan` body schema:
+
+```typescript
+migrateRoomSubscriptionPlan(roomId, {
+  amount_minor: "1000",
+  billing_interval: "week",
+  provider_agent_id?: string,  // human-owned 必填，agent-owned 忽略
+})
+```
+
+## 4. 与已合并 PR 的兼容
+
+- 现有 agent-owned 产品：migration 031 backfill 把 `owner_id = owner_agent_id, owner_type='agent', provider_agent_id = owner_agent_id`，行为不变
+- PR #352 的 `room_id` 反查路径 / mismatch cancel：完全不受影响
+- PR #352 frontend 的 `upsertRoomPlan` 两步分支：删除，改为一律 migrate-plan
+
+## 5. 任务拆分
+
+为了方便 review，建议两个 PR 并行 + 一个串联收尾：
+
+### PR A — Backend schema + service + auth (规模较大)
+
+**Schema / model**
+- [ ] migration 031: `subscription_products` polymorphic owner (`owner_id` + `owner_type`) + 新增 `provider_agent_id` + backfill (`owner_id=owner_agent_id, owner_type='agent', provider_agent_id=owner_agent_id`)
+- [ ] `SubscriptionProduct` model 加 `owner_id` / `owner_type` / `provider_agent_id`；`owner_agent_id` 列**保留但全部代码不再读**（PR C 收尾删列）
+
+**Service 层 — 全量切到 owner_id/owner_type 读路径** (Finding 5)
+- [ ] `create_subscription_product(owner_id, owner_type, provider_agent_id, ...)` 新签名
+- [ ] `list_subscription_products(owner_id=, owner_type=)` 改按 polymorphic 过滤
+- [ ] `archive_subscription_product` 的 `owner_agent_id == current_agent` 校验 → 改为按 owner_id+owner_type
+- [ ] `_product_response` 改返回 `owner_id` / `owner_type` 字段（也保留 `owner_agent_id` 老字段做向后兼容 — 老前端读老字段不报错；human-owned 时该字段为 NULL）
+- [ ] `_product_query` / 其它内部 helper 同步迁移
+- [ ] dashboard 的「product 必须属于 room owner」校验改为对比 `(owner_id, owner_type)`
+- [ ] migrate-plan 归档老 product 的逻辑：human-owned product 的归档不能依赖 `current_agent` 校验，改用 polymorphic owner 比对
+
+**Auth helpers**
+- [ ] 新建 `app/auth_room.py`：`viewer_can_admin_room` (返回 `"owner"|"admin"|None`) + `resolve_provider_agent_for_room` (从 body 读，不依赖 X-Active-Agent — Finding 1)
+
+**端点鉴权改造**
+- [ ] `POST /api/dashboard/rooms/{id}/subscription/migrate-plan`: 切 `require_user_with_optional_agent` + `viewer_can_admin_room == "owner"` + body 加 `provider_agent_id`
+- [ ] `PATCH /api/dashboard/rooms/{id}`: 切 `require_user_with_optional_agent` + 拆「基础字段 admin/owner」/「owner-only 字段 owner」两套门 (Finding 2)
+- [ ] `PATCH /api/humans/me/rooms/{id}` (humans.py BFF): **补齐** `required_subscription_product_id` 校验 (产品存在 / active / 属于 room owner) + clear-paid 的 legacy room_id backfill (Finding 3) — 与 dashboard PATCH 行为一致
+- [ ] **新增** `DELETE /api/dashboard/rooms/{id}` (BFF): 鉴权 = `viewer_can_admin_room == "owner"`，复用 PR #352 的 pre-cancel 订阅逻辑 (Finding 4)
+- [ ] `DELETE /hub/rooms/{id}`: **不动** — 保留 agent-token-only 语义，human 走 BFF 新路由
+
+**单测**
+- [ ] human-owned room: human 直接改价 (不切 identity) → 200
+- [ ] agent-owned room: human-as-bound-user 改价 (不切 identity) → 200
+- [ ] agent-owned room: 跨用户 (非 owner、非 bound) 改价 → 403
+- [ ] human-owned room: migrate-plan 不带 `provider_agent_id` → 400
+- [ ] human-owned room: `provider_agent_id` 不属于 ctx.user → 403
+- [ ] human BFF PATCH 设置无效 product_id → 404；非 owner 的 product → 403 (Finding 3 回归)
+- [ ] human BFF dissolve via 新 BFF 路由 → 订阅被 pre-cancel
+- [ ] hub `DELETE /rooms/{id}` agent-token (持有 owner agent token) → 200 (现有行为不破)
+
+### PR B — Frontend (依赖 A)
+- [ ] `RoomSettingsModal` props 新增 `roomOwnerId: string` + `roomOwnerType: "human" | "agent"`，**所有调用点都补齐** (Finding 6)：
+  - `frontend/src/components/dashboard/ChatHeader*` / `RoomHeader*` (打开 modal 的入口)
+  - 任何其它打开 modal 的地方 — 在 PR 描述里枚举确认
+  - 数据来源：chat store 的 room 对象已经有 `owner_id` / `owner_type` 字段 (后端已下发)，直接透传
+- [ ] `migrateRoomSubscriptionPlan` 签名加可选 `provider_agent_id`
+- [ ] `useDashboardSubscriptionStore.upsertRoomPlan` 删 first-time 两步分支，一律 `migrateRoomSubscriptionPlan`
+- [ ] `RoomSettingsModal`：
+  - human-owned room → 显示「收款 bot」下拉，必选；调用 migrate-plan 时带 `provider_agent_id`
+  - agent-owned room → 不再因 active agent 不匹配而锁订阅区
+  - dissolve 按钮调用新的 `DELETE /api/dashboard/rooms/{id}` (而不是 hub)
+- [ ] i18n: "收款机器人" / "Receiving bot" 文案 (en + zh)
+- [ ] 防御性：如果 `roomOwnerType` 缺失，订阅区显示「需要刷新」提示而不是猜，避免误把 human 当 agent 处理
+
+### PR C — 收尾 (依赖 A+B 都合)
+- [ ] 删除 `SubscriptionProduct.owner_agent_id` 列 (migration 032)
+- [ ] 任何残留 `owner_agent_id` 引用清理
+
+## 6. 不在本期范围
+
+- **Human 作为订阅者**: `agent_subscriptions.subscriber_agent_id` 仍 agent-only。Human 自己刷卡订阅是另一个设计 (要先打通 human 钱包 → human → agent 转账)
+- **Human-owned 产品的钱进 human 钱包**: 本期 provider 必须是 agent (= human 的某个 bot)
+- **跨用户产品共管**: 一个产品仍恰好一个 owner
+
+## 7. 待确认 (v2 收敛后)
+
+- [ ] PR A/B 并行 (用户已确认 §1)，PR C 收尾删 `owner_agent_id` 列
+- [x] 前端 human-owned 强制让用户显式选 provider bot — 静默用 active agent 易踩雷 (一旦 active 不在该 user 名下就 403)，且本期 active agent 在 human 模式下根本不发
+- [ ] **新待确认**：humansApi PATCH 是否要支持 `required_subscription_product_id` 字段？历史上能写但没校验。如果业务上允许 human 直接挂别人的产品到自己房间，那是 bug；否则就严校验。**倾向**：严校验 (与 dashboard PATCH 对齐)
+- [ ] **新待确认**：hub `DELETE /rooms/{id}` 是否最终也想删？目前各 daemon / agent CLI 还在用。**倾向**：保留，只是 frontend 不再调它
+
+## 8. 参考
+
+- `docs/room-subscription-redesign.md` — 上一轮设计 (PR #352)
+- migration 024 (`backend/migrations/024_human_participant.sql`) — polymorphic owner 模式参考
+- `backend/hub/models.py:64` Agent 模型 (`user_id` 是关键字段)
+- `backend/hub/models.py:958` User 模型 (`human_id` 关键字段)
+- `backend/app/auth.py:33` RequestContext 已经同时持有 `user_id`/`human_id`/`active_agent_id`

--- a/frontend/src/components/dashboard/RoomHeader.tsx
+++ b/frontend/src/components/dashboard/RoomHeader.tsx
@@ -385,6 +385,10 @@ export default function RoomHeader() {
       {showSettingsModal && !isDMRoom && (
         <RoomSettingsModal
           roomId={room.room_id}
+          // Fall back to "agent" for legacy rooms whose overview row predates
+          // the polymorphic owner field. Subscription routes will only enable
+          // the receiving-bot dropdown when the explicit ``"human"`` is set.
+          roomOwnerType={room.owner_type ?? "agent"}
           viewerMode={viewMode}
           viewerRole={myRole}
           initialName={room.name}

--- a/frontend/src/components/dashboard/RoomSettingsModal.tsx
+++ b/frontend/src/components/dashboard/RoomSettingsModal.tsx
@@ -10,7 +10,7 @@ import {
   roomAdvancedSettings,
   roomSettingsModal,
 } from "@/lib/i18n/translations/dashboard";
-import type { PublicRoomMember, SubscriptionProduct } from "@/lib/types";
+import type { ParticipantType, PublicRoomMember, SubscriptionProduct, UserAgent } from "@/lib/types";
 import AddRoomMemberModal from "./AddRoomMemberModal";
 import MemberActionsMenu from "./MemberActionsMenu";
 import PlanChangeConfirmDialog from "./PlanChangeConfirmDialog";
@@ -22,6 +22,10 @@ import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 
 interface RoomSettingsModalProps {
   roomId: string;
+  // Polymorphic owner type — drives whether the subscription section
+  // shows a "receiving bot" dropdown (human-owned) or hard-binds the
+  // provider to the owner agent (agent-owned).
+  roomOwnerType: ParticipantType;
   viewerMode: "human" | "agent";
   viewerRole?: string | null;
   initialName: string;
@@ -140,6 +144,7 @@ function ActionConfirmDialog({
 
 export default function RoomSettingsModal({
   roomId,
+  roomOwnerType,
   viewerMode,
   viewerRole,
   initialName,
@@ -198,6 +203,12 @@ export default function RoomSettingsModal({
   );
   const [subscriptionEnabled, setSubscriptionEnabled] = useState(Boolean(initialSubscriptionProductId));
   const [ownedProducts, setOwnedProducts] = useState<SubscriptionProduct[]>([]);
+  // Provider agent for human-owned rooms. Required when (re)creating the
+  // room's subscription product because the room owner is a Human and the
+  // wallet receiver must be one of the user's active bots.
+  const isHumanOwnedRoom = roomOwnerType === "human";
+  const [providerAgentId, setProviderAgentId] = useState<string>("");
+  const [ownedAgents, setOwnedAgents] = useState<UserAgent[]>([]);
   const [subscriptionProduct, setSubscriptionProduct] = useState<SubscriptionProduct | null>(null);
   const [subscriptionLoading, setSubscriptionLoading] = useState(false);
   const [priceInput, setPriceInput] = useState("");
@@ -265,6 +276,34 @@ export default function RoomSettingsModal({
     if (!initialSubscriptionProductId) return;
     void ensureSubscriptions().catch(() => {});
   }, [ensureSubscriptions, initialSubscriptionProductId]);
+
+  // Human-owned rooms need an explicit provider agent for migrate-plan.
+  // Load the user's bots once when the modal opens and seed the dropdown.
+  useEffect(() => {
+    if (!isHumanOwnedRoom || !isOwner) return;
+    let cancelled = false;
+    void api.getMyAgents().then(({ agents }) => {
+      if (cancelled) return;
+      setOwnedAgents(agents);
+      // Default to the current product's provider if known, else first agent.
+      setProviderAgentId((prev) => {
+        if (prev && agents.some((a) => a.agent_id === prev)) return prev;
+        return agents[0]?.agent_id ?? "";
+      });
+    }).catch(() => {
+      if (!cancelled) setOwnedAgents([]);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [isHumanOwnedRoom, isOwner]);
+
+  // When the subscription product loads, prefer its provider as the default.
+  useEffect(() => {
+    if (!isHumanOwnedRoom) return;
+    if (!subscriptionProduct?.provider_agent_id) return;
+    setProviderAgentId(subscriptionProduct.provider_agent_id);
+  }, [isHumanOwnedRoom, subscriptionProduct?.provider_agent_id]);
 
   useEffect(() => {
     let cancelled = false;
@@ -444,25 +483,39 @@ export default function RoomSettingsModal({
     }
     const amountMinor = String(Math.round(priceMajor * 100));
 
-    // First-time enable: no current product on the room → create + bind.
+    // Human-owned rooms must specify a provider bot; the dashboard human
+    // path doesn't send X-Active-Agent so the backend has no implicit fallback.
+    if (isHumanOwnedRoom && !providerAgentId) {
+      setError(ta.subscriptionProviderRequired ?? "Select a receiving bot");
+      return "blocked";
+    }
+
+    // Same product, identical price + interval (and provider, when human-owned)
+    // → noop. We only short-circuit when a current product exists.
+    if (initialSubscriptionProductId && subscriptionProduct) {
+      const currentMinor = Number(subscriptionProduct.amount_minor);
+      const sameAmount =
+        Number.isFinite(currentMinor) && Number(amountMinor) === currentMinor;
+      const sameInterval =
+        subscriptionProduct.billing_interval === billingInterval;
+      const sameProvider =
+        !isHumanOwnedRoom || providerAgentId === subscriptionProduct.provider_agent_id;
+      if (sameAmount && sameInterval && sameProvider) return "noop";
+    }
+
+    // First-time enable: drop the legacy two-step (createProduct + PATCH room)
+    // — a single migrate-plan call is atomic and works in both human and
+    // agent identity modes.
     if (!initialSubscriptionProductId) {
       await upsertRoomPlan(roomId, {
         amount_minor: amountMinor,
         billing_interval: billingInterval,
+        currentProductId: undefined,
+        providerAgentId: isHumanOwnedRoom ? providerAgentId : undefined,
       });
       await refreshOverview({ reloadOpenedRoom: true });
       return "applied";
     }
-
-    // Same product, identical price + interval → noop.
-    const currentMinor = subscriptionProduct
-      ? Number(subscriptionProduct.amount_minor)
-      : NaN;
-    const sameAmount =
-      Number.isFinite(currentMinor) && Number(amountMinor) === currentMinor;
-    const sameInterval =
-      subscriptionProduct?.billing_interval === billingInterval;
-    if (sameAmount && sameInterval) return "noop";
 
     // Plan change → defer to confirm dialog.
     setPlanChangeAffected(subscriberCount ?? 0);
@@ -480,6 +533,7 @@ export default function RoomSettingsModal({
         amount_minor: amountMinor,
         billing_interval: billingInterval,
         currentProductId: initialSubscriptionProductId ?? undefined,
+        providerAgentId: isHumanOwnedRoom ? providerAgentId : undefined,
       });
       await refreshOverview({ reloadOpenedRoom: true });
       setPlanChangeDialogOpen(false);
@@ -910,6 +964,30 @@ export default function RoomSettingsModal({
                           {ta.subscriptionMonthly}
                         </label>
                       </div>
+                      {isHumanOwnedRoom && (
+                        <div className="flex items-center gap-3">
+                          <label className="text-sm text-text-primary">
+                            {ta.subscriptionProviderLabel ?? "Receiving bot"}
+                          </label>
+                          <select
+                            value={providerAgentId}
+                            onChange={(e) => setProviderAgentId(e.target.value)}
+                            disabled={multiRoomBlocked || ownedAgents.length === 0}
+                            className="rounded-lg border border-glass-border bg-deep-black px-2 py-1 text-sm text-text-primary"
+                          >
+                            {ownedAgents.length === 0 && (
+                              <option value="">
+                                {ta.subscriptionProviderEmpty ?? "No bots available"}
+                              </option>
+                            )}
+                            {ownedAgents.map((agent) => (
+                              <option key={agent.agent_id} value={agent.agent_id}>
+                                {agent.display_name} ({agent.agent_id})
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                      )}
                       {subscriberCount !== null && (
                         <p className="text-xs text-text-secondary/80">
                           {ta.subscriptionCurrentSubscribers}: {subscriberCount}

--- a/frontend/src/components/dashboard/RoomSettingsModal.tsx
+++ b/frontend/src/components/dashboard/RoomSettingsModal.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { ChevronDown, Loader2, Search, X } from "lucide-react";
 import CopyableId from "@/components/ui/CopyableId";
-import { api, humansApi } from "@/lib/api";
+import { api, humansApi, userApi } from "@/lib/api";
 import { useLanguage } from "@/lib/i18n";
 import {
   agentBrowser,
@@ -282,7 +282,7 @@ export default function RoomSettingsModal({
   useEffect(() => {
     if (!isHumanOwnedRoom || !isOwner) return;
     let cancelled = false;
-    void api.getMyAgents().then(({ agents }) => {
+    void userApi.getMyAgents().then(({ agents }) => {
       if (cancelled) return;
       setOwnedAgents(agents);
       // Default to the current product's provider if known, else first agent.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -659,6 +659,8 @@ export const api = {
       amount_minor: string;
       billing_interval: "week" | "month";
       description?: string;
+      // Required when the target room is human-owned. Ignored otherwise.
+      provider_agent_id?: string;
     },
   ) {
     return apiPost<MigrateRoomPlanResponse>(

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -2316,6 +2316,9 @@ export const roomAdvancedSettings: TranslationMap<{
   subscriptionCurrentSubscribers: string
   subscriptionGrandfatherHint: string
   subscriptionMultiRoomBlock: string
+  subscriptionProviderLabel: string
+  subscriptionProviderEmpty: string
+  subscriptionProviderRequired: string
   planChangeTitle: string
   planChangeFromTo: string
   planChangeWarning: string
@@ -2358,6 +2361,9 @@ export const roomAdvancedSettings: TranslationMap<{
     subscriptionCurrentSubscribers: 'Current subscribers',
     subscriptionGrandfatherHint: 'Existing members keep free access; new joiners must subscribe.',
     subscriptionMultiRoomBlock: 'This subscription plan is shared across multiple rooms and cannot be edited here.',
+    subscriptionProviderLabel: 'Receiving bot',
+    subscriptionProviderEmpty: 'No active bots found',
+    subscriptionProviderRequired: 'Select a receiving bot for this room.',
     planChangeTitle: 'Change subscription price',
     planChangeFromTo: 'Current: {from} → New: {to}',
     planChangeWarning: '{count} existing subscribers will lose access at the end of their current cycle and need to resubscribe at the new price.',
@@ -2400,6 +2406,9 @@ export const roomAdvancedSettings: TranslationMap<{
     subscriptionCurrentSubscribers: '当前订阅者',
     subscriptionGrandfatherHint: '现有成员可继续免费使用；新加入者必须订阅。',
     subscriptionMultiRoomBlock: '此订阅套餐被多个房间共用，无法在此修改。',
+    subscriptionProviderLabel: '收款机器人',
+    subscriptionProviderEmpty: '没有可用的活跃机器人',
+    subscriptionProviderRequired: '请为本房间选择一个收款机器人。',
     planChangeTitle: '修改订阅价格',
     planChangeFromTo: '当前：{from} → 新：{to}',
     planChangeWarning: '{count} 位现有订阅者将在本周期到期后失效，需要按新价重新订阅。',

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -21,6 +21,7 @@ export interface DashboardRoom {
   name: string;
   description: string;
   owner_id: string;
+  owner_type?: ParticipantType;
   visibility: string;
   join_policy?: string;
   can_invite?: boolean;
@@ -619,7 +620,9 @@ export interface PublicRoomMembersResponse {
 
 export interface SubscriptionProduct {
   product_id: string;
-  owner_agent_id: string;
+  owner_id: string;
+  owner_type: ParticipantType;
+  provider_agent_id: string;
   name: string;
   description: string;
   asset_code: string;

--- a/frontend/src/store/dashboard-shared.ts
+++ b/frontend/src/store/dashboard-shared.ts
@@ -71,6 +71,7 @@ export function humanRoomToDashboardRoom(r: HumanRoomSummary): DashboardRoom {
     name: r.name,
     description: r.description,
     owner_id: r.owner_id,
+    owner_type: r.owner_type,
     visibility: r.visibility,
     join_policy: r.join_policy,
     member_count: r.member_count,

--- a/frontend/src/store/useDashboardChatStore.ts
+++ b/frontend/src/store/useDashboardChatStore.ts
@@ -66,6 +66,9 @@ function ownedAgentRoomToDashboardRoom(room: HumanAgentRoomSummary): DashboardRo
     name: room.name,
     description: room.description ?? "",
     owner_id: room.owner_id,
+    // ownedAgentRoomToDashboardRoom is the human-as-owner-via-bot listing —
+    // these rooms are by definition agent-owned.
+    owner_type: "agent",
     visibility: room.visibility,
     join_policy: room.join_policy ?? undefined,
     can_invite: undefined,

--- a/frontend/src/store/useDashboardSubscriptionStore.ts
+++ b/frontend/src/store/useDashboardSubscriptionStore.ts
@@ -29,6 +29,8 @@ interface DashboardSubscriptionState {
       billing_interval: "week" | "month";
       description?: string;
       currentProductId?: string | null;
+      // Required when the room is human-owned, ignored otherwise.
+      providerAgentId?: string;
     },
   ) => Promise<{ productId: string; affectedCount: number }>;
 }
@@ -131,25 +133,14 @@ export const useDashboardSubscriptionStore = create<DashboardSubscriptionState>(
   },
 
   upsertRoomPlan: async (roomId, body) => {
-    // First-time enable: room has no product yet → create product, then bind
-    // it via the existing PATCH /rooms/{id} route.
-    if (!body.currentProductId) {
-      const product = await api.createSubscriptionProduct({
-        name: `room:${roomId}:plan:${Date.now()}`,
-        amount_minor: body.amount_minor,
-        billing_interval: body.billing_interval,
-        description: body.description,
-      });
-      await api.updateRoomSettings(roomId, {
-        required_subscription_product_id: product.product_id,
-      });
-      return { productId: product.product_id, affectedCount: 0 };
-    }
-    // Plan change: backend handles create + bind + archive atomically.
+    // Single code path: migrate-plan creates + binds + archives atomically,
+    // and works without X-Active-Agent (human-as-owner) once the human path
+    // sends provider_agent_id explicitly.
     const result = await api.migrateRoomSubscriptionPlan(roomId, {
       amount_minor: body.amount_minor,
       billing_interval: body.billing_interval,
       description: body.description,
+      provider_agent_id: body.providerAgentId,
     });
     return { productId: result.product_id, affectedCount: result.affected_count };
   },


### PR DESCRIPTION
## Summary
- Subscription products gain polymorphic owner (`owner_id` + `owner_type`) and explicit `provider_agent_id`; humans can now own products and human-owned rooms can attach paid plans without an active agent context.
- Dashboard room admin (PATCH / migrate-plan / dissolve) is rebuilt around `viewer_can_admin_room`, supporting human-as-owner and bound-user-as-owner-via-bot capability paths.
- Humans BFF PATCH gains `required_subscription_product_id` validation; humans dissolve pre-cancels bound subs (matching hub behavior).
- Frontend `RoomSettingsModal` shows a "receiving bot" dropdown for human-owned rooms, collapses the legacy two-step first-time-enable into a single `migrate-plan` call.
- Cleanup migration drops the deprecated `owner_agent_id` mirror.

Design: [`docs/human-owner-subscription-redesign.md`](docs/human-owner-subscription-redesign.md)

## Test plan
- [x] `uv run pytest tests/` — 957 passing (8 new in `test_human_owner_subscription.py`)
- [ ] Apply migrations 031 + 032 against staging Postgres; verify backfill leaves agent-owned products with `owner_type='agent'` and `provider_agent_id = owner_id`
- [ ] Dashboard manual: human-owned room → set price (with provider bot), change price, dissolve
- [ ] Dashboard manual: agent-owned room → bound-user (no `X-Active-Agent`) edits price → 200
- [ ] Dashboard manual: agent-owned room → unrelated user → 403
- [ ] Hub agent CLI `DELETE /hub/rooms/{id}` still works for daemon paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)