### PR TITLE
feat(frontend): integrate Google Analytics 4

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -47,3 +47,7 @@ NEXT_PUBLIC_BETA_GATE_ENABLED=false
 
 # 绑定凭证签名密钥（用于一次性绑定票据）
 BIND_PROOF_SECRET=replace-with-long-random-secret
+
+# Google Analytics 4 测量 ID（留空则不加载 GA 脚本，开发环境通常留空）
+# 形如 G-XXXXXXXXXX
+NEXT_PUBLIC_GA_ID=

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -202,4 +202,12 @@ STRIPE_TOPUP_CURRENCY=usd
 STRIPE_TOPUP_PACKAGES=[...]
 BIND_PROOF_SECRET=...
 SHOW_MESSAGE_STATUS=true
+NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX   # Google Analytics 4 measurement ID; leave empty to disable
 ```
+
+## Analytics
+
+The site exposes two parallel analytics pipelines, both wired in `src/app/layout.tsx`:
+
+- **Vercel Analytics** (`@vercel/analytics/next`): zero-config, always on in production.
+- **Google Analytics 4** (`src/components/analytics/GoogleAnalytics.tsx` + `src/lib/analytics.ts`): loads `gtag.js` via `next/script` only when `NEXT_PUBLIC_GA_ID` is set; ships with App Router page-view tracking via `usePathname` + `useSearchParams`. Use the helpers in `src/lib/analytics.ts` (`trackEvent`, `trackPageView`, `setUserId`, `setUserProperties`) for custom event instrumentation — they no-op when GA is disabled, so call sites do not need to guard.

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -10,6 +10,7 @@ import { Analytics } from "@vercel/analytics/next";
 import NextTopLoader from "nextjs-toploader";
 import { inter, jetbrainsMono } from "@/lib/fonts";
 import { getAppBaseUrl } from "@/lib/share-metadata";
+import { GoogleAnalytics } from "@/components/analytics/GoogleAnalytics";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -55,6 +56,7 @@ export default function RootLayout({
         />
         {children}
         <Analytics />
+        <GoogleAnalytics />
       </body>
     </html>
   );

--- a/frontend/src/components/analytics/GoogleAnalytics.tsx
+++ b/frontend/src/components/analytics/GoogleAnalytics.tsx
@@ -1,0 +1,52 @@
+/**
+ * [INPUT]: 读取 NEXT_PUBLIC_GA_ID 环境变量，依赖 next/script 注入 gtag.js
+ * [OUTPUT]: 向 <head> 注入 GA4 脚本并暴露 window.gtag；监听 App Router 路由变化触发 page_view
+ * [POS]: 由 RootLayout 装载的全局组件；ID 缺失时整组件渲染为 null（生产保险丝）
+ */
+
+"use client";
+
+import Script from "next/script";
+import { usePathname, useSearchParams } from "next/navigation";
+import { Suspense, useEffect, type ReactNode } from "react";
+
+const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
+
+function RouteChangeTracker({ measurementId }: { measurementId: string }) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (typeof window.gtag !== "function") return;
+    const query = searchParams?.toString();
+    const url = query ? `${pathname}?${query}` : pathname;
+    window.gtag("config", measurementId, { page_path: url });
+  }, [pathname, searchParams, measurementId]);
+
+  return null;
+}
+
+export function GoogleAnalytics(): ReactNode {
+  if (!GA_ID) return null;
+
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
+        strategy="afterInteractive"
+      />
+      <Script id="ga4-init" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          window.gtag = gtag;
+          gtag('js', new Date());
+          gtag('config', '${GA_ID}', { send_page_view: false });
+        `}
+      </Script>
+      <Suspense fallback={null}>
+        <RouteChangeTracker measurementId={GA_ID} />
+      </Suspense>
+    </>
+  );
+}

--- a/frontend/src/components/analytics/GoogleAnalytics.tsx
+++ b/frontend/src/components/analytics/GoogleAnalytics.tsx
@@ -1,51 +1,57 @@
 /**
  * [INPUT]: 读取 NEXT_PUBLIC_GA_ID 环境变量，依赖 next/script 注入 gtag.js
- * [OUTPUT]: 向 <head> 注入 GA4 脚本并暴露 window.gtag；监听 App Router 路由变化触发 page_view
- * [POS]: 由 RootLayout 装载的全局组件；ID 缺失时整组件渲染为 null（生产保险丝）
+ * [OUTPUT]: 在 body 末尾挂载 GA4 脚本并暴露 window.dataLayer/gtag；监听 App Router 路由变化触发 page_view
+ * [POS]: 由 RootLayout 装载的全局组件；ID 缺失或格式非法时整组件渲染为 null（生产保险丝）
  */
 
 "use client";
 
 import Script from "next/script";
 import { usePathname, useSearchParams } from "next/navigation";
-import { Suspense, useEffect, type ReactNode } from "react";
+import { Suspense, useEffect } from "react";
+import { trackPageView } from "@/lib/analytics";
 
-const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
+const RAW_GA_ID = process.env.NEXT_PUBLIC_GA_ID;
+const GA_ID_PATTERN = /^G-[A-Z0-9]{4,20}$/;
+const GA_ID = RAW_GA_ID && GA_ID_PATTERN.test(RAW_GA_ID) ? RAW_GA_ID : null;
 
-function RouteChangeTracker({ measurementId }: { measurementId: string }) {
+function RouteChangeTracker() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
   useEffect(() => {
-    if (typeof window.gtag !== "function") return;
     const query = searchParams?.toString();
     const url = query ? `${pathname}?${query}` : pathname;
-    window.gtag("config", measurementId, { page_path: url });
-  }, [pathname, searchParams, measurementId]);
+    trackPageView(url);
+  }, [pathname, searchParams]);
 
   return null;
 }
 
-export function GoogleAnalytics(): ReactNode {
+export function GoogleAnalytics() {
   if (!GA_ID) return null;
+
+  const initScript = `
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    window.gtag = gtag;
+    gtag('js', new Date());
+    gtag('config', ${JSON.stringify(GA_ID)}, { send_page_view: false });
+  `;
 
   return (
     <>
       <Script
-        src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
+        src={`https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(GA_ID)}`}
         strategy="afterInteractive"
       />
-      <Script id="ga4-init" strategy="afterInteractive">
-        {`
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          window.gtag = gtag;
-          gtag('js', new Date());
-          gtag('config', '${GA_ID}', { send_page_view: false });
-        `}
-      </Script>
+      <Script
+        id="ga4-init"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{ __html: initScript }}
+      />
       <Suspense fallback={null}>
-        <RouteChangeTracker measurementId={GA_ID} />
+        <RouteChangeTracker />
       </Suspense>
     </>
   );

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -1,0 +1,50 @@
+/**
+ * [INPUT]: 依赖 window.gtag 全局函数（由 GoogleAnalytics 组件注入）
+ * [OUTPUT]: 暴露 trackEvent / trackPageView 等帮助函数，供业务组件埋点
+ * [POS]: 全站统一的 GA4 事件埋点入口；未配置 NEXT_PUBLIC_GA_ID 时所有函数为 no-op
+ */
+
+declare global {
+  interface Window {
+    gtag?: (
+      command: "config" | "event" | "set" | "consent" | "js",
+      targetId: string | Date,
+      params?: Record<string, unknown>,
+    ) => void;
+    dataLayer?: unknown[];
+  }
+}
+
+export const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_ID ?? "";
+
+export const isGAEnabled = (): boolean =>
+  typeof window !== "undefined" &&
+  GA_MEASUREMENT_ID.length > 0 &&
+  typeof window.gtag === "function";
+
+export function trackPageView(url: string): void {
+  if (!isGAEnabled()) return;
+  window.gtag!("config", GA_MEASUREMENT_ID, {
+    page_path: url,
+  });
+}
+
+export function trackEvent(
+  action: string,
+  params: Record<string, unknown> = {},
+): void {
+  if (!isGAEnabled()) return;
+  window.gtag!("event", action, params);
+}
+
+export function setUserId(userId: string | null): void {
+  if (!isGAEnabled()) return;
+  window.gtag!("set", GA_MEASUREMENT_ID, {
+    user_id: userId ?? undefined,
+  });
+}
+
+export function setUserProperties(props: Record<string, unknown>): void {
+  if (!isGAEnabled()) return;
+  window.gtag!("set", "user_properties", props);
+}

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -1,16 +1,20 @@
 /**
- * [INPUT]: 依赖 window.gtag 全局函数（由 GoogleAnalytics 组件注入）
+ * [INPUT]: 依赖 window.dataLayer 队列（由 GoogleAnalytics 组件在页面早期注入）
  * [OUTPUT]: 暴露 trackEvent / trackPageView 等帮助函数，供业务组件埋点
  * [POS]: 全站统一的 GA4 事件埋点入口；未配置 NEXT_PUBLIC_GA_ID 时所有函数为 no-op
  */
 
+type GtagArgs =
+  | ["js", Date]
+  | ["config", string, Record<string, unknown>?]
+  | ["event", string, Record<string, unknown>?]
+  | ["set", Record<string, unknown>]
+  | ["set", string, Record<string, unknown>]
+  | ["consent", "default" | "update", Record<string, unknown>];
+
 declare global {
   interface Window {
-    gtag?: (
-      command: "config" | "event" | "set" | "consent" | "js",
-      targetId: string | Date,
-      params?: Record<string, unknown>,
-    ) => void;
+    gtag?: (...args: GtagArgs) => void;
     dataLayer?: unknown[];
   }
 }
@@ -18,33 +22,33 @@ declare global {
 export const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_ID ?? "";
 
 export const isGAEnabled = (): boolean =>
-  typeof window !== "undefined" &&
-  GA_MEASUREMENT_ID.length > 0 &&
-  typeof window.gtag === "function";
+  typeof window !== "undefined" && GA_MEASUREMENT_ID.length > 0;
+
+/**
+ * Push directly to dataLayer instead of calling window.gtag, so events
+ * fired before gtag.js loads are queued and replayed on load.
+ */
+function dlPush(args: GtagArgs): void {
+  if (!isGAEnabled()) return;
+  window.dataLayer = window.dataLayer ?? [];
+  window.dataLayer.push(args);
+}
 
 export function trackPageView(url: string): void {
-  if (!isGAEnabled()) return;
-  window.gtag!("config", GA_MEASUREMENT_ID, {
-    page_path: url,
-  });
+  dlPush(["config", GA_MEASUREMENT_ID, { page_path: url }]);
 }
 
 export function trackEvent(
   action: string,
   params: Record<string, unknown> = {},
 ): void {
-  if (!isGAEnabled()) return;
-  window.gtag!("event", action, params);
+  dlPush(["event", action, params]);
 }
 
 export function setUserId(userId: string | null): void {
-  if (!isGAEnabled()) return;
-  window.gtag!("set", GA_MEASUREMENT_ID, {
-    user_id: userId ?? undefined,
-  });
+  dlPush(["config", GA_MEASUREMENT_ID, { user_id: userId ?? undefined }]);
 }
 
 export function setUserProperties(props: Record<string, unknown>): void {
-  if (!isGAEnabled()) return;
-  window.gtag!("set", "user_properties", props);
+  dlPush(["set", "user_properties", props]);
 }


### PR DESCRIPTION
Re-opens https://github.com/botlearn-ai/botcord/pull/659 (closed). Two commits on the branch:

1. `ce9f794` feat(frontend): integrate Google Analytics 4
2. `ac0e732` fix(frontend): address Copilot review on GA4 integration

## Summary
- Wire GA4 into the root layout via `next/script`, gated on `NEXT_PUBLIC_GA_ID` (no-op when unset or shape invalid).
- App Router page-view tracking through `usePathname` + `useSearchParams`; events go through `window.dataLayer` so hits fired before `gtag.js` loads are queued and replayed.
- Typed `src/lib/analytics.ts` helper (`trackEvent`, `trackPageView`, `setUserId`, `setUserProperties`) with discriminated `GtagArgs` covering `js / config / event / set / consent`.
- `setUserId` uses scoped `gtag('config', id, { user_id })` — the original `gtag('set', id, ...)` form was an invalid gtag API.
- Inline init script: `JSON.stringify` the GA ID and `encodeURIComponent` the gtag.js URL; regex-validate `^G-[A-Z0-9]{4,20}$` before rendering anything (XSS hardening per review).
- Docs: `frontend/.env.example` and `frontend/CLAUDE.md` updated.

Env var `NEXT_PUBLIC_GA_ID = G-DFSCW1X3WM` already provisioned on Vercel for Production only (Preview/Development intentionally excluded so dev traffic does not pollute the GA report).

## Test plan
- [x] `tsc --noEmit` clean on new files; pre-existing repo errors are unrelated.
- [x] `pnpm build` compile + TypeScript pass with a test GA ID; bundle contains `googletagmanager.com/gtag/js?id=` and the ID.
- [ ] After merge, verify on www.botcord.chat: GA4 Realtime shows traffic and DevTools Network shows `collect?v=2` on each route change.

## Follow-ups (out of scope, will track)
- Add `analytics.test.ts` covering no-op behavior + dataLayer push assertions.
- Instrument funnel events (signup, agent creation, message send, wallet topup).
- Bump GA4 data retention 2 → 14 months in console.
- If/when EU traffic grows: wire Consent Mode v2.