### PR TITLE
fix: restore real owner chat rooms

### DIFF
--- a/frontend/src/lib/messages-merge.test.ts
+++ b/frontend/src/lib/messages-merge.test.ts
@@ -198,7 +198,7 @@ describe("messages merge filters", () => {
     expect(applyMessagesFilter([room], "bots-bot-bot", ownedAgentIds)).toEqual([]);
   });
 
-  it("excludes owner-chat rm_oc rooms from the Messages list", () => {
+  it("keeps real owner-chat rm_oc rooms as my own bot conversations", () => {
     const rooms = mergeOwnerVisibleRooms({
       ownRooms: [],
       ownedAgentRooms: [
@@ -213,14 +213,17 @@ describe("messages merge filters", () => {
     });
     const ownedAgentIds = new Set(["ag_bot"]);
 
-    expect(rooms).toEqual([]);
-    expect(applyMessagesFilter(rooms, "self-my-bot", ownedAgentIds)).toEqual([]);
-    expect(applyMessagesFilter(rooms, "self-all", ownedAgentIds)).toEqual([]);
+    expect(applyMessagesFilter(rooms, "self-my-bot", ownedAgentIds).map((room) => room.room_id)).toEqual([
+      "rm_oc_abc123",
+    ]);
+    expect(applyMessagesFilter(rooms, "self-all", ownedAgentIds).map((room) => room.room_id)).toEqual([
+      "rm_oc_abc123",
+    ]);
     expect(applyMessagesFilter(rooms, "bots-all", ownedAgentIds)).toEqual([]);
     expect(applyMessagesFilter(rooms, "bots-group", ownedAgentIds)).toEqual([]);
     expect(countMessagesByFilter(rooms, ownedAgentIds)).toMatchObject({
-      "self-all": 0,
-      "self-my-bot": 0,
+      "self-all": 1,
+      "self-my-bot": 1,
       "bots-all": 0,
       "bots-group": 0,
     });

--- a/frontend/src/lib/messages-merge.ts
+++ b/frontend/src/lib/messages-merge.ts
@@ -67,7 +67,6 @@ export function mergeOwnerVisibleRooms({ ownedAgentRooms, ownRooms }: MergeOpts)
   return [
     ...ownRooms,
     ...ownedAgentRooms
-      .filter((room) => !isOwnerChatRoom(room.room_id))
       .filter((room) => !seen.has(room.room_id) || !isPrivateMessageRoom(room))
       .map(ownedAgentRoomToDashboardRoom),
   ].sort(compareRoomsByActivityDesc);


### PR DESCRIPTION
## Summary
- restore real rm_oc_* owner-chat rooms in the Messages room merge
- keep the synthetic Me & My Bot sidebar entry disabled from the previous PR
- update regression coverage so real owner-chat rooms remain classified as self-my-bot

## Tests
- npm test -- --run src/lib/messages-merge.test.ts src/store/dashboard-shared.test.ts