### PR TITLE
fix: pause e2b sandboxes on timeout

### DIFF
--- a/backend/hub/config.py
+++ b/backend/hub/config.py
@@ -326,8 +326,8 @@ CLOUD_AGENT_IDLE_SWEEP_INTERVAL_SECONDS: float = float(
 E2B_API_KEY: str | None = os.getenv("E2B_API_KEY")
 E2B_TEMPLATE_ID: str = os.getenv("E2B_TEMPLATE_ID", "z0f20u29zdgx7cxnuzcu")
 E2B_DEFAULT_REGION: str | None = os.getenv("E2B_DEFAULT_REGION") or None
-# Wall-clock cap on a sandbox between hellos; the provider passes it to E2B
-# as the sandbox's max-lifetime hint so a hung sandbox is recycled.
+# Wall-clock cap for each running E2B sandbox window. The provider configures
+# E2B lifecycle on create so timeout pauses the sandbox instead of killing it.
 E2B_SANDBOX_TIMEOUT_SECONDS: int = int(os.getenv("E2B_SANDBOX_TIMEOUT_SECONDS", "1800"))
 
 # Command Hub runs inside a freshly-created or resumed cloud daemon instance.

--- a/backend/hub/services/cloud_daemon_provider_e2b.py
+++ b/backend/hub/services/cloud_daemon_provider_e2b.py
@@ -73,6 +73,7 @@ class E2BSandboxClient(Protocol):
         env: dict[str, str],
         region: str | None,
         timeout_seconds: int,
+        lifecycle: dict[str, Any] | None,
     ) -> SandboxRunResult:
         ...
 
@@ -170,12 +171,14 @@ class _E2BSdkClient:
         env: dict[str, str],
         region: str | None,
         timeout_seconds: int,
+        lifecycle: dict[str, Any] | None,
     ) -> SandboxRunResult:
         try:
             sandbox = await self._e2b.AsyncSandbox.create(
                 template=template_id,
                 timeout=timeout_seconds,
                 envs=env,
+                lifecycle=lifecycle,
                 **self._api_opts(),
             )
         except self._e2b.SandboxException as exc:
@@ -268,6 +271,7 @@ class _FakeSandboxRecord:
     template_id: str
     region: str | None
     env: dict[str, str]
+    lifecycle: dict[str, Any]
     status: str  # running | paused | killed
     commands: list[str] = field(default_factory=list)
 
@@ -308,6 +312,7 @@ class FakeE2BSandboxClient:
         env: dict[str, str],
         region: str | None,
         timeout_seconds: int,
+        lifecycle: dict[str, Any] | None,
     ) -> SandboxRunResult:
         if self._fail_on == "create":
             raise RuntimeError("fake e2b create failure")
@@ -319,6 +324,7 @@ class FakeE2BSandboxClient:
                 template_id=template_id,
                 region=region,
                 env=dict(env),
+                lifecycle=dict(lifecycle or {}),
                 status="running",
             )
             return SandboxRunResult(
@@ -408,6 +414,7 @@ class E2BCloudDaemonProvider:
         deepseek_api_key: str | None = None,
         startup_command: str = CLOUD_DAEMON_STARTUP_COMMAND,
         daemon_npm_spec: str = CLOUD_DAEMON_NPM_SPEC,
+        sandbox_lifecycle: dict[str, Any] | None = None,
     ) -> None:
         self._client = client
         self._template_id = template_id
@@ -416,6 +423,11 @@ class E2BCloudDaemonProvider:
         self._hub_public_base_url = hub_public_base_url
         self._startup_command = startup_command
         self._daemon_npm_spec = daemon_npm_spec
+        self._sandbox_lifecycle = (
+            dict(sandbox_lifecycle)
+            if sandbox_lifecycle is not None
+            else {"on_timeout": "pause", "auto_resume": False}
+        )
         # Allow tests to inject a key; otherwise default to Hub config.
         self._deepseek_api_key = (
             deepseek_api_key if deepseek_api_key is not None else DEEPSEEK_API_KEY
@@ -470,6 +482,7 @@ class E2BCloudDaemonProvider:
                         env=env,
                         region=chosen_region,
                         timeout_seconds=self._sandbox_timeout_seconds,
+                        lifecycle=self._sandbox_lifecycle,
                     )
             else:
                 run = await self._client.create_sandbox(
@@ -477,6 +490,7 @@ class E2BCloudDaemonProvider:
                     env=env,
                     region=chosen_region,
                     timeout_seconds=self._sandbox_timeout_seconds,
+                    lifecycle=self._sandbox_lifecycle,
                 )
 
             # Launch (or relaunch) the daemon as a background process.

--- a/backend/tests/test_cloud_daemon_provider_e2b.py
+++ b/backend/tests/test_cloud_daemon_provider_e2b.py
@@ -81,6 +81,7 @@ async def test_create_or_resume_starts_sandbox_and_injects_env():
     sandbox = client.get(handle.provider_sandbox_id)
     assert sandbox is not None
     assert sandbox.template_id == "tpl_test_default"
+    assert sandbox.lifecycle == {"on_timeout": "pause", "auto_resume": False}
     assert sandbox.commands == [CLOUD_DAEMON_STARTUP_COMMAND]
 
     # Env vars carry the WS connection info + secrets.
@@ -440,6 +441,7 @@ async def test_sdk_client_create_sandbox_forwards_args(fake_e2b_sdk_client):
         env={"FOO": "bar"},
         region="us-east-1",
         timeout_seconds=600,
+        lifecycle={"on_timeout": "pause", "auto_resume": False},
     )
     assert run.sandbox_id == "sbx_alpha"
     assert run.template_id == "tpl-x"
@@ -451,6 +453,10 @@ async def test_sdk_client_create_sandbox_forwards_args(fake_e2b_sdk_client):
     assert call["template"] == "tpl-x"
     assert call["timeout"] == 600
     assert call["envs"] == {"FOO": "bar"}
+    assert call["opts"]["lifecycle"] == {
+        "on_timeout": "pause",
+        "auto_resume": False,
+    }
     assert call["opts"]["api_key"] == "ek_test_apikey"
 
 
@@ -531,4 +537,5 @@ async def test_sdk_client_create_wraps_sdk_exception(fake_e2b_sdk_client):
             env={},
             region=None,
             timeout_seconds=60,
+            lifecycle={"on_timeout": "pause", "auto_resume": False},
         )


### PR DESCRIPTION
## Summary
- configure E2B sandbox lifecycle to pause instead of kill when timeout expires
- pass lifecycle through the provider client abstraction and fake client
- update E2B provider tests to assert lifecycle forwarding

## Tests
- cd backend && uv run pytest tests/test_cloud_daemon_provider_e2b.py tests/test_cloud_agent_service.py tests/test_cloud_agent_runs.py