### PR TITLE
feat: add Kimi CLI daemon runtime

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -44,6 +44,7 @@ gateway 目前是 `@botcord/daemon` 的内部模块（`packages/daemon/src/gatew
 | Channels/sanitize | `channels/sanitize.ts` | `sanitizeUntrustedContent` / `sanitizeSenderName`，防 prompt injection |
 | Runtimes | `runtimes/claude-code.ts` | claude CLI，`--append-system-prompt`、stream-json、trust 敏感权限位 |
 | Runtimes | `runtimes/codex.ts` | codex CLI |
+| Runtimes | `runtimes/kimi.ts` | Kimi CLI，`--print --output-format stream-json`、`--session` 恢复 |
 | Runtimes | `runtimes/gemini.ts` | gemini CLI |
 | Runtimes | `runtimes/ndjson-stream.ts` | 通用 NDJSON 流基类：解析、拼接 assistant_text、抽 session id |
 | Runtimes | `runtimes/probe.ts` | 可执行文件探测（which / 指定路径 / 读版本） |

--- a/docs/third-party-gateway-design.md
+++ b/docs/third-party-gateway-design.md
@@ -9,7 +9,7 @@
 - `Dispatcher` 负责路由、session、runtime 调用、stream block、typing、attention gate。
 - `toGatewayConfig()` 当前为每个 BotCord agent 固定生成一个 `botcord` channel。
 
-因此微信、Telegram 的接入不应该作为新的 runtime 实现，而应该作为新的 **channel adapter** 实现。Agent 的 runtime 仍然是 `claude-code`、`codex`、`gemini`、`openclaw-acp`、`hermes-agent` 等；微信/Telegram 只是新的消息入口。
+因此微信、Telegram 的接入不应该作为新的 runtime 实现，而应该作为新的 **channel adapter** 实现。Agent 的 runtime 仍然是 `claude-code`、`codex`、`kimi-cli`、`gemini`、`openclaw-acp`、`hermes-agent` 等；微信/Telegram 只是新的消息入口。
 
 命名上建议避免继续扩大 `gateway` 的歧义：
 

--- a/packages/daemon/src/gateway/__tests__/kimi-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/kimi-adapter.test.ts
@@ -1,0 +1,174 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, chmodSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { KimiAdapter } from "../runtimes/kimi.js";
+import { createRuntime, envVarForRuntime, listRuntimeIds } from "../runtimes/registry.js";
+
+const tmpRoot = mkdtempSync(path.join(os.tmpdir(), "gateway-kimi-"));
+
+function makeScript(name: string, body: string): string {
+  const p = path.join(tmpRoot, name);
+  writeFileSync(p, `#!/usr/bin/env node\n${body}\n`, { mode: 0o755 });
+  chmodSync(p, 0o755);
+  return p;
+}
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function runAdapter(script: string, sessionId: string | null = null) {
+  const adapter = new KimiAdapter({ binary: script });
+  const ctrl = new AbortController();
+  return adapter.run({
+    text: "hi",
+    sessionId,
+    accountId: "ag_test",
+    cwd: tmpRoot,
+    signal: ctrl.signal,
+    trustLevel: "owner",
+  });
+}
+
+describe("KimiAdapter", () => {
+  it("is registered as a runnable runtime", () => {
+    expect(listRuntimeIds()).toContain("kimi-cli");
+    expect(envVarForRuntime("kimi-cli")).toBe("BOTCORD_KIMI_CLI_BIN");
+    expect(createRuntime("kimi-cli")).toBeInstanceOf(KimiAdapter);
+  });
+
+  it("parses final assistant text and persists the generated --session id", async () => {
+    const script = makeScript(
+      "happy.js",
+      `
+process.stdout.write(JSON.stringify({role:"assistant", content:"hello from kimi"}) + "\\n");
+`,
+    );
+    const res = await runAdapter(script);
+    expect(res.newSessionId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(res.text).toBe("hello from kimi");
+    expect(res.error).toBeUndefined();
+  });
+
+  it("passes an existing session id through --session", async () => {
+    const script = makeScript(
+      "resume-argv.js",
+      `
+const argv = process.argv.slice(2);
+process.stdout.write(JSON.stringify({role:"assistant", content:JSON.stringify(argv)}) + "\\n");
+`,
+    );
+    const res = await runAdapter(script, "sid-123");
+    const argv = JSON.parse(res.text) as string[];
+    const idx = argv.indexOf("--session");
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(argv[idx + 1]).toBe("sid-123");
+    expect(argv).toContain("--print");
+    expect(argv).toContain("stream-json");
+    expect(argv).toContain("--afk");
+  });
+
+  it("rejects session ids that could be parsed as flags", async () => {
+    const script = makeScript(
+      "should-not-spawn.js",
+      `
+process.stdout.write(JSON.stringify({role:"assistant", content:"spawned"}) + "\\n");
+`,
+    );
+    const res = await runAdapter(script, "--bad");
+    expect(res.newSessionId).toBe("");
+    expect(res.text).toBe("");
+    expect(res.error).toMatch(/invalid sessionId/);
+  });
+
+  it("prefixes systemContext as a system-reminder in the prompt", async () => {
+    const script = makeScript(
+      "echo-prompt.js",
+      `
+const argv = process.argv.slice(2);
+const prompt = argv[argv.indexOf("--prompt") + 1];
+process.stdout.write(JSON.stringify({role:"assistant", content:prompt}) + "\\n");
+`,
+    );
+    const adapter = new KimiAdapter({ binary: script });
+    const ctrl = new AbortController();
+    const res = await adapter.run({
+      text: "do the thing",
+      sessionId: null,
+      accountId: "ag_test",
+      cwd: tmpRoot,
+      signal: ctrl.signal,
+      trustLevel: "owner",
+      systemContext: "MEMORY: remember X",
+    });
+    expect(res.text).toContain("<system-reminder>");
+    expect(res.text).toContain("MEMORY: remember X");
+    expect(res.text).toContain("do the thing");
+  });
+
+  it("recognizes tool_use and tool_result blocks", async () => {
+    const script = makeScript(
+      "tools.js",
+      `
+const lines = [
+  {role:"assistant", content:null, tool_calls:[{id:"tc1", function:{name:"Bash", arguments:"{}"}}]},
+  {role:"tool", tool_call_id:"tc1", content:"ok"},
+  {role:"assistant", content:[{type:"text", text:"done"}]},
+];
+for (const l of lines) process.stdout.write(JSON.stringify(l) + "\\n");
+`,
+    );
+    const adapter = new KimiAdapter({ binary: script });
+    const ctrl = new AbortController();
+    const seen: string[] = [];
+    const res = await adapter.run({
+      text: "x",
+      sessionId: null,
+      accountId: "ag_test",
+      cwd: tmpRoot,
+      signal: ctrl.signal,
+      trustLevel: "owner",
+      onBlock: (b) => seen.push(b.kind),
+    });
+    expect(res.text).toBe("done");
+    expect(seen).toContain("tool_use");
+    expect(seen).toContain("tool_result");
+    expect(seen).toContain("assistant_text");
+  });
+
+  it("emits thinking status for think, tool call, tool result, and final text", async () => {
+    const script = makeScript(
+      "thinkflow.js",
+      `
+const lines = [
+  {role:"assistant", content:[{type:"think", think:"working"}]},
+  {role:"assistant", content:null, tool_calls:[{id:"tc1", function:{name:"ReadFile", arguments:"{}"}}]},
+  {role:"tool", tool_call_id:"tc1", content:"ok"},
+  {role:"assistant", content:"done"},
+];
+for (const l of lines) process.stdout.write(JSON.stringify(l) + "\\n");
+`,
+    );
+    const adapter = new KimiAdapter({ binary: script });
+    const ctrl = new AbortController();
+    const status: Array<{ phase: string; label?: string }> = [];
+    await adapter.run({
+      text: "x",
+      sessionId: null,
+      accountId: "ag_test",
+      cwd: tmpRoot,
+      signal: ctrl.signal,
+      trustLevel: "owner",
+      onStatus: (e) => {
+        if (e.kind === "thinking") status.push({ phase: e.phase, label: e.label });
+      },
+    });
+    expect(status).toEqual([
+      { phase: "started", label: "Thinking" },
+      { phase: "updated", label: "ReadFile" },
+      { phase: "updated", label: "Tool result" },
+      { phase: "stopped", label: undefined },
+    ]);
+  });
+});

--- a/packages/daemon/src/gateway/index.ts
+++ b/packages/daemon/src/gateway/index.ts
@@ -39,6 +39,7 @@ export {
   resolveClaudeCommand,
 } from "./runtimes/claude-code.js";
 export { CodexAdapter, probeCodex, resolveCodexCommand } from "./runtimes/codex.js";
+export { KimiAdapter, probeKimi, resolveKimiCommand } from "./runtimes/kimi.js";
 export { GeminiAdapter, probeGemini, resolveGeminiCommand } from "./runtimes/gemini.js";
 export {
   NdjsonStreamAdapter,

--- a/packages/daemon/src/gateway/runtimes/kimi.ts
+++ b/packages/daemon/src/gateway/runtimes/kimi.ts
@@ -1,0 +1,245 @@
+import { randomUUID } from "node:crypto";
+import { buildCliEnv } from "../cli-resolver.js";
+import { NdjsonStreamAdapter, type NdjsonEventCtx } from "./ndjson-stream.js";
+import {
+  readCommandVersion,
+  resolveCommandOnPath,
+  type ProbeDeps,
+} from "./probe.js";
+import type { RuntimeProbeResult, RuntimeRunOptions, StreamBlock } from "../types.js";
+
+function isValidKimiSessionId(sessionId: string): boolean {
+  if (sessionId.length === 0 || sessionId.length > 512) return false;
+  if (sessionId.startsWith("-")) return false;
+  for (const ch of sessionId) {
+    const code = ch.codePointAt(0);
+    if (code === undefined || code < 0x20 || code === 0x7f) return false;
+  }
+  return true;
+}
+
+function invalidKimiSessionIdError(): string {
+  return "kimi-cli: invalid sessionId (expected non-control text not starting with '-')";
+}
+
+/** Resolve the Kimi CLI executable on PATH. */
+export function resolveKimiCommand(deps: ProbeDeps = {}): string | null {
+  return resolveCommandOnPath("kimi", deps);
+}
+
+/** Probe whether the Kimi CLI is installed and report its version. */
+export function probeKimi(deps: ProbeDeps = {}): RuntimeProbeResult {
+  const command = resolveKimiCommand(deps);
+  if (!command) return { available: false };
+  return {
+    available: true,
+    path: command,
+    version: readCommandVersion(command, [], deps) ?? undefined,
+  };
+}
+
+/**
+ * Kimi CLI adapter — spawns:
+ *
+ *   kimi --work-dir <cwd> --print --output-format stream-json --session <sid> --prompt <text>
+ *
+ * `--session <sid>` resumes an existing session or creates a new session with
+ * that id, so the adapter generates a UUID on first turn and persists it for
+ * later turns. Kimi does not expose a Codex-style per-invocation AGENTS.md
+ * carrier, so dynamic `systemContext` is sent as a system-reminder prefix on
+ * the user prompt.
+ */
+export class KimiAdapter extends NdjsonStreamAdapter {
+  readonly id = "kimi-cli" as const;
+
+  private readonly explicitBinary: string | undefined;
+  private resolvedBinary: string | null = null;
+
+  constructor(opts?: { binary?: string }) {
+    super();
+    this.explicitBinary = opts?.binary ?? process.env.BOTCORD_KIMI_CLI_BIN;
+  }
+
+  probe(): RuntimeProbeResult {
+    return probeKimi();
+  }
+
+  override async run(opts: RuntimeRunOptions) {
+    if (opts.sessionId && !isValidKimiSessionId(opts.sessionId)) {
+      return { text: "", newSessionId: "", error: invalidKimiSessionIdError() };
+    }
+    const sessionId = opts.sessionId || randomUUID();
+    return super.run({ ...opts, sessionId });
+  }
+
+  protected resolveBinary(): string {
+    if (this.explicitBinary) return this.explicitBinary;
+    if (this.resolvedBinary) return this.resolvedBinary;
+    this.resolvedBinary = resolveKimiCommand() ?? "kimi";
+    return this.resolvedBinary;
+  }
+
+  protected buildArgs(opts: RuntimeRunOptions): string[] {
+    const sessionId = opts.sessionId || randomUUID();
+    if (!isValidKimiSessionId(sessionId)) throw new Error(invalidKimiSessionIdError());
+
+    const args = [
+      "--work-dir",
+      opts.cwd,
+      "--print",
+      "--output-format",
+      "stream-json",
+      "--session",
+      sessionId,
+      "--afk",
+    ];
+    if (opts.extraArgs?.length) args.push(...opts.extraArgs);
+    args.push("--prompt", promptWithSystemContext(opts.text, opts.systemContext));
+    return args;
+  }
+
+  protected spawnEnv(opts: RuntimeRunOptions): NodeJS.ProcessEnv {
+    const cliEnv = buildCliEnv({
+      hubUrl: opts.hubUrl,
+      accountId: opts.accountId,
+      basePath: process.env.PATH,
+    });
+    return {
+      ...process.env,
+      ...cliEnv,
+      FORCE_COLOR: "0",
+      NO_COLOR: "1",
+    };
+  }
+
+  protected handleEvent(raw: unknown, ctx: NdjsonEventCtx): void {
+    const obj = raw as KimiStreamJsonEvent;
+
+    const status = kimiStatusEvent(obj);
+    if (status) ctx.emitStatus(status);
+
+    ctx.emitBlock(normalizeBlock(obj, ctx.seq));
+
+    const sessionId = kimiSessionId(obj);
+    if (sessionId) ctx.state.newSessionId = sessionId;
+
+    if (obj.role === "assistant") {
+      const text = extractText(obj.content);
+      if (text) {
+        ctx.appendAssistantText(text);
+        ctx.state.finalText = text;
+      }
+      return;
+    }
+
+    const err = kimiErrorText(obj);
+    if (err) ctx.state.errorText = err;
+  }
+}
+
+type KimiContentPart = {
+  type?: string;
+  text?: string;
+  think?: string;
+};
+
+type KimiToolCall = {
+  id?: string;
+  function?: { name?: string; arguments?: string | null };
+};
+
+type KimiStreamJsonEvent = {
+  role?: string;
+  content?: string | KimiContentPart[] | null;
+  tool_calls?: KimiToolCall[] | null;
+  tool_call_id?: string | null;
+  content_type?: string;
+  file_path?: string;
+  session_id?: string;
+  id?: string;
+  category?: string;
+  type?: string;
+  title?: string;
+  body?: string;
+  severity?: string;
+  error?: string | { message?: string };
+  message?: string;
+};
+
+function promptWithSystemContext(text: string, systemContext: string | undefined): string {
+  if (!systemContext) return text;
+  return `<system-reminder>\n${systemContext}\n</system-reminder>\n\n${text}`;
+}
+
+function extractText(content: KimiStreamJsonEvent["content"]): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((part) => part?.type === "text" && typeof part.text === "string")
+    .map((part) => part.text)
+    .join("");
+}
+
+function hasThinking(content: KimiStreamJsonEvent["content"]): boolean {
+  return Array.isArray(content)
+    ? content.some((part) => part?.type === "think" && typeof part.think === "string" && part.think)
+    : false;
+}
+
+function firstToolName(toolCalls: KimiToolCall[] | null | undefined): string {
+  const name = toolCalls?.find((t) => typeof t.function?.name === "string")?.function?.name;
+  return name || "tool";
+}
+
+function kimiSessionId(obj: KimiStreamJsonEvent): string | undefined {
+  return typeof obj.session_id === "string" && obj.session_id ? obj.session_id : undefined;
+}
+
+function kimiErrorText(obj: KimiStreamJsonEvent): string | undefined {
+  if (typeof obj.error === "string" && obj.error) return obj.error;
+  if (obj.error && typeof obj.error === "object") {
+    const message = obj.error.message;
+    if (typeof message === "string" && message) return message;
+  }
+  if (obj.type === "error" && typeof obj.message === "string" && obj.message) {
+    return obj.message;
+  }
+  if (obj.severity === "error") {
+    return [obj.title, obj.body].filter(Boolean).join(": ") || "kimi-cli error";
+  }
+  return undefined;
+}
+
+function kimiStatusEvent(
+  obj: KimiStreamJsonEvent,
+): import("../types.js").RuntimeStatusEvent | undefined {
+  if (obj.role === "assistant" && hasThinking(obj.content)) {
+    return { kind: "thinking", phase: "started", label: "Thinking" };
+  }
+  if (obj.role === "assistant" && obj.tool_calls?.length) {
+    return { kind: "thinking", phase: "updated", label: firstToolName(obj.tool_calls) };
+  }
+  if (obj.role === "assistant" && extractText(obj.content)) {
+    return { kind: "thinking", phase: "stopped" };
+  }
+  if (obj.role === "tool") {
+    return { kind: "thinking", phase: "updated", label: "Tool result" };
+  }
+  return undefined;
+}
+
+function normalizeBlock(obj: KimiStreamJsonEvent, seq: number): StreamBlock {
+  let kind: StreamBlock["kind"] = "other";
+  if (obj.role === "assistant") {
+    if (obj.tool_calls?.length) kind = "tool_use";
+    else if (extractText(obj.content)) kind = "assistant_text";
+    else if (hasThinking(obj.content)) kind = "other";
+  } else if (obj.role === "tool") {
+    kind = "tool_result";
+  } else if (obj.file_path && typeof obj.content === "string") {
+    kind = "other";
+  } else if (obj.category || obj.severity) {
+    kind = "system";
+  }
+  return { raw: obj, kind, seq };
+}

--- a/packages/daemon/src/gateway/runtimes/registry.ts
+++ b/packages/daemon/src/gateway/runtimes/registry.ts
@@ -2,6 +2,7 @@ import { ClaudeCodeAdapter, probeClaude } from "./claude-code.js";
 import { CodexAdapter, probeCodex } from "./codex.js";
 import { GeminiAdapter, probeGemini } from "./gemini.js";
 import { HermesAgentAdapter, probeHermesAgent } from "./hermes-agent.js";
+import { KimiAdapter, probeKimi } from "./kimi.js";
 import { OpenclawAcpAdapter, probeOpenclaw } from "./openclaw-acp.js";
 import type { RuntimeAdapter, RuntimeProbeResult } from "../types.js";
 
@@ -55,6 +56,16 @@ export const codexModule: RuntimeModule = {
   create: () => new CodexAdapter(),
 };
 
+/** Built-in runtime module entry for Kimi CLI. */
+export const kimiModule: RuntimeModule = {
+  id: "kimi-cli",
+  displayName: "Kimi CLI",
+  binary: "kimi",
+  envVar: "BOTCORD_KIMI_CLI_BIN",
+  probe: () => probeKimi(),
+  create: () => new KimiAdapter(),
+};
+
 /** Built-in runtime module entry for Hermes Agent (ACP stdio). */
 export const hermesAgentModule: RuntimeModule = {
   id: "hermes-agent",
@@ -96,6 +107,7 @@ export const openclawAcpModule: RuntimeModule = {
 export const RUNTIME_MODULES: readonly RuntimeModule[] = [
   claudeCodeModule,
   codexModule,
+  kimiModule,
   hermesAgentModule,
   geminiModule,
   openclawAcpModule,


### PR DESCRIPTION
## Summary
- add `kimi-cli` as a daemon runtime backed by the local `kimi` CLI
- parse Kimi `stream-json` assistant text, tool calls/results, and thinking status
- register runtime discovery/export metadata and document the new runtime

## Verification
- `cd packages/daemon && npm test -- --run src/gateway/__tests__/kimi-adapter.test.ts src/gateway/__tests__/codex-adapter.test.ts src/gateway/__tests__/claude-code-adapter.test.ts src/__tests__/runtime-discovery.test.ts`
- `cd packages/daemon && npm run build`
- `cd packages/daemon && node dist/index.js doctor --json` shows `kimi-cli` available at `/Users/zhejianzhang/.local/bin/kimi`, version `kimi, version 1.41.0`
- real adapter smoke returned `{"text":"BOTCORD_KIMI_ADAPTER_OK","newSessionId":"fc4fff6c-b7be-44ae-a3f6-084d5c25d76f"}`