### PR TITLE
fix: remove dashboard global error toast

### DIFF
--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -1099,11 +1099,6 @@ export default function DashboardApp() {
         onSendMessage={handleSendMessageFromHumanCard}
         onRetry={handleRetryOwnerHumanCard}
       />
-      {chatStore.error && (
-        <div className="pointer-events-none absolute right-4 top-4 rounded border border-red-400/40 bg-red-400/10 px-3 py-1.5 text-xs text-red-200">
-          {chatStore.error}
-        </div>
-      )}
     </div>
   );
 }

--- a/frontend/src/store/useDashboardChatStore.test.ts
+++ b/frontend/src/store/useDashboardChatStore.test.ts
@@ -3,17 +3,23 @@ import type { DashboardOverview } from "@/lib/types";
 
 const mocks = vi.hoisted(() => ({
   getRoomMessages: vi.fn(),
+  getOverview: vi.fn(),
 }));
 
 vi.mock("@/lib/api", () => ({
   api: {
     getRoomMessages: mocks.getRoomMessages,
+    getOverview: mocks.getOverview,
   },
   humansApi: {},
   getActiveAgentId: vi.fn(() => null),
+  setActiveAgentId: vi.fn(),
+  getStoredActiveIdentity: vi.fn(() => null),
+  setStoredActiveIdentity: vi.fn(),
 }));
 
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
+import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 
 function makeOverview(lastMessageAt: string | null = null): DashboardOverview {
   return {
@@ -49,12 +55,17 @@ function makeOverview(lastMessageAt: string | null = null): DashboardOverview {
 describe("useDashboardChatStore message polling", () => {
   beforeEach(() => {
     mocks.getRoomMessages.mockReset();
+    mocks.getOverview.mockReset();
     useDashboardChatStore.setState({
       overview: makeOverview(),
+      overviewRefreshing: false,
+      overviewErrored: false,
+      error: null,
       messages: {},
       messagesLoading: {},
       messagesHasMore: {},
     });
+    useDashboardSessionStore.setState({ token: "token" });
   });
 
   it("does not refetch a room already loaded as empty when the room snapshot is unchanged", async () => {
@@ -75,5 +86,17 @@ describe("useDashboardChatStore message polling", () => {
     await useDashboardChatStore.getState().pollNewMessages("rm_empty");
 
     expect(mocks.getRoomMessages).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not show a global error toast when background overview refresh hits auth expiry", async () => {
+    const err = new Error("Unauthorized") as Error & { status: number };
+    err.status = 401;
+    mocks.getOverview.mockRejectedValue(err);
+
+    await useDashboardChatStore.getState().refreshOverview();
+
+    expect(useDashboardChatStore.getState().error).toBeNull();
+    expect(useDashboardChatStore.getState().overviewRefreshing).toBe(false);
+    expect(useDashboardChatStore.getState().overviewErrored).toBe(false);
   });
 });

--- a/frontend/src/store/useDashboardChatStore.ts
+++ b/frontend/src/store/useDashboardChatStore.ts
@@ -40,6 +40,14 @@ function isFetchNetworkError(error: unknown): boolean {
   return error.name === "TypeError" && error.message === "Failed to fetch";
 }
 
+function isAuthError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const status = (error as { status?: unknown }).status;
+  if (status === 401 || status === 403) return true;
+  if (!(error instanceof Error)) return false;
+  return error.message === "Unauthorized";
+}
+
 function applyRealtimeRoomHint<T extends {
   room_id: string;
   last_message_at: string | null;
@@ -556,6 +564,11 @@ export const useDashboardChatStore = create<DashboardChatState>()(
             void get().loadRoomMessages(openedRoomId);
           }
         } catch (error: any) {
+          if (isAuthError(error)) {
+            console.warn("[ChatStore] Background overview auth refresh failed:", error);
+            set({ overviewRefreshing: false, overviewErrored: false });
+            return;
+          }
           if (get().overview && isFetchNetworkError(error)) {
             console.warn("[ChatStore] Background overview refresh failed:", error);
             set({ overviewRefreshing: false, overviewErrored: false });


### PR DESCRIPTION
## Summary
- Remove the dashboard-level red error overlay that rendered chatStore.error in the top-right corner
- Keep background auth refresh failures from populating global chat error state
- Add regression coverage for 401/Unauthorized overview refresh behavior

## Tests
- npm test -- --run src/store/useDashboardChatStore.test.ts

## Notes
- npx tsc --noEmit was also checked, but it still fails on existing missing route/type and policy test type errors unrelated to this change.