### PR TITLE
fix: support wechat gateways in cloud daemon

### DIFF
--- a/backend/hub/config.py
+++ b/backend/hub/config.py
@@ -331,8 +331,10 @@ E2B_DEFAULT_REGION: str | None = os.getenv("E2B_DEFAULT_REGION") or None
 E2B_SANDBOX_TIMEOUT_SECONDS: int = int(os.getenv("E2B_SANDBOX_TIMEOUT_SECONDS", "1800"))
 
 # Command Hub runs inside a freshly-created or resumed cloud daemon instance.
-# The default supports purpose-built images that already contain
-# ``botcord-daemon`` and preview templates that need to install it at boot.
+# The default prefers the Hub-selected npm package so paused/resumed sandboxes
+# do not keep running an older daemon baked into the E2B template. Set
+# ``CLOUD_DAEMON_NPM_SPEC=bundled`` to force a purpose-built image's
+# preinstalled ``botcord-daemon`` instead.
 CLOUD_DAEMON_NPM_SPEC: str = os.getenv(
     "CLOUD_DAEMON_NPM_SPEC", "@botcord/daemon@latest"
 )
@@ -340,10 +342,25 @@ CLOUD_DAEMON_STARTUP_COMMAND: str = os.getenv(
     "CLOUD_DAEMON_STARTUP_COMMAND",
     (
         "sh -lc '"
+        "case \"${CLOUD_DAEMON_NPM_SPEC:-}\" in "
+        "bundled) "
         "if command -v botcord-daemon >/dev/null 2>&1; then "
         "exec botcord-daemon start --foreground; "
         "fi; "
-        "exec npx --yes --package \"${CLOUD_DAEMON_NPM_SPEC:-@botcord/daemon@latest}\" "
+        ";; "
+        "\"\") "
+        "if command -v botcord-daemon >/dev/null 2>&1; then "
+        "exec botcord-daemon start --foreground; "
+        "fi; "
+        "exec npx --yes --package @botcord/daemon@latest "
+        "botcord-daemon start --foreground; "
+        ";; "
+        "*) "
+        "exec npx --yes --package \"$CLOUD_DAEMON_NPM_SPEC\" "
+        "botcord-daemon start --foreground; "
+        ";; "
+        "esac; "
+        "exec npx --yes --package @botcord/daemon@latest "
         "botcord-daemon start --foreground"
         "'"
     ),

--- a/backend/tests/test_app/test_app_gateways.py
+++ b/backend/tests/test_app/test_app_gateways.py
@@ -559,6 +559,80 @@ async def test_create_telegram_for_cloud_agent_dispatches_to_cloud_daemon(
 
 
 @pytest.mark.asyncio
+async def test_create_wechat_for_cloud_agent_dispatches_to_cloud_daemon(
+    client, seed, db_session, monkeypatch
+):
+    calls: list[dict] = []
+
+    async def fake_send(cloud_daemon_instance_id, type_, params=None, timeout_ms=None):
+        calls.append(
+            {
+                "cloud_daemon_instance_id": cloud_daemon_instance_id,
+                "type": type_,
+                "params": params,
+                "timeout_ms": timeout_ms,
+            }
+        )
+        return {
+            "ok": True,
+            "result": {
+                "id": params["id"],
+                "type": "wechat",
+                "accountId": params["accountId"],
+                "enabled": True,
+                "tokenPreview": "wxab...mnop",
+                "status": {"running": True, "authorized": True},
+            },
+        }
+
+    _patch_daemon(monkeypatch, online=False)
+    _patch_cloud_daemon(monkeypatch, online=True, send=fake_send)
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    r = await client.post(
+        "/api/agents/ag_cloud/gateways",
+        headers=headers,
+        json={
+            "provider": "wechat",
+            "label": "cloud wx",
+            "login_id": "wxl_cloud",
+            "config": {"allowedSenderIds": ["xxx@im.wechat"]},
+        },
+    )
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["agent_id"] == "ag_cloud"
+    assert body["daemon_instance_id"] == seed["cloud_daemon_row_id"]
+    assert body["provider"] == "wechat"
+    assert body["config"]["tokenPreview"] == "wxab...mnop"
+    assert calls == [
+        {
+            "cloud_daemon_instance_id": seed["cloud_daemon_id"],
+            "type": "upsert_gateway",
+            "params": {
+                "id": body["id"],
+                "type": "wechat",
+                "accountId": "ag_cloud",
+                "label": "cloud wx",
+                "enabled": True,
+                "settings": {"allowedSenderIds": ["xxx@im.wechat"]},
+                "loginId": "wxl_cloud",
+            },
+            "timeout_ms": None,
+        }
+    ]
+
+    row = await db_session.scalar(
+        select(AgentGatewayConnection).where(
+            AgentGatewayConnection.agent_id == "ag_cloud"
+        )
+    )
+    assert row is not None
+    assert row.provider == "wechat"
+    assert row.daemon_instance_id == seed["cloud_daemon_row_id"]
+
+
+@pytest.mark.asyncio
 async def test_create_telegram_for_cloud_agent_resumes_when_cloud_daemon_offline(
     client, seed, monkeypatch
 ):

--- a/backend/tests/test_cloud_daemon_provider_e2b.py
+++ b/backend/tests/test_cloud_daemon_provider_e2b.py
@@ -62,6 +62,15 @@ def _make_provider(
 # ---------------------------------------------------------------------------
 
 
+def test_default_startup_command_prefers_configured_npm_spec():
+    """Default launch should not prefer a stale daemon baked into the template."""
+    assert "case \"${CLOUD_DAEMON_NPM_SPEC:-}\"" in CLOUD_DAEMON_STARTUP_COMMAND
+    assert "exec npx --yes --package \"$CLOUD_DAEMON_NPM_SPEC\"" in (
+        CLOUD_DAEMON_STARTUP_COMMAND
+    )
+    assert "bundled)" in CLOUD_DAEMON_STARTUP_COMMAND
+
+
 @pytest.mark.asyncio
 async def test_create_or_resume_starts_sandbox_and_injects_env():
     """Provider creates a sandbox, injects token + DeepSeek key, runs daemon."""

--- a/docs/cloud-agent-subscription-implementation-plan.md
+++ b/docs/cloud-agent-subscription-implementation-plan.md
@@ -354,7 +354,7 @@ PR 4 前已确认 (2026-05-20):
 
 - DeepSeek provider key 通过 Hub env `DEEPSEEK_API_KEY` 注入 sandbox;完整 secret manager 留待生产硬化阶段。
 - E2B template 默认 `botcord-deepseek-tui-ubuntu2404-dev2` (ID `z0f20u29zdgx7cxnuzcu`),通过 env `E2B_TEMPLATE_ID` 覆盖。
-- sandbox 启动命令 `botcord-daemon start --foreground`;注入 env: `BOTCORD_HUB_URL` / `BOTCORD_CLOUD_DAEMON_INSTANCE_ID` / `BOTCORD_DAEMON_INSTANCE_ID` / `BOTCORD_CLOUD_DAEMON_ACCESS_TOKEN` / `DEEPSEEK_API_KEY`。
+- sandbox 启动命令默认通过 `npx --package "$CLOUD_DAEMON_NPM_SPEC"` 运行 cloud daemon，避免使用模板中已过期的预装版本；设置 `CLOUD_DAEMON_NPM_SPEC=bundled` 时才使用镜像内置 `botcord-daemon`。注入 env: `BOTCORD_HUB_URL` / `BOTCORD_CLOUD_DAEMON_INSTANCE_ID` / `BOTCORD_DAEMON_INSTANCE_ID` / `BOTCORD_CLOUD_DAEMON_ACCESS_TOKEN` / `DEEPSEEK_API_KEY`。
 
 PR 6 前已确认 (2026-05-20):
 

--- a/docs/cloud-agent-technical-design.md
+++ b/docs/cloud-agent-technical-design.md
@@ -618,4 +618,4 @@ PR 4 前已确认 (2026-05-20):
 
 - DeepSeek provider key 通过 Hub env `DEEPSEEK_API_KEY` 注入 sandbox。完整 secret manager 集成留待生产硬化阶段。
 - E2B template 默认 `botcord-deepseek-tui-ubuntu2404-dev2` (ID `z0f20u29zdgx7cxnuzcu`),通过 env `E2B_TEMPLATE_ID` 覆盖。
-- sandbox 启动命令通过 Hub env `CLOUD_DAEMON_STARTUP_COMMAND` 覆盖。默认命令先检查 `botcord-daemon`，缺失时用 `npx --package "$CLOUD_DAEMON_NPM_SPEC"` 启动，再执行 `botcord-daemon start --foreground`。注入 env: `BOTCORD_HUB_URL` / `BOTCORD_CLOUD_DAEMON_INSTANCE_ID` / `BOTCORD_DAEMON_INSTANCE_ID` / `BOTCORD_CLOUD_DAEMON_ACCESS_TOKEN` / `CLOUD_DAEMON_NPM_SPEC` / `DEEPSEEK_API_KEY`。
+- sandbox 启动命令通过 Hub env `CLOUD_DAEMON_STARTUP_COMMAND` 覆盖。默认命令优先用 `npx --package "$CLOUD_DAEMON_NPM_SPEC"` 启动，避免复用模板中已过期的预装 daemon；设置 `CLOUD_DAEMON_NPM_SPEC=bundled` 时才强制使用镜像内置 `botcord-daemon`。注入 env: `BOTCORD_HUB_URL` / `BOTCORD_CLOUD_DAEMON_INSTANCE_ID` / `BOTCORD_DAEMON_INSTANCE_ID` / `BOTCORD_CLOUD_DAEMON_ACCESS_TOKEN` / `CLOUD_DAEMON_NPM_SPEC` / `DEEPSEEK_API_KEY`。

--- a/e2b/entrypoint.sh
+++ b/e2b/entrypoint.sh
@@ -14,6 +14,7 @@
 #
 # Optional:
 #   DEEPSEEK_API_KEY                 — forwarded to deepseek-tui at runtime
+#   CLOUD_DAEMON_NPM_SPEC            — npm package spec to prefer over bundled daemon
 #   BOTCORD_DAEMON_EXTRA_ARGS        — appended to the daemon start command
 
 set -euo pipefail
@@ -58,5 +59,9 @@ fi
 
 # shellcheck disable=SC2206
 extra=( ${BOTCORD_DAEMON_EXTRA_ARGS:-} )
+
+if [[ -n "${CLOUD_DAEMON_NPM_SPEC:-}" && "${CLOUD_DAEMON_NPM_SPEC}" != "bundled" ]]; then
+  exec npx --yes --package "$CLOUD_DAEMON_NPM_SPEC" botcord-daemon start "${extra[@]}"
+fi
 
 exec botcord-daemon start "${extra[@]}"

--- a/packages/daemon/src/__tests__/cloud-daemon.test.ts
+++ b/packages/daemon/src/__tests__/cloud-daemon.test.ts
@@ -173,43 +173,52 @@ describe("startCloudDaemon", () => {
     }
   });
 
-  it("allows third-party gateway channels to be hot-plugged in cloud mode", async () => {
-    let gateway: Pick<Gateway, "addChannel"> | undefined;
-    const ctor = makeFakeCtor();
-    class TestControlChannel extends ControlChannel {
-      constructor(opts: ConstructorParameters<typeof ControlChannel>[0]) {
-        super({ ...opts, webSocketCtor: ctor, hubPublicKey: null });
+  it.each(["telegram", "wechat", "feishu"] as const)(
+    "allows %s gateway channels to be hot-plugged in cloud mode",
+    async (type) => {
+      let gateway: Pick<Gateway, "addChannel"> | undefined;
+      const ctor = makeFakeCtor();
+      class TestControlChannel extends ControlChannel {
+        constructor(opts: ConstructorParameters<typeof ControlChannel>[0]) {
+          super({ ...opts, webSocketCtor: ctor, hubPublicKey: null });
+        }
       }
-    }
-    const handle = await startCloudDaemon({
-      cloudConfig: makeCfg(),
-      config: makeDaemonCfg(),
-      configPath: "(cloud-mode)",
-      controlChannelFactory: TestControlChannel as unknown as typeof ControlChannel,
-      provisionerFactory: ((args: { gateway: Gateway }) => {
-        gateway = args.gateway;
-        return vi.fn();
-      }) as unknown as typeof import("../provision.js").createProvisioner,
-      sessionStorePath: path.join(tmpDir, "sessions.json"),
-      snapshotPath: path.join(tmpDir, "snapshot.json"),
-      snapshotIntervalMs: 60_000,
-    });
-    try {
-      expect(gateway).toBeDefined();
-      await expect(
-        gateway!.addChannel({
-          id: "gw_tg_cloud",
-          type: "telegram",
+      const handle = await startCloudDaemon({
+        cloudConfig: makeCfg(),
+        config: makeDaemonCfg(),
+        configPath: "(cloud-mode)",
+        controlChannelFactory: TestControlChannel as unknown as typeof ControlChannel,
+        provisionerFactory: ((args: { gateway: Gateway }) => {
+          gateway = args.gateway;
+          return vi.fn();
+        }) as unknown as typeof import("../provision.js").createProvisioner,
+        sessionStorePath: path.join(tmpDir, "sessions.json"),
+        snapshotPath: path.join(tmpDir, "snapshot.json"),
+        snapshotIntervalMs: 60_000,
+      });
+      try {
+        expect(gateway).toBeDefined();
+        const cfg: GatewayChannelConfig = {
+          id: `gw_${type}_cloud`,
+          type,
           accountId: "ag_cloud",
-          allowedSenderIds: ["42"],
-          allowedChatIds: ["111"],
-          secretFile: path.join(tmpDir, "missing-telegram-secret.json"),
-        } satisfies GatewayChannelConfig),
-      ).resolves.toBeUndefined();
-    } finally {
-      await handle.stop("test");
-    }
-  });
+          allowedSenderIds: [type === "telegram" ? "42" : "alice"],
+          secretFile: path.join(tmpDir, `missing-${type}-secret.json`),
+        };
+        if (type !== "wechat") {
+          cfg.allowedChatIds = ["111"];
+        }
+        if (type === "feishu") {
+          cfg.appId = "cli_test";
+        }
+        await expect(
+          gateway!.addChannel(cfg),
+        ).resolves.toBeUndefined();
+      } finally {
+        await handle.stop("test");
+      }
+    },
+  );
 
   it("stop() is idempotent", async () => {
     const handle = await startCloudDaemon({


### PR DESCRIPTION
## Summary
- make cloud daemon startup prefer the Hub-selected npm package instead of stale bundled daemon builds
- allow bundled daemon only via CLOUD_DAEMON_NPM_SPEC=bundled
- add regression coverage for cloud WeChat gateway creation and cloud daemon hot-plugging

## Tests
- cd backend && uv run pytest tests/test_app/test_app_gateways.py tests/test_cloud_daemon_provider_e2b.py -q
- cd packages/daemon && npm test -- src/__tests__/cloud-daemon.test.ts