### PR TITLE
fix(invites): allow Human (hu_*) creators for friend invites

### DIFF
--- a/backend/app/routers/humans.py
+++ b/backend/app/routers/humans.py
@@ -930,6 +930,44 @@ async def create_room_share_as_human(
     )
 
 
+@router.post("/me/invite", status_code=201)
+async def create_friend_invite_as_human(
+    body: CreateHumanInviteBody | None = None,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    user = await _load_human(db, ctx)
+    payload = body or CreateHumanInviteBody()
+    invite = Invite(
+        code=f"iv_{uuid4().hex[:20]}",
+        kind="friend",
+        creator_agent_id=user.human_id,
+        expires_at=_now() + datetime.timedelta(hours=payload.expires_in_hours)
+        if payload.expires_in_hours
+        else None,
+        max_uses=max(1, payload.max_uses),
+    )
+    db.add(invite)
+    await db.commit()
+    return {
+        "code": invite.code,
+        "kind": invite.kind,
+        "entry_type": "friend_invite",
+        "target_type": "friend",
+        "target_id": user.human_id,
+        "invite_url": _invite_url(invite.code),
+        "continue_url": frontend_url("/chats/contacts/agents"),
+        "expires_at": invite.expires_at.isoformat() if invite.expires_at else None,
+        "max_uses": invite.max_uses,
+        "use_count": invite.use_count,
+        "creator": {
+            "agent_id": user.human_id,
+            "display_name": user.display_name or user.human_id,
+        },
+        "room": None,
+    }
+
+
 @router.post(
     "/me/rooms/{room_id}/invite",
     status_code=201,

--- a/backend/hub/invite_ops.py
+++ b/backend/hub/invite_ops.py
@@ -12,8 +12,8 @@ from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from hub.enums import RoomRole, SubscriptionStatus
-from hub.models import Agent, AgentSubscription, Contact, Invite, InviteRedemption, Room, RoomMember
+from hub.enums import ParticipantType, RoomRole, SubscriptionStatus
+from hub.models import Agent, AgentSubscription, Contact, Invite, InviteRedemption, Room, RoomMember, User
 from hub.share_payloads import frontend_url, room_continue_url, room_entry_type
 
 
@@ -33,21 +33,53 @@ def _invite_url(code: str) -> str:
     return frontend_url(f"/i/{code}")
 
 
-def _serialize_invite_preview(invite: Invite, creator: Agent, room: Room | None, member_count: int = 0) -> dict:
+def _participant_type_for(participant_id: str) -> ParticipantType:
+    if participant_id.startswith("hu_"):
+        return ParticipantType.human
+    return ParticipantType.agent
+
+
+async def _load_invite_creator(
+    creator_id: str, db: AsyncSession
+) -> tuple[str, str] | None:
+    """Resolve an invite creator to ``(id, display_name)``.
+
+    Friend/room invites can be created by either an Agent (``ag_*``) or a
+    Human (``hu_*``); we look up whichever matches the prefix and fall back
+    to a degraded preview when the principal can't be found.
+    """
+    if creator_id.startswith("hu_"):
+        user = await db.scalar(select(User).where(User.human_id == creator_id))
+        if user is None:
+            return None
+        return creator_id, user.display_name or creator_id
+    agent = await db.scalar(select(Agent).where(Agent.agent_id == creator_id))
+    if agent is None:
+        return None
+    return agent.agent_id, agent.display_name or creator_id
+
+
+def _serialize_invite_preview(
+    invite: Invite,
+    creator_id: str,
+    creator_display_name: str,
+    room: Room | None,
+    member_count: int = 0,
+) -> dict:
     return {
         "code": invite.code,
         "kind": invite.kind,
         "entry_type": "friend_invite" if invite.kind == "friend" else room_entry_type(room).replace("private_room", "private_invite") if room else "private_invite",
         "target_type": "friend" if invite.kind == "friend" else "room",
-        "target_id": creator.agent_id if invite.kind == "friend" else invite.room_id,
+        "target_id": creator_id if invite.kind == "friend" else invite.room_id,
         "invite_url": _invite_url(invite.code),
         "continue_url": _continue_url_for_invite(invite, room),
         "expires_at": invite.expires_at.isoformat() if invite.expires_at else None,
         "max_uses": invite.max_uses,
         "use_count": invite.use_count,
         "creator": {
-            "agent_id": creator.agent_id,
-            "display_name": creator.display_name,
+            "agent_id": creator_id,
+            "display_name": creator_display_name,
         },
         "room": None if room is None else {
             "room_id": room.room_id,
@@ -128,9 +160,10 @@ async def preview_invite(code: str, db: AsyncSession) -> dict:
     invite = await _load_invite_or_404(code, db)
     _ensure_invite_active(invite)
 
-    creator = await db.scalar(select(Agent).where(Agent.agent_id == invite.creator_agent_id))
-    if creator is None:
+    resolved = await _load_invite_creator(invite.creator_agent_id, db)
+    if resolved is None:
         raise HTTPException(status_code=404, detail="Invite creator not found")
+    creator_id, creator_display_name = resolved
 
     room = None
     member_count = 0
@@ -140,7 +173,13 @@ async def preview_invite(code: str, db: AsyncSession) -> dict:
             select(func.count(RoomMember.id)).where(RoomMember.room_id == invite.room_id)
         ) or 0
 
-    return _serialize_invite_preview(invite, creator=creator, room=room, member_count=member_count)
+    return _serialize_invite_preview(
+        invite,
+        creator_id=creator_id,
+        creator_display_name=creator_display_name,
+        room=room,
+        member_count=member_count,
+    )
 
 
 async def redeem_invite_for_agent(code: str, agent_id: str, db: AsyncSession) -> dict:
@@ -165,8 +204,24 @@ async def redeem_invite_for_agent(code: str, agent_id: str, db: AsyncSession) ->
         if invite.creator_agent_id == agent_id:
             raise HTTPException(status_code=400, detail="You cannot use your own friend invite")
         _ensure_invite_active(invite)
-        db.add(Contact(owner_id=agent_id, contact_agent_id=invite.creator_agent_id))
-        db.add(Contact(owner_id=invite.creator_agent_id, contact_agent_id=agent_id))
+        redeemer_type = _participant_type_for(agent_id)
+        creator_type = _participant_type_for(invite.creator_agent_id)
+        db.add(
+            Contact(
+                owner_id=agent_id,
+                owner_type=redeemer_type,
+                contact_agent_id=invite.creator_agent_id,
+                peer_type=creator_type,
+            )
+        )
+        db.add(
+            Contact(
+                owner_id=invite.creator_agent_id,
+                owner_type=creator_type,
+                contact_agent_id=agent_id,
+                peer_type=redeemer_type,
+            )
+        )
         await _record_redemption(invite, agent_id, db)
         await db.commit()
         return {

--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -634,8 +634,10 @@ class Invite(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     code: Mapped[str] = mapped_column(String(32), nullable=False, index=True)
     kind: Mapped[str] = mapped_column(String(16), nullable=False)
+    # Polymorphic — holds either ``ag_*`` or ``hu_*``. FK to agents was
+    # dropped in migration 034 so Human creators don't violate it.
     creator_agent_id: Mapped[str] = mapped_column(
-        String(32), ForeignKey("agents.agent_id"), nullable=False, index=True
+        String(32), nullable=False, index=True
     )
     room_id: Mapped[str | None] = mapped_column(
         String(64), ForeignKey("rooms.room_id"), nullable=True, index=True
@@ -663,8 +665,10 @@ class InviteRedemption(Base):
     code: Mapped[str] = mapped_column(
         String(32), ForeignKey("invites.code"), nullable=False, index=True
     )
+    # Polymorphic — holds either ``ag_*`` or ``hu_*``. FK to agents was
+    # dropped in migration 034.
     redeemer_agent_id: Mapped[str] = mapped_column(
-        String(32), ForeignKey("agents.agent_id"), nullable=False, index=True
+        String(32), nullable=False, index=True
     )
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()

--- a/backend/migrations/034_invites_polymorphic_creator.sql
+++ b/backend/migrations/034_invites_polymorphic_creator.sql
@@ -1,0 +1,14 @@
+-- Migration: Allow Human (hu_*) participants to author / redeem invites.
+--
+-- The original schema (018_create_invites.sql) constrained
+-- ``invites.creator_agent_id`` and ``invite_redemptions.redeemer_agent_id``
+-- to reference ``agents(agent_id)``. After the polymorphic Human rollout,
+-- both columns can legitimately hold ``hu_*`` ids, so the foreign keys
+-- need to be dropped — column types stay the same since both id families
+-- are 32-char prefixed strings.
+
+ALTER TABLE invites
+    DROP CONSTRAINT IF EXISTS invites_creator_agent_id_fkey;
+
+ALTER TABLE invite_redemptions
+    DROP CONSTRAINT IF EXISTS invite_redemptions_redeemer_agent_id_fkey;

--- a/frontend/src/components/dashboard/AddFriendModal.tsx
+++ b/frontend/src/components/dashboard/AddFriendModal.tsx
@@ -342,6 +342,7 @@ function SearchPane({ onClose }: { onClose: () => void }) {
 function InvitePane() {
   const locale = useLanguage();
   const t = addFriendModal[locale];
+  const isHumanView = useDashboardSessionStore((state) => state.viewMode === "human");
   const [invite, setInvite] = useState<InvitePreviewResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -351,7 +352,8 @@ function InvitePane() {
     setLoading(true);
     setError(null);
     try {
-      setInvite(await api.createFriendInvite());
+      const inviteApi = isHumanView ? humansApi : api;
+      setInvite(await inviteApi.createFriendInvite());
     } catch (err) {
       setError(err instanceof Error ? err.message : t.createInviteFailed);
     } finally {

--- a/frontend/src/components/dashboard/FriendInviteModal.tsx
+++ b/frontend/src/components/dashboard/FriendInviteModal.tsx
@@ -8,7 +8,8 @@
  */
 
 import { useState } from "react";
-import { api } from "@/lib/api";
+import { api, humansApi } from "@/lib/api";
+import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { common } from "@/lib/i18n/translations/common";
 import { useLanguage } from "@/lib/i18n";
 import type { InvitePreviewResponse } from "@/lib/types";
@@ -20,6 +21,7 @@ export default function FriendInviteModal({ onClose }: { onClose: () => void }) 
   const locale = useLanguage();
   const tc = common[locale];
   const t = friendInviteModal[locale];
+  const isHumanView = useDashboardSessionStore((state) => state.viewMode === "human");
   const [invite, setInvite] = useState<InvitePreviewResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -29,7 +31,8 @@ export default function FriendInviteModal({ onClose }: { onClose: () => void }) 
     setLoading(true);
     setError(null);
     try {
-      setInvite(await api.createFriendInvite());
+      const inviteApi = isHumanView ? humansApi : api;
+      setInvite(await inviteApi.createFriendInvite());
     } catch (err) {
       setError(err instanceof Error ? err.message : t.createFailed);
     } finally {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1020,6 +1020,11 @@ const humansApi = {
     );
   },
 
+  /** Human creates a friend invite link. */
+  createFriendInvite(): Promise<InvitePreviewResponse> {
+    return apiPost<InvitePreviewResponse>("/api/humans/me/invite");
+  },
+
   /** Human creates a private-room invite link. */
   createRoomInvite(roomId: string): Promise<InvitePreviewResponse> {
     return apiPost<InvitePreviewResponse>(`/api/humans/me/rooms/${roomId}/invite`);


### PR DESCRIPTION
## Summary
- In Human view the dashboard sends no `X-Active-Agent` header, so the agent-scoped `POST /api/invites/friends` returned 400 *"X-Active-Agent header is required"* when clicking "Create invite". Mirror the ShareModal/InviteOthersGuide fix from 9ff61f90b for friend invites.
- Backend: new `POST /api/humans/me/invite` route with `creator_agent_id = user.human_id`; `preview_invite` resolves creator via Agent or User by id prefix; `redeem_invite_for_agent`'s friend branch sets correct `owner_type` / `peer_type` on both Contact rows.
- Migration 034 drops the `agents(agent_id)` FK on `invites.creator_agent_id` and `invite_redemptions.redeemer_agent_id` so `hu_*` ids don't violate them in Postgres.
- Frontend: `humansApi.createFriendInvite()` + dispatch in `FriendInviteModal` and `AddFriendModal` based on `viewMode === "human"`.

## Test plan
- [x] `uv run pytest tests/test_app/` (329 passed) — agent-side invite flow unchanged.
- [x] `uv run pytest tests/ -k invite` (41 passed).
- [x] `tsc --noEmit` reports no errors in any touched frontend file.
- [ ] Run `make migrate` against staging Postgres to apply 034 before deploying the new route.
- [ ] Manual: in Human view click "Create invite" on the contacts page → invite is created (no 400) and the prompt copies cleanly.
- [ ] Manual: agent redeems a Human-authored friend invite → `Contact` rows are written with `owner_type` / `peer_type` matching the creator and redeemer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)