### PR TITLE
fix: bypass daemon runtime permissions by default

### DIFF
--- a/packages/daemon/src/gateway/__tests__/claude-code-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/claude-code-adapter.test.ts
@@ -263,7 +263,7 @@ process.stdout.write(JSON.stringify({type:"result", subtype:"success", session_i
       expect(argv[modeIdx + 1]).toBe("bypassPermissions");
     });
 
-    it("public → --permission-mode default", async () => {
+    it("public → --permission-mode bypassPermissions", async () => {
       const adapter = new ClaudeCodeAdapter({ binary: echoScript() });
       const ctrl = new AbortController();
       const res = await adapter.run({
@@ -277,10 +277,10 @@ process.stdout.write(JSON.stringify({type:"result", subtype:"success", session_i
       const argv = JSON.parse(res.text) as string[];
       const modeIdx = argv.indexOf("--permission-mode");
       expect(modeIdx).toBeGreaterThanOrEqual(0);
-      expect(argv[modeIdx + 1]).toBe("default");
+      expect(argv[modeIdx + 1]).toBe("bypassPermissions");
     });
 
-    it("trusted → --permission-mode default", async () => {
+    it("trusted → --permission-mode bypassPermissions", async () => {
       const adapter = new ClaudeCodeAdapter({ binary: echoScript() });
       const ctrl = new AbortController();
       const res = await adapter.run({
@@ -294,7 +294,7 @@ process.stdout.write(JSON.stringify({type:"result", subtype:"success", session_i
       const argv = JSON.parse(res.text) as string[];
       const modeIdx = argv.indexOf("--permission-mode");
       expect(modeIdx).toBeGreaterThanOrEqual(0);
-      expect(argv[modeIdx + 1]).toBe("default");
+      expect(argv[modeIdx + 1]).toBe("bypassPermissions");
     });
 
     it("systemContext → --append-system-prompt <text>", async () => {

--- a/packages/daemon/src/gateway/__tests__/codex-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/codex-adapter.test.ts
@@ -338,7 +338,7 @@ process.stdout.write(JSON.stringify({type:"item.completed", item:{id:"i0", type:
       expect(argv).not.toContain("-s");
     });
 
-    it("public → sandbox_mode=\"workspace-write\" + approval_policy=\"on-request\"", async () => {
+    it("public → sandbox_mode=\"danger-full-access\" + approval_policy=\"never\"", async () => {
       const adapter = new CodexAdapter({ binary: echoScript() });
       const ctrl = new AbortController();
       const res = await adapter.run({
@@ -350,12 +350,12 @@ process.stdout.write(JSON.stringify({type:"item.completed", item:{id:"i0", type:
         trustLevel: "public",
       });
       const argv = JSON.parse(res.text) as string[];
-      expect(argv).toContain('sandbox_mode="workspace-write"');
-      expect(argv).toContain('approval_policy="on-request"');
+      expect(argv).toContain('sandbox_mode="danger-full-access"');
+      expect(argv).toContain('approval_policy="never"');
       expect(argv).not.toContain("--dangerously-bypass-approvals-and-sandbox");
     });
 
-    it("trusted → sandbox_mode=\"workspace-write\" + approval_policy=\"on-request\"", async () => {
+    it("trusted → sandbox_mode=\"danger-full-access\" + approval_policy=\"never\"", async () => {
       const adapter = new CodexAdapter({ binary: echoScript() });
       const ctrl = new AbortController();
       const res = await adapter.run({
@@ -367,8 +367,8 @@ process.stdout.write(JSON.stringify({type:"item.completed", item:{id:"i0", type:
         trustLevel: "trusted",
       });
       const argv = JSON.parse(res.text) as string[];
-      expect(argv).toContain('sandbox_mode="workspace-write"');
-      expect(argv).toContain('approval_policy="on-request"');
+      expect(argv).toContain('sandbox_mode="danger-full-access"');
+      expect(argv).toContain('approval_policy="never"');
     });
 
     it("extraArgs `-s read-only` suppresses the default sandbox `-c`s", async () => {

--- a/packages/daemon/src/gateway/runtimes/claude-code.ts
+++ b/packages/daemon/src/gateway/runtimes/claude-code.ts
@@ -107,21 +107,13 @@ export class ClaudeCodeAdapter extends NdjsonStreamAdapter {
       args.push("--resume", opts.sessionId);
     }
     // Permission-mode policy:
-    //  - owner: bypassPermissions (owner fully trusts their own agent; daemon
-    //    has no authorization-relay UI yet, so any other mode causes Bash /
-    //    WebFetch / MCP tool calls to deadlock waiting for a prompt that
-    //    never reaches the user — see issue #332 for the planned MCP-bridge
-    //    relay that will let us tighten this back up).
-    //  - non-owner (trusted/public): default (let Claude Code prompt / reject
-    //    per its own rules — we must NOT auto-bypass for agents the operator
-    //    doesn't own).
-    // `extraArgs` still wins — operators who know what they're doing can override either.
+    // Daemon-driven Claude Code runs are non-interactive. Any mode that waits
+    // for a local permission prompt can deadlock tool use (Bash / WebFetch /
+    // MCP) because there is no prompt relay back to the user yet. Default to
+    // bypassPermissions for every trust tier; operators who need a stricter
+    // posture can still override with route/defaultRoute extraArgs.
     if (!opts.extraArgs?.some((a) => a.startsWith("--permission-mode"))) {
-      if (opts.trustLevel === "owner") {
-        args.push("--permission-mode", "bypassPermissions");
-      } else {
-        args.push("--permission-mode", "default");
-      }
+      args.push("--permission-mode", "bypassPermissions");
     }
     // Claude Code's `--append-system-prompt` is applied per invocation and NOT
     // persisted in the resumed session transcript — ideal for memory / digest

--- a/packages/daemon/src/gateway/runtimes/codex.ts
+++ b/packages/daemon/src/gateway/runtimes/codex.ts
@@ -171,8 +171,12 @@ export class CodexAdapter extends NdjsonStreamAdapter {
     // Sandbox / approval policy. Expressed as `-c` overrides because
     // `codex exec resume` rejects `-s` / `--full-auto`. `-c` works on both
     // the fresh `exec` and `exec resume` paths.
-    //  - owner turn: bypass approvals + sandbox (owner trusts their agent)
-    //  - non-owner turn: `workspace-write` sandbox + on-request approvals
+    //
+    // Daemon-driven Codex runs are non-interactive. Any mode that waits for a
+    // local approval prompt can deadlock tool use because there is no prompt
+    // relay back to the user yet. Default to bypassing both approvals and the
+    // sandbox for every trust tier; operators who need a stricter posture can
+    // still override with route/defaultRoute extraArgs.
     const hasSandboxOverride =
       opts.extraArgs?.some(
         (a) =>
@@ -184,21 +188,12 @@ export class CodexAdapter extends NdjsonStreamAdapter {
           a.startsWith("-csandbox_mode="),
       ) ?? false;
     if (!hasSandboxOverride) {
-      if (opts.trustLevel === "owner") {
-        tail.push(
-          "-c",
-          'sandbox_mode="danger-full-access"',
-          "-c",
-          'approval_policy="never"',
-        );
-      } else {
-        tail.push(
-          "-c",
-          'sandbox_mode="workspace-write"',
-          "-c",
-          'approval_policy="on-request"',
-        );
-      }
+      tail.push(
+        "-c",
+        'sandbox_mode="danger-full-access"',
+        "-c",
+        'approval_policy="never"',
+      );
     }
     tail.push("--skip-git-repo-check", "--json");
     if (opts.extraArgs?.length) tail.push(...opts.extraArgs);


### PR DESCRIPTION
## Summary
- Default daemon-driven Claude Code runs to `--permission-mode bypassPermissions` for every trust tier unless explicitly overridden.
- Default daemon-driven Codex runs to `sandbox_mode="danger-full-access"` and `approval_policy="never"` unless explicitly overridden.
- Update adapter tests for the new non-interactive runtime defaults.

## Tests
- `cd packages/daemon && npm test -- claude-code-adapter.test.ts codex-adapter.test.ts`

## Notes
- `cd packages/daemon && npm run build` is blocked in this local checkout by stale installed dependency `packages/daemon/node_modules/@botcord/protocol-core@0.2.2`; `origin/main` daemon sources reference protocol-core 0.2.3 Hermes types.