### PR TITLE
fix(CreateRoomModal): default new rooms to allow members inviting others

### DIFF
--- a/frontend/src/components/dashboard/CreateRoomModal.tsx
+++ b/frontend/src/components/dashboard/CreateRoomModal.tsx
@@ -93,6 +93,7 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
         name: trimmed,
         description: description.trim(),
         member_ids: Array.from(selected),
+        default_invite: true,
       };
       if (viewMode === "agent") {
         setError(t.createFailed);


### PR DESCRIPTION
## Summary
- New rooms created from the dashboard now pass `default_invite: true`, so regular members can invite others by default.
- `allow_human_send` and `default_send` already default to `true` server-side, so no extra fields are needed — the effective new defaults are: humans can send, members can send, members can invite.
- Owners can still flip any of these off in `RoomSettingsModal` after creation.

## Test plan
- [ ] Create a room from the dashboard, confirm the new room's settings show "Members can invite others" enabled.
- [ ] As a non-owner member, confirm the invite action is available.
- [ ] Backend `RoomSettingsModal` toggles still round-trip correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)