### PR TITLE
fix: settle deepseek owner chat streams

### DIFF
--- a/frontend/src/store/useOwnerChatStore.test.ts
+++ b/frontend/src/store/useOwnerChatStore.test.ts
@@ -186,3 +186,70 @@ describe("useOwnerChatStore empty message handling", () => {
     expect(useOwnerChatStore.getState().messages).toHaveLength(1);
   });
 });
+
+describe("useOwnerChatStore stream terminal handling", () => {
+  beforeEach(() => {
+    mocks.getRoomMessages.mockReset();
+    useOwnerChatStore.getState().reset();
+    useDashboardChatStore.setState({
+      ownedAgentRooms: [makeOwnedAgentRoom()],
+      optimisticOwnerChatRooms: {},
+    });
+    useOwnerChatStore.getState().setRoom("rm_oc_real", "Owned bot");
+  });
+
+  it("settles a streaming placeholder when a terminal block arrives before the final message", () => {
+    useOwnerChatStore.getState().appendStreamBlock({
+      trace_id: "msg_trace",
+      seq: 1,
+      created_at: "2026-05-19T09:00:00.000Z",
+      block: { kind: "assistant", payload: { text: "done" } },
+    });
+    useOwnerChatStore.getState().appendStreamBlock({
+      trace_id: "msg_trace",
+      seq: 2,
+      created_at: "2026-05-19T09:00:01.000Z",
+      block: { kind: "other", payload: { terminal: true, event: "turn.completed" } },
+    });
+
+    expect(useOwnerChatStore.getState().messages).toMatchObject([
+      {
+        traceId: "msg_trace",
+        text: "done",
+        status: "delivered",
+        hubMsgId: null,
+        streamBlocks: [{ block: { kind: "other" } }],
+      },
+    ]);
+    expect(useOwnerChatStore.getState().activeTraceId).toBeNull();
+  });
+
+  it("upgrades a terminal-settled placeholder when the final traced message arrives", () => {
+    useOwnerChatStore.getState().appendStreamBlock({
+      trace_id: "msg_trace",
+      seq: 1,
+      created_at: "2026-05-19T09:00:00.000Z",
+      block: { kind: "assistant", payload: { text: "streamed answer" } },
+    });
+    useOwnerChatStore.getState().appendStreamBlock({
+      trace_id: "msg_trace",
+      seq: 2,
+      created_at: "2026-05-19T09:00:01.000Z",
+      block: { kind: "other", payload: { terminal: true, event: "turn.completed" } },
+    });
+
+    useOwnerChatStore.getState().finalizeStream("msg_trace", {
+      hubMsgId: "msg_final",
+      text: "answer",
+      senderName: "Owned bot",
+      createdAt: "2026-05-19T09:00:02.000Z",
+    });
+
+    expect(useOwnerChatStore.getState().messages).toHaveLength(1);
+    expect(useOwnerChatStore.getState().messages[0]).toMatchObject({
+      hubMsgId: "msg_final",
+      text: "streamed answer",
+      status: "delivered",
+    });
+  });
+});

--- a/frontend/src/store/useOwnerChatStore.ts
+++ b/frontend/src/store/useOwnerChatStore.ts
@@ -91,6 +91,15 @@ function hasVisibleOwnerChatContent(msg: OwnerChatMessage): boolean {
   return msg.streamBlocks.length > 0;
 }
 
+function isTerminalStreamBlock(entry: StreamBlockEntry): boolean {
+  const payload = entry.block.payload;
+  return entry.block.kind === "other" && payload?.terminal === true;
+}
+
+function visibleExecutionBlocks(blocks: StreamBlockEntry[]): StreamBlockEntry[] {
+  return blocks.filter((b) => b.block.kind !== "assistant" && b.block.kind !== "assistant_text");
+}
+
 /** In-flight guard + request token to prevent stale loadInitial responses. */
 let loadInFlight = false;
 let loadRequestId = 0;
@@ -423,10 +432,11 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
   appendStreamBlock: (entry) => {
     set((state) => {
       const traceId = entry.trace_id;
+      const terminal = isTerminalStreamBlock(entry);
 
       // Find existing streaming message for this trace
       const idx = state.messages.findIndex(
-        (m) => m.traceId === traceId && m.status === "streaming"
+        (m) => m.traceId === traceId && (m.status === "streaming" || (m.sender === "agent" && !m.hubMsgId))
       );
 
       if (idx === -1) {
@@ -436,8 +446,8 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
           hubMsgId: null,
           sender: "agent",
           text: extractAssistantText([entry]),
-          streamBlocks: [entry],
-          status: "streaming",
+          streamBlocks: terminal ? visibleExecutionBlocks([entry]) : [entry],
+          status: terminal ? "delivered" : "streaming",
           createdAt: entry.created_at,
           senderName: state.agentName,
           type: "message",
@@ -445,7 +455,7 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
         };
         return {
           messages: [...state.messages, streamingMsg],
-          activeTraceId: traceId,
+          activeTraceId: terminal ? null : traceId,
           agentTyping: false,
         };
       }
@@ -456,10 +466,13 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
       if (existing.streamBlocks.some((b) => b.seq === entry.seq)) return state;
 
       const updatedBlocks = [...existing.streamBlocks, entry].sort((a, b) => a.seq - b.seq);
+      const updatedText = extractAssistantText(updatedBlocks);
+      const finalized = terminal || existing.status === "delivered";
       const updatedMsg: OwnerChatMessage = {
         ...existing,
-        streamBlocks: updatedBlocks,
-        text: extractAssistantText(updatedBlocks),
+        streamBlocks: finalized ? visibleExecutionBlocks(updatedBlocks) : updatedBlocks,
+        text: updatedText || existing.text,
+        status: terminal ? "delivered" : existing.status,
       };
 
       const newMessages = [...state.messages];
@@ -467,7 +480,7 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
 
       return {
         messages: newMessages,
-        activeTraceId: traceId,
+        activeTraceId: terminal ? null : traceId,
         agentTyping: false,
       };
     });
@@ -477,7 +490,7 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
   finalizeStream: (traceId, finalData) => {
     set((state) => {
       const idx = state.messages.findIndex(
-        (m) => m.traceId === traceId && m.status === "streaming"
+        (m) => m.traceId === traceId && (m.status === "streaming" || m.sender === "agent")
       );
 
       if (idx === -1) {
@@ -516,7 +529,7 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
       // Preserve the streamed assistant text if it is richer than the final
       // `message` text (e.g. Codex streams long intermediate reasoning/answer
       // segments but only sends a short summary via botcord_send).
-      const streamedText = extractAssistantText(existing.streamBlocks);
+      const streamedText = extractAssistantText(existing.streamBlocks) || existing.text;
       const finalText = finalData.text || "";
       let mergedText: string;
       if (streamedText.length > finalText.length) {
@@ -527,9 +540,7 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
       } else {
         mergedText = finalText;
       }
-      const visibleStreamBlocks = existing.streamBlocks.filter(
-        (b) => b.block.kind !== "assistant" && b.block.kind !== "assistant_text",
-      );
+      const visibleStreamBlocks = visibleExecutionBlocks(existing.streamBlocks);
       if (!mergedText.trim() && (finalData.attachments?.length ?? 0) === 0 && visibleStreamBlocks.length === 0) {
         const newMessages = state.messages.filter((_, i) => i !== idx);
         return {
@@ -589,7 +600,7 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
             text: partialText,
             status: "delivered" as const,
             // Keep streamBlocks for display (execution blocks, etc.)
-            streamBlocks: m.streamBlocks.filter((b) => b.block.kind !== "assistant" && b.block.kind !== "assistant_text"),
+            streamBlocks: visibleExecutionBlocks(m.streamBlocks),
           };
         }
         return m;

--- a/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
+++ b/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
@@ -868,6 +868,47 @@ describe("createBotCordChannel — streamBlock()", () => {
     }
   });
 
+  it("marks DeepSeek terminal events for owner-chat stream cleanup", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    try {
+      const client = makeClient({
+        getHubUrl: vi.fn().mockReturnValue("https://hub.example.com"),
+      });
+      const channel = createBotCordChannel({
+        id: "botcord-main",
+        accountId: "ag_self",
+        agentId: "ag_self",
+        client,
+        hubBaseUrl: "https://hub.example.com",
+      });
+      await channel.streamBlock!({
+        traceId: "m_trace",
+        accountId: "ag_self",
+        conversationId: "rm_oc_1",
+        block: {
+          kind: "other",
+          seq: 6,
+          raw: {
+            event: "turn.finished",
+            payload: { thread_id: "thr_1", turn_id: "turn_1" },
+          },
+        },
+        log: silentLog,
+      });
+      const [, init] = fetchSpy.mock.calls[0];
+      const body = JSON.parse(init.body as string);
+      expect(body.block).toMatchObject({
+        kind: "other",
+        seq: 6,
+        payload: { terminal: true, event: "turn.finished" },
+      });
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
   it("normalizes a thinking block with phase/label/source payload", async () => {
     const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
     const realFetch = globalThis.fetch;

--- a/packages/daemon/src/gateway/__tests__/deepseek-tui-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/deepseek-tui-adapter.test.ts
@@ -150,6 +150,25 @@ describe("DeepseekTuiAdapter", () => {
     }
   });
 
+  it("treats DeepSeek embedded terminal events as turn completion", async () => {
+    const server = await startMockDeepseekServer({
+      events: [
+        { event: "status", data: { event: "turn.started", thread_id: "thr_test", turn_id: "turn_test" } },
+        { event: "message.delta", data: { thread_id: "thr_test", turn_id: "turn_test", content: "done" } },
+        { event: "status", data: { event: "turn.finished", thread_id: "thr_test", turn_id: "turn_test" } },
+      ],
+    });
+    try {
+      const { result, blocks, status } = runAdapter(server.baseUrl, server.token);
+      const res = await result;
+      expect(res).toEqual({ text: "done", newSessionId: server.threadId });
+      expect(blocks).toContain("assistant_text");
+      expect(status.at(-1)).toEqual({ phase: "stopped", label: undefined });
+    } finally {
+      await server.close();
+    }
+  });
+
   it("reuses an existing DeepSeek thread id and patches per-turn system context", async () => {
     const server = await startMockDeepseekServer({ threadId: "thr_existing" });
     try {

--- a/packages/daemon/src/gateway/channels/botcord.ts
+++ b/packages/daemon/src/gateway/channels/botcord.ts
@@ -1053,12 +1053,32 @@ function normalizeBlockForHub(
   }
 
   // "other" — e.g. Claude Code `type:"result"` end-of-turn summary.
+  if (isTerminalRuntimeBlock(raw)) {
+    payload.terminal = true;
+    payload.details = formatBlockDetails(raw);
+    const event = typeof raw?.event === "string" ? raw.event : undefined;
+    const embedded = typeof raw?.payload?.event === "string" ? raw.payload.event : undefined;
+    if (event || embedded) payload.event = event ?? embedded;
+    return { kind: "other", seq, payload };
+  }
   if (raw?.type === "result") {
     if (typeof raw.result === "string") payload.text = raw.result;
     if (typeof raw.subtype === "string") payload.subtype = raw.subtype;
     if (typeof raw.total_cost_usd === "number") payload.total_cost_usd = raw.total_cost_usd;
   }
   return { kind: "other", seq, payload };
+}
+
+function isTerminalRuntimeBlock(raw: any): boolean {
+  const event = typeof raw?.event === "string" ? raw.event : undefined;
+  const embedded = typeof raw?.payload?.event === "string" ? raw.payload.event : undefined;
+  const terminal = event ?? embedded;
+  return (
+    terminal === "turn.completed" ||
+    terminal === "turn.finished" ||
+    terminal === "turn.done" ||
+    terminal === "done"
+  );
 }
 
 function formatBlockDetails(raw: unknown): string {

--- a/packages/daemon/src/gateway/runtimes/deepseek-tui.ts
+++ b/packages/daemon/src/gateway/runtimes/deepseek-tui.ts
@@ -379,12 +379,12 @@ export class DeepseekTuiAdapter implements RuntimeAdapter {
         } else if (eventName === "item.delta" && payload?.payload?.kind === "agent_message") {
           append(stringField(payload.payload, "delta") ?? "");
         }
-        if (eventName === "turn.started") {
+        if (eventName === "turn.started" || embeddedDeepseekEvent(payload) === "turn.started") {
           opts.onStatus?.({ kind: "thinking", phase: "started", label: "Thinking" });
         } else if (eventName === "tool.started" || isToolStarted(payload)) {
           const label = stringField(payload, "name") ?? stringField(payload?.payload?.tool, "name") ?? "tool";
           opts.onStatus?.({ kind: "thinking", phase: "updated", label });
-        } else if (eventName === "turn.completed" || eventName === "done") {
+        } else if (isDeepseekTerminalEvent(eventName, payload)) {
           opts.onStatus?.({ kind: "thinking", phase: "stopped" });
           return true;
         }
@@ -451,13 +451,31 @@ function normalizeDeepseekEvent(eventName: string, payload: any, seq: number): S
   if (eventName === "item.delta" && payload?.payload?.kind === "agent_message") {
     return { raw: { event: eventName, payload }, kind: "assistant_text", seq };
   }
-  if (eventName === "turn.started" || eventName === "status") {
+  if (eventName === "turn.started" || eventName === "status" || embeddedDeepseekEvent(payload) === "turn.started") {
     return { raw: { event: eventName, payload }, kind: "system", seq };
   }
-  if (eventName === "error" || eventName === "turn.completed" || eventName === "done") {
+  if (eventName === "error" || isDeepseekTerminalEvent(eventName, payload)) {
     return { raw: { event: eventName, payload }, kind: "other", seq };
   }
   return null;
+}
+
+function embeddedDeepseekEvent(payload: any): string | undefined {
+  return stringField(payload, "event") ?? stringField(payload?.payload, "event");
+}
+
+function isDeepseekTerminalEvent(eventName: string, payload: any): boolean {
+  const embedded = embeddedDeepseekEvent(payload);
+  return (
+    eventName === "turn.completed" ||
+    eventName === "turn.finished" ||
+    eventName === "turn.done" ||
+    eventName === "done" ||
+    embedded === "turn.completed" ||
+    embedded === "turn.finished" ||
+    embedded === "turn.done" ||
+    embedded === "done"
+  );
 }
 
 function isToolStarted(payload: any): boolean {
@@ -488,7 +506,7 @@ function extractDeepseekError(eventName: string, payload: any): string | undefin
       stringField(payload?.payload, "error")
     );
   }
-  if (eventName === "turn.completed") {
+  if (isDeepseekTerminalEvent(eventName, payload)) {
     const turn = payload?.payload?.turn ?? payload?.turn;
     const status = stringField(turn, "status");
     const err = stringField(turn, "error");


### PR DESCRIPTION
## Summary
- recognize DeepSeek embedded terminal events as turn completion
- mark terminal stream blocks for owner-chat cleanup
- settle streaming owner-chat placeholders before the final traced message arrives

## Tests
- cd packages/daemon && npm run test -- --run src/gateway/__tests__/deepseek-tui-adapter.test.ts src/gateway/__tests__/botcord-channel.test.ts
- cd frontend && npm run test -- useOwnerChatStore.test.ts