### PR TITLE
fix: human-owned room subscription migrate-plan + USDC label

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -170,6 +170,7 @@ async def _build_rooms_from_sql(
             return mapped
         orm_room_by_id = {room["room_id"]: room for room in orm_rooms}
         fill_keys = (
+            "owner_type",
             "join_policy",
             "can_invite",
             "required_subscription_product_id",

--- a/frontend/src/components/dashboard/RoomSettingsModal.tsx
+++ b/frontend/src/components/dashboard/RoomSettingsModal.tsx
@@ -1147,7 +1147,7 @@ export default function RoomSettingsModal({
         <PlanChangeConfirmDialog
           fromLabel={
             subscriptionProduct
-              ? `${(Number(subscriptionProduct.amount_minor) / 100).toFixed(2)} ${subscriptionProduct.asset_code} / ${subscriptionProduct.billing_interval}`
+              ? `${(Number(subscriptionProduct.amount_minor) / 100).toFixed(2)} USDC / ${subscriptionProduct.billing_interval}`
               : "—"
           }
           toLabel={`${Number(priceInput).toFixed(2)} USDC / ${billingInterval}`}

--- a/frontend/src/components/dashboard/SubscriptionBadge.tsx
+++ b/frontend/src/components/dashboard/SubscriptionBadge.tsx
@@ -221,8 +221,8 @@ export default function SubscriptionBadge({
           ? t.subscriptionActive
           : t.startSubscription;
 
-  const formatAmount = (minor: number, assetCode: string) =>
-    `${(minor / 100).toFixed(2)} ${assetCode}`;
+  const formatAmount = (minor: number, _assetCode: string) =>
+    `${(minor / 100).toFixed(2)} USDC`;
 
   const trigger = variant === "button" ? (
     <button


### PR DESCRIPTION
## Summary
- Backend: `get_agent_room_previews` SQL function does not return `owner_type`, and the ORM fallback merge in `_build_rooms_from_sql` did not include it in `fill_keys`. As a result `/overview` rooms came back without `owner_type` in production, the dashboard fell back to `"agent"`, and `RoomSettingsModal` omitted `provider_agent_id` on `/subscription/migrate-plan` — the Hub then rejected the call with `provider_agent_id is required for human-owned rooms`. Adding `owner_type` to `fill_keys` lets the ORM merge backfill it.
- Frontend: subscription price was rendered with the raw `asset_code` (`COIN`) in `SubscriptionBadge` and the plan-change confirm dialog, while the price input and target label already showed `USDC`. Display `USDC` consistently.

## Test plan
- [ ] Open a human-owned room's settings modal as the owner, set a price, save → request includes `provider_agent_id` and migrate-plan succeeds
- [ ] Subscribe badge and plan-change confirm dialog show `X.XX USDC / month`
- [ ] Backend tests: `cd backend && uv run pytest tests/test_app/test_human_owner_subscription.py tests/test_subscription.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)