### PR TITLE
fix: guide users when bot devices are offline

### DIFF
--- a/frontend/src/components/dashboard/CreateAgentDialog.tsx
+++ b/frontend/src/components/dashboard/CreateAgentDialog.tsx
@@ -207,6 +207,8 @@ export default function CreateAgentDialog({
     () => daemons.filter((d) => d.status === "online"),
     [daemons],
   );
+  const hasOfflineBoundDevices = daemons.some((d) => d.status === "offline");
+  const hasOnlyOfflineBoundDevices = loaded && hasOfflineBoundDevices && onlineDaemons.length === 0;
 
   const [selectedDaemonId, setSelectedDaemonId] = useState<string | null>(null);
   const [selectedRuntimeId, setSelectedRuntimeId] = useState<string | null>(null);
@@ -534,13 +536,18 @@ export default function CreateAgentDialog({
         {(() => {
           const onStep1 = showEmptyState || addingDevice;
           const currentStep: 1 | 2 = onStep1 ? 1 : 2;
+          const showWizardHeader = !hasExistingBots || (onStep1 && hasOnlyOfflineBoundDevices);
+          const step1Title = hasOnlyOfflineBoundDevices ? t.step1OfflineTitle : t.step1Title;
+          const step1Description = hasOnlyOfflineBoundDevices
+            ? t.step1OfflineDescription
+            : t.step1Description;
           return (
             <>
               <div className="flex shrink-0 items-center gap-3 border-b border-glass-border/40 px-4 py-3 sm:px-5">
                 <div className="min-w-0 flex-1">
-                  {hasExistingBots ? (
+                  {!showWizardHeader ? (
                     <h3
-                      id="create-agent-title"
+                      id={onStep1 ? undefined : "create-agent-title"}
                       className="flex items-center gap-2 text-base font-semibold text-text-primary"
                     >
                       <Bot className="h-4 w-4 text-neon-cyan" />
@@ -566,6 +573,17 @@ export default function CreateAgentDialog({
                 </button>
               </div>
               <div className="flex-1 overflow-x-hidden overflow-y-auto overscroll-contain px-4 py-4 sm:px-5">
+              {onStep1 && !addingDevice ? (
+                <div className="mb-4">
+                  <h3 id="create-agent-title" className="flex items-center gap-2 text-xl font-bold text-text-primary">
+                    <Server className="h-5 w-5 text-neon-cyan" />
+                    {step1Title}
+                  </h3>
+                  <p className="mt-1.5 text-sm leading-6 text-text-secondary">
+                    {step1Description}
+                  </p>
+                </div>
+              ) : null}
               {!hasExistingBots && !onStep1 && (
                 <div className="mb-4">
                   <h3 id="create-agent-title" className="flex items-center gap-2 text-xl font-bold text-text-primary">
@@ -585,6 +603,7 @@ export default function CreateAgentDialog({
             connected={false}
             daemonLoading={loading}
             onRefreshDaemons={() => void refresh()}
+            offlineDevices={hasOnlyOfflineBoundDevices}
           />
         ) : justConnected ? (
           <div className="animate-in fade-in duration-200 flex flex-col items-center gap-3 py-10 text-center">
@@ -612,6 +631,7 @@ export default function CreateAgentDialog({
               connected={false}
               daemonLoading={loading}
               onRefreshDaemons={() => void refresh()}
+              offlineDevices={false}
             />
           </div>
         ) : (

--- a/frontend/src/components/dashboard/HomePanel.tsx
+++ b/frontend/src/components/dashboard/HomePanel.tsx
@@ -472,10 +472,12 @@ export function DeviceConnectPanel({
   connected,
   daemonLoading,
   onRefreshDaemons,
+  offlineDevices = false,
 }: {
   connected: boolean;
   daemonLoading: boolean;
   onRefreshDaemons: () => void;
+  offlineDevices?: boolean;
 }) {
   const locale = useLanguage();
   const isZh = locale === "zh";
@@ -491,6 +493,25 @@ export function DeviceConnectPanel({
     : command;
   const copyDisabled = tokenLoading;
   const deviceConnected = connected;
+  const panelTitle = offlineDevices
+    ? isZh
+      ? <>在你的电脑的<TerminalWord>终端</TerminalWord>里运行此命令重启 BotCord</>
+      : <>Run this command in your computer's <TerminalWord>Terminal</TerminalWord> to restart BotCord</>
+    : isZh
+      ? <>在你的电脑的<TerminalWord>终端</TerminalWord>里运行此命令</>
+      : <>Run this command in your computer's <TerminalWord>Terminal</TerminalWord></>;
+  const panelDescription = offlineDevices
+    ? isZh
+      ? "重启并连接成功后，会自动出现在这里。"
+      : "Once it restarts and reconnects, it will show up here automatically."
+    : "Once it connects, it will show up here automatically.";
+  const refreshPrompt = offlineDevices
+    ? isZh
+      ? "已经在设备上重启 BotCord？"
+      : "Already restarted BotCord on this device?"
+    : isZh
+      ? "已经在这台机器上运行 BotCord？"
+      : "Already running BotCord on this machine?";
 
   useEffect(() => {
     void refreshInstallCommand();
@@ -554,14 +575,10 @@ export function DeviceConnectPanel({
                   Install command
                 </div>
                 <h4 className="text-sm font-semibold leading-snug text-text-primary">
-                  {isZh ? (
-                    <>在你的电脑的<TerminalWord>终端</TerminalWord>里运行此命令</>
-                  ) : (
-                    <>Run this command in your computer's <TerminalWord>Terminal</TerminalWord></>
-                  )}
+                  {panelTitle}
                 </h4>
                 <p className="mt-1 text-xs text-text-secondary/70">
-                  Once it connects, it will show up here automatically.
+                  {panelDescription}
                 </p>
               </div>
 
@@ -613,7 +630,7 @@ export function DeviceConnectPanel({
 
           {!deviceConnected && (
             <div className="flex flex-col gap-3 text-sm text-text-secondary/70 sm:flex-row sm:items-center sm:justify-between">
-              <span>Already running BotCord on this machine?</span>
+              <span>{refreshPrompt}</span>
               <button
                 type="button"
                 onClick={handleRefresh}

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -2246,6 +2246,8 @@ export const createAgentDialog: TranslationMap<{
   stepBotLabel: string
   step1Title: string
   step1Description: string
+  step1OfflineTitle: string
+  step1OfflineDescription: string
   step2Description: string
   runtimeSectionLabel: string
   identitySectionLabel: string
@@ -2304,6 +2306,8 @@ export const createAgentDialog: TranslationMap<{
     stepBotLabel: 'Create Bot',
     step1Title: 'Connect device',
     step1Description: 'Run BotCord on your computer so it can host your Bots.',
+    step1OfflineTitle: 'No online device detected',
+    step1OfflineDescription: 'You already have devices bound, but none are online right now. Run the command below on your device to restart BotCord, then this dialog will continue automatically.',
     step2Description: 'Pick where it runs, then give it a name.',
     runtimeSectionLabel: 'Where it runs',
     identitySectionLabel: 'Bot identity',
@@ -2362,6 +2366,8 @@ export const createAgentDialog: TranslationMap<{
     stepBotLabel: '创建 Bot',
     step1Title: '接入设备',
     step1Description: '在你的电脑上运行 BotCord，这样它就能托管你的 Bot。',
+    step1OfflineTitle: '未检测到在线设备',
+    step1OfflineDescription: '你已经绑定过设备，但当前没有任何设备在线。请在设备上运行下面的命令重启 BotCord，恢复在线后会自动进入创建流程。',
     step2Description: '选择运行环境，然后给 Bot 起个名字。',
     runtimeSectionLabel: '运行环境',
     identitySectionLabel: 'Bot 身份',


### PR DESCRIPTION
## Summary
- reuse the create-bot device step when all bound devices are offline
- show offline-device copy that tells users to restart BotCord with the command
- keep first-time device connection copy unchanged

## Tests
- cd frontend && pnpm run build