### PR TITLE
fix: reset and hide messages grouping

### DIFF
--- a/frontend/src/components/dashboard/ChatPane.tsx
+++ b/frontend/src/components/dashboard/ChatPane.tsx
@@ -412,8 +412,16 @@ function ExploreMainPane({ onHumanOpen }: ChatPaneProps) {
   const { authResolved } = useDashboardSessionStore(useShallow((state) => ({
     authResolved: state.authResolved,
   })));
-  const { exploreView, setExploreView, setFocusedRoomId, setOpenedRoomId, setSidebarTab } = useDashboardUIStore(useShallow((state) => ({
+  const {
+    exploreView,
+    resetMessagesGroupingForRoomOpen,
+    setExploreView,
+    setFocusedRoomId,
+    setOpenedRoomId,
+    setSidebarTab,
+  } = useDashboardUIStore(useShallow((state) => ({
     exploreView: state.exploreView,
+    resetMessagesGroupingForRoomOpen: state.resetMessagesGroupingForRoomOpen,
     setExploreView: state.setExploreView,
     setFocusedRoomId: state.setFocusedRoomId,
     setOpenedRoomId: state.setOpenedRoomId,
@@ -478,6 +486,7 @@ function ExploreMainPane({ onHumanOpen }: ChatPaneProps) {
   );
 
   const openRoomFromExplore = (room: PublicRoom) => {
+    resetMessagesGroupingForRoomOpen();
     setFocusedRoomId(room.room_id);
     setOpenedRoomId(room.room_id);
     setSidebarTab("messages");

--- a/frontend/src/components/dashboard/HomePanel.tsx
+++ b/frontend/src/components/dashboard/HomePanel.tsx
@@ -182,10 +182,11 @@ export default function HomePanel() {
       selectAgent: s.selectAgent,
     })),
   );
-  const { openCreateBotModal, requestOpenHuman, setBotDetailAgentId } = useDashboardUIStore(
+  const { openCreateBotModal, requestOpenHuman, resetMessagesGroupingForRoomOpen, setBotDetailAgentId } = useDashboardUIStore(
     useShallow((s) => ({
       openCreateBotModal: s.openCreateBotModal,
       requestOpenHuman: s.requestOpenHuman,
+      resetMessagesGroupingForRoomOpen: s.resetMessagesGroupingForRoomOpen,
       setBotDetailAgentId: s.setBotDetailAgentId,
     })),
   );
@@ -295,7 +296,10 @@ export default function HomePanel() {
                   key={room.room_id}
                   kind="room"
                   data={room}
-                  onRoomOpen={(r) => router.push(`/chats/messages/${encodeURIComponent(r.room_id)}`)}
+                  onRoomOpen={(r) => {
+                    resetMessagesGroupingForRoomOpen();
+                    router.push(`/chats/messages/${encodeURIComponent(r.room_id)}`);
+                  }}
                 />
               ))}
             </div>

--- a/frontend/src/components/dashboard/README.md
+++ b/frontend/src/components/dashboard/README.md
@@ -77,6 +77,7 @@ dashboard/
 
 ## 变更日志
 
+- 2026-05-13: `messages` 分组侧栏只在已登录状态展示；游客态保留公开消息列表，不再显示分组栏或展开分组按钮。
 - 2026-05-12: `/chats` 根入口默认选中 Home tab；消息入口仍使用 `/chats/messages`。
 - 2026-04-28: `RoomList.tsx` 与 `Sidebar.tsx` 的未读提示从蓝点改为数量徽标，后端 overview 同步返回 `unread_count`。
 - 2026-04-27: 新增 `PaidRoomPreview.tsx`，付费群未订阅视图从纯锁空态改为固定展示最近 3 条消息摘要，降低订阅前的不确定性。

--- a/frontend/src/components/dashboard/sidebar/MessagesPanel.tsx
+++ b/frontend/src/components/dashboard/sidebar/MessagesPanel.tsx
@@ -121,7 +121,7 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
       {/* Column header — peer-level to MessagesGroupingSidebar's header */}
       <div className="flex min-h-14 items-center justify-between border-b border-glass-border px-3 py-2.5">
         <div className="flex min-w-0 items-center gap-2">
-          {!messagesGroupingOpen ? (
+          {!isGuest && !messagesGroupingOpen ? (
             <button
               onClick={() => setMessagesGroupingOpen(true)}
               title="展开分组"

--- a/frontend/src/components/dashboard/sidebar/index.tsx
+++ b/frontend/src/components/dashboard/sidebar/index.tsx
@@ -276,6 +276,7 @@ export default function Sidebar({
   const secondaryPanelLoading = Boolean(
     uiStore.pendingPrimaryNavigation && uiStore.pendingPrimaryNavigation.tab === uiStore.sidebarTab,
   );
+  const showMessagesGrouping = uiStore.sidebarTab === "messages" && !isGuest && uiStore.messagesGroupingOpen;
 
   useEffect(() => {
     const prefetch = (path: string) => {
@@ -496,7 +497,7 @@ export default function Sidebar({
             : "max-md:!w-full"
         }`}
         style={{
-          width: uiStore.sidebarTab === "messages" && uiStore.messagesGroupingOpen
+          width: showMessagesGrouping
             ? uiStore.sidebarWidth + 200
             : uiStore.sidebarWidth,
           minWidth: SIDEBAR_MIN,
@@ -546,7 +547,7 @@ export default function Sidebar({
 
         {/* Panel content */}
         <div className="flex flex-1 min-h-0">
-          {!secondaryPanelLoading && uiStore.sidebarTab === "messages" && uiStore.messagesGroupingOpen && (
+          {!secondaryPanelLoading && showMessagesGrouping && (
             <MessagesGroupingSidebar />
           )}
           <div className="flex-1 overflow-y-auto">

--- a/frontend/src/store/useDashboardUIStore.test.ts
+++ b/frontend/src/store/useDashboardUIStore.test.ts
@@ -1,0 +1,22 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useDashboardUIStore } from "@/store/useDashboardUIStore";
+
+describe("useDashboardUIStore", () => {
+  beforeEach(() => {
+    useDashboardUIStore.getState().logout();
+  });
+
+  it("resets message grouping when opening a normal room from discovery", () => {
+    const store = useDashboardUIStore.getState();
+
+    store.setMessagesFilter("bots-group");
+    store.setMessagesScope({ type: "agent", id: "ag_owned" });
+    store.setMessagesBotScope("ag_owned");
+
+    useDashboardUIStore.getState().resetMessagesGroupingForRoomOpen();
+
+    expect(useDashboardUIStore.getState().messagesFilter).toBe("self-all");
+    expect(useDashboardUIStore.getState().messagesScope).toEqual({ type: "human" });
+    expect(useDashboardUIStore.getState().messagesBotScope).toBe("all");
+  });
+});

--- a/frontend/src/store/useDashboardUIStore.ts
+++ b/frontend/src/store/useDashboardUIStore.ts
@@ -93,6 +93,7 @@ export interface DashboardUIState {
   setMessagesGroupingOpen: (open: boolean) => void;
   setMessagesSearchOpen: (open: boolean) => void;
   setMessagesBotScope: (scope: DashboardUIState["messagesBotScope"]) => void;
+  resetMessagesGroupingForRoomOpen: () => void;
   /** Hides all wallet amounts behind a placeholder (default true). Toggle via the eye button on the wallet page. */
   walletAmountsHidden: boolean;
   toggleWalletAmountsHidden: () => void;
@@ -199,6 +200,22 @@ export const useDashboardUIStore = create<DashboardUIState>()((set) => ({
     set((state) => (state.messagesSearchOpen === messagesSearchOpen ? state : { messagesSearchOpen })),
   setMessagesBotScope: (messagesBotScope) =>
     set((state) => (state.messagesBotScope === messagesBotScope ? state : { messagesBotScope })),
+  resetMessagesGroupingForRoomOpen: () =>
+    set((state) => {
+      const next = {
+        messagesFilter: initialUIState.messagesFilter,
+        messagesScope: initialUIState.messagesScope,
+        messagesBotScope: initialUIState.messagesBotScope,
+      };
+      if (
+        state.messagesFilter === next.messagesFilter
+        && state.messagesScope.type === "human"
+        && state.messagesBotScope === next.messagesBotScope
+      ) {
+        return state;
+      }
+      return next;
+    }),
   toggleWalletAmountsHidden: () =>
     set((state) => ({ walletAmountsHidden: !state.walletAmountsHidden })),
   setExploreView: (exploreView) =>


### PR DESCRIPTION
## Summary
- reset Messages grouping filters when opening rooms from Explore/Home cards
- hide the Messages grouping sidebar and expand button for guest sessions
- add focused UI store coverage for grouping reset

## Tests
- npx vitest run src/store/useDashboardUIStore.test.ts

## Notes
- npm run build previously compiled and passed TypeScript, then failed during /admin/codes prerender because local Supabase URL/API key env vars are missing.