### PR TITLE
fix: improve daemon ACP handling and discovery

### DIFF
--- a/packages/daemon/src/__tests__/openclaw-acp.test.ts
+++ b/packages/daemon/src/__tests__/openclaw-acp.test.ts
@@ -202,6 +202,45 @@ describe("OpenclawAcpAdapter.run", () => {
     expect(res.error).toContain("Missing env var FOO_API_KEY");
   });
 
+  it("treats end_turn with warning-only stdout as an empty reply, not an error", async () => {
+    const child = new FakeChild();
+    const adapter = new OpenclawAcpAdapter({ spawnFn: makeSpawn(child) });
+    const gateway: ResolvedOpenclawGateway = {
+      name: "local",
+      url: "ws://127.0.0.1:1",
+      openclawAgent: "main",
+    };
+
+    child.stdin.on("data", (chunk: Buffer) => {
+      for (const line of chunk.toString("utf8").split("\n").filter(Boolean)) {
+        const frame = JSON.parse(line);
+        if (frame.method === "initialize") {
+          child.stdout.write("◇  Config warnings ─────────────────────╮\n");
+          child.stdout.write("│  - plugins.allow: plugin not installed: brave │\n");
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { protocolVersion: 1 } }) + "\n");
+        } else if (frame.method === "session/new") {
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { sessionId: "sid-warn-end" } }) + "\n");
+        } else if (frame.method === "session/prompt") {
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { stopReason: "end_turn" } }) + "\n");
+        }
+      }
+    });
+
+    const res = await adapter.run({
+      text: "hi",
+      sessionId: null,
+      cwd: "/tmp",
+      accountId: "ag_alice",
+      signal: new AbortController().signal,
+      trustLevel: "owner",
+      gateway,
+    });
+
+    expect(res.text).toBe("");
+    expect(res.newSessionId).toBe("sid-warn-end");
+    expect(res.error).toBeUndefined();
+  });
+
   it("streams only final text when OpenClaw sends reasoning before a final block", async () => {
     const child = new FakeChild();
     const adapter = new OpenclawAcpAdapter({ spawnFn: makeSpawn(child) });

--- a/packages/daemon/src/__tests__/openclaw-discovery.test.ts
+++ b/packages/daemon/src/__tests__/openclaw-discovery.test.ts
@@ -156,6 +156,7 @@ describe("discoverLocalOpenclawGateways", () => {
 
     expect(found).toEqual([
       expect.objectContaining({
+        name: "qclaw-127-0-0-1-28789",
         url: "ws://127.0.0.1:28789",
         token: "qclaw-token",
         source: "config-file",

--- a/packages/daemon/src/diagnostics.ts
+++ b/packages/daemon/src/diagnostics.ts
@@ -14,6 +14,7 @@ import {
   PID_PATH,
   SNAPSHOT_PATH,
   loadConfig,
+  saveConfig,
   type DaemonConfig,
 } from "./config.js";
 import { listDaemonLogFiles, LOG_FILE_PATH, type LogFileEntry } from "./log.js";
@@ -26,6 +27,12 @@ import {
   type DoctorRuntimeEntry,
 } from "./doctor.js";
 import { detectRuntimes } from "./adapters/runtimes.js";
+import { log as daemonLog } from "./log.js";
+import {
+  discoverLocalOpenclawGateways,
+  mergeOpenclawGateways,
+  openclawDiscoveryConfigEnabled,
+} from "./openclaw-discovery.js";
 
 const DIAGNOSTICS_DIR = path.join(homedir(), ".botcord", "diagnostics");
 const MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
@@ -124,6 +131,7 @@ async function buildDoctorEntries(): Promise<{
   let cfgForEndpoints: DaemonConfig | null = null;
   try {
     cfgForEndpoints = loadConfig();
+    cfgForEndpoints = await refreshDiscoveredOpenclawGateways(cfgForEndpoints);
     channels = channelsFromDaemonConfig(cfgForEndpoints);
   } catch {
     channels = [];
@@ -145,6 +153,31 @@ async function buildDoctorEntries(): Promise<{
     timeoutMs: 5_000,
   });
   return { text: renderDoctor(input), json: input };
+}
+
+async function refreshDiscoveredOpenclawGateways(cfg: DaemonConfig): Promise<DaemonConfig> {
+  if (!openclawDiscoveryConfigEnabled(cfg)) return cfg;
+  try {
+    const found = await discoverLocalOpenclawGateways({
+      searchPaths: cfg.openclawDiscovery?.searchPaths,
+      defaultPorts: cfg.openclawDiscovery?.defaultPorts,
+      timeoutMs: 500,
+    });
+    const merged = mergeOpenclawGateways(cfg, found);
+    if (!merged.changed) return cfg;
+    saveConfig(merged.cfg);
+    daemonLog.info("openclaw discovery: gateways merged", {
+      source: "diagnostics",
+      added: merged.added.map((g) => ({ name: g.name, url: g.url })),
+    });
+    return merged.cfg;
+  } catch (err) {
+    daemonLog.warn("openclaw discovery failed; continuing", {
+      source: "diagnostics",
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return cfg;
+  }
 }
 
 function crc32(buf: Buffer): number {

--- a/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
+++ b/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
@@ -344,6 +344,32 @@ describe("Dispatcher", () => {
     expect(store.all().length).toBe(0);
   });
 
+  it("drops the stored session when a resumed turn errors without text even if the adapter returns the same id", async () => {
+    let callNo = 0;
+    const runtimeFactory: RuntimeFactory = () => {
+      callNo += 1;
+      if (callNo === 1) return new FakeRuntime({ reply: "ok", newSessionId: "sid-1" });
+      return new FakeRuntime({
+        reply: "",
+        newSessionId: "sid-1",
+        errorText: "acp error -32603: Internal error",
+      });
+    };
+    const { dispatcher, store, channel } = await scaffold({ runtimeFactory });
+
+    await dispatcher.handle(
+      makeEnvelope({ id: "msg_1", conversation: { id: "rm_x", kind: "direct" } }),
+    );
+    expect(store.all()[0].runtimeSessionId).toBe("sid-1");
+
+    await dispatcher.handle(
+      makeEnvelope({ id: "msg_2", conversation: { id: "rm_x", kind: "direct" } }),
+    );
+
+    expect(store.all().length).toBe(0);
+    expect(channel.sends[0].message.type).toBe("error");
+  });
+
   it("applies composeUserTurn before handing text to the runtime", async () => {
     const runtime = new FakeRuntime({ reply: "ok", newSessionId: "sid-1" });
     const { store, dir } = await makeStore();

--- a/packages/daemon/src/gateway/__tests__/hermes-agent-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/hermes-agent-adapter.test.ts
@@ -183,6 +183,33 @@ describe("HermesAgentAdapter", () => {
     expect(res.error).toBeUndefined();
   });
 
+  it("drains late assistant text after a prompt RPC error before closing stdin", async () => {
+    const script = makeAcpServer(
+      "late-after-error.js",
+      `
+        if (msg.method === "initialize") {
+          reply(msg, { protocolVersion: 1 });
+        } else if (msg.method === "session/new") {
+          reply(msg, { sessionId: "sess-late-error" });
+        } else if (msg.method === "session/prompt") {
+          err(msg, -32603, "Internal error");
+          setTimeout(() => {
+            notify("session/update", {
+              sessionId: msg.params.sessionId,
+              update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "late but valid" } }
+            });
+            process.exit(0);
+          }, 25);
+        }
+      `,
+    );
+
+    const res = await runAdapter(script);
+    expect(res.newSessionId).toBe("sess-late-error");
+    expect(res.text).toBe("late but valid");
+    expect(res.error).toContain("acp error -32603");
+  });
+
   it("owner trust → request_permission selects an allow_* option", async () => {
     const script = makeAcpServer(
       "perm-allow.js",

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -1329,16 +1329,34 @@ export class Dispatcher {
 
       if (!result) return;
 
+      const replyText = (result.text || "").trim();
+      const finalTextField = truncateTextField(result.text || "");
+
       // Persist session before reply so next turn sees the new id even if send fails.
       //
       // Adapter contract:
-      //   result.newSessionId truthy  → upsert the entry
-      //   result.newSessionId empty + had-inbound-sessionId + result.error
-      //                               → the prior session is dead (e.g. Claude Code
-      //                                 "--resume <missing-uuid>"); delete the entry so
+      //   had-inbound-sessionId + result.error + no reply text
+      //                               → the prior session is suspect/dead; delete it so
       //                                 we don't keep resuming a stale id every turn
+      //                                 even when the adapter echoes that id back
+      //   result.newSessionId truthy  → upsert the entry
       //   otherwise                   → no-op (e.g. codex intentionally never persists)
-      if (result.newSessionId) {
+      if (sessionId && result.error && !replyText) {
+        try {
+          await this.sessionStore.delete(key);
+          this.log.info("dispatcher: dropped stale runtime session", {
+            key,
+            prevRuntimeSessionId: sessionId,
+            nextRuntimeSessionId: result.newSessionId || null,
+            error: result.error,
+          });
+        } catch (err) {
+          this.log.warn("dispatcher: session-store.delete failed", {
+            key,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      } else if (result.newSessionId) {
         const session: GatewaySessionEntry = {
           key,
           runtime: route.runtime,
@@ -1380,9 +1398,6 @@ export class Dispatcher {
           });
         }
       }
-
-      const replyText = (result.text || "").trim();
-      const finalTextField = truncateTextField(result.text || "");
 
       if (!replyText) {
         if (result.error) {

--- a/packages/daemon/src/gateway/runtimes/acp-stream.ts
+++ b/packages/daemon/src/gateway/runtimes/acp-stream.ts
@@ -33,6 +33,8 @@ const ASSISTANT_TEXT_CAP = 1 * 1024 * 1024;
 const KILL_GRACE_MS = 5_000;
 /** Deadline for the initial `initialize` handshake. */
 const INITIALIZE_TIMEOUT_MS = 30_000;
+/** Short drain window for late `session/update` chunks after a prompt RPC error. */
+const PROMPT_ERROR_DRAIN_MS = 750;
 /** ACP protocol version this client targets. */
 export const ACP_PROTOCOL_VERSION = 1;
 
@@ -142,6 +144,7 @@ class AcpConnection {
 
   private dispatchLine(line: string): void {
     let msg: any;
+
     try {
       msg = JSON.parse(line);
     } catch {
@@ -421,6 +424,7 @@ export abstract class AcpRuntimeAdapter implements RuntimeAdapter {
     });
 
     let newSessionId = opts.sessionId ?? "";
+    let promptStarted = false;
 
     try {
       // 1) initialize
@@ -471,6 +475,7 @@ export abstract class AcpRuntimeAdapter implements RuntimeAdapter {
       newSessionId = sessionId;
 
       // 3) session/prompt
+      promptStarted = true;
       const promptResult = (await conn.request<unknown>("session/prompt", {
         sessionId,
         prompt: [{ type: "text", text: opts.text }],
@@ -508,6 +513,9 @@ export abstract class AcpRuntimeAdapter implements RuntimeAdapter {
       const tail = stderrTail.slice(-STDERR_ERROR_SNIPPET).trim();
       state.errorText =
         state.errorText ?? (tail ? `${baseMsg}; stderr: ${tail}` : baseMsg);
+      if (promptStarted && !opts.signal.aborted) {
+        await sleepUnlessAborted(PROMPT_ERROR_DRAIN_MS, opts.signal);
+      }
       try {
         child.stdin.end();
       } catch {
@@ -562,4 +570,18 @@ export abstract class AcpRuntimeAdapter implements RuntimeAdapter {
       );
     });
   }
+}
+
+function sleepUnlessAborted(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const t = setTimeout(done, ms);
+    if (typeof t.unref === "function") t.unref();
+    function done(): void {
+      signal.removeEventListener("abort", done);
+      clearTimeout(t);
+      resolve();
+    }
+    signal.addEventListener("abort", done, { once: true });
+  });
 }

--- a/packages/daemon/src/gateway/runtimes/openclaw-acp.ts
+++ b/packages/daemon/src/gateway/runtimes/openclaw-acp.ts
@@ -358,6 +358,12 @@ export class OpenclawAcpAdapter implements RuntimeAdapter {
 
       if (!finalText) {
         const stopReason = pickStopReason(promptResult);
+        if (!stopReason || stopReason === "end_turn") {
+          return {
+            text: "",
+            newSessionId: acpSessionId,
+          };
+        }
         const warningTail = handle.nonJsonStdoutTail.slice(-8).join("\n").trim();
         const detail = warningTail ? `; stdout: ${truncateDetail(warningTail, 1000)}` : "";
         const reason = stopReason ? `prompt stopped: ${stopReason}` : "empty assistant response";

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -307,6 +307,34 @@ function loadOrInitConfig(args: ParsedArgs): DaemonConfig {
   }
 }
 
+async function refreshDiscoveredOpenclawGateways(
+  cfg: DaemonConfig,
+  source: string,
+): Promise<DaemonConfig> {
+  if (!openclawDiscoveryConfigEnabled(cfg)) return cfg;
+  try {
+    const found = await discoverLocalOpenclawGateways({
+      searchPaths: cfg.openclawDiscovery?.searchPaths,
+      defaultPorts: cfg.openclawDiscovery?.defaultPorts,
+      timeoutMs: 500,
+    });
+    const merged = mergeOpenclawGateways(cfg, found);
+    if (!merged.changed) return cfg;
+    saveConfig(merged.cfg);
+    log.info("openclaw discovery: gateways merged", {
+      source,
+      added: merged.added.map((g) => ({ name: g.name, url: g.url })),
+    });
+    return merged.cfg;
+  } catch (err) {
+    log.warn("openclaw discovery failed; continuing", {
+      source,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return cfg;
+  }
+}
+
 /**
  * Read the current user-auth record without throwing on parse / permission
  * errors — those are returned as `null` so the caller treats them like a
@@ -566,27 +594,7 @@ async function ensureUserAuthForStart(args: ParsedArgs): Promise<UserAuthRecord 
 
 async function cmdStart(args: ParsedArgs): Promise<void> {
   let cfg = loadOrInitConfig(args);
-  if (openclawDiscoveryConfigEnabled(cfg)) {
-    try {
-      const found = await discoverLocalOpenclawGateways({
-        searchPaths: cfg.openclawDiscovery?.searchPaths,
-        defaultPorts: cfg.openclawDiscovery?.defaultPorts,
-        timeoutMs: 500,
-      });
-      const merged = mergeOpenclawGateways(cfg, found);
-      if (merged.changed) {
-        cfg = merged.cfg;
-        saveConfig(cfg);
-        log.info("openclaw discovery: gateways merged", {
-          added: merged.added.map((g) => ({ name: g.name, url: g.url })),
-        });
-      }
-    } catch (err) {
-      log.warn("openclaw discovery failed; continuing", {
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
-  }
+  cfg = await refreshDiscoveredOpenclawGateways(cfg, "start");
   // Foreground is now the default. --background (alias -d) detaches.
   // --foreground is still accepted (no-op) for backwards compatibility and
   // is also what the detached child re-execs itself with.
@@ -1373,8 +1381,8 @@ async function cmdDoctor(args: ParsedArgs): Promise<void> {
   let cfgForEndpoints: import("./config.js").DaemonConfig | null = null;
   try {
     const cfg = loadConfig();
-    cfgForEndpoints = cfg;
-    channels = channelsFromDaemonConfig(cfg);
+    cfgForEndpoints = await refreshDiscoveredOpenclawGateways(cfg, "doctor");
+    channels = channelsFromDaemonConfig(cfgForEndpoints);
   } catch {
     channels = [];
   }

--- a/packages/daemon/src/openclaw-discovery.ts
+++ b/packages/daemon/src/openclaw-discovery.ts
@@ -346,6 +346,7 @@ export function mergeOpenclawGateways(
 
 function discoverFromConfigDir(root: string): DiscoveredOpenclawGateway[] {
   const dir = expandHome(root);
+  const rootIsQclaw = path.basename(dir) === ".qclaw";
   let names: string[];
   try {
     names = readdirSync(dir);
@@ -362,8 +363,9 @@ function discoverFromConfigDir(root: string): DiscoveredOpenclawGateway[] {
       const raw = readFileSync(file, "utf8");
       const parsed = name.endsWith(".json") ? parseJsonConfig(raw) : parseTomlConfig(raw);
       if (!parsed?.url) continue;
+      const namePrefix = rootIsQclaw || name.toLowerCase() === "qclaw.json" ? "qclaw" : "openclaw";
       const item: DiscoveredOpenclawGateway = {
-        name: nameFromUrl(parsed.url),
+        name: nameFromUrl(parsed.url, namePrefix),
         url: parsed.url,
         source: "config-file",
       };
@@ -487,11 +489,20 @@ function dedupeDiscovered(items: DiscoveredOpenclawGateway[]): DiscoveredOpencla
   for (const item of items) {
     const key = normalizeUrlKey(item.url);
     const prev = byUrl.get(key);
-    if (!prev || priority[item.source] > priority[prev.source] || hasMoreAuth(item, prev)) {
+    if (
+      !prev ||
+      priority[item.source] > priority[prev.source] ||
+      hasMoreAuth(item, prev) ||
+      prefersQclawName(item, prev)
+    ) {
       byUrl.set(key, item);
     }
   }
   return [...byUrl.values()];
+}
+
+function prefersQclawName(a: DiscoveredOpenclawGateway, b: DiscoveredOpenclawGateway): boolean {
+  return a.name.startsWith("qclaw-") && !b.name.startsWith("qclaw-");
 }
 
 function hasMoreAuth(a: DiscoveredOpenclawGateway, b: DiscoveredOpenclawGateway): boolean {
@@ -499,13 +510,13 @@ function hasMoreAuth(a: DiscoveredOpenclawGateway, b: DiscoveredOpenclawGateway)
   return score(a) > score(b);
 }
 
-function nameFromUrl(raw: string): string {
+function nameFromUrl(raw: string, prefix = "openclaw"): string {
   try {
     const u = new URL(raw);
     const base = `${u.hostname}-${u.port || (u.protocol === "wss:" ? "443" : "80")}`;
-    return `openclaw-${base.replace(/[^A-Za-z0-9_-]+/g, "-")}`;
+    return `${prefix}-${base.replace(/[^A-Za-z0-9_-]+/g, "-")}`;
   } catch {
-    return "openclaw-local";
+    return `${prefix}-local`;
   }
 }
 

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -49,6 +49,11 @@ import {
   prepareGatewayProfile,
 } from "./daemon-config-map.js";
 import {
+  discoverLocalOpenclawGateways,
+  mergeOpenclawGateways,
+  openclawDiscoveryConfigEnabled,
+} from "./openclaw-discovery.js";
+import {
   agentHomeDir,
   agentStateDir,
   agentWorkspaceDir,
@@ -324,9 +329,10 @@ export function createProvisioner(opts: ProvisionerOptions): (
       case CONTROL_FRAME_TYPES.LIST_RUNTIMES: {
         // Async path so the openclaw-acp endpoints get probed inline; gateway
         // / WS errors are swallowed inside `collectRuntimeSnapshotAsync`.
-        let cfgForProbe: { openclawGateways?: any[] } | undefined;
+        let cfgForProbe: DaemonConfig | undefined;
         try {
           cfgForProbe = loadConfig();
+          cfgForProbe = await refreshDiscoveredOpenclawGateways(cfgForProbe);
         } catch {
           cfgForProbe = undefined;
         }
@@ -426,6 +432,31 @@ export function createProvisioner(opts: ProvisionerOptions): (
         };
     }
   };
+}
+
+async function refreshDiscoveredOpenclawGateways(cfg: DaemonConfig): Promise<DaemonConfig> {
+  if (!openclawDiscoveryConfigEnabled(cfg)) return cfg;
+  try {
+    const found = await discoverLocalOpenclawGateways({
+      searchPaths: cfg.openclawDiscovery?.searchPaths,
+      defaultPorts: cfg.openclawDiscovery?.defaultPorts,
+      timeoutMs: 500,
+    });
+    const merged = mergeOpenclawGateways(cfg, found);
+    if (!merged.changed) return cfg;
+    saveConfig(merged.cfg);
+    daemonLog.info("openclaw discovery: gateways merged", {
+      source: "list_runtimes",
+      added: merged.added.map((g) => ({ name: g.name, url: g.url })),
+    });
+    return merged.cfg;
+  } catch (err) {
+    daemonLog.warn("openclaw discovery failed; continuing", {
+      source: "list_runtimes",
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return cfg;
+  }
 }
 
 interface WakeAgentParams {


### PR DESCRIPTION
## Summary
- treat OpenClaw `end_turn` turns with only config warning output as empty replies instead of runtime errors
- keep draining ACP `session/update` briefly after a prompt RPC error so late assistant text can still be captured
- refresh OpenClaw/QClaw gateway discovery before `list_runtimes`, `doctor`, and diagnostics so gateways started after daemon boot are picked up
- preserve QClaw identity for gateways discovered from `~/.qclaw`/`qclaw.json`, including custom ports

## Tests
- `cd packages/daemon && npm test -- src/__tests__/openclaw-discovery.test.ts src/__tests__/runtime-discovery.test.ts src/__tests__/diagnostics.test.ts`
- `cd packages/daemon && npm run build`

## Notes
- `cd packages/daemon && npx tsc --noEmit` is currently blocked by pre-existing test type errors outside this change.