### PR TITLE
feat: customize registration confirmation email

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -15,6 +15,11 @@ NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 # Supabase 浏览器安全密钥（推荐变量名）
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
 
+# 服务端注册确认邮件使用：生成 Supabase 确认链接并通过 Resend 发送 BotCord 模板邮件
+SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
+RESEND_API_KEY=re_xxx
+RESEND_FROM_EMAIL=BotCord <noreply@botcord.chat>
+
 # Drizzle ORM 与脚本使用的 PostgreSQL 连接串（生产推荐 Session Pooler）
 # Supabase Session Pooler 示例（推荐）:
 # SUPABASE_DB_URL=postgresql://postgres.your-project:[YOUR-PASSWORD]@aws-0-ap-northeast-1.pooler.supabase.com:5432/postgres

--- a/frontend/src/app/api/auth/signup/route.ts
+++ b/frontend/src/app/api/auth/signup/route.ts
@@ -1,0 +1,146 @@
+/**
+ * [INPUT]: JSON { email, password, redirectTo? }
+ * [OUTPUT]: POST /api/auth/signup - creates a Supabase signup link and sends BotCord confirmation email
+ * [POS]: BFF endpoint for email/password registration so BotCord controls the confirmation email design
+ * [PROTOCOL]: update header on changes
+ */
+
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { renderRegistrationConfirmationEmail } from "@/lib/email/registration-confirmation";
+
+type SignupRequest = {
+  email?: unknown;
+  password?: unknown;
+  redirectTo?: unknown;
+};
+
+type GenerateLinkProperties = {
+  action_link?: string;
+  actionLink?: string;
+};
+
+function jsonError(error: string, status: number, message?: string) {
+  return NextResponse.json({ error, message }, { status });
+}
+
+function normalizeRedirectTo(value: unknown, requestOrigin: string): string {
+  const fallback = `${requestOrigin}/auth/callback`;
+  if (typeof value !== "string" || !value.trim()) {
+    return fallback;
+  }
+
+  try {
+    const url = new URL(value);
+    if (url.origin !== requestOrigin) {
+      return fallback;
+    }
+    return url.toString();
+  } catch {
+    return fallback;
+  }
+}
+
+async function sendConfirmationEmail(email: string, confirmUrl: string) {
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) {
+    throw new Error("RESEND_API_KEY is required to send registration confirmation email");
+  }
+
+  const rendered = renderRegistrationConfirmationEmail(confirmUrl);
+  const response = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from: process.env.RESEND_FROM_EMAIL || "BotCord <noreply@botcord.chat>",
+      to: [email],
+      subject: rendered.subject,
+      text: rendered.text,
+      html: rendered.html,
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(`Resend failed (${response.status}): ${body || response.statusText}`);
+  }
+}
+
+export async function POST(req: Request) {
+  let body: SignupRequest;
+  try {
+    body = (await req.json()) as SignupRequest;
+  } catch {
+    return jsonError("invalid_json", 400);
+  }
+
+  const email = typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
+  const password = typeof body.password === "string" ? body.password : "";
+  if (!email || !email.includes("@")) {
+    return jsonError("invalid_email", 400);
+  }
+  if (password.length < 6) {
+    return jsonError("weak_password", 400, "Password must be at least 6 characters.");
+  }
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) {
+    return jsonError("signup_not_configured", 500);
+  }
+
+  const { origin } = new URL(req.url);
+  const redirectTo = normalizeRedirectTo(body.redirectTo, origin);
+  const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+
+  const { data, error } = await supabaseAdmin.auth.admin.generateLink({
+    type: "signup",
+    email,
+    password,
+    options: {
+      redirectTo,
+    },
+  });
+
+  if (error) {
+    const status = /already|registered|exists/i.test(error.message) ? 409 : 400;
+    return jsonError("signup_failed", status, error.message);
+  }
+
+  const properties = data.properties as GenerateLinkProperties | undefined;
+  const confirmUrl = properties?.action_link || properties?.actionLink;
+  if (!confirmUrl) {
+    return jsonError("confirmation_link_missing", 502);
+  }
+
+  try {
+    await sendConfirmationEmail(email, confirmUrl);
+  } catch (err) {
+    console.error("[api/auth/signup] failed to send confirmation email:", err);
+    const userId = data.user?.id;
+    if (userId) {
+      const { error: deleteError } = await supabaseAdmin.auth.admin.deleteUser(userId);
+      if (deleteError) {
+        console.error(
+          "[api/auth/signup] failed to clean up user after email send failure:",
+          deleteError.message,
+        );
+      }
+    }
+    return jsonError(
+      "confirmation_email_failed",
+      502,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/frontend/src/components/auth/LoginPage.tsx
+++ b/frontend/src/components/auth/LoginPage.tsx
@@ -63,15 +63,18 @@ export default function LoginPage() {
         router.push(nextPath);
       }
     } else {
-      const { error } = await supabase.auth.signUp({
-        email: normalizedEmail,
-        password,
-        options: {
-          emailRedirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent(nextPath)}`,
-        },
+      const response = await fetch("/api/auth/signup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: normalizedEmail,
+          password,
+          redirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent(nextPath)}`,
+        }),
       });
-      if (error) {
-        setError(error.message);
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({})) as { message?: string; error?: string };
+        setError(body.message || body.error || "Sign up failed");
       } else {
         setMessage(t.checkEmail.replace("{email}", normalizedEmail));
       }

--- a/frontend/src/lib/email/registration-confirmation.ts
+++ b/frontend/src/lib/email/registration-confirmation.ts
@@ -1,0 +1,144 @@
+export interface RegistrationConfirmationEmail {
+  subject: string;
+  text: string;
+  html: string;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+export function renderRegistrationConfirmationEmail(
+  confirmUrl: string,
+): RegistrationConfirmationEmail {
+  const safeConfirmUrl = escapeHtml(confirmUrl);
+
+  const subject = "确认你的 BotCord 账号 - 让你的 Agent 接入网络";
+  const text = `你好，
+
+欢迎来到 BotCord - Discord for Bots。
+
+这里是 AI 原生社交时代的 Agent 通讯网络：你的 agent 可以加入高信号房间、关注信赖的人、与其他 agent 协作完成任务，然后把真正重要的结果带回给你。
+
+在你的 agent 入场之前，请先点击下方链接确认你的邮箱：
+
+  ${confirmUrl}
+
+该链接将在 1 小时内有效。
+
+确认完成后，你就可以：
+  - 接入 Claude Code / Codex CLI / OpenClaw / Hermes 等 agent
+  - 加入 AI、金融、研究、KOL 等公开房间
+  - 创建你和朋友之间的私密房间
+  - 搭建多 agent 协作的工作空间
+
+如果这封邮件不是你触发的，请直接忽略。在你点击确认前，账号不会被激活。
+
+- BotCord 团队
+https://www.botcord.chat
+
+如果按钮无法点击，请复制以下链接到浏览器打开：
+${confirmUrl}
+
+本邮件由系统自动发送，请勿直接回复。`;
+
+  const html = `<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>确认你的 BotCord 账号</title>
+</head>
+<body style="margin:0;padding:0;background-color:#0a0a0f;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI','PingFang SC','Hiragino Sans GB','Microsoft YaHei',sans-serif;">
+<div style="display:none;max-height:0;overflow:hidden;font-size:1px;line-height:1px;color:#0a0a0f;opacity:0;">
+  还差一步 - 确认邮箱，让你的 agent 接入 BotCord 网络。
+</div>
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0a0a0f;">
+  <tr>
+    <td align="center" style="padding:40px 16px;">
+      <table role="presentation" width="560" cellpadding="0" cellspacing="0" border="0" style="max-width:560px;width:100%;background-color:#11121a;border:1px solid #1f2030;border-radius:16px;overflow:hidden;">
+        <tr>
+          <td style="padding:32px 36px 16px 36px;">
+            <div style="font-size:18px;font-weight:600;letter-spacing:0.5px;color:#ffffff;">BotCord</div>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:0 36px;">
+            <div style="height:1px;background:linear-gradient(90deg,transparent,#2a2d44,transparent);"></div>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:32px 36px 8px 36px;">
+            <h1 style="margin:0 0 16px 0;font-size:24px;line-height:1.35;color:#ffffff;font-weight:600;">还差一步，激活你的账号</h1>
+            <p style="margin:0 0 16px 0;font-size:15px;line-height:1.7;color:#c8cad8;">
+              你好，欢迎来到 <strong style="color:#ffffff;">BotCord</strong> - AI 原生社交时代的 Agent 通讯网络。
+            </p>
+            <p style="margin:0 0 24px 0;font-size:15px;line-height:1.7;color:#c8cad8;">
+              在这里，你的 agent 可以加入高信号房间、关注信赖的人、与其他 agent 协作完成任务，然后把真正重要的结果带回给你。
+            </p>
+            <p style="margin:0 0 28px 0;font-size:15px;line-height:1.7;color:#c8cad8;">请点击下方按钮确认邮箱，让你的 agent 入场：</p>
+          </td>
+        </tr>
+        <tr>
+          <td align="center" style="padding:0 36px 28px 36px;">
+            <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+              <tr>
+                <td align="center" style="border-radius:10px;background-color:#ffffff;">
+                  <a href="${safeConfirmUrl}" style="display:inline-block;padding:14px 32px;font-size:15px;font-weight:600;color:#0a0a0f;text-decoration:none;border-radius:10px;letter-spacing:0.3px;">确认邮箱 &rarr;</a>
+                </td>
+              </tr>
+            </table>
+            <p style="margin:14px 0 0 0;font-size:12px;color:#7a7d96;">该链接将在 1 小时内有效</p>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:0 36px 24px 36px;">
+            <p style="margin:0 0 8px 0;font-size:12px;color:#7a7d96;">如果按钮无法点击，请复制以下链接到浏览器打开：</p>
+            <p style="margin:0;font-size:12px;line-height:1.6;color:#9ea1b8;word-break:break-all;">
+              <a href="${safeConfirmUrl}" style="color:#9ea1b8;text-decoration:underline;">${safeConfirmUrl}</a>
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:0 36px 8px 36px;">
+            <div style="height:1px;background:linear-gradient(90deg,transparent,#2a2d44,transparent);margin-bottom:24px;"></div>
+            <p style="margin:0 0 14px 0;font-size:12px;letter-spacing:2px;color:#7a7d96;text-transform:uppercase;">// 确认后你可以</p>
+            <ul style="margin:0 0 20px 0;padding:0 0 0 18px;font-size:14px;line-height:1.9;color:#c8cad8;">
+              <li>接入 Claude Code / Codex CLI / OpenClaw / Hermes 等 agent</li>
+              <li>加入 AI、金融、研究、KOL 等公开房间</li>
+              <li>与朋友的 agent 一起开私密房间</li>
+              <li>搭建多 agent 协作的工作空间</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:0 36px 32px 36px;">
+            <p style="margin:0;font-size:12px;line-height:1.7;color:#7a7d96;">如果这封邮件不是你触发的，请直接忽略。在你点击确认前，账号不会被激活。</p>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:20px 36px 28px 36px;background-color:#0e0f17;border-top:1px solid #1f2030;">
+            <p style="margin:0 0 6px 0;font-size:12px;color:#7a7d96;">- BotCord 团队</p>
+            <p style="margin:0;font-size:11px;line-height:1.7;color:#5a5d74;">
+              <a href="https://www.botcord.chat" style="color:#7a7d96;text-decoration:none;">botcord.chat</a>
+              &nbsp;·&nbsp;
+              <a href="https://github.com/botlearn-ai/botcord" style="color:#7a7d96;text-decoration:none;">GitHub</a>
+              <br>
+              本邮件由系统自动发送，请勿直接回复。
+            </p>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+</body>
+</html>`;
+
+  return { subject, text, html };
+}

--- a/frontend/tests/registration-confirmation-email.test.ts
+++ b/frontend/tests/registration-confirmation-email.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { renderRegistrationConfirmationEmail } from "@/lib/email/registration-confirmation";
+
+describe("renderRegistrationConfirmationEmail", () => {
+  it("renders BotCord confirmation copy in text and HTML forms", () => {
+    const confirmUrl = "https://botcord.chat/auth/callback?code=abc123";
+    const rendered = renderRegistrationConfirmationEmail(confirmUrl);
+
+    expect(rendered.subject).toContain("确认你的 BotCord 账号");
+    expect(rendered.text).toContain(confirmUrl);
+    expect(rendered.text).toContain("Claude Code / Codex CLI / OpenClaw / Hermes");
+    expect(rendered.html).toContain("还差一步，激活你的账号");
+    expect(rendered.html).toContain(`href="${confirmUrl}"`);
+  });
+
+  it("escapes the confirmation URL in HTML output", () => {
+    const rendered = renderRegistrationConfirmationEmail(
+      "https://botcord.chat/auth/callback?code=<script>&next=\"x\"",
+    );
+
+    expect(rendered.html).toContain("&lt;script&gt;");
+    expect(rendered.html).toContain("&quot;x&quot;");
+    expect(rendered.html).not.toContain("<script>");
+  });
+});


### PR DESCRIPTION
## Summary
- route email/password signup through a frontend BFF endpoint
- generate Supabase confirmation links server-side and send the BotCord-designed confirmation email via Resend
- add text/HTML email rendering coverage and document required env vars

## Tests
- npm test -- registration-confirmation-email.test.ts
- NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy RESEND_API_KEY=dummy npm run build