### PR TITLE
fix: validate OpenClaw agent profiles

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -2005,6 +2005,7 @@ def _daemon_lists_runtime(
     instance: DaemonInstance,
     runtime: str,
     openclaw_gateway: str | None = None,
+    openclaw_agent: str | None = None,
     hermes_profile: str | None = None,
 ) -> bool:
     """Check that the daemon's last runtime probe lists `runtime` as available.
@@ -2038,6 +2039,23 @@ def _daemon_lists_runtime(
                 if not isinstance(ep, dict):
                     continue
                 if ep.get("name") == openclaw_gateway and ep.get("reachable") is True:
+                    if openclaw_agent:
+                        agents = ep.get("agents")
+                        if not isinstance(agents, list):
+                            return True
+                        for profile in agents:
+                            if not isinstance(profile, dict):
+                                continue
+                            if profile.get("id") != openclaw_agent:
+                                continue
+                            availability = profile.get("availability")
+                            if (
+                                isinstance(availability, dict)
+                                and availability.get("available") is False
+                            ):
+                                return False
+                            return True
+                        return False
                     return True
             return False
         if runtime == "hermes-agent" and hermes_profile:
@@ -2165,6 +2183,7 @@ async def provision_agent(
         instance,
         runtime,
         body.openclaw_gateway,
+        body.openclaw_agent,
         body.hermes_profile,
     ):
         raise HTTPException(status_code=409, detail="runtime_unavailable")

--- a/backend/tests/test_app/test_agent_provision.py
+++ b/backend/tests/test_app/test_agent_provision.py
@@ -438,6 +438,57 @@ async def test_provision_rejects_runtime_not_in_snapshot(
 
 
 @pytest.mark.asyncio
+async def test_provision_rejects_unavailable_openclaw_profile_in_snapshot(
+    client: AsyncClient, seed_user, db_session: AsyncSession
+):
+    instance_id = await _provision_instance(client, seed_user)
+    conn, _, registry = await _with_connected_daemon(
+        instance_id,
+        seed_user["user_id"],
+        runtimes_snapshot=[
+            {
+                "id": "openclaw-acp",
+                "available": True,
+                "endpoints": [
+                    {
+                        "name": "local",
+                        "url": "ws://127.0.0.1:18789",
+                        "reachable": True,
+                        "agents": [
+                            {
+                                "id": "claude-code",
+                                "availability": {
+                                    "available": False,
+                                    "code": "stale_config",
+                                    "message": 'Agent "claude-code" no longer exists in configuration',
+                                },
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+        db_session=db_session,
+    )
+    try:
+        r = await client.post(
+            "/api/users/me/agents/provision",
+            json={
+                "daemon_instance_id": instance_id,
+                "label": "writer",
+                "runtime": "openclaw-acp",
+                "openclaw_gateway": "local",
+                "openclaw_agent": "claude-code",
+            },
+            headers={"Authorization": f"Bearer {seed_user['token']}"},
+        )
+        assert r.status_code == 409
+        assert r.json()["detail"] == "runtime_unavailable"
+    finally:
+        await registry.unregister(conn)
+
+
+@pytest.mark.asyncio
 async def test_provision_permits_runtime_when_snapshot_empty(
     client: AsyncClient, seed_user, db_session: AsyncSession
 ):

--- a/frontend/src/components/dashboard/CreateAgentDialog.tsx
+++ b/frontend/src/components/dashboard/CreateAgentDialog.tsx
@@ -206,7 +206,7 @@ export default function CreateAgentDialog({
   const selectableOpenclawAgents = useMemo(
     () =>
       (selectedOpenclawEndpoint?.agents ?? []).filter(
-        (a) => !a.botcordBinding?.agentId,
+        (a) => !a.botcordBinding?.agentId && a.availability?.available !== false,
       ),
     [selectedOpenclawEndpoint],
   );
@@ -325,6 +325,12 @@ export default function CreateAgentDialog({
         case "daemon_timeout":
           return t.errorDaemonTimeout;
         case "daemon_failed":
+          if (
+            err.detail &&
+            /agent\s+["']?[^"']+["']?\s+no longer exists in configuration/i.test(err.detail)
+          ) {
+            return "The selected OpenClaw profile is no longer available. Fix the OpenClaw configuration, then refresh runtimes.";
+          }
           return err.detail
             ? `${t.errorDaemonFailed}: ${err.detail}`
             : t.errorDaemonFailed;
@@ -784,8 +790,13 @@ function OpenclawGatewayPicker({
   const reachable = endpoints.filter((e) => e.reachable);
   const current = endpoints.find((e) => e.name === selectedGateway) ?? null;
   const agents = current?.agents ?? [];
-  const availableAgents = agents.filter((a) => !a.botcordBinding?.agentId);
-  const boundCount = agents.length - availableAgents.length;
+  const availableAgents = agents.filter(
+    (a) => !a.botcordBinding?.agentId && a.availability?.available !== false,
+  );
+  const boundCount = agents.filter((a) => !!a.botcordBinding?.agentId).length;
+  const unavailableAgents = agents.filter(
+    (a) => !a.botcordBinding?.agentId && a.availability?.available === false,
+  );
   if (endpoints.length === 0) {
     return (
       <div className="rounded-xl border border-dashed border-glass-border bg-glass-bg/40 px-3 py-3 text-xs text-text-secondary">
@@ -865,6 +876,13 @@ function OpenclawGatewayPicker({
               );
             })}
           </select>
+        )}
+        {unavailableAgents.length > 0 && (
+          <p className="mt-1 text-[11px] text-orange-400">
+            {unavailableAgents.length} OpenClaw profile
+            {unavailableAgents.length === 1 ? " is" : "s are"} unavailable. Refresh
+            runtimes after fixing the OpenClaw configuration.
+          </p>
         )}
         {boundCount > 0 && (
           <p className="mt-1 text-[11px] text-text-tertiary">

--- a/frontend/src/store/useDaemonStore.ts
+++ b/frontend/src/store/useDaemonStore.ts
@@ -21,7 +21,7 @@ export interface DaemonRuntimeEndpoint {
   name: string;
   url: string;
   reachable: boolean;
-  status?: "reachable" | "unreachable" | "acp_disabled";
+  status?: "reachable" | "unreachable" | "acp_disabled" | "missing_token" | "auth_required";
   version?: string;
   error?: string;
   diagnostics?: Array<{ code: string; message?: string }>;
@@ -30,6 +30,11 @@ export interface DaemonRuntimeEndpoint {
     name?: string;
     workspace?: string;
     model?: { name?: string; provider?: string };
+    availability?: {
+      available: boolean;
+      code?: "stale_config" | "probe_failed";
+      message?: string;
+    };
     botcordBinding?: {
       agentId: string;
     };
@@ -268,6 +273,22 @@ function normalizeRuntimes(raw: unknown): DaemonRuntime[] | null | undefined {
                         workspace:
                           typeof ax.workspace === "string" ? ax.workspace : undefined,
                         model,
+                        availability:
+                          ax.availability &&
+                          typeof ax.availability === "object"
+                            ? {
+                                available:
+                                  (ax.availability as any).available !== false,
+                                code:
+                                  typeof (ax.availability as any).code === "string"
+                                    ? (ax.availability as any).code
+                                    : undefined,
+                                message:
+                                  typeof (ax.availability as any).message === "string"
+                                    ? (ax.availability as any).message
+                                    : undefined,
+                              }
+                            : undefined,
                         botcordBinding:
                           ax.botcordBinding &&
                           typeof ax.botcordBinding === "object" &&

--- a/packages/daemon/src/__tests__/provision.test.ts
+++ b/packages/daemon/src/__tests__/provision.test.ts
@@ -563,6 +563,7 @@ describe("provision_agent handler writes runtime + cwd", () => {
       const gw = makeFakeGateway();
       const provisioner = createProvisioner({
         gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+        validateOpenclawAgent: async () => ({ ok: true }),
       });
 
       // A valid 32-byte Ed25519 seed → deterministic keypair. Any fresh
@@ -640,6 +641,7 @@ describe("provision_agent handler writes runtime + cwd", () => {
       const gw = makeFakeGateway();
       const provisioner = createProvisioner({
         gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+        validateOpenclawAgent: async () => ({ ok: true }),
       });
       const privateKey = Buffer.alloc(32, 11).toString("base64");
       const ack = await provisioner({
@@ -747,6 +749,7 @@ describe("provision_agent seeds workspace + hot-adds managed route", () => {
       const gw = makeFakeGateway();
       const provisioner = createProvisioner({
         gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+        validateOpenclawAgent: async () => ({ ok: true }),
       });
       const privateKey = Buffer.alloc(32, 14).toString("base64");
       const ack = await provisioner({
@@ -772,6 +775,60 @@ describe("provision_agent seeds workspace + hot-adds managed route", () => {
       const route = gw.listManagedRoutes().find((r) => r.match?.accountId === "ag_openclaw_default");
       expect(route?.gateway?.name).toBe("local");
       expect(route?.gateway?.openclawAgent).toBe("default");
+    });
+  });
+
+  it("rejects an OpenClaw agent that ACP cannot open at session creation", async () => {
+    await withSandboxHome(async ({ tmp, fs, path: nodePath }) => {
+      mockState.cfg = {
+        defaultRoute: { adapter: "claude-code", cwd: "/tmp" },
+        routes: [],
+        streamBlocks: true,
+        openclawGateways: [{ name: "local", url: "ws://127.0.0.1:18789" }],
+      };
+      const gw = makeFakeGateway();
+      const validateOpenclawAgent = vi.fn(async () => ({
+        ok: false,
+        code: "stale_config" as const,
+        error: 'Internal error: Agent "claude-code" no longer exists in configuration',
+      }));
+      const provisioner = createProvisioner({
+        gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+        validateOpenclawAgent,
+      });
+      const privateKey = Buffer.alloc(32, 14).toString("base64");
+      const ack = await provisioner({
+        id: "req_openclaw_stale",
+        type: CONTROL_FRAME_TYPES.PROVISION_AGENT,
+        params: {
+          runtime: "openclaw-acp",
+          openclaw: { gateway: "local", agent: "claude-code" },
+          credentials: {
+            agentId: "ag_openclaw_stale",
+            keyId: "k_ocs",
+            privateKey,
+            hubUrl: "https://hub.example",
+          },
+        },
+      });
+
+      expect(ack.ok).toBe(false);
+      expect(ack.error).toMatchObject({
+        code: "openclaw_agent_unavailable",
+        gateway: "local",
+        openclawAgent: "claude-code",
+        availabilityCode: "stale_config",
+      });
+      expect(validateOpenclawAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          openclawAgent: "claude-code",
+          gateway: expect.objectContaining({ name: "local" }),
+        }),
+      );
+      expect(
+        fs.existsSync(nodePath.join(tmp, ".botcord", "credentials", "ag_openclaw_stale.json")),
+      ).toBe(false);
+      expect(gw.addChannel).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/daemon/src/__tests__/runtime-discovery.test.ts
+++ b/packages/daemon/src/__tests__/runtime-discovery.test.ts
@@ -194,6 +194,47 @@ describe("collectRuntimeSnapshotAsync", () => {
     }
   });
 
+  it("marks OpenClaw profiles unavailable when ACP session validation fails", async () => {
+    setRuntimes([
+      {
+        id: "openclaw-acp",
+        displayName: "OpenClaw",
+        binary: "openclaw",
+        supportsRun: true,
+        result: { available: true },
+      },
+    ]);
+
+    const snap = await collectRuntimeSnapshotAsync({
+      cfg: { openclawGateways: [{ name: "local", url: "ws://127.0.0.1:18789" }] },
+      wsProbe: async () => ({
+        ok: true,
+        agents: [{ id: "main" }, { id: "claude-code" }],
+      }),
+      acpAgentProbe: async ({ openclawAgent }) =>
+        openclawAgent === "claude-code"
+          ? {
+              ok: false,
+              code: "stale_config",
+              error: 'Internal error: Agent "claude-code" no longer exists in configuration',
+            }
+          : { ok: true },
+    });
+
+    const runtime = snap.runtimes.find((r) => r.id === "openclaw-acp");
+    expect(runtime?.endpoints?.[0]?.agents).toEqual([
+      { id: "main", availability: { available: true } },
+      {
+        id: "claude-code",
+        availability: {
+          available: false,
+          code: "stale_config",
+          message: 'Internal error: Agent "claude-code" no longer exists in configuration',
+        },
+      },
+    ]);
+  });
+
   it("reports acp_disabled without probing the gateway", async () => {
     const tmp = mkdtempSync(path.join(tmpdir(), "daemon-runtime-openclaw-"));
     const prevHome = process.env.HOME;

--- a/packages/daemon/src/gateway/runtimes/openclaw-acp.ts
+++ b/packages/daemon/src/gateway/runtimes/openclaw-acp.ts
@@ -136,6 +136,96 @@ interface SpawnDeps {
   spawnFn?: typeof spawn;
 }
 
+export interface OpenclawAgentValidationResult {
+  ok: boolean;
+  code?: "stale_config" | "probe_failed";
+  error?: string;
+}
+
+export async function validateOpenclawAgentProfile(args: {
+  gateway: { name: string; url: string; token?: string };
+  openclawAgent: string;
+  cwd: string;
+  timeoutMs?: number;
+  spawnFn?: typeof spawn;
+}): Promise<OpenclawAgentValidationResult> {
+  const command = resolveOpenclawCommand() ?? "openclaw";
+  const acpArgs = ["acp", "--url", args.gateway.url];
+  if (args.gateway.token) acpArgs.push("--token", args.gateway.token);
+  const child = (args.spawnFn ?? spawn)(command, acpArgs, {
+    stdio: ["pipe", "pipe", "pipe"],
+    env: { ...process.env },
+  }) as ChildProcessWithoutNullStreams;
+  const handle: AcpProcessHandle = {
+    child,
+    pending: new Map(),
+    subscribers: new Map(),
+    nextId: 1,
+    buffer: "",
+    nonJsonStdoutTail: [],
+    initialized: false,
+    inFlight: 0,
+    closed: false,
+    spawnedUrl: args.gateway.url,
+    spawnedToken: args.gateway.token,
+  };
+
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => onStdoutChunk(handle, chunk));
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk: string) => {
+    log.debug("openclaw-acp.validate.stderr", {
+      gateway: args.gateway.name,
+      openclawAgent: args.openclawAgent,
+      chunk: chunk.slice(0, 500),
+    });
+  });
+  child.on("exit", (code, signal) => {
+    shutdownHandle(handle, `exit code=${code ?? "null"} signal=${signal ?? "null"}`);
+  });
+  child.on("error", (err) => {
+    shutdownHandle(handle, `error: ${(err as Error).message}`);
+  });
+
+  const timeoutMs = args.timeoutMs ?? 3000;
+  try {
+    await withTimeout(
+      sendRequest(handle, "initialize", {
+        protocolVersion: ACP_PROTOCOL_VERSION,
+        clientCapabilities: {},
+      }),
+      timeoutMs,
+      "initialize timed out",
+    );
+    await withTimeout(
+      sendRequest(handle, "session/new", {
+        cwd: args.cwd,
+        mcpServers: [],
+        _meta: {
+          sessionKey: buildAcpSessionKey({
+            openclawAgent: args.openclawAgent,
+            accountId: "botcord-provision-check",
+            conversationKey: "validate",
+          }),
+        },
+      }),
+      timeoutMs,
+      "session/new timed out",
+    );
+    return { ok: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const stale = /agent\s+["']?[^"']+["']?\s+no longer exists in configuration/i.test(message);
+    return {
+      ok: false,
+      code: stale ? "stale_config" : "probe_failed",
+      error: message,
+    };
+  } finally {
+    shutdownHandle(handle, "validation-complete");
+  }
+}
+
 /**
  * OpenClaw ACP runtime adapter.
  *
@@ -620,6 +710,17 @@ function sendNotification(
   } catch {
     // best-effort fire-and-forget
   }
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<T>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+    timer.unref?.();
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -64,6 +64,10 @@ import {
   isValidHermesProfileName,
   listHermesProfiles,
 } from "./gateway/runtimes/hermes-agent.js";
+import {
+  validateOpenclawAgentProfile,
+  type OpenclawAgentValidationResult,
+} from "./gateway/runtimes/openclaw-acp.js";
 import { log as daemonLog } from "./log.js";
 import { discoverAgentCredentials } from "./agent-discovery.js";
 
@@ -117,6 +121,13 @@ export interface ProvisionerOptions {
    * the next restart.
    */
   onAgentInstalled?: OnAgentInstalledHook;
+  /** Test seam for OpenClaw profile runtime validation. */
+  validateOpenclawAgent?: (args: {
+    gateway: { name: string; url: string; token?: string };
+    openclawAgent: string;
+    cwd: string;
+    timeoutMs?: number;
+  }) => Promise<OpenclawAgentValidationResult>;
   /**
    * Optional shared login-session store for the third-party gateway login
    * frames. Tests inject a stub clock; production lets `createGatewayControl`
@@ -140,6 +151,7 @@ export function createProvisioner(opts: ProvisionerOptions): (
   const register = opts.register ?? BotCordClient.register;
   const policyResolver = opts.policyResolver;
   const onAgentInstalled = opts.onAgentInstalled;
+  const validateOpenclawAgent = opts.validateOpenclawAgent ?? validateOpenclawAgentProfile;
   const gatewayControl = createGatewayControl({
     gateway,
     ...(opts.loginSessions ? { loginSessions: opts.loginSessions } : {}),
@@ -197,8 +209,27 @@ export function createProvisioner(opts: ProvisionerOptions): (
             gateway,
             register,
             onAgentInstalled,
+            validateOpenclawAgent,
           });
         } catch (err) {
+          if (err instanceof OpenclawProfileError) {
+            daemonLog.warn("provision_agent: openclaw profile rejected", {
+              code: err.code,
+              gateway: err.gateway,
+              openclawAgent: err.openclawAgent,
+              availabilityCode: err.availabilityCode ?? null,
+            });
+            return {
+              ok: false,
+              error: {
+                code: err.code,
+                message: err.message,
+                gateway: err.gateway,
+                openclawAgent: err.openclawAgent,
+                ...(err.availabilityCode ? { availabilityCode: err.availabilityCode } : {}),
+              },
+            };
+          }
           if (err instanceof HermesProfileError) {
             daemonLog.warn("provision_agent: hermes profile rejected", {
               code: err.code,
@@ -555,6 +586,28 @@ interface ProvisionCtx {
   gateway: Gateway;
   register: typeof BotCordClient.register;
   onAgentInstalled?: OnAgentInstalledHook;
+  validateOpenclawAgent?: NonNullable<ProvisionerOptions["validateOpenclawAgent"]>;
+}
+
+class OpenclawProfileError extends Error {
+  readonly code: "openclaw_agent_unavailable";
+  readonly gateway: string;
+  readonly openclawAgent: string;
+  readonly availabilityCode?: string;
+
+  constructor(args: {
+    gateway: string;
+    openclawAgent: string;
+    message: string;
+    availabilityCode?: string;
+  }) {
+    super(args.message);
+    this.name = "OpenclawProfileError";
+    this.code = "openclaw_agent_unavailable";
+    this.gateway = args.gateway;
+    this.openclawAgent = args.openclawAgent;
+    this.availabilityCode = args.availabilityCode;
+  }
 }
 
 const openclawProvisionLocks = new Map<string, Promise<unknown>>();
@@ -761,6 +814,16 @@ async function provisionAgent(
   const resolvedParams = withResolvedOpenclawSelection(params, openclawSel);
   if (openclawSel.gateway && openclawSel.agent) {
     return withOpenclawProvisionLock(openclawSel.gateway, openclawSel.agent, async () => {
+      await validateOpenclawSelectionForProvision({
+        selection: openclawSel as { gateway: string; agent: string },
+        cfg: loadConfig(),
+        ctx,
+        cwd:
+          explicitCwd ??
+          (params.credentials?.agentId
+            ? agentWorkspaceDir(params.credentials.agentId)
+            : homedir()),
+      });
       const existing = findCredentialsByOpenclaw(openclawSel.gateway!, openclawSel.agent!);
       if (existing) {
         daemonLog.info("provision_agent: openclaw binding already exists", {
@@ -1255,6 +1318,39 @@ async function withHermesProvisionLock<T>(
   }
 }
 
+async function validateOpenclawSelectionForProvision(args: {
+  selection: { gateway: string; agent: string };
+  cfg: DaemonConfig;
+  ctx: ProvisionCtx;
+  cwd: string;
+}): Promise<void> {
+  const profile = (args.cfg.openclawGateways ?? []).find(
+    (g) => g.name === args.selection.gateway,
+  );
+  if (!profile) return;
+  const prepared = prepareGatewayProfile(profile);
+  const validate = args.ctx.validateOpenclawAgent ?? validateOpenclawAgentProfile;
+  const result = await validate({
+    gateway: {
+      name: prepared.name,
+      url: prepared.url,
+      ...(prepared.resolvedToken ? { token: prepared.resolvedToken } : {}),
+    },
+    openclawAgent: args.selection.agent,
+    cwd: args.cwd,
+    timeoutMs: 3000,
+  });
+  if (result.ok) return;
+  throw new OpenclawProfileError({
+    gateway: args.selection.gateway,
+    openclawAgent: args.selection.agent,
+    availabilityCode: result.code,
+    message:
+      result.error ??
+      `OpenClaw agent "${args.selection.agent}" is not available in gateway "${args.selection.gateway}"`,
+  });
+}
+
 class HermesProfileError extends Error {
   constructor(
     public readonly code:
@@ -1739,6 +1835,13 @@ export type WsEndpointProbeFn = (args: {
   error?: string;
 }>;
 
+export type OpenclawAgentAvailabilityProbeFn = (args: {
+  gateway: { name: string; url: string; token?: string };
+  openclawAgent: string;
+  cwd: string;
+  timeoutMs?: number;
+}) => Promise<OpenclawAgentValidationResult>;
+
 export function classifyOpenclawAuthError(message: string | undefined): "missing_token" | "auth_required" | null {
   const text = (message ?? "").toLowerCase();
   if (!text) return null;
@@ -1790,6 +1893,11 @@ async function defaultWsProbe(args: {
     name?: string;
     workspace?: string;
     model?: { name?: string; provider?: string };
+    availability?: {
+      available: boolean;
+      code?: "stale_config" | "probe_failed";
+      message?: string;
+    };
     botcordBinding?: { agentId: string };
   }>;
   error?: string;
@@ -2137,6 +2245,7 @@ function expandHomePath(p: string): string {
 export async function collectRuntimeSnapshotAsync(opts: {
   cfg?: { openclawGateways?: Array<{ name: string; url: string; token?: string; tokenFile?: string }> };
   wsProbe?: WsEndpointProbeFn;
+  acpAgentProbe?: OpenclawAgentAvailabilityProbeFn;
   timeoutMs?: number;
 } = {}): Promise<ListRuntimesResult> {
   const base = collectRuntimeSnapshot();
@@ -2146,6 +2255,7 @@ export async function collectRuntimeSnapshotAsync(opts: {
   // `list_runtimes` ack wait (10s, see backend/hub/routers/daemon_control.py)
   // so a single slow gateway can't blow the whole snapshot to a 504.
   const timeoutMs = opts.timeoutMs ?? 3000;
+  const acpAgentProbe = opts.acpAgentProbe ?? (opts.wsProbe ? undefined : validateOpenclawAgentProfile);
   const capped = gateways.slice(0, RUNTIME_ENDPOINTS_CAP);
   const endpoints = await Promise.all(
     capped.map(async (g) => {
@@ -2195,7 +2305,12 @@ export async function collectRuntimeSnapshotAsync(opts: {
           entry.error = res.error;
           entry.diagnostics = [{ code: "gateway_unreachable", message: res.error }];
         }
-        if (res.agents) entry.agents = annotateOpenclawAgentsWithBotcordBindings(g.name, res.agents);
+        if (res.agents) {
+          const withBindings = annotateOpenclawAgentsWithBotcordBindings(g.name, res.agents);
+          entry.agents = acpAgentProbe
+            ? await annotateOpenclawAgentsWithAvailability(g, withBindings, acpAgentProbe, timeoutMs)
+            : withBindings;
+        }
         return entry;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -2224,12 +2339,22 @@ function annotateOpenclawAgentsWithBotcordBindings(
     name?: string;
     workspace?: string;
     model?: { name?: string; provider?: string };
+    availability?: {
+      available: boolean;
+      code?: "stale_config" | "probe_failed";
+      message?: string;
+    };
   }>,
 ): Array<{
   id: string;
   name?: string;
   workspace?: string;
   model?: { name?: string; provider?: string };
+  availability?: {
+    available: boolean;
+    code?: "stale_config" | "probe_failed";
+    message?: string;
+  };
   botcordBinding?: { agentId: string };
 }> {
   const bindings = openclawBindingIndex();
@@ -2238,6 +2363,50 @@ function annotateOpenclawAgentsWithBotcordBindings(
     if (!botcordAgentId) return agent;
     return { ...agent, botcordBinding: { agentId: botcordAgentId } };
   });
+}
+
+async function annotateOpenclawAgentsWithAvailability(
+  gateway: { name: string; url: string; token?: string; tokenFile?: string },
+  agents: ReturnType<typeof annotateOpenclawAgentsWithBotcordBindings>,
+  probe: OpenclawAgentAvailabilityProbeFn,
+  timeoutMs: number,
+): Promise<ReturnType<typeof annotateOpenclawAgentsWithBotcordBindings>> {
+  const prepared = prepareGatewayProfile(gateway);
+  const checked = await Promise.all(
+    agents.map(async (agent) => {
+      try {
+        const result = await probe({
+          gateway: {
+            name: prepared.name,
+            url: prepared.url,
+            ...(prepared.resolvedToken ? { token: prepared.resolvedToken } : {}),
+          },
+          openclawAgent: agent.id,
+          cwd: agent.workspace ?? homedir(),
+          timeoutMs,
+        });
+        if (result.ok) return { ...agent, availability: { available: true } };
+        return {
+          ...agent,
+          availability: {
+            available: false,
+            code: result.code ?? "probe_failed",
+            message: result.error,
+          },
+        };
+      } catch (err) {
+        return {
+          ...agent,
+          availability: {
+            available: false,
+            code: "probe_failed" as const,
+            message: err instanceof Error ? err.message : String(err),
+          },
+        };
+      }
+    }),
+  );
+  return checked;
 }
 
 function openclawBindingIndex(): Map<string, string> {

--- a/packages/protocol-core/src/control-frame.ts
+++ b/packages/protocol-core/src/control-frame.ts
@@ -483,7 +483,7 @@ export interface RuntimeEndpointProbe {
    * Coarse diagnostic state for dashboards. `reachable` is kept for backward
    * compatibility; new clients should prefer `status` when present.
    */
-  status?: "reachable" | "unreachable" | "acp_disabled";
+  status?: "reachable" | "unreachable" | "acp_disabled" | "missing_token" | "auth_required";
   /** True when the gateway responded successfully within the timeout. */
   reachable: boolean;
   /** Gateway-reported version, when available. */
@@ -492,7 +492,7 @@ export interface RuntimeEndpointProbe {
   error?: string;
   /** Structured diagnostics for UI/tooling. */
   diagnostics?: Array<{
-    code: "gateway_unreachable" | "probe_failed" | "acp_disabled";
+    code: "gateway_unreachable" | "probe_failed" | "acp_disabled" | "missing_token" | "auth_required";
     message?: string;
   }>;
   /**
@@ -506,6 +506,16 @@ export interface RuntimeEndpointProbe {
     name?: string;
     workspace?: string;
     model?: { name?: string; provider?: string };
+    /**
+     * Runtime-level availability for this profile. `agents.list` can expose a
+     * stale profile that ACP later refuses at `session/new`; when the daemon
+     * detects that, it marks the row unavailable so dashboards can disable it.
+     */
+    availability?: {
+      available: boolean;
+      code?: "stale_config" | "probe_failed";
+      message?: string;
+    };
     /**
      * Present when this OpenClaw agent profile is already bound to a local
      * BotCord identity on the daemon. Dashboards should treat these profiles


### PR DESCRIPTION
## Summary
- validate selected OpenClaw agent profiles with ACP session creation before provisioning credentials
- surface profile availability in daemon runtime snapshots and disable stale profiles in the create-agent picker
- reject cached unavailable OpenClaw profiles in Hub provisioning and improve the dashboard error message

## Tests
- cd packages/daemon && npm test -- --run src/__tests__/runtime-discovery.test.ts src/__tests__/provision.test.ts
- cd packages/daemon && npm run build
- cd backend && uv run pytest tests/test_app/test_agent_provision.py
- cd frontend && NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build
- git diff --check