### PR TITLE
feat: enable cloud agent gateway integrations

### DIFF
--- a/backend/app/routers/gateways.py
+++ b/backend/app/routers/gateways.py
@@ -1,14 +1,15 @@
 """
-[INPUT]: Authenticated user + their owned daemon-hosted agent + Pydantic
+[INPUT]: Authenticated user + their owned daemon/cloud-hosted agent + Pydantic
          third-party gateway connection requests.
 [OUTPUT]: GET/POST/PATCH/DELETE /api/agents/{agent_id}/gateways*  +
           POST /api/agents/{agent_id}/gateways/wechat/login/{start,status} —
           BFF surface for the dashboard "Channels" (接入) tab.
 [POS]: BFF wrapper around the daemon control-frame contract for
        Telegram / WeChat third-party channel adapters.
-[PROTOCOL]: User must own the agent; agent must be ``hosting_kind == 'daemon'``
-            with a non-null ``daemon_instance_id``. Daemon must be online for
-            write/login/test calls; reads of saved rows are allowed offline.
+[PROTOCOL]: User must own the agent; agent must be hosted by a local daemon or
+            a cloud daemon with a non-null ``daemon_instance_id``. Daemon must
+            be online for write/login/test calls; reads of saved rows are
+            allowed offline.
             Bot tokens never persist in Hub DB — they are forwarded once to
             the daemon (Telegram) or pulled by the daemon from a local login
             session (WeChat) and written to the daemon's local secret store.
@@ -31,8 +32,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.auth import RequestContext, require_user
 from hub.database import get_db
 from hub.id_generators import generate_gateway_connection_id
-from hub.models import Agent, AgentGatewayConnection
+from hub.models import Agent, AgentGatewayConnection, CloudAgentInstance
 from hub.routers.daemon_control import is_daemon_online, send_control_frame
+from hub.routers.cloud_daemon_control import (
+    CloudDaemonDispatchError,
+    is_cloud_daemon_online,
+    send_cloud_control_frame,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -213,20 +219,39 @@ async def _load_owned_agent(
     return agent
 
 
-async def _load_daemon_agent_or_422(
+class _GatewayHost(BaseModel):
+    daemon_instance_id: str
+    cloud_daemon_instance_id: str | None = None
+
+
+async def _load_gateway_host_or_422(
     db: AsyncSession, ctx: RequestContext, agent_id: str
-) -> Agent:
-    """Resolve agent + assert it is daemon-hosted with a bound daemon."""
+) -> tuple[Agent, _GatewayHost]:
+    """Resolve agent + the control-plane target for gateway operations."""
     agent = await _load_owned_agent(db, ctx, agent_id)
-    if agent.hosting_kind != "daemon" or not agent.daemon_instance_id:
-        raise HTTPException(status_code=422, detail="agent_not_daemon_hosted")
-    return agent
+    if agent.hosting_kind == "daemon" and agent.daemon_instance_id:
+        return agent, _GatewayHost(daemon_instance_id=agent.daemon_instance_id)
+    if agent.hosting_kind == "cloud" and agent.daemon_instance_id:
+        binding = await db.scalar(
+            select(CloudAgentInstance).where(
+                CloudAgentInstance.agent_id == agent_id,
+                CloudAgentInstance.user_id == ctx.user_id,
+                CloudAgentInstance.status.notin_(("deleting", "deleted")),
+            )
+        )
+        if binding is None:
+            raise HTTPException(status_code=422, detail="agent_not_daemon_hosted")
+        return agent, _GatewayHost(
+            daemon_instance_id=binding.daemon_instance_id,
+            cloud_daemon_instance_id=binding.cloud_daemon_instance_id,
+        )
+    raise HTTPException(status_code=422, detail="agent_not_daemon_hosted")
 
 
 async def _load_owned_connection(
     db: AsyncSession, ctx: RequestContext, agent_id: str, gateway_id: str
-) -> tuple[Agent, AgentGatewayConnection]:
-    agent = await _load_owned_agent(db, ctx, agent_id)
+) -> tuple[Agent, _GatewayHost, AgentGatewayConnection]:
+    agent, host = await _load_gateway_host_or_422(db, ctx, agent_id)
     result = await db.execute(
         select(AgentGatewayConnection).where(
             AgentGatewayConnection.id == gateway_id,
@@ -237,12 +262,37 @@ async def _load_owned_connection(
     row = result.scalar_one_or_none()
     if row is None:
         raise HTTPException(status_code=404, detail="gateway_not_found")
-    return agent, row
+    return agent, host, row
 
 
-def _require_online(daemon_instance_id: str) -> None:
-    if not is_daemon_online(daemon_instance_id):
+def _require_online(host: _GatewayHost) -> None:
+    online = (
+        is_cloud_daemon_online(host.cloud_daemon_instance_id)
+        if host.cloud_daemon_instance_id
+        else is_daemon_online(host.daemon_instance_id)
+    )
+    if not online:
         raise HTTPException(status_code=409, detail="daemon_offline")
+
+
+async def _send_gateway_control_frame(
+    host: _GatewayHost,
+    type_: str,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    if not host.cloud_daemon_instance_id:
+        return await send_control_frame(host.daemon_instance_id, type_, params)
+    try:
+        return await send_cloud_control_frame(host.cloud_daemon_instance_id, type_, params)
+    except CloudDaemonDispatchError as exc:
+        if exc.code == "cloud_daemon_offline":
+            raise HTTPException(status_code=409, detail="daemon_offline") from exc
+        if exc.code == "cloud_daemon_ack_timeout":
+            raise HTTPException(status_code=504, detail="daemon_ack_timeout") from exc
+        raise HTTPException(
+            status_code=502,
+            detail={"code": exc.code, "daemon_message": exc.message},
+        ) from exc
 
 
 def _ack_or_raise(ack: Any) -> dict[str, Any]:
@@ -422,10 +472,8 @@ async def create_gateway(
     if body.provider not in _ALLOWED_PROVIDERS:
         raise HTTPException(status_code=422, detail="unsupported_provider")
 
-    agent = await _load_daemon_agent_or_422(db, ctx, agent_id)
-    daemon_id = agent.daemon_instance_id
-    assert daemon_id is not None  # narrow for the type checker
-    _require_online(daemon_id)
+    _, host = await _load_gateway_host_or_422(db, ctx, agent_id)
+    _require_online(host)
 
     if body.provider == "telegram" and not body.bot_token:
         raise HTTPException(status_code=400, detail="missing_bot_token")
@@ -452,7 +500,7 @@ async def create_gateway(
     if body.provider in ("wechat", "feishu"):
         params["loginId"] = body.login_id
 
-    ack = await send_control_frame(daemon_id, "upsert_gateway", params)
+    ack = await _send_gateway_control_frame(host, "upsert_gateway", params)
     result = _ack_or_raise(ack)
 
     token_preview = result.get("tokenPreview")
@@ -476,7 +524,7 @@ async def create_gateway(
         id=gateway_id,
         user_id=ctx.user_id,
         agent_id=agent_id,
-        daemon_instance_id=daemon_id,
+        daemon_instance_id=host.daemon_instance_id,
         provider=body.provider,
         label=body.label,
         enabled=body.enabled,
@@ -498,9 +546,8 @@ async def patch_gateway(
     db: AsyncSession = Depends(get_db),
 ) -> GatewayOut:
     _rate_limit(ctx.user_id, "gateway-write")
-    agent, row = await _load_owned_connection(db, ctx, agent_id, gateway_id)
-    daemon_id = row.daemon_instance_id
-    _require_online(daemon_id)
+    _, host, row = await _load_owned_connection(db, ctx, agent_id, gateway_id)
+    _require_online(host)
 
     fields = body.model_fields_set
     if "label" in fields:
@@ -540,7 +587,7 @@ async def patch_gateway(
         raise
 
     try:
-        ack = await send_control_frame(daemon_id, "upsert_gateway", params)
+        ack = await _send_gateway_control_frame(host, "upsert_gateway", params)
         result = _ack_or_raise(ack)
     except Exception:
         await db.rollback()
@@ -581,19 +628,18 @@ async def delete_gateway(
     ctx: RequestContext = Depends(require_user),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
-    _, row = await _load_owned_connection(db, ctx, agent_id, gateway_id)
-    daemon_id = row.daemon_instance_id
+    _, host, row = await _load_owned_connection(db, ctx, agent_id, gateway_id)
     if force:
         # C1: operator opt-in escape hatch — daemon is permanently dead and the
         # row would otherwise be orphaned. Skip the daemon round-trip entirely.
         logger.warning(
             "delete_gateway force=true: deleting Hub row without daemon ack",
-            extra={"daemon_instance_id": daemon_id, "gateway_id": row.id},
+            extra={"daemon_instance_id": host.daemon_instance_id, "gateway_id": row.id},
         )
     else:
-        _require_online(daemon_id)
+        _require_online(host)
 
-        ack = await send_control_frame(daemon_id, "remove_gateway", {"id": row.id})
+        ack = await _send_gateway_control_frame(host, "remove_gateway", {"id": row.id})
         _ack_or_raise(ack)
 
     await db.delete(row)
@@ -609,11 +655,10 @@ async def test_gateway(
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     _rate_limit(ctx.user_id, "gateway-test")
-    _, row = await _load_owned_connection(db, ctx, agent_id, gateway_id)
-    daemon_id = row.daemon_instance_id
-    _require_online(daemon_id)
+    _, host, row = await _load_owned_connection(db, ctx, agent_id, gateway_id)
+    _require_online(host)
 
-    ack = await send_control_frame(daemon_id, "test_gateway", {"id": row.id})
+    ack = await _send_gateway_control_frame(host, "test_gateway", {"id": row.id})
     result = _ack_or_raise(ack)
     return {"ok": True, "result": result}
 
@@ -637,10 +682,8 @@ async def wechat_login_start(
     the user calls ``POST /gateways`` with the matching ``loginId``.
     """
     _rate_limit(ctx.user_id, "wechat-login")
-    agent = await _load_daemon_agent_or_422(db, ctx, agent_id)
-    daemon_id = agent.daemon_instance_id
-    assert daemon_id is not None
-    _require_online(daemon_id)
+    _, host = await _load_gateway_host_or_422(db, ctx, agent_id)
+    _require_online(host)
 
     params: dict[str, Any] = {
         "provider": "wechat",
@@ -652,7 +695,7 @@ async def wechat_login_start(
         _validate_base_url(body.base_url)
         params["baseUrl"] = body.base_url
 
-    ack = await send_control_frame(daemon_id, "gateway_login_start", params)
+    ack = await _send_gateway_control_frame(host, "gateway_login_start", params)
     result = _ack_or_raise(ack)
     # Surface the daemon-reported envelope verbatim — the dashboard already
     # speaks `{loginId, qrcode, qrcodeUrl, expiresAt}` per the design doc.
@@ -672,13 +715,11 @@ async def wechat_login_status(
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     _rate_limit(ctx.user_id, "wechat-login")
-    agent = await _load_daemon_agent_or_422(db, ctx, agent_id)
-    daemon_id = agent.daemon_instance_id
-    assert daemon_id is not None
-    _require_online(daemon_id)
+    _, host = await _load_gateway_host_or_422(db, ctx, agent_id)
+    _require_online(host)
 
-    ack = await send_control_frame(
-        daemon_id,
+    ack = await _send_gateway_control_frame(
+        host,
         "gateway_login_status",
         {"provider": "wechat", "loginId": body.login_id, "accountId": agent_id},
     )
@@ -698,10 +739,8 @@ async def feishu_login_start(
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     _rate_limit(ctx.user_id, "wechat-login")
-    agent = await _load_daemon_agent_or_422(db, ctx, agent_id)
-    daemon_id = agent.daemon_instance_id
-    assert daemon_id is not None
-    _require_online(daemon_id)
+    _, host = await _load_gateway_host_or_422(db, ctx, agent_id)
+    _require_online(host)
 
     params: dict[str, Any] = {
         "provider": "feishu",
@@ -712,7 +751,7 @@ async def feishu_login_start(
     if body.domain:
         params["domain"] = body.domain
 
-    ack = await send_control_frame(daemon_id, "gateway_login_start", params)
+    ack = await _send_gateway_control_frame(host, "gateway_login_start", params)
     result = _ack_or_raise(ack)
     return {
         "loginId": result.get("loginId"),
@@ -730,13 +769,11 @@ async def feishu_login_status(
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     _rate_limit(ctx.user_id, "wechat-login")
-    agent = await _load_daemon_agent_or_422(db, ctx, agent_id)
-    daemon_id = agent.daemon_instance_id
-    assert daemon_id is not None
-    _require_online(daemon_id)
+    _, host = await _load_gateway_host_or_422(db, ctx, agent_id)
+    _require_online(host)
 
-    ack = await send_control_frame(
-        daemon_id,
+    ack = await _send_gateway_control_frame(
+        host,
         "gateway_login_status",
         {"provider": "feishu", "loginId": body.login_id, "accountId": agent_id},
     )
@@ -763,13 +800,11 @@ async def wechat_recent_senders(
     saved, so users can whitelist a sender without knowing ``xxx@im.wechat``.
     """
     _rate_limit(ctx.user_id, "wechat-login")
-    agent = await _load_daemon_agent_or_422(db, ctx, agent_id)
-    daemon_id = agent.daemon_instance_id
-    assert daemon_id is not None
-    _require_online(daemon_id)
+    _, host = await _load_gateway_host_or_422(db, ctx, agent_id)
+    _require_online(host)
 
-    ack = await send_control_frame(
-        daemon_id,
+    ack = await _send_gateway_control_frame(
+        host,
         "gateway_recent_senders",
         {
             "provider": "wechat",

--- a/backend/tests/test_app/test_app_gateways.py
+++ b/backend/tests/test_app/test_app_gateways.py
@@ -19,6 +19,8 @@ from hub.models import (
     Agent,
     AgentGatewayConnection,
     Base,
+    CloudAgentInstance,
+    CloudDaemonInstance,
     DaemonInstance,
     Role,
     User,
@@ -114,7 +116,14 @@ async def seed(db_session: AsyncSession):
         label="laptop",
         refresh_token_hash="hash",
     )
-    db_session.add(daemon)
+    cloud_daemon_row = DaemonInstance(
+        id="dm_cloud123456",
+        user_id=user_id,
+        label="cloud-codex",
+        kind="cloud",
+        refresh_token_hash="cloud-hash",
+    )
+    db_session.add_all([daemon, cloud_daemon_row])
 
     other_user_id = uuid.uuid4()
     other_user = User(
@@ -153,6 +162,16 @@ async def seed(db_session: AsyncSession):
         claimed_at=now,
         hosting_kind="openclaw",
     )
+    cloud_agent = Agent(
+        agent_id="ag_cloud",
+        display_name="Cloud Agent",
+        bio="b",
+        message_policy=MessagePolicy.contacts_only,
+        user_id=user_id,
+        claimed_at=now,
+        hosting_kind="cloud",
+        daemon_instance_id="dm_cloud123456",
+    )
     other_agent = Agent(
         agent_id="ag_other",
         display_name="Other Daemon",
@@ -163,12 +182,43 @@ async def seed(db_session: AsyncSession):
         hosting_kind="daemon",
         daemon_instance_id="dm_otherbeefcafe",
     )
-    db_session.add_all([daemon_agent, openclaw_agent, other_agent])
+    cloud_daemon = CloudDaemonInstance(
+        id="cloud_dm_abcdef123456",
+        user_id=user_id,
+        daemon_instance_id="dm_cloud123456",
+        provider="e2b",
+        status="ready",
+        runtime="codex",
+        max_agents=1,
+        active_agent_count=1,
+    )
+    cloud_binding = CloudAgentInstance(
+        id="cloud_ag_abcdef123456",
+        user_id=user_id,
+        agent_id="ag_cloud",
+        cloud_daemon_instance_id="cloud_dm_abcdef123456",
+        daemon_instance_id="dm_cloud123456",
+        runtime="codex",
+        model_profile="default",
+        status="ready",
+    )
+    db_session.add_all(
+        [
+            daemon_agent,
+            openclaw_agent,
+            cloud_agent,
+            other_agent,
+            cloud_daemon,
+            cloud_binding,
+        ]
+    )
     await db_session.commit()
     return {
         "token": _token(str(supabase_uuid)),
         "user_id": user_id,
         "daemon_id": "dm_abcdef123456",
+        "cloud_daemon_row_id": "dm_cloud123456",
+        "cloud_daemon_id": "cloud_dm_abcdef123456",
     }
 
 
@@ -179,6 +229,15 @@ def _patch_daemon(monkeypatch, *, online: bool, send=None):
     monkeypatch.setattr(gw, "is_daemon_online", lambda _id: online)
     if send is not None:
         monkeypatch.setattr(gw, "send_control_frame", send)
+
+
+def _patch_cloud_daemon(monkeypatch, *, online: bool, send=None):
+    """Stub the gateways router's cloud-daemon hooks."""
+    import app.routers.gateways as gw
+
+    monkeypatch.setattr(gw, "is_cloud_daemon_online", lambda _id: online)
+    if send is not None:
+        monkeypatch.setattr(gw, "send_cloud_control_frame", send)
 
 
 def _patch_hub_gateway_send(monkeypatch, *, online: bool, send=None):
@@ -419,6 +478,84 @@ async def test_create_telegram_persists_metadata_and_token_preview(
     assert len(rows) == 1
     assert "botToken" not in (rows[0].config_json or {})
     assert rows[0].config_json.get("tokenPreview") == "1234...wxyz"
+
+
+@pytest.mark.asyncio
+async def test_create_telegram_for_cloud_agent_dispatches_to_cloud_daemon(
+    client, seed, db_session, monkeypatch
+):
+    calls: list[dict] = []
+
+    async def fake_send(cloud_daemon_instance_id, type_, params=None, timeout_ms=None):
+        calls.append(
+            {
+                "cloud_daemon_instance_id": cloud_daemon_instance_id,
+                "type": type_,
+                "params": params,
+                "timeout_ms": timeout_ms,
+            }
+        )
+        return {
+            "ok": True,
+            "result": {
+                "id": params["id"],
+                "type": "telegram",
+                "accountId": params["accountId"],
+                "enabled": True,
+                "tokenPreview": "1234...wxyz",
+                "status": {"running": True, "authorized": True},
+            },
+        }
+
+    _patch_daemon(monkeypatch, online=False)
+    _patch_cloud_daemon(monkeypatch, online=True, send=fake_send)
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    r = await client.post(
+        "/api/agents/ag_cloud/gateways",
+        headers=headers,
+        json={
+            "provider": "telegram",
+            "label": "cloud tg",
+            "bot_token": "1234:abcd",
+            "config": {
+                "allowedChatIds": ["111"],
+                "allowedSenderIds": ["111"],
+            },
+        },
+    )
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["agent_id"] == "ag_cloud"
+    assert body["daemon_instance_id"] == seed["cloud_daemon_row_id"]
+    assert body["config"]["tokenPreview"] == "1234...wxyz"
+    assert calls == [
+        {
+            "cloud_daemon_instance_id": seed["cloud_daemon_id"],
+            "type": "upsert_gateway",
+            "params": {
+                "id": body["id"],
+                "type": "telegram",
+                "accountId": "ag_cloud",
+                "label": "cloud tg",
+                "enabled": True,
+                "settings": {
+                    "allowedSenderIds": ["111"],
+                    "allowedChatIds": ["111"],
+                },
+                "secret": {"botToken": "1234:abcd"},
+            },
+            "timeout_ms": None,
+        }
+    ]
+
+    row = await db_session.scalar(
+        select(AgentGatewayConnection).where(
+            AgentGatewayConnection.agent_id == "ag_cloud"
+        )
+    )
+    assert row is not None
+    assert row.daemon_instance_id == seed["cloud_daemon_row_id"]
 
 
 @pytest.mark.asyncio

--- a/packages/daemon/src/__tests__/cloud-daemon.test.ts
+++ b/packages/daemon/src/__tests__/cloud-daemon.test.ts
@@ -19,6 +19,7 @@ import { startCloudDaemon } from "../cloud-daemon.js";
 import type { CloudModeConfig } from "../cloud-mode.js";
 import { ControlChannel } from "../control-channel.js";
 import type { DaemonConfig } from "../config.js";
+import type { Gateway, GatewayChannelConfig } from "../gateway/index.js";
 
 class FakeWebSocket extends EventEmitter {
   public readyState = 0;
@@ -167,6 +168,44 @@ describe("startCloudDaemon", () => {
       expect(callArgs.gateway).toBeDefined();
       expect(callArgs.onAgentInstalled).toBeInstanceOf(Function);
       expect(callArgs.policyResolver).toBeDefined();
+    } finally {
+      await handle.stop("test");
+    }
+  });
+
+  it("allows third-party gateway channels to be hot-plugged in cloud mode", async () => {
+    let gateway: Pick<Gateway, "addChannel"> | undefined;
+    const ctor = makeFakeCtor();
+    class TestControlChannel extends ControlChannel {
+      constructor(opts: ConstructorParameters<typeof ControlChannel>[0]) {
+        super({ ...opts, webSocketCtor: ctor, hubPublicKey: null });
+      }
+    }
+    const handle = await startCloudDaemon({
+      cloudConfig: makeCfg(),
+      config: makeDaemonCfg(),
+      configPath: "(cloud-mode)",
+      controlChannelFactory: TestControlChannel as unknown as typeof ControlChannel,
+      provisionerFactory: ((args: { gateway: Gateway }) => {
+        gateway = args.gateway;
+        return vi.fn();
+      }) as unknown as typeof import("../provision.js").createProvisioner,
+      sessionStorePath: path.join(tmpDir, "sessions.json"),
+      snapshotPath: path.join(tmpDir, "snapshot.json"),
+      snapshotIntervalMs: 60_000,
+    });
+    try {
+      expect(gateway).toBeDefined();
+      await expect(
+        gateway!.addChannel({
+          id: "gw_tg_cloud",
+          type: "telegram",
+          accountId: "ag_cloud",
+          allowedSenderIds: ["42"],
+          allowedChatIds: ["111"],
+          secretFile: path.join(tmpDir, "missing-telegram-secret.json"),
+        } satisfies GatewayChannelConfig),
+      ).resolves.toBeUndefined();
     } finally {
       await handle.stop("test");
     }

--- a/packages/daemon/src/cloud-daemon.ts
+++ b/packages/daemon/src/cloud-daemon.ts
@@ -12,7 +12,6 @@
 import { shouldWake, type AttentionPolicy } from "@botcord/protocol-core";
 import {
   Gateway,
-  createBotCordChannel,
   resolveTranscriptEnabled,
   type ChannelAdapter,
   type GatewayChannelConfig,
@@ -27,7 +26,7 @@ import { ControlChannel } from "./control-channel.js";
 import { toGatewayConfig } from "./daemon-config-map.js";
 import { log as daemonLog } from "./log.js";
 import { createProvisioner } from "./provision.js";
-import { pushRuntimeSnapshot } from "./daemon.js";
+import { createDaemonChannel, pushRuntimeSnapshot } from "./daemon.js";
 import { SnapshotWriter } from "./snapshot-writer.js";
 import { createDaemonSystemContextBuilder } from "./system-context.js";
 import { readWorkingMemorySnapshot } from "./working-memory.js";
@@ -250,20 +249,8 @@ export async function startCloudDaemon(
     config: gwConfig,
     sessionStorePath: opts.sessionStorePath ?? SESSIONS_PATH,
     createChannel: (chCfg: GatewayChannelConfig): ChannelAdapter => {
-      // Only BotCord channels are supported in cloud mode — third-party
-      // gateways are a local-daemon feature.
-      if (chCfg.type !== "botcord") {
-        throw new Error(
-          `cloud daemon: channel type "${chCfg.type}" not supported in cloud mode`,
-        );
-      }
-      const agentId =
-        typeof chCfg.agentId === "string" ? chCfg.agentId : chCfg.accountId;
-      return createBotCordChannel({
-        id: chCfg.id,
-        accountId: chCfg.accountId,
-        agentId,
-        credentialsPath: credentialPathByAgentId.get(agentId),
+      return createDaemonChannel(chCfg, {
+        credentialPathByAgentId,
         hubBaseUrl: cloudCfg.hubUrl,
       });
     },


### PR DESCRIPTION
## Summary
- route gateway control operations for cloud agents through the cloud daemon control channel
- let cloud daemon mode create third-party gateway channels via the shared daemon channel factory
- add backend and daemon coverage for cloud-agent gateway setup

## Tests
- cd backend && uv run pytest tests/test_app/test_app_gateways.py -q
- cd packages/daemon && npm test -- --run src/__tests__/cloud-daemon.test.ts

## Note
- cd packages/daemon && npm run build still fails on pre-existing TS2367 errors in src/gateway/channels/botcord.ts around cloud_agent_run/cloud_run type narrowing.