### PR TITLE
fix: make OpenClaw auto-provision opt-in

### DIFF
--- a/docs/openclaw-discovery.md
+++ b/docs/openclaw-discovery.md
@@ -160,7 +160,7 @@ openclawDiscovery?: {
   enabled?: boolean;        // 默认 true
   searchPaths?: string[];   // 覆盖默认搜索路径
   defaultPorts?: number[];  // 覆盖默认探测端口
-  autoProvision?: boolean;  // 默认 true；false 时仅写入 gateway，不自动接入 agent
+  autoProvision?: boolean;  // 默认 false；true 时才自动接入 agent
 };
 ```
 

--- a/packages/daemon/src/__tests__/openclaw-discovery.test.ts
+++ b/packages/daemon/src/__tests__/openclaw-discovery.test.ts
@@ -8,6 +8,8 @@ import {
   defaultOpenclawDiscoveryTokenFilePaths,
   discoverLocalOpenclawGateways,
   mergeOpenclawGateways,
+  openclawAutoProvisionEnabled,
+  openclawDiscoveryConfigEnabled,
 } from "../openclaw-discovery.js";
 import type { DaemonConfig } from "../config.js";
 import type { WsEndpointProbeFn } from "../provision.js";
@@ -31,6 +33,40 @@ function baseConfig(): DaemonConfig {
     streamBlocks: true,
   };
 }
+
+describe("openclaw discovery config flags", () => {
+  it("keeps gateway discovery enabled by default", () => {
+    expect(openclawDiscoveryConfigEnabled(baseConfig())).toBe(true);
+    expect(
+      openclawDiscoveryConfigEnabled({
+        ...baseConfig(),
+        openclawDiscovery: { enabled: false },
+      }),
+    ).toBe(false);
+  });
+
+  it("requires explicit opt-in for OpenClaw auto-provision", () => {
+    expect(openclawAutoProvisionEnabled(baseConfig())).toBe(false);
+    expect(
+      openclawAutoProvisionEnabled({
+        ...baseConfig(),
+        openclawDiscovery: {},
+      }),
+    ).toBe(false);
+    expect(
+      openclawAutoProvisionEnabled({
+        ...baseConfig(),
+        openclawDiscovery: { autoProvision: true },
+      }),
+    ).toBe(true);
+    expect(
+      openclawAutoProvisionEnabled({
+        ...baseConfig(),
+        openclawDiscovery: { autoProvision: false },
+      }),
+    ).toBe(false);
+  });
+});
 
 describe("discoverLocalOpenclawGateways", () => {
   it("discovers JSON and TOML acp config files", async () => {

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -95,7 +95,7 @@ export interface OpenclawDiscoveryConfig {
   searchPaths?: string[];
   /** Overrides the local loopback ports to probe. */
   defaultPorts?: number[];
-  /** Defaults to true. When false, discovery only persists gateways. */
+  /** Defaults to false. When false, discovery only persists gateways. */
   autoProvision?: boolean;
 }
 

--- a/packages/daemon/src/openclaw-discovery.ts
+++ b/packages/daemon/src/openclaw-discovery.ts
@@ -525,5 +525,5 @@ export function openclawDiscoveryConfigEnabled(cfg: DaemonConfig): boolean {
 }
 
 export function openclawAutoProvisionEnabled(cfg: DaemonConfig): boolean {
-  return cfg.openclawDiscovery?.autoProvision !== false;
+  return cfg.openclawDiscovery?.autoProvision === true;
 }


### PR DESCRIPTION
## Summary
- make OpenClaw auto-provision require explicit `openclawDiscovery.autoProvision: true`
- keep gateway discovery enabled by default
- document the new default and add config flag coverage

## Tests
- `cd packages/daemon && npm test -- openclaw-discovery.test.ts`

## Notes
- `cd packages/daemon && npx tsc -p tsconfig.build.json --noEmit` still fails on existing Hermes type errors unrelated to this change.