### PR TITLE
fix(dashboard): show unread message counts

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -167,6 +167,16 @@ async def _build_rooms_from_sql(
             mapped.append(item)
         orm_rooms = await _build_rooms_from_membership(agent_id, db)
         if not orm_rooms:
+            unread_counts = await _build_room_unread_counts(agent_id, db, [
+                room["room_id"] for room in mapped if isinstance(room.get("room_id"), str)
+            ])
+            for item in mapped:
+                room_id = item.get("room_id")
+                if not isinstance(room_id, str):
+                    continue
+                count = unread_counts.get(room_id, 0)
+                item["unread_count"] = count
+                item["has_unread"] = bool(item.get("has_unread") or count > 0)
             return mapped
         orm_room_by_id = {room["room_id"]: room for room in orm_rooms}
         fill_keys = (
@@ -191,9 +201,18 @@ async def _build_rooms_from_sql(
                 if key not in item:
                     item[key] = fallback.get(key)
         missing_rooms = [room for room in orm_rooms if room["room_id"] not in sql_room_ids]
-        if not missing_rooms:
-            return mapped
-        return _sort_room_previews(mapped + missing_rooms)
+        combined = mapped if not missing_rooms else _sort_room_previews(mapped + missing_rooms)
+        unread_counts = await _build_room_unread_counts(agent_id, db, [
+            room["room_id"] for room in combined if isinstance(room.get("room_id"), str)
+        ])
+        for item in combined:
+            room_id = item.get("room_id")
+            if not isinstance(room_id, str):
+                continue
+            count = unread_counts.get(room_id, 0)
+            item["unread_count"] = count
+            item["has_unread"] = bool(item.get("has_unread") or count > 0)
+        return combined
     except Exception:
         _logger.debug(
             "get_agent_room_previews unavailable, falling back to ORM query",
@@ -213,6 +232,59 @@ def _sort_room_previews(rooms: list[dict]) -> list[dict]:
 
     rooms.sort(key=_sort_key, reverse=True)
     return rooms
+
+
+async def _build_room_unread_counts(
+    viewer_id: str,
+    db: AsyncSession,
+    room_ids: list[str],
+) -> dict[str, int]:
+    if not room_ids:
+        return {}
+
+    member_result = await db.execute(
+        select(RoomMember.room_id, RoomMember.last_viewed_at).where(
+            RoomMember.agent_id == viewer_id,
+            RoomMember.room_id.in_(room_ids),
+        )
+    )
+    last_viewed_by_room = dict(member_result.all())
+
+    dedup_sub = (
+        select(
+            MessageRecord.room_id,
+            MessageRecord.msg_id,
+            func.min(MessageRecord.id).label("min_id"),
+        )
+        .where(MessageRecord.room_id.in_(room_ids))
+        .group_by(MessageRecord.room_id, MessageRecord.msg_id)
+        .subquery()
+    )
+    message_result = await db.execute(
+        select(MessageRecord).where(MessageRecord.id.in_(select(dedup_sub.c.min_id)))
+    )
+
+    counts = {room_id: 0 for room_id in room_ids}
+    for rec in message_result.scalars().all():
+        room_id = rec.room_id
+        if not room_id or room_id not in counts:
+            continue
+        if rec.sender_id == viewer_id:
+            continue
+        _, _, msg_type = _extract_text_preview(rec.envelope_json)
+        if msg_type in _RECEIPT_TYPES:
+            continue
+        last_viewed_at = last_viewed_by_room.get(room_id)
+        if last_viewed_at is not None:
+            created_at = rec.created_at
+            if created_at.tzinfo is None and last_viewed_at.tzinfo is not None:
+                created_at = created_at.replace(tzinfo=datetime.timezone.utc)
+            elif created_at.tzinfo is not None and last_viewed_at.tzinfo is None:
+                last_viewed_at = last_viewed_at.replace(tzinfo=datetime.timezone.utc)
+            if created_at <= last_viewed_at:
+                continue
+        counts[room_id] += 1
+    return counts
 
 
 async def _build_rooms_from_membership(
@@ -310,6 +382,8 @@ async def _build_rooms_from_membership(
         )
         sender_names = dict(agent_result.all())
 
+    unread_counts = await _build_room_unread_counts(agent_id, db, room_ids)
+
     result_rooms = []
     for rid in room_ids:
         room = rooms.get(rid)
@@ -367,6 +441,8 @@ async def _build_rooms_from_membership(
             "last_message_preview": last_preview,
             "last_message_at": last_at.isoformat() if last_at else None,
             "last_sender_name": last_sender,
+            "has_unread": unread_counts.get(rid, 0) > 0,
+            "unread_count": unread_counts.get(rid, 0),
             "created_at": room.created_at.isoformat() if room.created_at else None,
         })
 

--- a/backend/hub/dashboard_schemas.py
+++ b/backend/hub/dashboard_schemas.py
@@ -35,6 +35,8 @@ class DashboardRoom(BaseModel):
     last_message_preview: str | None = None
     last_message_at: datetime.datetime | None = None
     last_sender_name: str | None = None
+    has_unread: bool = False
+    unread_count: int = 0
     url: str
 
 

--- a/backend/hub/schemas.py
+++ b/backend/hub/schemas.py
@@ -602,6 +602,8 @@ class DashboardRoom(BaseModel):
     last_message_preview: str | None = None
     last_message_at: datetime.datetime | None = None
     last_sender_name: str | None = None
+    has_unread: bool = False
+    unread_count: int = 0
     url: str
 
 

--- a/backend/tests/test_app/test_app_dashboard.py
+++ b/backend/tests/test_app/test_app_dashboard.py
@@ -16,6 +16,7 @@ from hub.models import (
     Contact,
     ContactRequest,
     ContactRequestState,
+    MessageRecord,
     MessagePolicy,
     Role,
     Room,
@@ -212,6 +213,73 @@ async def test_dashboard_overview(client: AsyncClient, seed_data: dict):
 
     # Pending requests
     assert data["pending_requests"] == 1
+
+
+@pytest.mark.asyncio
+async def test_dashboard_overview_includes_unread_count(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    seed_data: dict,
+):
+    token = seed_data["token"]
+    db_session.add_all([
+        MessageRecord(
+            hub_msg_id="hm_unread001",
+            msg_id="msg_unread001",
+            sender_id="ag_other00001",
+            receiver_id="ag_dashtest001",
+            room_id="rm_testroom001",
+            envelope_json='{"from":"ag_other00001","type":"message","payload":{"text":"one"}}',
+            ttl_sec=3600,
+        ),
+        MessageRecord(
+            hub_msg_id="hm_unread002",
+            msg_id="msg_unread002",
+            sender_id="ag_other00001",
+            receiver_id="ag_dashtest001",
+            room_id="rm_testroom001",
+            envelope_json='{"from":"ag_other00001","type":"message","payload":{"text":"two"}}',
+            ttl_sec=3600,
+        ),
+        MessageRecord(
+            hub_msg_id="hm_ack001",
+            msg_id="msg_ack001",
+            sender_id="ag_other00001",
+            receiver_id="ag_dashtest001",
+            room_id="rm_testroom001",
+            envelope_json='{"from":"ag_other00001","type":"ack","payload":{}}',
+            ttl_sec=3600,
+        ),
+        MessageRecord(
+            hub_msg_id="hm_own001",
+            msg_id="msg_own001",
+            sender_id="ag_dashtest001",
+            receiver_id="ag_other00001",
+            room_id="rm_testroom001",
+            envelope_json='{"from":"ag_dashtest001","type":"message","payload":{"text":"mine"}}',
+            ttl_sec=3600,
+        ),
+    ])
+    await db_session.commit()
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "X-Active-Agent": "ag_dashtest001",
+    }
+    resp = await client.get("/api/dashboard/overview", headers=headers)
+    assert resp.status_code == 200
+    room = resp.json()["rooms"][0]
+    assert room["has_unread"] is True
+    assert room["unread_count"] == 2
+
+    read_resp = await client.post("/api/dashboard/rooms/rm_testroom001/read", headers=headers)
+    assert read_resp.status_code == 200
+
+    resp = await client.get("/api/dashboard/overview", headers=headers)
+    assert resp.status_code == 200
+    room = resp.json()["rooms"][0]
+    assert room["has_unread"] is False
+    assert room["unread_count"] == 0
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/dashboard/README.md
+++ b/frontend/src/components/dashboard/README.md
@@ -67,7 +67,7 @@ dashboard/
 - Bot 创建入口只允许留在 `My Bots` 面板；左下角账户菜单只保留“当前身份”列表与基础动作，无 agent 时也只能复用同一个创建模态，避免身份入口和 Bot 生命周期入口混在一起。
 - 群成员邀请入口必须挂在右侧成员面板，由 owner/admin 以 Human 身份发起；候选集合只来自“好友 + 自有 Agent”两类真数据源，先过滤已在群里的成员，再调用单一 `members` API，避免 UI 自己分叉出第三套邀请模型。
 - dashboard realtime 只维护“当前 active agent 的单 Supabase private channel 订阅”；channel 只发轻量 meta 事件，`useDashboardRealtimeStore.ts` 再驱动 `useDashboardChatStore.ts` 走 Next BFF 拉完整 overview / 房间增量数据，避免把广播层变成第二套消息协议。
-- 未读状态以后端 `room_members.last_viewed_at` 为真相源：room 列表蓝点由 overview SQL 直接返回，组件只在实时消息和“已看到底”之间维护短暂乐观覆盖。
+- 未读状态以后端 `room_members.last_viewed_at` 为真相源：overview 返回 `has_unread` 与 `unread_count`，room 列表与 Messages 一级 tab 显示数量徽标；组件只在实时消息和“已看到底”之间维护短暂乐观覆盖。
 - `/chats` 顶层现在只做编排：`DashboardApp.tsx` 聚合 `session/ui/chat/realtime/unread/contact/wallet` 多个 store；组件层直接按职责从对应 store 取值，不再保留 dashboard 聚合 hook。
 
 ## 开发规范
@@ -77,6 +77,7 @@ dashboard/
 
 ## 变更日志
 
+- 2026-04-28: `RoomList.tsx` 与 `Sidebar.tsx` 的未读提示从蓝点改为数量徽标，后端 overview 同步返回 `unread_count`。
 - 2026-04-27: 新增 `PaidRoomPreview.tsx`，付费群未订阅视图从纯锁空态改为固定展示最近 3 条消息摘要，降低订阅前的不确定性。
 - 2026-04-27: `RoomHeader.tsx` 的右侧操作区改为不可换行的固定控件行，加入/申请加入按钮不再在窄宽度下被压成竖排。
 - 2026-04-27: `CreateRoomModal.tsx` 从建群流程移除群公告/规则输入与高级设置区；建群只处理基础信息和初始成员，高级项回到群设置里维护。
@@ -100,7 +101,7 @@ dashboard/
 - 2026-03-25: 新增 `DashboardMessagePaneSkeleton.tsx`，把 `DashboardShellSkeleton.tsx` 与 `UserChatPane.tsx` 的消息骨架收敛为同一实现，结束局部加载态样式复制。
 - 2026-03-22: `Sidebar.tsx` 为一级 `Contacts` 导航与二级 `Requests` 入口补上未处理联系人申请 badge，提醒直接复用 `overview.pending_requests`，避免再造联系人计数状态。
 - 2026-03-21: `DashboardApp.tsx` 改为直接编排 `ui/chat/realtime/unread` 四个拆分 store，并删除 `useDashboardChannelStore.ts` / `useDashboardStore.ts` 历史 facade，结束单文件混合消息缓存、未读、导航和连接状态的坏味道。
-- 2026-03-22: `MessageList.tsx` 在看到最新位置时通过 BFF 持久化 `room_members.last_viewed_at`，`RoomList.tsx` / `Sidebar.tsx` 的未读蓝点改读后端 SQL 返回的 `has_unread`。
+- 2026-03-22: `MessageList.tsx` 在看到最新位置时通过 BFF 持久化 `room_members.last_viewed_at`，`RoomList.tsx` / `Sidebar.tsx` 的未读提示改读后端 SQL 返回的 `has_unread`。
 - 2026-03-21: 所有 dashboard 子组件完成迁移，统一按 store selector 读取状态，`useDashboard()` 聚合 hook 被移除，热路径不再承受宽订阅重渲染。
 - 2026-03-21: `DashboardApp.tsx` 改为订阅 `agent:{agent_id}` Supabase private broadcast；`MessageList.tsx` 去掉组件级 5 秒轮询，改为基于滚动位置维护前端已读水位；`RoomList.tsx` 与 `Sidebar.tsx` 新增消息未读蓝点。
 - 2026-03-20: `selectAgent` 语义收敛为“打开统一 Agent 卡片”，`DashboardApp.tsx` 挂载全局 `AgentCardModal`；`/chats/contacts/agents`、消息气泡发送者名、Explore/成员列表等入口统一弹卡片，不再自动拉起右侧 `AgentBrowser`。

--- a/frontend/src/components/dashboard/RoomList.tsx
+++ b/frontend/src/components/dashboard/RoomList.tsx
@@ -2,7 +2,7 @@
 
 /**
  * [INPUT]: 依赖 ui/chat/unread store 的会话状态、缓存消息与后端未读标记，依赖 nextjs-toploader/app 做带进度反馈的路由跳转
- * [OUTPUT]: 对外提供 RoomList 组件，渲染消息会话列表项（头像 + 最后一条消息预览 + 未读蓝点）
+ * [OUTPUT]: 对外提供 RoomList 组件，渲染消息会话列表项（头像 + 最后一条消息预览 + 未读数量）
  * [POS]: dashboard 左侧消息导航区的会话列表渲染器，被 Sidebar 组合使用
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
@@ -39,6 +39,7 @@ function humanRoomToDashboardRoom(r: HumanRoomSummary): DashboardRoom {
     required_subscription_product_id: null,
     last_viewed_at: null,
     has_unread: false,
+    unread_count: 0,
     last_message_preview: null,
     last_message_at: null,
     last_sender_name: null,
@@ -80,6 +81,10 @@ function formatLastMessageTime(isoTime: string | null): string {
   return sameDay
     ? date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
     : date.toLocaleDateString();
+}
+
+function formatUnreadCount(count: number): string {
+  return count > 99 ? "99+" : String(count);
 }
 
 export default function RoomList({
@@ -269,6 +274,7 @@ export default function RoomList({
         const avatarLabel = buildRoomAvatarLabel(room.name);
         const avatarTone = buildAvatarTone(room.room_id);
         const isUnread = isRoomUnread(room.room_id, room.has_unread);
+        const unreadCount = isUnread ? Math.max(1, room.unread_count ?? 1) : 0;
 
         return (
           <div
@@ -295,8 +301,10 @@ export default function RoomList({
                     {room.name}
                   </span>
                   <div className="flex shrink-0 items-center gap-2">
-                    {isUnread && (
-                      <span className="h-2.5 w-2.5 rounded-full bg-neon-cyan shadow-[0_0_10px_rgba(34,211,238,0.6)]" />
+                    {unreadCount > 0 && (
+                      <span className="flex h-5 min-w-[20px] items-center justify-center rounded-full bg-neon-cyan px-1.5 text-[10px] font-bold leading-none text-black shadow-[0_0_10px_rgba(34,211,238,0.55)]">
+                        {formatUnreadCount(unreadCount)}
+                      </span>
                     )}
                     {messageTime && (
                       <span className="text-[11px] text-text-secondary/80">

--- a/frontend/src/components/dashboard/Sidebar.tsx
+++ b/frontend/src/components/dashboard/Sidebar.tsx
@@ -36,6 +36,10 @@ import { useDashboardRealtimeStore } from "@/store/useDashboardRealtimeStore";
 
 const USER_CHAT_ROUTE = "/chats/messages/__user-chat__";
 
+function formatBadgeCount(count: number): string {
+  return count > 99 ? "99+" : String(count);
+}
+
 function formatCoinAmount(minorStr: string): string {
   const minor = parseInt(minorStr, 10);
   if (isNaN(minor)) return "0.00";
@@ -230,7 +234,10 @@ export default function Sidebar() {
     recentVisitedRooms: state.recentVisitedRooms,
     switchActiveAgent: state.switchActiveAgent,
   })));
-  const optimisticUnreadRoomIds = useDashboardUnreadStore((state) => state.optimisticUnreadRoomIds);
+  const unreadStore = useDashboardUnreadStore(useShallow((state) => ({
+    optimisticUnreadRoomIds: state.optimisticUnreadRoomIds,
+    isRoomUnread: state.isRoomUnread,
+  })));
   const wallet = useDashboardWalletStore(useShallow((state) => ({
     wallet: state.wallet,
     walletError: state.walletError,
@@ -341,7 +348,17 @@ export default function Sidebar() {
   }, [chatStore.messages, normalizedMessageQuery, visibleMessageRooms]);
   const showOverviewSkeleton =
     sessionStore.sessionMode === "authed-ready" && !chatStore.overview && uiStore.sidebarTab === "messages";
-  const hasUnreadMessages = optimisticUnreadRoomIds.length > 0 || visibleMessageRooms.some((room) => room.has_unread);
+  const unreadMessageCount = useMemo(() => {
+    const roomIds = new Set(visibleMessageRooms.map((room) => room.room_id));
+    const persistedCount = visibleMessageRooms.reduce((total, room) => {
+      if (!unreadStore.isRoomUnread(room.room_id, room.has_unread)) {
+        return total;
+      }
+      return total + Math.max(1, room.unread_count ?? 1);
+    }, 0);
+    const optimisticOnlyCount = unreadStore.optimisticUnreadRoomIds.filter((roomId) => !roomIds.has(roomId)).length;
+    return persistedCount + optimisticOnlyCount;
+  }, [unreadStore, visibleMessageRooms]);
   const pendingContactRequests = chatStore.overview?.pending_requests || 0;
 
   useEffect(() => {
@@ -404,9 +421,11 @@ export default function Sidebar() {
             const isExplore = item.key === "explore";
             const requiresLogin = isGuest && (item.key === "contacts" || item.key === "activity");
             let badge: ReactNode = null;
-            if (item.key === "messages" && hasUnreadMessages && !requiresLogin) {
+            if (item.key === "messages" && unreadMessageCount > 0 && !requiresLogin) {
               badge = (
-                <div className="absolute right-1.5 top-1.5 h-2.5 w-2.5 rounded-full bg-neon-cyan shadow-[0_0_10px_rgba(34,211,238,0.6)]" />
+                <span className="absolute -right-1 -top-1 flex h-4 min-w-[16px] items-center justify-center rounded-full bg-neon-cyan px-1 text-[9px] font-bold leading-none text-black shadow-[0_0_12px_rgba(34,211,238,0.45)]">
+                  {formatBadgeCount(unreadMessageCount)}
+                </span>
               );
             }
             if (item.key === "contacts" && pendingContactRequests > 0 && !requiresLogin) {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -36,6 +36,7 @@ export interface DashboardRoom {
   slow_mode_seconds?: number | null;
   last_viewed_at?: string | null;
   has_unread: boolean;
+  unread_count?: number;
   last_message_preview: string | null;
   last_message_at: string | null;
   last_sender_name: string | null;

--- a/frontend/src/store/README.md
+++ b/frontend/src/store/README.md
@@ -21,7 +21,7 @@ useDashboardSubscriptionStore.ts: Subscription 业务域 store，负责当前 ag
 - 组件层统一通过 `DashboardApp/useDashboard` 聚合多 store，不再保留历史 facade；状态真相只存在于拆分后的业务 store。
 - realtime 不直接把 Supabase broadcast 当消息源；channel 只负责投递 meta 脉冲，`realtime/chat` store 负责通过 Next BFF 拉取最新 overview / 当前房间增量消息并合并本地状态。
 - realtime 事件以 `type` 作为唯一分发语义，`ext` 只承载附加字段；不要再引入第二个 `kind/category` 制造重复含义。
-- 已读未读以数据库为真相源：`room_members.last_viewed_at` 持久化成员级阅读水位，`unread` store 只保留本地乐观覆盖与 realtime 瞬时提示，不再单独定义持久化规则。
+- 已读未读以数据库为真相源：`room_members.last_viewed_at` 持久化成员级阅读水位，overview 提供 `has_unread` / `unread_count`，`unread` store 只保留本地乐观覆盖与 realtime 瞬时提示，不再单独定义持久化规则。
 
 开发规范
 - 新增业务状态优先放到对应业务 store，不再向 `DashboardApp` 回灌跨域字段。
@@ -29,9 +29,10 @@ useDashboardSubscriptionStore.ts: Subscription 业务域 store，负责当前 ag
 - 任何跨域状态重置（如 agent 切换、退出登录）必须在聚合层显式同步。
 - `useDashboardChatStore.ts` 的会话列表缓存必须绑定当前 active agent；身份切换后先换真相源，再清空上一身份残留，不能让 recents/overview 跨 agent 泄漏。
 - Supabase realtime 在线时，消息更新必须走 `useDashboardRealtimeStore.ts` 的同步动作；不要重新引入组件级定时轮询制造第二数据入口。
-- 进入房间并真正看到最新位置后，必须通过 BFF 写回 `last_viewed_at`；前端本地蓝点只能做短暂覆盖，不能替代后端状态。
+- 进入房间并真正看到最新位置后，必须通过 BFF 写回 `last_viewed_at`；前端本地未读数量只能做短暂覆盖，不能替代后端状态。
 
 变更日志
+- 2026-04-28: overview 房间摘要新增 `unread_count`，Messages 一级 tab 与 room 列表使用数量徽标替代未读蓝点。
 - 2026-04-24: `dashboard-shared.ts` 新增统一房间活跃度排序 helper，消息列表与联系人房间视图都以 `last_message_at -> created_at` 同一规则排序，消除重复排序逻辑漂移。
 - 2026-04-24: `useDashboardChatStore.ts` 的公开目录加载动作开始接收 `q` 并做请求序号保护，公开社区搜索不再依赖首屏缓存，也不会被旧请求回写覆盖。
 - 2026-04-08: `useDashboardChatStore.ts` 新增 `boundAgentId` 边界，claim/切换身份后会先切 active agent 再硬刷新，并在 agent 不一致时清空上一身份的会话缓存，修复 `/chats` 继续进入仍显示旧身份与旧会话列表残留的问题。


### PR DESCRIPTION
## Summary
- add unread_count to dashboard overview room summaries
- render unread count badges in the Messages tab and room list
- add backend coverage for unread count behavior and read watermark reset

## Tests
- cd backend && uv run pytest tests/test_app/test_app_dashboard.py tests/test_app/test_app_invites.py
- cd frontend && npm run build (fails during /admin/codes prerender because Supabase URL/API key env vars are not configured; compile and TypeScript phases complete before that failure)