### PR TITLE
fix: inject BotCord group runtime environment

### DIFF
--- a/packages/daemon/src/__tests__/system-context.test.ts
+++ b/packages/daemon/src/__tests__/system-context.test.ts
@@ -57,12 +57,22 @@ afterEach(() => {
 });
 
 describe("createDaemonSystemContextBuilder", () => {
-  it("returns undefined when working memory is empty and no activity tracker is wired", () => {
+  it("injects group-room runtime environment even when memory is empty", () => {
     const builder = createDaemonSystemContextBuilder({ agentId: "ag_me" });
-    expect(builder(makeMessage())).toBeUndefined();
+    const out = builder(makeMessage()) as string;
+    expect(out).toContain("[BotCord Runtime Environment]");
+    expect(out).toContain("local agent process");
+    expect(out).toContain("cannot access this machine's local filesystem");
   });
 
-  it("returns undefined when working memory is empty and the activity digest is empty", () => {
+  it("returns undefined for direct rooms when working memory is empty and no activity tracker is wired", () => {
+    const builder = createDaemonSystemContextBuilder({ agentId: "ag_me" });
+    expect(
+      builder(makeMessage({ conversation: { id: "rm_dm_peer", kind: "direct" } })),
+    ).toBeUndefined();
+  });
+
+  it("still injects group-room runtime environment when the activity digest is empty", () => {
     const tracker = new ActivityTracker({
       filePath: path.join(tmpDir, "activity.json"),
     });
@@ -70,7 +80,9 @@ describe("createDaemonSystemContextBuilder", () => {
       agentId: "ag_me",
       activityTracker: tracker,
     });
-    expect(builder(makeMessage({ conversation: { id: "rm_x", kind: "group" } }))).toBeUndefined();
+    const out = builder(makeMessage({ conversation: { id: "rm_x", kind: "group" } })) as string;
+    expect(out).toContain("[BotCord Runtime Environment]");
+    expect(out).not.toContain("[BotCord Cross-Room Awareness]");
   });
 
   it("injects the working-memory block when goal / sections are set", () => {
@@ -124,7 +136,8 @@ describe("createDaemonSystemContextBuilder", () => {
   it("skips the identity block cleanly when identity.md is missing", () => {
     // No ensureAgentWorkspace — workspace never provisioned.
     const builder = createDaemonSystemContextBuilder({ agentId: "ag_me" });
-    expect(builder(makeMessage())).toBeUndefined();
+    const out = builder(makeMessage({ conversation: { id: "rm_dm_peer", kind: "direct" } }));
+    expect(out).toBeUndefined();
   });
 
   it("skips the identity block when identity.md is blank", () => {
@@ -138,7 +151,9 @@ describe("createDaemonSystemContextBuilder", () => {
 
   it("detects a newly added global Claude skill on the next turn", () => {
     const builder = createDaemonSystemContextBuilder({ agentId: "ag_me" });
-    expect(builder(makeMessage())).toBeUndefined();
+    expect(
+      builder(makeMessage({ conversation: { id: "rm_dm_peer", kind: "direct" } })),
+    ).toBeUndefined();
 
     const skillDir = path.join(tmpDir, ".claude", "skills", "digest-query");
     mkdirSync(skillDir, { recursive: true });
@@ -310,7 +325,8 @@ describe("createDaemonSystemContextBuilder", () => {
         sender: { id: "ag_peer", kind: "agent" },
       }),
     );
-    expect(out).toBeUndefined();
+    expect(out).not.toContain("[BotCord Scene: Owner Chat]");
+    expect(out).toContain("[BotCord Runtime Environment]");
   });
 
   it("awaits roomContextBuilder and slots the [BotCord Room Context] block between memory and digest", async () => {
@@ -360,11 +376,12 @@ describe("createDaemonSystemContextBuilder", () => {
         throw new Error("hub 500");
       },
     });
-    // Empty working memory + no tracker + thrown room fetch ⇒ no blocks ⇒ undefined.
+    // The room metadata block is skipped, but group-room environment remains.
     const out = await builder(
       makeMessage({ conversation: { id: "rm_team", kind: "group" } }),
     );
-    expect(out).toBeUndefined();
+    expect(out).toContain("[BotCord Runtime Environment]");
+    expect(out).not.toContain("[BotCord Room Context]");
   });
 
   it("appends loopRiskBuilder output at the end of the system context", async () => {
@@ -399,7 +416,8 @@ describe("createDaemonSystemContextBuilder", () => {
       },
     });
     const out = await builder(makeMessage());
-    expect(out).toBeUndefined();
+    expect(out).toContain("[BotCord Runtime Environment]");
+    expect(out).not.toContain("[BotCord loop-risk check]");
   });
 
   it("translates GatewayInboundMessage.conversation.id → old `room_id` for the digest exclude key", () => {
@@ -423,7 +441,9 @@ describe("createDaemonSystemContextBuilder", () => {
     const out = builder(
       makeMessage({ conversation: { id: "rm_conv_id_123", kind: "group" } }),
     );
-    // Empty working memory + digest excluding the only entry → undefined.
-    expect(out).toBeUndefined();
+    // Empty working memory + digest excluding the only entry leaves only the
+    // always-on group-room runtime environment block.
+    expect(out).toContain("[BotCord Runtime Environment]");
+    expect(out).not.toContain("[BotCord Cross-Room Awareness]");
   });
 });

--- a/packages/daemon/src/system-context.ts
+++ b/packages/daemon/src/system-context.ts
@@ -57,6 +57,16 @@ function buildOwnerChatSceneContext(): string {
   ].join("\n");
 }
 
+function buildGroupRoomEnvironmentContext(message: GatewayInboundMessage): string | null {
+  if (message.conversation.kind !== "group") return null;
+  return [
+    "[BotCord Runtime Environment]",
+    "You are running as a local agent process connected to a remote BotCord group room.",
+    "Other room members can read your messages and any uploaded/attached files, but they cannot access this machine's local filesystem, container paths, or absolute paths such as /var/..., /tmp/..., or /Users/....",
+    "Do not present a local file path as a useful report link or deliverable in group chat. If an artifact needs to be shared, upload or attach it through the available BotCord file/attachment mechanism, then refer to the uploaded attachment or summarize the content in the message.",
+  ].join("\n");
+}
+
 /** Dependencies injected by the daemon bootstrap. */
 export interface SystemContextDeps {
   /** The owning daemon's agent id. Used to scope working-memory + activity lookups. */
@@ -133,6 +143,7 @@ export function createDaemonSystemContextBuilder(
   const gatherSyncBlocks = (message: GatewayInboundMessage): {
     identity: string | null;
     ownerScene: string | null;
+    environment: string | null;
     memory: string | null;
     digest: string | null;
   } => {
@@ -142,6 +153,7 @@ export function createDaemonSystemContextBuilder(
       classifyActivitySender(message).kind === "owner"
         ? buildOwnerChatSceneContext()
         : null;
+    const environment = ownerScene ? null : buildGroupRoomEnvironmentContext(message);
 
     const wm = safeReadWorkingMemory(deps.agentId);
     const memory = wm ? buildWorkingMemoryPrompt({ workingMemory: wm }) : null;
@@ -155,7 +167,7 @@ export function createDaemonSystemContextBuilder(
         }) || null
       : null;
 
-    return { identity, ownerScene, memory, digest };
+    return { identity, ownerScene, environment, memory, digest };
   };
 
   const assemble = (parts: Array<string | null | undefined>): string | undefined => {
@@ -195,13 +207,13 @@ export function createDaemonSystemContextBuilder(
 
   if (!deps.roomContextBuilder) {
     const syncBuilder = (message: GatewayInboundMessage): string | undefined => {
-      const { identity, ownerScene, memory, digest } = gatherSyncBlocks(message);
+      const { identity, ownerScene, environment, memory, digest } = gatherSyncBlocks(message);
       // Loop-risk sits at the end so its "reply NO_REPLY unless…" guidance
       // is the last thing the model sees before the user turn body.
       // Identity sits at the very front so it frames every other block.
       const skillIndex = buildSkillIndex(message);
       const loopRisk = runLoopRisk(message);
-      return assemble([identity, ownerScene, memory, digest, skillIndex, loopRisk]);
+      return assemble([identity, ownerScene, environment, memory, digest, skillIndex, loopRisk]);
     };
     // Compile-time witness that the narrower sync signature still satisfies
     // `SystemContextBuilder` (which allows async). Prevents the two contracts
@@ -215,7 +227,7 @@ export function createDaemonSystemContextBuilder(
   const asyncBuilder = async (
     message: GatewayInboundMessage,
   ): Promise<string | undefined> => {
-    const { identity, ownerScene, memory, digest } = gatherSyncBlocks(message);
+    const { identity, ownerScene, environment, memory, digest } = gatherSyncBlocks(message);
     // Room context landing order: after owner-scene / memory, before digest —
     // "what room am I in" belongs with the session's own identity, while the
     // cross-room digest deliberately describes OTHER rooms and should stay
@@ -233,7 +245,7 @@ export function createDaemonSystemContextBuilder(
     }
     const skillIndex = buildSkillIndex(message);
     const loopRisk = runLoopRisk(message);
-    return assemble([identity, ownerScene, memory, roomBlock, digest, skillIndex, loopRisk]);
+    return assemble([identity, ownerScene, environment, memory, roomBlock, digest, skillIndex, loopRisk]);
   };
   const _typecheck: SystemContextBuilder = asyncBuilder;
   void _typecheck;

--- a/plugin/src/__tests__/room-context.test.ts
+++ b/plugin/src/__tests__/room-context.test.ts
@@ -109,6 +109,19 @@ describe("room-context", () => {
       const result = await buildRoomStaticContext("botcord:dm-session");
       expect(result).toBeNull();
     });
+
+    it("returns runtime environment guidance for group sessions even when room metadata is unavailable", async () => {
+      registerSessionRoom("botcord:group-session", {
+        roomId: "rm_group_abc",
+        accountId: "default",
+        lastActivityAt: Date.now(),
+      });
+      const result = await buildRoomStaticContext("botcord:group-session");
+      expect(result).not.toBeNull();
+      expect(result).toContain("[BotCord Runtime Environment]");
+      expect(result).toContain("local agent process");
+      expect(result).toContain("cannot access this machine's local filesystem");
+    });
   });
 
   describe("buildCrossRoomDigest", () => {
@@ -328,12 +341,8 @@ describe("room-context", () => {
 
       // Should not return null — the session is registered even without prefix
       const result = await buildRoomStaticContextHookResult("agent:pm:botcord:group:rm_test");
-      // Result may be null because room info fetch fails (config not configured),
-      // but the function should not bail out at the session key check.
-      // We verify it didn't bail by checking it got past the map membership check.
-      // Since we can't fetch room info in test (mocked), it returns null, but
-      // the important thing is that it tried (didn't return early).
-      expect(result).toBeNull(); // no room info available in test
+      expect(result).not.toBeNull();
+      expect(result!.appendSystemContext).toContain("[BotCord Runtime Environment]");
     });
   });
 });

--- a/plugin/src/room-context.ts
+++ b/plugin/src/room-context.ts
@@ -54,6 +54,16 @@ type CachedRoomInfo = {
 
 const roomInfoCache = new Map<string, CachedRoomInfo>();
 const ROOM_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const GROUP_ROOM_ENVIRONMENT_LINES = [
+  `[BotCord Runtime Environment]`,
+  `You are running as a local agent process connected to a remote BotCord group room.`,
+  `Other room members can read your messages and any uploaded/attached files, but they cannot access this machine's local filesystem, container paths, or absolute paths such as /var/..., /tmp/..., or /Users/....`,
+  `Do not present a local file path as a useful report link or deliverable in group chat. If an artifact needs to be shared, upload or attach it through the available BotCord file/attachment mechanism, then refer to the uploaded attachment or summarize the content in the message.`,
+];
+
+function buildGroupRoomEnvironmentContext(): string {
+  return GROUP_ROOM_ENVIRONMENT_LINES.join("\n");
+}
 
 async function fetchRoomInfoCached(
   roomId: string,
@@ -115,7 +125,7 @@ export async function buildRoomStaticContext(
   if (entry.roomId.startsWith("rm_dm_")) return null;
 
   const cached = await fetchRoomInfoCached(entry.roomId, entry.accountId);
-  if (!cached) return null;
+  if (!cached) return buildGroupRoomEnvironmentContext();
 
   const { room, members } = cached;
   // Sanitize all tenant-controlled fields to prevent prompt injection
@@ -124,6 +134,8 @@ export async function buildRoomStaticContext(
   // prevent structural reshaping of the system prompt.
   const safeName = sanitizeUntrustedContent((room.name || "").replace(/[\r\n]+/g, " "));
   const lines: string[] = [
+    buildGroupRoomEnvironmentContext(),
+    "",
     `[BotCord Room Context]`,
     `Room: ${safeName} (${room.room_id})`,
   ];


### PR DESCRIPTION
## Summary
- inject a BotCord Runtime Environment block for daemon-managed group room turns
- add the same group-room environment guidance to the OpenClaw plugin room context, even when room metadata is unavailable
- update daemon and plugin tests for the always-on group-room guidance

## Testing
- npm test -- --run src/__tests__/system-context.test.ts src/__tests__/room-context.test.ts (packages/daemon)
- npm run build (packages/daemon)
- npm test -- --run src/__tests__/room-context.test.ts (plugin)
- npx tsc --noEmit (plugin) fails on existing src/inbound.ts SourceType comparisons at lines 344, 420, 458