### PR TITLE
feat: add OpenClaw runtime endpoint diagnostics

### DIFF
--- a/frontend/src/store/useDaemonStore.ts
+++ b/frontend/src/store/useDaemonStore.ts
@@ -21,8 +21,10 @@ export interface DaemonRuntimeEndpoint {
   name: string;
   url: string;
   reachable: boolean;
+  status?: "reachable" | "unreachable" | "acp_disabled";
   version?: string;
   error?: string;
+  diagnostics?: Array<{ code: string; message?: string }>;
   agents?: Array<{
     id: string;
     name?: string;
@@ -167,8 +169,29 @@ function normalizeRuntimes(raw: unknown): DaemonRuntime[] | null | undefined {
               name: epName,
               url: epUrl,
               reachable: ep.reachable === true,
+              status:
+                ep.status === "reachable" ||
+                ep.status === "unreachable" ||
+                ep.status === "acp_disabled"
+                  ? ep.status
+                  : undefined,
               version: typeof ep.version === "string" ? ep.version : undefined,
               error: typeof ep.error === "string" ? ep.error : undefined,
+              diagnostics: Array.isArray(ep.diagnostics)
+                ? (ep.diagnostics as unknown[])
+                    .map((d) => {
+                      if (!d || typeof d !== "object") return null;
+                      const dx = d as Record<string, unknown>;
+                      const code = typeof dx.code === "string" ? dx.code : null;
+                      if (!code) return null;
+                      return {
+                        code,
+                        message:
+                          typeof dx.message === "string" ? dx.message : undefined,
+                      };
+                    })
+                    .filter(Boolean) as DaemonRuntimeEndpoint["diagnostics"]
+                : undefined,
               agents: Array.isArray(ep.agents)
                 ? ((ep.agents as unknown[])
                     .map((a) => {

--- a/packages/daemon/src/__tests__/runtime-discovery.test.ts
+++ b/packages/daemon/src/__tests__/runtime-discovery.test.ts
@@ -1,4 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
 // Hoisted mock for `../adapters/runtimes.js` so each suite can stub
 // `detectRuntimes()` independently — we want coverage of the "empty
@@ -24,7 +27,12 @@ vi.mock("../adapters/runtimes.js", async () => {
   };
 });
 
-const { collectRuntimeSnapshot, clearRuntimeProbeCache, createProvisioner } = await import("../provision.js");
+const {
+  collectRuntimeSnapshot,
+  collectRuntimeSnapshotAsync,
+  clearRuntimeProbeCache,
+  createProvisioner,
+} = await import("../provision.js");
 
 beforeEach(() => {
   // The L1 probe is memoized for 30s in production; tests rotate the
@@ -91,6 +99,100 @@ describe("collectRuntimeSnapshot", () => {
     const [entry] = collectRuntimeSnapshot().runtimes;
     expect(entry).toBeDefined();
     expect(Object.keys(entry!).sort()).toEqual(["available", "id"]);
+  });
+});
+
+describe("collectRuntimeSnapshotAsync", () => {
+  it("adds OpenClaw endpoint status and diagnostics", async () => {
+    setRuntimes([
+      {
+        id: "openclaw-acp",
+        displayName: "OpenClaw",
+        binary: "openclaw",
+        supportsRun: true,
+        result: { available: true, version: "0.1.0" },
+      },
+    ]);
+
+    const snap = await collectRuntimeSnapshotAsync({
+      cfg: {
+        openclawGateways: [
+          { name: "ok", url: "ws://127.0.0.1:18789" },
+          { name: "bad", url: "ws://127.0.0.1:16200" },
+        ],
+      },
+      wsProbe: async ({ url }) =>
+        url.includes("18789")
+          ? { ok: true, version: "gw-1", agents: [{ id: "main" }] }
+          : { ok: false, error: "connect rejected" },
+    });
+
+    const runtime = snap.runtimes.find((r) => r.id === "openclaw-acp");
+    expect(runtime?.endpoints).toEqual([
+      expect.objectContaining({
+        name: "ok",
+        reachable: true,
+        status: "reachable",
+        version: "gw-1",
+        agents: [{ id: "main" }],
+      }),
+      expect.objectContaining({
+        name: "bad",
+        reachable: false,
+        status: "unreachable",
+        error: "connect rejected",
+        diagnostics: [{ code: "gateway_unreachable", message: "connect rejected" }],
+      }),
+    ]);
+  });
+
+  it("reports acp_disabled without probing the gateway", async () => {
+    const tmp = mkdtempSync(path.join(tmpdir(), "daemon-runtime-openclaw-"));
+    const prevHome = process.env.HOME;
+    process.env.HOME = tmp;
+    try {
+      mkdirSync(path.join(tmp, ".openclaw"), { recursive: true });
+      writeFileSync(
+        path.join(tmp, ".openclaw", "openclaw.json"),
+        JSON.stringify({ acp: { enabled: false } }),
+      );
+      setRuntimes([
+        {
+          id: "openclaw-acp",
+          displayName: "OpenClaw",
+          binary: "openclaw",
+          supportsRun: true,
+          result: { available: true },
+        },
+      ]);
+      const wsProbe = vi.fn(async () => ({ ok: true }));
+
+      const snap = await collectRuntimeSnapshotAsync({
+        cfg: { openclawGateways: [{ name: "local", url: "ws://127.0.0.1:18789" }] },
+        wsProbe,
+      });
+
+      expect(wsProbe).not.toHaveBeenCalled();
+      const runtime = snap.runtimes.find((r) => r.id === "openclaw-acp");
+      expect(runtime?.endpoints).toEqual([
+        expect.objectContaining({
+          name: "local",
+          reachable: false,
+          status: "acp_disabled",
+          error: "OpenClaw ACP runtime disabled",
+          diagnostics: [
+            {
+              code: "acp_disabled",
+              message: "OpenClaw config explicitly disables the ACP runtime",
+            },
+          ],
+        }),
+      ]);
+    } finally {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -1324,22 +1324,48 @@ export async function collectRuntimeSnapshotAsync(opts: {
   const capped = gateways.slice(0, RUNTIME_ENDPOINTS_CAP);
   const endpoints = await Promise.all(
     capped.map(async (g) => {
+      if (localOpenclawAcpDisabled(g.url)) {
+        return {
+          name: g.name,
+          url: g.url,
+          reachable: false,
+          status: "acp_disabled",
+          error: "OpenClaw ACP runtime disabled",
+          diagnostics: [
+            {
+              code: "acp_disabled",
+              message: "OpenClaw config explicitly disables the ACP runtime",
+            },
+          ],
+        };
+      }
       try {
         const res = await probeOpenclawAgents(g, {
           probe: opts.wsProbe,
           timeoutMs,
         });
-        const entry: any = { name: g.name, url: g.url, reachable: res.ok };
+        const entry: any = {
+          name: g.name,
+          url: g.url,
+          reachable: res.ok,
+          status: res.ok ? "reachable" : "unreachable",
+        };
         if (res.version) entry.version = res.version;
-        if (res.error) entry.error = res.error;
+        if (res.error) {
+          entry.error = res.error;
+          entry.diagnostics = [{ code: "gateway_unreachable", message: res.error }];
+        }
         if (res.agents) entry.agents = res.agents;
         return entry;
       } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
         return {
           name: g.name,
           url: g.url,
           reachable: false,
-          error: (err as Error).message,
+          status: "unreachable",
+          error: message,
+          diagnostics: [{ code: "probe_failed", message }],
         };
       }
     }),

--- a/packages/protocol-core/src/control-frame.ts
+++ b/packages/protocol-core/src/control-frame.ts
@@ -310,12 +310,22 @@ export interface RuntimeEndpointProbe {
   name: string;
   /** Endpoint URL (e.g. `wss://gw.example:18789`). */
   url: string;
+  /**
+   * Coarse diagnostic state for dashboards. `reachable` is kept for backward
+   * compatibility; new clients should prefer `status` when present.
+   */
+  status?: "reachable" | "unreachable" | "acp_disabled";
   /** True when the gateway responded successfully within the timeout. */
   reachable: boolean;
   /** Gateway-reported version, when available. */
   version?: string;
   /** Failure reason when `reachable === false`. */
   error?: string;
+  /** Structured diagnostics for UI/tooling. */
+  diagnostics?: Array<{
+    code: "gateway_unreachable" | "probe_failed" | "acp_disabled";
+    message?: string;
+  }>;
   /**
    * Listing of agent profiles, only set when `reachable` and the listing RPC
    * (`agents.list`) succeeded. Shape mirrors OpenClaw's


### PR DESCRIPTION
## Summary
- add `status` and structured `diagnostics` to OpenClaw runtime endpoint snapshots
- report `reachable`, `unreachable`, and `acp_disabled` states without re-running discovery logic
- preserve endpoint diagnostics in the dashboard daemon store

## Tests
- cd packages/daemon && npm test -- runtime-discovery
- cd packages/daemon && npm run build
- cd packages/protocol-core && npm run build
- cd frontend && npm run build (compiled and passed TypeScript; failed during prerender for `/admin/codes` because Supabase URL/API key env vars are not configured locally)
