### PR TITLE
feat: report runtime model parameters

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1560,6 +1560,9 @@ class ProvisionAgentBody(BaseModel):
     daemon_instance_id: str
     label: str
     runtime: str
+    runtime_model: str | None = None
+    reasoning_effort: str | None = None
+    thinking: bool | None = None
     cwd: str | None = None
     bio: str | None = None
     # Optional OpenClaw routing selection. Only meaningful when
@@ -1585,6 +1588,9 @@ class ProvisionAgentResponse(BaseModel):
 def _daemon_lists_runtime(
     instance: DaemonInstance,
     runtime: str,
+    runtime_model: str | None = None,
+    reasoning_effort: str | None = None,
+    thinking: bool | None = None,
     openclaw_gateway: str | None = None,
     hermes_profile: str | None = None,
 ) -> bool:
@@ -1610,6 +1616,13 @@ def _daemon_lists_runtime(
         if entry.get("id") != runtime:
             continue
         if entry.get("available") is not True:
+            return False
+        if not _runtime_snapshot_accepts_model_options(
+            entry,
+            runtime_model=runtime_model,
+            reasoning_effort=reasoning_effort,
+            thinking=thinking,
+        ):
             return False
         if runtime == "openclaw-acp" and openclaw_gateway:
             endpoints = entry.get("endpoints")
@@ -1642,6 +1655,60 @@ def _daemon_lists_runtime(
             return False
         return True
     return False
+
+
+def _runtime_snapshot_accepts_model_options(
+    entry: dict,
+    *,
+    runtime_model: str | None,
+    reasoning_effort: str | None,
+    thinking: bool | None,
+) -> bool:
+    selected_model: dict | None = None
+    if runtime_model:
+        models = entry.get("models")
+        if isinstance(models, list) and models:
+            for model in models:
+                if isinstance(model, dict) and model.get("id") == runtime_model:
+                    selected_model = model
+                    break
+            if selected_model is None:
+                return False
+
+    if reasoning_effort:
+        param = _find_runtime_parameter(
+            entry,
+            selected_model,
+            ("reasoning_effort", "effort"),
+        )
+        if param is not None:
+            values = param.get("values")
+            if isinstance(values, list) and values:
+                return reasoning_effort in {str(v) for v in values}
+
+    if thinking is not None:
+        param = _find_runtime_parameter(entry, selected_model, ("thinking",))
+        if param is None:
+            return False
+        if param.get("type") != "boolean":
+            return False
+
+    return True
+
+
+def _find_runtime_parameter(
+    entry: dict,
+    model: dict | None,
+    ids: tuple[str, ...],
+) -> dict | None:
+    for container in (model, entry):
+        params = container.get("parameters") if isinstance(container, dict) else None
+        if not isinstance(params, list):
+            continue
+        for param in params:
+            if isinstance(param, dict) and param.get("id") in ids:
+                return param
+    return None
 
 
 def _mark_daemon_runtime_snapshot_bound(
@@ -1745,6 +1812,9 @@ async def provision_agent(
     if not _daemon_lists_runtime(
         instance,
         runtime,
+        body.runtime_model,
+        body.reasoning_effort,
+        body.thinking,
         body.openclaw_gateway,
         body.hermes_profile,
     ):
@@ -1836,6 +1906,15 @@ async def provision_agent(
             "runtime": runtime,
         },
     }
+    if body.runtime_model:
+        frame_params["runtimeModel"] = body.runtime_model
+        frame_params["credentials"]["runtimeModel"] = body.runtime_model
+    if body.reasoning_effort:
+        frame_params["reasoningEffort"] = body.reasoning_effort
+        frame_params["credentials"]["reasoningEffort"] = body.reasoning_effort
+    if body.thinking is not None:
+        frame_params["thinking"] = body.thinking
+        frame_params["credentials"]["thinking"] = body.thinking
     if body.cwd:
         frame_params["cwd"] = body.cwd
         frame_params["credentials"]["cwd"] = body.cwd

--- a/backend/hub/routers/daemon_control.py
+++ b/backend/hub/routers/daemon_control.py
@@ -1506,6 +1506,19 @@ def _parse_runtime_snapshot_params(
         endpoints = entry.get("endpoints")
         if isinstance(endpoints, list) and len(endpoints) > 32:
             entry["endpoints"] = endpoints[:32]
+        models = entry.get("models")
+        if isinstance(models, list) and len(models) > 128:
+            entry["models"] = models[:128]
+        if isinstance(models, list):
+            for model in models:
+                if not isinstance(model, dict):
+                    continue
+                model_parameters = model.get("parameters")
+                if isinstance(model_parameters, list) and len(model_parameters) > 64:
+                    model["parameters"] = model_parameters[:64]
+        parameters = entry.get("parameters")
+        if isinstance(parameters, list) and len(parameters) > 64:
+            entry["parameters"] = parameters[:64]
         health = entry.get("health")
         if isinstance(health, dict):
             circuit_breakers = health.get("circuitBreakers")

--- a/backend/tests/test_app/test_agent_provision.py
+++ b/backend/tests/test_app/test_agent_provision.py
@@ -268,6 +268,105 @@ async def test_provision_happy_path_writes_runtime_and_dispatches_frame(
 
 
 @pytest.mark.asyncio
+async def test_provision_dispatches_runtime_model_options(
+    client: AsyncClient, seed_user, db_session: AsyncSession
+):
+    instance_id = await _provision_instance(client, seed_user)
+    conn, fake_ws, registry = await _with_connected_daemon(
+        instance_id,
+        seed_user["user_id"],
+        runtimes_snapshot=[
+            {
+                "id": "codex",
+                "available": True,
+                "models": [
+                    {
+                        "id": "gpt-5.2",
+                        "parameters": [
+                            {
+                                "id": "reasoning_effort",
+                                "type": "enum",
+                                "values": ["low", "medium", "high"],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+        db_session=db_session,
+    )
+    try:
+        ack_task = asyncio.create_task(_auto_ack(conn, fake_ws))
+        r = await client.post(
+            "/api/users/me/agents/provision",
+            json={
+                "daemon_instance_id": instance_id,
+                "label": "writer",
+                "runtime": "codex",
+                "runtime_model": "gpt-5.2",
+                "reasoning_effort": "high",
+            },
+            headers={"Authorization": f"Bearer {seed_user['token']}"},
+        )
+        sent = await ack_task
+
+        assert r.status_code == 201, r.text
+        assert sent["params"]["runtimeModel"] == "gpt-5.2"
+        assert sent["params"]["reasoningEffort"] == "high"
+        creds = sent["params"]["credentials"]
+        assert creds["runtimeModel"] == "gpt-5.2"
+        assert creds["reasoningEffort"] == "high"
+    finally:
+        await registry.unregister(conn)
+
+
+@pytest.mark.asyncio
+async def test_provision_rejects_reasoning_effort_not_supported_by_model(
+    client: AsyncClient, seed_user, db_session: AsyncSession
+):
+    instance_id = await _provision_instance(client, seed_user)
+    conn, _, registry = await _with_connected_daemon(
+        instance_id,
+        seed_user["user_id"],
+        runtimes_snapshot=[
+            {
+                "id": "codex",
+                "available": True,
+                "models": [
+                    {
+                        "id": "gpt-5.2",
+                        "parameters": [
+                            {
+                                "id": "reasoning_effort",
+                                "type": "enum",
+                                "values": ["low", "medium"],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+        db_session=db_session,
+    )
+    try:
+        r = await client.post(
+            "/api/users/me/agents/provision",
+            json={
+                "daemon_instance_id": instance_id,
+                "label": "writer",
+                "runtime": "codex",
+                "runtime_model": "gpt-5.2",
+                "reasoning_effort": "xhigh",
+            },
+            headers={"Authorization": f"Bearer {seed_user['token']}"},
+        )
+        assert r.status_code == 409
+        assert r.json()["detail"] == "runtime_unavailable"
+    finally:
+        await registry.unregister(conn)
+
+
+@pytest.mark.asyncio
 async def test_provision_marks_openclaw_profile_bound_in_cached_snapshot(
     client: AsyncClient, seed_user, db_session: AsyncSession
 ):

--- a/backend/tests/test_app/test_daemon_control.py
+++ b/backend/tests/test_app/test_daemon_control.py
@@ -1085,6 +1085,58 @@ async def test_runtime_snapshot_caps_nested_runtime_health(
 
 
 @pytest.mark.asyncio
+async def test_runtime_snapshot_caps_nested_models(
+    client: AsyncClient, seed_user, db_session: AsyncSession
+):
+    """Nested runtime model arrays are capped before persistence."""
+    from sqlalchemy import select
+
+    from hub.routers.daemon_control import _DaemonConn, _handle_daemon_event
+
+    bundle = await _provision_instance_via_device_code(client, seed_user)
+    instance_id = bundle["daemon_instance_id"]
+
+    fake_ws = _FakeWS()
+    conn = _DaemonConn(
+        ws=fake_ws,  # type: ignore[arg-type]
+        user_id=str(seed_user["user_id"]),
+        daemon_instance_id=instance_id,
+        pending_acks={},
+    )
+
+    models = [{"id": f"model-{i}", "source": "cli"} for i in range(140)]
+    await _handle_daemon_event(
+        conn,
+        {
+            "id": "frm_rs_models",
+            "type": "runtime_snapshot",
+            "params": {
+                "runtimes": [
+                    {
+                        "id": "codex",
+                        "available": True,
+                        "models": models,
+                    }
+                ],
+                "probedAt": _probed_now_ms(),
+            },
+        },
+    )
+    ack = json.loads(fake_ws.sent[-1])
+    assert ack == {"id": "frm_rs_models", "ok": True}
+
+    await db_session.commit()
+    res = await db_session.execute(
+        select(DaemonInstance).where(DaemonInstance.id == instance_id)
+    )
+    inst = res.scalar_one()
+    stored = inst.runtimes_json
+    if isinstance(stored, str):
+        stored = json.loads(stored)
+    assert len(stored[0]["models"]) == 128
+
+
+@pytest.mark.asyncio
 async def test_list_instances_without_runtimes_returns_none(
     client: AsyncClient, seed_user
 ):

--- a/frontend/src/components/dashboard/CreateAgentDialog.tsx
+++ b/frontend/src/components/dashboard/CreateAgentDialog.tsx
@@ -35,6 +35,9 @@ import {
   ProvisionAgentError,
   type DaemonInstance,
   type DaemonRuntime,
+  type DaemonRuntimeModel,
+  type DaemonRuntimeParameter,
+  type DaemonRuntimeParameterValue,
 } from "@/store/useDaemonStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import {
@@ -64,6 +67,26 @@ const QCLAW_RUNTIME_ID = "qclaw";
 const CLOUD_AGENT_OPTION_ID = "__botcord_cloud_agent__";
 
 type DaemonRuntimeEndpoint = NonNullable<DaemonRuntime["endpoints"]>[number];
+
+function parameterValueKey(value: DaemonRuntimeParameterValue): string {
+  return typeof value === "boolean" ? (value ? "true" : "false") : String(value);
+}
+
+function findRuntimeParameter(
+  runtime: DaemonRuntime | null,
+  model: DaemonRuntimeModel | null,
+  ids: string[],
+): DaemonRuntimeParameter | null {
+  const modelParam = model?.parameters?.find((param) => ids.includes(param.id));
+  if (modelParam) return modelParam;
+  return runtime?.parameters?.find((param) => ids.includes(param.id)) ?? null;
+}
+
+function modelLabel(model: DaemonRuntimeModel): string {
+  return model.displayName && model.displayName !== model.id
+    ? `${model.displayName} (${model.id})`
+    : model.id;
+}
 
 function isOpenclawFamilyRuntime(id: string | null): boolean {
   return id === OPENCLAW_RUNTIME_ID || id === QCLAW_RUNTIME_ID;
@@ -268,6 +291,9 @@ export default function CreateAgentDialog({
 
   const [selectedDaemonId, setSelectedDaemonId] = useState<string | null>(null);
   const [selectedRuntimeId, setSelectedRuntimeId] = useState<string | null>(null);
+  const [selectedRuntimeModel, setSelectedRuntimeModel] = useState<string | null>(null);
+  const [selectedReasoningEffort, setSelectedReasoningEffort] = useState<string | null>(null);
+  const [selectedThinking, setSelectedThinking] = useState<boolean | null>(null);
   const [selectedGateway, setSelectedGateway] = useState<string | null>(null);
   const [selectedOpenclawAgent, setSelectedOpenclawAgent] = useState<string | null>(null);
   const [selectedHermesProfile, setSelectedHermesProfile] = useState<string | null>(null);
@@ -394,6 +420,73 @@ export default function CreateAgentDialog({
     () => selectedDaemon?.runtimes?.find((r) => r.id === selectedRuntimeId) ?? null,
     [selectedDaemon, selectedRuntimeId],
   );
+  const selectedModel = useMemo(
+    () =>
+      selectedRuntime?.models?.find((model) => model.id === selectedRuntimeModel) ??
+      null,
+    [selectedRuntime, selectedRuntimeModel],
+  );
+  const reasoningParameter = useMemo(
+    () =>
+      findRuntimeParameter(selectedRuntime, selectedModel, [
+        "reasoning_effort",
+        "effort",
+      ]),
+    [selectedRuntime, selectedModel],
+  );
+  const thinkingParameter = useMemo(
+    () => findRuntimeParameter(selectedRuntime, selectedModel, ["thinking"]),
+    [selectedRuntime, selectedModel],
+  );
+  useEffect(() => {
+    const models = selectedRuntime?.models ?? [];
+    if (!selectedRuntime?.available || models.length === 0) {
+      setSelectedRuntimeModel(null);
+      return;
+    }
+    if (selectedRuntimeModel && models.some((model) => model.id === selectedRuntimeModel)) {
+      return;
+    }
+    const preferred = models.find((model) => model.isDefault) ?? models[0] ?? null;
+    setSelectedRuntimeModel(preferred?.id ?? null);
+  }, [selectedRuntime, selectedRuntimeModel]);
+
+  useEffect(() => {
+    if (!reasoningParameter) {
+      setSelectedReasoningEffort(null);
+      return;
+    }
+    const values = reasoningParameter.values?.map(parameterValueKey) ?? [];
+    const defaultValue =
+      reasoningParameter.defaultValue === undefined
+        ? null
+        : parameterValueKey(reasoningParameter.defaultValue);
+    if (values.length > 0) {
+      if (selectedReasoningEffort && values.includes(selectedReasoningEffort)) {
+        return;
+      }
+      setSelectedReasoningEffort(
+        defaultValue && values.includes(defaultValue)
+          ? defaultValue
+          : values[0] ?? null,
+      );
+      return;
+    }
+    setSelectedReasoningEffort(selectedReasoningEffort ?? defaultValue);
+  }, [reasoningParameter, selectedReasoningEffort]);
+
+  useEffect(() => {
+    if (!thinkingParameter || thinkingParameter.type !== "boolean") {
+      setSelectedThinking(null);
+      return;
+    }
+    if (selectedThinking !== null) return;
+    setSelectedThinking(
+      typeof thinkingParameter.defaultValue === "boolean"
+        ? thinkingParameter.defaultValue
+        : true,
+    );
+  }, [thinkingParameter, selectedThinking]);
   const selectedOpenclawEndpoint = useMemo(
     () =>
       selectedRuntime?.endpoints?.find((e) => e.name === selectedGateway) ??
@@ -555,6 +648,9 @@ export default function CreateAgentDialog({
             name: trimmedName,
             bio: bio.trim() || undefined,
             runtime: daemonRuntimeId(selectedRuntimeId!),
+            ...(selectedRuntimeModel ? { runtimeModel: selectedRuntimeModel } : {}),
+            ...(selectedReasoningEffort ? { reasoningEffort: selectedReasoningEffort } : {}),
+            ...(selectedThinking !== null ? { thinking: selectedThinking } : {}),
             ...(isOpenclawFamilyRuntime(selectedRuntimeId) && selectedGateway
               ? {
                   openclawGateway: selectedGateway,
@@ -578,6 +674,10 @@ export default function CreateAgentDialog({
   const needsHermesProfile = selectedRuntimeId === "hermes-agent";
   const needsOpenclawAgent =
     needsOpenclawGateway && (selectedOpenclawEndpoint?.agents?.length ?? 0) > 0;
+  const hasRuntimeModelOptions =
+    (selectedRuntime?.models?.length ?? 0) > 0 ||
+    !!reasoningParameter ||
+    thinkingParameter?.type === "boolean";
   const canSubmit =
     !!selectedDaemonId &&
     (isCloudAgentSelected || !!selectedRuntimeId) &&
@@ -587,34 +687,58 @@ export default function CreateAgentDialog({
     (isCloudAgentSelected || !needsHermesProfile || !!selectedHermesProfile) &&
     !submitting;
 
-  const selectedRuntimeDetails: ReactNode = needsOpenclawGateway ? (
-    <OpenclawGatewayPicker
-      runtime={selectedRuntime}
-      selectedGateway={selectedGateway}
-      onSelectGateway={(g) => {
-        setSelectedGateway(g);
-        setSelectedOpenclawAgent(null);
-      }}
-      selectedAgent={selectedOpenclawAgent}
-      onSelectAgent={setSelectedOpenclawAgent}
-      labels={{
-        subagentLabel: t.openclawSubagentLabel,
-        subagentInfo: t.openclawSubagentInfo,
-        subagentPlaceholder: t.openclawSubagentPlaceholder,
-        noProfiles: t.openclawNoProfiles,
-        selectProfile: t.openclawSelectProfile,
-        boundProfiles: t.openclawBoundProfiles,
-      }}
-      disabled={submitting}
-    />
-  ) : needsHermesProfile ? (
-    <HermesProfilePicker
-      runtime={selectedRuntime}
-      selectedProfile={selectedHermesProfile}
-      onSelect={setSelectedHermesProfile}
-      disabled={submitting}
-    />
-  ) : null;
+  const selectedRuntimeDetails: ReactNode =
+    hasRuntimeModelOptions || needsOpenclawGateway || needsHermesProfile ? (
+      <div className="ml-5 space-y-2 border-l border-neon-cyan/25 pl-4">
+        <RuntimeModelOptions
+          runtime={selectedRuntime}
+          selectedModel={selectedRuntimeModel}
+          onSelectModel={setSelectedRuntimeModel}
+          reasoningParameter={reasoningParameter}
+          selectedReasoningEffort={selectedReasoningEffort}
+          onSelectReasoningEffort={setSelectedReasoningEffort}
+          thinkingParameter={thinkingParameter}
+          selectedThinking={selectedThinking}
+          onSelectThinking={setSelectedThinking}
+          labels={{
+            modelLabel: t.modelLabel,
+            modelPlaceholder: t.modelPlaceholder,
+            reasoningEffortLabel: t.reasoningEffortLabel,
+            reasoningEffortPlaceholder: t.reasoningEffortPlaceholder,
+            thinkingLabel: t.thinkingLabel,
+          }}
+          disabled={submitting}
+        />
+        {needsOpenclawGateway ? (
+          <OpenclawGatewayPicker
+            runtime={selectedRuntime}
+            selectedGateway={selectedGateway}
+            onSelectGateway={(g) => {
+              setSelectedGateway(g);
+              setSelectedOpenclawAgent(null);
+            }}
+            selectedAgent={selectedOpenclawAgent}
+            onSelectAgent={setSelectedOpenclawAgent}
+            labels={{
+              subagentLabel: t.openclawSubagentLabel,
+              subagentInfo: t.openclawSubagentInfo,
+              subagentPlaceholder: t.openclawSubagentPlaceholder,
+              noProfiles: t.openclawNoProfiles,
+              selectProfile: t.openclawSelectProfile,
+              boundProfiles: t.openclawBoundProfiles,
+            }}
+            disabled={submitting}
+          />
+        ) : needsHermesProfile ? (
+          <HermesProfilePicker
+            runtime={selectedRuntime}
+            selectedProfile={selectedHermesProfile}
+            onSelect={setSelectedHermesProfile}
+            disabled={submitting}
+          />
+        ) : null}
+      </div>
+    ) : null;
 
   return (
     <div
@@ -1172,6 +1296,126 @@ function RuntimeCard({
   );
 }
 
+function RuntimeModelOptions({
+  runtime,
+  selectedModel,
+  onSelectModel,
+  reasoningParameter,
+  selectedReasoningEffort,
+  onSelectReasoningEffort,
+  thinkingParameter,
+  selectedThinking,
+  onSelectThinking,
+  labels,
+  disabled,
+}: {
+  runtime: DaemonRuntime | null;
+  selectedModel: string | null;
+  onSelectModel: (value: string | null) => void;
+  reasoningParameter: DaemonRuntimeParameter | null;
+  selectedReasoningEffort: string | null;
+  onSelectReasoningEffort: (value: string | null) => void;
+  thinkingParameter: DaemonRuntimeParameter | null;
+  selectedThinking: boolean | null;
+  onSelectThinking: (value: boolean | null) => void;
+  labels: {
+    modelLabel: string;
+    modelPlaceholder: string;
+    reasoningEffortLabel: string;
+    reasoningEffortPlaceholder: string;
+    thinkingLabel: string;
+  };
+  disabled: boolean;
+}) {
+  const models = runtime?.models ?? [];
+  const reasoningValues = reasoningParameter?.values?.map(parameterValueKey) ?? [];
+  const hasReasoning =
+    !!reasoningParameter &&
+    (reasoningValues.length > 0 || reasoningParameter.type === "string");
+  const hasThinking = thinkingParameter?.type === "boolean";
+  if (models.length === 0 && !hasReasoning && !hasThinking) return null;
+
+  return (
+    <section className="rounded-xl border border-glass-border bg-glass-bg/30 p-2.5">
+      <div className="grid gap-2.5 sm:grid-cols-2">
+        {models.length > 0 ? (
+          <div className={hasReasoning || hasThinking ? "" : "sm:col-span-2"}>
+            <label className="mb-1 block text-[11px] font-semibold uppercase tracking-wider text-text-secondary">
+              {labels.modelLabel}
+            </label>
+            <DashboardSelect
+              disabled={disabled}
+              value={selectedModel ?? ""}
+              onChange={onSelectModel}
+              placeholder={labels.modelPlaceholder}
+              options={models.map((model) => ({
+                value: model.id,
+                label: modelLabel(model),
+                sublabel: [
+                  model.provider,
+                  model.isDefault ? "default" : null,
+                  model.source,
+                ]
+                  .filter(Boolean)
+                  .join(" · "),
+              }))}
+            />
+          </div>
+        ) : null}
+
+        {hasReasoning ? (
+          <div className={models.length > 0 ? "" : "sm:col-span-2"}>
+            <label className="mb-1 block text-[11px] font-semibold uppercase tracking-wider text-text-secondary">
+              {labels.reasoningEffortLabel}
+            </label>
+            {reasoningValues.length > 0 ? (
+              <DashboardSelect
+                disabled={disabled}
+                value={selectedReasoningEffort ?? ""}
+                onChange={onSelectReasoningEffort}
+                placeholder={labels.reasoningEffortPlaceholder}
+                options={reasoningValues.map((value) => ({
+                  value,
+                  label: value,
+                  sublabel:
+                    reasoningParameter?.defaultValue !== undefined &&
+                    parameterValueKey(reasoningParameter.defaultValue) === value
+                      ? "default"
+                      : undefined,
+                }))}
+              />
+            ) : (
+              <input
+                disabled={disabled}
+                type="text"
+                value={selectedReasoningEffort ?? ""}
+                placeholder={labels.reasoningEffortPlaceholder}
+                onChange={(event) =>
+                  onSelectReasoningEffort(event.target.value.trim() || null)
+                }
+                className="h-10 w-full rounded-xl border border-glass-border bg-deep-black px-3 text-sm text-text-primary focus:border-neon-cyan focus:outline-none focus:ring-1 focus:ring-neon-cyan/50 disabled:opacity-50"
+              />
+            )}
+          </div>
+        ) : null}
+
+        {hasThinking ? (
+          <label className="flex min-h-10 items-center gap-2 rounded-xl border border-glass-border bg-deep-black px-3 text-sm text-text-primary sm:col-span-2">
+            <input
+              type="checkbox"
+              checked={selectedThinking === true}
+              disabled={disabled}
+              onChange={(event) => onSelectThinking(event.target.checked)}
+              className="h-4 w-4 rounded border-glass-border bg-deep-black text-neon-cyan focus:ring-neon-cyan/50"
+            />
+            <span>{labels.thinkingLabel}</span>
+          </label>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
 function OpenclawGatewayPicker({
   runtime,
   selectedGateway,
@@ -1212,7 +1456,7 @@ function OpenclawGatewayPicker({
     );
   }
   return (
-    <section className="ml-5 border-l border-neon-cyan/25 pl-4">
+    <section>
       <div className="rounded-xl border border-glass-border bg-glass-bg/30 p-2.5">
         <div className="grid gap-2.5">
       <div>

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -2293,6 +2293,11 @@ export const createAgentDialog: TranslationMap<{
   showUnavailable: string
   hideUnavailable: string
   runtimeNotSupported: string
+  modelLabel: string
+  modelPlaceholder: string
+  reasoningEffortLabel: string
+  reasoningEffortPlaceholder: string
+  thinkingLabel: string
   openclawSubagentLabel: string
   openclawSubagentInfo: string
   openclawSubagentPlaceholder: string
@@ -2356,6 +2361,11 @@ export const createAgentDialog: TranslationMap<{
     showUnavailable: 'Show',
     hideUnavailable: 'Hide',
     runtimeNotSupported: 'not yet supported',
+    modelLabel: 'Model',
+    modelPlaceholder: 'Select a model',
+    reasoningEffortLabel: 'Reasoning effort',
+    reasoningEffortPlaceholder: 'Select effort',
+    thinkingLabel: '思考模式',
     openclawSubagentLabel: 'Subagent',
     openclawSubagentInfo: 'Select a subagent profile from this gateway. Leave it blank to use the main agent configured as defaultAgent.',
     openclawSubagentPlaceholder: "Leave blank to use the gateway's main agent",
@@ -2419,6 +2429,11 @@ export const createAgentDialog: TranslationMap<{
     showUnavailable: '展开',
     hideUnavailable: '收起',
     runtimeNotSupported: '暂不支持',
+    modelLabel: '模型',
+    modelPlaceholder: '选择模型',
+    reasoningEffortLabel: '推理强度',
+    reasoningEffortPlaceholder: '选择强度',
+    thinkingLabel: 'Thinking',
     openclawSubagentLabel: '子 Agent（可选）',
     openclawSubagentInfo: '选择这个网关里的子 Agent。留空时，会使用网关配置里的主 Agent（defaultAgent）。',
     openclawSubagentPlaceholder: '留空则使用网关的主 Agent',

--- a/frontend/src/store/useDaemonStore.ts
+++ b/frontend/src/store/useDaemonStore.ts
@@ -144,6 +144,9 @@ export interface ProvisionAgentInput {
   name: string;
   bio?: string;
   runtime?: string;
+  runtimeModel?: string;
+  reasoningEffort?: string;
+  thinking?: boolean;
   cwd?: string;
   /** OpenClaw gateway profile name (only when runtime === "openclaw-acp"). */
   openclawGateway?: string;
@@ -924,6 +927,9 @@ export const useDaemonStore = create<DaemonState>()((set, get) => ({
       label,
     };
     if (input.runtime) body.runtime = input.runtime;
+    if (input.runtimeModel) body.runtime_model = input.runtimeModel;
+    if (input.reasoningEffort) body.reasoning_effort = input.reasoningEffort;
+    if (typeof input.thinking === "boolean") body.thinking = input.thinking;
     if (input.cwd) body.cwd = input.cwd;
     if (input.bio) body.bio = input.bio;
     if (input.openclawGateway) body.openclaw_gateway = input.openclawGateway;

--- a/frontend/src/store/useDaemonStore.ts
+++ b/frontend/src/store/useDaemonStore.ts
@@ -49,6 +49,33 @@ export interface DaemonHermesProfile {
   hasSoul?: boolean;
 }
 
+export interface DaemonRuntimeModel {
+  id: string;
+  displayName?: string;
+  provider?: string;
+  source?: "builtin" | "config" | "cli" | "api" | "gateway" | "env";
+  isDefault?: boolean;
+  capabilities?: string[];
+  contextLength?: number;
+  metadata?: Record<string, unknown>;
+  parameters?: DaemonRuntimeParameter[];
+}
+
+export type DaemonRuntimeParameterValue = string | number | boolean;
+
+export interface DaemonRuntimeParameter {
+  id: string;
+  displayName?: string;
+  type: "enum" | "boolean" | "integer" | "string";
+  flag?: string;
+  values?: DaemonRuntimeParameterValue[];
+  defaultValue?: DaemonRuntimeParameterValue;
+  minimum?: number;
+  maximum?: number;
+  source?: "builtin" | "config" | "cli" | "api" | "gateway" | "env";
+  metadata?: Record<string, unknown>;
+}
+
 export interface DaemonRuntime {
   id: string;
   available: boolean;
@@ -60,6 +87,10 @@ export interface DaemonRuntime {
   endpoints?: DaemonRuntimeEndpoint[];
   /** Hermes runtime carries the per-device profile listing (1 BotCord agent : 1 profile). */
   profiles?: DaemonHermesProfile[];
+  /** Runtime-selectable model catalog, when the daemon can discover one. */
+  models?: DaemonRuntimeModel[];
+  /** Runtime-level CLI/config parameters and defaults. */
+  parameters?: DaemonRuntimeParameter[];
 }
 
 export interface DaemonRuntimeHealth {
@@ -333,6 +364,44 @@ function normalizeRuntimes(raw: unknown): DaemonRuntime[] | null | undefined {
       r.health && typeof r.health === "object"
         ? normalizeRuntimeHealth(r.health as Record<string, unknown>)
         : undefined;
+    const models = Array.isArray(r.models)
+      ? ((r.models as unknown[])
+          .map((rawModel) => {
+            if (!rawModel || typeof rawModel !== "object") return null;
+            const m = rawModel as Record<string, unknown>;
+            const id = typeof m.id === "string" ? m.id : null;
+            if (!id) return null;
+            const source =
+              m.source === "builtin" ||
+              m.source === "config" ||
+              m.source === "cli" ||
+              m.source === "api" ||
+              m.source === "gateway" ||
+              m.source === "env"
+                ? m.source
+                : undefined;
+            return {
+              id,
+              displayName:
+                typeof m.displayName === "string" ? m.displayName : undefined,
+              provider: typeof m.provider === "string" ? m.provider : undefined,
+              source,
+              isDefault: m.isDefault === true,
+              capabilities: Array.isArray(m.capabilities)
+                ? m.capabilities.filter((x): x is string => typeof x === "string")
+                : undefined,
+              contextLength:
+                typeof m.contextLength === "number" ? m.contextLength : undefined,
+              metadata:
+                m.metadata && typeof m.metadata === "object" && !Array.isArray(m.metadata)
+                  ? (m.metadata as Record<string, unknown>)
+                  : undefined,
+              parameters: normalizeRuntimeParameters(m.parameters),
+            } as DaemonRuntimeModel;
+          })
+          .filter(Boolean) as DaemonRuntimeModel[])
+      : undefined;
+    const parameters = normalizeRuntimeParameters(r.parameters);
     out.push({
       id,
       available: r.available === true,
@@ -342,9 +411,66 @@ function normalizeRuntimes(raw: unknown): DaemonRuntime[] | null | undefined {
       health,
       endpoints,
       profiles,
+      models,
+      parameters,
     });
   }
   return out;
+}
+
+function normalizeRuntimeParameters(raw: unknown): DaemonRuntimeParameter[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out = raw
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") return null;
+      const p = entry as Record<string, unknown>;
+      const id = typeof p.id === "string" ? p.id : null;
+      const type =
+        p.type === "enum" ||
+        p.type === "boolean" ||
+        p.type === "integer" ||
+        p.type === "string"
+          ? p.type
+          : null;
+      if (!id || !type) return null;
+      const source =
+        p.source === "builtin" ||
+        p.source === "config" ||
+        p.source === "cli" ||
+        p.source === "api" ||
+        p.source === "gateway" ||
+        p.source === "env"
+          ? p.source
+          : undefined;
+      const defaultValue =
+        typeof p.defaultValue === "string" ||
+        typeof p.defaultValue === "number" ||
+        typeof p.defaultValue === "boolean"
+          ? p.defaultValue
+          : undefined;
+      return {
+        id,
+        type,
+        displayName: typeof p.displayName === "string" ? p.displayName : undefined,
+        flag: typeof p.flag === "string" ? p.flag : undefined,
+        values: Array.isArray(p.values)
+          ? p.values.filter(
+              (v): v is DaemonRuntimeParameterValue =>
+                typeof v === "string" || typeof v === "number" || typeof v === "boolean",
+            )
+          : undefined,
+        defaultValue,
+        minimum: typeof p.minimum === "number" ? p.minimum : undefined,
+        maximum: typeof p.maximum === "number" ? p.maximum : undefined,
+        source,
+        metadata:
+          p.metadata && typeof p.metadata === "object" && !Array.isArray(p.metadata)
+            ? (p.metadata as Record<string, unknown>)
+            : undefined,
+      } as DaemonRuntimeParameter;
+    })
+    .filter(Boolean) as DaemonRuntimeParameter[];
+  return out.length ? out : undefined;
 }
 
 function normalizeRuntimeHealth(raw: Record<string, unknown>): DaemonRuntimeHealth | undefined {

--- a/packages/daemon/src/__tests__/daemon-config-map.test.ts
+++ b/packages/daemon/src/__tests__/daemon-config-map.test.ts
@@ -416,6 +416,32 @@ describe("buildManagedRoutes", () => {
     expect(map.get("ag_one")?.extraArgs).not.toBe(withExtraArgs.extraArgs);
   });
 
+  it("appends per-agent model and reasoning selections to inherited extraArgs", () => {
+    const withExtraArgs: GatewayRoute = {
+      runtime: "codex",
+      cwd: "/home/default",
+      extraArgs: ["--skip-git-repo-check"],
+    };
+    const map = buildManagedRoutes(
+      ["ag_one"],
+      {
+        ag_one: {
+          runtime: "codex",
+          runtimeModel: "gpt-5.2",
+          reasoningEffort: "high",
+        },
+      },
+      withExtraArgs,
+    );
+    expect(map.get("ag_one")?.extraArgs).toEqual([
+      "--skip-git-repo-check",
+      "--model",
+      "gpt-5.2",
+      "-c",
+      'model_reasoning_effort="high"',
+    ]);
+  });
+
   it("omits extraArgs when defaultRoute has none", () => {
     const map = buildManagedRoutes(["ag_one"], {}, defaultRoute);
     expect(map.get("ag_one")).not.toHaveProperty("extraArgs");
@@ -492,4 +518,3 @@ describe("openclawGateways resolution", () => {
     expect(gw.managedRoutes).toEqual([]);
   });
 });
-

--- a/packages/daemon/src/__tests__/provision.test.ts
+++ b/packages/daemon/src/__tests__/provision.test.ts
@@ -660,6 +660,65 @@ describe("provision_agent handler writes runtime + cwd", () => {
     }
   });
 
+  it("persists model options and hot-adds them to the managed route", async () => {
+    const os = await import("node:os");
+    const fs = await import("node:fs");
+    const nodePath = await import("node:path");
+
+    const tmp = fs.mkdtempSync(nodePath.join(os.tmpdir(), "daemon-provision-"));
+    const prevHome = process.env.HOME;
+    process.env.HOME = tmp;
+    try {
+      mockState.cfg = {
+        defaultRoute: {
+          adapter: "codex",
+          cwd: tmp,
+          extraArgs: ["--skip-git-repo-check"],
+        },
+        routes: [],
+        streamBlocks: true,
+      };
+      const gw = makeFakeGateway();
+      const provisioner = createProvisioner({
+        gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+      });
+      const privateKey = Buffer.alloc(32, 8).toString("base64");
+
+      const ack = await provisioner({
+        id: "req_model",
+        type: CONTROL_FRAME_TYPES.PROVISION_AGENT,
+        params: {
+          runtime: "codex",
+          runtimeModel: "gpt-5.2",
+          reasoningEffort: "high",
+          credentials: {
+            agentId: "ag_model",
+            keyId: "k_model",
+            privateKey,
+            hubUrl: "https://hub.example",
+          },
+        },
+      });
+
+      expect(ack.ok).toBe(true);
+      const credFile = nodePath.join(tmp, ".botcord", "credentials", "ag_model.json");
+      const saved = JSON.parse(fs.readFileSync(credFile, "utf8")) as Record<string, unknown>;
+      expect(saved.runtimeModel).toBe("gpt-5.2");
+      expect(saved.reasoningEffort).toBe("high");
+      expect(gw.listManagedRoutes()[0].extraArgs).toEqual([
+        "--skip-git-repo-check",
+        "--model",
+        "gpt-5.2",
+        "-c",
+        'model_reasoning_effort="high"',
+      ]);
+    } finally {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("rejects unknown runtime ids before touching disk", async () => {
     const gw = makeFakeGateway();
     const provisioner = createProvisioner({

--- a/packages/daemon/src/__tests__/runtime-discovery.test.ts
+++ b/packages/daemon/src/__tests__/runtime-discovery.test.ts
@@ -76,15 +76,74 @@ describe("collectRuntimeSnapshot", () => {
       },
     ]);
     const snap = collectRuntimeSnapshot();
-    expect(snap.runtimes).toEqual([
-      {
-        id: "claude-code",
-        available: true,
-        version: "1.2.3",
-        path: "/usr/local/bin/claude",
-      },
-      { id: "codex", available: false },
-    ]);
+    expect(snap.runtimes[0]).toMatchObject({
+      id: "claude-code",
+      available: true,
+      version: "1.2.3",
+      path: "/usr/local/bin/claude",
+    });
+    const claudeModels = (snap.runtimes[0] as { models?: Array<{ id: string }> }).models;
+    expect(claudeModels?.map((m) => m.id)).toContain("sonnet");
+    expect(claudeModels?.map((m) => m.id)).toContain("opus");
+    expect(snap.runtimes[1]).toEqual({ id: "codex", available: false });
+  });
+
+  it("adds Kimi models from the local config file", () => {
+    const tmp = mkdtempSync(path.join(tmpdir(), "daemon-runtime-kimi-"));
+    const prevHome = process.env.HOME;
+    process.env.HOME = tmp;
+    try {
+      mkdirSync(path.join(tmp, ".kimi"), { recursive: true });
+      writeFileSync(
+        path.join(tmp, ".kimi", "config.toml"),
+        [
+          'default_model = "kimi-code/kimi-for-coding"',
+          "",
+          '[models."kimi-code/kimi-for-coding"]',
+          'provider = "managed:kimi-code"',
+          'model = "kimi-for-coding"',
+          "max_context_size = 262144",
+          'capabilities = ["thinking", "image_in"]',
+          'display_name = "Kimi-k2.6"',
+          "",
+        ].join("\n"),
+      );
+      setRuntimes([
+        {
+          id: "kimi-cli",
+          displayName: "Kimi",
+          binary: "kimi",
+          supportsRun: true,
+          result: { available: true },
+        },
+      ]);
+      const [runtime] = collectRuntimeSnapshot().runtimes;
+      expect((runtime as { models?: unknown[] }).models).toEqual([
+        {
+          id: "kimi-code/kimi-for-coding",
+          source: "config",
+          isDefault: true,
+          provider: "managed:kimi-code",
+          displayName: "Kimi-k2.6",
+          contextLength: 262144,
+          capabilities: ["thinking", "image_in"],
+          metadata: { model: "kimi-for-coding" },
+          parameters: [
+            {
+              id: "thinking",
+              displayName: "Thinking",
+              type: "boolean",
+              flag: "--thinking/--no-thinking",
+              source: "cli",
+            },
+          ],
+        },
+      ]);
+    } finally {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 
   it("omits optional fields rather than emitting explicit undefineds", () => {

--- a/packages/daemon/src/__tests__/runtime-models.test.ts
+++ b/packages/daemon/src/__tests__/runtime-models.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseCodexModelCatalog,
+  parseDeepseekModelList,
+  parseKimiConfigModels,
+  parseKimiRuntimeParameters,
+} from "../runtime-models.js";
+
+describe("runtime model discovery parsers", () => {
+  it("parses visible Codex models and trims heavyweight catalog fields", () => {
+    const models = parseCodexModelCatalog(
+      JSON.stringify({
+        models: [
+          {
+            slug: "gpt-5.5",
+            display_name: "GPT-5.5",
+            visibility: "list",
+            supported_in_api: true,
+            default_reasoning_level: "medium",
+            supported_reasoning_levels: [{ effort: "low" }, { effort: "medium" }],
+            base_instructions: "large prompt text should not be copied into metadata",
+          },
+          {
+            slug: "internal-hidden",
+            display_name: "Internal",
+            visibility: "hide",
+          },
+        ],
+      }),
+    );
+
+    expect(models).toEqual([
+      {
+        id: "gpt-5.5",
+        displayName: "GPT-5.5",
+        provider: "openai",
+        source: "cli",
+        metadata: {
+          supportedInApi: true,
+          defaultReasoningLevel: "medium",
+          supportedReasoningLevels: ["low", "medium"],
+        },
+        parameters: [
+          {
+            id: "reasoning_effort",
+            displayName: "Reasoning effort",
+            type: "enum",
+            flag: "-c model_reasoning_effort=<value>",
+            values: ["low", "medium"],
+            defaultValue: "medium",
+            source: "cli",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("parses DeepSeek model list output", () => {
+    expect(
+      parseDeepseekModelList(
+        [
+          "deepseek-v4-pro (deepseek)",
+          "gpt-4.1-mini (openai)",
+          "deepseek-coder:1.3b (ollama)",
+        ].join("\n"),
+      ),
+    ).toEqual([
+      {
+        id: "deepseek-v4-pro",
+        displayName: "deepseek-v4-pro",
+        provider: "deepseek",
+        source: "cli",
+      },
+      {
+        id: "gpt-4.1-mini",
+        displayName: "gpt-4.1-mini",
+        provider: "openai",
+        source: "cli",
+      },
+      {
+        id: "deepseek-coder:1.3b",
+        displayName: "deepseek-coder:1.3b",
+        provider: "ollama",
+        source: "cli",
+      },
+    ]);
+  });
+
+  it("parses Kimi models from config.toml", () => {
+    expect(
+      parseKimiConfigModels(
+        [
+          'default_model = "kimi-code/kimi-for-coding"',
+          "default_thinking = true",
+          "",
+          '[models."kimi-code/kimi-for-coding"]',
+          'provider = "managed:kimi-code"',
+          'model = "kimi-for-coding"',
+          "max_context_size = 262144",
+          'capabilities = ["thinking", "video_in", "image_in"]',
+          'display_name = "Kimi-k2.6"',
+        ].join("\n"),
+      ),
+    ).toEqual([
+      {
+        id: "kimi-code/kimi-for-coding",
+        source: "config",
+        isDefault: true,
+        provider: "managed:kimi-code",
+        displayName: "Kimi-k2.6",
+        contextLength: 262144,
+        capabilities: ["thinking", "video_in", "image_in"],
+        metadata: { model: "kimi-for-coding" },
+        parameters: [
+          {
+            id: "thinking",
+            displayName: "Thinking",
+            type: "boolean",
+            flag: "--thinking/--no-thinking",
+            defaultValue: true,
+            source: "config",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("parses Kimi runtime parameters from config.toml", () => {
+    expect(
+      parseKimiRuntimeParameters(
+        [
+          'default_model = "kimi-code/kimi-for-coding"',
+          "default_thinking = true",
+          "default_yolo = false",
+          "default_plan_mode = false",
+          "show_thinking_stream = true",
+          "max_steps_per_turn = 1000",
+          "max_retries_per_step = 3",
+          "max_ralph_iterations = 0",
+          "reserved_context_size = 50000",
+        ].join("\n"),
+      ),
+    ).toEqual([
+      {
+        id: "model",
+        displayName: "Default model",
+        type: "string",
+        flag: "-m, --model",
+        defaultValue: "kimi-code/kimi-for-coding",
+        source: "config",
+      },
+      {
+        id: "thinking",
+        displayName: "Thinking",
+        type: "boolean",
+        flag: "--thinking/--no-thinking",
+        defaultValue: true,
+        source: "config",
+      },
+      {
+        id: "show_thinking_stream",
+        displayName: "Show thinking stream",
+        type: "boolean",
+        defaultValue: true,
+        source: "config",
+      },
+      {
+        id: "yolo",
+        displayName: "Auto approve",
+        type: "boolean",
+        flag: "--yolo, --yes, -y",
+        defaultValue: false,
+        source: "config",
+      },
+      {
+        id: "plan_mode",
+        displayName: "Plan mode",
+        type: "boolean",
+        flag: "--plan",
+        defaultValue: false,
+        source: "config",
+      },
+      {
+        id: "max_steps_per_turn",
+        displayName: "Max steps per turn",
+        type: "integer",
+        flag: "--max-steps-per-turn",
+        defaultValue: 1000,
+        minimum: 1,
+        source: "config",
+      },
+      {
+        id: "max_retries_per_step",
+        displayName: "Max retries per step",
+        type: "integer",
+        flag: "--max-retries-per-step",
+        defaultValue: 3,
+        minimum: 1,
+        source: "config",
+      },
+      {
+        id: "max_ralph_iterations",
+        displayName: "Max Ralph iterations",
+        type: "integer",
+        flag: "--max-ralph-iterations",
+        defaultValue: 0,
+        minimum: -1,
+        source: "config",
+      },
+      {
+        id: "reserved_context_size",
+        displayName: "Reserved context size",
+        type: "integer",
+        defaultValue: 50000,
+        minimum: 0,
+        source: "config",
+      },
+    ]);
+  });
+});

--- a/packages/daemon/src/agent-discovery.ts
+++ b/packages/daemon/src/agent-discovery.ts
@@ -36,6 +36,12 @@ export interface DiscoveredAgentCredential {
    * in that case.
    */
   runtime?: string;
+  /** Runtime model id/alias selected for this agent. */
+  runtimeModel?: string;
+  /** Runtime reasoning effort selected for this agent. */
+  reasoningEffort?: string;
+  /** Kimi-style thinking toggle selected for this agent. */
+  thinking?: boolean;
   /** Working directory cached alongside `runtime`. */
   cwd?: string;
   /** OpenClaw gateway profile name from credentials (only meaningful for openclaw-acp). */
@@ -181,6 +187,9 @@ export function discoverAgentCredentials(
     };
     if (creds.displayName) entry.displayName = creds.displayName;
     if (creds.runtime) entry.runtime = creds.runtime;
+    if (creds.runtimeModel) entry.runtimeModel = creds.runtimeModel;
+    if (creds.reasoningEffort) entry.reasoningEffort = creds.reasoningEffort;
+    if (typeof creds.thinking === "boolean") entry.thinking = creds.thinking;
     if (creds.cwd) entry.cwd = creds.cwd;
     if (creds.openclawGateway) entry.openclawGateway = creds.openclawGateway;
     if (creds.openclawAgent) entry.openclawAgent = creds.openclawAgent;

--- a/packages/daemon/src/daemon-config-map.ts
+++ b/packages/daemon/src/daemon-config-map.ts
@@ -18,10 +18,20 @@ import type {
 import { resolveAgentIds } from "./config.js";
 import { agentWorkspaceDir } from "./agent-workspace.js";
 import { log as daemonLog } from "./log.js";
+import {
+  buildRuntimeSelectionExtraArgs,
+  mergeRuntimeExtraArgs,
+} from "./runtime-route-options.js";
 
 /** Per-agent metadata cached from credentials, used by `buildManagedRoutes`. */
 export interface AgentRuntimeMeta {
   runtime?: string;
+  /** Runtime model id/alias selected for this agent. */
+  runtimeModel?: string;
+  /** Runtime reasoning effort selected for this agent. */
+  reasoningEffort?: string;
+  /** Kimi-style thinking toggle selected for this agent. */
+  thinking?: boolean;
   cwd?: string;
   /** OpenClaw gateway profile name to lookup in the registry. */
   openclawGateway?: string;
@@ -346,10 +356,13 @@ export function buildManagedRoutes(
       match: { accountId: agentId },
       runtime,
       cwd: meta.cwd || agentWorkspaceDir(agentId),
-      // Inherit defaultRoute's extraArgs so synthesized per-agent routes
-      // pick up operator-wide flags (e.g. `--permission-mode bypassPermissions`)
-      // that would otherwise apply only to agents listed in `cfg.routes[]`.
-      ...(defaultRoute.extraArgs ? { extraArgs: defaultRoute.extraArgs.slice() } : {}),
+      ...(() => {
+        const extraArgs = mergeRuntimeExtraArgs(
+          defaultRoute.extraArgs,
+          buildRuntimeSelectionExtraArgs(runtime, meta),
+        );
+        return extraArgs ? { extraArgs } : {};
+      })(),
     };
     if (runtime === "openclaw-acp") {
       // Per RFC §3.4: prefer credentials, fall back to defaultRoute.gateway.

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -684,7 +684,7 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
  */
 export interface BootBackfillResult {
   credentialPathByAgentId: Map<string, string>;
-  agentRuntimes: Record<string, { runtime?: string; cwd?: string; openclawGateway?: string; openclawAgent?: string; hermesProfile?: string }>;
+  agentRuntimes: Record<string, { runtime?: string; runtimeModel?: string; reasoningEffort?: string; thinking?: boolean; cwd?: string; openclawGateway?: string; openclawAgent?: string; hermesProfile?: string }>;
 }
 
 /**
@@ -703,13 +703,25 @@ export function backfillBootAgents(
 ): BootBackfillResult {
   const ensure = opts.ensure ?? ensureAgentWorkspace;
   const credentialPathByAgentId = new Map<string, string>();
-  const agentRuntimes: Record<string, { runtime?: string; cwd?: string }> = {};
+  const agentRuntimes: Record<string, { runtime?: string; runtimeModel?: string; reasoningEffort?: string; thinking?: boolean; cwd?: string; openclawGateway?: string; openclawAgent?: string; hermesProfile?: string }> = {};
   const failed: string[] = [];
   for (const a of agents) {
     if (a.credentialsFile) credentialPathByAgentId.set(a.agentId, a.credentialsFile);
-    if (a.runtime || a.cwd || a.openclawGateway || a.openclawAgent || a.hermesProfile) {
+    if (
+      a.runtime ||
+      a.runtimeModel ||
+      a.reasoningEffort ||
+      typeof a.thinking === "boolean" ||
+      a.cwd ||
+      a.openclawGateway ||
+      a.openclawAgent ||
+      a.hermesProfile
+    ) {
       agentRuntimes[a.agentId] = {
         ...(a.runtime ? { runtime: a.runtime } : {}),
+        ...(a.runtimeModel ? { runtimeModel: a.runtimeModel } : {}),
+        ...(a.reasoningEffort ? { reasoningEffort: a.reasoningEffort } : {}),
+        ...(typeof a.thinking === "boolean" ? { thinking: a.thinking } : {}),
         ...(a.cwd ? { cwd: a.cwd } : {}),
         ...(a.openclawGateway ? { openclawGateway: a.openclawGateway } : {}),
         ...(a.openclawAgent ? { openclawAgent: a.openclawAgent } : {}),

--- a/packages/daemon/src/gateway/__tests__/deepseek-tui-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/deepseek-tui-adapter.test.ts
@@ -106,7 +106,12 @@ async function startMockDeepseekServer(opts?: {
   };
 }
 
-function runAdapter(serverUrl: string, authToken: string, sessionId: string | null = null) {
+function runAdapter(
+  serverUrl: string,
+  authToken: string,
+  sessionId: string | null = null,
+  extraArgs?: string[],
+) {
   const adapter = new DeepseekTuiAdapter({ serverUrl, authToken });
   const ctrl = new AbortController();
   const blocks: string[] = [];
@@ -118,6 +123,7 @@ function runAdapter(serverUrl: string, authToken: string, sessionId: string | nu
     cwd: tmpRoot,
     signal: ctrl.signal,
     trustLevel: "owner",
+    extraArgs,
     systemContext: "runtime memory",
     onBlock: (b) => blocks.push(b.kind),
     onStatus: (e) => {
@@ -179,6 +185,29 @@ describe("DeepseekTuiAdapter", () => {
       const patch = server.calls.find((c) => c.method === "PATCH");
       expect(patch?.url).toBe("/v1/threads/thr_existing");
       expect(patch?.body).toEqual({ system_prompt: "runtime memory" });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("passes selected model and reasoning effort through HTTP payloads", async () => {
+    const server = await startMockDeepseekServer();
+    try {
+      const { result } = runAdapter(server.baseUrl, server.token, null, [
+        "--model",
+        "deepseek-v4-pro",
+        "--reasoning-effort",
+        "auto",
+      ]);
+      await result;
+      expect(server.calls.find((c) => c.method === "POST" && c.url === "/v1/threads")?.body).toMatchObject({
+        model: "deepseek-v4-pro",
+        reasoning_effort: "auto",
+      });
+      expect(server.calls.find((c) => c.method === "POST" && c.url.endsWith("/turns"))?.body).toMatchObject({
+        model: "deepseek-v4-pro",
+        reasoning_effort: "auto",
+      });
     } finally {
       await server.close();
     }

--- a/packages/daemon/src/gateway/runtimes/deepseek-tui.ts
+++ b/packages/daemon/src/gateway/runtimes/deepseek-tui.ts
@@ -260,6 +260,9 @@ export class DeepseekTuiAdapter implements RuntimeAdapter {
       auto_approve: opts.trustLevel !== "public",
       archived: false,
     };
+    const selection = parseDeepseekRuntimeSelection(opts.extraArgs);
+    if (selection.model) body.model = selection.model;
+    if (selection.reasoningEffort) body.reasoning_effort = selection.reasoningEffort;
     if (opts.systemContext) body.system_prompt = opts.systemContext;
     const res = await this.requestJson<any>(`${baseUrl}/v1/threads`, {
       method: "POST",
@@ -306,18 +309,22 @@ export class DeepseekTuiAdapter implements RuntimeAdapter {
     });
     let turnId = "";
     try {
+      const selection = parseDeepseekRuntimeSelection(opts.extraArgs);
+      const body: Record<string, unknown> = {
+        prompt: opts.text,
+        mode: "agent",
+        allow_shell: opts.trustLevel !== "public",
+        trust_mode: opts.trustLevel !== "public",
+        auto_approve: opts.trustLevel !== "public",
+      };
+      if (selection.model) body.model = selection.model;
+      if (selection.reasoningEffort) body.reasoning_effort = selection.reasoningEffort;
       const started = await this.requestJson<any>(
         `${baseUrl}/v1/threads/${encodeURIComponent(threadId)}/turns`,
         {
           method: "POST",
           headers,
-          body: JSON.stringify({
-            prompt: opts.text,
-            mode: "agent",
-            allow_shell: opts.trustLevel !== "public",
-            trust_mode: opts.trustLevel !== "public",
-            auto_approve: opts.trustLevel !== "public",
-          }),
+          body: JSON.stringify(body),
           signal,
         },
       );
@@ -533,6 +540,41 @@ function parseSseFrame(raw: string): { event: string; data: any } | null {
 
 function authHeaders(token: string): HeadersInit {
   return token ? { authorization: `Bearer ${token}` } : {};
+}
+
+function parseDeepseekRuntimeSelection(
+  extraArgs: string[] | undefined,
+): { model?: string; reasoningEffort?: string } {
+  const out: { model?: string; reasoningEffort?: string } = {};
+  if (!extraArgs?.length) return out;
+  for (let i = 0; i < extraArgs.length; i += 1) {
+    const arg = extraArgs[i]!;
+    if (arg === "--model") {
+      const value = nextArgValue(extraArgs, i);
+      if (value !== undefined) {
+        out.model = value;
+        i += 1;
+      }
+    } else if (arg.startsWith("--model=")) {
+      out.model = arg.slice("--model=".length);
+    } else if (arg === "--reasoning-effort") {
+      const value = nextArgValue(extraArgs, i);
+      if (value !== undefined) {
+        out.reasoningEffort = value;
+        i += 1;
+      }
+    } else if (arg.startsWith("--reasoning-effort=")) {
+      out.reasoningEffort = arg.slice("--reasoning-effort=".length);
+    }
+  }
+  return out;
+}
+
+function nextArgValue(args: string[], index: number): string | undefined {
+  const next = args[index + 1];
+  if (typeof next !== "string") return undefined;
+  if (!next.startsWith("-")) return next;
+  return /^-\d/.test(next) ? next : undefined;
 }
 
 function poolKey(opts: RuntimeRunOptions): string {

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -72,6 +72,7 @@ import {
 import { log as daemonLog } from "./log.js";
 import { discoverAgentCredentials } from "./agent-discovery.js";
 import { resolveMemoryDir } from "./working-memory.js";
+import { discoverRuntimeModelCatalog } from "./runtime-models.js";
 
 /**
  * Information passed to {@link OnAgentInstalledHook} after a successful
@@ -1784,6 +1785,10 @@ export function collectRuntimeSnapshot(opts: { force?: boolean } = {}): ListRunt
     // style used above.
     if (entry.result.version) record.version = entry.result.version;
     if (entry.result.path) record.path = entry.result.path;
+    const catalog = discoverRuntimeModelCatalog(entry);
+    const models = catalog.models;
+    if (models?.length) record.models = models.slice(0, RUNTIME_MODELS_CAP);
+    if (catalog.parameters?.length) record.parameters = catalog.parameters.slice(0, RUNTIME_PARAMETERS_CAP);
     // Gateway's probe surface doesn't expose an `error` string today — it
     // already swallows throws into `{available: false}`. We leave the wire
     // field blank in that case and let callers treat `!available` as reason
@@ -1841,6 +1846,8 @@ export function attachRuntimeHealth(
 
 /** Maximum number of `endpoints[]` entries persisted per runtime (RFC §3.8.2). */
 export const RUNTIME_ENDPOINTS_CAP = 32;
+export const RUNTIME_MODELS_CAP = 128;
+export const RUNTIME_PARAMETERS_CAP = 64;
 
 /** Injection seam for L2 + L3 endpoint probes — kept testable + side-effect-free. */
 export type WsEndpointProbeFn = (args: {

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -73,6 +73,10 @@ import { log as daemonLog } from "./log.js";
 import { discoverAgentCredentials } from "./agent-discovery.js";
 import { resolveMemoryDir } from "./working-memory.js";
 import { discoverRuntimeModelCatalog } from "./runtime-models.js";
+import {
+  buildRuntimeSelectionExtraArgs,
+  mergeRuntimeExtraArgs,
+} from "./runtime-route-options.js";
 
 /**
  * Information passed to {@link OnAgentInstalledHook} after a successful
@@ -1058,6 +1062,11 @@ function upsertManagedRouteForCredentials(
     runtime: credentials.runtime ?? cfg.defaultRoute.adapter,
     cwd: credentials.cwd ?? agentWorkspaceDir(credentials.agentId),
   };
+  const extraArgs = mergeRuntimeExtraArgs(
+    cfg.defaultRoute.extraArgs,
+    buildRuntimeSelectionExtraArgs(synthRoute.runtime, credentials),
+  );
+  if (extraArgs) synthRoute.extraArgs = extraArgs;
   if (synthRoute.runtime === "openclaw-acp") {
     const profile = (cfg.openclawGateways ?? []).find(
       (g) => g.name === credentials.openclawGateway,
@@ -1170,6 +1179,10 @@ async function materializeCredentials(
     if (c.token) record.token = c.token;
     if (typeof c.tokenExpiresAt === "number") record.tokenExpiresAt = c.tokenExpiresAt;
     if (runtime) record.runtime = runtime;
+    const runtimeSelection = pickRuntimeSelection(params);
+    if (runtimeSelection.runtimeModel) record.runtimeModel = runtimeSelection.runtimeModel;
+    if (runtimeSelection.reasoningEffort) record.reasoningEffort = runtimeSelection.reasoningEffort;
+    if (typeof runtimeSelection.thinking === "boolean") record.thinking = runtimeSelection.thinking;
     record.cwd = cwd;
     const openclawSel = pickOpenclawSelection(params);
     if (openclawSel.gateway) record.openclawGateway = openclawSel.gateway;
@@ -1204,6 +1217,10 @@ async function materializeCredentials(
     tokenExpiresAt: reg.expiresAt,
   };
   if (runtime) record.runtime = runtime;
+  const runtimeSelection = pickRuntimeSelection(params);
+  if (runtimeSelection.runtimeModel) record.runtimeModel = runtimeSelection.runtimeModel;
+  if (runtimeSelection.reasoningEffort) record.reasoningEffort = runtimeSelection.reasoningEffort;
+  if (typeof runtimeSelection.thinking === "boolean") record.thinking = runtimeSelection.thinking;
   record.cwd = cwd;
   const openclawSel = pickOpenclawSelection(params);
   if (openclawSel.gateway) record.openclawGateway = openclawSel.gateway;
@@ -2518,20 +2535,34 @@ export async function reloadConfig(ctx: { gateway: Gateway }): Promise<ReloadRes
  */
 function readAgentRuntimesFromCredentials(
   agentIds: string[],
-): Record<string, { runtime?: string; cwd?: string; openclawGateway?: string; openclawAgent?: string; hermesProfile?: string }> {
-  const out: Record<string, { runtime?: string; cwd?: string; openclawGateway?: string; openclawAgent?: string; hermesProfile?: string }> = {};
+): Record<string, { runtime?: string; runtimeModel?: string; reasoningEffort?: string; thinking?: boolean; cwd?: string; openclawGateway?: string; openclawAgent?: string; hermesProfile?: string }> {
+  const out: Record<string, { runtime?: string; runtimeModel?: string; reasoningEffort?: string; thinking?: boolean; cwd?: string; openclawGateway?: string; openclawAgent?: string; hermesProfile?: string }> = {};
   for (const id of agentIds) {
     const file = defaultCredentialsFile(id);
     try {
       if (!existsSync(file)) continue;
       const creds = loadStoredCredentials(file);
-      const entry: { runtime?: string; cwd?: string; openclawGateway?: string; openclawAgent?: string; hermesProfile?: string } = {};
+      const entry: { runtime?: string; runtimeModel?: string; reasoningEffort?: string; thinking?: boolean; cwd?: string; openclawGateway?: string; openclawAgent?: string; hermesProfile?: string } = {};
       if (creds.runtime) entry.runtime = creds.runtime;
+      if (creds.runtimeModel) entry.runtimeModel = creds.runtimeModel;
+      if (creds.reasoningEffort) entry.reasoningEffort = creds.reasoningEffort;
+      if (typeof creds.thinking === "boolean") entry.thinking = creds.thinking;
       if (creds.cwd) entry.cwd = creds.cwd;
       if (creds.openclawGateway) entry.openclawGateway = creds.openclawGateway;
       if (creds.openclawAgent) entry.openclawAgent = creds.openclawAgent;
       if (creds.hermesProfile) entry.hermesProfile = creds.hermesProfile;
-      if (entry.runtime || entry.cwd || entry.openclawGateway || entry.openclawAgent || entry.hermesProfile) out[id] = entry;
+      if (
+        entry.runtime ||
+        entry.runtimeModel ||
+        entry.reasoningEffort ||
+        typeof entry.thinking === "boolean" ||
+        entry.cwd ||
+        entry.openclawGateway ||
+        entry.openclawAgent ||
+        entry.hermesProfile
+      ) {
+        out[id] = entry;
+      }
     } catch {
       // best-effort — skip agents with unreadable credentials
     }
@@ -2772,6 +2803,33 @@ function pickRuntime(params: ProvisionAgentParams): string | undefined {
   const candidates = [params.runtime, params.adapter, params.credentials?.runtime];
   for (const c of candidates) {
     if (typeof c === "string" && c.length > 0) return c;
+  }
+  return undefined;
+}
+
+function pickRuntimeSelection(
+  params: ProvisionAgentParams,
+): { runtimeModel?: string; reasoningEffort?: string; thinking?: boolean } {
+  const out: { runtimeModel?: string; reasoningEffort?: string; thinking?: boolean } = {};
+  const runtimeModel = pickString(params.runtimeModel, params.credentials?.runtimeModel);
+  const reasoningEffort = pickString(
+    params.reasoningEffort,
+    params.credentials?.reasoningEffort,
+  );
+  if (runtimeModel) out.runtimeModel = runtimeModel;
+  if (reasoningEffort) out.reasoningEffort = reasoningEffort;
+  if (typeof params.thinking === "boolean") {
+    out.thinking = params.thinking;
+  } else if (typeof params.credentials?.thinking === "boolean") {
+    out.thinking = params.credentials.thinking;
+  }
+  return out;
+}
+
+function pickString(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) return trimmed;
   }
   return undefined;
 }

--- a/packages/daemon/src/runtime-models.ts
+++ b/packages/daemon/src/runtime-models.ts
@@ -1,0 +1,601 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+import type { RuntimeModelProbe, RuntimeParameterProbe } from "@botcord/protocol-core";
+import type { RuntimeProbeEntry } from "./adapters/runtimes.js";
+
+const MODEL_LIST_TIMEOUT_MS = 5000;
+const MODEL_LIST_MAX_BUFFER = 16 * 1024 * 1024;
+
+const CLAUDE_ALIAS_MODELS: RuntimeModelProbe[] = [
+  { id: "default", displayName: "Default", provider: "anthropic", source: "builtin" },
+  { id: "best", displayName: "Best", provider: "anthropic", source: "builtin" },
+  { id: "sonnet", displayName: "Sonnet", provider: "anthropic", source: "builtin" },
+  { id: "opus", displayName: "Opus", provider: "anthropic", source: "builtin" },
+  { id: "haiku", displayName: "Haiku", provider: "anthropic", source: "builtin" },
+  { id: "sonnet[1m]", displayName: "Sonnet 1M", provider: "anthropic", source: "builtin" },
+  { id: "opus[1m]", displayName: "Opus 1M", provider: "anthropic", source: "builtin" },
+  { id: "opusplan", displayName: "Opus Plan", provider: "anthropic", source: "builtin" },
+];
+
+const CLAUDE_EFFORT_VALUES = ["low", "medium", "high", "xhigh", "max"];
+const CLAUDE_PERMISSION_MODE_VALUES = [
+  "acceptEdits",
+  "auto",
+  "bypassPermissions",
+  "default",
+  "dontAsk",
+  "plan",
+];
+const CODEX_SANDBOX_MODES = ["read-only", "workspace-write", "danger-full-access"];
+const CODEX_APPROVAL_POLICIES = ["untrusted", "on-failure", "on-request", "never"];
+const DEEPSEEK_PROVIDER_VALUES = [
+  "deepseek",
+  "nvidia-nim",
+  "openai",
+  "openrouter",
+  "novita",
+  "fireworks",
+  "sglang",
+  "vllm",
+  "ollama",
+];
+
+export interface RuntimeModelDiscovery {
+  models?: RuntimeModelProbe[];
+  parameters?: RuntimeParameterProbe[];
+}
+
+export function discoverRuntimeModelCatalog(entry: RuntimeProbeEntry): RuntimeModelDiscovery {
+  if (!entry.result.available) return {};
+  try {
+    switch (entry.id) {
+      case "claude-code":
+        return discoverClaudeCatalog();
+      case "codex":
+        return discoverCodexCatalog(entry.result.path);
+      case "deepseek-tui":
+        return discoverDeepseekCatalog(entry.result.path);
+      case "kimi-cli":
+        return discoverKimiCatalog();
+      default:
+        return {};
+    }
+  } catch {
+    return {};
+  }
+}
+
+export function discoverRuntimeModels(entry: RuntimeProbeEntry): RuntimeModelProbe[] | undefined {
+  return discoverRuntimeModelCatalog(entry).models;
+}
+
+export function discoverRuntimeParameters(entry: RuntimeProbeEntry): RuntimeParameterProbe[] | undefined {
+  return discoverRuntimeModelCatalog(entry).parameters;
+}
+
+function discoverClaudeCatalog(): RuntimeModelDiscovery {
+  return {
+    models: discoverClaudeModels(),
+    parameters: discoverClaudeParameters(),
+  };
+}
+
+export function discoverClaudeModels(): RuntimeModelProbe[] {
+  const models = new Map<string, RuntimeModelProbe>();
+  const add = (model: RuntimeModelProbe): void => {
+    if (!model.id) return;
+    const existing = models.get(model.id);
+    models.set(model.id, { ...existing, ...model });
+  };
+
+  for (const model of CLAUDE_ALIAS_MODELS) add(model);
+
+  const settings = readJsonObject(path.join(homedir(), ".claude", "settings.json"));
+  const defaultModel = stringField(settings, "model");
+  if (defaultModel) {
+    add({
+      id: defaultModel,
+      displayName: defaultModel,
+      provider: "anthropic",
+      source: "config",
+      isDefault: true,
+    });
+  }
+
+  for (const item of arrayField(settings, "availableModels")) {
+    if (typeof item === "string" && item) {
+      add({ id: item, displayName: item, provider: "anthropic", source: "config" });
+    }
+  }
+
+  for (const envName of [
+    "ANTHROPIC_DEFAULT_OPUS_MODEL",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+    "ANTHROPIC_CUSTOM_MODEL_OPTION",
+  ]) {
+    const value = process.env[envName];
+    if (value) {
+      add({
+        id: value,
+        displayName: value,
+        provider: "anthropic",
+        source: "env",
+        metadata: { env: envName },
+      });
+    }
+  }
+
+  return Array.from(models.values());
+}
+
+function discoverClaudeParameters(): RuntimeParameterProbe[] {
+  const settings = readJsonObject(path.join(homedir(), ".claude", "settings.json"));
+  const effort = stringField(settings, "effort");
+  const permissionMode =
+    stringField(settings, "permissionMode") ?? stringField(settings, "permission-mode");
+  const out: RuntimeParameterProbe[] = [
+    {
+      id: "effort",
+      displayName: "Effort",
+      type: "enum",
+      flag: "--effort",
+      values: CLAUDE_EFFORT_VALUES,
+      source: "cli",
+    },
+    {
+      id: "permission_mode",
+      displayName: "Permission mode",
+      type: "enum",
+      flag: "--permission-mode",
+      values: CLAUDE_PERMISSION_MODE_VALUES,
+      source: "cli",
+    },
+  ];
+  if (effort) out[0] = { ...out[0]!, defaultValue: effort, source: "config" };
+  if (permissionMode) out[1] = { ...out[1]!, defaultValue: permissionMode, source: "config" };
+  return out;
+}
+
+function discoverCodexCatalog(command: string | undefined): RuntimeModelDiscovery {
+  const raw = runCommand(codexCommand(command), ["debug", "models"]);
+  return {
+    models: raw ? parseCodexModelCatalog(raw) : undefined,
+    parameters: discoverCodexParameters(raw),
+  };
+}
+
+export function discoverCodexModels(command: string | undefined): RuntimeModelProbe[] | undefined {
+  return discoverCodexCatalog(command).models;
+}
+
+export function parseCodexModelCatalog(raw: string): RuntimeModelProbe[] | undefined {
+  const parsed = JSON.parse(raw) as { models?: unknown[] };
+  if (!Array.isArray(parsed.models)) return undefined;
+  const out: RuntimeModelProbe[] = [];
+  for (const item of parsed.models) {
+    if (!item || typeof item !== "object") continue;
+    const obj = item as Record<string, unknown>;
+    const id = stringField(obj, "slug");
+    if (!id) continue;
+    if (stringField(obj, "visibility") === "hide") continue;
+
+    const model: RuntimeModelProbe = {
+      id,
+      provider: "openai",
+      source: "cli",
+    };
+    const displayName = stringField(obj, "display_name");
+    if (displayName) model.displayName = displayName;
+
+    const metadata: Record<string, unknown> = {};
+    const supportedInApi = obj.supported_in_api;
+    if (typeof supportedInApi === "boolean") metadata.supportedInApi = supportedInApi;
+    const defaultReasoningLevel = stringField(obj, "default_reasoning_level");
+    if (defaultReasoningLevel) metadata.defaultReasoningLevel = defaultReasoningLevel;
+    const supportedReasoningLevels = arrayField(obj, "supported_reasoning_levels")
+      .map((level) =>
+        level && typeof level === "object"
+          ? stringField(level as Record<string, unknown>, "effort")
+          : undefined,
+      )
+      .filter((level): level is string => !!level);
+    if (supportedReasoningLevels.length) metadata.supportedReasoningLevels = supportedReasoningLevels;
+    if (Object.keys(metadata).length) model.metadata = metadata;
+    if (supportedReasoningLevels.length) {
+      model.parameters = [
+        {
+          id: "reasoning_effort",
+          displayName: "Reasoning effort",
+          type: "enum",
+          flag: "-c model_reasoning_effort=<value>",
+          values: supportedReasoningLevels,
+          ...(defaultReasoningLevel ? { defaultValue: defaultReasoningLevel } : {}),
+          source: "cli",
+        },
+      ];
+    }
+
+    out.push(model);
+  }
+  return out.length ? out : undefined;
+}
+
+function discoverCodexParameters(rawCatalog: string | null): RuntimeParameterProbe[] {
+  const config = readConfigScalars(path.join(homedir(), ".codex", "config.toml"));
+  const reasoningValues = new Set<string>();
+  if (rawCatalog) {
+    try {
+      const parsed = JSON.parse(rawCatalog) as { models?: unknown[] };
+      if (Array.isArray(parsed.models)) {
+        for (const item of parsed.models) {
+          if (!item || typeof item !== "object") continue;
+          for (const level of arrayField(item as Record<string, unknown>, "supported_reasoning_levels")) {
+            if (!level || typeof level !== "object") continue;
+            const effort = stringField(level as Record<string, unknown>, "effort");
+            if (effort) reasoningValues.add(effort);
+          }
+        }
+      }
+    } catch {
+      // ignore malformed catalog; runtime-level defaults still come from config.
+    }
+  }
+  return [
+    compactParameter({
+      id: "model",
+      displayName: "Default model",
+      type: "string",
+      flag: "-m, --model",
+      defaultValue: config.model,
+      source: config.model ? "config" : "cli",
+    }),
+    compactParameter({
+      id: "reasoning_effort",
+      displayName: "Reasoning effort",
+      type: reasoningValues.size > 0 ? "enum" : "string",
+      flag: "-c model_reasoning_effort=<value>",
+      values: reasoningValues.size > 0 ? Array.from(reasoningValues) : undefined,
+      defaultValue: config.model_reasoning_effort,
+      source: config.model_reasoning_effort ? "config" : "cli",
+      metadata: { scope: "per-model-values-may-differ" },
+    }),
+    compactParameter({
+      id: "approval_policy",
+      displayName: "Approval policy",
+      type: "enum",
+      flag: "-a, --ask-for-approval",
+      values: CODEX_APPROVAL_POLICIES,
+      defaultValue: config.approval_policy,
+      source: config.approval_policy ? "config" : "cli",
+    }),
+    compactParameter({
+      id: "sandbox_mode",
+      displayName: "Sandbox mode",
+      type: "enum",
+      flag: "-s, --sandbox",
+      values: CODEX_SANDBOX_MODES,
+      defaultValue: config.sandbox_mode,
+      source: config.sandbox_mode ? "config" : "cli",
+    }),
+    compactParameter({
+      id: "web_search",
+      displayName: "Web search",
+      type: "boolean",
+      flag: "--search",
+      defaultValue: parseTomlBool(config.web_search),
+      source: config.web_search ? "config" : "cli",
+    }),
+  ];
+}
+
+function discoverDeepseekCatalog(command: string | undefined): RuntimeModelDiscovery {
+  return {
+    models: discoverDeepseekModels(command),
+    parameters: discoverDeepseekParameters(),
+  };
+}
+
+export function discoverDeepseekModels(command: string | undefined): RuntimeModelProbe[] | undefined {
+  const raw = runCommand([command ?? "deepseek"], ["model", "list"]);
+  if (!raw) return undefined;
+  return parseDeepseekModelList(raw);
+}
+
+export function parseDeepseekModelList(raw: string): RuntimeModelProbe[] | undefined {
+  const out: RuntimeModelProbe[] = [];
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const match = trimmed.match(/^(.+?)\s+\(([^()]+)\)$/);
+    const id = match ? match[1]!.trim() : trimmed;
+    const provider = match ? match[2]!.trim() : "deepseek";
+    if (!id) continue;
+    out.push({ id, displayName: id, provider, source: "cli" });
+  }
+  return out.length ? out : undefined;
+}
+
+function discoverDeepseekParameters(): RuntimeParameterProbe[] {
+  const config = readConfigScalars(path.join(homedir(), ".deepseek", "config.toml"));
+  return [
+    compactParameter({
+      id: "model",
+      displayName: "Default model",
+      type: "string",
+      flag: "--model",
+      defaultValue: config.default_text_model,
+      source: config.default_text_model ? "config" : "cli",
+    }),
+    compactParameter({
+      id: "provider",
+      displayName: "Provider",
+      type: "enum",
+      flag: "--provider",
+      values: DEEPSEEK_PROVIDER_VALUES,
+      defaultValue: config.provider,
+      source: config.provider ? "config" : "cli",
+    }),
+    compactParameter({
+      id: "reasoning_effort",
+      displayName: "Reasoning effort",
+      type: "string",
+      flag: "reasoning_effort",
+      defaultValue: config.reasoning_effort,
+      source: config.reasoning_effort ? "config" : "cli",
+    }),
+    compactParameter({
+      id: "approval_policy",
+      displayName: "Approval policy",
+      type: "string",
+      flag: "--approval-policy",
+      defaultValue: config.approval_policy,
+      source: config.approval_policy ? "config" : "cli",
+    }),
+    compactParameter({
+      id: "sandbox_mode",
+      displayName: "Sandbox mode",
+      type: "string",
+      flag: "--sandbox-mode",
+      defaultValue: config.sandbox_mode,
+      source: config.sandbox_mode ? "config" : "cli",
+    }),
+  ];
+}
+
+function discoverKimiCatalog(): RuntimeModelDiscovery {
+  const configPath = path.join(homedir(), ".kimi", "config.toml");
+  if (!existsSync(configPath)) return {};
+  const raw = readFileSync(configPath, "utf8");
+  return {
+    models: parseKimiConfigModels(raw),
+    parameters: parseKimiRuntimeParameters(raw),
+  };
+}
+
+export function discoverKimiModels(): RuntimeModelProbe[] | undefined {
+  return discoverKimiCatalog().models;
+}
+
+export function parseKimiConfigModels(raw: string): RuntimeModelProbe[] | undefined {
+  const defaultModel = matchScalar(raw, /^default_model\s*=\s*["']([^"']+)["']/m);
+  const out: RuntimeModelProbe[] = [];
+  const sectionRe = /^\[models\."([^"]+)"\]\s*$/gm;
+  const matches = Array.from(raw.matchAll(sectionRe));
+  for (let i = 0; i < matches.length; i += 1) {
+    const match = matches[i]!;
+    const id = match[1]!;
+    const start = (match.index ?? 0) + match[0].length;
+    const end = i + 1 < matches.length ? matches[i + 1]!.index ?? raw.length : raw.length;
+    const body = raw.slice(start, end);
+    const model: RuntimeModelProbe = {
+      id,
+      source: "config",
+      isDefault: id === defaultModel,
+    };
+    const provider = matchScalar(body, /^\s*provider\s*=\s*["']([^"']+)["']/m);
+    if (provider) model.provider = provider;
+    const displayName = matchScalar(body, /^\s*display_name\s*=\s*["']([^"']+)["']/m);
+    if (displayName) model.displayName = displayName;
+    const contextLength = matchScalar(body, /^\s*max_context_size\s*=\s*(\d+)/m);
+    if (contextLength) model.contextLength = Number(contextLength);
+    const capabilities = matchArray(body, /^\s*capabilities\s*=\s*\[([^\]]*)\]/m);
+    if (capabilities.length) model.capabilities = capabilities;
+    if (capabilities.includes("thinking")) {
+      const defaultThinking = parseTomlBool(matchScalar(raw, /^default_thinking\s*=\s*(true|false)/m));
+      model.parameters = [
+        compactParameter({
+          id: "thinking",
+          displayName: "Thinking",
+          type: "boolean",
+          flag: "--thinking/--no-thinking",
+          defaultValue: defaultThinking,
+          source: defaultThinking === undefined ? "cli" : "config",
+        }),
+      ];
+    }
+    const runtimeModel = matchScalar(body, /^\s*model\s*=\s*["']([^"']+)["']/m);
+    if (runtimeModel) model.metadata = { model: runtimeModel };
+    out.push(model);
+  }
+  return out.length ? out : undefined;
+}
+
+export function parseKimiRuntimeParameters(raw: string): RuntimeParameterProbe[] {
+  return [
+    compactParameter({
+      id: "model",
+      displayName: "Default model",
+      type: "string",
+      flag: "-m, --model",
+      defaultValue: matchScalar(raw, /^default_model\s*=\s*["']([^"']+)["']/m),
+      source: "config",
+    }),
+    compactParameter({
+      id: "thinking",
+      displayName: "Thinking",
+      type: "boolean",
+      flag: "--thinking/--no-thinking",
+      defaultValue: parseTomlBool(matchScalar(raw, /^default_thinking\s*=\s*(true|false)/m)),
+      source: "config",
+    }),
+    compactParameter({
+      id: "show_thinking_stream",
+      displayName: "Show thinking stream",
+      type: "boolean",
+      defaultValue: parseTomlBool(matchScalar(raw, /^show_thinking_stream\s*=\s*(true|false)/m)),
+      source: "config",
+    }),
+    compactParameter({
+      id: "yolo",
+      displayName: "Auto approve",
+      type: "boolean",
+      flag: "--yolo, --yes, -y",
+      defaultValue: parseTomlBool(matchScalar(raw, /^default_yolo\s*=\s*(true|false)/m)),
+      source: "config",
+    }),
+    compactParameter({
+      id: "plan_mode",
+      displayName: "Plan mode",
+      type: "boolean",
+      flag: "--plan",
+      defaultValue: parseTomlBool(matchScalar(raw, /^default_plan_mode\s*=\s*(true|false)/m)),
+      source: "config",
+    }),
+    compactParameter({
+      id: "max_steps_per_turn",
+      displayName: "Max steps per turn",
+      type: "integer",
+      flag: "--max-steps-per-turn",
+      defaultValue: parseTomlInt(matchScalar(raw, /^max_steps_per_turn\s*=\s*(\d+)/m)),
+      minimum: 1,
+      source: "config",
+    }),
+    compactParameter({
+      id: "max_retries_per_step",
+      displayName: "Max retries per step",
+      type: "integer",
+      flag: "--max-retries-per-step",
+      defaultValue: parseTomlInt(matchScalar(raw, /^max_retries_per_step\s*=\s*(\d+)/m)),
+      minimum: 1,
+      source: "config",
+    }),
+    compactParameter({
+      id: "max_ralph_iterations",
+      displayName: "Max Ralph iterations",
+      type: "integer",
+      flag: "--max-ralph-iterations",
+      defaultValue: parseTomlInt(matchScalar(raw, /^max_ralph_iterations\s*=\s*(-?\d+)/m)),
+      minimum: -1,
+      source: "config",
+    }),
+    compactParameter({
+      id: "reserved_context_size",
+      displayName: "Reserved context size",
+      type: "integer",
+      defaultValue: parseTomlInt(matchScalar(raw, /^reserved_context_size\s*=\s*(\d+)/m)),
+      minimum: 0,
+      source: "config",
+    }),
+  ];
+}
+
+function codexCommand(command: string | undefined): string[] {
+  if (command?.endsWith(".js")) return [process.execPath, command];
+  return [command ?? "codex"];
+}
+
+function runCommand(command: string[], args: string[]): string | null {
+  try {
+    return execFileSync(command[0]!, [...command.slice(1), ...args], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: MODEL_LIST_TIMEOUT_MS,
+      maxBuffer: MODEL_LIST_MAX_BUFFER,
+      env: { ...process.env, FORCE_COLOR: "0", NO_COLOR: "1" },
+    });
+  } catch {
+    return null;
+  }
+}
+
+function readJsonObject(file: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(readFileSync(file, "utf8"));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function readConfigScalars(file: string): Record<string, string | undefined> {
+  try {
+    const raw = readFileSync(file, "utf8");
+    const out: Record<string, string | undefined> = {};
+    for (const match of raw.matchAll(/^([A-Za-z0-9_.-]+)\s*=\s*(.+?)\s*$/gm)) {
+      const key = match[1];
+      const rawValue = match[2]?.trim();
+      if (!key || !rawValue) continue;
+      out[key] = rawValue.replace(/^["']|["']$/g, "");
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function compactParameter(param: RuntimeParameterProbe): RuntimeParameterProbe {
+  const out: RuntimeParameterProbe = {
+    id: param.id,
+    type: param.type,
+  };
+  if (param.displayName) out.displayName = param.displayName;
+  if (param.flag) out.flag = param.flag;
+  if (param.values?.length) out.values = param.values;
+  if (param.defaultValue !== undefined) out.defaultValue = param.defaultValue;
+  if (param.minimum !== undefined) out.minimum = param.minimum;
+  if (param.maximum !== undefined) out.maximum = param.maximum;
+  if (param.source) out.source = param.source;
+  if (param.metadata && Object.keys(param.metadata).length > 0) out.metadata = param.metadata;
+  return out;
+}
+
+function parseTomlBool(value: string | undefined): boolean | undefined {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return undefined;
+}
+
+function parseTomlInt(value: string | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  const n = Number(value);
+  return Number.isInteger(n) ? n : undefined;
+}
+
+function stringField(obj: Record<string, unknown> | null, key: string): string | undefined {
+  const value = obj?.[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function arrayField(obj: Record<string, unknown> | null, key: string): unknown[] {
+  const value = obj?.[key];
+  return Array.isArray(value) ? value : [];
+}
+
+function matchScalar(raw: string, re: RegExp): string | undefined {
+  const match = raw.match(re);
+  return match?.[1]?.trim() || undefined;
+}
+
+function matchArray(raw: string, re: RegExp): string[] {
+  const match = raw.match(re);
+  if (!match?.[1]) return [];
+  return match[1]
+    .split(",")
+    .map((part) => part.trim().replace(/^["']|["']$/g, ""))
+    .filter(Boolean);
+}

--- a/packages/daemon/src/runtime-route-options.ts
+++ b/packages/daemon/src/runtime-route-options.ts
@@ -1,0 +1,52 @@
+export interface RuntimeSelectionOptions {
+  runtimeModel?: string;
+  reasoningEffort?: string;
+  thinking?: boolean;
+}
+
+export function buildRuntimeSelectionExtraArgs(
+  runtime: string | undefined,
+  selection: RuntimeSelectionOptions,
+): string[] {
+  if (!runtime) return [];
+  const out: string[] = [];
+  const model = cleanString(selection.runtimeModel);
+  const reasoningEffort = cleanString(selection.reasoningEffort);
+
+  if (runtime === "claude-code") {
+    if (model) out.push("--model", model);
+    if (reasoningEffort) out.push("--effort", reasoningEffort);
+  } else if (runtime === "codex") {
+    if (model) out.push("--model", model);
+    if (reasoningEffort) {
+      out.push("-c", `model_reasoning_effort=${quoteCodexConfigValue(reasoningEffort)}`);
+    }
+  } else if (runtime === "deepseek-tui") {
+    if (model) out.push("--model", model);
+    if (reasoningEffort) out.push("--reasoning-effort", reasoningEffort);
+  } else if (runtime === "kimi-cli") {
+    if (model) out.push("--model", model);
+    if (typeof selection.thinking === "boolean") {
+      out.push(selection.thinking ? "--thinking" : "--no-thinking");
+    }
+  }
+
+  return out;
+}
+
+export function mergeRuntimeExtraArgs(
+  inherited: string[] | undefined,
+  selected: string[],
+): string[] | undefined {
+  const out = [...(inherited ?? []), ...selected];
+  return out.length ? out : undefined;
+}
+
+function cleanString(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function quoteCodexConfigValue(value: string): string {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}

--- a/packages/protocol-core/src/control-frame.ts
+++ b/packages/protocol-core/src/control-frame.ts
@@ -432,11 +432,75 @@ export interface RuntimeProbeResult {
    */
   profiles?: HermesProfileProbe[];
   /**
+   * Optional list of models the local runtime can currently select. This is
+   * best-effort and runtime-specific:
+   * - Codex / DeepSeek can expose CLI catalogs.
+   * - Kimi exposes the locally refreshed config models.
+   * - Claude Code exposes built-in aliases plus local settings/env overrides.
+   *
+   * Older Hub builds pass this through opaquely in `runtimes_json`.
+   */
+  models?: RuntimeModelProbe[];
+  /**
+   * Runtime-level configurable parameters and current defaults. These are
+   * global CLI/config knobs, not guarantees that every model supports them.
+   * Per-model knobs live on `models[].parameters`.
+   */
+  parameters?: RuntimeParameterProbe[];
+  /**
    * Optional live health state for this runtime on the daemon. Unlike
    * `available`, this describes current dispatch health rather than whether
    * the binary is installed.
    */
   health?: RuntimeHealthSnapshot;
+}
+
+/** One selectable model surfaced by daemon runtime discovery. */
+export interface RuntimeModelProbe {
+  /** Runtime-facing model id or alias to pass back via runtime-specific flags. */
+  id: string;
+  /** Human-readable label when the runtime/provider exposes one. */
+  displayName?: string;
+  /** Provider or provider profile key, when known. */
+  provider?: string;
+  /** Where this model entry came from. */
+  source?: "builtin" | "config" | "cli" | "api" | "gateway" | "env";
+  /** True when local config marks this as the default model. */
+  isDefault?: boolean;
+  /** Runtime/provider capability labels such as `thinking` or `image_in`. */
+  capabilities?: string[];
+  /** Maximum context tokens when the runtime/provider reports it. */
+  contextLength?: number;
+  /** Small runtime-specific facts that should not become protocol fields yet. */
+  metadata?: Record<string, unknown>;
+  /** Parameters known to apply to this specific model. */
+  parameters?: RuntimeParameterProbe[];
+}
+
+export type RuntimeParameterValue = string | number | boolean;
+
+/** One configurable runtime or model parameter surfaced by discovery. */
+export interface RuntimeParameterProbe {
+  /** Stable machine id, e.g. `reasoning_effort`, `thinking`, `sandbox_mode`. */
+  id: string;
+  /** Human-readable label when useful for UI. */
+  displayName?: string;
+  /** Value kind. */
+  type: "enum" | "boolean" | "integer" | "string";
+  /** Runtime CLI flag or config key that controls this parameter, when known. */
+  flag?: string;
+  /** Selectable values when the runtime exposes a finite set. */
+  values?: RuntimeParameterValue[];
+  /** Current/default value from runtime metadata or local config. */
+  defaultValue?: RuntimeParameterValue;
+  /** Minimum value for integer parameters. */
+  minimum?: number;
+  /** Maximum value for integer parameters. */
+  maximum?: number;
+  /** Where this parameter entry came from. */
+  source?: "builtin" | "config" | "cli" | "api" | "gateway" | "env";
+  /** Small runtime-specific facts that should not become protocol fields yet. */
+  metadata?: Record<string, unknown>;
 }
 
 export interface RuntimeHealthSnapshot {

--- a/packages/protocol-core/src/control-frame.ts
+++ b/packages/protocol-core/src/control-frame.ts
@@ -169,6 +169,12 @@ export interface ProvisionAgentParams {
    * on both sides.
    */
   runtime?: string;
+  /** Runtime model id/alias selected for this agent. */
+  runtimeModel?: string;
+  /** Runtime reasoning effort selected for this agent, when supported. */
+  reasoningEffort?: string;
+  /** Kimi-style thinking toggle selected for this agent, when supported. */
+  thinking?: boolean;
   /**
    * @deprecated alias for `runtime`, retained for one release so in-flight
    * Hub builds emitting the pre-rename name still work. Daemons prefer
@@ -191,6 +197,12 @@ export interface ProvisionAgentParams {
     displayName?: string;
     /** Runtime bound to the agent, cached by the daemon for offline routing. */
     runtime?: string;
+    /** Runtime model id/alias cached alongside runtime. */
+    runtimeModel?: string;
+    /** Runtime reasoning effort cached alongside runtime. */
+    reasoningEffort?: string;
+    /** Kimi-style thinking toggle cached alongside runtime. */
+    thinking?: boolean;
     /** Working directory cached alongside the runtime, for route synthesis. */
     cwd?: string;
     /**

--- a/packages/protocol-core/src/credentials.ts
+++ b/packages/protocol-core/src/credentials.ts
@@ -23,6 +23,12 @@ export interface StoredBotCordCredentials {
    * bind-code credentials have no value here. Authoritative source is Hub.
    */
   runtime?: string;
+  /** Runtime model id/alias selected for this agent, if any. */
+  runtimeModel?: string;
+  /** Runtime reasoning effort selected for this agent, if any. */
+  reasoningEffort?: string;
+  /** Kimi-style thinking toggle selected for this agent, if any. */
+  thinking?: boolean;
   /** Working directory pinned for this agent, cached alongside runtime. */
   cwd?: string;
   /**


### PR DESCRIPTION
## Summary
- add runtime snapshot schema for model catalogs plus runtime/model parameter metadata
- discover Claude, Codex, Kimi, and DeepSeek selectable models and defaults
- attach Codex per-model reasoning effort options while keeping global CLI/config knobs at runtime level
- add Create Agent runtime model / reasoning effort / thinking controls and send selections through Hub provision
- persist selected model options in daemon credentials and translate them into runtime route args for Claude, Codex, Kimi, and DeepSeek
- cap persisted nested model/parameter arrays in Hub snapshots and normalize them in the frontend daemon store

## Tests
- npm run build (packages/protocol-core)
- npm run build (packages/daemon)
- npm test -- src/__tests__/runtime-models.test.ts src/__tests__/runtime-discovery.test.ts (packages/daemon)
- npm test -- src/__tests__/daemon-config-map.test.ts src/__tests__/provision.test.ts src/gateway/__tests__/deepseek-tui-adapter.test.ts src/gateway/__tests__/codex-adapter.test.ts src/gateway/__tests__/claude-code-adapter.test.ts src/gateway/__tests__/kimi-adapter.test.ts (packages/daemon)
- uv run pytest tests/test_app/test_daemon_control.py -k "runtime_snapshot_caps_nested_models or runtime_snapshot_caps_nested_runtime_health" (backend)
- uv run pytest tests/test_app/test_agent_provision.py -k "runtime_model_options or reasoning_effort_not_supported or happy_path" (backend)
- npm run build (frontend) reaches compile + TypeScript, then fails prerendering /admin because Supabase URL/API key env vars are not set locally
