### PR TITLE
fix: refresh dialog when daemon goes offline

### DIFF
--- a/frontend/src/components/dashboard/CreateAgentDialog.tsx
+++ b/frontend/src/components/dashboard/CreateAgentDialog.tsx
@@ -346,7 +346,7 @@ export default function CreateAgentDialog({
   // Auto-select first online daemon once the list arrives.
   // If a preselectedDaemonId was provided, use that instead.
   useEffect(() => {
-    if (preselectedDaemonId && daemons.some((d) => d.id === preselectedDaemonId)) {
+    if (preselectedDaemonId && onlineDaemons.some((d) => d.id === preselectedDaemonId)) {
       setSelectedDaemonId(preselectedDaemonId);
       return;
     }
@@ -366,7 +366,7 @@ export default function CreateAgentDialog({
   const selectedDaemon = useMemo(() => {
     if (isCloudAgentSelected) return null;
     const d = daemons.find((d) => d.id === selectedDaemonId) ?? null;
-    if (!d) return d;
+    if (!d || d.status !== "online") return null;
     return { ...d, runtimes: applyRuntimeSupport(d.runtimes, t.runtimeNotSupported) };
   }, [daemons, isCloudAgentSelected, selectedDaemonId, t.runtimeNotSupported]);
 

--- a/frontend/src/store/useDaemonStore.test.ts
+++ b/frontend/src/store/useDaemonStore.test.ts
@@ -1,10 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useDaemonStore } from "@/store/useDaemonStore";
 
-describe("useDaemonStore diagnostics", () => {
+describe("useDaemonStore", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     useDaemonStore.setState({
+      daemons: [],
+      refreshingRuntimesId: null,
+      runtimeErrors: {},
       collectingDiagnosticsId: null,
       diagnosticErrors: {},
       diagnosticResults: {},
@@ -34,6 +37,53 @@ describe("useDaemonStore diagnostics", () => {
     expect(result).toBeNull();
     expect(useDaemonStore.getState().diagnosticErrors.dm_1).toBe(
       "diagnostic upload failed: HTTP 500",
+    );
+  });
+
+  it("marks a daemon offline when runtime refresh reports daemon_offline", async () => {
+    useDaemonStore.setState({
+      daemons: [
+        {
+          id: "dm_1",
+          label: "workstation",
+          status: "online",
+          created_at: null,
+          last_seen_at: null,
+          revoked_at: null,
+          removal_requested_at: null,
+          cleanup_completed_at: null,
+          runtimes: [
+            {
+              id: "codex",
+              available: true,
+            },
+          ],
+          runtimes_probed_at: null,
+        },
+      ],
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          detail: "daemon_offline",
+          error: "daemon_offline",
+          hint: null,
+          retryable: false,
+        }),
+        {
+          status: 409,
+          statusText: "Conflict",
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    await useDaemonStore.getState().refreshRuntimes("dm_1");
+
+    expect(useDaemonStore.getState().daemons[0]?.status).toBe("offline");
+    expect(useDaemonStore.getState().refreshingRuntimesId).toBeNull();
+    expect(useDaemonStore.getState().runtimeErrors.dm_1).toBe(
+      "daemon offline, start it first",
     );
   });
 });

--- a/frontend/src/store/useDaemonStore.ts
+++ b/frontend/src/store/useDaemonStore.ts
@@ -600,6 +600,25 @@ export const useDaemonStore = create<DaemonState>()((set, get) => ({
         { method: "POST" },
       );
       if (!res.ok) {
+        const detail = await parseError(res);
+        const daemonOffline = res.status === 409 && detail === "daemon_offline";
+        if (daemonOffline) {
+          set((state) => ({
+            daemons: state.daemons.map((d) =>
+              d.id === id ? { ...d, status: "offline" } : d,
+            ),
+            ...(quiet
+              ? {}
+              : {
+                  refreshingRuntimesId: null,
+                  runtimeErrors: {
+                    ...state.runtimeErrors,
+                    [id]: "daemon offline, start it first",
+                  },
+                }),
+          }));
+          return;
+        }
         if (quiet) return;
         let msg: string;
         if (res.status === 409) {
@@ -607,7 +626,7 @@ export const useDaemonStore = create<DaemonState>()((set, get) => ({
         } else if (res.status === 502) {
           msg = "daemon didn't respond";
         } else {
-          msg = await parseError(res);
+          msg = detail;
         }
         set((state) => ({
           refreshingRuntimesId: null,


### PR DESCRIPTION
## Summary
- mark daemon instances offline when runtime refresh returns daemon_offline
- keep the create Bot dialog from showing stale runtimes for offline devices
- add a store regression test for the daemon_offline refresh path

## Tests
- npm run test -- useDaemonStore.test.ts
- npm run build (fails during /admin/codes prerender because local Supabase URL/API key env vars are missing)