### PR TITLE
fix: allow owner to read bot DM messages

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -2262,6 +2262,27 @@ async def get_room_messages(
                 if owner_agent_result.scalar_one_or_none() is not None:
                     is_member = True
                     viewer_agent_id = room.owner_id
+
+            # The Human-first messages list also exposes rooms joined only by
+            # bots owned by the signed-in user (see /api/humans/me/agent-rooms).
+            # Let the owner read those histories without forcing the frontend
+            # to switch the whole dashboard into X-Active-Agent mode.
+            if not is_member:
+                owned_agent_member_result = await db.execute(
+                    select(RoomMember.agent_id)
+                    .join(Agent, Agent.agent_id == RoomMember.agent_id)
+                    .where(
+                        RoomMember.room_id == room_id,
+                        RoomMember.participant_type == ParticipantType.agent,
+                        Agent.user_id == user.id,
+                    )
+                    .order_by(Agent.created_at)
+                    .limit(1)
+                )
+                owned_agent_id = owned_agent_member_result.scalar_one_or_none()
+                if owned_agent_id is not None:
+                    is_member = True
+                    viewer_agent_id = owned_agent_id
         except HTTPException:
             pass  # Invalid token — fall through to public view
 

--- a/backend/tests/test_app/test_app_dashboard.py
+++ b/backend/tests/test_app/test_app_dashboard.py
@@ -376,6 +376,62 @@ async def test_dashboard_overview_human_mode(
 
 
 @pytest.mark.asyncio
+async def test_dashboard_room_messages_allows_human_owner_to_read_owned_bot_dm(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    seed_data: dict,
+):
+    """Human owner can read bot-only rooms surfaced by /humans/me/agent-rooms."""
+    room_id = "rm_dm_ag_dashtest001_ag_other00001"
+    db_session.add(
+        Room(
+            room_id=room_id,
+            name="Bot DM",
+            description="Bot to bot DM",
+            owner_id="ag_dashtest001",
+            owner_type=ParticipantType.agent,
+            visibility=RoomVisibility.private,
+            join_policy=RoomJoinPolicy.invite_only,
+        )
+    )
+    db_session.add_all([
+        RoomMember(
+            room_id=room_id,
+            agent_id="ag_dashtest001",
+            participant_type=ParticipantType.agent,
+            role=RoomRole.owner,
+        ),
+        RoomMember(
+            room_id=room_id,
+            agent_id="ag_other00001",
+            participant_type=ParticipantType.agent,
+            role=RoomRole.member,
+        ),
+        MessageRecord(
+            hub_msg_id="hm_botdm001",
+            msg_id="msg_botdm001",
+            sender_id="ag_dashtest001",
+            receiver_id="ag_other00001",
+            room_id=room_id,
+            envelope_json='{"from":"ag_dashtest001","type":"message","payload":{"text":"owned bot hello"}}',
+            ttl_sec=3600,
+        ),
+    ])
+    await db_session.commit()
+
+    resp = await client.get(
+        f"/api/dashboard/rooms/{room_id}/messages",
+        headers={"Authorization": f"Bearer {seed_data['token']}"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["messages"][0]["hub_msg_id"] == "hm_botdm001"
+    assert data["messages"][0]["text"] == "owned bot hello"
+    assert data["messages"][0]["is_mine"] is True
+
+
+@pytest.mark.asyncio
 async def test_dashboard_overview_wrong_agent(client: AsyncClient, seed_data: dict):
     """Should return 404 when X-Active-Agent references a non-existent agent."""
     token = seed_data["token"]


### PR DESCRIPTION
## Summary
- allow the human owner to read room history for rooms joined by their owned bots
- keep bot-only DM message loading aligned with /api/humans/me/agent-rooms
- add regression coverage for rm_dm_ag_*_ag_* rooms without X-Active-Agent

## Tests
- cd backend && uv run pytest tests/test_app/test_app_dashboard.py -q
- cd backend && uv run pytest tests/test_app/test_app_humans.py -q -k "agent_rooms or owned_agent_rooms"