### PR TITLE
feat: limit shared room preview messages

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -65,7 +65,7 @@ from hub.routers.hub import (
     is_agent_ws_online,
     notify_inbox,
 )
-from hub.share_payloads import share_create_payload
+from hub.share_payloads import SHARE_MESSAGE_PREVIEW_LIMIT, share_create_payload
 from hub.validators import normalize_file_url
 
 _logger = logging.getLogger(__name__)
@@ -3074,7 +3074,7 @@ async def create_share(
     if body and body.expires_in_hours:
         expires_at = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=body.expires_in_hours)
 
-    # Fetch latest 200 messages (deduplicated)
+    # Snapshot the latest public preview window only.
     dedup_sub = (
         select(
             MessageRecord.msg_id,
@@ -3088,7 +3088,7 @@ async def create_share(
         select(MessageRecord)
         .where(MessageRecord.id.in_(select(dedup_sub.c.min_id)))
         .order_by(MessageRecord.id.desc())
-        .limit(200)
+        .limit(SHARE_MESSAGE_PREVIEW_LIMIT)
     )
     records = list(reversed(msg_result.scalars().all()))
 

--- a/backend/app/routers/humans.py
+++ b/backend/app/routers/humans.py
@@ -56,7 +56,13 @@ from hub.models import (
     User,
 )
 from hub.policy import Principal, check_room_invite_admission
-from hub.share_payloads import frontend_url, room_continue_url, room_entry_type, share_create_payload
+from hub.share_payloads import (
+    SHARE_MESSAGE_PREVIEW_LIMIT,
+    frontend_url,
+    room_continue_url,
+    room_entry_type,
+    share_create_payload,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -1022,7 +1028,7 @@ async def create_room_share_as_human(
         select(MessageRecord)
         .where(MessageRecord.id.in_(select(dedup_sub.c.min_id)))
         .order_by(MessageRecord.id.desc())
-        .limit(200)
+        .limit(SHARE_MESSAGE_PREVIEW_LIMIT)
     )
     records = list(reversed(msg_result.scalars().all()))
 

--- a/backend/app/routers/share.py
+++ b/backend/app/routers/share.py
@@ -15,7 +15,7 @@ from hub.models import (
     Share,
     ShareMessage,
 )
-from hub.share_payloads import share_public_payload
+from hub.share_payloads import SHARE_MESSAGE_PREVIEW_LIMIT, share_public_payload
 from sqlalchemy import func
 
 router = APIRouter(prefix="/api/share", tags=["app-share"])
@@ -53,9 +53,10 @@ async def get_share(
     msg_result = await db.execute(
         select(ShareMessage)
         .where(ShareMessage.share_id == share_id)
-        .order_by(ShareMessage.created_at)
+        .order_by(ShareMessage.id.desc())
+        .limit(SHARE_MESSAGE_PREVIEW_LIMIT)
     )
-    share_messages = msg_result.scalars().all()
+    share_messages = list(reversed(msg_result.scalars().all()))
 
     # Member count for room
     member_count = 0

--- a/backend/hub/routers/dashboard.py
+++ b/backend/hub/routers/dashboard.py
@@ -58,7 +58,13 @@ from hub.models import (
     ShareMessage,
     User,
 )
-from hub.share_payloads import frontend_url, room_entry_type, share_create_payload, share_public_payload
+from hub.share_payloads import (
+    SHARE_MESSAGE_PREVIEW_LIMIT,
+    frontend_url,
+    room_entry_type,
+    share_create_payload,
+    share_public_payload,
+)
 
 router = APIRouter(prefix="/dashboard", tags=["dashboard"])
 
@@ -697,9 +703,10 @@ async def create_share(
     msg_result = await db.execute(
         select(MessageRecord)
         .where(MessageRecord.id.in_(select(dedup_sub.c.min_id)))
-        .order_by(MessageRecord.id.asc())
+        .order_by(MessageRecord.id.desc())
+        .limit(SHARE_MESSAGE_PREVIEW_LIMIT)
     )
-    records = msg_result.scalars().all()
+    records = list(reversed(msg_result.scalars().all()))
 
     # Batch-resolve sender names
     sender_ids = set()
@@ -983,9 +990,10 @@ async def get_shared_room(
     msg_result = await db.execute(
         select(ShareMessage)
         .where(ShareMessage.share_id == share_id)
-        .order_by(ShareMessage.created_at.asc())
+        .order_by(ShareMessage.id.desc())
+        .limit(SHARE_MESSAGE_PREVIEW_LIMIT)
     )
-    share_messages = msg_result.scalars().all()
+    share_messages = list(reversed(msg_result.scalars().all()))
 
     messages = []
     for sm in share_messages:

--- a/backend/hub/share_payloads.py
+++ b/backend/hub/share_payloads.py
@@ -11,6 +11,8 @@ from hub.config import FRONTEND_BASE_URL
 from hub.enums import RoomVisibility
 from hub.models import Room
 
+SHARE_MESSAGE_PREVIEW_LIMIT = 30
+
 
 def frontend_url(path: str) -> str:
     return f"{FRONTEND_BASE_URL.rstrip('/')}{path}"

--- a/backend/tests/test_share.py
+++ b/backend/tests/test_share.py
@@ -1,6 +1,7 @@
 """Tests for Share Room Chat feature (snapshot freeze strategy)."""
 
 import base64
+import datetime
 import hashlib
 import json
 import time
@@ -16,7 +17,7 @@ from unittest.mock import AsyncMock
 
 from sqlalchemy import select
 
-from hub.models import Agent, Base, MessagePolicy
+from hub.models import Agent, Base, MessagePolicy, MessageRecord
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -317,6 +318,46 @@ class TestGetSharedRoom:
         sender_names = {m["sender_name"] for m in data["messages"]}
         assert "Alice" in sender_names
         assert "Bob" in sender_names
+
+    @pytest.mark.asyncio
+    async def test_share_preview_keeps_latest_30_messages(self, client, db_session):
+        ctx = await _setup_room_with_messages(client, db_session)
+
+        for i in range(35):
+            env = _build_envelope(
+                ctx["sk_a"],
+                ctx["key_a"],
+                ctx["agent_a"],
+                ctx["room_id"],
+                payload={"text": f"Bulk message {i}"},
+            )
+            db_session.add(
+                MessageRecord(
+                    hub_msg_id=f"hub_bulk_{i}_{uuid.uuid4().hex[:8]}",
+                    msg_id=env["msg_id"],
+                    sender_id=ctx["agent_a"],
+                    receiver_id=ctx["agent_b"],
+                    room_id=ctx["room_id"],
+                    envelope_json=json.dumps(env),
+                    ttl_sec=3600,
+                    created_at=datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=i),
+                )
+            )
+        await db_session.commit()
+
+        resp = await client.post(
+            f"/dashboard/rooms/{ctx['room_id']}/share",
+            headers=_auth_header(ctx["token_a"]),
+        )
+        assert resp.status_code == 201
+
+        resp = await client.get(f"/share/{resp.json()['share_id']}")
+        assert resp.status_code == 200
+        messages = resp.json()["messages"]
+
+        assert len(messages) == 30
+        assert messages[0]["text"] == "Bulk message 5"
+        assert messages[-1]["text"] == "Bulk message 34"
 
     @pytest.mark.asyncio
     async def test_empty_room_share(self, client, db_session):

--- a/frontend/src/components/share/SharedMessageBubble.tsx
+++ b/frontend/src/components/share/SharedMessageBubble.tsx
@@ -13,7 +13,11 @@ interface SharedMessageBubbleProps {
 export default function SharedMessageBubble({ message }: SharedMessageBubbleProps) {
   const textContent = message.payload?.text || message.payload?.body || message.payload?.message;
   const displayText = typeof textContent === "string" ? textContent : message.text;
-  const timestampLabel = new Date(message.created_at).toLocaleTimeString();
+  const timestampLabel = new Date(message.created_at).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  const senderInitial = (message.sender_name || message.sender_id || "?").trim().slice(0, 1).toUpperCase();
 
   if (message.type === "system") {
     return <SystemMessageNotice text={displayText || "System update"} timestamp={timestampLabel} />;
@@ -28,10 +32,13 @@ export default function SharedMessageBubble({ message }: SharedMessageBubbleProp
     : [];
 
   return (
-    <div className="mb-2 flex justify-start">
-      <div className="max-w-[70%] rounded-xl border border-glass-border bg-glass-bg px-3 py-2">
-        <div className="mb-0.5 flex items-center gap-1.5">
-          <span className="text-xs font-medium text-neon-purple">{message.sender_name}</span>
+    <div className="flex justify-start gap-3">
+      <div className="mt-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-white/10 bg-[linear-gradient(135deg,rgba(0,240,255,0.20),rgba(139,92,246,0.20))] text-xs font-semibold text-text-primary">
+        {senderInitial}
+      </div>
+      <div className="min-w-0 max-w-[min(720px,calc(100%-44px))] rounded-lg border border-white/10 bg-white/[0.055] px-3.5 py-3 shadow-lg shadow-black/10">
+        <div className="mb-1.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+          <span className="text-sm font-semibold text-text-primary">{message.sender_name}</span>
           <span className="font-mono text-[10px] text-text-secondary/50">{message.sender_id}</span>
         </div>
         {transferInfo ? (
@@ -46,12 +53,12 @@ export default function SharedMessageBubble({ message }: SharedMessageBubbleProp
             ))}
           </div>
         )}
-        <div className="mt-1 flex items-center gap-1.5">
+        <div className="mt-2 flex items-center gap-1.5">
           <span className="font-mono text-[10px] text-text-secondary/50">
-            {new Date(message.created_at).toLocaleTimeString()}
+            {timestampLabel}
           </span>
           {message.type !== "message" && (
-            <span className="rounded bg-glass-bg px-1 font-mono text-[10px] text-text-secondary/70">
+            <span className="rounded border border-white/10 bg-white/[0.06] px-1 font-mono text-[10px] text-text-secondary/70">
               {message.type}
             </span>
           )}

--- a/frontend/src/components/share/SharedRoomView.test.ts
+++ b/frontend/src/components/share/SharedRoomView.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { getSharedRoomOpenHref } from "./SharedRoomView";
+import type { SharedMessage } from "@/lib/types";
+import { getSharedRoomOpenHref, getSharedRoomPreviewMessages } from "./SharedRoomView";
 
 describe("getSharedRoomOpenHref", () => {
   it("opens public room shares directly without forcing login", () => {
@@ -19,5 +20,26 @@ describe("getSharedRoomOpenHref", () => {
       entry_type: "paid_room",
       continue_url: "/chats/messages/rm_paid",
     })).toBe("/login?next=%2Fchats%2Fmessages%2Frm_paid");
+  });
+});
+
+describe("getSharedRoomPreviewMessages", () => {
+  it("keeps only the latest 30 messages in chronological order", () => {
+    const messages = Array.from({ length: 35 }, (_, index) => ({
+      hub_msg_id: `hub_${index}`,
+      msg_id: `msg_${index}`,
+      sender_id: "ag_sender",
+      sender_name: "Sender",
+      type: "message",
+      text: `message ${index}`,
+      payload: {},
+      created_at: new Date(2026, 0, 1, 0, index).toISOString(),
+    })) satisfies SharedMessage[];
+
+    const preview = getSharedRoomPreviewMessages(messages);
+
+    expect(preview).toHaveLength(30);
+    expect(preview[0].text).toBe("message 5");
+    expect(preview.at(-1)?.text).toBe("message 34");
   });
 });

--- a/frontend/src/components/share/SharedRoomView.tsx
+++ b/frontend/src/components/share/SharedRoomView.tsx
@@ -2,23 +2,30 @@
 
 /**
  * [INPUT]: 依赖 api/getSharedRoom 拉取共享快照，依赖 next/link 提供站内返回入口，依赖 SharedMessageBubble 渲染消息内容
- * [OUTPUT]: 对外提供 SharedRoomView 组件，负责共享房间的加载、错误态与只读消息列表展示
+ * [OUTPUT]: 对外提供 SharedRoomView 组件，负责共享房间最新 30 条预览、加载、错误态与只读消息列表展示
  * [POS]: share 模块的页面主体，被 /share/[shareId] 路由消费，是外部访问共享快照的只读容器
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import Link from "next/link";
+import { ArrowUpRight, Clock, MessageSquareText, Users } from "lucide-react";
 import { api, ApiError } from "@/lib/api";
-import type { SharedRoomResponse } from "@/lib/types";
+import type { SharedMessage, SharedRoomResponse } from "@/lib/types";
 import SharedMessageBubble from "./SharedMessageBubble";
 import { useLanguage } from "@/lib/i18n";
 import { sharedRoomView } from "@/lib/i18n/translations/dashboard";
+
+const SHARED_ROOM_PREVIEW_LIMIT = 30;
 
 export function getSharedRoomOpenHref(data: Pick<SharedRoomResponse, "continue_url" | "entry_type">): string {
   const continuePath = data.continue_url.replace(/^https?:\/\/[^/]+/, "");
   if (data.entry_type === "public_room") return continuePath;
   return `/login?next=${encodeURIComponent(continuePath)}`;
+}
+
+export function getSharedRoomPreviewMessages(messages: SharedMessage[]): SharedMessage[] {
+  return messages.slice(-SHARED_ROOM_PREVIEW_LIMIT);
 }
 
 export default function SharedRoomView({ shareId }: { shareId: string }) {
@@ -27,6 +34,7 @@ export default function SharedRoomView({ shareId }: { shareId: string }) {
   const [data, setData] = useState<SharedRoomResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const messagesEndRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (!shareId) {
@@ -46,6 +54,18 @@ export default function SharedRoomView({ shareId }: { shareId: string }) {
       })
       .finally(() => setLoading(false));
   }, [shareId, t.invalidShare, t.loadFailed, t.missingShareId]);
+
+  const previewMessages = useMemo(() => (
+    data ? getSharedRoomPreviewMessages(data.messages) : []
+  ), [data]);
+
+  useEffect(() => {
+    if (!data || previewMessages.length === 0) return;
+    const frame = window.requestAnimationFrame(() => {
+      messagesEndRef.current?.scrollIntoView({ block: "end" });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [data, previewMessages.length]);
 
   if (loading) {
     return (
@@ -71,54 +91,89 @@ export default function SharedRoomView({ shareId }: { shareId: string }) {
   }
 
   const openHref = getSharedRoomOpenHref(data);
+  const sharedDate = new Date(data.shared_at).toLocaleDateString();
+  const messageCount = previewMessages.length;
 
   return (
-    <div className="mx-auto max-w-3xl px-4 pb-8 pt-20">
-      {/* Room header */}
-      <div className="mb-6 rounded-xl border border-glass-border bg-glass-bg p-4">
-        <h1 className="text-xl font-semibold text-text-primary">{data.room.name}</h1>
-        {data.room.description && (
-          <p className="mt-1 text-sm text-text-secondary">{data.room.description}</p>
-        )}
-        <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-text-secondary">
-          <span>{data.room.member_count} {data.room.member_count === 1 ? t.member : t.members}</span>
-          <span>{t.sharedBy} {data.shared_by}</span>
-          <span>{new Date(data.shared_at).toLocaleDateString()}</span>
-        </div>
-        <div className="mt-4 flex flex-wrap gap-3">
-          <Link
-            href={openHref}
-            className="rounded border border-neon-cyan/40 bg-neon-cyan/10 px-4 py-2 text-sm font-medium text-neon-cyan hover:bg-neon-cyan/20"
-          >
-            {t.openInBotcord}
-          </Link>
-        </div>
-        <p className="mt-3 text-xs leading-6 text-text-secondary">
+    <div className="min-h-screen bg-[linear-gradient(180deg,#0a0a0f_0%,#12121a_48%,#0a0a0f_100%)] px-4 pb-10 pt-16">
+      <div className="mx-auto flex max-w-4xl flex-col gap-5">
+        <header className="overflow-hidden rounded-lg border border-white/10 bg-white/[0.06] shadow-2xl shadow-black/30">
+          <div className="border-b border-white/10 bg-[linear-gradient(135deg,rgba(0,240,255,0.12),rgba(139,92,246,0.10)_48%,rgba(16,185,129,0.10))] px-5 py-5 sm:px-6">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div className="min-w-0">
+                <p className="mb-2 inline-flex items-center rounded-full border border-neon-cyan/30 bg-neon-cyan/10 px-2.5 py-1 text-xs font-medium text-neon-cyan">
+                  {t.previewBadge}
+                </p>
+                <h1 className="text-2xl font-semibold text-text-primary sm:text-3xl">{data.room.name}</h1>
+                {data.room.description && (
+                  <p className="mt-2 max-w-2xl text-sm leading-6 text-text-secondary">{data.room.description}</p>
+                )}
+              </div>
+              <Link
+                href={openHref}
+                className="inline-flex shrink-0 items-center justify-center gap-2 rounded-lg border border-neon-cyan/50 bg-neon-cyan px-4 py-2.5 text-sm font-semibold text-deep-black transition hover:bg-text-primary"
+              >
+                {t.openInBotcord}
+                <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+              </Link>
+            </div>
+          </div>
+
+          <div className="grid gap-3 px-5 py-4 text-sm text-text-secondary sm:grid-cols-3 sm:px-6">
+            <div className="flex items-center gap-2">
+              <Users className="h-4 w-4 text-neon-green" aria-hidden="true" />
+              <span>{data.room.member_count} {data.room.member_count === 1 ? t.member : t.members}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <MessageSquareText className="h-4 w-4 text-neon-purple" aria-hidden="true" />
+              <span>{t.latestMessages.replace("{count}", String(messageCount))}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Clock className="h-4 w-4 text-neon-cyan" aria-hidden="true" />
+              <span>{t.sharedBy} {data.shared_by} · {sharedDate}</span>
+            </div>
+          </div>
+        </header>
+
+        <main className="overflow-hidden rounded-lg border border-white/10 bg-deep-black-light/80 shadow-2xl shadow-black/20">
+          <div className="sticky top-0 z-10 border-b border-white/10 bg-deep-black-light/95 px-4 py-3 backdrop-blur sm:px-5">
+            <Link
+              href={openHref}
+              className="group flex items-center justify-between gap-3 rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2.5 text-sm text-text-secondary transition hover:border-neon-cyan/40 hover:bg-neon-cyan/10 hover:text-text-primary"
+            >
+              <span>{t.showMore}</span>
+              <span className="inline-flex items-center gap-1 font-medium text-neon-cyan">
+                {t.jumpToRoom}
+                <ArrowUpRight className="h-4 w-4 transition group-hover:translate-x-0.5 group-hover:-translate-y-0.5" aria-hidden="true" />
+              </span>
+            </Link>
+          </div>
+
+          <div className="px-3 py-4 sm:px-5 sm:py-5">
+            {previewMessages.length === 0 ? (
+              <p className="py-12 text-center text-sm text-text-secondary">{t.noMessages}</p>
+            ) : (
+              <div className="space-y-3">
+                {previewMessages.map((msg) => (
+                  <SharedMessageBubble key={msg.hub_msg_id} message={msg} />
+                ))}
+                <div ref={messagesEndRef} aria-hidden="true" />
+              </div>
+            )}
+          </div>
+        </main>
+
+        <p className="text-center text-xs text-text-secondary">
           {data.entry_type === "paid_room"
             ? t.paidHint
             : data.entry_type === "private_room"
               ? t.privateHint
-              : t.publicHint}
+              : t.publicHint}{" "}
+          {t.footerPrefix}{" "}
+          <Link href="/" className="text-neon-cyan hover:underline">
+            {t.footerBrand}
+          </Link>
         </p>
-      </div>
-
-      {/* Messages */}
-      <div className="space-y-0">
-        {data.messages.length === 0 ? (
-          <p className="py-8 text-center text-sm text-text-secondary">{t.noMessages}</p>
-        ) : (
-          data.messages.map((msg) => (
-            <SharedMessageBubble key={msg.hub_msg_id} message={msg} />
-          ))
-        )}
-      </div>
-
-      {/* Footer */}
-      <div className="mt-8 border-t border-glass-border pt-4 text-center text-xs text-text-secondary">
-        {t.footerPrefix}{" "}
-        <Link href="/" className="text-neon-cyan hover:underline">
-          {t.footerBrand}
-        </Link>
       </div>
     </div>
   );

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -2650,7 +2650,11 @@ export const sharedRoomView: TranslationMap<{
   loadFailed: string
   loading: string
   goHome: string
+  previewBadge: string
   sharedBy: string
+  latestMessages: string
+  showMore: string
+  jumpToRoom: string
   openInBotcord: string
   copyInvitePrompt: string
   promptCopied: string
@@ -2670,7 +2674,11 @@ export const sharedRoomView: TranslationMap<{
     loadFailed: 'Failed to load shared conversation.',
     loading: 'Loading shared conversation...',
     goHome: 'Go Home',
+    previewBadge: 'Latest room preview',
     sharedBy: 'Shared by',
+    latestMessages: '{count} latest messages',
+    showMore: 'Show more messages',
+    jumpToRoom: 'Open room',
     openInBotcord: 'Open in BotCord',
     copyInvitePrompt: 'Copy invite prompt',
     promptCopied: 'Prompt copied',
@@ -2690,7 +2698,11 @@ export const sharedRoomView: TranslationMap<{
     loadFailed: '加载分享对话失败。',
     loading: '正在加载分享对话...',
     goHome: '返回首页',
+    previewBadge: '最新房间预览',
     sharedBy: '分享者',
+    latestMessages: '最新 {count} 条消息',
+    showMore: '显示更多消息',
+    jumpToRoom: '进入房间',
     openInBotcord: '在 BotCord 中打开',
     copyInvitePrompt: '复制邀请 Prompt',
     promptCopied: 'Prompt 已复制',


### PR DESCRIPTION
## Summary
- limit share snapshots and public share reads to the latest 30 messages
- auto-scroll shared room pages to the newest message and route "show more" to the BotCord room
- refresh the shared room preview UI and add focused coverage

## Tests
- cd backend && uv run pytest tests/test_share.py -q
- cd backend && uv run pytest tests/test_app/test_app_dashboard_rooms.py -q -k share
- cd backend && uv run pytest tests/test_app/test_app_humans.py -q -k share
- cd frontend && npm test -- SharedRoomView.test.ts
- cd frontend && NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build