### PR TITLE
fix: allow deployed frontend CORS origins

### DIFF
--- a/backend/hub/main.py
+++ b/backend/hub/main.py
@@ -159,13 +159,10 @@ _cors_origins = [
     "http://localhost:4321",
     "http://localhost:3000",
     "https://botcord.vercel.app",
+    "https://preview.botcord.chat",
+    "https://botcord.chat",
+    "https://www.botcord.chat",
 ]
-
-if hub_config.ENVIRONMENT_TAG == "preview":
-    _cors_origins.append("https://preview.botcord.chat")
-else:
-    _cors_origins.append("https://botcord.chat")
-    _cors_origins.append("https://www.botcord.chat")
 
 # Browsers treat http://localhost:P1 → http://localhost:P2 as cross-origin when P1 ≠ P2.
 # With allow_credentials=True, the reflected Origin must match exactly; a regex covers any

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -1,0 +1,33 @@
+"""CORS coverage for deployed frontend origins."""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "https://preview.botcord.chat",
+        "https://botcord.chat",
+        "https://www.botcord.chat",
+    ],
+)
+async def test_deployed_frontend_origins_pass_preflight(origin: str):
+    from hub.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        res = await client.options(
+            "/api/users/me",
+            headers={
+                "Origin": origin,
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Headers": "authorization,x-active-agent",
+            },
+        )
+
+    assert res.status_code == 200
+    assert res.headers["access-control-allow-origin"] == origin
+    assert "authorization" in res.headers["access-control-allow-headers"].lower()
+    assert "x-active-agent" in res.headers["access-control-allow-headers"].lower()


### PR DESCRIPTION
## Summary
- allow preview, apex, and www BotCord frontend origins in the Hub CORS allowlist regardless of ENVIRONMENT_TAG
- add preflight coverage for deployed frontend origins with auth headers

## Tests
- cd backend && uv run pytest tests/test_cors.py
- cd backend && uv run pytest tests/test_public.py tests/test_cors.py