### PR TITLE
fix: stop pkg signing from hanging on keychain ACL prompt

### DIFF
--- a/.github/workflows/publish-desktop-appstore.yml
+++ b/.github/workflows/publish-desktop-appstore.yml
@@ -85,16 +85,12 @@ jobs:
           security import "$APP_CERT_PATH" \
             -k "$KEYCHAIN_PATH" \
             -P "$MAC_APP_DISTRIBUTION_CERTIFICATE_PASSWORD" \
-            -T /usr/bin/codesign \
-            -T /usr/bin/security
+            -A
           security import "$INSTALLER_CERT_PATH" \
             -k "$KEYCHAIN_PATH" \
             -P "$MAC_INSTALLER_DISTRIBUTION_CERTIFICATE_PASSWORD" \
-            -T /usr/bin/pkgbuild \
-            -T /usr/bin/productbuild \
-            -T /usr/bin/productsign \
-            -T /usr/bin/security
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+            -A
+          security set-key-partition-list -S apple-tool:,apple:,codesign:,unsigned: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" >/dev/null
 
           APP_SIGNING_IDENTITY="$(security find-certificate -a "$KEYCHAIN_PATH" | awk -F'"' '/alis/ && ($4 ~ /^Mac App Distribution:/ || $4 ~ /^3rd Party Mac Developer Application:/) { print $4; exit }')"
           INSTALLER_SIGNING_IDENTITY="$(security find-certificate -a "$KEYCHAIN_PATH" | awk -F'"' '/alis/ && ($4 ~ /^Mac Installer Distribution:/ || $4 ~ /^3rd Party Mac Developer Installer:/) { print $4; exit }')"
@@ -121,7 +117,9 @@ jobs:
             echo "MAC_INSTALLER_SIGNING_IDENTITY=$INSTALLER_SIGNING_IDENTITY"
             echo "MAC_INSTALLER_SIGNING_IDENTITY_HASH=$INSTALLER_SIGNING_IDENTITY_HASH"
             echo "SIGNING_KEYCHAIN=$KEYCHAIN_PATH"
+            echo "SIGNING_KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD"
           } >> "$GITHUB_ENV"
+          echo "::add-mask::$KEYCHAIN_PASSWORD"
 
       - name: Prepare App Store provisioning and configuration
         env:
@@ -210,13 +208,15 @@ jobs:
           du -sh "$APP_PATH"
           /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes" "$APP_PATH/Contents/Info.plist" | grep -q "botcord"
           codesign --verify --deep --strict --verbose=2 "$APP_PATH"
-          echo "Using installer signing identity: $MAC_INSTALLER_SIGNING_IDENTITY"
+          echo "Using installer signing identity: $MAC_INSTALLER_SIGNING_IDENTITY ($MAC_INSTALLER_SIGNING_IDENTITY_HASH)"
           security find-certificate -a -c "$MAC_INSTALLER_SIGNING_IDENTITY" "$SIGNING_KEYCHAIN" >/dev/null
+          security unlock-keychain -p "$SIGNING_KEYCHAIN_PASSWORD" "$SIGNING_KEYCHAIN"
+          security list-keychains -d user -s "$SIGNING_KEYCHAIN" $(security list-keychains -d user | tr -d '"')
 
           echo "Building signed App Store pkg with productbuild"
           xcrun productbuild \
             --component "$APP_PATH" /Applications \
-            --sign "$MAC_INSTALLER_SIGNING_IDENTITY" \
+            --sign "$MAC_INSTALLER_SIGNING_IDENTITY_HASH" \
             --keychain "$SIGNING_KEYCHAIN" \
             "$PKG_PATH"
 

--- a/.github/workflows/publish-desktop-dmg.yml
+++ b/.github/workflows/publish-desktop-dmg.yml
@@ -89,9 +89,8 @@ jobs:
           security import "$APP_CERT_PATH" \
             -k "$KEYCHAIN_PATH" \
             -P "$MAC_DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD" \
-            -T /usr/bin/codesign \
-            -T /usr/bin/security
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+            -A
+          security set-key-partition-list -S apple-tool:,apple:,codesign:,unsigned: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" >/dev/null
 
           APP_SIGNING_IDENTITY="$(security find-certificate -a "$KEYCHAIN_PATH" | awk -F'"' '/alis/ && $4 ~ /^Developer ID Application:/ { print $4; exit }')"
           APP_SIGNING_IDENTITY_HASH="$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | awk '/Developer ID Application:/{ print $2; exit }')"
@@ -111,7 +110,9 @@ jobs:
             echo "APPLE_SIGNING_IDENTITY=$APP_SIGNING_IDENTITY"
             echo "DEVELOPER_ID_SIGNING_IDENTITY_HASH=$APP_SIGNING_IDENTITY_HASH"
             echo "SIGNING_KEYCHAIN=$KEYCHAIN_PATH"
+            echo "SIGNING_KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD"
           } >> "$GITHUB_ENV"
+          echo "::add-mask::$KEYCHAIN_PASSWORD"
 
       - name: Prepare App Store Connect API key
         env:


### PR DESCRIPTION
## Summary
Previous fix replaced `productsign` with `productbuild --sign`, but CI still hangs at the signing call. Root cause is the imported private key's ACL: `-T /usr/bin/codesign …` only whitelists specific tools, so the other helpers `productbuild` spawns internally hit the keychain ACL gate and produce a GUI unlock prompt that nobody answers.

- Import certs with `-A` (any app can use the key) — safe, the keychain is ephemeral
- Broaden partition list (`apple-tool:,apple:,codesign:,unsigned:`)
- Persist keychain password to `GITHUB_ENV` (masked) so we can explicitly re-unlock + re-register the search list right before signing — guards against idle re-lock between import and pkg build
- Sign by SHA-1 hash instead of identity name (avoids duplicate-name resolution paths)
- Mirror the `-A` / partition fix in the DMG workflow

## Test plan
- [ ] Trigger `Publish Desktop App Store` after merge — "Build signed installer pkg" completes in under a couple of minutes
- [ ] `xcrun pkgutil --check-signature` reports a valid Apple-trusted signature
- [ ] App Store Connect upload succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)