### PR TITLE
fix(daemon): add periodic inbox polling fallback

### DIFF
--- a/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
+++ b/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
@@ -269,6 +269,39 @@ describe("createBotCordChannel — inbox normalization", () => {
     }
   });
 
+  it("polls inbox periodically as a fallback after websocket auth", async () => {
+    const server = await startAuthOkServer();
+    const pollInbox = vi.fn().mockResolvedValue({ messages: [], count: 0, has_more: false });
+    const client = makeClient({
+      pollInbox,
+      getHubUrl: vi.fn().mockReturnValue(server.url),
+    });
+    const channel = createBotCordChannel({
+      id: "botcord-main",
+      accountId: "ag_self",
+      agentId: "ag_self",
+      client,
+      hubBaseUrl: server.url,
+      pollIntervalMs: 10,
+    });
+    const abort = new AbortController();
+    const startPromise = channel.start({
+      config: stubConfig,
+      accountId: "ag_self",
+      abortSignal: abort.signal,
+      log: silentLog,
+      emit: async () => {},
+      setStatus: () => {},
+    });
+    try {
+      await vi.waitFor(() => expect(pollInbox.mock.calls.length).toBeGreaterThanOrEqual(2));
+    } finally {
+      abort.abort();
+      await startPromise;
+      await server.close();
+    }
+  });
+
   it("maps a group-room InboxMessage to a GatewayInboundMessage", async () => {
     const { emits, server } = await startWithInbox([
       makeInbox({

--- a/packages/daemon/src/gateway/channels/botcord.ts
+++ b/packages/daemon/src/gateway/channels/botcord.ts
@@ -43,7 +43,8 @@ type InboxDrainTrigger =
   | "ws_auth_ok"
   | "ws_inbox_update"
   | "coalesced_inbox_update"
-  | "has_more_continue";
+  | "has_more_continue"
+  | "poll_interval";
 
 /** Minimal surface the adapter needs from `BotCordClient`. Matches the subset used at runtime. */
 export interface BotCordChannelClient {
@@ -90,7 +91,7 @@ export interface BotCordChannelOptions {
   credentialsPath?: string;
   /** Override the Hub base URL. Defaults to the `hubUrl` stored in credentials. */
   hubBaseUrl?: string;
-  /** Not used by the WS-only loop today; kept for future polling fallback. */
+  /** Periodic inbox polling fallback. Set to 0 to disable. Defaults to 30s. */
   pollIntervalMs?: number;
   /** Test hook: supply a pre-built client instead of loading credentials from disk. */
   client?: BotCordChannelClient;
@@ -493,6 +494,7 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
     let ws: WebSocket | null = null;
     let reconnectTimer: NodeJS.Timeout | null = null;
     let keepaliveTimer: NodeJS.Timeout | null = null;
+    let pollTimer: NodeJS.Timeout | null = null;
     let reconnectAttempt = 0;
     let connectionSeq = 0;
     let consecutiveAuthFailures = 0;
@@ -517,6 +519,10 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
       if (keepaliveTimer) {
         clearInterval(keepaliveTimer);
         keepaliveTimer = null;
+      }
+      if (pollTimer) {
+        clearInterval(pollTimer);
+        pollTimer = null;
       }
     }
 
@@ -720,6 +726,16 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
           });
           log.info("botcord ws authenticated", { agentId: msg.agent_id });
           void fireInbox("ws_auth_ok");
+          const pollIntervalMs = options.pollIntervalMs ?? 30_000;
+          if (pollTimer) clearInterval(pollTimer);
+          if (pollIntervalMs > 0) {
+            pollTimer = setInterval(() => {
+              if (ws === socket && socket.readyState === WebSocket.OPEN) {
+                void fireInbox("poll_interval");
+              }
+            }, pollIntervalMs);
+            pollTimer.unref?.();
+          }
           if (keepaliveTimer) clearInterval(keepaliveTimer);
           keepaliveTimer = setInterval(() => {
             if (ws === socket && socket.readyState === WebSocket.OPEN) {


### PR DESCRIPTION
## Summary
- WS push can miss `inbox_update` notifications (network blips, Hub-side drops). Add a periodic poll as a safety net.
- New `poll_interval` trigger fires after `ws_auth_ok` and only while the socket stays open.
- Default 30s; pass `pollIntervalMs: 0` to disable.

## Test plan
- [x] `npx vitest run botcord-channel` — 25/25 pass
- [x] New test `polls inbox periodically as a fallback after websocket auth` confirms repeated polls under a short interval