### PR TITLE
fix: surface codex tool stream details

### DIFF
--- a/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
+++ b/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer, type WebSocket as WsType } from "ws";
 import type { AddressInfo } from "node:net";
-import { createBotCordChannel, type BotCordChannelClient } from "../channels/botcord.js";
+import {
+  createBotCordChannel,
+  __normalizeBlockForHubForTests,
+  type BotCordChannelClient,
+} from "../channels/botcord.js";
 import type { ChannelStartContext, GatewayInboundEnvelope } from "../types.js";
 import type { GatewayLogger } from "../log.js";
 import type { InboxMessage } from "@botcord/protocol-core";
@@ -649,6 +653,89 @@ describe("createBotCordChannel — ack + dedup", () => {
 // ---------------------------------------------------------------------------
 
 describe("createBotCordChannel — streamBlock()", () => {
+  it("normalizes Codex tool items without using internal ids as params", () => {
+    expect(
+      __normalizeBlockForHubForTests(
+        {
+          kind: "tool_use",
+          seq: 1,
+          raw: {
+            type: "item.started",
+            item: { id: "item_26", type: "command_execution", command: "rg stream-block" },
+          },
+        },
+        1,
+      ),
+    ).toEqual({
+      kind: "tool_call",
+      seq: 1,
+      payload: {
+        name: "command_execution",
+        id: "item_26",
+        params: { command: "rg stream-block" },
+      },
+    });
+
+    expect(
+      __normalizeBlockForHubForTests(
+        {
+          kind: "tool_use",
+          seq: 2,
+          raw: {
+            type: "item.started",
+            item: {
+              id: "ws_abc",
+              type: "web_search",
+              action: { type: "search", query: "codex stream response" },
+            },
+          },
+        },
+        2,
+      ),
+    ).toEqual({
+      kind: "tool_call",
+      seq: 2,
+      payload: {
+        name: "web_search",
+        id: "ws_abc",
+        params: {
+          action: { type: "search", query: "codex stream response" },
+          query: "codex stream response",
+        },
+      },
+    });
+  });
+
+  it("normalizes Codex completed tool items as results", () => {
+    expect(
+      __normalizeBlockForHubForTests(
+        {
+          kind: "tool_result",
+          seq: 3,
+          raw: {
+            type: "item.completed",
+            item: {
+              id: "item_26",
+              type: "command_execution",
+              status: "completed",
+              exit_code: 0,
+              output: "found 3 matches",
+            },
+          },
+        },
+        3,
+      ),
+    ).toEqual({
+      kind: "tool_result",
+      seq: 3,
+      payload: {
+        name: "command_execution",
+        tool_use_id: "item_26",
+        result: "status: completed\nexit_code: 0\nfound 3 matches",
+      },
+    });
+  });
+
   it("POSTs to /hub/stream-block with the right trace_id + block", async () => {
     const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
     const realFetch = globalThis.fetch;

--- a/packages/daemon/src/gateway/__tests__/codex-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/codex-adapter.test.ts
@@ -77,13 +77,14 @@ process.exit(0);
     expect(res.error).toBeUndefined();
   });
 
-  it("emits tool_use StreamBlock for command_execution items", async () => {
+  it("emits tool_use/tool_result StreamBlocks for command_execution items", async () => {
     const script = makeScript(
       "toolblock.js",
       `
 const lines = [
   {type:"thread.started", thread_id:"01234567-89ab-7def-8123-456789abcde0"},
   {type:"item.started", item:{id:"i0", type:"command_execution", command:"ls"}},
+  {type:"item.completed", item:{id:"i0", type:"command_execution", status:"completed", output:"ok"}},
   {type:"item.completed", item:{id:"i1", type:"agent_message", text:"done"}},
 ];
 for (const l of lines) process.stdout.write(JSON.stringify(l) + "\\n");
@@ -103,6 +104,7 @@ for (const l of lines) process.stdout.write(JSON.stringify(l) + "\\n");
     });
     expect(res.text).toBe("done");
     expect(seen).toContain("tool_use");
+    expect(seen).toContain("tool_result");
     expect(seen).toContain("assistant_text");
     expect(seen).toContain("system");
   });

--- a/packages/daemon/src/gateway/channels/botcord.ts
+++ b/packages/daemon/src/gateway/channels/botcord.ts
@@ -979,7 +979,7 @@ function normalizeBlockForHub(
 
   if (kind === "tool_use") {
     // Claude Code: assistant message w/ content[].type === "tool_use" → {id,name,input}
-    // Codex:       item.started / item.completed for command_execution, file_change, mcp_tool_call, web_search
+    // Codex:       item.started for command_execution, file_change, mcp_tool_call, web_search
     const contents = Array.isArray(raw?.message?.content) ? raw.message.content : [];
     const tu = contents.find((c: any) => c?.type === "tool_use");
     if (tu) {
@@ -988,13 +988,17 @@ function normalizeBlockForHub(
       if (typeof tu.id === "string") payload.id = tu.id;
     } else if (raw?.item && typeof raw.item === "object") {
       payload.name = typeof raw.item.type === "string" ? raw.item.type : "tool";
-      payload.params = raw.item;
+      const params = codexToolParams(raw.item);
+      if (Object.keys(params).length > 0) payload.params = params;
+      if (typeof raw.item.id === "string") payload.id = raw.item.id;
+      if (typeof raw.item.status === "string") payload.status = raw.item.status;
     }
     return { kind: "tool_call", seq, payload };
   }
 
   if (kind === "tool_result") {
     // Claude Code: {type:"user", message:{content:[{type:"tool_result",tool_use_id,content}]}}
+    // Codex:       item.completed for command_execution, file_change, mcp_tool_call, web_search
     const contents = Array.isArray(raw?.message?.content) ? raw.message.content : [];
     const tr = contents.find((c: any) => c?.type === "tool_result");
     if (tr) {
@@ -1008,6 +1012,11 @@ function normalizeBlockForHub(
       }
       payload.result = resultStr;
       if (typeof tr.tool_use_id === "string") payload.tool_use_id = tr.tool_use_id;
+    } else if (raw?.item && typeof raw.item === "object") {
+      payload.name = typeof raw.item.type === "string" ? raw.item.type : "tool";
+      if (typeof raw.item.id === "string") payload.tool_use_id = raw.item.id;
+      const result = codexToolResult(raw.item);
+      if (result) payload.result = result;
     }
     return { kind: "tool_result", seq, payload };
   }
@@ -1060,6 +1069,56 @@ function formatBlockDetails(raw: unknown): string {
   } catch {
     return String(raw);
   }
+}
+
+function codexToolParams(item: Record<string, unknown>): Record<string, unknown> {
+  const params: Record<string, unknown> = {};
+  for (const key of [
+    "command",
+    "cmd",
+    "args",
+    "path",
+    "query",
+    "url",
+    "name",
+    "input",
+    "arguments",
+    "action",
+    "changes",
+  ]) {
+    const value = item[key];
+    if (value !== undefined && value !== null && value !== "") params[key] = value;
+  }
+
+  const action = item.action as Record<string, unknown> | undefined;
+  if (action && typeof action === "object") {
+    for (const key of ["query", "url", "command", "path"]) {
+      const value = action[key];
+      if (value !== undefined && value !== null && value !== "") params[key] = value;
+    }
+  }
+
+  return params;
+}
+
+function codexToolResult(item: Record<string, unknown>): string {
+  const parts: string[] = [];
+  const status = typeof item.status === "string" ? item.status : "";
+  const exitCode = item.exit_code ?? item.exitCode;
+  if (status) parts.push(`status: ${status}`);
+  if (typeof exitCode === "number" || typeof exitCode === "string") parts.push(`exit_code: ${exitCode}`);
+
+  for (const key of ["output", "stdout", "stderr", "aggregated_output", "result", "summary"]) {
+    const value = item[key];
+    if (typeof value === "string" && value.trim()) parts.push(value.trim());
+  }
+
+  const results = item.results;
+  if (Array.isArray(results) && results.length > 0) {
+    parts.push(JSON.stringify(results, null, 2));
+  }
+
+  return parts.join("\n");
 }
 
 function extractContentText(content: unknown): string {

--- a/packages/daemon/src/gateway/runtimes/codex.ts
+++ b/packages/daemon/src/gateway/runtimes/codex.ts
@@ -420,7 +420,7 @@ function normalizeBlock(obj: any, seq: number): StreamBlock {
       itemType === "mcp_tool_call" ||
       itemType === "web_search"
     ) {
-      kind = "tool_use";
+      kind = type === "item.completed" ? "tool_result" : "tool_use";
     }
   }
   return { raw: obj, kind, seq };


### PR DESCRIPTION
## Summary
- classify Codex completed tool events as tool results instead of duplicate tool calls
- surface readable Codex tool params and results instead of internal item ids
- add regression coverage for Codex tool stream normalization

## Tests
- cd packages/daemon && npm run build
- cd packages/daemon && npm test -- src/gateway/__tests__/codex-adapter.test.ts src/gateway/__tests__/botcord-channel.test.ts