### PR TITLE
fix(dashboard): load human wallet in human view via ?as= query

### DIFF
--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -85,7 +85,9 @@ export default function DashboardApp() {
   const locale = useLanguage();
   const tSidebar = sidebarI18n[locale];
   const recoveredAgentRef = useRef<string | null>(null);
-  const walletBoundAgentRef = useRef<string | null>(null);
+  // Wallet is keyed on the active identity (agent OR human), since both
+  // can own a wallet (`backend/app/routers/wallet.py:_resolve_owner`).
+  const walletBoundIdentityRef = useRef<string | null>(null);
   const contactBoundAgentRef = useRef<string | null>(null);
   const subscriptionBoundAgentRef = useRef<string | null>(null);
   const initResolvedRef = useRef(false);
@@ -335,10 +337,17 @@ export default function DashboardApp() {
     // (Human viewer mode), skip the agent-specific binding/reset cycle and
     // let refreshOverview() run on the Human anchor. Only drop back into the
     // full reset branch for truly pre-auth states.
+    const walletIdentityKey = sessionStore.activeIdentity
+      ? `${sessionStore.activeIdentity.type}:${sessionStore.activeIdentity.id}`
+      : null;
+
     if (sessionStore.sessionMode === "authed-no-agent") {
-      walletBoundAgentRef.current = null;
       contactBoundAgentRef.current = null;
       subscriptionBoundAgentRef.current = null;
+      if (walletBoundIdentityRef.current !== walletIdentityKey) {
+        walletBoundIdentityRef.current = walletIdentityKey;
+        walletStore.resetWalletState();
+      }
       if (
         !chatStore.overview
         && !chatStore.overviewRefreshing
@@ -351,7 +360,7 @@ export default function DashboardApp() {
     }
 
     if (sessionStore.sessionMode !== "authed-ready" || !sessionStore.activeAgentId) {
-      walletBoundAgentRef.current = null;
+      walletBoundIdentityRef.current = null;
       contactBoundAgentRef.current = null;
       subscriptionBoundAgentRef.current = null;
       uiStore.resetUIState();
@@ -368,8 +377,8 @@ export default function DashboardApp() {
       chatStore.bindToActiveAgent(sessionStore.activeAgentId);
     }
 
-    if (walletBoundAgentRef.current !== sessionStore.activeAgentId) {
-      walletBoundAgentRef.current = sessionStore.activeAgentId;
+    if (walletBoundIdentityRef.current !== walletIdentityKey) {
+      walletBoundIdentityRef.current = walletIdentityKey;
       walletStore.resetWalletState();
     }
     if (contactBoundAgentRef.current !== sessionStore.activeAgentId) {
@@ -391,6 +400,7 @@ export default function DashboardApp() {
   }, [
     sessionStore.sessionMode,
     sessionStore.activeAgentId,
+    sessionStore.activeIdentity,
     uiStore.sidebarTab,
     chatStore.boundAgentId,
     chatStore.bindToActiveAgent,
@@ -609,11 +619,14 @@ export default function DashboardApp() {
   ]);
 
   useEffect(() => {
+    // Both Agent viewer (authed-ready) and Human viewer (authed-no-agent OR
+    // authed-ready with viewMode=human) own a wallet — backend resolves
+    // owner from activeIdentity.type via the `?as=` query param.
     if (
       sessionStore.sessionMode !== "authed-ready"
-      || !sessionStore.activeAgentId
-      || sessionStore.activeIdentity?.type !== "agent"
+      && sessionStore.sessionMode !== "authed-no-agent"
     ) return;
+    if (!sessionStore.activeIdentity) return;
 
     if (!walletStore.wallet && !walletStore.walletLoading && !walletStore.walletError) {
       void walletStore.loadWallet();
@@ -627,8 +640,7 @@ export default function DashboardApp() {
     }
   }, [
     sessionStore.sessionMode,
-    sessionStore.activeAgentId,
-    sessionStore.activeIdentity?.type,
+    sessionStore.activeIdentity,
     walletStore.wallet,
     walletStore.walletLoading,
     walletStore.walletError,

--- a/frontend/src/components/dashboard/WalletPanel.tsx
+++ b/frontend/src/components/dashboard/WalletPanel.tsx
@@ -9,15 +9,13 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useLanguage } from '@/lib/i18n';
-import { walletPanel, agentRequiredState } from '@/lib/i18n/translations/dashboard';
+import { walletPanel } from '@/lib/i18n/translations/dashboard';
 import { common } from '@/lib/i18n/translations/common';
 import { api, ApiError } from "@/lib/api";
 import type { WithdrawalResponse } from "@/lib/types";
 import { useShallow } from "zustand/react/shallow";
 import { Loader2 } from "lucide-react";
-import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardWalletStore } from "@/store/useDashboardWalletStore";
-import AgentRequiredState from "./AgentRequiredState";
 import LedgerList from "./LedgerList";
 import TransferDialog from "./TransferDialog";
 import TopupDialog from "./TopupDialog";
@@ -34,10 +32,6 @@ export default function WalletPanel() {
   const locale = useLanguage();
   const t = walletPanel[locale];
   const tc = common[locale];
-  const tAgent = agentRequiredState[locale];
-  const isAgentIdentity = useDashboardSessionStore(
-    (state) => state.activeIdentity?.type === "agent",
-  );
   const {
     wallet,
     walletView,
@@ -71,11 +65,10 @@ export default function WalletPanel() {
   const view = walletView;
 
   useEffect(() => {
-    if (!isAgentIdentity) return;
     if (!wallet && !walletError && !walletLoading) {
       void loadWallet();
     }
-  }, [isAgentIdentity, wallet, walletError, walletLoading, loadWallet]);
+  }, [wallet, walletError, walletLoading, loadWallet]);
 
   // Load ledger when switching to ledger view
   useEffect(() => {
@@ -105,17 +98,6 @@ export default function WalletPanel() {
     void loadWalletLedger();
     void loadWithdrawalRequests();
   }, [loadWallet, loadWalletLedger, loadWithdrawalRequests]);
-
-  if (!isAgentIdentity) {
-    return (
-      <div className="flex flex-1 flex-col items-center justify-center bg-deep-black px-6">
-        <AgentRequiredState
-          title={tAgent.selectAgentFirst}
-          description={tAgent.walletScopedToAgent}
-        />
-      </div>
-    );
-  }
 
   if (!wallet) {
     return (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -206,6 +206,16 @@ async function buildAuthHeaders(): Promise<Record<string, string>> {
   return headers;
 }
 
+/**
+ * Pick the `?as=agent|human` query value for wallet APIs based on the
+ * current active identity. Backend `_resolve_owner` uses this to choose
+ * between `ctx.active_agent_id` (requires X-Active-Agent) and `ctx.human_id`
+ * (resolved from Supabase JWT).
+ */
+function currentWalletAs(): "agent" | "human" {
+  return getActiveIdentity()?.type === "human" ? "human" : "agent";
+}
+
 // --- Core request helpers ---
 
 async function apiGet<T>(path: string, params?: Record<string, string>): Promise<T> {
@@ -570,34 +580,36 @@ export const api = {
   // --- Wallet APIs ---
 
   getWallet() {
-    return apiGet<WalletSummary>("/api/wallet/summary");
+    return apiGet<WalletSummary>("/api/wallet/summary", { as: currentWalletAs() });
   },
 
   getWalletLedger(opts?: { cursor?: string; limit?: number }) {
-    const params: Record<string, string> = {};
+    const params: Record<string, string> = { as: currentWalletAs() };
     if (opts?.cursor) params.cursor = opts.cursor;
     if (opts?.limit) params.limit = String(opts.limit);
     return apiGet<WalletLedgerResponse>("/api/wallet/ledger", params);
   },
 
   createTransfer(payload: CreateTransferRequest) {
-    return apiPost<WalletTransaction>("/api/wallet/transfers", payload);
+    return apiPost<WalletTransaction>(`/api/wallet/transfers?as=${currentWalletAs()}`, payload);
   },
 
   createTopup(payload: CreateTopupRequest) {
-    return apiPost<TopupResponse>("/api/wallet/topups", payload);
+    return apiPost<TopupResponse>(`/api/wallet/topups?as=${currentWalletAs()}`, payload);
   },
 
   createWithdrawal(payload: CreateWithdrawalRequest) {
-    return apiPost<WithdrawalResponse>("/api/wallet/withdrawals", payload);
+    return apiPost<WithdrawalResponse>(`/api/wallet/withdrawals?as=${currentWalletAs()}`, payload);
   },
 
   getWithdrawals() {
-    return apiGet<WithdrawalListResponse>("/api/wallet/withdrawals");
+    return apiGet<WithdrawalListResponse>("/api/wallet/withdrawals", { as: currentWalletAs() });
   },
 
   cancelWithdrawal(withdrawalId: string) {
-    return apiPost<{ withdrawal_id: string; status: string }>(`/api/wallet/withdrawals/${withdrawalId}/cancel`);
+    return apiPost<{ withdrawal_id: string; status: string }>(
+      `/api/wallet/withdrawals/${withdrawalId}/cancel?as=${currentWalletAs()}`,
+    );
   },
 
   // --- Stripe Checkout APIs ---
@@ -607,12 +619,16 @@ export const api = {
   },
 
   createStripeCheckoutSession(payload: StripeCheckoutRequest) {
-    return apiPost<StripeCheckoutResponse>("/api/wallet/stripe/checkout-session", payload);
+    return apiPost<StripeCheckoutResponse>(
+      `/api/wallet/stripe/checkout-session?as=${currentWalletAs()}`,
+      payload,
+    );
   },
 
   getStripeSessionStatus(sessionId: string) {
     return apiGet<StripeSessionStatusResponse>("/api/wallet/stripe/session-status", {
       session_id: sessionId,
+      as: currentWalletAs(),
     });
   },
 

--- a/frontend/src/store/useDashboardWalletStore.ts
+++ b/frontend/src/store/useDashboardWalletStore.ts
@@ -46,12 +46,8 @@ const initialWalletState = {
   walletView: "overview" as const,
 };
 
-function getAuthContext() {
-  const { token, activeAgentId, activeIdentity } = useDashboardSessionStore.getState();
-  return {
-    token,
-    hasReadyAgent: Boolean(token && activeAgentId && activeIdentity?.type === "agent"),
-  };
+function getToken(): string | null {
+  return useDashboardSessionStore.getState().token;
 }
 
 export const useDashboardWalletStore = create<DashboardWalletState>()((set, get) => ({
@@ -62,12 +58,7 @@ export const useDashboardWalletStore = create<DashboardWalletState>()((set, get)
   resetWalletState: () => set({ ...initialWalletState }),
 
   loadWallet: async () => {
-    const { token, hasReadyAgent } = getAuthContext();
-    if (!token) return;
-    if (!hasReadyAgent) {
-      set({ wallet: null, walletError: null });
-      return;
-    }
+    if (!getToken()) return;
     try {
       const wallet = await api.getWallet();
       set({ wallet, walletError: null });
@@ -77,19 +68,8 @@ export const useDashboardWalletStore = create<DashboardWalletState>()((set, get)
   },
 
   loadWalletLedger: async (loadMore = false) => {
-    const { token, hasReadyAgent } = getAuthContext();
+    if (!getToken()) return;
     const { walletLedgerCursor, walletLedger } = get();
-    if (!token) return;
-    if (!hasReadyAgent) {
-      set({
-        walletLedger: [],
-        walletLedgerCursor: null,
-        walletLedgerHasMore: false,
-        walletLedgerError: null,
-        walletLoading: false,
-      });
-      return;
-    }
     set({ walletLoading: true });
     try {
       const cursor = loadMore ? walletLedgerCursor : undefined;
@@ -115,17 +95,7 @@ export const useDashboardWalletStore = create<DashboardWalletState>()((set, get)
   },
 
   loadWithdrawalRequests: async () => {
-    const { token, hasReadyAgent } = getAuthContext();
-    if (!token) return;
-    if (!hasReadyAgent) {
-      set({
-        withdrawalRequests: [],
-        withdrawalRequestsError: null,
-        withdrawalRequestsLoaded: false,
-        withdrawalRequestsLoading: false,
-      });
-      return;
-    }
+    if (!getToken()) return;
     set({ withdrawalRequestsLoading: true, withdrawalRequestsError: null });
     try {
       const result = await api.getWithdrawals();


### PR DESCRIPTION
## Summary

Reverts the gate from #417 and wires the frontend through the backend's existing `?as=agent|human` wallet contract — humans see their own wallet, no longer pushed to "Select a Bot first".

- `WalletAccount.owner_id` is polymorphic (\`hu_*\` and \`ag_*\`); BFF \`/api/wallet/*\` accepts \`?as=agent|human\` and resolves owner from \`ctx.active_agent_id\` or \`ctx.human_id\` (\`backend/app/routers/wallet.py:_resolve_owner\`).
- Frontend now sends \`?as=\` derived from \`getActiveIdentity().type\` on every wallet call (summary, ledger, transfers, topups, withdrawals, cancel, Stripe checkout/session-status).
- Wallet bind-ref is keyed on identity (\`type:id\`), so switching agent ↔ human view triggers a refetch.
- Wallet bootstrap fires for both \`authed-ready\` and \`authed-no-agent\` whenever an identity is present.
- The sidebar wallet pane (the stuck "Loading wallet..." in the secondary column) reads the same store and is fixed transitively.

## Test plan

- [ ] In human view → \`/chats/wallet\` loads the human's wallet (not the spinner, not the gate)
- [ ] Sidebar's secondary "Loading wallet..." column resolves to balance
- [ ] Toggle viewMode agent ↔ human → wallet refetches each side's balance
- [ ] In agent view, wallet still works end-to-end (summary, ledger, transfer, topup, withdraw, cancel)
- [ ] Stripe checkout in human view creates a session that settles to the human's wallet on webhook fulfillment

🤖 Generated with [Claude Code](https://claude.com/claude-code)