### PR TITLE
Revert chore(ci): pin deploy-backend jobs to deploy-host

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -27,7 +27,7 @@ jobs:
   # ── Build + push docker image ────────────────────────────────────────────────
   deploy:
     name: Build & Push
-    runs-on: [self-hosted, deploy-host]
+    runs-on: self-hosted
     timeout-minutes: 20
     outputs:
       image_tag: ${{ steps.build.outputs.image_tag }}
@@ -61,7 +61,7 @@ jobs:
     name: Restart Preview
     needs: [deploy]
     if: inputs.env_name == 'preview'
-    runs-on: [self-hosted, deploy-host]
+    runs-on: self-hosted
     timeout-minutes: 10
     env:
       PROJECT: botcord-backend
@@ -77,7 +77,7 @@ jobs:
     name: Rollout Production
     needs: [deploy]
     if: inputs.env_name == 'prod'
-    runs-on: [self-hosted, deploy-host]
+    runs-on: self-hosted
     timeout-minutes: 15
     env:
       PROJECT: botcord-backend


### PR DESCRIPTION
Reverts #409.

The 2 GCP self-hosted runners that motivated the label pin have been unregistered, so all `runs-on: self-hosted` jobs now go back to the single EC2 runner. The `deploy-host` label pin is no longer needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)