### PR TITLE
fix: filter OpenClaw reasoning from chat stream

### DIFF
--- a/frontend/src/components/dashboard/StreamBlocksView.tsx
+++ b/frontend/src/components/dashboard/StreamBlocksView.tsx
@@ -50,9 +50,51 @@ interface BlockView {
   resultStr?: string;
   reasoningText?: string;
   systemLabel?: string;
+  systemDetails?: string;
   errorText?: string;
   todoItems?: Array<{ text: string; status?: string }>;
   rawKind: string;
+}
+
+function stringifyDetails(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value == null) return "";
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function extractContentText(content: unknown): string {
+  if (!content) return "";
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content.map(extractContentText).filter(Boolean).join("\n");
+  }
+  if (typeof content === "object") {
+    const c = content as any;
+    if (typeof c.text === "string") return c.text;
+    if (typeof c.thinking === "string") return c.thinking;
+    if (typeof c.content === "string") return c.content;
+    if (Array.isArray(c.content)) return extractContentText(c.content);
+  }
+  return "";
+}
+
+function blockDetails(raw: unknown, payload?: Record<string, unknown>): string {
+  const payloadDetails = stringifyDetails(payload?.details);
+  if (payloadDetails) return payloadDetails;
+  const rawAny = raw as any;
+  const direct =
+    typeof rawAny?.text === "string" ? rawAny.text
+    : typeof rawAny?.message === "string" ? rawAny.message
+    : typeof rawAny?.summary === "string" ? rawAny.summary
+    : "";
+  if (direct) return direct;
+  const contentText = extractContentText(rawAny?.content ?? rawAny?.message?.content ?? rawAny?.params?.update?.content);
+  if (contentText) return contentText;
+  return raw ? stringifyDetails(raw) : payload ? stringifyDetails(payload) : "";
 }
 
 /** Build a `tool_use_id → name` map by walking all blocks. Claude-code's
@@ -99,8 +141,17 @@ function normalizeBlock(
   if (kind === "reasoning") {
     return {
       kind: "reasoning",
-      reasoningText: (payload?.text as string) || "",
+      reasoningText: (payload?.text as string) || blockDetails(raw, payload),
       rawKind: kind,
+    };
+  }
+  if (kind === "thinking") {
+    const phase = typeof payload?.phase === "string" ? payload.phase : undefined;
+    const label = typeof payload?.label === "string" ? payload.label : undefined;
+    return {
+      kind: "reasoning",
+      reasoningText: blockDetails(raw, payload),
+      rawKind: label || (phase ? `thinking: ${phase}` : "thinking"),
     };
   }
 
@@ -168,11 +219,13 @@ function normalizeBlock(
     // Codex thread.started / turn.started / turn.completed; Claude-code system init.
     const type = rawAny?.type as string | undefined;
     const subtype = rawAny?.subtype as string | undefined;
+    const payloadSubtype = payload?.subtype as string | undefined;
     const turnStatus = rawAny?.turn?.status as string | undefined;
     let label = type || "system";
     if (type === "system" && subtype) label = `system: ${subtype}`;
+    else if (!type && payloadSubtype) label = `system: ${payloadSubtype}`;
     else if (type === "turn.completed" && turnStatus) label = `turn ${turnStatus}`;
-    return { kind: "system", systemLabel: label, rawKind: label };
+    return { kind: "system", systemLabel: label, systemDetails: blockDetails(raw, payload), rawKind: label };
   }
 
   // `other` — try to extract something useful from the raw event so users
@@ -286,12 +339,29 @@ function StreamBlockItem({
   }
 
   if (view.kind === "reasoning") {
+    const text = view.reasoningText || "";
     return (
-      <div className="flex items-start gap-2 py-1">
-        <Brain className="w-3 h-3 text-purple-400 shrink-0 mt-0.5" />
-        <p className="text-xs text-purple-300/70 italic leading-relaxed line-clamp-3">
-          {view.reasoningText || ""}
-        </p>
+      <div className="py-1">
+        <button
+          onClick={() => text && setResultExpanded(!resultExpanded)}
+          className="flex items-center gap-2 group"
+        >
+          <Brain className="w-3 h-3 text-purple-400 shrink-0" />
+          <span className="text-xs font-mono text-purple-300/80">{view.rawKind || "thinking"}</span>
+          {text && (
+            resultExpanded
+              ? <ChevronDown className="w-2.5 h-2.5 text-zinc-500" />
+              : <ChevronRight className="w-2.5 h-2.5 text-zinc-500" />
+          )}
+        </button>
+        {text && !resultExpanded && (
+          <p className="mt-0.5 ml-5 text-[10px] text-purple-300/60 italic leading-relaxed line-clamp-2">
+            {summarizeResult(text)}
+          </p>
+        )}
+        {text && resultExpanded && (
+          <ToolResultContent result={text} toolName={view.rawKind || "thinking"} />
+        )}
       </div>
     );
   }
@@ -338,10 +408,29 @@ function StreamBlockItem({
   }
 
   if (view.kind === "system") {
+    const details = view.systemDetails || "";
     return (
-      <div className="flex items-center gap-2 py-1">
-        <Info className="w-3 h-3 text-zinc-500 shrink-0" />
-        <span className="text-xs text-zinc-500 font-mono">{view.systemLabel || view.rawKind}</span>
+      <div className="py-1">
+        <button
+          onClick={() => details && setResultExpanded(!resultExpanded)}
+          className="flex items-center gap-2 group"
+        >
+          <Info className="w-3 h-3 text-zinc-500 shrink-0" />
+          <span className="text-xs text-zinc-500 font-mono">{view.systemLabel || view.rawKind}</span>
+          {details && (
+            resultExpanded
+              ? <ChevronDown className="w-2.5 h-2.5 text-zinc-500" />
+              : <ChevronRight className="w-2.5 h-2.5 text-zinc-500" />
+          )}
+        </button>
+        {details && !resultExpanded && (
+          <p className="mt-0.5 ml-5 text-[10px] text-zinc-500 truncate max-w-[400px]">
+            {summarizeResult(details)}
+          </p>
+        )}
+        {details && resultExpanded && (
+          <ToolResultContent result={details} toolName={view.systemLabel || view.rawKind} />
+        )}
       </div>
     );
   }

--- a/packages/daemon/src/__tests__/openclaw-acp.test.ts
+++ b/packages/daemon/src/__tests__/openclaw-acp.test.ts
@@ -162,6 +162,69 @@ describe("OpenclawAcpAdapter.run", () => {
     expect(spawnFn.mock.calls[0][1]).toEqual(["acp", "--url", "ws://127.0.0.1:1"]);
   });
 
+  it("streams only final text when OpenClaw sends reasoning before a final block", async () => {
+    const child = new FakeChild();
+    const adapter = new OpenclawAcpAdapter({ spawnFn: makeSpawn(child) });
+    const gateway: ResolvedOpenclawGateway = {
+      name: "local",
+      url: "ws://127.0.0.1:1",
+      openclawAgent: "main",
+    };
+
+    child.stdin.on("data", (chunk: Buffer) => {
+      for (const line of chunk.toString("utf8").split("\n").filter(Boolean)) {
+        const frame = JSON.parse(line);
+        if (frame.method === "initialize") {
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { protocolVersion: 1 } }) + "\n");
+        } else if (frame.method === "session/new") {
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { sessionId: "sid-final" } }) + "\n");
+        } else if (frame.method === "session/prompt") {
+          for (const text of [
+            "The user is asking for my location. I need to check it. ",
+            "<fin",
+            "al>The answer is Council Bluffs.",
+            "</final>",
+          ]) {
+            child.stdout.write(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                method: "session/update",
+                params: {
+                  sessionId: "sid-final",
+                  update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text } },
+                },
+              }) + "\n",
+            );
+          }
+          child.stdout.write(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: frame.id,
+              result: { text: "The user is asking for my location. I need to check it." },
+            }) + "\n",
+          );
+        }
+      }
+    });
+
+    const blocks: any[] = [];
+    const res = await adapter.run({
+      text: "what's your current location",
+      sessionId: null,
+      cwd: "/tmp",
+      accountId: "ag_alice",
+      signal: new AbortController().signal,
+      trustLevel: "owner",
+      gateway,
+      onBlock: (b) => blocks.push(b),
+    });
+
+    expect(res.text).toBe("The answer is Council Bluffs.");
+    expect(blocks.filter((b) => b.kind === "assistant_text").map((b) => b.raw.params.update.content[0].text).join("")).toBe(
+      "The answer is Council Bluffs.",
+    );
+  });
+
   it("respawns the pooled child when gateway.url or gateway.token changes under the same name", async () => {
     function newChild(): FakeChild {
       const c = new FakeChild();

--- a/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
+++ b/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
@@ -648,7 +648,7 @@ describe("createBotCordChannel — streamBlock()", () => {
       expect(body.block).toEqual({
         kind: "thinking",
         seq: 7,
-        payload: { phase: "updated", label: "Searching web", source: "runtime" },
+        payload: { phase: "updated", label: "Searching web", source: "runtime", details: "Searching web" },
       });
     } finally {
       globalThis.fetch = realFetch;

--- a/packages/daemon/src/gateway/channels/botcord.ts
+++ b/packages/daemon/src/gateway/channels/botcord.ts
@@ -955,6 +955,7 @@ function normalizeBlockForHub(
     if (typeof raw?.subtype === "string") payload.subtype = raw.subtype;
     if (typeof raw?.session_id === "string") payload.session_id = raw.session_id;
     if (typeof raw?.model === "string") payload.model = raw.model;
+    payload.details = formatBlockDetails(raw);
     return { kind: "system", seq, payload };
   }
 
@@ -966,6 +967,7 @@ function normalizeBlockForHub(
     if (typeof raw?.phase === "string") payload.phase = raw.phase;
     if (typeof raw?.label === "string") payload.label = raw.label;
     if (typeof raw?.source === "string") payload.source = raw.source;
+    payload.details = formatBlockDetails(raw);
     return { kind: "thinking", seq, payload };
   }
 
@@ -976,4 +978,41 @@ function normalizeBlockForHub(
     if (typeof raw.total_cost_usd === "number") payload.total_cost_usd = raw.total_cost_usd;
   }
   return { kind: "other", seq, payload };
+}
+
+function formatBlockDetails(raw: unknown): string {
+  if (!raw || typeof raw !== "object") return "";
+  const r = raw as any;
+  const direct =
+    typeof r.text === "string" ? r.text
+    : typeof r.message === "string" ? r.message
+    : typeof r.summary === "string" ? r.summary
+    : typeof r.label === "string" ? r.label
+    : "";
+  if (direct) return direct;
+
+  const contentText = extractContentText(r.content ?? r.message?.content ?? r.params?.update?.content);
+  if (contentText) return contentText;
+
+  try {
+    return JSON.stringify(raw, null, 2);
+  } catch {
+    return String(raw);
+  }
+}
+
+function extractContentText(content: unknown): string {
+  if (!content) return "";
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content.map(extractContentText).filter(Boolean).join("\n");
+  }
+  if (typeof content === "object") {
+    const c = content as any;
+    if (typeof c.text === "string") return c.text;
+    if (typeof c.thinking === "string") return c.thinking;
+    if (typeof c.content === "string") return c.content;
+    if (Array.isArray(c.content)) return extractContentText(c.content);
+  }
+  return "";
 }

--- a/packages/daemon/src/gateway/runtimes/openclaw-acp.ts
+++ b/packages/daemon/src/gateway/runtimes/openclaw-acp.ts
@@ -200,6 +200,7 @@ export class OpenclawAcpAdapter implements RuntimeAdapter {
     let assistantBytes = 0;
     let capped = false;
     let finalText = "";
+    const assistantTextFilter = createAssistantTextFilter();
 
     const emitBlock = (block: StreamBlock): void => {
       try {
@@ -212,14 +213,9 @@ export class OpenclawAcpAdapter implements RuntimeAdapter {
     };
 
     const onNotification = (note: AcpNotification): void => {
-      seq += 1;
-      // Forward raw notification as a stream block for downstream visibility.
-      const kind = classifyAcpUpdate(note);
-      emitBlock({ raw: note, kind, seq });
-
       const update = note.params?.update;
       if (update?.sessionUpdate === "agent_message_chunk") {
-        const text = extractText(update.content);
+        const text = assistantTextFilter.push(extractText(update.content));
         if (text && !capped) {
           const bytes = Buffer.byteLength(text, "utf8");
           if (assistantBytes + bytes > ASSISTANT_TEXT_CAP) {
@@ -229,7 +225,16 @@ export class OpenclawAcpAdapter implements RuntimeAdapter {
             assistantBytes += bytes;
           }
         }
+        if (!text) return;
+        seq += 1;
+        emitBlock({ raw: sanitizeAssistantChunk(note, text), kind: "assistant_text", seq });
+        return;
       }
+
+      seq += 1;
+      // Forward raw non-assistant notifications as stream blocks for downstream visibility.
+      const kind = classifyAcpUpdate(note);
+      emitBlock({ raw: note, kind, seq });
     };
 
     let abortListener: (() => void) | undefined;
@@ -322,7 +327,29 @@ export class OpenclawAcpAdapter implements RuntimeAdapter {
       // OpenClaw's prompt response shape isn't strictly fixed; pull a final
       // text out of common locations and otherwise fall back to the streamed
       // chunks accumulated above.
-      finalText = pickFinalText(promptResult) ?? assistantText;
+      const tailText = assistantTextFilter.flush();
+      if (tailText && !capped) {
+        const bytes = Buffer.byteLength(tailText, "utf8");
+        if (assistantBytes + bytes <= ASSISTANT_TEXT_CAP) {
+          assistantText += tailText;
+          assistantBytes += bytes;
+          seq += 1;
+          emitBlock({
+            raw: {
+              method: "session/update",
+              params: {
+                sessionId: acpSessionId,
+                update: { sessionUpdate: "agent_message_chunk", content: [{ type: "text", text: tailText }] },
+              },
+            },
+            kind: "assistant_text",
+            seq,
+          });
+        }
+      }
+      const pickedText = normalizeAssistantText(pickFinalText(promptResult));
+      const streamedText = normalizeAssistantText(assistantText);
+      finalText = pickedText && !looksLikeReasoningLeak(pickedText) ? pickedText : streamedText;
 
       if (capped) {
         log.warn("openclaw-acp.assistant-text-capped", { sessionId: acpSessionId });
@@ -639,6 +666,8 @@ function extractText(content: unknown): string {
   }
   if (typeof content === "object") {
     const c = content as Record<string, unknown>;
+    const type = typeof c.type === "string" ? c.type.toLowerCase() : "";
+    if (type === "thinking" || type === "reasoning" || type === "thought") return "";
     if (typeof c.text === "string") return c.text;
     if (typeof c.content === "string") return c.content;
     if (Array.isArray(c.content)) return extractText(c.content);
@@ -646,12 +675,187 @@ function extractText(content: unknown): string {
   return "";
 }
 
+function sanitizeAssistantChunk(note: AcpNotification, text: string): AcpNotification {
+  return {
+    ...note,
+    params: {
+      ...note.params,
+      update: {
+        ...note.params?.update,
+        content: [{ type: "text", text }],
+      },
+    },
+  };
+}
+
+function normalizeAssistantText(text: string | undefined): string {
+  if (!text) return "";
+  const finalMatch = text.match(/<final>([\s\S]*?)<\/final>/i);
+  const selected = finalMatch ? finalMatch[1] : text;
+  if (!finalMatch && selected.trimStart().toLowerCase().startsWith("<think")) {
+    return "";
+  }
+  return selected
+    .replace(/<think[^>]*>[\s\S]*?<\/think>/gi, "")
+    .replace(/<\/?final>/gi, "")
+    .trim();
+}
+
+function createAssistantTextFilter(): {
+  push(text: string): string;
+  flush(): string;
+} {
+  let pending = "";
+  let inThink = false;
+  let inFinal = false;
+  let seenFinal = false;
+  let fallback = "";
+
+  const consume = (flush: boolean): string => {
+    let out = "";
+    while (pending.length > 0) {
+      if (inThink) {
+        const close = pending.search(/<\/think>/i);
+        if (close === -1) {
+          if (flush) pending = "";
+          return out;
+        }
+        pending = pending.slice(close).replace(/^<\/think>/i, "");
+        inThink = false;
+        continue;
+      }
+      if (inFinal) {
+        const close = pending.search(/<\/final>/i);
+        if (close === -1) {
+          out += pending;
+          pending = "";
+          return out;
+        }
+        out += pending.slice(0, close);
+        pending = pending.slice(close).replace(/^<\/final>/i, "");
+        inFinal = false;
+        continue;
+      }
+
+      const lt = pending.indexOf("<");
+      if (lt === -1) {
+        if (seenFinal) {
+          out += pending;
+        } else {
+          fallback += pending;
+        }
+        pending = "";
+        return out;
+      }
+
+      if (lt > 0) {
+        if (seenFinal) {
+          out += pending.slice(0, lt);
+        } else {
+          fallback += pending.slice(0, lt);
+        }
+        pending = pending.slice(lt);
+        continue;
+      }
+
+      const lower = pending.toLowerCase();
+      if (lower.startsWith("<think")) {
+        const end = pending.indexOf(">");
+        if (end === -1) {
+          if (flush) pending = "";
+          return out;
+        }
+        pending = pending.slice(end + 1);
+        inThink = true;
+        continue;
+      }
+      if (lower.startsWith("</think")) {
+        const end = pending.indexOf(">");
+        if (end === -1) {
+          if (flush) pending = "";
+          return out;
+        }
+        pending = pending.slice(end + 1);
+        continue;
+      }
+      if (lower.startsWith("<final")) {
+        const end = pending.indexOf(">");
+        if (end === -1) {
+          if (flush) pending = "";
+          return out;
+        }
+        pending = pending.slice(end + 1);
+        seenFinal = true;
+        fallback = "";
+        inFinal = true;
+        continue;
+      }
+      if (lower.startsWith("</final")) {
+        const end = pending.indexOf(">");
+        if (end === -1) {
+          if (flush) pending = "";
+          return out;
+        }
+        pending = pending.slice(end + 1);
+        inFinal = false;
+        continue;
+      }
+
+      const knownPrefixes = ["<think", "</think", "<final", "</final"];
+      if (!flush && knownPrefixes.some((prefix) => prefix.startsWith(lower))) {
+        return out;
+      }
+
+      out += "<";
+      pending = pending.slice(1);
+    }
+    if (flush && !seenFinal && fallback) {
+      const text = normalizeAssistantText(fallback);
+      fallback = "";
+      if (!looksLikeReasoningLeak(text)) return text;
+    }
+    return out;
+  };
+
+  return {
+    push(text: string): string {
+      if (!text) return "";
+      pending += text;
+      return consume(false);
+    },
+    flush(): string {
+      return consume(true);
+    },
+  };
+}
+
 function pickFinalText(result: unknown): string | undefined {
   if (!result || typeof result !== "object") return undefined;
   const r = result as Record<string, unknown>;
+  if (Array.isArray(r.assistantTexts)) {
+    const text = r.assistantTexts.filter((x): x is string => typeof x === "string").join("\n");
+    if (text.length > 0) return text;
+  }
+  const contentText = extractText(r.content);
+  if (contentText.length > 0) return contentText;
+  const outputText = extractText(r.output);
+  if (outputText.length > 0) return outputText;
+  const responseText = extractText(r.response);
+  if (responseText.length > 0) return responseText;
   if (typeof r.text === "string" && r.text.length > 0) return r.text;
   if (typeof r.message === "string" && r.message.length > 0) return r.message;
   return undefined;
+}
+
+function looksLikeReasoningLeak(text: string): boolean {
+  const t = text.trim();
+  if (!t) return false;
+  return (
+    /^the user (said|asked|wants|is asking)\b/i.test(t) ||
+    /^i('|’)m .*\b(i('|’)ll|i will|need to|should|going to)\b/i.test(t) ||
+    /\bi('|’)ll respond\b/i.test(t) ||
+    /\bi need to\b/i.test(t)
+  );
 }
 
 function stringField(bag: Record<string, unknown> | undefined, key: string): string | undefined {

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -1556,10 +1556,15 @@ function readLocalOpenclawAgents(): Array<{
 }> | null {
   try {
     const file = path.join(homedir(), ".openclaw", "openclaw.json");
-    if (!existsSync(file)) return [{ id: "default" }];
+    if (!existsSync(file)) return readLocalOpenclawAgentDirs() ?? [{ id: "default" }];
     const cfg = JSON.parse(readFileSync(file, "utf8")) as any;
     const list = Array.isArray(cfg?.agents?.list) ? cfg.agents.list : [];
-    const defaultId = typeof cfg?.agents?.defaults?.id === "string" ? cfg.agents.defaults.id : "default";
+    const explicitDefaultId =
+      typeof cfg?.agents?.defaults?.id === "string" && cfg.agents.defaults.id
+        ? cfg.agents.defaults.id
+        : null;
+    const dirAgents = readLocalOpenclawAgentDirs();
+    const defaultId = explicitDefaultId ?? (list.length === 0 && !dirAgents ? "default" : null);
     const seen = new Set<string>();
     const out: Array<{ id: string; name?: string; workspace?: string; model?: { name?: string; provider?: string } }> = [];
     const push = (raw: any, fallbackId?: string): void => {
@@ -1581,10 +1586,36 @@ function readLocalOpenclawAgents(): Array<{
       }
       out.push(row);
     };
-    // Default agent first so it surfaces at the top of the dropdown.
-    push({ id: defaultId, workspace: cfg?.agents?.defaults?.workspace, model: cfg?.agents?.defaults?.model }, defaultId);
+    // Explicit default agent first so it surfaces at the top of the dropdown.
+    if (defaultId) push({ id: defaultId, workspace: cfg?.agents?.defaults?.workspace, model: cfg?.agents?.defaults?.model }, defaultId);
     for (const entry of list) push(entry);
+    for (const entry of dirAgents ?? []) push(entry);
     return out;
+  } catch {
+    return null;
+  }
+}
+
+function readLocalOpenclawAgentDirs(): Array<{
+  id: string;
+  workspace?: string;
+}> | null {
+  try {
+    const dir = path.join(homedir(), ".openclaw", "agents");
+    if (!existsSync(dir)) return null;
+    const agents = readdirSync(dir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && entry.name.length > 0)
+      .map((entry) => ({
+        id: entry.name,
+        workspace: path.join(dir, entry.name),
+      }));
+    if (agents.length === 0) return null;
+    agents.sort((a, b) => {
+      if (a.id === "main") return -1;
+      if (b.id === "main") return 1;
+      return a.id.localeCompare(b.id);
+    });
+    return agents;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- filter OpenClaw ACP assistant chunks so reasoning/thinking text does not leak into chat replies
- prefer structured/final assistant text and handle split <final> tags across streamed chunks
- include system/thinking stream details and render them expandable like tool results in the dashboard
- discover OpenClaw agent directories when openclaw.json is absent so profiles like main are surfaced

## Tests
- npm test -- openclaw-acp.test.ts botcord-channel.test.ts
- NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build