### PR TITLE
fix(frontend): fill mobile viewport and unclip new-messages pill

### DIFF
--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -967,7 +967,7 @@ export default function DashboardApp() {
   const mainPaneClass = `min-h-0 min-w-0 flex-1 ${mobileShowsMain ? "" : "max-md:hidden"}`;
 
   return (
-    <div className="relative flex h-[100dvh] overflow-hidden bg-deep-black max-md:flex-col-reverse md:h-screen">
+    <div className="fixed inset-0 flex overflow-hidden bg-deep-black max-md:flex-col-reverse">
       <Sidebar
         mobileHideSecondary={mobileHideSecondary}
         mobileSecondaryOpen={uiStore.mobileSidebarOpen}

--- a/frontend/src/components/dashboard/MessageList.tsx
+++ b/frontend/src/components/dashboard/MessageList.tsx
@@ -443,7 +443,7 @@ export default function MessageList() {
   const newMessagesBanner = showNewMessagesBanner && (
     <button
       onClick={scrollToBottom}
-      className="absolute bottom-4 left-1/2 -translate-x-1/2 z-20 rounded-full bg-neon-cyan/90 px-4 py-1.5 text-xs font-medium text-deep-black shadow-lg shadow-neon-cyan/20 transition-all hover:bg-neon-cyan animate-bounce"
+      className="absolute bottom-4 left-1/2 -translate-x-1/2 z-20 rounded-full bg-neon-cyan/90 px-4 py-1.5 text-xs font-medium text-deep-black shadow-lg shadow-neon-cyan/20 transition-all hover:bg-neon-cyan animate-bounce max-md:bottom-6"
     >
       {t.newMessages}
     </button>


### PR DESCRIPTION
## Summary
- Dashboard root switched from `h-[100dvh]` to `fixed inset-0` so iOS Chrome no longer leaves a black strip below the bottom tab bar (caused by body's `min-h-screen` being taller than `100dvh` when browser chrome is visible).
- New-messages pill in MessageList gets `max-md:bottom-6` so it stops pressing against the composer divider on mobile.

## Test plan
- [ ] iOS Chrome: open a room — tab bar fills down to the browser UI, no black gap.
- [ ] Mobile chat with unread messages while scrolled up: "new messages" pill sits clear of the composer.
- [ ] Desktop: no visual regression on dashboard layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)