### PR TITLE
fix: post transfer notices to source room

### DIFF
--- a/backend/app/routers/wallet.py
+++ b/backend/app/routers/wallet.py
@@ -6,17 +6,23 @@ wallet to operate on. ``as=agent`` still requires the
 ``X-Active-Agent`` header; ``as=human`` uses ``ctx.human_id``.
 """
 
+import datetime
 import json
 import logging
+import time
+import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import RequestContext, require_user_with_optional_agent
 from hub import config as hub_config
 from hub.database import get_db
-from hub.models import WithdrawalRequest
+from hub.id_generators import generate_hub_msg_id
+from hub.models import MessageRecord, MessageState, RoomMember, WithdrawalRequest
+from hub.routers.hub import build_message_realtime_event, notify_inbox
 from hub.services import wallet as wallet_svc
 from hub.services import stripe_topup as stripe_svc
 from hub.wallet_schemas import (
@@ -39,6 +45,10 @@ from hub.wallet_schemas import (
 _logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/wallet", tags=["app-wallet"])
+
+
+class AppTransferRequest(TransferRequest):
+    room_id: str | None = Field(default=None, description="Room where the transfer notice should be posted")
 
 
 # ---------------------------------------------------------------------------
@@ -92,6 +102,116 @@ def _tx_response(tx) -> dict:
         "updated_at": tx.updated_at,
         "completed_at": tx.completed_at,
     }
+
+
+def _format_coin_amount(amount_minor: int | str) -> str:
+    try:
+        minor = int(amount_minor)
+    except (TypeError, ValueError):
+        minor = 0
+    return f"{minor / 100:.2f} COIN"
+
+
+async def _record_room_transfer_notice(
+    db: AsyncSession,
+    *,
+    room_id: str,
+    from_owner_id: str,
+    to_owner_id: str,
+    tx,
+) -> None:
+    members_result = await db.execute(
+        select(RoomMember).where(RoomMember.room_id == room_id)
+    )
+    members = list(members_result.scalars().all())
+    member_ids = {member.agent_id for member in members}
+    if from_owner_id not in member_ids:
+        raise HTTPException(status_code=403, detail="Sender is not a room member")
+    if to_owner_id not in member_ids:
+        raise HTTPException(status_code=400, detail="Recipient is not a room member")
+
+    amount = _format_coin_amount(tx.amount_minor)
+    payload = {
+        "text": "\n".join([
+            "[BotCord Transfer]",
+            "Status: completed",
+            f"Transaction: {tx.tx_id}",
+            f"Amount: {amount}",
+            f"Asset: {tx.asset_code}",
+            f"From: {from_owner_id}",
+            f"To: {to_owner_id}",
+            f"Created: {tx.created_at}",
+        ]),
+        "event": "wallet_transfer_notice",
+        "tx_id": tx.tx_id,
+        "amount_minor": str(tx.amount_minor),
+        "asset_code": tx.asset_code,
+        "from_agent_id": from_owner_id,
+        "to_agent_id": to_owner_id,
+    }
+    envelope_data = {
+        "v": "a2a/0.1",
+        "msg_id": str(uuid.uuid4()),
+        "ts": int(time.time()),
+        "from": from_owner_id,
+        "to": room_id,
+        "type": "message",
+        "reply_to": None,
+        "ttl_sec": 3600,
+        "payload": payload,
+        "payload_hash": "",
+        "sig": {"alg": "ed25519", "key_id": "wallet", "value": ""},
+    }
+    envelope_json = json.dumps(envelope_data)
+    now = datetime.datetime.now(datetime.timezone.utc)
+    receiver_ids = [member.agent_id for member in members if not member.muted]
+    first_hub_msg_id: str | None = None
+    receiver_hub_msg_ids: dict[str, str] = {}
+
+    for receiver_id in receiver_ids:
+        hub_msg_id = generate_hub_msg_id()
+        if first_hub_msg_id is None:
+            first_hub_msg_id = hub_msg_id
+        receiver_hub_msg_ids[receiver_id] = hub_msg_id
+        db.add(
+            MessageRecord(
+                hub_msg_id=hub_msg_id,
+                msg_id=envelope_data["msg_id"],
+                sender_id=from_owner_id,
+                receiver_id=receiver_id,
+                room_id=room_id,
+                state=MessageState.queued,
+                envelope_json=envelope_json,
+                ttl_sec=3600,
+                created_at=now,
+                source_type="wallet_transfer_notice",
+                source_session_kind="room_human",
+            )
+        )
+
+    await db.flush()
+
+    for receiver_id in receiver_ids:
+        try:
+            await notify_inbox(
+                receiver_id,
+                db=db,
+                realtime_event=build_message_realtime_event(
+                    type="message",
+                    agent_id=receiver_id,
+                    sender_id=from_owner_id,
+                    room_id=room_id,
+                    hub_msg_id=receiver_hub_msg_ids.get(receiver_id, first_hub_msg_id),
+                    created_at=now,
+                    payload=payload,
+                    source_type="wallet_transfer_notice",
+                ),
+            )
+        except Exception as exc:
+            _logger.error(
+                "Wallet transfer room notice notify failed receiver=%s room=%s err=%s",
+                receiver_id, room_id, exc, exc_info=True,
+            )
 
 
 def _topup_response(topup, tx) -> dict:
@@ -186,7 +306,7 @@ async def get_wallet_ledger(
 
 @router.post("/transfers", status_code=201)
 async def create_transfer(
-    body: TransferRequest,
+    body: AppTransferRequest,
     as_: str = Query(default="agent", alias="as"),
     ctx: RequestContext = Depends(require_user_with_optional_agent),
     db: AsyncSession = Depends(get_db),
@@ -197,6 +317,15 @@ async def create_transfer(
         raise HTTPException(status_code=400, detail="Invalid amount_minor")
 
     from_owner_id = _resolve_owner(ctx, as_)
+    if body.room_id:
+        members_result = await db.execute(
+            select(RoomMember.agent_id).where(RoomMember.room_id == body.room_id)
+        )
+        member_ids = {row[0] for row in members_result.all()}
+        if from_owner_id not in member_ids:
+            raise HTTPException(status_code=403, detail="Sender is not a room member")
+        if body.to_agent_id not in member_ids:
+            raise HTTPException(status_code=400, detail="Recipient is not a room member")
 
     try:
         tx = await wallet_svc.create_transfer(
@@ -210,6 +339,14 @@ async def create_transfer(
             metadata=body.metadata,
             idempotency_key=body.idempotency_key,
         )
+        if body.room_id:
+            await _record_room_transfer_notice(
+                db,
+                room_id=body.room_id,
+                from_owner_id=from_owner_id,
+                to_owner_id=body.to_agent_id,
+                tx=tx,
+            )
         await db.commit()
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))

--- a/backend/tests/test_app/test_app_wallet_human.py
+++ b/backend/tests/test_app/test_app_wallet_human.py
@@ -13,14 +13,20 @@ import jwt
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from unittest.mock import AsyncMock
 
 from hub.models import (
     Agent,
     Base,
+    MessageRecord,
     MessagePolicy,
+    ParticipantType,
     Role,
+    Room,
+    RoomMember,
+    RoomRole,
     User,
     UserRole,
     WalletAccount,
@@ -238,6 +244,66 @@ async def test_human_to_agent_transfer(client, seed):
         headers={"Authorization": f"Bearer {seed['token']}"},
     )
     assert resp.json()["available_balance_minor"] == "1500"
+
+
+@pytest.mark.asyncio
+async def test_room_transfer_records_notice_message(client, db_session, seed):
+    """A room-scoped wallet transfer posts a transfer record into that room."""
+    room_id = "rm_wallet_notice"
+    db_session.add(Room(
+        room_id=room_id,
+        name="Wallet Notice Room",
+        owner_id=seed["human_id"],
+        owner_type=ParticipantType.human,
+    ))
+    db_session.add_all([
+        RoomMember(
+            room_id=room_id,
+            agent_id=seed["human_id"],
+            participant_type=ParticipantType.human,
+            role=RoomRole.owner,
+        ),
+        RoomMember(
+            room_id=room_id,
+            agent_id=seed["agent_id"],
+            participant_type=ParticipantType.agent,
+            role=RoomRole.member,
+        ),
+    ])
+    await db_session.commit()
+
+    await client.post(
+        "/api/wallet/transfers?as=agent",
+        headers={
+            "Authorization": f"Bearer {seed['token']}",
+            "X-Active-Agent": seed["agent_id"],
+        },
+        json={"to_agent_id": seed["human_id"], "amount_minor": "2000"},
+    )
+
+    resp = await client.post(
+        "/api/wallet/transfers?as=human",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+        json={
+            "to_agent_id": seed["agent_id"],
+            "amount_minor": "500",
+            "room_id": room_id,
+        },
+    )
+
+    assert resp.status_code == 201, resp.text
+    tx = resp.json()
+    records = list((await db_session.execute(
+        select(MessageRecord).where(
+            MessageRecord.room_id == room_id,
+            MessageRecord.source_type == "wallet_transfer_notice",
+        )
+    )).scalars().all())
+    assert len(records) == 2
+    assert {record.receiver_id for record in records} == {seed["human_id"], seed["agent_id"]}
+    assert records[0].envelope_json
+    assert "[BotCord Transfer]" in records[0].envelope_json
+    assert tx["tx_id"] in records[0].envelope_json
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/dashboard/RoomHumanComposer.tsx
+++ b/frontend/src/components/dashboard/RoomHumanComposer.tsx
@@ -22,13 +22,14 @@ const ROOM_MENTION_SOURCES = ["roomMembers"] as const;
 const PREFILL_ROOM_COMPOSER_EVENT = "botcord:prefill-room-composer";
 
 interface RoomTransferDialogProps {
+  roomId: string;
   members: PublicRoomMember[];
   senderIdentity: ActiveIdentity | null;
   onClose: () => void;
   onSuccess: () => void;
 }
 
-function RoomTransferDialog({ members, senderIdentity, onClose, onSuccess }: RoomTransferDialogProps) {
+function RoomTransferDialog({ roomId, members, senderIdentity, onClose, onSuccess }: RoomTransferDialogProps) {
   const locale = useLanguage();
   const t = transferDialog[locale];
   const senderId = senderIdentity?.id ?? "";
@@ -86,6 +87,7 @@ function RoomTransferDialog({ members, senderIdentity, onClose, onSuccess }: Roo
         to_agent_id: recipientId,
         amount_minor: String(amountCoin * 100),
         memo: memo.trim() || undefined,
+        room_id: roomId,
         idempotency_key: crypto.randomUUID(),
       }, senderIdentity);
       onSuccess();
@@ -414,6 +416,7 @@ export default function RoomHumanComposer({ roomId, topicId = null }: RoomHumanC
       {error && <p className="text-[11px] text-red-400">{error}</p>}
       {transferOpen ? (
         <RoomTransferDialog
+          roomId={roomId}
           members={members}
           senderIdentity={senderIdentity}
           onClose={() => setTransferOpen(false)}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -792,6 +792,7 @@ export interface CreateTransferRequest {
   to_agent_id: string;
   amount_minor: string;
   memo?: string;
+  room_id?: string;
   idempotency_key: string;
 }
 

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -30,7 +30,7 @@ import {
   didBotCordSendSucceed,
   recordBotCordOutboundText,
 } from "./src/loop-risk.js";
-import { buildRoomStaticContextHookResult, clearSessionRoom } from "./src/room-context.js";
+import { buildRoomStaticContextHookResult, clearSessionRoom, getSessionRoom } from "./src/room-context.js";
 import { activeOwnerChatStreams } from "./src/owner-chat-stream.js";
 import { buildDynamicContext } from "./src/dynamic-context.js";
 import { BotCordClient } from "./src/client.js";
@@ -76,6 +76,20 @@ export default {
     api.registerTool(createScheduleTool() as any);
 
     // Hooks
+    api.on("before_tool_call", async (event: any, ctx: any) => {
+      if (ctx.toolName !== "botcord_payment") return;
+      if (event.params?.action !== "transfer") return;
+
+      const roomId = getSessionRoom(ctx.sessionKey)?.roomId;
+      if (!roomId?.startsWith("rm_")) return;
+
+      return {
+        params: {
+          __botcord_context_room_id: roomId,
+        },
+      };
+    });
+
     api.on("after_tool_call", async (event: any, ctx: any) => {
       // Stream tool blocks to Hub for active owner-chat sessions
       const stream = activeOwnerChatStreams.get(ctx.sessionKey);

--- a/plugin/src/__tests__/payment.integration.test.ts
+++ b/plugin/src/__tests__/payment.integration.test.ts
@@ -177,6 +177,36 @@ describe("payment tool integration", () => {
     expect(hub.state.messages).toHaveLength(1);
   });
 
+  it("sends transfer record messages to the current room when provided by context", async () => {
+    const sender = makeClient("ag_sender", senderKeys.privateKey);
+    const tool = createPaymentTool();
+
+    await seedBalance(sender, "25000");
+    hub.state.contacts = [
+      { contact_agent_id: "ag_receiver", display_name: "Receiver", created_at: new Date().toISOString() },
+    ];
+    makeToolConfig("ag_sender", senderKeys.privateKey);
+
+    const transfer: any = await tool.execute("tool-room-transfer", {
+      action: "transfer",
+      to_agent_id: "ag_receiver",
+      amount: "50",
+      __botcord_context_room_id: "rm_group_payment",
+    });
+
+    expect(transfer.data.tx.type).toBe("transfer");
+    expect(transfer.data.transfer_record_message.sent).toBe(true);
+    expect(transfer.data.transfer_record_message.target_id).toBe("rm_group_payment");
+
+    const recordMessage = hub.state.messages.map((entry) => entry.envelope).find((envelope) =>
+      envelope.type === "message" &&
+      envelope.to === "rm_group_payment" &&
+      typeof envelope.payload?.text === "string" &&
+      envelope.payload.text.includes("[BotCord Transfer]"),
+    );
+    expect(recordMessage).toBeTruthy();
+  });
+
   it("requires confirmation for stranger transfers", async () => {
     const sender = makeClient("ag_sender", senderKeys.privateKey);
     const tool = createPaymentTool();

--- a/plugin/src/tools/payment-transfer.ts
+++ b/plugin/src/tools/payment-transfer.ts
@@ -5,6 +5,7 @@ import { formatCoinAmount } from "./coin-format.js";
 type FollowUpDeliveryResult = {
   attempted: true;
   sent: boolean;
+  target_id?: string;
   hub_msg_id?: string;
   error?: string;
 };
@@ -62,12 +63,14 @@ export function formatFollowUpDeliverySummary(result: TransferResult): string {
 async function sendRecordMessage(
   client: BotCordClient,
   tx: WalletTransaction,
+  targetId?: string,
 ): Promise<FollowUpDeliveryResult> {
+  const messageTarget = targetId || tx.to_agent_id || "";
   try {
-    const response = await client.sendMessage(tx.to_agent_id || "", buildTransferRecordMessage(tx));
-    return { attempted: true, sent: true, hub_msg_id: response.hub_msg_id };
+    const response = await client.sendMessage(messageTarget, buildTransferRecordMessage(tx));
+    return { attempted: true, sent: true, target_id: messageTarget, hub_msg_id: response.hub_msg_id };
   } catch (err: any) {
-    return { attempted: true, sent: false, error: err?.message ?? String(err) };
+    return { attempted: true, sent: false, target_id: messageTarget, error: err?.message ?? String(err) };
   }
 }
 
@@ -81,10 +84,12 @@ export async function executeTransfer(
     reference_id?: string;
     metadata?: Record<string, unknown>;
     idempotency_key?: string;
+    record_message_target_id?: string;
   },
 ): Promise<TransferResult> {
-  const tx = await client.createTransfer(params);
-  const recordMessage = await sendRecordMessage(client, tx);
+  const { record_message_target_id: recordMessageTargetId, ...transferParams } = params;
+  const tx = await client.createTransfer(transferParams);
+  const recordMessage = await sendRecordMessage(client, tx, recordMessageTargetId);
 
   return {
     tx,

--- a/plugin/src/tools/payment.ts
+++ b/plugin/src/tools/payment.ts
@@ -78,6 +78,11 @@ function sanitizeTransferResult(transfer: any): any {
   };
 }
 
+function internalContextRoomId(args: any): string | undefined {
+  const roomId = args?.__botcord_context_room_id;
+  return typeof roomId === "string" && roomId.startsWith("rm_") ? roomId : undefined;
+}
+
 function formatTransaction(tx: any): string {
   const lines = [
     `Transaction: ${tx.tx_id}`,
@@ -333,6 +338,7 @@ export function createPaymentTool(opts?: { name?: string; description?: string }
               reference_id: args.reference_id,
               metadata: args.metadata,
               idempotency_key: args.idempotency_key,
+              record_message_target_id: internalContextRoomId(args),
             });
             return {
               result: `${formatTransaction(transfer.tx)}\n${formatFollowUpDeliverySummary(transfer)}`,


### PR DESCRIPTION
## Summary
- route plugin payment transfer record messages to the current BotCord room when a room session is active
- include room_id for dashboard room transfer requests and persist a room transfer notice after successful wallet transfer
- add plugin and backend coverage for room-scoped transfer notices

## Tests
- cd backend && uv run pytest tests/test_app/test_app_wallet_human.py -q
- cd plugin && npm test -- --run src/__tests__/payment.integration.test.ts
- cd plugin && npx tsc --noEmit
- cd frontend && npm run build

Note: in the clean PR worktree, the first frontend build failed because the worktree had no local frontend/.env. Re-running with the same local env used in the main workspace passed.