### PR TITLE
fix: inherit owner bot room permissions

### DIFF
--- a/backend/app/auth_room.py
+++ b/backend/app/auth_room.py
@@ -22,6 +22,78 @@ from hub.models import Agent, Room, RoomMember
 
 RoomCapability = Literal["owner", "admin"]
 
+_ROLE_RANK = {
+    RoomRole.member: 0,
+    RoomRole.admin: 1,
+    RoomRole.owner: 2,
+}
+
+
+def _coerce_room_role(role: RoomRole | str | None) -> RoomRole | None:
+    if role is None:
+        return None
+    if isinstance(role, RoomRole):
+        return role
+    try:
+        return RoomRole(str(role))
+    except ValueError:
+        return None
+
+
+def strongest_room_role(roles: list[RoomRole | str | None]) -> RoomRole | None:
+    """Return the highest room role from a set of candidate roles."""
+    best: RoomRole | None = None
+    for raw_role in roles:
+        role = _coerce_room_role(raw_role)
+        if role is None:
+            continue
+        if best is None or _ROLE_RANK[role] > _ROLE_RANK[best]:
+            best = role
+    return best
+
+
+async def load_owned_agent_ids(db: AsyncSession, user_id) -> set[str]:
+    """Return the user's owned bot ids."""
+    if user_id is None:
+        return set()
+    result = await db.execute(select(Agent.agent_id).where(Agent.user_id == user_id))
+    return {row[0] for row in result.all()}
+
+
+async def effective_human_room_role(
+    db: AsyncSession,
+    *,
+    room: Room,
+    human_role: RoomRole | str | None,
+    user_id,
+    owned_agent_ids: set[str] | None = None,
+) -> RoomRole | None:
+    """Resolve a human viewer's strongest effective role in ``room``.
+
+    The viewer keeps their own Human RoomMember role and also inherits the
+    strongest role held by any bot owned by the same user in that room. If the
+    room itself is owned by one of those bots, the effective role is owner.
+    """
+    owned_ids = owned_agent_ids
+    if owned_ids is None:
+        owned_ids = await load_owned_agent_ids(db, user_id)
+
+    candidates: list[RoomRole | str | None] = [human_role]
+    if room.owner_type == ParticipantType.agent and room.owner_id in owned_ids:
+        candidates.append(RoomRole.owner)
+
+    if owned_ids:
+        result = await db.execute(
+            select(RoomMember.role).where(
+                RoomMember.room_id == room.room_id,
+                RoomMember.participant_type == ParticipantType.agent,
+                RoomMember.agent_id.in_(owned_ids),
+            )
+        )
+        candidates.extend(row[0] for row in result.all())
+
+    return strongest_room_role(candidates)
+
 
 async def viewer_can_admin_room(
     db: AsyncSession,
@@ -37,10 +109,11 @@ async def viewer_can_admin_room(
           ``ctx.user_id`` (transitive — viewer's user owns the bot);
         * room is human-owned and ``ctx.human_id`` matches ``room.owner_id``.
         * RoomMember.role == owner under the viewer's active agent.
-    - ``"admin"`` — viewer is a RoomMember with role admin under their
-      active agent (humans don't get admin-via-membership today).
+    - ``"admin"`` — viewer has an admin RoomMember row through their active
+      agent or any other bot owned by the same user.
     - ``None`` — no capability.
     """
+    owned_agent_ids: set[str] = set()
     if room.owner_type == ParticipantType.agent:
         if ctx.active_agent_id and ctx.active_agent_id == room.owner_id:
             return "owner"
@@ -51,9 +124,11 @@ async def viewer_can_admin_room(
         ).scalar_one_or_none()
         if owner_agent is not None and ctx.user_id is not None and owner_agent.user_id == ctx.user_id:
             return "owner"
+        owned_agent_ids = await load_owned_agent_ids(db, ctx.user_id)
     elif room.owner_type == ParticipantType.human:
         if ctx.human_id and ctx.human_id == room.owner_id:
             return "owner"
+        owned_agent_ids = await load_owned_agent_ids(db, ctx.user_id)
 
     # Admin-via-RoomMember — explicitly filter participant_type=agent so we
     # don't depend on ID prefixes as a discriminator inside auth code.
@@ -69,6 +144,23 @@ async def viewer_can_admin_room(
         ).scalar_one_or_none()
         if member is not None and member.role in (RoomRole.owner, RoomRole.admin):
             return "owner" if member.role == RoomRole.owner else "admin"
+
+    if owned_agent_ids:
+        inherited_role = strongest_room_role(
+            list(
+                (
+                    await db.execute(
+                        select(RoomMember.role).where(
+                            RoomMember.room_id == room.room_id,
+                            RoomMember.participant_type == ParticipantType.agent,
+                            RoomMember.agent_id.in_(owned_agent_ids),
+                        )
+                    )
+                ).scalars().all()
+            )
+        )
+        if inherited_role in (RoomRole.owner, RoomRole.admin):
+            return "owner" if inherited_role == RoomRole.owner else "admin"
 
     return None
 

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -16,7 +16,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import RequestContext, require_active_agent, require_user, require_user_with_optional_agent
-from app.auth_room import resolve_provider_agent_for_room, viewer_can_admin_room
+from app.auth_room import effective_human_room_role, resolve_provider_agent_for_room, viewer_can_admin_room
 from app.helpers import escape_like, extract_text_from_envelope
 from hub.database import get_db
 from hub.dashboard_message_shaping import (
@@ -112,6 +112,27 @@ class ChatAttachment(BaseModel):
 
 
 _RECEIPT_TYPES = frozenset({"ack", "result", "error"})
+
+
+async def _effective_dashboard_member_role(
+    db: AsyncSession,
+    *,
+    ctx: RequestContext,
+    room: Room,
+    member: RoomMember,
+) -> RoomRole:
+    """Resolve the strongest dashboard role for the signed-in viewer.
+
+    Dashboard requests are backed by a human user, so both human-anchored and
+    active-agent requests inherit the strongest role held by any bot owned by
+    the same user.
+    """
+    return await effective_human_room_role(
+        db,
+        room=room,
+        human_role=member.role,
+        user_id=ctx.user_id,
+    ) or member.role
 
 
 def _extract_text_preview(envelope_json: str) -> tuple[str, str | None, str]:
@@ -1848,6 +1869,10 @@ async def list_join_requests(
         viewer_id = ctx.human_id
         viewer_type = ParticipantType.human
 
+    room = await db.scalar(select(Room).where(Room.room_id == room_id))
+    if room is None:
+        raise HTTPException(status_code=404, detail="Room not found")
+
     member_result = await db.execute(
         select(RoomMember).where(
             RoomMember.room_id == room_id,
@@ -1856,7 +1881,12 @@ async def list_join_requests(
         )
     )
     member = member_result.scalar_one_or_none()
-    if member is None or member.role not in (RoomRole.owner, RoomRole.admin):
+    effective_role = (
+        await _effective_dashboard_member_role(db, ctx=ctx, room=room, member=member)
+        if member is not None
+        else None
+    )
+    if member is None or effective_role not in (RoomRole.owner, RoomRole.admin):
         raise HTTPException(status_code=403, detail="Owner or admin required")
 
     # Resolve requester display name against both agents and users (by human_id).
@@ -1916,6 +1946,10 @@ async def accept_join_request(
         viewer_id = ctx.human_id
         viewer_type = ParticipantType.human
 
+    room = await db.scalar(select(Room).where(Room.room_id == room_id))
+    if room is None:
+        raise HTTPException(status_code=404, detail="Room not found")
+
     member_result = await db.execute(
         select(RoomMember).where(
             RoomMember.room_id == room_id,
@@ -1924,7 +1958,12 @@ async def accept_join_request(
         )
     )
     member = member_result.scalar_one_or_none()
-    if member is None or member.role not in (RoomRole.owner, RoomRole.admin):
+    effective_role = (
+        await _effective_dashboard_member_role(db, ctx=ctx, room=room, member=member)
+        if member is not None
+        else None
+    )
+    if member is None or effective_role not in (RoomRole.owner, RoomRole.admin):
         raise HTTPException(status_code=403, detail="Owner or admin required")
 
     jr_result = await db.execute(
@@ -1939,9 +1978,7 @@ async def accept_join_request(
     if jr.status != RoomJoinRequestStatus.pending:
         raise HTTPException(status_code=409, detail="Request already resolved")
 
-    room_result = await db.execute(select(Room).where(Room.room_id == room_id))
-    room = room_result.scalar_one_or_none()
-    if room and room.max_members is not None:
+    if room.max_members is not None:
         count_result = await db.execute(
             select(func.count(RoomMember.id)).where(RoomMember.room_id == room_id)
         )
@@ -1991,6 +2028,10 @@ async def reject_join_request(
         viewer_id = ctx.human_id
         viewer_type = ParticipantType.human
 
+    room = await db.scalar(select(Room).where(Room.room_id == room_id))
+    if room is None:
+        raise HTTPException(status_code=404, detail="Room not found")
+
     member_result = await db.execute(
         select(RoomMember).where(
             RoomMember.room_id == room_id,
@@ -1999,7 +2040,12 @@ async def reject_join_request(
         )
     )
     member = member_result.scalar_one_or_none()
-    if member is None or member.role not in (RoomRole.owner, RoomRole.admin):
+    effective_role = (
+        await _effective_dashboard_member_role(db, ctx=ctx, room=room, member=member)
+        if member is not None
+        else None
+    )
+    if member is None or effective_role not in (RoomRole.owner, RoomRole.admin):
         raise HTTPException(status_code=403, detail="Owner or admin required")
 
     jr_result = await db.execute(
@@ -2592,8 +2638,22 @@ async def human_room_send(
     if not room.allow_human_send:
         raise HTTPException(status_code=403, detail="Human send disabled for this room")
 
+    effective_role = await _effective_dashboard_member_role(
+        db, ctx=ctx, room=room, member=active_member
+    )
+    effective_member = active_member
+    if effective_role != active_member.role:
+        effective_member = RoomMember(
+            room_id=active_member.room_id,
+            agent_id=active_member.agent_id,
+            participant_type=active_member.participant_type,
+            role=effective_role,
+            can_send=None,
+            can_invite=None,
+        )
+
     # _can_send (step 6)
-    if not _room_can_send(room, active_member):
+    if not _room_can_send(room, effective_member):
         raise HTTPException(status_code=403, detail="Sender cannot send in this room")
 
     topic_id: str | None = None
@@ -2632,7 +2692,7 @@ async def human_room_send(
     if normalized_attachments:
         payload_for_checks["attachments"] = normalized_attachments
     try:
-        _check_slow_mode(room, active_member)
+        _check_slow_mode(room, effective_member)
         _check_duplicate_content(room_id, sender_id, payload_for_checks)
     except HTTPException:
         raise

--- a/backend/app/routers/humans.py
+++ b/backend/app/routers/humans.py
@@ -24,6 +24,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import RequestContext, require_user
+from app.auth_room import effective_human_room_role, load_owned_agent_ids
 from app.routers.dashboard import _build_rooms_from_sql
 from hub.database import get_db
 from hub.enums import (
@@ -328,29 +329,29 @@ async def _load_owned_agent_ids(db: AsyncSession, user_id: UUID | None) -> set[s
     owns a room should see ``my_role == "owner"`` and pass owner-only gates
     on that room. Mirrors :func:`app.auth_room.viewer_can_admin_room`.
     """
-    if user_id is None:
-        return set()
-    result = await db.execute(select(Agent.agent_id).where(Agent.user_id == user_id))
-    return {row[0] for row in result.all()}
+    return await load_owned_agent_ids(db, user_id)
 
 
-def _effective_human_role(
+async def _effective_human_role(
+    db: AsyncSession,
     role: RoomRole | str,
     room: Room,
+    user_id: UUID | None,
     owned_agent_ids: set[str],
 ) -> RoomRole | str:
-    """Promote ``role`` to ``owner`` when the human owns the room's agent owner.
+    """Return the strongest role held by the Human or any owned bot.
 
-    Returning ``RoomRole.owner`` instead of mutating DB state keeps the
-    serialiser output and the in-process permission gates aligned without
-    rewriting room_members rows.
+    Returning an effective role instead of mutating DB state keeps the
+    serialiser output and permission gates aligned without rewriting
+    ``room_members`` rows.
     """
-    if (
-        room.owner_type == ParticipantType.agent
-        and room.owner_id in owned_agent_ids
-    ):
-        return RoomRole.owner
-    return role
+    return await effective_human_room_role(
+        db,
+        room=room,
+        human_role=role,
+        user_id=user_id,
+        owned_agent_ids=owned_agent_ids,
+    ) or role
 
 
 def _serialize_human_room_summary(
@@ -650,16 +651,20 @@ async def list_human_rooms(
         member_counts = {room_id: int(count or 0) for room_id, count in count_result.all()}
         previews_by_room = await _build_member_previews(db, room_ids)
     owned_agent_ids = await _load_owned_agent_ids(db, ctx.user_id)
-    rooms = [
-        _serialize_human_room_summary(
-            room,
-            _effective_human_role(role, room, owned_agent_ids),
-            member_count=member_counts.get(room.room_id, 0),
-            members_preview=previews_by_room.get(room.room_id)
-            if member_counts.get(room.room_id, 0) > 2 else None,
+    rooms = []
+    for room, role in rows:
+        effective_role = await _effective_human_role(
+            db, role, room, ctx.user_id, owned_agent_ids
         )
-        for room, role in rows
-    ]
+        rooms.append(
+            _serialize_human_room_summary(
+                room,
+                effective_role,
+                member_count=member_counts.get(room.room_id, 0),
+                members_preview=previews_by_room.get(room.room_id)
+                if member_counts.get(room.room_id, 0) > 2 else None,
+            )
+        )
     return HumanRoomListResponse(rooms=rooms)
 
 
@@ -1133,7 +1138,9 @@ async def create_room_invite_as_human(
     if inviter is None:
         raise HTTPException(status_code=403, detail="Not a member of this room")
     owned_agent_ids = await _load_owned_agent_ids(db, ctx.user_id)
-    effective_role = _effective_human_role(inviter.role, room, owned_agent_ids)
+    effective_role = await _effective_human_role(
+        db, inviter.role, room, ctx.user_id, owned_agent_ids
+    )
     if effective_role not in (RoomRole.owner, RoomRole.admin) and not bool(
         inviter.can_invite or room.default_invite
     ):
@@ -1212,7 +1219,9 @@ async def invite_room_member_as_human(
     if inviter is None:
         raise HTTPException(status_code=403, detail="Not a member of this room")
     owned_agent_ids = await _load_owned_agent_ids(db, ctx.user_id)
-    effective_role = _effective_human_role(inviter.role, room, owned_agent_ids)
+    effective_role = await _effective_human_role(
+        db, inviter.role, room, ctx.user_id, owned_agent_ids
+    )
     can_invite = (
         effective_role in (RoomRole.owner, RoomRole.admin)
         or inviter.can_invite
@@ -1476,7 +1485,9 @@ async def update_room_settings_as_human(
     user = await _load_human(db, ctx)
     room, caller = await _load_room_member_as_caller(db, room_id, user.human_id, lock=True)
     owned_agent_ids = await _load_owned_agent_ids(db, ctx.user_id)
-    effective_role = _effective_human_role(caller.role, room, owned_agent_ids)
+    effective_role = await _effective_human_role(
+        db, caller.role, room, ctx.user_id, owned_agent_ids
+    )
     if effective_role not in (RoomRole.owner, RoomRole.admin):
         raise HTTPException(status_code=403, detail="Only owner or admin can update room settings")
 
@@ -1589,7 +1600,11 @@ async def dissolve_room_as_human(
 ):
     user = await _load_human(db, ctx)
     room, caller = await _load_room_member_as_caller(db, room_id, user.human_id, lock=True)
-    if caller.role != RoomRole.owner:
+    owned_agent_ids = await _load_owned_agent_ids(db, ctx.user_id)
+    effective_role = await _effective_human_role(
+        db, caller.role, room, ctx.user_id, owned_agent_ids
+    )
+    if effective_role != RoomRole.owner:
         raise HTTPException(status_code=403, detail="Only the room owner can dissolve this room")
 
     # Pre-cancel subscriptions bound to this room — see hub dissolve route.
@@ -1633,7 +1648,11 @@ async def transfer_room_ownership_as_human(
     user = await _load_human(db, ctx)
     me = user.human_id
     room, caller = await _load_room_member_as_caller(db, room_id, me, lock=True)
-    if caller.role != RoomRole.owner:
+    owned_agent_ids = await _load_owned_agent_ids(db, ctx.user_id)
+    effective_role = await _effective_human_role(
+        db, caller.role, room, ctx.user_id, owned_agent_ids
+    )
+    if effective_role != RoomRole.owner:
         raise HTTPException(status_code=403, detail="Only the room owner can transfer ownership")
 
     new_owner_id = body.new_owner_id
@@ -1662,7 +1681,13 @@ async def transfer_room_ownership_as_human(
                 detail="Target must hold an active subscription to own this room",
             )
 
-    caller.role = RoomRole.member
+    outgoing_owner_member = caller
+    if room.owner_id != caller.agent_id:
+        current_owner_member = await _find_room_member(db, room_id, room.owner_id)
+        if current_owner_member is not None:
+            outgoing_owner_member = current_owner_member
+
+    outgoing_owner_member.role = RoomRole.member
     new_owner_member.role = RoomRole.owner
     room.owner_id = new_owner_id
     room.owner_type = new_owner_type
@@ -1684,8 +1709,12 @@ async def promote_member_as_human(
 ):
     """Promote/demote a member. Human owner only. Matches hub's `promote`."""
     user = await _load_human(db, ctx)
-    _, caller = await _load_room_member_as_caller(db, room_id, user.human_id, lock=True)
-    if caller.role != RoomRole.owner:
+    room, caller = await _load_room_member_as_caller(db, room_id, user.human_id, lock=True)
+    owned_agent_ids = await _load_owned_agent_ids(db, ctx.user_id)
+    effective_role = await _effective_human_role(
+        db, caller.role, room, ctx.user_id, owned_agent_ids
+    )
+    if effective_role != RoomRole.owner:
         raise HTTPException(status_code=403, detail="Only the room owner can promote or demote")
 
     target_type = _split_prefix(body.participant_id)
@@ -1721,8 +1750,12 @@ async def remove_member_as_human(
     """Remove a member. Human owner/admin only. Mirrors hub's remove_member,
     but accepts both ``ag_*`` and ``hu_*`` targets."""
     user = await _load_human(db, ctx)
-    _, caller = await _load_room_member_as_caller(db, room_id, user.human_id, lock=True)
-    if caller.role not in (RoomRole.owner, RoomRole.admin):
+    room, caller = await _load_room_member_as_caller(db, room_id, user.human_id, lock=True)
+    owned_agent_ids = await _load_owned_agent_ids(db, ctx.user_id)
+    effective_role = await _effective_human_role(
+        db, caller.role, room, ctx.user_id, owned_agent_ids
+    )
+    if effective_role not in (RoomRole.owner, RoomRole.admin):
         raise HTTPException(status_code=403, detail="Owner or admin required")
 
     target_type = _split_prefix(participant_id)
@@ -1731,7 +1764,7 @@ async def remove_member_as_human(
         raise HTTPException(status_code=404, detail="Member not found in room")
     if target.role == RoomRole.owner:
         raise HTTPException(status_code=400, detail="Cannot remove the room owner")
-    if target.role == RoomRole.admin and caller.role != RoomRole.owner:
+    if target.role == RoomRole.admin and effective_role != RoomRole.owner:
         raise HTTPException(status_code=403, detail="Only the owner can remove admins")
 
     removed_id = target.agent_id
@@ -1791,8 +1824,12 @@ async def set_member_permissions_as_human(
 ):
     """Set per-member permission overrides. Human owner/admin only."""
     user = await _load_human(db, ctx)
-    _, caller = await _load_room_member_as_caller(db, room_id, user.human_id, lock=True)
-    if caller.role not in (RoomRole.owner, RoomRole.admin):
+    room, caller = await _load_room_member_as_caller(db, room_id, user.human_id, lock=True)
+    owned_agent_ids = await _load_owned_agent_ids(db, ctx.user_id)
+    effective_role = await _effective_human_role(
+        db, caller.role, room, ctx.user_id, owned_agent_ids
+    )
+    if effective_role not in (RoomRole.owner, RoomRole.admin):
         raise HTTPException(status_code=403, detail="Owner or admin required")
 
     target_type = _split_prefix(body.participant_id)
@@ -1801,7 +1838,7 @@ async def set_member_permissions_as_human(
         raise HTTPException(status_code=404, detail="Member not found in room")
     if target.role == RoomRole.owner:
         raise HTTPException(status_code=400, detail="Cannot modify the owner's permissions")
-    if target.role == RoomRole.admin and caller.role != RoomRole.owner:
+    if target.role == RoomRole.admin and effective_role != RoomRole.owner:
         raise HTTPException(status_code=403, detail="Only the owner can modify admin permissions")
 
     target.can_send = body.can_send

--- a/backend/tests/test_app/test_app_humans.py
+++ b/backend/tests/test_app/test_app_humans.py
@@ -285,6 +285,89 @@ async def test_human_member_of_room_owned_by_their_agent_sees_owner_role(
 
 
 @pytest.mark.asyncio
+async def test_human_effective_role_uses_highest_owned_bot_role(
+    client, seed, db_session: AsyncSession
+):
+    now = datetime.datetime.now(datetime.timezone.utc)
+    admin_bot = Agent(
+        agent_id="ag_aliceadmin",
+        display_name="Alice Admin Bot",
+        message_policy=MessagePolicy.open,
+        user_id=seed["user_id"],
+        claimed_at=now,
+    )
+    member_bot = Agent(
+        agent_id="ag_alicemem01",
+        display_name="Alice Member Bot",
+        message_policy=MessagePolicy.open,
+        user_id=seed["user_id"],
+        claimed_at=now,
+    )
+    room = Room(
+        room_id="rm_role_merge",
+        name="Role Merge",
+        description="",
+        owner_id="ag_external01",
+        owner_type=ParticipantType.agent,
+        visibility=RoomVisibility.private,
+        join_policy=RoomJoinPolicy.invite_only,
+        default_invite=False,
+    )
+    db_session.add_all([
+        Agent(
+            agent_id="ag_external01",
+            display_name="External",
+            message_policy=MessagePolicy.open,
+        ),
+        admin_bot,
+        member_bot,
+        room,
+    ])
+    await db_session.flush()
+    db_session.add_all([
+        RoomMember(
+            room_id="rm_role_merge",
+            agent_id="ag_external01",
+            participant_type=ParticipantType.agent,
+            role=RoomRole.owner,
+        ),
+        RoomMember(
+            room_id="rm_role_merge",
+            agent_id="ag_aliceadmin",
+            participant_type=ParticipantType.agent,
+            role=RoomRole.admin,
+        ),
+        RoomMember(
+            room_id="rm_role_merge",
+            agent_id="ag_alicemem01",
+            participant_type=ParticipantType.agent,
+            role=RoomRole.member,
+        ),
+        RoomMember(
+            room_id="rm_role_merge",
+            agent_id=seed["human_id"],
+            participant_type=ParticipantType.human,
+            role=RoomRole.member,
+        ),
+    ])
+    await db_session.commit()
+
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    listing = await client.get("/api/humans/me/rooms", headers=headers)
+    assert listing.status_code == 200
+    listed = {r["room_id"]: r for r in listing.json()["rooms"]}
+    assert listed["rm_role_merge"]["my_role"] == "admin"
+
+    patch = await client.patch(
+        "/api/humans/me/rooms/rm_role_merge",
+        headers=headers,
+        json={"description": "updated as inherited admin"},
+    )
+    assert patch.status_code == 200, patch.text
+    assert patch.json()["my_role"] == "admin"
+
+
+@pytest.mark.asyncio
 async def test_list_owned_agent_rooms_excludes_current_human_rooms(
     client, seed, db_session: AsyncSession
 ):

--- a/backend/tests/test_dashboard_rooms_human_send.py
+++ b/backend/tests/test_dashboard_rooms_human_send.py
@@ -188,6 +188,98 @@ async def test_missing_active_agent_without_human_membership(client: AsyncClient
 
 
 @pytest.mark.asyncio
+async def test_human_send_inherits_highest_owned_bot_role(
+    client: AsyncClient, seed: dict, db_session: AsyncSession
+):
+    user = (
+        await db_session.execute(select(User).where(User.id == uuid.UUID(seed["uid1"])))
+    ).scalar_one()
+    room = Room(
+        room_id="rm_human_inherit",
+        name="Inherited",
+        description="",
+        owner_id=seed["agent3"],
+        visibility=RoomVisibility.public,
+        join_policy=RoomJoinPolicy.open,
+        default_send=False,
+    )
+    db_session.add(room)
+    await db_session.flush()
+    db_session.add_all([
+        RoomMember(room_id=room.room_id, agent_id=seed["agent3"], role=RoomRole.owner),
+        RoomMember(
+            room_id=room.room_id,
+            agent_id=seed["agent1"],
+            participant_type=ParticipantType.agent,
+            role=RoomRole.admin,
+        ),
+        RoomMember(
+            room_id=room.room_id,
+            agent_id=user.human_id,
+            participant_type=ParticipantType.human,
+            role=RoomRole.member,
+            can_send=False,
+        ),
+    ])
+    await db_session.commit()
+
+    r = await client.post(
+        "/api/dashboard/rooms/rm_human_inherit/send",
+        headers={"Authorization": f"Bearer {seed['token1']}"},
+        json={"text": "inherited admin can send"},
+    )
+    assert r.status_code == 202, r.text
+
+
+@pytest.mark.asyncio
+async def test_active_agent_send_inherits_sibling_owned_bot_role(
+    client: AsyncClient, seed: dict, db_session: AsyncSession
+):
+    sibling = Agent(
+        agent_id="ag_user1adm",
+        display_name="Alice Admin Sibling",
+        message_policy=MessagePolicy.open,
+        user_id=uuid.UUID(seed["uid1"]),
+        claimed_at=datetime.datetime.now(datetime.timezone.utc),
+    )
+    room = Room(
+        room_id="rm_sibling_role",
+        name="Sibling Role",
+        description="",
+        owner_id=seed["agent3"],
+        visibility=RoomVisibility.public,
+        join_policy=RoomJoinPolicy.open,
+        default_send=False,
+    )
+    db_session.add_all([sibling, room])
+    await db_session.flush()
+    db_session.add_all([
+        RoomMember(room_id=room.room_id, agent_id=seed["agent3"], role=RoomRole.owner),
+        RoomMember(
+            room_id=room.room_id,
+            agent_id=seed["agent1"],
+            participant_type=ParticipantType.agent,
+            role=RoomRole.member,
+            can_send=False,
+        ),
+        RoomMember(
+            room_id=room.room_id,
+            agent_id="ag_user1adm",
+            participant_type=ParticipantType.agent,
+            role=RoomRole.admin,
+        ),
+    ])
+    await db_session.commit()
+
+    r = await client.post(
+        "/api/dashboard/rooms/rm_sibling_role/send",
+        headers=_h(seed["token1"], seed["agent1"]),
+        json={"text": "sibling admin can send"},
+    )
+    assert r.status_code == 202, r.text
+
+
+@pytest.mark.asyncio
 async def test_active_agent_not_owned(client: AsyncClient, seed: dict):
     # token1 is Alice; ag_user2___ belongs to Bob
     r = await client.post(


### PR DESCRIPTION
## Summary
- add shared effective room-role resolution for human owners across their owned bots
- apply inherited highest role to human room management, dashboard join-request moderation, and dashboard room sends
- cover admin-over-member precedence for human and active-agent dashboard flows

## Tests
- cd backend && uv run pytest tests/test_app/test_app_humans.py tests/test_dashboard_rooms_human_send.py
- cd backend && uv run python -m py_compile app/auth_room.py app/routers/humans.py app/routers/dashboard.py