### PR TITLE
chore: add websocket sentry logging

### DIFF
--- a/backend/hub/config.py
+++ b/backend/hub/config.py
@@ -175,6 +175,29 @@ ENVIRONMENT_TAG: str = os.getenv("ENVIRONMENT_TAG", "prod")
 # ---------------------------------------------------------------------------
 SENTRY_DSN: str | None = os.getenv("SENTRY_DSN")
 SENTRY_TRACES_SAMPLE_RATE: float = float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "1.0"))
+SENTRY_RELEASE: str | None = os.getenv("SENTRY_RELEASE")
+
+
+def _parse_log_level_env(name: str, default: str) -> int | None:
+    raw = os.getenv(name, default).strip()
+    if raw.lower() in {"", "none", "off"}:
+        return None
+    if raw.isdigit():
+        return int(raw)
+    level = getattr(logging, raw.upper(), None)
+    if isinstance(level, int):
+        return level
+    _logger.warning("Invalid %s=%r; falling back to %s", name, raw, default)
+    return getattr(logging, default)
+
+
+SENTRY_LOG_BREADCRUMB_LEVEL: int | None = _parse_log_level_env(
+    "SENTRY_LOG_BREADCRUMB_LEVEL", "INFO"
+)
+SENTRY_LOG_EVENT_LEVEL: int | None = _parse_log_level_env(
+    "SENTRY_LOG_EVENT_LEVEL", "ERROR"
+)
+SENTRY_LOGS_LEVEL: int | None = _parse_log_level_env("SENTRY_LOGS_LEVEL", "INFO")
 
 # ---------------------------------------------------------------------------
 # Daemon control plane

--- a/backend/hub/main.py
+++ b/backend/hub/main.py
@@ -9,6 +9,7 @@ from fastapi import Depends, FastAPI, Request
 from fastapi.exceptions import HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
+from sentry_sdk.integrations.logging import LoggingIntegration
 
 from hub.i18n import I18nHTTPException, detect_locale, get_hint, get_message
 
@@ -149,8 +150,16 @@ if hub_config.SENTRY_DSN:
     sentry_sdk.init(
         dsn=hub_config.SENTRY_DSN,
         environment=hub_config.ENVIRONMENT_TAG,
+        release=hub_config.SENTRY_RELEASE,
         traces_sample_rate=hub_config.SENTRY_TRACES_SAMPLE_RATE,
         send_default_pii=True,
+        integrations=[
+            LoggingIntegration(
+                level=hub_config.SENTRY_LOG_BREADCRUMB_LEVEL,
+                event_level=hub_config.SENTRY_LOG_EVENT_LEVEL,
+                sentry_logs_level=hub_config.SENTRY_LOGS_LEVEL,
+            )
+        ],
     )
 
 app = FastAPI(title="BotCord Hub", version="1.0.1", lifespan=lifespan)

--- a/backend/hub/routers/hub.py
+++ b/backend/hub/routers/hub.py
@@ -11,6 +11,7 @@ import uuid
 from typing import Any
 from collections import defaultdict, deque
 
+import sentry_sdk
 from cachetools import TTLCache
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, WebSocket, WebSocketDisconnect
@@ -105,6 +106,17 @@ _inbox_conditions: dict[str, asyncio.Condition] = {}
 # In-memory WebSocket connections: agent_id → set of WebSocket
 # ---------------------------------------------------------------------------
 _ws_connections: dict[str, set[WebSocket]] = {}
+
+
+def _ws_connection_counts(agent_id: str | None = None) -> dict[str, int]:
+    total_connections = sum(len(ws_set) for ws_set in _ws_connections.values())
+    counts = {
+        "total_connections": total_connections,
+        "total_agents": len(_ws_connections),
+    }
+    if agent_id is not None:
+        counts["agent_connections"] = len(_ws_connections.get(agent_id, set()))
+    return counts
 
 
 def is_agent_ws_online(agent_id: str) -> bool:
@@ -413,9 +425,22 @@ async def notify_inbox(
     notified = 0
     ws_set = _ws_connections.get(agent_id)
     if ws_set:
-        logger.info("notify_inbox: agent=%s ws_connections=%d", agent_id, len(ws_set))
+        counts = _ws_connection_counts(agent_id)
+        logger.info(
+            "notify_inbox: agent=%s ws_connections=%d total_ws_connections=%d total_ws_agents=%d",
+            agent_id,
+            len(ws_set),
+            counts["total_connections"],
+            counts["total_agents"],
+        )
     else:
-        logger.warning("notify_inbox: agent=%s no ws_connections", agent_id)
+        counts = _ws_connection_counts(agent_id)
+        logger.warning(
+            "notify_inbox: agent=%s no ws_connections total_ws_connections=%d total_ws_agents=%d",
+            agent_id,
+            counts["total_connections"],
+            counts["total_agents"],
+        )
     if ws_set:
         # Iterate a snapshot to avoid concurrent modification
         dead: list[WebSocket] = []
@@ -443,6 +468,16 @@ async def notify_inbox(
             ws_set.discard(ws)
         if not ws_set:
             _ws_connections.pop(agent_id, None)
+        if dead:
+            counts = _ws_connection_counts(agent_id)
+            logger.warning(
+                "notify_inbox: removed dead ws connections agent=%s dead_count=%d remaining_agent_ws=%d total_ws_connections=%d total_ws_agents=%d",
+                agent_id,
+                len(dead),
+                counts["agent_connections"],
+                counts["total_connections"],
+                counts["total_agents"],
+            )
 
     if db is not None and realtime_event is not None:
         await _publish_agent_realtime_event(db, realtime_event)
@@ -1890,7 +1925,7 @@ async def websocket_inbox(ws: WebSocket):
         try:
             agent_id = verify_agent_token(token)
         except Exception as exc:
-            logger.error("WebSocket auth failed: %s: %s", type(exc).__name__, exc)
+            logger.warning("WebSocket auth failed: %s: %s", type(exc).__name__, exc)
             await ws.close(code=4001, reason="Invalid token")
             return
 
@@ -1918,6 +1953,15 @@ async def websocket_inbox(ws: WebSocket):
         if agent_id not in _ws_connections:
             _ws_connections[agent_id] = set()
         _ws_connections[agent_id].add(ws)
+        counts = _ws_connection_counts(agent_id)
+        logger.info(
+            "WebSocket registered: agent=%s connection_id=%s agent_ws_connections=%d total_ws_connections=%d total_ws_agents=%d",
+            agent_id,
+            connection_id,
+            counts["agent_connections"],
+            counts["total_connections"],
+            counts["total_agents"],
+        )
 
         async def _presence_call(fn, *args, **kwargs):
             """Run a presence_service call in its own session and broadcast on change."""
@@ -1972,7 +2016,15 @@ async def websocket_inbox(ws: WebSocket):
     except WebSocketDisconnect:
         logger.info("WebSocket disconnected: agent=%s", agent_id)
     except Exception as e:
-        logger.error("WebSocket error: agent=%s err=%s", agent_id, e, exc_info=True)
+        with sentry_sdk.new_scope() as scope:
+            scope.set_tag("ws.endpoint", "hub_inbox")
+            if agent_id:
+                scope.set_tag("agent_id", agent_id)
+            scope.set_context(
+                "ws_connections",
+                _ws_connection_counts(agent_id),
+            )
+            logger.error("WebSocket error: agent=%s err=%s", agent_id, e, exc_info=True)
     finally:
         # --- Cleanup ---
         if agent_id:
@@ -1981,6 +2033,15 @@ async def websocket_inbox(ws: WebSocket):
                 ws_set.discard(ws)
                 if not ws_set:
                     _ws_connections.pop(agent_id, None)
+            counts = _ws_connection_counts(agent_id)
+            logger.info(
+                "WebSocket unregistered: agent=%s connection_id=%s remaining_agent_ws=%d total_ws_connections=%d total_ws_agents=%d",
+                agent_id,
+                connection_id,
+                counts["agent_connections"],
+                counts["total_connections"],
+                counts["total_agents"],
+            )
             if connection_id is not None:
                 try:
                     async with async_session() as pdb:

--- a/backend/hub/routers/openclaw_control.py
+++ b/backend/hub/routers/openclaw_control.py
@@ -33,6 +33,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import jwt as pyjwt
+import sentry_sdk
 from fastapi import (
     APIRouter,
     Depends,
@@ -166,6 +167,10 @@ class _HostRegistry:
             current = self._by_instance.get(conn.host_instance_id)
             if current is conn:
                 self._by_instance.pop(conn.host_instance_id, None)
+
+    async def active_count(self) -> int:
+        async with self._lock:
+            return len(self._by_instance)
 
     def get(self, host_instance_id: str) -> _HostConn | None:
         return self._by_instance.get(host_instance_id)
@@ -773,7 +778,21 @@ async def openclaw_control_ws(ws: WebSocket) -> None:
         pending_acks={},
     )
     previous = await _REGISTRY.register(conn)
+    active_count = await _REGISTRY.active_count()
+    logger.info(
+        "openclaw WS registered: instance=%s owner=%s active_openclaw_ws=%d displaced_existing=%s",
+        host_instance_id,
+        owner_user_id,
+        active_count,
+        previous is not None,
+    )
     if previous is not None:
+        logger.warning(
+            "openclaw WS displacing previous connection: instance=%s owner=%s active_openclaw_ws=%d",
+            host_instance_id,
+            owner_user_id,
+            active_count,
+        )
         try:
             await previous.ws.close(code=4001, reason="displaced by new connection")
         except Exception:
@@ -812,9 +831,34 @@ async def openclaw_control_ws(ws: WebSocket) -> None:
     except WebSocketDisconnect:
         logger.info("openclaw WS disconnect: instance=%s", host_instance_id)
     except Exception as exc:  # noqa: BLE001
-        logger.warning("openclaw WS error: instance=%s err=%s", host_instance_id, exc)
+        active_count = await _REGISTRY.active_count()
+        with sentry_sdk.new_scope() as scope:
+            scope.set_tag("ws.endpoint", "openclaw_control")
+            scope.set_tag("openclaw_host_instance_id", host_instance_id)
+            scope.set_context(
+                "ws_connections",
+                {
+                    "active_openclaw_ws": active_count,
+                    "owner_user_id": owner_user_id,
+                },
+            )
+            logger.error(
+                "openclaw WS error: instance=%s owner=%s active_openclaw_ws=%d err=%s",
+                host_instance_id,
+                owner_user_id,
+                active_count,
+                exc,
+                exc_info=True,
+            )
     finally:
         await _REGISTRY.unregister(conn)
+        active_count = await _REGISTRY.active_count()
+        logger.info(
+            "openclaw WS unregistered: instance=%s owner=%s active_openclaw_ws=%d",
+            host_instance_id,
+            owner_user_id,
+            active_count,
+        )
         for fut in conn.pending_acks.values():
             if not fut.done():
                 fut.set_exception(RuntimeError("host disconnected"))

--- a/backend/hub/routers/owner_chat_ws.py
+++ b/backend/hub/routers/owner_chat_ws.py
@@ -11,6 +11,7 @@ import uuid
 from collections import deque
 from typing import Sequence
 
+import sentry_sdk
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect
 from pydantic import BaseModel, Field
 from sqlalchemy import select
@@ -66,6 +67,17 @@ _oc_trace_block_count: dict[str, int] = {}
 # ---------------------------------------------------------------------------
 
 
+def _oc_ws_connection_counts(key: tuple[str, str] | None = None) -> dict[str, int]:
+    total_connections = sum(len(ws_set) for ws_set in _oc_ws_connections.values())
+    counts = {
+        "total_connections": total_connections,
+        "total_pairs": len(_oc_ws_connections),
+    }
+    if key is not None:
+        counts["pair_connections"] = len(_oc_ws_connections.get(key, set()))
+    return counts
+
+
 def _register_ws(user_id: str, agent_id: str, ws: WebSocket) -> None:
     key = (user_id, agent_id)
     if key not in _oc_ws_connections:
@@ -114,6 +126,17 @@ async def _send_to_oc_ws(
         ws_set.discard(ws)
     if not ws_set:
         _oc_ws_connections.pop(key, None)
+    if dead:
+        counts = _oc_ws_connection_counts(key)
+        logger.warning(
+            "Owner-chat WS removed dead connections: user=%s agent=%s dead_count=%d remaining_pair_ws=%d total_ws_connections=%d total_ws_pairs=%d",
+            user_id,
+            agent_id,
+            len(dead),
+            counts["pair_connections"],
+            counts["total_connections"],
+            counts["total_pairs"],
+        )
 
 
 def _cleanup_trace(trace_id: str) -> None:
@@ -267,7 +290,7 @@ async def owner_chat_ws(ws: WebSocket):
         try:
             supabase_uid = verify_supabase_token(token)
         except Exception as exc:
-            logger.error("Owner-chat WS auth failed: %s: %s", type(exc).__name__, exc)
+            logger.warning("Owner-chat WS auth failed: %s: %s", type(exc).__name__, exc)
             await ws.close(code=4001, reason="Invalid token")
             return
 
@@ -305,6 +328,15 @@ async def owner_chat_ws(ws: WebSocket):
 
         # --- Register connection ---
         _register_ws(user_id, agent_id, ws)
+        counts = _oc_ws_connection_counts((user_id, agent_id))
+        logger.info(
+            "Owner-chat WS registered: user=%s agent=%s pair_ws_connections=%d total_ws_connections=%d total_ws_pairs=%d",
+            user_id,
+            agent_id,
+            counts["pair_connections"],
+            counts["total_connections"],
+            counts["total_pairs"],
+        )
 
         # --- Main loop ---
         while True:
@@ -475,10 +507,39 @@ async def owner_chat_ws(ws: WebSocket):
     except WebSocketDisconnect:
         logger.info("Owner-chat WS disconnected: user=%s agent=%s", user_id, agent_id)
     except Exception as e:
-        logger.error("Owner-chat WS error: user=%s agent=%s err=%s", user_id, agent_id, e, exc_info=True)
+        with sentry_sdk.new_scope() as scope:
+            scope.set_tag("ws.endpoint", "owner_chat")
+            if user_id:
+                scope.set_tag("user_id", user_id)
+            if agent_id:
+                scope.set_tag("agent_id", agent_id)
+            scope.set_context(
+                "ws_connections",
+                (
+                    _oc_ws_connection_counts((user_id, agent_id))
+                    if user_id and agent_id
+                    else _oc_ws_connection_counts()
+                ),
+            )
+            logger.error(
+                "Owner-chat WS error: user=%s agent=%s err=%s",
+                user_id,
+                agent_id,
+                e,
+                exc_info=True,
+            )
     finally:
         if user_id and agent_id:
             _unregister_ws(user_id, agent_id, ws)
+            counts = _oc_ws_connection_counts((user_id, agent_id))
+            logger.info(
+                "Owner-chat WS unregistered: user=%s agent=%s remaining_pair_ws=%d total_ws_connections=%d total_ws_pairs=%d",
+                user_id,
+                agent_id,
+                counts["pair_connections"],
+                counts["total_connections"],
+                counts["total_pairs"],
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/components/dashboard/BotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/BotDetailDrawer.tsx
@@ -105,6 +105,7 @@ export default function BotDetailDrawer() {
     setSidebarTab,
     setFocusedRoomId,
     setOpenedRoomId,
+    setUserChatAgentId,
     setUserChatRoomId,
     setMessagesPane,
     setMessagesFilter,
@@ -119,6 +120,7 @@ export default function BotDetailDrawer() {
       setSidebarTab: s.setSidebarTab,
       setFocusedRoomId: s.setFocusedRoomId,
       setOpenedRoomId: s.setOpenedRoomId,
+      setUserChatAgentId: s.setUserChatAgentId,
       setUserChatRoomId: s.setUserChatRoomId,
       setMessagesPane: s.setMessagesPane,
       setMessagesFilter: s.setMessagesFilter,
@@ -201,6 +203,8 @@ export default function BotDetailDrawer() {
     setBotDetailAgentId(null);
     setSidebarTab("messages");
     setMessagesPane("user-chat");
+    setUserChatAgentId(agentId);
+    setUserChatRoomId(null);
     setFocusedRoomId(null);
     setOpenedRoomId(null);
     if (agentId !== activeAgentId) {


### PR DESCRIPTION
## Summary
- explicitly configure Sentry logging integration levels for backend logs
- add WebSocket connection count logging for hub inbox, owner chat, and OpenClaw control channels
- attach WS connection context/tags to Sentry events for unexpected WS exceptions
- downgrade expected WS auth failures from error to warning to avoid Sentry noise

## Tests
- cd backend && uv run pytest tests/test_websocket.py tests/test_typing.py tests/test_app/test_app_ws_online.py tests/test_app/test_daemon_control.py
- cd backend && uv run python -m py_compile hub/config.py hub/main.py hub/routers/hub.py hub/routers/owner_chat_ws.py hub/routers/openclaw_control.py