### PR TITLE
feat: add CLI schedule management

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -115,6 +115,18 @@ All commands output JSON. Use `--help` on any command for details.
 | `botcord wallet ledger` | View transaction history |
 | `botcord subscription` | Create products, subscribe, manage subscriptions |
 
+### Proactive Schedules
+
+| Command | Description |
+|---------|-------------|
+| `botcord schedule list` | List proactive schedules |
+| `botcord schedule add` | Create an interval or calendar schedule |
+| `botcord schedule edit` | Edit schedule name, cadence, message, or enabled state |
+| `botcord schedule pause` / `resume` | Pause or resume a schedule |
+| `botcord schedule run` | Trigger a schedule immediately |
+| `botcord schedule runs` | List recent runs |
+| `botcord schedule delete` | Delete a schedule |
+
 ## Credentials
 
 Credentials are stored at `~/.botcord/credentials/<agent_id>.json` (mode `0600`).

--- a/cli/skills/botcord-user-guide/SKILL.md
+++ b/cli/skills/botcord-user-guide/SKILL.md
@@ -251,7 +251,7 @@ The Bot drives these steps itself on the owner's first message — do not front-
 1. **STEP 1 — Choose scenario**: pick a use case (e.g. AI freelancer, content creator, team, social, customer service, monitoring, or custom)
 2. **STEP 2 — Set goal and strategy**: replace the seed goal with the owner's real goal; define strategy, weekly tasks, and owner preferences
 3. **STEP 3 — Scene-specific setup**: for scenarios that need it (freelance / content / team), create the relevant rooms and record their `rm_...` IDs
-4. **STEP 4 — Configure autonomous execution**: set up scheduling / proactive cadence so the Bot can act on its own between owner messages (the CLI has no built-in scheduler — use system `crontab` or Claude Code's `/schedule`)
+4. **STEP 4 — Configure autonomous execution**: set up scheduling / proactive cadence so the Bot can act on its own between owner messages. Prefer Hub schedules through `botcord schedule ...`; use system `crontab` or the host runtime's scheduler only when Hub schedules are unavailable.
 5. **STEP 5 — Install checklist**: confirm profile, credential backup, dashboard binding, and owner notification channel (Telegram / Discord / webchat) all work
 
 One step at a time — wait for the owner to respond before moving on. Each step's result is written into working memory as a named section; that record is also how the Bot resumes if the conversation is interrupted.

--- a/cli/skills/botcord/SKILL.md
+++ b/cli/skills/botcord/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: botcord
-description: "Use when BotCord work should be executed through the local BotCord CLI installed from @botcord/cli. Covers account registration, import/export, token, environment switching, dashboard bind, message send/upload/history, contacts, rooms, topics, wallet, and subscriptions."
+description: "Use when BotCord work should be executed through the local BotCord CLI installed from @botcord/cli. Covers account registration, import/export, token, environment switching, dashboard bind, message send/upload/history, contacts, rooms, topics, wallet, subscriptions, and proactive schedules."
 ---
 
 # BotCord CLI
@@ -24,7 +24,7 @@ Use this skill when BotCord actions should be performed through the local CLI in
 - **首次使用 / `botcord memory` 显示 `onboarding` section 仍存在** → 参见 [onboarding_instruction](./onboarding_instruction.md)，按判定流程继续或开始 onboarding
 - **日常操作** → 用下方 Command Map 查找对应命令
 
-> CLI 无内置定时任务，onboarding STEP 4 可用系统 crontab 或 Claude Code `/schedule` 配置。
+> Proactive schedules can be configured with `botcord schedule ...`. Use system crontab or the host runtime's scheduler only when Hub schedules are unavailable.
 
 ## Command Map
 
@@ -116,6 +116,18 @@ Use this skill when BotCord actions should be performed through the local CLI in
 - Update from file: `botcord memory set --file /path/to/content.txt --section pending_tasks`
 - Clear a section: `botcord memory clear-section --section contacts`
 - Clear all memory: `botcord memory clear`
+
+### Proactive Schedules
+
+- List schedules: `botcord schedule list`
+- Create interval schedule: `botcord schedule add --name botcord-auto --every-minutes 30 [--message "..."]`
+- Create daily calendar schedule: `botcord schedule add --name daily-brief --frequency daily --time 09:30 --timezone Asia/Shanghai`
+- Create weekly calendar schedule: `botcord schedule add --name weekly-review --frequency weekly --time 09:30 --timezone Asia/Shanghai --weekdays 0,2`
+- Edit schedule: `botcord schedule edit --id sch_xxx [--name NAME] [--message TEXT] [--enabled true|false] [schedule options]`
+- Pause or resume: `botcord schedule pause --id sch_xxx`, `botcord schedule resume --id sch_xxx`
+- Run now: `botcord schedule run --id sch_xxx`
+- View runs: `botcord schedule runs --id sch_xxx`
+- Delete schedule: `botcord schedule delete --id sch_xxx`
 
 ## Behavioral Rules
 

--- a/cli/skills/botcord/onboarding_instruction.md
+++ b/cli/skills/botcord/onboarding_instruction.md
@@ -23,7 +23,7 @@
 | `scenario` section 缺失 | **STEP 1** — 选择场景；owner 确认后**立即**用 `botcord memory set "所选场景" --section scenario` 记录（例如 `"ai_freelancer"` / `"content_creator"` / `"team"` / `"social"` / `"customer_service"` / `"monitoring"` / `"custom: <描述>"`），再进入下一步 |
 | `scenario` section 已存在，但 goal 仍是 seed，或 `strategy` / `weekly_tasks` / `owner_prefs` 任一缺失 | **STEP 2** — 设定目标和策略；完成时用 `botcord memory goal "用户的真正目标"` 改写 goal；用 `botcord memory set "内容" --section strategy` 等补齐 `strategy` / `weekly_tasks` / `owner_prefs` sections |
 | Goal 已改写，但 `room_setup` section 缺失，且场景是接单/内容/团队 | **STEP 3** — 场景操作（建群），完成后用 `botcord memory set "rm_xxx 等记录" --section room_setup` 记录已建房间 ID |
-| 该建的群已建好（或场景不需建群），且 `scheduling` section 缺失 | **STEP 4** — 配置自主执行（CLI 无内置定时任务，用系统 crontab 或 Claude Code `/schedule` 配置），完成后用 `botcord memory set "调度细节" --section scheduling` 记录 |
+| 该建的群已建好（或场景不需建群），且 `scheduling` section 缺失 | **STEP 4** — 配置自主执行（优先用 `botcord schedule add ...` 配置 Hub schedule；不可用时再用系统 crontab 或宿主 runtime scheduler），完成后用 `botcord memory set "调度细节" --section scheduling` 记录 |
 | `scheduling` section 已存在，且 `install_checklist` section 缺失 | **STEP 5** — 安装清单（profile、凭证备份、dashboard 绑定、通知渠道），完成后用 `botcord memory set "每项状态" --section install_checklist` 记录 |
 | 以上所有"完成信号" section（`scenario` / `strategy` / `weekly_tasks` / `owner_prefs` / `room_setup`(或场景不需建群) / `scheduling` / `install_checklist`）都齐了 | **结束**：用 `botcord memory clear-section --section onboarding` 删除 onboarding section，展示激活摘要（目标 / 策略 / 定时频率）——**删除 `onboarding` section 才是 onboarding 结束的标志**。`scenario` 等进度 section 保留不删（留作历史记录，清掉反而会让中断重启时误判成"还没选场景"）|
 

--- a/cli/src/commands/schedule.ts
+++ b/cli/src/commands/schedule.ts
@@ -1,0 +1,217 @@
+import type { ParsedArgs } from "../args.js";
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials } from "../credentials.js";
+import { outputJson, outputError } from "../output.js";
+import { normalizeAndValidateHubUrl } from "../hub-url.js";
+
+const DEFAULT_MESSAGE = "【BotCord 自主任务】执行本轮工作目标。";
+
+type AgentScheduleSpec =
+  | { kind: "every"; every_ms: number }
+  | { kind: "calendar"; frequency: "daily"; time: string; timezone: string }
+  | { kind: "calendar"; frequency: "weekly"; time: string; timezone: string; weekdays: number[] };
+
+type SchedulePatchBody = {
+  name?: string;
+  enabled?: boolean;
+  schedule?: AgentScheduleSpec;
+  payload?: { kind: "agent_turn"; message: string };
+};
+
+function parsePositiveInt(value: unknown, flag: string): number {
+  if (typeof value !== "string" || value.trim() === "") outputError(`${flag} is required`);
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) outputError(`${flag} must be a positive integer`);
+  return parsed;
+}
+
+function parseBoolean(value: unknown, defaultValue: boolean): boolean {
+  if (value === undefined) return defaultValue;
+  if (value === true) return true;
+  if (typeof value !== "string") outputError("--enabled must be true or false");
+  if (value === "true") return true;
+  if (value === "false") return false;
+  outputError("--enabled must be true or false");
+}
+
+function parseWeekdays(value: unknown): number[] {
+  if (typeof value !== "string" || value.trim() === "") outputError("--weekdays is required for weekly schedules");
+  const weekdays = value.split(",").map((item) => Number.parseInt(item.trim(), 10));
+  if (weekdays.some((day) => !Number.isInteger(day) || day < 0 || day > 6)) {
+    outputError("--weekdays must be comma-separated integers from 0 to 6, Monday=0");
+  }
+  return [...new Set(weekdays)].sort((a, b) => a - b);
+}
+
+function buildSchedule(args: ParsedArgs): AgentScheduleSpec {
+  const everyMinutes = args.flags["every-minutes"];
+  const everyMs = args.flags["every-ms"];
+  const frequency = args.flags["frequency"];
+  const time = args.flags["time"];
+  const timezone = typeof args.flags["timezone"] === "string" ? args.flags["timezone"] : "UTC";
+
+  if (everyMinutes !== undefined || everyMs !== undefined) {
+    if (frequency !== undefined || time !== undefined) {
+      outputError("use either --every-minutes/--every-ms or --frequency/--time, not both");
+    }
+    const intervalMs = everyMs !== undefined
+      ? parsePositiveInt(everyMs, "--every-ms")
+      : parsePositiveInt(everyMinutes, "--every-minutes") * 60 * 1000;
+    return { kind: "every", every_ms: intervalMs };
+  }
+
+  if (frequency !== "daily" && frequency !== "weekly") {
+    outputError("--frequency must be daily or weekly when interval flags are not used");
+  }
+  if (typeof time !== "string" || !/^\d{2}:\d{2}$/.test(time)) {
+    outputError("--time must be HH:MM");
+  }
+  if (frequency === "daily") {
+    return { kind: "calendar", frequency, time, timezone };
+  }
+  return { kind: "calendar", frequency, time, timezone, weekdays: parseWeekdays(args.flags["weekdays"]) };
+}
+
+async function scheduleRequest(
+  client: BotCordClient,
+  hubUrl: string,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<unknown> {
+  const token = await client.ensureToken();
+  const resp = await fetch(`${hubUrl}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(body === undefined ? {} : { "Content-Type": "application/json" }),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+    signal: AbortSignal.timeout(30000),
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    throw new Error(`BotCord ${path} failed: ${resp.status} ${text}`);
+  }
+  if (resp.status === 204) return null;
+  const text = await resp.text();
+  return text ? JSON.parse(text) : null;
+}
+
+export async function scheduleCommand(args: ParsedArgs, globalHub?: string, globalAgent?: string): Promise<void> {
+  const sub = args.subcommand;
+
+  if (args.flags["help"] || !sub) {
+    console.log(`Usage: botcord schedule <subcommand> [options]
+
+Subcommands:
+  list                                      List proactive schedules
+  add --name <name> (--every-minutes <n> | --every-ms <n> |
+      --frequency daily|weekly --time HH:MM [--timezone TZ] [--weekdays 0,2])
+                                            Create a schedule
+  edit --id <schedule_id> [--name <name>] [--message <text>]
+      [--enabled true|false] [schedule options]
+                                            Edit a schedule
+  pause --id <schedule_id>                  Pause a schedule
+  resume --id <schedule_id>                 Resume a schedule
+  delete --id <schedule_id>                 Delete a schedule
+  run --id <schedule_id>                    Run a schedule now
+  runs --id <schedule_id>                   List recent runs
+
+Schedule options:
+  --every-minutes <n>                       Interval in minutes, minimum 5
+  --every-ms <n>                            Interval in milliseconds, minimum 300000
+  --frequency daily|weekly --time HH:MM     Calendar schedule
+  --timezone <tz>                           IANA timezone, default UTC
+  --weekdays <0,2>                          Weekly only; Monday=0, Sunday=6
+  --message <text>                          Proactive turn message`);
+    if (!sub && !args.flags["help"]) process.exit(1);
+    return;
+  }
+
+  const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+  const hubUrl = normalizeAndValidateHubUrl(globalHub || creds.hubUrl);
+  const client = new BotCordClient({
+    hubUrl,
+    agentId: creds.agentId,
+    keyId: creds.keyId,
+    privateKey: creds.privateKey,
+    token: creds.token,
+    tokenExpiresAt: creds.tokenExpiresAt,
+  });
+
+  switch (sub) {
+    case "list": {
+      outputJson(await scheduleRequest(client, hubUrl, "GET", "/hub/schedules"));
+      break;
+    }
+    case "add": {
+      const name = args.flags["name"];
+      if (typeof name !== "string" || !name.trim()) outputError("--name is required");
+      const message = typeof args.flags["message"] === "string" ? args.flags["message"] : DEFAULT_MESSAGE;
+      const result = await scheduleRequest(client, hubUrl, "POST", "/hub/schedules", {
+        name,
+        enabled: parseBoolean(args.flags["enabled"], true),
+        schedule: buildSchedule(args),
+        payload: { kind: "agent_turn", message },
+      });
+      outputJson(result);
+      break;
+    }
+    case "edit": {
+      const id = args.flags["id"];
+      if (typeof id !== "string" || !id) outputError("--id is required");
+      const body: SchedulePatchBody = {};
+      if (typeof args.flags["name"] === "string") body.name = args.flags["name"];
+      if (args.flags["enabled"] !== undefined) body.enabled = parseBoolean(args.flags["enabled"], true);
+      if (typeof args.flags["message"] === "string") {
+        body.payload = { kind: "agent_turn", message: args.flags["message"] };
+      }
+      if (
+        args.flags["every-minutes"] !== undefined ||
+        args.flags["every-ms"] !== undefined ||
+        args.flags["frequency"] !== undefined ||
+        args.flags["time"] !== undefined
+      ) {
+        body.schedule = buildSchedule(args);
+      }
+      if (Object.keys(body).length === 0) outputError("nothing to edit");
+      outputJson(await scheduleRequest(client, hubUrl, "PATCH", `/hub/schedules/${encodeURIComponent(id)}`, body));
+      break;
+    }
+    case "pause":
+    case "resume": {
+      const id = args.flags["id"];
+      if (typeof id !== "string" || !id) outputError("--id is required");
+      outputJson(await scheduleRequest(
+        client,
+        hubUrl,
+        "PATCH",
+        `/hub/schedules/${encodeURIComponent(id)}`,
+        { enabled: sub === "resume" },
+      ));
+      break;
+    }
+    case "delete": {
+      const id = args.flags["id"];
+      if (typeof id !== "string" || !id) outputError("--id is required");
+      await scheduleRequest(client, hubUrl, "DELETE", `/hub/schedules/${encodeURIComponent(id)}`);
+      outputJson({ deleted: true, id });
+      break;
+    }
+    case "run": {
+      const id = args.flags["id"];
+      if (typeof id !== "string" || !id) outputError("--id is required");
+      outputJson(await scheduleRequest(client, hubUrl, "POST", `/hub/schedules/${encodeURIComponent(id)}/run`));
+      break;
+    }
+    case "runs": {
+      const id = args.flags["id"];
+      if (typeof id !== "string" || !id) outputError("--id is required");
+      outputJson(await scheduleRequest(client, hubUrl, "GET", `/hub/schedules/${encodeURIComponent(id)}/runs`));
+      break;
+    }
+    default:
+      outputError(`unknown subcommand: ${sub}`);
+  }
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -24,6 +24,7 @@ import { uploadCommand } from "./commands/upload.js";
 import { tokenCommand } from "./commands/token.js";
 import { envCommand } from "./commands/env.js";
 import { memoryCommand } from "./commands/memory.js";
+import { scheduleCommand } from "./commands/schedule.js";
 
 const VERSION = "0.1.0";
 
@@ -55,6 +56,7 @@ Commands:
   token             Fetch current JWT token
   env               View or switch hub environment
   memory            Manage working memory
+  schedule          Manage proactive schedules
 
 Global options:
   --agent <id>      Use specific agent credentials
@@ -154,6 +156,9 @@ async function main(): Promise<void> {
         break;
       case "memory":
         await memoryCommand(args, globalHub, globalAgent);
+        break;
+      case "schedule":
+        await scheduleCommand(args, globalHub, globalAgent);
         break;
       default:
         outputError(`unknown command: ${args.command}. Run "botcord --help" for usage.`);

--- a/packages/protocol-core/src/client.ts
+++ b/packages/protocol-core/src/client.ts
@@ -23,6 +23,10 @@ import type {
   WithdrawalResponse,
   SubscriptionProduct,
   Subscription,
+  AgentSchedule,
+  AgentScheduleRun,
+  AgentScheduleSpec,
+  AgentSchedulePayload,
 } from "./types.js";
 
 const MAX_RETRIES = 2;
@@ -1010,5 +1014,64 @@ export class BotCordClient {
     } catch {
       return null;
     }
+  }
+
+  // ── Agent schedules ──────────────────────────────────────────
+
+  async listSchedules(): Promise<{ schedules: AgentSchedule[] }> {
+    const resp = await this.hubFetch("/hub/schedules");
+    return (await resp.json()) as { schedules: AgentSchedule[] };
+  }
+
+  async createSchedule(params: {
+    name: string;
+    enabled?: boolean;
+    schedule: AgentScheduleSpec;
+    payload?: AgentSchedulePayload;
+  }): Promise<AgentSchedule> {
+    const resp = await this.hubFetch("/hub/schedules", {
+      method: "POST",
+      body: JSON.stringify({
+        name: params.name,
+        enabled: params.enabled ?? true,
+        schedule: params.schedule,
+        payload: params.payload,
+      }),
+    });
+    return (await resp.json()) as AgentSchedule;
+  }
+
+  async updateSchedule(
+    scheduleId: string,
+    params: {
+      name?: string;
+      enabled?: boolean;
+      schedule?: AgentScheduleSpec;
+      payload?: AgentSchedulePayload;
+    },
+  ): Promise<AgentSchedule> {
+    const resp = await this.hubFetch(`/hub/schedules/${encodeURIComponent(scheduleId)}`, {
+      method: "PATCH",
+      body: JSON.stringify(params),
+    });
+    return (await resp.json()) as AgentSchedule;
+  }
+
+  async deleteSchedule(scheduleId: string): Promise<void> {
+    await this.hubFetch(`/hub/schedules/${encodeURIComponent(scheduleId)}`, {
+      method: "DELETE",
+    });
+  }
+
+  async runSchedule(scheduleId: string): Promise<AgentScheduleRun> {
+    const resp = await this.hubFetch(`/hub/schedules/${encodeURIComponent(scheduleId)}/run`, {
+      method: "POST",
+    });
+    return (await resp.json()) as AgentScheduleRun;
+  }
+
+  async listScheduleRuns(scheduleId: string): Promise<{ runs: AgentScheduleRun[] }> {
+    const resp = await this.hubFetch(`/hub/schedules/${encodeURIComponent(scheduleId)}/runs`);
+    return (await resp.json()) as { runs: AgentScheduleRun[] };
   }
 }

--- a/packages/protocol-core/src/types.ts
+++ b/packages/protocol-core/src/types.ts
@@ -282,3 +282,40 @@ export type SubscriptionChargeAttempt = {
   failure_reason: string | null;
   created_at: string;
 };
+
+export type AgentScheduleSpec =
+  | { kind: "every"; every_ms: number }
+  | { kind: "calendar"; frequency: "daily"; time: string; timezone: string }
+  | { kind: "calendar"; frequency: "weekly"; time: string; timezone: string; weekdays: number[] };
+
+export type AgentSchedulePayload = {
+  kind: "agent_turn";
+  message: string;
+};
+
+export type AgentSchedule = {
+  id: string;
+  agent_id: string;
+  name: string;
+  enabled: boolean;
+  schedule: AgentScheduleSpec;
+  payload: AgentSchedulePayload;
+  created_by: "owner" | "agent" | string;
+  next_fire_at: string | null;
+  last_fire_at: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+};
+
+export type AgentScheduleRun = {
+  id: string;
+  schedule_id: string;
+  agent_id: string;
+  scheduled_for: string;
+  started_at: string | null;
+  completed_at: string | null;
+  status: "queued" | "dispatched" | "offline" | "failed" | string;
+  error: string | null;
+  dedupe_key: string;
+  created_at: string | null;
+};

--- a/plugin/skills/botcord-user-guide/SKILL.md
+++ b/plugin/skills/botcord-user-guide/SKILL.md
@@ -253,7 +253,7 @@ The Bot drives these steps itself on the owner's first message — do not front-
 1. **STEP 1 — Choose scenario**: pick a use case (e.g. AI freelancer, content creator, team, social, customer service, monitoring, or custom)
 2. **STEP 2 — Set goal and strategy**: replace the seed goal with the owner's real goal; define strategy, weekly tasks, and owner preferences
 3. **STEP 3 — Scene-specific setup**: for scenarios that need it (freelance / content / team), create the relevant rooms and record their `rm_...` IDs
-4. **STEP 4 — Configure autonomous execution**: set up scheduling / proactive cadence so the Bot can act on its own between owner messages
+4. **STEP 4 — Configure autonomous execution**: set up scheduling / proactive cadence so the Bot can act on its own between owner messages. Prefer Hub schedules through `botcord_schedule`; use system `crontab` or the host runtime's scheduler only when Hub schedules are unavailable.
 5. **STEP 5 — Install checklist**: confirm profile, credential backup, dashboard binding, and owner notification channel (Telegram / Discord / webchat) all work
 
 One step at a time — wait for the owner to respond before moving on. Each step's result is written into working memory as a named section; that record is also how the Bot resumes if the conversation is interrupted.

--- a/plugin/skills/botcord/SKILL.md
+++ b/plugin/skills/botcord/SKILL.md
@@ -53,6 +53,7 @@ Send to a room with `"to": "rm_..."`.
 | `botcord_rooms` | [social](../botcord-social/SKILL.md) | Create/join/manage rooms and members |
 | `botcord_payment` | [payment](../botcord-payment/SKILL.md) | Wallet balance, transfers, topups, withdrawals |
 | `botcord_subscription` | [payment](../botcord-payment/SKILL.md) | Subscription products and gated rooms |
+| `botcord_schedule` | this skill | Create, list, edit, pause, delete, or run proactive Hub schedules |
 | `botcord_account` | [account](../botcord-account/SKILL.md) | Agent identity, profile, message policy |
 | `botcord_notify` | [account](../botcord-account/SKILL.md) | Send notification to owner's channel |
 | `botcord_bind` | [account](../botcord-account/SKILL.md) | Bind agent to web dashboard account |

--- a/plugin/skills/botcord/SKILL_PROACTIVE.md
+++ b/plugin/skills/botcord/SKILL_PROACTIVE.md
@@ -1,6 +1,6 @@
 ---
 name: botcord-proactive
-description: "BotCord proactive execution protocol. Load when: incoming message contains 'BotCord 自主任务' trigger phrase (typically from a scheduled cron job)."
+description: "BotCord proactive execution protocol. Load when: incoming message contains 'BotCord 自主任务' trigger phrase (typically from a Hub schedule or fallback cron job)."
 metadata:
   requires:
     plugins: ["@botcord/botcord"]
@@ -8,7 +8,7 @@ metadata:
 
 # BotCord — Proactive Execution Protocol
 
-**Trigger:** Load this when the incoming message contains「BotCord 自主任务」. This is typically a scheduled cron message, but the protocol applies regardless of how the trigger phrase arrives.
+**Trigger:** Load this when the incoming message contains「BotCord 自主任务」. This is typically a Hub schedule message, but the protocol applies regardless of how the trigger phrase arrives.
 
 **Prerequisites:** Read [`SKILL.md`](./SKILL.md) for protocol overview and agent behavior rules.
 

--- a/plugin/skills/botcord/onboarding_instruction.md
+++ b/plugin/skills/botcord/onboarding_instruction.md
@@ -23,7 +23,7 @@
 | `<section_scenario>` 缺失 | **STEP 1** — 选择场景；owner 确认后**立即**用 `botcord_update_working_memory` 写 `section: "scenario"` 记录所选场景（例如 `"ai_freelancer"` / `"content_creator"` / `"team"` / `"social"` / `"customer_service"` / `"monitoring"` / `"custom: <描述>"`），再进入下一步 |
 | `<section_scenario>` 已存在，但 Goal 仍是 seed，或 `strategy` / `weekly_tasks` / `owner_prefs` 任一缺失 | **STEP 2** — 设定目标和策略；完成时改写 `goal` 为 owner 的真正目标；补齐 `strategy` / `weekly_tasks` / `owner_prefs` sections |
 | Goal 已改写，但 `<section_room_setup>`（或类似群配置记录 section）缺失，且场景是接单/内容/团队 | **STEP 3** — 场景操作（建群），完成后用 `botcord_update_working_memory` 写 `section: "room_setup"` 记录已建房间的 `rm_...` ID |
-| 该建的群已建好（或场景不需建群），且 `<section_scheduling>` 缺失 | **STEP 4** — 配置自主执行，完成后写 `section: "scheduling"` 记录调度细节 |
+| 该建的群已建好（或场景不需建群），且 `<section_scheduling>` 缺失 | **STEP 4** — 配置自主执行（优先用 `botcord_schedule` 配置 Hub schedule；不可用时再用系统 crontab 或宿主 runtime scheduler），完成后写 `section: "scheduling"` 记录调度细节 |
 | `<section_scheduling>` 已存在，且 `<section_install_checklist>` 缺失 | **STEP 5** — 安装清单（profile、凭证备份、dashboard 绑定、通知渠道），完成后写 `section: "install_checklist"` 记录每项状态 |
 | 以上所有"完成信号" section（`scenario` / `strategy` / `weekly_tasks` / `owner_prefs` / `room_setup`(或场景不需建群) / `scheduling` / `install_checklist`）都齐了 | **结束**：用**一次** `botcord_update_working_memory(section: "onboarding", content: "")` 删除 onboarding section，展示激活摘要（目标 / 策略 / 定时频率）——**删除 `onboarding` section 才是 onboarding 结束的标志**。`scenario` 等进度 section 保留不删（留作历史记录，清掉反而会让中断重启时误判成"还没选场景"）|
 


### PR DESCRIPTION
## Summary
- add `botcord schedule` commands for listing, creating, editing, pausing, resuming, deleting, running, and inspecting proactive schedules
- add typed schedule APIs and types to `@botcord/protocol-core`
- align CLI and plugin skill docs around Hub schedules as the primary scheduling path

## Tests
- `cd cli && npm run build`
- `cd packages/protocol-core && npm run build`
- `cd backend && uv run pytest tests/test_app/test_agent_schedules.py`