### PR TITLE
fix: raise cloud agent sandbox capacity

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -37,6 +37,8 @@ RESEND_FROM_EMAIL=BotCord <noreply@mail.app.botcord.chat>
 
 # Cloud Agent
 CLOUD_AGENT_FEATURE_ENABLED=false
+CLOUD_AGENT_MAX_PER_USER=5
+CLOUD_AGENT_DEFAULT_MAX_AGENTS_PER_DAEMON=5
 # Use e2b for any environment where Cloud Agents should actually reply.
 # Local tests/dev may set this to fake intentionally.
 CLOUD_AGENT_DEFAULT_PROVIDER=e2b

--- a/backend/hub/config.py
+++ b/backend/hub/config.py
@@ -307,7 +307,7 @@ CLOUD_AGENT_FEATURE_ENABLED: bool = os.getenv(
     "CLOUD_AGENT_FEATURE_ENABLED", "false"
 ).lower() in ("true", "1", "yes")
 
-CLOUD_AGENT_MAX_PER_USER: int = int(os.getenv("CLOUD_AGENT_MAX_PER_USER", "3"))
+CLOUD_AGENT_MAX_PER_USER: int = int(os.getenv("CLOUD_AGENT_MAX_PER_USER", "5"))
 
 CLOUD_AGENT_DEFAULT_RUNTIME: str = os.getenv(
     "CLOUD_AGENT_DEFAULT_RUNTIME", "deepseek-tui"
@@ -325,7 +325,7 @@ CLOUD_AGENT_DEFAULT_PROVIDER: str = os.getenv("CLOUD_AGENT_DEFAULT_PROVIDER", "e
 # Slot capacity per cloud daemon — schema allows >1 to keep the per-agent
 # sandbox cost down. Conservative default while we observe real load.
 CLOUD_AGENT_DEFAULT_MAX_AGENTS_PER_DAEMON: int = int(
-    os.getenv("CLOUD_AGENT_DEFAULT_MAX_AGENTS_PER_DAEMON", str(CLOUD_AGENT_MAX_PER_USER))
+    os.getenv("CLOUD_AGENT_DEFAULT_MAX_AGENTS_PER_DAEMON", "5")
 )
 
 CLOUD_AGENT_IDLE_PAUSE_SECONDS: float = float(

--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -1779,7 +1779,7 @@ class CloudDaemonInstance(Base):
     region: Mapped[str | None] = mapped_column(String(64), nullable=True)
     runtime: Mapped[str] = mapped_column(String(64), nullable=False)
     max_agents: Mapped[int] = mapped_column(
-        Integer, nullable=False, default=1, server_default="1"
+        Integer, nullable=False, default=5, server_default="5"
     )
     active_agent_count: Mapped[int] = mapped_column(
         Integer, nullable=False, default=0, server_default="0"

--- a/backend/hub/services/cloud_agent.py
+++ b/backend/hub/services/cloud_agent.py
@@ -1322,7 +1322,7 @@ class CloudAgentService:
         if (count or 0) >= self._max_per_user:
             raise CloudAgentError(
                 "quota_exceeded",
-                f"Cloud Agent quota exceeded (max {self._max_per_user})",
+                f"你最多可以创建 {self._max_per_user} 个云端 Bot。请先删除不再使用的 Bot 后再创建。",
                 http_status=400,
             )
 
@@ -1378,7 +1378,7 @@ class CloudAgentService:
                 if (candidate.active_agent_count or 0) >= candidate.max_agents:
                     raise CloudAgentError(
                         "sandbox_capacity_exceeded",
-                        f"Cloud sandbox capacity exceeded (max {candidate.max_agents})",
+                        f"当前云端运行环境最多可托管 {candidate.max_agents} 个 Bot。请先删除不再使用的 Bot 后再创建。",
                         http_status=400,
                     )
                 return candidate, daemon_row

--- a/backend/migrations/014_cloud_daemon_max_agents_5.sql
+++ b/backend/migrations/014_cloud_daemon_max_agents_5.sql
@@ -1,0 +1,10 @@
+-- Raise Cloud Agent sandbox capacity to five Bots.
+-- Existing rows may have been created with lower environment defaults; lift
+-- those rows so users can immediately use the new capacity after migration.
+
+ALTER TABLE cloud_daemon_instances
+    ALTER COLUMN max_agents SET DEFAULT 5;
+
+UPDATE cloud_daemon_instances
+SET max_agents = 5
+WHERE max_agents < 5;


### PR DESCRIPTION
## Summary
- raise Cloud Agent per-user and per-sandbox defaults to 5
- add a migration to lift existing cloud daemon capacity values below 5
- replace cloud-agent quota/capacity errors with user-friendly Chinese copy

## Tests
- cd backend && uv run pytest tests/test_cloud_agent*.py tests/test_app/test_cloud_agents.py tests/test_app/test_cloud_agent_internal.py