### PR TITLE
fix(frontend): address Copilot review on GA4 integration

### DIFF
--- a/frontend/src/components/analytics/GoogleAnalytics.tsx
+++ b/frontend/src/components/analytics/GoogleAnalytics.tsx
@@ -1,51 +1,57 @@
 /**
  * [INPUT]: 读取 NEXT_PUBLIC_GA_ID 环境变量，依赖 next/script 注入 gtag.js
- * [OUTPUT]: 向 <head> 注入 GA4 脚本并暴露 window.gtag；监听 App Router 路由变化触发 page_view
- * [POS]: 由 RootLayout 装载的全局组件；ID 缺失时整组件渲染为 null（生产保险丝）
+ * [OUTPUT]: 在 body 末尾挂载 GA4 脚本并暴露 window.dataLayer/gtag；监听 App Router 路由变化触发 page_view
+ * [POS]: 由 RootLayout 装载的全局组件；ID 缺失或格式非法时整组件渲染为 null（生产保险丝）
  */
 
 "use client";
 
 import Script from "next/script";
 import { usePathname, useSearchParams } from "next/navigation";
-import { Suspense, useEffect, type ReactNode } from "react";
+import { Suspense, useEffect } from "react";
+import { trackPageView } from "@/lib/analytics";
 
-const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
+const RAW_GA_ID = process.env.NEXT_PUBLIC_GA_ID;
+const GA_ID_PATTERN = /^G-[A-Z0-9]{4,20}$/;
+const GA_ID = RAW_GA_ID && GA_ID_PATTERN.test(RAW_GA_ID) ? RAW_GA_ID : null;
 
-function RouteChangeTracker({ measurementId }: { measurementId: string }) {
+function RouteChangeTracker() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
   useEffect(() => {
-    if (typeof window.gtag !== "function") return;
     const query = searchParams?.toString();
     const url = query ? `${pathname}?${query}` : pathname;
-    window.gtag("config", measurementId, { page_path: url });
-  }, [pathname, searchParams, measurementId]);
+    trackPageView(url);
+  }, [pathname, searchParams]);
 
   return null;
 }
 
-export function GoogleAnalytics(): ReactNode {
+export function GoogleAnalytics() {
   if (!GA_ID) return null;
+
+  const initScript = `
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    window.gtag = gtag;
+    gtag('js', new Date());
+    gtag('config', ${JSON.stringify(GA_ID)}, { send_page_view: false });
+  `;
 
   return (
     <>
       <Script
-        src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
+        src={`https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(GA_ID)}`}
         strategy="afterInteractive"
       />
-      <Script id="ga4-init" strategy="afterInteractive">
-        {`
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          window.gtag = gtag;
-          gtag('js', new Date());
-          gtag('config', '${GA_ID}', { send_page_view: false });
-        `}
-      </Script>
+      <Script
+        id="ga4-init"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{ __html: initScript }}
+      />
       <Suspense fallback={null}>
-        <RouteChangeTracker measurementId={GA_ID} />
+        <RouteChangeTracker />
       </Suspense>
     </>
   );

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -1,16 +1,20 @@
 /**
- * [INPUT]: 依赖 window.gtag 全局函数（由 GoogleAnalytics 组件注入）
+ * [INPUT]: 依赖 window.dataLayer 队列（由 GoogleAnalytics 组件在页面早期注入）
  * [OUTPUT]: 暴露 trackEvent / trackPageView 等帮助函数，供业务组件埋点
  * [POS]: 全站统一的 GA4 事件埋点入口；未配置 NEXT_PUBLIC_GA_ID 时所有函数为 no-op
  */
 
+type GtagArgs =
+  | ["js", Date]
+  | ["config", string, Record<string, unknown>?]
+  | ["event", string, Record<string, unknown>?]
+  | ["set", Record<string, unknown>]
+  | ["set", string, Record<string, unknown>]
+  | ["consent", "default" | "update", Record<string, unknown>];
+
 declare global {
   interface Window {
-    gtag?: (
-      command: "config" | "event" | "set" | "consent" | "js",
-      targetId: string | Date,
-      params?: Record<string, unknown>,
-    ) => void;
+    gtag?: (...args: GtagArgs) => void;
     dataLayer?: unknown[];
   }
 }
@@ -18,33 +22,33 @@ declare global {
 export const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_ID ?? "";
 
 export const isGAEnabled = (): boolean =>
-  typeof window !== "undefined" &&
-  GA_MEASUREMENT_ID.length > 0 &&
-  typeof window.gtag === "function";
+  typeof window !== "undefined" && GA_MEASUREMENT_ID.length > 0;
+
+/**
+ * Push directly to dataLayer instead of calling window.gtag, so events
+ * fired before gtag.js loads are queued and replayed on load.
+ */
+function dlPush(args: GtagArgs): void {
+  if (!isGAEnabled()) return;
+  window.dataLayer = window.dataLayer ?? [];
+  window.dataLayer.push(args);
+}
 
 export function trackPageView(url: string): void {
-  if (!isGAEnabled()) return;
-  window.gtag!("config", GA_MEASUREMENT_ID, {
-    page_path: url,
-  });
+  dlPush(["config", GA_MEASUREMENT_ID, { page_path: url }]);
 }
 
 export function trackEvent(
   action: string,
   params: Record<string, unknown> = {},
 ): void {
-  if (!isGAEnabled()) return;
-  window.gtag!("event", action, params);
+  dlPush(["event", action, params]);
 }
 
 export function setUserId(userId: string | null): void {
-  if (!isGAEnabled()) return;
-  window.gtag!("set", GA_MEASUREMENT_ID, {
-    user_id: userId ?? undefined,
-  });
+  dlPush(["config", GA_MEASUREMENT_ID, { user_id: userId ?? undefined }]);
 }
 
 export function setUserProperties(props: Record<string, unknown>): void {
-  if (!isGAEnabled()) return;
-  window.gtag!("set", "user_properties", props);
+  dlPush(["set", "user_properties", props]);
 }


### PR DESCRIPTION
Follow-up to #659 (merged). Addresses six Copilot review comments without changing the overall GA4 integration shape.

## Fixes

| # | Severity | Fix |
|---|---|---|
| 1 | 🔴 Bug | `setUserId` now uses scoped `gtag('config', id, { user_id })`. The previous `gtag('set', id, { user_id })` form is not a valid gtag API and would silently drop the value. |
| 2 | 🔴 Bug | Helper writes directly to `window.dataLayer` instead of gating on `window.gtag` being defined. Hits fired before `gtag.js` is loaded are queued and replayed on load — fixes the lost landing page_view caused by `send_page_view: false` racing with `useEffect`. |
| 3 | 🟡 Security | Inline init script wraps the GA ID with `JSON.stringify`, the gtag.js URL with `encodeURIComponent`, and the component now validates `^G-[A-Z0-9]{4,20}$` before rendering anything. |
| 4 | 🟢 Types | `window.gtag` becomes a discriminated `GtagArgs` union covering `js / config / event / set (object|string) / consent`. |
| 5 | 🟢 Docs | Header comment in `GoogleAnalytics.tsx` now correctly says scripts mount in `<body>` (not `<head>`). |

Item #6 (vitest coverage for `analytics.ts`) is tracked as a follow-up — out of scope here to keep the diff focused.

## Test plan
- [x] `tsc --noEmit` clean on the touched files (pre-existing repo errors are unrelated).
- [x] `pnpm build` compile + TypeScript pass with a test GA ID; inline script renders the quoted ID and the gtag.js URL is properly encoded.
- [ ] After merge, verify www.botcord.chat sends a `page_view` on initial load (not only on subsequent navigations).