### PR TITLE
fix: preview image attachments

### DIFF
--- a/frontend/src/components/ui/AttachmentItem.test.ts
+++ b/frontend/src/components/ui/AttachmentItem.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { isImageAttachment, resolveAttachmentUrl } from "./AttachmentItem";
+
+describe("AttachmentItem helpers", () => {
+  it("resolves hub-relative attachment URLs", () => {
+    expect(resolveAttachmentUrl("/hub/files/f_123")).toBe("https://api.botcord.chat/hub/files/f_123");
+  });
+
+  it("detects image attachments by MIME type or filename extension", () => {
+    expect(isImageAttachment({
+      filename: "screenshot.bin",
+      url: "/hub/files/f_123",
+      content_type: "image/png",
+    })).toBe(true);
+
+    expect(isImageAttachment({
+      filename: "diagram.webp",
+      url: "/hub/files/f_456",
+    })).toBe(true);
+
+    expect(isImageAttachment({
+      filename: "report.pdf",
+      url: "/hub/files/f_789",
+    })).toBe(false);
+  });
+});

--- a/frontend/src/components/ui/AttachmentItem.tsx
+++ b/frontend/src/components/ui/AttachmentItem.tsx
@@ -2,38 +2,59 @@
 
 import type { Attachment } from "@/lib/types";
 
+const HUB_BASE_URL =
+  process.env.NEXT_PUBLIC_HUB_BASE_URL ||
+  (process.env.NODE_ENV === "development" ? "http://localhost:8000" : "https://api.botcord.chat");
+
 function formatFileSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-function isImageType(contentType?: string): boolean {
-  return !!contentType && contentType.startsWith("image/");
+export function resolveAttachmentUrl(url: string): string {
+  if (!url.startsWith("/")) return url;
+
+  try {
+    return new URL(url, HUB_BASE_URL).toString();
+  } catch {
+    return url;
+  }
+}
+
+export function isImageAttachment(attachment: Attachment): boolean {
+  if (attachment.content_type?.startsWith("image/")) return true;
+
+  const name = attachment.filename || attachment.url.split("?")[0] || "";
+  return /\.(avif|bmp|gif|jpe?g|png|svg|webp)$/i.test(name);
 }
 
 export default function AttachmentItem({ attachment }: { attachment: Attachment }) {
-  if (isImageType(attachment.content_type)) {
+  const attachmentUrl = resolveAttachmentUrl(attachment.url);
+
+  if (isImageAttachment(attachment)) {
     return (
       <a
-        href={attachment.url}
+        href={attachmentUrl}
         target="_blank"
         rel="noopener noreferrer"
         className="block"
       >
         <img
-          src={attachment.url}
-          alt={attachment.filename}
+          src={attachmentUrl}
+          alt={attachment.filename || "Image attachment"}
           className="max-h-48 max-w-full rounded-lg border border-glass-border object-cover hover:opacity-80 transition-opacity"
         />
-        <span className="mt-0.5 block text-[10px] text-text-secondary/60">{attachment.filename}</span>
+        {attachment.filename && (
+          <span className="mt-0.5 block text-[10px] text-text-secondary/60">{attachment.filename}</span>
+        )}
       </a>
     );
   }
 
   return (
     <a
-      href={attachment.url}
+      href={attachmentUrl}
       target="_blank"
       rel="noopener noreferrer"
       className="flex items-center gap-2 rounded-lg border border-glass-border bg-glass-bg/50 px-2.5 py-1.5 text-xs text-text-primary hover:border-neon-cyan/30 transition-colors"
@@ -51,7 +72,7 @@ export default function AttachmentItem({ attachment }: { attachment: Attachment 
           d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
         />
       </svg>
-      <span className="truncate">{attachment.filename}</span>
+      <span className="truncate">{attachment.filename || "Attachment"}</span>
       {attachment.size_bytes != null && (
         <span className="shrink-0 text-text-secondary/50">{formatFileSize(attachment.size_bytes)}</span>
       )}


### PR DESCRIPTION
## Summary
- preview image attachments in shared attachment rendering
- resolve Hub-relative attachment URLs before rendering links/images
- detect image attachments by MIME type or common image filename extensions

## Tests
- npm run test -- AttachmentItem.test.ts
- npm run build (fails during prerender of /admin/codes because local Supabase URL/API key are not configured; compile step completed successfully)