### PR TITLE
fix: sanitize kimi cli extra args

### DIFF
--- a/packages/daemon/src/gateway/__tests__/kimi-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/kimi-adapter.test.ts
@@ -18,7 +18,7 @@ afterAll(() => {
   rmSync(tmpRoot, { recursive: true, force: true });
 });
 
-function runAdapter(script: string, sessionId: string | null = null) {
+function runAdapter(script: string, sessionId: string | null = null, extraArgs?: string[]) {
   const adapter = new KimiAdapter({ binary: script });
   const ctrl = new AbortController();
   return adapter.run({
@@ -28,6 +28,7 @@ function runAdapter(script: string, sessionId: string | null = null) {
     cwd: tmpRoot,
     signal: ctrl.signal,
     trustLevel: "owner",
+    extraArgs,
   });
 }
 
@@ -67,6 +68,89 @@ process.stdout.write(JSON.stringify({role:"assistant", content:JSON.stringify(ar
     expect(argv).toContain("--print");
     expect(argv).toContain("stream-json");
     expect(argv).toContain("--afk");
+  });
+
+  it("drops non-Kimi inherited extraArgs and their values", async () => {
+    const script = makeScript(
+      "filter-foreign-argv.js",
+      `
+const argv = process.argv.slice(2);
+process.stdout.write(JSON.stringify({role:"assistant", content:JSON.stringify(argv)}) + "\\n");
+`,
+    );
+    const res = await runAdapter(script, "sid-123", [
+      "--permission-mode",
+      "bypassPermissions",
+      "--model",
+      "kimi-k2",
+    ]);
+    const argv = JSON.parse(res.text) as string[];
+    expect(argv).not.toContain("--permission-mode");
+    expect(argv).not.toContain("bypassPermissions");
+    expect(argv).toContain("--model");
+    expect(argv[argv.indexOf("--model") + 1]).toBe("kimi-k2");
+  });
+
+  it("preserves Kimi value flags with negative numeric values", async () => {
+    const script = makeScript(
+      "negative-value-argv.js",
+      `
+const argv = process.argv.slice(2);
+process.stdout.write(JSON.stringify({role:"assistant", content:JSON.stringify(argv)}) + "\\n");
+`,
+    );
+    const res = await runAdapter(script, "sid-123", [
+      "--max-ralph-iterations",
+      "-1",
+      "--max-steps-per-turn=3",
+    ]);
+    const argv = JSON.parse(res.text) as string[];
+    expect(argv).toContain("--max-ralph-iterations");
+    expect(argv[argv.indexOf("--max-ralph-iterations") + 1]).toBe("-1");
+    expect(argv).toContain("--max-steps-per-turn=3");
+  });
+
+  it("drops incomplete Kimi value flags instead of passing invalid argv", async () => {
+    const script = makeScript(
+      "incomplete-value-argv.js",
+      `
+const argv = process.argv.slice(2);
+process.stdout.write(JSON.stringify({role:"assistant", content:JSON.stringify(argv)}) + "\\n");
+`,
+    );
+    const res = await runAdapter(script, "sid-123", ["--model", "--plan"]);
+    const argv = JSON.parse(res.text) as string[];
+    expect(argv).not.toContain("--model");
+    expect(argv).toContain("--plan");
+  });
+
+  it("does not let extraArgs override adapter-owned stream/session/prompt flags", async () => {
+    const script = makeScript(
+      "filter-owned-argv.js",
+      `
+const argv = process.argv.slice(2);
+process.stdout.write(JSON.stringify({role:"assistant", content:JSON.stringify(argv)}) + "\\n");
+`,
+    );
+    const res = await runAdapter(script, "real-session", [
+      "--output-format",
+      "text",
+      "--session",
+      "evil-session",
+      "--prompt",
+      "evil prompt",
+      "--plan",
+    ]);
+    const argv = JSON.parse(res.text) as string[];
+    expect(argv.filter((a) => a === "--output-format")).toHaveLength(1);
+    expect(argv[argv.indexOf("--output-format") + 1]).toBe("stream-json");
+    expect(argv.filter((a) => a === "--session")).toHaveLength(1);
+    expect(argv[argv.indexOf("--session") + 1]).toBe("real-session");
+    expect(argv.filter((a) => a === "--prompt")).toHaveLength(1);
+    expect(argv[argv.indexOf("--prompt") + 1]).toBe("hi");
+    expect(argv).toContain("--plan");
+    expect(argv).not.toContain("evil-session");
+    expect(argv).not.toContain("evil prompt");
   });
 
   it("rejects session ids that could be parsed as flags", async () => {

--- a/packages/daemon/src/gateway/runtimes/kimi.ts
+++ b/packages/daemon/src/gateway/runtimes/kimi.ts
@@ -22,6 +22,113 @@ function invalidKimiSessionIdError(): string {
   return "kimi-cli: invalid sessionId (expected non-control text not starting with '-')";
 }
 
+const KIMI_EXTRA_FLAGS_WITH_VALUE = new Set([
+  "--add-dir",
+  "--agent",
+  "--agent-file",
+  "--config",
+  "--config-file",
+  "--max-ralph-iterations",
+  "--max-retries-per-step",
+  "--max-steps-per-turn",
+  "--mcp-config",
+  "--mcp-config-file",
+  "--model",
+  "--skills-dir",
+  "-m",
+]);
+
+const KIMI_EXTRA_BOOLEAN_FLAGS = new Set([
+  "--afk",
+  "--auto-approve",
+  "--debug",
+  "--no-thinking",
+  "--plan",
+  "--thinking",
+  "--verbose",
+  "--yes",
+  "--yolo",
+  "-y",
+]);
+
+// Flags owned by the adapter because BotCord depends on Kimi's non-interactive
+// stream-json contract, cwd isolation, prompt placement, and session routing.
+const KIMI_ADAPTER_OWNED_FLAGS = new Set([
+  "--acp",
+  "--command",
+  "--continue",
+  "--final-message-only",
+  "--help",
+  "--input-format",
+  "--output-format",
+  "--print",
+  "--prompt",
+  "--quiet",
+  "--resume",
+  "--session",
+  "--version",
+  "--wire",
+  "--work-dir",
+  "-C",
+  "-S",
+  "-V",
+  "-c",
+  "-h",
+  "-p",
+  "-r",
+  "-w",
+]);
+
+function flagName(arg: string): string {
+  if (!arg.startsWith("-")) return arg;
+  const eq = arg.indexOf("=");
+  return eq === -1 ? arg : arg.slice(0, eq);
+}
+
+function nextValue(args: string[], index: number): string | undefined {
+  const next = args[index + 1];
+  if (typeof next !== "string") return undefined;
+  if (!next.startsWith("-")) return next;
+  return /^-\d/.test(next) ? next : undefined;
+}
+
+function sanitizeKimiExtraArgs(extraArgs: string[] | undefined): string[] {
+  if (!extraArgs?.length) return [];
+  const out: string[] = [];
+  for (let i = 0; i < extraArgs.length; i += 1) {
+    const arg = extraArgs[i];
+    const name = flagName(arg);
+
+    if (KIMI_ADAPTER_OWNED_FLAGS.has(name)) {
+      if (!arg.includes("=") && nextValue(extraArgs, i) !== undefined) i += 1;
+      continue;
+    }
+
+    if (KIMI_EXTRA_FLAGS_WITH_VALUE.has(name)) {
+      if (arg.includes("=")) {
+        out.push(arg);
+        continue;
+      }
+      const value = nextValue(extraArgs, i);
+      if (value !== undefined) {
+        out.push(arg, value);
+        i += 1;
+      }
+      continue;
+    }
+
+    if (KIMI_EXTRA_BOOLEAN_FLAGS.has(name)) {
+      out.push(arg);
+      continue;
+    }
+
+    if (arg.startsWith("-") && !arg.includes("=") && nextValue(extraArgs, i) !== undefined) {
+      i += 1;
+    }
+  }
+  return out;
+}
+
 /** Resolve the Kimi CLI executable on PATH. */
 export function resolveKimiCommand(deps: ProbeDeps = {}): string | null {
   return resolveCommandOnPath("kimi", deps);
@@ -41,7 +148,7 @@ export function probeKimi(deps: ProbeDeps = {}): RuntimeProbeResult {
 /**
  * Kimi CLI adapter — spawns:
  *
- *   kimi --work-dir <cwd> --print --output-format stream-json --session <sid> --prompt <text>
+ *   kimi --work-dir <cwd> --print --output-format stream-json --session <sid> --afk --prompt <text>
  *
  * `--session <sid>` resumes an existing session or creates a new session with
  * that id, so the adapter generates a UUID on first turn and persists it for
@@ -93,7 +200,7 @@ export class KimiAdapter extends NdjsonStreamAdapter {
       sessionId,
       "--afk",
     ];
-    if (opts.extraArgs?.length) args.push(...opts.extraArgs);
+    args.push(...sanitizeKimiExtraArgs(opts.extraArgs));
     args.push("--prompt", promptWithSystemContext(opts.text, opts.systemContext));
     return args;
   }


### PR DESCRIPTION
## Summary
- filter Kimi extraArgs against the options supported by Kimi CLI
- prevent route/defaultRoute flags like `--permission-mode bypassPermissions` from being passed to Kimi
- keep adapter-owned stream/session/prompt flags under BotCord control and cover negative numeric values such as `--max-ralph-iterations -1`

## Tests
- `cd packages/daemon && npm test -- --run src/gateway/__tests__/kimi-adapter.test.ts`
- `cd packages/daemon && npx tsc --noEmit` *(fails on pre-existing unrelated test type errors)*

Note: the clean PR worktree did not have node_modules installed, so the target test was verified in the main working tree before creating the PR.