### PR TITLE
fix: mark bound OpenClaw profiles in runtime snapshot

### DIFF
--- a/packages/daemon/src/__tests__/openclaw-discovery.test.ts
+++ b/packages/daemon/src/__tests__/openclaw-discovery.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   defaultOpenclawDiscoveryPorts,
+  defaultOpenclawDiscoverySystemdUnitPaths,
   defaultOpenclawDiscoveryTokenFilePaths,
   discoverLocalOpenclawGateways,
   mergeOpenclawGateways,
@@ -144,6 +145,69 @@ describe("discoverLocalOpenclawGateways", () => {
         url: "ws://127.0.0.1:16200",
         token: "gateway-token",
         source: "env",
+      }),
+    ]);
+  });
+
+  it("discovers gateway port and token from a systemd OpenClaw unit", async () => {
+    const dir = tempDir();
+    const unit = path.join(dir, "openclaw.service");
+    writeFileSync(
+      unit,
+      [
+        "[Service]",
+        "User=openclaw",
+        'Environment="OPENCLAW_GATEWAY_TOKEN=systemd-token"',
+        "ExecStart=/usr/bin/openclaw gateway --bind lan --port 16200 --allow-unconfigured",
+      ].join("\n"),
+    );
+
+    const found = await discoverLocalOpenclawGateways({
+      searchPaths: [],
+      defaultPorts: [],
+      systemdUnitPaths: [unit],
+      env: {},
+    });
+
+    expect(defaultOpenclawDiscoverySystemdUnitPaths()).toEqual(
+      expect.arrayContaining(["/etc/systemd/system/openclaw.service"]),
+    );
+    expect(found).toEqual([
+      expect.objectContaining({
+        url: "ws://127.0.0.1:16200",
+        token: "systemd-token",
+        source: "systemd-unit",
+      }),
+    ]);
+  });
+
+  it("discovers gateway token from a systemd EnvironmentFile", async () => {
+    const dir = tempDir();
+    const unit = path.join(dir, "openclaw.service");
+    const envFile = path.join(dir, "openclaw.env");
+    writeFileSync(envFile, 'OPENCLAW_GATEWAY_TOKEN="file-token"\n');
+    writeFileSync(
+      unit,
+      [
+        "[Service]",
+        `EnvironmentFile=${envFile}`,
+        "Environment=OPENCLAW_GATEWAY_PORT=16200",
+        "ExecStart=/usr/bin/openclaw gateway --bind lan --allow-unconfigured",
+      ].join("\n"),
+    );
+
+    const found = await discoverLocalOpenclawGateways({
+      searchPaths: [],
+      defaultPorts: [],
+      systemdUnitPaths: [unit],
+      env: {},
+    });
+
+    expect(found).toEqual([
+      expect.objectContaining({
+        url: "ws://127.0.0.1:16200",
+        token: "file-token",
+        source: "systemd-unit",
       }),
     ]);
   });

--- a/packages/daemon/src/__tests__/runtime-discovery.test.ts
+++ b/packages/daemon/src/__tests__/runtime-discovery.test.ts
@@ -146,6 +146,54 @@ describe("collectRuntimeSnapshotAsync", () => {
     ]);
   });
 
+  it("marks OpenClaw agent profiles that already have a BotCord binding", async () => {
+    const tmp = mkdtempSync(path.join(tmpdir(), "daemon-runtime-binding-"));
+    const prevHome = process.env.HOME;
+    process.env.HOME = tmp;
+    try {
+      mkdirSync(path.join(tmp, ".botcord", "credentials"), { recursive: true });
+      writeFileSync(
+        path.join(tmp, ".botcord", "credentials", "ag_bound.json"),
+        JSON.stringify({
+          hubUrl: "https://api.preview.botcord.chat",
+          agentId: "ag_bound",
+          keyId: "kid_bound",
+          privateKey: Buffer.alloc(32, 1).toString("base64"),
+          runtime: "openclaw-acp",
+          openclawGateway: "local",
+          openclawAgent: "swe",
+        }),
+      );
+      setRuntimes([
+        {
+          id: "openclaw-acp",
+          displayName: "OpenClaw",
+          binary: "openclaw",
+          supportsRun: true,
+          result: { available: true },
+        },
+      ]);
+
+      const snap = await collectRuntimeSnapshotAsync({
+        cfg: { openclawGateways: [{ name: "local", url: "ws://127.0.0.1:18789" }] },
+        wsProbe: async () => ({
+          ok: true,
+          agents: [{ id: "default" }, { id: "swe", name: "SWE" }],
+        }),
+      });
+
+      const runtime = snap.runtimes.find((r) => r.id === "openclaw-acp");
+      expect(runtime?.endpoints?.[0]?.agents).toEqual([
+        { id: "default" },
+        { id: "swe", name: "SWE", botcordBinding: { agentId: "ag_bound" } },
+      ]);
+    } finally {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("reports acp_disabled without probing the gateway", async () => {
     const tmp = mkdtempSync(path.join(tmpdir(), "daemon-runtime-openclaw-"));
     const prevHome = process.env.HOME;

--- a/packages/daemon/src/openclaw-discovery.ts
+++ b/packages/daemon/src/openclaw-discovery.ts
@@ -5,7 +5,11 @@ import type { DaemonConfig, OpenclawGatewayProfile } from "./config.js";
 import { log as daemonLog } from "./log.js";
 import { probeOpenclawAgents, type WsEndpointProbeFn } from "./provision.js";
 
-export type DiscoveredOpenclawGatewaySource = "config-file" | "env" | "default-port";
+export type DiscoveredOpenclawGatewaySource =
+  | "config-file"
+  | "env"
+  | "systemd-unit"
+  | "default-port";
 
 export interface DiscoveredOpenclawGateway {
   name: string;
@@ -21,6 +25,7 @@ export interface OpenclawGatewayDiscoveryOptions {
   probe?: WsEndpointProbeFn;
   timeoutMs?: number;
   env?: NodeJS.ProcessEnv;
+  systemdUnitPaths?: string[];
 }
 
 export interface MergeOpenclawGatewayResult {
@@ -36,6 +41,14 @@ const DEFAULT_TOKEN_FILE_PATHS = [
   "/var/run/openclaw/gateway-token",
   "~/.openclaw/gateway-token",
 ];
+const DEFAULT_SYSTEMD_UNIT_PATHS = [
+  "/etc/systemd/system/openclaw.service",
+  "/etc/systemd/system/openclaw-gateway.service",
+  "/lib/systemd/system/openclaw.service",
+  "/lib/systemd/system/openclaw-gateway.service",
+  "/usr/lib/systemd/system/openclaw.service",
+  "/usr/lib/systemd/system/openclaw-gateway.service",
+];
 
 export async function discoverLocalOpenclawGateways(
   opts: OpenclawGatewayDiscoveryOptions = {},
@@ -47,6 +60,7 @@ export async function discoverLocalOpenclawGateways(
 
   const env = opts.env ?? process.env;
   found.push(...discoverFromEnv(env));
+  found.push(...discoverFromSystemdUnits(opts.systemdUnitPaths ?? DEFAULT_SYSTEMD_UNIT_PATHS));
   const envAuth = pickOpenclawEnvAuth(env) ?? pickDefaultTokenFile();
 
   const ports = opts.defaultPorts ?? DEFAULT_PORTS;
@@ -73,6 +87,164 @@ export async function discoverLocalOpenclawGateways(
   }
 
   return dedupeDiscovered(found);
+}
+
+function discoverFromSystemdUnits(paths: string[]): DiscoveredOpenclawGateway[] {
+  const out: DiscoveredOpenclawGateway[] = [];
+  for (const unitPath of paths) {
+    try {
+      if (!existsSync(unitPath)) continue;
+      const parsed = parseSystemdUnit(readFileSync(unitPath, "utf8"), path.dirname(unitPath));
+      const url = parsed.url ?? urlFromGatewayPort(parsed.env);
+      if (!url) continue;
+      const auth = pickOpenclawEnvAuth(parsed.env);
+      out.push({
+        name: nameFromUrl(url),
+        url,
+        source: "systemd-unit",
+        ...auth,
+      });
+    } catch (err) {
+      daemonLog.debug("openclaw discovery systemd unit skipped", {
+        file: unitPath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return out;
+}
+
+function parseSystemdUnit(
+  raw: string,
+  unitDir: string,
+): { env: NodeJS.ProcessEnv; url?: string } {
+  const env: NodeJS.ProcessEnv = {};
+  let url: string | undefined;
+  for (const line of joinedSystemdLines(raw)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    const key = trimmed.slice(0, eq);
+    const value = trimmed.slice(eq + 1).trim();
+    if (key === "Environment") {
+      Object.assign(env, parseSystemdEnvironment(value));
+    } else if (key === "EnvironmentFile") {
+      for (const file of splitSystemdWords(value)) {
+        const optional = file.startsWith("-");
+        const resolved = path.resolve(unitDir, expandHome(optional ? file.slice(1) : file));
+        try {
+          Object.assign(env, parseEnvFile(readFileSync(resolved, "utf8")));
+        } catch (err) {
+          if (!optional) {
+            daemonLog.debug("openclaw discovery environment file skipped", {
+              file: resolved,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+      }
+    } else if (key === "ExecStart") {
+      url = urlFromExecStart(value) ?? url;
+    }
+  }
+  return { env, url };
+}
+
+function joinedSystemdLines(raw: string): string[] {
+  const out: string[] = [];
+  let cur = "";
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmedEnd = line.replace(/\s+$/, "");
+    if (trimmedEnd.endsWith("\\")) {
+      cur += trimmedEnd.slice(0, -1) + " ";
+      continue;
+    }
+    out.push(cur + line);
+    cur = "";
+  }
+  if (cur) out.push(cur);
+  return out;
+}
+
+function parseSystemdEnvironment(raw: string): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const word of splitSystemdWords(raw)) {
+    const eq = word.indexOf("=");
+    if (eq <= 0) continue;
+    env[word.slice(0, eq)] = word.slice(eq + 1);
+  }
+  return env;
+}
+
+function parseEnvFile(raw: string): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    env[trimmed.slice(0, eq)] = unquote(trimmed.slice(eq + 1).trim());
+  }
+  return env;
+}
+
+function urlFromExecStart(raw: string): string | undefined {
+  const words = splitSystemdWords(raw);
+  const portIdx = words.indexOf("--port");
+  const rawPort =
+    portIdx >= 0 ? words[portIdx + 1] : words.find((w) => w.startsWith("--port="))?.slice(7);
+  if (!rawPort) return undefined;
+  const port = Number(rawPort);
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) return undefined;
+  return `ws://127.0.0.1:${port}`;
+}
+
+function splitSystemdWords(raw: string): string[] {
+  const words: string[] = [];
+  let cur = "";
+  let quote: '"' | "'" | null = null;
+  let escaped = false;
+  for (const ch of raw) {
+    if (escaped) {
+      cur += ch;
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (ch === quote) quote = null;
+      else cur += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (cur) {
+        words.push(cur);
+        cur = "";
+      }
+      continue;
+    }
+    cur += ch;
+  }
+  if (cur) words.push(cur);
+  return words.map(unquote);
+}
+
+function unquote(raw: string): string {
+  if (
+    (raw.startsWith('"') && raw.endsWith('"')) ||
+    (raw.startsWith("'") && raw.endsWith("'"))
+  ) {
+    return raw.slice(1, -1);
+  }
+  return raw;
 }
 
 function discoverFromEnv(env: NodeJS.ProcessEnv): DiscoveredOpenclawGateway[] {
@@ -275,8 +447,9 @@ function pickString(obj: Record<string, unknown>, keys: string[]): string | unde
 
 function dedupeDiscovered(items: DiscoveredOpenclawGateway[]): DiscoveredOpenclawGateway[] {
   const priority: Record<DiscoveredOpenclawGatewaySource, number> = {
-    "config-file": 3,
-    env: 2,
+    "config-file": 4,
+    env: 3,
+    "systemd-unit": 2,
     "default-port": 1,
   };
   const byUrl = new Map<string, DiscoveredOpenclawGateway>();
@@ -341,6 +514,10 @@ export function defaultOpenclawDiscoveryPorts(): number[] {
 
 export function defaultOpenclawDiscoveryTokenFilePaths(): string[] {
   return DEFAULT_TOKEN_FILE_PATHS.slice();
+}
+
+export function defaultOpenclawDiscoverySystemdUnitPaths(): string[] {
+  return DEFAULT_SYSTEMD_UNIT_PATHS.slice();
 }
 
 export function openclawDiscoveryConfigEnabled(cfg: DaemonConfig): boolean {

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -1150,6 +1150,7 @@ export type WsEndpointProbeFn = (args: {
     name?: string;
     workspace?: string;
     model?: { name?: string; provider?: string };
+    botcordBinding?: { agentId: string };
   }>;
   error?: string;
 }>;
@@ -1205,6 +1206,7 @@ async function defaultWsProbe(args: {
     name?: string;
     workspace?: string;
     model?: { name?: string; provider?: string };
+    botcordBinding?: { agentId: string };
   }>;
   error?: string;
 }> {
@@ -1539,7 +1541,7 @@ export async function collectRuntimeSnapshotAsync(opts: {
           entry.error = res.error;
           entry.diagnostics = [{ code: "gateway_unreachable", message: res.error }];
         }
-        if (res.agents) entry.agents = res.agents;
+        if (res.agents) entry.agents = annotateOpenclawAgentsWithBotcordBindings(g.name, res.agents);
         return entry;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -1558,6 +1560,41 @@ export async function collectRuntimeSnapshotAsync(opts: {
   out.runtimes = base.runtimes.map((r) =>
     r.id === "openclaw-acp" ? { ...r, endpoints } : r,
   );
+  return out;
+}
+
+function annotateOpenclawAgentsWithBotcordBindings(
+  gateway: string,
+  agents: Array<{
+    id: string;
+    name?: string;
+    workspace?: string;
+    model?: { name?: string; provider?: string };
+  }>,
+): Array<{
+  id: string;
+  name?: string;
+  workspace?: string;
+  model?: { name?: string; provider?: string };
+  botcordBinding?: { agentId: string };
+}> {
+  const bindings = openclawBindingIndex();
+  return agents.map((agent) => {
+    const botcordAgentId = bindings.get(`${gateway}\0${agent.id}`);
+    if (!botcordAgentId) return agent;
+    return { ...agent, botcordBinding: { agentId: botcordAgentId } };
+  });
+}
+
+function openclawBindingIndex(): Map<string, string> {
+  const out = new Map<string, string>();
+  const discovered = discoverAgentCredentials({
+    credentialsDir: path.join(homedir(), ".botcord", "credentials"),
+  });
+  for (const agent of discovered.agents) {
+    if (!agent.openclawGateway || !agent.openclawAgent) continue;
+    out.set(`${agent.openclawGateway}\0${agent.openclawAgent}`, agent.agentId);
+  }
   return out;
 }
 

--- a/packages/protocol-core/src/control-frame.ts
+++ b/packages/protocol-core/src/control-frame.ts
@@ -337,6 +337,15 @@ export interface RuntimeEndpointProbe {
     name?: string;
     workspace?: string;
     model?: { name?: string; provider?: string };
+    /**
+     * Present when this OpenClaw agent profile is already bound to a local
+     * BotCord identity on the daemon. Dashboards should treat these profiles
+     * as unavailable for "create new BotCord agent" flows and link to the
+     * existing identity instead.
+     */
+    botcordBinding?: {
+      agentId: string;
+    };
   }>;
 }
 


### PR DESCRIPTION
## Summary
- add botcordBinding metadata to OpenClaw agent profiles returned in runtime snapshots
- annotate probed OpenClaw profiles by scanning local BotCord credentials for openclawGateway/openclawAgent bindings
- cover bound-profile annotation in runtime discovery tests

## Tests
- cd packages/daemon && npm test -- --run src/__tests__/runtime-discovery.test.ts
- cd packages/daemon && npm run build

## Notes
- Full daemon tsconfig --noEmit is currently blocked by existing test typing errors unrelated to this change.