### PR TITLE
fix(frontend): route human sender clicks to HumanCardModal

### DIFF
--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -723,6 +723,14 @@ export default function DashboardApp() {
     }
   };
 
+  useEffect(() => {
+    const pending = uiStore.pendingHumanOpen;
+    if (!pending) return;
+    void handleOpenHumanCard(pending);
+    uiStore.clearPendingHumanOpen();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [uiStore.pendingHumanOpen]);
+
   const handleRetryOwnerHumanCard = () => {
     const human = ownerHumanCard?.human;
     if (!human) return;

--- a/frontend/src/components/dashboard/MessageBubble.tsx
+++ b/frontend/src/components/dashboard/MessageBubble.tsx
@@ -11,6 +11,7 @@ import MarkdownContent from "@/components/ui/MarkdownContent";
 import SystemMessageNotice from "@/components/ui/SystemMessageNotice";
 import TransferCard, { parseTransferText, parseTransferNotice } from "@/components/dashboard/TransferCard";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
+import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import { PresenceDot } from "./PresenceDot";
 
 interface MessageBubbleProps {
@@ -99,6 +100,7 @@ function formatMessageTimestamp(isoTime: string): string {
 
 export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = false }: MessageBubbleProps) {
   const selectAgent = useDashboardChatStore((state) => state.selectAgent);
+  const requestOpenHuman = useDashboardUIStore((state) => state.requestOpenHuman);
   const stateConfig = useStateConfig();
   const textContent = message.payload?.text || message.payload?.body || message.payload?.message;
   const displayText = typeof textContent === "string" ? textContent : message.text;
@@ -121,7 +123,11 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
 
   const sc = stateConfig[message.state];
   const handleSelectSender = () => {
-    selectAgent(message.sender_id);
+    if (isHuman) {
+      requestOpenHuman(message.sender_id, senderDisplayName);
+    } else {
+      selectAgent(message.sender_id);
+    }
   };
 
   const handleSelectSenderByKey = (e: KeyboardEvent<HTMLDivElement>) => {

--- a/frontend/src/store/useDashboardUIStore.ts
+++ b/frontend/src/store/useDashboardUIStore.ts
@@ -14,6 +14,8 @@ export interface DashboardUIState {
   userChatRoomId: string | null;
   rightPanelOpen: boolean;
   agentCardOpen: boolean;
+  /** Dispatch slot: a component requests opening the HumanCardModal for a given human. */
+  pendingHumanOpen: { humanId: string; displayName: string } | null;
   /** When set, the topic side drawer is open for this topic_id in the opened room. */
   openedTopicId: string | null;
   sidebarTab: "messages" | "contacts" | "explore" | "wallet" | "activity" | "bots";
@@ -36,6 +38,8 @@ export interface DashboardUIState {
   toggleRightPanel: () => void;
   openAgentCard: () => void;
   closeAgentCard: () => void;
+  requestOpenHuman: (humanId: string, displayName: string) => void;
+  clearPendingHumanOpen: () => void;
   sidebarWidth: number;
   setSidebarWidth: (width: number) => void;
   resetUIState: () => void;
@@ -48,6 +52,7 @@ const initialUIState = {
   userChatRoomId: null,
   rightPanelOpen: false,
   agentCardOpen: false,
+  pendingHumanOpen: null as { humanId: string; displayName: string } | null,
   openedTopicId: null as string | null,
   sidebarTab: "messages" as DashboardUIState["sidebarTab"],
   selectedBotAgentId: null as string | null,
@@ -83,6 +88,8 @@ export const useDashboardUIStore = create<DashboardUIState>()((set) => ({
   toggleRightPanel: () => set((state) => ({ rightPanelOpen: !state.rightPanelOpen })),
   openAgentCard: () => set({ agentCardOpen: true }),
   closeAgentCard: () => set({ agentCardOpen: false }),
+  requestOpenHuman: (humanId, displayName) => set({ pendingHumanOpen: { humanId, displayName } }),
+  clearPendingHumanOpen: () => set({ pendingHumanOpen: null }),
   resetUIState: () =>
     set((state) => ({
       ...initialUIState,


### PR DESCRIPTION
## Summary
- Clicking a human's name in a group chat called `selectAgent(sender_id)` where `sender_id` is a `hu_*` ID, hitting `/api/dashboard/agents/{id}` and rendering "Agent not found" in `AgentCardModal`.
- `MessageBubble` now branches on `sender_kind`: humans dispatch through a new `pendingHumanOpen` slot in `useDashboardUIStore`; `DashboardApp` consumes it via effect and reuses the existing `handleOpenHumanCard` → `getPublicHuman` → `HumanCardModal` flow.
- No new component or API: the human-card modal and `getPublicHuman` already existed for the agent-owner entry point — this just wires the message-sender entry to the same path.

## Test plan
- [ ] In a group chat, click a human member's display name → `HumanCardModal` opens with profile + add-friend action (no "Agent not found").
- [ ] Click an agent member's display name → `AgentCardModal` still opens as before.
- [ ] Owner-from-agent-card path (click human owner inside an agent card) still works.
- [ ] Same checks inside `TopicDrawer` (also renders `MessageBubble`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)