### PR TITLE
feat(dashboard): wallet owner switcher + transfer recipient picker

### DIFF
--- a/frontend/src/components/dashboard/TopupDialog.tsx
+++ b/frontend/src/components/dashboard/TopupDialog.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { useLanguage } from '@/lib/i18n';
 import { topupDialog } from '@/lib/i18n/translations/dashboard';
-import { api, ApiError } from "@/lib/api";
+import { api, ApiError, type ActiveIdentity } from "@/lib/api";
 import type { StripePackageItem } from "@/lib/types";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { Loader2 } from "lucide-react";
@@ -19,14 +19,19 @@ function formatFiat(amount: number): string {
 }
 
 interface TopupDialogProps {
+  /**
+   * Identity that owns the wallet receiving the topup. Defaults to the
+   * global active identity when ``null``.
+   */
+  viewer?: ActiveIdentity | null;
   onClose: () => void;
   onSuccess: () => void;
 }
 
-export default function TopupDialog({ onClose, onSuccess }: TopupDialogProps) {
+export default function TopupDialog({ viewer, onClose, onSuccess }: TopupDialogProps) {
   const locale = useLanguage();
   const t = topupDialog[locale];
-  const isAuthedReady = useDashboardSessionStore((state) => state.sessionMode === "authed-ready");
+  const isAuthed = useDashboardSessionStore((state) => state.sessionMode !== "guest");
   const [packages, setPackages] = useState<StripePackageItem[]>([]);
   const [packagesLoading, setPackagesLoading] = useState(true);
   const [packagesError, setPackagesError] = useState("");
@@ -61,7 +66,7 @@ export default function TopupDialog({ onClose, onSuccess }: TopupDialogProps) {
   };
 
   const handleCheckout = async () => {
-    if (!activePackage || !isAuthedReady) return;
+    if (!activePackage || !isAuthed) return;
     setError("");
     setSubmitting(true);
 
@@ -70,7 +75,7 @@ export default function TopupDialog({ onClose, onSuccess }: TopupDialogProps) {
         package_code: activePackage.package_code,
         idempotency_key: crypto.randomUUID(),
         quantity,
-      });
+      }, viewer);
       window.location.assign(res.checkout_url);
     } catch (err) {
       if (err instanceof ApiError) {

--- a/frontend/src/components/dashboard/TransferDialog.tsx
+++ b/frontend/src/components/dashboard/TransferDialog.tsx
@@ -1,28 +1,95 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useLanguage } from '@/lib/i18n';
 import { transferDialog } from '@/lib/i18n/translations/dashboard';
-import { api, ApiError } from "@/lib/api";
+import { api, ApiError, type ActiveIdentity } from "@/lib/api";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
+import { useShallow } from "zustand/react/shallow";
 import { Loader2 } from "lucide-react";
 
 interface TransferDialogProps {
+  /**
+   * Identity that owns the wallet sending the transfer. ``null`` follows the
+   * global active identity. The picker excludes this id so users can't
+   * select the source as the recipient.
+   */
+  viewer?: ActiveIdentity | null;
   onClose: () => void;
   onSuccess: () => void;
 }
 
-export default function TransferDialog({ onClose, onSuccess }: TransferDialogProps) {
+interface RecipientOption {
+  /** Stable key for <option> elements (group + id). */
+  key: string;
+  /** Display label rendered inline. */
+  label: string;
+  /** Owner id — `ag_*` or `hu_*`. Backend ``_assert_owner_exists`` accepts both. */
+  id: string;
+}
+
+export default function TransferDialog({ viewer, onClose, onSuccess }: TransferDialogProps) {
   const locale = useLanguage();
   const t = transferDialog[locale];
-  const myAgentId = useDashboardChatStore((state) => state.overview?.agent?.agent_id ?? "");
-  const isAuthedReady = useDashboardSessionStore((state) => state.sessionMode === "authed-ready");
+
+  const sessionStore = useDashboardSessionStore(
+    useShallow((s) => ({
+      activeIdentity: s.activeIdentity,
+      ownedAgents: s.ownedAgents,
+      human: s.human,
+      sessionMode: s.sessionMode,
+    })),
+  );
+  const contacts = useDashboardChatStore((s) => s.overview?.contacts) ?? [];
+
+  const senderIdentity: ActiveIdentity | null = viewer ?? sessionStore.activeIdentity;
+  const senderId = senderIdentity?.id ?? "";
+
+  // Build grouped recipient options. Backend transfer accepts agent and
+  // human owner ids interchangeably, so all three categories live in a
+  // single picker with optgroup labels.
+  const ownedBotOptions: RecipientOption[] = useMemo(() => {
+    return sessionStore.ownedAgents
+      .filter((a) => a.agent_id !== senderId)
+      .map((a) => ({
+        key: `bot:${a.agent_id}`,
+        label: `${a.display_name} · ${a.agent_id}`,
+        id: a.agent_id,
+      }));
+  }, [sessionStore.ownedAgents, senderId]);
+
+  const humanSelfOption: RecipientOption | null = useMemo(() => {
+    if (!sessionStore.human?.human_id) return null;
+    if (sessionStore.human.human_id === senderId) return null;
+    return {
+      key: `human:${sessionStore.human.human_id}`,
+      label: `${sessionStore.human.display_name} · ${sessionStore.human.human_id}`,
+      id: sessionStore.human.human_id,
+    };
+  }, [sessionStore.human, senderId]);
+
+  const contactOptions: RecipientOption[] = useMemo(() => {
+    return contacts
+      .filter((c) => c.contact_agent_id !== senderId)
+      .map((c) => ({
+        key: `contact:${c.contact_agent_id}`,
+        label: `${c.alias ?? c.display_name} · ${c.contact_agent_id}`,
+        id: c.contact_agent_id,
+      }));
+  }, [contacts, senderId]);
+
+  const isAuthed = sessionStore.sessionMode !== "guest";
   const [recipientId, setRecipientId] = useState("");
   const [amount, setAmount] = useState("");
   const [memo, setMemo] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
+
+  const handlePickRecipient = (value: string) => {
+    if (!value) return;
+    setRecipientId(value);
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -33,7 +100,7 @@ export default function TransferDialog({ onClose, onSuccess }: TransferDialogPro
       setError(t.recipientRequired);
       return;
     }
-    if (trimmedRecipient === myAgentId) {
+    if (trimmedRecipient === senderId) {
       setError(t.cannotTransferSelf);
       return;
     }
@@ -46,7 +113,7 @@ export default function TransferDialog({ onClose, onSuccess }: TransferDialogPro
 
     const amountMinor = Math.round(amountNum * 100);
 
-    if (!isAuthedReady) return;
+    if (!isAuthed) return;
     setSubmitting(true);
     try {
       await api.createTransfer({
@@ -54,7 +121,7 @@ export default function TransferDialog({ onClose, onSuccess }: TransferDialogPro
         amount_minor: String(amountMinor),
         memo: memo.trim() || undefined,
         idempotency_key: crypto.randomUUID(),
-      });
+      }, viewer);
       onSuccess();
     } catch (err) {
       if (err instanceof ApiError) {
@@ -66,6 +133,9 @@ export default function TransferDialog({ onClose, onSuccess }: TransferDialogPro
       setSubmitting(false);
     }
   };
+
+  const hasShortcuts =
+    humanSelfOption !== null || ownedBotOptions.length > 0 || contactOptions.length > 0;
 
   return (
     <div
@@ -91,6 +161,40 @@ export default function TransferDialog({ onClose, onSuccess }: TransferDialogPro
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-4">
+          {hasShortcuts ? (
+            <div>
+              <label className="mb-1 block text-xs font-medium text-text-secondary">
+                {t.pickRecipient}
+              </label>
+              <select
+                value={recipientId}
+                onChange={(e) => handlePickRecipient(e.target.value)}
+                className="w-full rounded-lg border border-glass-border bg-deep-black-light p-3 text-sm text-text-primary outline-none focus:border-neon-cyan/50"
+              >
+                <option value="">{t.pickRecipientDefault}</option>
+                {humanSelfOption ? (
+                  <optgroup label={t.groupHumanSelf}>
+                    <option value={humanSelfOption.id}>{humanSelfOption.label}</option>
+                  </optgroup>
+                ) : null}
+                {ownedBotOptions.length > 0 ? (
+                  <optgroup label={t.groupMyBots}>
+                    {ownedBotOptions.map((o) => (
+                      <option key={o.key} value={o.id}>{o.label}</option>
+                    ))}
+                  </optgroup>
+                ) : null}
+                {contactOptions.length > 0 ? (
+                  <optgroup label={t.groupContacts}>
+                    {contactOptions.map((o) => (
+                      <option key={o.key} value={o.id}>{o.label}</option>
+                    ))}
+                  </optgroup>
+                ) : null}
+              </select>
+            </div>
+          ) : null}
+
           <div>
             <label className="mb-1 block text-xs font-medium text-text-secondary">
               {t.recipientAgentId}

--- a/frontend/src/components/dashboard/WalletPanel.tsx
+++ b/frontend/src/components/dashboard/WalletPanel.tsx
@@ -7,14 +7,15 @@
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useLanguage } from '@/lib/i18n';
 import { walletPanel } from '@/lib/i18n/translations/dashboard';
 import { common } from '@/lib/i18n/translations/common';
-import { api, ApiError } from "@/lib/api";
+import { api, ApiError, type ActiveIdentity } from "@/lib/api";
 import type { WithdrawalResponse } from "@/lib/types";
 import { useShallow } from "zustand/react/shallow";
-import { Loader2 } from "lucide-react";
+import { ChevronDown, Loader2 } from "lucide-react";
+import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardWalletStore } from "@/store/useDashboardWalletStore";
 import LedgerList from "./LedgerList";
 import TransferDialog from "./TransferDialog";
@@ -38,6 +39,7 @@ export default function WalletPanel() {
     walletError,
     walletLoading,
     walletLedger,
+    walletViewer,
     withdrawalRequests,
     withdrawalRequestsLoading,
     withdrawalRequestsError,
@@ -46,12 +48,14 @@ export default function WalletPanel() {
     loadWalletLedger,
     loadWithdrawalRequests,
     setWalletView,
+    setWalletViewer,
   } = useDashboardWalletStore(useShallow((state) => ({
     wallet: state.wallet,
     walletView: state.walletView,
     walletError: state.walletError,
     walletLoading: state.walletLoading,
     walletLedger: state.walletLedger,
+    walletViewer: state.walletViewer,
     withdrawalRequests: state.withdrawalRequests,
     withdrawalRequestsLoading: state.withdrawalRequestsLoading,
     withdrawalRequestsError: state.withdrawalRequestsError,
@@ -60,9 +64,37 @@ export default function WalletPanel() {
     loadWalletLedger: state.loadWalletLedger,
     loadWithdrawalRequests: state.loadWithdrawalRequests,
     setWalletView: state.setWalletView,
+    setWalletViewer: state.setWalletViewer,
   })));
+  const sessionStore = useDashboardSessionStore(
+    useShallow((s) => ({
+      activeIdentity: s.activeIdentity,
+      ownedAgents: s.ownedAgents,
+      human: s.human,
+    })),
+  );
   const [activeDialog, setActiveDialog] = useState<"transfer" | "topup" | "withdraw" | null>(null);
   const view = walletView;
+
+  // Effective viewer: explicit override, otherwise the global active identity.
+  const effectiveViewer: ActiveIdentity | null = walletViewer ?? sessionStore.activeIdentity;
+  const ownerOptions = useMemo(() => {
+    const options: Array<{ identity: ActiveIdentity; label: string }> = [];
+    if (sessionStore.human?.human_id) {
+      options.push({
+        identity: { type: "human", id: sessionStore.human.human_id },
+        label: t.youHuman,
+      });
+    }
+    for (const agent of sessionStore.ownedAgents) {
+      options.push({
+        identity: { type: "agent", id: agent.agent_id },
+        label: `${t.botPrefix} · ${agent.display_name}`,
+      });
+    }
+    return options;
+  }, [sessionStore.human, sessionStore.ownedAgents, t.botPrefix, t.youHuman]);
+  const showOwnerSwitcher = ownerOptions.length > 1;
 
   useEffect(() => {
     if (!wallet && !walletError && !walletLoading) {
@@ -123,7 +155,17 @@ export default function WalletPanel() {
     <div className="flex flex-1 flex-col bg-deep-black">
       {/* Header */}
       <div className="flex items-center justify-between border-b border-glass-border px-6 py-4">
-        <h2 className="text-lg font-semibold text-text-primary">{t.wallet}</h2>
+        <div className="flex items-center gap-3">
+          <h2 className="text-lg font-semibold text-text-primary">{t.wallet}</h2>
+          {showOwnerSwitcher ? (
+            <WalletOwnerSwitcher
+              effectiveViewer={effectiveViewer}
+              options={ownerOptions}
+              onSelect={(identity) => setWalletViewer(identity)}
+              label={t.viewingWalletFor}
+            />
+          ) : null}
+        </div>
         <div className="flex gap-1">
           <button
             onClick={() => setWalletView("overview")}
@@ -152,6 +194,7 @@ export default function WalletPanel() {
         {view === "overview" ? (
           <WalletOverview
             wallet={wallet}
+            viewer={effectiveViewer}
             withdrawalRequests={withdrawalRequests}
             withdrawalsLoading={withdrawalRequestsLoading}
             withdrawalsError={withdrawalRequestsError}
@@ -169,18 +212,21 @@ export default function WalletPanel() {
       {/* Dialogs */}
       {activeDialog === "transfer" && (
         <TransferDialog
+          viewer={effectiveViewer}
           onClose={() => setActiveDialog(null)}
           onSuccess={handleDialogSuccess}
         />
       )}
       {activeDialog === "topup" && (
         <TopupDialog
+          viewer={effectiveViewer}
           onClose={() => setActiveDialog(null)}
           onSuccess={handleDialogSuccess}
         />
       )}
       {activeDialog === "withdraw" && (
         <WithdrawDialog
+          viewer={effectiveViewer}
           onClose={() => setActiveDialog(null)}
           onSuccess={handleDialogSuccess}
           availableBalance={wallet.available_balance_minor}
@@ -190,8 +236,77 @@ export default function WalletPanel() {
   );
 }
 
+interface OwnerOption {
+  identity: ActiveIdentity;
+  label: string;
+}
+
+function WalletOwnerSwitcher({
+  effectiveViewer,
+  options,
+  onSelect,
+  label,
+}: {
+  effectiveViewer: ActiveIdentity | null;
+  options: OwnerOption[];
+  onSelect: (identity: ActiveIdentity) => void;
+  label: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const current = effectiveViewer
+    ? options.find(
+        (o) => o.identity.type === effectiveViewer.type && o.identity.id === effectiveViewer.id,
+      )
+    : null;
+  const display = current?.label ?? "—";
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        onBlur={() => setTimeout(() => setOpen(false), 120)}
+        className="inline-flex items-center gap-1.5 rounded-lg border border-glass-border bg-glass-bg px-3 py-1.5 text-xs text-text-secondary hover:text-text-primary"
+      >
+        <span className="text-text-secondary/70">{label}</span>
+        <span className="font-medium text-text-primary">{display}</span>
+        <ChevronDown className="h-3.5 w-3.5" />
+      </button>
+      {open ? (
+        <div className="absolute left-0 top-full z-20 mt-1 min-w-[200px] overflow-hidden rounded-lg border border-glass-border bg-deep-black-light shadow-lg">
+          {options.map((opt) => {
+            const selected =
+              effectiveViewer?.type === opt.identity.type
+              && effectiveViewer?.id === opt.identity.id;
+            return (
+              <button
+                key={`${opt.identity.type}:${opt.identity.id}`}
+                type="button"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  onSelect(opt.identity);
+                  setOpen(false);
+                }}
+                className={`flex w-full items-center justify-between px-3 py-2 text-left text-xs transition-colors hover:bg-glass-bg ${
+                  selected ? "bg-neon-cyan/10 text-neon-cyan" : "text-text-primary"
+                }`}
+              >
+                <span className="truncate">{opt.label}</span>
+                <span className="ml-2 truncate font-mono text-[10px] text-text-secondary/60">
+                  {opt.identity.id}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 function WalletOverview({
   wallet,
+  viewer,
   withdrawalRequests,
   withdrawalsLoading,
   withdrawalsError,
@@ -202,6 +317,7 @@ function WalletOverview({
   onWithdraw,
 }: {
   wallet: { available_balance_minor: string; locked_balance_minor: string; total_balance_minor: string; asset_code: string; updated_at: string };
+  viewer: ActiveIdentity | null;
   withdrawalRequests: WithdrawalResponse[];
   withdrawalsLoading: boolean;
   withdrawalsError: string | null;
@@ -286,6 +402,7 @@ function WalletOverview({
       </div>
 
       <RecentWithdrawals
+        viewer={viewer}
         items={withdrawalRequests}
         loading={withdrawalsLoading}
         error={withdrawalsError}
@@ -297,12 +414,14 @@ function WalletOverview({
 }
 
 function RecentWithdrawals({
+  viewer,
   items,
   loading,
   error,
   onRefresh,
   onCancelled,
 }: {
+  viewer: ActiveIdentity | null;
   items: WithdrawalResponse[];
   loading: boolean;
   error: string | null;
@@ -321,7 +440,7 @@ function RecentWithdrawals({
 
     setCancellingId(withdrawalId);
     try {
-      await api.cancelWithdrawal(withdrawalId);
+      await api.cancelWithdrawal(withdrawalId, viewer);
       window.alert(t.cancelWithdrawalSuccess);
       onCancelled();
     } catch (err) {
@@ -333,7 +452,7 @@ function RecentWithdrawals({
     } finally {
       setCancellingId(null);
     }
-  }, [onCancelled, t]);
+  }, [onCancelled, t, viewer]);
 
   return (
     <div className="rounded-2xl border border-glass-border bg-glass-bg p-5 backdrop-blur-xl">

--- a/frontend/src/components/dashboard/WithdrawDialog.tsx
+++ b/frontend/src/components/dashboard/WithdrawDialog.tsx
@@ -3,13 +3,15 @@
 import { useState } from "react";
 import { useLanguage } from '@/lib/i18n';
 import { withdrawDialog } from '@/lib/i18n/translations/dashboard';
-import { api, ApiError } from "@/lib/api";
+import { api, ApiError, type ActiveIdentity } from "@/lib/api";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { Loader2 } from "lucide-react";
 
 const MIN_WITHDRAWAL_MINOR = 1000 * 100;
 
 interface WithdrawDialogProps {
+  /** Identity that owns the wallet to withdraw from. ``null`` follows global active identity. */
+  viewer?: ActiveIdentity | null;
   onClose: () => void;
   onSuccess: () => void;
   availableBalance: string;
@@ -22,10 +24,10 @@ function formatCoinAmount(minorStr: string): string {
   return major.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }
 
-export default function WithdrawDialog({ onClose, onSuccess, availableBalance }: WithdrawDialogProps) {
+export default function WithdrawDialog({ viewer, onClose, onSuccess, availableBalance }: WithdrawDialogProps) {
   const locale = useLanguage();
   const t = withdrawDialog[locale];
-  const isAuthedReady = useDashboardSessionStore((state) => state.sessionMode === "authed-ready");
+  const isAuthed = useDashboardSessionStore((state) => state.sessionMode !== "guest");
   const [amount, setAmount] = useState("");
   const [destinationType, setDestinationType] = useState<"bank" | "usdt_trc20" | "paypal">("bank");
   const [accountName, setAccountName] = useState("");
@@ -77,7 +79,7 @@ export default function WithdrawDialog({ onClose, onSuccess, availableBalance }:
       return;
     }
 
-    if (!isAuthedReady) return;
+    if (!isAuthed) return;
     setSubmitting(true);
     try {
       await api.createWithdrawal({
@@ -85,7 +87,7 @@ export default function WithdrawDialog({ onClose, onSuccess, availableBalance }:
         destination_type: destinationType,
         destination,
         idempotency_key: crypto.randomUUID(),
-      });
+      }, viewer);
       onSuccess();
     } catch (err) {
       if (err instanceof ApiError) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -191,7 +191,7 @@ async function getAccessToken(): Promise<string | null> {
   return session?.access_token ?? null;
 }
 
-async function buildAuthHeaders(): Promise<Record<string, string>> {
+async function buildAuthHeaders(identityOverride?: ActiveIdentity | null): Promise<Record<string, string>> {
   const headers: Record<string, string> = {};
   const token = await getAccessToken();
   if (token) {
@@ -199,7 +199,9 @@ async function buildAuthHeaders(): Promise<Record<string, string>> {
   }
   // New identity model: only send X-Active-Agent when acting as an agent.
   // For type='human', the backend resolves human_id from the Supabase JWT.
-  const identity = getActiveIdentity();
+  // `identityOverride` lets per-call code (e.g. wallet viewer switcher)
+  // address a different owned identity without mutating global session state.
+  const identity = identityOverride !== undefined ? identityOverride : getActiveIdentity();
   if (identity?.type === "agent") {
     headers["X-Active-Agent"] = identity.id;
   }
@@ -207,25 +209,30 @@ async function buildAuthHeaders(): Promise<Record<string, string>> {
 }
 
 /**
- * Pick the `?as=agent|human` query value for wallet APIs based on the
- * current active identity. Backend `_resolve_owner` uses this to choose
- * between `ctx.active_agent_id` (requires X-Active-Agent) and `ctx.human_id`
- * (resolved from Supabase JWT).
+ * Pick the `?as=agent|human` query value for wallet APIs based on a
+ * (possibly overridden) identity. Backend `_resolve_owner` uses this to
+ * choose between `ctx.active_agent_id` (requires X-Active-Agent) and
+ * `ctx.human_id` (resolved from Supabase JWT).
  */
-function currentWalletAs(): "agent" | "human" {
-  return getActiveIdentity()?.type === "human" ? "human" : "agent";
+function walletAsParam(identityOverride?: ActiveIdentity | null): "agent" | "human" {
+  const id = identityOverride !== undefined ? identityOverride : getActiveIdentity();
+  return id?.type === "human" ? "human" : "agent";
 }
 
 // --- Core request helpers ---
 
-async function apiGet<T>(path: string, params?: Record<string, string>): Promise<T> {
+async function apiGet<T>(
+  path: string,
+  params?: Record<string, string>,
+  identityOverride?: ActiveIdentity | null,
+): Promise<T> {
   const url = new URL(path, API_BASE);
   if (params) {
     Object.entries(params).forEach(([k, v]) => {
       if (v !== undefined && v !== null) url.searchParams.set(k, v);
     });
   }
-  const headers = await buildAuthHeaders();
+  const headers = await buildAuthHeaders(identityOverride);
   const res = await fetch(url.toString(), { headers });
   if (!res.ok) {
     const body = await res.json().catch(() => ({ error: res.statusText }));
@@ -234,8 +241,12 @@ async function apiGet<T>(path: string, params?: Record<string, string>): Promise
   return res.json();
 }
 
-async function apiPost<T>(path: string, body?: unknown): Promise<T> {
-  const headers: Record<string, string> = { ...(await buildAuthHeaders()) };
+async function apiPost<T>(
+  path: string,
+  body?: unknown,
+  identityOverride?: ActiveIdentity | null,
+): Promise<T> {
+  const headers: Record<string, string> = { ...(await buildAuthHeaders(identityOverride)) };
   const init: RequestInit = { method: "POST", headers };
   if (body !== undefined) {
     headers["Content-Type"] = "application/json";
@@ -578,37 +589,64 @@ export const api = {
   },
 
   // --- Wallet APIs ---
+  //
+  // All wallet methods accept an optional ``viewer`` (ActiveIdentity) so the
+  // wallet UI can switch between the user's owned identities (their human +
+  // owned bots) without mutating global session state. When omitted, the
+  // backend resolves the owner from the global active identity.
 
-  getWallet() {
-    return apiGet<WalletSummary>("/api/wallet/summary", { as: currentWalletAs() });
+  getWallet(viewer?: ActiveIdentity | null) {
+    return apiGet<WalletSummary>(
+      "/api/wallet/summary",
+      { as: walletAsParam(viewer) },
+      viewer,
+    );
   },
 
-  getWalletLedger(opts?: { cursor?: string; limit?: number }) {
-    const params: Record<string, string> = { as: currentWalletAs() };
+  getWalletLedger(opts?: { cursor?: string; limit?: number; viewer?: ActiveIdentity | null }) {
+    const params: Record<string, string> = { as: walletAsParam(opts?.viewer) };
     if (opts?.cursor) params.cursor = opts.cursor;
     if (opts?.limit) params.limit = String(opts.limit);
-    return apiGet<WalletLedgerResponse>("/api/wallet/ledger", params);
+    return apiGet<WalletLedgerResponse>("/api/wallet/ledger", params, opts?.viewer);
   },
 
-  createTransfer(payload: CreateTransferRequest) {
-    return apiPost<WalletTransaction>(`/api/wallet/transfers?as=${currentWalletAs()}`, payload);
+  createTransfer(payload: CreateTransferRequest, viewer?: ActiveIdentity | null) {
+    return apiPost<WalletTransaction>(
+      `/api/wallet/transfers?as=${walletAsParam(viewer)}`,
+      payload,
+      viewer,
+    );
   },
 
-  createTopup(payload: CreateTopupRequest) {
-    return apiPost<TopupResponse>(`/api/wallet/topups?as=${currentWalletAs()}`, payload);
+  createTopup(payload: CreateTopupRequest, viewer?: ActiveIdentity | null) {
+    return apiPost<TopupResponse>(
+      `/api/wallet/topups?as=${walletAsParam(viewer)}`,
+      payload,
+      viewer,
+    );
   },
 
-  createWithdrawal(payload: CreateWithdrawalRequest) {
-    return apiPost<WithdrawalResponse>(`/api/wallet/withdrawals?as=${currentWalletAs()}`, payload);
+  createWithdrawal(payload: CreateWithdrawalRequest, viewer?: ActiveIdentity | null) {
+    return apiPost<WithdrawalResponse>(
+      `/api/wallet/withdrawals?as=${walletAsParam(viewer)}`,
+      payload,
+      viewer,
+    );
   },
 
-  getWithdrawals() {
-    return apiGet<WithdrawalListResponse>("/api/wallet/withdrawals", { as: currentWalletAs() });
+  getWithdrawals(viewer?: ActiveIdentity | null) {
+    return apiGet<WithdrawalListResponse>(
+      "/api/wallet/withdrawals",
+      { as: walletAsParam(viewer) },
+      viewer,
+    );
   },
 
-  cancelWithdrawal(withdrawalId: string) {
+  cancelWithdrawal(withdrawalId: string, viewer?: ActiveIdentity | null) {
     return apiPost<{ withdrawal_id: string; status: string }>(
-      `/api/wallet/withdrawals/${withdrawalId}/cancel?as=${currentWalletAs()}`,
+      `/api/wallet/withdrawals/${withdrawalId}/cancel?as=${walletAsParam(viewer)}`,
+      undefined,
+      viewer,
     );
   },
 
@@ -618,18 +656,23 @@ export const api = {
     return apiGet<StripePackageResponse>("/api/wallet/stripe/packages");
   },
 
-  createStripeCheckoutSession(payload: StripeCheckoutRequest) {
+  createStripeCheckoutSession(payload: StripeCheckoutRequest, viewer?: ActiveIdentity | null) {
     return apiPost<StripeCheckoutResponse>(
-      `/api/wallet/stripe/checkout-session?as=${currentWalletAs()}`,
+      `/api/wallet/stripe/checkout-session?as=${walletAsParam(viewer)}`,
       payload,
+      viewer,
     );
   },
 
-  getStripeSessionStatus(sessionId: string) {
-    return apiGet<StripeSessionStatusResponse>("/api/wallet/stripe/session-status", {
-      session_id: sessionId,
-      as: currentWalletAs(),
-    });
+  getStripeSessionStatus(sessionId: string, viewer?: ActiveIdentity | null) {
+    return apiGet<StripeSessionStatusResponse>(
+      "/api/wallet/stripe/session-status",
+      {
+        session_id: sessionId,
+        as: walletAsParam(viewer),
+      },
+      viewer,
+    );
   },
 
   // --- Subscriptions ---

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -988,6 +988,9 @@ export const walletPanel: TranslationMap<{
   cancelWithdrawalConfirm: string
   cancelWithdrawalSuccess: string
   cancelWithdrawalFailed: string
+  viewingWalletFor: string
+  youHuman: string
+  botPrefix: string
 }> = {
   en: {
     wallet: 'Wallet',
@@ -1016,6 +1019,9 @@ export const walletPanel: TranslationMap<{
     cancelWithdrawalConfirm: 'Cancel this pending withdrawal request?',
     cancelWithdrawalSuccess: 'Withdrawal request cancelled.',
     cancelWithdrawalFailed: 'Failed to cancel withdrawal request',
+    viewingWalletFor: 'Viewing',
+    youHuman: 'You (Human)',
+    botPrefix: 'Bot',
   },
   zh: {
     wallet: '钱包',
@@ -1044,6 +1050,9 @@ export const walletPanel: TranslationMap<{
     cancelWithdrawalConfirm: '确认撤销这笔待审核提现吗？',
     cancelWithdrawalSuccess: '提现申请已撤销。',
     cancelWithdrawalFailed: '撤销提现申请失败',
+    viewingWalletFor: '查看',
+    youHuman: '我（Human）',
+    botPrefix: 'Bot',
   },
 }
 
@@ -1138,12 +1147,17 @@ export const transferDialog: TranslationMap<{
   transferFailed: string
   sending: string
   sendTransfer: string
+  pickRecipient: string
+  pickRecipientDefault: string
+  groupMyBots: string
+  groupContacts: string
+  groupHumanSelf: string
 }> = {
   en: {
     transfer: 'Transfer',
     sendCoins: 'Send coins to another agent',
     recipientAgentId: 'Recipient Agent ID',
-    recipientPlaceholder: 'ag_...',
+    recipientPlaceholder: 'ag_... or hu_...',
     amountCoin: 'Amount (COIN)',
     memoOptional: 'Memo (optional)',
     memoPlaceholder: 'What is this for?',
@@ -1153,12 +1167,17 @@ export const transferDialog: TranslationMap<{
     transferFailed: 'Transfer failed',
     sending: 'Sending...',
     sendTransfer: 'Send Transfer',
+    pickRecipient: 'Quick pick',
+    pickRecipientDefault: 'Choose a recipient',
+    groupMyBots: 'My Bots',
+    groupContacts: 'Contacts',
+    groupHumanSelf: 'Me (Human)',
   },
   zh: {
     transfer: '转账',
     sendCoins: '向另一个 Agent 发送代币',
     recipientAgentId: '接收者 Agent ID',
-    recipientPlaceholder: 'ag_...',
+    recipientPlaceholder: 'ag_... 或 hu_...',
     amountCoin: '金额 (COIN)',
     memoOptional: '备注（可选）',
     memoPlaceholder: '这笔转账用于？',
@@ -1168,6 +1187,11 @@ export const transferDialog: TranslationMap<{
     transferFailed: '转账失败',
     sending: '发送中...',
     sendTransfer: '发送转账',
+    pickRecipient: '快捷选择',
+    pickRecipientDefault: '选择收款方',
+    groupMyBots: '我的 Bot',
+    groupContacts: '联系人',
+    groupHumanSelf: '我（Human）',
   },
 }
 

--- a/frontend/src/store/useDashboardWalletStore.ts
+++ b/frontend/src/store/useDashboardWalletStore.ts
@@ -6,6 +6,7 @@
  */
 
 import { create } from "zustand";
+import type { ActiveIdentity } from "@/lib/api";
 import type { WalletLedgerEntry, WalletSummary, WithdrawalResponse } from "@/lib/types";
 import { api } from "@/lib/api";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
@@ -23,8 +24,16 @@ interface DashboardWalletState {
   withdrawalRequestsError: string | null;
   withdrawalRequestsLoaded: boolean;
   walletView: "overview" | "ledger";
+  /**
+   * Per-tab override for which owned identity's wallet to display. ``null``
+   * means follow the global active identity. The wallet UI lets the user
+   * switch between their human + each owned bot without mutating the
+   * dashboard-wide active identity (chat / contacts stay where they were).
+   */
+  walletViewer: ActiveIdentity | null;
 
   setWalletView: (view: DashboardWalletState["walletView"]) => void;
+  setWalletViewer: (viewer: ActiveIdentity | null) => void;
   resetWalletState: () => void;
   loadWallet: () => Promise<void>;
   loadWalletLedger: (loadMore?: boolean) => Promise<void>;
@@ -44,6 +53,7 @@ const initialWalletState = {
   withdrawalRequestsError: null,
   withdrawalRequestsLoaded: false,
   walletView: "overview" as const,
+  walletViewer: null as ActiveIdentity | null,
 };
 
 function getToken(): string | null {
@@ -55,12 +65,23 @@ export const useDashboardWalletStore = create<DashboardWalletState>()((set, get)
 
   setWalletView: (view) => set({ walletView: view }),
 
+  setWalletViewer: (viewer) => {
+    // Clear all loaded data so the next bootstrap re-fetches against the
+    // newly-selected owner. Preserve the viewer + the chosen sub-tab.
+    set({
+      ...initialWalletState,
+      walletView: get().walletView,
+      walletViewer: viewer,
+    });
+  },
+
   resetWalletState: () => set({ ...initialWalletState }),
 
   loadWallet: async () => {
     if (!getToken()) return;
+    const viewer = get().walletViewer;
     try {
-      const wallet = await api.getWallet();
+      const wallet = await api.getWallet(viewer);
       set({ wallet, walletError: null });
     } catch (err: any) {
       set({ walletError: err.message || "Failed to load wallet" });
@@ -69,11 +90,15 @@ export const useDashboardWalletStore = create<DashboardWalletState>()((set, get)
 
   loadWalletLedger: async (loadMore = false) => {
     if (!getToken()) return;
-    const { walletLedgerCursor, walletLedger } = get();
+    const { walletLedgerCursor, walletLedger, walletViewer } = get();
     set({ walletLoading: true });
     try {
       const cursor = loadMore ? walletLedgerCursor : undefined;
-      const result = await api.getWalletLedger({ cursor: cursor ?? undefined, limit: 20 });
+      const result = await api.getWalletLedger({
+        cursor: cursor ?? undefined,
+        limit: 20,
+        viewer: walletViewer,
+      });
       if (loadMore) {
         set({
           walletLedger: [...walletLedger, ...result.entries],
@@ -96,9 +121,10 @@ export const useDashboardWalletStore = create<DashboardWalletState>()((set, get)
 
   loadWithdrawalRequests: async () => {
     if (!getToken()) return;
+    const viewer = get().walletViewer;
     set({ withdrawalRequestsLoading: true, withdrawalRequestsError: null });
     try {
-      const result = await api.getWithdrawals();
+      const result = await api.getWithdrawals(viewer);
       set({
         withdrawalRequests: result.withdrawals,
         withdrawalRequestsLoaded: true,


### PR DESCRIPTION
## Summary

Two wallet UX improvements that share the same plumbing.

### 1) Owner switcher in WalletPanel header

Users with multiple owned identities (their human + N owned bots) can pick which wallet to view from a dropdown — without changing the dashboard-wide active identity. Chat / contacts / overview stay where they were.

- \`useDashboardWalletStore\` gains \`walletViewer\` (per-tab override) and \`setWalletViewer\` (resets loaded state + triggers re-bootstrap).
- All wallet API methods accept an optional \`viewer: ActiveIdentity | null\` and thread it through:
  - \`buildAuthHeaders\` overrides \`X-Active-Agent\`.
  - \`?as=agent|human\` query selects \`ctx.active_agent_id\` vs \`ctx.human_id\` in \`backend/app/routers/wallet.py:_resolve_owner\`.
- Backend already validates that \`X-Active-Agent\` belongs to the authenticated supabase user (\`backend/app/auth.py:281-288\`) — addressing an owned bot's wallet is a frontend-only change.
- Topup, Withdraw, Cancel-withdrawal, Stripe checkout / session-status all flow through the same viewer.

### 2) Quick-pick recipient in TransferDialog

Adds a grouped \`<select>\` above the free-form Recipient ID input:

- **Me (Human)** — the user's own \`hu_*\` (when not the sender).
- **My Bots** — every owned agent except the sender.
- **Contacts** — current overview's contact list (agents and human peers; \`contact_agent_id\` already covers both).

Selecting an option fills the Recipient ID field; users can still paste an arbitrary \`ag_*\` / \`hu_*\` id. Backend \`_assert_owner_exists\` accepts both prefixes.

### Auxiliary

Relaxed the \`isAuthedReady\` gate in Topup/Withdraw/Transfer dialogs to \`sessionMode !== \"guest\"\` so human-only sessions (\`authed-no-agent\`) can submit. Their wallet is correctly addressed by \`?as=human\`.

## Test plan

- [ ] Owner switcher shows when user has human + ≥1 bots; hidden otherwise.
- [ ] Switching the dropdown reloads balance, ledger, and recent withdrawals for that owner.
- [ ] Topup, Withdraw, Transfer-from, Cancel-withdrawal all act on the currently-viewed owner (not the global active identity).
- [ ] Switching global active identity (agent ↔ human) snaps walletViewer back to default (= new active identity).
- [ ] Transfer recipient picker: human self / owned bot / contact each populate the Recipient ID; send succeeds; sender excluded from the list.
- [ ] Free-form recipient input still works for arbitrary \`ag_*\` / \`hu_*\` id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)