### PR TITLE
fix: reset messages filter after creating room

### DIFF
--- a/frontend/src/components/dashboard/RoomZeroState.tsx
+++ b/frontend/src/components/dashboard/RoomZeroState.tsx
@@ -55,12 +55,13 @@ export default function RoomZeroState({ compact = false, hasRooms = false, onHum
       })),
     );
 
-  const { setFocusedRoomId, setOpenedRoomId, setSidebarTab, setMessagesPane } = useDashboardUIStore(
+  const { setFocusedRoomId, setOpenedRoomId, setSidebarTab, setMessagesPane, setMessagesFilter } = useDashboardUIStore(
     useShallow((state) => ({
       setFocusedRoomId: state.setFocusedRoomId,
       setOpenedRoomId: state.setOpenedRoomId,
       setSidebarTab: state.setSidebarTab,
       setMessagesPane: state.setMessagesPane,
+      setMessagesFilter: state.setMessagesFilter,
     })),
   );
 
@@ -68,6 +69,7 @@ export default function RoomZeroState({ compact = false, hasRooms = false, onHum
     setShowCreateRoom(false);
     setSidebarTab("messages");
     setMessagesPane("room");
+    setMessagesFilter("self-all");
     setFocusedRoomId(room.room_id);
     setOpenedRoomId(room.room_id);
     router.push(`/chats/messages/${encodeURIComponent(room.room_id)}`);

--- a/frontend/src/components/dashboard/sidebar/index.tsx
+++ b/frontend/src/components/dashboard/sidebar/index.tsx
@@ -151,6 +151,7 @@ export default function Sidebar({
     sidebarWidth: s.sidebarWidth,
     setSidebarTab: s.setSidebarTab,
     setMessagesPane: s.setMessagesPane,
+    setMessagesFilter: s.setMessagesFilter,
     setExploreView: s.setExploreView,
     setContactsView: s.setContactsView,
     setSidebarWidth: s.setSidebarWidth,
@@ -417,6 +418,7 @@ export default function Sidebar({
             setShowCreateRoom(false);
             uiStore.setSidebarTab("messages");
             uiStore.setMessagesPane("room");
+            uiStore.setMessagesFilter("self-all");
             uiStore.setFocusedRoomId(room.room_id);
             uiStore.setOpenedRoomId(room.room_id);
             onMobileSecondaryClose?.();


### PR DESCRIPTION
## Summary
- reset Messages grouping filter to `self-all` after creating a room from the sidebar modal
- apply the same reset for room creation from the Messages zero state

## Tests
- `npm run build` reached compile and TypeScript successfully, then failed during prerender of `/admin/codes` because local Supabase URL/API key env vars are not configured