### PR TITLE
fix: update room controls and reset messages grouping

### DIFF
--- a/frontend/src/components/dashboard/RoomHeader.tsx
+++ b/frontend/src/components/dashboard/RoomHeader.tsx
@@ -12,7 +12,7 @@ import { common } from "@/lib/i18n/translations/common";
 import { roomList } from "@/lib/i18n/translations/dashboard";
 import { useRouter } from "nextjs-toploader/app";
 import { useShallow } from "zustand/react/shallow";
-import { ArrowLeft, Bell, Info, Loader2, PanelLeftOpen, Plus, Settings, Share2, X } from "lucide-react";
+import { ArrowLeft, Bell, Info, Loader2, PanelLeftOpen, Settings, Share2, UserPlus, X } from "lucide-react";
 import CopyableId from "@/components/ui/CopyableId";
 import { api, humansApi } from "@/lib/api";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
@@ -110,7 +110,7 @@ export default function RoomHeader() {
   const canInvite = isHumanView
     ? isOwnerOrAdmin || (Boolean(myRole) && Boolean(humanRoom?.default_invite))
     : (authRoom?.can_invite ?? true);
-  const canAddMembers = activeIdentity?.type === "human" && isOwnerOrAdmin && isJoined && !isDMRoom && !isOwnerChatRoom;
+  const canAddMembers = activeIdentity?.type === "human" && canInvite && isJoined && !isDMRoom && !isOwnerChatRoom;
   const roleLabel = myRole
     ? locale === "zh"
       ? `你是 ${myRole}`
@@ -421,7 +421,7 @@ export default function RoomHeader() {
                 className={iconBtn}
                 aria-label={locale === "zh" ? "添加房间成员" : "Add members"}
               >
-                {addMemberLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+                {addMemberLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <UserPlus className="h-4 w-4" />}
               </button>
               <span className={tooltipCls}>{locale === "zh" ? "添加房间成员" : "Add members"}</span>
             </span>


### PR DESCRIPTION
## Summary
- keep the room add-member button update on this branch
- reset Messages grouping back to self-all when opening rooms from Explore/Home discovery
- add a UI store regression test for the grouping reset

## Tests
- npm test -- dashboard-shared.test.ts useDashboardUIStore.test.ts
- npm run build (fails during /admin/codes prerender without Supabase env vars after compile/TypeScript succeeds)
- npx tsc --noEmit (blocked by existing tests/api missing module/type errors)