### PR TITLE
fix: preinstall botcord skills for hermes attach

### DIFF
--- a/packages/daemon/src/__tests__/agent-workspace.test.ts
+++ b/packages/daemon/src/__tests__/agent-workspace.test.ts
@@ -18,6 +18,7 @@ import {
   agentStateDir,
   agentWorkspaceDir,
   applyAgentIdentity,
+  ensureAttachedHermesProfileSkills,
   ensureAgentCodexHome,
   ensureAgentHermesWorkspace,
   ensureAgentWorkspace,
@@ -148,6 +149,23 @@ describe("ensureAgentWorkspace", () => {
     const reseeded = readFileSync(skillFile, "utf8");
     expect(reseeded).not.toBe("stale content from a prior daemon version\n");
     expect(reseeded).toContain("name: botcord");
+  });
+
+  it("seeds bundled skills into an attached Hermes profile without creating private home state", () => {
+    const profileHome = path.join(tmpHome, ".hermes", "profiles", "coder");
+    mkdirSync(profileHome, { recursive: true });
+
+    const { hermesHome, hermesWorkspace } = ensureAgentHermesWorkspace("ag_hermes_attach", {
+      attached: true,
+    });
+    ensureAttachedHermesProfileSkills(profileHome);
+
+    expect(existsSync(path.join(profileHome, "skills", "botcord", "SKILL.md"))).toBe(true);
+    expect(existsSync(path.join(profileHome, "skills", "botcord-user-guide", "SKILL.md"))).toBe(
+      true,
+    );
+    expect(existsSync(hermesWorkspace)).toBe(true);
+    expect(existsSync(hermesHome)).toBe(false);
   });
 
   it("does not overwrite a user-modified memory.md on a second call", () => {

--- a/packages/daemon/src/__tests__/provision.test.ts
+++ b/packages/daemon/src/__tests__/provision.test.ts
@@ -1527,6 +1527,11 @@ describe("provision_agent hermes profile attach", () => {
       >;
       expect(saved.hermesProfile).toBe("coder");
       expect(saved.runtime).toBe("hermes-agent");
+      expect(
+        fs.existsSync(
+          nodePath.join(tmp, ".hermes", "profiles", "coder", "skills", "botcord", "SKILL.md"),
+        ),
+      ).toBe(true);
     });
   });
 

--- a/packages/daemon/src/agent-workspace.ts
+++ b/packages/daemon/src/agent-workspace.ts
@@ -370,8 +370,8 @@ export function ensureAgentHermesWorkspace(
   // Attach mode: HERMES_HOME points at the user's `~/.hermes/profiles/<n>/`
   // so we MUST NOT touch the per-agent isolated home. The cwd
   // (`hermesWorkspace`) is still ours and `prepareTurn` writes AGENTS.md
-  // there — that's the only thing the daemon is allowed to author when
-  // attached to a user-owned profile.
+  // there. Profile-owned skill seeding is handled separately by
+  // `ensureAttachedHermesProfileSkills`.
   if (opts.attached) {
     return { hermesHome, hermesWorkspace };
   }
@@ -460,6 +460,17 @@ function seedCodexSkills(codexHome: string): void {
  */
 function seedHermesAgentSkills(hermesHome: string): void {
   copyBundledSkills(path.join(hermesHome, "skills"));
+}
+
+/**
+ * Seed BotCord's bundled Hermes skills into a user-owned Hermes profile used
+ * by attach mode. Unlike `ensureAgentHermesWorkspace({ attached: true })`,
+ * this intentionally writes only the managed `botcord*` skill directories
+ * under the profile's `skills/` directory; it does not touch `.env`,
+ * `config.yaml`, sessions, or any user-authored skills.
+ */
+export function ensureAttachedHermesProfileSkills(profileHome: string): void {
+  seedHermesAgentSkills(profileHome);
 }
 
 /**

--- a/packages/daemon/src/gateway/runtimes/hermes-agent.ts
+++ b/packages/daemon/src/gateway/runtimes/hermes-agent.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import {
   agentHermesHomeDir,
   agentHermesWorkspaceDir,
+  ensureAttachedHermesProfileSkills,
   ensureAgentHermesWorkspace,
 } from "../../agent-workspace.js";
 import { buildCliEnv } from "../cli-resolver.js";
@@ -277,9 +278,10 @@ export class HermesAgentAdapter extends AcpRuntimeAdapter {
     };
     // Attach mode: BotCord agent shares a hermes profile (state.db /
     // sessions / skills / .env) with the user's command-line `hermes`. In
-    // this mode we DO NOT seed a private home — the profile is wholly owned
-    // by the user, and AGENTS.md is written under the per-agent
-    // hermes-workspace cwd (NOT into the profile root) by `prepareTurn`.
+    // this mode we DO NOT seed a private home — AGENTS.md is written under
+    // the per-agent hermes-workspace cwd (NOT into the profile root) by
+    // `prepareTurn`, while bundled BotCord skills are installed into the
+    // attached profile's `skills/` directory so hermes can discover them.
     if (opts.hermesProfile) {
       env.HERMES_HOME = hermesProfileHomeDir(opts.hermesProfile);
     } else if (opts.accountId) {
@@ -304,6 +306,9 @@ export class HermesAgentAdapter extends AcpRuntimeAdapter {
     const { hermesWorkspace } = ensureAgentHermesWorkspace(opts.accountId, {
       attached: !!opts.hermesProfile,
     });
+    if (opts.hermesProfile) {
+      ensureAttachedHermesProfileSkills(hermesProfileHomeDir(opts.hermesProfile));
+    }
     const target = path.join(hermesWorkspace, "AGENTS.md");
     const tmp = path.join(hermesWorkspace, `.AGENTS.md.${process.pid}.tmp`);
     mkdirSync(hermesWorkspace, { recursive: true, mode: 0o700 });

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -52,6 +52,7 @@ import {
   agentStateDir,
   agentWorkspaceDir,
   applyAgentIdentity,
+  ensureAttachedHermesProfileSkills,
   ensureAgentWorkspace,
 } from "./agent-workspace.js";
 import { detectRuntimes, getAdapterModule } from "./adapters/runtimes.js";
@@ -431,6 +432,9 @@ async function installLocalAgent(
       keyId: credentials.keyId,
       savedAt: credentials.savedAt,
     });
+    if (credentials.runtime === "hermes-agent" && credentials.hermesProfile) {
+      ensureAttachedHermesProfileSkills(hermesProfileHomeDir(credentials.hermesProfile));
+    }
   } catch (err) {
     try {
       unlinkSync(credentialsFile);


### PR DESCRIPTION
## Summary
- seed bundled BotCord skills into attached Hermes profiles during provisioning
- re-seed attached profile skills before Hermes turns so daemon upgrades refresh managed skills
- add coverage for attached-profile skill seeding and provision-time installation

## Tests
- cd packages/daemon && npm test -- agent-workspace provision hermes-agent-adapter
- cd packages/daemon && npx tsc -p tsconfig.build.json --noEmit