### PR TITLE
feat: agent presence & status v1 (Supabase-only)

### DIFF
--- a/backend/app/routers/presence.py
+++ b/backend/app/routers/presence.py
@@ -1,0 +1,265 @@
+"""
+[INPUT]: 依赖 hub.services.presence 与 dashboard 鉴权，承载前端拉取 agent 状态 snapshot 与设置 manual status 的入口。
+[OUTPUT]: 对外提供 GET/POST /api/presence/agents、PATCH /api/agents/{agent_id}/status。
+[POS]: BFF 层 presence 路由，负责权限过滤、observer 视图与 invisible 隐藏。
+[PROTOCOL]: 变更时更新此头部，然后检查 README.md。
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+from typing import Iterable
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import RequestContext, require_user
+from hub.database import get_db
+from hub.models import Agent, Contact, RoomMember, User
+from hub.services import presence as presence_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/presence", tags=["app-presence"])
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class SnapshotRequest(BaseModel):
+    agent_ids: list[str] = Field(default_factory=list, max_length=200)
+
+
+class SnapshotResponse(BaseModel):
+    agents: list[dict]
+
+
+class ManualStatusUpdate(BaseModel):
+    manual_status: str = Field(..., pattern=r"^(available|busy|away|invisible)$")
+    status_message: str | None = Field(default=None, max_length=140)
+    manual_expires_at: datetime.datetime | None = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _resolve_human_id(db: AsyncSession, user_id) -> str | None:
+    row = await db.execute(select(User.human_id).where(User.id == user_id))
+    return row.scalar_one_or_none()
+
+
+async def _filter_visible(
+    db: AsyncSession,
+    requester_human_id: str | None,
+    requester_owned_agent_ids: set[str],
+    agent_ids: Iterable[str],
+) -> dict[str, bool]:
+    """Return {agent_id: is_owner} for agents the requester is allowed to see.
+
+    Visibility rules:
+      - owner: always allowed (is_owner=True)
+      - contact: ``Contact.owner_id == requester_human_id`` and
+        ``contact_agent_id in agent_ids``
+      - room comember: ``RoomMember`` join via shared room
+      - else: hidden (entry omitted)
+    """
+    ids = list({a for a in agent_ids if a})
+    if not ids:
+        return {}
+
+    visible: dict[str, bool] = {}
+
+    # Owner check
+    own_rows = (
+        await db.execute(
+            select(Agent.agent_id).where(
+                Agent.agent_id.in_(ids),
+                Agent.agent_id.in_(requester_owned_agent_ids)
+                if requester_owned_agent_ids
+                else Agent.agent_id.is_(None),
+            )
+        )
+    ).scalars().all()
+    for aid in own_rows:
+        visible[aid] = True
+
+    if requester_human_id is None:
+        return visible
+
+    remaining = [a for a in ids if a not in visible]
+    if not remaining:
+        return visible
+
+    # Contact check (requester_human_id has contact_agent_id == aid)
+    contact_rows = (
+        await db.execute(
+            select(Contact.contact_agent_id).where(
+                Contact.owner_id == requester_human_id,
+                Contact.contact_agent_id.in_(remaining),
+            )
+        )
+    ).scalars().all()
+    for aid in contact_rows:
+        visible.setdefault(aid, False)
+
+    remaining = [a for a in ids if a not in visible]
+    if not remaining:
+        return visible
+
+    # Room comember check: requester membership is polymorphic — they may be in
+    # rooms as their human id (hu_*) OR via any of their owned agents (ag_*).
+    requester_membership_ids: list[str] = []
+    if requester_human_id is not None:
+        requester_membership_ids.append(requester_human_id)
+    requester_membership_ids.extend(requester_owned_agent_ids)
+    requester_rooms: list[str] = []
+    if requester_membership_ids:
+        requester_rooms = (
+            await db.execute(
+                select(RoomMember.room_id).where(
+                    RoomMember.agent_id.in_(requester_membership_ids)
+                )
+            )
+        ).scalars().all()
+    if requester_rooms:
+        comember_rows = (
+            await db.execute(
+                select(RoomMember.agent_id).where(
+                    RoomMember.agent_id.in_(remaining),
+                    RoomMember.room_id.in_(list(requester_rooms)),
+                )
+            )
+        ).scalars().all()
+        for aid in comember_rows:
+            visible.setdefault(aid, False)
+
+    return visible
+
+
+async def _requester_owned_agent_ids(
+    db: AsyncSession, user_id
+) -> set[str]:
+    rows = (
+        await db.execute(select(Agent.agent_id).where(Agent.user_id == user_id))
+    ).scalars().all()
+    return set(rows)
+
+
+async def _build_response(
+    db: AsyncSession, ctx: RequestContext, agent_ids: list[str]
+) -> SnapshotResponse:
+    requester_human_id = await _resolve_human_id(db, ctx.user_id)
+    owned_ids = await _requester_owned_agent_ids(db, ctx.user_id)
+    visible = await _filter_visible(
+        db, requester_human_id, owned_ids, agent_ids
+    )
+    if not visible:
+        return SnapshotResponse(agents=[])
+
+    snapshots = await presence_service.get_snapshots(db, list(visible.keys()))
+    seen = {s.agent_id for s in snapshots}
+    # For agents with no presence row yet, return a synthetic offline snapshot
+    # so the frontend always has an entry per requested id.
+    extras = []
+    for aid, is_owner in visible.items():
+        if aid in seen:
+            continue
+        extras.append(
+            {
+                "agent_id": aid,
+                "version": 0,
+                "effective_status": "offline",
+                "connected": False,
+                "manual_status": "available",
+                "status_message": None,
+                "manual_expires_at": None,
+                "activity": {},
+                "attributes": {},
+                "last_seen_at": None,
+                "updated_at": "",
+            }
+        )
+
+    payloads = [s.for_observer(is_owner=visible[s.agent_id]) for s in snapshots]
+    return SnapshotResponse(agents=payloads + extras)
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/agents", response_model=SnapshotResponse)
+async def get_agent_snapshots(
+    ids: str = Query(default="", description="Comma-separated agent ids"),
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+) -> SnapshotResponse:
+    agent_ids = [a.strip() for a in ids.split(",") if a.strip()][:200]
+    if not agent_ids:
+        return SnapshotResponse(agents=[])
+    return await _build_response(db, ctx, agent_ids)
+
+
+@router.post("/agents/snapshot", response_model=SnapshotResponse)
+async def post_agent_snapshots(
+    body: SnapshotRequest,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+) -> SnapshotResponse:
+    if not body.agent_ids:
+        return SnapshotResponse(agents=[])
+    return await _build_response(db, ctx, body.agent_ids)
+
+
+# Mounted on a separate prefix in main.py so that the URL is
+# /api/agents/{agent_id}/status — matching the design doc.
+status_router = APIRouter(prefix="/api/agents", tags=["app-presence"])
+
+
+@status_router.patch("/{agent_id}/status")
+async def update_manual_status(
+    agent_id: str,
+    body: ManualStatusUpdate,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    agent_row = (
+        await db.execute(select(Agent).where(Agent.agent_id == agent_id))
+    ).scalar_one_or_none()
+    if agent_row is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    if str(agent_row.user_id) != str(ctx.user_id):
+        raise HTTPException(status_code=403, detail="Not the owner of this agent")
+
+    snapshot, changed = await presence_service.set_manual_status(
+        db,
+        agent_id,
+        body.manual_status,
+        status_message=body.status_message,
+        manual_expires_at=body.manual_expires_at,
+        updated_by_type="user",
+        updated_by_id=str(ctx.user_id),
+    )
+    await db.commit()
+
+    if changed:
+        # Lazy import to avoid circular dependency
+        import asyncio
+
+        from hub.routers.hub import broadcast_status_changed
+
+        try:
+            asyncio.create_task(broadcast_status_changed(snapshot))
+        except RuntimeError:
+            # Event loop is shutting down — drop the broadcast.
+            pass
+
+    return snapshot.for_observer(is_owner=True)

--- a/backend/hub/config.py
+++ b/backend/hub/config.py
@@ -97,6 +97,30 @@ FILE_UPLOAD_DIR: str = os.getenv("FILE_UPLOAD_DIR", "/tmp/botcord/uploads")
 FILE_MAX_SIZE_BYTES: int = int(os.getenv("FILE_MAX_SIZE_BYTES", str(10 * 1024 * 1024)))  # 10 MB
 FILE_TTL_HOURS: int = int(os.getenv("FILE_TTL_HOURS", "1"))  # 1 hour
 FILE_CLEANUP_INTERVAL_SECONDS: float = float(os.getenv("FILE_CLEANUP_INTERVAL_SECONDS", "300"))  # 5 min
+
+# ---------------------------------------------------------------------------
+# Agent Presence & Status V1
+#   See docs/agent-presence-status-v1-supabase.md
+# ---------------------------------------------------------------------------
+
+PRESENCE_ONLINE_TIMEOUT_SECONDS: float = float(
+    os.getenv("PRESENCE_ONLINE_TIMEOUT_SECONDS", "45")
+)
+PRESENCE_IDLE_TIMEOUT_SECONDS: float = float(
+    os.getenv("PRESENCE_IDLE_TIMEOUT_SECONDS", "300")
+)
+PRESENCE_TYPING_TIMEOUT_SECONDS: float = float(
+    os.getenv("PRESENCE_TYPING_TIMEOUT_SECONDS", "8")
+)
+PRESENCE_PROCESSING_FAILSAFE_TIMEOUT_SECONDS: float = float(
+    os.getenv("PRESENCE_PROCESSING_FAILSAFE_TIMEOUT_SECONDS", "600")
+)
+PRESENCE_CLEANUP_INTERVAL_SECONDS: float = float(
+    os.getenv("PRESENCE_CLEANUP_INTERVAL_SECONDS", "30")
+)
+PRESENCE_NODE_ID: str = os.getenv(
+    "PRESENCE_NODE_ID", os.getenv("HOSTNAME", "hub")
+)[:64]
 SUPABASE_URL: str | None = os.getenv("SUPABASE_URL")
 SUPABASE_SERVICE_ROLE_KEY: str | None = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
 SUPABASE_STORAGE_BUCKET: str | None = os.getenv("SUPABASE_STORAGE_BUCKET")

--- a/backend/hub/main.py
+++ b/backend/hub/main.py
@@ -18,6 +18,7 @@ from hub.config import DATABASE_SCHEMA
 from hub.database import async_session, engine
 from hub.models import Agent, Base, MessagePolicy
 from hub.cleanup import file_cleanup_loop
+from hub.presence_cleanup import presence_cleanup_loop
 from hub import config as hub_config
 from hub.database import get_db
 from hub.expiry import message_expiry_loop
@@ -52,6 +53,7 @@ from hub.storage import storage_requires_local_disk
 from app.routers.humans import router as app_humans_router
 from app.routers.users import router as app_users_router
 from app.routers.dashboard import router as app_dashboard_router
+from app.routers.presence import router as app_presence_router, status_router as app_presence_status_router
 from app.routers.invites import router as app_invites_router
 from app.routers.public import router as app_public_router
 from app.routers.share import router as app_share_router
@@ -109,6 +111,7 @@ async def lifespan(app: FastAPI):
     cleanup_task = None
     subscription_billing_task = None
     version_poll_task = None
+    presence_task = None
     if not test_db_override:
         # Background message expiry loop
         expiry_task = asyncio.create_task(message_expiry_loop())
@@ -118,11 +121,13 @@ async def lifespan(app: FastAPI):
         subscription_billing_task = asyncio.create_task(subscription_billing_loop())
         # Background npm version polling loop
         version_poll_task = asyncio.create_task(version_poll_loop())
+        # Background presence cleanup loop
+        presence_task = asyncio.create_task(presence_cleanup_loop())
 
     yield
 
     # Shutdown
-    for task in (version_poll_task, subscription_billing_task, cleanup_task, expiry_task):
+    for task in (presence_task, version_poll_task, subscription_billing_task, cleanup_task, expiry_task):
         if task is None:
             continue
         task.cancel()
@@ -289,5 +294,7 @@ app.include_router(app_beta_router)
 app.include_router(app_admin_beta_router)
 app.include_router(app_policy_router, dependencies=_beta_gate)
 app.include_router(app_prompts_router)
+app.include_router(app_presence_router, dependencies=_beta_gate)
+app.include_router(app_presence_status_router, dependencies=_beta_gate)
 app.include_router(daemon_control_router)
 app.include_router(openclaw_control_router)

--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -26,6 +26,7 @@ from sqlalchemy import (
     func,
     text as sa_text,
 )
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 from hub.id_generators import generate_human_id
@@ -1400,4 +1401,122 @@ class AgentApprovalQueue(Base):
     )
     resolved_at: Mapped[datetime.datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
+    )
+
+
+# ---------------------------------------------------------------------------
+# Agent Presence & Status V1
+#   See docs/agent-presence-status-v1-supabase.md
+# ---------------------------------------------------------------------------
+
+
+class AgentStatusSettings(Base):
+    """Owner-driven manual status (available/busy/away/invisible)."""
+
+    __tablename__ = "agent_status_settings"
+    __table_args__ = (
+        CheckConstraint(
+            "manual_status IN ('available', 'busy', 'away', 'invisible')",
+            name="ck_agent_status_settings_manual_status",
+        ),
+    )
+
+    agent_id: Mapped[str] = mapped_column(
+        String(32),
+        ForeignKey("agents.agent_id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    manual_status: Mapped[str] = mapped_column(
+        String(16), nullable=False, default="available", server_default="available"
+    )
+    status_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    manual_expires_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    updated_by_type: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    updated_by_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+
+class AgentPresence(Base):
+    """Composed effective status + activity/attribute projection."""
+
+    __tablename__ = "agent_presence"
+    __table_args__ = (
+        CheckConstraint(
+            "effective_status IN ('offline', 'online', 'busy', 'away', 'working')",
+            name="ck_agent_presence_effective_status",
+        ),
+        Index("ix_agent_presence_status_updated", "effective_status", "updated_at"),
+        Index("ix_agent_presence_last_seen", "last_seen_at"),
+    )
+
+    agent_id: Mapped[str] = mapped_column(
+        String(32),
+        ForeignKey("agents.agent_id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    effective_status: Mapped[str] = mapped_column(
+        String(16), nullable=False, default="offline", server_default="offline"
+    )
+    connected: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa_text("FALSE")
+    )
+    connection_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    version: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=0, server_default="0"
+    )
+    last_seen_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    activity_json: Mapped[dict] = mapped_column(
+        JSONB().with_variant(JSON(), "sqlite"),
+        nullable=False,
+        default=dict,
+        server_default="{}",
+    )
+    attributes_json: Mapped[dict] = mapped_column(
+        JSONB().with_variant(JSON(), "sqlite"),
+        nullable=False,
+        default=dict,
+        server_default="{}",
+    )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+
+class AgentPresenceConnection(Base):
+    """Per-WebSocket connection lease. Multi-Hub safe."""
+
+    __tablename__ = "agent_presence_connections"
+    __table_args__ = (
+        Index(
+            "ix_agent_presence_connections_agent_seen",
+            "agent_id",
+            "last_seen_at",
+        ),
+        Index(
+            "ix_agent_presence_connections_node",
+            "node_id",
+            "last_seen_at",
+        ),
+    )
+
+    connection_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    agent_id: Mapped[str] = mapped_column(
+        String(32),
+        ForeignKey("agents.agent_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    node_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    last_seen_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
     )

--- a/backend/hub/presence_cleanup.py
+++ b/backend/hub/presence_cleanup.py
@@ -1,0 +1,91 @@
+"""Background loop that drops stale presence connection leases.
+
+See docs/agent-presence-status-v1-supabase.md (#cleanup-job).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from sqlalchemy import text
+
+from hub import config as hub_config
+from hub.database import async_session
+
+logger = logging.getLogger(__name__)
+
+# Random Postgres advisory-lock key for the presence cleanup job. The bigint
+# is arbitrary but stable; multiple Hub processes will only let one win.
+_ADVISORY_LOCK_KEY = 0x7072_6573_656E_6365  # "presence" in hex (8 bytes)
+
+
+async def _try_run_cleanup() -> int:
+    """Acquire the advisory lock, run cleanup, and broadcast snapshots.
+
+    The advisory lock is held in a dedicated session so a transaction
+    rollback in the cleanup path cannot leave it stuck.
+    """
+    from hub.routers.hub import broadcast_status_changed
+    from hub.services import presence as presence_service
+
+    # Detect dialect once — we need a session to read it.
+    async with async_session() as probe:
+        dialect = getattr(probe.get_bind(), "dialect", None)
+        is_postgres = dialect is not None and dialect.name == "postgresql"
+
+    lock_session = None
+    if is_postgres:
+        lock_session = async_session()
+        await lock_session.__aenter__()
+        got = (
+            await lock_session.execute(
+                text("SELECT pg_try_advisory_lock(:key)"),
+                {"key": _ADVISORY_LOCK_KEY},
+            )
+        ).scalar_one()
+        if not got:
+            await lock_session.__aexit__(None, None, None)
+            return 0
+
+    try:
+        async with async_session() as db:
+            try:
+                changed = await presence_service.cleanup_stale(db)
+                await db.commit()
+            except Exception:
+                await db.rollback()
+                raise
+    finally:
+        if lock_session is not None:
+            try:
+                await lock_session.execute(
+                    text("SELECT pg_advisory_unlock(:key)"),
+                    {"key": _ADVISORY_LOCK_KEY},
+                )
+                await lock_session.commit()
+            except Exception as exc:
+                logger.warning("presence advisory unlock failed: %s", exc)
+            finally:
+                await lock_session.__aexit__(None, None, None)
+
+    for snapshot in changed:
+        try:
+            asyncio.create_task(broadcast_status_changed(snapshot))
+        except RuntimeError:
+            break
+    return len(changed)
+
+
+async def presence_cleanup_loop() -> None:
+    """Background loop: drop stale connections + recompute presence."""
+    while True:
+        try:
+            count = await _try_run_cleanup()
+            if count:
+                logger.info("presence cleanup: %d agent(s) updated", count)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("presence_cleanup_loop error")
+        await asyncio.sleep(hub_config.PRESENCE_CLEANUP_INTERVAL_SECONDS)

--- a/backend/hub/routers/hub.py
+++ b/backend/hub/routers/hub.py
@@ -25,7 +25,8 @@ from hub.config import INBOX_POLL_MAX_TIMEOUT, PAIR_RATE_LIMIT_PER_MINUTE, RATE_
 from hub.constants import MIN_PLUGIN_VERSION, get_latest_plugin_version, is_below_min_version
 from hub.crypto import check_timestamp, verify_envelope_sig, verify_payload_hash
 from hub.dashboard_message_shaping import load_user_display_names
-from hub.database import get_db
+from hub.database import async_session, get_db
+from hub.services import presence as presence_service
 from hub.enums import TopicStatus
 from hub.id_generators import generate_hub_msg_id, generate_topic_id
 from hub.models import (
@@ -289,27 +290,54 @@ async def _collect_presence_observers(
     return observers
 
 
-async def broadcast_presence(agent_id: str, online: bool) -> None:
-    """Fan out a presence event to the subject + all observers.
+async def _resolve_owner_human_id(
+    db: AsyncSession, agent_id: str
+) -> str | None:
+    """Return the ``hu_*`` id of the user owning this agent, if any.
 
-    ``agent_id`` is polymorphic (``ag_*`` or ``hu_*``). Each target receives the
-    event on their own realtime topic — routing (``agent:`` vs ``human:``) is
-    handled by ``build_agent_realtime_topic`` which dispatches by id prefix.
+    Used by ``broadcast_status_changed`` to decide whether a target is the
+    owner (and therefore allowed to see ``invisible`` status).
+    """
+    if not agent_id.startswith("ag_"):
+        return None
+    row = await db.execute(
+        select(User.human_id)
+        .join(Agent, Agent.user_id == User.id)
+        .where(Agent.agent_id == agent_id)
+    )
+    return row.scalar_one_or_none()
+
+
+async def broadcast_status_changed(snapshot) -> None:
+    """Fan out an ``agent_status_changed`` event to subject + observers.
+
+    Observer projection: non-owners never see ``invisible``; the agent
+    appears as ``offline`` to them. The owning Human (if claimed) is
+    treated as owner.
     """
     from hub.database import async_session
 
     event_time = datetime.datetime.now(datetime.timezone.utc)
+    subject = snapshot.agent_id
     try:
         async with async_session() as db:
-            observers = await _collect_presence_observers(db, agent_id)
-            targets = observers | {agent_id}
+            observers = await _collect_presence_observers(db, subject)
+            owner_hu_id = await _resolve_owner_human_id(db, subject)
+            targets = observers | {subject}
+            if owner_hu_id:
+                targets.add(owner_hu_id)
             for target in targets:
+                is_owner = target == subject or (
+                    owner_hu_id is not None and target == owner_hu_id
+                )
+                payload = snapshot.for_observer(is_owner=is_owner)
                 event = build_agent_realtime_event(
-                    type="presence",
+                    type="agent_status_changed",
                     agent_id=target,
                     ext={
-                        "subject_agent_id": agent_id,
-                        "online": online,
+                        "subject_agent_id": subject,
+                        "version": snapshot.version,
+                        "status": payload,
                     },
                     created_at=event_time,
                 )
@@ -318,10 +346,13 @@ async def broadcast_presence(agent_id: str, online: bool) -> None:
                 except Exception as exc:
                     logger.warning(
                         "presence publish failed subject=%s target=%s err=%s",
-                        agent_id, target, exc,
+                        subject, target, exc,
                     )
     except Exception as exc:
-        logger.error("broadcast_presence failed subject=%s err=%s", agent_id, exc, exc_info=True)
+        logger.error(
+            "broadcast_status_changed failed subject=%s err=%s",
+            subject, exc, exc_info=True,
+        )
 
 
 async def notify_inbox(
@@ -751,6 +782,19 @@ async def _send_direct_message(
             envelope.to, envelope.msg_id, exc, exc_info=True,
         )
 
+    # Narrow processing signal: a DM addressed to a specific agent is the
+    # canonical "agent has work to do" trigger. Room fan-out is intentionally
+    # excluded — see the doc's "task/dispatch" guidance. Skip non-message
+    # types (contact_request / result / error) which don't represent a turn.
+    if (
+        envelope.to.startswith("ag_")
+        and envelope.from_ != envelope.to
+        and envelope.type == MessageType.message
+    ):
+        presence_service.emit_processing_signal_async(
+            envelope.to, True, current_task="replying"
+        )
+
     return SendResponse(
         queued=True,
         hub_msg_id=record.hub_msg_id,
@@ -1100,6 +1144,15 @@ async def send_message(
                 envelope.msg_id,
                 patterns,
             )
+
+    # Outbound message produced by an agent — clear its processing flag so
+    # the "working" badge drops back. Approximate (a single-turn assumption);
+    # mismatches recover via the failsafe timeout in set_processing.
+    # NOTE: a chatty agent that emits N messages in one turn will toggle
+    # processing 2N times, each of which is a realtime broadcast. Acceptable
+    # for V1; tighten when task/dispatch lifecycle wires explicit signals.
+    if current_agent.startswith("ag_") and envelope.type == MessageType.message:
+        presence_service.emit_processing_signal_async(current_agent, False)
 
     # Branch: room / direct message
     if envelope.to.startswith("rm_"):
@@ -1787,7 +1840,8 @@ async def send_typing(
 # WebSocket /hub/ws — real-time inbox push
 # ---------------------------------------------------------------------------
 
-_WS_HEARTBEAT_INTERVAL = 30  # seconds
+_WS_HEARTBEAT_INTERVAL = 15  # seconds — presence online_timeout is 45s
+_WS_MAX_SILENT_HEARTBEATS = 2  # close after ~30s of no client response
 
 
 @router.websocket("/ws")
@@ -1805,6 +1859,7 @@ async def websocket_inbox(ws: WebSocket):
     """
     await ws.accept()
     agent_id: str | None = None
+    connection_id: str | None = None
 
     try:
         # --- Auth phase: expect {"type": "auth", "token": "..."} ---
@@ -1846,19 +1901,34 @@ async def websocket_inbox(ws: WebSocket):
         logger.info("WebSocket connected: agent=%s plugin_version=%s", agent_id, plugin_version)
 
         # --- Register this connection ---
-        was_offline = agent_id not in _ws_connections or not _ws_connections[agent_id]
+        connection_id = f"ws_{uuid.uuid4().hex[:24]}"
         if agent_id not in _ws_connections:
             _ws_connections[agent_id] = set()
         _ws_connections[agent_id].add(ws)
-        # Edge: offline -> online, fan out presence
-        if was_offline:
-            asyncio.create_task(broadcast_presence(agent_id, True))
+
+        async def _presence_call(fn, *args, **kwargs):
+            """Run a presence_service call in its own session and broadcast on change."""
+            try:
+                async with async_session() as pdb:
+                    snapshot, changed = await fn(pdb, *args, **kwargs)
+                    await pdb.commit()
+                if changed:
+                    try:
+                        asyncio.create_task(broadcast_status_changed(snapshot))
+                    except RuntimeError:
+                        pass
+            except Exception as exc:
+                logger.warning(
+                    "presence_call failed agent=%s fn=%s err=%s",
+                    agent_id, getattr(fn, "__name__", str(fn)), exc,
+                )
+
+        await _presence_call(
+            presence_service.mark_connected, agent_id, connection_id
+        )
 
         # --- Main loop: heartbeat + listen for client messages ---
-        # Track consecutive heartbeats without any client response to detect
-        # ghost connections (e.g. Nginx h2 proxy silently dropping frames).
         _silent_heartbeats = 0
-        _MAX_SILENT_HEARTBEATS = 3  # kick after 3 unanswered heartbeats (~90s)
 
         while True:
             try:
@@ -1867,13 +1937,17 @@ async def websocket_inbox(ws: WebSocket):
                     ws.receive_json(), timeout=_WS_HEARTBEAT_INTERVAL
                 )
                 _silent_heartbeats = 0  # client is alive
+                # Refresh connection lease + last_seen on any client message
+                await _presence_call(
+                    presence_service.mark_heartbeat, agent_id, connection_id
+                )
                 # Handle client messages (ping/pong, future extensions)
                 if msg.get("type") == "ping":
                     await ws.send_json({"type": "pong"})
             except asyncio.TimeoutError:
                 # No client message within interval — send heartbeat
                 _silent_heartbeats += 1
-                if _silent_heartbeats >= _MAX_SILENT_HEARTBEATS:
+                if _silent_heartbeats >= _WS_MAX_SILENT_HEARTBEATS:
                     logger.warning(
                         "WebSocket ghost detected: agent=%s silent_heartbeats=%d, closing",
                         agent_id, _silent_heartbeats,
@@ -1890,11 +1964,25 @@ async def websocket_inbox(ws: WebSocket):
         # --- Cleanup ---
         if agent_id:
             ws_set = _ws_connections.get(agent_id)
-            went_offline = False
             if ws_set:
                 ws_set.discard(ws)
                 if not ws_set:
                     _ws_connections.pop(agent_id, None)
-                    went_offline = True
-            if went_offline:
-                asyncio.create_task(broadcast_presence(agent_id, False))
+            if connection_id is not None:
+                try:
+                    async with async_session() as pdb:
+                        snapshot, changed = await presence_service.mark_disconnected(
+                            pdb, agent_id, connection_id
+                        )
+                        await pdb.commit()
+                    if changed:
+                        try:
+                            asyncio.create_task(broadcast_status_changed(snapshot))
+                        except RuntimeError:
+                            # Event loop is shutting down — drop the broadcast.
+                            pass
+                except Exception as exc:
+                    logger.warning(
+                        "mark_disconnected failed agent=%s err=%s",
+                        agent_id, exc,
+                    )

--- a/backend/hub/services/presence.py
+++ b/backend/hub/services/presence.py
@@ -1,0 +1,672 @@
+"""
+[INPUT]: 依赖 agent_presence / agent_status_settings / agent_presence_connections 三张表与 Supabase Realtime broadcast 能力，承载 Agent 在线、忙碌、工作中等综合状态的统一写入路径。
+[OUTPUT]: 对外提供 mark_connected / mark_heartbeat / mark_disconnected / set_manual_status / set_processing / get_snapshots 等 Presence Service API。
+[POS]: hub 状态系统中枢，负责把连接信号、用户主动设置、活动信号合成为 effective_status 并广播。
+[PROTOCOL]: 变更时更新此头部，然后检查 README.md。
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime
+import logging
+from typing import Iterable
+
+from sqlalchemy import delete, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.exc import CompileError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from hub import config as hub_config
+from hub.models import AgentPresence, AgentPresenceConnection, AgentStatusSettings
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+EFFECTIVE_STATUSES = ("offline", "online", "busy", "away", "working")
+MANUAL_STATUSES = ("available", "busy", "away", "invisible")
+
+
+# ---------------------------------------------------------------------------
+# DTO
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class AgentPresenceSnapshot:
+    """Read model returned to API/realtime layers."""
+
+    agent_id: str
+    effective_status: str
+    connected: bool
+    connection_count: int
+    version: int
+    last_seen_at: datetime.datetime | None
+    activity: dict
+    attributes: dict
+    manual_status: str
+    status_message: str | None
+    manual_expires_at: datetime.datetime | None
+    updated_at: datetime.datetime | None
+
+    def to_dict(self) -> dict:
+        def _iso(value: datetime.datetime | None) -> str | None:
+            return value.isoformat() if value else None
+
+        return {
+            "agent_id": self.agent_id,
+            "version": self.version,
+            "effective_status": self.effective_status,
+            "connected": self.connected,
+            "manual_status": self.manual_status,
+            "status_message": self.status_message,
+            "manual_expires_at": _iso(self.manual_expires_at),
+            "activity": dict(self.activity),
+            "attributes": dict(self.attributes),
+            "last_seen_at": _iso(self.last_seen_at),
+            "updated_at": _iso(self.updated_at),
+        }
+
+    def for_observer(self, *, is_owner: bool) -> dict:
+        """Return public projection. Non-owners never see ``invisible`` —
+        the agent appears as ``offline`` instead.
+        """
+        if not is_owner and self.manual_status == "invisible":
+            d = self.to_dict()
+            d["effective_status"] = "offline"
+            d["connected"] = False
+            d["manual_status"] = "available"
+            d["status_message"] = None
+            return d
+        return self.to_dict()
+
+
+# ---------------------------------------------------------------------------
+# Pure resolver (unit-testable in isolation)
+# ---------------------------------------------------------------------------
+
+
+def resolve_effective_status(
+    *,
+    manual_status: str,
+    connected: bool,
+    activity: dict,
+) -> str:
+    """Compose effective_status from manual_status + connection + activity.
+
+    Priority:
+      invisible           -> offline
+      not connected       -> offline
+      activity.processing -> working
+      manual busy         -> busy
+      manual away / idle  -> away
+      otherwise           -> online
+    """
+    if manual_status == "invisible":
+        return "offline"
+    if not connected:
+        return "offline"
+    if bool(activity.get("processing")):
+        return "working"
+    if manual_status == "busy":
+        return "busy"
+    if manual_status == "away" or bool(activity.get("idle")):
+        return "away"
+    return "online"
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _now(now: datetime.datetime | None = None) -> datetime.datetime:
+    return now or datetime.datetime.now(datetime.timezone.utc)
+
+
+def _online_cutoff(now: datetime.datetime) -> datetime.datetime:
+    return now - datetime.timedelta(
+        seconds=hub_config.PRESENCE_ONLINE_TIMEOUT_SECONDS
+    )
+
+
+async def _ensure_row(
+    db: AsyncSession,
+    model,
+    agent_id: str,
+    insert_values: dict,
+):
+    """Race-safe upsert-then-lock pattern.
+
+    On Postgres: ``INSERT ... ON CONFLICT DO NOTHING`` then ``SELECT ... FOR
+    UPDATE``. Concurrent first-create attempts converge: only one INSERT
+    wins; both observers see the row under a row lock for the subsequent
+    update.
+
+    On other dialects (SQLite tests): fall back to get-or-add. The test
+    suite is single-connection so the race window doesn't apply.
+    """
+    bind = db.get_bind()
+    is_postgres = getattr(bind, "dialect", None) is not None and bind.dialect.name == "postgresql"
+
+    if is_postgres:
+        # Under READ COMMITTED, a concurrent in-flight INSERT for the same
+        # PK causes ON CONFLICT DO NOTHING to skip silently AND the follow-up
+        # SELECT FOR UPDATE will not see the uncommitted row, so a tight
+        # first-create race can yield no row. One retry covers it: the
+        # racing transaction will have committed by then.
+        stmt = (
+            pg_insert(model)
+            .values(**insert_values)
+            .on_conflict_do_nothing(index_elements=[model.agent_id])
+        )
+        for attempt in range(2):
+            await db.execute(stmt)
+            row = (
+                await db.execute(
+                    select(model).where(model.agent_id == agent_id).with_for_update()
+                )
+            ).scalar_one_or_none()
+            if row is not None:
+                return row
+        raise RuntimeError(
+            f"presence: could not ensure {model.__tablename__} row for {agent_id}"
+        )
+
+    row = await db.get(model, agent_id)
+    if row is None:
+        row = model(**insert_values)
+        db.add(row)
+        await db.flush()
+    return row
+
+
+async def _ensure_settings(
+    db: AsyncSession, agent_id: str
+) -> AgentStatusSettings:
+    return await _ensure_row(
+        db,
+        AgentStatusSettings,
+        agent_id,
+        {"agent_id": agent_id, "manual_status": "available"},
+    )
+
+
+async def _ensure_presence(
+    db: AsyncSession, agent_id: str
+) -> AgentPresence:
+    return await _ensure_row(
+        db, AgentPresence, agent_id, {"agent_id": agent_id}
+    )
+
+
+async def _count_connections(
+    db: AsyncSession, agent_id: str, *, now: datetime.datetime
+) -> int:
+    cutoff = _online_cutoff(now)
+    rows = await db.execute(
+        select(AgentPresenceConnection.connection_id).where(
+            AgentPresenceConnection.agent_id == agent_id,
+            AgentPresenceConnection.last_seen_at >= cutoff,
+        )
+    )
+    return len(rows.scalars().all())
+
+
+def _expire_manual_if_needed(
+    settings: AgentStatusSettings, now: datetime.datetime
+) -> None:
+    """In-place: if manual_expires_at has passed, reset to ``available``."""
+    if (
+        settings.manual_expires_at is not None
+        and settings.manual_expires_at <= now
+    ):
+        settings.manual_status = "available"
+        settings.status_message = None
+        settings.manual_expires_at = None
+
+
+def _expire_processing_if_needed(
+    activity: dict, now: datetime.datetime
+) -> dict:
+    """Return a copy of ``activity`` with ``processing`` cleared if expired."""
+    a = dict(activity)
+    expires_at = a.get("processing_expires_at")
+    if expires_at and a.get("processing"):
+        try:
+            ts = datetime.datetime.fromisoformat(str(expires_at))
+        except (TypeError, ValueError):
+            ts = None
+        if ts and ts <= now:
+            a["processing"] = False
+            a.pop("processing_expires_at", None)
+    return a
+
+
+async def _recompute_and_persist(
+    db: AsyncSession,
+    agent_id: str,
+    *,
+    now: datetime.datetime,
+    activity_override: dict | None = None,
+    attributes_override: dict | None = None,
+) -> tuple[AgentPresenceSnapshot, bool]:
+    """Recompute effective_status, persist, and return (snapshot, changed).
+
+    ``changed`` is True when version was bumped (effective_status, connected,
+    or one of activity/attributes changed). Callers can use this to skip
+    realtime broadcasts on no-op updates.
+    """
+    settings = await _ensure_settings(db, agent_id)
+    presence = await _ensure_presence(db, agent_id)
+
+    _expire_manual_if_needed(settings, now)
+
+    activity = activity_override if activity_override is not None else dict(presence.activity_json or {})
+    activity = _expire_processing_if_needed(activity, now)
+    attributes = (
+        attributes_override
+        if attributes_override is not None
+        else dict(presence.attributes_json or {})
+    )
+
+    connection_count = await _count_connections(db, agent_id, now=now)
+    connected = connection_count > 0
+
+    new_status = resolve_effective_status(
+        manual_status=settings.manual_status,
+        connected=connected,
+        activity=activity,
+    )
+
+    changed = (
+        presence.effective_status != new_status
+        or presence.connected != connected
+        or presence.connection_count != connection_count
+        or dict(presence.activity_json or {}) != activity
+        or dict(presence.attributes_json or {}) != attributes
+    )
+
+    presence.effective_status = new_status
+    presence.connected = connected
+    presence.connection_count = connection_count
+    presence.activity_json = activity
+    presence.attributes_json = attributes
+    presence.updated_at = now
+    if changed:
+        presence.version = (presence.version or 0) + 1
+        if connected:
+            presence.last_seen_at = now
+
+    await db.flush()
+    snapshot = _to_snapshot(presence, settings)
+    return snapshot, changed
+
+
+def _to_snapshot(
+    presence: AgentPresence, settings: AgentStatusSettings
+) -> AgentPresenceSnapshot:
+    return AgentPresenceSnapshot(
+        agent_id=presence.agent_id,
+        effective_status=presence.effective_status,
+        connected=presence.connected,
+        connection_count=presence.connection_count,
+        version=presence.version or 0,
+        last_seen_at=presence.last_seen_at,
+        activity=dict(presence.activity_json or {}),
+        attributes=dict(presence.attributes_json or {}),
+        manual_status=settings.manual_status,
+        status_message=settings.status_message,
+        manual_expires_at=settings.manual_expires_at,
+        updated_at=presence.updated_at,
+    )
+
+
+async def _upsert_connection(
+    db: AsyncSession,
+    *,
+    connection_id: str,
+    agent_id: str,
+    node_id: str,
+    now: datetime.datetime,
+) -> None:
+    """Insert or refresh ``last_seen_at`` for this connection lease.
+
+    Uses Postgres-style ON CONFLICT in production. For the SQLite test
+    backend we fall back to a manual upsert path.
+    """
+    try:
+        stmt = (
+            pg_insert(AgentPresenceConnection)
+            .values(
+                connection_id=connection_id,
+                agent_id=agent_id,
+                node_id=node_id,
+                last_seen_at=now,
+                created_at=now,
+            )
+            .on_conflict_do_update(
+                index_elements=[AgentPresenceConnection.connection_id],
+                set_={"last_seen_at": now, "node_id": node_id},
+            )
+        )
+        await db.execute(stmt)
+        return
+    except (CompileError, NotImplementedError):
+        pass
+
+    existing = await db.get(AgentPresenceConnection, connection_id)
+    if existing is None:
+        db.add(
+            AgentPresenceConnection(
+                connection_id=connection_id,
+                agent_id=agent_id,
+                node_id=node_id,
+                last_seen_at=now,
+                created_at=now,
+            )
+        )
+    else:
+        existing.last_seen_at = now
+        existing.node_id = node_id
+    await db.flush()
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def mark_connected(
+    db: AsyncSession,
+    agent_id: str,
+    connection_id: str,
+    *,
+    node_id: str | None = None,
+    now: datetime.datetime | None = None,
+) -> tuple[AgentPresenceSnapshot, bool]:
+    """Register a new agent WS connection and recompute presence."""
+    moment = _now(now)
+    await _upsert_connection(
+        db,
+        connection_id=connection_id,
+        agent_id=agent_id,
+        node_id=(node_id or hub_config.PRESENCE_NODE_ID),
+        now=moment,
+    )
+    return await _recompute_and_persist(db, agent_id, now=moment)
+
+
+async def mark_heartbeat(
+    db: AsyncSession,
+    agent_id: str,
+    connection_id: str,
+    *,
+    node_id: str | None = None,
+    now: datetime.datetime | None = None,
+) -> tuple[AgentPresenceSnapshot, bool]:
+    """Refresh ``last_seen_at`` for a known connection."""
+    moment = _now(now)
+    await _upsert_connection(
+        db,
+        connection_id=connection_id,
+        agent_id=agent_id,
+        node_id=(node_id or hub_config.PRESENCE_NODE_ID),
+        now=moment,
+    )
+    return await _recompute_and_persist(db, agent_id, now=moment)
+
+
+async def mark_disconnected(
+    db: AsyncSession,
+    agent_id: str,
+    connection_id: str,
+    *,
+    now: datetime.datetime | None = None,
+) -> tuple[AgentPresenceSnapshot, bool]:
+    """Drop a single connection lease and recompute presence."""
+    moment = _now(now)
+    await db.execute(
+        delete(AgentPresenceConnection).where(
+            AgentPresenceConnection.connection_id == connection_id
+        )
+    )
+    return await _recompute_and_persist(db, agent_id, now=moment)
+
+
+async def set_manual_status(
+    db: AsyncSession,
+    agent_id: str,
+    manual_status: str,
+    *,
+    status_message: str | None = None,
+    manual_expires_at: datetime.datetime | None = None,
+    updated_by_type: str | None = None,
+    updated_by_id: str | None = None,
+    now: datetime.datetime | None = None,
+) -> tuple[AgentPresenceSnapshot, bool]:
+    if manual_status not in MANUAL_STATUSES:
+        raise ValueError(f"invalid manual_status: {manual_status!r}")
+    moment = _now(now)
+    settings = await _ensure_settings(db, agent_id)
+    settings.manual_status = manual_status
+    settings.status_message = status_message
+    settings.manual_expires_at = manual_expires_at
+    settings.updated_by_type = updated_by_type
+    settings.updated_by_id = updated_by_id
+    settings.updated_at = moment
+    await db.flush()
+    return await _recompute_and_persist(db, agent_id, now=moment)
+
+
+async def set_processing(
+    db: AsyncSession,
+    agent_id: str,
+    processing: bool,
+    *,
+    current_task: str | None = None,
+    expires_at: datetime.datetime | None = None,
+    now: datetime.datetime | None = None,
+) -> tuple[AgentPresenceSnapshot, bool]:
+    moment = _now(now)
+    presence = await _ensure_presence(db, agent_id)
+    activity = dict(presence.activity_json or {})
+    attributes = dict(presence.attributes_json or {})
+
+    activity["processing"] = bool(processing)
+    if processing:
+        if expires_at is None:
+            expires_at = moment + datetime.timedelta(
+                seconds=hub_config.PRESENCE_PROCESSING_FAILSAFE_TIMEOUT_SECONDS
+            )
+        activity["processing_expires_at"] = expires_at.isoformat()
+        if current_task is not None:
+            attributes["current_task"] = current_task
+    else:
+        activity.pop("processing_expires_at", None)
+        attributes.pop("current_task", None)
+
+    return await _recompute_and_persist(
+        db,
+        agent_id,
+        now=moment,
+        activity_override=activity,
+        attributes_override=attributes,
+    )
+
+
+async def set_typing(
+    db: AsyncSession,
+    agent_id: str,
+    typing: bool,
+    *,
+    expires_at: datetime.datetime | None = None,
+    now: datetime.datetime | None = None,
+) -> tuple[AgentPresenceSnapshot, bool]:
+    moment = _now(now)
+    presence = await _ensure_presence(db, agent_id)
+    activity = dict(presence.activity_json or {})
+    activity["typing"] = bool(typing)
+    if typing:
+        if expires_at is None:
+            expires_at = moment + datetime.timedelta(
+                seconds=hub_config.PRESENCE_TYPING_TIMEOUT_SECONDS
+            )
+        activity["typing_expires_at"] = expires_at.isoformat()
+    else:
+        activity.pop("typing_expires_at", None)
+    return await _recompute_and_persist(
+        db, agent_id, now=moment, activity_override=activity
+    )
+
+
+_DEFAULT_SETTINGS_TUPLE = ("available", None, None)
+
+
+async def get_snapshots(
+    db: AsyncSession,
+    agent_ids: Iterable[str],
+) -> list[AgentPresenceSnapshot]:
+    ids = [a for a in dict.fromkeys(agent_ids) if a]
+    if not ids:
+        return []
+    presence_rows = (
+        await db.execute(select(AgentPresence).where(AgentPresence.agent_id.in_(ids)))
+    ).scalars().all()
+    settings_rows = (
+        await db.execute(
+            select(
+                AgentStatusSettings.agent_id,
+                AgentStatusSettings.manual_status,
+                AgentStatusSettings.status_message,
+                AgentStatusSettings.manual_expires_at,
+            ).where(AgentStatusSettings.agent_id.in_(ids))
+        )
+    ).all()
+    settings_by_id = {row[0]: (row[1], row[2], row[3]) for row in settings_rows}
+    out: list[AgentPresenceSnapshot] = []
+    for presence in presence_rows:
+        manual_status, status_message, manual_expires_at = settings_by_id.get(
+            presence.agent_id, _DEFAULT_SETTINGS_TUPLE
+        )
+        out.append(
+            AgentPresenceSnapshot(
+                agent_id=presence.agent_id,
+                effective_status=presence.effective_status,
+                connected=presence.connected,
+                connection_count=presence.connection_count,
+                version=presence.version or 0,
+                last_seen_at=presence.last_seen_at,
+                activity=dict(presence.activity_json or {}),
+                attributes=dict(presence.attributes_json or {}),
+                manual_status=manual_status,
+                status_message=status_message,
+                manual_expires_at=manual_expires_at,
+                updated_at=presence.updated_at,
+            )
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+
+def emit_processing_signal_async(
+    agent_id: str,
+    processing: bool,
+    *,
+    current_task: str | None = None,
+) -> None:
+    """Fire-and-forget helper for callers that don't have a DB session handy.
+
+    Schedules a background task that opens its own session, calls
+    ``set_processing``, and broadcasts on change. Failures are logged but
+    never raised — presence updates must never break the message path.
+    """
+    import asyncio
+
+    from hub.database import async_session
+
+    async def _run():
+        try:
+            async with async_session() as db:
+                snapshot, changed = await set_processing(
+                    db, agent_id, processing, current_task=current_task
+                )
+                await db.commit()
+            if changed:
+                from hub.routers.hub import broadcast_status_changed
+
+                asyncio.create_task(broadcast_status_changed(snapshot))
+        except Exception as exc:
+            logger.warning(
+                "emit_processing_signal_async failed agent=%s err=%s",
+                agent_id, exc,
+            )
+
+    try:
+        asyncio.create_task(_run())
+    except RuntimeError:
+        # No running event loop — running outside async context.
+        pass
+
+
+async def cleanup_stale(
+    db: AsyncSession,
+    *,
+    now: datetime.datetime | None = None,
+) -> list[AgentPresenceSnapshot]:
+    """Drop expired connection leases + recompute affected agents.
+
+    Returns snapshots whose effective_status changed (callers should
+    broadcast each one).
+    """
+    moment = _now(now)
+    cutoff = _online_cutoff(moment)
+
+    stale_rows = (
+        await db.execute(
+            select(AgentPresenceConnection.agent_id)
+            .where(AgentPresenceConnection.last_seen_at < cutoff)
+        )
+    ).scalars().all()
+
+    affected_agent_ids: set[str] = set(stale_rows)
+    if stale_rows:
+        await db.execute(
+            delete(AgentPresenceConnection).where(
+                AgentPresenceConnection.last_seen_at < cutoff
+            )
+        )
+
+    # Catch presence rows that still claim ``connected=True`` but no live
+    # connection lease exists (covers Hub restarts that left orphan rows).
+    orphan_rows = (
+        await db.execute(
+            select(AgentPresence.agent_id).where(
+                AgentPresence.connected == True,  # noqa: E712
+                ~select(AgentPresenceConnection.connection_id)
+                .where(
+                    AgentPresenceConnection.agent_id == AgentPresence.agent_id,
+                    AgentPresenceConnection.last_seen_at >= cutoff,
+                )
+                .exists(),
+            )
+        )
+    ).scalars().all()
+    affected_agent_ids.update(orphan_rows)
+
+    changed: list[AgentPresenceSnapshot] = []
+    for agent_id in affected_agent_ids:
+        snapshot, was_changed = await _recompute_and_persist(
+            db, agent_id, now=moment
+        )
+        if was_changed:
+            changed.append(snapshot)
+    return changed

--- a/backend/migrations/036_create_agent_presence.sql
+++ b/backend/migrations/036_create_agent_presence.sql
@@ -1,0 +1,54 @@
+-- Agent Presence & Status V1 (Supabase-only).
+--
+-- Three tables:
+--   agent_status_settings        owner-driven manual status (persisted)
+--   agent_presence               composed effective status + activity/attribute projection
+--   agent_presence_connections   per-WS connection lease (multi-Hub safe)
+--
+-- See docs/agent-presence-status-v1-supabase.md for the full design.
+
+CREATE TABLE IF NOT EXISTS agent_status_settings (
+  agent_id           VARCHAR(32)  PRIMARY KEY REFERENCES agents(agent_id) ON DELETE CASCADE,
+  manual_status      VARCHAR(16)  NOT NULL DEFAULT 'available',
+  status_message     TEXT         NULL,
+  manual_expires_at  TIMESTAMPTZ  NULL,
+  updated_by_type    VARCHAR(16)  NULL,
+  updated_by_id      VARCHAR(64)  NULL,
+  updated_at         TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  CONSTRAINT ck_agent_status_settings_manual_status
+    CHECK (manual_status IN ('available', 'busy', 'away', 'invisible'))
+);
+
+CREATE TABLE IF NOT EXISTS agent_presence (
+  agent_id          VARCHAR(32)  PRIMARY KEY REFERENCES agents(agent_id) ON DELETE CASCADE,
+  effective_status  VARCHAR(16)  NOT NULL DEFAULT 'offline',
+  connected         BOOLEAN      NOT NULL DEFAULT FALSE,
+  connection_count  INTEGER      NOT NULL DEFAULT 0,
+  version           BIGINT       NOT NULL DEFAULT 0,
+  last_seen_at      TIMESTAMPTZ  NULL,
+  activity_json     JSONB        NOT NULL DEFAULT '{}'::jsonb,
+  attributes_json   JSONB        NOT NULL DEFAULT '{}'::jsonb,
+  updated_at        TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  CONSTRAINT ck_agent_presence_effective_status
+    CHECK (effective_status IN ('offline', 'online', 'busy', 'away', 'working'))
+);
+
+CREATE INDEX IF NOT EXISTS ix_agent_presence_status_updated
+  ON agent_presence (effective_status, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS ix_agent_presence_last_seen
+  ON agent_presence (last_seen_at DESC);
+
+CREATE TABLE IF NOT EXISTS agent_presence_connections (
+  connection_id  VARCHAR(64)  PRIMARY KEY,
+  agent_id       VARCHAR(32)  NOT NULL REFERENCES agents(agent_id) ON DELETE CASCADE,
+  node_id        VARCHAR(64)  NOT NULL,
+  last_seen_at   TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  created_at     TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS ix_agent_presence_connections_agent_seen
+  ON agent_presence_connections (agent_id, last_seen_at DESC);
+
+CREATE INDEX IF NOT EXISTS ix_agent_presence_connections_node
+  ON agent_presence_connections (node_id, last_seen_at DESC);

--- a/backend/tests/test_presence_service.py
+++ b/backend/tests/test_presence_service.py
@@ -1,0 +1,280 @@
+"""Tests for hub.services.presence."""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from hub.models import Agent, AgentPresence, AgentPresenceConnection, AgentStatusSettings, Base
+from hub.services import presence as presence_service
+from hub.services.presence import resolve_effective_status
+
+
+TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
+
+
+# ---------------------------------------------------------------------------
+# Pure resolver
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_invisible_overrides_everything():
+    assert (
+        resolve_effective_status(
+            manual_status="invisible", connected=True, activity={"processing": True}
+        )
+        == "offline"
+    )
+
+
+def test_resolver_disconnected_is_offline():
+    assert (
+        resolve_effective_status(
+            manual_status="available", connected=False, activity={}
+        )
+        == "offline"
+    )
+
+
+def test_resolver_processing_beats_busy():
+    assert (
+        resolve_effective_status(
+            manual_status="busy", connected=True, activity={"processing": True}
+        )
+        == "working"
+    )
+
+
+def test_resolver_busy_when_no_processing():
+    assert (
+        resolve_effective_status(
+            manual_status="busy", connected=True, activity={}
+        )
+        == "busy"
+    )
+
+
+def test_resolver_idle_maps_to_away():
+    assert (
+        resolve_effective_status(
+            manual_status="available", connected=True, activity={"idle": True}
+        )
+        == "away"
+    )
+
+
+def test_resolver_manual_away_maps_to_away():
+    assert (
+        resolve_effective_status(
+            manual_status="away", connected=True, activity={}
+        )
+        == "away"
+    )
+
+
+def test_resolver_default_online():
+    assert (
+        resolve_effective_status(
+            manual_status="available", connected=True, activity={}
+        )
+        == "online"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Service-level fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(TEST_DB_URL)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        # Seed an agent so the FK on agent_presence_connections / agent_presence
+        # is satisfied.
+        session.add(Agent(agent_id="ag_test", display_name="Test"))
+        await session.commit()
+        yield session
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Connection lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mark_connected_sets_online(db_session: AsyncSession):
+    snapshot, changed = await presence_service.mark_connected(
+        db_session, "ag_test", "conn_1"
+    )
+    assert snapshot.effective_status == "online"
+    assert snapshot.connected is True
+    assert snapshot.connection_count == 1
+    assert snapshot.version == 1
+    assert changed is True
+
+
+@pytest.mark.asyncio
+async def test_mark_disconnected_returns_offline(db_session: AsyncSession):
+    await presence_service.mark_connected(db_session, "ag_test", "conn_1")
+    snapshot, _ = await presence_service.mark_disconnected(
+        db_session, "ag_test", "conn_1"
+    )
+    assert snapshot.effective_status == "offline"
+    assert snapshot.connected is False
+    assert snapshot.connection_count == 0
+    assert snapshot.version == 2
+
+
+@pytest.mark.asyncio
+async def test_multiple_connections_keep_online(db_session: AsyncSession):
+    await presence_service.mark_connected(db_session, "ag_test", "conn_1")
+    await presence_service.mark_connected(db_session, "ag_test", "conn_2")
+    snapshot, _ = await presence_service.mark_disconnected(
+        db_session, "ag_test", "conn_1"
+    )
+    assert snapshot.connected is True
+    assert snapshot.connection_count == 1
+    assert snapshot.effective_status == "online"
+
+
+# ---------------------------------------------------------------------------
+# Manual status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_manual_busy_updates_status(db_session: AsyncSession):
+    await presence_service.mark_connected(db_session, "ag_test", "conn_1")
+    snapshot, _ = await presence_service.set_manual_status(
+        db_session, "ag_test", "busy", status_message="In a meeting"
+    )
+    assert snapshot.effective_status == "busy"
+    assert snapshot.manual_status == "busy"
+    assert snapshot.status_message == "In a meeting"
+
+
+@pytest.mark.asyncio
+async def test_invisible_hides_online(db_session: AsyncSession):
+    await presence_service.mark_connected(db_session, "ag_test", "conn_1")
+    snapshot, _ = await presence_service.set_manual_status(
+        db_session, "ag_test", "invisible"
+    )
+    assert snapshot.effective_status == "offline"
+    assert snapshot.connected is True
+
+
+@pytest.mark.asyncio
+async def test_set_manual_invalid_raises(db_session: AsyncSession):
+    with pytest.raises(ValueError):
+        await presence_service.set_manual_status(
+            db_session, "ag_test", "bogus"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Processing signal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_processing_true_marks_working(db_session: AsyncSession):
+    await presence_service.mark_connected(db_session, "ag_test", "conn_1")
+    snapshot, _ = await presence_service.set_processing(
+        db_session, "ag_test", True, current_task="replying"
+    )
+    assert snapshot.effective_status == "working"
+    assert snapshot.activity["processing"] is True
+    assert snapshot.attributes["current_task"] == "replying"
+
+
+@pytest.mark.asyncio
+async def test_set_processing_false_clears(db_session: AsyncSession):
+    await presence_service.mark_connected(db_session, "ag_test", "conn_1")
+    await presence_service.set_processing(
+        db_session, "ag_test", True, current_task="replying"
+    )
+    snapshot, _ = await presence_service.set_processing(
+        db_session, "ag_test", False
+    )
+    assert snapshot.effective_status == "online"
+    assert snapshot.activity.get("processing") is False
+    assert "current_task" not in snapshot.attributes
+
+
+# ---------------------------------------------------------------------------
+# Snapshots and observer projection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_snapshots_for_unknown_agent_is_empty(db_session: AsyncSession):
+    out = await presence_service.get_snapshots(db_session, ["ag_missing"])
+    assert out == []
+
+
+@pytest.mark.asyncio
+async def test_get_snapshots_returns_connected(db_session: AsyncSession):
+    await presence_service.mark_connected(db_session, "ag_test", "conn_1")
+    out = await presence_service.get_snapshots(db_session, ["ag_test"])
+    assert len(out) == 1
+    assert out[0].agent_id == "ag_test"
+    assert out[0].effective_status == "online"
+
+
+@pytest.mark.asyncio
+async def test_invisible_observer_view_hides_status(db_session: AsyncSession):
+    await presence_service.mark_connected(db_session, "ag_test", "conn_1")
+    snapshot, _ = await presence_service.set_manual_status(
+        db_session, "ag_test", "invisible"
+    )
+    observer = snapshot.for_observer(is_owner=False)
+    assert observer["effective_status"] == "offline"
+    assert observer["manual_status"] == "available"
+    owner = snapshot.for_observer(is_owner=True)
+    assert owner["manual_status"] == "invisible"
+
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cleanup_drops_stale_connections(
+    db_session: AsyncSession, monkeypatch
+):
+    # Force online_timeout to 1 second for the test
+    from hub import config as hub_config
+
+    monkeypatch.setattr(hub_config, "PRESENCE_ONLINE_TIMEOUT_SECONDS", 1.0)
+
+    past = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+        seconds=120
+    )
+    await presence_service.mark_connected(
+        db_session, "ag_test", "conn_old", now=past
+    )
+    # Force last_seen back into the past after _recompute_and_persist set it.
+    await db_session.execute(
+        AgentPresenceConnection.__table__.update()
+        .where(AgentPresenceConnection.connection_id == "conn_old")
+        .values(last_seen_at=past)
+    )
+    await db_session.flush()
+
+    changed = await presence_service.cleanup_stale(db_session)
+    assert any(s.agent_id == "ag_test" for s in changed)
+
+    snap = (await presence_service.get_snapshots(db_session, ["ag_test"]))[0]
+    assert snap.connected is False
+    assert snap.effective_status == "offline"

--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -537,13 +537,11 @@ export default function DashboardApp() {
             roomId: realtimeEvent.room_id,
             hubMsgId: realtimeEvent.hub_msg_id,
           });
-          if (realtimeEvent.type === "presence") {
-            const ext = realtimeEvent.ext || {};
-            const subject = typeof ext.subject_agent_id === "string" ? ext.subject_agent_id : null;
-            const online = Boolean(ext.online);
-            if (subject) {
-              const ts = realtimeEvent.created_at ? new Date(realtimeEvent.created_at).getTime() : Date.now();
-              usePresenceStore.getState().setOnline(subject, online, Number.isFinite(ts) ? ts : Date.now());
+          if (realtimeEvent.type === "agent_status_changed") {
+            const ext = (realtimeEvent.ext || {}) as Record<string, unknown>;
+            const status = ext.status as Record<string, unknown> | undefined;
+            if (status && typeof status.agent_id === "string") {
+              usePresenceStore.getState().upsertStatus(status as never);
             }
             return;
           }
@@ -563,6 +561,17 @@ export default function DashboardApp() {
           });
           if (status === "SUBSCRIBED") {
             realtimeStore.setRealtimeStatus("connected");
+            // Refresh presence snapshots for any agents we're already tracking,
+            // so we recover from events missed during the disconnect window.
+            try {
+              const tracked = Object.keys(usePresenceStore.getState().entries);
+              if (tracked.length > 0) {
+                void api
+                  .getPresenceSnapshots(tracked)
+                  .then((res) => usePresenceStore.getState().upsertMany(res.agents))
+                  .catch(() => {});
+              }
+            } catch {}
             return;
           }
           if (status === "CHANNEL_ERROR" || status === "TIMED_OUT" || status === "CLOSED") {
@@ -596,6 +605,21 @@ export default function DashboardApp() {
     realtimeStore.syncRealtimeEvent,
     supabase,
   ]);
+
+  useEffect(() => {
+    if (!sessionStore.authResolved) return;
+    const onVisible = () => {
+      if (document.visibilityState !== "visible") return;
+      const tracked = Object.keys(usePresenceStore.getState().entries);
+      if (tracked.length === 0) return;
+      void api
+        .getPresenceSnapshots(tracked)
+        .then((res) => usePresenceStore.getState().upsertMany(res.agents))
+        .catch(() => {});
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
+  }, [sessionStore.authResolved]);
 
   useEffect(() => {
     if (!sessionStore.authResolved || !sessionStore.token || uiStore.sidebarTab !== "messages") {

--- a/frontend/src/components/dashboard/PresenceDot.tsx
+++ b/frontend/src/components/dashboard/PresenceDot.tsx
@@ -1,6 +1,6 @@
 /**
- * [INPUT]: 依赖 usePresenceStore 读取 agent 在线状态
- * [OUTPUT]: 对外提供 <PresenceDot />，在任意渲染 agent 的位置展示在线/离线小圆点
+ * [INPUT]: 依赖 usePresenceStore 读取 agent 富状态
+ * [OUTPUT]: 对外提供 <PresenceDot />，按 effectiveStatus 渲染不同颜色 (offline/online/busy/away/working)
  * [POS]: frontend dashboard 通用出席状态指示器，独立于具体业务列表
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
@@ -8,7 +8,10 @@
 "use client";
 
 import clsx from "clsx";
-import { usePresence } from "@/store/usePresenceStore";
+import {
+  AgentEffectiveStatus,
+  usePresenceStatus,
+} from "@/store/usePresenceStore";
 
 interface PresenceDotProps {
   agentId: string | null | undefined;
@@ -25,6 +28,22 @@ const SIZE_MAP = {
   md: "h-2.5 w-2.5",
 } as const;
 
+const COLOR_MAP: Record<AgentEffectiveStatus, string> = {
+  offline: "bg-white/25",
+  online: "bg-emerald-400 shadow-[0_0_6px_rgba(16,185,129,0.8)]",
+  busy: "bg-rose-400 shadow-[0_0_6px_rgba(244,63,94,0.7)]",
+  away: "bg-amber-400 shadow-[0_0_6px_rgba(245,158,11,0.7)]",
+  working: "bg-sky-400 shadow-[0_0_6px_rgba(56,189,248,0.8)] animate-pulse",
+};
+
+const LABEL_MAP: Record<AgentEffectiveStatus, string> = {
+  offline: "离线",
+  online: "在线",
+  busy: "忙碌",
+  away: "暂离",
+  working: "工作中",
+};
+
 export function PresenceDot({
   agentId,
   size = "sm",
@@ -33,21 +52,23 @@ export function PresenceDot({
   showOffline = true,
   title,
 }: PresenceDotProps) {
-  const liveOnline = usePresence(agentId);
-  const online = liveOnline || Boolean(fallback);
+  const entry = usePresenceStatus(agentId);
+  const status: AgentEffectiveStatus = entry
+    ? entry.effectiveStatus
+    : fallback
+      ? "online"
+      : "offline";
 
-  if (!online && !showOffline) return null;
+  if (status === "offline" && !showOffline) return null;
 
   return (
     <span
-      aria-label={online ? "online" : "offline"}
-      title={title ?? (online ? "在线" : "离线")}
+      aria-label={status}
+      title={title ?? LABEL_MAP[status]}
       className={clsx(
         "inline-block rounded-full ring-1 ring-[#0a0a0f]",
         SIZE_MAP[size],
-        online
-          ? "bg-emerald-400 shadow-[0_0_6px_rgba(16,185,129,0.8)]"
-          : "bg-white/25",
+        COLOR_MAP[status],
         className,
       )}
     />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -78,6 +78,7 @@ import type {
 } from "./types";
 
 import { createClient } from "@/lib/supabase/client";
+import type { AgentPresenceSnapshotPayload } from "@/store/usePresenceStore";
 
 /**
  * [INPUT]: Supabase client-side SDK for auth tokens, browser fetch, local active-agent state
@@ -473,6 +474,29 @@ export const api = {
 
   getPlatformStats() {
     return apiGet<PlatformStats>("/api/stats");
+  },
+
+  // --- Presence ---
+
+  getPresenceSnapshots(agentIds: string[]) {
+    return apiPost<{ agents: AgentPresenceSnapshotPayload[] }>(
+      "/api/presence/agents/snapshot",
+      { agent_ids: agentIds },
+    );
+  },
+
+  setManualStatus(
+    agentId: string,
+    body: {
+      manual_status: "available" | "busy" | "away" | "invisible";
+      status_message?: string | null;
+      manual_expires_at?: string | null;
+    },
+  ) {
+    return apiPatch<AgentPresenceSnapshotPayload>(
+      `/api/agents/${agentId}/status`,
+      body,
+    );
   },
 
   // --- Public (guest) APIs ---

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -340,7 +340,7 @@ export type RealtimeMetaEventType =
   | "error"
   | "system"
   | "typing"
-  | "presence";
+  | "agent_status_changed";
 
 export interface RealtimeMetaEvent {
   type: RealtimeMetaEventType;

--- a/frontend/src/store/useDashboardSessionStore.ts
+++ b/frontend/src/store/useDashboardSessionStore.ts
@@ -366,6 +366,7 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
     authInitRequestId += 1;
     setActiveAgentId(null);
     setStoredActiveIdentity(null);
+    usePresenceStore.getState().reset();
     set({
       ...initialSessionState,
       authResolved: true,

--- a/frontend/src/store/usePresenceStore.ts
+++ b/frontend/src/store/usePresenceStore.ts
@@ -1,55 +1,155 @@
 /**
- * [INPUT]: 依赖 zustand 保存 agent 在线状态的本地缓存，从列表接口或 realtime 事件种子化
- * [OUTPUT]: 对外提供 usePresenceStore 与 usePresence hook，给 UI 读取任意 agent 的 online/offline
- * [POS]: frontend dashboard 的出席状态汇总层，只存 agentId -> {online, updatedAt}，不直接发请求
+ * [INPUT]: 依赖 zustand 保存 agent 状态对象的本地缓存，从 /api/presence/agents snapshot 与 realtime agent_status_changed 事件种子化
+ * [OUTPUT]: 对外提供 usePresenceStore + usePresence (online?) + usePresenceStatus (full entry) hook
+ * [POS]: frontend dashboard 出席状态汇总层，存 agentId -> AgentPresenceEntry，按 version 去重乱序
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
 
 import { create } from "zustand";
 import { useMemo } from "react";
 
-interface PresenceEntry {
-  online: boolean;
+export type AgentEffectiveStatus =
+  | "offline"
+  | "online"
+  | "busy"
+  | "away"
+  | "working";
+
+export interface AgentPresenceEntry {
+  agentId: string;
+  version: number;
+  effectiveStatus: AgentEffectiveStatus;
+  connected: boolean;
+  manualStatus?: string | null;
+  statusMessage?: string | null;
+  activity: Record<string, unknown>;
+  attributes: Record<string, unknown>;
   updatedAt: number;
 }
 
+export interface AgentPresenceSnapshotPayload {
+  agent_id: string;
+  version?: number;
+  effective_status?: AgentEffectiveStatus;
+  connected?: boolean;
+  manual_status?: string | null;
+  status_message?: string | null;
+  activity?: Record<string, unknown>;
+  attributes?: Record<string, unknown>;
+  updated_at?: string;
+}
+
 interface PresenceState {
-  entries: Record<string, PresenceEntry>;
+  entries: Record<string, AgentPresenceEntry>;
+  upsertStatus: (snapshot: AgentPresenceSnapshotPayload) => void;
+  upsertMany: (snapshots: AgentPresenceSnapshotPayload[]) => void;
+  // Legacy boolean seeders — kept until REST APIs stop returning online/ws_online.
   setOnline: (agentId: string, online: boolean, updatedAt?: number) => void;
   seed: (seeds: Array<{ agentId: string; online: boolean }>) => void;
   reset: () => void;
 }
 
+function snapshotToEntry(s: AgentPresenceSnapshotPayload): AgentPresenceEntry {
+  const updatedAt = s.updated_at ? new Date(s.updated_at).getTime() : Date.now();
+  return {
+    agentId: s.agent_id,
+    version: s.version ?? 0,
+    effectiveStatus: (s.effective_status ?? "offline") as AgentEffectiveStatus,
+    connected: Boolean(s.connected),
+    manualStatus: s.manual_status ?? null,
+    statusMessage: s.status_message ?? null,
+    activity: s.activity ?? {},
+    attributes: s.attributes ?? {},
+    updatedAt: Number.isFinite(updatedAt) ? updatedAt : Date.now(),
+  };
+}
+
+function mergeEntry(
+  prev: AgentPresenceEntry | undefined,
+  next: AgentPresenceEntry,
+): AgentPresenceEntry | null {
+  if (prev) {
+    // Out-of-order events: only accept if version is strictly higher, or if
+    // version is 0 (legacy seed) and we have nothing fresher locally.
+    if (next.version > 0 && prev.version >= next.version) return null;
+    if (next.version === 0 && prev.version > 0) return null;
+    if (
+      prev.effectiveStatus === next.effectiveStatus
+      && prev.connected === next.connected
+      && prev.version === next.version
+      && prev.manualStatus === next.manualStatus
+    ) {
+      return null;
+    }
+  }
+  return next;
+}
+
 export const usePresenceStore = create<PresenceState>()((set) => ({
   entries: {},
+
+  upsertStatus: (snapshot) =>
+    set((state) => {
+      const next = snapshotToEntry(snapshot);
+      const merged = mergeEntry(state.entries[next.agentId], next);
+      if (!merged) return state;
+      return { entries: { ...state.entries, [next.agentId]: merged } };
+    }),
+
+  upsertMany: (snapshots) =>
+    set((state) => {
+      const entries = { ...state.entries };
+      let changed = false;
+      for (const raw of snapshots) {
+        const next = snapshotToEntry(raw);
+        const merged = mergeEntry(entries[next.agentId], next);
+        if (merged) {
+          entries[next.agentId] = merged;
+          changed = true;
+        }
+      }
+      return changed ? { entries } : state;
+    }),
 
   setOnline: (agentId, online, updatedAt = Date.now()) =>
     set((state) => {
       const prev = state.entries[agentId];
-      // Ignore out-of-order events
+      // Don't clobber a richer realtime-sourced entry with a stale boolean seed.
+      if (prev && prev.version > 0) return state;
       if (prev && prev.updatedAt > updatedAt) return state;
-      if (prev && prev.online === online && prev.updatedAt >= updatedAt) return state;
-      return {
-        entries: {
-          ...state.entries,
-          [agentId]: { online, updatedAt },
-        },
+      const entry: AgentPresenceEntry = {
+        agentId,
+        version: 0,
+        effectiveStatus: online ? "online" : "offline",
+        connected: online,
+        manualStatus: null,
+        statusMessage: null,
+        activity: {},
+        attributes: {},
+        updatedAt,
       };
+      return { entries: { ...state.entries, [agentId]: entry } };
     }),
 
   seed: (seeds) =>
     set((state) => {
       const now = Date.now();
-      let changed = false;
       const next = { ...state.entries };
+      let changed = false;
       for (const { agentId, online } of seeds) {
-        const prev = next[agentId];
-        // Snapshot only seeds if we have nothing yet, so we don't overwrite
-        // fresher realtime-sourced state.
-        if (!prev) {
-          next[agentId] = { online, updatedAt: now };
-          changed = true;
-        }
+        if (next[agentId]) continue; // don't overwrite richer entries
+        next[agentId] = {
+          agentId,
+          version: 0,
+          effectiveStatus: online ? "online" : "offline",
+          connected: online,
+          manualStatus: null,
+          statusMessage: null,
+          activity: {},
+          attributes: {},
+          updatedAt: now,
+        };
+        changed = true;
       }
       return changed ? { entries: next } : state;
     }),
@@ -58,8 +158,18 @@ export const usePresenceStore = create<PresenceState>()((set) => ({
 }));
 
 export function usePresence(agentId: string | null | undefined): boolean {
+  return usePresenceStore((state) => {
+    if (!agentId) return false;
+    const entry = state.entries[agentId];
+    return Boolean(entry && entry.effectiveStatus !== "offline");
+  });
+}
+
+export function usePresenceStatus(
+  agentId: string | null | undefined,
+): AgentPresenceEntry | undefined {
   return usePresenceStore((state) =>
-    agentId ? Boolean(state.entries[agentId]?.online) : false,
+    agentId ? state.entries[agentId] : undefined,
   );
 }
 
@@ -67,7 +177,10 @@ export function usePresenceMap(agentIds: string[]): Record<string, boolean> {
   const entries = usePresenceStore((state) => state.entries);
   return useMemo(() => {
     const out: Record<string, boolean> = {};
-    for (const id of agentIds) out[id] = Boolean(entries[id]?.online);
+    for (const id of agentIds) {
+      const entry = entries[id];
+      out[id] = Boolean(entry && entry.effectiveStatus !== "offline");
+    }
     return out;
   }, [entries, agentIds]);
 }


### PR DESCRIPTION
## Summary
- Implements [docs/agent-presence-status-v1-supabase.md](../blob/feat/agent-presence-v1/docs/agent-presence-status-v1-supabase.md): unified `effective_status` (offline/online/busy/away/working) replacing the old boolean presence.
- Postgres-backed (no Redis): `agent_presence` + `agent_status_settings` + `agent_presence_connections` (multi-Hub safe lease). Versioned projection broadcast via Supabase Realtime as `agent_status_changed`.
- Direct cutover from legacy `presence` event — no double-emit window. REST `online`/`ws_online` retained as legacy seeds; frontend store auto-upgrades on first realtime event.

## What's in
**Backend**
- Migration `036_create_agent_presence.sql` + SQLAlchemy models
- `hub/services/presence.py` — race-safe upsert (`INSERT ON CONFLICT DO NOTHING` + `SELECT FOR UPDATE`), version-monotonic recompute, pure resolver
- `/hub/ws` integration (15s heartbeat, 2-miss timeout, lease lifecycle)
- `GET/POST /api/presence/agents` snapshot APIs + `PATCH /api/agents/{id}/status` (owner-only); observer projection hides `invisible` from non-owners
- 30s cleanup loop with PG advisory lock in a dedicated session
- Narrow `processing` signal: DM-to-agent → working, agent outbound msg → clear; failsafe timeout caps stale state

**Frontend**
- `usePresenceStore` upgraded to versioned status object with monotonic upsert; legacy boolean seed path preserved
- `PresenceDot` renders 5 colors (working pulses); status reset on logout
- `DashboardApp` handles `agent_status_changed` + refetches snapshots on Realtime `SUBSCRIBED` and `visibilitychange`

## Test plan
- [x] `uv run pytest tests/` — 989 passed (incl. 19 new presence service tests)
- [x] `pnpm test` — 41 passed
- [x] `pnpm build` — clean
- [ ] Manual: open dashboard with two browser sessions for owner + contact; verify DM triggers `working`, outbound message reverts to `online`
- [ ] Manual: agent plugin disconnects (kill process); within ~30–45s the dashboard should flip to `offline`
- [ ] Manual: owner sets `manual_status=invisible`; non-owner contact sees `offline`, owner still sees their own state
- [ ] Manual: Realtime channel disconnect → reconnect; verify presence snapshot is refetched and stale state corrected

## Notes
- Single PR per request; covers all 10 steps in the design doc.
- 11 legacy `is_agent_ws_online` REST callsites left untouched — frontend's versioned store upgrades them automatically. Follow-up PR can swap them to `agent_presence.connected`.
- After merge, set `PRESENCE_NODE_ID` env per Hub replica if running multi-instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)