### PR TITLE
fix(daemon): hot-update per-agent caches + seed codex skills on provision

### DIFF
--- a/packages/daemon/src/__tests__/agent-workspace.test.ts
+++ b/packages/daemon/src/__tests__/agent-workspace.test.ts
@@ -12,11 +12,13 @@ import os from "node:os";
 import path from "node:path";
 
 import {
+  agentCodexHomeDir,
   agentHermesHomeDir,
   agentHomeDir,
   agentStateDir,
   agentWorkspaceDir,
   applyAgentIdentity,
+  ensureAgentCodexHome,
   ensureAgentHermesWorkspace,
   ensureAgentWorkspace,
 } from "../agent-workspace.js";
@@ -99,6 +101,30 @@ describe("ensureAgentWorkspace", () => {
     writeFileSync(skillFile, "stale content from a prior daemon version\n");
 
     ensureAgentWorkspace("ag_skill_upgrade", {});
+
+    const reseeded = readFileSync(skillFile, "utf8");
+    expect(reseeded).not.toBe("stale content from a prior daemon version\n");
+    expect(reseeded).toContain("name: botcord");
+  });
+
+  it("seeds bundled skills under codex-home/skills/ so per-agent CODEX_HOME sees them", () => {
+    ensureAgentWorkspace("ag_codex_skills", {});
+    const skillsDir = path.join(agentCodexHomeDir("ag_codex_skills"), "skills");
+    expect(existsSync(path.join(skillsDir, "botcord", "SKILL.md"))).toBe(true);
+    expect(existsSync(path.join(skillsDir, "botcord-user-guide", "SKILL.md"))).toBe(true);
+  });
+
+  it("re-seeds codex skills on subsequent ensureAgentCodexHome calls", () => {
+    ensureAgentCodexHome("ag_codex_reseed");
+    const skillFile = path.join(
+      agentCodexHomeDir("ag_codex_reseed"),
+      "skills",
+      "botcord",
+      "SKILL.md",
+    );
+    writeFileSync(skillFile, "stale content from a prior daemon version\n");
+
+    ensureAgentCodexHome("ag_codex_reseed");
 
     const reseeded = readFileSync(skillFile, "utf8");
     expect(reseeded).not.toBe("stale content from a prior daemon version\n");

--- a/packages/daemon/src/__tests__/provision.test.ts
+++ b/packages/daemon/src/__tests__/provision.test.ts
@@ -778,6 +778,86 @@ describe("provision_agent seeds workspace + hot-adds managed route", () => {
       expect(gw.listManagedRoutes()).toHaveLength(0);
     });
   });
+
+  // Regression: the daemon's per-agent caches (credentialPathByAgentId,
+  // hubUrlByAgentId, displayNameByAgent) used to be seeded only at boot.
+  // Hot-provisioning then left those caches missing the new agent until the
+  // next restart, and `room-context-fetcher` logged
+  // `daemon.room-context.no-credentials` on every turn. This contract test
+  // pins the install path: a successful provision MUST fire the hook with
+  // the credential file + hub URL + display name.
+  it("fires onAgentInstalled after a successful install so daemon caches stay warm", async () => {
+    await withSandboxHome(async ({ tmp, path: nodePath }) => {
+      const gw = makeFakeGateway();
+      const installed: Array<Record<string, unknown>> = [];
+      const provisioner = createProvisioner({
+        gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+        onAgentInstalled: (info) => {
+          installed.push({ ...info });
+        },
+      });
+      const privateKey = Buffer.alloc(32, 41).toString("base64");
+      const ack = await provisioner({
+        id: "req_hook",
+        type: CONTROL_FRAME_TYPES.PROVISION_AGENT,
+        params: {
+          // `name` only flows into `displayName` on the slow (daemon-register)
+          // path. Hub's fast path carries it via `credentials.displayName`.
+          runtime: "claude-code",
+          credentials: {
+            agentId: "ag_hook",
+            keyId: "k_hook",
+            privateKey,
+            hubUrl: "https://hub.example",
+            displayName: "zhejian's cc",
+          },
+        },
+      });
+      expect(ack.ok).toBe(true);
+      expect(installed).toHaveLength(1);
+      const credFile = nodePath.join(tmp, ".botcord", "credentials", "ag_hook.json");
+      expect(installed[0]).toMatchObject({
+        agentId: "ag_hook",
+        credentialsFile: credFile,
+        hubUrl: "https://hub.example",
+        displayName: "zhejian's cc",
+        runtime: "claude-code",
+      });
+    });
+  });
+
+  // The hook is best-effort wiring, not part of the install transaction.
+  // A throwing hook must not roll back the install (the agent is already
+  // on disk and in the gateway), and must not flip the control-frame ack
+  // to failure — the operator only sees a loud error log.
+  it("does not roll back the install when onAgentInstalled throws", async () => {
+    await withSandboxHome(async ({ tmp, fs, path: nodePath }) => {
+      const gw = makeFakeGateway();
+      const provisioner = createProvisioner({
+        gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+        onAgentInstalled: () => {
+          throw new Error("hook boom");
+        },
+      });
+      const privateKey = Buffer.alloc(32, 43).toString("base64");
+      const ack = await provisioner({
+        id: "req_hook_throws",
+        type: CONTROL_FRAME_TYPES.PROVISION_AGENT,
+        params: {
+          credentials: {
+            agentId: "ag_hookboom",
+            keyId: "k_hb",
+            privateKey,
+            hubUrl: "https://hub.example",
+          },
+        },
+      });
+      expect(ack.ok).toBe(true);
+      const credFile = nodePath.join(tmp, ".botcord", "credentials", "ag_hookboom.json");
+      expect(fs.existsSync(credFile)).toBe(true);
+      expect(gw.listManagedRoutes()).toHaveLength(1);
+    });
+  });
 });
 
 describe("adoptDiscoveredOpenclawAgents", () => {

--- a/packages/daemon/src/agent-workspace.ts
+++ b/packages/daemon/src/agent-workspace.ts
@@ -333,14 +333,18 @@ function isSymlink(p: string): boolean {
 }
 
 /**
- * Idempotently create the per-agent CODEX_HOME directory and link the
- * user's codex `auth.json` into it. Does NOT write an initial `AGENTS.md`
- * — the codex adapter writes it fresh per turn from `systemContext`.
+ * Idempotently create the per-agent CODEX_HOME directory, link the
+ * user's codex `auth.json` into it, and seed the bundled BotCord skills
+ * under `<dir>/skills/` so the codex runtime (which sees this as
+ * `CODEX_HOME`, not the user's `~/.codex`) can discover them. Does NOT
+ * write an initial `AGENTS.md` — the codex adapter writes it fresh per
+ * turn from `systemContext`.
  */
 export function ensureAgentCodexHome(agentId: string): string {
   const dir = agentCodexHomeDir(agentId);
   mkdirTolerant(dir);
   linkCodexAuth(dir);
+  seedCodexSkills(dir);
   return dir;
 }
 
@@ -369,12 +373,15 @@ export function ensureAgentHermesWorkspace(agentId: string): {
 }
 
 /**
- * Bundled Claude Code skills shipped inside `@botcord/cli/skills/`. Seeded
- * into every agent workspace so the spawned `claude` runtime (which loads
- * `.claude/` via `--setting-sources project`) can discover the BotCord CLI
- * skill without any manual setup.
+ * Bundled BotCord skills shipped inside `@botcord/cli/skills/`. Skill
+ * content (SKILL.md + helper scripts) is runtime-agnostic; only the
+ * discovery path differs:
+ *   - Claude Code: `<workspace>/.claude/skills/<name>/`
+ *   - Codex:       `<codex-home>/skills/<name>/`
+ * Seeded fresh per `ensureAgent*` call (force-overwrite) so daemon
+ * upgrades propagate.
  */
-const BUNDLED_CC_SKILLS = ["botcord", "botcord-user-guide"] as const;
+const BUNDLED_SKILLS = ["botcord", "botcord-user-guide"] as const;
 
 function resolveBundledCliSkillsRoot(): string | null {
   try {
@@ -387,27 +394,45 @@ function resolveBundledCliSkillsRoot(): string | null {
 }
 
 /**
- * Copy daemon-owned Claude Code skills into the workspace. Re-copied on every
- * `ensureAgentWorkspace` call (force-overwrite) so daemon upgrades propagate;
- * users wanting custom skills should pick a different directory name under
- * `.claude/skills/` — those are not touched here.
+ * Copy bundled skill directories into `destSkillsDir`, force-overwriting
+ * any prior copy of each named skill. Other entries in `destSkillsDir`
+ * are left alone so user-authored skills survive. Best-effort: silently
+ * skips on copy failure or when the bundled CLI isn't resolvable.
  */
-function seedClaudeCodeSkills(workspace: string): void {
+function copyBundledSkills(destSkillsDir: string): void {
   const sourceRoot = resolveBundledCliSkillsRoot();
   if (!sourceRoot) return;
-  const skillsDir = path.join(workspace, ".claude", "skills");
-  mkdirTolerant(path.join(workspace, ".claude"));
-  mkdirTolerant(skillsDir);
-  for (const name of BUNDLED_CC_SKILLS) {
+  mkdirTolerant(destSkillsDir);
+  for (const name of BUNDLED_SKILLS) {
     const src = path.join(sourceRoot, name);
     if (!existsSync(src)) continue;
-    const dst = path.join(skillsDir, name);
+    const dst = path.join(destSkillsDir, name);
     try {
       cpSync(src, dst, { recursive: true, force: true, dereference: true });
     } catch {
       /* best-effort */
     }
   }
+}
+
+/**
+ * Seed Claude Code's `.claude/skills/` discovery dir under the agent
+ * workspace. The `claude` adapter spawns with `--setting-sources project`
+ * so this dir is auto-discovered.
+ */
+function seedClaudeCodeSkills(workspace: string): void {
+  mkdirTolerant(path.join(workspace, ".claude"));
+  copyBundledSkills(path.join(workspace, ".claude", "skills"));
+}
+
+/**
+ * Seed Codex's `<CODEX_HOME>/skills/` discovery dir. The codex adapter
+ * sets `CODEX_HOME=<agent>/codex-home/`, isolating per-agent skills from
+ * the user's global `~/.codex/skills/` — so skills must be seeded here
+ * for Codex agents to discover them.
+ */
+function seedCodexSkills(codexHome: string): void {
+  copyBundledSkills(path.join(codexHome, "skills"));
 }
 
 /**

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -27,6 +27,7 @@ import {
   adoptDiscoveredOpenclawAgents,
   collectRuntimeSnapshot,
   createProvisioner,
+  type OnAgentInstalledHook,
 } from "./provision.js";
 import { openclawAutoProvisionEnabled } from "./openclaw-discovery.js";
 import { SnapshotWriter } from "./snapshot-writer.js";
@@ -382,6 +383,34 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
     });
   };
 
+  // Boot-seeded per-agent caches (`credentialPathByAgentId`,
+  // `hubUrlByAgentId`, `displayNameByAgent`, `scBuilders`) are scoped to
+  // the agents present at startup. Without this hook, agents added later
+  // via `provision_agent` or openclaw-adoption stay missing from those
+  // caches until the next daemon restart — `room-context-fetcher` then
+  // logs `daemon.room-context.no-credentials` on every turn for the new
+  // agent and the system context loses its `[BotCord Room]` block (member
+  // names, rule, role).
+  const onAgentInstalled: OnAgentInstalledHook = (info) => {
+    // Re-provision (e.g. credential rotation) overwrites in place so the
+    // next room-context fetch re-loads the BotCordClient against the new
+    // credential file.
+    credentialPathByAgentId.set(info.agentId, info.credentialsFile);
+    if (info.hubUrl) hubUrlByAgentId.set(info.agentId, info.hubUrl);
+    if (info.displayName) displayNameByAgent.set(info.agentId, info.displayName);
+    if (!scBuilders.has(info.agentId)) {
+      scBuilders.set(
+        info.agentId,
+        createDaemonSystemContextBuilder({
+          agentId: info.agentId,
+          activityTracker,
+          roomContextBuilder,
+          loopRiskBuilder,
+        }),
+      );
+    }
+  };
+
   const gateway = new Gateway({
     config: gwConfig,
     sessionStorePath: opts.sessionStorePath ?? SESSIONS_PATH,
@@ -437,6 +466,7 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
       const adopted = await adoptDiscoveredOpenclawAgents({
         gateway,
         cfg: opts.config,
+        onAgentInstalled,
       });
       if (
         adopted.adopted.length > 0 ||
@@ -465,7 +495,7 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
       userId: userAuth.current.userId,
       hubUrl: userAuth.current.hubUrl,
     });
-    const provisioner = createProvisioner({ gateway, policyResolver });
+    const provisioner = createProvisioner({ gateway, policyResolver, onAgentInstalled });
     controlChannel = new ControlChannel({
       auth: userAuth,
       handle: provisioner,

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -57,6 +57,30 @@ import { detectRuntimes, getAdapterModule } from "./adapters/runtimes.js";
 import { log as daemonLog } from "./log.js";
 import { discoverAgentCredentials } from "./agent-discovery.js";
 
+/**
+ * Information passed to {@link OnAgentInstalledHook} after a successful
+ * provision. Mirrors the credential fields the daemon's per-agent caches
+ * (`credentialPathByAgentId`, `hubUrlByAgentId`, `displayNameByAgent`) read at
+ * boot — fired again here so hot-provisioned agents land in those caches
+ * without waiting for a daemon restart.
+ */
+export interface InstalledAgentInfo {
+  agentId: string;
+  credentialsFile: string;
+  hubUrl: string;
+  displayName?: string;
+  runtime?: string;
+}
+
+/**
+ * Hook fired after `installLocalAgent` / `installExistingOpenclawBinding`
+ * finish successfully. Synchronous on purpose — the caller updates a few
+ * in-memory maps and we don't want a slow hook to delay the control-frame
+ * ack. Throwing from the hook is treated as a programmer error and
+ * surfaced; rollback of the install is the caller's responsibility.
+ */
+export type OnAgentInstalledHook = (info: InstalledAgentInfo) => void;
+
 /** Options accepted by {@link createProvisioner}. */
 export interface ProvisionerOptions {
   /** Live gateway handle used to hot-plug channels. */
@@ -74,6 +98,15 @@ export interface ProvisionerOptions {
    * extra round-trip.
    */
   policyResolver?: PolicyResolverLike;
+  /**
+   * Optional hook called after each successful agent install (whether via
+   * `provision_agent` or `installExistingOpenclawBinding`). The daemon
+   * wires this to write the new agent into its boot-seeded caches —
+   * without it, `room-context-fetcher` keeps emitting
+   * `daemon.room-context.no-credentials` for hot-provisioned agents until
+   * the next restart.
+   */
+  onAgentInstalled?: OnAgentInstalledHook;
 }
 
 /** The value a frame handler returns (minus the `id` which the channel fills in). */
@@ -90,6 +123,7 @@ export function createProvisioner(opts: ProvisionerOptions): (
   const gateway = opts.gateway;
   const register = opts.register ?? BotCordClient.register;
   const policyResolver = opts.policyResolver;
+  const onAgentInstalled = opts.onAgentInstalled;
 
   return async (frame: ControlFrame): Promise<AckBody> => {
     daemonLog.debug("provision.dispatch", { type: frame.type, id: frame.id });
@@ -137,7 +171,7 @@ export function createProvisioner(opts: ProvisionerOptions): (
           runtime: pickRuntime(params) ?? null,
           name: params.name ?? null,
         });
-        const agent = await provisionAgent(params, { gateway, register });
+        const agent = await provisionAgent(params, { gateway, register, onAgentInstalled });
         // Seed the policy resolver from the optional `defaultAttention` /
         // `attentionKeywords` fields (PR3, control-frame.ts). Hub builds that
         // don't yet emit these stay backwards-compatible — the resolver just
@@ -266,6 +300,7 @@ interface ProvisionedAgent {
 interface ProvisionCtx {
   gateway: Gateway;
   register: typeof BotCordClient.register;
+  onAgentInstalled?: OnAgentInstalledHook;
 }
 
 const openclawProvisionLocks = new Map<string, Promise<unknown>>();
@@ -428,6 +463,32 @@ async function installLocalAgent(
     throw err;
   }
 
+  // Update the daemon's boot-seeded per-agent caches in place. Without this
+  // a hot-provisioned agent keeps missing `credentialPathByAgentId` /
+  // `hubUrlByAgentId` / `displayNameByAgent` until the next daemon restart,
+  // and `room-context-fetcher` logs `daemon.room-context.no-credentials` on
+  // every turn for it (so the system-context loses the room block — member
+  // names, rule, role).
+  if (ctx.onAgentInstalled) {
+    try {
+      ctx.onAgentInstalled({
+        agentId: credentials.agentId,
+        credentialsFile,
+        hubUrl: credentials.hubUrl,
+        ...(credentials.displayName ? { displayName: credentials.displayName } : {}),
+        ...(credentials.runtime ? { runtime: credentials.runtime } : {}),
+      });
+    } catch (err) {
+      // Hook misbehavior must not fail the install — the agent is already
+      // on disk + in the gateway. Surface it loudly so the daemon owner
+      // notices the cache is out of sync.
+      daemonLog.error("provision.onAgentInstalled threw — caches may be stale", {
+        agentId: credentials.agentId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
   daemonLog.info("agent provisioned", {
     agentId: credentials.agentId,
     credentialsFile,
@@ -490,6 +551,26 @@ async function installExistingOpenclawBinding(
     });
   }
   upsertManagedRouteForCredentials(credentials, cfg, ctx.gateway);
+  // Same cache-warmup as `installLocalAgent` — re-binding an existing
+  // openclaw agent at runtime should also land it in the daemon's
+  // per-agent maps, otherwise room-context lookups stay broken until
+  // restart.
+  if (ctx.onAgentInstalled) {
+    try {
+      ctx.onAgentInstalled({
+        agentId: credentials.agentId,
+        credentialsFile,
+        hubUrl: credentials.hubUrl,
+        ...(credentials.displayName ? { displayName: credentials.displayName } : {}),
+        ...(credentials.runtime ? { runtime: credentials.runtime } : {}),
+      });
+    } catch (err) {
+      daemonLog.error("provision.onAgentInstalled threw — caches may be stale", {
+        agentId: credentials.agentId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
   return {
     agentId: credentials.agentId,
     hubUrl: credentials.hubUrl,
@@ -658,9 +739,11 @@ export async function adoptDiscoveredOpenclawAgents(ctx: {
   cfg?: DaemonConfig;
   timeoutMs?: number;
   probe?: WsEndpointProbeFn;
+  onAgentInstalled?: OnAgentInstalledHook;
 }): Promise<AdoptDiscoveredOpenclawAgentsResult> {
   const register = ctx.register ?? BotCordClient.register;
   const cfg = ctx.cfg ?? loadConfig();
+  const onAgentInstalled = ctx.onAgentInstalled;
   const result: AdoptDiscoveredOpenclawAgentsResult = {
     adopted: [],
     skipped: [],
@@ -733,12 +816,14 @@ export async function adoptDiscoveredOpenclawAgents(ctx: {
           const credentials = await materializeCredentials(params, freshCfg, {
             gateway: ctx.gateway,
             register,
+            ...(onAgentInstalled ? { onAgentInstalled } : {}),
           }, undefined);
           const installed = await installLocalAgent(credentials, {
             gateway: ctx.gateway,
             register,
             cfg: freshCfg,
             source: "adopted-openclaw",
+            ...(onAgentInstalled ? { onAgentInstalled } : {}),
           });
           result.adopted.push(installed.agentId);
         } catch (err) {


### PR DESCRIPTION
## Why

Freshly-provisioned agents (via `provision_agent` or openclaw adoption) showed up in the gateway and could receive inbox events, but stayed silent in group rooms. Two distinct boot-time gaps were responsible — both invisible at info-level logging.

### Gap 1 — boot-only caches

`daemon.ts` builds four per-agent caches from `boot.agents` at startup:

| Cache | Used by | Symptom when missing |
|---|---|---|
| `credentialPathByAgentId` | `room-context-fetcher` | `daemon.room-context.no-credentials` warn → `[BotCord Room]` block dropped from system context |
| `hubUrlByAgentId` | `BOTCORD_HUB` env for runtime CLI | wrong-hub `botcord` CLI calls in multi-hub setups |
| `displayNameByAgent` | mention-scan text fallback | `@<displayName>` mentions miss when policy ≠ `always` |
| `scBuilders` | per-agent system-context builder | falls back to first-agent's builder → wrong activity scope |

`provision.ts` did not touch any of these, so each hot-provisioned agent kept hitting the missing-credential branch on every turn until the next daemon restart.

### Gap 2 — codex skill discovery

Bundled `botcord` + `botcord-user-guide` skills were only copied to `<workspace>/.claude/skills/`. Codex spawns with `CODEX_HOME=<agent>/codex-home/` (isolated from the user's `~/.codex`), so it never saw the BotCord skill — the runtime didn't know `botcord_send` existed and dispatcher's non-owner-chat reply gate (`dispatcher.ts: "discarding result.text"`) silently dropped its plain text.

## What

**`packages/daemon/src/provision.ts`**
- Add `InstalledAgentInfo` + `OnAgentInstalledHook` (exported).
- Plumb optional hook through `ProvisionerOptions`, `ProvisionCtx`, and `adoptDiscoveredOpenclawAgents`.
- `installLocalAgent` and `installExistingOpenclawBinding` fire the hook after the install transaction succeeds. Hook errors are logged but don't roll back — the agent is already on disk + in the gateway.

**`packages/daemon/src/daemon.ts`**
- Define `onAgentInstalled` once where the four caches + builder dependencies are in scope.
- Pass it to both `createProvisioner({...})` and `adoptDiscoveredOpenclawAgents({...})`.
- `scBuilders` uses `!has` guard — re-provision overwrites credentials but keeps the existing builder identity.

**`packages/daemon/src/agent-workspace.ts`**
- Refactor: extract `copyBundledSkills(destSkillsDir)` from `seedClaudeCodeSkills`.
- Add `seedCodexSkills(codexHome)` and call it from `ensureAgentCodexHome`.
- Rename `BUNDLED_CC_SKILLS` → `BUNDLED_SKILLS` since both runtimes now consume them.

## Test plan

- [x] `vitest run` — **587/587** (was 583 + 2 provision-hook tests + 2 codex-skill tests)
- [x] `tsc -p tsconfig.build.json` — clean
- [x] New cases:
  - `fires onAgentInstalled after a successful install so daemon caches stay warm`
  - `does not roll back the install when onAgentInstalled throws`
  - `seeds bundled skills under codex-home/skills/`
  - `re-seeds codex skills on subsequent ensureAgentCodexHome calls`
- [ ] Manual: provision a fresh codex agent on a running daemon → no `daemon.room-context.no-credentials` warn on first turn → agent posts a reply in group via `botcord send`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)