### PR TITLE
fix: allow owners to DM their agents

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -2313,14 +2313,30 @@ async def _ensure_dashboard_dm_room(
         peer_agent = peer_row.scalar_one_or_none()
         if peer_agent is None:
             return None
+
+        sender_owns_peer = False
+        if sender_is_human and peer_agent.user_id is not None:
+            owner_row = await db.execute(
+                select(User.id).where(User.human_id == sender_id)
+            )
+            sender_user_id = owner_row.scalar_one_or_none()
+            sender_owns_peer = (
+                sender_user_id is not None
+                and str(peer_agent.user_id) == str(sender_user_id)
+            )
+
         # Centralised admission: block + contact_policy + allow_*_sender.
+        # The human owner of an agent may always open a direct chat with that
+        # agent; requiring a contact request to one's own bot is impossible by
+        # design and is rejected in the human contact-request flow.
         # Allow same-room bypass off since this call IS the room creation.
-        await check_direct_admission(
-            db,
-            sender=Principal(id=sender_id, type=sender_type),
-            receiver=peer_agent,
-            allow_same_room_bypass=False,
-        )
+        if not sender_owns_peer:
+            await check_direct_admission(
+                db,
+                sender=Principal(id=sender_id, type=sender_type),
+                receiver=peer_agent,
+                allow_same_room_bypass=False,
+            )
 
     room = Room(
         room_id=room_id,

--- a/backend/tests/test_app/test_app_dashboard.py
+++ b/backend/tests/test_app/test_app_dashboard.py
@@ -7,9 +7,11 @@ import jwt
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from unittest.mock import AsyncMock
 
+from hub.enums import ParticipantType
 from hub.models import (
     Agent,
     Base,
@@ -438,6 +440,55 @@ async def test_chat_room_for_explicit_owned_agent_without_active_agent(
     )
     assert messages_resp.status_code == 200
     assert len(messages_resp.json()["messages"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_human_owner_can_open_dm_with_own_contacts_only_agent(
+    client: AsyncClient, seed_data: dict, db_session: AsyncSession
+):
+    """Human owners should not need a contact request to DM their own bot."""
+    token = seed_data["token"]
+    agent_id = "ag_ownedbot001"
+    db_session.add(
+        Agent(
+            agent_id=agent_id,
+            display_name="Owned Bot",
+            message_policy=MessagePolicy.contacts_only,
+            user_id=seed_data["user_id"],
+            claimed_at=datetime.datetime.now(datetime.timezone.utc),
+        )
+    )
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/dashboard/dms/open",
+        json={"peer_id": agent_id},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 201, resp.text
+
+    room_id = resp.json()["room_id"]
+    members = (
+        await db_session.execute(
+            select(RoomMember).where(RoomMember.room_id == room_id)
+        )
+    ).scalars().all()
+    member_ids = {m.agent_id for m in members}
+    assert agent_id in member_ids
+    assert any(m.participant_type == ParticipantType.human for m in members)
+
+
+@pytest.mark.asyncio
+async def test_human_cannot_open_dm_with_unowned_contacts_only_agent_without_contact(
+    client: AsyncClient, seed_data: dict
+):
+    """The owner bypass must not open arbitrary contacts_only agents."""
+    resp = await client.post(
+        "/api/dashboard/dms/open",
+        json={"peer_id": "ag_other00001"},
+        headers={"Authorization": f"Bearer {seed_data['token']}"},
+    )
+    assert resp.status_code == 403, resp.text
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/components/dashboard/AgentCardModal.tsx
+++ b/frontend/src/components/dashboard/AgentCardModal.tsx
@@ -29,6 +29,7 @@ interface AgentCardModalProps {
   onSendFriendRequest: () => void;
   onSendMessage?: () => void;
   onRetry?: () => void;
+  isOwnAgent?: boolean;
 }
 
 export default function AgentCardModal({
@@ -44,6 +45,7 @@ export default function AgentCardModal({
   onSendFriendRequest,
   onSendMessage,
   onRetry,
+  isOwnAgent = false,
 }: AgentCardModalProps) {
   const locale = useLanguage();
   const t = exploreUi[locale];
@@ -118,7 +120,14 @@ export default function AgentCardModal({
                 {agent?.message_policy || "-"}
               </span>
             </div>
-            {alreadyInContacts ? (
+            {isOwnAgent ? (
+              <button
+                onClick={onSendMessage}
+                className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-green/40 bg-neon-green/10 py-2 text-xs font-medium text-neon-green transition-colors hover:bg-neon-green/20"
+              >
+                {t.sendMessage}
+              </button>
+            ) : alreadyInContacts ? (
               <button
                 onClick={onSendMessage}
                 className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-green/40 bg-neon-green/10 py-2 text-xs font-medium text-neon-green transition-colors hover:bg-neon-green/20"

--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -792,6 +792,11 @@ export default function DashboardApp() {
   }
 
   const selectedAgentForCard = chatStore.selectedAgentProfile;
+  const isSelectedAgentOwned = selectedAgentForCard
+    ? sessionStore.ownedAgents.some(
+      (item) => item.agent_id === selectedAgentForCard.agent_id,
+    )
+    : false;
   const alreadyInContacts = selectedAgentForCard
     ? (chatStore.overview?.contacts || []).some(
       (item) => item.contact_agent_id === selectedAgentForCard.agent_id,
@@ -1063,6 +1068,7 @@ export default function DashboardApp() {
         alreadyInContacts={alreadyInContacts}
         requestAlreadyPending={requestAlreadyPending}
         sendingFriendRequest={isSendingFriendRequest}
+        isOwnAgent={isSelectedAgentOwned}
         onSendFriendRequest={handleSendFriendRequestFromCard}
         onSendMessage={handleSendMessageFromAgentCard}
         onRetry={() => {


### PR DESCRIPTION
## Summary
- Allow a human owner to open a dashboard DM with their own contacts_only agent without requiring a contact request
- Keep normal contacts_only admission checks for unowned agents
- Hide the add-friend action on agent cards for the user's own agents and show the message action instead

## Tests
- cd backend && uv run pytest tests/test_app/test_app_dashboard.py -q
- cd frontend && npm run build (fails during /admin/codes prerender because Supabase URL/API key env vars are not set locally; compile and TypeScript stages completed)