### PR TITLE
fix: include avatar urls in chat API responses

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -27,7 +27,9 @@ from hub.database import get_db
 from hub.dashboard_message_shaping import (
     derive_sender_fields,
     load_agent_display_names,
+    load_agent_profiles,
     load_user_display_names,
+    load_user_profiles,
 )
 from hub.id_generators import generate_hub_msg_id, generate_join_request_id
 from hub.enums import SubscriptionProductStatus, SubscriptionStatus
@@ -2307,8 +2309,10 @@ async def get_room_messages(
     has_more = len(records) > limit
     records = records[:limit]
 
-    # Resolve sender names
-    sender_names = await load_agent_display_names(db, {r.sender_id for r in records})
+    # Resolve sender profiles
+    agent_profiles = await load_agent_profiles(db, {r.sender_id for r in records})
+    sender_names = {agent_id: profile[0] for agent_id, profile in agent_profiles.items()}
+    sender_avatars = {agent_id: profile[1] for agent_id, profile in agent_profiles.items()}
 
     # Resolve topic info
     topic_ids = {r.topic_id for r in records if r.topic_id}
@@ -2327,7 +2331,9 @@ async def get_room_messages(
         and r.source_user_id
     }
     human_user_ids.update(r.sender_id for r in records if (r.sender_id or "").startswith("hu_"))
-    user_name_map = await load_user_display_names(db, human_user_ids)
+    user_profiles = await load_user_profiles(db, human_user_ids)
+    user_name_map = {user_id: profile[0] for user_id, profile in user_profiles.items()}
+    user_avatar_map = {user_id: profile[1] for user_id, profile in user_profiles.items()}
 
     # Owner-chat rooms (rm_oc_*) are always viewed as the human owner — both
     # user-typed messages and the agent's replies share sender_id=agent_id, so
@@ -2341,7 +2347,9 @@ async def get_room_messages(
         extra = derive_sender_fields(
             rec,
             agent_name_map=sender_names,
+            agent_avatar_map=sender_avatars,
             user_name_map=user_name_map,
+            user_avatar_map=user_avatar_map,
             viewer_agent_id=viewer_agent_id,
             viewer_user_id=viewer_user_id,
         )
@@ -2966,10 +2974,12 @@ async def get_room_members(
             else str(m.participant_type)
         )
         display_name = (a.display_name if a else None) or (u.display_name if u else None) or m.agent_id
+        avatar_url = (a.avatar_url if a else None) or (u.avatar_url if u else None)
         members.append({
             "agent_id": m.agent_id,
             "participant_type": ptype,
             "display_name": display_name,
+            "avatar_url": avatar_url,
             "bio": a.bio if a else None,
             "message_policy": (
                 (a.message_policy.value if hasattr(a.message_policy, "value") else str(a.message_policy))

--- a/backend/app/routers/humans.py
+++ b/backend/app/routers/humans.py
@@ -114,6 +114,7 @@ class HumanRoomListResponse(BaseModel):
 class HumanAgentRoomBot(BaseModel):
     agent_id: str
     display_name: str
+    avatar_url: str | None = None
     role: str
 
 
@@ -170,6 +171,8 @@ class UpdateHumanRoomSettingsBody(BaseModel):
 class HumanContactSummary(BaseModel):
     peer_id: str
     peer_type: Literal["agent", "human"]
+    display_name: str | None = None
+    avatar_url: str | None = None
     alias: str | None
     created_at: int
 
@@ -678,7 +681,7 @@ async def list_owned_agent_only_rooms(
     human_id = user.human_id
 
     agent_result = await db.execute(
-        select(Agent.agent_id, Agent.display_name)
+        select(Agent.agent_id, Agent.display_name, Agent.avatar_url)
         .where(Agent.user_id == ctx.user_id)
         .order_by(Agent.created_at)
     )
@@ -686,11 +689,11 @@ async def list_owned_agent_only_rooms(
     if not owned_agents:
         return HumanAgentRoomListResponse(rooms=[])
 
-    agent_names = {agent_id: display_name for agent_id, display_name in owned_agents}
+    agent_names = {agent_id: display_name for agent_id, display_name, _avatar_url in owned_agents}
     rooms_by_id: dict[str, dict] = {}
     bots_by_room: dict[str, dict[str, HumanAgentRoomBot]] = {}
 
-    for agent_id, display_name in owned_agents:
+    for agent_id, display_name, avatar_url in owned_agents:
         previews = await _build_rooms_from_sql(agent_id, db)
         for preview in previews:
             room_id = preview.get("room_id")
@@ -701,6 +704,7 @@ async def list_owned_agent_only_rooms(
             bots_by_room.setdefault(room_id, {})[agent_id] = HumanAgentRoomBot(
                 agent_id=agent_id,
                 display_name=display_name or agent_id,
+                avatar_url=avatar_url,
                 role=str(role),
             )
 
@@ -1871,19 +1875,31 @@ async def list_human_contacts(
     me = user.human_id
 
     result = await db.execute(
-        select(Contact)
+        select(
+            Contact,
+            Agent.display_name.label("agent_display_name"),
+            Agent.avatar_url.label("agent_avatar_url"),
+            User.display_name.label("human_display_name"),
+            User.avatar_url.label("human_avatar_url"),
+        )
+        .outerjoin(Agent, Agent.agent_id == Contact.contact_agent_id)
+        .outerjoin(User, User.human_id == Contact.contact_agent_id)
         .where(Contact.owner_id == me, Contact.owner_type == ParticipantType.human)
         .order_by(Contact.created_at.desc())
     )
-    contacts = [
-        HumanContactSummary(
-            peer_id=c.contact_agent_id,
-            peer_type=c.peer_type.value if hasattr(c.peer_type, "value") else str(c.peer_type),
-            alias=c.alias,
-            created_at=_ts(c.created_at),
+    contacts = []
+    for c, agent_name, agent_avatar, human_name, human_avatar in result.all():
+        is_human = c.peer_type == ParticipantType.human
+        contacts.append(
+            HumanContactSummary(
+                peer_id=c.contact_agent_id,
+                peer_type=c.peer_type.value if hasattr(c.peer_type, "value") else str(c.peer_type),
+                display_name=(human_name if is_human else agent_name) or c.contact_agent_id,
+                avatar_url=human_avatar if is_human else agent_avatar,
+                alias=c.alias,
+                created_at=_ts(c.created_at),
+            )
         )
-        for c in result.scalars().all()
-    ]
     return HumanContactListResponse(contacts=contacts)
 
 

--- a/backend/app/routers/public.py
+++ b/backend/app/routers/public.py
@@ -311,6 +311,7 @@ async def get_public_room_members(
         {
             "agent_id": m.agent_id,
             "display_name": a.display_name if a else m.agent_id,
+            "avatar_url": a.avatar_url if a else None,
             "bio": a.bio if a else None,
             "message_policy": (a.message_policy.value if hasattr(a.message_policy, "value") else str(a.message_policy)) if a else None,
             "created_at": a.created_at.isoformat() if a and a.created_at else None,
@@ -377,12 +378,15 @@ async def get_public_room_messages(
     # Sender names
     sender_ids = {r.sender_id for r in records}
     sender_names: dict[str, str] = {}
+    sender_avatars: dict[str, str | None] = {}
     if sender_ids:
         name_result = await db.execute(
-            select(Agent.agent_id, Agent.display_name)
+            select(Agent.agent_id, Agent.display_name, Agent.avatar_url)
             .where(Agent.agent_id.in_(sender_ids))
         )
-        sender_names = dict(name_result.all())
+        for agent_id, display_name, avatar_url in name_result.all():
+            sender_names[agent_id] = display_name
+            sender_avatars[agent_id] = avatar_url
 
     # Topic info
     topic_ids = {r.topic_id for r in records if r.topic_id}
@@ -401,6 +405,7 @@ async def get_public_room_messages(
             "msg_id": rec.msg_id,
             "sender_id": rec.sender_id,
             "sender_display_name": sender_names.get(rec.sender_id),
+            "sender_avatar_url": sender_avatars.get(rec.sender_id),
             "text": parsed["text"],
             "type": parsed["type"],
             "topic": rec.topic,
@@ -451,12 +456,15 @@ async def get_subscription_room_message_previews(
 
     sender_ids = {r.sender_id for r in records}
     sender_names: dict[str, str] = {}
+    sender_avatars: dict[str, str | None] = {}
     if sender_ids:
         name_result = await db.execute(
-            select(Agent.agent_id, Agent.display_name)
+            select(Agent.agent_id, Agent.display_name, Agent.avatar_url)
             .where(Agent.agent_id.in_(sender_ids))
         )
-        sender_names = dict(name_result.all())
+        for agent_id, display_name, avatar_url in name_result.all():
+            sender_names[agent_id] = display_name
+            sender_avatars[agent_id] = avatar_url
 
     previews = []
     for rec in records:
@@ -468,6 +476,7 @@ async def get_subscription_room_message_previews(
             "hub_msg_id": rec.hub_msg_id,
             "sender_id": rec.sender_id,
             "sender_name": sender_names.get(rec.sender_id),
+            "sender_avatar_url": sender_avatars.get(rec.sender_id),
             "preview": preview,
             "created_at": rec.created_at.isoformat() if rec.created_at else None,
         })

--- a/backend/hub/dashboard_schemas.py
+++ b/backend/hub/dashboard_schemas.py
@@ -52,6 +52,7 @@ class DashboardContactInfo(BaseModel):
     contact_agent_id: str
     alias: str | None = None
     display_name: str
+    avatar_url: str | None = None
     created_at: datetime.datetime
     online: bool = False
 

--- a/backend/hub/routers/contacts.py
+++ b/backend/hub/routers/contacts.py
@@ -122,7 +122,7 @@ async def list_contacts(
     total = total_result.scalar_one()
 
     result = await db.execute(
-        select(Contact, Agent.display_name, Agent.bio)
+        select(Contact, Agent.display_name, Agent.avatar_url, Agent.bio)
         .outerjoin(Agent, Agent.agent_id == Contact.contact_agent_id)
         .where(Contact.owner_id == agent_id)
         .order_by(Contact.created_at.asc())
@@ -134,12 +134,13 @@ async def list_contacts(
             ContactResponse(
                 contact_agent_id=c.contact_agent_id,
                 display_name=dn or c.contact_agent_id,
+                avatar_url=avatar_url,
                 bio=bio,
                 alias=c.alias,
                 created_at=c.created_at,
                 online=is_agent_ws_online(c.contact_agent_id),
             )
-            for c, dn, bio in result.all()
+            for c, dn, avatar_url, bio in result.all()
         ],
         total=total,
     )
@@ -158,7 +159,7 @@ async def get_contact(
     check_agent_ownership(agent_id, current_agent)
 
     result = await db.execute(
-        select(Contact, Agent.display_name, Agent.bio)
+        select(Contact, Agent.display_name, Agent.avatar_url, Agent.bio)
         .outerjoin(Agent, Agent.agent_id == Contact.contact_agent_id)
         .where(
             Contact.owner_id == agent_id,
@@ -169,10 +170,11 @@ async def get_contact(
     if row is None:
         raise I18nHTTPException(status_code=404, message_key="contact_not_found")
 
-    contact, dn, bio = row
+    contact, dn, avatar_url, bio = row
     return ContactResponse(
         contact_agent_id=contact.contact_agent_id,
         display_name=dn or contact.contact_agent_id,
+        avatar_url=avatar_url,
         bio=bio,
         alias=contact.alias,
         created_at=contact.created_at,

--- a/backend/hub/routers/dashboard.py
+++ b/backend/hub/routers/dashboard.py
@@ -328,7 +328,7 @@ async def get_overview(
 
     # Contacts with display names
     contact_result = await db.execute(
-        select(Contact, Agent.display_name)
+        select(Contact, Agent.display_name, Agent.avatar_url)
         .outerjoin(Agent, Agent.agent_id == Contact.contact_agent_id)
         .where(Contact.owner_id == current_agent)
     )
@@ -337,10 +337,11 @@ async def get_overview(
             contact_agent_id=c.contact_agent_id,
             alias=c.alias,
             display_name=dn or c.contact_agent_id,
+            avatar_url=avatar_url,
             created_at=c.created_at,
             online=is_agent_ws_online(c.contact_agent_id),
         )
-        for c, dn in contact_result.all()
+        for c, dn, avatar_url in contact_result.all()
     ]
 
     # Pending contact request count

--- a/backend/hub/routers/public.py
+++ b/backend/hub/routers/public.py
@@ -78,6 +78,7 @@ class PublicAgentsResponse(BaseModel):
 class PublicRoomMember(BaseModel):
     agent_id: str
     display_name: str
+    avatar_url: str | None = None
     bio: str | None = None
     message_policy: str
     created_at: datetime.datetime
@@ -581,6 +582,7 @@ async def public_room_members(
         select(
             RoomMember,
             Agent.display_name,
+            Agent.avatar_url,
             Agent.bio,
             Agent.message_policy,
             Agent.created_at,
@@ -596,6 +598,7 @@ async def public_room_members(
         PublicRoomMember(
             agent_id=member.agent_id,
             display_name=display_name or member.agent_id,
+            avatar_url=avatar_url,
             bio=bio,
             message_policy=(
                 message_policy.value
@@ -607,7 +610,7 @@ async def public_room_members(
             joined_at=_ensure_utc(member.joined_at),
             online=is_agent_ws_online(member.agent_id),
         )
-        for member, display_name, bio, message_policy, created_at in rows
+        for member, display_name, avatar_url, bio, message_policy, created_at in rows
     ]
 
     return PublicRoomMembersResponse(

--- a/backend/hub/routers/room.py
+++ b/backend/hub/routers/room.py
@@ -198,6 +198,7 @@ def _build_room_response(room: Room) -> RoomResponse:
             RoomMemberResponse(
                 agent_id=m.agent_id,
                 display_name=m.agent.display_name if m.agent is not None else None,
+                avatar_url=m.agent.avatar_url if m.agent is not None else None,
                 role=m.role.value,
                 muted=m.muted,
                 can_send=m.can_send,

--- a/backend/hub/routers/room_context.py
+++ b/backend/hub/routers/room_context.py
@@ -433,7 +433,7 @@ async def room_summary(
 
     # Members
     members_result = await db.execute(
-        select(RoomMember, Agent.display_name)
+        select(RoomMember, Agent.display_name, Agent.avatar_url)
         .join(Agent, Agent.agent_id == RoomMember.agent_id)
         .where(RoomMember.room_id == room_id)
     )
@@ -441,10 +441,11 @@ async def room_summary(
         RoomContextMember(
             agent_id=rm.agent_id,
             name=display_name,
+            avatar_url=avatar_url,
             role=rm.role.value,
             last_active=_utc(rm.last_viewed_at),
         )
-        for rm, display_name in members_result.all()
+        for rm, display_name, avatar_url in members_result.all()
     ]
 
     # Active topics

--- a/backend/hub/schemas.py
+++ b/backend/hub/schemas.py
@@ -390,6 +390,7 @@ class HistoryResponse(BaseModel):
 class ContactResponse(BaseModel):
     contact_agent_id: str
     display_name: str | None = None
+    avatar_url: str | None = None
     bio: str | None = None
     alias: str | None = None
     created_at: datetime.datetime
@@ -505,6 +506,7 @@ class SetMemberPermissionsRequest(BaseModel):
 class RoomMemberResponse(BaseModel):
     agent_id: str
     display_name: str | None = None
+    avatar_url: str | None = None
     role: str
     muted: bool
     can_send: bool | None = None
@@ -614,6 +616,7 @@ class DashboardContactInfo(BaseModel):
     contact_agent_id: str
     alias: str | None = None
     display_name: str
+    avatar_url: str | None = None
     created_at: datetime.datetime
 
 
@@ -693,6 +696,7 @@ class TopicListResponse(BaseModel):
 class RoomContextMember(BaseModel):
     agent_id: str
     name: str
+    avatar_url: str | None = None
     role: str
     last_active: datetime.datetime | None = None
 

--- a/backend/tests/test_app/test_app_dashboard.py
+++ b/backend/tests/test_app/test_app_dashboard.py
@@ -128,6 +128,7 @@ async def seed_data(db_session: AsyncSession):
     other_agent = Agent(
         agent_id="ag_other00001",
         display_name="Other Agent",
+        avatar_url="/agent-avatars/3.png",
         message_policy=MessagePolicy.contacts_only,
     )
     db_session.add(other_agent)
@@ -212,6 +213,7 @@ async def test_dashboard_overview(client: AsyncClient, seed_data: dict):
     assert len(data["contacts"]) == 1
     assert data["contacts"][0]["contact_agent_id"] == "ag_other00001"
     assert data["contacts"][0]["alias"] == "Other"
+    assert data["contacts"][0]["avatar_url"] == "/agent-avatars/3.png"
 
     # Pending requests
     assert data["pending_requests"] == 1
@@ -273,6 +275,11 @@ async def test_dashboard_overview_includes_unread_count(
     room = resp.json()["rooms"][0]
     assert room["has_unread"] is True
     assert room["unread_count"] == 2
+
+    messages_resp = await client.get("/api/dashboard/rooms/rm_testroom001/messages", headers=headers)
+    assert messages_resp.status_code == 200
+    by_id = {message["hub_msg_id"]: message for message in messages_resp.json()["messages"]}
+    assert by_id["hm_unread001"]["sender_avatar_url"] == "/agent-avatars/3.png"
 
     read_resp = await client.post("/api/dashboard/rooms/rm_testroom001/read", headers=headers)
     assert read_resp.status_code == 200

--- a/backend/tests/test_app/test_app_humans.py
+++ b/backend/tests/test_app/test_app_humans.py
@@ -503,6 +503,7 @@ async def test_list_owned_agent_rooms_excludes_current_human_rooms(
     agent = Agent(
         agent_id="ag_alice00001",
         display_name="Alice Bot",
+        avatar_url="/agent-avatars/2.png",
         message_policy=MessagePolicy.open,
         user_id=seed["user_id"],
     )
@@ -593,11 +594,16 @@ async def test_list_owned_agent_rooms_excludes_current_human_rooms(
     rooms = resp.json()["rooms"]
     assert [room["room_id"] for room in rooms] == ["rm_bot_only"]
     assert rooms[0]["bots"] == [
-        {"agent_id": "ag_alice00001", "display_name": "Alice Bot", "role": "member"}
+        {
+            "agent_id": "ag_alice00001",
+            "avatar_url": "/agent-avatars/2.png",
+            "display_name": "Alice Bot",
+            "role": "member",
+        }
     ]
     assert rooms[0]["member_count"] == 3
     assert rooms[0]["members_preview"] == [
-        {"agent_id": "ag_alice00001", "avatar_url": None, "display_name": "Alice Bot"},
+        {"agent_id": "ag_alice00001", "avatar_url": "/agent-avatars/2.png", "display_name": "Alice Bot"},
         {"agent_id": "ag_peer000001", "avatar_url": None, "display_name": "Peer Bot"},
         {"agent_id": "ag_third00001", "avatar_url": None, "display_name": "Third Bot"},
     ]

--- a/backend/tests/test_app/test_app_public.py
+++ b/backend/tests/test_app/test_app_public.py
@@ -81,6 +81,7 @@ async def seed(db_session: AsyncSession):
     db_session.add(UserRole(id=uuid.uuid4(), user_id=uid, role_id=role.id))
 
     a1 = Agent(agent_id="ag_pub_agent1", display_name="Public Agent", message_policy=MessagePolicy.open,
+               avatar_url="/agent-avatars/1.png",
                user_id=uid, is_default=True, claimed_at=datetime.datetime.now(datetime.timezone.utc))
     a2 = Agent(agent_id="ag_pub_agent2", display_name="Agent Two", message_policy=MessagePolicy.contacts_only)
     db_session.add_all([a1, a2])
@@ -159,6 +160,7 @@ async def test_public_room_members(client: AsyncClient, seed: dict):
     assert "room_id" in data
     assert len(data["members"]) >= 1
     assert data["members"][0]["agent_id"] == "ag_pub_agent1"
+    assert data["members"][0]["avatar_url"] == "/agent-avatars/1.png"
 
 
 @pytest.mark.asyncio
@@ -174,6 +176,7 @@ async def test_public_room_messages(client: AsyncClient, seed: dict):
     data = resp.json()
     assert len(data["messages"]) >= 1
     assert data["messages"][0]["text"] == "Hello world"
+    assert data["messages"][0]["sender_avatar_url"] == "/agent-avatars/1.png"
 
 
 @pytest.mark.asyncio
@@ -218,8 +221,9 @@ async def test_subscription_room_message_previews_are_safe(
     data = resp.json()
     assert len(data["messages"]) == 3
     for item in data["messages"]:
-        assert set(item) == {"hub_msg_id", "sender_id", "sender_name", "preview", "created_at"}
+        assert set(item) == {"hub_msg_id", "sender_id", "sender_name", "sender_avatar_url", "preview", "created_at"}
         assert item["sender_name"] == "Public Agent"
+        assert item["sender_avatar_url"] == "/agent-avatars/1.png"
         assert len(item["preview"]) <= 99
         assert item["preview"].endswith("...")
 


### PR DESCRIPTION
## Summary
- include agent and human avatar URLs in dashboard room messages and members
- include avatar URLs in public room messages, previews, and members
- include avatar URLs in human owned-agent room/contact responses and hub-side contact/member schemas

## Tests
- cd backend && uv run python -m compileall app/routers/dashboard.py app/routers/public.py app/routers/humans.py hub/routers/dashboard.py hub/routers/contacts.py hub/routers/public.py hub/routers/room.py hub/routers/room_context.py hub/schemas.py hub/dashboard_schemas.py
- cd backend && uv run pytest tests/test_app/test_app_dashboard.py tests/test_app/test_app_public.py tests/test_app/test_app_humans.py
- cd backend && uv run pytest tests/test_dashboard.py tests/test_public.py tests/test_room_context.py tests/test_contacts.py