### PR TITLE
fix: use provider reply ids for gateway replies

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -170,6 +170,7 @@ jobs:
           if git ls-files --error-unmatch package-lock.json >/dev/null 2>&1; then
             git add package-lock.json
           fi
+          git add -u .
           case "$PKG" in
             cli) TAG_PREFIX="cli-" ;;
             protocol-core) TAG_PREFIX="protocol-core-" ;;

--- a/cli/dist/commands/bind.js
+++ b/cli/dist/commands/bind.js
@@ -4,14 +4,17 @@ import { normalizeAndValidateHubUrl } from "../hub-url.js";
 import { outputError, outputJson } from "../output.js";
 export async function bindCommand(args, globalHub, globalAgent) {
     if (args.flags["help"]) {
-        console.log(`Usage: botcord bind <bind_code_or_bind_ticket>
+        console.log(`Usage: botcord bind <bind_ticket>
 
 Bind the current BotCord agent to a BotCord web dashboard account.`);
         return;
     }
     const bindCredential = args.subcommand || args.positionals[0];
     if (!bindCredential)
-        outputError("bind code or bind ticket is required");
+        outputError("bind ticket is required");
+    if (bindCredential.startsWith("bd_")) {
+        outputError("bind codes are no longer supported; pass a bind ticket");
+    }
     const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
     const hubUrl = normalizeAndValidateHubUrl(globalHub || creds.hubUrl);
     const client = new BotCordClient({
@@ -34,9 +37,7 @@ Bind the current BotCord agent to a BotCord web dashboard account.`);
             agent_id: creds.agentId,
             display_name: displayName,
             agent_token: agentToken,
-            ...(bindCredential.startsWith("bd_")
-                ? { bind_code: bindCredential }
-                : { bind_ticket: bindCredential }),
+            bind_ticket: bindCredential,
         }),
         signal: AbortSignal.timeout(15000),
     });

--- a/cli/package.json
+++ b/cli/package.json
@@ -4,7 +4,7 @@
   "description": "BotCord CLI — register agents, send signed messages, manage rooms and contacts",
   "type": "module",
   "bin": {
-    "botcord": "./dist/index.js"
+    "botcord": "dist/index.js"
   },
   "scripts": {
     "build": "tsc",
@@ -23,7 +23,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/botlearn-ai/botcord",
+    "url": "git+https://github.com/botlearn-ai/botcord.git",
     "directory": "cli"
   },
   "publishConfig": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -4,7 +4,7 @@
   "description": "BotCord local daemon — bridges Hub inbox push to local Claude Code / Codex / Gemini CLIs",
   "type": "module",
   "bin": {
-    "botcord-daemon": "./dist/index.js"
+    "botcord-daemon": "dist/index.js"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
+++ b/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
@@ -293,6 +293,30 @@ describe("Dispatcher", () => {
     expect(store.all()[0].threadId).toBe("t_1");
   });
 
+  it("sends replies to the provider reply id when it differs from the internal message id", async () => {
+    const runtime = new FakeRuntime({ reply: "ok" });
+    const feishuChannel = new FakeChannel({ id: "gw_feishu_1", type: "feishu" });
+    const { dispatcher, channel } = await scaffold({
+      runtimeFactory: () => runtime,
+      channel: feishuChannel,
+      config: baseConfig({
+        channels: [{ id: "gw_feishu_1", type: "feishu", accountId: "ag_me" }],
+      }),
+    });
+
+    await dispatcher.handle(
+      makeEnvelope({
+        id: "feishu:om_internal_wrapped",
+        replyTo: "om_provider_raw",
+        channel: "gw_feishu_1",
+        conversation: { id: "feishu:user:oc_chat", kind: "direct" },
+      }),
+    );
+
+    expect(channel.sends.length).toBe(1);
+    expect(channel.sends[0].message.replyTo).toBe("om_provider_raw");
+  });
+
   it("reuses session id on second message with same queue key", async () => {
     const seen: Array<string | null> = [];
     const runtime = new FakeRuntime({
@@ -2009,7 +2033,8 @@ describe("Dispatcher", () => {
     });
     await dispatcher.handle(
       makeEnvelope({
-        id: "m_err",
+        id: "feishu:om_internal_err",
+        replyTo: "om_provider_err",
         conversation: { id: "rm_g_other", kind: "group" },
       }),
     );
@@ -2017,7 +2042,7 @@ describe("Dispatcher", () => {
     expect(channel.sends[0].message.type).toBe("error");
     expect(channel.sends[0].message.text).toContain("Runtime error: boom");
     expect(channel.sends[0].message.conversationId).toBe("rm_g_other");
-    expect(channel.sends[0].message.replyTo).toBe("m_err");
+    expect(channel.sends[0].message.replyTo).toBe("om_provider_err");
   });
 
   // ─────────────────────────────────────────────────────────────────────

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -1343,7 +1343,7 @@ export class Dispatcher {
             threadId: msg.conversation.threadId ?? null,
             type: "error",
             text: `⚠️ Runtime timeout after ${Math.round(this.turnTimeoutMs / 60000)} minute(s); aborted`,
-            replyTo: msg.id,
+            replyTo: this.providerReplyTo(msg),
             traceId: msg.trace?.id ?? null,
           }, turnId);
         } else {
@@ -1389,7 +1389,7 @@ export class Dispatcher {
             threadId: msg.conversation.threadId ?? null,
             type: "error",
             text: `⚠️ Runtime error: ${truncate(errMsg, 500)}`,
-            replyTo: msg.id,
+            replyTo: this.providerReplyTo(msg),
             traceId: msg.trace?.id ?? null,
           }, turnId);
         } else {
@@ -1494,7 +1494,7 @@ export class Dispatcher {
               threadId: msg.conversation.threadId ?? null,
               type: "error",
               text: `⚠️ Runtime error: ${truncate(result.error, 500)}`,
-              replyTo: msg.id,
+              replyTo: this.providerReplyTo(msg),
               traceId: msg.trace?.id ?? null,
             }, turnId);
             this.emitOutbound({
@@ -1571,7 +1571,7 @@ export class Dispatcher {
         conversationId: msg.conversation.id,
         threadId: msg.conversation.threadId ?? null,
         text: replyText,
-        replyTo: msg.id,
+        replyTo: this.providerReplyTo(msg),
         traceId: msg.trace?.id ?? null,
       }, turnId);
       this.emitOutbound({
@@ -1636,6 +1636,10 @@ export class Dispatcher {
       }
     }
     return { ok: true };
+  }
+
+  private providerReplyTo(msg: GatewayInboundMessage): string {
+    return msg.replyTo ?? msg.id;
   }
 
   private emitInbound(turnId: string, msg: GatewayInboundEnvelope["message"]): void {


### PR DESCRIPTION
## Summary
- use the provider-native inbound reply id when dispatching gateway replies
- apply the same provider reply id behavior to normal replies and runtime diagnostic replies
- add dispatcher coverage for gateway messages where internal ids differ from provider ids

## Testing
- cd packages/daemon && npm test -- --run src/gateway/__tests__/dispatcher.test.ts src/gateway/__tests__/feishu-channel.test.ts
- cd packages/daemon && npm run build