### PR TITLE
fix: include member previews for owned agent rooms

### DIFF
--- a/backend/app/routers/humans.py
+++ b/backend/app/routers/humans.py
@@ -131,6 +131,7 @@ class HumanAgentRoomSummary(BaseModel):
     last_message_at: str | None = None
     last_sender_name: str | None = None
     allow_human_send: bool | None = None
+    members_preview: list[HumanRoomMemberPreviewItem] | None = None
     bots: list[HumanAgentRoomBot]
 
 
@@ -711,6 +712,7 @@ async def list_owned_agent_only_rooms(
         )
     )
     human_member_room_ids = {row[0] for row in human_membership_result.all()}
+    previews_by_room = await _build_member_previews(db, room_ids)
 
     response_rooms: list[HumanAgentRoomSummary] = []
     for room_id, preview in rooms_by_id.items():
@@ -736,6 +738,8 @@ async def list_owned_agent_only_rooms(
                 last_message_at=preview.get("last_message_at"),
                 last_sender_name=preview.get("last_sender_name"),
                 allow_human_send=preview.get("allow_human_send"),
+                members_preview=previews_by_room.get(room_id)
+                if int(preview.get("member_count") or 0) > 2 else None,
                 bots=sorted(bots, key=lambda bot: agent_names.get(bot.agent_id) or bot.agent_id),
             )
         )

--- a/backend/tests/test_app/test_app_humans.py
+++ b/backend/tests/test_app/test_app_humans.py
@@ -294,6 +294,16 @@ async def test_list_owned_agent_rooms_excludes_current_human_rooms(
         message_policy=MessagePolicy.open,
         user_id=seed["user_id"],
     )
+    peer_agent = Agent(
+        agent_id="ag_peer000001",
+        display_name="Peer Bot",
+        message_policy=MessagePolicy.open,
+    )
+    third_agent = Agent(
+        agent_id="ag_third00001",
+        display_name="Third Bot",
+        message_policy=MessagePolicy.open,
+    )
     included = Room(
         room_id="rm_bot_only",
         name="Bot Only",
@@ -321,12 +331,24 @@ async def test_list_owned_agent_rooms_excludes_current_human_rooms(
         visibility=RoomVisibility.private,
         join_policy=RoomJoinPolicy.invite_only,
     )
-    db_session.add_all([agent, included, human_member, human_owner])
+    db_session.add_all([agent, peer_agent, third_agent, included, human_member, human_owner])
     await db_session.flush()
     db_session.add_all([
         RoomMember(
             room_id="rm_bot_only",
             agent_id="ag_alice00001",
+            participant_type=ParticipantType.agent,
+            role=RoomRole.member,
+        ),
+        RoomMember(
+            room_id="rm_bot_only",
+            agent_id="ag_peer000001",
+            participant_type=ParticipantType.agent,
+            role=RoomRole.member,
+        ),
+        RoomMember(
+            room_id="rm_bot_only",
+            agent_id="ag_third00001",
             participant_type=ParticipantType.agent,
             role=RoomRole.member,
         ),
@@ -360,6 +382,12 @@ async def test_list_owned_agent_rooms_excludes_current_human_rooms(
     assert [room["room_id"] for room in rooms] == ["rm_bot_only"]
     assert rooms[0]["bots"] == [
         {"agent_id": "ag_alice00001", "display_name": "Alice Bot", "role": "member"}
+    ]
+    assert rooms[0]["member_count"] == 3
+    assert rooms[0]["members_preview"] == [
+        {"agent_id": "ag_alice00001", "avatar_url": None, "display_name": "Alice Bot"},
+        {"agent_id": "ag_peer000001", "avatar_url": None, "display_name": "Peer Bot"},
+        {"agent_id": "ag_third00001", "avatar_url": None, "display_name": "Third Bot"},
     ]
 
 

--- a/frontend/src/lib/messages-merge.ts
+++ b/frontend/src/lib/messages-merge.ts
@@ -56,6 +56,7 @@ export function ownedAgentRoomToDashboardRoom(room: HumanAgentRoomSummary): Dash
     last_message_at: room.last_message_at,
     last_sender_name: room.last_sender_name,
     allow_human_send: room.allow_human_send ?? undefined,
+    members_preview: room.members_preview ?? undefined,
     peer_type: isOwnerChatRoom(room.room_id) ? "agent" : inferPeerTypeForOwnedAgentRoom(room),
     _originAgent: origin ?? undefined,
   };

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -966,6 +966,7 @@ export interface HumanAgentRoomSummary {
   last_message_at: string | null;
   last_sender_name: string | null;
   allow_human_send?: boolean | null;
+  members_preview?: RoomMemberPreview[] | null;
   bots: HumanAgentRoomBot[];
 }
 


### PR DESCRIPTION
## Summary
- add members_preview to /api/humans/me/agent-rooms responses for group rooms
- preserve members_preview when mapping owned agent rooms into dashboard rooms
- cover the owned-agent room API response with a regression test

## Tests
- cd backend && uv run pytest tests/test_app/test_app_humans.py -k "agent_rooms or human_rooms"