### PR TITLE
fix(dashboard): show agent-required gate on wallet in human view

### DIFF
--- a/frontend/src/components/dashboard/WalletPanel.tsx
+++ b/frontend/src/components/dashboard/WalletPanel.tsx
@@ -9,13 +9,15 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useLanguage } from '@/lib/i18n';
-import { walletPanel } from '@/lib/i18n/translations/dashboard';
+import { walletPanel, agentRequiredState } from '@/lib/i18n/translations/dashboard';
 import { common } from '@/lib/i18n/translations/common';
 import { api, ApiError } from "@/lib/api";
 import type { WithdrawalResponse } from "@/lib/types";
 import { useShallow } from "zustand/react/shallow";
 import { Loader2 } from "lucide-react";
+import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardWalletStore } from "@/store/useDashboardWalletStore";
+import AgentRequiredState from "./AgentRequiredState";
 import LedgerList from "./LedgerList";
 import TransferDialog from "./TransferDialog";
 import TopupDialog from "./TopupDialog";
@@ -32,6 +34,10 @@ export default function WalletPanel() {
   const locale = useLanguage();
   const t = walletPanel[locale];
   const tc = common[locale];
+  const tAgent = agentRequiredState[locale];
+  const isAgentIdentity = useDashboardSessionStore(
+    (state) => state.activeIdentity?.type === "agent",
+  );
   const {
     wallet,
     walletView,
@@ -65,10 +71,11 @@ export default function WalletPanel() {
   const view = walletView;
 
   useEffect(() => {
+    if (!isAgentIdentity) return;
     if (!wallet && !walletError && !walletLoading) {
       void loadWallet();
     }
-  }, [wallet, walletError, walletLoading, loadWallet]);
+  }, [isAgentIdentity, wallet, walletError, walletLoading, loadWallet]);
 
   // Load ledger when switching to ledger view
   useEffect(() => {
@@ -98,6 +105,17 @@ export default function WalletPanel() {
     void loadWalletLedger();
     void loadWithdrawalRequests();
   }, [loadWallet, loadWalletLedger, loadWithdrawalRequests]);
+
+  if (!isAgentIdentity) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center bg-deep-black px-6">
+        <AgentRequiredState
+          title={tAgent.selectAgentFirst}
+          description={tAgent.walletScopedToAgent}
+        />
+      </div>
+    );
+  }
 
   if (!wallet) {
     return (


### PR DESCRIPTION
## Summary

- In human view (`activeIdentity.type === "human"`), `WalletPanel` got stuck on the loading spinner forever.
- Root cause: `useDashboardWalletStore.loadWallet()` was tightened in #301 to gate on agent identity (the `/wallet/summary` endpoint requires `X-Active-Agent`), but it early-returns without flipping `walletLoading`. The panel's bootstrap `useEffect` keeps re-firing on every render because its guard `!wallet && !walletError && !walletLoading` stays true forever.
- Fix: gate `WalletPanel` on `activeIdentity.type === "agent"` — skip the bootstrap effect when not in agent identity, and render the existing `AgentRequiredState` with the prepared `walletScopedToAgent` / `selectAgentFirst` translations. Same pattern other dashboard panels already use.

## Test plan

- [ ] Open `/chats/wallet` while in human view → see the "Select a Bot first" gate (with "Use {agent}" / "Connect Bot with AI" CTAs) instead of an endless spinner
- [ ] Switch to an agent → wallet loads normally
- [ ] In agent view, retry / topup / withdraw / transfer flows still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)