### PR TITLE
feat: add daemon OpenClaw discovery

### DIFF
--- a/packages/daemon/src/__tests__/openclaw-discovery.test.ts
+++ b/packages/daemon/src/__tests__/openclaw-discovery.test.ts
@@ -1,0 +1,150 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  discoverLocalOpenclawGateways,
+  mergeOpenclawGateways,
+} from "../openclaw-discovery.js";
+import type { DaemonConfig } from "../config.js";
+import type { WsEndpointProbeFn } from "../provision.js";
+
+let tmp: string | null = null;
+
+afterEach(() => {
+  if (tmp) rmSync(tmp, { recursive: true, force: true });
+  tmp = null;
+});
+
+function tempDir(): string {
+  tmp = mkdtempSync(path.join(tmpdir(), "openclaw-discovery-"));
+  return tmp;
+}
+
+function baseConfig(): DaemonConfig {
+  return {
+    defaultRoute: { adapter: "claude-code", cwd: "/tmp" },
+    routes: [],
+    streamBlocks: true,
+  };
+}
+
+describe("discoverLocalOpenclawGateways", () => {
+  it("discovers JSON and TOML acp config files", async () => {
+    const dir = tempDir();
+    writeFileSync(
+      path.join(dir, "one.json"),
+      JSON.stringify({ acp: { url: "ws://127.0.0.1:18789/acp", tokenFile: "/tmp/token" } }),
+    );
+    writeFileSync(
+      path.join(dir, "two.toml"),
+      ['[acp]', 'url = "ws://127.0.0.1:18790/acp"', 'token = "secret"'].join("\n"),
+    );
+
+    const found = await discoverLocalOpenclawGateways({
+      searchPaths: [dir],
+      defaultPorts: [],
+    });
+
+    expect(found).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          url: "ws://127.0.0.1:18789/acp",
+          tokenFile: "/tmp/token",
+          source: "config-file",
+        }),
+        expect.objectContaining({
+          url: "ws://127.0.0.1:18790/acp",
+          token: "secret",
+          source: "config-file",
+        }),
+      ]),
+    );
+  });
+
+  it("uses OPENCLAW_ACP_URL and token env vars", async () => {
+    const found = await discoverLocalOpenclawGateways({
+      searchPaths: [],
+      defaultPorts: [],
+      env: {
+        OPENCLAW_ACP_URL: "ws://127.0.0.1:18888/acp",
+        OPENCLAW_ACP_TOKEN: "env-token",
+      },
+    });
+
+    expect(found).toEqual([
+      expect.objectContaining({
+        url: "ws://127.0.0.1:18888/acp",
+        token: "env-token",
+        source: "env",
+      }),
+    ]);
+  });
+
+  it("adds default-port candidates only when the probe succeeds", async () => {
+    const probe = vi.fn<WsEndpointProbeFn>(async ({ url }) => ({
+      ok: url.includes("18789"),
+      agents: [],
+    }));
+
+    const found = await discoverLocalOpenclawGateways({
+      searchPaths: [],
+      defaultPorts: [18789, 18790],
+      probe,
+      timeoutMs: 10,
+    });
+
+    expect(probe).toHaveBeenCalledTimes(2);
+    expect(found.map((g) => g.url)).toEqual(["ws://127.0.0.1:18789"]);
+  });
+
+  it("prefers config-file auth details over lower-priority duplicate sources", async () => {
+    const dir = tempDir();
+    writeFileSync(
+      path.join(dir, "one.json"),
+      JSON.stringify({ acp: { url: "ws://127.0.0.1:18789", token: "file-token" } }),
+    );
+    const probe = vi.fn<WsEndpointProbeFn>(async () => ({ ok: true }));
+
+    const found = await discoverLocalOpenclawGateways({
+      searchPaths: [dir],
+      defaultPorts: [18789],
+      probe,
+      env: {
+        OPENCLAW_ACP_URL: "ws://127.0.0.1:18789",
+        OPENCLAW_ACP_TOKEN: "env-token",
+      },
+    });
+
+    expect(found).toHaveLength(1);
+    expect(found[0]).toEqual(
+      expect.objectContaining({ source: "config-file", token: "file-token" }),
+    );
+  });
+});
+
+describe("mergeOpenclawGateways", () => {
+  it("appends new URLs and keeps existing profiles untouched", () => {
+    const cfg = baseConfig();
+    cfg.openclawGateways = [{ name: "local", url: "ws://127.0.0.1:18789/acp", token: "user-token" }];
+    const merged = mergeOpenclawGateways(cfg, [
+      {
+        name: "openclaw-127-0-0-1-18789",
+        url: "ws://127.0.0.1:18789/acp",
+        token: "discovered-token",
+        source: "env",
+      },
+      {
+        name: "openclaw-127-0-0-1-18790",
+        url: "ws://127.0.0.1:18790/acp",
+        source: "default-port",
+      },
+    ]);
+
+    expect(merged.changed).toBe(true);
+    expect(merged.cfg.openclawGateways).toEqual([
+      { name: "local", url: "ws://127.0.0.1:18789/acp", token: "user-token" },
+      { name: "openclaw-127-0-0-1-18790", url: "ws://127.0.0.1:18790/acp" },
+    ]);
+  });
+});

--- a/packages/daemon/src/__tests__/provision.test.ts
+++ b/packages/daemon/src/__tests__/provision.test.ts
@@ -26,6 +26,7 @@ vi.mock("../config.js", async () => {
 
 const {
   addAgentToConfig,
+  adoptDiscoveredOpenclawAgents,
   removeAgentFromConfig,
   reloadConfig,
   setRoute,
@@ -775,6 +776,110 @@ describe("provision_agent seeds workspace + hot-adds managed route", () => {
       const credFile = nodePath.join(tmp, ".botcord", "credentials", "ag_chfail.json");
       expect(fs.existsSync(credFile)).toBe(false);
       expect(gw.listManagedRoutes()).toHaveLength(0);
+    });
+  });
+});
+
+describe("adoptDiscoveredOpenclawAgents", () => {
+  it("registers unbound OpenClaw agents and writes the routing binding", async () => {
+    await withSandboxHome(async ({ tmp, fs, path: nodePath }) => {
+      const credDir = nodePath.join(tmp, ".botcord", "credentials");
+      fs.mkdirSync(credDir, { recursive: true });
+      fs.writeFileSync(
+        nodePath.join(credDir, "ag_seed.json"),
+        JSON.stringify({
+          version: 1,
+          hubUrl: "https://hub.example",
+          agentId: "ag_seed",
+          keyId: "k_seed",
+          privateKey: Buffer.alloc(32, 5).toString("base64"),
+          savedAt: new Date().toISOString(),
+        }),
+      );
+      mockState.cfg = {
+        defaultRoute: { adapter: "claude-code", cwd: "/tmp" },
+        routes: [],
+        streamBlocks: true,
+        agents: ["ag_seed"],
+        openclawGateways: [{ name: "local", url: "ws://127.0.0.1:18789" }],
+      };
+
+      const gw = makeFakeGateway(["ag_seed"]);
+      const register = vi.fn(async () => ({
+        agentId: "ag_adopted",
+        keyId: "k_adopted",
+        privateKey: Buffer.alloc(32, 31).toString("base64"),
+        publicKey: Buffer.alloc(32, 32).toString("base64"),
+        hubUrl: "https://hub.example",
+        token: "tok",
+        expiresAt: Date.now() + 60_000,
+      }));
+
+      const res = await adoptDiscoveredOpenclawAgents({
+        gateway: gw as unknown as Parameters<typeof adoptDiscoveredOpenclawAgents>[0]["gateway"],
+        register: register as unknown as Parameters<typeof adoptDiscoveredOpenclawAgents>[0]["register"],
+        cfg: mockState.cfg as unknown as DaemonConfig,
+        probe: async () => ({ ok: true, agents: [{ id: "main", name: "Main Agent" }] }),
+      });
+
+      expect(res.adopted).toEqual(["ag_adopted"]);
+      expect(register).toHaveBeenCalledWith("https://hub.example", "Main Agent", undefined);
+      const saved = JSON.parse(
+        fs.readFileSync(nodePath.join(credDir, "ag_adopted.json"), "utf8"),
+      ) as Record<string, unknown>;
+      expect(saved.runtime).toBe("openclaw-acp");
+      expect(saved.openclawGateway).toBe("local");
+      expect(saved.openclawAgent).toBe("main");
+      expect((mockState.cfg.agents as string[])).toContain("ag_adopted");
+      expect(gw.addChannel).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "ag_adopted", type: "botcord" }),
+      );
+      const route = gw.listManagedRoutes().find((r) => r.match?.accountId === "ag_adopted");
+      expect(route?.runtime).toBe("openclaw-acp");
+      expect(route?.gateway?.name).toBe("local");
+      expect(route?.gateway?.openclawAgent).toBe("main");
+    });
+  });
+
+  it("skips an OpenClaw agent that is already bound in credentials", async () => {
+    await withSandboxHome(async ({ tmp, fs, path: nodePath }) => {
+      const credDir = nodePath.join(tmp, ".botcord", "credentials");
+      fs.mkdirSync(credDir, { recursive: true });
+      fs.writeFileSync(
+        nodePath.join(credDir, "ag_existing.json"),
+        JSON.stringify({
+          version: 1,
+          hubUrl: "https://hub.example",
+          agentId: "ag_existing",
+          keyId: "k_existing",
+          privateKey: Buffer.alloc(32, 6).toString("base64"),
+          savedAt: new Date().toISOString(),
+          runtime: "openclaw-acp",
+          openclawGateway: "local",
+          openclawAgent: "main",
+        }),
+      );
+      mockState.cfg = {
+        defaultRoute: { adapter: "claude-code", cwd: "/tmp" },
+        routes: [],
+        streamBlocks: true,
+        agents: ["ag_existing"],
+        openclawGateways: [{ name: "local", url: "ws://127.0.0.1:18789" }],
+      };
+      const register = vi.fn();
+
+      const res = await adoptDiscoveredOpenclawAgents({
+        gateway: makeFakeGateway(["ag_existing"]) as unknown as Parameters<typeof adoptDiscoveredOpenclawAgents>[0]["gateway"],
+        register: register as unknown as Parameters<typeof adoptDiscoveredOpenclawAgents>[0]["register"],
+        cfg: mockState.cfg as unknown as DaemonConfig,
+        probe: async () => ({ ok: true, agents: [{ id: "main" }] }),
+      });
+
+      expect(res.adopted).toEqual([]);
+      expect(res.skipped).toEqual([
+        { gateway: "local", openclawAgent: "main", reason: "already_bound" },
+      ]);
+      expect(register).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -88,6 +88,17 @@ export interface AgentDiscoveryConfig {
   credentialsDir?: string;
 }
 
+export interface OpenclawDiscoveryConfig {
+  /** Defaults to true. */
+  enabled?: boolean;
+  /** Overrides the local config-file search roots. */
+  searchPaths?: string[];
+  /** Overrides the local loopback ports to probe. */
+  defaultPorts?: number[];
+  /** Defaults to true. When false, discovery only persists gateways. */
+  autoProvision?: boolean;
+}
+
 export interface DaemonConfig {
   /**
    * @deprecated Kept for backward compatibility with pre-multi-agent configs.
@@ -131,6 +142,12 @@ export interface DaemonConfig {
    * so the dispatcher never re-queries this list.
    */
   openclawGateways?: OpenclawGatewayProfile[];
+
+  /**
+   * Daemon-side local OpenClaw discovery. Omitted means enabled with default
+   * search paths/ports and automatic adoption of discovered agents.
+   */
+  openclawDiscovery?: OpenclawDiscoveryConfig;
 }
 
 /**
@@ -356,6 +373,25 @@ export function loadConfig(): DaemonConfig {
       copy.credentialsDir = discovery.credentialsDir;
     }
     out.agentDiscovery = copy;
+  }
+  const openclawDiscovery = parsed.openclawDiscovery;
+  if (openclawDiscovery && typeof openclawDiscovery === "object") {
+    const copy: OpenclawDiscoveryConfig = {};
+    if (typeof openclawDiscovery.enabled === "boolean") copy.enabled = openclawDiscovery.enabled;
+    if (Array.isArray(openclawDiscovery.searchPaths)) {
+      copy.searchPaths = openclawDiscovery.searchPaths.filter(
+        (p): p is string => typeof p === "string" && p.length > 0,
+      );
+    }
+    if (Array.isArray(openclawDiscovery.defaultPorts)) {
+      copy.defaultPorts = openclawDiscovery.defaultPorts.filter(
+        (p): p is number => Number.isInteger(p) && p > 0 && p < 65536,
+      );
+    }
+    if (typeof openclawDiscovery.autoProvision === "boolean") {
+      copy.autoProvision = openclawDiscovery.autoProvision;
+    }
+    out.openclawDiscovery = copy;
   }
   return out;
 }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -23,7 +23,12 @@ import { ensureAgentWorkspace } from "./agent-workspace.js";
 import { ControlChannel } from "./control-channel.js";
 import { toGatewayConfig } from "./daemon-config-map.js";
 import { log as daemonLog } from "./log.js";
-import { collectRuntimeSnapshot, createProvisioner } from "./provision.js";
+import {
+  adoptDiscoveredOpenclawAgents,
+  collectRuntimeSnapshot,
+  createProvisioner,
+} from "./provision.js";
+import { openclawAutoProvisionEnabled } from "./openclaw-discovery.js";
 import { SnapshotWriter } from "./snapshot-writer.js";
 import { createDaemonSystemContextBuilder } from "./system-context.js";
 import { createRoomStaticContextBuilder } from "./room-context.js";
@@ -421,6 +426,30 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
 
   await gateway.start();
   logger.info("daemon started", { agents: agentIds });
+
+  if (openclawAutoProvisionEnabled(opts.config)) {
+    try {
+      const adopted = await adoptDiscoveredOpenclawAgents({
+        gateway,
+        cfg: opts.config,
+      });
+      if (
+        adopted.adopted.length > 0 ||
+        adopted.failed.length > 0 ||
+        adopted.skipped.length > 0
+      ) {
+        logger.info("openclaw auto-provision completed", {
+          adopted: adopted.adopted,
+          skipped: adopted.skipped,
+          failed: adopted.failed,
+        });
+      }
+    } catch (err) {
+      logger.warn("openclaw auto-provision failed; continuing", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
 
   // Control channel is optional — daemon still runs (data-plane only)
   // when user-auth hasn't been set up yet. Operators can `login` later

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -57,6 +57,11 @@ import {
   updateWorkingMemory,
   DEFAULT_SECTION,
 } from "./working-memory.js";
+import {
+  discoverLocalOpenclawGateways,
+  mergeOpenclawGateways,
+  openclawDiscoveryConfigEnabled,
+} from "./openclaw-discovery.js";
 
 const ADAPTER_LIST = listAdapterIds().join("|");
 
@@ -402,7 +407,28 @@ async function ensureUserAuthForStart(args: ParsedArgs): Promise<UserAuthRecord 
 }
 
 async function cmdStart(args: ParsedArgs): Promise<void> {
-  const cfg = loadOrInitConfig(args);
+  let cfg = loadOrInitConfig(args);
+  if (openclawDiscoveryConfigEnabled(cfg)) {
+    try {
+      const found = await discoverLocalOpenclawGateways({
+        searchPaths: cfg.openclawDiscovery?.searchPaths,
+        defaultPorts: cfg.openclawDiscovery?.defaultPorts,
+        timeoutMs: 500,
+      });
+      const merged = mergeOpenclawGateways(cfg, found);
+      if (merged.changed) {
+        cfg = merged.cfg;
+        saveConfig(cfg);
+        log.info("openclaw discovery: gateways merged", {
+          added: merged.added.map((g) => ({ name: g.name, url: g.url })),
+        });
+      }
+    } catch (err) {
+      log.warn("openclaw discovery failed; continuing", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
   // Foreground is now the default. --background (alias -d) detaches.
   // --foreground is still accepted (no-op) for backwards compatibility and
   // is also what the detached child re-execs itself with.

--- a/packages/daemon/src/openclaw-discovery.ts
+++ b/packages/daemon/src/openclaw-discovery.ts
@@ -1,0 +1,262 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+import type { DaemonConfig, OpenclawGatewayProfile } from "./config.js";
+import { log as daemonLog } from "./log.js";
+import { probeOpenclawAgents, type WsEndpointProbeFn } from "./provision.js";
+
+export type DiscoveredOpenclawGatewaySource = "config-file" | "env" | "default-port";
+
+export interface DiscoveredOpenclawGateway {
+  name: string;
+  url: string;
+  token?: string;
+  tokenFile?: string;
+  source: DiscoveredOpenclawGatewaySource;
+}
+
+export interface OpenclawGatewayDiscoveryOptions {
+  searchPaths?: string[];
+  defaultPorts?: number[];
+  probe?: WsEndpointProbeFn;
+  timeoutMs?: number;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface MergeOpenclawGatewayResult {
+  cfg: DaemonConfig;
+  changed: boolean;
+  added: OpenclawGatewayProfile[];
+}
+
+const DEFAULT_SEARCH_PATHS = ["~/.openclaw/", "/etc/openclaw/"];
+const DEFAULT_PORTS = [18789];
+
+export async function discoverLocalOpenclawGateways(
+  opts: OpenclawGatewayDiscoveryOptions = {},
+): Promise<DiscoveredOpenclawGateway[]> {
+  const found: DiscoveredOpenclawGateway[] = [];
+  for (const root of opts.searchPaths ?? DEFAULT_SEARCH_PATHS) {
+    found.push(...discoverFromConfigDir(root));
+  }
+
+  const env = opts.env ?? process.env;
+  const envUrl = env.OPENCLAW_ACP_URL;
+  if (envUrl) {
+    const item: DiscoveredOpenclawGateway = {
+      name: nameFromUrl(envUrl),
+      url: envUrl,
+      source: "env",
+    };
+    if (env.OPENCLAW_ACP_TOKEN) item.token = env.OPENCLAW_ACP_TOKEN;
+    else if (env.OPENCLAW_ACP_TOKEN_FILE) item.tokenFile = env.OPENCLAW_ACP_TOKEN_FILE;
+    found.push(item);
+  }
+
+  const ports = opts.defaultPorts ?? DEFAULT_PORTS;
+  if (ports.length > 0) {
+    await Promise.all(
+      ports.map(async (port) => {
+        const url = `ws://127.0.0.1:${port}`;
+        try {
+          const res = await probeOpenclawAgents(
+            { url },
+            { probe: opts.probe, timeoutMs: opts.timeoutMs },
+          );
+          if (res.ok) {
+            found.push({ name: nameFromUrl(url), url, source: "default-port" });
+          }
+        } catch (err) {
+          daemonLog.debug("openclaw discovery default-port probe failed", {
+            url,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }),
+    );
+  }
+
+  return dedupeDiscovered(found);
+}
+
+export function mergeOpenclawGateways(
+  cfg: DaemonConfig,
+  found: DiscoveredOpenclawGateway[],
+): MergeOpenclawGatewayResult {
+  const existing = cfg.openclawGateways ?? [];
+  const existingUrls = new Set(existing.map((g) => normalizeUrlKey(g.url)));
+  const existingNames = new Set(existing.map((g) => g.name));
+  const added: OpenclawGatewayProfile[] = [];
+
+  for (const item of found) {
+    const key = normalizeUrlKey(item.url);
+    if (existingUrls.has(key)) continue;
+    const profile: OpenclawGatewayProfile = {
+      name: uniqueName(item.name, existingNames),
+      url: item.url,
+    };
+    if (item.token) profile.token = item.token;
+    else if (item.tokenFile) profile.tokenFile = item.tokenFile;
+    existingUrls.add(key);
+    existingNames.add(profile.name);
+    added.push(profile);
+  }
+
+  if (added.length === 0) return { cfg, changed: false, added };
+  return {
+    cfg: { ...cfg, openclawGateways: [...existing, ...added] },
+    changed: true,
+    added,
+  };
+}
+
+function discoverFromConfigDir(root: string): DiscoveredOpenclawGateway[] {
+  const dir = expandHome(root);
+  let names: string[];
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const out: DiscoveredOpenclawGateway[] = [];
+  for (const name of names.sort()) {
+    if (!name.endsWith(".json") && !name.endsWith(".toml")) continue;
+    const file = path.join(dir, name);
+    try {
+      const st = statSync(file);
+      if (!st.isFile()) continue;
+      const raw = readFileSync(file, "utf8");
+      const parsed = name.endsWith(".json") ? parseJsonConfig(raw) : parseTomlConfig(raw);
+      if (!parsed?.url) continue;
+      const item: DiscoveredOpenclawGateway = {
+        name: nameFromUrl(parsed.url),
+        url: parsed.url,
+        source: "config-file",
+      };
+      if (parsed.token) item.token = parsed.token;
+      else if (parsed.tokenFile) item.tokenFile = parsed.tokenFile;
+      out.push(item);
+    } catch (err) {
+      daemonLog.debug("openclaw discovery config skipped", {
+        file,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return out;
+}
+
+function parseJsonConfig(raw: string): { url?: string; token?: string; tokenFile?: string } | null {
+  const obj = JSON.parse(raw) as any;
+  const acp = obj?.acp ?? obj?.gateway?.acp ?? obj?.gateway ?? obj;
+  return pickConfigValues(acp);
+}
+
+function parseTomlConfig(raw: string): { url?: string; token?: string; tokenFile?: string } | null {
+  let inAcp = false;
+  const values: Record<string, string> = {};
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.replace(/#.*/, "").trim();
+    if (!trimmed) continue;
+    const section = trimmed.match(/^\[([^\]]+)\]$/);
+    if (section) {
+      inAcp = section[1] === "acp" || section[1].endsWith(".acp");
+      continue;
+    }
+    if (!inAcp) continue;
+    const m = trimmed.match(/^([A-Za-z0-9_-]+)\s*=\s*"(.*)"\s*$/);
+    if (m) values[m[1]] = m[2];
+  }
+  return pickConfigValues(values);
+}
+
+function pickConfigValues(obj: any): { url?: string; token?: string; tokenFile?: string } | null {
+  if (!obj || typeof obj !== "object") return null;
+  const url = pickString(obj, ["url", "wsUrl", "ws_url", "endpoint"]);
+  if (!url) return null;
+  const token = pickString(obj, ["token", "bearerToken", "bearer_token"]);
+  const tokenFile = pickString(obj, ["tokenFile", "token_file"]);
+  return { url, token, tokenFile };
+}
+
+function pickString(obj: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = obj[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+function dedupeDiscovered(items: DiscoveredOpenclawGateway[]): DiscoveredOpenclawGateway[] {
+  const priority: Record<DiscoveredOpenclawGatewaySource, number> = {
+    "config-file": 3,
+    env: 2,
+    "default-port": 1,
+  };
+  const byUrl = new Map<string, DiscoveredOpenclawGateway>();
+  for (const item of items) {
+    const key = normalizeUrlKey(item.url);
+    const prev = byUrl.get(key);
+    if (!prev || priority[item.source] > priority[prev.source] || hasMoreAuth(item, prev)) {
+      byUrl.set(key, item);
+    }
+  }
+  return [...byUrl.values()];
+}
+
+function hasMoreAuth(a: DiscoveredOpenclawGateway, b: DiscoveredOpenclawGateway): boolean {
+  const score = (x: DiscoveredOpenclawGateway): number => (x.token ? 2 : x.tokenFile ? 1 : 0);
+  return score(a) > score(b);
+}
+
+function nameFromUrl(raw: string): string {
+  try {
+    const u = new URL(raw);
+    const base = `${u.hostname}-${u.port || (u.protocol === "wss:" ? "443" : "80")}`;
+    return `openclaw-${base.replace(/[^A-Za-z0-9_-]+/g, "-")}`;
+  } catch {
+    return "openclaw-local";
+  }
+}
+
+function uniqueName(base: string, existing: Set<string>): string {
+  let candidate = base;
+  let i = 2;
+  while (existing.has(candidate)) {
+    candidate = `${base}-${i}`;
+    i += 1;
+  }
+  return candidate;
+}
+
+function normalizeUrlKey(raw: string): string {
+  try {
+    const u = new URL(raw);
+    u.hash = "";
+    return u.toString();
+  } catch {
+    return raw.trim();
+  }
+}
+
+function expandHome(p: string): string {
+  if (p === "~") return homedir();
+  if (p.startsWith("~/")) return path.join(homedir(), p.slice(2));
+  return p;
+}
+
+export function defaultOpenclawDiscoverySearchPaths(): string[] {
+  return DEFAULT_SEARCH_PATHS.slice();
+}
+
+export function defaultOpenclawDiscoveryPorts(): number[] {
+  return DEFAULT_PORTS.slice();
+}
+
+export function openclawDiscoveryConfigEnabled(cfg: DaemonConfig): boolean {
+  return cfg.openclawDiscovery?.enabled !== false;
+}
+
+export function openclawAutoProvisionEnabled(cfg: DaemonConfig): boolean {
+  return cfg.openclawDiscovery?.autoProvision !== false;
+}

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -55,6 +55,7 @@ import {
 } from "./agent-workspace.js";
 import { detectRuntimes, getAdapterModule } from "./adapters/runtimes.js";
 import { log as daemonLog } from "./log.js";
+import { discoverAgentCredentials } from "./agent-discovery.js";
 
 /** Options accepted by {@link createProvisioner}. */
 export interface ProvisionerOptions {
@@ -267,6 +268,8 @@ interface ProvisionCtx {
   register: typeof BotCordClient.register;
 }
 
+const openclawProvisionLocks = new Map<string, Promise<unknown>>();
+
 async function provisionAgent(
   params: ProvisionAgentParams,
   ctx: ProvisionCtx,
@@ -278,13 +281,53 @@ async function provisionAgent(
   const explicitCwd = params.credentials?.cwd ?? params.cwd;
   assertSafeCwd(explicitCwd);
 
+  const openclawSel = pickOpenclawSelection(params);
+  if (openclawSel.gateway && openclawSel.agent) {
+    return withOpenclawProvisionLock(openclawSel.gateway, openclawSel.agent, async () => {
+      const existing = findCredentialsByOpenclaw(openclawSel.gateway!, openclawSel.agent!);
+      if (existing) {
+        daemonLog.info("provision_agent: openclaw binding already exists", {
+          gateway: openclawSel.gateway,
+          openclawAgent: openclawSel.agent,
+          agentId: existing.agentId,
+        });
+        return installExistingOpenclawBinding(existing.agentId, ctx);
+      }
+      const cfg = loadConfig();
+      const credentials = await materializeCredentials(params, cfg, ctx, explicitCwd);
+      return installLocalAgent(credentials, {
+        ...ctx,
+        cfg,
+        bio: params.bio,
+        source: params.credentials ? "hub-supplied" : "registered",
+      });
+    });
+  }
+
   const cfg = loadConfig();
   const credentials = await materializeCredentials(params, cfg, ctx, explicitCwd);
+  return installLocalAgent(credentials, {
+    ...ctx,
+    cfg,
+    bio: params.bio,
+    source: params.credentials ? "hub-supplied" : "registered",
+  });
+}
+
+async function installLocalAgent(
+  credentials: StoredBotCordCredentials,
+  ctx: ProvisionCtx & {
+    cfg: DaemonConfig;
+    bio?: string;
+    source: "hub-supplied" | "registered" | "adopted-openclaw";
+  },
+): Promise<ProvisionedAgent> {
+  const cfg = ctx.cfg;
   daemonLog.debug("provision: credentials materialized", {
     agentId: credentials.agentId,
     hubUrl: credentials.hubUrl,
     runtime: credentials.runtime ?? null,
-    source: params.credentials ? "hub-supplied" : "registered",
+    source: ctx.source,
   });
 
   const credentialsFile = writeCredentialsFile(
@@ -298,7 +341,7 @@ async function provisionAgent(
   try {
     ensureAgentWorkspace(credentials.agentId, {
       displayName: credentials.displayName,
-      bio: params.bio,
+      bio: ctx.bio,
       runtime: credentials.runtime,
       keyId: credentials.keyId,
       savedAt: credentials.savedAt,
@@ -358,37 +401,7 @@ async function provisionAgent(
   // Hot-add the synthesized per-agent managed route so the next turn picks
   // the agent's runtime + workspace cwd without waiting for reload_config.
   try {
-    const synthRoute: import("./gateway/index.js").GatewayRoute = {
-      match: { accountId: credentials.agentId },
-      runtime: credentials.runtime ?? cfg.defaultRoute.adapter,
-      cwd: credentials.cwd ?? agentWorkspaceDir(credentials.agentId),
-    };
-    if (synthRoute.runtime === "openclaw-acp") {
-      // Resolve gateway from the freshly written credentials + the live
-      // openclawGateways registry. A missing/unknown gateway here yields a
-      // disabled route (set_route style); next turn for this agent falls
-      // back to defaultRoute. Caller already validated via reload semantics.
-      const profile = (cfg.openclawGateways ?? []).find(
-        (g) => g.name === credentials.openclawGateway,
-      );
-      if (profile) {
-        // Run the same tokenFile-aware resolver `toGatewayConfig` uses so the
-        // first turn after provisioning doesn't auth-fail when the gateway
-        // ships its bearer via `tokenFile` instead of an inline `token`.
-        const prepared = prepareGatewayProfile(profile);
-        synthRoute.gateway = {
-          name: prepared.name,
-          url: prepared.url,
-          ...(prepared.resolvedToken ? { token: prepared.resolvedToken } : {}),
-          ...(credentials.openclawAgent
-            ? { openclawAgent: credentials.openclawAgent }
-            : prepared.defaultAgent
-              ? { openclawAgent: prepared.defaultAgent }
-              : {}),
-        };
-      }
-    }
-    ctx.gateway.upsertManagedRoute(credentials.agentId, synthRoute);
+    upsertManagedRouteForCredentials(credentials, cfg, ctx.gateway);
   } catch (err) {
     // Rollback the channel + config + credentials on managed-route failure
     // (shouldn't happen — pure map op — but keeps the invariant tight).
@@ -420,6 +433,63 @@ async function provisionAgent(
     credentialsFile,
   });
 
+  return {
+    agentId: credentials.agentId,
+    hubUrl: credentials.hubUrl,
+    credentialsFile,
+  };
+}
+
+function upsertManagedRouteForCredentials(
+  credentials: StoredBotCordCredentials,
+  cfg: DaemonConfig,
+  gateway: Gateway,
+): void {
+  const synthRoute: import("./gateway/index.js").GatewayRoute = {
+    match: { accountId: credentials.agentId },
+    runtime: credentials.runtime ?? cfg.defaultRoute.adapter,
+    cwd: credentials.cwd ?? agentWorkspaceDir(credentials.agentId),
+  };
+  if (synthRoute.runtime === "openclaw-acp") {
+    const profile = (cfg.openclawGateways ?? []).find(
+      (g) => g.name === credentials.openclawGateway,
+    );
+    if (profile) {
+      const prepared = prepareGatewayProfile(profile);
+      synthRoute.gateway = {
+        name: prepared.name,
+        url: prepared.url,
+        ...(prepared.resolvedToken ? { token: prepared.resolvedToken } : {}),
+        ...(credentials.openclawAgent
+          ? { openclawAgent: credentials.openclawAgent }
+          : prepared.defaultAgent
+            ? { openclawAgent: prepared.defaultAgent }
+            : {}),
+      };
+    }
+  }
+  gateway.upsertManagedRoute(credentials.agentId, synthRoute);
+}
+
+async function installExistingOpenclawBinding(
+  agentId: string,
+  ctx: ProvisionCtx,
+): Promise<ProvisionedAgent> {
+  const credentialsFile = defaultCredentialsFile(agentId);
+  const credentials = loadStoredCredentials(credentialsFile);
+  const cfg = loadConfig();
+  const updated = addAgentToConfig(cfg, credentials.agentId);
+  if (updated) saveConfig(updated);
+  const snap = ctx.gateway.snapshot();
+  if (!snap.channels[credentials.agentId]) {
+    await ctx.gateway.addChannel({
+      id: credentials.agentId,
+      type: BOTCORD_CHANNEL_TYPE,
+      accountId: credentials.agentId,
+      agentId: credentials.agentId,
+    });
+  }
+  upsertManagedRouteForCredentials(credentials, cfg, ctx.gateway);
   return {
     agentId: credentials.agentId,
     hubUrl: credentials.hubUrl,
@@ -535,6 +605,140 @@ function pickOpenclawSelection(
     }
   }
   return out;
+}
+
+async function withOpenclawProvisionLock<T>(
+  gateway: string,
+  agent: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const key = `${gateway}\0${agent}`;
+  const prev = openclawProvisionLocks.get(key) ?? Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const chain = prev.then(() => current);
+  openclawProvisionLocks.set(key, chain);
+  await prev.catch(() => undefined);
+  try {
+    return await fn();
+  } finally {
+    release();
+    if (openclawProvisionLocks.get(key) === chain) {
+      openclawProvisionLocks.delete(key);
+    }
+  }
+}
+
+function findCredentialsByOpenclaw(
+  gateway: string,
+  openclawAgent: string,
+): { agentId: string; credentialsFile: string } | null {
+  const discovered = discoverAgentCredentials({
+    credentialsDir: path.join(homedir(), ".botcord", "credentials"),
+  });
+  for (const a of discovered.agents) {
+    if (a.openclawGateway === gateway && a.openclawAgent === openclawAgent) {
+      return { agentId: a.agentId, credentialsFile: a.credentialsFile };
+    }
+  }
+  return null;
+}
+
+export interface AdoptDiscoveredOpenclawAgentsResult {
+  adopted: string[];
+  skipped: Array<{ gateway: string; openclawAgent?: string; reason: string }>;
+  failed: Array<{ gateway: string; openclawAgent?: string; error: string }>;
+}
+
+export async function adoptDiscoveredOpenclawAgents(ctx: {
+  gateway: Gateway;
+  register?: typeof BotCordClient.register;
+  cfg?: DaemonConfig;
+  timeoutMs?: number;
+  probe?: WsEndpointProbeFn;
+}): Promise<AdoptDiscoveredOpenclawAgentsResult> {
+  const register = ctx.register ?? BotCordClient.register;
+  const cfg = ctx.cfg ?? loadConfig();
+  const result: AdoptDiscoveredOpenclawAgentsResult = {
+    adopted: [],
+    skipped: [],
+    failed: [],
+  };
+  for (const gw of cfg.openclawGateways ?? []) {
+    let probeResult: Awaited<ReturnType<typeof probeOpenclawAgents>>;
+    try {
+      probeResult = await probeOpenclawAgents(gw, {
+        timeoutMs: ctx.timeoutMs,
+        probe: ctx.probe,
+      });
+    } catch (err) {
+      result.failed.push({
+        gateway: gw.name,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      continue;
+    }
+    if (!probeResult.ok) {
+      result.skipped.push({
+        gateway: gw.name,
+        reason: probeResult.error ?? "gateway_unreachable",
+      });
+      continue;
+    }
+    for (const oc of probeResult.agents ?? []) {
+      await withOpenclawProvisionLock(gw.name, oc.id, async () => {
+        const existing = findCredentialsByOpenclaw(gw.name, oc.id);
+        if (existing) {
+          result.skipped.push({
+            gateway: gw.name,
+            openclawAgent: oc.id,
+            reason: "already_bound",
+          });
+          return;
+        }
+        const freshCfg = loadConfig();
+        if (!inferHubUrl(freshCfg)) {
+          result.skipped.push({
+            gateway: gw.name,
+            openclawAgent: oc.id,
+            reason: "missing_hub_url",
+          });
+          daemonLog.warn("openclaw adopt skipped: no known hubUrl", {
+            gateway: gw.name,
+            openclawAgent: oc.id,
+          });
+          return;
+        }
+        try {
+          const params: ProvisionAgentParams = {
+            runtime: "openclaw-acp",
+            name: oc.name ?? `openclaw-${oc.id}`,
+            openclaw: { gateway: gw.name, agent: oc.id },
+          };
+          const credentials = await materializeCredentials(params, freshCfg, {
+            gateway: ctx.gateway,
+            register,
+          }, undefined);
+          const installed = await installLocalAgent(credentials, {
+            gateway: ctx.gateway,
+            register,
+            cfg: freshCfg,
+            source: "adopted-openclaw",
+          });
+          result.adopted.push(installed.agentId);
+        } catch (err) {
+          result.failed.push({
+            gateway: gw.name,
+            openclawAgent: oc.id,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      });
+    }
+  }
+  return result;
 }
 
 async function revokeAgent(
@@ -872,6 +1076,34 @@ async function defaultWsProbe(args: {
   });
 }
 
+export async function probeOpenclawAgents(
+  profile: { url: string; token?: string; tokenFile?: string },
+  opts: { timeoutMs?: number; probe?: WsEndpointProbeFn } = {},
+): Promise<{
+  ok: boolean;
+  version?: string;
+  agents?: Array<{
+    id: string;
+    name?: string;
+    workspace?: string;
+    model?: { name?: string; provider?: string };
+  }>;
+  error?: string;
+}> {
+  const probe = opts.probe ?? defaultWsProbe;
+  const prepared = prepareGatewayProfile({
+    name: "probe",
+    url: profile.url,
+    ...(profile.token ? { token: profile.token } : {}),
+    ...(profile.tokenFile ? { tokenFile: profile.tokenFile } : {}),
+  });
+  return probe({
+    url: profile.url,
+    token: prepared.resolvedToken,
+    timeoutMs: opts.timeoutMs ?? 3000,
+  });
+}
+
 /**
  * Async variant that includes L2 (gateway reachability) and L3 (agent listing)
  * probes for runtimes that talk to external services. Used by the production
@@ -889,7 +1121,6 @@ export async function collectRuntimeSnapshotAsync(opts: {
   const base = collectRuntimeSnapshot();
   const gateways = opts.cfg?.openclawGateways ?? [];
   if (gateways.length === 0) return base;
-  const probe = opts.wsProbe ?? defaultWsProbe;
   // Default daemon-side budget is 3s — it must stay below the Hub's
   // `list_runtimes` ack wait (5s, see backend/hub/routers/daemon_control.py)
   // so a single slow gateway can't blow the whole snapshot to a 504.
@@ -897,11 +1128,11 @@ export async function collectRuntimeSnapshotAsync(opts: {
   const capped = gateways.slice(0, RUNTIME_ENDPOINTS_CAP);
   const endpoints = await Promise.all(
     capped.map(async (g) => {
-      // Resolve `tokenFile` here so token-file-only profiles probe with auth
-      // and aren't falsely marked unreachable in the dashboard.
-      const prepared = prepareGatewayProfile(g);
       try {
-        const res = await probe({ url: g.url, token: prepared.resolvedToken, timeoutMs });
+        const res = await probeOpenclawAgents(g, {
+          probe: opts.wsProbe,
+          timeoutMs,
+        });
         const entry: any = { name: g.name, url: g.url, reachable: res.ok };
         if (res.version) entry.version = res.version;
         if (res.error) entry.error = res.error;
@@ -1299,6 +1530,14 @@ function inferHubUrl(cfg: DaemonConfig): string | null {
       if (creds.hubUrl) return creds.hubUrl;
     } catch {
       // skip
+    }
+  }
+  if (ids.length === 0) {
+    const discovered = discoverAgentCredentials({
+      credentialsDir: path.join(homedir(), ".botcord", "credentials"),
+    });
+    for (const a of discovered.agents) {
+      if (a.hubUrl) return a.hubUrl;
     }
   }
   return null;


### PR DESCRIPTION
## Summary
- add daemon-side OpenClaw gateway discovery from local config, env, and loopback port probing
- persist newly discovered gateways and auto-adopt discovered OpenClaw agents after gateway startup
- refactor provision install flow for shared dashboard/adoption behavior and keyed OpenClaw binding idempotency

## Tests
- cd packages/daemon && npm test -- openclaw-discovery.test.ts provision.test.ts
- cd packages/daemon && npx tsc -p tsconfig.build.json --noEmit
- git diff --check