### PR TITLE
ci: allow app store package signing to finish

### DIFF
--- a/.github/workflows/publish-desktop-appstore.yml
+++ b/.github/workflows/publish-desktop-appstore.yml
@@ -198,7 +198,7 @@ jobs:
 
       - name: Build signed installer pkg
         id: package
-        timeout-minutes: 10
+        timeout-minutes: 30
         run: |
           set -euo pipefail
 
@@ -210,6 +210,8 @@ jobs:
           test -d "$APP_PATH"
           mkdir -p release-assets
           du -sh "$APP_PATH"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes" "$APP_PATH/Contents/Info.plist" | grep -q "botcord"
+          codesign --verify --deep --strict --verbose=2 "$APP_PATH"
           echo "Using installer signing identity: $MAC_INSTALLER_SIGNING_IDENTITY"
           security find-certificate -a -c "$MAC_INSTALLER_SIGNING_IDENTITY" "$SIGNING_KEYCHAIN" >/dev/null
 


### PR DESCRIPTION
## Summary
- increase App Store pkg packaging timeout so productsign can complete
- verify the built app still registers the botcord:// URL scheme before packaging
- verify the signed app bundle before productbuild/productsign

## Context
The latest App Store publish run timed out in productsign before uploading, so the desktop OAuth deep-link fix had not actually shipped in a new pkg.