### PR TITLE
fix: expose daemon conversation id in turns

### DIFF
--- a/packages/daemon/src/__tests__/turn-text.test.ts
+++ b/packages/daemon/src/__tests__/turn-text.test.ts
@@ -116,6 +116,8 @@ describe("composeBotCordUserTurn", () => {
     );
     expect(out).toContain("third-party gateway chat");
     expect(out).toContain("Reply normally in your final assistant message");
+    expect(out).toContain("conversation_id: telegram:user:7904063707");
+    expect(out).toContain("channel: gw_telegram_123");
     expect(out).not.toContain("Plain text output WILL NOT be sent");
     expect(out).not.toContain("botcord_send");
   });
@@ -219,6 +221,7 @@ describe("composeBotCordUserTurn", () => {
       }),
     );
     expect(out).toContain("[BotCord Messages (2 new)]");
+    expect(out).toContain("conversation_id: rm_team");
     expect(out).toContain("room: Ouraca");
     expect(out).toContain("mentioned: true");
     expect(out).toContain('<agent-message sender="ag_alice" sender_kind="agent">');

--- a/packages/daemon/src/turn-text.ts
+++ b/packages/daemon/src/turn-text.ts
@@ -76,6 +76,17 @@ function replyDeliveryHint(msg: GatewayInboundMessage): string {
     : NON_OWNER_REPLY_HINT;
 }
 
+function appendConversationFields(
+  fields: string[],
+  msg: GatewayInboundMessage,
+): void {
+  const conversationId = sanitizeSenderName(msg.conversation.id);
+  fields.push(`conversation_id: ${conversationId}`);
+  if (isThirdPartyConversation(msg.conversation.id)) {
+    fields.push(`channel: ${sanitizeSenderName(msg.channel)}`);
+  }
+}
+
 /** Minimal shape of one batched inbound entry. Matches the BotCord channel
  * `BatchedInboxRaw.batch[]` elements but expressed structurally so the
  * composer doesn't import channel internals. */
@@ -205,6 +216,7 @@ export function composeBotCordUserTurn(msg: GatewayInboundMessage): string {
     `from: ${sanitizedSenderLabel}`,
     `to: ${msg.accountId}`,
   ];
+  appendConversationFields(headerFields, msg);
   if (isGroup && roomTitle) {
     const safeRoom = sanitizeSenderName(roomTitle.replace(/[\r\n]+/g, " "));
     headerFields.push(`room: ${safeRoom}`);
@@ -267,6 +279,7 @@ function composeBatchedTurn(
     `[BotCord Messages (${batch.length} new)]`,
     `to: ${msg.accountId}`,
   ];
+  appendConversationFields(header, msg);
   if (isGroup && roomTitle) {
     const safeRoom = sanitizeSenderName(roomTitle.replace(/[\r\n]+/g, " "));
     header.push(`room: ${safeRoom}`);


### PR DESCRIPTION
## Summary
- include the current conversation_id in daemon-composed turn headers
- include the gateway channel for third-party conversations so Telegram/WeChat chats can identify their active session
- add coverage for Telegram direct chats and batched turns

## Tests
- cd packages/daemon && npm test -- --run src/__tests__/turn-text.test.ts
- cd packages/daemon && npx tsc -p tsconfig.build.json --noEmit