### PR TITLE
fix: expose schedule timing to daemon turns

### DIFF
--- a/backend/hub/services/agent_schedules.py
+++ b/backend/hub/services/agent_schedules.py
@@ -249,6 +249,8 @@ async def dispatch_schedule_run(
         "trigger": "botcord.proactive",
         "message": schedule.payload_json.get("message", DEFAULT_PROACTIVE_MESSAGE),
         "schedule_id": schedule.id,
+        "scheduled_for": aware(scheduled_for).isoformat(),
+        "dispatched_at": aware(run.started_at).isoformat() if run.started_at else now_utc().isoformat(),
         "run_id": run.id,
         "dedupe_key": run.dedupe_key,
     }

--- a/backend/tests/test_app/test_agent_schedules.py
+++ b/backend/tests/test_app/test_agent_schedules.py
@@ -165,7 +165,10 @@ async def test_manual_run_records_failed_ack(
 ):
     import hub.routers.openclaw_control as openclaw_control
 
-    async def fake_send_host_control_frame(*_args, **_kwargs):
+    captured: dict = {}
+
+    async def fake_send_host_control_frame(host_id, frame_type, params, **_kwargs):
+        captured.update({"host_id": host_id, "frame_type": frame_type, "params": params})
         return {
             "id": "frame_1",
             "ok": False,
@@ -199,3 +202,12 @@ async def test_manual_run_records_failed_ack(
     body = run_resp.json()
     assert body["status"] == "failed"
     assert body["error"] == "agent_not_loaded: not loaded"
+    assert captured["host_id"] == "oc_test"
+    assert captured["frame_type"] == "wake_agent"
+    params = captured["params"]
+    assert params["schedule_id"] == schedule_id
+    assert params["run_id"] == body["id"]
+    assert params["scheduled_for"]
+    assert params["dispatched_at"]
+    datetime.datetime.fromisoformat(params["scheduled_for"])
+    datetime.datetime.fromisoformat(params["dispatched_at"])

--- a/packages/daemon/src/__tests__/provision.test.ts
+++ b/packages/daemon/src/__tests__/provision.test.ts
@@ -265,6 +265,8 @@ describe("wake_agent handler", () => {
         message: "【BotCord 自主任务】执行本轮工作目标。",
         run_id: "sr_test",
         schedule_id: "sch_test",
+        scheduled_for: "2026-05-19T01:30:00+00:00",
+        dispatched_at: "2026-05-19T01:30:02+00:00",
         dedupe_key: "sch_test:1:auto",
       },
     });
@@ -279,6 +281,14 @@ describe("wake_agent handler", () => {
     expect(msg.sender.kind).toBe("system");
     expect(msg.text).toContain("BotCord 自主任务");
     expect(msg.conversation.threadId).toBe("sch_test");
+    expect(msg.raw).toMatchObject({
+      source_type: "botcord_schedule",
+      schedule_id: "sch_test",
+      scheduled_for: "2026-05-19T01:30:00+00:00",
+      dispatched_at: "2026-05-19T01:30:02+00:00",
+      run_id: "sr_test",
+      dedupe_key: "sch_test:1:auto",
+    });
   });
 
   it("rejects wake_agent for an unloaded agent", async () => {

--- a/packages/daemon/src/__tests__/turn-text.test.ts
+++ b/packages/daemon/src/__tests__/turn-text.test.ts
@@ -97,6 +97,31 @@ describe("composeBotCordUserTurn", () => {
     expect(out).not.toContain("do NOT reply unless");
   });
 
+  it("renders schedule timing metadata for proactive schedule turns", () => {
+    const out = composeBotCordUserTurn(
+      makeMessage({
+        conversation: { id: "rm_schedule_ag_me", kind: "direct", title: "BotCord Scheduler", threadId: "sch_daily" },
+        sender: { id: "hub", name: "BotCord Scheduler", kind: "system" },
+        text: "daily brief",
+        mentioned: true,
+        raw: {
+          source_type: "botcord_schedule",
+          schedule_id: "sch_daily",
+          scheduled_for: "2026-05-19T01:30:00+00:00",
+          dispatched_at: "2026-05-19T01:30:02+00:00",
+          run_id: "sr_daily",
+        },
+      }),
+    );
+    expect(out).toContain("[BotCord Schedule]");
+    expect(out).toContain("This turn was triggered by a proactive schedule.");
+    expect(out).toContain("schedule_id: sch_daily");
+    expect(out).toContain("scheduled_for: 2026-05-19T01:30:00+00:00");
+    expect(out).toContain("dispatched_at: 2026-05-19T01:30:02+00:00");
+    expect(out).toContain("run_id: sr_daily");
+    expect(out.indexOf("[BotCord Schedule]")).toBeLessThan(out.indexOf("<agent-message"));
+  });
+
   it("keeps the botcord_send delivery hint for non-owner BotCord rooms", () => {
     const out = composeBotCordUserTurn(
       makeMessage({

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -467,6 +467,10 @@ interface WakeAgentParams {
   runId?: string;
   schedule_id?: string;
   scheduleId?: string;
+  scheduled_for?: string;
+  scheduledFor?: string;
+  dispatched_at?: string;
+  dispatchedAt?: string;
   dedupe_key?: string;
   dedupeKey?: string;
 }
@@ -504,6 +508,8 @@ async function handleWakeAgent(gateway: Gateway, raw: unknown): Promise<AckBody>
 
   const runId = params.run_id || params.runId || `wake-${Date.now()}`;
   const scheduleId = params.schedule_id || params.scheduleId;
+  const scheduledFor = params.scheduled_for || params.scheduledFor;
+  const dispatchedAt = params.dispatched_at || params.dispatchedAt;
   const dedupeKey = params.dedupe_key || params.dedupeKey;
   const conversationId = `rm_schedule_${agentId}`;
   const msg: GatewayInboundMessage = {
@@ -525,6 +531,8 @@ async function handleWakeAgent(gateway: Gateway, raw: unknown): Promise<AckBody>
     raw: {
       source_type: "botcord_schedule",
       schedule_id: scheduleId,
+      scheduled_for: scheduledFor,
+      dispatched_at: dispatchedAt,
       run_id: runId,
       dedupe_key: dedupeKey,
     },

--- a/packages/daemon/src/turn-text.ts
+++ b/packages/daemon/src/turn-text.ts
@@ -120,6 +120,41 @@ interface RoomContextRaw {
   my_can_send?: unknown;
 }
 
+interface ScheduleRaw {
+  source_type?: unknown;
+  schedule_id?: unknown;
+  scheduled_for?: unknown;
+  dispatched_at?: unknown;
+  run_id?: unknown;
+}
+
+function formatScheduleContext(raw: unknown): string[] {
+  const r = raw && typeof raw === "object" ? (raw as ScheduleRaw) : {};
+  if (r.source_type !== "botcord_schedule") return [];
+
+  const fields: string[] = [];
+  if (typeof r.schedule_id === "string" && r.schedule_id) {
+    fields.push(`schedule_id: ${sanitizeSenderName(r.schedule_id)}`);
+  }
+  if (typeof r.scheduled_for === "string" && r.scheduled_for) {
+    fields.push(`scheduled_for: ${sanitizeSenderName(r.scheduled_for)}`);
+  }
+  if (typeof r.dispatched_at === "string" && r.dispatched_at) {
+    fields.push(`dispatched_at: ${sanitizeSenderName(r.dispatched_at)}`);
+  }
+  if (typeof r.run_id === "string" && r.run_id) {
+    fields.push(`run_id: ${sanitizeSenderName(r.run_id)}`);
+  }
+
+  return fields.length > 0
+    ? [
+        "[BotCord Schedule]",
+        "This turn was triggered by a proactive schedule.",
+        fields.join(" | "),
+      ]
+    : ["[BotCord Schedule]", "This turn was triggered by a proactive schedule."];
+}
+
 /**
  * Read the `raw.batch` array emitted by the BotCord channel when inbox
  * drain groups multiple messages for the same `(room, topic)`. Returns the
@@ -256,6 +291,7 @@ export function composeBotCordUserTurn(msg: GatewayInboundMessage): string {
 
   const lines: string[] = [
     headerFields.join(" | "),
+    ...formatScheduleContext(msg.raw),
     ...(isGroup ? formatRoomContext(msg.raw, { id: conversation.id, title: roomTitle }) : []),
     `<${tag} sender="${sanitizedSenderLabel}" sender_kind="${senderKindAttr}">`,
     trimmed,


### PR DESCRIPTION
## Summary
- include scheduled_for and dispatched_at in schedule wake_agent control params
- preserve schedule timing metadata in daemon raw inbound messages
- render schedule timing in the model-visible BotCord schedule prompt block

## Tests
- cd packages/daemon && npm test -- --run src/__tests__/provision.test.ts src/__tests__/turn-text.test.ts
- cd packages/daemon && npm run build
- cd backend && uv run pytest tests/test_app/test_agent_schedules.py