### PR TITLE
perf(daemon): parallelize per-room emit and chain has_more drains

### DIFF
--- a/packages/daemon/src/gateway/channels/botcord.ts
+++ b/packages/daemon/src/gateway/channels/botcord.ts
@@ -30,7 +30,11 @@ const OWNER_CHAT_PREFIX = "rm_oc_";
 const DM_ROOM_PREFIX = "rm_dm_";
 const INBOX_POLL_LIMIT = 50;
 
-type InboxDrainTrigger = "ws_auth_ok" | "ws_inbox_update" | "coalesced_inbox_update";
+type InboxDrainTrigger =
+  | "ws_auth_ok"
+  | "ws_inbox_update"
+  | "coalesced_inbox_update"
+  | "has_more_continue";
 
 /** Minimal surface the adapter needs from `BotCordClient`. Matches the subset used at runtime. */
 export interface BotCordChannelClient {
@@ -309,7 +313,7 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
     emit: (env: GatewayInboundEnvelope) => Promise<void>,
     log: GatewayLogger,
     trigger: InboxDrainTrigger,
-  ): Promise<void> {
+  ): Promise<{ hasMore: boolean }> {
     const startedAt = Date.now();
     const resp = await client.pollInbox({ limit: INBOX_POLL_LIMIT, ack: false });
     const msgs = resp.messages ?? [];
@@ -334,7 +338,10 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
     const eligible: InboxMessage[] = [];
     if (msgs.length === 0) {
       logDrain();
-      return;
+      // Defensive: if Hub returns 0 messages, refuse to honor has_more=true.
+      // A stuck cursor on the Hub side could otherwise produce an unbounded
+      // poll loop here (count=0 with has_more=true on every iteration).
+      return { hasMore: false };
     }
 
     // First pass: ack duplicates/skipped messages so Hub stops requeueing,
@@ -370,7 +377,7 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
 
     if (eligible.length === 0) {
       logDrain();
-      return;
+      return { hasMore: Boolean(resp.has_more) };
     }
 
     // Group by `(room_id, topic)`. Insertion order is the poll order, so
@@ -384,6 +391,13 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
       else groups.set(key, [msg]);
     }
 
+    // Emit groups in parallel: each `(room_id, topic)` group is an independent
+    // conversation thread, and the dispatcher already keys its per-turn queue
+    // by `(channel, accountId, roomId, threadId)` (see `buildQueueKey` in
+    // dispatcher.ts). Awaiting groups serially here forced a slow turn in
+    // room A to block room B's turn from starting; running them concurrently
+    // lets the dispatcher's per-room queues actually run in parallel.
+    const emitTasks: Promise<void>[] = [];
     for (const group of groups.values()) {
       const normalized = normalizeInboxBatch(group, {
         channelId: options.id,
@@ -409,17 +423,23 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
           },
         },
       };
-      try {
-        await emit(envelope);
-        emittedGroups += 1;
-      } catch (err) {
-        log.error("botcord emit threw", {
-          hubMsgIds: hubIds,
-          err: String(err),
-        });
-      }
+      emitTasks.push(
+        emit(envelope).then(
+          () => {
+            emittedGroups += 1;
+          },
+          (err) => {
+            log.error("botcord emit threw", {
+              hubMsgIds: hubIds,
+              err: String(err),
+            });
+          },
+        ),
+      );
     }
+    await Promise.all(emitTasks);
     logDrain();
+    return { hasMore: Boolean(resp.has_more) };
   }
 
   function startWsLoop(
@@ -470,11 +490,16 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
       processing = true;
       try {
         let currentTrigger = trigger;
+        let hasMore = false;
         do {
           pendingUpdate = false;
-          await drainInbox(client, emit, log, currentTrigger);
-          currentTrigger = "coalesced_inbox_update";
-        } while (pendingUpdate && running);
+          const result = await drainInbox(client, emit, log, currentTrigger);
+          hasMore = result.hasMore;
+          // Prefer `has_more_continue` when this iteration is chained because
+          // the previous poll capped at INBOX_POLL_LIMIT — distinguishes a
+          // backlog drain from a coalesced ws_inbox_update drain in logs.
+          currentTrigger = hasMore ? "has_more_continue" : "coalesced_inbox_update";
+        } while ((pendingUpdate || hasMore) && running);
       } catch (err) {
         log.error("botcord inbox drain failed", { err: String(err) });
       } finally {


### PR DESCRIPTION
## Summary

Two related throughput improvements to the BotCord channel adapter (`packages/daemon/src/gateway/channels/botcord.ts`), both motivated by real backlog/latency observed in daemon logs from preview.

### 1. Parallel emit per `(room, topic)` group

Previously `drainInbox` awaited each group's `emit()` serially:

```ts
for (const group of groups.values()) {
  await emit(envelope);  // a slow codex turn in room A blocks room B from starting
}
```

But the dispatcher already keys its per-turn queue by `(channel, accountId, roomId, threadId)` (see `buildQueueKey` in `dispatcher.ts:1362-1365`), so groups are independent. Awaiting them serially was just an artificial bottleneck. Switch to `Promise.all`:

```ts
const emitTasks: Promise<void>[] = [];
for (const group of groups.values()) {
  emitTasks.push(emit(envelope).then(...));
}
await Promise.all(emitTasks);
```

Drain duration becomes `max(emit times)` instead of `sum`. Same-room messages are still batched into a single envelope (preserves ordering) and the dispatcher's `runSerial` still serializes within a queue.

### 2. Honor `pollInbox` `has_more` to chain drains

`pollInbox` caps at `INBOX_POLL_LIMIT = 50`. The previous implementation **logged** `has_more` but never acted on it, so a 100-message backlog had to wait for the next ws `inbox_update` notification before the second 50 could be drained:

```
drain 50 → wait for ws notification → drain 50 → ...
```

Fix: `drainInbox` now returns `{ hasMore }`, and `fireInbox`'s do-while extends to `(pendingUpdate || hasMore) && running`. New trigger label `has_more_continue` distinguishes backlog continuation from coalesced ws notifications in the drain log.

### Safety

When `pollInbox` returns 0 messages, the empty-msgs branch refuses to honor `has_more=true` to avoid an unbounded poll loop if the Hub cursor ever sticks (count=0 with has_more=true is a nonsensical Hub-side state, but defensive coding catches it).

## Test plan

- [x] `vitest run src/gateway/__tests__/botcord-channel.test.ts` — 15/15 pass
- [x] `tsc --noEmit` — no new errors in `botcord.ts`
- [ ] Manual: deploy to preview daemon, observe drain log behavior under burst traffic — drain `durationMs` should approach `max(emit time)` instead of `sum`, and backlog drains should chain via `has_more_continue` trigger without waiting for ws notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)