### PR TITLE
fix: defer room loading until messages navigation

### DIFF
--- a/frontend/src/components/dashboard/BotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/BotDetailDrawer.tsx
@@ -115,6 +115,7 @@ export default function BotDetailDrawer() {
     setMessagesPane,
     setMessagesFilter,
     setMessagesBotScope,
+    startPrimaryNavigation,
   } = useDashboardUIStore(
     useShallow((s) => ({
       botDetailAgentId: s.botDetailAgentId,
@@ -128,6 +129,7 @@ export default function BotDetailDrawer() {
       setMessagesPane: s.setMessagesPane,
       setMessagesFilter: s.setMessagesFilter,
       setMessagesBotScope: s.setMessagesBotScope,
+      startPrimaryNavigation: s.startPrimaryNavigation,
     })),
   );
   const { activeAgentId, ownedAgents } = useDashboardSessionStore(
@@ -218,15 +220,11 @@ export default function BotDetailDrawer() {
   // scope so the Messages list narrows to this bot's rooms, then opens the room.
   const jumpToBotConversation = (roomId: string | null) => {
     setBotDetailAgentId(null);
-    setSidebarTab("messages");
     setMessagesFilter("bots-all");
     setMessagesBotScope(bot.agent_id);
-    if (roomId) {
-      setOpenedRoomId(roomId);
-      router.push(`/chats/messages/${encodeURIComponent(roomId)}`);
-    } else {
-      router.push("/chats/messages");
-    }
+    const path = roomId ? `/chats/messages/${encodeURIComponent(roomId)}` : "/chats/messages";
+    startPrimaryNavigation("messages", path);
+    router.push(path);
   };
 
   return (

--- a/frontend/src/components/dashboard/ChatPane.tsx
+++ b/frontend/src/components/dashboard/ChatPane.tsx
@@ -49,16 +49,12 @@ function ContactsMainPane({ onHumanOpen }: { onHumanOpen?: (human: PublicHumanPr
   const router = useRouter();
   const locale = useLanguage();
   const t = chatPane[locale];
-  const { contactsView, setFocusedRoomId, setOpenedRoomId, setSidebarTab } = useDashboardUIStore(useShallow((state) => ({
+  const { contactsView, startPrimaryNavigation } = useDashboardUIStore(useShallow((state) => ({
     contactsView: state.contactsView,
-    setFocusedRoomId: state.setFocusedRoomId,
-    setOpenedRoomId: state.setOpenedRoomId,
-    setSidebarTab: state.setSidebarTab,
+    startPrimaryNavigation: state.startPrimaryNavigation,
   })));
-  const { overview, messages, loadRoomMessages, selectAgent, refreshOverview } = useDashboardChatStore(useShallow((state) => ({
+  const { overview, selectAgent, refreshOverview } = useDashboardChatStore(useShallow((state) => ({
     overview: state.overview,
-    messages: state.messages,
-    loadRoomMessages: state.loadRoomMessages,
     selectAgent: state.selectAgent,
     refreshOverview: state.refreshOverview,
   })));
@@ -155,13 +151,9 @@ function ContactsMainPane({ onHumanOpen }: { onHumanOpen?: (human: PublicHumanPr
         : filteredContacts;
 
   const openJoinedRoom = (roomId: string) => {
-    setFocusedRoomId(roomId);
-    setOpenedRoomId(roomId);
-    setSidebarTab("messages");
-    router.push(`/chats/messages/${encodeURIComponent(roomId)}`);
-    if (!messages[roomId]) {
-      void loadRoomMessages(roomId);
-    }
+    const path = `/chats/messages/${encodeURIComponent(roomId)}`;
+    startPrimaryNavigation("messages", path);
+    startTransition(() => router.push(path));
   };
 
   return (
@@ -416,16 +408,12 @@ function ExploreMainPane({ onHumanOpen }: ChatPaneProps) {
     exploreView,
     resetMessagesGroupingForRoomOpen,
     setExploreView,
-    setFocusedRoomId,
-    setOpenedRoomId,
-    setSidebarTab,
+    startPrimaryNavigation,
   } = useDashboardUIStore(useShallow((state) => ({
     exploreView: state.exploreView,
     resetMessagesGroupingForRoomOpen: state.resetMessagesGroupingForRoomOpen,
     setExploreView: state.setExploreView,
-    setFocusedRoomId: state.setFocusedRoomId,
-    setOpenedRoomId: state.setOpenedRoomId,
-    setSidebarTab: state.setSidebarTab,
+    startPrimaryNavigation: state.startPrimaryNavigation,
   })));
   const {
     publicRooms,
@@ -434,11 +422,9 @@ function ExploreMainPane({ onHumanOpen }: ChatPaneProps) {
     publicAgentsLoading,
     publicHumans,
     publicHumansLoading,
-    messages,
     loadPublicRooms,
     loadPublicAgents,
     loadPublicHumans,
-    loadRoomMessages,
     selectAgent,
     addRecentPublicRoom,
   } = useDashboardChatStore(useShallow((state) => ({
@@ -448,11 +434,9 @@ function ExploreMainPane({ onHumanOpen }: ChatPaneProps) {
     publicAgentsLoading: state.publicAgentsLoading,
     publicHumans: state.publicHumans,
     publicHumansLoading: state.publicHumansLoading,
-    messages: state.messages,
     loadPublicRooms: state.loadPublicRooms,
     loadPublicAgents: state.loadPublicAgents,
     loadPublicHumans: state.loadPublicHumans,
-    loadRoomMessages: state.loadRoomMessages,
     selectAgent: state.selectAgent,
     addRecentPublicRoom: state.addRecentPublicRoom,
   })));
@@ -486,15 +470,11 @@ function ExploreMainPane({ onHumanOpen }: ChatPaneProps) {
   );
 
   const openRoomFromExplore = (room: PublicRoom) => {
+    const path = `/chats/messages/${encodeURIComponent(room.room_id)}`;
     resetMessagesGroupingForRoomOpen();
-    setFocusedRoomId(room.room_id);
-    setOpenedRoomId(room.room_id);
-    setSidebarTab("messages");
-    router.push(`/chats/messages/${encodeURIComponent(room.room_id)}`);
+    startPrimaryNavigation("messages", path);
     addRecentPublicRoom(room);
-    if (!messages[room.room_id]) {
-      void loadRoomMessages(room.room_id);
-    }
+    startTransition(() => router.push(path));
   };
 
   const openHumanOwnerFromAgent = async (humanId: string) => {

--- a/frontend/src/components/dashboard/ContactsDetailPane.tsx
+++ b/frontend/src/components/dashboard/ContactsDetailPane.tsx
@@ -97,8 +97,7 @@ export default function ContactsDetailPane() {
   const selectedContactKey = useDashboardUIStore((s) => s.selectedContactKey);
   const setBotDetailAgentId = useDashboardUIStore((s) => s.setBotDetailAgentId);
   const setPeerBotAgentId = useDashboardUIStore((s) => s.setPeerBotAgentId);
-  const setSidebarTab = useDashboardUIStore((s) => s.setSidebarTab);
-  const setOpenedRoomId = useDashboardUIStore((s) => s.setOpenedRoomId);
+  const startPrimaryNavigation = useDashboardUIStore((s) => s.startPrimaryNavigation);
   const { ownedAgents, humanRooms } = useDashboardSessionStore(
     useShallow((s) => ({ ownedAgents: s.ownedAgents, humanRooms: s.humanRooms })),
   );
@@ -202,13 +201,9 @@ export default function ContactsDetailPane() {
         roomId = dm?.room_id ?? null;
       }
     }
-    setSidebarTab("messages");
-    if (roomId) {
-      setOpenedRoomId(roomId);
-      router.push(`/chats/messages/${encodeURIComponent(roomId)}`);
-    } else {
-      router.push("/chats/messages");
-    }
+    const path = roomId ? `/chats/messages/${encodeURIComponent(roomId)}` : "/chats/messages";
+    startPrimaryNavigation("messages", path);
+    router.push(path);
   };
 
   return (

--- a/frontend/src/components/dashboard/PeerBotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/PeerBotDetailDrawer.tsx
@@ -30,12 +30,11 @@ function formatDate(iso?: string): string {
  */
 export default function PeerBotDetailDrawer() {
   const router = useRouter();
-  const { peerBotAgentId, setPeerBotAgentId, setSidebarTab, setOpenedRoomId } = useDashboardUIStore(
+  const { peerBotAgentId, setPeerBotAgentId, startPrimaryNavigation } = useDashboardUIStore(
     useShallow((s) => ({
       peerBotAgentId: s.peerBotAgentId,
       setPeerBotAgentId: s.setPeerBotAgentId,
-      setSidebarTab: s.setSidebarTab,
-      setOpenedRoomId: s.setOpenedRoomId,
+      startPrimaryNavigation: s.startPrimaryNavigation,
     })),
   );
   const { overview, publicAgents } = useDashboardChatStore(
@@ -75,13 +74,9 @@ export default function PeerBotDetailDrawer() {
       (r) => r.owner_id === agentId && (r.peer_type ?? r.owner_type) === "agent",
     );
     setPeerBotAgentId(null);
-    setSidebarTab("messages");
-    if (dm) {
-      setOpenedRoomId(dm.room_id);
-      router.push(`/chats/messages/${encodeURIComponent(dm.room_id)}`);
-    } else {
-      router.push("/chats/messages");
-    }
+    const path = dm ? `/chats/messages/${encodeURIComponent(dm.room_id)}` : "/chats/messages";
+    startPrimaryNavigation("messages", path);
+    router.push(path);
   };
 
   const handleAddContact = async () => {

--- a/frontend/src/components/dashboard/PublicRoomList.tsx
+++ b/frontend/src/components/dashboard/PublicRoomList.tsx
@@ -1,5 +1,5 @@
 /**
- * [INPUT]: 依赖 ui/chat store 的公开房间列表与消息加载动作，依赖 SubscriptionBadge 呈现付费房间标记
+ * [INPUT]: 依赖 ui/chat store 的公开房间列表与路由导航动作，依赖 SubscriptionBadge 呈现付费房间标记
  * [OUTPUT]: 对外提供 PublicRoomList 组件，渲染游客可浏览的公开房间列表
  * [POS]: dashboard 左侧公开房间列表视图，被游客模式与 explore 相关入口复用
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
@@ -23,24 +23,18 @@ export default function PublicRoomList() {
   const {
     publicRooms,
     publicRoomsLoading,
-    messages,
-    loadRoomMessages,
     loadPublicRooms,
     addRecentPublicRoom,
   } = useDashboardChatStore(useShallow((state) => ({
     publicRooms: state.publicRooms,
     publicRoomsLoading: state.publicRoomsLoading,
-    messages: state.messages,
-    loadRoomMessages: state.loadRoomMessages,
     loadPublicRooms: state.loadPublicRooms,
     addRecentPublicRoom: state.addRecentPublicRoom,
   })));
-  const { focusedRoomId, setFocusedRoomId, setOpenedRoomId, setSidebarTab } = useDashboardUIStore(
+  const { focusedRoomId, startPrimaryNavigation } = useDashboardUIStore(
     useShallow((state) => ({
       focusedRoomId: state.focusedRoomId,
-      setFocusedRoomId: state.setFocusedRoomId,
-      setOpenedRoomId: state.setOpenedRoomId,
-      setSidebarTab: state.setSidebarTab,
+      startPrimaryNavigation: state.startPrimaryNavigation,
     })),
   );
 
@@ -62,16 +56,12 @@ export default function PublicRoomList() {
 
   const handleSelect = (roomId: string) => {
     const room = publicRooms.find((item) => item.room_id === roomId);
-    setFocusedRoomId(roomId);
-    setOpenedRoomId(roomId);
-    setSidebarTab("messages");
-    router.push(`/chats/messages/${encodeURIComponent(roomId)}`);
+    const path = `/chats/messages/${encodeURIComponent(roomId)}`;
+    startPrimaryNavigation("messages", path);
     if (room) {
       addRecentPublicRoom(room);
     }
-    if (!messages[roomId]) {
-      void loadRoomMessages(roomId);
-    }
+    router.push(path);
   };
 
   return (

--- a/frontend/src/components/dashboard/SubscriptionBadge.tsx
+++ b/frontend/src/components/dashboard/SubscriptionBadge.tsx
@@ -66,14 +66,12 @@ export default function SubscriptionBadge({
     activeIdentityType: state.activeIdentity?.type ?? null,
   })));
   const isAgentMode = activeIdentityType === "agent" && !!activeAgentId;
-  const { joinRoom, loadRoomMessages } = useDashboardChatStore(useShallow((state) => ({
+  const { joinRoom } = useDashboardChatStore(useShallow((state) => ({
     joinRoom: state.joinRoom,
-    loadRoomMessages: state.loadRoomMessages,
   })));
-  const { setOpenedRoomId, setFocusedRoomId, setSidebarTab } = useDashboardUIStore(useShallow((state) => ({
-    setOpenedRoomId: state.setOpenedRoomId,
-    setFocusedRoomId: state.setFocusedRoomId,
+  const { setSidebarTab, startPrimaryNavigation } = useDashboardUIStore(useShallow((state) => ({
     setSidebarTab: state.setSidebarTab,
+    startPrimaryNavigation: state.startPrimaryNavigation,
   })));
   const {
     getActiveSubscription,
@@ -190,11 +188,9 @@ export default function SubscriptionBadge({
       }
       if (roomId) {
         await joinRoom(roomId);
-        setFocusedRoomId(roomId);
-        setOpenedRoomId(roomId);
-        setSidebarTab("messages");
-        loadRoomMessages(roomId);
-        router.push(`/chats/messages/${encodeURIComponent(roomId)}`);
+        const path = `/chats/messages/${encodeURIComponent(roomId)}`;
+        startPrimaryNavigation("messages", path);
+        router.push(path);
       }
       setShowModal(false);
     } catch (err) {

--- a/frontend/src/components/dashboard/sidebar/index.tsx
+++ b/frontend/src/components/dashboard/sidebar/index.tsx
@@ -436,13 +436,12 @@ export default function Sidebar({
           onClose={() => setShowCreateRoom(false)}
           onCreated={(room) => {
             setShowCreateRoom(false);
-            uiStore.setSidebarTab("messages");
             uiStore.setMessagesPane("room");
             uiStore.setMessagesFilter("self-all");
-            uiStore.setFocusedRoomId(room.room_id);
-            uiStore.setOpenedRoomId(room.room_id);
+            const path = `/chats/messages/${encodeURIComponent(room.room_id)}`;
+            uiStore.startPrimaryNavigation("messages", path);
             onMobileSecondaryClose?.();
-            router.push(`/chats/messages/${encodeURIComponent(room.room_id)}`);
+            startTransition(() => { router.push(path); });
           }}
         />
       )}


### PR DESCRIPTION
## Summary
- Route cross-tab room open actions through the messages navigation pending state before selecting the room
- Defer opened room state and message loading to the /chats/messages/:roomId route sync effect
- Keep latest messages grouping reset behavior when opening rooms from Explore

## Testing
- npm run build (passes compile and TypeScript; fails during prerender of /admin/codes because local Supabase URL/API key env vars are missing)