### PR TITLE
fix: sort empty message rooms by creation time

### DIFF
--- a/frontend/src/lib/messages-merge.test.ts
+++ b/frontend/src/lib/messages-merge.test.ts
@@ -2,46 +2,59 @@ import { describe, expect, it } from "vitest";
 import type { DashboardRoom, HumanAgentRoomSummary } from "@/lib/types";
 import { applyMessagesFilter, mergeOwnerVisibleRooms } from "@/lib/messages-merge";
 
-function makeHumanDmRoom(overrides: Partial<DashboardRoom> = {}): DashboardRoom {
+function makeRoom(overrides: Partial<DashboardRoom> = {}): DashboardRoom {
   return {
-    room_id: "rm_dm_ag_bot_hu_owner",
-    name: "My Bot",
+    room_id: "rm_room",
+    name: "Room",
     description: "",
     owner_id: "hu_owner",
     owner_type: "human",
     visibility: "private",
     join_policy: "invite",
-    member_count: 2,
-    my_role: "member",
+    member_count: 1,
+    my_role: "owner",
+    created_at: "2026-05-11T08:00:00Z",
     rule: null,
     required_subscription_product_id: null,
     last_viewed_at: null,
     has_unread: false,
+    unread_count: 0,
     last_message_preview: null,
-    last_message_at: "2026-05-13T08:00:00Z",
+    last_message_at: null,
     last_sender_name: null,
-    peer_type: "agent",
     ...overrides,
   };
 }
 
-function makeOwnedAgentRoom(overrides: Partial<HumanAgentRoomSummary> = {}): HumanAgentRoomSummary {
-  return {
+function makeHumanDmRoom(overrides: Partial<DashboardRoom> = {}): DashboardRoom {
+  return makeRoom({
     room_id: "rm_dm_ag_bot_hu_owner",
     name: "My Bot",
+    member_count: 2,
+    my_role: "member",
+    last_message_at: "2026-05-13T08:00:00Z",
+    peer_type: "agent",
+    ...overrides,
+  });
+}
+
+function makeOwnedAgentRoom(overrides: Partial<HumanAgentRoomSummary> = {}): HumanAgentRoomSummary {
+  return {
+    room_id: "rm_bot_room",
+    name: "Bot room",
     description: "",
-    owner_id: "hu_owner",
+    rule: null,
+    owner_id: "ag_owner",
     visibility: "private",
     join_policy: "invite",
     member_count: 2,
-    bots: [{ agent_id: "ag_bot", display_name: "My Bot", role: "member" }],
-    created_at: "2026-05-13T07:00:00Z",
-    rule: null,
+    created_at: "2026-05-11T09:00:00Z",
     required_subscription_product_id: null,
     last_message_preview: null,
-    last_message_at: "2026-05-13T08:00:00Z",
+    last_message_at: null,
     last_sender_name: null,
     allow_human_send: true,
+    bots: [{ agent_id: "ag_owner", display_name: "Bot", role: "owner" }],
     ...overrides,
   };
 }
@@ -49,7 +62,14 @@ function makeOwnedAgentRoom(overrides: Partial<HumanAgentRoomSummary> = {}): Hum
 describe("messages merge filters", () => {
   it("keeps a human-owned DM with my bot in the self-my-bot bucket", () => {
     const ownRoom = makeHumanDmRoom();
-    const ownedAgentRoom = makeOwnedAgentRoom();
+    const ownedAgentRoom = makeOwnedAgentRoom({
+      room_id: "rm_dm_ag_bot_hu_owner",
+      name: "My Bot",
+      owner_id: "hu_owner",
+      created_at: "2026-05-13T07:00:00Z",
+      last_message_at: "2026-05-13T08:00:00Z",
+      bots: [{ agent_id: "ag_bot", display_name: "My Bot", role: "member" }],
+    });
     const rooms = mergeOwnerVisibleRooms({
       ownRooms: [ownRoom],
       ownedAgentRooms: [ownedAgentRoom],
@@ -60,5 +80,48 @@ describe("messages merge filters", () => {
     expect(
       applyMessagesFilter(rooms, "self-my-bot", new Set([ownedAgentRoom.room_id])).map((room) => room.room_id),
     ).toEqual([ownRoom.room_id]);
+  });
+});
+
+describe("mergeOwnerVisibleRooms", () => {
+  it("falls back to created_at when sorting rooms without messages", () => {
+    const rooms = mergeOwnerVisibleRooms({
+      ownRooms: [
+        makeRoom({
+          room_id: "rm_old_message",
+          created_at: "2026-05-10T08:00:00Z",
+          last_message_at: "2026-05-11T08:00:00Z",
+          last_message_preview: "older activity",
+        }),
+        makeRoom({
+          room_id: "rm_new_empty",
+          created_at: "2026-05-12T08:00:00Z",
+          last_message_at: null,
+        }),
+      ],
+      ownedAgentRooms: [],
+    });
+
+    expect(rooms.map((room) => room.room_id)).toEqual(["rm_new_empty", "rm_old_message"]);
+  });
+
+  it("applies the same created_at fallback to owned bot rooms", () => {
+    const rooms = mergeOwnerVisibleRooms({
+      ownRooms: [
+        makeRoom({
+          room_id: "rm_old_message",
+          last_message_at: "2026-05-11T08:00:00Z",
+        }),
+      ],
+      ownedAgentRooms: [
+        makeOwnedAgentRoom({
+          room_id: "rm_new_empty_bot_room",
+          created_at: "2026-05-12T08:00:00Z",
+          last_message_at: null,
+        }),
+      ],
+    });
+
+    expect(rooms.map((room) => room.room_id)).toEqual(["rm_new_empty_bot_room", "rm_old_message"]);
   });
 });

--- a/frontend/src/lib/messages-merge.ts
+++ b/frontend/src/lib/messages-merge.ts
@@ -14,6 +14,7 @@
 
 import type { DashboardRoom, HumanAgentRoomSummary, ParticipantType } from "@/lib/types";
 import { parseDmRoomId } from "@/components/dashboard/dmRoom";
+import { compareRoomsByActivityDesc } from "@/store/dashboard-shared";
 
 interface MergeOpts {
   ownRooms: DashboardRoom[];
@@ -79,11 +80,7 @@ export function mergeOwnerVisibleRooms({ ownRooms, ownedAgentRooms }: MergeOpts)
       .map(ownedAgentRoomToDashboardRoom),
   ];
 
-  return tagged.sort((a, b) => {
-    const ta = a.last_message_at ? new Date(a.last_message_at).getTime() : 0;
-    const tb = b.last_message_at ? new Date(b.last_message_at).getTime() : 0;
-    return tb - ta;
-  });
+  return tagged.sort(compareRoomsByActivityDesc);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Reuse the shared room activity comparator for the unified Messages room merge
- Keep rooms without messages sorted by created_at instead of treating them as timestamp 0
- Add regression coverage for empty human rooms and owned-bot rooms

## Tests
- npm test -- --run src/lib/messages-merge.test.ts src/store/dashboard-shared.test.ts

## Notes
- npm run build compiles successfully but local prerendering stops at /admin/codes because Supabase URL/API key env vars are not configured.