### PR TITLE
fix: stabilize frontend API tests

### DIFF
--- a/frontend/tests/setup-env.ts
+++ b/frontend/tests/setup-env.ts
@@ -1,0 +1,2 @@
+process.env.NEXT_PUBLIC_SUPABASE_URL ??= "https://example.supabase.co";
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= "test-anon-key";

--- a/frontend/tests/usePolicyStore.test.ts
+++ b/frontend/tests/usePolicyStore.test.ts
@@ -59,10 +59,9 @@ describe("usePolicyStore", () => {
 
     expect(result).toEqual(baseGlobal);
     expect(usePolicyStore.getState().globalByAgent["ag_alice"]).toEqual(baseGlobal);
-    expect(fetchSpy).toHaveBeenCalledWith(
-      "/api/agents/ag_alice/policy",
-      expect.objectContaining({ cache: "no-store" }),
-    );
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(new URL(String(url)).pathname).toBe("/api/agents/ag_alice/policy");
+    expect(init).toEqual(expect.objectContaining({ cache: "no-store" }));
   });
 
   it("patchGlobal PATCHes and updates state with server response", async () => {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -4,6 +4,7 @@ import path from 'path';
 export default defineConfig({
   test: {
     environment: 'node',
+    setupFiles: ['./tests/setup-env.ts'],
     alias: {
       '@': path.resolve(__dirname, './src'),
     },


### PR DESCRIPTION
## Summary
- add Vitest setup env for Supabase public config used by direct Hub API helpers
- update policy store fetch assertion to validate the Hub URL path after BFF migration

## Tests
- cd frontend && npm test -- --run src/store/useDaemonStore.test.ts src/store/useAgentGatewayStore.test.ts tests/usePolicyStore.test.ts
- cd frontend && npm test -- --run
- cd frontend && NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build