### PR TITLE
fix: sync owner chat previews

### DIFF
--- a/frontend/src/store/useDashboardChatStore.ts
+++ b/frontend/src/store/useDashboardChatStore.ts
@@ -232,6 +232,7 @@ interface DashboardChatState {
   applyRealtimeEventHint: (event: RealtimeMetaEvent) => void;
   replaceOverview: (overview: DashboardOverview) => void;
   patchRoom: (roomId: string, patch: Partial<DashboardRoom>) => void;
+  patchOwnerChatRoomSummary: (roomId: string, patch: Pick<HumanAgentRoomSummary, "last_message_at" | "last_message_preview" | "last_sender_name">) => void;
   bumpRoomMembersVersion: (roomId: string) => void;
 
   insertMessage: (roomId: string, message: DashboardMessage) => void;
@@ -445,6 +446,37 @@ export const useDashboardChatStore = create<DashboardChatState>()(
             }
             : state.overview,
         })),
+
+      patchOwnerChatRoomSummary: (roomId, patch) =>
+        set((state) => {
+          const existing = state.ownedAgentRooms.find((room) => room.room_id === roomId);
+          if (!existing) return state;
+          const currentAt = existing.last_message_at ?? "";
+          const nextAt = patch.last_message_at ?? "";
+          if (currentAt && nextAt && nextAt < currentAt) return state;
+
+          const patchRoomSummary = (room: HumanAgentRoomSummary): HumanAgentRoomSummary =>
+            room.room_id === roomId
+              ? {
+                ...room,
+                last_message_at: patch.last_message_at,
+                last_message_preview: patch.last_message_preview,
+                last_sender_name: patch.last_sender_name,
+              }
+              : room;
+
+          return {
+            ownedAgentRooms: state.ownedAgentRooms
+              .map(patchRoomSummary)
+              .sort(compareRoomsByActivityDesc),
+            optimisticOwnerChatRooms: Object.fromEntries(
+              Object.entries(state.optimisticOwnerChatRooms).map(([agentId, room]) => [
+                agentId,
+                patchRoomSummary(room),
+              ]),
+            ),
+          };
+        }),
 
       bumpRoomMembersVersion: (roomId) =>
         set((state) => ({

--- a/frontend/src/store/useOwnerChatStore.test.ts
+++ b/frontend/src/store/useOwnerChatStore.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DashboardMessage, HumanAgentRoomSummary, OwnerChatMessage } from "@/lib/types";
+
+const mocks = vi.hoisted(() => ({
+  getRoomMessages: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    getRoomMessages: mocks.getRoomMessages,
+  },
+  humansApi: {
+    listAgentRooms: vi.fn(),
+  },
+  getActiveAgentId: vi.fn(() => null),
+  setActiveAgentId: vi.fn(),
+  getStoredActiveIdentity: vi.fn(() => null),
+  setStoredActiveIdentity: vi.fn(),
+}));
+
+import { useDashboardChatStore } from "@/store/useDashboardChatStore";
+import { useOwnerChatStore } from "@/store/useOwnerChatStore";
+
+function makeOwnedAgentRoom(overrides: Partial<HumanAgentRoomSummary> = {}): HumanAgentRoomSummary {
+  return {
+    room_id: "rm_oc_real",
+    name: "Owned bot",
+    description: null,
+    rule: null,
+    owner_id: "ag_bot",
+    visibility: "private",
+    join_policy: "invite_only",
+    member_count: 1,
+    created_at: "2026-05-14T00:00:00.000Z",
+    required_subscription_product_id: null,
+    last_message_preview: null,
+    last_message_at: null,
+    last_sender_name: null,
+    allow_human_send: true,
+    members_preview: null,
+    bots: [{ agent_id: "ag_bot", display_name: "Owned bot", role: "owner" }],
+    ...overrides,
+  };
+}
+
+function makeDashboardMessage(overrides: Partial<DashboardMessage> = {}): DashboardMessage {
+  return {
+    hub_msg_id: "msg_1",
+    msg_id: "msg_1",
+    room_id: "rm_oc_real",
+    sender_id: "ag_bot",
+    sender_name: "Owned bot",
+    type: "text",
+    text: "hello from bot",
+    payload: {},
+    topic: null,
+    topic_id: null,
+    goal: null,
+    state: "sent",
+    state_counts: null,
+    created_at: "2026-05-19T08:00:00.000Z",
+    sender_avatar_url: null,
+    is_mine: false,
+    ...overrides,
+  };
+}
+
+function makeOwnerChatMessage(overrides: Partial<OwnerChatMessage> = {}): OwnerChatMessage {
+  return {
+    clientId: "client_1",
+    hubMsgId: null,
+    sender: "user",
+    text: "local hello",
+    streamBlocks: [],
+    status: "optimistic",
+    createdAt: "2026-05-19T09:00:00.000Z",
+    senderName: "You",
+    type: "message",
+    ...overrides,
+  };
+}
+
+describe("useOwnerChatStore room summaries", () => {
+  beforeEach(() => {
+    mocks.getRoomMessages.mockReset();
+    useOwnerChatStore.getState().reset();
+    useDashboardChatStore.setState({
+      ownedAgentRooms: [makeOwnedAgentRoom()],
+      optimisticOwnerChatRooms: {},
+    });
+  });
+
+  it("patches the owner-chat room summary after initial load", async () => {
+    mocks.getRoomMessages.mockResolvedValue({
+      messages: [makeDashboardMessage()],
+      has_more: false,
+    });
+    useOwnerChatStore.getState().setRoom("rm_oc_real", "Owned bot");
+
+    await useOwnerChatStore.getState().loadInitial("rm_oc_real");
+
+    expect(useDashboardChatStore.getState().ownedAgentRooms[0]).toMatchObject({
+      last_message_at: "2026-05-19T08:00:00.000Z",
+      last_message_preview: "hello from bot",
+      last_sender_name: "Owned bot",
+    });
+  });
+
+  it("patches the owner-chat room summary for optimistic sends", () => {
+    useOwnerChatStore.getState().setRoom("rm_oc_real", "Owned bot");
+
+    useOwnerChatStore.getState().addOptimistic(makeOwnerChatMessage());
+
+    expect(useDashboardChatStore.getState().ownedAgentRooms[0]).toMatchObject({
+      last_message_at: "2026-05-19T09:00:00.000Z",
+      last_message_preview: "local hello",
+      last_sender_name: "You",
+    });
+  });
+
+  it("moves owner-chat rows by the latest local message time", () => {
+    useDashboardChatStore.setState({
+      ownedAgentRooms: [
+        makeOwnedAgentRoom({
+          room_id: "rm_oc_other",
+          owner_id: "ag_other",
+          last_message_at: "2026-05-19T08:30:00.000Z",
+          last_message_preview: "other room",
+          bots: [{ agent_id: "ag_other", display_name: "Other bot", role: "owner" }],
+        }),
+        makeOwnedAgentRoom(),
+      ],
+      optimisticOwnerChatRooms: {},
+    });
+    useOwnerChatStore.getState().setRoom("rm_oc_real", "Owned bot");
+
+    useOwnerChatStore.getState().addOptimistic(makeOwnerChatMessage());
+
+    expect(useDashboardChatStore.getState().ownedAgentRooms.map((room) => room.room_id)).toEqual([
+      "rm_oc_real",
+      "rm_oc_other",
+    ]);
+  });
+});

--- a/frontend/src/store/useOwnerChatStore.ts
+++ b/frontend/src/store/useOwnerChatStore.ts
@@ -20,6 +20,7 @@ import type {
   DashboardMessage,
 } from "@/lib/types";
 import { dashboardMsgToOwnerChat } from "@/lib/types";
+import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 
 const MAX_BLOCKS_PER_TRACE = 200;
 
@@ -60,6 +61,26 @@ function extractAssistantText(blocks: StreamBlockEntry[]): string {
     }
   }
   return parts.join("");
+}
+
+function latestPreviewableMessage(messages: OwnerChatMessage[]): OwnerChatMessage | null {
+  return messages.reduce<OwnerChatMessage | null>((latest, msg) => {
+    if (msg.type === "error" || msg.status === "failed") return latest;
+    if (!msg.text.trim() && (msg.attachments?.length ?? 0) === 0) return latest;
+    if (!latest) return msg;
+    return Date.parse(msg.createdAt) >= Date.parse(latest.createdAt) ? msg : latest;
+  }, null);
+}
+
+function syncOwnerChatRoomSummary(roomId: string | null, messages: OwnerChatMessage[]): void {
+  if (!roomId) return;
+  const latest = latestPreviewableMessage(messages);
+  if (!latest) return;
+  useDashboardChatStore.getState().patchOwnerChatRoomSummary(roomId, {
+    last_message_at: latest.createdAt,
+    last_message_preview: latest.text || ((latest.attachments?.length ?? 0) > 0 ? "[Attachment]" : ""),
+    last_sender_name: latest.senderName || (latest.sender === "user" ? "You" : null),
+  });
 }
 
 /** In-flight guard + request token to prevent stale loadInitial responses. */
@@ -205,6 +226,7 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
           roomId,
         };
       });
+      syncOwnerChatRoomSummary(roomId, get().messages);
     } catch (err: any) {
       set({ error: err?.message || "Failed to load messages", loading: false });
     } finally {
@@ -233,6 +255,7 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
         messages: [...older, ...state.messages],
         hasMore: result.has_more,
       }));
+      syncOwnerChatRoomSummary(roomId, get().messages);
     } catch (err) {
       console.error("[OwnerChatStore] Failed to load more:", err);
     } finally {
@@ -242,17 +265,21 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
 
   // ------ Message lifecycle ------
 
-  addOptimistic: (msg) =>
-    set((state) => ({ messages: [...state.messages, msg] })),
+  addOptimistic: (msg) => {
+    set((state) => ({ messages: [...state.messages, msg] }));
+    syncOwnerChatRoomSummary(get().roomId, get().messages);
+  },
 
-  confirmOptimistic: (clientId, hubMsgId, createdAt, attachments) =>
+  confirmOptimistic: (clientId, hubMsgId, createdAt, attachments) => {
     set((state) => ({
       messages: state.messages.map((m) =>
         m.clientId === clientId
           ? { ...m, hubMsgId, status: "confirmed" as const, createdAt, attachments: attachments ?? m.attachments, sendText: undefined, retryFiles: undefined }
           : m
       ),
-    })),
+    }));
+    syncOwnerChatRoomSummary(get().roomId, get().messages);
+  },
 
   failOptimistic: (clientId, error) =>
     set((state) => ({
@@ -274,7 +301,7 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
 
   // ------ Server-delivered messages ------
 
-  upsertMessage: (msg) =>
+  upsertMessage: (msg) => {
     set((state) => {
       // Dedup by hubMsgId
       if (msg.hubMsgId && state.messages.some((m) => m.hubMsgId === msg.hubMsgId)) {
@@ -324,7 +351,9 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
 
       // Append new message
       return { messages: [...state.messages, msg] };
-    }),
+    });
+    syncOwnerChatRoomSummary(get().roomId, get().messages);
+  },
 
   mergeApiMessages: (msgs, _direction) => {
     const agentName = get().agentName;
@@ -373,11 +402,12 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
       if (deduped.length === 0 && reconciled === state.messages) return state;
       return { messages: deduped.length > 0 ? [...reconciled, ...deduped] : reconciled };
     });
+    syncOwnerChatRoomSummary(get().roomId, get().messages);
   },
 
   // ------ Streaming ------
 
-  appendStreamBlock: (entry) =>
+  appendStreamBlock: (entry) => {
     set((state) => {
       const traceId = entry.trace_id;
 
@@ -427,9 +457,11 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
         activeTraceId: traceId,
         agentTyping: false,
       };
-    }),
+    });
+    syncOwnerChatRoomSummary(get().roomId, get().messages);
+  },
 
-  finalizeStream: (traceId, finalData) =>
+  finalizeStream: (traceId, finalData) => {
     set((state) => {
       const idx = state.messages.findIndex(
         (m) => m.traceId === traceId && m.status === "streaming"
@@ -497,7 +529,9 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
         messages: newMessages,
         activeTraceId: null,
       };
-    }),
+    });
+    syncOwnerChatRoomSummary(get().roomId, get().messages);
+  },
 
   // ------ Connection state ------
 


### PR DESCRIPTION
## Summary
- sync owner-chat messages back into owned agent room summaries
- update owner-chat room ordering from latest local/API/streamed activity
- add tests for summary preview/time updates and sorting

## Tests
- pnpm test -- --run src/store/useOwnerChatStore.test.ts src/store/useDashboardChatStore.test.ts src/lib/messages-merge.test.ts

## Notes
- pnpm build compiles but prerender is blocked locally by missing Supabase URL/API key for /admin/codes.