### PR TITLE
fix: hide bound OpenClaw profiles in agent picker

### DIFF
--- a/frontend/src/components/dashboard/CreateAgentDialog.tsx
+++ b/frontend/src/components/dashboard/CreateAgentDialog.tsx
@@ -137,6 +137,19 @@ export default function CreateAgentDialog({
     () => selectedDaemon?.runtimes?.find((r) => r.id === selectedRuntimeId) ?? null,
     [selectedDaemon, selectedRuntimeId],
   );
+  const selectedOpenclawEndpoint = useMemo(
+    () =>
+      selectedRuntime?.endpoints?.find((e) => e.name === selectedGateway) ??
+      null,
+    [selectedRuntime, selectedGateway],
+  );
+  const selectableOpenclawAgents = useMemo(
+    () =>
+      (selectedOpenclawEndpoint?.agents ?? []).filter(
+        (a) => !a.botcordBinding?.agentId,
+      ),
+    [selectedOpenclawEndpoint],
+  );
   useEffect(() => {
     if (selectedRuntimeId !== "openclaw-acp") {
       setSelectedGateway(null);
@@ -148,6 +161,22 @@ export default function CreateAgentDialog({
     setSelectedGateway(reachable[0]?.name ?? null);
     setSelectedOpenclawAgent(null);
   }, [selectedRuntime, selectedRuntimeId, selectedGateway]);
+
+  useEffect(() => {
+    if (selectedRuntimeId !== "openclaw-acp") return;
+    const agents = selectedOpenclawEndpoint?.agents ?? [];
+    if (agents.length === 0) return;
+    const stillSelectable =
+      selectedOpenclawAgent &&
+      selectableOpenclawAgents.some((a) => a.id === selectedOpenclawAgent);
+    if (stillSelectable) return;
+    setSelectedOpenclawAgent(selectableOpenclawAgents[0]?.id ?? null);
+  }, [
+    selectedRuntimeId,
+    selectedOpenclawEndpoint,
+    selectedOpenclawAgent,
+    selectableOpenclawAgents,
+  ]);
 
   // Auto-pick the first available hermes profile when the user lands on
   // hermes-agent. Prefer the active profile, falling back to the first
@@ -256,10 +285,13 @@ export default function CreateAgentDialog({
 
   const needsOpenclawGateway = selectedRuntimeId === "openclaw-acp";
   const needsHermesProfile = selectedRuntimeId === "hermes-agent";
+  const needsOpenclawAgent =
+    needsOpenclawGateway && (selectedOpenclawEndpoint?.agents?.length ?? 0) > 0;
   const canSubmit =
     !!selectedDaemonId &&
     !!selectedRuntimeId &&
     (!needsOpenclawGateway || !!selectedGateway) &&
+    (!needsOpenclawAgent || !!selectedOpenclawAgent) &&
     (!needsHermesProfile || !!selectedHermesProfile) &&
     !submitting;
 
@@ -615,6 +647,8 @@ function OpenclawGatewayPicker({
   const reachable = endpoints.filter((e) => e.reachable);
   const current = endpoints.find((e) => e.name === selectedGateway) ?? null;
   const agents = current?.agents ?? [];
+  const availableAgents = agents.filter((a) => !a.botcordBinding?.agentId);
+  const boundCount = agents.length - availableAgents.length;
   if (endpoints.length === 0) {
     return (
       <div className="rounded-xl border border-dashed border-glass-border bg-glass-bg/40 px-3 py-3 text-xs text-text-secondary">
@@ -666,13 +700,17 @@ function OpenclawGatewayPicker({
           />
         ) : (
           <select
-            disabled={disabled || !selectedGateway}
+            disabled={disabled || !selectedGateway || availableAgents.length === 0}
             value={selectedAgent ?? ""}
             onChange={(e) => onSelectAgent(e.target.value || null)}
             className="w-full rounded-xl border border-glass-border bg-deep-black px-3 py-2 text-sm text-text-primary"
           >
-            <option value="">(use gateway defaultAgent)</option>
-            {agents.map((a) => {
+            <option value="" disabled>
+              {availableAgents.length === 0
+                ? "No unbound profiles available"
+                : "Select an agent profile"}
+            </option>
+            {availableAgents.map((a) => {
               const label =
                 (a.name && a.name !== a.id ? `${a.name} (${a.id})` : a.id) +
                 (a.model?.name ? ` — ${a.model.name}` : "");
@@ -683,6 +721,11 @@ function OpenclawGatewayPicker({
               );
             })}
           </select>
+        )}
+        {boundCount > 0 && (
+          <p className="mt-1 text-[11px] text-text-tertiary">
+            {boundCount} profile{boundCount === 1 ? "" : "s"} already bound to BotCord.
+          </p>
         )}
       </div>
     </div>

--- a/frontend/src/store/useDaemonStore.ts
+++ b/frontend/src/store/useDaemonStore.ts
@@ -30,6 +30,9 @@ export interface DaemonRuntimeEndpoint {
     name?: string;
     workspace?: string;
     model?: { name?: string; provider?: string };
+    botcordBinding?: {
+      agentId: string;
+    };
   }>;
 }
 
@@ -235,6 +238,12 @@ function normalizeRuntimes(raw: unknown): DaemonRuntime[] | null | undefined {
                         workspace:
                           typeof ax.workspace === "string" ? ax.workspace : undefined,
                         model,
+                        botcordBinding:
+                          ax.botcordBinding &&
+                          typeof ax.botcordBinding === "object" &&
+                          typeof (ax.botcordBinding as any).agentId === "string"
+                            ? { agentId: (ax.botcordBinding as any).agentId }
+                            : undefined,
                       };
                     })
                     .filter(Boolean) as DaemonRuntimeEndpoint["agents"])

--- a/packages/daemon/src/gateway/__tests__/claude-code-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/claude-code-adapter.test.ts
@@ -263,7 +263,7 @@ process.stdout.write(JSON.stringify({type:"result", subtype:"success", session_i
       expect(argv[modeIdx + 1]).toBe("bypassPermissions");
     });
 
-    it("public → --permission-mode default", async () => {
+    it("public → --permission-mode bypassPermissions", async () => {
       const adapter = new ClaudeCodeAdapter({ binary: echoScript() });
       const ctrl = new AbortController();
       const res = await adapter.run({
@@ -277,10 +277,10 @@ process.stdout.write(JSON.stringify({type:"result", subtype:"success", session_i
       const argv = JSON.parse(res.text) as string[];
       const modeIdx = argv.indexOf("--permission-mode");
       expect(modeIdx).toBeGreaterThanOrEqual(0);
-      expect(argv[modeIdx + 1]).toBe("default");
+      expect(argv[modeIdx + 1]).toBe("bypassPermissions");
     });
 
-    it("trusted → --permission-mode default", async () => {
+    it("trusted → --permission-mode bypassPermissions", async () => {
       const adapter = new ClaudeCodeAdapter({ binary: echoScript() });
       const ctrl = new AbortController();
       const res = await adapter.run({
@@ -294,7 +294,7 @@ process.stdout.write(JSON.stringify({type:"result", subtype:"success", session_i
       const argv = JSON.parse(res.text) as string[];
       const modeIdx = argv.indexOf("--permission-mode");
       expect(modeIdx).toBeGreaterThanOrEqual(0);
-      expect(argv[modeIdx + 1]).toBe("default");
+      expect(argv[modeIdx + 1]).toBe("bypassPermissions");
     });
 
     it("systemContext → --append-system-prompt <text>", async () => {

--- a/packages/daemon/src/gateway/__tests__/codex-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/codex-adapter.test.ts
@@ -338,7 +338,7 @@ process.stdout.write(JSON.stringify({type:"item.completed", item:{id:"i0", type:
       expect(argv).not.toContain("-s");
     });
 
-    it("public → sandbox_mode=\"workspace-write\" + approval_policy=\"on-request\"", async () => {
+    it("public → sandbox_mode=\"danger-full-access\" + approval_policy=\"never\"", async () => {
       const adapter = new CodexAdapter({ binary: echoScript() });
       const ctrl = new AbortController();
       const res = await adapter.run({
@@ -350,12 +350,12 @@ process.stdout.write(JSON.stringify({type:"item.completed", item:{id:"i0", type:
         trustLevel: "public",
       });
       const argv = JSON.parse(res.text) as string[];
-      expect(argv).toContain('sandbox_mode="workspace-write"');
-      expect(argv).toContain('approval_policy="on-request"');
+      expect(argv).toContain('sandbox_mode="danger-full-access"');
+      expect(argv).toContain('approval_policy="never"');
       expect(argv).not.toContain("--dangerously-bypass-approvals-and-sandbox");
     });
 
-    it("trusted → sandbox_mode=\"workspace-write\" + approval_policy=\"on-request\"", async () => {
+    it("trusted → sandbox_mode=\"danger-full-access\" + approval_policy=\"never\"", async () => {
       const adapter = new CodexAdapter({ binary: echoScript() });
       const ctrl = new AbortController();
       const res = await adapter.run({
@@ -367,8 +367,8 @@ process.stdout.write(JSON.stringify({type:"item.completed", item:{id:"i0", type:
         trustLevel: "trusted",
       });
       const argv = JSON.parse(res.text) as string[];
-      expect(argv).toContain('sandbox_mode="workspace-write"');
-      expect(argv).toContain('approval_policy="on-request"');
+      expect(argv).toContain('sandbox_mode="danger-full-access"');
+      expect(argv).toContain('approval_policy="never"');
     });
 
     it("extraArgs `-s read-only` suppresses the default sandbox `-c`s", async () => {

--- a/packages/daemon/src/gateway/runtimes/claude-code.ts
+++ b/packages/daemon/src/gateway/runtimes/claude-code.ts
@@ -107,21 +107,13 @@ export class ClaudeCodeAdapter extends NdjsonStreamAdapter {
       args.push("--resume", opts.sessionId);
     }
     // Permission-mode policy:
-    //  - owner: bypassPermissions (owner fully trusts their own agent; daemon
-    //    has no authorization-relay UI yet, so any other mode causes Bash /
-    //    WebFetch / MCP tool calls to deadlock waiting for a prompt that
-    //    never reaches the user — see issue #332 for the planned MCP-bridge
-    //    relay that will let us tighten this back up).
-    //  - non-owner (trusted/public): default (let Claude Code prompt / reject
-    //    per its own rules — we must NOT auto-bypass for agents the operator
-    //    doesn't own).
-    // `extraArgs` still wins — operators who know what they're doing can override either.
+    // Daemon-driven Claude Code runs are non-interactive. Any mode that waits
+    // for a local permission prompt can deadlock tool use (Bash / WebFetch /
+    // MCP) because there is no prompt relay back to the user yet. Default to
+    // bypassPermissions for every trust tier; operators who need a stricter
+    // posture can still override with route/defaultRoute extraArgs.
     if (!opts.extraArgs?.some((a) => a.startsWith("--permission-mode"))) {
-      if (opts.trustLevel === "owner") {
-        args.push("--permission-mode", "bypassPermissions");
-      } else {
-        args.push("--permission-mode", "default");
-      }
+      args.push("--permission-mode", "bypassPermissions");
     }
     // Claude Code's `--append-system-prompt` is applied per invocation and NOT
     // persisted in the resumed session transcript — ideal for memory / digest

--- a/packages/daemon/src/gateway/runtimes/codex.ts
+++ b/packages/daemon/src/gateway/runtimes/codex.ts
@@ -171,8 +171,12 @@ export class CodexAdapter extends NdjsonStreamAdapter {
     // Sandbox / approval policy. Expressed as `-c` overrides because
     // `codex exec resume` rejects `-s` / `--full-auto`. `-c` works on both
     // the fresh `exec` and `exec resume` paths.
-    //  - owner turn: bypass approvals + sandbox (owner trusts their agent)
-    //  - non-owner turn: `workspace-write` sandbox + on-request approvals
+    //
+    // Daemon-driven Codex runs are non-interactive. Any mode that waits for a
+    // local approval prompt can deadlock tool use because there is no prompt
+    // relay back to the user yet. Default to bypassing both approvals and the
+    // sandbox for every trust tier; operators who need a stricter posture can
+    // still override with route/defaultRoute extraArgs.
     const hasSandboxOverride =
       opts.extraArgs?.some(
         (a) =>
@@ -184,21 +188,12 @@ export class CodexAdapter extends NdjsonStreamAdapter {
           a.startsWith("-csandbox_mode="),
       ) ?? false;
     if (!hasSandboxOverride) {
-      if (opts.trustLevel === "owner") {
-        tail.push(
-          "-c",
-          'sandbox_mode="danger-full-access"',
-          "-c",
-          'approval_policy="never"',
-        );
-      } else {
-        tail.push(
-          "-c",
-          'sandbox_mode="workspace-write"',
-          "-c",
-          'approval_policy="on-request"',
-        );
-      }
+      tail.push(
+        "-c",
+        'sandbox_mode="danger-full-access"',
+        "-c",
+        'approval_policy="never"',
+      );
     }
     tail.push("--skip-git-repo-check", "--json");
     if (opts.extraArgs?.length) tail.push(...opts.extraArgs);


### PR DESCRIPTION
## Summary
- preserve OpenClaw profile botcordBinding metadata in the daemon runtime store
- filter already-bound OpenClaw profiles out of the create-agent picker
- require selecting an unbound profile when profile discovery is available

## Tests
- NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build