### PR TITLE
fix: human owner of agent owner can edit room settings

### DIFF
--- a/backend/app/routers/humans.py
+++ b/backend/app/routers/humans.py
@@ -313,6 +313,38 @@ def _ts(dt: datetime.datetime | None) -> int:
     return int(dt.timestamp())
 
 
+async def _load_owned_agent_ids(db: AsyncSession, user_id: UUID | None) -> set[str]:
+    """Return the set of ``agent_id`` rows whose ``user_id`` matches.
+
+    Used to honour transitive ownership: the human owner of an agent that
+    owns a room should see ``my_role == "owner"`` and pass owner-only gates
+    on that room. Mirrors :func:`app.auth_room.viewer_can_admin_room`.
+    """
+    if user_id is None:
+        return set()
+    result = await db.execute(select(Agent.agent_id).where(Agent.user_id == user_id))
+    return {row[0] for row in result.all()}
+
+
+def _effective_human_role(
+    role: RoomRole | str,
+    room: Room,
+    owned_agent_ids: set[str],
+) -> RoomRole | str:
+    """Promote ``role`` to ``owner`` when the human owns the room's agent owner.
+
+    Returning ``RoomRole.owner`` instead of mutating DB state keeps the
+    serialiser output and the in-process permission gates aligned without
+    rewriting room_members rows.
+    """
+    if (
+        room.owner_type == ParticipantType.agent
+        and room.owner_id in owned_agent_ids
+    ):
+        return RoomRole.owner
+    return role
+
+
 def _serialize_human_room_summary(
     room: Room,
     my_role: RoomRole | str,
@@ -541,8 +573,13 @@ async def list_human_rooms(
             .group_by(RoomMember.room_id)
         )
         member_counts = {room_id: int(count or 0) for room_id, count in count_result.all()}
+    owned_agent_ids = await _load_owned_agent_ids(db, ctx.user_id)
     rooms = [
-        _serialize_human_room_summary(room, role, member_count=member_counts.get(room.room_id, 0))
+        _serialize_human_room_summary(
+            room,
+            _effective_human_role(role, room, owned_agent_ids),
+            member_count=member_counts.get(room.room_id, 0),
+        )
         for room, role in rows
     ]
     return HumanRoomListResponse(rooms=rooms)
@@ -1335,7 +1372,9 @@ async def update_room_settings_as_human(
 ):
     user = await _load_human(db, ctx)
     room, caller = await _load_room_member_as_caller(db, room_id, user.human_id, lock=True)
-    if caller.role not in (RoomRole.owner, RoomRole.admin):
+    owned_agent_ids = await _load_owned_agent_ids(db, ctx.user_id)
+    effective_role = _effective_human_role(caller.role, room, owned_agent_ids)
+    if effective_role not in (RoomRole.owner, RoomRole.admin):
         raise HTTPException(status_code=403, detail="Only owner or admin can update room settings")
 
     fields_set = body.model_fields_set
@@ -1349,7 +1388,7 @@ async def update_room_settings_as_human(
         "slow_mode_seconds",
         "required_subscription_product_id",
     }
-    if fields_set & owner_only_fields and caller.role != RoomRole.owner:
+    if fields_set & owner_only_fields and effective_role != RoomRole.owner:
         raise HTTPException(status_code=403, detail="Only the owner can change advanced settings")
 
     if "name" in fields_set:
@@ -1436,7 +1475,7 @@ async def update_room_settings_as_human(
         select(func.count(RoomMember.id)).where(RoomMember.room_id == room.room_id)
     )
     member_count = int(member_count_result.scalar() or 0)
-    return _serialize_human_room_summary(room, caller.role, member_count=member_count)
+    return _serialize_human_room_summary(room, effective_role, member_count=member_count)
 
 
 @router.delete("/me/rooms/{room_id}", response_model=dict)

--- a/backend/tests/test_app/test_app_humans.py
+++ b/backend/tests/test_app/test_app_humans.py
@@ -188,6 +188,73 @@ async def test_human_creates_and_lists_room(client, seed, db_session: AsyncSessi
 
 
 @pytest.mark.asyncio
+async def test_human_member_of_room_owned_by_their_agent_sees_owner_role(
+    client, seed, db_session: AsyncSession
+):
+    """The human owner of an agent that owns a room should see ``my_role ==
+    owner`` and be allowed to update room settings — even when the human's
+    own RoomMember row has ``role == member``."""
+    agent = Agent(
+        agent_id="ag_alice00099",
+        display_name="Alice Bot",
+        message_policy=MessagePolicy.open,
+        user_id=seed["user_id"],
+    )
+    room = Room(
+        room_id="rm_agent_owned",
+        name="Agent Den",
+        description="owned by Alice Bot",
+        owner_id="ag_alice00099",
+        owner_type=ParticipantType.agent,
+        visibility=RoomVisibility.private,
+        join_policy=RoomJoinPolicy.invite_only,
+    )
+    db_session.add_all([agent, room])
+    await db_session.flush()
+    db_session.add_all([
+        RoomMember(
+            room_id="rm_agent_owned",
+            agent_id="ag_alice00099",
+            participant_type=ParticipantType.agent,
+            role=RoomRole.owner,
+        ),
+        RoomMember(
+            room_id="rm_agent_owned",
+            agent_id=seed["human_id"],
+            participant_type=ParticipantType.human,
+            role=RoomRole.member,
+        ),
+    ])
+    await db_session.commit()
+
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+
+    listing = await client.get("/api/humans/me/rooms", headers=headers)
+    assert listing.status_code == 200
+    listed = {r["room_id"]: r for r in listing.json()["rooms"]}
+    assert listed["rm_agent_owned"]["my_role"] == "owner"
+
+    # Basic field — owner-or-admin gate must pass
+    patch_basic = await client.patch(
+        "/api/humans/me/rooms/rm_agent_owned",
+        headers=headers,
+        json={"description": "renamed by human owner"},
+    )
+    assert patch_basic.status_code == 200, patch_basic.text
+    assert patch_basic.json()["my_role"] == "owner"
+    assert patch_basic.json()["description"] == "renamed by human owner"
+
+    # Owner-only field — must also pass via transitive ownership
+    patch_advanced = await client.patch(
+        "/api/humans/me/rooms/rm_agent_owned",
+        headers=headers,
+        json={"visibility": "public"},
+    )
+    assert patch_advanced.status_code == 200, patch_advanced.text
+    assert patch_advanced.json()["visibility"] == "public"
+
+
+@pytest.mark.asyncio
 async def test_list_owned_agent_rooms_excludes_current_human_rooms(
     client, seed, db_session: AsyncSession
 ):


### PR DESCRIPTION
## Summary
- Fix mismatch where dashboard hid the room-settings edit UI for the human owner of an agent that owns a room, even though `auth_room.viewer_can_admin_room` already granted them owner capability
- `/api/humans/me/rooms` now reports `my_role == \"owner\"` for those rooms; `PATCH /api/humans/me/rooms/{room_id}` accepts both basic and owner-only field updates via the same transitive ownership

## Context
`backend/app/auth_room.py:44-53` already promotes the human to `owner` when `room.owner_type == agent` and the owner agent's `user_id` matches the viewer. The agent-mode dashboard PATCH respects that; the human-mode BFF (`/api/humans/me/rooms*`) was checking `RoomMember.role` directly, so the human appeared as a plain member in the listing and got 403 on PATCH for owner-only fields.

## Changes
- `backend/app/routers/humans.py`: add `_load_owned_agent_ids` + `_effective_human_role` helpers; apply in `list_human_rooms` and `update_room_settings_as_human` (both gates + response payload)
- `backend/tests/test_app/test_app_humans.py`: regression test covering listing role, basic-field PATCH, and owner-only-field PATCH

Other human owner-only endpoints (dissolve, transfer, promote, remove member, permissions) deliberately untouched — their semantics involve mutating the owner's own RoomMember row and warrant a separate decision.

## Test plan
- [x] `uv run pytest tests/test_app/ tests/test_dashboard.py tests/test_room.py` — 461 passed, 1 skipped
- [x] New test `test_human_member_of_room_owned_by_their_agent_sees_owner_role` passes
- [ ] Manual: as user A with agent B that owns room R, open R settings in the dashboard human view → settings UI is editable, name/description and visibility patches succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)