### PR TITLE
feat(daemon): seed bundled botcord skills into per-agent HERMES_HOME

### DIFF
--- a/packages/daemon/src/__tests__/agent-workspace.test.ts
+++ b/packages/daemon/src/__tests__/agent-workspace.test.ts
@@ -131,6 +131,25 @@ describe("ensureAgentWorkspace", () => {
     expect(reseeded).toContain("name: botcord");
   });
 
+  it("seeds bundled skills under hermes-home/skills/ so per-agent HERMES_HOME sees them", () => {
+    const { hermesHome } = ensureAgentHermesWorkspace("ag_hermes_skills");
+    const skillsDir = path.join(hermesHome, "skills");
+    expect(existsSync(path.join(skillsDir, "botcord", "SKILL.md"))).toBe(true);
+    expect(existsSync(path.join(skillsDir, "botcord-user-guide", "SKILL.md"))).toBe(true);
+  });
+
+  it("re-seeds hermes skills on subsequent ensureAgentHermesWorkspace calls", () => {
+    const { hermesHome } = ensureAgentHermesWorkspace("ag_hermes_reseed");
+    const skillFile = path.join(hermesHome, "skills", "botcord", "SKILL.md");
+    writeFileSync(skillFile, "stale content from a prior daemon version\n");
+
+    ensureAgentHermesWorkspace("ag_hermes_reseed");
+
+    const reseeded = readFileSync(skillFile, "utf8");
+    expect(reseeded).not.toBe("stale content from a prior daemon version\n");
+    expect(reseeded).toContain("name: botcord");
+  });
+
   it("does not overwrite a user-modified memory.md on a second call", () => {
     ensureAgentWorkspace("ag_keep", {});
     const memoryPath = path.join(agentWorkspaceDir("ag_keep"), "memory.md");

--- a/packages/daemon/src/agent-workspace.ts
+++ b/packages/daemon/src/agent-workspace.ts
@@ -352,7 +352,10 @@ export function ensureAgentCodexHome(agentId: string): string {
  * Idempotently create the per-agent HERMES_HOME and HERMES workspace
  * directories. Writes a stub `.env` inside HERMES_HOME so hermes-acp's
  * `_load_env` does not log "No .env found" on every spawn; users can edit
- * this file to add API keys / model overrides.
+ * this file to add API keys / model overrides. Also seeds the bundled
+ * BotCord skills under `<hermes-home>/skills/` so hermes-acp's skill
+ * loader (which only sees this isolated HERMES_HOME, not `~/.hermes`)
+ * can discover them.
  */
 export function ensureAgentHermesWorkspace(agentId: string): {
   hermesHome: string;
@@ -369,6 +372,7 @@ export function ensureAgentHermesWorkspace(agentId: string): {
   );
   seedHermesConfig(hermesHome);
   mergeHermesProviderEnv(path.join(hermesHome, ".env"));
+  seedHermesAgentSkills(hermesHome);
   return { hermesHome, hermesWorkspace };
 }
 
@@ -378,6 +382,7 @@ export function ensureAgentHermesWorkspace(agentId: string): {
  * discovery path differs:
  *   - Claude Code: `<workspace>/.claude/skills/<name>/`
  *   - Codex:       `<codex-home>/skills/<name>/`
+ *   - Hermes:      `<hermes-home>/skills/<name>/`
  * Seeded fresh per `ensureAgent*` call (force-overwrite) so daemon
  * upgrades propagate.
  */
@@ -433,6 +438,17 @@ function seedClaudeCodeSkills(workspace: string): void {
  */
 function seedCodexSkills(codexHome: string): void {
   copyBundledSkills(path.join(codexHome, "skills"));
+}
+
+/**
+ * Seed Hermes's `<HERMES_HOME>/skills/` discovery dir. hermes-acp's
+ * skill loader scans `$HERMES_HOME/skills/` (primary) plus any
+ * `skills.external_dirs` from config; the daemon points hermes-acp at
+ * the per-agent `<hermes-home>/`, so the user's global
+ * `~/.hermes/skills/` is invisible — bundled skills must be seeded here.
+ */
+function seedHermesAgentSkills(hermesHome: string): void {
+  copyBundledSkills(path.join(hermesHome, "skills"));
 }
 
 /**


### PR DESCRIPTION
## Summary

Mirror the codex skill-seeding fix (#414) for the hermes runtime. Hermes-acp's skill loader scans `\$HERMES_HOME/skills/` (primary) plus any `skills.external_dirs` from config; the daemon points hermes-acp at the per-agent `<agent-home>/hermes-home/`, so the user's global `~/.hermes/skills/` is invisible to the runtime — bundled skills must be seeded there.

- Add `seedHermesAgentSkills(hermesHome)` reusing the shared `copyBundledSkills` helper
- Wire into `ensureAgentHermesWorkspace` so every provision/turn force-overwrites `<hermes-home>/skills/{botcord, botcord-user-guide}/`
- Update top-of-file JSDoc to list all three runtime discovery paths

User-authored skills in the same dir are left alone (only the `BUNDLED_SKILLS` whitelist is overwritten).

## Test plan

- [x] `npm test` — full daemon suite 589/589 (+2 new hermes cases)
- [x] `npx tsc --noEmit` — no new errors
- [x] Manual: ran `ensureAgentHermesWorkspace('ag_52ccc5f1a5ff')` against existing on-disk agent — `hermes-home/skills/{botcord, botcord-user-guide}/SKILL.md` populated
- [ ] Smoke test on a hermes-routed agent in dev hub once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)