### PR TITLE
feat: rotate daemon logs and share diagnostics

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -59,6 +59,7 @@ from hub.routers.hub import (
     notify_inbox,
 )
 from hub.share_payloads import share_create_payload
+from hub.validators import normalize_file_url
 
 _logger = logging.getLogger(__name__)
 
@@ -95,6 +96,13 @@ class UpdateRoomSettingsBody(BaseModel):
     max_members: int | None = None
     slow_mode_seconds: int | None = None
     required_subscription_product_id: str | None = None
+
+
+class ChatAttachment(BaseModel):
+    filename: str = Field(..., max_length=200)
+    url: str = Field(..., max_length=500)
+    content_type: str | None = None
+    size_bytes: int | None = None
 
 
 
@@ -2434,6 +2442,7 @@ class HumanRoomSendBody(BaseModel):
     mentions: list[str] | None = None
     topic: str | None = None
     topic_id: str | None = None
+    attachments: list[ChatAttachment] | None = Field(default=None, max_length=10)
 
 
 @router.post("/rooms/{room_id}/send", status_code=202)
@@ -2535,8 +2544,20 @@ async def human_room_send(
         topic_row.message_count = (topic_row.message_count or 0) + 1
         topic_row.updated_at = datetime.datetime.now(datetime.timezone.utc)
 
+    normalized_attachments: list[dict] = []
+    if body.attachments:
+        for att in body.attachments:
+            normalized = normalize_file_url(att.url)
+            if normalized is None:
+                raise HTTPException(status_code=400, detail=f"Invalid attachment URL: {att.url}")
+            dumped = att.model_dump(exclude_none=True)
+            dumped["url"] = normalized
+            normalized_attachments.append(dumped)
+
     # Slow mode + duplicate content (step 7) keyed by (room_id, sender_id)
-    payload_for_checks = {"text": body.text}
+    payload_for_checks: dict = {"text": body.text}
+    if normalized_attachments:
+        payload_for_checks["attachments"] = normalized_attachments
     try:
         _check_slow_mode(room, active_member)
         _check_duplicate_content(room_id, sender_id, payload_for_checks)
@@ -2622,6 +2643,8 @@ async def human_room_send(
     msg_id = str(_uuid.uuid4())
     ts = int(_time.time())
     payload: dict = {"text": body.text}
+    if normalized_attachments:
+        payload["attachments"] = normalized_attachments
     envelope_data = {
         "v": "a2a/0.1",
         "msg_id": msg_id,
@@ -3043,16 +3066,6 @@ async def get_inbox(
 # ---------------------------------------------------------------------------
 # Owner-agent chat
 # ---------------------------------------------------------------------------
-
-
-from hub.validators import normalize_file_url
-
-
-class ChatAttachment(BaseModel):
-    filename: str = Field(..., max_length=200)
-    url: str = Field(..., max_length=500)
-    content_type: str | None = None
-    size_bytes: int | None = None
 
 
 class ChatSendBody(BaseModel):

--- a/frontend/src/components/daemon/DaemonsSettingsPage.tsx
+++ b/frontend/src/components/daemon/DaemonsSettingsPage.tsx
@@ -221,10 +221,10 @@ function RuntimesBlock({
       <div className="flex flex-wrap items-center justify-between gap-2 border-t border-glass-border/40 pt-2">
         <div className="flex flex-col">
           <span className="text-[11px] font-medium uppercase tracking-wide text-text-secondary">
-            Diagnostics
+            Troubleshooting logs
           </span>
           <span className="text-[11px] text-text-tertiary">
-            Full local log + doctor output.
+            Recent device logs for support.
           </span>
         </div>
         <button
@@ -234,8 +234,8 @@ function RuntimesBlock({
           className="inline-flex items-center gap-1 rounded-lg border border-glass-border px-2 py-1 text-[11px] text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
           title={
             daemon.status === "online"
-              ? "Collect daemon diagnostics"
-              : "Daemon must be online to collect diagnostics from Dashboard"
+              ? "Collect logs from this device"
+              : "Device must be online to collect logs"
           }
         >
           {collectingDiagnostics ? (
@@ -243,12 +243,12 @@ function RuntimesBlock({
           ) : (
             <FileArchive className="h-3 w-3" />
           )}
-          Upload diagnostics
+          Collect logs
         </button>
       </div>
       {diagnosticResult ? (
         <span className="rounded-md border border-neon-green/20 bg-neon-green/10 px-2 py-1 text-[11px] text-neon-green">
-          Uploaded {diagnosticResult.filename} ({diagnosticResult.size_bytes} bytes)
+          Log file ready: {diagnosticResult.filename} ({diagnosticResult.size_bytes} bytes)
           {diagnosticResult.expires_at
             ? `, expires ${compactDateTime(diagnosticResult.expires_at)}`
             : ""}

--- a/frontend/src/components/dashboard/ForwardModal.tsx
+++ b/frontend/src/components/dashboard/ForwardModal.tsx
@@ -2,8 +2,9 @@
 
 import { useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
-import { Check, Loader2, MessageSquare, Search, Users, User, X } from "lucide-react";
-import { api } from "@/lib/api";
+import { Check, FileArchive, Loader2, MessageSquare, Search, Users, User, X } from "lucide-react";
+import { api, getActiveIdentity } from "@/lib/api";
+import type { Attachment } from "@/lib/types";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
@@ -18,10 +19,16 @@ interface ForwardTarget {
 
 interface ForwardModalProps {
   quoteText: string;
+  sourceFile?: {
+    url: string;
+    filename: string;
+    contentType?: string;
+    sizeBytes?: number;
+  };
   onClose: () => void;
 }
 
-export default function ForwardModal({ quoteText, onClose }: ForwardModalProps) {
+export default function ForwardModal({ quoteText, sourceFile, onClose }: ForwardModalProps) {
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [sending, setSending] = useState(false);
   const [done, setDone] = useState(false);
@@ -83,18 +90,42 @@ export default function ForwardModal({ quoteText, onClose }: ForwardModalProps) 
     setSending(true);
     setError(null);
     try {
+      let attachments: Attachment[] | undefined;
+      if (sourceFile) {
+        const activeIdentity = getActiveIdentity();
+        const uploadAgentId =
+          activeIdentity?.type === "agent"
+            ? activeIdentity.id
+            : ownedAgents[0]?.agent_id;
+        if (!uploadAgentId) {
+          throw new Error("Choose or create an agent before sending files.");
+        }
+        const res = await fetch(sourceFile.url, { cache: "no-store" });
+        if (!res.ok) throw new Error("Failed to prepare file for sending");
+        const blob = await res.blob();
+        const file = new File([blob], sourceFile.filename, {
+          type: sourceFile.contentType || blob.type || "application/zip",
+        });
+        const uploaded = await api.uploadFile(file, uploadAgentId);
+        attachments = [{
+          filename: uploaded.original_filename,
+          url: uploaded.url,
+          content_type: uploaded.content_type,
+          size_bytes: uploaded.size_bytes,
+        }];
+      }
       const openRoomIds: string[] = [];
       await Promise.all(
         [...selected].map(async (targetId) => {
           const [kind, id] = targetId.split(":") as ["agent" | "contact" | "room", string];
           if (kind === "agent") {
-            await api.sendUserChatMessage(quoteText, undefined, id);
+            await api.sendUserChatMessage(quoteText, attachments, id);
           } else if (kind === "contact") {
             const dmRoom = await api.openDmRoom(id);
-            await api.sendRoomHumanMessage(dmRoom.room_id, quoteText);
+            await api.sendRoomHumanMessage(dmRoom.room_id, quoteText, undefined, undefined, attachments);
             openRoomIds.push(dmRoom.room_id);
           } else {
-            await api.sendRoomHumanMessage(id, quoteText);
+            await api.sendRoomHumanMessage(id, quoteText, undefined, undefined, attachments);
             openRoomIds.push(id);
           }
         })
@@ -116,7 +147,10 @@ export default function ForwardModal({ quoteText, onClose }: ForwardModalProps) 
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
-      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+      onClick={(e) => {
+        e.stopPropagation();
+        if (e.target === e.currentTarget) onClose();
+      }}
     >
       <div className="w-full max-w-sm rounded-xl border border-zinc-700 bg-zinc-900 shadow-2xl">
         {/* Header */}
@@ -140,11 +174,23 @@ export default function ForwardModal({ quoteText, onClose }: ForwardModalProps) 
           />
         </div>
 
-        {/* Quote preview */}
+        {/* Quote / file preview */}
         <div className="mx-4 mt-3 rounded-lg border border-zinc-700 bg-zinc-800/60 px-3 py-2">
-          <pre className="max-h-24 overflow-y-auto whitespace-pre-wrap font-mono text-[11px] text-zinc-400 leading-relaxed">
-            {quoteText}
-          </pre>
+          {sourceFile ? (
+            <div className="flex items-center gap-2 text-zinc-300">
+              <FileArchive className="h-4 w-4 shrink-0 text-cyan-400" />
+              <div className="min-w-0">
+                <p className="truncate text-xs font-medium">{sourceFile.filename}</p>
+                {sourceFile.sizeBytes != null && (
+                  <p className="text-[10px] text-zinc-500">{sourceFile.sizeBytes} bytes</p>
+                )}
+              </div>
+            </div>
+          ) : (
+            <pre className="max-h-24 overflow-y-auto whitespace-pre-wrap font-mono text-[11px] text-zinc-400 leading-relaxed">
+              {quoteText}
+            </pre>
+          )}
         </div>
 
         {/* Target list */}

--- a/frontend/src/components/dashboard/sidebar/DeviceSettingsModal.tsx
+++ b/frontend/src/components/dashboard/sidebar/DeviceSettingsModal.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import { RefreshCw, Loader2, Check, Trash2, FileArchive } from "lucide-react";
+import { RefreshCw, Loader2, Check, Trash2, FileArchive, Download, Send } from "lucide-react";
 import DaemonInstallCommand from "@/components/daemon/DaemonInstallCommand";
+import ForwardModal from "@/components/dashboard/ForwardModal";
 import type { DiagnosticBundleResult } from "@/store/useDaemonStore";
 
 interface DeviceSettingsModalProps {
@@ -49,6 +50,7 @@ export default function DeviceSettingsModal({
   const [showInstall, setShowInstall] = useState(false);
   const [confirmRemove, setConfirmRemove] = useState(false);
   const [removeError, setRemoveError] = useState<string | null>(null);
+  const [forwardLogs, setForwardLogs] = useState(false);
 
   async function handleRename() {
     if (editingName.trim() === label) return;
@@ -86,6 +88,9 @@ export default function DeviceSettingsModal({
   const isOffline = status === "offline";
   const removeDisabled = isRemoving || status === "revoked" || status === "removal_pending";
   const diagnosticsDisabled = isCollectingDiagnostics || status !== "online";
+  const diagnosticDownloadUrl = diagnosticResult
+    ? `/api/daemon/diagnostics/${encodeURIComponent(diagnosticResult.bundle_id)}/download`
+    : "";
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" onClick={onClose}>
@@ -157,12 +162,12 @@ export default function DeviceSettingsModal({
             <div className="flex items-start justify-between gap-3">
               <div className="min-w-0">
                 <p className="text-xs font-medium text-text-primary">
-                  {locale === "zh" ? "诊断日志" : "Diagnostics"}
+                  {locale === "zh" ? "排障日志" : "Troubleshooting logs"}
                 </p>
                 <p className="mt-1 text-[11px] leading-relaxed text-text-secondary/60">
                   {locale === "zh"
-                    ? "打包本机 daemon 日志和 doctor 输出。"
-                    : "Bundle local daemon logs and doctor output."}
+                    ? "收集这台设备最近的运行日志，便于排查问题。"
+                    : "Collect recent logs from this device to help troubleshoot issues."}
                 </p>
               </div>
               <button
@@ -181,20 +186,36 @@ export default function DeviceSettingsModal({
                 ) : (
                   <FileArchive className="h-3 w-3" />
                 )}
-                {locale === "zh" ? "打包" : "Bundle"}
+                {locale === "zh" ? "收集日志" : "Collect logs"}
               </button>
             </div>
             {diagnosticResult && (
-              <p className="mt-2 rounded-md border border-neon-green/20 bg-neon-green/10 px-2 py-1 text-[11px] text-neon-green">
-                {locale === "zh" ? "已生成" : "Ready"} {diagnosticResult.filename} ({diagnosticResult.size_bytes} bytes)
-                {" · "}
-                <a
-                  href={`/api/daemon/diagnostics/${encodeURIComponent(diagnosticResult.bundle_id)}/download`}
-                  className="underline underline-offset-2"
+              <div className="mt-2 flex items-center gap-2 rounded-md border border-neon-green/20 bg-neon-green/10 px-2 py-2">
+                <FileArchive className="h-4 w-4 shrink-0 text-neon-green" />
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-[11px] font-medium text-neon-green">
+                    {diagnosticResult.filename}
+                  </p>
+                  <p className="text-[10px] text-neon-green/70">
+                    {locale === "zh" ? "日志文件已准备好" : "Log file ready"} · {diagnosticResult.size_bytes} bytes
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setForwardLogs(true)}
+                  title={locale === "zh" ? "转发到聊天" : "Send to a chat"}
+                  className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-neon-green/80 transition-colors hover:bg-neon-green/10 hover:text-neon-green"
                 >
-                  {locale === "zh" ? "下载" : "Download"}
+                  <Send className="h-3.5 w-3.5" />
+                </button>
+                <a
+                  href={diagnosticDownloadUrl}
+                  title={locale === "zh" ? "下载日志文件" : "Download log file"}
+                  className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-neon-green/80 transition-colors hover:bg-neon-green/10 hover:text-neon-green"
+                >
+                  <Download className="h-3.5 w-3.5" />
                 </a>
-              </p>
+              </div>
             )}
             {diagnosticError && (
               <p className="mt-2 rounded-md border border-red-400/20 bg-red-400/10 px-2 py-1 text-[11px] text-red-300">
@@ -321,6 +342,18 @@ export default function DeviceSettingsModal({
           </div>
         </div>
       </div>
+      {forwardLogs && diagnosticResult && (
+        <ForwardModal
+          quoteText={locale === "zh" ? "设备排障日志" : "Device troubleshooting logs"}
+          sourceFile={{
+            url: diagnosticDownloadUrl,
+            filename: diagnosticResult.filename,
+            contentType: "application/zip",
+            sizeBytes: diagnosticResult.size_bytes,
+          }}
+          onClose={() => setForwardLogs(false)}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -777,10 +777,17 @@ export const api = {
     return apiPost<UserChatSendResponse>("/api/dashboard/chat/send", body);
   },
 
-  sendRoomHumanMessage(roomId: string, text: string, mentions?: string[], topicId?: string | null) {
+  sendRoomHumanMessage(
+    roomId: string,
+    text: string,
+    mentions?: string[],
+    topicId?: string | null,
+    attachments?: Attachment[],
+  ) {
     const body: Record<string, unknown> = { text };
     if (mentions && mentions.length > 0) body.mentions = mentions;
     if (topicId) body.topic_id = topicId;
+    if (attachments && attachments.length > 0) body.attachments = attachments;
     return apiPost<RoomHumanSendResponse>(`/api/dashboard/rooms/${roomId}/send`, body);
   },
 

--- a/packages/daemon/src/__tests__/diagnostics.test.ts
+++ b/packages/daemon/src/__tests__/diagnostics.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, utimesSync, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -48,5 +48,41 @@ describe("diagnostics bundle", () => {
     });
     expect(log).toContain("Authorization: Bearer [REDACTED]");
     expect(log).toContain('"refreshToken":"[REDACTED]"');
+  }, 20_000);
+
+  it("bundles active log plus latest 5 rotated logs by default, or all with includeAllLogs", async () => {
+    const tmp = mkdtempSync(path.join(tmpdir(), "botcord-diag-logs-test-"));
+    const logFile = path.join(tmp, "daemon.log");
+    const configFile = path.join(tmp, "config.json");
+    const snapshotFile = path.join(tmp, "snapshot.json");
+    writeFileSync(logFile, "active\n");
+    writeFileSync(configFile, "{}\n");
+    writeFileSync(snapshotFile, "{}\n");
+    for (let i = 0; i < 7; i += 1) {
+      const rotated = path.join(tmp, `daemon.log.rot-${i}`);
+      writeFileSync(rotated, `rotated ${i}\n`);
+      const t = new Date(1_700_000_000_000 + i * 1000);
+      utimesSync(rotated, t, t);
+    }
+
+    const baseOpts = {
+      diagnosticsDir: path.join(tmp, "diagnostics"),
+      logFile,
+      configFile,
+      snapshotFile,
+      doctor: { text: "doctor ok", json: { ok: true } },
+    };
+    const bundle = await createDiagnosticBundle(baseOpts);
+    const listing = execFileSync("unzip", ["-l", bundle.path], { encoding: "utf8" });
+    expect(listing).toContain("daemon.log");
+    expect(listing).toContain("logs/daemon.log.rot-6");
+    expect(listing).toContain("logs/daemon.log.rot-2");
+    expect(listing).not.toContain("logs/daemon.log.rot-1");
+    expect(listing).not.toContain("logs/daemon.log.rot-0");
+
+    const full = await createDiagnosticBundle({ ...baseOpts, includeAllLogs: true });
+    const fullListing = execFileSync("unzip", ["-l", full.path], { encoding: "utf8" });
+    expect(fullListing).toContain("logs/daemon.log.rot-0");
+    expect(fullListing).toContain("logs/daemon.log.rot-6");
   }, 20_000);
 });

--- a/packages/daemon/src/__tests__/log.test.ts
+++ b/packages/daemon/src/__tests__/log.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { formatLogLine } from "../log.js";
+import { mkdtempSync, readdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { formatLogLine, listDaemonLogFiles, rotateLogIfNeeded } from "../log.js";
 
 describe("formatLogLine", () => {
   it("renders compact text with level, message, details, and trailing timestamp", () => {
@@ -26,5 +29,29 @@ describe("formatLogLine", () => {
     expect(line).toBe(
       '[INFO] botcord ws server error msg={"type":"error","code":503} ts=2026-05-01T00:22:07.131Z',
     );
+  });
+
+  it("rotates oversized logs and keeps the newest 20 rotated files", () => {
+    const tmp = mkdtempSync(path.join(tmpdir(), "botcord-log-test-"));
+    try {
+      const logFile = path.join(tmp, "daemon.log");
+      writeFileSync(logFile, "active log line\n");
+      for (let i = 0; i < 20; i += 1) {
+        const rotated = path.join(tmp, `daemon.log.old-${String(i).padStart(2, "0")}`);
+        writeFileSync(rotated, `old ${i}\n`);
+        const t = new Date(1_700_000_000_000 + i * 1000);
+        utimesSync(rotated, t, t);
+      }
+
+      rotateLogIfNeeded(logFile, 1, 10, 20);
+      const logs = listDaemonLogFiles(logFile);
+      const rotated = logs.filter((entry) => !entry.active);
+
+      expect(rotated).toHaveLength(20);
+      expect(rotated.some((entry) => entry.name === "daemon.log.old-00")).toBe(false);
+      expect(rotated.some((entry) => entry.name.startsWith("daemon.log."))).toBe(true);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/daemon/src/diagnostics.ts
+++ b/packages/daemon/src/diagnostics.ts
@@ -16,7 +16,7 @@ import {
   loadConfig,
   type DaemonConfig,
 } from "./config.js";
-import { LOG_FILE_PATH } from "./log.js";
+import { listDaemonLogFiles, LOG_FILE_PATH, type LogFileEntry } from "./log.js";
 import {
   channelsFromDaemonConfig,
   defaultHttpFetcher,
@@ -29,6 +29,7 @@ import { detectRuntimes } from "./adapters/runtimes.js";
 
 const DIAGNOSTICS_DIR = path.join(homedir(), ".botcord", "diagnostics");
 const MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
+const DEFAULT_ROTATED_LOGS_IN_BUNDLE = 5;
 
 export interface CreateDiagnosticBundleOptions {
   diagnosticsDir?: string;
@@ -36,6 +37,7 @@ export interface CreateDiagnosticBundleOptions {
   configFile?: string;
   snapshotFile?: string;
   doctor?: { text: string; json: unknown };
+  includeAllLogs?: boolean;
 }
 
 export interface DiagnosticBundleResult {
@@ -273,6 +275,16 @@ function diagnosticBundleCommands(filePath: string): {
   };
 }
 
+function bundledLogs(logFile: string, includeAllLogs: boolean): LogFileEntry[] {
+  const all = listDaemonLogFiles(logFile);
+  const active = all.filter((entry) => entry.active);
+  const rotated = all.filter((entry) => !entry.active);
+  return [
+    ...active,
+    ...(includeAllLogs ? rotated : rotated.slice(0, DEFAULT_ROTATED_LOGS_IN_BUNDLE)),
+  ];
+}
+
 export async function createDiagnosticBundle(
   opts: CreateDiagnosticBundleOptions = {},
 ): Promise<DiagnosticBundleResult> {
@@ -283,6 +295,8 @@ export async function createDiagnosticBundle(
   const logFile = opts.logFile ?? LOG_FILE_PATH;
   const configFile = opts.configFile ?? CONFIG_FILE_PATH;
   const snapshotFile = opts.snapshotFile ?? SNAPSHOT_PATH;
+  const includeAllLogs = opts.includeAllLogs === true;
+  const logs = bundledLogs(logFile, includeAllLogs);
   mkdirSync(diagnosticsDir, { recursive: true, mode: 0o700 });
 
   const doctor = opts.doctor ?? await buildDoctorEntries();
@@ -298,6 +312,13 @@ export async function createDiagnosticBundle(
     configPath: configFile,
     snapshotPath: snapshotFile,
     logPath: logFile,
+    logsBundled: logs.map((entry) => ({
+      name: entry.name,
+      path: entry.path,
+      sizeBytes: entry.sizeBytes,
+      active: entry.active,
+    })),
+    logsBundleMode: includeAllLogs ? "all" : `active_plus_${DEFAULT_ROTATED_LOGS_IN_BUNDLE}_rotated`,
     diagnosticsDir,
     userAuth: readUserAuthSummary(),
   };
@@ -308,11 +329,20 @@ export async function createDiagnosticBundle(
     { name: "doctor.txt", data: doctor.text + "\n" },
     { name: "doctor.json", data: JSON.stringify(doctor.json, null, 2) + "\n" },
   ];
-  const log = safeReadText(logFile);
-  entries.push({
-    name: "daemon.log",
-    data: log ?? `no log file at ${logFile}\n`,
-  });
+  if (logs.length === 0) {
+    entries.push({
+      name: "daemon.log",
+      data: `no log file at ${logFile}\n`,
+    });
+  } else {
+    for (const entry of logs) {
+      const log = safeReadText(entry.path);
+      entries.push({
+        name: entry.active ? "daemon.log" : `logs/${entry.name}`,
+        data: log ?? `no log file at ${entry.path}\n`,
+      });
+    }
+  }
   const config = safeReadText(configFile);
   entries.push({
     name: "config.json.redacted",

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -132,9 +132,12 @@ Commands:
   route list
   route remove --room <rm_xxx>|--prefix <rm_xxx>
   config                                  Print resolved config
-  doctor [--json] [--bundle]              Scan local runtimes (${ADAPTER_LIST});
+  doctor [--json] [--bundle] [--full-log] Scan local runtimes (${ADAPTER_LIST});
                                           --bundle also writes a zip under
-                                          ~/.botcord/diagnostics/
+                                          ~/.botcord/diagnostics/. Bundles
+                                          daemon.log plus the latest 5 rotated
+                                          logs by default; --full-log bundles
+                                          all retained rotated logs.
   memory get [--agent <ag_xxx>] [--json]  Show current working memory
   memory set [--agent <ag_xxx>] --goal <text>
                                           Pin/update the agent's work goal
@@ -168,6 +171,7 @@ const BOOLEAN_FLAGS = new Set([
   "follow",
   "json",
   "bundle",
+  "full-log",
   "help",
   "h",
   "mentioned",
@@ -1347,7 +1351,9 @@ const fsFileReader: DoctorFileReader = {
 
 async function cmdDoctor(args: ParsedArgs): Promise<void> {
   if (args.flags.bundle === true) {
-    const bundle = await createDiagnosticBundle();
+    const bundle = await createDiagnosticBundle({
+      includeAllLogs: args.flags["full-log"] === true,
+    });
     if (args.flags.json === true) {
       console.log(JSON.stringify({ bundle }, null, 2));
       return;

--- a/packages/daemon/src/log.ts
+++ b/packages/daemon/src/log.ts
@@ -1,9 +1,11 @@
-import { appendFileSync, mkdirSync } from "node:fs";
+import { appendFileSync, mkdirSync, readdirSync, renameSync, statSync, unlinkSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 
 const LOG_DIR = path.join(homedir(), ".botcord", "logs");
 const LOG_FILE = path.join(LOG_DIR, "daemon.log");
+const LOG_ROTATE_MAX_BYTES = 10 * 1024 * 1024;
+const LOG_ROTATE_KEEP = 20;
 
 let inited = false;
 function ensureDir(): void {
@@ -17,6 +19,14 @@ function ensureDir(): void {
 }
 
 type Level = "info" | "warn" | "error" | "debug";
+
+export interface LogFileEntry {
+  path: string;
+  name: string;
+  sizeBytes: number;
+  mtimeMs: number;
+  active: boolean;
+}
 
 function formatValue(value: unknown): string {
   if (value instanceof Error) return JSON.stringify(value.stack ?? value.message);
@@ -44,10 +54,99 @@ export function formatLogLine(
   return detail ? `${prefix} ${detail} ${suffix}` : `${prefix} ${suffix}`;
 }
 
+function rotatedName(file: string, date = new Date()): string {
+  const stamp = date.toISOString().replace(/[:.]/g, "-");
+  return `${file}.${stamp}.${process.pid}`;
+}
+
+export function listDaemonLogFiles(logFile = LOG_FILE): LogFileEntry[] {
+  const dir = path.dirname(logFile);
+  const base = path.basename(logFile);
+  const entries: LogFileEntry[] = [];
+
+  try {
+    const st = statSync(logFile);
+    if (st.isFile()) {
+      entries.push({
+        path: logFile,
+        name: base,
+        sizeBytes: st.size,
+        mtimeMs: st.mtimeMs,
+        active: true,
+      });
+    }
+  } catch {
+    // no active log
+  }
+
+  let names: string[] = [];
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return entries;
+  }
+
+  for (const name of names) {
+    if (!name.startsWith(`${base}.`)) continue;
+    const file = path.join(dir, name);
+    try {
+      const st = statSync(file);
+      if (!st.isFile()) continue;
+      entries.push({
+        path: file,
+        name,
+        sizeBytes: st.size,
+        mtimeMs: st.mtimeMs,
+        active: false,
+      });
+    } catch {
+      // ignore disappearing files
+    }
+  }
+
+  return entries.sort((a, b) => {
+    if (a.active !== b.active) return a.active ? -1 : 1;
+    return b.mtimeMs - a.mtimeMs || b.name.localeCompare(a.name);
+  });
+}
+
+export function rotateLogIfNeeded(
+  logFile = LOG_FILE,
+  nextBytes = 0,
+  maxBytes = LOG_ROTATE_MAX_BYTES,
+  keep = LOG_ROTATE_KEEP,
+): void {
+  let currentSize = 0;
+  try {
+    const st = statSync(logFile);
+    if (!st.isFile()) return;
+    currentSize = st.size;
+  } catch {
+    return;
+  }
+  if (currentSize + nextBytes <= maxBytes) return;
+
+  try {
+    renameSync(logFile, rotatedName(logFile));
+  } catch {
+    return;
+  }
+
+  const rotated = listDaemonLogFiles(logFile).filter((entry) => !entry.active);
+  for (const entry of rotated.slice(Math.max(0, keep))) {
+    try {
+      unlinkSync(entry.path);
+    } catch {
+      // best-effort cleanup
+    }
+  }
+}
+
 function write(level: Level, msg: string, fields?: Record<string, unknown>): void {
   ensureDir();
   const line = formatLogLine(level, msg, fields);
   try {
+    rotateLogIfNeeded(LOG_FILE, Buffer.byteLength(line) + 1);
     appendFileSync(LOG_FILE, line + "\n", { mode: 0o600 });
   } catch {
     // ignore log write errors


### PR DESCRIPTION
## Summary
- rotate daemon.log at 10MB and retain the latest 20 rotated logs
- include active daemon.log plus latest 5 rotated logs in diagnostic bundles by default
- add doctor --bundle --full-log to include all retained rotated logs
- replace technical diagnostics copy with user-facing troubleshooting log copy
- show collected logs as a file item with download and send-to-chat actions
- allow forwarded diagnostic zips to be sent as attachments to agents, contacts, and rooms

## Tests
- cd packages/daemon && npm run build
- cd packages/daemon && npx vitest run src/__tests__/log.test.ts src/__tests__/diagnostics.test.ts
- cd packages/daemon && npm test -- --run
- cd frontend && npm run build
- cd backend && uv run pytest tests/test_app/test_app_dashboard.py tests/test_dashboard_rooms_human_send.py
- git diff --check