### PR TITLE
fix: show all message conversations

### DIFF
--- a/frontend/src/components/dashboard/sidebar/MessagesGroupingSidebar.tsx
+++ b/frontend/src/components/dashboard/sidebar/MessagesGroupingSidebar.tsx
@@ -16,7 +16,7 @@ interface FilterRow {
 }
 
 const SELF_ROWS: FilterRow[] = [
-  { key: "self-all", label: "全部私聊", icon: Inbox },
+  { key: "self-all", label: "全部", icon: Inbox },
   { key: "self-my-bot", label: "和我自己的 Bot", icon: Bot },
   { key: "self-third-bot", label: "和别人的 Bot", icon: Bot },
   { key: "self-human", label: "和真人", icon: User },
@@ -24,7 +24,7 @@ const SELF_ROWS: FilterRow[] = [
 ];
 
 const BOTS_ROWS: FilterRow[] = [
-  { key: "bots-all", label: "全部私聊", icon: Inbox },
+  { key: "bots-all", label: "全部", icon: Inbox },
   { key: "bots-bot-bot", label: "Bot 和其他 Bot", icon: Bot },
   { key: "bots-bot-human", label: "Bot 和真人", icon: UsersRound },
   { key: "bots-group", label: "Bot 加入的群", icon: Users },

--- a/frontend/src/lib/messages-merge.test.ts
+++ b/frontend/src/lib/messages-merge.test.ts
@@ -82,7 +82,7 @@ describe("messages merge filters", () => {
     ).toEqual([ownRoom.room_id]);
   });
 
-  it("keeps non-DM rooms out of private-chat buckets even when they have two members", () => {
+  it("keeps non-DM rooms out of private-chat child buckets but includes them in all buckets", () => {
     const ownGroup = makeRoom({
       room_id: "rm_small_room",
       name: "Small room",
@@ -98,20 +98,24 @@ describe("messages merge filters", () => {
     const rooms = [ownGroup, botGroup];
     const ownedAgentIds = new Set(["ag_bot"]);
 
-    expect(applyMessagesFilter(rooms, "self-all", ownedAgentIds)).toEqual([]);
+    expect(applyMessagesFilter(rooms, "self-all", ownedAgentIds).map((room) => room.room_id)).toEqual([
+      "rm_small_room",
+    ]);
     expect(applyMessagesFilter(rooms, "self-my-bot", ownedAgentIds)).toEqual([]);
     expect(applyMessagesFilter(rooms, "self-group", ownedAgentIds).map((room) => room.room_id)).toEqual([
       "rm_small_room",
     ]);
-    expect(applyMessagesFilter(rooms, "bots-all", ownedAgentIds)).toEqual([]);
+    expect(applyMessagesFilter(rooms, "bots-all", ownedAgentIds).map((room) => room.room_id)).toEqual([
+      "rm_bot_small_room",
+    ]);
     expect(applyMessagesFilter(rooms, "bots-bot-bot", ownedAgentIds)).toEqual([]);
     expect(applyMessagesFilter(rooms, "bots-group", ownedAgentIds).map((room) => room.room_id)).toEqual([
       "rm_bot_small_room",
     ]);
     expect(countMessagesByFilter(rooms, ownedAgentIds)).toMatchObject({
-      "self-all": 0,
+      "self-all": 1,
       "self-group": 1,
-      "bots-all": 0,
+      "bots-all": 1,
       "bots-group": 1,
     });
   });

--- a/frontend/src/lib/messages-merge.ts
+++ b/frontend/src/lib/messages-merge.ts
@@ -74,7 +74,7 @@ export function mergeOwnerVisibleRooms({ ownedAgentRooms, ownRooms }: MergeOpts)
 /**
  * Messages filter taxonomy. Two parent buckets — "self" (I am the participant)
  * and "bots" (one of my owned bots is the participant; I observe). Each parent
- * has an `*-all` private-chat aggregate that's the default leaf inside it.
+ * has an `*-all` aggregate that's the default leaf inside it.
  *
  * Important: this is a pure **filter** over a single unified data set —
  * NOT a role-switch. The owner identity never changes; whether a conversation
@@ -162,10 +162,10 @@ export function applyMessagesFilter(
   ownedAgentIds: Set<string>,
 ): import("@/lib/types").DashboardRoom[] {
   if (filter === "self-all") {
-    return rooms.filter((r) => !r._originAgent && isPrivateMessageRoom(r));
+    return rooms.filter((r) => !r._originAgent);
   }
   if (filter === "bots-all") {
-    return rooms.filter((r) => !!r._originAgent && isPrivateMessageRoom(r));
+    return rooms.filter((r) => !!r._originAgent);
   }
   return rooms.filter((r) => classifyMessagesRoom(r, ownedAgentIds) === filter);
 }
@@ -189,8 +189,8 @@ export function countMessagesByFilter(
   for (const room of rooms) {
     const key = classifyMessagesRoom(room, ownedAgentIds);
     counts[key] += 1;
-    if (key.startsWith("self-") && key !== "self-group") counts["self-all"] += 1;
-    else if (key.startsWith("bots-") && key !== "bots-group") counts["bots-all"] += 1;
+    if (key.startsWith("self-")) counts["self-all"] += 1;
+    else if (key.startsWith("bots-")) counts["bots-all"] += 1;
   }
   return counts;
 }

--- a/frontend/src/store/dashboard-shared.test.ts
+++ b/frontend/src/store/dashboard-shared.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { DashboardOverview, HumanRoomSummary, PublicRoom } from "@/lib/types";
+import type { DashboardOverview, DashboardRoom, HumanRoomSummary, PublicRoom } from "@/lib/types";
 import {
   buildVisibleMessageRooms,
   humanRoomToDashboardRoom,
@@ -131,6 +131,61 @@ describe("mergeDashboardRoomsWithHumanRooms", () => {
     expect(room.peer_type).toBe("human");
     expect(applyMessagesFilter([room], "self-human", new Set()).map((r) => r.room_id)).toEqual([
       "rm_dm_hu_1_hu_2",
+    ]);
+  });
+});
+
+describe("applyMessagesFilter", () => {
+  function makeDashboardRoom(overrides: Partial<DashboardRoom>): DashboardRoom {
+    return {
+      room_id: "rm_dm_hu_1_ag_1",
+      name: "Room",
+      description: "",
+      owner_id: "hu_1",
+      visibility: "private",
+      member_count: 2,
+      my_role: "member",
+      rule: null,
+      has_unread: false,
+      last_message_preview: null,
+      last_message_at: null,
+      last_sender_name: null,
+      ...overrides,
+    };
+  }
+
+  it("shows all self conversations, including groups, in the self-all filter", () => {
+    const selfDm = makeDashboardRoom({ room_id: "rm_dm_hu_1_ag_1" });
+    const selfGroup = makeDashboardRoom({ room_id: "rm_group_self", member_count: 3 });
+    const observedBotGroup = makeDashboardRoom({
+      room_id: "rm_group_bot",
+      member_count: 3,
+      _originAgent: { agent_id: "ag_owned", display_name: "Owned Bot" },
+    });
+
+    expect(applyMessagesFilter([selfDm, selfGroup, observedBotGroup], "self-all", new Set()).map((r) => r.room_id)).toEqual([
+      "rm_dm_hu_1_ag_1",
+      "rm_group_self",
+    ]);
+  });
+
+  it("shows all observed bot conversations, including groups, in the bots-all filter", () => {
+    const selfGroup = makeDashboardRoom({ room_id: "rm_group_self", member_count: 3 });
+    const observedBotDm = makeDashboardRoom({
+      room_id: "rm_dm_ag_owned_ag_2",
+      owner_id: "ag_owned",
+      _originAgent: { agent_id: "ag_owned", display_name: "Owned Bot" },
+    });
+    const observedBotGroup = makeDashboardRoom({
+      room_id: "rm_group_bot",
+      owner_id: "ag_owned",
+      member_count: 3,
+      _originAgent: { agent_id: "ag_owned", display_name: "Owned Bot" },
+    });
+
+    expect(applyMessagesFilter([selfGroup, observedBotDm, observedBotGroup], "bots-all", new Set()).map((r) => r.room_id)).toEqual([
+      "rm_dm_ag_owned_ag_2",
+      "rm_group_bot",
     ]);
   });
 });


### PR DESCRIPTION
## Summary
- rename the Messages all filters from 全部私聊 to 全部
- make self-all and bots-all include group chats as well as DMs
- update Vitest coverage for the new all-filter behavior

## Tests
- pnpm exec vitest run src/lib/messages-merge.test.ts src/store/dashboard-shared.test.ts
- NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=placeholder pnpm build