### PR TITLE
fix: deliver Telegram and WeChat runtime replies

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botcord/daemon",
-  "version": "0.2.42",
+  "version": "0.2.43",
   "description": "BotCord local daemon — bridges Hub inbox push to local Claude Code / Codex / Gemini CLIs",
   "type": "module",
   "bin": {

--- a/packages/daemon/src/gateway/__tests__/transcript.test.ts
+++ b/packages/daemon/src/gateway/__tests__/transcript.test.ts
@@ -43,6 +43,11 @@ class FakeChannel implements ChannelAdapter {
   }
 }
 
+class FakeTelegramChannel extends FakeChannel {
+  override readonly id = "gw_telegram_test";
+  override readonly type = "telegram";
+}
+
 interface FakeRuntimeOptions {
   reply?: string;
   newSessionId?: string;
@@ -284,6 +289,26 @@ describe("Dispatcher transcript integration", () => {
     const out = recs.find((r) => r.kind === "outbound") as Extract<TranscriptRecord, { kind: "outbound" }>;
     expect(out.deliveryStatus).toBe("gated_non_owner_chat");
     expect(s.channel.sends.length).toBe(0);
+  });
+
+  it("third-party direct chat: runtime text is delivered", async () => {
+    const channel = new FakeTelegramChannel();
+    const s = track(await scaffold({
+      runtimeFactory: () => new FakeRuntime({ reply: "ok" }),
+      channel,
+    }));
+    await s.dispatcher.handle(
+      makeEnvelope({
+        channel: "gw_telegram_test",
+        conversation: { id: "telegram:user:7904063707", kind: "direct" },
+        sender: { id: "telegram:user:7904063707", kind: "user", name: "danny_aaas" },
+      }),
+    );
+    const recs = await s.recordsForRoom("telegram:user:7904063707");
+    const out = recs.find((r) => r.kind === "outbound") as Extract<TranscriptRecord, { kind: "outbound" }>;
+    expect(out.deliveryStatus).toBe("delivered");
+    expect(channel.sends).toHaveLength(1);
+    expect(channel.sends[0].message.conversationId).toBe("telegram:user:7904063707");
   });
 
   it("dashboard_user_chat raw.source_type → delivered even outside rm_oc_", async () => {

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -1076,11 +1076,12 @@ export class Dispatcher {
         return;
       }
 
-      // Reply gating: only owner-chat rooms accept the runtime's plain text
-      // output as a delivered message. Every other room expects the agent to
+      // Reply gating: BotCord network rooms only accept the runtime's plain
+      // text output in owner-chat. Other BotCord rooms expect the agent to
       // call the `botcord_send` tool (or `botcord send` CLI via Bash)
-      // explicitly; runtime text in those rooms is logged and dropped,
-      // including timeout / error notifications.
+      // explicitly, so final assistant text is logged and dropped there.
+      // Third-party gateways (Telegram / WeChat) are themselves direct
+      // message transports; their final runtime text is the reply.
       //
       // Owner-chat is identified by either the `rm_oc_` room prefix OR
       // `source_type === "dashboard_user_chat"` on the raw envelope — the
@@ -1093,6 +1094,7 @@ export class Dispatcher {
       // expectation is that the agent's `botcord_send` tool calls do their
       // own loop-risk accounting downstream.
       const isOwnerChat = isOwnerChatRoom(msg);
+      const canDeliverRuntimeText = isOwnerChat || !isBotCordChannel(channel);
 
       if (slot.timedOut) {
         this.transcript.write({
@@ -1106,7 +1108,7 @@ export class Dispatcher {
           error: `runtime timeout after ${this.turnTimeoutMs}ms`,
           durationMs: Date.now() - slot.dispatchedAt,
         });
-        if (isOwnerChat) {
+        if (canDeliverRuntimeText) {
           await this.sendReply(channel, {
             channel: msg.channel,
             accountId: msg.accountId,
@@ -1151,7 +1153,7 @@ export class Dispatcher {
           error: errMsg,
           durationMs: Date.now() - slot.dispatchedAt,
         });
-        if (isOwnerChat) {
+        if (canDeliverRuntimeText) {
           await this.sendReply(channel, {
             channel: msg.channel,
             accountId: msg.accountId,
@@ -1240,7 +1242,7 @@ export class Dispatcher {
             runtime: route.runtime,
             error: result.error,
           });
-          if (isOwnerChat) {
+          if (canDeliverRuntimeText) {
             const sendResult = await this.sendReply(channel, {
               channel: msg.channel,
               accountId: msg.accountId,
@@ -1280,8 +1282,8 @@ export class Dispatcher {
         return;
       }
 
-      if (!isOwnerChat) {
-        // Non-owner-chat rooms: result.text never goes out. The agent is
+      if (!canDeliverRuntimeText) {
+        // Non-owner BotCord rooms: result.text never goes out. The agent is
         // expected to have used the `botcord_send` tool / `botcord send` CLI
         // already; whatever it left in the runtime's final assistant text is
         // discarded so it doesn't leak into the room.
@@ -1494,6 +1496,10 @@ function isOwnerChatRoom(msg: GatewayInboundEnvelope["message"]): boolean {
     if (sourceType === "dashboard_user_chat") return true;
   }
   return false;
+}
+
+function isBotCordChannel(channel: ChannelAdapter): boolean {
+  return channel.type === "botcord" || channel.id === "botcord";
 }
 
 function resolveQueueMode(


### PR DESCRIPTION
## Summary
- keep BotCord non-owner room final-text gating intact
- allow third-party gateway channels such as Telegram and WeChat to deliver runtime final text directly
- add a regression test for Telegram direct chats and bump @botcord/daemon to 0.2.43

## Fixes
- Resolves Telegram inbound turns ending as deliveryStatus=gated_non_owner_chat with no Telegram reply

## Tests
- cd packages/daemon && npm test -- --run src/gateway/__tests__/transcript.test.ts src/gateway/__tests__/dispatcher.test.ts
- cd packages/daemon && npm run build