### PR TITLE
fix(daemon): use OpenClaw identity names during adoption

### DIFF
--- a/packages/daemon/src/__tests__/provision.test.ts
+++ b/packages/daemon/src/__tests__/provision.test.ts
@@ -823,7 +823,11 @@ describe("adoptDiscoveredOpenclawAgents", () => {
       });
 
       expect(res.adopted).toEqual(["ag_adopted"]);
-      expect(register).toHaveBeenCalledWith("https://hub.example", "Main Agent", undefined);
+      expect(register).toHaveBeenCalledWith(
+        "https://hub.example",
+        "Main Agent",
+        "OpenClaw agent main adopted from gateway local.",
+      );
       const saved = JSON.parse(
         fs.readFileSync(nodePath.join(credDir, "ag_adopted.json"), "utf8"),
       ) as Record<string, unknown>;
@@ -880,6 +884,69 @@ describe("adoptDiscoveredOpenclawAgents", () => {
         { gateway: "local", openclawAgent: "main", reason: "already_bound" },
       ]);
       expect(register).not.toHaveBeenCalled();
+    });
+  });
+
+  it("uses the OpenClaw workspace identity name when agents.list has no name", async () => {
+    await withSandboxHome(async ({ tmp, fs, path: nodePath }) => {
+      const credDir = nodePath.join(tmp, ".botcord", "credentials");
+      fs.mkdirSync(credDir, { recursive: true });
+      fs.writeFileSync(
+        nodePath.join(credDir, "ag_seed.json"),
+        JSON.stringify({
+          version: 1,
+          hubUrl: "https://hub.example",
+          agentId: "ag_seed",
+          keyId: "k_seed",
+          privateKey: Buffer.alloc(32, 7).toString("base64"),
+          savedAt: new Date().toISOString(),
+        }),
+      );
+      const ocWorkspace = nodePath.join(tmp, ".openclaw", "workspace-swe");
+      fs.mkdirSync(ocWorkspace, { recursive: true });
+      fs.writeFileSync(
+        nodePath.join(ocWorkspace, "IDENTITY.md"),
+        ["# IDENTITY.md", "", "- **Name:** Danny", "- **Vibe:** ships fast"].join("\n"),
+      );
+      fs.writeFileSync(
+        nodePath.join(tmp, ".openclaw", "openclaw.json"),
+        JSON.stringify({
+          agents: {
+            defaults: { workspace: nodePath.join(tmp, ".openclaw", "workspace") },
+            list: [{ id: "swe", workspace: ocWorkspace }],
+          },
+        }),
+      );
+      mockState.cfg = {
+        defaultRoute: { adapter: "claude-code", cwd: "/tmp" },
+        routes: [],
+        streamBlocks: true,
+        agents: ["ag_seed"],
+        openclawGateways: [{ name: "local", url: "ws://127.0.0.1:18789" }],
+      };
+
+      const register = vi.fn(async () => ({
+        agentId: "ag_swe",
+        keyId: "k_swe",
+        privateKey: Buffer.alloc(32, 33).toString("base64"),
+        publicKey: Buffer.alloc(32, 34).toString("base64"),
+        hubUrl: "https://hub.example",
+        token: "tok",
+        expiresAt: Date.now() + 60_000,
+      }));
+
+      await adoptDiscoveredOpenclawAgents({
+        gateway: makeFakeGateway(["ag_seed"]) as unknown as Parameters<typeof adoptDiscoveredOpenclawAgents>[0]["gateway"],
+        register: register as unknown as Parameters<typeof adoptDiscoveredOpenclawAgents>[0]["register"],
+        cfg: mockState.cfg as unknown as DaemonConfig,
+        probe: async () => ({ ok: true, agents: [{ id: "swe" }] }),
+      });
+
+      expect(register).toHaveBeenCalledWith(
+        "https://hub.example",
+        "Danny",
+        "OpenClaw agent swe adopted from gateway local.",
+      );
     });
   });
 });

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -712,9 +712,11 @@ export async function adoptDiscoveredOpenclawAgents(ctx: {
           return;
         }
         try {
+          const name = resolveOpenclawIdentityName(oc.id, oc.workspace) ?? oc.name ?? `openclaw-${oc.id}`;
           const params: ProvisionAgentParams = {
             runtime: "openclaw-acp",
-            name: oc.name ?? `openclaw-${oc.id}`,
+            name,
+            bio: `OpenClaw agent ${oc.id} adopted from gateway ${gw.name}.`,
             openclaw: { gateway: gw.name, agent: oc.id },
           };
           const credentials = await materializeCredentials(params, freshCfg, {
@@ -1197,6 +1199,8 @@ function readLocalOpenclawAgents(): Array<{
       const row: { id: string; name?: string; workspace?: string; model?: { name?: string; provider?: string } } = { id };
       if (typeof raw?.name === "string") row.name = raw.name;
       if (typeof raw?.workspace === "string") row.workspace = raw.workspace;
+      const identityName = resolveOpenclawIdentityName(id, row.workspace, cfg);
+      if (identityName) row.name = identityName;
       const m = raw?.model;
       if (m && typeof m === "object") {
         const model: { name?: string; provider?: string } = {};
@@ -1214,6 +1218,63 @@ function readLocalOpenclawAgents(): Array<{
   } catch {
     return null;
   }
+}
+
+function resolveOpenclawIdentityName(
+  agentId: string,
+  workspace?: string,
+  cfg?: any,
+): string | undefined {
+  const root = workspace ?? resolveOpenclawWorkspace(agentId, cfg);
+  if (!root) return undefined;
+  const file = path.join(expandHomePath(root), "IDENTITY.md");
+  try {
+    if (!existsSync(file)) return undefined;
+    return parseIdentityName(readFileSync(file, "utf8"));
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveOpenclawWorkspace(agentId: string, cfg?: any): string | undefined {
+  let parsed = cfg;
+  if (!parsed) {
+    try {
+      const file = path.join(homedir(), ".openclaw", "openclaw.json");
+      if (!existsSync(file)) return undefined;
+      parsed = JSON.parse(readFileSync(file, "utf8"));
+    } catch {
+      return undefined;
+    }
+  }
+
+  const defaults = parsed?.agents?.defaults;
+  const defaultId = typeof defaults?.id === "string" && defaults.id ? defaults.id : "default";
+  if ((agentId === defaultId || agentId === "default") && typeof defaults?.workspace === "string") {
+    return defaults.workspace;
+  }
+
+  const list = Array.isArray(parsed?.agents?.list) ? parsed.agents.list : [];
+  for (const entry of list) {
+    if (entry?.id === agentId && typeof entry.workspace === "string") return entry.workspace;
+  }
+  return undefined;
+}
+
+function parseIdentityName(raw: string): string | undefined {
+  for (const line of raw.split(/\r?\n/)) {
+    const m = line.match(/^\s*-\s*\*\*Name:\*\*\s*(.+?)\s*$/i);
+    if (!m) continue;
+    const name = m[1].trim();
+    if (name && !name.startsWith("_(")) return name;
+  }
+  return undefined;
+}
+
+function expandHomePath(p: string): string {
+  if (p === "~") return homedir();
+  if (p.startsWith("~/")) return path.join(homedir(), p.slice(2));
+  return p;
 }
 
 /**

--- a/packages/protocol-core/src/client.ts
+++ b/packages/protocol-core/src/client.ts
@@ -897,15 +897,22 @@ export class BotCordClient {
         }
       : generateKeypair();
 
+    const trimmedBio = bio?.trim();
+    const body: {
+      display_name: string;
+      pubkey: string;
+      bio?: string;
+    } = {
+      display_name: name,
+      pubkey: keypair.pubkeyFormatted,
+    };
+    if (trimmedBio) body.bio = trimmedBio;
+
     // Step 1: POST /registry/agents
     const regResp = await fetch(`${normalizedHub}/registry/agents`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        display_name: name,
-        pubkey: keypair.pubkeyFormatted,
-        bio: bio || "",
-      }),
+      body: JSON.stringify(body),
       signal: AbortSignal.timeout(10000),
     });
 


### PR DESCRIPTION
## Summary
- read OpenClaw workspace IDENTITY.md names when enriching local agent discovery
- use identity names for OpenClaw auto-adoption registration, falling back to existing names/openclaw ids
- avoid sending empty bio fields to Hub registration

## Tests
- cd packages/daemon && npm test -- src/__tests__/provision.test.ts
- cd packages/daemon && npx tsc -p tsconfig.build.json --noEmit