### PR TITLE
fix(daemon): stop reconnect loop when refresh token is rejected

### DIFF
--- a/packages/daemon/src/control-channel.ts
+++ b/packages/daemon/src/control-channel.ts
@@ -18,6 +18,7 @@ import {
 } from "@botcord/protocol-core";
 import { log as daemonLog } from "./log.js";
 import {
+  AuthRefreshRejectedError,
   writeAuthExpiredFlag,
   type UserAuthManager,
 } from "./user-auth.js";
@@ -142,8 +143,17 @@ export class ControlChannel {
     });
     this.connectInflight = this.connect().catch((err) => {
       // Initial connect failure surfaces to the caller; subsequent
-      // reconnects are handled opaquely inside onClose.
-      this.scheduleReconnect(err);
+      // reconnects are handled opaquely inside onClose. A refresh-rejected
+      // error means the refresh token itself is dead — no point retrying;
+      // writeAuthExpiredFlag was already called in user-auth.refresh().
+      if (err instanceof AuthRefreshRejectedError) {
+        this.stopRequested = true;
+        daemonLog.warn("control-channel: refresh rejected; stopping (re-login required)", {
+          status: err.status,
+        });
+      } else {
+        this.scheduleReconnect(err);
+      }
       throw err;
     });
     try {
@@ -285,6 +295,13 @@ export class ControlChannel {
 
   private scheduleReconnect(err?: unknown): void {
     if (this.stopRequested) return;
+    if (err instanceof AuthRefreshRejectedError) {
+      this.stopRequested = true;
+      daemonLog.warn("control-channel: refresh rejected; halting reconnect (re-login required)", {
+        status: err.status,
+      });
+      return;
+    }
     const attempt = this.reconnectAttempts;
     this.reconnectAttempts = attempt + 1;
     const delay = this.backoff[Math.min(attempt, this.backoff.length - 1)];

--- a/packages/daemon/src/user-auth.ts
+++ b/packages/daemon/src/user-auth.ts
@@ -189,6 +189,20 @@ export function isTokenNearExpiry(record: UserAuthRecord, windowMs = 60_000): bo
 }
 
 /**
+ * Thrown when the Hub rejects a refresh token (401/403). Signals that the
+ * user must re-login — reconnect loops should stop instead of hammering
+ * the refresh endpoint forever with a known-bad token.
+ */
+export class AuthRefreshRejectedError extends Error {
+  readonly status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "AuthRefreshRejectedError";
+    this.status = status;
+  }
+}
+
+/**
  * Stateful helper that owns the in-memory copy of user-auth and knows how
  * to refresh it. Used by the control channel so reconnects always carry
  * a fresh access token.
@@ -245,13 +259,35 @@ export class UserAuthManager {
       expiresInMs: current.expiresAt - Date.now(),
     });
     this.refreshInflight = (async () => {
-      const tok = await refreshDaemonToken(current.hubUrl, current.refreshToken);
+      // Refresh tokens rotate server-side. If another local process (e.g. a
+      // second daemon racing on the same user-auth.json) refreshed in the
+      // meantime, the on-disk refreshToken now differs from our in-memory
+      // copy — using the in-memory one would 401 because the server already
+      // invalidated it. Re-read disk first and adopt any newer record.
+      let basis = current;
+      try {
+        const onDisk = loadUserAuth(this.file);
+        if (onDisk && onDisk.refreshToken !== current.refreshToken) {
+          daemonLog.info("user-auth refresh: adopting newer on-disk token", {
+            userId: onDisk.userId,
+            expiresAt: onDisk.expiresAt,
+          });
+          this.record = onDisk;
+          if (!isTokenNearExpiry(onDisk)) return onDisk;
+          basis = onDisk;
+        }
+      } catch (err) {
+        daemonLog.debug("user-auth refresh: disk reread failed (ignored)", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      const tok = await refreshDaemonToken(basis.hubUrl, basis.refreshToken);
       const next: UserAuthRecord = {
-        ...current,
+        ...basis,
         accessToken: tok.accessToken,
         refreshToken: tok.refreshToken,
         expiresAt: Date.now() + tok.expiresIn * 1000,
-        hubUrl: tok.hubUrl || current.hubUrl,
+        hubUrl: tok.hubUrl || basis.hubUrl,
       };
       saveUserAuth(next, this.file);
       this.record = next;
@@ -261,10 +297,23 @@ export class UserAuthManager {
       });
       return next;
     })().catch((err) => {
+      const status =
+        typeof (err as { status?: unknown }).status === "number"
+          ? ((err as { status: number }).status)
+          : null;
+      const message = err instanceof Error ? err.message : String(err);
       daemonLog.warn("user-auth refresh: failed", {
         userId: current.userId,
-        error: err instanceof Error ? err.message : String(err),
+        status,
+        error: message,
       });
+      if (status === 401 || status === 403) {
+        // Refresh token is permanently dead — write the expired flag so
+        // `status` surfaces it and re-throw a typed error so the control
+        // channel can stop reconnect loops instead of hammering the Hub.
+        writeAuthExpiredFlag();
+        throw new AuthRefreshRejectedError(status, message);
+      }
       throw err;
     }).finally(() => {
       this.refreshInflight = null;


### PR DESCRIPTION
## Summary

- When `/daemon/auth/refresh` returns 401 (refresh token rotated by a sibling daemon process or otherwise invalidated), the control channel previously looped `ensureAccessToken → refresh → 401 → scheduleReconnect` forever. Daemon stayed alive, never authenticated, dashboard saw it as offline indefinitely. `auth-expired.flag` was never written because that path only fired on WS close codes 4401/4403/1008 — refresh-API failures don't reach a WS close at all.
- `user-auth.refresh()` now re-reads `user-auth.json` before issuing a refresh, so a token rotation written by a sibling process is adopted instead of clobbered (the rotation race is the most common cause of the 401 in the first place).
- On 401/403 from `refreshDaemonToken`, write `auth-expired.flag` and throw a typed `AuthRefreshRejectedError` so callers can distinguish a dead refresh token from a transient network failure.
- `control-channel.start()` initial-connect catch and `scheduleReconnect()` both short-circuit on `AuthRefreshRejectedError`: set `stopRequested = true` and exit without scheduling another attempt. `botcord-daemon start` re-clears the flag and re-arms the channel after the user logs in again.

## Test plan

- [x] `vitest run src/__tests__/control-channel.test.ts src/__tests__/user-auth.test.ts` — 17/17 pass
- [x] Full `vitest run` — 524 pass; 4 pre-existing `policy-updated-handler` failures present on `main` without this change
- [ ] Manual: revoke a daemon's refresh token server-side, run `botcord-daemon start`, confirm process exits the reconnect loop and `~/.botcord/daemon/auth-expired.flag` is created
- [ ] Manual: start two daemon processes pointing at the same `user-auth.json`, confirm only the surviving one keeps a live WS (sibling adopts the rotated token from disk instead of 401ing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)