### PR TITLE
fix: sanitize Supabase storage object keys

### DIFF
--- a/backend/hub/storage.py
+++ b/backend/hub/storage.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import quote
@@ -44,7 +45,7 @@ async def store_file(
 
     if hub_config.FILE_STORAGE_BACKEND == "supabase":
         _validate_supabase_config()
-        object_key = f"{file_id}/{original_filename}"
+        object_key = f"{file_id}/{_storage_object_filename(original_filename)}"
         await _supabase_request(
             "POST",
             f"/storage/v1/object/{_quoted_bucket_and_key(hub_config.SUPABASE_STORAGE_BUCKET, object_key)}",
@@ -120,6 +121,17 @@ def _write_file(path: str, data: bytes) -> None:
 def _read_file(path: str) -> bytes:
     with open(path, "rb") as f:
         return f.read()
+
+
+def _storage_object_filename(original_filename: str) -> str:
+    """Return an ASCII-only object key segment accepted by Supabase Storage."""
+    name = os.path.basename(original_filename).strip()[:200] or "upload"
+    stem, ext = os.path.splitext(name)
+    safe_stem = re.sub(r"[^A-Za-z0-9._-]+", "-", stem)
+    safe_stem = re.sub(r"-+", "-", safe_stem).strip("._-")
+    safe_ext = re.sub(r"[^A-Za-z0-9.]+", "", ext)[:32]
+    safe_name = f"{safe_stem or 'upload'}{safe_ext}"
+    return safe_name[:200] or "upload"
 
 
 def _validate_supabase_config() -> None:

--- a/backend/tests/test_files.py
+++ b/backend/tests/test_files.py
@@ -293,6 +293,45 @@ async def test_upload_success_supabase(client: AsyncClient, db_session: AsyncSes
     assert record.storage_object_key == f"{data['file_id']}/report.pdf"
 
 
+@pytest.mark.asyncio
+async def test_upload_supabase_uses_ascii_storage_key_for_unicode_filename(
+    client: AsyncClient,
+    db_session: AsyncSession,
+):
+    from sqlalchemy import select as sa_select
+
+    _enable_supabase_storage()
+    sk, pubkey = _make_keypair()
+    _, _, token = await _register_and_verify(client, sk, pubkey)
+
+    with patch("hub.storage._supabase_request", new=AsyncMock(return_value=_supabase_response())) as mock_request:
+        resp = await client.post(
+            "/hub/upload",
+            headers=_auth_header(token),
+            files={
+                "file": (
+                    "BotLearn-完整战略蓝图-v4.0.md",
+                    io.BytesIO(b"# plan"),
+                    "text/markdown",
+                )
+            },
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["original_filename"] == "BotLearn-完整战略蓝图-v4.0.md"
+
+    result = await db_session.execute(
+        sa_select(FileRecord).where(FileRecord.file_id == data["file_id"])
+    )
+    record = result.scalar_one()
+    assert record.storage_object_key == f"{data['file_id']}/BotLearn-v4.0.md"
+
+    path = mock_request.await_args.args[1]
+    assert path.endswith(f"/{data['file_id']}/BotLearn-v4.0.md")
+    assert "完整战略蓝图" not in path
+
+
 # ===========================================================================
 # Download tests
 # ===========================================================================


### PR DESCRIPTION
## Summary
- sanitize Supabase Storage object key filenames to ASCII-safe segments
- preserve the original uploaded filename in metadata and API responses
- add coverage for Unicode filenames that previously caused Supabase InvalidKey errors

## Test
- cd backend && uv run pytest tests/test_files.py -q