### PR TITLE
feat: show runtime error message details

### DIFF
--- a/backend/hub/routers/dashboard.py
+++ b/backend/hub/routers/dashboard.py
@@ -83,6 +83,12 @@ def _extract_text_from_envelope(envelope_data: dict) -> tuple[str, str, dict]:
         text = payload.get("message", "")
         if text is not None and not isinstance(text, str):
             text = str(text)
+    if not text and msg_type == "error":
+        error = payload.get("error")
+        if isinstance(error, dict):
+            text = error.get("message") or error.get("code") or ""
+            if text is not None and not isinstance(text, str):
+                text = str(text)
     return sender_id, text, payload
 
 async def _build_dashboard_rooms(

--- a/backend/tests/test_dashboard_error_messages.py
+++ b/backend/tests/test_dashboard_error_messages.py
@@ -1,0 +1,32 @@
+from hub.routers.dashboard import _extract_text_from_envelope
+
+
+def test_dashboard_extracts_error_payload_message_as_text():
+    sender_id, text, payload = _extract_text_from_envelope(
+        {
+            "from": "ag_runtime",
+            "type": "error",
+            "payload": {
+                "error": {
+                    "code": "agent_error",
+                    "message": "Runtime error: missing API key",
+                }
+            },
+        }
+    )
+
+    assert sender_id == "ag_runtime"
+    assert text == "Runtime error: missing API key"
+    assert payload["error"]["code"] == "agent_error"
+
+
+def test_dashboard_error_text_falls_back_to_code():
+    _, text, _ = _extract_text_from_envelope(
+        {
+            "from": "ag_runtime",
+            "type": "error",
+            "payload": {"error": {"code": "agent_error"}},
+        }
+    )
+
+    assert text == "agent_error"

--- a/frontend/src/components/dashboard/MessageBubble.tsx
+++ b/frontend/src/components/dashboard/MessageBubble.tsx
@@ -3,8 +3,9 @@
 import { useCallback, useLayoutEffect, useRef, useState } from "react";
 import type { KeyboardEvent, ReactNode } from "react";
 import { createPortal } from "react-dom";
-import { Bot, ChevronDown, ChevronUp, MoreHorizontal, User } from "lucide-react";
+import { AlertTriangle, Bot, ChevronDown, ChevronUp, MoreHorizontal, User } from "lucide-react";
 import ForwardModal from "./ForwardModal";
+import RuntimeErrorDetailsDialog from "./RuntimeErrorDetailsDialog";
 import type { DashboardMessage, Attachment } from "@/lib/types";
 import { useLanguage } from '@/lib/i18n';
 import { messageBubble } from '@/lib/i18n/translations/dashboard';
@@ -347,6 +348,7 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
   const [hovered, setHovered] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const [forwardQuote, setForwardQuote] = useState<string | null>(null);
+  const [showErrorDetails, setShowErrorDetails] = useState(false);
   const locale = useLanguage();
   const selectAgent = useDashboardChatStore((state) => state.selectAgent);
   const publicHumans = useDashboardChatStore((state) => state.publicHumans);
@@ -354,8 +356,20 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
   const user = useDashboardSessionStore((state) => state.user);
   const requestOpenHuman = useDashboardUIStore((state) => state.requestOpenHuman);
   const stateConfig = useStateConfig();
+  const errorPayload =
+    message.payload?.error && typeof message.payload.error === "object"
+      ? message.payload.error as Record<string, unknown>
+      : null;
+  const errorMessage =
+    typeof errorPayload?.message === "string"
+      ? errorPayload.message
+      : typeof errorPayload?.code === "string"
+        ? errorPayload.code
+        : "";
+  const errorCode = typeof errorPayload?.code === "string" ? errorPayload.code : null;
   const textContent = message.payload?.text || message.payload?.body || message.payload?.message;
-  const displayText = typeof textContent === "string" ? textContent : message.text;
+  const displayText = typeof textContent === "string" ? textContent : message.text || errorMessage;
+  const isErrorMessage = message.type === "error";
   const timestampLabel = formatMessageTimestamp(message.created_at);
   const isOwn = typeof message.is_mine === "boolean" ? message.is_mine : isOwnProp;
   const isHuman = message.sender_kind === "human";
@@ -482,9 +496,11 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
       {!isOwn && sideAvatar}
       <div
         className={`${fullWidth ? "w-full" : "max-w-[70%]"} rounded-xl px-3 py-2 ${
-          isOwn
-            ? "border border-neon-cyan/30 bg-neon-cyan/5"
-            : "border border-glass-border bg-glass-bg"
+          isErrorMessage
+            ? "border border-amber-400/25 bg-amber-400/10"
+            : isOwn
+              ? "border border-neon-cyan/30 bg-neon-cyan/5"
+              : "border border-glass-border bg-glass-bg"
         }`}
       >
         <div
@@ -524,7 +540,27 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
           </div>
         )}
 
-        {transferInfo ? (
+        {isErrorMessage ? (
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              setShowErrorDetails(true);
+            }}
+            className="mt-2 flex w-full items-start gap-2 rounded-lg border border-amber-400/20 bg-amber-400/10 px-2.5 py-2 text-left transition-colors hover:bg-amber-400/15"
+          >
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-300" />
+            <span className="min-w-0 flex-1">
+              <span className="block text-xs font-semibold uppercase tracking-wide text-amber-300">
+                Runtime error
+              </span>
+              <span className="mt-1 line-clamp-3 block break-words text-sm leading-relaxed text-amber-100">
+                {displayText || "Runtime error"}
+              </span>
+              <span className="mt-1 block text-xs text-amber-300/70">Details</span>
+            </span>
+          </button>
+        ) : transferInfo ? (
           <TransferCard info={transferInfo} isNotice={displayText?.startsWith("[BotCord Notice]")} />
         ) : (
           displayText && (
@@ -587,6 +623,15 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
     </div>
     {forwardQuote && (
       <ForwardModal quoteText={forwardQuote} onClose={() => setForwardQuote(null)} />
+    )}
+    {showErrorDetails && createPortal(
+      <RuntimeErrorDetailsDialog
+        message={displayText || "Runtime error"}
+        code={errorCode}
+        payload={message.payload}
+        onClose={() => setShowErrorDetails(false)}
+      />,
+      document.body,
     )}
     </>
   );

--- a/frontend/src/components/dashboard/RuntimeErrorDetailsDialog.tsx
+++ b/frontend/src/components/dashboard/RuntimeErrorDetailsDialog.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { Copy, X } from "lucide-react";
+
+interface RuntimeErrorDetailsDialogProps {
+  title?: string;
+  message: string;
+  code?: string | null;
+  payload?: unknown;
+  onClose: () => void;
+}
+
+function prettyJson(value: unknown): string {
+  try {
+    return JSON.stringify(value ?? {}, null, 2);
+  } catch {
+    return String(value ?? "");
+  }
+}
+
+export default function RuntimeErrorDetailsDialog({
+  title = "Runtime error",
+  message,
+  code,
+  payload,
+  onClose,
+}: RuntimeErrorDetailsDialogProps) {
+  const raw = prettyJson(payload);
+  const copyText = [
+    title,
+    code ? `Code: ${code}` : null,
+    message ? `Message: ${message}` : null,
+    raw ? `Payload:\n${raw}` : null,
+  ].filter(Boolean).join("\n\n");
+
+  return (
+    <div
+      className="fixed inset-0 z-[80] flex items-center justify-center bg-black/60 px-4 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-lg rounded-xl border border-amber-400/25 bg-zinc-950 shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-center justify-between gap-3 border-b border-amber-400/15 px-4 py-3">
+          <div className="min-w-0">
+            <h2 className="truncate text-sm font-semibold text-amber-200">{title}</h2>
+            {code ? <p className="mt-0.5 font-mono text-xs text-amber-300/70">{code}</p> : null}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-zinc-500 transition-colors hover:bg-zinc-800 hover:text-zinc-200"
+            aria-label="Close"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="max-h-[70vh] space-y-4 overflow-y-auto px-4 py-4">
+          <div>
+            <p className="mb-1.5 text-xs font-medium uppercase tracking-wide text-zinc-500">Message</p>
+            <div className="whitespace-pre-wrap break-words rounded-lg border border-amber-400/15 bg-amber-400/10 px-3 py-2 text-sm leading-relaxed text-amber-100">
+              {message || "Runtime error"}
+            </div>
+          </div>
+
+          <details className="group">
+            <summary className="cursor-pointer select-none text-xs font-medium uppercase tracking-wide text-zinc-500 transition-colors hover:text-zinc-300">
+              Raw payload
+            </summary>
+            <pre className="mt-2 max-h-64 overflow-auto rounded-lg border border-zinc-800 bg-black/40 p-3 text-xs leading-relaxed text-zinc-300">
+              {raw}
+            </pre>
+          </details>
+        </div>
+
+        <div className="flex justify-end gap-2 border-t border-amber-400/15 px-4 py-3">
+          <button
+            type="button"
+            onClick={() => void navigator.clipboard?.writeText(copyText)}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-zinc-700 px-3 py-1.5 text-xs text-zinc-300 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
+          >
+            <Copy className="h-3.5 w-3.5" />
+            Copy details
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-1.5 text-xs font-medium text-amber-200 transition-colors hover:bg-amber-400/20"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import { ArrowLeft, Bot, Loader2, MessageSquare, AlertCircle, RotateCcw, Bell, FileText, PanelLeftOpen, Settings2, User } from "lucide-react";
+import { ArrowLeft, Bot, Loader2, MessageSquare, AlertCircle, AlertTriangle, RotateCcw, Bell, FileText, PanelLeftOpen, Settings2, User } from "lucide-react";
 import { useRouter } from "nextjs-toploader/app";
 import AgentSettingsDrawer from "./AgentSettingsDrawer";
 import { api } from "@/lib/api";
@@ -25,6 +25,7 @@ import { useOwnerChatWs } from "@/hooks/useOwnerChatWs";
 import DashboardMessagePaneSkeleton from "./DashboardMessagePaneSkeleton";
 import MarkdownContent from "@/components/ui/MarkdownContent";
 import StreamBlocksView from "./StreamBlocksView";
+import RuntimeErrorDetailsDialog from "./RuntimeErrorDetailsDialog";
 import CopyableId from "@/components/ui/CopyableId";
 import MessageComposer from "./MessageComposer";
 
@@ -94,6 +95,7 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
   const [initializingRoom, setInitializingRoom] = useState(false);
   const [initError, setInitError] = useState<string | null>(null);
   const [agentSettingsOpen, setAgentSettingsOpen] = useState(false);
+  const [errorDetailsId, setErrorDetailsId] = useState<string | null>(null);
   const settingsLabel = locale === "zh" ? "Bot 设置" : "Bot settings";
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -383,6 +385,16 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
         {messages.map((msg) => {
           const isUser = msg.sender === "user";
           const isNotification = msg.type === "notification";
+          const isErrorMessage = msg.type === "error";
+          const errorPayload =
+            msg.payload?.error && typeof msg.payload.error === "object"
+              ? msg.payload.error as Record<string, unknown>
+              : null;
+          const errorCode = typeof errorPayload?.code === "string" ? errorPayload.code : null;
+          const errorText =
+            typeof errorPayload?.message === "string"
+              ? errorPayload.message
+              : msg.text || "Runtime error";
 
           // --- Notification ---
           if (isNotification) {
@@ -397,6 +409,58 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
                     </div>
                   </div>
                 </div>
+              </div>
+            );
+          }
+
+          if (isErrorMessage) {
+            return (
+              <div key={msg.clientId} className="space-y-1.5">
+                <div className="flex justify-start">
+                  <div className="max-w-[75%] rounded-lg border border-amber-400/25 bg-amber-400/10 px-3 py-2 text-sm text-amber-100">
+                    <div className="mb-1 flex items-center gap-1.5">
+                      <span className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-purple-400/30 bg-purple-400/10 text-purple-300">
+                        <Bot className="h-2.5 w-2.5" />
+                      </span>
+                      <span className="text-xs font-medium text-zinc-300">{msg.senderName}</span>
+                      {chatAgentId && (
+                        <CopyableId value={chatAgentId} className="text-zinc-500 hover:text-zinc-300" />
+                      )}
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => setErrorDetailsId(msg.clientId)}
+                      className="flex w-full items-start gap-2 rounded-lg border border-amber-400/20 bg-amber-400/10 px-2.5 py-2 text-left transition-colors hover:bg-amber-400/15"
+                    >
+                      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-300" />
+                      <span className="min-w-0 flex-1">
+                        <span className="block text-xs font-semibold uppercase tracking-wide text-amber-300">
+                          Runtime error
+                        </span>
+                        <span className="mt-1 line-clamp-3 block break-words text-sm leading-relaxed text-amber-100">
+                          {errorText}
+                        </span>
+                        <span className="mt-1 block text-xs text-amber-300/70">Details</span>
+                      </span>
+                    </button>
+                    <div className="mt-1 flex items-center gap-1.5">
+                      <span className="text-[10px] text-zinc-500">
+                        {new Date(msg.createdAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+                      </span>
+                      <span className="rounded bg-amber-400/10 px-1 font-mono text-[10px] text-amber-300/80">
+                        error
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                {errorDetailsId === msg.clientId && (
+                  <RuntimeErrorDetailsDialog
+                    message={errorText}
+                    code={errorCode}
+                    payload={msg.payload}
+                    onClose={() => setErrorDetailsId(null)}
+                  />
+                )}
               </div>
             );
           }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -230,6 +230,7 @@ export interface OwnerChatMessage {
 
   sender: "user" | "agent";
   text: string;
+  payload?: Record<string, unknown>;
   attachments?: Attachment[];
   /** Embedded execution blocks (empty for user messages). */
   streamBlocks: StreamBlockEntry[];
@@ -239,7 +240,7 @@ export interface OwnerChatMessage {
 
   createdAt: string;
   senderName: string;
-  type: "message" | "notification";
+  type: "message" | "notification" | "error";
 
   /** Original text payload for retry (may differ from display text for file-only sends). */
   sendText?: string;
@@ -260,12 +261,18 @@ export function dashboardMsgToOwnerChat(
     hubMsgId: msg.hub_msg_id,
     sender: isUser ? "user" : "agent",
     text: msg.text || "",
+    payload: msg.payload,
     attachments: (msg.payload?.attachments as Attachment[] | undefined) ?? undefined,
     streamBlocks: [],
     status: "delivered",
     createdAt: msg.created_at,
     senderName: isUser ? "You" : (msg.sender_name || agentName),
-    type: msg.type === "notification" ? "notification" : "message",
+    type:
+      msg.type === "notification"
+        ? "notification"
+        : msg.type === "error"
+          ? "error"
+          : "message",
   };
 }
 


### PR DESCRIPTION
## Summary
- Extract runtime error payload messages into dashboard message text
- Render runtime error messages as amber warning bubbles in regular chats and owner chat
- Add a details dialog with code, full message, raw payload, and copy support

## Tests
- cd backend && uv run pytest tests/test_dashboard_error_messages.py
- cd frontend && NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=anon NEXT_PUBLIC_APP_URL=http://localhost:3000 NEXT_PUBLIC_HUB_BASE_URL=http://localhost:8000 pnpm run build