### PR TITLE
fix: make daemon install token start idempotent

### DIFF
--- a/packages/daemon/src/__tests__/start-auth.test.ts
+++ b/packages/daemon/src/__tests__/start-auth.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { resolveStartAuthAction } from "../start-auth.js";
+import type { UserAuthRecord } from "../user-auth.js";
+
+const existingAuth: UserAuthRecord = {
+  version: 1,
+  userId: "usr_1",
+  daemonInstanceId: "dm_1",
+  hubUrl: "https://hub.example",
+  accessToken: "at",
+  refreshToken: "rt",
+  expiresAt: Date.now() + 60_000,
+  loggedInAt: new Date().toISOString(),
+};
+
+describe("resolveStartAuthAction", () => {
+  it("reuses existing auth even when a one-time install token is present", () => {
+    expect(
+      resolveStartAuthAction({
+        existing: existingAuth,
+        relogin: false,
+        installToken: "dit_expired",
+      }),
+    ).toBe("reuse-existing");
+  });
+
+  it("redeems an install token when no existing auth is available", () => {
+    expect(
+      resolveStartAuthAction({
+        existing: null,
+        relogin: false,
+        installToken: "dit_new",
+      }),
+    ).toBe("install-token");
+  });
+
+  it("allows --relogin to re-bind with an install token", () => {
+    expect(
+      resolveStartAuthAction({
+        existing: existingAuth,
+        relogin: true,
+        installToken: "dit_new",
+      }),
+    ).toBe("install-token");
+  });
+});

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -57,6 +57,7 @@ import {
   updateWorkingMemory,
   DEFAULT_SECTION,
 } from "./working-memory.js";
+import { resolveStartAuthAction } from "./start-auth.js";
 import {
   discoverLocalOpenclawGateways,
   mergeOpenclawGateways,
@@ -417,9 +418,10 @@ async function runDeviceCodeFlow(opts: {
  * plane (legacy P0 behavior — caller may still log a warning).
  *
  * Decision tree (plan §4.4 + §6.4):
- * 1. Have existing creds, no `--relogin`, no `--install-token` → return existing record.
- * 2. `--install-token` (overrides existing creds — they may be stale or
- *    belong to a different account) → redeem the one-time dashboard ticket.
+ * 1. Have existing creds and no `--relogin` → return existing record, even
+ *    when a dashboard `--install-token` is present. The token is one-time and
+ *    the generated install command should be safe to re-run after first login.
+ * 2. No existing creds + `--install-token` → redeem the one-time dashboard ticket.
  * 3. `--relogin` → device-code login.
  * 4. No creds + TTY → device-code login.
  * 5. No creds + no TTY → exit 1 with the §6.4 hint.
@@ -432,8 +434,9 @@ async function ensureUserAuthForStart(args: ParsedArgs): Promise<UserAuthRecord 
   const relogin = args.flags.relogin === true;
 
   const existing = safeLoadUserAuth();
+  const authAction = resolveStartAuthAction({ existing, relogin, installToken });
 
-  if (!relogin && !installToken && existing) {
+  if (authAction === "reuse-existing" && existing) {
     // A previously-set auth-expired flag is stale by definition once the
     // operator runs `start` again — if creds genuinely don't work, the
     // control channel will re-write the flag on the next 4401/4403.
@@ -449,6 +452,9 @@ async function ensureUserAuthForStart(args: ParsedArgs): Promise<UserAuthRecord 
         `note: --label "${labelFlag}" ignored (already logged in as "${existing.label ?? "<unset>"}"); pass --relogin to change it`,
       );
     }
+    if (installToken) {
+      console.error("note: --install-token ignored because daemon is already logged in; pass --relogin to re-bind");
+    }
     return existing;
   }
 
@@ -456,7 +462,7 @@ async function ensureUserAuthForStart(args: ParsedArgs): Promise<UserAuthRecord 
   const hubUrl = hubFlag ?? existing?.hubUrl ?? DEFAULT_HUB;
   const label = labelFlag ?? defaultLoginLabel();
 
-  if (installToken) {
+  if (authAction === "install-token" && installToken) {
     const tok = await redeemInstallToken({ hubUrl, installToken, label });
     const record = userAuthFromTokenResponse(tok, { label });
     saveUserAuth(record);

--- a/packages/daemon/src/start-auth.ts
+++ b/packages/daemon/src/start-auth.ts
@@ -1,0 +1,13 @@
+import type { UserAuthRecord } from "./user-auth.js";
+
+export type StartAuthAction = "reuse-existing" | "install-token" | "device-code";
+
+export function resolveStartAuthAction(opts: {
+  existing: UserAuthRecord | null;
+  relogin: boolean;
+  installToken?: string;
+}): StartAuthAction {
+  if (opts.existing && !opts.relogin) return "reuse-existing";
+  if (opts.installToken) return "install-token";
+  return "device-code";
+}


### PR DESCRIPTION
## Summary
- Reuse existing daemon user auth on start even when a dashboard install token is present
- Keep install-token redemption for first login and explicit --relogin re-bind flows
- Add focused auth decision tests

## Tests
- npm test -- start-auth.test.ts
- npm run build

Note: npx tsc --noEmit currently reports pre-existing test typing errors outside this change.