### PR TITLE
fix: create gateway ingress ecr repository

### DIFF
--- a/.github/workflows/deploy-gateway-ingress.yml
+++ b/.github/workflows/deploy-gateway-ingress.yml
@@ -55,10 +55,18 @@ jobs:
       - name: Push to ECR
         run: |
           ENV_NAME="${{ inputs.env_name }}"
+          IMAGE_REPOSITORY="botlearn-ai/$PROJECT"
           aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $ECR_REGISTRY
-          docker tag $PROJECT:$ENV_NAME $ECR_REGISTRY/botlearn-ai/$PROJECT:$ENV_NAME
-          docker push $ECR_REGISTRY/botlearn-ai/$PROJECT:$ENV_NAME
-          echo "✅ Pushed $ECR_REGISTRY/botlearn-ai/$PROJECT:$ENV_NAME"
+          if ! aws ecr describe-repositories --region us-east-1 --repository-names "$IMAGE_REPOSITORY" >/dev/null 2>&1; then
+            if aws ecr create-repository --region us-east-1 --repository-name "$IMAGE_REPOSITORY" >/dev/null; then
+              echo "✅ Created ECR repository $IMAGE_REPOSITORY"
+            else
+              aws ecr describe-repositories --region us-east-1 --repository-names "$IMAGE_REPOSITORY" >/dev/null
+            fi
+          fi
+          docker tag $PROJECT:$ENV_NAME $ECR_REGISTRY/$IMAGE_REPOSITORY:$ENV_NAME
+          docker push $ECR_REGISTRY/$IMAGE_REPOSITORY:$ENV_NAME
+          echo "✅ Pushed $ECR_REGISTRY/$IMAGE_REPOSITORY:$ENV_NAME"
 
   # ── Restart preview (docker-compose) ─────────────────────────────────────────
   restart-preview:


### PR DESCRIPTION
## Summary
- ensure the gateway-ingress ECR repository exists before pushing the image
- keep the existing botlearn-ai/botcord-gateway-ingress image path
- tolerate a concurrent repository creation by re-checking ECR

## Validation
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-gateway-ingress.yml")'