### PR TITLE
fix: poll dashboard messages as realtime fallback

### DIFF
--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -598,6 +598,54 @@ export default function DashboardApp() {
   ]);
 
   useEffect(() => {
+    if (!sessionStore.authResolved || !sessionStore.token || uiStore.sidebarTab !== "messages") {
+      return;
+    }
+
+    let cancelled = false;
+    let syncInFlight = false;
+
+    const syncMessagesPane = async () => {
+      if (cancelled || syncInFlight) return;
+      syncInFlight = true;
+      try {
+        const { openedRoomId, messagesPane } = useDashboardUIStore.getState();
+        const session = useDashboardSessionStore.getState();
+        const chat = useDashboardChatStore.getState();
+        await Promise.all([
+          chat.refreshOverview(),
+          session.human?.human_id ? session.refreshHumanRooms() : Promise.resolve(),
+          openedRoomId && messagesPane === "room"
+            ? chat.pollNewMessages(openedRoomId)
+            : Promise.resolve(),
+        ]);
+      } finally {
+        syncInFlight = false;
+      }
+    };
+
+    const intervalId = window.setInterval(syncMessagesPane, 5_000);
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        void syncMessagesPane();
+      }
+    };
+    window.addEventListener("focus", syncMessagesPane);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+      window.removeEventListener("focus", syncMessagesPane);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [
+    sessionStore.authResolved,
+    sessionStore.token,
+    uiStore.sidebarTab,
+  ]);
+
+  useEffect(() => {
     if (!sessionStore.authResolved) return;
 
     if (!chatStore.publicRoomsLoaded && !chatStore.publicRoomsLoading) {


### PR DESCRIPTION
## Summary
- add a Messages-pane fallback sync while signed in
- refresh dashboard overview and Human room summaries every 5 seconds
- poll the currently opened room on the same cadence, plus on window focus / visibility restore

## Tests
- NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build