### PR TITLE
fix(daemon): revoke unclaimed local BotCord agents

### DIFF
--- a/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
+++ b/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
@@ -510,6 +510,61 @@ describe("createBotCordChannel — ack + dedup", () => {
       await server.close();
     }
   });
+
+  it("locally revokes the channel when Hub reports the agent is unclaimed", async () => {
+    const server = await startAuthOkServer();
+    try {
+      const err = new Error(
+        'BotCord /hub/inbox?limit=50 failed: 403 {"code":"agent_not_claimed_generic","retryable":false}',
+      ) as Error & { status?: number };
+      err.status = 403;
+      const client = makeClient({
+        getHubUrl: vi.fn().mockReturnValue(server.url),
+        pollInbox: vi.fn().mockRejectedValue(err),
+      });
+      const localRevokeAgent = vi.fn().mockResolvedValue({
+        agentId: "ag_self",
+        credentialsDeleted: true,
+        stateDeleted: true,
+        workspaceDeleted: false,
+      });
+      const statuses: Record<string, unknown>[] = [];
+      const logs: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+      const log: GatewayLogger = {
+        ...silentLog,
+        warn: (msg, meta) => logs.push({ msg, meta }),
+      };
+      const channel = createBotCordChannel({
+        id: "botcord-main",
+        accountId: "ag_self",
+        agentId: "ag_self",
+        client,
+        hubBaseUrl: server.url,
+        localRevokeAgent,
+      });
+      const startP = channel.start({
+        config: stubConfig,
+        accountId: "ag_self",
+        abortSignal: new AbortController().signal,
+        log,
+        emit: async () => undefined,
+        setStatus: (patch) => statuses.push(patch),
+      });
+
+      await expect(startP).rejects.toMatchObject({ code: "channel_permanent_stop" });
+      expect(localRevokeAgent).toHaveBeenCalledWith("ag_self", log);
+      expect(logs.some((entry) => entry.msg === "botcord agent unclaimed; revoked local binding"))
+        .toBe(true);
+      expect(statuses.at(-1)).toMatchObject({
+        running: false,
+        connected: false,
+        restartPending: false,
+        lastError: "agent not claimed; local binding revoked",
+      });
+    } finally {
+      await server.close();
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/gateway/__tests__/channel-manager.test.ts
+++ b/packages/daemon/src/gateway/__tests__/channel-manager.test.ts
@@ -270,6 +270,32 @@ describe("ChannelManager", () => {
     await mgr.stopAll();
   });
 
+  it("does not restart after permanent channel stop", async () => {
+    const c1 = new FakeChannel("c1");
+    const log = makeLogger();
+    const mgr = new ChannelManager({
+      config: makeConfig(["c1"]),
+      channels: [c1],
+      log,
+      emit: async () => {},
+      backoffMs: { initial: 1000, max: 60_000, factor: 2 },
+    });
+    await mgr.startAll();
+    await flush();
+    const err = new Error("agent not claimed; local binding revoked") as Error & {
+      code?: string;
+    };
+    err.code = "channel_permanent_stop";
+    c1.latest().reject(err);
+    await flush();
+    expect(mgr.status()["c1"].restartPending).toBeFalsy();
+    expect(c1.starts).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(1000);
+    await flush();
+    expect(c1.starts).toHaveLength(1);
+    expect(log.infos.some((entry) => entry[0] === "channel stopped permanently")).toBe(true);
+  });
+
   it("restarts when channel resolves (graceful) without stopAll", async () => {
     const c1 = new FakeChannel("c1");
     const mgr = new ChannelManager({

--- a/packages/daemon/src/gateway/channel-manager.ts
+++ b/packages/daemon/src/gateway/channel-manager.ts
@@ -43,6 +43,7 @@ const DEFAULT_INITIAL_BACKOFF = 1000;
 const DEFAULT_MAX_BACKOFF = 60_000;
 const DEFAULT_FACTOR = 2;
 const LONG_RUN_THRESHOLD_MS = 30_000;
+const CHANNEL_PERMANENT_STOP = "channel_permanent_stop";
 
 /** Supervises channel adapters: lifecycle, status tracking, and crash restart with backoff. */
 export class ChannelManager {
@@ -266,19 +267,30 @@ export class ChannelManager {
     const ranForMs = Date.now() - entry.currentStartAt;
     const channelId = entry.adapter.id;
     const crashed = err !== null && err !== undefined;
+    const permanentStop =
+      typeof err === "object" &&
+      err !== null &&
+      (err as { code?: unknown }).code === CHANNEL_PERMANENT_STOP;
 
     entry.snapshot = {
       ...entry.snapshot,
       running: false,
       lastStopAt: Date.now(),
-      lastError: crashed
+      lastError: crashed && !permanentStop
         ? err instanceof Error
           ? err.message
           : String(err)
         : entry.snapshot.lastError ?? null,
     };
 
-    if (crashed) {
+    if (permanentStop) {
+      this.log.info("channel stopped permanently", {
+        channel: channelId,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+      entry.state = "idle";
+      entry.stopRequested = true;
+    } else if (crashed) {
       this.log.warn("channel crashed", {
         channel: channelId,
         error: err instanceof Error ? err.message : String(err),

--- a/packages/daemon/src/gateway/channels/botcord.ts
+++ b/packages/daemon/src/gateway/channels/botcord.ts
@@ -20,7 +20,9 @@ import type {
   GatewayInboundMessage,
   GatewayLogger,
 } from "../index.js";
+import type { Gateway } from "../gateway.js";
 import { sanitizeUntrustedContent } from "./sanitize.js";
+import { revokeAgent } from "../../provision.js";
 
 const RECONNECT_BACKOFF = [1000, 2000, 4000, 8000, 16000, 30000];
 const KEEPALIVE_INTERVAL = 20_000;
@@ -29,6 +31,7 @@ const SEEN_MESSAGES_CAP = 500;
 const OWNER_CHAT_PREFIX = "rm_oc_";
 const DM_ROOM_PREFIX = "rm_dm_";
 const INBOX_POLL_LIMIT = 50;
+const CHANNEL_PERMANENT_STOP = "channel_permanent_stop";
 
 type InboxDrainTrigger =
   | "ws_auth_ok"
@@ -86,6 +89,20 @@ export interface BotCordChannelOptions {
    * can't spin up a real WS server.
    */
   webSocketCtor?: typeof WebSocket;
+  /** Test hook: override local cleanup after Hub says the agent is unclaimed. */
+  localRevokeAgent?: (agentId: string, log: GatewayLogger) => Promise<unknown>;
+}
+
+function isUnclaimedAgentError(err: unknown): boolean {
+  const status = (err as { status?: unknown } | null)?.status;
+  if (status !== 403) return false;
+  const message = err instanceof Error ? err.message : String(err);
+  return (
+    message.includes('"code":"agent_not_claimed_generic"') ||
+    message.includes('"code":"agent_not_claimed"') ||
+    message.includes("agent_not_claimed_generic") ||
+    message.includes("agent_not_claimed")
+  );
 }
 
 /** Default factory: wrap `loadStoredCredentials` + `new BotCordClient`. */
@@ -456,13 +473,16 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
     let reconnectAttempt = 0;
     let consecutiveAuthFailures = 0;
     let running = true;
+    let permanentStopping = false;
     let processing = false;
     let pendingUpdate = false;
     let pendingRefresh: Promise<unknown> | null = null;
     let resolveLoop: (() => void) | null = null;
+    let rejectLoop: ((err: Error) => void) | null = null;
 
-    const done = new Promise<void>((resolve) => {
+    const done = new Promise<void>((resolve, reject) => {
       resolveLoop = resolve;
+      rejectLoop = reject;
     });
 
     function clearTimers() {
@@ -479,6 +499,71 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
     function markStatus(patch: Partial<ChannelStatusSnapshot>) {
       statusSnapshot = { ...statusSnapshot, ...patch };
       setStatus(patch);
+    }
+
+    async function revokeLocalUnclaimedAgent(err: unknown) {
+      if (!isUnclaimedAgentError(err)) return false;
+      running = false;
+      permanentStopping = true;
+      clearTimers();
+      try {
+        ws?.close();
+      } catch {
+        // ignore
+      }
+      try {
+        const result = options.localRevokeAgent
+          ? await options.localRevokeAgent(options.agentId, log)
+          : await revokeAgent(
+              {
+                agentId: options.agentId,
+                deleteCredentials: true,
+                deleteState: true,
+                deleteWorkspace: false,
+              },
+              {
+                gateway: {
+                  removeChannel: async () => undefined,
+                  removeManagedRoute: () => undefined,
+                } as unknown as Gateway,
+              },
+            );
+        log.warn("botcord agent unclaimed; revoked local binding", {
+          agentId: options.agentId,
+          result,
+        });
+        markStatus({
+          running: false,
+          connected: false,
+          restartPending: false,
+          lastStopAt: Date.now(),
+          lastError: "agent not claimed; local binding revoked",
+        });
+      } catch (cleanupErr) {
+        log.error("botcord unclaimed local revoke failed", {
+          agentId: options.agentId,
+          err: String(cleanupErr),
+        });
+        markStatus({
+          running: false,
+          connected: false,
+          restartPending: false,
+          lastStopAt: Date.now(),
+          lastError: String(cleanupErr),
+        });
+      }
+      permanentStopping = false;
+      if (rejectLoop) {
+        const r = rejectLoop;
+        rejectLoop = null;
+        resolveLoop = null;
+        const stopErr = new Error("agent not claimed; local binding revoked") as Error & {
+          code?: string;
+        };
+        stopErr.code = CHANNEL_PERMANENT_STOP;
+        r(stopErr);
+      }
+      return true;
     }
 
     async function fireInbox(trigger: InboxDrainTrigger) {
@@ -501,6 +586,9 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
           currentTrigger = hasMore ? "has_more_continue" : "coalesced_inbox_update";
         } while ((pendingUpdate || hasMore) && running);
       } catch (err) {
+        if (await revokeLocalUnclaimedAgent(err)) {
+          return;
+        }
         log.error("botcord inbox drain failed", { err: String(err) });
       } finally {
         processing = false;
@@ -607,9 +695,11 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
         clearTimers();
         markStatus({ connected: false });
         if (!running) {
+          if (permanentStopping) return;
           if (resolveLoop) {
             const r = resolveLoop;
             resolveLoop = null;
+            rejectLoop = null;
             r();
           }
           return;
@@ -630,6 +720,7 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
             if (resolveLoop) {
               const r = resolveLoop;
               resolveLoop = null;
+              rejectLoop = null;
               r();
             }
             return;
@@ -667,6 +758,7 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
       if (resolveLoop) {
         const r = resolveLoop;
         resolveLoop = null;
+        rejectLoop = null;
         r();
       }
     }

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -1061,7 +1061,7 @@ function localOpenclawAcpDisabled(rawUrl: string): boolean {
   }
 }
 
-async function revokeAgent(
+export async function revokeAgent(
   params: RevokeAgentParams,
   ctx: { gateway: Gateway },
 ): Promise<RevokeAgentResult> {


### PR DESCRIPTION
## Summary
- self-heal stale local BotCord channels when Hub returns non-retryable unclaimed-agent 403 during inbox drain
- locally reuse revoke_agent cleanup semantics: remove config/credentials/state and preserve workspace
- permanently stop the channel after local cleanup so ChannelManager does not reconnect-loop on the removed binding

## Tests
- cd packages/daemon && npm test -- src/gateway/__tests__/botcord-channel.test.ts src/__tests__/provision.test.ts src/gateway/__tests__/channel-manager.test.ts
- cd packages/daemon && npx tsc -p tsconfig.build.json --noEmit
- git diff --check