### PR TITLE
fix: persist cross-room handoff guidance

### DIFF
--- a/packages/daemon/src/__tests__/working-memory.test.ts
+++ b/packages/daemon/src/__tests__/working-memory.test.ts
@@ -207,6 +207,15 @@ describe("buildWorkingMemoryPrompt", () => {
     expect(p).toContain("currently empty");
   });
 
+  it("instructs agents to persist cross-room handoffs", () => {
+    const p = wm.buildWorkingMemoryPrompt({ workingMemory: null });
+    expect(p).toContain("For cross-room work");
+    expect(p).toContain("pending_tasks");
+    expect(p).toContain("source room");
+    expect(p).toContain("target room");
+    expect(p).toContain("where to report completion");
+  });
+
   it("renders goal + named sections", () => {
     const p = wm.buildWorkingMemoryPrompt({
       workingMemory: {
@@ -237,4 +246,3 @@ describe("buildWorkingMemoryPrompt", () => {
     expect(p).toContain("‹current_memory›");
   });
 });
-

--- a/packages/daemon/src/working-memory.ts
+++ b/packages/daemon/src/working-memory.ts
@@ -307,6 +307,11 @@ export function buildWorkingMemoryPrompt(opts: {
     "- sections: named buckets (contacts, pending_tasks, preferences, etc.).",
     "- Updating one section never touches others. Empty content deletes a section.",
     "",
+    "For cross-room work, update memory before or immediately after delegating:",
+    "- If you accept a request in one room and continue it in another, record a `pending_tasks` entry with source room id/name, target room id/name, requested deliverable, current status, and where to report completion.",
+    "- When a delegated room replies or delivers an artifact, consult `pending_tasks` before deciding `NO_REPLY`; if it matches a pending handoff, acknowledge, update status, and send the promised follow-up to the source room when appropriate.",
+    "- Remove or mark the entry done once the source room has been updated.",
+    "",
     "Only update when something meaningful changes. Keep each section tight.",
   ];
 


### PR DESCRIPTION
## Summary
- clarify daemon working-memory guidance for cross-room handoffs
- instruct agents to persist source/target room, deliverable, status, and completion destination in `pending_tasks`
- add coverage for the cross-room handoff prompt guidance

## Tests
- `cd packages/daemon && npm test -- --run src/__tests__/working-memory.test.ts src/__tests__/system-context.test.ts`