### PR TITLE
fix: harden claude-code auth failures

### DIFF
--- a/backend/hub/routers/daemon_control.py
+++ b/backend/hub/routers/daemon_control.py
@@ -1506,6 +1506,11 @@ def _parse_runtime_snapshot_params(
         endpoints = entry.get("endpoints")
         if isinstance(endpoints, list) and len(endpoints) > 32:
             entry["endpoints"] = endpoints[:32]
+        health = entry.get("health")
+        if isinstance(health, dict):
+            circuit_breakers = health.get("circuitBreakers")
+            if isinstance(circuit_breakers, list) and len(circuit_breakers) > 32:
+                health["circuitBreakers"] = circuit_breakers[:32]
     if not isinstance(probed_at, (int, float)) or isinstance(probed_at, bool):
         return None
     if probed_at <= 0:

--- a/backend/tests/test_app/test_daemon_control.py
+++ b/backend/tests/test_app/test_daemon_control.py
@@ -1020,6 +1020,71 @@ async def test_runtime_snapshot_oversized_array_rejected(
 
 
 @pytest.mark.asyncio
+async def test_runtime_snapshot_caps_nested_runtime_health(
+    client: AsyncClient, seed_user, db_session: AsyncSession
+):
+    """Nested runtime health arrays are capped before persistence."""
+    from sqlalchemy import select
+
+    from hub.routers.daemon_control import _DaemonConn, _handle_daemon_event
+
+    bundle = await _provision_instance_via_device_code(client, seed_user)
+    instance_id = bundle["daemon_instance_id"]
+
+    fake_ws = _FakeWS()
+    conn = _DaemonConn(
+        ws=fake_ws,  # type: ignore[arg-type]
+        user_id=str(seed_user["user_id"]),
+        daemon_instance_id=instance_id,
+        pending_acks={},
+    )
+
+    breakers = [
+        {
+            "key": f"claude-code:botcord:ag_1:rm_oc_{i}:",
+            "channel": "botcord",
+            "accountId": "ag_1",
+            "conversationId": f"rm_oc_{i}",
+            "failures": 3,
+            "openedAt": 1000,
+            "blockedUntil": 2000,
+            "lastFailureAt": 1500,
+            "lastError": "Failed to authenticate",
+        }
+        for i in range(40)
+    ]
+    await _handle_daemon_event(
+        conn,
+        {
+            "id": "frm_rs_health",
+            "type": "runtime_snapshot",
+            "params": {
+                "runtimes": [
+                    {
+                        "id": "claude-code",
+                        "available": True,
+                        "health": {"circuitBreakers": breakers},
+                    }
+                ],
+                "probedAt": _probed_now_ms(),
+            },
+        },
+    )
+    ack = json.loads(fake_ws.sent[-1])
+    assert ack == {"id": "frm_rs_health", "ok": True}
+
+    await db_session.commit()
+    res = await db_session.execute(
+        select(DaemonInstance).where(DaemonInstance.id == instance_id)
+    )
+    inst = res.scalar_one()
+    stored = inst.runtimes_json
+    if isinstance(stored, str):
+        stored = json.loads(stored)
+    assert len(stored[0]["health"]["circuitBreakers"]) == 32
+
+
+@pytest.mark.asyncio
 async def test_list_instances_without_runtimes_returns_none(
     client: AsyncClient, seed_user
 ):

--- a/frontend/src/components/daemon/DaemonsSettingsPage.tsx
+++ b/frontend/src/components/daemon/DaemonsSettingsPage.tsx
@@ -165,6 +165,13 @@ function RuntimesBlock({
   onCollectDiagnostics: () => void;
 }) {
   const runtimes = daemon.runtimes;
+  const circuitBreakers =
+    runtimes?.flatMap((runtime) =>
+      (runtime.health?.circuitBreakers ?? []).map((breaker) => ({
+        runtimeId: runtime.id,
+        ...breaker,
+      })),
+    ) ?? [];
   const disabled = refreshing || daemon.status === "revoked";
   const diagnosticsDisabled =
     collectingDiagnostics || daemon.status !== "online";
@@ -211,6 +218,24 @@ function RuntimesBlock({
           ))}
         </div>
       )}
+
+      {circuitBreakers.length > 0 ? (
+        <div className="rounded-md border border-yellow-400/20 bg-yellow-400/10 px-2 py-1 text-[11px] text-yellow-200">
+          <div className="flex items-center gap-1 font-medium">
+            <AlertTriangle className="h-3 w-3" />
+            Runtime dispatch paused
+          </div>
+          <div className="mt-0.5 text-yellow-100/80">
+            {circuitBreakers.map((breaker) => {
+              const until = new Date(breaker.blockedUntil);
+              const untilText = Number.isNaN(until.getTime())
+                ? "temporarily"
+                : `until ${until.toLocaleTimeString()}`;
+              return `${breaker.runtimeId} in ${breaker.conversationId}: ${breaker.lastError || "authentication failed"} (${breaker.failures} failures, ${untilText})`;
+            }).join("; ")}
+          </div>
+        </div>
+      ) : null}
 
       {errorMsg ? (
         <span className="rounded-md border border-red-400/20 bg-red-400/10 px-2 py-1 text-[11px] text-red-300">

--- a/frontend/src/store/useDaemonStore.ts
+++ b/frontend/src/store/useDaemonStore.ts
@@ -55,10 +55,28 @@ export interface DaemonRuntime {
   version?: string;
   path?: string;
   error?: string;
+  health?: DaemonRuntimeHealth;
   /** OpenClaw-style runtimes carry per-gateway endpoint probe results. */
   endpoints?: DaemonRuntimeEndpoint[];
   /** Hermes runtime carries the per-device profile listing (1 BotCord agent : 1 profile). */
   profiles?: DaemonHermesProfile[];
+}
+
+export interface DaemonRuntimeHealth {
+  circuitBreakers?: DaemonRuntimeCircuitBreaker[];
+}
+
+export interface DaemonRuntimeCircuitBreaker {
+  key: string;
+  channel: string;
+  accountId: string;
+  conversationId: string;
+  threadId?: string | null;
+  failures: number;
+  openedAt: number;
+  blockedUntil: number;
+  lastFailureAt: number;
+  lastError: string;
 }
 
 export interface DaemonInstance {
@@ -311,17 +329,59 @@ function normalizeRuntimes(raw: unknown): DaemonRuntime[] | null | undefined {
           })
           .filter(Boolean) as DaemonHermesProfile[])
       : undefined;
+    const health =
+      r.health && typeof r.health === "object"
+        ? normalizeRuntimeHealth(r.health as Record<string, unknown>)
+        : undefined;
     out.push({
       id,
       available: r.available === true,
       version: typeof r.version === "string" ? r.version : undefined,
       path: typeof r.path === "string" ? r.path : undefined,
       error: typeof r.error === "string" ? r.error : undefined,
+      health,
       endpoints,
       profiles,
     });
   }
   return out;
+}
+
+function normalizeRuntimeHealth(raw: Record<string, unknown>): DaemonRuntimeHealth | undefined {
+  const circuitBreakers = Array.isArray(raw.circuitBreakers)
+    ? ((raw.circuitBreakers as unknown[])
+        .map((entry) => {
+          if (!entry || typeof entry !== "object") return null;
+          const b = entry as Record<string, unknown>;
+          const key = typeof b.key === "string" ? b.key : null;
+          const channel = typeof b.channel === "string" ? b.channel : null;
+          const accountId = typeof b.accountId === "string" ? b.accountId : null;
+          const conversationId =
+            typeof b.conversationId === "string" ? b.conversationId : null;
+          if (!key || !channel || !accountId || !conversationId) return null;
+          return {
+            key,
+            channel,
+            accountId,
+            conversationId,
+            threadId:
+              typeof b.threadId === "string"
+                ? b.threadId
+                : b.threadId === null
+                  ? null
+                  : undefined,
+            failures: typeof b.failures === "number" ? b.failures : 0,
+            openedAt: typeof b.openedAt === "number" ? b.openedAt : 0,
+            blockedUntil: typeof b.blockedUntil === "number" ? b.blockedUntil : 0,
+            lastFailureAt:
+              typeof b.lastFailureAt === "number" ? b.lastFailureAt : 0,
+            lastError: typeof b.lastError === "string" ? b.lastError : "",
+          } as DaemonRuntimeCircuitBreaker;
+        })
+        .filter(Boolean) as DaemonRuntimeCircuitBreaker[])
+    : undefined;
+  if (!circuitBreakers?.length) return undefined;
+  return { circuitBreakers };
 }
 
 function normalizeDaemon(raw: Record<string, unknown>): DaemonInstance {

--- a/packages/daemon/src/__tests__/doctor.test.ts
+++ b/packages/daemon/src/__tests__/doctor.test.ts
@@ -98,6 +98,18 @@ describe("probeChannel", () => {
     expect(result.hubMessage).toContain("503");
   });
 
+  it("treats HTTP 404 as reachable because the probe only needs the Hub host", async () => {
+    const credsPath = "/creds/ag_123.json";
+    const result = await probeChannel(ch, {
+      credentialsPath: () => credsPath,
+      fileReader: fileReader({ [credsPath]: okCreds }),
+      fetcher: fetcher({ ok: false, status: 404 }),
+      timeoutMs: 1000,
+    });
+    expect(result.hubOk).toBe(true);
+    expect(result.hubMessage).toContain("404");
+  });
+
   it("probeChannels returns an entry per input channel", async () => {
     const credsPath = "/creds/ag_123.json";
     const results = await probeChannels({
@@ -198,6 +210,28 @@ describe("renderDoctor", () => {
     expect(out).toContain("Channels:");
     expect(out).toContain("botcord-main");
     expect(out).toContain("✓");
+  });
+
+  it("renders optional runtime auth check results", () => {
+    const out = renderDoctor({
+      runtimes: [
+        {
+          id: "claude-code",
+          displayName: "Claude Code",
+          binary: "claude",
+          supportsRun: true,
+          result: { available: true, version: "1.0.0", path: "/usr/bin/claude" },
+          auth: {
+            checked: true,
+            ok: false,
+            message: "Failed to authenticate. API Error: 403 Request not allowed",
+          },
+        },
+      ],
+      channels: [],
+    });
+    expect(out).toContain("auth failed");
+    expect(out).toContain("Failed to authenticate");
   });
 
   it("shows 'No channels configured.' when the channel list is empty", () => {

--- a/packages/daemon/src/__tests__/runtime-discovery.test.ts
+++ b/packages/daemon/src/__tests__/runtime-discovery.test.ts
@@ -28,6 +28,7 @@ vi.mock("../adapters/runtimes.js", async () => {
 });
 
 const {
+  attachRuntimeHealth,
   collectRuntimeSnapshot,
   collectRuntimeSnapshotAsync,
   clearRuntimeProbeCache,
@@ -365,5 +366,94 @@ describe("pushRuntimeSnapshot (first-connect push)", () => {
     const ok = pushRuntimeSnapshot({ send });
     expect(ok).toBe(false);
     expect(send).toHaveBeenCalledOnce();
+  });
+
+  it("attaches live runtime circuit breaker health to the pushed runtime entry", () => {
+    setRuntimes([
+      {
+        id: "claude-code",
+        displayName: "Claude Code",
+        binary: "claude",
+        supportsRun: true,
+        result: { available: true },
+      },
+    ]);
+    const send = vi.fn(() => true);
+    const ok = pushRuntimeSnapshot(
+      { send },
+      {
+        channels: {},
+        turns: {},
+        runtimeCircuitBreakers: {
+          "claude-code:botcord:ag_1:rm_oc_a:": {
+            key: "claude-code:botcord:ag_1:rm_oc_a:",
+            runtime: "claude-code",
+            channel: "botcord",
+            accountId: "ag_1",
+            conversationId: "rm_oc_a",
+            threadId: null,
+            failures: 3,
+            openedAt: 1000,
+            blockedUntil: 2000,
+            lastFailureAt: 1500,
+            lastError: "Failed to authenticate",
+          },
+        },
+      },
+    );
+    expect(ok).toBe(true);
+    const frame = send.mock.calls[0]![0] as {
+      params: { runtimes: Array<{ id: string; health?: { circuitBreakers?: unknown[] } }> };
+    };
+    expect(frame.params.runtimes[0].health?.circuitBreakers).toEqual([
+      expect.objectContaining({
+        conversationId: "rm_oc_a",
+        failures: 3,
+        lastError: "Failed to authenticate",
+      }),
+    ]);
+  });
+});
+
+describe("attachRuntimeHealth", () => {
+  it("groups live circuit breakers onto matching runtime entries", () => {
+    const snap = {
+      runtimes: [
+        { id: "claude-code", available: true },
+        { id: "codex", available: true },
+      ],
+      probedAt: 1000,
+    };
+    const out = attachRuntimeHealth(snap, {
+      channels: {},
+      turns: {},
+      runtimeCircuitBreakers: {
+        "claude-code:botcord:ag_1:rm_oc_a:": {
+          key: "claude-code:botcord:ag_1:rm_oc_a:",
+          runtime: "claude-code",
+          channel: "botcord",
+          accountId: "ag_1",
+          conversationId: "rm_oc_a",
+          threadId: null,
+          failures: 3,
+          openedAt: 1000,
+          blockedUntil: 2000,
+          lastFailureAt: 1500,
+          lastError: "Failed to authenticate",
+        },
+      },
+    });
+    expect(out.runtimes[0]).toMatchObject({
+      id: "claude-code",
+      health: {
+        circuitBreakers: [
+          {
+            conversationId: "rm_oc_a",
+            lastError: "Failed to authenticate",
+          },
+        ],
+      },
+    });
+    expect(out.runtimes[1]).toEqual({ id: "codex", available: true });
   });
 });

--- a/packages/daemon/src/__tests__/status-render.test.ts
+++ b/packages/daemon/src/__tests__/status-render.test.ts
@@ -8,6 +8,7 @@ function snapshot(
   return {
     channels: overrides.channels ?? {},
     turns: overrides.turns ?? {},
+    runtimeCircuitBreakers: overrides.runtimeCircuitBreakers,
   };
 }
 
@@ -69,6 +70,7 @@ describe("renderStatus", () => {
     expect(out).toContain("rm_oc_abc");
     expect(out).toContain("claude-code");
     expect(out).toMatch(/12s ago/);
+    expect(out).toContain("Runtime circuit breakers:");
     expect(out).not.toContain("⚠ stale");
   });
 
@@ -133,5 +135,37 @@ describe("renderStatus", () => {
     );
     expect(out).toContain("Channels:");
     expect(out).toContain("(none)");
+  });
+
+  it("renders open runtime auth circuit breakers", () => {
+    const now = 1_700_000_000_000;
+    const out = renderStatus(
+      {
+        pid: 1,
+        alive: true,
+        snapshot: snapshot({
+          runtimeCircuitBreakers: {
+            "claude-code:botcord:ag_1:rm_oc_a:": {
+              key: "claude-code:botcord:ag_1:rm_oc_a:",
+              runtime: "claude-code",
+              channel: "botcord",
+              accountId: "ag_1",
+              conversationId: "rm_oc_a",
+              failures: 3,
+              openedAt: now - 1000,
+              blockedUntil: now + 60_000,
+              lastFailureAt: now - 1000,
+              lastError: "Failed to authenticate",
+            },
+          },
+        }),
+        snapshotAgeMs: 100,
+      },
+      now,
+    );
+    expect(out).toContain("Runtime circuit breakers:");
+    expect(out).toContain("claude-code");
+    expect(out).toContain("rm_oc_a");
+    expect(out).toContain("Failed to authenticate");
   });
 });

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -28,6 +28,7 @@ import { toGatewayConfig } from "./daemon-config-map.js";
 import { log as daemonLog } from "./log.js";
 import {
   adoptDiscoveredOpenclawAgents,
+  attachRuntimeHealth,
   collectRuntimeSnapshot,
   createProvisioner,
   type OnAgentInstalledHook,
@@ -222,8 +223,12 @@ export interface RuntimeSnapshotSink {
  * failure is non-fatal (the Hub will re-query via `list_runtimes` on demand
  * or wait for the next daemon restart). Exported for unit tests.
  */
-export function pushRuntimeSnapshot(sink: RuntimeSnapshotSink): boolean {
-  const snap = collectRuntimeSnapshot();
+export function pushRuntimeSnapshot(
+  sink: RuntimeSnapshotSink,
+  liveSnapshot?: GatewayRuntimeSnapshot,
+): boolean {
+  const base = collectRuntimeSnapshot();
+  const snap = liveSnapshot ? attachRuntimeHealth(base, liveSnapshot) : base;
   const ok = sink.send({
     id: `rt_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
     type: CONTROL_FRAME_TYPES.RUNTIME_SNAPSHOT,
@@ -502,7 +507,15 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
     }
   };
 
-  const gateway = new Gateway({
+  let controlChannel: ControlChannel | null = null;
+  let gateway: Gateway;
+  const pushLiveRuntimeSnapshot = (): void => {
+    if (!controlChannel) return;
+    const pushed = pushRuntimeSnapshot(controlChannel, gateway.snapshot());
+    logger.info("control-channel: live runtime_snapshot push", { ok: pushed });
+  };
+
+  gateway = new Gateway({
     config: gwConfig,
     sessionStorePath: opts.sessionStorePath ?? SESSIONS_PATH,
     createChannel: (chCfg: GatewayChannelConfig): ChannelAdapter =>
@@ -517,6 +530,7 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
     buildMemoryContext,
     onInbound,
     onOutbound,
+    onRuntimeCircuitBreakerChange: pushLiveRuntimeSnapshot,
     composeUserTurn: composeBotCordUserTurn,
     attentionGate,
     resolveHubUrl,
@@ -575,7 +589,6 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
   // Control channel is optional — daemon still runs (data-plane only)
   // when user-auth hasn't been set up yet. Operators can `login` later
   // without restarting, but for P0 we require a restart to pick it up.
-  let controlChannel: ControlChannel | null = null;
   if (userAuth?.current && !opts.disableControlChannel) {
     logger.info("control-channel: enabling", {
       userId: userAuth.current.userId,
@@ -614,7 +627,7 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
       // Plan §8.5 P0 — push one runtime snapshot immediately after connect
       // so Hub's `daemon_instances.runtimes_json` is populated for the
       // dashboard even before any user action. No periodic refresh in P0.
-      const pushed = pushRuntimeSnapshot(controlChannel);
+      const pushed = pushRuntimeSnapshot(controlChannel, gateway.snapshot());
       logger.info("control-channel: initial runtime_snapshot push", {
         ok: pushed,
       });

--- a/packages/daemon/src/doctor.ts
+++ b/packages/daemon/src/doctor.ts
@@ -1,6 +1,7 @@
 import type { RuntimeProbeEntry } from "./adapters/runtimes.js";
 import type { DaemonConfig } from "./config.js";
 import { resolveBootAgents } from "./agent-discovery.js";
+import { probeClaudeAuth, type ClaudeAuthProbeResult } from "./gateway/runtimes/claude-code.js";
 
 /** Summary of a single channel's readiness, printable by the doctor command. */
 export interface ChannelProbeResult {
@@ -54,6 +55,7 @@ export interface DoctorRuntimeEndpoint {
 /** Augmented runtime entry that may carry endpoint probe results. */
 export interface DoctorRuntimeEntry extends RuntimeProbeEntry {
   endpoints?: DoctorRuntimeEndpoint[];
+  auth?: ClaudeAuthProbeResult;
 }
 
 /** Input for the rendered doctor output. */
@@ -167,12 +169,11 @@ export async function probeChannel(
     return result;
   }
 
-  // Probe `/` — the hub is ASGI and responds 2xx/3xx/404 which is fine for
-  // "reachable". We treat any response as reachable; network errors fall
-  // through to hubOk=false.
+  // Probe `/` — the hub is ASGI and may answer 404 when the host is still
+  // reachable. Network errors fall through to hubOk=false.
   const probeUrl = `${result.hubUrl.replace(/\/+$/, "")}/`;
   const http = await opts.fetcher(probeUrl, opts.timeoutMs);
-  if (http.ok) {
+  if (http.ok || http.status === 404) {
     result.hubOk = true;
     result.hubMessage = `reachable (HTTP ${http.status})`;
   } else if (http.status !== undefined) {
@@ -260,6 +261,10 @@ export function renderDoctor(input: DoctorInput): string {
     if (!e.result.available && e.installHint) {
       lines.push(`    → ${e.installHint}`);
     }
+    if (e.auth) {
+      const authStatus = e.auth.checked ? (e.auth.ok ? "ok" : "failed") : "skipped";
+      lines.push(`    auth ${authStatus}: ${e.auth.message}`);
+    }
     if (e.endpoints && e.endpoints.length > 0) {
       for (const ep of e.endpoints) {
         const mark = ep.reachable ? "✓" : "✗";
@@ -312,15 +317,23 @@ export function renderDoctor(input: DoctorInput): string {
  * text. Keeps `index.ts` free of probe wiring.
  */
 export async function runDoctor(
-  runtimes: RuntimeProbeEntry[],
+  runtimes: DoctorRuntimeEntry[],
   channels: ChannelProbeConfig[],
   opts: {
     credentialsPath: (accountId: string) => string;
     fileReader: DoctorFileReader;
     fetcher: DoctorHttpFetcher;
     timeoutMs?: number;
+    authCheck?: boolean;
   },
 ): Promise<DoctorInput> {
+  if (opts.authCheck) {
+    for (const runtime of runtimes) {
+      if (runtime.id === "claude-code" && runtime.result.available) {
+        runtime.auth = probeClaudeAuth();
+      }
+    }
+  }
   const channelResults = await probeChannels({
     channels,
     credentialsPath: opts.credentialsPath,

--- a/packages/daemon/src/gateway/__tests__/claude-code-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/claude-code-adapter.test.ts
@@ -2,7 +2,8 @@ import { afterAll, describe, expect, it } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, chmodSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { ClaudeCodeAdapter } from "../runtimes/claude-code.js";
+import { ClaudeCodeAdapter, probeClaudeAuth } from "../runtimes/claude-code.js";
+import type { RuntimeRunOptions } from "../types.js";
 
 // The adapter spawns whatever binary we point it at; we point it at a small
 // Node script so we control stdout/stderr/exit precisely without needing the
@@ -31,6 +32,20 @@ function runAdapter(script: string, sessionId: string | null = null) {
     signal: ctrl.signal,
     trustLevel: "owner",
   });
+}
+
+class EnvProbeClaudeCodeAdapter extends ClaudeCodeAdapter {
+  env(opts: Partial<RuntimeRunOptions> = {}) {
+    return this.spawnEnv({
+      text: "hi",
+      sessionId: null,
+      accountId: "ag_test",
+      cwd: tmpRoot,
+      signal: new AbortController().signal,
+      trustLevel: "owner",
+      ...opts,
+    } as RuntimeRunOptions);
+  }
 }
 
 describe("ClaudeCodeAdapter", () => {
@@ -148,6 +163,91 @@ process.exit(2);
     expect(res.error).toBeDefined();
     expect(res.error).toMatch(/code 2/);
     expect(res.error).toMatch(/auth failure/);
+  });
+
+  it("treats Claude Code auth failures emitted as success results as runtime errors", async () => {
+    const script = makeScript(
+      "auth-success.js",
+      `
+process.stdout.write(JSON.stringify({type:"system", subtype:"init", session_id:"sid-auth"}) + "\\n");
+process.stdout.write(JSON.stringify({type:"assistant", message:{content:[{type:"text", text:"partial"}]}}) + "\\n");
+process.stdout.write(JSON.stringify({
+  type:"result",
+  subtype:"success",
+  session_id:"sid-bad",
+  total_cost_usd:0,
+  result:"Failed to authenticate. API Error: 403 Request not allowed"
+}) + "\\n");
+`,
+    );
+    const res = await runAdapter(script);
+    expect(res.text).toBe("");
+    expect(res.newSessionId).toBe("");
+    expect(res.error).toContain("Failed to authenticate");
+    expect(res.costUsd).toBe(0);
+  });
+
+  it("scrubs Claude Code auth env that can override stored login credentials", () => {
+    const previous = {
+      ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+      ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
+      ANTHROPIC_BASE_URL: process.env.ANTHROPIC_BASE_URL,
+      ANTHROPIC_CUSTOM_HEADERS: process.env.ANTHROPIC_CUSTOM_HEADERS,
+      CLAUDE_CODE_OAUTH_TOKEN: process.env.CLAUDE_CODE_OAUTH_TOKEN,
+    };
+    try {
+      process.env.ANTHROPIC_API_KEY = "stale-key";
+      process.env.ANTHROPIC_AUTH_TOKEN = "stale-token";
+      process.env.ANTHROPIC_BASE_URL = "https://wrong.example";
+      process.env.ANTHROPIC_CUSTOM_HEADERS = "Authorization: Bearer stale";
+      process.env.CLAUDE_CODE_OAUTH_TOKEN = "stale-oauth";
+
+      const env = new EnvProbeClaudeCodeAdapter().env();
+      expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+      expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+      expect(env.ANTHROPIC_BASE_URL).toBeUndefined();
+      expect(env.ANTHROPIC_CUSTOM_HEADERS).toBeUndefined();
+      expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+    } finally {
+      for (const [key, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+  });
+
+  it("auth probe recognizes success-shaped Claude Code auth failures", () => {
+    const res = probeClaudeAuth({
+      execFileSyncFn: ((command: string, args: string[]) => {
+        if (command === "which") return "/usr/bin/claude\n";
+        expect(args).toEqual(["-p", "ping", "--output-format", "stream-json"]);
+        return `${JSON.stringify({
+          type: "result",
+          subtype: "success",
+          total_cost_usd: 0,
+          result: "Failed to authenticate. API Error: 403 Request not allowed",
+        })}\n`;
+      }) as never,
+    });
+    expect(res.checked).toBe(true);
+    expect(res.ok).toBe(false);
+    expect(res.message).toContain("Failed to authenticate");
+  });
+
+  it("auth probe reports ok when Claude Code returns a normal result", () => {
+    const res = probeClaudeAuth({
+      execFileSyncFn: ((command: string, args: string[]) => {
+        if (command === "which") return "/usr/bin/claude\n";
+        expect(args).toEqual(["-p", "ping", "--output-format", "stream-json"]);
+        return `${JSON.stringify({
+          type: "result",
+          subtype: "success",
+          total_cost_usd: 0.001,
+          result: "pong",
+        })}\n`;
+      }) as never,
+    });
+    expect(res).toEqual({ checked: true, ok: true, message: "claude-code auth ok" });
   });
 
   it("wipes newSessionId on non-success result so dispatcher can drop the stale entry", async () => {

--- a/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
+++ b/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
@@ -242,6 +242,8 @@ describe("Dispatcher", () => {
     channel?: FakeChannel;
     runtimeFactory?: RuntimeFactory;
     turnTimeoutMs?: number;
+    runtimeAuthFailureThreshold?: number;
+    runtimeAuthFailureCooldownMs?: number;
   }) {
     const { store, dir } = await makeStore();
     tempDirs.push(dir);
@@ -254,6 +256,8 @@ describe("Dispatcher", () => {
       sessionStore: store,
       log: silentLogger(),
       turnTimeoutMs: args.turnTimeoutMs,
+      runtimeAuthFailureThreshold: args.runtimeAuthFailureThreshold,
+      runtimeAuthFailureCooldownMs: args.runtimeAuthFailureCooldownMs,
     });
     return { dispatcher, channel, store };
   }
@@ -454,6 +458,60 @@ describe("Dispatcher", () => {
 
     expect(store.all().length).toBe(0);
     expect(channel.sends[0].message.type).toBe("error");
+  });
+
+  it("treats auth failure text as an error and does not persist the failed session", async () => {
+    let callNo = 0;
+    const runtimeFactory: RuntimeFactory = () => {
+      callNo += 1;
+      if (callNo === 1) return new FakeRuntime({ reply: "ok", newSessionId: "sid-1" });
+      return new FakeRuntime({
+        reply: "Failed to authenticate. API Error: 403 Request not allowed",
+        newSessionId: "sid-bad",
+      });
+    };
+    const { dispatcher, store, channel } = await scaffold({ runtimeFactory });
+
+    await dispatcher.handle(
+      makeEnvelope({ id: "msg_1", conversation: { id: "rm_oc_auth", kind: "direct" } }),
+    );
+    expect(store.all()[0].runtimeSessionId).toBe("sid-1");
+
+    await dispatcher.handle(
+      makeEnvelope({ id: "msg_2", conversation: { id: "rm_oc_auth", kind: "direct" } }),
+    );
+
+    expect(store.all().length).toBe(0);
+    expect(channel.sends).toHaveLength(2);
+    expect(channel.sends[1].message.type).toBe("error");
+    expect(channel.sends[1].message.text).toContain("Runtime error");
+    expect(channel.sends[1].message.text).toContain("Failed to authenticate");
+  });
+
+  it("opens an auth circuit breaker after repeated failures and skips runtime spawn", async () => {
+    const runtime = new FakeRuntime({
+      reply: "Failed to authenticate. API Error: 403 Request not allowed",
+      newSessionId: "sid-bad",
+    });
+    const { dispatcher, channel, store } = await scaffold({
+      runtimeFactory: () => runtime,
+      runtimeAuthFailureThreshold: 2,
+      runtimeAuthFailureCooldownMs: 60_000,
+    });
+    const conversation = { id: "rm_oc_auth_breaker", kind: "direct" as const };
+
+    await dispatcher.handle(makeEnvelope({ id: "msg_1", conversation }));
+    await dispatcher.handle(makeEnvelope({ id: "msg_2", conversation }));
+    expect(runtime.calls).toHaveLength(2);
+    expect(Object.values(dispatcher.runtimeCircuitBreakers())).toHaveLength(1);
+
+    await dispatcher.handle(makeEnvelope({ id: "msg_3", conversation }));
+
+    expect(runtime.calls).toHaveLength(2);
+    expect(store.all()).toHaveLength(0);
+    expect(channel.sends).toHaveLength(3);
+    expect(channel.sends[2].message.type).toBe("error");
+    expect(channel.sends[2].message.text).toContain("dispatch paused");
   });
 
   it("applies composeUserTurn before handing text to the runtime", async () => {

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import type { GatewayLogger } from "./log.js";
+import { looksLikeRuntimeAuthFailure } from "./runtime-errors.js";
 import { resolveRoute } from "./router.js";
 import { sessionKey, type SessionStore } from "./session-store.js";
 import {
@@ -23,6 +24,7 @@ import type {
   QueueMode,
   RuntimeAdapter,
   RuntimeRunResult,
+  RuntimeCircuitBreakerSnapshot,
   RuntimeStatusEvent,
   StreamBlock,
   SystemContextBuilder,
@@ -31,6 +33,8 @@ import type {
 } from "./types.js";
 
 const DEFAULT_TURN_TIMEOUT_MS = 30 * 60 * 1000;
+const DEFAULT_RUNTIME_AUTH_FAILURE_THRESHOLD = 3;
+const DEFAULT_RUNTIME_AUTH_FAILURE_COOLDOWN_MS = 10 * 60 * 1000;
 
 /**
  * Owner-chat room prefix. Reply-text gating: only rooms with this prefix get
@@ -192,6 +196,8 @@ export interface DispatcherOptions {
   sessionStore: SessionStore;
   log: GatewayLogger;
   turnTimeoutMs?: number;
+  runtimeAuthFailureThreshold?: number;
+  runtimeAuthFailureCooldownMs?: number;
   /**
    * Live reference to the Gateway's managed-route map. Dispatcher reads
    * `values()` on every `resolveRoute` call so hot-add/remove take effect
@@ -230,6 +236,7 @@ export interface DispatcherOptions {
    * and suppressed so observer failures never break the turn.
    */
   onOutbound?: OutboundObserver;
+  onRuntimeCircuitBreakerChange?: () => void;
   /**
    * Optional observer fired exactly once per turn after ``runtime.run``
    * resolves (or throws / times out). Receives the inbound message, the
@@ -351,6 +358,8 @@ interface DeferredMultimodalEntry extends BufferedSerialEntry {
   queuedAt: number;
 }
 
+interface RuntimeAuthFailureState extends RuntimeCircuitBreakerSnapshot {}
+
 /**
  * Gateway dispatcher: consumes `GatewayInboundEnvelope` and drives a runtime
  * turn per message, respecting queue mode, trust level, streaming, and
@@ -368,11 +377,14 @@ export class Dispatcher {
   private readonly sessionStore: SessionStore;
   private readonly log: GatewayLogger;
   private readonly turnTimeoutMs: number;
+  private readonly runtimeAuthFailureThreshold: number;
+  private readonly runtimeAuthFailureCooldownMs: number;
   private readonly buildSystemContext?: SystemContextBuilder;
   private readonly buildMemoryContext?: MemoryContextBuilder;
   private readonly onInbound?: InboundObserver;
   private readonly onOutbound?: OutboundObserver;
   private readonly onTurnComplete?: DispatcherOptions["onTurnComplete"];
+  private readonly onRuntimeCircuitBreakerChange?: () => void;
   private readonly composeUserTurn?: UserTurnBuilder;
   private readonly managedRoutes?: Map<string, GatewayRoute>;
   private readonly attentionGate?: (
@@ -382,6 +394,7 @@ export class Dispatcher {
   private readonly transcript: TranscriptWriter;
   private readonly queues: Map<string, QueueState> = new Map();
   private readonly deferredMultimodal: Map<string, DeferredMultimodalEntry[]> = new Map();
+  private readonly runtimeAuthFailures: Map<string, RuntimeAuthFailureState> = new Map();
   /**
    * Last `/hub/typing` ping timestamp per (accountId, conversationId).
    * Used to debounce cancel-previous bursts so we don't trip Hub's 20/min
@@ -396,11 +409,16 @@ export class Dispatcher {
     this.sessionStore = opts.sessionStore;
     this.log = opts.log;
     this.turnTimeoutMs = opts.turnTimeoutMs ?? DEFAULT_TURN_TIMEOUT_MS;
+    this.runtimeAuthFailureThreshold =
+      opts.runtimeAuthFailureThreshold ?? DEFAULT_RUNTIME_AUTH_FAILURE_THRESHOLD;
+    this.runtimeAuthFailureCooldownMs =
+      opts.runtimeAuthFailureCooldownMs ?? DEFAULT_RUNTIME_AUTH_FAILURE_COOLDOWN_MS;
     this.buildSystemContext = opts.buildSystemContext;
     this.buildMemoryContext = opts.buildMemoryContext;
     this.onInbound = opts.onInbound;
     this.onOutbound = opts.onOutbound;
     this.onTurnComplete = opts.onTurnComplete;
+    this.onRuntimeCircuitBreakerChange = opts.onRuntimeCircuitBreakerChange;
     this.composeUserTurn = opts.composeUserTurn;
     this.managedRoutes = opts.managedRoutes;
     this.attentionGate = opts.attentionGate;
@@ -620,6 +638,18 @@ export class Dispatcher {
       });
     }
 
+    const openAuthBreaker = this.openRuntimeAuthBreaker(dispatchRoute, dispatchMsg);
+    if (openAuthBreaker) {
+      await this.skipRuntimeForAuthBreaker(
+        openAuthBreaker,
+        dispatchRoute,
+        dispatchMsg,
+        dispatchChannel,
+        dispatchTurnId,
+      );
+      return;
+    }
+
     if (mode === "cancel-previous") {
       await this.runCancelPrevious(
         queueKey,
@@ -648,6 +678,15 @@ export class Dispatcher {
     const out: Record<string, TurnStatusSnapshot> = {};
     for (const [key, q] of this.queues) {
       if (q.current) out[key] = { ...q.current.snapshot };
+    }
+    return out;
+  }
+
+  runtimeCircuitBreakers(): Record<string, RuntimeCircuitBreakerSnapshot> {
+    this.pruneExpiredRuntimeAuthBreakers();
+    const out: Record<string, RuntimeCircuitBreakerSnapshot> = {};
+    for (const [key, state] of this.runtimeAuthFailures) {
+      if (state.blockedUntil > Date.now()) out[key] = { ...state };
     }
     return out;
   }
@@ -712,6 +751,166 @@ export class Dispatcher {
     if (!list || list.length === 0) return [];
     this.deferredMultimodal.delete(queueKey);
     return list;
+  }
+
+  private runtimeAuthBreakerKey(route: GatewayRoute, msg: GatewayInboundMessage): string {
+    const thread = msg.conversation.threadId ?? "";
+    return `${route.runtime}:${msg.channel}:${msg.accountId}:${msg.conversation.id}:${thread}`;
+  }
+
+  private openRuntimeAuthBreaker(
+    route: GatewayRoute,
+    msg: GatewayInboundMessage,
+  ): RuntimeAuthFailureState | null {
+    const key = this.runtimeAuthBreakerKey(route, msg);
+    const state = this.runtimeAuthFailures.get(key);
+    if (!state) return null;
+    if (state.blockedUntil > 0 && state.blockedUntil <= Date.now()) {
+      this.runtimeAuthFailures.delete(key);
+      return null;
+    }
+    return state.blockedUntil > Date.now() ? state : null;
+  }
+
+  private pruneExpiredRuntimeAuthBreakers(): void {
+    const now = Date.now();
+    for (const [key, state] of this.runtimeAuthFailures) {
+      if (state.blockedUntil > 0 && state.blockedUntil <= now) this.runtimeAuthFailures.delete(key);
+    }
+  }
+
+  private recordRuntimeAuthFailure(
+    route: GatewayRoute,
+    msg: GatewayInboundMessage,
+    error: string,
+  ): RuntimeAuthFailureState | null {
+    const now = Date.now();
+    const key = this.runtimeAuthBreakerKey(route, msg);
+    const prev = this.runtimeAuthFailures.get(key);
+    const failures = (prev?.failures ?? 0) + 1;
+    const openedAt = prev?.openedAt ?? now;
+    const state: RuntimeAuthFailureState = {
+      key,
+      runtime: route.runtime,
+      channel: msg.channel,
+      accountId: msg.accountId,
+      conversationId: msg.conversation.id,
+      threadId: msg.conversation.threadId ?? null,
+      failures,
+      openedAt,
+      blockedUntil:
+        failures >= this.runtimeAuthFailureThreshold
+          ? now + this.runtimeAuthFailureCooldownMs
+          : 0,
+      lastFailureAt: now,
+      lastError: error,
+    };
+    this.runtimeAuthFailures.set(key, state);
+    if (state.blockedUntil > now) {
+      this.log.error("dispatcher: runtime auth circuit breaker opened", {
+        key,
+        runtime: route.runtime,
+        agentId: msg.accountId,
+        roomId: msg.conversation.id,
+        topicId: msg.conversation.threadId ?? null,
+        failures,
+        blockedUntil: state.blockedUntil,
+        error,
+      });
+      this.notifyRuntimeCircuitBreakerChange();
+      return state;
+    }
+    this.log.warn("dispatcher: runtime authentication failure recorded", {
+      key,
+      runtime: route.runtime,
+      agentId: msg.accountId,
+      roomId: msg.conversation.id,
+      topicId: msg.conversation.threadId ?? null,
+      failures,
+      threshold: this.runtimeAuthFailureThreshold,
+      error,
+    });
+    return null;
+  }
+
+  private clearRuntimeAuthFailures(route: GatewayRoute, msg: GatewayInboundMessage): void {
+    const key = this.runtimeAuthBreakerKey(route, msg);
+    if (!this.runtimeAuthFailures.delete(key)) return;
+    this.log.info("dispatcher: runtime auth circuit breaker cleared", {
+      key,
+      runtime: route.runtime,
+      agentId: msg.accountId,
+      roomId: msg.conversation.id,
+      topicId: msg.conversation.threadId ?? null,
+    });
+    this.notifyRuntimeCircuitBreakerChange();
+  }
+
+  private notifyRuntimeCircuitBreakerChange(): void {
+    try {
+      this.onRuntimeCircuitBreakerChange?.();
+    } catch (err) {
+      this.log.warn("dispatcher: onRuntimeCircuitBreakerChange threw", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  private async skipRuntimeForAuthBreaker(
+    state: RuntimeAuthFailureState,
+    route: GatewayRoute,
+    msg: GatewayInboundMessage,
+    channel: ChannelAdapter,
+    turnId: string,
+  ): Promise<void> {
+    const error =
+      `runtime authentication failed repeatedly; dispatch paused until ${new Date(state.blockedUntil).toISOString()}`;
+    this.log.warn("dispatcher: runtime auth circuit breaker blocking turn", {
+      key: state.key,
+      runtime: route.runtime,
+      agentId: msg.accountId,
+      roomId: msg.conversation.id,
+      topicId: msg.conversation.threadId ?? null,
+      turnId,
+      blockedUntil: state.blockedUntil,
+    });
+    this.transcript.write({
+      ts: nowIso(),
+      kind: "turn_error",
+      turnId,
+      agentId: msg.accountId,
+      roomId: msg.conversation.id,
+      topicId: msg.conversation.threadId ?? null,
+      phase: "runtime",
+      error,
+      durationMs: 0,
+    });
+
+    const canDeliverRuntimeText = isOwnerChatRoom(msg) || !isBotCordChannel(channel);
+    const canDeliverRuntimeDiagnostics = canDeliverRuntimeText || isBotCordChannel(channel);
+    if (canDeliverRuntimeDiagnostics) {
+      const sendResult = await this.sendReply(channel, {
+        channel: msg.channel,
+        accountId: msg.accountId,
+        conversationId: msg.conversation.id,
+        threadId: msg.conversation.threadId ?? null,
+        type: "error",
+        text: `⚠️ Runtime error: ${truncate(error, 500)}`,
+        replyTo: this.providerReplyTo(msg),
+        traceId: msg.trace?.id ?? null,
+      }, turnId);
+      this.emitOutbound({
+        turnId,
+        msg,
+        runtime: route.runtime,
+        runtimeSessionId: null,
+        startedAt: Date.now(),
+        finalText: truncateTextField(""),
+        deliveryStatus: sendResult.ok ? "delivered" : "send_failed",
+        deliveryReason: sendResult.ok ? null : sendResult.error,
+        blocks: [],
+      });
+    }
   }
 
   private async runCancelPrevious(
@@ -1583,8 +1782,28 @@ export class Dispatcher {
 
       if (!result) return;
 
-      const replyText = (result.text || "").trim();
-      const finalTextField = truncateTextField(result.text || "");
+      const rawReplyText = (result.text || "").trim();
+      const replyLooksLikeAuthFailure = looksLikeRuntimeAuthFailure(rawReplyText);
+      const replyText = replyLooksLikeAuthFailure ? "" : rawReplyText;
+      const effectiveError = result.error ?? (replyLooksLikeAuthFailure ? rawReplyText : undefined);
+      const authFailureError =
+        effectiveError && looksLikeRuntimeAuthFailure(effectiveError) ? effectiveError : undefined;
+      const finalTextField = truncateTextField(replyLooksLikeAuthFailure ? "" : result.text || "");
+      if (replyLooksLikeAuthFailure) {
+        this.log.error("dispatcher: runtime text looked like authentication failure; treating as error", {
+          agentId: msg.accountId,
+          roomId: msg.conversation.id,
+          topicId: msg.conversation.threadId ?? null,
+          turnId,
+          runtime: route.runtime,
+          error: rawReplyText,
+        });
+      }
+      if (authFailureError) {
+        this.recordRuntimeAuthFailure(route, msg, authFailureError);
+      } else if (!effectiveError) {
+        this.clearRuntimeAuthFailures(route, msg);
+      }
 
       // Persist session before reply so next turn sees the new id even if send fails.
       //
@@ -1595,14 +1814,14 @@ export class Dispatcher {
       //                                 even when the adapter echoes that id back
       //   result.newSessionId truthy  → upsert the entry
       //   otherwise                   → no-op (e.g. codex intentionally never persists)
-      if (sessionId && result.error && !replyText) {
+      if (sessionId && effectiveError && !replyText) {
         try {
           await this.sessionStore.delete(key);
           this.log.info("dispatcher: dropped stale runtime session", {
             key,
             prevRuntimeSessionId: sessionId,
             nextRuntimeSessionId: result.newSessionId || null,
-            error: result.error,
+            error: effectiveError,
           });
         } catch (err) {
           this.log.warn("dispatcher: session-store.delete failed", {
@@ -1610,7 +1829,7 @@ export class Dispatcher {
             error: err instanceof Error ? err.message : String(err),
           });
         }
-      } else if (result.newSessionId) {
+      } else if (result.newSessionId && !authFailureError) {
         const session: GatewaySessionEntry = {
           key,
           runtime: route.runtime,
@@ -1638,13 +1857,13 @@ export class Dispatcher {
             error: err instanceof Error ? err.message : String(err),
           });
         }
-      } else if (sessionId && result.error) {
+      } else if (sessionId && effectiveError) {
         try {
           await this.sessionStore.delete(key);
           this.log.info("dispatcher: dropped stale runtime session", {
             key,
             prevRuntimeSessionId: sessionId,
-            error: result.error,
+            error: effectiveError,
           });
         } catch (err) {
           this.log.warn("dispatcher: session-store.delete failed", {
@@ -1655,14 +1874,14 @@ export class Dispatcher {
       }
 
       if (!replyText) {
-        if (result.error) {
+        if (effectiveError) {
           this.log.warn("dispatcher: runtime returned error without reply text", {
             agentId: msg.accountId,
             roomId: msg.conversation.id,
             topicId: msg.conversation.threadId ?? null,
             turnId,
             runtime: route.runtime,
-            error: result.error,
+            error: effectiveError,
           });
           if (canDeliverRuntimeDiagnostics) {
             const sendResult = await this.sendReply(channel, {
@@ -1671,7 +1890,7 @@ export class Dispatcher {
               conversationId: msg.conversation.id,
               threadId: msg.conversation.threadId ?? null,
               type: "error",
-              text: `⚠️ Runtime error: ${truncate(result.error, 500)}`,
+              text: `⚠️ Runtime error: ${truncate(effectiveError, 500)}`,
               replyTo: this.providerReplyTo(msg),
               traceId: msg.trace?.id ?? null,
             }, turnId);
@@ -1699,7 +1918,7 @@ export class Dispatcher {
           costUsd: result.costUsd,
           finalText: finalTextField,
           deliveryStatus: "empty_text",
-          deliveryReason: result.error ?? null,
+          deliveryReason: effectiveError ?? null,
           blocks: slot.blocks,
         });
         return;

--- a/packages/daemon/src/gateway/gateway.ts
+++ b/packages/daemon/src/gateway/gateway.ts
@@ -65,6 +65,7 @@ export interface GatewayBootOptions {
    * bookkeeping like loop-risk tracking.
    */
   onOutbound?: OutboundObserver;
+  onRuntimeCircuitBreakerChange?: () => void;
   /**
    * Optional observer fired after each runtime turn resolves. Forwarded
    * to the dispatcher verbatim — see {@link Dispatcher} for semantics.
@@ -181,6 +182,7 @@ export class Gateway {
       composeUserTurn: opts.composeUserTurn,
       onOutbound: opts.onOutbound,
       onTurnComplete: opts.onTurnComplete,
+      onRuntimeCircuitBreakerChange: opts.onRuntimeCircuitBreakerChange,
       managedRoutes: this.managedRoutes,
       attentionGate: opts.attentionGate,
       resolveHubUrl: opts.resolveHubUrl,
@@ -216,6 +218,7 @@ export class Gateway {
     return {
       channels: this.channelManager.status(),
       turns: this.dispatcher.turns(),
+      runtimeCircuitBreakers: this.dispatcher.runtimeCircuitBreakers(),
     };
   }
 

--- a/packages/daemon/src/gateway/runtime-errors.ts
+++ b/packages/daemon/src/gateway/runtime-errors.ts
@@ -1,0 +1,15 @@
+/**
+ * Runtime CLIs sometimes report authentication failures as ordinary final
+ * text. Keep this intentionally narrow so normal model replies about auth do
+ * not get reclassified unless they look like a top-level CLI/API failure.
+ */
+export function looksLikeRuntimeAuthFailure(text: string): boolean {
+  const s = text.trim();
+  if (!s) return false;
+  return (
+    /^(Failed to authenticate|Authentication failed|Invalid API key|Invalid Anthropic API key)\b/i.test(s) ||
+    /^API Error:\s*4\d\d\b/i.test(s) ||
+    /\b(API Error:\s*4\d\d|Request not allowed|invalid x-api-key)\b/i.test(s) ||
+    /^(Unauthorized|Forbidden)(?:\b|:)/i.test(s)
+  );
+}

--- a/packages/daemon/src/gateway/runtimes/claude-code.ts
+++ b/packages/daemon/src/gateway/runtimes/claude-code.ts
@@ -1,5 +1,8 @@
+import { execFileSync, type ExecFileSyncOptions } from "node:child_process";
 import path from "node:path";
 import { NdjsonStreamAdapter, type NdjsonEventCtx } from "./ndjson-stream.js";
+import { consoleLogger } from "../log.js";
+import { looksLikeRuntimeAuthFailure } from "../runtime-errors.js";
 import {
   firstExistingPath,
   readCommandVersion,
@@ -18,6 +21,24 @@ const CLAUDE_DESKTOP_CLI_RELATIVE_PATH = path.join(
 );
 const CLAUDE_DESKTOP_CLI_SYSTEM_PATH =
   "/Applications/Claude Code URL Handler.app/Contents/MacOS/claude";
+const log = consoleLogger;
+
+const CLAUDE_CODE_AUTH_ENV_DENYLIST = [
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+  "ANTHROPIC_BASE_URL",
+  "ANTHROPIC_CUSTOM_HEADERS",
+  "CLAUDE_CODE_OAUTH_TOKEN",
+];
+
+export function scrubClaudeCodeAuthEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const out = { ...env };
+  for (const key of CLAUDE_CODE_AUTH_ENV_DENYLIST) {
+    delete out[key];
+  }
+  return out;
+}
+
 function isValidClaudeSessionId(sessionId: string): boolean {
   if (sessionId.length === 0 || sessionId.length > 512) return false;
   if (sessionId.startsWith("-")) return false;
@@ -125,6 +146,63 @@ export function probeClaude(deps: ProbeDeps = {}): RuntimeProbeResult {
   };
 }
 
+export interface ClaudeAuthProbeResult {
+  checked: boolean;
+  ok: boolean;
+  message: string;
+}
+
+export function probeClaudeAuth(deps: ProbeDeps = {}): ClaudeAuthProbeResult {
+  const command = resolveClaudeCommand(deps);
+  if (!command) return { checked: false, ok: false, message: "claude command not found" };
+  return runClaudeAuthProbe(command, deps);
+}
+
+function runClaudeAuthProbe(command: string, deps: ProbeDeps = {}): ClaudeAuthProbeResult {
+  const execFn = deps.execFileSyncFn ?? execFileSync;
+  const env = scrubClaudeCodeAuthEnv(deps.env ?? process.env);
+  try {
+    const raw = execFn(command, ["-p", "ping", "--output-format", "stream-json"], {
+      stdio: ["ignore", "pipe", "pipe"],
+      env,
+      timeout: 20_000,
+    } as ExecFileSyncOptions);
+    const output = Buffer.isBuffer(raw) ? raw.toString("utf8") : String(raw ?? "");
+    const authFailure = claudeAuthFailureFromOutput(output);
+    if (authFailure) return { checked: true, ok: false, message: authFailure };
+    return { checked: true, ok: true, message: "claude-code auth ok" };
+  } catch (err) {
+    const e = err as Error & { stdout?: Buffer | string; stderr?: Buffer | string };
+    const output = `${bufferishToString(e.stdout)}\n${bufferishToString(e.stderr)}`.trim();
+    const authFailure = claudeAuthFailureFromOutput(output);
+    return {
+      checked: true,
+      ok: false,
+      message: authFailure || e.message || "claude-code auth probe failed",
+    };
+  }
+}
+
+function bufferishToString(raw: Buffer | string | undefined): string {
+  return Buffer.isBuffer(raw) ? raw.toString("utf8") : String(raw ?? "");
+}
+
+function claudeAuthFailureFromOutput(output: string): string | null {
+  for (const line of output.split(/\r?\n/)) {
+    const s = line.trim();
+    if (!s) continue;
+    try {
+      const obj = JSON.parse(s) as { type?: string; result?: unknown; total_cost_usd?: unknown };
+      if (obj.type === "result" && typeof obj.result === "string" && looksLikeRuntimeAuthFailure(obj.result)) {
+        return obj.result;
+      }
+    } catch {
+      if (looksLikeRuntimeAuthFailure(s)) return s;
+    }
+  }
+  return looksLikeRuntimeAuthFailure(output) ? output : null;
+}
+
 /**
  * Claude Code adapter — spawns `claude -p "<text>" --output-format stream-json`
  * (with `--resume <sid>` when available) and parses the ndjson stream.
@@ -197,6 +275,10 @@ export class ClaudeCodeAdapter extends NdjsonStreamAdapter {
     return args;
   }
 
+  protected override spawnEnv(opts: RuntimeRunOptions): NodeJS.ProcessEnv {
+    return scrubClaudeCodeAuthEnv(super.spawnEnv(opts));
+  }
+
   protected handleEvent(raw: unknown, ctx: NdjsonEventCtx): void {
     const obj = raw as {
       type?: string;
@@ -229,8 +311,22 @@ export class ClaudeCodeAdapter extends NdjsonStreamAdapter {
     if (obj.type === "result") {
       if (typeof obj.total_cost_usd === "number") ctx.state.costUsd = obj.total_cost_usd;
       if (obj.subtype === "success") {
-        if (typeof obj.session_id === "string") ctx.state.newSessionId = obj.session_id;
-        if (typeof obj.result === "string") ctx.state.finalText = obj.result;
+        const result = typeof obj.result === "string" ? obj.result : "";
+        const looksLikeAuthFailure =
+          obj.total_cost_usd === 0 && looksLikeRuntimeAuthFailure(result);
+        if (looksLikeAuthFailure) {
+          log.error("claude-code authentication failed; check ~/.claude login or unset stale Anthropic env vars", {
+            error: result,
+          });
+          ctx.state.newSessionId = "";
+          ctx.state.finalText = "";
+          ctx.state.assistantTextChunks = [];
+          ctx.state.assistantTextBytes = 0;
+          ctx.state.errorText = result;
+        } else {
+          if (typeof obj.session_id === "string") ctx.state.newSessionId = obj.session_id;
+          if (typeof obj.result === "string") ctx.state.finalText = obj.result;
+        }
       } else {
         // Non-success result (e.g. resume targeted a missing UUID). Claude Code
         // still emits a fresh `session_id` for the just-spawned empty session —

--- a/packages/daemon/src/gateway/types.ts
+++ b/packages/daemon/src/gateway/types.ts
@@ -240,10 +240,26 @@ export interface TurnStatusSnapshot {
   startedAt: number;
 }
 
+/** Per-runtime auth circuit breaker state exposed through daemon snapshots. */
+export interface RuntimeCircuitBreakerSnapshot {
+  key: string;
+  runtime: string;
+  channel: string;
+  accountId: string;
+  conversationId: string;
+  threadId?: string | null;
+  failures: number;
+  openedAt: number;
+  blockedUntil: number;
+  lastFailureAt: number;
+  lastError: string;
+}
+
 /** Aggregate gateway state combining channel and turn snapshots. */
 export interface GatewayRuntimeSnapshot {
   channels: Record<string, ChannelStatusSnapshot>;
   turns: Record<string, TurnStatusSnapshot>;
+  runtimeCircuitBreakers?: Record<string, RuntimeCircuitBreakerSnapshot>;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -144,7 +144,10 @@ Commands:
   route list
   route remove --room <rm_xxx>|--prefix <rm_xxx>
   config                                  Print resolved config
-  doctor [--json] [--bundle] [--full-log] Scan local runtimes (${ADAPTER_LIST});
+  doctor [--json] [--auth-check] [--bundle] [--full-log]
+                                          Scan local runtimes (${ADAPTER_LIST});
+                                          --auth-check also runs a Claude Code
+                                          ping probe and may contact Anthropic.
                                           --bundle also writes a zip under
                                           ~/.botcord/diagnostics/. Bundles
                                           daemon.log plus the latest 5 rotated
@@ -1413,6 +1416,7 @@ async function cmdDoctor(args: ParsedArgs): Promise<void> {
     fileReader: fsFileReader,
     fetcher: defaultHttpFetcher,
     timeoutMs: 5_000,
+    authCheck: args.flags["auth-check"] === true,
   });
 
   if (args.flags.json === true) {

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -337,7 +337,10 @@ export function createProvisioner(opts: ProvisionerOptions): (
         } catch {
           cfgForProbe = undefined;
         }
-        const snapshot = await collectRuntimeSnapshotAsync({ cfg: cfgForProbe });
+        const snapshot = attachRuntimeHealth(
+          await collectRuntimeSnapshotAsync({ cfg: cfgForProbe }),
+          gateway.snapshot(),
+        );
         daemonLog.debug("list_runtimes", { count: snapshot.runtimes.length });
         return { ok: true, result: snapshot };
       }
@@ -1793,6 +1796,47 @@ export function collectRuntimeSnapshot(opts: { force?: boolean } = {}): ListRunt
   const value: ListRuntimesResult = { runtimes, probedAt: Date.now() };
   _runtimeProbeCache = { at: Date.now(), value };
   return value;
+}
+
+export function attachRuntimeHealth(
+  snapshot: ListRuntimesResult,
+  live: GatewayRuntimeSnapshot,
+): ListRuntimesResult {
+  const breakers = Object.values(live.runtimeCircuitBreakers ?? {});
+  if (breakers.length === 0) return snapshot;
+
+  const byRuntime = new Map<string, typeof breakers>();
+  for (const breaker of breakers) {
+    const list = byRuntime.get(breaker.runtime) ?? [];
+    if (list.length < 32) list.push(breaker);
+    byRuntime.set(breaker.runtime, list);
+  }
+
+  return {
+    ...snapshot,
+    runtimes: snapshot.runtimes.map((runtime) => {
+      const runtimeBreakers = byRuntime.get(runtime.id);
+      if (!runtimeBreakers?.length) return runtime;
+      return {
+        ...runtime,
+        health: {
+          ...((runtime as { health?: Record<string, unknown> }).health ?? {}),
+          circuitBreakers: runtimeBreakers.map((b) => ({
+            key: b.key,
+            channel: b.channel,
+            accountId: b.accountId,
+            conversationId: b.conversationId,
+            threadId: b.threadId ?? null,
+            failures: b.failures,
+            openedAt: b.openedAt,
+            blockedUntil: b.blockedUntil,
+            lastFailureAt: b.lastFailureAt,
+            lastError: b.lastError,
+          })),
+        },
+      };
+    }),
+  };
 }
 
 /** Maximum number of `endpoints[]` entries persisted per runtime (RFC §3.8.2). */

--- a/packages/daemon/src/status-render.ts
+++ b/packages/daemon/src/status-render.ts
@@ -85,6 +85,28 @@ function renderTurns(
   return out;
 }
 
+function renderRuntimeCircuitBreakers(
+  snap: GatewayRuntimeSnapshot,
+  now: number,
+): string[] {
+  const entries = Object.values(snap.runtimeCircuitBreakers ?? {});
+  if (entries.length === 0) return ["Runtime circuit breakers:", "  (none)"];
+  const out: string[] = ["Runtime circuit breakers:"];
+  const keyW = Math.max(3, ...entries.map((b) => b.key.length));
+  const rtW = Math.max(7, ...entries.map((b) => b.runtime.length));
+  const convW = Math.max(12, ...entries.map((b) => b.conversationId.length));
+  out.push(
+    `  ${pad("KEY", keyW)}  ${pad("RUNTIME", rtW)}  ${pad("CONVERSATION", convW)}  FAILS  BLOCKED FOR  LAST ERROR`,
+  );
+  for (const b of entries) {
+    const blockedFor = relTime(b.blockedUntil - now).replace(" ago", "");
+    out.push(
+      `  ${pad(b.key, keyW)}  ${pad(b.runtime, rtW)}  ${pad(b.conversationId, convW)}  ${pad(String(b.failures), 5)}  ${pad(blockedFor, 11)}  ${b.lastError}`,
+    );
+  }
+  return out;
+}
+
 /**
  * Format a human-readable status block. Kept pure so it can be unit-tested
  * without touching disk or spawning a daemon.
@@ -125,6 +147,8 @@ export function renderStatus(input: StatusRenderInput, now: number = Date.now())
     lines.push(...renderChannels(input.snapshot));
     lines.push("");
     lines.push(...renderTurns(input.snapshot, now));
+    lines.push("");
+    lines.push(...renderRuntimeCircuitBreakers(input.snapshot, now));
   } else if (input.alive) {
     lines.push("snapshot: unavailable (daemon running but no snapshot file found)");
   }

--- a/packages/protocol-core/src/control-frame.ts
+++ b/packages/protocol-core/src/control-frame.ts
@@ -431,6 +431,29 @@ export interface RuntimeProbeResult {
    * as `endpoints`).
    */
   profiles?: HermesProfileProbe[];
+  /**
+   * Optional live health state for this runtime on the daemon. Unlike
+   * `available`, this describes current dispatch health rather than whether
+   * the binary is installed.
+   */
+  health?: RuntimeHealthSnapshot;
+}
+
+export interface RuntimeHealthSnapshot {
+  circuitBreakers?: RuntimeCircuitBreakerProbe[];
+}
+
+export interface RuntimeCircuitBreakerProbe {
+  key: string;
+  channel: string;
+  accountId: string;
+  conversationId: string;
+  threadId?: string | null;
+  failures: number;
+  openedAt: number;
+  blockedUntil: number;
+  lastFailureAt: number;
+  lastError: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- scrub stale Anthropic/Claude auth env vars before spawning Claude Code
- classify success-shaped Claude Code auth failures as runtime errors so they are not sent as replies or persisted as sessions
- add per-conversation auth circuit breakers and surface runtime health through status, control snapshots, backend storage, and the daemon settings UI
- add optional `doctor --auth-check` probing for Claude Code auth health

## Tests
- `cd packages/protocol-core && npm run build`
- `cd packages/daemon && npm run build`
- `cd packages/daemon && npm test`
- `cd backend && uv run pytest tests/test_app/test_daemon_control.py -k "runtime_snapshot"`
- `cd frontend && NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy corepack pnpm build`