### PR TITLE
fix: align diagnostic bundle command test

### DIFF
--- a/packages/daemon/src/__tests__/diagnostics.test.ts
+++ b/packages/daemon/src/__tests__/diagnostics.test.ts
@@ -25,7 +25,11 @@ describe("diagnostics bundle", () => {
     });
     expect(bundle.filename).toMatch(/^botcord-daemon-diagnostics-.*\.zip$/);
     expect(bundle.path).toContain(diagnosticsDir);
-    expect(bundle.revealCommand).toContain(bundle.path);
+    if (process.platform === "linux") {
+      expect(bundle.revealCommand).toContain(diagnosticsDir);
+    } else {
+      expect(bundle.revealCommand).toContain(bundle.path);
+    }
     expect(bundle.copyPathCommand).toContain(bundle.path);
     expect(existsSync(bundle.path)).toBe(true);
     const bytes = readFileSync(bundle.path);


### PR DESCRIPTION
## Summary
- make the diagnostic bundle helper-command test platform-aware
- allow Linux xdg-open fallback to open the diagnostics directory while macOS/Windows still assert the selected file path

## Tests
- cd packages/daemon && npm run build
- cd packages/daemon && npx vitest run src/__tests__/diagnostics.test.ts
- cd packages/daemon && npm test -- --run
- git diff --check