### PR TITLE
fix: require Telegram chat and sender allowlists

### DIFF
--- a/backend/app/routers/gateways.py
+++ b/backend/app/routers/gateways.py
@@ -362,7 +362,7 @@ def _list_has_value(config: dict[str, Any], key: str) -> bool:
 
 def _require_whitelist(provider: str, config: dict[str, Any]) -> None:
     if provider == "telegram":
-        if _list_has_value(config, "allowedChatIds") or _list_has_value(
+        if _list_has_value(config, "allowedChatIds") and _list_has_value(
             config, "allowedSenderIds"
         ):
             return

--- a/backend/tests/test_app/test_app_gateways.py
+++ b/backend/tests/test_app/test_app_gateways.py
@@ -266,7 +266,11 @@ async def test_create_telegram_persists_metadata_and_token_preview(
             "provider": "telegram",
             "label": "my bot",
             "bot_token": "1234:abcd",
-            "config": {"allowedSenderIds": ["111"], "splitAt": 1800},
+            "config": {
+                "allowedChatIds": ["111"],
+                "allowedSenderIds": ["111"],
+                "splitAt": 1800,
+            },
         },
     )
     assert r.status_code == 200, r.text
@@ -275,6 +279,7 @@ async def test_create_telegram_persists_metadata_and_token_preview(
     assert body["status"] == "active"
     assert body["enabled"] is True
     assert body["config"]["tokenPreview"] == "1234...wxyz"
+    assert body["config"]["allowedChatIds"] == ["111"]
     assert body["config"]["allowedSenderIds"] == ["111"]
     assert body["config"]["splitAt"] == 1800
     assert body["daemon_instance_id"] == seed["daemon_id"]
@@ -286,6 +291,7 @@ async def test_create_telegram_persists_metadata_and_token_preview(
     assert p["type"] == "telegram"
     assert p["accountId"] == "ag_daemon"
     assert p["secret"] == {"botToken": "1234:abcd"}
+    assert p["settings"]["allowedChatIds"] == ["111"]
     assert p["settings"]["allowedSenderIds"] == ["111"]
 
     # DB row carries no botToken.
@@ -327,8 +333,18 @@ async def test_create_wechat_requires_login_id(client, seed, monkeypatch):
     assert r.json()["detail"] == "missing_login_id"
 
 
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"allowedChatIds": [], "allowedSenderIds": []},
+        {"allowedChatIds": ["111"], "allowedSenderIds": []},
+        {"allowedChatIds": [], "allowedSenderIds": ["111"]},
+    ],
+)
 @pytest.mark.asyncio
-async def test_create_telegram_requires_whitelist(client, seed, monkeypatch):
+async def test_create_telegram_requires_chat_and_sender_whitelists(
+    client, seed, monkeypatch, config
+):
     async def fake_send(*a, **kw):
         raise AssertionError("daemon contacted before whitelist validation")
 
@@ -340,7 +356,7 @@ async def test_create_telegram_requires_whitelist(client, seed, monkeypatch):
         json={
             "provider": "telegram",
             "bot_token": "1234:abcd",
-            "config": {"allowedChatIds": [], "allowedSenderIds": []},
+            "config": config,
         },
     )
     assert r.status_code == 400
@@ -430,7 +446,7 @@ async def test_create_maps_daemon_provider_auth_failure_to_400(
         json={
             "provider": "telegram",
             "bot_token": "x",
-            "config": {"allowedSenderIds": ["111"]},
+            "config": {"allowedChatIds": ["111"], "allowedSenderIds": ["111"]},
         },
     )
     assert r.status_code == 400
@@ -451,7 +467,7 @@ async def test_create_maps_other_daemon_errors_to_502(client, seed, monkeypatch)
         json={
             "provider": "telegram",
             "bot_token": "x",
-            "config": {"allowedSenderIds": ["111"]},
+            "config": {"allowedChatIds": ["111"], "allowedSenderIds": ["111"]},
         },
     )
     assert r.status_code == 502
@@ -471,7 +487,7 @@ async def test_create_propagates_504_timeout(client, seed, monkeypatch):
         json={
             "provider": "telegram",
             "bot_token": "x",
-            "config": {"allowedSenderIds": ["111"]},
+            "config": {"allowedChatIds": ["111"], "allowedSenderIds": ["111"]},
         },
     )
     assert r.status_code == 504
@@ -493,7 +509,11 @@ async def _seed_one_connection(db_session: AsyncSession, seed: dict) -> str:
         label="bot",
         enabled=True,
         status="active",
-        config_json={"allowedSenderIds": ["111"], "tokenPreview": "1234...wxyz"},
+        config_json={
+            "allowedChatIds": ["111"],
+            "allowedSenderIds": ["111"],
+            "tokenPreview": "1234...wxyz",
+        },
     )
     db_session.add(row)
     await db_session.commit()
@@ -520,6 +540,7 @@ async def test_patch_updates_settings_without_token(client, seed, db_session, mo
     assert r.status_code == 200, r.text
     body = r.json()
     assert body["label"] == "renamed"
+    assert body["config"]["allowedChatIds"] == ["111"]
     assert body["config"]["allowedSenderIds"] == ["222"]
     # tokenPreview survives merge.
     assert body["config"]["tokenPreview"] == "1234...wxyz"
@@ -751,7 +772,7 @@ async def test_create_accepts_nested_secret_botToken_camelCase(
         json={
             "provider": "telegram",
             "secret": {"botToken": "1234:abcd"},
-            "config": {"allowedSenderIds": ["111"]},
+            "config": {"allowedChatIds": ["111"], "allowedSenderIds": ["111"]},
         },
     )
     assert r.status_code == 200, r.text
@@ -888,6 +909,7 @@ async def test_create_drops_caller_supplied_tokenPreview_in_config(
             "provider": "telegram",
             "bot_token": "1234:abcd",
             "config": {
+                "allowedChatIds": ["111"],
                 "allowedSenderIds": ["111"],
                 "tokenPreview": "ATTACKER...EVIL",
             },
@@ -1074,7 +1096,14 @@ async def test_create_gateway_rate_limited_after_burst(client, seed, monkeypatch
         r = await client.post(
             "/api/agents/ag_daemon/gateways",
             headers=headers,
-            json={"provider": "telegram", "bot_token": f"111:tok{i}"},
+            json={
+                "provider": "telegram",
+                "bot_token": f"111:tok{i}",
+                "config": {
+                    "allowedChatIds": ["111"],
+                    "allowedSenderIds": ["111"],
+                },
+            },
         )
         status_codes.append(r.status_code)
 

--- a/frontend/src/components/dashboard/AgentChannelsTab.tsx
+++ b/frontend/src/components/dashboard/AgentChannelsTab.tsx
@@ -404,8 +404,9 @@ function TelegramAddForm({
 
   const allowedChatIds = csvToList(chatIds);
   const allowedSenderIds = csvToList(senderIds);
-  const whitelistEmpty = allowedChatIds.length === 0 && allowedSenderIds.length === 0;
-  const canSave = !!token.trim() && !whitelistEmpty && !daemonOffline && !saving;
+  const whitelistIncomplete =
+    allowedChatIds.length === 0 || allowedSenderIds.length === 0;
+  const canSave = !!token.trim() && !whitelistIncomplete && !daemonOffline && !saving;
 
   async function handleSave() {
     if (!canSave) return;
@@ -627,7 +628,7 @@ function TelegramAddForm({
           className="w-full resize-none rounded-lg border border-glass-border bg-deep-black/40 px-3 py-2 font-mono text-xs text-text-primary outline-none focus:border-neon-cyan/40 disabled:opacity-50"
         />
         <p className="mt-1 text-[10px] text-text-tertiary">
-          可选；如果不填发送者，必须填写允许的 chat id。
+          必填；Telegram 需要同时限制 chat id 和发送者 user id。
         </p>
       </Field>
       <label className="flex cursor-pointer items-center gap-2 text-xs text-text-primary">
@@ -640,9 +641,9 @@ function TelegramAddForm({
         />
         立即启用
       </label>
-      {whitelistEmpty && (
+      {whitelistIncomplete && (
         <p className="rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-[11px] text-amber-200">
-          必须填写至少一个允许的 chat id 或发送者 user id，才能保存 Telegram 接入。
+          必须同时填写允许的 chat id 和发送者 user id，才能保存 Telegram 接入。
         </p>
       )}
       {error && (
@@ -1139,11 +1140,11 @@ function GatewayEditForm({
 
   const allowedChatIds = csvToList(chatIds);
   const allowedSenderIds = csvToList(senderIds);
-  const whitelistEmpty =
+  const whitelistIncomplete =
     gateway.provider === "telegram"
-      ? allowedChatIds.length === 0 && allowedSenderIds.length === 0
+      ? allowedChatIds.length === 0 || allowedSenderIds.length === 0
       : allowedSenderIds.length === 0;
-  const canSave = !whitelistEmpty && !daemonOffline && !saving;
+  const canSave = !whitelistIncomplete && !daemonOffline && !saving;
 
   async function handleSave() {
     if (!canSave) return;
@@ -1610,9 +1611,11 @@ function GatewayEditForm({
           </div>
         )}
       </Field>
-      {whitelistEmpty && (
+      {whitelistIncomplete && (
         <p className="rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-[11px] text-amber-200">
-          必须保留至少一个允许的用户或会话，才能保存修改。
+          {gateway.provider === "telegram"
+            ? "必须同时保留允许的 chat id 和发送者 user id，才能保存修改。"
+            : "必须保留至少一个允许的微信用户 ID，才能保存修改。"}
         </p>
       )}
       <div className="flex justify-end gap-2">


### PR DESCRIPTION
## Summary
- require Telegram gateways to include both allowed chat IDs and sender user IDs
- align create/edit UI validation and warning copy with the AND requirement
- update gateway API tests so Telegram success paths include both allowlists

## Tests
- cd backend && uv run pytest tests/test_app/test_app_gateways.py
- cd frontend && npm run build
