### PR TITLE
fix: package desktop app store build in stages

### DIFF
--- a/.github/workflows/publish-desktop-appstore.yml
+++ b/.github/workflows/publish-desktop-appstore.yml
@@ -187,6 +187,8 @@ jobs:
           set -euo pipefail
 
           APP_PATH="src-tauri/target/universal-apple-darwin/release/bundle/macos/${APP_NAME}.app"
+          COMPONENT_PKG_PATH="release-assets/${APP_NAME}_component_unsigned.pkg"
+          UNSIGNED_PKG_PATH="release-assets/${APP_NAME}_macos_appstore_unsigned.pkg"
           PKG_PATH="release-assets/${APP_NAME}_macos_appstore.pkg"
 
           test -d "$APP_PATH"
@@ -195,10 +197,19 @@ jobs:
           echo "Using installer signing identity: $MAC_INSTALLER_SIGNING_IDENTITY"
           security find-certificate -a -c "$MAC_INSTALLER_SIGNING_IDENTITY" "$SIGNING_KEYCHAIN" >/dev/null
 
+          xcrun pkgbuild \
+            --component "$APP_PATH" \
+            --install-location /Applications \
+            "$COMPONENT_PKG_PATH"
+
           xcrun productbuild \
+            --package "$COMPONENT_PKG_PATH" \
+            "$UNSIGNED_PKG_PATH"
+
+          xcrun productsign \
             --sign "$MAC_INSTALLER_SIGNING_IDENTITY" \
             --keychain "$SIGNING_KEYCHAIN" \
-            --component "$APP_PATH" /Applications \
+            "$UNSIGNED_PKG_PATH" \
             "$PKG_PATH"
 
           xcrun pkgutil --check-signature "$PKG_PATH"


### PR DESCRIPTION
## Summary
- replace productbuild --component --sign with staged pkgbuild/productbuild/productsign packaging
- keep the final App Store pkg signature check and artifact output

## Checks
- ruby YAML parse for publish-desktop-appstore.yml
- git diff --check