### PR TITLE
fix(daemon): report runtime failures in botcord rooms

### DIFF
--- a/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
+++ b/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
@@ -1903,7 +1903,7 @@ describe("Dispatcher", () => {
     expect(channel.sends.length).toBe(0);
   });
 
-  it("non-owner-chat room: timeout reply is suppressed (logged only)", async () => {
+  it("non-owner-chat room: timeout sends a diagnostic reply", async () => {
     vi.useFakeTimers();
     try {
       const runtime = new FakeRuntime({ hang: true });
@@ -1920,13 +1920,16 @@ describe("Dispatcher", () => {
       await vi.advanceTimersByTimeAsync(501);
       await p;
       expect(runtime.calls[0].signal.aborted).toBe(true);
-      expect(channel.sends.length).toBe(0);
+      expect(channel.sends.length).toBe(1);
+      expect(channel.sends[0].message.text).toMatch(/Runtime timeout/);
+      expect(channel.sends[0].message.conversationId).toBe("rm_g_other");
+      expect(channel.sends[0].message.replyTo).toBe("m_to");
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it("non-owner-chat room: runtime error reply is suppressed", async () => {
+  it("non-owner-chat room: runtime error sends a diagnostic reply", async () => {
     const runtime = new FakeRuntime({ throwError: "boom" });
     const { dispatcher, channel } = await scaffold({
       runtimeFactory: () => runtime,
@@ -1937,7 +1940,10 @@ describe("Dispatcher", () => {
         conversation: { id: "rm_g_other", kind: "group" },
       }),
     );
-    expect(channel.sends.length).toBe(0);
+    expect(channel.sends.length).toBe(1);
+    expect(channel.sends[0].message.text).toContain("Runtime error: boom");
+    expect(channel.sends[0].message.conversationId).toBe("rm_g_other");
+    expect(channel.sends[0].message.replyTo).toBe("m_err");
   });
 
   // ─────────────────────────────────────────────────────────────────────

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -1244,6 +1244,7 @@ export class Dispatcher {
       // own loop-risk accounting downstream.
       const isOwnerChat = isOwnerChatRoom(msg);
       const canDeliverRuntimeText = isOwnerChat || !isBotCordChannel(channel);
+      const canDeliverRuntimeDiagnostics = canDeliverRuntimeText || isBotCordChannel(channel);
 
       if (slot.timedOut) {
         this.transcript.write({
@@ -1257,7 +1258,7 @@ export class Dispatcher {
           error: `runtime timeout after ${this.turnTimeoutMs}ms`,
           durationMs: Date.now() - slot.dispatchedAt,
         });
-        if (canDeliverRuntimeText) {
+        if (canDeliverRuntimeDiagnostics) {
           await this.sendReply(channel, {
             channel: msg.channel,
             accountId: msg.accountId,
@@ -1302,7 +1303,7 @@ export class Dispatcher {
           error: errMsg,
           durationMs: Date.now() - slot.dispatchedAt,
         });
-        if (canDeliverRuntimeText) {
+        if (canDeliverRuntimeDiagnostics) {
           await this.sendReply(channel, {
             channel: msg.channel,
             accountId: msg.accountId,
@@ -1391,7 +1392,7 @@ export class Dispatcher {
             runtime: route.runtime,
             error: result.error,
           });
-          if (canDeliverRuntimeText) {
+          if (canDeliverRuntimeDiagnostics) {
             const sendResult = await this.sendReply(channel, {
               channel: msg.channel,
               accountId: msg.accountId,


### PR DESCRIPTION
## Summary
- send diagnostic timeout/error replies in BotCord non-owner chat rooms
- keep normal runtime text gated so agents must still use botcord_send
- update dispatcher tests for timeout and runtime error diagnostics

## Tests
- cd packages/daemon && npm test -- --run src/gateway/__tests__/dispatcher.test.ts
- cd packages/daemon && npm run build