### PR TITLE
feat: harden Feishu channel adapter

### DIFF
--- a/packages/daemon/src/gateway/__tests__/feishu-channel.test.ts
+++ b/packages/daemon/src/gateway/__tests__/feishu-channel.test.ts
@@ -1,0 +1,306 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createFeishuChannel } from "../channels/feishu.js";
+import type {
+  ChannelStartContext,
+  GatewayInboundEnvelope,
+  GatewayLogger,
+} from "../types.js";
+
+const larkMock = vi.hoisted(() => ({
+  requests: [] as unknown[],
+  responses: [] as unknown[],
+  handlers: {} as Record<string, (data: unknown) => unknown>,
+  wsStartError: null as Error | null,
+  wsClosed: false,
+}));
+
+vi.mock("@larksuiteoapi/node-sdk", () => ({
+  AppType: { SelfBuild: "SelfBuild" },
+  Domain: { Feishu: "feishu", Lark: "lark" },
+  LoggerLevel: { info: "info" },
+  Client: vi.fn().mockImplementation(function Client() {
+    return {
+    request: vi.fn(async (args: unknown) => {
+      larkMock.requests.push(args);
+      const next = larkMock.responses.shift();
+      if (next instanceof Error) throw next;
+      return next ?? { code: 0, data: {} };
+    }),
+    };
+  }),
+  EventDispatcher: vi.fn().mockImplementation(function EventDispatcher() {
+    return {
+      register: vi.fn((handlers: Record<string, (data: unknown) => unknown>) => {
+        Object.assign(larkMock.handlers, handlers);
+      }),
+    };
+  }),
+  WSClient: vi.fn().mockImplementation(function WSClient() {
+    return {
+      start: vi.fn(() => {
+      if (larkMock.wsStartError) return Promise.reject(larkMock.wsStartError);
+      return Promise.resolve();
+      }),
+      close: vi.fn(() => {
+        larkMock.wsClosed = true;
+      }),
+    };
+  }),
+}));
+
+const SILENT_LOG: GatewayLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+const stubConfig = {
+  channels: [],
+  defaultRoute: { runtime: "claude-code", cwd: "/tmp" },
+};
+
+function makeStartCtx(abort: AbortController): {
+  ctx: ChannelStartContext;
+  envelopes: GatewayInboundEnvelope[];
+  statuses: Array<Record<string, unknown>>;
+} {
+  const envelopes: GatewayInboundEnvelope[] = [];
+  const statuses: Array<Record<string, unknown>> = [];
+  return {
+    envelopes,
+    statuses,
+    ctx: {
+      config: stubConfig,
+      accountId: "ag_self",
+      abortSignal: abort.signal,
+      log: SILENT_LOG,
+      emit: async (env) => {
+        envelopes.push(env);
+      },
+      setStatus: (patch) => {
+        statuses.push({ ...patch });
+      },
+    },
+  };
+}
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(tmpdir(), "feishu-channel-"));
+  larkMock.requests = [];
+  larkMock.responses = [];
+  larkMock.handlers = {};
+  larkMock.wsStartError = null;
+  larkMock.wsClosed = false;
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("createFeishuChannel", () => {
+  it("normalizes non-text events and deduplicates repeated message ids", async () => {
+    larkMock.responses.push({
+      code: 0,
+      data: { pingBotInfo: { botID: "ou_bot", botName: "Bot" } },
+    });
+    const adapter = createFeishuChannel({
+      id: "gw_fs",
+      accountId: "ag_self",
+      appId: "cli_a",
+      appSecret: "sec",
+      allowedSenderIds: ["ou_alice"],
+      allowedChatIds: ["oc_chat"],
+      stateFile: path.join(tmp, "state.json"),
+      stateDebounceMs: 0,
+    });
+    const abort = new AbortController();
+    const { ctx, envelopes } = makeStartCtx(abort);
+    const started = adapter.start(ctx);
+    await vi.waitUntil(() => typeof larkMock.handlers["im.message.receive_v1"] === "function");
+
+    const event = {
+      sender: { sender_id: { open_id: "ou_alice" } },
+      message: {
+        message_id: "om_img_1",
+        chat_id: "oc_chat",
+        chat_type: "group",
+        message_type: "image",
+        content: JSON.stringify({ image_key: "img_v2_x" }),
+      },
+    };
+    await larkMock.handlers["im.message.receive_v1"]!(event);
+    await larkMock.handlers["im.message.receive_v1"]!(event);
+    abort.abort();
+    await started;
+
+    expect(envelopes).toHaveLength(1);
+    expect(envelopes[0]!.message.text).toBe("[image: img_v2_x]");
+    expect(envelopes[0]!.message.conversation.id).toBe("feishu:chat:oc_chat");
+  });
+
+  it("sends text replies through Feishu reply API with thread mode", async () => {
+    larkMock.responses.push({ code: 0, data: { message_id: "om_reply_1" } });
+    const adapter = createFeishuChannel({
+      id: "gw_fs",
+      accountId: "ag_self",
+      appId: "cli_a",
+      appSecret: "sec",
+    });
+
+    const result = await adapter.send({
+      log: SILENT_LOG,
+      message: {
+        channel: "gw_fs",
+        accountId: "ag_self",
+        conversationId: "feishu:chat:oc_chat",
+        threadId: "om_root",
+        replyTo: "om_parent",
+        text: "hello",
+      },
+    });
+
+    expect(result.providerMessageId).toBe("om_reply_1");
+    expect(larkMock.requests).toHaveLength(1);
+    const req = larkMock.requests[0] as { url: string; data: Record<string, unknown> };
+    expect(req.url).toBe("/open-apis/im/v1/messages/om_parent/reply");
+    expect(req.data.reply_in_thread).toBe(true);
+    expect(req.data.msg_type).toBe("text");
+  });
+
+  it("uploads image attachments and sends them as Feishu image replies", async () => {
+    larkMock.responses.push(
+      { code: 0, data: { image_key: "img_v2_uploaded" } },
+      { code: 0, data: { message_id: "om_image_reply" } },
+    );
+    const adapter = createFeishuChannel({
+      id: "gw_fs",
+      accountId: "ag_self",
+      appId: "cli_a",
+      appSecret: "sec",
+    });
+
+    const result = await adapter.send({
+      log: SILENT_LOG,
+      message: {
+        channel: "gw_fs",
+        accountId: "ag_self",
+        conversationId: "feishu:chat:oc_chat",
+        text: "",
+        replyTo: "om_parent",
+        attachments: [
+          {
+            data: new Uint8Array([1, 2, 3]),
+            filename: "shot.png",
+            contentType: "image/png",
+          },
+        ],
+      },
+    });
+
+    expect(result.providerMessageId).toBe("om_image_reply");
+    expect(larkMock.requests).toHaveLength(2);
+    const upload = larkMock.requests[0] as { url: string; data: Record<string, unknown> };
+    expect(upload.url).toBe("/open-apis/im/v1/images");
+    expect(upload.data.image_type).toBe("message");
+    const send = larkMock.requests[1] as { url: string; data: Record<string, unknown> };
+    expect(send.url).toBe("/open-apis/im/v1/messages/om_parent/reply");
+    expect(send.data.msg_type).toBe("image");
+    expect(JSON.parse(send.data.content as string)).toEqual({ image_key: "img_v2_uploaded" });
+  });
+
+  it("uploads file attachments and sends them as Feishu file messages", async () => {
+    larkMock.responses.push(
+      { code: 0, data: { file_key: "file_v2_uploaded" } },
+      { code: 0, data: { message_id: "om_file_msg" } },
+    );
+    const adapter = createFeishuChannel({
+      id: "gw_fs",
+      accountId: "ag_self",
+      appId: "cli_a",
+      appSecret: "sec",
+    });
+
+    const result = await adapter.send({
+      log: SILENT_LOG,
+      message: {
+        channel: "gw_fs",
+        accountId: "ag_self",
+        conversationId: "feishu:chat:oc_chat",
+        text: "",
+        attachments: [
+          {
+            data: new Uint8Array([4, 5, 6]),
+            filename: "report.pdf",
+            contentType: "application/pdf",
+          },
+        ],
+      },
+    });
+
+    expect(result.providerMessageId).toBe("om_file_msg");
+    expect(larkMock.requests).toHaveLength(2);
+    const upload = larkMock.requests[0] as { url: string; data: Record<string, unknown> };
+    expect(upload.url).toBe("/open-apis/im/v1/files");
+    expect(upload.data.file_type).toBe("pdf");
+    expect(upload.data.file_name).toBe("report.pdf");
+    const send = larkMock.requests[1] as { url: string; data: Record<string, unknown> };
+    expect(send.url).toBe("/open-apis/im/v1/messages");
+    expect(send.data.msg_type).toBe("file");
+    expect(JSON.parse(send.data.content as string)).toEqual({ file_key: "file_v2_uploaded" });
+  });
+
+  it("exposes typing as a safe no-op because Feishu has no bot typing API", async () => {
+    const debug = vi.fn();
+    const adapter = createFeishuChannel({
+      id: "gw_fs",
+      accountId: "ag_self",
+      appId: "cli_a",
+      appSecret: "sec",
+    });
+
+    await adapter.typing?.({
+      traceId: "feishu:om_1",
+      accountId: "ag_self",
+      conversationId: "feishu:chat:oc_chat",
+      log: { ...SILENT_LOG, debug },
+    });
+
+    expect(larkMock.requests).toHaveLength(0);
+    expect(debug).toHaveBeenCalledWith(
+      "feishu typing ignored: no native bot typing API",
+      expect.objectContaining({ channel: "gw_fs" }),
+    );
+  });
+
+  it("surfaces websocket start failures in channel status", async () => {
+    larkMock.responses.push({
+      code: 0,
+      data: { pingBotInfo: { botID: "ou_bot", botName: "Bot" } },
+    });
+    larkMock.wsStartError = new Error("ws denied");
+    const adapter = createFeishuChannel({
+      id: "gw_fs",
+      accountId: "ag_self",
+      appId: "cli_a",
+      appSecret: "sec",
+      allowedSenderIds: ["ou_alice"],
+      stateFile: path.join(tmp, "state.json"),
+      stateDebounceMs: 0,
+    });
+    const abort = new AbortController();
+    const { ctx, statuses } = makeStartCtx(abort);
+    const started = adapter.start(ctx);
+    await vi.waitUntil(() => statuses.some((s) => s.lastError === "ws denied"));
+    abort.abort();
+    await started;
+
+    expect(adapter.status()?.lastError).toBe("ws denied");
+    expect(adapter.status()?.authorized).toBe(false);
+  });
+});

--- a/packages/daemon/src/gateway/channels/feishu.ts
+++ b/packages/daemon/src/gateway/channels/feishu.ts
@@ -1,4 +1,6 @@
 import * as Lark from "@larksuiteoapi/node-sdk";
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import type {
   ChannelAdapter,
   ChannelSendContext,
@@ -6,15 +8,19 @@ import type {
   ChannelStartContext,
   ChannelStatusSnapshot,
   ChannelStopContext,
+  ChannelTypingContext,
+  GatewayOutboundAttachment,
   GatewayInboundMessage,
 } from "../types.js";
 import { sanitizeUntrustedContent } from "./sanitize.js";
 import { loadGatewaySecret } from "./secret-store.js";
+import { GatewayStateStore } from "./state-store.js";
 import { splitText } from "./text-split.js";
 import type { FeishuDomain } from "./feishu-registration.js";
 
 const FEISHU_PROVIDER = "feishu" as const;
 const DEFAULT_SPLIT_AT = 4000;
+const MAX_SEEN_MESSAGES = 2048;
 
 export interface FeishuChannelOptions {
   id: string;
@@ -26,6 +32,8 @@ export interface FeishuChannelOptions {
   allowedChatIds?: string[];
   splitAt?: number;
   secretFile?: string;
+  stateFile?: string;
+  stateDebounceMs?: number;
 }
 
 interface FeishuSecret {
@@ -60,6 +68,19 @@ interface FeishuMessageEvent {
   message?: FeishuEventMessage;
 }
 
+interface FeishuProviderState {
+  seenMessageIds?: Record<string, number>;
+}
+
+interface FeishuApiResponse {
+  code?: number;
+  msg?: string;
+  data?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+type FeishuClient = { request(args: unknown): Promise<unknown> };
+
 function sdkDomain(domain: FeishuDomain | undefined): unknown {
   const sdk = Lark as unknown as {
     Domain?: { Feishu?: unknown; Lark?: unknown };
@@ -67,14 +88,35 @@ function sdkDomain(domain: FeishuDomain | undefined): unknown {
   return domain === "lark" ? sdk.Domain?.Lark : sdk.Domain?.Feishu;
 }
 
-function parseTextContent(content: string | undefined): string | null {
+function parseMessageContent(content: string | undefined): Record<string, unknown> | null {
   if (!content) return null;
   try {
-    const parsed = JSON.parse(content) as { text?: unknown };
-    return typeof parsed.text === "string" ? parsed.text : null;
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    return parsed && typeof parsed === "object" ? parsed : null;
   } catch {
-    return content;
+    return { text: content };
   }
+}
+
+function parseInboundText(message: FeishuEventMessage): string | null {
+  const parsed = parseMessageContent(message.content);
+  if (!parsed) return null;
+  if (typeof parsed.text === "string") return parsed.text;
+  if (message.message_type === "image" && typeof parsed.image_key === "string") {
+    return `[image: ${parsed.image_key}]`;
+  }
+  if (message.message_type === "file" && typeof parsed.file_key === "string") {
+    const name = typeof parsed.file_name === "string" ? ` ${parsed.file_name}` : "";
+    return `[file${name}: ${parsed.file_key}]`;
+  }
+  if (message.message_type === "audio" && typeof parsed.file_key === "string") {
+    return `[audio: ${parsed.file_key}]`;
+  }
+  if (message.message_type === "media" && typeof parsed.file_key === "string") {
+    return `[video: ${parsed.file_key}]`;
+  }
+  if (message.message_type) return `[${message.message_type} message]`;
+  return null;
 }
 
 function senderLabel(event: FeishuMessageEvent): string | undefined {
@@ -90,7 +132,8 @@ export function createFeishuChannel(opts: FeishuChannelOptions): ChannelAdapter 
   const allowedChatIds = new Set((opts.allowedChatIds ?? []).map(String));
   let appSecret = opts.appSecret;
   let wsClient: { start(opts: unknown): unknown; close(opts?: unknown): unknown } | null = null;
-  let client: { request(args: unknown): Promise<unknown> } | null = null;
+  let client: FeishuClient | null = null;
+  let stateStore: GatewayStateStore | null = null;
   let botOpenId: string | undefined;
   let botName: string | undefined;
   let liveSetStatus: ((patch: Partial<ChannelStatusSnapshot>) => void) | null = null;
@@ -106,6 +149,38 @@ export function createFeishuChannel(opts: FeishuChannelOptions): ChannelAdapter 
     authorized: false,
   };
 
+  function ensureState(): GatewayStateStore {
+    if (!stateStore) {
+      stateStore = new GatewayStateStore(opts.id, {
+        override: opts.stateFile,
+        debounceMs: opts.stateDebounceMs,
+      });
+    }
+    return stateStore;
+  }
+
+  function readProviderState(): FeishuProviderState {
+    return (ensureState().getProviderState() ?? {}) as FeishuProviderState;
+  }
+
+  function hasSeenMessage(messageId: string): boolean {
+    const seen = readProviderState().seenMessageIds ?? {};
+    return Object.prototype.hasOwnProperty.call(seen, messageId);
+  }
+
+  function rememberMessage(messageId: string): void {
+    const providerState = readProviderState();
+    const seen = { ...(providerState.seenMessageIds ?? {}), [messageId]: Date.now() };
+    const entries = Object.entries(seen).sort((a, b) => a[1] - b[1]);
+    while (entries.length > MAX_SEEN_MESSAGES) entries.shift();
+    ensureState().update({
+      providerState: {
+        ...providerState,
+        seenMessageIds: Object.fromEntries(entries),
+      },
+    });
+  }
+
   function loadSecretIfNeeded(): string | undefined {
     if (appSecret) return appSecret;
     const secret = loadGatewaySecret<FeishuSecret>(opts.id, opts.secretFile);
@@ -115,7 +190,7 @@ export function createFeishuChannel(opts: FeishuChannelOptions): ChannelAdapter 
     return appSecret;
   }
 
-  function ensureClient(): { request(args: unknown): Promise<unknown> } {
+  function ensureClient(): FeishuClient {
     if (client) return client;
     if (!opts.appId || !loadSecretIfNeeded()) {
       throw new Error("feishu appId/appSecret not loaded");
@@ -158,18 +233,19 @@ export function createFeishuChannel(opts: FeishuChannelOptions): ChannelAdapter 
     const message = event.message;
     const sender = event.sender;
     if (!message || !sender) return null;
-    if (message.message_type !== "text") return null;
     const chatId = message.chat_id;
     const messageId = message.message_id;
     const senderOpenId = sender.sender_id?.open_id;
     if (!chatId || !messageId || !senderOpenId) return null;
     if (botOpenId && senderOpenId === botOpenId) return null;
+    if (hasSeenMessage(messageId)) return null;
 
     if (allowedChatIds.size > 0 && !allowedChatIds.has(chatId)) return null;
     if (!allowedSenderIds.has(senderOpenId)) return null;
 
-    const text = parseTextContent(message.content);
+    const text = parseInboundText(message);
     if (text === null) return null;
+    rememberMessage(messageId);
     const chatType = message.chat_type ?? "";
     const conversationKind: "direct" | "group" =
       chatType === "p2p" ? "direct" : "group";
@@ -244,7 +320,17 @@ export function createFeishuChannel(opts: FeishuChannelOptions): ChannelAdapter 
         authorized: true,
         lastError: null,
       }, ctx.setStatus);
-      void wsClient.start({ eventDispatcher: dispatcher });
+      Promise.resolve(wsClient.start({ eventDispatcher: dispatcher })).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        markStatus({
+          running: false,
+          connected: false,
+          authorized: false,
+          lastError: message,
+          reconnectAttempts: (statusSnapshot.reconnectAttempts ?? 0) + 1,
+        });
+        ctx.log.warn("feishu ws client failed", { err: message });
+      });
       await new Promise<void>((resolve) => {
         if (ctx.abortSignal.aborted) return resolve();
         ctx.abortSignal.addEventListener("abort", () => resolve(), { once: true });
@@ -266,6 +352,13 @@ export function createFeishuChannel(opts: FeishuChannelOptions): ChannelAdapter 
       }
       wsClient = null;
       markStatus({ running: false, connected: false }, ctx.setStatus);
+      try {
+        stateStore?.flush();
+      } catch (err) {
+        ctx.log.warn("feishu state flush failed", {
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
   }
 
@@ -279,31 +372,159 @@ export function createFeishuChannel(opts: FeishuChannelOptions): ChannelAdapter 
     return null;
   }
 
+  async function callFeishu(args: unknown): Promise<FeishuApiResponse> {
+    const res = (await ensureClient().request(args)) as FeishuApiResponse;
+    if (res.code !== undefined && res.code !== 0) {
+      throw new Error(res.msg || `feishu api failed: code=${res.code}`);
+    }
+    return res;
+  }
+
+  function resultMessageId(res: FeishuApiResponse): string | undefined {
+    return (
+      (typeof res.data?.message_id === "string" ? res.data.message_id : undefined) ??
+      (typeof res.message_id === "string" ? res.message_id : undefined)
+    );
+  }
+
+  function resultResourceKey(res: FeishuApiResponse, key: "image_key" | "file_key"): string {
+    const direct = res[key];
+    if (typeof direct === "string") return direct;
+    const nested = res.data?.[key];
+    if (typeof nested === "string") return nested;
+    throw new Error(`feishu upload failed: ${key} missing`);
+  }
+
+  function attachmentBytes(attachment: GatewayOutboundAttachment): Buffer {
+    if (attachment.data) return Buffer.from(attachment.data);
+    if (attachment.filePath) return readFileSync(attachment.filePath);
+    throw new Error("feishu attachment requires filePath or data");
+  }
+
+  function fileNameForAttachment(attachment: GatewayOutboundAttachment): string {
+    if (attachment.filename) return attachment.filename;
+    if (attachment.filePath) return path.basename(attachment.filePath);
+    return "attachment";
+  }
+
+  function isImageAttachment(attachment: GatewayOutboundAttachment): boolean {
+    if (attachment.kind === "image") return true;
+    if (attachment.contentType?.startsWith("image/")) return true;
+    return /\.(png|jpe?g|gif|webp|bmp|tiff?|ico)$/i.test(fileNameForAttachment(attachment));
+  }
+
+  function feishuFileType(attachment: GatewayOutboundAttachment): string {
+    if (attachment.kind === "video") return "mp4";
+    const name = fileNameForAttachment(attachment).toLowerCase();
+    const contentType = attachment.contentType?.toLowerCase() ?? "";
+    if (contentType.includes("pdf") || name.endsWith(".pdf")) return "pdf";
+    if (contentType.includes("word") || /\.(doc|docx)$/i.test(name)) return "doc";
+    if (contentType.includes("spreadsheet") || /\.(xls|xlsx)$/i.test(name)) return "xls";
+    if (contentType.includes("presentation") || /\.(ppt|pptx)$/i.test(name)) return "ppt";
+    if (contentType.includes("audio/ogg") || name.endsWith(".opus")) return "opus";
+    if (contentType.includes("video/mp4") || name.endsWith(".mp4")) return "mp4";
+    return "stream";
+  }
+
+  async function uploadAttachment(attachment: GatewayOutboundAttachment): Promise<{
+    msgType: "image" | "file" | "audio" | "media";
+    content: Record<string, unknown>;
+  }> {
+    const bytes = attachmentBytes(attachment);
+    if (isImageAttachment(attachment)) {
+      const res = await callFeishu({
+        method: "POST",
+        url: "/open-apis/im/v1/images",
+        data: { image_type: "message", image: bytes },
+        headers: { "Content-Type": "multipart/form-data" },
+      });
+      return { msgType: "image", content: { image_key: resultResourceKey(res, "image_key") } };
+    }
+    const fileType = feishuFileType(attachment);
+    const res = await callFeishu({
+      method: "POST",
+      url: "/open-apis/im/v1/files",
+      data: {
+        file_type: fileType,
+        file_name: fileNameForAttachment(attachment),
+        file: bytes,
+      },
+      headers: { "Content-Type": "multipart/form-data" },
+    });
+    const fileKey = resultResourceKey(res, "file_key");
+    if (fileType === "opus") return { msgType: "audio", content: { file_key: fileKey } };
+    if (fileType === "mp4") return { msgType: "media", content: { file_key: fileKey } };
+    return { msgType: "file", content: { file_key: fileKey } };
+  }
+
+  async function sendPayload(args: {
+    chatId: string;
+    msgType: string;
+    content: Record<string, unknown>;
+    replyTo?: string | null;
+    replyInThread?: boolean;
+  }): Promise<string | undefined> {
+    const data: Record<string, unknown> = {
+      msg_type: args.msgType,
+      content: JSON.stringify(args.content),
+    };
+    if (args.replyTo) {
+      data.reply_in_thread = args.replyInThread ?? false;
+      const res = await callFeishu({
+        method: "POST",
+        url: `/open-apis/im/v1/messages/${encodeURIComponent(args.replyTo)}/reply`,
+        data,
+      });
+      return resultMessageId(res);
+    }
+    const res = await callFeishu({
+      method: "POST",
+      url: "/open-apis/im/v1/messages",
+      params: { receive_id_type: "chat_id" },
+      data: {
+        ...data,
+        receive_id: args.chatId,
+      },
+    });
+    return resultMessageId(res);
+  }
+
   async function send(ctx: ChannelSendContext): Promise<ChannelSendResult> {
     const chatId = chatIdFromConversation(ctx.message.conversationId);
     if (!chatId) {
-        throw new Error("unsupported feishu conversation id");
+      throw new Error("unsupported feishu conversation id");
     }
-    const c = ensureClient();
     let providerMessageId: string | undefined;
-    for (const part of splitText(ctx.message.text, splitAt)) {
-      const res = (await c.request({
-        method: "POST",
-        url: "/open-apis/im/v1/messages",
-        params: { receive_id_type: "chat_id" },
-        data: {
-          receive_id: chatId,
-          msg_type: "text",
-          content: JSON.stringify({ text: part }),
-        },
-      })) as { code?: number; msg?: string; data?: { message_id?: string } };
-      if (res.code !== 0) {
-        throw new Error(res.msg || `feishu send failed: code=${res.code}`);
-      }
-      providerMessageId = res.data?.message_id ?? providerMessageId;
+    const replyTo = ctx.message.replyTo ?? ctx.message.threadId ?? null;
+    const textParts = ctx.message.text.length > 0 ? splitText(ctx.message.text, splitAt) : [];
+    for (const part of textParts) {
+      providerMessageId = await sendPayload({
+        chatId,
+        msgType: "text",
+        content: { text: part },
+        replyTo,
+        replyInThread: Boolean(ctx.message.threadId),
+      }) ?? providerMessageId;
+    }
+    for (const attachment of ctx.message.attachments ?? []) {
+      const uploaded = await uploadAttachment(attachment);
+      providerMessageId = await sendPayload({
+        chatId,
+        msgType: uploaded.msgType,
+        content: uploaded.content,
+        replyTo,
+        replyInThread: Boolean(ctx.message.threadId),
+      }) ?? providerMessageId;
     }
     markStatus({ lastSendAt: Date.now() });
     return { providerMessageId };
+  }
+
+  async function typing(ctx: ChannelTypingContext): Promise<void> {
+    ctx.log.debug("feishu typing ignored: no native bot typing API", {
+      channel: opts.id,
+      conversationId: ctx.conversationId,
+    });
   }
 
   async function stop(_ctx: ChannelStopContext): Promise<void> {
@@ -313,6 +534,11 @@ export function createFeishuChannel(opts: FeishuChannelOptions): ChannelAdapter 
       // best effort
     }
     wsClient = null;
+    try {
+      stateStore?.close();
+    } catch {
+      // best effort
+    }
     markStatus({ running: false, connected: false });
   }
 
@@ -322,6 +548,7 @@ export function createFeishuChannel(opts: FeishuChannelOptions): ChannelAdapter 
     start,
     stop,
     send,
+    typing,
     status: () => ({ ...statusSnapshot }),
   };
 }


### PR DESCRIPTION
## Summary
- add Feishu adapter message dedup state and non-text inbound normalization
- support Feishu reply/thread sends plus image/file attachment uploads
- surface websocket startup failures in status and add a safe typing no-op
- add focused Feishu channel adapter tests

## Tests
- cd packages/daemon && npm run build
- cd packages/daemon && npm test -- --run src/gateway/__tests__/feishu-channel.test.ts src/__tests__/third-party-gateway.test.ts src/__tests__/gateway-control.test.ts