### PR TITLE
fix: respect owner bot room overrides

### DIFF
--- a/backend/app/auth_room.py
+++ b/backend/app/auth_room.py
@@ -16,7 +16,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import RequestContext
-from hub.enums import ParticipantType, RoomRole
+from hub.enums import ParticipantType, RoomJoinPolicy, RoomRole, RoomVisibility
 from hub.models import Agent, Room, RoomMember
 
 
@@ -93,6 +93,108 @@ async def effective_human_room_role(
         candidates.extend(row[0] for row in result.all())
 
     return strongest_room_role(candidates)
+
+
+def room_member_can_send(room: Room, member: RoomMember) -> bool:
+    """Match hub room-send permission semantics for one member row."""
+    if member.role == RoomRole.owner:
+        return True
+    if member.can_send is not None:
+        return member.can_send
+    if member.role == RoomRole.admin:
+        return True
+    return room.default_send
+
+
+def room_member_can_invite(room: Room, member: RoomMember) -> bool:
+    """Match hub room-invite permission semantics for one member row."""
+    if member.role == RoomRole.owner:
+        return True
+    if room.visibility == RoomVisibility.public and room.join_policy == RoomJoinPolicy.open:
+        return True
+    if member.can_invite is not None:
+        return member.can_invite
+    if member.role == RoomRole.admin:
+        return True
+    return room.default_invite
+
+
+async def load_owned_agent_room_members(
+    db: AsyncSession,
+    *,
+    room: Room,
+    user_id,
+    owned_agent_ids: set[str] | None = None,
+) -> list[RoomMember]:
+    """Load room memberships for all bots owned by the user."""
+    owned_ids = owned_agent_ids
+    if owned_ids is None:
+        owned_ids = await load_owned_agent_ids(db, user_id)
+    if not owned_ids:
+        return []
+    result = await db.execute(
+        select(RoomMember).where(
+            RoomMember.room_id == room.room_id,
+            RoomMember.participant_type == ParticipantType.agent,
+            RoomMember.agent_id.in_(owned_ids),
+        )
+    )
+    return list(result.scalars().all())
+
+
+async def effective_human_can_send(
+    db: AsyncSession,
+    *,
+    room: Room,
+    member: RoomMember,
+    user_id,
+    owned_agent_ids: set[str] | None = None,
+) -> bool:
+    """Return whether the user can send through any owned room identity."""
+    if room_member_can_send(room, member):
+        return True
+    owned_members = await load_owned_agent_room_members(
+        db, room=room, user_id=user_id, owned_agent_ids=owned_agent_ids
+    )
+    return any(room_member_can_send(room, owned_member) for owned_member in owned_members)
+
+
+async def effective_human_send_member(
+    db: AsyncSession,
+    *,
+    room: Room,
+    member: RoomMember,
+    user_id,
+    owned_agent_ids: set[str] | None = None,
+) -> RoomMember | None:
+    """Return the strongest owned member row that grants send permission."""
+    candidates = [member]
+    candidates.extend(
+        await load_owned_agent_room_members(
+            db, room=room, user_id=user_id, owned_agent_ids=owned_agent_ids
+        )
+    )
+    allowed = [candidate for candidate in candidates if room_member_can_send(room, candidate)]
+    if not allowed:
+        return None
+    return max(allowed, key=lambda candidate: _ROLE_RANK[_coerce_room_role(candidate.role) or RoomRole.member])
+
+
+async def effective_human_can_invite(
+    db: AsyncSession,
+    *,
+    room: Room,
+    member: RoomMember,
+    user_id,
+    owned_agent_ids: set[str] | None = None,
+) -> bool:
+    """Return whether the user can invite through any owned room identity."""
+    if room_member_can_invite(room, member):
+        return True
+    owned_members = await load_owned_agent_room_members(
+        db, room=room, user_id=user_id, owned_agent_ids=owned_agent_ids
+    )
+    return any(room_member_can_invite(room, owned_member) for owned_member in owned_members)
 
 
 async def viewer_can_admin_room(

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -16,7 +16,12 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import RequestContext, require_active_agent, require_user, require_user_with_optional_agent
-from app.auth_room import effective_human_room_role, resolve_provider_agent_for_room, viewer_can_admin_room
+from app.auth_room import (
+    effective_human_room_role,
+    effective_human_send_member,
+    resolve_provider_agent_for_room,
+    viewer_can_admin_room,
+)
 from app.helpers import escape_like, extract_text_from_envelope
 from hub.database import get_db
 from hub.dashboard_message_shaping import (
@@ -2638,18 +2643,22 @@ async def human_room_send(
     if not room.allow_human_send:
         raise HTTPException(status_code=403, detail="Human send disabled for this room")
 
-    effective_role = await _effective_dashboard_member_role(
-        db, ctx=ctx, room=room, member=active_member
+    effective_member = await effective_human_send_member(
+        db,
+        room=room,
+        member=active_member,
+        user_id=ctx.user_id,
     )
-    effective_member = active_member
-    if effective_role != active_member.role:
+    if effective_member is None:
+        raise HTTPException(status_code=403, detail="Sender cannot send in this room")
+    if effective_member.agent_id != active_member.agent_id:
         effective_member = RoomMember(
             room_id=active_member.room_id,
             agent_id=active_member.agent_id,
             participant_type=active_member.participant_type,
-            role=effective_role,
-            can_send=None,
-            can_invite=None,
+            role=effective_member.role,
+            can_send=effective_member.can_send,
+            can_invite=effective_member.can_invite,
         )
 
     # _can_send (step 6)

--- a/backend/app/routers/humans.py
+++ b/backend/app/routers/humans.py
@@ -24,7 +24,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import RequestContext, require_user
-from app.auth_room import effective_human_room_role, load_owned_agent_ids
+from app.auth_room import effective_human_can_invite, effective_human_room_role, load_owned_agent_ids
 from app.routers.dashboard import _build_rooms_from_sql
 from hub.database import get_db
 from hub.enums import (
@@ -1138,12 +1138,14 @@ async def create_room_invite_as_human(
     if inviter is None:
         raise HTTPException(status_code=403, detail="Not a member of this room")
     owned_agent_ids = await _load_owned_agent_ids(db, ctx.user_id)
-    effective_role = await _effective_human_role(
-        db, inviter.role, room, ctx.user_id, owned_agent_ids
+    can_invite = await effective_human_can_invite(
+        db,
+        room=room,
+        member=inviter,
+        user_id=ctx.user_id,
+        owned_agent_ids=owned_agent_ids,
     )
-    if effective_role not in (RoomRole.owner, RoomRole.admin) and not bool(
-        inviter.can_invite or room.default_invite
-    ):
+    if not can_invite:
         raise HTTPException(
             status_code=403,
             detail="You do not have invite permission",
@@ -1219,13 +1221,12 @@ async def invite_room_member_as_human(
     if inviter is None:
         raise HTTPException(status_code=403, detail="Not a member of this room")
     owned_agent_ids = await _load_owned_agent_ids(db, ctx.user_id)
-    effective_role = await _effective_human_role(
-        db, inviter.role, room, ctx.user_id, owned_agent_ids
-    )
-    can_invite = (
-        effective_role in (RoomRole.owner, RoomRole.admin)
-        or inviter.can_invite
-        or room.default_invite
+    can_invite = await effective_human_can_invite(
+        db,
+        room=room,
+        member=inviter,
+        user_id=ctx.user_id,
+        owned_agent_ids=owned_agent_ids,
     )
     if not can_invite:
         raise HTTPException(status_code=403, detail="You don't have permission to invite members")

--- a/backend/tests/test_app/test_app_humans.py
+++ b/backend/tests/test_app/test_app_humans.py
@@ -368,6 +368,135 @@ async def test_human_effective_role_uses_highest_owned_bot_role(
 
 
 @pytest.mark.asyncio
+async def test_human_invite_uses_owned_bot_invite_override(
+    client, seed, db_session: AsyncSession
+):
+    owned_bot = Agent(
+        agent_id="ag_inviteok01",
+        display_name="Invite Bot",
+        message_policy=MessagePolicy.open,
+        user_id=seed["user_id"],
+    )
+    target = Agent(
+        agent_id="ag_invitetgt1",
+        display_name="Invite Target",
+        message_policy=MessagePolicy.open,
+    )
+    owner = Agent(
+        agent_id="ag_invowner1",
+        display_name="Room Owner",
+        message_policy=MessagePolicy.open,
+    )
+    room = Room(
+        room_id="rm_invite_override",
+        name="Invite Override",
+        description="",
+        owner_id=owner.agent_id,
+        owner_type=ParticipantType.agent,
+        visibility=RoomVisibility.private,
+        join_policy=RoomJoinPolicy.invite_only,
+        default_invite=False,
+    )
+    db_session.add_all([owned_bot, target, owner, room])
+    await db_session.flush()
+    db_session.add_all([
+        RoomMember(
+            room_id=room.room_id,
+            agent_id=owner.agent_id,
+            participant_type=ParticipantType.agent,
+            role=RoomRole.owner,
+        ),
+        RoomMember(
+            room_id=room.room_id,
+            agent_id=owned_bot.agent_id,
+            participant_type=ParticipantType.agent,
+            role=RoomRole.member,
+            can_invite=True,
+        ),
+        RoomMember(
+            room_id=room.room_id,
+            agent_id=seed["human_id"],
+            participant_type=ParticipantType.human,
+            role=RoomRole.member,
+            can_invite=False,
+        ),
+    ])
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/humans/me/rooms/rm_invite_override/members",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+        json={"participant_id": target.agent_id},
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["participant_id"] == target.agent_id
+
+
+@pytest.mark.asyncio
+async def test_human_invite_respects_owned_bot_explicit_invite_deny(
+    client, seed, db_session: AsyncSession
+):
+    owned_bot = Agent(
+        agent_id="ag_invdeny01",
+        display_name="Invite Denied Bot",
+        message_policy=MessagePolicy.open,
+        user_id=seed["user_id"],
+    )
+    target = Agent(
+        agent_id="ag_invdenyt1",
+        display_name="Invite Denied Target",
+        message_policy=MessagePolicy.open,
+    )
+    owner = Agent(
+        agent_id="ag_invowner2",
+        display_name="Room Owner",
+        message_policy=MessagePolicy.open,
+    )
+    room = Room(
+        room_id="rm_invite_deny",
+        name="Invite Deny",
+        description="",
+        owner_id=owner.agent_id,
+        owner_type=ParticipantType.agent,
+        visibility=RoomVisibility.private,
+        join_policy=RoomJoinPolicy.invite_only,
+        default_invite=False,
+    )
+    db_session.add_all([owned_bot, target, owner, room])
+    await db_session.flush()
+    db_session.add_all([
+        RoomMember(
+            room_id=room.room_id,
+            agent_id=owner.agent_id,
+            participant_type=ParticipantType.agent,
+            role=RoomRole.owner,
+        ),
+        RoomMember(
+            room_id=room.room_id,
+            agent_id=owned_bot.agent_id,
+            participant_type=ParticipantType.agent,
+            role=RoomRole.admin,
+            can_invite=False,
+        ),
+        RoomMember(
+            room_id=room.room_id,
+            agent_id=seed["human_id"],
+            participant_type=ParticipantType.human,
+            role=RoomRole.member,
+            can_invite=False,
+        ),
+    ])
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/humans/me/rooms/rm_invite_deny/members",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+        json={"participant_id": target.agent_id},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
 async def test_list_owned_agent_rooms_excludes_current_human_rooms(
     client, seed, db_session: AsyncSession
 ):

--- a/backend/tests/test_dashboard_rooms_human_send.py
+++ b/backend/tests/test_dashboard_rooms_human_send.py
@@ -280,6 +280,51 @@ async def test_active_agent_send_inherits_sibling_owned_bot_role(
 
 
 @pytest.mark.asyncio
+async def test_human_send_respects_owned_bot_explicit_send_deny(
+    client: AsyncClient, seed: dict, db_session: AsyncSession
+):
+    user = (
+        await db_session.execute(select(User).where(User.id == uuid.UUID(seed["uid1"])))
+    ).scalar_one()
+    room = Room(
+        room_id="rm_admin_send_deny",
+        name="Admin Deny",
+        description="",
+        owner_id=seed["agent3"],
+        visibility=RoomVisibility.public,
+        join_policy=RoomJoinPolicy.open,
+        default_send=False,
+    )
+    db_session.add(room)
+    await db_session.flush()
+    db_session.add_all([
+        RoomMember(room_id=room.room_id, agent_id=seed["agent3"], role=RoomRole.owner),
+        RoomMember(
+            room_id=room.room_id,
+            agent_id=seed["agent1"],
+            participant_type=ParticipantType.agent,
+            role=RoomRole.admin,
+            can_send=False,
+        ),
+        RoomMember(
+            room_id=room.room_id,
+            agent_id=user.human_id,
+            participant_type=ParticipantType.human,
+            role=RoomRole.member,
+            can_send=False,
+        ),
+    ])
+    await db_session.commit()
+
+    r = await client.post(
+        "/api/dashboard/rooms/rm_admin_send_deny/send",
+        headers={"Authorization": f"Bearer {seed['token1']}"},
+        json={"text": "denied"},
+    )
+    assert r.status_code == 403
+
+
+@pytest.mark.asyncio
 async def test_active_agent_not_owned(client: AsyncClient, seed: dict):
     # token1 is Alice; ag_user2___ belongs to Bob
     r = await client.post(


### PR DESCRIPTION
## Summary
- aggregate effective send/invite capabilities across human and owned bot room memberships
- preserve per-member can_send/can_invite overrides when inheriting owner bot permissions
- add regressions for inherited invite allow and explicit send/invite deny overrides

## Tests
- cd backend && uv run python -m py_compile app/auth_room.py app/routers/humans.py app/routers/dashboard.py
- cd backend && uv run pytest tests/test_app/test_app_humans.py tests/test_dashboard_rooms_human_send.py