### PR TITLE
fix(dashboard): sync owned agents ws_online into presence store

### DIFF
--- a/frontend/src/store/useDashboardSessionStore.ts
+++ b/frontend/src/store/useDashboardSessionStore.ts
@@ -15,6 +15,19 @@ import {
   getStoredActiveIdentity,
   setStoredActiveIdentity,
 } from "@/lib/api";
+import { usePresenceStore } from "./usePresenceStore";
+
+// Sync owned agents' daemon-derived ws_online (from /api/users/me) into the
+// presence store, so MessageBubble's PresenceDot reflects the same state the
+// Sidebar shows. Realtime presence events will still override via setOnline's
+// timestamp ordering.
+function syncOwnedAgentsPresence(agents: UserAgent[]): void {
+  const setOnline = usePresenceStore.getState().setOnline;
+  const now = Date.now();
+  for (const agent of agents) {
+    setOnline(agent.agent_id, Boolean(agent.ws_online), now);
+  }
+}
 
 export type DashboardSessionMode = "guest" | "authed-no-agent" | "authed-ready";
 
@@ -130,12 +143,14 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
     });
   },
 
-  setUser: (user) =>
+  setUser: (user) => {
+    syncOwnedAgentsPresence(user.agents);
     set((state) => ({
       user,
       ownedAgents: user.agents,
       sessionMode: resolveSessionMode(state.token, state.activeAgentId),
-    })),
+    }));
+  },
 
   setHuman: (human) =>
     set((state) => ({
@@ -238,6 +253,7 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
       const activeIdentity: ActiveIdentity | null =
         stored ?? (human ? { type: "human", id: human.human_id } : deriveIdentityFromAgent(activeId));
       if (activeIdentity) setStoredActiveIdentity(activeIdentity);
+      syncOwnedAgentsPresence(user.agents);
       set({
         authResolved: true,
         authBootstrapping: false,
@@ -294,6 +310,7 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
       const user = await userApi.getMe({ force: true });
       const activeAgentId = resolveStoredActiveAgentId(user);
       setActiveAgentId(activeAgentId);
+      syncOwnedAgentsPresence(user.agents);
       set((state) => {
         // Preserve human identity if already active; otherwise track agent.
         const nextIdentity: ActiveIdentity | null =


### PR DESCRIPTION
## Summary
- Owned agents' `ws_online` (daemon-derived, from `/api/users/me`) was only read by the Sidebar. `MessageBubble`'s `PresenceDot` reads `usePresenceStore`, which was never seeded from session — so messages from one's own agents always rendered as gray/offline even when the daemon page showed them online.
- Sync `ws_online` into the presence store on `setUser`, `initAuth`, and `refreshUserProfile`. Realtime presence events still win via `setOnline`'s timestamp ordering.

## Test plan
- [ ] Open a room where one of your own agents has sent messages; presence dot in the message bubble should match the green dot in Sidebar "My Bots" and the daemon page status.
- [ ] Stop the local daemon → both Sidebar dot and message-bubble dot turn offline after refresh.
- [ ] Restart daemon → both turn online again.
- [ ] Trigger a Supabase realtime presence event for that agent → message bubble updates without a page reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)