### PR TITLE
fix: use configured avatars for device bots

### DIFF
--- a/frontend/src/components/dashboard/DeviceDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/DeviceDetailDrawer.tsx
@@ -224,7 +224,12 @@ export default function DeviceDetailDrawer() {
                 onClick={() => setViewingBotId(bot.agent_id)}
                 className="flex items-center gap-2.5 rounded-lg border border-glass-border bg-glass-bg/60 px-2 py-1.5 text-left transition-colors hover:border-neon-cyan/40 hover:bg-neon-cyan/5"
               >
-                <BotAvatar agentId={bot.agent_id} size={28} alt={bot.display_name} />
+                <BotAvatar
+                  agentId={bot.agent_id}
+                  avatarUrl={bot.avatar_url}
+                  size={28}
+                  alt={bot.display_name}
+                />
                 <span className="flex-1 truncate text-sm text-text-primary">{bot.display_name}</span>
                 {bot.is_default ? (
                   <span className="rounded-full border border-neon-purple/30 bg-neon-purple/10 px-1.5 py-px text-[9px] text-neon-purple">

--- a/frontend/src/components/dashboard/MyDevicesView.tsx
+++ b/frontend/src/components/dashboard/MyDevicesView.tsx
@@ -104,7 +104,12 @@ export default function MyDevicesView() {
                           key={bot.agent_id}
                           className="flex items-center gap-2 rounded-full border border-glass-border bg-glass-bg/60 py-1 pl-1 pr-3 transition-colors hover:border-neon-cyan/30"
                         >
-                          <BotAvatar agentId={bot.agent_id} size={24} alt={bot.display_name} />
+                          <BotAvatar
+                            agentId={bot.agent_id}
+                            avatarUrl={bot.avatar_url}
+                            size={24}
+                            alt={bot.display_name}
+                          />
                           <span className="text-xs text-text-primary">{bot.display_name}</span>
                           {bot.is_default ? (
                             <span className="rounded-full border border-neon-purple/30 bg-neon-purple/10 px-1.5 py-px text-[9px] text-neon-purple">


### PR DESCRIPTION
## Summary
- pass each owned bot's configured avatar_url into device list bot avatars
- apply the same avatar_url handling in the device detail drawer hosted-bot list

## Tests
- NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build