### PR TITLE
fix: clear observed room unread state

### DIFF
--- a/frontend/src/components/dashboard/MessageList.tsx
+++ b/frontend/src/components/dashboard/MessageList.tsx
@@ -17,6 +17,7 @@ import type { DashboardMessage, PublicRoomMember, TopicInfo } from "@/lib/types"
 import type { MentionTextCandidate } from "@/components/ui/MarkdownContent";
 import { getLatestSeenAtForRoom } from "@/store/dashboard-shared";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
+import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import { useDashboardUnreadStore } from "@/store/useDashboardUnreadStore";
 import { usePresenceStore } from "@/store/usePresenceStore";
@@ -399,10 +400,6 @@ export default function MessageList() {
   }, [roomId, roomMemberVersion, loadRoomMembers]);
 
   const commitRoomSeen = useCallback((targetRoomId: string) => {
-    const joinedRoom = overview?.rooms.find((room) => room.room_id === targetRoomId);
-    if (!joinedRoom) {
-      return;
-    }
     void markRoomSeen(
       targetRoomId,
       getLatestSeenAtForRoom(targetRoomId, {
@@ -411,9 +408,11 @@ export default function MessageList() {
         publicRoomDetails: useDashboardChatStore.getState().publicRoomDetails,
         publicRooms: useDashboardChatStore.getState().publicRooms,
         recentVisitedRooms: useDashboardChatStore.getState().recentVisitedRooms,
+        ownedAgentRooms: useDashboardChatStore.getState().ownedAgentRooms,
+        humanRooms: useDashboardSessionStore.getState().humanRooms,
       }),
     );
-  }, [markRoomSeen, overview]);
+  }, [markRoomSeen]);
 
   useEffect(() => {
     setOpenedTopicId(null);

--- a/frontend/src/store/dashboard-shared.ts
+++ b/frontend/src/store/dashboard-shared.ts
@@ -9,6 +9,7 @@ import type {
   DashboardMessage,
   DashboardOverview,
   DashboardRoom,
+  HumanAgentRoomSummary,
   HumanRoomSummary,
   ParticipantType,
   PublicRoom,
@@ -152,6 +153,8 @@ export function getLatestSeenAtForRoom(
     publicRoomDetails: Record<string, PublicRoom>;
     publicRooms: PublicRoom[];
     recentVisitedRooms: PublicRoom[];
+    ownedAgentRooms?: HumanAgentRoomSummary[];
+    humanRooms?: HumanRoomSummary[];
   },
 ): string | null {
   const latestMessage = data.messages[roomId]?.[data.messages[roomId].length - 1];
@@ -164,5 +167,11 @@ export function getLatestSeenAtForRoom(
   if (publicRoom?.last_message_at) return publicRoom.last_message_at;
 
   const recentRoom = data.recentVisitedRooms.find((room) => room.room_id === roomId);
-  return recentRoom?.last_message_at ?? null;
+  if (recentRoom?.last_message_at) return recentRoom.last_message_at;
+
+  const ownedAgentRoom = data.ownedAgentRooms?.find((room) => room.room_id === roomId);
+  if (ownedAgentRoom?.last_message_at) return ownedAgentRoom.last_message_at;
+
+  const humanRoom = data.humanRooms?.find((room) => room.room_id === roomId);
+  return humanRoom?.last_message_at ?? null;
 }


### PR DESCRIPTION
## Summary
- clear unread state for opened message rooms even when they are observed bot-owned rooms outside overview.rooms
- include owned-agent and human room summaries when deriving the latest seen timestamp

## Verification
- git diff --check -- frontend/src/components/dashboard/MessageList.tsx frontend/src/store/dashboard-shared.ts
- npm run build (compiled and TypeScript passed; static generation stopped at /admin/codes because local Supabase URL/API key env vars are missing)
- npx tsc --noEmit (blocked by existing root tests with missing route/module references and stale types)