### PR TITLE
fix: show contact request badges

### DIFF
--- a/backend/app/routers/humans.py
+++ b/backend/app/routers/humans.py
@@ -2077,6 +2077,32 @@ async def _resolve_participant_display_name(
     return row.scalar_one_or_none()
 
 
+async def _resolve_participant_display_names(
+    db: AsyncSession,
+    ids_by_type: dict[ParticipantType, set[str]],
+) -> dict[tuple[ParticipantType, str], str | None]:
+    """Batch lookup display names for mixed Agent/Human participant ids."""
+    name_lookup: dict[tuple[ParticipantType, str], str | None] = {}
+    agent_ids = ids_by_type.get(ParticipantType.agent, set())
+    if agent_ids:
+        rows = await db.execute(
+            select(Agent.agent_id, Agent.display_name).where(Agent.agent_id.in_(agent_ids))
+        )
+        for aid, name in rows.all():
+            name_lookup[(ParticipantType.agent, aid)] = name
+
+    human_ids = ids_by_type.get(ParticipantType.human, set())
+    if human_ids:
+        rows = await db.execute(
+            select(User.human_id, User.display_name).where(User.human_id.in_(human_ids))
+        )
+        for hid, name in rows.all():
+            if hid is not None:
+                name_lookup[(ParticipantType.human, hid)] = name
+
+    return name_lookup
+
+
 async def _serialise_contact_requests(
     db: AsyncSession,
     rows: list[ContactRequest],
@@ -2328,11 +2354,45 @@ async def list_pending_approvals(
         .order_by(AgentApprovalQueue.created_at.asc())
     )
     approvals: list[PendingApprovalSummary] = []
-    for entry in queue_result.scalars().all():
+    queue_entries = list(queue_result.scalars().all())
+    queue_payloads: list[tuple[AgentApprovalQueue, dict]] = []
+    queue_name_ids: dict[ParticipantType, set[str]] = {
+        ParticipantType.agent: set(),
+        ParticipantType.human: set(),
+    }
+    for entry in queue_entries:
         try:
             payload = json.loads(entry.payload_json or "{}")
         except json.JSONDecodeError:
             payload = {}
+        if entry.kind == ApprovalKind.contact_request:
+            from_pid = payload.get("from_participant_id")
+            if isinstance(from_pid, str) and from_pid:
+                from_type_raw = payload.get("from_type")
+                if from_type_raw in {p.value for p in ParticipantType}:
+                    from_type = ParticipantType(from_type_raw)
+                elif from_pid.startswith("ag_"):
+                    from_type = ParticipantType.agent
+                    payload["from_type"] = from_type.value
+                elif from_pid.startswith("hu_"):
+                    from_type = ParticipantType.human
+                    payload["from_type"] = from_type.value
+                else:
+                    from_type = ParticipantType.human
+                    payload["from_type"] = from_type.value
+                if not payload.get("from_display_name"):
+                    queue_name_ids[from_type].add(from_pid)
+        queue_payloads.append((entry, payload))
+
+    queue_name_lookup = await _resolve_participant_display_names(db, queue_name_ids)
+    for entry, payload in queue_payloads:
+        if entry.kind == ApprovalKind.contact_request and not payload.get("from_display_name"):
+            from_pid = payload.get("from_participant_id")
+            from_type_raw = payload.get("from_type")
+            if isinstance(from_pid, str) and from_type_raw in {p.value for p in ParticipantType}:
+                payload["from_display_name"] = queue_name_lookup.get(
+                    (ParticipantType(from_type_raw), from_pid)
+                )
         approvals.append(
             PendingApprovalSummary(
                 id=str(entry.id),

--- a/backend/tests/test_app/test_app_humans.py
+++ b/backend/tests/test_app/test_app_humans.py
@@ -2102,6 +2102,14 @@ async def test_a2a_contact_request_approval_creates_correct_contacts(
     assert entry.owner_user_id == bob.id
 
     bob_headers = {"Authorization": f"Bearer {_token(str(bob_supa))}"}
+    listing = await client.get("/api/humans/me/pending-approvals", headers=bob_headers)
+    assert listing.status_code == 200, listing.text
+    approvals = listing.json()["approvals"]
+    assert len(approvals) == 1
+    assert approvals[0]["payload"]["from_participant_id"] == ext_id
+    assert approvals[0]["payload"]["from_type"] == "agent"
+    assert approvals[0]["payload"]["from_display_name"] == "external"
+
     resolve = await client.post(
         f"/api/humans/me/pending-approvals/{entry.id}/resolve",
         headers=bob_headers,

--- a/frontend/src/components/dashboard/ContactRequestsInbox.tsx
+++ b/frontend/src/components/dashboard/ContactRequestsInbox.tsx
@@ -137,13 +137,14 @@ export default function ContactRequestsInbox({
       try {
         await humansApi.resolvePendingApproval(approvalId, decision);
         setBotApprovals((prev) => prev.filter((approval) => approval.id !== approvalId));
+        await loadContactRequests();
       } catch (err: any) {
         setBotApprovalsError(err?.message || (locale === "zh" ? "处理 Bot 请求失败" : "Failed to resolve bot request"));
       } finally {
         setBotApprovalAction(null);
       }
     },
-    [locale],
+    [loadContactRequests, locale],
   );
 
   return (

--- a/frontend/src/components/dashboard/sidebar/ContactsPanel.tsx
+++ b/frontend/src/components/dashboard/sidebar/ContactsPanel.tsx
@@ -126,11 +126,14 @@ export default function ContactsPanel({ onOpenAddFriend }: ContactsPanelProps) {
     selectedContactKey: s.selectedContactKey,
     setSelectedContactKey: s.setSelectedContactKey,
   })));
-  const { contactRequestsReceived } = useDashboardContactStore(useShallow((s) => ({
+  const { contactRequestsReceived, contactRequestsBotApprovalCount } = useDashboardContactStore(useShallow((s) => ({
     contactRequestsReceived: s.contactRequestsReceived,
+    contactRequestsBotApprovalCount: s.contactRequestsBotApprovalCount,
   })));
 
   const pending = contactRequestsReceived.filter((r) => r.state === "pending");
+  const directPendingCount = Math.max(pending.length, overview?.pending_requests || 0);
+  const totalPendingRequests = directPendingCount + contactRequestsBotApprovalCount;
   const contacts = overview?.contacts || [];
   const ownedAgentIds = new Set(ownedAgents.map((a) => a.agent_id));
   // Owned bots are listed separately at the top; drop them from the contact list
@@ -207,15 +210,15 @@ export default function ContactsPanel({ onOpenAddFriend }: ContactsPanelProps) {
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
             <span className="text-sm font-medium text-text-primary">{t.newRequests}</span>
-            {pending.length > 0 ? (
+            {totalPendingRequests > 0 ? (
               <span className="rounded-full bg-neon-cyan px-1.5 text-[10px] font-bold text-black">
-                {pending.length}
+                {totalPendingRequests > 99 ? "99+" : totalPendingRequests}
               </span>
             ) : null}
           </div>
           <p className="truncate text-[11px] text-text-secondary/60">
-            {pending.length > 0
-              ? t.pendingRequests(pending.length)
+            {totalPendingRequests > 0
+              ? t.pendingRequests(totalPendingRequests)
               : t.noPendingRequests}
           </p>
         </div>

--- a/frontend/src/components/dashboard/sidebar/index.tsx
+++ b/frontend/src/components/dashboard/sidebar/index.tsx
@@ -171,6 +171,10 @@ export default function Sidebar({
     overview: s.overview,
     recentVisitedRooms: s.recentVisitedRooms,
   })));
+  const contactStore = useDashboardContactStore(useShallow((s) => ({
+    contactRequestsBotApprovalCount: s.contactRequestsBotApprovalCount,
+    loadContactRequests: s.loadContactRequests,
+  })));
   const unreadStore = useDashboardUnreadStore(useShallow((s) => ({
     optimisticUnreadRoomIds: s.optimisticUnreadRoomIds,
     isRoomUnread: s.isRoomUnread,
@@ -270,12 +274,16 @@ export default function Sidebar({
     return persistedCount + optimisticOnlyCount;
   }, [unreadStore, visibleMessageRooms]);
 
-  const pendingContactRequests = chatStore.overview?.pending_requests || 0;
+  const pendingContactRequests = (chatStore.overview?.pending_requests || 0) + contactStore.contactRequestsBotApprovalCount;
   const visibleSidebarTab = sidebarTabOverride ?? uiStore.sidebarTab;
   const secondaryPanelLoading = Boolean(
     uiStore.pendingPrimaryNavigation && uiStore.pendingPrimaryNavigation.tab === visibleSidebarTab,
   );
   const showMessagesGrouping = visibleSidebarTab === "messages" && !isGuest && uiStore.messagesGroupingOpen;
+
+  useEffect(() => {
+    if (!isGuest) void contactStore.loadContactRequests();
+  }, [contactStore.loadContactRequests, isGuest]);
 
   useEffect(() => {
     const prefetch = (path: string) => {
@@ -349,7 +357,7 @@ export default function Sidebar({
             if (item.key === "contacts" && pendingContactRequests > 0 && !requiresLogin) {
               badge = (
                 <span className="absolute -right-1 -top-1 flex h-4 min-w-[16px] items-center justify-center rounded-full bg-neon-cyan px-1 text-[9px] font-bold text-black shadow-[0_0_12px_rgba(34,211,238,0.45)]">
-                  {pendingContactRequests > 9 ? "9+" : pendingContactRequests}
+                  {formatBadgeCount(pendingContactRequests)}
                 </span>
               );
             }
@@ -393,7 +401,7 @@ export default function Sidebar({
             <>
               <AccountMenu
                 user={sessionStore.user}
-                pendingRequests={chatStore.overview?.pending_requests || 0}
+                pendingRequests={pendingContactRequests}
                 onLogout={handleLogout}
               />
             </>

--- a/frontend/src/store/useDashboardContactStore.ts
+++ b/frontend/src/store/useDashboardContactStore.ts
@@ -15,6 +15,7 @@ interface DashboardContactState {
   pendingFriendRequests: string[];
   contactRequestsReceived: ContactRequestItem[];
   contactRequestsSent: ContactRequestItem[];
+  contactRequestsBotApprovalCount: number;
   contactRequestsLoading: boolean;
   processingContactRequestId: number | string | null;
   processingContactRequestAction: "accept" | "reject" | null;
@@ -31,6 +32,7 @@ const initialContactState = {
   pendingFriendRequests: [],
   contactRequestsReceived: [],
   contactRequestsSent: [],
+  contactRequestsBotApprovalCount: 0,
   contactRequestsLoading: false,
   processingContactRequestId: null,
   processingContactRequestAction: null,
@@ -82,30 +84,36 @@ export const useDashboardContactStore = create<DashboardContactState>()((set, ge
       set({
         contactRequestsReceived: [],
         contactRequestsSent: [],
+        contactRequestsBotApprovalCount: 0,
         contactRequestsLoading: false,
       });
       return;
     }
     set({ contactRequestsLoading: true });
     try {
-      const [received, sent] = isHumanContactSurface()
+      const [received, sent, botApprovalCount] = isHumanContactSurface()
         ? await Promise.all([
             humansApi.listReceivedContactRequests(),
             humansApi.listSentContactRequests(),
-          ]).then(([receivedRes, sentRes]) => [
+            humansApi.listPendingApprovals(),
+          ]).then(([receivedRes, sentRes, approvalsRes]) => [
             { requests: receivedRes.requests.map(normalizeHumanContactRequest) },
             { requests: sentRes.requests.map(normalizeHumanContactRequest) },
+            approvalsRes.approvals.filter((approval) => (
+              approval.kind === "contact_request" && !approval.id.startsWith("cr_")
+            )).length,
           ] as const)
         : await Promise.all([
             api.getContactRequestsReceived(),
             api.getContactRequestsSent(),
-          ]);
+          ]).then(([receivedRes, sentRes]) => [receivedRes, sentRes, 0] as const);
       const pendingSentTargets = sent.requests
         .filter((item) => item.state === "pending")
         .map((item) => item.to_agent_id);
       set({
         contactRequestsReceived: received.requests,
         contactRequestsSent: sent.requests,
+        contactRequestsBotApprovalCount: botApprovalCount,
         pendingFriendRequests: Array.from(new Set([...get().pendingFriendRequests, ...pendingSentTargets])),
         contactRequestsLoading: false,
       });


### PR DESCRIPTION
## Summary
- hydrate queued bot contact-request approvals with requester type/name for display
- include bot approval-queue requests in Contacts tab and New Requests badge counts
- refresh contact request counts after resolving bot approvals

## Tests
- cd backend && uv run pytest tests/test_app/test_app_humans.py
- cd frontend && npm run build (compilation and TypeScript passed; prerender failed because Supabase URL/API key env vars are missing for /admin/codes)
- cd frontend && npx tsc --noEmit (fails on existing test import/type errors unrelated to this change)