### PR TITLE
fix: align daemon memory path with CLI

### DIFF
--- a/packages/daemon/src/__tests__/working-memory.test.ts
+++ b/packages/daemon/src/__tests__/working-memory.test.ts
@@ -30,7 +30,11 @@ vi.mock("../log.js", () => ({
 const wm = await import("../working-memory.js");
 const { agentStateDir } = await import("../agent-workspace.js");
 
-function newPathFor(agentId: string): string {
+function cliPathFor(agentId: string): string {
+  return path.join(tmpHome, ".botcord", "memory", agentId, "working-memory.json");
+}
+
+function daemonStatePathFor(agentId: string): string {
   return path.join(agentStateDir(agentId), "working-memory.json");
 }
 
@@ -44,8 +48,14 @@ function writeLegacy(agentId: string, body: unknown): void {
   writeFileSync(p, JSON.stringify(body));
 }
 
-function writeNew(agentId: string, body: unknown): void {
-  const p = newPathFor(agentId);
+function writeDaemonState(agentId: string, body: unknown): void {
+  const p = daemonStatePathFor(agentId);
+  mkdirSync(path.dirname(p), { recursive: true });
+  writeFileSync(p, JSON.stringify(body));
+}
+
+function writeCli(agentId: string, body: unknown): void {
+  const p = cliPathFor(agentId);
   mkdirSync(path.dirname(p), { recursive: true });
   writeFileSync(p, JSON.stringify(body));
 }
@@ -79,9 +89,10 @@ describe("working-memory I/O", () => {
     expect(got?.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 
-  it("writes land in the new state dir", () => {
+  it("writes land in the CLI-compatible memory dir", () => {
     wm.updateWorkingMemory("ag_new", { goal: "g" });
-    expect(existsSync(newPathFor("ag_new"))).toBe(true);
+    expect(existsSync(cliPathFor("ag_new"))).toBe(true);
+    expect(existsSync(daemonStatePathFor("ag_new"))).toBe(false);
     expect(existsSync(legacyPathFor("ag_new"))).toBe(false);
   });
 
@@ -136,34 +147,51 @@ describe("working-memory I/O", () => {
   });
 });
 
-describe("working-memory migration (§8)", () => {
-  it("reads from new path when present and ignores legacy", () => {
-    writeNew("ag_mig", { version: 2, sections: { notes: "fresh" }, updatedAt: "2026-01-01" });
+describe("working-memory migration", () => {
+  it("reads from CLI path when present and ignores daemon paths", () => {
+    writeCli("ag_mig", { version: 2, sections: { notes: "fresh" }, updatedAt: "2026-01-01" });
+    writeDaemonState("ag_mig", { version: 2, sections: { notes: "state" }, updatedAt: "2025-01-01" });
     writeLegacy("ag_mig", { version: 2, sections: { notes: "stale" }, updatedAt: "2024-01-01" });
 
     const got = wm.readWorkingMemory("ag_mig");
     expect(got?.sections.notes).toBe("fresh");
-    // Legacy is left in place when new wins; warning is emitted once.
+    // Old daemon paths are left in place when CLI wins; warning is emitted once.
+    expect(existsSync(daemonStatePathFor("ag_mig"))).toBe(true);
     expect(existsSync(legacyPathFor("ag_mig"))).toBe(true);
     expect(warnSpy).toHaveBeenCalled();
   });
 
-  it("renames legacy → new on first read when only legacy exists", () => {
+  it("renames daemon state → CLI path on first read when only daemon state exists", () => {
+    writeDaemonState("ag_onlystate", {
+      version: 2,
+      sections: { notes: "state notes" },
+      updatedAt: "2025-01-01",
+    });
+    expect(existsSync(cliPathFor("ag_onlystate"))).toBe(false);
+
+    const got = wm.readWorkingMemory("ag_onlystate");
+    expect(got?.sections.notes).toBe("state notes");
+
+    expect(existsSync(daemonStatePathFor("ag_onlystate"))).toBe(false);
+    expect(existsSync(cliPathFor("ag_onlystate"))).toBe(true);
+  });
+
+  it("renames legacy daemon memory → CLI path on first read when only legacy exists", () => {
     writeLegacy("ag_onlyold", {
       version: 2,
       sections: { notes: "old notes" },
       updatedAt: "2024-01-01",
     });
-    expect(existsSync(newPathFor("ag_onlyold"))).toBe(false);
+    expect(existsSync(cliPathFor("ag_onlyold"))).toBe(false);
 
     const got = wm.readWorkingMemory("ag_onlyold");
     expect(got?.sections.notes).toBe("old notes");
 
-    // Legacy moved away; new path now holds the data.
+    // Legacy moved away; CLI path now holds the data.
     expect(existsSync(legacyPathFor("ag_onlyold"))).toBe(false);
-    expect(existsSync(newPathFor("ag_onlyold"))).toBe(true);
+    expect(existsSync(cliPathFor("ag_onlyold"))).toBe(true);
 
-    // Subsequent reads come from new path — delete legacy dir tree to
+    // Subsequent reads come from CLI path — delete legacy dir tree to
     // prove no re-read falls through to it.
     const got2 = wm.readWorkingMemory("ag_onlyold");
     expect(got2?.sections.notes).toBe("old notes");
@@ -180,13 +208,13 @@ describe("working-memory migration (§8)", () => {
       updatedAt: "2024-01-01",
     });
 
-    // Plant a regular file where the new state *directory* would live, so
+    // Plant a regular file where the CLI memory *directory* would live, so
     // mkdirSync+renameSync inside the migration branch fails with ENOTDIR
-    // (the agent home's `state` path already exists as a file). The
+    // (`~/.botcord/memory/<agentId>` already exists as a file). The
     // migration path must log and fall back to reading the legacy file.
-    const home = path.join(tmpHome, ".botcord", "agents", "ag_renamefail");
+    const home = path.join(tmpHome, ".botcord", "memory");
     mkdirSync(home, { recursive: true });
-    writeFileSync(path.join(home, "state"), "not a dir");
+    writeFileSync(path.join(home, "ag_renamefail"), "not a dir");
 
     const got = wm.readWorkingMemory("ag_renamefail");
     expect(got?.sections.notes).toBe("still readable");

--- a/packages/daemon/src/working-memory.ts
+++ b/packages/daemon/src/working-memory.ts
@@ -1,8 +1,9 @@
 /**
  * Working memory — persistent, account-scoped notes injected into every turn.
  *
- * Stored at `~/.botcord/agents/{agentId}/state/working-memory.json` (the
- * per-agent state dir owned by the daemon).
+ * Stored at `~/.botcord/memory/{agentId}/working-memory.json`, matching the
+ * @botcord/cli `botcord memory` command so writes made by an agent are visible
+ * to daemon context injection on the next turn.
  *
  * Ported from plugin/src/memory.ts (dropping workspace + OpenClaw runtime
  * branches) and plugin/src/memory-protocol.ts (prompt builder).
@@ -16,6 +17,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
 import { agentStateDir } from "./agent-workspace.js";
 import { DAEMON_DIR_PATH } from "./config.js";
@@ -50,18 +52,21 @@ const RESERVED_TAGS_RE = /<\/?(?:current_memory|section_\w+)\b[^>]*>/gi;
 // ── Path resolution ────────────────────────────────────────────────
 
 /**
- * Canonical per-agent state directory. Returns the new location
- * (`~/.botcord/agents/{agentId}/state`). The legacy location under
- * `~/.botcord/daemon/memory/{agentId}` is migrated lazily on first read —
- * see §8 of the daemon-agent-workspace plan.
+ * Canonical per-agent memory directory. This intentionally matches
+ * @botcord/cli's `botcord memory` path so the CLI and daemon share one store.
  */
 export function resolveMemoryDir(agentId: string): string {
   if (!agentId) throw new Error("resolveMemoryDir: agentId is required");
+  return path.join(homedir(), ".botcord", "memory", agentId);
+}
+
+/** Previous daemon-owned location retained for one-shot migration on read. */
+function daemonStateMemoryDir(agentId: string): string {
   return agentStateDir(agentId);
 }
 
-/** Legacy location retained for one-shot migration on read. */
-function legacyMemoryDir(agentId: string): string {
+/** Older daemon location retained for one-shot migration on read. */
+function daemonLegacyMemoryDir(agentId: string): string {
   return path.join(DAEMON_DIR_PATH, "memory", agentId);
 }
 
@@ -69,8 +74,12 @@ function workingMemoryPath(agentId: string): string {
   return path.join(resolveMemoryDir(agentId), "working-memory.json");
 }
 
-function legacyWorkingMemoryPath(agentId: string): string {
-  return path.join(legacyMemoryDir(agentId), "working-memory.json");
+function daemonStateWorkingMemoryPath(agentId: string): string {
+  return path.join(daemonStateMemoryDir(agentId), "working-memory.json");
+}
+
+function daemonLegacyWorkingMemoryPath(agentId: string): string {
+  return path.join(daemonLegacyMemoryDir(agentId), "working-memory.json");
 }
 
 // Migration conflict warnings are emitted at most once per agent per
@@ -79,59 +88,63 @@ function legacyWorkingMemoryPath(agentId: string): string {
 const warnedMigrationConflict = new Set<string>();
 
 /**
- * Resolve the path to read from, migrating from the legacy location if
+ * Resolve the path to read from, migrating from daemon-only locations if
  * necessary. Returns the path the caller should read, or `null` when no
  * memory file exists anywhere.
- *
- * Migration branch (the `else if` on `legacyExists` below) is meant to be
- * deleted one release after this change ships; see plan §8 step 6.
  */
 function resolveReadPath(agentId: string): string | null {
-  const newPath = workingMemoryPath(agentId);
-  const oldPath = legacyWorkingMemoryPath(agentId);
-  const newExists = existsSync(newPath);
-  const oldExists = existsSync(oldPath);
+  const cliPath = workingMemoryPath(agentId);
+  const daemonStatePath = daemonStateWorkingMemoryPath(agentId);
+  const daemonLegacyPath = daemonLegacyWorkingMemoryPath(agentId);
+  const cliExists = existsSync(cliPath);
+  const daemonStateExists = existsSync(daemonStatePath);
+  const daemonLegacyExists = existsSync(daemonLegacyPath);
 
-  if (newExists) {
-    if (oldExists && !warnedMigrationConflict.has(agentId)) {
+  if (cliExists) {
+    if ((daemonStateExists || daemonLegacyExists) && !warnedMigrationConflict.has(agentId)) {
       warnedMigrationConflict.add(agentId);
-      daemonLog.warn("working-memory: both new and legacy paths exist; using new", {
+      daemonLog.warn("working-memory: both cli and daemon paths exist; using cli", {
         agentId,
-        oldPath,
-        newPath,
+        cliPath,
+        daemonStatePath,
+        daemonLegacyPath,
       });
     }
-    return newPath;
+    return cliPath;
   }
-  if (oldExists) {
+
+  const migrateFrom = daemonStateExists
+    ? daemonStatePath
+    : daemonLegacyExists
+      ? daemonLegacyPath
+      : null;
+  if (migrateFrom) {
     try {
-      mkdirSync(path.dirname(newPath), { recursive: true, mode: 0o700 });
+      mkdirSync(path.dirname(cliPath), { recursive: true, mode: 0o700 });
       try {
-        renameSync(oldPath, newPath);
+        renameSync(migrateFrom, cliPath);
       } catch (err) {
-        // EXDEV = legacy and new paths live on different filesystems
+        // EXDEV = old and canonical paths live on different filesystems
         // (bind mounts, tmpfs overlays). `renameSync` cannot cross fs
-        // boundaries, so fall back to copy + unlink. Without this, the
-        // next write would go to newPath while legacy still has the old
-        // payload — silent divergence the reviewer of §8 flagged.
+        // boundaries, so fall back to copy + unlink.
         if ((err as NodeJS.ErrnoException).code === "EXDEV") {
-          copyFileSync(oldPath, newPath);
-          unlinkSync(oldPath);
+          copyFileSync(migrateFrom, cliPath);
+          unlinkSync(migrateFrom);
         } else {
           throw err;
         }
       }
-      return newPath;
+      return cliPath;
     } catch (err) {
       const e = err as NodeJS.ErrnoException;
-      daemonLog.warn("working-memory: migration rename failed; reading legacy path", {
+      daemonLog.warn("working-memory: migration rename failed; reading daemon path", {
         agentId,
-        oldPath,
-        newPath,
+        oldPath: migrateFrom,
+        newPath: cliPath,
         code: e.code,
         error: e.message ?? String(err),
       });
-      return oldPath;
+      return migrateFrom;
     }
   }
   return null;


### PR DESCRIPTION
## Summary
- store daemon working memory in the same ~/.botcord/memory/{agentId} path used by @botcord/cli
- migrate previous daemon-owned memory files into the CLI-compatible path on read
- cover CLI precedence and migration paths with daemon tests

## Tests
- cd packages/daemon && npm test -- --run src/__tests__/working-memory.test.ts
- cd packages/daemon && npx tsc -p tsconfig.build.json --noEmit
- cd packages/daemon && npm run build