### PR TITLE
fix: treat Feishu chats as third-party gateway

### DIFF
--- a/packages/daemon/src/__tests__/turn-text.test.ts
+++ b/packages/daemon/src/__tests__/turn-text.test.ts
@@ -134,6 +134,22 @@ describe("composeBotCordUserTurn", () => {
     expect(out).not.toContain("botcord_send");
   });
 
+  it("does not tell Feishu chats to use botcord_send", () => {
+    const out = composeBotCordUserTurn(
+      makeMessage({
+        channel: "gw_feishu_123",
+        conversation: { id: "feishu:user:oc_alice", kind: "direct" },
+        sender: { id: "feishu:user:ou_alice", name: "Alice", kind: "user" },
+      }),
+    );
+    expect(out).toContain("third-party gateway chat");
+    expect(out).toContain("Reply normally in your final assistant message");
+    expect(out).toContain("conversation_id: feishu:user:oc_alice");
+    expect(out).toContain("channel: gw_feishu_123");
+    expect(out).not.toContain("Plain text output WILL NOT be sent");
+    expect(out).not.toContain("botcord_send");
+  });
+
   it("passes owner-chat messages through verbatim (no wrapper, no hint)", () => {
     const out = composeBotCordUserTurn(
       makeMessage({

--- a/packages/daemon/src/turn-text.ts
+++ b/packages/daemon/src/turn-text.ts
@@ -66,7 +66,8 @@ function readEnvelopeType(raw: unknown): string | undefined {
 function isThirdPartyConversation(conversationId: string): boolean {
   return (
     conversationId.startsWith("telegram:") ||
-    conversationId.startsWith("wechat:")
+    conversationId.startsWith("wechat:") ||
+    conversationId.startsWith("feishu:")
   );
 }
 


### PR DESCRIPTION
## Summary
- Treat `feishu:` conversations as third-party gateway chats in daemon user-turn prompt composition.
- Add Feishu prompt coverage so the runtime is told to reply normally instead of using `botcord_send`.

## Tests
- `cd packages/daemon && npm test -- --run src/__tests__/turn-text.test.ts`
- `cd packages/daemon && npx tsc -p tsconfig.json --noEmit` (fails on existing unrelated test type errors)