### PR TITLE
fix: stabilize daemon websocket reconnects

### DIFF
--- a/frontend/src/components/dashboard/BotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/BotDetailDrawer.tsx
@@ -105,6 +105,7 @@ export default function BotDetailDrawer() {
     setSidebarTab,
     setFocusedRoomId,
     setOpenedRoomId,
+    setUserChatAgentId,
     setUserChatRoomId,
     setMessagesPane,
     setMessagesFilter,
@@ -119,6 +120,7 @@ export default function BotDetailDrawer() {
       setSidebarTab: s.setSidebarTab,
       setFocusedRoomId: s.setFocusedRoomId,
       setOpenedRoomId: s.setOpenedRoomId,
+      setUserChatAgentId: s.setUserChatAgentId,
       setUserChatRoomId: s.setUserChatRoomId,
       setMessagesPane: s.setMessagesPane,
       setMessagesFilter: s.setMessagesFilter,
@@ -201,6 +203,8 @@ export default function BotDetailDrawer() {
     setBotDetailAgentId(null);
     setSidebarTab("messages");
     setMessagesPane("user-chat");
+    setUserChatAgentId(agentId);
+    setUserChatRoomId(null);
     setFocusedRoomId(null);
     setOpenedRoomId(null);
     if (agentId !== activeAgentId) {

--- a/packages/daemon/src/__tests__/control-channel.test.ts
+++ b/packages/daemon/src/__tests__/control-channel.test.ts
@@ -322,6 +322,43 @@ describe("ControlChannel — REVOKE frame (plan §6.3)", () => {
   });
 });
 
+describe("ControlChannel — reconnect scheduling", () => {
+  beforeEach(() => {
+    FakeWebSocket.instances.length = 0;
+  });
+
+  it("adds jitter and coalesces duplicate close events into one reconnect", async () => {
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(1);
+    const auth = new UserAuthManager({
+      record: makeAuthRecord(),
+      file: "/tmp/never-written-user-auth.json",
+    });
+    const ctor = makeFakeCtor();
+    const ch = new ControlChannel({
+      auth,
+      handle: () => ({ ok: true }),
+      webSocketCtor: ctor as unknown as typeof import("ws").default,
+      hubPublicKey: null,
+      backoffMs: [25],
+    });
+    await ch.start();
+    const ws = FakeWebSocket.instances[0];
+
+    ws.emit("close", 1012, Buffer.from(""));
+    ws.emit("close", 1012, Buffer.from(""));
+
+    // Base delay is 25ms; with random=1 and 25% jitter the actual delay is
+    // 31ms. Duplicate close events should still leave only one timer queued.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    await new Promise((r) => setTimeout(r, 20));
+    expect(FakeWebSocket.instances).toHaveLength(2);
+
+    randomSpy.mockRestore();
+    await ch.stop();
+  });
+});
+
 afterEach(() => {
   FakeWebSocket.instances.length = 0;
 });

--- a/packages/daemon/src/control-channel.ts
+++ b/packages/daemon/src/control-channel.ts
@@ -25,6 +25,7 @@ import {
 
 /** Exponential backoff plan for transient disconnects. */
 const RECONNECT_BACKOFF_MS = [1000, 2000, 4000, 8000, 16000, 30000];
+const RECONNECT_JITTER_RATIO = 0.25;
 /**
  * Keepalive cadence. Has to stay below the smallest idle-timeout in any
  * intermediary on the daemon → Hub WS path. Cloudflare and AWS ALB both
@@ -53,6 +54,11 @@ export function controlSigningInput(
     ts: typeof frame.ts === "number" ? frame.ts : 0,
   };
   return jcsCanonicalize(obj) ?? "{}";
+}
+
+function withReconnectJitter(delayMs: number): { delayMs: number; jitterMs: number } {
+  const jitterMs = Math.floor(Math.random() * delayMs * RECONNECT_JITTER_RATIO);
+  return { delayMs: delayMs + jitterMs, jitterMs };
 }
 
 /** Handler invoked for each inbound frame. Return value is the ack payload. */
@@ -110,6 +116,7 @@ export class ControlChannel {
   private readonly seenFrameIds: string[] = [];
   private connectInflight: Promise<void> | null = null;
   private connected = false;
+  private connectionSeq = 0;
 
   constructor(opts: ControlChannelOptions) {
     this.auth = opts.auth;
@@ -220,6 +227,20 @@ export class ControlChannel {
   private async connect(): Promise<void> {
     const record = this.auth.current;
     if (!record) throw new Error("control-channel: no user-auth");
+    const current = this.ws;
+    if (
+      current &&
+      (current.readyState === WebSocket.CONNECTING || current.readyState === WebSocket.OPEN)
+    ) {
+      daemonLog.debug("control-channel connect skipped (socket already active)", {
+        readyState: current.readyState,
+      });
+      return;
+    }
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
 
     const accessToken = await this.auth.ensureAccessToken();
     const url = buildDaemonWebSocketUrl(
@@ -229,6 +250,7 @@ export class ControlChannel {
     );
     daemonLog.info("control-channel connecting", { url });
 
+    const connectionId = ++this.connectionSeq;
     const ws = new this.webSocketCtor(url, {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
@@ -237,6 +259,15 @@ export class ControlChannel {
     await new Promise<void>((resolve, reject) => {
       const onOpen = (): void => {
         ws.removeListener("error", onError);
+        if (this.stopRequested || this.ws !== ws || connectionId !== this.connectionSeq) {
+          try {
+            ws.close(1000, "stale control-channel connection");
+          } catch {
+            // ignore
+          }
+          resolve();
+          return;
+        }
         this.connected = true;
         this.reconnectAttempts = 0;
         daemonLog.info("control-channel connected", { url });
@@ -245,14 +276,21 @@ export class ControlChannel {
       };
       const onError = (err: Error): void => {
         ws.removeListener("open", onOpen);
+        if (this.ws !== ws || connectionId !== this.connectionSeq) {
+          resolve();
+          return;
+        }
         reject(err);
       };
       ws.once("open", onOpen);
       ws.once("error", onError);
     });
 
-    ws.on("message", (data) => this.onMessage(data));
-    ws.on("close", (code, reason) => this.onClose(code, reason));
+    ws.on("message", (data) => {
+      if (this.ws !== ws || connectionId !== this.connectionSeq) return;
+      void this.onMessage(data);
+    });
+    ws.on("close", (code, reason) => this.onClose(code, reason, ws, connectionId));
     ws.on("error", (err) =>
       daemonLog.warn("control-channel error", {
         error: err instanceof Error ? err.message : String(err),
@@ -292,8 +330,12 @@ export class ControlChannel {
     }
   }
 
-  private onClose(code: number, reason: Buffer): void {
+  private onClose(code: number, reason: Buffer, ws?: WebSocket, connectionId?: number): void {
     const reasonText = reason?.toString() || "";
+    if (ws && (this.ws !== ws || connectionId !== this.connectionSeq)) {
+      daemonLog.debug("control-channel stale close ignored", { code, reason: reasonText });
+      return;
+    }
     this.connected = false;
     this.stopKeepalive();
     this.ws = null;
@@ -314,6 +356,14 @@ export class ControlChannel {
 
   private scheduleReconnect(err?: unknown): void {
     if (this.stopRequested) return;
+    if (this.reconnectTimer) return;
+    const current = this.ws;
+    if (
+      current &&
+      (current.readyState === WebSocket.CONNECTING || current.readyState === WebSocket.OPEN)
+    ) {
+      return;
+    }
     if (err instanceof AuthRefreshRejectedError) {
       this.stopRequested = true;
       daemonLog.warn("control-channel: refresh rejected; halting reconnect (re-login required)", {
@@ -323,20 +373,23 @@ export class ControlChannel {
     }
     const attempt = this.reconnectAttempts;
     this.reconnectAttempts = attempt + 1;
-    const delay = this.backoff[Math.min(attempt, this.backoff.length - 1)];
+    const baseDelayMs = this.backoff[Math.min(attempt, this.backoff.length - 1)];
+    const { delayMs, jitterMs } = withReconnectJitter(baseDelayMs);
     if (err) {
       daemonLog.warn("control-channel reconnect scheduled", {
-        delayMs: delay,
+        delayMs,
+        baseDelayMs,
+        jitterMs,
         error: err instanceof Error ? err.message : String(err),
       });
     } else {
-      daemonLog.info("control-channel reconnect scheduled", { delayMs: delay });
+      daemonLog.info("control-channel reconnect scheduled", { delayMs, baseDelayMs, jitterMs });
     }
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
       if (this.stopRequested) return;
       this.connect().catch((err) => this.scheduleReconnect(err));
-    }, delay);
+    }, delayMs);
   }
 
   private async onMessage(data: WebSocket.RawData): Promise<void> {

--- a/packages/daemon/src/gateway/channels/botcord.ts
+++ b/packages/daemon/src/gateway/channels/botcord.ts
@@ -25,6 +25,7 @@ import { sanitizeUntrustedContent } from "./sanitize.js";
 import { revokeAgent } from "../../provision.js";
 
 const RECONNECT_BACKOFF = [1000, 2000, 4000, 8000, 16000, 30000];
+const RECONNECT_JITTER_RATIO = 0.25;
 const KEEPALIVE_INTERVAL = 20_000;
 const MAX_AUTH_FAILURES = 5;
 const SEEN_MESSAGES_CAP = 500;
@@ -32,6 +33,11 @@ const OWNER_CHAT_PREFIX = "rm_oc_";
 const DM_ROOM_PREFIX = "rm_dm_";
 const INBOX_POLL_LIMIT = 50;
 const CHANNEL_PERMANENT_STOP = "channel_permanent_stop";
+
+function withReconnectJitter(delayMs: number): { delayMs: number; jitterMs: number } {
+  const jitterMs = Math.floor(Math.random() * delayMs * RECONNECT_JITTER_RATIO);
+  return { delayMs: delayMs + jitterMs, jitterMs };
+}
 
 type InboxDrainTrigger =
   | "ws_auth_ok"
@@ -477,6 +483,7 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
     let reconnectTimer: NodeJS.Timeout | null = null;
     let keepaliveTimer: NodeJS.Timeout | null = null;
     let reconnectAttempt = 0;
+    let connectionSeq = 0;
     let consecutiveAuthFailures = 0;
     let running = true;
     let permanentStopping = false;
@@ -603,23 +610,36 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
 
     function scheduleReconnect() {
       if (!running) return;
-      const delay =
+      if (reconnectTimer) return;
+      if (ws && (ws.readyState === WebSocket.CONNECTING || ws.readyState === WebSocket.OPEN)) {
+        return;
+      }
+      const baseDelayMs =
         RECONNECT_BACKOFF[Math.min(reconnectAttempt, RECONNECT_BACKOFF.length - 1)];
+      const { delayMs, jitterMs } = withReconnectJitter(baseDelayMs);
       reconnectAttempt += 1;
       markStatus({
         connected: false,
         restartPending: true,
         reconnectAttempts: reconnectAttempt,
       });
-      log.info("botcord ws reconnect scheduled", { delayMs: delay, attempt: reconnectAttempt });
+      log.info("botcord ws reconnect scheduled", {
+        delayMs,
+        baseDelayMs,
+        jitterMs,
+        attempt: reconnectAttempt,
+      });
       reconnectTimer = setTimeout(() => {
         reconnectTimer = null;
         void connect();
-      }, delay);
+      }, delayMs);
     }
 
     async function connect() {
       if (!running) return;
+      if (ws && (ws.readyState === WebSocket.CONNECTING || ws.readyState === WebSocket.OPEN)) {
+        return;
+      }
       const agentId = options.agentId;
       markStatus({ connected: false, restartPending: false });
       if (pendingRefresh) {
@@ -644,8 +664,11 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
       const url = buildHubWebSocketUrl(hubUrl);
       log.info("botcord ws connecting", { url, agentId });
 
+      const connectionId = ++connectionSeq;
+      let socket: WebSocket;
       try {
-        ws = new wsCtor(url);
+        socket = new wsCtor(url);
+        ws = socket;
       } catch (err) {
         log.error("botcord ws construct failed", { agentId, err: String(err) });
         markStatus({ lastError: String(err) });
@@ -653,11 +676,20 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
         return;
       }
 
-      ws.on("open", () => {
-        ws!.send(JSON.stringify({ type: "auth", token }));
+      socket.on("open", () => {
+        if (!running || ws !== socket || connectionId !== connectionSeq) {
+          try {
+            socket.close();
+          } catch {
+            // ignore
+          }
+          return;
+        }
+        socket.send(JSON.stringify({ type: "auth", token }));
       });
 
-      ws.on("message", (data: WebSocket.RawData) => {
+      socket.on("message", (data: WebSocket.RawData) => {
+        if (ws !== socket || connectionId !== connectionSeq) return;
         let msg: { type?: string; agent_id?: string } | null = null;
         try {
           msg = JSON.parse(String(data));
@@ -677,10 +709,11 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
           });
           log.info("botcord ws authenticated", { agentId: msg.agent_id });
           void fireInbox("ws_auth_ok");
+          if (keepaliveTimer) clearInterval(keepaliveTimer);
           keepaliveTimer = setInterval(() => {
-            if (ws && ws.readyState === WebSocket.OPEN) {
+            if (ws === socket && socket.readyState === WebSocket.OPEN) {
               try {
-                ws.send(JSON.stringify({ type: "ping" }));
+                socket.send(JSON.stringify({ type: "ping" }));
               } catch {
                 // ignore
               }
@@ -696,10 +729,15 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
         }
       });
 
-      ws.on("close", (code: number, reason: Buffer) => {
+      socket.on("close", (code: number, reason: Buffer) => {
         const reasonStr = reason?.toString() || "";
+        if (ws !== socket || connectionId !== connectionSeq) {
+          log.debug("botcord ws stale close ignored", { agentId, code, reason: reasonStr });
+          return;
+        }
         log.info("botcord ws closed", { agentId, code, reason: reasonStr });
         clearTimers();
+        ws = null;
         markStatus({ connected: false });
         if (!running) {
           if (permanentStopping) return;
@@ -740,7 +778,8 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
         scheduleReconnect();
       });
 
-      ws.on("error", (err: Error) => {
+      socket.on("error", (err: Error) => {
+        if (ws !== socket || connectionId !== connectionSeq) return;
         log.warn("botcord ws error", { agentId, err: String(err) });
         markStatus({ lastError: String(err) });
       });


### PR DESCRIPTION
## Summary
- add 0-25% jitter to daemon control-channel and BotCord agent websocket reconnect backoff
- coalesce duplicate reconnect scheduling so repeated close/error paths do not queue multiple timers
- guard websocket event handlers with connection generation checks so stale sockets cannot clear newer connection state
- add regression coverage for jittered reconnect scheduling and duplicate close coalescing

## Tests
- cd packages/daemon && npm test -- --run src/__tests__/control-channel.test.ts src/gateway/__tests__/botcord-channel.test.ts
- cd packages/daemon && npm test -- --run

## Notes
- cd packages/daemon && npx tsc --noEmit currently fails on existing test type errors unrelated to this change, including daemon-config-map.test.ts, runtime-discovery.test.ts, wechat-channel.test.ts, botcord-channel.test.ts fixture casts, dispatcher.test.ts, feishu-channel.test.ts, telegram-channel.test.ts, and transcript.test.ts.