### PR TITLE
fix: strip openclaw acp leading boundary residue

### DIFF
--- a/packages/daemon/src/__tests__/openclaw-acp.test.ts
+++ b/packages/daemon/src/__tests__/openclaw-acp.test.ts
@@ -265,6 +265,88 @@ describe("OpenclawAcpAdapter.run", () => {
     );
   });
 
+  it("strips a lone leading ACP boundary marker from final prompt text", async () => {
+    const child = new FakeChild();
+    const adapter = new OpenclawAcpAdapter({ spawnFn: makeSpawn(child) });
+    const gateway: ResolvedOpenclawGateway = {
+      name: "local",
+      url: "ws://127.0.0.1:1",
+      openclawAgent: "main",
+    };
+
+    child.stdin.on("data", (chunk: Buffer) => {
+      for (const line of chunk.toString("utf8").split("\n").filter(Boolean)) {
+        const frame = JSON.parse(line);
+        if (frame.method === "initialize") {
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { protocolVersion: 1 } }) + "\n");
+        } else if (frame.method === "session/new") {
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { sessionId: "sid-boundary" } }) + "\n");
+        } else if (frame.method === "session/prompt") {
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { text: "<你好！终于可以正常交流了。" } }) + "\n");
+        }
+      }
+    });
+
+    const res = await adapter.run({
+      text: "hi",
+      sessionId: null,
+      cwd: "/tmp",
+      accountId: "ag_alice",
+      signal: new AbortController().signal,
+      trustLevel: "owner",
+      gateway,
+    });
+
+    expect(res.text).toBe("你好！终于可以正常交流了。");
+  });
+
+  it("strips a lone leading ACP boundary marker from streamed fallback text", async () => {
+    const child = new FakeChild();
+    const adapter = new OpenclawAcpAdapter({ spawnFn: makeSpawn(child) });
+    const gateway: ResolvedOpenclawGateway = {
+      name: "local",
+      url: "ws://127.0.0.1:1",
+      openclawAgent: "main",
+    };
+
+    child.stdin.on("data", (chunk: Buffer) => {
+      for (const line of chunk.toString("utf8").split("\n").filter(Boolean)) {
+        const frame = JSON.parse(line);
+        if (frame.method === "initialize") {
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { protocolVersion: 1 } }) + "\n");
+        } else if (frame.method === "session/new") {
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { sessionId: "sid-stream-boundary" } }) + "\n");
+        } else if (frame.method === "session/prompt") {
+          for (const text of ["<", "好！终于可以正常交流了。"]) {
+            child.stdout.write(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                method: "session/update",
+                params: {
+                  sessionId: "sid-stream-boundary",
+                  update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text } },
+                },
+              }) + "\n",
+            );
+          }
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { stopReason: "end_turn" } }) + "\n");
+        }
+      }
+    });
+
+    const res = await adapter.run({
+      text: "hi",
+      sessionId: null,
+      cwd: "/tmp",
+      accountId: "ag_alice",
+      signal: new AbortController().signal,
+      trustLevel: "owner",
+      gateway,
+    });
+
+    expect(res.text).toBe("好！终于可以正常交流了。");
+  });
+
   it("respawns the pooled child when gateway.url or gateway.token changes under the same name", async () => {
     function newChild(): FakeChild {
       const c = new FakeChild();

--- a/packages/daemon/src/gateway/runtimes/openclaw-acp.ts
+++ b/packages/daemon/src/gateway/runtimes/openclaw-acp.ts
@@ -709,10 +709,20 @@ function normalizeAssistantText(text: string | undefined): string {
   if (!finalMatch && selected.trimStart().toLowerCase().startsWith("<think")) {
     return "";
   }
-  return selected
+  return stripLeadingBoundaryResidue(selected
     .replace(/<think[^>]*>[\s\S]*?<\/think>/gi, "")
     .replace(/<\/?final>/gi, "")
-    .trim();
+    .trim());
+}
+
+function stripLeadingBoundaryResidue(text: string): string {
+  if (!text.startsWith("<")) return text;
+  // Keep real HTML/XML-ish tags and common comparison operators. A lone
+  // leading "<" before normal prose can be left behind when ACP streams a
+  // structural marker boundary separately from the final assistant text.
+  if (/^<\/?[A-Za-z][A-Za-z0-9:-]*(?:\s|>|\/>)/.test(text)) return text;
+  if (/^<(?:\s|=|<)/.test(text)) return text;
+  return text.slice(1).trimStart();
 }
 
 function createAssistantTextFilter(): {


### PR DESCRIPTION
## Summary
- strip a lone leading ACP boundary marker from normalized OpenClaw assistant text
- preserve real HTML/XML-ish tags and comparison operators
- cover both final prompt text and streamed fallback text cases

## Tests
- cd packages/daemon && npm test -- --run src/__tests__/openclaw-acp.test.ts
- cd packages/daemon && npm run build