### PR TITLE
fix: guide users in empty rooms

### DIFF
--- a/frontend/src/components/dashboard/MessageList.tsx
+++ b/frontend/src/components/dashboard/MessageList.tsx
@@ -11,6 +11,7 @@ import { useEffect, useRef, useCallback, useMemo, useState } from "react";
 import { useLanguage } from '@/lib/i18n';
 import { messageList } from '@/lib/i18n/translations/dashboard';
 import { useShallow } from "zustand/react/shallow";
+import { Bot, Settings, UserPlus } from "lucide-react";
 import MessageBubble from "./MessageBubble";
 import type { DashboardMessage, PublicRoomMember, TopicInfo } from "@/lib/types";
 import type { MentionTextCandidate } from "@/components/ui/MarkdownContent";
@@ -88,6 +89,9 @@ function buildTimelineItems(
 }
 
 const TOPIC_PREVIEW_COUNT = 2;
+const PREFILL_ROOM_COMPOSER_EVENT = "botcord:prefill-room-composer";
+const OPEN_ROOM_ADD_MEMBER_EVENT = "botcord:open-room-add-member";
+const OPEN_ROOM_SETTINGS_EVENT = "botcord:open-room-settings";
 
 function messagePreviewText(msg: DashboardMessage): string {
   if (msg.text) return msg.text;
@@ -222,6 +226,90 @@ function isNearBottom(el: HTMLElement, threshold = 150): boolean {
   return el.scrollHeight - el.scrollTop - el.clientHeight < threshold;
 }
 
+function EmptyRoomGuide({
+  room,
+}: {
+  room: {
+    room_id: string;
+    member_count: number;
+    my_role?: string;
+  } | null;
+}) {
+  const locale = useLanguage();
+  const t = messageList[locale];
+  const canManageRoom = room?.my_role === "owner" || room?.my_role === "admin";
+  const hasOtherMembers = (room?.member_count ?? 0) > 1;
+  const starterPrompts = [t.emptyPromptPlan, t.emptyPromptSummary, t.emptyPromptRoles];
+
+  const prefillComposer = (text: string) => {
+    window.dispatchEvent(new CustomEvent(PREFILL_ROOM_COMPOSER_EVENT, {
+      detail: { roomId: room?.room_id, text },
+    }));
+  };
+
+  return (
+    <div className="flex flex-1 items-center justify-center overflow-y-auto px-4 py-8">
+      <div className="w-full max-w-2xl rounded-lg border border-glass-border bg-deep-black-light/70 p-5 shadow-lg shadow-black/20">
+        <div className="flex items-start gap-3">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-neon-cyan/30 bg-neon-cyan/10 text-neon-cyan">
+            <Bot className="h-5 w-5" />
+          </div>
+          <div className="min-w-0">
+            <h3 className="text-base font-semibold text-text-primary">{t.emptyTitle}</h3>
+            <p className="mt-1 text-sm leading-6 text-text-secondary">
+              {hasOtherMembers ? t.emptyGroupDesc : t.emptySoloDesc}
+            </p>
+          </div>
+        </div>
+
+        {canManageRoom && (
+          <div className="mt-4 flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => window.dispatchEvent(new CustomEvent(OPEN_ROOM_ADD_MEMBER_EVENT))}
+              className="inline-flex items-center gap-2 rounded-md border border-neon-cyan/30 bg-neon-cyan/10 px-3 py-2 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20"
+            >
+              <UserPlus className="h-4 w-4" />
+              {t.emptyAddMember}
+            </button>
+            <button
+              type="button"
+              onClick={() => window.dispatchEvent(new CustomEvent(OPEN_ROOM_SETTINGS_EVENT))}
+              className="inline-flex items-center gap-2 rounded-md border border-glass-border bg-glass-bg px-3 py-2 text-xs font-medium text-text-secondary transition-colors hover:text-text-primary"
+            >
+              <Settings className="h-4 w-4" />
+              {t.emptyRoomSettings}
+            </button>
+          </div>
+        )}
+
+        <div className="mt-5">
+          <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-text-secondary/70">
+            {t.emptyPromptLabel}
+          </p>
+          <div className="grid gap-2">
+            {starterPrompts.map((prompt) => (
+              <button
+                type="button"
+                key={prompt}
+                onClick={() => prefillComposer(prompt)}
+                className="group flex items-start justify-between gap-3 rounded-md border border-glass-border bg-deep-black px-3 py-2 text-left transition-colors hover:border-neon-cyan/40 hover:bg-neon-cyan/5"
+              >
+                <span className="min-w-0 text-sm leading-5 text-text-secondary group-hover:text-text-primary">
+                  {prompt}
+                </span>
+                <span className="shrink-0 rounded border border-neon-cyan/30 px-2 py-1 text-[11px] font-medium text-neon-cyan">
+                  {t.emptyTryPrompt}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function MessageList() {
   const locale = useLanguage();
   const t = messageList[locale];
@@ -261,7 +349,17 @@ export default function MessageList() {
   const isRoomMessagesLoading = roomId ? messagesLoading[roomId] ?? false : false;
   const hasMore = roomId ? messagesHasMore[roomId] ?? false : false;
   const currentAgentId = overview?.agent?.agent_id;
-  const currentRoomName = overview?.rooms?.find((r) => r.room_id === roomId)?.name ?? roomId ?? "";
+  const currentRoom = useMemo(() => {
+    if (!roomId) return null;
+    return (
+      overview?.rooms?.find((r) => r.room_id === roomId)
+      || publicRoomDetails[roomId]
+      || publicRooms.find((r) => r.room_id === roomId)
+      || recentVisitedRooms.find((r) => r.room_id === roomId)
+      || null
+    );
+  }, [overview?.rooms, publicRoomDetails, publicRooms, recentVisitedRooms, roomId]);
+  const currentRoomName = currentRoom?.name ?? roomId ?? "";
   const mentionCandidates = useMemo<MentionTextCandidate[]>(() => {
     const candidates: MentionTextCandidate[] = [];
     const seen = new Set<string>();
@@ -433,11 +531,7 @@ export default function MessageList() {
   }
 
   if (messages.length === 0) {
-    return (
-      <div className="flex flex-1 items-center justify-center text-sm text-text-secondary">
-        {t.noMessages}
-      </div>
-    );
+    return <EmptyRoomGuide room={currentRoom} />;
   }
 
   const newMessagesBanner = showNewMessagesBanner && (

--- a/frontend/src/components/dashboard/RoomHeader.tsx
+++ b/frontend/src/components/dashboard/RoomHeader.tsx
@@ -26,6 +26,9 @@ import RoomPolicyModal from "./RoomPolicyModal";
 import AddRoomMemberModal from "./AddRoomMemberModal";
 import { dmPeerId, resolveDmDisplayName } from "./dmRoom";
 
+const OPEN_ROOM_ADD_MEMBER_EVENT = "botcord:open-room-add-member";
+const OPEN_ROOM_SETTINGS_EVENT = "botcord:open-room-settings";
+
 export default function RoomHeader() {
   const [joinRequestStatus, setJoinRequestStatus] = useState<"idle" | "sending" | "pending" | "rejected">("idle");
   const [showRulePopover, setShowRulePopover] = useState(false);
@@ -204,6 +207,22 @@ export default function RoomHeader() {
       setShowAddMemberModal(true);
     }
   }, [activeAgentId, addMemberLoading, humanId, room?.room_id]);
+
+  useEffect(() => {
+    const openAddMember = () => {
+      if (canAddMembers) void handleOpenAddMemberModal();
+    };
+    const openSettings = () => {
+      setShowSettingsModal(true);
+    };
+
+    window.addEventListener(OPEN_ROOM_ADD_MEMBER_EVENT, openAddMember);
+    window.addEventListener(OPEN_ROOM_SETTINGS_EVENT, openSettings);
+    return () => {
+      window.removeEventListener(OPEN_ROOM_ADD_MEMBER_EVENT, openAddMember);
+      window.removeEventListener(OPEN_ROOM_SETTINGS_EVENT, openSettings);
+    };
+  }, [canAddMembers, handleOpenAddMemberModal]);
 
   if (!room) return null;
 

--- a/frontend/src/components/dashboard/RoomHumanComposer.tsx
+++ b/frontend/src/components/dashboard/RoomHumanComposer.tsx
@@ -19,6 +19,7 @@ interface RoomHumanComposerProps {
 }
 
 const ROOM_MENTION_SOURCES = ["roomMembers"] as const;
+const PREFILL_ROOM_COMPOSER_EVENT = "botcord:prefill-room-composer";
 
 interface RoomTransferDialogProps {
   members: PublicRoomMember[];
@@ -242,6 +243,8 @@ export default function RoomHumanComposer({ roomId, topicId = null }: RoomHumanC
   const [error, setError] = useState<string | null>(null);
   const [members, setMembers] = useState<PublicRoomMember[]>([]);
   const [transferOpen, setTransferOpen] = useState(false);
+  const [prefillText, setPrefillText] = useState("");
+  const [prefillNonce, setPrefillNonce] = useState(0);
   const roomMemberVersion = useDashboardChatStore(
     (s) => s.roomMemberVersions[roomId] ?? 0,
   );
@@ -297,6 +300,19 @@ export default function RoomHumanComposer({ roomId, topicId = null }: RoomHumanC
 
   const sendDenied = !isOwnerChat && !!selfId &&
     members.find((m) => m.agent_id === selfId)?.can_send === false;
+
+  useEffect(() => {
+    const handlePrefill = (event: Event) => {
+      const detail = (event as CustomEvent<{ roomId?: string; text?: string }>).detail;
+      if (detail?.roomId && detail.roomId !== roomId) return;
+      if (!detail?.text) return;
+      setPrefillText(detail.text);
+      setPrefillNonce((value) => value + 1);
+    };
+
+    window.addEventListener(PREFILL_ROOM_COMPOSER_EVENT, handlePrefill);
+    return () => window.removeEventListener(PREFILL_ROOM_COMPOSER_EVENT, handlePrefill);
+  }, [roomId]);
 
   const handleSend = useCallback(async (text: string, files: File[], mentions?: string[]) => {
     if (!text && files.length === 0) return;
@@ -380,11 +396,14 @@ export default function RoomHumanComposer({ roomId, topicId = null }: RoomHumanC
         </p>
       )}
       <MessageComposer
+        key={`${roomId}:${prefillNonce}`}
         onSend={handleSend}
         onTransfer={() => setTransferOpen(true)}
         allowAttachments
         placeholder={placeholder}
         mentionCandidates={mentionCandidates}
+        initialText={prefillText}
+        autoFocus={prefillNonce > 0}
         actionLabels={{
           add: locale === "zh" ? "添加" : "Add",
           file: locale === "zh" ? "文件" : "File",

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -1619,6 +1619,16 @@ export const messageList: TranslationMap<{
   topic: string
   viewThread: string
   moreInThread: string
+  emptyTitle: string
+  emptySoloDesc: string
+  emptyGroupDesc: string
+  emptyPromptLabel: string
+  emptyAddMember: string
+  emptyRoomSettings: string
+  emptyTryPrompt: string
+  emptyPromptPlan: string
+  emptyPromptSummary: string
+  emptyPromptRoles: string
 }> = {
   en: {
     open: 'Open',
@@ -1634,6 +1644,16 @@ export const messageList: TranslationMap<{
     topic: 'Topic',
     viewThread: 'View thread',
     moreInThread: 'more in thread',
+    emptyTitle: 'Start this room',
+    emptySoloDesc: 'Invite a Bot or teammate, set the room goal, then send a starter message.',
+    emptyGroupDesc: 'This room is ready. Send a starter message so the Bots know what to work on.',
+    emptyPromptLabel: 'Starter prompts',
+    emptyAddMember: 'Add Bot or member',
+    emptyRoomSettings: 'Room settings',
+    emptyTryPrompt: 'Use prompt',
+    emptyPromptPlan: '@all Help me turn this room into a working plan. Ask clarifying questions, then propose next steps.',
+    emptyPromptSummary: '@all Please introduce what you can help with in this room and suggest three useful tasks to start.',
+    emptyPromptRoles: '@all Based on this room goal, suggest roles, owners, and a first checklist.',
   },
   zh: {
     open: '进行中',
@@ -1649,6 +1669,16 @@ export const messageList: TranslationMap<{
     topic: '话题',
     viewThread: '查看话题',
     moreInThread: '条消息在话题中',
+    emptyTitle: '启动这个房间',
+    emptySoloDesc: '先邀请 Bot 或成员，设置房间目标，然后发一条开场消息。',
+    emptyGroupDesc: '房间已经准备好。发一条开场消息，让 Bot 知道要做什么。',
+    emptyPromptLabel: '开场 Prompt',
+    emptyAddMember: '添加 Bot 或成员',
+    emptyRoomSettings: '房间设置',
+    emptyTryPrompt: '使用',
+    emptyPromptPlan: '@all 帮我把这个房间变成可执行计划。先问必要的澄清问题，再给出下一步。',
+    emptyPromptSummary: '@all 请介绍你们在这个房间里能帮我做什么，并建议 3 个适合马上开始的任务。',
+    emptyPromptRoles: '@all 根据这个房间目标，建议分工、负责人和第一版 checklist。',
   },
 }
 


### PR DESCRIPTION
## Summary
- replace the blank empty-room message with a starter guide
- add quick actions for adding members and opening room settings
- add starter prompts that prefill and focus the room composer

## Tests
- npm run build (compilation and TypeScript completed; prerender failed on /admin/codes because Supabase URL/API key env vars are not configured locally)