### PR TITLE
fix: improve mobile dashboard tabs

### DIFF
--- a/frontend/src/components/dashboard/ContactsDetailPane.tsx
+++ b/frontend/src/components/dashboard/ContactsDetailPane.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "nextjs-toploader/app";
-import { MessageCircle, Settings2, Share2, SlidersHorizontal, UserCircle, Users } from "lucide-react";
+import { ArrowLeft, MessageCircle, SlidersHorizontal, UserCircle, Users } from "lucide-react";
 import { useShallow } from "zustand/shallow";
 import { api } from "@/lib/api";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
@@ -104,6 +104,7 @@ export default function ContactsDetailPane() {
   const t = contactsUiI18n[useLanguage()];
   const [messageBusy, setMessageBusy] = useState(false);
   const selectedContactKey = useDashboardUIStore((s) => s.selectedContactKey);
+  const setSelectedContactKey = useDashboardUIStore((s) => s.setSelectedContactKey);
   const setBotDetailAgentId = useDashboardUIStore((s) => s.setBotDetailAgentId);
   const setPeerBotAgentId = useDashboardUIStore((s) => s.setPeerBotAgentId);
   const {
@@ -269,7 +270,16 @@ export default function ContactsDetailPane() {
   };
 
   return (
-    <div className="flex h-full w-full flex-1 flex-col bg-deep-black">
+    <div className="relative flex h-full w-full flex-1 flex-col bg-deep-black">
+      <button
+        type="button"
+        onClick={() => setSelectedContactKey(null)}
+        className="absolute left-2 top-2 hidden h-9 w-9 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary max-md:inline-flex"
+        aria-label="Back to contacts"
+        title="Back to contacts"
+      >
+        <ArrowLeft className="h-5 w-5" />
+      </button>
       <div className="flex flex-1 flex-col items-center justify-center px-6 py-10">
         {avatar}
         <div className="mt-5 flex items-center gap-2">

--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -1019,20 +1019,35 @@ export default function DashboardApp() {
     }
   };
 
-  const mobileShowsMain =
+  const mobileMessagesShowsMain =
+    routeSidebarTab === "messages"
+    && (
+      uiStore.messagesShowRequests
+      || uiStore.messagesPane === "user-chat"
+      || Boolean(uiStore.openedRoomId)
+    );
+  const mobileContactsShowsMain =
     routeSidebarTab === "contacts"
+    && (
+      uiStore.contactsView === "requests"
+      || Boolean(uiStore.selectedContactKey)
+    );
+  const mobileShowsMain =
+    routeSidebarTab === "home"
     || routeSidebarTab === "explore"
     || routeSidebarTab === "wallet"
     || routeSidebarTab === "activity"
-    || (routeSidebarTab === "messages" && (uiStore.messagesPane === "user-chat" || Boolean(uiStore.openedRoomId)))
-    || (routeSidebarTab === "bots" && Boolean(uiStore.selectedBotAgentId));
+    || routeSidebarTab === "bots"
+    || mobileMessagesShowsMain
+    || mobileContactsShowsMain;
   const mobileHideSecondary =
-    routeSidebarTab === "wallet"
+    routeSidebarTab === "home"
+    || routeSidebarTab === "wallet"
     || routeSidebarTab === "activity"
     || routeSidebarTab === "explore"
-    || routeSidebarTab === "contacts"
-    || (routeSidebarTab === "messages" && (uiStore.messagesPane === "user-chat" || Boolean(uiStore.openedRoomId)))
-    || (routeSidebarTab === "bots" && Boolean(uiStore.selectedBotAgentId));
+    || routeSidebarTab === "bots"
+    || mobileMessagesShowsMain
+    || mobileContactsShowsMain;
   const mainPaneClass = `min-h-0 min-w-0 flex-1 ${mobileShowsMain ? "" : "max-md:hidden"}`;
   const primaryNavigationPending = Boolean(
     uiStore.pendingPrimaryNavigation && pathname !== uiStore.pendingPrimaryNavigation.path,

--- a/frontend/src/components/dashboard/sidebar/index.tsx
+++ b/frontend/src/components/dashboard/sidebar/index.tsx
@@ -320,9 +320,9 @@ export default function Sidebar({
   };
 
   return (
-    <div className={`flex h-full max-md:w-full max-md:flex-col-reverse ${mobileHideSecondary ? "max-md:h-16" : "max-md:h-full"}`}>
+    <div className={`flex h-full max-md:w-full max-md:flex-col-reverse ${mobileHideSecondary ? "max-md:h-[calc(4rem+env(safe-area-inset-bottom))]" : "max-md:h-full"}`}>
       {/* Primary rail */}
-      <div className="flex h-full w-16 min-w-[64px] flex-col items-center border-r border-glass-border bg-deep-black py-3 max-md:h-16 max-md:w-full max-md:min-w-0 max-md:shrink-0 max-md:flex-row max-md:border-r-0 max-md:border-t max-md:px-2 max-md:py-2">
+      <div className="flex h-full w-16 min-w-[64px] flex-col items-center border-r border-glass-border bg-deep-black py-3 max-md:h-[calc(4rem+env(safe-area-inset-bottom))] max-md:w-full max-md:min-w-0 max-md:shrink-0 max-md:flex-row max-md:border-r-0 max-md:border-t max-md:px-2 max-md:pb-[env(safe-area-inset-bottom)] max-md:pt-2">
         <Link
           href="/"
           className="mb-3 flex h-11 w-11 items-center justify-center rounded-xl border border-glass-border bg-deep-black-light transition-colors hover:border-neon-cyan/50 hover:bg-glass-bg max-md:mb-0 max-md:mr-2 max-md:hidden"
@@ -365,7 +365,7 @@ export default function Sidebar({
           })}
         </div>
 
-        <div className="flex flex-col items-center gap-2 border-t border-glass-border pt-3 max-md:ml-2 max-md:border-l max-md:border-t-0 max-md:pl-2 max-md:pt-0">
+        <div className="flex flex-col items-center gap-2 border-t border-glass-border pt-3 max-md:ml-1 max-md:shrink-0 max-md:gap-1 max-md:border-l max-md:border-t-0 max-md:pl-1 max-md:pt-0">
           <button
             onClick={() => setLanguage(locale === "zh" ? "en" : "zh")}
             aria-label="Toggle language"
@@ -436,7 +436,7 @@ export default function Sidebar({
         <button
           type="button"
           aria-label="Close sidebar"
-          className="fixed inset-x-0 bottom-16 top-0 z-30 hidden bg-black/45 backdrop-blur-sm max-md:block"
+          className="fixed inset-x-0 bottom-[calc(4rem+env(safe-area-inset-bottom))] top-0 z-30 hidden bg-black/45 backdrop-blur-sm max-md:block"
           onClick={onMobileSecondaryClose}
         />
       )}
@@ -447,7 +447,7 @@ export default function Sidebar({
         className={`relative flex h-full flex-col border-r border-glass-border bg-deep-black-light max-md:min-h-0 max-md:flex-1 max-md:!min-w-0 max-md:border-r-0 ${
           mobileHideSecondary
             ? mobileSecondaryOpen
-              ? "max-md:fixed max-md:inset-x-3 max-md:bottom-20 max-md:top-4 max-md:z-40 max-md:!w-auto max-md:rounded-xl max-md:border max-md:border-glass-border max-md:shadow-2xl max-md:shadow-black/50"
+              ? "max-md:fixed max-md:inset-x-3 max-md:bottom-[calc(5rem+env(safe-area-inset-bottom))] max-md:top-4 max-md:z-40 max-md:!w-auto max-md:rounded-xl max-md:border max-md:border-glass-border max-md:shadow-2xl max-md:shadow-black/50"
               : "max-md:hidden"
             : "max-md:!w-full"
         }`}
@@ -503,7 +503,9 @@ export default function Sidebar({
         {/* Panel content */}
         <div className="flex flex-1 min-h-0">
           {!secondaryPanelLoading && showMessagesGrouping && (
-            <MessagesGroupingSidebar />
+            <div className="max-md:hidden">
+              <MessagesGroupingSidebar />
+            </div>
           )}
           <div className="min-w-0 flex-1 overflow-y-auto overflow-x-hidden">
           {secondaryPanelLoading ? (


### PR DESCRIPTION
Summary:
- show the correct main/list pane for mobile dashboard tabs
- keep Messages grouping from crowding the mobile conversation list
- account for iPhone bottom safe area and add a mobile back action for contact details

Tests:
- NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build