### PR TITLE
fix: highlight plain text mentions

### DIFF
--- a/frontend/src/components/dashboard/MessageBubble.tsx
+++ b/frontend/src/components/dashboard/MessageBubble.tsx
@@ -11,6 +11,7 @@ import { messageBubble } from '@/lib/i18n/translations/dashboard';
 import AttachmentItem from "@/components/ui/AttachmentItem";
 import CopyableId from "@/components/ui/CopyableId";
 import MarkdownContent from "@/components/ui/MarkdownContent";
+import type { MentionTextCandidate } from "@/components/ui/MarkdownContent";
 import SystemMessageNotice from "@/components/ui/SystemMessageNotice";
 import TransferCard, { parseTransferText, parseTransferNotice } from "@/components/dashboard/TransferCard";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
@@ -27,6 +28,8 @@ interface MessageBubbleProps {
   sourceName?: string;
   /** Source room_id or DM agent_id included in the forward quote for AI context. */
   sourceId?: string;
+  /** Known participants used to resolve plain-text @display-name mentions. */
+  mentionCandidates?: MentionTextCandidate[];
 }
 
 const stateColors: Record<string, { color: string; icon: string }> = {
@@ -130,7 +133,7 @@ function MentionChip({
   const publicAgent = publicAgents.find((agent) => agent.agent_id === id);
   const displayName = contact?.alias || ownAgent?.display_name || contact?.display_name || publicAgent?.display_name || label;
   const bio = ownAgent?.bio ?? publicAgent?.bio ?? null;
-  const role = isHuman ? "Human" : "Agent";
+  const role = isHuman ? "Human" : isAgent ? "Agent" : "Mention";
   const canOpen = isHuman || isAgent;
 
   const updateTooltipPosition = useCallback(() => {
@@ -195,7 +198,7 @@ function MentionChip({
         disabled={!canOpen}
         className="inline-flex max-w-full items-center gap-1 rounded border border-neon-cyan/30 bg-neon-cyan/10 px-1.5 py-0.5 text-[0.85em] font-medium leading-none text-neon-cyan transition-colors hover:border-neon-cyan/50 hover:bg-neon-cyan/20 disabled:cursor-default"
       >
-        {!isHuman && <PresenceDot agentId={id} size="xs" showOffline={false} />}
+        {isAgent && <PresenceDot agentId={id} size="xs" showOffline={false} />}
         <span className="truncate">@{displayName}</span>
       </button>
       {tooltipPosition && typeof document !== "undefined" && createPortal(
@@ -204,7 +207,7 @@ function MentionChip({
           style={{ left: tooltipPosition.left, top: tooltipPosition.top }}
         >
           <span className="mb-1 flex items-center gap-2">
-            {!isHuman && <PresenceDot agentId={id} size="sm" />}
+            {isAgent && <PresenceDot agentId={id} size="sm" />}
             <span className={`truncate text-xs font-semibold ${isHuman ? "text-neon-green" : "text-neon-purple"}`}>
               {displayName}
             </span>
@@ -221,7 +224,7 @@ function MentionChip({
   );
 }
 
-export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = false, sourceName, sourceId }: MessageBubbleProps) {
+export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = false, sourceName, sourceId, mentionCandidates }: MessageBubbleProps) {
   const [hovered, setHovered] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const [forwardQuote, setForwardQuote] = useState<string | null>(null);
@@ -360,6 +363,7 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
           displayText && (
             <MarkdownContent
               content={displayText}
+              mentionCandidates={mentionCandidates}
               renderMention={({ id, label }) => (
                 <MentionChip
                   id={id}

--- a/frontend/src/components/dashboard/MessageList.tsx
+++ b/frontend/src/components/dashboard/MessageList.tsx
@@ -12,7 +12,9 @@ import { useLanguage } from '@/lib/i18n';
 import { messageList } from '@/lib/i18n/translations/dashboard';
 import { useShallow } from "zustand/react/shallow";
 import MessageBubble from "./MessageBubble";
-import type { DashboardMessage, TopicInfo } from "@/lib/types";
+import type { DashboardMessage, PublicRoomMember, TopicInfo } from "@/lib/types";
+import type { MentionTextCandidate } from "@/components/ui/MarkdownContent";
+import { api } from "@/lib/api";
 import { getLatestSeenAtForRoom } from "@/store/dashboard-shared";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
@@ -101,12 +103,14 @@ function TopicCard({
   currentAgentId,
   sourceName,
   sourceId,
+  mentionCandidates,
   onOpen,
 }: {
   group: TopicGroup;
   currentAgentId: string | undefined;
   sourceName?: string;
   sourceId?: string;
+  mentionCandidates?: MentionTextCandidate[];
   onOpen: () => void;
 }) {
   const topicStatusConfig = useTopicStatusConfig();
@@ -152,6 +156,7 @@ function TopicCard({
           isOwn={firstMsg.sender_id === currentAgentId}
           sourceName={sourceName}
           sourceId={sourceId}
+          mentionCandidates={mentionCandidates}
         />
       )}
 
@@ -244,6 +249,7 @@ export default function MessageList() {
   const prevLengthRef = useRef(0);
   const isLoadingMore = useRef(false);
   const [showNewMessagesBanner, setShowNewMessagesBanner] = useState(false);
+  const [roomMembers, setRoomMembers] = useState<PublicRoomMember[]>([]);
   const showBannerRef = useRef(false);
   const wasNearBottomRef = useRef(true);
 
@@ -253,6 +259,42 @@ export default function MessageList() {
   const hasMore = roomId ? messagesHasMore[roomId] ?? false : false;
   const currentAgentId = overview?.agent?.agent_id;
   const currentRoomName = overview?.rooms?.find((r) => r.room_id === roomId)?.name ?? roomId ?? "";
+  const mentionCandidates = useMemo<MentionTextCandidate[]>(() => {
+    const candidates: MentionTextCandidate[] = [];
+    const seen = new Set<string>();
+    const add = (id: string | null | undefined, label: string | null | undefined) => {
+      if (!id || !label || seen.has(id)) return;
+      seen.add(id);
+      candidates.push({ id, label });
+    };
+
+    add("@all", "all");
+    for (const member of roomMembers) add(member.agent_id, member.display_name);
+    for (const agent of overview?.agent ? [overview.agent] : []) add(agent.agent_id, agent.display_name);
+    for (const contact of overview?.contacts ?? []) add(contact.contact_agent_id, contact.alias || contact.display_name);
+
+    return candidates;
+  }, [overview?.agent, overview?.contacts, roomMembers]);
+
+  useEffect(() => {
+    if (!roomId) {
+      setRoomMembers([]);
+      return;
+    }
+    let cancelled = false;
+    api.getRoomMembers(roomId)
+      .catch(() => api.getPublicRoomMembers(roomId))
+      .then((result) => {
+        if (!cancelled) setRoomMembers(result.members);
+      })
+      .catch(() => {
+        if (!cancelled) setRoomMembers([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [roomId]);
+
   const commitRoomSeen = useCallback((targetRoomId: string) => {
     const joinedRoom = overview?.rooms.find((room) => room.room_id === targetRoomId);
     if (!joinedRoom) {
@@ -426,6 +468,7 @@ export default function MessageList() {
                 isOwn={msg.sender_id === currentAgentId}
                 sourceName={currentRoomName}
                 sourceId={roomId}
+                mentionCandidates={mentionCandidates}
               />
             );
           }
@@ -439,6 +482,7 @@ export default function MessageList() {
               currentAgentId={currentAgentId}
               sourceName={currentRoomName}
               sourceId={roomId}
+              mentionCandidates={mentionCandidates}
               onOpen={() => group.topicId && setOpenedTopicId(group.topicId)}
             />
           );

--- a/frontend/src/components/ui/MarkdownContent.test.ts
+++ b/frontend/src/components/ui/MarkdownContent.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { splitPlainMentionText } from "./MarkdownContent";
+
+function mentionProps(node: unknown) {
+  return (node as { properties?: Record<string, unknown> }).properties;
+}
+
+describe("splitPlainMentionText", () => {
+  it("resolves plain display-name mentions with spaces and apostrophes", () => {
+    const nodes = splitPlainMentionText("@Garry's Codex 谢谢", [
+      { id: "ag_garry", label: "Garry's Codex" },
+    ]);
+
+    expect(nodes).toHaveLength(2);
+    expect(mentionProps(nodes[0])?.["data-mention-id"]).toBe("ag_garry");
+    expect(mentionProps(nodes[0])?.["data-mention-label"]).toBe("Garry's Codex");
+    expect(nodes[1]).toEqual({ type: "text", value: " 谢谢" });
+  });
+
+  it("does not resolve @ inside email addresses", () => {
+    const nodes = splitPlainMentionText("ping me@example.com", [
+      { id: "ag_example", label: "example" },
+    ]);
+
+    expect(nodes).toEqual([{ type: "text", value: "ping me@example.com" }]);
+  });
+
+  it("prefers the longest matching display name", () => {
+    const nodes = splitPlainMentionText("@Garry's Codex hi", [
+      { id: "ag_short", label: "Garry" },
+      { id: "ag_long", label: "Garry's Codex" },
+    ]);
+
+    expect(mentionProps(nodes[0])?.["data-mention-id"]).toBe("ag_long");
+  });
+});

--- a/frontend/src/components/ui/MarkdownContent.tsx
+++ b/frontend/src/components/ui/MarkdownContent.tsx
@@ -9,6 +9,12 @@ import type { Components } from "react-markdown";
 interface MarkdownContentProps {
   content: string;
   renderMention?: (mention: { id: string; label: string }) => ReactNode;
+  mentionCandidates?: MentionTextCandidate[];
+}
+
+export interface MentionTextCandidate {
+  id: string;
+  label: string;
 }
 
 interface HastTextNode {
@@ -32,7 +38,70 @@ type HastNode = HastTextNode | HastElementNode | HastRootNode | { type?: string;
 
 const MENTION_WITH_ID_RE = /@([^\n@]*?)\(((?:ag|hu)_[^)]+)\)/g;
 
-function splitMentionText(value: string): HastNode[] {
+function isMentionStartBoundary(value: string, index: number): boolean {
+  if (index === 0) return true;
+  return /[\s([{'"“‘]/.test(value[index - 1]);
+}
+
+function isMentionEndBoundary(value: string, index: number): boolean {
+  const after = value[index];
+  return after === undefined || /[\s.,!?;:()[\]{}'"“”‘’]/.test(after);
+}
+
+export function splitPlainMentionText(value: string, candidates: MentionTextCandidate[] = []): HastNode[] {
+  const sortedCandidates = candidates
+    .filter((candidate) => candidate.id && candidate.label)
+    .sort((a, b) => b.label.length - a.label.length);
+
+  if (sortedCandidates.length === 0) {
+    return [{ type: "text", value }];
+  }
+
+  const nodes: HastNode[] = [];
+  let cursor = 0;
+  let textStart = 0;
+
+  while (cursor < value.length) {
+    if (value[cursor] !== "@" || !isMentionStartBoundary(value, cursor)) {
+      cursor += 1;
+      continue;
+    }
+
+    const restLower = value.slice(cursor + 1).toLowerCase();
+    const match = sortedCandidates.find((candidate) => {
+      if (!restLower.startsWith(candidate.label.toLowerCase())) return false;
+      return isMentionEndBoundary(value, cursor + 1 + candidate.label.length);
+    });
+
+    if (!match) {
+      cursor += 1;
+      continue;
+    }
+
+    if (cursor > textStart) {
+      nodes.push({ type: "text", value: value.slice(textStart, cursor) });
+    }
+    nodes.push({
+      type: "element",
+      tagName: "span",
+      properties: {
+        "data-mention-id": match.id,
+        "data-mention-label": match.label,
+      },
+      children: [{ type: "text", value: `@${match.label}` }],
+    });
+    cursor = cursor + 1 + match.label.length;
+    textStart = cursor;
+  }
+
+  if (textStart < value.length) {
+    nodes.push({ type: "text", value: value.slice(textStart) });
+  }
+
+  return nodes.length > 0 ? nodes : [{ type: "text", value }];
+}
+
+function splitMentionText(value: string, candidates: MentionTextCandidate[] = []): HastNode[] {
   const nodes: HastNode[] = [];
   let lastIndex = 0;
   MENTION_WITH_ID_RE.lastIndex = 0;
@@ -44,7 +113,7 @@ function splitMentionText(value: string): HastNode[] {
     if (!rawLabel || !id) continue;
 
     if (index > lastIndex) {
-      nodes.push({ type: "text", value: value.slice(lastIndex, index) });
+      nodes.push(...splitPlainMentionText(value.slice(lastIndex, index), candidates));
     }
     nodes.push({
       type: "element",
@@ -59,7 +128,7 @@ function splitMentionText(value: string): HastNode[] {
   }
 
   if (lastIndex < value.length) {
-    nodes.push({ type: "text", value: value.slice(lastIndex) });
+    nodes.push(...splitPlainMentionText(value.slice(lastIndex), candidates));
   }
 
   return nodes.length > 0 ? nodes : [{ type: "text", value }];
@@ -73,8 +142,9 @@ function isHastElement(node: HastNode): node is HastElementNode {
   return node.type === "element" && typeof (node as { tagName?: unknown }).tagName === "string";
 }
 
-function rehypeMentions() {
+function rehypeMentions(options?: { candidates?: MentionTextCandidate[] }) {
   const skipTags = new Set(["a", "code", "pre", "script", "style"]);
+  const candidates = options?.candidates ?? [];
 
   const visit = (node: HastNode, parentTag?: string) => {
     if (!("children" in node) || !Array.isArray(node.children)) return;
@@ -83,7 +153,7 @@ function rehypeMentions() {
 
     for (const child of node.children) {
       if (isHastText(child) && !skipTags.has(currentTag ?? "")) {
-        nextChildren.push(...splitMentionText(child.value));
+        nextChildren.push(...splitMentionText(child.value, candidates));
         continue;
       }
       visit(child, currentTag);
@@ -189,12 +259,12 @@ function createComponents(renderMention?: MarkdownContentProps["renderMention"])
   };
 }
 
-export default function MarkdownContent({ content, renderMention }: MarkdownContentProps) {
+export default function MarkdownContent({ content, renderMention, mentionCandidates }: MarkdownContentProps) {
   return (
     <div className="break-words text-sm text-text-primary [&>*:first-child]:mt-0">
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkBreaks]}
-        rehypePlugins={[rehypeMentions]}
+        rehypePlugins={[[rehypeMentions, { candidates: mentionCandidates ?? [] }]]}
         components={createComponents(renderMention)}
       >
         {content}

--- a/frontend/src/store/useDashboardChatStore.ts
+++ b/frontend/src/store/useDashboardChatStore.ts
@@ -34,6 +34,11 @@ let publicRoomsRequestSeq = 0;
 let publicAgentsRequestSeq = 0;
 let publicHumansRequestSeq = 0;
 
+function isFetchNetworkError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return error.name === "TypeError" && error.message === "Failed to fetch";
+}
+
 function applyRealtimeRoomHint<T extends {
   room_id: string;
   last_message_at: string | null;
@@ -524,6 +529,11 @@ export const useDashboardChatStore = create<DashboardChatState>()(
             void get().loadRoomMessages(openedRoomId);
           }
         } catch (error: any) {
+          if (get().overview && isFetchNetworkError(error)) {
+            console.warn("[ChatStore] Background overview refresh failed:", error);
+            set({ overviewRefreshing: false, overviewErrored: false });
+            return;
+          }
           set({ error: error?.message || "Failed to refresh", overviewRefreshing: false, overviewErrored: true });
         }
       },


### PR DESCRIPTION
## Summary
- Resolve plain-text @display-name mentions against room members, contacts, and the active agent when rendering dashboard messages
- Keep structured @Name(id) mentions working and reuse the existing mention chip UI
- Add coverage for display names with spaces/apostrophes and avoiding email-address false positives

## Tests
- cd frontend && npm test -- MessageComposer.test.ts MarkdownContent.test.ts
- cd frontend && npm run build