### PR TITLE
fix: keep owner chat visible for new bots

### DIFF
--- a/frontend/src/components/dashboard/MessageList.tsx
+++ b/frontend/src/components/dashboard/MessageList.tsx
@@ -348,6 +348,7 @@ export default function MessageList() {
   const [showNewMessagesBanner, setShowNewMessagesBanner] = useState(false);
   const showBannerRef = useRef(false);
   const wasNearBottomRef = useRef(true);
+  const initialScrollDoneRef = useRef(false);
 
   const roomMemberVersion = useDashboardChatStore(
     (state) => roomId ? (state.roomMemberVersions[roomId] ?? 0) : 0,
@@ -418,6 +419,7 @@ export default function MessageList() {
     setOpenedTopicId(null);
     prevLengthRef.current = 0;
     wasNearBottomRef.current = true;
+    initialScrollDoneRef.current = false;
     setShowNewMessagesBanner(false);
   }, [roomId, setOpenedTopicId]);
 
@@ -451,13 +453,33 @@ export default function MessageList() {
 
   const timelineItems = useMemo(() => buildTimelineItems(messages, topicsMap), [messages, topicsMap]);
 
+  const scrollToBottom = useCallback(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "auto" });
+    setShowNewMessagesBanner(false);
+    if (roomId) {
+      commitRoomSeen(roomId);
+    }
+  }, [roomId, commitRoomSeen]);
+
+  const scrollToBottomAfterLayout = useCallback(() => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(scrollToBottom);
+    });
+  }, [scrollToBottom]);
+
+  useEffect(() => {
+    if (!roomId || isRoomMessagesLoading || messages.length === 0 || initialScrollDoneRef.current) return;
+    initialScrollDoneRef.current = true;
+    scrollToBottomAfterLayout();
+  }, [roomId, isRoomMessagesLoading, messages.length, scrollToBottomAfterLayout]);
+
   // Auto-scroll or show "new messages" banner when new messages arrive.
   // Uses wasNearBottomRef (snapshotted on scroll events, before DOM changes)
   // to decide whether to auto-scroll or show the banner.
   useEffect(() => {
     if (messages.length > prevLengthRef.current && !isLoadingMore.current) {
       if (wasNearBottomRef.current) {
-        bottomRef.current?.scrollIntoView({ behavior: "auto" });
+        scrollToBottomAfterLayout();
         setShowNewMessagesBanner(false);
         if (roomId) {
           commitRoomSeen(roomId);
@@ -469,7 +491,7 @@ export default function MessageList() {
     }
     prevLengthRef.current = messages.length;
     isLoadingMore.current = false;
-  }, [messages.length, roomId, commitRoomSeen]);
+  }, [messages.length, roomId, commitRoomSeen, scrollToBottomAfterLayout]);
 
   // Keep ref in sync with state for use in scroll handler
   useEffect(() => {
@@ -502,15 +524,6 @@ export default function MessageList() {
   useEffect(() => {
     setShowNewMessagesBanner(false);
   }, [roomId]);
-
-  const scrollToBottom = useCallback(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "auto" });
-    setShowNewMessagesBanner(false);
-    if (roomId) {
-      commitRoomSeen(roomId);
-    }
-  }, [roomId, commitRoomSeen]);
-
 
   if (!roomId) return null;
 

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -106,6 +106,17 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
   const wasNearBottomRef = useRef(true);
   const [, forceRender] = useState(0);
 
+  const scrollToBottom = useCallback(() => {
+    const el = scrollContainerRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, []);
+
+  const scrollToBottomAfterLayout = useCallback(() => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(scrollToBottom);
+    });
+  }, [scrollToBottom]);
+
   // WS hook authenticates the selected owner-chat target explicitly.
   const { wsClientRef, streamedTraceIds } = useOwnerChatWs({
     activeAgentId: chatAgentId,
@@ -143,6 +154,7 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
           animatedRef.current.add(msg.clientId);
         }
         initialLoadRef.current = false;
+        scrollToBottomAfterLayout();
       } catch (err: any) {
         if (cancelled) return;
         setInitError(err?.message || "Failed to initialize chat");
@@ -158,19 +170,11 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
   // ------ Scroll to bottom once initial messages render ------
   useEffect(() => {
     if (!loading && messages.length > 0 && prevLengthRef.current === 0) {
-      requestAnimationFrame(() => {
-        const el = scrollContainerRef.current;
-        if (el) el.scrollTop = el.scrollHeight;
-      });
+      scrollToBottomAfterLayout();
     }
-  }, [loading, messages]);
+  }, [loading, messages.length, scrollToBottomAfterLayout]);
 
   // ------ Scroll helpers ------
-
-  const scrollToBottom = useCallback(() => {
-    const el = scrollContainerRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
-  }, []);
 
   useEffect(() => {
     if (messages.length > prevLengthRef.current && !isLoadingMore.current) {

--- a/frontend/src/store/useDashboardChatStore.test.ts
+++ b/frontend/src/store/useDashboardChatStore.test.ts
@@ -112,6 +112,7 @@ describe("useDashboardChatStore message polling", () => {
     useDashboardSessionStore.setState({
       token: "token",
       activeIdentity: { type: "human", id: "hu_1" },
+      ownedAgents: [],
     });
   });
 
@@ -224,6 +225,32 @@ describe("useDashboardChatStore message polling", () => {
     const state = useDashboardChatStore.getState();
     expect(state.optimisticOwnerChatRooms).toEqual({});
     expect(state.ownedAgentRooms.map((room) => room.room_id)).toEqual(["rm_oc_real_123"]);
+  });
+
+  it("keeps an owner-chat row for a new owned bot when the backend has no room yet", async () => {
+    useDashboardSessionStore.setState({
+      ownedAgents: [{
+        agent_id: "ag_barry",
+        display_name: "Barry",
+        is_default: false,
+        claimed_at: "2026-05-18T00:00:00.000Z",
+        ws_online: false,
+      }],
+    });
+    mocks.listAgentRooms.mockResolvedValue({ rooms: [] });
+
+    await useDashboardChatStore.getState().loadOwnedAgentRooms();
+
+    expect(useDashboardChatStore.getState().ownedAgentRooms).toEqual([
+      expect.objectContaining({
+        room_id: "rm_oc_pending_ag_barry",
+        name: "Barry",
+        owner_id: "ag_barry",
+        created_at: "2026-05-18T00:00:00.000Z",
+        last_message_at: null,
+        bots: [{ agent_id: "ag_barry", display_name: "Barry", role: "owner" }],
+      }),
+    ]);
   });
 
   it("does not wipe an existing owner-chat preview when reopening the same bot chat", () => {

--- a/frontend/src/store/useDashboardChatStore.ts
+++ b/frontend/src/store/useDashboardChatStore.ts
@@ -97,11 +97,12 @@ function ownerChatAgentId(room: HumanAgentRoomSummary): string | null {
 }
 
 function buildOptimisticOwnerChatRoom(
-  agent: Pick<UserAgent, "agent_id" | "display_name">,
+  agent: Pick<UserAgent, "agent_id" | "display_name"> & Partial<Pick<UserAgent, "claimed_at">>,
   roomId?: string | null,
   existing?: HumanAgentRoomSummary,
 ): HumanAgentRoomSummary {
   const now = new Date().toISOString();
+  const createdAt = existing?.created_at ?? agent.claimed_at ?? now;
   return {
     ...existing,
     room_id: roomId || ownerChatRoomIdForOptimistic(agent.agent_id),
@@ -112,10 +113,10 @@ function buildOptimisticOwnerChatRoom(
     visibility: existing?.visibility || "private",
     join_policy: existing?.join_policy || "invite_only",
     member_count: existing?.member_count ?? 1,
-    created_at: existing?.created_at ?? now,
+    created_at: createdAt,
     required_subscription_product_id: existing?.required_subscription_product_id ?? null,
     last_message_preview: existing?.last_message_preview ?? null,
-    last_message_at: existing?.last_message_at ?? now,
+    last_message_at: existing?.last_message_at ?? null,
     last_sender_name: existing?.last_sender_name ?? null,
     allow_human_send: existing?.allow_human_send ?? true,
     members_preview: existing?.members_preview ?? null,
@@ -125,6 +126,25 @@ function buildOptimisticOwnerChatRoom(
       role: "owner",
     }],
   };
+}
+
+function ensureOwnerChatRoomsForOwnedAgents(
+  rooms: HumanAgentRoomSummary[],
+  agents: UserAgent[],
+): HumanAgentRoomSummary[] {
+  if (agents.length === 0) return rooms;
+
+  const roomAgentIds = new Set(
+    rooms
+      .map(ownerChatAgentId)
+      .filter((agentId): agentId is string => Boolean(agentId)),
+  );
+  const fallbackRooms = agents
+    .filter((agent) => !roomAgentIds.has(agent.agent_id))
+    .map((agent) => buildOptimisticOwnerChatRoom(agent));
+
+  if (fallbackRooms.length === 0) return rooms;
+  return [...rooms, ...fallbackRooms].sort(compareRoomsByActivityDesc);
 }
 
 function mergeOptimisticOwnerChatRooms(
@@ -802,7 +822,7 @@ export const useDashboardChatStore = create<DashboardChatState>()(
       },
 
       loadOwnedAgentRooms: async () => {
-        const { token, activeIdentity } = useDashboardSessionStore.getState();
+        const { token, activeIdentity, ownedAgents } = useDashboardSessionStore.getState();
         if (!token || activeIdentity?.type !== "human") {
           set({ ownedAgentRooms: [], ownedAgentRoomsLoading: false, ownedAgentRoomsLoaded: true });
           return;
@@ -815,13 +835,20 @@ export const useDashboardChatStore = create<DashboardChatState>()(
             get().optimisticOwnerChatRooms,
           );
           set({
-            ownedAgentRooms: mergeOptimisticOwnerChatRooms(result.rooms, optimisticOwnerChatRooms),
+            ownedAgentRooms: ensureOwnerChatRoomsForOwnedAgents(
+              mergeOptimisticOwnerChatRooms(result.rooms, optimisticOwnerChatRooms),
+              ownedAgents,
+            ),
             optimisticOwnerChatRooms,
             ownedAgentRoomsLoading: false,
             ownedAgentRoomsLoaded: true,
           });
         } catch (error) {
           set({
+            ownedAgentRooms: ensureOwnerChatRoomsForOwnedAgents(
+              get().ownedAgentRooms,
+              ownedAgents,
+            ),
             ownedAgentRoomsLoading: false,
             ownedAgentRoomsLoaded: true,
           });


### PR DESCRIPTION
## Summary
- keep owner-chat rows visible for newly created owned bots even before backend returns a real room
- wait for message DOM layout before initial scroll-to-bottom in room and owner-chat panes
- add coverage for the new-owned-bot fallback row

## Tests
- pnpm test -- --run src/store/useDashboardChatStore.test.ts src/lib/messages-merge.test.ts
- pnpm build (using local frontend/.env for Supabase build-time config)