### PR TITLE
fix: remove room origin label

### DIFF
--- a/frontend/src/components/dashboard/RoomList.tsx
+++ b/frontend/src/components/dashboard/RoomList.tsx
@@ -428,12 +428,6 @@ export default function RoomList({
                     )}
                   </div>
                 </div>
-                {room._originAgent ? (
-                  <div className="mt-0.5 flex items-center gap-1 text-[10px] text-text-secondary/55">
-                    <span className="inline-flex h-1.5 w-1.5 shrink-0 rounded-full bg-neon-cyan/40" />
-                    <span className="truncate">via {room._originAgent.display_name}</span>
-                  </div>
-                ) : null}
                 <div className="mt-0.5 flex items-center gap-1.5">
                   {room.required_subscription_product_id && (
                     <span className="shrink-0">


### PR DESCRIPTION
## Summary
- remove the room list origin line that displayed `via <bot name>`
- keep underlying origin-agent data available for routing and filters

## Tests
- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy-anon-key npm run build`