### PR TITLE
fix(dashboard): render DM peer name and refresh sidebar after first send

### DIFF
--- a/frontend/src/components/dashboard/ChatPane.tsx
+++ b/frontend/src/components/dashboard/ChatPane.tsx
@@ -31,6 +31,7 @@ import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import { usePresenceStore } from "@/store/usePresenceStore";
 import RoomZeroState from "./RoomZeroState";
 import { initialsFromName } from "./roomVisualTheme";
+import { dmPeerId } from "./dmRoom";
 
 const EXPLORE_GRID_CLASS = "grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5";
 
@@ -650,15 +651,9 @@ export default function ChatPane({ onHumanOpen }: ChatPaneProps) {
   const isHumanView = viewMode === "human";
   // DM rooms are auto-created server-side on first send, so treat the user
   // as a member of an unseen rm_dm_* room when their own id is one of the
-  // two encoded parties. Substring matching would false-positive on ids that
-  // happen to share a prefix, so parse the id explicitly.
+  // two encoded parties.
   const selfId = (isHumanView || isAuthedHuman) ? humanId : activeAgentId;
-  const dmRoomMatch = openedRoomId
-    ? openedRoomId.match(/^rm_dm_((?:ag|hu)_[A-Za-z0-9]+)_((?:ag|hu)_[A-Za-z0-9]+)$/)
-    : null;
-  const isPendingDmForSelf = Boolean(
-    dmRoomMatch && selfId && (dmRoomMatch[1] === selfId || dmRoomMatch[2] === selfId),
-  );
+  const isPendingDmForSelf = dmPeerId(openedRoomId, selfId) !== null;
   const isJoinedRoom = ((isHumanView || isAuthedHuman) ? Boolean(joinedHumanRoom) : Boolean(joinedRoom))
     || isPendingDmForSelf;
   const humanSendAllowed = joinedRoom?.allow_human_send !== false;

--- a/frontend/src/components/dashboard/RoomHeader.tsx
+++ b/frontend/src/components/dashboard/RoomHeader.tsx
@@ -22,6 +22,7 @@ import ShareModal from "./ShareModal";
 import RoomSettingsModal from "./RoomSettingsModal";
 import DMSettingsModal from "./DMSettingsModal";
 import RoomPolicyModal from "./RoomPolicyModal";
+import { dmPeerId, resolveDmDisplayName } from "./dmRoom";
 
 export default function RoomHeader() {
   const [joinRequestStatus, setJoinRequestStatus] = useState<"idle" | "sending" | "pending" | "rejected">("idle");
@@ -41,6 +42,7 @@ export default function RoomHeader() {
   const activeAgentId = useDashboardSessionStore((state) => state.activeAgentId);
   const viewMode = useDashboardSessionStore((state) => state.viewMode);
   const humanRooms = useDashboardSessionStore((state) => state.humanRooms);
+  const humanId = useDashboardSessionStore((state) => state.human?.human_id ?? null);
   const refreshHumanRooms = useDashboardSessionStore((state) => state.refreshHumanRooms);
   const { openedRoomId } = useDashboardUIStore(useShallow((state) => ({
     openedRoomId: state.openedRoomId,
@@ -76,15 +78,20 @@ export default function RoomHeader() {
   // The user is not stored as a RoomMember (only the agent is), so generic
   // join/invite logic would mistakenly treat the user as an outsider.
   const isOwnerChatRoom = Boolean(openedRoomId?.startsWith("rm_oc_"));
-  // For DM rooms, figure out the partner agent by filtering activeAgentId from the room ID parts
-  const dmPartnerAgentId = isDMRoom && openedRoomId && activeAgentId
-    ? openedRoomId.replace("rm_dm_", "").split("_ag_")
-        .map((p) => (p ? "ag_" + p : "")).find((id) => id && id !== activeAgentId) ?? null
-    : null;
+  // Resolve the partner id from rm_dm_{a}_{b} given the current viewer id.
+  // Works uniformly for ag_* / hu_* peers — the legacy split("_ag_") code
+  // could not handle hu_-prefixed peers.
+  const selfId = viewMode === "human" ? humanId : activeAgentId;
+  const dmPartnerAgentId = isDMRoom ? dmPeerId(openedRoomId, selfId) : null;
   const isOwnAgentDM = isDMRoom && dmPartnerAgentId === null;
   const dmContact = isDMRoom && dmPartnerAgentId
     ? (overview?.contacts.find((c) => c.contact_agent_id === dmPartnerAgentId) ?? null)
     : null;
+  // For DMs, surface the peer's display name instead of the raw "DM ag_X & ag_Y"
+  // string the backend stores on Room.name.
+  const titleText = isDMRoom && room
+    ? resolveDmDisplayName(openedRoomId, selfId, overview?.contacts ?? [], room.name)
+    : room?.name ?? "";
   const canInvite = isHumanView
     ? isOwnerOrAdmin || (Boolean(myRole) && Boolean(humanRoom?.default_invite))
     : (authRoom?.can_invite ?? true);
@@ -233,7 +240,7 @@ export default function RoomHeader() {
       <div className="flex min-h-16 items-center justify-between border-b border-glass-border px-4 py-3">
         <div className="min-w-0 py-0.5">
           <div className="flex items-center gap-2">
-            <h3 className="truncate text-sm font-semibold text-text-primary">{room.name}</h3>
+            <h3 className="truncate text-sm font-semibold text-text-primary">{titleText}</h3>
             {room.required_subscription_product_id ? (
               <SubscriptionBadge productId={room.required_subscription_product_id} roomId={room.room_id} />
             ) : null}

--- a/frontend/src/components/dashboard/RoomHumanComposer.tsx
+++ b/frontend/src/components/dashboard/RoomHumanComposer.tsx
@@ -22,10 +22,18 @@ export default function RoomHumanComposer({ roomId }: RoomHumanComposerProps) {
     human: s.human,
     viewMode: s.viewMode,
   })));
-  const { insertMessage, loadRoomMessages } = useDashboardChatStore(useShallow((s) => ({
+  const { insertMessage, loadRoomMessages, refreshOverview } = useDashboardChatStore(useShallow((s) => ({
     insertMessage: s.insertMessage,
     loadRoomMessages: s.loadRoomMessages,
+    refreshOverview: s.refreshOverview,
   })));
+  const hasRoomInOverview = useDashboardChatStore(
+    (s) => Boolean(s.overview?.rooms.some((r) => r.room_id === roomId)),
+  );
+  const refreshHumanRooms = useDashboardSessionStore((s) => s.refreshHumanRooms);
+  const hasRoomInHumanRooms = useDashboardSessionStore(
+    (s) => s.humanRooms.some((r) => r.room_id === roomId),
+  );
 
   const [error, setError] = useState<string | null>(null);
   const [members, setMembers] = useState<PublicRoomMember[]>([]);
@@ -116,10 +124,19 @@ export default function RoomHumanComposer({ roomId }: RoomHumanComposerProps) {
     try {
       await api.sendRoomHumanMessage(roomId, text, mentions);
       await loadRoomMessages(roomId);
+      // First send into a brand-new DM room (auto-created server-side) won't
+      // show up in the sidebar until overview/humanRooms is re-fetched.
+      if (roomId.startsWith("rm_dm_")) {
+        if (viewMode === "human") {
+          if (!hasRoomInHumanRooms) void refreshHumanRooms();
+        } else if (!hasRoomInOverview) {
+          void refreshOverview();
+        }
+      }
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Failed to send");
     }
-  }, [senderId, displayName, user?.id, roomId, insertMessage, loadRoomMessages]);
+  }, [senderId, displayName, user?.id, roomId, viewMode, insertMessage, loadRoomMessages, refreshOverview, refreshHumanRooms, hasRoomInOverview, hasRoomInHumanRooms]);
 
   if (sendDenied) {
     return (

--- a/frontend/src/components/dashboard/RoomList.tsx
+++ b/frontend/src/components/dashboard/RoomList.tsx
@@ -19,6 +19,7 @@ import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import { useDashboardUnreadStore } from "@/store/useDashboardUnreadStore";
 import { useOwnerChatStore } from "@/store/useOwnerChatStore";
 import SubscriptionBadge from "./SubscriptionBadge";
+import { resolveDmDisplayName } from "./dmRoom";
 
 /** Fill missing DashboardRoom fields so a Human-owned room renders alongside
  * agent rooms without special-casing the render path. Unread / last-message
@@ -112,6 +113,8 @@ export default function RoomList({
   const activeAgentId = useDashboardSessionStore((state) => state.activeAgentId);
   const viewMode = useDashboardSessionStore((state) => state.viewMode);
   const humanRooms = useDashboardSessionStore((state) => state.humanRooms);
+  const humanId = useDashboardSessionStore((state) => state.human?.human_id ?? null);
+  const contacts = useDashboardChatStore((state) => state.overview?.contacts ?? []);
   const isRoomUnread = useDashboardUnreadStore((state) => state.isRoomUnread);
   const ownerChatMessages = useOwnerChatStore((state) => state.messages);
   const ownerChatLoading = useOwnerChatStore((state) => state.loading);
@@ -271,7 +274,9 @@ export default function RoomList({
         const previewLine = previewSender ? `${previewSender}: ${previewText}` : previewText;
         const metaLine = roomMeta?.[room.room_id] ?? null;
         const messageTime = formatLastMessageTime(room.last_message_at);
-        const avatarLabel = buildRoomAvatarLabel(room.name);
+        const selfRoomId = viewMode === "human" ? humanId : activeAgentId;
+        const displayName = resolveDmDisplayName(room.room_id, selfRoomId, contacts, room.name);
+        const avatarLabel = buildRoomAvatarLabel(displayName);
         const avatarTone = buildAvatarTone(room.room_id);
         const isUnread = isRoomUnread(room.room_id, room.has_unread);
         const unreadCount = isUnread ? Math.max(1, room.unread_count ?? 1) : 0;
@@ -281,7 +286,7 @@ export default function RoomList({
             key={room.room_id}
             role="button"
             tabIndex={0}
-            aria-label={`Open room ${room.name}`}
+            aria-label={`Open room ${displayName}`}
             aria-current={isSelected ? "page" : undefined}
             onClick={() => handleSelect(room.room_id)}
             onKeyDown={(event) => handleRoomKeyDown(event, room.room_id)}
@@ -298,7 +303,7 @@ export default function RoomList({
               <div className="min-w-0 flex-1">
                 <div className="flex items-center justify-between gap-2">
                   <span className={`min-w-0 truncate text-sm font-medium ${isSelected ? "text-neon-cyan" : "text-text-primary"}`}>
-                    {room.name}
+                    {displayName}
                   </span>
                   <div className="flex shrink-0 items-center gap-2">
                     {unreadCount > 0 && (

--- a/frontend/src/components/dashboard/dmRoom.ts
+++ b/frontend/src/components/dashboard/dmRoom.ts
@@ -1,0 +1,47 @@
+/**
+ * [INPUT]: 依赖 rm_dm_* 房间 ID 形态与 dashboard 的联系人/会话列表
+ * [OUTPUT]: 对外提供 DM 房间 ID 解析与 peer 显示名解析的统一工具
+ * [POS]: dashboard DM 渲染共用层，避免 RoomHeader / RoomList / ChatPane 各自实现
+ * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
+ */
+
+const DM_ROOM_RE = /^rm_dm_((?:ag|hu)_[A-Za-z0-9]+)_((?:ag|hu)_[A-Za-z0-9]+)$/;
+
+export function parseDmRoomId(
+  roomId: string | null | undefined,
+): { a: string; b: string } | null {
+  if (!roomId) return null;
+  const m = roomId.match(DM_ROOM_RE);
+  if (!m) return null;
+  return { a: m[1], b: m[2] };
+}
+
+export function dmPeerId(
+  roomId: string | null | undefined,
+  selfId: string | null | undefined,
+): string | null {
+  const parsed = parseDmRoomId(roomId);
+  if (!parsed || !selfId) return null;
+  if (parsed.a === selfId) return parsed.b;
+  if (parsed.b === selfId) return parsed.a;
+  return null;
+}
+
+export interface DmContactLike {
+  contact_agent_id: string;
+  alias: string | null;
+  display_name: string;
+}
+
+export function resolveDmDisplayName(
+  roomId: string | null | undefined,
+  selfId: string | null | undefined,
+  contacts: DmContactLike[],
+  fallback: string,
+): string {
+  const peer = dmPeerId(roomId, selfId);
+  if (!peer) return fallback;
+  const contact = contacts.find((c) => c.contact_agent_id === peer);
+  if (contact) return contact.alias || contact.display_name || peer;
+  return peer;
+}


### PR DESCRIPTION
## Summary

Follow-up to #428. After manual testing of the DM bootstrap flow we found two regressions still visible in the UI:

1. RoomHeader and the messages sidebar showed the raw \`DM hu_X & hu_Y\` string the backend stores on \`Room.name\`. The legacy \`dmPartnerAgentId\` parser only handled \`_ag_\` splits, so for human peers it returned null and the UI fell through to the raw room name.
2. After sending the first message into a freshly auto-created DM, the new room did not appear in the messages list until a manual page refresh — nothing re-fetched \`overview\` / \`humanRooms\`.

## What changed

- New \`frontend/src/components/dashboard/dmRoom.ts\` with \`parseDmRoomId\`, \`dmPeerId\`, \`resolveDmDisplayName\` helpers that handle \`ag_*\` and \`hu_*\` peers uniformly via a single regex.
- \`RoomHeader\` derives \`selfId\` from \`viewMode\` (human_id vs activeAgentId), then resolves the title through the peer's contact entry (alias > display_name > peer_id), only falling back to \`room.name\` when the room is not a DM.
- \`RoomList\` (sidebar) renders the same resolved display name and avatar label/aria-label for every DM row.
- \`ChatPane\` reuses \`dmPeerId\` for the pending-DM-for-self check (replacing the inline regex from #428).
- \`RoomHumanComposer\` calls \`refreshOverview()\` (agent view) or \`refreshHumanRooms()\` (human view) after a successful send into an \`rm_dm_*\` room not yet known locally, so the new DM lands in the sidebar without a manual refresh.

## Test plan

- [x] Frontend \`tsc --noEmit\` clean for the modified files.
- [ ] Manual: human view → click an agent contact → **Send Message** → header shows the peer's display name (not raw \`DM hu_X & ag_Y\`) → sidebar lists the DM with the same name and an avatar tied to that name → first message sends, room appears in the list immediately.
- [ ] Manual: agent view → equivalent flow with \`rm_dm_ag_*_ag_*\`.
- [ ] Manual: open an existing DM with a peer not in contacts → header/sidebar fall back to the peer id rather than the \`DM ... & ...\` string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)