### PR TITLE
fix: allow human file uploads

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -3246,6 +3246,19 @@ async def _resolve_owner_chat_agent(
     return agent_id, (agent.display_name or agent_id)
 
 
+async def _resolve_dashboard_upload_owner(
+    db: AsyncSession,
+    ctx: RequestContext,
+    requested_agent_id: str | None,
+) -> str:
+    if requested_agent_id or ctx.active_agent_id:
+        agent_id, _display_name = await _resolve_owner_chat_agent(db, ctx, requested_agent_id)
+        return agent_id
+    if not ctx.human_id:
+        raise HTTPException(status_code=404, detail="Human identity not found")
+    return ctx.human_id
+
+
 @router.get("/chat/room")
 async def get_chat_room(
     agent_id: str | None = Query(default=None),
@@ -3300,7 +3313,7 @@ async def dashboard_upload_file(
     if len(buf) == 0:
         raise HTTPException(status_code=400, detail="Empty file")
 
-    uploader_agent_id, _display_name = await _resolve_owner_chat_agent(db, ctx, agent_id)
+    uploader_id = await _resolve_dashboard_upload_owner(db, ctx, agent_id)
 
     raw_name = file.filename or "upload"
     original_filename = os.path.basename(raw_name).strip()[:200] or "upload"
@@ -3316,7 +3329,7 @@ async def dashboard_upload_file(
     )
     record = FileRecord(
         file_id=file_id,
-        uploader_id=uploader_agent_id,
+        uploader_id=uploader_id,
         original_filename=original_filename,
         content_type=content_type,
         size_bytes=len(data),

--- a/backend/doc/doc.md
+++ b/backend/doc/doc.md
@@ -1477,7 +1477,7 @@ Response 404: 文件不存在或已过期
 | 字段 | 类型 | 说明 |
 |------|------|------|
 | `file_id` | string(64) | 唯一标识，`f_` + 32 hex（128-bit 随机），有索引 |
-| `uploader_id` | string(32) | 上传者 agent_id，外键关联 agents 表 |
+| `uploader_id` | string(32) | 上传者参与者 ID，可为 `ag_*` 或 `hu_*` |
 | `original_filename` | string(256) | 原始文件名（清理后） |
 | `content_type` | string(128) | MIME 类型 |
 | `size_bytes` | integer | 文件大小（字节） |
@@ -1494,7 +1494,7 @@ Response 404: 文件不存在或已过期
 CREATE TABLE file_records (
     id SERIAL PRIMARY KEY,
     file_id VARCHAR(64) NOT NULL UNIQUE,
-    uploader_id VARCHAR(32) NOT NULL REFERENCES agents(agent_id),
+    uploader_id VARCHAR(32) NOT NULL,
     original_filename VARCHAR(256) NOT NULL,
     content_type VARCHAR(128) NOT NULL,
     size_bytes INTEGER NOT NULL,

--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -760,7 +760,7 @@ class FileRecord(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     file_id: Mapped[str] = mapped_column(String(64), unique=True, nullable=False, index=True)
     uploader_id: Mapped[str] = mapped_column(
-        String(32), ForeignKey("agents.agent_id"), nullable=False, index=True
+        String(32), nullable=False, index=True
     )
     original_filename: Mapped[str] = mapped_column(String(256), nullable=False)
     content_type: Mapped[str] = mapped_column(String(128), nullable=False)

--- a/backend/migrations/010_allow_human_file_uploads.sql
+++ b/backend/migrations/010_allow_human_file_uploads.sql
@@ -1,0 +1,2 @@
+ALTER TABLE file_records
+    DROP CONSTRAINT IF EXISTS file_records_uploader_id_fkey;

--- a/backend/tests/test_app/test_dashboard_upload.py
+++ b/backend/tests/test_app/test_dashboard_upload.py
@@ -1,0 +1,140 @@
+"""Tests for dashboard-authenticated file uploads."""
+
+import datetime
+import io
+import os
+import uuid
+from unittest.mock import AsyncMock
+
+import jwt
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from hub.models import Agent, Base, FileRecord, User
+
+TEST_SUPABASE_SECRET = "test-supabase-jwt-secret-for-unit-tests"
+
+
+def _make_token(sub: str) -> str:
+    payload = {
+        "sub": sub,
+        "aud": "authenticated",
+        "exp": datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=1),
+        "iss": "supabase",
+    }
+    return jwt.encode(payload, TEST_SUPABASE_SECRET, algorithm="HS256")
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    from tests.test_app.conftest import create_test_engine
+
+    engine = create_test_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client(db_session: AsyncSession, monkeypatch, tmp_path):
+    import app.auth
+    import hub.config
+
+    monkeypatch.setattr(app.auth, "SUPABASE_JWT_SECRET", TEST_SUPABASE_SECRET)
+    monkeypatch.setattr(hub.config, "SUPABASE_JWT_SECRET", TEST_SUPABASE_SECRET)
+    monkeypatch.setattr(hub.config, "FILE_UPLOAD_DIR", str(tmp_path / "uploads"))
+    monkeypatch.setattr(hub.config, "FILE_STORAGE_BACKEND", "disk")
+    monkeypatch.setattr(hub.config, "SUPABASE_URL", None)
+    monkeypatch.setattr(hub.config, "SUPABASE_SERVICE_ROLE_KEY", None)
+    monkeypatch.setattr(hub.config, "SUPABASE_STORAGE_BUCKET", None)
+    os.makedirs(hub.config.FILE_UPLOAD_DIR, exist_ok=True)
+
+    from hub.database import get_db
+    from hub.main import app
+
+    async def _override():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override
+    app.state.http_client = AsyncMock(spec=AsyncClient)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_dashboard_upload_without_agent_uses_human_id(
+    client: AsyncClient,
+    db_session: AsyncSession,
+):
+    supabase_uid = uuid.uuid4()
+    user = User(
+        supabase_user_id=supabase_uid,
+        display_name="Human Only",
+        email="human@example.com",
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+
+    resp = await client.post(
+        "/api/dashboard/upload",
+        headers={"Authorization": f"Bearer {_make_token(str(supabase_uid))}"},
+        files={"file": ("note.txt", io.BytesIO(b"hello"), "text/plain")},
+    )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    record = await db_session.scalar(
+        select(FileRecord).where(FileRecord.file_id == data["file_id"])
+    )
+    assert record is not None
+    assert record.uploader_id == user.human_id
+
+
+@pytest.mark.asyncio
+async def test_dashboard_upload_with_agent_query_keeps_agent_uploader(
+    client: AsyncClient,
+    db_session: AsyncSession,
+):
+    supabase_uid = uuid.uuid4()
+    user = User(
+        supabase_user_id=supabase_uid,
+        display_name="Agent Owner",
+        email="owner@example.com",
+    )
+    db_session.add(user)
+    await db_session.flush()
+    db_session.add(
+        Agent(
+            agent_id="ag_uploadowner",
+            display_name="Upload Owner",
+            user_id=user.id,
+            claimed_at=datetime.datetime.now(datetime.timezone.utc),
+        )
+    )
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/dashboard/upload?agent_id=ag_uploadowner",
+        headers={"Authorization": f"Bearer {_make_token(str(supabase_uid))}"},
+        files={"file": ("note.txt", io.BytesIO(b"hello"), "text/plain")},
+    )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    record = await db_session.scalar(
+        select(FileRecord).where(FileRecord.file_id == data["file_id"])
+    )
+    assert record is not None
+    assert record.uploader_id == "ag_uploadowner"

--- a/frontend/src/components/dashboard/ForwardModal.tsx
+++ b/frontend/src/components/dashboard/ForwardModal.tsx
@@ -87,9 +87,6 @@ export default function ForwardModal({ quoteText, sourceFile, onClose }: Forward
           activeIdentity?.type === "agent"
             ? activeIdentity.id
             : ownedAgents[0]?.agent_id;
-        if (!uploadAgentId) {
-          throw new Error("Choose or create an agent before sending files.");
-        }
         const res = await fetch(sourceFile.url, { cache: "no-store" });
         if (!res.ok) throw new Error("Failed to prepare file for sending");
         const blob = await res.blob();

--- a/frontend/src/components/dashboard/RoomHumanComposer.test.ts
+++ b/frontend/src/components/dashboard/RoomHumanComposer.test.ts
@@ -30,9 +30,18 @@ describe("uploadRoomAttachments", () => {
     expect(uploadFile).toHaveBeenCalledWith(file, "ag_owner");
   });
 
-  it("requires an owned agent for file uploads", async () => {
-    await expect(uploadRoomAttachments([{ name: "report.pdf" } as File], null)).rejects.toThrow(
-      "Choose or create an agent before sending files.",
-    );
+  it("uploads files without an agent so the backend can attribute them to the human user", async () => {
+    const file = { name: "report.pdf" } as File;
+    const uploadFile = vi.fn(async () => ({
+      file_id: "f_123",
+      url: "https://api.example.test/hub/files/f_123",
+      original_filename: "report.pdf",
+      content_type: "application/pdf",
+      size_bytes: 42,
+      expires_at: "2026-05-12T00:00:00Z",
+    }));
+
+    await expect(uploadRoomAttachments([file], null, uploadFile)).resolves.toHaveLength(1);
+    expect(uploadFile).toHaveBeenCalledWith(file, null);
   });
 });

--- a/frontend/src/components/dashboard/RoomHumanComposer.tsx
+++ b/frontend/src/components/dashboard/RoomHumanComposer.tsx
@@ -202,12 +202,9 @@ export async function uploadRoomAttachments(
   uploadFile: (file: File, agentId?: string | null) => Promise<FileUploadResult> = api.uploadFile,
 ): Promise<Attachment[]> {
   if (files.length === 0) return [];
-  if (!uploadAgentId) {
-    throw new Error("Choose or create an agent before sending files.");
-  }
   const results: Attachment[] = [];
   for (const file of files) {
-    const uploaded = await uploadFile(file, uploadAgentId);
+    const uploaded = await uploadFile(file, uploadAgentId ?? null);
     results.push({
       filename: uploaded.original_filename,
       url: uploaded.url,


### PR DESCRIPTION
## Summary
- allow dashboard uploads without an agent by attributing files to the current human id
- relax file_records.uploader_id so it can store ag_* or hu_* participant ids
- remove frontend agent-only upload guards and cover human uploads with tests

## Tests
- cd backend && uv run pytest tests/test_app/test_dashboard_upload.py
- cd backend && uv run pytest tests/test_files.py tests/test_dashboard_rooms_human_send.py::test_attachment_only_message_allowed
- cd frontend && npm test -- --run RoomHumanComposer.test.ts

## Notes
- cd frontend && npm run build compiles and passes TypeScript, then fails prerendering /admin/codes because the local Supabase URL/API key env vars are not configured.