### PR TITLE
fix: show owner chat rooms optimistically

### DIFF
--- a/frontend/src/components/dashboard/BotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/BotDetailDrawer.tsx
@@ -113,7 +113,13 @@ export default function BotDetailDrawer() {
   );
   const ownedAgents = useDashboardSessionStore((s) => s.ownedAgents);
   const daemons = useDaemonStore((s) => s.daemons);
-  const ownedAgentRooms = useDashboardChatStore((s) => s.ownedAgentRooms);
+  const { loadOwnedAgentRooms, ownedAgentRooms, upsertOptimisticOwnerChatRoom } = useDashboardChatStore(
+    useShallow((s) => ({
+      loadOwnedAgentRooms: s.loadOwnedAgentRooms,
+      ownedAgentRooms: s.ownedAgentRooms,
+      upsertOptimisticOwnerChatRoom: s.upsertOptimisticOwnerChatRoom,
+    })),
+  );
 
   const open = botDetailAgentId !== null;
   const bot = botDetailAgentId ? ownedAgents.find((a) => a.agent_id === botDetailAgentId) ?? null : null;
@@ -181,9 +187,12 @@ export default function BotDetailDrawer() {
     setMessagesPane("user-chat");
     setFocusedRoomId(null);
     setOpenedRoomId(null);
+    upsertOptimisticOwnerChatRoom(bot);
     try {
       const room = await api.getUserChatRoom(agentId);
+      upsertOptimisticOwnerChatRoom(bot, room.room_id);
       setUserChatRoomId(room.room_id);
+      void loadOwnedAgentRooms();
     } catch (error) {
       console.error("[BotDetailDrawer] getUserChatRoom failed:", error);
     }

--- a/frontend/src/components/dashboard/ContactsDetailPane.tsx
+++ b/frontend/src/components/dashboard/ContactsDetailPane.tsx
@@ -128,13 +128,15 @@ export default function ContactsDetailPane() {
       refreshHumanRooms: s.refreshHumanRooms,
     })),
   );
-  const { overview, publicAgents, refreshOverview, loadRoomMessages, setError } = useDashboardChatStore(
+  const { overview, publicAgents, refreshOverview, loadOwnedAgentRooms, loadRoomMessages, setError, upsertOptimisticOwnerChatRoom } = useDashboardChatStore(
     useShallow((s) => ({
       overview: s.overview,
       publicAgents: s.publicAgents,
       refreshOverview: s.refreshOverview,
+      loadOwnedAgentRooms: s.loadOwnedAgentRooms,
       loadRoomMessages: s.loadRoomMessages,
       setError: s.setError,
+      upsertOptimisticOwnerChatRoom: s.upsertOptimisticOwnerChatRoom,
     })),
   );
 
@@ -229,7 +231,10 @@ export default function ContactsDetailPane() {
     try {
       if (target.kind === "owned-bot") {
         const agentId = target.agent.agent_id;
+        upsertOptimisticOwnerChatRoom(target.agent);
         const room = await api.getUserChatRoom(agentId);
+        upsertOptimisticOwnerChatRoom(target.agent, room.room_id);
+        void loadOwnedAgentRooms();
         setMessagesPane("user-chat");
         setUserChatAgentId(agentId);
         setUserChatRoomId(room.room_id);

--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -901,8 +901,17 @@ export default function DashboardApp() {
         uiStore.setUserChatAgentId(agentId);
         uiStore.setFocusedRoomId(null);
         uiStore.setOpenedRoomId(null);
+        chatStore.upsertOptimisticOwnerChatRoom({
+          agent_id: selectedAgentForCard.agent_id,
+          display_name: selectedAgentForCard.display_name || selectedAgentForCard.agent_id,
+        });
         api.getUserChatRoom(agentId).then((room) => {
+          chatStore.upsertOptimisticOwnerChatRoom({
+            agent_id: selectedAgentForCard.agent_id,
+            display_name: selectedAgentForCard.display_name || selectedAgentForCard.agent_id,
+          }, room.room_id);
           uiStore.setUserChatRoomId(room.room_id);
+          void chatStore.loadOwnedAgentRooms();
         }).catch((error) => {
           console.error("[DashboardApp] getUserChatRoom failed:", error);
         });

--- a/frontend/src/store/useDashboardChatStore.test.ts
+++ b/frontend/src/store/useDashboardChatStore.test.ts
@@ -1,11 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { DashboardOverview } from "@/lib/types";
+import type { DashboardOverview, HumanAgentRoomSummary } from "@/lib/types";
 
 const mocks = vi.hoisted(() => ({
   getRoomMessages: vi.fn(),
   leaveRoom: vi.fn(),
   getOverview: vi.fn(),
   getPublicRoom: vi.fn(),
+  listAgentRooms: vi.fn(),
 }));
 
 vi.mock("@/lib/api", () => ({
@@ -15,7 +16,9 @@ vi.mock("@/lib/api", () => ({
     getOverview: mocks.getOverview,
     getPublicRoom: mocks.getPublicRoom,
   },
-  humansApi: {},
+  humansApi: {
+    listAgentRooms: mocks.listAgentRooms,
+  },
   getActiveAgentId: vi.fn(() => null),
   setActiveAgentId: vi.fn(),
   getStoredActiveIdentity: vi.fn(() => null),
@@ -57,13 +60,39 @@ function makeOverview(lastMessageAt: string | null = null): DashboardOverview {
   };
 }
 
+function makeOwnedAgentRoom(overrides: Partial<HumanAgentRoomSummary> = {}): HumanAgentRoomSummary {
+  return {
+    room_id: "rm_oc_real",
+    name: "Owned bot",
+    description: null,
+    rule: null,
+    owner_id: "ag_bot",
+    visibility: "private",
+    join_policy: "invite_only",
+    member_count: 1,
+    created_at: "2026-05-14T00:00:00.000Z",
+    required_subscription_product_id: null,
+    last_message_preview: null,
+    last_message_at: "2026-05-14T00:00:00.000Z",
+    last_sender_name: null,
+    allow_human_send: true,
+    members_preview: null,
+    bots: [{ agent_id: "ag_bot", display_name: "Owned bot", role: "owner" }],
+    ...overrides,
+  };
+}
+
 describe("useDashboardChatStore message polling", () => {
   beforeEach(() => {
     mocks.getRoomMessages.mockReset();
     mocks.leaveRoom.mockReset();
     mocks.getOverview.mockReset();
     mocks.getPublicRoom.mockReset();
-    useDashboardSessionStore.setState({ token: "test-token" });
+    mocks.listAgentRooms.mockReset();
+    useDashboardSessionStore.setState({
+      token: "test-token",
+      activeIdentity: { type: "human", id: "hu_1" },
+    });
     useDashboardUIStore.setState({
       focusedRoomId: null,
       openedRoomId: null,
@@ -77,8 +106,13 @@ describe("useDashboardChatStore message polling", () => {
       messages: {},
       messagesLoading: {},
       messagesHasMore: {},
+      ownedAgentRooms: [],
+      optimisticOwnerChatRooms: {},
     });
-    useDashboardSessionStore.setState({ token: "token" });
+    useDashboardSessionStore.setState({
+      token: "token",
+      activeIdentity: { type: "human", id: "hu_1" },
+    });
   });
 
   it("does not refetch a room already loaded as empty when the room snapshot is unchanged", async () => {
@@ -158,5 +192,61 @@ describe("useDashboardChatStore message polling", () => {
     expect(useDashboardChatStore.getState().error).toBeNull();
     expect(useDashboardChatStore.getState().overviewRefreshing).toBe(false);
     expect(useDashboardChatStore.getState().overviewErrored).toBe(false);
+  });
+
+  it("inserts an optimistic owner-chat room immediately", () => {
+    useDashboardChatStore.getState().upsertOptimisticOwnerChatRoom({
+      agent_id: "ag_bot",
+      display_name: "Owned bot",
+    });
+
+    const state = useDashboardChatStore.getState();
+    expect(state.ownedAgentRooms).toHaveLength(1);
+    expect(state.ownedAgentRooms[0]).toMatchObject({
+      room_id: "rm_oc_pending_ag_bot",
+      name: "Owned bot",
+      owner_id: "ag_bot",
+      bots: [{ agent_id: "ag_bot", display_name: "Owned bot", role: "owner" }],
+    });
+  });
+
+  it("reconciles an optimistic owner-chat room when the backend returns the real room", async () => {
+    useDashboardChatStore.getState().upsertOptimisticOwnerChatRoom({
+      agent_id: "ag_bot",
+      display_name: "Owned bot",
+    });
+    mocks.listAgentRooms.mockResolvedValue({
+      rooms: [makeOwnedAgentRoom({ room_id: "rm_oc_real_123" })],
+    });
+
+    await useDashboardChatStore.getState().loadOwnedAgentRooms();
+
+    const state = useDashboardChatStore.getState();
+    expect(state.optimisticOwnerChatRooms).toEqual({});
+    expect(state.ownedAgentRooms.map((room) => room.room_id)).toEqual(["rm_oc_real_123"]);
+  });
+
+  it("does not wipe an existing owner-chat preview when reopening the same bot chat", () => {
+    useDashboardChatStore.setState({
+      ownedAgentRooms: [
+        makeOwnedAgentRoom({
+          room_id: "rm_oc_existing",
+          last_message_preview: "existing preview",
+          last_sender_name: "Owned bot",
+        }),
+      ],
+      optimisticOwnerChatRooms: {},
+    });
+
+    useDashboardChatStore.getState().upsertOptimisticOwnerChatRoom({
+      agent_id: "ag_bot",
+      display_name: "Owned bot",
+    });
+
+    expect(useDashboardChatStore.getState().ownedAgentRooms[0]).toMatchObject({
+      room_id: "rm_oc_existing",
+      last_message_preview: "existing preview",
+      last_sender_name: "Owned bot",
+    });
   });
 });

--- a/frontend/src/store/useDashboardChatStore.ts
+++ b/frontend/src/store/useDashboardChatStore.ts
@@ -17,10 +17,12 @@ import type {
   PublicHumanProfile,
   PublicRoom,
   RealtimeMetaEvent,
+  UserAgent,
 } from "@/lib/types";
 import { api, humansApi } from "@/lib/api";
 import {
   buildVisibleMessageRooms,
+  compareRoomsByActivityDesc,
   roomMessagesInFlight,
   roomMessagesReloadPending,
   roomPollInFlight,
@@ -79,6 +81,83 @@ function getRoomMessageSnapshot(room: DashboardRoom | null): string | null {
   return room?.last_message_at ?? null;
 }
 
+function ownerChatRoomIdForOptimistic(agentId: string): string {
+  return `rm_oc_pending_${agentId}`;
+}
+
+function isOwnerChatSummary(room: Pick<HumanAgentRoomSummary, "room_id">): boolean {
+  return room.room_id.startsWith("rm_oc_");
+}
+
+function ownerChatAgentId(room: HumanAgentRoomSummary): string | null {
+  if (!isOwnerChatSummary(room)) return null;
+  return room.bots[0]?.agent_id ?? null;
+}
+
+function buildOptimisticOwnerChatRoom(
+  agent: Pick<UserAgent, "agent_id" | "display_name">,
+  roomId?: string | null,
+  existing?: HumanAgentRoomSummary,
+): HumanAgentRoomSummary {
+  const now = new Date().toISOString();
+  return {
+    ...existing,
+    room_id: roomId || ownerChatRoomIdForOptimistic(agent.agent_id),
+    name: existing?.name || agent.display_name || agent.agent_id,
+    description: existing?.description ?? null,
+    rule: existing?.rule ?? null,
+    owner_id: agent.agent_id,
+    visibility: existing?.visibility || "private",
+    join_policy: existing?.join_policy || "invite_only",
+    member_count: existing?.member_count ?? 1,
+    created_at: existing?.created_at ?? now,
+    required_subscription_product_id: existing?.required_subscription_product_id ?? null,
+    last_message_preview: existing?.last_message_preview ?? null,
+    last_message_at: existing?.last_message_at ?? now,
+    last_sender_name: existing?.last_sender_name ?? null,
+    allow_human_send: existing?.allow_human_send ?? true,
+    members_preview: existing?.members_preview ?? null,
+    bots: existing?.bots ?? [{
+      agent_id: agent.agent_id,
+      display_name: agent.display_name || agent.agent_id,
+      role: "owner",
+    }],
+  };
+}
+
+function mergeOptimisticOwnerChatRooms(
+  rooms: HumanAgentRoomSummary[],
+  optimisticByAgent: Record<string, HumanAgentRoomSummary>,
+): HumanAgentRoomSummary[] {
+  const optimisticRooms = Object.values(optimisticByAgent);
+  if (optimisticRooms.length === 0) return rooms;
+
+  const optimisticAgentIds = new Set(optimisticRooms.map((room) => room.bots[0]?.agent_id).filter(Boolean));
+  const baseRooms = rooms.filter((room) => {
+    const agentId = ownerChatAgentId(room);
+    return !agentId || !optimisticAgentIds.has(agentId);
+  });
+  return [...baseRooms, ...optimisticRooms].sort(compareRoomsByActivityDesc);
+}
+
+function reconcileOptimisticOwnerChatRooms(
+  serverRooms: HumanAgentRoomSummary[],
+  optimisticByAgent: Record<string, HumanAgentRoomSummary>,
+): Record<string, HumanAgentRoomSummary> {
+  if (Object.keys(optimisticByAgent).length === 0) return optimisticByAgent;
+
+  const serverOwnerChatAgents = new Set(
+    serverRooms
+      .map(ownerChatAgentId)
+      .filter((agentId): agentId is string => Boolean(agentId)),
+  );
+  const next = { ...optimisticByAgent };
+  for (const agentId of serverOwnerChatAgents) {
+    delete next[agentId];
+  }
+  return next;
+}
+
 export function mapOwnedAgentRoomToDashboardRoom(room: HumanAgentRoomSummary): DashboardRoom {
   return ownedAgentRoomToDashboardRoom(room);
 }
@@ -113,6 +192,7 @@ interface DashboardChatState {
   publicHumansLoaded: boolean;
   recentVisitedRooms: PublicRoom[];
   ownedAgentRooms: HumanAgentRoomSummary[];
+  optimisticOwnerChatRooms: Record<string, HumanAgentRoomSummary>;
   ownedAgentRoomsLoading: boolean;
   ownedAgentRoomsLoaded: boolean;
   roomMemberVersions: Record<string, number>;
@@ -145,6 +225,7 @@ interface DashboardChatState {
   loadPublicAgents: (q?: string) => Promise<void>;
   loadPublicHumans: (q?: string) => Promise<void>;
   loadOwnedAgentRooms: () => Promise<void>;
+  upsertOptimisticOwnerChatRoom: (agent: Pick<UserAgent, "agent_id" | "display_name">, roomId?: string | null) => void;
 }
 
 const initialChatState = {
@@ -177,6 +258,7 @@ const initialChatState = {
   publicHumansLoaded: false,
   recentVisitedRooms: [],
   ownedAgentRooms: [],
+  optimisticOwnerChatRooms: {},
   ownedAgentRoomsLoading: false,
   ownedAgentRoomsLoaded: false,
   roomMemberVersions: {},
@@ -203,6 +285,7 @@ function hasTransientChatState(state: DashboardChatState): boolean {
     || state.leavingRoomId !== null
     || state.publicRoomsLoading
     || state.publicAgentsLoading
+    || Object.keys(state.optimisticOwnerChatRooms).length > 0
     || state.ownedAgentRoomsLoading
   );
 }
@@ -672,8 +755,13 @@ export const useDashboardChatStore = create<DashboardChatState>()(
         set({ ownedAgentRoomsLoading: true });
         try {
           const result = await humansApi.listAgentRooms();
+          const optimisticOwnerChatRooms = reconcileOptimisticOwnerChatRooms(
+            result.rooms,
+            get().optimisticOwnerChatRooms,
+          );
           set({
-            ownedAgentRooms: result.rooms,
+            ownedAgentRooms: mergeOptimisticOwnerChatRooms(result.rooms, optimisticOwnerChatRooms),
+            optimisticOwnerChatRooms,
             ownedAgentRoomsLoading: false,
             ownedAgentRoomsLoaded: true,
           });
@@ -686,6 +774,25 @@ export const useDashboardChatStore = create<DashboardChatState>()(
         }
       },
 
+      upsertOptimisticOwnerChatRoom: (agent, roomId) => {
+        set((state) => {
+          const existingOwnerChatRoom = state.ownedAgentRooms.find((room) => ownerChatAgentId(room) === agent.agent_id);
+          const optimisticRoom = roomId || !existingOwnerChatRoom
+            ? buildOptimisticOwnerChatRoom(agent, roomId, existingOwnerChatRoom)
+            : existingOwnerChatRoom;
+          const optimisticOwnerChatRooms = {
+            ...state.optimisticOwnerChatRooms,
+            [agent.agent_id]: optimisticRoom,
+          };
+          return {
+            optimisticOwnerChatRooms,
+            ownedAgentRooms: mergeOptimisticOwnerChatRooms(
+              state.ownedAgentRooms,
+              optimisticOwnerChatRooms,
+            ),
+          };
+        });
+      },
     }),
     {
       name: "dashboard-chat-storage",


### PR DESCRIPTION
## Summary
- add optimistic owner-chat room entries for owned bot conversations so Messages updates immediately
- reconcile pending rm_oc entries when /me/agent-rooms returns the real room
- cover owner-chat optimistic insert and reconciliation in chat store tests

## Tests
- pnpm exec vitest run src/store/useDashboardChatStore.test.ts
- pnpm exec tsc --noEmit --pretty false --noErrorTruncation (fails on existing frontend/tests/api missing route modules and tests/usePolicyStore fixture type)
- pnpm run build (fails during /admin/codes prerender because Supabase URL/API key env vars are not configured; compile + TypeScript stages complete)