### PR TITLE
fix(dashboard): stabilize empty contacts ref in RoomList selector

### DIFF
--- a/frontend/src/components/dashboard/RoomList.tsx
+++ b/frontend/src/components/dashboard/RoomList.tsx
@@ -12,7 +12,7 @@ import { roomList } from '@/lib/i18n/translations/dashboard';
 import { useRouter } from "nextjs-toploader/app";
 import { useShallow } from "zustand/react/shallow";
 
-import { DashboardRoom, HumanRoomSummary } from "@/lib/types";
+import { ContactInfo, DashboardRoom, HumanRoomSummary } from "@/lib/types";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
@@ -56,6 +56,7 @@ interface RoomListProps {
 }
 
 const USER_CHAT_PATH = "/chats/messages/__user-chat__";
+const EMPTY_CONTACTS: ContactInfo[] = [];
 
 function buildRoomAvatarLabel(roomName: string): string {
   const normalized = roomName.trim();
@@ -114,7 +115,11 @@ export default function RoomList({
   const viewMode = useDashboardSessionStore((state) => state.viewMode);
   const humanRooms = useDashboardSessionStore((state) => state.humanRooms);
   const humanId = useDashboardSessionStore((state) => state.human?.human_id ?? null);
-  const contacts = useDashboardChatStore((state) => state.overview?.contacts ?? []);
+  // Reuse `overview` (already subscribed above) to derive contacts. Returning
+  // `state.overview?.contacts ?? []` from a fresh selector minted a new `[]`
+  // whenever overview is null, breaking Zustand's Object.is check and
+  // triggering React error #185 (max update depth).
+  const contacts = overview?.contacts ?? EMPTY_CONTACTS;
   const isRoomUnread = useDashboardUnreadStore((state) => state.isRoomUnread);
   const ownerChatMessages = useOwnerChatStore((state) => state.messages);
   const ownerChatLoading = useOwnerChatStore((state) => state.loading);


### PR DESCRIPTION
## Summary

Hotfix for a regression introduced by #431. After merging the DM peer-name work the dashboard threw **React error #185** ("Maximum update depth exceeded") in production-minified builds.

The new selector

\`\`\`ts
const contacts = useDashboardChatStore((state) => state.overview?.contacts ?? []);
\`\`\`

minted a fresh \`[]\` literal on every call whenever \`overview\` was null. Zustand's default selector check uses \`Object.is\`, so the previous and current selections never compared equal, the subscription notified the component to re-render, the selector ran again, produced yet another \`[]\`, and so on — an infinite render loop.

## Fix

- Reuse the already-subscribed \`overview\` (same store, same field; reference is stable across renders) instead of opening a second subscription.
- Fall back to a module-level \`EMPTY_CONTACTS: ContactInfo[]\` constant so the empty-state reference is stable.
- Add a comment explaining the trap so the next maintainer doesn't reintroduce it.

## Test plan

- [x] \`tsc --noEmit\` clean for the modified file.
- [ ] Manual: load \`/chats/messages\` while signed out / overview not yet fetched → no React error in console.
- [ ] Manual: signed-in user with contacts → DM rows still render the resolved peer display name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)