### PR TITLE
feat: detect QClaw OpenClaw gateways

### DIFF
--- a/packages/daemon/src/__tests__/openclaw-discovery.test.ts
+++ b/packages/daemon/src/__tests__/openclaw-discovery.test.ts
@@ -128,6 +128,41 @@ describe("discoverLocalOpenclawGateways", () => {
     ]);
   });
 
+  it("discovers QClaw's state config and referenced OpenClaw config", async () => {
+    const dir = tempDir();
+    const openclawConfig = path.join(dir, "openclaw.json");
+    writeFileSync(
+      openclawConfig,
+      JSON.stringify({
+        gateway: {
+          port: 28789,
+          bind: "loopback",
+          auth: { mode: "token", token: "qclaw-token" },
+        },
+      }),
+    );
+    writeFileSync(
+      path.join(dir, "qclaw.json"),
+      JSON.stringify({
+        configPath: openclawConfig,
+        port: 28789,
+      }),
+    );
+
+    const found = await discoverLocalOpenclawGateways({
+      searchPaths: [dir],
+      defaultPorts: [],
+    });
+
+    expect(found).toEqual([
+      expect.objectContaining({
+        url: "ws://127.0.0.1:28789",
+        token: "qclaw-token",
+        source: "config-file",
+      }),
+    ]);
+  });
+
   it("uses OPENCLAW_ACP_URL and token env vars", async () => {
     const found = await discoverLocalOpenclawGateways({
       searchPaths: [],
@@ -269,8 +304,8 @@ describe("discoverLocalOpenclawGateways", () => {
     ]);
   });
 
-  it("includes 16200 in default discovery ports", () => {
-    expect(defaultOpenclawDiscoveryPorts()).toEqual(expect.arrayContaining([18789, 16200]));
+  it("includes OpenClaw and QClaw ports in default discovery ports", () => {
+    expect(defaultOpenclawDiscoveryPorts()).toEqual(expect.arrayContaining([18789, 16200, 28789]));
   });
 
   it("adds default-port candidates only when the probe succeeds", async () => {

--- a/packages/daemon/src/__tests__/provision.test.ts
+++ b/packages/daemon/src/__tests__/provision.test.ts
@@ -27,6 +27,7 @@ vi.mock("../config.js", async () => {
 const {
   addAgentToConfig,
   adoptDiscoveredOpenclawAgents,
+  probeOpenclawAgents,
   removeAgentFromConfig,
   reloadConfig,
   setRoute,
@@ -34,6 +35,7 @@ const {
 } = await import("../provision.js");
 const { CONTROL_FRAME_TYPES } = await import("@botcord/protocol-core");
 import type { DaemonConfig } from "../config.js";
+import type { WsEndpointProbeFn } from "../provision.js";
 import type {
   GatewayChannelConfig,
   GatewayRoute,
@@ -1139,7 +1141,7 @@ describe("adoptDiscoveredOpenclawAgents", () => {
         openclawGateways: [{ name: "local", url: "ws://127.0.0.1:18789" }],
       };
       const register = vi.fn();
-      const probe = vi.fn<Parameters<typeof adoptDiscoveredOpenclawAgents>[0]["probe"]>(
+      const probe = vi.fn<WsEndpointProbeFn>(
         async () => ({ ok: true, agents: [{ id: "main" }] }),
       );
 
@@ -1220,6 +1222,70 @@ describe("adoptDiscoveredOpenclawAgents", () => {
         "Danny",
         "OpenClaw agent swe adopted from gateway local.",
       );
+    });
+  });
+});
+
+describe("probeOpenclawAgents local profiles", () => {
+  it("enriches loopback QClaw gateways from ~/.qclaw/openclaw.json", async () => {
+    await withSandboxHome(async ({ tmp, fs, path: nodePath }) => {
+      const { WebSocketServer } = await import("ws");
+      const qclawDir = nodePath.join(tmp, ".qclaw");
+      fs.mkdirSync(qclawDir, { recursive: true });
+
+      const wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+      await new Promise<void>((resolve) => wss.once("listening", resolve));
+      const address = wss.address();
+      if (typeof address === "string" || address === null) {
+        throw new Error("expected tcp websocket address");
+      }
+
+      fs.writeFileSync(
+        nodePath.join(qclawDir, "openclaw.json"),
+        JSON.stringify({
+          agents: {
+            defaults: {
+              workspace: nodePath.join(qclawDir, "workspace"),
+              model: { primary: "qclaw/modelroute" },
+            },
+            list: [{ id: "main", name: "QClaw" }],
+          },
+          gateway: {
+            port: address.port,
+            auth: { mode: "token", token: "qclaw-token" },
+          },
+        }),
+      );
+
+      wss.on("connection", (ws) => {
+        ws.send(JSON.stringify({ type: "event", event: "connect.challenge", payload: { nonce: "n" } }));
+        ws.on("message", (raw) => {
+          const msg = JSON.parse(raw.toString("utf8"));
+          if (msg.method === "connect") {
+            ws.send(
+              JSON.stringify({
+                type: "res",
+                id: msg.id,
+                ok: true,
+                payload: { type: "hello-ok", server: { version: "2026.4.21" } },
+              }),
+            );
+          }
+        });
+      });
+
+      try {
+        const res = await probeOpenclawAgents({
+          url: `ws://127.0.0.1:${address.port}`,
+          token: "qclaw-token",
+        });
+
+        expect(res.ok).toBe(true);
+        expect(res.version).toBe("2026.4.21");
+        expect(res.agents).toEqual([{ id: "main", name: "QClaw" }]);
+      } finally {
+        await new Promise<void>((resolve) => wss.close(() => resolve()));
+      }
     });
   });
 });

--- a/packages/daemon/src/openclaw-discovery.ts
+++ b/packages/daemon/src/openclaw-discovery.ts
@@ -34,8 +34,8 @@ export interface MergeOpenclawGatewayResult {
   added: OpenclawGatewayProfile[];
 }
 
-const DEFAULT_SEARCH_PATHS = ["~/.openclaw/", "/etc/openclaw/"];
-const DEFAULT_PORTS = [18789, 16200];
+const DEFAULT_SEARCH_PATHS = ["~/.openclaw/", "~/.qclaw/", "/etc/openclaw/"];
+const DEFAULT_PORTS = [18789, 16200, 28789];
 const DEFAULT_TOKEN_FILE_PATHS = [
   "/run/openclaw/gateway-token",
   "/var/run/openclaw/gateway-token",
@@ -382,12 +382,43 @@ function discoverFromConfigDir(root: string): DiscoveredOpenclawGateway[] {
 
 function parseJsonConfig(raw: string): { url?: string; token?: string; tokenFile?: string } | null {
   const obj = JSON.parse(raw) as any;
+  const qclaw = pickQclawGatewayValues(obj);
+  if (qclaw) return qclaw;
   // Prefer OpenClaw's native shape: `gateway.port` + `gateway.auth.token`.
   // The legacy `acp.url` shape is also supported for explicit user-authored configs.
   const native = pickOpenclawGatewayValues(obj?.gateway);
   if (native) return native;
   const acp = obj?.acp ?? obj?.gateway?.acp ?? obj?.gateway ?? obj;
   return pickConfigValues(acp);
+}
+
+function pickQclawGatewayValues(
+  obj: any,
+): { url?: string; token?: string; tokenFile?: string } | null {
+  if (!obj || typeof obj !== "object") return null;
+  const port = typeof obj.port === "number" ? obj.port : undefined;
+  const configPath = typeof obj.configPath === "string" && obj.configPath.trim()
+    ? obj.configPath.trim()
+    : undefined;
+  if (!port && !configPath) return null;
+
+  const fromConfig = configPath ? readGatewayValuesFromConfigPath(configPath) : null;
+  if (fromConfig) return fromConfig;
+  if (!port) return null;
+  return { url: `ws://127.0.0.1:${port}` };
+}
+
+function readGatewayValuesFromConfigPath(
+  configPath: string,
+): { url?: string; token?: string; tokenFile?: string } | null {
+  try {
+    const raw = readFileSync(expandHome(configPath), "utf8");
+    const parsed = parseJsonConfig(raw);
+    if (parsed?.url) return parsed;
+  } catch {
+    // qclaw.json may be copied without its referenced openclaw.json.
+  }
+  return null;
 }
 
 function pickOpenclawGatewayValues(

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -1362,9 +1362,9 @@ export async function adoptDiscoveredOpenclawAgents(ctx: {
 function localOpenclawAcpDisabled(rawUrl: string): boolean {
   if (!isLoopbackUrl(rawUrl)) return false;
   try {
-    const file = path.join(homedir(), ".openclaw", "openclaw.json");
-    if (!existsSync(file)) return false;
-    const cfg = JSON.parse(readFileSync(file, "utf8")) as any;
+    const source = pickLocalOpenclawConfig(rawUrl);
+    if (!source) return false;
+    const cfg = JSON.parse(readFileSync(source.file, "utf8")) as any;
     return cfg?.acp?.enabled === false;
   } catch {
     return false;
@@ -1838,12 +1838,13 @@ export async function probeOpenclawAgents(
     token: prepared.resolvedToken,
     timeoutMs: opts.timeoutMs ?? 3000,
   });
-  // For loopback gateways the agent roster lives in `~/.openclaw/openclaw.json`
+  // For loopback gateways the agent roster lives in local OpenClaw config
+  // (`~/.openclaw/openclaw.json`, or QClaw's `~/.qclaw/openclaw.json`)
   // and is the source of truth — listing it over the wire would require a
   // paired device identity (operator.read scope). When the WS probe is the
   // default (i.e. no test injection) we enrich the result from disk.
   if (result.ok && !result.agents && !opts.probe && isLoopbackUrl(profile.url)) {
-    const local = readLocalOpenclawAgents();
+    const local = readLocalOpenclawAgents(profile.url);
     if (local && local.length > 0) result.agents = local;
   }
   return result;
@@ -1858,22 +1859,23 @@ function isLoopbackUrl(raw: string): boolean {
   }
 }
 
-function readLocalOpenclawAgents(): Array<{
+function readLocalOpenclawAgents(rawUrl?: string): Array<{
   id: string;
   name?: string;
   workspace?: string;
   model?: { name?: string; provider?: string };
 }> | null {
   try {
-    const file = path.join(homedir(), ".openclaw", "openclaw.json");
-    if (!existsSync(file)) return readLocalOpenclawAgentDirs() ?? [{ id: "default" }];
+    const source = pickLocalOpenclawConfig(rawUrl);
+    if (!source) return readLocalOpenclawAgentDirs(path.join(homedir(), ".openclaw")) ?? [{ id: "default" }];
+    const { file, stateDir } = source;
     const cfg = JSON.parse(readFileSync(file, "utf8")) as any;
     const list = Array.isArray(cfg?.agents?.list) ? cfg.agents.list : [];
     const explicitDefaultId =
       typeof cfg?.agents?.defaults?.id === "string" && cfg.agents.defaults.id
         ? cfg.agents.defaults.id
         : null;
-    const dirAgents = readLocalOpenclawAgentDirs();
+    const dirAgents = readLocalOpenclawAgentDirs(stateDir);
     const defaultId = explicitDefaultId ?? (list.length === 0 && !dirAgents ? "default" : null);
     const seen = new Set<string>();
     const out: Array<{ id: string; name?: string; workspace?: string; model?: { name?: string; provider?: string } }> = [];
@@ -1906,18 +1908,50 @@ function readLocalOpenclawAgents(): Array<{
   }
 }
 
-function readLocalOpenclawAgentDirs(): Array<{
+function pickLocalOpenclawConfig(rawUrl?: string): { file: string; stateDir: string } | null {
+  const candidates = [
+    { file: path.join(homedir(), ".openclaw", "openclaw.json"), stateDir: path.join(homedir(), ".openclaw") },
+    { file: path.join(homedir(), ".qclaw", "openclaw.json"), stateDir: path.join(homedir(), ".qclaw") },
+  ];
+  const targetPort = urlPort(rawUrl);
+  let firstExisting: { file: string; stateDir: string } | null = null;
+  for (const candidate of candidates) {
+    if (!existsSync(candidate.file)) continue;
+    firstExisting ??= candidate;
+    if (!targetPort) continue;
+    try {
+      const cfg = JSON.parse(readFileSync(candidate.file, "utf8")) as any;
+      if (Number(cfg?.gateway?.port) === targetPort) return candidate;
+    } catch {
+      // Try the next local config.
+    }
+  }
+  return firstExisting;
+}
+
+function urlPort(rawUrl?: string): number | null {
+  if (!rawUrl) return null;
+  try {
+    const u = new URL(rawUrl);
+    const port = Number(u.port || (u.protocol === "wss:" ? 443 : 80));
+    return Number.isInteger(port) && port > 0 ? port : null;
+  } catch {
+    return null;
+  }
+}
+
+function readLocalOpenclawAgentDirs(stateDir: string): Array<{
   id: string;
   workspace?: string;
 }> | null {
   try {
-    const dir = path.join(homedir(), ".openclaw", "agents");
+    const dir = path.join(stateDir, "agents");
     if (!existsSync(dir)) return null;
     const agents = readdirSync(dir, { withFileTypes: true })
       .filter((entry) => entry.isDirectory() && entry.name.length > 0)
       .map((entry) => ({
         id: entry.name,
-        workspace: path.join(dir, entry.name),
+        workspace: resolveAgentDirWorkspace(dir, entry.name),
       }));
     if (agents.length === 0) return null;
     agents.sort((a, b) => {
@@ -1929,6 +1963,11 @@ function readLocalOpenclawAgentDirs(): Array<{
   } catch {
     return null;
   }
+}
+
+function resolveAgentDirWorkspace(agentsDir: string, agentId: string): string {
+  const nested = path.join(agentsDir, agentId, "agent");
+  return existsSync(nested) ? nested : path.join(agentsDir, agentId);
 }
 
 function resolveOpenclawIdentityName(


### PR DESCRIPTION
## Summary
- discover QClaw's bundled OpenClaw gateway from `~/.qclaw` and default port `28789`
- parse `qclaw.json` -> referenced `openclaw.json` to preserve gateway auth details
- enrich loopback OpenClaw profiles from the matching local config, including QClaw profiles

## Testing
- `cd packages/daemon && npm test -- openclaw-discovery provision`
- `cd packages/daemon && npx tsc --noEmit` *(fails on existing unrelated test type errors in daemon test files)*

## Local verification
- detected QClaw gateway `ws://127.0.0.1:28789` with profile `main` / `QClaw`
