### PR TITLE
feat: clarify bot permission settings UI

### DIFF
--- a/frontend/src/app/(dashboard)/settings/policy/PolicySettingsClient.tsx
+++ b/frontend/src/app/(dashboard)/settings/policy/PolicySettingsClient.tsx
@@ -36,8 +36,8 @@ const ROOM_INVITE_OPTIONS: { value: RoomInvitePolicy; label: string; hint: strin
 const ATTENTION_OPTIONS: { value: AttentionMode; label: string; hint: string }[] = [
   { value: "always", label: "所有房间消息", hint: "非私聊房间内收到任何消息都唤醒 Bot" },
   { value: "mention_only", label: "仅 @ 我", hint: "只有被 @ 或被明确点名时才唤醒" },
-  { value: "keyword", label: "关键词命中", hint: "消息包含关键词时才唤醒" },
   { value: "muted", label: "默认静音", hint: "房间消息默认不唤醒 Bot" },
+  { value: "keyword", label: "关键词命中", hint: "消息包含关键词时才唤醒" },
 ];
 
 function Card({

--- a/frontend/src/app/(dashboard)/settings/policy/PolicySettingsClient.tsx
+++ b/frontend/src/app/(dashboard)/settings/policy/PolicySettingsClient.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Loader2, MessageSquare, X } from "lucide-react";
+import { Bell, Bot, Loader2, MessageSquare, Shield, UserRound, X } from "lucide-react";
 import { userApi } from "@/lib/api";
 import type { UserAgent } from "@/lib/types";
 import {
@@ -21,23 +21,23 @@ import {
 } from "@/store/usePolicyStore";
 
 const CONTACT_OPTIONS: { value: ContactPolicy; label: string; hint: string }[] = [
-  { value: "open", label: "公开", hint: "任何人都可以联系我" },
-  { value: "contacts_only", label: "仅联系人", hint: "联系人或同房间成员" },
-  { value: "whitelist", label: "白名单", hint: "仅联系人（严格）" },
-  { value: "closed", label: "关闭", hint: "拒绝所有新对话（联系人申请仍可发起）" },
+  { value: "open", label: "所有人可私聊", hint: "任何未被屏蔽的 Agent 或 Human 都能直接发起对话" },
+  { value: "contacts_only", label: "联系人 + 同房间成员", hint: "联系人可以私聊；同一房间成员也可以发起私聊" },
+  { value: "whitelist", label: "仅联系人白名单", hint: "只有联系人列表中的对象可以直接私聊" },
+  { value: "closed", label: "只收联系申请", hint: "拒绝普通私聊；未被屏蔽的人仍可发送联系申请" },
 ];
 
-const ROOM_INVITE_OPTIONS: { value: RoomInvitePolicy; label: string }[] = [
-  { value: "open", label: "公开" },
-  { value: "contacts_only", label: "仅联系人" },
-  { value: "closed", label: "关闭" },
+const ROOM_INVITE_OPTIONS: { value: RoomInvitePolicy; label: string; hint: string }[] = [
+  { value: "open", label: "任何人可邀请", hint: "未被屏蔽的对象都可以邀请此 Bot 加入房间" },
+  { value: "contacts_only", label: "仅联系人可邀请", hint: "只有联系人可以邀请此 Bot 加入房间" },
+  { value: "closed", label: "不接受邀请", hint: "拒绝新的房间邀请" },
 ];
 
 const ATTENTION_OPTIONS: { value: AttentionMode; label: string; hint: string }[] = [
-  { value: "always", label: "全部", hint: "房间里收到任何消息都唤醒回复" },
-  { value: "mention_only", label: "仅被@", hint: "只在被 @ 时唤醒" },
-  { value: "keyword", label: "关键词", hint: "命中关键词才唤醒" },
-  { value: "muted", label: "静音", hint: "房间不主动回复" },
+  { value: "always", label: "所有房间消息", hint: "非私聊房间内收到任何消息都唤醒 Bot" },
+  { value: "mention_only", label: "仅 @ 我", hint: "只有被 @ 或被明确点名时才唤醒" },
+  { value: "keyword", label: "关键词命中", hint: "消息包含关键词时才唤醒" },
+  { value: "muted", label: "默认静音", hint: "房间消息默认不唤醒 Bot" },
 ];
 
 function Card({
@@ -360,9 +360,9 @@ function Header({ right }: { right?: React.ReactNode }) {
       <div className="flex items-center gap-2">
         <MessageSquare className="h-5 w-5 text-neon-cyan" />
         <div>
-          <h1 className="text-lg font-semibold text-text-primary">对话与回复</h1>
+          <h1 className="text-lg font-semibold text-text-primary">Bot 权限与回复</h1>
           <p className="text-xs text-text-secondary">
-            控制谁能联系你的 Agent，以及 Agent 在房间中的默认回复策略。
+            准入决定谁能把消息送到 Bot；回复策略决定送达后是否唤醒 Bot。
           </p>
         </div>
       </div>
@@ -395,9 +395,33 @@ function PolicyForm({
 }) {
   return (
     <>
+      <div className="mb-6 grid gap-3 md:grid-cols-3">
+        <SummaryTile
+          icon={<Shield className="h-4 w-4" />}
+          label="直接联系"
+          value={CONTACT_OPTIONS.find((o) => o.value === policy.contact_policy)?.label ?? policy.contact_policy}
+          tone="cyan"
+        />
+        <SummaryTile
+          icon={<UserRound className="h-4 w-4" />}
+          label="允许来源"
+          value={[
+            policy.allow_agent_sender ? "Agent" : null,
+            policy.allow_human_sender ? "Human" : null,
+          ].filter(Boolean).join(" + ") || "全部关闭"}
+          tone={policy.allow_agent_sender || policy.allow_human_sender ? "green" : "red"}
+        />
+        <SummaryTile
+          icon={<Bell className="h-4 w-4" />}
+          label="默认房间回复"
+          value={ATTENTION_OPTIONS.find((o) => o.value === policy.default_attention)?.label ?? policy.default_attention}
+          tone={policy.default_attention === "muted" ? "yellow" : "cyan"}
+        />
+      </div>
+
       <Card
-        title="谁能联系我"
-        description="Hub 准入：是否接受来自其他 Agent 或人类用户的对话与加入房间邀请。"
+        title="直接联系我"
+        description="Hub 准入权限：控制谁可以把私聊消息送到这个 Bot。Blocklist 仍然拥有最高优先级。"
       >
         <RadioGroup
           name="contact_policy"
@@ -407,8 +431,16 @@ function PolicyForm({
           disabled={saving}
         />
 
-        <div className="mt-4 flex flex-col gap-2">
-          <label className="flex cursor-pointer items-center gap-2 text-sm text-text-primary">
+        <div className="mt-5 rounded-xl border border-glass-border bg-deep-black/20 p-3">
+          <div className="mb-3 flex items-center gap-2 text-xs font-medium uppercase tracking-normal text-text-secondary">
+            <Bot className="h-3.5 w-3.5" />
+            允许的发送者类型
+          </div>
+          <label className="mb-2 flex cursor-pointer items-center justify-between gap-3 rounded-lg border border-glass-border/70 bg-glass-bg/30 px-3 py-2 text-sm text-text-primary">
+            <span>
+              Agent
+              <span className="ml-2 text-xs text-text-secondary">其他 bot / agent</span>
+            </span>
             <input
               type="checkbox"
               checked={policy.allow_agent_sender}
@@ -416,9 +448,12 @@ function PolicyForm({
               disabled={saving}
               className="accent-neon-cyan"
             />
-            接受其他 agent 直接对话
           </label>
-          <label className="flex cursor-pointer items-center gap-2 text-sm text-text-primary">
+          <label className="flex cursor-pointer items-center justify-between gap-3 rounded-lg border border-glass-border/70 bg-glass-bg/30 px-3 py-2 text-sm text-text-primary">
+            <span>
+              Human
+              <span className="ml-2 text-xs text-text-secondary">人类用户 / dashboard</span>
+            </span>
             <input
               type="checkbox"
               checked={policy.allow_human_sender}
@@ -426,34 +461,26 @@ function PolicyForm({
               disabled={saving}
               className="accent-neon-cyan"
             />
-            接受人类用户对话
           </label>
         </div>
 
-        <div className="mt-4">
-          <label className="flex items-center gap-2 text-sm text-text-secondary">
-            加入房间邀请
-            <select
-              value={policy.room_invite_policy}
-              onChange={(e) =>
-                onPatch({ room_invite_policy: e.target.value as RoomInvitePolicy })
-              }
-              disabled={saving}
-              className="rounded-lg border border-glass-border bg-deep-black/40 px-2 py-1 text-text-primary"
-            >
-              {ROOM_INVITE_OPTIONS.map((opt) => (
-                <option key={opt.value} value={opt.value}>
-                  {opt.label}
-                </option>
-              ))}
-            </select>
-          </label>
+        <div className="mt-5">
+          <div className="mb-2 text-xs font-medium uppercase tracking-normal text-text-secondary">
+            谁能邀请我进房间
+          </div>
+          <RadioGroup
+            name="room_invite_policy"
+            value={policy.room_invite_policy}
+            options={ROOM_INVITE_OPTIONS}
+            onChange={(v) => onPatch({ room_invite_policy: v })}
+            disabled={saving}
+          />
         </div>
       </Card>
 
       <Card
-        title="默认回复策略"
-        description="Daemon 注意力：房间里收到消息后是否唤醒 LLM。私聊不受此设置影响，始终回复。"
+        title="默认房间回复"
+        description="Daemon 注意力策略：消息已进入 inbox 后，是否值得唤醒 Bot。这个设置只作为房间默认值，单个房间可以覆盖。"
       >
         <RadioGroup
           name="default_attention"
@@ -474,8 +501,8 @@ function PolicyForm({
           </div>
         ) : null}
 
-        <p className="mt-4 inline-flex items-center gap-2 rounded-lg border border-glass-border/60 bg-glass-bg/40 px-3 py-2 text-xs text-text-secondary">
-          ⓘ 私聊不受此设置影响，始终回复
+        <p className="mt-4 rounded-lg border border-glass-border/60 bg-glass-bg/40 px-3 py-2 text-xs text-text-secondary">
+          私聊 DM 当前强制始终唤醒；房间消息会先看房间级覆盖，没有覆盖时继承这里的默认策略。
         </p>
       </Card>
 
@@ -486,5 +513,35 @@ function PolicyForm({
         </div>
       ) : null}
     </>
+  );
+}
+
+function SummaryTile({
+  icon,
+  label,
+  value,
+  tone,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  tone: "cyan" | "green" | "yellow" | "red";
+}) {
+  const toneClass =
+    tone === "green"
+      ? "border-neon-green/30 bg-neon-green/5 text-neon-green"
+      : tone === "yellow"
+        ? "border-yellow-400/30 bg-yellow-400/5 text-yellow-300"
+        : tone === "red"
+          ? "border-red-400/30 bg-red-400/5 text-red-300"
+          : "border-neon-cyan/30 bg-neon-cyan/5 text-neon-cyan";
+  return (
+    <div className={`rounded-xl border px-3 py-3 ${toneClass}`}>
+      <div className="mb-1 flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-normal opacity-80">
+        {icon}
+        {label}
+      </div>
+      <div className="text-sm font-semibold leading-snug">{value}</div>
+    </div>
   );
 }

--- a/frontend/src/components/dashboard/AgentSettingsDrawer.tsx
+++ b/frontend/src/components/dashboard/AgentSettingsDrawer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { Clock, FileText, Loader2, MessageSquare, Plug, RefreshCw, Trash2, User, X } from "lucide-react";
+import { Bell, Bot, Clock, FileText, Loader2, MessageSquare, Plug, RefreshCw, Shield, Trash2, User, UserRound, X } from "lucide-react";
 import { userApi } from "@/lib/api";
 import { useLanguage } from "@/lib/i18n";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
@@ -28,23 +28,23 @@ interface AgentSettingsDrawerProps {
 }
 
 const CONTACT_OPTIONS: { value: ContactPolicy; label: string; hint: string }[] = [
-  { value: "open", label: "公开", hint: "任何人都可以联系我" },
-  { value: "contacts_only", label: "仅联系人", hint: "联系人或同房间成员" },
-  { value: "whitelist", label: "白名单", hint: "仅联系人（严格）" },
-  { value: "closed", label: "关闭", hint: "拒绝所有新对话（联系人申请仍可发起）" },
+  { value: "open", label: "所有人可私聊", hint: "任何未被屏蔽的 Agent 或 Human 都能直接发起对话" },
+  { value: "contacts_only", label: "联系人 + 同房间成员", hint: "联系人可以私聊；同一房间成员也可以发起私聊" },
+  { value: "whitelist", label: "仅联系人白名单", hint: "只有联系人列表中的对象可以直接私聊" },
+  { value: "closed", label: "只收联系申请", hint: "拒绝普通私聊；未被屏蔽的人仍可发送联系申请" },
 ];
 
-const ROOM_INVITE_OPTIONS: { value: RoomInvitePolicy; label: string }[] = [
-  { value: "open", label: "公开" },
-  { value: "contacts_only", label: "仅联系人" },
-  { value: "closed", label: "关闭" },
+const ROOM_INVITE_OPTIONS: { value: RoomInvitePolicy; label: string; hint: string }[] = [
+  { value: "open", label: "任何人可邀请", hint: "未被屏蔽的对象都可以邀请此 Bot 加入房间" },
+  { value: "contacts_only", label: "仅联系人可邀请", hint: "只有联系人可以邀请此 Bot 加入房间" },
+  { value: "closed", label: "不接受邀请", hint: "拒绝新的房间邀请" },
 ];
 
 const ATTENTION_OPTIONS: { value: AttentionMode; label: string; hint: string }[] = [
-  { value: "always", label: "全部", hint: "房间里收到任何消息都唤醒回复" },
-  { value: "mention_only", label: "仅被@", hint: "只在被 @ 时唤醒" },
-  { value: "keyword", label: "关键词", hint: "命中关键词才唤醒" },
-  { value: "muted", label: "静音", hint: "房间不主动回复" },
+  { value: "always", label: "所有房间消息", hint: "非私聊房间内收到任何消息都唤醒 Bot" },
+  { value: "mention_only", label: "仅 @ 我", hint: "只有被 @ 或被明确点名时才唤醒" },
+  { value: "keyword", label: "关键词命中", hint: "消息包含关键词时才唤醒" },
+  { value: "muted", label: "默认静音", hint: "房间消息默认不唤醒 Bot" },
 ];
 
 type Tab = "profile" | "policy" | "schedules" | "gateways" | "files";
@@ -196,6 +196,36 @@ function scopeLabel(scope: AgentRuntimeFile["scope"]): string {
   if (scope === "hermes") return "Hermes";
   if (scope === "openclaw") return "OpenClaw";
   return "Workspace";
+}
+
+function SummaryTile({
+  icon,
+  label,
+  value,
+  tone,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  tone: "cyan" | "green" | "yellow" | "red";
+}) {
+  const toneClass =
+    tone === "green"
+      ? "border-neon-green/30 bg-neon-green/5 text-neon-green"
+      : tone === "yellow"
+        ? "border-yellow-400/30 bg-yellow-400/5 text-yellow-300"
+        : tone === "red"
+          ? "border-red-400/30 bg-red-400/5 text-red-300"
+          : "border-neon-cyan/30 bg-neon-cyan/5 text-neon-cyan";
+  return (
+    <div className={`rounded-xl border px-3 py-3 ${toneClass}`}>
+      <div className="mb-1 flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-normal opacity-80">
+        {icon}
+        {label}
+      </div>
+      <div className="text-sm font-semibold leading-snug">{value}</div>
+    </div>
+  );
 }
 
 export default function AgentSettingsDrawer({
@@ -374,9 +404,9 @@ export default function AgentSettingsDrawer({
                 <FileText className="h-3.5 w-3.5" />
               )}
               {t === "profile"
-                ? "资料"
+                  ? "资料"
                 : t === "policy"
-                  ? "对话与回复"
+                  ? "权限与回复"
                   : t === "schedules"
                     ? "自主"
                     : t === "gateways"
@@ -505,10 +535,34 @@ export default function AgentSettingsDrawer({
                 </div>
               ) : (
                 <>
+                  <div className="grid gap-3">
+                    <SummaryTile
+                      icon={<Shield className="h-4 w-4" />}
+                      label="直接联系"
+                      value={CONTACT_OPTIONS.find((o) => o.value === policy.contact_policy)?.label ?? policy.contact_policy}
+                      tone="cyan"
+                    />
+                    <SummaryTile
+                      icon={<UserRound className="h-4 w-4" />}
+                      label="允许来源"
+                      value={[
+                        policy.allow_agent_sender ? "Agent" : null,
+                        policy.allow_human_sender ? "Human" : null,
+                      ].filter(Boolean).join(" + ") || "全部关闭"}
+                      tone={policy.allow_agent_sender || policy.allow_human_sender ? "green" : "red"}
+                    />
+                    <SummaryTile
+                      icon={<Bell className="h-4 w-4" />}
+                      label="默认房间回复"
+                      value={ATTENTION_OPTIONS.find((o) => o.value === policy.default_attention)?.label ?? policy.default_attention}
+                      tone={policy.default_attention === "muted" ? "yellow" : "cyan"}
+                    />
+                  </div>
+
                   <section className="rounded-2xl border border-glass-border bg-glass-bg/40 p-5">
-                    <h3 className="mb-1 text-sm font-semibold text-text-primary">谁能联系我</h3>
+                    <h3 className="mb-1 text-sm font-semibold text-text-primary">直接联系我</h3>
                     <p className="mb-4 text-xs text-text-secondary">
-                      是否接受来自其他 Agent 或人类用户的对话与加入房间邀请。
+                      Hub 准入权限：控制谁可以把私聊消息送到这个 Bot。Blocklist 仍然拥有最高优先级。
                     </p>
                     <RadioGroup
                       name={`contact_policy_${agentId}`}
@@ -517,8 +571,17 @@ export default function AgentSettingsDrawer({
                       onChange={(v) => void applyPolicy({ contact_policy: v })}
                       disabled={policySaving}
                     />
-                    <div className="mt-4 flex flex-col gap-2">
-                      <label className="flex cursor-pointer items-center gap-2 text-sm text-text-primary">
+
+                    <div className="mt-5 rounded-xl border border-glass-border bg-deep-black/20 p-3">
+                      <div className="mb-3 flex items-center gap-2 text-xs font-medium uppercase tracking-normal text-text-secondary">
+                        <Bot className="h-3.5 w-3.5" />
+                        允许的发送者类型
+                      </div>
+                      <label className="mb-2 flex cursor-pointer items-center justify-between gap-3 rounded-lg border border-glass-border/70 bg-glass-bg/30 px-3 py-2 text-sm text-text-primary">
+                        <span>
+                          Agent
+                          <span className="ml-2 text-xs text-text-secondary">其他 bot / agent</span>
+                        </span>
                         <input
                           type="checkbox"
                           checked={policy.allow_agent_sender}
@@ -526,9 +589,12 @@ export default function AgentSettingsDrawer({
                           disabled={policySaving}
                           className="accent-neon-cyan"
                         />
-                        接受其他 agent 直接对话
                       </label>
-                      <label className="flex cursor-pointer items-center gap-2 text-sm text-text-primary">
+                      <label className="flex cursor-pointer items-center justify-between gap-3 rounded-lg border border-glass-border/70 bg-glass-bg/30 px-3 py-2 text-sm text-text-primary">
+                        <span>
+                          Human
+                          <span className="ml-2 text-xs text-text-secondary">人类用户 / dashboard</span>
+                        </span>
                         <input
                           type="checkbox"
                           checked={policy.allow_human_sender}
@@ -536,34 +602,27 @@ export default function AgentSettingsDrawer({
                           disabled={policySaving}
                           className="accent-neon-cyan"
                         />
-                        接受人类用户对话
                       </label>
                     </div>
-                    <div className="mt-4">
-                      <label className="flex items-center gap-2 text-sm text-text-secondary">
-                        加入房间邀请
-                        <select
-                          value={policy.room_invite_policy}
-                          onChange={(e) =>
-                            void applyPolicy({ room_invite_policy: e.target.value as RoomInvitePolicy })
-                          }
-                          disabled={policySaving}
-                          className="rounded-lg border border-glass-border bg-deep-black/40 px-2 py-1 text-text-primary"
-                        >
-                          {ROOM_INVITE_OPTIONS.map((opt) => (
-                            <option key={opt.value} value={opt.value}>
-                              {opt.label}
-                            </option>
-                          ))}
-                        </select>
-                      </label>
+
+                    <div className="mt-5">
+                      <div className="mb-2 text-xs font-medium uppercase tracking-normal text-text-secondary">
+                        谁能邀请我进房间
+                      </div>
+                      <RadioGroup
+                        name={`room_invite_policy_${agentId}`}
+                        value={policy.room_invite_policy}
+                        options={ROOM_INVITE_OPTIONS}
+                        onChange={(v) => void applyPolicy({ room_invite_policy: v })}
+                        disabled={policySaving}
+                      />
                     </div>
                   </section>
 
                   <section className="rounded-2xl border border-glass-border bg-glass-bg/40 p-5">
-                    <h3 className="mb-1 text-sm font-semibold text-text-primary">默认回复策略</h3>
+                    <h3 className="mb-1 text-sm font-semibold text-text-primary">默认房间回复</h3>
                     <p className="mb-4 text-xs text-text-secondary">
-                      Daemon 注意力：房间里收到消息后是否唤醒 LLM。
+                      Daemon 注意力策略：消息已进入 inbox 后，是否值得唤醒 Bot。单个房间可以覆盖。
                     </p>
                     <RadioGroup
                       name={`default_attention_${agentId}`}
@@ -582,8 +641,8 @@ export default function AgentSettingsDrawer({
                         />
                       </div>
                     )}
-                    <p className="mt-4 inline-flex items-center gap-2 rounded-lg border border-glass-border/60 bg-glass-bg/40 px-3 py-2 text-xs text-text-secondary">
-                      ⓘ 私聊不受此设置影响，始终回复
+                    <p className="mt-4 rounded-lg border border-glass-border/60 bg-glass-bg/40 px-3 py-2 text-xs text-text-secondary">
+                      私聊 DM 当前强制始终唤醒；房间消息会先看房间级覆盖，没有覆盖时继承这里的默认策略。
                     </p>
                   </section>
 

--- a/frontend/src/components/dashboard/AgentSettingsDrawer.tsx
+++ b/frontend/src/components/dashboard/AgentSettingsDrawer.tsx
@@ -43,8 +43,8 @@ const ROOM_INVITE_OPTIONS: { value: RoomInvitePolicy; label: string; hint: strin
 const ATTENTION_OPTIONS: { value: AttentionMode; label: string; hint: string }[] = [
   { value: "always", label: "所有房间消息", hint: "非私聊房间内收到任何消息都唤醒 Bot" },
   { value: "mention_only", label: "仅 @ 我", hint: "只有被 @ 或被明确点名时才唤醒" },
-  { value: "keyword", label: "关键词命中", hint: "消息包含关键词时才唤醒" },
   { value: "muted", label: "默认静音", hint: "房间消息默认不唤醒 Bot" },
+  { value: "keyword", label: "关键词命中", hint: "消息包含关键词时才唤醒" },
 ];
 
 type Tab = "profile" | "policy" | "schedules" | "gateways" | "files";

--- a/frontend/src/components/dashboard/RoomHeader.tsx
+++ b/frontend/src/components/dashboard/RoomHeader.tsx
@@ -427,15 +427,16 @@ export default function RoomHeader() {
             </span>
           )}
           {isAuthedReady && activeAgentId && !isHumanView && isJoined && !isOwnerChatRoom && (
-            <span className="group relative max-md:hidden">
+            <span className="group relative">
               <button
                 onClick={() => setShowPolicyModal(true)}
-                className={iconBtn}
-                aria-label="我的回复策略"
+                className="inline-flex h-9 shrink-0 items-center gap-1.5 whitespace-nowrap rounded-lg border border-neon-cyan/35 bg-neon-cyan/10 px-2.5 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/15 disabled:opacity-60 max-md:h-8 max-md:px-2 max-md:text-[11px]"
+                aria-label="本房间回复策略"
               >
-                <Bell className="h-4 w-4" />
+                <Bell className="h-4 w-4 max-md:h-3.5 max-md:w-3.5" />
+                <span>本房间回复</span>
               </button>
-              <span className={tooltipCls}>我的回复策略</span>
+              <span className={tooltipCls}>本房间回复策略</span>
             </span>
           )}
           {!isOwnerChatRoom && (

--- a/frontend/src/components/dashboard/RoomHeader.tsx
+++ b/frontend/src/components/dashboard/RoomHeader.tsx
@@ -426,7 +426,7 @@ export default function RoomHeader() {
               <span className={tooltipCls}>{locale === "zh" ? "添加房间成员" : "Add members"}</span>
             </span>
           )}
-          {isAuthedReady && activeAgentId && !isHumanView && isJoined && !isOwnerChatRoom && (
+          {isAuthedReady && activeAgentId && isJoined && !isOwnerChatRoom && (
             <span className="group relative">
               <button
                 onClick={() => setShowPolicyModal(true)}

--- a/frontend/src/components/dashboard/RoomPolicyModal.tsx
+++ b/frontend/src/components/dashboard/RoomPolicyModal.tsx
@@ -27,8 +27,8 @@ import {
 const ATTENTION_OPTIONS: { value: AttentionMode; label: string; hint: string }[] = [
   { value: "always", label: "所有消息", hint: "本房间任何新消息都会唤醒 Bot" },
   { value: "mention_only", label: "仅 @ 我", hint: "只有被 @ 或明确点名时唤醒" },
-  { value: "keyword", label: "关键词命中", hint: "消息包含关键词时唤醒" },
   { value: "muted", label: "静音", hint: "本房间不主动唤醒 Bot" },
+  { value: "keyword", label: "关键词命中", hint: "消息包含关键词时唤醒" },
 ];
 
 function modeLabel(mode: AttentionMode): string {

--- a/frontend/src/components/dashboard/RoomPolicyModal.tsx
+++ b/frontend/src/components/dashboard/RoomPolicyModal.tsx
@@ -17,18 +17,18 @@
  */
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Loader2, X } from "lucide-react";
+import { Bell, Loader2, RotateCcw, X } from "lucide-react";
 import {
   usePolicyStore,
   type AttentionMode,
   type RoomPolicyEffective,
 } from "@/store/usePolicyStore";
 
-const ATTENTION_OPTIONS: { value: AttentionMode; label: string }[] = [
-  { value: "always", label: "全部回复" },
-  { value: "mention_only", label: "仅被@" },
-  { value: "keyword", label: "关键词" },
-  { value: "muted", label: "静音" },
+const ATTENTION_OPTIONS: { value: AttentionMode; label: string; hint: string }[] = [
+  { value: "always", label: "所有消息", hint: "本房间任何新消息都会唤醒 Bot" },
+  { value: "mention_only", label: "仅 @ 我", hint: "只有被 @ 或明确点名时唤醒" },
+  { value: "keyword", label: "关键词命中", hint: "消息包含关键词时唤醒" },
+  { value: "muted", label: "静音", hint: "本房间不主动唤醒 Bot" },
 ];
 
 function modeLabel(mode: AttentionMode): string {
@@ -113,12 +113,15 @@ export default function RoomPolicyModal({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4 backdrop-blur">
-      <div className="w-full max-w-md rounded-2xl border border-glass-border bg-deep-black-light p-5 shadow-2xl">
+      <div className="w-full max-w-lg rounded-2xl border border-glass-border bg-deep-black-light p-5 shadow-2xl">
         <div className="mb-4 flex items-start justify-between">
-          <div>
-            <h2 className="text-base font-semibold text-text-primary">我的回复策略</h2>
+          <div className="min-w-0">
+            <div className="mb-1 flex items-center gap-2">
+              <Bell className="h-4 w-4 text-neon-cyan" />
+              <h2 className="text-base font-semibold text-text-primary">本房间回复策略</h2>
+            </div>
             <p className="mt-0.5 text-xs text-text-secondary">
-              控制此 Agent 在该房间内的注意力（是否唤醒回复）。
+              只控制这个 Bot 在当前房间是否被唤醒；不影响谁能发消息到房间。
             </p>
           </div>
           <button
@@ -142,14 +145,21 @@ export default function RoomPolicyModal({
           </div>
         ) : data && effective ? (
           isDM ? (
-            <div className="rounded-xl border border-glass-border bg-glass-bg/40 px-3 py-3 text-sm text-text-secondary">
-              一对一始终回复
+            <div className="rounded-xl border border-neon-cyan/25 bg-neon-cyan/5 px-4 py-4">
+              <div className="text-sm font-medium text-neon-cyan">私聊始终唤醒</div>
+              <p className="mt-1 text-xs text-text-secondary">
+                DM 房间当前强制使用所有消息唤醒，不能在房间级静音或覆盖。
+              </p>
             </div>
           ) : (
             <>
               <EffectiveBadge effective={effective} hasOverride={hasOverride} />
 
-              <div className="mt-4 flex flex-wrap gap-2">
+              <div className="mt-4">
+                <div className="mb-2 text-xs font-medium uppercase tracking-normal text-text-secondary">
+                  快速静音
+                </div>
+                <div className="flex flex-wrap gap-2">
                 <button
                   type="button"
                   onClick={() =>
@@ -175,6 +185,16 @@ export default function RoomPolicyModal({
                 <button
                   type="button"
                   onClick={() =>
+                    void apply(() => snoozeRoom(agentId, roomId, 7 * 24 * 60))
+                  }
+                  disabled={busy}
+                  className="rounded-lg border border-glass-border bg-glass-bg/40 px-3 py-1.5 text-xs text-text-primary transition-colors hover:bg-glass-bg disabled:opacity-50"
+                >
+                  静音 7 天
+                </button>
+                <button
+                  type="button"
+                  onClick={() =>
                     void apply(() =>
                       putRoomOverride(agentId, roomId, { attention_mode: "muted" }),
                     )
@@ -184,15 +204,16 @@ export default function RoomPolicyModal({
                 >
                   永久静音
                 </button>
+                </div>
               </div>
 
               <div className="mt-4 rounded-xl border border-glass-border bg-glass-bg/30 p-3">
                 <button
                   type="button"
                   onClick={() => setExpanded((v) => !v)}
-                  className="text-sm text-neon-cyan transition-colors hover:text-neon-cyan/80"
+                  className="text-sm font-medium text-neon-cyan transition-colors hover:text-neon-cyan/80"
                 >
-                  {expanded ? "▾ 改为本房间专属" : "▸ 改为本房间专属"}
+                  {expanded ? "收起本房间专属策略" : "设置本房间专属策略"}
                 </button>
 
                 {expanded ? (
@@ -292,6 +313,11 @@ function EffectiveBadge({
           ))}
         </div>
       ) : null}
+      <p className="mt-3 text-xs text-text-secondary">
+        {effective.source === "override" || hasOverride
+          ? "此房间正在使用专属策略；修改 Bot 默认回复不会覆盖这里。"
+          : "此房间继承 Bot 默认房间回复策略。"}
+      </p>
     </div>
   );
 }
@@ -334,7 +360,11 @@ function OverrideForm({
         {ATTENTION_OPTIONS.map((opt) => (
           <label
             key={opt.value}
-            className="flex cursor-pointer items-center gap-2 text-sm text-text-primary"
+            className={`flex cursor-pointer items-start gap-3 rounded-lg border px-3 py-2 transition-colors ${
+              mode === opt.value
+                ? "border-neon-cyan/40 bg-neon-cyan/5"
+                : "border-glass-border bg-transparent hover:bg-glass-bg/50"
+            }`}
           >
             <input
               type="radio"
@@ -342,10 +372,13 @@ function OverrideForm({
               value={opt.value}
               checked={mode === opt.value}
               onChange={() => setMode(opt.value)}
-              className="accent-neon-cyan"
+              className="mt-1 accent-neon-cyan"
               disabled={busy}
             />
-            {opt.label}
+            <span>
+              <span className="block text-sm text-text-primary">{opt.label}</span>
+              <span className="block text-xs text-text-secondary">{opt.hint}</span>
+            </span>
           </label>
         ))}
       </div>
@@ -394,6 +427,20 @@ function OverrideForm({
       ) : null}
 
       <div className="mt-3 flex justify-end">
+        {currentMode !== mode || mode === "keyword" ? (
+          <button
+            type="button"
+            onClick={() => {
+              setMode(currentMode);
+              setKeywords(currentKeywords);
+            }}
+            disabled={busy}
+            className="mr-2 inline-flex items-center gap-1.5 rounded-lg border border-glass-border px-3 py-1.5 text-xs text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+          >
+            <RotateCcw className="h-3.5 w-3.5" />
+            撤销更改
+          </button>
+        ) : null}
         <button
           type="button"
           onClick={() => onApply(mode, keywords)}


### PR DESCRIPTION
## Summary
- Reframe global bot policy settings around admission vs attention concepts
- Update agent settings drawer to use the same permission/reply model
- Clarify per-room reply overrides, inheritance, DM forced-always behavior, and quick snooze options

## Tests
- NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build