### PR TITLE
fix: update contacts detail routing

### DIFF
--- a/frontend/src/components/dashboard/sidebar/ContactsPanel.tsx
+++ b/frontend/src/components/dashboard/sidebar/ContactsPanel.tsx
@@ -119,8 +119,9 @@ export default function ContactsPanel({ onOpenAddFriend }: ContactsPanelProps) {
   const overview = useDashboardChatStore((s) => s.overview);
   const humanRooms = useDashboardSessionStore((s) => s.humanRooms);
   const ownedAgents = useDashboardSessionStore((s) => s.ownedAgents);
-  const { setSidebarTab, setContactsView, selectedContactKey, setSelectedContactKey } = useDashboardUIStore(useShallow((s) => ({
+  const { setSidebarTab, startPrimaryNavigation, setContactsView, selectedContactKey, setSelectedContactKey } = useDashboardUIStore(useShallow((s) => ({
     setSidebarTab: s.setSidebarTab,
+    startPrimaryNavigation: s.startPrimaryNavigation,
     setContactsView: s.setContactsView,
     selectedContactKey: s.selectedContactKey,
     setSelectedContactKey: s.setSelectedContactKey,
@@ -142,15 +143,38 @@ export default function ContactsPanel({ onOpenAddFriend }: ContactsPanelProps) {
   const groups = rooms.filter((r) => (r.member_count ?? 0) > 2);
 
   const openRequests = () => {
+    const path = "/chats/contacts/requests";
     setContactsView("requests");
     setSidebarTab("contacts");
     setSelectedContactKey(null);
-    startTransition(() => router.push("/chats/contacts/requests"));
+    startPrimaryNavigation("contacts", path);
+    startTransition(() => router.push(path));
   };
 
-  const selectAgent = (id: string) => setSelectedContactKey({ type: "agent", id });
-  const selectHuman = (id: string) => setSelectedContactKey({ type: "human", id });
-  const selectGroup = (id: string) => setSelectedContactKey({ type: "group", id });
+  const selectAgent = (id: string) => {
+    const path = "/chats/contacts/agents";
+    setContactsView("agents");
+    setSidebarTab("contacts");
+    setSelectedContactKey({ type: "agent", id });
+    startPrimaryNavigation("contacts", path);
+    startTransition(() => router.push(path));
+  };
+  const selectHuman = (id: string) => {
+    const path = "/chats/contacts/agents";
+    setContactsView("agents");
+    setSidebarTab("contacts");
+    setSelectedContactKey({ type: "human", id });
+    startPrimaryNavigation("contacts", path);
+    startTransition(() => router.push(path));
+  };
+  const selectGroup = (id: string) => {
+    const path = "/chats/contacts/rooms";
+    setContactsView("rooms");
+    setSidebarTab("contacts");
+    setSelectedContactKey({ type: "group", id });
+    startPrimaryNavigation("contacts", path);
+    startTransition(() => router.push(path));
+  };
 
   const isActive = (type: "agent" | "human" | "group", id: string) =>
     selectedContactKey?.type === type && selectedContactKey.id === id;
@@ -182,7 +206,7 @@ export default function ContactsPanel({ onOpenAddFriend }: ContactsPanelProps) {
         </div>
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
-            <span className="text-sm font-medium text-text-primary">New Requests</span>
+            <span className="text-sm font-medium text-text-primary">{t.newRequests}</span>
             {pending.length > 0 ? (
               <span className="rounded-full bg-neon-cyan px-1.5 text-[10px] font-bold text-black">
                 {pending.length}
@@ -199,7 +223,7 @@ export default function ContactsPanel({ onOpenAddFriend }: ContactsPanelProps) {
 
       <div className="flex-1 overflow-y-auto">
         {/* Agents */}
-        <Section title="Agents" count={ownedAgents.length + agentContacts.length}>
+        <Section title={t.agentsGroup} count={ownedAgents.length + agentContacts.length}>
           {/* Sub-group: my owned bots */}
           {ownedAgents.length > 0 ? (
             <SubGroupHeader title={t.myBotGroup} count={ownedAgents.length} />
@@ -236,9 +260,9 @@ export default function ContactsPanel({ onOpenAddFriend }: ContactsPanelProps) {
         </Section>
 
         {/* Humans */}
-        <Section title="Humans" count={humanContacts.length}>
+        <Section title={t.humansGroup} count={humanContacts.length}>
           {humanContacts.length === 0 ? (
-            <p className="px-3 py-3 text-xs text-text-secondary/50">No human contacts yet</p>
+            <p className="px-3 py-3 text-xs text-text-secondary/50">{t.noHumanContactsYet}</p>
           ) : (
             humanContacts.map((c) => (
               <ListRow
@@ -255,7 +279,7 @@ export default function ContactsPanel({ onOpenAddFriend }: ContactsPanelProps) {
         </Section>
 
         {/* Groups */}
-        <Section title="Groups" count={groups.length}>
+        <Section title={t.groupsGroup} count={groups.length}>
           {groups.length === 0 ? (
             <p className="px-3 py-3 text-xs text-text-secondary/50">{t.noGroupsJoined}</p>
           ) : (

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -558,11 +558,16 @@ export const chatPane: TranslationMap<{
 export const contactsUi: TranslationMap<{
   emptyTitle: string
   emptyDescription: string
+  newRequests: string
+  agentsGroup: string
+  humansGroup: string
+  groupsGroup: string
   myBotGroup: string
   externalBotGroup: string
   myBotSubtitle: string
   myBotSubtitleDefault: string
   noAgentsYet: string
+  noHumanContactsYet: string
   noGroupsJoined: string
   pendingRequests: (count: number) => string
   noPendingRequests: string
@@ -578,11 +583,16 @@ export const contactsUi: TranslationMap<{
   en: {
     emptyTitle: 'Pick a contact from the left',
     emptyDescription: 'Pick a Bot, human or group chat to view profile and start a conversation here.',
+    newRequests: 'New Requests',
+    agentsGroup: 'Agents',
+    humansGroup: 'Humans',
+    groupsGroup: 'Groups',
     myBotGroup: 'My Bots',
     externalBotGroup: 'Bot contacts',
     myBotSubtitle: 'My Bot',
     myBotSubtitleDefault: 'Default · My Bot',
     noAgentsYet: 'No agents yet',
+    noHumanContactsYet: 'No human contacts yet',
     noGroupsJoined: 'No groups joined yet',
     pendingRequests: (count) => `${count} pending request${count === 1 ? '' : 's'}`,
     noPendingRequests: 'No new requests',
@@ -598,11 +608,16 @@ export const contactsUi: TranslationMap<{
   zh: {
     emptyTitle: '从左侧选一个联系人',
     emptyDescription: '选择一个 Bot、真人或群聊，在这里查看资料并发起对话。',
+    newRequests: '新联系人请求',
+    agentsGroup: 'Bot',
+    humansGroup: '真人',
+    groupsGroup: '群聊',
     myBotGroup: '我的 Bot',
     externalBotGroup: 'Bot 联系人',
     myBotSubtitle: '我的 Bot',
     myBotSubtitleDefault: '默认 · 我的 Bot',
     noAgentsYet: '还没有 Agent',
+    noHumanContactsYet: '还没有真人联系人',
     noGroupsJoined: '还没加入任何群',
     pendingRequests: (count) => `${count} 个待处理请求`,
     noPendingRequests: '暂无新请求',


### PR DESCRIPTION
## Summary
- switch contacts sidebar selections out of the requests view before opening detail panes
- keep contacts URL state aligned for agent, human, and group selections
- add missing localized labels used by the contacts sidebar

## Testing
- npm run build (passes compile and TypeScript; fails during /admin/codes prerender because local Supabase URL/API key env vars are missing)