### PR TITLE
feat(daemon): seed @botcord/cli skills into agent .claude/ workspace

### DIFF
--- a/packages/daemon/src/__tests__/agent-workspace.test.ts
+++ b/packages/daemon/src/__tests__/agent-workspace.test.ts
@@ -80,6 +80,31 @@ describe("ensureAgentWorkspace", () => {
     expect(existsSync(path.join(agentWorkspaceDir("ag_notes"), "notes", ".gitkeep"))).toBe(true);
   });
 
+  it("seeds bundled Claude Code skills under .claude/skills/", () => {
+    ensureAgentWorkspace("ag_skills", {});
+    const skillsDir = path.join(agentWorkspaceDir("ag_skills"), ".claude", "skills");
+    expect(existsSync(path.join(skillsDir, "botcord", "SKILL.md"))).toBe(true);
+    expect(existsSync(path.join(skillsDir, "botcord-user-guide", "SKILL.md"))).toBe(true);
+  });
+
+  it("re-seeds skills on a second call so daemon upgrades propagate", () => {
+    ensureAgentWorkspace("ag_skill_upgrade", {});
+    const skillFile = path.join(
+      agentWorkspaceDir("ag_skill_upgrade"),
+      ".claude",
+      "skills",
+      "botcord",
+      "SKILL.md",
+    );
+    writeFileSync(skillFile, "stale content from a prior daemon version\n");
+
+    ensureAgentWorkspace("ag_skill_upgrade", {});
+
+    const reseeded = readFileSync(skillFile, "utf8");
+    expect(reseeded).not.toBe("stale content from a prior daemon version\n");
+    expect(reseeded).toContain("name: botcord");
+  });
+
   it("does not overwrite a user-modified memory.md on a second call", () => {
     ensureAgentWorkspace("ag_keep", {});
     const memoryPath = path.join(agentWorkspaceDir("ag_keep"), "memory.md");

--- a/packages/daemon/src/agent-workspace.ts
+++ b/packages/daemon/src/agent-workspace.ts
@@ -19,6 +19,7 @@
 import {
   chmodSync,
   copyFileSync,
+  cpSync,
   existsSync,
   lstatSync,
   mkdirSync,
@@ -28,8 +29,11 @@ import {
   unlinkSync,
   writeFileSync,
 } from "node:fs";
+import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import path from "node:path";
+
+const require = createRequire(import.meta.url);
 
 // Accepted agent id pattern. Enforced at every path-builder entry so a
 // malicious / malformed agentId (e.g. "../../etc") cannot escape
@@ -365,6 +369,48 @@ export function ensureAgentHermesWorkspace(agentId: string): {
 }
 
 /**
+ * Bundled Claude Code skills shipped inside `@botcord/cli/skills/`. Seeded
+ * into every agent workspace so the spawned `claude` runtime (which loads
+ * `.claude/` via `--setting-sources project`) can discover the BotCord CLI
+ * skill without any manual setup.
+ */
+const BUNDLED_CC_SKILLS = ["botcord", "botcord-user-guide"] as const;
+
+function resolveBundledCliSkillsRoot(): string | null {
+  try {
+    const pkgJsonPath = require.resolve("@botcord/cli/package.json");
+    const root = path.join(path.dirname(pkgJsonPath), "skills");
+    return existsSync(root) ? root : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Copy daemon-owned Claude Code skills into the workspace. Re-copied on every
+ * `ensureAgentWorkspace` call (force-overwrite) so daemon upgrades propagate;
+ * users wanting custom skills should pick a different directory name under
+ * `.claude/skills/` — those are not touched here.
+ */
+function seedClaudeCodeSkills(workspace: string): void {
+  const sourceRoot = resolveBundledCliSkillsRoot();
+  if (!sourceRoot) return;
+  const skillsDir = path.join(workspace, ".claude", "skills");
+  mkdirTolerant(path.join(workspace, ".claude"));
+  mkdirTolerant(skillsDir);
+  for (const name of BUNDLED_CC_SKILLS) {
+    const src = path.join(sourceRoot, name);
+    if (!existsSync(src)) continue;
+    const dst = path.join(skillsDir, name);
+    try {
+      cpSync(src, dst, { recursive: true, force: true, dereference: true });
+    } catch {
+      /* best-effort */
+    }
+  }
+}
+
+/**
  * Idempotently create the agent's home / workspace / state directories and
  * seed the workspace Markdown files. Existing files are never overwritten —
  * users' edits to AGENTS.md, memory.md, etc. are preserved across calls.
@@ -392,6 +438,7 @@ export function ensureAgentWorkspace(agentId: string, seed: WorkspaceSeed): void
   writeIfMissing(path.join(workspace, "memory.md"), MEMORY_MD);
   writeIfMissing(path.join(workspace, "task.md"), TASK_MD);
   writeIfMissing(path.join(notes, ".gitkeep"), "");
+  seedClaudeCodeSkills(workspace);
 }
 
 /** Patch fields accepted by {@link applyAgentIdentity}. `bio = null` clears it. */


### PR DESCRIPTION
## Summary

- Daemon-spawned Claude Code runtimes already pass `--setting-sources project` so they will load `<workspace>/.claude/skills/` — but `ensureAgentWorkspace()` never seeded that directory. Net effect: the bundled `botcord` CLI was on the runtime's PATH, but the model had no idea the command existed or how to call it.
- Copy `botcord` and `botcord-user-guide` skills out of the daemon's own `@botcord/cli` dependency into every agent workspace on each `ensureAgentWorkspace()` call. Force-overwrite so daemon upgrades propagate; user-authored skills under other directory names are not touched.
- CLI itself was already "pre-installed" via `buildCliEnv()` PATH injection — only the skill seeding piece was missing.

## Test plan

- [x] `npx vitest run src/__tests__/agent-workspace.test.ts` — 27/27 pass, including new cases asserting (a) both skill SKILL.md files land in `.claude/skills/` and (b) a stale skill file gets re-seeded on the next `ensureAgentWorkspace()` call
- [ ] Provision a fresh agent with a CC runtime end-to-end and confirm the runtime can answer "what is the botcord skill?" / actually invoke `botcord` commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)