### PR TITLE
fix(frontend): show curl|sh install command on settings/daemons

### DIFF
--- a/frontend/src/components/daemon/DaemonInstallCommand.tsx
+++ b/frontend/src/components/daemon/DaemonInstallCommand.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+/**
+ * [INPUT]: install-ticket BFF (`/api/daemon/auth/install-ticket`); env URLs
+ * [OUTPUT]: DaemonInstallCommand — copy-paste curl|sh panel that installs/starts
+ *   the BotCord daemon and (when an install token is granted) auto-authorizes it
+ * [POS]: shared between CreateAgentDialog (no-daemon state) and DaemonsSettingsPage
+ *   (install/reconnect banner)
+ * [PROTOCOL]: update header on changes
+ */
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import {
+  Check,
+  Copy,
+  ExternalLink,
+  Loader2,
+  RefreshCcw,
+  Server,
+} from "lucide-react";
+
+const HUB_BASE_URL =
+  process.env.NEXT_PUBLIC_HUB_BASE_URL ||
+  (process.env.NODE_ENV === "development"
+    ? "http://localhost:8000"
+    : "https://api.botcord.chat");
+const APP_BASE_URL =
+  process.env.NEXT_PUBLIC_APP_URL ||
+  (process.env.NODE_ENV === "development"
+    ? "http://localhost:3000"
+    : "https://botcord.chat");
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function buildDaemonStartCommand(installToken?: string): string {
+  const args = [`--hub ${shellQuote(HUB_BASE_URL)}`];
+  if (installToken) args.push(`--install-token ${shellQuote(installToken)}`);
+  return `curl -fsSL ${APP_BASE_URL.replace(/\/$/, "")}/daemon/install.sh | sh -s -- ${args.join(" ")}`;
+}
+
+export interface DaemonInstallCommandLabels {
+  title: string;
+  hint: string;
+  copy: string;
+  copied: string;
+  openActivate: string;
+  refresh: string;
+  installTokenError?: string;
+}
+
+interface DaemonInstallCommandProps {
+  labels: DaemonInstallCommandLabels;
+  /** Optional outer-state spinner — combined with internal token-loading state. */
+  busy?: boolean;
+  /** Optional callback fired in addition to refreshing the install token. */
+  onRefresh?: () => void;
+}
+
+export default function DaemonInstallCommand({
+  labels,
+  busy,
+  onRefresh,
+}: DaemonInstallCommandProps) {
+  const [command, setCommand] = useState(() => buildDaemonStartCommand());
+  const [tokenLoading, setTokenLoading] = useState(false);
+  const [tokenError, setTokenError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const copyTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    void refreshInstallCommand();
+    return () => {
+      if (copyTimerRef.current !== null) {
+        window.clearTimeout(copyTimerRef.current);
+        copyTimerRef.current = null;
+      }
+    };
+    // Run once on mount — manual refresh handles retries.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function refreshInstallCommand(): Promise<void> {
+    setTokenLoading(true);
+    setTokenError(null);
+    try {
+      const res = await fetch("/api/daemon/auth/install-ticket", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      if (!res.ok) {
+        throw new Error(await res.text());
+      }
+      const data = (await res.json()) as { install_token?: string };
+      if (!data.install_token) throw new Error("install_token missing");
+      setCommand(buildDaemonStartCommand(data.install_token));
+    } catch (err) {
+      setCommand(buildDaemonStartCommand());
+      setTokenError(
+        err instanceof Error ? err.message : "Failed to generate install token",
+      );
+    } finally {
+      setTokenLoading(false);
+    }
+  }
+
+  async function handleCopy(): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+      if (copyTimerRef.current !== null) {
+        window.clearTimeout(copyTimerRef.current);
+      }
+      copyTimerRef.current = window.setTimeout(() => {
+        copyTimerRef.current = null;
+        setCopied(false);
+      }, 1500);
+    } catch {
+      // ignore — user can select-and-copy manually
+    }
+  }
+
+  function handleRefresh() {
+    void refreshInstallCommand();
+    onRefresh?.();
+  }
+
+  const loading = !!busy || tokenLoading;
+  const fallbackErrorMsg =
+    labels.installTokenError ??
+    "Install token unavailable; command will fall back to interactive auth.";
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl border border-dashed border-glass-border bg-glass-bg/40 p-4">
+        <div className="mb-1 flex items-center gap-2 text-sm font-medium text-text-primary">
+          <Server className="h-4 w-4 text-text-secondary" />
+          {labels.title}
+        </div>
+        <p className="text-xs text-text-secondary">{labels.hint}</p>
+      </div>
+
+      <div>
+        <div className="flex items-stretch gap-2">
+          <code className="flex-1 overflow-x-auto whitespace-nowrap rounded-xl border border-glass-border bg-deep-black px-3 py-2 font-mono text-xs text-text-primary">
+            {command}
+          </code>
+          <button
+            type="button"
+            onClick={() => void handleCopy()}
+            className="inline-flex items-center gap-1.5 rounded-xl border border-glass-border px-3 py-2 text-xs text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
+          >
+            {copied ? (
+              <>
+                <Check className="h-3.5 w-3.5 text-neon-green" />
+                {labels.copied}
+              </>
+            ) : (
+              <>
+                <Copy className="h-3.5 w-3.5" />
+                {labels.copy}
+              </>
+            )}
+          </button>
+        </div>
+        {tokenError && (
+          <p className="mt-2 text-xs text-red-400">{fallbackErrorMsg}</p>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between gap-3">
+        <Link
+          href="/activate"
+          className="inline-flex items-center gap-1.5 text-xs font-medium text-neon-cyan hover:underline"
+        >
+          <ExternalLink className="h-3.5 w-3.5" />
+          {labels.openActivate}
+        </Link>
+        <button
+          type="button"
+          onClick={handleRefresh}
+          disabled={loading}
+          className="inline-flex items-center gap-1.5 rounded-lg border border-glass-border px-2.5 py-1.5 text-xs text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+        >
+          {loading ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <RefreshCcw className="h-3.5 w-3.5" />
+          )}
+          {labels.refresh}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/daemon/DaemonsSettingsPage.tsx
+++ b/frontend/src/components/daemon/DaemonsSettingsPage.tsx
@@ -8,14 +8,12 @@
  */
 
 import { Fragment, useEffect, useMemo, useState } from "react";
-import Link from "next/link";
 import {
   AlertTriangle,
   Check,
   Loader2,
   Pencil,
   RefreshCcw,
-  Server,
   X,
   XCircle,
 } from "lucide-react";
@@ -24,6 +22,7 @@ import {
   type DaemonInstance,
   type DaemonRuntime,
 } from "@/store/useDaemonStore";
+import DaemonInstallCommand from "@/components/daemon/DaemonInstallCommand";
 
 function relativeTime(iso: string | null): string {
   if (!iso) return "never";
@@ -330,6 +329,26 @@ export default function DaemonsSettingsPage() {
   }, [daemons]);
 
   const empty = loaded && sorted.length === 0;
+  const hasOffline = sorted.some((d) => d.status === "offline");
+  const showInstallPanel = empty || hasOffline;
+
+  const installLabels = empty
+    ? {
+        title: "No daemons connected yet",
+        hint: "Run this command on the machine you want to authorize. Once it connects, it will show up here automatically.",
+        copy: "Copy",
+        copied: "Copied",
+        openActivate: "Open activation page",
+        refresh: "Refresh",
+      }
+    : {
+        title: "Reconnect or install a daemon",
+        hint: "Daemon offline? Run this command on the machine to reinstall and reconnect. Same machine reuses its credentials; new machines are authorized automatically.",
+        copy: "Copy",
+        copied: "Copied",
+        openActivate: "Open activation page",
+        refresh: "Refresh",
+      };
 
   return (
     <div className="space-y-6">
@@ -361,24 +380,15 @@ export default function DaemonsSettingsPage() {
         </p>
       )}
 
-      {empty ? (
-        <div className="rounded-2xl border border-dashed border-glass-border bg-glass-bg/40 p-10 text-center">
-          <Server className="mx-auto mb-3 h-8 w-8 text-text-tertiary" />
-          <p className="text-sm text-text-secondary">
-            No daemons connected yet.
-          </p>
-          <p className="mt-1 text-sm text-text-secondary">
-            Visit{" "}
-            <Link
-              href="/activate"
-              className="font-medium text-neon-cyan hover:underline"
-            >
-              /activate
-            </Link>{" "}
-            to authorize one.
-          </p>
-        </div>
-      ) : (
+      {showInstallPanel && (
+        <DaemonInstallCommand
+          labels={installLabels}
+          busy={loading}
+          onRefresh={() => void refresh()}
+        />
+      )}
+
+      {empty ? null : (
         <div className="overflow-x-auto rounded-2xl border border-glass-border">
           <table className="w-full text-sm">
             <thead className="border-b border-glass-border bg-glass-bg">

--- a/frontend/src/components/dashboard/CreateAgentDialog.tsx
+++ b/frontend/src/components/dashboard/CreateAgentDialog.tsx
@@ -7,13 +7,10 @@
  * [PROTOCOL]: update header on changes
  */
 
-import { useEffect, useMemo, useRef, useState } from "react";
-import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
 import {
   Bot,
   Check,
-  Copy,
-  ExternalLink,
   Loader2,
   RefreshCcw,
   Server,
@@ -34,31 +31,11 @@ import {
   type OpenclawInstallTicket,
 } from "@/store/useOpenclawHostStore";
 import InstallCommandPanel from "./InstallCommandPanel";
+import DaemonInstallCommand from "@/components/daemon/DaemonInstallCommand";
 
 interface CreateAgentDialogProps {
   onClose: () => void;
   onSuccess: (agentId: string) => Promise<void> | void;
-}
-
-const HUB_BASE_URL =
-  process.env.NEXT_PUBLIC_HUB_BASE_URL ||
-  (process.env.NODE_ENV === "development"
-    ? "http://localhost:8000"
-    : "https://api.botcord.chat");
-const APP_BASE_URL =
-  process.env.NEXT_PUBLIC_APP_URL ||
-  (process.env.NODE_ENV === "development"
-    ? "http://localhost:3000"
-    : "https://botcord.chat");
-
-function shellQuote(value: string): string {
-  return `'${value.replace(/'/g, `'\\''`)}'`;
-}
-
-function buildStartCommand(installToken?: string): string {
-  const args = [`--hub ${shellQuote(HUB_BASE_URL)}`];
-  if (installToken) args.push(`--install-token ${shellQuote(installToken)}`);
-  return `curl -fsSL ${APP_BASE_URL.replace(/\/$/, "")}/daemon/install.sh | sh -s -- ${args.join(" ")}`;
 }
 
 function firstOnline(daemons: DaemonInstance[]): DaemonInstance | null {
@@ -107,24 +84,10 @@ export default function CreateAgentDialog({
   const [bio, setBio] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
-  const [installCommand, setInstallCommand] = useState(() => buildStartCommand());
-  const [installCommandLoading, setInstallCommandLoading] = useState(false);
-  const [installCommandError, setInstallCommandError] = useState<string | null>(null);
-  const copyTimerRef = useRef<number | null>(null);
 
   useEffect(() => {
     void refresh();
   }, [refresh]);
-
-  useEffect(() => {
-    return () => {
-      if (copyTimerRef.current !== null) {
-        window.clearTimeout(copyTimerRef.current);
-        copyTimerRef.current = null;
-      }
-    };
-  }, []);
 
   // Auto-select first online daemon once the list arrives.
   useEffect(() => {
@@ -175,55 +138,6 @@ export default function CreateAgentDialog({
   }, [selectedRuntime, selectedRuntimeId, selectedGateway]);
 
   const showEmptyState = loaded && onlineDaemons.length === 0;
-
-  async function refreshInstallCommand(): Promise<void> {
-    setInstallCommandLoading(true);
-    setInstallCommandError(null);
-    try {
-      const res = await fetch("/api/daemon/auth/install-ticket", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
-      });
-      if (!res.ok) {
-        throw new Error(await res.text());
-      }
-      const data = (await res.json()) as { install_token?: string };
-      if (!data.install_token) throw new Error("install_token missing");
-      setInstallCommand(buildStartCommand(data.install_token));
-    } catch (err) {
-      setInstallCommand(buildStartCommand());
-      setInstallCommandError(
-        err instanceof Error ? err.message : "Failed to generate install token",
-      );
-    } finally {
-      setInstallCommandLoading(false);
-    }
-  }
-
-  useEffect(() => {
-    if (showEmptyState) {
-      void refreshInstallCommand();
-    }
-    // Only refresh when entering the no-daemon state; manual refresh handles retries.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [showEmptyState]);
-
-  async function handleCopy(): Promise<void> {
-    try {
-      await navigator.clipboard.writeText(installCommand);
-      setCopied(true);
-      if (copyTimerRef.current !== null) {
-        window.clearTimeout(copyTimerRef.current);
-      }
-      copyTimerRef.current = window.setTimeout(() => {
-        copyTimerRef.current = null;
-        setCopied(false);
-      }, 1500);
-    } catch {
-      // ignore — user can select-and-copy manually
-    }
-  }
 
   function translateError(err: unknown): string {
     if (err instanceof ProvisionAgentError) {
@@ -301,16 +215,9 @@ export default function CreateAgentDialog({
             <Loader2 className="h-5 w-5 animate-spin" />
           </div>
         ) : showEmptyState ? (
-          <NoDaemonState
-            command={installCommand}
-            copied={copied}
-            onCopy={handleCopy}
-            loading={loading || installCommandLoading}
-            onRefresh={() => {
-              void refresh();
-              void refreshInstallCommand();
-            }}
-            error={installCommandError}
+          <DaemonInstallCommand
+            busy={loading}
+            onRefresh={() => void refresh()}
             labels={{
               title: t.noDaemonTitle,
               hint: t.noDaemonHint,
@@ -449,96 +356,6 @@ export default function CreateAgentDialog({
             </button>
           </div>
         )}
-      </div>
-    </div>
-  );
-}
-
-function NoDaemonState({
-  command,
-  copied,
-  onCopy,
-  loading,
-  onRefresh,
-  error,
-  labels,
-}: {
-  command: string;
-  copied: boolean;
-  onCopy: () => void | Promise<void>;
-  loading: boolean;
-  onRefresh: () => void;
-  error: string | null;
-  labels: {
-    title: string;
-    hint: string;
-    copy: string;
-    copied: string;
-    openActivate: string;
-    refresh: string;
-  };
-}) {
-  return (
-    <div className="space-y-4">
-      <div className="rounded-xl border border-dashed border-glass-border bg-glass-bg/40 p-4">
-        <div className="mb-1 flex items-center gap-2 text-sm font-medium text-text-primary">
-          <Server className="h-4 w-4 text-text-secondary" />
-          {labels.title}
-        </div>
-        <p className="text-xs text-text-secondary">{labels.hint}</p>
-      </div>
-
-      <div>
-        <div className="flex items-stretch gap-2">
-          <code className="flex-1 overflow-x-auto whitespace-nowrap rounded-xl border border-glass-border bg-deep-black px-3 py-2 font-mono text-xs text-text-primary">
-            {command}
-          </code>
-          <button
-            type="button"
-            onClick={() => void onCopy()}
-            className="inline-flex items-center gap-1.5 rounded-xl border border-glass-border px-3 py-2 text-xs text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
-          >
-            {copied ? (
-              <>
-                <Check className="h-3.5 w-3.5 text-neon-green" />
-                {labels.copied}
-              </>
-            ) : (
-              <>
-                <Copy className="h-3.5 w-3.5" />
-                {labels.copy}
-              </>
-            )}
-          </button>
-        </div>
-        {error && (
-          <p className="mt-2 text-xs text-red-400">
-            Install token unavailable; command will fall back to interactive auth.
-          </p>
-        )}
-      </div>
-
-      <div className="flex items-center justify-between gap-3">
-        <Link
-          href="/activate"
-          className="inline-flex items-center gap-1.5 text-xs font-medium text-neon-cyan hover:underline"
-        >
-          <ExternalLink className="h-3.5 w-3.5" />
-          {labels.openActivate}
-        </Link>
-        <button
-          type="button"
-          onClick={onRefresh}
-          disabled={loading}
-          className="inline-flex items-center gap-1.5 rounded-lg border border-glass-border px-2.5 py-1.5 text-xs text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
-        >
-          {loading ? (
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
-          ) : (
-            <RefreshCcw className="h-3.5 w-3.5" />
-          )}
-          {labels.refresh}
-        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- `/settings/daemons` had no actionable info when a daemon went offline — users were stuck guessing how to reconnect.
- Lift the curl|sh install panel out of `CreateAgentDialog` into a shared `DaemonInstallCommand` component (fetches `/api/daemon/auth/install-ticket`, copy/refresh/`/activate` link built in).
- Render it on `/settings/daemons` when the list is empty or any daemon is offline. Same install-ticket flow as Create Agent: same machine reuses existing creds; a new machine auto-authorizes via the install token.

## Behavior
- Empty list → full panel with "No daemons connected yet" copy (replaces the old "/activate" hint).
- Any offline daemon → same panel above the table with reconnect copy.
- All online → panel hidden, page stays clean.

## Test plan
- [ ] `/settings/daemons` with no daemons: panel shown, command copies, `/activate` link works
- [ ] `/settings/daemons` with an offline daemon: panel renders above the table; running the command on that machine brings it back online
- [ ] `/settings/daemons` with all daemons online: panel hidden
- [ ] Create Agent dialog still shows the same panel in its no-daemon state (refactor preserves behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)