### PR TITLE
feat: show runtime chip on bot detail drawer

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -962,6 +962,7 @@ async def get_me(
                 "claimed_at": a.claimed_at.isoformat() if a.claimed_at else None,
                 "ws_online": is_agent_ws_online(a.agent_id),
                 "daemon_instance_id": a.daemon_instance_id,
+                "runtime": a.runtime,
             }
             for a in agents
         ],
@@ -996,6 +997,8 @@ async def get_my_agents(
                 "status": a.status,
                 "deleted_at": a.deleted_at.isoformat() if a.deleted_at else None,
                 "ws_online": is_agent_ws_online(a.agent_id),
+                "daemon_instance_id": a.daemon_instance_id,
+                "runtime": a.runtime,
             }
             for a in agents
         ],

--- a/backend/tests/test_app/test_app_user_agents.py
+++ b/backend/tests/test_app/test_app_user_agents.py
@@ -169,6 +169,7 @@ async def seed_user(db_session: AsyncSession):
         is_default=True,
         claimed_at=now,
         created_at=now,
+        runtime="codex",
     )
     agent2 = Agent(
         agent_id="ag_agent002",
@@ -179,6 +180,7 @@ async def seed_user(db_session: AsyncSession):
         is_default=False,
         claimed_at=now,
         created_at=now + datetime.timedelta(seconds=1),
+        runtime="claude-code",
     )
     db_session.add(agent1)
     db_session.add(agent2)
@@ -218,6 +220,7 @@ async def test_get_my_agents_hides_deleted_by_default_and_can_include_them(
     assert default_resp.status_code == 200
     default_agents = default_resp.json()["agents"]
     assert [agent["agent_id"] for agent in default_agents] == ["ag_agent001"]
+    assert default_agents[0]["runtime"] == "codex"
 
     include_resp = await client.get(
         "/api/users/me/agents?include_deleted=true",
@@ -231,6 +234,7 @@ async def test_get_my_agents_hides_deleted_by_default_and_can_include_them(
     assert set(agents_by_id) == {"ag_agent001", "ag_agent002"}
     assert agents_by_id["ag_agent002"]["status"] == "deleted"
     assert agents_by_id["ag_agent002"]["deleted_at"] == deleted_at.isoformat()
+    assert agents_by_id["ag_agent002"]["runtime"] == "claude-code"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_app/test_app_users.py
+++ b/backend/tests/test_app/test_app_users.py
@@ -113,6 +113,7 @@ async def seed_user(db_session: AsyncSession):
         user_id=user_id,
         is_default=True,
         claimed_at=datetime.datetime.now(datetime.timezone.utc),
+        runtime="codex",
     )
     db_session.add(agent)
     await db_session.commit()
@@ -142,6 +143,7 @@ async def test_get_me(client: AsyncClient, seed_user: dict):
     assert len(data["agents"]) == 1
     assert data["agents"][0]["agent_id"] == "ag_testuser001"
     assert data["agents"][0]["is_default"] is True
+    assert data["agents"][0]["runtime"] == "codex"
     assert data["max_agents"] == 30
 
 
@@ -178,6 +180,7 @@ async def test_get_my_agents(client: AsyncClient, seed_user: dict):
     assert agents[0]["bio"] == "A test agent"
     assert agents[0]["message_policy"] == "contacts_only"
     assert agents[0]["is_default"] is True
+    assert agents[0]["runtime"] == "codex"
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/dashboard/BotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/BotDetailDrawer.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "nextjs-toploader/app";
 import {
+  Bot,
   Eye,
   FileText,
   Loader2,
@@ -14,15 +15,16 @@ import {
   Wallet as WalletIcon,
   X,
 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { useShallow } from "zustand/shallow";
 import { api, userApi } from "@/lib/api";
-import type { ActivityStats, HumanAgentRoomSummary } from "@/lib/types";
+import type { ActivityStats, HumanAgentRoomSummary, UserAgent } from "@/lib/types";
 import { dmPeerId } from "@/components/dashboard/dmRoom";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import { isOwnerChatRoom } from "@/store/dashboard-shared";
-import { useDaemonStore } from "@/store/useDaemonStore";
+import { useDaemonStore, type DaemonInstance } from "@/store/useDaemonStore";
 import { useLanguage } from "@/lib/i18n";
 import { botDetailDrawer } from "@/lib/i18n/translations/dashboard";
 import {
@@ -347,9 +349,9 @@ function OverviewTab({
   onOpenChat,
 }: {
   t: BotDetailDrawerCopy;
-  bot: { agent_id: string; display_name: string; bio?: string | null };
+  bot: UserAgent;
   stats: ActivityStats | null;
-  device: { id: string; label: string | null; status: string } | null;
+  device: DaemonInstance | null;
   friends: BotFriendRoom[];
   groups: HumanAgentRoomSummary[];
   onJumpToDevice: (id: string) => void;
@@ -357,9 +359,18 @@ function OverviewTab({
   onJumpToGroup: (group: HumanAgentRoomSummary) => void;
   onOpenChat: () => void;
 }) {
+  const runtimeId = getBotRuntimeId(bot, device);
   return (
     <div className="space-y-4">
-      <ProfileEditor t={t} agentId={bot.agent_id} initialName={bot.display_name} initialBio={bot.bio ?? ""} />
+      <ProfileEditor
+        t={t}
+        agentId={bot.agent_id}
+        initialName={bot.display_name}
+        initialBio={bot.bio ?? ""}
+        runtimeLabel={t.overview.runtime}
+        runtimeId={runtimeId}
+        unknownRuntimeLabel={t.overview.unknownRuntime}
+      />
 
       {stats ? (
         <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
@@ -526,6 +537,86 @@ function OverviewTab({
   );
 }
 
+type RuntimeLogoEntry =
+  | { kind: "img"; src: string; classes: string }
+  | { kind: "icon"; Icon: LucideIcon; classes: string };
+
+const RUNTIME_LOGO: Record<string, RuntimeLogoEntry> = {
+  "claude-code": { kind: "img", src: "/runtime-logos/Claude.png", classes: "border-glass-border bg-glass-bg/40" },
+  codex: { kind: "img", src: "/runtime-logos/Codex.png", classes: "border-glass-border bg-glass-bg/40" },
+  gemini: { kind: "img", src: "/runtime-logos/Gemini.png", classes: "border-glass-border bg-glass-bg/40" },
+  "openclaw-acp": { kind: "img", src: "/runtime-logos/Openclaw.png", classes: "border-glass-border bg-glass-bg/40" },
+  qclaw: { kind: "img", src: "/runtime-logos/Qclaw.png", classes: "border-glass-border bg-glass-bg/40" },
+  "hermes-agent": { kind: "img", src: "/runtime-logos/Hermes.png", classes: "border-glass-border bg-glass-bg/40" },
+};
+
+function RuntimeLogo({ runtimeId }: { runtimeId: string | null }) {
+  const entry: RuntimeLogoEntry | null = runtimeId
+    ? RUNTIME_LOGO[runtimeId] ?? {
+        kind: "icon",
+        Icon: Bot,
+        classes: "border-glass-border bg-glass-bg/40 text-text-secondary",
+      }
+    : null;
+  if (!entry) {
+    return (
+      <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-md border border-glass-border bg-glass-bg/40 text-text-secondary">
+        <Bot className="h-3 w-3" />
+      </span>
+    );
+  }
+  if (entry.kind === "img") {
+    return (
+      <span className="relative block h-5 w-5 shrink-0 overflow-hidden rounded-md">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={entry.src} alt="" className="h-full w-full object-cover" />
+      </span>
+    );
+  }
+  return (
+    <span className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-md border ${entry.classes}`}>
+      <entry.Icon className="h-3 w-3" />
+    </span>
+  );
+}
+
+function RuntimeChip({
+  label,
+  runtimeId,
+  unknownLabel,
+}: {
+  label: string;
+  runtimeId: string | null;
+  unknownLabel: string;
+}) {
+  return (
+    <span
+      title={`${label}: ${runtimeId || unknownLabel}`}
+      className="inline-flex max-w-[180px] shrink-0 items-center gap-1.5 rounded-full border border-glass-border bg-deep-black/40 px-2 py-1"
+    >
+      <RuntimeLogo runtimeId={runtimeId} />
+      <span className="truncate font-mono text-[11px] text-text-primary">{runtimeId || unknownLabel}</span>
+    </span>
+  );
+}
+
+function getBotRuntimeId(bot: UserAgent, device: DaemonInstance | null): string | null {
+  if (bot.runtime) return bot.runtime;
+  for (const runtime of device?.runtimes ?? []) {
+    if (runtime.profiles?.some((profile) => profile.occupiedBy === bot.agent_id)) {
+      return runtime.id;
+    }
+    if (
+      runtime.endpoints?.some((endpoint) =>
+        endpoint.agents?.some((profile) => profile.botcordBinding?.agentId === bot.agent_id),
+      )
+    ) {
+      return runtime.id;
+    }
+  }
+  return null;
+}
+
 /* --------------------------- Profile --------------------------- */
 
 function ProfileEditor({
@@ -533,11 +624,17 @@ function ProfileEditor({
   agentId,
   initialName,
   initialBio,
+  runtimeLabel,
+  runtimeId,
+  unknownRuntimeLabel,
 }: {
   t: BotDetailDrawerCopy;
   agentId: string;
   initialName: string;
   initialBio: string;
+  runtimeLabel: string;
+  runtimeId: string | null;
+  unknownRuntimeLabel: string;
 }) {
   const [name, setName] = useState(initialName);
   const [bio, setBio] = useState(initialBio);
@@ -566,9 +663,12 @@ function ProfileEditor({
 
   return (
     <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
-      <div className="mb-3 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-wider text-text-secondary/70">
-        <Pencil className="h-3.5 w-3.5" />
-        {t.profile.title}
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2 text-[11px] font-semibold uppercase tracking-wider text-text-secondary/70">
+          <Pencil className="h-3.5 w-3.5" />
+          {t.profile.title}
+        </div>
+        <RuntimeChip label={runtimeLabel} runtimeId={runtimeId} unknownLabel={unknownRuntimeLabel} />
       </div>
       <label className="mb-1 block text-xs text-text-secondary/65">{t.profile.displayName}</label>
       <input

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -3480,6 +3480,8 @@ export const botDetailDrawer: TranslationMap<{
     openTopics: string
     completedTopics: string
     hostedDevice: string
+    runtime: string
+    unknownRuntime: string
     view: string
     noDevice: string
     friends: (count: number) => string
@@ -3554,6 +3556,8 @@ export const botDetailDrawer: TranslationMap<{
       openTopics: 'Open',
       completedTopics: 'Done',
       hostedDevice: 'Hosted device',
+      runtime: 'Runtime',
+      unknownRuntime: 'Unknown runtime',
       view: 'View',
       noDevice: 'No device linked',
       friends: (count) => `Friends · ${count}`,
@@ -3642,6 +3646,8 @@ export const botDetailDrawer: TranslationMap<{
       openTopics: '打开',
       completedTopics: '完成',
       hostedDevice: '托管设备',
+      runtime: '运行环境',
+      unknownRuntime: '未知运行环境',
       view: '查看',
       noDevice: '未关联任何设备',
       friends: (count) => `好友 · ${count}`,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -870,6 +870,7 @@ export interface UserAgent {
   claimed_at: string;
   ws_online: boolean;
   daemon_instance_id?: string | null;
+  runtime?: string | null;
 }
 
 // --- Activity / Observability types ---


### PR DESCRIPTION
## Summary
- Backend `/users/me` and `/users/me/agents` now include `runtime` (and `daemon_instance_id` on the agents list) so the frontend can label each bot with its hosting CLI.
- `BotDetailDrawer` profile section gets a runtime chip (logo + id) for claude-code / codex / gemini / openclaw-acp / qclaw / hermes-agent, with a daemon-side fallback that scans `device.runtimes[*].profiles/endpoints` when the agent row lacks `runtime`.
- Adds EN/ZH copy for the chip (`runtime`, `unknownRuntime`).

## Test plan
- [ ] `cd backend && uv run pytest tests/test_app/test_app_users.py tests/test_app/test_app_user_agents.py`
- [ ] `cd frontend && pnpm build`
- [ ] Manual: open a bot in the dashboard drawer and confirm the runtime chip renders with the right logo (and falls back gracefully when runtime is unknown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)