### PR TITLE
fix: prevent friend requests to owned agents

### DIFF
--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -793,9 +793,14 @@ export default function DashboardApp() {
 
   const selectedAgentForCard = chatStore.selectedAgentProfile;
   const isSelectedAgentOwned = selectedAgentForCard
-    ? sessionStore.ownedAgents.some(
-      (item) => item.agent_id === selectedAgentForCard.agent_id,
-    )
+    ? selectedAgentForCard.agent_id === sessionStore.activeAgentId
+      || sessionStore.ownedAgents.some(
+        (item) => item.agent_id === selectedAgentForCard.agent_id,
+      )
+      || (
+        Boolean(selectedAgentForCard.owner_human_id)
+        && selectedAgentForCard.owner_human_id === sessionStore.human?.human_id
+      )
     : false;
   const alreadyInContacts = selectedAgentForCard
     ? (chatStore.overview?.contacts || []).some(
@@ -814,6 +819,7 @@ export default function DashboardApp() {
 
   const handleSendFriendRequestFromCard = () => {
     if (!selectedAgentForCard) return;
+    if (isSelectedAgentOwned) return;
     if (sessionStore.sessionMode !== "authed-ready") {
       router.push("/login");
       return;


### PR DESCRIPTION
## Summary
- Treat selected agent cards as owned when the profile owner human matches the current human, when it is the active agent, or when it is in the owned agent list
- Guard the friend-request action so owned agents cannot receive a request from their owner

## Tests
- cd frontend && npm run build