### PR TITLE
fix: use browser time for home greeting

### DIFF
--- a/frontend/src/components/dashboard/HomePanel.tsx
+++ b/frontend/src/components/dashboard/HomePanel.tsx
@@ -34,6 +34,14 @@ import BotAvatar from "./BotAvatar";
 import ExploreEntityCard from "./ExploreEntityCard";
 
 type AgentStats = ActivityStats | null;
+type GreetingPeriod = "morning" | "noon" | "evening";
+
+function getGreetingPeriod(date = new Date()): GreetingPeriod {
+  const hour = date.getHours();
+  if (hour < 12) return "morning";
+  if (hour < 18) return "noon";
+  return "evening";
+}
 
 function SectionHeader({
   title,
@@ -717,6 +725,7 @@ export default function HomePanel() {
     })),
   );
   const [statsByAgent, setStatsByAgent] = useState<Record<string, ActivityStats>>({});
+  const [greetingPeriod, setGreetingPeriod] = useState<GreetingPeriod>(() => getGreetingPeriod());
   const [deviceModalOpen, setDeviceModalOpen] = useState(false);
   const hasOnlineDaemon = useMemo(
     () => daemons.some((daemon) => daemon.status === "online"),
@@ -733,6 +742,13 @@ export default function HomePanel() {
   useEffect(() => {
     void refreshDaemons({ quiet: true });
   }, [refreshDaemons]);
+
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      setGreetingPeriod(getGreetingPeriod());
+    }, 60_000);
+    return () => window.clearInterval(id);
+  }, []);
 
   useEffect(() => {
     if (!deviceModalOpen || hasOnlineDaemon) return;
@@ -772,7 +788,7 @@ export default function HomePanel() {
       <div className="mx-auto max-w-5xl px-6 pb-10 pt-16">
         <div className="mb-10">
           <h1 className="text-4xl font-semibold tracking-tight text-text-primary">
-            {t.greetings.morning}, {displayName} 👋
+            {t.greetings[greetingPeriod]}, {displayName} 👋
           </h1>
           <p className="mt-3 text-base text-text-secondary/70">
             {t.homeSubtitle}

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -114,7 +114,7 @@ export const homePanel: TranslationMap<{
   zh: {
     greetings: {
       morning: '早安',
-      noon: '中午好',
+      noon: '午安',
       evening: '晚上好',
     },
     subtitle: '看看你的 Bots，再发现一些有趣的房间和人。',


### PR DESCRIPTION
## Summary
- choose the home panel greeting from the browser's local hour
- refresh the greeting every minute while the page stays open
- update the Chinese afternoon copy to 午安

## Tests
- NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build