### PR TITLE
feat: add agent schedules

### DIFF
--- a/backend/app/routers/schedules.py
+++ b/backend/app/routers/schedules.py
@@ -1,0 +1,200 @@
+"""Dashboard-facing agent schedule management."""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import RequestContext, require_user
+from hub.database import get_db
+from hub.models import Agent, AgentSchedule, AgentScheduleRun
+from hub.services.agent_schedules import (
+    compute_next_fire_at,
+    create_schedule,
+    dispatch_schedule_run,
+    now_utc,
+    serialize_run,
+    serialize_schedule,
+    validate_payload_json,
+    validate_schedule_json,
+)
+
+router = APIRouter(prefix="/api/agents", tags=["agent-schedules"])
+
+
+class ScheduleBody(BaseModel):
+    name: str = Field(..., min_length=1, max_length=80)
+    enabled: bool = True
+    schedule: dict[str, Any]
+    payload: dict[str, Any] | None = None
+
+
+class SchedulePatchBody(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=80)
+    enabled: bool | None = None
+    schedule: dict[str, Any] | None = None
+    payload: dict[str, Any] | None = None
+
+
+async def _load_owned_agent(db: AsyncSession, ctx: RequestContext, agent_id: str) -> Agent:
+    agent = await db.scalar(select(Agent).where(Agent.agent_id == agent_id))
+    if agent is None or str(agent.user_id) != str(ctx.user_id) or agent.status != "active":
+        raise HTTPException(status_code=404, detail="agent_not_found")
+    return agent
+
+
+async def _load_owned_schedule(
+    db: AsyncSession,
+    ctx: RequestContext,
+    agent_id: str,
+    schedule_id: str,
+) -> AgentSchedule:
+    await _load_owned_agent(db, ctx, agent_id)
+    row = await db.scalar(
+        select(AgentSchedule).where(
+            AgentSchedule.id == schedule_id,
+            AgentSchedule.agent_id == agent_id,
+        )
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="schedule_not_found")
+    return row
+
+
+@router.get("/{agent_id}/schedules")
+async def list_schedules(
+    agent_id: str,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    await _load_owned_agent(db, ctx, agent_id)
+    rows = (
+        await db.execute(
+            select(AgentSchedule)
+            .where(AgentSchedule.agent_id == agent_id)
+            .order_by(AgentSchedule.created_at, AgentSchedule.id)
+        )
+    ).scalars().all()
+    return {"schedules": [serialize_schedule(row) for row in rows]}
+
+
+@router.post("/{agent_id}/schedules", status_code=201)
+async def create_agent_schedule(
+    agent_id: str,
+    body: ScheduleBody,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    agent = await _load_owned_agent(db, ctx, agent_id)
+    row = await create_schedule(
+        db,
+        agent=agent,
+        name=body.name,
+        schedule_json=body.schedule,
+        payload_json=body.payload,
+        enabled=body.enabled,
+        created_by="owner",
+    )
+    try:
+        await db.commit()
+    except Exception as exc:  # noqa: BLE001
+        await db.rollback()
+        if "agent_schedules" in str(exc):
+            raise HTTPException(status_code=409, detail="schedule_name_exists")
+        raise
+    await db.refresh(row)
+    return serialize_schedule(row)
+
+
+@router.patch("/{agent_id}/schedules/{schedule_id}")
+async def patch_agent_schedule(
+    agent_id: str,
+    schedule_id: str,
+    body: SchedulePatchBody,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    row = await _load_owned_schedule(db, ctx, agent_id, schedule_id)
+    schedule_changed = False
+    if body.name is not None:
+        row.name = body.name.strip()
+    if body.schedule is not None:
+        row.schedule_json = validate_schedule_json(body.schedule)
+        schedule_changed = True
+    if body.payload is not None:
+        row.payload_json = validate_payload_json(body.payload)
+    if body.enabled is not None:
+        row.enabled = body.enabled
+        schedule_changed = True
+    if schedule_changed:
+        row.next_fire_at = compute_next_fire_at(row.schedule_json) if row.enabled else None
+        row.locked_until = None
+        row.locked_by = None
+    try:
+        await db.commit()
+    except Exception as exc:  # noqa: BLE001
+        await db.rollback()
+        if "agent_schedules" in str(exc):
+            raise HTTPException(status_code=409, detail="schedule_name_exists")
+        raise
+    await db.refresh(row)
+    return serialize_schedule(row)
+
+
+@router.delete("/{agent_id}/schedules/{schedule_id}", status_code=204)
+async def delete_agent_schedule(
+    agent_id: str,
+    schedule_id: str,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    row = await _load_owned_schedule(db, ctx, agent_id, schedule_id)
+    await db.delete(row)
+    await db.commit()
+
+
+@router.post("/{agent_id}/schedules/{schedule_id}/run")
+async def run_agent_schedule(
+    agent_id: str,
+    schedule_id: str,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    row = await _load_owned_schedule(db, ctx, agent_id, schedule_id)
+    run = await dispatch_schedule_run(
+        db,
+        schedule=row,
+        scheduled_for=now_utc(),
+        manual=True,
+    )
+    row.last_fire_at = datetime.datetime.now(datetime.timezone.utc)
+    await db.commit()
+    await db.refresh(run)
+    return serialize_run(run)
+
+
+@router.get("/{agent_id}/schedules/{schedule_id}/runs")
+async def list_schedule_runs(
+    agent_id: str,
+    schedule_id: str,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    await _load_owned_schedule(db, ctx, agent_id, schedule_id)
+    rows = (
+        await db.execute(
+            select(AgentScheduleRun)
+            .where(
+                AgentScheduleRun.schedule_id == schedule_id,
+                AgentScheduleRun.agent_id == agent_id,
+            )
+            .order_by(AgentScheduleRun.created_at.desc())
+            .limit(20)
+        )
+    ).scalars().all()
+    return {"runs": [serialize_run(row) for row in rows]}

--- a/backend/hub/id_generators.py
+++ b/backend/hub/id_generators.py
@@ -93,6 +93,16 @@ def generate_subscription_charge_attempt_id() -> str:
     return "sca_" + secrets.token_hex(8)
 
 
+def generate_agent_schedule_id() -> str:
+    """Generate agent schedule ID: 'sch_' + 16 random hex chars."""
+    return "sch_" + secrets.token_hex(8)
+
+
+def generate_agent_schedule_run_id() -> str:
+    """Generate agent schedule run ID: 'sr_' + 16 random hex chars."""
+    return "sr_" + secrets.token_hex(8)
+
+
 def generate_join_request_id() -> str:
     """Generate room join request ID: 'jr_' + 16 random hex chars."""
     return "jr_" + secrets.token_hex(8)

--- a/backend/hub/main.py
+++ b/backend/hub/main.py
@@ -23,6 +23,7 @@ from hub import config as hub_config
 from hub.database import get_db
 from hub.expiry import message_expiry_loop
 from hub.subscription_billing import subscription_billing_loop
+from hub.services.agent_schedules import agent_schedule_loop
 from hub.version_poll import version_poll_loop
 from hub.routers.contact_requests import router as contact_requests_router
 from hub.routers.daemon_control import router as daemon_control_router
@@ -44,6 +45,7 @@ from hub.routers.room_context import router as room_context_router
 from hub.routers.subscriptions import internal_router as subscriptions_internal_router
 from hub.routers.subscriptions import router as subscriptions_router
 from hub.routers.memory import router as memory_router
+from hub.routers.agent_schedules import router as agent_schedules_router
 from hub.routers.topics import router as topics_router
 from hub.routers.stripe import router as stripe_router
 from hub.routers.wallet import internal_router as wallet_internal_router
@@ -67,6 +69,7 @@ from app.routers.policy import router as app_policy_router
 from app.routers.gateways import router as app_gateways_router
 from app.routers.prompts import router as app_prompts_router
 from app.routers.runtime_files import router as app_runtime_files_router
+from app.routers.schedules import router as app_schedules_router
 from app.auth import require_beta_user
 
 logging.basicConfig(level=logging.INFO)
@@ -114,6 +117,7 @@ async def lifespan(app: FastAPI):
     subscription_billing_task = None
     version_poll_task = None
     presence_task = None
+    agent_schedule_task = None
     if not test_db_override:
         # Background message expiry loop
         expiry_task = asyncio.create_task(message_expiry_loop())
@@ -125,11 +129,13 @@ async def lifespan(app: FastAPI):
         version_poll_task = asyncio.create_task(version_poll_loop())
         # Background presence cleanup loop
         presence_task = asyncio.create_task(presence_cleanup_loop())
+        # Background proactive agent schedule loop
+        agent_schedule_task = asyncio.create_task(agent_schedule_loop())
 
     yield
 
     # Shutdown
-    for task in (presence_task, version_poll_task, subscription_billing_task, cleanup_task, expiry_task):
+    for task in (agent_schedule_task, presence_task, version_poll_task, subscription_billing_task, cleanup_task, expiry_task):
         if task is None:
             continue
         task.cancel()
@@ -277,6 +283,7 @@ app.include_router(dashboard_router)
 app.include_router(dashboard_chat_router)
 app.include_router(owner_chat_ws_router)
 app.include_router(memory_router)
+app.include_router(agent_schedules_router)
 app.include_router(leaderboard_router)
 app.include_router(public_router)
 app.include_router(share_public_router)
@@ -297,6 +304,7 @@ app.include_router(app_admin_beta_router)
 app.include_router(app_policy_router, dependencies=_beta_gate)
 app.include_router(app_gateways_router, dependencies=_beta_gate)
 app.include_router(app_runtime_files_router, dependencies=_beta_gate)
+app.include_router(app_schedules_router, dependencies=_beta_gate)
 app.include_router(app_prompts_router)
 app.include_router(app_presence_router, dependencies=_beta_gate)
 app.include_router(app_presence_status_router, dependencies=_beta_gate)

--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -1368,6 +1368,62 @@ class OpenclawHostInstance(Base):
     )
 
 
+class AgentSchedule(Base):
+    """Owner/agent-managed schedule for proactive agent turns."""
+
+    __tablename__ = "agent_schedules"
+    __table_args__ = (
+        UniqueConstraint("agent_id", "name", name="uq_agent_schedules_agent_name"),
+        Index("ix_agent_schedules_due", "enabled", "next_fire_at"),
+        Index("ix_agent_schedules_agent", "agent_id"),
+    )
+
+    id: Mapped[str] = mapped_column(String(32), primary_key=True)
+    agent_id: Mapped[str] = mapped_column(
+        String(32), ForeignKey("agents.agent_id", ondelete="CASCADE"), nullable=False
+    )
+    user_id: Mapped[_uuid.UUID | None] = mapped_column(Uuid, nullable=True, index=True)
+    name: Mapped[str] = mapped_column(String(80), nullable=False)
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default=sa_text("TRUE"))
+    schedule_json: Mapped[dict] = mapped_column(JSON, nullable=False)
+    payload_json: Mapped[dict] = mapped_column(JSON, nullable=False)
+    created_by: Mapped[str] = mapped_column(String(16), nullable=False, default="owner", server_default="owner")
+    next_fire_at: Mapped[datetime.datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, index=True)
+    last_fire_at: Mapped[datetime.datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    locked_until: Mapped[datetime.datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    locked_by: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    created_at: Mapped[datetime.datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+
+class AgentScheduleRun(Base):
+    """Audit trail for schedule dispatch attempts."""
+
+    __tablename__ = "agent_schedule_runs"
+    __table_args__ = (
+        Index("ix_agent_schedule_runs_schedule", "schedule_id", "scheduled_for"),
+        Index("ix_agent_schedule_runs_agent", "agent_id", "scheduled_for"),
+        UniqueConstraint("dedupe_key", name="uq_agent_schedule_runs_dedupe_key"),
+    )
+
+    id: Mapped[str] = mapped_column(String(32), primary_key=True)
+    schedule_id: Mapped[str] = mapped_column(
+        String(32), ForeignKey("agent_schedules.id", ondelete="CASCADE"), nullable=False
+    )
+    agent_id: Mapped[str] = mapped_column(
+        String(32), ForeignKey("agents.agent_id", ondelete="CASCADE"), nullable=False
+    )
+    scheduled_for: Mapped[datetime.datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    started_at: Mapped[datetime.datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    completed_at: Mapped[datetime.datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    status: Mapped[str] = mapped_column(String(24), nullable=False, default="queued", server_default="queued")
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    dedupe_key: Mapped[str] = mapped_column(String(128), nullable=False)
+    created_at: Mapped[datetime.datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
 class DaemonDeviceCode(Base):
     """Transient device-code rows for the daemon login flow.
 

--- a/backend/hub/routers/agent_schedules.py
+++ b/backend/hub/routers/agent_schedules.py
@@ -1,0 +1,195 @@
+"""Agent-facing schedule management endpoints."""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from hub.auth import get_current_agent
+from hub.database import get_db
+from hub.models import Agent, AgentSchedule, AgentScheduleRun
+from hub.services.agent_schedules import (
+    compute_next_fire_at,
+    create_schedule,
+    dispatch_schedule_run,
+    now_utc,
+    serialize_run,
+    serialize_schedule,
+    validate_payload_json,
+    validate_schedule_json,
+)
+
+router = APIRouter(prefix="/hub/schedules", tags=["agent-schedules"])
+
+
+class ScheduleBody(BaseModel):
+    name: str = Field(..., min_length=1, max_length=80)
+    enabled: bool = True
+    schedule: dict[str, Any]
+    payload: dict[str, Any] | None = None
+
+
+class SchedulePatchBody(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=80)
+    enabled: bool | None = None
+    schedule: dict[str, Any] | None = None
+    payload: dict[str, Any] | None = None
+
+
+async def _load_self_agent(db: AsyncSession, agent_id: str) -> Agent:
+    agent = await db.scalar(select(Agent).where(Agent.agent_id == agent_id))
+    if agent is None or agent.status != "active":
+        raise HTTPException(status_code=404, detail="agent_not_found")
+    if agent.user_id is None:
+        raise HTTPException(status_code=403, detail="agent_not_claimed")
+    return agent
+
+
+async def _load_self_schedule(
+    db: AsyncSession,
+    agent_id: str,
+    schedule_id: str,
+) -> AgentSchedule:
+    await _load_self_agent(db, agent_id)
+    row = await db.scalar(
+        select(AgentSchedule).where(
+            AgentSchedule.id == schedule_id,
+            AgentSchedule.agent_id == agent_id,
+        )
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="schedule_not_found")
+    return row
+
+
+@router.get("")
+async def list_self_schedules(
+    current_agent: str = Depends(get_current_agent),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    await _load_self_agent(db, current_agent)
+    rows = (
+        await db.execute(
+            select(AgentSchedule)
+            .where(AgentSchedule.agent_id == current_agent)
+            .order_by(AgentSchedule.created_at, AgentSchedule.id)
+        )
+    ).scalars().all()
+    return {"schedules": [serialize_schedule(row) for row in rows]}
+
+
+@router.post("", status_code=201)
+async def create_self_schedule(
+    body: ScheduleBody,
+    current_agent: str = Depends(get_current_agent),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    agent = await _load_self_agent(db, current_agent)
+    row = await create_schedule(
+        db,
+        agent=agent,
+        name=body.name,
+        schedule_json=body.schedule,
+        payload_json=body.payload,
+        enabled=body.enabled,
+        created_by="agent",
+    )
+    try:
+        await db.commit()
+    except Exception as exc:  # noqa: BLE001
+        await db.rollback()
+        if "agent_schedules" in str(exc):
+            raise HTTPException(status_code=409, detail="schedule_name_exists")
+        raise
+    await db.refresh(row)
+    return serialize_schedule(row)
+
+
+@router.patch("/{schedule_id}")
+async def patch_self_schedule(
+    schedule_id: str,
+    body: SchedulePatchBody,
+    current_agent: str = Depends(get_current_agent),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    row = await _load_self_schedule(db, current_agent, schedule_id)
+    schedule_changed = False
+    if body.name is not None:
+        row.name = body.name.strip()
+    if body.schedule is not None:
+        row.schedule_json = validate_schedule_json(body.schedule)
+        schedule_changed = True
+    if body.payload is not None:
+        row.payload_json = validate_payload_json(body.payload)
+    if body.enabled is not None:
+        row.enabled = body.enabled
+        schedule_changed = True
+    if schedule_changed:
+        row.next_fire_at = compute_next_fire_at(row.schedule_json) if row.enabled else None
+        row.locked_until = None
+        row.locked_by = None
+    try:
+        await db.commit()
+    except Exception as exc:  # noqa: BLE001
+        await db.rollback()
+        if "agent_schedules" in str(exc):
+            raise HTTPException(status_code=409, detail="schedule_name_exists")
+        raise
+    await db.refresh(row)
+    return serialize_schedule(row)
+
+
+@router.delete("/{schedule_id}", status_code=204)
+async def delete_self_schedule(
+    schedule_id: str,
+    current_agent: str = Depends(get_current_agent),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    row = await _load_self_schedule(db, current_agent, schedule_id)
+    await db.delete(row)
+    await db.commit()
+
+
+@router.post("/{schedule_id}/run")
+async def run_self_schedule(
+    schedule_id: str,
+    current_agent: str = Depends(get_current_agent),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    row = await _load_self_schedule(db, current_agent, schedule_id)
+    run = await dispatch_schedule_run(
+        db,
+        schedule=row,
+        scheduled_for=now_utc(),
+        manual=True,
+    )
+    row.last_fire_at = datetime.datetime.now(datetime.timezone.utc)
+    await db.commit()
+    await db.refresh(run)
+    return serialize_run(run)
+
+
+@router.get("/{schedule_id}/runs")
+async def list_self_schedule_runs(
+    schedule_id: str,
+    current_agent: str = Depends(get_current_agent),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    await _load_self_schedule(db, current_agent, schedule_id)
+    rows = (
+        await db.execute(
+            select(AgentScheduleRun)
+            .where(
+                AgentScheduleRun.schedule_id == schedule_id,
+                AgentScheduleRun.agent_id == current_agent,
+            )
+            .order_by(AgentScheduleRun.created_at.desc())
+            .limit(20)
+        )
+    ).scalars().all()
+    return {"runs": [serialize_run(row) for row in rows]}

--- a/backend/hub/services/agent_schedules.py
+++ b/backend/hub/services/agent_schedules.py
@@ -1,0 +1,298 @@
+"""Agent schedule validation, dispatch, and background processing."""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import logging
+import os
+import socket
+from typing import Any
+
+from fastapi import HTTPException
+from sqlalchemy import or_, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from hub.database import async_session
+from hub.id_generators import generate_agent_schedule_id, generate_agent_schedule_run_id
+from hub.models import Agent, AgentSchedule, AgentScheduleRun
+
+logger = logging.getLogger(__name__)
+
+MIN_EVERY_MS = 5 * 60 * 1000
+MAX_EVERY_MS = 30 * 24 * 60 * 60 * 1000
+DEFAULT_PROACTIVE_MESSAGE = "【BotCord 自主任务】执行本轮工作目标。"
+_BACKGROUND_RUNS: set[asyncio.Task] = set()
+
+
+def now_utc() -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def aware(dt: datetime.datetime | None) -> datetime.datetime | None:
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=datetime.timezone.utc)
+    return dt
+
+
+def validate_schedule_json(value: dict[str, Any]) -> dict[str, Any]:
+    kind = value.get("kind")
+    if kind != "every":
+        raise HTTPException(status_code=400, detail="unsupported_schedule_kind")
+    every_ms = value.get("every_ms", value.get("everyMs"))
+    if not isinstance(every_ms, int):
+        raise HTTPException(status_code=400, detail="every_ms_required")
+    if every_ms < MIN_EVERY_MS:
+        raise HTTPException(status_code=400, detail="schedule_interval_too_short")
+    if every_ms > MAX_EVERY_MS:
+        raise HTTPException(status_code=400, detail="schedule_interval_too_long")
+    return {"kind": "every", "every_ms": every_ms}
+
+
+def validate_payload_json(value: dict[str, Any] | None) -> dict[str, Any]:
+    payload = value or {}
+    kind = payload.get("kind", "agent_turn")
+    if kind != "agent_turn":
+        raise HTTPException(status_code=400, detail="unsupported_payload_kind")
+    message = payload.get("message", DEFAULT_PROACTIVE_MESSAGE)
+    if not isinstance(message, str) or not message.strip():
+        raise HTTPException(status_code=400, detail="message_required")
+    message = message.strip()
+    if len(message) > 2000:
+        raise HTTPException(status_code=400, detail="message_too_long")
+    return {"kind": "agent_turn", "message": message}
+
+
+def compute_next_fire_at(
+    schedule_json: dict[str, Any],
+    base: datetime.datetime | None = None,
+) -> datetime.datetime:
+    schedule = validate_schedule_json(schedule_json)
+    return (base or now_utc()) + datetime.timedelta(milliseconds=schedule["every_ms"])
+
+
+def serialize_schedule(row: AgentSchedule) -> dict[str, Any]:
+    return {
+        "id": row.id,
+        "agent_id": row.agent_id,
+        "name": row.name,
+        "enabled": row.enabled,
+        "schedule": row.schedule_json,
+        "payload": row.payload_json,
+        "created_by": row.created_by,
+        "next_fire_at": aware(row.next_fire_at).isoformat() if row.next_fire_at else None,
+        "last_fire_at": aware(row.last_fire_at).isoformat() if row.last_fire_at else None,
+        "created_at": aware(row.created_at).isoformat() if row.created_at else None,
+        "updated_at": aware(row.updated_at).isoformat() if row.updated_at else None,
+    }
+
+
+def serialize_run(row: AgentScheduleRun) -> dict[str, Any]:
+    return {
+        "id": row.id,
+        "schedule_id": row.schedule_id,
+        "agent_id": row.agent_id,
+        "scheduled_for": aware(row.scheduled_for).isoformat(),
+        "started_at": aware(row.started_at).isoformat() if row.started_at else None,
+        "completed_at": aware(row.completed_at).isoformat() if row.completed_at else None,
+        "status": row.status,
+        "error": row.error,
+        "dedupe_key": row.dedupe_key,
+        "created_at": aware(row.created_at).isoformat() if row.created_at else None,
+    }
+
+
+def _ack_error_message(ack: Any) -> str:
+    if not isinstance(ack, dict):
+        return "malformed_ack"
+    err = ack.get("error")
+    if isinstance(err, dict):
+        code = err.get("code")
+        message = err.get("message")
+        if isinstance(code, str) and isinstance(message, str):
+            return f"{code}: {message}"[:1000]
+        if isinstance(code, str):
+            return code[:1000]
+        if isinstance(message, str):
+            return message[:1000]
+    return "ack_not_ok"
+
+
+async def create_schedule(
+    db: AsyncSession,
+    *,
+    agent: Agent,
+    name: str,
+    schedule_json: dict[str, Any],
+    payload_json: dict[str, Any] | None,
+    enabled: bool = True,
+    created_by: str = "owner",
+) -> AgentSchedule:
+    clean_name = name.strip()
+    if not clean_name:
+        raise HTTPException(status_code=400, detail="name_required")
+    if len(clean_name) > 80:
+        raise HTTPException(status_code=400, detail="name_too_long")
+    schedule = validate_schedule_json(schedule_json)
+    payload = validate_payload_json(payload_json)
+    row = AgentSchedule(
+        id=generate_agent_schedule_id(),
+        agent_id=agent.agent_id,
+        user_id=agent.user_id,
+        name=clean_name,
+        enabled=enabled,
+        schedule_json=schedule,
+        payload_json=payload,
+        created_by=created_by,
+        next_fire_at=compute_next_fire_at(schedule) if enabled else None,
+    )
+    db.add(row)
+    await db.flush()
+    return row
+
+
+async def dispatch_schedule_run(
+    db: AsyncSession,
+    *,
+    schedule: AgentSchedule,
+    scheduled_for: datetime.datetime,
+    manual: bool = False,
+) -> AgentScheduleRun:
+    agent = await db.scalar(select(Agent).where(Agent.agent_id == schedule.agent_id))
+    if agent is None or agent.status != "active":
+        raise HTTPException(status_code=404, detail="agent_not_found")
+
+    run = AgentScheduleRun(
+        id=generate_agent_schedule_run_id(),
+        schedule_id=schedule.id,
+        agent_id=schedule.agent_id,
+        scheduled_for=scheduled_for,
+        started_at=now_utc(),
+        status="queued",
+        dedupe_key=f"{schedule.id}:{int(scheduled_for.timestamp())}:{'manual' if manual else 'auto'}",
+    )
+    db.add(run)
+    await db.flush()
+
+    params = {
+        "agent_id": schedule.agent_id,
+        "reason": "manual" if manual else "scheduled",
+        "trigger": "botcord.proactive",
+        "message": schedule.payload_json.get("message", DEFAULT_PROACTIVE_MESSAGE),
+        "schedule_id": schedule.id,
+        "run_id": run.id,
+        "dedupe_key": run.dedupe_key,
+    }
+
+    try:
+        if agent.hosting_kind == "daemon" and agent.daemon_instance_id:
+            from hub.routers.daemon_control import send_control_frame
+
+            ack = await send_control_frame(agent.daemon_instance_id, "wake_agent", params, timeout_ms=30000)
+        elif agent.hosting_kind == "plugin" and agent.openclaw_host_id:
+            from hub.routers.openclaw_control import send_host_control_frame
+
+            ack = await send_host_control_frame(agent.openclaw_host_id, "wake_agent", params, timeout_ms=30000)
+        else:
+            run.status = "failed"
+            run.error = "agent_not_hosted"
+            run.completed_at = now_utc()
+            await db.flush()
+            return run
+
+        if not isinstance(ack, dict) or ack.get("ok") is not True:
+            run.status = "failed"
+            run.error = _ack_error_message(ack)
+            run.completed_at = now_utc()
+            await db.flush()
+            return run
+    except HTTPException as exc:
+        detail = exc.detail
+        code = detail if isinstance(detail, str) else str(detail)
+        run.status = "offline" if exc.status_code == 409 and code in {"daemon_offline", "host_offline"} else "failed"
+        run.error = code[:1000]
+        run.completed_at = now_utc()
+        await db.flush()
+        return run
+    except Exception as exc:  # noqa: BLE001
+        run.status = "failed"
+        run.error = str(exc)[:1000]
+        run.completed_at = now_utc()
+        await db.flush()
+        return run
+
+    run.status = "dispatched"
+    run.error = None
+    run.completed_at = now_utc()
+    await db.flush()
+    return run
+
+
+async def process_due_schedules_once(worker_id: str | None = None, limit: int = 25) -> int:
+    worker = worker_id or f"{socket.gethostname()}:{os.getpid()}"
+    now = now_utc()
+    lease_until = now + datetime.timedelta(seconds=60)
+    processed = 0
+
+    async with async_session() as db:
+        rows = (
+            await db.execute(
+                select(AgentSchedule)
+                .where(
+                    AgentSchedule.enabled.is_(True),
+                    AgentSchedule.next_fire_at.is_not(None),
+                    AgentSchedule.next_fire_at <= now,
+                    or_(AgentSchedule.locked_until.is_(None), AgentSchedule.locked_until < now),
+                )
+                .order_by(AgentSchedule.next_fire_at, AgentSchedule.id)
+                .limit(limit)
+            )
+        ).scalars().all()
+
+        for candidate in rows:
+            result = await db.execute(
+                update(AgentSchedule)
+                .where(
+                    AgentSchedule.id == candidate.id,
+                    AgentSchedule.enabled.is_(True),
+                    AgentSchedule.next_fire_at == candidate.next_fire_at,
+                    or_(AgentSchedule.locked_until.is_(None), AgentSchedule.locked_until < now),
+                )
+                .values(locked_until=lease_until, locked_by=worker)
+            )
+            if result.rowcount != 1:
+                continue
+            await db.commit()
+
+            schedule = await db.get(AgentSchedule, candidate.id)
+            if schedule is None or schedule.next_fire_at is None:
+                continue
+            scheduled_for = aware(schedule.next_fire_at) or now
+            await dispatch_schedule_run(db, schedule=schedule, scheduled_for=scheduled_for)
+            schedule.last_fire_at = now_utc()
+            schedule.next_fire_at = compute_next_fire_at(schedule.schedule_json, base=now_utc())
+            schedule.locked_until = None
+            schedule.locked_by = None
+            await db.commit()
+            processed += 1
+
+    return processed
+
+
+async def agent_schedule_loop(interval_seconds: int = 10) -> None:
+    while True:
+        try:
+            await process_due_schedules_once()
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            logger.exception("agent schedule loop failed")
+        await asyncio.sleep(interval_seconds)
+
+
+def start_background_schedule_run(coro: Any) -> None:
+    task = asyncio.create_task(coro)
+    _BACKGROUND_RUNS.add(task)
+    task.add_done_callback(_BACKGROUND_RUNS.discard)

--- a/backend/migrations/003_agent_schedules.sql
+++ b/backend/migrations/003_agent_schedules.sql
@@ -1,0 +1,46 @@
+CREATE TABLE IF NOT EXISTS agent_schedules (
+  id text PRIMARY KEY,
+  agent_id varchar(32) NOT NULL REFERENCES agents(agent_id) ON DELETE CASCADE,
+  user_id uuid NULL,
+  name varchar(80) NOT NULL,
+  enabled boolean NOT NULL DEFAULT true,
+  schedule_json json NOT NULL,
+  payload_json json NOT NULL,
+  created_by varchar(16) NOT NULL DEFAULT 'owner',
+  next_fire_at timestamptz NULL,
+  last_fire_at timestamptz NULL,
+  locked_until timestamptz NULL,
+  locked_by varchar(64) NULL,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now(),
+  CONSTRAINT uq_agent_schedules_agent_name UNIQUE (agent_id, name)
+);
+
+CREATE INDEX IF NOT EXISTS ix_agent_schedules_due
+  ON agent_schedules(enabled, next_fire_at);
+
+CREATE INDEX IF NOT EXISTS ix_agent_schedules_agent
+  ON agent_schedules(agent_id);
+
+CREATE INDEX IF NOT EXISTS ix_agent_schedules_user
+  ON agent_schedules(user_id);
+
+CREATE TABLE IF NOT EXISTS agent_schedule_runs (
+  id text PRIMARY KEY,
+  schedule_id text NOT NULL REFERENCES agent_schedules(id) ON DELETE CASCADE,
+  agent_id varchar(32) NOT NULL REFERENCES agents(agent_id) ON DELETE CASCADE,
+  scheduled_for timestamptz NOT NULL,
+  started_at timestamptz NULL,
+  completed_at timestamptz NULL,
+  status varchar(24) NOT NULL DEFAULT 'queued',
+  error text NULL,
+  dedupe_key varchar(128) NOT NULL,
+  created_at timestamptz DEFAULT now(),
+  CONSTRAINT uq_agent_schedule_runs_dedupe_key UNIQUE (dedupe_key)
+);
+
+CREATE INDEX IF NOT EXISTS ix_agent_schedule_runs_schedule
+  ON agent_schedule_runs(schedule_id, scheduled_for);
+
+CREATE INDEX IF NOT EXISTS ix_agent_schedule_runs_agent
+  ON agent_schedule_runs(agent_id, scheduled_for);

--- a/backend/tests/test_app/test_agent_schedules.py
+++ b/backend/tests/test_app/test_agent_schedules.py
@@ -1,0 +1,138 @@
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from hub.models import AgentSchedule
+
+from .test_app_user_agents import client, db_engine, db_session, seed_user  # noqa: F401
+
+
+@pytest.mark.asyncio
+async def test_dashboard_can_create_patch_run_and_delete_schedule(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    seed_user: dict,
+):
+    token = seed_user["token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    create_resp = await client.post(
+        "/api/agents/ag_agent001/schedules",
+        headers=headers,
+        json={
+            "name": "botcord-auto",
+            "enabled": True,
+            "schedule": {"kind": "every", "every_ms": 300000},
+            "payload": {
+                "kind": "agent_turn",
+                "message": "【BotCord 自主任务】执行本轮工作目标。",
+            },
+        },
+    )
+    assert create_resp.status_code == 201
+    created = create_resp.json()
+    assert created["name"] == "botcord-auto"
+    assert created["schedule"]["every_ms"] == 300000
+    assert created["next_fire_at"]
+
+    list_resp = await client.get("/api/agents/ag_agent001/schedules", headers=headers)
+    assert list_resp.status_code == 200
+    assert [row["id"] for row in list_resp.json()["schedules"]] == [created["id"]]
+
+    patch_resp = await client.patch(
+        f"/api/agents/ag_agent001/schedules/{created['id']}",
+        headers=headers,
+        json={"enabled": False},
+    )
+    assert patch_resp.status_code == 200
+    assert patch_resp.json()["enabled"] is False
+    assert patch_resp.json()["next_fire_at"] is None
+
+    run_resp = await client.post(
+        f"/api/agents/ag_agent001/schedules/{created['id']}/run",
+        headers=headers,
+    )
+    assert run_resp.status_code == 200
+    run = run_resp.json()
+    assert run["status"] == "failed"
+    assert run["error"] == "agent_not_hosted"
+
+    runs_resp = await client.get(
+        f"/api/agents/ag_agent001/schedules/{created['id']}/runs",
+        headers=headers,
+    )
+    assert runs_resp.status_code == 200
+    assert runs_resp.json()["runs"][0]["id"] == run["id"]
+
+    delete_resp = await client.delete(
+        f"/api/agents/ag_agent001/schedules/{created['id']}",
+        headers=headers,
+    )
+    assert delete_resp.status_code == 204
+    remaining = (await db_session.execute(select(AgentSchedule))).scalars().all()
+    assert remaining == []
+
+
+@pytest.mark.asyncio
+async def test_schedule_rejects_too_short_interval(
+    client: AsyncClient,
+    seed_user: dict,
+):
+    resp = await client.post(
+        "/api/agents/ag_agent001/schedules",
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+        json={
+            "name": "too-fast",
+            "enabled": True,
+            "schedule": {"kind": "every", "every_ms": 60000},
+            "payload": {"kind": "agent_turn", "message": "tick"},
+        },
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "schedule_interval_too_short"
+
+
+@pytest.mark.asyncio
+async def test_manual_run_records_failed_ack(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    seed_user: dict,
+    monkeypatch,
+):
+    import hub.routers.openclaw_control as openclaw_control
+
+    async def fake_send_host_control_frame(*_args, **_kwargs):
+        return {
+            "id": "frame_1",
+            "ok": False,
+            "error": {"code": "agent_not_loaded", "message": "not loaded"},
+        }
+
+    monkeypatch.setattr(openclaw_control, "send_host_control_frame", fake_send_host_control_frame)
+    seed_user["agent1"].hosting_kind = "plugin"
+    seed_user["agent1"].openclaw_host_id = "oc_test"
+    await db_session.commit()
+
+    headers = {"Authorization": f"Bearer {seed_user['token']}"}
+    create_resp = await client.post(
+        "/api/agents/ag_agent001/schedules",
+        headers=headers,
+        json={
+            "name": "botcord-auto",
+            "enabled": True,
+            "schedule": {"kind": "every", "every_ms": 300000},
+            "payload": {"kind": "agent_turn", "message": "tick"},
+        },
+    )
+    assert create_resp.status_code == 201
+    schedule_id = create_resp.json()["id"]
+
+    run_resp = await client.post(
+        f"/api/agents/ag_agent001/schedules/{schedule_id}/run",
+        headers=headers,
+    )
+    assert run_resp.status_code == 200
+    body = run_resp.json()
+    assert body["status"] == "failed"
+    assert body["error"] == "agent_not_loaded: not loaded"

--- a/frontend/src/components/dashboard/AgentSchedulesTab.tsx
+++ b/frontend/src/components/dashboard/AgentSchedulesTab.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Clock, Loader2, Pause, Play, Plus, RefreshCw, Trash2 } from "lucide-react";
+import { userApi } from "@/lib/api";
+
+interface AgentSchedulesTabProps {
+  agentId: string;
+}
+
+interface AgentSchedule {
+  id: string;
+  name: string;
+  enabled: boolean;
+  schedule: { kind: "every"; every_ms: number };
+  payload: { kind: "agent_turn"; message: string };
+  created_by: string;
+  next_fire_at?: string | null;
+  last_fire_at?: string | null;
+}
+
+interface AgentScheduleRun {
+  id: string;
+  status: string;
+  error?: string | null;
+  scheduled_for: string;
+  completed_at?: string | null;
+}
+
+const DEFAULT_MESSAGE = "【BotCord 自主任务】执行本轮工作目标。";
+
+function formatTime(value?: string | null): string {
+  if (!value) return "未安排";
+  return new Intl.DateTimeFormat(undefined, {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+function intervalLabel(ms: number): string {
+  const minutes = Math.round(ms / 60000);
+  if (minutes < 60) return `${minutes} 分钟`;
+  const hours = minutes / 60;
+  if (Number.isInteger(hours)) return `${hours} 小时`;
+  return `${hours.toFixed(1)} 小时`;
+}
+
+function statusClass(status?: string): string {
+  if (status === "dispatched") return "border-green-400/20 bg-green-400/10 text-green-300";
+  if (status === "offline") return "border-yellow-400/20 bg-yellow-400/10 text-yellow-300";
+  if (status === "failed") return "border-red-400/20 bg-red-400/10 text-red-300";
+  return "border-glass-border bg-glass-bg/60 text-text-secondary";
+}
+
+export default function AgentSchedulesTab({ agentId }: AgentSchedulesTabProps) {
+  const [schedules, setSchedules] = useState<AgentSchedule[]>([]);
+  const [runsBySchedule, setRunsBySchedule] = useState<Record<string, AgentScheduleRun[]>>({});
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [name, setName] = useState("botcord-auto");
+  const [everyMinutes, setEveryMinutes] = useState(30);
+  const [message, setMessage] = useState(DEFAULT_MESSAGE);
+
+  const canCreate = useMemo(
+    () => name.trim().length > 0 && everyMinutes >= 5 && message.trim().length > 0 && !saving,
+    [everyMinutes, message, name, saving],
+  );
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await userApi.listAgentSchedules(agentId);
+      const rows = (data.schedules || []) as AgentSchedule[];
+      setSchedules(rows);
+      const runPairs = await Promise.all(
+        rows.map(async (row) => {
+          try {
+            const res = await userApi.listAgentScheduleRuns(agentId, row.id);
+            return [row.id, (res.runs || []) as AgentScheduleRun[]] as const;
+          } catch {
+            return [row.id, []] as const;
+          }
+        }),
+      );
+      setRunsBySchedule(Object.fromEntries(runPairs));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "读取 schedule 失败");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agentId]);
+
+  async function createSchedule() {
+    if (!canCreate) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await userApi.createAgentSchedule(agentId, {
+        name: name.trim(),
+        enabled: true,
+        schedule: { kind: "every", every_ms: everyMinutes * 60 * 1000 },
+        payload: { kind: "agent_turn", message: message.trim() },
+      });
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "创建失败");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function patchSchedule(scheduleId: string, body: Parameters<typeof userApi.updateAgentSchedule>[2]) {
+    setSaving(true);
+    setError(null);
+    try {
+      await userApi.updateAgentSchedule(agentId, scheduleId, body);
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "保存失败");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function deleteSchedule(scheduleId: string) {
+    setSaving(true);
+    setError(null);
+    try {
+      await userApi.deleteAgentSchedule(agentId, scheduleId);
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "删除失败");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function runSchedule(scheduleId: string) {
+    setSaving(true);
+    setError(null);
+    try {
+      await userApi.runAgentSchedule(agentId, scheduleId);
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "运行失败");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold text-text-primary">自主执行</h3>
+          <p className="text-xs text-text-secondary">配置 Agent 定期主动推进目标。</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void load()}
+          disabled={loading}
+          className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-glass-border bg-glass-bg text-text-secondary hover:text-text-primary disabled:opacity-60"
+          title="刷新"
+        >
+          {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+        </button>
+      </div>
+
+      {error ? (
+        <div className="rounded-xl border border-red-400/20 bg-red-400/5 px-4 py-3 text-sm text-red-300">
+          {error}
+        </div>
+      ) : null}
+
+      <section className="rounded-xl border border-glass-border bg-glass-bg/40 p-4">
+        <div className="mb-3 flex items-center gap-2 text-sm font-medium text-text-primary">
+          <Plus className="h-4 w-4" />
+          新建 schedule
+        </div>
+        <div className="grid gap-3">
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="rounded-lg border border-glass-border bg-deep-black/40 px-3 py-2 text-sm text-text-primary outline-none focus:border-neon-cyan/50"
+            placeholder="名称"
+          />
+          <label className="grid gap-1 text-xs text-text-secondary">
+            间隔分钟
+            <input
+              type="number"
+              min={5}
+              step={5}
+              value={everyMinutes}
+              onChange={(e) => setEveryMinutes(Number(e.target.value))}
+              className="rounded-lg border border-glass-border bg-deep-black/40 px-3 py-2 text-sm text-text-primary outline-none focus:border-neon-cyan/50"
+            />
+          </label>
+          <textarea
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            rows={3}
+            className="resize-none rounded-lg border border-glass-border bg-deep-black/40 px-3 py-2 text-sm text-text-primary outline-none focus:border-neon-cyan/50"
+          />
+          <button
+            type="button"
+            onClick={() => void createSchedule()}
+            disabled={!canCreate}
+            className="inline-flex items-center justify-center gap-2 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-2 text-sm font-semibold text-neon-cyan hover:bg-neon-cyan/20 disabled:opacity-60"
+          >
+            {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+            创建
+          </button>
+        </div>
+      </section>
+
+      {schedules.length === 0 && !loading ? (
+        <div className="rounded-xl border border-glass-border bg-glass-bg/40 px-4 py-8 text-center text-sm text-text-secondary">
+          暂无 schedule
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {schedules.map((schedule) => {
+            const lastRun = runsBySchedule[schedule.id]?.[0];
+            return (
+              <section key={schedule.id} className="rounded-xl border border-glass-border bg-glass-bg/40 p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <Clock className="h-4 w-4 text-text-secondary" />
+                      <h4 className="truncate text-sm font-semibold text-text-primary">{schedule.name}</h4>
+                      <span className={`rounded border px-1.5 py-0.5 text-[10px] ${schedule.enabled ? "border-green-400/20 text-green-300" : "border-glass-border text-text-secondary"}`}>
+                        {schedule.enabled ? "启用" : "暂停"}
+                      </span>
+                    </div>
+                    <p className="mt-1 text-xs text-text-secondary">
+                      每 {intervalLabel(schedule.schedule.every_ms)} · 下次 {formatTime(schedule.next_fire_at)}
+                    </p>
+                    <p className="mt-2 line-clamp-2 text-xs text-text-secondary">{schedule.payload.message}</p>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-1">
+                    <button
+                      type="button"
+                      onClick={() => void patchSchedule(schedule.id, { enabled: !schedule.enabled })}
+                      disabled={saving}
+                      className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-glass-border bg-deep-black/40 text-text-secondary hover:text-text-primary disabled:opacity-60"
+                      title={schedule.enabled ? "暂停" : "恢复"}
+                    >
+                      {schedule.enabled ? <Pause className="h-3.5 w-3.5" /> : <Play className="h-3.5 w-3.5" />}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => void runSchedule(schedule.id)}
+                      disabled={saving}
+                      className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-glass-border bg-deep-black/40 text-text-secondary hover:text-text-primary disabled:opacity-60"
+                      title="立即运行"
+                    >
+                      <RefreshCw className="h-3.5 w-3.5" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => void deleteSchedule(schedule.id)}
+                      disabled={saving}
+                      className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-red-400/30 bg-red-500/10 text-red-300 hover:bg-red-500/20 disabled:opacity-60"
+                      title="删除"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                </div>
+                {lastRun ? (
+                  <div className={`mt-3 rounded-lg border px-3 py-2 text-xs ${statusClass(lastRun.status)}`}>
+                    最近运行：{lastRun.status} · {formatTime(lastRun.completed_at || lastRun.scheduled_for)}
+                    {lastRun.error ? ` · ${lastRun.error}` : ""}
+                  </div>
+                ) : null}
+              </section>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/AgentSettingsDrawer.tsx
+++ b/frontend/src/components/dashboard/AgentSettingsDrawer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { FileText, Loader2, MessageSquare, Plug, RefreshCw, Settings, Trash2, User, X } from "lucide-react";
+import { Clock, FileText, Loader2, MessageSquare, Plug, RefreshCw, Trash2, User, X } from "lucide-react";
 import { userApi } from "@/lib/api";
 import { useLanguage } from "@/lib/i18n";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
@@ -15,6 +15,7 @@ import {
 } from "@/store/usePolicyStore";
 import UnbindAgentDialog from "./UnbindAgentDialog";
 import AgentChannelsTab from "./AgentChannelsTab";
+import AgentSchedulesTab from "./AgentSchedulesTab";
 
 interface AgentSettingsDrawerProps {
   agentId: string;
@@ -44,7 +45,7 @@ const ATTENTION_OPTIONS: { value: AttentionMode; label: string; hint: string }[]
   { value: "muted", label: "静音", hint: "群聊不主动回复" },
 ];
 
-type Tab = "profile" | "policy" | "gateways" | "files";
+type Tab = "profile" | "policy" | "schedules" | "gateways" | "files";
 
 interface AgentRuntimeFile {
   id: string;
@@ -344,7 +345,7 @@ export default function AgentSettingsDrawer({
 
         {/* Tabs */}
         <div className="flex border-b border-glass-border/60 px-4">
-          {(["profile", "policy", "gateways", "files"] as Tab[]).map((t) => (
+          {(["profile", "policy", "schedules", "gateways", "files"] as Tab[]).map((t) => (
             <button
               key={t}
               type="button"
@@ -361,6 +362,8 @@ export default function AgentSettingsDrawer({
                 <MessageSquare className="h-3.5 w-3.5" />
               ) : t === "gateways" ? (
                 <Plug className="h-3.5 w-3.5" />
+              ) : t === "schedules" ? (
+                <Clock className="h-3.5 w-3.5" />
               ) : (
                 <FileText className="h-3.5 w-3.5" />
               )}
@@ -368,9 +371,11 @@ export default function AgentSettingsDrawer({
                 ? "资料"
                 : t === "policy"
                   ? "对话与回复"
-                  : t === "gateways"
-                    ? "接入"
-                    : "文件/记忆"}
+                  : t === "schedules"
+                    ? "自主"
+                    : t === "gateways"
+                      ? "接入"
+                      : "文件/记忆"}
             </button>
           ))}
         </div>
@@ -560,6 +565,8 @@ export default function AgentSettingsDrawer({
           )}
 
           {tab === "gateways" && <AgentChannelsTab agentId={agentId} />}
+
+          {tab === "schedules" && <AgentSchedulesTab agentId={agentId} />}
 
           {tab === "files" && (
             <div className="space-y-4">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -924,6 +924,56 @@ const userApi = {
     }
     return result;
   },
+
+  listAgentSchedules(agentId: string): Promise<{ schedules: any[] }> {
+    return apiGet<{ schedules: any[] }>(`/api/agents/${encodeURIComponent(agentId)}/schedules`);
+  },
+
+  createAgentSchedule(
+    agentId: string,
+    body: {
+      name: string;
+      enabled: boolean;
+      schedule: { kind: "every"; every_ms: number };
+      payload: { kind: "agent_turn"; message: string };
+    },
+  ): Promise<any> {
+    return apiPost<any>(`/api/agents/${encodeURIComponent(agentId)}/schedules`, body);
+  },
+
+  updateAgentSchedule(
+    agentId: string,
+    scheduleId: string,
+    body: {
+      name?: string;
+      enabled?: boolean;
+      schedule?: { kind: "every"; every_ms: number };
+      payload?: { kind: "agent_turn"; message: string };
+    },
+  ): Promise<any> {
+    return apiPatch<any>(
+      `/api/agents/${encodeURIComponent(agentId)}/schedules/${encodeURIComponent(scheduleId)}`,
+      body,
+    );
+  },
+
+  deleteAgentSchedule(agentId: string, scheduleId: string): Promise<void> {
+    return apiDelete<void>(
+      `/api/agents/${encodeURIComponent(agentId)}/schedules/${encodeURIComponent(scheduleId)}`,
+    );
+  },
+
+  runAgentSchedule(agentId: string, scheduleId: string): Promise<any> {
+    return apiPost<any>(
+      `/api/agents/${encodeURIComponent(agentId)}/schedules/${encodeURIComponent(scheduleId)}/run`,
+    );
+  },
+
+  listAgentScheduleRuns(agentId: string, scheduleId: string): Promise<{ runs: any[] }> {
+    return apiGet<{ runs: any[] }>(
+      `/api/agents/${encodeURIComponent(agentId)}/schedules/${encodeURIComponent(scheduleId)}/runs`,
+    );
+  },
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/__tests__/provision.test.ts
+++ b/packages/daemon/src/__tests__/provision.test.ts
@@ -104,6 +104,7 @@ interface FakeGateway {
   upsertManagedRoute: ReturnType<typeof vi.fn>;
   removeManagedRoute: ReturnType<typeof vi.fn>;
   replaceManagedRoutes: ReturnType<typeof vi.fn>;
+  injectInbound: ReturnType<typeof vi.fn>;
   listManagedRoutes: () => GatewayRoute[];
   snapshot: () => GatewayRuntimeSnapshot;
 }
@@ -128,6 +129,7 @@ function makeFakeGateway(initialChannelIds: string[] = []): FakeGateway {
       managed.clear();
       for (const [id, route] of routes) managed.set(id, route);
     }),
+    injectInbound: vi.fn(async () => {}),
     listManagedRoutes: (): GatewayRoute[] => Array.from(managed.values()),
     snapshot: (): GatewayRuntimeSnapshot => ({
       channels: Object.fromEntries(
@@ -248,6 +250,49 @@ describe("list_agent_files handler", () => {
       if (prevHome === undefined) delete process.env.HOME;
       else process.env.HOME = prevHome;
     }
+  });
+});
+
+describe("wake_agent handler", () => {
+  it("injects a scheduled turn into the gateway dispatcher", async () => {
+    const gw = makeFakeGateway(["ag_wake"]);
+    const handler = createProvisioner({ gateway: gw as any });
+    const res = await handler({
+      id: "req_wake",
+      type: "wake_agent",
+      params: {
+        agent_id: "ag_wake",
+        message: "【BotCord 自主任务】执行本轮工作目标。",
+        run_id: "sr_test",
+        schedule_id: "sch_test",
+        dedupe_key: "sch_test:1:auto",
+      },
+    });
+
+    expect(res.ok).toBe(true);
+    expect(gw.injectInbound).toHaveBeenCalledTimes(1);
+    const msg = gw.injectInbound.mock.calls[0][0];
+    expect(msg.id).toBe("sr_test");
+    expect(msg.channel).toBe("ag_wake");
+    expect(msg.accountId).toBe("ag_wake");
+    expect(msg.sender.id).toBe("hub");
+    expect(msg.sender.kind).toBe("system");
+    expect(msg.text).toContain("BotCord 自主任务");
+    expect(msg.conversation.threadId).toBe("sch_test");
+  });
+
+  it("rejects wake_agent for an unloaded agent", async () => {
+    const gw = makeFakeGateway(["ag_loaded"]);
+    const handler = createProvisioner({ gateway: gw as any });
+    const res = await handler({
+      id: "req_wake_missing",
+      type: "wake_agent",
+      params: { agent_id: "ag_missing", message: "tick" },
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.error?.code).toBe("agent_not_loaded");
+    expect(gw.injectInbound).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/daemon/src/__tests__/working-memory.test.ts
+++ b/packages/daemon/src/__tests__/working-memory.test.ts
@@ -207,6 +207,15 @@ describe("buildWorkingMemoryPrompt", () => {
     expect(p).toContain("currently empty");
   });
 
+  it("instructs agents to persist cross-room handoffs", () => {
+    const p = wm.buildWorkingMemoryPrompt({ workingMemory: null });
+    expect(p).toContain("For cross-room work");
+    expect(p).toContain("pending_tasks");
+    expect(p).toContain("source room");
+    expect(p).toContain("target room");
+    expect(p).toContain("where to report completion");
+  });
+
   it("renders goal + named sections", () => {
     const p = wm.buildWorkingMemoryPrompt({
       workingMemory: {
@@ -237,4 +246,3 @@ describe("buildWorkingMemoryPrompt", () => {
     expect(p).toContain("‹current_memory›");
   });
 });
-

--- a/packages/daemon/src/gateway/gateway.ts
+++ b/packages/daemon/src/gateway/gateway.ts
@@ -261,4 +261,13 @@ export class Gateway {
     const idx = this.config.channels.findIndex((c) => c.id === id);
     if (idx >= 0) this.config.channels.splice(idx, 1);
   }
+
+  /**
+   * Inject a daemon-internal inbound message into the normal dispatcher.
+   * Control-plane wakeups use this path so scheduled turns share the same
+   * routing, queueing, transcript, and runtime behavior as channel messages.
+   */
+  async injectInbound(message: GatewayInboundMessage): Promise<void> {
+    await this.dispatcher.handle({ message });
+  }
 }

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -28,6 +28,7 @@ import {
   type UpdateAgentParams,
 } from "@botcord/protocol-core";
 import type { Gateway } from "./gateway/index.js";
+import type { GatewayInboundMessage } from "./gateway/index.js";
 import type { PolicyResolverLike } from "./gateway/policy-resolver.js";
 import type { PolicyUpdatedParams } from "@botcord/protocol-core";
 import type {
@@ -398,6 +399,10 @@ export function createProvisioner(opts: ProvisionerOptions): (
         return { ok: true, result };
       }
 
+      case "wake_agent": {
+        return handleWakeAgent(gateway, frame.params);
+      }
+
       default:
         daemonLog.warn("provision.dispatch: unknown frame type", {
           type: frame.type,
@@ -409,6 +414,87 @@ export function createProvisioner(opts: ProvisionerOptions): (
         };
     }
   };
+}
+
+interface WakeAgentParams {
+  agent_id?: string;
+  agentId?: string;
+  message?: string;
+  run_id?: string;
+  runId?: string;
+  schedule_id?: string;
+  scheduleId?: string;
+  dedupe_key?: string;
+  dedupeKey?: string;
+}
+
+async function handleWakeAgent(gateway: Gateway, raw: unknown): Promise<AckBody> {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    return {
+      ok: false,
+      error: { code: "bad_params", message: "wake_agent params must be an object" },
+    };
+  }
+  const params = raw as WakeAgentParams;
+  const agentId = params.agent_id || params.agentId;
+  const message = params.message;
+  if (!agentId || typeof agentId !== "string") {
+    return {
+      ok: false,
+      error: { code: "bad_params", message: "wake_agent requires params.agent_id" },
+    };
+  }
+  if (!message || typeof message !== "string") {
+    return {
+      ok: false,
+      error: { code: "bad_params", message: "wake_agent requires params.message" },
+    };
+  }
+
+  const channels = gateway.snapshot().channels;
+  if (!channels[agentId]) {
+    return {
+      ok: false,
+      error: { code: "agent_not_loaded", message: `agent ${agentId} is not loaded in daemon gateway` },
+    };
+  }
+
+  const runId = params.run_id || params.runId || `wake-${Date.now()}`;
+  const scheduleId = params.schedule_id || params.scheduleId;
+  const dedupeKey = params.dedupe_key || params.dedupeKey;
+  const conversationId = `rm_schedule_${agentId}`;
+  const msg: GatewayInboundMessage = {
+    id: runId,
+    channel: agentId,
+    accountId: agentId,
+    conversation: {
+      id: conversationId,
+      kind: "direct",
+      title: "BotCord Scheduler",
+      threadId: scheduleId ?? null,
+    },
+    sender: {
+      id: "hub",
+      name: "BotCord Scheduler",
+      kind: "system",
+    },
+    text: message,
+    raw: {
+      source_type: "botcord_schedule",
+      schedule_id: scheduleId,
+      run_id: runId,
+      dedupe_key: dedupeKey,
+    },
+    mentioned: true,
+    receivedAt: Date.now(),
+    trace: {
+      id: runId,
+      streamable: false,
+    },
+  };
+
+  await gateway.injectInbound(msg);
+  return { ok: true, result: { agent_id: agentId } };
 }
 
 // W8: hand-written runtime validator for the third-party gateway frame

--- a/packages/daemon/src/working-memory.ts
+++ b/packages/daemon/src/working-memory.ts
@@ -307,6 +307,11 @@ export function buildWorkingMemoryPrompt(opts: {
     "- sections: named buckets (contacts, pending_tasks, preferences, etc.).",
     "- Updating one section never touches others. Empty content deletes a section.",
     "",
+    "For cross-room work, update memory before or immediately after delegating:",
+    "- If you accept a request in one room and continue it in another, record a `pending_tasks` entry with source room id/name, target room id/name, requested deliverable, current status, and where to report completion.",
+    "- When a delegated room replies or delivers an artifact, consult `pending_tasks` before deciding `NO_REPLY`; if it matches a pending handoff, acknowledge, update status, and send the promised follow-up to the source room when appropriate.",
+    "- Remove or mark the entry done once the source room has been updated.",
+    "",
     "Only update when something meaningful changes. Keep each section tight.",
   ];
 

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -18,6 +18,7 @@ import { createRegisterTool } from "./src/tools/register.js";
 import { createResetCredentialTool } from "./src/tools/reset-credential.js";
 import { createWorkingMemoryTool } from "./src/tools/working-memory.js";
 import { createApiTool } from "./src/tools/api.js";
+import { createScheduleTool } from "./src/tools/schedule.js";
 import { createHealthcheckCommand } from "./src/commands/healthcheck.js";
 import { createTokenCommand } from "./src/commands/token.js";
 import { createBindCommand } from "./src/commands/bind.js";
@@ -72,6 +73,7 @@ export default {
     api.registerTool(createResetCredentialTool() as any);
     api.registerTool(createWorkingMemoryTool() as any);
     api.registerTool(createApiTool() as any);
+    api.registerTool(createScheduleTool() as any);
 
     // Hooks
     api.on("after_tool_call", async (event: any, ctx: any) => {

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.3.8",
       "license": "MIT",
       "dependencies": {
+        "@botcord/protocol-core": "^0.1.0",
         "ws": "^8.18.0"
       },
       "devDependencies": {
@@ -868,6 +869,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@botcord/protocol-core": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@botcord/protocol-core/-/protocol-core-0.1.1.tgz",
+      "integrity": "sha512-qxbiavALKS7ecxw/DG3kXNxEgknvw7th+TUvapxKVuI87PCbGRnPL6kEOdNesJwj9h0lGyDtDnv3LIBfz9Y3Gw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@clack/core": {

--- a/plugin/src/host-control.ts
+++ b/plugin/src/host-control.ts
@@ -30,6 +30,9 @@ import {
   jcsCanonicalize,
   signChallenge,
 } from "@botcord/protocol-core";
+import { getConfig } from "./runtime.js";
+import { resolveAccounts } from "./config.js";
+import { dispatchInbound } from "./inbound.js";
 
 // Inline minimal types + helpers — the published `@botcord/protocol-core`
 // (v0.1.x) doesn't yet ship the control-frame schemas; this duplicates
@@ -497,6 +500,53 @@ export async function handleControlFrame(
       // Best-effort: agent credentials cleanup is left to the user /
       // dashboard for now; the host just acks so Hub doesn't retry.
       return { ok: true };
+    }
+    case "wake_agent": {
+      const params = (frame.params ?? {}) as {
+        agent_id?: string;
+        message?: string;
+        run_id?: string;
+        schedule_id?: string;
+      };
+      if (!params.agent_id || !params.message) {
+        return {
+          ok: false,
+          error: { code: "bad_params", message: "agent_id and message required" },
+        };
+      }
+      try {
+        const cfg = getConfig();
+        const accounts = resolveAccounts((cfg?.channels?.botcord ?? {}) as any);
+        const entry = Object.entries(accounts).find(([, account]) => account.agentId === params.agent_id)
+          ?? Object.entries(accounts).find(([accountId]) => accountId === params.agent_id);
+        if (!cfg || !entry) {
+          return {
+            ok: false,
+            error: { code: "agent_not_loaded", message: "BotCord account is not loaded in OpenClaw config" },
+          };
+        }
+        const [accountId] = entry;
+        await dispatchInbound({
+          cfg,
+          accountId,
+          senderName: "BotCord Scheduler",
+          senderId: "hub",
+          senderKind: "agent",
+          content: params.message,
+          messageId: params.run_id || `schedule-${Date.now()}`,
+          messageType: "message" as any,
+          chatType: "direct",
+          replyTarget: "hub",
+          roomId: `rm_schedule_${params.agent_id}`,
+          topic: params.schedule_id,
+          mentioned: true,
+        });
+        return { ok: true, result: { agent_id: params.agent_id } };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        ctx.log("warn", `wake_agent failed: ${message}`);
+        return { ok: false, error: { code: "wake_failed", message } };
+      }
     }
     case "set_route":
       return { ok: true };

--- a/plugin/src/inbound.ts
+++ b/plugin/src/inbound.ts
@@ -341,7 +341,8 @@ async function handleA2AMessage(
   const chatType = isGroupRoom ? "group" : "direct";
 
   // Human sender: dashboard_human_room source type OR hu_* ID prefix
-  const isHumanSender = msg.source_type === "dashboard_human_room" || senderId.startsWith("hu_");
+  const sourceType = String(msg.source_type || "");
+  const isHumanSender = sourceType === "dashboard_human_room" || senderId.startsWith("hu_");
   const senderKind: "human" | "agent" = isHumanSender ? "human" : "agent";
   const sanitizedSender = isHumanSender
     ? sanitizeSenderName(msg.source_user_name || "User")
@@ -417,7 +418,8 @@ async function handleA2AMessageBatch(
         ? envelope.payload
         : (envelope.payload?.text as string) ?? JSON.stringify(envelope.payload));
 
-    const isHumanSender = msg.source_type === "dashboard_human_room" || senderId.startsWith("hu_");
+    const sourceType = String(msg.source_type || "");
+    const isHumanSender = sourceType === "dashboard_human_room" || senderId.startsWith("hu_");
     const kind: "human" | "agent" = isHumanSender ? "human" : "agent";
     const sanitizedSender = isHumanSender
       ? sanitizeSenderName(msg.source_user_name || "User")
@@ -455,7 +457,8 @@ async function handleA2AMessageBatch(
   const last = msgs[msgs.length - 1];
   const lastEnvelope = last.envelope;
   const lastSenderId = lastEnvelope.from || "unknown";
-  const lastIsHuman = last.source_type === "dashboard_human_room" || lastSenderId.startsWith("hu_");
+  const lastSourceType = String(last.source_type || "");
+  const lastIsHuman = lastSourceType === "dashboard_human_room" || lastSenderId.startsWith("hu_");
 
   await dispatchInbound({
     cfg,

--- a/plugin/src/tools/schedule.ts
+++ b/plugin/src/tools/schedule.ts
@@ -1,0 +1,108 @@
+/**
+ * botcord_schedule — manage BotCord proactive schedules from the agent.
+ */
+import { withClient } from "./with-client.js";
+import { validationError } from "./tool-result.js";
+
+const DEFAULT_MESSAGE = "【BotCord 自主任务】执行本轮工作目标。";
+
+function everyMsFromArgs(args: any): number | undefined {
+  if (typeof args.everyMs === "number") return Math.trunc(args.everyMs);
+  if (typeof args.every_ms === "number") return Math.trunc(args.every_ms);
+  return undefined;
+}
+
+export function createScheduleTool() {
+  return {
+    name: "botcord_schedule",
+    label: "BotCord Schedule",
+    description:
+      "Create, list, edit, pause, delete, or manually run BotCord proactive schedules. " +
+      "Use this to configure autonomous execution after the owner has approved the cadence.",
+    parameters: {
+      type: "object" as const,
+      properties: {
+        action: {
+          type: "string" as const,
+          enum: ["list", "add", "edit", "pause", "resume", "delete", "run", "runs"],
+        },
+        scheduleId: { type: "string" as const, description: "Schedule id for edit/delete/run/runs." },
+        name: { type: "string" as const, description: "Human-readable schedule name." },
+        everyMs: { type: "number" as const, description: "Interval in milliseconds. Minimum 300000." },
+        message: {
+          type: "string" as const,
+          description: "Message used to trigger the proactive turn.",
+        },
+        confirm: {
+          type: "boolean" as const,
+          description: "Required for add/edit/pause/resume/delete/run.",
+        },
+      },
+      required: ["action"],
+    },
+    execute: async (_toolCallId: any, args: any) => {
+      const action = String(args?.action || "");
+      if (!action) return validationError("action is required");
+      const mutating = action !== "list" && action !== "runs";
+      if (mutating && !args?.confirm) {
+        return validationError("confirm=true is required for schedule mutations");
+      }
+
+      return withClient(async (client) => {
+        switch (action) {
+          case "list":
+            return { response: await client.request("GET", "/hub/schedules") };
+          case "runs": {
+            if (!args.scheduleId) return validationError("scheduleId is required");
+            return {
+              response: await client.request("GET", `/hub/schedules/${encodeURIComponent(args.scheduleId)}/runs`),
+            };
+          }
+          case "add": {
+            const everyMs = everyMsFromArgs(args);
+            if (!args.name) return validationError("name is required");
+            if (!everyMs) return validationError("everyMs is required");
+            return { response: await client.request("POST", "/hub/schedules", {
+              body: {
+                name: args.name,
+                enabled: args.enabled !== false,
+                schedule: { kind: "every", every_ms: everyMs },
+                payload: { kind: "agent_turn", message: args.message || DEFAULT_MESSAGE },
+              },
+            }) };
+          }
+          case "edit": {
+            if (!args.scheduleId) return validationError("scheduleId is required");
+            const body: Record<string, unknown> = {};
+            const everyMs = everyMsFromArgs(args);
+            if (args.name) body.name = args.name;
+            if (everyMs) body.schedule = { kind: "every", every_ms: everyMs };
+            if (args.message) body.payload = { kind: "agent_turn", message: args.message };
+            if (args.enabled !== undefined) body.enabled = Boolean(args.enabled);
+            if (Object.keys(body).length === 0) return validationError("nothing to edit");
+            return {
+              response: await client.request("PATCH", `/hub/schedules/${encodeURIComponent(args.scheduleId)}`, { body }),
+            };
+          }
+          case "pause":
+          case "resume": {
+            if (!args.scheduleId) return validationError("scheduleId is required");
+            return { response: await client.request("PATCH", `/hub/schedules/${encodeURIComponent(args.scheduleId)}`, {
+              body: { enabled: action === "resume" },
+            }) };
+          }
+          case "delete": {
+            if (!args.scheduleId) return validationError("scheduleId is required");
+            return { response: await client.request("DELETE", `/hub/schedules/${encodeURIComponent(args.scheduleId)}`) };
+          }
+          case "run": {
+            if (!args.scheduleId) return validationError("scheduleId is required");
+            return { response: await client.request("POST", `/hub/schedules/${encodeURIComponent(args.scheduleId)}/run`) };
+          }
+          default:
+            return validationError(`unsupported action: ${action}`);
+        }
+      });
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add Hub-backed agent schedules and schedule run audit records
- add dashboard and agent-facing schedule APIs plus the Hub background tick loop
- add wake_agent dispatch for OpenClaw plugin hosts and daemon-hosted agents
- add botcord_schedule tool and dashboard schedule management UI

## Tests
- cd backend && uv run python -m py_compile hub/services/agent_schedules.py hub/routers/agent_schedules.py app/routers/schedules.py
- cd backend && uv run pytest tests/test_app/test_agent_schedules.py tests/test_app/test_app_user_agents.py tests/test_app/test_install_claim.py
- cd plugin && npx tsc --noEmit
- cd plugin && npx vitest run src/__tests__/host-control.test.ts src/__tests__/inbound.user-chat.test.ts src/__tests__/inbound.human-room.test.ts src/__tests__/index.hooks.test.ts
- cd frontend && NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build
- cd packages/daemon && npm run build
- cd packages/daemon && npx vitest run src/__tests__/provision.test.ts