### PR TITLE
fix(daemon): let --install-token override stale local creds

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -417,8 +417,9 @@ async function runDeviceCodeFlow(opts: {
  * plane (legacy P0 behavior — caller may still log a warning).
  *
  * Decision tree (plan §4.4 + §6.4):
- * 1. Have existing creds and no `--relogin` → return existing record.
- * 2. `--install-token` → redeem the one-time dashboard ticket.
+ * 1. Have existing creds, no `--relogin`, no `--install-token` → return existing record.
+ * 2. `--install-token` (overrides existing creds — they may be stale or
+ *    belong to a different account) → redeem the one-time dashboard ticket.
  * 3. `--relogin` → device-code login.
  * 4. No creds + TTY → device-code login.
  * 5. No creds + no TTY → exit 1 with the §6.4 hint.
@@ -432,7 +433,7 @@ async function ensureUserAuthForStart(args: ParsedArgs): Promise<UserAuthRecord 
 
   const existing = safeLoadUserAuth();
 
-  if (!relogin && existing) {
+  if (!relogin && !installToken && existing) {
     // A previously-set auth-expired flag is stale by definition once the
     // operator runs `start` again — if creds genuinely don't work, the
     // control channel will re-write the flag on the next 4401/4403.
@@ -447,9 +448,6 @@ async function ensureUserAuthForStart(args: ParsedArgs): Promise<UserAuthRecord 
       console.error(
         `note: --label "${labelFlag}" ignored (already logged in as "${existing.label ?? "<unset>"}"); pass --relogin to change it`,
       );
-    }
-    if (installToken) {
-      console.error("note: --install-token ignored because daemon is already logged in");
     }
     return existing;
   }


### PR DESCRIPTION
## Summary
- A second machine that already had a stale \`~/.botcord/daemon/user-auth.json\` (expired refresh_token, or creds belonging to a different account) was silently falling back to the existing record and **ignoring** the freshly issued install token. The control channel then failed to start with \`401 invalid_refresh_token\`.
- Treat \`--install-token\` as an explicit operator action that takes precedence over any existing creds — redeem it and overwrite the local record, just like \`--relogin\` does.

## Repro (before)
1. On a host that already has stale daemon creds, run the dashboard's \`curl ... | sh -s -- --hub ... --install-token <dit_xxx>\` command.
2. Daemon logs: \`note: --install-token ignored because daemon is already logged in\` (gone after this PR), then \`user-auth refresh: failed status=401 error=invalid_refresh_token\`, then \`control-channel failed to start\`.

## After
- \`--install-token\` redeems unconditionally; the new record is written and the control channel comes up cleanly.
- Existing fast path (no flags → reuse existing creds) is unchanged.
- \`--label\` precedence is unchanged.

## Test plan
- [ ] Fresh machine + install command → daemon connects (existing flow, regression check)
- [ ] Machine with stale \`user-auth.json\` (e.g. expired refresh_token) + install command → daemon overwrites creds and connects, no 401
- [ ] Restart \`botcord-daemon start\` with no flags after install → existing creds reused, no extra network call

🤖 Generated with [Claude Code](https://claude.com/claude-code)