### PR TITLE
fix: expose public agent online status

### DIFF
--- a/backend/app/routers/public.py
+++ b/backend/app/routers/public.py
@@ -232,6 +232,7 @@ async def public_overview(
             "bio": a.bio,
             "message_policy": a.message_policy.value if hasattr(a.message_policy, "value") else str(a.message_policy),
             "created_at": a.created_at.isoformat() if a.created_at else None,
+            "online": is_agent_ws_online(a.agent_id),
         }
         for a in agent_result.scalars().all()
     ]
@@ -526,6 +527,7 @@ async def list_public_agents(
                 "created_at": agent.created_at.isoformat() if agent.created_at else None,
                 "owner_human_id": owner_human_id,
                 "owner_display_name": owner_display_name,
+                "online": is_agent_ws_online(agent.agent_id),
             }
             for agent, owner_human_id, owner_display_name in result.all()
         ],
@@ -557,6 +559,7 @@ async def get_public_agent(
         "created_at": agent.created_at.isoformat() if agent.created_at else None,
         "owner_human_id": owner_human_id,
         "owner_display_name": owner_display_name,
+        "online": is_agent_ws_online(agent.agent_id),
     }
 
 

--- a/backend/tests/test_app/test_app_public.py
+++ b/backend/tests/test_app/test_app_public.py
@@ -261,6 +261,28 @@ async def test_public_agents_list(client: AsyncClient, seed: dict):
 
 
 @pytest.mark.asyncio
+async def test_public_agents_list_includes_online(
+    client: AsyncClient,
+    seed: dict,
+    monkeypatch,
+):
+    import app.routers.public as public_mod
+
+    monkeypatch.setattr(
+        public_mod,
+        "is_agent_ws_online",
+        lambda agent_id: agent_id == "ag_pub_agent2",
+    )
+
+    resp = await client.get("/api/public/agents")
+
+    assert resp.status_code == 200
+    agents = {agent["agent_id"]: agent for agent in resp.json()["agents"]}
+    assert agents["ag_pub_agent1"]["online"] is False
+    assert agents["ag_pub_agent2"]["online"] is True
+
+
+@pytest.mark.asyncio
 async def test_public_agents_list_orders_by_newest_created(
     client: AsyncClient,
     db_session: AsyncSession,
@@ -303,6 +325,22 @@ async def test_public_agent_detail(client: AsyncClient, seed: dict):
     data = resp.json()
     assert data["agent_id"] == "ag_pub_agent1"
     assert data["display_name"] == "Public Agent"
+
+
+@pytest.mark.asyncio
+async def test_public_agent_detail_includes_online(
+    client: AsyncClient,
+    seed: dict,
+    monkeypatch,
+):
+    import app.routers.public as public_mod
+
+    monkeypatch.setattr(public_mod, "is_agent_ws_online", lambda _agent_id: True)
+
+    resp = await client.get("/api/public/agents/ag_pub_agent1")
+
+    assert resp.status_code == 200
+    assert resp.json()["online"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- return online status from public agent overview, list, and detail endpoints
- add public API coverage for agent online fields

## Tests
- cd backend && uv run pytest tests/test_app/test_app_public.py -q