### PR TITLE
fix: open desktop auth callback via deep link

### DIFF
--- a/frontend/src/app/auth/desktop-callback/route.ts
+++ b/frontend/src/app/auth/desktop-callback/route.ts
@@ -29,7 +29,7 @@ export async function GET(request: Request) {
     <main>
       <h1>Opening BotCord</h1>
       <p id="status">If this tab does not close automatically, you can close it after BotCord opens.</p>
-      <button id="open" type="button">Open BotCord</button>
+      <a id="open" href=${JSON.stringify(deepLink)}>Open BotCord</a>
       <iframe id="handoff" title="BotCord handoff"></iframe>
     </main>
     <script>
@@ -45,13 +45,17 @@ export async function GET(request: Request) {
 
       function openBotCord() {
         status.textContent = "Opening BotCord...";
-        // Do not navigate the top-level browser tab to botcord://. Chrome/Safari
-        // can leave that tab on a blank custom-scheme page. A hidden iframe
-        // triggers the protocol handler while this page remains closable.
-        handoff.src = target;
+        // Custom protocol launches from hidden iframes can be blocked by modern
+        // browsers after OAuth redirects. A top-level navigation is the most
+        // reliable handoff, with the iframe kept as a secondary trigger for
+        // browsers that allow it.
+        window.location.href = target;
+        window.setTimeout(() => {
+          handoff.src = target;
+        }, 250);
         window.setTimeout(tryClose, 800);
         window.setTimeout(() => {
-          status.textContent = "BotCord should be open now. You can close this tab.";
+          status.textContent = "If BotCord did not open, use the Open BotCord button.";
         }, 1600);
       }
 

--- a/frontend/tests/desktop-auth-callback.test.ts
+++ b/frontend/tests/desktop-auth-callback.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { GET } from "@/app/auth/desktop-callback/route";
+
+describe("desktop auth callback", () => {
+  it("hands OAuth results back to the installed desktop app via a top-level deep link", async () => {
+    const response = await GET(
+      new Request("https://botcord.chat/auth/desktop-callback?code=abc123&next=%2Fchats%2Fhome"),
+    );
+    const html = await response.text();
+
+    expect(response.headers.get("content-type")).toContain("text/html");
+    expect(html).toContain("botcord://auth/callback?code=abc123&next=%2Fchats%2Fhome");
+    expect(html).toContain("window.location.href = target");
+    expect(html).toContain('id="handoff"');
+  });
+});


### PR DESCRIPTION
## Summary
- launch BotCord from the desktop OAuth callback using a top-level botcord:// navigation
- keep the hidden iframe and manual button as fallback handoff paths
- add coverage for the desktop callback handoff page

## Tests
- npm test -- desktop-auth-callback.test.ts
- npm run build