### PR TITLE
fix: sign app store pkg with installer identity hash

### DIFF
--- a/.github/workflows/publish-desktop-appstore.yml
+++ b/.github/workflows/publish-desktop-appstore.yml
@@ -66,15 +66,22 @@ jobs:
           KEYCHAIN_PASSWORD="$(uuidgen)"
           APP_CERT_PATH="$RUNNER_TEMP/mac-app-distribution.p12"
           INSTALLER_CERT_PATH="$RUNNER_TEMP/mac-installer-distribution.p12"
+          WWDR_CERT_PATH="$RUNNER_TEMP/AppleWWDRCAG3.cer"
 
           printf "%s" "$MAC_APP_DISTRIBUTION_CERTIFICATE_BASE64" | base64 -D > "$APP_CERT_PATH"
           printf "%s" "$MAC_INSTALLER_DISTRIBUTION_CERTIFICATE_BASE64" | base64 -D > "$INSTALLER_CERT_PATH"
+          curl -fsSL https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer -o "$WWDR_CERT_PATH"
 
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
 
+          security import "$WWDR_CERT_PATH" \
+            -k "$KEYCHAIN_PATH" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/productsign \
+            -T /usr/bin/security
           security import "$APP_CERT_PATH" \
             -k "$KEYCHAIN_PATH" \
             -P "$MAC_APP_DISTRIBUTION_CERTIFICATE_PASSWORD" \
@@ -87,10 +94,11 @@ jobs:
             -T /usr/bin/productbuild \
             -T /usr/bin/productsign \
             -T /usr/bin/security
-          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
           APP_SIGNING_IDENTITY="$(security find-certificate -a "$KEYCHAIN_PATH" | awk -F'"' '/alis/ && ($4 ~ /^Mac App Distribution:/ || $4 ~ /^3rd Party Mac Developer Application:/) { print $4; exit }')"
           INSTALLER_SIGNING_IDENTITY="$(security find-certificate -a "$KEYCHAIN_PATH" | awk -F'"' '/alis/ && ($4 ~ /^Mac Installer Distribution:/ || $4 ~ /^3rd Party Mac Developer Installer:/) { print $4; exit }')"
+          INSTALLER_SIGNING_IDENTITY_HASH="$(security find-identity -v -p basic "$KEYCHAIN_PATH" | awk '/Mac Installer Distribution:|3rd Party Mac Developer Installer:/{ print $2; exit }')"
 
           if [ -z "$APP_SIGNING_IDENTITY" ]; then
             echo "Mac App Distribution signing identity was not found." >&2
@@ -102,10 +110,16 @@ jobs:
             security find-certificate -a "$KEYCHAIN_PATH" | awk -F'"' '/alis/{ print $4 }' >&2 || true
             exit 1
           fi
+          if [ -z "$INSTALLER_SIGNING_IDENTITY_HASH" ]; then
+            echo "Mac Installer Distribution signing identity hash was not found." >&2
+            security find-identity -v -p basic "$KEYCHAIN_PATH" >&2 || true
+            exit 1
+          fi
 
           {
             echo "APPLE_SIGNING_IDENTITY=$APP_SIGNING_IDENTITY"
             echo "MAC_INSTALLER_SIGNING_IDENTITY=$INSTALLER_SIGNING_IDENTITY"
+            echo "MAC_INSTALLER_SIGNING_IDENTITY_HASH=$INSTALLER_SIGNING_IDENTITY_HASH"
             echo "SIGNING_KEYCHAIN=$KEYCHAIN_PATH"
           } >> "$GITHUB_ENV"
 
@@ -209,7 +223,7 @@ jobs:
             "$UNSIGNED_PKG_PATH"
 
           xcrun productsign \
-            --sign "$MAC_INSTALLER_SIGNING_IDENTITY" \
+            --sign "$MAC_INSTALLER_SIGNING_IDENTITY_HASH" \
             --keychain "$SIGNING_KEYCHAIN" \
             "$UNSIGNED_PKG_PATH" \
             "$PKG_PATH"


### PR DESCRIPTION
## Summary
- import Apple WWDR G3 into the CI signing keychain
- resolve the installer signing identity hash and use it for productsign
- matches the local package signing flow that successfully produced a signed pkg

## Checks
- local BotCord pkg signed successfully in desktop/release-assets-local/BotCord_macos_appstore.pkg
- ruby YAML parse for publish-desktop-appstore.yml
- git diff --check