### PR TITLE
fix: keep messages room switches on stable url

### DIFF
--- a/frontend/src/components/dashboard/AgentBrowser.tsx
+++ b/frontend/src/components/dashboard/AgentBrowser.tsx
@@ -41,11 +41,13 @@ export default function AgentBrowser() {
     toggleRightPanel,
     setFocusedRoomId,
     setOpenedRoomId,
+    setMessagesPane,
   } = useDashboardUIStore(useShallow((state) => ({
     focusedRoomId: state.focusedRoomId,
     toggleRightPanel: state.toggleRightPanel,
     setFocusedRoomId: state.setFocusedRoomId,
     setOpenedRoomId: state.setOpenedRoomId,
+    setMessagesPane: state.setMessagesPane,
   })));
   const {
     messages,
@@ -167,9 +169,10 @@ export default function AgentBrowser() {
   };
 
   const openRoomConversation = (roomId: string) => {
+    setMessagesPane("room");
     setFocusedRoomId(roomId);
     setOpenedRoomId(roomId);
-    router.push(`/chats/messages/${encodeURIComponent(roomId)}`);
+    router.push("/chats/messages");
     if (!messages[roomId]) {
       void loadRoomMessages(roomId);
     }

--- a/frontend/src/components/dashboard/BotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/BotDetailDrawer.tsx
@@ -201,7 +201,7 @@ export default function BotDetailDrawer() {
     } catch (error) {
       console.error("[BotDetailDrawer] getUserChatRoom failed:", error);
     }
-    router.push("/chats/messages/__user-chat__");
+    router.push("/chats/messages");
   };
 
   // Jump to a conversation visible from THIS bot's perspective. Sets BOT 监控
@@ -210,7 +210,12 @@ export default function BotDetailDrawer() {
     setBotDetailAgentId(null);
     setMessagesFilter("bots-all");
     setMessagesBotScope(bot.agent_id);
-    const path = roomId ? `/chats/messages/${encodeURIComponent(roomId)}` : "/chats/messages";
+    const path = "/chats/messages";
+    if (roomId) {
+      setMessagesPane("room");
+      setFocusedRoomId(roomId);
+      setOpenedRoomId(roomId);
+    }
     startPrimaryNavigation("messages", path);
     router.push(path);
   };

--- a/frontend/src/components/dashboard/ChatPane.tsx
+++ b/frontend/src/components/dashboard/ChatPane.tsx
@@ -51,8 +51,17 @@ function ContactsMainPane({ onHumanOpen }: { onHumanOpen?: (human: PublicHumanPr
   const router = useRouter();
   const locale = useLanguage();
   const t = chatPane[locale];
-  const { contactsView, startPrimaryNavigation } = useDashboardUIStore(useShallow((state) => ({
+  const {
+    contactsView,
+    setFocusedRoomId,
+    setOpenedRoomId,
+    setMessagesPane,
+    startPrimaryNavigation,
+  } = useDashboardUIStore(useShallow((state) => ({
     contactsView: state.contactsView,
+    setFocusedRoomId: state.setFocusedRoomId,
+    setOpenedRoomId: state.setOpenedRoomId,
+    setMessagesPane: state.setMessagesPane,
     startPrimaryNavigation: state.startPrimaryNavigation,
   })));
   const { overview, selectAgent, refreshOverview } = useDashboardChatStore(useShallow((state) => ({
@@ -145,7 +154,10 @@ function ContactsMainPane({ onHumanOpen }: { onHumanOpen?: (human: PublicHumanPr
         : filteredContacts;
 
   const openJoinedRoom = (roomId: string) => {
-    const path = `/chats/messages/${encodeURIComponent(roomId)}`;
+    const path = "/chats/messages";
+    setMessagesPane("room");
+    setFocusedRoomId(roomId);
+    setOpenedRoomId(roomId);
     startPrimaryNavigation("messages", path);
     startTransition(() => router.push(path));
   };
@@ -363,11 +375,17 @@ function ExploreMainPane({ onHumanOpen }: ChatPaneProps) {
     exploreView,
     resetMessagesGroupingForRoomOpen,
     setExploreView,
+    setFocusedRoomId,
+    setOpenedRoomId,
+    setMessagesPane,
     startPrimaryNavigation,
   } = useDashboardUIStore(useShallow((state) => ({
     exploreView: state.exploreView,
     resetMessagesGroupingForRoomOpen: state.resetMessagesGroupingForRoomOpen,
     setExploreView: state.setExploreView,
+    setFocusedRoomId: state.setFocusedRoomId,
+    setOpenedRoomId: state.setOpenedRoomId,
+    setMessagesPane: state.setMessagesPane,
     startPrimaryNavigation: state.startPrimaryNavigation,
   })));
   const {
@@ -433,8 +451,11 @@ function ExploreMainPane({ onHumanOpen }: ChatPaneProps) {
   );
 
   const openRoomFromExplore = (room: PublicRoom) => {
-    const path = `/chats/messages/${encodeURIComponent(room.room_id)}`;
+    const path = "/chats/messages";
     resetMessagesGroupingForRoomOpen();
+    setMessagesPane("room");
+    setFocusedRoomId(room.room_id);
+    setOpenedRoomId(room.room_id);
     startPrimaryNavigation("messages", path);
     addRecentPublicRoom(room);
     startTransition(() => router.push(path));

--- a/frontend/src/components/dashboard/ContactsDetailPane.tsx
+++ b/frontend/src/components/dashboard/ContactsDetailPane.tsx
@@ -220,7 +220,7 @@ export default function ContactsDetailPane() {
     setUserChatAgentId(null);
     setFocusedRoomId(roomId);
     setOpenedRoomId(roomId);
-    const path = `/chats/messages/${encodeURIComponent(roomId)}`;
+    const path = "/chats/messages";
     startPrimaryNavigation("messages", path);
     router.push(path);
   };
@@ -240,7 +240,7 @@ export default function ContactsDetailPane() {
         setUserChatRoomId(room.room_id);
         setFocusedRoomId(null);
         setOpenedRoomId(null);
-        const path = `/chats/messages/${encodeURIComponent(room.room_id)}`;
+        const path = "/chats/messages";
         startPrimaryNavigation("messages", path);
         router.push(path);
         return;

--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -286,15 +286,21 @@ export default function DashboardApp() {
 
       if (normalizedTab === "messages" || normalizedTab === "user-chat") {
         const roomIdFromSubtab = subtab && subtab !== USER_CHAT_SUBTAB ? decodeRoomIdFromPath(subtab) : null;
+        const agentIdFromQuery = searchParams.get("agent_id");
+        const paneFromQuery = searchParams.get("pane");
+        const shouldNormalizeMessagesUrl =
+          pathname !== "/chats/messages"
+          || searchParams.has("pane")
+          || searchParams.has("agent_id");
         const opensUserChat =
           tab === "user-chat"
+          || paneFromQuery === "user-chat"
           || subtab === USER_CHAT_SUBTAB
           || (roomIdFromSubtab !== null && (
             roomIdFromSubtab === uiStore.userChatRoomId
             || roomIdFromSubtab.startsWith("rm_oc_")
           ));
         if (opensUserChat) {
-          const agentIdFromQuery = searchParams.get("agent_id");
           if (agentIdFromQuery && uiStore.userChatAgentId !== agentIdFromQuery) {
             uiStore.setUserChatAgentId(agentIdFromQuery);
           }
@@ -304,11 +310,14 @@ export default function DashboardApp() {
           if (uiStore.messagesPane !== "user-chat") uiStore.setMessagesPane("user-chat");
           if (uiStore.focusedRoomId !== null) uiStore.setFocusedRoomId(null);
           if (uiStore.openedRoomId !== null) uiStore.setOpenedRoomId(null);
+          if (shouldNormalizeMessagesUrl) {
+            router.replace("/chats/messages");
+          }
           return;
         }
-        if (uiStore.messagesPane !== "room") uiStore.setMessagesPane("room");
         const roomIdFromPath = subtab ? decodeRoomIdFromPath(subtab) : null;
         if (roomIdFromPath) {
+          if (uiStore.messagesPane !== "room") uiStore.setMessagesPane("room");
           if (uiStore.focusedRoomId !== roomIdFromPath) uiStore.setFocusedRoomId(roomIdFromPath);
           if (uiStore.openedRoomId !== roomIdFromPath) uiStore.setOpenedRoomId(roomIdFromPath);
 
@@ -319,6 +328,9 @@ export default function DashboardApp() {
           if (!knownRoom) {
             void chatStore.loadPublicRoomDetail(roomIdFromPath);
           }
+          if (shouldNormalizeMessagesUrl) {
+            router.replace("/chats/messages");
+          }
           if (chatStore.messagesLoading[roomIdFromPath]) {
             return;
           }
@@ -327,9 +339,6 @@ export default function DashboardApp() {
           } else {
             void chatStore.pollNewMessages(roomIdFromPath);
           }
-        } else {
-          if (uiStore.focusedRoomId !== null) uiStore.setFocusedRoomId(null);
-          if (uiStore.openedRoomId !== null) uiStore.setOpenedRoomId(null);
         }
       }
     } else if (uiStore.sidebarTab !== "home") {
@@ -358,6 +367,7 @@ export default function DashboardApp() {
     uiStore.setUserChatAgentId,
     uiStore.setExploreView,
     uiStore.setContactsView,
+    router,
     searchParams,
     chatStore.getRoomSummary,
     chatStore.discoverRooms,
@@ -892,7 +902,7 @@ export default function DashboardApp() {
     if (cachedRoom) {
       uiStore.setFocusedRoomId(cachedRoom.room_id);
       uiStore.setOpenedRoomId(cachedRoom.room_id);
-      router.push(`/chats/messages/${encodeURIComponent(cachedRoom.room_id)}`);
+      router.push("/chats/messages");
       return;
     }
 
@@ -909,13 +919,13 @@ export default function DashboardApp() {
       }
       uiStore.setFocusedRoomId(room_id);
       uiStore.setOpenedRoomId(room_id);
-      router.push(`/chats/messages/${encodeURIComponent(room_id)}`);
+      router.push("/chats/messages");
     } catch (error) {
       console.error("[DashboardApp] openDmRoom failed:", error);
       if (predictedRoomId) {
         uiStore.setFocusedRoomId(predictedRoomId);
         uiStore.setOpenedRoomId(predictedRoomId);
-        router.push(`/chats/messages/${encodeURIComponent(predictedRoomId)}`);
+        router.push("/chats/messages");
       } else {
         router.push("/chats/messages");
       }
@@ -948,7 +958,7 @@ export default function DashboardApp() {
         }).catch((error) => {
           console.error("[DashboardApp] getUserChatRoom failed:", error);
         });
-        router.push(`/chats/messages/${USER_CHAT_SUBTAB}`);
+        router.push("/chats/messages");
       })();
       return;
     }

--- a/frontend/src/components/dashboard/ForwardModal.tsx
+++ b/frontend/src/components/dashboard/ForwardModal.tsx
@@ -35,7 +35,15 @@ export default function ForwardModal({ quoteText, sourceFile, onClose }: Forward
   const [done, setDone] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const router = useRouter();
-  const { setOpenedRoomId } = useDashboardUIStore(useShallow((s) => ({ setOpenedRoomId: s.setOpenedRoomId })));
+  const {
+    setFocusedRoomId,
+    setOpenedRoomId,
+    setMessagesPane,
+  } = useDashboardUIStore(useShallow((s) => ({
+    setFocusedRoomId: s.setFocusedRoomId,
+    setOpenedRoomId: s.setOpenedRoomId,
+    setMessagesPane: s.setMessagesPane,
+  })));
 
   const { ownedAgents, viewMode } = useDashboardSessionStore(
     useShallow((s) => ({ ownedAgents: s.ownedAgents, viewMode: s.viewMode }))
@@ -116,8 +124,10 @@ export default function ForwardModal({ quoteText, sourceFile, onClose }: Forward
       // Navigate to the forwarded conversation — if exactly one room target, open it directly
       if (openRoomIds.length === 1) {
         const roomId = openRoomIds[0];
+        setMessagesPane("room");
+        setFocusedRoomId(roomId);
         setOpenedRoomId(roomId);
-        router.push(`/chats/messages/${encodeURIComponent(roomId)}`);
+        router.push("/chats/messages");
       }
       setTimeout(onClose, 800);
     } catch (err: unknown) {

--- a/frontend/src/components/dashboard/HomePanel.tsx
+++ b/frontend/src/components/dashboard/HomePanel.tsx
@@ -737,12 +737,23 @@ export default function HomePanel() {
       selectAgent: s.selectAgent,
     })),
   );
-  const { openCreateBotModal, requestOpenHuman, resetMessagesGroupingForRoomOpen, setBotDetailAgentId } = useDashboardUIStore(
+  const {
+    openCreateBotModal,
+    requestOpenHuman,
+    resetMessagesGroupingForRoomOpen,
+    setBotDetailAgentId,
+    setFocusedRoomId,
+    setOpenedRoomId,
+    setMessagesPane,
+  } = useDashboardUIStore(
     useShallow((s) => ({
       openCreateBotModal: s.openCreateBotModal,
       requestOpenHuman: s.requestOpenHuman,
       resetMessagesGroupingForRoomOpen: s.resetMessagesGroupingForRoomOpen,
       setBotDetailAgentId: s.setBotDetailAgentId,
+      setFocusedRoomId: s.setFocusedRoomId,
+      setOpenedRoomId: s.setOpenedRoomId,
+      setMessagesPane: s.setMessagesPane,
     })),
   );
   const { daemons, daemonLoading, refreshDaemons } = useDaemonStore(
@@ -858,7 +869,10 @@ export default function HomePanel() {
                   data={room}
                   onRoomOpen={(r) => {
                     resetMessagesGroupingForRoomOpen();
-                    router.push(`/chats/messages/${encodeURIComponent(r.room_id)}`);
+                    setMessagesPane("room");
+                    setFocusedRoomId(r.room_id);
+                    setOpenedRoomId(r.room_id);
+                    router.push("/chats/messages");
                   }}
                 />
               ))}

--- a/frontend/src/components/dashboard/MessageList.tsx
+++ b/frontend/src/components/dashboard/MessageList.tsx
@@ -321,11 +321,13 @@ export default function MessageList() {
     setOpenedTopicId: state.setOpenedTopicId,
   })));
   const roomId = openedRoomId;
-  const { messages, isRoomMessagesLoading, hasMore, loadMoreMessages, overview, roomMembers, loadRoomMembers } = useDashboardChatStore(
+  const { messages, hasMessagesCache, isRoomMessagesLoading, hasMore, loadRoomMessages, loadMoreMessages, overview, roomMembers, loadRoomMembers } = useDashboardChatStore(
     useShallow((state) => ({
       messages: roomId ? (state.messages[roomId] ?? EMPTY_MESSAGES) : EMPTY_MESSAGES,
+      hasMessagesCache: roomId ? Object.prototype.hasOwnProperty.call(state.messages, roomId) : false,
       isRoomMessagesLoading: roomId ? (state.messagesLoading[roomId] ?? false) : false,
       hasMore: roomId ? (state.messagesHasMore[roomId] ?? false) : false,
+      loadRoomMessages: state.loadRoomMessages,
       loadMoreMessages: state.loadMoreMessages,
       overview: state.overview,
       roomMembers: roomId ? (state.roomMembersByRoom[roomId] ?? EMPTY_ROOM_MEMBERS) : EMPTY_ROOM_MEMBERS,
@@ -377,6 +379,13 @@ export default function MessageList() {
 
     return candidates;
   }, [overview?.agent, overview?.contacts, roomMembers]);
+
+  useEffect(() => {
+    if (!roomId) return;
+    if (!hasMessagesCache && !isRoomMessagesLoading) {
+      void loadRoomMessages(roomId);
+    }
+  }, [roomId, hasMessagesCache, isRoomMessagesLoading, loadRoomMessages]);
 
   useEffect(() => {
     if (!roomId) return;

--- a/frontend/src/components/dashboard/PeerBotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/PeerBotDetailDrawer.tsx
@@ -30,10 +30,20 @@ function formatDate(iso?: string): string {
  */
 export default function PeerBotDetailDrawer() {
   const router = useRouter();
-  const { peerBotAgentId, setPeerBotAgentId, startPrimaryNavigation } = useDashboardUIStore(
+  const {
+    peerBotAgentId,
+    setPeerBotAgentId,
+    setFocusedRoomId,
+    setOpenedRoomId,
+    setMessagesPane,
+    startPrimaryNavigation,
+  } = useDashboardUIStore(
     useShallow((s) => ({
       peerBotAgentId: s.peerBotAgentId,
       setPeerBotAgentId: s.setPeerBotAgentId,
+      setFocusedRoomId: s.setFocusedRoomId,
+      setOpenedRoomId: s.setOpenedRoomId,
+      setMessagesPane: s.setMessagesPane,
       startPrimaryNavigation: s.startPrimaryNavigation,
     })),
   );
@@ -74,7 +84,12 @@ export default function PeerBotDetailDrawer() {
       (r) => r.owner_id === agentId && (r.peer_type ?? r.owner_type) === "agent",
     );
     setPeerBotAgentId(null);
-    const path = dm ? `/chats/messages/${encodeURIComponent(dm.room_id)}` : "/chats/messages";
+    const path = "/chats/messages";
+    if (dm) {
+      setMessagesPane("room");
+      setFocusedRoomId(dm.room_id);
+      setOpenedRoomId(dm.room_id);
+    }
     startPrimaryNavigation("messages", path);
     router.push(path);
   };

--- a/frontend/src/components/dashboard/PublicRoomList.tsx
+++ b/frontend/src/components/dashboard/PublicRoomList.tsx
@@ -31,9 +31,18 @@ export default function PublicRoomList() {
     loadPublicRooms: state.loadPublicRooms,
     addRecentPublicRoom: state.addRecentPublicRoom,
   })));
-  const { focusedRoomId, startPrimaryNavigation } = useDashboardUIStore(
+  const {
+    focusedRoomId,
+    setFocusedRoomId,
+    setOpenedRoomId,
+    setMessagesPane,
+    startPrimaryNavigation,
+  } = useDashboardUIStore(
     useShallow((state) => ({
       focusedRoomId: state.focusedRoomId,
+      setFocusedRoomId: state.setFocusedRoomId,
+      setOpenedRoomId: state.setOpenedRoomId,
+      setMessagesPane: state.setMessagesPane,
       startPrimaryNavigation: state.startPrimaryNavigation,
     })),
   );
@@ -56,7 +65,10 @@ export default function PublicRoomList() {
 
   const handleSelect = (roomId: string) => {
     const room = publicRooms.find((item) => item.room_id === roomId);
-    const path = `/chats/messages/${encodeURIComponent(roomId)}`;
+    const path = "/chats/messages";
+    setMessagesPane("room");
+    setFocusedRoomId(roomId);
+    setOpenedRoomId(roomId);
     startPrimaryNavigation("messages", path);
     if (room) {
       addRecentPublicRoom(room);

--- a/frontend/src/components/dashboard/RoomList.tsx
+++ b/frontend/src/components/dashboard/RoomList.tsx
@@ -34,7 +34,6 @@ interface RoomListProps {
   roomMeta?: Record<string, string>;
 }
 
-const USER_CHAT_PATH = "/chats/messages/__user-chat__";
 const EMPTY_CONTACTS: ContactInfo[] = [];
 
 function latestPreviewMessage(messages: DashboardMessage[] | undefined): DashboardMessage | null {
@@ -94,7 +93,7 @@ export default function RoomList({
     }
     return latestByRoom;
   }));
-  const { focusedRoomId, messagesPane, userChatAgentId, closeMobileSidebar, setFocusedRoomId, setOpenedRoomId, setMessagesPane, setUserChatAgentId } = useDashboardUIStore(useShallow((state) => ({
+  const { focusedRoomId, messagesPane, userChatAgentId, closeMobileSidebar, setFocusedRoomId, setOpenedRoomId, setMessagesPane, setUserChatAgentId, setUserChatRoomId } = useDashboardUIStore(useShallow((state) => ({
     focusedRoomId: state.focusedRoomId,
     messagesPane: state.messagesPane,
     userChatAgentId: state.userChatAgentId,
@@ -103,6 +102,7 @@ export default function RoomList({
     setOpenedRoomId: state.setOpenedRoomId,
     setMessagesPane: state.setMessagesPane,
     setUserChatAgentId: state.setUserChatAgentId,
+    setUserChatRoomId: state.setUserChatRoomId,
   })));
   const activeAgentId = useDashboardSessionStore((state) => state.activeAgentId);
   const viewMode = useDashboardSessionStore((state) => state.viewMode);
@@ -169,10 +169,11 @@ export default function RoomList({
       const agentId = room._originAgent?.agent_id || room.owner_id;
       setUserChatAgentId(agentId || null);
       setMessagesPane("user-chat");
+      setUserChatRoomId(room.room_id);
       setFocusedRoomId(null);
       setOpenedRoomId(null);
       closeMobileSidebar();
-      router.push(USER_CHAT_PATH);
+      router.push("/chats/messages");
       return;
     }
 
@@ -180,7 +181,7 @@ export default function RoomList({
     setFocusedRoomId(room.room_id);
     setOpenedRoomId(room.room_id);
     closeMobileSidebar();
-    router.push(`/chats/messages/${encodeURIComponent(room.room_id)}`);
+    router.push("/chats/messages");
   };
 
   const handleRoomKeyDown = (event: React.KeyboardEvent<HTMLDivElement>, room: DashboardRoom) => {
@@ -201,7 +202,7 @@ export default function RoomList({
     setFocusedRoomId(null);
     setOpenedRoomId(null);
     closeMobileSidebar();
-    router.push(USER_CHAT_PATH);
+    router.push("/chats/messages");
   };
 
   const handleUserChatKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {

--- a/frontend/src/components/dashboard/RoomZeroState.tsx
+++ b/frontend/src/components/dashboard/RoomZeroState.tsx
@@ -72,7 +72,7 @@ export default function RoomZeroState({ compact = false, hasRooms = false, onHum
     setMessagesFilter("self-all");
     setFocusedRoomId(room.room_id);
     setOpenedRoomId(room.room_id);
-    router.push(`/chats/messages/${encodeURIComponent(room.room_id)}`);
+    router.push("/chats/messages");
   };
 
   useEffect(() => {
@@ -97,17 +97,19 @@ export default function RoomZeroState({ compact = false, hasRooms = false, onHum
     setJoiningId(room.room_id);
     await joinRoom(room.room_id);
     setJoiningId(null);
+    setMessagesPane("room");
     setFocusedRoomId(room.room_id);
     setOpenedRoomId(room.room_id);
     setSidebarTab("messages");
-    router.push(`/chats/messages/${encodeURIComponent(room.room_id)}`);
+    router.push("/chats/messages");
   };
 
   const handleOpenRoom = (room: PublicRoom) => {
+    setMessagesPane("room");
     setFocusedRoomId(room.room_id);
     setOpenedRoomId(room.room_id);
     setSidebarTab("messages");
-    router.push(`/chats/messages/${encodeURIComponent(room.room_id)}`);
+    router.push("/chats/messages");
   };
 
   if (compact) {

--- a/frontend/src/components/dashboard/SubscriptionBadge.tsx
+++ b/frontend/src/components/dashboard/SubscriptionBadge.tsx
@@ -69,8 +69,17 @@ export default function SubscriptionBadge({
   const { joinRoom } = useDashboardChatStore(useShallow((state) => ({
     joinRoom: state.joinRoom,
   })));
-  const { setSidebarTab, startPrimaryNavigation } = useDashboardUIStore(useShallow((state) => ({
+  const {
+    setSidebarTab,
+    setFocusedRoomId,
+    setOpenedRoomId,
+    setMessagesPane,
+    startPrimaryNavigation,
+  } = useDashboardUIStore(useShallow((state) => ({
     setSidebarTab: state.setSidebarTab,
+    setFocusedRoomId: state.setFocusedRoomId,
+    setOpenedRoomId: state.setOpenedRoomId,
+    setMessagesPane: state.setMessagesPane,
     startPrimaryNavigation: state.startPrimaryNavigation,
   })));
   const {
@@ -188,7 +197,10 @@ export default function SubscriptionBadge({
       }
       if (roomId) {
         await joinRoom(roomId);
-        const path = `/chats/messages/${encodeURIComponent(roomId)}`;
+        const path = "/chats/messages";
+        setMessagesPane("room");
+        setFocusedRoomId(roomId);
+        setOpenedRoomId(roomId);
         startPrimaryNavigation("messages", path);
         router.push(path);
       }

--- a/frontend/src/components/dashboard/sidebar/index.tsx
+++ b/frontend/src/components/dashboard/sidebar/index.tsx
@@ -40,7 +40,6 @@ import { SidebarListSkeleton, SkeletonBlock } from "../DashboardTabSkeleton";
 import { UserPlus, LogIn, Bot, Plus, RefreshCw, MessageSquarePlus, Search, X } from "lucide-react";
 import { useAppStore } from "@/store/useAppStore";
 
-const USER_CHAT_ROUTE = "/chats/messages/__user-chat__";
 
 function formatBadgeCount(count: number): string {
   return count > 99 ? "99+" : String(count);
@@ -297,14 +296,9 @@ export default function Sidebar({
       showLoginModal();
       return;
     }
-    const openedRoomPath = uiStore.openedRoomId
-      ? `/chats/messages/${encodeURIComponent(uiStore.openedRoomId)}`
-      : uiStore.messagesPane === "user-chat"
-        ? USER_CHAT_ROUTE
-        : "/chats/messages";
     const pathByTab: Record<typeof tab, string> = {
       home: "/chats/home",
-      messages: openedRoomPath,
+      messages: "/chats/messages",
       contacts: `/chats/contacts/${uiStore.contactsView}`,
       explore: `/chats/explore/${uiStore.exploreView}`,
       wallet: "/chats/wallet",
@@ -416,7 +410,9 @@ export default function Sidebar({
             setShowCreateRoom(false);
             uiStore.setMessagesPane("room");
             uiStore.setMessagesFilter("self-all");
-            const path = `/chats/messages/${encodeURIComponent(room.room_id)}`;
+            uiStore.setFocusedRoomId(room.room_id);
+            uiStore.setOpenedRoomId(room.room_id);
+            const path = "/chats/messages";
             uiStore.startPrimaryNavigation("messages", path);
             onMobileSecondaryClose?.();
             startTransition(() => { router.push(path); });


### PR DESCRIPTION
## Summary
- keep internal Messages room switches on `/chats/messages` instead of changing the URL per room
- keep user-chat pane selection in dashboard UI state instead of requiring `/chats/messages/__user-chat__`
- preserve room and user-chat deep links as initialization paths that normalize back to `/chats/messages`
- let `MessageList` load messages from `openedRoomId` so loading no longer depends on route params

## Verification
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build`
