### PR TITLE
fix: surface OpenClaw ACP empty responses

### DIFF
--- a/packages/daemon/src/__tests__/openclaw-acp.test.ts
+++ b/packages/daemon/src/__tests__/openclaw-acp.test.ts
@@ -162,6 +162,46 @@ describe("OpenclawAcpAdapter.run", () => {
     expect(spawnFn.mock.calls[0][1]).toEqual(["acp", "--url", "ws://127.0.0.1:1"]);
   });
 
+  it("returns an error instead of empty text when OpenClaw emits warnings and no assistant text", async () => {
+    const child = new FakeChild();
+    const adapter = new OpenclawAcpAdapter({ spawnFn: makeSpawn(child) });
+    const gateway: ResolvedOpenclawGateway = {
+      name: "local",
+      url: "ws://127.0.0.1:1",
+      openclawAgent: "main",
+    };
+
+    child.stdin.on("data", (chunk: Buffer) => {
+      for (const line of chunk.toString("utf8").split("\n").filter(Boolean)) {
+        const frame = JSON.parse(line);
+        if (frame.method === "initialize") {
+          child.stdout.write("◇  Config warnings ─────────────────────╮\n");
+          child.stdout.write("│  - models.providers.foo.apiKey: Missing env var FOO_API_KEY │\n");
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { protocolVersion: 1 } }) + "\n");
+        } else if (frame.method === "session/new") {
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { sessionId: "sid-warn" } }) + "\n");
+        } else if (frame.method === "session/prompt") {
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { stopReason: "error" } }) + "\n");
+        }
+      }
+    });
+
+    const res = await adapter.run({
+      text: "hi",
+      sessionId: null,
+      cwd: "/tmp",
+      accountId: "ag_alice",
+      signal: new AbortController().signal,
+      trustLevel: "owner",
+      gateway,
+    });
+
+    expect(res.text).toBe("");
+    expect(res.newSessionId).toBe("sid-warn");
+    expect(res.error).toContain("prompt stopped: error");
+    expect(res.error).toContain("Missing env var FOO_API_KEY");
+  });
+
   it("streams only final text when OpenClaw sends reasoning before a final block", async () => {
     const child = new FakeChild();
     const adapter = new OpenclawAcpAdapter({ spawnFn: makeSpawn(child) });

--- a/packages/daemon/src/gateway/runtimes/openclaw-acp.ts
+++ b/packages/daemon/src/gateway/runtimes/openclaw-acp.ts
@@ -37,6 +37,7 @@ interface AcpProcessHandle {
   subscribers: Map<string, (note: AcpNotification) => void>;
   nextId: number;
   buffer: string;
+  nonJsonStdoutTail: string[];
   initialized: boolean;
   initializePromise?: Promise<void>;
   idleTimer?: NodeJS.Timeout;
@@ -355,6 +356,14 @@ export class OpenclawAcpAdapter implements RuntimeAdapter {
         log.warn("openclaw-acp.assistant-text-capped", { sessionId: acpSessionId });
       }
 
+      if (!finalText) {
+        const stopReason = pickStopReason(promptResult);
+        const warningTail = handle.nonJsonStdoutTail.slice(-8).join("\n").trim();
+        const detail = warningTail ? `; stdout: ${truncateDetail(warningTail, 1000)}` : "";
+        const reason = stopReason ? `prompt stopped: ${stopReason}` : "empty assistant response";
+        return failResult(acpSessionId, `openclaw-acp: ${reason}${detail}`);
+      }
+
       return {
         text: finalText,
         newSessionId: acpSessionId,
@@ -447,6 +456,7 @@ export class OpenclawAcpAdapter implements RuntimeAdapter {
       subscribers: new Map(),
       nextId: 1,
       buffer: "",
+      nonJsonStdoutTail: [],
       initialized: false,
       inFlight: 0,
       closed: false,
@@ -533,6 +543,10 @@ function onStdoutChunk(handle: AcpProcessHandle, chunk: string): void {
     try {
       msg = JSON.parse(line);
     } catch (err) {
+      handle.nonJsonStdoutTail.push(line.slice(0, 500));
+      if (handle.nonJsonStdoutTail.length > 20) {
+        handle.nonJsonStdoutTail.splice(0, handle.nonJsonStdoutTail.length - 20);
+      }
       log.warn("openclaw-acp.parse-error", {
         error: err instanceof Error ? err.message : String(err),
         line: line.slice(0, 200),
@@ -845,6 +859,16 @@ function pickFinalText(result: unknown): string | undefined {
   if (typeof r.text === "string" && r.text.length > 0) return r.text;
   if (typeof r.message === "string" && r.message.length > 0) return r.message;
   return undefined;
+}
+
+function pickStopReason(result: unknown): string | undefined {
+  if (!result || typeof result !== "object") return undefined;
+  const v = (result as Record<string, unknown>).stopReason;
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+function truncateDetail(text: string, max: number): string {
+  return text.length <= max ? text : `${text.slice(0, max)}…`;
 }
 
 function looksLikeReasoningLeak(text: string): boolean {


### PR DESCRIPTION
## Summary
- keep a short tail of non-JSON OpenClaw ACP stdout warnings
- return a runtime error when ACP completes without assistant text instead of silently producing empty_text
- add regression coverage for config warning + stopReason=error responses

## Fixes
- Turns OpenClaw ACP config-warning failures into visible runtime errors for Telegram/WeChat instead of empty replies

## Tests
- cd packages/daemon && npm test -- --run src/__tests__/openclaw-acp.test.ts src/gateway/__tests__/transcript.test.ts
- cd packages/daemon && npm run build