### PR TITLE
fix: match dashboard skeleton to route tab

### DIFF
--- a/frontend/src/components/dashboard/ChatPane.tsx
+++ b/frontend/src/components/dashboard/ChatPane.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 /**
- * [INPUT]: 依赖 session/ui/chat/contact store 与 RoomHeader/MessageList/PaidRoomPreview/ExploreEntityCard 等内容组件
+ * [INPUT]: 依赖 session/ui/chat/contact store、可选路由 tab 覆盖值与 RoomHeader/MessageList/PaidRoomPreview/ExploreEntityCard 等内容组件
  * [OUTPUT]: 对外提供 ChatPane 组件，渲染 explore/contacts/message 三类主内容视图，并把公开目录搜索委托给远端查询
  * [POS]: dashboard 第三栏主工作区，承载会话浏览与消息阅读；无 agent 准入由 DashboardApp 顶层统一处理
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
@@ -41,6 +41,7 @@ import ContactsDetailPane from "./ContactsDetailPane";
 import { DashboardMainSkeleton } from "./DashboardTabSkeleton";
 
 const EXPLORE_GRID_CLASS = "grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5";
+type ChatPaneTab = "messages" | "contacts" | "explore";
 
 function GridSkeletonCards() {
   return <DashboardMainSkeleton variant="explore" />;
@@ -348,6 +349,7 @@ function ContactsMainPane({ onHumanOpen }: { onHumanOpen?: (human: PublicHumanPr
 
 interface ChatPaneProps {
   onHumanOpen?: (human: PublicHumanProfile) => void;
+  sidebarTabOverride?: ChatPaneTab;
 }
 
 function ExploreMainPane({ onHumanOpen }: ChatPaneProps) {
@@ -594,7 +596,7 @@ function MessagesEmptyState({ filter }: { filter: MessagesFilter }) {
   );
 }
 
-export default function ChatPane({ onHumanOpen }: ChatPaneProps) {
+export default function ChatPane({ onHumanOpen, sidebarTabOverride }: ChatPaneProps) {
   const router = useRouter();
   const locale = useLanguage();
   const t = chatPane[locale];
@@ -618,6 +620,7 @@ export default function ChatPane({ onHumanOpen }: ChatPaneProps) {
     recentVisitedRooms: state.recentVisitedRooms,
     getRoomSummary: state.getRoomSummary,
   })));
+  const effectiveSidebarTab = sidebarTabOverride ?? sidebarTab;
   const visibleMessageRooms = useMemo(
     () => buildVisibleMessageRooms({ overview, recentVisitedRooms, token, humanRooms }),
     [overview, recentVisitedRooms, token, humanRooms],
@@ -648,11 +651,11 @@ export default function ChatPane({ onHumanOpen }: ChatPaneProps) {
     };
   }, [openedRoomId]);
 
-  if (sidebarTab === "explore") {
+  if (effectiveSidebarTab === "explore") {
     return <ExploreMainPane onHumanOpen={onHumanOpen} />;
   }
 
-  if (sidebarTab === "contacts") {
+  if (effectiveSidebarTab === "contacts") {
     if (contactsView === "requests") {
       return <ContactRequestsInbox initialTab="received" />;
     }

--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 /**
- * [INPUT]: 依赖 session/ui/chat/realtime/unread/contact/wallet 多业务 store 聚合 dashboard 状态，依赖 react effect 在后台预热跨 tab 数据与 Supabase Realtime 订阅，依赖 Sidebar/ChatPane/WalletPanel/AgentCardModal 组织主界面
+ * [INPUT]: 依赖 session/ui/chat/realtime/unread/contact/wallet 多业务 store 聚合 dashboard 状态，依赖 pathname 同步首帧 tab，依赖 react effect 在后台预热跨 tab 数据与 Supabase Realtime 订阅，依赖 Sidebar/ChatPane/WalletPanel/AgentCardModal 组织主界面
  * [OUTPUT]: 对外提供 DashboardApp 组件，负责鉴权初始化、请求闸门、realtime 生命周期与三栏布局编排
  * [POS]: /chats 页面的顶层容器，连接路由状态、实时事件流与拆分后的 dashboard store
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
@@ -45,6 +45,7 @@ import WalletPanel from "./WalletPanel";
 import ActivityPanel from "./ActivityPanel";
 
 const USER_CHAT_SUBTAB = "__user-chat__";
+type DashboardSidebarTab = "home" | "messages" | "contacts" | "explore" | "wallet" | "activity" | "bots";
 
 type BotcordDebugRealtimeSnapshot = {
   supabaseUrl: string | undefined;
@@ -77,6 +78,21 @@ function getCurrentMessageRoomFromPath(pathname: string): string | null {
   return decodeRoomIdFromPath(subtab);
 }
 
+function getSidebarTabFromPathParts(parts: string[]): DashboardSidebarTab {
+  const tab = parts[1];
+  if (tab === "dm" || tab === "rooms" || tab === "messages" || tab === "user-chat") return "messages";
+  if (
+    tab === "contacts"
+    || tab === "explore"
+    || tab === "wallet"
+    || tab === "activity"
+    || tab === "bots"
+  ) {
+    return tab;
+  }
+  return "home";
+}
+
 export default function DashboardApp() {
   const sessionStore = useDashboardSessionStore();
   const uiStore = useDashboardUIStore();
@@ -101,6 +117,7 @@ export default function DashboardApp() {
   const initResolvedRef = useRef(false);
   const lastAccessTokenRef = useRef<string | null>(null);
   const pathnameParts = useMemo(() => pathname.split("/").filter(Boolean), [pathname]);
+  const routeSidebarTab = useMemo(() => getSidebarTabFromPathParts(pathnameParts), [pathnameParts]);
   const userChatAgentIdFromQuery = searchParams.get("agent_id");
   const shouldShowBootstrapSkeleton = !sessionStore.authResolved || sessionStore.authBootstrapping;
   // Human-first: never force-block on "no agent". Authed users always proceed
@@ -992,54 +1009,63 @@ export default function DashboardApp() {
   };
 
   const mobileShowsMain =
-    uiStore.sidebarTab === "contacts"
-    || uiStore.sidebarTab === "explore"
-    || uiStore.sidebarTab === "wallet"
-    || uiStore.sidebarTab === "activity"
-    || (uiStore.sidebarTab === "messages" && (uiStore.messagesPane === "user-chat" || Boolean(uiStore.openedRoomId)))
-    || (uiStore.sidebarTab === "bots" && Boolean(uiStore.selectedBotAgentId));
+    routeSidebarTab === "contacts"
+    || routeSidebarTab === "explore"
+    || routeSidebarTab === "wallet"
+    || routeSidebarTab === "activity"
+    || (routeSidebarTab === "messages" && (uiStore.messagesPane === "user-chat" || Boolean(uiStore.openedRoomId)))
+    || (routeSidebarTab === "bots" && Boolean(uiStore.selectedBotAgentId));
   const mobileHideSecondary =
-    uiStore.sidebarTab === "wallet"
-    || uiStore.sidebarTab === "activity"
-    || uiStore.sidebarTab === "explore"
-    || uiStore.sidebarTab === "contacts"
-    || (uiStore.sidebarTab === "messages" && (uiStore.messagesPane === "user-chat" || Boolean(uiStore.openedRoomId)))
-    || (uiStore.sidebarTab === "bots" && Boolean(uiStore.selectedBotAgentId));
+    routeSidebarTab === "wallet"
+    || routeSidebarTab === "activity"
+    || routeSidebarTab === "explore"
+    || routeSidebarTab === "contacts"
+    || (routeSidebarTab === "messages" && (uiStore.messagesPane === "user-chat" || Boolean(uiStore.openedRoomId)))
+    || (routeSidebarTab === "bots" && Boolean(uiStore.selectedBotAgentId));
   const mainPaneClass = `min-h-0 min-w-0 flex-1 ${mobileShowsMain ? "" : "max-md:hidden"}`;
   const primaryNavigationPending = Boolean(
     uiStore.pendingPrimaryNavigation && pathname !== uiStore.pendingPrimaryNavigation.path,
   );
+  const visibleSidebarTab = primaryNavigationPending
+    ? uiStore.pendingPrimaryNavigation?.tab ?? uiStore.sidebarTab
+    : routeSidebarTab;
 
   return (
     <div className="fixed inset-0 flex overflow-hidden bg-deep-black max-md:flex-col-reverse">
       <Sidebar
+        sidebarTabOverride={visibleSidebarTab}
         mobileHideSecondary={mobileHideSecondary}
         mobileSecondaryOpen={uiStore.mobileSidebarOpen}
         onMobileSecondaryClose={uiStore.closeMobileSidebar}
       />
       <div className={mainPaneClass}>
         {primaryNavigationPending ? (
-          <DashboardTabSkeleton variant={uiStore.sidebarTab} />
-        ) : uiStore.sidebarTab === "home" ? (
+          <DashboardTabSkeleton variant={visibleSidebarTab} />
+        ) : visibleSidebarTab === "home" ? (
           <HomePanel />
-        ) : uiStore.sidebarTab === "activity" ? (
+        ) : visibleSidebarTab === "activity" ? (
           <ActivityPanel />
-        ) : uiStore.sidebarTab === "wallet" ? (
+        ) : visibleSidebarTab === "wallet" ? (
           <WalletPanel />
-        ) : uiStore.sidebarTab === "bots" ? (
+        ) : visibleSidebarTab === "bots" ? (
           <MyBotsPanel />
-        ) : uiStore.sidebarTab === "messages" && uiStore.messagesShowRequests ? (
+        ) : visibleSidebarTab === "messages" && uiStore.messagesShowRequests ? (
           <ContactRequestsInbox
             title={tChatPane.contactRequests}
             hideTabs
           />
-        ) : uiStore.sidebarTab === "messages" && uiStore.messagesPane === "user-chat" ? (
+        ) : visibleSidebarTab === "messages" && uiStore.messagesPane === "user-chat" ? (
           <div className="h-full min-w-0">
             <UserChatPane agentId={uiStore.userChatAgentId || userChatAgentIdFromQuery} />
           </div>
         ) : (
           <div className="flex h-full min-w-0">
             <ChatPane
+              sidebarTabOverride={
+                visibleSidebarTab === "contacts" || visibleSidebarTab === "explore"
+                  ? visibleSidebarTab
+                  : "messages"
+              }
               onHumanOpen={(human) => {
                 void handleOpenHumanCard({
                   humanId: human.human_id,
@@ -1047,7 +1073,7 @@ export default function DashboardApp() {
                 });
               }}
             />
-            {uiStore.sidebarTab !== "explore" && uiStore.rightPanelOpen && <AgentBrowser />}
+            {visibleSidebarTab !== "explore" && uiStore.rightPanelOpen && <AgentBrowser />}
           </div>
         )}
       </div>

--- a/frontend/src/components/dashboard/DashboardShellSkeleton.test.ts
+++ b/frontend/src/components/dashboard/DashboardShellSkeleton.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { getShellSkeletonVariantFromPathname } from "./DashboardShellSkeleton";
+
+describe("getShellSkeletonVariantFromPathname", () => {
+  it("treats /chats root and home routes as home", () => {
+    expect(getShellSkeletonVariantFromPathname("/chats")).toBe("home");
+    expect(getShellSkeletonVariantFromPathname("/chats/home")).toBe("home");
+    expect(getShellSkeletonVariantFromPathname(null)).toBe("home");
+  });
+
+  it("maps message aliases to the messages skeleton", () => {
+    expect(getShellSkeletonVariantFromPathname("/chats/messages")).toBe("messages");
+    expect(getShellSkeletonVariantFromPathname("/chats/messages/rm_123")).toBe("messages");
+    expect(getShellSkeletonVariantFromPathname("/chats/dm")).toBe("messages");
+    expect(getShellSkeletonVariantFromPathname("/chats/rooms")).toBe("messages");
+    expect(getShellSkeletonVariantFromPathname("/chats/user-chat")).toBe("messages");
+  });
+
+  it("keeps other supported tabs distinct", () => {
+    expect(getShellSkeletonVariantFromPathname("/chats/contacts")).toBe("contacts");
+    expect(getShellSkeletonVariantFromPathname("/chats/explore")).toBe("explore");
+    expect(getShellSkeletonVariantFromPathname("/chats/wallet")).toBe("wallet");
+    expect(getShellSkeletonVariantFromPathname("/chats/activity")).toBe("activity");
+    expect(getShellSkeletonVariantFromPathname("/chats/bots")).toBe("bots");
+  });
+});

--- a/frontend/src/components/dashboard/DashboardShellSkeleton.tsx
+++ b/frontend/src/components/dashboard/DashboardShellSkeleton.tsx
@@ -1,17 +1,38 @@
 "use client";
 
 /**
- * [INPUT]: 依赖 dashboard 视觉 token 与 Tailwind 原子类提供骨架外观
- * [OUTPUT]: 对外提供 DashboardShellSkeleton 组件，渲染 /chats 整体应用级骨架屏
+ * [INPUT]: 依赖 dashboard 视觉 token、当前 /chats 路径与 Tailwind 原子类提供骨架外观
+ * [OUTPUT]: 对外提供 DashboardShellSkeleton 组件，按目标 tab 渲染 /chats 整体应用级骨架屏
  * [POS]: dashboard 顶层加载壳，统一覆盖路由进入与鉴权等待，避免局部 spinner 带来的视觉抖动
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
 
 import DashboardMessagePaneSkeleton from "./DashboardMessagePaneSkeleton";
-import { Bot, Home, LogIn, MessageSquare, Search, UserRound, Wallet } from "lucide-react";
+import DashboardTabSkeleton, { SidebarListSkeleton } from "./DashboardTabSkeleton";
+import { Activity, Bot, Home, LogIn, MessageSquare, Search, UserRound, Wallet } from "lucide-react";
+import { usePathname } from "next/navigation";
+
+type ShellSkeletonVariant = "home" | "messages" | "bots" | "contacts" | "explore" | "wallet" | "activity";
 
 function SkeletonLine({ className }: { className: string }) {
   return <div className={`dashboard-skeleton-block rounded ${className}`} />;
+}
+
+export function getShellSkeletonVariantFromPathname(pathname: string | null): ShellSkeletonVariant {
+  const parts = (pathname || "/chats").split("/").filter(Boolean);
+  const tab = parts[1];
+  if (tab === "dm" || tab === "rooms" || tab === "user-chat") return "messages";
+  if (
+    tab === "messages"
+    || tab === "contacts"
+    || tab === "explore"
+    || tab === "wallet"
+    || tab === "activity"
+    || tab === "bots"
+  ) {
+    return tab;
+  }
+  return "home";
 }
 
 function SkeletonRoomList() {
@@ -27,19 +48,72 @@ function SkeletonRoomList() {
   );
 }
 
-export default function DashboardShellSkeleton() {
+function SecondaryPanelSkeleton({ variant }: { variant: ShellSkeletonVariant }) {
+  if (variant === "messages") {
+    return (
+      <div className="flex h-full w-[200px] shrink-0 flex-col border-r border-glass-border bg-deep-black/50">
+        <div className="flex h-14 items-center justify-between border-b border-glass-border px-3">
+          <span className="text-[11px] font-semibold uppercase tracking-[0.16em] text-text-secondary/70">分组</span>
+          <SkeletonLine className="h-3.5 w-3.5 bg-glass-border/50" />
+        </div>
+        <div className="flex-1 py-2">
+          <div className="px-3 py-2">
+            <SkeletonLine className="h-3 w-28" />
+            <SkeletonLine className="mt-2 h-2.5 w-20 bg-glass-border/40" />
+          </div>
+          {Array.from({ length: 5 }).map((_, idx) => (
+            <div key={`self-${idx}`} className="flex items-center gap-2 py-1.5 pl-[28px] pr-3">
+              <SkeletonLine className="h-3.5 w-3.5 bg-glass-border/45" />
+              <SkeletonLine className="h-3 w-20 bg-glass-border/45" />
+              <SkeletonLine className="ml-auto h-4 w-6 rounded-full bg-glass-border/40" />
+            </div>
+          ))}
+          <div className="my-2 border-t border-glass-border/40" />
+          <div className="px-3 py-2">
+            <SkeletonLine className="h-3 w-20" />
+            <SkeletonLine className="mt-2 h-2.5 w-28 bg-glass-border/40" />
+          </div>
+          {Array.from({ length: 4 }).map((_, idx) => (
+            <div key={`bots-${idx}`} className="flex items-center gap-2 py-1.5 pl-[28px] pr-3">
+              <SkeletonLine className="h-3.5 w-3.5 bg-glass-border/45" />
+              <SkeletonLine className="h-3 w-24 bg-glass-border/45" />
+              <SkeletonLine className="ml-auto h-4 w-6 rounded-full bg-glass-border/40" />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (variant !== "contacts" && variant !== "activity") return null;
+
+  return (
+    <div className="flex h-full w-[280px] shrink-0 flex-col border-r border-glass-border bg-deep-black-light">
+      <div className="flex h-14 items-center justify-between border-b border-glass-border px-4">
+        <SkeletonLine className="h-4 w-24" />
+        <SkeletonLine className="h-8 w-8 rounded-lg bg-glass-border/40" />
+      </div>
+      <SidebarListSkeleton rows={variant === "contacts" ? 9 : 7} withAvatar={variant === "contacts"} />
+    </div>
+  );
+}
+
+export default function DashboardShellSkeleton({ variant: variantProp }: { variant?: ShellSkeletonVariant }) {
+  const pathname = usePathname();
+  const variant = variantProp ?? getShellSkeletonVariantFromPathname(pathname);
   const primaryNav = [
-    { key: "home", label: "Home", icon: <Home className="h-5 w-5" strokeWidth={1.5} />, active: false },
-    { key: "messages", label: "Messages", icon: <MessageSquare className="h-5 w-5" strokeWidth={1.5} />, active: true },
-    { key: "bots", label: "My Bots", icon: <Bot className="h-5 w-5" strokeWidth={1.5} />, active: false },
-    { key: "contacts", label: "Contacts", icon: <UserRound className="h-5 w-5" strokeWidth={1.5} />, active: false },
-    { key: "explore", label: "Explore", icon: <Search className="h-5 w-5" strokeWidth={1.5} />, active: false },
-    { key: "wallet", label: "Wallet", icon: <Wallet className="h-5 w-5" strokeWidth={1.5} />, active: false },
+    { key: "home", label: "Home", icon: <Home className="h-5 w-5" strokeWidth={1.5} /> },
+    { key: "messages", label: "Messages", icon: <MessageSquare className="h-5 w-5" strokeWidth={1.5} /> },
+    { key: "bots", label: "My Bots", icon: <Bot className="h-5 w-5" strokeWidth={1.5} /> },
+    { key: "contacts", label: "Contacts", icon: <UserRound className="h-5 w-5" strokeWidth={1.5} /> },
+    { key: "explore", label: "Explore", icon: <Search className="h-5 w-5" strokeWidth={1.5} /> },
+    { key: "wallet", label: "Wallet", icon: <Wallet className="h-5 w-5" strokeWidth={1.5} /> },
+    { key: "activity", label: "Activity", icon: <Activity className="h-5 w-5" strokeWidth={1.5} /> },
   ] as const;
 
   return (
     <div className="relative flex h-screen overflow-hidden bg-deep-black">
-      <div className="flex h-full w-[624px] min-w-[624px] bg-deep-black-light">
+      <div className="flex h-full bg-deep-black-light">
         <div className="flex h-full w-16 min-w-[64px] flex-col items-center border-r border-glass-border bg-deep-black py-3">
           <div className="mb-3 flex h-11 w-11 items-center justify-center rounded-xl border border-glass-border bg-deep-black-light">
             <img src="/logo.svg" alt="BotCord" className="h-6 w-6 opacity-80" />
@@ -49,7 +123,7 @@ export default function DashboardShellSkeleton() {
               <div
                 key={item.key}
                 className={`group relative flex h-12 w-12 flex-col items-center justify-center rounded-xl transition-all duration-200 ${
-                  item.active
+                  item.key === variant
                     ? "bg-neon-cyan/15 text-neon-cyan"
                     : "text-text-secondary"
                 }`}
@@ -64,39 +138,10 @@ export default function DashboardShellSkeleton() {
           </div>
         </div>
 
-        <div className="flex h-full w-[200px] shrink-0 flex-col border-r border-glass-border bg-deep-black/50">
-          <div className="flex h-14 items-center justify-between border-b border-glass-border px-3">
-            <span className="text-[11px] font-semibold uppercase tracking-[0.16em] text-text-secondary/70">分组</span>
-            <SkeletonLine className="h-3.5 w-3.5 bg-glass-border/50" />
-          </div>
-          <div className="flex-1 py-2">
-            <div className="px-3 py-2">
-              <SkeletonLine className="h-3 w-28" />
-              <SkeletonLine className="mt-2 h-2.5 w-20 bg-glass-border/40" />
-            </div>
-            {Array.from({ length: 5 }).map((_, idx) => (
-              <div key={`self-${idx}`} className="flex items-center gap-2 py-1.5 pl-[28px] pr-3">
-                <SkeletonLine className="h-3.5 w-3.5 bg-glass-border/45" />
-                <SkeletonLine className="h-3 w-20 bg-glass-border/45" />
-                <SkeletonLine className="ml-auto h-4 w-6 rounded-full bg-glass-border/40" />
-              </div>
-            ))}
-            <div className="my-2 border-t border-glass-border/40" />
-            <div className="px-3 py-2">
-              <SkeletonLine className="h-3 w-20" />
-              <SkeletonLine className="mt-2 h-2.5 w-28 bg-glass-border/40" />
-            </div>
-            {Array.from({ length: 4 }).map((_, idx) => (
-              <div key={`bots-${idx}`} className="flex items-center gap-2 py-1.5 pl-[28px] pr-3">
-                <SkeletonLine className="h-3.5 w-3.5 bg-glass-border/45" />
-                <SkeletonLine className="h-3 w-24 bg-glass-border/45" />
-                <SkeletonLine className="ml-auto h-4 w-6 rounded-full bg-glass-border/40" />
-              </div>
-            ))}
-          </div>
-        </div>
+        <SecondaryPanelSkeleton variant={variant} />
 
-        <div className="flex h-full min-w-0 flex-1 flex-col border-r border-glass-border">
+        {variant === "messages" ? (
+          <div className="flex h-full min-w-0 flex-1 flex-col border-r border-glass-border">
           <div className="flex h-14 items-center justify-between border-b border-glass-border px-3">
             <span className="text-sm font-semibold text-text-primary">Messages</span>
             <div className="flex items-center gap-3 text-text-secondary">
@@ -106,10 +151,17 @@ export default function DashboardShellSkeleton() {
             </div>
           </div>
           <SkeletonRoomList />
-        </div>
+          </div>
+        ) : null}
       </div>
 
-      <DashboardMessagePaneSkeleton />
+      {variant === "messages" ? (
+        <DashboardMessagePaneSkeleton />
+      ) : (
+        <div className="min-w-0 flex-1">
+          <DashboardTabSkeleton variant={variant} />
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/dashboard/README.md
+++ b/frontend/src/components/dashboard/README.md
@@ -77,6 +77,7 @@ dashboard/
 
 ## 变更日志
 
+- 2026-05-14: `DashboardShellSkeleton.tsx`、`DashboardApp.tsx`、`Sidebar.tsx` 与 `ChatPane.tsx` 改为按 `/chats` 当前路径推导首帧 tab；刷新 Home/Explore/Contacts/Wallet/My Bots 时不再误用 Messages 会话骨架或默认消息视图。
 - 2026-05-14: 移除 Messages 里的 Bot 身份切换能力；点击自有 Bot 私聊、Bot 详情私聊、联系人里的 owned-bot 私聊都不再重绑 chat store 或强制刷新消息列表。
 - 2026-05-13: `messages` 分组侧栏只在已登录状态展示；游客态保留公开消息列表，不再显示分组栏或展开分组按钮。
 - 2026-05-12: `/chats` 根入口默认选中 Home tab；消息入口仍使用 `/chats/messages`。

--- a/frontend/src/components/dashboard/sidebar/index.tsx
+++ b/frontend/src/components/dashboard/sidebar/index.tsx
@@ -17,7 +17,7 @@ import { common, nav } from "@/lib/i18n/translations/common";
 import { useShallow } from "zustand/react/shallow";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
-import { useDashboardUIStore } from "@/store/useDashboardUIStore";
+import { useDashboardUIStore, type DashboardUIState } from "@/store/useDashboardUIStore";
 import { useDashboardUnreadStore } from "@/store/useDashboardUnreadStore";
 import { useDashboardContactStore } from "@/store/useDashboardContactStore";
 import { useDashboardRealtimeStore } from "@/store/useDashboardRealtimeStore";
@@ -112,12 +112,14 @@ interface SidebarProps {
   mobileHideSecondary?: boolean;
   mobileSecondaryOpen?: boolean;
   onMobileSecondaryClose?: () => void;
+  sidebarTabOverride?: DashboardUIState["sidebarTab"];
 }
 
 export default function Sidebar({
   mobileHideSecondary = false,
   mobileSecondaryOpen = false,
   onMobileSecondaryClose,
+  sidebarTabOverride,
 }: SidebarProps) {
   const router = useRouter();
   const supabase = useMemo(() => createClient(), []);
@@ -270,10 +272,11 @@ export default function Sidebar({
   }, [unreadStore, visibleMessageRooms]);
 
   const pendingContactRequests = chatStore.overview?.pending_requests || 0;
+  const visibleSidebarTab = sidebarTabOverride ?? uiStore.sidebarTab;
   const secondaryPanelLoading = Boolean(
-    uiStore.pendingPrimaryNavigation && uiStore.pendingPrimaryNavigation.tab === uiStore.sidebarTab,
+    uiStore.pendingPrimaryNavigation && uiStore.pendingPrimaryNavigation.tab === visibleSidebarTab,
   );
-  const showMessagesGrouping = uiStore.sidebarTab === "messages" && !isGuest && uiStore.messagesGroupingOpen;
+  const showMessagesGrouping = visibleSidebarTab === "messages" && !isGuest && uiStore.messagesGroupingOpen;
 
   useEffect(() => {
     const prefetch = (path: string) => {
@@ -339,7 +342,7 @@ export default function Sidebar({
         </Link>
         <div className="flex flex-1 flex-col items-center gap-1 pt-1 max-md:min-w-0 max-md:flex-row max-md:justify-around max-md:pt-0">
           {navItems.map((item) => {
-            const isActive = uiStore.sidebarTab === item.key;
+            const isActive = visibleSidebarTab === item.key;
             const requiresLogin = isGuest && (item.key === "contacts" || item.key === "activity");
             let badge: ReactNode = null;
             if (item.key === "messages" && unreadMessageCount > 0 && !requiresLogin) {
@@ -447,7 +450,7 @@ export default function Sidebar({
       )}
 
       {/* Secondary panel — hidden on Home, My Bots, Explore, Wallet (those pages get full width). */}
-      {uiStore.sidebarTab !== "home" && uiStore.sidebarTab !== "bots" && uiStore.sidebarTab !== "explore" && uiStore.sidebarTab !== "wallet" && (
+      {visibleSidebarTab !== "home" && visibleSidebarTab !== "bots" && visibleSidebarTab !== "explore" && visibleSidebarTab !== "wallet" && (
       <div
         className={`relative flex h-full flex-col border-r border-glass-border bg-deep-black-light max-md:min-h-0 max-md:flex-1 max-md:!min-w-0 max-md:border-r-0 ${
           mobileHideSecondary
@@ -469,10 +472,10 @@ export default function Sidebar({
           className="absolute right-0 top-0 z-10 h-full w-1 cursor-col-resize transition-colors hover:bg-neon-cyan/30 active:bg-neon-cyan/50 max-md:hidden"
         />
         {/* Outer panel header — hidden on messages tab; MessagesPanel owns its own column header (Feishu-style). */}
-        {uiStore.sidebarTab !== "messages" && (
+        {visibleSidebarTab !== "messages" && (
         <div className="flex min-h-14 items-center justify-between border-b border-glass-border px-4 py-3">
           <div className="min-w-0">
-            <h2 className="text-sm font-semibold text-text-primary">{tabTitles[uiStore.sidebarTab]}</h2>
+            <h2 className="text-sm font-semibold text-text-primary">{tabTitles[visibleSidebarTab]}</h2>
             {isGuest && (
               <p className="truncate text-[10px] text-text-secondary/60">{t.browseAsGuest}</p>
             )}
@@ -488,7 +491,7 @@ export default function Sidebar({
               <X className="h-4 w-4" />
             </button>
           )}
-          {uiStore.sidebarTab === "contacts" && !isGuest && (
+          {visibleSidebarTab === "contacts" && !isGuest && (
             <div className="flex items-center gap-1">
               <button
                 onClick={() => setShowAddFriend(true)}
@@ -513,7 +516,7 @@ export default function Sidebar({
           <div className="min-w-0 flex-1 overflow-y-auto overflow-x-hidden">
           {secondaryPanelLoading ? (
             <>
-              {uiStore.sidebarTab === "messages" ? (
+              {visibleSidebarTab === "messages" ? (
                 <div className="flex min-h-14 items-center justify-between border-b border-glass-border px-3 py-2.5">
                   <SkeletonBlock className="h-4 w-28" />
                   <div className="flex gap-1">
@@ -522,16 +525,16 @@ export default function Sidebar({
                   </div>
                 </div>
               ) : null}
-              <SidebarListSkeleton rows={uiStore.sidebarTab === "contacts" ? 9 : 7} />
+              <SidebarListSkeleton rows={visibleSidebarTab === "contacts" ? 9 : 7} />
             </>
-          ) : uiStore.sidebarTab === "messages" && (
+          ) : visibleSidebarTab === "messages" && (
             <MessagesPanel
               isGuest={isGuest}
               onCreateRoom={() => setShowCreateRoom(true)}
               onAddFriend={() => setShowAddFriend(true)}
             />
           )}
-          {!secondaryPanelLoading && uiStore.sidebarTab === "contacts" && (
+          {!secondaryPanelLoading && visibleSidebarTab === "contacts" && (
             <ContactsPanel onOpenAddFriend={() => setShowAddFriend(true)} />
           )}
           </div>


### PR DESCRIPTION
## Summary
- derive dashboard shell skeleton variant from the current /chats route
- use the route tab for the first render of DashboardApp, Sidebar, and ChatPane
- add coverage for dashboard skeleton route-to-tab mapping

## Tests
- npx vitest run src/components/dashboard/DashboardShellSkeleton.test.ts
- NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy-anon-key npm run build