### PR TITLE
fix(dashboard): align room invite UI with backend default_invite

### DIFF
--- a/frontend/src/components/dashboard/CreateRoomModal.tsx
+++ b/frontend/src/components/dashboard/CreateRoomModal.tsx
@@ -93,6 +93,7 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
         name: trimmed,
         description: description.trim(),
         member_ids: Array.from(selected),
+        default_invite: true,
       };
       if (viewMode === "agent") {
         setError(t.createFailed);

--- a/frontend/src/components/dashboard/InviteOthersGuide.tsx
+++ b/frontend/src/components/dashboard/InviteOthersGuide.tsx
@@ -8,7 +8,8 @@
 "use client";
 
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { api } from "@/lib/api";
+import { api, humansApi } from "@/lib/api";
+import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useLanguage } from "@/lib/i18n";
 import { common } from "@/lib/i18n/translations/common";
 import { joinGuide } from "@/lib/i18n/translations/dashboard";
@@ -26,6 +27,7 @@ export default function InviteOthersGuide({ roomId, roomName, visibility, canInv
   const locale = useLanguage();
   const tc = common[locale];
   const t = joinGuide[locale];
+  const isHumanView = useDashboardSessionStore((state) => state.viewMode === "human");
   const [copied, setCopied] = useState(false);
   const [shareData, setShareData] = useState<CreateShareResponse | InvitePreviewResponse | null>(null);
   const [promptError, setPromptError] = useState<string | null>(null);
@@ -46,9 +48,10 @@ export default function InviteOthersGuide({ roomId, roomName, visibility, canInv
       setIsPreparingPrompt(true);
       setPromptError(null);
       try {
+        const inviteApi = isHumanView ? humansApi : api;
         const nextShareData = needsInviteLink
-          ? await api.createRoomInvite(roomId)
-          : await api.createShareLink(roomId);
+          ? await inviteApi.createRoomInvite(roomId)
+          : await inviteApi.createShareLink(roomId);
         if (!cancelled) {
           setShareData(nextShareData);
         }
@@ -68,7 +71,7 @@ export default function InviteOthersGuide({ roomId, roomName, visibility, canInv
     return () => {
       cancelled = true;
     };
-  }, [canInvite, needsInviteLink, roomId, t.preparePromptFailed]);
+  }, [canInvite, needsInviteLink, roomId, isHumanView, t.preparePromptFailed]);
 
   const combinedPrompt = useMemo(() => {
     if (!shareData) {

--- a/frontend/src/components/dashboard/RoomHeader.tsx
+++ b/frontend/src/components/dashboard/RoomHeader.tsx
@@ -85,7 +85,9 @@ export default function RoomHeader() {
   const dmContact = isDMRoom && dmPartnerAgentId
     ? (overview?.contacts.find((c) => c.contact_agent_id === dmPartnerAgentId) ?? null)
     : null;
-  const canInvite = isHumanView ? isOwnerOrAdmin : (authRoom?.can_invite ?? true);
+  const canInvite = isHumanView
+    ? isOwnerOrAdmin || (Boolean(myRole) && Boolean(humanRoom?.default_invite))
+    : (authRoom?.can_invite ?? true);
   const roleLabel = myRole
     ? locale === "zh"
       ? `你是 ${myRole}`

--- a/frontend/src/components/dashboard/RoomSettingsModal.tsx
+++ b/frontend/src/components/dashboard/RoomSettingsModal.tsx
@@ -178,7 +178,6 @@ export default function RoomSettingsModal({
 
   const canEditBasics = viewerRole === "owner" || viewerRole === "admin";
   const isOwner = viewerRole === "owner";
-  const canManageMembers = viewerMode === "human" && (isOwner || viewerRole === "admin");
   const isLeaving = leavingRoomId === roomId;
   const activeSubscription = initialSubscriptionProductId
     ? getActiveSubscription(initialSubscriptionProductId)
@@ -191,6 +190,8 @@ export default function RoomSettingsModal({
   const [joinPolicy, setJoinPolicy] = useState(initialJoinPolicy);
   const [defaultSend, setDefaultSend] = useState(initialDefaultSend);
   const [defaultInvite, setDefaultInvite] = useState(initialDefaultInvite);
+  const canManageMembers =
+    isOwner || viewerRole === "admin" || (Boolean(viewerRole) && defaultInvite);
   const [allowHumanSend, setAllowHumanSend] = useState(initialAllowHumanSend);
   const [maxMembers, setMaxMembers] = useState(
     initialMaxMembers == null ? "" : String(initialMaxMembers),

--- a/frontend/src/components/dashboard/ShareModal.tsx
+++ b/frontend/src/components/dashboard/ShareModal.tsx
@@ -10,7 +10,8 @@ import { useEffect, useMemo, useState } from "react";
 import { useLanguage } from "@/lib/i18n";
 import { shareModal } from "@/lib/i18n/translations/dashboard";
 import { common } from "@/lib/i18n/translations/common";
-import { api } from "@/lib/api";
+import { api, humansApi } from "@/lib/api";
+import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import type { CreateShareResponse, InvitePreviewResponse, PublicRoomMember } from "@/lib/types";
 import { buildSharePrompt } from "@/lib/onboarding";
 import { Copy, Globe2, Link2, Loader2, Lock, Sparkles, X } from "lucide-react";
@@ -28,6 +29,7 @@ export default function ShareModal({ roomId, roomName, roomVisibility, canInvite
   const locale = useLanguage();
   const t = shareModal[locale];
   const tc = common[locale];
+  const isHumanView = useDashboardSessionStore((state) => state.viewMode === "human");
   const [shareData, setShareData] = useState<(CreateShareResponse | InvitePreviewResponse) | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -62,9 +64,10 @@ export default function ShareModal({ roomId, roomName, roomVisibility, canInvite
     setLoading(true);
     setError(null);
     try {
+      const inviteApi = isHumanView ? humansApi : api;
       const data = roomVisibility === "private"
-        ? await api.createRoomInvite(roomId)
-        : await api.createShareLink(roomId);
+        ? await inviteApi.createRoomInvite(roomId)
+        : await inviteApi.createShareLink(roomId);
       setShareData(data);
     } catch (err: any) {
       setError(err.message || t.failedToCreateLink);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1020,6 +1020,16 @@ const humansApi = {
     );
   },
 
+  /** Human creates a private-room invite link. */
+  createRoomInvite(roomId: string): Promise<InvitePreviewResponse> {
+    return apiPost<InvitePreviewResponse>(`/api/humans/me/rooms/${roomId}/invite`);
+  },
+
+  /** Human creates a public-room share snapshot. */
+  createShareLink(roomId: string): Promise<CreateShareResponse> {
+    return apiPost<CreateShareResponse>(`/api/humans/me/rooms/${roomId}/share`);
+  },
+
   /** Received contact requests (pending-by-default). */
   listReceivedContactRequests(
     opts?: { state?: "pending" | "accepted" | "rejected" },


### PR DESCRIPTION
## Summary

Brings the dashboard's invite/add-member UX in line with the backend's `_can_invite` rule so that "members can invite" actually works end-to-end.

- **`RoomSettingsModal` Add Members button** (`RoomSettingsModal.tsx`): now visible when the viewer is owner, admin, **or any member of a room with `default_invite=true`**. Drops the `viewerMode === "human"` restriction so agent members can invite too. Uses live state so toggling `default_invite` in the panel reflects immediately.
- **`RoomHeader` Invite/Share button** (`RoomHeader.tsx`): extends `canInvite` in human view to cover members of rooms where `default_invite=true`. Agent view already trusted the backend-resolved `authRoom.can_invite` and is unchanged.
- **`ShareModal` / `InviteOthersGuide`**: route through `humansApi.createRoomInvite` / `createShareLink` when in Human view (avoids the 400 "X-Active-Agent header is required" because Human view sends no agent header).
- **`CreateRoomModal`**: new rooms default to `default_invite: true` for friendlier collaboration defaults.

Backend rule for reference (`backend/hub/routers/room.py` `_can_invite`): owner → public+open → per-member `can_invite` override → admin → `room.default_invite`.

## Test plan
- [ ] As a non-admin member of a room with `default_invite=true`, "Add Members" appears in Room Settings and the header Invite button is visible
- [ ] As a non-admin member of a room with `default_invite=false`, both entries stay hidden
- [ ] Owner toggling `default_invite` ON inside the settings panel makes the Add Members button appear immediately (no save round-trip needed)
- [ ] In Human view, "Create invite" / "Share" succeed without the prior `X-Active-Agent header is required` 400
- [ ] New rooms created from the dashboard have `default_invite=true` (verify via room settings or backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)