### PR TITLE
feat(contacts): show name and avatar instead of raw IDs

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -422,22 +422,32 @@ async def get_overview(
     rooms = await _build_rooms_from_sql(viewer_id, db)
 
     contact_result = await db.execute(
-        select(Contact, Agent.display_name)
+        select(
+            Contact,
+            Agent.display_name.label("agent_dn"),
+            User.display_name.label("user_dn"),
+            User.avatar_url.label("user_avatar"),
+        )
         .outerjoin(Agent, Agent.agent_id == Contact.contact_agent_id)
+        .outerjoin(User, User.human_id == Contact.contact_agent_id)
         .where(
             Contact.owner_id == viewer_id,
             Contact.owner_type == viewer_type,
         )
     )
-    contacts = [
-        {
+    contacts = []
+    for c, agent_dn, user_dn, user_avatar in contact_result.all():
+        is_human = c.peer_type == ParticipantType.human
+        dn = (user_dn if is_human else agent_dn) or c.contact_agent_id
+        avatar = user_avatar if is_human else None
+        contacts.append({
             "contact_agent_id": c.contact_agent_id,
             "alias": c.alias,
-            "display_name": dn or c.contact_agent_id,
+            "display_name": dn,
+            "avatar_url": avatar,
+            "peer_type": c.peer_type.value if hasattr(c.peer_type, "value") else str(c.peer_type),
             "created_at": c.created_at.isoformat() if c.created_at else None,
-        }
-        for c, dn in contact_result.all()
-    ]
+        })
 
     pending_result = await db.execute(
         select(func.count())

--- a/frontend/src/components/dashboard/ChatPane.tsx
+++ b/frontend/src/components/dashboard/ChatPane.tsx
@@ -31,6 +31,7 @@ import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import RoomZeroState from "./RoomZeroState";
 import PendingApprovalsPanel from "./PendingApprovalsPanel";
+import { initialsFromName } from "./roomVisualTheme";
 
 const EXPLORE_GRID_CLASS = "grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5";
 
@@ -328,24 +329,55 @@ function ContactsMainPane() {
           <p className="text-xs text-text-secondary">{t.noContactsFound}</p>
         ) : (
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-            {(pageItems as typeof filteredContacts).map((contact) => (
-              <button
-                key={contact.contact_agent_id}
-                onClick={() => selectAgent(contact.contact_agent_id)}
-                className="rounded-2xl border border-glass-border bg-deep-black-light p-4 text-left transition-all hover:border-neon-cyan/60 hover:bg-glass-bg"
-              >
-                <p className="truncate text-sm font-semibold text-text-primary">
-                  {contact.alias || contact.display_name}
-                </p>
-                <p className="mt-1 truncate font-mono text-[11px] text-text-secondary/60">{contact.contact_agent_id}</p>
-                {contact.alias && (
-                  <p className="mt-2 text-xs text-text-secondary">{t.display}: {contact.display_name}</p>
-                )}
-                <p className="mt-2 text-[11px] text-text-secondary/70">
-                  {t.addedAt} {new Date(contact.created_at).toLocaleDateString()}
-                </p>
-              </button>
-            ))}
+            {(pageItems as typeof filteredContacts).map((contact) => {
+              const isHuman = contact.peer_type === "human" || contact.contact_agent_id.startsWith("hu_");
+              const primaryName = contact.alias || contact.display_name;
+              const hasRealName = primaryName && primaryName !== contact.contact_agent_id;
+              const initials = initialsFromName(hasRealName ? primaryName : contact.contact_agent_id);
+              const avatarBorder = isHuman ? "border-neon-green/30" : "border-neon-cyan/30";
+              const avatarFallback = isHuman
+                ? "border-neon-green/30 bg-neon-green/10 text-neon-green"
+                : "border-neon-cyan/30 bg-neon-cyan/10 text-neon-cyan";
+              return (
+                <button
+                  key={contact.contact_agent_id}
+                  onClick={() => selectAgent(contact.contact_agent_id)}
+                  className="rounded-2xl border border-glass-border bg-deep-black-light p-4 text-left transition-all hover:border-neon-cyan/60 hover:bg-glass-bg"
+                >
+                  <div className="flex items-start gap-3">
+                    {contact.avatar_url ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={contact.avatar_url}
+                        alt={primaryName}
+                        className={`h-10 w-10 shrink-0 rounded-full border object-cover ${avatarBorder}`}
+                      />
+                    ) : (
+                      <div
+                        className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full border text-xs font-semibold ${avatarFallback}`}
+                      >
+                        {initials}
+                      </div>
+                    )}
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-semibold text-text-primary">
+                        {hasRealName ? primaryName : (isHuman ? t.unnamedHuman : t.unnamedAgent)}
+                      </p>
+                      <p className="mt-0.5 text-[10px] uppercase tracking-wide text-text-secondary/60">
+                        {isHuman ? t.contactKindHuman : t.contactKindAgent}
+                      </p>
+                      <p className="mt-1 truncate font-mono text-[11px] text-text-secondary/60">{contact.contact_agent_id}</p>
+                      {contact.alias && contact.display_name && contact.display_name !== contact.alias && (
+                        <p className="mt-1 truncate text-xs text-text-secondary">{t.display}: {contact.display_name}</p>
+                      )}
+                    </div>
+                  </div>
+                  <p className="mt-3 text-[11px] text-text-secondary/70">
+                    {t.addedAt} {new Date(contact.created_at).toLocaleDateString()}
+                  </p>
+                </button>
+              );
+            })}
           </div>
         )}
       </div>

--- a/frontend/src/components/dashboard/ContactList.tsx
+++ b/frontend/src/components/dashboard/ContactList.tsx
@@ -8,6 +8,7 @@ import { useEffect } from "react";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { usePresenceStore } from "@/store/usePresenceStore";
 import { PresenceDot } from "./PresenceDot";
+import { initialsFromName } from "./roomVisualTheme";
 
 export default function ContactList() {
   const locale = useLanguage();
@@ -35,22 +36,48 @@ export default function ContactList() {
 
   return (
     <div className="py-1">
-      {contacts.map((contact) => (
-        <button
-          key={contact.contact_agent_id}
-          onClick={() => selectAgent(contact.contact_agent_id)}
-          className="w-full px-4 py-2.5 text-left transition-colors hover:bg-glass-bg border-l-2 border-transparent"
-        >
-          <div className="flex items-center gap-2 text-sm font-medium text-text-primary">
-            <PresenceDot agentId={contact.contact_agent_id} fallback={contact.online} />
-            <span>{contact.alias || contact.display_name}</span>
-          </div>
-          {contact.alias && (
-            <div className="text-xs text-text-secondary">{contact.display_name}</div>
-          )}
-          <CopyableId value={contact.contact_agent_id} className="mt-0.5" />
-        </button>
-      ))}
+      {contacts.map((contact) => {
+        const isHuman = contact.peer_type === "human" || contact.contact_agent_id.startsWith("hu_");
+        const primaryName = contact.alias || contact.display_name;
+        const hasRealName = primaryName && primaryName !== contact.contact_agent_id;
+        const displayLabel = hasRealName ? primaryName : (isHuman ? t.unnamedHuman : t.unnamedAgent);
+        const initials = initialsFromName(hasRealName ? primaryName : contact.contact_agent_id);
+        const avatarBorder = isHuman ? "border-neon-green/30" : "border-neon-cyan/30";
+        const avatarFallback = isHuman
+          ? "border-neon-green/30 bg-neon-green/10 text-neon-green"
+          : "border-neon-cyan/30 bg-neon-cyan/10 text-neon-cyan";
+        return (
+          <button
+            key={contact.contact_agent_id}
+            onClick={() => selectAgent(contact.contact_agent_id)}
+            className="w-full px-4 py-2.5 text-left transition-colors hover:bg-glass-bg border-l-2 border-transparent"
+          >
+            <div className="flex items-center gap-2.5">
+              {contact.avatar_url ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={contact.avatar_url}
+                  alt={displayLabel}
+                  className={`h-8 w-8 shrink-0 rounded-full border object-cover ${avatarBorder}`}
+                />
+              ) : (
+                <div
+                  className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full border text-[11px] font-semibold ${avatarFallback}`}
+                >
+                  {initials}
+                </div>
+              )}
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2 text-sm font-medium text-text-primary">
+                  <PresenceDot agentId={contact.contact_agent_id} fallback={contact.online} />
+                  <span className="truncate">{displayLabel}</span>
+                </div>
+                <CopyableId value={contact.contact_agent_id} className="mt-0.5" />
+              </div>
+            </div>
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -199,6 +199,10 @@ export const chatPane: TranslationMap<{
   noPreviewMessages: string
   inviteFriend: string
   humanSendDisabled: string
+  contactKindHuman: string
+  contactKindAgent: string
+  unnamedHuman: string
+  unnamedAgent: string
 }> = {
   en: {
     selectPublicRoom: 'Select a public group to browse messages',
@@ -244,6 +248,10 @@ export const chatPane: TranslationMap<{
     noPreviewMessages: 'No preview messages yet',
     inviteFriend: 'Invite friend',
     humanSendDisabled: 'Human messages are disabled for this room',
+    contactKindHuman: 'Human',
+    contactKindAgent: 'Agent',
+    unnamedHuman: 'Unnamed Human',
+    unnamedAgent: 'Unnamed Agent',
   },
   zh: {
     selectPublicRoom: '选择一个公开群浏览消息',
@@ -289,6 +297,10 @@ export const chatPane: TranslationMap<{
     noPreviewMessages: '暂无可预览消息',
     inviteFriend: '邀请好友',
     humanSendDisabled: '该房间已禁用真人发言',
+    contactKindHuman: '真人',
+    contactKindAgent: 'Agent',
+    unnamedHuman: '未命名真人',
+    unnamedAgent: '未命名 Agent',
   },
 }
 
@@ -419,9 +431,11 @@ export const roomList: TranslationMap<{
 
 export const contactList: TranslationMap<{
   noContacts: string
+  unnamedHuman: string
+  unnamedAgent: string
 }> = {
-  en: { noContacts: 'No contacts yet' },
-  zh: { noContacts: '暂无联系人' },
+  en: { noContacts: 'No contacts yet', unnamedHuman: 'Unnamed Human', unnamedAgent: 'Unnamed Agent' },
+  zh: { noContacts: '暂无联系人', unnamedHuman: '未命名真人', unnamedAgent: '未命名 Agent' },
 }
 
 export const agentBrowser: TranslationMap<{

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -71,6 +71,8 @@ export interface ContactInfo {
   contact_agent_id: string;
   alias: string | null;
   display_name: string;
+  avatar_url?: string | null;
+  peer_type?: "agent" | "human";
   created_at: string;
   online?: boolean;
 }


### PR DESCRIPTION
## Summary
- Backend `/api/dashboard/overview` now resolves contact `display_name` and `avatar_url` for both agent and human peers (LEFT JOIN on `Agent.agent_id` and `User.human_id`), and returns `peer_type`.
- Frontend `ContactInfo` type extended with `avatar_url` / `peer_type`.
- Contacts page (`ChatPane` cards) and sidebar (`ContactList`) now render avatar (or initials fallback), real name, and a Human/Agent kind label, falling back to localized "Unnamed Human/Agent" when no real name is set. Cyan tone for agents, green tone for humans.
- New i18n keys: `contactKindHuman/Agent`, `unnamedHuman/Agent` (en + zh).

## Test plan
- [ ] Login with a user that has both human and agent contacts; verify Contacts page shows real names + avatars (humans) and initials (agents) instead of `hu_*` / `ag_*` IDs.
- [ ] Switch language to Chinese; verify "真人" / "Agent" / "未命名真人" / "未命名 Agent" labels.
- [ ] Verify sidebar friend list (left rail) renders identically.
- [ ] Verify `pnpm build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)