### PR TITLE
feat: add share room social cards

### DIFF
--- a/frontend/src/app/(marketing)/share/[shareId]/og-image/route.tsx
+++ b/frontend/src/app/(marketing)/share/[shareId]/og-image/route.tsx
@@ -1,0 +1,161 @@
+import { ImageResponse } from "next/og";
+import {
+  getShareMetadataData,
+  truncate,
+} from "@/lib/share-metadata";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ shareId: string }> },
+) {
+  const { shareId } = await params;
+  const data = await getShareMetadataData(shareId);
+  const roomName = data ? truncate(data.roomName, 72) : "BotCord shared room";
+  const description = data
+    ? truncate(data.roomDescription || `Shared by ${data.sharedBy}`, 132)
+    : "Open this BotCord room snapshot and continue in the chat app.";
+  const messageCount = data?.messageCount ?? 0;
+  const memberCount = data?.memberCount ?? 0;
+  const entryLabel = data?.entryType === "paid_room"
+    ? "Paid room"
+    : data?.entryType === "private_room"
+      ? "Private snapshot"
+      : "Shared room";
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          background: "#07090d",
+          color: "#f6f8fb",
+          padding: 72,
+          fontFamily: "Inter, Arial, sans-serif",
+          position: "relative",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            background:
+              "linear-gradient(135deg, rgba(0,240,255,0.20), transparent 34%), radial-gradient(circle at 78% 22%, rgba(255,214,10,0.20), transparent 28%), linear-gradient(180deg, rgba(255,255,255,0.06), transparent)",
+          }}
+        />
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            position: "relative",
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: 18 }}>
+            <div
+              style={{
+                width: 54,
+                height: 54,
+                borderRadius: 16,
+                background: "#f6f8fb",
+                color: "#07090d",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontSize: 28,
+                fontWeight: 900,
+              }}
+            >
+              B
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+              <div style={{ fontSize: 30, fontWeight: 800 }}>BotCord</div>
+              <div style={{ fontSize: 18, color: "#a8b3c7" }}>room snapshot</div>
+            </div>
+          </div>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              border: "1px solid rgba(255,255,255,0.18)",
+              borderRadius: 999,
+              padding: "12px 20px",
+              color: "#00f0ff",
+              fontSize: 20,
+              fontWeight: 700,
+              textTransform: "uppercase",
+            }}
+          >
+            {entryLabel}
+          </div>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 26, position: "relative" }}>
+          <div
+            style={{
+              display: "flex",
+              fontSize: 72,
+              lineHeight: 1.03,
+              fontWeight: 900,
+              maxWidth: 920,
+            }}
+          >
+            {roomName}
+          </div>
+          <div
+            style={{
+              display: "flex",
+              fontSize: 30,
+              lineHeight: 1.35,
+              color: "#c9d2e3",
+              maxWidth: 930,
+            }}
+          >
+            {description}
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "flex-end",
+            position: "relative",
+          }}
+        >
+          <div style={{ display: "flex", gap: 16 }}>
+            <Metric label="messages" value={messageCount} />
+            <Metric label="members" value={memberCount} />
+          </div>
+          <div style={{ color: "#7f8ca3", fontSize: 22 }}>www.botcord.chat</div>
+        </div>
+      </div>
+    ),
+    {
+      width: 1200,
+      height: 630,
+    },
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 4,
+        border: "1px solid rgba(255,255,255,0.16)",
+        borderRadius: 18,
+        padding: "16px 22px",
+        minWidth: 132,
+      }}
+    >
+      <div style={{ fontSize: 32, fontWeight: 900 }}>{value}</div>
+      <div style={{ fontSize: 16, color: "#8d9bb2", textTransform: "uppercase" }}>{label}</div>
+    </div>
+  );
+}

--- a/frontend/src/app/(marketing)/share/[shareId]/page.tsx
+++ b/frontend/src/app/(marketing)/share/[shareId]/page.tsx
@@ -1,10 +1,52 @@
 import type { Metadata } from "next";
 import SharedRoomView from "@/components/share/SharedRoomView";
+import {
+  buildShareDescription,
+  buildShareTitle,
+  getAppBaseUrl,
+  getShareMetadataData,
+} from "@/lib/share-metadata";
 
-export const metadata: Metadata = {
-  title: "BotCord Group Invite | BotCord 群邀请",
-  description: "Open a BotCord group link and continue in the BotCord chat app. 打开 BotCord 群链接，并在 BotCord 聊天应用中继续。",
-};
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ shareId: string }>;
+}): Promise<Metadata> {
+  const { shareId } = await params;
+  const data = await getShareMetadataData(shareId);
+  const title = buildShareTitle(data);
+  const description = buildShareDescription(data);
+  const appBaseUrl = getAppBaseUrl();
+  const pageUrl = new URL(`/share/${shareId}`, appBaseUrl);
+  const imageUrl = new URL(`/share/${shareId}/og-image`, appBaseUrl);
+
+  return {
+    title,
+    description,
+    alternates: { canonical: pageUrl },
+    openGraph: {
+      title,
+      description,
+      url: pageUrl,
+      siteName: "BotCord",
+      type: "article",
+      images: [
+        {
+          url: imageUrl,
+          width: 1200,
+          height: 630,
+          alt: data ? `${data.roomName} shared on BotCord` : "BotCord shared room",
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [imageUrl],
+    },
+  };
+}
 
 export default async function SharePage({
   params,

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -9,9 +9,11 @@ import type { Metadata } from "next";
 import { Analytics } from "@vercel/analytics/next";
 import NextTopLoader from "nextjs-toploader";
 import { inter, jetbrainsMono } from "@/lib/fonts";
+import { getAppBaseUrl } from "@/lib/share-metadata";
 import "./globals.css";
 
 export const metadata: Metadata = {
+  metadataBase: new URL(getAppBaseUrl()),
   title: "BotCord — Discord for Bots",
   description:
     "Agent-to-Agent Messaging Protocol for the AI Native Social era",

--- a/frontend/src/lib/share-metadata.ts
+++ b/frontend/src/lib/share-metadata.ts
@@ -1,0 +1,89 @@
+/**
+ * [INPUT]: public Hub share endpoint and app URL environment
+ * [OUTPUT]: server-side helpers for share-link social metadata and OG image rendering
+ * [POS]: shared metadata layer for /share/[shareId], isolated from browser auth API helpers
+ */
+
+import type { SharedRoomResponse } from "@/lib/types";
+
+const DEFAULT_APP_URL = "https://www.botcord.chat";
+const DEFAULT_HUB_URL = "https://api.botcord.chat";
+
+export type ShareMetadataData = {
+  shareId: string;
+  roomName: string;
+  roomDescription: string;
+  sharedBy: string;
+  sharedAt: string;
+  messageCount: number;
+  memberCount: number;
+  entryType: SharedRoomResponse["entry_type"];
+};
+
+export function getAppBaseUrl(): string {
+  return normalizeAbsoluteUrl(process.env.NEXT_PUBLIC_APP_URL || DEFAULT_APP_URL);
+}
+
+export async function getShareMetadataData(shareId: string): Promise<ShareMetadataData | null> {
+  if (!shareId) return null;
+
+  const hubBaseUrl = normalizeAbsoluteUrl(process.env.NEXT_PUBLIC_HUB_BASE_URL || DEFAULT_HUB_URL);
+  const url = `${hubBaseUrl}/api/share/${encodeURIComponent(shareId)}`;
+
+  try {
+    const res = await fetch(url, {
+      next: { revalidate: 300 },
+    });
+    if (!res.ok) return null;
+
+    const data = (await res.json()) as SharedRoomResponse;
+    return {
+      shareId: data.share_id,
+      roomName: data.room.name || "BotCord shared room",
+      roomDescription: data.room.description || "",
+      sharedBy: data.shared_by || "BotCord",
+      sharedAt: data.shared_at,
+      messageCount: data.messages.length,
+      memberCount: data.room.member_count,
+      entryType: data.entry_type,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function buildShareTitle(data: ShareMetadataData | null): string {
+  if (!data) return "BotCord shared room";
+  return `${data.roomName} | BotCord shared room`;
+}
+
+export function buildShareDescription(data: ShareMetadataData | null): string {
+  if (!data) return "Open this BotCord room snapshot and continue in the chat app.";
+
+  const roomDescription = normalizeWhitespace(data.roomDescription);
+  if (roomDescription) return truncate(roomDescription, 150);
+
+  const messageLabel = data.messageCount === 1 ? "message" : "messages";
+  const memberLabel = data.memberCount === 1 ? "member" : "members";
+  return `A read-only BotCord room snapshot shared by ${data.sharedBy}, with ${data.messageCount} ${messageLabel} and ${data.memberCount} ${memberLabel}.`;
+}
+
+export function truncate(value: string, maxLength: number): string {
+  const text = normalizeWhitespace(value);
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, maxLength - 1).trimEnd()}...`;
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function stripTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+function normalizeAbsoluteUrl(value: string): string {
+  const trimmed = value.trim();
+  const withProtocol = /^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+  return stripTrailingSlash(withProtocol);
+}


### PR DESCRIPTION
## Summary
- Generate per-room metadata for /share/[shareId] from the public Hub share endpoint
- Add a stable dynamic PNG OG image at /share/[shareId]/og-image
- Configure metadataBase from the app URL helper so social image URLs resolve correctly

## Test
- cd frontend && npm run build
- curl local share page to confirm og:title, og:description, and og:image
- curl -I local /share/[shareId]/og-image to confirm image/png