### PR TITLE
fix(backend): include online status in room members API

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -54,6 +54,7 @@ from hub.routers.hub import (
     _check_slow_mode,
     _record_slow_mode_send,
     build_message_realtime_event,
+    is_agent_ws_online,
     notify_inbox,
 )
 from hub.share_payloads import share_create_payload
@@ -2604,6 +2605,7 @@ async def get_room_members(
             "can_send": m.can_send,
             "can_invite": m.can_invite,
             "joined_at": m.joined_at.isoformat() if m.joined_at else None,
+            "online": is_agent_ws_online(m.agent_id),
         })
     return {"room_id": room_id, "members": members, "total": len(members)}
 

--- a/backend/app/routers/public.py
+++ b/backend/app/routers/public.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.helpers import escape_like, extract_text_from_envelope
 from hub.database import get_db
 from hub.auth import get_optional_dashboard_agent
+from hub.routers.hub import is_agent_ws_online
 from hub.models import (
     Agent,
     Contact,
@@ -314,6 +315,7 @@ async def get_public_room_members(
             "created_at": a.created_at.isoformat() if a and a.created_at else None,
             "role": m.role.value if hasattr(m.role, "value") else str(m.role),
             "joined_at": m.joined_at.isoformat() if m.joined_at else None,
+            "online": is_agent_ws_online(m.agent_id),
         }
         for m, a in rows
     ]


### PR DESCRIPTION
## Summary
- Both `/api/dashboard/rooms/{room_id}/members` and `/api/public/rooms/{room_id}/members` were missing the `online` field.
- Frontend `AgentBrowser.tsx` seeded `usePresenceStore` via `Boolean(m.online)` — `undefined` collapsed to `false`, so every room member rendered as offline.
- Realtime presence events only fire on online/offline transitions, so already-connected agents stayed offline forever after the initial load.
- Fix reuses the existing `is_agent_ws_online()` helper that hub-layer endpoints already use (registry, contacts, hub-layer public room members).

## Test plan
- [x] `uv run pytest tests/test_app/test_app_dashboard_rooms.py tests/test_app/test_app_public.py` (31 passed)
- [ ] Manually verify in dashboard: open a room with online agents → green presence dots appear immediately, no need to wait for a transition event

🤖 Generated with [Claude Code](https://claude.com/claude-code)