### PR TITLE
fix: speed up message room switching

### DIFF
--- a/frontend/src/components/dashboard/BotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/BotDetailDrawer.tsx
@@ -105,6 +105,7 @@ export default function BotDetailDrawer() {
     setSidebarTab,
     setFocusedRoomId,
     setOpenedRoomId,
+    setUserChatAgentId,
     setUserChatRoomId,
     setMessagesPane,
     setMessagesFilter,
@@ -119,6 +120,7 @@ export default function BotDetailDrawer() {
       setSidebarTab: s.setSidebarTab,
       setFocusedRoomId: s.setFocusedRoomId,
       setOpenedRoomId: s.setOpenedRoomId,
+      setUserChatAgentId: s.setUserChatAgentId,
       setUserChatRoomId: s.setUserChatRoomId,
       setMessagesPane: s.setMessagesPane,
       setMessagesFilter: s.setMessagesFilter,
@@ -201,6 +203,8 @@ export default function BotDetailDrawer() {
     setBotDetailAgentId(null);
     setSidebarTab("messages");
     setMessagesPane("user-chat");
+    setUserChatAgentId(agentId);
+    setUserChatRoomId(null);
     setFocusedRoomId(null);
     setOpenedRoomId(null);
     if (agentId !== activeAgentId) {

--- a/frontend/src/components/dashboard/ChatPane.tsx
+++ b/frontend/src/components/dashboard/ChatPane.tsx
@@ -633,19 +633,14 @@ export default function ChatPane({ onHumanOpen }: ChatPaneProps) {
   // session — realtime presence events only fire on online/offline edges.
   useEffect(() => {
     if (!openedRoomId) return;
-    let cancelled = false;
-    api.getRoomMembers(openedRoomId)
-      .catch(() => api.getPublicRoomMembers(openedRoomId))
-      .then((result) => {
-        if (cancelled) return;
+    void useDashboardChatStore.getState()
+      .loadRoomMembers(openedRoomId)
+      .then((members) => {
         usePresenceStore.getState().seed(
-          result.members.map((m) => ({ agentId: m.agent_id, online: Boolean(m.online) })),
+          members.map((m) => ({ agentId: m.agent_id, online: Boolean(m.online) })),
         );
       })
       .catch(() => {});
-    return () => {
-      cancelled = true;
-    };
   }, [openedRoomId]);
 
   if (sidebarTab === "explore") {

--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -298,6 +298,9 @@ export default function DashboardApp() {
           if (!knownRoom) {
             void chatStore.loadPublicRoomDetail(roomIdFromPath);
           }
+          if (chatStore.messagesLoading[roomIdFromPath]) {
+            return;
+          }
           if (!chatStore.messages[roomIdFromPath]) {
             void chatStore.loadRoomMessages(roomIdFromPath);
           } else {

--- a/frontend/src/components/dashboard/MessageList.tsx
+++ b/frontend/src/components/dashboard/MessageList.tsx
@@ -15,7 +15,6 @@ import { Bot, Settings, UserPlus } from "lucide-react";
 import MessageBubble from "./MessageBubble";
 import type { DashboardMessage, PublicRoomMember, TopicInfo } from "@/lib/types";
 import type { MentionTextCandidate } from "@/components/ui/MarkdownContent";
-import { api } from "@/lib/api";
 import { getLatestSeenAtForRoom } from "@/store/dashboard-shared";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
@@ -54,6 +53,9 @@ interface TopicGroup {
 type TimelineItem =
   | { kind: "message"; message: DashboardMessage }
   | { kind: "topic"; group: TopicGroup };
+
+const EMPTY_MESSAGES: DashboardMessage[] = [];
+const EMPTY_ROOM_MEMBERS: PublicRoomMember[] = [];
 
 function buildTimelineItems(
   messages: DashboardMessage[],
@@ -317,13 +319,16 @@ export default function MessageList() {
     openedRoomId: state.openedRoomId,
     setOpenedTopicId: state.setOpenedTopicId,
   })));
-  const { messagesByRoom, messagesLoading, messagesHasMore, loadMoreMessages, overview } = useDashboardChatStore(
+  const roomId = openedRoomId;
+  const { messages, isRoomMessagesLoading, hasMore, loadMoreMessages, overview, roomMembers, loadRoomMembers } = useDashboardChatStore(
     useShallow((state) => ({
-      messagesByRoom: state.messages,
-      messagesLoading: state.messagesLoading,
-      messagesHasMore: state.messagesHasMore,
+      messages: roomId ? (state.messages[roomId] ?? EMPTY_MESSAGES) : EMPTY_MESSAGES,
+      isRoomMessagesLoading: roomId ? (state.messagesLoading[roomId] ?? false) : false,
+      hasMore: roomId ? (state.messagesHasMore[roomId] ?? false) : false,
       loadMoreMessages: state.loadMoreMessages,
       overview: state.overview,
+      roomMembers: roomId ? (state.roomMembersByRoom[roomId] ?? EMPTY_ROOM_MEMBERS) : EMPTY_ROOM_MEMBERS,
+      loadRoomMembers: state.loadRoomMembers,
     })),
   );
   const { publicRoomDetails, publicRooms, recentVisitedRooms } = useDashboardChatStore(useShallow((state) => ({
@@ -337,17 +342,12 @@ export default function MessageList() {
   const prevLengthRef = useRef(0);
   const isLoadingMore = useRef(false);
   const [showNewMessagesBanner, setShowNewMessagesBanner] = useState(false);
-  const [roomMembers, setRoomMembers] = useState<PublicRoomMember[]>([]);
   const showBannerRef = useRef(false);
   const wasNearBottomRef = useRef(true);
 
-  const roomId = openedRoomId;
-  const messages = roomId ? messagesByRoom[roomId] || [] : [];
   const roomMemberVersion = useDashboardChatStore(
     (state) => roomId ? (state.roomMemberVersions[roomId] ?? 0) : 0,
   );
-  const isRoomMessagesLoading = roomId ? messagesLoading[roomId] ?? false : false;
-  const hasMore = roomId ? messagesHasMore[roomId] ?? false : false;
   const currentAgentId = overview?.agent?.agent_id;
   const currentRoom = useMemo(() => {
     if (!roomId) return null;
@@ -378,23 +378,9 @@ export default function MessageList() {
   }, [overview?.agent, overview?.contacts, roomMembers]);
 
   useEffect(() => {
-    if (!roomId) {
-      setRoomMembers([]);
-      return;
-    }
-    let cancelled = false;
-    api.getRoomMembers(roomId)
-      .catch(() => api.getPublicRoomMembers(roomId))
-      .then((result) => {
-        if (!cancelled) setRoomMembers(result.members);
-      })
-      .catch(() => {
-        if (!cancelled) setRoomMembers([]);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [roomId, roomMemberVersion]);
+    if (!roomId) return;
+    void loadRoomMembers(roomId);
+  }, [roomId, roomMemberVersion, loadRoomMembers]);
 
   const commitRoomSeen = useCallback((targetRoomId: string) => {
     const joinedRoom = overview?.rooms.find((room) => room.room_id === targetRoomId);
@@ -404,14 +390,14 @@ export default function MessageList() {
     void markRoomSeen(
       targetRoomId,
       getLatestSeenAtForRoom(targetRoomId, {
-        messages: messagesByRoom,
-        overview,
-        publicRoomDetails,
-        publicRooms,
-        recentVisitedRooms,
+        messages: useDashboardChatStore.getState().messages,
+        overview: useDashboardChatStore.getState().overview,
+        publicRoomDetails: useDashboardChatStore.getState().publicRoomDetails,
+        publicRooms: useDashboardChatStore.getState().publicRooms,
+        recentVisitedRooms: useDashboardChatStore.getState().recentVisitedRooms,
       }),
     );
-  }, [markRoomSeen, messagesByRoom, overview, publicRoomDetails, publicRooms, recentVisitedRooms]);
+  }, [markRoomSeen, overview]);
 
   useEffect(() => {
     setOpenedTopicId(null);

--- a/frontend/src/components/dashboard/RoomList.tsx
+++ b/frontend/src/components/dashboard/RoomList.tsx
@@ -13,7 +13,7 @@ import { roomList, messagesGrouping } from '@/lib/i18n/translations/dashboard';
 import { useRouter } from "nextjs-toploader/app";
 import { useShallow } from "zustand/react/shallow";
 
-import { ContactInfo, DashboardRoom } from "@/lib/types";
+import { ContactInfo, DashboardMessage, DashboardRoom } from "@/lib/types";
 import { humanRoomToDashboardRoom, isOwnerChatRoom } from "@/store/dashboard-shared";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
@@ -36,6 +36,10 @@ interface RoomListProps {
 
 const USER_CHAT_PATH = "/chats/messages/__user-chat__";
 const EMPTY_CONTACTS: ContactInfo[] = [];
+
+function latestPreviewMessage(messages: DashboardMessage[] | undefined): DashboardMessage | null {
+  return messages?.findLast((m) => m.type !== "ack" && m.type !== "result" && m.type !== "error") ?? null;
+}
 
 function buildRoomAvatarLabel(roomName: string): string {
   const normalized = roomName.trim();
@@ -79,11 +83,17 @@ export default function RoomList({
   const locale = useLanguage();
   const t = roomList[locale];
   const tGroup = messagesGrouping[locale];
-  const { overview, messages, publicAgents } = useDashboardChatStore(useShallow((state) => ({
+  const { overview, publicAgents } = useDashboardChatStore(useShallow((state) => ({
     overview: state.overview,
-    messages: state.messages,
     publicAgents: state.publicAgents,
   })));
+  const cachedLatestMessages = useDashboardChatStore(useShallow((state) => {
+    const latestByRoom: Record<string, DashboardMessage | null> = {};
+    for (const [roomId, roomMessages] of Object.entries(state.messages)) {
+      latestByRoom[roomId] = latestPreviewMessage(roomMessages);
+    }
+    return latestByRoom;
+  }));
   const { focusedRoomId, messagesPane, closeMobileSidebar, setFocusedRoomId, setOpenedRoomId, setMessagesPane, setUserChatAgentId } = useDashboardUIStore(useShallow((state) => ({
     focusedRoomId: state.focusedRoomId,
     messagesPane: state.messagesPane,
@@ -263,11 +273,7 @@ export default function RoomList({
         const isSelected = ownerChatAgentId
           ? messagesPane === "user-chat" && ownerChatAgentId === activeAgentId
           : messagesPane === "room" && focusedRoomId === room.room_id;
-        const roomMessages = messages[room.room_id] || [];
-        // Find the latest real message (skip ack/result/error receipts)
-        const cachedLatestMessage = roomMessages.findLast(
-          (m) => m.type !== "ack" && m.type !== "result" && m.type !== "error",
-        );
+        const cachedLatestMessage = cachedLatestMessages[room.room_id] ?? null;
         // Preview text and sender must come from the same source to stay consistent
         let previewText: string;
         let previewSender: string;

--- a/frontend/src/components/dashboard/TopicDrawer.tsx
+++ b/frontend/src/components/dashboard/TopicDrawer.tsx
@@ -17,6 +17,7 @@ import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import MessageBubble from "./MessageBubble";
 import RoomHumanComposer from "./RoomHumanComposer";
+import type { DashboardMessage } from "@/lib/types";
 
 const topicStatusColors: Record<string, { color: string; icon: string }> = {
   open:      { color: "text-neon-cyan bg-neon-cyan/10 border-neon-cyan/30",    icon: "●" },
@@ -24,6 +25,8 @@ const topicStatusColors: Record<string, { color: string; icon: string }> = {
   failed:    { color: "text-red-400 bg-red-400/10 border-red-400/30",          icon: "✗" },
   expired:   { color: "text-yellow-400 bg-yellow-400/10 border-yellow-400/30", icon: "⏱" },
 };
+
+const EMPTY_MESSAGES: DashboardMessage[] = [];
 
 export default function TopicDrawer() {
   const locale = useLanguage();
@@ -36,7 +39,9 @@ export default function TopicDrawer() {
       setOpenedTopicId: state.setOpenedTopicId,
     })),
   );
-  const messagesByRoom = useDashboardChatStore((s) => s.messages);
+  const messages = useDashboardChatStore(
+    (s) => openedRoomId ? (s.messages[openedRoomId] ?? EMPTY_MESSAGES) : EMPTY_MESSAGES,
+  );
   const activeAgentId = useDashboardSessionStore((s) => s.activeAgentId);
 
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -45,8 +50,7 @@ export default function TopicDrawer() {
     if (!openedRoomId || !openedTopicId) {
       return { topicMessages: [], topicName: "", topicStatus: null as string | null, topicGoal: null as string | null };
     }
-    const all = messagesByRoom[openedRoomId] || [];
-    const filtered = all.filter((m) => m.topic_id === openedTopicId);
+    const filtered = messages.filter((m) => m.topic_id === openedTopicId);
     const first = filtered[0];
     return {
       topicMessages: filtered,
@@ -54,7 +58,7 @@ export default function TopicDrawer() {
       topicStatus: first?.topic_status || null,
       topicGoal: first?.topic_goal || null,
     };
-  }, [messagesByRoom, openedRoomId, openedTopicId]);
+  }, [messages, openedRoomId, openedTopicId]);
 
   useEffect(() => {
     if (openedTopicId) {

--- a/frontend/src/store/useDashboardChatStore.ts
+++ b/frontend/src/store/useDashboardChatStore.ts
@@ -14,6 +14,7 @@ import type {
   DashboardRoom,
   DiscoverRoom,
   HumanAgentRoomSummary,
+  PublicRoomMember,
   PublicHumanProfile,
   PublicRoom,
   RealtimeMetaEvent,
@@ -35,6 +36,7 @@ let publicRoomsRequestSeq = 0;
 let publicAgentsRequestSeq = 0;
 let publicHumansRequestSeq = 0;
 const emptyRoomMessageSnapshot = new Map<string, string | null>();
+const roomMembersInFlight = new Map<string, Promise<PublicRoomMember[]>>();
 
 function isFetchNetworkError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
@@ -91,6 +93,8 @@ interface DashboardChatState {
   messages: Record<string, DashboardMessage[]>;
   messagesLoading: Record<string, boolean>;
   messagesHasMore: Record<string, boolean>;
+  roomMembersByRoom: Record<string, PublicRoomMember[]>;
+  roomMembersLoading: Record<string, boolean>;
   error: string | null;
   selectedAgentId: string | null;
   selectedAgentLoading: boolean;
@@ -133,9 +137,10 @@ interface DashboardChatState {
   bumpRoomMembersVersion: (roomId: string) => void;
 
   insertMessage: (roomId: string, message: DashboardMessage) => void;
-  loadRoomMessages: (roomId: string) => Promise<void>;
+  loadRoomMessages: (roomId: string, opts?: { force?: boolean }) => Promise<void>;
   pollNewMessages: (roomId: string, opts?: { expectedHubMsgId?: string | null; retries?: number }) => Promise<void>;
   loadMoreMessages: (roomId: string) => Promise<void>;
+  loadRoomMembers: (roomId: string, opts?: { force?: boolean }) => Promise<PublicRoomMember[]>;
   selectAgent: (agentId: string) => Promise<void>;
   searchAgents: (q: string) => Promise<void>;
   refreshOverview: (opts?: { reloadOpenedRoom?: boolean }) => Promise<void>;
@@ -158,6 +163,8 @@ const initialChatState = {
   messages: {},
   messagesLoading: {},
   messagesHasMore: {},
+  roomMembersByRoom: {},
+  roomMembersLoading: {},
   error: null,
   selectedAgentId: null,
   selectedAgentLoading: false,
@@ -194,6 +201,8 @@ function hasTransientChatState(state: DashboardChatState): boolean {
     || Object.keys(state.messages).length > 0
     || Object.keys(state.messagesLoading).length > 0
     || Object.keys(state.messagesHasMore).length > 0
+    || Object.keys(state.roomMembersByRoom).length > 0
+    || Object.keys(state.roomMembersLoading).length > 0
     || state.error !== null
     || state.selectedAgentId !== null
     || state.selectedAgentLoading
@@ -354,15 +363,20 @@ export const useDashboardChatStore = create<DashboardChatState>()(
 
       bumpRoomMembersVersion: (roomId) =>
         set((state) => ({
+          roomMembersByRoom: Object.fromEntries(
+            Object.entries(state.roomMembersByRoom).filter(([key]) => key !== roomId),
+          ),
           roomMemberVersions: {
             ...state.roomMemberVersions,
             [roomId]: (state.roomMemberVersions[roomId] ?? 0) + 1,
           },
         })),
 
-      loadRoomMessages: async (roomId: string) => {
+      loadRoomMessages: async (roomId: string, opts) => {
         if (roomMessagesInFlight.has(roomId)) {
-          roomMessagesReloadPending.add(roomId);
+          if (opts?.force) {
+            roomMessagesReloadPending.add(roomId);
+          }
           return;
         }
         set((state) => ({
@@ -389,7 +403,7 @@ export const useDashboardChatStore = create<DashboardChatState>()(
             messagesLoading: { ...state.messagesLoading, [roomId]: false },
           }));
           if (roomMessagesReloadPending.delete(roomId)) {
-            void get().loadRoomMessages(roomId);
+            void get().loadRoomMessages(roomId, { force: true });
           }
         }
       },
@@ -406,14 +420,14 @@ export const useDashboardChatStore = create<DashboardChatState>()(
             const currentSnapshot = getRoomMessageSnapshot(get().getRoomSummary(roomId));
             const previousSnapshot = emptyRoomMessageSnapshot.get(roomId);
             if (opts?.expectedHubMsgId || previousSnapshot !== currentSnapshot) {
-              await get().loadRoomMessages(roomId);
+              await get().loadRoomMessages(roomId, { force: Boolean(opts?.expectedHubMsgId) });
             }
           } else {
             const newestPersisted = [...existing].reverse().find(
               (m) => m.hub_msg_id && !m.hub_msg_id.startsWith("tmp_"),
             );
             if (!newestPersisted) {
-              await get().loadRoomMessages(roomId);
+              await get().loadRoomMessages(roomId, { force: Boolean(opts?.expectedHubMsgId) });
               return;
             }
             const result = await api.getRoomMessages(roomId, { after: newestPersisted.hub_msg_id, limit: 50 });
@@ -475,6 +489,43 @@ export const useDashboardChatStore = create<DashboardChatState>()(
         } catch (error) {
           console.error("[ChatStore] Failed to load more messages:", error);
         }
+      },
+
+      loadRoomMembers: async (roomId: string, opts) => {
+        const cached = get().roomMembersByRoom[roomId];
+        if (cached && !opts?.force) return cached;
+
+        const inFlight = roomMembersInFlight.get(roomId);
+        if (inFlight && !opts?.force) return inFlight;
+
+        const request = (async () => {
+          set((state) => ({
+            roomMembersLoading: { ...state.roomMembersLoading, [roomId]: true },
+          }));
+          try {
+            const result = await api.getRoomMembers(roomId).catch(() => api.getPublicRoomMembers(roomId));
+            set((state) => ({
+              roomMembersByRoom: { ...state.roomMembersByRoom, [roomId]: result.members },
+            }));
+            return result.members;
+          } catch (error) {
+            console.error("[ChatStore] Failed to load room members:", error);
+            set((state) => ({
+              roomMembersByRoom: { ...state.roomMembersByRoom, [roomId]: [] },
+            }));
+            return [];
+          } finally {
+            roomMembersInFlight.delete(roomId);
+            set((state) => {
+              const next = { ...state.roomMembersLoading };
+              delete next[roomId];
+              return { roomMembersLoading: next };
+            });
+          }
+        })();
+
+        roomMembersInFlight.set(roomId, request);
+        return request;
       },
 
       selectAgent: async (agentId: string) => {
@@ -593,10 +644,14 @@ export const useDashboardChatStore = create<DashboardChatState>()(
             const messages = { ...state.messages };
             const messagesLoading = { ...state.messagesLoading };
             const messagesHasMore = { ...state.messagesHasMore };
+            const roomMembersByRoom = { ...state.roomMembersByRoom };
+            const roomMembersLoading = { ...state.roomMembersLoading };
             delete messages[roomId];
             delete messagesLoading[roomId];
             delete messagesHasMore[roomId];
-            return { leavingRoomId: null, messages, messagesLoading, messagesHasMore };
+            delete roomMembersByRoom[roomId];
+            delete roomMembersLoading[roomId];
+            return { leavingRoomId: null, messages, messagesLoading, messagesHasMore, roomMembersByRoom, roomMembersLoading };
           });
           const ui = useDashboardUIStore.getState();
           if (ui.openedRoomId === roomId || ui.focusedRoomId === roomId) {


### PR DESCRIPTION
## Summary
- avoid duplicate full room-message reloads while a room fetch is already in flight
- cache room members in the dashboard chat store and share the request between ChatPane and MessageList
- narrow message subscriptions so the list, drawer, and sidebar react to less global message state

## Tests
- npm test -- --run src/store/useDashboardChatStore.test.ts
- git diff --check

## Notes
- npm run build reached compile/TypeScript successfully, then failed while prerendering /admin/codes because Supabase URL/API key env vars are not configured in this worktree.
- npx tsc --noEmit still fails on pre-existing tests/api missing module/type errors unrelated to this change.