### PR TITLE
fix(frontend): channels tab infinite render (React #185)

### DIFF
--- a/frontend/src/components/dashboard/AgentChannelsTab.tsx
+++ b/frontend/src/components/dashboard/AgentChannelsTab.tsx
@@ -60,13 +60,18 @@ function providerName(provider: GatewayProvider): string {
   return provider === "telegram" ? "Telegram" : "微信";
 }
 
+// Stable empty list reference — must live outside the component so selectors
+// don't return a fresh `[]` each render and trigger zustand's
+// useSyncExternalStore infinite-render guard (React #185).
+const EMPTY_LIST: AgentGatewayConnection[] = [];
+
 export default function AgentChannelsTab({ agentId }: Props) {
-  const list = useAgentGatewayStore((s) => s.byAgent[agentId] ?? []);
+  const list = useAgentGatewayStore((s) => s.byAgent[agentId]) ?? EMPTY_LIST;
   const loading = useAgentGatewayStore((s) => Boolean(s.loading[agentId]));
   const daemonOffline = useAgentGatewayStore((s) =>
     Boolean(s.daemonOffline[agentId]),
   );
-  const lastError = useAgentGatewayStore((s) => s.lastError[agentId] ?? null);
+  const lastError = useAgentGatewayStore((s) => s.lastError[agentId]) ?? null;
   const load = useAgentGatewayStore((s) => s.load);
   const enable = useAgentGatewayStore((s) => s.enable);
   const disable = useAgentGatewayStore((s) => s.disable);


### PR DESCRIPTION
## Summary

Clicking the **接入 / Channels** tab in `AgentSettingsDrawer` crashed the dashboard with the minified React error \`#185\` (\"Maximum update depth exceeded\").

Root cause: the zustand selector

\`\`\`tsx
const list = useAgentGatewayStore((s) => s.byAgent[agentId] ?? []);
\`\`\`

returns a brand-new \`[]\` reference on every render whenever the agent has no entry in \`byAgent\` yet. zustand's internal \`useSyncExternalStore\` reads the snapshot twice per render and treats the new array as a state change, triggering an infinite re-render loop the very first time the tab mounts (before \`load(agentId)\` resolves).

Same shape on \`lastError\`. Hoist a module-level \`EMPTY_LIST\` constant and apply the nullish-coalescing **outside** the selector so the selector itself returns either the stored array or \`undefined\` — both stable across renders.

## Test plan

- [ ] Open AgentSettingsDrawer, click \`接入\` — page no longer crashes; empty-state UI renders
- [ ] Bind a Telegram bot, refresh — list selector picks up the populated array
- [ ] Switch agents while the tab is open — no extra renders / no console warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)