### PR TITLE
fix(dashboard): auto-collapse stream trace when final response starts

### DIFF
--- a/frontend/src/components/dashboard/StreamBlocksView.tsx
+++ b/frontend/src/components/dashboard/StreamBlocksView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Search, FileText, CheckCircle2, Code2, Brain, HelpCircle, Wrench, ChevronDown, ChevronRight, Bot, AlertTriangle, ListTodo, Info } from "lucide-react";
 import type { StreamBlockEntry } from "@/lib/types";
 import MarkdownContent from "@/components/ui/MarkdownContent";
@@ -364,6 +364,7 @@ export default function StreamBlocksView({
   onScrollRequest?: () => void;
 }) {
   const [expanded, setExpanded] = useState(defaultExpanded ?? false);
+  const autoCollapsedRef = useRef(false);
 
   const isAssistant = (k: string) => k === "assistant" || k === "assistant_text";
   const executionBlocks = blocks.filter((b) => !isAssistant(b.block.kind));
@@ -407,6 +408,13 @@ export default function StreamBlocksView({
   useEffect(() => {
     onScrollRequest?.();
   }, [blocks.length, onScrollRequest]);
+
+  useEffect(() => {
+    if (composingText && !autoCollapsedRef.current) {
+      autoCollapsedRef.current = true;
+      setExpanded(false);
+    }
+  }, [composingText]);
 
   if (blocks.length === 0) return null;
 


### PR DESCRIPTION
## Summary
- When the assistant begins streaming its final response, the "N tool calls" trace panel above the message now auto-collapses so the user's eye lands on the answer instead of the execution log.
- Implemented in `StreamBlocksView` via a one-shot effect that fires the first time `composingText` becomes non-empty; a `useRef` guard ensures subsequent re-renders won't fight the user if they manually re-expand.

## Test plan
- [ ] Send a message that triggers tool calls; verify the trace panel is expanded while tools run.
- [ ] As soon as the assistant starts composing the final response, the trace collapses to the summary header.
- [ ] Click the trace header to re-expand; subsequent stream chunks (more composing text, scroll updates) do not auto-collapse it again.
- [ ] After the message finalizes, the persisted trace is rendered collapsed by default (existing behavior, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)