### PR TITLE
feat: add Feishu scan gateway

### DIFF
--- a/backend/app/routers/gateways.py
+++ b/backend/app/routers/gateways.py
@@ -39,15 +39,21 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/agents", tags=["app-gateways"])
 
 
-ProviderLit = Literal["telegram", "wechat"]
+ProviderLit = Literal["telegram", "wechat", "feishu"]
 StatusLit = Literal["pending", "active", "disabled", "error"]
 
-_ALLOWED_PROVIDERS: set[str] = {"telegram", "wechat"}
+_ALLOWED_PROVIDERS: set[str] = {"telegram", "wechat", "feishu"}
 # config_json keys we accept from the dashboard. Anything else is dropped to
 # avoid arbitrary blob storage / leaking secrets.
 # W4: tokenPreview is server-managed (overwritten with the daemon-returned
 # value on create/patch); never accept it from the caller.
-_CONFIG_KEYS = {"baseUrl", "allowedSenderIds", "allowedChatIds", "splitAt"}
+_CONFIG_KEYS = {
+    "baseUrl",
+    "domain",
+    "allowedSenderIds",
+    "allowedChatIds",
+    "splitAt",
+}
 
 
 # ---------------------------------------------------------------------------
@@ -75,6 +81,7 @@ class GatewayListOut(BaseModel):
 
 class _ConfigPatch(BaseModel):
     baseUrl: str | None = None
+    domain: Literal["feishu", "lark"] | None = None
     allowedSenderIds: list[str] | None = None
     allowedChatIds: list[str] | None = None
     splitAt: int | None = Field(default=None, ge=64, le=8192)
@@ -99,7 +106,7 @@ class GatewayCreate(BaseModel):
     # ``bot_token`` / ``botToken``. ``_normalize_secret`` collapses both.
     bot_token: str | None = Field(default=None, alias="botToken", max_length=512)
     secret: _SecretIn | None = None
-    # WeChat only — references a previously-confirmed daemon login session.
+    # WeChat/Feishu only — references a previously-confirmed daemon login session.
     login_id: str | None = Field(default=None, alias="loginId", max_length=128)
     config: _ConfigPatch | None = None
 
@@ -146,6 +153,7 @@ class WechatLoginStartIn(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
     base_url: str | None = Field(default=None, alias="baseUrl", max_length=256)
     gateway_id: str | None = Field(default=None, alias="gatewayId", max_length=128)
+    domain: Literal["feishu", "lark"] | None = None
 
 
 class WechatLoginStatusIn(BaseModel):
@@ -168,7 +176,7 @@ def _serialize(row: AgentGatewayConnection) -> GatewayOut:
     # W10: explicit narrowing replaces the previous `# type: ignore` casts so a
     # future schema drift surfaces as a clear 500 instead of silently emitting
     # an out-of-spec literal.
-    if row.provider not in ("telegram", "wechat"):
+    if row.provider not in ("telegram", "wechat", "feishu"):
         raise ValueError(f"unexpected gateway provider in DB: {row.provider!r}")
     if row.status not in ("pending", "active", "disabled", "error"):
         raise ValueError(f"unexpected gateway status in DB: {row.status!r}")
@@ -347,7 +355,7 @@ def _filter_config(patch: _ConfigPatch | None) -> dict[str, Any]:
 def _build_settings(config: dict[str, Any]) -> dict[str, Any]:
     """Project the user-facing config into the daemon ``settings`` envelope."""
     out: dict[str, Any] = {}
-    for k in ("baseUrl", "allowedSenderIds", "allowedChatIds", "splitAt"):
+    for k in ("baseUrl", "domain", "allowedSenderIds", "allowedChatIds", "splitAt"):
         if k in config and config[k] is not None:
             out[k] = config[k]
     return out
@@ -368,6 +376,8 @@ def _require_whitelist(provider: str, config: dict[str, Any]) -> None:
             return
         raise HTTPException(status_code=400, detail="missing_gateway_whitelist")
     if provider == "wechat" and not _list_has_value(config, "allowedSenderIds"):
+        raise HTTPException(status_code=400, detail="missing_gateway_whitelist")
+    if provider == "feishu" and not _list_has_value(config, "allowedSenderIds"):
         raise HTTPException(status_code=400, detail="missing_gateway_whitelist")
 
 
@@ -421,6 +431,8 @@ async def create_gateway(
         raise HTTPException(status_code=400, detail="missing_bot_token")
     if body.provider == "wechat" and not body.login_id:
         raise HTTPException(status_code=400, detail="missing_login_id")
+    if body.provider == "feishu" and not body.login_id:
+        raise HTTPException(status_code=400, detail="missing_login_id")
 
     gateway_id = generate_gateway_connection_id(body.provider)
     config = _filter_config(body.config)
@@ -437,7 +449,7 @@ async def create_gateway(
     }
     if body.provider == "telegram":
         params["secret"] = {"botToken": body.bot_token}
-    if body.provider == "wechat":
+    if body.provider in ("wechat", "feishu"):
         params["loginId"] = body.login_id
 
     ack = await send_control_frame(daemon_id, "upsert_gateway", params)
@@ -450,6 +462,10 @@ async def create_gateway(
         config["tokenPreview"] = token_preview
     else:
         config.pop("tokenPreview", None)
+    for key in ("appId", "domain", "userOpenId"):
+        value = result.get(key)
+        if isinstance(value, str) and value:
+            config[key] = value
 
     daemon_status = result.get("status") if isinstance(result.get("status"), dict) else None
     status_value: str = "active" if body.enabled else "disabled"
@@ -670,6 +686,66 @@ async def wechat_login_status(
     return {
         "status": result.get("status"),
         "baseUrl": result.get("baseUrl"),
+        "tokenPreview": result.get("tokenPreview"),
+    }
+
+
+@router.post("/{agent_id}/gateways/feishu/login/start")
+async def feishu_login_start(
+    agent_id: str,
+    body: WechatLoginStartIn,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    _rate_limit(ctx.user_id, "wechat-login")
+    agent = await _load_daemon_agent_or_422(db, ctx, agent_id)
+    daemon_id = agent.daemon_instance_id
+    assert daemon_id is not None
+    _require_online(daemon_id)
+
+    params: dict[str, Any] = {
+        "provider": "feishu",
+        "accountId": agent_id,
+    }
+    if body.gateway_id:
+        params["gatewayId"] = body.gateway_id
+    if body.domain:
+        params["domain"] = body.domain
+
+    ack = await send_control_frame(daemon_id, "gateway_login_start", params)
+    result = _ack_or_raise(ack)
+    return {
+        "loginId": result.get("loginId"),
+        "qrcode": result.get("qrcode"),
+        "qrcodeUrl": result.get("qrcodeUrl"),
+        "expiresAt": result.get("expiresAt"),
+    }
+
+
+@router.post("/{agent_id}/gateways/feishu/login/status")
+async def feishu_login_status(
+    agent_id: str,
+    body: WechatLoginStatusIn,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    _rate_limit(ctx.user_id, "wechat-login")
+    agent = await _load_daemon_agent_or_422(db, ctx, agent_id)
+    daemon_id = agent.daemon_instance_id
+    assert daemon_id is not None
+    _require_online(daemon_id)
+
+    ack = await send_control_frame(
+        daemon_id,
+        "gateway_login_status",
+        {"provider": "feishu", "loginId": body.login_id, "accountId": agent_id},
+    )
+    result = _ack_or_raise(ack)
+    return {
+        "status": result.get("status"),
+        "appId": result.get("appId"),
+        "domain": result.get("domain"),
+        "userOpenId": result.get("userOpenId"),
         "tokenPreview": result.get("tokenPreview"),
     }
 

--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -1671,7 +1671,7 @@ class AgentGatewayConnection(Base):
     __tablename__ = "agent_gateway_connections"
     __table_args__ = (
         CheckConstraint(
-            "provider IN ('telegram', 'wechat')",
+            "provider IN ('telegram', 'wechat', 'feishu')",
             name="ck_agent_gateway_connections_provider",
         ),
         CheckConstraint(

--- a/backend/migrations/001_create_agent_gateway_connections.sql
+++ b/backend/migrations/001_create_agent_gateway_connections.sql
@@ -1,4 +1,4 @@
--- Third-party gateway (Telegram / WeChat) connection metadata.
+-- Third-party gateway (Telegram / WeChat / Feishu) connection metadata.
 -- See docs/third-party-gateway-design.md "Hub / Backend 设计".
 -- Hub stores metadata only (provider, label, whitelist, baseUrl, splitAt,
 -- tokenPreview, status). Bot tokens NEVER live here — they are written to
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS agent_gateway_connections (
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     CONSTRAINT ck_agent_gateway_connections_provider
-        CHECK (provider IN ('telegram', 'wechat')),
+        CHECK (provider IN ('telegram', 'wechat', 'feishu')),
     CONSTRAINT ck_agent_gateway_connections_status
         CHECK (status IN ('pending', 'active', 'disabled', 'error'))
 );

--- a/backend/migrations/008_agent_gateway_connections_feishu.sql
+++ b/backend/migrations/008_agent_gateway_connections_feishu.sql
@@ -1,0 +1,8 @@
+-- Add Feishu/Lark as a third-party gateway provider.
+
+ALTER TABLE agent_gateway_connections
+    DROP CONSTRAINT IF EXISTS ck_agent_gateway_connections_provider;
+
+ALTER TABLE agent_gateway_connections
+    ADD CONSTRAINT ck_agent_gateway_connections_provider
+        CHECK (provider IN ('telegram', 'wechat', 'feishu'));

--- a/backend/tests/test_app/test_app_gateways.py
+++ b/backend/tests/test_app/test_app_gateways.py
@@ -423,6 +423,52 @@ async def test_create_wechat_forwards_login_id_no_token_in_db(
     assert "tokenPreview" in body["config"]
 
 
+@pytest.mark.asyncio
+async def test_create_feishu_forwards_login_id_and_persists_public_metadata(
+    client, seed, monkeypatch
+):
+    captured: dict = {}
+
+    async def fake_send(daemon_instance_id, type_, params=None, timeout_ms=None):
+        captured["params"] = params
+        return {
+            "ok": True,
+            "result": {
+                "id": params["id"],
+                "type": "feishu",
+                "accountId": params["accountId"],
+                "enabled": True,
+                "tokenPreview": "feis...7890",
+                "appId": "cli_feishu_123",
+                "domain": "feishu",
+                "userOpenId": "ou_alice",
+                "status": {"running": True},
+            },
+        }
+
+    _patch_daemon(monkeypatch, online=True, send=fake_send)
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    r = await client.post(
+        "/api/agents/ag_daemon/gateways",
+        headers=headers,
+        json={
+            "provider": "feishu",
+            "label": "飞书助手",
+            "loginId": "fsl_abc",
+            "config": {"allowedSenderIds": ["ou_alice"], "domain": "feishu"},
+        },
+    )
+    assert r.status_code == 200, r.text
+    assert captured["params"]["loginId"] == "fsl_abc"
+    assert captured["params"]["type"] == "feishu"
+    assert "secret" not in captured["params"]
+    body = r.json()
+    assert body["provider"] == "feishu"
+    assert body["config"]["appId"] == "cli_feishu_123"
+    assert body["config"]["userOpenId"] == "ou_alice"
+    assert body["config"]["tokenPreview"] == "feis...7890"
+
+
 # ---------------------------------------------------------------------------
 # Daemon failure mapping
 # ---------------------------------------------------------------------------
@@ -693,6 +739,57 @@ async def test_wechat_login_status_proxies(client, seed, monkeypatch):
     assert body["tokenPreview"] == "abcd...wxyz"
 
 
+@pytest.mark.asyncio
+async def test_feishu_login_start_and_status_proxy(client, seed, monkeypatch):
+    calls: list[tuple[str, dict]] = []
+
+    async def fake_send(daemon_instance_id, type_, params=None, timeout_ms=None):
+        calls.append((type_, params))
+        if type_ == "gateway_login_start":
+            return {
+                "ok": True,
+                "result": {
+                    "loginId": "fsl_xyz",
+                    "qrcode": "DEV",
+                    "qrcodeUrl": "https://accounts.feishu.cn/verify",
+                    "expiresAt": 1700000000,
+                },
+            }
+        return {
+            "ok": True,
+            "result": {
+                "status": "confirmed",
+                "appId": "cli_feishu_123",
+                "domain": "feishu",
+                "userOpenId": "ou_alice",
+                "tokenPreview": "feis...7890",
+            },
+        }
+
+    _patch_daemon(monkeypatch, online=True, send=fake_send)
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    start = await client.post(
+        "/api/agents/ag_daemon/gateways/feishu/login/start",
+        headers=headers,
+        json={"domain": "feishu"},
+    )
+    assert start.status_code == 200, start.text
+    assert start.json()["loginId"] == "fsl_xyz"
+    status = await client.post(
+        "/api/agents/ag_daemon/gateways/feishu/login/status",
+        headers=headers,
+        json={"loginId": "fsl_xyz"},
+    )
+    assert status.status_code == 200, status.text
+    assert status.json()["appId"] == "cli_feishu_123"
+    assert calls[0] == (
+        "gateway_login_start",
+        {"provider": "feishu", "accountId": "ag_daemon", "domain": "feishu"},
+    )
+    assert calls[1] == (
+        "gateway_login_status",
+        {"provider": "feishu", "loginId": "fsl_xyz", "accountId": "ag_daemon"},
+    )
 @pytest.mark.asyncio
 async def test_wechat_recent_senders_proxies(client, seed, monkeypatch):
     async def fake_send(daemon_instance_id, type_, params=None, timeout_ms=None):

--- a/frontend/src/app/api/agents/[agentId]/gateways/feishu/login/start/route.ts
+++ b/frontend/src/app/api/agents/[agentId]/gateways/feishu/login/start/route.ts
@@ -1,0 +1,28 @@
+/**
+ * [INPUT]: agentId from path; POST body optional { domain }
+ * [OUTPUT]: POST /api/agents/[agentId]/gateways/feishu/login/start — proxies to Hub
+ * [POS]: BFF endpoint for the Feishu scan-to-create-bot flow
+ * [PROTOCOL]: update header on changes
+ */
+
+import { NextResponse } from "next/server";
+import { proxyHub } from "../../../../../../_lib/proxy-hub";
+
+type Params = { params: Promise<{ agentId: string }> };
+
+export async function POST(req: Request, { params }: Params) {
+  const { agentId } = await params;
+  if (!agentId) {
+    return NextResponse.json({ error: "missing_agent_id" }, { status: 400 });
+  }
+  let body: unknown = {};
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  return proxyHub(
+    `/api/agents/${encodeURIComponent(agentId)}/gateways/feishu/login/start`,
+    { method: "POST", body },
+  );
+}

--- a/frontend/src/app/api/agents/[agentId]/gateways/feishu/login/status/route.ts
+++ b/frontend/src/app/api/agents/[agentId]/gateways/feishu/login/status/route.ts
@@ -1,0 +1,28 @@
+/**
+ * [INPUT]: agentId from path; POST body { loginId }
+ * [OUTPUT]: POST /api/agents/[agentId]/gateways/feishu/login/status — proxies to Hub
+ * [POS]: BFF endpoint polled by the Feishu scan-to-create-bot dialog
+ * [PROTOCOL]: update header on changes
+ */
+
+import { NextResponse } from "next/server";
+import { proxyHub } from "../../../../../../_lib/proxy-hub";
+
+type Params = { params: Promise<{ agentId: string }> };
+
+export async function POST(req: Request, { params }: Params) {
+  const { agentId } = await params;
+  if (!agentId) {
+    return NextResponse.json({ error: "missing_agent_id" }, { status: 400 });
+  }
+  let body: unknown = {};
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  return proxyHub(
+    `/api/agents/${encodeURIComponent(agentId)}/gateways/feishu/login/status`,
+    { method: "POST", body },
+  );
+}

--- a/frontend/src/components/dashboard/AgentChannelsTab.tsx
+++ b/frontend/src/components/dashboard/AgentChannelsTab.tsx
@@ -4,7 +4,7 @@
  * [INPUT]: agentId; uses useAgentGatewayStore for data + actions
  * [OUTPUT]: AgentChannelsTab — content of the "接入 / Channels" tab inside
  *          AgentSettingsDrawer. Provider-specific add forms are split into
- *          TelegramAddForm and WechatAddForm so future providers (LINE, Discord)
+ *          TelegramAddForm, WechatAddForm, and FeishuAddForm so future providers
  *          can drop into the same surface without tangling.
  * [POS]: dashboard third-party gateway management UI
  * [PROTOCOL]: update header on changes
@@ -39,7 +39,7 @@ interface Props {
   agentId: string;
 }
 
-type AddMode = null | "telegram" | "wechat";
+type AddMode = null | "telegram" | "wechat" | "feishu";
 type TelegramDiscoveryChat = { id: string; type: string | null; label: string | null };
 type TelegramDiscoverySender = { id: string; label: string | null };
 
@@ -61,11 +61,16 @@ function ProviderIcon({ provider }: { provider: GatewayProvider }) {
   if (provider === "telegram") {
     return <Send className="h-3.5 w-3.5" />;
   }
+  if (provider === "feishu") {
+    return <MessageCircle className="h-3.5 w-3.5" />;
+  }
   return <MessageCircle className="h-3.5 w-3.5" />;
 }
 
 function providerName(provider: GatewayProvider): string {
-  return provider === "telegram" ? "Telegram" : "微信";
+  if (provider === "telegram") return "Telegram";
+  if (provider === "feishu") return "飞书";
+  return "微信";
 }
 
 function isAckTimeoutError(err: unknown): boolean {
@@ -377,7 +382,7 @@ export default function AgentChannelsTab({ agentId }: Props) {
           </div>
           {/* provider segmented control */}
           <div className="mb-4 inline-flex rounded-lg border border-glass-border bg-deep-black/40 p-0.5">
-            {(["wechat", "telegram"] as const).map((p) => (
+            {(["feishu", "wechat", "telegram"] as const).map((p) => (
               <button
                 key={p}
                 type="button"
@@ -388,7 +393,7 @@ export default function AgentChannelsTab({ agentId }: Props) {
                     : "text-text-secondary hover:text-text-primary"
                 }`}
               >
-                {p === "wechat" ? "微信" : "Telegram"}
+                {p === "feishu" ? "飞书" : p === "wechat" ? "微信" : "Telegram"}
               </button>
             ))}
           </div>
@@ -399,8 +404,15 @@ export default function AgentChannelsTab({ agentId }: Props) {
               onCancel={() => setAddMode(null)}
               onCreated={() => setAddMode(null)}
             />
-          ) : (
+          ) : addMode === "wechat" ? (
             <WechatAddForm
+              agentId={agentId}
+              daemonOffline={daemonOffline}
+              onCancel={() => setAddMode(null)}
+              onCreated={() => setAddMode(null)}
+            />
+          ) : (
+            <FeishuAddForm
               agentId={agentId}
               daemonOffline={daemonOffline}
               onCancel={() => setAddMode(null)}
@@ -912,6 +924,250 @@ function TelegramTokenGuideDialog({ onClose }: { onClose: () => void }) {
             知道了
           </button>
         </div>
+      </div>
+    </div>
+  );
+}
+
+function FeishuAddForm({
+  agentId,
+  daemonOffline,
+  onCancel,
+  onCreated,
+}: {
+  agentId: string;
+  daemonOffline: boolean;
+  onCancel: () => void;
+  onCreated: () => void;
+}) {
+  const startFeishuLogin = useAgentGatewayStore((s) => s.startFeishuLogin);
+  const pollFeishuLogin = useAgentGatewayStore((s) => s.pollFeishuLogin);
+  const create = useAgentGatewayStore((s) => s.create);
+  const [domain, setDomain] = useState<"feishu" | "lark">("feishu");
+  const [phase, setPhase] = useState<"idle" | "scanning" | "ready">("idle");
+  const [loginId, setLoginId] = useState<string | null>(null);
+  const [qrcodeUrl, setQrcodeUrl] = useState<string | null>(null);
+  const [status, setStatus] = useState<WechatLoginStatus>("pending");
+  const [appId, setAppId] = useState<string | null>(null);
+  const [userOpenId, setUserOpenId] = useState<string | null>(null);
+  const [tokenPreview, setTokenPreview] = useState<string | null>(null);
+  const [label, setLabel] = useState("");
+  const [senderIds, setSenderIds] = useState("");
+  const [chatIds, setChatIds] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (pollTimer.current) clearInterval(pollTimer.current);
+    };
+  }, []);
+
+  async function doPoll(id: string) {
+    try {
+      const r = await pollFeishuLogin(agentId, id);
+      setStatus(r.status);
+      if (r.tokenPreview) setTokenPreview(r.tokenPreview);
+      if (r.appId) setAppId(r.appId);
+      if (r.domain === "feishu" || r.domain === "lark") setDomain(r.domain);
+      if (r.userOpenId) {
+        setUserOpenId(r.userOpenId);
+        setSenderIds((cur) => cur || r.userOpenId || "");
+      }
+      if (r.status === "confirmed") {
+        if (pollTimer.current) clearInterval(pollTimer.current);
+        pollTimer.current = null;
+        setPhase("ready");
+      } else if (r.status === "expired" || r.status === "failed") {
+        if (pollTimer.current) clearInterval(pollTimer.current);
+        pollTimer.current = null;
+      }
+    } catch (err) {
+      if (!isAckTimeoutError(err)) {
+        setError(err instanceof Error ? err.message : String(err));
+        if (pollTimer.current) clearInterval(pollTimer.current);
+        pollTimer.current = null;
+      }
+    }
+  }
+
+  async function handleStart() {
+    setBusy(true);
+    setError(null);
+    try {
+      const r = await startFeishuLogin(agentId, { domain });
+      setLoginId(r.loginId);
+      setQrcodeUrl(r.qrcodeUrl ?? null);
+      setStatus("pending");
+      setPhase("scanning");
+      if (pollTimer.current) clearInterval(pollTimer.current);
+      pollTimer.current = setInterval(() => {
+        void doPoll(r.loginId);
+      }, 2500);
+    } catch (err) {
+      if (!isAckTimeoutError(err)) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const allowedSenderIds = csvToList(senderIds);
+  const allowedChatIds = csvToList(chatIds);
+  const canSave =
+    phase === "ready" &&
+    !!loginId &&
+    allowedSenderIds.length > 0 &&
+    !daemonOffline &&
+    !busy;
+
+  async function handleSave() {
+    if (!canSave || !loginId) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await create(agentId, {
+        provider: "feishu",
+        label: label.trim() || null,
+        enabled: true,
+        loginId,
+        config: {
+          label: label.trim() || undefined,
+          domain,
+          allowedSenderIds,
+          ...(allowedChatIds.length > 0 ? { allowedChatIds } : {}),
+        },
+      });
+      onCreated();
+    } catch (err) {
+      if (!isAckTimeoutError(err)) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const statusText: Record<WechatLoginStatus, string> = {
+    pending: "等待扫码",
+    scanned: "等待确认",
+    confirmed: "已创建",
+    expired: "已过期",
+    failed: "创建失败",
+  };
+
+  return (
+    <div className="space-y-3">
+      <StepSection
+        step={1}
+        title="扫码创建飞书 Bot"
+        description="使用飞书扫码后，daemon 会拿到该 PersonalAgent 的 App ID 和 App Secret。"
+        complete={phase === "ready"}
+      >
+        <div className="mb-3 inline-flex rounded-lg border border-glass-border bg-deep-black/40 p-0.5">
+          {(["feishu", "lark"] as const).map((d) => (
+            <button
+              key={d}
+              type="button"
+              onClick={() => setDomain(d)}
+              disabled={phase !== "idle" || busy}
+              className={`rounded-md px-3 py-1 text-xs transition-colors ${
+                domain === d
+                  ? "bg-neon-cyan/20 text-neon-cyan"
+                  : "text-text-secondary hover:text-text-primary"
+              } disabled:opacity-50`}
+            >
+              {d === "feishu" ? "飞书" : "Lark"}
+            </button>
+          ))}
+        </div>
+        {phase === "idle" ? (
+          <button
+            type="button"
+            onClick={handleStart}
+            disabled={daemonOffline || busy}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-neon-cyan/50 bg-neon-cyan/15 px-3 py-2 text-xs font-semibold text-neon-cyan hover:bg-neon-cyan/25 disabled:opacity-50"
+          >
+            {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <MessageCircle className="h-3.5 w-3.5" />}
+            生成二维码
+          </button>
+        ) : (
+          <div className="space-y-2">
+            <div className="text-xs text-text-secondary">{statusText[status]}</div>
+            {phase === "scanning" && qrcodeUrl ? (
+              <div className="inline-block rounded-xl border border-glass-border bg-white p-3">
+                <QRCodeSVG value={qrcodeUrl} size={176} />
+              </div>
+            ) : null}
+            {phase === "ready" ? (
+              <div className="space-y-1 text-[11px] text-text-secondary">
+                {appId ? <div className="font-mono">App ID: {appId}</div> : null}
+                {userOpenId ? <div className="font-mono">open_id: {userOpenId}</div> : null}
+                {tokenPreview ? <div>secret {tokenPreview}</div> : null}
+              </div>
+            ) : null}
+          </div>
+        )}
+      </StepSection>
+
+      {phase === "ready" && (
+        <StepSection
+          step={2}
+          title="设置允许的飞书用户"
+          description="默认只允许扫码创建者触发，也可以追加其他 open_id。群聊可选填 chat_id。"
+          complete={allowedSenderIds.length > 0}
+        >
+          <div className="space-y-3">
+            <Field label="接入名称">
+              <input
+                value={label}
+                onChange={(e) => setLabel(e.target.value)}
+                placeholder="例如：飞书助手"
+                className="w-full rounded-lg border border-glass-border bg-deep-black/40 px-3 py-2 text-xs text-text-primary outline-none focus:border-neon-cyan/40"
+              />
+            </Field>
+            <Field label="允许的用户 open_id（逗号或换行分隔）">
+              <textarea
+                value={senderIds}
+                onChange={(e) => setSenderIds(e.target.value)}
+                rows={2}
+                className="w-full resize-none rounded-lg border border-glass-border bg-deep-black/40 px-3 py-2 font-mono text-xs text-text-primary outline-none focus:border-neon-cyan/40"
+              />
+            </Field>
+            <Field label="允许的群 chat_id（可选）">
+              <textarea
+                value={chatIds}
+                onChange={(e) => setChatIds(e.target.value)}
+                rows={2}
+                placeholder="oc_xxxxx"
+                className="w-full resize-none rounded-lg border border-glass-border bg-deep-black/40 px-3 py-2 font-mono text-xs text-text-primary outline-none focus:border-neon-cyan/40"
+              />
+            </Field>
+          </div>
+        </StepSection>
+      )}
+
+      {error && <div className="text-xs text-red-300">{error}</div>}
+      <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={busy}
+          className="rounded-lg border border-glass-border px-3 py-2 text-xs text-text-secondary hover:text-text-primary disabled:opacity-50"
+        >
+          取消
+        </button>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={!canSave}
+          className="inline-flex items-center gap-1.5 rounded-lg border border-neon-cyan/50 bg-neon-cyan/15 px-3 py-2 text-xs font-semibold text-neon-cyan hover:bg-neon-cyan/25 disabled:opacity-50"
+        >
+          {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
+          保存接入
+        </button>
       </div>
     </div>
   );

--- a/frontend/src/store/useAgentGatewayStore.ts
+++ b/frontend/src/store/useAgentGatewayStore.ts
@@ -8,7 +8,7 @@
 
 import { create } from "zustand";
 
-export type GatewayProvider = "telegram" | "wechat";
+export type GatewayProvider = "telegram" | "wechat" | "feishu";
 export type GatewayStatus = "pending" | "active" | "error" | "disabled";
 
 export interface AgentGatewayConnection {
@@ -47,7 +47,21 @@ export interface WechatCreateInput {
   };
 }
 
-export type GatewayCreateInput = TelegramCreateInput | WechatCreateInput;
+export interface FeishuCreateInput {
+  provider: "feishu";
+  label?: string | null;
+  enabled?: boolean;
+  loginId: string;
+  config: {
+    label?: string;
+    allowedSenderIds?: string[];
+    allowedChatIds?: string[];
+    domain?: "feishu" | "lark";
+    splitAt?: number;
+  };
+}
+
+export type GatewayCreateInput = TelegramCreateInput | WechatCreateInput | FeishuCreateInput;
 
 export interface GatewayPatchInput {
   label?: string | null;
@@ -56,6 +70,7 @@ export interface GatewayPatchInput {
     allowedChatIds?: string[];
     allowedSenderIds?: string[];
     baseUrl?: string;
+    domain?: "feishu" | "lark";
     splitAt?: number;
     label?: string;
   };
@@ -188,6 +203,18 @@ interface AgentGatewayState {
     loginId: string,
     opts?: { timeoutSeconds?: number },
   ) => Promise<WechatSenderDiscoveryResponse>;
+  startFeishuLogin: (
+    agentId: string,
+    opts?: { domain?: "feishu" | "lark"; gatewayId?: string },
+  ) => Promise<WechatLoginStartResponse>;
+  pollFeishuLogin: (
+    agentId: string,
+    loginId: string,
+  ) => Promise<WechatLoginStatusResponse & {
+    appId?: string | null;
+    domain?: "feishu" | "lark" | null;
+    userOpenId?: string | null;
+  }>;
 }
 
 function base(agentId: string): string {
@@ -452,5 +479,49 @@ export const useAgentGatewayStore = create<AgentGatewayState>((set, get) => ({
       }
     }
     return { senders };
+  },
+
+  async startFeishuLogin(agentId, opts) {
+    const res = await fetch(`${base(agentId)}/feishu/login/start`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(opts ?? {}),
+    });
+    if (!res.ok) {
+      const err = await readErr(res);
+      if (err.status === 409) {
+        set((s) => ({ daemonOffline: { ...s.daemonOffline, [agentId]: true } }));
+      }
+      throw err;
+    }
+    return (await res.json()) as WechatLoginStartResponse;
+  },
+
+  async pollFeishuLogin(agentId, loginId) {
+    const res = await fetch(`${base(agentId)}/feishu/login/status`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ loginId }),
+    });
+    if (!res.ok) {
+      const err = await readErr(res);
+      if (err.status === 409) {
+        set((s) => ({ daemonOffline: { ...s.daemonOffline, [agentId]: true } }));
+      }
+      throw err;
+    }
+    const json = (await res.json()) as Partial<WechatLoginStatusResponse> & {
+      appId?: string | null;
+      domain?: "feishu" | "lark" | null;
+      userOpenId?: string | null;
+    };
+    return {
+      status: normalizeWechatStatus(json.status),
+      baseUrl: json.baseUrl ?? null,
+      tokenPreview: json.tokenPreview ?? null,
+      appId: json.appId ?? null,
+      domain: json.domain ?? null,
+      userOpenId: json.userOpenId ?? null,
+    };
   },
 }));

--- a/packages/daemon/package-lock.json
+++ b/packages/daemon/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@botcord/cli": "^0.1.7",
         "@botcord/protocol-core": "^0.2.4",
+        "@larksuiteoapi/node-sdk": "^1.63.1",
         "ws": "^8.18.0"
       },
       "bin": {
@@ -92,6 +93,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@larksuiteoapi/node-sdk": {
+      "version": "1.63.1",
+      "resolved": "https://registry.npmjs.org/@larksuiteoapi/node-sdk/-/node-sdk-1.63.1.tgz",
+      "integrity": "sha512-bVC2QVkITZ1i6kLP7hI7DXtp61ic9shP/F+bp/2qZ0ISSvrcHp2euu1xt6C29jPJVNieRgvdsBPuapOlybviVw==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "~1.13.3",
+        "lodash.identity": "^3.0.0",
+        "lodash.merge": "^4.6.2",
+        "lodash.pickby": "^4.6.0",
+        "protobufjs": "^7.2.6",
+        "qs": "^6.14.2",
+        "ws": "^8.19.0"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -120,6 +136,70 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.17",
@@ -432,7 +512,6 @@
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -571,6 +650,52 @@
         "node": ">=12"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -581,12 +706,33 @@
         "node": ">=18"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -598,12 +744,71 @@
         "node": ">=8"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
@@ -643,6 +848,42 @@
         }
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -656,6 +897,103 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/lightningcss": {
@@ -919,6 +1257,30 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lodash.identity": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-3.0.0.tgz",
+      "integrity": "sha512-AupTIzdLQxJS5wIYUQlgGyk2XRTfGXA+MCghDHqZk0pzUNYvd3EESS6dkChNauNYVIutcb0dfHw1ri9Q1yPV8Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.pickby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
+      "integrity": "sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -927,6 +1289,36 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/nanoid": {
@@ -946,6 +1338,18 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/obug": {
@@ -1015,6 +1419,51 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
@@ -1047,6 +1496,78 @@
         "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
         "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -1150,7 +1671,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@botcord/cli": "^0.1.7",
     "@botcord/protocol-core": "^0.2.4",
+    "@larksuiteoapi/node-sdk": "^1.63.1",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/packages/daemon/src/__tests__/gateway-control.test.ts
+++ b/packages/daemon/src/__tests__/gateway-control.test.ts
@@ -240,6 +240,90 @@ describe("gateway_login_start / status", () => {
     expect(JSON.stringify(statusResult)).not.toContain("wechat-bot-token-1234567890");
   });
 
+  it("round-trips Feishu registration and upsert stores app secret locally", async () => {
+    const gw = makeFakeGateway();
+    const { state, io } = makeConfigIO(baseCfg());
+    const sessions = new LoginSessionStore();
+    const feishuLogin = {
+      startFeishuRegistration: vi.fn(async () => ({
+        deviceCode: "DEV-CODE",
+        verificationUriComplete: "https://accounts.feishu.cn/verify?x=1",
+        expiresIn: 600,
+        interval: 5,
+        domain: "feishu" as const,
+        raw: {},
+      })),
+      pollFeishuRegistration: vi.fn(async () => ({
+        status: "confirmed" as const,
+        appId: "cli_feishu_123",
+        appSecret: "feishu-secret-1234567890",
+        userOpenId: "ou_alice",
+        domain: "feishu" as const,
+        raw: {},
+      })),
+    };
+    const ctrl = createGatewayControl({
+      gateway: gw as any,
+      configIO: io,
+      loginSessions: sessions,
+      feishuLoginClient: feishuLogin,
+    });
+
+    const startAck = await ctrl.handleLoginStart({
+      provider: "feishu",
+      accountId: "ag_alice",
+      domain: "feishu",
+    });
+    expect(startAck.ok).toBe(true);
+    const startResult = startAck.result as { loginId: string; qrcodeUrl?: string };
+    expect(startResult.loginId).toMatch(/^fsl_/);
+    expect(startResult.qrcodeUrl).toBe("https://accounts.feishu.cn/verify?x=1");
+
+    const statusAck = await ctrl.handleLoginStatus({
+      provider: "feishu",
+      loginId: startResult.loginId,
+      accountId: "ag_alice",
+    });
+    expect(statusAck.ok).toBe(true);
+    const statusResult = statusAck.result as {
+      status: string;
+      appId?: string;
+      userOpenId?: string;
+      tokenPreview?: string;
+    };
+    expect(statusResult).toMatchObject({
+      status: "confirmed",
+      appId: "cli_feishu_123",
+      userOpenId: "ou_alice",
+      tokenPreview: "feis...7890",
+    });
+    expect(JSON.stringify(statusResult)).not.toContain("feishu-secret-1234567890");
+
+    const gwId = uniqId("fs");
+    const upsertAck = await ctrl.handleUpsert({
+      id: gwId,
+      type: "feishu",
+      accountId: "ag_alice",
+      enabled: true,
+      loginId: startResult.loginId,
+      settings: { allowedSenderIds: ["ou_alice"], domain: "feishu" },
+    });
+    expect(upsertAck.ok).toBe(true);
+    expect(state.cfg.thirdPartyGateways?.[0]).toMatchObject({
+      id: gwId,
+      type: "feishu",
+      appId: "cli_feishu_123",
+      domain: "feishu",
+      userOpenId: "ou_alice",
+    });
+    expect(gw.addChannel).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: gwId, type: "feishu", appId: "cli_feishu_123" }),
+    );
+    const secretPath = trackSecret(gwId);
+    const secret = JSON.parse(readFileSync(secretPath, "utf8")) as { appSecret?: string };
+    expect(secret.appSecret).toBe("feishu-secret-1234567890");
+  });
+
   it("discovers recent WeChat senders from a confirmed login session", async () => {
     const gw = makeFakeGateway();
     const { io } = makeConfigIO(baseCfg());

--- a/packages/daemon/src/__tests__/third-party-gateway.test.ts
+++ b/packages/daemon/src/__tests__/third-party-gateway.test.ts
@@ -37,6 +37,15 @@ describe("toGatewayConfig + thirdPartyGateways", () => {
           allowedSenderIds: ["abc@im.wechat"],
           splitAt: 1800,
         },
+        {
+          id: "gw_fs_1",
+          type: "feishu",
+          accountId: "ag_daemon",
+          appId: "cli_xxx",
+          domain: "feishu",
+          allowedSenderIds: ["ou_alice"],
+          allowedChatIds: ["oc_team"],
+        },
       ],
     });
     const gw = toGatewayConfig(cfg);
@@ -44,6 +53,7 @@ describe("toGatewayConfig + thirdPartyGateways", () => {
       { id: "ag_daemon", type: BOTCORD_CHANNEL_TYPE },
       { id: "gw_tg_1", type: TELEGRAM_CHANNEL_TYPE },
       { id: "gw_wx_1", type: WECHAT_CHANNEL_TYPE },
+      { id: "gw_fs_1", type: "feishu" },
     ]);
     const tg = gw.channels[1]!;
     expect(tg.accountId).toBe("ag_daemon");
@@ -52,6 +62,11 @@ describe("toGatewayConfig + thirdPartyGateways", () => {
     expect(wx.baseUrl).toBe("https://ilinkai.weixin.qq.com");
     expect(wx.allowedSenderIds).toEqual(["abc@im.wechat"]);
     expect(wx.splitAt).toBe(1800);
+    const fs = gw.channels[3]!;
+    expect(fs.appId).toBe("cli_xxx");
+    expect(fs.domain).toBe("feishu");
+    expect(fs.allowedSenderIds).toEqual(["ou_alice"]);
+    expect(fs.allowedChatIds).toEqual(["oc_team"]);
   });
 
   it("filters out gateways with enabled === false", () => {
@@ -113,6 +128,19 @@ describe("createDaemonChannel", () => {
     const adapter = createDaemonChannel(chCfg, deps);
     expect(adapter.type).toBe("wechat");
     expect(adapter.id).toBe("gw_wx_1");
+  });
+
+  it("dispatches feishu type to the Feishu adapter", () => {
+    const chCfg: GatewayChannelConfig = {
+      id: "gw_fs_1",
+      type: "feishu",
+      accountId: "ag_x",
+      appId: "cli_xxx",
+      domain: "feishu",
+    };
+    const adapter = createDaemonChannel(chCfg, deps);
+    expect(adapter.type).toBe("feishu");
+    expect(adapter.id).toBe("gw_fs_1");
   });
 
   it("throws on unknown channel type", () => {

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -100,7 +100,7 @@ export interface OpenclawDiscoveryConfig {
 }
 
 /** Third-party messaging provider supported by the daemon's channel factory. */
-export type ThirdPartyGatewayType = "telegram" | "wechat";
+export type ThirdPartyGatewayType = "telegram" | "wechat" | "feishu";
 
 /**
  * One third-party gateway profile bound to a BotCord agent. `id` is the
@@ -122,6 +122,9 @@ export interface ThirdPartyGatewayProfile {
   allowedChatIds?: string[];
   splitAt?: number;
   baseUrl?: string;
+  appId?: string;
+  domain?: "feishu" | "lark";
+  userOpenId?: string;
 }
 
 export interface DaemonConfig {
@@ -445,9 +448,9 @@ export function loadConfig(): DaemonConfig {
           `daemon config thirdPartyGateways[${i}].id must be a non-empty string (${CONFIG_PATH})`,
         );
       }
-      if (gg.type !== "telegram" && gg.type !== "wechat") {
+      if (gg.type !== "telegram" && gg.type !== "wechat" && gg.type !== "feishu") {
         throw new Error(
-          `daemon config thirdPartyGateways[${i}].type must be "telegram" or "wechat" (${CONFIG_PATH})`,
+          `daemon config thirdPartyGateways[${i}].type must be "telegram", "wechat", or "feishu" (${CONFIG_PATH})`,
         );
       }
       if (typeof gg.accountId !== "string" || gg.accountId.length === 0) {

--- a/packages/daemon/src/daemon-config-map.ts
+++ b/packages/daemon/src/daemon-config-map.ts
@@ -262,6 +262,9 @@ export function toGatewayConfig(
     if (g.allowedChatIds !== undefined) ch.allowedChatIds = g.allowedChatIds;
     if (g.splitAt !== undefined) ch.splitAt = g.splitAt;
     if (g.baseUrl !== undefined) ch.baseUrl = g.baseUrl;
+    if (g.appId !== undefined) ch.appId = g.appId;
+    if (g.domain !== undefined) ch.domain = g.domain;
+    if (g.userOpenId !== undefined) ch.userOpenId = g.userOpenId;
     channels.push(ch);
   }
 

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -6,6 +6,7 @@ import {
 import {
   Gateway,
   createBotCordChannel,
+  createFeishuChannel,
   createTelegramChannel,
   createWechatChannel,
   resolveTranscriptEnabled,
@@ -177,6 +178,23 @@ export function createDaemonChannel(
         ...(typeof chCfg.splitAt === "number" ? { splitAt: chCfg.splitAt } : {}),
         ...(typeof chCfg.secretFile === "string" ? { secretFile: chCfg.secretFile } : {}),
         ...(typeof chCfg.stateFile === "string" ? { stateFile: chCfg.stateFile } : {}),
+      });
+    case "feishu":
+      return createFeishuChannel({
+        id: chCfg.id,
+        accountId: chCfg.accountId,
+        ...(typeof chCfg.appId === "string" ? { appId: chCfg.appId } : {}),
+        ...(chCfg.domain === "feishu" || chCfg.domain === "lark"
+          ? { domain: chCfg.domain }
+          : {}),
+        ...(Array.isArray(chCfg.allowedSenderIds)
+          ? { allowedSenderIds: chCfg.allowedSenderIds as string[] }
+          : {}),
+        ...(Array.isArray(chCfg.allowedChatIds)
+          ? { allowedChatIds: chCfg.allowedChatIds as string[] }
+          : {}),
+        ...(typeof chCfg.splitAt === "number" ? { splitAt: chCfg.splitAt } : {}),
+        ...(typeof chCfg.secretFile === "string" ? { secretFile: chCfg.secretFile } : {}),
       });
     default:
       throw new Error(`unknown channel type "${chCfg.type}"`);

--- a/packages/daemon/src/gateway-control.ts
+++ b/packages/daemon/src/gateway-control.ts
@@ -33,6 +33,11 @@ import {
   getBotQrcode,
   getQrcodeStatus,
 } from "./gateway/channels/wechat-login.js";
+import {
+  pollFeishuRegistration,
+  startFeishuRegistration,
+  type FeishuDomain,
+} from "./gateway/channels/feishu-registration.js";
 import { WECHAT_BASE_INFO, wechatHeaders } from "./gateway/channels/wechat-http.js";
 import { assertSafeBaseUrl, UnsafeBaseUrlError } from "./gateway/channels/url-guard.js";
 import { log as daemonLog } from "./log.js";
@@ -42,7 +47,7 @@ import type { FetchLike } from "./gateway/channels/http-types.js";
 
 type AckBody = Omit<ControlAck, "id">;
 
-type GatewayProvider = "telegram" | "wechat";
+type GatewayProvider = "telegram" | "wechat" | "feishu";
 
 interface GatewayProfileSummary {
   id: string;
@@ -51,6 +56,9 @@ interface GatewayProfileSummary {
   label?: string;
   enabled: boolean;
   baseUrl?: string;
+  appId?: string;
+  domain?: "feishu" | "lark";
+  userOpenId?: string;
   allowedSenderIds?: string[];
   allowedChatIds?: string[];
   splitAt?: number;
@@ -81,6 +89,7 @@ interface UpsertGatewayParams {
   };
   settings?: {
     baseUrl?: string;
+    domain?: "feishu" | "lark";
     allowedSenderIds?: string[];
     allowedChatIds?: string[];
     splitAt?: number;
@@ -93,6 +102,9 @@ interface UpsertGatewayResult {
   accountId: string;
   enabled: boolean;
   tokenPreview?: string;
+  appId?: string;
+  domain?: "feishu" | "lark";
+  userOpenId?: string;
   status?: GatewayProfileSummary["status"];
 }
 
@@ -123,6 +135,7 @@ interface GatewayLoginStartParams {
   accountId: string;
   gatewayId?: string;
   baseUrl?: string;
+  domain?: "feishu" | "lark";
 }
 
 interface GatewayLoginStartResult {
@@ -141,6 +154,9 @@ interface GatewayLoginStatusParams {
 interface GatewayLoginStatusResult {
   status: "pending" | "scanned" | "confirmed" | "expired" | "failed";
   baseUrl?: string;
+  appId?: string;
+  domain?: "feishu" | "lark";
+  userOpenId?: string;
   tokenPreview?: string;
 }
 
@@ -179,6 +195,10 @@ export interface GatewayControlContext {
     getBotQrcode: typeof getBotQrcode;
     getQrcodeStatus: typeof getQrcodeStatus;
   };
+  feishuLoginClient?: {
+    startFeishuRegistration: typeof startFeishuRegistration;
+    pollFeishuRegistration: typeof pollFeishuRegistration;
+  };
   /** Override the global fetch — used by `test_gateway` for Telegram getMe. */
   fetchImpl?: FetchLike;
 }
@@ -192,6 +212,8 @@ export function createGatewayControl(ctx: GatewayControlContext) {
   const cfgIO = ctx.configIO ?? { load: loadConfig, save: saveConfig };
   const sessions = ctx.loginSessions ?? new LoginSessionStore();
   const wechatLogin = ctx.wechatLoginClient ?? { getBotQrcode, getQrcodeStatus };
+  const feishuLogin =
+    ctx.feishuLoginClient ?? { startFeishuRegistration, pollFeishuRegistration };
   // W7: validate fetch availability at construction so a missing global is
   // diagnosed at startup, not during the first control frame. Tests inject
   // `ctx.fetchImpl` explicitly and bypass the global lookup entirely.
@@ -252,9 +274,13 @@ export function createGatewayControl(ctx: GatewayControlContext) {
     }
 
     // Provider-specific secret resolution.
-    let botToken: string | undefined;
+    let secretPayload: Record<string, unknown>;
+    let tokenPreviewSource: string | undefined;
+    let feishuAppId: string | undefined;
+    let feishuDomain: "feishu" | "lark" | undefined;
+    let feishuUserOpenId: string | undefined;
     if (params.type === "telegram") {
-      botToken = params.secret?.botToken;
+      const botToken = params.secret?.botToken;
       if (!botToken) {
         // Allow updates that only flip enabled/whitelist — only require a
         // token when none is on disk yet.
@@ -262,7 +288,11 @@ export function createGatewayControl(ctx: GatewayControlContext) {
         if (!existing?.botToken) {
           return badParams("upsert_gateway: telegram requires secret.botToken on first install");
         }
-        botToken = existing.botToken;
+        secretPayload = { botToken: existing.botToken };
+        tokenPreviewSource = existing.botToken;
+      } else {
+        secretPayload = { botToken };
+        tokenPreviewSource = botToken;
       }
     } else if (params.type === "wechat") {
       const loginId = params.loginId;
@@ -294,8 +324,45 @@ export function createGatewayControl(ctx: GatewayControlContext) {
           error: { code: "login_unconfirmed", message: "wechat login session has no bot token yet" },
         };
       }
-      botToken = session.botToken;
+      secretPayload = { botToken: session.botToken };
+      tokenPreviewSource = session.botToken;
       // Bind the session to its eventual gateway id for forensic logging.
+      sessions.update(loginId, { gatewayId: params.id });
+    } else if (params.type === "feishu") {
+      const loginId = params.loginId;
+      if (!loginId) {
+        return badParams("upsert_gateway: feishu requires loginId");
+      }
+      const session = sessions.get(loginId);
+      if (!session) {
+        return {
+          ok: false,
+          error: { code: "login_expired", message: `feishu login session "${loginId}" not found or expired` },
+        };
+      }
+      if (session.provider !== "feishu") {
+        return badParams(`upsert_gateway: login session provider "${session.provider}" != "feishu"`);
+      }
+      if (session.accountId !== params.accountId) {
+        return {
+          ok: false,
+          error: {
+            code: "login_account_mismatch",
+            message: "feishu login session accountId does not match upsert request",
+          },
+        };
+      }
+      if (!session.appId || !session.appSecret) {
+        return {
+          ok: false,
+          error: { code: "login_unconfirmed", message: "feishu login session has no app credentials yet" },
+        };
+      }
+      secretPayload = { appSecret: session.appSecret };
+      tokenPreviewSource = session.appSecret;
+      feishuAppId = session.appId;
+      feishuDomain = session.domain ?? params.settings?.domain ?? "feishu";
+      feishuUserOpenId = session.userOpenId;
       sessions.update(loginId, { gatewayId: params.id });
     } else {
       return badParams(`upsert_gateway: unknown provider "${(params as { type: string }).type}"`);
@@ -314,7 +381,7 @@ export function createGatewayControl(ctx: GatewayControlContext) {
 
     // Persist secret first (so a config write that succeeds is never
     // followed by a missing-secret crash). Atomic rename inside saveSecret.
-    const secretFile = saveGatewaySecret(params.id, { botToken });
+    const secretFile = saveGatewaySecret(params.id, secretPayload);
 
     // Update or insert the third-party gateway profile in config.
     const enabled = params.enabled !== false;
@@ -328,6 +395,9 @@ export function createGatewayControl(ctx: GatewayControlContext) {
       allowedSenderIds: params.settings?.allowedSenderIds,
       allowedChatIds: params.settings?.allowedChatIds,
       splitAt: params.settings?.splitAt,
+      appId: feishuAppId,
+      domain: feishuDomain,
+      userOpenId: feishuUserOpenId,
     });
     cfgIO.save(next);
 
@@ -340,7 +410,12 @@ export function createGatewayControl(ctx: GatewayControlContext) {
         // best-effort
       }
       try {
-        await ctx.gateway.addChannel(buildChannelConfig(params, secretFile));
+        await ctx.gateway.addChannel(
+          buildChannelConfig(params, secretFile, {
+            ...(feishuAppId ? { appId: feishuAppId } : {}),
+            ...(feishuDomain ? { domain: feishuDomain } : {}),
+          }),
+        );
       } catch (addErr) {
         const message = addErr instanceof Error ? addErr.message : String(addErr);
         daemonLog.warn("upsert_gateway.addChannel failed", { id: params.id, error: message });
@@ -380,9 +455,14 @@ export function createGatewayControl(ctx: GatewayControlContext) {
                       allowedSenderIds: prevProfile.allowedSenderIds,
                       allowedChatIds: prevProfile.allowedChatIds,
                       splitAt: prevProfile.splitAt,
+                      domain: prevProfile.domain,
                     },
                   },
                   secretFile,
+                  {
+                    ...(prevProfile.appId ? { appId: prevProfile.appId } : {}),
+                    ...(prevProfile.domain ? { domain: prevProfile.domain } : {}),
+                  },
                 ),
               );
             }
@@ -417,7 +497,10 @@ export function createGatewayControl(ctx: GatewayControlContext) {
       type: params.type,
       accountId: params.accountId,
       enabled,
-      tokenPreview: maskTokenPreview(botToken),
+      tokenPreview: maskTokenPreview(tokenPreviewSource),
+      ...(feishuAppId ? { appId: feishuAppId } : {}),
+      ...(feishuDomain ? { domain: feishuDomain } : {}),
+      ...(feishuUserOpenId ? { userOpenId: feishuUserOpenId } : {}),
       ...(liveStatus ? { status: pickStatus(liveStatus) } : {}),
     };
     daemonLog.info("upsert_gateway applied", {
@@ -527,9 +610,8 @@ export function createGatewayControl(ctx: GatewayControlContext) {
       }
     }
 
-    // WeChat: iLink has no no-side-effect probe today. Fall back to the
-    // adapter's last poll snapshot. `authorized === true` means the secret
-    // is loaded and at least one poll succeeded.
+    // WeChat/Feishu: fall back to the adapter snapshot. `authorized === true`
+    // means the secret is loaded and the provider client started.
     const snap = ctx.gateway.snapshot().channels[profile.id];
     const result: TestGatewayResult = snap
       ? {
@@ -542,7 +624,7 @@ export function createGatewayControl(ctx: GatewayControlContext) {
           },
           ...(snap.lastError ? { error: snap.lastError } : {}),
         }
-      : { id: profile.id, ok: false, error: "wechat channel not running" };
+      : { id: profile.id, ok: false, error: `${profile.type} channel not running` };
     return { ok: true, result };
   }
 
@@ -554,9 +636,7 @@ export function createGatewayControl(ctx: GatewayControlContext) {
     if (!params.accountId || typeof params.accountId !== "string") {
       return badParams("gateway_login_start: accountId is required");
     }
-    if (params.provider !== "wechat") {
-      // Telegram has no qrcode flow; surface a clear error so the dashboard
-      // can fall through to the token form.
+    if (params.provider !== "wechat" && params.provider !== "feishu") {
       return badParams(`gateway_login_start: provider "${params.provider}" does not require login`);
     }
     // W1: SSRF guard — `baseUrl` flows directly into an authenticated fetch.
@@ -566,6 +646,38 @@ export function createGatewayControl(ctx: GatewayControlContext) {
       if (urlErr instanceof UnsafeBaseUrlError) return badParams(urlErr.message);
       throw urlErr;
     }
+    if (params.provider === "feishu") {
+      const domain: FeishuDomain = params.domain === "lark" ? "lark" : "feishu";
+      try {
+        const r = await feishuLogin.startFeishuRegistration({ domain });
+        const loginId = mintLoginId("feishu");
+        const session = sessions.create({
+          loginId,
+          accountId: params.accountId,
+          ...(params.gatewayId ? { gatewayId: params.gatewayId } : {}),
+          provider: "feishu",
+          qrcode: r.deviceCode,
+          qrcodeUrl: r.verificationUriComplete,
+          domain: r.domain,
+        });
+        const result: GatewayLoginStartResult = {
+          loginId,
+          qrcode: r.deviceCode,
+          qrcodeUrl: r.verificationUriComplete,
+          expiresAt: session.expiresAt,
+        };
+        daemonLog.info("gateway_login_start", { provider: "feishu", loginId, accountId: params.accountId });
+        return { ok: true, result };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        daemonLog.warn("gateway_login_start.feishu failed", { error: message });
+        return {
+          ok: false,
+          error: { code: "provider_unreachable", message },
+        };
+      }
+    }
+
     const baseUrl = params.baseUrl ?? DEFAULT_WECHAT_BASE_URL;
     let qrcode: string;
     let qrcodeUrl: string | undefined;
@@ -640,8 +752,56 @@ export function createGatewayControl(ctx: GatewayControlContext) {
       };
       return { ok: true, result };
     }
+    if (params.provider === "feishu") {
+      if (!session.qrcode) {
+        return {
+          ok: false,
+          error: { code: "no_qrcode", message: "login session has no device code to poll" },
+        };
+      }
+      try {
+        const probe = await feishuLogin.pollFeishuRegistration(session.qrcode, {
+          domain: session.domain ?? "feishu",
+        });
+        if (probe.status === "confirmed" && probe.appId && probe.appSecret) {
+          const tokenPreview = maskTokenPreview(probe.appSecret);
+          sessions.update(params.loginId, {
+            appId: probe.appId,
+            appSecret: probe.appSecret,
+            domain: probe.domain,
+            userOpenId: probe.userOpenId,
+            tokenPreview,
+          });
+          const result: GatewayLoginStatusResult = {
+            status: "confirmed",
+            appId: probe.appId,
+            domain: probe.domain,
+            userOpenId: probe.userOpenId,
+            tokenPreview,
+          };
+          return { ok: true, result };
+        }
+        const status =
+          probe.status === "denied"
+            ? "failed"
+            : probe.status === "expired"
+              ? "expired"
+              : probe.status === "failed"
+                ? "failed"
+                : "pending";
+        const result: GatewayLoginStatusResult = { status, domain: probe.domain };
+        return { ok: true, result };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        daemonLog.warn("gateway_login_status.feishu failed", { error: message });
+        return {
+          ok: false,
+          error: { code: "provider_unreachable", message },
+        };
+      }
+    }
+
     if (params.provider !== "wechat") {
-      // Future provider hook — today only WeChat poll path exists.
       return badParams(`gateway_login_status: provider "${params.provider}" not supported`);
     }
     if (!session.qrcode) {
@@ -789,7 +949,7 @@ function badParams(message: string): AckBody {
 }
 
 function isProvider(p: unknown): p is GatewayProvider {
-  return p === "telegram" || p === "wechat";
+  return p === "telegram" || p === "wechat" || p === "feishu";
 }
 
 function validateUpsertParams(p: UpsertGatewayParams): string | null {
@@ -810,6 +970,9 @@ function annotateProfile(
     ...(p.label !== undefined ? { label: p.label } : {}),
     enabled: p.enabled !== false,
     ...(p.baseUrl !== undefined ? { baseUrl: p.baseUrl } : {}),
+    ...(p.appId !== undefined ? { appId: p.appId } : {}),
+    ...(p.domain !== undefined ? { domain: p.domain } : {}),
+    ...(p.userOpenId !== undefined ? { userOpenId: p.userOpenId } : {}),
     ...(p.allowedSenderIds !== undefined ? { allowedSenderIds: p.allowedSenderIds } : {}),
     ...(p.allowedChatIds !== undefined ? { allowedChatIds: p.allowedChatIds } : {}),
     ...(p.splitAt !== undefined ? { splitAt: p.splitAt } : {}),
@@ -857,6 +1020,9 @@ function compactProfile(p: ThirdPartyGatewayProfile): ThirdPartyGatewayProfile {
   if (p.label !== undefined) out.label = p.label;
   if (p.enabled !== undefined) out.enabled = p.enabled;
   if (p.baseUrl !== undefined) out.baseUrl = p.baseUrl;
+  if (p.appId !== undefined) out.appId = p.appId;
+  if (p.domain !== undefined) out.domain = p.domain;
+  if (p.userOpenId !== undefined) out.userOpenId = p.userOpenId;
   if (p.allowedSenderIds !== undefined) out.allowedSenderIds = p.allowedSenderIds;
   if (p.allowedChatIds !== undefined) out.allowedChatIds = p.allowedChatIds;
   if (p.splitAt !== undefined) out.splitAt = p.splitAt;
@@ -868,6 +1034,7 @@ function compactProfile(p: ThirdPartyGatewayProfile): ThirdPartyGatewayProfile {
 function buildChannelConfig(
   params: UpsertGatewayParams,
   secretFile: string,
+  extra: { appId?: string; domain?: "feishu" | "lark" } = {},
 ): GatewayChannelConfig {
   const ch: GatewayChannelConfig = {
     id: params.id,
@@ -878,6 +1045,10 @@ function buildChannelConfig(
   if (params.label !== undefined) ch.label = params.label;
   const s = params.settings ?? {};
   if (s.baseUrl !== undefined) ch.baseUrl = s.baseUrl;
+  if (params.type === "feishu") {
+    if (extra.appId) ch.appId = extra.appId;
+    if (extra.domain) ch.domain = extra.domain;
+  }
   if (s.allowedSenderIds !== undefined) ch.allowedSenderIds = s.allowedSenderIds;
   if (s.allowedChatIds !== undefined) ch.allowedChatIds = s.allowedChatIds;
   if (s.splitAt !== undefined) ch.splitAt = s.splitAt;

--- a/packages/daemon/src/gateway/channels/feishu-registration.ts
+++ b/packages/daemon/src/gateway/channels/feishu-registration.ts
@@ -1,0 +1,155 @@
+/**
+ * Feishu/Lark PersonalAgent app registration helpers.
+ *
+ * Mirrors the flow used by `@larksuite/openclaw-lark-tools`:
+ *   POST /oauth/v1/app/registration action=init
+ *   POST /oauth/v1/app/registration action=begin
+ *   POST /oauth/v1/app/registration action=poll
+ */
+
+import type { FetchLike } from "./http-types.js";
+
+export type FeishuDomain = "feishu" | "lark";
+
+const FEISHU_ACCOUNTS_BASE = "https://accounts.feishu.cn";
+const LARK_ACCOUNTS_BASE = "https://accounts.larksuite.com";
+
+export interface FeishuRegistrationOptions {
+  domain?: FeishuDomain;
+  fetchImpl?: FetchLike;
+}
+
+export interface FeishuRegistrationStart {
+  deviceCode: string;
+  verificationUriComplete: string;
+  verificationUri?: string;
+  expiresIn: number;
+  interval: number;
+  domain: FeishuDomain;
+  raw: Record<string, unknown>;
+}
+
+export interface FeishuRegistrationPoll {
+  status: "pending" | "confirmed" | "expired" | "denied" | "failed";
+  appId?: string;
+  appSecret?: string;
+  userOpenId?: string;
+  domain: FeishuDomain;
+  interval?: number;
+  error?: string;
+  raw: Record<string, unknown>;
+}
+
+function baseForDomain(domain: FeishuDomain): string {
+  return domain === "lark" ? LARK_ACCOUNTS_BASE : FEISHU_ACCOUNTS_BASE;
+}
+
+function fetcher(opts: FeishuRegistrationOptions): FetchLike {
+  return opts.fetchImpl ?? ((globalThis.fetch as unknown) as FetchLike);
+}
+
+async function postRegistration(
+  action: string,
+  params: Record<string, string>,
+  opts: FeishuRegistrationOptions,
+): Promise<Record<string, unknown>> {
+  const domain = opts.domain ?? "feishu";
+  const res = await fetcher(opts)(`${baseForDomain(domain)}/oauth/v1/app/registration`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ action, ...params }).toString(),
+  });
+  const raw = await res.text();
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    throw new Error(`feishu registration ${action}: non-json response`);
+  }
+}
+
+export async function startFeishuRegistration(
+  opts: FeishuRegistrationOptions = {},
+): Promise<FeishuRegistrationStart> {
+  const domain = opts.domain ?? "feishu";
+  const init = await postRegistration("init", {}, { ...opts, domain });
+  const methods = Array.isArray(init.supported_auth_methods)
+    ? init.supported_auth_methods.map(String)
+    : [];
+  if (methods.length > 0 && !methods.includes("client_secret")) {
+    throw new Error("feishu registration: client_secret auth is not supported");
+  }
+  const begin = await postRegistration(
+    "begin",
+    {
+      archetype: "PersonalAgent",
+      auth_method: "client_secret",
+      request_user_info: "open_id",
+    },
+    { ...opts, domain },
+  );
+  const deviceCode = typeof begin.device_code === "string" ? begin.device_code : "";
+  const verificationUriComplete =
+    typeof begin.verification_uri_complete === "string"
+      ? begin.verification_uri_complete
+      : "";
+  if (!deviceCode || !verificationUriComplete) {
+    throw new Error("feishu registration: missing device_code or verification_uri_complete");
+  }
+  return {
+    deviceCode,
+    verificationUriComplete,
+    ...(typeof begin.verification_uri === "string"
+      ? { verificationUri: begin.verification_uri }
+      : {}),
+    expiresIn: typeof begin.expire_in === "number" ? begin.expire_in : 600,
+    interval: typeof begin.interval === "number" ? begin.interval : 5,
+    domain,
+    raw: begin,
+  };
+}
+
+export async function pollFeishuRegistration(
+  deviceCode: string,
+  opts: FeishuRegistrationOptions = {},
+): Promise<FeishuRegistrationPoll> {
+  const domain = opts.domain ?? "feishu";
+  const data = await postRegistration(
+    "poll",
+    { device_code: deviceCode },
+    { ...opts, domain },
+  );
+  const tenantBrand =
+    typeof (data.user_info as Record<string, unknown> | undefined)?.tenant_brand === "string"
+      ? String((data.user_info as Record<string, unknown>).tenant_brand)
+      : "";
+  const resolvedDomain: FeishuDomain = tenantBrand === "lark" ? "lark" : domain;
+  const appId = typeof data.client_id === "string" ? data.client_id : undefined;
+  const appSecret =
+    typeof data.client_secret === "string" ? data.client_secret : undefined;
+  if (appId && appSecret) {
+    const userInfo = data.user_info as Record<string, unknown> | undefined;
+    return {
+      status: "confirmed",
+      appId,
+      appSecret,
+      userOpenId: typeof userInfo?.open_id === "string" ? userInfo.open_id : undefined,
+      domain: resolvedDomain,
+      raw: data,
+    };
+  }
+  const error = typeof data.error === "string" ? data.error : "";
+  if (!error || error === "authorization_pending") {
+    return { status: "pending", domain: resolvedDomain, raw: data };
+  }
+  if (error === "slow_down") {
+    return { status: "pending", domain: resolvedDomain, interval: 10, raw: data };
+  }
+  if (error === "access_denied") {
+    return { status: "denied", domain: resolvedDomain, error, raw: data };
+  }
+  if (error === "expired_token" || error === "invalid_grant") {
+    return { status: "expired", domain: resolvedDomain, error, raw: data };
+  }
+  return { status: "failed", domain: resolvedDomain, error: error || "unknown", raw: data };
+}

--- a/packages/daemon/src/gateway/channels/feishu.ts
+++ b/packages/daemon/src/gateway/channels/feishu.ts
@@ -1,0 +1,327 @@
+import * as Lark from "@larksuiteoapi/node-sdk";
+import type {
+  ChannelAdapter,
+  ChannelSendContext,
+  ChannelSendResult,
+  ChannelStartContext,
+  ChannelStatusSnapshot,
+  ChannelStopContext,
+  GatewayInboundMessage,
+} from "../types.js";
+import { sanitizeUntrustedContent } from "./sanitize.js";
+import { loadGatewaySecret } from "./secret-store.js";
+import { splitText } from "./text-split.js";
+import type { FeishuDomain } from "./feishu-registration.js";
+
+const FEISHU_PROVIDER = "feishu" as const;
+const DEFAULT_SPLIT_AT = 4000;
+
+export interface FeishuChannelOptions {
+  id: string;
+  accountId: string;
+  appId?: string;
+  appSecret?: string;
+  domain?: FeishuDomain;
+  allowedSenderIds?: string[];
+  allowedChatIds?: string[];
+  splitAt?: number;
+  secretFile?: string;
+}
+
+interface FeishuSecret {
+  appSecret?: string;
+  [key: string]: unknown;
+}
+
+interface FeishuEventSender {
+  sender_id?: {
+    open_id?: string;
+    user_id?: string;
+    union_id?: string;
+  };
+  sender_type?: string;
+  tenant_key?: string;
+}
+
+interface FeishuEventMessage {
+  message_id?: string;
+  root_id?: string;
+  parent_id?: string;
+  create_time?: string;
+  chat_id?: string;
+  chat_type?: string;
+  message_type?: string;
+  content?: string;
+  mentions?: Array<{ id?: { open_id?: string; user_id?: string }; name?: string }>;
+}
+
+interface FeishuMessageEvent {
+  sender?: FeishuEventSender;
+  message?: FeishuEventMessage;
+}
+
+function sdkDomain(domain: FeishuDomain | undefined): unknown {
+  const sdk = Lark as unknown as {
+    Domain?: { Feishu?: unknown; Lark?: unknown };
+  };
+  return domain === "lark" ? sdk.Domain?.Lark : sdk.Domain?.Feishu;
+}
+
+function parseTextContent(content: string | undefined): string | null {
+  if (!content) return null;
+  try {
+    const parsed = JSON.parse(content) as { text?: unknown };
+    return typeof parsed.text === "string" ? parsed.text : null;
+  } catch {
+    return content;
+  }
+}
+
+function senderLabel(event: FeishuMessageEvent): string | undefined {
+  const mentions = event.message?.mentions ?? [];
+  const senderOpenId = event.sender?.sender_id?.open_id;
+  const hit = mentions.find((m) => m.id?.open_id && m.id.open_id === senderOpenId);
+  return typeof hit?.name === "string" && hit.name ? hit.name : undefined;
+}
+
+export function createFeishuChannel(opts: FeishuChannelOptions): ChannelAdapter {
+  const splitAt = opts.splitAt && opts.splitAt > 0 ? opts.splitAt : DEFAULT_SPLIT_AT;
+  const allowedSenderIds = new Set((opts.allowedSenderIds ?? []).map(String));
+  const allowedChatIds = new Set((opts.allowedChatIds ?? []).map(String));
+  let appSecret = opts.appSecret;
+  let wsClient: { start(opts: unknown): unknown; close(opts?: unknown): unknown } | null = null;
+  let client: { request(args: unknown): Promise<unknown> } | null = null;
+  let botOpenId: string | undefined;
+  let botName: string | undefined;
+  let liveSetStatus: ((patch: Partial<ChannelStatusSnapshot>) => void) | null = null;
+
+  let statusSnapshot: ChannelStatusSnapshot = {
+    channel: opts.id,
+    accountId: opts.accountId,
+    running: false,
+    connected: false,
+    reconnectAttempts: 0,
+    lastError: null,
+    provider: FEISHU_PROVIDER,
+    authorized: false,
+  };
+
+  function loadSecretIfNeeded(): string | undefined {
+    if (appSecret) return appSecret;
+    const secret = loadGatewaySecret<FeishuSecret>(opts.id, opts.secretFile);
+    if (typeof secret?.appSecret === "string" && secret.appSecret.length > 0) {
+      appSecret = secret.appSecret;
+    }
+    return appSecret;
+  }
+
+  function ensureClient(): { request(args: unknown): Promise<unknown> } {
+    if (client) return client;
+    if (!opts.appId || !loadSecretIfNeeded()) {
+      throw new Error("feishu appId/appSecret not loaded");
+    }
+    const sdk = Lark as unknown as {
+      Client: new (args: Record<string, unknown>) => { request(args: unknown): Promise<unknown> };
+      AppType?: { SelfBuild?: unknown };
+    };
+    client = new sdk.Client({
+      appId: opts.appId,
+      appSecret,
+      appType: sdk.AppType?.SelfBuild,
+      domain: sdkDomain(opts.domain),
+    });
+    return client;
+  }
+
+  function markStatus(
+    patch: Partial<ChannelStatusSnapshot>,
+    setStatus?: (patch: Partial<ChannelStatusSnapshot>) => void,
+  ): void {
+    statusSnapshot = { ...statusSnapshot, ...patch };
+    (setStatus ?? liveSetStatus)?.(patch);
+  }
+
+  async function probe(): Promise<void> {
+    const res = (await ensureClient().request({
+      method: "POST",
+      url: "/open-apis/bot/v1/openclaw_bot/ping",
+      data: { needBotInfo: true },
+    })) as { code?: number; msg?: string; data?: { pingBotInfo?: { botID?: string; botName?: string } } };
+    if (res.code !== 0) {
+      throw new Error(res.msg || `feishu bot ping failed: code=${res.code}`);
+    }
+    botOpenId = res.data?.pingBotInfo?.botID;
+    botName = res.data?.pingBotInfo?.botName;
+  }
+
+  function normalizeMessage(event: FeishuMessageEvent): GatewayInboundMessage | null {
+    const message = event.message;
+    const sender = event.sender;
+    if (!message || !sender) return null;
+    if (message.message_type !== "text") return null;
+    const chatId = message.chat_id;
+    const messageId = message.message_id;
+    const senderOpenId = sender.sender_id?.open_id;
+    if (!chatId || !messageId || !senderOpenId) return null;
+    if (botOpenId && senderOpenId === botOpenId) return null;
+
+    if (allowedChatIds.size > 0 && !allowedChatIds.has(chatId)) return null;
+    if (!allowedSenderIds.has(senderOpenId)) return null;
+
+    const text = parseTextContent(message.content);
+    if (text === null) return null;
+    const chatType = message.chat_type ?? "";
+    const conversationKind: "direct" | "group" =
+      chatType === "p2p" ? "direct" : "group";
+    const conversationId =
+      conversationKind === "direct" ? `feishu:user:${chatId}` : `feishu:chat:${chatId}`;
+    const receivedAt = Number(message.create_time) || Date.now();
+
+    return {
+      id: `feishu:${messageId}`,
+      channel: opts.id,
+      accountId: opts.accountId,
+      conversation: {
+        id: conversationId,
+        kind: conversationKind,
+        threadId: message.root_id || message.parent_id || null,
+      },
+      sender: {
+        id: `feishu:user:${senderOpenId}`,
+        ...(senderLabel(event) ? { name: senderLabel(event) } : {}),
+        kind: "user",
+      },
+      text: sanitizeUntrustedContent(text),
+      raw: event,
+      replyTo: messageId,
+      mentioned: true,
+      receivedAt,
+      trace: { id: `feishu:${messageId}`, streamable: true },
+    };
+  }
+
+  async function start(ctx: ChannelStartContext): Promise<void> {
+    liveSetStatus = ctx.setStatus;
+    try {
+      if (!opts.appId || !loadSecretIfNeeded()) {
+        markStatus({
+          running: false,
+          connected: false,
+          authorized: false,
+          lastError: "feishu appId/appSecret not loaded",
+        }, ctx.setStatus);
+        return;
+      }
+      await probe();
+      const sdk = Lark as unknown as {
+        EventDispatcher: new (args?: Record<string, unknown>) => {
+          register(handlers: Record<string, (data: unknown) => unknown>): void;
+        };
+        WSClient: new (args: Record<string, unknown>) => {
+          start(opts: unknown): unknown;
+          close(opts?: unknown): unknown;
+        };
+        LoggerLevel?: { info?: unknown };
+      };
+      const dispatcher = new sdk.EventDispatcher({});
+      dispatcher.register({
+        "im.message.receive_v1": async (data: unknown) => {
+          const normalized = normalizeMessage(data as FeishuMessageEvent);
+          if (!normalized) return;
+          markStatus({ lastInboundAt: Date.now(), connected: true, authorized: true });
+          await ctx.emit({ message: normalized });
+        },
+      });
+      wsClient = new sdk.WSClient({
+        appId: opts.appId,
+        appSecret,
+        domain: sdkDomain(opts.domain),
+        loggerLevel: sdk.LoggerLevel?.info,
+      });
+      markStatus({
+        running: true,
+        connected: true,
+        authorized: true,
+        lastError: null,
+      }, ctx.setStatus);
+      void wsClient.start({ eventDispatcher: dispatcher });
+      await new Promise<void>((resolve) => {
+        if (ctx.abortSignal.aborted) return resolve();
+        ctx.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      markStatus({
+        running: false,
+        connected: false,
+        authorized: false,
+        lastError: message,
+      }, ctx.setStatus);
+      throw err;
+    } finally {
+      try {
+        wsClient?.close({ force: true });
+      } catch {
+        // best effort
+      }
+      wsClient = null;
+      markStatus({ running: false, connected: false }, ctx.setStatus);
+    }
+  }
+
+  function chatIdFromConversation(conversationId: string): string | null {
+    if (conversationId.startsWith("feishu:user:")) {
+      return conversationId.slice("feishu:user:".length);
+    }
+    if (conversationId.startsWith("feishu:chat:")) {
+      return conversationId.slice("feishu:chat:".length);
+    }
+    return null;
+  }
+
+  async function send(ctx: ChannelSendContext): Promise<ChannelSendResult> {
+    const chatId = chatIdFromConversation(ctx.message.conversationId);
+    if (!chatId) {
+        throw new Error("unsupported feishu conversation id");
+    }
+    const c = ensureClient();
+    let providerMessageId: string | undefined;
+    for (const part of splitText(ctx.message.text, splitAt)) {
+      const res = (await c.request({
+        method: "POST",
+        url: "/open-apis/im/v1/messages",
+        params: { receive_id_type: "chat_id" },
+        data: {
+          receive_id: chatId,
+          msg_type: "text",
+          content: JSON.stringify({ text: part }),
+        },
+      })) as { code?: number; msg?: string; data?: { message_id?: string } };
+      if (res.code !== 0) {
+        throw new Error(res.msg || `feishu send failed: code=${res.code}`);
+      }
+      providerMessageId = res.data?.message_id ?? providerMessageId;
+    }
+    markStatus({ lastSendAt: Date.now() });
+    return { providerMessageId };
+  }
+
+  async function stop(_ctx: ChannelStopContext): Promise<void> {
+    try {
+      wsClient?.close({ force: true });
+    } catch {
+      // best effort
+    }
+    wsClient = null;
+    markStatus({ running: false, connected: false });
+  }
+
+  return {
+    id: opts.id,
+    type: FEISHU_PROVIDER,
+    start,
+    stop,
+    send,
+    status: () => ({ ...statusSnapshot }),
+  };
+}

--- a/packages/daemon/src/gateway/channels/index.ts
+++ b/packages/daemon/src/gateway/channels/index.ts
@@ -6,6 +6,12 @@ export type {
 } from "./botcord.js";
 export { createTelegramChannel, type TelegramChannelOptions } from "./telegram.js";
 export { createWechatChannel, type WechatChannelOptions } from "./wechat.js";
+export { createFeishuChannel, type FeishuChannelOptions } from "./feishu.js";
+export {
+  startFeishuRegistration,
+  pollFeishuRegistration,
+  type FeishuDomain,
+} from "./feishu-registration.js";
 export {
   getBotQrcode,
   getQrcodeStatus,

--- a/packages/daemon/src/gateway/channels/login-session.ts
+++ b/packages/daemon/src/gateway/channels/login-session.ts
@@ -11,7 +11,7 @@
 
 import { randomBytes } from "node:crypto";
 
-export type LoginProvider = "wechat" | "telegram";
+export type LoginProvider = "wechat" | "telegram" | "feishu";
 
 export interface LoginSession {
   loginId: string;
@@ -26,6 +26,14 @@ export interface LoginSession {
   baseUrl?: string;
   /** Stored only after the user confirms the qrcode. Never returned to Hub. */
   botToken?: string;
+  /** Feishu/Lark PersonalAgent app id returned by app registration. */
+  appId?: string;
+  /** Feishu/Lark PersonalAgent app secret returned by app registration. */
+  appSecret?: string;
+  /** Feishu/Lark tenant domain selected during registration. */
+  domain?: "feishu" | "lark";
+  /** Feishu/Lark user open_id returned by app registration. */
+  userOpenId?: string;
   /** Masked preview safe for Hub/dashboard display. */
   tokenPreview?: string;
   /** Unix millis. */
@@ -127,7 +135,7 @@ export function maskTokenPreview(token: string | undefined | null): string {
  * ids and racefully claim someone else's session.
  */
 export function mintLoginId(provider: LoginProvider): string {
-  const prefix = provider === "wechat" ? "wxl" : "tgl";
+  const prefix = provider === "wechat" ? "wxl" : provider === "feishu" ? "fsl" : "tgl";
   const ts = Date.now().toString(36);
   // 32 hex chars = 128 bits of entropy — W5 regression fix from round 2.
   const rand = randomBytes(16).toString("hex");

--- a/packages/daemon/src/gateway/types.ts
+++ b/packages/daemon/src/gateway/types.ts
@@ -209,7 +209,7 @@ export interface ChannelStatusSnapshot {
   lastStopAt?: number;
   lastError?: string | null;
   /** Third-party provider id when this channel is not the built-in BotCord. */
-  provider?: "wechat" | "telegram";
+  provider?: "wechat" | "telegram" | "feishu";
   /** Last time the adapter polled the upstream provider (ms epoch). */
   lastPollAt?: number;
   /** Last time the adapter accepted an inbound message (ms epoch). */

--- a/packages/protocol-core/src/control-frame.ts
+++ b/packages/protocol-core/src/control-frame.ts
@@ -550,7 +550,7 @@ export interface ListRuntimesResult {
 // ---------------------------------------------------------------------------
 
 /** Provider tag used by every third-party gateway frame today. */
-export type GatewayProvider = "telegram" | "wechat";
+export type GatewayProvider = "telegram" | "wechat" | "feishu";
 
 /**
  * One annotated gateway entry returned by `list_gateways`. Mirrors the on-disk
@@ -564,6 +564,9 @@ export interface GatewayProfileSummary {
   label?: string;
   enabled: boolean;
   baseUrl?: string;
+  appId?: string;
+  domain?: "feishu" | "lark";
+  userOpenId?: string;
   allowedSenderIds?: string[];
   allowedChatIds?: string[];
   splitAt?: number;
@@ -613,6 +616,7 @@ export interface UpsertGatewayParams {
   };
   settings?: {
     baseUrl?: string;
+    domain?: "feishu" | "lark";
     allowedSenderIds?: string[];
     allowedChatIds?: string[];
     splitAt?: number;
@@ -666,6 +670,7 @@ export interface GatewayLoginStartParams {
   gatewayId?: string;
   /** WeChat — override the iLink base URL. Defaults to `https://ilinkai.weixin.qq.com`. */
   baseUrl?: string;
+  domain?: "feishu" | "lark";
 }
 
 export interface GatewayLoginStartResult {
@@ -694,6 +699,9 @@ export interface GatewayLoginStatusResult {
   status: "pending" | "scanned" | "confirmed" | "expired" | "failed";
   /** Mirror of the daemon-resolved baseUrl (WeChat only). */
   baseUrl?: string;
+  appId?: string;
+  domain?: "feishu" | "lark";
+  userOpenId?: string;
   /** Masked token preview, e.g. `"abcd...wxyz"`. Only present on `confirmed`. */
   tokenPreview?: string;
 }


### PR DESCRIPTION
## Summary
- Add Feishu/Lark as a third-party gateway provider with scan-to-create PersonalAgent registration.
- Add daemon Feishu registration helpers and a Feishu text channel adapter using the Lark SDK.
- Wire backend BFF routes, DB provider constraint migration, frontend scan UI, and protocol/control-frame types.

## Verification
- `cd packages/daemon && npm run build`
- `cd packages/daemon && npm test -- --run src/__tests__/third-party-gateway.test.ts src/__tests__/gateway-control.test.ts`
- `cd backend && uv run pytest tests/test_app/test_app_gateways.py`
- `cd packages/protocol-core && npm run build`
- `cd frontend && NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build`

## Notes
- Feishu channel is MVP text in/out. File/card/reaction support can be layered on separately.
- Real Feishu scan endpoint was manually smoke-tested by generating a registration QR URL.