### PR TITLE
fix: align discover tab active color

### DIFF
--- a/frontend/src/components/dashboard/sidebar/index.tsx
+++ b/frontend/src/components/dashboard/sidebar/index.tsx
@@ -341,7 +341,6 @@ export default function Sidebar({
         <div className="flex flex-1 flex-col items-center gap-1 pt-1 max-md:min-w-0 max-md:flex-row max-md:justify-around max-md:pt-0">
           {navItems.map((item) => {
             const isActive = uiStore.sidebarTab === item.key;
-            const isExplore = item.key === "explore";
             const requiresLogin = isGuest && (item.key === "contacts" || item.key === "activity");
             let badge: ReactNode = null;
             if (item.key === "messages" && unreadMessageCount > 0 && !requiresLogin) {
@@ -363,7 +362,7 @@ export default function Sidebar({
                 key={item.key}
                 onClick={() => navigatePrimaryTab(item.key)}
                 active={isActive}
-                activeTone={isExplore ? "purple" : "cyan"}
+                activeTone="cyan"
                 badge={badge}
                 disabled={requiresLogin}
                 icon={item.icon}


### PR DESCRIPTION
## Summary
- Make the Discover primary nav tab use the same cyan active state as the other tabs
- Remove the special purple active-state branch for Explore/Discover

## Testing
- `cd frontend && npm run build` *(compilation and TypeScript passed; prerender failed on `/admin/codes` because local Supabase URL/API key env vars are missing)*