### PR TITLE
fix(dashboard): auto-detect daemon online + OpenClaw gateways while user waits

### DIFF
--- a/frontend/src/components/daemon/DaemonsSettingsPage.tsx
+++ b/frontend/src/components/daemon/DaemonsSettingsPage.tsx
@@ -332,6 +332,15 @@ export default function DaemonsSettingsPage() {
   const hasOffline = sorted.some((d) => d.status === "offline");
   const showInstallPanel = empty || hasOffline;
 
+  // Auto-detect daemons coming online while the install/reconnect banner is up.
+  useEffect(() => {
+    if (!showInstallPanel) return;
+    const id = window.setInterval(() => {
+      void refresh({ quiet: true });
+    }, 3_000);
+    return () => window.clearInterval(id);
+  }, [showInstallPanel, refresh]);
+
   const installLabels = empty
     ? {
         title: "No daemons connected yet",

--- a/frontend/src/components/dashboard/CreateAgentDialog.tsx
+++ b/frontend/src/components/dashboard/CreateAgentDialog.tsx
@@ -139,6 +139,29 @@ export default function CreateAgentDialog({
 
   const showEmptyState = loaded && onlineDaemons.length === 0;
 
+  // Auto-detect daemon coming online while user stares at the install command.
+  useEffect(() => {
+    if (!showEmptyState) return;
+    const id = window.setInterval(() => {
+      void refresh({ quiet: true });
+    }, 3_000);
+    return () => window.clearInterval(id);
+  }, [showEmptyState, refresh]);
+
+  // Auto-detect OpenClaw gateways once the user picks the openclaw-acp runtime
+  // but no reachable endpoint has been probed yet.
+  useEffect(() => {
+    if (selectedRuntimeId !== "openclaw-acp") return;
+    if (!selectedDaemon) return;
+    const reachable = (selectedRuntime?.endpoints ?? []).filter((e) => e.reachable);
+    if (reachable.length > 0) return;
+    const daemonId = selectedDaemon.id;
+    const id = window.setInterval(() => {
+      void refreshRuntimes(daemonId, { quiet: true });
+    }, 5_000);
+    return () => window.clearInterval(id);
+  }, [selectedRuntimeId, selectedDaemon, selectedRuntime, refreshRuntimes]);
+
   function translateError(err: unknown): string {
     if (err instanceof ProvisionAgentError) {
       switch (err.code) {

--- a/frontend/src/store/useDaemonStore.ts
+++ b/frontend/src/store/useDaemonStore.ts
@@ -96,10 +96,10 @@ interface DaemonState {
   runtimeErrors: Record<string, string>;
   renameErrors: Record<string, string>;
 
-  refresh: () => Promise<void>;
+  refresh: (opts?: { quiet?: boolean }) => Promise<void>;
   revoke: (id: string) => Promise<void>;
   rename: (id: string, label: string | null) => Promise<boolean>;
-  refreshRuntimes: (id: string) => Promise<void>;
+  refreshRuntimes: (id: string, opts?: { quiet?: boolean }) => Promise<void>;
   provisionAgent: (
     daemonId: string,
     input: ProvisionAgentInput,
@@ -246,14 +246,16 @@ function normalizeDaemon(raw: Record<string, unknown>): DaemonInstance {
 export const useDaemonStore = create<DaemonState>()((set, get) => ({
   ...initialState,
 
-  refresh: async () => {
-    set({ loading: true, error: null });
+  refresh: async (opts) => {
+    const quiet = opts?.quiet === true;
+    if (!quiet) set({ loading: true, error: null });
     try {
       const res = await fetch("/api/daemon/instances", {
         method: "GET",
         cache: "no-store",
       });
       if (!res.ok) {
+        if (quiet) return;
         const msg = await parseError(res);
         set({ loading: false, error: msg });
         return;
@@ -266,13 +268,14 @@ export const useDaemonStore = create<DaemonState>()((set, get) => ({
           : Array.isArray(data)
             ? data
             : [];
-      set({
-        daemons: (list as Record<string, unknown>[]).map(normalizeDaemon),
-        loading: false,
-        loaded: true,
-        error: null,
-      });
+      const daemons = (list as Record<string, unknown>[]).map(normalizeDaemon);
+      set(
+        quiet
+          ? { daemons, loaded: true }
+          : { daemons, loading: false, loaded: true, error: null },
+      );
     } catch (err) {
+      if (quiet) return;
       set({
         loading: false,
         error: err instanceof Error ? err.message : "Failed to load daemons",
@@ -361,18 +364,22 @@ export const useDaemonStore = create<DaemonState>()((set, get) => ({
     }
   },
 
-  refreshRuntimes: async (id: string) => {
-    set((state) => {
-      const next = { ...state.runtimeErrors };
-      delete next[id];
-      return { refreshingRuntimesId: id, runtimeErrors: next };
-    });
+  refreshRuntimes: async (id, opts) => {
+    const quiet = opts?.quiet === true;
+    if (!quiet) {
+      set((state) => {
+        const next = { ...state.runtimeErrors };
+        delete next[id];
+        return { refreshingRuntimesId: id, runtimeErrors: next };
+      });
+    }
     try {
       const res = await fetch(
         `/api/daemon/instances/${encodeURIComponent(id)}/refresh-runtimes`,
         { method: "POST" },
       );
       if (!res.ok) {
+        if (quiet) return;
         let msg: string;
         if (res.status === 409) {
           msg = "daemon offline, start it first";
@@ -399,9 +406,10 @@ export const useDaemonStore = create<DaemonState>()((set, get) => ({
             ? { ...d, runtimes, runtimes_probed_at: probedAt }
             : d,
         ),
-        refreshingRuntimesId: null,
+        ...(quiet ? {} : { refreshingRuntimesId: null }),
       });
     } catch (err) {
+      if (quiet) return;
       const msg = err instanceof Error ? err.message : "Failed to refresh runtimes";
       set((state) => ({
         refreshingRuntimesId: null,


### PR DESCRIPTION
## Summary
- After copying the daemon `curl|sh` install command, the dashboard dialog and Daemons settings page now auto-detect the daemon coming online without requiring a manual Refresh click — same UX that the OpenClaw `InstallCommandPanel` already had.
- After picking the `openclaw-acp` runtime, the gateway picker now polls `refreshRuntimes` until at least one reachable endpoint shows up, so users no longer get stuck on the static "No OpenClaw gateways configured… click Detect runtimes" message after editing `openclawGateways` and reloading the daemon.
- Polling is bounded: it only runs while the user is actively waiting (install banner visible / `openclaw-acp` picked with no reachable endpoint) and stops as soon as state resolves. A new `{ quiet: true }` option on `refresh` / `refreshRuntimes` skips touching `loading` / `refreshingRuntimesId` / `error`, so spinners and error banners do not flicker during background polls.

## Test plan
- [ ] Open Create Agent dialog with no daemons connected → run install command in terminal → dialog auto-advances to runtime picker within ~3s.
- [ ] In Create Agent dialog, pick `openclaw-acp` on a daemon whose `openclawGateways` is empty → add an entry on the daemon and reload it → gateway picker auto-populates within ~5s without clicking Detect runtimes.
- [ ] Settings → Daemons with no daemons (or one offline) → install/reconnect banner stays visible and auto-clears within ~3s once the daemon reports online; manual Refresh button still works and shows its spinner.
- [ ] Manual Refresh buttons still surface errors as before (quiet polls do not overwrite the error banner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)