### PR TITLE
fix(frontend): seed room member presence on room open

### DIFF
--- a/frontend/src/components/dashboard/ChatPane.tsx
+++ b/frontend/src/components/dashboard/ChatPane.tsx
@@ -28,6 +28,7 @@ import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardContactStore } from "@/store/useDashboardContactStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
+import { usePresenceStore } from "@/store/usePresenceStore";
 import RoomZeroState from "./RoomZeroState";
 import { initialsFromName } from "./roomVisualTheme";
 
@@ -603,6 +604,27 @@ export default function ChatPane({ onHumanOpen }: ChatPaneProps) {
   const isAuthedReady = sessionMode === "authed-ready";
   const isAuthedHuman = sessionMode === "authed-no-agent";
   const showLoginModal = () => router.push("/login");
+
+  // Seed presence for the opened room's members so MessageBubble's PresenceDot
+  // reflects real online state. Without this, senders that aren't the user's
+  // own agents stay "offline" until they happen to transition during the
+  // session — realtime presence events only fire on online/offline edges.
+  useEffect(() => {
+    if (!openedRoomId) return;
+    let cancelled = false;
+    api.getRoomMembers(openedRoomId)
+      .catch(() => api.getPublicRoomMembers(openedRoomId))
+      .then((result) => {
+        if (cancelled) return;
+        usePresenceStore.getState().seed(
+          result.members.map((m) => ({ agentId: m.agent_id, online: Boolean(m.online) })),
+        );
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [openedRoomId]);
 
   if (sidebarTab === "explore") {
     return <ExploreMainPane onHumanOpen={onHumanOpen} />;


### PR DESCRIPTION
## Summary
Companion to #416. The backend now returns \`online\` for room members, but in the frontend the message stream (\`MessageBubble\`) was still showing wrong presence — because nobody seeded the presence store for non-self message senders unless the right-panel \`AgentBrowser\` happened to be open.

- \`syncOwnedAgentsPresence\` only seeds the user's own agents
- \`AgentBrowser\` only seeds when the right panel is open
- Realtime presence events only fire on online/offline transitions

So opening a room with the right panel closed → every non-self sender stayed "offline" forever.

This change lifts the same fetch-and-seed pattern \`AgentBrowser\` uses into \`ChatPane\`, keyed on \`openedRoomId\`. The store's \`seed()\` only writes when no entry exists, so realtime events still take precedence.

## Test plan
- [x] \`tsc --noEmit\` clean for the changed file
- [ ] Manually verify in dashboard: open a room with the right panel collapsed → presence dots in MessageBubbles match real online state immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)