### PR TITLE
fix(contacts): route human contact clicks to HumanCardModal

### DIFF
--- a/frontend/src/components/dashboard/ChatPane.tsx
+++ b/frontend/src/components/dashboard/ChatPane.tsx
@@ -50,7 +50,7 @@ function GridSkeletonCards({ count = 10 }: { count?: number }) {
   );
 }
 
-function ContactsMainPane() {
+function ContactsMainPane({ onHumanOpen }: { onHumanOpen?: (human: PublicHumanProfile) => void }) {
   const router = useRouter();
   const locale = useLanguage();
   const t = chatPane[locale];
@@ -341,7 +341,23 @@ function ContactsMainPane() {
               return (
                 <button
                   key={contact.contact_agent_id}
-                  onClick={() => selectAgent(contact.contact_agent_id)}
+                  onClick={async () => {
+                    if (isHuman) {
+                      try {
+                        const human = await api.getPublicHuman(contact.contact_agent_id);
+                        onHumanOpen?.(human);
+                      } catch {
+                        onHumanOpen?.({
+                          human_id: contact.contact_agent_id,
+                          display_name: contact.display_name,
+                          avatar_url: contact.avatar_url ?? null,
+                          created_at: contact.created_at,
+                        });
+                      }
+                    } else {
+                      void selectAgent(contact.contact_agent_id);
+                    }
+                  }}
                   className="rounded-2xl border border-glass-border bg-deep-black-light p-4 text-left transition-all hover:border-neon-cyan/60 hover:bg-glass-bg"
                 >
                   <div className="flex items-start gap-3">
@@ -594,7 +610,7 @@ export default function ChatPane({ onHumanOpen }: ChatPaneProps) {
   }
 
   if (sidebarTab === "contacts") {
-    return <ContactsMainPane />;
+    return <ContactsMainPane onHumanOpen={onHumanOpen} />;
   }
 
   if (!focusedRoomId) {

--- a/frontend/src/components/dashboard/ContactList.tsx
+++ b/frontend/src/components/dashboard/ContactList.tsx
@@ -6,6 +6,7 @@ import CopyableId from "@/components/ui/CopyableId";
 import { useShallow } from "zustand/react/shallow";
 import { useEffect } from "react";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
+import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import { usePresenceStore } from "@/store/usePresenceStore";
 import { PresenceDot } from "./PresenceDot";
 import { initialsFromName } from "./roomVisualTheme";
@@ -17,6 +18,7 @@ export default function ContactList() {
     overview: state.overview,
     selectAgent: state.selectAgent,
   })));
+  const requestOpenHuman = useDashboardUIStore((state) => state.requestOpenHuman);
   const contacts = overview?.contacts || [];
 
   useEffect(() => {
@@ -49,7 +51,13 @@ export default function ContactList() {
         return (
           <button
             key={contact.contact_agent_id}
-            onClick={() => selectAgent(contact.contact_agent_id)}
+            onClick={() => {
+              if (isHuman) {
+                requestOpenHuman(contact.contact_agent_id, displayLabel);
+              } else {
+                void selectAgent(contact.contact_agent_id);
+              }
+            }}
             className="w-full px-4 py-2.5 text-left transition-colors hover:bg-glass-bg border-l-2 border-transparent"
           >
             <div className="flex items-center gap-2.5">


### PR DESCRIPTION
## Summary
- Clicking a contact card whose ID is `hu_*` previously called `selectAgent` and produced an "Agent not found" error.
- ChatPane contacts grid: route human contacts via `onHumanOpen` (with `api.getPublicHuman` lookup, falling back to inline contact data on failure); keep agent contacts on `selectAgent`.
- Sidebar `ContactList`: route human contacts via `useDashboardUIStore.requestOpenHuman` dispatch (already consumed by `DashboardApp`); keep agent contacts on `selectAgent`.

## Test plan
- [ ] Click a human contact card in Contacts > My Friends — `HumanCardModal` opens, no error toast.
- [ ] Click an agent contact card — agent profile card opens as before.
- [ ] Same checks from the sidebar friends list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)