### PR TITLE
fix: reduce messages refresh requests

### DIFF
--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -720,17 +720,8 @@ export default function DashboardApp() {
   ]);
 
   useEffect(() => {
-    if (!sessionStore.authResolved) return;
+    if (!sessionStore.authResolved || routeSidebarTab !== "messages") return;
 
-    if (!chatStore.publicRoomsLoaded && !chatStore.publicRoomsLoading) {
-      void chatStore.loadPublicRooms();
-    }
-    if (!chatStore.publicAgentsLoaded && !chatStore.publicAgentsLoading) {
-      void chatStore.loadPublicAgents();
-    }
-    if (!chatStore.publicHumansLoaded && !chatStore.publicHumansLoading) {
-      void chatStore.loadPublicHumans();
-    }
     if (
       sessionStore.activeIdentity?.type === "human"
       && !chatStore.ownedAgentRoomsLoaded
@@ -741,17 +732,9 @@ export default function DashboardApp() {
   }, [
     sessionStore.authResolved,
     sessionStore.activeIdentity?.type,
-    chatStore.publicRoomsLoaded,
-    chatStore.publicRoomsLoading,
-    chatStore.publicAgentsLoaded,
-    chatStore.publicAgentsLoading,
-    chatStore.publicHumansLoaded,
-    chatStore.publicHumansLoading,
+    routeSidebarTab,
     chatStore.ownedAgentRoomsLoaded,
     chatStore.ownedAgentRoomsLoading,
-    chatStore.loadPublicRooms,
-    chatStore.loadPublicAgents,
-    chatStore.loadPublicHumans,
     chatStore.loadOwnedAgentRooms,
   ]);
 
@@ -762,6 +745,7 @@ export default function DashboardApp() {
       sessionStore.sessionMode !== "authed-ready"
       && sessionStore.sessionMode !== "authed-no-agent"
     ) return;
+    if (uiStore.sidebarTab !== "wallet") return;
     if (!sessionStore.activeIdentity) return;
 
     if (!walletStore.wallet && !walletStore.walletLoading && !walletStore.walletError) {
@@ -777,6 +761,7 @@ export default function DashboardApp() {
   }, [
     sessionStore.sessionMode,
     sessionStore.activeIdentity,
+    uiStore.sidebarTab,
     walletStore.wallet,
     walletStore.walletLoading,
     walletStore.walletError,

--- a/frontend/src/components/dashboard/README.md
+++ b/frontend/src/components/dashboard/README.md
@@ -77,6 +77,7 @@ dashboard/
 
 ## 变更日志
 
+- 2026-05-19: `/chats/messages` 刷新不再预取其它 tab 的 RSC 路由，也不再后台预热公开目录和钱包接口；MessagesPanel 复用 Sidebar 的联系人请求加载，避免 received/sent/pending-approvals 重复请求。
 - 2026-05-14: `DashboardShellSkeleton.tsx`、`DashboardApp.tsx`、`Sidebar.tsx` 与 `ChatPane.tsx` 改为按 `/chats` 当前路径推导首帧 tab；刷新 Home/Explore/Contacts/Wallet/My Bots 时不再误用 Messages 会话骨架或默认消息视图。
 - 2026-05-14: 移除 Messages 里的 Bot 身份切换能力；点击自有 Bot 私聊、Bot 详情私聊、联系人里的 owned-bot 私聊都不再重绑 chat store 或强制刷新消息列表。
 - 2026-05-13: `messages` 分组侧栏只在已登录状态展示；游客态保留公开消息列表，不再显示分组栏或展开分组按钮。

--- a/frontend/src/components/dashboard/sidebar/MessagesPanel.tsx
+++ b/frontend/src/components/dashboard/sidebar/MessagesPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { startTransition, useEffect, useMemo, useState } from "react";
+import { startTransition, useMemo, useState } from "react";
 // messagesFilter is in useDashboardUIStore so ChatPane can also read it.
 import { useRouter } from "nextjs-toploader/app";
 import { useLanguage } from "@/lib/i18n";
@@ -55,15 +55,11 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
     setOpenedTopicId: s.setOpenedTopicId,
   })));
   const contactRequestsReceived = useDashboardContactStore((s) => s.contactRequestsReceived);
-  const loadContactRequests = useDashboardContactStore((s) => s.loadContactRequests);
   const pendingRequests = useMemo(
     () => contactRequestsReceived.filter((r) => r.state === "pending"),
     [contactRequestsReceived],
   );
   const pendingRequestCount = pendingRequests.length;
-  useEffect(() => {
-    void loadContactRequests();
-  }, [loadContactRequests]);
   const { overview, messages, recentVisitedRooms, ownedAgentRooms } = useDashboardChatStore(useShallow((s) => ({
     overview: s.overview,
     messages: s.messages,

--- a/frontend/src/components/dashboard/sidebar/index.tsx
+++ b/frontend/src/components/dashboard/sidebar/index.tsx
@@ -285,18 +285,6 @@ export default function Sidebar({
     if (!isGuest) void contactStore.loadContactRequests();
   }, [contactStore.loadContactRequests, isGuest]);
 
-  useEffect(() => {
-    const prefetch = (path: string) => {
-      if (typeof router.prefetch !== "function") return;
-      void router.prefetch(path);
-    };
-    prefetch("/chats/messages");
-    prefetch(`/chats/contacts/${uiStore.contactsView}`);
-    prefetch(`/chats/explore/${uiStore.exploreView}`);
-    prefetch("/chats/wallet");
-    prefetch("/chats/activity");
-  }, [router, uiStore.contactsView, uiStore.exploreView]);
-
   const showLoginModal = () => router.push("/login");
 
   const navigatePrimaryTab = (tab: "home" | "messages" | "contacts" | "explore" | "wallet" | "activity" | "bots") => {


### PR DESCRIPTION
## Summary
- stop prefetching other dashboard tabs from the messages sidebar
- avoid loading public directory and wallet data during messages refresh
- reuse the Sidebar contact request load instead of firing a duplicate MessagesPanel load

## Tests
- npm test -- --run

Note: npm run build still needs local Supabase env vars for /admin/codes prerendering.