### PR TITLE
fix: optimize home bot stats loading

### DIFF
--- a/backend/app/routers/activity.py
+++ b/backend/app/routers/activity.py
@@ -5,11 +5,11 @@ import json
 import logging
 from typing import Any
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import distinct, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth import RequestContext, require_active_agent
+from app.auth import RequestContext, require_active_agent, require_user_with_optional_agent
 from hub.database import get_db
 from hub.models import (
     Agent,
@@ -72,16 +72,11 @@ def _extract_preview(envelope_json: str | None, max_len: int = 60) -> str | None
 # ---------------------------------------------------------------------------
 
 
-@router.get("/activity/stats")
-async def get_activity_stats(
-    period: str = Query(default="today", pattern="^(today|7d|30d)$"),
-    ctx: RequestContext = Depends(require_active_agent),
-    db: AsyncSession = Depends(get_db),
-):
-    """User-friendly overview statistics."""
-    agent_id = ctx.active_agent_id
-    start = _period_start(period)
-
+async def _activity_stats_for_agent(
+    agent_id: str,
+    start: datetime.datetime,
+    db: AsyncSession,
+) -> dict[str, int]:
     sent_result = await db.execute(
         select(func.count(distinct(MessageRecord.msg_id))).where(
             MessageRecord.sender_id == agent_id,
@@ -147,6 +142,51 @@ async def get_activity_stats(
         "topics_completed": tc.get("completed", 0),
         "active_rooms": active_rooms,
     }
+
+
+@router.get("/activity/stats")
+async def get_activity_stats(
+    period: str = Query(default="today", pattern="^(today|7d|30d)$"),
+    ctx: RequestContext = Depends(require_active_agent),
+    db: AsyncSession = Depends(get_db),
+):
+    """User-friendly overview statistics."""
+    agent_id = ctx.active_agent_id
+    start = _period_start(period)
+
+    return await _activity_stats_for_agent(agent_id, start, db)
+
+
+@router.get("/activity/stats/batch")
+async def get_activity_stats_batch(
+    agent_ids: str = Query(..., min_length=1),
+    period: str = Query(default="today", pattern="^(today|7d|30d)$"),
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return activity statistics for multiple owned agents in one request."""
+    requested_ids = list(dict.fromkeys(aid.strip() for aid in agent_ids.split(",") if aid.strip()))
+    if not requested_ids:
+        return {"stats": {}}
+    if len(requested_ids) > 12:
+        raise HTTPException(status_code=400, detail="Too many agent ids")
+
+    owned_result = await db.execute(
+        select(Agent.agent_id).where(
+            Agent.user_id == ctx.user_id,
+            Agent.agent_id.in_(requested_ids),
+        )
+    )
+    owned_ids = {row[0] for row in owned_result.all()}
+    unauthorized = [aid for aid in requested_ids if aid not in owned_ids]
+    if unauthorized:
+        raise HTTPException(status_code=403, detail="Agent not owned by user")
+
+    start = _period_start(period)
+    stats: dict[str, dict[str, int]] = {}
+    for agent_id in requested_ids:
+        stats[agent_id] = await _activity_stats_for_agent(agent_id, start, db)
+    return {"stats": stats}
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/components/dashboard/HomePanel.tsx
+++ b/frontend/src/components/dashboard/HomePanel.tsx
@@ -57,11 +57,13 @@ function SectionHeader({
   );
 }
 
-function Stat({ label, value }: { label: string; value: number | string }) {
+function Stat({ label, value, loading }: { label: string; value: number | string; loading?: boolean }) {
   return (
     <div className="rounded-lg bg-glass-bg px-2 py-1.5">
       <div className="text-[10px] uppercase tracking-wider text-text-secondary/60">{label}</div>
-      <div className="text-sm font-semibold text-text-primary">{value}</div>
+      <div className="text-sm font-semibold text-text-primary">
+        {loading ? <span className="block h-4 w-8 animate-pulse rounded bg-text-secondary/15" /> : value}
+      </div>
     </div>
   );
 }
@@ -84,7 +86,8 @@ function BotSummaryCard({
   const online = presence?.effective_status
     ? presence.effective_status !== "offline"
     : agent.ws_online;
-  const loadingValue = statsLoading ? "..." : "-";
+  const fallbackValue = "-";
+  const loading = statsLoading && !stats;
   return (
     <button
       type="button"
@@ -104,10 +107,10 @@ function BotSummaryCard({
         </div>
       </div>
       <div className="grid grid-cols-2 gap-2 text-xs">
-        <Stat label={t.statsSent} value={stats?.messages_sent ?? loadingValue} />
-        <Stat label={t.statsReceived} value={stats?.messages_received ?? loadingValue} />
-        <Stat label={t.statsActiveRooms} value={stats?.active_rooms ?? loadingValue} />
-        <Stat label={t.statsCompletedTopics} value={stats?.topics_completed ?? loadingValue} />
+        <Stat label={t.statsSent} value={stats?.messages_sent ?? fallbackValue} loading={loading} />
+        <Stat label={t.statsReceived} value={stats?.messages_received ?? fallbackValue} loading={loading} />
+        <Stat label={t.statsActiveRooms} value={stats?.active_rooms ?? fallbackValue} loading={loading} />
+        <Stat label={t.statsCompletedTopics} value={stats?.topics_completed ?? fallbackValue} loading={loading} />
       </div>
     </button>
   );
@@ -179,7 +182,7 @@ export default function HomePanel() {
     publicHumans: s.publicHumans,
   })));
   const [botStats, setBotStats] = useState<Record<string, ActivityStats>>({});
-  const [botStatsLoading, setBotStatsLoading] = useState(false);
+  const [botStatsLoading, setBotStatsLoading] = useState<Record<string, boolean>>({});
   const [botPresence, setBotPresence] = useState<Record<string, AgentPresenceSnapshotPayload>>({});
   const [greetingPeriod, setGreetingPeriod] = useState<GreetingPeriod>("morning");
   const visibleBots = useMemo(() => (noBots ? [] : ownedAgents), [noBots, ownedAgents]);
@@ -198,32 +201,42 @@ export default function HomePanel() {
         || a.display_name.localeCompare(b.display_name);
     }).slice(0, 6);
   }, [visibleBots]);
+  const shownBotIds = useMemo(
+    () => sortedVisibleBots.map((agent) => agent.agent_id),
+    [sortedVisibleBots],
+  );
 
   useEffect(() => {
-    if (visibleBots.length === 0) {
+    if (shownBotIds.length === 0) {
       setBotStats({});
       setBotPresence({});
+      setBotStatsLoading({});
       return;
     }
     let cancelled = false;
-    setBotStatsLoading(true);
-    void Promise.all(
-      visibleBots.map(async (agent) => {
-        try {
-          const stats = await api.getActivityStats("7d", { type: "agent", id: agent.agent_id });
-          return [agent.agent_id, stats] as const;
-        } catch {
-          return [agent.agent_id, null] as const;
-        }
-      }),
-    ).then((entries) => {
+    const loadingMap = Object.fromEntries(shownBotIds.map((agentId) => [agentId, true]));
+    setBotStatsLoading(loadingMap);
+    void api.getActivityStatsBatch(shownBotIds, "7d").then((result) => {
       if (cancelled) return;
-      setBotStats(Object.fromEntries(entries.filter((entry): entry is readonly [string, ActivityStats] => entry[1] !== null)));
+      setBotStats((current) => {
+        const next = Object.fromEntries(
+          Object.entries(current).filter(([agentId]) => shownBotIds.includes(agentId)),
+        ) as Record<string, ActivityStats>;
+        return { ...next, ...result.stats };
+      });
+    }).catch(() => {
+      if (!cancelled) {
+        setBotStats((current) => (
+          Object.fromEntries(
+            Object.entries(current).filter(([agentId]) => shownBotIds.includes(agentId)),
+          ) as Record<string, ActivityStats>
+        ));
+      }
     }).finally(() => {
-      if (!cancelled) setBotStatsLoading(false);
+      if (!cancelled) setBotStatsLoading({});
     });
 
-    void api.getPresenceSnapshots(visibleBots.map((agent) => agent.agent_id))
+    void api.getPresenceSnapshots(shownBotIds)
       .then((result) => {
         if (cancelled) return;
         setBotPresence(Object.fromEntries(result.agents.map((agent) => [agent.agent_id, agent])));
@@ -234,7 +247,7 @@ export default function HomePanel() {
     return () => {
       cancelled = true;
     };
-  }, [visibleBots]);
+  }, [shownBotIds]);
 
   useEffect(() => {
     const refreshGreeting = () => setGreetingPeriod(getGreetingPeriod());
@@ -270,7 +283,7 @@ export default function HomePanel() {
                   agent={agent}
                   presence={botPresence[agent.agent_id]}
                   stats={botStats[agent.agent_id]}
-                  statsLoading={botStatsLoading}
+                  statsLoading={Boolean(botStatsLoading[agent.agent_id])}
                   t={t}
                   onOpen={() => setBotDetailAgentId(agent.agent_id)}
                 />

--- a/frontend/src/components/dashboard/sidebar/index.tsx
+++ b/frontend/src/components/dashboard/sidebar/index.tsx
@@ -267,16 +267,41 @@ export default function Sidebar({
   const pendingContactRequests = chatStore.overview?.pending_requests || 0;
 
   useEffect(() => {
-    const prefetch = (path: string) => {
-      if (typeof router.prefetch !== "function") return;
-      void router.prefetch(path);
+    if (typeof router.prefetch !== "function") return;
+    const paths = [
+      "/chats/messages",
+      `/chats/contacts/${uiStore.contactsView}`,
+      `/chats/explore/${uiStore.exploreView}`,
+      "/chats/wallet",
+      ...(sessionStore.viewMode === "human" ? ["/chats/bots"] : ["/chats/activity"]),
+    ];
+    const timers: number[] = [];
+    let idleId: number | null = null;
+
+    const prefetch = () => {
+      paths.forEach((path, index) => {
+        timers.push(window.setTimeout(() => {
+          void router.prefetch(path);
+        }, index * 150));
+      });
     };
-    prefetch("/chats/messages");
-    prefetch(`/chats/contacts/${uiStore.contactsView}`);
-    prefetch(`/chats/explore/${uiStore.exploreView}`);
-    prefetch("/chats/wallet");
-    prefetch("/chats/activity");
-  }, [router, uiStore.contactsView, uiStore.exploreView]);
+
+    const startTimer = window.setTimeout(() => {
+      if ("requestIdleCallback" in window) {
+        idleId = window.requestIdleCallback(prefetch, { timeout: 3000 });
+      } else {
+        prefetch();
+      }
+    }, 1200);
+
+    return () => {
+      window.clearTimeout(startTimer);
+      timers.forEach((timer) => window.clearTimeout(timer));
+      if (idleId !== null && "cancelIdleCallback" in window) {
+        window.cancelIdleCallback(idleId);
+      }
+    };
+  }, [router, sessionStore.viewMode, uiStore.contactsView, uiStore.exploreView]);
 
   useEffect(() => {
     let cancelled = false;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -56,6 +56,7 @@ import type {
   JoinRequestListResponse,
   MyJoinRequestResponse,
   ActivityStats,
+  ActivityStatsBatchResponse,
   ActivityFeedResponse,
   RoomResponse,
   UpdateRoomBody,
@@ -820,6 +821,16 @@ export const api = {
     identityOverride?: ActiveIdentity | null,
   ) {
     return apiGet<ActivityStats>("/api/dashboard/activity/stats", { period }, identityOverride);
+  },
+
+  getActivityStatsBatch(
+    agentIds: string[],
+    period: "today" | "7d" | "30d" = "today",
+  ) {
+    return apiGet<ActivityStatsBatchResponse>("/api/dashboard/activity/stats/batch", {
+      period,
+      agent_ids: agentIds.join(","),
+    });
   },
 
   getActivityFeed(opts?: { period?: string; limit?: number; offset?: number }) {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -874,6 +874,10 @@ export interface ActivityStats {
   active_rooms: number;
 }
 
+export interface ActivityStatsBatchResponse {
+  stats: Record<string, ActivityStats>;
+}
+
 export type ActivityEventType =
   | "message_sent"
   | "message_received"


### PR DESCRIPTION
## Summary
- add a batch activity stats endpoint for loading multiple owned bot cards in one request
- update the Home My Bots panel to request stats only for displayed bots and show per-card skeleton loading
- delay and stagger dashboard route prefetching so it does not compete with first-screen stats loading

## Tests
- cd frontend && npm run build
- cd backend && uv run python -m py_compile app/routers/activity.py
- cd backend && uv run pytest tests/test_app/test_app_dashboard.py *(fails: existing owner-chat room name assertions expect `Chat with ...`, current response returns the bot name)*