### PR TITLE
fix(frontend): remove OpenClaw host toggle from Create Agent dialog

### DIFF
--- a/frontend/src/components/dashboard/CreateAgentDialog.tsx
+++ b/frontend/src/components/dashboard/CreateAgentDialog.tsx
@@ -74,7 +74,6 @@ export default function CreateAgentDialog({
     [daemons],
   );
 
-  const [hostKind, setHostKind] = useState<"daemon" | "openclaw">("daemon");
   const [selectedDaemonId, setSelectedDaemonId] = useState<string | null>(null);
   const [selectedRuntimeId, setSelectedRuntimeId] = useState<string | null>(null);
   const [selectedGateway, setSelectedGateway] = useState<string | null>(null);
@@ -234,42 +233,7 @@ export default function CreateAgentDialog({
           <p className="mt-2 text-sm text-text-secondary">{t.description}</p>
         </div>
 
-        <div className="mb-4 inline-flex rounded-xl border border-glass-border bg-glass-bg/40 p-0.5 text-xs">
-          <button
-            type="button"
-            onClick={() => {
-              setHostKind("daemon");
-              setError(null);
-            }}
-            disabled={submitting}
-            className={`rounded-lg px-3 py-1.5 transition-colors ${
-              hostKind === "daemon"
-                ? "bg-neon-cyan/20 text-neon-cyan"
-                : "text-text-secondary hover:text-text-primary"
-            }`}
-          >
-            Local daemon
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              setHostKind("openclaw");
-              setError(null);
-            }}
-            disabled={submitting}
-            className={`rounded-lg px-3 py-1.5 transition-colors ${
-              hostKind === "openclaw"
-                ? "bg-neon-cyan/20 text-neon-cyan"
-                : "text-text-secondary hover:text-text-primary"
-            }`}
-          >
-            OpenClaw host
-          </button>
-        </div>
-
-        {hostKind === "openclaw" ? (
-          <OpenclawBranch onSuccess={onSuccess} onClose={onClose} />
-        ) : !loaded && loading ? (
+        {!loaded && loading ? (
           <div className="flex items-center justify-center py-10 text-text-secondary">
             <Loader2 className="h-5 w-5 animate-spin" />
           </div>
@@ -394,7 +358,7 @@ export default function CreateAgentDialog({
           </p>
         )}
 
-        {hostKind === "daemon" && !showEmptyState && loaded && (
+        {!showEmptyState && loaded && (
           <div className="mt-6 flex items-center justify-end gap-3">
             <button
               onClick={onClose}

--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -662,43 +662,6 @@ export default function DashboardApp() {
     router.replace(continueTarget);
   }, [continueTarget, pathname, router, sessionStore.sessionMode]);
 
-  useEffect(() => {
-    const pending = uiStore.pendingHumanOpen;
-    if (!pending) return;
-    void handleOpenHumanCard(pending);
-    uiStore.clearPendingHumanOpen();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [uiStore.pendingHumanOpen]);
-
-  if (shouldShowBootstrapSkeleton) {
-    return <DashboardShellSkeleton />;
-  }
-
-  const selectedAgentForCard = chatStore.selectedAgentProfile;
-  const alreadyInContacts = selectedAgentForCard
-    ? (chatStore.overview?.contacts || []).some(
-      (item) => item.contact_agent_id === selectedAgentForCard.agent_id,
-    )
-    : false;
-  const requestAlreadyPending = selectedAgentForCard
-    ? contactStore.pendingFriendRequests.includes(selectedAgentForCard.agent_id)
-      || contactStore.contactRequestsSent.some(
-        (item) => item.to_agent_id === selectedAgentForCard.agent_id && item.state === "pending",
-      )
-    : false;
-  const isSendingFriendRequest = selectedAgentForCard
-    ? contactStore.sendingContactRequestAgentId === selectedAgentForCard.agent_id
-    : false;
-
-  const handleSendFriendRequestFromCard = () => {
-    if (!selectedAgentForCard) return;
-    if (sessionStore.sessionMode !== "authed-ready") {
-      router.push("/login");
-      return;
-    }
-    void contactStore.sendContactRequest(selectedAgentForCard.agent_id);
-  };
-
   const handleOpenHumanCard = async (owner: { humanId: string; displayName: string }) => {
     const placeholder: PublicHumanProfile = {
       human_id: owner.humanId,
@@ -738,6 +701,35 @@ export default function DashboardApp() {
     uiStore.clearPendingHumanOpen();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [uiStore.pendingHumanOpen]);
+
+  if (shouldShowBootstrapSkeleton) {
+    return <DashboardShellSkeleton />;
+  }
+
+  const selectedAgentForCard = chatStore.selectedAgentProfile;
+  const alreadyInContacts = selectedAgentForCard
+    ? (chatStore.overview?.contacts || []).some(
+      (item) => item.contact_agent_id === selectedAgentForCard.agent_id,
+    )
+    : false;
+  const requestAlreadyPending = selectedAgentForCard
+    ? contactStore.pendingFriendRequests.includes(selectedAgentForCard.agent_id)
+      || contactStore.contactRequestsSent.some(
+        (item) => item.to_agent_id === selectedAgentForCard.agent_id && item.state === "pending",
+      )
+    : false;
+  const isSendingFriendRequest = selectedAgentForCard
+    ? contactStore.sendingContactRequestAgentId === selectedAgentForCard.agent_id
+    : false;
+
+  const handleSendFriendRequestFromCard = () => {
+    if (!selectedAgentForCard) return;
+    if (sessionStore.sessionMode !== "authed-ready") {
+      router.push("/login");
+      return;
+    }
+    void contactStore.sendContactRequest(selectedAgentForCard.agent_id);
+  };
 
   const handleRetryOwnerHumanCard = () => {
     const human = ownerHumanCard?.human;


### PR DESCRIPTION
## Summary
- Removes the Local daemon / OpenClaw host toggle in the Create Agent dialog so it always uses the Local daemon flow.
- Keeps the `OpenclawBranch` component and related stores untouched in case the toggle is reintroduced later.

## Test plan
- [ ] Open the dashboard, trigger Create Agent — verify only the Local daemon UI shows and provisioning still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)