### PR TITLE
chore(ci): pin deploy-backend jobs to deploy-host runner label

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -27,7 +27,7 @@ jobs:
   # ── Build + push docker image ────────────────────────────────────────────────
   deploy:
     name: Build & Push
-    runs-on: self-hosted
+    runs-on: [self-hosted, deploy-host]
     timeout-minutes: 20
     outputs:
       image_tag: ${{ steps.build.outputs.image_tag }}
@@ -61,7 +61,7 @@ jobs:
     name: Restart Preview
     needs: [deploy]
     if: inputs.env_name == 'preview'
-    runs-on: self-hosted
+    runs-on: [self-hosted, deploy-host]
     timeout-minutes: 10
     env:
       PROJECT: botcord-backend
@@ -77,7 +77,7 @@ jobs:
     name: Rollout Production
     needs: [deploy]
     if: inputs.env_name == 'prod'
-    runs-on: self-hosted
+    runs-on: [self-hosted, deploy-host]
     timeout-minutes: 15
     env:
       PROJECT: botcord-backend


### PR DESCRIPTION
## Summary

- Pin all 3 jobs in `deploy-backend.yml` (`Build & Push`, `Restart Preview`, `Rollout Production`) to `runs-on: [self-hosted, deploy-host]`.
- Required because we just added 2 GCP self-hosted runners (`botcord-gha-runner-1/2`) that share the `self-hosted` label with the existing AWS EC2 runner. Without this, GCP runners would pick up deploy jobs and fail (no implicit AWS IAM role for ECR, no local `${DEPLOY_ROOT}/botcord-backend-preview/docker-compose.yaml`, no kubeconfig at `${K8S_PROD_CONFIG}`).
- The EC2 runner has been relabeled with `deploy-host`; other workflows (CI / test / release / db-migrate / deploy-frontend / publish-package) stay on plain `self-hosted` and load-balance across all 3 runners.

## Test plan

- [ ] Open this PR — `CI` workflow should pick a runner from any of the 3 (validates non-deploy jobs still work on GCP runners)
- [ ] After merge, trigger a preview deploy — `Build & Push` + `Restart Preview` should land specifically on `ec2-ip-172-31-18-51.ec2.internal-botlearn-ai`
- [ ] Confirm preview env still comes up after the redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)