### PR TITLE
fix: resume cloud gateway actions

### DIFF
--- a/backend/app/routers/gateways.py
+++ b/backend/app/routers/gateways.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import datetime
 import logging
 import os
@@ -39,6 +40,7 @@ from hub.routers.cloud_daemon_control import (
     is_cloud_daemon_online,
     send_cloud_control_frame,
 )
+from hub.services.cloud_agent import CloudAgentError, CloudAgentService
 
 logger = logging.getLogger(__name__)
 
@@ -275,6 +277,57 @@ def _require_online(host: _GatewayHost) -> None:
         raise HTTPException(status_code=409, detail="daemon_offline")
 
 
+_CLOUD_GATEWAY_RESUME_WAIT_SECONDS = 20.0
+_CLOUD_GATEWAY_RESUME_POLL_SECONDS = 0.5
+
+
+async def _ensure_gateway_host_online(
+    db: AsyncSession,
+    ctx: RequestContext,
+    agent: Agent,
+    host: _GatewayHost,
+) -> None:
+    """Ensure the daemon target is reachable before a gateway write.
+
+    Local daemon-hosted agents still require an already-connected user daemon.
+    Cloud agents are different: their sandbox may have been paused by idle
+    management, so a gateway action is user intent to resume it.
+    """
+    if not host.cloud_daemon_instance_id:
+        _require_online(host)
+        return
+
+    if is_cloud_daemon_online(host.cloud_daemon_instance_id):
+        return
+
+    try:
+        await CloudAgentService().resume_cloud_agent(
+            db,
+            user_id=ctx.user_id,
+            agent_id=agent.agent_id,
+        )
+    except CloudAgentError as exc:
+        logger.warning(
+            "cloud gateway resume failed: agent=%s cloud=%s code=%s err=%s",
+            agent.agent_id,
+            host.cloud_daemon_instance_id,
+            exc.code,
+            exc.message,
+        )
+        raise HTTPException(
+            status_code=409 if exc.http_status == 409 else exc.http_status,
+            detail="daemon_offline" if exc.http_status == 409 else exc.code,
+        ) from exc
+
+    deadline = time.monotonic() + _CLOUD_GATEWAY_RESUME_WAIT_SECONDS
+    while time.monotonic() < deadline:
+        if is_cloud_daemon_online(host.cloud_daemon_instance_id):
+            return
+        await asyncio.sleep(_CLOUD_GATEWAY_RESUME_POLL_SECONDS)
+
+    raise HTTPException(status_code=409, detail="daemon_offline")
+
+
 async def _send_gateway_control_frame(
     host: _GatewayHost,
     type_: str,
@@ -472,8 +525,8 @@ async def create_gateway(
     if body.provider not in _ALLOWED_PROVIDERS:
         raise HTTPException(status_code=422, detail="unsupported_provider")
 
-    _, host = await _load_gateway_host_or_422(db, ctx, agent_id)
-    _require_online(host)
+    agent, host = await _load_gateway_host_or_422(db, ctx, agent_id)
+    await _ensure_gateway_host_online(db, ctx, agent, host)
 
     if body.provider == "telegram" and not body.bot_token:
         raise HTTPException(status_code=400, detail="missing_bot_token")
@@ -546,8 +599,8 @@ async def patch_gateway(
     db: AsyncSession = Depends(get_db),
 ) -> GatewayOut:
     _rate_limit(ctx.user_id, "gateway-write")
-    _, host, row = await _load_owned_connection(db, ctx, agent_id, gateway_id)
-    _require_online(host)
+    agent, host, row = await _load_owned_connection(db, ctx, agent_id, gateway_id)
+    await _ensure_gateway_host_online(db, ctx, agent, host)
 
     fields = body.model_fields_set
     if "label" in fields:
@@ -628,7 +681,7 @@ async def delete_gateway(
     ctx: RequestContext = Depends(require_user),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
-    _, host, row = await _load_owned_connection(db, ctx, agent_id, gateway_id)
+    agent, host, row = await _load_owned_connection(db, ctx, agent_id, gateway_id)
     if force:
         # C1: operator opt-in escape hatch — daemon is permanently dead and the
         # row would otherwise be orphaned. Skip the daemon round-trip entirely.
@@ -637,7 +690,7 @@ async def delete_gateway(
             extra={"daemon_instance_id": host.daemon_instance_id, "gateway_id": row.id},
         )
     else:
-        _require_online(host)
+        await _ensure_gateway_host_online(db, ctx, agent, host)
 
         ack = await _send_gateway_control_frame(host, "remove_gateway", {"id": row.id})
         _ack_or_raise(ack)
@@ -655,8 +708,8 @@ async def test_gateway(
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     _rate_limit(ctx.user_id, "gateway-test")
-    _, host, row = await _load_owned_connection(db, ctx, agent_id, gateway_id)
-    _require_online(host)
+    agent, host, row = await _load_owned_connection(db, ctx, agent_id, gateway_id)
+    await _ensure_gateway_host_online(db, ctx, agent, host)
 
     ack = await _send_gateway_control_frame(host, "test_gateway", {"id": row.id})
     result = _ack_or_raise(ack)
@@ -682,8 +735,8 @@ async def wechat_login_start(
     the user calls ``POST /gateways`` with the matching ``loginId``.
     """
     _rate_limit(ctx.user_id, "wechat-login")
-    _, host = await _load_gateway_host_or_422(db, ctx, agent_id)
-    _require_online(host)
+    agent, host = await _load_gateway_host_or_422(db, ctx, agent_id)
+    await _ensure_gateway_host_online(db, ctx, agent, host)
 
     params: dict[str, Any] = {
         "provider": "wechat",
@@ -715,8 +768,8 @@ async def wechat_login_status(
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     _rate_limit(ctx.user_id, "wechat-login")
-    _, host = await _load_gateway_host_or_422(db, ctx, agent_id)
-    _require_online(host)
+    agent, host = await _load_gateway_host_or_422(db, ctx, agent_id)
+    await _ensure_gateway_host_online(db, ctx, agent, host)
 
     ack = await _send_gateway_control_frame(
         host,
@@ -739,8 +792,8 @@ async def feishu_login_start(
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     _rate_limit(ctx.user_id, "wechat-login")
-    _, host = await _load_gateway_host_or_422(db, ctx, agent_id)
-    _require_online(host)
+    agent, host = await _load_gateway_host_or_422(db, ctx, agent_id)
+    await _ensure_gateway_host_online(db, ctx, agent, host)
 
     params: dict[str, Any] = {
         "provider": "feishu",
@@ -769,8 +822,8 @@ async def feishu_login_status(
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     _rate_limit(ctx.user_id, "wechat-login")
-    _, host = await _load_gateway_host_or_422(db, ctx, agent_id)
-    _require_online(host)
+    agent, host = await _load_gateway_host_or_422(db, ctx, agent_id)
+    await _ensure_gateway_host_online(db, ctx, agent, host)
 
     ack = await _send_gateway_control_frame(
         host,
@@ -800,8 +853,8 @@ async def wechat_recent_senders(
     saved, so users can whitelist a sender without knowing ``xxx@im.wechat``.
     """
     _rate_limit(ctx.user_id, "wechat-login")
-    _, host = await _load_gateway_host_or_422(db, ctx, agent_id)
-    _require_online(host)
+    agent, host = await _load_gateway_host_or_422(db, ctx, agent_id)
+    await _ensure_gateway_host_online(db, ctx, agent, host)
 
     ack = await _send_gateway_control_frame(
         host,

--- a/backend/tests/test_app/test_app_gateways.py
+++ b/backend/tests/test_app/test_app_gateways.py
@@ -559,6 +559,70 @@ async def test_create_telegram_for_cloud_agent_dispatches_to_cloud_daemon(
 
 
 @pytest.mark.asyncio
+async def test_create_telegram_for_cloud_agent_resumes_when_cloud_daemon_offline(
+    client, seed, monkeypatch
+):
+    import app.routers.gateways as gw
+
+    gw._RATE_BUCKETS.clear()
+    online = {"value": False}
+    resume_calls: list[dict] = []
+    send_calls: list[dict] = []
+
+    class FakeCloudAgentService:
+        async def resume_cloud_agent(self, db, *, user_id, agent_id):
+            resume_calls.append({"user_id": user_id, "agent_id": agent_id})
+            online["value"] = True
+            return None
+
+    async def fake_send(cloud_daemon_instance_id, type_, params=None, timeout_ms=None):
+        send_calls.append(
+            {
+                "cloud_daemon_instance_id": cloud_daemon_instance_id,
+                "type": type_,
+                "params": params,
+                "timeout_ms": timeout_ms,
+            }
+        )
+        return {
+            "ok": True,
+            "result": {
+                "id": params["id"],
+                "type": "telegram",
+                "accountId": params["accountId"],
+                "enabled": True,
+                "tokenPreview": "1234...wxyz",
+                "status": {"running": True, "authorized": True},
+            },
+        }
+
+    monkeypatch.setattr(gw, "CloudAgentService", lambda: FakeCloudAgentService())
+    monkeypatch.setattr(gw, "is_cloud_daemon_online", lambda _id: online["value"])
+    monkeypatch.setattr(gw, "send_cloud_control_frame", fake_send)
+    _patch_daemon(monkeypatch, online=False)
+
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    r = await client.post(
+        "/api/agents/ag_cloud/gateways",
+        headers=headers,
+        json={
+            "provider": "telegram",
+            "label": "cloud tg",
+            "bot_token": "1234:abcd",
+            "config": {
+                "allowedChatIds": ["111"],
+                "allowedSenderIds": ["111"],
+            },
+        },
+    )
+
+    assert r.status_code == 200, r.text
+    assert resume_calls == [{"user_id": seed["user_id"], "agent_id": "ag_cloud"}]
+    assert send_calls[0]["cloud_daemon_instance_id"] == seed["cloud_daemon_id"]
+    assert send_calls[0]["type"] == "upsert_gateway"
+
+
+@pytest.mark.asyncio
 async def test_create_telegram_requires_bot_token(client, seed, monkeypatch):
     _patch_daemon(monkeypatch, online=True)
     headers = {"Authorization": f"Bearer {seed['token']}"}

--- a/frontend/src/components/dashboard/AgentChannelsTab.tsx
+++ b/frontend/src/components/dashboard/AgentChannelsTab.tsx
@@ -37,6 +37,7 @@ import {
 
 interface Props {
   agentId: string;
+  hostingKind?: string | null;
 }
 
 type AddMode = null | "telegram" | "wechat" | "feishu";
@@ -124,12 +125,14 @@ function StepSection({
 // useSyncExternalStore infinite-render guard (React #185).
 const EMPTY_LIST: AgentGatewayConnection[] = [];
 
-export default function AgentChannelsTab({ agentId }: Props) {
+export default function AgentChannelsTab({ agentId, hostingKind }: Props) {
   const list = useAgentGatewayStore((s) => s.byAgent[agentId]) ?? EMPTY_LIST;
   const loading = useAgentGatewayStore((s) => Boolean(s.loading[agentId]));
   const daemonOffline = useAgentGatewayStore((s) =>
     Boolean(s.daemonOffline[agentId]),
   );
+  const isCloudAgent = hostingKind === "cloud";
+  const blockedByOffline = daemonOffline && !isCloudAgent;
   const lastError = useAgentGatewayStore((s) => s.lastError[agentId]) ?? null;
   const load = useAgentGatewayStore((s) => s.load);
   const enable = useAgentGatewayStore((s) => s.enable);
@@ -168,7 +171,7 @@ export default function AgentChannelsTab({ agentId }: Props) {
   }, []);
 
   async function handleToggle(g: AgentGatewayConnection) {
-    if (daemonOffline) return;
+    if (blockedByOffline) return;
     setBusyId(g.id);
     setErr(g.id, null);
     setOk(g.id, null);
@@ -207,9 +210,13 @@ export default function AgentChannelsTab({ agentId }: Props) {
         <div className="flex items-start gap-2 rounded-xl border border-amber-400/40 bg-amber-400/10 px-3 py-2.5 text-xs text-amber-200">
           <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
           <div>
-            <div className="font-semibold">Daemon 离线</div>
+            <div className="font-semibold">
+              {isCloudAgent ? "云端运行环境暂不可用" : "Daemon 离线"}
+            </div>
             <div className="text-amber-200/80">
-              本地 daemon 当前不在线，已连接列表仍可读，但无法创建、扫码、编辑、启用、停用或删除接入。
+              {isCloudAgent
+                ? "已连接列表仍可读。云端环境会在操作时尝试自动恢复；如果刚刚恢复超时，请稍后重试。"
+                : "本地 daemon 当前不在线，已连接列表仍可读，但无法创建、扫码、编辑、启用、停用或删除接入。"}
             </div>
           </div>
         </div>
@@ -223,7 +230,7 @@ export default function AgentChannelsTab({ agentId }: Props) {
             <button
               type="button"
               onClick={() => setAddMode("telegram")}
-              disabled={daemonOffline}
+              disabled={blockedByOffline}
               className="inline-flex items-center gap-1 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-2.5 py-1 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20 disabled:cursor-not-allowed disabled:opacity-50"
             >
               <Plus className="h-3 w-3" />
@@ -297,7 +304,7 @@ export default function AgentChannelsTab({ agentId }: Props) {
                       <button
                         type="button"
                         onClick={() => handleToggle(g)}
-                        disabled={daemonOffline || busyId === g.id}
+                        disabled={blockedByOffline || busyId === g.id}
                         className="rounded-md border border-glass-border bg-glass-bg/60 px-2 py-1 text-[11px] text-text-secondary transition-colors hover:text-text-primary disabled:opacity-50"
                       >
                         {g.enabled ? "停用" : "启用"}
@@ -309,7 +316,7 @@ export default function AgentChannelsTab({ agentId }: Props) {
                           setErr(g.id, null);
                           setOk(g.id, null);
                         }}
-                        disabled={daemonOffline || busyId === g.id}
+                        disabled={blockedByOffline || busyId === g.id}
                         className="inline-flex items-center gap-1 rounded-md border border-glass-border bg-glass-bg/60 px-2 py-1 text-[11px] text-text-secondary transition-colors hover:text-text-primary disabled:opacity-50"
                       >
                         <SquarePen className="h-3 w-3" />
@@ -318,7 +325,7 @@ export default function AgentChannelsTab({ agentId }: Props) {
                       <button
                         type="button"
                         onClick={() => setPendingDelete(g)}
-                        disabled={daemonOffline || busyId === g.id}
+                        disabled={blockedByOffline || busyId === g.id}
                         className="rounded-md border border-red-400/40 bg-red-500/10 p-1 text-red-300 transition-colors hover:bg-red-500/20 disabled:opacity-50"
                         title="删除"
                       >
@@ -330,7 +337,7 @@ export default function AgentChannelsTab({ agentId }: Props) {
                     <GatewayEditForm
                       agentId={agentId}
                       gateway={g}
-                      daemonOffline={daemonOffline}
+                      daemonOffline={blockedByOffline}
                       onCancel={() => setEditingId(null)}
                       onSaved={() => {
                         setEditingId(null);
@@ -345,7 +352,7 @@ export default function AgentChannelsTab({ agentId }: Props) {
           </ul>
         )}
 
-        {!addMode && lastError && !daemonOffline && (
+        {!addMode && lastError && !blockedByOffline && (
           <div className="text-[11px] text-red-300">{lastError}</div>
         )}
       </section>
@@ -383,21 +390,21 @@ export default function AgentChannelsTab({ agentId }: Props) {
           {addMode === "telegram" ? (
             <TelegramAddForm
               agentId={agentId}
-              daemonOffline={daemonOffline}
+              daemonOffline={blockedByOffline}
               onCancel={() => setAddMode(null)}
               onCreated={() => setAddMode(null)}
             />
           ) : addMode === "wechat" ? (
             <WechatAddForm
               agentId={agentId}
-              daemonOffline={daemonOffline}
+              daemonOffline={blockedByOffline}
               onCancel={() => setAddMode(null)}
               onCreated={() => setAddMode(null)}
             />
           ) : (
             <FeishuAddForm
               agentId={agentId}
-              daemonOffline={daemonOffline}
+              daemonOffline={blockedByOffline}
               onCancel={() => setAddMode(null)}
               onCreated={() => setAddMode(null)}
             />

--- a/frontend/src/components/dashboard/AgentSettingsDrawer.tsx
+++ b/frontend/src/components/dashboard/AgentSettingsDrawer.tsx
@@ -701,7 +701,9 @@ export default function AgentSettingsDrawer({
             </div>
           )}
 
-          {tab === "gateways" && <AgentChannelsTab agentId={agentId} />}
+          {tab === "gateways" && (
+            <AgentChannelsTab agentId={agentId} hostingKind={hostingKind} />
+          )}
 
           {tab === "schedules" && <AgentSchedulesTab agentId={agentId} />}
 

--- a/frontend/src/components/dashboard/BotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/BotDetailDrawer.tsx
@@ -302,7 +302,13 @@ export default function BotDetailDrawer() {
               onOpenChat={() => void openOwnerChat()}
             />
           )}
-          {tab === "settings" && <SettingsTab agentId={bot.agent_id} t={t} />}
+          {tab === "settings" && (
+            <SettingsTab
+              agentId={bot.agent_id}
+              hostingKind={bot.hosting_kind ?? null}
+              t={t}
+            />
+          )}
           {tab === "files" && <FilesTab agentId={bot.agent_id} t={t} />}
           {tab === "wallet" && <BotWalletTab agentId={bot.agent_id} displayName={bot.display_name} />}
         </div>
@@ -703,7 +709,15 @@ function ProfileEditor({
 
 /* --------------------------- Settings --------------------------- */
 
-function SettingsTab({ agentId, t }: { agentId: string; t: BotDetailDrawerCopy }) {
+function SettingsTab({
+  agentId,
+  hostingKind,
+  t,
+}: {
+  agentId: string;
+  hostingKind?: string | null;
+  t: BotDetailDrawerCopy;
+}) {
   return (
     <div className="space-y-6">
       <section className="space-y-3">
@@ -724,7 +738,7 @@ function SettingsTab({ agentId, t }: { agentId: string; t: BotDetailDrawerCopy }
         <h3 className="text-[11px] font-semibold uppercase tracking-wider text-text-secondary/70">
           {t.settings.channels}
         </h3>
-        <AgentChannelsTab agentId={agentId} />
+        <AgentChannelsTab agentId={agentId} hostingKind={hostingKind} />
       </section>
     </div>
   );

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -374,6 +374,8 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
           agentId={ownedAgent.agent_id}
           displayName={ownedAgent.display_name}
           bio={ownedAgent.bio ?? null}
+          avatarUrl={ownedAgent.avatar_url ?? null}
+          hostingKind={ownedAgent.hosting_kind ?? null}
           onClose={() => setAgentSettingsOpen(false)}
         />
       )}


### PR DESCRIPTION
## Summary
- resume cloud-hosted agents before third-party gateway write/login/test actions when the cloud daemon is not connected
- keep local daemon offline behavior unchanged
- update the dashboard channels tab to distinguish cloud runtime availability from local daemon offline state and keep cloud gateway controls retryable

## Tests
- cd backend && uv run pytest tests/test_app/test_app_gateways.py -q
- cd frontend && NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key npm run build

Note: plain `npm run build` requires Supabase env vars for `/admin/codes` prerendering.