### PR TITLE
feat: add third-party gateway send

### DIFF
--- a/backend/hub/routers/daemon_control.py
+++ b/backend/hub/routers/daemon_control.py
@@ -843,6 +843,7 @@ _ALLOWED_DISPATCH_TYPES = {
     # per-room override endpoints (the latter ship in PR2). Daemon handler
     # invalidates `policyResolver` cache for the (agent, room?) pair.
     "policy_updated",
+    "gateway_send",
 }
 
 

--- a/backend/hub/routers/hub.py
+++ b/backend/hub/routers/hub.py
@@ -15,6 +15,7 @@ from cachetools import TTLCache
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, WebSocket, WebSocketDisconnect
 from hub.i18n import I18nHTTPException
+from pydantic import BaseModel, Field
 from sqlalchemy import func, select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -36,6 +37,7 @@ from hub.id_generators import generate_hub_msg_id, generate_topic_id
 from hub.models import (
     Agent,
     AgentApprovalQueue,
+    AgentGatewayConnection,
     Block,
     Contact,
     ContactRequest,
@@ -52,6 +54,7 @@ from hub.models import (
     Topic,
     User,
 )
+from hub.routers.daemon_control import is_daemon_online, send_control_frame
 from hub.enums import ApprovalKind, ApprovalState, ParticipantType
 from hub.policy import Principal, check_direct_admission
 from hub.prompt_guard import scan_content, InjectionRisk
@@ -104,6 +107,23 @@ _inbox_conditions: dict[str, asyncio.Condition] = {}
 # In-memory WebSocket connections: agent_id → set of WebSocket
 # ---------------------------------------------------------------------------
 _ws_connections: dict[str, set[WebSocket]] = {}
+
+
+class GatewaySendRequest(BaseModel):
+    conversation_id: str = Field(..., alias="conversationId", min_length=1, max_length=256)
+    text: str = Field(..., min_length=1, max_length=20000)
+    idempotency_key: str | None = Field(
+        default=None,
+        alias="idempotencyKey",
+        max_length=160,
+    )
+
+
+class GatewaySendResponse(BaseModel):
+    ok: bool
+    gateway_id: str
+    conversation_id: str
+    provider_message_id: str | None = None
 
 
 def _ws_connection_counts(agent_id: str | None = None) -> dict[str, int]:
@@ -518,6 +538,86 @@ def _check_rate_limit(agent_id: str, target_id: str | None = None) -> None:
                 limit=PAIR_RATE_LIMIT_PER_MINUTE,
             )
         pair_window.append(now)
+
+
+def _gateway_chat_id(provider: str, conversation_id: str) -> str | None:
+    prefixes = {
+        "telegram": ("telegram:user:", "telegram:group:"),
+        "feishu": ("feishu:user:", "feishu:chat:"),
+    }.get(provider)
+    if not prefixes:
+        return None
+    for prefix in prefixes:
+        if conversation_id.startswith(prefix):
+            return conversation_id[len(prefix):]
+    return None
+
+
+def _conversation_allowed(provider: str, config: dict[str, Any], conversation_id: str) -> bool:
+    chat_id = _gateway_chat_id(provider, conversation_id)
+    if not chat_id:
+        return False
+    allowed = config.get("allowedChatIds")
+    return isinstance(allowed, list) and chat_id in {str(v) for v in allowed}
+
+
+@router.post("/gateways/{gateway_id}/send", response_model=GatewaySendResponse)
+async def send_gateway_message(
+    gateway_id: str,
+    body: GatewaySendRequest,
+    current_agent: str = Depends(get_current_claimed_agent),
+    db: AsyncSession = Depends(get_db),
+) -> GatewaySendResponse:
+    """Send a proactive outbound message through a third-party gateway."""
+    _check_rate_limit(current_agent, gateway_id)
+    result = await db.execute(
+        select(AgentGatewayConnection).where(
+            AgentGatewayConnection.id == gateway_id,
+            AgentGatewayConnection.agent_id == current_agent,
+        )
+    )
+    row = result.scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail="gateway_not_found")
+    if not row.enabled or row.status == "disabled":
+        raise HTTPException(status_code=409, detail="gateway_disabled")
+    if row.provider == "wechat":
+        raise HTTPException(status_code=400, detail="gateway_provider_unsupported")
+    if row.provider not in ("telegram", "feishu"):
+        raise HTTPException(status_code=400, detail="gateway_provider_unsupported")
+
+    config = dict(row.config_json or {})
+    if not _conversation_allowed(row.provider, config, body.conversation_id):
+        raise HTTPException(status_code=403, detail="gateway_conversation_not_allowed")
+    if not is_daemon_online(row.daemon_instance_id):
+        raise HTTPException(status_code=409, detail="daemon_offline")
+
+    params: dict[str, Any] = {
+        "agentId": current_agent,
+        "gatewayId": row.id,
+        "conversationId": body.conversation_id,
+        "text": body.text,
+    }
+    if body.idempotency_key:
+        params["idempotencyKey"] = body.idempotency_key
+
+    ack = await send_control_frame(
+        row.daemon_instance_id,
+        "gateway_send",
+        params,
+        timeout_ms=30000,
+    )
+    if not isinstance(ack, dict) or ack.get("ok") is not True:
+        detail = ack.get("error") if isinstance(ack, dict) else "daemon_gateway_send_failed"
+        raise HTTPException(status_code=502, detail=detail)
+    ack_result = ack.get("result") if isinstance(ack.get("result"), dict) else {}
+    provider_message_id = ack_result.get("providerMessageId")
+    return GatewaySendResponse(
+        ok=True,
+        gateway_id=row.id,
+        conversation_id=body.conversation_id,
+        provider_message_id=provider_message_id if isinstance(provider_message_id, str) else None,
+    )
 
 
 async def _verify_envelope(envelope: MessageEnvelope, db: AsyncSession) -> None:

--- a/backend/tests/test_app/test_app_gateways.py
+++ b/backend/tests/test_app/test_app_gateways.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from sqlalchemy.pool import StaticPool
 from unittest.mock import AsyncMock
 
+from hub.auth import create_agent_token
 from hub.enums import MessagePolicy
 from hub.models import (
     Agent,
@@ -180,6 +181,45 @@ def _patch_daemon(monkeypatch, *, online: bool, send=None):
         monkeypatch.setattr(gw, "send_control_frame", send)
 
 
+def _patch_hub_gateway_send(monkeypatch, *, online: bool, send=None):
+    """Stub the /hub/gateways/{id}/send daemon hooks."""
+    import hub.routers.hub as hub_router
+
+    monkeypatch.setattr(hub_router, "is_daemon_online", lambda _id: online)
+    if send is not None:
+        monkeypatch.setattr(hub_router, "send_control_frame", send)
+
+
+async def _insert_gateway(
+    db_session: AsyncSession,
+    *,
+    gateway_id: str = "gw_tg_send",
+    user_id: uuid.UUID | None = None,
+    provider: str = "telegram",
+    agent_id: str = "ag_daemon",
+    daemon_id: str = "dm_abcdef123456",
+    enabled: bool = True,
+    status: str = "active",
+    config: dict | None = None,
+) -> AgentGatewayConnection:
+    row = AgentGatewayConnection(
+        id=gateway_id,
+        user_id=user_id or uuid.UUID("00000000-0000-0000-0000-000000000001"),
+        agent_id=agent_id,
+        daemon_instance_id=daemon_id,
+        provider=provider,
+        status=status,
+        enabled=enabled,
+        config_json=config or {
+            "allowedChatIds": ["-1001"],
+            "allowedSenderIds": ["42"],
+        },
+    )
+    db_session.add(row)
+    await db_session.commit()
+    return row
+
+
 # ---------------------------------------------------------------------------
 # Auth / ownership / shape gates
 # ---------------------------------------------------------------------------
@@ -224,6 +264,80 @@ async def test_create_returns_409_when_daemon_offline(client, seed, monkeypatch)
     )
     assert r.status_code == 409
     assert r.json()["detail"] == "daemon_offline"
+
+
+@pytest.mark.asyncio
+async def test_agent_gateway_send_dispatches_to_daemon(client, seed, db_session, monkeypatch):
+    token, _ = create_agent_token("ag_daemon")
+    await _insert_gateway(db_session, user_id=seed["user_id"])
+    calls: list[dict] = []
+
+    async def fake_send(daemon_instance_id, type_, params=None, timeout_ms=None):
+        calls.append(
+            {
+                "daemon_instance_id": daemon_instance_id,
+                "type": type_,
+                "params": params,
+                "timeout_ms": timeout_ms,
+            }
+        )
+        return {
+            "ok": True,
+            "result": {"providerMessageId": "telegram:-1001:10"},
+        }
+
+    _patch_hub_gateway_send(monkeypatch, online=True, send=fake_send)
+    r = await client.post(
+        "/hub/gateways/gw_tg_send/send",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "conversationId": "telegram:group:-1001",
+            "text": "hello",
+            "idempotencyKey": "k1",
+        },
+    )
+
+    assert r.status_code == 200, r.text
+    assert r.json() == {
+        "ok": True,
+        "gateway_id": "gw_tg_send",
+        "conversation_id": "telegram:group:-1001",
+        "provider_message_id": "telegram:-1001:10",
+    }
+    assert calls == [
+        {
+            "daemon_instance_id": seed["daemon_id"],
+            "type": "gateway_send",
+            "params": {
+                "agentId": "ag_daemon",
+                "gatewayId": "gw_tg_send",
+                "conversationId": "telegram:group:-1001",
+                "text": "hello",
+                "idempotencyKey": "k1",
+            },
+            "timeout_ms": 30000,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_agent_gateway_send_rejects_unallowed_conversation(
+    client, seed, db_session, monkeypatch
+):
+    token, _ = create_agent_token("ag_daemon")
+    await _insert_gateway(db_session, user_id=seed["user_id"])
+    fake_send = AsyncMock()
+    _patch_hub_gateway_send(monkeypatch, online=True, send=fake_send)
+
+    r = await client.post(
+        "/hub/gateways/gw_tg_send/send",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"conversationId": "telegram:group:-9999", "text": "hello"},
+    )
+
+    assert r.status_code == 403
+    assert r.json()["detail"] == "gateway_conversation_not_allowed"
+    fake_send.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/cli/src/commands/gateway.ts
+++ b/cli/src/commands/gateway.ts
@@ -1,0 +1,71 @@
+import type { ParsedArgs } from "../args.js";
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials } from "../credentials.js";
+import { normalizeAndValidateHubUrl } from "../hub-url.js";
+import { outputError, outputJson } from "../output.js";
+
+export async function gatewayCommand(
+  args: ParsedArgs,
+  globalHub?: string,
+  globalAgent?: string,
+): Promise<void> {
+  if (args.flags["help"] || args.subcommand !== "send") {
+    console.log(`Usage: botcord gateway send --gateway <id> --conversation <id> --text <msg> [options]
+
+Send a message through a configured third-party gateway.
+
+Options:
+  --gateway <id>        Gateway connection ID (required)
+  --conversation <id>   Provider conversation ID, e.g. telegram:group:-100... or feishu:chat:oc_... (required)
+  --text <msg>          Message text (required)
+  --idempotency-key <k> Optional request key forwarded to the daemon`);
+    return;
+  }
+
+  const gatewayId = args.flags["gateway"];
+  const conversationId = args.flags["conversation"];
+  const text = args.flags["text"];
+  if (!gatewayId || typeof gatewayId !== "string") outputError("--gateway is required");
+  if (!conversationId || typeof conversationId !== "string") {
+    outputError("--conversation is required");
+  }
+  if (!text || typeof text !== "string") outputError("--text is required");
+
+  const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+  const hubUrl = normalizeAndValidateHubUrl(globalHub || creds.hubUrl);
+
+  const client = new BotCordClient({
+    hubUrl,
+    agentId: creds.agentId,
+    keyId: creds.keyId,
+    privateKey: creds.privateKey,
+    token: creds.token,
+    tokenExpiresAt: creds.tokenExpiresAt,
+  });
+
+  const idempotencyKey =
+    typeof args.flags["idempotency-key"] === "string"
+      ? args.flags["idempotency-key"]
+      : undefined;
+
+  const token = await client.ensureToken();
+  const resp = await fetch(`${hubUrl.replace(/\/+$/, "")}/hub/gateways/${encodeURIComponent(gatewayId)}/send`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      conversationId,
+      text,
+      ...(idempotencyKey ? { idempotencyKey } : {}),
+    }),
+    signal: AbortSignal.timeout(30000),
+  });
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => "");
+    throw new Error(`gateway send failed: ${resp.status} ${body}`);
+  }
+  const result = await resp.json();
+  outputJson(result);
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -24,6 +24,7 @@ import { tokenCommand } from "./commands/token.js";
 import { envCommand } from "./commands/env.js";
 import { memoryCommand } from "./commands/memory.js";
 import { scheduleCommand } from "./commands/schedule.js";
+import { gatewayCommand } from "./commands/gateway.js";
 
 const VERSION = "0.1.0";
 
@@ -55,6 +56,7 @@ Commands:
   env               View or switch hub environment
   memory            Manage working memory
   schedule          Manage proactive schedules
+  gateway           Send through third-party gateways
 
 Global options:
   --agent <id>      Use specific agent credentials
@@ -154,6 +156,9 @@ async function main(): Promise<void> {
         break;
       case "schedule":
         await scheduleCommand(args, globalHub, globalAgent);
+        break;
+      case "gateway":
+        await gatewayCommand(args, globalHub, globalAgent);
         break;
       default:
         outputError(`unknown command: ${args.command}. Run "botcord --help" for usage.`);

--- a/packages/daemon/src/__tests__/gateway-control.test.ts
+++ b/packages/daemon/src/__tests__/gateway-control.test.ts
@@ -43,6 +43,7 @@ interface FakeGateway {
   channels: Map<string, { id: string; status: Record<string, unknown> }>;
   addChannel: ReturnType<typeof vi.fn>;
   removeChannel: ReturnType<typeof vi.fn>;
+  sendOutbound: ReturnType<typeof vi.fn>;
   snapshot: () => { channels: Record<string, any>; turns: Record<string, any> };
 }
 
@@ -66,6 +67,7 @@ function makeFakeGateway(): FakeGateway {
     removeChannel: vi.fn(async (id: string) => {
       channels.delete(id);
     }),
+    sendOutbound: vi.fn(async () => ({ providerMessageId: "provider-msg-1" })),
     snapshot: () => ({
       channels: Object.fromEntries([...channels].map(([id, e]) => [id, e.status])),
       turns: {},
@@ -614,6 +616,75 @@ describe("list_gateways", () => {
     expect(g.enabled).toBe(true);
     expect(g.status?.running).toBe(true);
     expect(g.status?.authorized).toBe(true);
+  });
+});
+
+describe("gateway_send", () => {
+  it("sends through an enabled allowed telegram gateway", async () => {
+    const gw = makeFakeGateway();
+    const gwId = uniqId("send");
+    const { io } = makeConfigIO({
+      ...baseCfg(),
+      thirdPartyGateways: [
+        {
+          id: gwId,
+          type: "telegram",
+          accountId: "ag_alice",
+          enabled: true,
+          allowedChatIds: ["-1001"],
+        },
+      ],
+    });
+    const ctrl = createGatewayControl({ gateway: gw as any, configIO: io });
+
+    const ack = await ctrl.handleSend({
+      agentId: "ag_alice",
+      gatewayId: gwId,
+      conversationId: "telegram:group:-1001",
+      text: "hello",
+      idempotencyKey: "k1",
+    });
+
+    expect(ack.ok).toBe(true);
+    expect(gw.sendOutbound).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: gwId,
+        accountId: "ag_alice",
+        conversationId: "telegram:group:-1001",
+        text: "hello",
+        traceId: "gateway-send:k1",
+      }),
+    );
+    expect((ack.result as any).providerMessageId).toBe("provider-msg-1");
+  });
+
+  it("rejects conversations outside allowedChatIds", async () => {
+    const gw = makeFakeGateway();
+    const gwId = uniqId("send-deny");
+    const { io } = makeConfigIO({
+      ...baseCfg(),
+      thirdPartyGateways: [
+        {
+          id: gwId,
+          type: "feishu",
+          accountId: "ag_alice",
+          enabled: true,
+          allowedChatIds: ["oc_allowed"],
+        },
+      ],
+    });
+    const ctrl = createGatewayControl({ gateway: gw as any, configIO: io });
+
+    const ack = await ctrl.handleSend({
+      agentId: "ag_alice",
+      gatewayId: gwId,
+      conversationId: "feishu:chat:oc_other",
+      text: "hello",
+    });
+
+    expect(ack.ok).toBe(false);
+    expect(ack.error?.code).toBe("conversation_not_allowed");
+    expect(gw.sendOutbound).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/daemon/src/gateway-control.ts
+++ b/packages/daemon/src/gateway-control.ts
@@ -176,6 +176,20 @@ interface GatewayRecentSendersResult {
   senders: GatewayRecentSender[];
 }
 
+interface GatewaySendParams {
+  agentId: string;
+  gatewayId: string;
+  conversationId: string;
+  text: string;
+  idempotencyKey?: string;
+}
+
+interface GatewaySendResult {
+  gatewayId: string;
+  conversationId: string;
+  providerMessageId?: string | null;
+}
+
 export type { FetchLike };
 
 export interface GatewayControlContext {
@@ -927,6 +941,80 @@ export function createGatewayControl(ctx: GatewayControlContext) {
     }
   }
 
+  // --- gateway_send -------------------------------------------------------
+  async function handleSend(params: GatewaySendParams): Promise<AckBody> {
+    if (!params.agentId || typeof params.agentId !== "string") {
+      return badParams("gateway_send: agentId is required");
+    }
+    if (!params.gatewayId || typeof params.gatewayId !== "string") {
+      return badParams("gateway_send: gatewayId is required");
+    }
+    if (!params.conversationId || typeof params.conversationId !== "string") {
+      return badParams("gateway_send: conversationId is required");
+    }
+    if (typeof params.text !== "string" || params.text.length === 0) {
+      return badParams("gateway_send: text is required");
+    }
+
+    const cfg = cfgIO.load();
+    const profile = (cfg.thirdPartyGateways ?? []).find((g) => g.id === params.gatewayId);
+    if (!profile) {
+      return {
+        ok: false,
+        error: { code: "unknown_gateway", message: `no gateway with id "${params.gatewayId}"` },
+      };
+    }
+    if (profile.accountId !== params.agentId) {
+      return {
+        ok: false,
+        error: { code: "account_mismatch", message: "gateway is bound to a different agent" },
+      };
+    }
+    if (profile.enabled === false) {
+      return {
+        ok: false,
+        error: { code: "gateway_disabled", message: "gateway is disabled" },
+      };
+    }
+    if (profile.type === "wechat") {
+      return {
+        ok: false,
+        error: { code: "unsupported_provider", message: "wechat gateway_send requires an inbound context_token and is not supported" },
+      };
+    }
+
+    const conversationErr = validateOutboundConversation(profile, params.conversationId);
+    if (conversationErr) return conversationErr;
+
+    try {
+      const sendResult = await ctx.gateway.sendOutbound({
+        channel: params.gatewayId,
+        accountId: params.agentId,
+        conversationId: params.conversationId,
+        text: params.text,
+        traceId: `gateway-send:${params.idempotencyKey ?? Date.now()}`,
+      });
+      const result: GatewaySendResult = {
+        gatewayId: params.gatewayId,
+        conversationId: params.conversationId,
+        providerMessageId: sendResult.providerMessageId ?? null,
+      };
+      return { ok: true, result };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      daemonLog.warn("gateway_send failed", {
+        gatewayId: params.gatewayId,
+        accountId: params.agentId,
+        conversationId: params.conversationId,
+        error: message,
+      });
+      return {
+        ok: false,
+        error: { code: "send_failed", message },
+      };
+    }
+  }
+
   return {
     handleList,
     handleUpsert,
@@ -935,6 +1023,7 @@ export function createGatewayControl(ctx: GatewayControlContext) {
     handleLoginStart,
     handleLoginStatus,
     handleRecentSenders,
+    handleSend,
     /** Exposed for tests — direct access to the in-memory session map. */
     _sessions: sessions,
   };
@@ -956,6 +1045,55 @@ function validateUpsertParams(p: UpsertGatewayParams): string | null {
   if (!p.id || typeof p.id !== "string") return "upsert_gateway: id is required";
   if (!isProvider(p.type)) return `upsert_gateway: unknown provider "${String(p.type)}"`;
   if (!p.accountId || typeof p.accountId !== "string") return "upsert_gateway: accountId is required";
+  return null;
+}
+
+function validateOutboundConversation(
+  profile: ThirdPartyGatewayProfile,
+  conversationId: string,
+): AckBody | null {
+  const chatId = chatIdFromConversation(profile.type, conversationId);
+  if (!chatId) {
+    return {
+      ok: false,
+      error: {
+        code: "bad_conversation",
+        message: `conversationId "${conversationId}" is not valid for ${profile.type}`,
+      },
+    };
+  }
+  const allowed = new Set((profile.allowedChatIds ?? []).map(String));
+  if (!allowed.has(chatId)) {
+    return {
+      ok: false,
+      error: {
+        code: "conversation_not_allowed",
+        message: "conversation is not in the gateway allowedChatIds list",
+      },
+    };
+  }
+  return null;
+}
+
+function chatIdFromConversation(provider: ThirdPartyGatewayProfile["type"], conversationId: string): string | null {
+  if (provider === "telegram") {
+    if (conversationId.startsWith("telegram:user:")) {
+      return conversationId.slice("telegram:user:".length);
+    }
+    if (conversationId.startsWith("telegram:group:")) {
+      return conversationId.slice("telegram:group:".length);
+    }
+    return null;
+  }
+  if (provider === "feishu") {
+    if (conversationId.startsWith("feishu:user:")) {
+      return conversationId.slice("feishu:user:".length);
+    }
+    if (conversationId.startsWith("feishu:chat:")) {
+      return conversationId.slice("feishu:chat:".length);
+    }
+    return null;
+  }
   return null;
 }
 

--- a/packages/daemon/src/gateway/gateway.ts
+++ b/packages/daemon/src/gateway/gateway.ts
@@ -13,6 +13,7 @@ import type {
   GatewayChannelConfig,
   GatewayConfig,
   GatewayInboundMessage,
+  GatewayOutboundMessage,
   GatewayRoute,
   GatewayRuntimeSnapshot,
   InboundObserver,
@@ -270,5 +271,18 @@ export class Gateway {
    */
   async injectInbound(message: GatewayInboundMessage): Promise<void> {
     await this.dispatcher.handle({ message });
+  }
+
+  /**
+   * Send a daemon-control initiated outbound message through a registered
+   * channel. Used by proactive third-party gateway sends where the runtime
+   * explicitly targets an external provider conversation.
+   */
+  async sendOutbound(message: GatewayOutboundMessage): Promise<{ providerMessageId?: string | null }> {
+    const channel = this.channelMap.get(message.channel);
+    if (!channel) {
+      throw new Error(`channel "${message.channel}" is not registered`);
+    }
+    return channel.send({ message, log: this.log });
   }
 }

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -400,6 +400,16 @@ export function createProvisioner(opts: ProvisionerOptions): (
         );
       }
 
+      case "gateway_send": {
+        const v = validateGatewayParams(frame.params, {
+          required: ["agentId", "gatewayId", "conversationId", "text"],
+        });
+        if (!v.ok) return v.ack;
+        return gatewayControl.handleSend(
+          v.params as unknown as Parameters<typeof gatewayControl.handleSend>[0],
+        );
+      }
+
       case "list_agent_files": {
         const params = (frame.params ?? {}) as unknown as ListAgentFilesParams;
         if (!params.agentId) {

--- a/packages/protocol-core/src/client.ts
+++ b/packages/protocol-core/src/client.ts
@@ -8,6 +8,7 @@ import { buildSignedEnvelope, derivePublicKey, generateKeypair, signChallenge } 
 import { normalizeAndValidateHubUrl } from "./hub-url.js";
 import type {
   BotCordMessageEnvelope,
+  GatewaySendResponse,
   InboxPollResponse,
   SendResponse,
   RoomInfo,
@@ -285,6 +286,23 @@ export class BotCordClient {
       body: JSON.stringify(envelope),
     });
     return (await resp.json()) as SendResponse;
+  }
+
+  async sendGatewayMessage(params: {
+    gatewayId: string;
+    conversationId: string;
+    text: string;
+    idempotencyKey?: string;
+  }): Promise<GatewaySendResponse> {
+    const resp = await this.hubFetch(`/hub/gateways/${encodeURIComponent(params.gatewayId)}/send`, {
+      method: "POST",
+      body: JSON.stringify({
+        conversationId: params.conversationId,
+        text: params.text,
+        ...(params.idempotencyKey ? { idempotencyKey: params.idempotencyKey } : {}),
+      }),
+    });
+    return (await resp.json()) as GatewaySendResponse;
   }
 
   // ── Inbox ─────────────────────────────────────────────────────

--- a/packages/protocol-core/src/types.ts
+++ b/packages/protocol-core/src/types.ts
@@ -71,6 +71,13 @@ export type SendResponse = {
   topic_id?: string;
 };
 
+export type GatewaySendResponse = {
+  ok: boolean;
+  gateway_id: string;
+  conversation_id: string;
+  provider_message_id?: string | null;
+};
+
 export type RoomInfo = {
   room_id: string;
   name: string;


### PR DESCRIPTION
## Summary
- add agent-token /hub/gateways/{gateway_id}/send endpoint with ownership and allowlist checks
- add daemon gateway_send control frame and outbound adapter dispatch
- add protocol-core client type/method and botcord gateway send CLI command

## Tests
- cd backend && uv run pytest tests/test_app/test_app_gateways.py -q
- cd packages/daemon && npm test -- --run src/__tests__/gateway-control.test.ts
- cd packages/daemon && npm run build
- cd packages/protocol-core && npm run build
- cd cli && npm run build
- cd cli && npx tsc --noEmit