### PR TITLE
fix: remove active agent switching from messages

### DIFF
--- a/frontend/src/components/agents/AddAgentPage.tsx
+++ b/frontend/src/components/agents/AddAgentPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 /**
- * [INPUT]: 依赖 userApi 的 issueBindTicket / getBindTicketStatus / revokeBindTicket，依赖 next 路由跳转新 agent
+ * [INPUT]: 依赖 userApi 的 issueBindTicket / getBindTicketStatus / revokeBindTicket，依赖 next 路由跳转新 bot 私聊
  * [OUTPUT]: 对外提供 AddAgentPage，承接 dashboard "Add Agent to OpenClaw" 入口
  * [POS]: /agents/add 落地页，展示一次性 install 命令并轮询 install-claim 完成态
  * [PROTOCOL]: 变更时更新此头部
@@ -10,8 +10,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Check, Copy, RefreshCw, Trash2 } from "lucide-react";
-import { setActiveAgentId, userApi, ApiError } from "@/lib/api";
-import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
+import { userApi, ApiError } from "@/lib/api";
 import type {
   BindTicketResponse,
   BindTicketStatusResponse,
@@ -29,9 +28,6 @@ function formatRemaining(secondsLeft: number): string {
 
 export default function AddAgentPage() {
   const router = useRouter();
-  const setSessionActiveAgentId = useDashboardSessionStore(
-    (state) => state.setActiveAgentId,
-  );
 
   const [intendedName, setIntendedName] = useState("");
   const [issuing, setIssuing] = useState(false);
@@ -184,13 +180,11 @@ export default function AddAgentPage() {
   // Auto-jump to the new agent once it is claimed.
   useEffect(() => {
     if (status !== "claimed" || !claimedAgentId) return;
-    setActiveAgentId(claimedAgentId);
-    setSessionActiveAgentId(claimedAgentId);
     const timeout = window.setTimeout(() => {
-      router.replace("/chats/messages/__user-chat__");
+      router.replace(`/chats/messages/__user-chat__?agent_id=${encodeURIComponent(claimedAgentId)}`);
     }, 1500);
     return () => window.clearTimeout(timeout);
-  }, [status, claimedAgentId, router, setSessionActiveAgentId]);
+  }, [status, claimedAgentId, router]);
 
   const copy = useCallback(async () => {
     if (!ticket?.install_command) return;

--- a/frontend/src/components/claim/ClaimAgentPage.tsx
+++ b/frontend/src/components/claim/ClaimAgentPage.tsx
@@ -9,8 +9,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { setActiveAgentId, userApi } from "@/lib/api";
-import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
+import { userApi } from "@/lib/api";
 
 interface ClaimAgentPageProps {
   claimCode: string;
@@ -27,7 +26,6 @@ export default function ClaimAgentPage({ claimCode }: ClaimAgentPageProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const continuePath = searchParams.get("next") || "/chats/messages/__user-chat__";
-  const setSessionActiveAgentId = useDashboardSessionStore((state) => state.setActiveAgentId);
 
   const [loading, setLoading] = useState(false);
   const [claimed, setClaimed] = useState<ClaimedAgent | null>(null);
@@ -126,9 +124,8 @@ export default function ClaimAgentPage({ claimCode }: ClaimAgentPageProps) {
             </p>
             <button
               onClick={() => {
-                setActiveAgentId(claimed.agent_id);
-                setSessionActiveAgentId(claimed.agent_id);
-                window.location.replace(continuePath);
+                const separator = continuePath.includes("?") ? "&" : "?";
+                window.location.replace(`${continuePath}${separator}agent_id=${encodeURIComponent(claimed.agent_id)}`);
               }}
               className="mt-4 rounded-lg border border-green-500/50 bg-green-500/20 px-4 py-2 text-sm font-medium text-green-100 hover:bg-green-500/30"
             >

--- a/frontend/src/components/dashboard/AccountMenu.tsx
+++ b/frontend/src/components/dashboard/AccountMenu.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useState } from "react";
-import type { UserAgent, UserProfile } from "@/lib/types";
+import type { UserProfile } from "@/lib/types";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { LogOut, Pencil, Settings } from "lucide-react";
 import HumanProfileEditModal from "./HumanProfileEditModal";
@@ -20,12 +20,7 @@ import { useShallow } from "zustand/react/shallow";
 
 interface AccountMenuProps {
   user: UserProfile | null;
-  agents: UserAgent[];
-  activeAgentId: string | null;
   pendingRequests: number;
-  agentsWithApprovals?: Set<string>;
-  onSwitchAgent: (agentId: string) => Promise<void> | void;
-  onOpenCreateBot: () => void;
   onLogout: () => void;
 }
 

--- a/frontend/src/components/dashboard/AgentRequiredState.tsx
+++ b/frontend/src/components/dashboard/AgentRequiredState.tsx
@@ -1,17 +1,16 @@
 "use client";
 
 /**
- * [INPUT]: 依赖 session/chat store 提供 agent 切换与刷新动作，依赖 AgentBindDialog 提供统一绑定入口
+ * [INPUT]: 依赖 session store 提供用户资料刷新，依赖 AgentBindDialog 提供统一绑定入口
  * [OUTPUT]: 对外提供 AgentRequiredState 组件，渲染“缺少当前 agent”空态与恢复动作
- * [POS]: dashboard 身份前置条件的复用提示层，被钱包、联系人等需要 active agent 的视图消费
+ * [POS]: dashboard 身份前置条件的复用提示层，被仍需 Bot 连接前置条件的视图消费
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
 
 import { useCallback, useState } from "react";
 import { useLanguage } from "@/lib/i18n";
-import { agentRequiredState, bindDialog } from "@/lib/i18n/translations/dashboard";
+import { bindDialog } from "@/lib/i18n/translations/dashboard";
 import { useShallow } from "zustand/react/shallow";
-import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import AgentBindDialog from "./AgentBindDialog";
 
@@ -26,22 +25,17 @@ export default function AgentRequiredState({
   description,
   compact = false,
 }: AgentRequiredStateProps) {
-  const { ownedAgents, refreshUserProfile } = useDashboardSessionStore(useShallow((state) => ({
-    ownedAgents: state.ownedAgents,
+  const { refreshUserProfile } = useDashboardSessionStore(useShallow((state) => ({
     refreshUserProfile: state.refreshUserProfile,
   })));
-  const switchActiveAgent = useDashboardChatStore((state) => state.switchActiveAgent);
   const [showBindDialog, setShowBindDialog] = useState(false);
-  const fallbackAgent = ownedAgents[0] ?? null;
   const locale = useLanguage();
-  const t = agentRequiredState[locale];
   const tb = bindDialog[locale];
 
-  const handleAgentBound = useCallback(async (agentId: string) => {
+  const handleAgentBound = useCallback(async () => {
     await refreshUserProfile();
-    await switchActiveAgent(agentId);
     setShowBindDialog(false);
-  }, [refreshUserProfile, switchActiveAgent]);
+  }, [refreshUserProfile]);
 
   const containerClass = compact
     ? "space-y-3 rounded-xl border border-glass-border bg-glass-bg p-4"
@@ -57,21 +51,9 @@ export default function AgentRequiredState({
           {description}
         </p>
         <div className={`${compact ? "space-y-2" : "mt-5 flex flex-col gap-3"}`}>
-          {fallbackAgent ? (
-            <button
-              onClick={() => switchActiveAgent(fallbackAgent.agent_id)}
-              className="w-full rounded-lg border border-neon-cyan/30 bg-neon-cyan/10 px-4 py-2 text-sm font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20"
-            >
-              {t.useAgent}{fallbackAgent.display_name}
-            </button>
-          ) : null}
           <button
             onClick={() => setShowBindDialog(true)}
-            className={`w-full rounded-lg border px-4 py-2 text-sm transition-colors ${
-              fallbackAgent
-                ? "border-glass-border text-text-primary hover:bg-glass-bg"
-                : "border-neon-cyan/30 bg-neon-cyan/10 font-medium text-neon-cyan hover:bg-neon-cyan/20"
-            }`}
+            className="w-full rounded-lg border border-neon-cyan/30 bg-neon-cyan/10 px-4 py-2 text-sm font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20"
           >
             {tb.linkAgentWithAi}
           </button>

--- a/frontend/src/components/dashboard/BotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/BotDetailDrawer.tsx
@@ -126,16 +126,9 @@ export default function BotDetailDrawer() {
       startPrimaryNavigation: s.startPrimaryNavigation,
     })),
   );
-  const { activeAgentId, ownedAgents } = useDashboardSessionStore(
-    useShallow((s) => ({ activeAgentId: s.activeAgentId, ownedAgents: s.ownedAgents })),
-  );
+  const ownedAgents = useDashboardSessionStore((s) => s.ownedAgents);
   const daemons = useDaemonStore((s) => s.daemons);
-  const { ownedAgentRooms, switchActiveAgent } = useDashboardChatStore(
-    useShallow((s) => ({
-      ownedAgentRooms: s.ownedAgentRooms,
-      switchActiveAgent: s.switchActiveAgent,
-    })),
-  );
+  const ownedAgentRooms = useDashboardChatStore((s) => s.ownedAgentRooms);
 
   const open = botDetailAgentId !== null;
   const bot = botDetailAgentId ? ownedAgents.find((a) => a.agent_id === botDetailAgentId) ?? null : null;
@@ -203,9 +196,6 @@ export default function BotDetailDrawer() {
     setMessagesPane("user-chat");
     setFocusedRoomId(null);
     setOpenedRoomId(null);
-    if (agentId !== activeAgentId) {
-      await switchActiveAgent(agentId);
-    }
     try {
       const room = await api.getUserChatRoom(agentId);
       setUserChatRoomId(room.room_id);

--- a/frontend/src/components/dashboard/ContactsDetailPane.tsx
+++ b/frontend/src/components/dashboard/ContactsDetailPane.tsx
@@ -121,22 +121,20 @@ export default function ContactsDetailPane() {
     setUserChatRoomId: s.setUserChatRoomId,
     startPrimaryNavigation: s.startPrimaryNavigation,
   })));
-  const { ownedAgents, humanRooms, activeAgentId, refreshHumanRooms } = useDashboardSessionStore(
+  const { ownedAgents, humanRooms, refreshHumanRooms } = useDashboardSessionStore(
     useShallow((s) => ({
       ownedAgents: s.ownedAgents,
       humanRooms: s.humanRooms,
-      activeAgentId: s.activeAgentId,
       refreshHumanRooms: s.refreshHumanRooms,
     })),
   );
-  const { overview, publicAgents, refreshOverview, loadRoomMessages, setError, switchActiveAgent } = useDashboardChatStore(
+  const { overview, publicAgents, refreshOverview, loadRoomMessages, setError } = useDashboardChatStore(
     useShallow((s) => ({
       overview: s.overview,
       publicAgents: s.publicAgents,
       refreshOverview: s.refreshOverview,
       loadRoomMessages: s.loadRoomMessages,
       setError: s.setError,
-      switchActiveAgent: s.switchActiveAgent,
     })),
   );
 
@@ -231,9 +229,6 @@ export default function ContactsDetailPane() {
     try {
       if (target.kind === "owned-bot") {
         const agentId = target.agent.agent_id;
-        if (agentId !== activeAgentId) {
-          await switchActiveAgent(agentId);
-        }
         const room = await api.getUserChatRoom(agentId);
         setMessagesPane("user-chat");
         setUserChatAgentId(agentId);

--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -93,7 +93,6 @@ export default function DashboardApp() {
   const locale = useLanguage();
   const tSidebar = sidebarI18n[locale];
   const tChatPane = chatPaneI18n[locale];
-  const recoveredAgentRef = useRef<string | null>(null);
   // Wallet is keyed on the active identity (agent OR human), since both
   // can own a wallet (`backend/app/routers/wallet.py:_resolve_owner`).
   const walletBoundIdentityRef = useRef<string | null>(null);
@@ -102,9 +101,8 @@ export default function DashboardApp() {
   const initResolvedRef = useRef(false);
   const lastAccessTokenRef = useRef<string | null>(null);
   const pathnameParts = useMemo(() => pathname.split("/").filter(Boolean), [pathname]);
+  const userChatAgentIdFromQuery = searchParams.get("agent_id");
   const shouldShowBootstrapSkeleton = !sessionStore.authResolved || sessionStore.authBootstrapping;
-  const fallbackAgent =
-    sessionStore.ownedAgents.find((agent) => agent.is_default) ?? sessionStore.ownedAgents[0] ?? null;
   // Human-first: never force-block on "no agent". Authed users always proceed
   // into /chats as their Human identity; creating an Agent is a later,
   // optional CTA. AgentGateModal is kept for manual entry points (account
@@ -277,6 +275,10 @@ export default function DashboardApp() {
             || roomIdFromSubtab.startsWith("rm_oc_")
           ));
         if (opensUserChat) {
+          const agentIdFromQuery = searchParams.get("agent_id");
+          if (agentIdFromQuery && uiStore.userChatAgentId !== agentIdFromQuery) {
+            uiStore.setUserChatAgentId(agentIdFromQuery);
+          }
           if (roomIdFromSubtab?.startsWith("rm_oc_") && uiStore.userChatRoomId !== roomIdFromSubtab) {
             uiStore.setUserChatRoomId(roomIdFromSubtab);
           }
@@ -331,37 +333,16 @@ export default function DashboardApp() {
     uiStore.clearPrimaryNavigation,
     uiStore.setMessagesPane,
     uiStore.setUserChatRoomId,
+    uiStore.setUserChatAgentId,
     uiStore.setExploreView,
     uiStore.setContactsView,
+    searchParams,
     chatStore.getRoomSummary,
     chatStore.discoverRooms,
     chatStore.messages,
     chatStore.loadPublicRoomDetail,
     chatStore.loadRoomMessages,
     chatStore.pollNewMessages,
-  ]);
-
-  useEffect(() => {
-    if (
-      !sessionStore.authResolved
-      || sessionStore.sessionMode !== "authed-no-agent"
-      || sessionStore.activeAgentId
-      || !fallbackAgent
-    ) {
-      if (sessionStore.sessionMode !== "authed-no-agent") {
-        recoveredAgentRef.current = null;
-      }
-      return;
-    }
-    if (recoveredAgentRef.current === fallbackAgent.agent_id) return;
-    recoveredAgentRef.current = fallbackAgent.agent_id;
-    void chatStore.switchActiveAgent(fallbackAgent.agent_id);
-  }, [
-    sessionStore.authResolved,
-    sessionStore.sessionMode,
-    sessionStore.activeAgentId,
-    fallbackAgent,
-    chatStore.switchActiveAgent,
   ]);
 
   useEffect(() => {
@@ -405,10 +386,6 @@ export default function DashboardApp() {
       return;
     }
 
-    if (chatStore.boundAgentId !== sessionStore.activeAgentId) {
-      chatStore.bindToActiveAgent(sessionStore.activeAgentId);
-    }
-
     if (walletBoundIdentityRef.current !== walletIdentityKey) {
       walletBoundIdentityRef.current = walletIdentityKey;
       walletStore.resetWalletState();
@@ -434,8 +411,6 @@ export default function DashboardApp() {
     sessionStore.activeAgentId,
     sessionStore.activeIdentity,
     uiStore.sidebarTab,
-    chatStore.boundAgentId,
-    chatStore.bindToActiveAgent,
     uiStore.resetUIState,
     chatStore.overview,
     chatStore.overviewRefreshing,
@@ -926,9 +901,6 @@ export default function DashboardApp() {
         uiStore.setUserChatAgentId(agentId);
         uiStore.setFocusedRoomId(null);
         uiStore.setOpenedRoomId(null);
-        if (agentId !== sessionStore.activeAgentId) {
-          await chatStore.switchActiveAgent(agentId);
-        }
         api.getUserChatRoom(agentId).then((room) => {
           uiStore.setUserChatRoomId(room.room_id);
         }).catch((error) => {
@@ -1054,7 +1026,7 @@ export default function DashboardApp() {
           />
         ) : uiStore.sidebarTab === "messages" && uiStore.messagesPane === "user-chat" ? (
           <div className="h-full min-w-0">
-            <UserChatPane agentId={uiStore.userChatAgentId} />
+            <UserChatPane agentId={uiStore.userChatAgentId || userChatAgentIdFromQuery} />
           </div>
         ) : (
           <div className="flex h-full min-w-0">
@@ -1078,7 +1050,7 @@ export default function DashboardApp() {
         <AgentGateModal
           onAgentReady={async (agentId) => {
             await sessionStore.refreshUserProfile();
-            await chatStore.switchActiveAgent(agentId);
+            uiStore.setUserChatAgentId(agentId);
           }}
         />
       ) : null}

--- a/frontend/src/components/dashboard/README.md
+++ b/frontend/src/components/dashboard/README.md
@@ -56,7 +56,7 @@ dashboard/
 - 消息会话状态拆为 `focusedRoomId` 与 `openedRoomId`：前者只在显式选中房间时驱动左侧高亮，后者负责会话头部与正文消息加载；`/chats/messages` 根路由不默认聚焦任何房间。
 - Contacts 采用与 Explore 同构的三级结构：二级仅导航，三级渲染联系人卡片与请求处理视图。
 - 消息入口采用微信/飞书式单列表：DM 与房间会话不再拆分 tab，统一在 `messages` 展示最近会话。
-- 用户与自己 active agent 的私聊不再占用一级 tab，而是固定插入 `messages` 列表首项，并使用特殊标记与 tooltip 明示“这是给自己 Agent 发消息的入口”。
+- 用户与自有 Bot 的私聊不再占用一级 tab，而是固定插入 `messages` 列表首项；打开具体 Bot 私聊时只设置 `userChatAgentId`，不切换全局身份。
 - 消息骨架采用共享组件统一渲染，`/chats` 首屏骨架与 user-chat 局部加载态只允许调参数，不允许再各画一套。
 - 登录但无 agent 时由 `AgentGateModal.tsx` 顶层强制拦截；在身份准备好之前不渲染主工作区，也不触发 rooms/messages API。
 - 话题分组语义统一从消息流派生：未加入成员或游客只要拿到公开消息，就能得到一致的 topic 分组视图，避免 message/topics 双接口时序竞争。
@@ -66,7 +66,7 @@ dashboard/
 - 一级/二级 tab 切换必须先提交本地导航状态，再以 transition 方式同步 URL；跨 tab 首次数据改为后台预热，不能让请求阻塞视图切换。
 - Bot 创建入口只允许留在 `My Bots` 面板；左下角账户菜单只保留“当前身份”列表与基础动作，无 agent 时也只能复用同一个创建模态，避免身份入口和 Bot 生命周期入口混在一起。
 - 群成员邀请入口必须挂在右侧成员面板，由 owner/admin 以 Human 身份发起；候选集合只来自“好友 + 自有 Agent”两类真数据源，先过滤已在群里的成员，再调用单一 `members` API，避免 UI 自己分叉出第三套邀请模型。
-- dashboard realtime 只维护“当前 active agent 的单 Supabase private channel 订阅”；channel 只发轻量 meta 事件，`useDashboardRealtimeStore.ts` 再驱动 `useDashboardChatStore.ts` 走 Next BFF 拉完整 overview / 房间增量数据，避免把广播层变成第二套消息协议。
+- dashboard realtime 订阅 Human 与默认自有 Bot 相关 topic；channel 只发轻量 meta 事件，`useDashboardRealtimeStore.ts` 再驱动 `useDashboardChatStore.ts` 走 Next BFF 拉完整 overview / 房间增量数据，避免把广播层变成第二套消息协议。
 - 未读状态以后端 `room_members.last_viewed_at` 为真相源：overview 返回 `has_unread` 与 `unread_count`，room 列表与 Messages 一级 tab 显示数量徽标；组件只在实时消息和“已看到底”之间维护短暂乐观覆盖。
 - `/chats` 顶层现在只做编排：`DashboardApp.tsx` 聚合 `session/ui/chat/realtime/unread/contact/wallet` 多个 store；组件层直接按职责从对应 store 取值，不再保留 dashboard 聚合 hook。
 
@@ -77,6 +77,7 @@ dashboard/
 
 ## 变更日志
 
+- 2026-05-14: 移除 Messages 里的 Bot 身份切换能力；点击自有 Bot 私聊、Bot 详情私聊、联系人里的 owned-bot 私聊都不再重绑 chat store 或强制刷新消息列表。
 - 2026-05-13: `messages` 分组侧栏只在已登录状态展示；游客态保留公开消息列表，不再显示分组栏或展开分组按钮。
 - 2026-05-12: `/chats` 根入口默认选中 Home tab；消息入口仍使用 `/chats/messages`。
 - 2026-04-28: `RoomList.tsx` 与 `Sidebar.tsx` 的未读提示从蓝点改为数量徽标，后端 overview 同步返回 `unread_count`。
@@ -87,7 +88,7 @@ dashboard/
 - 2026-04-24: `Sidebar.tsx` 与 `ChatPane.tsx` 的房间排序统一收敛到 `dashboard-shared.ts`，空房间改按 `created_at` 回退排序，新创建群不会再掉进列表中段。
 - 2026-04-24: `ChatPane.tsx` 的公开社区搜索改为直接调用 `/api/public/*?q=` 远端查询，停止只在首屏 50/100 条缓存上本地 `filter()` 的假搜索。
 - 2026-04-24: 新增 `AddRoomMemberModal.tsx`，并在 `AgentBrowser.tsx` 的群成员标题区补上“添加”入口；owner/admin 现在可以直接从好友或自有 Agent 中手动选人入群，不再只能依赖外部 invite 流程。
-- 2026-04-08: `ClaimAgentPage.tsx` 的 continue 改为先写入新 `active-agent` 再用浏览器级刷新进入目标 `/chats/*` 地址；`DashboardApp.tsx` 同步校验 chat store 的 `boundAgentId`，身份不一致时立即清空旧会话缓存，结束 claim 后继续页仍显示旧身份和旧会话列表的坏味道。
+- 2026-04-08: 历史上 claim 后曾写入本地 Bot 选择并重置 chat store；2026-05-14 后 claim/add 只通过 URL `agent_id` 打开目标 owner-chat，不再切换全局身份。
 - 2026-04-24: `Sidebar.tsx` 开始独占 `My Bots` 的创建入口；`AccountMenu.tsx` 收缩为纯账户菜单，并删除“还没有连接 Bot”等状态提示，结束左下角同时承担账户、身份和 Bot 生命周期管理的坏味道。
 - 2026-04-07: dashboard 内所有留在原位等待异步结果的关键操作按钮统一补上旋转 loading icon，包括好友请求、联系人审批、Join/Request Join、订阅、转账、提现、充值与邀请/分享创建，结束“按钮变灰但无明确工作中信号”的坏味道。
 - 2026-04-08: `LedgerList.tsx` 账本视图开始直接显示交易来源类型（如 claim gift / grant / transfer），结束“只有收支方向却看不出钱从哪来”的坏味道。
@@ -108,7 +109,7 @@ dashboard/
 - 2026-03-21: `DashboardApp.tsx` 改为订阅 `agent:{agent_id}` Supabase private broadcast；`MessageList.tsx` 去掉组件级 5 秒轮询，改为基于滚动位置维护前端已读水位；`RoomList.tsx` 与 `Sidebar.tsx` 新增消息未读蓝点。
 - 2026-03-20: `selectAgent` 语义收敛为“打开统一 Agent 卡片”，`DashboardApp.tsx` 挂载全局 `AgentCardModal`；`/chats/contacts/agents`、消息气泡发送者名、Explore/成员列表等入口统一弹卡片，不再自动拉起右侧 `AgentBrowser`。
 - 2026-03-20: `Sidebar.tsx` 将一级/二级 tab 的 `router.push` 包进 transition，并预取常用 `/chats/*` 子路由；`DashboardApp.tsx` 在后台预热 explore 与 wallet 数据，避免切 tab 时先等请求再换视图。
-- 2026-03-19: `AgentGateModal` 的顶层拦截收窄为“已登录且确实没有任何 owned agent”的 onboarding 场景；已有 agent 但 active agent 丢失时优先自动恢复，不再打断后续 room/tab 切换体验。
+- 2026-03-19: `AgentGateModal` 的顶层拦截收窄为“已登录且确实没有任何 owned agent”的 onboarding 场景；后续已改为 Human-first，不再依赖全局 Bot 选择恢复。
 - 2026-03-19: `DashboardApp.tsx` 仅在真正冷启动且无任何已知会话上下文时展示 `DashboardShellSkeleton`，已有用户/agent 上下文时直接复用应用内数据骨架，避免进入 `/chats` 出现双阶段 loading。
 - 2026-03-19: 新增 `DashboardShellSkeleton.tsx`，将 `/chats` 首屏等待从居中 spinner 改为整页应用骨架，降低路由进入时的抖动感。
 - 2026-03-19: `useDashboardStore` 移除语义混杂的全局 `loading`，拆为 `authBootstrapping` 与 `overviewRefreshing`，避免 tab 切换或身份切换误触发全局骨架屏。

--- a/frontend/src/components/dashboard/RoomList.tsx
+++ b/frontend/src/components/dashboard/RoomList.tsx
@@ -84,9 +84,10 @@ export default function RoomList({
     messages: state.messages,
     publicAgents: state.publicAgents,
   })));
-  const { focusedRoomId, messagesPane, closeMobileSidebar, setFocusedRoomId, setOpenedRoomId, setMessagesPane, setUserChatAgentId } = useDashboardUIStore(useShallow((state) => ({
+  const { focusedRoomId, messagesPane, userChatAgentId, closeMobileSidebar, setFocusedRoomId, setOpenedRoomId, setMessagesPane, setUserChatAgentId } = useDashboardUIStore(useShallow((state) => ({
     focusedRoomId: state.focusedRoomId,
     messagesPane: state.messagesPane,
+    userChatAgentId: state.userChatAgentId,
     closeMobileSidebar: state.closeMobileSidebar,
     setFocusedRoomId: state.setFocusedRoomId,
     setOpenedRoomId: state.setOpenedRoomId,
@@ -94,7 +95,6 @@ export default function RoomList({
     setUserChatAgentId: state.setUserChatAgentId,
   })));
   const activeAgentId = useDashboardSessionStore((state) => state.activeAgentId);
-  const switchActiveAgent = useDashboardSessionStore((state) => state.switchActiveAgent);
   const viewMode = useDashboardSessionStore((state) => state.viewMode);
   const humanRooms = useDashboardSessionStore((state) => state.humanRooms);
   const humanId = useDashboardSessionStore((state) => state.human?.human_id ?? null);
@@ -143,9 +143,6 @@ export default function RoomList({
   const handleSelect = async (room: DashboardRoom) => {
     if (isOwnerChatRoom(room.room_id)) {
       const agentId = room._originAgent?.agent_id || room.owner_id;
-      if (agentId && agentId !== activeAgentId) {
-        await switchActiveAgent(agentId);
-      }
       setUserChatAgentId(agentId || null);
       setMessagesPane("user-chat");
       setFocusedRoomId(null);
@@ -261,7 +258,7 @@ export default function RoomList({
       {rooms.map((room) => {
         const ownerChatAgentId = isOwnerChatRoom(room.room_id) ? room._originAgent?.agent_id || room.owner_id : null;
         const isSelected = ownerChatAgentId
-          ? messagesPane === "user-chat" && ownerChatAgentId === activeAgentId
+          ? messagesPane === "user-chat" && ownerChatAgentId === (userChatAgentId || activeAgentId)
           : messagesPane === "room" && focusedRoomId === room.room_id;
         const roomMessages = messages[room.room_id] || [];
         // Find the latest real message (skip ack/result/error receipts)

--- a/frontend/src/components/dashboard/sidebar/index.tsx
+++ b/frontend/src/components/dashboard/sidebar/index.tsx
@@ -37,7 +37,7 @@ import BotsPanel from "./BotsPanel";
 import MessagesPanel from "./MessagesPanel";
 import { SidebarListSkeleton, SkeletonBlock } from "../DashboardTabSkeleton";
 
-import { api, humansApi } from "@/lib/api";
+import { api } from "@/lib/api";
 import { UserPlus, LogIn, Bot, Plus, RefreshCw, MessageSquarePlus, Search, X } from "lucide-react";
 import { useAppStore } from "@/store/useAppStore";
 
@@ -170,7 +170,6 @@ export default function Sidebar({
   const chatStore = useDashboardChatStore(useShallow((s) => ({
     overview: s.overview,
     recentVisitedRooms: s.recentVisitedRooms,
-    switchActiveAgent: s.switchActiveAgent,
   })));
   const unreadStore = useDashboardUnreadStore(useShallow((s) => ({
     optimisticUnreadRoomIds: s.optimisticUnreadRoomIds,
@@ -182,7 +181,6 @@ export default function Sidebar({
   const [showCreateRoom, setShowCreateRoom] = useState(false);
   const [refreshingBots, setRefreshingBots] = useState(false);
   const [createBotForDaemonId, setCreateBotForDaemonId] = useState<string | null>(null);
-  const [agentsWithApprovals, setAgentsWithApprovals] = useState<Set<string>>(new Set());
 
   const showCreateBot = uiStore.createBotModalOpen;
   const setShowCreateBot = (v: boolean) => v ? uiStore.openCreateBotModal() : uiStore.closeCreateBotModal();
@@ -289,22 +287,6 @@ export default function Sidebar({
     prefetch("/chats/wallet");
     prefetch("/chats/activity");
   }, [router, uiStore.contactsView, uiStore.exploreView]);
-
-  useEffect(() => {
-    let cancelled = false;
-    const fetchApprovals = async () => {
-      try {
-        const res = await humansApi.listPendingApprovals();
-        if (!cancelled) {
-          setAgentsWithApprovals(new Set(res.approvals.map((a: { agent_id: string }) => a.agent_id)));
-        }
-      } catch {
-        // non-fatal
-      }
-    };
-    void fetchApprovals();
-    return () => { cancelled = true; };
-  }, []);
 
   const showLoginModal = () => router.push("/login");
 
@@ -416,12 +398,7 @@ export default function Sidebar({
             <>
               <AccountMenu
                 user={sessionStore.user}
-                agents={sessionStore.ownedAgents}
-                activeAgentId={sessionStore.activeAgentId}
                 pendingRequests={chatStore.overview?.pending_requests || 0}
-                agentsWithApprovals={agentsWithApprovals}
-                onSwitchAgent={chatStore.switchActiveAgent}
-                onOpenCreateBot={() => setShowCreateBot(true)}
                 onLogout={handleLogout}
               />
             </>

--- a/frontend/src/components/share/InviteLinkView.tsx
+++ b/frontend/src/components/share/InviteLinkView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 /**
- * [INPUT]: 依赖分享/邀请 API 读取邀请预览，依赖 Supabase session 与本地 active agent 判断用户是否可直接兑换
+ * [INPUT]: 依赖分享/邀请 API 读取邀请预览，依赖 Supabase session 与用户资料判断用户是否可直接兑换
  * [OUTPUT]: 对外提供 InviteLinkView 组件，负责好友/群邀请页的预览、兑换与续接跳转
  * [POS]: marketing invite 页面主体，统一承接 `/i/[inviteCode]` 的公开入口
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
@@ -9,7 +9,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { api, ApiError, getActiveAgentId, userApi } from "@/lib/api";
+import { api, ApiError, userApi } from "@/lib/api";
 import type { InvitePreviewResponse } from "@/lib/types";
 import { createClient } from "@/lib/supabase/client";
 import { useLanguage } from "@/lib/i18n";
@@ -56,8 +56,7 @@ export default function InviteLinkView({ inviteCode }: { inviteCode: string }) {
         try {
           const me = await userApi.getMe({ force: true });
           if (cancelled) return;
-          const activeAgentId = getActiveAgentId();
-          const isReady = Boolean(activeAgentId && me.agents.some((agent) => agent.agent_id === activeAgentId));
+          const isReady = me.agents.length > 0;
           setAuthMode(isReady ? "authed-ready" : "authed-no-agent");
         } catch {
           if (!cancelled) setAuthMode("guest");

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -82,8 +82,8 @@ import { createClient } from "@/lib/supabase/client";
 import type { AgentPresenceSnapshotPayload } from "@/store/usePresenceStore";
 
 /**
- * [INPUT]: Supabase client-side SDK for auth tokens, browser fetch, local active-agent state
- * [OUTPUT]: api/userApi request wrappers, ApiError class, active-agent utilities
+ * [INPUT]: Supabase client-side SDK for auth tokens and browser fetch
+ * [OUTPUT]: api/userApi request wrappers, ApiError class, legacy agent-selection utilities
  * [POS]: frontend data access layer — all calls go directly to the backend Hub API
  * [PROTOCOL]: update this header on changes, then check README.md
  */

--- a/frontend/src/store/README.md
+++ b/frontend/src/store/README.md
@@ -5,7 +5,7 @@
 成员清单
 useAppStore.ts: 全局轻量 UI 状态（语言等），独立于 dashboard 业务域。  
 dashboard-shared.ts: dashboard 多 store 共享的房间摘要、时间比较与增量拉取辅助函数。  
-useDashboardSessionStore.ts: Session 业务域 store，负责登录态、用户资料、活跃 agent 与鉴权初始化。  
+useDashboardSessionStore.ts: Session 业务域 store，负责登录态、用户资料、Human 身份与鉴权初始化。
 useDashboardUIStore.ts: 纯界面状态 store，负责 tab、消息特殊入口选择、房间焦点、右侧面板与 Agent 卡片开合。  
 useDashboardChatStore.ts: Chat 数据 store，负责 overview、消息缓存、房间成员刷新版本、公开目录远端搜索结果与 Agent 卡片数据。  
 useDashboardRealtimeStore.ts: Realtime 协调 store，负责 Supabase channel 连接状态与“事件 -> 最小同步”决策。  
@@ -25,18 +25,19 @@ useDashboardSubscriptionStore.ts: Subscription 业务域 store，负责当前 ag
 
 开发规范
 - 新增业务状态优先放到对应业务 store，不再向 `DashboardApp` 回灌跨域字段。
-- 跨域依赖只能读取必要上下文（如 token/activeAgentId），避免双向循环调用。
-- 任何跨域状态重置（如 agent 切换、退出登录）必须在聚合层显式同步。
-- `useDashboardChatStore.ts` 的会话列表缓存必须绑定当前 active agent；身份切换后先换真相源，再清空上一身份残留，不能让 recents/overview 跨 agent 泄漏。
+- 跨域依赖只能读取必要上下文（如 token/Human identity），避免双向循环调用。
+- 任何跨域状态重置（如退出登录）必须在聚合层显式同步。
+- `useDashboardChatStore.ts` 的会话列表缓存绑定 Human 视角；选择某个 Bot 的私聊只写入 UI 目标，不允许重置 overview/messages。
 - Supabase realtime 在线时，消息更新必须走 `useDashboardRealtimeStore.ts` 的同步动作；不要重新引入组件级定时轮询制造第二数据入口。
 - 进入房间并真正看到最新位置后，必须通过 BFF 写回 `last_viewed_at`；前端本地未读数量只能做短暂覆盖，不能替代后端状态。
 
 变更日志
+- 2026-05-14: 移除 dashboard 前端的 Bot 身份切换能力；`userChatAgentId` 只作为 owner-chat 目标，`useDashboardChatStore.ts` 不再按 Bot 边界清空消息列表。
 - 2026-05-11: `useDashboardRealtimeStore.ts` 在 `room_member_added/room_member_removed` 事件后推进 `useDashboardChatStore.ts` 的房间成员刷新版本，打开中的房间会重新拉取成员，让 @ 候选人与 presence 种子及时包含新成员。
 - 2026-04-28: overview 房间摘要新增 `unread_count`，Messages 一级 tab 与 room 列表使用数量徽标替代未读蓝点。
 - 2026-04-24: `dashboard-shared.ts` 新增统一房间活跃度排序 helper，消息列表与联系人房间视图都以 `last_message_at -> created_at` 同一规则排序，消除重复排序逻辑漂移。
 - 2026-04-24: `useDashboardChatStore.ts` 的公开目录加载动作开始接收 `q` 并做请求序号保护，公开社区搜索不再依赖首屏缓存，也不会被旧请求回写覆盖。
-- 2026-04-08: `useDashboardChatStore.ts` 新增 `boundAgentId` 边界，claim/切换身份后会先切 active agent 再硬刷新，并在 agent 不一致时清空上一身份的会话缓存，修复 `/chats` 继续进入仍显示旧身份与旧会话列表残留的问题。
+- 2026-04-08: 历史上 `useDashboardChatStore.ts` 曾新增 Bot 边界缓存重置；2026-05-14 已移除该策略，Messages 统一回到 Human 视角缓存。
 - 2026-04-07: `useDashboardContactStore.ts` 的联系人请求提交/处理状态细化为“按目标 agent 跟踪发送中”和“按 request + action 跟踪处理中”，让按钮 loading 能准确落在真正正在执行的那一项上。
 - 2026-03-25: `useDashboardUIStore.ts` 新增 `messagesPane`，把“固定私聊入口”和普通房间选择拆开，避免再用一级 tab 承载同属 `messages` 域的特殊会话。
 - 2026-03-22: 新增 `useDashboardSubscriptionStore.ts`，把付费房间的订阅状态从 `SubscriptionBadge.tsx` 组件内缓存上收回到业务 store，统一支撑 Header join、订阅弹窗与成员面板底部的退订动作。

--- a/frontend/src/store/dashboard-shared.ts
+++ b/frontend/src/store/dashboard-shared.ts
@@ -1,5 +1,5 @@
 /**
- * [INPUT]: 依赖 dashboard 类型定义、@/lib/api 的 active-agent 工具与浏览器时间解析
+ * [INPUT]: 依赖 dashboard 类型定义、DM 解析工具与浏览器时间解析
  * [OUTPUT]: 对外提供 dashboard chat/unread/realtime store 共用的房间摘要、DM 类型推断、合并与时间比较工具
  * [POS]: frontend store 层的共享基础模块，负责消除多 store 拆分后的重复逻辑
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
@@ -13,7 +13,6 @@ import type {
   ParticipantType,
   PublicRoom,
 } from "@/lib/types";
-import { getActiveAgentId } from "@/lib/api";
 import { parseDmRoomId } from "@/components/dashboard/dmRoom";
 
 export const roomMessagesInFlight = new Set<string>();
@@ -38,10 +37,6 @@ export function toRoomSummary(room: PublicRoom): DashboardRoom {
     last_message_at: room.last_message_at,
     last_sender_name: room.last_sender_name,
   };
-}
-
-export function hasReadyActiveAgent(token: string | null, activeAgentId?: string | null): activeAgentId is string {
-  return Boolean(token && (activeAgentId || getActiveAgentId()));
 }
 
 export function getIsoTimestampValue(isoTime: string | null | undefined): number {

--- a/frontend/src/store/useDashboardChatStore.ts
+++ b/frontend/src/store/useDashboardChatStore.ts
@@ -84,7 +84,6 @@ export function mapOwnedAgentRoomToDashboardRoom(room: HumanAgentRoomSummary): D
 }
 
 interface DashboardChatState {
-  boundAgentId: string | null;
   overviewRefreshing: boolean;
   overviewErrored: boolean;
   overview: DashboardOverview | null;
@@ -120,7 +119,6 @@ interface DashboardChatState {
 
   setError: (error: string | null) => void;
   addRecentPublicRoom: (room: PublicRoom) => void;
-  bindToActiveAgent: (agentId: string | null) => void;
   resetChatState: () => void;
   logout: () => void;
   closeAgentCardState: () => void;
@@ -147,11 +145,9 @@ interface DashboardChatState {
   loadPublicAgents: (q?: string) => Promise<void>;
   loadPublicHumans: (q?: string) => Promise<void>;
   loadOwnedAgentRooms: () => Promise<void>;
-  switchActiveAgent: (agentId: string) => Promise<void>;
 }
 
 const initialChatState = {
-  boundAgentId: null,
   overviewRefreshing: false,
   overviewErrored: false,
   overview: null,
@@ -239,20 +235,6 @@ export const useDashboardChatStore = create<DashboardChatState>()(
             ...state.recentVisitedRooms.filter((item) => item.room_id !== room.room_id),
           ].slice(0, 20),
         })),
-
-      bindToActiveAgent: (agentId) =>
-        set((state) => {
-          if (state.boundAgentId === agentId) {
-            return state;
-          }
-          return {
-            ...initialChatState,
-            boundAgentId: agentId,
-            publicRooms: state.publicRooms,
-            publicAgents: state.publicAgents,
-            publicRoomDetails: state.publicRoomDetails,
-          };
-        }),
 
       resetChatState: () =>
         set((state) => {
@@ -704,17 +686,10 @@ export const useDashboardChatStore = create<DashboardChatState>()(
         }
       },
 
-      switchActiveAgent: async (agentId: string) => {
-        const { activeAgentId } = useDashboardSessionStore.getState();
-        if (agentId === activeAgentId) return;
-        get().bindToActiveAgent(agentId);
-        useDashboardSessionStore.getState().switchActiveAgent(agentId);
-      },
     }),
     {
       name: "dashboard-chat-storage",
       partialize: (state) => ({
-        boundAgentId: state.boundAgentId,
         recentVisitedRooms: state.recentVisitedRooms,
         publicRooms: state.publicRooms,
         publicAgents: state.publicAgents,

--- a/frontend/src/store/useDashboardSessionStore.ts
+++ b/frontend/src/store/useDashboardSessionStore.ts
@@ -1,5 +1,5 @@
 /**
- * [INPUT]: 依赖 zustand 保存 dashboard 会话状态，依赖 @/lib/api 与 active-agent 工具完成用户身份解析
+ * [INPUT]: 依赖 zustand 保存 dashboard 会话状态，依赖 @/lib/api 完成用户身份解析
  * [OUTPUT]: 对外提供 useDashboardSessionStore 会话域状态仓库与鉴权相关异步动作
  * [POS]: frontend dashboard 的 session 主域，负责登录态、用户资料、活跃 agent 与准入模式
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
@@ -10,8 +10,6 @@ import type { HumanInfo, HumanRoomSummary, UserProfile, UserAgent } from "@/lib/
 import {
   humansApi,
   userApi,
-  getActiveAgentId,
-  setActiveAgentId as persistActiveAgentId,
   setStoredActiveIdentity,
 } from "@/lib/api";
 import { usePresenceStore } from "./usePresenceStore";
@@ -58,7 +56,6 @@ interface DashboardSessionState {
   setAuthResolved: (resolved: boolean) => void;
   setToken: (token: string | null) => void;
   setUser: (user: UserProfile) => void;
-  setActiveAgentId: (agentId: string | null) => void;
   setViewMode: (mode: "human" | "agent") => void;
   setActiveIdentity: (identity: ActiveIdentity | null) => void;
   resetSessionState: () => void;
@@ -66,7 +63,6 @@ interface DashboardSessionState {
   refreshUserProfile: () => Promise<void>;
   refreshHumanRooms: () => Promise<void>;
   removeAgent: (agentId: string) => void;
-  switchActiveAgent: (agentId: string) => Promise<void>;
   logout: () => void;
 }
 
@@ -90,11 +86,7 @@ function deriveIdentityFromHuman(human: HumanInfo | null): ActiveIdentity | null
 
 let authInitRequestId = 0;
 
-function resolveStoredActiveAgentId(user: UserProfile): string | null {
-  const savedAgentId = getActiveAgentId();
-  if (savedAgentId && user.agents.some((agent) => agent.agent_id === savedAgentId)) {
-    return savedAgentId;
-  }
+function resolveDefaultAgentId(user: UserProfile): string | null {
   const defaultAgent = user.agents.find((agent) => agent.is_default) || user.agents[0];
   return defaultAgent?.agent_id ?? null;
 }
@@ -112,7 +104,6 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
   setToken: (token) => {
     if (!token) {
       authInitRequestId += 1;
-      persistActiveAgentId(null);
       setStoredActiveIdentity(null);
       set({
         ...initialSessionState,
@@ -122,17 +113,16 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
       return;
     }
 
-    const activeAgentId = get().activeAgentId || getActiveAgentId();
     const activeIdentity = deriveIdentityFromHuman(get().human);
     setStoredActiveIdentity(activeIdentity);
     set({
       authResolved: true,
       authBootstrapping: false,
       token,
-      activeAgentId,
+      activeAgentId: get().activeAgentId,
       activeIdentity,
       viewMode: "human",
-      sessionMode: resolveSessionMode(token, activeAgentId),
+      sessionMode: resolveSessionMode(token, get().activeAgentId),
     });
   },
 
@@ -154,17 +144,6 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
         user: state.user ? { ...state.user, display_name: human.display_name, avatar_url: human.avatar_url } : state.user,
         activeIdentity,
         viewMode: "human",
-      };
-    }),
-
-  setActiveAgentId: (agentId) =>
-    set((state) => {
-      persistActiveAgentId(agentId);
-      return {
-        activeAgentId: agentId,
-        activeIdentity: state.activeIdentity,
-        viewMode: "human",
-        sessionMode: resolveSessionMode(state.token, agentId),
       };
     }),
 
@@ -195,7 +174,6 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
 
   resetSessionState: () => {
     authInitRequestId += 1;
-    persistActiveAgentId(null);
     setStoredActiveIdentity(null);
     set({ ...initialSessionState });
   },
@@ -229,8 +207,7 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
       if (requestId !== authInitRequestId) {
         return;
       }
-      const activeId = resolveStoredActiveAgentId(user);
-      persistActiveAgentId(activeId);
+      const activeId = resolveDefaultAgentId(user);
       const activeIdentity = deriveIdentityFromHuman(human);
       setStoredActiveIdentity(activeIdentity);
       syncOwnedAgentsPresence(user.agents);
@@ -252,7 +229,6 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
         return;
       }
       if (err?.status === 401 || err?.status === 403) {
-        persistActiveAgentId(null);
         setStoredActiveIdentity(null);
         set({
           ...initialSessionState,
@@ -261,7 +237,6 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
         });
         return;
       }
-      persistActiveAgentId(null);
       setStoredActiveIdentity(null);
       set({
         authResolved: true,
@@ -288,8 +263,7 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
   refreshUserProfile: async () => {
     try {
       const user = await userApi.getMe({ force: true });
-      const activeAgentId = resolveStoredActiveAgentId(user);
-      persistActiveAgentId(activeAgentId);
+      const activeAgentId = resolveDefaultAgentId(user);
       syncOwnedAgentsPresence(user.agents);
       set((state) => {
         const nextIdentity = deriveIdentityFromHuman(state.human);
@@ -314,7 +288,6 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
     const newActiveId = agentId === activeAgentId
       ? (remaining.find((a) => a.is_default) || remaining[0])?.agent_id ?? null
       : activeAgentId;
-    persistActiveAgentId(newActiveId);
     set({
       ownedAgents: remaining,
       activeAgentId: newActiveId,
@@ -324,19 +297,8 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
     });
   },
 
-  switchActiveAgent: async (agentId: string) => {
-    persistActiveAgentId(agentId);
-    set((state) => ({
-      activeAgentId: agentId,
-      activeIdentity: state.activeIdentity,
-      viewMode: "human",
-      sessionMode: resolveSessionMode(state.token, agentId),
-    }));
-  },
-
   logout: () => {
     authInitRequestId += 1;
-    persistActiveAgentId(null);
     setStoredActiveIdentity(null);
     usePresenceStore.getState().reset();
     set({

--- a/frontend/src/store/useDashboardSubscriptionStore.ts
+++ b/frontend/src/store/useDashboardSubscriptionStore.ts
@@ -1,5 +1,5 @@
 /**
- * [INPUT]: 依赖 zustand 保存订阅域状态，依赖 @/lib/api 发起订阅查询/订阅/退订请求，依赖 session store 提供当前 active agent
+ * [INPUT]: 依赖 zustand 保存订阅域状态，依赖 @/lib/api 发起订阅查询/订阅/退订请求，依赖 session store 提供当前身份上下文
  * [OUTPUT]: 对外提供 useDashboardSubscriptionStore 订阅业务域仓库与订阅生命周期动作
  * [POS]: frontend dashboard 的订阅真相源，统一管理当前 agent 的订阅列表与商品级订阅状态
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md


### PR DESCRIPTION
## Summary
- remove dashboard active-agent switching and chat-store rebinding from Messages owner-chat flows
- route owned-bot owner chats via userChatAgentId / URL agent_id instead of mutating global agent state
- stop Add/Claim Bot flows from writing local active-agent state before opening owner-chat

## Tests
- npm test -- --run src/store/useDashboardChatStore.test.ts src/store/useDashboardUIStore.test.ts src/store/dashboard-shared.test.ts src/lib/messages-merge.test.ts
- npm run build (fails during prerender /admin/codes because Supabase URL/API key env vars are not configured locally; compile and TypeScript stages pass)