### PR TITLE
fix(backend): honor transitive ownership in human invite endpoints

### DIFF
--- a/backend/app/routers/humans.py
+++ b/backend/app/routers/humans.py
@@ -1042,7 +1042,9 @@ async def create_room_invite_as_human(
     )
     if inviter is None:
         raise HTTPException(status_code=403, detail="Not a member of this room")
-    if inviter.role not in (RoomRole.owner, RoomRole.admin) and not bool(
+    owned_agent_ids = await _load_owned_agent_ids(db, ctx.user_id)
+    effective_role = _effective_human_role(inviter.role, room, owned_agent_ids)
+    if effective_role not in (RoomRole.owner, RoomRole.admin) and not bool(
         inviter.can_invite or room.default_invite
     ):
         raise HTTPException(
@@ -1119,8 +1121,10 @@ async def invite_room_member_as_human(
     inviter = inviter_row.scalar_one_or_none()
     if inviter is None:
         raise HTTPException(status_code=403, detail="Not a member of this room")
+    owned_agent_ids = await _load_owned_agent_ids(db, ctx.user_id)
+    effective_role = _effective_human_role(inviter.role, room, owned_agent_ids)
     can_invite = (
-        inviter.role in (RoomRole.owner, RoomRole.admin)
+        effective_role in (RoomRole.owner, RoomRole.admin)
         or inviter.can_invite
         or room.default_invite
     )

--- a/backend/tests/test_app/test_app_humans.py
+++ b/backend/tests/test_app/test_app_humans.py
@@ -821,6 +821,118 @@ async def test_invite_members_endpoint_rejects_bad_prefix(client, seed):
 
 
 @pytest.mark.asyncio
+async def test_invite_members_endpoint_transitive_owner_can_invite(
+    client, seed, db_session: AsyncSession
+):
+    """A Human who owns the agent that owns the room can invite even when
+    default_invite=False and their RoomMember.role is plain 'member'.
+
+    Regression: previously the handler checked raw ``inviter.role`` and
+    refused with "You don't have permission to invite members".
+    """
+    db_session.add_all([
+        Agent(
+            agent_id="ag_owner00001",
+            display_name="Owner Bot",
+            message_policy=MessagePolicy.open,
+            user_id=seed["user_id"],
+        ),
+        Room(
+            room_id="rm_transitive",
+            name="Transitive owner room",
+            description="",
+            owner_id="ag_owner00001",
+            owner_type=ParticipantType.agent,
+            visibility=RoomVisibility.private,
+            join_policy=RoomJoinPolicy.invite_only,
+            default_invite=False,
+        ),
+        Agent(
+            agent_id="ag_invitee0001",
+            display_name="Invitee",
+            message_policy=MessagePolicy.open,
+            user_id=None,
+        ),
+    ])
+    await db_session.flush()
+    db_session.add_all([
+        RoomMember(
+            room_id="rm_transitive",
+            agent_id="ag_owner00001",
+            participant_type=ParticipantType.agent,
+            role=RoomRole.owner,
+        ),
+        RoomMember(
+            room_id="rm_transitive",
+            agent_id=seed["human_id"],
+            participant_type=ParticipantType.human,
+            role=RoomRole.member,
+        ),
+    ])
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/humans/me/rooms/rm_transitive/members",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+        json={"participant_id": "ag_invitee0001"},
+    )
+    assert resp.status_code == 201, resp.text
+
+
+@pytest.mark.asyncio
+async def test_invite_link_endpoint_transitive_owner_can_create(
+    client, seed, db_session: AsyncSession
+):
+    """Same regression for the invite-link path:
+    POST /api/humans/me/rooms/{room_id}/invite must accept the human
+    when their owned agent is the room owner.
+    """
+    db_session.add_all([
+        Agent(
+            agent_id="ag_owner00002",
+            display_name="Owner Bot 2",
+            message_policy=MessagePolicy.open,
+            user_id=seed["user_id"],
+        ),
+        Room(
+            room_id="rm_transitive_link",
+            name="Transitive link room",
+            description="",
+            owner_id="ag_owner00002",
+            owner_type=ParticipantType.agent,
+            visibility=RoomVisibility.private,
+            join_policy=RoomJoinPolicy.invite_only,
+            default_invite=False,
+        ),
+    ])
+    await db_session.flush()
+    db_session.add_all([
+        RoomMember(
+            room_id="rm_transitive_link",
+            agent_id="ag_owner00002",
+            participant_type=ParticipantType.agent,
+            role=RoomRole.owner,
+        ),
+        RoomMember(
+            room_id="rm_transitive_link",
+            agent_id=seed["human_id"],
+            participant_type=ParticipantType.human,
+            role=RoomRole.member,
+        ),
+    ])
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/humans/me/rooms/rm_transitive_link/invite",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+        json={},
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["code"].startswith("iv_")
+
+
+@pytest.mark.asyncio
 async def test_invite_members_endpoint_409_on_duplicate(
     client, seed, db_session: AsyncSession
 ):


### PR DESCRIPTION
## Summary
- `POST /api/humans/me/rooms/{id}/members` and `POST /api/humans/me/rooms/{id}/invite` checked the raw `RoomMember.role` of the human caller. When a human owns the agent that owns the room, the human is seated as a regular member (`role=member`), so the owner branch was skipped and `default_invite=false` rooms returned 403 with "You don't have permission to invite members".
- Dashboard already promotes the human to `my_role=owner` for the same room (`_effective_human_role` is used by `list_human_rooms` and the PATCH room handler), so the UI shows the Invite button while the backend rejects the action — frontend/backend mismatch.
- Fix: reuse the existing `_effective_human_role` helper inside both invite handlers to compute the promoted role before the permission check.

## Test plan
- [x] `uv run pytest tests/test_app/test_app_humans.py tests/test_app/test_human_owner_subscription.py tests/test_room.py` — 172 passed, 1 skipped
- [x] New regression tests cover both endpoints with `room.owner_type=agent`, `room.owner_id` ∈ caller's owned agents, `default_invite=False`, human seated as `RoomMember(role=member)`
- [ ] Manual: in dashboard human view, uncheck "members can invite" on a room owned by your agent → owner can still invite

🤖 Generated with [Claude Code](https://claude.com/claude-code)