### PR TITLE
fix: include owner in owner chat rooms

### DIFF
--- a/backend/hub/routers/dashboard_chat.py
+++ b/backend/hub/routers/dashboard_chat.py
@@ -23,11 +23,13 @@ from hub.models import (
     Agent,
     MessageRecord,
     MessageState,
+    ParticipantType,
     Room,
     RoomJoinPolicy,
     RoomMember,
     RoomRole,
     RoomVisibility,
+    User,
 )
 from hub.routers.hub import notify_inbox
 from hub.i18n import I18nHTTPException
@@ -76,6 +78,61 @@ def _build_owner_chat_room_id(user_id: str, agent_id: str) -> str:
     return f"{_OWNER_CHAT_ROOM_PREFIX}{digest}"
 
 
+async def _resolve_owner_human_id(db: AsyncSession, user_id: str) -> str | None:
+    try:
+        user_uuid = uuid.UUID(user_id)
+    except ValueError:
+        return None
+
+    result = await db.execute(select(User.human_id).where(User.id == user_uuid))
+    return result.scalar_one_or_none()
+
+
+async def _ensure_owner_chat_members(
+    db: AsyncSession,
+    room_id: str,
+    user_id: str,
+    agent_id: str,
+) -> None:
+    """Ensure owner-chat rooms expose both participants in RoomMember."""
+    result = await db.execute(
+        select(RoomMember).where(
+            RoomMember.room_id == room_id,
+            RoomMember.agent_id == agent_id,
+        )
+    )
+    if result.scalar_one_or_none() is None:
+        db.add(
+            RoomMember(
+                room_id=room_id,
+                agent_id=agent_id,
+                participant_type=ParticipantType.agent,
+                role=RoomRole.owner,
+            )
+        )
+
+    human_id = await _resolve_owner_human_id(db, user_id)
+    if not human_id:
+        return
+
+    result = await db.execute(
+        select(RoomMember).where(
+            RoomMember.room_id == room_id,
+            RoomMember.agent_id == human_id,
+            RoomMember.participant_type == ParticipantType.human,
+        )
+    )
+    if result.scalar_one_or_none() is None:
+        db.add(
+            RoomMember(
+                room_id=room_id,
+                agent_id=human_id,
+                participant_type=ParticipantType.human,
+                role=RoomRole.member,
+            )
+        )
+
+
 async def _ensure_owner_chat_room(
     db: AsyncSession,
     user_id: str,
@@ -87,6 +144,8 @@ async def _ensure_owner_chat_room(
 
     result = await db.execute(select(Room).where(Room.room_id == room_id))
     if result.scalar_one_or_none() is not None:
+        await _ensure_owner_chat_members(db, room_id, user_id, agent_id)
+        await db.flush()
         return room_id
 
     room = Room(
@@ -104,12 +163,11 @@ async def _ensure_owner_chat_room(
             await db.flush()
     except IntegrityError:
         # Race: another request created it first
+        await _ensure_owner_chat_members(db, room_id, user_id, agent_id)
+        await db.flush()
         return room_id
 
-    # Add the agent as the sole member (owner-perspective).
-    # The user is not an agent so they don't get a RoomMember row;
-    # they interact exclusively via the dashboard chat API.
-    db.add(RoomMember(room_id=room_id, agent_id=agent_id, role=RoomRole.owner))
+    await _ensure_owner_chat_members(db, room_id, user_id, agent_id)
     await db.flush()
 
     return room_id

--- a/backend/hub/routers/hub.py
+++ b/backend/hub/routers/hub.py
@@ -946,6 +946,7 @@ async def _send_room_message(
 ) -> SendResponse:
     """Handle sending a message to a room (fan-out to all members except sender)."""
     room_id = envelope.to
+    is_owner_chat = room_id.startswith("rm_oc_")
 
     # Load room with members
     result = await db.execute(
@@ -997,11 +998,25 @@ async def _send_room_message(
             db, room_id, topic, envelope.from_, envelope.type, goal=goal,
         )
 
-    # Fan-out: create a MessageRecord for each member except sender, skip muted and blockers
-    receivers = {
+    # Fan-out: create a MessageRecord for each member except sender, skip muted and blockers.
+    # Owner-chat rooms include the human owner as a RoomMember for discoverability,
+    # but the human does not poll /hub/inbox. Deliver those rows immediately and
+    # push through the dedicated owner-chat websocket below.
+    owner_chat_human_receivers = {
         m.agent_id for m in room.members
-        if m.agent_id != envelope.from_ and not m.muted and m.agent_id not in blocked_by
+        if is_owner_chat
+        and m.agent_id != envelope.from_
+        and m.participant_type == ParticipantType.human
+        and not m.muted
+        and m.agent_id not in blocked_by
     }
+    if owner_chat_human_receivers:
+        receivers = owner_chat_human_receivers
+    else:
+        receivers = {
+            m.agent_id for m in room.members
+            if m.agent_id != envelope.from_ and not m.muted and m.agent_id not in blocked_by
+        }
 
     # Resolve sender display name for realtime events
     _sender_name_result = await db.execute(
@@ -1040,10 +1055,12 @@ async def _send_room_message(
             receiver_id in mentioned_set or "@all" in mentioned_set
         )
 
-        # Self-delivery records are marked as 'delivered' immediately so they
-        # never appear in the agent's inbox poll.  They exist solely for room
-        # history queries.
+        # Self-delivery and owner-chat human-delivery records are marked as
+        # delivered immediately so they never appear in any plugin inbox poll.
         _is_self_delivery = _self_delivery and receiver_id == envelope.from_
+        _is_owner_chat_human_delivery = (
+            is_owner_chat and receiver_id in owner_chat_human_receivers
+        )
         record = MessageRecord(
             hub_msg_id=hub_msg_id,
             msg_id=envelope.msg_id,
@@ -1053,7 +1070,11 @@ async def _send_room_message(
             topic=topic,
             topic_id=topic_id,
             goal=goal,
-            state=MessageState.delivered if _is_self_delivery else MessageState.queued,
+            state=(
+                MessageState.delivered
+                if (_is_self_delivery or _is_owner_chat_human_delivery)
+                else MessageState.queued
+            ),
             envelope_json=envelope_json,
             ttl_sec=envelope.ttl_sec,
             mentioned=is_mentioned,
@@ -1098,8 +1119,11 @@ async def _send_room_message(
                 # Skip Supabase realtime for owner-chat rooms — the dedicated
                 # WS path handles delivery; publishing here would cause
                 # redundant polling from the Supabase realtime listener.
-                if not room_id.startswith("rm_oc_"):
+                if not is_owner_chat:
                     await _publish_agent_realtime_event(db, rt_event)
+            elif is_owner_chat and receiver_id in owner_chat_human_receivers:
+                # Dedicated owner-chat WS handles immediate dashboard delivery.
+                pass
             else:
                 await notify_inbox(receiver_id, db=db, realtime_event=rt_event)
         except Exception as exc:
@@ -1109,7 +1133,7 @@ async def _send_room_message(
             )
 
     # Push agent reply to owner-chat WS clients when applicable
-    if _self_delivery and room_id.startswith("rm_oc_"):
+    if is_owner_chat and (_self_delivery or owner_chat_human_receivers):
         from hub.routers.owner_chat_ws import notify_oc_ws_message
         _oc_text = (envelope.payload or {}).get("text", "")
         await notify_oc_ws_message(

--- a/backend/hub/routers/room.py
+++ b/backend/hub/routers/room.py
@@ -174,11 +174,56 @@ def _normalize_room_rule(rule: str | None) -> str | None:
     return normalized or None
 
 
+def _is_human_member(member: RoomMember) -> bool:
+    ptype = getattr(member, "participant_type", None)
+    return ptype == ParticipantType.human or getattr(ptype, "value", None) == "human"
+
+
+async def _ensure_owner_chat_human_member(db: AsyncSession, room: Room) -> bool:
+    """Backfill the human owner RoomMember for legacy rm_oc_* rooms."""
+    if not room.room_id.startswith("rm_oc_"):
+        return False
+    if any(_is_human_member(m) for m in room.members):
+        return False
+
+    result = await db.execute(
+        select(User.human_id)
+        .join(Agent, Agent.user_id == User.id)
+        .where(Agent.agent_id == room.owner_id)
+    )
+    human_id = result.scalar_one_or_none()
+    if not human_id:
+        return False
+    if any(m.agent_id == human_id for m in room.members):
+        return False
+
+    room.members.append(
+        RoomMember(
+            room_id=room.room_id,
+            agent_id=human_id,
+            participant_type=ParticipantType.human,
+            role=RoomRole.member,
+        )
+    )
+    await db.flush()
+    return True
+
+
 def _room_url(room_id: str) -> str:
     return frontend_url(f"/chats/messages/{room_id}")
 
 
 def _build_room_response(room: Room) -> RoomResponse:
+    def _agent_display_name(member: RoomMember) -> str | None:
+        if _is_human_member(member):
+            return None
+        return member.agent.display_name if member.agent is not None else None
+
+    def _agent_avatar_url(member: RoomMember) -> str | None:
+        if _is_human_member(member):
+            return None
+        return member.agent.avatar_url if member.agent is not None else None
+
     return RoomResponse(
         room_id=room.room_id,
         name=room.name,
@@ -197,8 +242,8 @@ def _build_room_response(room: Room) -> RoomResponse:
         members=[
             RoomMemberResponse(
                 agent_id=m.agent_id,
-                display_name=m.agent.display_name if m.agent is not None else None,
-                avatar_url=m.agent.avatar_url if m.agent is not None else None,
+                display_name=_agent_display_name(m),
+                avatar_url=_agent_avatar_url(m),
                 role=m.role.value,
                 muted=m.muted,
                 can_send=m.can_send,
@@ -819,6 +864,11 @@ async def list_my_rooms(
         .offset(offset)
     )
     rooms = list(result.scalars().unique().all())
+    repaired = False
+    for room in rooms:
+        repaired = await _ensure_owner_chat_human_member(db, room) or repaired
+    if repaired:
+        await db.commit()
     return RoomListResponse(
         rooms=[_build_room_response(r) for r in rooms]
     )
@@ -833,6 +883,8 @@ async def get_room(
     """Get room info. Only members can view."""
     room = await _load_room(db, room_id, fresh=True)
     _require_membership(room, current_agent)
+    if await _ensure_owner_chat_human_member(db, room):
+        await db.commit()
     return _build_room_response(room)
 
 

--- a/backend/tests/test_dashboard_chat.py
+++ b/backend/tests/test_dashboard_chat.py
@@ -14,7 +14,8 @@ from nacl.signing import SigningKey
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from unittest.mock import AsyncMock
 
-from hub.models import Agent, Base, MessagePolicy, MessageRecord
+from hub.enums import ParticipantType
+from hub.models import Agent, Base, MessagePolicy, MessageRecord, RoomMember, User
 
 TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
 
@@ -151,6 +152,15 @@ async def test_dashboard_chat_send_and_room_creation(
     import uuid as _uuid
 
     user_id = str(_uuid.uuid4())
+    owner = User(
+        id=_uuid.UUID(user_id),
+        display_name="Owner User",
+        email="owner@example.com",
+        status="active",
+        supabase_user_id=_uuid.uuid4(),
+        human_id="hu_ownerchat01",
+    )
+    db_session.add(owner)
     await db_session.execute(
         update(Agent)
         .where(Agent.agent_id == agent_id)
@@ -238,6 +248,61 @@ async def test_dashboard_chat_room_is_stable(
 
 
 @pytest.mark.asyncio
+async def test_owner_chat_room_info_backfills_human_member(
+    client: AsyncClient,
+    db_session: AsyncSession,
+):
+    """Legacy owner-chat rooms are repaired when an agent reads room info."""
+    agent_id, token, _sk, _kid = await _register_and_verify(client, "BackfillAgent")
+
+    import uuid as _uuid
+    from sqlalchemy import select, update
+
+    user_id = str(_uuid.uuid4())
+    owner = User(
+        id=_uuid.UUID(user_id),
+        display_name="Owner User",
+        email="backfill-owner@example.com",
+        status="active",
+        supabase_user_id=_uuid.uuid4(),
+        human_id="hu_backfill01",
+    )
+    db_session.add(owner)
+    owner_human_id = owner.human_id
+    await db_session.execute(
+        update(Agent)
+        .where(Agent.agent_id == agent_id)
+        .values(
+            user_id=_uuid.UUID(user_id),
+            claimed_at=datetime.datetime.now(datetime.timezone.utc),
+        )
+    )
+    await db_session.commit()
+
+    headers = _auth_header(token)
+    resp = await client.get("/dashboard/chat/room", headers=headers)
+    assert resp.status_code == 200
+    room_id = resp.json()["room_id"]
+
+    human_member = (
+        await db_session.execute(
+            select(RoomMember).where(
+                RoomMember.room_id == room_id,
+                RoomMember.agent_id == owner_human_id,
+            )
+        )
+    ).scalar_one()
+    await db_session.delete(human_member)
+    await db_session.commit()
+
+    resp = await client.get(f"/hub/rooms/{room_id}", headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["member_count"] == 2
+    assert {m["agent_id"] for m in data["members"]} == {agent_id, owner_human_id}
+
+
+@pytest.mark.asyncio
 async def test_dashboard_chat_inbox_includes_source_type(
     client: AsyncClient,
     db_session: AsyncSession,
@@ -290,14 +355,24 @@ async def test_agent_reply_to_owner_chat_creates_record(
     client: AsyncClient,
     db_session: AsyncSession,
 ):
-    """When an agent sends a reply to its owner-chat room (rm_oc_*), a self-delivery
-    MessageRecord is created so the dashboard can display the reply."""
+    """When an agent sends a reply to its owner-chat room (rm_oc_*), a delivered
+    MessageRecord is created for the human owner so the dashboard can display it."""
     agent_id, token, sk, key_id = await _register_and_verify(client, "ReplyAgent")
 
     import uuid as _uuid
     from sqlalchemy import select, update
 
     user_id = str(_uuid.uuid4())
+    owner = User(
+        id=_uuid.UUID(user_id),
+        display_name="Owner User",
+        email="reply-owner@example.com",
+        status="active",
+        supabase_user_id=_uuid.uuid4(),
+        human_id="hu_replyown01",
+    )
+    db_session.add(owner)
+    owner_human_id = owner.human_id
     await db_session.execute(
         update(Agent)
         .where(Agent.agent_id == agent_id)
@@ -315,6 +390,17 @@ async def test_agent_reply_to_owner_chat_creates_record(
     assert resp.status_code == 200
     room_id = resp.json()["room_id"]
     assert room_id.startswith("rm_oc_")
+    members_result = await db_session.execute(
+        select(RoomMember).where(RoomMember.room_id == room_id)
+    )
+    members = members_result.scalars().all()
+    assert {
+        (m.agent_id, m.participant_type)
+        for m in members
+    } == {
+        (agent_id, ParticipantType.agent),
+        (owner_human_id, ParticipantType.human),
+    }
 
     # Agent sends a reply back to this room via /hub/send (simulating plugin reply)
     envelope = _build_envelope(
@@ -341,8 +427,7 @@ async def test_agent_reply_to_owner_chat_creates_record(
     record = result.scalar_one()
     assert record.room_id == room_id
     assert record.sender_id == agent_id
-    # Self-delivery: receiver is the sender
-    assert record.receiver_id == agent_id
+    assert record.receiver_id == owner_human_id
     # Crucially: state is 'delivered' (not 'queued') so it never appears in
     # inbox polling — the plugin must not re-process its own reply.
     assert record.state.value == "delivered"


### PR DESCRIPTION
## Summary
- add the human owner as a RoomMember in rm_oc owner-chat rooms
- preserve owner-chat delivery semantics so agent replies are delivered to the dashboard without entering the agent inbox
- lazily backfill legacy rm_oc rooms when agents list or inspect rooms

## Tests
- cd backend && uv run pytest tests/test_dashboard_chat.py tests/test_room.py tests/test_hub_room_human_guard.py -q