### PR TITLE
fix(daemon): default OpenClaw agent routing

### DIFF
--- a/packages/daemon/src/__tests__/openclaw-acp.test.ts
+++ b/packages/daemon/src/__tests__/openclaw-acp.test.ts
@@ -69,12 +69,26 @@ describe("OpenclawAcpAdapter.run", () => {
     expect(res.error).toMatch(/missing gateway/);
   });
 
-  it("fails when gateway has no openclawAgent resolved", async () => {
-    const adapter = new OpenclawAcpAdapter({ spawnFn: makeSpawn(new FakeChild()) });
+  it("defaults to OpenClaw's default agent when gateway has no openclawAgent resolved", async () => {
+    const child = new FakeChild();
+    const adapter = new OpenclawAcpAdapter({ spawnFn: makeSpawn(child) });
     const gateway: ResolvedOpenclawGateway = {
       name: "local",
       url: "ws://127.0.0.1:1",
     };
+    child.stdin.on("data", (chunk: Buffer) => {
+      for (const line of chunk.toString("utf8").split("\n").filter(Boolean)) {
+        const frame = JSON.parse(line);
+        if (frame.method === "initialize") {
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { protocolVersion: 1 } }) + "\n");
+        } else if (frame.method === "session/new") {
+          expect(frame.params._meta.sessionKey).toContain("agent:default:");
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { sessionId: "sid-default" } }) + "\n");
+        } else if (frame.method === "session/prompt") {
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { text: "ok" } }) + "\n");
+        }
+      }
+    });
     const res = await adapter.run({
       text: "hi",
       sessionId: null,
@@ -84,7 +98,7 @@ describe("OpenclawAcpAdapter.run", () => {
       trustLevel: "owner",
       gateway,
     });
-    expect(res.error).toMatch(/openclawAgent/);
+    expect(res.text).toBe("ok");
   });
 
   it("performs initialize → newSession → prompt and returns final text", async () => {

--- a/packages/daemon/src/__tests__/provision.test.ts
+++ b/packages/daemon/src/__tests__/provision.test.ts
@@ -585,6 +585,45 @@ describe("provision_agent seeds workspace + hot-adds managed route", () => {
     });
   });
 
+  it("binds OpenClaw default agent when provisioning only specifies a loopback gateway", async () => {
+    await withSandboxHome(async ({ tmp, fs, path: nodePath }) => {
+      mockState.cfg = {
+        defaultRoute: { adapter: "claude-code", cwd: "/tmp" },
+        routes: [],
+        streamBlocks: true,
+        openclawGateways: [{ name: "local", url: "ws://127.0.0.1:18789" }],
+      };
+      const gw = makeFakeGateway();
+      const provisioner = createProvisioner({
+        gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+      });
+      const privateKey = Buffer.alloc(32, 14).toString("base64");
+      const ack = await provisioner({
+        id: "req_openclaw_default",
+        type: CONTROL_FRAME_TYPES.PROVISION_AGENT,
+        params: {
+          runtime: "openclaw-acp",
+          openclaw: { gateway: "local" },
+          credentials: {
+            agentId: "ag_openclaw_default",
+            keyId: "k_ocd",
+            privateKey,
+            hubUrl: "https://hub.example",
+          },
+        },
+      });
+
+      expect(ack.ok).toBe(true);
+      const credFile = nodePath.join(tmp, ".botcord", "credentials", "ag_openclaw_default.json");
+      const saved = JSON.parse(fs.readFileSync(credFile, "utf8")) as Record<string, unknown>;
+      expect(saved.openclawGateway).toBe("local");
+      expect(saved.openclawAgent).toBe("default");
+      const route = gw.listManagedRoutes().find((r) => r.match?.accountId === "ag_openclaw_default");
+      expect(route?.gateway?.name).toBe("local");
+      expect(route?.gateway?.openclawAgent).toBe("default");
+    });
+  });
+
   it("defaults cwd to agentWorkspaceDir on the slow path (daemon register)", async () => {
     await withSandboxHome(async ({ tmp, fs, path: nodePath }) => {
       // Seed an existing credential so `inferHubUrl` finds a hubUrl.

--- a/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
+++ b/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
@@ -430,6 +430,18 @@ describe("Dispatcher", () => {
     expect(store.all().length).toBe(0);
   });
 
+  it("runtime empty text with error: sends owner-chat error reply", async () => {
+    const runtime = new FakeRuntime({ reply: "", newSessionId: "", errorText: "missing openclawAgent" });
+    const channel = new FakeChannel();
+    const { dispatcher } = await scaffold({ channel, runtimeFactory: () => runtime });
+
+    await dispatcher.handle(makeEnvelope({ id: "msg_error" }));
+
+    expect(channel.sends.length).toBe(1);
+    expect(channel.sends[0].message.text).toContain("Runtime error");
+    expect(channel.sends[0].message.text).toContain("missing openclawAgent");
+  });
+
   it("cancel-previous: prior turn is aborted and does not write session, new turn writes", async () => {
     const prior = new FakeRuntime({ hang: true, newSessionId: "prior-sid" });
     const newer = new FakeRuntime({ reply: "newer", newSessionId: "newer-sid" });

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -1228,6 +1228,40 @@ export class Dispatcher {
       const finalTextField = truncateTextField(result.text || "");
 
       if (!replyText) {
+        if (result.error) {
+          this.log.warn("dispatcher: runtime returned error without reply text", {
+            agentId: msg.accountId,
+            roomId: msg.conversation.id,
+            topicId: msg.conversation.threadId ?? null,
+            turnId,
+            runtime: route.runtime,
+            error: result.error,
+          });
+          if (isOwnerChat) {
+            const sendResult = await this.sendReply(channel, {
+              channel: msg.channel,
+              accountId: msg.accountId,
+              conversationId: msg.conversation.id,
+              threadId: msg.conversation.threadId ?? null,
+              text: `⚠️ Runtime error: ${truncate(result.error, 500)}`,
+              replyTo: msg.id,
+              traceId: msg.trace?.id ?? null,
+            }, turnId);
+            this.emitOutbound({
+              turnId,
+              msg,
+              runtime: route.runtime,
+              runtimeSessionId: result.newSessionId || null,
+              startedAt: slot.dispatchedAt,
+              costUsd: result.costUsd,
+              finalText: finalTextField,
+              deliveryStatus: sendResult.ok ? "delivered" : "send_failed",
+              deliveryReason: sendResult.ok ? null : sendResult.error,
+              blocks: slot.blocks,
+            });
+            return;
+          }
+        }
         this.emitOutbound({
           turnId,
           msg,
@@ -1237,7 +1271,7 @@ export class Dispatcher {
           costUsd: result.costUsd,
           finalText: finalTextField,
           deliveryStatus: "empty_text",
-          deliveryReason: null,
+          deliveryReason: result.error ?? null,
           blocks: slot.blocks,
         });
         return;

--- a/packages/daemon/src/gateway/runtimes/openclaw-acp.ts
+++ b/packages/daemon/src/gateway/runtimes/openclaw-acp.ts
@@ -169,14 +169,9 @@ export class OpenclawAcpAdapter implements RuntimeAdapter {
         "openclaw-acp: missing gateway endpoint (route.gateway not resolved)",
       );
     }
-    if (!gateway.openclawAgent) {
-      return failResult(
-        opts.sessionId ?? "",
-        `openclaw-acp: gateway "${gateway.name}" did not resolve an openclawAgent (set defaultAgent on the profile or openclawAgent on the route)`,
-      );
-    }
+    const openclawAgent = gateway.openclawAgent ?? "default";
     const sessionKey = buildAcpSessionKey({
-      openclawAgent: gateway.openclawAgent,
+      openclawAgent,
       accountId: opts.accountId,
       // The dispatcher passes `context.conversationKey` in for routing;
       // fall back to a stable per-accountId key when it's not present (e.g.

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -316,7 +316,9 @@ async function provisionAgent(
   const explicitCwd = params.credentials?.cwd ?? params.cwd;
   assertSafeCwd(explicitCwd);
 
-  const openclawSel = pickOpenclawSelection(params);
+  const initialCfg = loadConfig();
+  const openclawSel = await resolveProvisionOpenclawSelection(params, initialCfg);
+  const resolvedParams = withResolvedOpenclawSelection(params, openclawSel);
   if (openclawSel.gateway && openclawSel.agent) {
     return withOpenclawProvisionLock(openclawSel.gateway, openclawSel.agent, async () => {
       const existing = findCredentialsByOpenclaw(openclawSel.gateway!, openclawSel.agent!);
@@ -329,7 +331,7 @@ async function provisionAgent(
         return installExistingOpenclawBinding(existing.agentId, ctx);
       }
       const cfg = loadConfig();
-      const credentials = await materializeCredentials(params, cfg, ctx, explicitCwd);
+      const credentials = await materializeCredentials(resolvedParams, cfg, ctx, explicitCwd);
       return installLocalAgent(credentials, {
         ...ctx,
         cfg,
@@ -339,11 +341,10 @@ async function provisionAgent(
     });
   }
 
-  const cfg = loadConfig();
-  const credentials = await materializeCredentials(params, cfg, ctx, explicitCwd);
+  const credentials = await materializeCredentials(resolvedParams, initialCfg, ctx, explicitCwd);
   return installLocalAgent(credentials, {
     ...ctx,
-    cfg,
+    cfg: initialCfg,
     bio: params.bio,
     source: params.credentials ? "hub-supplied" : "registered",
   });
@@ -686,6 +687,67 @@ function pickOpenclawSelection(
     }
   }
   return out;
+}
+
+async function resolveProvisionOpenclawSelection(
+  params: ProvisionAgentParams,
+  cfg: DaemonConfig,
+): Promise<{ gateway?: string; agent?: string }> {
+  const out = pickOpenclawSelection(params);
+  if (!out.gateway || out.agent) return out;
+
+  const profile = (cfg.openclawGateways ?? []).find((g) => g.name === out.gateway);
+  if (!profile) return out;
+
+  const prepared = prepareGatewayProfile(profile);
+  if (prepared.defaultAgent) {
+    out.agent = prepared.defaultAgent;
+    return out;
+  }
+
+  if (isLoopbackUrl(prepared.url)) {
+    const localAgents = readLocalOpenclawAgents();
+    const defaultAgent = localAgents?.find((a) => a.id === "default") ?? (localAgents?.length === 1 ? localAgents[0] : undefined);
+    if (defaultAgent) {
+      out.agent = defaultAgent.id;
+      return out;
+    }
+  }
+
+  try {
+    const probeResult = await probeOpenclawAgents(prepared);
+    if (probeResult.ok) {
+      const agents = probeResult.agents ?? [];
+      const defaultAgent = agents.find((a) => a.id === "default") ?? (agents.length === 1 ? agents[0] : undefined);
+      if (defaultAgent) {
+        out.agent = defaultAgent.id;
+        return out;
+      }
+    }
+  } catch (err) {
+    daemonLog.debug("provision_agent: openclaw default probe failed", {
+      gateway: out.gateway,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  if (isLoopbackUrl(prepared.url)) out.agent = "default";
+  return out;
+}
+
+function withResolvedOpenclawSelection(
+  params: ProvisionAgentParams,
+  selection: { gateway?: string; agent?: string },
+): ProvisionAgentParams {
+  if (!selection.gateway) return params;
+  return {
+    ...params,
+    openclaw: {
+      ...(params.openclaw ?? {}),
+      gateway: selection.gateway,
+      ...(selection.agent ? { agent: selection.agent } : {}),
+    },
+  };
 }
 
 async function withOpenclawProvisionLock<T>(
@@ -1294,7 +1356,7 @@ function readLocalOpenclawAgents(): Array<{
 }> | null {
   try {
     const file = path.join(homedir(), ".openclaw", "openclaw.json");
-    if (!existsSync(file)) return null;
+    if (!existsSync(file)) return [{ id: "default" }];
     const cfg = JSON.parse(readFileSync(file, "utf8")) as any;
     const list = Array.isArray(cfg?.agents?.list) ? cfg.agents.list : [];
     const defaultId = typeof cfg?.agents?.defaults?.id === "string" ? cfg.agents.defaults.id : "default";


### PR DESCRIPTION
## Summary
- default OpenClaw ACP routing to the `default` agent when no explicit `openclawAgent` is resolved
- resolve and persist the default OpenClaw agent during provision when only a loopback gateway is provided
- surface runtime `error` results with empty text back to owner chat instead of silently emitting `empty_text`

## Tests
- `cd packages/daemon && npm test -- --run src/__tests__/openclaw-acp.test.ts src/__tests__/provision.test.ts src/gateway/__tests__/dispatcher.test.ts src/gateway/__tests__/transcript.test.ts`
- `cd packages/daemon && npx tsc --noEmit -p tsconfig.build.json`