### PR TITLE
fix(frontend): move pendingHumanOpen effect before bootstrap early return

### DIFF
--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -723,6 +723,14 @@ export default function DashboardApp() {
     }
   };
 
+  useEffect(() => {
+    const pending = uiStore.pendingHumanOpen;
+    if (!pending) return;
+    void handleOpenHumanCard(pending);
+    uiStore.clearPendingHumanOpen();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [uiStore.pendingHumanOpen]);
+
   const handleRetryOwnerHumanCard = () => {
     const human = ownerHumanCard?.human;
     if (!human) return;

--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -662,6 +662,14 @@ export default function DashboardApp() {
     router.replace(continueTarget);
   }, [continueTarget, pathname, router, sessionStore.sessionMode]);
 
+  useEffect(() => {
+    const pending = uiStore.pendingHumanOpen;
+    if (!pending) return;
+    void handleOpenHumanCard(pending);
+    uiStore.clearPendingHumanOpen();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [uiStore.pendingHumanOpen]);
+
   if (shouldShowBootstrapSkeleton) {
     return <DashboardShellSkeleton />;
   }
@@ -722,14 +730,6 @@ export default function DashboardApp() {
       });
     }
   };
-
-  useEffect(() => {
-    const pending = uiStore.pendingHumanOpen;
-    if (!pending) return;
-    void handleOpenHumanCard(pending);
-    uiStore.clearPendingHumanOpen();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [uiStore.pendingHumanOpen]);
 
   const handleRetryOwnerHumanCard = () => {
     const human = ownerHumanCard?.human;

--- a/frontend/src/components/dashboard/MessageBubble.tsx
+++ b/frontend/src/components/dashboard/MessageBubble.tsx
@@ -11,6 +11,7 @@ import MarkdownContent from "@/components/ui/MarkdownContent";
 import SystemMessageNotice from "@/components/ui/SystemMessageNotice";
 import TransferCard, { parseTransferText, parseTransferNotice } from "@/components/dashboard/TransferCard";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
+import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import { PresenceDot } from "./PresenceDot";
 
 interface MessageBubbleProps {
@@ -99,6 +100,7 @@ function formatMessageTimestamp(isoTime: string): string {
 
 export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = false }: MessageBubbleProps) {
   const selectAgent = useDashboardChatStore((state) => state.selectAgent);
+  const requestOpenHuman = useDashboardUIStore((state) => state.requestOpenHuman);
   const stateConfig = useStateConfig();
   const textContent = message.payload?.text || message.payload?.body || message.payload?.message;
   const displayText = typeof textContent === "string" ? textContent : message.text;
@@ -121,7 +123,11 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
 
   const sc = stateConfig[message.state];
   const handleSelectSender = () => {
-    selectAgent(message.sender_id);
+    if (isHuman) {
+      requestOpenHuman(message.sender_id, senderDisplayName);
+    } else {
+      selectAgent(message.sender_id);
+    }
   };
 
   const handleSelectSenderByKey = (e: KeyboardEvent<HTMLDivElement>) => {

--- a/frontend/src/store/useDashboardUIStore.ts
+++ b/frontend/src/store/useDashboardUIStore.ts
@@ -14,6 +14,8 @@ export interface DashboardUIState {
   userChatRoomId: string | null;
   rightPanelOpen: boolean;
   agentCardOpen: boolean;
+  /** Dispatch slot: a component requests opening the HumanCardModal for a given human. */
+  pendingHumanOpen: { humanId: string; displayName: string } | null;
   /** When set, the topic side drawer is open for this topic_id in the opened room. */
   openedTopicId: string | null;
   sidebarTab: "messages" | "contacts" | "explore" | "wallet" | "activity" | "bots";
@@ -36,6 +38,8 @@ export interface DashboardUIState {
   toggleRightPanel: () => void;
   openAgentCard: () => void;
   closeAgentCard: () => void;
+  requestOpenHuman: (humanId: string, displayName: string) => void;
+  clearPendingHumanOpen: () => void;
   sidebarWidth: number;
   setSidebarWidth: (width: number) => void;
   resetUIState: () => void;
@@ -48,6 +52,7 @@ const initialUIState = {
   userChatRoomId: null,
   rightPanelOpen: false,
   agentCardOpen: false,
+  pendingHumanOpen: null as { humanId: string; displayName: string } | null,
   openedTopicId: null as string | null,
   sidebarTab: "messages" as DashboardUIState["sidebarTab"],
   selectedBotAgentId: null as string | null,
@@ -83,6 +88,8 @@ export const useDashboardUIStore = create<DashboardUIState>()((set) => ({
   toggleRightPanel: () => set((state) => ({ rightPanelOpen: !state.rightPanelOpen })),
   openAgentCard: () => set({ agentCardOpen: true }),
   closeAgentCard: () => set({ agentCardOpen: false }),
+  requestOpenHuman: (humanId, displayName) => set({ pendingHumanOpen: { humanId, displayName } }),
+  clearPendingHumanOpen: () => set({ pendingHumanOpen: null }),
   resetUIState: () =>
     set((state) => ({
       ...initialUIState,


### PR DESCRIPTION
## Summary
- The `useEffect` added in e828d2b6 (route human sender clicks to HumanCardModal) was placed **after** the `shouldShowBootstrapSkeleton` early return in `DashboardApp`, violating Rules of Hooks.
- During the bootstrap skeleton render the early return skipped all later hooks; once bootstrap finished, the extra `useEffect` appeared, so React saw a different hook count between renders and threw **error #310** ("Rendered more hooks than during the previous render").
- Move the effect above the early return alongside the other `useEffect`s. The closure over `handleOpenHumanCard` (declared later as a `const`) is safe because the effect callback only runs after commit, by which point the const is initialized.

## Test plan
- [ ] Load dashboard, confirm no React #310 in console
- [ ] Click a human sender's name in a group chat → `HumanCardModal` still opens with the correct profile
- [ ] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)