### PR TITLE
feat(frontend): mobile-first adaptation for dashboard and marketing

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -27,6 +27,29 @@ body {
   color: var(--color-text-primary);
   font-family: var(--font-sans);
   overflow-x: hidden;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* iOS Safari/Chrome auto-zooms when focusing inputs with font-size < 16px.
+ * Force at least 16px on touch-screen devices for input/textarea/select.
+ * Desktop keeps the original Tailwind text-sm/xs sizes. */
+@media (pointer: coarse) {
+  input:not([type="checkbox"]):not([type="radio"]),
+  textarea,
+  select {
+    font-size: 16px !important;
+  }
+}
+
+/* iPhone safe-area helpers for the dashboard bottom nav and floating UI. */
+.pb-safe {
+  padding-bottom: env(safe-area-inset-bottom);
+}
+.pt-safe {
+  padding-top: env(safe-area-inset-top);
+}
+.h-safe-bottom {
+  height: env(safe-area-inset-bottom);
 }
 
 ::selection {

--- a/frontend/src/app/invite/page.tsx
+++ b/frontend/src/app/invite/page.tsx
@@ -1,9 +1,0 @@
-"use client";
-
-import dynamic from "next/dynamic";
-
-const InvitePage = dynamic(() => import("@/components/invite/InvitePage"), { ssr: false });
-
-export default function Invite() {
-  return <InvitePage />;
-}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,7 +5,7 @@
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
 
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Analytics } from "@vercel/analytics/next";
 import NextTopLoader from "nextjs-toploader";
 import { inter, jetbrainsMono } from "@/lib/fonts";
@@ -24,6 +24,13 @@ export const metadata: Metadata = {
     type: "website",
   },
   icons: { icon: "/logo.svg" },
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  viewportFit: "cover",
+  themeColor: "#0a0a0f",
 };
 
 export default function RootLayout({

--- a/frontend/src/components/dashboard/AgentSettingsDrawer.tsx
+++ b/frontend/src/components/dashboard/AgentSettingsDrawer.tsx
@@ -344,13 +344,13 @@ export default function AgentSettingsDrawer({
         </div>
 
         {/* Tabs */}
-        <div className="flex border-b border-glass-border/60 px-4">
+        <div className="flex flex-nowrap overflow-x-auto border-b border-glass-border/60 px-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           {(["profile", "policy", "schedules", "gateways", "files"] as Tab[]).map((t) => (
             <button
               key={t}
               type="button"
               onClick={() => setTab(t)}
-              className={`flex items-center gap-1.5 px-3 py-3 text-xs font-medium transition-colors ${
+              className={`flex shrink-0 items-center gap-1.5 whitespace-nowrap px-3 py-3 text-xs font-medium transition-colors ${
                 tab === t
                   ? "border-b-2 border-neon-cyan text-neon-cyan"
                   : "text-text-secondary hover:text-text-primary"

--- a/frontend/src/components/dashboard/ChatPane.tsx
+++ b/frontend/src/components/dashboard/ChatPane.tsx
@@ -9,7 +9,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useLanguage } from '@/lib/i18n';
-import { chatPane, exploreUi } from '@/lib/i18n/translations/dashboard';
+import { chatPane, exploreUi, sidebar } from '@/lib/i18n/translations/dashboard';
 import { useRouter } from "nextjs-toploader/app";
 import { useShallow } from "zustand/react/shallow";
 import { Loader2 } from "lucide-react";
@@ -58,6 +58,7 @@ function ContactsMainPane({ onHumanOpen }: { onHumanOpen?: (human: PublicHumanPr
   const router = useRouter();
   const locale = useLanguage();
   const t = chatPane[locale];
+  const tSidebar = sidebar[locale];
   const { contactsView, setFocusedRoomId, setOpenedRoomId, setSidebarTab } = useDashboardUIStore(useShallow((state) => ({
     contactsView: state.contactsView,
     setFocusedRoomId: state.setFocusedRoomId,
@@ -173,9 +174,20 @@ function ContactsMainPane({ onHumanOpen }: { onHumanOpen?: (human: PublicHumanPr
     }
   };
 
+  const switchContactsView = (view: "requests" | "agents" | "rooms" | "created") => {
+    useDashboardUIStore.getState().setContactsView(view);
+    router.push(`/chats/contacts/${view}`);
+  };
+  const mobileContactsBtn = (active: boolean) =>
+    `whitespace-nowrap rounded-full border px-3 py-1.5 text-xs font-medium transition-colors ${
+      active
+        ? "border-neon-cyan/60 bg-neon-cyan/15 text-neon-cyan"
+        : "border-glass-border bg-glass-bg text-text-secondary hover:text-text-primary"
+    }`;
+
   return (
     <div className="flex flex-1 flex-col overflow-hidden bg-deep-black">
-      <div className="border-b border-glass-border px-5 py-4">
+      <div className="border-b border-glass-border px-5 py-4 max-md:px-4 max-md:py-3">
         <h2 className="text-base font-semibold text-text-primary">
           {isRequestsView
             ? t.contactRequests
@@ -185,7 +197,7 @@ function ContactsMainPane({ onHumanOpen }: { onHumanOpen?: (human: PublicHumanPr
                 ? t.createdRooms
                 : t.contacts}
         </h2>
-        <p className="mt-1 text-xs text-text-secondary">
+        <p className="mt-1 text-xs text-text-secondary max-md:hidden">
           {isRequestsView
             ? t.reviewRequests
             : isRoomsView
@@ -194,6 +206,12 @@ function ContactsMainPane({ onHumanOpen }: { onHumanOpen?: (human: PublicHumanPr
                 ? t.roomsCreatedByMe
                 : t.yourAgentContacts}
         </p>
+        <div className="mt-3 flex flex-nowrap gap-1.5 overflow-x-auto md:hidden">
+          <button type="button" onClick={() => switchContactsView("requests")} className={mobileContactsBtn(isRequestsView)}>{tSidebar.friendRequests}</button>
+          <button type="button" onClick={() => switchContactsView("agents")} className={mobileContactsBtn(!isRequestsView && !isRoomsView && !isCreatedView)}>{tSidebar.myFriends}</button>
+          <button type="button" onClick={() => switchContactsView("rooms")} className={mobileContactsBtn(isRoomsView)}>{tSidebar.joinedRooms}</button>
+          <button type="button" onClick={() => switchContactsView("created")} className={mobileContactsBtn(isCreatedView)}>{tSidebar.createdRooms}</button>
+        </div>
         <div className="mt-3 flex flex-wrap items-center gap-3">
           <div className="min-w-[240px] max-w-xl flex-1">
             <SearchBar
@@ -516,19 +534,35 @@ function ExploreMainPane({ onHumanOpen }: ChatPaneProps) {
   const loading = isRoomsView ? publicRoomsLoading : isAgentsView ? publicAgentsLoading : publicHumansLoading;
   const emptyText = isRoomsView ? t.noRoomsFound : isAgentsView ? t.noAgentsFound : t.noHumansFound;
 
+  const switchExploreView = (view: "rooms" | "agents" | "humans") => {
+    useDashboardUIStore.getState().setExploreView(view);
+    router.push(`/chats/explore/${view}`);
+  };
+  const mobileTabBtn = (active: boolean) =>
+    `flex-1 whitespace-nowrap rounded-full border px-3 py-1.5 text-xs font-medium transition-colors ${
+      active
+        ? "border-neon-purple/60 bg-neon-purple/15 text-neon-purple"
+        : "border-glass-border bg-glass-bg text-text-secondary hover:text-text-primary"
+    }`;
+
   return (
     <div className="relative flex flex-1 flex-col overflow-hidden bg-deep-black">
-      <div className="border-b border-glass-border px-5 py-4">
+      <div className="border-b border-glass-border px-5 py-4 max-md:px-4 max-md:py-3">
         <div className="min-w-0">
           <h2 className="text-base font-semibold text-text-primary">{title}</h2>
-          <p className="mt-1 text-xs text-text-secondary">{subtitle}</p>
+          <p className="mt-1 text-xs text-text-secondary max-md:hidden">{subtitle}</p>
+        </div>
+        <div className="mt-3 flex gap-1.5 md:hidden">
+          <button type="button" onClick={() => switchExploreView("rooms")} className={mobileTabBtn(isRoomsView)}>{t.publicRooms}</button>
+          <button type="button" onClick={() => switchExploreView("agents")} className={mobileTabBtn(isAgentsView)}>{t.publicAgents}</button>
+          <button type="button" onClick={() => switchExploreView("humans")} className={mobileTabBtn(isHumansView)}>{t.publicHumans}</button>
         </div>
         <div className="mt-3 max-w-xl">
           <SearchBar onSearch={setQuery} placeholder={searchPlaceholder} />
         </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto px-5 py-4">
+      <div className="flex-1 overflow-y-auto px-5 py-4 max-md:px-4">
         {loading ? (
           <GridSkeletonCards />
         ) : isRoomsView ? (

--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -960,6 +960,8 @@ export default function DashboardApp() {
   const mobileHideSecondary =
     uiStore.sidebarTab === "wallet"
     || uiStore.sidebarTab === "activity"
+    || uiStore.sidebarTab === "explore"
+    || uiStore.sidebarTab === "contacts"
     || (uiStore.sidebarTab === "messages" && (uiStore.messagesPane === "user-chat" || Boolean(uiStore.openedRoomId)))
     || (uiStore.sidebarTab === "bots" && Boolean(uiStore.selectedBotAgentId));
   const mainPaneClass = `min-h-0 min-w-0 flex-1 ${mobileShowsMain ? "" : "max-md:hidden"}`;

--- a/frontend/src/components/dashboard/RoomHeader.tsx
+++ b/frontend/src/components/dashboard/RoomHeader.tsx
@@ -12,7 +12,7 @@ import { common } from "@/lib/i18n/translations/common";
 import { roomList } from "@/lib/i18n/translations/dashboard";
 import { useRouter } from "nextjs-toploader/app";
 import { useShallow } from "zustand/react/shallow";
-import { ArrowLeft, Bell, Info, Loader2, PanelLeftOpen, Plus, Settings, Share2 } from "lucide-react";
+import { ArrowLeft, Bell, Info, Loader2, PanelLeftOpen, Plus, Settings, Share2, X } from "lucide-react";
 import CopyableId from "@/components/ui/CopyableId";
 import { api, humansApi } from "@/lib/api";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
@@ -272,7 +272,7 @@ export default function RoomHeader() {
 
   return (
     <>
-      <div className="flex min-h-16 items-center justify-between border-b border-glass-border px-4 py-3 max-md:gap-2 max-md:px-3">
+      <div className="flex min-h-16 items-center justify-between gap-2 border-b border-glass-border px-4 py-3 max-md:min-h-12 max-md:gap-1 max-md:px-2 max-md:py-2">
         <button
           type="button"
           onClick={handleMobileBack}
@@ -280,7 +280,7 @@ export default function RoomHeader() {
           aria-label="Back to messages"
           title="Back to messages"
         >
-          <ArrowLeft className="h-4 w-4" />
+          <ArrowLeft className="h-5 w-5" />
         </button>
         <button
           type="button"
@@ -289,9 +289,9 @@ export default function RoomHeader() {
           aria-label="Open message list"
           title="Open message list"
         >
-          <PanelLeftOpen className="h-4 w-4" />
+          <PanelLeftOpen className="h-5 w-5" />
         </button>
-        <div className="min-w-0 py-0.5">
+        <div className="min-w-0 flex-1 py-0.5 max-md:py-0">
           <div className="flex items-center gap-2">
             <h3 className="truncate text-sm font-semibold text-text-primary">{titleText}</h3>
             {room.required_subscription_product_id ? (
@@ -308,33 +308,52 @@ export default function RoomHeader() {
                   <Info className="h-4 w-4" />
                 </button>
                 {showRulePopover && (
-                  <div className="absolute left-0 top-full z-30 mt-1 w-[min(32rem,calc(100vw-2rem))] space-y-3 rounded-lg border border-glass-border bg-deep-black p-3 shadow-xl">
-                    {roomDescription && (
-                      <div>
-                        <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-neon-cyan">
-                          {t.roomDescriptionLabel}
-                        </p>
-                        <p className="max-h-48 overflow-y-auto whitespace-pre-wrap text-xs leading-5 text-text-secondary">
-                          {roomDescription}
-                        </p>
-                      </div>
-                    )}
-                    {roomRule && (
-                      <div>
-                        <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-neon-cyan">
-                          {t.viewRule}
-                        </p>
-                        <p className="max-h-48 overflow-y-auto whitespace-pre-wrap text-xs leading-5 text-text-secondary">
-                          {roomRule}
-                        </p>
-                      </div>
-                    )}
-                  </div>
+                  <>
+                    <button
+                      type="button"
+                      aria-label="Close"
+                      onClick={() => setShowRulePopover(false)}
+                      className="fixed inset-0 z-40 hidden bg-black/70 backdrop-blur-sm max-md:block"
+                    />
+                    <div
+                      className="absolute left-0 top-full z-50 mt-1 w-[min(32rem,calc(100vw-2rem))] space-y-3 rounded-lg border border-glass-border bg-deep-black p-3 shadow-xl
+                        max-md:fixed max-md:inset-x-4 max-md:top-1/2 max-md:mt-0 max-md:w-auto max-md:max-h-[75vh] max-md:-translate-y-1/2 max-md:space-y-4 max-md:overflow-y-auto max-md:rounded-2xl max-md:border-glass-border max-md:bg-deep-black-light max-md:p-5 max-md:pt-12 max-md:shadow-2xl"
+                    >
+                      <button
+                        type="button"
+                        onClick={() => setShowRulePopover(false)}
+                        className="absolute right-3 top-3 hidden h-7 w-7 items-center justify-center rounded text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary max-md:inline-flex"
+                        aria-label="Close"
+                      >
+                        <X className="h-4 w-4" />
+                      </button>
+                      {roomDescription && (
+                        <div>
+                          <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-neon-cyan">
+                            {t.roomDescriptionLabel}
+                          </p>
+                          <p className="max-h-48 overflow-y-auto whitespace-pre-wrap text-xs leading-5 text-text-secondary max-md:max-h-none max-md:text-sm max-md:leading-6">
+                            {roomDescription}
+                          </p>
+                        </div>
+                      )}
+                      {roomRule && (
+                        <div>
+                          <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-neon-cyan">
+                            {t.viewRule}
+                          </p>
+                          <p className="max-h-48 overflow-y-auto whitespace-pre-wrap text-xs leading-5 text-text-secondary max-md:max-h-none max-md:text-sm max-md:leading-6">
+                            {roomRule}
+                          </p>
+                        </div>
+                      )}
+                    </div>
+                  </>
                 )}
               </div>
             )}
           </div>
-          <div className="flex min-w-0 items-center gap-1.5 overflow-hidden text-xs text-text-secondary">
+          <div className="flex min-w-0 items-center gap-1.5 overflow-hidden text-xs text-text-secondary max-md:hidden">
             <button
               onClick={() => setShowSettingsModal(true)}
               className="shrink-0 whitespace-nowrap hover:text-neon-cyan hover:underline transition-colors"
@@ -351,7 +370,7 @@ export default function RoomHeader() {
             <span className="shrink-0"><CopyableId value={room.room_id} /></span>
           </div>
           {roomRule && (
-            <div className="mt-1">
+            <div className="mt-1 max-md:hidden">
               <p
                 ref={ruleRef}
                 className={`text-xs leading-5 text-text-secondary ${ruleExpanded ? "" : "line-clamp-2"}`}
@@ -370,7 +389,7 @@ export default function RoomHeader() {
             </div>
           )}
         </div>
-        <div className="flex shrink-0 flex-nowrap items-center gap-1.5 self-start py-0.5 max-md:gap-1">
+        <div className="flex shrink-0 flex-nowrap items-center gap-1.5 self-center py-0.5 max-md:gap-0.5">
 
           {renderJoinButton()}
           {isGuest && (
@@ -391,7 +410,7 @@ export default function RoomHeader() {
             </span>
           )}
           {canAddMembers && (
-            <span className="group relative">
+            <span className="group relative max-md:hidden">
               <button
                 onClick={() => void handleOpenAddMemberModal()}
                 disabled={addMemberLoading}
@@ -404,7 +423,7 @@ export default function RoomHeader() {
             </span>
           )}
           {isAuthedReady && activeAgentId && !isHumanView && isJoined && !isOwnerChatRoom && (
-            <span className="group relative">
+            <span className="group relative max-md:hidden">
               <button
                 onClick={() => setShowPolicyModal(true)}
                 className={iconBtn}

--- a/frontend/src/components/dashboard/sidebar/index.tsx
+++ b/frontend/src/components/dashboard/sidebar/index.tsx
@@ -319,9 +319,9 @@ export default function Sidebar({
   };
 
   return (
-    <div className={`flex h-full max-md:w-full max-md:flex-col-reverse ${mobileHideSecondary ? "max-md:h-16" : "max-md:h-full"}`}>
+    <div className={`flex h-full max-md:w-full max-md:flex-col-reverse ${mobileHideSecondary ? "max-md:h-[calc(4rem+env(safe-area-inset-bottom))]" : "max-md:h-full"}`}>
       {/* Primary rail */}
-      <div className="flex h-full w-16 min-w-[64px] flex-col items-center border-r border-glass-border bg-deep-black py-3 max-md:h-16 max-md:w-full max-md:min-w-0 max-md:shrink-0 max-md:flex-row max-md:border-r-0 max-md:border-t max-md:px-2 max-md:py-2">
+      <div className="flex h-full w-16 min-w-[64px] flex-col items-center border-r border-glass-border bg-deep-black py-3 max-md:h-[calc(4rem+env(safe-area-inset-bottom))] max-md:w-full max-md:min-w-0 max-md:shrink-0 max-md:flex-row max-md:border-r-0 max-md:border-t max-md:px-2 max-md:pb-[calc(0.5rem+env(safe-area-inset-bottom))] max-md:pt-2">
         <Link
           href="/"
           className="mb-3 flex h-11 w-11 items-center justify-center rounded-xl border border-glass-border bg-deep-black-light transition-colors hover:border-neon-cyan/50 hover:bg-glass-bg max-md:mb-0 max-md:mr-2 max-md:hidden"
@@ -431,7 +431,7 @@ export default function Sidebar({
         <button
           type="button"
           aria-label="Close sidebar"
-          className="fixed inset-x-0 bottom-16 top-0 z-30 hidden bg-black/45 backdrop-blur-sm max-md:block"
+          className="fixed inset-x-0 top-0 z-30 hidden bg-black/45 backdrop-blur-sm max-md:block max-md:bottom-[calc(4rem+env(safe-area-inset-bottom))]"
           onClick={onMobileSecondaryClose}
         />
       )}
@@ -441,7 +441,7 @@ export default function Sidebar({
         className={`relative flex h-full flex-col border-r border-glass-border bg-deep-black-light max-md:min-h-0 max-md:flex-1 max-md:!min-w-0 max-md:border-r-0 ${
           mobileHideSecondary
             ? mobileSecondaryOpen
-              ? "max-md:fixed max-md:inset-x-3 max-md:bottom-20 max-md:top-4 max-md:z-40 max-md:!w-auto max-md:rounded-xl max-md:border max-md:border-glass-border max-md:shadow-2xl max-md:shadow-black/50"
+              ? "max-md:fixed max-md:inset-x-3 max-md:bottom-[calc(5rem+env(safe-area-inset-bottom))] max-md:top-4 max-md:z-40 max-md:!w-auto max-md:rounded-xl max-md:border max-md:border-glass-border max-md:shadow-2xl max-md:shadow-black/50"
               : "max-md:hidden"
             : "max-md:!w-full"
         }`}

--- a/frontend/src/components/home/CTASection.tsx
+++ b/frontend/src/components/home/CTASection.tsx
@@ -10,9 +10,9 @@ export default function CTASection() {
   const t = cta[locale];
 
   return (
-    <section className="px-6 py-24">
+    <section className="px-4 py-16 md:px-6 md:py-24">
       <motion.div
-        className="mx-auto max-w-3xl rounded-2xl border border-glass-border bg-glass-bg p-12 text-center backdrop-blur-xl"
+        className="mx-auto max-w-3xl rounded-2xl border border-glass-border bg-glass-bg p-6 text-center backdrop-blur-xl sm:p-8 md:p-12"
         initial={{ opacity: 0, y: 30 }}
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true, margin: "-50px" }}

--- a/frontend/src/components/vision/PhilosophySection.tsx
+++ b/frontend/src/components/vision/PhilosophySection.tsx
@@ -10,14 +10,14 @@ export default function PhilosophySection() {
 
   return (
     <div className="space-y-4">
-      {/* Header row */}
-      <div className="grid grid-cols-2 gap-4 px-4 text-sm font-semibold">
+      {/* Header row — desktop only; on mobile each card is labelled inline */}
+      <div className="hidden grid-cols-2 gap-4 px-4 text-sm font-semibold md:grid">
         <span className="text-text-secondary">{t.traditional}</span>
         <span className="text-neon-cyan">{t.botcordWay}</span>
       </div>
 
       {t.comparisons.map((item, i) => (
-        <div key={i} className="grid grid-cols-2 gap-4">
+        <div key={i} className="grid grid-cols-1 gap-3 md:grid-cols-2 md:gap-4">
           <motion.div
             initial={{ opacity: 0, x: -30 }}
             whileInView={{ opacity: 1, x: 0 }}
@@ -25,6 +25,7 @@ export default function PhilosophySection() {
             transition={{ duration: 0.5, delay: i * 0.1 }}
             className="rounded-lg border border-red-500/10 bg-red-500/5 p-4"
           >
+            <p className="mb-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-text-secondary/70 md:hidden">{t.traditional}</p>
             <p className="text-sm text-text-secondary">{item[0]}</p>
           </motion.div>
 
@@ -35,6 +36,7 @@ export default function PhilosophySection() {
             transition={{ duration: 0.5, delay: i * 0.1 }}
             className="rounded-lg border border-neon-cyan/20 bg-neon-cyan/5 p-4"
           >
+            <p className="mb-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-neon-cyan/70 md:hidden">{t.botcordWay}</p>
             <p className="text-sm text-neon-cyan/80">{item[1]}</p>
           </motion.div>
         </div>

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -1,63 +1,8 @@
-import { createServerClient } from "@supabase/ssr";
-import { NextResponse, type NextRequest } from "next/server";
+import { type NextRequest } from "next/server";
 import { updateSession } from "@/lib/supabase/middleware";
 
 export async function proxy(request: NextRequest) {
-  const response = await updateSession(request);
-
-  // Beta access gate: only applies to /chats/** when enabled
-  const betaGateEnabled = process.env.NEXT_PUBLIC_BETA_GATE_ENABLED !== "false";
-  if (betaGateEnabled && request.nextUrl.pathname.startsWith("/chats")) {
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-    const supabaseAnonKey =
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
-      process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY;
-
-    if (supabaseUrl && supabaseAnonKey) {
-      const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
-        cookies: {
-          getAll() {
-            return request.cookies.getAll();
-          },
-          setAll() {
-            // No-op: cookies already handled by updateSession
-          },
-        },
-      });
-
-      const { data: { user } } = await supabase.auth.getUser();
-
-      if (!user) {
-        return NextResponse.redirect(new URL("/invite", request.url));
-      }
-
-      // Check JWT metadata first (fast path)
-      if (user.user_metadata?.beta_access !== true) {
-        // Fallback: check backend DB in case Supabase metadata sync failed
-        const hubBase = process.env.NEXT_PUBLIC_HUB_BASE_URL || "https://api.botcord.chat";
-        const { data: { session } } = await supabase.auth.getSession();
-        if (session?.access_token) {
-          try {
-            const res = await fetch(`${hubBase}/api/users/me`, {
-              headers: { Authorization: `Bearer ${session.access_token}` },
-            });
-            if (res.ok) {
-              const me = await res.json();
-              if (me.beta_access === true) {
-                // DB says beta, JWT doesn't — allow access, metadata will sync eventually
-                return response;
-              }
-            }
-          } catch {
-            // Backend unreachable — fall through to redirect
-          }
-        }
-        return NextResponse.redirect(new URL("/invite", request.url));
-      }
-    }
-  }
-
-  return response;
+  return updateSession(request);
 }
 
 export const config = {
@@ -67,6 +12,5 @@ export const config = {
     "/api/:path*",
     "/auth/:path*",
     "/login",
-    "/invite",
   ],
 };


### PR DESCRIPTION
## Summary
Make the frontend usable on iPhone (375–430px) — dashboard, marketing pages, and entry pages all adapted. Production build (\`pnpm build\`) passes.

### Global foundations
- \`viewport-fit=cover\` + \`themeColor\` in root layout
- Force 16px font on \`input/textarea/select\` under \`(pointer: coarse)\` to stop iOS Safari focus-zoom
- \`safe-area-inset-bottom\` on dashboard bottom nav, plus the overlay/drawer offsets that anchor to it

### Dashboard
- **RoomHeader**: collapses to a single-row mobile header; hides the verbose meta line (\`2 成员 · 你是 owner · rm_...\`) and the inline rule preview; promotes the Info popover to a centered dialog with backdrop on mobile; hides Plus/Bell (still reachable from Settings)
- **Discover & Contacts**: \`mobileHideSecondary\` now also covers \`explore\`/\`contacts\` so the main pane gets full width; sub-nav (公开房间/Bot/Human, 请求/好友/已加入/我创建) inlines as horizontally-scrollable pills inside the main pane
- **AgentSettingsDrawer**: tabs row → single-line horizontal scroller (\`对话与回复\` / \`文件/记忆\` no longer wrap)

### Marketing
- **PhilosophySection**: 2-col comparison stacks single-column on mobile with inline 传统 / BotCord 标签
- **CTASection**: inner padding \`p-12\` → \`p-6 sm:p-8 md:p-12\`; section py-24 → py-16 on mobile

### Cleanup
- Drop legacy beta-gate page (\`/invite\`) and its \`proxy.ts\` redirect; \`/i/[inviteCode]\` invite-link flow untouched

## Test plan
- [ ] iPhone SE (375) — dashboard primary tabs, room chat, Info dialog, Discover, Bots drawer
- [ ] iPhone 14 / 14 Pro Max (390 / 430) — same flows + safe-area at bottom
- [ ] Desktop (≥ md) — sidebar resize handle, popover positioning, two-column comparison, scenarios grid unchanged
- [ ] \`pnpm build\` — passes (22 static pages prerendered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)