### PR TITLE
feat: add daemon runtime trace transcripts

### DIFF
--- a/packages/daemon/src/acp-logs.ts
+++ b/packages/daemon/src/acp-logs.ts
@@ -20,6 +20,7 @@ export type AcpTraceStream =
   | "child_error"
   | "stderr"
   | "stdout_non_json"
+  | "turn_context"
   | "rpc_in"
   | "rpc_out";
 
@@ -37,6 +38,10 @@ export interface AcpTraceMeta {
 
 export interface AcpTraceEvent {
   stream: AcpTraceStream;
+  turnId?: string;
+  messageId?: string;
+  roomId?: string;
+  topicId?: string | null;
   direction?: "in" | "out";
   pid?: number;
   id?: number | string;
@@ -132,9 +137,10 @@ function writeAcpTrace(
       ts: new Date().toISOString(),
       runtime: meta.runtime,
       accountId: meta.accountId,
-      turnId: meta.turnId,
-      roomId: meta.roomId,
-      topicId: meta.topicId ?? undefined,
+      turnId: event.turnId ?? meta.turnId,
+      messageId: event.messageId,
+      roomId: event.roomId ?? meta.roomId,
+      topicId: event.topicId ?? meta.topicId ?? undefined,
       gatewayName: meta.gatewayName,
       gatewayUrl: meta.gatewayUrl,
       hermesProfile: meta.hermesProfile,

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -159,7 +159,7 @@ export interface DaemonConfig {
   streamBlocks: boolean;
   /**
    * Persistent transcript-logging settings (design §3 / §6). Defaults to
-   * disabled — see `BOTCORD_TRANSCRIPT` for env-driven temporary overrides.
+   * enabled — see `BOTCORD_TRANSCRIPT` for env-driven temporary overrides.
    */
   transcript?: TranscriptConfig;
 
@@ -186,8 +186,8 @@ export interface DaemonConfig {
 }
 
 /**
- * Persistent transcript settings (design §6). Default-off — `botcord-daemon
- * transcript enable` flips `enabled` and `transcript disable` flips it back.
+ * Persistent transcript settings (design §6). Default-on — `botcord-daemon
+ * transcript disable` sets `enabled=false`, and `transcript enable` flips it back.
  * The env var `BOTCORD_TRANSCRIPT` can override at boot.
  */
 export interface TranscriptConfig {

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -518,7 +518,7 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
     resolveHubUrl,
     transcriptEnabled: resolveTranscriptEnabled(
       process.env.BOTCORD_TRANSCRIPT,
-      opts.config.transcript?.enabled === true,
+      opts.config.transcript?.enabled,
     ),
   });
 

--- a/packages/daemon/src/diagnostics.ts
+++ b/packages/daemon/src/diagnostics.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { homedir, hostname, platform, release, arch } from "node:os";
 import path from "node:path";
 import { Buffer } from "node:buffer";
@@ -22,6 +22,7 @@ import {
 } from "./config.js";
 import { listDaemonLogFiles, LOG_FILE_PATH, type LogFileEntry } from "./log.js";
 import { listAcpTraceLogFiles, listRuntimeLogFiles } from "./acp-logs.js";
+import { defaultTranscriptRoot } from "./gateway/transcript.js";
 import {
   channelsFromDaemonConfig,
   defaultHttpFetcher,
@@ -59,6 +60,9 @@ const ENV_ALLOWLIST = new Set([
   "BOTCORD_KIMI_CLI_BIN",
   "OPENCLAW_ACP_URL",
 ]);
+const TRANSCRIPT_LOG_DIAGNOSTICS_DEFAULT = 10;
+const TRANSCRIPT_LOG_DIAGNOSTICS_ALL = 50;
+const TRANSCRIPT_LOG_MAX_FILE_BYTES = 2 * 1024 * 1024;
 
 export interface CreateDiagnosticBundleOptions {
   diagnosticsDir?: string;
@@ -416,6 +420,55 @@ function bundledLogs(logFile: string, includeAllLogs: boolean): LogFileEntry[] {
   ];
 }
 
+function listTranscriptLogFiles(includeAll: boolean): LogFileEntry[] {
+  const root = defaultTranscriptRoot();
+  const out: LogFileEntry[] = [];
+  collectTranscriptFiles(root, root, out, 5);
+  const limit = includeAll ? TRANSCRIPT_LOG_DIAGNOSTICS_ALL : TRANSCRIPT_LOG_DIAGNOSTICS_DEFAULT;
+  return out
+    .sort((a, b) => b.mtimeMs - a.mtimeMs || b.name.localeCompare(a.name))
+    .slice(0, limit);
+}
+
+function collectTranscriptFiles(
+  root: string,
+  dir: string,
+  out: LogFileEntry[],
+  maxDepth: number,
+): void {
+  if (maxDepth < 0) return;
+  let names: string[];
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const name of names) {
+    const file = path.join(dir, name);
+    try {
+      const st = statSync(file);
+      if (st.isDirectory()) {
+        collectTranscriptFiles(root, file, out, maxDepth - 1);
+      } else if (
+        st.isFile() &&
+        name.endsWith(".jsonl") &&
+        file.includes(`${path.sep}transcripts${path.sep}`) &&
+        st.size <= TRANSCRIPT_LOG_MAX_FILE_BYTES
+      ) {
+        out.push({
+          path: file,
+          name: path.relative(root, file) || name,
+          sizeBytes: st.size,
+          mtimeMs: st.mtimeMs,
+          active: true,
+        });
+      }
+    } catch {
+      // ignore files that disappear while collecting diagnostics
+    }
+  }
+}
+
 export async function createDiagnosticBundle(
   opts: CreateDiagnosticBundleOptions = {},
 ): Promise<DiagnosticBundleResult> {
@@ -431,6 +484,7 @@ export async function createDiagnosticBundle(
   const logs = bundledLogs(logFile, includeAllLogs);
   const acpLogs = listAcpTraceLogFiles(includeAllLogs);
   const runtimeLogs = listRuntimeLogFiles(includeAllLogs);
+  const transcriptLogs = listTranscriptLogFiles(includeAllLogs);
   mkdirSync(diagnosticsDir, { recursive: true, mode: 0o700 });
 
   const doctor = opts.doctor ?? await buildDoctorEntries();
@@ -462,6 +516,11 @@ export async function createDiagnosticBundle(
     })),
     runtimeLogsBundled: runtimeLogs.map((entry) => ({
       name: entry.bundleName,
+      path: entry.path,
+      sizeBytes: entry.sizeBytes,
+    })),
+    transcriptLogsBundled: transcriptLogs.map((entry) => ({
+      name: entry.name,
       path: entry.path,
       sizeBytes: entry.sizeBytes,
     })),
@@ -502,6 +561,13 @@ export async function createDiagnosticBundle(
     entries.push({
       name: entry.bundleName,
       data: log ?? `no runtime log file at ${entry.path}\n`,
+    });
+  }
+  for (const entry of transcriptLogs) {
+    const log = safeReadText(entry.path);
+    entries.push({
+      name: `transcripts/${entry.name.split(path.sep).join("/")}`,
+      data: log ?? `no transcript log file at ${entry.path}\n`,
     });
   }
   const config = safeReadText(configFile);

--- a/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
+++ b/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
@@ -1276,6 +1276,50 @@ describe("Dispatcher", () => {
     expect(blockTypes).toEqual(["system", "tool_use"]);
   });
 
+  it("transcript: records runtime blocks even when channel streaming is disabled", async () => {
+    const blocks: StreamBlock[] = [
+      {
+        raw: {
+          params: {
+            update: {
+              sessionUpdate: "tool_call",
+              toolCall: { name: "botcord_send", rawInput: { text: "hello" } },
+            },
+          },
+        },
+        kind: "tool_use",
+        seq: 7,
+      },
+    ];
+    const runtime = new FakeRuntime({ blocks, reply: "ok", newSessionId: "sid" });
+    const channel = new FakeChannel();
+    const records: import("../transcript.js").TranscriptRecord[] = [];
+    const { store, dir } = await makeStore();
+    tempDirs.push(dir);
+    const channels = new Map<string, ChannelAdapter>([[channel.id, channel]]);
+    const dispatcher = new Dispatcher({
+      config: baseConfig(),
+      channels,
+      runtime: () => runtime,
+      sessionStore: store,
+      log: silentLogger(),
+      transcript: { enabled: true, rootDir: dir, write: (rec) => records.push(rec) },
+    });
+
+    await dispatcher.handle(
+      makeEnvelope({ trace: { id: "tr", streamable: false } }),
+    );
+
+    expect(channel.streams).toHaveLength(0);
+    const block = records.find((r) => r.kind === "block");
+    expect(block).toMatchObject({
+      kind: "block",
+      blockType: "tool_use",
+      seq: 7,
+      summary: { type: "tool_use", name: "botcord_send" },
+    });
+  });
+
   it("runtime throws: sends error reply, does not write session", async () => {
     const runtime = new FakeRuntime({ throwError: "boom" });
     const channel = new FakeChannel();

--- a/packages/daemon/src/gateway/__tests__/transcript.test.ts
+++ b/packages/daemon/src/gateway/__tests__/transcript.test.ts
@@ -1,5 +1,5 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
-import { existsSync, statSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { existsSync, statSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -7,7 +7,9 @@ import { Dispatcher, type RuntimeFactory } from "../dispatcher.js";
 import { SessionStore } from "../session-store.js";
 import {
   createTranscriptWriter,
+  cleanupTranscriptFiles,
   resolveTranscriptEnabled,
+  TRANSCRIPT_RETENTION_MS,
   TRANSCRIPT_TEXT_LIMIT,
   truncateTextField,
   type TranscriptRecord,
@@ -239,6 +241,10 @@ describe("resolveTranscriptEnabled", () => {
     expect(resolveTranscriptEnabled("yes", true)).toBe(true);
     expect(resolveTranscriptEnabled("yes", false)).toBe(false);
   });
+  it("defaults on when env and config are both unset", () => {
+    expect(resolveTranscriptEnabled(undefined, undefined)).toBe(true);
+    expect(resolveTranscriptEnabled("yes", undefined)).toBe(true);
+  });
 });
 
 describe("truncateTextField", () => {
@@ -458,6 +464,25 @@ describe("Dispatcher transcript integration", () => {
     expect(files.length).toBeGreaterThan(1);
     expect(files.some((f) => /_default\.\d{8}-\d{6}\.jsonl$/.test(f))).toBe(true);
     expect(files).toContain("_default.jsonl");
+  });
+
+  it("cleans transcript files older than the retention window", async () => {
+    const tmp = await mkdtemp(path.join(tmpdir(), "transcript-clean-"));
+    cleanups.push(() => rm(tmp, { recursive: true, force: true }));
+    const oldFile = transcriptFilePath(tmp, "ag_me", "rm_old", null);
+    const freshFile = transcriptFilePath(tmp, "ag_me", "rm_fresh", null);
+    await mkdir(path.dirname(oldFile), { recursive: true });
+    await mkdir(path.dirname(freshFile), { recursive: true });
+    await writeFile(oldFile, "{}\n", { mode: 0o600 });
+    await writeFile(freshFile, "{}\n", { mode: 0o600 });
+    const oldDate = new Date(Date.now() - TRANSCRIPT_RETENTION_MS - 60_000);
+    utimesSync(oldFile, oldDate, oldDate);
+
+    const removed = cleanupTranscriptFiles(tmp, Date.now() - TRANSCRIPT_RETENTION_MS);
+
+    expect(removed).toBe(1);
+    expect(existsSync(oldFile)).toBe(false);
+    expect(existsSync(freshFile)).toBe(true);
   });
 
   it("disabled writer does not create files", async () => {

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -37,6 +37,8 @@ const DEFAULT_TURN_TIMEOUT_MS = 30 * 60 * 1000;
  * (or `botcord send` CLI via Bash) to actually deliver replies.
  */
 const OWNER_CHAT_ROOM_PREFIX = "rm_oc_";
+const TRANSCRIPT_BLOCK_RAW_LIMIT = 16 * 1024;
+const SECRET_KEY_RE = /token|secret|private.?key|api.?key|authorization|password/i;
 
 /** Maximum number of buffered serial entries per queue. Excess entries drop oldest. */
 const MAX_BATCH_BUFFER_ENTRIES = 40;
@@ -65,6 +67,62 @@ const TYPING_REFRESH_MS = 4000;
 
 /** LRU cap on the typing-recency map so long-running daemons don't grow unbounded. */
 const TYPING_RECENCY_CAP = 1024;
+
+function transcriptBlocksVerbose(): boolean {
+  return process.env.BOTCORD_TRANSCRIPT_BLOCKS === "verbose" ||
+    process.env.BOTCORD_TRACE_VERBOSE === "1";
+}
+
+function summarizeStreamBlock(block: StreamBlock): TranscriptBlockSummary {
+  const summary: TranscriptBlockSummary = { type: block.kind };
+  const raw = block.raw as {
+    text?: unknown;
+    name?: unknown;
+    update?: unknown;
+    params?: { update?: unknown };
+  } | null | undefined;
+  if (raw && typeof raw === "object") {
+    if (typeof raw.text === "string") summary.chars = raw.text.length;
+    if (typeof raw.name === "string") summary.name = raw.name;
+    const update = raw.params?.update ?? raw.update;
+    if (update && typeof update === "object") {
+      const u = update as Record<string, unknown>;
+      if (typeof u.sessionUpdate === "string" && !summary.name) summary.name = u.sessionUpdate;
+      const toolCall = u.toolCall;
+      if (toolCall && typeof toolCall === "object") {
+        const toolName = (toolCall as Record<string, unknown>).name;
+        if (typeof toolName === "string") summary.name = toolName;
+      }
+    }
+  }
+  return summary;
+}
+
+function redactAndCap(value: unknown, budget = TRANSCRIPT_BLOCK_RAW_LIMIT): unknown {
+  const seen = new WeakSet<object>();
+  const walk = (v: unknown): unknown => {
+    if (typeof v === "string") {
+      return redactSecretString(v.length > budget ? `${v.slice(0, budget)}…` : v);
+    }
+    if (Array.isArray(v)) return v.slice(0, 50).map(walk);
+    if (!v || typeof v !== "object") return v;
+    if (seen.has(v)) return "[Circular]";
+    seen.add(v);
+    const out: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(v as Record<string, unknown>).slice(0, 80)) {
+      out[key] = SECRET_KEY_RE.test(key) ? "[REDACTED]" : walk(child);
+    }
+    return out;
+  };
+  return walk(value);
+}
+
+function redactSecretString(value: string): string {
+  return value
+    .replace(/(Authorization:\s*Bearer\s+)[^\s"']+/gi, "$1[REDACTED]")
+    .replace(/\b(token=)[^\s"']+/gi, "$1[REDACTED]")
+    .replace(/\b(drt_|dit_|gho_)[A-Za-z0-9_-]+/g, "$1[REDACTED]");
+}
 
 /** Factory signature for building a runtime adapter at turn dispatch time. */
 export type RuntimeFactory = (
@@ -943,13 +1001,23 @@ export class Dispatcher {
     const canStream =
       streamable && typeof traceId === "string" && typeof channel.streamBlock === "function";
     const recordBlock = (block: StreamBlock): void => {
-      const summary: TranscriptBlockSummary = { type: block.kind };
-      const raw = block.raw as { text?: unknown; name?: unknown } | null | undefined;
-      if (raw && typeof raw === "object") {
-        if (typeof raw.text === "string") summary.chars = raw.text.length;
-        if (typeof raw.name === "string") summary.name = raw.name;
-      }
+      const summary = summarizeStreamBlock(block);
       slot.blocks.push(summary);
+      if (this.transcript.enabled) {
+        this.transcript.write({
+          ts: new Date().toISOString(),
+          kind: "block",
+          turnId,
+          agentId: msg.accountId,
+          roomId: msg.conversation.id,
+          topicId: msg.conversation.threadId ?? null,
+          runtime: route.runtime,
+          seq: block.seq,
+          blockType: block.kind,
+          summary,
+          ...(transcriptBlocksVerbose() ? { raw: redactAndCap(block.raw) } : {}),
+        });
+      }
     };
 
     // Owner-chat lifecycle state for typing/thinking. The dispatcher is the
@@ -1118,13 +1186,14 @@ export class Dispatcher {
         }
       : undefined;
 
-    const onBlock = canStream
+    const onBlock = (canStream || this.transcript.enabled)
       ? (block: StreamBlock) => {
           // Always record adapter-emitted blocks for transcript fidelity, even
           // after abort — the transcript reflects what the runtime emitted,
           // not what the dispatcher chose to forward.
           recordBlock(block);
           if (controller.signal.aborted) return;
+          if (!canStream) return;
           // Synthesize thinking.started before non-assistant blocks. After
           // we've seen any assistant_text, only `tool_use` may re-enter
           // thinking — terminal markers like `system`/`other` (codex
@@ -1144,7 +1213,7 @@ export class Dispatcher {
             thinkingActive = false;
             sawAssistantText = true;
           }
-          forwardBlockToChannel!(block);
+          forwardBlockToChannel?.(block);
         }
       : undefined;
 

--- a/packages/daemon/src/gateway/gateway.ts
+++ b/packages/daemon/src/gateway/gateway.ts
@@ -78,7 +78,8 @@ export interface GatewayBootOptions {
    * Tri-state convenience: if `transcript` is not provided, the gateway
    * constructs a writer using this flag plus `transcriptRootDir`. Use
    * {@link resolveTranscriptEnabled} to combine `BOTCORD_TRANSCRIPT` env with
-   * the persistent daemon-config flag.
+   * the persistent daemon-config flag. When omitted, transcripts are enabled
+   * by default.
    */
   transcriptEnabled?: boolean;
   /** Root directory for transcript files. Defaults to `~/.botcord/agents`. */
@@ -145,7 +146,7 @@ export class Gateway {
       opts.transcript
       ?? createTranscriptWriter({
         log: this.log,
-        enabled: opts.transcriptEnabled === true,
+        enabled: opts.transcriptEnabled,
         rootDir: opts.transcriptRootDir,
       });
 

--- a/packages/daemon/src/gateway/runtimes/openclaw-acp.ts
+++ b/packages/daemon/src/gateway/runtimes/openclaw-acp.ts
@@ -35,7 +35,7 @@ interface AcpProcessHandle {
   /** Pending JSON-RPC requests keyed by id. */
   pending: Map<number, PendingCall>;
   /** Per-ACP-sessionId notification subscribers. */
-  subscribers: Map<string, (note: AcpNotification) => void>;
+  subscribers: Map<string, AcpSubscriber>;
   nextId: number;
   buffer: string;
   nonJsonStdoutTail: string[];
@@ -64,6 +64,18 @@ interface PendingCall {
 interface AcpNotification {
   method: string;
   params: any;
+}
+
+interface AcpTurnTraceContext {
+  turnId?: string;
+  messageId?: string;
+  roomId?: string;
+  topicId?: string | null;
+}
+
+interface AcpSubscriber {
+  notify: (note: AcpNotification) => void;
+  traceContext: AcpTurnTraceContext;
 }
 
 const ACP_POOL = new Map<string, AcpProcessHandle>();
@@ -183,6 +195,12 @@ export class OpenclawAcpAdapter implements RuntimeAdapter {
       // synthetic test calls).
       conversationKey: stringField(opts.context, "conversationKey") ?? "default",
     });
+    const traceContext: AcpTurnTraceContext = {
+      turnId: stringField(opts.context, "turnId"),
+      messageId: stringField(opts.context, "messageId"),
+      roomId: stringField(opts.context, "roomId"),
+      topicId: nullableStringField(opts.context, "topicId"),
+    };
 
     const key = poolKey(opts.accountId, gateway.name);
     let handle: AcpProcessHandle;
@@ -273,7 +291,17 @@ export class OpenclawAcpAdapter implements RuntimeAdapter {
           throw new Error(`newSession failed: ${(err as Error).message}`);
         }
       }
-      handle.subscribers.set(acpSessionId, onNotification);
+      handle.subscribers.set(acpSessionId, { notify: onNotification, traceContext });
+      handle.trace?.write({
+        stream: "turn_context",
+        ...traceContext,
+        params: {
+          sessionId: acpSessionId,
+          sessionKey,
+          openclawAgent,
+          cwd: opts.cwd,
+        },
+      });
 
       if (opts.signal?.aborted) {
         return failResult(acpSessionId, "openclaw-acp: aborted before prompt");
@@ -308,7 +336,18 @@ export class OpenclawAcpAdapter implements RuntimeAdapter {
             });
             handle.subscribers.delete(acpSessionId);
             acpSessionId = fresh;
-            handle.subscribers.set(acpSessionId, onNotification);
+            handle.subscribers.set(acpSessionId, { notify: onNotification, traceContext });
+            handle.trace?.write({
+              stream: "turn_context",
+              ...traceContext,
+              params: {
+                sessionId: acpSessionId,
+                sessionKey,
+                openclawAgent,
+                cwd: opts.cwd,
+                recreatedFrom: oldSessionId,
+              },
+            });
             log.info("openclaw-acp.session-recreated", {
               accountId: opts.accountId,
               oldSessionId,
@@ -627,19 +666,20 @@ function routeMessage(handle: AcpProcessHandle, msg: any): void {
   }
   // Notification.
   if (msg?.method && msg?.params) {
+    const sid = msg.params?.sessionId;
+    const sub = typeof sid === "string" ? handle.subscribers.get(sid) : undefined;
     handle.trace?.write({
       stream: "rpc_in",
       direction: "in",
       method: msg.method,
       status: "notification",
+      ...(sub?.traceContext ?? {}),
       params: msg.params,
     });
-    const sid = msg.params?.sessionId;
     if (typeof sid === "string") {
-      const sub = handle.subscribers.get(sid);
       if (sub) {
         try {
-          sub({ method: msg.method, params: msg.params });
+          sub.notify({ method: msg.method, params: msg.params });
         } catch (err) {
           log.warn("openclaw-acp.subscriber-threw", {
             error: err instanceof Error ? err.message : String(err),
@@ -1023,6 +1063,16 @@ function isReasoningNarration(text: string): boolean {
 function stringField(bag: Record<string, unknown> | undefined, key: string): string | undefined {
   if (!bag) return undefined;
   const v = bag[key];
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+function nullableStringField(
+  bag: Record<string, unknown> | undefined,
+  key: string,
+): string | null | undefined {
+  if (!bag) return undefined;
+  const v = bag[key];
+  if (v === null) return null;
   return typeof v === "string" && v.length > 0 ? v : undefined;
 }
 

--- a/packages/daemon/src/gateway/transcript.ts
+++ b/packages/daemon/src/gateway/transcript.ts
@@ -1,4 +1,4 @@
-import { appendFileSync, mkdirSync, renameSync, statSync } from "node:fs";
+import { appendFileSync, mkdirSync, readdirSync, renameSync, rmSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 
@@ -14,6 +14,12 @@ export const TRANSCRIPT_TEXT_LIMIT = 32 * 1024;
 /** Soft cap on a single transcript file before rotation. */
 export const TRANSCRIPT_FILE_LIMIT = 8 * 1024 * 1024;
 
+/** Default retention window for transcript JSONL files. */
+export const TRANSCRIPT_RETENTION_MS = 3 * 24 * 60 * 60 * 1000;
+
+/** Minimum interval between background transcript retention sweeps. */
+export const TRANSCRIPT_CLEANUP_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
 /** Default root directory for per-agent transcript trees. */
 export function defaultTranscriptRoot(): string {
   return path.join(homedir(), ".botcord", "agents");
@@ -26,6 +32,7 @@ export function defaultTranscriptRoot(): string {
 export type TranscriptRecordKind =
   | "inbound"
   | "dispatched"
+  | "block"
   | "compose_failed"
   | "outbound"
   | "turn_error"
@@ -63,6 +70,15 @@ export interface DispatchedTranscriptRecord extends TranscriptRecordBase {
   mergedFromTurnIds?: string[];
   runtime: string;
   truncated?: { composedText?: true };
+}
+
+export interface BlockTranscriptRecord extends TranscriptRecordBase {
+  kind: "block";
+  runtime: string;
+  seq: number;
+  blockType: string;
+  summary: TranscriptBlockSummary;
+  raw?: unknown;
 }
 
 export interface ComposeFailedTranscriptRecord extends TranscriptRecordBase {
@@ -122,6 +138,7 @@ export interface DroppedTranscriptRecord extends TranscriptRecordBase {
 export type TranscriptRecord =
   | InboundTranscriptRecord
   | DispatchedTranscriptRecord
+  | BlockTranscriptRecord
   | ComposeFailedTranscriptRecord
   | OutboundTranscriptRecord
   | TurnErrorTranscriptRecord
@@ -162,10 +179,14 @@ export interface CreateTranscriptWriterOptions {
   /** Defaults to `~/.botcord/agents`. */
   rootDir?: string;
   log: GatewayLogger;
-  /** Defaults to `false` — see design §6 (default-off). */
+  /** Defaults to `true`; pass `false` to disable persistence. */
   enabled?: boolean;
   /** Override file rotation threshold (bytes). Defaults to TRANSCRIPT_FILE_LIMIT. */
   maxFileBytes?: number;
+  /** Delete transcript JSONL files older than this. Defaults to 3 days. */
+  retentionMs?: number;
+  /** Minimum interval between retention sweeps. Defaults to 6 hours. */
+  cleanupIntervalMs?: number;
 }
 
 interface FileMeta {
@@ -188,17 +209,29 @@ class FsTranscriptWriter implements TranscriptWriter {
   readonly rootDir: string;
   private readonly log: GatewayLogger;
   private readonly maxFileBytes: number;
+  private readonly retentionMs: number;
+  private readonly cleanupIntervalMs: number;
   private readonly fileMeta = new Map<string, FileMeta>();
   private firstWriteAnnounced = false;
+  private lastCleanupAt = 0;
 
-  constructor(rootDir: string, log: GatewayLogger, maxFileBytes: number) {
+  constructor(
+    rootDir: string,
+    log: GatewayLogger,
+    maxFileBytes: number,
+    retentionMs: number,
+    cleanupIntervalMs: number,
+  ) {
     this.rootDir = rootDir;
     this.log = log;
     this.maxFileBytes = maxFileBytes;
+    this.retentionMs = retentionMs;
+    this.cleanupIntervalMs = cleanupIntervalMs;
   }
 
   write(rec: TranscriptRecord): void {
     try {
+      this.cleanupOldFiles();
       const file = transcriptFilePath(this.rootDir, rec.agentId, rec.roomId, rec.topicId);
       const dir = path.dirname(file);
       try {
@@ -264,16 +297,37 @@ class FsTranscriptWriter implements TranscriptWriter {
       });
     }
   }
+
+  private cleanupOldFiles(): void {
+    const now = Date.now();
+    if (now - this.lastCleanupAt < this.cleanupIntervalMs) return;
+    this.lastCleanupAt = now;
+    const cutoff = now - this.retentionMs;
+    const removed = cleanupTranscriptFiles(this.rootDir, cutoff);
+    if (removed > 0) {
+      this.log.info("transcript cleanup removed old files", {
+        dir: this.rootDir,
+        removed,
+        retentionMs: this.retentionMs,
+      });
+    }
+  }
 }
 
 export function createTranscriptWriter(
   opts: CreateTranscriptWriterOptions,
 ): TranscriptWriter {
   const rootDir = opts.rootDir ?? defaultTranscriptRoot();
-  const enabled = opts.enabled ?? false;
+  const enabled = opts.enabled ?? true;
   if (!enabled) return new NoopTranscriptWriter(rootDir);
   const maxBytes = opts.maxFileBytes ?? TRANSCRIPT_FILE_LIMIT;
-  return new FsTranscriptWriter(rootDir, opts.log, maxBytes);
+  return new FsTranscriptWriter(
+    rootDir,
+    opts.log,
+    maxBytes,
+    opts.retentionMs ?? TRANSCRIPT_RETENTION_MS,
+    opts.cleanupIntervalMs ?? TRANSCRIPT_CLEANUP_INTERVAL_MS,
+  );
 }
 
 /**
@@ -284,11 +338,47 @@ export function createTranscriptWriter(
  */
 export function resolveTranscriptEnabled(
   envVal: string | undefined,
-  configEnabled: boolean,
+  configEnabled: boolean | undefined,
 ): boolean {
   if (envVal === "1") return true;
   if (envVal === "0") return false;
-  return configEnabled;
+  return configEnabled ?? true;
+}
+
+export function cleanupTranscriptFiles(rootDir: string, cutoffMs: number): number {
+  let removed = 0;
+  const visit = (dir: string, depth: number): void => {
+    if (depth < 0) return;
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const file = path.join(dir, entry);
+      try {
+        const st = statSync(file);
+        if (st.isDirectory()) {
+          visit(file, depth - 1);
+          continue;
+        }
+        if (
+          st.isFile() &&
+          entry.endsWith(".jsonl") &&
+          file.includes(`${path.sep}transcripts${path.sep}`) &&
+          st.mtimeMs < cutoffMs
+        ) {
+          rmSync(file, { force: true });
+          removed += 1;
+        }
+      } catch {
+        // ignore disappearing files and permission errors
+      }
+    }
+  };
+  visit(rootDir, 6);
+  return removed;
 }
 
 function formatStamp(d: Date): string {

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -888,13 +888,14 @@ function cmdTranscriptStatus(): void {
     const e = err as Error & { code?: string };
     if (e.code !== CONFIG_MISSING) throw err;
   }
-  const configEnabled = cfg?.transcript?.enabled === true;
+  const configEnabled = cfg?.transcript?.enabled;
   const env = process.env.BOTCORD_TRANSCRIPT;
   const effective = resolveTranscriptEnabled(env, configEnabled);
   let source: string;
   if (env === "1" || env === "0") source = `env BOTCORD_TRANSCRIPT=${env}`;
-  else if (configEnabled) source = "config (transcript.enabled=true)";
-  else source = "default-off";
+  else if (configEnabled === true) source = "config (transcript.enabled=true)";
+  else if (configEnabled === false) source = "config (transcript.enabled=false)";
+  else source = "default-on";
   console.log(`enabled: ${effective}`);
   console.log(`source: ${source}`);
   console.log(`root: ${defaultTranscriptRoot()}`);
@@ -942,11 +943,11 @@ function cmdTranscriptTail(args: ParsedArgs): Promise<void> | void {
     }
     const enabled = resolveTranscriptEnabled(
       process.env.BOTCORD_TRANSCRIPT,
-      cfg?.transcript?.enabled === true,
+      cfg?.transcript?.enabled,
     );
     if (!enabled) {
       console.error(
-        "hint: transcripts are disabled (default-off). Run `botcord-daemon transcript enable` and restart the daemon, then send a new message.",
+        "hint: transcripts are disabled. Run `botcord-daemon transcript enable` and restart the daemon, then send a new message.",
       );
     }
     process.exit(1);


### PR DESCRIPTION
## Summary
- enable daemon transcript logging by default with 3-day retention cleanup
- record runtime block summaries even when channel streaming is disabled
- attach turn context to OpenClaw ACP trace notifications and include transcripts in diagnostics bundles

## Tests
- cd packages/daemon && npm run build
- cd packages/daemon && npm test