### PR TITLE
chore(desktop): notarize release, add marketing download page

### DIFF
--- a/.github/workflows/publish-desktop-dmg.yml
+++ b/.github/workflows/publish-desktop-dmg.yml
@@ -62,6 +62,35 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Validate required release secrets
+        env:
+          MAC_DEVELOPER_ID_APPLICATION_CERTIFICATE_BASE64: ${{ secrets.MAC_DEVELOPER_ID_APPLICATION_CERTIFICATE_BASE64 }}
+          MAC_DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD: ${{ secrets.MAC_DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD }}
+          APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+
+          missing=()
+          for name in \
+            MAC_DEVELOPER_ID_APPLICATION_CERTIFICATE_BASE64 \
+            MAC_DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD \
+            APP_STORE_CONNECT_API_KEY_BASE64 \
+            APP_STORE_CONNECT_API_KEY_ID \
+            APP_STORE_CONNECT_API_ISSUER_ID
+          do
+            if [ -z "${!name:-}" ]; then
+              missing+=("$name")
+            fi
+          done
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            printf "Missing required GitHub Actions secrets:\n" >&2
+            printf "  - %s\n" "${missing[@]}" >&2
+            exit 1
+          fi
+
       - name: Import Developer ID certificate
         env:
           MAC_DEVELOPER_ID_APPLICATION_CERTIFICATE_BASE64: ${{ secrets.MAC_DEVELOPER_ID_APPLICATION_CERTIFICATE_BASE64 }}
@@ -164,8 +193,20 @@ jobs:
           mkdir -p release-assets
           DMG_OUT="release-assets/${{ steps.meta.outputs.asset_prefix }}.dmg"
           ZIP_OUT="release-assets/${{ steps.meta.outputs.asset_prefix }}.app.zip"
+          APP_NOTARY_ZIP="$RUNNER_TEMP/BotCord.app.notary.zip"
 
           codesign --verify --deep --strict --verbose=2 "$APP"
+
+          ditto -c -k --sequesterRsrc --keepParent "$APP" "$APP_NOTARY_ZIP"
+          xcrun notarytool submit "$APP_NOTARY_ZIP" \
+            --key "$HOME/.appstoreconnect/private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8" \
+            --key-id "$APP_STORE_CONNECT_API_KEY_ID" \
+            --issuer "$APP_STORE_CONNECT_API_ISSUER_ID" \
+            --wait
+          xcrun stapler staple "$APP"
+          xcrun stapler validate "$APP"
+          spctl -a -vv --type execute "$APP"
+
           cp "$DMG" "$DMG_OUT"
           codesign --force \
             --sign "$DEVELOPER_ID_SIGNING_IDENTITY_HASH" \
@@ -226,8 +267,8 @@ jobs:
               `BotCord Desktop ${process.env.DESKTOP_VERSION}`,
               "",
               "Assets:",
-              "- macOS DMG installer",
-              "- zipped .app bundle",
+              "- signed and notarized macOS DMG installer",
+              "- signed, notarized, and stapled zipped .app bundle",
               "- SHA256 checksums",
             ].join("\n");
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 desktop/node_modules/
 desktop/dist/
 desktop/src-tauri/target/
+desktop/release-assets-local/
 # env files: ignore all, but keep example templates
 .env*
 !.env.example

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -33,3 +33,63 @@ When `botcord-daemon` is not already available, the desktop shell installs an
 app-managed copy under `~/.botcord/daemon`, creates
 `~/.botcord/bin/botcord-daemon`, and then starts it with the install token
 minted by the authenticated Dashboard flow.
+
+## macOS Release
+
+Public macOS distribution is built by the `Publish Desktop DMG` GitHub Actions
+workflow in `.github/workflows/publish-desktop-dmg.yml`. The workflow imports a
+Developer ID Application certificate, builds the Tauri app, signs and notarizes
+the DMG, notarizes and staples the zipped `.app`, validates both artifacts, and
+uploads the DMG, zip, and SHA256 checksums to a GitHub Release.
+
+### Apple Requirements
+
+- Active Apple Developer Program membership for the distribution team.
+- A Developer ID Application certificate for the Apple team that owns the
+  `ai.ouraca.botcord` bundle identifier.
+- An App Store Connect API key that can submit notarization requests for that
+  Apple team.
+
+Confirm the imported signing identity in the workflow logs matches the intended
+Apple team before publishing a public release.
+
+### Required GitHub Actions Secrets
+
+Configure these repository secrets before running the workflow:
+
+- `MAC_DEVELOPER_ID_APPLICATION_CERTIFICATE_BASE64`: base64-encoded `.p12`
+  export of the Developer ID Application certificate and private key.
+- `MAC_DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD`: password for the `.p12`
+  certificate export.
+- `APP_STORE_CONNECT_API_KEY_BASE64`: base64-encoded App Store Connect
+  `AuthKey_<KEY_ID>.p8` private key.
+- `APP_STORE_CONNECT_API_KEY_ID`: App Store Connect API key ID.
+- `APP_STORE_CONNECT_API_ISSUER_ID`: App Store Connect issuer ID.
+
+Create the base64 values on macOS with:
+
+```bash
+base64 -i DeveloperIDApplication.p12 | pbcopy
+base64 -i AuthKey_<KEY_ID>.p8 | pbcopy
+```
+
+### Publishing Flow
+
+1. Update `desktop/package.json` and `desktop/src-tauri/tauri.conf.json` to the
+   desktop version being released.
+2. Push a tag matching `desktop-v*` or `botcord-desktop-*`, or run `Publish
+   Desktop DMG` manually from GitHub Actions.
+3. For a manual run, use `main` or the release tag as `ref`; use a release tag
+   such as `desktop-v0.1.0` or `botcord-desktop-beta` as `release_tag`.
+4. Wait for the workflow to finish and confirm the Release includes:
+   - `BotCord_<tag>_macos_<arch>.dmg`
+   - `BotCord_<tag>_macos_<arch>.app.zip`
+   - `SHA256SUMS.txt`
+5. Confirm the workflow logs include passing `codesign --verify`, `xcrun
+   stapler validate`, and `spctl` checks.
+6. Install the DMG on a clean macOS machine and verify first launch, `botcord://`
+   deep link registration, daemon install/start, and update or reinstall
+   behavior.
+
+Files in `desktop/release-assets-local/` are local test artifacts only. Do not
+publish them unless they are rebuilt through the signed and notarized workflow.

--- a/frontend/src/app/(marketing)/download/page.tsx
+++ b/frontend/src/app/(marketing)/download/page.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { Apple, Shield, AlertTriangle } from "lucide-react";
+import NeonButton from "@/components/ui/NeonButton";
+import { useLanguage } from "@/lib/i18n";
+
+const RELEASE_TAG = "botcord-desktop-beta-v0.1.0";
+const DMG_NAME = `BotCord_${RELEASE_TAG}_macos_arm64.dmg`;
+const DMG_URL = `https://github.com/botlearn-ai/botcord/releases/download/${RELEASE_TAG}/${DMG_NAME}`;
+const VERSION = "0.1.0";
+
+const copy = {
+  en: {
+    badge: "Beta",
+    title: "Download BotCord Desktop",
+    description:
+      "Local control panel for the BotCord daemon. Manages agent runtimes and bridges your Hub inbox to local Claude Code / Codex / Gemini CLIs.",
+    downloadCta: "Download for macOS",
+    arch: "Apple Silicon (M1+) · macOS 11 or later",
+    version: `Version ${VERSION} · Signed & notarized by Apple`,
+    securityHeading: "Install in three steps",
+    securitySteps: [
+      "Click the button above directly in a web browser (Safari / Chrome / Firefox). Do not have someone forward the DMG via Feishu, WeChat or other messengers — macOS refuses to launch executables that arrive through sandboxed apps.",
+      "Open the downloaded DMG and drag BotCord into your Applications folder.",
+      "Launch BotCord from Applications. On first run macOS asks you to confirm — click Open.",
+    ],
+    troubleHeading: "App can't be opened?",
+    troubleBody:
+      "If you received the file through a messenger or AirDrop and see \"BotCord can't be opened\", run this in Terminal and try again:",
+  },
+  zh: {
+    badge: "Beta",
+    title: "下载 BotCord Desktop",
+    description:
+      "本地的 BotCord daemon 控制台。管理 Agent 运行时，把 Hub 收件箱桥接到本机的 Claude Code / Codex / Gemini CLI。",
+    downloadCta: "下载 macOS 版",
+    arch: "Apple Silicon (M1+) · macOS 11 及以上",
+    version: `版本 ${VERSION} · 已通过 Apple 公证签名`,
+    securityHeading: "三步完成安装",
+    securitySteps: [
+      "请直接在浏览器（Safari / Chrome / Firefox）里点击上方按钮下载。不要让别人通过飞书、微信等 IM 把 DMG 转发给你 —— macOS 会拒绝从沙盒应用接收的可执行文件。",
+      "双击下载好的 DMG 挂载，把 BotCord 拖进 Applications 文件夹。",
+      '从 Applications 双击启动。首次运行 macOS 会提示来自互联网，点 "打开" 即可。',
+    ],
+    troubleHeading: "提示 \"无法打开\" 怎么办？",
+    troubleBody:
+      "如果文件是通过 IM 或 AirDrop 收到的，启动时报 \"BotCord 无法打开\"，请在终端里执行下面这条命令再重启 App：",
+  },
+} as const;
+
+export default function DownloadPage() {
+  const locale = useLanguage();
+  const t = copy[locale];
+
+  return (
+    <section className="px-6 pb-24 pt-32">
+      <div className="mx-auto max-w-3xl">
+        <span className="inline-block rounded-full border border-neon-cyan/30 bg-neon-cyan/5 px-4 py-1.5 text-xs font-medium tracking-wider text-neon-cyan">
+          {t.badge}
+        </span>
+        <h1 className="mt-6 text-4xl font-bold leading-tight md:text-5xl">
+          {t.title}
+        </h1>
+        <p className="mt-4 max-w-2xl text-lg text-text-secondary">
+          {t.description}
+        </p>
+
+        <div className="mt-10 flex flex-col items-start gap-3">
+          <NeonButton href={DMG_URL} variant="cyan-filled">
+            <Apple className="h-5 w-5" />
+            {t.downloadCta}
+          </NeonButton>
+          <div className="text-sm text-text-secondary">
+            {t.arch} ·{" "}
+            <a href={DMG_URL} className="text-neon-cyan hover:underline">
+              {DMG_NAME}
+            </a>
+          </div>
+          <div className="text-xs text-text-secondary">{t.version}</div>
+        </div>
+
+        <div className="mt-12 rounded-2xl border border-glass-border bg-glass-background p-6">
+          <h2 className="flex items-center gap-2 text-lg font-semibold">
+            <Shield className="h-5 w-5 text-neon-cyan" />
+            {t.securityHeading}
+          </h2>
+          <ol className="mt-4 space-y-3 text-sm text-text-secondary">
+            {t.securitySteps.map((step, i) => (
+              <li key={i} className="flex gap-3">
+                <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-neon-cyan/10 text-xs font-medium text-neon-cyan">
+                  {i + 1}
+                </span>
+                <span>{step}</span>
+              </li>
+            ))}
+          </ol>
+        </div>
+
+        <div className="mt-6 rounded-xl border border-neon-purple/20 bg-neon-purple/5 p-4">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-neon-purple" />
+            <div className="flex-1">
+              <div className="text-sm font-medium text-text-primary">
+                {t.troubleHeading}
+              </div>
+              <div className="mt-1 text-sm text-text-secondary">
+                {t.troubleBody}
+              </div>
+              <pre className="mt-3 overflow-x-auto rounded-lg border border-glass-border bg-deep-black/60 px-3 py-2 font-mono text-xs text-neon-cyan">
+                sudo xattr -cr /Applications/BotCord.app
+              </pre>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- **Workflow** — validate required Apple signing/notarization secrets early; notarize + staple the `.app` bundle before packaging DMG and zip; update release notes to call out the signed+notarized assets.
- **Marketing** — new `/download` page that links to the GitHub release DMG, with install steps and a Terminal workaround for messenger-quarantined downloads.
- **Misc** — gitignore `desktop/release-assets-local/`; document local resign + App Store flow in `desktop/README.md`.

## Test plan
- [ ] Trigger `publish-desktop-dmg` workflow against a tag and confirm notarization + stapling succeed
- [ ] Visit `/download` locally (`pnpm dev` in `frontend/`) and confirm the DMG link resolves to the expected release asset
- [ ] Confirm `git status` no longer surfaces `desktop/release-assets-local/`