### PR TITLE
fix(daemon): surface OpenClaw gateway auth failures

### DIFF
--- a/packages/daemon/src/__tests__/openclaw-discovery.test.ts
+++ b/packages/daemon/src/__tests__/openclaw-discovery.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   defaultOpenclawDiscoveryPorts,
+  defaultOpenclawDiscoveryTokenFilePaths,
   discoverLocalOpenclawGateways,
   mergeOpenclawGateways,
 } from "../openclaw-discovery.js";
@@ -218,6 +219,49 @@ describe("discoverLocalOpenclawGateways", () => {
         source: "default-port",
       }),
     ]);
+  });
+
+  it("attaches conventional tokenFile fallback to default-port discovery", async () => {
+    const home = tempDir();
+    const prevHome = process.env.HOME;
+    process.env.HOME = home;
+    mkdirSync(path.join(home, ".openclaw"), { recursive: true });
+    const tokenFile = path.join(home, ".openclaw", "gateway-token");
+    writeFileSync(tokenFile, "gateway-token\n");
+    const probe = vi.fn<WsEndpointProbeFn>(async () => ({
+      ok: true,
+      agents: [],
+    }));
+
+    try {
+      const found = await discoverLocalOpenclawGateways({
+        searchPaths: [],
+        defaultPorts: [16200],
+        probe,
+        timeoutMs: 10,
+        env: {},
+      });
+
+      expect(defaultOpenclawDiscoveryTokenFilePaths()).toEqual(
+        expect.arrayContaining(["~/.openclaw/gateway-token"]),
+      );
+      expect(probe).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "ws://127.0.0.1:16200",
+          token: "gateway-token",
+        }),
+      );
+      expect(found).toEqual([
+        expect.objectContaining({
+          url: "ws://127.0.0.1:16200",
+          tokenFile: "~/.openclaw/gateway-token",
+          source: "default-port",
+        }),
+      ]);
+    } finally {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+    }
   });
 
   it("prefers config-file auth details over lower-priority duplicate sources", async () => {

--- a/packages/daemon/src/__tests__/runtime-discovery.test.ts
+++ b/packages/daemon/src/__tests__/runtime-discovery.test.ts
@@ -194,6 +194,46 @@ describe("collectRuntimeSnapshotAsync", () => {
       rmSync(tmp, { recursive: true, force: true });
     }
   });
+
+  it("reports missing_token when an OpenClaw gateway requires auth without a token", async () => {
+    setRuntimes([
+      {
+        id: "openclaw-acp",
+        displayName: "OpenClaw",
+        binary: "openclaw",
+        supportsRun: true,
+        result: { available: true },
+      },
+    ]);
+
+    const snap = await collectRuntimeSnapshotAsync({
+      cfg: {
+        openclawGateways: [{ name: "local", url: "ws://127.0.0.1:16200" }],
+      },
+      wsProbe: async () => ({
+        ok: false,
+        error: "unauthorized: gateway token missing (set gateway.remote.token to match gateway.auth.token)",
+      }),
+    });
+
+    const runtime = snap.runtimes.find((r) => r.id === "openclaw-acp");
+    expect(runtime?.endpoints).toEqual([
+      expect.objectContaining({
+        name: "local",
+        reachable: false,
+        status: "missing_token",
+        error:
+          "unauthorized: gateway token missing (set gateway.remote.token to match gateway.auth.token)",
+        diagnostics: [
+          {
+            code: "missing_token",
+            message:
+              "OpenClaw gateway requires token; configure OPENCLAW_GATEWAY_TOKEN or tokenFile",
+          },
+        ],
+      }),
+    ]);
+  });
 });
 
 interface FakeGateway {

--- a/packages/daemon/src/openclaw-discovery.ts
+++ b/packages/daemon/src/openclaw-discovery.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import type { DaemonConfig, OpenclawGatewayProfile } from "./config.js";
@@ -31,6 +31,11 @@ export interface MergeOpenclawGatewayResult {
 
 const DEFAULT_SEARCH_PATHS = ["~/.openclaw/", "/etc/openclaw/"];
 const DEFAULT_PORTS = [18789, 16200];
+const DEFAULT_TOKEN_FILE_PATHS = [
+  "/run/openclaw/gateway-token",
+  "/var/run/openclaw/gateway-token",
+  "~/.openclaw/gateway-token",
+];
 
 export async function discoverLocalOpenclawGateways(
   opts: OpenclawGatewayDiscoveryOptions = {},
@@ -42,7 +47,7 @@ export async function discoverLocalOpenclawGateways(
 
   const env = opts.env ?? process.env;
   found.push(...discoverFromEnv(env));
-  const envAuth = pickOpenclawEnvAuth(env);
+  const envAuth = pickOpenclawEnvAuth(env) ?? pickDefaultTokenFile();
 
   const ports = opts.defaultPorts ?? DEFAULT_PORTS;
   if (ports.length > 0) {
@@ -87,12 +92,19 @@ function discoverFromEnv(env: NodeJS.ProcessEnv): DiscoveredOpenclawGateway[] {
   ];
 }
 
-function pickOpenclawEnvAuth(env: NodeJS.ProcessEnv): { token?: string; tokenFile?: string } {
+function pickOpenclawEnvAuth(env: NodeJS.ProcessEnv): { token?: string; tokenFile?: string } | undefined {
   const token = pickEnv(env, "OPENCLAW_ACP_TOKEN") ?? pickEnv(env, "OPENCLAW_GATEWAY_TOKEN");
   if (token) return { token };
   const tokenFile =
     pickEnv(env, "OPENCLAW_ACP_TOKEN_FILE") ?? pickEnv(env, "OPENCLAW_GATEWAY_TOKEN_FILE");
   if (tokenFile) return { tokenFile };
+  return undefined;
+}
+
+function pickDefaultTokenFile(): { tokenFile?: string } {
+  for (const tokenFile of DEFAULT_TOKEN_FILE_PATHS) {
+    if (existsSync(expandHome(tokenFile))) return { tokenFile };
+  }
   return {};
 }
 
@@ -325,6 +337,10 @@ export function defaultOpenclawDiscoverySearchPaths(): string[] {
 
 export function defaultOpenclawDiscoveryPorts(): number[] {
   return DEFAULT_PORTS.slice();
+}
+
+export function defaultOpenclawDiscoveryTokenFilePaths(): string[] {
+  return DEFAULT_TOKEN_FILE_PATHS.slice();
 }
 
 export function openclawDiscoveryConfigEnabled(cfg: DaemonConfig): boolean {

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -1154,6 +1154,27 @@ export type WsEndpointProbeFn = (args: {
   error?: string;
 }>;
 
+export function classifyOpenclawAuthError(message: string | undefined): "missing_token" | "auth_required" | null {
+  const text = (message ?? "").toLowerCase();
+  if (!text) return null;
+  if (
+    text.includes("token missing") ||
+    text.includes("missing token") ||
+    text.includes("gateway token missing")
+  ) {
+    return "missing_token";
+  }
+  if (
+    text.includes("unauthorized") ||
+    text.includes("authentication required") ||
+    text.includes("auth required") ||
+    text.includes("missing auth")
+  ) {
+    return "auth_required";
+  }
+  return null;
+}
+
 /**
  * Default L2 + L3 probe — speaks OpenClaw's WS frame protocol against the
  * gateway and enumerates agent profiles via `agents.list`.
@@ -1278,7 +1299,8 @@ async function defaultWsProbe(args: {
       if (msg.id === CONNECT_ID) {
         if (!msg.ok) {
           const errMsg = msg.error?.message ? String(msg.error.message) : "connect rejected";
-          settle({ ok: true, error: errMsg });
+          const authStatus = classifyOpenclawAuthError(errMsg);
+          settle({ ok: authStatus ? false : true, error: errMsg });
           return;
         }
         const v = msg.payload?.server?.version;
@@ -1491,6 +1513,21 @@ export async function collectRuntimeSnapshotAsync(opts: {
           probe: opts.wsProbe,
           timeoutMs,
         });
+        const authStatus = classifyOpenclawAuthError(res.error);
+        if (!res.ok && authStatus) {
+          const message =
+            authStatus === "missing_token"
+              ? "OpenClaw gateway requires token; configure OPENCLAW_GATEWAY_TOKEN or tokenFile"
+              : "OpenClaw gateway requires authentication; configure gateway credentials";
+          return {
+            name: g.name,
+            url: g.url,
+            reachable: false,
+            status: authStatus,
+            error: res.error ?? message,
+            diagnostics: [{ code: authStatus, message }],
+          };
+        }
         const entry: any = {
           name: g.name,
           url: g.url,


### PR DESCRIPTION
## Summary
- discover conventional OpenClaw gateway token files when probing local default ports
- classify missing gateway token/auth failures instead of treating them as reachable endpoints
- expose missing_token diagnostics in runtime snapshots so setup fails clearly before ACP child startup

## Tests
- cd packages/daemon && npm test
- cd packages/daemon && npm run build