### PR TITLE
fix: restore auth session on chat entry

### DIFF
--- a/frontend/src/components/auth/LoginPage.tsx
+++ b/frontend/src/components/auth/LoginPage.tsx
@@ -7,7 +7,7 @@
 
 "use client";
 
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { createClient } from "@/lib/supabase/client";
 import { useSearchParams } from "next/navigation";
 import { useRouter } from "nextjs-toploader/app";
@@ -28,7 +28,22 @@ export default function LoginPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const nextPath = searchParams.get("next") || "/chats/messages";
-  const supabase = createClient();
+  const supabase = useMemo(() => createClient(), []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!cancelled && session) {
+        router.replace(nextPath);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [nextPath, router, supabase]);
 
   const handleEmailAuth = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -175,7 +175,6 @@ export default function DashboardApp() {
       const accessToken = session?.access_token ?? null;
       const isSignOutEvent = event === "SIGNED_OUT";
 
-      if (source === "authEvent" && event === "INITIAL_SESSION") return;
       if (source === "authEvent" && !initResolvedRef.current && !accessToken && !isSignOutEvent) return;
 
       if (accessToken) {
@@ -196,11 +195,11 @@ export default function DashboardApp() {
       await syncSession(session, "getSession");
     };
 
-    void resolveSession();
-
     const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
       void syncSession(session, "authEvent", _event);
     });
+
+    void resolveSession();
 
     return () => {
       cancelled = true;


### PR DESCRIPTION
## Summary
- handle Supabase INITIAL_SESSION when /chats remounts so existing sessions initialize correctly
- redirect already-authenticated users away from /login back to the requested chat route

## Tests
- NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy NEXT_PUBLIC_BETA_GATE_ENABLED=false npm run build