### PR TITLE
fix: enable telegram gateway typing

### DIFF
--- a/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
+++ b/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
@@ -619,7 +619,7 @@ describe("Dispatcher", () => {
   // typing / thinking lifecycle (design: runtime-typing-thinking-status-design.md)
   // ---------------------------------------------------------------------------
 
-  it("typing: fires channel.typing once before runtime.run when canStream", async () => {
+  it("typing: fires channel.typing once before runtime.run when trace is streamable", async () => {
     const observed: Array<{ typings: number; calls: number }> = [];
     const runtime = new FakeRuntime({
       observeRun: () => {
@@ -642,6 +642,21 @@ describe("Dispatcher", () => {
     expect(channel.typings[0].traceId).toBe("trace_t");
     expect(channel.typings[0].conversationId).toBe("rm_oc_1");
     expect(observed[0]?.typings).toBe(1);
+  });
+
+  it("typing: does not require channel streamBlock support", async () => {
+    const runtime = new FakeRuntime({ reply: "ok", newSessionId: "sid" });
+    const channel = new FakeChannel({ withStream: false });
+    const { dispatcher } = await scaffold({ channel, runtimeFactory: () => runtime });
+
+    await dispatcher.handle(
+      makeEnvelope({ trace: { id: "trace_t", streamable: true } }),
+    );
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(channel.typings.length).toBe(1);
+    expect(channel.streams.length).toBe(0);
+    expect(channel.sends.length).toBe(1);
   });
 
   it("typing: not fired when streamable is false", async () => {

--- a/packages/daemon/src/gateway/__tests__/telegram-channel.test.ts
+++ b/packages/daemon/src/gateway/__tests__/telegram-channel.test.ts
@@ -144,6 +144,7 @@ describe("createTelegramChannel — start()", () => {
     expect(msg.text).toBe("hello world");
     expect(msg.accountId).toBe("ag_self");
     expect(msg.channel).toBe("gw_tg_a");
+    expect(msg.trace).toEqual({ id: "telegram:42:7", streamable: true });
   });
 
   it("uses telegram:group:<id> for non-private chats", async () => {

--- a/packages/daemon/src/gateway/channels/telegram.ts
+++ b/packages/daemon/src/gateway/channels/telegram.ts
@@ -237,7 +237,7 @@ export function createTelegramChannel(opts: TelegramChannelOptions): ChannelAdap
       replyTo: null,
       mentioned: false,
       receivedAt: Date.now(),
-      trace: { id: messageId, streamable: false },
+      trace: { id: messageId, streamable: true },
     };
   }
 
@@ -466,4 +466,3 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
     signal?.addEventListener("abort", onAbort, { once: true });
   });
 }
-

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -803,6 +803,8 @@ export class Dispatcher {
 
     const streamable = msg.trace?.streamable === true;
     const traceId = msg.trace?.id;
+    const canType =
+      streamable && typeof traceId === "string" && typeof channel.typing === "function";
     const canStream =
       streamable && typeof traceId === "string" && typeof channel.streamBlock === "function";
     const recordBlock = (block: StreamBlock): void => {
@@ -886,7 +888,7 @@ export class Dispatcher {
     };
 
     const fireTypingIfNeeded = (): void => {
-      if (!canStream || typingFired || typeof channel.typing !== "function") return;
+      if (!canType || typingFired) return;
       typingFired = true;
       const key = `${msg.accountId}:${msg.conversation.id}`;
       const now = Date.now();


### PR DESCRIPTION
## Summary
- allow dispatcher typing cues without requiring channel streamBlock support
- mark Telegram inbound traces streamable so received messages trigger sendChatAction typing
- add dispatcher and Telegram channel test coverage

## Tests
- cd packages/daemon && npx vitest run src/gateway/__tests__/telegram-channel.test.ts src/gateway/__tests__/dispatcher.test.ts