### PR TITLE
feat: Remove Device flow with bot detach + local cleanup drain

### DIFF
--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -1248,6 +1248,18 @@ class DaemonInstance(Base):
     revoked_at: Mapped[datetime.datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    # Device-removal lifecycle. When `removal_requested_at` is set but
+    # `revoked_at` is null, the daemon is in "pending removal": bots have
+    # been detached but local cleanup is still draining (the device may be
+    # offline). Once cleanup completes we stamp `cleanup_completed_at` and
+    # finalize via `revoked_at`.
+    removal_requested_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    removal_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    cleanup_completed_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     # Latest runtime-discovery snapshot pushed by the daemon (or pulled via
     # list_runtimes). `runtimes_json` mirrors the protocol `runtimes` array;
     # `runtimes_probed_at` is the daemon-side probe wall-clock in UTC.

--- a/backend/hub/routers/daemon_control.py
+++ b/backend/hub/routers/daemon_control.py
@@ -38,7 +38,7 @@ from fastapi import (
 )
 from nacl.signing import SigningKey
 from pydantic import BaseModel, Field
-from sqlalchemy import select
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import RequestContext, require_user
@@ -519,9 +519,36 @@ class _InstanceView(BaseModel):
     created_at: datetime.datetime
     last_seen_at: datetime.datetime | None = None
     revoked_at: datetime.datetime | None = None
+    removal_requested_at: datetime.datetime | None = None
+    cleanup_completed_at: datetime.datetime | None = None
+    status: str
     online: bool
     runtimes: list[dict[str, Any]] | None = None
     runtimes_probed_at: datetime.datetime | None = None
+
+
+def _instance_status(instance: DaemonInstance) -> str:
+    if instance.revoked_at is not None:
+        return "revoked"
+    if instance.removal_requested_at is not None:
+        return "removal_pending"
+    return "active"
+
+
+def _instance_to_view(instance: DaemonInstance) -> _InstanceView:
+    return _InstanceView(
+        id=instance.id,
+        label=instance.label,
+        created_at=instance.created_at,
+        last_seen_at=instance.last_seen_at,
+        revoked_at=instance.revoked_at,
+        removal_requested_at=instance.removal_requested_at,
+        cleanup_completed_at=instance.cleanup_completed_at,
+        status=_instance_status(instance),
+        online=_REGISTRY.is_online(instance.id),
+        runtimes=instance.runtimes_json if instance.runtimes_json else None,
+        runtimes_probed_at=instance.runtimes_probed_at,
+    )
 
 
 class _InstancesResponse(BaseModel):
@@ -539,21 +566,7 @@ async def list_instances(
         .order_by(DaemonInstance.created_at.desc())
     )
     rows = result.scalars().all()
-    return _InstancesResponse(
-        instances=[
-            _InstanceView(
-                id=row.id,
-                label=row.label,
-                created_at=row.created_at,
-                last_seen_at=row.last_seen_at,
-                revoked_at=row.revoked_at,
-                online=_REGISTRY.is_online(row.id),
-                runtimes=row.runtimes_json if row.runtimes_json else None,
-                runtimes_probed_at=row.runtimes_probed_at,
-            )
-            for row in rows
-        ]
-    )
+    return _InstancesResponse(instances=[_instance_to_view(row) for row in rows])
 
 
 async def _load_owned_instance(
@@ -586,16 +599,34 @@ async def rename_instance(
     instance.label = new_label or None
     await db.commit()
     await db.refresh(instance)
-    return _InstanceView(
-        id=instance.id,
-        label=instance.label,
-        created_at=instance.created_at,
-        last_seen_at=instance.last_seen_at,
-        revoked_at=instance.revoked_at,
-        online=_REGISTRY.is_online(instance.id),
-        runtimes=instance.runtimes_json if instance.runtimes_json else None,
-        runtimes_probed_at=instance.runtimes_probed_at,
-    )
+    return _instance_to_view(instance)
+
+
+def _mark_instance_revoked(instance: DaemonInstance) -> None:
+    """Mutate ``instance`` to a terminal revoked state. Caller commits."""
+    if instance.revoked_at is None:
+        instance.revoked_at = _now()
+    # Burn the refresh hash so /refresh can never re-issue.
+    instance.refresh_token_hash = "revoked:" + secrets.token_hex(8)
+
+
+async def _push_daemon_revoke(daemon_instance_id: str, reason: str) -> bool:
+    """Send the daemon-level ``revoke`` frame and close the socket. Returns
+    True when a live websocket existed, False otherwise."""
+    conn = _REGISTRY.get(daemon_instance_id)
+    if conn is None:
+        return False
+    try:
+        frame = _build_signed_frame("revoke", {"reason": reason})
+        await conn.ws.send_text(json.dumps(frame))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("revoke push failed: %s", exc)
+    try:
+        await conn.ws.close(code=4403, reason="daemon revoked")
+    except Exception:
+        pass
+    await _REGISTRY.unregister(conn)
+    return True
 
 
 @router.post("/daemon/instances/{daemon_instance_id}/revoke")
@@ -606,26 +637,165 @@ async def revoke_instance(
 ) -> dict[str, Any]:
     instance = await _load_owned_instance(db, ctx.user_id, daemon_instance_id)
     if instance.revoked_at is None:
-        instance.revoked_at = _now()
-        # Burn the refresh hash so /refresh can never re-issue.
-        instance.refresh_token_hash = "revoked:" + secrets.token_hex(8)
+        _mark_instance_revoked(instance)
         await db.commit()
 
-    conn = _REGISTRY.get(daemon_instance_id)
-    was_online = conn is not None
-    if conn is not None:
-        try:
-            frame = _build_signed_frame("revoke", {"reason": "revoked_by_user"})
-            await conn.ws.send_text(json.dumps(frame))
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("revoke push failed: %s", exc)
-        try:
-            await conn.ws.close(code=4403, reason="daemon revoked")
-        except Exception:
-            pass
-        await _REGISTRY.unregister(conn)
-
+    was_online = await _push_daemon_revoke(daemon_instance_id, "revoked_by_user")
     return {"ok": True, "was_online": was_online}
+
+
+# ---------------------------------------------------------------------------
+# Device removal — detach hosted bots, drain local cleanup, then revoke.
+# ---------------------------------------------------------------------------
+
+
+class _RemoveInstanceRequest(BaseModel):
+    forget_if_offline: bool = False
+    reason: str | None = Field(default=None, max_length=200)
+
+
+class _RemovedAgentView(BaseModel):
+    agent_id: str
+    display_name: str | None = None
+
+
+class _RemoveInstanceResponse(BaseModel):
+    ok: bool
+    daemon_instance_id: str
+    status: str
+    was_online: bool
+    detached_agents: list[_RemovedAgentView]
+    cleanup_jobs_queued: int
+
+
+async def _detach_hosted_agents(
+    db: AsyncSession,
+    *,
+    daemon_instance_id: str,
+    user_id: _uuid.UUID,
+) -> tuple[list[Agent], int]:
+    """Detach all active user-owned agents from ``daemon_instance_id`` and
+    insert one pending ``DaemonAgentCleanup`` per agent (skipping any agent
+    that already has a pending cleanup row for this daemon)."""
+    result = await db.execute(
+        select(Agent).where(
+            Agent.user_id == user_id,
+            Agent.daemon_instance_id == daemon_instance_id,
+            Agent.status == "active",
+        )
+    )
+    agents = list(result.scalars().all())
+    if not agents:
+        return [], 0
+
+    existing = await db.execute(
+        select(DaemonAgentCleanup.agent_id).where(
+            DaemonAgentCleanup.daemon_instance_id == daemon_instance_id,
+            DaemonAgentCleanup.status == "pending",
+            DaemonAgentCleanup.agent_id.in_([a.agent_id for a in agents]),
+        )
+    )
+    pending_agent_ids = {row for row in existing.scalars().all()}
+
+    await db.execute(
+        update(Agent)
+        .where(Agent.agent_id.in_([a.agent_id for a in agents]))
+        .values(daemon_instance_id=None)
+    )
+    queued = 0
+    for agent in agents:
+        # Keep ORM state coherent with the bulk UPDATE so callers reading
+        # ``agent.daemon_instance_id`` see ``None`` without an extra refresh.
+        agent.daemon_instance_id = None
+        if agent.agent_id not in pending_agent_ids:
+            db.add(
+                DaemonAgentCleanup(
+                    daemon_instance_id=daemon_instance_id,
+                    agent_id=agent.agent_id,
+                    delete_credentials=True,
+                    delete_state=True,
+                    delete_workspace=False,
+                )
+            )
+            queued += 1
+    return agents, queued
+
+
+@router.post(
+    "/daemon/instances/{daemon_instance_id}/remove",
+    response_model=_RemoveInstanceResponse,
+)
+async def remove_instance(
+    daemon_instance_id: str,
+    body: _RemoveInstanceRequest,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+) -> _RemoveInstanceResponse:
+    """Remove a device: detach hosted bots, queue local cleanup, optionally
+    revoke immediately when offline-forget is requested."""
+    instance = await _load_owned_instance(db, ctx.user_id, daemon_instance_id)
+    if instance.revoked_at is not None:
+        # Already terminal — surface idempotent success.
+        return _RemoveInstanceResponse(
+            ok=True,
+            daemon_instance_id=instance.id,
+            status="revoked",
+            was_online=False,
+            detached_agents=[],
+            cleanup_jobs_queued=0,
+        )
+
+    online = _REGISTRY.is_online(daemon_instance_id)
+    detached, queued = await _detach_hosted_agents(
+        db, daemon_instance_id=daemon_instance_id, user_id=ctx.user_id
+    )
+
+    if instance.removal_requested_at is None:
+        instance.removal_requested_at = _now()
+    if body.reason:
+        instance.removal_reason = body.reason
+
+    forget = bool(body.forget_if_offline) and not online
+
+    if forget:
+        # Cancel any pending cleanup rows — they cannot ever drain.
+        pending_rows = (
+            await db.execute(
+                select(DaemonAgentCleanup).where(
+                    DaemonAgentCleanup.daemon_instance_id == daemon_instance_id,
+                    DaemonAgentCleanup.status == "pending",
+                )
+            )
+        ).scalars().all()
+        now = _now()
+        for row in pending_rows:
+            row.status = "cancelled"
+            row.completed_at = now
+            row.last_error = "device forgotten before local cleanup"
+        instance.cleanup_completed_at = now
+        _mark_instance_revoked(instance)
+
+    await db.commit()
+    await db.refresh(instance)
+
+    if forget:
+        await _push_daemon_revoke(daemon_instance_id, "removed_by_user")
+    elif online:
+        # Drain pending cleanup jobs immediately. If the drain finishes them
+        # all, the worker will finalize revoke at the tail.
+        schedule_pending_daemon_cleanups(daemon_instance_id)
+
+    return _RemoveInstanceResponse(
+        ok=True,
+        daemon_instance_id=instance.id,
+        status=_instance_status(instance),
+        was_online=online,
+        detached_agents=[
+            _RemovedAgentView(agent_id=a.agent_id, display_name=a.display_name)
+            for a in detached
+        ],
+        cleanup_jobs_queued=queued,
+    )
 
 
 _ALLOWED_DISPATCH_TYPES = {
@@ -710,10 +880,48 @@ async def _cleanup_still_applies(
     db: AsyncSession,
     cleanup: DaemonAgentCleanup,
 ) -> bool:
+    """A pending cleanup is still applicable as long as the agent is no
+    longer bound to *this specific daemon*. Covers both:
+
+    - **Unbind**: agent fully released (``user_id is None``,
+      ``daemon_instance_id is None``).
+    - **Device removal**: agent retains cloud ownership but was detached
+      from this daemon (``user_id`` set, ``daemon_instance_id`` is None or
+      points elsewhere).
+
+    Only when the agent re-bound to *this same daemon* before we drained do
+    we cancel the cleanup (sending ``revoke_agent`` would wipe live creds).
+    """
     agent = await db.scalar(select(Agent).where(Agent.agent_id == cleanup.agent_id))
     if agent is None:
         return True
-    return agent.user_id is None and agent.daemon_instance_id is None
+    return agent.daemon_instance_id != cleanup.daemon_instance_id
+
+
+async def _finalize_removal_if_drained(daemon_instance_id: str) -> bool:
+    """If the daemon is in pending-removal and no pending cleanup jobs remain,
+    stamp ``cleanup_completed_at`` + ``revoked_at``, burn the refresh hash,
+    and push a ``revoke`` frame. Returns True when finalization happened."""
+    async with async_session() as db:
+        instance = await db.get(DaemonInstance, daemon_instance_id)
+        if instance is None:
+            return False
+        if instance.removal_requested_at is None or instance.revoked_at is not None:
+            return False
+        count = await db.scalar(
+            select(func.count(DaemonAgentCleanup.id)).where(
+                DaemonAgentCleanup.daemon_instance_id == daemon_instance_id,
+                DaemonAgentCleanup.status == "pending",
+            )
+        )
+        if count and count > 0:
+            return False
+        instance.cleanup_completed_at = _now()
+        _mark_instance_revoked(instance)
+        await db.commit()
+
+    await _push_daemon_revoke(daemon_instance_id, "cleanup_completed")
+    return True
 
 
 async def process_pending_daemon_cleanups(daemon_instance_id: str) -> None:
@@ -778,6 +986,10 @@ async def process_pending_daemon_cleanups(daemon_instance_id: str) -> None:
             else:
                 current.last_error = _cleanup_error_message(ack if isinstance(ack, dict) else {})
             await db.commit()
+
+    # Finalize the device removal if the queue is now drained and the daemon
+    # was scheduled for removal. Safe no-op for plain agent unbinds.
+    await _finalize_removal_if_drained(daemon_instance_id)
 
 
 def schedule_pending_daemon_cleanups(daemon_instance_id: str) -> None:

--- a/backend/migrations/002_daemon_instances_removal.sql
+++ b/backend/migrations/002_daemon_instances_removal.sql
@@ -1,0 +1,15 @@
+-- Device removal lifecycle for daemon_instances.
+--
+-- `removal_requested_at` marks a device as scheduled for removal but still
+-- allowed to reconnect to drain pending local cleanup. `revoked_at` remains
+-- terminal; we only set it after cleanup drains (or when the user explicitly
+-- forgets an offline device).
+
+ALTER TABLE daemon_instances
+    ADD COLUMN IF NOT EXISTS removal_requested_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS removal_reason TEXT,
+    ADD COLUMN IF NOT EXISTS cleanup_completed_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS ix_daemon_instances_removal_pending
+    ON daemon_instances (user_id)
+    WHERE removal_requested_at IS NOT NULL AND revoked_at IS NULL;

--- a/backend/tests/test_app/test_app_user_agents.py
+++ b/backend/tests/test_app/test_app_user_agents.py
@@ -422,6 +422,17 @@ async def test_unbind_agent_skips_revoke_when_daemon_offline(
 async def test_pending_daemon_cleanup_cancelled_after_rebind(
     db_session: AsyncSession, db_engine, seed_user: dict, monkeypatch
 ):
+    """If the agent gets re-bound to the SAME daemon before its pending
+    cleanup drains, sending ``revoke_agent`` would wipe the live creds.
+    The drainer must cancel the row in that case.
+
+    Note: re-binding to a *different* daemon, or staying detached but
+    cloud-owned (the device-removal flow), still leaves the OLD machine's
+    local creds in place and the cleanup remains applicable — covered by
+    ``test_cleanup_still_applies_for_device_removal`` in test_daemon_control.
+    """
+    # Re-bind ag_agent001 to the same daemon the cleanup targets.
+    seed_user["agent1"].daemon_instance_id = "di_old"
     cleanup = DaemonAgentCleanup(
         daemon_instance_id="di_old",
         agent_id="ag_agent001",

--- a/backend/tests/test_app/test_daemon_control.py
+++ b/backend/tests/test_app/test_daemon_control.py
@@ -1057,3 +1057,405 @@ async def test_load_agent_identity_snapshot_returns_active_bound_agents(
     assert by_id["ag_keep2"]["bio"] is None
     # runtime is intentionally not on the wire — it's cached locally on the daemon.
     assert "runtime" not in by_id["ag_keep1"]
+
+
+# ---------------------------------------------------------------------------
+# Device removal — POST /daemon/instances/{id}/remove
+# ---------------------------------------------------------------------------
+
+
+async def _seed_hosted_agent(
+    db_session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    daemon_instance_id: str,
+    agent_id: str,
+    display_name: str = "Bot",
+) -> Agent:
+    agent = Agent(
+        agent_id=agent_id,
+        display_name=display_name,
+        runtime="claude-code",
+        user_id=user_id,
+        daemon_instance_id=daemon_instance_id,
+        message_policy=MessagePolicy.contacts_only,
+        status="active",
+    )
+    db_session.add(agent)
+    await db_session.commit()
+    return agent
+
+
+@pytest.mark.asyncio
+async def test_remove_device_offline_detaches_and_queues_cleanup(
+    client: AsyncClient, seed_user, db_session: AsyncSession
+):
+    import hub.routers.daemon_control as dcm
+
+    bundle = await _provision_instance_via_device_code(client, seed_user)
+    instance_id = bundle["daemon_instance_id"]
+
+    await _seed_hosted_agent(
+        db_session,
+        user_id=seed_user["user_id"],
+        daemon_instance_id=instance_id,
+        agent_id="ag_one",
+        display_name="One",
+    )
+    await _seed_hosted_agent(
+        db_session,
+        user_id=seed_user["user_id"],
+        daemon_instance_id=instance_id,
+        agent_id="ag_two",
+        display_name="Two",
+    )
+
+    # Daemon is offline — registry has no conn for this instance.
+    assert dcm._REGISTRY.is_online(instance_id) is False
+
+    r = await client.post(
+        f"/daemon/instances/{instance_id}/remove",
+        json={"forget_if_offline": False},
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["ok"] is True
+    assert body["status"] == "removal_pending"
+    assert body["was_online"] is False
+    assert body["cleanup_jobs_queued"] == 2
+    assert {a["agent_id"] for a in body["detached_agents"]} == {"ag_one", "ag_two"}
+
+    # Bots detached but still owned (cloud identity preserved).
+    from sqlalchemy import select
+
+    res = await db_session.execute(
+        select(Agent).where(Agent.user_id == seed_user["user_id"])
+    )
+    agents = res.scalars().all()
+    assert {a.agent_id for a in agents} == {"ag_one", "ag_two"}
+    assert all(a.daemon_instance_id is None for a in agents)
+    assert all(a.user_id is not None for a in agents)
+
+    # Daemon stays in pending-removal: revoked_at NULL but removal_requested_at set.
+    inst = await db_session.get(DaemonInstance, instance_id)
+    await db_session.refresh(inst)
+    assert inst.revoked_at is None
+    assert inst.removal_requested_at is not None
+
+    # Refresh token still works — daemon is allowed back online to drain.
+    r = await client.post(
+        "/daemon/auth/refresh", json={"refresh_token": bundle["refresh_token"]}
+    )
+    assert r.status_code == 200, r.text
+
+    # Cleanup rows queued in pending state.
+    from hub.models import DaemonAgentCleanup
+
+    res = await db_session.execute(
+        select(DaemonAgentCleanup).where(
+            DaemonAgentCleanup.daemon_instance_id == instance_id
+        )
+    )
+    rows = res.scalars().all()
+    assert {r.agent_id for r in rows} == {"ag_one", "ag_two"}
+    assert all(r.status == "pending" for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_remove_device_forget_if_offline_revokes_immediately(
+    client: AsyncClient, seed_user, db_session: AsyncSession
+):
+    bundle = await _provision_instance_via_device_code(client, seed_user)
+    instance_id = bundle["daemon_instance_id"]
+
+    await _seed_hosted_agent(
+        db_session,
+        user_id=seed_user["user_id"],
+        daemon_instance_id=instance_id,
+        agent_id="ag_solo",
+    )
+
+    r = await client.post(
+        f"/daemon/instances/{instance_id}/remove",
+        json={"forget_if_offline": True},
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "revoked"
+    assert body["was_online"] is False
+
+    inst = await db_session.get(DaemonInstance, instance_id)
+    await db_session.refresh(inst)
+    assert inst.revoked_at is not None
+    assert inst.cleanup_completed_at is not None
+
+    # Pending cleanup rows should be cancelled.
+    from sqlalchemy import select
+    from hub.models import DaemonAgentCleanup
+
+    rows = (
+        await db_session.execute(
+            select(DaemonAgentCleanup).where(
+                DaemonAgentCleanup.daemon_instance_id == instance_id
+            )
+        )
+    ).scalars().all()
+    assert all(r.status == "cancelled" for r in rows)
+    assert all(r.last_error and "forgotten" in r.last_error for r in rows)
+
+    # Refresh now blocked.
+    r = await client.post(
+        "/daemon/auth/refresh", json={"refresh_token": bundle["refresh_token"]}
+    )
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_remove_device_is_idempotent(
+    client: AsyncClient, seed_user, db_session: AsyncSession
+):
+    bundle = await _provision_instance_via_device_code(client, seed_user)
+    instance_id = bundle["daemon_instance_id"]
+
+    await _seed_hosted_agent(
+        db_session,
+        user_id=seed_user["user_id"],
+        daemon_instance_id=instance_id,
+        agent_id="ag_idem",
+    )
+
+    r1 = await client.post(
+        f"/daemon/instances/{instance_id}/remove",
+        json={},
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert r1.status_code == 200
+    assert r1.json()["cleanup_jobs_queued"] == 1
+
+    # Second call: agents already detached, so no new cleanup row should be added.
+    r2 = await client.post(
+        f"/daemon/instances/{instance_id}/remove",
+        json={},
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert r2.status_code == 200
+    body = r2.json()
+    assert body["status"] == "removal_pending"
+    assert body["cleanup_jobs_queued"] == 0
+    assert body["detached_agents"] == []
+
+    from sqlalchemy import select
+    from hub.models import DaemonAgentCleanup
+
+    rows = (
+        await db_session.execute(
+            select(DaemonAgentCleanup).where(
+                DaemonAgentCleanup.daemon_instance_id == instance_id
+            )
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_remove_device_does_not_touch_other_user_agents(
+    client: AsyncClient, seed_user, db_session: AsyncSession
+):
+    bundle = await _provision_instance_via_device_code(client, seed_user)
+    instance_id = bundle["daemon_instance_id"]
+
+    other_user_id = uuid.uuid4()
+    db_session.add(
+        User(
+            id=other_user_id,
+            display_name="Other",
+            email="other@example.com",
+            status="active",
+            supabase_user_id=uuid.uuid4(),
+            max_agents=10,
+        )
+    )
+    await db_session.commit()
+
+    # Active agent owned by another user but somehow bound to this daemon (shouldn't happen
+    # in practice, but the endpoint must guard against it).
+    db_session.add(
+        Agent(
+            agent_id="ag_other",
+            display_name="Other's bot",
+            runtime="claude-code",
+            user_id=other_user_id,
+            daemon_instance_id=instance_id,
+            message_policy=MessagePolicy.contacts_only,
+            status="active",
+        )
+    )
+    await db_session.commit()
+
+    r = await client.post(
+        f"/daemon/instances/{instance_id}/remove",
+        json={},
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert r.status_code == 200
+    assert r.json()["detached_agents"] == []
+
+    from sqlalchemy import select
+
+    other = (
+        await db_session.execute(select(Agent).where(Agent.agent_id == "ag_other"))
+    ).scalar_one()
+    await db_session.refresh(other)
+    assert other.daemon_instance_id == instance_id
+
+
+@pytest.mark.asyncio
+async def test_finalize_drains_then_revokes(
+    client: AsyncClient, seed_user, db_session: AsyncSession, monkeypatch
+):
+    """After all pending cleanup jobs succeed and the daemon is in
+    pending-removal, finalization must mark revoked_at and burn the token."""
+    import hub.routers.daemon_control as dcm
+
+    bundle = await _provision_instance_via_device_code(client, seed_user)
+    instance_id = bundle["daemon_instance_id"]
+
+    await _seed_hosted_agent(
+        db_session,
+        user_id=seed_user["user_id"],
+        daemon_instance_id=instance_id,
+        agent_id="ag_drain",
+    )
+
+    # Step 1: request removal (offline) so removal_requested_at is set and a
+    # pending cleanup row exists.
+    r = await client.post(
+        f"/daemon/instances/{instance_id}/remove",
+        json={},
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert r.status_code == 200
+
+    # Step 2: pretend the daemon reconnected and the cleanup succeeded — mark
+    # the row succeeded directly and run the finalizer.
+    from sqlalchemy import select
+    from hub.models import DaemonAgentCleanup
+
+    row = (
+        await db_session.execute(
+            select(DaemonAgentCleanup).where(
+                DaemonAgentCleanup.daemon_instance_id == instance_id
+            )
+        )
+    ).scalar_one()
+    row.status = "succeeded"
+    row.completed_at = datetime.datetime.now(datetime.timezone.utc)
+    await db_session.commit()
+
+    # Suppress any websocket push (no daemon is actually connected).
+    async def _noop_push(*args, **kwargs):
+        return False
+
+    monkeypatch.setattr(dcm, "_push_daemon_revoke", _noop_push)
+
+    finalized = await dcm._finalize_removal_if_drained(instance_id)
+    assert finalized is True
+
+    inst = await db_session.get(DaemonInstance, instance_id)
+    await db_session.refresh(inst)
+    assert inst.revoked_at is not None
+    assert inst.cleanup_completed_at is not None
+
+    # Refresh now blocked.
+    r = await client.post(
+        "/daemon/auth/refresh", json={"refresh_token": bundle["refresh_token"]}
+    )
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_cleanup_still_applies_for_device_removal(
+    client: AsyncClient, seed_user, db_session: AsyncSession
+):
+    """Regression: device removal detaches an agent but keeps `user_id`.
+    The cleanup applicability check must NOT cancel such rows — otherwise
+    the daemon-side `revoke_agent` frame is never sent and local
+    credentials linger on the machine forever."""
+    import hub.routers.daemon_control as dcm
+
+    bundle = await _provision_instance_via_device_code(client, seed_user)
+    instance_id = bundle["daemon_instance_id"]
+
+    await _seed_hosted_agent(
+        db_session,
+        user_id=seed_user["user_id"],
+        daemon_instance_id=instance_id,
+        agent_id="ag_keep_owned",
+    )
+
+    r = await client.post(
+        f"/daemon/instances/{instance_id}/remove",
+        json={},
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert r.status_code == 200
+
+    from sqlalchemy import select
+    from hub.models import DaemonAgentCleanup
+
+    cleanup = (
+        await db_session.execute(
+            select(DaemonAgentCleanup).where(
+                DaemonAgentCleanup.daemon_instance_id == instance_id
+            )
+        )
+    ).scalar_one()
+
+    # Agent still owned by user (user_id != None) but unbound from the
+    # daemon — _cleanup_still_applies must return True so the drainer will
+    # actually send the revoke_agent frame.
+    applies = await dcm._cleanup_still_applies(db_session, cleanup)
+    assert applies is True, "device-removal cleanup must still apply on drain"
+
+    # And if the agent gets re-bound to the same daemon (rare, but possible
+    # if the user cancelled and re-provisioned), the cleanup must NOT fire.
+    agent = (
+        await db_session.execute(select(Agent).where(Agent.agent_id == "ag_keep_owned"))
+    ).scalar_one()
+    agent.daemon_instance_id = instance_id
+    await db_session.commit()
+    applies = await dcm._cleanup_still_applies(db_session, cleanup)
+    assert applies is False, "rebinding to same daemon should cancel cleanup"
+
+
+@pytest.mark.asyncio
+async def test_finalize_skips_when_pending_jobs_remain(
+    client: AsyncClient, seed_user, db_session: AsyncSession
+):
+    import hub.routers.daemon_control as dcm
+
+    bundle = await _provision_instance_via_device_code(client, seed_user)
+    instance_id = bundle["daemon_instance_id"]
+
+    await _seed_hosted_agent(
+        db_session,
+        user_id=seed_user["user_id"],
+        daemon_instance_id=instance_id,
+        agent_id="ag_pending",
+    )
+
+    r = await client.post(
+        f"/daemon/instances/{instance_id}/remove",
+        json={},
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert r.status_code == 200
+
+    finalized = await dcm._finalize_removal_if_drained(instance_id)
+    assert finalized is False
+
+    inst = await db_session.get(DaemonInstance, instance_id)
+    await db_session.refresh(inst)
+    assert inst.revoked_at is None

--- a/frontend/src/app/api/daemon/instances/[id]/remove/route.ts
+++ b/frontend/src/app/api/daemon/instances/[id]/remove/route.ts
@@ -1,0 +1,44 @@
+/**
+ * [INPUT]: Supabase user session, daemon instance id from path, optional body
+ *          { forget_if_offline?: boolean, reason?: string }
+ * [OUTPUT]: POST /api/daemon/instances/[id]/remove — detach hosted bots and
+ *           queue local cleanup; revoke immediately when forget_if_offline.
+ * [POS]: BFF endpoint for the My Bots / Settings Remove Device action
+ * [PROTOCOL]: update header on changes
+ */
+
+import { NextResponse } from "next/server";
+import { proxyDaemon } from "../../../_lib/proxy";
+
+type RemoveBody = {
+  forget_if_offline?: boolean;
+  reason?: string;
+};
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  if (!id) {
+    return NextResponse.json({ error: "missing_id" }, { status: 400 });
+  }
+
+  let body: RemoveBody = {};
+  try {
+    const raw = await req.text();
+    if (raw) {
+      const parsed = JSON.parse(raw) as RemoveBody;
+      if (parsed && typeof parsed === "object") {
+        body = parsed;
+      }
+    }
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  return proxyDaemon(
+    `/daemon/instances/${encodeURIComponent(id)}/remove`,
+    { method: "POST", body },
+  );
+}

--- a/frontend/src/components/daemon/DaemonsSettingsPage.tsx
+++ b/frontend/src/components/daemon/DaemonsSettingsPage.tsx
@@ -48,6 +48,7 @@ function StatusBadge({ status }: { status: DaemonInstance["status"] }) {
     online: "bg-neon-green/10 text-neon-green",
     offline: "bg-glass-bg text-text-secondary",
     revoked: "bg-red-400/10 text-red-300",
+    removal_pending: "bg-yellow-400/10 text-yellow-300",
   };
   return (
     <span
@@ -317,7 +318,8 @@ export default function DaemonsSettingsPage() {
       const order: Record<DaemonInstance["status"], number> = {
         online: 0,
         offline: 1,
-        revoked: 2,
+        removal_pending: 2,
+        revoked: 3,
       };
       const oa = order[a.status] ?? 3;
       const ob = order[b.status] ?? 3;

--- a/frontend/src/components/dashboard/sidebar/BotsPanel.tsx
+++ b/frontend/src/components/dashboard/sidebar/BotsPanel.tsx
@@ -86,6 +86,9 @@ export default function BotsPanel({
   const daemons = useDaemonStore((s) => s.daemons);
   const renameDaemon = useDaemonStore((s) => s.rename);
   const renamingId = useDaemonStore((s) => s.renamingId);
+  const removeDevice = useDaemonStore((s) => s.removeDevice);
+  const removingId = useDaemonStore((s) => s.removingId);
+  const refreshDaemons = useDaemonStore((s) => s.refresh);
 
   const [showAddDevice, setShowAddDevice] = useState(false);
   const [deviceSettingsId, setDeviceSettingsId] = useState<string | null>(null);
@@ -111,8 +114,18 @@ export default function BotsPanel({
     }
   }
 
+  // Devices in `removal_pending` have already had their bots detached. Skip
+  // their device card so My Bots doesn't render an empty group; the bots
+  // surface under "No Device" via the unbound list instead. We still keep
+  // the device with hosted agents (i.e., the rare case where detach failed
+  // mid-flight) so the user can retry.
+  const removalPendingIds = new Set(
+    daemons.filter((d) => d.status === "removal_pending").map((d) => d.id),
+  );
   const allDaemonIds = new Set([
-    ...daemons.map((d) => d.id),
+    ...daemons
+      .filter((d) => !(removalPendingIds.has(d.id) && !byDaemon.has(d.id)))
+      .map((d) => d.id),
     ...byDaemon.keys(),
   ]);
 
@@ -265,14 +278,21 @@ export default function BotsPanel({
           label={settingsDaemon?.label ?? ""}
           status={settingsDaemon?.status ?? "offline"}
           lastSeen={settingsDaemon?.last_seen_at ?? null}
+          hostedAgentCount={(byDaemon.get(deviceSettingsId) ?? []).length}
           isRenaming={renamingId === deviceSettingsId}
           isRefreshing={refreshingBots}
+          isRemoving={removingId === deviceSettingsId}
           locale={locale}
           onClose={() => setDeviceSettingsId(null)}
           onRename={async (newLabel: string) => {
             await renameDaemon(deviceSettingsId, newLabel);
           }}
           onRefreshDaemons={onRefreshDaemons}
+          onRemove={async (forgetIfOffline) => {
+            await removeDevice(deviceSettingsId, { forgetIfOffline });
+            await refreshDaemons({ quiet: true });
+            setDeviceSettingsId(null);
+          }}
         />
       )}
 

--- a/frontend/src/components/dashboard/sidebar/DeviceSettingsModal.tsx
+++ b/frontend/src/components/dashboard/sidebar/DeviceSettingsModal.tsx
@@ -1,20 +1,23 @@
 "use client";
 
 import { useState } from "react";
-import { RefreshCw, Loader2, Check } from "lucide-react";
+import { RefreshCw, Loader2, Check, Trash2 } from "lucide-react";
 import DaemonInstallCommand from "@/components/daemon/DaemonInstallCommand";
 
 interface DeviceSettingsModalProps {
   daemonId: string;
   label: string;
-  status: "online" | "offline" | "revoked";
+  status: "online" | "offline" | "revoked" | "removal_pending";
   lastSeen: string | null;
+  hostedAgentCount: number;
   isRenaming: boolean;
   isRefreshing: boolean;
+  isRemoving: boolean;
   locale: string;
   onClose: () => void;
   onRename: (label: string) => Promise<void>;
   onRefreshDaemons: () => void;
+  onRemove: (forgetIfOffline: boolean) => Promise<void>;
 }
 
 export default function DeviceSettingsModal({
@@ -22,16 +25,21 @@ export default function DeviceSettingsModal({
   label,
   status,
   lastSeen,
+  hostedAgentCount,
   isRenaming,
   isRefreshing,
+  isRemoving,
   locale,
   onClose,
   onRename,
   onRefreshDaemons,
+  onRemove,
 }: DeviceSettingsModalProps) {
   const [editingName, setEditingName] = useState(label);
   const [nameSaved, setNameSaved] = useState(false);
   const [showInstall, setShowInstall] = useState(false);
+  const [confirmRemove, setConfirmRemove] = useState(false);
+  const [removeError, setRemoveError] = useState<string | null>(null);
 
   async function handleRename() {
     if (editingName.trim() === label) return;
@@ -40,12 +48,34 @@ export default function DeviceSettingsModal({
     setTimeout(() => setNameSaved(false), 2000);
   }
 
-  const statusColor = status === "online" ? "text-neon-green" : status === "revoked" ? "text-red-400" : "text-text-secondary/50";
-  const statusLabel = status === "online"
-    ? (locale === "zh" ? "在线" : "Online")
-    : status === "revoked"
-    ? (locale === "zh" ? "已撤销" : "Revoked")
-    : (locale === "zh" ? "离线" : "Offline");
+  async function handleRemove(forgetIfOffline: boolean) {
+    setRemoveError(null);
+    try {
+      await onRemove(forgetIfOffline);
+    } catch (err) {
+      setRemoveError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  const statusColor =
+    status === "online"
+      ? "text-neon-green"
+      : status === "revoked"
+        ? "text-red-400"
+        : status === "removal_pending"
+          ? "text-yellow-400"
+          : "text-text-secondary/50";
+  const statusLabel =
+    status === "online"
+      ? locale === "zh" ? "在线" : "Online"
+      : status === "revoked"
+        ? locale === "zh" ? "已撤销" : "Revoked"
+        : status === "removal_pending"
+          ? locale === "zh" ? "待清理" : "Cleanup pending"
+          : locale === "zh" ? "离线" : "Offline";
+
+  const isOffline = status === "offline";
+  const removeDisabled = isRemoving || status === "revoked" || status === "removal_pending";
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" onClick={onClose}>
@@ -110,6 +140,95 @@ export default function DeviceSettingsModal({
                 {isRenaming ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : nameSaved ? <Check className="h-3.5 w-3.5 text-neon-green" /> : <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="h-3.5 w-3.5"><path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>}
               </button>
             </div>
+          </div>
+
+          {/* Danger zone — Remove Device */}
+          <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3">
+            {!confirmRemove ? (
+              <button
+                type="button"
+                disabled={removeDisabled}
+                onClick={() => setConfirmRemove(true)}
+                className="flex w-full items-center justify-between text-left text-xs text-red-300/80 transition-colors hover:text-red-300 disabled:opacity-40"
+              >
+                <span className="flex items-center gap-2">
+                  <Trash2 className="h-3.5 w-3.5" />
+                  {locale === "zh" ? "移除此设备" : "Remove device"}
+                </span>
+                <span className="text-text-secondary/50">
+                  {hostedAgentCount > 0
+                    ? locale === "zh"
+                      ? `${hostedAgentCount} 个 Agent`
+                      : `${hostedAgentCount} agent${hostedAgentCount === 1 ? "" : "s"}`
+                    : ""}
+                </span>
+              </button>
+            ) : (
+              <div className="space-y-3">
+                <p className="text-xs font-semibold text-red-300">
+                  {locale === "zh"
+                    ? "确认移除此设备？"
+                    : "Remove this device?"}
+                </p>
+                <p className="text-[11px] leading-relaxed text-text-secondary/70">
+                  {hostedAgentCount > 0
+                    ? locale === "zh"
+                      ? `${hostedAgentCount} 个 Agent 将移到「未关联设备」分组，云端身份和聊天记录都会保留。`
+                      : `${hostedAgentCount} agent${hostedAgentCount === 1 ? "" : "s"} will move to "No Device". Cloud identities, rooms, and history are kept.`
+                    : locale === "zh"
+                      ? "此设备没有托管的 Agent。移除后云端记录会保留。"
+                      : "No agents are hosted on this device. Cloud records will be kept."}
+                </p>
+                {isOffline ? (
+                  <p className="text-[11px] leading-relaxed text-yellow-400/80">
+                    {locale === "zh"
+                      ? "设备当前离线。本地凭据/状态需等设备重新启动后才能清理。"
+                      : "Device is offline. Local credentials and state can't be cleaned until the daemon starts again."}
+                  </p>
+                ) : (
+                  <p className="text-[11px] leading-relaxed text-text-secondary/60">
+                    {locale === "zh"
+                      ? "设备在线，本地凭据将立即清理。"
+                      : "Device is online — local credentials will be cleaned now."}
+                  </p>
+                )}
+                {removeError && (
+                  <p className="text-[11px] text-red-400">{removeError}</p>
+                )}
+                <div className="flex flex-wrap items-center justify-end gap-2">
+                  <button
+                    type="button"
+                    disabled={isRemoving}
+                    onClick={() => {
+                      setConfirmRemove(false);
+                      setRemoveError(null);
+                    }}
+                    className="rounded-lg border border-glass-border px-3 py-1.5 text-[11px] text-text-secondary transition-colors hover:bg-glass-bg disabled:opacity-40"
+                  >
+                    {locale === "zh" ? "取消" : "Cancel"}
+                  </button>
+                  {isOffline && (
+                    <button
+                      type="button"
+                      disabled={isRemoving}
+                      onClick={() => void handleRemove(true)}
+                      className="rounded-lg border border-red-500/40 px-3 py-1.5 text-[11px] text-red-300 transition-colors hover:bg-red-500/10 disabled:opacity-40"
+                    >
+                      {locale === "zh" ? "强制移除" : "Forget anyway"}
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    disabled={isRemoving}
+                    onClick={() => void handleRemove(false)}
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-red-500/60 bg-red-500/15 px-3 py-1.5 text-[11px] font-medium text-red-200 transition-colors hover:bg-red-500/25 disabled:opacity-40"
+                  >
+                    {isRemoving && <Loader2 className="h-3 w-3 animate-spin" />}
+                    {locale === "zh" ? "移除设备" : "Remove device"}
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
 
           {/* Restart command toggle */}

--- a/frontend/src/store/useDaemonStore.ts
+++ b/frontend/src/store/useDaemonStore.ts
@@ -64,12 +64,22 @@ export interface DaemonRuntime {
 export interface DaemonInstance {
   id: string;
   label: string | null;
-  status: "online" | "offline" | "revoked";
+  status: "online" | "offline" | "revoked" | "removal_pending";
   created_at: string | null;
   last_seen_at: string | null;
   revoked_at: string | null;
+  removal_requested_at: string | null;
+  cleanup_completed_at: string | null;
   runtimes?: DaemonRuntime[] | null;
   runtimes_probed_at?: string | null;
+}
+
+export interface RemoveDeviceResult {
+  ok: boolean;
+  status: "removal_pending" | "revoked";
+  was_online: boolean;
+  detached_agents: Array<{ agent_id: string; display_name: string | null }>;
+  cleanup_jobs_queued: number;
 }
 
 export interface ProvisionAgentInput {
@@ -114,6 +124,7 @@ interface DaemonState {
   loaded: boolean;
   error: string | null;
   revokingId: string | null;
+  removingId: string | null;
   renamingId: string | null;
   refreshingRuntimesId: string | null;
   runtimeErrors: Record<string, string>;
@@ -121,6 +132,10 @@ interface DaemonState {
 
   refresh: (opts?: { quiet?: boolean }) => Promise<void>;
   revoke: (id: string) => Promise<void>;
+  removeDevice: (
+    id: string,
+    opts?: { forgetIfOffline?: boolean; reason?: string },
+  ) => Promise<RemoveDeviceResult>;
   rename: (id: string, label: string | null) => Promise<boolean>;
   refreshRuntimes: (id: string, opts?: { quiet?: boolean }) => Promise<void>;
   provisionAgent: (
@@ -136,6 +151,7 @@ const initialState = {
   loaded: false,
   error: null as string | null,
   revokingId: null as string | null,
+  removingId: null as string | null,
   renamingId: null as string | null,
   refreshingRuntimesId: null as string | null,
   runtimeErrors: {} as Record<string, string>,
@@ -296,16 +312,16 @@ function normalizeRuntimes(raw: unknown): DaemonRuntime[] | null | undefined {
 
 function normalizeDaemon(raw: Record<string, unknown>): DaemonInstance {
   const revokedAt = (raw.revoked_at as string | null) ?? null;
+  const removalRequestedAt = (raw.removal_requested_at as string | null) ?? null;
+  const cleanupCompletedAt = (raw.cleanup_completed_at as string | null) ?? null;
   const explicitStatus = (raw.status as string | undefined) ?? null;
   const online = raw.online === true;
   let status: DaemonInstance["status"];
-  if (revokedAt) {
+  if (revokedAt || explicitStatus === "revoked") {
     status = "revoked";
-  } else if (
-    explicitStatus === "online" ||
-    explicitStatus === "offline" ||
-    explicitStatus === "revoked"
-  ) {
+  } else if (removalRequestedAt || explicitStatus === "removal_pending") {
+    status = "removal_pending";
+  } else if (explicitStatus === "online" || explicitStatus === "offline") {
     status = explicitStatus;
   } else {
     status = online ? "online" : "offline";
@@ -317,6 +333,8 @@ function normalizeDaemon(raw: Record<string, unknown>): DaemonInstance {
     created_at: (raw.created_at as string | null) ?? null,
     last_seen_at: (raw.last_seen_at as string | null) ?? null,
     revoked_at: revokedAt,
+    removal_requested_at: removalRequestedAt,
+    cleanup_completed_at: cleanupCompletedAt,
     runtimes: normalizeRuntimes(raw.runtimes),
     runtimes_probed_at: (raw.runtimes_probed_at as string | null) ?? null,
   };
@@ -443,6 +461,63 @@ export const useDaemonStore = create<DaemonState>()((set, get) => ({
         revokingId: null,
         error: err instanceof Error ? err.message : "Failed to revoke",
       });
+    }
+  },
+
+  removeDevice: async (id, opts) => {
+    set({ removingId: id, error: null });
+    try {
+      const res = await fetch(
+        `/api/daemon/instances/${encodeURIComponent(id)}/remove`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            forget_if_offline: opts?.forgetIfOffline === true,
+            ...(opts?.reason ? { reason: opts.reason } : {}),
+          }),
+        },
+      );
+      if (!res.ok) {
+        const msg = await parseError(res);
+        set({ removingId: null, error: msg });
+        throw new Error(msg);
+      }
+      const data = (await res.json().catch(() => null)) as
+        | RemoveDeviceResult
+        | null;
+      // Optimistic local update: drop the device when fully revoked,
+      // mark it removal_pending otherwise. `refresh` reconciles after.
+      const finalStatus = data?.status ?? "removal_pending";
+      set({
+        daemons:
+          finalStatus === "revoked"
+            ? get().daemons.filter((d) => d.id !== id)
+            : get().daemons.map((d) =>
+                d.id === id ? { ...d, status: "removal_pending" } : d,
+              ),
+        removingId: null,
+      });
+      void get().refresh({ quiet: true });
+      return (
+        data ?? {
+          ok: true,
+          status: "removal_pending",
+          was_online: false,
+          detached_agents: [],
+          cleanup_jobs_queued: 0,
+        }
+      );
+    } catch (err) {
+      if (!(err instanceof Error)) {
+        set({ removingId: null });
+        throw new Error("Failed to remove device");
+      }
+      set((state) => ({
+        removingId: null,
+        error: state.error ?? err.message,
+      }));
+      throw err;
     }
   },
 


### PR DESCRIPTION
## Summary

- Adds **Remove Device** in My Bots / Settings: detaches hosted bots to "No Device" (cloud identity / rooms / history preserved), queues per-agent local cleanup on the daemon, and only sets `revoked_at` after the queue drains.
- Offline devices stay in a new `removal_pending` state and finish cleanup when they reconnect; users can `forget_if_offline` when the machine is gone.
- Fixes a **critical pre-existing bug**: `_cleanup_still_applies` keyed on `user_id` would cancel offline-remove cleanups on reconnect (device removal keeps `user_id`), leaving local credentials on the machine forever. Now keyed on `daemon_instance_id`, which also keeps unbind semantics correct.

Design doc: `docs/device-removal-agent-cleanup-design.md`.

## Changes

**Backend**
- Migration `002_daemon_instances_removal.sql` — `removal_requested_at`, `removal_reason`, `cleanup_completed_at` columns + partial index for pending-removal lookup.
- `POST /daemon/instances/{id}/remove` — one transaction: bulk UPDATE detach + dedup `DaemonAgentCleanup` insert; `forget_if_offline` cancels pending rows and stamps `revoked_at` immediately.
- `_finalize_removal_if_drained` runs at the tail of `process_pending_daemon_cleanups`: when no pending rows remain and `removal_requested_at` is set, stamps `cleanup_completed_at` + `revoked_at`, burns the refresh hash, pushes daemon-level `revoke`.

**Frontend**
- BFF `/api/daemon/instances/[id]/remove`.
- `useDaemonStore.removeDevice` + new `removal_pending` status. My Bots hides pending-removal device cards once their bots have moved to No Device; settings page shows a yellow "Cleanup pending" badge.
- `DeviceSettingsModal` danger zone with online/offline copy and a `Forget anyway` action for offline devices.

## Test plan

- [x] `uv run pytest tests/` — 1052 passed (7 new device-removal tests + reworked rebind test for the corrected `_cleanup_still_applies` semantics).
- [x] `pnpm exec next build` — TypeScript pass (prerender failure is the pre-existing env-var issue, unrelated).
- [ ] Smoke: in dashboard, remove an online device → bots reappear under No Device, daemon disappears.
- [ ] Smoke: stop the daemon, remove device offline → device shows "Cleanup pending", bots already moved; restart daemon → device disappears after drain.
- [ ] Smoke: stop the daemon, remove with "Forget anyway" → device disappears immediately, refresh token rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)