### PR TITLE
fix(dashboard): default new rooms to allow invites + route invite/share via Human API

### DIFF
--- a/frontend/src/components/dashboard/CreateRoomModal.tsx
+++ b/frontend/src/components/dashboard/CreateRoomModal.tsx
@@ -93,6 +93,7 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
         name: trimmed,
         description: description.trim(),
         member_ids: Array.from(selected),
+        default_invite: true,
       };
       if (viewMode === "agent") {
         setError(t.createFailed);

--- a/frontend/src/components/dashboard/InviteOthersGuide.tsx
+++ b/frontend/src/components/dashboard/InviteOthersGuide.tsx
@@ -8,7 +8,8 @@
 "use client";
 
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { api } from "@/lib/api";
+import { api, humansApi } from "@/lib/api";
+import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useLanguage } from "@/lib/i18n";
 import { common } from "@/lib/i18n/translations/common";
 import { joinGuide } from "@/lib/i18n/translations/dashboard";
@@ -26,6 +27,7 @@ export default function InviteOthersGuide({ roomId, roomName, visibility, canInv
   const locale = useLanguage();
   const tc = common[locale];
   const t = joinGuide[locale];
+  const isHumanView = useDashboardSessionStore((state) => state.viewMode === "human");
   const [copied, setCopied] = useState(false);
   const [shareData, setShareData] = useState<CreateShareResponse | InvitePreviewResponse | null>(null);
   const [promptError, setPromptError] = useState<string | null>(null);
@@ -46,9 +48,10 @@ export default function InviteOthersGuide({ roomId, roomName, visibility, canInv
       setIsPreparingPrompt(true);
       setPromptError(null);
       try {
+        const inviteApi = isHumanView ? humansApi : api;
         const nextShareData = needsInviteLink
-          ? await api.createRoomInvite(roomId)
-          : await api.createShareLink(roomId);
+          ? await inviteApi.createRoomInvite(roomId)
+          : await inviteApi.createShareLink(roomId);
         if (!cancelled) {
           setShareData(nextShareData);
         }
@@ -68,7 +71,7 @@ export default function InviteOthersGuide({ roomId, roomName, visibility, canInv
     return () => {
       cancelled = true;
     };
-  }, [canInvite, needsInviteLink, roomId, t.preparePromptFailed]);
+  }, [canInvite, needsInviteLink, roomId, isHumanView, t.preparePromptFailed]);
 
   const combinedPrompt = useMemo(() => {
     if (!shareData) {

--- a/frontend/src/components/dashboard/ShareModal.tsx
+++ b/frontend/src/components/dashboard/ShareModal.tsx
@@ -10,7 +10,8 @@ import { useEffect, useMemo, useState } from "react";
 import { useLanguage } from "@/lib/i18n";
 import { shareModal } from "@/lib/i18n/translations/dashboard";
 import { common } from "@/lib/i18n/translations/common";
-import { api } from "@/lib/api";
+import { api, humansApi } from "@/lib/api";
+import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import type { CreateShareResponse, InvitePreviewResponse, PublicRoomMember } from "@/lib/types";
 import { buildSharePrompt } from "@/lib/onboarding";
 import { Copy, Globe2, Link2, Loader2, Lock, Sparkles, X } from "lucide-react";
@@ -28,6 +29,7 @@ export default function ShareModal({ roomId, roomName, roomVisibility, canInvite
   const locale = useLanguage();
   const t = shareModal[locale];
   const tc = common[locale];
+  const isHumanView = useDashboardSessionStore((state) => state.viewMode === "human");
   const [shareData, setShareData] = useState<(CreateShareResponse | InvitePreviewResponse) | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -62,9 +64,10 @@ export default function ShareModal({ roomId, roomName, roomVisibility, canInvite
     setLoading(true);
     setError(null);
     try {
+      const inviteApi = isHumanView ? humansApi : api;
       const data = roomVisibility === "private"
-        ? await api.createRoomInvite(roomId)
-        : await api.createShareLink(roomId);
+        ? await inviteApi.createRoomInvite(roomId)
+        : await inviteApi.createShareLink(roomId);
       setShareData(data);
     } catch (err: any) {
       setError(err.message || t.failedToCreateLink);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1020,6 +1020,16 @@ const humansApi = {
     );
   },
 
+  /** Human creates a private-room invite link. */
+  createRoomInvite(roomId: string): Promise<InvitePreviewResponse> {
+    return apiPost<InvitePreviewResponse>(`/api/humans/me/rooms/${roomId}/invite`);
+  },
+
+  /** Human creates a public-room share snapshot. */
+  createShareLink(roomId: string): Promise<CreateShareResponse> {
+    return apiPost<CreateShareResponse>(`/api/humans/me/rooms/${roomId}/share`);
+  },
+
   /** Received contact requests (pending-by-default). */
   listReceivedContactRequests(
     opts?: { state?: "pending" | "accepted" | "rejected" },


### PR DESCRIPTION
## Summary
- **CreateRoomModal**: default new rooms to `default_invite=true` so members can invite others without an admin toggling permissions first.
- **ShareModal / InviteOthersGuide**: when the dashboard is in Human view (`viewMode === "human"`), dispatch to `humansApi.createRoomInvite` / `createShareLink` (`/api/humans/me/rooms/{id}/invite|/share`). The agent-scoped endpoints require `X-Active-Agent`, which Human view never sends, so "Create invite" was failing with `400 X-Active-Agent header is required`.

## Test plan
- [ ] In Human view, open a private room → click Share → "Create invite link" succeeds and returns a working `iv_*` code
- [ ] In Human view, open a public room → click Share → snapshot share link is generated
- [ ] In Agent view, both flows still work via the agent-scoped endpoints (regression check)
- [ ] Create a new room from CreateRoomModal → confirm `default_invite` is true and ordinary members can invite

🤖 Generated with [Claude Code](https://claude.com/claude-code)