### PR TITLE
fix: reauthorize daemon install token restarts

### DIFF
--- a/backend/hub/routers/daemon_control.py
+++ b/backend/hub/routers/daemon_control.py
@@ -304,6 +304,7 @@ async def issue_install_ticket(
 class _InstallTokenRequest(BaseModel):
     install_token: str = Field(..., min_length=8, max_length=128)
     label: str | None = Field(default=None, max_length=64)
+    daemon_instance_id: str | None = Field(default=None, max_length=32)
 
 
 @router.post("/daemon/auth/install-token")
@@ -328,10 +329,31 @@ async def redeem_install_token(
         if isinstance(body.label, str) and body.label.strip()
         else row.label
     )
-    daemon_instance_id, refresh_token = await _provision_daemon_instance(
-        db, row.user_id, label
+    requested_daemon_id = (
+        body.daemon_instance_id.strip()
+        if isinstance(body.daemon_instance_id, str) and body.daemon_instance_id.strip()
+        else None
     )
-    bundle, _ = _build_token_bundle(str(row.user_id), daemon_instance_id)
+    if requested_daemon_id:
+        existing_result = await db.execute(
+            select(DaemonInstance).where(DaemonInstance.id == requested_daemon_id)
+        )
+        instance = existing_result.scalar_one_or_none()
+        if instance is None or str(instance.user_id) != str(row.user_id):
+            raise HTTPException(status_code=404, detail="daemon_instance_not_found")
+        if instance.revoked_at is not None:
+            raise HTTPException(status_code=409, detail="daemon_revoked")
+        bundle, refresh_token = _build_token_bundle(str(row.user_id), instance.id)
+        instance.refresh_token_hash = _hash_refresh_token(refresh_token)
+        instance.last_seen_at = _now()
+        if label:
+            instance.label = label
+        daemon_instance_id = instance.id
+    else:
+        daemon_instance_id, refresh_token = await _provision_daemon_instance(
+            db, row.user_id, label
+        )
+        bundle, _ = _build_token_bundle(str(row.user_id), daemon_instance_id)
     bundle["refresh_token"] = refresh_token
 
     row.consumed_at = _now()

--- a/backend/tests/test_app/test_daemon_control.py
+++ b/backend/tests/test_app/test_daemon_control.py
@@ -260,6 +260,58 @@ async def test_install_ticket_redeems_once(
 
 
 @pytest.mark.asyncio
+async def test_install_ticket_can_reauthorize_existing_daemon_instance(
+    client: AsyncClient, seed_user, db_session: AsyncSession
+):
+    bundle = await _provision_instance_via_device_code(
+        client, seed_user, label="MacBook"
+    )
+    instance_id = bundle["daemon_instance_id"]
+    old_refresh = bundle["refresh_token"]
+
+    # Burn the old refresh token to simulate an expired local daemon auth.
+    r = await client.post("/daemon/auth/refresh", json={"refresh_token": old_refresh})
+    assert r.status_code == 200, r.text
+
+    r = await client.post(
+        "/daemon/auth/install-ticket",
+        json={"label": "MacBook Reloaded"},
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert r.status_code == 200, r.text
+    issued = r.json()
+
+    r = await client.post(
+        "/daemon/auth/install-token",
+        json={
+            "install_token": issued["install_token"],
+            "daemon_instance_id": instance_id,
+            "label": "MacBook Reloaded",
+        },
+    )
+    assert r.status_code == 200, r.text
+    rebound = r.json()
+    assert rebound["daemon_instance_id"] == instance_id
+    assert rebound["refresh_token"].startswith("drt_")
+    assert rebound["refresh_token"] != old_refresh
+
+    from sqlalchemy import select
+
+    res = await db_session.execute(
+        select(DaemonInstance).where(DaemonInstance.id == instance_id)
+    )
+    inst = res.scalar_one()
+    assert inst.label == "MacBook Reloaded"
+
+    # The newly issued refresh token belongs to the same daemon instance.
+    r = await client.post(
+        "/daemon/auth/refresh", json={"refresh_token": rebound["refresh_token"]}
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["daemon_instance_id"] == instance_id
+
+
+@pytest.mark.asyncio
 async def test_install_ticket_requires_user_auth(client: AsyncClient):
     r = await client.post("/daemon/auth/install-ticket", json={})
     assert r.status_code == 401

--- a/docs/daemon-noninteractive-install-token-design.md
+++ b/docs/daemon-noninteractive-install-token-design.md
@@ -207,6 +207,22 @@ function buildStartCommand(token: string, label?: string): string {
 botcord-daemon start --relogin --install-token <token>
 ```
 
+后续修正：当已有 `user-auth.json` 但 refresh 被 Hub 明确拒绝为
+`invalid_refresh_token` / `daemon_revoked` 时，启动命令里携带的
+`--install-token` 不应继续被忽略。daemon 应优先尝试用本地
+`daemonInstanceId` 重新授权同一个 daemon instance，而不是新建 daemon instance。
+否则旧设备会被保留为离线，已绑定到旧 `daemon_instance_id` 的 agents 也会继续
+挂在旧设备下；新建 instance 后再批量改绑 agents 会破坏设备历史和管理语义。
+
+期望行为：
+
+1. 本地有 `daemonInstanceId` 且 Hub 返回 `invalid_refresh_token`：用用户授权的
+   install token / device-code 为同一个 instance 重新签发 daemon auth。
+2. 本地没有 `daemonInstanceId`，或旧 instance 不属于当前用户 / 已删除：才创建新
+   daemon instance。
+3. `daemon_revoked` 应保持终态，不自动恢复同一个 instance，除非产品明确提供
+   “恢复已撤销设备”流程。
+
 也可以新增更明确的：
 
 ```sh
@@ -334,3 +350,6 @@ hash = sha256(token)
 2. 前端是否需要每次展示弹窗都签发新 ticket？建议是。
 3. install token 是否绑定 IP / UA？不建议第一版做，容易误伤用户在远端机器安装的场景。
 4. 是否需要在 dashboard 上显示 pending install tickets？第一版不需要，只显示 daemon instances。
+5. relogin / install-token 是否支持“恢复同一个 daemon instance”？建议支持：
+   CLI 提交本地 `daemonInstanceId`，Hub 验证该 instance 属于当前用户且未 revoked，
+   然后仅重发 daemon auth，不新建 instance，也不改绑 agents。

--- a/frontend/src/components/dashboard/sidebar/DeviceSettingsModal.tsx
+++ b/frontend/src/components/dashboard/sidebar/DeviceSettingsModal.tsx
@@ -246,7 +246,9 @@ export default function DeviceSettingsModal({
                 <DaemonInstallCommand
                   labels={{
                     title: locale === "zh" ? "重新启动 BotCord Daemon" : "Restart BotCord Daemon",
-                    hint: locale === "zh" ? "在设备终端运行以下命令重新连接" : "Run this command in your device terminal to reconnect",
+                    hint: locale === "zh"
+                      ? "在这台同一设备的终端运行；daemon 会使用本机保存的设备 ID 重新连接"
+                      : "Run this in the terminal on this same device; the daemon will reconnect using the device ID saved locally.",
                     copy: locale === "zh" ? "复制" : "Copy",
                     copied: locale === "zh" ? "已复制" : "Copied",
                     refresh: locale === "zh" ? "刷新" : "Refresh",

--- a/packages/daemon/src/__tests__/start-auth.test.ts
+++ b/packages/daemon/src/__tests__/start-auth.test.ts
@@ -14,14 +14,14 @@ const existingAuth: UserAuthRecord = {
 };
 
 describe("resolveStartAuthAction", () => {
-  it("reuses existing auth even when a one-time install token is present", () => {
+  it("redeems an install token even when existing auth is available", () => {
     expect(
       resolveStartAuthAction({
         existing: existingAuth,
         relogin: false,
         installToken: "dit_expired",
       }),
-    ).toBe("reuse-existing");
+    ).toBe("install-token");
   });
 
   it("redeems an install token when no existing auth is available", () => {

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -231,6 +231,44 @@ function pidAlive(pid: number): boolean {
   }
 }
 
+async function waitForPidExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!pidAlive(pid)) return true;
+    await delay(100);
+  }
+  return !pidAlive(pid);
+}
+
+async function stopExistingDaemonForRestart(pid: number): Promise<void> {
+  if (pid === process.pid) return;
+  log.info("existing daemon found; restarting", { pid });
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch {
+    try {
+      unlinkSync(PID_PATH);
+    } catch {
+      // ignore
+    }
+    return;
+  }
+  if (!(await waitForPidExit(pid, 5_000))) {
+    log.warn("existing daemon did not stop after SIGTERM; sending SIGKILL", { pid });
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // ignore
+    }
+    await waitForPidExit(pid, 2_000);
+  }
+  try {
+    unlinkSync(PID_PATH);
+  } catch {
+    // ignore
+  }
+}
+
 /**
  * Load the daemon config, auto-creating `~/.botcord/daemon/config.json`
  * with sensible defaults on first run. `--agent` (repeated) pins explicit
@@ -323,9 +361,11 @@ async function redeemInstallToken(opts: {
   hubUrl: string;
   installToken: string;
   label?: string;
+  daemonInstanceId?: string;
 }): Promise<DaemonTokenResponse> {
   const body: Record<string, unknown> = { install_token: opts.installToken };
   if (opts.label) body.label = opts.label;
+  if (opts.daemonInstanceId) body.daemon_instance_id = opts.daemonInstanceId;
   const resp = await fetch(`${opts.hubUrl.replace(/\/+$/, "")}/daemon/auth/install-token`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -334,7 +374,9 @@ async function redeemInstallToken(opts: {
   });
   if (!resp.ok) {
     const text = await resp.text().catch(() => "");
-    throw new Error(`daemon install-token redeem failed: ${resp.status} ${text}`);
+    const err = new Error(`daemon install-token redeem failed: ${resp.status} ${text}`);
+    (err as unknown as { status?: number }).status = resp.status;
+    throw err;
   }
   return parseDaemonTokenResponse(await resp.json(), opts.hubUrl);
 }
@@ -418,10 +460,10 @@ async function runDeviceCodeFlow(opts: {
  * plane (legacy P0 behavior — caller may still log a warning).
  *
  * Decision tree (plan §4.4 + §6.4):
- * 1. Have existing creds and no `--relogin` → return existing record, even
- *    when a dashboard `--install-token` is present. The token is one-time and
- *    the generated install command should be safe to re-run after first login.
- * 2. No existing creds + `--install-token` → redeem the one-time dashboard ticket.
+ * 1. `--install-token` → redeem the one-time dashboard ticket. If local
+ *    user-auth exists, include its daemonInstanceId so Hub can re-authorize
+ *    the same device instead of creating a new one.
+ * 2. Have existing creds and no `--relogin` → return existing record.
  * 3. `--relogin` → device-code login.
  * 4. No creds + TTY → device-code login.
  * 5. No creds + no TTY → exit 1 with the §6.4 hint.
@@ -452,9 +494,6 @@ async function ensureUserAuthForStart(args: ParsedArgs): Promise<UserAuthRecord 
         `note: --label "${labelFlag}" ignored (already logged in as "${existing.label ?? "<unset>"}"); pass --relogin to change it`,
       );
     }
-    if (installToken) {
-      console.error("note: --install-token ignored because daemon is already logged in; pass --relogin to re-bind");
-    }
     return existing;
   }
 
@@ -463,13 +502,37 @@ async function ensureUserAuthForStart(args: ParsedArgs): Promise<UserAuthRecord 
   const label = labelFlag ?? defaultLoginLabel();
 
   if (authAction === "install-token" && installToken) {
-    const tok = await redeemInstallToken({ hubUrl, installToken, label });
-    const record = userAuthFromTokenResponse(tok, { label });
+    let tok: DaemonTokenResponse;
+    try {
+      tok = await redeemInstallToken({
+        hubUrl,
+        installToken,
+        label,
+        daemonInstanceId: existing?.daemonInstanceId,
+      });
+    } catch (err) {
+      if (existing && !relogin && !existsSync(AUTH_EXPIRED_FLAG_PATH)) {
+        console.error(
+          `note: --install-token could not be redeemed (${err instanceof Error ? err.message : String(err)}); reusing existing daemon auth`,
+        );
+        return existing;
+      }
+      throw err;
+    }
+    const record = userAuthFromTokenResponse(tok, {
+      label,
+      loggedInAt:
+        existing?.daemonInstanceId && existing.daemonInstanceId === tok.daemonInstanceId
+          ? existing.loggedInAt
+          : undefined,
+    });
     saveUserAuth(record);
     clearAuthExpiredFlag();
     log.info("install-token flow: authorized", {
       userId: record.userId,
       daemonInstanceId: record.daemonInstanceId,
+      reusedExistingDaemonInstance:
+        existing?.daemonInstanceId === record.daemonInstanceId,
       hubUrl: record.hubUrl,
       label,
     });
@@ -527,12 +590,6 @@ async function cmdStart(args: ParsedArgs): Promise<void> {
     child: process.env.BOTCORD_DAEMON_CHILD === "1",
   });
 
-  const existing = readPid();
-  if (existing && pidAlive(existing)) {
-    console.error(`daemon already running (pid ${existing})`);
-    process.exit(1);
-  }
-
   // Login MUST happen before fork — once detached, stdio is gone and the
   // user can't see the device code. We also run it for explicit
   // --foreground so an interactive user can log in without the fork dance.
@@ -540,6 +597,16 @@ async function cmdStart(args: ParsedArgs): Promise<void> {
   // var so we don't try to re-prompt for credentials it already has.
   if (process.env.BOTCORD_DAEMON_CHILD !== "1") {
     await ensureUserAuthForStart(args);
+    const existing = readPid();
+    if (existing && pidAlive(existing)) {
+      await stopExistingDaemonForRestart(existing);
+    }
+  } else {
+    const existing = readPid();
+    if (existing && existing !== process.pid && pidAlive(existing)) {
+      console.error(`daemon already running (pid ${existing})`);
+      process.exit(1);
+    }
   }
 
   if (background) {

--- a/packages/daemon/src/start-auth.ts
+++ b/packages/daemon/src/start-auth.ts
@@ -7,7 +7,7 @@ export function resolveStartAuthAction(opts: {
   relogin: boolean;
   installToken?: string;
 }): StartAuthAction {
-  if (opts.existing && !opts.relogin) return "reuse-existing";
   if (opts.installToken) return "install-token";
+  if (opts.existing && !opts.relogin) return "reuse-existing";
   return "device-code";
 }

--- a/packages/protocol-core/package-lock.json
+++ b/packages/protocol-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@botcord/protocol-core",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@botcord/protocol-core",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/packages/protocol-core/src/daemon-client.ts
+++ b/packages/protocol-core/src/daemon-client.ts
@@ -81,11 +81,12 @@ export async function refreshDaemonToken(
 export async function redeemDaemonInstallToken(
   hubUrl: string,
   installToken: string,
-  opts?: { label?: string; timeoutMs?: number },
+  opts?: { label?: string; daemonInstanceId?: string; timeoutMs?: number },
 ): Promise<DaemonTokenResponse> {
   const base = normalizeAndValidateHubUrl(hubUrl);
   const body: Record<string, unknown> = { install_token: installToken };
   if (opts?.label) body.label = opts.label;
+  if (opts?.daemonInstanceId) body.daemon_instance_id = opts.daemonInstanceId;
   const resp = await fetch(`${base}/daemon/auth/install-token`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- allow install-token redemption to reauthorize an existing daemon instance when the local daemonInstanceId is present
- make daemon start restart an already-running daemon after auth is refreshed
- update tests and install-token design notes for the reauth flow

## Tests
- cd backend && uv run pytest tests/test_app/test_daemon_control.py -q
- cd packages/daemon && npm test -- --run src/__tests__/start-auth.test.ts
- cd packages/daemon && npm run build
- cd packages/protocol-core && npm run build
- cd packages/protocol-core && npm test -- --run src/__tests__/should-wake.test.ts