### PR TITLE
fix: enforce cloud daemon singleton

### DIFF
--- a/frontend/src/store/useAgentGatewayStore.test.ts
+++ b/frontend/src/store/useAgentGatewayStore.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GatewayApiError, useAgentGatewayStore } from "@/store/useAgentGatewayStore";
+
+describe("useAgentGatewayStore errors", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    useAgentGatewayStore.setState({
+      daemonOffline: {},
+      lastError: {},
+    });
+  });
+
+  it("surfaces daemon gateway failure details from Hub", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          detail: {
+            code: "daemon_gateway_failed",
+            daemon_code: "provider_unreachable",
+            daemon_message: "fetch failed",
+          },
+        }),
+        {
+          status: 502,
+          statusText: "Bad Gateway",
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    await expect(
+      useAgentGatewayStore.getState().pollWechatLogin("ag_1", "wxl_1"),
+    ).rejects.toMatchObject({
+      message: "fetch failed",
+      status: 502,
+      code: "provider_unreachable",
+    } satisfies Partial<GatewayApiError>);
+  });
+});

--- a/frontend/src/store/useAgentGatewayStore.ts
+++ b/frontend/src/store/useAgentGatewayStore.ts
@@ -149,8 +149,22 @@ async function readErr(res: Response): Promise<GatewayApiError> {
       error?: unknown;
       code?: unknown;
     };
-    if (typeof json.detail === "string") detail = json.detail;
-    else if (typeof json.message === "string") detail = json.message;
+    if (typeof json.detail === "string") {
+      detail = json.detail;
+    } else if (json.detail && typeof json.detail === "object") {
+      const nested = json.detail as {
+        code?: unknown;
+        daemon_code?: unknown;
+        daemon_message?: unknown;
+        message?: unknown;
+      };
+      if (typeof nested.daemon_message === "string") detail = nested.daemon_message;
+      else if (typeof nested.message === "string") detail = nested.message;
+      if (typeof nested.daemon_code === "string") code = nested.daemon_code;
+      else if (typeof nested.code === "string") code = nested.code;
+    } else if (typeof json.message === "string") {
+      detail = json.message;
+    }
     if (typeof json.error === "string") code = json.error;
     else if (typeof json.code === "string") code = json.code;
   } catch {

--- a/packages/daemon/src/__tests__/daemon-singleton.test.ts
+++ b/packages/daemon/src/__tests__/daemon-singleton.test.ts
@@ -1,0 +1,89 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  ensureNoOtherDaemonFromPidFile,
+  readPid,
+  removePidFile,
+  stopDaemonFromPidFileForRestart,
+  writeCurrentPid,
+} from "../daemon-singleton.js";
+
+describe("daemon singleton pid helpers", () => {
+  let tmpDir: string;
+  let children: ChildProcess[];
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), "botcord-singleton-test-"));
+    children = [];
+  });
+
+  afterEach(() => {
+    for (const child of children) {
+      if (child.pid) {
+        try {
+          process.kill(child.pid, "SIGKILL");
+        } catch {
+          // ignore
+        }
+      }
+    }
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes and reads the current pid", () => {
+    const pidPath = path.join(tmpDir, "daemon.pid");
+
+    writeCurrentPid({ pidPath, currentPid: 12345 });
+
+    expect(readPid(pidPath)).toBe(12345);
+    expect(readFileSync(pidPath, "utf8")).toBe("12345");
+  });
+
+  it("does not report the current process as another daemon", () => {
+    const pidPath = path.join(tmpDir, "daemon.pid");
+    writeCurrentPid({ pidPath, currentPid: process.pid });
+
+    expect(ensureNoOtherDaemonFromPidFile({ pidPath, currentPid: process.pid })).toBeNull();
+  });
+
+  it("terminates the daemon recorded in the pid file before restart", async () => {
+    const pidPath = path.join(tmpDir, "daemon.pid");
+    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      stdio: "ignore",
+    });
+    children.push(child);
+    await waitForPid(child);
+    writeCurrentPid({ pidPath, currentPid: child.pid! });
+
+    await stopDaemonFromPidFileForRestart({ pidPath, currentPid: process.pid });
+
+    expect(existsSync(pidPath)).toBe(false);
+    await waitForExit(child);
+    expect(child.exitCode === null && child.signalCode === null).toBe(false);
+  });
+
+  it("removes stale pid files", () => {
+    const pidPath = path.join(tmpDir, "daemon.pid");
+    writeCurrentPid({ pidPath, currentPid: 99999999 });
+
+    removePidFile(pidPath);
+
+    expect(readPid(pidPath)).toBeNull();
+  });
+});
+
+async function waitForPid(child: ChildProcess): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (!child.pid && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  if (!child.pid) throw new Error("child pid was not assigned");
+}
+
+async function waitForExit(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  await new Promise<void>((resolve) => child.once("exit", () => resolve()));
+}

--- a/packages/daemon/src/daemon-singleton.ts
+++ b/packages/daemon/src/daemon-singleton.ts
@@ -1,0 +1,122 @@
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { PID_PATH } from "./config.js";
+
+export interface SingletonLogger {
+  info(message: string, meta?: Record<string, unknown>): void;
+  warn(message: string, meta?: Record<string, unknown>): void;
+}
+
+const noopLogger: SingletonLogger = {
+  info() {
+    // noop
+  },
+  warn() {
+    // noop
+  },
+};
+
+export function readPid(pidPath = PID_PATH): number | null {
+  if (!existsSync(pidPath)) return null;
+  const raw = readFileSync(pidPath, "utf8").trim();
+  const pid = Number(raw);
+  return Number.isFinite(pid) && pid > 0 ? pid : null;
+}
+
+export function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function waitForPidExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!pidAlive(pid)) return true;
+    await delay(100);
+  }
+  return !pidAlive(pid);
+}
+
+export async function stopExistingDaemonForRestart(
+  pid: number,
+  opts: {
+    pidPath?: string;
+    currentPid?: number;
+    logger?: SingletonLogger;
+  } = {},
+): Promise<void> {
+  const pidPath = opts.pidPath ?? PID_PATH;
+  const currentPid = opts.currentPid ?? process.pid;
+  const logger = opts.logger ?? noopLogger;
+  if (pid === currentPid) return;
+  logger.info("existing daemon found; restarting", { pid });
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch {
+    removePidFile(pidPath);
+    return;
+  }
+  if (!(await waitForPidExit(pid, 5_000))) {
+    logger.warn("existing daemon did not stop after SIGTERM; sending SIGKILL", { pid });
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // ignore
+    }
+    await waitForPidExit(pid, 2_000);
+  }
+  removePidFile(pidPath);
+}
+
+export async function stopDaemonFromPidFileForRestart(
+  opts: {
+    pidPath?: string;
+    currentPid?: number;
+    logger?: SingletonLogger;
+  } = {},
+): Promise<void> {
+  const pidPath = opts.pidPath ?? PID_PATH;
+  const existing = readPid(pidPath);
+  if (existing && pidAlive(existing)) {
+    await stopExistingDaemonForRestart(existing, opts);
+  }
+}
+
+export function ensureNoOtherDaemonFromPidFile(
+  opts: {
+    pidPath?: string;
+    currentPid?: number;
+  } = {},
+): number | null {
+  const pidPath = opts.pidPath ?? PID_PATH;
+  const currentPid = opts.currentPid ?? process.pid;
+  const existing = readPid(pidPath);
+  if (existing && existing !== currentPid && pidAlive(existing)) {
+    return existing;
+  }
+  return null;
+}
+
+export function writeCurrentPid(
+  opts: {
+    pidPath?: string;
+    currentPid?: number;
+  } = {},
+): void {
+  writeFileSync(opts.pidPath ?? PID_PATH, String(opts.currentPid ?? process.pid), { mode: 0o600 });
+}
+
+export function removePidFile(pidPath = PID_PATH): void {
+  try {
+    unlinkSync(pidPath);
+  } catch {
+    // ignore
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync, unlinkSync, readdirSync, statSync, rmSync } from "node:fs";
+import { existsSync, readFileSync, unlinkSync, readdirSync, statSync, rmSync } from "node:fs";
 import { homedir, hostname } from "node:os";
 import path from "node:path";
 import { augmentProcessPath } from "./path-env.js";
@@ -9,7 +9,6 @@ import {
   saveConfig,
   initDefaultConfig,
   resolveConfiguredAgentIds,
-  PID_PATH,
   SNAPSHOT_PATH,
   CONFIG_FILE_PATH,
   CONFIG_MISSING,
@@ -17,6 +16,14 @@ import {
   type RouteRule,
   type RouteRuleMatch,
 } from "./config.js";
+import {
+  ensureNoOtherDaemonFromPidFile,
+  pidAlive,
+  readPid,
+  removePidFile,
+  stopDaemonFromPidFileForRestart,
+  writeCurrentPid,
+} from "./daemon-singleton.js";
 import { resolveBootAgents } from "./agent-discovery.js";
 import {
   defaultTranscriptRoot,
@@ -226,60 +233,6 @@ function parseArgs(argv: string[]): ParsedArgs {
     }
   }
   return { cmd: cmd ?? "", sub, flags, lists };
-}
-
-function readPid(): number | null {
-  if (!existsSync(PID_PATH)) return null;
-  const raw = readFileSync(PID_PATH, "utf8").trim();
-  const pid = Number(raw);
-  return Number.isFinite(pid) && pid > 0 ? pid : null;
-}
-
-function pidAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function waitForPidExit(pid: number, timeoutMs: number): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (!pidAlive(pid)) return true;
-    await delay(100);
-  }
-  return !pidAlive(pid);
-}
-
-async function stopExistingDaemonForRestart(pid: number): Promise<void> {
-  if (pid === process.pid) return;
-  log.info("existing daemon found; restarting", { pid });
-  try {
-    process.kill(pid, "SIGTERM");
-  } catch {
-    try {
-      unlinkSync(PID_PATH);
-    } catch {
-      // ignore
-    }
-    return;
-  }
-  if (!(await waitForPidExit(pid, 5_000))) {
-    log.warn("existing daemon did not stop after SIGTERM; sending SIGKILL", { pid });
-    try {
-      process.kill(pid, "SIGKILL");
-    } catch {
-      // ignore
-    }
-    await waitForPidExit(pid, 2_000);
-  }
-  try {
-    unlinkSync(PID_PATH);
-  } catch {
-    // ignore
-  }
 }
 
 /**
@@ -628,13 +581,10 @@ async function cmdStart(args: ParsedArgs): Promise<void> {
   // var so we don't try to re-prompt for credentials it already has.
   if (process.env.BOTCORD_DAEMON_CHILD !== "1") {
     await ensureUserAuthForStart(args);
-    const existing = readPid();
-    if (existing && pidAlive(existing)) {
-      await stopExistingDaemonForRestart(existing);
-    }
+    await stopDaemonFromPidFileForRestart({ logger: log });
   } else {
-    const existing = readPid();
-    if (existing && existing !== process.pid && pidAlive(existing)) {
+    const existing = ensureNoOtherDaemonFromPidFile();
+    if (existing) {
       console.error(`daemon already running (pid ${existing})`);
       process.exit(1);
     }
@@ -669,17 +619,13 @@ async function cmdStart(args: ParsedArgs): Promise<void> {
   }
 
   // Foreground: we ARE the daemon.
-  writeFileSync(PID_PATH, String(process.pid), { mode: 0o600 });
+  writeCurrentPid();
   const handle = await startDaemon({ config: cfg, configPath: CONFIG_FILE_PATH });
 
   const shutdown = async (sig: string) => {
     log.info("signal received", { sig });
     await handle.stop(sig);
-    try {
-      unlinkSync(PID_PATH);
-    } catch {
-      // ignore
-    }
+    removePidFile();
     process.exit(0);
   };
   process.on("SIGTERM", () => shutdown("SIGTERM"));
@@ -695,10 +641,9 @@ async function cmdStart(args: ParsedArgs): Promise<void> {
 /**
  * Cloud-mode start: launched by the Hub-managed E2B sandbox provider.
  *
- * No login flow, no on-disk credentials at boot, no PID-file dance
- * (the sandbox is the lifecycle manager). The cloud daemon stays in the
- * foreground until killed; agents arrive via `provision_agent` frames
- * over `/cloud/daemon/ws`.
+ * No login flow and no on-disk credentials at boot. The daemon still uses
+ * the same PID-file singleton guard as local foreground starts because E2B
+ * resume hooks can run the startup command more than once in one sandbox.
  *
  * Always foreground — `--background` / `-d` is silently ignored because
  * E2B sandboxes don't have a meaningful detach concept.
@@ -710,6 +655,8 @@ async function cmdStartCloud(_args: ParsedArgs): Promise<void> {
     daemonInstanceId: cloudConfig.daemonInstanceId,
     hubUrl: cloudConfig.hubUrl,
   });
+  await stopDaemonFromPidFileForRestart({ logger: log });
+  writeCurrentPid();
 
   // Cloud daemons always start with an empty in-memory config — every
   // agent + route arrives over the control plane. We synthesize the
@@ -731,6 +678,7 @@ async function cmdStartCloud(_args: ParsedArgs): Promise<void> {
   const shutdown = async (sig: string): Promise<void> => {
     log.info("signal received", { sig });
     await handle.stop(sig);
+    removePidFile();
     process.exit(0);
   };
   process.on("SIGTERM", () => void shutdown("SIGTERM"));
@@ -750,11 +698,7 @@ async function cmdStop(): Promise<void> {
   }
   if (!pidAlive(pid)) {
     console.error(`pid ${pid} not alive; removing stale pid file`);
-    try {
-      unlinkSync(PID_PATH);
-    } catch {
-      // ignore
-    }
+    removePidFile();
     process.exit(1);
   }
   process.kill(pid, "SIGTERM");


### PR DESCRIPTION
## Summary
- share PID-file singleton enforcement between local and cloud daemon starts
- stop any existing daemon before a cloud foreground start writes the new PID
- surface nested daemon gateway errors in the frontend store

## Tests
- cd packages/daemon && npm run test -- src/__tests__/daemon-singleton.test.ts src/__tests__/cloud-daemon.test.ts src/__tests__/cloud-mode.test.ts
- cd packages/daemon && npm run build
- cd frontend && npm run test -- src/store/useAgentGatewayStore.test.ts src/store/useDaemonStore.test.ts

## Notes
- frontend npm run build was not rerun in this PR flow; earlier it failed on missing Supabase URL/API key while prerendering /admin/codes, unrelated to this change.