### PR TITLE
fix: cache room members during message switches

### DIFF
--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -45,6 +45,7 @@ import ActivityPanel from "./ActivityPanel";
 
 const USER_CHAT_SUBTAB = "__user-chat__";
 const MESSAGES_DIRECTORY_SYNC_INTERVAL_MS = 30_000;
+const ROOM_SWITCH_DIRECTORY_DEFER_MS = 5_000;
 
 type BotcordDebugRealtimeSnapshot = {
   supabaseUrl: string | undefined;
@@ -101,6 +102,7 @@ export default function DashboardApp() {
   const initResolvedRef = useRef(false);
   const lastAccessTokenRef = useRef<string | null>(null);
   const lastMessagesDirectorySyncRef = useRef(0);
+  const lastMessageRoomSwitchRef = useRef(0);
   const pathnameParts = useMemo(() => pathname.split("/").filter(Boolean), [pathname]);
   const shouldShowBootstrapSkeleton = !sessionStore.authResolved || sessionStore.authBootstrapping;
   const fallbackAgent =
@@ -288,6 +290,10 @@ export default function DashboardApp() {
         if (uiStore.messagesPane !== "room") uiStore.setMessagesPane("room");
         const roomIdFromPath = subtab ? decodeRoomIdFromPath(subtab) : null;
         if (roomIdFromPath) {
+          const isSwitchingRooms = uiStore.openedRoomId !== roomIdFromPath;
+          if (isSwitchingRooms) {
+            lastMessageRoomSwitchRef.current = Date.now();
+          }
           if (uiStore.focusedRoomId !== roomIdFromPath) uiStore.setFocusedRoomId(roomIdFromPath);
           if (uiStore.openedRoomId !== roomIdFromPath) uiStore.setOpenedRoomId(roomIdFromPath);
 
@@ -667,8 +673,12 @@ export default function DashboardApp() {
         const session = useDashboardSessionStore.getState();
         const chat = useDashboardChatStore.getState();
         const now = Date.now();
+        const recentlySwitchedRoom = now - lastMessageRoomSwitchRef.current < ROOM_SWITCH_DIRECTORY_DEFER_MS;
         const shouldSyncDirectory = Boolean(opts?.forceDirectory)
-          || now - lastMessagesDirectorySyncRef.current >= MESSAGES_DIRECTORY_SYNC_INTERVAL_MS;
+          || (
+            !recentlySwitchedRoom
+            && now - lastMessagesDirectorySyncRef.current >= MESSAGES_DIRECTORY_SYNC_INTERVAL_MS
+          );
         if (shouldSyncDirectory) {
           lastMessagesDirectorySyncRef.current = now;
         }

--- a/frontend/src/components/dashboard/MessageList.tsx
+++ b/frontend/src/components/dashboard/MessageList.tsx
@@ -14,7 +14,6 @@ import { useShallow } from "zustand/react/shallow";
 import MessageBubble from "./MessageBubble";
 import type { DashboardMessage, PublicRoomMember, TopicInfo } from "@/lib/types";
 import type { MentionTextCandidate } from "@/components/ui/MarkdownContent";
-import { api } from "@/lib/api";
 import { getLatestSeenAtForRoom } from "@/store/dashboard-shared";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
@@ -230,12 +229,13 @@ export default function MessageList() {
     openedRoomId: state.openedRoomId,
     setOpenedTopicId: state.setOpenedTopicId,
   })));
-  const { messagesByRoom, messagesLoading, messagesHasMore, loadMoreMessages, overview } = useDashboardChatStore(
+  const { messagesByRoom, messagesLoading, messagesHasMore, loadMoreMessages, loadRoomMembers, overview } = useDashboardChatStore(
     useShallow((state) => ({
       messagesByRoom: state.messages,
       messagesLoading: state.messagesLoading,
       messagesHasMore: state.messagesHasMore,
       loadMoreMessages: state.loadMoreMessages,
+      loadRoomMembers: state.loadRoomMembers,
       overview: state.overview,
     })),
   );
@@ -286,13 +286,12 @@ export default function MessageList() {
       return;
     }
     let cancelled = false;
-    api.getRoomMembers(roomId)
-      .catch(() => api.getPublicRoomMembers(roomId))
-      .then((result) => {
+    loadRoomMembers(roomId)
+      .then((members) => {
         if (cancelled) return;
-        setRoomMembers(result.members);
+        setRoomMembers(members);
         usePresenceStore.getState().seed(
-          result.members.map((m) => ({ agentId: m.agent_id, online: Boolean(m.online) })),
+          members.map((m) => ({ agentId: m.agent_id, online: Boolean(m.online) })),
         );
       })
       .catch(() => {
@@ -301,7 +300,7 @@ export default function MessageList() {
     return () => {
       cancelled = true;
     };
-  }, [roomId, roomMemberVersion]);
+  }, [roomId, roomMemberVersion, loadRoomMembers]);
 
   const commitRoomSeen = useCallback((targetRoomId: string) => {
     const joinedRoom = overview?.rooms.find((room) => room.room_id === targetRoomId);

--- a/frontend/src/components/dashboard/RoomHumanComposer.tsx
+++ b/frontend/src/components/dashboard/RoomHumanComposer.tsx
@@ -223,11 +223,12 @@ export default function RoomHumanComposer({ roomId, topicId = null }: RoomHumanC
     human: s.human,
     viewMode: s.viewMode,
   })));
-  const { insertMessage, patchRoom, pollNewMessages, refreshOverview } = useDashboardChatStore(useShallow((s) => ({
+  const { insertMessage, patchRoom, pollNewMessages, refreshOverview, loadRoomMembers } = useDashboardChatStore(useShallow((s) => ({
     insertMessage: s.insertMessage,
     patchRoom: s.patchRoom,
     pollNewMessages: s.pollNewMessages,
     refreshOverview: s.refreshOverview,
+    loadRoomMembers: s.loadRoomMembers,
   })));
   const hasRoomInOverview = useDashboardChatStore(
     (s) => Boolean(s.overview?.rooms.some((r) => r.room_id === roomId)),
@@ -269,14 +270,14 @@ export default function RoomHumanComposer({ roomId, topicId = null }: RoomHumanC
     let cancelled = false;
     (async () => {
       try {
-        const res = await api.getRoomMembers(roomId);
-        if (!cancelled) setMembers(res.members);
+        const members = await loadRoomMembers(roomId);
+        if (!cancelled) setMembers(members);
       } catch {
         if (!cancelled) setMembers([]);
       }
     })();
     return () => { cancelled = true; };
-  }, [roomId, isOwnerChat, roomMemberVersion]);
+  }, [roomId, isOwnerChat, roomMemberVersion, loadRoomMembers]);
 
   const selfId = viewMode === "agent" ? activeAgentId : human?.human_id;
   const senderIdentity: ActiveIdentity | null = activeIdentity ?? (

--- a/frontend/src/store/useDashboardChatStore.ts
+++ b/frontend/src/store/useDashboardChatStore.ts
@@ -15,6 +15,7 @@ import type {
   DiscoverRoom,
   HumanAgentRoomSummary,
   PublicHumanProfile,
+  PublicRoomMember,
   PublicRoom,
   RealtimeMetaEvent,
 } from "@/lib/types";
@@ -35,6 +36,14 @@ let publicRoomsRequestSeq = 0;
 let publicAgentsRequestSeq = 0;
 let publicHumansRequestSeq = 0;
 const emptyRoomMessageSnapshot = new Map<string, string | null>();
+const ROOM_MEMBERS_CACHE_TTL_MS = 5 * 60 * 1000;
+const roomMembersInFlight = new Map<string, Promise<PublicRoomMember[]>>();
+
+interface RoomMembersCacheEntry {
+  members: PublicRoomMember[];
+  version: number;
+  loadedAt: number;
+}
 
 function isFetchNetworkError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
@@ -117,6 +126,7 @@ interface DashboardChatState {
   ownedAgentRoomsLoading: boolean;
   ownedAgentRoomsLoaded: boolean;
   roomMemberVersions: Record<string, number>;
+  roomMembersByRoom: Record<string, RoomMembersCacheEntry>;
 
   setError: (error: string | null) => void;
   addRecentPublicRoom: (room: PublicRoom) => void;
@@ -131,6 +141,7 @@ interface DashboardChatState {
   replaceOverview: (overview: DashboardOverview) => void;
   patchRoom: (roomId: string, patch: Partial<DashboardRoom>) => void;
   bumpRoomMembersVersion: (roomId: string) => void;
+  loadRoomMembers: (roomId: string, opts?: { force?: boolean }) => Promise<PublicRoomMember[]>;
 
   insertMessage: (roomId: string, message: DashboardMessage) => void;
   loadRoomMessages: (roomId: string) => Promise<void>;
@@ -184,6 +195,7 @@ const initialChatState = {
   ownedAgentRoomsLoading: false,
   ownedAgentRoomsLoaded: false,
   roomMemberVersions: {},
+  roomMembersByRoom: {},
 };
 
 function hasTransientChatState(state: DashboardChatState): boolean {
@@ -194,6 +206,7 @@ function hasTransientChatState(state: DashboardChatState): boolean {
     || Object.keys(state.messages).length > 0
     || Object.keys(state.messagesLoading).length > 0
     || Object.keys(state.messagesHasMore).length > 0
+    || Object.keys(state.roomMembersByRoom).length > 0
     || state.error !== null
     || state.selectedAgentId !== null
     || state.selectedAgentLoading
@@ -358,7 +371,54 @@ export const useDashboardChatStore = create<DashboardChatState>()(
             ...state.roomMemberVersions,
             [roomId]: (state.roomMemberVersions[roomId] ?? 0) + 1,
           },
+          roomMembersByRoom: Object.fromEntries(
+            Object.entries(state.roomMembersByRoom).filter(([key]) => key !== roomId),
+          ),
         })),
+
+      loadRoomMembers: async (roomId, opts) => {
+        const state = get();
+        const version = state.roomMemberVersions[roomId] ?? 0;
+        const cached = state.roomMembersByRoom[roomId];
+        const now = Date.now();
+        if (
+          !opts?.force
+          && cached
+          && cached.version === version
+          && now - cached.loadedAt < ROOM_MEMBERS_CACHE_TTL_MS
+        ) {
+          return cached.members;
+        }
+
+        const inFlight = roomMembersInFlight.get(roomId);
+        if (inFlight && !opts?.force) return inFlight;
+
+        const request = api
+          .getRoomMembers(roomId)
+          .catch(() => api.getPublicRoomMembers(roomId))
+          .then((result) => {
+            const members = result.members;
+            set((current) => ({
+              roomMembersByRoom: {
+                ...current.roomMembersByRoom,
+                [roomId]: {
+                  members,
+                  version: current.roomMemberVersions[roomId] ?? 0,
+                  loadedAt: Date.now(),
+                },
+              },
+            }));
+            return members;
+          })
+          .finally(() => {
+            if (roomMembersInFlight.get(roomId) === request) {
+              roomMembersInFlight.delete(roomId);
+            }
+          });
+
+        roomMembersInFlight.set(roomId, request);
+        return request;
+      },
 
       loadRoomMessages: async (roomId: string) => {
         if (roomMessagesInFlight.has(roomId)) {


### PR DESCRIPTION
## Summary
- add cached, in-flight deduped room member loading in the dashboard chat store
- share room member loads between MessageList and RoomHumanComposer so room switches do not issue duplicate /members requests
- defer directory refreshes for a short window after switching message rooms so background sync does not contend with the active room load

## Verification
- cd frontend && npm run build

## Notes
- Build was run in a clean worktree using local env values for Supabase prerendering.