### PR TITLE
fix: stabilize wechat gateway login

### DIFF
--- a/backend/app/routers/gateways.py
+++ b/backend/app/routers/gateways.py
@@ -279,6 +279,11 @@ def _require_online(host: _GatewayHost) -> None:
 
 _CLOUD_GATEWAY_RESUME_WAIT_SECONDS = 20.0
 _CLOUD_GATEWAY_RESUME_POLL_SECONDS = 0.5
+_CLOUD_GATEWAY_DISPATCH_RETRY_CODES = {
+    "cloud_daemon_offline",
+    "cloud_daemon_disconnected",
+    "cloud_daemon_send_failed",
+}
 
 
 async def _ensure_gateway_host_online(
@@ -332,13 +337,47 @@ async def _send_gateway_control_frame(
     host: _GatewayHost,
     type_: str,
     params: dict[str, Any],
+    *,
+    db: AsyncSession | None = None,
+    ctx: RequestContext | None = None,
+    agent: Agent | None = None,
+    retry_cloud_disconnect: bool = False,
 ) -> dict[str, Any]:
     if not host.cloud_daemon_instance_id:
         return await send_control_frame(host.daemon_instance_id, type_, params)
     try:
         return await send_cloud_control_frame(host.cloud_daemon_instance_id, type_, params)
     except CloudDaemonDispatchError as exc:
+        if (
+            retry_cloud_disconnect
+            and exc.code in _CLOUD_GATEWAY_DISPATCH_RETRY_CODES
+            and db is not None
+            and ctx is not None
+            and agent is not None
+        ):
+            logger.warning(
+                "cloud gateway dispatch lost connection; attempting resume and retry: "
+                "agent=%s cloud=%s type=%s code=%s err=%s",
+                agent.agent_id,
+                host.cloud_daemon_instance_id,
+                type_,
+                exc.code,
+                exc.message,
+            )
+            await _ensure_gateway_host_online(db, ctx, agent, host)
+            try:
+                return await send_cloud_control_frame(
+                    host.cloud_daemon_instance_id,
+                    type_,
+                    params,
+                )
+            except CloudDaemonDispatchError as retry_exc:
+                exc = retry_exc
         if exc.code == "cloud_daemon_offline":
+            raise HTTPException(status_code=409, detail="daemon_offline") from exc
+        if exc.code == "cloud_daemon_disconnected":
+            raise HTTPException(status_code=409, detail="daemon_offline") from exc
+        if exc.code == "cloud_daemon_send_failed":
             raise HTTPException(status_code=409, detail="daemon_offline") from exc
         if exc.code == "cloud_daemon_ack_timeout":
             raise HTTPException(status_code=504, detail="daemon_ack_timeout") from exc
@@ -553,7 +592,15 @@ async def create_gateway(
     if body.provider in ("wechat", "feishu"):
         params["loginId"] = body.login_id
 
-    ack = await _send_gateway_control_frame(host, "upsert_gateway", params)
+    ack = await _send_gateway_control_frame(
+        host,
+        "upsert_gateway",
+        params,
+        db=db,
+        ctx=ctx,
+        agent=agent,
+        retry_cloud_disconnect=True,
+    )
     result = _ack_or_raise(ack)
 
     token_preview = result.get("tokenPreview")
@@ -692,7 +739,15 @@ async def delete_gateway(
     else:
         await _ensure_gateway_host_online(db, ctx, agent, host)
 
-        ack = await _send_gateway_control_frame(host, "remove_gateway", {"id": row.id})
+        ack = await _send_gateway_control_frame(
+            host,
+            "remove_gateway",
+            {"id": row.id},
+            db=db,
+            ctx=ctx,
+            agent=agent,
+            retry_cloud_disconnect=True,
+        )
         _ack_or_raise(ack)
 
     await db.delete(row)
@@ -711,7 +766,15 @@ async def test_gateway(
     agent, host, row = await _load_owned_connection(db, ctx, agent_id, gateway_id)
     await _ensure_gateway_host_online(db, ctx, agent, host)
 
-    ack = await _send_gateway_control_frame(host, "test_gateway", {"id": row.id})
+    ack = await _send_gateway_control_frame(
+        host,
+        "test_gateway",
+        {"id": row.id},
+        db=db,
+        ctx=ctx,
+        agent=agent,
+        retry_cloud_disconnect=True,
+    )
     result = _ack_or_raise(ack)
     return {"ok": True, "result": result}
 
@@ -748,7 +811,15 @@ async def wechat_login_start(
         _validate_base_url(body.base_url)
         params["baseUrl"] = body.base_url
 
-    ack = await _send_gateway_control_frame(host, "gateway_login_start", params)
+    ack = await _send_gateway_control_frame(
+        host,
+        "gateway_login_start",
+        params,
+        db=db,
+        ctx=ctx,
+        agent=agent,
+        retry_cloud_disconnect=True,
+    )
     result = _ack_or_raise(ack)
     # Surface the daemon-reported envelope verbatim — the dashboard already
     # speaks `{loginId, qrcode, qrcodeUrl, expiresAt}` per the design doc.
@@ -775,6 +846,10 @@ async def wechat_login_status(
         host,
         "gateway_login_status",
         {"provider": "wechat", "loginId": body.login_id, "accountId": agent_id},
+        db=db,
+        ctx=ctx,
+        agent=agent,
+        retry_cloud_disconnect=True,
     )
     result = _ack_or_raise(ack)
     return {
@@ -804,7 +879,15 @@ async def feishu_login_start(
     if body.domain:
         params["domain"] = body.domain
 
-    ack = await _send_gateway_control_frame(host, "gateway_login_start", params)
+    ack = await _send_gateway_control_frame(
+        host,
+        "gateway_login_start",
+        params,
+        db=db,
+        ctx=ctx,
+        agent=agent,
+        retry_cloud_disconnect=True,
+    )
     result = _ack_or_raise(ack)
     return {
         "loginId": result.get("loginId"),
@@ -829,6 +912,10 @@ async def feishu_login_status(
         host,
         "gateway_login_status",
         {"provider": "feishu", "loginId": body.login_id, "accountId": agent_id},
+        db=db,
+        ctx=ctx,
+        agent=agent,
+        retry_cloud_disconnect=True,
     )
     result = _ack_or_raise(ack)
     return {
@@ -865,6 +952,10 @@ async def wechat_recent_senders(
             "accountId": agent_id,
             "timeoutSeconds": body.timeout_seconds,
         },
+        db=db,
+        ctx=ctx,
+        agent=agent,
+        retry_cloud_disconnect=True,
     )
     result = _ack_or_raise(ack)
     senders = result.get("senders")

--- a/backend/hub/routers/cloud_daemon_control.py
+++ b/backend/hub/routers/cloud_daemon_control.py
@@ -240,6 +240,7 @@ async def send_cloud_control_frame(
         await conn.ws.send_text(json.dumps(frame))
     except Exception as exc:  # noqa: BLE001
         conn.pending_acks.pop(frame["id"], None)
+        await _REGISTRY.unregister(conn)
         raise CloudDaemonDispatchError(
             "cloud_daemon_send_failed", f"daemon send failed: {exc}"
         ) from exc

--- a/backend/tests/test_app/test_app_gateways.py
+++ b/backend/tests/test_app/test_app_gateways.py
@@ -623,6 +623,85 @@ async def test_create_telegram_for_cloud_agent_resumes_when_cloud_daemon_offline
 
 
 @pytest.mark.asyncio
+async def test_create_telegram_for_cloud_agent_retries_after_disconnect(
+    client, seed, db_session, monkeypatch
+):
+    import app.routers.gateways as gw
+
+    gw._RATE_BUCKETS.clear()
+    online = {"value": True}
+    resume_calls: list[dict] = []
+    send_calls: list[dict] = []
+
+    class FakeCloudAgentService:
+        async def resume_cloud_agent(self, db, *, user_id, agent_id):
+            resume_calls.append({"user_id": user_id, "agent_id": agent_id})
+            online["value"] = True
+            return None
+
+    async def fake_send(cloud_daemon_instance_id, type_, params=None, timeout_ms=None):
+        send_calls.append(
+            {
+                "cloud_daemon_instance_id": cloud_daemon_instance_id,
+                "type": type_,
+                "params": params,
+                "timeout_ms": timeout_ms,
+            }
+        )
+        if len(send_calls) == 1:
+            online["value"] = False
+            raise gw.CloudDaemonDispatchError(
+                "cloud_daemon_disconnected",
+                "cloud daemon disconnected",
+            )
+        return {
+            "ok": True,
+            "result": {
+                "id": params["id"],
+                "type": "telegram",
+                "accountId": params["accountId"],
+                "enabled": True,
+                "tokenPreview": "1234...wxyz",
+                "status": {"running": True, "authorized": True},
+            },
+        }
+
+    monkeypatch.setattr(gw, "CloudAgentService", lambda: FakeCloudAgentService())
+    monkeypatch.setattr(gw, "is_cloud_daemon_online", lambda _id: online["value"])
+    monkeypatch.setattr(gw, "send_cloud_control_frame", fake_send)
+    _patch_daemon(monkeypatch, online=False)
+
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    r = await client.post(
+        "/api/agents/ag_cloud/gateways",
+        headers=headers,
+        json={
+            "provider": "telegram",
+            "label": "cloud tg",
+            "bot_token": "1234:abcd",
+            "config": {
+                "allowedChatIds": ["111"],
+                "allowedSenderIds": ["111"],
+            },
+        },
+    )
+
+    assert r.status_code == 200, r.text
+    assert resume_calls == [{"user_id": seed["user_id"], "agent_id": "ag_cloud"}]
+    assert len(send_calls) == 2
+    assert send_calls[0]["type"] == "upsert_gateway"
+    assert send_calls[1]["type"] == "upsert_gateway"
+    rows = (
+        await db_session.execute(
+            select(AgentGatewayConnection).where(
+                AgentGatewayConnection.agent_id == "ag_cloud"
+            )
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
 async def test_create_telegram_requires_bot_token(client, seed, monkeypatch):
     _patch_daemon(monkeypatch, online=True)
     headers = {"Authorization": f"Bearer {seed['token']}"}

--- a/backend/tests/test_cloud_agent_provisioning.py
+++ b/backend/tests/test_cloud_agent_provisioning.py
@@ -197,6 +197,34 @@ async def test_send_cloud_control_frame_timeout_raises():
         await _registry_for_tests().unregister(conn)
 
 
+@pytest.mark.asyncio
+async def test_send_cloud_control_frame_send_failure_unregisters_stale_conn():
+    class FailingWS(_FakeWS):
+        async def send_text(self, payload: str) -> None:
+            raise RuntimeError("socket closed")
+
+    ws = FailingWS()
+    conn = _CloudDaemonConn(
+        ws=ws,
+        user_id="u",
+        cloud_daemon_instance_id="cloud_dm_send_fail",
+        daemon_instance_id="dm_send_fail",
+    )
+    await _registry_for_tests().register(conn)
+
+    with pytest.raises(CloudDaemonDispatchError) as excinfo:
+        await send_cloud_control_frame(
+            "cloud_dm_send_fail",
+            "ping",
+            {},
+            timeout_ms=100,
+        )
+
+    assert excinfo.value.code == "cloud_daemon_send_failed"
+    assert not conn.pending_acks
+    assert _registry_for_tests().get_by_cloud("cloud_dm_send_fail") is None
+
+
 # ---------------------------------------------------------------------------
 # Service create + provision flow (E2B provider returns ``starting``)
 # ---------------------------------------------------------------------------

--- a/frontend/src/components/dashboard/AgentChannelsTab.tsx
+++ b/frontend/src/components/dashboard/AgentChannelsTab.tsx
@@ -14,6 +14,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import {
   AlertTriangle,
   CheckCircle2,
+  Clock,
   Copy,
   Info,
   Loader2,
@@ -78,6 +79,50 @@ function isAckTimeoutError(err: unknown): boolean {
   return (
     err instanceof GatewayApiError &&
     (err.status === 504 || err.message === "daemon_ack_timeout")
+  );
+}
+
+function useExpiryCountdown(expiresAt: number | null): number | null {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!expiresAt) return;
+    setNow(Date.now());
+    const timer = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(timer);
+  }, [expiresAt]);
+
+  if (!expiresAt) return null;
+  return Math.max(0, expiresAt - now);
+}
+
+function formatCountdown(ms: number): string {
+  const totalSeconds = Math.ceil(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+function WechatLoginExpiryNotice({
+  remainingMs,
+}: {
+  remainingMs: number | null;
+}) {
+  if (remainingMs === null) return null;
+  const expired = remainingMs <= 0;
+  return (
+    <div
+      className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-[10px] ${
+        expired
+          ? "border-amber-400/35 bg-amber-400/10 text-amber-200"
+          : remainingMs <= 60_000
+            ? "border-amber-400/30 bg-amber-400/10 text-amber-200"
+            : "border-glass-border bg-glass-bg/45 text-text-tertiary"
+      }`}
+    >
+      <Clock className="h-3 w-3" />
+      {expired ? "临时登录态已过期，请重新扫码" : `临时登录态剩余 ${formatCountdown(remainingMs)}`}
+    </div>
   );
 }
 
@@ -1183,6 +1228,7 @@ function WechatAddForm({
   const [loginId, setLoginId] = useState<string | null>(null);
   const [qrcode, setQrcode] = useState<string | null>(null);
   const [qrcodeUrl, setQrcodeUrl] = useState<string | null>(null);
+  const [loginExpiresAt, setLoginExpiresAt] = useState<number | null>(null);
   const [status, setStatus] = useState<WechatLoginStatus>("pending");
   const [tokenPreview, setTokenPreview] = useState<string | null>(null);
   const [baseUrl, setBaseUrl] = useState<string | null>(null);
@@ -1201,6 +1247,8 @@ function WechatAddForm({
   const [senderDiscoverError, setSenderDiscoverError] = useState<string | null>(null);
   const [copiedSenderId, setCopiedSenderId] = useState<string | null>(null);
   const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const loginRemainingMs = useExpiryCountdown(loginExpiresAt);
+  const loginExpired = loginRemainingMs !== null && loginRemainingMs <= 0;
 
   useEffect(() => {
     return () => {
@@ -1208,15 +1256,32 @@ function WechatAddForm({
     };
   }, []);
 
+  useEffect(() => {
+    if (!loginExpired) return;
+    if (phase === "scanning" && status !== "expired" && status !== "failed") {
+      setStatus("expired");
+    }
+    if (pollTimer.current) {
+      clearInterval(pollTimer.current);
+      pollTimer.current = null;
+    }
+  }, [loginExpired, phase, status]);
+
   async function handleStart() {
     setBusy(true);
     setError(null);
+    setSenderDiscoverError(null);
+    setSenderDiscoverHint(null);
+    setDiscoveredSenders([]);
     try {
       const r = await startWechatLogin(agentId, {});
       setLoginId(r.loginId);
       setQrcode(r.qrcode);
       setQrcodeUrl(r.qrcodeUrl ?? null);
+      setLoginExpiresAt(r.expiresAt);
       setStatus("pending");
+      setTokenPreview(null);
+      setBaseUrl(null);
       setPhase("scanning");
       // start polling
       if (pollTimer.current) clearInterval(pollTimer.current);
@@ -1265,9 +1330,19 @@ function WechatAddForm({
   const whitelistEmpty = allowedSenderIds.length === 0;
   const loginReady = phase === "ready" && !!loginId;
   const senderReady = allowedSenderIds.length > 0;
-  const canSave = phase === "ready" && !!loginId && !whitelistEmpty && !daemonOffline && !busy;
+  const canSave =
+    phase === "ready" &&
+    !!loginId &&
+    !whitelistEmpty &&
+    !loginExpired &&
+    !daemonOffline &&
+    !busy;
 
   async function handleSave() {
+    if (loginExpired) {
+      setError("微信临时登录态已过期，请重新扫码。");
+      return;
+    }
     if (!canSave || !loginId) return;
     setBusy(true);
     setError(null);
@@ -1295,6 +1370,11 @@ function WechatAddForm({
 
   async function handleDiscoverSenders() {
     if (!loginId || discoveringSenders) return;
+    if (loginExpired) {
+      setSenderDiscoverHint(null);
+      setSenderDiscoverError("微信临时登录态已过期，请重新扫码。");
+      return;
+    }
     setDiscoveringSenders(true);
     setSenderDiscoverHint("等待最近微信消息...");
     setSenderDiscoverError(null);
@@ -1379,7 +1459,10 @@ function WechatAddForm({
 
         {phase === "scanning" && (
           <div className="space-y-2 rounded-lg border border-glass-border bg-deep-black/40 p-3">
-            <div className="text-xs text-text-secondary">{statusText[status]}</div>
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-xs text-text-secondary">{statusText[status]}</span>
+              <WechatLoginExpiryNotice remainingMs={loginRemainingMs} />
+            </div>
             {qrcodeUrl ? (
               <div className="inline-flex h-44 w-44 items-center justify-center rounded-md border border-glass-border bg-white p-2">
                 <QRCodeSVG
@@ -1426,11 +1509,14 @@ function WechatAddForm({
         )}
 
         {phase === "ready" && (
-          <div className="rounded-lg border border-emerald-400/30 bg-emerald-400/10 p-2 text-[11px] text-emerald-200">
-            已授权
-            {tokenPreview ? (
-              <span className="ml-1 font-mono">· token {tokenPreview}</span>
-            ) : null}
+          <div className="space-y-2 rounded-lg border border-emerald-400/30 bg-emerald-400/10 p-2">
+            <div className="text-[11px] text-emerald-200">
+              已授权
+              {tokenPreview ? (
+                <span className="ml-1 font-mono">· token {tokenPreview}</span>
+              ) : null}
+            </div>
+            <WechatLoginExpiryNotice remainingMs={loginRemainingMs} />
           </div>
         )}
       </StepSection>
@@ -1455,7 +1541,7 @@ function WechatAddForm({
               <button
                 type="button"
                 onClick={handleDiscoverSenders}
-                disabled={!loginId || busy || discoveringSenders}
+                disabled={!loginId || loginExpired || busy || discoveringSenders}
                 className="inline-flex h-9 shrink-0 items-center justify-center gap-1.5 rounded-md border border-neon-cyan/50 bg-neon-cyan/15 px-3 text-xs font-semibold text-neon-cyan hover:bg-neon-cyan/25 disabled:opacity-50 sm:w-auto"
               >
                 {discoveringSenders ? (
@@ -1570,6 +1656,11 @@ function WechatAddForm({
             {busy && <Loader2 className="h-3 w-3 animate-spin" />}
             保存
           </button>
+          {loginExpired && (
+            <p className="mt-2 text-[10px] leading-relaxed text-amber-200">
+              微信临时登录态已过期，请重新扫码后保存。
+            </p>
+          )}
         </StepSection>
       )}
 
@@ -1638,6 +1729,7 @@ function GatewayEditForm({
   const [wechatLoginId, setWechatLoginId] = useState<string | null>(null);
   const [wechatQrcodeUrl, setWechatQrcodeUrl] = useState<string | null>(null);
   const [wechatQrcode, setWechatQrcode] = useState<string | null>(null);
+  const [wechatLoginExpiresAt, setWechatLoginExpiresAt] = useState<number | null>(null);
   const [wechatStatus, setWechatStatus] = useState<WechatLoginStatus>("pending");
   const [wechatLoginBusy, setWechatLoginBusy] = useState(false);
   const [discoveringSenders, setDiscoveringSenders] = useState(false);
@@ -1648,12 +1740,25 @@ function GatewayEditForm({
   const [senderDiscoverError, setSenderDiscoverError] = useState<string | null>(null);
   const [copiedSenderId, setCopiedSenderId] = useState<string | null>(null);
   const editPollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const wechatLoginRemainingMs = useExpiryCountdown(wechatLoginExpiresAt);
+  const wechatLoginExpired = wechatLoginRemainingMs !== null && wechatLoginRemainingMs <= 0;
 
   useEffect(() => {
     return () => {
       if (editPollTimer.current) clearInterval(editPollTimer.current);
     };
   }, []);
+
+  useEffect(() => {
+    if (!wechatLoginExpired) return;
+    if (wechatStatus !== "confirmed" && wechatStatus !== "failed") {
+      setWechatStatus("expired");
+    }
+    if (editPollTimer.current) {
+      clearInterval(editPollTimer.current);
+      editPollTimer.current = null;
+    }
+  }, [wechatLoginExpired, wechatStatus]);
 
   const allowedChatIds = csvToList(chatIds);
   const allowedSenderIds = csvToList(senderIds);
@@ -1772,6 +1877,7 @@ function GatewayEditForm({
       setWechatLoginId(r.loginId);
       setWechatQrcodeUrl(r.qrcodeUrl ?? null);
       setWechatQrcode(r.qrcode);
+      setWechatLoginExpiresAt(r.expiresAt);
       setWechatStatus("pending");
       if (editPollTimer.current) clearInterval(editPollTimer.current);
       editPollTimer.current = setInterval(() => {
@@ -1812,6 +1918,11 @@ function GatewayEditForm({
 
   async function handleDiscoverWechatSenders() {
     if (!wechatLoginId || discoveringSenders || wechatStatus !== "confirmed") return;
+    if (wechatLoginExpired) {
+      setSenderDiscoverHint(null);
+      setSenderDiscoverError("微信临时登录态已过期，请重新扫码。");
+      return;
+    }
     setDiscoveringSenders(true);
     setSenderDiscoverHint("等待最近微信消息...");
     setSenderDiscoverError(null);
@@ -2035,6 +2146,7 @@ function GatewayEditForm({
                 disabled={
                   !wechatLoginId ||
                   wechatStatus !== "confirmed" ||
+                  wechatLoginExpired ||
                   saving ||
                   discoveringSenders
                 }
@@ -2051,6 +2163,9 @@ function GatewayEditForm({
                 用要接入的微信账号发一条消息。
               </span>
             </div>
+            {wechatLoginId && (
+              <WechatLoginExpiryNotice remainingMs={wechatLoginRemainingMs} />
+            )}
             {wechatLoginId && wechatStatus !== "confirmed" && (
               <div className="space-y-2 rounded-lg border border-glass-border bg-glass-bg/35 p-2">
                 <div className="text-[11px] text-text-secondary">


### PR DESCRIPTION
## Summary
- show a countdown for WeChat login sessions and block sender discovery/save after expiry
- retry cloud gateway control dispatch once after cloud daemon disconnect/send failure by resuming the cloud agent
- unregister stale cloud daemon websocket connections after send failures

## Tests
- cd backend && uv run pytest tests/test_app/test_app_gateways.py
- cd backend && uv run pytest tests/test_cloud_agent_provisioning.py
- cd frontend && NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build