### PR TITLE
fix: localize bot settings drawers

### DIFF
--- a/frontend/src/components/dashboard/AgentSettingsDrawer.tsx
+++ b/frontend/src/components/dashboard/AgentSettingsDrawer.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { Bell, Bot, Clock, FileText, Loader2, MessageSquare, Plug, RefreshCw, Shield, Trash2, User, UserRound, X } from "lucide-react";
 import { userApi } from "@/lib/api";
 import { useLanguage } from "@/lib/i18n";
+import { botDetailDrawer } from "@/lib/i18n/translations/dashboard";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import {
   usePolicyStore,
@@ -27,27 +28,8 @@ interface AgentSettingsDrawerProps {
   onSaved?: () => void;
 }
 
-const CONTACT_OPTIONS: { value: ContactPolicy; label: string; hint: string }[] = [
-  { value: "open", label: "所有人可私聊", hint: "任何未被屏蔽的 Agent 或 Human 都能直接发起对话" },
-  { value: "contacts_only", label: "联系人 + 同房间成员", hint: "联系人可以私聊；同一房间成员也可以发起私聊" },
-  { value: "whitelist", label: "仅联系人白名单", hint: "只有联系人列表中的对象可以直接私聊" },
-  { value: "closed", label: "只收联系申请", hint: "拒绝普通私聊；未被屏蔽的人仍可发送联系申请" },
-];
-
-const ROOM_INVITE_OPTIONS: { value: RoomInvitePolicy; label: string; hint: string }[] = [
-  { value: "open", label: "任何人可邀请", hint: "未被屏蔽的对象都可以邀请此 Bot 加入房间" },
-  { value: "contacts_only", label: "仅联系人可邀请", hint: "只有联系人可以邀请此 Bot 加入房间" },
-  { value: "closed", label: "不接受邀请", hint: "拒绝新的房间邀请" },
-];
-
-const ATTENTION_OPTIONS: { value: AttentionMode; label: string; hint: string }[] = [
-  { value: "always", label: "所有房间消息", hint: "非私聊房间内收到任何消息都唤醒 Bot" },
-  { value: "mention_only", label: "仅 @ 我", hint: "只有被 @ 或被明确点名时才唤醒" },
-  { value: "muted", label: "默认静音", hint: "房间消息默认不唤醒 Bot" },
-  { value: "keyword", label: "关键词命中", hint: "消息包含关键词时才唤醒" },
-];
-
 type Tab = "profile" | "policy" | "schedules" | "gateways" | "files";
+type BotDetailDrawerCopy = typeof botDetailDrawer["en"];
 
 interface AgentRuntimeFile {
   id: string;
@@ -120,10 +102,14 @@ function KeywordChips({
   value,
   onChange,
   disabled,
+  emptyLabel,
+  placeholder,
 }: {
   value: string[];
   onChange: (next: string[]) => void;
   disabled?: boolean;
+  emptyLabel: string;
+  placeholder: string;
 }) {
   const [draft, setDraft] = useState("");
 
@@ -146,7 +132,7 @@ function KeywordChips({
     <div className="flex flex-col gap-2">
       <div className="flex flex-wrap gap-1.5">
         {value.length === 0 ? (
-          <span className="text-xs text-text-tertiary">尚未配置关键词</span>
+          <span className="text-xs text-text-tertiary">{emptyLabel}</span>
         ) : (
           value.map((kw) => (
             <span
@@ -178,7 +164,7 @@ function KeywordChips({
         }}
         onBlur={() => add(draft)}
         disabled={disabled}
-        placeholder="输入关键词后按回车添加"
+        placeholder={placeholder}
         className="rounded-xl border border-glass-border bg-deep-black/40 px-3 py-2 text-sm text-text-primary placeholder:text-text-tertiary focus:border-neon-cyan/40 focus:outline-none disabled:opacity-50"
       />
     </div>
@@ -196,6 +182,32 @@ function scopeLabel(scope: AgentRuntimeFile["scope"]): string {
   if (scope === "hermes") return "Hermes";
   if (scope === "openclaw") return "OpenClaw";
   return "Workspace";
+}
+
+function contactOptions(t: BotDetailDrawerCopy): { value: ContactPolicy; label: string; hint: string }[] {
+  return [
+    { value: "open", ...t.settings.contactOptions.open },
+    { value: "contacts_only", ...t.settings.contactOptions.contacts_only },
+    { value: "whitelist", ...t.settings.contactOptions.whitelist },
+    { value: "closed", ...t.settings.contactOptions.closed },
+  ];
+}
+
+function roomInviteOptions(t: BotDetailDrawerCopy): { value: RoomInvitePolicy; label: string; hint?: string }[] {
+  return [
+    { value: "open", ...t.settings.roomInviteOptions.open },
+    { value: "contacts_only", ...t.settings.roomInviteOptions.contacts_only },
+    { value: "closed", ...t.settings.roomInviteOptions.closed },
+  ];
+}
+
+function attentionOptions(t: BotDetailDrawerCopy): { value: AttentionMode; label: string; hint: string }[] {
+  return [
+    { value: "always", ...t.settings.attentionOptions.always },
+    { value: "mention_only", ...t.settings.attentionOptions.mention_only },
+    { value: "muted", ...t.settings.attentionOptions.muted },
+    { value: "keyword", ...t.settings.attentionOptions.keyword },
+  ];
 }
 
 function SummaryTile({
@@ -237,6 +249,33 @@ export default function AgentSettingsDrawer({
   onSaved,
 }: AgentSettingsDrawerProps) {
   const locale = useLanguage();
+  const t = botDetailDrawer[locale];
+  const contactPolicyOptions = contactOptions(t);
+  const roomInvitePolicyOptions = roomInviteOptions(t);
+  const attentionPolicyOptions = attentionOptions(t);
+  const labels = {
+    avatar: locale === "zh" ? "头像" : "Avatar",
+    chooseAvatar: locale === "zh" ? "选择头像" : "Choose avatar",
+    saveProfile: locale === "zh" ? "保存资料" : "Save profile",
+    deleteAgent: locale === "zh" ? "删除 Agent" : "Delete Agent",
+    policyTab: locale === "zh" ? "权限与回复" : "Permissions",
+    filesTab: locale === "zh" ? "文件/记忆" : "Files / Memory",
+    directContact: locale === "zh" ? "直接联系" : "Direct contact",
+    allowedSources: locale === "zh" ? "允许来源" : "Allowed sources",
+    allOff: locale === "zh" ? "全部关闭" : "All off",
+    contactMe: locale === "zh" ? "直接联系我" : "Contact me directly",
+    contactMeDesc: locale === "zh"
+      ? "Hub 准入权限：控制谁可以把私聊消息送到这个 Bot。Blocklist 仍然拥有最高优先级。"
+      : "Hub admission policy: controls who can deliver direct messages to this Bot. Blocklist still has the highest priority.",
+    senderTypes: locale === "zh" ? "允许的发送者类型" : "Allowed sender types",
+    agentSenderHint: locale === "zh" ? "其他 bot / agent" : "other bots / agents",
+    humanSenderHint: locale === "zh" ? "人类用户 / dashboard" : "human users / dashboard",
+    inviteMe: locale === "zh" ? "谁能邀请我进房间" : "Who can invite me to rooms",
+    keywordEmpty: locale === "zh" ? "尚未配置关键词" : "No keywords configured",
+    dmReplyNote: locale === "zh"
+      ? "私聊 DM 当前强制始终唤醒；房间消息会先看房间级覆盖，没有覆盖时继承这里的默认策略。"
+      : "DMs always wake the Bot. Room messages use room-level overrides first, then inherit this default policy.",
+  };
   const refreshUserProfile = useDashboardSessionStore((s) => s.refreshUserProfile);
 
   const [tab, setTab] = useState<Tab>("profile");
@@ -274,7 +313,7 @@ export default function AgentSettingsDrawer({
       await refreshUserProfile();
       onSaved?.();
     } catch (err: any) {
-      setProfileError(err?.message || "保存失败");
+      setProfileError(err?.message || t.profile.saveFailed);
     } finally {
       setProfileSaving(false);
     }
@@ -326,10 +365,10 @@ export default function AgentSettingsDrawer({
             : typeof detail === "string"
               ? detail
               : typeof detail?.code === "string"
-                ? detail.code
+                  ? detail.code
                 : res.status === 409
-                  ? "Daemon 未在线或此 Agent 未由 daemon 托管"
-                  : "读取文件失败";
+                  ? t.files.daemonUnavailable
+                  : t.files.loadFailed;
         throw new Error(msg);
       }
       const data = (await res.json()) as AgentRuntimeFilesResponse;
@@ -341,12 +380,12 @@ export default function AgentSettingsDrawer({
       );
       setFilesLoaded(true);
     } catch (err) {
-      setFilesError(err instanceof Error ? err.message : "读取文件失败");
+      setFilesError(err instanceof Error ? err.message : t.files.loadFailed);
       setFilesLoaded(true);
     } finally {
       setFilesLoading(false);
     }
-  }, [agentId]);
+  }, [agentId, t.files.daemonUnavailable, t.files.loadFailed]);
 
   useEffect(() => {
     if (tab === "files" && !filesLoaded && !filesLoading) {
@@ -404,14 +443,14 @@ export default function AgentSettingsDrawer({
                 <FileText className="h-3.5 w-3.5" />
               )}
               {t === "profile"
-                  ? "资料"
+                  ? botDetailDrawer[locale].profile.title
                 : t === "policy"
-                  ? "权限与回复"
-                  : t === "schedules"
-                    ? "自主"
+                  ? labels.policyTab
+                : t === "schedules"
+                    ? botDetailDrawer[locale].settings.autonomy
                     : t === "gateways"
-                      ? "接入"
-                      : "文件/记忆"}
+                      ? botDetailDrawer[locale].settings.channels
+                      : labels.filesTab}
             </button>
           ))}
         </div>
@@ -422,7 +461,7 @@ export default function AgentSettingsDrawer({
             <div className="space-y-4">
               <div>
                 <label className="mb-2 block text-xs font-medium text-text-secondary">
-                  头像
+                  {labels.avatar}
                 </label>
                 <div className="grid grid-cols-6 gap-2 sm:grid-cols-8">
                   {AGENT_AVATAR_URLS.map((url) => {
@@ -438,7 +477,7 @@ export default function AgentSettingsDrawer({
                             ? "border-neon-cyan ring-2 ring-neon-cyan/30"
                             : "border-glass-border hover:border-neon-cyan/50"
                         }`}
-                        aria-label="选择头像"
+                        aria-label={labels.chooseAvatar}
                       >
                         {/* eslint-disable-next-line @next/next/no-img-element */}
                         <img src={url} alt="" className="h-full w-full object-cover" />
@@ -450,7 +489,7 @@ export default function AgentSettingsDrawer({
 
               <div>
                 <label className="mb-1 block text-xs font-medium text-text-secondary">
-                  显示名称
+                  {t.profile.displayName}
                 </label>
                 <input
                   type="text"
@@ -464,7 +503,7 @@ export default function AgentSettingsDrawer({
 
               <div>
                 <label className="mb-1 block text-xs font-medium text-text-secondary">
-                  简介
+                  {t.profile.bio}
                 </label>
                 <textarea
                   value={bioVal}
@@ -472,7 +511,7 @@ export default function AgentSettingsDrawer({
                   disabled={profileSaving}
                   rows={4}
                   maxLength={4000}
-                  placeholder="介绍这个 Agent（可选）"
+                  placeholder={t.profile.bioPlaceholder}
                   className="w-full resize-none rounded-lg border border-glass-border bg-glass-bg px-3 py-2 text-sm text-text-primary outline-none transition-colors focus:border-neon-cyan/50 disabled:opacity-60"
                 />
               </div>
@@ -492,10 +531,10 @@ export default function AgentSettingsDrawer({
                 {profileSaving ? (
                   <>
                     <Loader2 className="h-4 w-4 animate-spin" />
-                    保存中...
+                    {t.profile.saving}
                   </>
                 ) : (
-                  "保存资料"
+                  labels.saveProfile
                 )}
               </button>
 
@@ -507,7 +546,7 @@ export default function AgentSettingsDrawer({
                   className="flex w-full items-center justify-center gap-2 rounded-xl border border-red-400/40 bg-red-500/10 px-4 py-2.5 text-sm font-bold text-red-400 transition-all hover:bg-red-500/20 disabled:opacity-60"
                 >
                   <Trash2 className="h-4 w-4" />
-                  删除 Agent
+                  {labels.deleteAgent}
                 </button>
               </div>
             </div>
@@ -538,36 +577,36 @@ export default function AgentSettingsDrawer({
                   <div className="grid gap-3">
                     <SummaryTile
                       icon={<Shield className="h-4 w-4" />}
-                      label="直接联系"
-                      value={CONTACT_OPTIONS.find((o) => o.value === policy.contact_policy)?.label ?? policy.contact_policy}
+                      label={labels.directContact}
+                      value={contactPolicyOptions.find((o) => o.value === policy.contact_policy)?.label ?? policy.contact_policy}
                       tone="cyan"
                     />
                     <SummaryTile
                       icon={<UserRound className="h-4 w-4" />}
-                      label="允许来源"
+                      label={labels.allowedSources}
                       value={[
                         policy.allow_agent_sender ? "Agent" : null,
                         policy.allow_human_sender ? "Human" : null,
-                      ].filter(Boolean).join(" + ") || "全部关闭"}
+                      ].filter(Boolean).join(" + ") || labels.allOff}
                       tone={policy.allow_agent_sender || policy.allow_human_sender ? "green" : "red"}
                     />
                     <SummaryTile
                       icon={<Bell className="h-4 w-4" />}
-                      label="默认房间回复"
-                      value={ATTENTION_OPTIONS.find((o) => o.value === policy.default_attention)?.label ?? policy.default_attention}
+                      label={t.settings.defaultReplyTitle}
+                      value={attentionPolicyOptions.find((o) => o.value === policy.default_attention)?.label ?? policy.default_attention}
                       tone={policy.default_attention === "muted" ? "yellow" : "cyan"}
                     />
                   </div>
 
                   <section className="rounded-2xl border border-glass-border bg-glass-bg/40 p-5">
-                    <h3 className="mb-1 text-sm font-semibold text-text-primary">直接联系我</h3>
+                    <h3 className="mb-1 text-sm font-semibold text-text-primary">{labels.contactMe}</h3>
                     <p className="mb-4 text-xs text-text-secondary">
-                      Hub 准入权限：控制谁可以把私聊消息送到这个 Bot。Blocklist 仍然拥有最高优先级。
+                      {labels.contactMeDesc}
                     </p>
                     <RadioGroup
                       name={`contact_policy_${agentId}`}
                       value={policy.contact_policy}
-                      options={CONTACT_OPTIONS}
+                      options={contactPolicyOptions}
                       onChange={(v) => void applyPolicy({ contact_policy: v })}
                       disabled={policySaving}
                     />
@@ -575,12 +614,12 @@ export default function AgentSettingsDrawer({
                     <div className="mt-5 rounded-xl border border-glass-border bg-deep-black/20 p-3">
                       <div className="mb-3 flex items-center gap-2 text-xs font-medium uppercase tracking-normal text-text-secondary">
                         <Bot className="h-3.5 w-3.5" />
-                        允许的发送者类型
+                        {labels.senderTypes}
                       </div>
                       <label className="mb-2 flex cursor-pointer items-center justify-between gap-3 rounded-lg border border-glass-border/70 bg-glass-bg/30 px-3 py-2 text-sm text-text-primary">
                         <span>
                           Agent
-                          <span className="ml-2 text-xs text-text-secondary">其他 bot / agent</span>
+                          <span className="ml-2 text-xs text-text-secondary">{labels.agentSenderHint}</span>
                         </span>
                         <input
                           type="checkbox"
@@ -593,7 +632,7 @@ export default function AgentSettingsDrawer({
                       <label className="flex cursor-pointer items-center justify-between gap-3 rounded-lg border border-glass-border/70 bg-glass-bg/30 px-3 py-2 text-sm text-text-primary">
                         <span>
                           Human
-                          <span className="ml-2 text-xs text-text-secondary">人类用户 / dashboard</span>
+                          <span className="ml-2 text-xs text-text-secondary">{labels.humanSenderHint}</span>
                         </span>
                         <input
                           type="checkbox"
@@ -607,12 +646,12 @@ export default function AgentSettingsDrawer({
 
                     <div className="mt-5">
                       <div className="mb-2 text-xs font-medium uppercase tracking-normal text-text-secondary">
-                        谁能邀请我进房间
+                        {labels.inviteMe}
                       </div>
                       <RadioGroup
                         name={`room_invite_policy_${agentId}`}
                         value={policy.room_invite_policy}
-                        options={ROOM_INVITE_OPTIONS}
+                        options={roomInvitePolicyOptions}
                         onChange={(v) => void applyPolicy({ room_invite_policy: v })}
                         disabled={policySaving}
                       />
@@ -620,36 +659,38 @@ export default function AgentSettingsDrawer({
                   </section>
 
                   <section className="rounded-2xl border border-glass-border bg-glass-bg/40 p-5">
-                    <h3 className="mb-1 text-sm font-semibold text-text-primary">默认房间回复</h3>
+                    <h3 className="mb-1 text-sm font-semibold text-text-primary">{t.settings.defaultReplyTitle}</h3>
                     <p className="mb-4 text-xs text-text-secondary">
-                      Daemon 注意力策略：消息已进入 inbox 后，是否值得唤醒 Bot。单个房间可以覆盖。
+                      {t.settings.defaultReplyDescription}
                     </p>
                     <RadioGroup
                       name={`default_attention_${agentId}`}
                       value={policy.default_attention}
-                      options={ATTENTION_OPTIONS}
+                      options={attentionPolicyOptions}
                       onChange={(v) => void applyPolicy({ default_attention: v })}
                       disabled={policySaving}
                     />
                     {policy.default_attention === "keyword" && (
                       <div className="mt-4">
-                        <div className="mb-2 text-xs text-text-secondary">关键词</div>
+                        <div className="mb-2 text-xs text-text-secondary">{t.settings.keywords}</div>
                         <KeywordChips
                           value={policy.attention_keywords}
                           onChange={(next) => void applyPolicy({ attention_keywords: next })}
                           disabled={policySaving}
+                          emptyLabel={labels.keywordEmpty}
+                          placeholder={t.settings.keywordPlaceholder}
                         />
                       </div>
                     )}
                     <p className="mt-4 rounded-lg border border-glass-border/60 bg-glass-bg/40 px-3 py-2 text-xs text-text-secondary">
-                      私聊 DM 当前强制始终唤醒；房间消息会先看房间级覆盖，没有覆盖时继承这里的默认策略。
+                      {labels.dmReplyNote}
                     </p>
                   </section>
 
                   {policySaving && (
                     <div className="flex items-center gap-2 text-xs text-text-secondary">
                       <Loader2 className="h-3 w-3 animate-spin" />
-                      保存中…
+                      {t.settings.saving}
                     </div>
                   )}
                 </>
@@ -665,9 +706,9 @@ export default function AgentSettingsDrawer({
             <div className="space-y-4">
               <div className="flex items-center justify-between gap-3">
                 <div className="min-w-0">
-                  <h3 className="text-sm font-semibold text-text-primary">运行时文件</h3>
+                  <h3 className="text-sm font-semibold text-text-primary">{t.files.title}</h3>
                   <p className="truncate text-xs text-text-secondary">
-                    {runtimeLabel ? runtimeLabel : "当前 Agent 的本地文件"}
+                    {runtimeLabel ? runtimeLabel : t.files.subtitle}
                   </p>
                 </div>
                 <button
@@ -675,7 +716,7 @@ export default function AgentSettingsDrawer({
                   onClick={() => void loadRuntimeFiles()}
                   disabled={filesLoading}
                   className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-glass-border bg-glass-bg text-text-secondary transition-colors hover:text-text-primary disabled:opacity-60"
-                  title="刷新"
+                  title={t.files.refresh}
                 >
                   {filesLoading ? (
                     <Loader2 className="h-4 w-4 animate-spin" />
@@ -699,7 +740,7 @@ export default function AgentSettingsDrawer({
                 </div>
               ) : runtimeFiles.length === 0 ? (
                 <div className="rounded-xl border border-glass-border bg-glass-bg/40 px-4 py-8 text-center text-sm text-text-secondary">
-                  没有可显示的文件
+                  {t.files.empty}
                 </div>
               ) : (
                 <div className="space-y-3">
@@ -728,7 +769,7 @@ export default function AgentSettingsDrawer({
                           </div>
                           {file.truncated ? (
                             <span className="shrink-0 rounded border border-yellow-400/30 px-1.5 py-0.5 text-[10px] text-yellow-300">
-                              过大
+                              {t.files.tooLarge}
                             </span>
                           ) : null}
                         </button>
@@ -747,7 +788,7 @@ export default function AgentSettingsDrawer({
                         {selectedFile.error
                           ? selectedFile.error
                           : selectedFile.truncated
-                            ? "文件超过预览大小限制"
+                            ? t.files.previewTooLarge
                             : selectedFile.content ?? ""}
                       </pre>
                     </section>

--- a/frontend/src/components/dashboard/BotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/BotDetailDrawer.tsx
@@ -23,6 +23,8 @@ import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import { isOwnerChatRoom } from "@/store/dashboard-shared";
 import { useDaemonStore } from "@/store/useDaemonStore";
+import { useLanguage } from "@/lib/i18n";
+import { botDetailDrawer } from "@/lib/i18n/translations/dashboard";
 import {
   usePolicyStore,
   type AgentPolicyPatch,
@@ -37,32 +39,13 @@ import { CompositeAvatar } from "./CompositeAvatar";
 import BotWalletTab from "./BotWalletTab";
 
 type TabKey = "overview" | "wallet" | "settings" | "files";
+type BotDetailDrawerCopy = typeof botDetailDrawer["en"];
 
-const TABS: { key: TabKey; label: string; icon: React.ComponentType<{ className?: string }> }[] = [
-  { key: "overview", label: "概览", icon: Eye },
-  { key: "wallet", label: "钱包", icon: WalletIcon },
-  { key: "settings", label: "设置", icon: Settings2 },
-  { key: "files", label: "文件", icon: FileText },
-];
-
-const CONTACT_OPTIONS: { value: ContactPolicy; label: string; hint: string }[] = [
-  { value: "open", label: "公开", hint: "任何人都可以联系我" },
-  { value: "contacts_only", label: "仅联系人", hint: "联系人或同房间成员" },
-  { value: "whitelist", label: "白名单", hint: "仅联系人（严格）" },
-  { value: "closed", label: "关闭", hint: "拒绝所有新对话（联系人申请仍可发起）" },
-];
-
-const ROOM_INVITE_OPTIONS: { value: RoomInvitePolicy; label: string }[] = [
-  { value: "open", label: "公开" },
-  { value: "contacts_only", label: "仅联系人" },
-  { value: "closed", label: "关闭" },
-];
-
-const ATTENTION_OPTIONS: { value: AttentionMode; label: string; hint: string }[] = [
-  { value: "always", label: "全部", hint: "房间里收到任何消息都唤醒回复" },
-  { value: "mention_only", label: "仅被@", hint: "只在被 @ 时唤醒" },
-  { value: "keyword", label: "关键词", hint: "命中关键词才唤醒" },
-  { value: "muted", label: "静音", hint: "房间不主动回复" },
+const TABS: { key: TabKey; icon: React.ComponentType<{ className?: string }> }[] = [
+  { key: "overview", icon: Eye },
+  { key: "wallet", icon: WalletIcon },
+  { key: "settings", icon: Settings2 },
+  { key: "files", icon: FileText },
 ];
 
 interface AgentRuntimeFile {
@@ -97,6 +80,8 @@ interface BotFriendRoom {
  */
 export default function BotDetailDrawer() {
   const router = useRouter();
+  const locale = useLanguage();
+  const t = botDetailDrawer[locale];
   const {
     botDetailAgentId,
     botDetailInitialTab,
@@ -226,7 +211,7 @@ export default function BotDetailDrawer() {
       <aside
         className="fixed inset-y-0 right-0 z-50 flex w-full max-w-md flex-col border-l border-glass-border bg-deep-black-light shadow-2xl shadow-black/50"
         role="dialog"
-        aria-label="Bot 详情"
+        aria-label={t.ariaLabel}
       >
         {/* Header */}
         <div className="flex items-center justify-between border-b border-glass-border px-5 py-4">
@@ -238,18 +223,18 @@ export default function BotDetailDrawer() {
                   {bot.display_name}
                 </h2>
                 <span className="rounded-full border border-neon-cyan/40 bg-neon-cyan/10 px-1.5 py-px text-[10px] font-medium text-neon-cyan">
-                  {bot.is_default ? "My Bot · 默认" : "My Bot"}
+                  {bot.is_default ? t.defaultBadge : t.botBadge}
                 </span>
               </div>
               <p className={`text-[11px] ${online ? "text-neon-green" : "text-text-secondary/60"}`}>
-                ● {online ? "Online" : "Offline"}
+                ● {online ? t.online : t.offline}
               </p>
             </div>
           </div>
           <button
             onClick={() => setBotDetailAgentId(null)}
-            title="关闭"
-            aria-label="关闭"
+            title={t.close}
+            aria-label={t.close}
             className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-secondary/70 transition-colors hover:bg-glass-bg hover:text-text-primary"
           >
             <X className="h-4 w-4" />
@@ -258,7 +243,7 @@ export default function BotDetailDrawer() {
 
         {/* Tab strip */}
         <div className="grid grid-cols-4 border-b border-glass-border">
-          {TABS.map(({ key, label, icon: Icon }) => {
+          {TABS.map(({ key, icon: Icon }) => {
             const active = tab === key;
             return (
               <button
@@ -271,7 +256,7 @@ export default function BotDetailDrawer() {
                 }`}
               >
                 <Icon className="h-3.5 w-3.5" />
-                {label}
+                {t.tabs[key]}
               </button>
             );
           })}
@@ -281,6 +266,7 @@ export default function BotDetailDrawer() {
         <div className="flex-1 overflow-y-auto px-5 py-4">
           {tab === "overview" && (
             <OverviewTab
+              t={t}
               bot={bot}
               stats={stats}
               device={device}
@@ -295,8 +281,8 @@ export default function BotDetailDrawer() {
               onOpenChat={() => void openOwnerChat()}
             />
           )}
-          {tab === "settings" && <SettingsTab agentId={bot.agent_id} />}
-          {tab === "files" && <FilesTab agentId={bot.agent_id} />}
+          {tab === "settings" && <SettingsTab agentId={bot.agent_id} t={t} />}
+          {tab === "files" && <FilesTab agentId={bot.agent_id} t={t} />}
           {tab === "wallet" && <BotWalletTab agentId={bot.agent_id} displayName={bot.display_name} />}
         </div>
       </aside>
@@ -330,6 +316,7 @@ function deriveBotFriends(agentId: string, rooms: HumanAgentRoomSummary[]): BotF
 /* --------------------------- Overview --------------------------- */
 
 function OverviewTab({
+  t,
   bot,
   stats,
   device,
@@ -340,6 +327,7 @@ function OverviewTab({
   onJumpToGroup,
   onOpenChat,
 }: {
+  t: BotDetailDrawerCopy;
   bot: { agent_id: string; display_name: string; bio?: string | null };
   stats: ActivityStats | null;
   device: { id: string; label: string | null; status: string } | null;
@@ -352,25 +340,25 @@ function OverviewTab({
 }) {
   return (
     <div className="space-y-4">
-      <ProfileEditor agentId={bot.agent_id} initialName={bot.display_name} initialBio={bot.bio ?? ""} />
+      <ProfileEditor t={t} agentId={bot.agent_id} initialName={bot.display_name} initialBio={bot.bio ?? ""} />
 
       {stats ? (
         <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
           <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-wider text-text-secondary/70">
-            7 天活跃
+            {t.overview.activity7d}
           </h3>
           <div className="grid grid-cols-4 gap-2 text-center">
-            <Stat label="消息" value={stats.messages_sent + stats.messages_received} />
-            <Stat label="房间" value={stats.active_rooms} />
-            <Stat label="打开" value={stats.topics_open} />
-            <Stat label="完成" value={stats.topics_completed} />
+            <Stat label={t.overview.messages} value={stats.messages_sent + stats.messages_received} />
+            <Stat label={t.overview.rooms} value={stats.active_rooms} />
+            <Stat label={t.overview.openTopics} value={stats.topics_open} />
+            <Stat label={t.overview.completedTopics} value={stats.topics_completed} />
           </div>
         </section>
       ) : null}
 
       <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
         <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-wider text-text-secondary/70">
-          托管设备
+          {t.overview.hostedDevice}
         </h3>
         {device ? (
           <button
@@ -390,21 +378,21 @@ function OverviewTab({
                   }`}
                 >
                   <span className={`h-1 w-1 rounded-full ${device.status === "online" ? "bg-neon-green" : "bg-text-secondary/40"}`} />
-                  {device.status === "online" ? "Online" : "Offline"}
+                  {device.status === "online" ? t.online : t.offline}
                 </span>
               </div>
               <p className="mt-0.5 font-mono text-[10px] text-text-secondary/55">{device.id}</p>
             </div>
-            <span className="shrink-0 text-[11px] text-text-secondary/65">查看 →</span>
+            <span className="shrink-0 text-[11px] text-text-secondary/65">{t.overview.view} -&gt;</span>
           </button>
         ) : (
-          <p className="text-xs text-text-secondary/55">未关联任何设备</p>
+          <p className="text-xs text-text-secondary/55">{t.overview.noDevice}</p>
         )}
       </section>
 
       <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
         <h3 className="mb-3 flex items-center justify-between text-[11px] font-semibold uppercase tracking-wider text-text-secondary/70">
-          <span>好友 · {friends.length}</span>
+          <span>{t.overview.friends(friends.length)}</span>
         </h3>
         {friends.length > 0 ? (
           <ul className="space-y-1">
@@ -435,18 +423,18 @@ function OverviewTab({
             ))}
             {friends.length > 6 ? (
               <li className="px-2 pt-1 text-[11px] text-text-secondary/55">
-                还有 {friends.length - 6} 位
+                {t.overview.moreFriends(friends.length - 6)}
               </li>
             ) : null}
           </ul>
         ) : (
-          <p className="text-xs text-text-secondary/55">还没有好友</p>
+          <p className="text-xs text-text-secondary/55">{t.overview.noFriends}</p>
         )}
       </section>
 
       <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
         <h3 className="mb-3 flex items-center justify-between text-[11px] font-semibold uppercase tracking-wider text-text-secondary/70">
-          <span>加入的群 · {groups.length}</span>
+          <span>{t.overview.groups(groups.length)}</span>
         </h3>
         {groups.length > 0 ? (
           <ul className="space-y-1">
@@ -472,19 +460,19 @@ function OverviewTab({
                   )}
                   <div className="min-w-0 flex-1">
                     <p className="truncate text-xs text-text-primary">{group.name}</p>
-                    <p className="text-[10px] text-text-secondary/55">{group.member_count} 成员</p>
+                    <p className="text-[10px] text-text-secondary/55">{t.overview.members(group.member_count)}</p>
                   </div>
                 </button>
               </li>
             ))}
             {groups.length > 8 ? (
               <li className="px-2 pt-1 text-[11px] text-text-secondary/55">
-                还有 {groups.length - 8} 个群
+                {t.overview.moreGroups(groups.length - 8)}
               </li>
             ) : null}
           </ul>
         ) : (
-          <p className="text-xs text-text-secondary/55">还没加入任何群</p>
+          <p className="text-xs text-text-secondary/55">{t.overview.noGroups}</p>
         )}
       </section>
 
@@ -495,7 +483,7 @@ function OverviewTab({
             className="flex flex-1 items-center justify-center gap-1.5 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-2 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20"
           >
             <MessageCircle className="h-3.5 w-3.5" />
-            打开对话
+            {t.overview.openChat}
           </button>
         </div>
       </section>
@@ -503,7 +491,7 @@ function OverviewTab({
       <section className="rounded-2xl border border-red-500/25 bg-red-500/5 p-4">
         <button
           onClick={() => {
-            if (window.confirm("确定要删除此 Bot 吗？")) {
+            if (window.confirm(t.overview.deleteConfirm)) {
               void userApi.unbindAgent(bot.agent_id).then(() => window.location.reload());
             }
           }}
@@ -511,7 +499,7 @@ function OverviewTab({
         >
           <span className="flex items-center gap-2">
             <Trash2 className="h-3.5 w-3.5" />
-            删除此 Bot
+            {t.overview.deleteBot}
           </span>
         </button>
       </section>
@@ -522,10 +510,12 @@ function OverviewTab({
 /* --------------------------- Profile --------------------------- */
 
 function ProfileEditor({
+  t,
   agentId,
   initialName,
   initialBio,
 }: {
+  t: BotDetailDrawerCopy;
   agentId: string;
   initialName: string;
   initialBio: string;
@@ -549,7 +539,7 @@ function ProfileEditor({
       setSaved(true);
       setTimeout(() => setSaved(false), 1800);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "保存失败");
+      setError(err instanceof Error ? err.message : t.profile.saveFailed);
     } finally {
       setSaving(false);
     }
@@ -559,22 +549,22 @@ function ProfileEditor({
     <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
       <div className="mb-3 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-wider text-text-secondary/70">
         <Pencil className="h-3.5 w-3.5" />
-        资料
+        {t.profile.title}
       </div>
-      <label className="mb-1 block text-xs text-text-secondary/65">显示名称</label>
+      <label className="mb-1 block text-xs text-text-secondary/65">{t.profile.displayName}</label>
       <input
         value={name}
         onChange={(e) => setName(e.target.value)}
         maxLength={128}
         className="w-full rounded-lg border border-glass-border bg-glass-bg/30 px-3 py-2 text-sm text-text-primary outline-none focus:border-neon-cyan/40"
       />
-      <label className="mb-1 mt-4 block text-xs text-text-secondary/65">简介</label>
+      <label className="mb-1 mt-4 block text-xs text-text-secondary/65">{t.profile.bio}</label>
       <textarea
         value={bio}
         onChange={(e) => setBio(e.target.value)}
         rows={4}
         maxLength={4000}
-        placeholder="介绍这个 Bot（可选）"
+        placeholder={t.profile.bioPlaceholder}
         className="w-full resize-none rounded-lg border border-glass-border bg-glass-bg/30 px-3 py-2 text-sm text-text-primary outline-none focus:border-neon-cyan/40"
       />
       <div className="mt-4 flex items-center justify-between">
@@ -584,7 +574,7 @@ function ProfileEditor({
           disabled={!dirty || saving}
           className="rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-1.5 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20 disabled:opacity-50"
         >
-          {saving ? "保存中..." : saved ? "已保存 ✓" : "保存"}
+          {saving ? t.profile.saving : saved ? `${t.profile.saved} ✓` : t.profile.save}
         </button>
       </div>
       {error ? <p className="mt-2 text-xs text-red-300">{error}</p> : null}
@@ -594,26 +584,26 @@ function ProfileEditor({
 
 /* --------------------------- Settings --------------------------- */
 
-function SettingsTab({ agentId }: { agentId: string }) {
+function SettingsTab({ agentId, t }: { agentId: string; t: BotDetailDrawerCopy }) {
   return (
     <div className="space-y-6">
       <section className="space-y-3">
         <h3 className="text-[11px] font-semibold uppercase tracking-wider text-text-secondary/70">
-          对话与回复
+          {t.settings.conversation}
         </h3>
-        <PolicyTab agentId={agentId} />
+        <PolicyTab agentId={agentId} t={t} />
       </section>
 
       <section className="space-y-3">
         <h3 className="text-[11px] font-semibold uppercase tracking-wider text-text-secondary/70">
-          自主
+          {t.settings.autonomy}
         </h3>
         <AgentSchedulesTab agentId={agentId} />
       </section>
 
       <section className="space-y-3">
         <h3 className="text-[11px] font-semibold uppercase tracking-wider text-text-secondary/70">
-          接入
+          {t.settings.channels}
         </h3>
         <AgentChannelsTab agentId={agentId} />
       </section>
@@ -623,7 +613,7 @@ function SettingsTab({ agentId }: { agentId: string }) {
 
 /* --------------------------- Policy --------------------------- */
 
-function PolicyTab({ agentId }: { agentId: string }) {
+function PolicyTab({ agentId, t }: { agentId: string; t: BotDetailDrawerCopy }) {
   const policy = usePolicyStore((s) => s.globalByAgent[agentId]);
   const loadingPolicy = usePolicyStore((s) => Boolean(s.globalLoading[agentId]));
   const loadGlobal = usePolicyStore((s) => s.loadGlobal);
@@ -631,6 +621,23 @@ function PolicyTab({ agentId }: { agentId: string }) {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [draftKeyword, setDraftKeyword] = useState("");
+  const contactOptions: { value: ContactPolicy; label: string; hint: string }[] = [
+    { value: "open", ...t.settings.contactOptions.open },
+    { value: "contacts_only", ...t.settings.contactOptions.contacts_only },
+    { value: "whitelist", ...t.settings.contactOptions.whitelist },
+    { value: "closed", ...t.settings.contactOptions.closed },
+  ];
+  const roomInviteOptions: { value: RoomInvitePolicy; label: string }[] = [
+    { value: "open", ...t.settings.roomInviteOptions.open },
+    { value: "contacts_only", ...t.settings.roomInviteOptions.contacts_only },
+    { value: "closed", ...t.settings.roomInviteOptions.closed },
+  ];
+  const attentionOptions: { value: AttentionMode; label: string; hint: string }[] = [
+    { value: "always", ...t.settings.attentionOptions.always },
+    { value: "mention_only", ...t.settings.attentionOptions.mention_only },
+    { value: "keyword", ...t.settings.attentionOptions.keyword },
+    { value: "muted", ...t.settings.attentionOptions.muted },
+  ];
 
   useEffect(() => {
     if (!policy && !loadingPolicy) {
@@ -644,7 +651,7 @@ function PolicyTab({ agentId }: { agentId: string }) {
     try {
       await patchGlobal(agentId, patch);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "保存失败");
+      setError(err instanceof Error ? err.message : t.settings.saveFailed);
     } finally {
       setSaving(false);
     }
@@ -678,51 +685,51 @@ function PolicyTab({ agentId }: { agentId: string }) {
       {error ? <div className="rounded-xl border border-red-400/20 bg-red-400/5 px-4 py-3 text-sm text-red-300">{error}</div> : null}
 
       <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
-        <h3 className="mb-1 text-sm font-semibold text-text-primary">谁能联系我</h3>
-        <p className="mb-4 text-xs text-text-secondary/65">是否接受来自其他 Agent 或人类用户的对话与加入房间邀请。</p>
+        <h3 className="mb-1 text-sm font-semibold text-text-primary">{t.settings.contactTitle}</h3>
+        <p className="mb-4 text-xs text-text-secondary/65">{t.settings.contactDescription}</p>
         <RadioGroup
           name={`contact_policy_${agentId}`}
           value={policy.contact_policy}
-          options={CONTACT_OPTIONS}
+          options={contactOptions}
           disabled={saving}
           onChange={(value) => void applyPolicy({ contact_policy: value })}
         />
         <div className="mt-4 flex flex-col gap-2">
           <label className="flex cursor-pointer items-center gap-2 text-sm text-text-primary">
             <input type="checkbox" checked={policy.allow_agent_sender} onChange={(e) => void applyPolicy({ allow_agent_sender: e.target.checked })} disabled={saving} className="accent-neon-cyan" />
-            接受其他 agent 直接对话
+            {t.settings.allowAgentSender}
           </label>
           <label className="flex cursor-pointer items-center gap-2 text-sm text-text-primary">
             <input type="checkbox" checked={policy.allow_human_sender} onChange={(e) => void applyPolicy({ allow_human_sender: e.target.checked })} disabled={saving} className="accent-neon-cyan" />
-            接受人类用户对话
+            {t.settings.allowHumanSender}
           </label>
         </div>
         <label className="mt-4 flex items-center gap-2 text-sm text-text-secondary">
-          加入房间邀请
+          {t.settings.roomInvite}
           <select
             value={policy.room_invite_policy}
             onChange={(e) => void applyPolicy({ room_invite_policy: e.target.value as RoomInvitePolicy })}
             disabled={saving}
             className="rounded-lg border border-glass-border bg-deep-black/40 px-2 py-1 text-text-primary"
           >
-            {ROOM_INVITE_OPTIONS.map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
+            {roomInviteOptions.map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
           </select>
         </label>
       </section>
 
       <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
-        <h3 className="mb-1 text-sm font-semibold text-text-primary">默认回复策略</h3>
-        <p className="mb-4 text-xs text-text-secondary/65">Daemon 注意力：房间里收到消息后是否唤醒 LLM。</p>
+        <h3 className="mb-1 text-sm font-semibold text-text-primary">{t.settings.defaultReplyTitle}</h3>
+        <p className="mb-4 text-xs text-text-secondary/65">{t.settings.defaultReplyDescription}</p>
         <RadioGroup
           name={`default_attention_${agentId}`}
           value={policy.default_attention}
-          options={ATTENTION_OPTIONS}
+          options={attentionOptions}
           disabled={saving}
           onChange={(value) => void applyPolicy({ default_attention: value })}
         />
         {policy.default_attention === "keyword" ? (
           <div className="mt-4">
-            <div className="mb-2 text-xs text-text-secondary">关键词</div>
+            <div className="mb-2 text-xs text-text-secondary">{t.settings.keywords}</div>
             <div className="flex flex-wrap gap-1.5">
               {policy.attention_keywords.map((keyword) => (
                 <span key={keyword} className="inline-flex items-center gap-1 rounded-full border border-neon-cyan/30 bg-neon-cyan/5 px-2 py-0.5 text-xs text-neon-cyan">
@@ -748,19 +755,19 @@ function PolicyTab({ agentId }: { agentId: string }) {
                 }}
                 onBlur={addKeyword}
                 disabled={saving}
-                placeholder="输入关键词后按回车添加"
+                placeholder={t.settings.keywordPlaceholder}
                 className="min-w-[150px] flex-1 rounded-full border border-dashed border-glass-border bg-transparent px-2 py-0.5 text-xs text-text-primary placeholder:text-text-tertiary outline-none focus:border-neon-cyan/40"
               />
             </div>
           </div>
         ) : null}
-        <p className="mt-4 rounded-lg border border-glass-border/60 bg-glass-bg/40 px-3 py-2 text-xs text-text-secondary">私聊不受此设置影响，始终回复</p>
+        <p className="mt-4 rounded-lg border border-glass-border/60 bg-glass-bg/40 px-3 py-2 text-xs text-text-secondary">{t.settings.dmAlwaysReply}</p>
       </section>
 
       {saving ? (
         <div className="flex items-center gap-2 text-xs text-text-secondary">
           <Loader2 className="h-3 w-3 animate-spin" />
-          保存中...
+          {t.settings.saving}
         </div>
       ) : null}
     </div>
@@ -769,7 +776,7 @@ function PolicyTab({ agentId }: { agentId: string }) {
 
 /* --------------------------- Files --------------------------- */
 
-function FilesTab({ agentId }: { agentId: string }) {
+function FilesTab({ agentId, t }: { agentId: string; t: BotDetailDrawerCopy }) {
   const [files, setFiles] = useState<AgentRuntimeFile[]>([]);
   const [runtimeLabel, setRuntimeLabel] = useState<string | null>(null);
   const [selectedFileId, setSelectedFileId] = useState<string | null>(null);
@@ -796,8 +803,8 @@ function FilesTab({ agentId }: { agentId: string }) {
               : typeof detail?.code === "string"
                 ? detail.code
                 : res.status === 409
-                  ? "Daemon 未在线或此 Agent 未由 daemon 托管"
-                  : "读取文件失败";
+                  ? t.files.daemonUnavailable
+                  : t.files.loadFailed;
         throw new Error(msg);
       }
       const data = (await res.json()) as AgentRuntimeFilesResponse;
@@ -809,7 +816,7 @@ function FilesTab({ agentId }: { agentId: string }) {
       );
       setLoaded(true);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "读取文件失败");
+      setError(err instanceof Error ? err.message : t.files.loadFailed);
       setLoaded(true);
     } finally {
       setLoading(false);
@@ -829,15 +836,15 @@ function FilesTab({ agentId }: { agentId: string }) {
     <div className="space-y-4">
       <div className="flex items-center justify-between gap-3">
         <div className="min-w-0">
-          <h3 className="text-sm font-semibold text-text-primary">运行时文件</h3>
-          <p className="truncate text-xs text-text-secondary">{runtimeLabel || "当前 Agent 的本地文件"}</p>
+          <h3 className="text-sm font-semibold text-text-primary">{t.files.title}</h3>
+          <p className="truncate text-xs text-text-secondary">{runtimeLabel || t.files.subtitle}</p>
         </div>
         <button
           type="button"
           onClick={() => void loadFiles()}
           disabled={loading}
           className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-glass-border bg-glass-bg text-text-secondary transition-colors hover:text-text-primary disabled:opacity-60"
-          title="刷新"
+          title={t.files.refresh}
         >
           {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
         </button>
@@ -851,7 +858,7 @@ function FilesTab({ agentId }: { agentId: string }) {
         </div>
       ) : files.length === 0 ? (
         <div className="rounded-xl border border-glass-border bg-glass-bg/40 px-4 py-8 text-center text-sm text-text-secondary">
-          没有可显示的文件
+          {t.files.empty}
         </div>
       ) : (
         <div className="space-y-3">
@@ -875,7 +882,7 @@ function FilesTab({ agentId }: { agentId: string }) {
                       {typeof file.size === "number" ? <span>{formatBytes(file.size)}</span> : null}
                     </span>
                   </span>
-                  {file.truncated ? <span className="shrink-0 rounded border border-yellow-400/30 px-1.5 py-0.5 text-[10px] text-yellow-300">过大</span> : null}
+                  {file.truncated ? <span className="shrink-0 rounded border border-yellow-400/30 px-1.5 py-0.5 text-[10px] text-yellow-300">{t.files.tooLarge}</span> : null}
                 </button>
               );
             })}
@@ -890,7 +897,7 @@ function FilesTab({ agentId }: { agentId: string }) {
                 {selectedFile.error
                   ? selectedFile.error
                   : selectedFile.truncated
-                    ? "文件超过预览大小限制"
+                    ? t.files.previewTooLarge
                     : selectedFile.content ?? ""}
               </pre>
             </section>

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -3413,3 +3413,255 @@ export const pendingApprovalsPanel: TranslationMap<{
     errorResolve: "审批操作失败",
   },
 }
+
+export const botDetailDrawer: TranslationMap<{
+  ariaLabel: string
+  close: string
+  defaultBadge: string
+  botBadge: string
+  online: string
+  offline: string
+  tabs: {
+    overview: string
+    wallet: string
+    settings: string
+    files: string
+  }
+  overview: {
+    activity7d: string
+    messages: string
+    rooms: string
+    openTopics: string
+    completedTopics: string
+    hostedDevice: string
+    view: string
+    noDevice: string
+    friends: (count: number) => string
+    moreFriends: (count: number) => string
+    noFriends: string
+    groups: (count: number) => string
+    members: (count: number) => string
+    moreGroups: (count: number) => string
+    noGroups: string
+    openChat: string
+    deleteBot: string
+    deleteConfirm: string
+  }
+  profile: {
+    title: string
+    displayName: string
+    bio: string
+    bioPlaceholder: string
+    save: string
+    saving: string
+    saved: string
+    saveFailed: string
+  }
+  settings: {
+    conversation: string
+    autonomy: string
+    channels: string
+    saveFailed: string
+    saving: string
+    contactTitle: string
+    contactDescription: string
+    allowAgentSender: string
+    allowHumanSender: string
+    roomInvite: string
+    defaultReplyTitle: string
+    defaultReplyDescription: string
+    keywords: string
+    keywordPlaceholder: string
+    dmAlwaysReply: string
+    contactOptions: Record<'open' | 'contacts_only' | 'whitelist' | 'closed', { label: string; hint: string }>
+    roomInviteOptions: Record<'open' | 'contacts_only' | 'closed', { label: string }>
+    attentionOptions: Record<'always' | 'mention_only' | 'keyword' | 'muted', { label: string; hint: string }>
+  }
+  files: {
+    title: string
+    subtitle: string
+    refresh: string
+    daemonUnavailable: string
+    loadFailed: string
+    empty: string
+    tooLarge: string
+    previewTooLarge: string
+  }
+}> = {
+  en: {
+    ariaLabel: 'Bot details',
+    close: 'Close',
+    defaultBadge: 'My Bot · Default',
+    botBadge: 'My Bot',
+    online: 'Online',
+    offline: 'Offline',
+    tabs: {
+      overview: 'Overview',
+      wallet: 'Wallet',
+      settings: 'Settings',
+      files: 'Files',
+    },
+    overview: {
+      activity7d: '7-day activity',
+      messages: 'Messages',
+      rooms: 'Rooms',
+      openTopics: 'Open',
+      completedTopics: 'Done',
+      hostedDevice: 'Hosted device',
+      view: 'View',
+      noDevice: 'No device linked',
+      friends: (count) => `Friends · ${count}`,
+      moreFriends: (count) => `${count} more`,
+      noFriends: 'No friends yet',
+      groups: (count) => `Joined groups · ${count}`,
+      members: (count) => `${count} members`,
+      moreGroups: (count) => `${count} more groups`,
+      noGroups: 'Not in any groups yet',
+      openChat: 'Open chat',
+      deleteBot: 'Delete this Bot',
+      deleteConfirm: 'Delete this Bot?',
+    },
+    profile: {
+      title: 'Profile',
+      displayName: 'Display name',
+      bio: 'Bio',
+      bioPlaceholder: 'Introduce this Bot (optional)',
+      save: 'Save',
+      saving: 'Saving...',
+      saved: 'Saved',
+      saveFailed: 'Failed to save',
+    },
+    settings: {
+      conversation: 'Conversation and replies',
+      autonomy: 'Autonomy',
+      channels: 'Channels',
+      saveFailed: 'Failed to save',
+      saving: 'Saving...',
+      contactTitle: 'Who can contact me',
+      contactDescription: 'Controls conversations and room invitations from other Agents or human users.',
+      allowAgentSender: 'Allow direct messages from other agents',
+      allowHumanSender: 'Allow messages from human users',
+      roomInvite: 'Room invitations',
+      defaultReplyTitle: 'Default reply policy',
+      defaultReplyDescription: 'Daemon attention: whether room messages should wake the LLM.',
+      keywords: 'Keywords',
+      keywordPlaceholder: 'Type a keyword and press Enter',
+      dmAlwaysReply: 'Direct messages are not affected by this setting and always reply.',
+      contactOptions: {
+        open: { label: 'Open', hint: 'Anyone can contact me' },
+        contacts_only: { label: 'Contacts only', hint: 'Contacts or members in the same room' },
+        whitelist: { label: 'Allowlist', hint: 'Contacts only (strict)' },
+        closed: { label: 'Closed', hint: 'Reject all new conversations; contact requests are still allowed' },
+      },
+      roomInviteOptions: {
+        open: { label: 'Open' },
+        contacts_only: { label: 'Contacts only' },
+        closed: { label: 'Closed' },
+      },
+      attentionOptions: {
+        always: { label: 'All', hint: 'Wake and reply to any message in a room' },
+        mention_only: { label: 'Mentions only', hint: 'Wake only when mentioned' },
+        keyword: { label: 'Keywords', hint: 'Wake only when a keyword matches' },
+        muted: { label: 'Muted', hint: 'Do not reply proactively in rooms' },
+      },
+    },
+    files: {
+      title: 'Runtime files',
+      subtitle: "This Agent's local files",
+      refresh: 'Refresh',
+      daemonUnavailable: 'Daemon is offline or this Agent is not hosted by a daemon',
+      loadFailed: 'Failed to load files',
+      empty: 'No files to display',
+      tooLarge: 'Too large',
+      previewTooLarge: 'File exceeds the preview size limit',
+    },
+  },
+  zh: {
+    ariaLabel: 'Bot 详情',
+    close: '关闭',
+    defaultBadge: 'My Bot · 默认',
+    botBadge: 'My Bot',
+    online: 'Online',
+    offline: 'Offline',
+    tabs: {
+      overview: '概览',
+      wallet: '钱包',
+      settings: '设置',
+      files: '文件',
+    },
+    overview: {
+      activity7d: '7 天活跃',
+      messages: '消息',
+      rooms: '房间',
+      openTopics: '打开',
+      completedTopics: '完成',
+      hostedDevice: '托管设备',
+      view: '查看',
+      noDevice: '未关联任何设备',
+      friends: (count) => `好友 · ${count}`,
+      moreFriends: (count) => `还有 ${count} 位`,
+      noFriends: '还没有好友',
+      groups: (count) => `加入的群 · ${count}`,
+      members: (count) => `${count} 成员`,
+      moreGroups: (count) => `还有 ${count} 个群`,
+      noGroups: '还没加入任何群',
+      openChat: '打开对话',
+      deleteBot: '删除此 Bot',
+      deleteConfirm: '确定要删除此 Bot 吗？',
+    },
+    profile: {
+      title: '资料',
+      displayName: '显示名称',
+      bio: '简介',
+      bioPlaceholder: '介绍这个 Bot（可选）',
+      save: '保存',
+      saving: '保存中...',
+      saved: '已保存',
+      saveFailed: '保存失败',
+    },
+    settings: {
+      conversation: '对话与回复',
+      autonomy: '自主',
+      channels: '接入',
+      saveFailed: '保存失败',
+      saving: '保存中...',
+      contactTitle: '谁能联系我',
+      contactDescription: '是否接受来自其他 Agent 或人类用户的对话与加入房间邀请。',
+      allowAgentSender: '接受其他 agent 直接对话',
+      allowHumanSender: '接受人类用户对话',
+      roomInvite: '加入房间邀请',
+      defaultReplyTitle: '默认回复策略',
+      defaultReplyDescription: 'Daemon 注意力：房间里收到消息后是否唤醒 LLM。',
+      keywords: '关键词',
+      keywordPlaceholder: '输入关键词后按回车添加',
+      dmAlwaysReply: '私聊不受此设置影响，始终回复',
+      contactOptions: {
+        open: { label: '公开', hint: '任何人都可以联系我' },
+        contacts_only: { label: '仅联系人', hint: '联系人或同房间成员' },
+        whitelist: { label: '白名单', hint: '仅联系人（严格）' },
+        closed: { label: '关闭', hint: '拒绝所有新对话（联系人申请仍可发起）' },
+      },
+      roomInviteOptions: {
+        open: { label: '公开' },
+        contacts_only: { label: '仅联系人' },
+        closed: { label: '关闭' },
+      },
+      attentionOptions: {
+        always: { label: '全部', hint: '房间里收到任何消息都唤醒回复' },
+        mention_only: { label: '仅被@', hint: '只在被 @ 时唤醒' },
+        keyword: { label: '关键词', hint: '命中关键词才唤醒' },
+        muted: { label: '静音', hint: '房间不主动回复' },
+      },
+    },
+    files: {
+      title: '运行时文件',
+      subtitle: '当前 Agent 的本地文件',
+      refresh: '刷新',
+      daemonUnavailable: 'Daemon 未在线或此 Agent 未由 daemon 托管',
+      loadFailed: '读取文件失败',
+      empty: '没有可显示的文件',
+      tooLarge: '过大',
+      previewTooLarge: '文件超过预览大小限制',
+    },
+  },
+}


### PR DESCRIPTION
## Summary
- add shared bot detail drawer translations for English and Chinese
- wire BotDetailDrawer tab/profile/policy/files labels to current locale
- wire legacy AgentSettingsDrawer profile/policy/files labels to the same locale copy

## Verification
- git diff --check
- npx tsc --noEmit (fails on existing missing route/module test references and existing RoomPolicyEffective test fixture type issue)