### PR TITLE
fix: resume cloud agents from owner chat

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -3405,6 +3405,7 @@ async def send_chat_message(
         build_message_realtime_event,
         notify_inbox,
     )
+    from hub.services.cloud_agent import resume_cloud_agent_for_inbox
 
     user_id = str(ctx.user_id)
     agent_id, agent_display_name = await _resolve_owner_chat_agent(db, ctx, body.agent_id)
@@ -3426,6 +3427,8 @@ async def send_chat_message(
             dumped = att.model_dump(exclude_none=True)
             dumped["url"] = normalized
             normalized_attachments.append(dumped)
+
+    cloud_resume_ok = await resume_cloud_agent_for_inbox(db, agent_id)
 
     # Ensure room exists
     room_id = await _ensure_owner_chat_room(db, user_id, agent_id, agent_display_name)
@@ -3491,6 +3494,7 @@ async def send_chat_message(
             payload=payload,
             sender_name=agent_display_name,
         ),
+        resume_cloud=not cloud_resume_ok,
     )
 
     return {"hub_msg_id": hub_msg_id, "room_id": room_id, "status": "queued"}

--- a/backend/hub/routers/hub.py
+++ b/backend/hub/routers/hub.py
@@ -449,13 +449,16 @@ async def notify_inbox(
     *,
     db: AsyncSession | None = None,
     realtime_event: dict[str, Any] | None = None,
+    resume_cloud: bool = True,
 ) -> int:
     """Wake up any long-polling readers and WebSocket connections waiting on this agent's inbox.
 
     Returns the number of WebSocket connections that were successfully notified.
     """
-    if db is not None:
-        await _resume_cloud_agent_for_inbox(agent_id, db)
+    if db is not None and resume_cloud:
+        from hub.services.cloud_agent import resume_cloud_agent_for_inbox
+
+        await resume_cloud_agent_for_inbox(db, agent_id)
 
     # Wake long-polling readers
     cond = _inbox_conditions.get(agent_id)
@@ -525,41 +528,6 @@ async def notify_inbox(
         await _publish_agent_realtime_event(db, realtime_event)
 
     return notified
-
-
-async def _resume_cloud_agent_for_inbox(agent_id: str, db: AsyncSession) -> None:
-    """Best-effort wakeup for cloud-hosted agents when new inbox work arrives."""
-    try:
-        agent = await db.scalar(select(Agent).where(Agent.agent_id == agent_id))
-    except Exception as exc:  # noqa: BLE001
-        logger.debug("cloud inbox resume lookup failed: agent=%s err=%s", agent_id, exc)
-        return
-
-    if agent is None or agent.hosting_kind != "cloud" or agent.user_id is None:
-        return
-
-    try:
-        from hub.services.cloud_agent import CloudAgentError, CloudAgentService
-
-        await CloudAgentService().resume_cloud_agent(
-            db,
-            user_id=agent.user_id,
-            agent_id=agent_id,
-        )
-    except CloudAgentError as exc:
-        logger.warning(
-            "cloud inbox resume skipped: agent=%s code=%s err=%s",
-            agent_id,
-            exc.code,
-            exc.message,
-        )
-    except Exception as exc:  # noqa: BLE001
-        logger.error(
-            "cloud inbox resume failed: agent=%s err=%s",
-            agent_id,
-            exc,
-            exc_info=True,
-        )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/hub/routers/owner_chat_ws.py
+++ b/backend/hub/routers/owner_chat_ws.py
@@ -35,6 +35,7 @@ from hub.routers.hub import (
     notify_inbox,
     build_message_realtime_event,
 )
+from hub.services.cloud_agent import resume_cloud_agent_for_inbox
 from hub.validators import normalize_file_url
 
 import jwt as pyjwt
@@ -153,7 +154,8 @@ async def _notify_inbox_with_retry(agent_id: str) -> None:
     """Background task: retry notify_inbox until the agent's WS reconnects or retries exhaust."""
     for delay in _NOTIFY_RETRY_DELAYS:
         await asyncio.sleep(delay)
-        notified = await notify_inbox(agent_id)
+        async with async_session() as db:
+            notified = await notify_inbox(agent_id, db=db)
         if notified > 0:
             logger.info("Owner-chat notify retry succeeded: agent=%s after %.0fs", agent_id, delay)
             return
@@ -400,6 +402,8 @@ async def owner_chat_ws(ws: WebSocket):
 
                 logger.info("Owner-chat WS recv: user=%s agent=%s text_len=%d attachments=%d", user_id, agent_id, len(text), len(attachments))
 
+                cloud_resume_ok = False
+
                 # Create MessageRecord (same logic as dashboard_chat.send_chat_message)
                 msg_id = str(uuid.uuid4())
                 ts = int(time.time())
@@ -438,6 +442,8 @@ async def owner_chat_ws(ws: WebSocket):
                 )
 
                 async with async_session() as db:
+                    cloud_resume_ok = await resume_cloud_agent_for_inbox(db, agent_id)
+
                     try:
                         async with db.begin_nested():
                             db.add(record)
@@ -473,6 +479,7 @@ async def owner_chat_ws(ws: WebSocket):
                             payload=payload,
                             sender_name=display_name,
                         ),
+                        resume_cloud=not cloud_resume_ok,
                     )
                     logger.info(
                         "Owner-chat WS forwarded: hub_msg_id=%s agent=%s room=%s ws_notified=%d",

--- a/backend/hub/services/cloud_agent.py
+++ b/backend/hub/services/cloud_agent.py
@@ -1433,6 +1433,49 @@ async def _notify_inbox(agent_id: str, db: AsyncSession) -> int:
     return await notify_inbox(agent_id, db=db)
 
 
+async def resume_cloud_agent_for_inbox(
+    db: AsyncSession,
+    agent_id: str,
+) -> bool:
+    """Best-effort wakeup for a cloud-hosted agent with queued inbox work.
+
+    Returns ``True`` when ``agent_id`` is a cloud agent and the resume call
+    completed. Non-cloud agents and failed resume attempts return ``False`` so
+    callers can decide whether to retry on a later notification pass.
+    """
+    try:
+        agent = await db.scalar(select(Agent).where(Agent.agent_id == agent_id))
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("cloud inbox resume lookup failed: agent=%s err=%s", agent_id, exc)
+        return False
+
+    if agent is None or agent.hosting_kind != "cloud" or agent.user_id is None:
+        return False
+
+    try:
+        await CloudAgentService().resume_cloud_agent(
+            db,
+            user_id=agent.user_id,
+            agent_id=agent_id,
+        )
+        return True
+    except CloudAgentError as exc:
+        logger.warning(
+            "cloud inbox resume skipped: agent=%s code=%s err=%s",
+            agent_id,
+            exc.code,
+            exc.message,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.error(
+            "cloud inbox resume failed: agent=%s err=%s",
+            agent_id,
+            exc,
+            exc_info=True,
+        )
+    return False
+
+
 def _scrub_provisioning_metadata(cai: CloudAgentInstance) -> None:
     """Remove the temporary private key from ``metadata_json``.
 

--- a/backend/tests/test_app/test_app_dashboard.py
+++ b/backend/tests/test_app/test_app_dashboard.py
@@ -15,6 +15,7 @@ from hub.enums import ParticipantType
 from hub.models import (
     Agent,
     Base,
+    CloudAgentInstance,
     Contact,
     ContactRequest,
     ContactRequestState,
@@ -644,3 +645,45 @@ async def test_chat_send_success(
     assert data["hub_msg_id"].startswith("h_")
     assert "room_id" in data
     assert data["status"] == "queued"
+
+
+@pytest.mark.asyncio
+async def test_chat_send_resumes_paused_cloud_agent(
+    client: AsyncClient,
+    seed_data: dict,
+    db_session: AsyncSession,
+    monkeypatch,
+):
+    import hub.services.cloud_agent as cloud_agent_mod
+    from hub.services.cloud_agent import CloudAgentService, CreateCloudAgentInput
+    from hub.services.cloud_daemon_provider import FakeCloudDaemonProvider
+
+    provider = FakeCloudDaemonProvider()
+    service = CloudAgentService(provider=provider, feature_enabled=True)
+    created = await service.create_cloud_agent(
+        db_session,
+        user_id=seed_data["user_id"],
+        body=CreateCloudAgentInput(name="Cloud Bot"),
+    )
+    await service.pause_cloud_agent(
+        db_session,
+        user_id=seed_data["user_id"],
+        agent_id=created.agent_id,
+    )
+    monkeypatch.setattr(cloud_agent_mod, "get_provider", lambda _name: provider)
+
+    resp = await client.post(
+        "/api/dashboard/chat/send",
+        json={"agent_id": created.agent_id, "text": "wake up"},
+        headers={"Authorization": f"Bearer {seed_data['token']}"},
+    )
+
+    assert resp.status_code == 202, resp.text
+    row = await db_session.scalar(
+        select(CloudAgentInstance).where(
+            CloudAgentInstance.agent_id == created.agent_id
+        )
+    )
+    assert row is not None
+    assert row.status == "ready"
+    assert provider.calls(created.cloud_daemon_instance_id)["create"] == 2


### PR DESCRIPTION
## Summary
- explicitly resumes paused cloud agents from the real /api/dashboard/chat/send owner-chat path before queueing the message
- shares cloud inbox resume logic between notify_inbox, REST owner-chat, and owner-chat WS
- lets owner-chat WS notify retries carry a DB session so retry notifications can also resume cloud sandboxes

## Tests
- cd backend && uv run pytest tests/test_app/test_app_dashboard.py::test_chat_send_resumes_paused_cloud_agent tests/test_app/test_cloud_agents.py::test_inbox_notification_resumes_paused_cloud_agent -q
- cd backend && uv run pytest tests/test_app/test_app_dashboard.py -q
- cd backend && uv run pytest tests/test_app/test_cloud_agents.py tests/test_cloud_daemon_ws.py tests/test_cloud_agent_service.py tests/test_dashboard_chat.py -q
- cd packages/daemon && npm test -- --run src/gateway/__tests__/botcord-channel.test.ts src/__tests__/cloud-daemon.test.ts