### PR TITLE
fix: refresh dashboard room messages

### DIFF
--- a/frontend/src/components/dashboard/RoomHumanComposer.tsx
+++ b/frontend/src/components/dashboard/RoomHumanComposer.tsx
@@ -23,9 +23,10 @@ export default function RoomHumanComposer({ roomId }: RoomHumanComposerProps) {
     human: s.human,
     viewMode: s.viewMode,
   })));
-  const { insertMessage, loadRoomMessages, refreshOverview } = useDashboardChatStore(useShallow((s) => ({
+  const { insertMessage, patchRoom, pollNewMessages, refreshOverview } = useDashboardChatStore(useShallow((s) => ({
     insertMessage: s.insertMessage,
-    loadRoomMessages: s.loadRoomMessages,
+    patchRoom: s.patchRoom,
+    pollNewMessages: s.pollNewMessages,
     refreshOverview: s.refreshOverview,
   })));
   const hasRoomInOverview = useDashboardChatStore(
@@ -114,8 +115,13 @@ export default function RoomHumanComposer({ roomId }: RoomHumanComposerProps) {
     setError(null);
 
     try {
-      await api.sendRoomHumanMessage(roomId, text, mentions);
-      await loadRoomMessages(roomId);
+      const result = await api.sendRoomHumanMessage(roomId, text, mentions);
+      patchRoom(roomId, {
+        last_message_preview: text,
+        last_message_at: now,
+        last_sender_name: displayName,
+      });
+      await pollNewMessages(roomId, { expectedHubMsgId: result.hub_msg_id, retries: 4 });
       // First send into a brand-new DM room (auto-created server-side) won't
       // show up in the sidebar until overview/humanRooms is re-fetched.
       if (roomId.startsWith("rm_dm_")) {
@@ -128,7 +134,7 @@ export default function RoomHumanComposer({ roomId }: RoomHumanComposerProps) {
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Failed to send");
     }
-  }, [senderId, displayName, user?.id, roomId, viewMode, insertMessage, loadRoomMessages, refreshOverview, refreshHumanRooms, hasRoomInOverview, hasRoomInHumanRooms]);
+  }, [senderId, displayName, user?.id, roomId, viewMode, insertMessage, patchRoom, pollNewMessages, refreshOverview, refreshHumanRooms, hasRoomInOverview, hasRoomInHumanRooms]);
 
   if (sendDenied) {
     return (

--- a/frontend/src/components/dashboard/RoomList.tsx
+++ b/frontend/src/components/dashboard/RoomList.tsx
@@ -12,7 +12,8 @@ import { roomList } from '@/lib/i18n/translations/dashboard';
 import { useRouter } from "nextjs-toploader/app";
 import { useShallow } from "zustand/react/shallow";
 
-import { ContactInfo, DashboardRoom, HumanRoomSummary } from "@/lib/types";
+import { ContactInfo, DashboardRoom } from "@/lib/types";
+import { humanRoomToDashboardRoom } from "@/store/dashboard-shared";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
@@ -20,32 +21,6 @@ import { useDashboardUnreadStore } from "@/store/useDashboardUnreadStore";
 import { useOwnerChatStore } from "@/store/useOwnerChatStore";
 import SubscriptionBadge from "./SubscriptionBadge";
 import { resolveDmDisplayName } from "./dmRoom";
-
-/** Fill missing DashboardRoom fields so a Human-owned room renders alongside
- * agent rooms without special-casing the render path. Unread / last-message
- * metadata is not returned by /api/humans/me/rooms yet — zero-fill for now. */
-function humanRoomToDashboardRoom(r: HumanRoomSummary): DashboardRoom {
-  return {
-    room_id: r.room_id,
-    name: r.name,
-    description: r.description,
-    owner_id: r.owner_id,
-    visibility: r.visibility,
-    join_policy: r.join_policy,
-    can_invite: undefined,
-    member_count: 0,
-    my_role: r.my_role,
-    created_at: null,
-    rule: null,
-    required_subscription_product_id: null,
-    last_viewed_at: null,
-    has_unread: false,
-    unread_count: 0,
-    last_message_preview: null,
-    last_message_at: null,
-    last_sender_name: null,
-  };
-}
 
 interface RoomListProps {
   rooms?: DashboardRoom[];
@@ -278,7 +253,7 @@ export default function RoomList({
         }
         const previewLine = previewSender ? `${previewSender}: ${previewText}` : previewText;
         const metaLine = roomMeta?.[room.room_id] ?? null;
-        const messageTime = formatLastMessageTime(room.last_message_at);
+        const messageTime = formatLastMessageTime(room.last_message_at || cachedLatestMessage?.created_at || null);
         const selfRoomId = viewMode === "human" ? humanId : activeAgentId;
         const displayName = resolveDmDisplayName(room.room_id, selfRoomId, contacts, room.name);
         const avatarLabel = buildRoomAvatarLabel(displayName);

--- a/frontend/src/components/dashboard/RoomZeroState.tsx
+++ b/frontend/src/components/dashboard/RoomZeroState.tsx
@@ -55,13 +55,23 @@ export default function RoomZeroState({ compact = false, hasRooms = false, onHum
       })),
     );
 
-  const { setFocusedRoomId, setOpenedRoomId, setSidebarTab } = useDashboardUIStore(
+  const { setFocusedRoomId, setOpenedRoomId, setSidebarTab, setMessagesPane } = useDashboardUIStore(
     useShallow((state) => ({
       setFocusedRoomId: state.setFocusedRoomId,
       setOpenedRoomId: state.setOpenedRoomId,
       setSidebarTab: state.setSidebarTab,
+      setMessagesPane: state.setMessagesPane,
     })),
   );
+
+  const handleCreatedRoom = (room: { room_id: string }) => {
+    setShowCreateRoom(false);
+    setSidebarTab("messages");
+    setMessagesPane("room");
+    setFocusedRoomId(room.room_id);
+    setOpenedRoomId(room.room_id);
+    router.push(`/chats/messages/${encodeURIComponent(room.room_id)}`);
+  };
 
   useEffect(() => {
     if (!publicRoomsLoaded) loadPublicRooms();
@@ -130,7 +140,7 @@ export default function RoomZeroState({ compact = false, hasRooms = false, onHum
             </button>
           )}
         </div>
-        {showCreateRoom && <CreateRoomModal onClose={() => setShowCreateRoom(false)} />}
+        {showCreateRoom && <CreateRoomModal onClose={() => setShowCreateRoom(false)} onCreated={handleCreatedRoom} />}
       </div>
     );
   }
@@ -306,7 +316,7 @@ export default function RoomZeroState({ compact = false, hasRooms = false, onHum
         </section>
       )}
 
-      {showCreateRoom && <CreateRoomModal onClose={() => setShowCreateRoom(false)} />}
+      {showCreateRoom && <CreateRoomModal onClose={() => setShowCreateRoom(false)} onCreated={handleCreatedRoom} />}
     </div>
   );
 }

--- a/frontend/src/components/dashboard/sidebar/index.tsx
+++ b/frontend/src/components/dashboard/sidebar/index.tsx
@@ -130,6 +130,7 @@ export default function Sidebar() {
     setExploreView: s.setExploreView,
     setContactsView: s.setContactsView,
     setSidebarWidth: s.setSidebarWidth,
+    setFocusedRoomId: s.setFocusedRoomId,
     setOpenedRoomId: s.setOpenedRoomId,
     createBotModalOpen: s.createBotModalOpen,
     openCreateBotModal: s.openCreateBotModal,
@@ -387,6 +388,9 @@ export default function Sidebar() {
           onClose={() => setShowCreateRoom(false)}
           onCreated={(room) => {
             setShowCreateRoom(false);
+            uiStore.setSidebarTab("messages");
+            uiStore.setMessagesPane("room");
+            uiStore.setFocusedRoomId(room.room_id);
             uiStore.setOpenedRoomId(room.room_id);
             router.push(`/chats/messages/${encodeURIComponent(room.room_id)}`);
           }}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -909,6 +909,9 @@ export interface HumanRoomSummary {
   max_members: number | null;
   slow_mode_seconds: number | null;
   required_subscription_product_id: string | null;
+  last_message_preview?: string | null;
+  last_message_at?: string | null;
+  last_sender_name?: string | null;
   created_at: string | null;
 }
 

--- a/frontend/src/store/dashboard-shared.ts
+++ b/frontend/src/store/dashboard-shared.ts
@@ -15,6 +15,7 @@ import type {
 import { getActiveAgentId } from "@/lib/api";
 
 export const roomMessagesInFlight = new Set<string>();
+export const roomMessagesReloadPending = new Set<string>();
 export const roomPollInFlight = new Set<string>();
 
 export function toRoomSummary(room: PublicRoom): DashboardRoom {
@@ -84,9 +85,9 @@ export function humanRoomToDashboardRoom(r: HumanRoomSummary): DashboardRoom {
     slow_mode_seconds: r.slow_mode_seconds,
     last_viewed_at: null,
     has_unread: false,
-    last_message_preview: null,
-    last_message_at: null,
-    last_sender_name: null,
+    last_message_preview: r.last_message_preview ?? null,
+    last_message_at: r.last_message_at ?? null,
+    last_sender_name: r.last_sender_name ?? null,
     allow_human_send: r.allow_human_send,
     created_at: r.created_at,
   };

--- a/frontend/src/store/useDashboardChatStore.ts
+++ b/frontend/src/store/useDashboardChatStore.ts
@@ -22,6 +22,7 @@ import { api, humansApi } from "@/lib/api";
 import {
   buildVisibleMessageRooms,
   roomMessagesInFlight,
+  roomMessagesReloadPending,
   roomPollInFlight,
   toRoomSummary,
 } from "@/store/dashboard-shared";
@@ -356,7 +357,10 @@ export const useDashboardChatStore = create<DashboardChatState>()(
         })),
 
       loadRoomMessages: async (roomId: string) => {
-        if (roomMessagesInFlight.has(roomId)) return;
+        if (roomMessagesInFlight.has(roomId)) {
+          roomMessagesReloadPending.add(roomId);
+          return;
+        }
         set((state) => ({
           messagesLoading: { ...state.messagesLoading, [roomId]: true },
         }));
@@ -375,6 +379,9 @@ export const useDashboardChatStore = create<DashboardChatState>()(
           set((state) => ({
             messagesLoading: { ...state.messagesLoading, [roomId]: false },
           }));
+          if (roomMessagesReloadPending.delete(roomId)) {
+            void get().loadRoomMessages(roomId);
+          }
         }
       },
 
@@ -402,8 +409,18 @@ export const useDashboardChatStore = create<DashboardChatState>()(
                 const existingIds = new Set(current.map((message) => message.hub_msg_id));
                 const deduped = newMsgs.filter((message) => !existingIds.has(message.hub_msg_id));
                 if (deduped.length === 0) return state;
+                const currentWithoutMatchedOptimistic = current.filter((message) => {
+                  if (!message.hub_msg_id?.startsWith("tmp_")) return true;
+                  return !deduped.some((newMessage) =>
+                    newMessage.text === message.text
+                    && (
+                      newMessage.sender_id === message.sender_id
+                      || newMessage.is_mine === message.is_mine
+                    ),
+                  );
+                });
                 return {
-                  messages: { ...state.messages, [roomId]: [...current, ...deduped] },
+                  messages: { ...state.messages, [roomId]: [...currentWithoutMatchedOptimistic, ...deduped] },
                 };
               });
             }


### PR DESCRIPTION
## Summary
- queue room message reloads when a load is already in flight
- reconcile optimistic sends with persisted messages and refresh room previews after human sends
- focus newly created rooms from sidebar and zero-state create flows
- preserve last-message metadata for human room summaries in the shared mapper

## Test plan
- NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build