### PR TITLE
feat(dashboard): add new device entry in Create Agent dialog

### DIFF
--- a/frontend/src/components/dashboard/CreateAgentDialog.tsx
+++ b/frontend/src/components/dashboard/CreateAgentDialog.tsx
@@ -9,9 +9,11 @@
 
 import { useEffect, useMemo, useState } from "react";
 import {
+  ArrowLeft,
   Bot,
   Check,
   Loader2,
+  Plus,
   RefreshCcw,
   Server,
   X,
@@ -84,6 +86,7 @@ export default function CreateAgentDialog({
   const [bio, setBio] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [addingDevice, setAddingDevice] = useState(false);
 
   useEffect(() => {
     void refresh();
@@ -227,13 +230,47 @@ export default function CreateAgentDialog({
               refresh: t.refreshDaemons,
             }}
           />
+        ) : addingDevice ? (
+          <div className="space-y-4">
+            <DaemonInstallCommand
+              busy={loading}
+              onRefresh={() => void refresh()}
+              labels={{
+                title: t.addDeviceTitle,
+                hint: t.addDeviceHint,
+                copy: t.copy,
+                copied: t.copied,
+                openActivate: t.openActivate,
+                refresh: t.refreshDaemons,
+              }}
+            />
+            <button
+              type="button"
+              onClick={() => setAddingDevice(false)}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-glass-border px-3 py-1.5 text-xs text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
+            >
+              <ArrowLeft className="h-3.5 w-3.5" />
+              {t.backLabel}
+            </button>
+          </div>
         ) : (
           <div className="space-y-4">
-            {onlineDaemons.length > 1 && (
-              <div>
-                <label className="mb-1.5 block text-xs font-semibold uppercase tracking-wider text-text-secondary">
+            <div>
+              <div className="mb-1.5 flex items-center justify-between">
+                <label className="text-xs font-semibold uppercase tracking-wider text-text-secondary">
                   {t.daemonLabel}
                 </label>
+                <button
+                  type="button"
+                  onClick={() => setAddingDevice(true)}
+                  disabled={submitting}
+                  className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+                >
+                  <Plus className="h-3 w-3" />
+                  {t.addDeviceLabel}
+                </button>
+              </div>
+              {onlineDaemons.length > 1 ? (
                 <select
                   value={selectedDaemonId ?? ""}
                   onChange={(e) => setSelectedDaemonId(e.target.value)}
@@ -246,18 +283,16 @@ export default function CreateAgentDialog({
                     </option>
                   ))}
                 </select>
-              </div>
-            )}
-
-            {onlineDaemons.length === 1 && selectedDaemon && (
-              <div className="flex items-center gap-2 rounded-xl border border-glass-border bg-glass-bg/40 px-3 py-2 text-xs text-text-secondary">
-                <Server className="h-3.5 w-3.5 text-neon-cyan" />
-                <span className="text-text-primary">
-                  {selectedDaemon.label || selectedDaemon.id}
-                </span>
-                <span className="ml-auto inline-flex h-1.5 w-1.5 rounded-full bg-neon-green" />
-              </div>
-            )}
+              ) : selectedDaemon ? (
+                <div className="flex items-center gap-2 rounded-xl border border-glass-border bg-glass-bg/40 px-3 py-2 text-xs text-text-secondary">
+                  <Server className="h-3.5 w-3.5 text-neon-cyan" />
+                  <span className="text-text-primary">
+                    {selectedDaemon.label || selectedDaemon.id}
+                  </span>
+                  <span className="ml-auto inline-flex h-1.5 w-1.5 rounded-full bg-neon-green" />
+                </div>
+              ) : null}
+            </div>
 
             <RuntimePicker
               daemon={selectedDaemon}
@@ -331,7 +366,7 @@ export default function CreateAgentDialog({
           </p>
         )}
 
-        {!showEmptyState && loaded && (
+        {!showEmptyState && !addingDevice && loaded && (
           <div className="mt-6 flex items-center justify-end gap-3">
             <button
               onClick={onClose}

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -1580,6 +1580,10 @@ export const createAgentDialog: TranslationMap<{
   daemonLabel: string
   noDaemonTitle: string
   noDaemonHint: string
+  addDeviceLabel: string
+  addDeviceTitle: string
+  addDeviceHint: string
+  backLabel: string
   copy: string
   copied: string
   openActivate: string
@@ -1610,6 +1614,10 @@ export const createAgentDialog: TranslationMap<{
     daemonLabel: 'Machine',
     noDaemonTitle: 'No device connected',
     noDaemonHint: 'Run the command below on your computer to install BotCord — once it connects, it will show up here automatically.',
+    addDeviceLabel: 'Add device',
+    addDeviceTitle: 'Connect another device',
+    addDeviceHint: 'Run the command below on the new computer — once BotCord connects, it will appear in the Machine list.',
+    backLabel: 'Back',
     copy: 'Copy',
     copied: 'Copied',
     openActivate: 'Open activation page',
@@ -1640,6 +1648,10 @@ export const createAgentDialog: TranslationMap<{
     daemonLabel: '机器',
     noDaemonTitle: '未连接设备',
     noDaemonHint: '在你的电脑上运行下面的命令安装并启动 BotCord，连接成功后会自动出现在这里。',
+    addDeviceLabel: '新增设备',
+    addDeviceTitle: '连接新设备',
+    addDeviceHint: '在另一台电脑上运行下面的命令，BotCord 连接成功后会自动出现在机器列表里。',
+    backLabel: '返回',
     copy: '复制',
     copied: '已复制',
     openActivate: '打开授权页面',


### PR DESCRIPTION
## Summary
- Adds a `+ Add device` button to the Machine section of the Create Agent dialog so users can connect a second daemon without leaving the flow
- Reuses `DaemonInstallCommand` to render the curl install command with a freshly issued install token; a `Back` button returns to the agent creation form once the new daemon shows up
- New i18n keys (`addDeviceLabel`, `addDeviceTitle`, `addDeviceHint`, `backLabel`) for en + zh

## Test plan
- [ ] Open Create Agent dialog with one online daemon — verify the `+ Add device` button is visible next to the Machine label
- [ ] Click `+ Add device` — verify the curl command + install token panel renders, refresh button works
- [ ] Run the install command on a second machine — verify the new daemon appears in the list after clicking Back + selecting it
- [ ] Open the dialog with multiple online daemons — verify the select dropdown still works and the `+ Add device` button is still visible
- [ ] Open the dialog with zero daemons — verify the no-daemon empty state still renders unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)