### PR TITLE
fix(dashboard): allow @-mentioning human members in group rooms

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -2337,8 +2337,8 @@ async def human_room_send(
     _record_slow_mode_send(room_id, sender_id)
 
     # Normalize mentions. Owner-chat rooms (rm_oc_) ignore mentions entirely.
-    # Human sends may mention specific agent_ids or the special "@all" token;
-    # any other non-"ag_" string is dropped. Cap at 20 to avoid abuse.
+    # Human sends may mention agent_ids (ag_*), human_ids (hu_*) or the special
+    # "@all" token; anything else is dropped. Cap at 20 to avoid abuse.
     raw_mentions = body.mentions or []
     if room_id.startswith("rm_oc_"):
         raw_mentions = []
@@ -2353,7 +2353,7 @@ async def human_room_send(
             normalized_mentions = ["@all"]
             seen_mentions.add(m)
             break
-        if not m.startswith("ag_"):
+        if not (m.startswith("ag_") or m.startswith("hu_")):
             continue
         seen_mentions.add(m)
         normalized_mentions.append(m)

--- a/backend/tests/test_dashboard_rooms_human_send.py
+++ b/backend/tests/test_dashboard_rooms_human_send.py
@@ -584,6 +584,44 @@ async def test_mentions_allow_at_all_and_drop_other_non_ag_prefix(
 
 
 @pytest.mark.asyncio
+async def test_mentions_allow_human_id(
+    client: AsyncClient, seed: dict, db_session: AsyncSession
+):
+    # Add Carol (uid3) as a Human RoomMember in rm_humanroom so she can be @-mentioned.
+    user_row = await db_session.execute(
+        select(User).where(User.email == "c@x.com")
+    )
+    carol = user_row.scalar_one()
+    carol_human_id = carol.human_id
+    assert carol_human_id and carol_human_id.startswith("hu_")
+    db_session.add(
+        RoomMember(
+            room_id="rm_humanroom",
+            agent_id=carol_human_id,
+            participant_type=ParticipantType.human,
+            role=RoomRole.member,
+        )
+    )
+    await db_session.commit()
+
+    r = await client.post(
+        "/api/dashboard/rooms/rm_humanroom/send",
+        headers=_h(seed["token1"], seed["agent1"]),
+        json={"text": f"hey @{carol.display_name}", "mentions": [carol_human_id]},
+    )
+    assert r.status_code == 202, r.text
+
+    rows = (await db_session.execute(
+        select(MessageRecord).where(MessageRecord.room_id == "rm_humanroom")
+    )).scalars().all()
+    by_receiver = {r.receiver_id: r for r in rows}
+    assert by_receiver[carol_human_id].mentioned is True
+    assert by_receiver["ag_user1___"].mentioned is False
+    env = json.loads(by_receiver[carol_human_id].envelope_json)
+    assert env["mentions"] == [carol_human_id]
+
+
+@pytest.mark.asyncio
 async def test_mentions_cap_at_20(client: AsyncClient, seed: dict):
     too_many = [f"ag_x{i:08d}" for i in range(21)]
     r = await client.post(

--- a/frontend/src/components/dashboard/RoomHumanComposer.tsx
+++ b/frontend/src/components/dashboard/RoomHumanComposer.tsx
@@ -64,7 +64,7 @@ export default function RoomHumanComposer({ roomId }: RoomHumanComposerProps) {
   const mentionCandidates = useMemo<MentionCandidate[]>(() => {
     if (!allowAllMention) return [];
     const roomCandidates = members
-      .filter((m) => m.agent_id !== selfId && m.agent_id.startsWith("ag_"))
+      .filter((m) => m.agent_id !== selfId && (m.agent_id.startsWith("ag_") || m.agent_id.startsWith("hu_")))
       .map((m) => ({ agent_id: m.agent_id, display_name: m.display_name }));
     return [{ agent_id: "@all", display_name: "all" }, ...roomCandidates];
   }, [members, selfId, allowAllMention]);


### PR DESCRIPTION
## Summary
- Group-chat composer now lists `hu_*` room members in the @ candidate dropdown alongside `ag_*` agents.
- Human-send endpoint (`/api/dashboard/rooms/{room_id}/send`) accepts `hu_*` mentions in addition to `ag_*` and `@all`.
- Per-receiver `mentioned` flag + room-membership filter remain unchanged, so security and fan-out behavior are preserved.

## Why
Human members (the user themselves and other room participants who joined as humans) couldn't be @-mentioned. Backend fan-out and Supabase realtime topic routing already handle `hu_*` receivers correctly — the only blockers were the prefix filter at `backend/app/routers/dashboard.py:2356` and the candidate filter at `frontend/src/components/dashboard/RoomHumanComposer.tsx:67`.

## Test plan
- [x] `uv run pytest tests/test_dashboard_rooms_human_send.py` (26/26 pass, includes new `test_mentions_allow_human_id`)
- [ ] Open a group room with at least one human member, type `@`, verify the human appears in the dropdown
- [ ] Pick the human and send — verify the resulting message envelope's `mentions` contains the `hu_*` id and the human's `MessageRecord.mentioned` is `True`
- [ ] Verify owner-chat (`rm_oc_*`) still ignores mentions and DM rooms still hide the dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)