### PR TITLE
fix: sanitize inherited runtime args

### DIFF
--- a/packages/daemon/src/gateway/__tests__/claude-code-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/claude-code-adapter.test.ts
@@ -349,5 +349,40 @@ process.stdout.write(JSON.stringify({type:"result", subtype:"success", session_i
       const modeIdx = argv.indexOf("--permission-mode");
       expect(argv[modeIdx + 1]).toBe("plan");
     });
+
+    it("drops inherited Codex-only extraArgs while preserving shared Claude flags", async () => {
+      const adapter = new ClaudeCodeAdapter({ binary: echoScript() });
+      const ctrl = new AbortController();
+      const res = await adapter.run({
+        text: "x",
+        sessionId: null,
+        accountId: "ag_test",
+        cwd: tmpRoot,
+        signal: ctrl.signal,
+        trustLevel: "public",
+        extraArgs: [
+          "-c",
+          'model="gpt-5.2"',
+          "--sandbox",
+          "read-only",
+          "--skip-git-repo-check",
+          "--json",
+          "-p",
+          "codex-profile",
+          "--model",
+          "sonnet",
+        ],
+      });
+      const argv = JSON.parse(res.text) as string[];
+      expect(argv).not.toContain("-c");
+      expect(argv).not.toContain('model="gpt-5.2"');
+      expect(argv).not.toContain("--sandbox");
+      expect(argv).not.toContain("read-only");
+      expect(argv).not.toContain("--skip-git-repo-check");
+      expect(argv).not.toContain("--json");
+      expect(argv).not.toContain("codex-profile");
+      expect(argv).toContain("--model");
+      expect(argv[argv.indexOf("--model") + 1]).toBe("sonnet");
+    });
   });
 });

--- a/packages/daemon/src/gateway/__tests__/codex-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/codex-adapter.test.ts
@@ -371,7 +371,7 @@ process.stdout.write(JSON.stringify({type:"item.completed", item:{id:"i0", type:
       expect(argv).toContain('approval_policy="never"');
     });
 
-    it("extraArgs `-s read-only` suppresses the default sandbox `-c`s", async () => {
+    it("extraArgs `-s read-only` is converted to resume-compatible sandbox config", async () => {
       const adapter = new CodexAdapter({ binary: echoScript() });
       const ctrl = new AbortController();
       const res = await adapter.run({
@@ -384,11 +384,87 @@ process.stdout.write(JSON.stringify({type:"item.completed", item:{id:"i0", type:
         extraArgs: ["-s", "read-only"],
       });
       const argv = JSON.parse(res.text) as string[];
-      // Only the operator-supplied `-s` appears; our defaults are suppressed.
-      expect(argv.filter((a) => a === "-s").length).toBe(1);
-      expect(argv[argv.indexOf("-s") + 1]).toBe("read-only");
+      expect(argv).not.toContain("-s");
+      expect(argv).toContain('sandbox_mode="read-only"');
       expect(argv).not.toContain('sandbox_mode="workspace-write"');
       expect(argv).not.toContain('sandbox_mode="danger-full-access"');
+    });
+
+    it("extraArgs `--sandbox=value` is converted on resume too", async () => {
+      const adapter = new CodexAdapter({ binary: echoScript() });
+      const ctrl = new AbortController();
+      const res = await adapter.run({
+        text: "x",
+        sessionId: "01234567-89ab-7def-8123-456789abcdef",
+        accountId: "ag_test",
+        cwd: tmpRoot,
+        signal: ctrl.signal,
+        trustLevel: "public",
+        extraArgs: ["--sandbox=workspace-write"],
+      });
+      const argv = JSON.parse(res.text) as string[];
+      expect(argv[0]).toBe("exec");
+      expect(argv[1]).toBe("resume");
+      expect(argv).not.toContain("--sandbox=workspace-write");
+      expect(argv).toContain('sandbox_mode="workspace-write"');
+      expect(argv).not.toContain('sandbox_mode="danger-full-access"');
+    });
+
+    it("maps legacy Codex --full-auto to the current bypass flag", async () => {
+      const adapter = new CodexAdapter({ binary: echoScript() });
+      const ctrl = new AbortController();
+      const res = await adapter.run({
+        text: "x",
+        sessionId: null,
+        accountId: "ag_test",
+        cwd: tmpRoot,
+        signal: ctrl.signal,
+        trustLevel: "public",
+        extraArgs: ["--full-auto"],
+      });
+      const argv = JSON.parse(res.text) as string[];
+      expect(argv).not.toContain("--full-auto");
+      expect(argv).toContain("--dangerously-bypass-approvals-and-sandbox");
+      expect(argv).not.toContain('sandbox_mode="danger-full-access"');
+    });
+
+    it("drops inherited Claude --permission-mode extraArgs and their values", async () => {
+      const adapter = new CodexAdapter({ binary: echoScript() });
+      const ctrl = new AbortController();
+      const res = await adapter.run({
+        text: "x",
+        sessionId: null,
+        accountId: "ag_test",
+        cwd: tmpRoot,
+        signal: ctrl.signal,
+        trustLevel: "public",
+        extraArgs: ["--permission-mode", "bypassPermissions", "--model", "gpt-5.2"],
+      });
+      const argv = JSON.parse(res.text) as string[];
+      expect(argv).not.toContain("--permission-mode");
+      expect(argv).not.toContain("bypassPermissions");
+      expect(argv).toContain("--model");
+      expect(argv[argv.indexOf("--model") + 1]).toBe("gpt-5.2");
+      expect(argv).toContain('sandbox_mode="danger-full-access"');
+      expect(argv).toContain('approval_policy="never"');
+    });
+
+    it("drops inherited Claude --permission-mode=value extraArgs", async () => {
+      const adapter = new CodexAdapter({ binary: echoScript() });
+      const ctrl = new AbortController();
+      const res = await adapter.run({
+        text: "x",
+        sessionId: null,
+        accountId: "ag_test",
+        cwd: tmpRoot,
+        signal: ctrl.signal,
+        trustLevel: "public",
+        extraArgs: ["--permission-mode=bypassPermissions"],
+      });
+      const argv = JSON.parse(res.text) as string[];
+      expect(argv).not.toContain("--permission-mode=bypassPermissions");
+      expect(argv).toContain('sandbox_mode="danger-full-access"');
+      expect(argv).toContain('approval_policy="never"');
     });
   });
 });

--- a/packages/daemon/src/gateway/runtimes/claude-code.ts
+++ b/packages/daemon/src/gateway/runtimes/claude-code.ts
@@ -32,6 +32,77 @@ function invalidClaudeSessionIdError(): string {
   return "claude-code: invalid sessionId (expected non-control text not starting with '-')";
 }
 
+const CLAUDE_FOREIGN_FLAGS_WITH_VALUE = new Set([
+  "--color",
+  "--config",
+  "--disable",
+  "--enable",
+  "--image",
+  "--local-provider",
+  "--output-last-message",
+  "--output-schema",
+  "--profile",
+  "--sandbox",
+  "-i",
+  "-o",
+  "-p",
+  "-s",
+]);
+const CLAUDE_FOREIGN_BOOLEAN_FLAGS = new Set([
+  "--all",
+  "--dangerously-bypass-approvals-and-sandbox",
+  "--ephemeral",
+  "--full-auto",
+  "--ignore-rules",
+  "--ignore-user-config",
+  "--json",
+  "--last",
+  "--oss",
+  "--print",
+  "--skip-git-repo-check",
+]);
+
+function extraFlagName(arg: string): string {
+  if (!arg.startsWith("-")) return arg;
+  const eq = arg.indexOf("=");
+  return eq === -1 ? arg : arg.slice(0, eq);
+}
+
+function nextExtraValue(args: string[], index: number): string | undefined {
+  const next = args[index + 1];
+  if (typeof next !== "string") return undefined;
+  if (!next.startsWith("-")) return next;
+  return /^-\d/.test(next) ? next : undefined;
+}
+
+function sanitizeClaudeExtraArgs(extraArgs: string[] | undefined): string[] {
+  if (!extraArgs?.length) return [];
+  const out: string[] = [];
+  for (let i = 0; i < extraArgs.length; i += 1) {
+    const arg = extraArgs[i];
+    const name = extraFlagName(arg);
+
+    if (arg === "-c") {
+      const value = nextExtraValue(extraArgs, i);
+      if (value !== undefined) i += 1;
+      continue;
+    }
+    if (name === "--config" || name === "--sandbox") {
+      if (!arg.includes("=") && nextExtraValue(extraArgs, i) !== undefined) i += 1;
+      continue;
+    }
+    if (CLAUDE_FOREIGN_FLAGS_WITH_VALUE.has(name)) {
+      if (!arg.includes("=") && nextExtraValue(extraArgs, i) !== undefined) i += 1;
+      continue;
+    }
+    if (CLAUDE_FOREIGN_BOOLEAN_FLAGS.has(name)) {
+      continue;
+    }
+    out.push(arg);
+  }
+  return out;
+}
+
 /** Resolve the Claude Code CLI path on PATH or the macOS desktop bundle fallback. */
 export function resolveClaudeCommand(deps: ProbeDeps = {}): string | null {
   const onPath = resolveCommandOnPath("claude", deps);
@@ -95,11 +166,12 @@ export class ClaudeCodeAdapter extends NdjsonStreamAdapter {
   }
 
   protected buildArgs(opts: RuntimeRunOptions): string[] {
+    const extraArgs = sanitizeClaudeExtraArgs(opts.extraArgs);
     const args = ["-p", opts.text, "--output-format", "stream-json", "--verbose"];
     // Headless `-p` mode does not load project `.claude/` by default, so
     // per-agent skills seeded at `<workspace>/.claude/skills/` are invisible
     // unless we opt in. `extraArgs` wins so operators can still override.
-    if (!opts.extraArgs?.some((a) => a.startsWith("--setting-sources"))) {
+    if (!extraArgs.some((a) => a.startsWith("--setting-sources"))) {
       args.push("--setting-sources", "project");
     }
     if (opts.sessionId) {
@@ -112,16 +184,16 @@ export class ClaudeCodeAdapter extends NdjsonStreamAdapter {
     // MCP) because there is no prompt relay back to the user yet. Default to
     // bypassPermissions for every trust tier; operators who need a stricter
     // posture can still override with route/defaultRoute extraArgs.
-    if (!opts.extraArgs?.some((a) => a.startsWith("--permission-mode"))) {
+    if (!extraArgs.some((a) => a.startsWith("--permission-mode"))) {
       args.push("--permission-mode", "bypassPermissions");
     }
     // Claude Code's `--append-system-prompt` is applied per invocation and NOT
     // persisted in the resumed session transcript — ideal for memory / digest
     // content that should re-evaluate every turn.
-    if (opts.systemContext && !opts.extraArgs?.includes("--append-system-prompt")) {
+    if (opts.systemContext && !extraArgs.includes("--append-system-prompt")) {
       args.push("--append-system-prompt", opts.systemContext);
     }
-    if (opts.extraArgs?.length) args.push(...opts.extraArgs);
+    if (extraArgs.length) args.push(...extraArgs);
     return args;
   }
 

--- a/packages/daemon/src/gateway/runtimes/codex.ts
+++ b/packages/daemon/src/gateway/runtimes/codex.ts
@@ -15,6 +15,69 @@ import type { RuntimeProbeResult, RuntimeRunOptions, StreamBlock } from "../type
 const CODEX_DESKTOP_BUNDLE_PATH = "/Applications/Codex.app/Contents/Resources/codex";
 /** Codex UUIDv7 / v4 session ids are 36-char dashed hex; reject anything else to keep argv safe. */
 const CODEX_SESSION_ID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+const CODEX_FOREIGN_EXTRA_FLAGS_WITH_VALUE = new Set([
+  "--append-system-prompt",
+  "--permission-mode",
+]);
+const CODEX_SANDBOX_MODES = new Set(["read-only", "workspace-write", "danger-full-access"]);
+
+function extraFlagName(arg: string): string {
+  if (!arg.startsWith("-")) return arg;
+  const eq = arg.indexOf("=");
+  return eq === -1 ? arg : arg.slice(0, eq);
+}
+
+function nextExtraValue(args: string[], index: number): string | undefined {
+  const next = args[index + 1];
+  if (typeof next !== "string") return undefined;
+  if (!next.startsWith("-")) return next;
+  return /^-\d/.test(next) ? next : undefined;
+}
+
+function sanitizeCodexExtraArgs(extraArgs: string[] | undefined): string[] {
+  if (!extraArgs?.length) return [];
+  const out: string[] = [];
+  for (let i = 0; i < extraArgs.length; i += 1) {
+    const arg = extraArgs[i];
+    const name = extraFlagName(arg);
+    if (CODEX_FOREIGN_EXTRA_FLAGS_WITH_VALUE.has(name)) {
+      if (!arg.includes("=") && nextExtraValue(extraArgs, i) !== undefined) i += 1;
+      continue;
+    }
+    if (name === "-s" || name === "--sandbox") {
+      const value = arg.includes("=") ? arg.slice(arg.indexOf("=") + 1) : nextExtraValue(extraArgs, i);
+      if (!arg.includes("=") && value !== undefined) i += 1;
+      if (value && CODEX_SANDBOX_MODES.has(value)) {
+        out.push("-c", `sandbox_mode="${value}"`);
+      }
+      continue;
+    }
+    if (arg === "--full-auto") {
+      out.push("--dangerously-bypass-approvals-and-sandbox");
+      continue;
+    }
+    out.push(arg);
+  }
+  return out;
+}
+
+function hasCodexSandboxOverride(args: string[]): boolean {
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (
+      arg === "--dangerously-bypass-approvals-and-sandbox" ||
+      arg.startsWith("-c sandbox_mode=") ||
+      arg.startsWith("-csandbox_mode=") ||
+      arg.startsWith("--config=sandbox_mode=")
+    ) {
+      return true;
+    }
+    if ((arg === "-c" || arg === "--config") && args[i + 1]?.startsWith("sandbox_mode=")) {
+      return true;
+    }
+  }
+  return false;
+}
 
 /** Resolve the Codex CLI executable via PATH or macOS desktop bundle. */
 export function resolveCodexCommand(deps: ProbeDeps = {}): string | null {
@@ -167,6 +230,7 @@ export class CodexAdapter extends NdjsonStreamAdapter {
    */
   protected buildArgs(opts: RuntimeRunOptions): string[] {
     const tail: string[] = [];
+    const extraArgs = sanitizeCodexExtraArgs(opts.extraArgs);
 
     // Sandbox / approval policy. Expressed as `-c` overrides because
     // `codex exec resume` rejects `-s` / `--full-auto`. `-c` works on both
@@ -177,16 +241,7 @@ export class CodexAdapter extends NdjsonStreamAdapter {
     // relay back to the user yet. Default to bypassing both approvals and the
     // sandbox for every trust tier; operators who need a stricter posture can
     // still override with route/defaultRoute extraArgs.
-    const hasSandboxOverride =
-      opts.extraArgs?.some(
-        (a) =>
-          a === "-s" ||
-          a.startsWith("--sandbox") ||
-          a === "--full-auto" ||
-          a === "--dangerously-bypass-approvals-and-sandbox" ||
-          a.startsWith("-c sandbox_mode=") ||
-          a.startsWith("-csandbox_mode="),
-      ) ?? false;
+    const hasSandboxOverride = hasCodexSandboxOverride(extraArgs);
     if (!hasSandboxOverride) {
       tail.push(
         "-c",
@@ -196,7 +251,7 @@ export class CodexAdapter extends NdjsonStreamAdapter {
       );
     }
     tail.push("--skip-git-repo-check", "--json");
-    if (opts.extraArgs?.length) tail.push(...opts.extraArgs);
+    if (extraArgs.length) tail.push(...extraArgs);
 
     // `--` separates flags from positionals so a prompt starting with `-`
     // can never be parsed as an option. `systemContext` is NOT prepended to


### PR DESCRIPTION
## Summary
- drop Claude-only inherited args before spawning Codex
- normalize Codex sandbox args so fresh and resume invocations both work
- drop Codex-only inherited args before spawning Claude Code

## Tests
- npm test
- npm run build