### PR TITLE
fix: accept prefixed human contact request ids

### DIFF
--- a/backend/app/routers/humans.py
+++ b/backend/app/routers/humans.py
@@ -369,6 +369,16 @@ def _split_prefix(participant_id: str) -> ParticipantType:
     raise HTTPException(status_code=400, detail="peer_id must be prefixed with ag_ or hu_")
 
 
+def _parse_contact_request_id(request_id: str) -> int:
+    raw = request_id
+    if raw.startswith("cr_"):
+        raw = raw[len("cr_") :]
+    try:
+        return int(raw)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Contact request not found")
+
+
 def _invite_url(code: str) -> str:
     return frontend_url(f"/i/{code}")
 
@@ -2029,7 +2039,7 @@ async def _reject_human_contact_request(
     response_model=HumanContactRequestResolveResponse,
 )
 async def accept_contact_request_as_human(
-    request_id: int,
+    request_id: str,
     ctx: RequestContext = Depends(require_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -2043,7 +2053,7 @@ async def accept_contact_request_as_human(
     me = user.human_id
 
     result = await db.execute(
-        select(ContactRequest).where(ContactRequest.id == request_id)
+        select(ContactRequest).where(ContactRequest.id == _parse_contact_request_id(request_id))
     )
     req = result.scalar_one_or_none()
     if req is None:
@@ -2066,7 +2076,7 @@ async def accept_contact_request_as_human(
     response_model=HumanContactRequestResolveResponse,
 )
 async def reject_contact_request_as_human(
-    request_id: int,
+    request_id: str,
     ctx: RequestContext = Depends(require_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -2075,7 +2085,7 @@ async def reject_contact_request_as_human(
     me = user.human_id
 
     result = await db.execute(
-        select(ContactRequest).where(ContactRequest.id == request_id)
+        select(ContactRequest).where(ContactRequest.id == _parse_contact_request_id(request_id))
     )
     req = result.scalar_one_or_none()
     if req is None:

--- a/backend/tests/test_app/test_app_humans.py
+++ b/backend/tests/test_app/test_app_humans.py
@@ -1068,6 +1068,41 @@ async def test_h2h_accept_creates_mutual_contacts(
 
 
 @pytest.mark.asyncio
+async def test_h2h_accept_direct_endpoint_accepts_prefixed_contact_request_id(
+    client, seed, db_session: AsyncSession
+):
+    """The UI may pass the merged approval id form (cr_<id>) to the direct
+    Human contact-request endpoint; it should resolve to the same row.
+    """
+    _, bob_human_id, bob_token = await _seed_second_human(db_session, "Bob")
+
+    resp = await client.post(
+        "/api/humans/me/contacts/request",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+        json={"peer_id": bob_human_id},
+    )
+    assert resp.status_code == 202
+
+    received = await client.get(
+        "/api/humans/me/contact-requests/received",
+        headers={"Authorization": f"Bearer {bob_token}"},
+    )
+    req_id = received.json()["requests"][0]["id"]
+
+    accept = await client.post(
+        f"/api/humans/me/contact-requests/cr_{req_id}/accept",
+        headers={"Authorization": f"Bearer {bob_token}"},
+    )
+    assert accept.status_code == 200, accept.text
+    assert accept.json()["state"] == "accepted"
+
+    rows = list((await db_session.execute(select(Contact))).scalars().all())
+    pairs = {(c.owner_id, c.contact_agent_id) for c in rows}
+    assert (bob_human_id, seed["human_id"]) in pairs
+    assert (seed["human_id"], bob_human_id) in pairs
+
+
+@pytest.mark.asyncio
 async def test_h2h_request_surfaces_in_pending_approvals(
     client, seed, db_session: AsyncSession
 ):


### PR DESCRIPTION
## Summary
- allow human contact-request accept/reject endpoints to parse both numeric ids and cr_<id> approval ids
- add regression coverage for accepting a direct human request using the prefixed id form

## Tests
- cd backend && uv run pytest tests/test_app/test_app_humans.py -q