### PR TITLE
fix: include dashboard room member previews

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -199,6 +199,7 @@ async def _build_rooms_from_sql(
             "default_invite",
             "max_members",
             "slow_mode_seconds",
+            "members_preview",
         )
         for item in mapped:
             room_id = item.get("room_id")
@@ -297,6 +298,68 @@ async def _build_room_unread_counts(
     return counts
 
 
+async def _build_member_previews(
+    db: AsyncSession,
+    room_ids: list[str],
+) -> dict[str, list[dict[str, str | None]]]:
+    """Build top member previews for room list composite avatars."""
+    if not room_ids:
+        return {}
+
+    rows = await db.execute(
+        select(
+            RoomMember.room_id,
+            RoomMember.agent_id,
+            RoomMember.participant_type,
+        )
+        .where(RoomMember.room_id.in_(room_ids))
+        .order_by(RoomMember.room_id, RoomMember.joined_at)
+    )
+    buckets: dict[str, list[tuple[str, ParticipantType]]] = {}
+    for rid, pid, ptype in rows.all():
+        bucket = buckets.setdefault(rid, [])
+        if len(bucket) < 4:
+            bucket.append((pid, ptype))
+
+    agent_ids: set[str] = set()
+    human_ids: set[str] = set()
+    for entries in buckets.values():
+        for pid, ptype in entries:
+            if ptype == ParticipantType.human:
+                human_ids.add(pid)
+            else:
+                agent_ids.add(pid)
+
+    agent_info: dict[str, tuple[str, str | None]] = {}
+    if agent_ids:
+        ar = await db.execute(
+            select(Agent.agent_id, Agent.display_name, Agent.avatar_url)
+            .where(Agent.agent_id.in_(agent_ids))
+        )
+        agent_info = {aid: (name, avatar) for aid, name, avatar in ar.all()}
+
+    human_info: dict[str, tuple[str, str | None]] = {}
+    if human_ids:
+        hr = await db.execute(
+            select(User.human_id, User.display_name, User.avatar_url)
+            .where(User.human_id.in_(human_ids))
+        )
+        human_info = {hid: (name, avatar) for hid, name, avatar in hr.all()}
+
+    out: dict[str, list[dict[str, str | None]]] = {}
+    for rid, entries in buckets.items():
+        items: list[dict[str, str | None]] = []
+        for pid, ptype in entries:
+            if ptype == ParticipantType.human:
+                name, avatar = human_info.get(pid, (pid, None))
+                items.append({"display_name": name, "avatar_url": avatar, "agent_id": None})
+            else:
+                name, avatar = agent_info.get(pid, (pid, None))
+                items.append({"display_name": name, "avatar_url": avatar, "agent_id": pid})
+        out[rid] = items
+    return out
+
+
 async def _build_rooms_from_membership(
     agent_id: str,
     db: AsyncSession,
@@ -324,6 +387,7 @@ async def _build_rooms_from_membership(
         .group_by(RoomMember.room_id)
     )
     member_counts = dict(count_result.all())
+    members_preview = await _build_member_previews(db, room_ids)
 
     dedup_sub = (
         select(
@@ -441,6 +505,7 @@ async def _build_rooms_from_membership(
             "visibility": room.visibility.value if hasattr(room.visibility, "value") else str(room.visibility),
             "join_policy": room.join_policy.value if hasattr(room.join_policy, "value") else str(room.join_policy),
             "member_count": member_counts.get(rid, 0),
+            "members_preview": members_preview.get(rid) if member_counts.get(rid, 0) > 2 else None,
             "my_role": my_role,
             "can_invite": computed_can_invite,
             "allow_human_send": room.allow_human_send,

--- a/backend/tests/test_app/test_app_dashboard.py
+++ b/backend/tests/test_app/test_app_dashboard.py
@@ -285,6 +285,62 @@ async def test_dashboard_overview_includes_unread_count(
 
 
 @pytest.mark.asyncio
+async def test_dashboard_overview_includes_members_preview_for_group_room(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    seed_data: dict,
+):
+    db_session.add_all([
+        Agent(
+            agent_id="ag_groupmate01",
+            display_name="Group Mate",
+            message_policy=MessagePolicy.open,
+        ),
+        User(
+            id=uuid.uuid4(),
+            human_id="hu_groupmate01",
+            display_name="Human Mate",
+            avatar_url="https://example.test/human.png",
+            email="human@example.test",
+            status="active",
+            supabase_user_id=uuid.uuid4(),
+        ),
+    ])
+    await db_session.flush()
+    db_session.add_all([
+        RoomMember(
+            room_id="rm_testroom001",
+            agent_id="ag_groupmate01",
+            participant_type=ParticipantType.agent,
+            role=RoomRole.member,
+        ),
+        RoomMember(
+            room_id="rm_testroom001",
+            agent_id="hu_groupmate01",
+            participant_type=ParticipantType.human,
+            role=RoomRole.member,
+        ),
+    ])
+    await db_session.commit()
+
+    resp = await client.get(
+        "/api/dashboard/overview",
+        headers={
+            "Authorization": f"Bearer {seed_data['token']}",
+            "X-Active-Agent": "ag_dashtest001",
+        },
+    )
+    assert resp.status_code == 200
+    room = resp.json()["rooms"][0]
+    assert room["member_count"] == 3
+    assert room["members_preview"] == [
+        {"agent_id": "ag_dashtest001", "avatar_url": None, "display_name": "Dashboard Agent"},
+        {"agent_id": "ag_groupmate01", "avatar_url": None, "display_name": "Group Mate"},
+        {"agent_id": None, "avatar_url": "https://example.test/human.png", "display_name": "Human Mate"},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_dashboard_overview_human_mode(
     client: AsyncClient, seed_data: dict
 ):


### PR DESCRIPTION
## Summary
- add members_preview to /api/dashboard/overview room rows for group avatars
- merge fallback preview data into SQL-backed overview rows
- cover group room member previews in app dashboard tests

## Tests
- cd backend && uv run pytest tests/test_app/test_app_dashboard.py -q