### PR TITLE
fix: preserve owner chat previews in messages

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -228,6 +228,9 @@ async def _build_rooms_from_sql(
             "max_members",
             "slow_mode_seconds",
             "members_preview",
+            "last_message_preview",
+            "last_message_at",
+            "last_sender_name",
         )
         for item in mapped:
             room_id = item.get("room_id")
@@ -237,7 +240,7 @@ async def _build_rooms_from_sql(
             if fallback is None:
                 continue
             for key in fill_keys:
-                if key not in item:
+                if key not in item or item.get(key) is None:
                     item[key] = fallback.get(key)
         missing_rooms = [room for room in orm_rooms if room["room_id"] not in sql_room_ids]
         combined = mapped if not missing_rooms else _sort_room_previews(mapped + missing_rooms)

--- a/backend/app/routers/humans.py
+++ b/backend/app/routers/humans.py
@@ -728,7 +728,12 @@ async def list_owned_agent_only_rooms(
     response_rooms: list[HumanAgentRoomSummary] = []
     for room_id, preview in rooms_by_id.items():
         owner_id = str(preview.get("owner_id") or "")
-        if room_id in human_member_room_ids or owner_id == human_id:
+        # Owner-chat rooms are rendered through the bot-owned conversation
+        # surface even when legacy/backfill data has also seated the Human.
+        if (
+            not room_id.startswith("rm_oc_")
+            and (room_id in human_member_room_ids or owner_id == human_id)
+        ):
             continue
         bots = list(bots_by_room.get(room_id, {}).values())
         if not bots:

--- a/backend/tests/test_app/test_app_humans.py
+++ b/backend/tests/test_app/test_app_humans.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import base64
 import datetime
 import hashlib
+import json
 import time
 import uuid
 from unittest.mock import AsyncMock
@@ -27,8 +28,9 @@ import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.sql.elements import TextClause
 
-from hub.enums import RoomInvitePolicy, RoomJoinPolicy, RoomVisibility
+from hub.enums import MessageState, RoomInvitePolicy, RoomJoinPolicy, RoomVisibility
 from hub.models import (
     Agent,
     AgentApprovalQueue,
@@ -39,6 +41,7 @@ from hub.models import (
     ContactRequest,
     ContactRequestState,
     MessagePolicy,
+    MessageRecord,
     ParticipantType,
     Role,
     Room,
@@ -612,6 +615,148 @@ async def test_list_owned_agent_rooms_excludes_current_human_rooms(
         {"agent_id": "ag_peer000001", "avatar_url": None, "display_name": "Peer Bot"},
         {"agent_id": "ag_third00001", "avatar_url": None, "display_name": "Third Bot"},
     ]
+
+
+@pytest.mark.asyncio
+async def test_list_owned_agent_rooms_keeps_owner_chat_even_with_human_member(
+    client, seed, db_session: AsyncSession
+):
+    agent = Agent(
+        agent_id="ag_aliceowner1",
+        display_name="Alice Owner Bot",
+        message_policy=MessagePolicy.open,
+        user_id=seed["user_id"],
+    )
+    room = Room(
+        room_id="rm_oc_aliceowner1",
+        name="Alice Owner Bot",
+        description="Owner chat",
+        owner_id="ag_aliceowner1",
+        owner_type=ParticipantType.agent,
+        visibility=RoomVisibility.private,
+        join_policy=RoomJoinPolicy.invite_only,
+    )
+    db_session.add_all([
+        agent,
+        room,
+        RoomMember(
+            room_id="rm_oc_aliceowner1",
+            agent_id="ag_aliceowner1",
+            participant_type=ParticipantType.agent,
+            role=RoomRole.owner,
+        ),
+        RoomMember(
+            room_id="rm_oc_aliceowner1",
+            agent_id=seed["human_id"],
+            participant_type=ParticipantType.human,
+            role=RoomRole.member,
+        ),
+        MessageRecord(
+            hub_msg_id="hm_ownerchat001",
+            msg_id="msg_ownerchat001",
+            sender_id=seed["human_id"],
+            receiver_id="ag_aliceowner1",
+            room_id="rm_oc_aliceowner1",
+            envelope_json=json.dumps({
+                "from": seed["human_id"],
+                "type": "message",
+                "payload": {"text": "owner chat latest"},
+            }),
+            state=MessageState.delivered,
+            ttl_sec=3600,
+        ),
+    ])
+    await db_session.commit()
+
+    resp = await client.get(
+        "/api/humans/me/agent-rooms",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+    )
+    assert resp.status_code == 200, resp.text
+    rooms = {room["room_id"]: room for room in resp.json()["rooms"]}
+    assert rooms["rm_oc_aliceowner1"]["last_message_preview"] == "owner chat latest"
+    assert rooms["rm_oc_aliceowner1"]["last_message_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_sql_room_preview_nulls_are_filled_from_orm_fallback(
+    seed, db_session: AsyncSession, monkeypatch
+):
+    from app.routers.dashboard import _build_rooms_from_sql
+
+    agent = Agent(
+        agent_id="ag_previewfill1",
+        display_name="Preview Fill Bot",
+        message_policy=MessagePolicy.open,
+        user_id=seed["user_id"],
+    )
+    room = Room(
+        room_id="rm_previewfill1",
+        name="Preview Fill",
+        description="Preview fallback",
+        owner_id="ag_previewfill1",
+        owner_type=ParticipantType.agent,
+        visibility=RoomVisibility.private,
+        join_policy=RoomJoinPolicy.invite_only,
+    )
+    db_session.add_all([
+        agent,
+        room,
+        RoomMember(
+            room_id="rm_previewfill1",
+            agent_id="ag_previewfill1",
+            participant_type=ParticipantType.agent,
+            role=RoomRole.owner,
+        ),
+        MessageRecord(
+            hub_msg_id="hm_previewfill1",
+            msg_id="msg_previewfill1",
+            sender_id="ag_previewfill1",
+            receiver_id="ag_previewfill1",
+            room_id="rm_previewfill1",
+            envelope_json=json.dumps({
+                "from": "ag_previewfill1",
+                "type": "message",
+                "payload": {"text": "filled by orm fallback"},
+            }),
+            state=MessageState.delivered,
+            ttl_sec=3600,
+        ),
+    ])
+    await db_session.commit()
+
+    real_execute = db_session.execute
+
+    class _MappingsResult:
+        def mappings(self):
+            return self
+
+        def all(self):
+            return [{
+                "room_id": "rm_previewfill1",
+                "room_name": "Preview Fill",
+                "room_description": "Preview fallback",
+                "owner_id": "ag_previewfill1",
+                "visibility": "private",
+                "member_count": 1,
+                "my_role": "owner",
+                "last_message_preview": None,
+                "last_message_at": None,
+                "last_sender_name": None,
+            }]
+
+    async def execute_with_null_sql_preview(statement, *args, **kwargs):
+        if isinstance(statement, TextClause) and "get_agent_room_previews" in str(statement):
+            return _MappingsResult()
+        return await real_execute(statement, *args, **kwargs)
+
+    monkeypatch.setattr(db_session, "execute", execute_with_null_sql_preview)
+
+    rooms = await _build_rooms_from_sql("ag_previewfill1", db_session)
+    assert rooms[0]["room_id"] == "rm_previewfill1"
+    assert rooms[0]["last_message_preview"] == "filled by orm fallback"
+    assert rooms[0]["last_message_at"] is not None
+    assert rooms[0]["last_sender_name"] == "Preview Fill Bot"
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -720,17 +720,8 @@ export default function DashboardApp() {
   ]);
 
   useEffect(() => {
-    if (!sessionStore.authResolved) return;
+    if (!sessionStore.authResolved || routeSidebarTab !== "messages") return;
 
-    if (!chatStore.publicRoomsLoaded && !chatStore.publicRoomsLoading) {
-      void chatStore.loadPublicRooms();
-    }
-    if (!chatStore.publicAgentsLoaded && !chatStore.publicAgentsLoading) {
-      void chatStore.loadPublicAgents();
-    }
-    if (!chatStore.publicHumansLoaded && !chatStore.publicHumansLoading) {
-      void chatStore.loadPublicHumans();
-    }
     if (
       sessionStore.activeIdentity?.type === "human"
       && !chatStore.ownedAgentRoomsLoaded
@@ -741,17 +732,9 @@ export default function DashboardApp() {
   }, [
     sessionStore.authResolved,
     sessionStore.activeIdentity?.type,
-    chatStore.publicRoomsLoaded,
-    chatStore.publicRoomsLoading,
-    chatStore.publicAgentsLoaded,
-    chatStore.publicAgentsLoading,
-    chatStore.publicHumansLoaded,
-    chatStore.publicHumansLoading,
+    routeSidebarTab,
     chatStore.ownedAgentRoomsLoaded,
     chatStore.ownedAgentRoomsLoading,
-    chatStore.loadPublicRooms,
-    chatStore.loadPublicAgents,
-    chatStore.loadPublicHumans,
     chatStore.loadOwnedAgentRooms,
   ]);
 
@@ -762,6 +745,7 @@ export default function DashboardApp() {
       sessionStore.sessionMode !== "authed-ready"
       && sessionStore.sessionMode !== "authed-no-agent"
     ) return;
+    if (uiStore.sidebarTab !== "wallet") return;
     if (!sessionStore.activeIdentity) return;
 
     if (!walletStore.wallet && !walletStore.walletLoading && !walletStore.walletError) {
@@ -777,6 +761,7 @@ export default function DashboardApp() {
   }, [
     sessionStore.sessionMode,
     sessionStore.activeIdentity,
+    uiStore.sidebarTab,
     walletStore.wallet,
     walletStore.walletLoading,
     walletStore.walletError,

--- a/frontend/src/components/dashboard/README.md
+++ b/frontend/src/components/dashboard/README.md
@@ -77,6 +77,7 @@ dashboard/
 
 ## 变更日志
 
+- 2026-05-19: `/chats/messages` 刷新不再预取其它 tab 的 RSC 路由，也不再后台预热公开目录和钱包接口；MessagesPanel 复用 Sidebar 的联系人请求加载，避免 received/sent/pending-approvals 重复请求。
 - 2026-05-14: `DashboardShellSkeleton.tsx`、`DashboardApp.tsx`、`Sidebar.tsx` 与 `ChatPane.tsx` 改为按 `/chats` 当前路径推导首帧 tab；刷新 Home/Explore/Contacts/Wallet/My Bots 时不再误用 Messages 会话骨架或默认消息视图。
 - 2026-05-14: 移除 Messages 里的 Bot 身份切换能力；点击自有 Bot 私聊、Bot 详情私聊、联系人里的 owned-bot 私聊都不再重绑 chat store 或强制刷新消息列表。
 - 2026-05-13: `messages` 分组侧栏只在已登录状态展示；游客态保留公开消息列表，不再显示分组栏或展开分组按钮。

--- a/frontend/src/components/dashboard/sidebar/MessagesPanel.tsx
+++ b/frontend/src/components/dashboard/sidebar/MessagesPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { startTransition, useEffect, useMemo, useState } from "react";
+import { startTransition, useMemo, useState } from "react";
 // messagesFilter is in useDashboardUIStore so ChatPane can also read it.
 import { useRouter } from "nextjs-toploader/app";
 import { useLanguage } from "@/lib/i18n";
@@ -55,15 +55,11 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
     setOpenedTopicId: s.setOpenedTopicId,
   })));
   const contactRequestsReceived = useDashboardContactStore((s) => s.contactRequestsReceived);
-  const loadContactRequests = useDashboardContactStore((s) => s.loadContactRequests);
   const pendingRequests = useMemo(
     () => contactRequestsReceived.filter((r) => r.state === "pending"),
     [contactRequestsReceived],
   );
   const pendingRequestCount = pendingRequests.length;
-  useEffect(() => {
-    void loadContactRequests();
-  }, [loadContactRequests]);
   const { overview, messages, recentVisitedRooms, ownedAgentRooms } = useDashboardChatStore(useShallow((s) => ({
     overview: s.overview,
     messages: s.messages,

--- a/frontend/src/components/dashboard/sidebar/index.tsx
+++ b/frontend/src/components/dashboard/sidebar/index.tsx
@@ -285,18 +285,6 @@ export default function Sidebar({
     if (!isGuest) void contactStore.loadContactRequests();
   }, [contactStore.loadContactRequests, isGuest]);
 
-  useEffect(() => {
-    const prefetch = (path: string) => {
-      if (typeof router.prefetch !== "function") return;
-      void router.prefetch(path);
-    };
-    prefetch("/chats/messages");
-    prefetch(`/chats/contacts/${uiStore.contactsView}`);
-    prefetch(`/chats/explore/${uiStore.exploreView}`);
-    prefetch("/chats/wallet");
-    prefetch("/chats/activity");
-  }, [router, uiStore.contactsView, uiStore.exploreView]);
-
   const showLoginModal = () => router.push("/login");
 
   const navigatePrimaryTab = (tab: "home" | "messages" | "contacts" | "explore" | "wallet" | "activity" | "bots") => {


### PR DESCRIPTION
## Summary
- preserve rm_oc owner-chat rooms in the human-owned agent room list even when legacy data also seats the human
- fill null SQL room preview fields from the ORM fallback so last message time, preview, and sender survive refresh
- add regression coverage for owner-chat list summaries and null SQL preview fallback

## Tests
- cd backend && uv run pytest tests/test_app/test_app_humans.py -q
- cd backend && uv run pytest tests/test_app/test_app_dashboard.py tests/test_app/test_app_invites.py -q