### PR TITLE
fix: handle daemon gateway control frames

### DIFF
--- a/packages/daemon/package-lock.json
+++ b/packages/daemon/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@botcord/daemon",
-  "version": "0.2.36",
+  "version": "0.2.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@botcord/daemon",
-      "version": "0.2.36",
+      "version": "0.2.39",
       "license": "MIT",
       "dependencies": {
         "@botcord/cli": "^0.1.7",
-        "@botcord/protocol-core": "^0.2.2",
+        "@botcord/protocol-core": "^0.2.4",
         "ws": "^8.18.0"
       },
       "bin": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botcord/daemon",
-  "version": "0.2.37",
+  "version": "0.2.39",
   "description": "BotCord local daemon — bridges Hub inbox push to local Claude Code / Codex / Gemini CLIs",
   "type": "module",
   "bin": {
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@botcord/cli": "^0.1.7",
-    "@botcord/protocol-core": "^0.2.2",
+    "@botcord/protocol-core": "^0.2.4",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/packages/daemon/src/__tests__/provision.test.ts
+++ b/packages/daemon/src/__tests__/provision.test.ts
@@ -1698,7 +1698,7 @@ describe("W8: gateway frame param validation in provision dispatch", () => {
     });
     const ack = await provisioner({
       id: "req_w8a",
-      type: CONTROL_FRAME_TYPES.UPSERT_GATEWAY,
+      type: "upsert_gateway",
       params: { id: "gw_x", type: "telegram" } as unknown as Record<string, unknown>,
     });
     expect(ack.ok).toBe(false);
@@ -1714,7 +1714,7 @@ describe("W8: gateway frame param validation in provision dispatch", () => {
     });
     const ack = await provisioner({
       id: "req_w8b",
-      type: CONTROL_FRAME_TYPES.REMOVE_GATEWAY,
+      type: "remove_gateway",
       // @ts-expect-error — exercising the runtime guard
       params: "not-an-object",
     });
@@ -1729,7 +1729,7 @@ describe("W8: gateway frame param validation in provision dispatch", () => {
     });
     const ack = await provisioner({
       id: "req_w8c",
-      type: CONTROL_FRAME_TYPES.TEST_GATEWAY,
+      type: "test_gateway",
       params: {},
     });
     expect(ack.ok).toBe(false);
@@ -1743,7 +1743,7 @@ describe("W8: gateway frame param validation in provision dispatch", () => {
     });
     const ack = await provisioner({
       id: "req_w8d",
-      type: CONTROL_FRAME_TYPES.GATEWAY_LOGIN_START,
+      type: "gateway_login_start",
       params: { accountId: "ag_a" },
     });
     expect(ack.ok).toBe(false);
@@ -1757,7 +1757,7 @@ describe("W8: gateway frame param validation in provision dispatch", () => {
     });
     const ack = await provisioner({
       id: "req_w8e",
-      type: CONTROL_FRAME_TYPES.GATEWAY_LOGIN_STATUS,
+      type: "gateway_login_status",
       params: { provider: "wechat" },
     });
     expect(ack.ok).toBe(false);

--- a/packages/daemon/src/gateway-control.ts
+++ b/packages/daemon/src/gateway-control.ts
@@ -9,22 +9,7 @@
  * wires the production defaults.
  */
 
-import type {
-  ControlAck,
-  GatewayLoginStartParams,
-  GatewayLoginStartResult,
-  GatewayLoginStatusParams,
-  GatewayLoginStatusResult,
-  GatewayProfileSummary,
-  GatewayProvider,
-  ListGatewaysResult,
-  RemoveGatewayParams,
-  RemoveGatewayResult,
-  TestGatewayParams,
-  TestGatewayResult,
-  UpsertGatewayParams,
-  UpsertGatewayResult,
-} from "@botcord/protocol-core";
+import type { ControlAck } from "@botcord/protocol-core";
 import type { Gateway, GatewayChannelConfig } from "./gateway/index.js";
 import {
   loadConfig,
@@ -55,6 +40,108 @@ import { log as daemonLog } from "./log.js";
 import type { FetchLike } from "./gateway/channels/http-types.js";
 
 type AckBody = Omit<ControlAck, "id">;
+
+type GatewayProvider = "telegram" | "wechat";
+
+interface GatewayProfileSummary {
+  id: string;
+  type: GatewayProvider;
+  accountId: string;
+  label?: string;
+  enabled: boolean;
+  baseUrl?: string;
+  allowedSenderIds?: string[];
+  allowedChatIds?: string[];
+  splitAt?: number;
+  status?: {
+    running: boolean;
+    connected?: boolean;
+    authorized?: boolean;
+    lastPollAt?: number;
+    lastInboundAt?: number;
+    lastSendAt?: number;
+    lastError?: string | null;
+  };
+}
+
+interface ListGatewaysResult {
+  gateways: GatewayProfileSummary[];
+}
+
+interface UpsertGatewayParams {
+  id: string;
+  type: GatewayProvider;
+  accountId: string;
+  label?: string;
+  enabled?: boolean;
+  loginId?: string;
+  secret?: {
+    botToken?: string;
+  };
+  settings?: {
+    baseUrl?: string;
+    allowedSenderIds?: string[];
+    allowedChatIds?: string[];
+    splitAt?: number;
+  };
+}
+
+interface UpsertGatewayResult {
+  id: string;
+  type: GatewayProvider;
+  accountId: string;
+  enabled: boolean;
+  tokenPreview?: string;
+  status?: GatewayProfileSummary["status"];
+}
+
+interface RemoveGatewayParams {
+  id: string;
+  deleteSecret?: boolean;
+}
+
+interface RemoveGatewayResult {
+  id: string;
+  removed: boolean;
+  secretDeleted: boolean;
+}
+
+interface TestGatewayParams {
+  id: string;
+}
+
+interface TestGatewayResult {
+  id: string;
+  ok: boolean;
+  info?: Record<string, unknown>;
+  error?: string;
+}
+
+interface GatewayLoginStartParams {
+  provider: GatewayProvider;
+  accountId: string;
+  gatewayId?: string;
+  baseUrl?: string;
+}
+
+interface GatewayLoginStartResult {
+  loginId: string;
+  qrcode?: string;
+  qrcodeUrl?: string;
+  expiresAt: number;
+}
+
+interface GatewayLoginStatusParams {
+  provider: GatewayProvider;
+  loginId: string;
+  accountId: string;
+}
+
+interface GatewayLoginStatusResult {
+  status: "pending" | "scanned" | "confirmed" | "expired" | "failed";
+  baseUrl?: string;
+  tokenPreview?: string;
+}
 
 export type { FetchLike };
 

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -322,10 +322,10 @@ export function createProvisioner(opts: ProvisionerOptions): (
         return { ok: true, result: snapshot };
       }
 
-      case CONTROL_FRAME_TYPES.LIST_GATEWAYS:
+      case "list_gateways":
         return gatewayControl.handleList();
 
-      case CONTROL_FRAME_TYPES.UPSERT_GATEWAY: {
+      case "upsert_gateway": {
         const v = validateGatewayParams(frame.params, {
           required: ["id", "type", "accountId"],
         });
@@ -335,7 +335,7 @@ export function createProvisioner(opts: ProvisionerOptions): (
         );
       }
 
-      case CONTROL_FRAME_TYPES.REMOVE_GATEWAY: {
+      case "remove_gateway": {
         const v = validateGatewayParams(frame.params, { required: ["id"] });
         if (!v.ok) return v.ack;
         return gatewayControl.handleRemove(
@@ -343,7 +343,7 @@ export function createProvisioner(opts: ProvisionerOptions): (
         );
       }
 
-      case CONTROL_FRAME_TYPES.TEST_GATEWAY: {
+      case "test_gateway": {
         const v = validateGatewayParams(frame.params, { required: ["id"] });
         if (!v.ok) return v.ack;
         return gatewayControl.handleTest(
@@ -351,7 +351,7 @@ export function createProvisioner(opts: ProvisionerOptions): (
         );
       }
 
-      case CONTROL_FRAME_TYPES.GATEWAY_LOGIN_START: {
+      case "gateway_login_start": {
         const v = validateGatewayParams(frame.params, {
           required: ["provider", "accountId"],
         });
@@ -361,7 +361,7 @@ export function createProvisioner(opts: ProvisionerOptions): (
         );
       }
 
-      case CONTROL_FRAME_TYPES.GATEWAY_LOGIN_STATUS: {
+      case "gateway_login_status": {
         const v = validateGatewayParams(frame.params, {
           required: ["provider", "loginId"],
         });


### PR DESCRIPTION
## Summary
- handle gateway control frame dispatch by wire string names instead of protocol-core constants
- keep gateway-control wire types local to daemon so old published protocol-core packages do not make gateway frames unknown
- bump daemon package metadata to 0.2.39 and require protocol-core ^0.2.4

## Root Cause
Preview daemon logs showed `provision.dispatch: unknown frame type type="upsert_gateway"`. The published daemon code has gateway handlers, but it compared against `CONTROL_FRAME_TYPES.*` fields that are absent from older published `@botcord/protocol-core` packages. Existing daemon installs can retain that older dependency, making those switch cases compare against `undefined`.

## Testing
- cd packages/daemon && npm run build
- cd packages/daemon && npm test -- --run src/__tests__/provision.test.ts src/__tests__/gateway-control.test.ts