### PR TITLE
fix: target selected owned bot chat

### DIFF
--- a/frontend/src/components/dashboard/RoomList.tsx
+++ b/frontend/src/components/dashboard/RoomList.tsx
@@ -84,13 +84,14 @@ export default function RoomList({
     loadRoomMessages: state.loadRoomMessages,
     publicAgents: state.publicAgents,
   })));
-  const { focusedRoomId, messagesPane, closeMobileSidebar, setFocusedRoomId, setOpenedRoomId, setMessagesPane } = useDashboardUIStore(useShallow((state) => ({
+  const { focusedRoomId, messagesPane, closeMobileSidebar, setFocusedRoomId, setOpenedRoomId, setMessagesPane, setUserChatAgentId } = useDashboardUIStore(useShallow((state) => ({
     focusedRoomId: state.focusedRoomId,
     messagesPane: state.messagesPane,
     closeMobileSidebar: state.closeMobileSidebar,
     setFocusedRoomId: state.setFocusedRoomId,
     setOpenedRoomId: state.setOpenedRoomId,
     setMessagesPane: state.setMessagesPane,
+    setUserChatAgentId: state.setUserChatAgentId,
   })));
   const activeAgentId = useDashboardSessionStore((state) => state.activeAgentId);
   const switchActiveAgent = useDashboardSessionStore((state) => state.switchActiveAgent);
@@ -145,6 +146,7 @@ export default function RoomList({
       if (agentId && agentId !== activeAgentId) {
         await switchActiveAgent(agentId);
       }
+      setUserChatAgentId(agentId || null);
       setMessagesPane("user-chat");
       setFocusedRoomId(null);
       setOpenedRoomId(null);
@@ -177,6 +179,7 @@ export default function RoomList({
   const handleSelectUserChat = () => {
     if (!showUserChatEntry) return;
     setMessagesPane("user-chat");
+    setUserChatAgentId(null);
     setFocusedRoomId(null);
     setOpenedRoomId(null);
     closeMobileSidebar();


### PR DESCRIPTION
## Summary
- Set the owner-chat target agent when selecting a specific owned bot from Messages
- Clear the explicit owner-chat target when opening the generic user-chat entry so it follows the active bot again

## Tests
- npm test -- --run (passed in frontend working tree: 17 files, 66 tests)
- npm run build (compiled and TypeScript passed; failed during /admin/codes prerender because Supabase URL/API key env vars are missing)