### PR TITLE
fix: label bot message policy

### DIFF
--- a/frontend/src/components/dashboard/AgentCardModal.tsx
+++ b/frontend/src/components/dashboard/AgentCardModal.tsx
@@ -50,6 +50,7 @@ export default function AgentCardModal({
 }: AgentCardModalProps) {
   const locale = useLanguage();
   const t = exploreUi[locale];
+  const messagePolicyLabel = getMessagePolicyLabel(agent?.message_policy, t.messagePolicyLabels);
 
   useEffect(() => {
     if (!agent) return;
@@ -87,7 +88,7 @@ export default function AgentCardModal({
             <div className="flex items-center gap-2">
               {agent && <CopyableId value={agent.agent_id} />}
               <span className="rounded border border-glass-border px-1.5 py-0.5 text-[10px] text-text-secondary">
-                {agent?.message_policy || "-"}
+                {messagePolicyLabel}
               </span>
             </div>
             <p className="text-xs text-text-secondary animate-pulse">Loading profile...</p>
@@ -123,7 +124,7 @@ export default function AgentCardModal({
             <div className="mb-4 flex items-center gap-2">
               {agent && <CopyableId value={agent.agent_id} />}
               <span className="rounded border border-glass-border px-1.5 py-0.5 text-[10px] text-text-secondary">
-                {agent?.message_policy || "-"}
+                {messagePolicyLabel}
               </span>
             </div>
             {isOwnAgent ? (
@@ -157,4 +158,12 @@ export default function AgentCardModal({
       </div>
     </div>
   );
+}
+
+function getMessagePolicyLabel(
+  policy: string | null | undefined,
+  labels: Record<"open" | "contacts_only" | "whitelist" | "closed", string>,
+): string {
+  if (!policy) return "-";
+  return labels[policy as keyof typeof labels] || policy;
 }

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -1261,6 +1261,7 @@ export const exploreUi: TranslationMap<{
   sendFriendRequest: string
   sendingFriendRequest: string
   sendMessage: string
+  messagePolicyLabels: Record<'open' | 'contacts_only' | 'whitelist' | 'closed', string>
 }> = {
   en: {
     publicRooms: 'Public Rooms',
@@ -1312,6 +1313,12 @@ export const exploreUi: TranslationMap<{
     sendFriendRequest: 'Send Friend Request',
     sendingFriendRequest: 'Sending request...',
     sendMessage: 'Send Message',
+    messagePolicyLabels: {
+      open: 'Open',
+      contacts_only: 'Contacts only',
+      whitelist: 'Allowlist',
+      closed: 'Closed',
+    },
   },
   zh: {
     publicRooms: '公开社区',
@@ -1363,6 +1370,12 @@ export const exploreUi: TranslationMap<{
     sendFriendRequest: '发送好友请求',
     sendingFriendRequest: '发送请求中...',
     sendMessage: '发送消息',
+    messagePolicyLabels: {
+      open: '公开',
+      contacts_only: '仅联系人',
+      whitelist: '白名单',
+      closed: '关闭',
+    },
   },
 }
 


### PR DESCRIPTION
## Summary
- show localized labels for Bot message policy badges instead of raw enum values
- add Chinese and English policy labels for the Explore Bot card modal

## Tests
- npm run build (fails during /admin/codes prerender because local Supabase URL/API key are not configured; compile and TypeScript passed before prerender)
- npx tsc --noEmit (fails on existing stale tests/api imports and RoomPolicyEffective fixture type mismatch)