### PR TITLE
feat: support pasted image attachments

### DIFF
--- a/frontend/src/components/dashboard/MessageComposer.test.ts
+++ b/frontend/src/components/dashboard/MessageComposer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isImeComposing, textHasMention } from "./MessageComposer";
+import { getClipboardFiles, isImeComposing, textHasMention } from "./MessageComposer";
 
 describe("textHasMention", () => {
   it("keeps structured @Name(agentId) mentions active", () => {
@@ -26,5 +26,29 @@ describe("isImeComposing", () => {
 
   it("returns false for regular key events outside composition", () => {
     expect(isImeComposing({ isComposing: false, keyCode: 13 }, false)).toBe(false);
+  });
+});
+
+describe("getClipboardFiles", () => {
+  it("uses clipboard files when the browser exposes them directly", () => {
+    const image = { name: "screenshot.png", type: "image/png" } as File;
+    const text = { name: "notes.txt", type: "text/plain" } as File;
+
+    expect(getClipboardFiles({
+      files: [image, text] as unknown as FileList,
+      items: [] as unknown as DataTransferItemList,
+    })).toEqual([image, text]);
+  });
+
+  it("falls back to file items for pasted screenshots", () => {
+    const image = { name: "image.png", type: "image/png" } as File;
+
+    expect(getClipboardFiles({
+      files: [] as unknown as FileList,
+      items: [
+        { kind: "string", getAsFile: () => null },
+        { kind: "file", getAsFile: () => image },
+      ] as unknown as DataTransferItemList,
+    })).toEqual([image]);
   });
 });

--- a/frontend/src/components/dashboard/MessageComposer.tsx
+++ b/frontend/src/components/dashboard/MessageComposer.tsx
@@ -81,6 +81,20 @@ export function isImeComposing(
   return compositionActive || event.isComposing || event.keyCode === 229;
 }
 
+export function getClipboardFiles(
+  clipboardData: Pick<DataTransfer, "files" | "items"> | null | undefined,
+): File[] {
+  if (!clipboardData) return [];
+
+  const files = Array.from(clipboardData.files || []);
+  if (files.length > 0) return files;
+
+  return Array.from(clipboardData.items || [])
+    .filter((item) => item.kind === "file")
+    .map((item) => item.getAsFile())
+    .filter((file): file is File => Boolean(file));
+}
+
 export default function MessageComposer({
   onSend,
   onTransfer,
@@ -185,7 +199,7 @@ export default function MessageComposer({
     setMentionMatch(detectMention(el.value, cursor));
   }, [mentionEnabled]);
 
-  const addFiles = useCallback((list: FileList | null) => {
+  const addFiles = useCallback((list: FileList | File[] | null) => {
     if (!list || list.length === 0 || !allowAttachments) return;
     setFiles((prev) => {
       const remaining = maxFiles - prev.length;
@@ -345,10 +359,14 @@ export default function MessageComposer({
   }, [wouldExceedMaxLength]);
 
   const handlePaste = useCallback((e: ClipboardEvent<HTMLTextAreaElement>) => {
+    const pastedFiles = getClipboardFiles(e.clipboardData);
+    if (pastedFiles.length > 0) {
+      addFiles(pastedFiles);
+    }
     if (wouldExceedMaxLength(e.clipboardData.getData("text"))) {
       setShowLengthError(true);
     }
-  }, [wouldExceedMaxLength]);
+  }, [addFiles, wouldExceedMaxLength]);
 
   const hasLengthError = text.length > MESSAGE_MAX_LENGTH || showLengthError;
   const canSend = !disabled && !hasLengthError && (text.trim().length > 0 || files.length > 0);


### PR DESCRIPTION
## Summary
- support screenshot/image files pasted into the message composer
- reuse the existing attachment preview and upload flow
- add unit coverage for clipboard file extraction

## Tests
- pnpm test -- MessageComposer.test.ts
- NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=anon-test-key pnpm build