### PR TITLE
fix: group owner chat with my bot messages

### DIFF
--- a/frontend/src/components/dashboard/RoomList.tsx
+++ b/frontend/src/components/dashboard/RoomList.tsx
@@ -14,7 +14,7 @@ import { useRouter } from "nextjs-toploader/app";
 import { useShallow } from "zustand/react/shallow";
 
 import { ContactInfo, DashboardRoom } from "@/lib/types";
-import { humanRoomToDashboardRoom } from "@/store/dashboard-shared";
+import { humanRoomToDashboardRoom, isOwnerChatRoom } from "@/store/dashboard-shared";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
@@ -92,6 +92,7 @@ export default function RoomList({
     setMessagesPane: state.setMessagesPane,
   })));
   const activeAgentId = useDashboardSessionStore((state) => state.activeAgentId);
+  const switchActiveAgent = useDashboardSessionStore((state) => state.switchActiveAgent);
   const viewMode = useDashboardSessionStore((state) => state.viewMode);
   const humanRooms = useDashboardSessionStore((state) => state.humanRooms);
   const humanId = useDashboardSessionStore((state) => state.human?.human_id ?? null);
@@ -126,7 +127,7 @@ export default function RoomList({
       .map(humanRoomToDashboardRoom);
     return [...agentRooms, ...extras];
   })();
-  const showUserChatEntry = includeUserChat && Boolean(activeAgentId) && viewMode === "agent" && (
+  const showUserChatEntry = includeUserChat && Boolean(activeAgentId) && (
     !normalizedSearchQuery ||
     [t.userChatTitle, t.userChatPreview, t.userChatTooltip, activeAgentId]
       .join("\n")
@@ -137,18 +138,31 @@ export default function RoomList({
   // (roomId is set), to avoid false positives when store is in default empty state.
   const isOwnerChatEmpty = showUserChatEntry && Boolean(ownerChatRoomId) && !ownerChatLoading && ownerChatMessages.length === 0;
 
-  const handleSelect = (roomId: string) => {
+  const handleSelect = async (room: DashboardRoom) => {
+    if (isOwnerChatRoom(room.room_id)) {
+      const agentId = room._originAgent?.agent_id || room.owner_id;
+      if (agentId && agentId !== activeAgentId) {
+        await switchActiveAgent(agentId);
+      }
+      setMessagesPane("user-chat");
+      setFocusedRoomId(null);
+      setOpenedRoomId(null);
+      closeMobileSidebar();
+      router.push(USER_CHAT_PATH);
+      return;
+    }
+
     setMessagesPane("room");
-    setFocusedRoomId(roomId);
-    setOpenedRoomId(roomId);
+    setFocusedRoomId(room.room_id);
+    setOpenedRoomId(room.room_id);
     closeMobileSidebar();
-    router.push(`/chats/messages/${encodeURIComponent(roomId)}`);
-    if (!messages[roomId]) {
-      loadRoomMessages(roomId);
+    router.push(`/chats/messages/${encodeURIComponent(room.room_id)}`);
+    if (!messages[room.room_id]) {
+      loadRoomMessages(room.room_id);
     }
   };
 
-  const handleRoomKeyDown = (event: React.KeyboardEvent<HTMLDivElement>, roomId: string) => {
+  const handleRoomKeyDown = (event: React.KeyboardEvent<HTMLDivElement>, room: DashboardRoom) => {
     if (event.target !== event.currentTarget) {
       return;
     }
@@ -156,7 +170,7 @@ export default function RoomList({
       return;
     }
     event.preventDefault();
-    handleSelect(roomId);
+    void handleSelect(room);
   };
 
   const handleSelectUserChat = () => {
@@ -246,7 +260,10 @@ export default function RoomList({
         </div>
       )}
       {!loading && rooms.map((room) => {
-        const isSelected = messagesPane === "room" && focusedRoomId === room.room_id;
+        const ownerChatAgentId = isOwnerChatRoom(room.room_id) ? room._originAgent?.agent_id || room.owner_id : null;
+        const isSelected = ownerChatAgentId
+          ? messagesPane === "user-chat" && ownerChatAgentId === activeAgentId
+          : messagesPane === "room" && focusedRoomId === room.room_id;
         const roomMessages = messages[room.room_id] || [];
         // Find the latest real message (skip ack/result/error receipts)
         const cachedLatestMessage = roomMessages.findLast(
@@ -283,8 +300,8 @@ export default function RoomList({
             tabIndex={0}
             aria-label={`Open room ${displayName}`}
             aria-current={isSelected ? "page" : undefined}
-            onClick={() => handleSelect(room.room_id)}
-            onKeyDown={(event) => handleRoomKeyDown(event, room.room_id)}
+            onClick={() => void handleSelect(room)}
+            onKeyDown={(event) => handleRoomKeyDown(event, room)}
             className={`w-full border-l-2 px-4 py-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-cyan/60 ${
               isSelected
                 ? "border-neon-cyan bg-neon-cyan/10"

--- a/frontend/src/components/dashboard/sidebar/MessagesPanel.tsx
+++ b/frontend/src/components/dashboard/sidebar/MessagesPanel.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "nextjs-toploader/app";
 import { useLanguage } from "@/lib/i18n";
 import { sidebar } from "@/lib/i18n/translations/dashboard";
 import { useShallow } from "zustand/react/shallow";
-import { buildVisibleMessageRooms } from "@/store/dashboard-shared";
+import { buildVisibleMessageRooms, isOwnerChatRoom } from "@/store/dashboard-shared";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
@@ -101,6 +101,11 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
     });
   }, [messages, normalizedMessageQuery, categorizedRooms]);
 
+  const includeUserChat = (messagesFilter === "self-all" || messagesFilter === "self-my-bot")
+    && !filteredMessageRooms.some(
+      (room) => isOwnerChatRoom(room.room_id) && room._originAgent?.agent_id === activeAgentId,
+    );
+
   // (filter chips moved into MessagesGroupingSidebar as expandable children)
 
   const showOverviewSkeleton = sessionMode === "authed-ready" && !overview && sidebarTab === "messages";
@@ -193,7 +198,12 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
         </div>
       ) : (
         <>
-          <RoomList rooms={filteredMessageRooms} loading={showOverviewSkeleton} searchQuery={messageQuery} />
+          <RoomList
+            rooms={filteredMessageRooms}
+            loading={showOverviewSkeleton}
+            searchQuery={messageQuery}
+            includeUserChat={includeUserChat}
+          />
           {!showOverviewSkeleton && !normalizedMessageQuery && filteredMessageRooms.length < 5 && (
             <div className="mx-3 mb-3 mt-auto rounded-2xl border border-dashed border-glass-border/60 bg-glass-bg/20 p-4">
               <p className="text-[11px] font-semibold text-text-secondary/80">

--- a/frontend/src/lib/messages-merge.test.ts
+++ b/frontend/src/lib/messages-merge.test.ts
@@ -157,6 +157,37 @@ describe("messages merge filters", () => {
     ]);
     expect(applyMessagesFilter([room], "bots-bot-bot", ownedAgentIds)).toEqual([]);
   });
+
+  it("classifies owner-chat rm_oc rooms as my own bot conversations", () => {
+    const rooms = mergeOwnerVisibleRooms({
+      ownRooms: [],
+      ownedAgentRooms: [
+        makeOwnedAgentRoom({
+          room_id: "rm_oc_abc123",
+          name: "My Bot",
+          owner_id: "ag_bot",
+          member_count: 1,
+          bots: [{ agent_id: "ag_bot", display_name: "My Bot", role: "owner" }],
+        }),
+      ],
+    });
+    const ownedAgentIds = new Set(["ag_bot"]);
+
+    expect(applyMessagesFilter(rooms, "self-my-bot", ownedAgentIds).map((room) => room.room_id)).toEqual([
+      "rm_oc_abc123",
+    ]);
+    expect(applyMessagesFilter(rooms, "self-all", ownedAgentIds).map((room) => room.room_id)).toEqual([
+      "rm_oc_abc123",
+    ]);
+    expect(applyMessagesFilter(rooms, "bots-all", ownedAgentIds)).toEqual([]);
+    expect(applyMessagesFilter(rooms, "bots-group", ownedAgentIds)).toEqual([]);
+    expect(countMessagesByFilter(rooms, ownedAgentIds)).toMatchObject({
+      "self-all": 1,
+      "self-my-bot": 1,
+      "bots-all": 0,
+      "bots-group": 0,
+    });
+  });
 });
 
 describe("mergeOwnerVisibleRooms", () => {

--- a/frontend/src/lib/messages-merge.ts
+++ b/frontend/src/lib/messages-merge.ts
@@ -13,7 +13,7 @@
 
 import type { DashboardRoom, HumanAgentRoomSummary, ParticipantType } from "@/lib/types";
 import { parseDmRoomId } from "@/components/dashboard/dmRoom";
-import { compareRoomsByActivityDesc } from "@/store/dashboard-shared";
+import { compareRoomsByActivityDesc, isOwnerChatRoom } from "@/store/dashboard-shared";
 
 interface MergeOpts {
   ownRooms: DashboardRoom[];
@@ -56,7 +56,7 @@ export function ownedAgentRoomToDashboardRoom(room: HumanAgentRoomSummary): Dash
     last_message_at: room.last_message_at,
     last_sender_name: room.last_sender_name,
     allow_human_send: room.allow_human_send ?? undefined,
-    peer_type: inferPeerTypeForOwnedAgentRoom(room),
+    peer_type: isOwnerChatRoom(room.room_id) ? "agent" : inferPeerTypeForOwnedAgentRoom(room),
     _originAgent: origin ?? undefined,
   };
 }
@@ -93,7 +93,7 @@ export type MessagesFilterKey =
   | "bots-group";
 
 function isPrivateMessageRoom(room: Pick<DashboardRoom, "room_id">): boolean {
-  return room.room_id.startsWith("rm_dm_");
+  return room.room_id.startsWith("rm_dm_") || isOwnerChatRoom(room.room_id);
 }
 
 function hasOwnedAgentParticipant(room: Pick<DashboardRoom, "owner_id" | "room_id">, ownedAgentIds: Set<string>): boolean {
@@ -138,6 +138,8 @@ export function classifyMessagesRoom(
   room: import("@/lib/types").DashboardRoom,
   ownedAgentIds: Set<string>,
 ): MessagesFilterKey {
+  if (isOwnerChatRoom(room.room_id)) return "self-my-bot";
+
   const isObserver = !!room._originAgent;
   const isPrivateChat = isPrivateMessageRoom(room);
   const dmPeerType = isPrivateChat ? inferDmPeerType(room) : undefined;
@@ -162,10 +164,10 @@ export function applyMessagesFilter(
   ownedAgentIds: Set<string>,
 ): import("@/lib/types").DashboardRoom[] {
   if (filter === "self-all") {
-    return rooms.filter((r) => !r._originAgent);
+    return rooms.filter((r) => !r._originAgent || isOwnerChatRoom(r.room_id));
   }
   if (filter === "bots-all") {
-    return rooms.filter((r) => !!r._originAgent);
+    return rooms.filter((r) => !!r._originAgent && !isOwnerChatRoom(r.room_id));
   }
   return rooms.filter((r) => classifyMessagesRoom(r, ownedAgentIds) === filter);
 }

--- a/frontend/src/store/dashboard-shared.ts
+++ b/frontend/src/store/dashboard-shared.ts
@@ -63,8 +63,8 @@ export function compareRoomsByActivityDesc<T extends RoomActivityLike>(a: T, b: 
   return getRoomActivityTimestamp(b) - getRoomActivityTimestamp(a);
 }
 
-/** Owner-chat rooms (rm_oc_*) are shown via the dedicated UserChatPane entry, not the room list. */
-function isOwnerChatRoom(roomId: string): boolean {
+/** Owner-chat rooms (rm_oc_*) are shown via the dedicated UserChatPane entry. */
+export function isOwnerChatRoom(roomId: string): boolean {
   return roomId.startsWith("rm_oc_");
 }
 


### PR DESCRIPTION
## Summary
- classify rm_oc owner-chat rooms as "self-my-bot" conversations
- show the owner-chat entry only in self/all and self/my-bot message filters
- route rm_oc room rows through UserChatPane so owner-chat keeps its dedicated behavior

## Tests
- npm test -- messages-merge.test.ts --run
- npm run build (fails during prerender of /admin/codes because Supabase URL/API key env vars are not configured locally; compile and TypeScript stages pass)