### PR TITLE
fix: show human-created rooms in contacts

### DIFF
--- a/frontend/src/components/dashboard/ChatPane.tsx
+++ b/frontend/src/components/dashboard/ChatPane.tsx
@@ -13,7 +13,11 @@ import { chatPane, exploreUi } from '@/lib/i18n/translations/dashboard';
 import { useRouter } from "nextjs-toploader/app";
 import { useShallow } from "zustand/react/shallow";
 import { Loader2 } from "lucide-react";
-import { buildVisibleMessageRooms, compareRoomsByActivityDesc } from "@/store/dashboard-shared";
+import {
+  buildVisibleMessageRooms,
+  isRoomOwnedByCurrentViewer,
+  mergeDashboardRoomsWithHumanRooms,
+} from "@/store/dashboard-shared";
 import RoomHeader from "./RoomHeader";
 import MessageList from "./MessageList";
 import PaidRoomPreview from "./PaidRoomPreview";
@@ -84,6 +88,8 @@ function ContactsMainPane({ onHumanOpen }: { onHumanOpen?: (human: PublicHumanPr
   })));
   const sessionMode = useDashboardSessionStore((state) => state.sessionMode);
   const activeAgentId = useDashboardSessionStore((state) => state.activeAgentId);
+  const humanId = useDashboardSessionStore((state) => state.human?.human_id ?? null);
+  const humanRooms = useDashboardSessionStore((state) => state.humanRooms);
   const isAuthed = sessionMode === "authed-ready" || sessionMode === "authed-no-agent";
   const [query, setQuery] = useState("");
   const [showFriendInvite, setShowFriendInvite] = useState(false);
@@ -92,16 +98,17 @@ function ContactsMainPane({ onHumanOpen }: { onHumanOpen?: (human: PublicHumanPr
   const isCreatedView = contactsView === "created";
   const contacts = overview?.contacts || [];
   const sortedRooms = useMemo(
-    () => [...(overview?.rooms || [])].sort(compareRoomsByActivityDesc),
-    [overview?.rooms],
+    () => mergeDashboardRoomsWithHumanRooms(overview?.rooms || [], humanRooms),
+    [overview?.rooms, humanRooms],
   );
+  const ownerViewer = useMemo(() => ({ activeAgentId, humanId }), [activeAgentId, humanId]);
   const joinedRooms = useMemo(
-    () => sortedRooms.filter((room) => !activeAgentId || room.owner_id !== activeAgentId),
-    [sortedRooms, activeAgentId],
+    () => sortedRooms.filter((room) => !isRoomOwnedByCurrentViewer(room, ownerViewer)),
+    [sortedRooms, ownerViewer],
   );
   const createdRooms = useMemo(
-    () => sortedRooms.filter((room) => activeAgentId && room.owner_id === activeAgentId),
-    [sortedRooms, activeAgentId],
+    () => sortedRooms.filter((room) => isRoomOwnedByCurrentViewer(room, ownerViewer)),
+    [sortedRooms, ownerViewer],
   );
   const pendingReceived = contactRequestsReceived.filter((item) => item.state === "pending");
 

--- a/frontend/src/store/dashboard-shared.test.ts
+++ b/frontend/src/store/dashboard-shared.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { DashboardOverview, HumanRoomSummary, PublicRoom } from "@/lib/types";
-import { buildVisibleMessageRooms } from "@/store/dashboard-shared";
+import {
+  buildVisibleMessageRooms,
+  isRoomOwnedByCurrentViewer,
+  mergeDashboardRoomsWithHumanRooms,
+} from "@/store/dashboard-shared";
 
 function makePublicRoom(overrides: Partial<PublicRoom> = {}): PublicRoom {
   return {
@@ -57,10 +61,19 @@ function makeHumanRoom(overrides: Partial<HumanRoomSummary> = {}): HumanRoomSumm
     name: "Human room",
     description: "human",
     owner_id: "hu_owner",
+    owner_type: "human",
     visibility: "private",
     join_policy: "invite",
+    member_count: 1,
     my_role: "member",
+    allow_human_send: true,
+    default_send: true,
+    default_invite: true,
+    max_members: null,
+    slow_mode_seconds: null,
+    required_subscription_product_id: null,
     created_at: "2026-04-27T08:00:00Z",
+    rule: null,
     ...overrides,
   };
 }
@@ -85,5 +98,43 @@ describe("buildVisibleMessageRooms", () => {
     });
 
     expect(rooms.map((room) => room.room_id)).toEqual(["rm_public_1", "rm_joined_1", "rm_human_1"]);
+  });
+});
+
+describe("mergeDashboardRoomsWithHumanRooms", () => {
+  it("keeps human-owned created rooms visible outside the agent overview", () => {
+    const rooms = mergeDashboardRoomsWithHumanRooms(makeOverview().rooms, [
+      makeHumanRoom({
+        room_id: "rm_created_by_human",
+        owner_id: "hu_1",
+        my_role: "owner",
+        created_at: "2026-04-27T11:00:00Z",
+      }),
+    ]);
+
+    expect(rooms.map((room) => room.room_id)).toEqual(["rm_created_by_human", "rm_joined_1"]);
+    expect(rooms[0]).toMatchObject({
+      owner_id: "hu_1",
+      owner_type: "human",
+      my_role: "owner",
+    });
+  });
+});
+
+describe("isRoomOwnedByCurrentViewer", () => {
+  it("matches human-owned rooms by human id", () => {
+    const room = mergeDashboardRoomsWithHumanRooms([], [
+      makeHumanRoom({ owner_id: "hu_1", owner_type: "human", my_role: "owner" }),
+    ])[0];
+
+    expect(isRoomOwnedByCurrentViewer(room, { activeAgentId: "ag_1", humanId: "hu_1" })).toBe(true);
+    expect(isRoomOwnedByCurrentViewer(room, { activeAgentId: "ag_1", humanId: "hu_2" })).toBe(false);
+  });
+
+  it("matches agent-owned rooms by active agent id", () => {
+    const room = makeOverview({ owner_id: "ag_1" }).rooms[0];
+
+    expect(isRoomOwnedByCurrentViewer(room, { activeAgentId: "ag_1", humanId: "hu_1" })).toBe(true);
+    expect(isRoomOwnedByCurrentViewer(room, { activeAgentId: "ag_2", humanId: "hu_1" })).toBe(false);
   });
 });

--- a/frontend/src/store/dashboard-shared.ts
+++ b/frontend/src/store/dashboard-shared.ts
@@ -1,6 +1,6 @@
 /**
  * [INPUT]: 依赖 dashboard 类型定义、@/lib/api 的 active-agent 工具与浏览器时间解析
- * [OUTPUT]: 对外提供 dashboard chat/unread/realtime store 共用的房间摘要与时间比较工具
+ * [OUTPUT]: 对外提供 dashboard chat/unread/realtime store 共用的房间摘要、合并与时间比较工具
  * [POS]: frontend store 层的共享基础模块，负责消除多 store 拆分后的重复逻辑
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
@@ -92,6 +92,32 @@ export function humanRoomToDashboardRoom(r: HumanRoomSummary): DashboardRoom {
   };
 }
 
+export function mergeDashboardRoomsWithHumanRooms(
+  agentRooms: DashboardRoom[],
+  humanRooms: HumanRoomSummary[],
+): DashboardRoom[] {
+  if (humanRooms.length === 0) {
+    return [...agentRooms].sort(compareRoomsByActivityDesc);
+  }
+
+  const seen = new Set(agentRooms.map((room) => room.room_id));
+  const humanOnlyRooms = humanRooms
+    .filter((room) => !seen.has(room.room_id))
+    .map(humanRoomToDashboardRoom);
+  return [...agentRooms, ...humanOnlyRooms].sort(compareRoomsByActivityDesc);
+}
+
+export function isRoomOwnedByCurrentViewer(
+  room: Pick<DashboardRoom, "owner_id" | "owner_type">,
+  viewer: { activeAgentId?: string | null; humanId?: string | null },
+): boolean {
+  const ownerType = room.owner_type ?? "agent";
+  if (ownerType === "human") {
+    return Boolean(viewer.humanId && room.owner_id === viewer.humanId);
+  }
+  return Boolean(viewer.activeAgentId && room.owner_id === viewer.activeAgentId);
+}
+
 export function buildVisibleMessageRooms(state: {
   overview: DashboardOverview | null;
   recentVisitedRooms: PublicRoom[];
@@ -107,12 +133,8 @@ export function buildVisibleMessageRooms(state: {
   const recentUnjoinedRooms = state.recentVisitedRooms
     .filter((room) => !joinedRoomIds.has(room.room_id) && !isOwnerChatRoom(room.room_id))
     .map(toRoomSummary);
-  const allKnownRoomIds = new Set([...joinedRoomIds, ...recentUnjoinedRooms.map((r) => r.room_id)]);
-  const humanOnlyRooms = (state.humanRooms || [])
-    .filter((r) => !allKnownRoomIds.has(r.room_id) && !isOwnerChatRoom(r.room_id))
-    .map(humanRoomToDashboardRoom);
-  const mergedRooms = [...joinedRooms, ...recentUnjoinedRooms, ...humanOnlyRooms].sort(compareRoomsByActivityDesc);
-  return mergedRooms;
+  const humanRooms = (state.humanRooms || []).filter((room) => !isOwnerChatRoom(room.room_id));
+  return mergeDashboardRoomsWithHumanRooms([...joinedRooms, ...recentUnjoinedRooms], humanRooms);
 }
 
 export function getLatestSeenAtForRoom(


### PR DESCRIPTION
## Summary
- merge human room summaries into the contacts room views
- classify created rooms by owner_type plus human/agent identity
- add coverage for human-owned room merging and owner detection

## Tests
- cd frontend && npm test -- dashboard-shared.test.ts
- cd frontend && NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build