### PR TITLE
feat: include diagnostic bundle helper commands

### DIFF
--- a/packages/daemon/src/__tests__/diagnostics.test.ts
+++ b/packages/daemon/src/__tests__/diagnostics.test.ts
@@ -25,6 +25,8 @@ describe("diagnostics bundle", () => {
     });
     expect(bundle.filename).toMatch(/^botcord-daemon-diagnostics-.*\.zip$/);
     expect(bundle.path).toContain(diagnosticsDir);
+    expect(bundle.revealCommand).toContain(bundle.path);
+    expect(bundle.copyPathCommand).toContain(bundle.path);
     expect(existsSync(bundle.path)).toBe(true);
     const bytes = readFileSync(bundle.path);
     expect(bytes.subarray(0, 4).toString("binary")).toBe("PK\u0003\u0004");

--- a/packages/daemon/src/diagnostics.ts
+++ b/packages/daemon/src/diagnostics.ts
@@ -43,6 +43,8 @@ export interface DiagnosticBundleResult {
   filename: string;
   sizeBytes: number;
   createdAt: string;
+  revealCommand: string;
+  copyPathCommand: string;
 }
 
 export interface DiagnosticUploadResult {
@@ -242,6 +244,35 @@ function createZip(entries: Array<{ name: string; data: string | Buffer }>): Buf
   return Buffer.concat([...localParts, central, end]);
 }
 
+function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+function diagnosticBundleCommands(filePath: string): {
+  revealCommand: string;
+  copyPathCommand: string;
+} {
+  if (process.platform === "darwin") {
+    return {
+      revealCommand: `open -R ${shellQuote(filePath)}`,
+      copyPathCommand: `printf '%s' ${shellQuote(filePath)} | pbcopy`,
+    };
+  }
+
+  if (process.platform === "win32") {
+    const psPath = filePath.replace(/'/g, "''");
+    return {
+      revealCommand: `explorer.exe /select,"${filePath.replace(/"/g, '""')}"`,
+      copyPathCommand: `powershell.exe -NoProfile -Command "Set-Clipboard -Value '${psPath}'"`,
+    };
+  }
+
+  return {
+    revealCommand: `xdg-open ${shellQuote(path.dirname(filePath))}`,
+    copyPathCommand: `printf '%s' ${shellQuote(filePath)} | xclip -selection clipboard`,
+  };
+}
+
 export async function createDiagnosticBundle(
   opts: CreateDiagnosticBundleOptions = {},
 ): Promise<DiagnosticBundleResult> {
@@ -296,11 +327,13 @@ export async function createDiagnosticBundle(
   const zip = createZip(entries);
   const out = path.join(diagnosticsDir, filename);
   writeFileSync(out, zip, { mode: 0o600 });
+  const commands = diagnosticBundleCommands(out);
   return {
     path: out,
     filename,
     sizeBytes: zip.length,
     createdAt: createdAt.toISOString(),
+    ...commands,
   };
 }
 

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -1354,6 +1354,8 @@ async function cmdDoctor(args: ParsedArgs): Promise<void> {
     }
     console.log(`diagnostic bundle written: ${bundle.path}`);
     console.log(`size: ${bundle.sizeBytes} bytes`);
+    console.log(`open in Finder/file manager: ${bundle.revealCommand}`);
+    console.log(`copy path to clipboard: ${bundle.copyPathCommand}`);
     console.log("Send this zip file to the BotCord developer/support contact.");
     return;
   }


### PR DESCRIPTION
## Summary
- add reveal/copy helper commands to diagnostic bundle JSON output
- print the same helper commands in plain doctor --bundle output
- cover the new bundle fields in diagnostics tests

## Tests
- cd packages/daemon && npm run build
- cd packages/daemon && npx vitest run src/__tests__/diagnostics.test.ts
- git diff --check