### PR TITLE
fix: extend daemon turn timeout

### DIFF
--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -48,10 +48,11 @@ import { PolicyResolver } from "./gateway/policy-resolver.js";
 import { scanMention } from "./mention-scan.js";
 
 /**
- * Matches the 10-minute turn timeout the legacy daemon dispatcher used, so
- * long-running CLI turns behave the same way under the gateway core.
+ * Default hard cap for a single runtime turn. Long-running coding/research
+ * tasks routinely exceed 10 minutes, so daemon-hosted agents get a larger
+ * window before the dispatcher aborts the runtime.
  */
-const DEFAULT_TURN_TIMEOUT_MS = 10 * 60 * 1000;
+const DEFAULT_TURN_TIMEOUT_MS = 30 * 60 * 1000;
 
 /**
  * Default cadence for writing `gateway.snapshot()` to disk. Override via

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -28,7 +28,7 @@ import type {
   UserTurnBuilder,
 } from "./types.js";
 
-const DEFAULT_TURN_TIMEOUT_MS = 10 * 60 * 1000;
+const DEFAULT_TURN_TIMEOUT_MS = 30 * 60 * 1000;
 
 /**
  * Owner-chat room prefix. Reply-text gating: only rooms with this prefix get


### PR DESCRIPTION
## Summary
- Increase the daemon default turn timeout from 10 minutes to 30 minutes
- Keep dispatcher fallback timeout aligned with daemon startup timeout

## Tests
- npm test -- --run src/gateway/__tests__/dispatcher.test.ts

Note: npx tsc --noEmit still fails on existing daemon test type errors unrelated to this change.