### PR TITLE
fix: clarify daemon group background actions

### DIFF
--- a/packages/daemon/package-lock.json
+++ b/packages/daemon/package-lock.json
@@ -640,6 +640,18 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -657,14 +669,15 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -724,6 +737,23 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -994,6 +1024,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/lightningcss": {
@@ -1321,6 +1364,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
@@ -1444,10 +1493,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/qs": {
       "version": "6.15.1",

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -32,6 +32,9 @@
     "@larksuiteoapi/node-sdk": "^1.63.1",
     "ws": "^8.18.0"
   },
+  "overrides": {
+    "axios": "^1.15.2"
+  },
   "devDependencies": {
     "@types/node": "^20.0.0",
     "@types/ws": "^8.5.0",

--- a/packages/daemon/src/__tests__/loop-risk.test.ts
+++ b/packages/daemon/src/__tests__/loop-risk.test.ts
@@ -22,7 +22,13 @@ describe("stripBotCordPromptScaffolding", () => {
       "hello world",
       "</agent-message>",
       "",
-      '[In group chats, do NOT reply unless you are explicitly mentioned or addressed. If no response is needed, reply with exactly "NO_REPLY" and nothing else.]',
+      "[In group chats, do not send a message back to the current group room unless you are explicitly mentioned, addressed, or the room policy says you should participate.",
+      "",
+      "This group-reply restriction only controls whether you post back into the current group. It does not prevent you from performing owner-approved or policy-approved background actions, including analyzing the message, updating memory, calling tools, starting a task, forwarding a summary, or notifying the owner.",
+      "",
+      "When a message matches an active monitoring rule, automation goal, working-memory task, keyword, sender rule, or owner-approved workflow, perform the required action even if you do not reply to the group.",
+      "",
+      'If no group reply and no background action is needed, reply exactly "NO_REPLY".]',
     ].join("\n");
     expect(stripBotCordPromptScaffolding(wrapped)).toBe("hello world");
   });

--- a/packages/daemon/src/__tests__/turn-text.test.ts
+++ b/packages/daemon/src/__tests__/turn-text.test.ts
@@ -34,7 +34,9 @@ describe("composeBotCordUserTurn", () => {
     expect(out).toContain('<agent-message sender="ag_alice" sender_kind="agent">');
     expect(out).toContain("hey everyone");
     expect(out).toContain("</agent-message>");
-    expect(out).toContain('do NOT reply unless you are explicitly mentioned');
+    expect(out).toContain("do not send a message back to the current group room");
+    expect(out).toContain("owner-approved or policy-approved background actions");
+    expect(out).toContain("active monitoring rule");
     expect(out).toContain('"NO_REPLY"');
   });
 
@@ -247,7 +249,8 @@ describe("composeBotCordUserTurn", () => {
     // Single-message header must NOT appear in batch mode.
     expect(out).not.toContain("[BotCord Message]");
     // Group hint still appears after the blocks.
-    expect(out).toContain("do NOT reply unless");
+    expect(out).toContain("do not send a message back to the current group room");
+    expect(out).toContain("no background action is needed");
   });
 
   it("batched path tags dashboard_human_room senders as human-message", () => {

--- a/packages/daemon/src/loop-risk.ts
+++ b/packages/daemon/src/loop-risk.ts
@@ -83,9 +83,16 @@ export function stripBotCordPromptScaffolding(text: string): string {
       if (line.startsWith("[BotCord Message]")) return false;
       if (line.startsWith("[BotCord Notification]")) return false;
       if (line.startsWith("[Room Rule]")) return false;
-      if (line.startsWith("[In group chats, do NOT reply")) return false;
+      if (line.startsWith("[In group chats,")) return false;
+      if (line.startsWith("This group-reply restriction")) return false;
+      if (line.startsWith("including analyzing the message")) return false;
+      if (line.startsWith("forwarding a summary")) return false;
+      if (line.startsWith("When a message matches an active monitoring rule")) return false;
+      if (line.startsWith("keyword, sender rule")) return false;
+      if (line.startsWith("you do not reply to the group")) return false;
       if (line.startsWith("[If the conversation has naturally concluded")) return false;
       if (line.startsWith("[You received a contact request")) return false;
+      if (line.includes("no background action is needed")) return false;
       if (line.includes('reply with exactly "NO_REPLY"')) return false;
       if (line.startsWith("<agent-message")) return false;
       if (line === "</agent-message>") return false;

--- a/packages/daemon/src/turn-text.ts
+++ b/packages/daemon/src/turn-text.ts
@@ -15,9 +15,11 @@
  *   hello
  *   </agent-message>
  *
- *   [In group chats, do NOT reply unless you are explicitly mentioned or
- *    addressed. If no response is needed, reply with exactly "NO_REPLY"
- *    and nothing else.]
+ *   [In group chats, do not send a message back to the current group room
+ *    unless you are explicitly mentioned, addressed, or the room policy says
+ *    you should participate. This group-reply restriction only controls
+ *    whether you post back into the current group. It does not prevent
+ *    owner-approved or policy-approved background actions...]
  *
  * Owner-chat messages bypass the wrapper entirely — they are trusted and
  * the owner-chat scene prompt in `system-context.ts` already gives the
@@ -28,8 +30,16 @@ import { sanitizeSenderName, sanitizeUntrustedContent } from "./gateway/index.js
 import { classifyActivitySender } from "./sender-classify.js";
 
 const GROUP_HINT =
-  '[In group chats, do NOT reply unless you are explicitly mentioned or addressed. ' +
-  'If no response is needed, reply with exactly "NO_REPLY" and nothing else.]';
+  "[In group chats, do not send a message back to the current group room " +
+  "unless you are explicitly mentioned, addressed, or the room policy says you should participate.\n\n" +
+  "This group-reply restriction only controls whether you post back into the current group. " +
+  "It does not prevent you from performing owner-approved or policy-approved background actions, " +
+  "including analyzing the message, updating memory, calling tools, starting a task, " +
+  "forwarding a summary, or notifying the owner.\n\n" +
+  "When a message matches an active monitoring rule, automation goal, working-memory task, " +
+  "keyword, sender rule, or owner-approved workflow, perform the required action even if " +
+  "you do not reply to the group.\n\n" +
+  'If no group reply and no background action is needed, reply exactly "NO_REPLY".]';
 const DIRECT_HINT =
   '[If the conversation has naturally concluded or no response is needed, ' +
   'reply with exactly "NO_REPLY" and nothing else.]';


### PR DESCRIPTION
## Summary
- Clarify daemon group-chat prompting so no group reply does not block owner-approved background actions
- Keep loop-risk prompt stripping aligned with the new group hint
- Override daemon axios transitive dependency to a patched version and clear npm audit findings

## Verification
- cd packages/daemon && npm test -- --run src/__tests__/turn-text.test.ts src/__tests__/loop-risk.test.ts
- cd packages/daemon && npm run build
- cd packages/daemon && npm audit