### PR TITLE
fix: use real bot avatars in request surfaces

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -663,6 +663,8 @@ def _serialize_contact_request(
     req: ContactRequest,
     from_display_name: str | None = None,
     to_display_name: str | None = None,
+    from_avatar_url: str | None = None,
+    to_avatar_url: str | None = None,
 ) -> dict:
     """Return the canonical JSON shape for a ContactRequest row."""
 
@@ -675,6 +677,8 @@ def _serialize_contact_request(
         "to_agent_id": req.to_agent_id,
         "from_type": _state(req.from_type),
         "to_type": _state(req.to_type),
+        "from_avatar_url": from_avatar_url,
+        "to_avatar_url": to_avatar_url,
         "state": _state(req.state),
         "message": req.message,
         "created_at": req.created_at.isoformat() if req.created_at else None,
@@ -818,29 +822,29 @@ async def send_contact_request(
     )
 
 
-async def _resolve_display_names(
+async def _resolve_participant_profiles(
     db: AsyncSession,
     ids_by_type: dict[ParticipantType, set[str]],
-) -> dict[tuple[ParticipantType, str], str]:
-    """Bulk-resolve display names for a mixed set of agent/human ids."""
-    out: dict[tuple[ParticipantType, str], str] = {}
+) -> dict[tuple[ParticipantType, str], tuple[str | None, str | None]]:
+    """Bulk-resolve display names and avatars for mixed agent/human ids."""
+    out: dict[tuple[ParticipantType, str], tuple[str | None, str | None]] = {}
 
     agent_ids = ids_by_type.get(ParticipantType.agent, set())
     if agent_ids:
         result = await db.execute(
-            select(Agent.agent_id, Agent.display_name).where(Agent.agent_id.in_(agent_ids))
+            select(Agent.agent_id, Agent.display_name, Agent.avatar_url).where(Agent.agent_id.in_(agent_ids))
         )
-        for agent_id, name in result.all():
-            out[(ParticipantType.agent, agent_id)] = name
+        for agent_id, name, avatar_url in result.all():
+            out[(ParticipantType.agent, agent_id)] = (name, avatar_url)
 
     human_ids = ids_by_type.get(ParticipantType.human, set())
     if human_ids:
         result = await db.execute(
-            select(User.human_id, User.display_name).where(User.human_id.in_(human_ids))
+            select(User.human_id, User.display_name, User.avatar_url).where(User.human_id.in_(human_ids))
         )
-        for human_id, name in result.all():
+        for human_id, name, avatar_url in result.all():
             if human_id is not None:
-                out[(ParticipantType.human, human_id)] = name
+                out[(ParticipantType.human, human_id)] = (name, avatar_url)
 
     return out
 
@@ -881,13 +885,14 @@ async def list_received_requests(
     }
     for cr in rows:
         ids_by_type[cr.from_type].add(cr.from_agent_id)
-    names = await _resolve_display_names(db, ids_by_type)
+    profiles = await _resolve_participant_profiles(db, ids_by_type)
 
     return {
         "requests": [
             _serialize_contact_request(
                 cr,
-                from_display_name=names.get((cr.from_type, cr.from_agent_id)),
+                from_display_name=profiles.get((cr.from_type, cr.from_agent_id), (None, None))[0],
+                from_avatar_url=profiles.get((cr.from_type, cr.from_agent_id), (None, None))[1],
                 to_display_name=None,
             )
             for cr in rows
@@ -931,14 +936,15 @@ async def list_sent_requests(
     }
     for cr in rows:
         ids_by_type[cr.to_type].add(cr.to_agent_id)
-    names = await _resolve_display_names(db, ids_by_type)
+    profiles = await _resolve_participant_profiles(db, ids_by_type)
 
     return {
         "requests": [
             _serialize_contact_request(
                 cr,
                 from_display_name=None,
-                to_display_name=names.get((cr.to_type, cr.to_agent_id)),
+                to_display_name=profiles.get((cr.to_type, cr.to_agent_id), (None, None))[0],
+                to_avatar_url=profiles.get((cr.to_type, cr.to_agent_id), (None, None))[1],
             )
             for cr in rows
         ],

--- a/backend/app/routers/humans.py
+++ b/backend/app/routers/humans.py
@@ -259,9 +259,11 @@ class HumanContactRequestSummary(BaseModel):
     from_participant_id: str
     from_type: Literal["agent", "human"]
     from_display_name: str | None
+    from_avatar_url: str | None = None
     to_participant_id: str
     to_type: Literal["agent", "human"]
     to_display_name: str | None
+    to_avatar_url: str | None = None
     state: Literal["pending", "accepted", "rejected"]
     message: str | None
     created_at: int
@@ -2077,30 +2079,30 @@ async def _resolve_participant_display_name(
     return row.scalar_one_or_none()
 
 
-async def _resolve_participant_display_names(
+async def _resolve_participant_profiles(
     db: AsyncSession,
     ids_by_type: dict[ParticipantType, set[str]],
-) -> dict[tuple[ParticipantType, str], str | None]:
-    """Batch lookup display names for mixed Agent/Human participant ids."""
-    name_lookup: dict[tuple[ParticipantType, str], str | None] = {}
+) -> dict[tuple[ParticipantType, str], tuple[str | None, str | None]]:
+    """Batch lookup display names and avatars for mixed Agent/Human participant ids."""
+    profile_lookup: dict[tuple[ParticipantType, str], tuple[str | None, str | None]] = {}
     agent_ids = ids_by_type.get(ParticipantType.agent, set())
     if agent_ids:
         rows = await db.execute(
-            select(Agent.agent_id, Agent.display_name).where(Agent.agent_id.in_(agent_ids))
+            select(Agent.agent_id, Agent.display_name, Agent.avatar_url).where(Agent.agent_id.in_(agent_ids))
         )
-        for aid, name in rows.all():
-            name_lookup[(ParticipantType.agent, aid)] = name
+        for aid, name, avatar_url in rows.all():
+            profile_lookup[(ParticipantType.agent, aid)] = (name, avatar_url)
 
     human_ids = ids_by_type.get(ParticipantType.human, set())
     if human_ids:
         rows = await db.execute(
-            select(User.human_id, User.display_name).where(User.human_id.in_(human_ids))
+            select(User.human_id, User.display_name, User.avatar_url).where(User.human_id.in_(human_ids))
         )
-        for hid, name in rows.all():
+        for hid, name, avatar_url in rows.all():
             if hid is not None:
-                name_lookup[(ParticipantType.human, hid)] = name
+                profile_lookup[(ParticipantType.human, hid)] = (name, avatar_url)
 
-    return name_lookup
+    return profile_lookup
 
 
 async def _serialise_contact_requests(
@@ -2122,25 +2124,18 @@ async def _serialise_contact_requests(
         else:
             human_ids.add(req.to_agent_id)
 
-    name_lookup: dict[tuple[ParticipantType, str], str | None] = {}
-    if agent_ids:
-        agent_rows = await db.execute(
-            select(Agent.agent_id, Agent.display_name).where(Agent.agent_id.in_(agent_ids))
-        )
-        for aid, name in agent_rows.all():
-            name_lookup[(ParticipantType.agent, aid)] = name
-    if human_ids:
-        human_rows = await db.execute(
-            select(User.human_id, User.display_name).where(User.human_id.in_(human_ids))
-        )
-        for hid, name in human_rows.all():
-            if hid is not None:
-                name_lookup[(ParticipantType.human, hid)] = name
+    profile_lookup = await _resolve_participant_profiles(
+        db,
+        {
+            ParticipantType.agent: agent_ids,
+            ParticipantType.human: human_ids,
+        },
+    )
 
     summaries: list[HumanContactRequestSummary] = []
     for req in rows:
-        from_name = name_lookup.get((req.from_type, req.from_agent_id))
-        to_name = name_lookup.get((req.to_type, req.to_agent_id))
+        from_name, from_avatar = profile_lookup.get((req.from_type, req.from_agent_id), (None, None))
+        to_name, to_avatar = profile_lookup.get((req.to_type, req.to_agent_id), (None, None))
         summaries.append(
             HumanContactRequestSummary(
                 id=str(req.id),
@@ -2149,11 +2144,13 @@ async def _serialise_contact_requests(
                 if hasattr(req.from_type, "value")
                 else str(req.from_type),
                 from_display_name=from_name,
+                from_avatar_url=from_avatar,
                 to_participant_id=req.to_agent_id,
                 to_type=req.to_type.value
                 if hasattr(req.to_type, "value")
                 else str(req.to_type),
                 to_display_name=to_name,
+                to_avatar_url=to_avatar,
                 state=req.state.value if hasattr(req.state, "value") else str(req.state),
                 message=req.message,
                 created_at=_ts(req.created_at),
@@ -2384,15 +2381,22 @@ async def list_pending_approvals(
                     queue_name_ids[from_type].add(from_pid)
         queue_payloads.append((entry, payload))
 
-    queue_name_lookup = await _resolve_participant_display_names(db, queue_name_ids)
+    queue_profile_lookup = await _resolve_participant_profiles(db, queue_name_ids)
     for entry, payload in queue_payloads:
-        if entry.kind == ApprovalKind.contact_request and not payload.get("from_display_name"):
+        if entry.kind == ApprovalKind.contact_request and (
+            not payload.get("from_display_name") or not payload.get("from_avatar_url")
+        ):
             from_pid = payload.get("from_participant_id")
             from_type_raw = payload.get("from_type")
             if isinstance(from_pid, str) and from_type_raw in {p.value for p in ParticipantType}:
-                payload["from_display_name"] = queue_name_lookup.get(
-                    (ParticipantType(from_type_raw), from_pid)
+                from_name, from_avatar = queue_profile_lookup.get(
+                    (ParticipantType(from_type_raw), from_pid),
+                    (None, None),
                 )
+                if not payload.get("from_display_name"):
+                    payload["from_display_name"] = from_name
+                if not payload.get("from_avatar_url"):
+                    payload["from_avatar_url"] = from_avatar
         approvals.append(
             PendingApprovalSummary(
                 id=str(entry.id),
@@ -2419,22 +2423,17 @@ async def list_pending_approvals(
     cr_rows = list(cr_result.scalars().all())
     if cr_rows:
         # Resolve display names once per request for the panel header.
-        name_lookup: dict[tuple[ParticipantType, str], str | None] = {}
         agent_ids = {r.from_agent_id for r in cr_rows if r.from_type == ParticipantType.agent}
         human_ids = {r.from_agent_id for r in cr_rows if r.from_type == ParticipantType.human}
-        if agent_ids:
-            rows = await db.execute(
-                select(Agent.agent_id, Agent.display_name).where(Agent.agent_id.in_(agent_ids))
-            )
-            for aid, name in rows.all():
-                name_lookup[(ParticipantType.agent, aid)] = name
-        if human_ids:
-            rows = await db.execute(
-                select(User.human_id, User.display_name).where(User.human_id.in_(human_ids))
-            )
-            for hid, name in rows.all():
-                name_lookup[(ParticipantType.human, hid)] = name
+        profile_lookup = await _resolve_participant_profiles(
+            db,
+            {
+                ParticipantType.agent: agent_ids,
+                ParticipantType.human: human_ids,
+            },
+        )
         for req in cr_rows:
+            from_name, from_avatar = profile_lookup.get((req.from_type, req.from_agent_id), (None, None))
             approvals.append(
                 PendingApprovalSummary(
                     id=f"cr_{req.id}",
@@ -2443,9 +2442,8 @@ async def list_pending_approvals(
                     payload={
                         "from_participant_id": req.from_agent_id,
                         "from_type": req.from_type.value,
-                        "from_display_name": name_lookup.get(
-                            (req.from_type, req.from_agent_id)
-                        ),
+                        "from_display_name": from_name,
+                        "from_avatar_url": from_avatar,
                         "message": req.message,
                     },
                     created_at=_ts(req.created_at),

--- a/backend/tests/test_app/test_app_dashboard_contacts_a2h.py
+++ b/backend/tests/test_app/test_app_dashboard_contacts_a2h.py
@@ -114,7 +114,8 @@ async def seed(db_session: AsyncSession):
     u1 = User(id=uid1, display_name="Alice User", email="a@x.com", status="active",
               supabase_user_id=supa1)
     u2 = User(id=uid2, display_name="Bob Human", email="b@x.com", status="active",
-              supabase_user_id=supa2, human_id="hu_boboo001")
+              supabase_user_id=supa2, human_id="hu_boboo001",
+              avatar_url="https://example.test/bob-human.png")
     u3 = User(id=uid3, display_name="Carol", email="c@x.com", status="active",
               supabase_user_id=supa3, human_id="hu_carol001")
     db_session.add_all([u1, u2, u3])
@@ -130,7 +131,8 @@ async def seed(db_session: AsyncSession):
 
     now = datetime.datetime.now(datetime.timezone.utc)
     a1 = Agent(agent_id="ag_alice001", display_name="Alice", message_policy=MessagePolicy.open,
-               user_id=uid1, is_default=True, claimed_at=now)
+               user_id=uid1, is_default=True, claimed_at=now,
+               avatar_url="/agent-avatars/4.png")
     a3 = Agent(agent_id="ag_carol001", display_name="Carol Agent",
                message_policy=MessagePolicy.open,
                user_id=uid3, is_default=True, claimed_at=now)
@@ -259,6 +261,7 @@ async def test_sent_listing_includes_human_target(client, seed):
     assert row["to_type"] == "human"
     assert row["from_type"] == "agent"
     assert row["to_display_name"] == seed["display_bob"]
+    assert row["to_avatar_url"] == "https://example.test/bob-human.png"
 
 
 @pytest.mark.asyncio
@@ -292,6 +295,7 @@ async def test_received_listing_includes_human_sender_display_name(
     assert item["from_type"] == "human"
     assert item["to_type"] == "agent"
     assert item["from_display_name"] == seed["display_bob"]
+    assert item["from_avatar_url"] == "https://example.test/bob-human.png"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_app/test_app_humans.py
+++ b/backend/tests/test_app/test_app_humans.py
@@ -106,7 +106,12 @@ async def client(db_session: AsyncSession, monkeypatch):
 async def seed(db_session: AsyncSession):
     """Create one authenticated user + a Role, and assign it."""
     supabase_uid = uuid.uuid4()
-    user = User(supabase_user_id=supabase_uid, display_name="Alice", email="alice@example.com")
+    user = User(
+        supabase_user_id=supabase_uid,
+        display_name="Alice",
+        email="alice@example.com",
+        avatar_url="https://example.test/alice-human.png",
+    )
     db_session.add(user)
     await db_session.flush()
 
@@ -1425,7 +1430,11 @@ async def test_moderator_non_owner_cannot_transfer(
 
 async def _seed_second_human(db_session: AsyncSession, display_name: str = "Bob") -> tuple[uuid.UUID, str, str]:
     supa = uuid.uuid4()
-    u = User(supabase_user_id=supa, display_name=display_name)
+    u = User(
+        supabase_user_id=supa,
+        display_name=display_name,
+        avatar_url=f"https://example.test/{display_name.lower()}-human.png",
+    )
     db_session.add(u)
     await db_session.commit()
     await db_session.refresh(u)
@@ -1462,6 +1471,8 @@ async def test_h2h_request_received_listing(
     # Display-name resolution: Alice's User row.
     assert reqs[0]["from_display_name"] == "Alice"
     assert reqs[0]["to_display_name"] == "Bob"
+    assert reqs[0]["from_avatar_url"] == "https://example.test/alice-human.png"
+    assert reqs[0]["to_avatar_url"] == "https://example.test/bob-human.png"
 
     # Alice sees the same request in sent.
     sent = await client.get(
@@ -1588,6 +1599,7 @@ async def test_h2h_request_surfaces_in_pending_approvals(
     assert entry["payload"]["from_participant_id"] == seed["human_id"]
     assert entry["payload"]["from_type"] == "human"
     assert entry["payload"]["from_display_name"] == "Alice"
+    assert entry["payload"]["from_avatar_url"] == "https://example.test/alice-human.png"
     assert entry["payload"]["message"] == "ping"
 
     # Alice cannot resolve Bob's approval.

--- a/frontend/src/components/dashboard/AgentCardModal.tsx
+++ b/frontend/src/components/dashboard/AgentCardModal.tsx
@@ -65,7 +65,7 @@ export default function AgentCardModal({
         <div className="mb-3 flex items-start justify-between gap-3">
           <div className="flex min-w-0 items-start gap-3">
             {agent ? (
-              <BotAvatar agentId={agent.agent_id} size={44} alt={agent.display_name} />
+              <BotAvatar agentId={agent.agent_id} avatarUrl={agent.avatar_url} size={44} alt={agent.display_name} />
             ) : null}
             <div className="min-w-0">
               <div className="flex items-center gap-2">

--- a/frontend/src/components/dashboard/ContactRequestsInbox.tsx
+++ b/frontend/src/components/dashboard/ContactRequestsInbox.tsx
@@ -39,6 +39,7 @@ interface Props {
 interface BotApprovalGroup {
   agentId: string;
   displayName: string;
+  avatarUrl: string | null;
   approvals: PendingApproval[];
 }
 
@@ -112,6 +113,10 @@ export default function ContactRequestsInbox({
     () => new Map(ownedAgents.map((agent) => [agent.agent_id, agent.display_name])),
     [ownedAgents],
   );
+  const agentAvatarById = useMemo(
+    () => new Map(ownedAgents.map((agent) => [agent.agent_id, agent.avatar_url ?? null])),
+    [ownedAgents],
+  );
   const botApprovalGroups = useMemo<BotApprovalGroup[]>(() => {
     const grouped = new Map<string, PendingApproval[]>();
     for (const approval of botApprovals) {
@@ -123,10 +128,11 @@ export default function ContactRequestsInbox({
       .map(([agentId, approvals]) => ({
         agentId,
         displayName: agentNameById.get(agentId) || agentId,
+        avatarUrl: agentAvatarById.get(agentId) ?? null,
         approvals,
       }))
       .sort((a, b) => a.displayName.localeCompare(b.displayName));
-  }, [agentNameById, botApprovals]);
+  }, [agentAvatarById, agentNameById, botApprovals]);
   const receivedCount = pendingReceived.length + botApprovals.length;
   const receivedLoading = contactRequestsLoading || botApprovalsLoading;
 
@@ -228,7 +234,7 @@ export default function ContactRequestsInbox({
                             }
                             className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-glass-bg/50"
                           >
-                            <BotAvatar agentId={group.agentId} alt={group.displayName} size={36} />
+                            <BotAvatar agentId={group.agentId} avatarUrl={group.avatarUrl} alt={group.displayName} size={36} />
                             <div className="min-w-0 flex-1">
                               <p className="truncate text-sm font-semibold text-text-primary">
                                 {group.displayName}
@@ -329,7 +335,7 @@ function ReceivedRequestCard({
             {initial || "?"}
           </div>
         ) : (
-          <BotAvatar agentId={req.from_agent_id} alt={req.from_display_name ?? undefined} size={40} />
+          <BotAvatar agentId={req.from_agent_id} avatarUrl={req.from_avatar_url} alt={req.from_display_name ?? undefined} size={40} />
         )}
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
@@ -386,6 +392,7 @@ function BotApprovalCard({
   const fromId = payloadString(approval.payload, "from_participant_id") || "unknown";
   const fromName = payloadString(approval.payload, "from_display_name") || fromId;
   const message = payloadString(approval.payload, "message");
+  const fromAvatarUrl = payloadString(approval.payload, "from_avatar_url");
   const isHuman = payloadString(approval.payload, "from_type") === "human" || isHumanId(fromId);
   const initial = fromName.trim().charAt(0).toUpperCase();
   const processing = isApproving || isRejecting;
@@ -398,7 +405,7 @@ function BotApprovalCard({
             {initial || "?"}
           </div>
         ) : (
-          <BotAvatar agentId={fromId} alt={fromName} size={40} />
+          <BotAvatar agentId={fromId} avatarUrl={fromAvatarUrl} alt={fromName} size={40} />
         )}
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
@@ -469,7 +476,7 @@ function SentRequestCard({
             {toInitial || "?"}
           </div>
         ) : (
-          <BotAvatar agentId={req.to_agent_id} alt={req.to_display_name ?? undefined} size={40} />
+          <BotAvatar agentId={req.to_agent_id} avatarUrl={req.to_avatar_url} alt={req.to_display_name ?? undefined} size={40} />
         )}
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -100,6 +100,8 @@ export interface ContactRequestItem {
   id: number | string;
   from_agent_id: string;
   to_agent_id: string;
+  from_avatar_url?: string | null;
+  to_avatar_url?: string | null;
   state: "pending" | "accepted" | "rejected";
   message: string | null;
   created_at: string;
@@ -1083,9 +1085,11 @@ export interface HumanContactRequestSummary {
   from_participant_id: string;
   from_type: ParticipantType;
   from_display_name: string | null;
+  from_avatar_url?: string | null;
   to_participant_id: string;
   to_type: ParticipantType;
   to_display_name: string | null;
+  to_avatar_url?: string | null;
   state: "pending" | "accepted" | "rejected";
   message: string | null;
   created_at: number;

--- a/frontend/src/store/useDashboardContactStore.ts
+++ b/frontend/src/store/useDashboardContactStore.ts
@@ -64,6 +64,8 @@ function normalizeHumanContactRequest(item: HumanContactRequestSummary): Contact
     resolved_at: null,
     from_display_name: item.from_display_name,
     to_display_name: item.to_display_name,
+    from_avatar_url: item.from_avatar_url,
+    to_avatar_url: item.to_avatar_url,
   };
 }
 


### PR DESCRIPTION
## Summary
- pass real agent avatar URLs into the shared Agent card modal so Home cards and modal avatars match
- include participant avatar URLs in dashboard/human contact-request responses and pending approval payloads
- render contact-request bot avatars from the returned avatar URLs, with deterministic fallback unchanged

## Tests
- cd backend && uv run pytest tests/test_app/test_app_humans.py tests/test_app/test_app_dashboard_contacts_a2h.py tests/test_contact_requests.py

## Notes
- frontend npm run build was attempted but local build failed while fetching Google Fonts (Inter and JetBrains Mono), unrelated to this change