### PR TITLE
fix: use configured avatars in contacts

### DIFF
--- a/frontend/src/components/dashboard/ContactsDetailPane.tsx
+++ b/frontend/src/components/dashboard/ContactsDetailPane.tsx
@@ -175,7 +175,7 @@ export default function ContactsDetailPane() {
     tag = { tone: "cyan", label: a.is_default ? t.myBotTagDefault : t.myBot };
     statusText = a.ws_online ? "● Online" : "● Offline";
     bio = a.bio ?? null;
-    avatar = <BotAvatar agentId={a.agent_id} size={96} alt={a.display_name} />;
+    avatar = <BotAvatar agentId={a.agent_id} avatarUrl={a.avatar_url} size={96} alt={a.display_name} />;
   } else if (target.kind === "agent-contact") {
     const c = target.contact;
     title = c.alias || c.display_name;
@@ -183,7 +183,7 @@ export default function ContactsDetailPane() {
     const ownerName = publicAgents.find((a) => a.agent_id === c.contact_agent_id)?.owner_display_name;
     tag = { tone: "gray", label: ownerName ? t.ownedBotOf(ownerName) : t.externalBot };
     statusText = c.online ? "● Online" : "● Offline";
-    avatar = <BotAvatar agentId={c.contact_agent_id} size={96} alt={c.display_name} />;
+    avatar = <BotAvatar agentId={c.contact_agent_id} avatarUrl={c.avatar_url} size={96} alt={c.display_name} />;
   } else if (target.kind === "human-contact") {
     const c = target.contact;
     title = c.alias || c.display_name;

--- a/frontend/src/components/dashboard/sidebar/ContactsPanel.tsx
+++ b/frontend/src/components/dashboard/sidebar/ContactsPanel.tsx
@@ -231,7 +231,7 @@ export default function ContactsPanel({ onOpenAddFriend }: ContactsPanelProps) {
           {ownedAgents.map((agent) => (
             <ListRow
               key={`owned-${agent.agent_id}`}
-              avatar={<BotAvatar agentId={agent.agent_id} size={32} alt={agent.display_name} />}
+              avatar={<BotAvatar agentId={agent.agent_id} avatarUrl={agent.avatar_url} size={32} alt={agent.display_name} />}
               name={agent.display_name}
               subtitle={agent.is_default ? t.myBotSubtitleDefault : t.myBotSubtitle}
               online={agent.ws_online}
@@ -246,7 +246,7 @@ export default function ContactsPanel({ onOpenAddFriend }: ContactsPanelProps) {
           {agentContacts.map((c) => (
             <ListRow
               key={`agent-${c.contact_agent_id}`}
-              avatar={<BotAvatar agentId={c.contact_agent_id} size={32} alt={c.display_name} />}
+              avatar={<BotAvatar agentId={c.contact_agent_id} avatarUrl={c.avatar_url} size={32} alt={c.display_name} />}
               name={c.alias || c.display_name}
               subtitle={c.alias ? c.display_name : c.contact_agent_id}
               online={c.online}


### PR DESCRIPTION
## Summary
- Pass configured bot avatar URLs through the Contacts sidebar rows
- Use configured avatar URLs in the Contacts detail pane for owned and external bots

## Tests
- npm run build (passes in existing main worktree with .env)
- npm run build (clean worktree reached prerender, then failed because Supabase env vars were absent)