### PR TITLE
feat: add chat sender identity icons

### DIFF
--- a/frontend/src/components/dashboard/MessageBubble.tsx
+++ b/frontend/src/components/dashboard/MessageBubble.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import type { KeyboardEvent } from "react";
-import { MoreHorizontal, User } from "lucide-react";
+import { Bot, MoreHorizontal, User } from "lucide-react";
 import ForwardModal from "./ForwardModal";
 import type { DashboardMessage, Attachment } from "@/lib/types";
 import { useLanguage } from '@/lib/i18n';
@@ -207,11 +207,18 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
           onKeyDown={handleSelectSenderByKey}
           className={`mb-0.5 flex items-center gap-1.5 rounded px-1 transition-colors hover:bg-glass-bg ${isOwn ? "justify-end" : "-ml-1"}`}
         >
-          {isHuman ? (
-            <User className="h-3 w-3 text-neon-green/80" aria-label="human" />
-          ) : (
-            <PresenceDot agentId={message.sender_id} size="xs" />
-          )}
+          <span
+            className={`inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border ${
+              isHuman
+                ? "border-neon-green/30 bg-neon-green/10 text-neon-green"
+                : "border-neon-purple/30 bg-neon-purple/10 text-neon-purple"
+            }`}
+            title={isHuman ? "Human" : "Bot"}
+            aria-label={isHuman ? "Human sender" : "Bot sender"}
+          >
+            {isHuman ? <User className="h-2.5 w-2.5" /> : <Bot className="h-2.5 w-2.5" />}
+          </span>
+          {!isHuman && <PresenceDot agentId={message.sender_id} size="xs" />}
           <span
             className={`text-xs font-medium hover:underline ${
               isHuman ? "text-neon-green" : "text-neon-purple"

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import { Loader2, MessageSquare, AlertCircle, RotateCcw, Bell, FileText, Settings2 } from "lucide-react";
+import { Bot, Loader2, MessageSquare, AlertCircle, RotateCcw, Bell, FileText, Settings2, User } from "lucide-react";
 import AgentSettingsDrawer from "./AgentSettingsDrawer";
 import { api } from "@/lib/api";
 import type { Attachment, OwnerChatMessage } from "@/lib/types";
@@ -383,6 +383,18 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
             return (
               <div key={msg.clientId} className="flex justify-end">
                 <div className="max-w-[75%] rounded-lg px-3 py-2 text-sm bg-cyan-500/20 text-cyan-100 border border-cyan-500/30">
+                  <div className="mb-1 flex items-center justify-end gap-1.5">
+                    <span className="text-xs font-medium text-cyan-100/90">
+                      {msg.senderName}
+                    </span>
+                    <span
+                      className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-cyan-300/30 bg-cyan-300/10 text-cyan-200"
+                      title="Human"
+                      aria-label="Human sender"
+                    >
+                      <User className="h-2.5 w-2.5" />
+                    </span>
+                  </div>
                   <MarkdownContent content={msg.text} />
                   <div className="flex items-center justify-end gap-1.5 mt-1">
                     {msg.status === "optimistic" && (
@@ -431,16 +443,38 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
                       : "bg-zinc-800 text-zinc-200 border border-zinc-700"
                   }`}
                 >
-                  {!isUser && (
-                    <div className="mb-1 flex items-center gap-1.5">
+                  <div className={`mb-1 flex items-center gap-1.5 ${isUser ? "justify-end" : ""}`}>
+                    {isUser ? (
+                      <>
+                        <span className="text-xs font-medium text-cyan-100/90">
+                          {msg.senderName}
+                        </span>
+                        <span
+                          className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-cyan-300/30 bg-cyan-300/10 text-cyan-200"
+                          title="Human"
+                          aria-label="Human sender"
+                        >
+                          <User className="h-2.5 w-2.5" />
+                        </span>
+                      </>
+                    ) : (
+                      <>
+                        <span
+                          className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-purple-400/30 bg-purple-400/10 text-purple-300"
+                          title="Bot"
+                          aria-label="Bot sender"
+                        >
+                          <Bot className="h-2.5 w-2.5" />
+                        </span>
                       <span className="text-xs font-medium text-zinc-300">
                         {msg.senderName}
                       </span>
                       {chatAgentId && (
                         <CopyableId value={chatAgentId} className="text-zinc-500 hover:text-zinc-300" />
                       )}
-                    </div>
-                  )}
+                      </>
+                    )}
+                  </div>
                   {/* Typewriter for new agent messages; skip if already animated or was streamed */}
                   {(() => {
                     const wasStreamed = msg.traceId && streamedTraceIds.current?.has(msg.traceId);


### PR DESCRIPTION
## Summary
- add compact human/bot identity badges to room message headers
- show human/bot badges in owner-chat messages, including optimistic and failed user sends

## Tests
- npm run build
- NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build