### PR TITLE
fix: use working memory as single memory source

### DIFF
--- a/backend/app/routers/runtime_files.py
+++ b/backend/app/routers/runtime_files.py
@@ -30,7 +30,7 @@ router = APIRouter(prefix="/api/agents", tags=["app-runtime-files"])
 class AgentRuntimeFileOut(BaseModel):
     id: str
     name: str
-    scope: Literal["workspace", "hermes", "openclaw"]
+    scope: Literal["workspace", "memory", "hermes", "openclaw"]
     runtime: str | None = None
     profile: str | None = None
     size: int | None = None

--- a/backend/tests/test_app/test_app_policy.py
+++ b/backend/tests/test_app/test_app_policy.py
@@ -234,10 +234,10 @@ async def test_runtime_files_for_owned_daemon_agent_dispatches_control_frame(
                 "runtime": "hermes-agent",
                 "files": [
                     {
-                        "id": "workspace:memory.md",
-                        "name": "workspace/memory.md",
-                        "scope": "workspace",
-                        "content": "# Memory\n",
+                        "id": "memory:working-memory.json",
+                        "name": "memory/working-memory.json",
+                        "scope": "memory",
+                        "content": '{"sections":{}}\n',
                     }
                 ],
             },
@@ -247,16 +247,16 @@ async def test_runtime_files_for_owned_daemon_agent_dispatches_control_frame(
 
     headers = {"Authorization": f"Bearer {seed['token']}"}
     r = await client.get(
-        "/api/agents/ag_owned/runtime-files?file_id=workspace%3Amemory.md",
+        "/api/agents/ag_owned/runtime-files?file_id=memory%3Aworking-memory.json",
         headers=headers,
     )
     assert r.status_code == 200, r.text
-    assert r.json()["files"][0]["content"] == "# Memory\n"
+    assert r.json()["files"][0]["content"] == '{"sections":{}}\n'
     assert calls == [
         {
             "daemon_instance_id": "dm_files",
             "type": "list_agent_files",
-            "params": {"agentId": "ag_owned", "fileId": "workspace:memory.md"},
+            "params": {"agentId": "ag_owned", "fileId": "memory:working-memory.json"},
             "timeout_ms": 5000,
         }
     ]

--- a/frontend/src/components/dashboard/AgentSettingsDrawer.tsx
+++ b/frontend/src/components/dashboard/AgentSettingsDrawer.tsx
@@ -34,7 +34,7 @@ type BotDetailDrawerCopy = typeof botDetailDrawer["en"];
 interface AgentRuntimeFile {
   id: string;
   name: string;
-  scope: "workspace" | "hermes" | "openclaw";
+  scope: "workspace" | "memory" | "hermes" | "openclaw";
   runtime?: string;
   profile?: string;
   size?: number;
@@ -179,6 +179,7 @@ function formatBytes(value?: number): string {
 }
 
 function scopeLabel(scope: AgentRuntimeFile["scope"]): string {
+  if (scope === "memory") return "Memory";
   if (scope === "hermes") return "Hermes";
   if (scope === "openclaw") return "OpenClaw";
   return "Workspace";

--- a/frontend/src/components/dashboard/BotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/BotDetailDrawer.tsx
@@ -54,7 +54,7 @@ const TABS: { key: TabKey; icon: React.ComponentType<{ className?: string }> }[]
 interface AgentRuntimeFile {
   id: string;
   name: string;
-  scope: "workspace" | "hermes" | "openclaw";
+  scope: "workspace" | "memory" | "hermes" | "openclaw";
   runtime?: string;
   profile?: string;
   size?: number;
@@ -1096,6 +1096,7 @@ function formatBytes(value?: number): string {
 }
 
 function scopeLabel(scope: AgentRuntimeFile["scope"]): string {
+  if (scope === "memory") return "Memory";
   if (scope === "hermes") return "Hermes";
   if (scope === "openclaw") return "OpenClaw";
   return "Workspace";

--- a/packages/daemon/src/__tests__/agent-workspace.test.ts
+++ b/packages/daemon/src/__tests__/agent-workspace.test.ts
@@ -60,9 +60,10 @@ describe("ensureAgentWorkspace", () => {
     expect(existsSync(state)).toBe(true);
     expect(existsSync(path.join(workspace, "notes"))).toBe(true);
 
-    for (const name of ["AGENTS.md", "CLAUDE.md", "identity.md", "memory.md", "task.md"]) {
+    for (const name of ["AGENTS.md", "CLAUDE.md", "identity.md", "task.md"]) {
       expect(existsSync(path.join(workspace, name))).toBe(true);
     }
+    expect(existsSync(path.join(workspace, "memory.md"))).toBe(false);
 
     const agentsMd = readFileSync(path.join(workspace, "AGENTS.md"), "utf8");
     const claudeMd = readFileSync(path.join(workspace, "CLAUDE.md"), "utf8");
@@ -172,16 +173,6 @@ describe("ensureAgentWorkspace", () => {
     );
     expect(existsSync(hermesWorkspace)).toBe(true);
     expect(existsSync(hermesHome)).toBe(false);
-  });
-
-  it("does not overwrite a user-modified memory.md on a second call", () => {
-    ensureAgentWorkspace("ag_keep", {});
-    const memoryPath = path.join(agentWorkspaceDir("ag_keep"), "memory.md");
-    writeFileSync(memoryPath, "my custom notes\n");
-
-    ensureAgentWorkspace("ag_keep", {});
-
-    expect(readFileSync(memoryPath, "utf8")).toBe("my custom notes\n");
   });
 
   it("seeds Hermes config and provider env without copying unrelated secrets", () => {

--- a/packages/daemon/src/__tests__/daemon.test.ts
+++ b/packages/daemon/src/__tests__/daemon.test.ts
@@ -255,12 +255,11 @@ describe("backfillBootAgents", () => {
 
   it("is idempotent: a second call leaves user-edited files alone", () => {
     backfillBootAgents([bootAgent("ag_one")], { logger: silentLogger() });
-    const memoryPath = path.join(agentWorkspaceDir("ag_one"), "memory.md");
-    const edited = "# My notes\n\nremembered thing\n";
-    // Simulate the LLM/user editing memory.md.
-    writeFileSync(memoryPath, edited);
+    const taskPath = path.join(agentWorkspaceDir("ag_one"), "task.md");
+    const edited = "# Current Task\n\nin progress\n";
+    writeFileSync(taskPath, edited);
     backfillBootAgents([bootAgent("ag_one")], { logger: silentLogger() });
-    expect(readFileSync(memoryPath, "utf8")).toBe(edited);
+    expect(readFileSync(taskPath, "utf8")).toBe(edited);
   });
 
   it("warns and continues when ensureAgentWorkspace throws for one agent", () => {

--- a/packages/daemon/src/__tests__/provision.test.ts
+++ b/packages/daemon/src/__tests__/provision.test.ts
@@ -175,8 +175,10 @@ describe("list_agent_files handler", () => {
       );
 
       const workspace = nodePath.join(tmp, ".botcord", "agents", "ag_hermes", "workspace");
+      const memoryDir = nodePath.join(tmp, ".botcord", "memory", "ag_hermes");
       fs.mkdirSync(workspace, { recursive: true });
-      fs.writeFileSync(nodePath.join(workspace, "memory.md"), "# Memory\nowned\n");
+      fs.mkdirSync(memoryDir, { recursive: true });
+      fs.writeFileSync(nodePath.join(memoryDir, "working-memory.json"), '{"sections":{}}\n');
       fs.writeFileSync(nodePath.join(workspace, "task.md"), "# Task\n");
 
       const hermesMem = nodePath.join(tmp, ".hermes", "memories");
@@ -196,7 +198,7 @@ describe("list_agent_files handler", () => {
       expect(result.agentId).toBe("ag_hermes");
       expect(result.runtime).toBe("hermes-agent");
       const byName = Object.fromEntries(result.files.map((f: any) => [f.name, f]));
-      expect(byName["workspace/memory.md"].content).toBe("# Memory\nowned\n");
+      expect(byName["memory/working-memory.json"].content).toBe('{"sections":{}}\n');
       expect(byName["workspace/task.md"].content).toBe("# Task\n");
       expect(byName["hermes/default/SOUL.md"].content).toBe("# Soul\n");
       expect(byName["hermes/default/memories/MEMORY.md"].content).toBe("# Hermes Memory\n");
@@ -231,7 +233,6 @@ describe("list_agent_files handler", () => {
       );
       const workspace = nodePath.join(tmp, ".botcord", "agents", "ag_one", "workspace");
       fs.mkdirSync(workspace, { recursive: true });
-      fs.writeFileSync(nodePath.join(workspace, "memory.md"), "# Memory\n");
       fs.writeFileSync(nodePath.join(workspace, "task.md"), "# Task\n");
 
       const handler = createProvisioner({ gateway: makeFakeGateway() as any });
@@ -246,6 +247,50 @@ describe("list_agent_files handler", () => {
       expect(result.files).toHaveLength(1);
       expect(result.files[0].name).toBe("workspace/task.md");
       expect(result.files[0].content).toBe("# Task\n");
+    } finally {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+    }
+  });
+
+  it("returns a stable empty working-memory file when none exists yet", async () => {
+    const os = await import("node:os");
+    const fs = await import("node:fs");
+    const nodePath = await import("node:path");
+
+    const tmp = fs.mkdtempSync(nodePath.join(os.tmpdir(), "daemon-runtime-files-"));
+    const prevHome = process.env.HOME;
+    process.env.HOME = tmp;
+    try {
+      const credDir = nodePath.join(tmp, ".botcord", "credentials");
+      fs.mkdirSync(credDir, { recursive: true });
+      fs.writeFileSync(
+        nodePath.join(credDir, "ag_empty_mem.json"),
+        JSON.stringify({
+          version: 1,
+          hubUrl: "https://hub.example",
+          agentId: "ag_empty_mem",
+          keyId: "k_empty_mem",
+          privateKey: Buffer.alloc(32, 9).toString("base64"),
+          runtime: "claude-code",
+        }),
+      );
+
+      const handler = createProvisioner({ gateway: makeFakeGateway() as any });
+      const res = await handler({
+        id: "req_empty_memory_file",
+        type: "list_agent_files",
+        params: { agentId: "ag_empty_mem", fileId: "memory:working-memory.json" },
+      });
+
+      expect(res.ok).toBe(true);
+      const result = res.result as any;
+      expect(result.files).toHaveLength(1);
+      expect(result.files[0].id).toBe("memory:working-memory.json");
+      expect(result.files[0].name).toBe("memory/working-memory.json");
+      expect(result.files[0].scope).toBe("memory");
+      expect(result.files[0].content).toContain('"version": 2');
+      expect(result.files[0].content).toContain('"sections": {}');
     } finally {
       if (prevHome === undefined) delete process.env.HOME;
       else process.env.HOME = prevHome;
@@ -704,7 +749,7 @@ async function withSandboxHome<T>(run: (sbx: SandboxFixture) => Promise<T>): Pro
   }
 }
 
-const SEED_FILES = ["AGENTS.md", "CLAUDE.md", "identity.md", "memory.md", "task.md"];
+const SEED_FILES = ["AGENTS.md", "CLAUDE.md", "identity.md", "task.md"];
 
 describe("provision_agent seeds workspace + hot-adds managed route", () => {
   it("defaults cwd to agentWorkspaceDir on the fast path (Hub-supplied credentials)", async () => {
@@ -1375,7 +1420,7 @@ function seedAgentOnDisk(
       savedAt: new Date().toISOString(),
     }),
   );
-  fs.writeFileSync(nodePath.join(workspaceDir, "memory.md"), "# Memory\nprecious\n");
+  fs.writeFileSync(nodePath.join(workspaceDir, "task.md"), "# Task\nprecious\n");
   fs.writeFileSync(nodePath.join(stateDir, "working-memory.json"), "{}");
   return { credFile, workspaceDir, stateDir, homeDir };
 }

--- a/packages/daemon/src/__tests__/system-context.test.ts
+++ b/packages/daemon/src/__tests__/system-context.test.ts
@@ -65,11 +65,12 @@ describe("createDaemonSystemContextBuilder", () => {
     expect(out).toContain("cannot access this machine's local filesystem");
   });
 
-  it("returns undefined for direct rooms when working memory is empty and no activity tracker is wired", () => {
+  it("injects the empty working-memory block even when no memory file exists", () => {
     const builder = createDaemonSystemContextBuilder({ agentId: "ag_me" });
-    expect(
-      builder(makeMessage({ conversation: { id: "rm_dm_peer", kind: "direct" } })),
-    ).toBeUndefined();
+    const out = builder(makeMessage({ conversation: { id: "rm_dm_peer", kind: "direct" } }));
+    expect(out).toContain("[BotCord Working Memory]");
+    expect(out).toContain("This is the only BotCord memory source.");
+    expect(out).toContain("Your working memory is currently empty.");
   });
 
   it("still injects group-room runtime environment when the activity digest is empty", () => {
@@ -137,7 +138,8 @@ describe("createDaemonSystemContextBuilder", () => {
     // No ensureAgentWorkspace — workspace never provisioned.
     const builder = createDaemonSystemContextBuilder({ agentId: "ag_me" });
     const out = builder(makeMessage({ conversation: { id: "rm_dm_peer", kind: "direct" } }));
-    expect(out).toBeUndefined();
+    expect(out).not.toContain("[BotCord Identity]");
+    expect(out).toContain("[BotCord Working Memory]");
   });
 
   it("skips the identity block when identity.md is blank", () => {
@@ -151,9 +153,9 @@ describe("createDaemonSystemContextBuilder", () => {
 
   it("detects a newly added global Claude skill on the next turn", () => {
     const builder = createDaemonSystemContextBuilder({ agentId: "ag_me" });
-    expect(
-      builder(makeMessage({ conversation: { id: "rm_dm_peer", kind: "direct" } })),
-    ).toBeUndefined();
+    const before = builder(makeMessage({ conversation: { id: "rm_dm_peer", kind: "direct" } }));
+    expect(before).toContain("[BotCord Working Memory]");
+    expect(before).not.toContain("[BotCord Daemon Skill Index]");
 
     const skillDir = path.join(tmpDir, ".claude", "skills", "digest-query");
     mkdirSync(skillDir, { recursive: true });

--- a/packages/daemon/src/agent-workspace.ts
+++ b/packages/daemon/src/agent-workspace.ts
@@ -3,7 +3,7 @@
  * directory tree under `~/.botcord/agents/{agentId}/`:
  *
  *   workspace/   — runtime cwd; seed Markdown files live here (LLM-owned)
- *   state/       — daemon-owned JSON (e.g. working-memory.json)
+ *   state/       — daemon-owned JSON
  *   codex-home/  — per-agent CODEX_HOME used by the codex adapter so codex
  *                  reads a daemon-written AGENTS.md (systemContext carrier)
  *                  and stores its sessions/ without touching ~/.codex.
@@ -108,8 +108,6 @@ This directory is your persistent workspace. You run with \`cwd\` set here.
 ## Files you own
 
 - \`identity.md\` — who you are, your role, your boundaries. Read before responding.
-- \`memory.md\` — long-lived facts, user preferences, past decisions. Update when
-  you learn something durable. Prune when it grows stale.
 - \`task.md\` — current task and plan. Update as you make progress. Clear when done.
 - \`notes/\` — free-form scratch space.
 
@@ -118,6 +116,10 @@ This directory is your persistent workspace. You run with \`cwd\` set here.
 - Do not modify files outside this workspace unless the user explicitly asks.
 - \`../state/\` (sibling directory, outside this workspace) is managed by the
   daemon — do not read or edit it directly.
+- Working memory is stored outside this workspace at
+  \`~/.botcord/memory/{agentId}/working-memory.json\`. Read and update it with
+  \`botcord memory\` or the \`botcord_memory\` skill instead of creating local
+  memory notes.
 
 ## How to use this
 
@@ -125,21 +127,10 @@ This directory is your persistent workspace. You run with \`cwd\` set here.
   system context as the \`[BotCord Identity]\` block. Edits to this file (yours,
   the dashboard's via \`applyAgentIdentity\`, or a hello-snapshot reapply) take
   effect on the next turn — no restart needed.
-- \`memory.md\` and \`task.md\` are **convention, not mechanism**. The daemon does
-  not auto-load them; you are instructed to skim them before responding and to
-  write back what changed after meaningful turns. Keep them tight enough to be
-  worth re-reading.
-`;
-
-const MEMORY_MD = `# Memory
-
-<!--
-Long-lived facts about the user, past decisions, and preferences that should
-survive across conversations. Organize by topic. Keep entries short. Prune
-regularly — AGENTS.md instructs you to consult this file before each
-response, but nothing loads it automatically (unlike identity.md); keep it
-short enough to be worth re-reading.
--->
+- Working memory is **mechanism**: the daemon loads \`working-memory.json\` fresh
+  and injects it into every turn as the \`[BotCord Working Memory]\` block.
+- \`task.md\` is **convention, not mechanism**. The daemon does not auto-load it;
+  keep it only for short-lived task notes that are not durable memory.
 `;
 
 const TASK_MD = `# Current Task
@@ -491,7 +482,7 @@ export function ensureAttachedHermesProfileSkills(profileHome: string): void {
 /**
  * Idempotently create the agent's home / workspace / state directories and
  * seed the workspace Markdown files. Existing files are never overwritten —
- * users' edits to AGENTS.md, memory.md, etc. are preserved across calls.
+ * users' edits to AGENTS.md, task.md, etc. are preserved across calls.
  * State files are not touched here; working-memory.ts owns `state/`.
  */
 export function ensureAgentWorkspace(agentId: string, seed: WorkspaceSeed): void {
@@ -513,7 +504,6 @@ export function ensureAgentWorkspace(agentId: string, seed: WorkspaceSeed): void
   writeIfMissing(agentsMdPath, AGENTS_MD);
   writeIfMissing(claudeMdPath, AGENTS_MD);
   writeIfMissing(path.join(workspace, "identity.md"), renderIdentity(agentId, seed));
-  writeIfMissing(path.join(workspace, "memory.md"), MEMORY_MD);
   writeIfMissing(path.join(workspace, "task.md"), TASK_MD);
   writeIfMissing(path.join(notes, ".gitkeep"), "");
   seedClaudeCodeSkills(workspace);

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -71,6 +71,7 @@ import {
 } from "./gateway/runtimes/hermes-agent.js";
 import { log as daemonLog } from "./log.js";
 import { discoverAgentCredentials } from "./agent-discovery.js";
+import { resolveMemoryDir } from "./working-memory.js";
 
 /**
  * Information passed to {@link OnAgentInstalledHook} after a successful
@@ -618,7 +619,7 @@ interface ListAgentFilesParams {
 interface AgentRuntimeFile {
   id: string;
   name: string;
-  scope: "workspace" | "hermes" | "openclaw";
+  scope: "workspace" | "memory" | "hermes" | "openclaw";
   runtime?: string;
   profile?: string;
   size?: number;
@@ -642,6 +643,7 @@ interface RuntimeFileCandidate {
   relativePath: string;
   runtime?: string;
   profile?: string;
+  missingContent?: string;
 }
 
 function listAgentRuntimeFiles(params: ListAgentFilesParams): ListAgentFilesResult {
@@ -664,6 +666,7 @@ function runtimeFileCandidates(credentials: StoredBotCordCredentials): RuntimeFi
   const out: RuntimeFileCandidate[] = [];
 
   addWorkspaceFiles(out, agentId, runtime);
+  addWorkingMemoryFile(out, agentId, runtime);
 
   if (runtime === "hermes-agent") {
     addHermesFiles(out, credentials);
@@ -681,7 +684,7 @@ function addWorkspaceFiles(
   runtime?: string,
 ): void {
   const root = agentWorkspaceDir(agentId);
-  for (const file of ["AGENTS.md", "CLAUDE.md", "identity.md", "memory.md", "task.md"]) {
+  for (const file of ["AGENTS.md", "CLAUDE.md", "identity.md", "task.md"]) {
     out.push({
       id: `workspace:${file}`,
       name: `workspace/${file}`,
@@ -691,6 +694,26 @@ function addWorkspaceFiles(
       ...(runtime ? { runtime } : {}),
     });
   }
+}
+
+function addWorkingMemoryFile(
+  out: RuntimeFileCandidate[],
+  agentId: string,
+  runtime?: string,
+): void {
+  out.push({
+    id: "memory:working-memory.json",
+    name: "memory/working-memory.json",
+    scope: "memory",
+    root: resolveMemoryDir(agentId),
+    relativePath: "working-memory.json",
+    ...(runtime ? { runtime } : {}),
+    missingContent: JSON.stringify(
+      { version: 2, sections: {}, updatedAt: null },
+      null,
+      2,
+    ),
+  });
 }
 
 function addHermesFiles(
@@ -786,7 +809,16 @@ function readRuntimeFileCandidate(candidate: RuntimeFileCandidate): AgentRuntime
     base.content = readFileSync(resolved, "utf8");
     return base;
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      if (candidate.missingContent !== undefined) {
+        return {
+          ...base,
+          size: Buffer.byteLength(candidate.missingContent, "utf8"),
+          content: candidate.missingContent,
+        };
+      }
+      return null;
+    }
     return {
       ...base,
       error: err instanceof Error ? err.message : String(err),

--- a/packages/daemon/src/system-context.ts
+++ b/packages/daemon/src/system-context.ts
@@ -156,7 +156,7 @@ export function createDaemonSystemContextBuilder(
     const environment = ownerScene ? null : buildGroupRoomEnvironmentContext(message);
 
     const wm = safeReadWorkingMemory(deps.agentId);
-    const memory = wm ? buildWorkingMemoryPrompt({ workingMemory: wm }) : null;
+    const memory = buildWorkingMemoryPrompt({ workingMemory: wm });
 
     const digest = deps.activityTracker
       ? buildCrossRoomDigest({

--- a/packages/daemon/src/working-memory.ts
+++ b/packages/daemon/src/working-memory.ts
@@ -347,6 +347,7 @@ export function buildWorkingMemoryPrompt(opts: {
     "[BotCord Working Memory]",
     "You have a persistent working memory that survives across turns and rooms.",
     "Use it to track your goal, important facts, pending commitments, and context worth remembering.",
+    "This is the only BotCord memory source. It is stored in `~/.botcord/memory/{agentId}/working-memory.json`; do not create or update workspace memory files.",
     "",
     "Update via the daemon's `memory` CLI (or whatever tool the operator wires):",
     "- goal: a short pinned statement of what you're working on.",

--- a/packages/protocol-core/src/control-frame.ts
+++ b/packages/protocol-core/src/control-frame.ts
@@ -332,10 +332,10 @@ export interface AgentRuntimeFile {
    * read one file; they must not construct filesystem paths.
    */
   id: string;
-  /** Display filename, e.g. `SOUL.md` or `workspace/memory.md`. */
+  /** Display filename, e.g. `SOUL.md` or `memory/working-memory.json`. */
   name: string;
   /** Logical source bucket for UI grouping. */
-  scope: "workspace" | "hermes" | "openclaw";
+  scope: "workspace" | "memory" | "hermes" | "openclaw";
   /** Runtime that exposed this file. */
   runtime?: string;
   /** Runtime profile binding, when applicable. */


### PR DESCRIPTION
## Summary
- remove workspace memory.md from agent workspace seeding and guidance
- always inject the BotCord working-memory prompt from working-memory.json
- expose memory/working-memory.json in runtime-files, including a stable empty view before the file exists

## Tests
- cd packages/daemon && npm ci && npm test -- --run src/__tests__/agent-workspace.test.ts src/__tests__/provision.test.ts src/__tests__/system-context.test.ts && npm run build
- cd packages/protocol-core && npm ci && npm run build
- cd backend && uv sync && uv run pytest tests/test_app/test_app_policy.py -q
- cd frontend && pnpm install --frozen-lockfile && pnpm run build (fails during prerender /admin/codes because Supabase URL/API key env vars are not configured; compile and TypeScript stages pass)