### PR TITLE
fix: expand daemon runtime PATH

### DIFF
--- a/backend/static/daemon/install.sh
+++ b/backend/static/daemon/install.sh
@@ -208,7 +208,7 @@ DAEMON_BIN="$DAEMON_PREFIX/node_modules/.bin/botcord-daemon"
 WRAPPER="$BIN_DIR/botcord-daemon"
 {
   printf '#!/bin/sh\n'
-  printf 'PATH="%s:$PATH"\n' "$NODE_BIN_DIR"
+  printf 'PATH="%s:$HOME/.botcord/bin:$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.bun/bin:$HOME/.deno/bin:$HOME/.npm-global/bin:$HOME/.yarn/bin:$HOME/.pnpm:$HOME/.pyenv/shims:$HOME/.rye/shims:$HOME/.pixi/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/local/sbin:$PATH"\n' "$NODE_BIN_DIR"
   printf 'export PATH\n'
   printf 'exec "%s" "%s" "$@"\n' "$NODE_BIN" "$DAEMON_BIN"
 } > "$WRAPPER"

--- a/frontend/src/lib/templates/daemon-install.template.sh
+++ b/frontend/src/lib/templates/daemon-install.template.sh
@@ -204,7 +204,7 @@ DAEMON_BIN="$DAEMON_PREFIX/node_modules/.bin/botcord-daemon"
 WRAPPER="$BIN_DIR/botcord-daemon"
 {
   printf '#!/bin/sh\n'
-  printf 'PATH="%s:$PATH"\n' "$NODE_BIN_DIR"
+  printf 'PATH="%s:$HOME/.botcord/bin:$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.bun/bin:$HOME/.deno/bin:$HOME/.npm-global/bin:$HOME/.yarn/bin:$HOME/.pnpm:$HOME/.pyenv/shims:$HOME/.rye/shims:$HOME/.pixi/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/local/sbin:$PATH"\n' "$NODE_BIN_DIR"
   printf 'export PATH\n'
   printf 'exec "%s" "%s" "$@"\n' "$NODE_BIN" "$DAEMON_BIN"
 } > "$WRAPPER"

--- a/packages/daemon/src/__tests__/path-env.test.ts
+++ b/packages/daemon/src/__tests__/path-env.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import path from "node:path";
+import { commonDaemonPathEntries, mergePathEntries } from "../path-env.js";
+
+describe("path-env", () => {
+  it("adds common user CLI locations", () => {
+    expect(commonDaemonPathEntries("/Users/alice")).toEqual(
+      expect.arrayContaining([
+        "/Users/alice/.botcord/bin",
+        "/Users/alice/.local/bin",
+        "/Users/alice/.cargo/bin",
+        "/Users/alice/.bun/bin",
+        "/Users/alice/.pyenv/shims",
+      ]),
+    );
+  });
+
+  it("preserves existing PATH precedence and de-duplicates entries", () => {
+    const base = ["/usr/bin", "/bin", "/Users/alice/.local/bin"].join(path.delimiter);
+    const merged = mergePathEntries(base, [
+      "/Users/alice/.local/bin",
+      "/opt/homebrew/bin",
+      "/usr/bin",
+    ]);
+
+    expect(merged.split(path.delimiter)).toEqual([
+      "/usr/bin",
+      "/bin",
+      "/Users/alice/.local/bin",
+      "/opt/homebrew/bin",
+    ]);
+  });
+});

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -3,6 +3,7 @@ import { spawn } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync, unlinkSync, readdirSync, statSync, rmSync } from "node:fs";
 import { homedir, hostname } from "node:os";
 import path from "node:path";
+import { augmentProcessPath } from "./path-env.js";
 import {
   loadConfig,
   saveConfig,
@@ -64,6 +65,8 @@ import {
   mergeOpenclawGateways,
   openclawDiscoveryConfigEnabled,
 } from "./openclaw-discovery.js";
+
+augmentProcessPath();
 
 const ADAPTER_LIST = listAdapterIds().join("|");
 

--- a/packages/daemon/src/path-env.ts
+++ b/packages/daemon/src/path-env.ts
@@ -1,0 +1,53 @@
+import path from "node:path";
+
+const COMMON_USER_BIN_RELATIVE_PATHS = [
+  ".botcord/bin",
+  ".local/bin",
+  ".cargo/bin",
+  ".bun/bin",
+  ".deno/bin",
+  ".npm-global/bin",
+  ".yarn/bin",
+  ".pnpm",
+  ".pyenv/shims",
+  ".rye/shims",
+  ".pixi/bin",
+];
+
+const COMMON_SYSTEM_BIN_PATHS =
+  process.platform === "darwin"
+    ? ["/opt/homebrew/bin", "/opt/homebrew/sbin", "/usr/local/bin", "/usr/local/sbin"]
+    : ["/usr/local/bin", "/usr/local/sbin"];
+
+export function commonDaemonPathEntries(home = process.env.HOME): string[] {
+  const userEntries = home
+    ? COMMON_USER_BIN_RELATIVE_PATHS.map((entry) => path.join(home, entry))
+    : [];
+  return [...COMMON_SYSTEM_BIN_PATHS, ...userEntries];
+}
+
+export function mergePathEntries(basePath: string | undefined, extras: string[]): string {
+  const seen = new Set<string>();
+  const out: string[] = [];
+
+  for (const raw of [...(basePath ?? "").split(path.delimiter), ...extras]) {
+    const entry = raw.trim();
+    if (!entry || seen.has(entry)) continue;
+    seen.add(entry);
+    out.push(entry);
+  }
+
+  return out.join(path.delimiter);
+}
+
+/**
+ * GUI-launched macOS apps inherit a sparse launchd PATH and do not read the
+ * user's shell profile. Add common per-user CLI install locations so runtime
+ * adapters can find tools installed by uv/pipx, cargo, bun, npm, etc.
+ */
+export function augmentProcessPath(): void {
+  process.env.PATH = mergePathEntries(
+    process.env.PATH,
+    commonDaemonPathEntries(process.env.HOME),
+  );
+}


### PR DESCRIPTION
## Summary
- Augment daemon process PATH with common user CLI install directories for GUI-launched environments
- Update daemon install wrappers to include the same runtime lookup paths
- Add focused tests for PATH merging and common user directories

## Tests
- cd packages/daemon && npm test -- path-env.test.ts
- cd packages/daemon && npm run build
- bash -n backend/static/daemon/install.sh && sh -n backend/static/daemon/install.sh
- bash -n frontend/src/lib/templates/daemon-install.template.sh && sh -n frontend/src/lib/templates/daemon-install.template.sh