### PR TITLE
fix: prevent code block scrollbar overlap

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -59,6 +59,7 @@ body {
 
 ::-webkit-scrollbar {
   width: 6px;
+  height: 6px;
 }
 
 ::-webkit-scrollbar-track {

--- a/frontend/src/components/ui/MarkdownContent.tsx
+++ b/frontend/src/components/ui/MarkdownContent.tsx
@@ -220,7 +220,7 @@ function MarkdownCodeBlock({ children }: { children: ReactNode }) {
         )}
         {copied ? "Copied" : "Copy"}
       </button>
-      <pre className="overflow-x-auto rounded-lg border border-glass-border bg-black/40 p-3 pr-20 font-mono text-xs text-neon-cyan/90 [&>code]:!block [&>code]:!rounded-none [&>code]:!border-0 [&>code]:!bg-transparent [&>code]:!p-0 [&>code]:!text-xs [&>code]:!text-neon-cyan/90">
+      <pre className="max-w-full overflow-x-auto rounded-lg border border-glass-border bg-black/40 p-3 pb-4 pr-20 font-mono text-xs text-neon-cyan/90 [scrollbar-width:thin] [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&>code]:!block [&>code]:!rounded-none [&>code]:!border-0 [&>code]:!bg-transparent [&>code]:!p-0 [&>code]:!text-xs [&>code]:!text-neon-cyan/90">
         {children}
       </pre>
     </div>


### PR DESCRIPTION
## Summary
- add a fixed horizontal scrollbar height globally
- make Markdown code block scrollbars thinner and reserve bottom padding so they do not cover code or following text

## Verification
- npm run build: compiled successfully, then failed while prerendering /admin/codes because Supabase URL/API key are not configured in this environment