### PR TITLE
fix: show runtime tool call inputs

### DIFF
--- a/frontend/src/components/dashboard/StreamBlocksView.tsx
+++ b/frontend/src/components/dashboard/StreamBlocksView.tsx
@@ -18,14 +18,88 @@ function ToolCallIcon({ name }: { name: string }) {
   return <Code2 className="w-3 h-3 text-cyan-400 shrink-0" />;
 }
 
-function summarizeParams(params: Record<string, unknown> | undefined): string | null {
-  if (!params || Object.keys(params).length === 0) return null;
-  for (const v of Object.values(params)) {
-    if (typeof v === "string" && v.length > 0) {
-      return v.length > 60 ? v.slice(0, 60) + "..." : v;
+const PARAM_HINT_KEYS = [
+  "command",
+  "cmd",
+  "query",
+  "path",
+  "file_path",
+  "filename",
+  "tool_name",
+  "name",
+  "input",
+  "arguments",
+  "args",
+  "rawInput",
+  "raw_input",
+];
+
+function truncate(text: string, max = 80): string {
+  return text.length > max ? `${text.slice(0, max)}...` : text;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseMaybeJson(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return value;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return value;
+  }
+}
+
+function compactValue(value: unknown): string | null {
+  if (typeof value === "string" && value.length > 0) return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (isRecord(value) || Array.isArray(value)) {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
     }
   }
   return null;
+}
+
+function summarizeParams(params: unknown): string | null {
+  const parsed = parseMaybeJson(params);
+  if (parsed == null) return null;
+  if (typeof parsed !== "object") return compactValue(parsed);
+  if (Array.isArray(parsed)) return parsed.length > 0 ? truncate(JSON.stringify(parsed)) : null;
+  const record = parsed as Record<string, unknown>;
+  if (Object.keys(record).length === 0) return null;
+
+  for (const key of PARAM_HINT_KEYS) {
+    if (key in record) {
+      const hint = compactValue(record[key]);
+      if (hint) return truncate(hint);
+    }
+  }
+
+  for (const v of Object.values(record)) {
+    const hint = compactValue(v);
+    if (hint) return truncate(hint);
+  }
+  return null;
+}
+
+function formatToolParams(params: unknown): string | null {
+  const parsed = parseMaybeJson(params);
+  if (parsed == null) return null;
+  if (typeof parsed === "string") return parsed;
+  if (typeof parsed === "number" || typeof parsed === "boolean") return String(parsed);
+  if (isRecord(parsed) && Object.keys(parsed).length === 0) return null;
+  if (Array.isArray(parsed) && parsed.length === 0) return null;
+  try {
+    return JSON.stringify(parsed, null, 2);
+  } catch {
+    return String(parsed);
+  }
 }
 
 function summarizeResult(result: string): string {
@@ -47,6 +121,7 @@ interface BlockView {
   kind: "tool_call" | "tool_result" | "reasoning" | "system" | "error" | "todo" | "unknown";
   toolName?: string;
   paramHint?: string | null;
+  paramDetails?: string | null;
   resultStr?: string;
   reasoningText?: string;
   systemLabel?: string;
@@ -103,6 +178,9 @@ function blockDetails(raw: unknown, payload?: Record<string, unknown>): string {
 function buildToolNameById(blocks: StreamBlockEntry[]): Record<string, string> {
   const m: Record<string, string> = {};
   for (const b of blocks) {
+    if (b.block.kind === "tool_call" && typeof b.block.payload?.id === "string" && typeof b.block.payload?.name === "string") {
+      m[b.block.payload.id] = b.block.payload.name;
+    }
     const contents = (b.block.raw as any)?.message?.content;
     if (!Array.isArray(contents)) continue;
     for (const c of contents) {
@@ -114,6 +192,183 @@ function buildToolNameById(blocks: StreamBlockEntry[]): Record<string, string> {
   return m;
 }
 
+function stringField(obj: any, key: string): string | undefined {
+  const value = obj?.[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function extractToolCall(raw: any): { name: string; params?: unknown; id?: string } | null {
+  const contents = Array.isArray(raw?.message?.content) ? raw.message.content : [];
+  const tu = contents.find((c: any) => c?.type === "tool_use");
+  if (tu) {
+    return {
+      name: stringField(tu, "name") ?? "tool",
+      params: parseMaybeJson(tu.input ?? tu.arguments),
+      id: stringField(tu, "id"),
+    };
+  }
+
+  const deepseek = extractDeepseekToolCall(raw);
+  if (deepseek) return deepseek;
+
+  const item = raw?.item;
+  if (item && typeof item === "object") {
+    return {
+      name: stringField(item, "type") ?? stringField(item, "name") ?? "tool",
+      params: item,
+      id: stringField(item, "id"),
+    };
+  }
+
+  const toolCalls = Array.isArray(raw?.tool_calls) ? raw.tool_calls : [];
+  const toolCall = toolCalls.find((t: any) => t && typeof t === "object");
+  if (toolCall) {
+    const fn = toolCall.function && typeof toolCall.function === "object" ? toolCall.function : undefined;
+    return {
+      name: stringField(fn, "name") ?? stringField(toolCall, "name") ?? "tool",
+      params: parseMaybeJson(fn?.arguments ?? toolCall.arguments ?? toolCall.input ?? toolCall.rawInput),
+      id: stringField(toolCall, "id"),
+    };
+  }
+
+  const update = raw?.params?.update ?? raw?.update;
+  const acpTool = update?.toolCall ?? update?.tool_call ?? update?.tool;
+  if (acpTool && typeof acpTool === "object") {
+    return {
+      name: stringField(acpTool, "name") ?? stringField(update, "name") ?? "tool",
+      params: parseMaybeJson(
+        acpTool.rawInput ??
+          acpTool.raw_input ??
+          acpTool.input ??
+          acpTool.arguments ??
+          acpTool.args ??
+          acpTool.params,
+      ) ?? acpTool,
+      id: stringField(acpTool, "id") ?? stringField(update, "toolCallId"),
+    };
+  }
+
+  return null;
+}
+
+function extractDeepseekToolCall(raw: any): { name: string; params?: unknown; id?: string } | null {
+  const payload = raw?.payload;
+  if (!payload || typeof payload !== "object") return null;
+
+  if (raw?.event === "tool.started") {
+    const tool = payload.tool && typeof payload.tool === "object" ? payload.tool : undefined;
+    return {
+      name: stringField(payload, "name") ?? stringField(tool, "name") ?? "tool",
+      params: parseMaybeJson(payload.input ?? payload.arguments ?? payload.params ?? tool?.input ?? tool?.rawInput),
+      id: stringField(payload, "id") ?? stringField(tool, "id"),
+    };
+  }
+
+  if (payload.event === "item.started") {
+    const inner = payload.payload && typeof payload.payload === "object" ? payload.payload : {};
+    const item = inner.item && typeof inner.item === "object" ? inner.item : undefined;
+    const tool = inner.tool && typeof inner.tool === "object" ? inner.tool : item?.tool;
+    return {
+      name:
+        stringField(tool, "name") ??
+        stringField(inner, "name") ??
+        stringField(item, "name") ??
+        stringField(item, "type") ??
+        "tool",
+      params: parseMaybeJson(
+        tool?.input ??
+          tool?.rawInput ??
+          tool?.arguments ??
+          inner.input ??
+          item?.input ??
+          item?.arguments,
+      ) ?? tool ?? item,
+      id: stringField(tool, "id") ?? stringField(inner, "id") ?? stringField(item, "id"),
+    };
+  }
+
+  return null;
+}
+
+function extractToolResult(raw: any): { name?: string; result: string; id?: string } | null {
+  const deepseek = extractDeepseekToolResult(raw);
+  if (deepseek) return deepseek;
+
+  const item = raw?.item;
+  if (item && typeof item === "object") {
+    const result = item.output ?? item.result ?? item.text ?? item.summary ?? item.diff ?? item.error ?? item;
+    return {
+      name: stringField(item, "type") ?? stringField(item, "name"),
+      result: stringifyDetails(result),
+      id: stringField(item, "id"),
+    };
+  }
+
+  if (raw?.role === "tool") {
+    return {
+      result: stringifyDetails(raw.content),
+      id: stringField(raw, "tool_call_id"),
+    };
+  }
+
+  const update = raw?.params?.update ?? raw?.update;
+  const acpTool = update?.toolCall ?? update?.tool_call ?? update?.tool;
+  if (acpTool && typeof acpTool === "object") {
+    const result =
+      acpTool.output ??
+      acpTool.result ??
+      acpTool.content ??
+      acpTool.error ??
+      update.content ??
+      update;
+    return {
+      name: stringField(acpTool, "name") ?? stringField(update, "name"),
+      result: stringifyDetails(result),
+      id: stringField(acpTool, "id") ?? stringField(update, "toolCallId"),
+    };
+  }
+
+  return null;
+}
+
+function extractDeepseekToolResult(raw: any): { name?: string; result: string; id?: string } | null {
+  const payload = raw?.payload;
+  if (!payload || typeof payload !== "object") return null;
+
+  if (raw?.event === "tool.completed") {
+    const result = payload.output ?? payload.result ?? payload.content ?? payload.error ?? payload;
+    return {
+      name: stringField(payload, "name"),
+      result: stringifyDetails(result),
+      id: stringField(payload, "id"),
+    };
+  }
+
+  if (payload.event === "item.completed" || payload.event === "item.failed") {
+    const inner = payload.payload && typeof payload.payload === "object" ? payload.payload : {};
+    const item = inner.item && typeof inner.item === "object" ? inner.item : undefined;
+    const result =
+      item?.output ??
+      item?.result ??
+      item?.content ??
+      item?.detail ??
+      item?.summary ??
+      item?.error ??
+      inner.output ??
+      inner.result ??
+      inner.error ??
+      item ??
+      inner;
+    return {
+      name: stringField(item, "name") ?? stringField(item, "type") ?? stringField(inner, "name"),
+      result: stringifyDetails(result),
+      id: stringField(item, "id") ?? stringField(inner, "id"),
+    };
+  }
+
+  return null;
+}
+
 function normalizeBlock(
   block: StreamBlockEntry["block"],
   ctx?: { toolNameById?: Record<string, string> },
@@ -123,17 +378,20 @@ function normalizeBlock(
 
   // Legacy shape ------------------------------------------------------------
   if (kind === "tool_call") {
+    const params = payload?.params ?? payload?.input ?? payload?.arguments ?? payload?.details;
     return {
       kind: "tool_call",
       toolName: (payload?.name as string) || "tool",
-      paramHint: summarizeParams(payload?.params as Record<string, unknown> | undefined),
+      paramHint: summarizeParams(params),
+      paramDetails: formatToolParams(params),
       rawKind: kind,
     };
   }
   if (kind === "tool_result" && payload) {
+    const id = typeof payload.tool_use_id === "string" ? payload.tool_use_id : undefined;
     return {
       kind: "tool_result",
-      toolName: (payload.name as string) || "tool",
+      toolName: (payload.name as string) || (id && ctx?.toolNameById?.[id]) || "tool",
       resultStr: String(payload.result ?? ""),
       rawKind: kind,
     };
@@ -157,6 +415,17 @@ function normalizeBlock(
 
   // Daemon-gateway shape (Codex / Claude-code) ------------------------------
   if (kind === "tool_use") {
+    const call = extractToolCall(rawAny);
+    if (call) {
+      return {
+        kind: "tool_call",
+        toolName: call.name,
+        paramHint: summarizeParams(call.params),
+        paramDetails: formatToolParams(call.params),
+        rawKind: kind,
+      };
+    }
+
     // Claude-code: raw.message.content[*] where type === "tool_use"
     const contents = rawAny?.message?.content;
     if (Array.isArray(contents)) {
@@ -165,7 +434,8 @@ function normalizeBlock(
         return {
           kind: "tool_call",
           toolName: (tu.name as string) || "tool",
-          paramHint: summarizeParams((tu.input || tu.arguments) as Record<string, unknown> | undefined),
+          paramHint: summarizeParams(tu.input || tu.arguments),
+          paramDetails: formatToolParams(tu.input || tu.arguments),
           rawKind: kind,
         };
       }
@@ -183,6 +453,7 @@ function normalizeBlock(
         kind: "tool_call",
         toolName: name,
         paramHint: typeof hint === "string" && hint.length > 60 ? hint.slice(0, 60) + "..." : hint ?? null,
+        paramDetails: formatToolParams(item),
         rawKind: kind,
       };
     }
@@ -190,6 +461,16 @@ function normalizeBlock(
   }
 
   if (kind === "tool_result") {
+    const directResult = extractToolResult(rawAny);
+    if (directResult) {
+      return {
+        kind: "tool_result",
+        toolName: directResult.name || "tool",
+        resultStr: directResult.result,
+        rawKind: kind,
+      };
+    }
+
     // Claude-code: raw.message.content[*] where type === "tool_result".
     // The tool name is not on the result itself — look it up via tool_use_id.
     const contents = rawAny?.message?.content;
@@ -295,15 +576,29 @@ function StreamBlockItem({
 
   if (view.kind === "tool_call") {
     const name = view.toolName || "tool";
+    const details = view.paramDetails || "";
     return (
-      <div className="flex items-start gap-2 py-1">
-        <ToolCallIcon name={name} />
-        <div className="min-w-0">
+      <div className="py-1">
+        <button
+          onClick={() => details && setResultExpanded(!resultExpanded)}
+          className="flex items-center gap-2 group min-w-0 text-left"
+        >
+          <ToolCallIcon name={name} />
           <span className="text-xs font-mono text-cyan-400">{name}</span>
-          {view.paramHint && (
-            <p className="text-[10px] text-zinc-500 truncate mt-0.5">{view.paramHint}</p>
+          {details && (
+            resultExpanded
+              ? <ChevronDown className="inline ml-1 w-2.5 h-2.5 text-zinc-500" />
+              : <ChevronRight className="inline ml-1 w-2.5 h-2.5 text-zinc-500" />
           )}
-        </div>
+        </button>
+        {view.paramHint && !resultExpanded && (
+          <p className="mt-0.5 ml-5 text-[10px] text-zinc-500 truncate max-w-[400px]">
+            {view.paramHint}
+          </p>
+        )}
+        {details && resultExpanded && (
+          <ToolResultContent result={details} toolName={`${name} input`} unwrapContentArray={false} />
+        )}
       </div>
     );
   }

--- a/frontend/src/components/dashboard/ToolResultContent.tsx
+++ b/frontend/src/components/dashboard/ToolResultContent.tsx
@@ -248,11 +248,14 @@ export interface ToolResultContentProps {
   result: string;
   /** Tool name (for fullscreen title) */
   toolName?: string;
+  /** Disable Claude content-array unwrapping when rendering tool inputs. */
+  unwrapContentArray?: boolean;
 }
 
 export default function ToolResultContent({
   result,
   toolName = "tool",
+  unwrapContentArray = true,
 }: ToolResultContentProps) {
   const [fullScreen, setFullScreen] = useState(false);
 
@@ -263,7 +266,7 @@ export default function ToolResultContent({
       try {
         const parsed = JSON.parse(trimmed);
         // Claude API content format: { content: [{ type: "text", text: "..." }] }
-        if (parsed?.content?.[0]?.text && typeof parsed.content[0].text === "string") {
+        if (unwrapContentArray && parsed?.content?.[0]?.text && typeof parsed.content[0].text === "string") {
           return parsed.content[0].text as string;
         }
       } catch {
@@ -271,7 +274,7 @@ export default function ToolResultContent({
       }
     }
     return result;
-  }, [result]);
+  }, [result, unwrapContentArray]);
 
   const contentType = useMemo(() => detectContentType(rawText), [rawText]);
   const truncated = rawText.length > MAX_INLINE_CHARS;

--- a/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
+++ b/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
@@ -769,6 +769,30 @@ describe("createBotCordChannel — streamBlock()", () => {
     });
   });
 
+  it("normalizes DeepSeek tool input so the dashboard can expand it", () => {
+    expect(
+      __normalizeBlockForHubForTests(
+        {
+          kind: "tool_use",
+          seq: 4,
+          raw: {
+            event: "tool.started",
+            payload: { id: "tool_1", name: "exec_shell", input: { cmd: "pwd" } },
+          },
+        },
+        4,
+      ),
+    ).toEqual({
+      kind: "tool_call",
+      seq: 4,
+      payload: {
+        id: "tool_1",
+        name: "exec_shell",
+        params: { cmd: "pwd" },
+      },
+    });
+  });
+
   it("POSTs to /hub/stream-block with the right trace_id + block", async () => {
     const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
     const realFetch = globalThis.fetch;

--- a/packages/daemon/src/gateway/channels/botcord.ts
+++ b/packages/daemon/src/gateway/channels/botcord.ts
@@ -153,10 +153,11 @@ function defaultClientFactory(input: {
  */
 function isOwnerTrust(msg: InboxMessage): boolean {
   if (msg.room_id?.startsWith(OWNER_CHAT_PREFIX)) return true;
-  if (msg.source_type === "dashboard_user_chat") return true;
+  const sourceType = msg.source_type as string | undefined;
+  if (sourceType === "dashboard_user_chat") return true;
   // Cloud Agent run tasks are Hub-issued on the user's behalf, same
   // trust posture as owner chat.
-  if (msg.source_type === "cloud_agent_run") return true;
+  if (sourceType === "cloud_agent_run") return true;
   return false;
 }
 
@@ -197,10 +198,11 @@ function normalizeInbox(
   // run completes). All other envelope types (notification, system,
   // contact_added/removed, …) are still filtered out — they belong in
   // a separate push-notification path that daemon does not yet implement.
+  const envType = env.type as string;
   if (
-    env.type !== "message" &&
-    env.type !== "contact_request" &&
-    env.type !== "cloud_run"
+    envType !== "message" &&
+    envType !== "contact_request" &&
+    envType !== "cloud_run"
   )
     return null;
   if (!msg.room_id) return null;
@@ -214,8 +216,9 @@ function normalizeInbox(
 
   const isDm = msg.room_id.startsWith(DM_ROOM_PREFIX);
   const isOwnerChat = msg.room_id.startsWith(OWNER_CHAT_PREFIX);
+  const sourceType = msg.source_type as string | undefined;
   const senderKind: "user" | "agent" =
-    ownerTrust || msg.source_type === "dashboard_human_room" ? "user" : "agent";
+    ownerTrust || sourceType === "dashboard_human_room" ? "user" : "agent";
 
   const senderName = msg.source_user_name ?? undefined;
   const threadId = msg.topic_id ?? msg.topic ?? null;
@@ -1005,45 +1008,25 @@ function normalizeBlockForHub(
   }
 
   if (kind === "tool_use") {
-    // Claude Code: assistant message w/ content[].type === "tool_use" → {id,name,input}
-    // Codex:       item.started for command_execution, file_change, mcp_tool_call, web_search
-    const contents = Array.isArray(raw?.message?.content) ? raw.message.content : [];
-    const tu = contents.find((c: any) => c?.type === "tool_use");
-    if (tu) {
-      payload.name = typeof tu.name === "string" ? tu.name : "tool";
-      if (tu.input && typeof tu.input === "object") payload.params = tu.input;
-      if (typeof tu.id === "string") payload.id = tu.id;
-    } else if (raw?.item && typeof raw.item === "object") {
-      payload.name = typeof raw.item.type === "string" ? raw.item.type : "tool";
-      const params = codexToolParams(raw.item);
-      if (Object.keys(params).length > 0) payload.params = params;
-      if (typeof raw.item.id === "string") payload.id = raw.item.id;
-      if (typeof raw.item.status === "string") payload.status = raw.item.status;
+    // Claude Code, Codex, DeepSeek TUI, Kimi, and ACP all expose tool calls
+    // with slightly different field names. Preserve the real invocation input
+    // so the dashboard can show more than a bare "tool" label.
+    const call = extractToolCall(raw);
+    if (call) {
+      payload.name = call.name;
+      if (call.params !== undefined && !isEmptyRecord(call.params)) payload.params = call.params;
+      if (call.id) payload.id = call.id;
+      if (call.status) payload.status = call.status;
     }
     return { kind: "tool_call", seq, payload };
   }
 
   if (kind === "tool_result") {
-    // Claude Code: {type:"user", message:{content:[{type:"tool_result",tool_use_id,content}]}}
-    // Codex:       item.completed for command_execution, file_change, mcp_tool_call, web_search
-    const contents = Array.isArray(raw?.message?.content) ? raw.message.content : [];
-    const tr = contents.find((c: any) => c?.type === "tool_result");
-    if (tr) {
-      let resultStr = "";
-      if (typeof tr.content === "string") {
-        resultStr = tr.content;
-      } else if (Array.isArray(tr.content)) {
-        resultStr = tr.content
-          .map((c: any) => (typeof c?.text === "string" ? c.text : JSON.stringify(c)))
-          .join("\n");
-      }
-      payload.result = resultStr;
-      if (typeof tr.tool_use_id === "string") payload.tool_use_id = tr.tool_use_id;
-    } else if (raw?.item && typeof raw.item === "object") {
-      payload.name = typeof raw.item.type === "string" ? raw.item.type : "tool";
-      if (typeof raw.item.id === "string") payload.tool_use_id = raw.item.id;
-      const result = codexToolResult(raw.item);
-      if (result) payload.result = result;
+    const result = extractToolResult(raw);
+    if (result) {
+      if (result.name) payload.name = result.name;
+      payload.result = result.result;
+      if (result.id) payload.tool_use_id = result.id;
     }
     return { kind: "tool_result", seq, payload };
   }
@@ -1095,6 +1078,191 @@ function isTerminalRuntimeBlock(raw: any): boolean {
     terminal === "turn.done" ||
     terminal === "done"
   );
+}
+
+function extractToolCall(raw: any): { name: string; params?: unknown; id?: string; status?: string } | null {
+  const contents = Array.isArray(raw?.message?.content) ? raw.message.content : [];
+  const tu = contents.find((c: any) => c?.type === "tool_use");
+  if (tu) {
+    return {
+      name: stringField(tu, "name") ?? "tool",
+      params: parseMaybeJson(tu.input ?? tu.arguments),
+      id: stringField(tu, "id"),
+    };
+  }
+
+  const deepseek = extractDeepseekToolCall(raw);
+  if (deepseek) return deepseek;
+
+  const item = raw?.item;
+  if (item && typeof item === "object") {
+    const params = codexToolParams(item);
+    return {
+      name: stringField(item, "type") ?? stringField(item, "name") ?? "tool",
+      params,
+      id: stringField(item, "id"),
+      status: stringField(item, "status"),
+    };
+  }
+
+  const toolCalls = Array.isArray(raw?.tool_calls) ? raw.tool_calls : [];
+  const toolCall = toolCalls.find((t: any) => t && typeof t === "object");
+  if (toolCall) {
+    const fn = toolCall.function && typeof toolCall.function === "object" ? toolCall.function : undefined;
+    return {
+      name: stringField(fn, "name") ?? stringField(toolCall, "name") ?? "tool",
+      params: parseMaybeJson(fn?.arguments ?? toolCall.arguments ?? toolCall.input ?? toolCall.rawInput),
+      id: stringField(toolCall, "id"),
+    };
+  }
+
+  const update = raw?.params?.update ?? raw?.update;
+  const acpTool = update?.toolCall ?? update?.tool_call ?? update?.tool;
+  if (acpTool && typeof acpTool === "object") {
+    return {
+      name: stringField(acpTool, "name") ?? stringField(update, "name") ?? "tool",
+      params: parseMaybeJson(
+        acpTool.rawInput ??
+          acpTool.raw_input ??
+          acpTool.input ??
+          acpTool.arguments ??
+          acpTool.args ??
+          acpTool.params,
+      ) ?? acpTool,
+      id: stringField(acpTool, "id") ?? stringField(update, "toolCallId"),
+    };
+  }
+
+  return null;
+}
+
+function extractToolResult(raw: any): { name?: string; result: string; id?: string } | null {
+  const contents = Array.isArray(raw?.message?.content) ? raw.message.content : [];
+  const tr = contents.find((c: any) => c?.type === "tool_result");
+  if (tr) {
+    return {
+      result: stringifyToolResult(tr.content),
+      id: stringField(tr, "tool_use_id"),
+    };
+  }
+
+  const deepseek = extractDeepseekToolResult(raw);
+  if (deepseek) return deepseek;
+
+  const item = raw?.item;
+  if (item && typeof item === "object") {
+    const result = codexToolResult(item);
+    return {
+      name: stringField(item, "type") ?? stringField(item, "name"),
+      result: result || stringifyToolResult(item),
+      id: stringField(item, "id"),
+    };
+  }
+
+  if (raw?.role === "tool") {
+    return {
+      result: stringifyToolResult(raw.content),
+      id: stringField(raw, "tool_call_id"),
+    };
+  }
+
+  const update = raw?.params?.update ?? raw?.update;
+  const acpTool = update?.toolCall ?? update?.tool_call ?? update?.tool;
+  if (acpTool && typeof acpTool === "object") {
+    const result =
+      acpTool.output ??
+      acpTool.result ??
+      acpTool.content ??
+      acpTool.error ??
+      update.content ??
+      update;
+    return {
+      name: stringField(acpTool, "name") ?? stringField(update, "name"),
+      result: stringifyToolResult(result),
+      id: stringField(acpTool, "id") ?? stringField(update, "toolCallId"),
+    };
+  }
+
+  return null;
+}
+
+function extractDeepseekToolCall(raw: any): { name: string; params?: unknown; id?: string; status?: string } | null {
+  const payload = raw?.payload;
+  if (!payload || typeof payload !== "object") return null;
+
+  if (raw?.event === "tool.started") {
+    const tool = payload.tool && typeof payload.tool === "object" ? payload.tool : undefined;
+    return {
+      name: stringField(payload, "name") ?? stringField(tool, "name") ?? "tool",
+      params: parseMaybeJson(payload.input ?? payload.arguments ?? payload.params ?? tool?.input ?? tool?.rawInput),
+      id: stringField(payload, "id") ?? stringField(tool, "id"),
+      status: stringField(payload, "status") ?? stringField(tool, "status"),
+    };
+  }
+
+  if (payload.event === "item.started") {
+    const inner = payload.payload && typeof payload.payload === "object" ? payload.payload : {};
+    const item = inner.item && typeof inner.item === "object" ? inner.item : undefined;
+    const tool = inner.tool && typeof inner.tool === "object" ? inner.tool : item?.tool;
+    return {
+      name:
+        stringField(tool, "name") ??
+        stringField(inner, "name") ??
+        stringField(item, "name") ??
+        stringField(item, "type") ??
+        "tool",
+      params: parseMaybeJson(
+        tool?.input ??
+          tool?.rawInput ??
+          tool?.arguments ??
+          inner.input ??
+          item?.input ??
+          item?.arguments,
+      ) ?? tool ?? item,
+      id: stringField(tool, "id") ?? stringField(inner, "id") ?? stringField(item, "id"),
+      status: stringField(tool, "status") ?? stringField(inner, "status") ?? stringField(item, "status"),
+    };
+  }
+
+  return null;
+}
+
+function extractDeepseekToolResult(raw: any): { name?: string; result: string; id?: string } | null {
+  const payload = raw?.payload;
+  if (!payload || typeof payload !== "object") return null;
+
+  if (raw?.event === "tool.completed") {
+    const result = payload.output ?? payload.result ?? payload.content ?? payload.error ?? payload;
+    return {
+      name: stringField(payload, "name"),
+      result: stringifyToolResult(result),
+      id: stringField(payload, "id"),
+    };
+  }
+
+  if (payload.event === "item.completed" || payload.event === "item.failed") {
+    const inner = payload.payload && typeof payload.payload === "object" ? payload.payload : {};
+    const item = inner.item && typeof inner.item === "object" ? inner.item : undefined;
+    const result =
+      item?.output ??
+      item?.result ??
+      item?.content ??
+      item?.detail ??
+      item?.summary ??
+      item?.error ??
+      inner.output ??
+      inner.result ??
+      inner.error ??
+      item ??
+      inner;
+    return {
+      name: stringField(item, "name") ?? stringField(item, "type") ?? stringField(inner, "name"),
+      result: stringifyToolResult(result),
+      id: stringField(item, "id") ?? stringField(inner, "id"),
+    };
+  }
+
+  return null;
 }
 
 function formatBlockDetails(raw: unknown): string {
@@ -1166,6 +1334,47 @@ function codexToolResult(item: Record<string, unknown>): string {
   }
 
   return parts.join("\n");
+}
+
+function stringifyToolResult(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    return value
+      .map((c: any) => {
+        if (typeof c === "string") return c;
+        if (typeof c?.text === "string") return c.text;
+        return stringifyToolResult(c);
+      })
+      .filter(Boolean)
+      .join("\n");
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function parseMaybeJson(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  const trimmed = value.trim();
+  if (!trimmed) return value;
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return value;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return value;
+  }
+}
+
+function isEmptyRecord(value: unknown): boolean {
+  return !!value && typeof value === "object" && !Array.isArray(value) && Object.keys(value).length === 0;
+}
+
+function stringField(obj: any, key: string): string | undefined {
+  const value = obj?.[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
 function extractContentText(content: unknown): string {


### PR DESCRIPTION
## Summary
- preserve real runtime tool inputs/results when normalizing stream blocks for the dashboard
- add expandable tool-call input rendering in owner chat stream blocks
- cover DeepSeek tool input normalization and keep latest Codex tool-result handling

## Tests
- cd packages/daemon && npm test -- --run
- cd packages/daemon && npm run build
- cd frontend && NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build