### PR TITLE
feat: adapt dashboard for mobile

### DIFF
--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -940,86 +940,102 @@ export default function DashboardApp() {
     }
   };
 
+  const mobileShowsMain =
+    uiStore.sidebarTab === "contacts"
+    || uiStore.sidebarTab === "explore"
+    || uiStore.sidebarTab === "wallet"
+    || uiStore.sidebarTab === "activity"
+    || (uiStore.sidebarTab === "messages" && (uiStore.messagesPane === "user-chat" || Boolean(uiStore.openedRoomId)))
+    || (uiStore.sidebarTab === "bots" && Boolean(uiStore.selectedBotAgentId));
+  const mobileHideSecondary =
+    uiStore.sidebarTab === "wallet"
+    || uiStore.sidebarTab === "activity"
+    || (uiStore.sidebarTab === "messages" && (uiStore.messagesPane === "user-chat" || Boolean(uiStore.openedRoomId)))
+    || (uiStore.sidebarTab === "bots" && Boolean(uiStore.selectedBotAgentId));
+  const mainPaneClass = `min-h-0 min-w-0 flex-1 ${mobileShowsMain ? "" : "max-md:hidden"}`;
+
   return (
-    <div className="relative flex h-screen overflow-hidden">
-      <Sidebar />
-      {uiStore.sidebarTab === "activity" ? (
-        <ActivityPanel />
-      ) : uiStore.sidebarTab === "wallet" ? (
-        <WalletPanel />
-      ) : uiStore.sidebarTab === "bots" ? (
-        <div className="flex-1 min-w-0">
-          {uiStore.selectedBotAgentId ? (
-            <UserChatPane agentId={uiStore.selectedBotAgentId} />
-          ) : sessionStore.ownedAgents.length === 0 ? (
-            <div className="flex h-full items-center justify-center px-8">
-              <div className="w-full max-w-md">
-                <div className="mb-8 text-center">
-                  <div className="mb-3 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-neon-cyan/10 text-neon-cyan">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-                      <rect x="3" y="11" width="18" height="10" rx="2" />
-                      <circle cx="12" cy="5" r="2" />
-                      <path d="M12 7v4" />
-                      <path d="M8 15h.01M12 15h.01M16 15h.01" />
-                    </svg>
+    <div className="relative flex h-[100dvh] overflow-hidden bg-deep-black max-md:flex-col-reverse md:h-screen">
+      <Sidebar mobileHideSecondary={mobileHideSecondary} />
+      <div className={mainPaneClass}>
+        {uiStore.sidebarTab === "activity" ? (
+          <ActivityPanel />
+        ) : uiStore.sidebarTab === "wallet" ? (
+          <WalletPanel />
+        ) : uiStore.sidebarTab === "bots" ? (
+          <div className="h-full min-w-0">
+            {uiStore.selectedBotAgentId ? (
+              <UserChatPane agentId={uiStore.selectedBotAgentId} />
+            ) : sessionStore.ownedAgents.length === 0 ? (
+              <div className="flex h-full items-center justify-center px-8">
+                <div className="w-full max-w-md">
+                  <div className="mb-8 text-center">
+                    <div className="mb-3 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-neon-cyan/10 text-neon-cyan">
+                      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                        <rect x="3" y="11" width="18" height="10" rx="2" />
+                        <circle cx="12" cy="5" r="2" />
+                        <path d="M12 7v4" />
+                        <path d="M8 15h.01M12 15h.01M16 15h.01" />
+                      </svg>
+                    </div>
+                    <h2 className="text-base font-semibold text-text-primary">{tSidebar.onboardingTitle}</h2>
+                    <p className="mt-1 text-sm text-text-secondary/70">{tSidebar.onboardingSubtitle}</p>
                   </div>
-                  <h2 className="text-base font-semibold text-text-primary">{tSidebar.onboardingTitle}</h2>
-                  <p className="mt-1 text-sm text-text-secondary/70">{tSidebar.onboardingSubtitle}</p>
-                </div>
-                <ol className="space-y-4">
-                  {[
-                    { title: tSidebar.onboardingStep1Title, desc: tSidebar.onboardingStep1Desc },
-                    { title: tSidebar.onboardingStep2Title, desc: tSidebar.onboardingStep2Desc },
-                    { title: tSidebar.onboardingStep3Title, desc: tSidebar.onboardingStep3Desc },
-                  ].map((step, i) => (
-                    <li key={i} className="flex gap-4">
-                      <span className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-glass-bg border border-glass-border text-[11px] font-semibold text-neon-cyan">
-                        {i + 1}
-                      </span>
-                      <div className="min-w-0 pt-0.5">
-                        <p className="text-sm font-medium text-text-primary">{step.title}</p>
-                        <p className="mt-0.5 text-xs text-text-secondary/70">{step.desc}</p>
-                      </div>
-                    </li>
-                  ))}
-                </ol>
-                <div className="mt-8 text-center">
-                  <button
-                    type="button"
-                    onClick={() => uiStore.openCreateBotModal()}
-                    className="inline-flex items-center gap-2 rounded-lg bg-neon-cyan/10 border border-neon-cyan/40 px-4 py-2 text-sm font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20"
-                  >
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                      <path d="M12 5v14M5 12h14" />
-                    </svg>
-                    {tSidebar.onboardingCta}
-                  </button>
+                  <ol className="space-y-4">
+                    {[
+                      { title: tSidebar.onboardingStep1Title, desc: tSidebar.onboardingStep1Desc },
+                      { title: tSidebar.onboardingStep2Title, desc: tSidebar.onboardingStep2Desc },
+                      { title: tSidebar.onboardingStep3Title, desc: tSidebar.onboardingStep3Desc },
+                    ].map((step, i) => (
+                      <li key={i} className="flex gap-4">
+                        <span className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-glass-bg border border-glass-border text-[11px] font-semibold text-neon-cyan">
+                          {i + 1}
+                        </span>
+                        <div className="min-w-0 pt-0.5">
+                          <p className="text-sm font-medium text-text-primary">{step.title}</p>
+                          <p className="mt-0.5 text-xs text-text-secondary/70">{step.desc}</p>
+                        </div>
+                      </li>
+                    ))}
+                  </ol>
+                  <div className="mt-8 text-center">
+                    <button
+                      type="button"
+                      onClick={() => uiStore.openCreateBotModal()}
+                      className="inline-flex items-center gap-2 rounded-lg bg-neon-cyan/10 border border-neon-cyan/40 px-4 py-2 text-sm font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20"
+                    >
+                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M12 5v14M5 12h14" />
+                      </svg>
+                      {tSidebar.onboardingCta}
+                    </button>
+                  </div>
                 </div>
               </div>
-            </div>
-          ) : (
-            <div className="flex h-full items-center justify-center px-6 text-center text-sm text-text-secondary/70">
-              <span>{tSidebar.selectBotPrompt}</span>
-            </div>
-          )}
-        </div>
-      ) : uiStore.sidebarTab === "messages" && uiStore.messagesPane === "user-chat" ? (
-        <div className="flex-1 min-w-0">
-          <UserChatPane />
-        </div>
-      ) : (
-        <>
-          <ChatPane
-            onHumanOpen={(human) => {
-              void handleOpenHumanCard({
-                humanId: human.human_id,
-                displayName: human.display_name,
-              });
-            }}
-          />
-          {uiStore.sidebarTab !== "explore" && uiStore.rightPanelOpen && <AgentBrowser />}
-        </>
-      )}
+            ) : (
+              <div className="flex h-full items-center justify-center px-6 text-center text-sm text-text-secondary/70">
+                <span>{tSidebar.selectBotPrompt}</span>
+              </div>
+            )}
+          </div>
+        ) : uiStore.sidebarTab === "messages" && uiStore.messagesPane === "user-chat" ? (
+          <div className="h-full min-w-0">
+            <UserChatPane />
+          </div>
+        ) : (
+          <div className="flex h-full min-w-0">
+            <ChatPane
+              onHumanOpen={(human) => {
+                void handleOpenHumanCard({
+                  humanId: human.human_id,
+                  displayName: human.display_name,
+                });
+              }}
+            />
+            {uiStore.sidebarTab !== "explore" && uiStore.rightPanelOpen && <AgentBrowser />}
+          </div>
+        )}
+      </div>
       <StripeReturnBanner />
       {shouldShowAgentGate ? (
         <AgentGateModal

--- a/frontend/src/components/dashboard/RoomHeader.tsx
+++ b/frontend/src/components/dashboard/RoomHeader.tsx
@@ -10,8 +10,9 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react
 import { useLanguage } from "@/lib/i18n";
 import { common } from "@/lib/i18n/translations/common";
 import { roomList } from "@/lib/i18n/translations/dashboard";
+import { useRouter } from "nextjs-toploader/app";
 import { useShallow } from "zustand/react/shallow";
-import { Bell, Info, Loader2, Plus, Settings, Share2 } from "lucide-react";
+import { ArrowLeft, Bell, Info, Loader2, Plus, Settings, Share2 } from "lucide-react";
 import CopyableId from "@/components/ui/CopyableId";
 import { api, humansApi } from "@/lib/api";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
@@ -37,6 +38,7 @@ export default function RoomHeader() {
   const [humanJoining, setHumanJoining] = useState(false);
   const rulePopoverRef = useRef<HTMLDivElement>(null);
   const locale = useLanguage();
+  const router = useRouter();
   const t = roomList[locale];
   const tc = common[locale];
   const [ruleExpanded, setRuleExpanded] = useState(false);
@@ -51,6 +53,11 @@ export default function RoomHeader() {
   const refreshHumanRooms = useDashboardSessionStore((state) => state.refreshHumanRooms);
   const { openedRoomId } = useDashboardUIStore(useShallow((state) => ({
     openedRoomId: state.openedRoomId,
+  })));
+  const { setFocusedRoomId, setOpenedRoomId, setMessagesPane } = useDashboardUIStore(useShallow((state) => ({
+    setFocusedRoomId: state.setFocusedRoomId,
+    setOpenedRoomId: state.setOpenedRoomId,
+    setMessagesPane: state.setMessagesPane,
   })));
   const { overview, getRoomSummary, refreshOverview } = useDashboardChatStore(useShallow((state) => ({
     overview: state.overview,
@@ -195,6 +202,13 @@ export default function RoomHeader() {
 
   if (!room) return null;
 
+  const handleMobileBack = () => {
+    setMessagesPane("room");
+    setFocusedRoomId(null);
+    setOpenedRoomId(null);
+    router.push("/chats/messages");
+  };
+
   const renderJoinButton = () => {
     if (isJoined || isOwnerChatRoom) return null;
 
@@ -257,7 +271,16 @@ export default function RoomHeader() {
 
   return (
     <>
-      <div className="flex min-h-16 items-center justify-between border-b border-glass-border px-4 py-3">
+      <div className="flex min-h-16 items-center justify-between border-b border-glass-border px-4 py-3 max-md:gap-2 max-md:px-3">
+        <button
+          type="button"
+          onClick={handleMobileBack}
+          className="hidden h-9 w-9 shrink-0 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary max-md:inline-flex"
+          aria-label="Back to messages"
+          title="Back to messages"
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </button>
         <div className="min-w-0 py-0.5">
           <div className="flex items-center gap-2">
             <h3 className="truncate text-sm font-semibold text-text-primary">{titleText}</h3>
@@ -301,7 +324,7 @@ export default function RoomHeader() {
               </div>
             )}
           </div>
-          <div className="flex items-center gap-1.5 text-xs text-text-secondary">
+          <div className="flex min-w-0 items-center gap-1.5 overflow-hidden text-xs text-text-secondary">
             <button
               onClick={() => setShowSettingsModal(true)}
               className="shrink-0 whitespace-nowrap hover:text-neon-cyan hover:underline transition-colors"
@@ -337,7 +360,7 @@ export default function RoomHeader() {
             </div>
           )}
         </div>
-        <div className="flex shrink-0 flex-nowrap items-center gap-1.5 self-start py-0.5">
+        <div className="flex shrink-0 flex-nowrap items-center gap-1.5 self-start py-0.5 max-md:gap-1">
 
           {renderJoinButton()}
           {isGuest && (

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -10,7 +10,8 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import { Bot, Loader2, MessageSquare, AlertCircle, RotateCcw, Bell, FileText, Settings2, User } from "lucide-react";
+import { ArrowLeft, Bot, Loader2, MessageSquare, AlertCircle, RotateCcw, Bell, FileText, Settings2, User } from "lucide-react";
+import { useRouter } from "nextjs-toploader/app";
 import AgentSettingsDrawer from "./AgentSettingsDrawer";
 import { api } from "@/lib/api";
 import { useLanguage } from "@/lib/i18n";
@@ -68,11 +69,12 @@ function TypewriterText({
 
 export default function UserChatPane({ agentId }: { agentId?: string | null }) {
   const locale = useLanguage();
+  const router = useRouter();
   const { activeAgentId, activeIdentity } = useDashboardSessionStore();
   const ownedAgents = useDashboardSessionStore((s) => s.ownedAgents);
   const isAgentMode = activeIdentity?.type === "agent" && !!activeAgentId;
   const chatAgentId = agentId || (isAgentMode ? activeAgentId : null);
-  const { setUserChatRoomId } = useDashboardUIStore();
+  const { setMessagesPane, setSelectedBotAgentId, setUserChatRoomId } = useDashboardUIStore();
   const ownedAgent = chatAgentId
     ? ownedAgents.find((a) => a.agent_id === chatAgentId) ?? null
     : null;
@@ -304,13 +306,31 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
   }
 
   const hasStreamingMsg = messages.some((m) => m.status === "streaming");
+  const handleMobileBack = () => {
+    if (agentId) {
+      setSelectedBotAgentId(null);
+      router.push("/chats/bots");
+      return;
+    }
+    setMessagesPane("room");
+    router.push("/chats/messages");
+  };
 
   return (
     <div className="relative flex flex-col h-full">
       {/* Header */}
-      <div className="flex items-center gap-2 px-4 py-3 border-b border-zinc-800">
+      <div className="flex items-center gap-2 px-4 py-3 border-b border-zinc-800 max-md:px-3">
+        <button
+          type="button"
+          onClick={handleMobileBack}
+          className="hidden h-9 w-9 shrink-0 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary max-md:inline-flex"
+          aria-label="Back"
+          title="Back"
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </button>
         <MessageSquare className="w-4 h-4 text-cyan-400" />
-        <h2 className="text-sm font-medium text-zinc-200">
+        <h2 className="min-w-0 truncate text-sm font-medium text-zinc-200">
           {chatRoomName || "Chat with Agent"}
         </h2>
         <div className="ml-auto flex items-center gap-2">

--- a/frontend/src/components/dashboard/sidebar/NavButtons.tsx
+++ b/frontend/src/components/dashboard/sidebar/NavButtons.tsx
@@ -31,7 +31,7 @@ export function PrimaryNavButton({
   return (
     <button
       onClick={onClick}
-      className={`group relative flex h-12 w-12 flex-col items-center justify-center rounded-xl transition-all duration-200 ${
+      className={`group relative flex h-12 w-12 flex-col items-center justify-center rounded-xl transition-all duration-200 max-md:h-12 max-md:min-w-0 max-md:flex-1 max-md:px-1 ${
         disabled
           ? "text-text-secondary/45 hover:bg-neon-cyan/10 hover:text-neon-cyan"
           : active
@@ -41,11 +41,11 @@ export function PrimaryNavButton({
       title={title}
     >
       {active && !disabled && (
-        <div className={`absolute left-0 top-1/2 h-5 w-[3px] -translate-y-1/2 rounded-r-full ${indicatorClass}`} />
+        <div className={`absolute left-0 top-1/2 h-5 w-[3px] -translate-y-1/2 rounded-r-full max-md:left-1/2 max-md:top-0 max-md:h-[3px] max-md:w-5 max-md:-translate-x-1/2 max-md:translate-y-0 max-md:rounded-b-full max-md:rounded-r-none ${indicatorClass}`} />
       )}
       {badge}
       {icon}
-      <span className="mt-0.5 text-[9px] font-medium leading-none">{label}</span>
+      <span className="mt-0.5 max-w-full truncate text-[9px] font-medium leading-none">{label}</span>
     </button>
   );
 }

--- a/frontend/src/components/dashboard/sidebar/index.tsx
+++ b/frontend/src/components/dashboard/sidebar/index.tsx
@@ -97,7 +97,11 @@ const authNavItems = [
   },
 ] as const;
 
-export default function Sidebar() {
+interface SidebarProps {
+  mobileHideSecondary?: boolean;
+}
+
+export default function Sidebar({ mobileHideSecondary = false }: SidebarProps) {
   const router = useRouter();
   const supabase = useMemo(() => createClient(), []);
   const locale = useLanguage();
@@ -308,17 +312,17 @@ export default function Sidebar() {
   };
 
   return (
-    <div className="flex h-full">
+    <div className={`flex h-full max-md:w-full max-md:flex-col-reverse ${mobileHideSecondary ? "max-md:h-16" : "max-md:h-full"}`}>
       {/* Primary rail */}
-      <div className="flex h-full w-16 min-w-[64px] flex-col items-center border-r border-glass-border bg-deep-black py-3">
+      <div className="flex h-full w-16 min-w-[64px] flex-col items-center border-r border-glass-border bg-deep-black py-3 max-md:h-16 max-md:w-full max-md:min-w-0 max-md:shrink-0 max-md:flex-row max-md:border-r-0 max-md:border-t max-md:px-2 max-md:py-2">
         <Link
           href="/"
-          className="mb-3 flex h-11 w-11 items-center justify-center rounded-xl border border-glass-border bg-deep-black-light transition-colors hover:border-neon-cyan/50 hover:bg-glass-bg"
+          className="mb-3 flex h-11 w-11 items-center justify-center rounded-xl border border-glass-border bg-deep-black-light transition-colors hover:border-neon-cyan/50 hover:bg-glass-bg max-md:mb-0 max-md:mr-2 max-md:hidden"
           title={tNav.home}
         >
           <img src="/logo.svg" alt="BotCord" className="h-6 w-6" />
         </Link>
-        <div className="flex flex-1 flex-col items-center gap-1 pt-1">
+        <div className="flex flex-1 flex-col items-center gap-1 pt-1 max-md:min-w-0 max-md:flex-row max-md:justify-around max-md:pt-0">
           {navItems.map((item) => {
             const isActive = uiStore.sidebarTab === item.key;
             const isExplore = item.key === "explore";
@@ -354,11 +358,11 @@ export default function Sidebar() {
           })}
         </div>
 
-        <div className="flex flex-col items-center gap-2 border-t border-glass-border pt-3">
+        <div className="flex flex-col items-center gap-2 border-t border-glass-border pt-3 max-md:ml-2 max-md:border-l max-md:border-t-0 max-md:pl-2 max-md:pt-0">
           {isGuest ? (
             <button
               onClick={showLoginModal}
-              className="flex h-10 w-12 flex-col items-center justify-center rounded-xl text-neon-cyan transition-all duration-200 hover:bg-neon-cyan/10"
+              className="flex h-10 w-12 flex-col items-center justify-center rounded-xl text-neon-cyan transition-all duration-200 hover:bg-neon-cyan/10 max-md:w-10"
               title={tc.login}
             >
               <LogIn className="h-5 w-5" strokeWidth={1.75} />
@@ -415,11 +419,14 @@ export default function Sidebar() {
       )}
 
       {/* Secondary panel */}
-      <div className="relative flex h-full flex-col border-r border-glass-border bg-deep-black-light" style={{ width: uiStore.sidebarWidth, minWidth: SIDEBAR_MIN }}>
+      <div
+        className={`relative flex h-full flex-col border-r border-glass-border bg-deep-black-light max-md:min-h-0 max-md:flex-1 max-md:!w-full max-md:!min-w-0 max-md:border-r-0 ${mobileHideSecondary ? "max-md:hidden" : ""}`}
+        style={{ width: uiStore.sidebarWidth, minWidth: SIDEBAR_MIN }}
+      >
         {/* Resize handle */}
         <div
           onMouseDown={handleResizeStart}
-          className="absolute right-0 top-0 z-10 h-full w-1 cursor-col-resize transition-colors hover:bg-neon-cyan/30 active:bg-neon-cyan/50"
+          className="absolute right-0 top-0 z-10 h-full w-1 cursor-col-resize transition-colors hover:bg-neon-cyan/30 active:bg-neon-cyan/50 max-md:hidden"
         />
         {/* Panel header */}
         <div className="flex min-h-14 items-center justify-between border-b border-glass-border px-4 py-3">


### PR DESCRIPTION
## Summary
- switch the dashboard to a mobile master/detail layout with a bottom nav
- hide the secondary list panel while viewing mobile chat or bot detail screens
- add mobile back controls for room and owner-chat detail headers

## Tests
- NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy-anon-key npm run build