### PR TITLE
fix: load cloud agent runtime files

### DIFF
--- a/backend/app/routers/runtime_files.py
+++ b/backend/app/routers/runtime_files.py
@@ -19,7 +19,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import RequestContext, require_user
 from hub.database import get_db
-from hub.models import Agent
+from hub.models import Agent, CloudAgentInstance
+from hub.routers.cloud_daemon_control import (
+    CloudDaemonDispatchError,
+    is_cloud_daemon_online,
+    send_cloud_control_frame,
+)
 from hub.routers.daemon_control import is_daemon_online, send_control_frame
 
 logger = logging.getLogger(__name__)
@@ -46,6 +51,11 @@ class AgentRuntimeFilesOut(BaseModel):
     files: list[AgentRuntimeFileOut]
 
 
+class _RuntimeFilesHost(BaseModel):
+    daemon_instance_id: str
+    cloud_daemon_instance_id: str | None = None
+
+
 async def _load_owned_agent(db: AsyncSession, ctx: RequestContext, agent_id: str) -> Agent:
     result = await db.execute(
         select(Agent).where(
@@ -60,6 +70,71 @@ async def _load_owned_agent(db: AsyncSession, ctx: RequestContext, agent_id: str
     return agent
 
 
+async def _load_runtime_files_host(
+    db: AsyncSession,
+    ctx: RequestContext,
+    agent: Agent,
+) -> _RuntimeFilesHost:
+    if agent.hosting_kind == "cloud":
+        if not agent.daemon_instance_id:
+            raise HTTPException(status_code=409, detail="agent_not_daemon_hosted")
+        binding = await db.scalar(
+            select(CloudAgentInstance).where(
+                CloudAgentInstance.agent_id == agent.agent_id,
+                CloudAgentInstance.user_id == ctx.user_id,
+                CloudAgentInstance.status.notin_(("deleting", "deleted")),
+            )
+        )
+        if binding is None:
+            raise HTTPException(status_code=409, detail="agent_not_daemon_hosted")
+        return _RuntimeFilesHost(
+            daemon_instance_id=binding.daemon_instance_id,
+            cloud_daemon_instance_id=binding.cloud_daemon_instance_id,
+        )
+
+    if not agent.daemon_instance_id:
+        raise HTTPException(status_code=409, detail="agent_not_daemon_hosted")
+    return _RuntimeFilesHost(daemon_instance_id=agent.daemon_instance_id)
+
+
+async def _send_runtime_files_control_frame(
+    host: _RuntimeFilesHost,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    if host.cloud_daemon_instance_id:
+        if not is_cloud_daemon_online(host.cloud_daemon_instance_id):
+            raise HTTPException(status_code=409, detail="daemon_offline")
+        try:
+            return await send_cloud_control_frame(
+                host.cloud_daemon_instance_id,
+                "list_agent_files",
+                params,
+                timeout_ms=5000,
+            )
+        except CloudDaemonDispatchError as exc:
+            if exc.code in {
+                "cloud_daemon_offline",
+                "cloud_daemon_disconnected",
+                "cloud_daemon_send_failed",
+            }:
+                raise HTTPException(status_code=409, detail="daemon_offline") from exc
+            if exc.code == "cloud_daemon_ack_timeout":
+                raise HTTPException(status_code=504, detail="daemon_ack_timeout") from exc
+            raise HTTPException(
+                status_code=502,
+                detail={"code": exc.code, "daemon_message": exc.message},
+            ) from exc
+
+    if not is_daemon_online(host.daemon_instance_id):
+        raise HTTPException(status_code=409, detail="daemon_offline")
+    return await send_control_frame(
+        host.daemon_instance_id,
+        "list_agent_files",
+        params,
+        timeout_ms=5000,
+    )
+
+
 @router.get("/{agent_id}/runtime-files", response_model=AgentRuntimeFilesOut)
 async def get_agent_runtime_files(
     agent_id: str,
@@ -68,21 +143,13 @@ async def get_agent_runtime_files(
     db: AsyncSession = Depends(get_db),
 ) -> AgentRuntimeFilesOut:
     agent = await _load_owned_agent(db, ctx, agent_id)
-    if not agent.daemon_instance_id:
-        raise HTTPException(status_code=409, detail="agent_not_daemon_hosted")
-    if not is_daemon_online(agent.daemon_instance_id):
-        raise HTTPException(status_code=409, detail="daemon_offline")
+    host = await _load_runtime_files_host(db, ctx, agent)
 
     params: dict[str, Any] = {"agentId": agent.agent_id}
     if file_id:
         params["fileId"] = file_id
 
-    ack = await send_control_frame(
-        agent.daemon_instance_id,
-        "list_agent_files",
-        params,
-        timeout_ms=5000,
-    )
+    ack = await _send_runtime_files_control_frame(host, params)
     if not isinstance(ack, dict) or not ack.get("ok"):
         err = ack.get("error") if isinstance(ack, dict) else None
         code = (err or {}).get("code") if isinstance(err, dict) else None

--- a/backend/tests/test_app/test_app_policy.py
+++ b/backend/tests/test_app/test_app_policy.py
@@ -25,6 +25,9 @@ from hub.models import (
     Agent,
     AgentRoomPolicyOverride,
     Base,
+    CloudAgentInstance,
+    CloudDaemonInstance,
+    DaemonInstance,
     Role,
     Room,
     RoomMember,
@@ -257,6 +260,93 @@ async def test_runtime_files_for_owned_daemon_agent_dispatches_control_frame(
             "daemon_instance_id": "dm_files",
             "type": "list_agent_files",
             "params": {"agentId": "ag_owned", "fileId": "memory:working-memory.json"},
+            "timeout_ms": 5000,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_runtime_files_for_owned_cloud_agent_dispatches_cloud_control_frame(
+    client, seed, db_session, monkeypatch
+):
+    from app.routers import runtime_files as runtime_files_mod
+
+    row = await db_session.execute(select(Agent).where(Agent.agent_id == "ag_owned"))
+    agent = row.scalar_one()
+    agent.hosting_kind = "cloud"
+    agent.daemon_instance_id = "dm_cloudfiles"
+    agent.runtime = "codex"
+    daemon = DaemonInstance(
+        id="dm_cloudfiles",
+        user_id=agent.user_id,
+        kind="cloud",
+        refresh_token_hash="hash",
+    )
+    cloud_daemon = CloudDaemonInstance(
+        id="cloud_dm_files",
+        user_id=agent.user_id,
+        daemon_instance_id=daemon.id,
+        provider="e2b",
+        status="ready",
+        runtime="codex",
+        max_agents=1,
+        active_agent_count=1,
+    )
+    cloud_binding = CloudAgentInstance(
+        id="cloud_ag_files",
+        user_id=agent.user_id,
+        agent_id=agent.agent_id,
+        cloud_daemon_instance_id=cloud_daemon.id,
+        daemon_instance_id=daemon.id,
+        runtime="codex",
+        model_profile="default",
+        status="ready",
+    )
+    db_session.add_all([daemon, cloud_daemon, cloud_binding])
+    await db_session.commit()
+
+    monkeypatch.setattr(
+        runtime_files_mod,
+        "is_cloud_daemon_online",
+        lambda cloud_daemon_id: cloud_daemon_id == "cloud_dm_files",
+    )
+
+    calls = []
+
+    async def fake_send_cloud(cloud_daemon_instance_id, type_, params=None, timeout_ms=None):
+        calls.append({
+            "cloud_daemon_instance_id": cloud_daemon_instance_id,
+            "type": type_,
+            "params": params,
+            "timeout_ms": timeout_ms,
+        })
+        return {
+            "ok": True,
+            "result": {
+                "agentId": "ag_owned",
+                "runtime": "codex",
+                "files": [
+                    {
+                        "id": "workspace:AGENTS.md",
+                        "name": "AGENTS.md",
+                        "scope": "workspace",
+                        "content": "# rules\n",
+                    }
+                ],
+            },
+        }
+
+    monkeypatch.setattr(runtime_files_mod, "send_cloud_control_frame", fake_send_cloud)
+
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    r = await client.get("/api/agents/ag_owned/runtime-files", headers=headers)
+    assert r.status_code == 200, r.text
+    assert r.json()["files"][0]["content"] == "# rules\n"
+    assert calls == [
+        {
+            "cloud_daemon_instance_id": "cloud_dm_files",
+            "type": "list_agent_files",
+            "params": {"agentId": "ag_owned"},
             "timeout_ms": 5000,
         }
     ]

--- a/frontend/src/components/dashboard/AgentSettingsDrawer.tsx
+++ b/frontend/src/components/dashboard/AgentSettingsDrawer.tsx
@@ -186,6 +186,25 @@ function scopeLabel(scope: AgentRuntimeFile["scope"]): string {
   return "Workspace";
 }
 
+function runtimeFilesErrorMessage(data: any, status: number, t: BotDetailDrawerCopy): string {
+  const detail = data?.detail;
+  const code =
+    typeof detail === "string"
+      ? detail
+      : typeof detail?.code === "string"
+        ? detail.code
+        : typeof data?.error === "string"
+          ? data.error
+          : null;
+  if (status === 409 || code === "daemon_offline" || code === "agent_not_daemon_hosted") {
+    return t.files.daemonUnavailable;
+  }
+  if (typeof data?.error === "string") return data.error;
+  if (typeof detail === "string") return detail;
+  if (typeof detail?.code === "string") return detail.code;
+  return t.files.loadFailed;
+}
+
 function contactOptions(t: BotDetailDrawerCopy): { value: ContactPolicy; label: string; hint: string }[] {
   return [
     { value: "open", ...t.settings.contactOptions.open },
@@ -361,18 +380,7 @@ export default function AgentSettingsDrawer({
       });
       if (!res.ok) {
         const data = await res.json().catch(() => null);
-        const detail = data?.detail;
-        const msg =
-          typeof data?.error === "string"
-            ? data.error
-            : typeof detail === "string"
-              ? detail
-              : typeof detail?.code === "string"
-                  ? detail.code
-                : res.status === 409
-                  ? t.files.daemonUnavailable
-                  : t.files.loadFailed;
-        throw new Error(msg);
+        throw new Error(runtimeFilesErrorMessage(data, res.status, t));
       }
       const data = (await res.json()) as AgentRuntimeFilesResponse;
       const files = Array.isArray(data.files) ? data.files : [];

--- a/frontend/src/components/dashboard/BotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/BotDetailDrawer.tsx
@@ -930,18 +930,7 @@ function FilesTab({ agentId, t }: { agentId: string; t: BotDetailDrawerCopy }) {
       });
       if (!res.ok) {
         const data = await res.json().catch(() => null);
-        const detail = data?.detail;
-        const msg =
-          typeof data?.error === "string"
-            ? data.error
-            : typeof detail === "string"
-              ? detail
-              : typeof detail?.code === "string"
-                ? detail.code
-                : res.status === 409
-                  ? t.files.daemonUnavailable
-                  : t.files.loadFailed;
-        throw new Error(msg);
+        throw new Error(runtimeFilesErrorMessage(data, res.status, t));
       }
       const data = (await res.json()) as AgentRuntimeFilesResponse;
       const nextFiles = Array.isArray(data.files) ? data.files : [];
@@ -1114,4 +1103,23 @@ function scopeLabel(scope: AgentRuntimeFile["scope"]): string {
   if (scope === "hermes") return "Hermes";
   if (scope === "openclaw") return "OpenClaw";
   return "Workspace";
+}
+
+function runtimeFilesErrorMessage(data: any, status: number, t: BotDetailDrawerCopy): string {
+  const detail = data?.detail;
+  const code =
+    typeof detail === "string"
+      ? detail
+      : typeof detail?.code === "string"
+        ? detail.code
+        : typeof data?.error === "string"
+          ? data.error
+          : null;
+  if (status === 409 || code === "daemon_offline" || code === "agent_not_daemon_hosted") {
+    return t.files.daemonUnavailable;
+  }
+  if (typeof data?.error === "string") return data.error;
+  if (typeof detail === "string") return detail;
+  if (typeof detail?.code === "string") return detail.code;
+  return t.files.loadFailed;
 }


### PR DESCRIPTION
## Summary
- route runtime-files requests for cloud-hosted agents through the cloud daemon control plane
- keep local daemon-hosted runtime-files behavior unchanged
- map runtime-files offline/not-hosted errors to the existing user-facing unavailable copy

## Tests
- cd backend && uv run pytest tests/test_app/test_app_policy.py -q
- cd frontend && NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy pnpm run build