### PR TITLE
fix: preserve OpenClaw ACP final text

### DIFF
--- a/packages/daemon/src/__tests__/openclaw-acp.test.ts
+++ b/packages/daemon/src/__tests__/openclaw-acp.test.ts
@@ -353,6 +353,62 @@ describe("OpenclawAcpAdapter.run", () => {
     expect(assistantChunks).toEqual(["好！终于可以正常交流了。"]);
   });
 
+  it("keeps final streamed text after an untagged reasoning preamble", async () => {
+    const child = new FakeChild();
+    const adapter = new OpenclawAcpAdapter({ spawnFn: makeSpawn(child) });
+    const gateway: ResolvedOpenclawGateway = {
+      name: "local",
+      url: "ws://127.0.0.1:1",
+      openclawAgent: "main",
+    };
+
+    child.stdin.on("data", (chunk: Buffer) => {
+      for (const line of chunk.toString("utf8").split("\n").filter(Boolean)) {
+        const frame = JSON.parse(line);
+        if (frame.method === "initialize") {
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { protocolVersion: 1 } }) + "\n");
+        } else if (frame.method === "session/new") {
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { sessionId: "sid-reasoning-preamble" } }) + "\n");
+        } else if (frame.method === "session/prompt") {
+          child.stdout.write(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              method: "session/update",
+              params: {
+                sessionId: "sid-reasoning-preamble",
+                update: {
+                  sessionUpdate: "agent_message_chunk",
+                  content: {
+                    type: "text",
+                    text: "The user is asking about today's weather in Chinese. Let me check the weather skill to see how to get this info.\n\n今天上海天气不错！\n\n- 气温：29°C\n- 湿度：52%",
+                  },
+                },
+              },
+            }) + "\n",
+          );
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { stopReason: "end_turn" } }) + "\n");
+        }
+      }
+    });
+
+    const blocks: any[] = [];
+    const res = await adapter.run({
+      text: "今天天气咋样",
+      sessionId: null,
+      cwd: "/tmp",
+      accountId: "ag_alice",
+      signal: new AbortController().signal,
+      trustLevel: "owner",
+      gateway,
+      onBlock: (b) => blocks.push(b),
+    });
+
+    expect(res.error).toBeUndefined();
+    expect(res.text).toBe("今天上海天气不错！\n\n- 气温：29°C\n- 湿度：52%");
+    expect(blocks.filter((b) => b.kind === "assistant_text")).toHaveLength(1);
+    expect(JSON.stringify(blocks)).not.toContain("The user is asking");
+  });
+
   it("preserves real leading angle syntax in streamed fallback text", async () => {
     const child = new FakeChild();
     const adapter = new OpenclawAcpAdapter({ spawnFn: makeSpawn(child) });

--- a/packages/daemon/src/gateway/runtimes/openclaw-acp.ts
+++ b/packages/daemon/src/gateway/runtimes/openclaw-acp.ts
@@ -350,7 +350,7 @@ export class OpenclawAcpAdapter implements RuntimeAdapter {
       }
       const pickedText = normalizeAssistantText(pickFinalText(promptResult));
       const streamedText = normalizeAssistantText(assistantText);
-      finalText = pickedText && !looksLikeReasoningLeak(pickedText) ? pickedText : streamedText;
+      finalText = pickSafeAssistantText(pickedText) || pickSafeAssistantText(streamedText);
 
       if (capped) {
         log.warn("openclaw-acp.assistant-text-capped", { sessionId: acpSessionId });
@@ -853,7 +853,7 @@ function createAssistantTextFilter(): {
     if (flush && !seenFinal && fallback) {
       const text = normalizeAssistantText(fallback);
       fallback = "";
-      if (!looksLikeReasoningLeak(text)) return text;
+      return pickSafeAssistantText(text);
     }
     return out;
   };
@@ -906,6 +906,41 @@ function looksLikeReasoningLeak(text: string): boolean {
     /^i('|’)m .*\b(i('|’)ll|i will|need to|should|going to)\b/i.test(t) ||
     /\bi('|’)ll respond\b/i.test(t) ||
     /\bi need to\b/i.test(t)
+  );
+}
+
+function pickSafeAssistantText(text: string | undefined): string {
+  if (!text) return "";
+  const trimmed = text.trim();
+  if (!looksLikeReasoningLeak(trimmed)) return trimmed;
+  return stripLeadingReasoningLeak(trimmed);
+}
+
+function stripLeadingReasoningLeak(text: string): string {
+  const paragraphs = text
+    .replace(/\r\n/g, "\n")
+    .split(/\n{2,}/)
+    .map((p) => p.trim())
+    .filter(Boolean);
+
+  while (paragraphs.length > 0 && isReasoningNarration(paragraphs[0])) {
+    paragraphs.shift();
+  }
+
+  const candidate = paragraphs.join("\n\n").trim();
+  return candidate && !looksLikeReasoningLeak(candidate) ? candidate : "";
+}
+
+function isReasoningNarration(text: string): boolean {
+  const t = text.trim();
+  if (!t) return false;
+  return (
+    looksLikeReasoningLeak(t) ||
+    /^let me\b/i.test(t) ||
+    /^i('|’)ll\b/i.test(t) ||
+    /^i will\b/i.test(t) ||
+    /^i should\b/i.test(t) ||
+    /^i need to\b/i.test(t)
   );
 }
 


### PR DESCRIPTION
## Summary
- preserve final assistant text when OpenClaw ACP streams an untagged reasoning preamble before the answer
- keep the reasoning preamble out of streamed BotCord blocks
- add regression coverage for the QClaw weather-style response shape

## Tests
- cd packages/daemon && npm test -- src/__tests__/openclaw-acp.test.ts
- cd packages/daemon && npx tsc -p tsconfig.build.json --noEmit
- git diff --check