### PR TITLE
fix: render WeChat login QR code

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "next": "16.1.7",
     "nextjs-toploader": "3.9.17",
     "postgres": "^3.4.8",
+    "qrcode.react": "^4.2.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       postgres:
         specifier: ^3.4.8
         version: 3.4.8
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -2222,6 +2225,11 @@ packages:
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react-dom@19.2.3:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
@@ -4536,6 +4544,10 @@ snapshots:
       react-is: 16.13.1
 
   property-information@7.1.0: {}
+
+  qrcode.react@4.2.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
 
   react-dom@19.2.3(react@19.2.3):
     dependencies:

--- a/frontend/src/components/dashboard/AgentChannelsTab.tsx
+++ b/frontend/src/components/dashboard/AgentChannelsTab.tsx
@@ -23,6 +23,7 @@ import {
   Trash2,
   X,
 } from "lucide-react";
+import { QRCodeSVG } from "qrcode.react";
 import {
   useAgentGatewayStore,
   type AgentGatewayConnection,
@@ -822,12 +823,15 @@ function WechatAddForm({
         <div className="space-y-2 rounded-lg border border-glass-border bg-deep-black/40 p-3">
           <div className="text-xs text-text-secondary">{statusText[status]}</div>
           {qrcodeUrl ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              src={qrcodeUrl}
-              alt="WeChat 二维码"
-              className="h-44 w-44 rounded-md border border-glass-border bg-white p-1"
-            />
+            <div className="inline-flex h-44 w-44 items-center justify-center rounded-md border border-glass-border bg-white p-2">
+              <QRCodeSVG
+                value={qrcodeUrl}
+                size={160}
+                marginSize={1}
+                level="M"
+                title="WeChat 二维码"
+              />
+            </div>
           ) : qrcode ? (
             <div className="space-y-1.5">
               <div className="break-all rounded-md border border-glass-border bg-glass-bg/40 p-2 font-mono text-[10px] text-text-secondary">


### PR DESCRIPTION
## Summary
- render the WeChat login qrcodeUrl as an actual QR code instead of loading it as an image URL
- add qrcode.react for SVG QR rendering

## Tests
- npm run build

Note: npx tsc --noEmit is currently blocked by existing frontend/tests/api route import errors unrelated to this change.