### PR TITLE
fix: optimize activity stats batch

### DIFF
--- a/backend/app/routers/activity.py
+++ b/backend/app/routers/activity.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import distinct, func, or_, select
+from sqlalchemy import distinct, func, or_, select, union_all
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import RequestContext, require_active_agent, require_user_with_optional_agent
@@ -77,71 +77,138 @@ async def _activity_stats_for_agent(
     start: datetime.datetime,
     db: AsyncSession,
 ) -> dict[str, int]:
+    stats = await _activity_stats_for_agents([agent_id], start, db)
+    return stats[agent_id]
+
+
+def _empty_activity_stats() -> dict[str, int]:
+    return {
+        "messages_sent": 0,
+        "messages_received": 0,
+        "topics_open": 0,
+        "topics_completed": 0,
+        "active_rooms": 0,
+    }
+
+
+def _status_key(status: Any) -> str:
+    return status.value if hasattr(status, "value") else str(status)
+
+
+async def _activity_stats_for_agents(
+    agent_ids: list[str],
+    start: datetime.datetime,
+    db: AsyncSession,
+) -> dict[str, dict[str, int]]:
+    ids = list(dict.fromkeys(agent_id for agent_id in agent_ids if agent_id))
+    stats = {agent_id: _empty_activity_stats() for agent_id in ids}
+    if not ids:
+        return stats
+
     sent_result = await db.execute(
-        select(func.count(distinct(MessageRecord.msg_id))).where(
-            MessageRecord.sender_id == agent_id,
+        select(
+            MessageRecord.sender_id,
+            func.count(distinct(MessageRecord.msg_id)),
+        )
+        .where(
+            MessageRecord.sender_id.in_(ids),
             MessageRecord.created_at >= start,
             _not_owner_chat,
         )
+        .group_by(MessageRecord.sender_id)
     )
-    messages_sent = sent_result.scalar() or 0
+    for agent_id, count in sent_result.all():
+        stats[agent_id]["messages_sent"] = count or 0
 
     received_result = await db.execute(
-        select(func.count()).select_from(MessageRecord).where(
-            MessageRecord.receiver_id == agent_id,
+        select(MessageRecord.receiver_id, func.count())
+        .select_from(MessageRecord)
+        .where(
+            MessageRecord.receiver_id.in_(ids),
             MessageRecord.created_at >= start,
             _not_owner_chat,
         )
+        .group_by(MessageRecord.receiver_id)
     )
-    messages_received = received_result.scalar() or 0
+    for agent_id, count in received_result.all():
+        stats[agent_id]["messages_received"] = count or 0
 
-    msg_topic_sub = (
-        select(distinct(MessageRecord.topic_id))
-        .where(
-            MessageRecord.topic_id.isnot(None),
-            or_(
-                MessageRecord.sender_id == agent_id,
-                MessageRecord.receiver_id == agent_id,
-            ),
-        )
-        .subquery()
-    )
-    topic_counts_result = await db.execute(
-        select(Topic.status, func.count().label("cnt"))
-        .where(
-            Topic.updated_at >= start,
-            or_(
-                Topic.creator_id == agent_id,
-                Topic.topic_id.in_(select(msg_topic_sub)),
-            ),
-        )
-        .group_by(Topic.status)
-    )
-    tc: dict[str, int] = {}
-    for row in topic_counts_result.all():
-        sv = row[0].value if hasattr(row[0], "value") else str(row[0])
-        tc[sv] = row[1]
-
-    active_rooms_result = await db.execute(
-        select(func.count(distinct(MessageRecord.room_id))).where(
+    active_room_rows = union_all(
+        select(
+            MessageRecord.sender_id.label("agent_id"),
+            MessageRecord.room_id.label("room_id"),
+        ).where(
+            MessageRecord.sender_id.in_(ids),
             MessageRecord.room_id.isnot(None),
             ~MessageRecord.room_id.startswith(_OWNER_CHAT_ROOM_PREFIX),
             MessageRecord.created_at >= start,
-            or_(
-                MessageRecord.sender_id == agent_id,
-                MessageRecord.receiver_id == agent_id,
-            ),
-        )
+        ),
+        select(
+            MessageRecord.receiver_id.label("agent_id"),
+            MessageRecord.room_id.label("room_id"),
+        ).where(
+            MessageRecord.receiver_id.in_(ids),
+            MessageRecord.room_id.isnot(None),
+            ~MessageRecord.room_id.startswith(_OWNER_CHAT_ROOM_PREFIX),
+            MessageRecord.created_at >= start,
+        ),
+    ).subquery()
+    active_rooms_result = await db.execute(
+        select(
+            active_room_rows.c.agent_id,
+            func.count(distinct(active_room_rows.c.room_id)),
+        ).group_by(active_room_rows.c.agent_id)
     )
-    active_rooms = active_rooms_result.scalar() or 0
+    for agent_id, count in active_rooms_result.all():
+        stats[agent_id]["active_rooms"] = count or 0
 
-    return {
-        "messages_sent": messages_sent,
-        "messages_received": messages_received,
-        "topics_open": tc.get("open", 0),
-        "topics_completed": tc.get("completed", 0),
-        "active_rooms": active_rooms,
-    }
+    topic_rows = union_all(
+        select(
+            Topic.creator_id.label("agent_id"),
+            Topic.topic_id.label("topic_id"),
+            Topic.status.label("status"),
+        ).where(
+            Topic.creator_id.in_(ids),
+            Topic.updated_at >= start,
+        ),
+        select(
+            MessageRecord.sender_id.label("agent_id"),
+            MessageRecord.topic_id.label("topic_id"),
+            Topic.status.label("status"),
+        )
+        .join(Topic, Topic.topic_id == MessageRecord.topic_id)
+        .where(
+            MessageRecord.sender_id.in_(ids),
+            MessageRecord.topic_id.isnot(None),
+            Topic.updated_at >= start,
+        ),
+        select(
+            MessageRecord.receiver_id.label("agent_id"),
+            MessageRecord.topic_id.label("topic_id"),
+            Topic.status.label("status"),
+        )
+        .join(Topic, Topic.topic_id == MessageRecord.topic_id)
+        .where(
+            MessageRecord.receiver_id.in_(ids),
+            MessageRecord.topic_id.isnot(None),
+            Topic.updated_at >= start,
+        ),
+    ).subquery()
+    topic_counts_result = await db.execute(
+        select(
+            topic_rows.c.agent_id,
+            topic_rows.c.status,
+            func.count(distinct(topic_rows.c.topic_id)),
+        ).group_by(topic_rows.c.agent_id, topic_rows.c.status)
+    )
+    for agent_id, status, count in topic_counts_result.all():
+        key = _status_key(status)
+        if key == "open":
+            stats[agent_id]["topics_open"] = count or 0
+        elif key == "completed":
+            stats[agent_id]["topics_completed"] = count or 0
+
+    return stats
 
 
 @router.get("/activity/stats")
@@ -183,9 +250,7 @@ async def get_activity_stats_batch(
         raise HTTPException(status_code=403, detail="Agent not owned by user")
 
     start = _period_start(period)
-    stats: dict[str, dict[str, int]] = {}
-    for agent_id in requested_ids:
-        stats[agent_id] = await _activity_stats_for_agent(agent_id, start, db)
+    stats = await _activity_stats_for_agents(requested_ids, start, db)
     return {"stats": stats}
 
 

--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -479,6 +479,8 @@ class MessageRecord(Base):
         UniqueConstraint("msg_id", "receiver_id"),
         Index("ix_message_records_retry", "state", "next_retry_at"),
         Index("ix_message_records_room_id_created_at_id", "room_id", "created_at", "id"),
+        Index("ix_message_records_sender_created_room", "sender_id", "created_at", "room_id"),
+        Index("ix_message_records_receiver_created_room", "receiver_id", "created_at", "room_id"),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
@@ -721,6 +723,7 @@ class Topic(Base):
     __tablename__ = "topics"
     __table_args__ = (
         UniqueConstraint("room_id", "title", name="uq_topic_room_title"),
+        Index("ix_topics_creator_updated_status", "creator_id", "updated_at", "status"),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)

--- a/backend/migrations/009_activity_stats_indexes.sql
+++ b/backend/migrations/009_activity_stats_indexes.sql
@@ -1,0 +1,8 @@
+CREATE INDEX IF NOT EXISTS ix_message_records_sender_created_room
+    ON message_records (sender_id, created_at, room_id);
+
+CREATE INDEX IF NOT EXISTS ix_message_records_receiver_created_room
+    ON message_records (receiver_id, created_at, room_id);
+
+CREATE INDEX IF NOT EXISTS ix_topics_creator_updated_status
+    ON topics (creator_id, updated_at, status);

--- a/backend/tests/test_app/test_app_activity_stats.py
+++ b/backend/tests/test_app/test_app_activity_stats.py
@@ -1,0 +1,244 @@
+import datetime
+import json
+import uuid
+from unittest.mock import AsyncMock
+
+import jwt
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from hub.enums import MessagePolicy, MessageState, RoomJoinPolicy, RoomVisibility, TopicStatus
+from hub.models import Agent, Base, MessageRecord, Room, Topic, User
+
+TEST_SUPABASE_SECRET = "test-supabase-jwt-secret-for-unit-tests"
+
+
+def _make_token(sub: str) -> str:
+    payload = {
+        "sub": sub,
+        "aud": "authenticated",
+        "exp": datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=1),
+        "iss": "supabase",
+    }
+    return jwt.encode(payload, TEST_SUPABASE_SECRET, algorithm="HS256")
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    from tests.test_app.conftest import create_test_engine
+
+    engine = create_test_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client(db_session: AsyncSession, monkeypatch):
+    import app.auth as app_auth
+    import hub.config
+    from hub.database import get_db
+    from hub.main import app
+
+    monkeypatch.setattr(hub.config, "SUPABASE_JWT_SECRET", TEST_SUPABASE_SECRET)
+    monkeypatch.setattr(app_auth, "SUPABASE_JWT_SECRET", TEST_SUPABASE_SECRET)
+
+    async def _override():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override
+    app.state.http_client = AsyncMock(spec=AsyncClient)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def seed_activity(db_session: AsyncSession):
+    user_id = uuid.uuid4()
+    supabase_uid = uuid.uuid4()
+    other_user_id = uuid.uuid4()
+    now = datetime.datetime.now(datetime.timezone.utc)
+    old = now - datetime.timedelta(days=8)
+
+    user = User(
+        id=user_id,
+        display_name="Stats User",
+        email="stats@example.com",
+        status="active",
+        supabase_user_id=supabase_uid,
+    )
+    other = User(
+        id=other_user_id,
+        display_name="Other User",
+        email="other@example.com",
+        status="active",
+        supabase_user_id=uuid.uuid4(),
+    )
+    db_session.add_all([user, other])
+    db_session.add_all(
+        [
+            Agent(
+                agent_id="ag_stats001",
+                display_name="Stats One",
+                message_policy=MessagePolicy.contacts_only,
+                user_id=user_id,
+                claimed_at=now,
+                created_at=now,
+            ),
+            Agent(
+                agent_id="ag_stats002",
+                display_name="Stats Two",
+                message_policy=MessagePolicy.contacts_only,
+                user_id=user_id,
+                claimed_at=now,
+                created_at=now,
+            ),
+            Agent(
+                agent_id="ag_other001",
+                display_name="Other",
+                message_policy=MessagePolicy.contacts_only,
+                user_id=other_user_id,
+                claimed_at=now,
+                created_at=now,
+            ),
+        ]
+    )
+    db_session.add_all(
+        [
+            Room(
+                room_id="rm_stats_main",
+                name="Main",
+                description="",
+                owner_id="ag_stats001",
+                visibility=RoomVisibility.private,
+                join_policy=RoomJoinPolicy.invite_only,
+                created_at=now,
+            ),
+            Room(
+                room_id="rm_stats_other",
+                name="Other",
+                description="",
+                owner_id="ag_stats002",
+                visibility=RoomVisibility.private,
+                join_policy=RoomJoinPolicy.invite_only,
+                created_at=now,
+            ),
+        ]
+    )
+    db_session.add_all(
+        [
+            Topic(
+                topic_id="tp_stats_open",
+                room_id="rm_stats_main",
+                title="Open",
+                description="",
+                status=TopicStatus.open,
+                creator_id="ag_stats001",
+                created_at=now,
+                updated_at=now,
+            ),
+            Topic(
+                topic_id="tp_stats_done",
+                room_id="rm_stats_other",
+                title="Done",
+                description="",
+                status=TopicStatus.completed,
+                creator_id="ag_stats002",
+                created_at=now,
+                updated_at=now,
+            ),
+            Topic(
+                topic_id="tp_stats_old",
+                room_id="rm_stats_main",
+                title="Old",
+                description="",
+                status=TopicStatus.open,
+                creator_id="ag_stats001",
+                created_at=old,
+                updated_at=old,
+            ),
+        ]
+    )
+
+    def msg(
+        hub_msg_id: str,
+        msg_id: str,
+        sender_id: str,
+        receiver_id: str,
+        room_id: str | None,
+        created_at: datetime.datetime,
+        topic_id: str | None = None,
+    ) -> MessageRecord:
+        return MessageRecord(
+            hub_msg_id=hub_msg_id,
+            msg_id=msg_id,
+            sender_id=sender_id,
+            receiver_id=receiver_id,
+            room_id=room_id,
+            topic_id=topic_id,
+            state=MessageState.done,
+            envelope_json=json.dumps({"payload": {"text": hub_msg_id}}),
+            ttl_sec=3600,
+            created_at=created_at,
+        )
+
+    db_session.add_all(
+        [
+            msg("h_stats_001", "m_stats_001", "ag_stats001", "ag_stats002", "rm_stats_main", now, "tp_stats_open"),
+            msg("h_stats_002", "m_stats_001", "ag_stats001", "ag_other001", "rm_stats_main", now, "tp_stats_open"),
+            msg("h_stats_003", "m_stats_002", "ag_stats002", "ag_stats001", "rm_stats_other", now, "tp_stats_done"),
+            msg("h_stats_004", "m_stats_003", "ag_stats001", "ag_stats002", "rm_oc_secret", now),
+            msg("h_stats_005", "m_stats_004", "ag_stats001", "ag_stats002", "rm_stats_main", old, "tp_stats_old"),
+        ]
+    )
+    await db_session.commit()
+
+    return {
+        "token": _make_token(str(supabase_uid)),
+    }
+
+
+@pytest.mark.asyncio
+async def test_activity_stats_batch_counts_owned_agents(client: AsyncClient, seed_activity: dict):
+    resp = await client.get(
+        "/api/dashboard/activity/stats/batch?period=7d&agent_ids=ag_stats001,ag_stats002",
+        headers={"Authorization": f"Bearer {seed_activity['token']}"},
+    )
+
+    assert resp.status_code == 200
+    stats = resp.json()["stats"]
+    assert stats["ag_stats001"] == {
+        "messages_sent": 1,
+        "messages_received": 1,
+        "topics_open": 1,
+        "topics_completed": 1,
+        "active_rooms": 2,
+    }
+    assert stats["ag_stats002"] == {
+        "messages_sent": 1,
+        "messages_received": 1,
+        "topics_open": 1,
+        "topics_completed": 1,
+        "active_rooms": 2,
+    }
+
+
+@pytest.mark.asyncio
+async def test_activity_stats_batch_rejects_unowned_agent(client: AsyncClient, seed_activity: dict):
+    resp = await client.get(
+        "/api/dashboard/activity/stats/batch?period=7d&agent_ids=ag_stats001,ag_other001",
+        headers={"Authorization": f"Bearer {seed_activity['token']}"},
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Agent not owned by user"


### PR DESCRIPTION
## Summary
- batch aggregate activity stats for multiple owned agents instead of looping per agent
- add activity-stat indexes for message and topic lookups
- cover stats dimensions and ownership checks with app tests

## Tests
- cd backend && uv run pytest tests/test_app/test_app_user_agents.py::test_get_my_agents_hides_deleted_by_default_and_can_include_them tests/test_app/test_app_activity_stats.py
- cd backend && uv run python -m py_compile app/routers/activity.py hub/models.py tests/test_app/test_app_activity_stats.py