### PR TITLE
fix: separate inbox room context from message body

### DIFF
--- a/backend/hub/routers/hub.py
+++ b/backend/hub/routers/hub.py
@@ -21,7 +21,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from hub.auth import get_current_claimed_agent, get_dashboard_claimed_agent, verify_agent_token
-from hub.config import INBOX_POLL_MAX_TIMEOUT, PAIR_RATE_LIMIT_PER_MINUTE, RATE_LIMIT_PER_MINUTE
+from hub.config import (
+    HUB_PUBLIC_BASE_URL,
+    INBOX_POLL_MAX_TIMEOUT,
+    PAIR_RATE_LIMIT_PER_MINUTE,
+    RATE_LIMIT_PER_MINUTE,
+)
 from hub.constants import MIN_PLUGIN_VERSION, get_latest_plugin_version, is_below_min_version
 from hub.crypto import check_timestamp, verify_envelope_sig, verify_payload_hash
 from hub.dashboard_message_shaping import load_user_display_names
@@ -50,10 +55,6 @@ from hub.models import (
 )
 from hub.enums import ApprovalKind, ApprovalState, ParticipantType
 from hub.policy import Principal, check_direct_admission
-from hub.forward import (
-    RoomContext as _RoomContext,
-    build_flat_text as _build_flat_text,
-)
 from hub.prompt_guard import scan_content, InjectionRisk
 from hub.schemas import (
     HistoryMessage,
@@ -149,6 +150,43 @@ def build_agent_realtime_event(
 
 def _message_preview(payload: dict[str, Any]) -> str:
     return (payload.get("text") or payload.get("message") or "")[:160]
+
+
+def _inbox_body_text(envelope: MessageEnvelope) -> str:
+    """Return only the sender-authored body for /hub/inbox `text`.
+
+    Room metadata, topic, goal, mentions, sender identity, and delivery
+    context are exposed as structured InboxMessage fields and should be
+    rendered by the runtime adapter outside the message body.
+    """
+    p = envelope.payload
+    if envelope.type == MessageType.message:
+        text_value = p.get("text") or p.get("body") or p.get("message")
+        body = (
+            text_value
+            if isinstance(text_value, str) and text_value
+            else json.dumps(p, ensure_ascii=False)
+        )
+        attachments = p.get("attachments", [])
+        if isinstance(attachments, list) and attachments:
+            att_lines = []
+            for att in attachments:
+                if not isinstance(att, dict):
+                    continue
+                name = att.get("filename", "file")
+                url = att.get("url", "")
+                if isinstance(url, str) and url.startswith("/"):
+                    url = f"{HUB_PUBLIC_BASE_URL}{url}"
+                size = att.get("size_bytes")
+                size_str = f", {size} bytes" if size else ""
+                att_lines.append(f"  📎 {name}{size_str}: {url}")
+            if att_lines:
+                body = (body or "") + "\n【Attachments】\n" + "\n".join(att_lines)
+        return body
+    if envelope.type == MessageType.contact_request:
+        msg = p.get("message")
+        return msg if isinstance(msg, str) and msg else "sent you a contact request."
+    return envelope.to_text(include_sender=False)
 
 
 def build_message_realtime_event(
@@ -1423,17 +1461,6 @@ async def poll_inbox(
                 "my_can_send": my_can_send,
             }
 
-    # Batch-load sender display names
-    sender_ids = {rec.sender_id for rec in rows if rec.sender_id}
-    sender_name_map: dict[str, str | None] = {}
-    if sender_ids:
-        sender_result = await db.execute(
-            select(Agent.agent_id, Agent.display_name).where(
-                Agent.agent_id.in_(sender_ids)
-            )
-        )
-        sender_name_map = dict(sender_result.all())
-
     # Batch-load dashboard user display names (owner-chat + human-room rows
     # store an internal User.id in source_user_id — the shared helper falls
     # back to supabase_user_id for legacy rows).
@@ -1453,27 +1480,11 @@ async def poll_inbox(
         envelope = MessageEnvelope(**envelope_data)
         ri = room_info_map.get(rec.room_id) if rec.room_id else None
 
-        # Build RoomContext for build_flat_text
-        room_ctx = None
-        if ri:
-            room_ctx = _RoomContext(
-                room_id=rec.room_id,
-                name=ri["name"],
-                member_count=ri["member_count"],
-                rule=ri.get("rule"),
-                member_names=ri["member_names"],
-                my_role=ri.get("my_role"),
-                my_can_send=ri.get("my_can_send"),
-            )
-
-        flat_text = _build_flat_text(
-            envelope,
-            sender_display_name=sender_name_map.get(rec.sender_id),
-            room_context=room_ctx,
-            mentioned=rec.mentioned,
-            topic_id=rec.topic_id,
-            include_sender=rec.source_type != "dashboard_user_chat",
-        )
+        # Keep inbox `text` focused on the message body. Room metadata is
+        # returned below as structured fields (`room_name`, `room_rule`,
+        # `room_member_names`, `my_role`, ...), so local runtimes can place it
+        # outside sender message blocks instead of mixing context into content.
+        flat_text = _inbox_body_text(envelope)
 
         messages.append(
             InboxMessage(

--- a/backend/tests/test_room.py
+++ b/backend/tests/test_room.py
@@ -1439,8 +1439,7 @@ async def test_inbox_includes_room_rule_and_text_hint(client: AsyncClient):
     message = inbox.json()["messages"][0]
     assert message["room_id"] == room_id
     assert message["room_rule"] == "Only post deploy status updates."
-    assert "[房间规则] Only post deploy status updates." in message["text"]
-    assert "[系统提示] 你在该群聊中的行为和回复必须遵循上述房间规则。" in message["text"]
+    assert message["text"] == "deploy started"
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/dashboard/MessageComposer.test.ts
+++ b/frontend/src/components/dashboard/MessageComposer.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { textHasMention } from "./MessageComposer";
+
+describe("textHasMention", () => {
+  it("keeps structured @Name(agentId) mentions active", () => {
+    expect(textHasMention("@Harry(ag_973dfb9193eb) 今天的AI日报发一下呢", "Harry")).toBe(true);
+  });
+
+  it("does not match a display name prefix inside a longer name", () => {
+    expect(textHasMention("@HarryPotter please reply", "Harry")).toBe(false);
+  });
+});

--- a/frontend/src/components/dashboard/MessageComposer.tsx
+++ b/frontend/src/components/dashboard/MessageComposer.tsx
@@ -54,14 +54,14 @@ function detectMention(text: string, cursor: number): MentionMatch | null {
 // Boundary-aware check: returns true only when "@<displayName>" appears in text
 // followed by a word boundary (whitespace, punctuation, or end-of-string).
 // Without this, "@Alice" would be incorrectly detected inside "@AliceX".
-function textHasMention(text: string, displayName: string): boolean {
+export function textHasMention(text: string, displayName: string): boolean {
   const needle = `@${displayName}`;
   let idx = 0;
   while (true) {
     const found = text.indexOf(needle, idx);
     if (found === -1) return false;
     const after = text[found + needle.length];
-    if (after === undefined || /[\s.,!?;:)\]}'"]/.test(after)) return true;
+    if (after === undefined || /[\s.,!?;:()\]}'"]/.test(after)) return true;
     idx = found + needle.length;
   }
 }

--- a/packages/daemon/src/__tests__/mention-scan.test.ts
+++ b/packages/daemon/src/__tests__/mention-scan.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { scanMention } from "../mention-scan.js";
+
+describe("scanMention", () => {
+  it("matches the exact agent id in structured @Name(agentId) mentions", () => {
+    expect(
+      scanMention("@Harry(ag_973dfb9193eb) 今天的AI日报发一下呢", {
+        agentId: "ag_973dfb9193eb",
+      }),
+    ).toBe(true);
+  });
+
+  it("still matches display-name mentions", () => {
+    expect(scanMention("@Harry 今天的AI日报发一下呢", { displayName: "Harry" })).toBe(true);
+  });
+});

--- a/packages/daemon/src/__tests__/turn-text.test.ts
+++ b/packages/daemon/src/__tests__/turn-text.test.ts
@@ -57,6 +57,33 @@ describe("composeBotCordUserTurn", () => {
     expect(out).toContain("mentioned: true");
   });
 
+  it("renders structured room context outside the human message body", () => {
+    const out = composeBotCordUserTurn(
+      makeMessage({
+        sender: { id: "hu_alice", name: "Alice", kind: "user" },
+        text: "@Harry(ag_973dfb9193eb) 今天的AI日报发一下呢",
+        conversation: { id: "rm_news", kind: "group", title: "AI News Daily Brief" },
+        raw: {
+          room_id: "rm_news",
+          room_name: "AI News Daily Brief",
+          room_member_count: 6,
+          room_member_names: ["Alice", "Harry"],
+          my_role: "member",
+          my_can_send: true,
+          room_rule: "Post concise daily summaries.",
+        },
+      }),
+    );
+    const roomIdx = out.indexOf("[BotCord Room]");
+    const tagIdx = out.indexOf('<human-message sender="Alice" sender_kind="human">');
+    const closeIdx = out.indexOf("</human-message>");
+    expect(roomIdx).toBeGreaterThan(-1);
+    expect(roomIdx).toBeLessThan(tagIdx);
+    expect(out).toContain("[Room Rule] Post concise daily summaries.");
+    expect(out.slice(tagIdx, closeIdx)).not.toContain("[BotCord Room]");
+    expect(out.slice(tagIdx, closeIdx)).toContain("@Harry(ag_973dfb9193eb)");
+  });
+
   it("emits the direct-chat hint (not the group hint) for DM conversations", () => {
     const out = composeBotCordUserTurn(
       makeMessage({

--- a/packages/daemon/src/mention-scan.ts
+++ b/packages/daemon/src/mention-scan.ts
@@ -24,8 +24,12 @@ export interface MentionTargets {
 export function scanMention(text: string | undefined, targets: MentionTargets): boolean {
   if (!text) return false;
   const lower = text.toLowerCase();
+  const normalizedAgentId = targets.agentId?.trim().toLowerCase();
+  if (normalizedAgentId && lower.includes("(" + normalizedAgentId + ")")) {
+    return true;
+  }
   const candidates: string[] = [];
-  if (targets.agentId) candidates.push(targets.agentId.toLowerCase());
+  if (normalizedAgentId) candidates.push(normalizedAgentId);
   if (targets.displayName) {
     const trimmed = targets.displayName.trim();
     if (trimmed) candidates.push(trimmed.toLowerCase());

--- a/packages/daemon/src/turn-text.ts
+++ b/packages/daemon/src/turn-text.ts
@@ -88,6 +88,16 @@ interface BatchedEntry {
   mentioned?: unknown;
 }
 
+interface RoomContextRaw {
+  room_id?: unknown;
+  room_name?: unknown;
+  room_rule?: unknown;
+  room_member_count?: unknown;
+  room_member_names?: unknown;
+  my_role?: unknown;
+  my_can_send?: unknown;
+}
+
 /**
  * Read the `raw.batch` array emitted by the BotCord channel when inbox
  * drain groups multiple messages for the same `(room, topic)`. Returns the
@@ -123,6 +133,36 @@ function entryText(e: BatchedEntry): string {
   if (typeof e.text === "string") return e.text;
   if (typeof e.envelope?.payload?.text === "string") return e.envelope.payload.text;
   return "";
+}
+
+function formatRoomContext(raw: unknown, fallback: { id: string; title?: string }): string[] {
+  const r = raw && typeof raw === "object" ? (raw as RoomContextRaw) : {};
+  const roomId = typeof r.room_id === "string" && r.room_id ? r.room_id : fallback.id;
+  const roomName = typeof r.room_name === "string" && r.room_name ? r.room_name : fallback.title;
+  const memberCount =
+    typeof r.room_member_count === "number" && Number.isFinite(r.room_member_count)
+      ? r.room_member_count
+      : undefined;
+  const memberNames = Array.isArray(r.room_member_names)
+    ? r.room_member_names.filter((n): n is string => typeof n === "string" && n.length > 0)
+    : [];
+  const role = typeof r.my_role === "string" && r.my_role ? r.my_role : undefined;
+  const canSend = typeof r.my_can_send === "boolean" ? r.my_can_send : undefined;
+
+  const parts = [`id: ${sanitizeSenderName(roomId)}`];
+  if (roomName) parts.push(`name: ${sanitizeSenderName(roomName)}`);
+  if (memberCount !== undefined) {
+    const names = memberNames.slice(0, 10).map(sanitizeSenderName).join(", ");
+    parts.push(names ? `members: ${memberCount}: ${names}` : `members: ${memberCount}`);
+  }
+  if (role) parts.push(`role: ${sanitizeSenderName(role)}`);
+  if (canSend !== undefined) parts.push(`can_send: ${canSend ? "true" : "false"}`);
+
+  const lines = [`[BotCord Room] | ${parts.join(" | ")}`];
+  if (typeof r.room_rule === "string" && r.room_rule.trim()) {
+    lines.push(`[Room Rule] ${sanitizeUntrustedContent(r.room_rule.trim())}`);
+  }
+  return lines;
 }
 
 /**
@@ -193,6 +233,7 @@ export function composeBotCordUserTurn(msg: GatewayInboundMessage): string {
 
   const lines: string[] = [
     headerFields.join(" | "),
+    ...(isGroup ? formatRoomContext(msg.raw, { id: conversation.id, title: roomTitle }) : []),
     `<${tag} sender="${sanitizedSenderLabel}" sender_kind="${senderKindAttr}">`,
     trimmed,
     `</${tag}>`,
@@ -256,6 +297,7 @@ function composeBatchedTurn(
   const hint = isGroup ? GROUP_HINT : DIRECT_HINT;
   const lines: string[] = [
     header.join(" | "),
+    ...(isGroup ? formatRoomContext(msg.raw, { id: conversation.id, title: roomTitle }) : []),
     blocks.join("\n"),
     "",
     hint,


### PR DESCRIPTION
## Summary
- keep Hub inbox `text` focused on sender-authored message body and leave room metadata in structured fields
- render BotCord room metadata outside daemon `<human-message>` / `<agent-message>` blocks
- preserve structured `@Name(agentId)` mentions in the frontend and daemon fallback scanner

## Tests
- `cd backend && uv run pytest tests/test_room.py::test_inbox_includes_room_rule_and_text_hint tests/test_room.py::test_mention_specific_agent`
- `cd packages/daemon && npm test -- turn-text.test.ts mention-scan.test.ts`
- `cd frontend && npm test -- MessageComposer.test.ts`