### PR TITLE
fix: handle WeChat sender discovery in daemon

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botcord/daemon",
-  "version": "0.2.41",
+  "version": "0.2.42",
   "description": "BotCord local daemon — bridges Hub inbox push to local Claude Code / Codex / Gemini CLIs",
   "type": "module",
   "bin": {

--- a/packages/daemon/src/__tests__/gateway-control.test.ts
+++ b/packages/daemon/src/__tests__/gateway-control.test.ts
@@ -239,6 +239,87 @@ describe("gateway_login_start / status", () => {
     // Bot token never escapes the daemon.
     expect(JSON.stringify(statusResult)).not.toContain("wechat-bot-token-1234567890");
   });
+
+  it("discovers recent WeChat senders from a confirmed login session", async () => {
+    const gw = makeFakeGateway();
+    const { io } = makeConfigIO(baseCfg());
+    const sessions = new LoginSessionStore();
+    sessions.create({
+      loginId: "wxl_discover",
+      accountId: "ag_alice",
+      provider: "wechat",
+      qrcode: "QR",
+      baseUrl: "https://ilinkai.weixin.qq.com",
+      botToken: "wechat-bot-token-1234567890",
+    });
+    const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+      expect(String(_url)).toBe("https://ilinkai.weixin.qq.com/ilink/bot/getupdates");
+      expect(init?.method).toBe("POST");
+      expect((init?.headers as Record<string, string>).Authorization).toBe(
+        "Bearer wechat-bot-token-1234567890",
+      );
+      return {
+        text: async () =>
+          JSON.stringify({
+            ret: 0,
+            msgs: [
+              { from_user_id: "alice@im.wechat", from_user_name: "Alice" },
+              { from_user_id: "bob@im.wechat" },
+              { from_user_id: "alice@im.wechat", from_user_name: "Alice" },
+              { to_user_id: "ignored" },
+            ],
+          }),
+      };
+    });
+    const ctrl = createGatewayControl({
+      gateway: gw as any,
+      configIO: io,
+      loginSessions: sessions,
+      fetchImpl: fetchImpl as any,
+    });
+
+    const ack = await ctrl.handleRecentSenders({
+      provider: "wechat",
+      loginId: "wxl_discover",
+      accountId: "ag_alice",
+      timeoutSeconds: 8,
+    });
+
+    expect(ack.ok).toBe(true);
+    expect(ack.result).toEqual({
+      senders: [
+        { id: "alice@im.wechat", label: "Alice" },
+        { id: "bob@im.wechat", label: null },
+      ],
+    });
+  });
+
+  it("rejects sender discovery before WeChat login is confirmed", async () => {
+    const gw = makeFakeGateway();
+    const { io } = makeConfigIO(baseCfg());
+    const sessions = new LoginSessionStore();
+    sessions.create({
+      loginId: "wxl_pending",
+      accountId: "ag_alice",
+      provider: "wechat",
+      qrcode: "QR",
+      baseUrl: "https://ilinkai.weixin.qq.com",
+    });
+    const ctrl = createGatewayControl({
+      gateway: gw as any,
+      configIO: io,
+      loginSessions: sessions,
+    });
+
+    const ack = await ctrl.handleRecentSenders({
+      provider: "wechat",
+      loginId: "wxl_pending",
+      accountId: "ag_alice",
+    });
+
+    expect(ack.ok).toBe(false);
+    expect(ack.error?.code).toBe("login_unconfirmed");
+  });
 });
 
 describe("frame schema validation", () => {

--- a/packages/daemon/src/__tests__/provision.test.ts
+++ b/packages/daemon/src/__tests__/provision.test.ts
@@ -1763,4 +1763,19 @@ describe("W8: gateway frame param validation in provision dispatch", () => {
     expect(ack.ok).toBe(false);
     expect(ack.error?.code).toBe("bad_params");
   });
+
+  it("rejects malformed GATEWAY_RECENT_SENDERS (missing accountId)", async () => {
+    const gw = makeFakeGateway();
+    const provisioner = createProvisioner({
+      gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+    });
+    const ack = await provisioner({
+      id: "req_w8f",
+      type: "gateway_recent_senders",
+      params: { provider: "wechat", loginId: "wxl_1" },
+    });
+    expect(ack.ok).toBe(false);
+    expect(ack.error?.code).toBe("bad_params");
+    expect(ack.error?.message).toContain("accountId");
+  });
 });

--- a/packages/daemon/src/gateway-control.ts
+++ b/packages/daemon/src/gateway-control.ts
@@ -33,6 +33,7 @@ import {
   getBotQrcode,
   getQrcodeStatus,
 } from "./gateway/channels/wechat-login.js";
+import { WECHAT_BASE_INFO, wechatHeaders } from "./gateway/channels/wechat-http.js";
 import { assertSafeBaseUrl, UnsafeBaseUrlError } from "./gateway/channels/url-guard.js";
 import { log as daemonLog } from "./log.js";
 // W7: canonical FetchLike lives in gateway/channels/http-types.ts so the
@@ -141,6 +142,22 @@ interface GatewayLoginStatusResult {
   status: "pending" | "scanned" | "confirmed" | "expired" | "failed";
   baseUrl?: string;
   tokenPreview?: string;
+}
+
+interface GatewayRecentSendersParams {
+  provider: GatewayProvider;
+  loginId: string;
+  accountId: string;
+  timeoutSeconds?: number;
+}
+
+interface GatewayRecentSender {
+  id: string;
+  label?: string | null;
+}
+
+interface GatewayRecentSendersResult {
+  senders: GatewayRecentSender[];
 }
 
 export type { FetchLike };
@@ -664,6 +681,92 @@ export function createGatewayControl(ctx: GatewayControlContext) {
     return { ok: true, result };
   }
 
+  // --- gateway_recent_senders --------------------------------------------
+  async function handleRecentSenders(params: GatewayRecentSendersParams): Promise<AckBody> {
+    if (!isProvider(params.provider)) {
+      return badParams(`gateway_recent_senders: unknown provider "${String(params.provider)}"`);
+    }
+    if (params.provider !== "wechat") {
+      return badParams(`gateway_recent_senders: provider "${params.provider}" not supported`);
+    }
+    if (!params.loginId) {
+      return badParams("gateway_recent_senders: loginId is required");
+    }
+    if (!params.accountId || typeof params.accountId !== "string") {
+      return badParams("gateway_recent_senders: accountId is required");
+    }
+    const session = sessions.get(params.loginId);
+    if (!session) {
+      return {
+        ok: false,
+        error: { code: "login_expired", message: `wechat login session "${params.loginId}" not found or expired` },
+      };
+    }
+    if (session.provider !== "wechat") {
+      return badParams("gateway_recent_senders: provider does not match login session");
+    }
+    if (session.accountId !== params.accountId) {
+      return {
+        ok: false,
+        error: {
+          code: "forbidden",
+          message: "gateway_recent_senders: accountId does not match login session",
+        },
+      };
+    }
+    if (!session.botToken) {
+      return {
+        ok: false,
+        error: { code: "login_unconfirmed", message: "wechat login session has no bot token yet" },
+      };
+    }
+    try {
+      assertSafeBaseUrl(session.baseUrl);
+    } catch (urlErr) {
+      if (urlErr instanceof UnsafeBaseUrlError) return badParams(urlErr.message);
+      throw urlErr;
+    }
+
+    const baseUrl = (session.baseUrl ?? DEFAULT_WECHAT_BASE_URL).replace(/\/+$/, "");
+    const timeoutSeconds =
+      typeof params.timeoutSeconds === "number"
+        ? Math.min(Math.max(Math.floor(params.timeoutSeconds), 0), 10)
+        : 0;
+    try {
+      const res = await fetchImpl(`${baseUrl}/ilink/bot/getupdates`, {
+        method: "POST",
+        headers: wechatHeaders(session.botToken),
+        body: JSON.stringify({
+          get_updates_buf: "",
+          base_info: { ...WECHAT_BASE_INFO },
+        }),
+        signal: AbortSignal.timeout((timeoutSeconds + 10) * 1000),
+      });
+      const raw = await res.text();
+      const data = raw ? (JSON.parse(raw) as { msgs?: unknown[]; ret?: number }) : {};
+      if (data.ret !== undefined && data.ret !== 0) {
+        return {
+          ok: false,
+          error: {
+            code: "provider_auth_failed",
+            message: `wechat getupdates failed: ret=${data.ret}`,
+          },
+        };
+      }
+      const result: GatewayRecentSendersResult = {
+        senders: extractWechatSenders(data.msgs),
+      };
+      return { ok: true, result };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      daemonLog.warn("gateway_recent_senders.getupdates failed", { error: message });
+      return {
+        ok: false,
+        error: { code: "provider_unreachable", message },
+      };
+    }
+  }
+
   return {
     handleList,
     handleUpsert,
@@ -671,6 +774,7 @@ export function createGatewayControl(ctx: GatewayControlContext) {
     handleTest,
     handleLoginStart,
     handleLoginStatus,
+    handleRecentSenders,
     /** Exposed for tests — direct access to the in-memory session map. */
     _sessions: sessions,
   };
@@ -793,4 +897,21 @@ function mapWechatStatus(raw: string): GatewayLoginStatusResult["status"] {
   if (v === "pending" || v === "waiting") return "pending";
   if (v === "expired" || v === "timeout") return "expired";
   return "failed";
+}
+
+function extractWechatSenders(msgs: unknown): GatewayRecentSender[] {
+  const out = new Map<string, GatewayRecentSender>();
+  if (!Array.isArray(msgs)) return [];
+  for (const msg of msgs) {
+    if (!msg || typeof msg !== "object") continue;
+    const raw = msg as Record<string, unknown>;
+    const id = typeof raw.from_user_id === "string" ? raw.from_user_id.trim() : "";
+    if (!id) continue;
+    const label =
+      (typeof raw.from_user_name === "string" && raw.from_user_name.trim()) ||
+      (typeof raw.sender_name === "string" && raw.sender_name.trim()) ||
+      null;
+    out.set(id, { id, label });
+  }
+  return Array.from(out.values());
 }

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -371,6 +371,16 @@ export function createProvisioner(opts: ProvisionerOptions): (
         );
       }
 
+      case "gateway_recent_senders": {
+        const v = validateGatewayParams(frame.params, {
+          required: ["provider", "loginId", "accountId"],
+        });
+        if (!v.ok) return v.ack;
+        return gatewayControl.handleRecentSenders(
+          v.params as unknown as Parameters<typeof gatewayControl.handleRecentSenders>[0],
+        );
+      }
+
       case "list_agent_files": {
         const params = (frame.params ?? {}) as unknown as ListAgentFilesParams;
         if (!params.agentId) {

--- a/packages/protocol-core/src/control-frame.ts
+++ b/packages/protocol-core/src/control-frame.ts
@@ -134,6 +134,12 @@ export const CONTROL_FRAME_TYPES = {
    * the user scans + confirms; bot token never leaves the daemon.
    */
   GATEWAY_LOGIN_STATUS: "gateway_login_status",
+  /**
+   * Hub→daemon: discover recent provider sender ids for setup UX. WeChat
+   * uses the confirmed login session's bot token to inspect recent updates
+   * before the gateway row is saved.
+   */
+  GATEWAY_RECENT_SENDERS: "gateway_recent_senders",
 } as const;
 
 export type ControlFrameType = (typeof CONTROL_FRAME_TYPES)[keyof typeof CONTROL_FRAME_TYPES];
@@ -688,4 +694,23 @@ export interface GatewayLoginStatusResult {
   baseUrl?: string;
   /** Masked token preview, e.g. `"abcd...wxyz"`. Only present on `confirmed`. */
   tokenPreview?: string;
+}
+
+/** Payload shape for `gateway_recent_senders`. */
+export interface GatewayRecentSendersParams {
+  provider: GatewayProvider;
+  loginId: string;
+  /** W4: accountId ownership check — must match the login session's accountId. */
+  accountId: string;
+  /** Optional long-poll timeout. Daemon clamps to 0..10 seconds. */
+  timeoutSeconds?: number;
+}
+
+export interface GatewayRecentSender {
+  id: string;
+  label?: string | null;
+}
+
+export interface GatewayRecentSendersResult {
+  senders: GatewayRecentSender[];
 }


### PR DESCRIPTION
## Summary
- add daemon support for the gateway_recent_senders control frame
- discover recent WeChat from_user_id values from confirmed login sessions
- add protocol-core types and bump @botcord/daemon to 0.2.42

## Fixes
- Resolves preview error: unknown control frame type "gateway_recent_senders"

## Tests
- cd packages/daemon && npm test -- --run src/__tests__/gateway-control.test.ts src/__tests__/provision.test.ts
- cd packages/daemon && npm run build

## Notes
- protocol-core direct build was not run because that package lacks local node_modules in this workspace; daemon build passed against the change.