### PR TITLE
fix: suppress empty owner chat bubbles

### DIFF
--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -534,113 +534,122 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
           }
 
           // --- Confirmed / Delivered messages ---
+          const hasText = msg.text.trim().length > 0;
+          const hasAttachments = (msg.attachments?.length ?? 0) > 0;
+          const hasVisibleBubble = hasText || hasAttachments || isUser;
+          if (!hasVisibleBubble && msg.streamBlocks.length === 0) {
+            return null;
+          }
+
           return (
             <div key={msg.clientId} className="space-y-1.5">
               {/* Finalized execution blocks above agent message */}
               {!isUser && msg.streamBlocks.length > 0 && (
                 <StreamBlocksView key={`${msg.clientId}-delivered`} blocks={msg.streamBlocks} />
               )}
-              <div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
-                <div
-                  className={`max-w-[75%] rounded-lg px-3 py-2 text-sm ${
-                    isUser
-                      ? "bg-cyan-500/20 text-cyan-100 border border-cyan-500/30"
-                      : "bg-zinc-800 text-zinc-200 border border-zinc-700"
-                  }`}
-                >
-                  <div className={`mb-1 flex items-center gap-1.5 ${isUser ? "justify-end" : ""}`}>
-                    {isUser ? (
-                      <>
-                        <span className="text-xs font-medium text-cyan-100/90">
-                          {msg.senderName}
-                        </span>
-                        <span
-                          className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-cyan-300/30 bg-cyan-300/10 text-cyan-200"
-                          title="Human"
-                          aria-label="Human sender"
-                        >
-                          <User className="h-2.5 w-2.5" />
-                        </span>
-                      </>
-                    ) : (
-                      <>
-                        <span
-                          className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-purple-400/30 bg-purple-400/10 text-purple-300"
-                          title="Bot"
-                          aria-label="Bot sender"
-                        >
-                          <Bot className="h-2.5 w-2.5" />
-                        </span>
-                      <span className="text-xs font-medium text-zinc-300">
-                        {msg.senderName}
-                      </span>
-                      {chatAgentId && (
-                        <CopyableId value={chatAgentId} className="text-zinc-500 hover:text-zinc-300" />
+              {hasVisibleBubble && (
+                <div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
+                  <div
+                    className={`max-w-[75%] rounded-lg px-3 py-2 text-sm ${
+                      isUser
+                        ? "bg-cyan-500/20 text-cyan-100 border border-cyan-500/30"
+                        : "bg-zinc-800 text-zinc-200 border border-zinc-700"
+                    }`}
+                  >
+                    <div className={`mb-1 flex items-center gap-1.5 ${isUser ? "justify-end" : ""}`}>
+                      {isUser ? (
+                        <>
+                          <span className="text-xs font-medium text-cyan-100/90">
+                            {msg.senderName}
+                          </span>
+                          <span
+                            className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-cyan-300/30 bg-cyan-300/10 text-cyan-200"
+                            title="Human"
+                            aria-label="Human sender"
+                          >
+                            <User className="h-2.5 w-2.5" />
+                          </span>
+                        </>
+                      ) : (
+                        <>
+                          <span
+                            className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-purple-400/30 bg-purple-400/10 text-purple-300"
+                            title="Bot"
+                            aria-label="Bot sender"
+                          >
+                            <Bot className="h-2.5 w-2.5" />
+                          </span>
+                          <span className="text-xs font-medium text-zinc-300">
+                            {msg.senderName}
+                          </span>
+                          {chatAgentId && (
+                            <CopyableId value={chatAgentId} className="text-zinc-500 hover:text-zinc-300" />
+                          )}
+                        </>
                       )}
-                      </>
-                    )}
-                  </div>
-                  {/* Typewriter for new agent messages; skip if already animated or was streamed */}
-                  {(() => {
-                    const wasStreamed = msg.traceId && streamedTraceIds.current?.has(msg.traceId);
-                    if (wasStreamed) {
-                      // Mark as animated and clean up traceId to avoid memory leak
-                      animatedRef.current.add(msg.clientId);
-                      streamedTraceIds.current.delete(msg.traceId!);
-                    }
-                    const skipTypewriter = isUser || initialLoadRef.current || animatedRef.current.has(msg.clientId);
-                    if (skipTypewriter) {
-                      return <MarkdownContent content={msg.text || ""} />;
-                    }
-                    return (
-                      <TypewriterText
-                        text={msg.text || ""}
-                        onTick={scrollToBottom}
-                        onComplete={() => {
-                          animatedRef.current.add(msg.clientId);
-                          forceRender((n) => n + 1);
-                        }}
-                      />
-                    );
-                  })()}
-                  {/* Attachments */}
-                  {msg.attachments && msg.attachments.length > 0 && (
-                    <div className="mt-2 space-y-1.5">
-                      {msg.attachments.map((att, idx) => {
-                        const fullUrl = att.url.startsWith("/") ? `${HUB_BASE_URL}${att.url}` : att.url;
-                        const isImage = att.content_type?.startsWith("image/");
-                        if (isImage) {
+                    </div>
+                    {/* Typewriter for new agent messages; skip if already animated or was streamed */}
+                    {(() => {
+                      const wasStreamed = msg.traceId && streamedTraceIds.current?.has(msg.traceId);
+                      if (wasStreamed) {
+                        // Mark as animated and clean up traceId to avoid memory leak
+                        animatedRef.current.add(msg.clientId);
+                        streamedTraceIds.current.delete(msg.traceId!);
+                      }
+                      const skipTypewriter = isUser || initialLoadRef.current || animatedRef.current.has(msg.clientId);
+                      if (skipTypewriter) {
+                        return <MarkdownContent content={msg.text || ""} />;
+                      }
+                      return (
+                        <TypewriterText
+                          text={msg.text || ""}
+                          onTick={scrollToBottom}
+                          onComplete={() => {
+                            animatedRef.current.add(msg.clientId);
+                            forceRender((n) => n + 1);
+                          }}
+                        />
+                      );
+                    })()}
+                    {/* Attachments */}
+                    {msg.attachments && msg.attachments.length > 0 && (
+                      <div className="mt-2 space-y-1.5">
+                        {msg.attachments.map((att, idx) => {
+                          const fullUrl = att.url.startsWith("/") ? `${HUB_BASE_URL}${att.url}` : att.url;
+                          const isImage = att.content_type?.startsWith("image/");
+                          if (isImage) {
+                            return (
+                              <a key={idx} href={fullUrl} target="_blank" rel="noopener noreferrer" className="block">
+                                <img
+                                  src={fullUrl}
+                                  alt={att.filename || "Image"}
+                                  className="max-h-48 max-w-full rounded border border-zinc-600 object-cover hover:opacity-80 transition-opacity"
+                                />
+                                <span className="mt-0.5 block text-[10px] text-zinc-500">{att.filename}</span>
+                              </a>
+                            );
+                          }
                           return (
-                            <a key={idx} href={fullUrl} target="_blank" rel="noopener noreferrer" className="block">
-                              <img
-                                src={fullUrl}
-                                alt={att.filename || "Image"}
-                                className="max-h-48 max-w-full rounded border border-zinc-600 object-cover hover:opacity-80 transition-opacity"
-                              />
-                              <span className="mt-0.5 block text-[10px] text-zinc-500">{att.filename}</span>
+                            <a
+                              key={idx}
+                              href={fullUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="flex items-center gap-1.5 text-xs text-cyan-400 hover:text-cyan-300 transition-colors"
+                            >
+                              <FileText className="w-3.5 h-3.5 shrink-0" />
+                              <span className="truncate">{att.filename || "Attachment"}</span>
                             </a>
                           );
-                        }
-                        return (
-                          <a
-                            key={idx}
-                            href={fullUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="flex items-center gap-1.5 text-xs text-cyan-400 hover:text-cyan-300 transition-colors"
-                          >
-                            <FileText className="w-3.5 h-3.5 shrink-0" />
-                            <span className="truncate">{att.filename || "Attachment"}</span>
-                          </a>
-                        );
-                      })}
+                        })}
+                      </div>
+                    )}
+                    <div className="text-xs text-zinc-500 mt-1 text-right">
+                      {new Date(msg.createdAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
                     </div>
-                  )}
-                  <div className="text-xs text-zinc-500 mt-1 text-right">
-                    {new Date(msg.createdAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
                   </div>
                 </div>
-              </div>
+              )}
             </div>
           );
         })}

--- a/frontend/src/store/useOwnerChatStore.test.ts
+++ b/frontend/src/store/useOwnerChatStore.test.ts
@@ -142,3 +142,47 @@ describe("useOwnerChatStore room summaries", () => {
     ]);
   });
 });
+
+describe("useOwnerChatStore empty message handling", () => {
+  beforeEach(() => {
+    mocks.getRoomMessages.mockReset();
+    useOwnerChatStore.getState().reset();
+    useDashboardChatStore.setState({
+      ownedAgentRooms: [makeOwnedAgentRoom()],
+      optimisticOwnerChatRooms: {},
+    });
+    useOwnerChatStore.getState().setRoom("rm_oc_real", "Owned bot");
+  });
+
+  it("filters delivered API messages with no visible content", async () => {
+    mocks.getRoomMessages.mockResolvedValue({
+      messages: [
+        makeDashboardMessage({ hub_msg_id: "msg_empty", msg_id: "msg_empty", text: "", payload: {} }),
+        makeDashboardMessage({ hub_msg_id: "msg_text", msg_id: "msg_text", text: "visible" }),
+      ],
+      has_more: false,
+    });
+
+    await useOwnerChatStore.getState().loadInitial("rm_oc_real");
+
+    expect(useOwnerChatStore.getState().messages.map((m) => m.hubMsgId)).toEqual(["msg_text"]);
+  });
+
+  it("keeps delivered messages that only have visible stream blocks", () => {
+    useOwnerChatStore.getState().upsertMessage(makeOwnerChatMessage({
+      hubMsgId: "msg_1",
+      sender: "agent",
+      text: "",
+      status: "delivered",
+      senderName: "Owned bot",
+      streamBlocks: [{
+        trace_id: "tr_1",
+        seq: 1,
+        created_at: "2026-05-19T03:00:00.000Z",
+        block: { kind: "reasoning", payload: { text: "reasoning" } },
+      }],
+    }));
+
+    expect(useOwnerChatStore.getState().messages).toHaveLength(1);
+  });
+});

--- a/frontend/src/store/useOwnerChatStore.ts
+++ b/frontend/src/store/useOwnerChatStore.ts
@@ -83,6 +83,14 @@ function syncOwnerChatRoomSummary(roomId: string | null, messages: OwnerChatMess
   });
 }
 
+function hasVisibleOwnerChatContent(msg: OwnerChatMessage): boolean {
+  if (msg.type !== "message") return true;
+  if (msg.status === "streaming" || msg.status === "optimistic" || msg.status === "failed") return true;
+  if (msg.text.trim()) return true;
+  if ((msg.attachments?.length ?? 0) > 0) return true;
+  return msg.streamBlocks.length > 0;
+}
+
 /** In-flight guard + request token to prevent stale loadInitial responses. */
 let loadInFlight = false;
 let loadRequestId = 0;
@@ -175,15 +183,12 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
       if (thisRequestId !== loadRequestId || get().roomId !== roomId) return;
 
       const agentName = get().agentName;
-      const apiMsgs = result.messages.reverse().map((m) => dashboardMsgToOwnerChat(m, agentName));
+      const apiMsgs = result.messages
+        .reverse()
+        .map((m) => dashboardMsgToOwnerChat(m, agentName))
+        .filter(hasVisibleOwnerChatContent);
 
       set((state) => {
-        // Build lookup for API messages by hubMsgId
-        const apiByHubId = new Map<string, OwnerChatMessage>();
-        for (const m of apiMsgs) {
-          if (m.hubMsgId) apiByHubId.set(m.hubMsgId, m);
-        }
-
         // Build lookup for existing messages by hubMsgId
         const existingByHubId = new Map<string, OwnerChatMessage>();
         for (const m of state.messages) {
@@ -249,7 +254,10 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
         limit: 50,
       });
       const agentName = get().agentName;
-      const older = result.messages.reverse().map((m) => dashboardMsgToOwnerChat(m, agentName));
+      const older = result.messages
+        .reverse()
+        .map((m) => dashboardMsgToOwnerChat(m, agentName))
+        .filter(hasVisibleOwnerChatContent);
 
       set((state) => ({
         messages: [...older, ...state.messages],
@@ -303,6 +311,8 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
 
   upsertMessage: (msg) => {
     set((state) => {
+      if (!hasVisibleOwnerChatContent(msg)) return state;
+
       // Dedup by hubMsgId
       if (msg.hubMsgId && state.messages.some((m) => m.hubMsgId === msg.hubMsgId)) {
         return state;
@@ -358,7 +368,10 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
   mergeApiMessages: (msgs, _direction) => {
     const agentName = get().agentName;
     // API returns newest-first; reverse to chronological order before merge
-    const converted = [...msgs].reverse().map((m) => dashboardMsgToOwnerChat(m, agentName));
+    const converted = [...msgs]
+      .reverse()
+      .map((m) => dashboardMsgToOwnerChat(m, agentName))
+      .filter(hasVisibleOwnerChatContent);
 
     set((state) => {
       const existingIds = new Set(
@@ -468,6 +481,10 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
       );
 
       if (idx === -1) {
+        if (!finalData.text.trim() && (finalData.attachments?.length ?? 0) === 0) {
+          return { activeTraceId: null };
+        }
+
         // No streaming placeholder — insert as a new delivered message
         const msg: OwnerChatMessage = {
           clientId: finalData.hubMsgId,
@@ -510,6 +527,17 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
       } else {
         mergedText = finalText;
       }
+      const visibleStreamBlocks = existing.streamBlocks.filter(
+        (b) => b.block.kind !== "assistant" && b.block.kind !== "assistant_text",
+      );
+      if (!mergedText.trim() && (finalData.attachments?.length ?? 0) === 0 && visibleStreamBlocks.length === 0) {
+        const newMessages = state.messages.filter((_, i) => i !== idx);
+        return {
+          messages: newMessages,
+          activeTraceId: null,
+        };
+      }
+
       const finalizedMsg: OwnerChatMessage = {
         ...existing,
         hubMsgId: finalData.hubMsgId,
@@ -519,7 +547,7 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
         attachments: finalData.attachments,
         status: "delivered",
         // Keep only execution blocks (assistant text now lives in `text`)
-        streamBlocks: existing.streamBlocks.filter((b) => b.block.kind !== "assistant" && b.block.kind !== "assistant_text"),
+        streamBlocks: visibleStreamBlocks,
       };
 
       const newMessages = [...state.messages];
@@ -587,8 +615,9 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
 
       if (result.messages.length === 0) return;
 
-      const serverMsgs = result.messages.map((m) => dashboardMsgToOwnerChat(m, agentName));
-      const serverTexts = new Set(serverMsgs.map((m) => m.text));
+      const serverMsgs = result.messages
+        .map((m) => dashboardMsgToOwnerChat(m, agentName))
+        .filter(hasVisibleOwnerChatContent);
 
       set((state) => {
         const existingHubIds = new Set(


### PR DESCRIPTION
## Summary
- filter owner-chat delivered messages that have no visible text, attachments, or stream blocks
- skip rendering empty delivered bubbles while preserving stream/tool/reasoning block displays
- add owner-chat store regression coverage for empty messages alongside existing room-summary tests

## Tests
- npm run test -- src/store/useOwnerChatStore.test.ts src/store/useDashboardChatStore.test.ts --run
- NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build