### PR TITLE
fix: improve message room switching and dashboard dialogs

### DIFF
--- a/frontend/src/app/(dashboard)/settings/policy/PolicySettingsClient.tsx
+++ b/frontend/src/app/(dashboard)/settings/policy/PolicySettingsClient.tsx
@@ -11,6 +11,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { Bell, Bot, Loader2, MessageSquare, Shield, UserRound, X } from "lucide-react";
 import { userApi } from "@/lib/api";
 import type { UserAgent } from "@/lib/types";
+import DashboardSelect from "@/components/dashboard/DashboardSelect";
 import {
   usePolicyStore,
   type AgentPolicy,
@@ -264,18 +265,18 @@ export default function PolicySettingsClient() {
     }
     return (
       <label className="flex items-center gap-2 text-sm text-text-secondary">
-        Agent
-        <select
+        <span className="shrink-0">Agent</span>
+        <DashboardSelect
           value={selectedAgentId ?? ""}
-          onChange={(e) => setSelectedAgentId(e.target.value || null)}
-          className="rounded-lg border border-glass-border bg-deep-black/40 px-2 py-1 text-text-primary"
-        >
-          {agents.map((a) => (
-            <option key={a.agent_id} value={a.agent_id}>
-              {a.display_name}
-            </option>
-          ))}
-        </select>
+          onChange={(value) => setSelectedAgentId(value || null)}
+          placeholder="选择 Agent"
+          className="min-w-48"
+          buttonClassName="min-h-8 rounded-lg bg-deep-black/40 px-2 text-xs"
+          options={agents.map((a) => ({
+            value: a.agent_id,
+            label: a.display_name,
+          }))}
+        />
       </label>
     );
   }, [agents, selectedAgentId]);

--- a/frontend/src/components/dashboard/AddDeviceDialog.tsx
+++ b/frontend/src/components/dashboard/AddDeviceDialog.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+/**
+ * [INPUT]: daemon store refresh state + DeviceConnectPanel shared onboarding UI
+ * [OUTPUT]: AddDeviceDialog — standalone add-device modal using the same device binding panel as CreateAgentDialog
+ * [POS]: My Bots devices page and sidebar Bots panel add-device actions
+ * [PROTOCOL]: update header on changes
+ */
+
+import { useEffect, useRef } from "react";
+import { Cpu, X } from "lucide-react";
+import { useDaemonStore } from "@/store/useDaemonStore";
+import { useLanguage } from "@/lib/i18n";
+import { DeviceConnectPanel } from "./HomePanel";
+
+interface AddDeviceDialogProps {
+  onClose: () => void;
+}
+
+export default function AddDeviceDialog({ onClose }: AddDeviceDialogProps) {
+  const locale = useLanguage();
+  const daemons = useDaemonStore((s) => s.daemons);
+  const loading = useDaemonStore((s) => s.loading);
+  const refresh = useDaemonStore((s) => s.refresh);
+  const existingIdsRef = useRef<Set<string> | null>(null);
+
+  if (existingIdsRef.current === null) {
+    existingIdsRef.current = new Set(daemons.map((d) => d.id));
+  }
+
+  const connected = daemons.some(
+    (d) => d.status === "online" && !existingIdsRef.current?.has(d.id),
+  );
+
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      void refresh({ quiet: true });
+    }, 3_000);
+    return () => window.clearInterval(id);
+  }, [refresh]);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-[110] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="add-device-title"
+        className="relative flex max-h-[calc(100dvh-2rem)] w-full max-w-xl flex-col overflow-hidden rounded-2xl border border-glass-border bg-deep-black-light shadow-2xl"
+      >
+        <div className="flex shrink-0 items-center gap-3 border-b border-glass-border/40 px-4 py-3 sm:px-5">
+          <h3
+            id="add-device-title"
+            className="flex min-w-0 flex-1 items-center gap-2 text-base font-semibold text-text-primary"
+          >
+            <Cpu className="h-4 w-4 shrink-0 text-neon-cyan" />
+            {locale === "zh" ? "添加设备" : "Add Device"}
+          </h3>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={locale === "zh" ? "关闭" : "Close"}
+            className="shrink-0 rounded-full p-1.5 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+        <div className="flex-1 overflow-x-hidden overflow-y-auto overscroll-contain px-4 py-4 sm:px-5">
+          {connected ? (
+            <div className="mb-4 rounded-xl border border-neon-green/30 bg-neon-green/10 px-3 py-2 text-xs text-neon-green">
+              {locale === "zh" ? "新设备已连接。" : "New device connected."}
+            </div>
+          ) : null}
+          <DeviceConnectPanel
+            connected={connected}
+            daemonLoading={loading}
+            onRefreshDaemons={() => void refresh()}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/AddRoomMemberModal.tsx
+++ b/frontend/src/components/dashboard/AddRoomMemberModal.tsx
@@ -94,9 +94,9 @@ export default function AddRoomMemberModal({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4" onClick={onClose}>
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4" onClick={onClose}>
       <div
-        className="flex max-h-[90vh] w-full max-w-lg flex-col overflow-hidden rounded-xl border border-glass-border bg-deep-black"
+        className="flex h-[min(760px,calc(100dvh-2rem))] w-full max-w-2xl flex-col overflow-hidden rounded-xl border border-glass-border bg-deep-black"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between border-b border-glass-border px-6 py-4">
@@ -145,6 +145,7 @@ export default function AddRoomMemberModal({
               searchPlaceholder={t.searchAddableMembers}
               emptyLabel={t.noAddableMembers}
               selectedLabel={(count) => t.addMemberSelectableCount.replace("{count}", String(count))}
+              panelClassName="max-h-[min(440px,calc(100dvh-20rem))]"
             />
           )}
         </div>

--- a/frontend/src/components/dashboard/BotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/BotDetailDrawer.tsx
@@ -37,6 +37,7 @@ import AgentSchedulesTab from "./AgentSchedulesTab";
 import BotAvatar from "./BotAvatar";
 import { CompositeAvatar } from "./CompositeAvatar";
 import BotWalletTab from "./BotWalletTab";
+import DashboardSelect from "./DashboardSelect";
 
 type TabKey = "overview" | "wallet" | "settings" | "files";
 type BotDetailDrawerCopy = typeof botDetailDrawer["en"];
@@ -718,15 +719,18 @@ function PolicyTab({ agentId, t }: { agentId: string; t: BotDetailDrawerCopy }) 
           </label>
         </div>
         <label className="mt-4 flex items-center gap-2 text-sm text-text-secondary">
-          {t.settings.roomInvite}
-          <select
+          <span className="shrink-0">{t.settings.roomInvite}</span>
+          <DashboardSelect
             value={policy.room_invite_policy}
-            onChange={(e) => void applyPolicy({ room_invite_policy: e.target.value as RoomInvitePolicy })}
+            onChange={(value) => {
+              if (value) void applyPolicy({ room_invite_policy: value as RoomInvitePolicy });
+            }}
             disabled={saving}
-            className="rounded-lg border border-glass-border bg-deep-black/40 px-2 py-1 text-text-primary"
-          >
-            {roomInviteOptions.map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
-          </select>
+            placeholder={t.settings.roomInvite}
+            className="min-w-40"
+            buttonClassName="min-h-8 rounded-lg bg-deep-black/40 px-2 text-xs"
+            options={roomInviteOptions.map((opt) => ({ value: opt.value, label: opt.label }))}
+          />
         </label>
       </section>
 

--- a/frontend/src/components/dashboard/ChatPane.tsx
+++ b/frontend/src/components/dashboard/ChatPane.tsx
@@ -630,22 +630,6 @@ export default function ChatPane({ onHumanOpen, sidebarTabOverride }: ChatPanePr
   const isAuthedHuman = sessionMode === "authed-no-agent";
   const showLoginModal = () => router.push("/login");
 
-  // Seed presence for the opened room's members so MessageBubble's PresenceDot
-  // reflects real online state. Without this, senders that aren't the user's
-  // own agents stay "offline" until they happen to transition during the
-  // session — realtime presence events only fire on online/offline edges.
-  useEffect(() => {
-    if (!openedRoomId) return;
-    void useDashboardChatStore.getState()
-      .loadRoomMembers(openedRoomId)
-      .then((members) => {
-        usePresenceStore.getState().seed(
-          members.map((m) => ({ agentId: m.agent_id, online: Boolean(m.online) })),
-        );
-      })
-      .catch(() => {});
-  }, [openedRoomId]);
-
   if (effectiveSidebarTab === "explore") {
     return <ExploreMainPane onHumanOpen={onHumanOpen} />;
   }

--- a/frontend/src/components/dashboard/CreateAgentDialog.tsx
+++ b/frontend/src/components/dashboard/CreateAgentDialog.tsx
@@ -45,6 +45,7 @@ import {
 import InstallCommandPanel from "./InstallCommandPanel";
 import DaemonInstallCommand from "@/components/daemon/DaemonInstallCommand";
 import { DeviceConnectPanel } from "./HomePanel";
+import DashboardSelect from "./DashboardSelect";
 
 interface CreateAgentDialogProps {
   onClose: () => void;
@@ -687,23 +688,20 @@ export default function CreateAgentDialog({
                 </button>
               </div>
               {onlineDaemons.length > 1 ? (
-                <div className="relative">
-                  <Server className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-neon-cyan" />
-                  <select
-                    value={selectedDaemonId ?? ""}
-                    onChange={(e) => setSelectedDaemonId(e.target.value)}
-                    disabled={submitting}
-                    className="h-11 w-full appearance-none rounded-xl border border-glass-border bg-deep-black py-0 pl-9 pr-10 text-sm text-text-primary focus:border-neon-cyan focus:outline-none focus:ring-1 focus:ring-neon-cyan/50 disabled:opacity-50"
-                  >
-                    {onlineDaemons.map((d, index) => (
-                      <option key={d.id} value={d.id}>
-                        {d.label || d.id}
-                        {index === onlineDaemons.length - 1 ? " · latest" : ""}
-                      </option>
-                    ))}
-                  </select>
-                  <ChevronDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-secondary" />
-                </div>
+                <DashboardSelect
+                  value={selectedDaemonId}
+                  onChange={(value) => {
+                    if (value) setSelectedDaemonId(value);
+                  }}
+                  disabled={submitting}
+                  placeholder={t.daemonLabel}
+                  leadingIcon={<Server className="h-3.5 w-3.5 text-neon-cyan" />}
+                  buttonClassName="min-h-11 pl-3"
+                  options={onlineDaemons.map((d, index) => ({
+                    value: d.id,
+                    label: `${d.label || d.id}${index === onlineDaemons.length - 1 ? " · latest" : ""}`,
+                  }))}
+                />
               ) : selectedDaemon ? (
                 <div className="flex h-11 items-center gap-2 rounded-xl border border-glass-border bg-deep-black px-3 text-xs text-text-secondary">
                   <Server className="h-3.5 w-3.5 text-neon-cyan" />
@@ -1133,22 +1131,18 @@ function OpenclawGatewayPicker({
           Gateway
         </label>
         <div className="relative">
-          <select
+          <DashboardSelect
             disabled={disabled}
             value={selectedGateway ?? ""}
-            onChange={(e) => onSelectGateway(e.target.value || null)}
-            className="h-10 w-full appearance-none rounded-xl border border-glass-border bg-deep-black px-3 pr-10 text-sm text-text-primary focus:border-neon-cyan focus:outline-none focus:ring-1 focus:ring-neon-cyan/50 disabled:opacity-50"
-          >
-            <option value="" disabled>
-              Select a gateway
-            </option>
-            {endpoints.map((e) => (
-              <option key={e.name} value={e.name} disabled={!e.reachable}>
-                {e.name} — {e.url} {e.reachable ? `(${e.version ?? "ok"})` : `✗ ${e.error ?? "unreachable"}`}
-              </option>
-            ))}
-          </select>
-          <ChevronDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-secondary" />
+            onChange={onSelectGateway}
+            placeholder="Select a gateway"
+            options={endpoints.map((e) => ({
+              value: e.name,
+              label: e.name,
+              sublabel: `${e.url} ${e.reachable ? `(${e.version ?? "ok"})` : `- ${e.error ?? "unreachable"}`}`,
+              disabled: !e.reachable,
+            }))}
+          />
         </div>
         {reachable.length === 0 && (
           <p className="mt-1 text-[11px] text-orange-400">
@@ -1180,27 +1174,21 @@ function OpenclawGatewayPicker({
           />
         ) : (
           <div className="relative">
-            <select
+            <DashboardSelect
               disabled={disabled || !selectedGateway || availableAgents.length === 0}
               value={selectedAgent ?? ""}
-              onChange={(e) => onSelectAgent(e.target.value || null)}
-              className="h-10 w-full appearance-none rounded-xl border border-glass-border bg-deep-black px-3 pr-10 text-sm text-text-primary focus:border-neon-cyan focus:outline-none focus:ring-1 focus:ring-neon-cyan/50 disabled:opacity-50"
-            >
-              <option value="" disabled>
-                {availableAgents.length === 0 ? labels.noProfiles : labels.selectProfile}
-              </option>
-              {availableAgents.map((a) => {
+              onChange={onSelectAgent}
+              placeholder={availableAgents.length === 0 ? labels.noProfiles : labels.selectProfile}
+              options={availableAgents.map((a) => {
                 const label =
                   (a.name && a.name !== a.id ? `${a.name} (${a.id})` : a.id) +
                   (a.model?.name ? ` — ${a.model.name}` : "");
-                return (
-                  <option key={a.id} value={a.id}>
-                    {label}
-                  </option>
-                );
+                return {
+                  value: a.id,
+                  label,
+                };
               })}
-            </select>
-            <ChevronDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-secondary" />
+            />
           </div>
         )}
         {boundCount > 0 && (
@@ -1246,35 +1234,30 @@ function HermesProfilePicker({
         Hermes profile
       </label>
       <div className="relative">
-        <select
+        <DashboardSelect
           disabled={disabled}
           value={selectedProfile ?? ""}
-          onChange={(e) => onSelect(e.target.value || null)}
-          className="h-10 w-full appearance-none rounded-xl border border-glass-border bg-deep-black px-3 pr-10 text-sm text-text-primary focus:border-neon-cyan focus:outline-none focus:ring-1 focus:ring-neon-cyan/50 disabled:opacity-50"
-        >
-          <option value="" disabled>
-            Select a profile
-          </option>
-          {profiles.map((p) => {
+          onChange={onSelect}
+          placeholder="Select a profile"
+          options={profiles.map((p) => {
             const occupied = !!p.occupiedBy;
             const labelParts: string[] = [p.name];
             if (p.isDefault) labelParts.push("(default)");
             if (p.modelName) labelParts.push(`— ${p.modelName}`);
+            const sublabelParts: string[] = [];
             if (occupied) {
-              labelParts.push(
-                `· bound to ${p.occupiedByName ?? p.occupiedBy ?? "another agent"}`,
-              );
+              sublabelParts.push(`bound to ${p.occupiedByName ?? p.occupiedBy ?? "another agent"}`);
             } else if (p.isActive) {
-              labelParts.push("· active");
+              sublabelParts.push("active");
             }
-            return (
-              <option key={p.name} value={p.name} disabled={occupied}>
-                {labelParts.join(" ")}
-              </option>
-            );
+            return {
+              value: p.name,
+              label: labelParts.join(" "),
+              sublabel: sublabelParts.join(" "),
+              disabled: occupied,
+            };
           })}
-        </select>
-        <ChevronDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-secondary" />
+        />
       </div>
       <p className="mt-1 text-[11px] text-text-tertiary">
         BotCord agent attaches to this profile&apos;s{" "}

--- a/frontend/src/components/dashboard/CreateAgentDialog.tsx
+++ b/frontend/src/components/dashboard/CreateAgentDialog.tsx
@@ -263,6 +263,30 @@ export default function CreateAgentDialog({
     prevHadOnlineRef.current = hasOnline;
   }, [loaded, onlineDaemons.length]);
 
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape" && !submitting) onClose();
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onClose, submitting]);
+
+  // Brief celebratory state when a daemon transitions from offline to online
+  // while the user is staring at step 1. Without this, the dialog snaps to
+  // step 2 with no acknowledgement that the device just connected.
+  useEffect(() => {
+    if (!loaded) return;
+    const hasOnline = onlineDaemons.length > 0;
+    const prev = prevHadOnlineRef.current;
+    if (prev === false && hasOnline) {
+      setJustConnected(true);
+      const t = window.setTimeout(() => setJustConnected(false), 1500);
+      prevHadOnlineRef.current = hasOnline;
+      return () => window.clearTimeout(t);
+    }
+    prevHadOnlineRef.current = hasOnline;
+  }, [loaded, onlineDaemons.length]);
+
   // Auto-select first online daemon once the list arrives.
   // If a preselectedDaemonId was provided, use that instead.
   useEffect(() => {

--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -46,6 +46,7 @@ import ActivityPanel from "./ActivityPanel";
 
 const USER_CHAT_SUBTAB = "__user-chat__";
 type DashboardSidebarTab = "home" | "messages" | "contacts" | "explore" | "wallet" | "activity" | "bots";
+const MESSAGES_DIRECTORY_SYNC_INTERVAL_MS = 30_000;
 
 type BotcordDebugRealtimeSnapshot = {
   supabaseUrl: string | undefined;
@@ -116,6 +117,7 @@ export default function DashboardApp() {
   const subscriptionBoundAgentRef = useRef<string | null>(null);
   const initResolvedRef = useRef(false);
   const lastAccessTokenRef = useRef<string | null>(null);
+  const lastMessagesDirectorySyncRef = useRef(0);
   const pathnameParts = useMemo(() => pathname.split("/").filter(Boolean), [pathname]);
   const routeSidebarTab = useMemo(() => getSidebarTabFromPathParts(pathnameParts), [pathnameParts]);
   const userChatAgentIdFromQuery = searchParams.get("agent_id");
@@ -359,7 +361,6 @@ export default function DashboardApp() {
     searchParams,
     chatStore.getRoomSummary,
     chatStore.discoverRooms,
-    chatStore.messages,
     chatStore.loadPublicRoomDetail,
     chatStore.loadRoomMessages,
     chatStore.pollNewMessages,
@@ -655,17 +656,26 @@ export default function DashboardApp() {
     let cancelled = false;
     let syncInFlight = false;
 
-    const syncMessagesPane = async () => {
+    const syncMessagesPane = async (opts?: { forceDirectory?: boolean }) => {
       if (cancelled || syncInFlight) return;
       syncInFlight = true;
       try {
         const { openedRoomId, messagesPane } = useDashboardUIStore.getState();
         const session = useDashboardSessionStore.getState();
         const chat = useDashboardChatStore.getState();
-        await Promise.all([
+        const now = Date.now();
+        const shouldSyncDirectory = Boolean(opts?.forceDirectory)
+          || now - lastMessagesDirectorySyncRef.current >= MESSAGES_DIRECTORY_SYNC_INTERVAL_MS;
+        if (shouldSyncDirectory) {
+          lastMessagesDirectorySyncRef.current = now;
+        }
+        const directorySync = shouldSyncDirectory ? [
           chat.refreshOverview(),
           session.human?.human_id ? session.refreshHumanRooms() : Promise.resolve(),
           session.activeIdentity?.type === "human" ? chat.loadOwnedAgentRooms() : Promise.resolve(),
+        ] : [];
+        await Promise.all([
+          ...directorySync,
           openedRoomId && messagesPane === "room"
             ? chat.pollNewMessages(openedRoomId)
             : Promise.resolve(),
@@ -678,16 +688,19 @@ export default function DashboardApp() {
     const intervalId = window.setInterval(syncMessagesPane, 5_000);
     const handleVisibilityChange = () => {
       if (document.visibilityState === "visible") {
-        void syncMessagesPane();
+        void syncMessagesPane({ forceDirectory: true });
       }
     };
-    window.addEventListener("focus", syncMessagesPane);
+    const handleFocus = () => {
+      void syncMessagesPane({ forceDirectory: true });
+    };
+    window.addEventListener("focus", handleFocus);
     document.addEventListener("visibilitychange", handleVisibilityChange);
 
     return () => {
       cancelled = true;
       window.clearInterval(intervalId);
-      window.removeEventListener("focus", syncMessagesPane);
+      window.removeEventListener("focus", handleFocus);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   }, [

--- a/frontend/src/components/dashboard/DashboardSelect.tsx
+++ b/frontend/src/components/dashboard/DashboardSelect.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+/**
+ * [INPUT]: 受控 value/options/onChange 与可选图标、占位文案
+ * [OUTPUT]: DashboardSelect — dashboard 风格的单选下拉控件，替代弹窗中的原生 select
+ * [POS]: dashboard 表单和弹窗里的统一单选控件
+ * [PROTOCOL]: 变更时更新此头部
+ */
+
+import { type ReactNode, useEffect, useId, useMemo, useRef, useState } from "react";
+import { Check, ChevronDown } from "lucide-react";
+
+export interface DashboardSelectOption {
+  value: string;
+  label: string;
+  sublabel?: string;
+  disabled?: boolean;
+}
+
+interface DashboardSelectProps {
+  value: string | null;
+  onChange: (value: string | null) => void;
+  options: DashboardSelectOption[];
+  placeholder: string;
+  disabled?: boolean;
+  leadingIcon?: ReactNode;
+  className?: string;
+  buttonClassName?: string;
+  panelClassName?: string;
+}
+
+export default function DashboardSelect({
+  value,
+  onChange,
+  options,
+  placeholder,
+  disabled = false,
+  leadingIcon,
+  className = "",
+  buttonClassName = "",
+  panelClassName = "",
+}: DashboardSelectProps) {
+  const id = useId();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const [open, setOpen] = useState(false);
+
+  const selected = useMemo(
+    () => options.find((option) => option.value === value) ?? null,
+    [options, value],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+        buttonRef.current?.focus();
+      }
+    };
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  return (
+    <div ref={rootRef} className={`relative ${className}`}>
+      <button
+        ref={buttonRef}
+        type="button"
+        disabled={disabled}
+        onClick={() => setOpen((next) => !next)}
+        className={`flex min-h-10 w-full items-center justify-between gap-3 rounded-xl border border-glass-border bg-deep-black px-3 text-left text-sm text-text-primary transition-colors hover:border-neon-cyan/45 focus:border-neon-cyan focus:outline-none focus:ring-1 focus:ring-neon-cyan/50 disabled:cursor-not-allowed disabled:opacity-50 ${buttonClassName}`}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={`${id}-panel`}
+      >
+        <span className="flex min-w-0 items-center gap-2">
+          {leadingIcon ? <span className="shrink-0">{leadingIcon}</span> : null}
+          <span className="min-w-0">
+            <span className={`block truncate ${selected ? "text-text-primary" : "text-text-secondary/70"}`}>
+              {selected?.label ?? placeholder}
+            </span>
+            {selected?.sublabel ? (
+              <span className="mt-0.5 block truncate font-mono text-[10px] text-text-secondary/60">
+                {selected.sublabel}
+              </span>
+            ) : null}
+          </span>
+        </span>
+        <ChevronDown className={`h-4 w-4 shrink-0 text-text-secondary transition-transform ${open ? "rotate-180" : ""}`} />
+      </button>
+
+      {open ? (
+        <div
+          id={`${id}-panel`}
+          role="listbox"
+          className={`absolute left-0 right-0 z-50 mt-2 max-h-64 overflow-y-auto rounded-xl border border-glass-border bg-deep-black-light py-1 shadow-2xl shadow-black/40 ${panelClassName}`}
+        >
+          {options.length === 0 ? (
+            <p className="px-3 py-3 text-xs text-text-secondary/70">{placeholder}</p>
+          ) : (
+            options.map((option) => {
+              const isSelected = option.value === value;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  role="option"
+                  aria-selected={isSelected}
+                  disabled={option.disabled}
+                  onClick={() => {
+                    if (option.disabled) return;
+                    onChange(option.value);
+                    setOpen(false);
+                    buttonRef.current?.focus();
+                  }}
+                  className={`flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-45 ${
+                    isSelected ? "bg-neon-cyan/10 text-neon-cyan" : "text-text-primary hover:bg-glass-bg"
+                  }`}
+                >
+                  <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+                    {isSelected ? <Check className="h-3.5 w-3.5" /> : null}
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate font-medium">{option.label}</span>
+                    {option.sublabel ? (
+                      <span className="mt-0.5 block truncate font-mono text-[10px] text-text-secondary/65">
+                        {option.sublabel}
+                      </span>
+                    ) : null}
+                  </span>
+                </button>
+              );
+            })
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/MessageBubble.tsx
+++ b/frontend/src/components/dashboard/MessageBubble.tsx
@@ -351,9 +351,12 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
   const [showErrorDetails, setShowErrorDetails] = useState(false);
   const locale = useLanguage();
   const selectAgent = useDashboardChatStore((state) => state.selectAgent);
+  const overview = useDashboardChatStore((state) => state.overview);
+  const publicAgents = useDashboardChatStore((state) => state.publicAgents);
   const publicHumans = useDashboardChatStore((state) => state.publicHumans);
   const human = useDashboardSessionStore((state) => state.human);
   const user = useDashboardSessionStore((state) => state.user);
+  const ownedAgents = useDashboardSessionStore((state) => state.ownedAgents);
   const requestOpenHuman = useDashboardUIStore((state) => state.requestOpenHuman);
   const stateConfig = useStateConfig();
   const errorPayload =
@@ -374,16 +377,24 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
   const errorDetailsLabel = locale === "zh" ? "详情" : "Details";
   const timestampLabel = formatMessageTimestamp(message.created_at);
   const isOwn = typeof message.is_mine === "boolean" ? message.is_mine : isOwnProp;
-  const isHuman = message.sender_kind === "human";
+  const isHuman = message.sender_kind === "human" || message.sender_id.startsWith("hu_");
   const senderDisplayName = message.display_sender_name || message.sender_name || message.sender_id;
+  const ownedAgent = ownedAgents.find((item) => item.agent_id === message.sender_id);
+  const currentAgent = overview?.agent?.agent_id === message.sender_id ? overview.agent : null;
+  const contactAgent = overview?.contacts.find((item) => item.contact_agent_id === message.sender_id);
+  const publicAgent = publicAgents.find((item) => item.agent_id === message.sender_id);
   const publicHuman = isHuman ? publicHumans.find((item) => item.human_id === message.sender_id) : null;
   const isCurrentHumanSender = isHuman && (
     message.sender_id === human?.human_id
     || (message.source_user_id && message.source_user_id === user?.id)
   );
-  const senderAvatarUrl = message.sender_avatar_url
+  const senderAvatarUrl = ownedAgent?.avatar_url
+    || currentAgent?.avatar_url
+    || contactAgent?.avatar_url
+    || publicAgent?.avatar_url
     || (isCurrentHumanSender ? human?.avatar_url || user?.avatar_url : null)
     || publicHuman?.avatar_url
+    || message.sender_avatar_url
     || null;
 
   if (message.type === "system") {

--- a/frontend/src/components/dashboard/MessageList.tsx
+++ b/frontend/src/components/dashboard/MessageList.tsx
@@ -19,6 +19,7 @@ import { getLatestSeenAtForRoom } from "@/store/dashboard-shared";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import { useDashboardUnreadStore } from "@/store/useDashboardUnreadStore";
+import { usePresenceStore } from "@/store/usePresenceStore";
 
 const topicStatusColors: Record<string, { color: string; icon: string }> = {
   open:      { color: "text-neon-cyan bg-neon-cyan/10 border-neon-cyan/30",       icon: "●" },
@@ -379,7 +380,13 @@ export default function MessageList() {
 
   useEffect(() => {
     if (!roomId) return;
-    void loadRoomMembers(roomId);
+    void loadRoomMembers(roomId)
+      .then((members) => {
+        usePresenceStore.getState().seed(
+          members.map((m) => ({ agentId: m.agent_id, online: Boolean(m.online) })),
+        );
+      })
+      .catch(() => {});
   }, [roomId, roomMemberVersion, loadRoomMembers]);
 
   const commitRoomSeen = useCallback((targetRoomId: string) => {

--- a/frontend/src/components/dashboard/MyBotsPanel.tsx
+++ b/frontend/src/components/dashboard/MyBotsPanel.tsx
@@ -5,10 +5,10 @@ import { Plus } from "lucide-react";
 import { useShallow } from "zustand/shallow";
 import { api } from "@/lib/api";
 import type { ActivityStats } from "@/lib/types";
-import DaemonInstallCommand from "@/components/daemon/DaemonInstallCommand";
 import BotAvatar from "./BotAvatar";
 import { BotEmptyHero } from "./HomePanel";
 import MyDevicesView from "./MyDevicesView";
+import AddDeviceDialog from "./AddDeviceDialog";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import { useDaemonStore } from "@/store/useDaemonStore";
@@ -37,8 +37,6 @@ export default function MyBotsPanel() {
   useEffect(() => {
     void useDaemonStore.getState().refresh();
   }, []);
-
-  const refreshDaemons = useDaemonStore((s) => s.refresh);
 
   function handleCreateBot() {
     openCreateBotModal();
@@ -103,30 +101,7 @@ export default function MyBotsPanel() {
           <MyDevicesView />
         )}
       </div>
-      {showAddDevice ? (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" onClick={() => setShowAddDevice(false)}>
-          <div className="relative w-full max-w-md rounded-2xl border border-glass-border bg-deep-black-light p-6 shadow-2xl" onClick={(event) => event.stopPropagation()}>
-            <button
-              type="button"
-              onClick={() => setShowAddDevice(false)}
-              className="absolute right-4 top-4 flex h-7 w-7 items-center justify-center rounded-lg text-text-secondary/60 transition-colors hover:bg-glass-bg hover:text-text-primary"
-              aria-label={t.closeDialog}
-            >
-              ×
-            </button>
-            <DaemonInstallCommand
-              labels={{
-                title: t.daemonInstallTitle,
-                hint: t.daemonInstallHint,
-                copy: t.daemonCopy,
-                copied: t.daemonCopied,
-                refresh: t.daemonRefresh,
-              }}
-              onRefresh={() => void refreshDaemons()}
-            />
-          </div>
-        </div>
-      ) : null}
+      {showAddDevice ? <AddDeviceDialog onClose={() => setShowAddDevice(false)} /> : null}
     </div>
   );
 }

--- a/frontend/src/components/dashboard/RoomHumanComposer.tsx
+++ b/frontend/src/components/dashboard/RoomHumanComposer.tsx
@@ -12,6 +12,7 @@ import { useShallow } from "zustand/react/shallow";
 import MessageComposer from "./MessageComposer";
 import { useMentionCandidates } from "@/hooks/useMentionCandidates";
 import { Loader2, X } from "lucide-react";
+import DashboardSelect from "./DashboardSelect";
 
 interface RoomHumanComposerProps {
   roomId: string;
@@ -126,16 +127,17 @@ function RoomTransferDialog({ roomId, members, senderIdentity, onClose, onSucces
             <label className="mb-1 block text-xs font-medium text-text-secondary">
               {locale === "zh" ? "接收方" : "Recipient"}
             </label>
-            <select
-              value={recipientId}
-              onChange={(event) => setRecipientId(event.target.value)}
-              className="w-full rounded-lg border border-glass-border bg-deep-black-light p-3 text-sm text-text-primary outline-none focus:border-neon-cyan/50"
-            >
-              <option value="">{recipientOptions.length > 0 ? t.pickRecipientDefault : (locale === "zh" ? "当前群没有可选接收方" : "No eligible recipients in this group")}</option>
-              {recipientOptions.map((option) => (
-                <option key={option.id} value={option.id}>{option.label}</option>
-              ))}
-            </select>
+            <DashboardSelect
+              value={recipientId || null}
+              onChange={(value) => setRecipientId(value ?? "")}
+              placeholder={recipientOptions.length > 0 ? t.pickRecipientDefault : (locale === "zh" ? "当前群没有可选接收方" : "No eligible recipients in this group")}
+              disabled={recipientOptions.length === 0}
+              buttonClassName="min-h-11 bg-deep-black-light p-3"
+              options={recipientOptions.map((option) => ({
+                value: option.id,
+                label: option.label,
+              }))}
+            />
           </div>
 
           <div>

--- a/frontend/src/components/dashboard/RoomSettingsModal.tsx
+++ b/frontend/src/components/dashboard/RoomSettingsModal.tsx
@@ -21,6 +21,7 @@ import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardSubscriptionStore } from "@/store/useDashboardSubscriptionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
+import DashboardSelect from "./DashboardSelect";
 
 interface RoomSettingsModalProps {
   roomId: string;
@@ -889,24 +890,19 @@ export default function RoomSettingsModal({
                     </p>
                   </div>
                   <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-                    <select
-                      value={policyAgentId}
-                      onChange={(event) => setPolicyAgentId(event.target.value)}
+                    <DashboardSelect
+                      value={policyAgentId || null}
+                      onChange={(value) => setPolicyAgentId(value ?? "")}
                       disabled={roomOwnedAgents.length === 0}
-                      className="min-w-0 flex-1 rounded-lg border border-glass-border bg-deep-black px-2 py-2 text-sm text-text-primary"
-                    >
-                      {roomOwnedAgents.length === 0 ? (
-                        <option value="">
-                          {locale === "zh" ? "当前群里没有你的 Bot" : "No owned bots in this room"}
-                        </option>
-                      ) : (
-                        roomOwnedAgents.map((agent) => (
-                          <option key={agent.agent_id} value={agent.agent_id}>
-                            {agent.display_name} ({agent.agent_id})
-                          </option>
-                        ))
-                      )}
-                    </select>
+                      placeholder={locale === "zh" ? "当前群里没有你的 Bot" : "No owned bots in this room"}
+                      className="min-w-0 flex-1"
+                      buttonClassName="min-h-10 rounded-lg px-2 py-2 text-sm"
+                      options={roomOwnedAgents.map((agent) => ({
+                        value: agent.agent_id,
+                        label: agent.display_name,
+                        sublabel: agent.agent_id,
+                      }))}
+                    />
                     <button
                       type="button"
                       onClick={() => setShowPolicyModal(true)}
@@ -952,27 +948,35 @@ export default function RoomSettingsModal({
                   <div className="grid gap-4">
                     <label className="block">
                       <span className="mb-1.5 block text-xs text-text-secondary">{ta.visibilityLabel}</span>
-                      <select
+                      <DashboardSelect
                         disabled={!isOwner}
                         value={visibility}
-                        onChange={(e) => setVisibility(e.target.value)}
-                        className="w-full rounded-xl border border-glass-border bg-glass-bg px-3 py-2.5 text-sm text-text-primary outline-none focus:border-neon-cyan/60 disabled:opacity-60"
-                      >
-                        <option value="private">{ta.visibilityPrivate}</option>
-                        <option value="public">{ta.visibilityPublic}</option>
-                      </select>
+                        onChange={(value) => {
+                          if (value) setVisibility(value);
+                        }}
+                        placeholder={ta.visibilityLabel}
+                        buttonClassName="bg-glass-bg"
+                        options={[
+                          { value: "private", label: ta.visibilityPrivate },
+                          { value: "public", label: ta.visibilityPublic },
+                        ]}
+                      />
                     </label>
                     <label className="block">
                       <span className="mb-1.5 block text-xs text-text-secondary">{ta.joinPolicyLabel}</span>
-                      <select
+                      <DashboardSelect
                         disabled={!isOwner}
                         value={joinPolicy}
-                        onChange={(e) => setJoinPolicy(e.target.value)}
-                        className="w-full rounded-xl border border-glass-border bg-glass-bg px-3 py-2.5 text-sm text-text-primary outline-none focus:border-neon-cyan/60 disabled:opacity-60"
-                      >
-                        <option value="invite_only">{ta.joinPolicyInviteOnly}</option>
-                        <option value="open">{ta.joinPolicyOpen}</option>
-                      </select>
+                        onChange={(value) => {
+                          if (value) setJoinPolicy(value);
+                        }}
+                        placeholder={ta.joinPolicyLabel}
+                        buttonClassName="bg-glass-bg"
+                        options={[
+                          { value: "invite_only", label: ta.joinPolicyInviteOnly },
+                          { value: "open", label: ta.joinPolicyOpen },
+                        ]}
+                      />
                     </label>
                   </div>
                   <div className="grid gap-3">
@@ -1112,23 +1116,19 @@ export default function RoomSettingsModal({
                           <label className="text-sm text-text-primary">
                             {ta.subscriptionProviderLabel ?? "Receiving bot"}
                           </label>
-                          <select
-                            value={providerAgentId}
-                            onChange={(e) => setProviderAgentId(e.target.value)}
+                          <DashboardSelect
+                            value={providerAgentId || null}
+                            onChange={(value) => setProviderAgentId(value ?? "")}
                             disabled={multiRoomBlocked || ownedAgents.length === 0}
-                            className="rounded-lg border border-glass-border bg-deep-black px-2 py-1 text-sm text-text-primary"
-                          >
-                            {ownedAgents.length === 0 && (
-                              <option value="">
-                                {ta.subscriptionProviderEmpty ?? "No bots available"}
-                              </option>
-                            )}
-                            {ownedAgents.map((agent) => (
-                              <option key={agent.agent_id} value={agent.agent_id}>
-                                {agent.display_name} ({agent.agent_id})
-                              </option>
-                            ))}
-                          </select>
+                            placeholder={ta.subscriptionProviderEmpty ?? "No bots available"}
+                            className="min-w-[240px] flex-1"
+                            buttonClassName="min-h-9 rounded-lg px-2 text-sm"
+                            options={ownedAgents.map((agent) => ({
+                              value: agent.agent_id,
+                              label: agent.display_name,
+                              sublabel: agent.agent_id,
+                            }))}
+                          />
                         </div>
                       )}
                       {subscriberCount !== null && (

--- a/frontend/src/components/dashboard/TransferOwnershipDialog.tsx
+++ b/frontend/src/components/dashboard/TransferOwnershipDialog.tsx
@@ -12,6 +12,7 @@ import type { PublicRoomMember } from "@/lib/types";
 import { humansApi } from "@/lib/api";
 import { useLanguage } from "@/lib/i18n";
 import { agentBrowser } from "@/lib/i18n/translations/dashboard";
+import DashboardSelect from "./DashboardSelect";
 
 interface Props {
   roomId: string;
@@ -83,17 +84,19 @@ export default function TransferOwnershipDialog({
               <span className="mb-1 block text-[11px] text-text-secondary">
                 {t.transferSelectLabel}
               </span>
-              <select
+              <DashboardSelect
                 value={selectedId}
-                onChange={(e) => setSelectedId(e.target.value)}
-                className="w-full rounded border border-glass-border bg-deep-black px-2 py-1.5 text-xs text-text-primary"
-              >
-                {candidates.map((c) => (
-                  <option key={c.agent_id} value={c.agent_id}>
-                    {c.display_name} · {c.agent_id.startsWith("hu_") ? "H" : "A"} · {c.role}
-                  </option>
-                ))}
-              </select>
+                onChange={(value) => {
+                  if (value) setSelectedId(value);
+                }}
+                placeholder={t.transferSelectLabel}
+                buttonClassName="min-h-9 rounded px-2 text-xs"
+                options={candidates.map((c) => ({
+                  value: c.agent_id,
+                  label: c.display_name,
+                  sublabel: `${c.agent_id.startsWith("hu_") ? "H" : "A"} · ${c.role} · ${c.agent_id}`,
+                }))}
+              />
             </label>
 
             <label className="mb-3 block">

--- a/frontend/src/components/dashboard/WithdrawDialog.tsx
+++ b/frontend/src/components/dashboard/WithdrawDialog.tsx
@@ -9,6 +9,7 @@ import { useDashboardWalletStore } from "@/store/useDashboardWalletStore";
 import { useShallow } from "zustand/react/shallow";
 import { Loader2 } from "lucide-react";
 import WalletAccountSelector from "./WalletAccountSelector";
+import DashboardSelect from "./DashboardSelect";
 
 const MIN_WITHDRAWAL_MINOR = 1000 * 100;
 
@@ -187,15 +188,19 @@ export default function WithdrawDialog({ viewer, onClose, onSuccess, availableBa
             <label className="mb-1 block text-xs font-medium text-text-secondary">
               {t.destinationType}
             </label>
-            <select
+            <DashboardSelect
               value={destinationType}
-              onChange={(e) => setDestinationType(e.target.value as "bank" | "usdt_trc20" | "paypal")}
-              className="w-full rounded-lg border border-glass-border bg-deep-black-light p-3 text-sm text-text-primary outline-none focus:border-neon-purple/50"
-            >
-              <option value="bank">{t.destinationTypeBank}</option>
-              <option value="usdt_trc20">{t.destinationTypeUsdt}</option>
-              <option value="paypal">{t.destinationTypePaypal}</option>
-            </select>
+              onChange={(value) => {
+                if (value) setDestinationType(value as "bank" | "usdt_trc20" | "paypal");
+              }}
+              placeholder={t.destinationType}
+              buttonClassName="min-h-11 bg-deep-black-light p-3 focus:border-neon-purple/50 focus:ring-neon-purple/40"
+              options={[
+                { value: "bank", label: t.destinationTypeBank },
+                { value: "usdt_trc20", label: t.destinationTypeUsdt },
+                { value: "paypal", label: t.destinationTypePaypal },
+              ]}
+            />
           </div>
 
           {destinationType === "bank" && (

--- a/frontend/src/components/dashboard/sidebar/BotsPanel.tsx
+++ b/frontend/src/components/dashboard/sidebar/BotsPanel.tsx
@@ -9,9 +9,9 @@ import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import { useDaemonStore } from "@/store/useDaemonStore";
 import { Bot, Plus, Settings2 } from "lucide-react";
-import DaemonInstallCommand from "@/components/daemon/DaemonInstallCommand";
 import DeviceSettingsModal from "./DeviceSettingsModal";
 import AgentSettingsDrawer from "@/components/dashboard/AgentSettingsDrawer";
+import AddDeviceDialog from "@/components/dashboard/AddDeviceDialog";
 import type { UserAgent } from "@/lib/types";
 
 interface AgentRowProps {
@@ -269,32 +269,7 @@ export default function BotsPanel({
       )}
 
       {/* Add Device modal */}
-      {showAddDevice && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" onClick={() => setShowAddDevice(false)}>
-          <div className="relative w-full max-w-md rounded-2xl border border-glass-border bg-deep-black-light p-6 shadow-2xl" onClick={(e) => e.stopPropagation()}>
-            <button
-              type="button"
-              onClick={() => setShowAddDevice(false)}
-              className="absolute right-4 top-4 flex h-7 w-7 items-center justify-center rounded-lg text-text-secondary/60 transition-colors hover:bg-glass-bg hover:text-text-primary"
-            >
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="h-4 w-4"><path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
-            </button>
-            <p className="mb-4 text-sm font-semibold text-text-primary">
-              {locale === "zh" ? "添加新设备" : "Add New Device"}
-            </p>
-            <DaemonInstallCommand
-              labels={{
-                title: locale === "zh" ? "安装并启动 BotCord Daemon" : "Install & Start BotCord Daemon",
-                hint: locale === "zh" ? "在你的设备上运行以下命令以完成连接" : "Run this command on your device to connect it",
-                copy: locale === "zh" ? "复制" : "Copy",
-                copied: locale === "zh" ? "已复制" : "Copied",
-                refresh: locale === "zh" ? "刷新" : "Refresh",
-              }}
-              onRefresh={() => void onRefreshDaemons()}
-            />
-          </div>
-        </div>
-      )}
+      {showAddDevice ? <AddDeviceDialog onClose={() => setShowAddDevice(false)} /> : null}
 
       {/* Device settings modal */}
       {deviceSettingsId && (


### PR DESCRIPTION
## Summary
- reduce message room switch fetch/render churn
- replace dashboard native selects with the shared DashboardSelect control
- reuse the create-bot device binding panel for add-device dialogs
- increase the add-room-member dialog height

## Tests
- cd frontend && npm run build