### PR TITLE
ci: add manual PR backend preview deploy

### DIFF
--- a/.github/workflows/deploy-pr-backend-preview.yml
+++ b/.github/workflows/deploy-pr-backend-preview.yml
@@ -1,0 +1,271 @@
+name: Deploy PR Backend Preview
+run-name: Deploy PR #${{ inputs.pr_number }} backend to preview
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to deploy"
+        required: true
+        type: string
+      run_tests:
+        description: "Run backend tests before deploying"
+        required: false
+        default: true
+        type: boolean
+      run_migrations:
+        description: "Run preview DB migrations before deploying"
+        required: false
+        default: false
+        type: boolean
+      notes:
+        description: "Optional deployment notes"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: deploy-pr-backend-preview
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Resolve PR
+    runs-on: self-hosted
+    timeout-minutes: 5
+    outputs:
+      pr_number: ${{ steps.pr.outputs.pr_number }}
+      pr_title: ${{ steps.pr.outputs.pr_title }}
+      pr_url: ${{ steps.pr.outputs.pr_url }}
+      head_ref: ${{ steps.pr.outputs.head_ref }}
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+    steps:
+      - name: Resolve same-repository PR head
+        id: pr
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+        with:
+          script: |
+            const raw = process.env.PR_NUMBER || "";
+            const prNumber = Number.parseInt(raw, 10);
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              core.setFailed(`Invalid PR number: ${raw}`);
+              return;
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            if (pr.state !== "open") {
+              core.setFailed(`PR #${prNumber} is ${pr.state}; only open PRs can be deployed to preview.`);
+              return;
+            }
+
+            const repoFullName = `${context.repo.owner}/${context.repo.repo}`;
+            if (pr.head.repo.full_name !== repoFullName) {
+              core.setFailed(`PR #${prNumber} comes from ${pr.head.repo.full_name}; preview deploy only allows same-repository PRs.`);
+              return;
+            }
+
+            core.setOutput("pr_number", String(prNumber));
+            core.setOutput("pr_title", pr.title);
+            core.setOutput("pr_url", pr.html_url);
+            core.setOutput("head_ref", pr.head.ref);
+            core.setOutput("head_sha", pr.head.sha);
+
+      - name: Create summary
+        run: |
+          echo "## Backend Preview Deployment" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Item | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| PR | [#${{ steps.pr.outputs.pr_number }}](${{ steps.pr.outputs.pr_url }}) |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Branch | \`${{ steps.pr.outputs.head_ref }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Commit | \`${{ steps.pr.outputs.head_sha }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Run tests | ${{ inputs.run_tests }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Run migrations | ${{ inputs.run_migrations }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Notes | ${{ inputs.notes || 'none' }} |" >> "$GITHUB_STEP_SUMMARY"
+
+  backend-tests:
+    name: Backend Tests
+    needs: [prepare]
+    if: inputs.run_tests == true
+    runs-on: self-hosted
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.head_sha }}
+      - uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.12"
+      - name: Install deps
+        run: uv sync
+      - name: Run backend tests
+        run: uv run pytest tests/
+
+  migrate-preview:
+    name: Migrate Preview DB
+    needs: [prepare, backend-tests]
+    if: |
+      always() &&
+      inputs.run_migrations == true &&
+      needs.prepare.result == 'success' &&
+      (inputs.run_tests == false || needs.backend-tests.result == 'success')
+    runs-on: self-hosted
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.head_sha }}
+      - uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.12"
+      - name: Install deps
+        run: uv sync
+      - name: Run SQL migrations
+        run: uv run python scripts/run_sql_migrations.py
+        env:
+          DATABASE_URL: ${{ secrets.PREVIEW_DATABASE_URL }}
+
+  deploy-preview:
+    name: Deploy Backend Preview
+    needs: [prepare, backend-tests, migrate-preview]
+    if: |
+      always() &&
+      needs.prepare.result == 'success' &&
+      (inputs.run_tests == false || needs.backend-tests.result == 'success') &&
+      (inputs.run_migrations == false || needs.migrate-preview.result == 'success')
+    uses: ./.github/workflows/deploy-backend.yml
+    with:
+      env_name: preview
+      ref: ${{ needs.prepare.outputs.head_sha }}
+    secrets: inherit
+
+  pr-comment:
+    name: Comment on PR
+    needs: [prepare, backend-tests, migrate-preview, deploy-preview]
+    if: always() && needs.prepare.result == 'success'
+    runs-on: self-hosted
+    timeout-minutes: 5
+    steps:
+      - name: Post or update preview deployment comment
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
+          PR_TITLE: ${{ needs.prepare.outputs.pr_title }}
+          HEAD_REF: ${{ needs.prepare.outputs.head_ref }}
+          HEAD_SHA: ${{ needs.prepare.outputs.head_sha }}
+          TEST_RESULT: ${{ needs.backend-tests.result }}
+          MIGRATE_RESULT: ${{ needs.migrate-preview.result }}
+          DEPLOY_RESULT: ${{ needs.deploy-preview.result }}
+          RUN_TESTS: ${{ inputs.run_tests }}
+          RUN_MIGRATIONS: ${{ inputs.run_migrations }}
+          NOTES: ${{ inputs.notes }}
+        with:
+          script: |
+            const prNumber = Number.parseInt(process.env.PR_NUMBER, 10);
+            const sha = (process.env.HEAD_SHA || "").slice(0, 7);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const commitUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${process.env.HEAD_SHA}`;
+            const statusIcon = process.env.DEPLOY_RESULT === "success" ? "✅" : "❌";
+            const tests = process.env.RUN_TESTS === "true" ? process.env.TEST_RESULT : "skipped by input";
+            const migrations = process.env.RUN_MIGRATIONS === "true" ? process.env.MIGRATE_RESULT : "skipped by input";
+            const notes = process.env.NOTES ? `\n\nNotes: ${process.env.NOTES}` : "";
+
+            const marker = "<!-- botcord-pr-backend-preview-deploy -->";
+            const body = [
+              marker,
+              `## ${statusIcon} Backend Preview Deployment`,
+              "",
+              "| Item | Value |",
+              "|---|---|",
+              `| PR | #${prNumber} ${process.env.PR_TITLE || ""} |`,
+              `| Branch | \`${process.env.HEAD_REF}\` |`,
+              `| Commit | [\`${sha}\`](${commitUrl}) |`,
+              `| Backend tests | ${tests} |`,
+              `| Migrations | ${migrations} |`,
+              `| Deploy | ${process.env.DEPLOY_RESULT} |`,
+              `| Preview API | https://api.preview.botcord.chat |`,
+              `| Workflow | [View run](${runUrl}) |`,
+              notes,
+            ].join("\n");
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find((comment) =>
+              comment.user?.type === "Bot" && comment.body?.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
+
+  notify:
+    name: Notify Feishu
+    needs: [prepare, backend-tests, migrate-preview, deploy-preview]
+    if: always() && needs.prepare.result == 'success'
+    runs-on: self-hosted
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.head_sha }}
+      - name: Determine status
+        id: status
+        run: |
+          if [ "${{ needs.deploy-preview.result }}" = "success" ]; then
+            echo "title=✅ BotCord PR Backend Preview 部署成功" >> "$GITHUB_OUTPUT"
+            echo "color=green" >> "$GITHUB_OUTPUT"
+          else
+            echo "title=❌ BotCord PR Backend Preview 部署失败" >> "$GITHUB_OUTPUT"
+            echo "color=red" >> "$GITHUB_OUTPUT"
+          fi
+      - uses: ./.github/actions/feishu-notify
+        with:
+          webhook_url: ${{ secrets.FEISHU_WEBHOOK_URL }}
+          title: ${{ steps.status.outputs.title }}
+          color: ${{ steps.status.outputs.color }}
+          commit_msg: ${{ needs.prepare.outputs.pr_title }}
+          fields: |
+            [
+              {"label": "PR", "value": "[#${{ needs.prepare.outputs.pr_number }}](${{ needs.prepare.outputs.pr_url }})"},
+              {"label": "分支", "value": "${{ needs.prepare.outputs.head_ref }}"},
+              {"label": "Commit", "value": "[${{ needs.prepare.outputs.head_sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ needs.prepare.outputs.head_sha }})"},
+              {"label": "Backend Tests", "value": "${{ needs.backend-tests.result }}"},
+              {"label": "Migrations", "value": "${{ needs.migrate-preview.result }}"},
+              {"label": "Deploy", "value": "${{ needs.deploy-preview.result }}"},
+              {"label": "触发者", "value": "${{ github.actor }}"}
+            ]
+          buttons: |
+            [
+              {"text": "查看 Workflow", "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}", "type": "primary"},
+              {"text": "打开 PR", "url": "${{ needs.prepare.outputs.pr_url }}", "type": "default"}
+            ]


### PR DESCRIPTION
## Summary
- add a manual workflow to deploy a same-repository PR backend to the shared preview environment
- resolve the PR head SHA, optionally run backend tests and preview DB migrations, then reuse the existing backend preview deployment workflow
- post deployment status back to the PR and send the existing Feishu notification

## Testing
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/deploy-pr-backend-preview.yml'); puts 'yaml ok'"\n\n## Notes\n- GitHub only exposes workflow_dispatch workflows from the default branch, so this should be merged to main before it can be used from the Actions UI.