### PR TITLE
feat: add mobile dashboard sidebar drawer

### DIFF
--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -175,7 +175,6 @@ export default function DashboardApp() {
       const accessToken = session?.access_token ?? null;
       const isSignOutEvent = event === "SIGNED_OUT";
 
-      if (source === "authEvent" && event === "INITIAL_SESSION") return;
       if (source === "authEvent" && !initResolvedRef.current && !accessToken && !isSignOutEvent) return;
 
       if (accessToken) {
@@ -196,11 +195,11 @@ export default function DashboardApp() {
       await syncSession(session, "getSession");
     };
 
-    void resolveSession();
-
     const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
       void syncSession(session, "authEvent", _event);
     });
+
+    void resolveSession();
 
     return () => {
       cancelled = true;
@@ -956,7 +955,11 @@ export default function DashboardApp() {
 
   return (
     <div className="relative flex h-[100dvh] overflow-hidden bg-deep-black max-md:flex-col-reverse md:h-screen">
-      <Sidebar mobileHideSecondary={mobileHideSecondary} />
+      <Sidebar
+        mobileHideSecondary={mobileHideSecondary}
+        mobileSecondaryOpen={uiStore.mobileSidebarOpen}
+        onMobileSecondaryClose={uiStore.closeMobileSidebar}
+      />
       <div className={mainPaneClass}>
         {uiStore.sidebarTab === "activity" ? (
           <ActivityPanel />

--- a/frontend/src/components/dashboard/RoomHeader.tsx
+++ b/frontend/src/components/dashboard/RoomHeader.tsx
@@ -12,7 +12,7 @@ import { common } from "@/lib/i18n/translations/common";
 import { roomList } from "@/lib/i18n/translations/dashboard";
 import { useRouter } from "nextjs-toploader/app";
 import { useShallow } from "zustand/react/shallow";
-import { ArrowLeft, Bell, Info, Loader2, Plus, Settings, Share2 } from "lucide-react";
+import { ArrowLeft, Bell, Info, Loader2, PanelLeftOpen, Plus, Settings, Share2 } from "lucide-react";
 import CopyableId from "@/components/ui/CopyableId";
 import { api, humansApi } from "@/lib/api";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
@@ -54,10 +54,11 @@ export default function RoomHeader() {
   const { openedRoomId } = useDashboardUIStore(useShallow((state) => ({
     openedRoomId: state.openedRoomId,
   })));
-  const { setFocusedRoomId, setOpenedRoomId, setMessagesPane } = useDashboardUIStore(useShallow((state) => ({
+  const { setFocusedRoomId, setOpenedRoomId, setMessagesPane, openMobileSidebar } = useDashboardUIStore(useShallow((state) => ({
     setFocusedRoomId: state.setFocusedRoomId,
     setOpenedRoomId: state.setOpenedRoomId,
     setMessagesPane: state.setMessagesPane,
+    openMobileSidebar: state.openMobileSidebar,
   })));
   const { overview, getRoomSummary, refreshOverview } = useDashboardChatStore(useShallow((state) => ({
     overview: state.overview,
@@ -280,6 +281,15 @@ export default function RoomHeader() {
           title="Back to messages"
         >
           <ArrowLeft className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          onClick={openMobileSidebar}
+          className="hidden h-9 w-9 shrink-0 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary max-md:inline-flex"
+          aria-label="Open message list"
+          title="Open message list"
+        >
+          <PanelLeftOpen className="h-4 w-4" />
         </button>
         <div className="min-w-0 py-0.5">
           <div className="flex items-center gap-2">

--- a/frontend/src/components/dashboard/RoomList.tsx
+++ b/frontend/src/components/dashboard/RoomList.tsx
@@ -79,9 +79,10 @@ export default function RoomList({
     messages: state.messages,
     loadRoomMessages: state.loadRoomMessages,
   })));
-  const { focusedRoomId, messagesPane, setFocusedRoomId, setOpenedRoomId, setMessagesPane } = useDashboardUIStore(useShallow((state) => ({
+  const { focusedRoomId, messagesPane, closeMobileSidebar, setFocusedRoomId, setOpenedRoomId, setMessagesPane } = useDashboardUIStore(useShallow((state) => ({
     focusedRoomId: state.focusedRoomId,
     messagesPane: state.messagesPane,
+    closeMobileSidebar: state.closeMobileSidebar,
     setFocusedRoomId: state.setFocusedRoomId,
     setOpenedRoomId: state.setOpenedRoomId,
     setMessagesPane: state.setMessagesPane,
@@ -129,6 +130,7 @@ export default function RoomList({
     setMessagesPane("room");
     setFocusedRoomId(roomId);
     setOpenedRoomId(roomId);
+    closeMobileSidebar();
     router.push(`/chats/messages/${encodeURIComponent(roomId)}`);
     if (!messages[roomId]) {
       loadRoomMessages(roomId);
@@ -151,6 +153,7 @@ export default function RoomList({
     setMessagesPane("user-chat");
     setFocusedRoomId(null);
     setOpenedRoomId(null);
+    closeMobileSidebar();
     router.push(USER_CHAT_PATH);
   };
 

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import { ArrowLeft, Bot, Loader2, MessageSquare, AlertCircle, RotateCcw, Bell, FileText, Settings2, User } from "lucide-react";
+import { ArrowLeft, Bot, Loader2, MessageSquare, AlertCircle, RotateCcw, Bell, FileText, PanelLeftOpen, Settings2, User } from "lucide-react";
 import { useRouter } from "nextjs-toploader/app";
 import AgentSettingsDrawer from "./AgentSettingsDrawer";
 import { api } from "@/lib/api";
@@ -74,7 +74,7 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
   const ownedAgents = useDashboardSessionStore((s) => s.ownedAgents);
   const isAgentMode = activeIdentity?.type === "agent" && !!activeAgentId;
   const chatAgentId = agentId || (isAgentMode ? activeAgentId : null);
-  const { setMessagesPane, setSelectedBotAgentId, setUserChatRoomId } = useDashboardUIStore();
+  const { openMobileSidebar, setMessagesPane, setSelectedBotAgentId, setUserChatRoomId } = useDashboardUIStore();
   const ownedAgent = chatAgentId
     ? ownedAgents.find((a) => a.agent_id === chatAgentId) ?? null
     : null;
@@ -328,6 +328,15 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
           title="Back"
         >
           <ArrowLeft className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          onClick={openMobileSidebar}
+          className="hidden h-9 w-9 shrink-0 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary max-md:inline-flex"
+          aria-label={agentId ? "Open bot list" : "Open message list"}
+          title={agentId ? "Open bot list" : "Open message list"}
+        >
+          <PanelLeftOpen className="h-4 w-4" />
         </button>
         <MessageSquare className="w-4 h-4 text-cyan-400" />
         <h2 className="min-w-0 truncate text-sm font-medium text-zinc-200">

--- a/frontend/src/components/dashboard/sidebar/BotsPanel.tsx
+++ b/frontend/src/components/dashboard/sidebar/BotsPanel.tsx
@@ -87,8 +87,9 @@ export default function BotsPanel({
   const { ownedAgents } = useDashboardSessionStore(useShallow((s) => ({
     ownedAgents: s.ownedAgents,
   })));
-  const { selectedBotAgentId, setSelectedBotAgentId } = useDashboardUIStore(useShallow((s) => ({
+  const { selectedBotAgentId, closeMobileSidebar, setSelectedBotAgentId } = useDashboardUIStore(useShallow((s) => ({
     selectedBotAgentId: s.selectedBotAgentId,
+    closeMobileSidebar: s.closeMobileSidebar,
     setSelectedBotAgentId: s.setSelectedBotAgentId,
   })));
   const daemons = useDaemonStore((s) => s.daemons);
@@ -104,6 +105,7 @@ export default function BotsPanel({
 
   const handleSelectAgent = (agentId: string) => {
     setSelectedBotAgentId(agentId);
+    closeMobileSidebar();
     startTransition(() => {
       router.push(`/chats/bots/${encodeURIComponent(agentId)}`);
     });

--- a/frontend/src/components/dashboard/sidebar/index.tsx
+++ b/frontend/src/components/dashboard/sidebar/index.tsx
@@ -36,7 +36,7 @@ import MessagesPanel from "./MessagesPanel";
 import WalletPanel from "./WalletPanel";
 
 import { humansApi } from "@/lib/api";
-import { UserPlus, LogIn, Bot, Plus, RefreshCw, MessageSquarePlus } from "lucide-react";
+import { UserPlus, LogIn, Bot, Plus, RefreshCw, MessageSquarePlus, X } from "lucide-react";
 
 const USER_CHAT_ROUTE = "/chats/messages/__user-chat__";
 
@@ -99,9 +99,15 @@ const authNavItems = [
 
 interface SidebarProps {
   mobileHideSecondary?: boolean;
+  mobileSecondaryOpen?: boolean;
+  onMobileSecondaryClose?: () => void;
 }
 
-export default function Sidebar({ mobileHideSecondary = false }: SidebarProps) {
+export default function Sidebar({
+  mobileHideSecondary = false,
+  mobileSecondaryOpen = false,
+  onMobileSecondaryClose,
+}: SidebarProps) {
   const router = useRouter();
   const supabase = useMemo(() => createClient(), []);
   const locale = useLanguage();
@@ -298,6 +304,7 @@ export default function Sidebar({ mobileHideSecondary = false }: SidebarProps) {
     if (tab === "messages" && !uiStore.openedRoomId && uiStore.messagesPane !== "user-chat") {
       uiStore.setMessagesPane("room");
     }
+    onMobileSecondaryClose?.();
     startTransition(() => { router.push(pathByTab[tab]); });
   };
 
@@ -396,6 +403,7 @@ export default function Sidebar({ mobileHideSecondary = false }: SidebarProps) {
             uiStore.setMessagesPane("room");
             uiStore.setFocusedRoomId(room.room_id);
             uiStore.setOpenedRoomId(room.room_id);
+            onMobileSecondaryClose?.();
             router.push(`/chats/messages/${encodeURIComponent(room.room_id)}`);
           }}
         />
@@ -413,14 +421,30 @@ export default function Sidebar({ mobileHideSecondary = false }: SidebarProps) {
             await sessionStore.refreshUserProfile();
             uiStore.setSidebarTab("bots");
             useDashboardUIStore.getState().setSelectedBotAgentId(agentId);
+            onMobileSecondaryClose?.();
             startTransition(() => { router.push(`/chats/bots/${encodeURIComponent(agentId)}`); });
           }}
         />
       )}
 
+      {mobileHideSecondary && mobileSecondaryOpen && (
+        <button
+          type="button"
+          aria-label="Close sidebar"
+          className="fixed inset-x-0 bottom-16 top-0 z-30 hidden bg-black/45 backdrop-blur-sm max-md:block"
+          onClick={onMobileSecondaryClose}
+        />
+      )}
+
       {/* Secondary panel */}
       <div
-        className={`relative flex h-full flex-col border-r border-glass-border bg-deep-black-light max-md:min-h-0 max-md:flex-1 max-md:!w-full max-md:!min-w-0 max-md:border-r-0 ${mobileHideSecondary ? "max-md:hidden" : ""}`}
+        className={`relative flex h-full flex-col border-r border-glass-border bg-deep-black-light max-md:min-h-0 max-md:flex-1 max-md:!min-w-0 max-md:border-r-0 ${
+          mobileHideSecondary
+            ? mobileSecondaryOpen
+              ? "max-md:fixed max-md:inset-x-3 max-md:bottom-20 max-md:top-4 max-md:z-40 max-md:!w-auto max-md:rounded-xl max-md:border max-md:border-glass-border max-md:shadow-2xl max-md:shadow-black/50"
+              : "max-md:hidden"
+            : "max-md:!w-full"
+        }`}
         style={{ width: uiStore.sidebarWidth, minWidth: SIDEBAR_MIN }}
       >
         {/* Resize handle */}
@@ -436,6 +460,17 @@ export default function Sidebar({ mobileHideSecondary = false }: SidebarProps) {
               <p className="truncate text-[10px] text-text-secondary/60">{t.browseAsGuest}</p>
             )}
           </div>
+          {mobileHideSecondary && (
+            <button
+              type="button"
+              onClick={onMobileSecondaryClose}
+              className="mr-1 hidden h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary max-md:inline-flex"
+              aria-label="Close sidebar"
+              title="Close sidebar"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          )}
           {uiStore.sidebarTab === "messages" && !isGuest && (
             <div className="flex items-center gap-1">
               <button

--- a/frontend/src/store/useDashboardUIStore.ts
+++ b/frontend/src/store/useDashboardUIStore.ts
@@ -18,6 +18,8 @@ export interface DashboardUIState {
   pendingHumanOpen: { humanId: string; displayName: string } | null;
   /** When set, the topic side drawer is open for this topic_id in the opened room. */
   openedTopicId: string | null;
+  /** Mobile-only temporary drawer for the secondary sidebar/list panel. */
+  mobileSidebarOpen: boolean;
   sidebarTab: "messages" | "contacts" | "explore" | "wallet" | "activity" | "bots";
   /** Currently selected owned bot (agent_id) in the My Bots tab. Null = list view. */
   selectedBotAgentId: string | null;
@@ -39,6 +41,8 @@ export interface DashboardUIState {
   setExploreView: (view: DashboardUIState["exploreView"]) => void;
   setContactsView: (view: DashboardUIState["contactsView"]) => void;
   setOpenedTopicId: (topicId: string | null) => void;
+  openMobileSidebar: () => void;
+  closeMobileSidebar: () => void;
   toggleRightPanel: () => void;
   openAgentCard: () => void;
   closeAgentCard: () => void;
@@ -58,6 +62,7 @@ const initialUIState = {
   agentCardOpen: false,
   pendingHumanOpen: null as { humanId: string; displayName: string } | null,
   openedTopicId: null as string | null,
+  mobileSidebarOpen: false,
   sidebarTab: "messages" as DashboardUIState["sidebarTab"],
   selectedBotAgentId: null as string | null,
   messagesPane: "room" as const,
@@ -88,6 +93,8 @@ export const useDashboardUIStore = create<DashboardUIState>()((set) => ({
     set((state) => (state.contactsView === contactsView ? state : { contactsView })),
   setOpenedTopicId: (openedTopicId) =>
     set((state) => (state.openedTopicId === openedTopicId ? state : { openedTopicId })),
+  openMobileSidebar: () => set({ mobileSidebarOpen: true }),
+  closeMobileSidebar: () => set({ mobileSidebarOpen: false }),
   setSidebarWidth: (sidebarWidth) =>
     set((state) => (state.sidebarWidth === sidebarWidth ? state : { sidebarWidth })),
   toggleRightPanel: () => set((state) => ({ rightPanelOpen: !state.rightPanelOpen })),


### PR DESCRIPTION
## Summary
- add a mobile-only temporary drawer state for the dashboard secondary sidebar
- expose drawer triggers in room and owner-chat detail headers
- close the mobile drawer automatically after selecting a room or bot

## Tests
- git diff --check origin/main...HEAD
- NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy-anon-key npm run build *(blocked on current main: frontend/src/components/dashboard/AgentChannelsTab.tsx references missing StepSection)*