### PR TITLE
fix: hide owner chat from messages list

### DIFF
--- a/frontend/src/components/dashboard/RoomList.tsx
+++ b/frontend/src/components/dashboard/RoomList.tsx
@@ -75,7 +75,7 @@ export default function RoomList({
   rooms: propsRooms,
   loading = false,
   searchQuery = "",
-  includeUserChat = true,
+  includeUserChat = false,
   roomMeta,
 }: RoomListProps) {
   const router = useRouter();

--- a/frontend/src/components/dashboard/sidebar/MessagesPanel.tsx
+++ b/frontend/src/components/dashboard/sidebar/MessagesPanel.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "nextjs-toploader/app";
 import { useLanguage } from "@/lib/i18n";
 import { sidebar } from "@/lib/i18n/translations/dashboard";
 import { useShallow } from "zustand/react/shallow";
-import { buildVisibleMessageRooms, isOwnerChatRoom } from "@/store/dashboard-shared";
+import { buildVisibleMessageRooms } from "@/store/dashboard-shared";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
@@ -31,8 +31,7 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
   const locale = useLanguage();
   const t = sidebar[locale];
 
-  const { activeAgentId, sessionMode, token, humanRooms, ownedAgents } = useDashboardSessionStore(useShallow((s) => ({
-    activeAgentId: s.activeAgentId,
+  const { sessionMode, token, humanRooms, ownedAgents } = useDashboardSessionStore(useShallow((s) => ({
     sessionMode: s.sessionMode,
     token: s.token,
     humanRooms: s.humanRooms,
@@ -116,11 +115,6 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
       return searchHaystack.includes(normalizedMessageQuery);
     });
   }, [messages, normalizedMessageQuery, categorizedRooms]);
-
-  const includeUserChat = (messagesFilter === "self-all" || messagesFilter === "self-my-bot")
-    && !filteredMessageRooms.some(
-      (room) => isOwnerChatRoom(room.room_id) && room._originAgent?.agent_id === activeAgentId,
-    );
 
   // (filter chips moved into MessagesGroupingSidebar as expandable children)
 
@@ -233,9 +227,9 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
             创建 Bot
           </button>
         </div>
-      ) : visibleMessageRooms.length === 0 && !activeAgentId ? (
+      ) : visibleMessageRooms.length === 0 ? (
         <RoomZeroState compact />
-      ) : !showOverviewSkeleton && filteredMessageRooms.length === 0 && !activeAgentId ? (
+      ) : !showOverviewSkeleton && filteredMessageRooms.length === 0 ? (
         <div className="px-4 py-6 text-center text-xs text-text-secondary">
           {t.noMessages}
         </div>
@@ -245,7 +239,6 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
             rooms={filteredMessageRooms}
             loading={showRoomListSkeleton}
             searchQuery={messageQuery}
-            includeUserChat={includeUserChat}
           />
           {!showOverviewSkeleton && !normalizedMessageQuery && filteredMessageRooms.length < 5 && (
             <div className="mx-3 mb-3 mt-auto rounded-2xl border border-dashed border-glass-border/60 bg-glass-bg/20 p-4">

--- a/frontend/src/lib/messages-merge.test.ts
+++ b/frontend/src/lib/messages-merge.test.ts
@@ -198,7 +198,7 @@ describe("messages merge filters", () => {
     expect(applyMessagesFilter([room], "bots-bot-bot", ownedAgentIds)).toEqual([]);
   });
 
-  it("classifies owner-chat rm_oc rooms as my own bot conversations", () => {
+  it("excludes owner-chat rm_oc rooms from the Messages list", () => {
     const rooms = mergeOwnerVisibleRooms({
       ownRooms: [],
       ownedAgentRooms: [
@@ -213,17 +213,14 @@ describe("messages merge filters", () => {
     });
     const ownedAgentIds = new Set(["ag_bot"]);
 
-    expect(applyMessagesFilter(rooms, "self-my-bot", ownedAgentIds).map((room) => room.room_id)).toEqual([
-      "rm_oc_abc123",
-    ]);
-    expect(applyMessagesFilter(rooms, "self-all", ownedAgentIds).map((room) => room.room_id)).toEqual([
-      "rm_oc_abc123",
-    ]);
+    expect(rooms).toEqual([]);
+    expect(applyMessagesFilter(rooms, "self-my-bot", ownedAgentIds)).toEqual([]);
+    expect(applyMessagesFilter(rooms, "self-all", ownedAgentIds)).toEqual([]);
     expect(applyMessagesFilter(rooms, "bots-all", ownedAgentIds)).toEqual([]);
     expect(applyMessagesFilter(rooms, "bots-group", ownedAgentIds)).toEqual([]);
     expect(countMessagesByFilter(rooms, ownedAgentIds)).toMatchObject({
-      "self-all": 1,
-      "self-my-bot": 1,
+      "self-all": 0,
+      "self-my-bot": 0,
       "bots-all": 0,
       "bots-group": 0,
     });

--- a/frontend/src/lib/messages-merge.ts
+++ b/frontend/src/lib/messages-merge.ts
@@ -67,6 +67,7 @@ export function mergeOwnerVisibleRooms({ ownedAgentRooms, ownRooms }: MergeOpts)
   return [
     ...ownRooms,
     ...ownedAgentRooms
+      .filter((room) => !isOwnerChatRoom(room.room_id))
       .filter((room) => !seen.has(room.room_id) || !isPrivateMessageRoom(room))
       .map(ownedAgentRoomToDashboardRoom),
   ].sort(compareRoomsByActivityDesc);


### PR DESCRIPTION
## Summary
- remove the synthetic Me & My Bot entry from the Messages sidebar
- exclude rm_oc_* owner-chat rooms from owner-visible Messages merges
- update message filter regression coverage

## Tests
- npm test -- --run src/lib/messages-merge.test.ts src/store/dashboard-shared.test.ts
- npm run build (fails during static generation for /admin/codes because Supabase URL/API key are not configured locally; compile and TypeScript complete first)