### PR TITLE
feat: add room join system messages

### DIFF
--- a/backend/app/routers/humans.py
+++ b/backend/app/routers/humans.py
@@ -848,12 +848,21 @@ async def join_room_as_human(
     await db.refresh(new_member)
 
     try:
-        from hub.routers.room import _notify_room_member_change
+        from hub.routers.room import (
+            _notify_room_member_change,
+            record_room_member_joined_system_message,
+        )
 
         members_row = await db.execute(
             select(RoomMember.agent_id).where(RoomMember.room_id == room_id)
         )
         all_member_ids = [row[0] for row in members_row.all()]
+        await record_room_member_joined_system_message(
+            db,
+            room_id=room_id,
+            participant_id=me,
+            notify_participant_ids=all_member_ids,
+        )
         await _notify_room_member_change(
             db,
             event_type="room_member_added",
@@ -1285,12 +1294,21 @@ async def invite_room_member_as_human(
 
     # --- W4: realtime broadcast (mirror hub's add_member) -----------------
     try:
-        from hub.routers.room import _notify_room_member_change
+        from hub.routers.room import (
+            _notify_room_member_change,
+            record_room_member_joined_system_message,
+        )
 
         members_row = await db.execute(
             select(RoomMember.agent_id).where(RoomMember.room_id == room_id)
         )
         all_member_ids = [row[0] for row in members_row.all()]
+        await record_room_member_joined_system_message(
+            db,
+            room_id=room_id,
+            participant_id=participant_id,
+            notify_participant_ids=all_member_ids,
+        )
         await _notify_room_member_change(
             db,
             event_type="room_member_added",
@@ -2308,6 +2326,7 @@ async def resolve_pending_approval(
         entry.state = ApprovalState.approved
         entry.resolved_by_user_id = ctx.user_id
         entry.resolved_at = now
+        joined_room_id: str | None = None
 
         if entry.kind == ApprovalKind.contact_request:
             try:
@@ -2359,6 +2378,7 @@ async def resolve_pending_approval(
                         can_invite=payload.get("can_invite"),
                     )
                 )
+                joined_room_id = room_id_for_invite
 
         # For payment and future kinds, approval is recorded; side-effects
         # are handled by their own downstream services.
@@ -2375,6 +2395,22 @@ async def resolve_pending_approval(
             entry.resolved_by_user_id = ctx.user_id
             entry.resolved_at = now
             await db.commit()
+            joined_room_id = None
+        if joined_room_id:
+            try:
+                from hub.routers.room import record_room_member_joined_system_message
+
+                members_row = await db.execute(
+                    select(RoomMember.agent_id).where(RoomMember.room_id == joined_room_id)
+                )
+                await record_room_member_joined_system_message(
+                    db,
+                    room_id=joined_room_id,
+                    participant_id=entry.agent_id,
+                    notify_participant_ids=[row[0] for row in members_row.all()],
+                )
+            except Exception:  # pragma: no cover — notification must not break approval
+                _logger.exception("room member joined system message failed for %s", joined_room_id)
         return ResolveApprovalResponse(id=str(entry.id), state="approved")
 
     # reject

--- a/backend/hub/invite_ops.py
+++ b/backend/hub/invite_ops.py
@@ -268,6 +268,18 @@ async def redeem_invite_for_agent(code: str, agent_id: str, db: AsyncSession) ->
     )
     await _record_redemption(invite, agent_id, db)
     await db.commit()
+
+    from hub.routers.room import record_room_member_joined_system_message
+
+    members_row = await db.execute(
+        select(RoomMember.agent_id).where(RoomMember.room_id == room.room_id)
+    )
+    await record_room_member_joined_system_message(
+        db,
+        room_id=room.room_id,
+        participant_id=agent_id,
+        notify_participant_ids=[row[0] for row in members_row.all()],
+    )
     return {
         "status": "redeemed",
         "kind": "room",

--- a/backend/hub/routers/dashboard.py
+++ b/backend/hub/routers/dashboard.py
@@ -818,6 +818,18 @@ async def join_room(
 
     await db.commit()
 
+    from hub.routers.room import record_room_member_joined_system_message
+
+    members_row = await db.execute(
+        select(RoomMember.agent_id).where(RoomMember.room_id == room_id)
+    )
+    await record_room_member_joined_system_message(
+        db,
+        room_id=room_id,
+        participant_id=current_agent,
+        notify_participant_ids=[row[0] for row in members_row.all()],
+    )
+
     # Get updated member count
     updated_count_result = await db.execute(
         select(func.count(RoomMember.id)).where(RoomMember.room_id == room_id)

--- a/backend/hub/routers/room.py
+++ b/backend/hub/routers/room.py
@@ -29,10 +29,15 @@ same room doesn't collide or grant the agent unintended privileges.
 from __future__ import annotations
 
 import asyncio
+import datetime
+import hashlib
+import json
 import logging
 import time
+import uuid
 from collections import defaultdict, deque
 
+import jcs
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from fastapi.responses import JSONResponse
 from hub.i18n import I18nHTTPException
@@ -47,14 +52,16 @@ from hub import config as hub_config
 from hub.config import JOIN_RATE_LIMIT_PER_MINUTE
 from hub.share_payloads import frontend_url
 from hub.database import get_db
-from hub.id_generators import generate_room_id
-from hub.enums import SubscriptionProductStatus, SubscriptionStatus
+from hub.id_generators import generate_hub_msg_id, generate_room_id
+from hub.enums import MessageType, SubscriptionProductStatus, SubscriptionStatus
 from hub.models import (
     Agent,
     AgentApprovalQueue,
     AgentSubscription,
     Contact,
     MessagePolicy,
+    MessageRecord,
+    MessageState,
     Room,
     RoomJoinPolicy,
     RoomMember,
@@ -62,6 +69,7 @@ from hub.models import (
     RoomVisibility,
     SubscriptionRoomCreatorPolicy,
     SubscriptionProduct,
+    User,
 )
 from hub.enums import ApprovalKind, ApprovalState, ParticipantType
 from hub.policy import Principal, check_room_invite_admission
@@ -458,6 +466,113 @@ async def _notify_room_member_change(
         await notify_inbox(agent_id, db=db, realtime_event=event)
 
     await asyncio.gather(*[_send(aid) for aid in notify_agent_ids], return_exceptions=True)
+
+
+async def _participant_display_name(db: AsyncSession, participant_id: str) -> str:
+    if participant_id.startswith("hu_"):
+        result = await db.execute(
+            select(User.display_name).where(User.human_id == participant_id)
+        )
+    else:
+        result = await db.execute(
+            select(Agent.display_name).where(Agent.agent_id == participant_id)
+        )
+    return result.scalar_one_or_none() or participant_id
+
+
+def _build_room_member_joined_envelope(
+    *,
+    room_id: str,
+    participant_id: str,
+    participant_name: str,
+) -> dict:
+    text = f"{participant_name} joined the room"
+    payload = {
+        "text": text,
+        "subtype": "room_member_joined",
+        "room_id": room_id,
+        "participant_id": participant_id,
+        "participant_name": participant_name,
+    }
+    canonical = jcs.canonicalize(payload)
+    payload_hash = "sha256:" + hashlib.sha256(canonical).hexdigest()
+    return {
+        "v": "a2a/0.1",
+        "msg_id": str(uuid.uuid4()),
+        "ts": int(time.time()),
+        "from": "hub",
+        "to": room_id,
+        "type": MessageType.system.value,
+        "reply_to": None,
+        "ttl_sec": 3600,
+        "payload": payload,
+        "payload_hash": payload_hash,
+        "sig": {"alg": "ed25519", "key_id": "hub", "value": ""},
+    }
+
+
+async def record_room_member_joined_system_message(
+    db: AsyncSession,
+    *,
+    room_id: str,
+    participant_id: str,
+    notify_participant_ids: list[str] | None = None,
+) -> None:
+    """Persist a WeChat-style room timeline notice for a newly joined member.
+
+    Records are marked delivered so the notice appears in room history without
+    waking agent runtimes through /hub/inbox. Realtime events are still
+    published so dashboards refresh immediately.
+    """
+    from hub.routers.hub import build_message_realtime_event, _publish_agent_realtime_event
+
+    participant_name = await _participant_display_name(db, participant_id)
+    envelope = _build_room_member_joined_envelope(
+        room_id=room_id,
+        participant_id=participant_id,
+        participant_name=participant_name,
+    )
+    envelope_json = json.dumps(envelope)
+    now = datetime.datetime.now(datetime.timezone.utc)
+    receiver_ids = list(dict.fromkeys(notify_participant_ids or [participant_id]))
+    first_hub_msg_id: str | None = None
+
+    for receiver_id in receiver_ids:
+        hub_msg_id = generate_hub_msg_id()
+        if first_hub_msg_id is None:
+            first_hub_msg_id = hub_msg_id
+        db.add(
+            MessageRecord(
+                hub_msg_id=hub_msg_id,
+                msg_id=envelope["msg_id"],
+                sender_id="hub",
+                receiver_id=receiver_id,
+                room_id=room_id,
+                state=MessageState.delivered,
+                envelope_json=envelope_json,
+                ttl_sec=3600,
+                created_at=now,
+                delivered_at=now,
+                source_type="system",
+            )
+        )
+
+    await db.commit()
+
+    for receiver_id in receiver_ids:
+        await _publish_agent_realtime_event(
+            db,
+            build_message_realtime_event(
+                type=MessageType.system.value,
+                agent_id=receiver_id,
+                sender_id="hub",
+                room_id=room_id,
+                hub_msg_id=first_hub_msg_id or "",
+                created_at=now,
+                payload=envelope["payload"],
+                sender_name="BotCord Hub",
+            ),
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -952,6 +1067,12 @@ async def add_member(
 
     # Notify the new member and all existing members about the addition
     all_member_ids = [m.agent_id for m in room.members]
+    await record_room_member_joined_system_message(
+        db,
+        room_id=room.room_id,
+        participant_id=target_agent_id,
+        notify_participant_ids=all_member_ids,
+    )
     await _notify_room_member_change(
         db,
         event_type="room_member_added",

--- a/backend/tests/test_room.py
+++ b/backend/tests/test_room.py
@@ -2,6 +2,7 @@
 
 import base64
 import hashlib
+import json
 import time
 import uuid
 
@@ -10,10 +11,11 @@ import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 from nacl.signing import SigningKey
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from unittest.mock import AsyncMock
 
-from hub.models import Base
+from hub.models import Base, MessageRecord, MessageState
 
 TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
 
@@ -214,6 +216,55 @@ async def test_create_room_with_initial_members(client: AsyncClient):
     assert data["member_count"] == 3
     member_ids = {m["agent_id"] for m in data["members"]}
     assert member_ids == {a_id, b_id, c_id}
+
+
+@pytest.mark.asyncio
+async def test_add_member_creates_room_join_system_message(
+    client: AsyncClient,
+    db_session: AsyncSession,
+):
+    """Adding a member records a WeChat-style system notice in room history."""
+    sk_a, a_id, a_key, a_token = await _create_agent(client, "Alice")
+    sk_b, b_id, b_key, b_token = await _create_agent(client, "Bob")
+
+    resp = await client.post(
+        "/hub/rooms",
+        json={"name": "Team Room"},
+        headers=_auth_header(a_token),
+    )
+    assert resp.status_code == 201
+    room_id = resp.json()["room_id"]
+
+    resp = await client.post(
+        f"/hub/rooms/{room_id}/members",
+        json={"agent_id": b_id},
+        headers=_auth_header(a_token),
+    )
+    assert resp.status_code == 201
+
+    resp = await client.get(
+        f"/dashboard/rooms/{room_id}/messages",
+        headers=_auth_header(a_token),
+    )
+    assert resp.status_code == 200
+    messages = resp.json()["messages"]
+    assert len(messages) == 1
+    assert messages[0]["type"] == "system"
+    assert messages[0]["text"] == "Bob joined the room"
+    assert messages[0]["payload"]["subtype"] == "room_member_joined"
+    assert messages[0]["payload"]["participant_id"] == b_id
+
+    result = await db_session.execute(
+        select(MessageRecord).where(
+            MessageRecord.room_id == room_id,
+            MessageRecord.sender_id == "hub",
+        )
+    )
+    records = list(result.scalars().all())
+    assert len(records) == 2
+    assert {rec.receiver_id for rec in records} == {a_id, b_id}
+    assert all(rec.state == MessageState.delivered for rec in records)
+    assert all(json.loads(rec.envelope_json)["type"] == "system" for rec in records)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a shared backend helper that records room member join notices as system messages
- hook the notice into agent, dashboard, invite redemption, human, and approval-based room joins
- add backend coverage for the room history notice and delivered-only records

## Tests
- cd backend && uv run pytest tests/test_room.py
- cd backend && uv run python -m compileall hub app -q