### PR TITLE
feat(daemon): attach hermes-agent to existing hermes profile

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1909,6 +1909,10 @@ class ProvisionAgentBody(BaseModel):
     # synthesized managed route can resolve a `ResolvedOpenclawGateway`.
     openclaw_gateway: str | None = None
     openclaw_agent: str | None = None
+    # Hermes profile to attach to. Only meaningful when `runtime ==
+    # "hermes-agent"` — daemon enforces 1 BotCord agent : 1 hermes profile
+    # and rejects with `hermes_profile_occupied` when already bound.
+    hermes_profile: str | None = None
 
 
 class ProvisionAgentResponse(BaseModel):
@@ -1923,6 +1927,7 @@ def _daemon_lists_runtime(
     instance: DaemonInstance,
     runtime: str,
     openclaw_gateway: str | None = None,
+    hermes_profile: str | None = None,
 ) -> bool:
     """Check that the daemon's last runtime probe lists `runtime` as available.
 
@@ -1955,6 +1960,25 @@ def _daemon_lists_runtime(
                 if not isinstance(ep, dict):
                     continue
                 if ep.get("name") == openclaw_gateway and ep.get("reachable") is True:
+                    return True
+            return False
+        if runtime == "hermes-agent" and hermes_profile:
+            # Mirror the openclaw gating: when a specific profile is selected,
+            # require it to appear in the snapshot's `profiles[]`. Daemon will
+            # still re-validate (existence + occupancy) under its per-profile
+            # lock, but rejecting here gives the dashboard a fast 409 instead
+            # of a 5s round-trip to the daemon.
+            profiles = entry.get("profiles")
+            if not isinstance(profiles, list):
+                # Empty / missing snapshot — let the daemon decide.
+                return True
+            for p in profiles:
+                if not isinstance(p, dict):
+                    continue
+                if p.get("name") == hermes_profile:
+                    occupied = p.get("occupiedBy")
+                    if isinstance(occupied, str) and occupied:
+                        return False
                     return True
             return False
         return True
@@ -1996,7 +2020,12 @@ async def provision_agent(
         raise HTTPException(status_code=409, detail="daemon_revoked")
     if not is_daemon_online(body.daemon_instance_id):
         raise HTTPException(status_code=409, detail="daemon_offline")
-    if not _daemon_lists_runtime(instance, runtime, body.openclaw_gateway):
+    if not _daemon_lists_runtime(
+        instance,
+        runtime,
+        body.openclaw_gateway,
+        body.hermes_profile,
+    ):
         raise HTTPException(status_code=409, detail="runtime_unavailable")
 
     # --- Quota check ---------------------------------------------------
@@ -2100,6 +2129,12 @@ async def provision_agent(
         frame_params["credentials"]["openclawGateway"] = body.openclaw_gateway
         if body.openclaw_agent:
             frame_params["credentials"]["openclawAgent"] = body.openclaw_agent
+    if body.hermes_profile:
+        # Same dual-write pattern as openclaw — top-level nested form for the
+        # daemon's runtime selector, flat credentials mirror for the offline
+        # reload path.
+        frame_params["hermes"] = {"profile": body.hermes_profile}
+        frame_params["credentials"]["hermesProfile"] = body.hermes_profile
 
     # Seed the daemon's policyResolver with the agent's default attention so
     # it has a real policy from message zero (no first-message refetch race).

--- a/frontend/src/components/dashboard/CreateAgentDialog.tsx
+++ b/frontend/src/components/dashboard/CreateAgentDialog.tsx
@@ -84,6 +84,7 @@ export default function CreateAgentDialog({
   const [selectedRuntimeId, setSelectedRuntimeId] = useState<string | null>(null);
   const [selectedGateway, setSelectedGateway] = useState<string | null>(null);
   const [selectedOpenclawAgent, setSelectedOpenclawAgent] = useState<string | null>(null);
+  const [selectedHermesProfile, setSelectedHermesProfile] = useState<string | null>(null);
   const [name, setName] = useState("");
   const [bio, setBio] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -147,6 +148,26 @@ export default function CreateAgentDialog({
     setSelectedGateway(reachable[0]?.name ?? null);
     setSelectedOpenclawAgent(null);
   }, [selectedRuntime, selectedRuntimeId, selectedGateway]);
+
+  // Auto-pick the first available hermes profile when the user lands on
+  // hermes-agent. Prefer the active profile, falling back to the first
+  // unoccupied entry. Reset when leaving the runtime.
+  useEffect(() => {
+    if (selectedRuntimeId !== "hermes-agent") {
+      setSelectedHermesProfile(null);
+      return;
+    }
+    const profiles = selectedRuntime?.profiles ?? [];
+    const stillAvailable =
+      selectedHermesProfile &&
+      profiles.some(
+        (p) => p.name === selectedHermesProfile && !p.occupiedBy,
+      );
+    if (stillAvailable) return;
+    const active = profiles.find((p) => p.isActive && !p.occupiedBy);
+    const firstFree = profiles.find((p) => !p.occupiedBy);
+    setSelectedHermesProfile((active ?? firstFree)?.name ?? null);
+  }, [selectedRuntime, selectedRuntimeId, selectedHermesProfile]);
 
   const showEmptyState = loaded && onlineDaemons.length === 0;
 
@@ -220,6 +241,9 @@ export default function CreateAgentDialog({
               ...(selectedOpenclawAgent ? { openclawAgent: selectedOpenclawAgent } : {}),
             }
           : {}),
+        ...(selectedRuntimeId === "hermes-agent" && selectedHermesProfile
+          ? { hermesProfile: selectedHermesProfile }
+          : {}),
       });
       await onSuccess(res.agentId);
       onClose();
@@ -231,10 +255,12 @@ export default function CreateAgentDialog({
   }
 
   const needsOpenclawGateway = selectedRuntimeId === "openclaw-acp";
+  const needsHermesProfile = selectedRuntimeId === "hermes-agent";
   const canSubmit =
     !!selectedDaemonId &&
     !!selectedRuntimeId &&
     (!needsOpenclawGateway || !!selectedGateway) &&
+    (!needsHermesProfile || !!selectedHermesProfile) &&
     !submitting;
 
   return (
@@ -370,6 +396,15 @@ export default function CreateAgentDialog({
                 }}
                 selectedAgent={selectedOpenclawAgent}
                 onSelectAgent={setSelectedOpenclawAgent}
+                disabled={submitting}
+              />
+            )}
+
+            {needsHermesProfile && (
+              <HermesProfilePicker
+                runtime={selectedRuntime}
+                selectedProfile={selectedHermesProfile}
+                onSelect={setSelectedHermesProfile}
                 disabled={submitting}
               />
             )}
@@ -650,6 +685,80 @@ function OpenclawGatewayPicker({
           </select>
         )}
       </div>
+    </div>
+  );
+}
+
+function HermesProfilePicker({
+  runtime,
+  selectedProfile,
+  onSelect,
+  disabled,
+}: {
+  runtime: DaemonRuntime | null;
+  selectedProfile: string | null;
+  onSelect: (name: string | null) => void;
+  disabled: boolean;
+}) {
+  const profiles = runtime?.profiles ?? [];
+  if (!runtime?.available) {
+    return null;
+  }
+  if (profiles.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-glass-border bg-glass-bg/40 px-3 py-3 text-xs text-text-secondary">
+        No hermes profiles detected. Make sure hermes is installed and run{" "}
+        <code className="mx-1 font-mono">hermes profile create &lt;name&gt;</code>
+        on this device, then refresh runtimes.
+      </div>
+    );
+  }
+  const allOccupied = profiles.every((p) => !!p.occupiedBy);
+  return (
+    <div>
+      <label className="mb-1.5 block text-xs font-semibold uppercase tracking-wider text-text-secondary">
+        Hermes profile
+      </label>
+      <select
+        disabled={disabled}
+        value={selectedProfile ?? ""}
+        onChange={(e) => onSelect(e.target.value || null)}
+        className="w-full rounded-xl border border-glass-border bg-deep-black px-3 py-2 text-sm text-text-primary"
+      >
+        <option value="" disabled>
+          Select a profile
+        </option>
+        {profiles.map((p) => {
+          const occupied = !!p.occupiedBy;
+          const labelParts: string[] = [p.name];
+          if (p.isDefault) labelParts.push("(default)");
+          if (p.modelName) labelParts.push(`— ${p.modelName}`);
+          if (occupied) {
+            labelParts.push(
+              `· bound to ${p.occupiedByName ?? p.occupiedBy ?? "another agent"}`,
+            );
+          } else if (p.isActive) {
+            labelParts.push("· active");
+          }
+          return (
+            <option key={p.name} value={p.name} disabled={occupied}>
+              {labelParts.join(" ")}
+            </option>
+          );
+        })}
+      </select>
+      <p className="mt-1 text-[11px] text-text-tertiary">
+        BotCord agent attaches to this profile&apos;s{" "}
+        <code className="font-mono">HERMES_HOME</code>; sessions, memory and
+        skills are shared with your command-line <code className="font-mono">hermes</code>.
+      </p>
+      {allOccupied && (
+        <p className="mt-1 text-[11px] text-orange-400">
+          All profiles are bound. Run{" "}
+          <code className="font-mono">hermes profile create &lt;name&gt; --clone</code>{" "}
+          on this device and refresh.
+        </p>
+      )}
     </div>
   );
 }

--- a/frontend/src/store/useDaemonStore.ts
+++ b/frontend/src/store/useDaemonStore.ts
@@ -33,6 +33,19 @@ export interface DaemonRuntimeEndpoint {
   }>;
 }
 
+export interface DaemonHermesProfile {
+  name: string;
+  home: string;
+  isDefault?: boolean;
+  isActive?: boolean;
+  /** BotCord agent currently bound to this profile, if any. */
+  occupiedBy?: string;
+  occupiedByName?: string;
+  modelName?: string;
+  sessionsCount?: number;
+  hasSoul?: boolean;
+}
+
 export interface DaemonRuntime {
   id: string;
   available: boolean;
@@ -41,6 +54,8 @@ export interface DaemonRuntime {
   error?: string;
   /** OpenClaw-style runtimes carry per-gateway endpoint probe results. */
   endpoints?: DaemonRuntimeEndpoint[];
+  /** Hermes runtime carries the per-device profile listing (1 BotCord agent : 1 profile). */
+  profiles?: DaemonHermesProfile[];
 }
 
 export interface DaemonInstance {
@@ -63,6 +78,8 @@ export interface ProvisionAgentInput {
   openclawGateway?: string;
   /** OpenClaw agent profile override. */
   openclawAgent?: string;
+  /** Hermes profile name to attach to (only when runtime === "hermes-agent"). */
+  hermesProfile?: string;
 }
 
 export interface ProvisionAgentResult {
@@ -226,6 +243,34 @@ function normalizeRuntimes(raw: unknown): DaemonRuntime[] | null | undefined {
           })
           .filter(Boolean) as DaemonRuntimeEndpoint[]
       : undefined;
+    const profiles = Array.isArray(r.profiles)
+      ? ((r.profiles as unknown[])
+          .map((rawP) => {
+            if (!rawP || typeof rawP !== "object") return null;
+            const p = rawP as Record<string, unknown>;
+            const name = typeof p.name === "string" ? p.name : null;
+            const home = typeof p.home === "string" ? p.home : null;
+            if (!name || !home) return null;
+            return {
+              name,
+              home,
+              isDefault: p.isDefault === true,
+              isActive: p.isActive === true,
+              occupiedBy:
+                typeof p.occupiedBy === "string" ? p.occupiedBy : undefined,
+              occupiedByName:
+                typeof p.occupiedByName === "string"
+                  ? p.occupiedByName
+                  : undefined,
+              modelName:
+                typeof p.modelName === "string" ? p.modelName : undefined,
+              sessionsCount:
+                typeof p.sessionsCount === "number" ? p.sessionsCount : undefined,
+              hasSoul: p.hasSoul === true,
+            } as DaemonHermesProfile;
+          })
+          .filter(Boolean) as DaemonHermesProfile[])
+      : undefined;
     out.push({
       id,
       available: r.available === true,
@@ -233,6 +278,7 @@ function normalizeRuntimes(raw: unknown): DaemonRuntime[] | null | undefined {
       path: typeof r.path === "string" ? r.path : undefined,
       error: typeof r.error === "string" ? r.error : undefined,
       endpoints,
+      profiles,
     });
   }
   return out;
@@ -456,6 +502,7 @@ export const useDaemonStore = create<DaemonState>()((set, get) => ({
     if (input.bio) body.bio = input.bio;
     if (input.openclawGateway) body.openclaw_gateway = input.openclawGateway;
     if (input.openclawAgent) body.openclaw_agent = input.openclawAgent;
+    if (input.hermesProfile) body.hermes_profile = input.hermesProfile;
 
     const res = await fetch("/api/users/me/agents/provision", {
       method: "POST",

--- a/packages/daemon/src/__tests__/provision.test.ts
+++ b/packages/daemon/src/__tests__/provision.test.ts
@@ -1421,3 +1421,162 @@ describe("update_agent handler", () => {
     expect(ack.error?.code).toBe("bad_params");
   });
 });
+
+describe("provision_agent hermes profile attach", () => {
+  it("rejects invalid hermes profile names before resolving HERMES_HOME", async () => {
+    await withSandboxHome(async ({ tmp, fs, path: nodePath }) => {
+      fs.mkdirSync(nodePath.join(tmp, ".hermes", "profiles"), {
+        recursive: true,
+      });
+      fs.mkdirSync(nodePath.join(tmp, "outside"), { recursive: true });
+      const gw = makeFakeGateway();
+      const provisioner = createProvisioner({
+        gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+      });
+      const privateKey = Buffer.alloc(32, 23).toString("base64");
+      const ack = await provisioner({
+        id: "req_hp_invalid",
+        type: CONTROL_FRAME_TYPES.PROVISION_AGENT,
+        params: {
+          runtime: "hermes-agent",
+          hermes: { profile: "../../outside" },
+          credentials: {
+            agentId: "ag_hp_invalid",
+            keyId: "k_hp_invalid",
+            privateKey,
+            hubUrl: "https://hub.example",
+            runtime: "hermes-agent",
+          },
+        },
+      });
+      expect(ack.ok).toBe(false);
+      expect(ack.error?.code).toBe("hermes_profile_invalid");
+      expect(gw.addChannel).not.toHaveBeenCalled();
+    });
+  });
+
+  it("rejects with hermes_profile_not_found when the profile does not exist", async () => {
+    await withSandboxHome(async ({ tmp: _tmp }) => {
+      const gw = makeFakeGateway();
+      const provisioner = createProvisioner({
+        gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+      });
+      const privateKey = Buffer.alloc(32, 11).toString("base64");
+      const ack = await provisioner({
+        id: "req_hp_missing",
+        type: CONTROL_FRAME_TYPES.PROVISION_AGENT,
+        params: {
+          runtime: "hermes-agent",
+          hermes: { profile: "ghost" },
+          credentials: {
+            agentId: "ag_hp_missing",
+            keyId: "k_hp",
+            privateKey,
+            hubUrl: "https://hub.example",
+            runtime: "hermes-agent",
+          },
+        },
+      });
+      expect(ack.ok).toBe(false);
+      expect(ack.error?.code).toBe("hermes_profile_not_found");
+      expect(ack.error?.profile).toBe("ghost");
+      expect(gw.addChannel).not.toHaveBeenCalled();
+    });
+  });
+
+  it("persists hermesProfile to credentials when the profile exists and is free", async () => {
+    await withSandboxHome(async ({ tmp, fs, path: nodePath }) => {
+      // Lay down ~/.hermes/profiles/coder so validateHermesProfileForProvision
+      // sees it.
+      fs.mkdirSync(nodePath.join(tmp, ".hermes", "profiles", "coder"), {
+        recursive: true,
+      });
+      const gw = makeFakeGateway();
+      const provisioner = createProvisioner({
+        gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+      });
+      const privateKey = Buffer.alloc(32, 13).toString("base64");
+      const ack = await provisioner({
+        id: "req_hp_ok",
+        type: CONTROL_FRAME_TYPES.PROVISION_AGENT,
+        params: {
+          runtime: "hermes-agent",
+          hermes: { profile: "coder" },
+          credentials: {
+            agentId: "ag_hp_ok",
+            keyId: "k_hp",
+            privateKey,
+            hubUrl: "https://hub.example",
+            displayName: "coder agent",
+            runtime: "hermes-agent",
+          },
+        },
+      });
+      expect(ack.ok).toBe(true);
+      expect(gw.addChannel).toHaveBeenCalledOnce();
+
+      const credFile = nodePath.join(
+        tmp,
+        ".botcord",
+        "credentials",
+        "ag_hp_ok.json",
+      );
+      const saved = JSON.parse(fs.readFileSync(credFile, "utf8")) as Record<
+        string,
+        unknown
+      >;
+      expect(saved.hermesProfile).toBe("coder");
+      expect(saved.runtime).toBe("hermes-agent");
+    });
+  });
+
+  it("rejects with hermes_profile_occupied when another agent already binds the profile", async () => {
+    await withSandboxHome(async ({ tmp, fs, path: nodePath }) => {
+      fs.mkdirSync(nodePath.join(tmp, ".hermes", "profiles", "coder"), {
+        recursive: true,
+      });
+      const gw = makeFakeGateway();
+      const provisioner = createProvisioner({
+        gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+      });
+
+      const privateKey = Buffer.alloc(32, 17).toString("base64");
+      const okAck = await provisioner({
+        id: "req_first",
+        type: CONTROL_FRAME_TYPES.PROVISION_AGENT,
+        params: {
+          runtime: "hermes-agent",
+          hermes: { profile: "coder" },
+          credentials: {
+            agentId: "ag_first",
+            keyId: "k_first",
+            privateKey,
+            hubUrl: "https://hub.example",
+            runtime: "hermes-agent",
+          },
+        },
+      });
+      expect(okAck.ok).toBe(true);
+
+      const privateKey2 = Buffer.alloc(32, 19).toString("base64");
+      const ack = await provisioner({
+        id: "req_second",
+        type: CONTROL_FRAME_TYPES.PROVISION_AGENT,
+        params: {
+          runtime: "hermes-agent",
+          hermes: { profile: "coder" },
+          credentials: {
+            agentId: "ag_second",
+            keyId: "k_second",
+            privateKey: privateKey2,
+            hubUrl: "https://hub.example",
+            runtime: "hermes-agent",
+          },
+        },
+      });
+      expect(ack.ok).toBe(false);
+      expect(ack.error?.code).toBe("hermes_profile_occupied");
+      expect(ack.error?.occupiedBy).toBe("ag_first");
+    });
+  });
+});

--- a/packages/daemon/src/agent-discovery.ts
+++ b/packages/daemon/src/agent-discovery.ts
@@ -42,6 +42,8 @@ export interface DiscoveredAgentCredential {
   openclawGateway?: string;
   /** OpenClaw agent profile override from credentials. */
   openclawAgent?: string;
+  /** Hermes profile name from credentials (only meaningful for hermes-agent). */
+  hermesProfile?: string;
   /** Key id from the credentials file — surfaced so boot-time workspace
    * seeding (see daemon-agent-workspace-plan.md §9) can render identity.md
    * without re-reading the file. */
@@ -182,6 +184,7 @@ export function discoverAgentCredentials(
     if (creds.cwd) entry.cwd = creds.cwd;
     if (creds.openclawGateway) entry.openclawGateway = creds.openclawGateway;
     if (creds.openclawAgent) entry.openclawAgent = creds.openclawAgent;
+    if (creds.hermesProfile) entry.hermesProfile = creds.hermesProfile;
     if (creds.keyId) entry.keyId = creds.keyId;
     if (creds.savedAt) entry.savedAt = creds.savedAt;
     agents.push(entry);

--- a/packages/daemon/src/agent-workspace.ts
+++ b/packages/daemon/src/agent-workspace.ts
@@ -357,14 +357,25 @@ export function ensureAgentCodexHome(agentId: string): string {
  * loader (which only sees this isolated HERMES_HOME, not `~/.hermes`)
  * can discover them.
  */
-export function ensureAgentHermesWorkspace(agentId: string): {
+export function ensureAgentHermesWorkspace(
+  agentId: string,
+  opts: { attached?: boolean } = {},
+): {
   hermesHome: string;
   hermesWorkspace: string;
 } {
   const hermesHome = agentHermesHomeDir(agentId);
   const hermesWorkspace = agentHermesWorkspaceDir(agentId);
-  mkdirTolerant(hermesHome);
   mkdirTolerant(hermesWorkspace);
+  // Attach mode: HERMES_HOME points at the user's `~/.hermes/profiles/<n>/`
+  // so we MUST NOT touch the per-agent isolated home. The cwd
+  // (`hermesWorkspace`) is still ours and `prepareTurn` writes AGENTS.md
+  // there — that's the only thing the daemon is allowed to author when
+  // attached to a user-owned profile.
+  if (opts.attached) {
+    return { hermesHome, hermesWorkspace };
+  }
+  mkdirTolerant(hermesHome);
   writeIfMissing(
     path.join(hermesHome, ".env"),
     "# hermes-agent environment overrides for this BotCord agent.\n" +

--- a/packages/daemon/src/daemon-config-map.ts
+++ b/packages/daemon/src/daemon-config-map.ts
@@ -27,6 +27,8 @@ export interface AgentRuntimeMeta {
   openclawGateway?: string;
   /** Optional override of the OpenClaw agent profile within the gateway. */
   openclawAgent?: string;
+  /** Hermes profile name to attach to (`runtime === "hermes-agent"` only). */
+  hermesProfile?: string;
 }
 
 /** Profile + tokenFile-resolved bearer token. Exported so other module-boundary
@@ -338,6 +340,9 @@ export function buildManagedRoutes(
         continue;
       }
       route.gateway = resolved;
+    }
+    if (runtime === "hermes-agent" && meta.hermesProfile) {
+      route.hermesProfile = meta.hermesProfile;
     }
     out.set(agentId, route);
   }

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -562,7 +562,7 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
  */
 export interface BootBackfillResult {
   credentialPathByAgentId: Map<string, string>;
-  agentRuntimes: Record<string, { runtime?: string; cwd?: string; openclawGateway?: string; openclawAgent?: string }>;
+  agentRuntimes: Record<string, { runtime?: string; cwd?: string; openclawGateway?: string; openclawAgent?: string; hermesProfile?: string }>;
 }
 
 /**
@@ -585,12 +585,13 @@ export function backfillBootAgents(
   const failed: string[] = [];
   for (const a of agents) {
     if (a.credentialsFile) credentialPathByAgentId.set(a.agentId, a.credentialsFile);
-    if (a.runtime || a.cwd || a.openclawGateway || a.openclawAgent) {
+    if (a.runtime || a.cwd || a.openclawGateway || a.openclawAgent || a.hermesProfile) {
       agentRuntimes[a.agentId] = {
         ...(a.runtime ? { runtime: a.runtime } : {}),
         ...(a.cwd ? { cwd: a.cwd } : {}),
         ...(a.openclawGateway ? { openclawGateway: a.openclawGateway } : {}),
         ...(a.openclawAgent ? { openclawAgent: a.openclawAgent } : {}),
+        ...(a.hermesProfile ? { hermesProfile: a.hermesProfile } : {}),
       };
     }
     // Seed files are written only when missing (see `ensureAgentWorkspace`),

--- a/packages/daemon/src/gateway/__tests__/hermes-agent-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/hermes-agent-adapter.test.ts
@@ -12,6 +12,8 @@ import os from "node:os";
 import path from "node:path";
 import {
   HermesAgentAdapter,
+  hermesProfileHomeDir,
+  listHermesProfiles,
   resolveHermesAcpCommand,
 } from "../runtimes/hermes-agent.js";
 import { agentHermesWorkspaceDir } from "../../agent-workspace.js";
@@ -365,5 +367,90 @@ describe("HermesAgentAdapter", () => {
     expect(status.some((s) => s.phase === "updated" && s.label === "Thinking")).toBe(true);
     // And the prompt-done thinking.stopped fires from the ACP base.
     expect(status.some((s) => s.phase === "stopped")).toBe(true);
+  });
+});
+
+describe("listHermesProfiles", () => {
+  it("returns the synthetic default entry when only ~/.hermes exists", () => {
+    // beforeAll set HOME to an empty tmp dir; create just ~/.hermes.
+    const root = path.join(agentHomeRoot, ".hermes");
+    mkdirSync(root, { recursive: true });
+    // Drop a config.yaml to exercise the optional model snapshot.
+    writeFileSync(
+      path.join(root, "config.yaml"),
+      "model:\n  default: anthropic/claude-opus-4.6\n  provider: custom\n",
+    );
+    writeFileSync(path.join(root, "SOUL.md"), "test soul");
+    mkdirSync(path.join(root, "sessions"), { recursive: true });
+    writeFileSync(path.join(root, "sessions", "20260101_abc.jsonl"), "{}\n");
+
+    const profiles = listHermesProfiles();
+    const def = profiles.find((p) => p.name === "default");
+    expect(def).toBeDefined();
+    expect(def?.isDefault).toBe(true);
+    expect(def?.home).toBe(root);
+    expect(def?.modelName).toBe("anthropic/claude-opus-4.6");
+    expect(def?.hasSoul).toBe(true);
+    expect(def?.sessionsCount).toBe(1);
+
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("enumerates named profiles and honours active_profile", () => {
+    const root = path.join(agentHomeRoot, ".hermes");
+    mkdirSync(path.join(root, "profiles", "coder"), { recursive: true });
+    mkdirSync(path.join(root, "profiles", "writer"), { recursive: true });
+    // Garbage / invalid profile names should be skipped.
+    mkdirSync(path.join(root, "profiles", "BadName"), { recursive: true });
+    writeFileSync(path.join(root, "active_profile"), "writer\n");
+
+    const profiles = listHermesProfiles();
+    const names = profiles.map((p) => p.name).sort();
+    expect(names).toEqual(["coder", "default", "writer"]);
+    const writer = profiles.find((p) => p.name === "writer");
+    expect(writer?.isActive).toBe(true);
+    expect(writer?.home).toBe(hermesProfileHomeDir("writer"));
+
+    rmSync(root, { recursive: true, force: true });
+  });
+});
+
+describe("HermesAgentAdapter.spawnEnv attach mode", () => {
+  it("points HERMES_HOME at the user profile when hermesProfile is set", () => {
+    const adapter = new HermesAgentAdapter({ binary: "/dev/null" });
+    type EnvProbe = { HERMES_HOME?: string };
+    const env = (
+      adapter as unknown as {
+        spawnEnv: (opts: unknown) => EnvProbe;
+      }
+    ).spawnEnv({
+      text: "",
+      sessionId: null,
+      cwd: tmpRoot,
+      accountId: "ag_attach",
+      signal: new AbortController().signal,
+      trustLevel: "owner",
+      hermesProfile: "coder",
+    });
+    expect(env.HERMES_HOME).toBe(hermesProfileHomeDir("coder"));
+  });
+
+  it("falls back to per-agent isolated home when hermesProfile is unset", () => {
+    const adapter = new HermesAgentAdapter({ binary: "/dev/null" });
+    type EnvProbe = { HERMES_HOME?: string };
+    const env = (
+      adapter as unknown as {
+        spawnEnv: (opts: unknown) => EnvProbe;
+      }
+    ).spawnEnv({
+      text: "",
+      sessionId: null,
+      cwd: tmpRoot,
+      accountId: "ag_isolated",
+      signal: new AbortController().signal,
+      trustLevel: "owner",
+    });
+    expect(env.HERMES_HOME).toContain(path.join(".botcord", "agents", "ag_isolated"));
+    expect(env.HERMES_HOME).not.toBe(hermesProfileHomeDir("default"));
   });
 });

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -1050,6 +1050,7 @@ export class Dispatcher {
           onBlock,
           onStatus,
           gateway: route.gateway,
+          ...(route.hermesProfile ? { hermesProfile: route.hermesProfile } : {}),
         });
       } catch (err) {
         threw = err;

--- a/packages/daemon/src/gateway/runtimes/hermes-agent.ts
+++ b/packages/daemon/src/gateway/runtimes/hermes-agent.ts
@@ -1,4 +1,5 @@
-import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
 import {
   agentHermesHomeDir,
@@ -63,6 +64,139 @@ export function probeHermesAgent(deps: ProbeDeps = {}): RuntimeProbeResult {
     path: command,
     version: readCommandVersion(command, [], deps) ?? undefined,
   };
+}
+
+/**
+ * Discovered hermes profile entry (daemon-side shape; wire shape lives in
+ * protocol-core's `HermesProfileProbe`). Occupancy is filled in later by
+ * `provision.ts` from local credentials, not here.
+ */
+export interface HermesProfileInfo {
+  name: string;
+  home: string;
+  isDefault?: boolean;
+  isActive?: boolean;
+  modelName?: string;
+  sessionsCount?: number;
+  hasSoul?: boolean;
+}
+
+/**
+ * Resolve the hermes root (`~/.hermes`) — this is the location of the
+ * synthetic `default` profile per upstream's "default profile = HERMES_HOME
+ * itself" convention (`hermes_cli/profiles.py:8`).
+ */
+export function hermesRootDir(): string {
+  return path.join(homedir(), ".hermes");
+}
+
+/** Profile-name shape mirrors `hermes_cli/profiles.py:_PROFILE_ID_RE`. */
+const HERMES_PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+
+export function isValidHermesProfileName(name: string): boolean {
+  return name === "default" || HERMES_PROFILE_NAME_RE.test(name);
+}
+
+/**
+ * Resolve a hermes profile's HERMES_HOME directory. `default` maps to
+ * `~/.hermes`; all other names map to `~/.hermes/profiles/<name>`. Mirrors
+ * `hermes_cli/profiles.py:get_profile_dir`.
+ */
+export function hermesProfileHomeDir(name: string): string {
+  if (!isValidHermesProfileName(name)) {
+    throw new Error(`Invalid hermes profile name: ${name}`);
+  }
+  if (name === "default") return hermesRootDir();
+  return path.join(hermesRootDir(), "profiles", name);
+}
+
+function readActiveProfileName(): string {
+  try {
+    const raw = readFileSync(path.join(hermesRootDir(), "active_profile"), "utf8").trim();
+    return raw || "default";
+  } catch {
+    return "default";
+  }
+}
+
+function readProfileModelName(profileHome: string): string | undefined {
+  try {
+    const raw = readFileSync(path.join(profileHome, "config.yaml"), "utf8");
+    // Cheap surface-level YAML peek — config.yaml's first block is
+    // `model:\n  default: <name>`. Avoid pulling in a YAML dependency for
+    // a single optional field.
+    const match = raw.match(/^model:\s*\n(?:[ \t]+[^\n]*\n)*?[ \t]+default:\s*([^\n#]+)/m);
+    if (!match) return undefined;
+    return match[1].trim().replace(/^['"]|['"]$/g, "") || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function countSessions(profileHome: string): number | undefined {
+  try {
+    const dir = path.join(profileHome, "sessions");
+    if (!existsSync(dir)) return 0;
+    return readdirSync(dir).filter((f) => f.endsWith(".jsonl")).length;
+  } catch {
+    return undefined;
+  }
+}
+
+function hasSoul(profileHome: string): boolean {
+  return existsSync(path.join(profileHome, "SOUL.md"));
+}
+
+/**
+ * Enumerate available hermes profiles on this device. Pure local filesystem
+ * scan — does not invoke any hermes binary. Returns the synthetic `default`
+ * entry first when `~/.hermes` exists (which it should, given that the probe
+ * already located `hermes-acp`); each `~/.hermes/profiles/<name>/` directory
+ * follows.
+ */
+export function listHermesProfiles(): HermesProfileInfo[] {
+  const out: HermesProfileInfo[] = [];
+  const root = hermesRootDir();
+  const active = readActiveProfileName();
+
+  if (existsSync(root)) {
+    out.push({
+      name: "default",
+      home: root,
+      isDefault: true,
+      isActive: active === "default",
+      modelName: readProfileModelName(root),
+      sessionsCount: countSessions(root),
+      hasSoul: hasSoul(root),
+    });
+  }
+
+  const profilesDir = path.join(root, "profiles");
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(profilesDir);
+  } catch {
+    return out;
+  }
+  for (const name of entries) {
+    if (!HERMES_PROFILE_NAME_RE.test(name)) continue;
+    const home = path.join(profilesDir, name);
+    try {
+      if (!statSync(home).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    out.push({
+      name,
+      home,
+      isActive: active === name,
+      modelName: readProfileModelName(home),
+      sessionsCount: countSessions(home),
+      hasSoul: hasSoul(home),
+    });
+  }
+
+  return out;
 }
 
 /**
@@ -141,7 +275,14 @@ export class HermesAgentAdapter extends AcpRuntimeAdapter {
       // Route dangerous tool calls through ACP request_permission.
       HERMES_INTERACTIVE: "1",
     };
-    if (opts.accountId) {
+    // Attach mode: BotCord agent shares a hermes profile (state.db /
+    // sessions / skills / .env) with the user's command-line `hermes`. In
+    // this mode we DO NOT seed a private home — the profile is wholly owned
+    // by the user, and AGENTS.md is written under the per-agent
+    // hermes-workspace cwd (NOT into the profile root) by `prepareTurn`.
+    if (opts.hermesProfile) {
+      env.HERMES_HOME = hermesProfileHomeDir(opts.hermesProfile);
+    } else if (opts.accountId) {
       env.HERMES_HOME = agentHermesHomeDir(opts.accountId);
     }
     return env;
@@ -160,7 +301,9 @@ export class HermesAgentAdapter extends AcpRuntimeAdapter {
    */
   protected prepareTurn(opts: RuntimeRunOptions): void {
     if (!opts.accountId) return;
-    const { hermesWorkspace } = ensureAgentHermesWorkspace(opts.accountId);
+    const { hermesWorkspace } = ensureAgentHermesWorkspace(opts.accountId, {
+      attached: !!opts.hermesProfile,
+    });
     const target = path.join(hermesWorkspace, "AGENTS.md");
     const tmp = path.join(hermesWorkspace, `.AGENTS.md.${process.pid}.tmp`);
     mkdirSync(hermesWorkspace, { recursive: true, mode: 0o700 });

--- a/packages/daemon/src/gateway/types.ts
+++ b/packages/daemon/src/gateway/types.ts
@@ -45,6 +45,14 @@ export interface GatewayRoute {
   trustLevel?: TrustLevel;
   /** Required when `runtime === "openclaw-acp"`. Resolved at config-load time. */
   gateway?: ResolvedOpenclawGateway;
+  /**
+   * Hermes profile name to attach to. Set when `runtime === "hermes-agent"`
+   * and the agent is bound to a specific `~/.hermes/profiles/<name>/`. The
+   * dispatcher forwards this to the adapter as
+   * {@link RuntimeRunOptions.hermesProfile}, which is what the adapter uses
+   * to switch `HERMES_HOME` at spawn time.
+   */
+  hermesProfile?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -362,6 +370,15 @@ export interface RuntimeRunOptions {
    * lifting service URLs out of `extraArgs` into typed first-class fields.
    */
   gateway?: ResolvedOpenclawGateway;
+  /**
+   * Hermes profile to attach to. Only meaningful when `runtime ===
+   * "hermes-agent"`. When set, the adapter switches
+   * `HERMES_HOME=~/.hermes/profiles/<name>/` (or `~/.hermes` for `default`)
+   * so the BotCord agent shares state.db / sessions / skills with the
+   * user's command-line `hermes`. Mirrors how `gateway` is lifted out of
+   * `extraArgs` for the openclaw-acp runtime.
+   */
+  hermesProfile?: string;
 }
 
 /** Result returned by a runtime adapter after a turn completes. */

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -4,7 +4,7 @@
  * side effects (register agent, write credentials, load route, add/remove
  * gateway channel) and return an ack payload.
  */
-import { existsSync, readFileSync, rmSync, unlinkSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, rmSync, unlinkSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import {
@@ -22,6 +22,7 @@ import {
   type ProvisionAgentParams,
   type RevokeAgentParams,
   type RevokeAgentResult,
+  type HermesProfileProbe,
   type RuntimeProbeResult,
   type StoredBotCordCredentials,
   type UpdateAgentParams,
@@ -54,6 +55,11 @@ import {
   ensureAgentWorkspace,
 } from "./agent-workspace.js";
 import { detectRuntimes, getAdapterModule } from "./adapters/runtimes.js";
+import {
+  hermesProfileHomeDir,
+  isValidHermesProfileName,
+  listHermesProfiles,
+} from "./gateway/runtimes/hermes-agent.js";
 import { log as daemonLog } from "./log.js";
 import { discoverAgentCredentials } from "./agent-discovery.js";
 
@@ -171,7 +177,32 @@ export function createProvisioner(opts: ProvisionerOptions): (
           runtime: pickRuntime(params) ?? null,
           name: params.name ?? null,
         });
-        const agent = await provisionAgent(params, { gateway, register, onAgentInstalled });
+        let agent: ProvisionedAgent;
+        try {
+          agent = await provisionAgent(params, {
+            gateway,
+            register,
+            onAgentInstalled,
+          });
+        } catch (err) {
+          if (err instanceof HermesProfileError) {
+            daemonLog.warn("provision_agent: hermes profile rejected", {
+              code: err.code,
+              profile: err.profile,
+              occupiedBy: err.occupiedBy ?? null,
+            });
+            return {
+              ok: false,
+              error: {
+                code: err.code,
+                message: err.message,
+                ...(err.occupiedBy ? { occupiedBy: err.occupiedBy } : {}),
+                profile: err.profile,
+              },
+            };
+          }
+          throw err;
+        }
         // Seed the policy resolver from the optional `defaultAttention` /
         // `attentionKeywords` fields (PR3, control-frame.ts). Hub builds that
         // don't yet emit these stay backwards-compatible — the resolver just
@@ -330,6 +361,24 @@ async function provisionAgent(
         });
         return installExistingOpenclawBinding(existing.agentId, ctx);
       }
+      const cfg = loadConfig();
+      const credentials = await materializeCredentials(resolvedParams, cfg, ctx, explicitCwd);
+      return installLocalAgent(credentials, {
+        ...ctx,
+        cfg,
+        bio: params.bio,
+        source: params.credentials ? "hub-supplied" : "registered",
+      });
+    });
+  }
+
+  const hermesSel = pickHermesSelection(resolvedParams);
+  if (hermesSel) {
+    return withHermesProvisionLock(hermesSel, async () => {
+      // Race-safe re-check inside the per-profile lock so two concurrent
+      // provisions for the same profile (e.g. two dashboard tabs) cannot
+      // both succeed.
+      validateHermesProfileForProvision(hermesSel, params.credentials?.agentId);
       const cfg = loadConfig();
       const credentials = await materializeCredentials(resolvedParams, cfg, ctx, explicitCwd);
       return installLocalAgent(credentials, {
@@ -530,6 +579,9 @@ function upsertManagedRouteForCredentials(
       };
     }
   }
+  if (synthRoute.runtime === "hermes-agent" && credentials.hermesProfile) {
+    synthRoute.hermesProfile = credentials.hermesProfile;
+  }
   gateway.upsertManagedRoute(credentials.agentId, synthRoute);
 }
 
@@ -625,6 +677,8 @@ async function materializeCredentials(
     const openclawSel = pickOpenclawSelection(params);
     if (openclawSel.gateway) record.openclawGateway = openclawSel.gateway;
     if (openclawSel.agent) record.openclawAgent = openclawSel.agent;
+    const hermesSel = pickHermesSelection(params);
+    if (hermesSel) record.hermesProfile = hermesSel;
     return record;
   }
 
@@ -657,6 +711,8 @@ async function materializeCredentials(
   const openclawSel = pickOpenclawSelection(params);
   if (openclawSel.gateway) record.openclawGateway = openclawSel.gateway;
   if (openclawSel.agent) record.openclawAgent = openclawSel.agent;
+  const hermesSel = pickHermesSelection(params);
+  if (hermesSel) record.hermesProfile = hermesSel;
   return record;
 }
 
@@ -748,6 +804,94 @@ function withResolvedOpenclawSelection(
       ...(selection.agent ? { agent: selection.agent } : {}),
     },
   };
+}
+
+/**
+ * Resolve hermes profile selection from a `provision_agent` frame. Top-level
+ * `params.hermes.profile` (nested) wins over the flat
+ * `credentials.hermesProfile` mirror. Returning `undefined` is fine — the
+ * adapter falls back to the BotCord-isolated HERMES_HOME under
+ * `~/.botcord/agents/<id>/` when the agent is not attached to a profile.
+ */
+function pickHermesSelection(params: ProvisionAgentParams): string | undefined {
+  const top = params.hermes;
+  if (top && typeof top.profile === "string" && top.profile.length > 0) {
+    return top.profile;
+  }
+  const flat = params.credentials;
+  if (flat && typeof flat.hermesProfile === "string" && flat.hermesProfile.length > 0) {
+    return flat.hermesProfile;
+  }
+  return undefined;
+}
+
+const hermesProvisionLocks = new Map<string, Promise<unknown>>();
+
+async function withHermesProvisionLock<T>(
+  profile: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const prev = hermesProvisionLocks.get(profile) ?? Promise.resolve();
+  const next = prev.then(fn, fn);
+  hermesProvisionLocks.set(profile, next);
+  try {
+    return (await next) as T;
+  } finally {
+    if (hermesProvisionLocks.get(profile) === next) {
+      hermesProvisionLocks.delete(profile);
+    }
+  }
+}
+
+class HermesProfileError extends Error {
+  constructor(
+    public readonly code:
+      | "hermes_profile_invalid"
+      | "hermes_profile_not_found"
+      | "hermes_profile_occupied",
+    message: string,
+    public readonly profile: string,
+    public readonly occupiedBy?: string,
+  ) {
+    super(message);
+    this.name = "HermesProfileError";
+  }
+}
+
+/**
+ * Validate that `profile` exists on disk and is not already bound to another
+ * BotCord agent. Throws {@link HermesProfileError} on failure so the caller
+ * can surface the structured error code via the control-frame ack.
+ */
+function validateHermesProfileForProvision(
+  profile: string,
+  selfAgentId: string | undefined,
+): void {
+  if (!isValidHermesProfileName(profile)) {
+    throw new HermesProfileError(
+      "hermes_profile_invalid",
+      `Hermes profile "${profile}" is not a valid profile name.`,
+      profile,
+    );
+  }
+  const home = hermesProfileHomeDir(profile);
+  if (!existsSync(home)) {
+    throw new HermesProfileError(
+      "hermes_profile_not_found",
+      `Hermes profile "${profile}" does not exist at ${home}. Create it via "hermes profile create ${profile}" and retry.`,
+      profile,
+    );
+  }
+  const occupancy = profileOccupancyMap();
+  const owner = occupancy.get(profile);
+  if (owner && owner.agentId !== selfAgentId) {
+    throw new HermesProfileError(
+      "hermes_profile_occupied",
+      `Hermes profile "${profile}" is already bound to BotCord agent ${owner.agentId}.`,
+      profile,
+      owner.agentId,
+    );
+  }
 }
 
 async function withOpenclawProvisionLock<T>(
@@ -1100,6 +1244,30 @@ export function clearRuntimeProbeCache(): void {
  * Cached for {@link RUNTIME_PROBE_CACHE_TTL_MS}; pass `{ force: true }` to
  * bypass the cache.
  */
+/**
+ * Build the wire-shape `HermesProfileProbe[]` for the runtime snapshot,
+ * joining the on-disk profile listing with the BotCord-side occupancy map
+ * so dashboards can render disabled rows without a second round trip.
+ */
+function listHermesProfilesForSnapshot(
+  occupancy: Map<string, { agentId: string; agentName?: string }>,
+): HermesProfileProbe[] {
+  return listHermesProfiles().map((p) => {
+    const out: HermesProfileProbe = { name: p.name, home: p.home };
+    if (p.isDefault) out.isDefault = true;
+    if (p.isActive) out.isActive = true;
+    if (p.modelName) out.modelName = p.modelName;
+    if (typeof p.sessionsCount === "number") out.sessionsCount = p.sessionsCount;
+    if (p.hasSoul) out.hasSoul = true;
+    const owner = occupancy.get(p.name);
+    if (owner) {
+      out.occupiedBy = owner.agentId;
+      if (owner.agentName) out.occupiedByName = owner.agentName;
+    }
+    return out;
+  });
+}
+
 export function collectRuntimeSnapshot(opts: { force?: boolean } = {}): ListRuntimesResult {
   if (
     !opts.force &&
@@ -1109,6 +1277,7 @@ export function collectRuntimeSnapshot(opts: { force?: boolean } = {}): ListRunt
     return _runtimeProbeCache.value;
   }
   const entries = detectRuntimes();
+  const occupancy = profileOccupancyMap();
   const runtimes: RuntimeProbeResult[] = entries.map((entry) => {
     const record: RuntimeProbeResult = {
       id: entry.id,
@@ -1123,6 +1292,9 @@ export function collectRuntimeSnapshot(opts: { force?: boolean } = {}): ListRunt
     // already swallows throws into `{available: false}`. We leave the wire
     // field blank in that case and let callers treat `!available` as reason
     // enough; filling a synthetic message would be misleading.
+    if (entry.id === "hermes-agent" && entry.result.available) {
+      record.profiles = listHermesProfilesForSnapshot(occupancy);
+    }
     return record;
   });
   const value: ListRuntimesResult = { runtimes, probedAt: Date.now() };
@@ -1695,21 +1867,60 @@ export async function reloadConfig(ctx: { gateway: Gateway }): Promise<ReloadRes
  */
 function readAgentRuntimesFromCredentials(
   agentIds: string[],
-): Record<string, { runtime?: string; cwd?: string; openclawGateway?: string; openclawAgent?: string }> {
-  const out: Record<string, { runtime?: string; cwd?: string; openclawGateway?: string; openclawAgent?: string }> = {};
+): Record<string, { runtime?: string; cwd?: string; openclawGateway?: string; openclawAgent?: string; hermesProfile?: string }> {
+  const out: Record<string, { runtime?: string; cwd?: string; openclawGateway?: string; openclawAgent?: string; hermesProfile?: string }> = {};
   for (const id of agentIds) {
     const file = defaultCredentialsFile(id);
     try {
       if (!existsSync(file)) continue;
       const creds = loadStoredCredentials(file);
-      const entry: { runtime?: string; cwd?: string; openclawGateway?: string; openclawAgent?: string } = {};
+      const entry: { runtime?: string; cwd?: string; openclawGateway?: string; openclawAgent?: string; hermesProfile?: string } = {};
       if (creds.runtime) entry.runtime = creds.runtime;
       if (creds.cwd) entry.cwd = creds.cwd;
       if (creds.openclawGateway) entry.openclawGateway = creds.openclawGateway;
       if (creds.openclawAgent) entry.openclawAgent = creds.openclawAgent;
-      if (entry.runtime || entry.cwd || entry.openclawGateway || entry.openclawAgent) out[id] = entry;
+      if (creds.hermesProfile) entry.hermesProfile = creds.hermesProfile;
+      if (entry.runtime || entry.cwd || entry.openclawGateway || entry.openclawAgent || entry.hermesProfile) out[id] = entry;
     } catch {
       // best-effort — skip agents with unreadable credentials
+    }
+  }
+  return out;
+}
+
+/**
+ * Scan `~/.botcord/credentials/*.json` and return a mapping from hermes
+ * profile name to the BotCord agent currently bound to it. Used by the
+ * runtime snapshot path to mark profiles as occupied in the picker, and by
+ * the provision path to enforce the 1 BotCord agent : 1 hermes profile
+ * invariant. The scan is cheap and authoritative — running daemon state may
+ * lag (e.g. between provision and reconcile), so we always read disk.
+ */
+export function profileOccupancyMap(): Map<string, { agentId: string; agentName?: string }> {
+  const out = new Map<string, { agentId: string; agentName?: string }>();
+  const dir = path.join(homedir(), ".botcord", "credentials");
+  let names: string[] = [];
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const file of names) {
+    if (!file.endsWith(".json")) continue;
+    try {
+      const creds = loadStoredCredentials(path.join(dir, file));
+      if (creds.runtime !== "hermes-agent") continue;
+      if (!creds.hermesProfile) continue;
+      // First write wins — ties shouldn't happen, but if they do, the
+      // provision path's race check will surface it.
+      if (!out.has(creds.hermesProfile)) {
+        out.set(creds.hermesProfile, {
+          agentId: creds.agentId,
+          agentName: creds.displayName,
+        });
+      }
+    } catch {
+      // skip unreadable
     }
   }
   return out;

--- a/packages/protocol-core/src/control-frame.ts
+++ b/packages/protocol-core/src/control-frame.ts
@@ -28,6 +28,13 @@ export interface ControlAck {
   error?: {
     code: string;
     message: string;
+    /**
+     * Optional structured details for error codes that carry context (e.g.
+     * `hermes_profile_occupied` carries `occupiedBy` + `profile`). Older
+     * consumers ignore unknown fields; new fields here must remain
+     * additive so wire compatibility is preserved.
+     */
+    [key: string]: unknown;
   };
 }
 
@@ -141,6 +148,15 @@ export interface ProvisionAgentParams {
     openclawGateway?: string;
     /** Optional OpenClaw agent profile override for this agent. */
     openclawAgent?: string;
+    /**
+     * Hermes profile name to attach this BotCord agent to. Only meaningful
+     * when `runtime === "hermes-agent"`. The daemon will set
+     * `HERMES_HOME=~/.hermes/profiles/<name>/` (or `~/.hermes` for `default`)
+     * on spawn so the BotCord agent shares state.db / sessions / skills with
+     * the user's command-line `hermes`. When unset, the daemon falls back to
+     * a BotCord-isolated HERMES_HOME under `~/.botcord/agents/<id>/`.
+     */
+    hermesProfile?: string;
   };
   /**
    * OpenClaw runtime parameters. When `runtime === "openclaw-acp"` the daemon
@@ -154,6 +170,17 @@ export interface ProvisionAgentParams {
     gateway: string;
     /** Overrides `OpenclawGatewayProfile.defaultAgent` for this agent. */
     agent?: string;
+  };
+  /**
+   * Hermes runtime parameters. When `runtime === "hermes-agent"` and
+   * `hermes.profile` is set, the daemon attaches the BotCord agent to the
+   * named hermes profile (1:1 mapping). Top-level nesting mirrors the
+   * `openclaw` cluster; the flat `credentials.hermesProfile` field exists
+   * for the same envelope-only reason.
+   */
+  hermes?: {
+    /** Hermes profile name (`~/.hermes/profiles/<name>/`); `"default"` → `~/.hermes`. */
+    profile: string;
   };
   /**
    * Optional initial attention policy seed. When the Hub already knows the
@@ -297,6 +324,51 @@ export interface RuntimeProbeResult {
    * `runtimes_json` blob.
    */
   endpoints?: RuntimeEndpointProbe[];
+  /**
+   * Optional list of hermes profiles available on this device. Populated only
+   * by the `hermes-agent` runtime; one entry per `~/.hermes/profiles/<name>/`
+   * directory plus a synthetic `default` entry for `~/.hermes` itself. The
+   * daemon attaches `occupiedBy` when a BotCord credential file already binds
+   * to that profile so picker UIs can render disabled rows. Older Hub builds
+   * that don't recognize this field pass it through opaquely (same precedent
+   * as `endpoints`).
+   */
+  profiles?: HermesProfileProbe[];
+}
+
+/**
+ * One hermes profile entry attached to a `RuntimeProbeResult` for the
+ * `hermes-agent` runtime. Daemon-side discovery is a pure local filesystem
+ * scan (`~/.hermes/profiles/*`); the synthetic `"default"` entry models
+ * `~/.hermes` itself per the upstream "default profile = HERMES_HOME"
+ * convention (`hermes_cli/profiles.py`).
+ */
+export interface HermesProfileProbe {
+  /** Profile name; `"default"` is reserved for `~/.hermes`. */
+  name: string;
+  /** Absolute HERMES_HOME for this profile. */
+  home: string;
+  /** True when this entry is the synthetic `~/.hermes` default. */
+  isDefault?: boolean;
+  /**
+   * True when this profile matches `~/.hermes/active_profile`. Picker UIs may
+   * use this to suggest a default selection.
+   */
+  isActive?: boolean;
+  /**
+   * BotCord agent id that already binds to this profile, when any. The
+   * daemon resolves this by scanning local `credentials/*.json` for matching
+   * `runtime === "hermes-agent"` + `hermesProfile === <name>` records.
+   */
+  occupiedBy?: string;
+  /** Display name of the occupying BotCord agent, if known. */
+  occupiedByName?: string;
+  /** Optional snapshot of the profile's default model (from `config.yaml`). */
+  modelName?: string;
+  /** Optional count of `sessions/*.jsonl` files. */
+  sessionsCount?: number;
+  /** Whether `SOUL.md` exists in the profile root. */
+  hasSoul?: boolean;
 }
 
 /**

--- a/packages/protocol-core/src/credentials.ts
+++ b/packages/protocol-core/src/credentials.ts
@@ -37,6 +37,14 @@ export interface StoredBotCordCredentials {
    * falling back to `OpenclawGatewayProfile.defaultAgent` when absent.
    */
   openclawAgent?: string;
+  /**
+   * Hermes profile this agent is attached to (`~/.hermes/profiles/<name>/`,
+   * or `~/.hermes` when the value is `"default"`). Only meaningful when
+   * `runtime === "hermes-agent"`. Read by the daemon's hermes adapter to
+   * route `HERMES_HOME` at spawn time so the BotCord agent shares state
+   * with the user's command-line `hermes`.
+   */
+  hermesProfile?: string;
 }
 
 function normalizeCredentialValue(raw: any, keys: string[]): string | undefined {
@@ -111,6 +119,7 @@ export function loadStoredCredentials(credentialsFile: string): StoredBotCordCre
   const cwd = normalizeCredentialValue(raw, ["cwd"]);
   const openclawGateway = normalizeCredentialValue(raw, ["openclawGateway", "openclaw_gateway"]);
   const openclawAgent = normalizeCredentialValue(raw, ["openclawAgent", "openclaw_agent"]);
+  const hermesProfile = normalizeCredentialValue(raw, ["hermesProfile", "hermes_profile"]);
 
   return {
     version: 1,
@@ -128,6 +137,7 @@ export function loadStoredCredentials(credentialsFile: string): StoredBotCordCre
     cwd,
     openclawGateway,
     openclawAgent,
+    hermesProfile,
   };
 }
 


### PR DESCRIPTION
## Summary

- Lets BotCord agents on the `hermes-agent` runtime attach to an existing local hermes profile (`~/.hermes/profiles/<name>/`, or `~/.hermes` as `default`) instead of always provisioning a fresh BotCord-isolated HERMES_HOME
- Daemon enforces 1 BotCord agent : 1 hermes profile (rejects with `hermes_profile_occupied` / `hermes_profile_not_found`); sessions, memory, skills, SOUL.md are then shared with the user's command-line `hermes`
- Dashboard `CreateAgentDialog` gets a `HermesProfilePicker` that lists local profiles + occupancy state; provision frame carries the selection through Hub BFF → daemon

## Rationale

The previous behaviour was \"each BotCord agent gets a wholly isolated `~/.botcord/agents/<id>/hermes-home/` seeded from `~/.hermes`\". That's safe but means the dashboard cannot offer parity with OpenClaw's \"select an existing agent\" flow, and forces users to re-onboard hermes from scratch for every BotCord identity. Upstream hermes already models this as `profile`s (`hermes_cli/profiles.py`); this PR exposes that 1:1 mapping end-to-end.

## What changed

| Layer | Change |
|---|---|
| `protocol-core` | `HermesProfileProbe`, `ProvisionAgentParams.hermes`, `credentials.hermesProfile`; relax `ControlAck.error` to allow structured details |
| `daemon` | Probe `~/.hermes/profiles/*` + `profileOccupancyMap()`; validate exists/unoccupied; per-profile mutex; spawn switches `HERMES_HOME` and skips seed/merge into the user profile while still writing AGENTS.md to the per-agent hermes-workspace |
| `backend` | `ProvisionAgentBody.hermes_profile` + gating against `runtimes_json.profiles[]`; dual-write into frame `hermes` + `credentials.hermesProfile` |
| `frontend` | Parse `runtime.profiles[]`; new `HermesProfilePicker`; send `hermesProfile` through `useDaemonStore.provisionAgent` |
| `tests` | 7 new daemon vitests (listing, active_profile, attach-mode spawn, provision not_found / occupied / success) |

## Behaviour notes

- AGENTS.md is still written to the per-agent `~/.botcord/agents/<id>/hermes-workspace/` (cwd) — never inside the user profile
- Revoke deletes only `~/.botcord/agents/<id>/`; the hermes profile is left intact
- When attaching, daemon does NOT seed `.env` / `config.yaml` into the profile; the user owns those

## Test plan

- [x] daemon: `npm test` → 590 passed
- [x] daemon + protocol-core: TS build clean
- [x] frontend: TS compile clean (prerender skipped — needs Supabase env, unrelated)
- [ ] manual: provision a hermes-agent on a daemon with `~/.hermes` only; confirm picker shows `default`, occupied state flips after creation
- [ ] manual: try a second BotCord agent on same profile → expect 409 `hermes_profile_occupied`
- [ ] manual: send a turn through the new BotCord agent and verify the session shows up in `~/.hermes/sessions/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)