### PR TITLE
feat: collect ACP runtime diagnostics

### DIFF
--- a/packages/daemon/src/__tests__/acp-logs.test.ts
+++ b/packages/daemon/src/__tests__/acp-logs.test.ts
@@ -1,0 +1,88 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const originalHome = process.env.HOME;
+
+afterEach(() => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  delete process.env.BOTCORD_ACP_LOGS;
+  delete process.env.BOTCORD_ACP_TRACE;
+  vi.resetModules();
+});
+
+describe("ACP trace logs", () => {
+  it("writes redacted safe-mode jsonl and lists it for diagnostics", async () => {
+    const home = mkdtempSync(path.join(tmpdir(), "botcord-acp-log-home-"));
+    process.env.HOME = home;
+    vi.resetModules();
+    const { createAcpTraceLogger, listAcpTraceLogFiles } = await import("../acp-logs.js");
+
+    const logger = createAcpTraceLogger({
+      runtime: "openclaw-acp",
+      accountId: "ag_test",
+      roomId: "rm_test",
+      gatewayName: "qclaw-127-0-0-1-28789",
+      gatewayUrl: "ws://127.0.0.1:28789",
+    });
+    expect(logger).not.toBeNull();
+    logger!.write({
+      stream: "rpc_out",
+      direction: "out",
+      id: 1,
+      method: "session/prompt",
+      status: "request",
+      params: {
+        sessionId: "sess_1",
+        token: "secret-token",
+        prompt: [{ type: "text", text: "hello from a user prompt" }],
+      },
+    });
+
+    const raw = readFileSync(logger!.path, "utf8");
+    expect(raw).toContain('"method":"session/prompt"');
+    expect(raw).toContain('"preview":"[REDACTED]"');
+    expect(raw).toContain('"textBytes"');
+    expect(raw).toContain('"textPreview"');
+    expect(raw).not.toContain("secret-token");
+    const files = listAcpTraceLogFiles();
+    expect(files).toHaveLength(1);
+    expect(files[0].path).toBe(logger!.path);
+  });
+
+  it("bundles ACP and runtime logs in diagnostics", async () => {
+    const home = mkdtempSync(path.join(tmpdir(), "botcord-diag-acp-home-"));
+    process.env.HOME = home;
+    vi.resetModules();
+    const { createAcpTraceLogger } = await import("../acp-logs.js");
+    const { createDiagnosticBundle } = await import("../diagnostics.js");
+
+    const logger = createAcpTraceLogger({ runtime: "hermes-agent", accountId: "ag_hermes" });
+    logger!.write({ stream: "stderr", chunk: "hermes auth token=secret\n" });
+    const botcordDaemon = path.join(home, ".botcord", "daemon");
+    const qclawLogs = path.join(home, ".qclaw", "logs");
+    mkdirSync(botcordDaemon, { recursive: true });
+    writeFileSync(path.join(home, ".botcord", "daemon.log"), "daemon\n", { flag: "w" });
+    writeFileSync(path.join(home, ".botcord", "snapshot.json"), "{}\n", { flag: "w" });
+    writeFileSync(path.join(botcordDaemon, "config.json"), "{}\n", { flag: "w" });
+    mkdirSync(qclawLogs, { recursive: true });
+    writeFileSync(path.join(qclawLogs, "qclaw.log"), "qclaw token=secret\n");
+
+    const bundle = await createDiagnosticBundle({
+      diagnosticsDir: path.join(home, ".botcord", "diagnostics"),
+      doctor: { text: "doctor ok", json: { ok: true } },
+    });
+
+    expect(existsSync(bundle.path)).toBe(true);
+    const listing = execFileSync("unzip", ["-l", bundle.path], { encoding: "utf8" });
+    expect(listing).toContain("acp-logs/hermes-agent");
+    expect(listing).toContain("runtime-logs/qclaw/qclaw.log");
+    const acpLog = execFileSync("unzip", ["-p", bundle.path, "acp-logs/hermes-agent/ag_hermes.jsonl"], {
+      encoding: "utf8",
+    });
+    expect(acpLog).toContain("[REDACTED]");
+  });
+});

--- a/packages/daemon/src/acp-logs.ts
+++ b/packages/daemon/src/acp-logs.ts
@@ -1,0 +1,382 @@
+import { appendFileSync, existsSync, mkdirSync, readdirSync, renameSync, statSync, unlinkSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+import type { LogFileEntry } from "./log.js";
+
+const ACP_LOG_DIR = path.join(homedir(), ".botcord", "logs", "acp");
+const ACP_LOG_MAX_BYTES = 2 * 1024 * 1024;
+const ACP_LOG_KEEP = 20;
+const ACP_LOG_DIAGNOSTICS_DEFAULT = 10;
+const ACP_LOG_DIAGNOSTICS_ALL = 50;
+const RUNTIME_LOG_DEFAULT_PER_ROOT = 5;
+const RUNTIME_LOG_ALL_PER_ROOT = 25;
+const RUNTIME_LOG_MAX_FILE_BYTES = 2 * 1024 * 1024;
+
+const SECRET_KEY_RE = /token|secret|private.?key|api.?key|authorization|password/i;
+
+export type AcpTraceStream =
+  | "child_start"
+  | "child_exit"
+  | "child_error"
+  | "stderr"
+  | "stdout_non_json"
+  | "rpc_in"
+  | "rpc_out";
+
+export interface AcpTraceMeta {
+  runtime: string;
+  accountId?: string;
+  turnId?: string;
+  roomId?: string;
+  topicId?: string | null;
+  gatewayName?: string;
+  gatewayUrl?: string;
+  hermesProfile?: string;
+  sessionId?: string | null;
+}
+
+export interface AcpTraceEvent {
+  stream: AcpTraceStream;
+  direction?: "in" | "out";
+  pid?: number;
+  id?: number | string;
+  method?: string;
+  status?: "request" | "notification" | "response" | "error";
+  code?: number | null;
+  signal?: NodeJS.Signals | null;
+  error?: string;
+  chunk?: string;
+  params?: unknown;
+  result?: unknown;
+}
+
+export interface AcpTraceLogger {
+  path: string;
+  verbose: boolean;
+  write(event: AcpTraceEvent): void;
+}
+
+interface RuntimeLogRoot {
+  label: string;
+  dir: string;
+}
+
+interface RuntimeLogFile extends LogFileEntry {
+  bundleName: string;
+}
+
+export function createAcpTraceLogger(meta: AcpTraceMeta): AcpTraceLogger | null {
+  if (process.env.BOTCORD_ACP_LOGS === "0") return null;
+  const runtime = safePathSegment(meta.runtime || "acp");
+  const key = safePathSegment(
+    [
+      meta.accountId,
+      meta.gatewayName,
+      meta.hermesProfile,
+      meta.roomId,
+    ].filter(Boolean).join("_") || "default",
+  );
+  const dir = path.join(ACP_LOG_DIR, runtime);
+  const file = path.join(dir, `${key}.jsonl`);
+  const verbose = process.env.BOTCORD_ACP_TRACE === "verbose";
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  return {
+    path: file,
+    verbose,
+    write(event) {
+      writeAcpTrace(file, meta, event, verbose);
+    },
+  };
+}
+
+export function listAcpTraceLogFiles(includeAll = false): LogFileEntry[] {
+  const limit = includeAll ? ACP_LOG_DIAGNOSTICS_ALL : ACP_LOG_DIAGNOSTICS_DEFAULT;
+  const out: LogFileEntry[] = [];
+  collectFiles(ACP_LOG_DIR, out, (name) => name.endsWith(".jsonl") || name.includes(".jsonl."));
+  return out
+    .sort((a, b) => b.mtimeMs - a.mtimeMs || b.name.localeCompare(a.name))
+    .slice(0, limit);
+}
+
+export function listRuntimeLogFiles(includeAll = false): RuntimeLogFile[] {
+  const limit = includeAll ? RUNTIME_LOG_ALL_PER_ROOT : RUNTIME_LOG_DEFAULT_PER_ROOT;
+  const out: RuntimeLogFile[] = [];
+  for (const root of runtimeLogRoots()) {
+    const files: LogFileEntry[] = [];
+    collectFiles(root.dir, files, looksLikeLogFile, 4);
+    for (const entry of files
+      .sort((a, b) => b.mtimeMs - a.mtimeMs || b.name.localeCompare(a.name))
+      .slice(0, limit)) {
+      out.push({
+        ...entry,
+        bundleName: path.posix.join(
+          "runtime-logs",
+          root.label,
+          relativeBundlePath(root.dir, entry.path),
+        ),
+      });
+    }
+  }
+  return out;
+}
+
+function writeAcpTrace(
+  file: string,
+  meta: AcpTraceMeta,
+  event: AcpTraceEvent,
+  verbose: boolean,
+): void {
+  try {
+    rotateIfNeeded(file);
+    const record = {
+      ts: new Date().toISOString(),
+      runtime: meta.runtime,
+      accountId: meta.accountId,
+      turnId: meta.turnId,
+      roomId: meta.roomId,
+      topicId: meta.topicId ?? undefined,
+      gatewayName: meta.gatewayName,
+      gatewayUrl: meta.gatewayUrl,
+      hermesProfile: meta.hermesProfile,
+      sessionId: event.params && typeof event.params === "object"
+        ? pickString(event.params as Record<string, unknown>, "sessionId") ?? meta.sessionId ?? undefined
+        : meta.sessionId ?? undefined,
+      ...summarizeEvent(event, verbose),
+    };
+    appendFileSync(file, JSON.stringify(record) + "\n", { mode: 0o600 });
+  } catch {
+    // ACP trace logging must never affect runtime execution.
+  }
+}
+
+function summarizeEvent(event: AcpTraceEvent, verbose: boolean): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    stream: event.stream,
+  };
+  if (event.direction) out.direction = event.direction;
+  if (event.pid !== undefined) out.pid = event.pid;
+  if (event.id !== undefined) out.id = event.id;
+  if (event.method) out.method = event.method;
+  if (event.status) out.status = event.status;
+  if (event.code !== undefined) out.code = event.code;
+  if (event.signal !== undefined) out.signal = event.signal;
+  if (event.error) out.error = truncate(event.error, 1000);
+  if (event.chunk) out.chunk = truncate(redactSecretString(event.chunk), 2000);
+  if (event.params !== undefined) out.params = summarizePayload(event.params, verbose);
+  if (event.result !== undefined) out.result = summarizePayload(event.result, verbose);
+  return out;
+}
+
+function summarizePayload(value: unknown, verbose: boolean): unknown {
+  const redacted = redactSecrets(value);
+  if (verbose) return capPayload(redacted);
+  if (Array.isArray(redacted)) return { type: "array", length: redacted.length };
+  if (!redacted || typeof redacted !== "object") return redacted;
+  const obj = redacted as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const [key, v] of Object.entries(obj)) {
+    if (key === "prompt") {
+      out.prompt = summarizePrompt(v);
+    } else if (key === "cwd" || key === "sessionId") {
+      out[key] = v;
+    } else if (key === "_meta") {
+      out[key] = summarizePayload(v, false);
+    } else if (key === "update") {
+      out.update = summarizeUpdate(v);
+    } else if (key === "toolCall") {
+      out.toolCall = summarizeToolCall(v);
+    } else if (typeof v === "string") {
+      out[key] = stringSummary(v);
+    } else if (Array.isArray(v)) {
+      out[key] = { type: "array", length: v.length };
+    } else if (v && typeof v === "object") {
+      out[key] = { type: "object", keys: Object.keys(v as Record<string, unknown>).slice(0, 20) };
+    } else {
+      out[key] = v;
+    }
+  }
+  return out;
+}
+
+function summarizePrompt(value: unknown): unknown {
+  if (!Array.isArray(value)) return summarizePayload(value, false);
+  return value.map((item) => {
+    if (!item || typeof item !== "object") return summarizePayload(item, false);
+    const obj = item as Record<string, unknown>;
+    const text = typeof obj.text === "string" ? obj.text : "";
+    return {
+      type: obj.type,
+      textBytes: text ? Buffer.byteLength(text, "utf8") : undefined,
+      textPreview: text ? truncate(text.replace(/\s+/g, " "), 120) : undefined,
+    };
+  });
+}
+
+function summarizeUpdate(value: unknown): unknown {
+  if (!value || typeof value !== "object") return summarizePayload(value, false);
+  const obj = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  if (typeof obj.sessionUpdate === "string") out.sessionUpdate = obj.sessionUpdate;
+  if (typeof obj.title === "string") out.title = stringSummary(obj.title);
+  if (obj.content !== undefined) out.content = summarizePayload(obj.content, false);
+  return Object.keys(out).length > 0 ? out : { type: "object", keys: Object.keys(obj).slice(0, 20) };
+}
+
+function summarizeToolCall(value: unknown): unknown {
+  if (!value || typeof value !== "object") return summarizePayload(value, false);
+  const obj = value as Record<string, unknown>;
+  return {
+    name: typeof obj.name === "string" ? obj.name : undefined,
+    rawInput: obj.rawInput === undefined ? undefined : summarizePayload(obj.rawInput, false),
+  };
+}
+
+function redactSecrets(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redactSecrets);
+  if (!value || typeof value !== "object") {
+    return typeof value === "string" ? redactSecretString(value) : value;
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+    out[key] = SECRET_KEY_RE.test(key) ? "[REDACTED]" : redactSecrets(v);
+  }
+  return out;
+}
+
+function redactSecretString(value: string): string {
+  return value
+    .replace(/(Authorization:\s*Bearer\s+)[^\s"']+/gi, "$1[REDACTED]")
+    .replace(/\b(token=)[^\s"']+/gi, "$1[REDACTED]")
+    .replace(/\b(drt_|dit_|gho_)[A-Za-z0-9_-]+/g, "$1[REDACTED]");
+}
+
+function capPayload(value: unknown): unknown {
+  if (typeof value === "string") return truncate(value, 2000);
+  if (Array.isArray(value)) return value.slice(0, 50).map(capPayload);
+  if (!value || typeof value !== "object") return value;
+  const out: Record<string, unknown> = {};
+  for (const [key, v] of Object.entries(value as Record<string, unknown>).slice(0, 50)) {
+    out[key] = capPayload(v);
+  }
+  return out;
+}
+
+function stringSummary(value: string): Record<string, unknown> {
+  return {
+    bytes: Buffer.byteLength(value, "utf8"),
+    preview: truncate(value.replace(/\s+/g, " "), 160),
+  };
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max)}…` : value;
+}
+
+function pickString(obj: Record<string, unknown>, key: string): string | undefined {
+  const value = obj[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function rotateIfNeeded(file: string): void {
+  try {
+    const st = statSync(file);
+    if (!st.isFile() || st.size <= ACP_LOG_MAX_BYTES) return;
+    renameSync(file, `${file}.${new Date().toISOString().replace(/[:.]/g, "-")}.${process.pid}`);
+    const dir = path.dirname(file);
+    const base = path.basename(file);
+    const rotated = readdirSync(dir)
+      .filter((name) => name.startsWith(`${base}.`))
+      .map((name) => {
+        const p = path.join(dir, name);
+        const st = statSync(p);
+        return { p, mtimeMs: st.mtimeMs };
+      })
+      .sort((a, b) => b.mtimeMs - a.mtimeMs);
+    for (const entry of rotated.slice(ACP_LOG_KEEP)) unlinkSync(entry.p);
+  } catch {
+    // best-effort
+  }
+}
+
+function collectFiles(
+  dir: string,
+  out: LogFileEntry[],
+  accept: (name: string, file: string) => boolean,
+  maxDepth = 3,
+): void {
+  if (maxDepth < 0) return;
+  let names: string[];
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const name of names) {
+    const file = path.join(dir, name);
+    try {
+      const st = statSync(file);
+      if (st.isDirectory()) {
+        collectFiles(file, out, accept, maxDepth - 1);
+      } else if (st.isFile() && st.size <= RUNTIME_LOG_MAX_FILE_BYTES && accept(name, file)) {
+        out.push({
+          path: file,
+          name: path.relative(ACP_LOG_DIR, file) || name,
+          sizeBytes: st.size,
+          mtimeMs: st.mtimeMs,
+          active: true,
+        });
+      }
+    } catch {
+      // ignore disappearing files
+    }
+  }
+}
+
+function runtimeLogRoots(): RuntimeLogRoot[] {
+  const roots: RuntimeLogRoot[] = [
+    { label: "openclaw", dir: path.join(homedir(), ".openclaw", "logs") },
+    { label: "qclaw", dir: path.join(homedir(), ".qclaw", "logs") },
+    { label: "hermes", dir: path.join(homedir(), ".hermes", "logs") },
+  ];
+  const hermesProfiles = path.join(homedir(), ".hermes", "profiles");
+  try {
+    for (const name of readdirSync(hermesProfiles)) {
+      roots.push({
+        label: path.posix.join("hermes-profiles", safePathSegment(name)),
+        dir: path.join(hermesProfiles, name, "logs"),
+      });
+    }
+  } catch {
+    // no profiles
+  }
+  const botcordAgents = path.join(homedir(), ".botcord", "agents");
+  try {
+    for (const agent of readdirSync(botcordAgents)) {
+      roots.push({
+        label: path.posix.join("botcord-hermes", safePathSegment(agent)),
+        dir: path.join(botcordAgents, agent, "hermes-home", "logs"),
+      });
+    }
+  } catch {
+    // no botcord agent homes
+  }
+  return roots.filter((root) => existsSync(root.dir));
+}
+
+function looksLikeLogFile(name: string): boolean {
+  const lower = name.toLowerCase();
+  return (
+    lower.endsWith(".log") ||
+    lower.endsWith(".jsonl") ||
+    lower.endsWith(".txt") ||
+    lower.includes("log")
+  );
+}
+
+function relativeBundlePath(root: string, file: string): string {
+  return path.relative(root, file).split(path.sep).map(safePathSegment).join("/");
+}
+
+function safePathSegment(raw: string): string {
+  return raw.replace(/[^A-Za-z0-9._-]+/g, "_").slice(0, 120) || "unknown";
+}

--- a/packages/daemon/src/diagnostics.ts
+++ b/packages/daemon/src/diagnostics.ts
@@ -18,6 +18,7 @@ import {
   type DaemonConfig,
 } from "./config.js";
 import { listDaemonLogFiles, LOG_FILE_PATH, type LogFileEntry } from "./log.js";
+import { listAcpTraceLogFiles, listRuntimeLogFiles } from "./acp-logs.js";
 import {
   channelsFromDaemonConfig,
   defaultHttpFetcher,
@@ -330,6 +331,8 @@ export async function createDiagnosticBundle(
   const snapshotFile = opts.snapshotFile ?? SNAPSHOT_PATH;
   const includeAllLogs = opts.includeAllLogs === true;
   const logs = bundledLogs(logFile, includeAllLogs);
+  const acpLogs = listAcpTraceLogFiles(includeAllLogs);
+  const runtimeLogs = listRuntimeLogFiles(includeAllLogs);
   mkdirSync(diagnosticsDir, { recursive: true, mode: 0o700 });
 
   const doctor = opts.doctor ?? await buildDoctorEntries();
@@ -350,6 +353,16 @@ export async function createDiagnosticBundle(
       path: entry.path,
       sizeBytes: entry.sizeBytes,
       active: entry.active,
+    })),
+    acpLogsBundled: acpLogs.map((entry) => ({
+      name: entry.name,
+      path: entry.path,
+      sizeBytes: entry.sizeBytes,
+    })),
+    runtimeLogsBundled: runtimeLogs.map((entry) => ({
+      name: entry.bundleName,
+      path: entry.path,
+      sizeBytes: entry.sizeBytes,
     })),
     logsBundleMode: includeAllLogs ? "all" : `active_plus_${DEFAULT_ROTATED_LOGS_IN_BUNDLE}_rotated`,
     diagnosticsDir,
@@ -375,6 +388,20 @@ export async function createDiagnosticBundle(
         data: log ?? `no log file at ${entry.path}\n`,
       });
     }
+  }
+  for (const entry of acpLogs) {
+    const log = safeReadText(entry.path);
+    entries.push({
+      name: `acp-logs/${entry.name.split(path.sep).join("/")}`,
+      data: log ?? `no ACP log file at ${entry.path}\n`,
+    });
+  }
+  for (const entry of runtimeLogs) {
+    const log = safeReadText(entry.path);
+    entries.push({
+      name: entry.bundleName,
+      data: log ?? `no runtime log file at ${entry.path}\n`,
+    });
   }
   const config = safeReadText(configFile);
   entries.push({

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -1200,6 +1200,14 @@ export class Dispatcher {
           systemContext,
           onBlock,
           onStatus,
+          context: {
+            turnId,
+            messageId: msg.id,
+            roomId: msg.conversation.id,
+            topicId: msg.conversation.threadId ?? null,
+            channel: msg.channel,
+            conversationKind: msg.conversation.kind,
+          },
           gateway: route.gateway,
           ...(route.hermesProfile ? { hermesProfile: route.hermesProfile } : {}),
         });

--- a/packages/daemon/src/gateway/runtimes/acp-stream.ts
+++ b/packages/daemon/src/gateway/runtimes/acp-stream.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { createAcpTraceLogger, type AcpTraceLogger } from "../../acp-logs.js";
 import { consoleLogger } from "../log.js";
 import type {
   RuntimeAdapter,
@@ -37,6 +38,12 @@ const INITIALIZE_TIMEOUT_MS = 30_000;
 const PROMPT_ERROR_DRAIN_MS = 750;
 /** ACP protocol version this client targets. */
 export const ACP_PROTOCOL_VERSION = 1;
+
+function stringField(obj: unknown, key: string): string | undefined {
+  if (!obj || typeof obj !== "object") return undefined;
+  const value = (obj as Record<string, unknown>)[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
 
 export interface AcpInitializeResult {
   protocolVersion?: number;
@@ -121,6 +128,7 @@ class AcpConnection {
       ): Promise<unknown> | unknown;
     },
     private readonly logId: string,
+    private readonly trace: AcpTraceLogger | null = null,
   ) {
     child.stdout.setEncoding("utf8");
     child.stdout.on("data", (chunk: string) => this.onStdout(chunk));
@@ -148,6 +156,7 @@ class AcpConnection {
     try {
       msg = JSON.parse(line);
     } catch {
+      this.trace?.write({ stream: "stdout_non_json", chunk: line });
       log.warn(`${this.logId} non-json acp line`, { line: line.slice(0, 200) });
       return;
     }
@@ -158,11 +167,26 @@ class AcpConnection {
       if (!pending) return;
       this.pending.delete(msg.id);
       if (msg.error) {
+        this.trace?.write({
+          stream: "rpc_in",
+          direction: "in",
+          id: msg.id,
+          status: "error",
+          code: typeof msg.error.code === "number" ? msg.error.code : undefined,
+          error: msg.error.message ?? "(no message)",
+        });
         const err = new Error(
           `acp error ${msg.error.code ?? "?"}: ${msg.error.message ?? "(no message)"}`,
         );
         pending.reject(err);
       } else {
+        this.trace?.write({
+          stream: "rpc_in",
+          direction: "in",
+          id: msg.id,
+          status: "response",
+          result: msg.result ?? null,
+        });
         pending.resolve(msg.result ?? null);
       }
       return;
@@ -170,8 +194,23 @@ class AcpConnection {
     if (typeof msg.method === "string") {
       // Server→client request (has `id`) or notification (no `id`)
       if (msg.id !== undefined) {
+        this.trace?.write({
+          stream: "rpc_in",
+          direction: "in",
+          id: msg.id,
+          method: msg.method,
+          status: "request",
+          params: msg.params,
+        });
         void this.handleServerRequest(msg.id, msg.method, msg.params);
       } else {
+        this.trace?.write({
+          stream: "rpc_in",
+          direction: "in",
+          method: msg.method,
+          status: "notification",
+          params: msg.params,
+        });
         try {
           this.handlers.onNotification(msg.method, msg.params);
         } catch (err) {
@@ -202,6 +241,15 @@ class AcpConnection {
     const reply = error
       ? { jsonrpc: "2.0", id, error }
       : { jsonrpc: "2.0", id, result: result ?? null };
+    this.trace?.write({
+      stream: "rpc_out",
+      direction: "out",
+      id,
+      status: error ? "error" : "response",
+      code: error?.code,
+      error: error?.message,
+      result: error ? undefined : result ?? null,
+    });
     this.writeMessage(reply);
   }
 
@@ -224,11 +272,26 @@ class AcpConnection {
         resolve: (v) => resolve(v as T),
         reject,
       });
+      this.trace?.write({
+        stream: "rpc_out",
+        direction: "out",
+        id,
+        method,
+        status: "request",
+        params,
+      });
       this.writeMessage({ jsonrpc: "2.0", id, method, params });
     });
   }
 
   notify(method: string, params: unknown): void {
+    this.trace?.write({
+      stream: "rpc_out",
+      direction: "out",
+      method,
+      status: "notification",
+      params,
+    });
     this.writeMessage({ jsonrpc: "2.0", method, params });
   }
 
@@ -326,6 +389,20 @@ export abstract class AcpRuntimeAdapter implements RuntimeAdapter {
       env: this.spawnEnv(opts),
       stdio: ["pipe", "pipe", "pipe"],
     }) as ChildProcessWithoutNullStreams;
+    const trace = createAcpTraceLogger({
+      runtime: this.id,
+      accountId: opts.accountId,
+      turnId: stringField(opts.context, "turnId"),
+      roomId: stringField(opts.context, "roomId"),
+      topicId: stringField(opts.context, "topicId") ?? null,
+      hermesProfile: opts.hermesProfile,
+      sessionId: opts.sessionId,
+    });
+    trace?.write({
+      stream: "child_start",
+      pid: child.pid,
+      params: { command: binary, args, cwd: opts.cwd },
+    });
 
     let killTimer: ReturnType<typeof setTimeout> | null = null;
     const onAbort = () => {
@@ -354,6 +431,7 @@ export abstract class AcpRuntimeAdapter implements RuntimeAdapter {
     child.stderr.setEncoding("utf8");
     child.stderr.on("data", (chunk: string) => {
       stderrTail = (stderrTail + chunk).slice(-STDERR_TAIL_CAP);
+      trace?.write({ stream: "stderr", pid: child.pid, chunk });
     });
 
     const state: AcpRunState = {
@@ -417,10 +495,21 @@ export abstract class AcpRuntimeAdapter implements RuntimeAdapter {
         },
       },
       this.id,
+      trace,
     );
 
     const childExit = new Promise<number>((resolve) => {
-      child.on("close", (code) => resolve(code ?? 0));
+      child.on("close", (code, signal) => {
+        trace?.write({ stream: "child_exit", pid: child.pid, code, signal });
+        resolve(code ?? 0);
+      });
+      child.on("error", (err) => {
+        trace?.write({
+          stream: "child_error",
+          pid: child.pid,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
     });
 
     let newSessionId = opts.sessionId ?? "";

--- a/packages/daemon/src/gateway/runtimes/openclaw-acp.ts
+++ b/packages/daemon/src/gateway/runtimes/openclaw-acp.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { createAcpTraceLogger, type AcpTraceLogger } from "../../acp-logs.js";
 import {
   readCommandVersion,
   resolveCommandOnPath,
@@ -51,6 +52,7 @@ interface AcpProcessHandle {
    */
   spawnedUrl: string;
   spawnedToken: string | undefined;
+  trace: AcpTraceLogger | null;
 }
 
 interface PendingCall {
@@ -450,11 +452,23 @@ export class OpenclawAcpAdapter implements RuntimeAdapter {
     const command = resolveOpenclawCommand() ?? "openclaw";
     const args = ["acp", "--url", gateway.url];
     if (gateway.token) args.push("--token", gateway.token);
+    const accountId = key.split("::", 1)[0];
+    const trace = createAcpTraceLogger({
+      runtime: acpRuntimeLogName(gateway),
+      accountId,
+      gatewayName: gateway.name,
+      gatewayUrl: gateway.url,
+    });
 
     const child = this.spawnFn(command, args, {
       stdio: ["pipe", "pipe", "pipe"],
       env: { ...process.env },
     }) as ChildProcessWithoutNullStreams;
+    trace?.write({
+      stream: "child_start",
+      pid: child.pid,
+      params: { command, args, gateway: gateway.name },
+    });
 
     const handle: AcpProcessHandle = {
       child,
@@ -468,19 +482,27 @@ export class OpenclawAcpAdapter implements RuntimeAdapter {
       closed: false,
       spawnedUrl: gateway.url,
       spawnedToken: gateway.token,
+      trace,
     };
 
     child.stdout.setEncoding("utf8");
     child.stdout.on("data", (chunk: string) => onStdoutChunk(handle, chunk));
     child.stderr.setEncoding("utf8");
     child.stderr.on("data", (chunk: string) => {
+      trace?.write({ stream: "stderr", pid: child.pid, chunk });
       log.debug("openclaw-acp.stderr", { key, chunk: chunk.slice(0, 500) });
     });
     child.on("exit", (code, signal) => {
+      trace?.write({ stream: "child_exit", pid: child.pid, code, signal });
       shutdownHandle(handle, `exit code=${code ?? "null"} signal=${signal ?? "null"}`);
       ACP_POOL.delete(key);
     });
     child.on("error", (err) => {
+      trace?.write({
+        stream: "child_error",
+        pid: child.pid,
+        error: err instanceof Error ? err.message : String(err),
+      });
       log.warn("openclaw-acp.child-error", {
         key,
         error: err instanceof Error ? err.message : String(err),
@@ -538,6 +560,16 @@ export class OpenclawAcpAdapter implements RuntimeAdapter {
 // JSON-RPC stdio plumbing
 // ---------------------------------------------------------------------------
 
+function acpRuntimeLogName(gateway: NonNullable<RuntimeRunOptions["gateway"]>): string {
+  if (gateway.name.toLowerCase().includes("qclaw")) return "qclaw-acp";
+  try {
+    if (new URL(gateway.url).port === "28789") return "qclaw-acp";
+  } catch {
+    // Fall back to OpenClaw.
+  }
+  return "openclaw-acp";
+}
+
 function onStdoutChunk(handle: AcpProcessHandle, chunk: string): void {
   handle.buffer += chunk;
   let idx: number;
@@ -557,6 +589,7 @@ function onStdoutChunk(handle: AcpProcessHandle, chunk: string): void {
         error: err instanceof Error ? err.message : String(err),
         line: line.slice(0, 200),
       });
+      handle.trace?.write({ stream: "stdout_non_json", chunk: line });
       continue;
     }
     routeMessage(handle, msg);
@@ -571,14 +604,36 @@ function routeMessage(handle: AcpProcessHandle, msg: any): void {
     handle.pending.delete(id);
     if (msg.error) {
       const message = formatRpcError(msg.error);
+      handle.trace?.write({
+        stream: "rpc_in",
+        direction: "in",
+        id,
+        status: "error",
+        code: typeof msg.error.code === "number" ? msg.error.code : undefined,
+        error: message,
+      });
       pending.reject(new Error(message));
     } else {
+      handle.trace?.write({
+        stream: "rpc_in",
+        direction: "in",
+        id,
+        status: "response",
+        result: msg.result ?? null,
+      });
       pending.resolve(msg.result);
     }
     return;
   }
   // Notification.
   if (msg?.method && msg?.params) {
+    handle.trace?.write({
+      stream: "rpc_in",
+      direction: "in",
+      method: msg.method,
+      status: "notification",
+      params: msg.params,
+    });
     const sid = msg.params?.sessionId;
     if (typeof sid === "string") {
       const sub = handle.subscribers.get(sid);
@@ -604,6 +659,14 @@ function sendRequest(
   return new Promise((resolve, reject) => {
     const id = handle.nextId++;
     handle.pending.set(id, { resolve, reject, method });
+    handle.trace?.write({
+      stream: "rpc_out",
+      direction: "out",
+      id,
+      method,
+      status: "request",
+      params,
+    });
     const frame = JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n";
     try {
       handle.child.stdin.write(frame);
@@ -620,6 +683,13 @@ function sendNotification(
   params: any,
 ): void {
   if (handle.closed) return;
+  handle.trace?.write({
+    stream: "rpc_out",
+    direction: "out",
+    method,
+    status: "notification",
+    params,
+  });
   const frame = JSON.stringify({ jsonrpc: "2.0", method, params }) + "\n";
   try {
     handle.child.stdin.write(frame);


### PR DESCRIPTION
## Summary
- add daemon-owned ACP trace logs under `~/.botcord/logs/acp/<runtime>/*.jsonl` for Hermes, OpenClaw, and QClaw ACP traffic
- record safe-mode RPC metadata, child lifecycle, stderr, and non-JSON stdout with secret redaction; allow opt-out via `BOTCORD_ACP_LOGS=0` and verbose payloads via `BOTCORD_ACP_TRACE=verbose`
- include recent ACP logs and OpenClaw/QClaw/Hermes runtime logs in daemon diagnostics bundles
- pass turn/room context from the dispatcher into runtime options so ACP traces can be correlated with BotCord turns

## Tests
- `cd packages/daemon && npm run build`
- `cd packages/daemon && npm test -- src/__tests__/acp-logs.test.ts src/__tests__/diagnostics.test.ts src/gateway/__tests__/hermes-agent-adapter.test.ts src/__tests__/openclaw-acp.test.ts`