### PR TITLE
fix: surface daemon diagnostics errors

### DIFF
--- a/frontend/src/store/useDaemonStore.test.ts
+++ b/frontend/src/store/useDaemonStore.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useDaemonStore } from "@/store/useDaemonStore";
+
+describe("useDaemonStore diagnostics", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    useDaemonStore.setState({
+      collectingDiagnosticsId: null,
+      diagnosticErrors: {},
+      diagnosticResults: {},
+    });
+  });
+
+  it("surfaces daemon diagnostics failure details from Hub", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          detail: {
+            code: "upstream_error",
+            daemon_code: "handler_error",
+            daemon_message: "diagnostic upload failed: HTTP 500",
+          },
+        }),
+        {
+          status: 502,
+          statusText: "Bad Gateway",
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    const result = await useDaemonStore.getState().collectDiagnostics("dm_1");
+
+    expect(result).toBeNull();
+    expect(useDaemonStore.getState().diagnosticErrors.dm_1).toBe(
+      "diagnostic upload failed: HTTP 500",
+    );
+  });
+});

--- a/frontend/src/store/useDaemonStore.ts
+++ b/frontend/src/store/useDaemonStore.ts
@@ -193,6 +193,13 @@ async function parseError(res: Response): Promise<string> {
     if (typeof data?.error === "string") return data.error;
     if (typeof data?.message === "string") return data.message;
     if (typeof data?.detail === "string") return data.detail;
+    if (data?.detail && typeof data.detail === "object") {
+      const detail = data.detail as Record<string, unknown>;
+      if (typeof detail.daemon_message === "string") return detail.daemon_message;
+      if (typeof detail.message === "string") return detail.message;
+      if (typeof detail.daemon_code === "string") return detail.daemon_code;
+      if (typeof detail.code === "string") return detail.code;
+    }
   } catch {
     // ignore
   }
@@ -659,7 +666,10 @@ export const useDaemonStore = create<DaemonState>()((set, get) => ({
         } else if (res.status === 504) {
           msg = "daemon timed out while collecting diagnostics";
         } else if (res.status === 502) {
-          msg = "daemon failed to collect diagnostics";
+          msg = await parseError(res);
+          if (!msg || msg === "Bad Gateway") {
+            msg = "daemon failed to collect diagnostics";
+          }
         } else {
           msg = await parseError(res);
         }


### PR DESCRIPTION
## Summary
- show daemon diagnostics failure details returned by Hub instead of a generic 502 message
- add store coverage for diagnostics upload failures

## Verification
- pnpm test -- --run src/store/useDaemonStore.test.ts