### PR TITLE
fix: show human sender on transfer records

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -2326,6 +2326,7 @@ async def get_room_messages(
         if (r.source_type or "") in ("dashboard_human_room", "dashboard_user_chat")
         and r.source_user_id
     }
+    human_user_ids.update(r.sender_id for r in records if (r.sender_id or "").startswith("hu_"))
     user_name_map = await load_user_display_names(db, human_user_ids)
 
     # Owner-chat rooms (rm_oc_*) are always viewed as the human owner — both
@@ -3057,6 +3058,7 @@ async def create_share(
         r.source_user_id for r in records
         if (r.source_type or "") == "dashboard_human_room" and r.source_user_id
     }
+    share_human_user_ids.update(r.sender_id for r in records if (r.sender_id or "").startswith("hu_"))
     share_user_name_map = await load_user_display_names(db, share_human_user_ids)
 
     share = Share(

--- a/backend/app/routers/wallet.py
+++ b/backend/app/routers/wallet.py
@@ -119,6 +119,8 @@ async def _record_room_transfer_notice(
     from_owner_id: str,
     to_owner_id: str,
     tx,
+    source_user_id: str | None = None,
+    source_user_name: str | None = None,
 ) -> None:
     members_result = await db.execute(
         select(RoomMember).where(RoomMember.room_id == room_id)
@@ -148,6 +150,7 @@ async def _record_room_transfer_notice(
         "asset_code": tx.asset_code,
         "from_agent_id": from_owner_id,
         "to_agent_id": to_owner_id,
+        "from_display_name": source_user_name,
     }
     envelope_data = {
         "v": "a2a/0.1",
@@ -184,7 +187,8 @@ async def _record_room_transfer_notice(
                 envelope_json=envelope_json,
                 ttl_sec=3600,
                 created_at=now,
-                source_type="wallet_transfer_notice",
+                source_type="dashboard_human_room" if source_user_id else "wallet_transfer_notice",
+                source_user_id=source_user_id,
                 source_session_kind="room_human",
             )
         )
@@ -204,7 +208,7 @@ async def _record_room_transfer_notice(
                     hub_msg_id=receiver_hub_msg_ids.get(receiver_id, first_hub_msg_id),
                     created_at=now,
                     payload=payload,
-                    source_type="wallet_transfer_notice",
+                    source_type="dashboard_human_room" if source_user_id else "wallet_transfer_notice",
                 ),
             )
         except Exception as exc:
@@ -346,6 +350,8 @@ async def create_transfer(
                 from_owner_id=from_owner_id,
                 to_owner_id=body.to_agent_id,
                 tx=tx,
+                source_user_id=str(ctx.user_id) if as_ == "human" else None,
+                source_user_name=ctx.user_display_name if as_ == "human" else None,
             )
         await db.commit()
     except ValueError as exc:

--- a/backend/hub/dashboard_message_shaping.py
+++ b/backend/hub/dashboard_message_shaping.py
@@ -39,10 +39,13 @@ async def load_user_profiles(
         return {}
     out: dict[str, tuple[str, str | None]] = {}
     uuid_ids: list[_uuid.UUID] = []
+    human_ids: list[str] = []
     for s in ids:
         try:
             uuid_ids.append(_uuid.UUID(str(s)))
         except (ValueError, TypeError):
+            if str(s).startswith("hu_"):
+                human_ids.append(str(s))
             continue
     if uuid_ids:
         try:
@@ -71,6 +74,17 @@ async def load_user_profiles(
                     "load_user_display_names: supabase_user_id fallback failed",
                     exc_info=True,
                 )
+    if human_ids:
+        try:
+            result = await db.execute(
+                select(User.human_id, User.display_name, User.avatar_url).where(
+                    User.human_id.in_(human_ids)
+                )
+            )
+            for human_id, name, avatar_url in result.all():
+                out[str(human_id)] = (name, avatar_url)
+        except Exception:
+            _logger.warning("load_user_display_names: human_id lookup failed", exc_info=True)
     return out
 
 
@@ -118,15 +132,21 @@ def derive_sender_fields(
     """
     source_type = rec.source_type or "agent"
     kind = sender_kind_for(source_type)
+    if kind != "human" and (rec.sender_id or "").startswith("hu_"):
+        kind = "human"
     source_user_id = rec.source_user_id
     source_user_name: str | None = None
     sender_avatar_url: str | None = None
     is_mine = False
 
     if kind == "human":
-        source_user_name = user_name_map.get(source_user_id) if source_user_id else None
+        source_user_name = (
+            user_name_map.get(source_user_id) if source_user_id else None
+        ) or user_name_map.get(rec.sender_id)
         display_sender_name = source_user_name or "User"
-        sender_avatar_url = user_avatar_map.get(source_user_id) if user_avatar_map and source_user_id else None
+        sender_avatar_url = (
+            user_avatar_map.get(source_user_id) if user_avatar_map and source_user_id else None
+        ) or (user_avatar_map.get(rec.sender_id) if user_avatar_map else None)
         if viewer_user_id and source_user_id and str(viewer_user_id) == str(source_user_id):
             is_mine = True
     else:

--- a/backend/hub/routers/dashboard.py
+++ b/backend/hub/routers/dashboard.py
@@ -453,6 +453,7 @@ async def get_room_messages(
         rec.source_user_id for rec in rows
         if (rec.source_type or "") in HUMAN_SOURCE_TYPES and rec.source_user_id
     }
+    _human_user_ids.update(rec.sender_id for rec in rows if (rec.sender_id or "").startswith("hu_"))
     _user_profiles = await load_user_profiles(db, _human_user_ids)
     _user_name_map = {uid: profile[0] for uid, profile in _user_profiles.items()}
     _user_avatar_map = {uid: profile[1] for uid, profile in _user_profiles.items()}

--- a/backend/tests/test_app/test_app_wallet_human.py
+++ b/backend/tests/test_app/test_app_wallet_human.py
@@ -134,6 +134,8 @@ async def seed(db_session: AsyncSession):
         "token": _make_token(str(supabase_uuid)),
         "agent_id": "ag_humanwal01",
         "human_id": user.human_id,
+        "user_id": str(user_id),
+        "user_name": user.display_name,
     }
 
 
@@ -296,13 +298,15 @@ async def test_room_transfer_records_notice_message(client, db_session, seed):
     records = list((await db_session.execute(
         select(MessageRecord).where(
             MessageRecord.room_id == room_id,
-            MessageRecord.source_type == "wallet_transfer_notice",
         )
     )).scalars().all())
     assert len(records) == 2
     assert {record.receiver_id for record in records} == {seed["human_id"], seed["agent_id"]}
+    assert {record.source_type for record in records} == {"dashboard_human_room"}
+    assert {record.source_user_id for record in records} == {seed["user_id"]}
     assert records[0].envelope_json
     assert "[BotCord Transfer]" in records[0].envelope_json
+    assert seed["user_name"] in records[0].envelope_json
     assert tx["tx_id"] in records[0].envelope_json
 
 

--- a/frontend/src/components/dashboard/TransferCard.tsx
+++ b/frontend/src/components/dashboard/TransferCard.tsx
@@ -9,6 +9,8 @@ interface TransferInfo {
   asset: string;
   from: string;
   to: string;
+  from_label?: string;
+  to_label?: string;
   memo?: string;
   created_at?: string;
 }
@@ -60,6 +62,8 @@ export function parseTransferNotice(
       asset: String(payload.asset_code ?? "COIN"),
       from: String(payload.from_agent_id ?? ""),
       to: String(payload.to_agent_id ?? ""),
+      from_label: typeof payload.from_display_name === "string" ? payload.from_display_name : undefined,
+      to_label: typeof payload.to_display_name === "string" ? payload.to_display_name : undefined,
     };
   }
 
@@ -100,6 +104,18 @@ const statusStyles: Record<string, string> = {
   failed: "text-red-400 bg-red-400/10 border-red-400/30",
 };
 
+function TransferParty({ id, label }: { id: string; label?: string }) {
+  if (label && label !== id) {
+    return (
+      <span className="min-w-0 text-right">
+        <span className="block truncate text-text-primary/85">{label}</span>
+        <CopyableId value={id} />
+      </span>
+    );
+  }
+  return <CopyableId value={id} />;
+}
+
 export default function TransferCard({ info, isNotice }: { info: TransferInfo; isNotice?: boolean }) {
   const amountNum = parseFloat(info.amount);
   const amountDisplay = isNaN(amountNum) ? info.amount : `${amountNum.toFixed(2)} ${info.asset}`;
@@ -132,13 +148,13 @@ export default function TransferCard({ info, isNotice }: { info: TransferInfo; i
         {info.from && (
           <div className="flex items-center justify-between gap-2">
             <span className="shrink-0 text-text-secondary/60">From</span>
-            <CopyableId value={info.from} />
+            <TransferParty id={info.from} label={info.from_label} />
           </div>
         )}
         {info.to && (
           <div className="flex items-center justify-between gap-2">
             <span className="shrink-0 text-text-secondary/60">To</span>
-            <CopyableId value={info.to} />
+            <TransferParty id={info.to} label={info.to_label} />
           </div>
         )}
         {info.memo && (


### PR DESCRIPTION
## Summary
- mark human-initiated room transfer records as human dashboard messages
- include the human display name in transfer notice payloads and cards
- resolve legacy hu_* sender IDs through user profiles for dashboard message shaping

## Tests
- cd backend && uv run pytest tests/test_app/test_app_wallet_human.py -q
- cd frontend && NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build