### PR TITLE
feat: auto-pause idle cloud agents

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -34,3 +34,13 @@ BETA_GATE_ENABLED=false
 # Resend email service
 RESEND_API_KEY=
 RESEND_FROM_EMAIL=BotCord <noreply@mail.app.botcord.chat>
+
+# Cloud Agent
+CLOUD_AGENT_FEATURE_ENABLED=false
+# Use e2b for any environment where Cloud Agents should actually reply.
+# Local tests/dev may set this to fake intentionally.
+CLOUD_AGENT_DEFAULT_PROVIDER=e2b
+CLOUD_AGENT_IDLE_PAUSE_SECONDS=300
+CLOUD_AGENT_IDLE_SWEEP_INTERVAL_SECONDS=60
+E2B_API_KEY=
+DEEPSEEK_API_KEY=

--- a/backend/hub/cloud_agent_idle.py
+++ b/backend/hub/cloud_agent_idle.py
@@ -1,0 +1,41 @@
+"""Background loop for idle Cloud Agent sandbox pause."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from hub import config as hub_config
+from hub.database import async_session
+from hub.services.cloud_agent import CloudAgentService
+
+logger = logging.getLogger(__name__)
+
+
+async def cloud_agent_idle_pause_loop() -> None:
+    """Pause ready Cloud Agent sandboxes after the configured idle window."""
+    service = CloudAgentService()
+    while True:
+        try:
+            count = await _pause_idle_cloud_daemons(service)
+            if count:
+                logger.info("Idle-paused %d cloud daemon sandbox(es)", count)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("cloud_agent_idle_pause_loop error")
+        await asyncio.sleep(hub_config.CLOUD_AGENT_IDLE_SWEEP_INTERVAL_SECONDS)
+
+
+async def _pause_idle_cloud_daemons(service: CloudAgentService | None = None) -> int:
+    if not hub_config.CLOUD_AGENT_FEATURE_ENABLED:
+        return 0
+    if hub_config.CLOUD_AGENT_IDLE_PAUSE_SECONDS <= 0:
+        return 0
+
+    svc = service or CloudAgentService()
+    async with async_session() as session:
+        return await svc.pause_idle_cloud_daemons(
+            session,
+            idle_seconds=hub_config.CLOUD_AGENT_IDLE_PAUSE_SECONDS,
+        )

--- a/backend/hub/config.py
+++ b/backend/hub/config.py
@@ -296,14 +296,22 @@ CLOUD_AGENT_DEFAULT_MODEL_PROFILE: str = os.getenv(
     "CLOUD_AGENT_DEFAULT_MODEL_PROFILE", "deepseek-v4-flash"
 )
 
-# Provider implementation key. ``fake`` for PR 3 unit tests and local dev.
-# PR 4 will introduce ``e2b`` once the E2BCloudDaemonProvider lands.
-CLOUD_AGENT_DEFAULT_PROVIDER: str = os.getenv("CLOUD_AGENT_DEFAULT_PROVIDER", "fake")
+# Provider implementation key. Production/preview must use ``e2b`` so a
+# created Cloud Agent actually gets a sandbox-backed daemon. Tests and local
+# smoke runs that intentionally avoid E2B can opt into ``fake`` explicitly.
+CLOUD_AGENT_DEFAULT_PROVIDER: str = os.getenv("CLOUD_AGENT_DEFAULT_PROVIDER", "e2b")
 
 # Slot capacity per cloud daemon — schema allows >1 to keep the per-agent
 # sandbox cost down. Conservative default while we observe real load.
 CLOUD_AGENT_DEFAULT_MAX_AGENTS_PER_DAEMON: int = int(
     os.getenv("CLOUD_AGENT_DEFAULT_MAX_AGENTS_PER_DAEMON", "2")
+)
+
+CLOUD_AGENT_IDLE_PAUSE_SECONDS: float = float(
+    os.getenv("CLOUD_AGENT_IDLE_PAUSE_SECONDS", "300")
+)
+CLOUD_AGENT_IDLE_SWEEP_INTERVAL_SECONDS: float = float(
+    os.getenv("CLOUD_AGENT_IDLE_SWEEP_INTERVAL_SECONDS", "60")
 )
 
 # ---------------------------------------------------------------------------

--- a/backend/hub/main.py
+++ b/backend/hub/main.py
@@ -18,6 +18,7 @@ from sqlalchemy import text
 from hub.config import DATABASE_SCHEMA
 from hub.database import async_session, engine
 from hub.models import Agent, Base, MessagePolicy
+from hub.cloud_agent_idle import cloud_agent_idle_pause_loop
 from hub.cleanup import file_cleanup_loop
 from hub.presence_cleanup import presence_cleanup_loop
 from hub import config as hub_config
@@ -119,6 +120,7 @@ async def lifespan(app: FastAPI):
     subscription_billing_task = None
     presence_task = None
     agent_schedule_task = None
+    cloud_agent_idle_task = None
     if not test_db_override:
         # Background message expiry loop
         expiry_task = asyncio.create_task(message_expiry_loop())
@@ -130,11 +132,20 @@ async def lifespan(app: FastAPI):
         presence_task = asyncio.create_task(presence_cleanup_loop())
         # Background proactive agent schedule loop
         agent_schedule_task = asyncio.create_task(agent_schedule_loop())
+        # Background Cloud Agent idle sandbox pause loop
+        cloud_agent_idle_task = asyncio.create_task(cloud_agent_idle_pause_loop())
 
     yield
 
     # Shutdown
-    for task in (agent_schedule_task, presence_task, subscription_billing_task, cleanup_task, expiry_task):
+    for task in (
+        cloud_agent_idle_task,
+        agent_schedule_task,
+        presence_task,
+        subscription_billing_task,
+        cleanup_task,
+        expiry_task,
+    ):
         if task is None:
             continue
         task.cancel()

--- a/backend/hub/routers/dashboard_chat.py
+++ b/backend/hub/routers/dashboard_chat.py
@@ -216,11 +216,32 @@ async def send_chat_message(
     if not user_id:
         raise I18nHTTPException(status_code=400, message_key="user_id_required_for_chat")
 
-    # Fetch agent display name
-    agent_result = await db.execute(
-        select(Agent.display_name).where(Agent.agent_id == agent_id)
-    )
-    agent_display_name = agent_result.scalar_one_or_none() or agent_id
+    # Fetch agent and wake/resume its cloud runtime when needed.
+    agent_result = await db.execute(select(Agent).where(Agent.agent_id == agent_id))
+    agent = agent_result.scalar_one_or_none()
+    agent_display_name = agent.display_name if agent is not None else agent_id
+    if agent is not None and agent.hosting_kind == "cloud":
+        try:
+            from hub.services.cloud_agent import CloudAgentError, CloudAgentService
+
+            await CloudAgentService().resume_cloud_agent(
+                db,
+                user_id=uuid.UUID(user_id),
+                agent_id=agent_id,
+            )
+        except (CloudAgentError, ValueError) as exc:
+            logger.warning(
+                "Dashboard chat cloud resume skipped: agent=%s err=%s",
+                agent_id,
+                exc,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "Dashboard chat cloud resume failed: agent=%s err=%s",
+                agent_id,
+                exc,
+                exc_info=True,
+            )
 
     # Ensure room exists
     room_id = await _ensure_owner_chat_room(db, user_id, agent_id, agent_display_name)

--- a/backend/hub/services/cloud_agent.py
+++ b/backend/hub/services/cloud_agent.py
@@ -59,6 +59,7 @@ from hub.models import (
     MessageRecord,
     SigningKey,
     UsageEvent,
+    UsageReservation,
 )
 from hub.routers.cloud_daemon_control import (
     CloudDaemonDispatchError,
@@ -187,6 +188,27 @@ _RUN_PROMPT_MAX_CHARS = 64 * 1024
 
 def _now() -> datetime.datetime:
     return datetime.datetime.now(datetime.timezone.utc)
+
+
+def _as_aware_utc(value: datetime.datetime | None) -> datetime.datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=datetime.timezone.utc)
+    return value.astimezone(datetime.timezone.utc)
+
+
+def _cloud_agent_last_activity_at(
+    cai: CloudAgentInstance, cdi: CloudDaemonInstance
+) -> datetime.datetime:
+    candidates = [
+        _as_aware_utc(cai.last_run_at),
+        _as_aware_utc(cai.updated_at),
+        _as_aware_utc(cai.created_at),
+        _as_aware_utc(cdi.last_started_at),
+        _as_aware_utc(cdi.created_at),
+    ]
+    return max(ts for ts in candidates if ts is not None)
 
 
 def _placeholder_refresh_hash() -> str:
@@ -475,6 +497,51 @@ class CloudAgentService:
         await db.refresh(cdi)
         return _make_view(agent, cai, cdi)
 
+    async def pause_idle_cloud_daemons(
+        self,
+        db: AsyncSession,
+        *,
+        idle_seconds: float,
+        now: datetime.datetime | None = None,
+        limit: int = 100,
+    ) -> int:
+        """Pause ready cloud daemon sandboxes that have been idle long enough.
+
+        This is intentionally conservative: a daemon is eligible only when all
+        ready agents under it are idle and no cloud-run message or usage
+        reservation suggests work is still pending.
+        """
+        if idle_seconds <= 0:
+            return 0
+
+        current = now or _now()
+        cutoff = current - datetime.timedelta(seconds=idle_seconds)
+        result = await db.execute(
+            select(CloudDaemonInstance)
+            .where(CloudDaemonInstance.status == "ready")
+            .order_by(CloudDaemonInstance.updated_at.asc())
+            .limit(limit)
+        )
+        candidates = list(result.scalars().all())
+        paused = 0
+
+        for cdi in candidates:
+            try:
+                if await self._pause_cloud_daemon_if_idle(
+                    db, cdi, cutoff=cutoff, now=current
+                ):
+                    paused += 1
+            except Exception as exc:  # noqa: BLE001
+                await db.rollback()
+                logger.warning(
+                    "idle pause failed: cloud=%s sandbox=%s err=%s",
+                    cdi.id,
+                    cdi.provider_sandbox_id,
+                    exc,
+                )
+
+        return paused
+
     async def resume_cloud_agent(
         self,
         db: AsyncSession,
@@ -489,11 +556,18 @@ class CloudAgentService:
                 f"cannot resume cloud agent in status {cai.status!r}",
                 http_status=409,
             )
-        if cai.status == "ready":
+        daemon_online = is_cloud_daemon_online(cdi.id)
+        if cai.status == "ready" and daemon_online:
             return _make_view(agent, cai, cdi)
 
         provider = self._get_provider()
-        if cdi.status != "ready":
+        if cdi.status != "ready" or not daemon_online:
+            if not daemon_online:
+                _ensure_provisioning_metadata(db, cai, agent)
+                cai.status = "provisioning"
+                cai.error_code = None
+                cai.error_message = None
+                await db.commit()
             handle = await provider.create_or_resume(
                 cloud_daemon_instance_id=cdi.id,
                 daemon_instance_id=cdi.daemon_instance_id,
@@ -503,9 +577,22 @@ class CloudAgentService:
             )
             _apply_handle_to_rows(cdi, handle)
             cdi.last_started_at = _now()
-        cai.status = "ready"
-        cai.error_code = None
-        cai.error_message = None
+            if handle.status == "failed":
+                cai.status = "failed"
+                cai.error_code = handle.error_code
+                cai.error_message = handle.error_message
+            elif handle.status == "ready":
+                cai.status = "ready"
+                cai.error_code = None
+                cai.error_message = None
+            else:
+                cai.status = "provisioning"
+                cai.error_code = None
+                cai.error_message = None
+        else:
+            cai.status = "ready"
+            cai.error_code = None
+            cai.error_message = None
         await db.commit()
         await db.refresh(cai)
         await db.refresh(cdi)
@@ -1049,6 +1136,89 @@ class CloudAgentService:
                 http_status=403,
             )
 
+    async def _pause_cloud_daemon_if_idle(
+        self,
+        db: AsyncSession,
+        cdi: CloudDaemonInstance,
+        *,
+        cutoff: datetime.datetime,
+        now: datetime.datetime,
+    ) -> bool:
+        agents_result = await db.execute(
+            select(CloudAgentInstance).where(
+                CloudAgentInstance.cloud_daemon_instance_id == cdi.id,
+                CloudAgentInstance.status.in_(("provisioning", "ready")),
+            )
+        )
+        agents = list(agents_result.scalars().all())
+        if not agents:
+            return False
+        if any(agent.status == "provisioning" for agent in agents):
+            return False
+        if await self._cloud_daemon_has_active_run(db, cdi.id):
+            return False
+
+        for agent in agents:
+            if _cloud_agent_last_activity_at(agent, cdi) > cutoff:
+                return False
+
+        provider = self._get_provider()
+        handle = await provider.pause(
+            cloud_daemon_instance_id=cdi.id,
+            provider_sandbox_id=cdi.provider_sandbox_id,
+        )
+        _apply_handle_to_rows(cdi, handle)
+        cdi.last_paused_at = now
+        cdi.metadata_json = {
+            **(cdi.metadata_json or {}),
+            "last_pause_reason": "idle_timeout",
+        }
+        flag_modified(cdi, "metadata_json")
+        for agent in agents:
+            agent.status = "paused"
+            agent.error_code = None
+            agent.error_message = None
+        await db.commit()
+        logger.info(
+            "idle-paused cloud daemon %s after %d idle agent(s)",
+            cdi.id,
+            len(agents),
+        )
+        return True
+
+    async def _cloud_daemon_has_active_run(
+        self, db: AsyncSession, cloud_daemon_instance_id: str
+    ) -> bool:
+        agent_ids_subquery = (
+            select(CloudAgentInstance.agent_id)
+            .where(
+                CloudAgentInstance.cloud_daemon_instance_id
+                == cloud_daemon_instance_id
+            )
+            .subquery()
+        )
+        active_reservations = await db.scalar(
+            select(func.count())
+            .select_from(UsageReservation)
+            .where(
+                UsageReservation.agent_id.in_(select(agent_ids_subquery.c.agent_id)),
+                UsageReservation.state == "active",
+            )
+        )
+        if (active_reservations or 0) > 0:
+            return True
+
+        active_messages = await db.scalar(
+            select(func.count())
+            .select_from(MessageRecord)
+            .where(
+                MessageRecord.receiver_id.in_(select(agent_ids_subquery.c.agent_id)),
+                MessageRecord.source_type == "cloud_agent_run",
+                MessageRecord.state.notin_((MessageState.done, MessageState.failed)),
+            )
+        )
+        return (active_messages or 0) > 0
+
     async def _enforce_per_user_quota(
         self,
         db: AsyncSession,
@@ -1196,6 +1366,51 @@ def _scrub_provisioning_metadata(cai: CloudAgentInstance) -> None:
     # SQLAlchemy needs an explicit dirty flag on mutable JSON columns
     # when we mutate-in-place; assigning a fresh dict above already
     # triggers it, but flag_modified is the safer pattern here.
+    flag_modified(cai, "metadata_json")
+
+
+def _ensure_provisioning_metadata(
+    db: AsyncSession,
+    cai: CloudAgentInstance,
+    agent: Agent,
+) -> None:
+    """Ensure a cloud agent can be provisioned into a fresh sandbox.
+
+    E2B sandboxes can disappear after their lifetime elapses. A restarted
+    cloud daemon always boots with zero channels, so Hub must be able to send
+    ``provision_agent`` again even for agents that were previously ready. If
+    the one-time provisioning key was scrubbed, rotate in a new signing key for
+    the same agent id and issue a fresh agent token.
+    """
+    provisioning = (cai.metadata_json or {}).get("provisioning") or {}
+    if provisioning.get("private_key_b64") and provisioning.get("key_id"):
+        return
+
+    signing_key = NaClSigningKey.generate()
+    pubkey_b64 = base64.b64encode(bytes(signing_key.verify_key)).decode("ascii")
+    private_key_b64 = base64.b64encode(bytes(signing_key)).decode("ascii")
+    key_id = generate_key_id()
+    cai.metadata_json = {
+        **(cai.metadata_json or {}),
+        "provisioning": {
+            "private_key_b64": private_key_b64,
+            "public_key_b64": pubkey_b64,
+            "key_id": key_id,
+        },
+    }
+    db.add(
+        SigningKey(
+            agent_id=agent.agent_id,
+            key_id=key_id,
+            pubkey=f"ed25519:{pubkey_b64}",
+            state=KeyState.active,
+        )
+    )
+    agent_token, token_expires_at = create_agent_token(agent.agent_id)
+    agent.agent_token = agent_token
+    agent.token_expires_at = datetime.datetime.fromtimestamp(
+        token_expires_at, tz=datetime.timezone.utc
+    )
     flag_modified(cai, "metadata_json")
 
 

--- a/backend/tests/test_cloud_agent_provisioning.py
+++ b/backend/tests/test_cloud_agent_provisioning.py
@@ -296,6 +296,47 @@ async def test_provision_dispatch_ack_false_leaves_provisioning(db_session):
 
 
 @pytest.mark.asyncio
+async def test_resume_ready_agent_offline_rotates_key_for_reprovision(db_session):
+    service = _make_e2b_service()
+    user_id = uuid.uuid4()
+    view = await service.create_cloud_agent(
+        db_session, user_id=user_id, body=CreateCloudAgentInput(name="A")
+    )
+
+    conn, ws = await _register_fake_conn(view.cloud_daemon_instance_id, "dm_resume")
+    try:
+        t = asyncio.create_task(
+            _ack_frame_when_sent(conn, ws, expected_type="provision_agent")
+        )
+        await service.provision_pending_for_cloud_daemon(
+            db_session, cloud_daemon_instance_id=view.cloud_daemon_instance_id
+        )
+        await t
+    finally:
+        await _registry_for_tests().unregister(conn)
+
+    cai = await db_session.scalar(
+        select(CloudAgentInstance).where(CloudAgentInstance.agent_id == view.agent_id)
+    )
+    assert cai is not None
+    assert "provisioning" not in (cai.metadata_json or {})
+
+    resumed = await service.resume_cloud_agent(
+        db_session, user_id=user_id, agent_id=view.agent_id
+    )
+    assert resumed.status == "provisioning"
+    assert resumed.cloud_daemon_status == "starting"
+
+    refreshed = await db_session.scalar(
+        select(CloudAgentInstance).where(CloudAgentInstance.agent_id == view.agent_id)
+    )
+    provisioning = (refreshed.metadata_json or {}).get("provisioning")
+    assert provisioning["private_key_b64"]
+    assert provisioning["public_key_b64"]
+    assert provisioning["key_id"]
+
+
+@pytest.mark.asyncio
 async def test_provision_dispatch_offline_records_error(db_session):
     """provision drain with no daemon connected stamps an error, no exception."""
     service = _make_e2b_service()

--- a/backend/tests/test_cloud_agent_service.py
+++ b/backend/tests/test_cloud_agent_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime
 import uuid
 
 import pytest
@@ -10,7 +11,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from hub.auth import assert_current_agent_token
-from hub.enums import KeyState
+from hub.enums import KeyState, MessageState
 from hub.i18n import I18nHTTPException
 from hub.models import (
     Agent,
@@ -18,7 +19,9 @@ from hub.models import (
     CloudAgentInstance,
     CloudDaemonInstance,
     DaemonInstance,
+    MessageRecord,
     SigningKey,
+    UsageReservation,
 )
 from hub.services.cloud_agent import (
     CloudAgentError,
@@ -280,6 +283,141 @@ async def test_pause_only_pauses_daemon_when_last_agent_paused(db_session):
     await db_session.refresh(cdi)
     assert cdi.status == "paused"
     assert fake.calls(a.cloud_daemon_instance_id)["pause"] == 1
+
+
+@pytest.mark.asyncio
+async def test_idle_pause_pauses_ready_daemon_and_agents(db_session):
+    user_id = uuid.uuid4()
+    svc, fake = _make_service()
+    view = await svc.create_cloud_agent(
+        db_session, user_id=user_id, body=CreateCloudAgentInput(name="A")
+    )
+    future_now = datetime.datetime(2030, 1, 1, tzinfo=datetime.timezone.utc)
+
+    paused_count = await svc.pause_idle_cloud_daemons(
+        db_session, idle_seconds=300, now=future_now
+    )
+
+    cai = await db_session.scalar(
+        select(CloudAgentInstance).where(CloudAgentInstance.agent_id == view.agent_id)
+    )
+    cdi = await db_session.scalar(
+        select(CloudDaemonInstance).where(
+            CloudDaemonInstance.id == view.cloud_daemon_instance_id
+        )
+    )
+    assert paused_count == 1
+    assert cai.status == "paused"
+    assert cdi.status == "paused"
+    assert cdi.last_paused_at.replace(tzinfo=datetime.timezone.utc) == future_now
+    assert cdi.metadata_json["last_pause_reason"] == "idle_timeout"
+    assert fake.calls(view.cloud_daemon_instance_id)["pause"] == 1
+
+
+@pytest.mark.asyncio
+async def test_idle_pause_waits_for_all_agents_on_daemon(db_session):
+    user_id = uuid.uuid4()
+    svc, fake = _make_service(max_per_user=4, max_agents_per_daemon=2)
+    a = await svc.create_cloud_agent(
+        db_session, user_id=user_id, body=CreateCloudAgentInput(name="A")
+    )
+    b = await svc.create_cloud_agent(
+        db_session, user_id=user_id, body=CreateCloudAgentInput(name="B")
+    )
+    assert a.cloud_daemon_instance_id == b.cloud_daemon_instance_id
+
+    now = datetime.datetime(2030, 1, 1, tzinfo=datetime.timezone.utc)
+    recent = now - datetime.timedelta(seconds=30)
+    b_row = await db_session.scalar(
+        select(CloudAgentInstance).where(CloudAgentInstance.agent_id == b.agent_id)
+    )
+    b_row.last_run_at = recent
+    await db_session.commit()
+
+    paused_count = await svc.pause_idle_cloud_daemons(
+        db_session, idle_seconds=300, now=now
+    )
+
+    cdi = await db_session.scalar(
+        select(CloudDaemonInstance).where(
+            CloudDaemonInstance.id == a.cloud_daemon_instance_id
+        )
+    )
+    assert paused_count == 0
+    assert cdi.status == "ready"
+    assert fake.calls(a.cloud_daemon_instance_id)["pause"] == 0
+
+
+@pytest.mark.asyncio
+async def test_idle_pause_skips_active_reservation(db_session):
+    user_id = uuid.uuid4()
+    svc, fake = _make_service()
+    view = await svc.create_cloud_agent(
+        db_session, user_id=user_id, body=CreateCloudAgentInput(name="A")
+    )
+    db_session.add(
+        UsageReservation(
+            user_id=user_id,
+            agent_id=view.agent_id,
+            run_id="run_active",
+            reserved_credits=10,
+            reserved_sandbox_seconds=60,
+            state="active",
+        )
+    )
+    await db_session.commit()
+
+    paused_count = await svc.pause_idle_cloud_daemons(
+        db_session,
+        idle_seconds=300,
+        now=datetime.datetime(2030, 1, 1, tzinfo=datetime.timezone.utc),
+    )
+
+    cdi = await db_session.scalar(
+        select(CloudDaemonInstance).where(
+            CloudDaemonInstance.id == view.cloud_daemon_instance_id
+        )
+    )
+    assert paused_count == 0
+    assert cdi.status == "ready"
+    assert fake.calls(view.cloud_daemon_instance_id)["pause"] == 0
+
+
+@pytest.mark.asyncio
+async def test_idle_pause_skips_active_cloud_run_message(db_session):
+    user_id = uuid.uuid4()
+    svc, fake = _make_service()
+    view = await svc.create_cloud_agent(
+        db_session, user_id=user_id, body=CreateCloudAgentInput(name="A")
+    )
+    db_session.add(
+        MessageRecord(
+            hub_msg_id="hub_msg_idle_active",
+            msg_id="msg_idle_active",
+            sender_id=view.agent_id,
+            receiver_id=view.agent_id,
+            state=MessageState.queued,
+            envelope_json="{}",
+            ttl_sec=300,
+            source_type="cloud_agent_run",
+        )
+    )
+    await db_session.commit()
+
+    paused_count = await svc.pause_idle_cloud_daemons(
+        db_session,
+        idle_seconds=300,
+        now=datetime.datetime(2030, 1, 1, tzinfo=datetime.timezone.utc),
+    )
+
+    cdi = await db_session.scalar(
+        select(CloudDaemonInstance).where(
+            CloudDaemonInstance.id == view.cloud_daemon_instance_id
+        )
+    )
+    assert paused_count == 0
+    assert cdi.status == "ready"
+    assert fake.calls(view.cloud_daemon_instance_id)["pause"] == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a Cloud Agent idle pause background loop with configurable idle/sweep intervals
- pause ready cloud daemon sandboxes only when every hosted ready agent is idle
- skip idle pause while cloud-run messages or active usage reservations indicate pending work
- keep cloud agents resumable by refreshing provisioning metadata when the sandbox is offline

## Tests
- cd backend && uv run pytest tests/test_cloud_agent_service.py tests/test_cloud_agent_runs.py tests/test_cloud_agent_usage.py tests/test_cloud_daemon_provider_e2b.py tests/test_app/test_cloud_agents.py
- cd backend && uv run python -c "import hub.main; print('ok')"