### PR TITLE
fix(dashboard): show send-message for existing contacts and bootstrap DMs

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -3,6 +3,7 @@
 import datetime
 import json
 import logging
+import re as _re
 import time as _time
 import uuid as _uuid
 
@@ -2243,6 +2244,118 @@ async def get_room_messages(
 # ---------------------------------------------------------------------------
 
 
+_DM_ROOM_RE = _re.compile(r"^rm_dm_((?:ag|hu)_[A-Za-z0-9]+)_((?:ag|hu)_[A-Za-z0-9]+)$")
+
+
+async def _ensure_dashboard_dm_room(
+    room_id: str, sender_id: str, db: AsyncSession
+) -> Room | None:
+    """Create a missing rm_dm_* room with both parties seated.
+
+    Returns the Room when ``room_id`` matches the DM format and the sender
+    is one of the two distinct encoded parties; returns ``None`` on shape
+    failures so the caller can surface a 404. Admission for agent peers is
+    delegated to ``check_direct_admission`` (block + contact_policy +
+    allow_*_sender) which raises ``I18nHTTPException(403)`` on deny, mirroring
+    ``_send_direct_message``. Human peers only need a bidirectional block
+    check since they have no ``message_policy``.
+    """
+    from hub.policy import Principal, check_direct_admission
+
+    match = _DM_ROOM_RE.match(room_id)
+    if match is None:
+        return None
+    a, b = match.group(1), match.group(2)
+    # Reject self-DMs — RoomMember (room_id, agent_id) is unique, and seating
+    # the same id twice would commit an orphan Room before failing on members.
+    if a == b:
+        return None
+    if sender_id not in (a, b):
+        return None
+    # Re-derive the canonical (sorted) form to reject mis-ordered ids.
+    canonical = f"rm_dm_{a}_{b}" if a < b else f"rm_dm_{b}_{a}"
+    if canonical != room_id:
+        return None
+
+    peer_id = b if sender_id == a else a
+    peer_is_human = peer_id.startswith("hu_")
+    sender_is_human = sender_id.startswith("hu_")
+    sender_type = ParticipantType.human if sender_is_human else ParticipantType.agent
+    peer_type = ParticipantType.human if peer_is_human else ParticipantType.agent
+
+    # Peer must exist before we seat it — RoomMember.agent_id no longer has a
+    # FK, so a phantom id would leave the user stuck in a half-formed DM.
+    if peer_is_human:
+        peer_row = await db.execute(select(User).where(User.human_id == peer_id))
+        peer_user = peer_row.scalar_one_or_none()
+        if peer_user is None or peer_user.banned_at is not None:
+            return None
+        # Humans have no message_policy; the only admission gate is mutual
+        # block. Mirror ``_is_blocked`` (typed) to match policy.py semantics.
+        block_row = await db.execute(
+            select(Block.id).where(
+                (
+                    (Block.owner_id == sender_id)
+                    & (Block.blocked_agent_id == peer_id)
+                    & (Block.blocked_type == peer_type)
+                )
+                | (
+                    (Block.owner_id == peer_id)
+                    & (Block.blocked_agent_id == sender_id)
+                    & (Block.blocked_type == sender_type)
+                )
+            ).limit(1)
+        )
+        if block_row.scalar_one_or_none() is not None:
+            return None
+    else:
+        peer_row = await db.execute(select(Agent).where(Agent.agent_id == peer_id))
+        peer_agent = peer_row.scalar_one_or_none()
+        if peer_agent is None:
+            return None
+        # Centralised admission: block + contact_policy + allow_*_sender.
+        # Allow same-room bypass off since this call IS the room creation.
+        await check_direct_admission(
+            db,
+            sender=Principal(id=sender_id, type=sender_type),
+            receiver=peer_agent,
+            allow_same_room_bypass=False,
+        )
+
+    room = Room(
+        room_id=room_id,
+        name=f"DM {a} & {b}",
+        owner_id=sender_id,
+        visibility=RoomVisibility.private,
+        join_policy=RoomJoinPolicy.invite_only,
+        max_members=2,
+        default_send=True,
+    )
+    try:
+        async with db.begin_nested():
+            db.add(room)
+            await db.flush()
+    except IntegrityError:
+        # Concurrent creator won the race; reload and return.
+        existing = await db.execute(select(Room).where(Room.room_id == room_id))
+        return existing.scalar_one_or_none()
+
+    db.add(RoomMember(
+        room_id=room_id,
+        agent_id=sender_id,
+        participant_type=sender_type,
+        role=RoomRole.member,
+    ))
+    db.add(RoomMember(
+        room_id=room_id,
+        agent_id=peer_id,
+        participant_type=peer_type,
+        role=RoomRole.member,
+    ))
+    await db.flush()
+    return room
+
+
 class HumanRoomSendBody(BaseModel):
     text: str = Field(..., min_length=1, max_length=8000)
     mentions: list[str] | None = None
@@ -2295,13 +2408,17 @@ async def human_room_send(
             raise HTTPException(status_code=404, detail="Human identity not found")
         sender_id = user.human_id
 
-    # Room exists (PRD §6.2 step 4)
+    # Room exists (PRD §6.2 step 4). For rm_dm_* rooms we auto-create the
+    # DM and seat both participants on first send, mirroring the protocol-
+    # level /hub/send behaviour so dashboard users can start a brand-new DM.
     room_result = await db.execute(
         select(Room).where(Room.room_id == room_id)
     )
     room = room_result.scalar_one_or_none()
     if room is None:
-        raise HTTPException(status_code=404, detail="Room not found")
+        room = await _ensure_dashboard_dm_room(room_id, sender_id, db)
+        if room is None:
+            raise HTTPException(status_code=404, detail="Room not found")
 
     # Sender is a RoomMember (step 5). Match participant_type so that a Human
     # and an Agent sharing the same string prefix cannot be confused.

--- a/frontend/src/components/dashboard/ChatPane.tsx
+++ b/frontend/src/components/dashboard/ChatPane.tsx
@@ -580,11 +580,13 @@ export default function ChatPane({ onHumanOpen }: ChatPaneProps) {
   const router = useRouter();
   const locale = useLanguage();
   const t = chatPane[locale];
-  const { sessionMode, token, humanRooms, viewMode } = useDashboardSessionStore(useShallow((state) => ({
+  const { sessionMode, token, humanRooms, viewMode, activeAgentId, humanId } = useDashboardSessionStore(useShallow((state) => ({
     sessionMode: state.sessionMode,
     token: state.token,
     humanRooms: state.humanRooms,
     viewMode: state.viewMode,
+    activeAgentId: state.activeAgentId,
+    humanId: state.human?.human_id ?? null,
   })));
   const { sidebarTab, focusedRoomId, openedRoomId } = useDashboardUIStore(useShallow((state) => ({
     sidebarTab: state.sidebarTab,
@@ -646,7 +648,19 @@ export default function ChatPane({ onHumanOpen }: ChatPaneProps) {
   const joinedRoom = overview?.rooms.find((r) => r.room_id === openedRoomId);
   const joinedHumanRoom = humanRooms.find((r) => r.room_id === openedRoomId);
   const isHumanView = viewMode === "human";
-  const isJoinedRoom = (isHumanView || isAuthedHuman) ? Boolean(joinedHumanRoom) : Boolean(joinedRoom);
+  // DM rooms are auto-created server-side on first send, so treat the user
+  // as a member of an unseen rm_dm_* room when their own id is one of the
+  // two encoded parties. Substring matching would false-positive on ids that
+  // happen to share a prefix, so parse the id explicitly.
+  const selfId = (isHumanView || isAuthedHuman) ? humanId : activeAgentId;
+  const dmRoomMatch = openedRoomId
+    ? openedRoomId.match(/^rm_dm_((?:ag|hu)_[A-Za-z0-9]+)_((?:ag|hu)_[A-Za-z0-9]+)$/)
+    : null;
+  const isPendingDmForSelf = Boolean(
+    dmRoomMatch && selfId && (dmRoomMatch[1] === selfId || dmRoomMatch[2] === selfId),
+  );
+  const isJoinedRoom = ((isHumanView || isAuthedHuman) ? Boolean(joinedHumanRoom) : Boolean(joinedRoom))
+    || isPendingDmForSelf;
   const humanSendAllowed = joinedRoom?.allow_human_send !== false;
   const isPaidRoom = Boolean(openedRoom?.required_subscription_product_id);
   const isPaidAndNotJoined = isPaidRoom && !isJoinedRoom;

--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -680,8 +680,11 @@ export default function DashboardApp() {
     });
     try {
       const human = await api.getPublicHuman(owner.humanId);
+      const localContact = (chatStore.overview?.contacts || []).some(
+        (item) => item.contact_agent_id === owner.humanId,
+      );
       const status =
-        human.contact_status === "contact" ? "exists"
+        human.contact_status === "contact" || localContact ? "exists"
         : human.contact_status === "pending" ? "pending"
         : "idle";
       setOwnerHumanCard({
@@ -738,9 +741,14 @@ export default function DashboardApp() {
   };
 
   const navigateToDmWith = (peerId: string, onClose: () => void) => {
-    const activeId = sessionStore.activeAgentId;
-    const dmRoomId = activeId
-      ? `rm_dm_${[activeId, peerId].sort().join("_")}`
+    // Pick the sender id based on view mode: human view uses the user's
+    // hu_*, agent view uses the active agent. DM ids encode both parties so
+    // the backend can ensure the room on first send.
+    const selfId = sessionStore.viewMode === "human"
+      ? sessionStore.human?.human_id ?? null
+      : sessionStore.activeAgentId;
+    const dmRoomId = selfId
+      ? `rm_dm_${[selfId, peerId].sort().join("_")}`
       : null;
     const dmRoom = dmRoomId
       ? chatStore.overview?.rooms.find((r) => r.room_id === dmRoomId)


### PR DESCRIPTION
## Summary

Fixes two bugs in the contacts flow reported from human view:

- HumanCardModal showed **"Send Friend Request"** for users already in the contacts list. The backend `get_public_human` only sets `contact_status` when `X-Active-Agent` is supplied, so human-view users never got the field — and the modal fell through to the friend-request branch.
- Clicking **"Send Message"** for a peer the user had never DM'd before either silently dropped human-view users on `/chats/messages` (because `navigateToDmWith` keyed on `activeAgentId` only), or landed agent-view users on a non-existent `rm_dm_*` room with the composer hidden. The dashboard human-send endpoint required the room to pre-exist, so first-time DMs were impossible from the UI.

## What changed

### Frontend
- `HumanCardModal` flow (`DashboardApp.handleOpenHumanCard`) now cross-checks `chatStore.overview.contacts` in addition to the backend `contact_status`, so a local match is enough to flip the button to **Send Message**.
- `navigateToDmWith` derives the sender id from `viewMode`: `human_id` in human view, `activeAgentId` in agent view — fixing the silent fallback.
- `ChatPane` parses `rm_dm_*` ids with a regex and treats the user as a member when their own id is one of the two encoded parties, so the composer renders for unseen DMs while the backend bootstraps the room on first send.

### Backend
- `human_room_send` calls a new `_ensure_dashboard_dm_room` helper when the room is missing. The helper:
  - Rejects shape mismatches and self-DMs (would otherwise IntegrityError on the unique RoomMember constraint after committing the Room).
  - Validates the peer exists (Agent table for `ag_*`, User table + banned-check for `hu_*`).
  - Runs a typed bidirectional Block check for human peers (no `message_policy` on humans).
  - Delegates agent-peer admission to the canonical `hub.policy.check_direct_admission` (block + `contact_policy: open/contacts_only/whitelist/closed` + `allow_*_sender`), with `allow_same_room_bypass=False` since this call IS the room-creation moment.
  - Seats both parties with the correct `participant_type`.

## Test plan

- [x] Backend: `tests/test_dashboard_rooms_human_send.py` (26), `tests/test_room.py` (129), `tests/test_dashboard.py`, `tests/test_contacts.py` — 181 passed, 1 skipped.
- [x] Frontend: `tsc --noEmit` clean for the 3 modified files.
- [ ] Manual: human view → click an agent contact's card → button reads **Send Message** → click → navigates to a `rm_dm_hu_*_ag_*` room with composer visible → first message sends, room appears in the list afterward.
- [ ] Manual: agent view → same flow, with `rm_dm_ag_*_ag_*` room.
- [ ] Manual: try sending to a peer that blocked you → 403, no orphan room.
- [ ] Manual: try sending to a `contacts_only` agent that hasn't friended you → 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)