### PR TITLE
fix: require agent name before provisioning

### DIFF
--- a/frontend/src/components/dashboard/CreateAgentDialog.tsx
+++ b/frontend/src/components/dashboard/CreateAgentDialog.tsx
@@ -199,6 +199,7 @@ export default function CreateAgentDialog({
   }, [selectedRuntime, selectedRuntimeId, selectedHermesProfile]);
 
   const showEmptyState = loaded && onlineDaemons.length === 0;
+  const trimmedName = name.trim();
 
   // Auto-detect daemon coming online while user stares at the install command.
   useEffect(() => {
@@ -246,6 +247,8 @@ export default function CreateAgentDialog({
           return err.detail
             ? `${t.errorDaemonFailed}: ${err.detail}`
             : t.errorDaemonFailed;
+        case "missing_name":
+          return t.nameRequired;
         case "missing_agent_id":
           return t.errorMissingAgentId;
         case "http_error":
@@ -257,11 +260,15 @@ export default function CreateAgentDialog({
 
   async function handleSubmit(): Promise<void> {
     if (!selectedDaemonId || !selectedRuntimeId) return;
+    if (!trimmedName) {
+      setError(t.nameRequired);
+      return;
+    }
     setSubmitting(true);
     setError(null);
     try {
       const res = await provisionAgent(selectedDaemonId, {
-        name: name.trim() || undefined,
+        name: trimmedName,
         bio: bio.trim() || undefined,
         runtime: selectedRuntimeId,
         ...(selectedRuntimeId === "openclaw-acp" && selectedGateway
@@ -290,6 +297,7 @@ export default function CreateAgentDialog({
   const canSubmit =
     !!selectedDaemonId &&
     !!selectedRuntimeId &&
+    !!trimmedName &&
     (!needsOpenclawGateway || !!selectedGateway) &&
     (!needsOpenclawAgent || !!selectedOpenclawAgent) &&
     (!needsHermesProfile || !!selectedHermesProfile) &&
@@ -448,7 +456,12 @@ export default function CreateAgentDialog({
               <input
                 type="text"
                 value={name}
-                onChange={(e) => setName(e.target.value)}
+                onChange={(e) => {
+                  setName(e.target.value);
+                  if (error === t.nameRequired && e.target.value.trim()) {
+                    setError(null);
+                  }
+                }}
                 placeholder={t.namePlaceholder}
                 disabled={submitting}
                 className="w-full rounded-xl border border-glass-border bg-deep-black px-3 py-2 text-sm text-text-primary placeholder-text-tertiary focus:border-neon-cyan focus:outline-none focus:ring-1 focus:ring-neon-cyan/50 disabled:opacity-50"

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -1631,6 +1631,7 @@ export const createAgentDialog: TranslationMap<{
   runtimeNotSupported: string
   nameLabel: string
   namePlaceholder: string
+  nameRequired: string
   bioLabel: string
   bioPlaceholder: string
   submit: string
@@ -1665,6 +1666,7 @@ export const createAgentDialog: TranslationMap<{
     runtimeNotSupported: 'not yet supported',
     nameLabel: 'Name',
     namePlaceholder: 'my-agent',
+    nameRequired: 'Name is required',
     bioLabel: 'Bio (optional)',
     bioPlaceholder: 'What does this agent do?',
     submit: 'Create',
@@ -1699,6 +1701,7 @@ export const createAgentDialog: TranslationMap<{
     runtimeNotSupported: '暂不支持',
     nameLabel: '名称',
     namePlaceholder: 'my-agent',
+    nameRequired: '名称不能为空',
     bioLabel: '简介（可选）',
     bioPlaceholder: '这个 agent 用来做什么？',
     submit: '创建',

--- a/frontend/src/store/useDaemonStore.ts
+++ b/frontend/src/store/useDaemonStore.ts
@@ -73,7 +73,7 @@ export interface DaemonInstance {
 }
 
 export interface ProvisionAgentInput {
-  name?: string;
+  name: string;
   bio?: string;
   runtime?: string;
   cwd?: string;
@@ -93,6 +93,7 @@ export type ProvisionAgentErrorCode =
   | "daemon_offline"
   | "daemon_timeout"
   | "daemon_failed"
+  | "missing_name"
   | "missing_agent_id"
   | "http_error";
 
@@ -501,7 +502,10 @@ export const useDaemonStore = create<DaemonState>()((set, get) => ({
     // frame. The raw /dispatch path cannot be used here because it
     // bypasses the Agent/SigningKey insert and leaves the new identity
     // unclaimed in the registry.
-    const label = (input.name ?? "").trim() || `agent-${Date.now()}`;
+    const label = input.name.trim();
+    if (!label) {
+      throw new ProvisionAgentError("missing_name");
+    }
     const body: Record<string, unknown> = {
       daemon_instance_id: daemonId,
       label,


### PR DESCRIPTION
## Summary
- require a non-empty name before submitting the Create Agent dialog
- remove the frontend fallback that auto-generated agent names for empty input
- add localized required-name validation copy

## Tests
- NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build