### PR TITLE
fix: abort telegram polling on gateway removal

### DIFF
--- a/packages/daemon/src/gateway/__tests__/telegram-channel.test.ts
+++ b/packages/daemon/src/gateway/__tests__/telegram-channel.test.ts
@@ -320,6 +320,55 @@ describe("createTelegramChannel — start()", () => {
     expect(calls).toHaveLength(1);
     expect((calls[0]!.body as Record<string, unknown>).offset).toBe(999);
   });
+
+  it("aborts an in-flight getUpdates request when stopped", async () => {
+    const calls: FetchCall[] = [];
+    let requestSignal: AbortSignal | undefined;
+    let fetchStarted!: () => void;
+    const fetchStartedPromise = new Promise<void>((resolve) => {
+      fetchStarted = resolve;
+    });
+    const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const body = init?.body ? JSON.parse(init.body as string) : undefined;
+      calls.push({ url, body });
+      requestSignal = init?.signal ?? undefined;
+      fetchStarted();
+      return await new Promise<Response>((_resolve, reject) => {
+        requestSignal?.addEventListener(
+          "abort",
+          () => {
+            const err = new Error("aborted");
+            err.name = "AbortError";
+            reject(err);
+          },
+          { once: true },
+        );
+      });
+    }) as typeof fetch;
+
+    const channel = createTelegramChannel({
+      id: "gw_tg_stop",
+      accountId: "ag_self",
+      botToken: "tok",
+      allowedChatIds: ["42"],
+      allowedSenderIds: ["42"],
+      stateFile: path.join(tmp, "state.json"),
+      stateDebounceMs: 0,
+      fetchImpl,
+    });
+    const abort = new AbortController();
+    const { ctx } = makeStartCtx({ abort });
+    const startPromise = channel.start(ctx);
+
+    await fetchStartedPromise;
+    expect(requestSignal?.aborted).toBe(false);
+    await channel.stop!({ reason: "remove_gateway" });
+    await startPromise;
+
+    expect(requestSignal?.aborted).toBe(true);
+    expect(calls[0]!.url).toContain("/getUpdates");
+  });
 });
 
 describe("createTelegramChannel — send()", () => {

--- a/packages/daemon/src/gateway/channels/telegram.ts
+++ b/packages/daemon/src/gateway/channels/telegram.ts
@@ -152,16 +152,18 @@ export function createTelegramChannel(opts: TelegramChannelOptions): ChannelAdap
     method: string,
     params: Record<string, unknown>,
     timeoutMs: number,
+    abortSignal?: AbortSignal,
   ): Promise<TelegramApiResult<T>> {
     if (!botToken) throw new Error("telegram bot token not loaded");
     const url = `${baseUrl}/bot${botToken}/${method}`;
+    const signalLease = createTimeoutSignal(timeoutMs, abortSignal);
     let resp: Response;
     try {
       resp = await fetchImpl(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(params),
-        signal: AbortSignal.timeout(timeoutMs),
+        signal: signalLease.signal,
       });
     } catch (err) {
       // C3: fetch errors often stringify the URL (which embeds the token).
@@ -171,6 +173,8 @@ export function createTelegramChannel(opts: TelegramChannelOptions): ChannelAdap
       const next = new Error(redacted);
       next.name = e.name ?? "Error";
       throw next;
+    } finally {
+      signalLease.cleanup();
     }
     const json = (await resp.json()) as TelegramApiResult<T>;
     return json;
@@ -280,13 +284,13 @@ export function createTelegramChannel(opts: TelegramChannelOptions): ChannelAdap
     log.info("telegram poll loop starting", { gatewayId: opts.id, offset });
 
     let stopped = false;
+    const stopController = new AbortController();
     const onAbort = () => {
       stopped = true;
+      stopController.abort();
     };
     abortSignal.addEventListener("abort", onAbort, { once: true });
-    stopCallback = () => {
-      stopped = true;
-    };
+    stopCallback = onAbort;
 
     while (!stopped && !abortSignal.aborted) {
       try {
@@ -298,6 +302,7 @@ export function createTelegramChannel(opts: TelegramChannelOptions): ChannelAdap
             allowed_updates: ["message"],
           },
           (POLL_TIMEOUT_S + 15) * 1000,
+          stopController.signal,
         );
         markStatus({ lastPollAt: Date.now() });
         if (!resp.ok) {
@@ -465,4 +470,43 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
     };
     signal?.addEventListener("abort", onAbort, { once: true });
   });
+}
+
+function createTimeoutSignal(
+  timeoutMs: number,
+  parent?: AbortSignal,
+): { signal: AbortSignal; cleanup: () => void } {
+  const controller = new AbortController();
+  let settled = false;
+
+  const abort = (reason?: unknown) => {
+    if (settled) return;
+    settled = true;
+    try {
+      controller.abort(reason);
+    } catch {
+      controller.abort();
+    }
+  };
+
+  const timer = setTimeout(() => {
+    abort(new DOMException("Timeout", "TimeoutError"));
+  }, timeoutMs);
+
+  const onParentAbort = () => abort(parent?.reason);
+  if (parent) {
+    if (parent.aborted) {
+      onParentAbort();
+    } else {
+      parent.addEventListener("abort", onParentAbort, { once: true });
+    }
+  }
+
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      clearTimeout(timer);
+      if (parent) parent.removeEventListener("abort", onParentAbort);
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- abort in-flight Telegram `getUpdates` requests when a gateway channel is stopped or removed
- keep Telegram API request timeout handling while also honoring the channel lifecycle abort signal
- add coverage that `stop()` cancels an active long-poll request

## DB migration
- Not needed. This only changes daemon runtime lifecycle behavior; no persisted schema changes.

## Tests
- `cd packages/daemon && npm test -- --run src/gateway/__tests__/telegram-channel.test.ts`
- `cd packages/daemon && npm test -- --run src/__tests__/gateway-control.test.ts`
- `cd packages/daemon && npm test -- --run src/gateway/__tests__/gateway-add-channel.test.ts`
- `cd packages/daemon && npx tsc -p tsconfig.build.json --noEmit`