### PR TITLE
feat: revoke daemon agents on unbind

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -33,6 +33,7 @@ from hub.models import (
     Agent,
     AgentSubscription,
     DaemonInstance,
+    OpenclawAgentCleanup,
     OpenclawHostInstance,
     Role,
     ShortCode,
@@ -356,6 +357,29 @@ async def _promote_next_default_agent(db: AsyncSession, user_id: UUID, agent_id:
         next_agent.is_default = True
 
 
+async def _enqueue_openclaw_agent_cleanup(
+    db: AsyncSession,
+    *,
+    host_id: str | None,
+    agent_id: str,
+    delete_credentials: bool = True,
+    delete_state: bool = True,
+    delete_workspace: bool = False,
+) -> bool:
+    if not host_id:
+        return False
+    db.add(
+        OpenclawAgentCleanup(
+            host_id=host_id,
+            agent_id=agent_id,
+            delete_credentials=delete_credentials,
+            delete_state=delete_state,
+            delete_workspace=delete_workspace,
+        )
+    )
+    return True
+
+
 async def _unbind_agent_from_user(db: AsyncSession, agent_id: str, user_id: UUID) -> dict:
     result = await db.execute(
         select(Agent).where(
@@ -372,14 +396,21 @@ async def _unbind_agent_from_user(db: AsyncSession, agent_id: str, user_id: UUID
 
     now = _utc_now()
     was_default = agent.is_default
+    openclaw_host_id = agent.openclaw_host_id
 
     await _cancel_agent_subscriptions(db, agent_id, now)
+    cleanup_queued = await _enqueue_openclaw_agent_cleanup(
+        db,
+        host_id=openclaw_host_id,
+        agent_id=agent_id,
+    )
 
     agent.user_id = None
     agent.claimed_at = None
     agent.is_default = False
     agent.agent_token = None
     agent.token_expires_at = None
+    agent.openclaw_host_id = None
     agent.claim_code = f"clm_{uuid4().hex}"
 
     if was_default:
@@ -387,7 +418,12 @@ async def _unbind_agent_from_user(db: AsyncSession, agent_id: str, user_id: UUID
 
     await _maybe_remove_agent_owner_role(db, user_id)
     await db.flush()
-    return {"agent_id": agent_id, "unbound_at": now.isoformat()}
+    return {
+        "agent_id": agent_id,
+        "unbound_at": now.isoformat(),
+        "openclaw_host_id": openclaw_host_id,
+        "local_cleanup_queued": cleanup_queued,
+    }
 
 
 async def _maybe_grant_claim_gift(
@@ -995,6 +1031,15 @@ async def unbind_agent_binding(
     """Unbind an active agent from the current user."""
     payload = await _unbind_agent_from_user(db, agent_id, ctx.user_id)
     await db.commit()
+    if payload.get("local_cleanup_queued") and payload.get("openclaw_host_id"):
+        from hub.routers.openclaw_control import (
+            is_openclaw_host_online,
+            process_pending_openclaw_cleanups,
+        )
+
+        host_id = str(payload["openclaw_host_id"])
+        if is_openclaw_host_online(host_id):
+            asyncio.create_task(process_pending_openclaw_cleanups(host_id))
     return payload
 
 
@@ -1008,6 +1053,15 @@ async def delete_agent(
     """Deprecated alias for unbinding an agent from the current user."""
     payload = await _unbind_agent_from_user(db, agent_id, ctx.user_id)
     await db.commit()
+    if payload.get("local_cleanup_queued") and payload.get("openclaw_host_id"):
+        from hub.routers.openclaw_control import (
+            is_openclaw_host_online,
+            process_pending_openclaw_cleanups,
+        )
+
+        host_id = str(payload["openclaw_host_id"])
+        if is_openclaw_host_online(host_id):
+            asyncio.create_task(process_pending_openclaw_cleanups(host_id))
     response.headers["Deprecation"] = "true"
     response.headers["Link"] = f'</api/users/me/agents/{agent_id}/binding>; rel="successor-version"'
     return {"ok": True, "deprecated": True, **payload}
@@ -2428,8 +2482,6 @@ async def delete_openclaw_host(
     now = _utc_now()
     if instance.revoked_at is None:
         instance.revoked_at = now
-    instance.refresh_token_hash = None
-    instance.refresh_token_expires_at = None
 
     rows = (
         await db.execute(
@@ -2451,6 +2503,11 @@ async def delete_openclaw_host(
         if agent.is_default:
             any_was_default = True
         await _cancel_agent_subscriptions(db, agent.agent_id, now)
+        await _enqueue_openclaw_agent_cleanup(
+            db,
+            host_id=host_id,
+            agent_id=agent.agent_id,
+        )
         agent.user_id = None
         agent.claimed_at = None
         agent.is_default = False
@@ -2458,6 +2515,10 @@ async def delete_openclaw_host(
         agent.token_expires_at = None
         agent.openclaw_host_id = None
         agent.claim_code = f"clm_{uuid4().hex}"
+
+    if not rows:
+        instance.refresh_token_hash = None
+        instance.refresh_token_expires_at = None
 
     # Promote a single replacement default *after* every host agent has been
     # detached, so the helper can't pick another agent that is still in
@@ -2481,6 +2542,14 @@ async def delete_openclaw_host(
         await _maybe_remove_agent_owner_role(db, ctx.user_id)
 
     await db.commit()
+
+    from hub.routers.openclaw_control import (
+        is_openclaw_host_online,
+        process_pending_openclaw_cleanups,
+    )
+
+    if is_openclaw_host_online(host_id):
+        await process_pending_openclaw_cleanups(host_id)
 
     conn = _HOST_REGISTRY.get(host_id)
     if conn is not None:
@@ -2683,4 +2752,3 @@ async def openclaw_provision(
         config_patched=bool(config_patched_raw) if config_patched_raw is not None else True,
         config_skip_reason=config_skip_reason if isinstance(config_skip_reason, str) else None,
     )
-

--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -1314,6 +1314,47 @@ class OpenclawHostInstance(Base):
     )
 
 
+class OpenclawAgentCleanup(Base):
+    """Durable best-effort local cleanup queued for an OpenClaw host."""
+
+    __tablename__ = "openclaw_agent_cleanups"
+    __table_args__ = (
+        Index("ix_openclaw_agent_cleanups_host_status", "host_id", "status"),
+        Index("ix_openclaw_agent_cleanups_agent", "agent_id"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    host_id: Mapped[str] = mapped_column(
+        String(32),
+        ForeignKey("openclaw_host_instances.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    agent_id: Mapped[str] = mapped_column(String(32), nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(16), nullable=False, default="pending", server_default="pending"
+    )
+    delete_credentials: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=sa_text("TRUE")
+    )
+    delete_state: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=sa_text("TRUE")
+    )
+    delete_workspace: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa_text("FALSE")
+    )
+    attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+    completed_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+
 class DaemonDeviceCode(Base):
     """Transient device-code rows for the daemon login flow.
 

--- a/backend/hub/routers/openclaw_control.py
+++ b/backend/hub/routers/openclaw_control.py
@@ -60,7 +60,7 @@ from hub.id_generators import (
     generate_key_id,
     generate_openclaw_host_id_from_pubkey,
 )
-from hub.models import Agent, OpenclawHostInstance, ShortCode, SigningKey
+from hub.models import Agent, OpenclawAgentCleanup, OpenclawHostInstance, ShortCode, SigningKey
 from hub.enums import KeyState
 from hub.routers.daemon_control import _build_signed_frame
 from hub.validators import parse_pubkey
@@ -88,8 +88,14 @@ def _generate_refresh_token() -> str:
     return "ort_" + secrets.token_urlsafe(48)
 
 
-def _create_host_access_token(host_instance_id: str, owner_user_id: str) -> tuple[str, int]:
-    expires_at = _now() + datetime.timedelta(seconds=OPENCLAW_ACCESS_TOKEN_EXPIRE_SECONDS)
+def _create_host_access_token(
+    host_instance_id: str,
+    owner_user_id: str,
+    *,
+    cleanup_only: bool = False,
+) -> tuple[str, int]:
+    expires_in = 600 if cleanup_only else OPENCLAW_ACCESS_TOKEN_EXPIRE_SECONDS
+    expires_at = _now() + datetime.timedelta(seconds=expires_in)
     payload = {
         "sub": host_instance_id,
         "user_id": str(owner_user_id),
@@ -98,8 +104,10 @@ def _create_host_access_token(host_instance_id: str, owner_user_id: str) -> tupl
         "exp": expires_at,
         "iss": "botcord-openclaw",
     }
+    if cleanup_only:
+        payload["cleanup_only"] = True
     token = pyjwt.encode(payload, JWT_SECRET, algorithm=JWT_ALGORITHM)
-    return token, OPENCLAW_ACCESS_TOKEN_EXPIRE_SECONDS
+    return token, expires_in
 
 
 def _verify_host_access_token(token: str) -> dict[str, Any]:
@@ -134,6 +142,35 @@ def _issue_host_token_bundle(
         "refresh_expires_at": int(refresh_expires_at.timestamp()),
     }
     return bundle, refresh_token
+
+
+async def _has_pending_openclaw_cleanup(
+    db: AsyncSession,
+    host_instance_id: str,
+) -> bool:
+    pending = (
+        await db.execute(
+            select(OpenclawAgentCleanup.id)
+            .where(
+                OpenclawAgentCleanup.host_id == host_instance_id,
+                OpenclawAgentCleanup.status == "pending",
+            )
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    return pending is not None
+
+
+async def _clear_revoked_host_refresh_if_cleanup_done(host_instance_id: str) -> None:
+    async with async_session() as db:
+        instance = await db.get(OpenclawHostInstance, host_instance_id)
+        if instance is None or instance.revoked_at is None:
+            return
+        if await _has_pending_openclaw_cleanup(db, host_instance_id):
+            return
+        instance.refresh_token_hash = None
+        instance.refresh_token_expires_at = None
+        await db.commit()
 
 
 # ---------------------------------------------------------------------------
@@ -222,6 +259,72 @@ async def send_host_control_frame(
             detail={"code": "host_disconnected", "host_message": str(exc)},
         )
     return ack
+
+
+def _cleanup_error_message(ack: dict[str, Any]) -> str:
+    err = ack.get("error")
+    if isinstance(err, dict):
+        message = err.get("message") or err.get("code")
+        if isinstance(message, str) and message:
+            return message[:1000]
+    return "host cleanup failed"
+
+
+async def process_pending_openclaw_cleanups(host_instance_id: str) -> None:
+    """Best-effort drain of pending local cleanup jobs for one OpenClaw host."""
+    async with async_session() as db:
+        rows = (
+            await db.execute(
+                select(OpenclawAgentCleanup)
+                .where(
+                    OpenclawAgentCleanup.host_id == host_instance_id,
+                    OpenclawAgentCleanup.status == "pending",
+                )
+                .order_by(OpenclawAgentCleanup.created_at, OpenclawAgentCleanup.id)
+                .limit(50)
+            )
+        ).scalars().all()
+
+    for row in rows:
+        now = _now()
+        try:
+            ack = await send_host_control_frame(
+                host_instance_id,
+                "revoke_agent",
+                {
+                    "agentId": row.agent_id,
+                    "deleteCredentials": row.delete_credentials,
+                    "deleteState": row.delete_state,
+                    "deleteWorkspace": row.delete_workspace,
+                },
+                timeout_ms=10000,
+            )
+        except HTTPException as exc:
+            # Offline hosts keep the job pending for the next reconnect.
+            if exc.status_code == 409:
+                return
+            async with async_session() as db:
+                current = await db.get(OpenclawAgentCleanup, row.id)
+                if current is not None and current.status == "pending":
+                    current.attempts += 1
+                    current.last_error = str(exc.detail)[:1000]
+                    await db.commit()
+            continue
+
+        async with async_session() as db:
+            current = await db.get(OpenclawAgentCleanup, row.id)
+            if current is None or current.status != "pending":
+                continue
+            current.attempts += 1
+            if isinstance(ack, dict) and ack.get("ok"):
+                current.status = "succeeded"
+                current.completed_at = now
+                current.last_error = None
+            else:
+                current.last_error = _cleanup_error_message(ack if isinstance(ack, dict) else {})
+            await db.commit()
+
+    await _clear_revoked_host_refresh_if_cleanup_done(host_instance_id)
 
 
 # ---------------------------------------------------------------------------
@@ -487,13 +590,29 @@ async def openclaw_refresh_token(
     instance = result.scalar_one_or_none()
     if instance is None:
         raise HTTPException(status_code=401, detail="invalid_refresh_token")
-    if instance.revoked_at is not None:
-        raise HTTPException(status_code=401, detail="host_revoked")
     expires_at = instance.refresh_token_expires_at
     if expires_at is not None and expires_at.tzinfo is None:
         expires_at = expires_at.replace(tzinfo=datetime.timezone.utc)
     if expires_at is not None and expires_at < _now():
         raise HTTPException(status_code=401, detail="invalid_refresh_token")
+
+    if instance.revoked_at is not None:
+        if not await _has_pending_openclaw_cleanup(db, instance.id):
+            raise HTTPException(status_code=401, detail="host_revoked")
+        access_token, expires_in = _create_host_access_token(
+            instance.id,
+            str(instance.owner_user_id),
+            cleanup_only=True,
+        )
+        access_expires_at = _now() + datetime.timedelta(seconds=expires_in)
+        instance.last_seen_at = _now()
+        await db.commit()
+        return {
+            "host_instance_id": instance.id,
+            "access_token": access_token,
+            "access_expires_at": int(access_expires_at.timestamp()),
+            "cleanup_only": True,
+        }
 
     bundle, new_refresh = _issue_host_token_bundle(instance)
     instance.refresh_token_hash = _hash_refresh_token(new_refresh)
@@ -753,9 +872,12 @@ async def openclaw_control_ws(ws: WebSocket) -> None:
         if instance is None:
             await ws.close(code=4401, reason="instance not found")
             return
+        cleanup_only = bool(claims.get("cleanup_only"))
         if instance.revoked_at is not None:
-            await ws.close(code=4403, reason="instance revoked")
-            return
+            if not await _has_pending_openclaw_cleanup(db, host_instance_id):
+                await ws.close(code=4403, reason="instance revoked")
+                return
+            cleanup_only = True
         instance.last_seen_at = _now()
         await db.commit()
 
@@ -782,6 +904,16 @@ async def openclaw_control_ws(ws: WebSocket) -> None:
         await ws.send_text(json.dumps(hello))
     except Exception as exc:  # noqa: BLE001
         logger.warning("openclaw hello send failed: %s", exc)
+
+    async def _drain_pending_cleanup() -> None:
+        await process_pending_openclaw_cleanups(host_instance_id)
+        if cleanup_only:
+            try:
+                await ws.close(code=4403, reason="host revoked")
+            except Exception:
+                pass
+
+    asyncio.create_task(_drain_pending_cleanup())
 
     try:
         while True:

--- a/backend/migrations/037_openclaw_agent_cleanups.sql
+++ b/backend/migrations/037_openclaw_agent_cleanups.sql
@@ -1,0 +1,24 @@
+-- Durable best-effort local cleanup jobs for OpenClaw-hosted agents.
+-- Hub-side unbind can complete while the host is offline; the control plane
+-- retries pending cleanup when the host reconnects.
+
+CREATE TABLE IF NOT EXISTS openclaw_agent_cleanups (
+    id                 BIGSERIAL PRIMARY KEY,
+    host_id            VARCHAR(32) NOT NULL REFERENCES openclaw_host_instances(id) ON DELETE CASCADE,
+    agent_id           VARCHAR(32) NOT NULL,
+    status             VARCHAR(16) NOT NULL DEFAULT 'pending',
+    delete_credentials BOOLEAN NOT NULL DEFAULT TRUE,
+    delete_state       BOOLEAN NOT NULL DEFAULT TRUE,
+    delete_workspace   BOOLEAN NOT NULL DEFAULT FALSE,
+    attempts           INTEGER NOT NULL DEFAULT 0,
+    last_error         TEXT NULL,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+    completed_at       TIMESTAMPTZ NULL
+);
+
+CREATE INDEX IF NOT EXISTS ix_openclaw_agent_cleanups_host_status
+  ON openclaw_agent_cleanups(host_id, status);
+
+CREATE INDEX IF NOT EXISTS ix_openclaw_agent_cleanups_agent
+  ON openclaw_agent_cleanups(agent_id);

--- a/backend/tests/test_app/test_app_user_agents.py
+++ b/backend/tests/test_app/test_app_user_agents.py
@@ -31,6 +31,8 @@ from hub.models import (
     Base,
     KeyState,
     MessagePolicy,
+    OpenclawAgentCleanup,
+    OpenclawHostInstance,
     Role,
     SigningKey,
     SubscriptionProduct,
@@ -281,6 +283,51 @@ async def test_unbind_agent_binding(client: AsyncClient, db_session: AsyncSessio
         )
     )
     assert role_result.scalar_one_or_none() is not None
+
+
+@pytest.mark.asyncio
+async def test_unbind_openclaw_agent_queues_local_cleanup(
+    client: AsyncClient, db_session: AsyncSession, seed_user: dict
+):
+    """OpenClaw-backed unbind detaches the host relation and queues local cleanup."""
+    host = OpenclawHostInstance(
+        id="oc_cleanup001",
+        owner_user_id=seed_user["user_id"],
+        host_pubkey="ed25519:test-cleanup",
+    )
+    db_session.add(host)
+    seed_user["agent1"].openclaw_host_id = host.id
+    seed_user["agent1"].hosting_kind = "plugin"
+    await db_session.commit()
+
+    resp = await client.delete(
+        "/api/users/me/agents/ag_agent001/binding",
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["local_cleanup_queued"] is True
+    assert body["openclaw_host_id"] == host.id
+
+    agent = (
+        await db_session.execute(select(Agent).where(Agent.agent_id == "ag_agent001"))
+    ).scalar_one()
+    assert agent.user_id is None
+    assert agent.openclaw_host_id is None
+
+    cleanup = (
+        await db_session.execute(
+            select(OpenclawAgentCleanup).where(
+                OpenclawAgentCleanup.host_id == host.id,
+                OpenclawAgentCleanup.agent_id == "ag_agent001",
+            )
+        )
+    ).scalar_one()
+    assert cleanup.status == "pending"
+    assert cleanup.delete_credentials is True
+    assert cleanup.delete_state is True
+    assert cleanup.delete_workspace is False
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_app/test_openclaw_onboarding.py
+++ b/backend/tests/test_app/test_openclaw_onboarding.py
@@ -25,6 +25,7 @@ from sqlalchemy.pool import StaticPool
 from hub.models import (
     Agent,
     Base,
+    OpenclawAgentCleanup,
     OpenclawHostInstance,
     Role,
     User,
@@ -285,6 +286,7 @@ async def test_openclaw_host_revoke_unbinds_all_agents_and_promotes_one_default(
     issued = await _issue_install(client, fresh_user["token"], name="A")
     claim_a = (await _claim(client, issued["bind_code"], issued["nonce"])).json()
     host_id = claim_a["host"]["host_instance_id"]
+    host_refresh_token = claim_a["host"]["refresh_token"]
     agent_a_id = claim_a["agent"]["id"]
 
     # Manually attach a second agent (B) to the same host so we can verify
@@ -346,7 +348,26 @@ async def test_openclaw_host_revoke_unbinds_all_agents_and_promotes_one_default(
         )
     ).scalar_one()
     assert instance.revoked_at is not None
-    assert instance.refresh_token_hash is None
+    assert instance.refresh_token_hash is not None
+
+    cleanup_rows = (
+        await db_session.execute(
+            select(OpenclawAgentCleanup).where(OpenclawAgentCleanup.host_id == host_id)
+        )
+    ).scalars().all()
+    assert {row.agent_id for row in cleanup_rows} == {agent_a_id, agent_b.agent_id}
+    assert all(row.status == "pending" for row in cleanup_rows)
+
+    refresh_resp = await client.post(
+        "/openclaw/auth/refresh",
+        json={"refresh_token": host_refresh_token},
+    )
+    assert refresh_resp.status_code == 200
+    refresh_body = refresh_resp.json()
+    assert refresh_body["host_instance_id"] == host_id
+    assert refresh_body["cleanup_only"] is True
+    assert "access_token" in refresh_body
+    assert "refresh_token" not in refresh_body
 
 
 @pytest.mark.asyncio

--- a/packages/daemon/src/gateway/runtimes/acp-stream.ts
+++ b/packages/daemon/src/gateway/runtimes/acp-stream.ts
@@ -478,7 +478,12 @@ export abstract class AcpRuntimeAdapter implements RuntimeAdapter {
 
       const stopReason = promptResult?.stopReason ?? "end_turn";
       if (stopReason === "refusal" || stopReason === "error") {
-        state.errorText = state.errorText ?? `prompt stopped: ${stopReason}`;
+        const tail = stderrTail.slice(-STDERR_ERROR_SNIPPET).trim();
+        state.errorText =
+          state.errorText ??
+          (tail
+            ? `prompt stopped: ${stopReason}; stderr: ${tail}`
+            : `prompt stopped: ${stopReason}`);
       }
       // Tell the dispatcher the runtime has finished its reasoning loop —
       // important for turns that ended without an `agent_message_chunk`
@@ -499,9 +504,10 @@ export abstract class AcpRuntimeAdapter implements RuntimeAdapter {
         /* best-effort */
       }
     } catch (err) {
+      const baseMsg = err instanceof Error ? err.message : String(err);
+      const tail = stderrTail.slice(-STDERR_ERROR_SNIPPET).trim();
       state.errorText =
-        state.errorText ??
-        (err instanceof Error ? err.message : String(err));
+        state.errorText ?? (tail ? `${baseMsg}; stderr: ${tail}` : baseMsg);
       try {
         child.stdin.end();
       } catch {

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.3.8",
       "license": "MIT",
       "dependencies": {
+        "@botcord/protocol-core": "^0.1.0",
         "ws": "^8.18.0"
       },
       "devDependencies": {
@@ -868,6 +869,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@botcord/protocol-core": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@botcord/protocol-core/-/protocol-core-0.1.1.tgz",
+      "integrity": "sha512-qxbiavALKS7ecxw/DG3kXNxEgknvw7th+TUvapxKVuI87PCbGRnPL6kEOdNesJwj9h0lGyDtDnv3LIBfz9Y3Gw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@clack/core": {

--- a/plugin/src/__tests__/host-control.test.ts
+++ b/plugin/src/__tests__/host-control.test.ts
@@ -6,6 +6,8 @@ import {
   handleControlFrame,
   patchOpenclawConfigForAgent,
   provisionAgentLocal,
+  removeOpenclawConfigForAgent,
+  revokeAgentLocal,
 } from "../host-control.js";
 
 const fakeHost = {
@@ -192,6 +194,71 @@ describe("patchOpenclawConfigForAgent", () => {
   });
 });
 
+describe("revokeAgentLocal", () => {
+  it("removes the OpenClaw account plus credentials and state, preserving workspace", () => {
+    const agentId = "ag_cleanup";
+    const cfgPath = join(tmpHome, ".openclaw", "openclaw.json");
+    const credPath = join(tmpHome, ".botcord", "credentials", `${agentId}.json`);
+    const stateDir = join(tmpHome, ".botcord", "agents", agentId, "state");
+    const workspaceDir = join(tmpHome, ".botcord", "agents", agentId, "workspace");
+    mkdirSync(join(tmpHome, ".openclaw"), { recursive: true });
+    mkdirSync(join(tmpHome, ".botcord", "credentials"), { recursive: true });
+    mkdirSync(stateDir, { recursive: true });
+    mkdirSync(workspaceDir, { recursive: true });
+    writeFileSync(credPath, "{}");
+    writeFileSync(join(stateDir, "runtime.json"), "{}");
+    writeFileSync(join(workspaceDir, "memory.md"), "# keep\n");
+    writeFileSync(
+      cfgPath,
+      JSON.stringify({
+        channels: {
+          botcord: {
+            enabled: true,
+            accounts: {
+              [agentId]: { enabled: true, credentialsFile: credPath },
+            },
+          },
+        },
+      }),
+    );
+
+    const result = revokeAgentLocal({ agentId });
+
+    expect(result.config_removed).toBe(true);
+    expect(result.credentials_deleted).toBe(true);
+    expect(result.state_deleted).toBe(true);
+    expect(result.workspace_deleted).toBe(false);
+    expect(() => readFileSync(credPath, "utf8")).toThrow();
+    expect(() => readFileSync(join(stateDir, "runtime.json"), "utf8")).toThrow();
+    expect(readFileSync(join(workspaceDir, "memory.md"), "utf8")).toContain("# keep");
+    const cfg = JSON.parse(readFileSync(cfgPath, "utf8"));
+    expect(cfg.channels.botcord.accounts).toBeUndefined();
+  });
+
+  it("can remove a legacy single-account config entry", () => {
+    const agentId = "ag_legacy";
+    const cfgPath = join(tmpHome, ".openclaw", "openclaw.json");
+    const credPath = join(tmpHome, ".botcord", "credentials", `${agentId}.json`);
+    mkdirSync(join(tmpHome, ".openclaw"), { recursive: true });
+    writeFileSync(
+      cfgPath,
+      JSON.stringify({
+        channels: { botcord: { enabled: true, credentialsFile: credPath } },
+      }),
+    );
+
+    const result = removeOpenclawConfigForAgent({
+      agentId,
+      credentialsFile: credPath,
+      configPath: cfgPath,
+    });
+
+    expect(result).toEqual({ removed: true, reason: "legacy_credentials" });
+    const cfg = JSON.parse(readFileSync(cfgPath, "utf8"));
+    expect(cfg.channels.botcord.credentialsFile).toBeUndefined();
+  });
+});
+
 describe("handleControlFrame", () => {
   const baseCtx = {
     host: fakeHost,
@@ -215,6 +282,32 @@ describe("handleControlFrame", () => {
       ok: false,
       error: { code: "bad_params", message: "provision_id and nonce required" },
     });
+  });
+
+  it("handles revoke_agent by cleaning local files", async () => {
+    const agentId = "ag_frame";
+    const credPath = join(tmpHome, ".botcord", "credentials", `${agentId}.json`);
+    mkdirSync(join(tmpHome, ".botcord", "credentials"), { recursive: true });
+    mkdirSync(join(tmpHome, ".openclaw"), { recursive: true });
+    writeFileSync(credPath, "{}");
+    writeFileSync(
+      join(tmpHome, ".openclaw", "openclaw.json"),
+      JSON.stringify({
+        channels: {
+          botcord: {
+            accounts: { [agentId]: { credentialsFile: credPath } },
+          },
+        },
+      }),
+    );
+
+    const ack = await handleControlFrame(
+      { id: "5", type: "revoke_agent", params: { agentId } },
+      baseCtx,
+    );
+
+    expect(ack?.ok).toBe(true);
+    expect(() => readFileSync(credPath, "utf8")).toThrow();
   });
 
   it("returns unknown_type for unrecognised frames", async () => {

--- a/plugin/src/host-control.ts
+++ b/plugin/src/host-control.ts
@@ -21,7 +21,15 @@
  * a follow-up; see TODO at bottom of the file).
  */
 import WebSocket from "ws";
-import { writeFileSync, mkdirSync, readFileSync, chmodSync, existsSync } from "node:fs";
+import {
+  writeFileSync,
+  mkdirSync,
+  readFileSync,
+  chmodSync,
+  existsSync,
+  rmSync,
+  unlinkSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { createPublicKey, verify as nodeVerify } from "node:crypto";
@@ -87,6 +95,15 @@ function hostFile(): string {
 }
 function credDir(): string {
   return join(botcordHome(), ".botcord", "credentials");
+}
+function defaultCredentialsFile(agentId: string): string {
+  return join(credDir(), `${agentId}.json`);
+}
+function agentHomeDir(agentId: string): string {
+  return join(botcordHome(), ".botcord", "agents", agentId);
+}
+function agentStateDir(agentId: string): string {
+  return join(agentHomeDir(agentId), "state");
 }
 
 interface HostFile {
@@ -297,6 +314,128 @@ export function patchOpenclawConfigForAgent(args: {
   }
 }
 
+export type ConfigRemoveResult =
+  | { removed: true; reason: "account" | "legacy_credentials" }
+  | { removed: false; reason: "not_found" | "io_error"; error?: string };
+
+export function removeOpenclawConfigForAgent(args: {
+  agentId: string;
+  credentialsFile?: string;
+  configPath?: string;
+}): ConfigRemoveResult {
+  const path =
+    args.configPath ??
+    process.env.OPENCLAW_CONFIG_PATH ??
+    join(botcordHome(), ".openclaw", "openclaw.json");
+  if (!existsSync(path)) return { removed: false, reason: "not_found" };
+
+  let cfg: Record<string, any>;
+  try {
+    cfg = JSON.parse(readFileSync(path, "utf8"));
+  } catch (err) {
+    return {
+      removed: false,
+      reason: "io_error",
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  const botcord = cfg?.channels?.botcord;
+  if (!botcord || typeof botcord !== "object") {
+    return { removed: false, reason: "not_found" };
+  }
+
+  const credentialsFile = args.credentialsFile ?? defaultCredentialsFile(args.agentId);
+  let removed: ConfigRemoveResult | null = null;
+  if (botcord.accounts && typeof botcord.accounts === "object") {
+    const accounts = botcord.accounts as Record<string, any>;
+    if (accounts[args.agentId]) {
+      delete accounts[args.agentId];
+      removed = { removed: true, reason: "account" };
+      if (Object.keys(accounts).length === 0) {
+        delete botcord.accounts;
+      }
+    }
+  }
+
+  if (
+    !removed &&
+    typeof botcord.credentialsFile === "string" &&
+    botcord.credentialsFile === credentialsFile
+  ) {
+    delete botcord.credentialsFile;
+    removed = { removed: true, reason: "legacy_credentials" };
+  }
+
+  if (!removed) return { removed: false, reason: "not_found" };
+
+  try {
+    writeFileSync(path, JSON.stringify(cfg, null, 2) + "\n", { encoding: "utf8" });
+    return removed;
+  } catch (err) {
+    return {
+      removed: false,
+      reason: "io_error",
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export function revokeAgentLocal(params: {
+  agentId: string;
+  deleteCredentials?: boolean;
+  deleteState?: boolean;
+  deleteWorkspace?: boolean;
+}): {
+  agent_id: string;
+  config_removed: boolean;
+  config_reason: string;
+  credentials_deleted: boolean;
+  state_deleted: boolean;
+  workspace_deleted: boolean;
+} {
+  const deleteCredentials = params.deleteCredentials !== false;
+  const deleteState = params.deleteState ?? deleteCredentials;
+  const deleteWorkspace = params.deleteWorkspace === true;
+  const credentialsFile = defaultCredentialsFile(params.agentId);
+  const config = removeOpenclawConfigForAgent({
+    agentId: params.agentId,
+    credentialsFile,
+  });
+
+  let credentialsDeleted = false;
+  if (deleteCredentials && existsSync(credentialsFile)) {
+    unlinkSync(credentialsFile);
+    credentialsDeleted = true;
+  }
+
+  let stateDeleted = false;
+  let workspaceDeleted = false;
+  if (deleteWorkspace) {
+    const home = agentHomeDir(params.agentId);
+    if (existsSync(home)) {
+      rmSync(home, { recursive: true, force: true });
+      stateDeleted = true;
+      workspaceDeleted = true;
+    }
+  } else if (deleteState) {
+    const state = agentStateDir(params.agentId);
+    if (existsSync(state)) {
+      rmSync(state, { recursive: true, force: true });
+      stateDeleted = true;
+    }
+  }
+
+  return {
+    agent_id: params.agentId,
+    config_removed: config.removed,
+    config_reason: config.reason,
+    credentials_deleted: credentialsDeleted,
+    state_deleted: stateDeleted,
+    workspace_deleted: workspaceDeleted,
+  };
+}
+
 // ── Frame signature verification ────────────────────────────────────────────
 
 function controlSigningInput(frame: ControlFrame): string {
@@ -332,16 +471,17 @@ async function refreshHostToken(host: HostFile): Promise<HostFile> {
   const body = (await resp.json()) as {
     host_instance_id: string;
     access_token: string;
-    refresh_token: string;
+    refresh_token?: string;
     access_expires_at: number;
-    refresh_expires_at: number;
+    refresh_expires_at?: number;
+    cleanup_only?: boolean;
   };
   const next: HostFile = {
     ...host,
     accessToken: body.access_token,
-    refreshToken: body.refresh_token,
+    refreshToken: body.refresh_token ?? host.refreshToken,
     accessExpiresAt: body.access_expires_at,
-    refreshExpiresAt: body.refresh_expires_at,
+    refreshExpiresAt: body.refresh_expires_at ?? host.refreshExpiresAt,
     savedAt: new Date().toISOString(),
   };
   writeHostFile(next);
@@ -494,9 +634,32 @@ export async function handleControlFrame(
       }
     }
     case "revoke_agent": {
-      // Best-effort: agent credentials cleanup is left to the user /
-      // dashboard for now; the host just acks so Hub doesn't retry.
-      return { ok: true };
+      const params = (frame.params ?? {}) as {
+        agentId?: string;
+        deleteCredentials?: boolean;
+        deleteState?: boolean;
+        deleteWorkspace?: boolean;
+      };
+      if (!params.agentId) {
+        return {
+          ok: false,
+          error: { code: "bad_params", message: "agentId required" },
+        };
+      }
+      try {
+        const result = revokeAgentLocal({
+          agentId: params.agentId,
+          deleteCredentials: params.deleteCredentials,
+          deleteState: params.deleteState,
+          deleteWorkspace: params.deleteWorkspace,
+        });
+        ctx.log("info", `revoked local agent ${params.agentId}`);
+        return { ok: true, result };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        ctx.log("warn", `revoke_agent failed: ${message}`);
+        return { ok: false, error: { code: "revoke_failed", message } };
+      }
     }
     case "set_route":
       return { ok: true };


### PR DESCRIPTION
## Summary
- queue durable OpenClaw local cleanup jobs when an OpenClaw-backed agent is unbound or its host is revoked
- drain pending cleanup over the OpenClaw control channel, including cleanup-only reconnects for revoked hosts
- implement OpenClaw plugin revoke_agent cleanup for botcord config accounts, credentials, and state while preserving workspace by default

## Tests
- cd plugin && npm test -- host-control.test.ts
- cd backend && uv run pytest tests/test_app/test_app_user_agents.py tests/test_app/test_openclaw_onboarding.py

## Notes
- cd plugin && npx tsc --noEmit still fails on pre-existing src/inbound.ts SourceType comparisons unrelated to this change