### PR TITLE
fix: stop empty room message poll loop

### DIFF
--- a/frontend/src/store/useDashboardChatStore.test.ts
+++ b/frontend/src/store/useDashboardChatStore.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DashboardOverview } from "@/lib/types";
+
+const mocks = vi.hoisted(() => ({
+  getRoomMessages: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    getRoomMessages: mocks.getRoomMessages,
+  },
+  humansApi: {},
+  getActiveAgentId: vi.fn(() => null),
+}));
+
+import { useDashboardChatStore } from "@/store/useDashboardChatStore";
+
+function makeOverview(lastMessageAt: string | null = null): DashboardOverview {
+  return {
+    agent: null,
+    viewer: {
+      type: "human",
+      id: "hu_1",
+      display_name: "Human",
+    },
+    rooms: [
+      {
+        room_id: "rm_empty",
+        name: "Empty room",
+        description: "",
+        owner_id: "ag_owner",
+        visibility: "private",
+        join_policy: "invite",
+        member_count: 1,
+        my_role: "member",
+        rule: null,
+        required_subscription_product_id: null,
+        has_unread: false,
+        last_message_preview: null,
+        last_message_at: lastMessageAt,
+        last_sender_name: null,
+      },
+    ],
+    contacts: [],
+    pending_requests: 0,
+  };
+}
+
+describe("useDashboardChatStore message polling", () => {
+  beforeEach(() => {
+    mocks.getRoomMessages.mockReset();
+    useDashboardChatStore.setState({
+      overview: makeOverview(),
+      messages: {},
+      messagesLoading: {},
+      messagesHasMore: {},
+    });
+  });
+
+  it("does not refetch a room already loaded as empty when the room snapshot is unchanged", async () => {
+    mocks.getRoomMessages.mockResolvedValue({ messages: [], has_more: false });
+
+    await useDashboardChatStore.getState().loadRoomMessages("rm_empty");
+    await useDashboardChatStore.getState().pollNewMessages("rm_empty");
+
+    expect(mocks.getRoomMessages).toHaveBeenCalledTimes(1);
+    expect(useDashboardChatStore.getState().messages.rm_empty).toEqual([]);
+  });
+
+  it("refetches an empty room after the room summary indicates a newer message", async () => {
+    mocks.getRoomMessages.mockResolvedValue({ messages: [], has_more: false });
+
+    await useDashboardChatStore.getState().loadRoomMessages("rm_empty");
+    useDashboardChatStore.setState({ overview: makeOverview("2026-05-11T08:00:00Z") });
+    await useDashboardChatStore.getState().pollNewMessages("rm_empty");
+
+    expect(mocks.getRoomMessages).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/store/useDashboardChatStore.ts
+++ b/frontend/src/store/useDashboardChatStore.ts
@@ -33,6 +33,7 @@ import { useDashboardUnreadStore } from "@/store/useDashboardUnreadStore";
 let publicRoomsRequestSeq = 0;
 let publicAgentsRequestSeq = 0;
 let publicHumansRequestSeq = 0;
+const emptyRoomMessageSnapshot = new Map<string, string | null>();
 
 function isFetchNetworkError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
@@ -63,6 +64,10 @@ function applyRealtimeRoomHint<T extends {
     last_message_preview: preview,
     last_sender_name: senderName,
   };
+}
+
+function getRoomMessageSnapshot(room: DashboardRoom | null): string | null {
+  return room?.last_message_at ?? null;
 }
 
 function ownedAgentRoomToDashboardRoom(room: HumanAgentRoomSummary): DashboardRoom {
@@ -373,6 +378,11 @@ export const useDashboardChatStore = create<DashboardChatState>()(
 
         try {
           const result = await api.getRoomMessages(roomId, { limit: 50 });
+          if (result.messages.length === 0) {
+            emptyRoomMessageSnapshot.set(roomId, getRoomMessageSnapshot(get().getRoomSummary(roomId)));
+          } else {
+            emptyRoomMessageSnapshot.delete(roomId);
+          }
           set((state) => ({
             messages: { ...state.messages, [roomId]: result.messages.reverse() },
             messagesHasMore: { ...state.messagesHasMore, [roomId]: result.has_more },
@@ -396,8 +406,14 @@ export const useDashboardChatStore = create<DashboardChatState>()(
         try {
           const existing = get().messages[roomId];
 
-          if (!existing || existing.length === 0) {
+          if (!existing) {
             await get().loadRoomMessages(roomId);
+          } else if (existing.length === 0) {
+            const currentSnapshot = getRoomMessageSnapshot(get().getRoomSummary(roomId));
+            const previousSnapshot = emptyRoomMessageSnapshot.get(roomId);
+            if (opts?.expectedHubMsgId || previousSnapshot !== currentSnapshot) {
+              await get().loadRoomMessages(roomId);
+            }
           } else {
             const newestPersisted = [...existing].reverse().find(
               (m) => m.hub_msg_id && !m.hub_msg_id.startsWith("tmp_"),


### PR DESCRIPTION
## Summary
- distinguish unloaded room messages from rooms that were already loaded as empty
- cache the empty-room message snapshot so polling skips repeat first-page loads until the room summary changes
- add store coverage for empty-room polling behavior

## Tests
- pnpm vitest run src/store/useDashboardChatStore.test.ts
- pnpm vitest run
- pnpm build (compiled and TypeScript passed; prerender failed at /admin/codes because Supabase URL/API key env vars are not configured)