### PR TITLE
fix: route new bots to owner chat

### DIFF
--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -270,8 +270,14 @@ export default function DashboardApp() {
         const opensUserChat =
           tab === "user-chat"
           || subtab === USER_CHAT_SUBTAB
-          || (roomIdFromSubtab !== null && roomIdFromSubtab === uiStore.userChatRoomId);
+          || (roomIdFromSubtab !== null && (
+            roomIdFromSubtab === uiStore.userChatRoomId
+            || roomIdFromSubtab.startsWith("rm_oc_")
+          ));
         if (opensUserChat) {
+          if (roomIdFromSubtab?.startsWith("rm_oc_") && uiStore.userChatRoomId !== roomIdFromSubtab) {
+            uiStore.setUserChatRoomId(roomIdFromSubtab);
+          }
           if (uiStore.messagesPane !== "user-chat") uiStore.setMessagesPane("user-chat");
           if (uiStore.focusedRoomId !== null) uiStore.setFocusedRoomId(null);
           if (uiStore.openedRoomId !== null) uiStore.setOpenedRoomId(null);
@@ -314,6 +320,7 @@ export default function DashboardApp() {
     uiStore.sidebarTab,
     uiStore.messagesPane,
     uiStore.userChatRoomId,
+    uiStore.userChatAgentId,
     uiStore.exploreView,
     uiStore.contactsView,
     uiStore.setFocusedRoomId,
@@ -321,6 +328,7 @@ export default function DashboardApp() {
     uiStore.setSidebarTab,
     uiStore.clearPrimaryNavigation,
     uiStore.setMessagesPane,
+    uiStore.setUserChatRoomId,
     uiStore.setExploreView,
     uiStore.setContactsView,
     chatStore.getRoomSummary,
@@ -913,6 +921,7 @@ export default function DashboardApp() {
         chatStore.closeAgentCardState();
         uiStore.setSidebarTab("messages");
         uiStore.setMessagesPane("user-chat");
+        uiStore.setUserChatAgentId(agentId);
         uiStore.setFocusedRoomId(null);
         uiStore.setOpenedRoomId(null);
         if (agentId !== sessionStore.activeAgentId) {
@@ -1038,7 +1047,7 @@ export default function DashboardApp() {
           <MyBotsPanel />
         ) : uiStore.sidebarTab === "messages" && uiStore.messagesPane === "user-chat" ? (
           <div className="h-full min-w-0">
-            <UserChatPane />
+            <UserChatPane agentId={uiStore.userChatAgentId} />
           </div>
         ) : (
           <div className="flex h-full min-w-0">

--- a/frontend/src/components/dashboard/sidebar/index.tsx
+++ b/frontend/src/components/dashboard/sidebar/index.tsx
@@ -38,7 +38,7 @@ import MessagesPanel from "./MessagesPanel";
 import WalletPanel from "./WalletPanel";
 import { SidebarListSkeleton, SkeletonBlock } from "../DashboardTabSkeleton";
 
-import { humansApi } from "@/lib/api";
+import { api, humansApi } from "@/lib/api";
 import { UserPlus, LogIn, Bot, Plus, RefreshCw, MessageSquarePlus, Search, X } from "lucide-react";
 
 const USER_CHAT_ROUTE = "/chats/messages/__user-chat__";
@@ -155,6 +155,8 @@ export default function Sidebar({
     startPrimaryNavigation: s.startPrimaryNavigation,
     setMessagesPane: s.setMessagesPane,
     setMessagesFilter: s.setMessagesFilter,
+    setUserChatRoomId: s.setUserChatRoomId,
+    setUserChatAgentId: s.setUserChatAgentId,
     setExploreView: s.setExploreView,
     setContactsView: s.setContactsView,
     setSidebarWidth: s.setSidebarWidth,
@@ -443,10 +445,22 @@ export default function Sidebar({
             setShowCreateBot(false);
             setCreateBotForDaemonId(null);
             await sessionStore.refreshUserProfile();
-            uiStore.setSidebarTab("bots");
-            useDashboardUIStore.getState().setSelectedBotAgentId(agentId);
+            uiStore.setSidebarTab("messages");
+            uiStore.setMessagesPane("user-chat");
+            uiStore.setUserChatAgentId(agentId);
+            uiStore.setFocusedRoomId(null);
+            uiStore.setOpenedRoomId(null);
             onMobileSecondaryClose?.();
-            startTransition(() => { router.push(`/chats/bots/${encodeURIComponent(agentId)}`); });
+            try {
+              const room = await api.getUserChatRoom(agentId);
+              uiStore.setUserChatRoomId(room.room_id);
+              startTransition(() => {
+                router.push(`/chats/messages/${encodeURIComponent(room.room_id)}`);
+              });
+            } catch (error) {
+              console.error("[Sidebar] getUserChatRoom after create failed:", error);
+              startTransition(() => { router.push(USER_CHAT_ROUTE); });
+            }
           }}
         />
       )}

--- a/frontend/src/store/useDashboardUIStore.ts
+++ b/frontend/src/store/useDashboardUIStore.ts
@@ -12,6 +12,8 @@ export interface DashboardUIState {
   openedRoomId: string | null;
   /** Separate slot for the user-chat pane so it doesn't clobber openedRoomId. */
   userChatRoomId: string | null;
+  /** Agent currently targeted by the user-chat pane; independent from activeAgentId. */
+  userChatAgentId: string | null;
   rightPanelOpen: boolean;
   agentCardOpen: boolean;
   /** Dispatch slot: a component requests opening the HumanCardModal for a given human. */
@@ -78,6 +80,7 @@ export interface DashboardUIState {
   setFocusedRoomId: (roomId: string | null) => void;
   setOpenedRoomId: (roomId: string | null) => void;
   setUserChatRoomId: (roomId: string | null) => void;
+  setUserChatAgentId: (agentId: string | null) => void;
   setSidebarTab: (tab: DashboardUIState["sidebarTab"]) => void;
   startPrimaryNavigation: (tab: DashboardUIState["sidebarTab"], path: string) => void;
   clearPrimaryNavigation: () => void;
@@ -108,6 +111,7 @@ const initialUIState = {
   focusedRoomId: null,
   openedRoomId: null,
   userChatRoomId: null,
+  userChatAgentId: null,
   rightPanelOpen: false,
   agentCardOpen: false,
   pendingHumanOpen: null as { humanId: string; displayName: string } | null,
@@ -142,6 +146,8 @@ export const useDashboardUIStore = create<DashboardUIState>()((set) => ({
     set((state) => (state.openedRoomId === openedRoomId ? state : { openedRoomId })),
   setUserChatRoomId: (userChatRoomId) =>
     set((state) => (state.userChatRoomId === userChatRoomId ? state : { userChatRoomId })),
+  setUserChatAgentId: (userChatAgentId) =>
+    set((state) => (state.userChatAgentId === userChatAgentId ? state : { userChatAgentId })),
   setSidebarTab: (sidebarTab) =>
     set((state) => (
       state.sidebarTab === sidebarTab


### PR DESCRIPTION
## Summary
- route newly created bots directly to their rm_oc owner-chat URL
- treat rm_oc message routes as UserChatPane routes
- track the user-chat target agent separately from the active bot

## Tests
- cd frontend && npm run build