### PR TITLE
feat: add dashboard multi-select component

### DIFF
--- a/frontend/src/components/dashboard/AddRoomMemberModal.tsx
+++ b/frontend/src/components/dashboard/AddRoomMemberModal.tsx
@@ -7,10 +7,11 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { Loader2, Search, X } from "lucide-react";
+import { Loader2, X } from "lucide-react";
 import { humansApi } from "@/lib/api";
 import { useLanguage } from "@/lib/i18n";
 import { agentBrowser } from "@/lib/i18n/translations/dashboard";
+import DashboardMultiSelect from "./DashboardMultiSelect";
 import type { ContactInfo, UserAgent } from "@/lib/types";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
@@ -44,7 +45,6 @@ export default function AddRoomMemberModal({
   const contacts = useDashboardChatStore((state) => state.overview?.contacts) ?? EMPTY_CONTACTS;
   const ownedAgents = useDashboardSessionStore((state) => state.ownedAgents) ?? EMPTY_AGENTS;
 
-  const [query, setQuery] = useState("");
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -72,26 +72,9 @@ export default function AddRoomMemberModal({
       });
     }
 
-    const normalized = query.trim().toLowerCase();
     return Array.from(merged.values())
-      .filter((candidate) => {
-        if (!normalized) return true;
-        return (
-          candidate.displayName.toLowerCase().includes(normalized)
-          || candidate.participantId.toLowerCase().includes(normalized)
-        );
-      })
       .sort((a, b) => a.displayName.localeCompare(b.displayName));
-  }, [contacts, existingMemberIds, ownedAgents, query]);
-
-  const toggleCandidate = (participantId: string) => {
-    setSelectedIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(participantId)) next.delete(participantId);
-      else next.add(participantId);
-      return next;
-    });
-  };
+  }, [contacts, existingMemberIds, ownedAgents]);
 
   const handleAddMembers = async () => {
     if (selectedIds.size === 0 || saving) return;
@@ -138,17 +121,6 @@ export default function AddRoomMemberModal({
             </div>
           ) : null}
 
-          <div className="flex items-center gap-2 rounded border border-glass-border bg-glass-bg px-3">
-            <Search className="h-4 w-4 text-text-secondary/70" />
-            <input
-              autoFocus
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder={t.searchAddableMembers}
-              className="w-full bg-transparent py-2.5 text-sm text-text-primary outline-none"
-            />
-          </div>
-
           <div className="flex items-center justify-between text-xs text-text-secondary">
             <span>{t.addMemberSelectableCount.replace("{count}", String(selectedIds.size))}</span>
             <span>{t.addMemberCandidateCount.replace("{count}", String(candidates.length))}</span>
@@ -159,43 +131,21 @@ export default function AddRoomMemberModal({
               {t.noAddableMembers}
             </div>
           ) : (
-            <div className="max-h-80 overflow-y-auto rounded border border-glass-border">
-              {candidates.map((candidate) => {
-                const checked = selectedIds.has(candidate.participantId);
-                return (
-                  <label
-                    key={candidate.participantId}
-                    className={`flex cursor-pointer items-center gap-3 border-b border-glass-border/60 px-4 py-3 text-sm last:border-b-0 ${
-                      checked ? "bg-neon-cyan/10" : "hover:bg-glass-bg"
-                    }`}
-                  >
-                    <input
-                      type="checkbox"
-                      checked={checked}
-                      onChange={() => toggleCandidate(candidate.participantId)}
-                      className="accent-neon-cyan"
-                    />
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-2">
-                        <span className="truncate text-text-primary">{candidate.displayName}</span>
-                        <span
-                          className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${
-                            candidate.source === "owned_agent"
-                              ? "bg-neon-cyan/10 text-neon-cyan"
-                              : "bg-neon-green/10 text-neon-green"
-                          }`}
-                        >
-                          {candidate.source === "owned_agent" ? t.addMemberSourceOwnedAgent : t.addMemberSourceFriend}
-                        </span>
-                      </div>
-                      <p className="mt-1 truncate font-mono text-[11px] text-text-secondary/70">
-                        {candidate.participantId}
-                      </p>
-                    </div>
-                  </label>
-                );
-              })}
-            </div>
+            <DashboardMultiSelect
+              value={Array.from(selectedIds)}
+              onChange={(next) => setSelectedIds(new Set(next))}
+              options={candidates.map((candidate) => ({
+                value: candidate.participantId,
+                label: candidate.displayName,
+                sublabel: candidate.participantId,
+                badge: candidate.source === "owned_agent" ? t.addMemberSourceOwnedAgent : t.addMemberSourceFriend,
+                tone: candidate.source === "owned_agent" ? "cyan" : "green",
+              }))}
+              placeholder={t.addMembersAction}
+              searchPlaceholder={t.searchAddableMembers}
+              emptyLabel={t.noAddableMembers}
+              selectedLabel={(count) => t.addMemberSelectableCount.replace("{count}", String(count))}
+            />
           )}
         </div>
 

--- a/frontend/src/components/dashboard/CreateRoomModal.tsx
+++ b/frontend/src/components/dashboard/CreateRoomModal.tsx
@@ -8,13 +8,14 @@
  */
 
 import { useMemo, useState } from "react";
-import { Loader2, Search } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { humansApi } from "@/lib/api";
 import { useLanguage } from "@/lib/i18n";
 import { common } from "@/lib/i18n/translations/common";
 import { createRoomModal } from "@/lib/i18n/translations/dashboard";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
+import DashboardMultiSelect, { type DashboardMultiSelectGroup } from "./DashboardMultiSelect";
 import type { ContactInfo, HumanRoomSummary } from "@/lib/types";
 
 const EMPTY_CONTACTS: ContactInfo[] = [];
@@ -44,37 +45,37 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [selected, setSelected] = useState<Set<string>>(new Set());
-  const [memberQuery, setMemberQuery] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const filteredContacts = useMemo(() => {
-    const q = memberQuery.trim().toLowerCase();
-    if (!q) return contacts;
-    return contacts.filter((c) =>
-      c.display_name.toLowerCase().includes(q) ||
-      c.contact_agent_id.toLowerCase().includes(q) ||
-      (c.alias ?? "").toLowerCase().includes(q),
-    );
-  }, [contacts, memberQuery]);
-
-  const filteredBots = useMemo(() => {
-    const q = memberQuery.trim().toLowerCase();
-    if (!q) return ownedAgents;
-    return ownedAgents.filter((a) =>
-      a.display_name.toLowerCase().includes(q) ||
-      a.agent_id.toLowerCase().includes(q),
-    );
-  }, [ownedAgents, memberQuery]);
-
-  function toggleMember(id: string) {
-    setSelected((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  }
+  const memberGroups = useMemo<DashboardMultiSelectGroup[]>(() => {
+    const groups: DashboardMultiSelectGroup[] = [];
+    if (ownedAgents.length > 0) {
+      groups.push({
+        label: t.myBotsLabel,
+        options: ownedAgents.map((agent) => ({
+          value: agent.agent_id,
+          label: agent.display_name,
+          sublabel: agent.agent_id,
+          badge: "Bot",
+          tone: "cyan",
+        })),
+      });
+    }
+    if (contacts.length > 0) {
+      groups.push({
+        label: t.contactsLabel,
+        options: contacts.map((contact) => ({
+          value: contact.contact_agent_id,
+          label: contact.alias || contact.display_name,
+          sublabel: contact.contact_agent_id,
+          badge: "Contact",
+          tone: "green",
+        })),
+      });
+    }
+    return groups;
+  }, [contacts, ownedAgents, t.contactsLabel, t.myBotsLabel]);
 
   async function handleCreate() {
     const trimmed = name.trim();
@@ -172,97 +173,15 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
                   {t.noContacts}
                 </p>
               ) : (
-                <>
-                  <div className="mb-2 flex items-center gap-2 rounded border border-glass-border bg-glass-bg px-2">
-                    <Search className="h-3.5 w-3.5 text-text-secondary/70" />
-                    <input
-                      value={memberQuery}
-                      onChange={(e) => setMemberQuery(e.target.value)}
-                      placeholder={t.searchMembers}
-                      className="w-full bg-transparent py-1.5 text-xs text-text-primary outline-none"
-                    />
-                  </div>
-
-                  {ownedAgents.length > 0 && (
-                    <div className="mb-2">
-                      <p className="mb-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-text-secondary/60">
-                        {t.myBotsLabel}
-                      </p>
-                      <div className="max-h-40 overflow-y-auto rounded border border-glass-border">
-                        {filteredBots.length === 0 ? (
-                          <p className="px-3 py-2 text-[11px] text-text-secondary/60">
-                            {t.noBotsMatch}
-                          </p>
-                        ) : (
-                          filteredBots.map((a) => {
-                            const checked = selected.has(a.agent_id);
-                            return (
-                              <label
-                                key={a.agent_id}
-                                className={`flex cursor-pointer items-center gap-2 border-b border-glass-border/60 px-3 py-2 text-xs last:border-b-0 ${
-                                  checked ? "bg-neon-cyan/10" : "hover:bg-glass-bg"
-                                }`}
-                              >
-                                <input
-                                  type="checkbox"
-                                  checked={checked}
-                                  onChange={() => toggleMember(a.agent_id)}
-                                  className="accent-neon-cyan"
-                                />
-                                <span className="flex-1 truncate text-text-primary">
-                                  {a.display_name}
-                                </span>
-                                <span className="font-mono text-[10px] text-text-secondary/70">
-                                  {a.agent_id}
-                                </span>
-                              </label>
-                            );
-                          })
-                        )}
-                      </div>
-                    </div>
-                  )}
-
-                  {contacts.length > 0 && (
-                    <div>
-                      <p className="mb-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-text-secondary/60">
-                        {t.contactsLabel}
-                      </p>
-                      <div className="max-h-40 overflow-y-auto rounded border border-glass-border">
-                        {filteredContacts.length === 0 ? (
-                          <p className="px-3 py-2 text-[11px] text-text-secondary/60">
-                            {t.noContactsMatch}
-                          </p>
-                        ) : (
-                          filteredContacts.map((c: ContactInfo) => {
-                            const checked = selected.has(c.contact_agent_id);
-                            return (
-                              <label
-                                key={c.contact_agent_id}
-                                className={`flex cursor-pointer items-center gap-2 border-b border-glass-border/60 px-3 py-2 text-xs last:border-b-0 ${
-                                  checked ? "bg-neon-cyan/10" : "hover:bg-glass-bg"
-                                }`}
-                              >
-                                <input
-                                  type="checkbox"
-                                  checked={checked}
-                                  onChange={() => toggleMember(c.contact_agent_id)}
-                                  className="accent-neon-cyan"
-                                />
-                                <span className="flex-1 truncate text-text-primary">
-                                  {c.alias || c.display_name}
-                                </span>
-                                <span className="font-mono text-[10px] text-text-secondary/70">
-                                  {c.contact_agent_id}
-                                </span>
-                              </label>
-                            );
-                          })
-                        )}
-                      </div>
-                    </div>
-                  )}
-                </>
+                <DashboardMultiSelect
+                  value={Array.from(selected)}
+                  onChange={(next) => setSelected(new Set(next))}
+                  groups={memberGroups}
+                  placeholder={t.membersLabel}
+                  searchPlaceholder={t.searchMembers}
+                  emptyLabel={`${t.noBotsMatch} ${t.noContactsMatch}`}
+                  selectedLabel={(count) => (count > 0 ? `${count} ${t.selected}` : t.selected)}
+                />
               )}
             </div>
           </section>

--- a/frontend/src/components/dashboard/DashboardMultiSelect.tsx
+++ b/frontend/src/components/dashboard/DashboardMultiSelect.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+/**
+ * [INPUT]: 受控的 option/value/onChange 与可选分组、搜索文案
+ * [OUTPUT]: 对外提供 DashboardMultiSelect，渲染 BotCord dashboard 风格的可搜索多选下拉
+ * [POS]: dashboard 表单和弹窗里的统一多选控件，替代分散的原生/临时多选列表
+ * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
+ */
+
+import { type ReactNode, useEffect, useId, useMemo, useRef, useState } from "react";
+import { Check, ChevronDown, Search, X } from "lucide-react";
+
+export interface DashboardMultiSelectOption {
+  value: string;
+  label: string;
+  sublabel?: string;
+  badge?: string;
+  tone?: "cyan" | "green" | "purple" | "zinc";
+  icon?: ReactNode;
+}
+
+export interface DashboardMultiSelectGroup {
+  label?: string;
+  options: DashboardMultiSelectOption[];
+}
+
+interface DashboardMultiSelectProps {
+  value: string[];
+  onChange: (value: string[]) => void;
+  groups?: DashboardMultiSelectGroup[];
+  options?: DashboardMultiSelectOption[];
+  placeholder: string;
+  searchPlaceholder: string;
+  emptyLabel: string;
+  selectedLabel?: (count: number) => string;
+  disabled?: boolean;
+  className?: string;
+  panelClassName?: string;
+}
+
+const toneClasses = {
+  cyan: "bg-neon-cyan/10 text-neon-cyan",
+  green: "bg-neon-green/10 text-neon-green",
+  purple: "bg-neon-purple/10 text-neon-purple",
+  zinc: "bg-zinc-700/50 text-zinc-300",
+};
+
+export default function DashboardMultiSelect({
+  value,
+  onChange,
+  groups,
+  options,
+  placeholder,
+  searchPlaceholder,
+  emptyLabel,
+  selectedLabel = (count) => `${count} selected`,
+  disabled = false,
+  className = "",
+  panelClassName = "",
+}: DashboardMultiSelectProps) {
+  const id = useId();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  const normalizedGroups = useMemo<DashboardMultiSelectGroup[]>(() => {
+    if (groups) return groups;
+    return [{ options: options ?? [] }];
+  }, [groups, options]);
+
+  const selectedSet = useMemo(() => new Set(value), [value]);
+  const optionByValue = useMemo(() => {
+    const map = new Map<string, DashboardMultiSelectOption>();
+    for (const group of normalizedGroups) {
+      for (const option of group.options) map.set(option.value, option);
+    }
+    return map;
+  }, [normalizedGroups]);
+
+  const selectedOptions = value
+    .map((selectedValue) => optionByValue.get(selectedValue))
+    .filter((option): option is DashboardMultiSelectOption => Boolean(option));
+
+  const filteredGroups = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return normalizedGroups;
+    return normalizedGroups
+      .map((group) => ({
+        ...group,
+        options: group.options.filter((option) => {
+          return (
+            option.label.toLowerCase().includes(q) ||
+            option.sublabel?.toLowerCase().includes(q) ||
+            option.badge?.toLowerCase().includes(q)
+          );
+        }),
+      }))
+      .filter((group) => group.options.length > 0);
+  }, [normalizedGroups, query]);
+
+  const visibleCount = filteredGroups.reduce((sum, group) => sum + group.options.length, 0);
+
+  useEffect(() => {
+    if (!open) return;
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (open) window.setTimeout(() => searchRef.current?.focus(), 0);
+    else setQuery("");
+  }, [open]);
+
+  const toggle = (optionValue: string) => {
+    const next = new Set(selectedSet);
+    if (next.has(optionValue)) next.delete(optionValue);
+    else next.add(optionValue);
+    onChange(Array.from(next));
+  };
+
+  const clear = () => onChange([]);
+
+  return (
+    <div ref={rootRef} className={`relative ${className}`}>
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => setOpen((next) => !next)}
+        className="flex min-h-11 w-full items-center justify-between gap-3 rounded-lg border border-glass-border bg-glass-bg px-3 py-2 text-left text-sm text-text-primary transition-colors hover:border-neon-cyan/30 disabled:cursor-not-allowed disabled:opacity-50"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={`${id}-panel`}
+      >
+        <span className="min-w-0 flex-1">
+          {selectedOptions.length === 0 ? (
+            <span className="text-text-secondary/70">{placeholder}</span>
+          ) : (
+            <span className="flex min-w-0 flex-wrap gap-1.5">
+              {selectedOptions.slice(0, 3).map((option) => (
+                <span
+                  key={option.value}
+                  className="max-w-[11rem] truncate rounded border border-neon-cyan/20 bg-neon-cyan/10 px-2 py-0.5 text-xs text-neon-cyan"
+                >
+                  {option.label}
+                </span>
+              ))}
+              {selectedOptions.length > 3 ? (
+                <span className="rounded border border-glass-border bg-deep-black-light px-2 py-0.5 text-xs text-text-secondary">
+                  +{selectedOptions.length - 3}
+                </span>
+              ) : null}
+            </span>
+          )}
+        </span>
+        <span className="flex shrink-0 items-center gap-2">
+          <span className="text-[11px] text-text-secondary">{selectedLabel(selectedOptions.length)}</span>
+          <ChevronDown className={`h-4 w-4 text-text-secondary transition-transform ${open ? "rotate-180" : ""}`} />
+        </span>
+      </button>
+
+      {open ? (
+        <div
+          id={`${id}-panel`}
+          className={`absolute left-0 right-0 z-40 mt-2 overflow-hidden rounded-xl border border-glass-border bg-deep-black-light shadow-2xl shadow-black/40 ${panelClassName}`}
+        >
+          <div className="border-b border-glass-border p-2">
+            <div className="flex items-center gap-2 rounded-lg border border-glass-border bg-deep-black px-2.5">
+              <Search className="h-3.5 w-3.5 text-text-secondary/70" />
+              <input
+                ref={searchRef}
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder={searchPlaceholder}
+                className="w-full bg-transparent py-2 text-xs text-text-primary outline-none placeholder:text-text-secondary/50"
+              />
+              {value.length > 0 ? (
+                <button
+                  type="button"
+                  onClick={clear}
+                  className="rounded p-1 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
+                  aria-label="Clear selected"
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="max-h-72 overflow-y-auto py-1" role="listbox" aria-multiselectable="true">
+            {visibleCount === 0 ? (
+              <p className="px-3 py-6 text-center text-xs text-text-secondary/70">{emptyLabel}</p>
+            ) : (
+              filteredGroups.map((group, groupIndex) => (
+                <div key={group.label ?? groupIndex} className="py-1">
+                  {group.label ? (
+                    <p className="px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-text-secondary/60">
+                      {group.label}
+                    </p>
+                  ) : null}
+                  {group.options.map((option) => {
+                    const selected = selectedSet.has(option.value);
+                    return (
+                      <button
+                        key={option.value}
+                        type="button"
+                        role="option"
+                        aria-selected={selected}
+                        onClick={() => toggle(option.value)}
+                        className={`flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors ${
+                          selected ? "bg-neon-cyan/10 text-neon-cyan" : "text-text-primary hover:bg-glass-bg"
+                        }`}
+                      >
+                        <span
+                          className={`flex h-4 w-4 shrink-0 items-center justify-center rounded border ${
+                            selected
+                              ? "border-neon-cyan bg-neon-cyan text-deep-black"
+                              : "border-glass-border bg-deep-black-light"
+                          }`}
+                        >
+                          {selected ? <Check className="h-3 w-3" /> : null}
+                        </span>
+                        {option.icon ? <span className="shrink-0">{option.icon}</span> : null}
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate text-xs font-medium">{option.label}</span>
+                          {option.sublabel ? (
+                            <span className="mt-0.5 block truncate font-mono text-[10px] text-text-secondary/70">
+                              {option.sublabel}
+                            </span>
+                          ) : null}
+                        </span>
+                        {option.badge ? (
+                          <span
+                            className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${
+                              toneClasses[option.tone ?? "zinc"]
+                            }`}
+                          >
+                            {option.badge}
+                          </span>
+                        ) : null}
+                      </button>
+                    );
+                  })}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/ForwardModal.tsx
+++ b/frontend/src/components/dashboard/ForwardModal.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { Check, FileArchive, Loader2, MessageSquare, Search, Users, User, X } from "lucide-react";
+import { FileArchive, Loader2, MessageSquare, Users, User, X } from "lucide-react";
 import { api, getActiveIdentity } from "@/lib/api";
 import type { Attachment } from "@/lib/types";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
+import DashboardMultiSelect from "./DashboardMultiSelect";
 import { useShallow } from "zustand/react/shallow";
 
 interface ForwardTarget {
@@ -33,7 +34,6 @@ export default function ForwardModal({ quoteText, sourceFile, onClose }: Forward
   const [sending, setSending] = useState(false);
   const [done, setDone] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [query, setQuery] = useState("");
   const router = useRouter();
   const { setOpenedRoomId } = useDashboardUIStore(useShallow((s) => ({ setOpenedRoomId: s.setOpenedRoomId })));
 
@@ -66,24 +66,6 @@ export default function ForwardModal({ quoteText, sourceFile, onClose }: Forward
         sublabel: r.room_id,
       })),
   ];
-
-  const targets = useMemo(() => {
-    if (!query.trim()) return allTargets;
-    const q = query.toLowerCase();
-    return allTargets.filter(
-      (t) => t.label.toLowerCase().includes(q) || t.sublabel?.toLowerCase().includes(q)
-    );
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [query, allTargets.length]);
-
-  const toggle = (id: string) => {
-    setSelected((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  };
 
   const handleSend = async () => {
     if (selected.size === 0 || sending) return;
@@ -161,19 +143,6 @@ export default function ForwardModal({ quoteText, sourceFile, onClose }: Forward
           </button>
         </div>
 
-        {/* Search */}
-        <div className="relative mx-4 mt-3">
-          <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-zinc-500 pointer-events-none" />
-          <input
-            type="text"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="搜索联系人或房间..."
-            className="w-full rounded-lg border border-zinc-700 bg-zinc-800 py-1.5 pl-8 pr-3 text-xs text-zinc-200 placeholder-zinc-500 focus:border-cyan-500/50 focus:outline-none"
-            autoFocus
-          />
-        </div>
-
         {/* Quote / file preview */}
         <div className="mx-4 mt-3 rounded-lg border border-zinc-700 bg-zinc-800/60 px-3 py-2">
           {sourceFile ? (
@@ -193,37 +162,35 @@ export default function ForwardModal({ quoteText, sourceFile, onClose }: Forward
           )}
         </div>
 
-        {/* Target list */}
-        <div className="max-h-64 overflow-y-auto px-4 py-2 space-y-1">
-          {targets.length === 0 && (
-            <p className="py-6 text-center text-xs text-zinc-500">暂无可用目标</p>
-          )}
-          {targets.map((t) => {
-            const isSelected = selected.has(t.id);
-            return (
-              <button
-                key={t.id}
-                type="button"
-                onClick={() => toggle(t.id)}
-                className={`flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left transition-colors ${
-                  isSelected ? "bg-cyan-500/15 text-cyan-200" : "text-zinc-300 hover:bg-zinc-800"
-                }`}
-              >
-                {t.kind === "room" ? (
-                  <Users className="h-3.5 w-3.5 shrink-0 text-neon-purple/70" />
-                ) : t.kind === "agent" ? (
-                  <MessageSquare className="h-3.5 w-3.5 shrink-0 text-neon-cyan/70" />
-                ) : (
-                  <User className="h-3.5 w-3.5 shrink-0 text-neon-green/70" />
-                )}
-                <span className="flex-1 truncate text-xs font-medium">{t.label}</span>
-                {t.sublabel && (
-                  <span className="shrink-0 font-mono text-[10px] text-zinc-500 truncate max-w-[100px]">{t.sublabel}</span>
-                )}
-                {isSelected && <Check className="h-3.5 w-3.5 shrink-0 text-cyan-400" />}
-              </button>
-            );
-          })}
+        {/* Target selector */}
+        <div className="px-4 py-3">
+          <DashboardMultiSelect
+            value={Array.from(selected)}
+            onChange={(next) => setSelected(new Set(next))}
+            placeholder="选择发送目标"
+            searchPlaceholder="搜索联系人或房间..."
+            emptyLabel="暂无可用目标"
+            selectedLabel={(count) => (count > 0 ? `已选 ${count} 个` : "未选择")}
+            groups={[
+              {
+                options: allTargets.map((target) => ({
+                  value: target.id,
+                  label: target.label,
+                  sublabel: target.sublabel,
+                  badge: target.kind === "room" ? "Room" : target.kind === "agent" ? "Bot" : "Contact",
+                  tone: target.kind === "room" ? "purple" : target.kind === "agent" ? "cyan" : "green",
+                  icon:
+                    target.kind === "room" ? (
+                      <Users className="h-3.5 w-3.5 text-neon-purple/70" />
+                    ) : target.kind === "agent" ? (
+                      <MessageSquare className="h-3.5 w-3.5 text-neon-cyan/70" />
+                    ) : (
+                      <User className="h-3.5 w-3.5 text-neon-green/70" />
+                    ),
+                })),
+              },
+            ]}
+          />
         </div>
 
         {/* Footer */}


### PR DESCRIPTION
## Summary
- add a reusable BotCord-styled DashboardMultiSelect with search, grouped options, badges, and clear support
- replace scattered dashboard multi-select lists in create room, add room member, and forward message flows
- keep existing selection payloads unchanged while removing duplicated checkbox/search UI

## Tests
- cd frontend && npm run build