### PR TITLE
fix(daemon): make logs readable with agent ids

### DIFF
--- a/packages/daemon/src/__tests__/log.test.ts
+++ b/packages/daemon/src/__tests__/log.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { formatLogLine } from "../log.js";
+
+describe("formatLogLine", () => {
+  it("renders compact text with level, message, details, and trailing timestamp", () => {
+    const line = formatLogLine(
+      "warn",
+      "botcord ws error",
+      { err: "Error: Unexpected server response: 503" },
+      new Date("2026-05-01T00:22:07.131Z"),
+    );
+
+    expect(line).toBe(
+      '[WARN] botcord ws error err="Error: Unexpected server response: 503" ts=2026-05-01T00:22:07.131Z',
+    );
+  });
+
+  it("keeps object details readable without replacing the primary message", () => {
+    const line = formatLogLine(
+      "info",
+      "botcord ws server error",
+      { msg: { type: "error", code: 503 } },
+      new Date("2026-05-01T00:22:07.131Z"),
+    );
+
+    expect(line).toBe(
+      '[INFO] botcord ws server error msg={"type":"error","code":503} ts=2026-05-01T00:22:07.131Z',
+    );
+  });
+});

--- a/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
+++ b/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
@@ -661,6 +661,52 @@ describe("createBotCordChannel — typing()", () => {
   });
 });
 
+describe("createBotCordChannel — websocket logging", () => {
+  it("includes the agent id on websocket server errors", async () => {
+    const server = await startAuthOkServer();
+    const client = makeClient({
+      getHubUrl: vi.fn().mockReturnValue(server.url),
+    });
+    const channel = createBotCordChannel({
+      id: "botcord-main",
+      accountId: "ag_self",
+      agentId: "ag_self",
+      client,
+      hubBaseUrl: server.url,
+    });
+    const abort = new AbortController();
+    const log: GatewayLogger = {
+      ...silentLog,
+      warn: vi.fn(),
+    };
+    const startPromise = channel.start({
+      config: stubConfig,
+      accountId: "ag_self",
+      abortSignal: abort.signal,
+      log,
+      emit: async () => {},
+      setStatus: () => {},
+    });
+    try {
+      await vi.waitFor(() => expect(server.connections.length).toBe(1));
+      server.connections[0].send(JSON.stringify({ type: "error", code: 503 }));
+      await vi.waitFor(() => {
+        expect(log.warn).toHaveBeenCalledWith(
+          "botcord ws server error",
+          expect.objectContaining({
+            agentId: "ag_self",
+            msg: expect.objectContaining({ type: "error", code: 503 }),
+          }),
+        );
+      });
+    } finally {
+      abort.abort();
+      await startPromise;
+      await server.close();
+    }
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Shared: a tiny WS server that acks every `auth` with `auth_ok`.
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/gateway/channels/botcord.ts
+++ b/packages/daemon/src/gateway/channels/botcord.ts
@@ -526,6 +526,7 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
 
     async function connect() {
       if (!running) return;
+      const agentId = options.agentId;
       markStatus({ connected: false, restartPending: false });
       if (pendingRefresh) {
         try {
@@ -540,19 +541,19 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
       try {
         token = await client.ensureToken();
       } catch (err) {
-        log.error("botcord ws token refresh failed", { err: String(err) });
+        log.error("botcord ws token refresh failed", { agentId, err: String(err) });
         markStatus({ lastError: String(err) });
         scheduleReconnect();
         return;
       }
 
       const url = buildHubWebSocketUrl(hubUrl);
-      log.info("botcord ws connecting", { url, agentId: options.agentId });
+      log.info("botcord ws connecting", { url, agentId });
 
       try {
         ws = new wsCtor(url);
       } catch (err) {
-        log.error("botcord ws construct failed", { err: String(err) });
+        log.error("botcord ws construct failed", { agentId, err: String(err) });
         markStatus({ lastError: String(err) });
         scheduleReconnect();
         return;
@@ -597,13 +598,13 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
         } else if (msg.type === "heartbeat" || msg.type === "pong") {
           // no-op
         } else if (msg.type === "error" || msg.type === "auth_failed") {
-          log.warn("botcord ws server error", { msg });
+          log.warn("botcord ws server error", { agentId, msg });
         }
       });
 
       ws.on("close", (code: number, reason: Buffer) => {
         const reasonStr = reason?.toString() || "";
-        log.info("botcord ws closed", { code, reason: reasonStr });
+        log.info("botcord ws closed", { agentId, code, reason: reasonStr });
         clearTimers();
         markStatus({ connected: false });
         if (!running) {
@@ -618,6 +619,7 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
           consecutiveAuthFailures += 1;
           if (consecutiveAuthFailures >= MAX_AUTH_FAILURES) {
             log.error("botcord ws auth failing persistently — giving up reconnects", {
+              agentId,
               failures: consecutiveAuthFailures,
             });
             running = false;
@@ -636,13 +638,13 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
           }
           pendingRefresh = client
             .refreshToken()
-            .catch((err) => log.error("botcord ws forced refresh failed", { err: String(err) }));
+            .catch((err) => log.error("botcord ws forced refresh failed", { agentId, err: String(err) }));
         }
         scheduleReconnect();
       });
 
       ws.on("error", (err: Error) => {
-        log.warn("botcord ws error", { err: String(err) });
+        log.warn("botcord ws error", { agentId, err: String(err) });
         markStatus({ lastError: String(err) });
       });
     }

--- a/packages/daemon/src/gateway/log.ts
+++ b/packages/daemon/src/gateway/log.ts
@@ -1,3 +1,5 @@
+import { formatLogLine } from "../log.js";
+
 /** Structured logger interface used across the gateway core and adapters. */
 export interface GatewayLogger {
   info(msg: string, meta?: Record<string, unknown>): void;
@@ -9,17 +11,12 @@ export interface GatewayLogger {
 type Level = "info" | "warn" | "error" | "debug";
 
 function write(level: Level, msg: string, meta?: Record<string, unknown>): void {
-  const line = JSON.stringify({
-    ts: new Date().toISOString(),
-    level,
-    msg,
-    ...(meta ?? {}),
-  });
+  const line = formatLogLine(level, msg, meta);
   // Always write to stderr so stdout stays clean for NDJSON-style channel output.
   process.stderr.write(line + "\n");
 }
 
-/** Default logger that writes JSON lines to stderr; debug lines gated by BOTCORD_GATEWAY_DEBUG. */
+/** Default logger that writes compact text lines to stderr; debug lines gated by BOTCORD_GATEWAY_DEBUG. */
 export const consoleLogger: GatewayLogger = {
   info: (msg, meta) => write("info", msg, meta),
   warn: (msg, meta) => write("warn", msg, meta),

--- a/packages/daemon/src/log.ts
+++ b/packages/daemon/src/log.ts
@@ -18,14 +18,35 @@ function ensureDir(): void {
 
 type Level = "info" | "warn" | "error" | "debug";
 
+function formatValue(value: unknown): string {
+  if (value instanceof Error) return JSON.stringify(value.stack ?? value.message);
+  if (typeof value === "string") return JSON.stringify(value);
+  if (typeof value === "number" || typeof value === "boolean" || value === null) return String(value);
+  if (value === undefined) return "undefined";
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return JSON.stringify(String(value));
+  }
+}
+
+export function formatLogLine(
+  level: Level,
+  msg: string,
+  fields: Record<string, unknown> | undefined,
+  date = new Date(),
+): string {
+  const detail = Object.entries(fields ?? {})
+    .map(([key, value]) => `${key}=${formatValue(value)}`)
+    .join(" ");
+  const prefix = `[${level.toUpperCase()}] ${msg}`;
+  const suffix = `ts=${date.toISOString()}`;
+  return detail ? `${prefix} ${detail} ${suffix}` : `${prefix} ${suffix}`;
+}
+
 function write(level: Level, msg: string, fields?: Record<string, unknown>): void {
   ensureDir();
-  const line = JSON.stringify({
-    ts: new Date().toISOString(),
-    level,
-    msg,
-    ...(fields ?? {}),
-  });
+  const line = formatLogLine(level, msg, fields);
   try {
     appendFileSync(LOG_FILE, line + "\n", { mode: 0o600 });
   } catch {


### PR DESCRIPTION
## Summary
- switch daemon/gateway log output from JSON lines to compact text lines like `[WARN] message key=value ts=...`
- include `agentId` on BotCord websocket error/close paths
- add focused coverage for log formatting and websocket server error logging

## Tests
- `cd packages/daemon && npm test -- src/__tests__/log.test.ts`
- `cd packages/daemon && npm test -- src/gateway/__tests__/botcord-channel.test.ts`

Note: full daemon `npm test` and `npm run build` still have existing hermes/provision-related failures unrelated to this change.