### PR TITLE
fix(dashboard): point daemon install URL at Hub host

### DIFF
--- a/frontend/src/components/daemon/DaemonInstallCommand.tsx
+++ b/frontend/src/components/daemon/DaemonInstallCommand.tsx
@@ -25,11 +25,6 @@ const HUB_BASE_URL =
   (process.env.NODE_ENV === "development"
     ? "http://localhost:8000"
     : "https://api.botcord.chat");
-const APP_BASE_URL =
-  process.env.NEXT_PUBLIC_APP_URL ||
-  (process.env.NODE_ENV === "development"
-    ? "http://localhost:3000"
-    : "https://botcord.chat");
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
@@ -38,7 +33,7 @@ function shellQuote(value: string): string {
 export function buildDaemonStartCommand(installToken?: string): string {
   const args = [`--hub ${shellQuote(HUB_BASE_URL)}`];
   if (installToken) args.push(`--install-token ${shellQuote(installToken)}`);
-  return `curl -fsSL ${APP_BASE_URL.replace(/\/$/, "")}/daemon/install.sh | sh -s -- ${args.join(" ")}`;
+  return `curl -fsSL ${HUB_BASE_URL.replace(/\/$/, "")}/daemon/install.sh | sh -s -- ${args.join(" ")}`;
 }
 
 export interface DaemonInstallCommandLabels {


### PR DESCRIPTION
## Summary
- Build the daemon install one-liner against `HUB_BASE_URL` instead of `APP_BASE_URL` so `curl | sh` doesn't hit the Vercel-fronted dashboard domain.
- Drop the now-unused `APP_BASE_URL` constant from `DaemonInstallCommand`.

## Why
Vercel's bot mitigation returns `403` (`x-vercel-mitigated: challenge`) to non-browser UAs on `https://preview.botcord.chat/daemon/install.sh`, so the install command copied from the dashboard fails for end users. The same script is already served by the Hub at `https://api.preview.botcord.chat/daemon/install.sh` (the script's own header even documents that as the canonical one-liner), so we just point the dashboard there.

Repro before fix:
```
$ curl -fsSL https://preview.botcord.chat/daemon/install.sh | sh -s -- --hub 'https://api.preview.botcord.chat' --install-token '...'
curl: (56) The requested URL returned error: 403
```

## Test plan
- [ ] Open Create Agent dialog (no-daemon state) on preview, copy the install command, run it on a clean machine, daemon installs and connects.
- [ ] Verify the same flow on `DaemonsSettingsPage` reconnect banner.
- [ ] Confirm `https://api.<env>.botcord.chat/daemon/install.sh` returns 200 in each environment (dev/preview/prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)