### PR TITLE
fix: refresh provider typing indicators

### DIFF
--- a/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
+++ b/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
@@ -27,6 +27,7 @@ function silentLogger(): GatewayLogger {
 
 interface FakeChannelOptions {
   id?: string;
+  type?: string;
   withStream?: boolean;
   withTyping?: boolean;
   sendImpl?: (ctx: ChannelSendContext) => Promise<ChannelSendResult> | ChannelSendResult;
@@ -36,7 +37,7 @@ interface FakeChannelOptions {
 
 class FakeChannel implements ChannelAdapter {
   readonly id: string;
-  readonly type = "fake";
+  readonly type: string;
   readonly sends: ChannelSendContext[] = [];
   readonly streams: ChannelStreamBlockContext[] = [];
   readonly typings: ChannelTypingContext[] = [];
@@ -48,6 +49,7 @@ class FakeChannel implements ChannelAdapter {
 
   constructor(opts: FakeChannelOptions = {}) {
     this.id = opts.id ?? "botcord";
+    this.type = opts.type ?? "fake";
     this.sendImpl = opts.sendImpl;
     this.streamImpl = opts.streamImpl;
     this.typingImpl = opts.typingImpl;
@@ -659,8 +661,21 @@ describe("Dispatcher", () => {
     expect(channel.sends.length).toBe(1);
   });
 
-  it("typing: not fired when streamable is false", async () => {
-    const channel = new FakeChannel();
+  it("typing: fires for non-BotCord channels even when streamable is false", async () => {
+    const channel = new FakeChannel({ id: "gw_provider", type: "telegram" });
+    const { dispatcher } = await scaffold({
+      channel,
+      runtimeFactory: () => new FakeRuntime({ reply: "ok", newSessionId: "sid" }),
+    });
+
+    await dispatcher.handle(
+      makeEnvelope({ channel: "gw_provider", trace: { id: "t1", streamable: false } }),
+    );
+    expect(channel.typings.length).toBe(1);
+  });
+
+  it("typing: not fired for BotCord rooms when streamable is false", async () => {
+    const channel = new FakeChannel({ type: "botcord" });
     const { dispatcher } = await scaffold({
       channel,
       runtimeFactory: () => new FakeRuntime({ reply: "ok", newSessionId: "sid" }),
@@ -670,6 +685,41 @@ describe("Dispatcher", () => {
       makeEnvelope({ trace: { id: "t1", streamable: false } }),
     );
     expect(channel.typings.length).toBe(0);
+  });
+
+  it("typing: refreshes while a provider turn is still running", async () => {
+    vi.useFakeTimers();
+    try {
+      const channel = new FakeChannel({ id: "gw_tg", type: "telegram" });
+      const runtime = new FakeRuntime({ delayMs: 8500, reply: "ok", newSessionId: "sid" });
+      const { dispatcher } = await scaffold({ channel, runtimeFactory: () => runtime });
+
+      const pending = dispatcher.handle(
+        makeEnvelope({
+          channel: "gw_tg",
+          conversation: { id: "telegram:user:42", kind: "direct" },
+          trace: { id: "telegram:42:1", streamable: true },
+        }),
+      );
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(channel.typings.length).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(4000);
+      expect(channel.typings.length).toBe(2);
+
+      await vi.advanceTimersByTimeAsync(4000);
+      expect(channel.typings.length).toBe(3);
+
+      await vi.advanceTimersByTimeAsync(500);
+      await pending;
+
+      await vi.advanceTimersByTimeAsync(4000);
+      expect(channel.typings.length).toBe(3);
+      expect(channel.sends.length).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("typing: not fired when channel has no typing capability", async () => {

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -55,6 +55,14 @@ const MAX_BATCH_BUFFER_CHARS = 16000;
  */
 const TYPING_DEBOUNCE_MS = 2000;
 
+/**
+ * Most provider typing APIs are short-lived one-shots. Telegram's
+ * `sendChatAction(typing)`, for example, must be refreshed while the runtime
+ * is still working or the visible typing indicator disappears before the
+ * reply lands.
+ */
+const TYPING_REFRESH_MS = 4000;
+
 /** LRU cap on the typing-recency map so long-running daemons don't grow unbounded. */
 const TYPING_RECENCY_CAP = 1024;
 
@@ -804,7 +812,9 @@ export class Dispatcher {
     const streamable = msg.trace?.streamable === true;
     const traceId = msg.trace?.id;
     const canType =
-      streamable && typeof traceId === "string" && typeof channel.typing === "function";
+      typeof traceId === "string" &&
+      typeof channel.typing === "function" &&
+      (streamable || !isBotCordChannel(channel));
     const canStream =
       streamable && typeof traceId === "string" && typeof channel.streamBlock === "function";
     const recordBlock = (block: StreamBlock): void => {
@@ -824,7 +834,8 @@ export class Dispatcher {
     // arrival), and `thinking` is auto-synthesized on the first non-assistant
     // block so adapters that emit nothing-but-blocks still drive the
     // "Thinking..." UI.
-    let typingFired = false;
+    let typingLoopStarted = false;
+    let typingRefreshTimer: NodeJS.Timeout | null = null;
     let thinkingActive = false;
     /**
      * Sticky: once we've forwarded any assistant_text to the wire, we stop
@@ -887,9 +898,8 @@ export class Dispatcher {
       forwardBlockToChannel(synth);
     };
 
-    const fireTypingIfNeeded = (): void => {
-      if (!canType || typingFired) return;
-      typingFired = true;
+    const sendTypingPing = (): void => {
+      if (!canType) return;
       const key = `${msg.accountId}:${msg.conversation.id}`;
       const now = Date.now();
       const last = this.recentTypingPings.get(key);
@@ -934,7 +944,21 @@ export class Dispatcher {
       }
     };
 
-    const onStatus = canStream
+    const fireTypingIfNeeded = (): void => {
+      if (!canType || typingLoopStarted) return;
+      typingLoopStarted = true;
+      sendTypingPing();
+      typingRefreshTimer = setInterval(sendTypingPing, TYPING_REFRESH_MS);
+      if (typeof typingRefreshTimer.unref === "function") typingRefreshTimer.unref();
+    };
+
+    const stopTypingRefresh = (): void => {
+      if (!typingRefreshTimer) return;
+      clearInterval(typingRefreshTimer);
+      typingRefreshTimer = null;
+    };
+
+    const onStatus = canType || canStream
       ? (event: RuntimeStatusEvent) => {
           // Drop runtime callbacks after this turn's controller aborts —
           // NDJSON/ACP adapters keep parsing stdout until the child exits
@@ -1342,6 +1366,7 @@ export class Dispatcher {
         blocks: slot.blocks,
       });
     } finally {
+      stopTypingRefresh();
       // Emit a final thinking.stopped on terminal paths so the frontend
       // never sticks at "Thinking..." when no assistant_text ever landed
       // (timeout, error, gated reply). Skipped on cancel-previous: the


### PR DESCRIPTION
## Summary
- allow third-party gateway typing even when the trace is not streamable
- refresh provider typing indicators during long-running turns
- keep BotCord non-streamable typing behavior unchanged

## Tests
- cd packages/daemon && npm test -- --run src/gateway/__tests__/dispatcher.test.ts src/gateway/__tests__/telegram-channel.test.ts src/__tests__/wechat-channel.test.ts
- cd packages/daemon && npm run build