### PR TITLE
chore: raise default agent quota

### DIFF
--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -1084,7 +1084,7 @@ class User(Base):
         index=True,
         default=generate_human_id,
     )
-    max_agents: Mapped[int] = mapped_column(Integer, nullable=False, default=10)
+    max_agents: Mapped[int] = mapped_column(Integer, nullable=False, default=30)
     banned_at: Mapped[datetime.datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     ban_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime.datetime] = mapped_column(

--- a/backend/tests/test_app/test_app_users.py
+++ b/backend/tests/test_app/test_app_users.py
@@ -84,7 +84,7 @@ async def seed_user(db_session: AsyncSession):
         avatar_url="https://example.com/avatar.png",
         status="active",
         supabase_user_id=supabase_uuid,
-        max_agents=10,
+        max_agents=30,
     )
     db_session.add(user)
 
@@ -142,7 +142,7 @@ async def test_get_me(client: AsyncClient, seed_user: dict):
     assert len(data["agents"]) == 1
     assert data["agents"][0]["agent_id"] == "ag_testuser001"
     assert data["agents"][0]["is_default"] is True
-    assert data["max_agents"] == 10
+    assert data["max_agents"] == 30
 
 
 @pytest.mark.asyncio

--- a/frontend/db/schema/users.ts
+++ b/frontend/db/schema/users.ts
@@ -7,7 +7,7 @@ export const users = pgTable("users", {
   avatarUrl: text("avatar_url"),
   status: varchar("status", { length: 20 }).default("active").notNull(),
   supabaseUserId: uuid("supabase_user_id").notNull().unique(),
-  maxAgents: integer("max_agents").default(10).notNull(),
+  maxAgents: integer("max_agents").default(30).notNull(),
   bannedAt: timestamp("banned_at", { withTimezone: true }),
   banReason: text("ban_reason"),
   createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),

--- a/frontend/drizzle/0006_set_user_max_agents_30.sql
+++ b/frontend/drizzle/0006_set_user_max_agents_30.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "users"
+  ALTER COLUMN "max_agents" SET DEFAULT 30;
+--> statement-breakpoint
+UPDATE "users"
+SET "max_agents" = 30;

--- a/frontend/drizzle/meta/_journal.json
+++ b/frontend/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1774003202000,
       "tag": "0005_add_agent_avatar_url",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1774003203000,
+      "tag": "0006_set_user_max_agents_30",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- raise the default per-user agent quota from 10 to 30
- add a Drizzle migration that sets the users.max_agents default to 30 and updates all existing users to 30
- update the users API test fixture/assertion

## Tests
- cd backend && uv run pytest tests/test_app/test_app_users.py -q