### PR TITLE
fix: optimize dashboard tab loading

### DIFF
--- a/frontend/src/components/dashboard/ActivityPanel.tsx
+++ b/frontend/src/components/dashboard/ActivityPanel.tsx
@@ -6,6 +6,7 @@ import type { ActivityStats, ActivityFeedItem } from "@/lib/types";
 import { useLanguage } from "@/lib/i18n";
 import { sidebar } from "@/lib/i18n/translations/dashboard";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
+import { DashboardMainSkeleton } from "./DashboardTabSkeleton";
 
 type Period = "today" | "7d" | "30d";
 
@@ -290,9 +291,7 @@ export default function ActivityPanel() {
             </button>
           </div>
         ) : loading && feed.length === 0 ? (
-          <div className="flex items-center justify-center py-16">
-            <div className="h-6 w-6 animate-spin rounded-full border-2 border-glass-border border-t-neon-cyan" />
-          </div>
+          <DashboardMainSkeleton variant="activity" />
         ) : (
           <>
             {/* Stats */}

--- a/frontend/src/components/dashboard/ChatPane.tsx
+++ b/frontend/src/components/dashboard/ChatPane.tsx
@@ -37,22 +37,12 @@ import RoomZeroState from "./RoomZeroState";
 import { initialsFromName } from "./roomVisualTheme";
 import { dmPeerId } from "./dmRoom";
 import ContactsDetailPane from "./ContactsDetailPane";
+import { DashboardMainSkeleton } from "./DashboardTabSkeleton";
 
 const EXPLORE_GRID_CLASS = "grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5";
 
-function GridSkeletonCards({ count = 10 }: { count?: number }) {
-  return (
-    <div className={EXPLORE_GRID_CLASS}>
-      {Array.from({ length: count }).map((_, idx) => (
-        <div key={idx} className="rounded-xl border border-glass-border bg-deep-black-light p-3">
-          <div className="h-3 w-2/3 animate-pulse rounded bg-glass-border/60" />
-          <div className="mt-1.5 h-2.5 w-1/2 animate-pulse rounded bg-glass-border/50" />
-          <div className="mt-2.5 h-2.5 w-full animate-pulse rounded bg-glass-border/50" />
-          <div className="mt-1.5 h-2.5 w-5/6 animate-pulse rounded bg-glass-border/40" />
-        </div>
-      ))}
-    </div>
-  );
+function GridSkeletonCards() {
+  return <DashboardMainSkeleton variant="explore" />;
 }
 
 function ContactsMainPane({ onHumanOpen }: { onHumanOpen?: (human: PublicHumanProfile) => void }) {
@@ -225,7 +215,7 @@ function ContactsMainPane({ onHumanOpen }: { onHumanOpen?: (human: PublicHumanPr
       <div className="flex-1 overflow-y-auto px-5 py-4">
         {isRequestsView ? (
           contactRequestsLoading ? (
-            <GridSkeletonCards />
+            <DashboardMainSkeleton variant="contacts" />
           ) : pageItems.length === 0 ? (
             <p className="text-xs text-text-secondary">{t.noPendingRequests}</p>
           ) : (
@@ -269,7 +259,7 @@ function ContactsMainPane({ onHumanOpen }: { onHumanOpen?: (human: PublicHumanPr
           )
         ) : isRoomsView ? (
           !overview ? (
-            <GridSkeletonCards />
+            <DashboardMainSkeleton variant="contacts" />
           ) : pageItems.length === 0 ? (
             <p className="text-xs text-text-secondary">{t.noJoinedRoomsFound}</p>
           ) : (
@@ -301,7 +291,7 @@ function ContactsMainPane({ onHumanOpen }: { onHumanOpen?: (human: PublicHumanPr
           )
         ) : isCreatedView ? (
           !overview ? (
-            <GridSkeletonCards />
+            <DashboardMainSkeleton variant="contacts" />
           ) : pageItems.length === 0 ? (
             <p className="text-xs text-text-secondary">{t.noCreatedRoomsFound}</p>
           ) : (
@@ -332,7 +322,7 @@ function ContactsMainPane({ onHumanOpen }: { onHumanOpen?: (human: PublicHumanPr
             </div>
           )
         ) : !overview ? (
-          <GridSkeletonCards />
+          <DashboardMainSkeleton variant="contacts" />
         ) : pageItems.length === 0 ? (
           <p className="text-xs text-text-secondary">{t.noContactsFound}</p>
         ) : (

--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -33,6 +33,7 @@ import DeviceDetailDrawer from "./DeviceDetailDrawer";
 import PeerBotDetailDrawer from "./PeerBotDetailDrawer";
 import ChatPane from "./ChatPane";
 import DashboardShellSkeleton from "./DashboardShellSkeleton";
+import DashboardTabSkeleton from "./DashboardTabSkeleton";
 import HomePanel from "./HomePanel";
 import MyBotsPanel from "./MyBotsPanel";
 import HumanCardModal from "./HumanCardModal";
@@ -216,6 +217,15 @@ export default function DashboardApp() {
   useEffect(() => {
     if (!sessionStore.authResolved) return;
 
+    const pendingPrimaryNavigation = uiStore.pendingPrimaryNavigation;
+    if (pendingPrimaryNavigation) {
+      if (pathname === pendingPrimaryNavigation.path) {
+        uiStore.clearPrimaryNavigation();
+      } else {
+        return;
+      }
+    }
+
     // Previously: authed-no-agent short-circuited the router and forced
     // focusedRoomId=null, pairing with the AgentGateModal block. Human-first
     // drops that short-circuit so users without an Agent can still navigate
@@ -296,7 +306,9 @@ export default function DashboardApp() {
   }, [
     sessionStore.authResolved,
     sessionStore.sessionMode,
+    pathname,
     pathnameParts,
+    uiStore.pendingPrimaryNavigation,
     uiStore.focusedRoomId,
     uiStore.openedRoomId,
     uiStore.sidebarTab,
@@ -307,6 +319,7 @@ export default function DashboardApp() {
     uiStore.setFocusedRoomId,
     uiStore.setOpenedRoomId,
     uiStore.setSidebarTab,
+    uiStore.clearPrimaryNavigation,
     uiStore.setMessagesPane,
     uiStore.setExploreView,
     uiStore.setContactsView,
@@ -980,6 +993,9 @@ export default function DashboardApp() {
     || (uiStore.sidebarTab === "messages" && (uiStore.messagesPane === "user-chat" || Boolean(uiStore.openedRoomId)))
     || (uiStore.sidebarTab === "bots" && Boolean(uiStore.selectedBotAgentId));
   const mainPaneClass = `min-h-0 min-w-0 flex-1 ${mobileShowsMain ? "" : "max-md:hidden"}`;
+  const primaryNavigationPending = Boolean(
+    uiStore.pendingPrimaryNavigation && pathname !== uiStore.pendingPrimaryNavigation.path,
+  );
 
   return (
     <div className="fixed inset-0 flex overflow-hidden bg-deep-black max-md:flex-col-reverse">
@@ -989,7 +1005,9 @@ export default function DashboardApp() {
         onMobileSecondaryClose={uiStore.closeMobileSidebar}
       />
       <div className={mainPaneClass}>
-        {uiStore.sidebarTab === "home" ? (
+        {primaryNavigationPending ? (
+          <DashboardTabSkeleton variant={uiStore.sidebarTab} />
+        ) : uiStore.sidebarTab === "home" ? (
           <HomePanel />
         ) : uiStore.sidebarTab === "activity" ? (
           <ActivityPanel />

--- a/frontend/src/components/dashboard/DashboardTabSkeleton.tsx
+++ b/frontend/src/components/dashboard/DashboardTabSkeleton.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+/**
+ * [INPUT]: Tailwind dashboard tokens and a tab variant
+ * [OUTPUT]: Shared tab-specific skeletons for dashboard secondary panels and main panes
+ * [POS]: Loading UI primitives for dashboard tab transitions and data hydration
+ * [PROTOCOL]: Update this header when behavior changes, then check README.md
+ */
+import DashboardMessagePaneSkeleton from "./DashboardMessagePaneSkeleton";
+
+type TabSkeletonVariant = "home" | "messages" | "contacts" | "explore" | "wallet" | "activity" | "bots";
+
+export function SkeletonBlock({ className }: { className: string }) {
+  return <div className={`dashboard-skeleton-block rounded ${className}`} />;
+}
+
+function HeaderSkeleton({ compact = false }: { compact?: boolean }) {
+  return (
+    <div className={compact ? "border-b border-glass-border px-3 py-3" : "border-b border-glass-border px-6 py-4"}>
+      <SkeletonBlock className={compact ? "h-4 w-28" : "h-5 w-36"} />
+      <SkeletonBlock className={compact ? "mt-2 h-3 w-40 bg-glass-border/40" : "mt-2 h-3 w-56 bg-glass-border/40"} />
+    </div>
+  );
+}
+
+export function SidebarListSkeleton({ rows = 7, withAvatar = true }: { rows?: number; withAvatar?: boolean }) {
+  return (
+    <div className="space-y-1 p-2">
+      {Array.from({ length: rows }).map((_, idx) => (
+        <div key={idx} className="flex items-center gap-3 rounded-lg px-2 py-2.5">
+          {withAvatar ? <SkeletonBlock className="h-9 w-9 shrink-0 rounded-xl" /> : null}
+          <div className="min-w-0 flex-1">
+            <SkeletonBlock className="h-3.5 w-3/5" />
+            <SkeletonBlock className="mt-2 h-2.5 w-4/5 bg-glass-border/40" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function CardGridSkeleton({ rows = 6, statCards = false }: { rows?: number; statCards?: boolean }) {
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+      {Array.from({ length: rows }).map((_, idx) => (
+        <div key={idx} className="rounded-2xl border border-glass-border bg-deep-black-light p-4">
+          <div className="flex items-start gap-3">
+            <SkeletonBlock className="h-10 w-10 shrink-0 rounded-xl" />
+            <div className="min-w-0 flex-1">
+              <SkeletonBlock className="h-4 w-2/3" />
+              <SkeletonBlock className="mt-2 h-3 w-1/2 bg-glass-border/40" />
+              <SkeletonBlock className="mt-3 h-3 w-full bg-glass-border/40" />
+            </div>
+          </div>
+          {statCards ? (
+            <div className="mt-4 grid grid-cols-4 gap-2 border-t border-glass-border pt-3">
+              {Array.from({ length: 4 }).map((_, statIdx) => (
+                <SkeletonBlock key={statIdx} className="h-10 rounded-lg bg-glass-border/40" />
+              ))}
+            </div>
+          ) : (
+            <SkeletonBlock className="mt-4 h-3 w-1/3 bg-glass-border/40" />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ExploreGridSkeleton() {
+  return (
+    <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+      {Array.from({ length: 10 }).map((_, idx) => (
+        <div key={idx} className="rounded-xl border border-glass-border bg-deep-black-light p-3">
+          <SkeletonBlock className="h-11 w-11 rounded-xl" />
+          <SkeletonBlock className="mt-3 h-3.5 w-3/4" />
+          <SkeletonBlock className="mt-2 h-2.5 w-1/2 bg-glass-border/40" />
+          <SkeletonBlock className="mt-3 h-2.5 w-full bg-glass-border/40" />
+          <SkeletonBlock className="mt-1.5 h-2.5 w-5/6 bg-glass-border/40" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function WalletSkeleton() {
+  return (
+    <div className="mx-auto w-full max-w-2xl space-y-6">
+      <div className="rounded-2xl border border-glass-border bg-glass-bg p-6">
+        <SkeletonBlock className="h-3 w-28" />
+        <SkeletonBlock className="mt-4 h-10 w-56" />
+        <div className="mt-5 grid grid-cols-2 gap-4">
+          <SkeletonBlock className="h-20 rounded-xl bg-glass-border/40" />
+          <SkeletonBlock className="h-20 rounded-xl bg-glass-border/40" />
+        </div>
+      </div>
+      <div className="grid grid-cols-3 gap-3">
+        {Array.from({ length: 3 }).map((_, idx) => (
+          <SkeletonBlock key={idx} className="h-24 rounded-xl bg-glass-border/40" />
+        ))}
+      </div>
+      <div className="rounded-2xl border border-glass-border bg-glass-bg p-5">
+        <SkeletonBlock className="h-4 w-36" />
+        <SkeletonBlock className="mt-2 h-3 w-52 bg-glass-border/40" />
+        <div className="mt-4 space-y-3">
+          {Array.from({ length: 3 }).map((_, idx) => (
+            <SkeletonBlock key={idx} className="h-16 rounded-xl bg-glass-border/40" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ActivitySkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-3 gap-3">
+        {Array.from({ length: 3 }).map((_, idx) => (
+          <SkeletonBlock key={idx} className="h-24 rounded-xl bg-glass-border/40" />
+        ))}
+      </div>
+      <div>
+        <SkeletonBlock className="mb-3 h-4 w-32" />
+        <div className="space-y-2">
+          {Array.from({ length: 7 }).map((_, idx) => (
+            <div key={idx} className="flex gap-3 rounded-xl border border-glass-border bg-glass-bg p-3">
+              <SkeletonBlock className="h-8 w-8 shrink-0 rounded-lg" />
+              <div className="min-w-0 flex-1">
+                <SkeletonBlock className="h-3.5 w-3/5" />
+                <SkeletonBlock className="mt-2 h-3 w-4/5 bg-glass-border/40" />
+              </div>
+              <SkeletonBlock className="h-3 w-10 bg-glass-border/40" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function DashboardMainSkeleton({ variant }: { variant: TabSkeletonVariant }) {
+  if (variant === "wallet") return <WalletSkeleton />;
+  if (variant === "activity") return <ActivitySkeleton />;
+  if (variant === "explore") return <ExploreGridSkeleton />;
+  if (variant === "bots") return <CardGridSkeleton rows={4} statCards />;
+  if (variant === "home") {
+    return (
+      <div className="space-y-8">
+        <div>
+          <SkeletonBlock className="h-10 w-72" />
+          <SkeletonBlock className="mt-3 h-4 w-96 bg-glass-border/40" />
+        </div>
+        <CardGridSkeleton rows={3} statCards />
+        <ExploreGridSkeleton />
+      </div>
+    );
+  }
+  return <CardGridSkeleton rows={6} />;
+}
+
+export default function DashboardTabSkeleton({
+  variant,
+  compactHeader = false,
+}: {
+  variant: TabSkeletonVariant;
+  compactHeader?: boolean;
+}) {
+  if (variant === "messages") {
+    return <DashboardMessagePaneSkeleton />;
+  }
+
+  return (
+    <div className="flex h-full flex-col bg-deep-black">
+      <HeaderSkeleton compact={compactHeader} />
+      <div className={variant === "explore" || variant === "home" || variant === "bots" ? "flex-1 overflow-y-auto px-6 py-6" : "flex-1 overflow-y-auto px-5 py-4"}>
+        <DashboardMainSkeleton variant={variant} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/RoomList.tsx
+++ b/frontend/src/components/dashboard/RoomList.tsx
@@ -24,6 +24,7 @@ import SubscriptionBadge from "./SubscriptionBadge";
 import { resolveDmDisplayName } from "./dmRoom";
 import { CompositeAvatar } from "./CompositeAvatar";
 import BotAvatar from "./BotAvatar";
+import { SidebarListSkeleton } from "./DashboardTabSkeleton";
 
 interface RoomListProps {
   rooms?: DashboardRoom[];
@@ -245,14 +246,7 @@ export default function RoomList({
         </div>
       )}
       {loading && (
-        <div className="space-y-2 px-3 py-2">
-          {Array.from({ length: 6 }).map((_, idx) => (
-            <div key={idx} className="rounded-lg border border-glass-border bg-deep-black-light p-3">
-              <div className="h-3 w-2/3 animate-pulse rounded bg-glass-border/60" />
-              <div className="mt-2 h-2.5 w-1/2 animate-pulse rounded bg-glass-border/50" />
-            </div>
-          ))}
-        </div>
+        <SidebarListSkeleton rows={6} />
       )}
       {!loading && rooms.length === 0 && !showUserChatEntry && (
         <div className="p-4 text-center text-xs text-text-secondary">

--- a/frontend/src/components/dashboard/WalletPanel.tsx
+++ b/frontend/src/components/dashboard/WalletPanel.tsx
@@ -21,6 +21,7 @@ import LedgerList from "./LedgerList";
 import TransferDialog from "./TransferDialog";
 import TopupDialog from "./TopupDialog";
 import WithdrawDialog from "./WithdrawDialog";
+import DashboardTabSkeleton from "./DashboardTabSkeleton";
 
 function formatCoinAmount(minorStr: string): string {
   const minor = parseInt(minorStr, 10);
@@ -132,21 +133,18 @@ export default function WalletPanel() {
   }, [loadWallet, loadWalletLedger, loadWithdrawalRequests]);
 
   if (!wallet) {
+    if (!walletError) {
+      return <DashboardTabSkeleton variant="wallet" />;
+    }
     return (
       <div className="flex flex-1 flex-col items-center justify-center bg-deep-black gap-3">
-        {walletError ? (
-          <>
-            <div className="text-sm text-red-400">{walletError}</div>
-            <button
-              onClick={() => void loadWallet()}
-              className="rounded border border-glass-border px-4 py-2 text-xs text-text-secondary hover:text-text-primary"
-            >
-              {tc.retry}
-            </button>
-          </>
-        ) : (
-          <div className="text-neon-cyan animate-pulse text-sm">{tc.loading}</div>
-        )}
+        <div className="text-sm text-red-400">{walletError}</div>
+        <button
+          onClick={() => void loadWallet()}
+          className="rounded border border-glass-border px-4 py-2 text-xs text-text-secondary hover:text-text-primary"
+        >
+          {tc.retry}
+        </button>
       </div>
     );
   }

--- a/frontend/src/components/dashboard/sidebar/ContactsPanel.tsx
+++ b/frontend/src/components/dashboard/sidebar/ContactsPanel.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "nextjs-toploader/app";
 import { ChevronDown, UserPlus2, Users } from "lucide-react";
 import { CompositeAvatar } from "../CompositeAvatar";
 import BotAvatar from "../BotAvatar";
+import { SidebarListSkeleton, SkeletonBlock } from "../DashboardTabSkeleton";
 import { useShallow } from "zustand/shallow";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardContactStore } from "@/store/useDashboardContactStore";
@@ -150,6 +151,21 @@ export default function ContactsPanel({ onOpenAddFriend }: ContactsPanelProps) {
 
   const isActive = (type: "agent" | "human" | "group", id: string) =>
     selectedContactKey?.type === type && selectedContactKey.id === id;
+
+  if (!overview) {
+    return (
+      <div className="flex h-full flex-col">
+        <div className="flex items-center gap-3 border-b border-glass-border px-3 py-3">
+          <SkeletonBlock className="h-10 w-10 rounded-full" />
+          <div className="min-w-0 flex-1">
+            <SkeletonBlock className="h-3.5 w-32" />
+            <SkeletonBlock className="mt-2 h-2.5 w-24 bg-glass-border/40" />
+          </div>
+        </div>
+        <SidebarListSkeleton rows={9} />
+      </div>
+    );
+  }
 
   return (
     <div className="flex h-full flex-col">

--- a/frontend/src/components/dashboard/sidebar/WalletPanel.tsx
+++ b/frontend/src/components/dashboard/sidebar/WalletPanel.tsx
@@ -4,6 +4,7 @@ import { useLanguage } from "@/lib/i18n";
 import { sidebar } from "@/lib/i18n/translations/dashboard";
 import { useShallow } from "zustand/react/shallow";
 import { useDashboardWalletStore } from "@/store/useDashboardWalletStore";
+import { SkeletonBlock } from "../DashboardTabSkeleton";
 
 function formatCoinAmount(minorStr: string): string {
   const minor = parseInt(minorStr, 10);
@@ -67,7 +68,11 @@ export default function WalletPanel({ isGuest, onLogin }: WalletPanelProps) {
               <p className="text-center text-xs text-red-400">{walletError}</p>
             </div>
           ) : (
-            <p className="text-center text-xs text-text-secondary animate-pulse">{t.loadingWallet}</p>
+            <div className="space-y-3">
+              <SkeletonBlock className="h-20 rounded-xl bg-glass-border/40" />
+              <SkeletonBlock className="h-16 rounded-xl bg-glass-border/40" />
+              <SkeletonBlock className="h-16 rounded-xl bg-glass-border/40" />
+            </div>
           )}
         </>
       )}

--- a/frontend/src/components/dashboard/sidebar/index.tsx
+++ b/frontend/src/components/dashboard/sidebar/index.tsx
@@ -36,6 +36,7 @@ import MessagesGroupingSidebar from "./MessagesGroupingSidebar";
 import BotsPanel from "./BotsPanel";
 import MessagesPanel from "./MessagesPanel";
 import WalletPanel from "./WalletPanel";
+import { SidebarListSkeleton, SkeletonBlock } from "../DashboardTabSkeleton";
 
 import { humansApi } from "@/lib/api";
 import { UserPlus, LogIn, Bot, Plus, RefreshCw, MessageSquarePlus, Search, X } from "lucide-react";
@@ -141,6 +142,7 @@ export default function Sidebar({
   })));
   const uiStore = useDashboardUIStore(useShallow((s) => ({
     sidebarTab: s.sidebarTab,
+    pendingPrimaryNavigation: s.pendingPrimaryNavigation,
     contactsView: s.contactsView,
     exploreView: s.exploreView,
     openedRoomId: s.openedRoomId,
@@ -150,6 +152,7 @@ export default function Sidebar({
     messagesSearchOpen: s.messagesSearchOpen,
     sidebarWidth: s.sidebarWidth,
     setSidebarTab: s.setSidebarTab,
+    startPrimaryNavigation: s.startPrimaryNavigation,
     setMessagesPane: s.setMessagesPane,
     setMessagesFilter: s.setMessagesFilter,
     setExploreView: s.setExploreView,
@@ -267,6 +270,9 @@ export default function Sidebar({
   }, [unreadStore, visibleMessageRooms]);
 
   const pendingContactRequests = chatStore.overview?.pending_requests || 0;
+  const secondaryPanelLoading = Boolean(
+    uiStore.pendingPrimaryNavigation && uiStore.pendingPrimaryNavigation.tab === uiStore.sidebarTab,
+  );
 
   useEffect(() => {
     const prefetch = (path: string) => {
@@ -317,7 +323,7 @@ export default function Sidebar({
       activity: "/chats/activity",
       bots: "/chats/bots",
     };
-    uiStore.setSidebarTab(tab);
+    uiStore.startPrimaryNavigation(tab, pathByTab[tab]);
     if (tab === "messages" && !uiStore.openedRoomId && uiStore.messagesPane !== "user-chat") {
       uiStore.setMessagesPane("room");
     }
@@ -515,21 +521,42 @@ export default function Sidebar({
 
         {/* Panel content */}
         <div className="flex flex-1 min-h-0">
-          {uiStore.sidebarTab === "messages" && uiStore.messagesGroupingOpen && (
+          {!secondaryPanelLoading && uiStore.sidebarTab === "messages" && uiStore.messagesGroupingOpen && (
             <MessagesGroupingSidebar />
           )}
           <div className="flex-1 overflow-y-auto">
-          {uiStore.sidebarTab === "messages" && (
+          {secondaryPanelLoading ? (
+            uiStore.sidebarTab === "wallet" ? (
+              <div className="space-y-3 p-4">
+                <SkeletonBlock className="h-20 rounded-xl bg-glass-border/40" />
+                <SkeletonBlock className="h-16 rounded-xl bg-glass-border/40" />
+                <SkeletonBlock className="h-16 rounded-xl bg-glass-border/40" />
+              </div>
+            ) : (
+              <>
+                {uiStore.sidebarTab === "messages" ? (
+                  <div className="flex min-h-14 items-center justify-between border-b border-glass-border px-3 py-2.5">
+                    <SkeletonBlock className="h-4 w-28" />
+                    <div className="flex gap-1">
+                      <SkeletonBlock className="h-8 w-8 rounded-lg" />
+                      <SkeletonBlock className="h-8 w-8 rounded-lg" />
+                    </div>
+                  </div>
+                ) : null}
+                <SidebarListSkeleton rows={uiStore.sidebarTab === "contacts" ? 9 : 7} />
+              </>
+            )
+          ) : uiStore.sidebarTab === "messages" && (
             <MessagesPanel
               isGuest={isGuest}
               onCreateRoom={() => setShowCreateRoom(true)}
               onAddFriend={() => setShowAddFriend(true)}
             />
           )}
-          {uiStore.sidebarTab === "contacts" && (
+          {!secondaryPanelLoading && uiStore.sidebarTab === "contacts" && (
             <ContactsPanel onOpenAddFriend={() => setShowAddFriend(true)} />
           )}
-          {uiStore.sidebarTab === "wallet" && (
+          {!secondaryPanelLoading && uiStore.sidebarTab === "wallet" && (
             <WalletPanel isGuest={isGuest} onLogin={showLoginModal} />
           )}
           </div>

--- a/frontend/src/store/useDashboardUIStore.ts
+++ b/frontend/src/store/useDashboardUIStore.ts
@@ -21,6 +21,7 @@ export interface DashboardUIState {
   /** Mobile-only temporary drawer for the secondary sidebar/list panel. */
   mobileSidebarOpen: boolean;
   sidebarTab: "home" | "messages" | "contacts" | "explore" | "wallet" | "activity" | "bots";
+  pendingPrimaryNavigation: { tab: DashboardUIState["sidebarTab"]; path: string } | null;
   /** Currently selected owned bot (agent_id) in the My Bots tab. Null = list view. */
   selectedBotAgentId: string | null;
   /** Active sub-tab inside the My Bots tab. */
@@ -78,6 +79,8 @@ export interface DashboardUIState {
   setOpenedRoomId: (roomId: string | null) => void;
   setUserChatRoomId: (roomId: string | null) => void;
   setSidebarTab: (tab: DashboardUIState["sidebarTab"]) => void;
+  startPrimaryNavigation: (tab: DashboardUIState["sidebarTab"], path: string) => void;
+  clearPrimaryNavigation: () => void;
   setMessagesPane: (pane: DashboardUIState["messagesPane"]) => void;
   setMessagesFilter: (filter: DashboardUIState["messagesFilter"]) => void;
   setMessagesScope: (scope: DashboardUIState["messagesScope"]) => void;
@@ -111,6 +114,7 @@ const initialUIState = {
   openedTopicId: null as string | null,
   mobileSidebarOpen: false,
   sidebarTab: "messages" as DashboardUIState["sidebarTab"],
+  pendingPrimaryNavigation: null as DashboardUIState["pendingPrimaryNavigation"],
   selectedBotAgentId: null as string | null,
   myBotsTab: "bots" as DashboardUIState["myBotsTab"],
   selectedDeviceId: null as string | null,
@@ -139,7 +143,14 @@ export const useDashboardUIStore = create<DashboardUIState>()((set) => ({
   setUserChatRoomId: (userChatRoomId) =>
     set((state) => (state.userChatRoomId === userChatRoomId ? state : { userChatRoomId })),
   setSidebarTab: (sidebarTab) =>
-    set((state) => (state.sidebarTab === sidebarTab ? state : { sidebarTab })),
+    set((state) => (
+      state.sidebarTab === sidebarTab
+        ? state.pendingPrimaryNavigation ? { pendingPrimaryNavigation: null } : state
+        : { sidebarTab, pendingPrimaryNavigation: null }
+    )),
+  startPrimaryNavigation: (sidebarTab, path) =>
+    set({ sidebarTab, pendingPrimaryNavigation: { tab: sidebarTab, path } }),
+  clearPrimaryNavigation: () => set({ pendingPrimaryNavigation: null }),
   setMyBotsTab: (myBotsTab) =>
     set((state) => (state.myBotsTab === myBotsTab ? state : { myBotsTab })),
   setSelectedDeviceId: (selectedDeviceId) =>


### PR DESCRIPTION
## Summary
- switch dashboard primary tabs immediately before route loading completes
- add tab-specific skeleton layouts for dashboard main panes
- replace spinner/text loading states in messages, contacts, wallet, explore, and activity surfaces

## Test
- npm run build *(compiles and TypeScript passes; prerender fails at /admin/codes because NEXT_PUBLIC_SUPABASE_URL / Supabase API key env vars are not configured locally)*