### PR TITLE
fix: improve dashboard message dm routing

### DIFF
--- a/frontend/src/components/dashboard/BotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/BotDetailDrawer.tsx
@@ -94,26 +94,38 @@ function formatTime(iso: string | null): string {
 
 export default function BotDetailDrawer() {
   const router = useRouter();
-  const { botDetailAgentId, setBotDetailAgentId, setSelectedDeviceId, setMessagesPane, setUserChatRoomId } = useDashboardUIStore(
+  const {
+    botDetailAgentId,
+    setBotDetailAgentId,
+    setSelectedDeviceId,
+    setSidebarTab,
+    setFocusedRoomId,
+    setOpenedRoomId,
+    setMessagesPane,
+    setMessagesFilter,
+  } = useDashboardUIStore(
     useShallow((s) => ({
       botDetailAgentId: s.botDetailAgentId,
       setBotDetailAgentId: s.setBotDetailAgentId,
       setSelectedDeviceId: s.setSelectedDeviceId,
+      setSidebarTab: s.setSidebarTab,
+      setFocusedRoomId: s.setFocusedRoomId,
+      setOpenedRoomId: s.setOpenedRoomId,
       setMessagesPane: s.setMessagesPane,
-      setUserChatRoomId: s.setUserChatRoomId,
+      setMessagesFilter: s.setMessagesFilter,
     })),
   );
-  const { ownedAgents, activeAgentId, refreshUserProfile } = useDashboardSessionStore(
+  const { ownedAgents, refreshHumanRooms, refreshUserProfile } = useDashboardSessionStore(
     useShallow((s) => ({
       ownedAgents: s.ownedAgents,
-      activeAgentId: s.activeAgentId,
+      refreshHumanRooms: s.refreshHumanRooms,
       refreshUserProfile: s.refreshUserProfile,
     })),
   );
-  const switchActiveAgent = useDashboardChatStore((s) => s.switchActiveAgent);
   const overview = useDashboardChatStore((s) => s.overview);
   const daemons = useDaemonStore((s) => s.daemons);
   const refreshOverview = useDashboardChatStore((s) => s.refreshOverview);
+  const loadOwnedAgentRooms = useDashboardChatStore((s) => s.loadOwnedAgentRooms);
 
   const bot = botDetailAgentId ? ownedAgents.find((a) => a.agent_id === botDetailAgentId) ?? null : null;
   const device = bot?.daemon_instance_id ? daemons.find((d) => d.id === bot.daemon_instance_id) ?? null : null;
@@ -137,17 +149,24 @@ export default function BotDetailDrawer() {
 
   const handleOpenChat = async () => {
     try {
-      if (bot.agent_id !== activeAgentId) {
-        await switchActiveAgent(bot.agent_id);
-      }
-      const room = await api.getUserChatRoom(bot.agent_id);
-      setUserChatRoomId(room.room_id);
-      setMessagesPane("user-chat");
+      const { room_id } = await api.openDmRoom(bot.agent_id);
+      await Promise.all([
+        refreshHumanRooms(),
+        loadOwnedAgentRooms(),
+      ]);
+      setSidebarTab("messages");
+      setMessagesPane("room");
+      setMessagesFilter("self-my-bot");
+      setFocusedRoomId(room_id);
+      setOpenedRoomId(room_id);
       setBotDetailAgentId(null);
-      router.push(`/chats/messages/${encodeURIComponent(room.room_id)}`);
-    } catch {
+      router.push(`/chats/messages/${encodeURIComponent(room_id)}`);
+    } catch (error) {
+      console.error("[BotDetailDrawer] openDmRoom failed:", error);
+      setSidebarTab("messages");
+      setMessagesPane("room");
       setBotDetailAgentId(null);
-      router.push("/chats/messages/__user-chat__");
+      router.push("/chats/messages");
     }
   };
 

--- a/frontend/src/components/dashboard/MessageBubble.tsx
+++ b/frontend/src/components/dashboard/MessageBubble.tsx
@@ -290,6 +290,9 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
   const [menuOpen, setMenuOpen] = useState(false);
   const [forwardQuote, setForwardQuote] = useState<string | null>(null);
   const selectAgent = useDashboardChatStore((state) => state.selectAgent);
+  const publicHumans = useDashboardChatStore((state) => state.publicHumans);
+  const human = useDashboardSessionStore((state) => state.human);
+  const user = useDashboardSessionStore((state) => state.user);
   const requestOpenHuman = useDashboardUIStore((state) => state.requestOpenHuman);
   const stateConfig = useStateConfig();
   const textContent = message.payload?.text || message.payload?.body || message.payload?.message;
@@ -298,6 +301,15 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
   const isOwn = typeof message.is_mine === "boolean" ? message.is_mine : isOwnProp;
   const isHuman = message.sender_kind === "human";
   const senderDisplayName = message.display_sender_name || message.sender_name || message.sender_id;
+  const publicHuman = isHuman ? publicHumans.find((item) => item.human_id === message.sender_id) : null;
+  const isCurrentHumanSender = isHuman && (
+    message.sender_id === human?.human_id
+    || (message.source_user_id && message.source_user_id === user?.id)
+  );
+  const senderAvatarUrl = message.sender_avatar_url
+    || (isCurrentHumanSender ? human?.avatar_url || user?.avatar_url : null)
+    || publicHuman?.avatar_url
+    || null;
 
   if (message.type === "system") {
     const joinParticipant = getSystemJoinParticipant(message.payload);
@@ -368,7 +380,7 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
     <SenderAvatar
       senderId={message.sender_id}
       displayName={senderDisplayName}
-      avatarUrl={message.sender_avatar_url}
+      avatarUrl={senderAvatarUrl}
       isHuman={isHuman}
       onClick={handleSelectSender}
       onKeyDown={handleSelectSenderByKey}

--- a/frontend/src/components/dashboard/RoomHumanComposer.tsx
+++ b/frontend/src/components/dashboard/RoomHumanComposer.tsx
@@ -332,6 +332,7 @@ export default function RoomHumanComposer({ roomId, topicId = null }: RoomHumanC
       source_type: "dashboard_human_room",
       sender_kind: "human",
       display_sender_name: displayName,
+      sender_avatar_url: human?.avatar_url ?? user?.avatar_url ?? null,
       source_user_id: user?.id ?? null,
       source_user_name: displayName,
       is_mine: true,

--- a/frontend/src/lib/messages-merge.test.ts
+++ b/frontend/src/lib/messages-merge.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import type { DashboardRoom, HumanAgentRoomSummary } from "@/lib/types";
+import { applyMessagesFilter, mergeOwnerVisibleRooms } from "@/lib/messages-merge";
+
+function makeHumanDmRoom(overrides: Partial<DashboardRoom> = {}): DashboardRoom {
+  return {
+    room_id: "rm_dm_ag_bot_hu_owner",
+    name: "My Bot",
+    description: "",
+    owner_id: "hu_owner",
+    owner_type: "human",
+    visibility: "private",
+    join_policy: "invite",
+    member_count: 2,
+    my_role: "member",
+    rule: null,
+    required_subscription_product_id: null,
+    last_viewed_at: null,
+    has_unread: false,
+    last_message_preview: null,
+    last_message_at: "2026-05-13T08:00:00Z",
+    last_sender_name: null,
+    peer_type: "agent",
+    ...overrides,
+  };
+}
+
+function makeOwnedAgentRoom(overrides: Partial<HumanAgentRoomSummary> = {}): HumanAgentRoomSummary {
+  return {
+    room_id: "rm_dm_ag_bot_hu_owner",
+    name: "My Bot",
+    description: "",
+    owner_id: "hu_owner",
+    visibility: "private",
+    join_policy: "invite",
+    member_count: 2,
+    bots: [{ agent_id: "ag_bot", display_name: "My Bot", role: "member" }],
+    created_at: "2026-05-13T07:00:00Z",
+    rule: null,
+    required_subscription_product_id: null,
+    last_message_preview: null,
+    last_message_at: "2026-05-13T08:00:00Z",
+    last_sender_name: null,
+    allow_human_send: true,
+    ...overrides,
+  };
+}
+
+describe("messages merge filters", () => {
+  it("keeps a human-owned DM with my bot in the self-my-bot bucket", () => {
+    const ownRoom = makeHumanDmRoom();
+    const ownedAgentRoom = makeOwnedAgentRoom();
+    const rooms = mergeOwnerVisibleRooms({
+      ownRooms: [ownRoom],
+      ownedAgentRooms: [ownedAgentRoom],
+    });
+
+    expect(rooms).toHaveLength(1);
+    expect(rooms[0]._originAgent).toBeUndefined();
+    expect(
+      applyMessagesFilter(rooms, "self-my-bot", new Set([ownedAgentRoom.room_id])).map((room) => room.room_id),
+    ).toEqual([ownRoom.room_id]);
+  });
+});

--- a/frontend/src/store/dashboard-shared.test.ts
+++ b/frontend/src/store/dashboard-shared.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 import type { DashboardOverview, HumanRoomSummary, PublicRoom } from "@/lib/types";
 import {
   buildVisibleMessageRooms,
+  humanRoomToDashboardRoom,
   isRoomOwnedByCurrentViewer,
   mergeDashboardRoomsWithHumanRooms,
 } from "@/store/dashboard-shared";
+import { applyMessagesFilter } from "@/lib/messages-merge";
 
 function makePublicRoom(overrides: Partial<PublicRoom> = {}): PublicRoom {
   return {
@@ -118,6 +120,18 @@ describe("mergeDashboardRoomsWithHumanRooms", () => {
       owner_type: "human",
       my_role: "owner",
     });
+  });
+
+  it("marks human-to-human DMs so the self-human messages filter catches them", () => {
+    const room = humanRoomToDashboardRoom(makeHumanRoom({
+      room_id: "rm_dm_hu_1_hu_2",
+      member_count: 2,
+    }));
+
+    expect(room.peer_type).toBe("human");
+    expect(applyMessagesFilter([room], "self-human", new Set()).map((r) => r.room_id)).toEqual([
+      "rm_dm_hu_1_hu_2",
+    ]);
   });
 });
 

--- a/frontend/src/store/dashboard-shared.ts
+++ b/frontend/src/store/dashboard-shared.ts
@@ -1,6 +1,6 @@
 /**
  * [INPUT]: 依赖 dashboard 类型定义、@/lib/api 的 active-agent 工具与浏览器时间解析
- * [OUTPUT]: 对外提供 dashboard chat/unread/realtime store 共用的房间摘要、合并与时间比较工具
+ * [OUTPUT]: 对外提供 dashboard chat/unread/realtime store 共用的房间摘要、DM 类型推断、合并与时间比较工具
  * [POS]: frontend store 层的共享基础模块，负责消除多 store 拆分后的重复逻辑
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
@@ -10,9 +10,11 @@ import type {
   DashboardOverview,
   DashboardRoom,
   HumanRoomSummary,
+  ParticipantType,
   PublicRoom,
 } from "@/lib/types";
 import { getActiveAgentId } from "@/lib/api";
+import { parseDmRoomId } from "@/components/dashboard/dmRoom";
 
 export const roomMessagesInFlight = new Set<string>();
 export const roomMessagesReloadPending = new Set<string>();
@@ -66,6 +68,13 @@ function isOwnerChatRoom(roomId: string): boolean {
   return roomId.startsWith("rm_oc_");
 }
 
+function inferPeerTypeForHumanRoom(room: HumanRoomSummary): ParticipantType | undefined {
+  if ((room.member_count ?? 0) > 2) return undefined;
+  const parsed = parseDmRoomId(room.room_id);
+  if (!parsed) return undefined;
+  return parsed.a.startsWith("hu_") && parsed.b.startsWith("hu_") ? "human" : "agent";
+}
+
 export function humanRoomToDashboardRoom(r: HumanRoomSummary): DashboardRoom {
   return {
     room_id: r.room_id,
@@ -91,6 +100,7 @@ export function humanRoomToDashboardRoom(r: HumanRoomSummary): DashboardRoom {
     allow_human_send: r.allow_human_send,
     created_at: r.created_at,
     members_preview: r.members_preview ?? undefined,
+    peer_type: inferPeerTypeForHumanRoom(r),
   };
 }
 


### PR DESCRIPTION
## Summary
- route bot detail chat actions through the standard DM room flow and messages list
- preserve human sender avatars for optimistic and rendered message bubbles
- infer human-to-human DM peer types so the Messages self-human filter catches real human private chats
- add regression coverage for message room filter buckets

## Tests
- npm run build
- npm test -- --run src/store/dashboard-shared.test.ts src/lib/messages-merge.test.ts src/components/dashboard/MessageComposer.test.ts src/components/dashboard/RoomHumanComposer.test.ts