### PR TITLE
fix: use published protocol-core in daemon package

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@botcord/cli": "^0.1.7",
-    "@botcord/protocol-core": "file:../protocol-core",
+    "@botcord/protocol-core": "^0.2.9",
     "@larksuiteoapi/node-sdk": "^1.63.1",
     "ws": "^8.20.1"
   },


### PR DESCRIPTION
## Summary
- replace the daemon package's local file dependency on @botcord/protocol-core with the published package range
- fixes npx installs of @botcord/daemon failing outside the monorepo because ../protocol-core does not exist

## Verification
- cd packages/daemon && npm install --package-lock=false
- cd packages/daemon && npm run build
- cd packages/daemon && npm test
- packed package smoke install in a temp project; verified no ERR_MODULE_NOT_FOUND / Cannot find package