### PR TITLE
fix: clarify agent name input

### DIFF
--- a/frontend/src/components/dashboard/CreateAgentDialog.tsx
+++ b/frontend/src/components/dashboard/CreateAgentDialog.tsx
@@ -450,9 +450,14 @@ export default function CreateAgentDialog({
             )}
 
             <div>
-              <label className="mb-1.5 block text-xs font-semibold uppercase tracking-wider text-text-secondary">
-                {t.nameLabel}
-              </label>
+              <div className="mb-1.5 flex items-center justify-between gap-3">
+                <label className="text-xs font-semibold uppercase tracking-wider text-text-secondary">
+                  {t.nameLabel}
+                </label>
+                <span className="text-[11px] font-medium text-neon-cyan">
+                  {t.nameRequired}
+                </span>
+              </div>
               <input
                 type="text"
                 value={name}
@@ -467,6 +472,9 @@ export default function CreateAgentDialog({
                 className="w-full rounded-xl border border-glass-border bg-deep-black px-3 py-2 text-sm text-text-primary placeholder-text-tertiary focus:border-neon-cyan focus:outline-none focus:ring-1 focus:ring-neon-cyan/50 disabled:opacity-50"
                 maxLength={64}
               />
+              <p className="mt-1.5 text-xs leading-5 text-text-secondary">
+                {t.nameHint}
+              </p>
             </div>
 
             <div>

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -1631,6 +1631,7 @@ export const createAgentDialog: TranslationMap<{
   runtimeNotSupported: string
   nameLabel: string
   namePlaceholder: string
+  nameHint: string
   nameRequired: string
   bioLabel: string
   bioPlaceholder: string
@@ -1664,8 +1665,9 @@ export const createAgentDialog: TranslationMap<{
     probeRuntimes: 'Detect runtimes',
     runtimeUnavailable: 'unavailable',
     runtimeNotSupported: 'not yet supported',
-    nameLabel: 'Name',
-    namePlaceholder: 'my-agent',
+    nameLabel: 'Agent name',
+    namePlaceholder: 'Enter a name, e.g. Research assistant',
+    nameHint: 'This is the display name people will see. Pick your own name before creating.',
     nameRequired: 'Name is required',
     bioLabel: 'Bio (optional)',
     bioPlaceholder: 'What does this agent do?',
@@ -1699,8 +1701,9 @@ export const createAgentDialog: TranslationMap<{
     probeRuntimes: '检测运行时',
     runtimeUnavailable: '不可用',
     runtimeNotSupported: '暂不支持',
-    nameLabel: '名称',
-    namePlaceholder: 'my-agent',
+    nameLabel: 'Agent 名称',
+    namePlaceholder: '输入名称，例如：研究助理',
+    nameHint: '这是创建后的显示名称，请先填写你自己的名称。',
     nameRequired: '名称不能为空',
     bioLabel: '简介（可选）',
     bioPlaceholder: '这个 agent 用来做什么？',


### PR DESCRIPTION
## Summary
- make the Create Agent name field explicitly refer to the Agent display name
- replace the example-like placeholder with an action-oriented prompt
- add a required marker and short helper text under the field

## Tests
- cd frontend && npm run build