### PR TITLE
fix: show contact request start time

### DIFF
--- a/frontend/src/components/dashboard/ContactRequestsInbox.tsx
+++ b/frontend/src/components/dashboard/ContactRequestsInbox.tsx
@@ -2,7 +2,7 @@
 
 /**
  * [INPUT]: 依赖 contact store 的 received/sent requests、humansApi pending approvals 与 respond/resolve 动作；本地状态控制 received/sent sub-tab 与 Bot 分组折叠
- * [OUTPUT]: ContactRequestsInbox — 联系人申请收件箱，Human 请求置顶、Bot 收到的请求按目标 Bot 折叠分组、Sent tab 展示发出请求
+ * [OUTPUT]: ContactRequestsInbox — 联系人申请收件箱，Human 请求置顶、Bot 收到的请求按目标 Bot 折叠分组、Sent tab 展示发出请求并显示发起时间
  * [POS]: 联系人申请处理模块的复用组件
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
@@ -308,6 +308,35 @@ function payloadString(payload: Record<string, unknown>, key: string): string | 
   return typeof value === "string" && value.trim() ? value : null;
 }
 
+function formatRequestStartedAt(value: string | number | null | undefined, locale: Locale): string | null {
+  if (value === null || value === undefined || value === "" || value === 0) return null;
+  const timestamp = typeof value === "number" && value < 1_000_000_000_000 ? value * 1000 : value;
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleString(locale === "zh" ? "zh-CN" : "en-US", {
+    dateStyle: "short",
+    timeStyle: "short",
+  });
+}
+
+function RequestStartedAt({
+  value,
+  locale,
+  label,
+}: {
+  value: string | number | null | undefined;
+  locale: Locale;
+  label: string;
+}) {
+  const formatted = formatRequestStartedAt(value, locale);
+  if (!formatted) return null;
+  return (
+    <p className="mt-3 text-[10px] text-text-secondary/50">
+      {label} {formatted}
+    </p>
+  );
+}
+
 function ReceivedRequestCard({
   req,
   locale,
@@ -352,6 +381,7 @@ function ReceivedRequestCard({
       <p className="mt-3 line-clamp-3 min-h-[48px] text-xs text-text-secondary">
         {req.message || t.noRequestMessage}
       </p>
+      <RequestStartedAt value={req.created_at} locale={locale} label={t.requestStartedAt} />
       <div className="mt-3 flex items-center gap-2">
         <button
           onClick={() => onRespond(req.id, "accept")}
@@ -420,6 +450,7 @@ function BotApprovalCard({
       <p className="mt-3 line-clamp-3 min-h-[48px] text-xs text-text-secondary">
         {message || t.noRequestMessage}
       </p>
+      <RequestStartedAt value={approval.created_at} locale={locale} label={t.requestStartedAt} />
       <div className="mt-3 flex items-center gap-2">
         <button
           type="button"
@@ -496,9 +527,7 @@ function SentRequestCard({
       <p className="mt-3 line-clamp-3 min-h-[48px] text-xs text-text-secondary">
         {req.message || t.noRequestMessage}
       </p>
-      <p className="mt-3 text-[10px] text-text-secondary/50">
-        {new Date(req.created_at).toLocaleString()}
-      </p>
+      <RequestStartedAt value={req.created_at} locale={locale} label={t.requestStartedAt} />
     </div>
   );
 }

--- a/frontend/src/components/dashboard/README.md
+++ b/frontend/src/components/dashboard/README.md
@@ -77,6 +77,7 @@ dashboard/
 
 ## 变更日志
 
+- 2026-05-24: `ContactRequestsInbox.tsx` 在收到的好友申请、Bot 审批申请和已发送申请卡片上统一显示发起时间，避免申请列表只展示对象和消息却无法判断先后。
 - 2026-05-19: `/chats/messages` 刷新不再预取其它 tab 的 RSC 路由，也不再后台预热公开目录和钱包接口；MessagesPanel 复用 Sidebar 的联系人请求加载，避免 received/sent/pending-approvals 重复请求。
 - 2026-05-14: `DashboardShellSkeleton.tsx`、`DashboardApp.tsx`、`Sidebar.tsx` 与 `ChatPane.tsx` 改为按 `/chats` 当前路径推导首帧 tab；刷新 Home/Explore/Contacts/Wallet/My Bots 时不再误用 Messages 会话骨架或默认消息视图。
 - 2026-05-14: 移除 Messages 里的 Bot 身份切换能力；点击自有 Bot 私聊、Bot 详情私聊、联系人里的 owned-bot 私聊都不再重绑 chat store 或强制刷新消息列表。

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -435,6 +435,7 @@ export const chatPane: TranslationMap<{
   requestsTabReceived: string
   requestsTabSent: string
   noSentRequests: string
+  requestStartedAt: string
   sentRequestPending: string
   sentRequestAccepted: string
   sentRequestRejected: string
@@ -493,6 +494,7 @@ export const chatPane: TranslationMap<{
     requestsTabReceived: 'Received',
     requestsTabSent: 'Sent',
     noSentRequests: 'You haven\'t sent any requests yet.',
+    requestStartedAt: 'Requested at',
     sentRequestPending: 'Awaiting reply',
     sentRequestAccepted: 'Accepted',
     sentRequestRejected: 'Rejected',
@@ -551,6 +553,7 @@ export const chatPane: TranslationMap<{
     requestsTabReceived: '收到',
     requestsTabSent: '已发送',
     noSentRequests: '你还没有发出任何申请。',
+    requestStartedAt: '发起时间',
     sentRequestPending: '等待回复',
     sentRequestAccepted: '已接受',
     sentRequestRejected: '已拒绝',


### PR DESCRIPTION
## Summary
- show the request start time on received contact request cards, bot approval cards, and sent request cards
- add localized labels for the request start time
- update the dashboard component changelog

## Tests
- git diff --check
- NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy-anon-key npm run build