### PR TITLE
fix: hide revoked daemon instances

### DIFF
--- a/frontend/src/store/useDaemonStore.ts
+++ b/frontend/src/store/useDaemonStore.ts
@@ -291,7 +291,9 @@ export const useDaemonStore = create<DaemonState>()((set, get) => ({
           : Array.isArray(data)
             ? data
             : [];
-      const daemons = (list as Record<string, unknown>[]).map(normalizeDaemon);
+      const daemons = (list as Record<string, unknown>[])
+        .map(normalizeDaemon)
+        .filter((d) => !d.revoked_at);
       set(
         quiet
           ? { daemons, loaded: true }
@@ -318,13 +320,10 @@ export const useDaemonStore = create<DaemonState>()((set, get) => ({
         set({ revokingId: null, error: msg });
         return;
       }
-      // Optimistic local update; refresh will reconcile
+      // Optimistic local update; refresh will reconcile. Revoked daemon
+      // instances are hidden from the frontend list.
       set({
-        daemons: get().daemons.map((d) =>
-          d.id === id
-            ? { ...d, status: "revoked", revoked_at: new Date().toISOString() }
-            : d,
-        ),
+        daemons: get().daemons.filter((d) => d.id !== id),
         revokingId: null,
       });
       void get().refresh();


### PR DESCRIPTION
## Summary
- Hide daemon instances with revoked_at from the frontend daemon store
- Remove revoked daemons from the local list immediately after revoke succeeds

## Tests
- npm run build *(fails: missing dependency remark-breaks imported by src/components/ui/MarkdownContent.tsx)*