### PR TITLE
fix: open device drawer from bot details

### DIFF
--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -29,6 +29,7 @@ import AgentBrowser from "./AgentBrowser";
 import AgentCardModal from "./AgentCardModal";
 import AgentGateModal from "./AgentGateModal";
 import BotDetailDrawer from "./BotDetailDrawer";
+import DeviceDetailDrawer from "./DeviceDetailDrawer";
 import PeerBotDetailDrawer from "./PeerBotDetailDrawer";
 import ChatPane from "./ChatPane";
 import DashboardShellSkeleton from "./DashboardShellSkeleton";
@@ -1016,6 +1017,7 @@ export default function DashboardApp() {
       </div>
       <StripeReturnBanner />
       <BotDetailDrawer />
+      <DeviceDetailDrawer />
       <PeerBotDetailDrawer />
       {shouldShowAgentGate ? (
         <AgentGateModal

--- a/frontend/src/components/dashboard/HomePanel.tsx
+++ b/frontend/src/components/dashboard/HomePanel.tsx
@@ -14,6 +14,15 @@ import ExploreEntityCard from "./ExploreEntityCard";
 
 type AgentStats = ActivityStats | null;
 
+function getTimeGreeting(date: Date): string {
+  const hour = date.getHours();
+  if (hour >= 5 && hour < 11) return "早安";
+  if (hour >= 11 && hour < 14) return "午安";
+  if (hour >= 14 && hour < 18) return "下午好";
+  if (hour >= 18 && hour < 24) return "晚上好";
+  return "夜深了";
+}
+
 function SectionHeader({
   title,
   subtitle,
@@ -147,6 +156,7 @@ export default function HomePanel() {
       ownedAgents: s.ownedAgents,
     })),
   );
+  const [greeting, setGreeting] = useState("你好");
   const {
     publicRooms,
     publicAgents,
@@ -180,6 +190,13 @@ export default function HomePanel() {
     })),
   );
   const [statsByAgent, setStatsByAgent] = useState<Record<string, ActivityStats>>({});
+
+  useEffect(() => {
+    const updateGreeting = () => setGreeting(getTimeGreeting(new Date()));
+    updateGreeting();
+    const interval = window.setInterval(updateGreeting, 60_000);
+    return () => window.clearInterval(interval);
+  }, []);
 
   useEffect(() => {
     if (!publicRoomsLoaded) void loadPublicRooms();
@@ -217,7 +234,7 @@ export default function HomePanel() {
       <div className="mx-auto max-w-5xl px-6 pb-10 pt-16">
         <div className="mb-10">
           <h1 className="text-4xl font-semibold tracking-tight text-text-primary">
-            早安，{displayName} 👋
+            {greeting}，{displayName} 👋
           </h1>
           <p className="mt-3 text-base text-text-secondary/70">
             看看你的 Bots 今天的表现，再发现一些有趣的房间和人。

--- a/frontend/src/components/dashboard/MyBotsPanel.tsx
+++ b/frontend/src/components/dashboard/MyBotsPanel.tsx
@@ -8,7 +8,6 @@ import type { ActivityStats } from "@/lib/types";
 import DaemonInstallCommand from "@/components/daemon/DaemonInstallCommand";
 import BotAvatar from "./BotAvatar";
 import MyDevicesView from "./MyDevicesView";
-import DeviceDetailDrawer from "./DeviceDetailDrawer";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import { useDaemonStore } from "@/store/useDaemonStore";
@@ -116,7 +115,6 @@ export default function MyBotsPanel() {
           </div>
         </div>
       ) : null}
-      <DeviceDetailDrawer />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Mount the device detail drawer at the dashboard root so selecting a hosted device from bot details opens the drawer from any page.
- Remove the duplicate device drawer mount from My Bots.
- Make the Home greeting use browser local time and refresh every minute.

## Testing
- npm run build in frontend compiles and passes TypeScript, then fails during prerender of /admin/codes because local Supabase URL/API key env vars are missing.
- npm run build in the clean PR worktree could not run because node_modules is not installed there: next: command not found.