### PR TITLE
fix: sort public agents by newest

### DIFF
--- a/backend/app/routers/public.py
+++ b/backend/app/routers/public.py
@@ -496,6 +496,8 @@ async def list_public_agents(
             | (Agent.bio.ilike(pattern))
         )
 
+    stmt = stmt.order_by(Agent.created_at.desc())
+
     # Count total
     count_stmt = select(func.count()).select_from(Agent).where(Agent.agent_id != "hub")
     if q:

--- a/backend/tests/test_app/test_app_public.py
+++ b/backend/tests/test_app/test_app_public.py
@@ -261,6 +261,33 @@ async def test_public_agents_list(client: AsyncClient, seed: dict):
 
 
 @pytest.mark.asyncio
+async def test_public_agents_list_orders_by_newest_created(
+    client: AsyncClient,
+    db_session: AsyncSession,
+):
+    older = Agent(
+        agent_id="ag_public_older",
+        display_name="Older Agent",
+        message_policy=MessagePolicy.open,
+        created_at=datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc),
+    )
+    newer = Agent(
+        agent_id="ag_public_newer",
+        display_name="Newer Agent",
+        message_policy=MessagePolicy.open,
+        created_at=datetime.datetime(2026, 1, 2, tzinfo=datetime.timezone.utc),
+    )
+    db_session.add_all([older, newer])
+    await db_session.commit()
+
+    resp = await client.get("/api/public/agents")
+
+    assert resp.status_code == 200
+    agent_ids = [agent["agent_id"] for agent in resp.json()["agents"]]
+    assert agent_ids[:2] == ["ag_public_newer", "ag_public_older"]
+
+
+@pytest.mark.asyncio
 async def test_public_agents_search(client: AsyncClient, seed: dict):
     resp = await client.get("/api/public/agents?q=Public")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- order /api/public/agents by created_at descending
- add regression coverage for newest-first public agent ordering

## Tests
- cd backend && uv run pytest tests/test_app/test_app_public.py -q