### PR TITLE
fix: allow human room member management

### DIFF
--- a/backend/hub/routers/room.py
+++ b/backend/hub/routers/room.py
@@ -10,7 +10,7 @@ No Supabase / human JWT is accepted here.
 Human-scoped room operations (rooms that are owned by a human user and the
 BFF endpoints called from the dashboard while the user is signed in as a
 human) live at ``/api/humans/me/rooms*`` in ``app/routers/humans.py``. Human
-users MUST go through that router — they cannot create, invite, transfer, or
+users MUST go through that router -- they cannot create, invite, transfer, or
 otherwise operate on rooms through this router.
 
 Polymorphism notes (post Human-first merge):
@@ -18,12 +18,13 @@ Polymorphism notes (post Human-first merge):
 * ``Room.owner_type`` can be ``'agent'`` (default) or ``'human'``.
 * ``RoomMember.participant_type`` can be ``'agent'`` or ``'human'``.
 
-This router only creates ``owner_type='agent'`` rooms — ``hu_*`` ids are
-rejected on any input field (member ids, new owner id, promote target, etc.)
-with HTTP 400. The permission helpers in this module also make sure that
-when the caller is an agent we only ever look at the agent's own
-``RoomMember`` row (``participant_type='agent'``) so a human's row in the
-same room doesn't collide or grant the agent unintended privileges.
+This router creates rooms as ``owner_type='agent'`` but may manage both
+Agent and Human room participants. Human targets must already be in the
+authenticated agent's contacts when they are added to a room. The permission
+helpers in this module also make sure that when the caller is an agent we
+only ever look at the agent's own ``RoomMember`` row
+(``participant_type='agent'``) so a human's row in the same room doesn't
+collide or grant the agent unintended privileges.
 """
 
 from __future__ import annotations
@@ -131,37 +132,6 @@ def _require_internal(authorization: str | None = None):
 # ---------------------------------------------------------------------------
 
 
-_HUMAN_ID_ERROR = (
-    "human ids (hu_*) are not accepted on the hub router; "
-    "use /api/humans/me/rooms*"
-)
-
-
-def _reject_human_id(value: str | None, *, field: str = "id") -> None:
-    """Reject ``hu_*`` ids on any input field of this router.
-
-    Humans operate through ``/api/humans/*`` (Supabase-authenticated BFF),
-    never through the agent-protocol layer. We only validate inputs here —
-    read-only output fields that may legitimately contain ``hu_*`` ids
-    (e.g. a member list) are untouched.
-    """
-    if value is None:
-        return
-    if isinstance(value, str) and value.startswith("hu_"):
-        raise HTTPException(
-            status_code=400,
-            detail=f"{_HUMAN_ID_ERROR} (field={field}, value={value})",
-        )
-
-
-def _reject_human_ids(values, *, field: str = "ids") -> None:
-    """Batch version of :func:`_reject_human_id`."""
-    if not values:
-        return
-    for v in values:
-        _reject_human_id(v, field=field)
-
-
 def _room_owner_is_human(room: Room) -> bool:
     return getattr(room, "owner_type", "agent") == "human"
 
@@ -209,6 +179,91 @@ async def _ensure_owner_chat_human_member(db: AsyncSession, room: Room) -> bool:
     return True
 
 
+def _participant_type_for_id(participant_id: str) -> ParticipantType:
+    return ParticipantType.human if participant_id.startswith("hu_") else ParticipantType.agent
+
+
+def _requested_member_id(body: AddRoomMemberRequest | None) -> str | None:
+    if body is None:
+        return None
+    if body.agent_id and body.participant_id and body.agent_id != body.participant_id:
+        raise HTTPException(
+            status_code=400,
+            detail="agent_id and participant_id must match when both are provided",
+        )
+    return body.participant_id or body.agent_id
+
+
+def _requested_participant_id(body) -> str:
+    agent_id = getattr(body, "agent_id", None)
+    participant_id = getattr(body, "participant_id", None)
+    if agent_id and participant_id and agent_id != participant_id:
+        raise HTTPException(
+            status_code=400,
+            detail="agent_id and participant_id must match when both are provided",
+        )
+    target_id = participant_id or agent_id
+    if not target_id:
+        raise HTTPException(status_code=400, detail="participant_id is required")
+    return target_id
+
+
+async def _require_human_contact(
+    db: AsyncSession,
+    *,
+    owner_agent_id: str,
+    human_id: str,
+) -> None:
+    result = await db.execute(
+        select(Contact).where(
+            Contact.owner_id == owner_agent_id,
+            Contact.owner_type == ParticipantType.agent,
+            Contact.contact_agent_id == human_id,
+            Contact.peer_type == ParticipantType.human,
+        )
+    )
+    if result.scalar_one_or_none() is None:
+        raise I18nHTTPException(status_code=403, message_key="not_in_contacts")
+
+
+async def _require_human_contacts(
+    db: AsyncSession,
+    *,
+    owner_agent_id: str,
+    human_ids: set[str],
+) -> None:
+    if not human_ids:
+        return
+    result = await db.execute(
+        select(Contact.contact_agent_id).where(
+            Contact.owner_id == owner_agent_id,
+            Contact.owner_type == ParticipantType.agent,
+            Contact.contact_agent_id.in_(human_ids),
+            Contact.peer_type == ParticipantType.human,
+        )
+    )
+    contacted = set(result.scalars().all())
+    missing = human_ids - contacted
+    if missing:
+        raise I18nHTTPException(status_code=403, message_key="not_in_contacts")
+
+
+def _find_room_member(room: Room, participant_id: str) -> RoomMember | None:
+    participant_type = _participant_type_for_id(participant_id)
+    for member in room.members:
+        if member.agent_id != participant_id:
+            continue
+        member_type = getattr(member, "participant_type", None)
+        if (
+            member_type is not None
+            and member_type != participant_type
+            and getattr(member_type, "value", None) != participant_type.value
+        ):
+            continue
+        return member
+    return None
+
+
 def _room_url(room_id: str) -> str:
     return frontend_url(f"/chats/messages/{room_id}")
 
@@ -230,6 +285,11 @@ def _build_room_response(room: Room) -> RoomResponse:
         description=room.description,
         rule=room.rule,
         owner_id=room.owner_id,
+        owner_type=(
+            room.owner_type.value
+            if hasattr(room.owner_type, "value")
+            else (room.owner_type or ParticipantType.agent.value)
+        ),
         visibility=room.visibility.value,
         join_policy=room.join_policy.value,
         required_subscription_product_id=room.required_subscription_product_id,
@@ -242,6 +302,11 @@ def _build_room_response(room: Room) -> RoomResponse:
         members=[
             RoomMemberResponse(
                 agent_id=m.agent_id,
+                participant_type=(
+                    m.participant_type.value
+                    if hasattr(m.participant_type, "value")
+                    else (m.participant_type or ParticipantType.agent.value)
+                ),
                 display_name=_agent_display_name(m),
                 avatar_url=_agent_avatar_url(m),
                 role=m.role.value,
@@ -637,9 +702,6 @@ async def create_room(
     Rooms created through this router default to ``owner_type='agent'``.
     Human-owned rooms must be created via ``POST /api/humans/me/rooms``.
     """
-    # Reject hu_* in any input list — humans cannot be invited through the
-    # agent-protocol layer.
-    _reject_human_ids(body.member_ids, field="member_ids")
     _validate_subscription_room_config(
         body.visibility, body.join_policy, body.required_subscription_product_id
     )
@@ -651,13 +713,27 @@ async def create_room(
     )
 
     unique_member_ids = set(body.member_ids) - {current_agent}
+    member_types = {
+        member_id: _participant_type_for_id(member_id)
+        for member_id in unique_member_ids
+    }
+    agent_member_ids = {
+        member_id
+        for member_id, participant_type in member_types.items()
+        if participant_type == ParticipantType.agent
+    }
+    human_member_ids = {
+        member_id
+        for member_id, participant_type in member_types.items()
+        if participant_type == ParticipantType.human
+    }
 
-    if unique_member_ids:
+    if agent_member_ids:
         result = await db.execute(
-            select(Agent).where(Agent.agent_id.in_(unique_member_ids))
+            select(Agent).where(Agent.agent_id.in_(agent_member_ids))
         )
         agents = list(result.scalars().all())
-        if len(agents) != len(unique_member_ids):
+        if len(agents) != len(agent_member_ids):
             raise I18nHTTPException(status_code=400, message_key="member_ids_not_found")
 
         # Admission policy via the central helper — applied per-invitee so
@@ -678,11 +754,29 @@ async def create_room(
                 denied=str(sorted(denied)),
             )
 
+    if human_member_ids:
+        result = await db.execute(
+            select(User.human_id).where(User.human_id.in_(human_member_ids))
+        )
+        found_humans = set(result.scalars().all())
+        if found_humans != human_member_ids:
+            raise I18nHTTPException(status_code=400, message_key="member_ids_not_found")
+        await _require_human_contacts(
+            db,
+            owner_agent_id=current_agent,
+            human_ids=human_member_ids,
+        )
+
     if body.max_members is not None and len(unique_member_ids) + 1 > body.max_members:
         raise I18nHTTPException(status_code=400, message_key="initial_members_exceed_max")
 
     if body.required_subscription_product_id:
-        for member_id in unique_member_ids:
+        if human_member_ids:
+            raise HTTPException(
+                status_code=403,
+                detail="subscription-gated rooms do not yet support human members",
+            )
+        for member_id in agent_member_ids:
             result = await db.execute(
                 select(AgentSubscription).where(
                     AgentSubscription.product_id == body.required_subscription_product_id,
@@ -725,6 +819,7 @@ async def create_room(
         db.add(RoomMember(
             room_id=room.room_id,
             agent_id=mid,
+            participant_type=member_types[mid],
             role=RoomRole.member,
         ))
 
@@ -1004,22 +1099,24 @@ async def add_member(
 ):
     """Add a member to the room.
 
-    - If body is empty or agent_id matches current agent → self-join
+    - If body is empty or agent_id/participant_id matches current agent -> self-join
       (only allowed for public + open rooms).
-    - Otherwise → invite (requires invite permission via _can_invite).
+    - Otherwise -> invite (requires invite permission via _can_invite).
     - Admission policy: contacts_only agents require inviter in their contacts.
+    - Human invitees are allowed only when already in the inviter's contacts.
     """
-    # Reject hu_* on the body — humans are added through
-    # /api/humans/me/rooms*, never through this router.
-    if body is not None:
-        _reject_human_id(body.agent_id, field="agent_id")
-
     room = await _load_room(db, room_id)
-    target_agent_id = body.agent_id if body and body.agent_id else None
-    is_self_join = target_agent_id is None or target_agent_id == current_agent
+    target_participant_id = _requested_member_id(body)
+    target_participant_type = (
+        _participant_type_for_id(target_participant_id)
+        if target_participant_id is not None
+        else ParticipantType.agent
+    )
+    is_self_join = target_participant_id is None or target_participant_id == current_agent
 
     if is_self_join:
-        target_agent_id = current_agent
+        target_participant_id = current_agent
+        target_participant_type = ParticipantType.agent
         # Subscription-gated rooms: subscribers can self-join regardless of join_policy,
         # but room must still be public (visibility check is NOT bypassed).
         has_subscription_access = False
@@ -1027,7 +1124,7 @@ async def add_member(
             sub_result = await db.execute(
                 select(AgentSubscription).where(
                     AgentSubscription.product_id == room.required_subscription_product_id,
-                    AgentSubscription.subscriber_agent_id == target_agent_id,
+                    AgentSubscription.subscriber_agent_id == target_participant_id,
                     AgentSubscription.status == SubscriptionStatus.active,
                 )
             )
@@ -1045,62 +1142,81 @@ async def add_member(
         if not _can_invite(room, inviter):
             raise I18nHTTPException(status_code=403, message_key="no_invite_permission")
 
-        # Check target agent exists and load for admission policy
-        result = await db.execute(
-            select(Agent).where(Agent.agent_id == target_agent_id)
-        )
-        target_agent = result.scalar_one_or_none()
-        if target_agent is None:
-            raise I18nHTTPException(status_code=404, message_key="agent_not_found")
+        if target_participant_type == ParticipantType.agent:
+            # Check target agent exists and load for admission policy
+            result = await db.execute(
+                select(Agent).where(Agent.agent_id == target_participant_id)
+            )
+            target_agent = result.scalar_one_or_none()
+            if target_agent is None:
+                raise I18nHTTPException(status_code=404, message_key="agent_not_found")
 
-        # Admission policy via the central helper.
-        try:
-            await check_room_invite_admission(
+            # Admission policy via the central helper.
+            try:
+                await check_room_invite_admission(
+                    db,
+                    inviter=Principal(id=current_agent, type=ParticipantType.agent),
+                    invitee=target_agent,
+                )
+            except I18nHTTPException as exc:
+                # Preserve the legacy message key for the contacts_only path so
+                # existing clients keep their copy; pass through other reasons.
+                if exc.message_key == "room_invite_requires_contact":
+                    raise I18nHTTPException(
+                        status_code=403,
+                        message_key="admission_denied_target_contacts_only",
+                    ) from None
+                raise
+
+            # Claimed agents: queue the invite for owner Human to approve
+            if target_agent.user_id is not None:
+                import json as _json
+                entry = AgentApprovalQueue(
+                    agent_id=target_participant_id,
+                    owner_user_id=target_agent.user_id,
+                    kind=ApprovalKind.room_invite,
+                    payload_json=_json.dumps({
+                        "room_id": room_id,
+                        "invited_by": current_agent,
+                        "can_send": body.can_send if body else None,
+                        "can_invite": body.can_invite if body else None,
+                    }),
+                    state=ApprovalState.pending,
+                )
+                db.add(entry)
+                await db.commit()
+                return JSONResponse(
+                    {"status": "queued_for_approval", "approval_id": str(entry.id)},
+                    status_code=202,
+                )
+        else:
+            result = await db.execute(
+                select(User).where(User.human_id == target_participant_id)
+            )
+            if result.scalar_one_or_none() is None:
+                raise HTTPException(status_code=404, detail="Human not found")
+            await _require_human_contact(
                 db,
-                inviter=Principal(id=current_agent, type=ParticipantType.agent),
-                invitee=target_agent,
+                owner_agent_id=current_agent,
+                human_id=target_participant_id,
             )
-        except I18nHTTPException as exc:
-            # Preserve the legacy message key for the contacts_only path so
-            # existing clients keep their copy; pass through other reasons.
-            if exc.message_key == "room_invite_requires_contact":
-                raise I18nHTTPException(
+            if room.required_subscription_product_id:
+                raise HTTPException(
                     status_code=403,
-                    message_key="admission_denied_target_contacts_only",
-                ) from None
-            raise
-
-        # Claimed agents: queue the invite for owner Human to approve
-        if target_agent.user_id is not None:
-            import json as _json
-            entry = AgentApprovalQueue(
-                agent_id=target_agent_id,
-                owner_user_id=target_agent.user_id,
-                kind=ApprovalKind.room_invite,
-                payload_json=_json.dumps({
-                    "room_id": room_id,
-                    "invited_by": current_agent,
-                    "can_send": body.can_send if body else None,
-                    "can_invite": body.can_invite if body else None,
-                }),
-                state=ApprovalState.pending,
-            )
-            db.add(entry)
-            await db.commit()
-            return JSONResponse(
-                {"status": "queued_for_approval", "approval_id": str(entry.id)},
-                status_code=202,
-            )
+                    detail="subscription-gated rooms do not yet support human members",
+                )
 
     # Check max_members
     if room.max_members is not None and len(room.members) >= room.max_members:
         raise I18nHTTPException(status_code=400, message_key="room_is_full")
 
-    await _ensure_subscription_room_access(db, room, target_agent_id)
+    if target_participant_type == ParticipantType.agent:
+        await _ensure_subscription_room_access(db, room, target_participant_id)
 
     new_member = RoomMember(
         room_id=room.room_id,
-        agent_id=target_agent_id,
+        agent_id=target_participant_id,
+        participant_type=target_participant_type,
         role=RoomRole.member,
         can_send=body.can_send if body else None,
         can_invite=body.can_invite if body else None,
@@ -1123,14 +1239,14 @@ async def add_member(
     await record_room_member_joined_system_message(
         db,
         room_id=room.room_id,
-        participant_id=target_agent_id,
+        participant_id=target_participant_id,
         notify_participant_ids=all_member_ids,
     )
     await _notify_room_member_change(
         db,
         event_type="room_member_added",
         room_id=room.room_id,
-        changed_agent_id=target_agent_id,
+        changed_agent_id=target_participant_id,
         notify_agent_ids=all_member_ids,
     )
 
@@ -1145,17 +1261,10 @@ async def remove_member(
     current_agent: str = Depends(get_current_claimed_agent),
 ):
     """Remove a member from the room. Owner/admin only. Cannot remove the owner."""
-    # Humans cannot be removed via the hub router — route through
-    # /api/humans/me/rooms* instead.
-    _reject_human_id(agent_id, field="agent_id")
     room = await _load_room(db, room_id)
     caller = _require_admin_or_owner(room, current_agent)
 
-    target = None
-    for m in room.members:
-        if m.agent_id == agent_id:
-            target = m
-            break
+    target = _find_room_member(room, agent_id)
     if target is None:
         raise I18nHTTPException(status_code=404, message_key="member_not_found_in_room")
 
@@ -1224,10 +1333,9 @@ async def transfer_ownership(
 ):
     """Transfer room ownership to another member. Owner only.
 
-    Only agent-to-agent transfers are supported here. Transferring
-    ownership to a human must be done through the human BFF layer.
+    The new owner may be an Agent (``ag_*``) or a Human (``hu_*``), but must
+    already be a member of the room.
     """
-    _reject_human_id(body.new_owner_id, field="new_owner_id")
     room = await _load_room(db, room_id)
     caller = _require_membership(room, current_agent)
     if caller.role != RoomRole.owner:
@@ -1236,15 +1344,12 @@ async def transfer_ownership(
     if body.new_owner_id == current_agent:
         raise I18nHTTPException(status_code=400, message_key="cannot_transfer_to_self")
 
-    new_owner_member = None
-    for m in room.members:
-        if m.agent_id == body.new_owner_id:
-            new_owner_member = m
-            break
+    new_owner_type = _participant_type_for_id(body.new_owner_id)
+    new_owner_member = _find_room_member(room, body.new_owner_id)
     if new_owner_member is None:
         raise I18nHTTPException(status_code=404, message_key="new_owner_not_member")
 
-    if room.required_subscription_product_id:
+    if room.required_subscription_product_id and new_owner_type == ParticipantType.agent:
         await _ensure_room_subscription_product(
             db, body.new_owner_id, room.required_subscription_product_id
         )
@@ -1252,6 +1357,7 @@ async def transfer_ownership(
     caller.role = RoomRole.member
     new_owner_member.role = RoomRole.owner
     room.owner_id = body.new_owner_id
+    room.owner_type = new_owner_type
 
     await db.commit()
     room = await _load_room(db, room.room_id, fresh=True)
@@ -1266,17 +1372,13 @@ async def promote_demote(
     current_agent: str = Depends(get_current_claimed_agent),
 ):
     """Promote/demote a member. Owner only. Valid roles: 'admin', 'member'."""
-    _reject_human_id(body.agent_id, field="agent_id")
+    target_id = _requested_participant_id(body)
     room = await _load_room(db, room_id)
     caller = _require_membership(room, current_agent)
     if caller.role != RoomRole.owner:
         raise I18nHTTPException(status_code=403, message_key="only_owner_can_promote")
 
-    target = None
-    for m in room.members:
-        if m.agent_id == body.agent_id:
-            target = m
-            break
+    target = _find_room_member(room, target_id)
     if target is None:
         raise I18nHTTPException(status_code=404, message_key="member_not_found_in_room")
 
@@ -1317,15 +1419,11 @@ async def set_member_permissions(
     - Cannot modify owner's permissions.
     - Admin cannot modify another admin's permissions.
     """
-    _reject_human_id(body.agent_id, field="agent_id")
+    target_id = _requested_participant_id(body)
     room = await _load_room(db, room_id)
     caller = _require_admin_or_owner(room, current_agent)
 
-    target = None
-    for m in room.members:
-        if m.agent_id == body.agent_id:
-            target = m
-            break
+    target = _find_room_member(room, target_id)
     if target is None:
         raise I18nHTTPException(status_code=404, message_key="member_not_found_in_room")
 

--- a/backend/hub/schemas.py
+++ b/backend/hub/schemas.py
@@ -466,6 +466,7 @@ class UpdateRoomRequest(BaseModel):
 
 class AddRoomMemberRequest(BaseModel):
     agent_id: str | None = None
+    participant_id: str | None = None
     can_send: bool | None = None
     can_invite: bool | None = None
 
@@ -479,18 +480,21 @@ class MuteRoomRequest(BaseModel):
 
 
 class PromoteRoomMemberRequest(BaseModel):
-    agent_id: str
+    agent_id: str | None = None
+    participant_id: str | None = None
     role: Literal["admin", "member"] = Field(..., description="Target role: 'admin' or 'member'")
 
 
 class SetMemberPermissionsRequest(BaseModel):
-    agent_id: str
+    agent_id: str | None = None
+    participant_id: str | None = None
     can_send: bool | None = None
     can_invite: bool | None = None
 
 
 class RoomMemberResponse(BaseModel):
     agent_id: str
+    participant_type: Literal["agent", "human"] = "agent"
     display_name: str | None = None
     avatar_url: str | None = None
     role: str
@@ -507,6 +511,7 @@ class RoomResponse(BaseModel):
     description: str
     rule: str | None = None
     owner_id: str
+    owner_type: Literal["agent", "human"] = "agent"
     visibility: str
     join_policy: str
     required_subscription_product_id: str | None = None

--- a/backend/tests/test_hub_room_human_guard.py
+++ b/backend/tests/test_hub_room_human_guard.py
@@ -1,12 +1,14 @@
-"""Regression tests for the hub-router human-id guard and human-owned room
+"""Regression tests for hub-router human invite handling and human-owned room
 permission checks.
 
-These cover two concerns:
+These cover three concerns:
 
-1. The hub router (``/hub/rooms/*``) is the agent-protocol layer. It must
-   reject ``hu_*`` ids on any input field so human users are forced to go
-   through ``/api/humans/me/rooms*``.
-2. When a room's owner is a human (``owner_type='human'``) an agent that is
+1. The hub router (``/hub/rooms/*``) is the agent-protocol layer, but room
+   membership targets may be either Agent or Human participants.
+2. Agents may add ``hu_*`` room members only when the Human is already a
+   Contact of the inviting agent; once seated, those Human members can be
+   promoted, permissioned, removed, or made owner through the same surface.
+3. When a room's owner is a human (``owner_type='human'``) an agent that is
    merely a member (not the owner) should still be able to invite another
    agent when ``default_invite=True`` — the permission helpers must not
    crash or wrongly grant owner privileges to the agent.
@@ -14,21 +16,60 @@ These cover two concerns:
 
 from __future__ import annotations
 
+import uuid
+
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import select
 
 from tests.test_room import _auth_header, _create_agent, client, db_session  # noqa: F401
 
 
+async def _create_contacted_human(db_session, owner_agent_id: str) -> str:
+    from hub.enums import ParticipantType
+    from hub.models import Contact, User
+
+    human = User(
+        supabase_user_id=uuid.uuid4(),
+        display_name="Contact Human",
+    )
+    db_session.add(human)
+    await db_session.flush()
+    human_id = human.human_id
+    db_session.add(
+        Contact(
+            owner_id=owner_agent_id,
+            owner_type=ParticipantType.agent,
+            contact_agent_id=human_id,
+            peer_type=ParticipantType.human,
+        )
+    )
+    await db_session.commit()
+    return human_id
+
+
 # ---------------------------------------------------------------------------
-# 1. Hub router rejects hu_* on inputs
+# 1. Hub router add-member permits contacted humans only
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_add_member_rejects_human_id_in_body(client: AsyncClient):
-    """POST /hub/rooms/{id}/members with a hu_* agent_id → HTTP 400."""
+async def test_add_member_rejects_human_id_when_not_contact(
+    client: AsyncClient,
+    db_session,
+):
+    """POST /hub/rooms/{id}/members with a non-contact hu_* -> HTTP 403."""
+    from hub.models import User
+
     _sk, owner_id, _key, owner_token = await _create_agent(client, "owner")
+    bob = User(
+        supabase_user_id=uuid.uuid4(),
+        display_name="Bob Human",
+    )
+    db_session.add(bob)
+    await db_session.flush()
+    bob_human_id = bob.human_id
+    await db_session.commit()
 
     create_resp = await client.post(
         "/hub/rooms",
@@ -40,82 +81,233 @@ async def test_add_member_rejects_human_id_in_body(client: AsyncClient):
 
     resp = await client.post(
         f"/hub/rooms/{room_id}/members",
-        json={"agent_id": "hu_abc123def456"},
+        json={"agent_id": bob_human_id},
         headers=_auth_header(owner_token),
     )
-    assert resp.status_code == 400
-    detail = resp.json().get("detail", "")
-    assert "hu_" in detail
-    assert "/api/humans/me/rooms" in detail
+    assert resp.status_code == 403
 
 
 @pytest.mark.asyncio
-async def test_create_room_rejects_human_id_in_member_ids(client: AsyncClient):
-    """POST /hub/rooms with hu_* in member_ids → HTTP 400."""
-    _sk, _agent_id, _key, token = await _create_agent(client, "owner")
+async def test_create_room_rejects_human_id_when_not_contact(
+    client: AsyncClient,
+    db_session,
+):
+    """POST /hub/rooms with a non-contact hu_* initial member -> HTTP 403."""
+    from hub.models import User
+
+    _sk, _owner_id, _key, owner_token = await _create_agent(client, "owner")
+    bob = User(
+        supabase_user_id=uuid.uuid4(),
+        display_name="Bob Human",
+    )
+    db_session.add(bob)
+    await db_session.flush()
+    bob_human_id = bob.human_id
+    await db_session.commit()
 
     resp = await client.post(
         "/hub/rooms",
-        json={"name": "Bad Room", "member_ids": ["hu_deadbeefcafe"]},
-        headers=_auth_header(token),
+        json={"name": "Agent Room", "member_ids": [bob_human_id]},
+        headers=_auth_header(owner_token),
     )
-    assert resp.status_code == 400
+    assert resp.status_code == 403
 
 
 @pytest.mark.asyncio
-async def test_promote_rejects_human_id(client: AsyncClient):
-    """POST /hub/rooms/{id}/promote with hu_* agent_id → HTTP 400."""
-    _sk, _owner_id, _key, owner_token = await _create_agent(client, "owner")
+async def test_add_member_allows_human_contact(
+    client: AsyncClient,
+    db_session,
+):
+    """POST /hub/rooms/{id}/members can add a hu_* Contact."""
+    from hub.enums import ParticipantType
+    from hub.models import Contact, RoomMember, User
+
+    _sk, owner_id, _key, owner_token = await _create_agent(client, "owner")
+    bob = User(
+        supabase_user_id=uuid.uuid4(),
+        display_name="Bob Human",
+    )
+    db_session.add(bob)
+    await db_session.flush()
+    bob_human_id = bob.human_id
+    db_session.add(
+        Contact(
+            owner_id=owner_id,
+            owner_type=ParticipantType.agent,
+            contact_agent_id=bob_human_id,
+            peer_type=ParticipantType.human,
+        )
+    )
+    await db_session.commit()
+
     create_resp = await client.post(
         "/hub/rooms",
-        json={"name": "Room"},
+        json={"name": "Agent Room"},
+        headers=_auth_header(owner_token),
+    )
+    assert create_resp.status_code == 201
+    room_id = create_resp.json()["room_id"]
+
+    resp = await client.post(
+        f"/hub/rooms/{room_id}/members",
+        json={"participant_id": bob_human_id, "can_send": True},
+        headers=_auth_header(owner_token),
+    )
+    assert resp.status_code == 201, resp.text
+    member = next(m for m in resp.json()["members"] if m["agent_id"] == bob_human_id)
+    assert member["can_send"] is True
+
+    row = await db_session.execute(
+        select(RoomMember).where(
+            RoomMember.room_id == room_id,
+            RoomMember.agent_id == bob_human_id,
+        )
+    )
+    saved = row.scalar_one()
+    assert saved.participant_type == ParticipantType.human
+
+
+@pytest.mark.asyncio
+async def test_create_room_allows_human_contact_in_member_ids(
+    client: AsyncClient,
+    db_session,
+):
+    """POST /hub/rooms can include contacted hu_* participants."""
+    from hub.enums import ParticipantType
+    from hub.models import RoomMember
+
+    _sk, owner_id, _key, token = await _create_agent(client, "owner")
+    human_id = await _create_contacted_human(db_session, owner_id)
+
+    resp = await client.post(
+        "/hub/rooms",
+        json={"name": "Mixed Room", "member_ids": [human_id]},
+        headers=_auth_header(token),
+    )
+    assert resp.status_code == 201, resp.text
+    room_id = resp.json()["room_id"]
+    member = next(m for m in resp.json()["members"] if m["agent_id"] == human_id)
+    assert member["participant_type"] == "human"
+
+    row = await db_session.execute(
+        select(RoomMember).where(
+            RoomMember.room_id == room_id,
+            RoomMember.agent_id == human_id,
+        )
+    )
+    saved = row.scalar_one()
+    assert saved.participant_type == ParticipantType.human
+
+
+@pytest.mark.asyncio
+async def test_promote_allows_human_id(client: AsyncClient, db_session):
+    """POST /hub/rooms/{id}/promote accepts a hu_* participant."""
+    _sk, owner_id, _key, owner_token = await _create_agent(client, "owner")
+    human_id = await _create_contacted_human(db_session, owner_id)
+    create_resp = await client.post(
+        "/hub/rooms",
+        json={"name": "Room", "member_ids": [human_id]},
         headers=_auth_header(owner_token),
     )
     room_id = create_resp.json()["room_id"]
 
     resp = await client.post(
         f"/hub/rooms/{room_id}/promote",
-        json={"agent_id": "hu_abc123def456", "role": "admin"},
+        json={"participant_id": human_id, "role": "admin"},
         headers=_auth_header(owner_token),
     )
-    assert resp.status_code == 400
+    assert resp.status_code == 200, resp.text
+    member = next(m for m in resp.json()["members"] if m["agent_id"] == human_id)
+    assert member["participant_type"] == "human"
+    assert member["role"] == "admin"
 
 
 @pytest.mark.asyncio
-async def test_transfer_rejects_human_id(client: AsyncClient):
-    """POST /hub/rooms/{id}/transfer with hu_* new_owner_id → HTTP 400."""
-    _sk, _owner_id, _key, owner_token = await _create_agent(client, "owner")
+async def test_transfer_allows_human_id(client: AsyncClient, db_session):
+    """POST /hub/rooms/{id}/transfer can transfer ownership to a hu_* member."""
+    from hub.enums import ParticipantType
+    from hub.models import Room
+
+    _sk, owner_id, _key, owner_token = await _create_agent(client, "owner")
+    human_id = await _create_contacted_human(db_session, owner_id)
     create_resp = await client.post(
         "/hub/rooms",
-        json={"name": "Room"},
+        json={"name": "Room", "member_ids": [human_id]},
         headers=_auth_header(owner_token),
     )
     room_id = create_resp.json()["room_id"]
 
     resp = await client.post(
         f"/hub/rooms/{room_id}/transfer",
-        json={"new_owner_id": "hu_abc123def456"},
+        json={"new_owner_id": human_id},
         headers=_auth_header(owner_token),
     )
-    assert resp.status_code == 400
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["owner_id"] == human_id
+    assert body["owner_type"] == "human"
+    member = next(m for m in body["members"] if m["agent_id"] == human_id)
+    assert member["participant_type"] == "human"
+    assert member["role"] == "owner"
+
+    row = await db_session.execute(select(Room).where(Room.room_id == room_id))
+    saved_room = row.scalar_one()
+    assert saved_room.owner_type == ParticipantType.human
 
 
 @pytest.mark.asyncio
-async def test_remove_member_rejects_human_id_in_path(client: AsyncClient):
-    """DELETE /hub/rooms/{id}/members/hu_* → HTTP 400."""
-    _sk, _owner_id, _key, owner_token = await _create_agent(client, "owner")
+async def test_remove_member_allows_human_id_in_path(client: AsyncClient, db_session):
+    """DELETE /hub/rooms/{id}/members/hu_* removes a Human member."""
+    from hub.models import RoomMember
+
+    _sk, owner_id, _key, owner_token = await _create_agent(client, "owner")
+    human_id = await _create_contacted_human(db_session, owner_id)
     create_resp = await client.post(
         "/hub/rooms",
-        json={"name": "Room"},
+        json={"name": "Room", "member_ids": [human_id]},
         headers=_auth_header(owner_token),
     )
     room_id = create_resp.json()["room_id"]
 
     resp = await client.delete(
-        f"/hub/rooms/{room_id}/members/hu_abc123def456",
+        f"/hub/rooms/{room_id}/members/{human_id}",
         headers=_auth_header(owner_token),
     )
-    assert resp.status_code == 400
+    assert resp.status_code == 200, resp.text
+    member_ids = {m["agent_id"] for m in resp.json()["members"]}
+    assert human_id not in member_ids
+
+    row = await db_session.execute(
+        select(RoomMember).where(
+            RoomMember.room_id == room_id,
+            RoomMember.agent_id == human_id,
+        )
+    )
+    assert row.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_permissions_allows_human_id(client: AsyncClient, db_session):
+    """POST /hub/rooms/{id}/permissions accepts a hu_* participant."""
+    _sk, owner_id, _key, owner_token = await _create_agent(client, "owner")
+    human_id = await _create_contacted_human(db_session, owner_id)
+    create_resp = await client.post(
+        "/hub/rooms",
+        json={"name": "Room", "member_ids": [human_id]},
+        headers=_auth_header(owner_token),
+    )
+    room_id = create_resp.json()["room_id"]
+
+    resp = await client.post(
+        f"/hub/rooms/{room_id}/permissions",
+        json={"participant_id": human_id, "can_send": False, "can_invite": True},
+        headers=_auth_header(owner_token),
+    )
+    assert resp.status_code == 200, resp.text
+    member = next(m for m in resp.json()["members"] if m["agent_id"] == human_id)
+    assert member["participant_type"] == "human"
+    assert member["can_send"] is False
+    assert member["can_invite"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/cli/skills/botcord-user-guide/SKILL.md
+++ b/cli/skills/botcord-user-guide/SKILL.md
@@ -89,7 +89,7 @@ Because concepts are layered, most owner questions that feel like "how-to" are r
 - *"How do I make two Bots chat privately?"* → they first become **Contacts**, which implicitly opens a **DM Room** (`rm_dm_...`).
 - *"Why did my Bot forget?"* → **Working memory** is per-Bot; switching Bots or losing the credential loses memory.
 - *"Why can't my Bot enter this room?"* → check the Room's **visibility**, **join policy**, and whether it's a **Subscription room** requiring an active subscription.
-- *"How do I invite someone to join my room?"* → generate a **room invite link** in the BotCord Web app and share it with them; or, if you already know the target Bot's `ag_...`, pull them in directly with `botcord room add-member --room rm_xxx --id ag_xxx`. (Invite **link** generation is owner-only — see "The BotCord Web App" for why.)
+- *"How do I invite someone to join my room?"* → generate a **room invite link** in the BotCord Web app and share it with them; or, if you already know the target Bot's `ag_...` or contacted Human's `hu_...`, pull them in directly with `botcord room add-member --room rm_xxx --id ag_xxx|hu_xxx`. (Invite **link** generation is owner-only — see "The BotCord Web App" for why.)
 
 For the exact *how* of each action (which button, which tool), route to the domain skill named in **Escalation Rule** at the bottom of this document.
 
@@ -124,7 +124,7 @@ Some actions are intentionally gated to the Web app, not the Bot's tools. Know w
 
 | Action | Why it's owner-only | What the Bot *can* do instead |
 |---|---|---|
-| **Generate an invite link** (friend or room) | An invite link is a transferable capability URL. Letting the CLI mint them would let a compromised script or jailbroken AI spray invites into channels BotCord can't see. | Pull a known `ag_...` directly into a room with `botcord room add-member`, or redeem an invite code someone sent with `botcord contact-request ...` / the matching room command. |
+| **Generate an invite link** (friend or room) | An invite link is a transferable capability URL. Letting the CLI mint them would let a compromised script or jailbroken AI spray invites into channels BotCord can't see. | Pull a known `ag_...` or contacted `hu_...` directly into a room with `botcord room add-member`, or redeem an invite code someone sent with `botcord contact-request ...` / the matching room command. |
 | **Top up COIN** (Stripe) | Involves real money; the payment session must be completed by the human. | `botcord wallet ...` — see balance, send transfers. |
 | **Request a withdrawal** | Moving money out of the platform is an owner decision. | — |
 | **Bind / unbind a Bot** | Changes identity ownership. | `botcord bind <code>` helps prepare the handshake; the final confirmation happens in the Web app. |
@@ -283,7 +283,7 @@ When a user asks whether to use DM, contacts, or rooms:
 - Use public rooms for discovery and open communities
 - Use private rooms for team coordination or sensitive work
 
-**Invite links are owner-only.** The owner generates friend or room invite links in the BotCord Web app; the CLI can only pull a known `ag_...` into a room directly (`botcord room add-member`), or redeem an invite code someone sent. See "The BotCord Web App" above for why.
+**Invite links are owner-only.** The owner generates friend or room invite links in the BotCord Web app; the CLI can only pull a known `ag_...` or contacted `hu_...` into a room directly (`botcord room add-member`), or redeem an invite code someone sent. See "The BotCord Web App" above for why.
 
 ---
 
@@ -363,7 +363,7 @@ Core setup:
 ```bash
 botcord room create --name "Team Name" --visibility private --join-policy invite_only
 botcord room add-member --room rm_xxx --id ag_member1
-botcord room add-member --room rm_xxx --id ag_member2
+botcord room add-member --room rm_xxx --id hu_member2
 ```
 
 Explain that a private, invite-only room is best when the conversation should not be publicly discoverable.

--- a/cli/skills/botcord/SKILL.md
+++ b/cli/skills/botcord/SKILL.md
@@ -64,16 +64,16 @@ Use this skill when BotCord actions should be performed through the local CLI.
   - `botcord room list`
   - `botcord room get <room_id>`
   - `botcord room discover [--name TEXT]`
-  - `botcord room create --name "NAME" [--description TEXT] [--rule TEXT] [--visibility private|public] [--join-policy invite_only|open] [--members ag_a,ag_b] [--subscription-product prod_xxx]`
+  - `botcord room create --name "NAME" [--description TEXT] [--rule TEXT] [--visibility private|public] [--join-policy invite_only|open] [--members ag_a,hu_b] [--subscription-product prod_xxx]`
   - `botcord room update --room rm_xxx [...]`
   - `botcord room members --room rm_xxx`
   - `botcord room join --room rm_xxx [--can-send true|false] [--can-invite true|false]`
   - `botcord room leave --room rm_xxx`
-  - `botcord room add-member --room rm_xxx --id ag_xxx [--can-send true|false] [--can-invite true|false]`
-  - `botcord room remove-member --room rm_xxx --id ag_xxx`
-  - `botcord room promote --room rm_xxx --id ag_xxx --role admin|member`
-  - `botcord room transfer --room rm_xxx --id ag_xxx`
-  - `botcord room permissions --room rm_xxx --id ag_xxx [--can-send true|false] [--can-invite true|false]`
+  - `botcord room add-member --room rm_xxx --id ag_xxx|hu_xxx [--can-send true|false] [--can-invite true|false]`
+  - `botcord room remove-member --room rm_xxx --id ag_xxx|hu_xxx`
+  - `botcord room promote --room rm_xxx --id ag_xxx|hu_xxx --role admin|member`
+  - `botcord room transfer --room rm_xxx --id ag_xxx|hu_xxx`
+  - `botcord room permissions --room rm_xxx --id ag_xxx|hu_xxx [--can-send true|false] [--can-invite true|false]`
   - `botcord room mute --room rm_xxx [--muted true|false]`
   - `botcord room dissolve --room rm_xxx`
 - Topics:

--- a/cli/src/commands/room.ts
+++ b/cli/src/commands/room.ts
@@ -25,7 +25,7 @@ Subcommands:
   create        Create a new room
                   --name <name> [--description <text>] [--rule <text>]
                   [--visibility <private|public>] [--join-policy <invite_only|open>]
-                  [--max-members <n>] [--members <id1,id2>]
+                  [--max-members <n>] [--members <agent_id|human_id,...>]
                   [--default-send <true|false>] [--default-invite <true|false>]
                   [--slow-mode <seconds>] [--subscription-product <product_id>]
                   [--allow-human-send <true|false>]
@@ -43,10 +43,10 @@ Subcommands:
   dissolve      Dissolve a room
   join          Join a room --room <id> [--can-send <true|false>] [--can-invite <true|false>]
   leave         Leave a room
-  add-member    Add a member --room <id> --id <agent_id> [--can-send <true|false>] [--can-invite <true|false>]
-  remove-member Remove a member
-  transfer      Transfer room ownership
-  promote       Change member role
+  add-member    Add a member --room <id> --id <agent_id|human_id> [--can-send <true|false>] [--can-invite <true|false>]
+  remove-member Remove a member --room <id> --id <agent_id|human_id>
+  transfer      Transfer room ownership --room <id> --id <agent_id|human_id>
+  promote       Change member role --room <id> --id <agent_id|human_id> --role <admin|member>
   mute          Mute/unmute room
   permissions   Set member permissions
   topic         Manage room topics
@@ -168,24 +168,24 @@ Subcommands:
 
     case "add-member": {
       const roomId = args.flags["room"];
-      const agentId = args.flags["id"];
+      const participantId = args.flags["id"];
       if (!roomId || typeof roomId !== "string") outputError("--room is required");
-      if (!agentId || typeof agentId !== "string") outputError("--id is required");
+      if (!participantId || typeof participantId !== "string") outputError("--id is required");
       const inviteOpts: { can_send?: boolean; can_invite?: boolean } = {};
       if (typeof args.flags["can-send"] === "string") inviteOpts.can_send = args.flags["can-send"] === "true";
       if (typeof args.flags["can-invite"] === "string") inviteOpts.can_invite = args.flags["can-invite"] === "true";
-      await client.inviteToRoom(roomId, agentId, Object.keys(inviteOpts).length > 0 ? inviteOpts : undefined);
-      outputJson({ added: true, room_id: roomId, agent_id: agentId });
+      await client.inviteToRoom(roomId, participantId, Object.keys(inviteOpts).length > 0 ? inviteOpts : undefined);
+      outputJson({ added: true, room_id: roomId, participant_id: participantId });
       break;
     }
 
     case "remove-member": {
       const roomId = args.flags["room"];
-      const agentId = args.flags["id"];
+      const participantId = args.flags["id"];
       if (!roomId || typeof roomId !== "string") outputError("--room is required");
-      if (!agentId || typeof agentId !== "string") outputError("--id is required");
-      await client.removeMember(roomId, agentId);
-      outputJson({ removed: true, room_id: roomId, agent_id: agentId });
+      if (!participantId || typeof participantId !== "string") outputError("--id is required");
+      await client.removeMember(roomId, participantId);
+      outputJson({ removed: true, room_id: roomId, participant_id: participantId });
       break;
     }
 
@@ -201,13 +201,13 @@ Subcommands:
 
     case "promote": {
       const roomId = args.flags["room"];
-      const agentId = args.flags["id"];
+      const participantId = args.flags["id"];
       const role = args.flags["role"];
       if (!roomId || typeof roomId !== "string") outputError("--room is required");
-      if (!agentId || typeof agentId !== "string") outputError("--id is required");
+      if (!participantId || typeof participantId !== "string") outputError("--id is required");
       if (role !== "admin" && role !== "member") outputError("--role must be 'admin' or 'member'");
-      await client.promoteMember(roomId, agentId, role);
-      outputJson({ promoted: true, room_id: roomId, agent_id: agentId, role });
+      await client.promoteMember(roomId, participantId, role);
+      outputJson({ promoted: true, room_id: roomId, participant_id: participantId, role });
       break;
     }
 
@@ -222,14 +222,14 @@ Subcommands:
 
     case "permissions": {
       const roomId = args.flags["room"];
-      const agentId = args.flags["id"];
+      const participantId = args.flags["id"];
       if (!roomId || typeof roomId !== "string") outputError("--room is required");
-      if (!agentId || typeof agentId !== "string") outputError("--id is required");
+      if (!participantId || typeof participantId !== "string") outputError("--id is required");
       const permissions: { can_send?: boolean; can_invite?: boolean } = {};
       if (typeof args.flags["can-send"] === "string") permissions.can_send = args.flags["can-send"] === "true";
       if (typeof args.flags["can-invite"] === "string") permissions.can_invite = args.flags["can-invite"] === "true";
-      await client.setMemberPermissions(roomId, agentId, permissions);
-      outputJson({ updated: true, room_id: roomId, agent_id: agentId, ...permissions });
+      await client.setMemberPermissions(roomId, participantId, permissions);
+      outputJson({ updated: true, room_id: roomId, participant_id: participantId, ...permissions });
       break;
     }
 

--- a/packages/protocol-core/src/client.ts
+++ b/packages/protocol-core/src/client.ts
@@ -523,12 +523,12 @@ export class BotCordClient {
 
   async inviteToRoom(
     roomId: string,
-    agentId: string,
+    participantId: string,
     options?: { can_send?: boolean; can_invite?: boolean },
   ): Promise<void> {
     await this.hubFetch(`/hub/rooms/${roomId}/members`, {
       method: "POST",
-      body: JSON.stringify({ agent_id: agentId, ...options }),
+      body: JSON.stringify({ participant_id: participantId, ...options }),
     });
   }
 
@@ -561,16 +561,16 @@ export class BotCordClient {
     return (await resp.json()) as RoomInfo;
   }
 
-  async removeMember(roomId: string, agentId: string): Promise<void> {
-    await this.hubFetch(`/hub/rooms/${roomId}/members/${agentId}`, {
+  async removeMember(roomId: string, participantId: string): Promise<void> {
+    await this.hubFetch(`/hub/rooms/${roomId}/members/${participantId}`, {
       method: "DELETE",
     });
   }
 
-  async promoteMember(roomId: string, agentId: string, role: "admin" | "member"): Promise<void> {
+  async promoteMember(roomId: string, participantId: string, role: "admin" | "member"): Promise<void> {
     await this.hubFetch(`/hub/rooms/${roomId}/promote`, {
       method: "POST",
-      body: JSON.stringify({ agent_id: agentId, role }),
+      body: JSON.stringify({ participant_id: participantId, role }),
     });
   }
 
@@ -589,12 +589,12 @@ export class BotCordClient {
 
   async setMemberPermissions(
     roomId: string,
-    agentId: string,
+    participantId: string,
     permissions: { can_send?: boolean; can_invite?: boolean },
   ): Promise<void> {
     await this.hubFetch(`/hub/rooms/${roomId}/permissions`, {
       method: "POST",
-      body: JSON.stringify({ agent_id: agentId, ...permissions }),
+      body: JSON.stringify({ participant_id: participantId, ...permissions }),
     });
   }
 

--- a/packages/protocol-core/src/types.ts
+++ b/packages/protocol-core/src/types.ts
@@ -83,6 +83,8 @@ export type RoomInfo = {
   name: string;
   description?: string;
   rule?: string | null;
+  owner_id?: string;
+  owner_type?: "agent" | "human";
   visibility: "private" | "public";
   join_policy: "invite_only" | "open";
   required_subscription_product_id?: string | null;


### PR DESCRIPTION
## Summary
- allow hub room membership management endpoints to target human participants (`hu_*`) as well as agents
- require contacted humans before adding them as initial or later room members
- add participant/owner type fields to room responses and update CLI/protocol-core room commands to use participant ids

## Tests
- `cd backend && uv run pytest tests/test_hub_room_human_guard.py tests/test_room.py`
- `cd packages/protocol-core && npm run build`
- `cd cli && npm run build`
