### PR TITLE
fix(wallet): default loads + post-Stripe polling for non-global viewers

### DIFF
--- a/frontend/src/components/dashboard/StripeReturnBanner.tsx
+++ b/frontend/src/components/dashboard/StripeReturnBanner.tsx
@@ -6,11 +6,18 @@ import type { StripeSessionStatusResponse } from "@/lib/types";
 import { useShallow } from "zustand/react/shallow";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardWalletStore } from "@/store/useDashboardWalletStore";
+import {
+  clearStripeTopupContext,
+  readStripeTopupContext,
+} from "@/lib/stripe-topup-context";
 
 type BannerMode = "success_polling" | "cancelled";
 
 export default function StripeReturnBanner() {
-  const isAuthedReady = useDashboardSessionStore((state) => state.sessionMode === "authed-ready");
+  // Relaxed from `authed-ready` to any authenticated session: human-only
+  // (`authed-no-agent`) sessions can also start a topup and need the same
+  // post-redirect polling.
+  const isAuthed = useDashboardSessionStore((state) => state.sessionMode !== "guest");
   const token = useDashboardSessionStore((state) => state.token);
   const { loadWallet, loadWalletLedger } = useDashboardWalletStore(useShallow((state) => ({
     loadWallet: state.loadWallet,
@@ -21,7 +28,7 @@ export default function StripeReturnBanner() {
   const [polling, setPolling] = useState(false);
 
   useEffect(() => {
-    if (!isAuthedReady) return;
+    if (!isAuthed) return;
 
     const params = new URLSearchParams(window.location.search);
     const walletTopup = params.get("wallet_topup");
@@ -36,21 +43,28 @@ export default function StripeReturnBanner() {
     window.history.replaceState({}, "", url.pathname + url.search);
 
     if (walletTopup === "cancelled") {
+      if (sessionId) clearStripeTopupContext(sessionId);
       setMode("cancelled");
       return;
     }
 
     if (walletTopup === "success" && sessionId) {
+      // Restore the wallet owner that started the checkout (saved by
+      // TopupDialog before redirect). Backend `get_checkout_status`
+      // requires the resolved owner to match the topup's owner_id, so
+      // polling without this would 403/404 for non-default viewers.
+      const topupViewer = readStripeTopupContext(sessionId);
       setMode("success_polling");
       setPolling(true);
 
       const poll = async () => {
         for (let i = 0; i < 10; i++) {
           try {
-            const res = await api.getStripeSessionStatus(sessionId);
+            const res = await api.getStripeSessionStatus(sessionId, topupViewer);
             setStatus(res);
             if (res.wallet_credited) {
               setPolling(false);
+              clearStripeTopupContext(sessionId);
               loadWallet();
               loadWalletLedger();
               return;
@@ -64,7 +78,7 @@ export default function StripeReturnBanner() {
       };
       poll();
     }
-  }, [isAuthedReady, token, loadWallet, loadWalletLedger]);
+  }, [isAuthed, token, loadWallet, loadWalletLedger]);
 
   if (!mode) return null;
 

--- a/frontend/src/components/dashboard/TopupDialog.tsx
+++ b/frontend/src/components/dashboard/TopupDialog.tsx
@@ -6,6 +6,7 @@ import { topupDialog } from '@/lib/i18n/translations/dashboard';
 import { api, ApiError, type ActiveIdentity } from "@/lib/api";
 import type { StripePackageItem } from "@/lib/types";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
+import { saveStripeTopupContext } from "@/lib/stripe-topup-context";
 import { Loader2 } from "lucide-react";
 
 function formatCoin(minorStr: string): string {
@@ -76,6 +77,10 @@ export default function TopupDialog({ viewer, onClose, onSuccess }: TopupDialogP
         idempotency_key: crypto.randomUUID(),
         quantity,
       }, viewer);
+      // Stash the viewer so StripeReturnBanner can poll status against the
+      // same owner after Stripe redirects back (the URL only carries the
+      // session_id; backend get_checkout_status requires a matching owner).
+      saveStripeTopupContext(res.checkout_session_id, viewer ?? null);
       window.location.assign(res.checkout_url);
     } catch (err) {
       if (err instanceof ApiError) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -201,7 +201,11 @@ async function buildAuthHeaders(identityOverride?: ActiveIdentity | null): Promi
   // For type='human', the backend resolves human_id from the Supabase JWT.
   // `identityOverride` lets per-call code (e.g. wallet viewer switcher)
   // address a different owned identity without mutating global session state.
-  const identity = identityOverride !== undefined ? identityOverride : getActiveIdentity();
+  // ``null`` and ``undefined`` both mean "no override — follow global active
+  // identity"; only a concrete ``ActiveIdentity`` overrides. The wallet
+  // store passes ``walletViewer`` (default ``null``) on every call and
+  // depends on this fallback to send X-Active-Agent for the global agent.
+  const identity = identityOverride ?? getActiveIdentity();
   if (identity?.type === "agent") {
     headers["X-Active-Agent"] = identity.id;
   }
@@ -212,10 +216,11 @@ async function buildAuthHeaders(identityOverride?: ActiveIdentity | null): Promi
  * Pick the `?as=agent|human` query value for wallet APIs based on a
  * (possibly overridden) identity. Backend `_resolve_owner` uses this to
  * choose between `ctx.active_agent_id` (requires X-Active-Agent) and
- * `ctx.human_id` (resolved from Supabase JWT).
+ * `ctx.human_id` (resolved from Supabase JWT). ``null``/``undefined``
+ * fall back to the global active identity (matching ``buildAuthHeaders``).
  */
 function walletAsParam(identityOverride?: ActiveIdentity | null): "agent" | "human" {
-  const id = identityOverride !== undefined ? identityOverride : getActiveIdentity();
+  const id = identityOverride ?? getActiveIdentity();
   return id?.type === "human" ? "human" : "agent";
 }
 

--- a/frontend/src/lib/stripe-topup-context.test.ts
+++ b/frontend/src/lib/stripe-topup-context.test.ts
@@ -1,0 +1,128 @@
+/**
+ * [INPUT]: 依赖 vitest 的伪 localStorage 与时间控制，验证 stripe-topup-context 的存取/过期/清理协议
+ * [OUTPUT]: 对外提供 stripe-topup-context helper 的回归护栏，锁定 viewer 透传 Stripe redirect 的关键不变量
+ * [POS]: frontend/lib 的纯函数测试，保证 wallet 多 owner 切换在跨 Stripe checkout 后仍能正确轮询
+ * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const STORAGE_KEY = "botcord_stripe_topup_contexts_v1";
+const TTL_MS = 30 * 60 * 1000;
+
+// vitest.config.ts pins `environment: 'node'`, which has no `window`. The
+// helper short-circuits when `window` is undefined, so we install a minimal
+// localStorage-backed fake before importing the module under test, and
+// re-import per test so each starts from a clean slate.
+function installFakeWindow(): { storage: Record<string, string> } {
+  const storage: Record<string, string> = {};
+  (globalThis as unknown as { window: unknown }).window = {
+    localStorage: {
+      getItem: (k: string) => (k in storage ? storage[k] : null),
+      setItem: (k: string, v: string) => { storage[k] = v; },
+      removeItem: (k: string) => { delete storage[k]; },
+      clear: () => { for (const k of Object.keys(storage)) delete storage[k]; },
+    },
+  };
+  return { storage };
+}
+
+function uninstallFakeWindow() {
+  delete (globalThis as unknown as { window?: unknown }).window;
+}
+
+async function loadModule() {
+  // Force a fresh module so each test runs against the freshly-installed
+  // fake window (the module reads `typeof window` once at use time, so this
+  // isn't strictly required, but it isolates module-level caching if any
+  // is ever introduced).
+  vi.resetModules();
+  return await import("./stripe-topup-context");
+}
+
+let storageRef: { storage: Record<string, string> };
+
+beforeEach(() => {
+  storageRef = installFakeWindow();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  uninstallFakeWindow();
+});
+
+describe("stripe-topup-context", () => {
+  it("returns the saved viewer for a known sessionId", async () => {
+    const { saveStripeTopupContext, readStripeTopupContext } = await loadModule();
+    const viewer = { type: "agent" as const, id: "ag_test" };
+    saveStripeTopupContext("cs_abc", viewer);
+
+    expect(readStripeTopupContext("cs_abc")).toEqual(viewer);
+  });
+
+  it("returns null for an unknown sessionId", async () => {
+    const { saveStripeTopupContext, readStripeTopupContext } = await loadModule();
+    saveStripeTopupContext("cs_abc", { type: "human", id: "hu_x" });
+    expect(readStripeTopupContext("cs_other")).toBeNull();
+  });
+
+  it("preserves null viewer (= follow global identity)", async () => {
+    const { saveStripeTopupContext, readStripeTopupContext } = await loadModule();
+    saveStripeTopupContext("cs_abc", null);
+    // The helper returns the stored viewer directly, so a null viewer
+    // resolves to null — the banner reads "no override → follow global".
+    expect(readStripeTopupContext("cs_abc")).toBeNull();
+    // The entry must still exist in storage; absence of an entry would
+    // also produce null, but we want to verify the entry is *present*
+    // so a follow-up clear could remove it.
+    expect(storageRef.storage[STORAGE_KEY]).toContain("cs_abc");
+  });
+
+  it("clear removes the entry", async () => {
+    const { saveStripeTopupContext, readStripeTopupContext, clearStripeTopupContext } = await loadModule();
+    saveStripeTopupContext("cs_abc", { type: "agent", id: "ag_x" });
+    clearStripeTopupContext("cs_abc");
+    expect(readStripeTopupContext("cs_abc")).toBeNull();
+    const raw = storageRef.storage[STORAGE_KEY] ?? "";
+    expect(raw).not.toContain("cs_abc");
+  });
+
+  it("expired entries are returned as null and pruned", async () => {
+    const { saveStripeTopupContext, readStripeTopupContext } = await loadModule();
+    saveStripeTopupContext("cs_old", { type: "agent", id: "ag_x" });
+
+    vi.advanceTimersByTime(TTL_MS + 1000);
+
+    expect(readStripeTopupContext("cs_old")).toBeNull();
+    const raw = storageRef.storage[STORAGE_KEY] ?? "";
+    expect(raw).not.toContain("cs_old");
+  });
+
+  it("save prunes other expired entries to keep the bag bounded", async () => {
+    const { saveStripeTopupContext } = await loadModule();
+    saveStripeTopupContext("cs_old", { type: "agent", id: "ag_old" });
+
+    vi.advanceTimersByTime(TTL_MS + 1000);
+
+    saveStripeTopupContext("cs_new", { type: "agent", id: "ag_new" });
+
+    const raw = storageRef.storage[STORAGE_KEY] ?? "";
+    expect(raw).toContain("cs_new");
+    expect(raw).not.toContain("cs_old");
+  });
+
+  it("tolerates corrupted JSON in localStorage", async () => {
+    storageRef.storage[STORAGE_KEY] = "{not json";
+    const { saveStripeTopupContext, readStripeTopupContext } = await loadModule();
+    expect(readStripeTopupContext("cs_abc")).toBeNull();
+    saveStripeTopupContext("cs_new", { type: "agent", id: "ag_new" });
+    expect(readStripeTopupContext("cs_new")).toEqual({ type: "agent", id: "ag_new" });
+  });
+
+  it("save with empty sessionId is a no-op", async () => {
+    const { saveStripeTopupContext } = await loadModule();
+    saveStripeTopupContext("", { type: "agent", id: "ag_x" });
+    expect(storageRef.storage[STORAGE_KEY]).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/stripe-topup-context.ts
+++ b/frontend/src/lib/stripe-topup-context.ts
@@ -1,0 +1,79 @@
+/**
+ * [INPUT]: 依赖浏览器 localStorage 暂存 Stripe checkout 期间的钱包 owner 上下文
+ * [OUTPUT]: 对外提供 saveStripeTopupContext / readStripeTopupContext / clearStripeTopupContext，把发起 topup 时的 viewer 信息透传到 Stripe 跳转返回后的 session-status 轮询
+ * [POS]: 解决跨 Stripe redirect 的状态丢失：发起方钱包归属在 redirect 前已知（来自 wallet store 的 viewer），但回到页面时 URL 只带了 session_id，需要复原 viewer 才能正确轮询
+ * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
+ */
+
+import type { ActiveIdentity } from "@/lib/api";
+
+const STORAGE_KEY = "botcord_stripe_topup_contexts_v1";
+const TTL_MS = 30 * 60 * 1000; // 30 min — Stripe checkout sessions expire in this range
+
+interface StoredEntry {
+  viewer: ActiveIdentity | null;
+  ts: number;
+}
+
+type ContextMap = Record<string, StoredEntry>;
+
+function readMap(): ContextMap {
+  if (typeof window === "undefined") return {};
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object") return parsed as ContextMap;
+  } catch {
+    // fall through to {} — corrupted entries are harmless beyond a missed
+    // refetch; the next save will overwrite.
+  }
+  return {};
+}
+
+function writeMap(map: ContextMap): void {
+  if (typeof window === "undefined") return;
+  // Drop expired entries on every write so the bag doesn't grow.
+  const now = Date.now();
+  const pruned: ContextMap = {};
+  for (const [k, v] of Object.entries(map)) {
+    if (now - v.ts < TTL_MS) pruned[k] = v;
+  }
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(pruned));
+  } catch {
+    // localStorage may be full / unavailable; non-fatal.
+  }
+}
+
+/** Remember the viewer that started this Stripe checkout session. */
+export function saveStripeTopupContext(sessionId: string, viewer: ActiveIdentity | null): void {
+  if (!sessionId) return;
+  const map = readMap();
+  map[sessionId] = { viewer: viewer ?? null, ts: Date.now() };
+  writeMap(map);
+}
+
+/** Look up the viewer that started a Stripe session. ``null`` means "follow global identity". */
+export function readStripeTopupContext(sessionId: string): ActiveIdentity | null {
+  if (!sessionId) return null;
+  const map = readMap();
+  const entry = map[sessionId];
+  if (!entry) return null;
+  if (Date.now() - entry.ts >= TTL_MS) {
+    delete map[sessionId];
+    writeMap(map);
+    return null;
+  }
+  return entry.viewer;
+}
+
+/** Drop the entry once polling resolves so localStorage doesn't accumulate. */
+export function clearStripeTopupContext(sessionId: string): void {
+  if (!sessionId) return;
+  const map = readMap();
+  if (sessionId in map) {
+    delete map[sessionId];
+    writeMap(map);
+  }
+}


### PR DESCRIPTION
## Summary

Two regressions surfaced after #422 shipped — both reachable as soon as the user opens \`/chats/wallet\` in production. The follow-up fix on PR #422 didn't actually land (squash merged before the second commit was pushed), so re-applying here.

### P1 — default wallet loads bypass the global agent identity

Confirmed in prod via \`GET /api/wallet/summary?as=agent\` returning \`400 X-Active-Agent header is required when as=agent\`.

Root cause: \`useDashboardWalletStore.{loadWallet,loadWalletLedger,loadWithdrawalRequests}\` pass \`walletViewer\` (default \`null\`) directly into the wallet API. The \`buildAuthHeaders\` / \`walletAsParam\` helpers were written as

\`\`\`ts
const identity = identityOverride !== undefined ? identityOverride : getActiveIdentity();
\`\`\`

which treats \`null\` as an explicit override to \"no identity\". The default-load \`null\` skipped the global fallback, sending \`?as=agent\` with no \`X-Active-Agent\`.

Collapse the contract: \`null\` and \`undefined\` both mean \"no override — follow global active identity\"; only a concrete \`ActiveIdentity\` overrides. Both helpers now use \`identityOverride ?? getActiveIdentity()\`.

### P2 — StripeReturnBanner polls without the original viewer

\`StripeReturnBanner\` calls \`getStripeSessionStatus(sessionId)\` without the viewer that started the checkout. Backend \`get_checkout_status\` (\`backend/app/routers/wallet.py:415-419\`) compares the resolved owner against \`topup.owner_id\`, so topups initiated for a non-global wallet fail polling. Human-only \`authed-no-agent\` sessions never see the banner at all because of the \`authed-ready\` gate.

- New \`lib/stripe-topup-context.ts\`: a small localStorage map keyed by \`checkout_session_id\`, holding the viewer used to create the topup with a 30-min TTL (matches Stripe checkout session expiry).
- \`TopupDialog\`: \`saveStripeTopupContext\` just before \`window.location.assign(checkout_url)\`.
- \`StripeReturnBanner\`: \`readStripeTopupContext(sessionId)\` on return, threads it through \`getStripeSessionStatus(sessionId, viewer)\`, \`clearStripeTopupContext\` once \`wallet_credited\` resolves. Gate relaxed to \`sessionMode !== \"guest\"\`.

## Test plan

- [ ] In agent view, open \`/chats/wallet\` → balance loads (no 400).
- [ ] In human view, open \`/chats/wallet\` → balance loads (no 400).
- [ ] Switch wallet owner via the dropdown → balance / ledger / withdrawals reload for the picked owner.
- [ ] Topup → Stripe → return: banner shows + polls successfully when topup was for the global agent.
- [ ] Topup → Stripe → return: banner shows + polls successfully when topup was for a non-default owned bot (\`viewer\` set in dropdown before topup).
- [ ] Topup from \`authed-no-agent\` session: banner appears on return (was previously suppressed entirely).

🤖 Generated with [Claude Code](https://claude.com/claude-code)