### PR TITLE
fix: show newest bots first

### DIFF
--- a/frontend/src/components/dashboard/HomePanel.tsx
+++ b/frontend/src/components/dashboard/HomePanel.tsx
@@ -27,6 +27,7 @@ import { useLanguage } from "@/lib/i18n";
 import { homePanel as homePanelI18n } from "@/lib/i18n/translations/dashboard";
 import { api } from "@/lib/api";
 import type { ActivityStats, PublicRoom, UserAgent } from "@/lib/types";
+import { sortOwnedAgentsNewestFirst } from "@/lib/owned-agents";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
@@ -788,7 +789,10 @@ export default function HomePanel() {
     return () => window.clearInterval(id);
   }, []);
 
-  const previewOwnedAgents = useMemo(() => ownedAgents.slice(0, 5), [ownedAgents]);
+  const previewOwnedAgents = useMemo(
+    () => sortOwnedAgentsNewestFirst(ownedAgents).slice(0, 5),
+    [ownedAgents],
+  );
 
   useEffect(() => {
     const agentIds = previewOwnedAgents.map((agent) => agent.agent_id);

--- a/frontend/src/components/dashboard/MyBotsPanel.tsx
+++ b/frontend/src/components/dashboard/MyBotsPanel.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Plus } from "lucide-react";
 import { useShallow } from "zustand/shallow";
 import { api } from "@/lib/api";
 import type { ActivityStats } from "@/lib/types";
+import { sortOwnedAgentsNewestFirst } from "@/lib/owned-agents";
 import BotAvatar from "./BotAvatar";
 import { BotEmptyHero } from "./HomePanel";
 import MyDevicesView from "./MyDevicesView";
@@ -116,9 +117,13 @@ function BotsView({
   const t = myBotsPanelI18n[useLanguage()];
   const setBotDetailAgentId = useDashboardUIStore((s) => s.setBotDetailAgentId);
   const [statsById, setStatsById] = useState<Record<string, ActivityStats>>({});
+  const orderedAgents = useMemo(
+    () => sortOwnedAgentsNewestFirst(ownedAgents),
+    [ownedAgents],
+  );
 
   useEffect(() => {
-    const agentIds = ownedAgents.map((agent) => agent.agent_id);
+    const agentIds = orderedAgents.map((agent) => agent.agent_id);
     if (agentIds.length === 0) {
       setStatsById({});
       return;
@@ -134,7 +139,7 @@ function BotsView({
     return () => {
       cancelled = true;
     };
-  }, [ownedAgents]);
+  }, [orderedAgents]);
 
   return (
     <>
@@ -142,7 +147,7 @@ function BotsView({
         <BotEmptyHero onCreateBot={onCreateBot} />
       ) : (
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-          {ownedAgents.map((agent) => {
+          {orderedAgents.map((agent) => {
             const stats = statsById[agent.agent_id] ?? null;
             const online = agent.ws_online;
             return (

--- a/frontend/src/lib/owned-agents.ts
+++ b/frontend/src/lib/owned-agents.ts
@@ -1,0 +1,14 @@
+import type { UserAgent } from "./types";
+
+export function sortOwnedAgentsNewestFirst<T extends Pick<UserAgent, "agent_id" | "claimed_at">>(
+  agents: readonly T[],
+): T[] {
+  return [...agents].sort((a, b) => {
+    const aClaimedAt = Date.parse(a.claimed_at);
+    const bClaimedAt = Date.parse(b.claimed_at);
+    const aTime = Number.isNaN(aClaimedAt) ? 0 : aClaimedAt;
+    const bTime = Number.isNaN(bClaimedAt) ? 0 : bClaimedAt;
+    if (aTime !== bTime) return bTime - aTime;
+    return a.agent_id.localeCompare(b.agent_id);
+  });
+}


### PR DESCRIPTION
## Summary
- Sort owned bots by claimed_at descending in the My Bots page
- Reuse the same newest-first ordering for the Home page bot preview

## Test
- NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=placeholder pnpm build