### PR TITLE
feat(dashboard): mark Gemini runtime as not yet supported in Create Agent dialog

### DIFF
--- a/frontend/src/components/dashboard/CreateAgentDialog.tsx
+++ b/frontend/src/components/dashboard/CreateAgentDialog.tsx
@@ -59,6 +59,20 @@ function firstOnline(daemons: DaemonInstance[]): DaemonInstance | null {
   return daemons.find((d) => d.status === "online") ?? null;
 }
 
+const UNSUPPORTED_RUNTIME_IDS = new Set(["gemini"]);
+
+function applyRuntimeSupport(
+  runtimes: DaemonRuntime[] | null | undefined,
+  notSupportedLabel: string,
+): DaemonRuntime[] {
+  if (!runtimes) return [];
+  return runtimes.map((r) =>
+    UNSUPPORTED_RUNTIME_IDS.has(r.id)
+      ? { ...r, available: false, error: notSupportedLabel }
+      : r,
+  );
+}
+
 export default function CreateAgentDialog({
   onClose,
   onSuccess,
@@ -113,10 +127,11 @@ export default function CreateAgentDialog({
     setSelectedDaemonId(pick?.id ?? null);
   }, [daemons, onlineDaemons, selectedDaemonId]);
 
-  const selectedDaemon = useMemo(
-    () => daemons.find((d) => d.id === selectedDaemonId) ?? null,
-    [daemons, selectedDaemonId],
-  );
+  const selectedDaemon = useMemo(() => {
+    const d = daemons.find((d) => d.id === selectedDaemonId) ?? null;
+    if (!d) return d;
+    return { ...d, runtimes: applyRuntimeSupport(d.runtimes, t.runtimeNotSupported) };
+  }, [daemons, selectedDaemonId, t.runtimeNotSupported]);
 
   // Auto-select first available runtime when daemon changes.
   useEffect(() => {

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -1592,6 +1592,7 @@ export const createAgentDialog: TranslationMap<{
   noRuntimesDetected: string
   probeRuntimes: string
   runtimeUnavailable: string
+  runtimeNotSupported: string
   nameLabel: string
   namePlaceholder: string
   bioLabel: string
@@ -1622,6 +1623,7 @@ export const createAgentDialog: TranslationMap<{
     noRuntimesDetected: 'No runtimes detected on this daemon.',
     probeRuntimes: 'Probe runtimes',
     runtimeUnavailable: 'unavailable',
+    runtimeNotSupported: 'not yet supported',
     nameLabel: 'Name',
     namePlaceholder: 'my-agent',
     bioLabel: 'Bio (optional)',
@@ -1652,6 +1654,7 @@ export const createAgentDialog: TranslationMap<{
     noRuntimesDetected: '该 daemon 上未检测到可用 runtime。',
     probeRuntimes: '重新探测 runtime',
     runtimeUnavailable: '不可用',
+    runtimeNotSupported: '暂不支持',
     nameLabel: '名称',
     namePlaceholder: 'my-agent',
     bioLabel: '简介（可选）',


### PR DESCRIPTION
## Summary
- Force the Gemini runtime card in the Create Agent dialog to render disabled with a localized "暂不支持" / "not yet supported" hint.
- Override happens in `selectedDaemon` memo via `applyRuntimeSupport`, so auto-select and click handlers naturally skip Gemini — no separate gating needed.
- Background: `geminiModule.supportsRun = false` on the daemon, so picking it would fail at provision time anyway.

## Test plan
- [ ] Open Create Agent dialog on a daemon that probes Gemini as `available: true` → Gemini card renders disabled with "暂不支持" (zh) / "not yet supported" (en) and cannot be selected.
- [ ] Auto-selection skips Gemini and lands on the next available runtime (e.g. Claude Code).
- [ ] Other runtimes (claude-code, codex, hermes-agent, openclaw-acp) behave unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)