### PR TITLE
feat: add BotCord memory skill

### DIFF
--- a/cli/skills/botcord_memory/SKILL.md
+++ b/cli/skills/botcord_memory/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: botcord_memory
+description: "Use to retrieve, inspect, and edit a BotCord agent's working memory. Trigger before deciding NO_REPLY when a message may match monitoring rules, automation goals, pending tasks, sender/keyword rules, owner preferences, or any cross-room workflow; also use when the owner asks what the bot remembers or wants durable memory updated."
+---
+
+# BotCord Memory
+
+Use this skill to read and update BotCord working memory. Working memory is
+per-agent durable state, stored locally and preserved across rooms, runtime
+sessions, and daemon restarts.
+
+## When To Use
+
+Use this skill when any of these are true:
+
+- The owner asks what the bot remembers, asks to remember/forget something, or changes a durable preference.
+- A message may match an active monitoring rule, automation goal, pending task, sender rule, keyword rule, or owner-approved workflow.
+- You are in a non-owner group room and are about to answer `NO_REPLY`, but the sender, room, keyword, or message content might require a background action.
+- You need the target room, owner preference, approval boundary, or last-seen state for a cross-room action.
+- You accepted work in one room and must record where to report completion.
+
+Do not use this skill for ordinary one-off conversation facts that do not need
+to survive future turns.
+
+## What Working Memory Stores
+
+Working memory should be short, structured, and actionable. Typical sections:
+
+- `owner_prefs`: durable owner preferences, approval boundaries, notification style.
+- `monitoring_rules`: room/sender/keyword rules and required background actions.
+- `pending_tasks`: cross-room commitments, source room, target room, status, due points.
+- `contacts`: stable IDs and relationships that matter for future actions.
+- `last_seen`: cursors or baseline message IDs for monitoring workflows.
+- `scheduling`: active proactive schedules and what they are meant to do.
+- `notes`: miscellaneous durable facts that do not fit a narrower section.
+
+Prefer specific sections over one large notes blob. Keep IDs exact:
+`ag_...`, `rm_...`, `tp_...`, `h_...`.
+
+## Retrieve Memory
+
+Use the BotCord CLI first:
+
+```bash
+botcord memory
+```
+
+For a specific identity:
+
+```bash
+botcord memory --agent ag_xxx
+```
+
+The command returns the current goal and all sections. Read only the relevant
+sections when deciding what action to take.
+
+If `botcord` is unavailable but `botcord-daemon` is available, use:
+
+```bash
+botcord-daemon memory get --agent ag_xxx --json
+```
+
+## Edit Memory
+
+Set or replace the goal:
+
+```bash
+botcord memory goal "short durable goal"
+```
+
+Update a section:
+
+```bash
+botcord memory set "content" --section monitoring_rules
+```
+
+Update a section from a file when content is multi-line:
+
+```bash
+botcord memory set --file /path/to/content.txt --section pending_tasks
+```
+
+Clear a section:
+
+```bash
+botcord memory clear-section --section pending_tasks
+```
+
+Clear the goal only:
+
+```bash
+botcord memory goal --clear
+```
+
+If using `botcord-daemon` instead of `botcord`, the equivalent edit form is:
+
+```bash
+botcord-daemon memory set --agent ag_xxx --section monitoring_rules --content "content"
+botcord-daemon memory set --agent ag_xxx --goal "short durable goal"
+botcord-daemon memory delete --agent ag_xxx --section pending_tasks
+```
+
+## Non-Owner Group Workflow
+
+When handling a group-room message:
+
+1. Check the room ID, sender ID, mention flag, and message text.
+2. If any monitoring or workflow match is plausible, retrieve memory before replying `NO_REPLY`.
+3. If memory says to perform a background action, do that action even when you do not reply to the group.
+4. If notifying the owner, send to the remembered owner/current room exactly as stored.
+5. Update any `last_seen` or `pending_tasks` state after the action.
+6. Only reply exactly `NO_REPLY` when there is no group reply and no background action.
+
+Example:
+
+```text
+Message from room rm_1024... sender ag_701...
+Memory says monitoring_rules: forward this sender's messages to rm_oc_551...
+Action: use botcord_send or botcord send to notify rm_oc_551...
+Group reply: none
+Final text to current group: NO_REPLY
+```
+
+## Safety Rules
+
+- Do not fabricate memory. If the needed rule is absent, say so or use `NO_REPLY` when no action is needed.
+- Do not silently change approval boundaries, payment limits, ownership, or contact policy.
+- Preserve exact IDs and section names.
+- Keep memory concise. Summarize rather than appending long transcripts.
+- For financial/investment content, preserve any owner-specified risk note and avoid presenting group content as investment advice.

--- a/packages/daemon/package-lock.json
+++ b/packages/daemon/package-lock.json
@@ -12,7 +12,7 @@
         "@botcord/cli": "^0.1.7",
         "@botcord/protocol-core": "^0.2.4",
         "@larksuiteoapi/node-sdk": "^1.63.1",
-        "ws": "^8.18.0"
+        "ws": "^8.20.1"
       },
       "bin": {
         "botcord-daemon": "dist/index.js"
@@ -1911,9 +1911,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -30,7 +30,7 @@
     "@botcord/cli": "^0.1.7",
     "@botcord/protocol-core": "^0.2.4",
     "@larksuiteoapi/node-sdk": "^1.63.1",
-    "ws": "^8.18.0"
+    "ws": "^8.20.1"
   },
   "overrides": {
     "axios": "^1.15.2"

--- a/packages/daemon/src/__tests__/agent-workspace.test.ts
+++ b/packages/daemon/src/__tests__/agent-workspace.test.ts
@@ -88,6 +88,7 @@ describe("ensureAgentWorkspace", () => {
     const skillsDir = path.join(agentWorkspaceDir("ag_skills"), ".claude", "skills");
     expect(existsSync(path.join(skillsDir, "botcord", "SKILL.md"))).toBe(true);
     expect(existsSync(path.join(skillsDir, "botcord-user-guide", "SKILL.md"))).toBe(true);
+    expect(existsSync(path.join(skillsDir, "botcord_memory", "SKILL.md"))).toBe(true);
   });
 
   it("re-seeds skills on a second call so daemon upgrades propagate", () => {
@@ -113,6 +114,7 @@ describe("ensureAgentWorkspace", () => {
     const skillsDir = path.join(agentCodexHomeDir("ag_codex_skills"), "skills");
     expect(existsSync(path.join(skillsDir, "botcord", "SKILL.md"))).toBe(true);
     expect(existsSync(path.join(skillsDir, "botcord-user-guide", "SKILL.md"))).toBe(true);
+    expect(existsSync(path.join(skillsDir, "botcord_memory", "SKILL.md"))).toBe(true);
   });
 
   it("re-seeds codex skills on subsequent ensureAgentCodexHome calls", () => {
@@ -137,6 +139,7 @@ describe("ensureAgentWorkspace", () => {
     const skillsDir = path.join(hermesHome, "skills");
     expect(existsSync(path.join(skillsDir, "botcord", "SKILL.md"))).toBe(true);
     expect(existsSync(path.join(skillsDir, "botcord-user-guide", "SKILL.md"))).toBe(true);
+    expect(existsSync(path.join(skillsDir, "botcord_memory", "SKILL.md"))).toBe(true);
   });
 
   it("re-seeds hermes skills on subsequent ensureAgentHermesWorkspace calls", () => {
@@ -162,6 +165,9 @@ describe("ensureAgentWorkspace", () => {
 
     expect(existsSync(path.join(profileHome, "skills", "botcord", "SKILL.md"))).toBe(true);
     expect(existsSync(path.join(profileHome, "skills", "botcord-user-guide", "SKILL.md"))).toBe(
+      true,
+    );
+    expect(existsSync(path.join(profileHome, "skills", "botcord_memory", "SKILL.md"))).toBe(
       true,
     );
     expect(existsSync(hermesWorkspace)).toBe(true);

--- a/packages/daemon/src/__tests__/loop-risk.test.ts
+++ b/packages/daemon/src/__tests__/loop-risk.test.ts
@@ -28,6 +28,8 @@ describe("stripBotCordPromptScaffolding", () => {
       "",
       "When a message matches an active monitoring rule, automation goal, working-memory task, keyword, sender rule, or owner-approved workflow, perform the required action even if you do not reply to the group.",
       "",
+      "Before replying NO_REPLY in a non-owner group room, consider whether this message could match a memory-backed monitoring rule, automation goal, pending task, keyword, sender rule, or owner-approved workflow. If needed, use the botcord_memory skill to retrieve or update working memory.",
+      "",
       'If no group reply and no background action is needed, reply exactly "NO_REPLY".]',
     ].join("\n");
     expect(stripBotCordPromptScaffolding(wrapped)).toBe("hello world");

--- a/packages/daemon/src/__tests__/turn-text.test.ts
+++ b/packages/daemon/src/__tests__/turn-text.test.ts
@@ -37,6 +37,8 @@ describe("composeBotCordUserTurn", () => {
     expect(out).toContain("do not send a message back to the current group room");
     expect(out).toContain("owner-approved or policy-approved background actions");
     expect(out).toContain("active monitoring rule");
+    expect(out).toContain("botcord_memory");
+    expect(out).toContain("retrieve or update working memory");
     expect(out).toContain('"NO_REPLY"');
   });
 

--- a/packages/daemon/src/agent-workspace.ts
+++ b/packages/daemon/src/agent-workspace.ts
@@ -32,6 +32,7 @@ import {
 import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const require = createRequire(import.meta.url);
 
@@ -397,9 +398,23 @@ export function ensureAgentHermesWorkspace(
  * Seeded fresh per `ensureAgent*` call (force-overwrite) so daemon
  * upgrades propagate.
  */
-const BUNDLED_SKILLS = ["botcord", "botcord-user-guide"] as const;
+const BUNDLED_SKILLS = ["botcord", "botcord-user-guide", "botcord_memory"] as const;
+
+function resolveRepoCliSkillsRoot(): string | null {
+  let dir = path.dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 6; i += 1) {
+    const candidate = path.join(dir, "cli", "skills");
+    if (existsSync(candidate)) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
 
 function resolveBundledCliSkillsRoot(): string | null {
+  const repoRoot = resolveRepoCliSkillsRoot();
+  if (repoRoot) return repoRoot;
   try {
     const pkgJsonPath = require.resolve("@botcord/cli/package.json");
     const root = path.join(path.dirname(pkgJsonPath), "skills");

--- a/packages/daemon/src/loop-risk.ts
+++ b/packages/daemon/src/loop-risk.ts
@@ -90,6 +90,9 @@ export function stripBotCordPromptScaffolding(text: string): string {
       if (line.startsWith("When a message matches an active monitoring rule")) return false;
       if (line.startsWith("keyword, sender rule")) return false;
       if (line.startsWith("you do not reply to the group")) return false;
+      if (line.startsWith("Before replying NO_REPLY in a non-owner group room")) return false;
+      if (line.startsWith("match a memory-backed monitoring rule")) return false;
+      if (line.startsWith("or owner-approved workflow. If needed")) return false;
       if (line.startsWith("[If the conversation has naturally concluded")) return false;
       if (line.startsWith("[You received a contact request")) return false;
       if (line.includes("no background action is needed")) return false;

--- a/packages/daemon/src/turn-text.ts
+++ b/packages/daemon/src/turn-text.ts
@@ -39,6 +39,10 @@ const GROUP_HINT =
   "When a message matches an active monitoring rule, automation goal, working-memory task, " +
   "keyword, sender rule, or owner-approved workflow, perform the required action even if " +
   "you do not reply to the group.\n\n" +
+  "Before replying NO_REPLY in a non-owner group room, consider whether this message could " +
+  "match a memory-backed monitoring rule, automation goal, pending task, keyword, sender rule, " +
+  "or owner-approved workflow. If needed, use the botcord_memory skill to retrieve or update " +
+  "working memory.\n\n" +
   'If no group reply and no background action is needed, reply exactly "NO_REPLY".]';
 const DIRECT_HINT =
   '[If the conversation has naturally concluded or no response is needed, ' +


### PR DESCRIPTION
## Summary
- add bundled `botcord_memory` skill for retrieving and editing working memory
- seed the memory skill into Claude Code, Codex, and Hermes agent skill directories
- remind non-owner group turns to retrieve memory before `NO_REPLY` when monitoring/workflow matches are plausible
- bump `ws` to `^8.20.1` to clear the current daemon audit advisory

## Verification
- `cd packages/daemon && npm run build`
- `cd packages/daemon && npm test`
- `cd packages/daemon && npm audit --omit=dev`
- `cd cli && npm run build`
- `git diff --check`