### PR TITLE
fix: send daemon diagnostics as attachment only

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -2438,7 +2438,7 @@ async def open_dm_room(
 
 
 class HumanRoomSendBody(BaseModel):
-    text: str = Field(..., min_length=1, max_length=8000)
+    text: str = Field(default="", max_length=8000)
     mentions: list[str] | None = None
     topic: str | None = None
     topic_id: str | None = None
@@ -2554,8 +2554,12 @@ async def human_room_send(
             dumped["url"] = normalized
             normalized_attachments.append(dumped)
 
+    text = (body.text or "").strip()
+    if not text and not normalized_attachments:
+        raise HTTPException(status_code=400, detail="Message must contain text or attachments")
+
     # Slow mode + duplicate content (step 7) keyed by (room_id, sender_id)
-    payload_for_checks: dict = {"text": body.text}
+    payload_for_checks: dict = {"text": text}
     if normalized_attachments:
         payload_for_checks["attachments"] = normalized_attachments
     try:
@@ -2642,7 +2646,7 @@ async def human_room_send(
 
     msg_id = str(_uuid.uuid4())
     ts = int(_time.time())
-    payload: dict = {"text": body.text}
+    payload: dict = {"text": text}
     if normalized_attachments:
         payload["attachments"] = normalized_attachments
     envelope_data = {

--- a/backend/tests/test_dashboard_rooms_human_send.py
+++ b/backend/tests/test_dashboard_rooms_human_send.py
@@ -246,6 +246,45 @@ async def test_happy_path_fanout(client: AsyncClient, seed: dict, db_session: As
 
 
 @pytest.mark.asyncio
+async def test_attachment_only_message_allowed(client: AsyncClient, seed: dict, db_session: AsyncSession):
+    r = await client.post(
+        "/api/dashboard/rooms/rm_humanroom/send",
+        headers=_h(seed["token1"], seed["agent1"]),
+        json={
+            "text": "",
+            "attachments": [
+                {
+                    "filename": "diagnostics.zip",
+                    "url": "/hub/files/f_diagnostics",
+                    "content_type": "application/zip",
+                    "size_bytes": 123,
+                }
+            ],
+        },
+    )
+    assert r.status_code == 202, r.text
+
+    rows = (await db_session.execute(
+        select(MessageRecord).where(MessageRecord.room_id == "rm_humanroom")
+    )).scalars().all()
+    assert rows
+    env = json.loads(rows[0].envelope_json)
+    assert env["payload"]["text"] == ""
+    assert env["payload"]["attachments"][0]["filename"] == "diagnostics.zip"
+
+
+@pytest.mark.asyncio
+async def test_empty_message_without_attachments_rejected(client: AsyncClient, seed: dict):
+    r = await client.post(
+        "/api/dashboard/rooms/rm_humanroom/send",
+        headers=_h(seed["token1"], seed["agent1"]),
+        json={"text": ""},
+    )
+    assert r.status_code == 400
+    assert r.json()["detail"] == "Message must contain text or attachments"
+
+
+@pytest.mark.asyncio
 async def test_topic_reply_keeps_message_in_topic(
     client: AsyncClient, seed: dict, db_session: AsyncSession
 ):

--- a/frontend/src/components/dashboard/sidebar/DeviceSettingsModal.tsx
+++ b/frontend/src/components/dashboard/sidebar/DeviceSettingsModal.tsx
@@ -344,7 +344,7 @@ export default function DeviceSettingsModal({
       </div>
       {forwardLogs && diagnosticResult && (
         <ForwardModal
-          quoteText={locale === "zh" ? "设备排障日志" : "Device troubleshooting logs"}
+          quoteText=""
           sourceFile={{
             url: diagnosticDownloadUrl,
             filename: diagnosticResult.filename,


### PR DESCRIPTION
## Summary
- send forwarded daemon diagnostics without message text
- allow room sends with attachments and empty text while rejecting fully empty messages
- add room-send coverage for attachment-only and empty-message cases

## Tests
- cd backend && uv run pytest tests/test_dashboard_rooms_human_send.py -q