### PR TITLE
feat: improve WeChat gateway setup

### DIFF
--- a/backend/app/routers/gateways.py
+++ b/backend/app/routers/gateways.py
@@ -153,6 +153,12 @@ class WechatLoginStatusIn(BaseModel):
     login_id: str = Field(..., alias="loginId", min_length=4, max_length=128)
 
 
+class WechatSenderDiscoveryIn(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    login_id: str = Field(..., alias="loginId", min_length=4, max_length=128)
+    timeout_seconds: int = Field(default=0, alias="timeoutSeconds", ge=0, le=10)
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -646,3 +652,38 @@ async def wechat_login_status(
         "baseUrl": result.get("baseUrl"),
         "tokenPreview": result.get("tokenPreview"),
     }
+
+
+@router.post("/{agent_id}/gateways/wechat/senders")
+async def wechat_recent_senders(
+    agent_id: str,
+    body: WechatSenderDiscoveryIn,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Proxy recent WeChat sender discovery to the daemon login session.
+
+    The dashboard calls this after scan confirmation, before the gateway row is
+    saved, so users can whitelist a sender without knowing ``xxx@im.wechat``.
+    """
+    _rate_limit(ctx.user_id, "wechat-login")
+    agent = await _load_daemon_agent_or_422(db, ctx, agent_id)
+    daemon_id = agent.daemon_instance_id
+    assert daemon_id is not None
+    _require_online(daemon_id)
+
+    ack = await send_control_frame(
+        daemon_id,
+        "gateway_recent_senders",
+        {
+            "provider": "wechat",
+            "loginId": body.login_id,
+            "accountId": agent_id,
+            "timeoutSeconds": body.timeout_seconds,
+        },
+    )
+    result = _ack_or_raise(ack)
+    senders = result.get("senders")
+    if not isinstance(senders, list):
+        senders = result.get("users")
+    return {"senders": senders if isinstance(senders, list) else []}

--- a/backend/tests/test_app/test_app_gateways.py
+++ b/backend/tests/test_app/test_app_gateways.py
@@ -621,6 +621,37 @@ async def test_wechat_login_status_proxies(client, seed, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_wechat_recent_senders_proxies(client, seed, monkeypatch):
+    async def fake_send(daemon_instance_id, type_, params=None, timeout_ms=None):
+        assert type_ == "gateway_recent_senders"
+        assert params == {
+            "provider": "wechat",
+            "loginId": "wxl_xyz",
+            "accountId": "ag_daemon",
+            "timeoutSeconds": 8,
+        }
+        return {
+            "ok": True,
+            "result": {
+                "senders": [
+                    {"id": "alice@im.wechat", "label": "Alice"},
+                ],
+            },
+        }
+
+    _patch_daemon(monkeypatch, online=True, send=fake_send)
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    r = await client.post(
+        "/api/agents/ag_daemon/gateways/wechat/senders",
+        headers=headers,
+        json={"loginId": "wxl_xyz", "timeoutSeconds": 8},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["senders"] == [{"id": "alice@im.wechat", "label": "Alice"}]
+
+
+@pytest.mark.asyncio
 async def test_wechat_login_start_offline_returns_409(client, seed, monkeypatch):
     _patch_daemon(monkeypatch, online=False)
     headers = {"Authorization": f"Bearer {seed['token']}"}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "next": "16.1.7",
     "nextjs-toploader": "3.9.17",
     "postgres": "^3.4.8",
+    "qrcode.react": "^4.2.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       postgres:
         specifier: ^3.4.8
         version: 3.4.8
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -2222,6 +2225,11 @@ packages:
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react-dom@19.2.3:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
@@ -4536,6 +4544,10 @@ snapshots:
       react-is: 16.13.1
 
   property-information@7.1.0: {}
+
+  qrcode.react@4.2.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
 
   react-dom@19.2.3(react@19.2.3):
     dependencies:

--- a/frontend/src/app/api/agents/[agentId]/gateways/wechat/senders/route.ts
+++ b/frontend/src/app/api/agents/[agentId]/gateways/wechat/senders/route.ts
@@ -1,0 +1,28 @@
+/**
+ * [INPUT]: agentId from path; POST body { loginId, timeoutSeconds? }
+ * [OUTPUT]: POST /api/agents/[agentId]/gateways/wechat/senders — proxies to Hub
+ * [POS]: BFF helper for discovering WeChat allowedSenderIds after scan login
+ * [PROTOCOL]: update header on changes
+ */
+
+import { NextResponse } from "next/server";
+import { proxyHub } from "../../../../../_lib/proxy-hub";
+
+type Params = { params: Promise<{ agentId: string }> };
+
+export async function POST(req: Request, { params }: Params) {
+  const { agentId } = await params;
+  if (!agentId) {
+    return NextResponse.json({ error: "missing_agent_id" }, { status: 400 });
+  }
+  let body: unknown = {};
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  return proxyHub(
+    `/api/agents/${encodeURIComponent(agentId)}/gateways/wechat/senders`,
+    { method: "POST", body },
+  );
+}

--- a/frontend/src/components/dashboard/AgentChannelsTab.tsx
+++ b/frontend/src/components/dashboard/AgentChannelsTab.tsx
@@ -23,6 +23,7 @@ import {
   Trash2,
   X,
 } from "lucide-react";
+import { QRCodeSVG } from "qrcode.react";
 import {
   useAgentGatewayStore,
   type AgentGatewayConnection,
@@ -822,12 +823,15 @@ function WechatAddForm({
         <div className="space-y-2 rounded-lg border border-glass-border bg-deep-black/40 p-3">
           <div className="text-xs text-text-secondary">{statusText[status]}</div>
           {qrcodeUrl ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              src={qrcodeUrl}
-              alt="WeChat 二维码"
-              className="h-44 w-44 rounded-md border border-glass-border bg-white p-1"
-            />
+            <div className="inline-flex h-44 w-44 items-center justify-center rounded-md border border-glass-border bg-white p-2">
+              <QRCodeSVG
+                value={qrcodeUrl}
+                size={160}
+                marginSize={1}
+                level="M"
+                title="WeChat 二维码"
+              />
+            </div>
           ) : qrcode ? (
             <div className="space-y-1.5">
               <div className="break-all rounded-md border border-glass-border bg-glass-bg/40 p-2 font-mono text-[10px] text-text-secondary">

--- a/frontend/src/components/dashboard/AgentChannelsTab.tsx
+++ b/frontend/src/components/dashboard/AgentChannelsTab.tsx
@@ -689,6 +689,7 @@ function WechatAddForm({
 }) {
   const startWechatLogin = useAgentGatewayStore((s) => s.startWechatLogin);
   const pollWechatLogin = useAgentGatewayStore((s) => s.pollWechatLogin);
+  const discoverWechatSenders = useAgentGatewayStore((s) => s.discoverWechatSenders);
   const create = useAgentGatewayStore((s) => s.create);
 
   const [phase, setPhase] = useState<"idle" | "scanning" | "ready">("idle");
@@ -707,6 +708,13 @@ function WechatAddForm({
   const [enableNow, setEnableNow] = useState(true);
   const [acceptEmpty, setAcceptEmpty] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [discoveringSenders, setDiscoveringSenders] = useState(false);
+  const [discoveredSenders, setDiscoveredSenders] = useState<
+    { id: string; label?: string | null }[]
+  >([]);
+  const [senderDiscoverHint, setSenderDiscoverHint] = useState<string | null>(null);
+  const [senderDiscoverError, setSenderDiscoverError] = useState<string | null>(null);
+  const [copiedSenderId, setCopiedSenderId] = useState<string | null>(null);
   const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
@@ -794,6 +802,60 @@ function WechatAddForm({
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       setBusy(false);
+    }
+  }
+
+  async function handleDiscoverSenders() {
+    if (!loginId || discoveringSenders) return;
+    setDiscoveringSenders(true);
+    setSenderDiscoverHint("等待最近微信消息...");
+    setSenderDiscoverError(null);
+    setDiscoveredSenders([]);
+    try {
+      let senders: { id: string; label?: string | null }[] = [];
+      for (let attempt = 1; attempt <= 3; attempt += 1) {
+        setSenderDiscoverHint(
+          attempt === 1
+            ? "等待最近微信消息..."
+            : `还没发现消息，继续等待 ${attempt}/3...`,
+        );
+        const result = await discoverWechatSenders(agentId, loginId, {
+          timeoutSeconds: 8,
+        });
+        senders = result.senders;
+        if (senders.length > 0) break;
+      }
+      setDiscoveredSenders(senders);
+      if (senders.length === 1) {
+        setSenderIds(senders[0].id);
+        setSenderDiscoverHint("已自动填入发现的微信用户 ID。");
+      } else if (senders.length === 0) {
+        setSenderDiscoverHint(null);
+        setSenderDiscoverError("还没有发现用户。请先用要授权的微信账号发一条消息，再读取。");
+      } else {
+        setSenderDiscoverHint("发现多个用户，请选择要允许的微信用户 ID。");
+      }
+    } catch (err) {
+      setSenderDiscoverHint(null);
+      setSenderDiscoverError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setDiscoveringSenders(false);
+    }
+  }
+
+  function appendSenderId(id: string) {
+    const existing = new Set(csvToList(senderIds));
+    existing.add(id);
+    setSenderIds(Array.from(existing).join("\n"));
+  }
+
+  async function copySenderId(id: string) {
+    try {
+      await navigator.clipboard.writeText(id);
+      setCopiedSenderId(id);
+      window.setTimeout(() => setCopiedSenderId(null), 1600);
+    } catch {
+      setSenderDiscoverError("复制失败，请手动复制微信用户 ID。");
     }
   }
 
@@ -894,6 +956,84 @@ function WechatAddForm({
               placeholder="xxx@im.wechat"
               className="w-full resize-none rounded-lg border border-glass-border bg-deep-black/40 px-3 py-2 font-mono text-xs text-text-primary outline-none focus:border-neon-cyan/40 disabled:opacity-50"
             />
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                onClick={handleDiscoverSenders}
+                disabled={!loginId || busy || discoveringSenders}
+                className="inline-flex items-center gap-1 rounded-md border border-glass-border bg-glass-bg/50 px-2.5 py-1 text-[11px] text-text-secondary hover:border-neon-cyan/35 hover:text-neon-cyan disabled:opacity-50"
+              >
+                {discoveringSenders ? (
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                ) : (
+                  <Search className="h-3 w-3" />
+                )}
+                读取最近微信用户 ID
+              </button>
+              <span className="text-[10px] text-text-tertiary">
+                先用要授权的微信账号发一条消息。
+              </span>
+            </div>
+            {discoveredSenders.length > 0 && (
+              <div className="mt-2 space-y-1.5">
+                {discoveredSenders.map((sender) => (
+                  <div
+                    key={sender.id}
+                    className="flex flex-wrap items-center gap-2 rounded-lg border border-glass-border bg-glass-bg/45 px-2.5 py-2"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <span className="block max-w-[180px] truncate text-[11px] font-medium text-text-primary">
+                        {sender.label || "未命名用户"}
+                      </span>
+                      <code className="mt-1 block break-all font-mono text-[10px] text-neon-cyan">
+                        {sender.id}
+                      </code>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-1">
+                      <button
+                        type="button"
+                        onClick={() => setSenderIds(sender.id)}
+                        disabled={busy}
+                        className="rounded border border-neon-cyan/35 bg-neon-cyan/10 px-2 py-1 text-[10px] text-neon-cyan hover:bg-neon-cyan/20 disabled:opacity-50"
+                      >
+                        填入
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => appendSenderId(sender.id)}
+                        disabled={busy}
+                        className="rounded border border-glass-border px-2 py-1 text-[10px] text-text-secondary hover:border-neon-cyan/35 hover:text-neon-cyan disabled:opacity-50"
+                      >
+                        追加
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => copySenderId(sender.id)}
+                        disabled={busy}
+                        title={copiedSenderId === sender.id ? "已复制" : "复制微信用户 ID"}
+                        className="inline-flex h-6 w-6 items-center justify-center rounded border border-glass-border text-text-secondary hover:border-neon-cyan/35 hover:text-neon-cyan disabled:opacity-50"
+                      >
+                        {copiedSenderId === sender.id ? (
+                          <CheckCircle2 className="h-3 w-3" />
+                        ) : (
+                          <Copy className="h-3 w-3" />
+                        )}
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+            {senderDiscoverHint && (
+              <p className="mt-1 text-[10px] leading-relaxed text-text-tertiary">
+                {senderDiscoverHint}
+              </p>
+            )}
+            {senderDiscoverError && (
+              <p className="mt-1 text-[10px] leading-relaxed text-amber-200">
+                {senderDiscoverError}
+              </p>
+            )}
           </Field>
           <label className="flex cursor-pointer items-center gap-2 text-xs text-text-primary">
             <input

--- a/frontend/src/store/useAgentGatewayStore.ts
+++ b/frontend/src/store/useAgentGatewayStore.ts
@@ -83,6 +83,15 @@ export interface WechatLoginStatusResponse {
   tokenPreview?: string | null;
 }
 
+export interface WechatSenderDiscoveryItem {
+  id: string;
+  label?: string | null;
+}
+
+export interface WechatSenderDiscoveryResponse {
+  senders: WechatSenderDiscoveryItem[];
+}
+
 export interface GatewayTestResult {
   ok: boolean;
   message?: string | null;
@@ -174,6 +183,11 @@ interface AgentGatewayState {
     agentId: string,
     loginId: string,
   ) => Promise<WechatLoginStatusResponse>;
+  discoverWechatSenders: (
+    agentId: string,
+    loginId: string,
+    opts?: { timeoutSeconds?: number },
+  ) => Promise<WechatSenderDiscoveryResponse>;
 }
 
 function base(agentId: string): string {
@@ -379,5 +393,54 @@ export const useAgentGatewayStore = create<AgentGatewayState>((set, get) => ({
       baseUrl: json.baseUrl ?? null,
       tokenPreview: json.tokenPreview ?? null,
     };
+  },
+
+  async discoverWechatSenders(agentId, loginId, opts) {
+    const res = await fetch(`${base(agentId)}/wechat/senders`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        loginId,
+        timeoutSeconds: opts?.timeoutSeconds ?? 0,
+      }),
+    });
+    if (!res.ok) {
+      const err = await readErr(res);
+      if (err.status === 409) {
+        set((s) => ({ daemonOffline: { ...s.daemonOffline, [agentId]: true } }));
+      }
+      throw err;
+    }
+    const json = (await res.json()) as { senders?: unknown[] };
+    const senders: WechatSenderDiscoveryItem[] = [];
+    if (Array.isArray(json.senders)) {
+      for (const item of json.senders) {
+        if (typeof item === "string") {
+          senders.push({ id: item, label: null });
+          continue;
+        }
+        if (!item || typeof item !== "object") continue;
+        const raw = item as Record<string, unknown>;
+        const id =
+          typeof raw.id === "string"
+            ? raw.id
+            : typeof raw.userId === "string"
+              ? raw.userId
+              : typeof raw.senderId === "string"
+                ? raw.senderId
+                : "";
+        if (!id) continue;
+        const label =
+          typeof raw.label === "string"
+            ? raw.label
+            : typeof raw.name === "string"
+              ? raw.name
+              : typeof raw.remark === "string"
+                ? raw.remark
+                : null;
+        senders.push({ id, label });
+      }
+    }
+    return { senders };
   },
 }));


### PR DESCRIPTION
## Summary
- render the WeChat login QR code directly in the gateway setup flow
- add a WeChat sender discovery endpoint through the Hub/BFF
- let users read recent WeChat user IDs and fill/append/copy them in the whitelist UI

## Tests
- cd backend && uv run pytest tests/test_app/test_app_gateways.py -q
- cd frontend && npm run build