### PR TITLE
feat: @all mention + hide composer for denied members

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -2336,8 +2336,8 @@ async def human_room_send(
     _record_slow_mode_send(room_id, sender_id)
 
     # Normalize mentions. Owner-chat rooms (rm_oc_) ignore mentions entirely.
-    # Human sends may only mention specific agent_ids — "@all" is not allowed
-    # here; any non-"ag_" string is dropped. Cap at 20 to avoid abuse.
+    # Human sends may mention specific agent_ids or the special "@all" token;
+    # any other non-"ag_" string is dropped. Cap at 20 to avoid abuse.
     raw_mentions = body.mentions or []
     if room_id.startswith("rm_oc_"):
         raw_mentions = []
@@ -2346,7 +2346,13 @@ async def human_room_send(
     normalized_mentions: list[str] = []
     seen_mentions: set[str] = set()
     for m in raw_mentions:
-        if not isinstance(m, str) or not m.startswith("ag_") or m in seen_mentions:
+        if not isinstance(m, str) or m in seen_mentions:
+            continue
+        if m == "@all":
+            normalized_mentions = ["@all"]
+            seen_mentions.add(m)
+            break
+        if not m.startswith("ag_"):
             continue
         seen_mentions.add(m)
         normalized_mentions.append(m)
@@ -2359,7 +2365,9 @@ async def human_room_send(
 
     # Drop mentions that aren't actually room members
     member_ids = {m.agent_id for m in all_members}
-    normalized_mentions = [m for m in normalized_mentions if m in member_ids]
+    mention_all = "@all" in normalized_mentions
+    if not mention_all:
+        normalized_mentions = [m for m in normalized_mentions if m in member_ids]
     mentioned_set: set[str] = set(normalized_mentions)
 
     # Block check anchored on sender_id
@@ -2438,7 +2446,7 @@ async def human_room_send(
             state=MessageState.queued,
             envelope_json=envelope_json,
             ttl_sec=3600,
-            mentioned=receiver_id in mentioned_set,
+            mentioned=mention_all or receiver_id in mentioned_set,
             source_type="dashboard_human_room",
             source_user_id=source_user_id_str,
             source_session_kind="room_human",

--- a/backend/tests/test_dashboard_rooms_human_send.py
+++ b/backend/tests/test_dashboard_rooms_human_send.py
@@ -564,7 +564,7 @@ async def test_mentions_filter_non_member_agent_ids(
 
 
 @pytest.mark.asyncio
-async def test_mentions_drop_at_all_and_non_ag_prefix(
+async def test_mentions_allow_at_all_and_drop_other_non_ag_prefix(
     client: AsyncClient, seed: dict, db_session: AsyncSession
 ):
     r = await client.post(
@@ -577,8 +577,10 @@ async def test_mentions_drop_at_all_and_non_ag_prefix(
     rows = (await db_session.execute(
         select(MessageRecord).where(MessageRecord.room_id == "rm_humanroom")
     )).scalars().all()
+    assert rows
+    assert all(row.mentioned is True for row in rows)
     env = json.loads(rows[0].envelope_json)
-    assert env["mentions"] == ["ag_user3___"]
+    assert env["mentions"] == ["@all"]
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/dashboard/MessageComposer.tsx
+++ b/frontend/src/components/dashboard/MessageComposer.tsx
@@ -171,7 +171,6 @@ export default function MessageComposer({
   }, [mentionMatch, text]);
 
   const activeMentions = useMemo(() => {
-    if (!pickedMentions.length) return [] as string[];
     const seen = new Set<string>();
     const out: string[] = [];
     for (const m of pickedMentions) {
@@ -180,8 +179,12 @@ export default function MessageComposer({
       seen.add(m.agent_id);
       out.push(m.agent_id);
     }
+    const allMention = mentionCandidates?.find((m) => m.agent_id === "@all");
+    if (allMention && !seen.has(allMention.agent_id) && textHasMention(text, allMention.display_name)) {
+      out.push(allMention.agent_id);
+    }
     return out;
-  }, [pickedMentions, text]);
+  }, [pickedMentions, text, mentionCandidates]);
 
   const handleSend = useCallback(async () => {
     const trimmed = text.trim();

--- a/frontend/src/components/dashboard/RoomHumanComposer.tsx
+++ b/frontend/src/components/dashboard/RoomHumanComposer.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { api } from "@/lib/api";
-import { useLanguage } from "@/lib/i18n";
+import { useLanguage, chatPane } from "@/lib/i18n";
 import type { DashboardMessage, PublicRoomMember } from "@/lib/types";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
@@ -30,6 +30,8 @@ export default function RoomHumanComposer({ roomId }: RoomHumanComposerProps) {
 
   const displayName = user?.display_name || "You";
   const isOwnerChat = roomId.startsWith("rm_oc_");
+  const isDirectMessage = roomId.startsWith("rm_dm_");
+  const allowAllMention = !isOwnerChat && !isDirectMessage;
   const activeAgent = activeAgentId
     ? ownedAgents.find((a) => a.agent_id === activeAgentId) ?? null
     : null;
@@ -57,13 +59,21 @@ export default function RoomHumanComposer({ roomId }: RoomHumanComposerProps) {
     return () => { cancelled = true; };
   }, [roomId, isOwnerChat]);
 
+  const selfId = viewMode === "agent" ? activeAgentId : human?.human_id;
+
   const mentionCandidates = useMemo<MentionCandidate[]>(() => {
-    if (isOwnerChat) return [];
-    const selfId = viewMode === "agent" ? activeAgentId : human?.human_id;
-    return members
-      .filter((m) => m.agent_id !== selfId)
+    if (!allowAllMention) return [];
+    const roomCandidates = members
+      .filter((m) => m.agent_id !== selfId && m.agent_id.startsWith("ag_"))
       .map((m) => ({ agent_id: m.agent_id, display_name: m.display_name }));
-  }, [members, activeAgentId, human?.human_id, viewMode, isOwnerChat]);
+    return [{ agent_id: "@all", display_name: "all" }, ...roomCandidates];
+  }, [members, selfId, allowAllMention]);
+
+  const sendDenied = useMemo(() => {
+    if (isOwnerChat || !selfId) return false;
+    const self = members.find((m) => m.agent_id === selfId);
+    return self?.can_send === false;
+  }, [members, selfId, isOwnerChat]);
 
   const handleSend = useCallback(async (text: string, _files: File[], mentions?: string[]) => {
     if (!text) return;
@@ -103,6 +113,14 @@ export default function RoomHumanComposer({ roomId }: RoomHumanComposerProps) {
       setError(err instanceof Error ? err.message : "Failed to send");
     }
   }, [senderId, displayName, user?.id, roomId, insertMessage, loadRoomMessages]);
+
+  if (sendDenied) {
+    return (
+      <p className="text-center text-xs text-text-secondary/50">
+        {chatPane[locale].memberSendDenied}
+      </p>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-1">

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -261,6 +261,7 @@ export const chatPane: TranslationMap<{
   noPreviewMessages: string
   inviteFriend: string
   humanSendDisabled: string
+  memberSendDenied: string
   contactKindHuman: string
   contactKindAgent: string
   unnamedHuman: string
@@ -309,6 +310,7 @@ export const chatPane: TranslationMap<{
     noPreviewMessages: 'No preview messages yet',
     inviteFriend: 'Invite friend',
     humanSendDisabled: 'Human messages are disabled for this room',
+    memberSendDenied: "You don't have permission to send messages in this room",
     contactKindHuman: 'Human',
     contactKindAgent: 'Agent',
     unnamedHuman: 'Unnamed Human',
@@ -357,6 +359,7 @@ export const chatPane: TranslationMap<{
     noPreviewMessages: '暂无可预览消息',
     inviteFriend: '邀请好友',
     humanSendDisabled: '该房间已禁用真人发言',
+    memberSendDenied: '你在该群没有发言权限',
     contactKindHuman: '真人',
     contactKindAgent: 'Agent',
     unnamedHuman: '未命名真人',


### PR DESCRIPTION
## Summary

- **Human room `@all` mention**: humans can now post `@all` to broadcast-mention every room member. Backend normalizes mentions so any `@all` token wins (clears other mentions, breaks early), and every receiver row is flagged `mentioned=true`. Composer auto-detects literal `@all` in text via boundary check and emits the `@all` token; suppressed in owner-chat (`rm_oc_`) and DM rooms (`rm_dm_`).
- **Hide composer for denied members**: when the current user (active agent in agent mode, human in human mode) has `can_send === false` on their `PublicRoomMember` row, `RoomHumanComposer` swaps the textarea for a read-only "no permission" notice. Pairs with the existing room-level `allow_human_send` gate in `ChatPane`.

## Test plan

- [x] `backend/tests/test_dashboard_rooms_human_send.py` — 25/25 passed (including renamed `test_mentions_allow_at_all_and_drop_other_non_ag_prefix` which asserts `env["mentions"] == ["@all"]` and every receiver row has `mentioned=true`).
- [x] Frontend `tsc --noEmit` — no new errors in changed files.
- [ ] Manual: send `@all` in a human room, verify all members see notification badge.
- [ ] Manual: as room admin, set another member's `can_send=false` via member menu, verify they see the "no permission" notice instead of the input.
- [ ] Manual: open a DM (`rm_dm_*`), verify `@all` does not appear in the mention picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)