### PR TITLE
fix: require gateway whitelist

### DIFF
--- a/backend/app/routers/gateways.py
+++ b/backend/app/routers/gateways.py
@@ -353,6 +353,24 @@ def _build_settings(config: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
+def _list_has_value(config: dict[str, Any], key: str) -> bool:
+    value = config.get(key)
+    return isinstance(value, list) and any(
+        isinstance(item, str) and item.strip() for item in value
+    )
+
+
+def _require_whitelist(provider: str, config: dict[str, Any]) -> None:
+    if provider == "telegram":
+        if _list_has_value(config, "allowedChatIds") or _list_has_value(
+            config, "allowedSenderIds"
+        ):
+            return
+        raise HTTPException(status_code=400, detail="missing_gateway_whitelist")
+    if provider == "wechat" and not _list_has_value(config, "allowedSenderIds"):
+        raise HTTPException(status_code=400, detail="missing_gateway_whitelist")
+
+
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
@@ -407,6 +425,7 @@ async def create_gateway(
     gateway_id = generate_gateway_connection_id(body.provider)
     config = _filter_config(body.config)
     _validate_base_url(config.get("baseUrl"))
+    _require_whitelist(body.provider, config)
 
     params: dict[str, Any] = {
         "id": gateway_id,
@@ -480,6 +499,7 @@ async def patch_gateway(
 
     config = dict(row.config_json or {})
     _validate_base_url(config.get("baseUrl"))
+    _require_whitelist(row.provider, config)
     params: dict[str, Any] = {
         "id": row.id,
         "type": row.provider,

--- a/backend/tests/test_app/test_app_gateways.py
+++ b/backend/tests/test_app/test_app_gateways.py
@@ -328,6 +328,46 @@ async def test_create_wechat_requires_login_id(client, seed, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_create_telegram_requires_whitelist(client, seed, monkeypatch):
+    async def fake_send(*a, **kw):
+        raise AssertionError("daemon contacted before whitelist validation")
+
+    _patch_daemon(monkeypatch, online=True, send=fake_send)
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    r = await client.post(
+        "/api/agents/ag_daemon/gateways",
+        headers=headers,
+        json={
+            "provider": "telegram",
+            "bot_token": "1234:abcd",
+            "config": {"allowedChatIds": [], "allowedSenderIds": []},
+        },
+    )
+    assert r.status_code == 400
+    assert r.json()["detail"] == "missing_gateway_whitelist"
+
+
+@pytest.mark.asyncio
+async def test_create_wechat_requires_whitelist(client, seed, monkeypatch):
+    async def fake_send(*a, **kw):
+        raise AssertionError("daemon contacted before whitelist validation")
+
+    _patch_daemon(monkeypatch, online=True, send=fake_send)
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    r = await client.post(
+        "/api/agents/ag_daemon/gateways",
+        headers=headers,
+        json={
+            "provider": "wechat",
+            "loginId": "wxl_camel",
+            "config": {"allowedSenderIds": []},
+        },
+    )
+    assert r.status_code == 400
+    assert r.json()["detail"] == "missing_gateway_whitelist"
+
+
+@pytest.mark.asyncio
 async def test_create_wechat_forwards_login_id_no_token_in_db(
     client, seed, db_session, monkeypatch
 ):
@@ -387,7 +427,11 @@ async def test_create_maps_daemon_provider_auth_failure_to_400(
     r = await client.post(
         "/api/agents/ag_daemon/gateways",
         headers=headers,
-        json={"provider": "telegram", "bot_token": "x"},
+        json={
+            "provider": "telegram",
+            "bot_token": "x",
+            "config": {"allowedSenderIds": ["111"]},
+        },
     )
     assert r.status_code == 400
     detail = r.json()["detail"]
@@ -404,7 +448,11 @@ async def test_create_maps_other_daemon_errors_to_502(client, seed, monkeypatch)
     r = await client.post(
         "/api/agents/ag_daemon/gateways",
         headers=headers,
-        json={"provider": "telegram", "bot_token": "x"},
+        json={
+            "provider": "telegram",
+            "bot_token": "x",
+            "config": {"allowedSenderIds": ["111"]},
+        },
     )
     assert r.status_code == 502
     assert r.json()["detail"]["code"] == "daemon_gateway_failed"
@@ -420,7 +468,11 @@ async def test_create_propagates_504_timeout(client, seed, monkeypatch):
     r = await client.post(
         "/api/agents/ag_daemon/gateways",
         headers=headers,
-        json={"provider": "telegram", "bot_token": "x"},
+        json={
+            "provider": "telegram",
+            "bot_token": "x",
+            "config": {"allowedSenderIds": ["111"]},
+        },
     )
     assert r.status_code == 504
 
@@ -729,7 +781,11 @@ async def test_create_wechat_accepts_loginId_camelCase(client, seed, monkeypatch
     r = await client.post(
         "/api/agents/ag_daemon/gateways",
         headers=headers,
-        json={"provider": "wechat", "loginId": "wxl_camel"},
+        json={
+            "provider": "wechat",
+            "loginId": "wxl_camel",
+            "config": {"allowedSenderIds": ["xxx@im.wechat"]},
+        },
     )
     assert r.status_code == 200, r.text
     assert captured["params"]["loginId"] == "wxl_camel"
@@ -831,7 +887,10 @@ async def test_create_drops_caller_supplied_tokenPreview_in_config(
         json={
             "provider": "telegram",
             "bot_token": "1234:abcd",
-            "config": {"tokenPreview": "ATTACKER...EVIL"},
+            "config": {
+                "allowedSenderIds": ["111"],
+                "tokenPreview": "ATTACKER...EVIL",
+            },
         },
     )
     assert r.status_code == 200, r.text
@@ -862,6 +921,24 @@ async def test_patch_preserves_existing_tokenPreview_when_daemon_returns_none(
     body = r.json()
     # Stored preview survives; injected one is ignored.
     assert body["config"].get("tokenPreview") == "1234...wxyz"
+
+
+@pytest.mark.asyncio
+async def test_patch_rejects_empty_whitelist(client, seed, db_session, monkeypatch):
+    gw_id = await _seed_one_connection(db_session, seed)
+
+    async def fake_send(*a, **kw):
+        raise AssertionError("daemon contacted before whitelist validation")
+
+    _patch_daemon(monkeypatch, online=True, send=fake_send)
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    r = await client.patch(
+        f"/api/agents/ag_daemon/gateways/{gw_id}",
+        headers=headers,
+        json={"config": {"allowedSenderIds": [], "allowedChatIds": []}},
+    )
+    assert r.status_code == 400
+    assert r.json()["detail"] == "missing_gateway_whitelist"
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/components/dashboard/AgentChannelsTab.tsx
+++ b/frontend/src/components/dashboard/AgentChannelsTab.tsx
@@ -405,7 +405,7 @@ function TelegramAddForm({
   const allowedChatIds = csvToList(chatIds);
   const allowedSenderIds = csvToList(senderIds);
   const whitelistEmpty = allowedChatIds.length === 0 && allowedSenderIds.length === 0;
-  const canSave = !!token.trim() && !daemonOffline && !saving;
+  const canSave = !!token.trim() && !whitelistEmpty && !daemonOffline && !saving;
 
   async function handleSave() {
     if (!canSave) return;
@@ -627,7 +627,7 @@ function TelegramAddForm({
           className="w-full resize-none rounded-lg border border-glass-border bg-deep-black/40 px-3 py-2 font-mono text-xs text-text-primary outline-none focus:border-neon-cyan/40 disabled:opacity-50"
         />
         <p className="mt-1 text-[10px] text-text-tertiary">
-          留空则不限制发送者；也可以之后在已连接列表里编辑。
+          可选；如果不填发送者，必须填写允许的 chat id。
         </p>
       </Field>
       <label className="flex cursor-pointer items-center gap-2 text-xs text-text-primary">
@@ -641,8 +641,8 @@ function TelegramAddForm({
         立即启用
       </label>
       {whitelistEmpty && (
-        <p className="rounded-lg border border-glass-border bg-glass-bg/35 px-3 py-2 text-[11px] text-text-tertiary">
-          当前未设置白名单，也可以先保存此 Telegram 接入，后续再编辑补充 chat 或发送者。
+        <p className="rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-[11px] text-amber-200">
+          必须填写至少一个允许的 chat id 或发送者 user id，才能保存 Telegram 接入。
         </p>
       )}
       {error && (
@@ -770,7 +770,7 @@ function WechatAddForm({
 
   const allowedSenderIds = csvToList(senderIds);
   const whitelistEmpty = allowedSenderIds.length === 0;
-  const canSave = phase === "ready" && !!loginId && !daemonOffline && !busy;
+  const canSave = phase === "ready" && !!loginId && !whitelistEmpty && !daemonOffline && !busy;
 
   async function handleSave() {
     if (!canSave || !loginId) return;
@@ -1037,8 +1037,8 @@ function WechatAddForm({
             立即启用
           </label>
           {whitelistEmpty && (
-            <p className="rounded-lg border border-glass-border bg-glass-bg/35 px-3 py-2 text-[11px] text-text-tertiary">
-              当前未设置白名单，也可以先保存此微信接入，后续再编辑补充允许的用户。
+            <p className="rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-[11px] text-amber-200">
+              必须填写至少一个允许的微信用户 ID，才能保存微信接入。
             </p>
           )}
         </div>
@@ -1114,9 +1114,10 @@ function GatewayEditForm({
     gateway.provider === "telegram"
       ? allowedChatIds.length === 0 && allowedSenderIds.length === 0
       : allowedSenderIds.length === 0;
+  const canSave = !whitelistEmpty && !daemonOffline && !saving;
 
   async function handleSave() {
-    if (daemonOffline || saving) return;
+    if (!canSave) return;
     setSaving(true);
     onError(null);
     try {
@@ -1194,8 +1195,8 @@ function GatewayEditForm({
         />
       </Field>
       {whitelistEmpty && (
-        <p className="rounded-lg border border-glass-border bg-glass-bg/35 px-3 py-2 text-[11px] text-text-tertiary">
-          当前未设置白名单，也可以保存修改，稍后再补充允许的用户或会话。
+        <p className="rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-[11px] text-amber-200">
+          必须保留至少一个允许的用户或会话，才能保存修改。
         </p>
       )}
       <div className="flex justify-end gap-2">
@@ -1210,7 +1211,7 @@ function GatewayEditForm({
         <button
           type="button"
           onClick={handleSave}
-          disabled={daemonOffline || saving}
+          disabled={!canSave}
           className="inline-flex items-center gap-1 rounded-md border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-1.5 text-xs font-medium text-neon-cyan hover:bg-neon-cyan/20 disabled:opacity-50"
         >
           {saving && <Loader2 className="h-3 w-3 animate-spin" />}


### PR DESCRIPTION
## Summary
- require Telegram gateway saves to include at least one allowed chat or sender id
- require WeChat gateway saves to include at least one allowed sender id
- add backend tests for create/patch whitelist validation

## Tests
- cd backend && uv run pytest tests/test_app/test_app_gateways.py
- cd frontend && npm run build