### PR TITLE
fix(daemon): prevent list_runtimes ack timeout and idle-close drops

### DIFF
--- a/backend/hub/routers/daemon_control.py
+++ b/backend/hub/routers/daemon_control.py
@@ -629,7 +629,7 @@ class _RefreshRuntimesResponse(BaseModel):
     runtimes_probed_at: datetime.datetime
 
 
-_REFRESH_RUNTIMES_TIMEOUT_MS = 5000
+_REFRESH_RUNTIMES_TIMEOUT_MS = 10000
 
 
 @router.post(

--- a/packages/daemon/src/__tests__/runtime-discovery.test.ts
+++ b/packages/daemon/src/__tests__/runtime-discovery.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Hoisted mock for `../adapters/runtimes.js` so each suite can stub
 // `detectRuntimes()` independently — we want coverage of the "empty
@@ -24,7 +24,13 @@ vi.mock("../adapters/runtimes.js", async () => {
   };
 });
 
-const { collectRuntimeSnapshot, createProvisioner } = await import("../provision.js");
+const { collectRuntimeSnapshot, clearRuntimeProbeCache, createProvisioner } = await import("../provision.js");
+
+beforeEach(() => {
+  // The L1 probe is memoized for 30s in production; tests rotate the
+  // mocked runtime list between cases, so reset before each.
+  clearRuntimeProbeCache();
+});
 const { pushRuntimeSnapshot } = await import("../daemon.js");
 const { CONTROL_FRAME_TYPES } = await import("@botcord/protocol-core");
 import type { GatewayChannelConfig, GatewayRuntimeSnapshot } from "../gateway/index.js";

--- a/packages/daemon/src/control-channel.ts
+++ b/packages/daemon/src/control-channel.ts
@@ -25,7 +25,14 @@ import {
 
 /** Exponential backoff plan for transient disconnects. */
 const RECONNECT_BACKOFF_MS = [1000, 2000, 4000, 8000, 16000, 30000];
-const KEEPALIVE_INTERVAL_MS = 25_000;
+/**
+ * Keepalive cadence. Has to stay below the smallest idle-timeout in any
+ * intermediary on the daemon → Hub WS path. Cloudflare and AWS ALB both
+ * default to ~60s of idle without app-level data, and some tunnels strip
+ * WS-level ping/pong control frames entirely — hence we send an app-level
+ * `pong` heartbeat alongside `ws.ping()` rather than relying on it alone.
+ */
+const KEEPALIVE_INTERVAL_MS = 20_000;
 const REPLAY_DEDUPE_CAP = 256;
 
 /**
@@ -258,11 +265,23 @@ export class ControlChannel {
     this.keepaliveTimer = setInterval(() => {
       const ws = this.ws;
       if (!ws || ws.readyState !== WebSocket.OPEN) return;
+      // WS-level ping for normal cases.
       try {
         ws.ping();
       } catch {
         // ignore — next failed send will trigger close
       }
+      // App-level heartbeat: a `pong` daemon-initiated frame. Hub recognizes
+      // it via `_DAEMON_INITIATED_TYPES` and bumps `last_seen_at`. Critical
+      // when an intermediary (Cloudflare, AWS ALB, some k8s ingresses)
+      // drops WS-level control frames — those proxies idle-close the WS at
+      // ~60s without app-level activity, masquerading as a clean 1006 to
+      // both peers.
+      this.send({
+        id: `hb_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+        type: "pong",
+        ts: Date.now(),
+      });
     }, this.keepaliveMs);
   }
 
@@ -331,6 +350,16 @@ export class ControlChannel {
       return;
     }
     if (!frame || typeof frame.id !== "string" || typeof frame.type !== "string") {
+      // Hub ack responses for daemon-initiated frames (runtime_snapshot push,
+      // heartbeat, etc.) carry `{id, ok}` and no `type`. They're expected,
+      // not malformed — drop silently. Anything else stays a warn.
+      if (
+        frame &&
+        typeof (frame as { id?: unknown }).id === "string" &&
+        typeof (frame as { ok?: unknown }).ok === "boolean"
+      ) {
+        return;
+      }
       daemonLog.warn("control-channel: malformed frame", { frame });
       return;
     }

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -904,14 +904,38 @@ export function removeAgentFromConfig(
 // ---------------------------------------------------------------------------
 
 /**
+ * TTL for the L1 runtime-detection cache. `detectRuntimes()` shells out to
+ * each adapter binary (claude / codex / gemini / openclaw / hermes) to read
+ * `--version`, which routinely costs 1.5–2s in aggregate — long enough to
+ * push `list_runtimes` past the Hub's 10s ack budget when combined with the
+ * 3s openclaw gateway probe. Versions don't change between dashboard refresh
+ * clicks, so cache the L1 snapshot briefly and recompute on miss.
+ */
+const RUNTIME_PROBE_CACHE_TTL_MS = 30_000;
+
+let _runtimeProbeCache: { at: number; value: ListRuntimesResult } | null = null;
+
+/** Drop the cache (e.g. before a `doctor`-style interactive re-probe). */
+export function clearRuntimeProbeCache(): void {
+  _runtimeProbeCache = null;
+}
+
+/**
  * Probe every registered adapter and shape the result as the wire-level
  * {@link ListRuntimesResult} — used by both the `list_runtimes` ack path and
  * the daemon-side first-connect `runtime_snapshot` push in `daemon.ts`.
  *
- * Kept pure: the only side effects are `detectRuntimes()` itself (which the
- * gateway already isolates from throwing) and reading the wall clock.
+ * Cached for {@link RUNTIME_PROBE_CACHE_TTL_MS}; pass `{ force: true }` to
+ * bypass the cache.
  */
-export function collectRuntimeSnapshot(): ListRuntimesResult {
+export function collectRuntimeSnapshot(opts: { force?: boolean } = {}): ListRuntimesResult {
+  if (
+    !opts.force &&
+    _runtimeProbeCache &&
+    Date.now() - _runtimeProbeCache.at < RUNTIME_PROBE_CACHE_TTL_MS
+  ) {
+    return _runtimeProbeCache.value;
+  }
   const entries = detectRuntimes();
   const runtimes: RuntimeProbeResult[] = entries.map((entry) => {
     const record: RuntimeProbeResult = {
@@ -929,7 +953,9 @@ export function collectRuntimeSnapshot(): ListRuntimesResult {
     // enough; filling a synthetic message would be misleading.
     return record;
   });
-  return { runtimes, probedAt: Date.now() };
+  const value: ListRuntimesResult = { runtimes, probedAt: Date.now() };
+  _runtimeProbeCache = { at: Date.now(), value };
+  return value;
 }
 
 /** Maximum number of `endpoints[]` entries persisted per runtime (RFC §3.8.2). */
@@ -1208,7 +1234,7 @@ export async function collectRuntimeSnapshotAsync(opts: {
   const gateways = opts.cfg?.openclawGateways ?? [];
   if (gateways.length === 0) return base;
   // Default daemon-side budget is 3s — it must stay below the Hub's
-  // `list_runtimes` ack wait (5s, see backend/hub/routers/daemon_control.py)
+  // `list_runtimes` ack wait (10s, see backend/hub/routers/daemon_control.py)
   // so a single slow gateway can't blow the whole snapshot to a 504.
   const timeoutMs = opts.timeoutMs ?? 3000;
   const capped = gateways.slice(0, RUNTIME_ENDPOINTS_CAP);


### PR DESCRIPTION
## Summary

Three independent issues that together produced the "Refresh runtimes" 504 + 10-minute control-channel disappearance both reported on preview today.

1. **`list_runtimes` blew the Hub's 5s ack budget.** Daemon-side instrumentation showed `collectRuntimeSnapshotAsync` taking ~5.3s on a fresh connect — `detectRuntimes()` spawns child processes for each adapter binary (`claude`, `codex`, `gemini`, `hermes-agent`, `openclaw-acp`) to read `--version` (~1.5–2s in aggregate), then the openclaw gateway WS probe adds another 3s. Bumped the Hub timeout to 10s and memoized the L1 probe for 30s; `clearRuntimeProbeCache()` is exported for interactive `doctor`-style callers that want fresh data.

2. **WS idle-close (1006) after ~10 minutes.** Keepalive only sent `ws.ping()` control frames every 25s — Cloudflare/ALB/some k8s ingresses strip WS control frames and idle-close at ~60s without app-level activity. Now sending an app-level `pong` daemon-initiated frame alongside the WS ping, and tightened cadence to 20s. Hub already accepts daemon-initiated `pong` via `_DAEMON_INITIATED_TYPES` and uses it to bump `last_seen_at`.

3. **Spurious `malformed frame` warnings.** Hub acks for daemon-initiated pushes (`{id, ok}`, no `type`) were logged at warn level on every runtime_snapshot and would have been logged on every heartbeat after #2. Treat that exact shape as the expected ack envelope.

## Test plan

- [x] `vitest run src/__tests__/runtime-discovery.test.ts src/__tests__/control-channel.test.ts src/__tests__/user-auth.test.ts` — 23/23 pass (added `beforeEach(clearRuntimeProbeCache)` since tests rotate the mocked runtime list across cases).
- [x] Full `vitest run` — 533 pass; 5 pre-existing failures on `main` unchanged (4 `policy-updated-handler` + 1 `provision adoptDiscoveredOpenclawAgents`).
- [ ] Manual on preview: deploy hub, publish daemon patch, click Refresh runtimes — confirm 200 + populated snapshot rather than 504 `daemon_ack_timeout`.
- [ ] Manual on preview: leave daemon idle 15 min, confirm WS stays up (no 1006 close in `~/.botcord/logs/daemon.log`) and dashboard still shows the daemon online.

🤖 Generated with [Claude Code](https://claude.com/claude-code)