### PR TITLE
fix: sync runtime selections after provisioning

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -7,6 +7,7 @@
 
 import asyncio
 import base64
+import copy
 import datetime
 import hashlib
 import hmac
@@ -18,6 +19,7 @@ from uuid import UUID, uuid4
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from pydantic import BaseModel, Field
 from sqlalchemy import delete, case, func as sa_func, select, update
+from sqlalchemy.orm.attributes import flag_modified
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -2043,6 +2045,69 @@ def _daemon_lists_runtime(
     return False
 
 
+def _mark_daemon_runtime_snapshot_bound(
+    instance: DaemonInstance,
+    *,
+    runtime: str,
+    agent_id: str,
+    display_name: str,
+    openclaw_gateway: str | None = None,
+    openclaw_agent: str | None = None,
+    hermes_profile: str | None = None,
+) -> None:
+    """Patch the cached runtime snapshot after a successful provision.
+
+    The daemon only pushes runtime snapshots on connect or explicit
+    refresh-runtimes. Without this patch, the dashboard can immediately reopen
+    the create dialog and still see a just-bound OpenClaw/Hermes profile as
+    selectable until the user manually refreshes runtime discovery.
+    """
+    snap = copy.deepcopy(instance.runtimes_json)
+    if not isinstance(snap, list) or not snap:
+        return
+
+    changed = False
+    for entry in snap:
+        if not isinstance(entry, dict) or entry.get("id") != runtime:
+            continue
+
+        if runtime == "openclaw-acp" and openclaw_gateway and openclaw_agent:
+            endpoints = entry.get("endpoints")
+            if not isinstance(endpoints, list):
+                return
+            for ep in endpoints:
+                if not isinstance(ep, dict) or ep.get("name") != openclaw_gateway:
+                    continue
+                agents = ep.get("agents")
+                if not isinstance(agents, list):
+                    return
+                for profile in agents:
+                    if not isinstance(profile, dict) or profile.get("id") != openclaw_agent:
+                        continue
+                    profile["botcordBinding"] = {"agentId": agent_id}
+                    changed = True
+                    break
+                break
+
+        if runtime == "hermes-agent" and hermes_profile:
+            profiles = entry.get("profiles")
+            if not isinstance(profiles, list):
+                return
+            for profile in profiles:
+                if not isinstance(profile, dict) or profile.get("name") != hermes_profile:
+                    continue
+                profile["occupiedBy"] = agent_id
+                profile["occupiedByName"] = display_name
+                changed = True
+                break
+
+        break
+
+    if changed:
+        instance.runtimes_json = snap
+        flag_modified(instance, "runtimes_json")
+
+
 @router.post(
     "/me/agents/provision",
     status_code=201,
@@ -2231,6 +2296,16 @@ async def provision_agent(
                 "daemon_message": message,
             },
         )
+
+    _mark_daemon_runtime_snapshot_bound(
+        instance,
+        runtime=runtime,
+        agent_id=agent.agent_id,
+        display_name=agent.display_name,
+        openclaw_gateway=body.openclaw_gateway,
+        openclaw_agent=body.openclaw_agent,
+        hermes_profile=body.hermes_profile,
+    )
 
     await db.commit()
     await db.refresh(agent)

--- a/backend/tests/test_app/test_agent_provision.py
+++ b/backend/tests/test_app/test_agent_provision.py
@@ -267,6 +267,125 @@ async def test_provision_happy_path_writes_runtime_and_dispatches_frame(
         await registry.unregister(conn)
 
 
+@pytest.mark.asyncio
+async def test_provision_marks_openclaw_profile_bound_in_cached_snapshot(
+    client: AsyncClient, seed_user, db_session: AsyncSession
+):
+    instance_id = await _provision_instance(client, seed_user)
+    conn, fake_ws, registry = await _with_connected_daemon(
+        instance_id,
+        seed_user["user_id"],
+        runtimes_snapshot=[
+            {
+                "id": "openclaw-acp",
+                "available": True,
+                "endpoints": [
+                    {
+                        "name": "local",
+                        "url": "ws://127.0.0.1:18789",
+                        "reachable": True,
+                        "agents": [{"id": "pm"}, {"id": "swe", "name": "SWE"}],
+                    }
+                ],
+            }
+        ],
+        db_session=db_session,
+    )
+    try:
+        ack_task = asyncio.create_task(_auto_ack(conn, fake_ws))
+        r = await client.post(
+            "/api/users/me/agents/provision",
+            json={
+                "daemon_instance_id": instance_id,
+                "label": "writer",
+                "runtime": "openclaw-acp",
+                "openclaw_gateway": "local",
+                "openclaw_agent": "swe",
+            },
+            headers={"Authorization": f"Bearer {seed_user['token']}"},
+        )
+        await ack_task
+        assert r.status_code == 201, r.text
+        agent_id = r.json()["agent_id"]
+
+        await db_session.commit()
+        res = await db_session.execute(
+            select(DaemonInstance).where(DaemonInstance.id == instance_id)
+        )
+        inst = res.scalar_one()
+        runtimes = inst.runtimes_json
+        if isinstance(runtimes, str):
+            runtimes = json.loads(runtimes)
+        agents = runtimes[0]["endpoints"][0]["agents"]
+        assert agents == [
+            {"id": "pm"},
+            {
+                "id": "swe",
+                "name": "SWE",
+                "botcordBinding": {"agentId": agent_id},
+            },
+        ]
+    finally:
+        await registry.unregister(conn)
+
+
+@pytest.mark.asyncio
+async def test_provision_marks_hermes_profile_occupied_in_cached_snapshot(
+    client: AsyncClient, seed_user, db_session: AsyncSession
+):
+    instance_id = await _provision_instance(client, seed_user)
+    conn, fake_ws, registry = await _with_connected_daemon(
+        instance_id,
+        seed_user["user_id"],
+        runtimes_snapshot=[
+            {
+                "id": "hermes-agent",
+                "available": True,
+                "profiles": [
+                    {"name": "coder", "home": "/tmp/hermes/coder"},
+                    {"name": "reviewer", "home": "/tmp/hermes/reviewer"},
+                ],
+            }
+        ],
+        db_session=db_session,
+    )
+    try:
+        ack_task = asyncio.create_task(_auto_ack(conn, fake_ws))
+        r = await client.post(
+            "/api/users/me/agents/provision",
+            json={
+                "daemon_instance_id": instance_id,
+                "label": "writer",
+                "runtime": "hermes-agent",
+                "hermes_profile": "coder",
+            },
+            headers={"Authorization": f"Bearer {seed_user['token']}"},
+        )
+        await ack_task
+        assert r.status_code == 201, r.text
+        agent_id = r.json()["agent_id"]
+
+        await db_session.commit()
+        res = await db_session.execute(
+            select(DaemonInstance).where(DaemonInstance.id == instance_id)
+        )
+        inst = res.scalar_one()
+        runtimes = inst.runtimes_json
+        if isinstance(runtimes, str):
+            runtimes = json.loads(runtimes)
+        assert runtimes[0]["profiles"] == [
+            {
+                "name": "coder",
+                "home": "/tmp/hermes/coder",
+                "occupiedBy": agent_id,
+                "occupiedByName": "writer",
+            },
+            {"name": "reviewer", "home": "/tmp/hermes/reviewer"},
+        ]
+    finally:
+        await registry.unregister(conn)
+
+
 # ---------------------------------------------------------------------------
 # Failure cases
 # ---------------------------------------------------------------------------

--- a/frontend/src/store/useDaemonStore.ts
+++ b/frontend/src/store/useDaemonStore.ts
@@ -322,6 +322,61 @@ function normalizeDaemon(raw: Record<string, unknown>): DaemonInstance {
   };
 }
 
+function markRuntimeSelectionBound(
+  daemons: DaemonInstance[],
+  daemonId: string,
+  input: ProvisionAgentInput,
+  agentId: string,
+): DaemonInstance[] {
+  if (input.runtime !== "openclaw-acp" && input.runtime !== "hermes-agent") {
+    return daemons;
+  }
+
+  return daemons.map((daemon) => {
+    if (daemon.id !== daemonId || !daemon.runtimes) return daemon;
+    let changed = false;
+    const runtimes = daemon.runtimes.map((runtime) => {
+      if (runtime.id !== input.runtime) return runtime;
+
+      if (
+        input.runtime === "openclaw-acp" &&
+        input.openclawGateway &&
+        input.openclawAgent &&
+        runtime.endpoints
+      ) {
+        const endpoints = runtime.endpoints.map((endpoint) => {
+          if (endpoint.name !== input.openclawGateway || !endpoint.agents) {
+            return endpoint;
+          }
+          const agents = endpoint.agents.map((profile) => {
+            if (profile.id !== input.openclawAgent) return profile;
+            changed = true;
+            return { ...profile, botcordBinding: { agentId } };
+          });
+          return { ...endpoint, agents };
+        });
+        return { ...runtime, endpoints };
+      }
+
+      if (input.runtime === "hermes-agent" && input.hermesProfile && runtime.profiles) {
+        const profiles = runtime.profiles.map((profile) => {
+          if (profile.name !== input.hermesProfile) return profile;
+          changed = true;
+          return {
+            ...profile,
+            occupiedBy: agentId,
+            occupiedByName: input.name.trim() || agentId,
+          };
+        });
+        return { ...runtime, profiles };
+      }
+
+      return runtime;
+    });
+    return changed ? { ...daemon, runtimes } : daemon;
+  });
+}
+
 export const useDaemonStore = create<DaemonState>()((set, get) => ({
   ...initialState,
 
@@ -548,6 +603,9 @@ export const useDaemonStore = create<DaemonState>()((set, get) => ({
     if (!agentId) {
       throw new ProvisionAgentError("missing_agent_id");
     }
+    set((state) => ({
+      daemons: markRuntimeSelectionBound(state.daemons, daemonId, input, agentId),
+    }));
     return { agentId };
   },
 


### PR DESCRIPTION
## Summary
- patch cached daemon runtime snapshots after successful daemon agent provisioning
- mark OpenClaw agent profiles and Hermes profiles as bound without requiring manual runtime refresh
- update frontend daemon store optimistically after provision success

## Tests
- cd backend && uv run pytest tests/test_app/test_agent_provision.py
- cd frontend && NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build
- git diff --check