### PR TITLE
fix: prevent publish workflow dirty rebase failure

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -170,6 +170,7 @@ jobs:
           if git ls-files --error-unmatch package-lock.json >/dev/null 2>&1; then
             git add package-lock.json
           fi
+          git add -u .
           case "$PKG" in
             cli) TAG_PREFIX="cli-" ;;
             protocol-core) TAG_PREFIX="protocol-core-" ;;

--- a/cli/dist/commands/bind.js
+++ b/cli/dist/commands/bind.js
@@ -4,14 +4,17 @@ import { normalizeAndValidateHubUrl } from "../hub-url.js";
 import { outputError, outputJson } from "../output.js";
 export async function bindCommand(args, globalHub, globalAgent) {
     if (args.flags["help"]) {
-        console.log(`Usage: botcord bind <bind_code_or_bind_ticket>
+        console.log(`Usage: botcord bind <bind_ticket>
 
 Bind the current BotCord agent to a BotCord web dashboard account.`);
         return;
     }
     const bindCredential = args.subcommand || args.positionals[0];
     if (!bindCredential)
-        outputError("bind code or bind ticket is required");
+        outputError("bind ticket is required");
+    if (bindCredential.startsWith("bd_")) {
+        outputError("bind codes are no longer supported; pass a bind ticket");
+    }
     const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
     const hubUrl = normalizeAndValidateHubUrl(globalHub || creds.hubUrl);
     const client = new BotCordClient({
@@ -34,9 +37,7 @@ Bind the current BotCord agent to a BotCord web dashboard account.`);
             agent_id: creds.agentId,
             display_name: displayName,
             agent_token: agentToken,
-            ...(bindCredential.startsWith("bd_")
-                ? { bind_code: bindCredential }
-                : { bind_ticket: bindCredential }),
+            bind_ticket: bindCredential,
         }),
         signal: AbortSignal.timeout(15000),
     });

--- a/cli/package.json
+++ b/cli/package.json
@@ -4,7 +4,7 @@
   "description": "BotCord CLI — register agents, send signed messages, manage rooms and contacts",
   "type": "module",
   "bin": {
-    "botcord": "./dist/index.js"
+    "botcord": "dist/index.js"
   },
   "scripts": {
     "build": "tsc",
@@ -23,7 +23,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/botlearn-ai/botcord",
+    "url": "git+https://github.com/botlearn-ai/botcord.git",
     "directory": "cli"
   },
   "publishConfig": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -4,7 +4,7 @@
   "description": "BotCord local daemon — bridges Hub inbox push to local Claude Code / Codex / Gemini CLIs",
   "type": "module",
   "bin": {
-    "botcord-daemon": "./dist/index.js"
+    "botcord-daemon": "dist/index.js"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary
- stage tracked package changes before the publish workflow rebases
- normalize npm package metadata for CLI and daemon
- refresh tracked CLI build output for bind command

## Verification
- npm run build (cli)
- npx npm@11.12.1 publish --dry-run --access public (cli; reached expected already-published error)
- npx npm@11.12.1 publish --dry-run --access public (packages/daemon; reached expected already-published error)