### PR TITLE
fix(daemon): include stderr tail in ACP runtime error text

### DIFF
--- a/packages/daemon/src/gateway/runtimes/acp-stream.ts
+++ b/packages/daemon/src/gateway/runtimes/acp-stream.ts
@@ -478,7 +478,12 @@ export abstract class AcpRuntimeAdapter implements RuntimeAdapter {
 
       const stopReason = promptResult?.stopReason ?? "end_turn";
       if (stopReason === "refusal" || stopReason === "error") {
-        state.errorText = state.errorText ?? `prompt stopped: ${stopReason}`;
+        const tail = stderrTail.slice(-STDERR_ERROR_SNIPPET).trim();
+        state.errorText =
+          state.errorText ??
+          (tail
+            ? `prompt stopped: ${stopReason}; stderr: ${tail}`
+            : `prompt stopped: ${stopReason}`);
       }
       // Tell the dispatcher the runtime has finished its reasoning loop —
       // important for turns that ended without an `agent_message_chunk`
@@ -499,9 +504,10 @@ export abstract class AcpRuntimeAdapter implements RuntimeAdapter {
         /* best-effort */
       }
     } catch (err) {
+      const baseMsg = err instanceof Error ? err.message : String(err);
+      const tail = stderrTail.slice(-STDERR_ERROR_SNIPPET).trim();
       state.errorText =
-        state.errorText ??
-        (err instanceof Error ? err.message : String(err));
+        state.errorText ?? (tail ? `${baseMsg}; stderr: ${tail}` : baseMsg);
       try {
         child.stdin.end();
       } catch {


### PR DESCRIPTION
## Summary
- When an ACP runtime (hermes-agent, codex, etc.) returns `stopReason: refusal|error` or throws a JSON-RPC error during `session/prompt`, the child is still alive — so the post-exit branch that appends `stderrTail` never fires.
- Daemon logs end up with opaque messages like `acp error -32603: Internal error` or `prompt stopped: refusal`, with no hint of the underlying cause. Debugging requires ssh-ing into the host and tailing the runtime's own log files.
- This patch appends the last 500 bytes of `stderrTail` to `state.errorText` in both branches in `acp-stream.ts`, so the runtime's traceback surfaces directly in daemon logs.

## Test plan
- [ ] Deploy to one EC2 daemon, trigger a hermes-agent refusal/internal error, confirm daemon log line now carries the hermes Python traceback tail.
- [ ] Confirm normal turns (no error) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)