### PR TITLE
fix(daemon): probe hermes-acp in upstream install.sh venv path

### DIFF
--- a/packages/daemon/src/doctor.ts
+++ b/packages/daemon/src/doctor.ts
@@ -257,6 +257,9 @@ export function renderDoctor(input: DoctorInput): string {
     lines.push(
       `${pad(r.runtime, widths.runtime)}  ${pad(r.name, widths.name)}  ${pad(r.status, widths.status)}  ${pad(r.version, widths.version)}  ${r.path}`,
     );
+    if (!e.result.available && e.installHint) {
+      lines.push(`    → ${e.installHint}`);
+    }
     if (e.endpoints && e.endpoints.length > 0) {
       for (const ep of e.endpoints) {
         const mark = ep.reachable ? "✓" : "✗";

--- a/packages/daemon/src/gateway/__tests__/hermes-agent-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/hermes-agent-adapter.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   chmodSync,
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -9,7 +10,10 @@ import {
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { HermesAgentAdapter } from "../runtimes/hermes-agent.js";
+import {
+  HermesAgentAdapter,
+  resolveHermesAcpCommand,
+} from "../runtimes/hermes-agent.js";
 import { agentHermesWorkspaceDir } from "../../agent-workspace.js";
 
 // Spawn a tiny Node "ACP server" we control instead of the real hermes-acp.
@@ -286,6 +290,30 @@ describe("HermesAgentAdapter", () => {
     });
     expect(res.text).toBe("");
     expect(res.error).toMatch(/aborted before spawn/);
+  });
+
+  it("resolveHermesAcpCommand falls back to ~/.hermes venv when PATH lookup fails", () => {
+    // Upstream `scripts/install.sh` puts hermes-acp at
+    // ~/.hermes/hermes-agent/venv/bin/hermes-acp and only symlinks `hermes`
+    // into ~/.local/bin. Simulate that layout: `which hermes-acp` fails,
+    // but the venv path exists on disk.
+    const fakeHome = mkdtempSync(path.join(os.tmpdir(), "hermes-fallback-"));
+    const venvBin = path.join(fakeHome, ".hermes", "hermes-agent", "venv", "bin");
+    const target = path.join(venvBin, "hermes-acp");
+    mkdirSync(venvBin, { recursive: true });
+    writeFileSync(target, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+    chmodSync(target, 0o755);
+
+    const resolved = resolveHermesAcpCommand({
+      env: { PATH: "/nonexistent" },
+      homeDir: fakeHome,
+      execFileSyncFn: (() => {
+        throw new Error("which: not found");
+      }) as never,
+    });
+    expect(resolved).toBe(target);
+
+    rmSync(fakeHome, { recursive: true, force: true });
   });
 
   it("surfaces non-zero exit with stderr snippet", async () => {

--- a/packages/daemon/src/gateway/runtimes/hermes-agent.ts
+++ b/packages/daemon/src/gateway/runtimes/hermes-agent.ts
@@ -13,12 +13,45 @@ import {
   type AcpUpdateCtx,
   type AcpUpdateParams,
 } from "./acp-stream.js";
-import { readCommandVersion, resolveCommandOnPath, type ProbeDeps } from "./probe.js";
+import {
+  firstExistingPath,
+  readCommandVersion,
+  resolveCommandOnPath,
+  resolveHomePath,
+  type ProbeDeps,
+} from "./probe.js";
 import type { RuntimeProbeResult, RuntimeRunOptions, StreamBlock } from "../types.js";
 
-/** Resolve the `hermes-acp` executable on PATH. */
+/**
+ * Known absolute locations of the `hermes-acp` entry point when it is not on
+ * PATH. The upstream `scripts/install.sh` (curl|bash installer) installs a
+ * private virtualenv under `~/.hermes/hermes-agent/venv/` and only symlinks
+ * the user-facing `hermes` command into `~/.local/bin/` — the `hermes-acp`
+ * entry point stays inside the venv. Without a fallback, daemon's PATH-only
+ * probe misses every user who installed via the README-recommended script.
+ */
+const HERMES_ACP_FALLBACK_RELATIVE_PATHS = [
+  path.join(".hermes", "hermes-agent", "venv", "bin", "hermes-acp"),
+];
+const HERMES_ACP_FALLBACK_SYSTEM_PATHS = [
+  "/opt/hermes/hermes-agent/venv/bin/hermes-acp",
+];
+
+/**
+ * Resolve the `hermes-acp` executable. Tries PATH first, then falls back to
+ * the upstream install.sh's private venv location (`~/.hermes/...`) before
+ * giving up. `BOTCORD_HERMES_AGENT_BIN` always wins via the adapter override.
+ */
 export function resolveHermesAcpCommand(deps: ProbeDeps = {}): string | null {
-  return resolveCommandOnPath("hermes-acp", deps);
+  const onPath = resolveCommandOnPath("hermes-acp", deps);
+  if (onPath) return onPath;
+  return firstExistingPath(
+    [
+      ...HERMES_ACP_FALLBACK_RELATIVE_PATHS.map((p) => resolveHomePath(p, deps)),
+      ...HERMES_ACP_FALLBACK_SYSTEM_PATHS,
+    ],
+    deps,
+  );
 }
 
 /** Probe whether `hermes-acp` is installed and report its version. */

--- a/packages/daemon/src/gateway/runtimes/registry.ts
+++ b/packages/daemon/src/gateway/runtimes/registry.ts
@@ -29,6 +29,11 @@ export interface RuntimeModule {
    * config loader rejects routing turns to this adapter.
    */
   supportsRun?: boolean;
+  /**
+   * Short, single-line install hint shown by `doctor` when the runtime
+   * probes as unavailable. Helps users recover without reading source.
+   */
+  installHint?: string;
 }
 
 /** Built-in runtime module entry for Claude Code. */
@@ -58,6 +63,8 @@ export const hermesAgentModule: RuntimeModule = {
   envVar: "BOTCORD_HERMES_AGENT_BIN",
   probe: () => probeHermesAgent(),
   create: () => new HermesAgentAdapter(),
+  installHint:
+    'Install: pip install "hermes-agent[acp]"  (or set BOTCORD_HERMES_AGENT_BIN to the absolute path of hermes-acp)',
 };
 
 /** Built-in runtime module entry for Gemini (probe-only stub). */
@@ -143,6 +150,7 @@ export interface RuntimeProbeEntry {
   binary: string;
   supportsRun: boolean;
   result: RuntimeProbeResult;
+  installHint?: string;
 }
 
 /** Probe every registered runtime and report installation status. */
@@ -161,6 +169,7 @@ export function detectRuntimes(): RuntimeProbeEntry[] {
       binary: m.binary,
       supportsRun: m.supportsRun !== false,
       result,
+      installHint: m.installHint,
     });
   }
   return out;


### PR DESCRIPTION
## Summary

The official Hermes Agent install path `curl ... install.sh | bash` puts `hermes-acp` inside `~/.hermes/hermes-agent/venv/bin/` and only symlinks the user-facing `hermes` command into `~/.local/bin`. Daemon's previous `which hermes-acp` probe missed this entire install layout — so users who followed the README-recommended setup saw `available: false` in `doctor` and got their `hermes-agent` route rejected.

## Changes

- `gateway/runtimes/hermes-agent.ts` — `resolveHermesAcpCommand` falls back to `~/.hermes/hermes-agent/venv/bin/hermes-acp` (and `/opt/hermes/...` for FHS root installs) after PATH lookup fails. `BOTCORD_HERMES_AGENT_BIN` override and `which` lookup remain unchanged in priority.
- `gateway/runtimes/registry.ts` — added `installHint` field on `RuntimeModule` / `RuntimeProbeEntry`; populated for hermes with `pip install "hermes-agent[acp]"` guidance.
- `doctor.ts` — renders the install hint indented under any missing-runtime row, so users can recover without reading source.
- `gateway/__tests__/hermes-agent-adapter.test.ts` — new unit test simulates install.sh layout (stub `which` failure + venv path on disk) and asserts fallback resolution.

## Verification

Reproduced locally: ran upstream `scripts/install.sh`, confirmed `which hermes-acp` returns nothing, confirmed daemon probe returned `{ available: false }` before the fix and `{ available: true, path: ~/.hermes/.../hermes-acp }` after.

## Test plan

- [ ] `cd packages/daemon && npm test` — hermes-agent suite passes (10/10 incl. new fallback test)
- [ ] `node -e 'import(\"./dist/gateway/runtimes/hermes-agent.js\").then(m => console.log(m.probeHermesAgent()))'` on a machine with install.sh-installed hermes returns `available: true`
- [ ] `botcord-daemon doctor` on a machine without `hermes-acp` shows the install hint line under the missing row