### PR TITLE
fix: allow productsign to use installer certificate

### DIFF
--- a/.github/workflows/publish-desktop-appstore.yml
+++ b/.github/workflows/publish-desktop-appstore.yml
@@ -83,7 +83,9 @@ jobs:
           security import "$INSTALLER_CERT_PATH" \
             -k "$KEYCHAIN_PATH" \
             -P "$MAC_INSTALLER_DISTRIBUTION_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/pkgbuild \
             -T /usr/bin/productbuild \
+            -T /usr/bin/productsign \
             -T /usr/bin/security
           security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 


### PR DESCRIPTION
## Summary
- grant pkgbuild and productsign access to the imported installer certificate private key
- prevents productsign from hanging on CI keychain access

## Checks
- ruby YAML parse for publish-desktop-appstore.yml
- git diff --check