### PR TITLE
fix: refresh contacts after friend updates

### DIFF
--- a/frontend/src/components/dashboard/AddFriendModal.tsx
+++ b/frontend/src/components/dashboard/AddFriendModal.tsx
@@ -98,6 +98,7 @@ function SearchPane({ onClose }: { onClose: () => void }) {
   const locale = useLanguage();
   const t = addFriendModal[locale];
   const contacts = useDashboardChatStore((s) => s.overview?.contacts) ?? EMPTY_CONTACTS;
+  const refreshOverview = useDashboardChatStore((s) => s.refreshOverview);
   const activeAgentId = useDashboardSessionStore((s) => s.activeAgentId);
   // Identity signal: viewMode flips to "human" once /api/humans/me loads.
   const viewMode = useDashboardSessionStore((s) => s.viewMode);
@@ -194,11 +195,17 @@ function SearchPane({ onClose }: { onClose: () => void }) {
       } else {
         setStatus("sent");
       }
+      await refreshOverview();
     } catch (err) {
       const msg = err instanceof Error ? err.message : t.requestFailed;
-      if (/already.*contact/i.test(msg)) setStatus("exists");
-      else if (/already.*request|pending/i.test(msg)) setStatus("pending");
-      else setError(msg);
+      if (/already.*contact/i.test(msg)) {
+        setStatus("exists");
+        await refreshOverview();
+      } else if (/already.*request|pending/i.test(msg)) {
+        setStatus("pending");
+      } else {
+        setError(msg);
+      }
     } finally {
       setSending(false);
     }

--- a/frontend/src/components/dashboard/ChatPane.tsx
+++ b/frontend/src/components/dashboard/ChatPane.tsx
@@ -82,6 +82,7 @@ function ContactsMainPane({ onHumanOpen }: { onHumanOpen?: (human: PublicHumanPr
   })));
   const sessionMode = useDashboardSessionStore((state) => state.sessionMode);
   const activeAgentId = useDashboardSessionStore((state) => state.activeAgentId);
+  const isAuthed = sessionMode === "authed-ready" || sessionMode === "authed-no-agent";
   const [query, setQuery] = useState("");
   const [showFriendInvite, setShowFriendInvite] = useState(false);
   const isRequestsView = contactsView === "requests";
@@ -103,19 +104,19 @@ function ContactsMainPane({ onHumanOpen }: { onHumanOpen?: (human: PublicHumanPr
   const pendingReceived = contactRequestsReceived.filter((item) => item.state === "pending");
 
   useEffect(() => {
-    if (sessionMode === "authed-ready") {
+    if (isAuthed) {
       void loadContactRequests();
     }
-  }, [sessionMode, loadContactRequests]);
+  }, [isAuthed, loadContactRequests]);
 
   // Always refresh overview when entering the contacts pane so that newly
   // created rooms (built by the agent via /hub/rooms with no messages yet)
   // and freshly added contacts show up without waiting for a realtime event.
   useEffect(() => {
-    if (sessionMode === "authed-ready") {
+    if (isAuthed) {
       void refreshOverview();
     }
-  }, [sessionMode, contactsView, refreshOverview]);
+  }, [isAuthed, contactsView, refreshOverview]);
 
   const normalized = query.trim().toLowerCase();
   const filteredContacts = contacts.filter((item) => {

--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -757,13 +757,15 @@ export default function DashboardApp() {
               ? "pending"
               : "sent",
       });
+      await chatStore.refreshOverview();
     } catch (error) {
       const message = error instanceof Error ? error.message : "Request failed";
+      const alreadyContact = /already.*contact/i.test(message);
       setOwnerHumanCard((prev) => prev && {
         ...prev,
         sending: false,
         status:
-          /already.*contact/i.test(message)
+          alreadyContact
             ? "exists"
             : /already.*request|pending/i.test(message)
               ? "pending"
@@ -773,6 +775,9 @@ export default function DashboardApp() {
             ? null
             : message,
       });
+      if (alreadyContact) {
+        await chatStore.refreshOverview();
+      }
     }
   };
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -79,7 +79,7 @@ export interface ContactInfo {
 }
 
 export interface ContactRequestItem {
-  id: number;
+  id: number | string;
   from_agent_id: string;
   to_agent_id: string;
   state: "pending" | "accepted" | "rejected";

--- a/frontend/src/store/useDashboardContactStore.ts
+++ b/frontend/src/store/useDashboardContactStore.ts
@@ -6,8 +6,8 @@
  */
 
 import { create } from "zustand";
-import type { ContactRequestItem } from "@/lib/types";
-import { api } from "@/lib/api";
+import type { ContactRequestItem, HumanContactRequestSummary } from "@/lib/types";
+import { api, humansApi } from "@/lib/api";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 
@@ -16,7 +16,7 @@ interface DashboardContactState {
   contactRequestsReceived: ContactRequestItem[];
   contactRequestsSent: ContactRequestItem[];
   contactRequestsLoading: boolean;
-  processingContactRequestId: number | null;
+  processingContactRequestId: number | string | null;
   processingContactRequestAction: "accept" | "reject" | null;
   sendingContactRequestAgentId: string | null;
 
@@ -24,7 +24,7 @@ interface DashboardContactState {
   resetContactState: () => void;
   loadContactRequests: () => Promise<void>;
   sendContactRequest: (toAgentId: string, message?: string) => Promise<void>;
-  respondContactRequest: (requestId: number, action: "accept" | "reject") => Promise<void>;
+  respondContactRequest: (requestId: number | string, action: "accept" | "reject") => Promise<void>;
 }
 
 const initialContactState = {
@@ -37,9 +37,32 @@ const initialContactState = {
   sendingContactRequestAgentId: null,
 };
 
-function hasReadyAgent() {
-  const { token, activeAgentId } = useDashboardSessionStore.getState();
-  return Boolean(token && activeAgentId);
+function isHumanContactSurface() {
+  const { activeIdentity, viewMode } = useDashboardSessionStore.getState();
+  return activeIdentity?.type === "human" || viewMode === "human";
+}
+
+function hasReadyContactIdentity() {
+  const { token, activeAgentId, activeIdentity, viewMode, human } = useDashboardSessionStore.getState();
+  if (!token) return false;
+  if (activeIdentity?.type === "human" || viewMode === "human") {
+    return Boolean(human?.human_id);
+  }
+  return Boolean(activeAgentId);
+}
+
+function normalizeHumanContactRequest(item: HumanContactRequestSummary): ContactRequestItem {
+  return {
+    id: item.id,
+    from_agent_id: item.from_participant_id,
+    to_agent_id: item.to_participant_id,
+    state: item.state,
+    message: item.message,
+    created_at: new Date(item.created_at * 1000).toISOString(),
+    resolved_at: null,
+    from_display_name: item.from_display_name,
+    to_display_name: item.to_display_name,
+  };
 }
 
 export const useDashboardContactStore = create<DashboardContactState>()((set, get) => ({
@@ -55,7 +78,7 @@ export const useDashboardContactStore = create<DashboardContactState>()((set, ge
   resetContactState: () => set({ ...initialContactState }),
 
   loadContactRequests: async () => {
-    if (!hasReadyAgent()) {
+    if (!hasReadyContactIdentity()) {
       set({
         contactRequestsReceived: [],
         contactRequestsSent: [],
@@ -65,10 +88,18 @@ export const useDashboardContactStore = create<DashboardContactState>()((set, ge
     }
     set({ contactRequestsLoading: true });
     try {
-      const [received, sent] = await Promise.all([
-        api.getContactRequestsReceived(),
-        api.getContactRequestsSent(),
-      ]);
+      const [received, sent] = isHumanContactSurface()
+        ? await Promise.all([
+            humansApi.listReceivedContactRequests(),
+            humansApi.listSentContactRequests(),
+          ]).then(([receivedRes, sentRes]) => [
+            { requests: receivedRes.requests.map(normalizeHumanContactRequest) },
+            { requests: sentRes.requests.map(normalizeHumanContactRequest) },
+          ] as const)
+        : await Promise.all([
+            api.getContactRequestsReceived(),
+            api.getContactRequestsSent(),
+          ]);
       const pendingSentTargets = sent.requests
         .filter((item) => item.state === "pending")
         .map((item) => item.to_agent_id);
@@ -88,8 +119,13 @@ export const useDashboardContactStore = create<DashboardContactState>()((set, ge
     if (!token) return;
     set({ sendingContactRequestAgentId: toAgentId });
     try {
-      await api.createContactRequest({ to_agent_id: toAgentId, message });
-      await get().loadContactRequests();
+      if (isHumanContactSurface()) {
+        await humansApi.sendContactRequest({ peer_id: toAgentId, message });
+      } else {
+        await api.createContactRequest({ to_agent_id: toAgentId, message });
+      }
+      const chatStore = useDashboardChatStore.getState();
+      await Promise.all([chatStore.refreshOverview(), get().loadContactRequests()]);
       set((state) => ({
         pendingFriendRequests: state.pendingFriendRequests.includes(toAgentId)
           ? state.pendingFriendRequests
@@ -102,15 +138,23 @@ export const useDashboardContactStore = create<DashboardContactState>()((set, ge
     }
   },
 
-  respondContactRequest: async (requestId: number, action: "accept" | "reject") => {
+  respondContactRequest: async (requestId: number | string, action: "accept" | "reject") => {
     const { token } = useDashboardSessionStore.getState();
     if (!token) return;
     set({ processingContactRequestId: requestId, processingContactRequestAction: action });
     try {
       if (action === "accept") {
-        await api.acceptContactRequest(requestId);
+        if (isHumanContactSurface()) {
+          await humansApi.acceptContactRequest(String(requestId));
+        } else {
+          await api.acceptContactRequest(Number(requestId));
+        }
       } else {
-        await api.rejectContactRequest(requestId);
+        if (isHumanContactSurface()) {
+          await humansApi.rejectContactRequest(String(requestId));
+        } else {
+          await api.rejectContactRequest(Number(requestId));
+        }
       }
       const chatStore = useDashboardChatStore.getState();
       await Promise.all([chatStore.refreshOverview(), get().loadContactRequests()]);


### PR DESCRIPTION
## Summary
- refresh dashboard overview after friend request outcomes so My Friends updates immediately
- support human contact request APIs in the dashboard contact store
- load contact requests and overview for human-only sessions on the contacts page

## Test
- NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build