### PR TITLE
fix: constrain create bot dialog height

### DIFF
--- a/frontend/src/components/dashboard/CreateAgentDialog.tsx
+++ b/frontend/src/components/dashboard/CreateAgentDialog.tsx
@@ -386,7 +386,7 @@ export default function CreateAgentDialog({
 
   return (
     <div className="fixed inset-0 z-[110] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm">
-      <div className="relative w-full max-w-lg rounded-2xl border border-glass-border bg-deep-black-light p-5 shadow-2xl">
+      <div className="relative max-h-[calc(100dvh-2rem)] w-full max-w-lg overflow-y-auto overscroll-contain rounded-2xl border border-glass-border bg-deep-black-light p-5 shadow-2xl">
         <button
           onClick={onClose}
           disabled={submitting}


### PR DESCRIPTION
## Summary
- limit the Create Bot dialog height to the viewport
- allow overflowing dialog content to scroll inside the modal

## Test plan
- `cd frontend && npm run build` *(fails during prerender of `/admin/codes` because Supabase URL/API key env vars are not configured locally; compile and TypeScript completed before that)*