### PR TITLE
fix: resume cloud agents on inbox wake

### DIFF
--- a/backend/hub/routers/hub.py
+++ b/backend/hub/routers/hub.py
@@ -454,6 +454,9 @@ async def notify_inbox(
 
     Returns the number of WebSocket connections that were successfully notified.
     """
+    if db is not None:
+        await _resume_cloud_agent_for_inbox(agent_id, db)
+
     # Wake long-polling readers
     cond = _inbox_conditions.get(agent_id)
     if cond:
@@ -522,6 +525,41 @@ async def notify_inbox(
         await _publish_agent_realtime_event(db, realtime_event)
 
     return notified
+
+
+async def _resume_cloud_agent_for_inbox(agent_id: str, db: AsyncSession) -> None:
+    """Best-effort wakeup for cloud-hosted agents when new inbox work arrives."""
+    try:
+        agent = await db.scalar(select(Agent).where(Agent.agent_id == agent_id))
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("cloud inbox resume lookup failed: agent=%s err=%s", agent_id, exc)
+        return
+
+    if agent is None or agent.hosting_kind != "cloud" or agent.user_id is None:
+        return
+
+    try:
+        from hub.services.cloud_agent import CloudAgentError, CloudAgentService
+
+        await CloudAgentService().resume_cloud_agent(
+            db,
+            user_id=agent.user_id,
+            agent_id=agent_id,
+        )
+    except CloudAgentError as exc:
+        logger.warning(
+            "cloud inbox resume skipped: agent=%s code=%s err=%s",
+            agent_id,
+            exc.code,
+            exc.message,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.error(
+            "cloud inbox resume failed: agent=%s err=%s",
+            agent_id,
+            exc,
+            exc_info=True,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/hub/services/cloud_agent.py
+++ b/backend/hub/services/cloud_agent.py
@@ -737,14 +737,23 @@ class CloudAgentService:
         *,
         cloud_daemon_instance_id: str,
     ) -> list[CloudAgentView]:
-        """Dispatch ``provision_agent`` for every provisioning Cloud Agent on this daemon.
+        """Dispatch ``provision_agent`` for agents missing from a connected daemon.
 
-        Called from the ``/cloud/daemon/ws`` hello handler once the daemon
-        is registered. Each successful dispatch transitions the agent to
-        ``ready`` and scrubs the temporary private key from metadata.
-        Failures leave the agent in ``provisioning`` with ``error_code`` /
-        ``error_message`` set so the dashboard can surface the cause.
+        Called from the ``/cloud/daemon/ws`` hello handler once the daemon is
+        registered. A cloud daemon process always boots with an empty in-memory
+        config, so a sandbox/process restart must re-provision ready agents
+        before their BotCord inbox channels can drain queued messages. A plain
+        control-WS reconnect, however, may still have live channels; we avoid
+        duplicate installs by asking the daemon for ``list_agents`` first.
         """
+        live_agent_ids = await self._list_cloud_daemon_agent_ids(
+            cloud_daemon_instance_id
+        )
+        statuses = (
+            ("provisioning", "ready")
+            if live_agent_ids is not None
+            else ("provisioning",)
+        )
         rows = (
             await db.execute(
                 select(CloudAgentInstance, Agent, CloudDaemonInstance)
@@ -755,7 +764,7 @@ class CloudAgentService:
                 )
                 .where(
                     CloudAgentInstance.cloud_daemon_instance_id == cloud_daemon_instance_id,
-                    CloudAgentInstance.status == "provisioning",
+                    CloudAgentInstance.status.in_(statuses),
                 )
             )
         ).all()
@@ -764,6 +773,29 @@ class CloudAgentService:
 
         results: list[CloudAgentView] = []
         for cai, agent, cdi in rows:
+            if live_agent_ids is not None and cai.agent_id in live_agent_ids:
+                cai.status = "ready"
+                cai.error_code = None
+                cai.error_message = None
+                _scrub_provisioning_metadata(cai)
+                if cdi.status != "ready":
+                    cdi.status = "ready"
+                    cdi.last_started_at = _now()
+                    cdi.last_seen_at = _now()
+                await db.commit()
+                await db.refresh(cai)
+                await db.refresh(cdi)
+                await db.refresh(agent)
+                results.append(_make_view(agent, cai, cdi))
+                continue
+
+            if cai.status == "ready":
+                _ensure_provisioning_metadata(db, cai, agent)
+                cai.status = "provisioning"
+                cai.error_code = None
+                cai.error_message = None
+                await db.flush()
+
             await self._provision_one(db, cai, agent, cdi)
             # Columns with ``onupdate=func.now()`` get marked as needing
             # a refresh after commit even with expire_on_commit=False.
@@ -772,6 +804,56 @@ class CloudAgentService:
             await db.refresh(agent)
             results.append(_make_view(agent, cai, cdi))
         return results
+
+    async def _list_cloud_daemon_agent_ids(
+        self,
+        cloud_daemon_instance_id: str,
+    ) -> set[str] | None:
+        """Return agent ids currently loaded in the connected cloud daemon.
+
+        ``None`` means the probe failed; callers should avoid re-provisioning
+        already-ready agents in that case because a transient control-plane
+        failure is more likely than a clean process restart with no channels.
+        """
+        try:
+            ack = await send_cloud_control_frame(
+                cloud_daemon_instance_id,
+                "list_agents",
+                {},
+                timeout_ms=10000,
+            )
+        except CloudDaemonDispatchError as exc:
+            logger.warning(
+                "cloud daemon list_agents failed: cloud=%s code=%s err=%s",
+                cloud_daemon_instance_id,
+                exc.code,
+                exc.message,
+            )
+            return None
+
+        if not ack.get("ok"):
+            err = ack.get("error") or {}
+            logger.warning(
+                "cloud daemon list_agents rejected: cloud=%s code=%s err=%s",
+                cloud_daemon_instance_id,
+                err.get("code"),
+                err.get("message"),
+            )
+            return None
+
+        result = ack.get("result")
+        agents = result.get("agents") if isinstance(result, dict) else None
+        if not isinstance(agents, list):
+            return set()
+
+        out: set[str] = set()
+        for entry in agents:
+            if not isinstance(entry, dict):
+                continue
+            raw_id = entry.get("id") or entry.get("agentId")
+            if isinstance(raw_id, str) and raw_id:
+                out.add(raw_id)
+        return out
 
     async def create_run(
         self,

--- a/backend/tests/test_app/test_cloud_agents.py
+++ b/backend/tests/test_app/test_cloud_agents.py
@@ -9,10 +9,11 @@ import jwt
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from hub.models import Base, Role, User, UserRole
-from hub.services.cloud_agent import CloudAgentService
+from hub.models import Base, CloudAgentInstance, Role, User, UserRole
+from hub.services.cloud_agent import CloudAgentService, CreateCloudAgentInput
 from hub.services.cloud_daemon_provider import FakeCloudDaemonProvider
 from tests.test_app.conftest import create_test_engine
 
@@ -239,6 +240,139 @@ async def test_pause_resume_round_trip(client_factory, seed_user):
     body = r.json()
     assert body["status"] == "ready"
     assert body["cloud_daemon_status"] == "ready"
+
+
+@pytest.mark.asyncio
+async def test_inbox_notification_resumes_paused_cloud_agent(
+    client_factory, seed_user, db_session, monkeypatch
+):
+    import hub.services.cloud_agent as cloud_agent_mod
+    from hub.routers.hub import notify_inbox
+
+    client, provider = await client_factory()
+    monkeypatch.setattr(cloud_agent_mod, "get_provider", lambda _name: provider)
+    headers = {"Authorization": f"Bearer {seed_user['token']}"}
+    r = await client.post(
+        "/api/cloud-agents",
+        json={"name": "Bot"},
+        headers=headers,
+    )
+    agent_id = r.json()["agent_id"]
+    cloud_daemon_instance_id = r.json()["cloud_daemon_instance_id"]
+
+    r = await client.post(
+        f"/api/cloud-agents/{agent_id}/pause", headers=headers
+    )
+    assert r.status_code == 200
+    assert r.json()["status"] == "paused"
+
+    await notify_inbox(agent_id, db=db_session)
+
+    row = await db_session.scalar(
+        select(CloudAgentInstance).where(CloudAgentInstance.agent_id == agent_id)
+    )
+    assert row is not None
+    assert row.status == "ready"
+    assert provider.calls(cloud_daemon_instance_id)["create"] == 2
+
+
+@pytest.mark.asyncio
+async def test_cloud_daemon_reconnect_reprovisions_missing_ready_agent(
+    db_session, seed_user, monkeypatch
+):
+    import hub.services.cloud_agent as cloud_agent_mod
+
+    provider = FakeCloudDaemonProvider()
+    service = CloudAgentService(provider=provider, feature_enabled=True)
+    created = await service.create_cloud_agent(
+        db_session,
+        user_id=seed_user["user_id"],
+        body=CreateCloudAgentInput(name="Bot"),
+    )
+
+    calls: list[tuple[str, dict | None]] = []
+
+    async def fake_send_cloud_control_frame(
+        _cloud_daemon_instance_id: str,
+        type_: str,
+        params: dict | None = None,
+        timeout_ms: int | None = None,
+    ) -> dict:
+        calls.append((type_, params))
+        if type_ == "list_agents":
+            return {"ok": True, "result": {"agents": []}}
+        if type_ == "provision_agent":
+            assert params is not None
+            assert params["credentials"]["agentId"] == created.agent_id
+            assert params["credentials"]["privateKey"]
+            return {"ok": True, "result": {"agentId": created.agent_id}}
+        raise AssertionError(f"unexpected frame {type_}")
+
+    monkeypatch.setattr(
+        cloud_agent_mod,
+        "send_cloud_control_frame",
+        fake_send_cloud_control_frame,
+    )
+
+    restored = await service.provision_pending_for_cloud_daemon(
+        db_session,
+        cloud_daemon_instance_id=created.cloud_daemon_instance_id,
+    )
+
+    assert [call[0] for call in calls] == ["list_agents", "provision_agent"]
+    assert [view.agent_id for view in restored] == [created.agent_id]
+    row = await db_session.scalar(
+        select(CloudAgentInstance).where(
+            CloudAgentInstance.agent_id == created.agent_id
+        )
+    )
+    assert row is not None
+    assert row.status == "ready"
+    assert "provisioning" not in (row.metadata_json or {})
+
+
+@pytest.mark.asyncio
+async def test_cloud_daemon_reconnect_skips_agent_already_loaded(
+    db_session, seed_user, monkeypatch
+):
+    import hub.services.cloud_agent as cloud_agent_mod
+
+    provider = FakeCloudDaemonProvider()
+    service = CloudAgentService(provider=provider, feature_enabled=True)
+    created = await service.create_cloud_agent(
+        db_session,
+        user_id=seed_user["user_id"],
+        body=CreateCloudAgentInput(name="Bot"),
+    )
+
+    calls: list[str] = []
+
+    async def fake_send_cloud_control_frame(
+        _cloud_daemon_instance_id: str,
+        type_: str,
+        params: dict | None = None,
+        timeout_ms: int | None = None,
+    ) -> dict:
+        calls.append(type_)
+        if type_ == "list_agents":
+            return {"ok": True, "result": {"agents": [{"id": created.agent_id}]}}
+        if type_ == "provision_agent":
+            raise AssertionError("already-loaded agent must not be provisioned again")
+        raise AssertionError(f"unexpected frame {type_}")
+
+    monkeypatch.setattr(
+        cloud_agent_mod,
+        "send_cloud_control_frame",
+        fake_send_cloud_control_frame,
+    )
+
+    restored = await service.provision_pending_for_cloud_daemon(
+        db_session,
+        cloud_daemon_instance_id=created.cloud_daemon_instance_id,
+    )
+
+    assert calls == ["list_agents"]
+    assert [view.agent_id for view in restored] == [created.agent_id]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- resume cloud-hosted agents from the shared inbox notification path so paused sandboxes wake for chat or message-triggered work
- re-provision ready cloud agents missing from a reconnected daemon after process restart while skipping agents already loaded
- add coverage for paused inbox resume and cloud daemon restart/reconnect provisioning behavior

## Tests
- cd backend && uv run pytest tests/test_app/test_cloud_agents.py -q
- cd backend && uv run pytest tests/test_cloud_daemon_ws.py tests/test_cloud_agent_service.py tests/test_dashboard_chat.py -q
- cd packages/daemon && npm test -- --run src/gateway/__tests__/botcord-channel.test.ts src/__tests__/cloud-daemon.test.ts