### PR TITLE
fix: harden OpenClaw daemon discovery

### DIFF
--- a/e2e/gcp-run.sh
+++ b/e2e/gcp-run.sh
@@ -292,6 +292,11 @@ for i in $(seq 1 "$INSTANCE_COUNT"); do
   \"channels\": {},
   \"gateway\": {
     \"mode\": \"local\",
+    \"port\": ${GATEWAY_PORT},
+    \"auth\": {
+      \"mode\": \"token\",
+      \"token\": \"${TOKEN}\"
+    },
     \"controlUi\": {
       \"dangerouslyAllowHostHeaderOriginFallback\": true,
       \"allowInsecureAuth\": true,
@@ -321,6 +326,7 @@ Environment=\"NODE_OPTIONS=--require /home/openclaw/.openclaw/gaxios-fetch-patch
 Environment=GOOGLE_APPLICATION_CREDENTIALS=/home/openclaw/.openclaw/vertex-sa-key.json
 Environment=GOOGLE_CLOUD_PROJECT=${GCP_PROJECT}
 Environment=GOOGLE_CLOUD_LOCATION=global
+Environment=OPENCLAW_GATEWAY_PORT=${GATEWAY_PORT}
 Environment=OPENCLAW_GATEWAY_TOKEN=${TOKEN}
 ExecStart=/usr/bin/openclaw gateway --bind lan --port ${GATEWAY_PORT} --allow-unconfigured
 Restart=always

--- a/frontend/src/components/daemon/DaemonsSettingsPage.tsx
+++ b/frontend/src/components/daemon/DaemonsSettingsPage.tsx
@@ -332,6 +332,15 @@ export default function DaemonsSettingsPage() {
   const hasOffline = sorted.some((d) => d.status === "offline");
   const showInstallPanel = empty || hasOffline;
 
+  // Auto-detect daemons coming online while the install/reconnect banner is up.
+  useEffect(() => {
+    if (!showInstallPanel) return;
+    const id = window.setInterval(() => {
+      void refresh({ quiet: true });
+    }, 3_000);
+    return () => window.clearInterval(id);
+  }, [showInstallPanel, refresh]);
+
   const installLabels = empty
     ? {
         title: "No daemons connected yet",

--- a/frontend/src/components/dashboard/CreateAgentDialog.tsx
+++ b/frontend/src/components/dashboard/CreateAgentDialog.tsx
@@ -139,6 +139,29 @@ export default function CreateAgentDialog({
 
   const showEmptyState = loaded && onlineDaemons.length === 0;
 
+  // Auto-detect daemon coming online while user stares at the install command.
+  useEffect(() => {
+    if (!showEmptyState) return;
+    const id = window.setInterval(() => {
+      void refresh({ quiet: true });
+    }, 3_000);
+    return () => window.clearInterval(id);
+  }, [showEmptyState, refresh]);
+
+  // Auto-detect OpenClaw gateways once the user picks the openclaw-acp runtime
+  // but no reachable endpoint has been probed yet.
+  useEffect(() => {
+    if (selectedRuntimeId !== "openclaw-acp") return;
+    if (!selectedDaemon) return;
+    const reachable = (selectedRuntime?.endpoints ?? []).filter((e) => e.reachable);
+    if (reachable.length > 0) return;
+    const daemonId = selectedDaemon.id;
+    const id = window.setInterval(() => {
+      void refreshRuntimes(daemonId, { quiet: true });
+    }, 5_000);
+    return () => window.clearInterval(id);
+  }, [selectedRuntimeId, selectedDaemon, selectedRuntime, refreshRuntimes]);
+
   function translateError(err: unknown): string {
     if (err instanceof ProvisionAgentError) {
       switch (err.code) {

--- a/frontend/src/store/useDaemonStore.ts
+++ b/frontend/src/store/useDaemonStore.ts
@@ -96,10 +96,10 @@ interface DaemonState {
   runtimeErrors: Record<string, string>;
   renameErrors: Record<string, string>;
 
-  refresh: () => Promise<void>;
+  refresh: (opts?: { quiet?: boolean }) => Promise<void>;
   revoke: (id: string) => Promise<void>;
   rename: (id: string, label: string | null) => Promise<boolean>;
-  refreshRuntimes: (id: string) => Promise<void>;
+  refreshRuntimes: (id: string, opts?: { quiet?: boolean }) => Promise<void>;
   provisionAgent: (
     daemonId: string,
     input: ProvisionAgentInput,
@@ -246,14 +246,16 @@ function normalizeDaemon(raw: Record<string, unknown>): DaemonInstance {
 export const useDaemonStore = create<DaemonState>()((set, get) => ({
   ...initialState,
 
-  refresh: async () => {
-    set({ loading: true, error: null });
+  refresh: async (opts) => {
+    const quiet = opts?.quiet === true;
+    if (!quiet) set({ loading: true, error: null });
     try {
       const res = await fetch("/api/daemon/instances", {
         method: "GET",
         cache: "no-store",
       });
       if (!res.ok) {
+        if (quiet) return;
         const msg = await parseError(res);
         set({ loading: false, error: msg });
         return;
@@ -266,13 +268,14 @@ export const useDaemonStore = create<DaemonState>()((set, get) => ({
           : Array.isArray(data)
             ? data
             : [];
-      set({
-        daemons: (list as Record<string, unknown>[]).map(normalizeDaemon),
-        loading: false,
-        loaded: true,
-        error: null,
-      });
+      const daemons = (list as Record<string, unknown>[]).map(normalizeDaemon);
+      set(
+        quiet
+          ? { daemons, loaded: true }
+          : { daemons, loading: false, loaded: true, error: null },
+      );
     } catch (err) {
+      if (quiet) return;
       set({
         loading: false,
         error: err instanceof Error ? err.message : "Failed to load daemons",
@@ -361,18 +364,22 @@ export const useDaemonStore = create<DaemonState>()((set, get) => ({
     }
   },
 
-  refreshRuntimes: async (id: string) => {
-    set((state) => {
-      const next = { ...state.runtimeErrors };
-      delete next[id];
-      return { refreshingRuntimesId: id, runtimeErrors: next };
-    });
+  refreshRuntimes: async (id, opts) => {
+    const quiet = opts?.quiet === true;
+    if (!quiet) {
+      set((state) => {
+        const next = { ...state.runtimeErrors };
+        delete next[id];
+        return { refreshingRuntimesId: id, runtimeErrors: next };
+      });
+    }
     try {
       const res = await fetch(
         `/api/daemon/instances/${encodeURIComponent(id)}/refresh-runtimes`,
         { method: "POST" },
       );
       if (!res.ok) {
+        if (quiet) return;
         let msg: string;
         if (res.status === 409) {
           msg = "daemon offline, start it first";
@@ -399,9 +406,10 @@ export const useDaemonStore = create<DaemonState>()((set, get) => ({
             ? { ...d, runtimes, runtimes_probed_at: probedAt }
             : d,
         ),
-        refreshingRuntimesId: null,
+        ...(quiet ? {} : { refreshingRuntimesId: null }),
       });
     } catch (err) {
+      if (quiet) return;
       const msg = err instanceof Error ? err.message : "Failed to refresh runtimes";
       set((state) => ({
         refreshingRuntimesId: null,

--- a/packages/daemon/src/__tests__/agent-discovery.test.ts
+++ b/packages/daemon/src/__tests__/agent-discovery.test.ts
@@ -159,6 +159,44 @@ describe("resolveBootAgents", () => {
     expect(res.agents[0].credentialsFile).toBe("/creds/x.json");
   });
 
+  it("skips discovered credentials from a different Hub host", () => {
+    const res = resolveBootAgents(cfg(), {
+      credentialsDir: "/creds",
+      expectedHubUrl: "https://api.preview.botcord.chat",
+      readDir: () => ["prod.json", "preview.json"],
+      stat: () => fakeStat(1),
+      loadCredentials: (f) =>
+        f.endsWith("prod.json")
+          ? fakeCreds("ag_prod", { hubUrl: "https://api.botcord.chat" })
+          : fakeCreds("ag_preview", { hubUrl: "https://api.preview.botcord.chat" }),
+    });
+
+    expect(res.source).toBe("credentials");
+    expect(res.agents.map((a) => a.agentId)).toEqual(["ag_preview"]);
+    expect(res.warnings).toEqual([
+      "credential skipped: hubUrl does not match daemon environment (/creds/prod.json)",
+    ]);
+  });
+
+  it("filters by Hub host before resolving duplicate agentIds", () => {
+    const res = resolveBootAgents(cfg(), {
+      credentialsDir: "/creds",
+      expectedHubUrl: "https://api.preview.botcord.chat",
+      readDir: () => ["preview.json", "prod.json"],
+      stat: (p) => (p.endsWith("prod.json") ? fakeStat(200) : fakeStat(100)),
+      loadCredentials: (f) =>
+        f.endsWith("prod.json")
+          ? fakeCreds("ag_same", { hubUrl: "https://api.botcord.chat" })
+          : fakeCreds("ag_same", { hubUrl: "https://api.preview.botcord.chat" }),
+    });
+
+    expect(res.agents.map((a) => a.agentId)).toEqual(["ag_same"]);
+    expect(res.agents[0].credentialsFile).toBe("/creds/preview.json");
+    expect(res.warnings).toEqual([
+      "credential skipped: hubUrl does not match daemon environment (/creds/prod.json)",
+    ]);
+  });
+
   it("returns an empty agent list (not a throw) when discovery finds nothing", () => {
     const res = resolveBootAgents(cfg(), {
       credentialsDir: "/creds",

--- a/packages/daemon/src/__tests__/openclaw-discovery.test.ts
+++ b/packages/daemon/src/__tests__/openclaw-discovery.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  defaultOpenclawDiscoveryPorts,
   discoverLocalOpenclawGateways,
   mergeOpenclawGateways,
 } from "../openclaw-discovery.js";
@@ -108,6 +109,69 @@ describe("discoverLocalOpenclawGateways", () => {
     ]);
   });
 
+  it("uses OPENCLAW_GATEWAY_URL and gateway token env vars", async () => {
+    const found = await discoverLocalOpenclawGateways({
+      searchPaths: [],
+      defaultPorts: [],
+      env: {
+        OPENCLAW_GATEWAY_URL: "ws://127.0.0.1:16200",
+        OPENCLAW_GATEWAY_TOKEN: "gateway-token",
+      },
+    });
+
+    expect(found).toEqual([
+      expect.objectContaining({
+        url: "ws://127.0.0.1:16200",
+        token: "gateway-token",
+        source: "env",
+      }),
+    ]);
+  });
+
+  it("builds gateway URL from OPENCLAW_GATEWAY_PORT", async () => {
+    const found = await discoverLocalOpenclawGateways({
+      searchPaths: [],
+      defaultPorts: [],
+      env: {
+        OPENCLAW_GATEWAY_PORT: "16200",
+        OPENCLAW_GATEWAY_TOKEN: "gateway-token",
+      },
+    });
+
+    expect(found).toEqual([
+      expect.objectContaining({
+        url: "ws://127.0.0.1:16200",
+        token: "gateway-token",
+        source: "env",
+      }),
+    ]);
+  });
+
+  it("prefers OPENCLAW_ACP env vars over OPENCLAW_GATEWAY env vars", async () => {
+    const found = await discoverLocalOpenclawGateways({
+      searchPaths: [],
+      defaultPorts: [],
+      env: {
+        OPENCLAW_ACP_URL: "ws://127.0.0.1:18888",
+        OPENCLAW_ACP_TOKEN: "acp-token",
+        OPENCLAW_GATEWAY_URL: "ws://127.0.0.1:16200",
+        OPENCLAW_GATEWAY_TOKEN: "gateway-token",
+      },
+    });
+
+    expect(found).toEqual([
+      expect.objectContaining({
+        url: "ws://127.0.0.1:18888",
+        token: "acp-token",
+        source: "env",
+      }),
+    ]);
+  });
+
+  it("includes 16200 in default discovery ports", () => {
+    expect(defaultOpenclawDiscoveryPorts()).toEqual(expect.arrayContaining([18789, 16200]));
+  });
+
   it("adds default-port candidates only when the probe succeeds", async () => {
     const probe = vi.fn<WsEndpointProbeFn>(async ({ url }) => ({
       ok: url.includes("18789"),
@@ -123,6 +187,37 @@ describe("discoverLocalOpenclawGateways", () => {
 
     expect(probe).toHaveBeenCalledTimes(2);
     expect(found.map((g) => g.url)).toEqual(["ws://127.0.0.1:18789"]);
+  });
+
+  it("attaches gateway token fallback to default-port discovery", async () => {
+    const probe = vi.fn<WsEndpointProbeFn>(async () => ({
+      ok: true,
+      agents: [],
+    }));
+
+    const found = await discoverLocalOpenclawGateways({
+      searchPaths: [],
+      defaultPorts: [16200],
+      probe,
+      timeoutMs: 10,
+      env: {
+        OPENCLAW_GATEWAY_TOKEN: "gateway-token",
+      },
+    });
+
+    expect(probe).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "ws://127.0.0.1:16200",
+        token: "gateway-token",
+      }),
+    );
+    expect(found).toEqual([
+      expect.objectContaining({
+        url: "ws://127.0.0.1:16200",
+        token: "gateway-token",
+        source: "default-port",
+      }),
+    ]);
   });
 
   it("prefers config-file auth details over lower-priority duplicate sources", async () => {

--- a/packages/daemon/src/__tests__/provision.test.ts
+++ b/packages/daemon/src/__tests__/provision.test.ts
@@ -887,6 +887,56 @@ describe("adoptDiscoveredOpenclawAgents", () => {
     });
   });
 
+  it("skips auto-adopt when local OpenClaw ACP is explicitly disabled", async () => {
+    await withSandboxHome(async ({ tmp, fs, path: nodePath }) => {
+      const credDir = nodePath.join(tmp, ".botcord", "credentials");
+      fs.mkdirSync(credDir, { recursive: true });
+      fs.writeFileSync(
+        nodePath.join(credDir, "ag_seed.json"),
+        JSON.stringify({
+          version: 1,
+          hubUrl: "https://hub.example",
+          agentId: "ag_seed",
+          keyId: "k_seed",
+          privateKey: Buffer.alloc(32, 8).toString("base64"),
+          savedAt: new Date().toISOString(),
+        }),
+      );
+      const openclawDir = nodePath.join(tmp, ".openclaw");
+      fs.mkdirSync(openclawDir, { recursive: true });
+      fs.writeFileSync(
+        nodePath.join(openclawDir, "openclaw.json"),
+        JSON.stringify({ acp: { enabled: false } }),
+      );
+      mockState.cfg = {
+        defaultRoute: { adapter: "claude-code", cwd: "/tmp" },
+        routes: [],
+        streamBlocks: true,
+        agents: ["ag_seed"],
+        openclawGateways: [{ name: "local", url: "ws://127.0.0.1:18789" }],
+      };
+      const register = vi.fn();
+      const probe = vi.fn<Parameters<typeof adoptDiscoveredOpenclawAgents>[0]["probe"]>(
+        async () => ({ ok: true, agents: [{ id: "main" }] }),
+      );
+
+      const res = await adoptDiscoveredOpenclawAgents({
+        gateway: makeFakeGateway(["ag_seed"]) as unknown as Parameters<typeof adoptDiscoveredOpenclawAgents>[0]["gateway"],
+        register: register as unknown as Parameters<typeof adoptDiscoveredOpenclawAgents>[0]["register"],
+        cfg: mockState.cfg as unknown as DaemonConfig,
+        probe,
+      });
+
+      expect(res).toEqual({
+        adopted: [],
+        skipped: [{ gateway: "local", reason: "acp_disabled" }],
+        failed: [],
+      });
+      expect(probe).not.toHaveBeenCalled();
+      expect(register).not.toHaveBeenCalled();
+    });
+  });
+
   it("uses the OpenClaw workspace identity name when agents.list has no name", async () => {
     await withSandboxHome(async ({ tmp, fs, path: nodePath }) => {
       const credDir = nodePath.join(tmp, ".botcord", "credentials");

--- a/packages/daemon/src/agent-discovery.ts
+++ b/packages/daemon/src/agent-discovery.ts
@@ -66,6 +66,12 @@ export interface DiscoveryFs {
 export interface DiscoveryOptions extends DiscoveryFs {
   /** Directory to scan. Defaults to {@link DEFAULT_CREDENTIALS_DIR}. */
   credentialsDir?: string;
+  /**
+   * Optional daemon target Hub. When set, auto-discovered credentials whose
+   * hubUrl points at a different host are skipped so preview/prod identities
+   * are not mixed by accident.
+   */
+  expectedHubUrl?: string;
 }
 
 /**
@@ -137,6 +143,12 @@ export function discoverAgentCredentials(
       warnings.push(`credentials at ${file} missing agentId; skipped`);
       continue;
     }
+    if (opts.expectedHubUrl && !sameHubHost(creds.hubUrl, opts.expectedHubUrl)) {
+      warnings.push(
+        `credential skipped: hubUrl does not match daemon environment (${file})`,
+      );
+      continue;
+    }
 
     const existing = byAgent.get(creds.agentId);
     if (!existing) {
@@ -186,6 +198,15 @@ export function discoverAgentCredentials(
 
 function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+function sameHubHost(a: string | undefined, b: string | undefined): boolean {
+  if (!a || !b) return true;
+  try {
+    return new URL(a).host === new URL(b).host;
+  } catch {
+    return true;
+  }
 }
 
 /** Result of composing explicit config + discovery into the final boot list. */

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -217,12 +217,17 @@ function buildDaemonLogger(): GatewayLogger {
  */
 export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHandle> {
   const logger = opts.log ?? buildDaemonLogger();
+  const userAuth =
+    opts.userAuth === undefined
+      ? tryLoadUserAuth(logger)
+      : opts.userAuth;
+  const expectedHubUrl = opts.hubBaseUrl ?? userAuth?.current?.hubUrl;
 
   // Resolve boot agents: explicit `agents` config wins; otherwise scan the
   // credentials directory. A zero-agent result is valid in P1 — the daemon
   // still starts with zero channels so operators can drop credentials in
   // and restart without re-running `init`.
-  const boot = opts.bootAgents ?? resolveBootAgents(opts.config);
+  const boot = opts.bootAgents ?? resolveBootAgents(opts.config, { expectedHubUrl });
   for (const w of boot.warnings) {
     logger.warn("daemon.discovery.warning", { message: w });
   }
@@ -455,10 +460,6 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
   // when user-auth hasn't been set up yet. Operators can `login` later
   // without restarting, but for P0 we require a restart to pick it up.
   let controlChannel: ControlChannel | null = null;
-  const userAuth =
-    opts.userAuth === undefined
-      ? tryLoadUserAuth(logger)
-      : opts.userAuth;
   if (userAuth?.current && !opts.disableControlChannel) {
     logger.info("control-channel: enabling", {
       userId: userAuth.current.userId,

--- a/packages/daemon/src/openclaw-discovery.ts
+++ b/packages/daemon/src/openclaw-discovery.ts
@@ -30,7 +30,7 @@ export interface MergeOpenclawGatewayResult {
 }
 
 const DEFAULT_SEARCH_PATHS = ["~/.openclaw/", "/etc/openclaw/"];
-const DEFAULT_PORTS = [18789];
+const DEFAULT_PORTS = [18789, 16200];
 
 export async function discoverLocalOpenclawGateways(
   opts: OpenclawGatewayDiscoveryOptions = {},
@@ -41,17 +41,8 @@ export async function discoverLocalOpenclawGateways(
   }
 
   const env = opts.env ?? process.env;
-  const envUrl = env.OPENCLAW_ACP_URL;
-  if (envUrl) {
-    const item: DiscoveredOpenclawGateway = {
-      name: nameFromUrl(envUrl),
-      url: envUrl,
-      source: "env",
-    };
-    if (env.OPENCLAW_ACP_TOKEN) item.token = env.OPENCLAW_ACP_TOKEN;
-    else if (env.OPENCLAW_ACP_TOKEN_FILE) item.tokenFile = env.OPENCLAW_ACP_TOKEN_FILE;
-    found.push(item);
-  }
+  found.push(...discoverFromEnv(env));
+  const envAuth = pickOpenclawEnvAuth(env);
 
   const ports = opts.defaultPorts ?? DEFAULT_PORTS;
   if (ports.length > 0) {
@@ -60,11 +51,11 @@ export async function discoverLocalOpenclawGateways(
         const url = `ws://127.0.0.1:${port}`;
         try {
           const res = await probeOpenclawAgents(
-            { url },
+            { url, ...envAuth },
             { probe: opts.probe, timeoutMs: opts.timeoutMs },
           );
           if (res.ok) {
-            found.push({ name: nameFromUrl(url), url, source: "default-port" });
+            found.push({ name: nameFromUrl(url), url, source: "default-port", ...envAuth });
           }
         } catch (err) {
           daemonLog.debug("openclaw discovery default-port probe failed", {
@@ -77,6 +68,46 @@ export async function discoverLocalOpenclawGateways(
   }
 
   return dedupeDiscovered(found);
+}
+
+function discoverFromEnv(env: NodeJS.ProcessEnv): DiscoveredOpenclawGateway[] {
+  const url =
+    pickEnv(env, "OPENCLAW_ACP_URL") ??
+    pickEnv(env, "OPENCLAW_GATEWAY_URL") ??
+    urlFromGatewayPort(env);
+  if (!url) return [];
+
+  return [
+    {
+      name: nameFromUrl(url),
+      url,
+      source: "env",
+      ...pickOpenclawEnvAuth(env),
+    },
+  ];
+}
+
+function pickOpenclawEnvAuth(env: NodeJS.ProcessEnv): { token?: string; tokenFile?: string } {
+  const token = pickEnv(env, "OPENCLAW_ACP_TOKEN") ?? pickEnv(env, "OPENCLAW_GATEWAY_TOKEN");
+  if (token) return { token };
+  const tokenFile =
+    pickEnv(env, "OPENCLAW_ACP_TOKEN_FILE") ?? pickEnv(env, "OPENCLAW_GATEWAY_TOKEN_FILE");
+  if (tokenFile) return { tokenFile };
+  return {};
+}
+
+function urlFromGatewayPort(env: NodeJS.ProcessEnv): string | undefined {
+  const raw = pickEnv(env, "OPENCLAW_GATEWAY_PORT");
+  if (!raw) return undefined;
+  const port = Number(raw);
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) return undefined;
+  return `ws://127.0.0.1:${port}`;
+}
+
+function pickEnv(env: NodeJS.ProcessEnv, key: string): string | undefined {
+  const value = env[key];
+  if (typeof value === "string" && value.trim()) return value.trim();
+  return undefined;
 }
 
 export function mergeOpenclawGateways(

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -667,6 +667,17 @@ export async function adoptDiscoveredOpenclawAgents(ctx: {
     failed: [],
   };
   for (const gw of cfg.openclawGateways ?? []) {
+    if (localOpenclawAcpDisabled(gw.url)) {
+      result.skipped.push({
+        gateway: gw.name,
+        reason: "acp_disabled",
+      });
+      daemonLog.warn("openclaw discovery: gateway found but ACP runtime disabled", {
+        gateway: gw.name,
+        url: gw.url,
+      });
+      continue;
+    }
     let probeResult: Awaited<ReturnType<typeof probeOpenclawAgents>>;
     try {
       probeResult = await probeOpenclawAgents(gw, {
@@ -741,6 +752,18 @@ export async function adoptDiscoveredOpenclawAgents(ctx: {
     }
   }
   return result;
+}
+
+function localOpenclawAcpDisabled(rawUrl: string): boolean {
+  if (!isLoopbackUrl(rawUrl)) return false;
+  try {
+    const file = path.join(homedir(), ".openclaw", "openclaw.json");
+    if (!existsSync(file)) return false;
+    const cfg = JSON.parse(readFileSync(file, "utf8")) as any;
+    return cfg?.acp?.enabled === false;
+  } catch {
+    return false;
+  }
 }
 
 async function revokeAgent(


### PR DESCRIPTION
## Summary
- discover OpenClaw gateways from OPENCLAW_GATEWAY_* env vars and default port 16200
- attach env token fallback to default-port probes for token-only systemd deployments
- skip OpenClaw auto-adopt when local ACP is explicitly disabled
- filter auto-discovered BotCord credentials by daemon Hub host to avoid preview/prod mixing
- update E2E GCP OpenClaw service config to persist gateway port/auth and export OPENCLAW_GATEWAY_PORT
- add runtime endpoint status/diagnostics for OpenClaw gateway snapshots (`reachable`, `unreachable`, `acp_disabled`) and preserve them in the dashboard store

## Tests
- cd packages/daemon && npm test -- openclaw-discovery agent-discovery provision
- cd packages/daemon && npm test -- runtime-discovery provision openclaw-discovery agent-discovery
- cd packages/daemon && npm run build
- cd packages/daemon && npm test
- cd packages/protocol-core && npm run build
- bash -n e2e/gcp-run.sh

## Notes
- `cd frontend && npm run build` compiled and passed TypeScript, then failed during prerender for `/admin/codes` because Supabase URL/API key env vars are not configured in this local environment.