### PR TITLE
fix: default login redirect to home

### DIFF
--- a/frontend/src/app/auth/callback/route.ts
+++ b/frontend/src/app/auth/callback/route.ts
@@ -5,7 +5,7 @@ import { findOrCreateUser } from "@/lib/auth";
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
-  const next = searchParams.get("next") ?? "/chats";
+  const next = searchParams.get("next") ?? "/chats/home";
 
   if (code) {
     const supabase = await createClient();

--- a/frontend/src/components/auth/LoginPage.tsx
+++ b/frontend/src/components/auth/LoginPage.tsx
@@ -27,7 +27,7 @@ export default function LoginPage() {
   const [message, setMessage] = useState("");
   const router = useRouter();
   const searchParams = useSearchParams();
-  const nextPath = searchParams.get("next") || "/chats/messages";
+  const nextPath = searchParams.get("next") || "/chats/home";
   const supabase = useMemo(() => createClient(), []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Default login redirects to /chats/home when no next parameter is provided
- Align OAuth auth callback fallback with the same home route

## Testing
- npm run build (fails during prerender of /admin/codes because local Supabase URL/API key env vars are missing)