### PR TITLE
fix: reduce message room switch fetches

### DIFF
--- a/frontend/src/components/dashboard/ChatPane.tsx
+++ b/frontend/src/components/dashboard/ChatPane.tsx
@@ -725,27 +725,6 @@ export default function ChatPane({ onHumanOpen }: ChatPaneProps) {
   const isAuthedHuman = sessionMode === "authed-no-agent";
   const showLoginModal = () => router.push("/login");
 
-  // Seed presence for the opened room's members so MessageBubble's PresenceDot
-  // reflects real online state. Without this, senders that aren't the user's
-  // own agents stay "offline" until they happen to transition during the
-  // session — realtime presence events only fire on online/offline edges.
-  useEffect(() => {
-    if (!openedRoomId) return;
-    let cancelled = false;
-    api.getRoomMembers(openedRoomId)
-      .catch(() => api.getPublicRoomMembers(openedRoomId))
-      .then((result) => {
-        if (cancelled) return;
-        usePresenceStore.getState().seed(
-          result.members.map((m) => ({ agentId: m.agent_id, online: Boolean(m.online) })),
-        );
-      })
-      .catch(() => {});
-    return () => {
-      cancelled = true;
-    };
-  }, [openedRoomId]);
-
   if (sidebarTab === "explore") {
     return <ExploreMainPane onHumanOpen={onHumanOpen} />;
   }

--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -44,6 +44,7 @@ import WalletPanel from "./WalletPanel";
 import ActivityPanel from "./ActivityPanel";
 
 const USER_CHAT_SUBTAB = "__user-chat__";
+const MESSAGES_DIRECTORY_SYNC_INTERVAL_MS = 30_000;
 
 type BotcordDebugRealtimeSnapshot = {
   supabaseUrl: string | undefined;
@@ -99,6 +100,7 @@ export default function DashboardApp() {
   const subscriptionBoundAgentRef = useRef<string | null>(null);
   const initResolvedRef = useRef(false);
   const lastAccessTokenRef = useRef<string | null>(null);
+  const lastMessagesDirectorySyncRef = useRef(0);
   const pathnameParts = useMemo(() => pathname.split("/").filter(Boolean), [pathname]);
   const shouldShowBootstrapSkeleton = !sessionStore.authResolved || sessionStore.authBootstrapping;
   const fallbackAgent =
@@ -333,7 +335,6 @@ export default function DashboardApp() {
     uiStore.setContactsView,
     chatStore.getRoomSummary,
     chatStore.discoverRooms,
-    chatStore.messages,
     chatStore.loadPublicRoomDetail,
     chatStore.loadRoomMessages,
     chatStore.pollNewMessages,
@@ -658,17 +659,26 @@ export default function DashboardApp() {
     let cancelled = false;
     let syncInFlight = false;
 
-    const syncMessagesPane = async () => {
+    const syncMessagesPane = async (opts?: { forceDirectory?: boolean }) => {
       if (cancelled || syncInFlight) return;
       syncInFlight = true;
       try {
         const { openedRoomId, messagesPane } = useDashboardUIStore.getState();
         const session = useDashboardSessionStore.getState();
         const chat = useDashboardChatStore.getState();
-        await Promise.all([
+        const now = Date.now();
+        const shouldSyncDirectory = Boolean(opts?.forceDirectory)
+          || now - lastMessagesDirectorySyncRef.current >= MESSAGES_DIRECTORY_SYNC_INTERVAL_MS;
+        if (shouldSyncDirectory) {
+          lastMessagesDirectorySyncRef.current = now;
+        }
+        const directorySync = shouldSyncDirectory ? [
           chat.refreshOverview(),
           session.human?.human_id ? session.refreshHumanRooms() : Promise.resolve(),
           session.activeIdentity?.type === "human" ? chat.loadOwnedAgentRooms() : Promise.resolve(),
+        ] : [];
+        await Promise.all([
+          ...directorySync,
           openedRoomId && messagesPane === "room"
             ? chat.pollNewMessages(openedRoomId)
             : Promise.resolve(),
@@ -681,16 +691,19 @@ export default function DashboardApp() {
     const intervalId = window.setInterval(syncMessagesPane, 5_000);
     const handleVisibilityChange = () => {
       if (document.visibilityState === "visible") {
-        void syncMessagesPane();
+        void syncMessagesPane({ forceDirectory: true });
       }
     };
-    window.addEventListener("focus", syncMessagesPane);
+    const handleFocus = () => {
+      void syncMessagesPane({ forceDirectory: true });
+    };
+    window.addEventListener("focus", handleFocus);
     document.addEventListener("visibilitychange", handleVisibilityChange);
 
     return () => {
       cancelled = true;
       window.clearInterval(intervalId);
-      window.removeEventListener("focus", syncMessagesPane);
+      window.removeEventListener("focus", handleFocus);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   }, [

--- a/frontend/src/components/dashboard/MessageList.tsx
+++ b/frontend/src/components/dashboard/MessageList.tsx
@@ -19,6 +19,7 @@ import { getLatestSeenAtForRoom } from "@/store/dashboard-shared";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import { useDashboardUnreadStore } from "@/store/useDashboardUnreadStore";
+import { usePresenceStore } from "@/store/usePresenceStore";
 
 const topicStatusColors: Record<string, { color: string; icon: string }> = {
   open:      { color: "text-neon-cyan bg-neon-cyan/10 border-neon-cyan/30",       icon: "●" },
@@ -288,7 +289,11 @@ export default function MessageList() {
     api.getRoomMembers(roomId)
       .catch(() => api.getPublicRoomMembers(roomId))
       .then((result) => {
-        if (!cancelled) setRoomMembers(result.members);
+        if (cancelled) return;
+        setRoomMembers(result.members);
+        usePresenceStore.getState().seed(
+          result.members.map((m) => ({ agentId: m.agent_id, online: Boolean(m.online) })),
+        );
       })
       .catch(() => {
         if (!cancelled) setRoomMembers([]);


### PR DESCRIPTION
## Summary
- seed room-member presence from MessageList so room switches make one member fetch instead of duplicating it in ChatPane
- stop the route sync effect from rerunning when the messages cache changes, avoiding an immediate poll after the initial room load
- throttle Messages directory background refreshes to 30s while keeping opened-room polling at 5s and forcing directory sync on focus/visibility

## Verification
- cd frontend && npm run build

## Notes
- This PR intentionally touches only frontend room-switch critical-path files. Existing unrelated worktree changes are not included.