### PR TITLE
fix: open owned bot messages in owner chat

### DIFF
--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -906,6 +906,27 @@ export default function DashboardApp() {
 
   const handleSendMessageFromAgentCard = () => {
     if (!selectedAgentForCard) return;
+    if (isSelectedAgentOwned) {
+      const agentId = selectedAgentForCard.agent_id;
+      void (async () => {
+        uiStore.closeAgentCard();
+        chatStore.closeAgentCardState();
+        uiStore.setSidebarTab("messages");
+        uiStore.setMessagesPane("user-chat");
+        uiStore.setFocusedRoomId(null);
+        uiStore.setOpenedRoomId(null);
+        if (agentId !== sessionStore.activeAgentId) {
+          await chatStore.switchActiveAgent(agentId);
+        }
+        api.getUserChatRoom(agentId).then((room) => {
+          uiStore.setUserChatRoomId(room.room_id);
+        }).catch((error) => {
+          console.error("[DashboardApp] getUserChatRoom failed:", error);
+        });
+        router.push(`/chats/messages/${USER_CHAT_SUBTAB}`);
+      })();
+      return;
+    }
     void navigateToDmWith(selectedAgentForCard.agent_id, () => {
       uiStore.closeAgentCard();
       chatStore.closeAgentCardState();


### PR DESCRIPTION
## Summary
- Route Send Message for owned bots to the dedicated owner-chat pane instead of creating a regular DM room
- Ensure the owner-chat rm_oc room is registered before navigating
- Keep external bot and human Send Message behavior on ordinary DM rooms

## Tests
- cd frontend && npm run build