### PR TITLE
fix: hold openclaw acp angle boundary chunks

### DIFF
--- a/packages/daemon/src/__tests__/openclaw-acp.test.ts
+++ b/packages/daemon/src/__tests__/openclaw-acp.test.ts
@@ -334,6 +334,59 @@ describe("OpenclawAcpAdapter.run", () => {
       }
     });
 
+    const blocks: any[] = [];
+    const res = await adapter.run({
+      text: "hi",
+      sessionId: null,
+      cwd: "/tmp",
+      accountId: "ag_alice",
+      signal: new AbortController().signal,
+      trustLevel: "owner",
+      gateway,
+      onBlock: (b) => blocks.push(b),
+    });
+
+    expect(res.text).toBe("好！终于可以正常交流了。");
+    const assistantChunks = blocks
+      .filter((b) => b.kind === "assistant_text")
+      .map((b) => b.raw.params.update.content[0].text);
+    expect(assistantChunks).toEqual(["好！终于可以正常交流了。"]);
+  });
+
+  it("preserves real leading angle syntax in streamed fallback text", async () => {
+    const child = new FakeChild();
+    const adapter = new OpenclawAcpAdapter({ spawnFn: makeSpawn(child) });
+    const gateway: ResolvedOpenclawGateway = {
+      name: "local",
+      url: "ws://127.0.0.1:1",
+      openclawAgent: "main",
+    };
+
+    child.stdin.on("data", (chunk: Buffer) => {
+      for (const line of chunk.toString("utf8").split("\n").filter(Boolean)) {
+        const frame = JSON.parse(line);
+        if (frame.method === "initialize") {
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { protocolVersion: 1 } }) + "\n");
+        } else if (frame.method === "session/new") {
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { sessionId: "sid-angle" } }) + "\n");
+        } else if (frame.method === "session/prompt") {
+          for (const text of ["<", "b>bold</b> and ", "<", " 5"]) {
+            child.stdout.write(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                method: "session/update",
+                params: {
+                  sessionId: "sid-angle",
+                  update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text } },
+                },
+              }) + "\n",
+            );
+          }
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { stopReason: "end_turn" } }) + "\n");
+        }
+      }
+    });
+
     const res = await adapter.run({
       text: "hi",
       sessionId: null,
@@ -344,7 +397,44 @@ describe("OpenclawAcpAdapter.run", () => {
       gateway,
     });
 
-    expect(res.text).toBe("好！终于可以正常交流了。");
+    expect(res.text).toBe("<b>bold</b> and < 5");
+  });
+
+  it("forwards slash-command user text to session/prompt unchanged", async () => {
+    const child = new FakeChild();
+    const adapter = new OpenclawAcpAdapter({ spawnFn: makeSpawn(child) });
+    const gateway: ResolvedOpenclawGateway = {
+      name: "local",
+      url: "ws://127.0.0.1:1",
+      openclawAgent: "main",
+    };
+    let promptPayload: any = null;
+
+    child.stdin.on("data", (chunk: Buffer) => {
+      for (const line of chunk.toString("utf8").split("\n").filter(Boolean)) {
+        const frame = JSON.parse(line);
+        if (frame.method === "initialize") {
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { protocolVersion: 1 } }) + "\n");
+        } else if (frame.method === "session/new") {
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { sessionId: "sid-slash" } }) + "\n");
+        } else if (frame.method === "session/prompt") {
+          promptPayload = frame.params.prompt;
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { text: "ok" } }) + "\n");
+        }
+      }
+    });
+
+    await adapter.run({
+      text: "/start",
+      sessionId: null,
+      cwd: "/tmp",
+      accountId: "ag_alice",
+      signal: new AbortController().signal,
+      trustLevel: "owner",
+      gateway,
+    });
+
+    expect(promptPayload).toEqual([{ type: "text", text: "/start" }]);
   });
 
   it("respawns the pooled child when gateway.url or gateway.token changes under the same name", async () => {

--- a/packages/daemon/src/gateway/runtimes/openclaw-acp.ts
+++ b/packages/daemon/src/gateway/runtimes/openclaw-acp.ts
@@ -720,9 +720,15 @@ function stripLeadingBoundaryResidue(text: string): string {
   // Keep real HTML/XML-ish tags and common comparison operators. A lone
   // leading "<" before normal prose can be left behind when ACP streams a
   // structural marker boundary separately from the final assistant text.
-  if (/^<\/?[A-Za-z][A-Za-z0-9:-]*(?:\s|>|\/>)/.test(text)) return text;
-  if (/^<(?:\s|=|<)/.test(text)) return text;
+  if (startsWithRealAngleSyntax(text)) return text;
   return text.slice(1).trimStart();
+}
+
+function startsWithRealAngleSyntax(text: string): boolean {
+  return (
+    /^<\/?[A-Za-z][A-Za-z0-9:-]*(?:\s|>|\/>)/.test(text) ||
+    /^<(?:\s|=|<)/.test(text)
+  );
 }
 
 function createAssistantTextFilter(): {
@@ -830,7 +836,18 @@ function createAssistantTextFilter(): {
         return out;
       }
 
-      out += "<";
+      if (!flush && pending === "<") {
+        return out;
+      }
+      if (!startsWithRealAngleSyntax(pending)) {
+        pending = pending.slice(1).trimStart();
+        continue;
+      }
+      if (seenFinal) {
+        out += "<";
+      } else {
+        fallback += "<";
+      }
       pending = pending.slice(1);
     }
     if (flush && !seenFinal && fallback) {


### PR DESCRIPTION
## Summary
- do not emit a lone leading < from OpenClaw ACP streamed chunks before confirming the marker type
- drop ACP boundary residue before normal prose while preserving real HTML/XML-ish tags and comparison operators
- add coverage for streamed boundary residue, real angle syntax, and slash-command prompt forwarding

## Tests
- cd packages/daemon && npm test -- --run src/__tests__/openclaw-acp.test.ts
- cd packages/daemon && npm run build