### PR TITLE
feat(gateway-ingress): shared gateway types + feishu/wechat providers + discord design

### DIFF
--- a/docs/gateway-ingress-discord-channel.md
+++ b/docs/gateway-ingress-discord-channel.md
@@ -1,0 +1,358 @@
+<!--
+- [INPUT]: 依赖 cloud-gateway-ingress-technical-design.md 的 always-on observer + thin Hub lifecycle 架构，依赖 packages/gateway-ingress/src/providers/telegram.ts 的 ProviderAdapter 实现样板，参考 ~/cc-connect/platform/discord/discord.go 的成熟 discordgo Gateway 接入模式。
+- [OUTPUT]: 输出 Cloud Agent Discord 第三方接入方案，包括 provider adapter 形态、Gateway/Intent 选择、mention/thread/slash 语义、Hub 侧 schema 与配置 UX、运维与灰度计划。
+- [POS]: cloud-gateway-ingress-technical-design.md 的 Discord 章节展开；总架构以主文档为准，本文只补 Discord 特定差异。
+- [PROTOCOL]: 影响 RuntimeGatewayProvider 枚举、gateway-ingress provider 注册、Discord 侧消息可见性策略或 thread 路由的变更，先更新本文，再改实现。
+-->
+
+# Cloud Gateway Ingress: Discord 接入设计
+
+> 状态: 方案草案，待评审
+> 日期: 2026-05-25
+> 范围: 在 `gateway-ingress` 中新增 `discord` provider；Hub 侧 thin lifecycle / dashboard config 扩展；不改动 cloud daemon 与 Hub 的边界
+
+## 1. 背景
+
+`gateway-ingress` 已落地 Telegram getUpdates polling adapter（`packages/gateway-ingress/src/providers/telegram.ts`），架构上把 _always-on observer_ 和 _runtime executor_ 拆开（主文档 §1）。Discord 是用户量级最大、最稳定的第三方 IM，且 **Discord Gateway 是出站 WS**，不需要公网入口或 webhook，正好契合 ingress "本机或单点常驻 + 出站连接 + 拉取式拉起 cloud sandbox" 的形态。
+
+参考实现是 [`cc-connect/platform/discord/discord.go`](https://github.com/chenhg5/cc-connect/blob/main/platform/discord/discord.go)（约 1400 行 Go，基于 [`bwmarrin/discordgo`](https://github.com/bwmarrin/discordgo)）。它已经覆盖：连接保活、Intents、guild mention-only、Bot Role mention、@everyone/@here、thread_isolation、slash command、ApplicationCommand 注册与 follow-up、attachment 分类（image / file / audio）、reply preview、typing、消息切片（2000 char）。本文复用其工程经验，不重新走一遍这套设计的踩坑过程。
+
+Discord 接入做完后，`RuntimeGatewayProvider` 从 `"telegram" | "wechat" | "feishu"` 变成 `… | "discord"`，Cloud Agent 可以以 Discord Bot 身份在用户的 Discord 服务器里被 @ 并对话。
+
+## 2. 设计目标与非目标
+
+### 目标
+
+- Cloud Agent 可以绑定一个 Discord Bot Token，gateway-ingress 维持该 Bot 的 Gateway WS。
+- Discord guild 消息：默认 mention-only；可选 group_reply_all（白名单 guild）。
+- Discord DM：mention 与否都接收。
+- 可选 `thread_isolation`：每个 fresh session 在 parent channel 下开一个 thread，会话隔离 + 复用同一 channel 的工作目录绑定。
+- 出站消息：自动按 2000 char 切片；MVP 不支持 edit-message 流式（与 telegram 一致先做 final-only / chunk）。
+- attachment：image / file / audio 分类后随入站 frame 透出给 cloud daemon（图片占用同样的 `images` 字段，运行时按 provider 透明处理）。
+- Hub 与第三方消息正文继续完全解耦（沿用主文档 §4.2 约束）。
+
+### 非目标（MVP 不做）
+
+- slash command 注册与 Application Command Interaction 的全功能支持（先用普通 message 路径；slash 命令进入第二阶段）。
+- voice / video / sticker / poll / forum channel。
+- Discord 端原生流式 edit-message（先 final-only；下一阶段引入 `gateway_outbound_delta` → `ChannelMessageEdit`）。
+- 把 Discord 对话写入 BotCord room/history（主文档明确不做）。
+- 让本地 daemon 通过 ingress 走 Discord（本地 daemon 沿用现状，自己启 discordgo 连接）。
+- 全局 ApplicationCommand 注册（实例数 × ratelimit 不可控，仅在 phase 2 用 guild_id-scoped 注册做 per-deployment 试点）。
+
+## 3. 总体形态
+
+```text
+Discord                           gateway-ingress                       Cloud daemon
+─────────                         ───────────────                       ────────────
+guild / DM ── Gateway WS ─►  DiscordProviderAdapter
+                              │  - discord.js v14 / @discordjs/ws
+                              │  - dedupe(message_id, interaction_id)
+                              │  - mention / role / @everyone 判定
+                              │  - thread_isolation 路由
+                              │  - attachment 分类下载
+                              ▼
+                       NormalizedInboundMessage
+                              │
+                              ▼
+                       Orchestrator (现有)
+                              │
+                              ▼
+                       Hub ensure-running (现有 thin API)
+                              │
+                              ▼
+                       Runtime WS frame: gateway_inbound  ───────────►  agent turn
+                                                                            │
+                       provider sender ◄────  gateway_outbound_complete ◄───┘
+                              │
+                              ▼
+                  Discord REST: createMessage / editMessage / startThread / sendFile
+```
+
+Hub 不在 data path 上，只暴露已有的 `POST /internal/cloud-gateway/agents/{agent_id}/ensure-running` 等接口（runtime-frame.ts §Hub thin lifecycle）。
+
+## 4. 类型与契约扩展
+
+### 4.1 `RuntimeGatewayProvider`
+
+`packages/protocol-core/src/runtime-frame.ts`：
+
+```diff
+- export type RuntimeGatewayProvider = "telegram" | "wechat" | "feishu";
++ export type RuntimeGatewayProvider = "telegram" | "wechat" | "feishu" | "discord";
+```
+
+Cloud daemon、Hub model 一次性更新枚举校验（保持现有的 union 验证模式）。
+
+### 4.2 NormalizedInboundMessage 的 Discord 字段约定
+
+不改 schema，仅约定取值：
+
+| 字段 | Discord 取值 |
+|---|---|
+| `id` | `discord:{channelId}:{messageId}`（与 cc-connect 的 dedupe key 命名风格保持一致）|
+| `channel` | gateway connection id（如 `gw_dc_xxx`），与其他 provider 一致|
+| `accountId` | `ag_…`|
+| `conversation.id` | DM: `discord:dm:{channelId}`；guild 普通频道: `discord:channel:{channelId}`；thread: `discord:thread:{threadId}`|
+| `conversation.kind` | DM → `direct`；guild channel / thread → `group`|
+| `conversation.title` | `channel.name`（thread 用 thread name；用于 ChatName 展示）|
+| `conversation.threadId` | thread 模式下填 thread.id；否则 null|
+| `sender.id` | `discord:user:{userId}`|
+| `sender.name` | `username` 或 `globalName`|
+| `text` | 已剥离 `<@botId>` / `<@!botId>` / `<@&botRoleId>` 与可选的 `@everyone` / `@here` 后的纯文本|
+| `mentioned` | guild 模式：bot 被 @user / @role / @everyone 中任一即 true；DM 默认 true|
+| `replyTo` | 若为 reply，填被引用 message 的 id；referenced 内容会拼到 `text` 前缀（"[replying to {author}: …]"）以保留语境，与 cc-connect 一致|
+
+> 设计点：`conversation.id` 用三种前缀显式区分 DM / channel / thread，让运行时无需再访问 Discord API 即可判断。
+
+### 4.3 Outbound 路由约定
+
+`OutboundSendRequest.conversationId` 在 ingress 内部直接解析回 `(channelId, threadId?)`，再选择：
+
+| 场景 | Discord REST |
+|---|---|
+| DM / 普通 channel | `POST /channels/{channelId}/messages`|
+| thread | `POST /channels/{threadId}/messages`|
+| 回复指定消息（保留 ReplyContext.messageId） | `messages` + `message_reference` |
+| 切片 | 单条 > 1900 char 时本地切（与 cc-connect 同步缩到 1900，给富文本 markdown 余量）|
+
+## 5. Provider Adapter 实现
+
+文件：`packages/gateway-ingress/src/providers/discord.ts`，签名遵循 `ProviderAdapter`：
+
+```ts
+export interface DiscordProviderOptions {
+  gatewayId: string;
+  /** 测试钩子，注入 mock client */
+  clientFactory?: (token: string) => DiscordGatewayClient;
+}
+
+export function createDiscordProvider(opts: DiscordProviderOptions): ProviderAdapter
+```
+
+### 5.1 依赖选择
+
+| 选项 | 评价 |
+|---|---|
+| **`discord.js` v14**（推荐）| TS 原生、维护活跃、社区最大、覆盖 Gateway + REST + interaction；体积偏大但 ingress 是单进程服务可接受。|
+| `@discordjs/ws` + `@discordjs/rest`| 更轻量，自己拼 shard / interaction。可作为 phase 2 的优化项。|
+| 自写 WS（gorilla 风格）| 复刻 cc-connect 的成本远大于收益；不建议。|
+
+MVP 选 **discord.js**。锁定到 next-supported LTS，不开自动 ETF / zlib（Node 22 性能 OK）。
+
+### 5.2 ProviderRuntimeContext 用法
+
+```ts
+async function loop(ctx: ProviderRuntimeContext) {
+  const secret = ctx.secret as { botToken: string };
+  const config = ctx.connection.config as DiscordConnectionConfig;
+
+  const client = new Client({
+    intents: [
+      GatewayIntentBits.Guilds,
+      GatewayIntentBits.GuildMessages,
+      GatewayIntentBits.MessageContent,   // privileged: 必须在开发者后台开启
+      GatewayIntentBits.DirectMessages,
+    ],
+    partials: [Partials.Channel],          // 接收 DM 需要
+  });
+
+  client.on(Events.MessageCreate, async (m) => onMessage(m, ctx, config));
+  client.on(Events.ClientReady, (c) => {
+    botId = c.user.id;
+    appId = c.application.id;
+    ctx.markActivity({ lastPollAt: Date.now() });
+  });
+  client.on(Events.Error, (err) => ctx.markActivity({ lastError: String(err) }));
+  client.on(Events.ShardDisconnect, …);
+
+  ctx.abortSignal.addEventListener("abort", () => client.destroy(), { once: true });
+  await client.login(secret.botToken);
+}
+```
+
+cursor 不需要（Gateway 是 push）。`persistCursor` 留空；`loadCursor` 返回 `{}`。
+
+### 5.3 入站消息处理（核心）
+
+照搬 cc-connect 的判定顺序，保证语义一致：
+
+```text
+1. dedupe(m.id) via in-memory LRU(window=2min)        // 与 telegram 不同，message id 全局唯一即可
+2. m.author.bot 或 m.author.id == botId → 丢弃
+3. core.IsOldMessage 等价：m.createdTimestamp < startupTs - 60s → 丢弃（避免重启回放）
+4. allowFrom allowlist 判定 m.author.id              // 与 ingress 现有 allowedSenderIds 对齐
+5. 若是 guild 且非 group_reply_all guild：
+     - 计算 botRoleId（每个 guild 缓存一次，从 GuildMember.roles 找 managed=true）
+     - isDiscordBotMention(m, botId, botRoleId, respondToAtEveryoneAndHere) → false 则丢弃
+     - 剥离 `<@botId>` `<@!botId>` `<@&botRoleId>` 与可选 `@everyone`/`@here`
+6. 计算 sessionKey / conversationId / replyContext
+7. attachment 分类 + 下载（最大 50MB / 每附件）
+8. referenced message 内容前缀化拼到 text，referenced attachment 中的图片同步前置
+9. emit(normalized, providerEventId="dc:{guildOrDm}:{messageId}")
+```
+
+### 5.4 Thread Isolation
+
+`config.threadIsolation === true` 且消息来自 guild text/news channel 时：
+
+```text
+if 消息已经在 thread 内：
+    parentChannelId = channel.parentId
+    conversation.id = `discord:thread:${channel.id}`
+elif 消息所在 message 已 attach 了 thread：
+    join 那个 thread；后续从 thread 内继续路由
+else：
+    startThread(channelId, messageId, name=truncate(text, 90), archiveDuration=1440)
+    join 新 thread
+```
+
+设计要点（继承自 cc-connect）：
+- `conversation.title` 用 **thread name**，但工作目录绑定线索仍走 **parent channel id**（mirror cc-connect 的 `channelKey` 机制）。这一点要把 parent channel id 顺路传给 cloud daemon——但目前 NormalizedInboundMessage 没有 `parentChannel` 字段。
+- 处理方式：在 `conversation.id` 里用 `discord:thread:{threadId}`，并新增可选字段 `conversation.parentId?: string`（仅 Discord 用，其他 provider 留空）。这是对 schema 的最小扩展。
+
+### 5.5 Slash Command（Phase 2，不在 MVP）
+
+- 仅在 `config.guildId` 配置时调用 `ApplicationCommandBulkOverwrite(appId, guildId, cmds)`，避免 global 1h propagation 和 ratelimit 风险。
+- Interaction 入站：先 `InteractionRespond(Deferred)`，再走与 messageCreate 相同的 normalized 路径；出站第一条用 `InteractionResponseEdit`，后续用 `FollowupMessageCreate`。
+- 注册 source-of-truth：Hub 不感知；ingress 启动时拉 BotCord 的 `command_registry`（已有概念）做一次 bulk overwrite。
+
+### 5.6 出站消息
+
+```ts
+async function send(req: OutboundSendRequest): Promise<OutboundSendResult> {
+  const target = parseConversationId(req.conversationId);   // {channelId, isThread}
+  const channel = await client.channels.fetch(target.channelId);
+  const chunks = splitText(req.text, 1900);                  // ascii-aware + code-fence-aware
+  let lastId: string | null = null;
+  for (const chunk of chunks) {
+    const sent = await channel.send({ content: chunk });
+    lastId = `discord:${channel.id}:${sent.id}`;
+  }
+  return { providerMessageId: lastId };
+}
+```
+
+streaming（phase 2）：第一次 `delta` 创建 message → 后续 `delta` `messages.edit` 同一条直到 `complete`；超过 5 次/秒 edit 时退化为追加。
+
+### 5.7 错误与重连
+
+- discord.js 内部已带自动重连；ingress 只需在 `Events.ShardError` / `ShardDisconnect(1000)` 时记 `lastError` 即可。
+- token 失效（4004）→ markActivity({ lastError: "invalid_token" }) → stop adapter；上层 orchestrator 把 connection.status 置为 `error`，等待用户重新绑定。
+- Privileged Intent 未开启（4014）→ 与 token 失效同处理路径，但 `lastError = "message_content_intent_required"` 给 dashboard 明确指引。
+
+## 6. 注册到 Registry
+
+`packages/gateway-ingress/src/providers/registry.ts`：
+
+```ts
+import { telegramProviderFactory } from "./telegram.js";
+import { discordProviderFactory } from "./discord.js";
+
+export const DEFAULT_PROVIDER_FACTORIES: Record<string, ProviderAdapterFactory> = {
+  telegram: telegramProviderFactory,
+  discord: discordProviderFactory,
+};
+```
+
+`discordProviderFactory: ProviderAdapterFactory = (gatewayId) => createDiscordProvider({ gatewayId })`。
+
+## 7. Hub 侧增量
+
+Hub 在第三方消息链路中保持 thin，但 dashboard 配置仍由 Hub 持久化。
+
+### 7.1 Schema
+
+`gateway_connections.provider` 加入 `discord` 取值。`config_json` 形如：
+
+```jsonc
+{
+  "appId":        "1234567890",          // 可选，仅 phase 2 注册 slash 时用
+  "guildId":      "9876543210",          // 可选，仅注册 guild-scoped slash
+  "groupReplyAll": false,
+  "groupReplyAllGuilds": ["123…"],       // 任一为 "*" 即全 guild 都开
+  "shareSessionInChannel": false,
+  "threadIsolation": true,
+  "respondToAtEveryoneAndHere": false,
+  "allowedSenderIds": ["…"],
+  "allowedChatIds":   ["…"]
+}
+```
+
+`secret_ref` 指向 ingress secret store 中的 `{ botToken: "MTk4…" }`。Hub 不存 token 明文，token 只下发到 ingress secret store；dashboard 录入时直传 ingress、Hub 只持有 `secret_ref` 句柄（与 telegram 现有路径一致）。
+
+### 7.2 Dashboard 接入向导（用户视角）
+
+参考 [cc-connect/docs/discord.md](https://github.com/chenhg5/cc-connect/blob/main/docs/discord.md) 的 9 步流程，但 BotCord 这边把 ingress 部分变透明：
+
+1. Discord Developer Portal 新建 Application + Bot
+2. **必须**开启 `Message Content Intent`（顶级 FAQ）
+3. 复制 Bot Token
+4. OAuth2 URL Generator：scope=`bot`（+ phase 2 加 `applications.commands`）；Permissions 勾：View Channels / Send Messages / Create Public Threads / Send Messages in Threads / Read Message History
+5. 用 URL 邀请 Bot 到 Server
+6. 回到 BotCord Dashboard → 选 Cloud Agent → Bind Discord → 粘 Token、勾 thread_isolation 等开关、Save
+7. Save 后由 Hub 写 `gateway_connections` + 把 token 透传给 ingress secret store；ingress orchestrator 触发新 adapter 上线
+8. 在 Discord 任意频道 @bot 验证
+
+## 8. 失败语义补充
+
+主文档 §12 的策略对 Discord 直接适用，下面只列差异：
+
+| 场景 | 处理 |
+|---|---|
+| Privileged Intent 未开 | adapter ready 后 messageCreate 永远收不到，需要主动探测。**做法**：连上 5 分钟内若 `lastInboundAt` 一直为空且接收到的 messageCreate `content === ""` 比例 > 90%，标记 `lastError="message_content_intent_required"` 并提示 dashboard。|
+| Bot 被踢出 server | guild 消失事件后，cache 中该 guild 的 botRoleId 清掉；不影响其他 guild。|
+| Discord 全局 ratelimit | discord.js 内置 bucket；ingress 不需要额外处理。手动限流出现 `RateLimitedError` 时本地排队（短时 < 5s）或推后到下一次 send。|
+| message ID 重复 | Gateway 偶发重复 dispatch（与 cc-connect 注释一致）→ 2 分钟 LRU 直接丢弃。|
+| Bot Token rotate | dashboard 触发 secret 更新 → orchestrator 收到 connection update → stop old client → start new client；事件流不丢失（events 已经在 durable queue）。|
+
+## 9. 安全与隐私
+
+- Bot Token 只存在于 ingress secret store；Hub 与 cloud daemon 都拿不到原 token。
+- 出站 frame 中不携带 Discord token、user email、avatar URL 之外的 PII；runtime 看到的 sender 仅 username + numeric id。
+- attachment 下载存放在 ingress 临时目录，最长保留至 outbound complete + 1h；不持久化原始 binary 到 Hub。
+- 日志：必须 redact token（discord.js 默认会，二次校验 logger 字段白名单）。
+- guild 消息默认 mention-only；`groupReplyAllGuilds` 必须显式开启，dashboard 上做二次确认。
+
+## 10. 实施阶段
+
+| Phase | 内容 | 退出条件 |
+|---|---|---|
+| **0** | `RuntimeGatewayProvider` 枚举扩展 + `NormalizedInboundMessage.conversation.parentId?` 可选字段 + 全链路类型编译通过 | `pnpm build` 全绿；现有 telegram e2e 不回归 |
+| **1** | `discord.ts` provider adapter（DM + guild mention-only + 切片出站 + dedupe + 重连） | 一个测试 Bot 在测试 server 完整跑通：@bot → cloud daemon turn → final text 回复 |
+| **2** | thread_isolation + reply context + attachment 入站 | 同一会话连续多轮 thread 内运行；图片上传后 agent 能看到 |
+| **3** | Slash command（仅 guild-scoped）+ ratelimit dashboard 指标 | `/help` 等命令可触发 turn |
+| **4** | Streaming（edit-message）+ progress card 等价物 | 一次 turn 中只编辑同一条消息直到 complete |
+
+Phase 1 即可独立合并、灰度放给少数内测 agent。每个 phase 一个 PR，commit prefix `feat(gateway-ingress): discord …`。
+
+## 11. 测试策略
+
+- **单元**：discord.ts 通过注入 `clientFactory` mock 出 Gateway client，覆盖 dedupe / mention 判定 / thread 路由 / 切片。仿 telegram.ts 的 fetchImpl 注入模式。
+- **集成**：`packages/gateway-ingress/src/__tests__/discord.integration.test.ts` 用 `nock` 拦截 Discord REST，WS 端用本地 fake gateway server。
+- **手测**：脚本 `scripts/discord-smoke.ts`，读取本地 `.env` 中的 testing token + guild + channel id，发一条 `@bot ping`，断言返回中包含 `pong`。
+- **不引入** Discord 官方账号到 CI；token 只在 ingress 维护者本地 + staging 部署中存在。
+
+## 12. 开放问题
+
+- `NormalizedInboundMessage.conversation.parentId` 的命名是否要更通用（`conversation.parentChannelId`）以便 Feishu / Slack 后续复用？建议在 phase 0 决定后冻结。
+- discord.js 是否需要在 ingress Dockerfile 中固定到具体 minor 版本？社区每 ~3 个月推一次 API 变动，建议锁 minor、CI 定期升级。
+- Slash command 注册的 source-of-truth：由 ingress 启动时从 Hub 拉，还是由 dashboard 显式 `Register Commands` 按钮触发？建议后者，避免每次 ingress 重启都 bulk overwrite。
+- streaming edit-message 的速率：Discord 单频道 5 edits/5s，对 token-stream 太紧；phase 4 需要内置一个 `coalesce(delta, minIntervalMs=1000)` 的 buffer。
+
+## 13. 与 cc-connect 实现的差异速查
+
+| 维度 | cc-connect (Go, single-process) | botcord ingress (TS, multi-tenant) |
+|---|---|---|
+| 进程模型 | 一个 cc-connect 对一个 bot token | 一个 ingress 进程承载多个 agent 的多个 bot adapter |
+| 入站去重 | sync.Map + 2 min TTL | 同语义；用 LRUMap 或 in-memory Map + setTimeout |
+| 会话 key | `discord:{channelId}[:{userId}]` 字符串 | 用 NormalizedInboundMessage.conversation.id；runtime 自己派生 session |
+| 工作目录绑定 | `<base_dir>/<parent-channel-name>` | 不存在；runtime 不绑工作目录 |
+| 出站切片 | 1900 chars + code-fence aware | 同 |
+| Slash 注册 | 每次 ready 时 bulk overwrite | dashboard 显式触发，避免大规模 bot 时雷暴 |
+| Progress 卡片 | 三种 style (`legacy`/`compact`/`card`) | MVP 不引入；statement 仍是 final-only |
+| 代理 | 支持 HTTP proxy | ingress 部署侧解决（k8s egress 或 HTTP_PROXY 环境变量），不进 adapter 配置 |
+
+## 14. 一句话总结
+
+把 cc-connect 那一套验证过的 discordgo 玩法翻译成 TS 上的 `ProviderAdapter`，复用 `gateway-ingress` 现有的 always-on + durable + ensure-running 链路；Hub 不在 data path 上，新增的只是 `provider="discord"` 这一个枚举值和一份配置 JSON。

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@botcord/cli": "^0.1.7",
-    "@botcord/protocol-core": "^0.2.9",
+    "@botcord/protocol-core": "^0.2.10",
     "@larksuiteoapi/node-sdk": "^1.63.1",
     "ws": "^8.20.1"
   },

--- a/packages/daemon/src/gateway/channels/sanitize.ts
+++ b/packages/daemon/src/gateway/channels/sanitize.ts
@@ -1,68 +1,10 @@
 /**
- * Sanitize untrusted inbound content before handing it off to a local runtime.
- *
- * Copied from `packages/daemon/src/sanitize.ts` so the gateway channel adapter
- * does not depend back on the daemon package. Keep these two files in sync —
- * any new structural marker added in one place should be mirrored in the other.
- *
- * Neutralizes:
- *   - BotCord structural markers the channel itself emits (so peers can't forge them).
- *   - Common LLM prompt-injection patterns (<system>, [INST], <<SYS>>, <|im_start|>, etc.).
- *   - Wrapper XML tags the channel uses to frame inbound content
- *     (<agent-message>, <human-message>, <room-rule>).
+ * Thin re-export — `sanitizeUntrustedContent` / `sanitizeSenderName` live
+ * in `@botcord/protocol-core` so the daemon channel adapters and the
+ * `gateway-ingress` provider adapters use one canonical implementation.
+ * Existing imports of this module keep working unchanged.
  */
-
-export function sanitizeUntrustedContent(text: string): string {
-  let s = text;
-  s = s.replace(
-    /<\/?a[\s]*g[\s]*e[\s]*n[\s]*t[\s]*-[\s]*m[\s]*e[\s]*s[\s]*s[\s]*a[\s]*g[\s]*e[\s\S]*?>/gi,
-    "[⚠ stripped: agent-message tag]",
-  );
-  s = s.replace(
-    /<\/?h[\s]*u[\s]*m[\s]*a[\s]*n[\s]*-[\s]*m[\s]*e[\s]*s[\s]*s[\s]*a[\s]*g[\s]*e[\s\S]*?>/gi,
-    "[⚠ stripped: human-message tag]",
-  );
-  s = s.replace(
-    /<\/?r[\s]*o[\s]*o[\s]*m[\s]*-[\s]*r[\s]*u[\s]*l[\s]*e[\s\S]*?>/gi,
-    "[⚠ stripped: room-rule tag]",
-  );
-
-  return s
-    .split(/\r?\n/)
-    .map((line) => {
-      let l = line;
-      l = l.replace(/^\[(BotCord (?:Message|Notification))\]/i, "[⚠ fake: $1]");
-      l = l.replace(/^\[Room Rule\]/i, "[⚠ fake: Room Rule]");
-      l = l.replace(/^\[房间规则\]/i, "[⚠ fake: 房间规则]");
-      l = l.replace(/^\[系统提示\]/i, "[⚠ fake: 系统提示]");
-      l = l.replace(/^\[BotCord\s+([^\]\r\n]+)\]/i, (_m, label) => {
-        const head = String(label).split(":")[0].trim() || String(label).trim();
-        return `[⚠ fake: BotCord ${head}]`;
-      });
-      l = l.replace(/^\[(System|SYSTEM|Assistant|ASSISTANT|User|USER)\]/, "[⚠ fake: $1]");
-      l = l.replace(/<\/?\s*system(?:-reminder)?\s*>/gi, "[⚠ stripped: system tag]");
-      l = l.replace(/<\|im_start\|>/gi, "[⚠ stripped: im_start]");
-      l = l.replace(/<\|im_end\|>/gi, "[⚠ stripped: im_end]");
-      l = l.replace(/\[\/?INST\]/gi, "[⚠ stripped: INST]");
-      l = l.replace(/<<\/?SYS>>/gi, "[⚠ stripped: SYS]");
-      l = l.replace(/<\s*\/?\|(?:system|user|assistant)\|?\s*>/gi, "[⚠ stripped: role tag]");
-      return l;
-    })
-    .join("\n");
-}
-
-/**
- * Sanitize a sender label so it's safe to embed inside
- * `<agent-message sender="...">`. Must not contain newlines, structural
- * markers, or characters that could break the XML attribute boundary.
- */
-export function sanitizeSenderName(name: string): string {
-  return name
-    .replace(/[\n\r]/g, " ")
-    .replace(/\[/g, "⟦")
-    .replace(/\]/g, "⟧")
-    .replace(/"/g, "'")
-    .replace(/</g, "＜")
-    .replace(/>/g, "＞")
-    .slice(0, 100);
-}
+export {
+  sanitizeUntrustedContent,
+  sanitizeSenderName,
+} from "@botcord/protocol-core";

--- a/packages/daemon/src/gateway/channels/text-split.ts
+++ b/packages/daemon/src/gateway/channels/text-split.ts
@@ -1,29 +1,7 @@
 /**
- * Split a long message into chunks <= `limit` characters each. Prefers to cut
- * on newline boundaries so multi-paragraph replies don't fragment mid-line.
- *
- * Shared by third-party channel adapters (Telegram, WeChat) which both have a
- * per-message size cap from upstream and no native streaming. WeChat caller
- * passes a smaller `limit` (~1800), Telegram a larger one (~4000, since the
- * raw Telegram limit is 4096).
- *
- * Empty input returns `[""]` so callers can iterate uniformly without a length
- * check.
+ * Thin re-export — `splitText` lives in `@botcord/protocol-core` so the
+ * daemon channel adapters and the `gateway-ingress` provider adapters use
+ * one canonical implementation. Existing imports of this module keep
+ * working unchanged.
  */
-export function splitText(text: string, limit: number): string[] {
-  if (limit <= 0) return [text];
-  if (text.length === 0) return [""];
-  if (text.length <= limit) return [text];
-
-  const out: string[] = [];
-  let remaining = text;
-  while (remaining.length > limit) {
-    let cut = remaining.lastIndexOf("\n", limit);
-    if (cut <= 0) cut = limit;
-    out.push(remaining.slice(0, cut));
-    // Drop the leading newline so the next chunk doesn't start with a blank line.
-    remaining = remaining.slice(cut).replace(/^\n/, "");
-  }
-  if (remaining.length > 0) out.push(remaining);
-  return out;
-}
+export { splitText } from "@botcord/protocol-core";

--- a/packages/daemon/src/gateway/types.ts
+++ b/packages/daemon/src/gateway/types.ts
@@ -1,4 +1,20 @@
 import type { GatewayLogger } from "./log.js";
+import type {
+  GatewayInboundEnvelope as CanonicalGatewayInboundEnvelope,
+  GatewayInboundMessage as CanonicalGatewayInboundMessage,
+  GatewayOutboundAttachment as CanonicalGatewayOutboundAttachment,
+  GatewayOutboundMessage as CanonicalGatewayOutboundMessage,
+  RuntimeGatewayProvider,
+} from "@botcord/protocol-core";
+
+// Canonical gateway message shapes live in `@botcord/protocol-core` so the
+// `gateway-ingress` provider adapters can import the same types without
+// pulling the entire daemon. Daemon re-exports the canonical shapes here so
+// every existing import (`from "./gateway/index.js"`) keeps working.
+export type GatewayInboundMessage = CanonicalGatewayInboundMessage;
+export type GatewayInboundEnvelope = CanonicalGatewayInboundEnvelope;
+export type GatewayOutboundAttachment = CanonicalGatewayOutboundAttachment;
+export type GatewayOutboundMessage = CanonicalGatewayOutboundMessage;
 
 // ---------------------------------------------------------------------------
 // Routing (§9)
@@ -89,42 +105,9 @@ export interface GatewayConfig {
 // Inbound / outbound message shape (§7.3, §7.4, §7.5)
 // ---------------------------------------------------------------------------
 
-/** Normalized inbound message produced by a channel adapter for the dispatcher. */
-export interface GatewayInboundMessage {
-  id: string;
-  /** Channel adapter id (`ChannelAdapter.id`), not channel type. */
-  channel: string;
-  accountId: string;
-  conversation: {
-    id: string;
-    kind: "direct" | "group";
-    title?: string;
-    threadId?: string | null;
-  };
-  sender: {
-    id: string;
-    name?: string;
-    kind: "user" | "agent" | "system";
-  };
-  text?: string;
-  raw: unknown;
-  replyTo?: string | null;
-  mentioned?: boolean;
-  receivedAt: number;
-  trace?: {
-    id: string;
-    streamable?: boolean;
-  };
-}
-
-/** Inbound envelope wrapping a normalized message with optional upstream ack callbacks. */
-export interface GatewayInboundEnvelope {
-  message: GatewayInboundMessage;
-  ack?: {
-    accept(): Promise<void>;
-    reject?(reason: string): Promise<void>;
-  };
-}
+// `GatewayInboundMessage` and `GatewayInboundEnvelope` are re-exported from
+// `@botcord/protocol-core` at the top of this file. The wire-level subset is
+// `RuntimeGatewayInboundPayload` in protocol-core/runtime-frame.ts.
 
 /**
  * Channel-agnostic hook that produces a system-context string for a turn.
@@ -179,28 +162,8 @@ export type OutboundObserver = (
   message: GatewayOutboundMessage,
 ) => Promise<void> | void;
 
-/** Outbound reply payload passed to `ChannelAdapter.send()`. */
-export interface GatewayOutboundAttachment {
-  /** Local daemon-readable file path. */
-  filePath?: string;
-  /** In-memory bytes, primarily for tests and in-process tool callers. */
-  data?: Uint8Array;
-  filename?: string;
-  contentType?: string;
-  kind?: "image" | "file" | "video";
-}
-
-export interface GatewayOutboundMessage {
-  channel: string;
-  accountId: string;
-  conversationId: string;
-  threadId?: string | null;
-  type?: "message" | "error";
-  text: string;
-  attachments?: GatewayOutboundAttachment[];
-  replyTo?: string | null;
-  traceId?: string | null;
-}
+// `GatewayOutboundAttachment` and `GatewayOutboundMessage` are re-exported from
+// `@botcord/protocol-core` at the top of this file.
 
 // ---------------------------------------------------------------------------
 // Status (§14)
@@ -218,7 +181,7 @@ export interface ChannelStatusSnapshot {
   lastStopAt?: number;
   lastError?: string | null;
   /** Third-party provider id when this channel is not the built-in BotCord. */
-  provider?: "wechat" | "telegram" | "feishu";
+  provider?: RuntimeGatewayProvider;
   /** Last time the adapter polled the upstream provider (ms epoch). */
   lastPollAt?: number;
   /** Last time the adapter accepted an inbound message (ms epoch). */

--- a/packages/gateway-ingress/package.json
+++ b/packages/gateway-ingress/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@botcord/protocol-core": "file:../protocol-core",
+    "@larksuiteoapi/node-sdk": "^1.63.1",
     "ws": "^8.20.1"
   },
   "devDependencies": {

--- a/packages/gateway-ingress/src/__tests__/feishu.test.ts
+++ b/packages/gateway-ingress/src/__tests__/feishu.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from "vitest";
+
+import type { GatewayInboundMessage } from "@botcord/protocol-core";
+import { noopLogger } from "../log.js";
+import { createFeishuProvider } from "../providers/feishu.js";
+import type { ProviderRuntimeContext } from "../providers/types.js";
+import type { GatewayConnection } from "../types.js";
+
+const conn: GatewayConnection = {
+  id: "gw_fs_unit",
+  agentId: "ag_unit",
+  provider: "feishu",
+  status: "active",
+  enabled: true,
+  config: {
+    appId: "cli_test",
+    domain: "feishu",
+    allowedSenderIds: ["ou_alice"],
+    allowedChatIds: ["oc_chat"],
+  },
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+function makeCtx(secret: Record<string, unknown>, abort: AbortController) {
+  const emits: { msg: GatewayInboundMessage; providerEventId: string }[] = [];
+  const cursors: Record<string, unknown>[] = [];
+  const activity: {
+    lastPollAt?: number;
+    lastInboundAt?: number;
+    lastError?: string | null;
+  }[] = [];
+  const ctx: ProviderRuntimeContext = {
+    connection: conn,
+    secret,
+    log: noopLogger,
+    abortSignal: abort.signal,
+    async emit(msg, id) {
+      emits.push({ msg, providerEventId: id });
+      return true;
+    },
+    persistCursor(cursor) {
+      cursors.push(cursor);
+    },
+    loadCursor() {
+      return {};
+    },
+    markActivity(patch) {
+      activity.push(patch);
+    },
+  };
+  return { ctx, emits, cursors, activity };
+}
+
+interface FakeRequest {
+  method: string;
+  url: string;
+  data?: Record<string, unknown>;
+  params?: Record<string, unknown>;
+}
+
+function makeSdkOverride(opts: {
+  probeBotId?: string;
+  /** Called when send POSTs to /open-apis/im/v1/messages. */
+  onSend?: (req: FakeRequest) => { messageId?: string };
+}) {
+  const requests: FakeRequest[] = [];
+  let registeredHandlers: Record<string, (data: unknown) => unknown> | null = null;
+  const wsStarted: unknown[] = [];
+
+  const sdkOverride = {
+    createClient(_args: Record<string, unknown>) {
+      return {
+        async request(args: unknown): Promise<unknown> {
+          const r = args as FakeRequest;
+          requests.push(r);
+          if (r.url.endsWith("/openclaw_bot/ping")) {
+            return {
+              code: 0,
+              data: { pingBotInfo: { botID: opts.probeBotId ?? "ou_bot" } },
+            };
+          }
+          if (r.url.endsWith("/im/v1/messages")) {
+            const out = opts.onSend?.(r) ?? {};
+            return {
+              code: 0,
+              data: { message_id: out.messageId ?? "om_sent" },
+            };
+          }
+          return { code: 0, data: {} };
+        },
+      };
+    },
+    createWsClient(_args: Record<string, unknown>) {
+      return {
+        start(startOpts: unknown): unknown {
+          wsStarted.push(startOpts);
+          return Promise.resolve();
+        },
+        close(_opts?: unknown): unknown {
+          return Promise.resolve();
+        },
+      };
+    },
+    createDispatcher() {
+      return {
+        register(handlers: Record<string, (data: unknown) => unknown>): void {
+          registeredHandlers = handlers;
+        },
+      };
+    },
+  };
+
+  return {
+    sdkOverride,
+    requests,
+    wsStarted,
+    fireMessageEvent(data: unknown): unknown {
+      const h = registeredHandlers?.["im.message.receive_v1"];
+      if (!h) throw new Error("dispatcher not registered yet");
+      return h(data);
+    },
+  };
+}
+
+describe("Feishu provider adapter", () => {
+  it("probes botOpenId on start and normalizes a p2p message", async () => {
+    const harness = makeSdkOverride({ probeBotId: "ou_bot" });
+    const provider = createFeishuProvider({
+      gatewayId: conn.id,
+      sdkOverride: harness.sdkOverride,
+    });
+    const abort = new AbortController();
+    const { ctx, emits, activity } = makeCtx({ appSecret: "shh" }, abort);
+
+    const running = provider.start(ctx);
+
+    // Wait until probe + dispatcher registration have happened.
+    const deadline = Date.now() + 1_000;
+    while (Date.now() < deadline && harness.wsStarted.length === 0) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+
+    await harness.fireMessageEvent({
+      sender: {
+        sender_id: { open_id: "ou_alice" },
+        sender_type: "user",
+      },
+      message: {
+        message_id: "om_abc",
+        chat_id: "oc_chat",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "hi feishu" }),
+        create_time: "1700000000000",
+        mentions: [{ id: { open_id: "ou_alice" }, name: "Alice" }],
+      },
+    });
+
+    abort.abort();
+    await running;
+
+    expect(emits).toHaveLength(1);
+    expect(emits[0]!.msg.text).toBe("hi feishu");
+    expect(emits[0]!.msg.conversation.id).toBe("feishu:user:oc_chat");
+    expect(emits[0]!.msg.conversation.kind).toBe("direct");
+    expect(emits[0]!.msg.sender.id).toBe("feishu:user:ou_alice");
+    expect(emits[0]!.msg.sender.name).toBe("Alice");
+    expect(emits[0]!.providerEventId).toBe("feishu:om_abc");
+    expect(activity.some((a) => a.lastInboundAt !== undefined)).toBe(true);
+  });
+
+  it("skips messages from the bot itself", async () => {
+    const harness = makeSdkOverride({ probeBotId: "ou_bot" });
+    const provider = createFeishuProvider({
+      gatewayId: conn.id,
+      sdkOverride: harness.sdkOverride,
+    });
+    const abort = new AbortController();
+    const { ctx, emits } = makeCtx({ appSecret: "shh" }, abort);
+
+    const running = provider.start(ctx);
+    const deadline = Date.now() + 1_000;
+    while (Date.now() < deadline && harness.wsStarted.length === 0) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+
+    await harness.fireMessageEvent({
+      sender: {
+        sender_id: { open_id: "ou_bot" }, // bot's own id
+      },
+      message: {
+        message_id: "om_echo",
+        chat_id: "oc_chat",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "should be ignored" }),
+      },
+    });
+
+    abort.abort();
+    await running;
+    expect(emits).toHaveLength(0);
+  });
+
+  it("rejects senders outside allowedSenderIds", async () => {
+    const harness = makeSdkOverride({ probeBotId: "ou_bot" });
+    const provider = createFeishuProvider({
+      gatewayId: conn.id,
+      sdkOverride: harness.sdkOverride,
+    });
+    const abort = new AbortController();
+    const { ctx, emits } = makeCtx({ appSecret: "shh" }, abort);
+
+    const running = provider.start(ctx);
+    const deadline = Date.now() + 1_000;
+    while (Date.now() < deadline && harness.wsStarted.length === 0) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+
+    await harness.fireMessageEvent({
+      sender: { sender_id: { open_id: "ou_eve" } }, // not in allowedSenderIds
+      message: {
+        message_id: "om_blocked",
+        chat_id: "oc_chat",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "blocked" }),
+      },
+    });
+
+    abort.abort();
+    await running;
+    expect(emits).toHaveLength(0);
+  });
+
+  it("send() posts text and returns the provider message id", async () => {
+    const harness = makeSdkOverride({
+      probeBotId: "ou_bot",
+      onSend: () => ({ messageId: "om_reply" }),
+    });
+    const provider = createFeishuProvider({
+      gatewayId: conn.id,
+      sdkOverride: harness.sdkOverride,
+    });
+    const abort = new AbortController();
+    const { ctx } = makeCtx({ appSecret: "shh" }, abort);
+
+    const running = provider.start(ctx);
+    const deadline = Date.now() + 1_000;
+    while (Date.now() < deadline && harness.wsStarted.length === 0) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+
+    const result = await provider.send({
+      gatewayId: conn.id,
+      conversationId: "feishu:user:oc_chat",
+      text: "reply text",
+      final: true,
+    });
+
+    abort.abort();
+    await running;
+
+    expect(result.providerMessageId).toBe("feishu:om_reply");
+    const sendCalls = harness.requests.filter((r) => r.url.endsWith("/im/v1/messages"));
+    expect(sendCalls).toHaveLength(1);
+    expect(sendCalls[0]!.data).toMatchObject({
+      receive_id: "oc_chat",
+      msg_type: "text",
+    });
+  });
+});

--- a/packages/gateway-ingress/src/__tests__/orchestrator.test.ts
+++ b/packages/gateway-ingress/src/__tests__/orchestrator.test.ts
@@ -8,7 +8,8 @@ import { noopLogger } from "../log.js";
 import { IngressOrchestrator } from "../orchestrator.js";
 import { RuntimeSessionManager } from "../runtime/session.js";
 import { FileSystemIngressStore } from "../storage/store.js";
-import type { GatewayConnection, NormalizedInboundMessage } from "../types.js";
+import type { GatewayInboundMessage } from "@botcord/protocol-core";
+import type { GatewayConnection } from "../types.js";
 import { FakeHubClient, FakeRuntimeSocket, FakeSocketFactory } from "./fixtures.js";
 
 import type {
@@ -32,7 +33,7 @@ const CONN: GatewayConnection = {
   updatedAt: 1,
 };
 
-const NORMALIZED: NormalizedInboundMessage = {
+const NORMALIZED: GatewayInboundMessage = {
   id: "telegram:42:1",
   channel: CONN.id,
   accountId: CONN.agentId,

--- a/packages/gateway-ingress/src/__tests__/storage.test.ts
+++ b/packages/gateway-ingress/src/__tests__/storage.test.ts
@@ -4,11 +4,11 @@ import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import type { GatewayInboundMessage } from "@botcord/protocol-core";
 import { FileSystemIngressStore } from "../storage/store.js";
 import type {
   GatewayConnection,
   InboundEvent,
-  NormalizedInboundMessage,
   OutboundDelivery,
 } from "../types.js";
 
@@ -16,7 +16,7 @@ function tmp(): string {
   return mkdtempSync(join(tmpdir(), "botcord-ingress-"));
 }
 
-const NORMALIZED: NormalizedInboundMessage = {
+const NORMALIZED: GatewayInboundMessage = {
   id: "telegram:42:1",
   channel: "gw_tg_test",
   accountId: "ag_test",

--- a/packages/gateway-ingress/src/__tests__/telegram.test.ts
+++ b/packages/gateway-ingress/src/__tests__/telegram.test.ts
@@ -3,7 +3,8 @@ import { describe, expect, it } from "vitest";
 import { noopLogger } from "../log.js";
 import { createTelegramProvider } from "../providers/telegram.js";
 import type { ProviderRuntimeContext } from "../providers/types.js";
-import type { GatewayConnection, NormalizedInboundMessage } from "../types.js";
+import type { GatewayInboundMessage } from "@botcord/protocol-core";
+import type { GatewayConnection } from "../types.js";
 
 const conn: GatewayConnection = {
   id: "gw_tg_unit",
@@ -21,11 +22,11 @@ const conn: GatewayConnection = {
 
 function makeCtx(secret: Record<string, unknown>, abort: AbortController): {
   ctx: ProviderRuntimeContext;
-  emits: { msg: NormalizedInboundMessage; providerEventId: string }[];
+  emits: { msg: GatewayInboundMessage; providerEventId: string }[];
   cursors: Record<string, unknown>[];
   activity: { lastPollAt?: number; lastInboundAt?: number; lastError?: string | null }[];
 } {
-  const emits: { msg: NormalizedInboundMessage; providerEventId: string }[] = [];
+  const emits: { msg: GatewayInboundMessage; providerEventId: string }[] = [];
   const cursors: Record<string, unknown>[] = [];
   const activity: { lastPollAt?: number; lastInboundAt?: number; lastError?: string | null }[] = [];
   const ctx: ProviderRuntimeContext = {

--- a/packages/gateway-ingress/src/__tests__/wechat.test.ts
+++ b/packages/gateway-ingress/src/__tests__/wechat.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from "vitest";
+
+import type { GatewayInboundMessage } from "@botcord/protocol-core";
+import { noopLogger } from "../log.js";
+import { createWechatProvider } from "../providers/wechat.js";
+import type { ProviderRuntimeContext } from "../providers/types.js";
+import type { GatewayConnection } from "../types.js";
+
+const conn: GatewayConnection = {
+  id: "gw_wc_unit",
+  agentId: "ag_unit",
+  provider: "wechat",
+  status: "active",
+  enabled: true,
+  config: {
+    allowedSenderIds: ["alice"],
+  },
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+function makeCtx(secret: Record<string, unknown>, abort: AbortController) {
+  const emits: { msg: GatewayInboundMessage; providerEventId: string }[] = [];
+  const cursors: Record<string, unknown>[] = [];
+  const activity: {
+    lastPollAt?: number;
+    lastInboundAt?: number;
+    lastError?: string | null;
+  }[] = [];
+  const ctx: ProviderRuntimeContext = {
+    connection: conn,
+    secret,
+    log: noopLogger,
+    abortSignal: abort.signal,
+    async emit(msg, id) {
+      emits.push({ msg, providerEventId: id });
+      return true;
+    },
+    persistCursor(cursor) {
+      cursors.push(cursor);
+    },
+    loadCursor() {
+      return {};
+    },
+    markActivity(patch) {
+      activity.push(patch);
+    },
+  };
+  return { ctx, emits, cursors, activity };
+}
+
+describe("WeChat provider adapter", () => {
+  it("polls getupdates, normalizes text, advances cursor only after emit", async () => {
+    let pollCount = 0;
+    const fetchImpl = (async (url: string, init?: RequestInit) => {
+      if (url.endsWith("/ilink/bot/getupdates")) {
+        pollCount += 1;
+        if (pollCount === 1) {
+          return new Response(
+            JSON.stringify({
+              ret: 0,
+              get_updates_buf: "buf-1",
+              msgs: [
+                {
+                  message_type: 1,
+                  from_user_id: "alice",
+                  context_token: "ctx-tok-1",
+                  client_id: "wc_client_1",
+                  item_list: [{ type: 1, text_item: { text: "hello wechat" } }],
+                },
+              ],
+            }),
+            { status: 200 },
+          );
+        }
+        // After the first batch, hold open until aborted.
+        return new Promise<Response>((_res, rej) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => rej(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        });
+      }
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const provider = createWechatProvider({
+      gatewayId: conn.id,
+      fetchImpl,
+    });
+    const abort = new AbortController();
+    const { ctx, emits, cursors } = makeCtx({ botToken: "tok" }, abort);
+
+    const running = provider.start(ctx);
+    const deadline = Date.now() + 1_000;
+    while (Date.now() < deadline && emits.length === 0) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    abort.abort();
+    await running;
+
+    expect(emits).toHaveLength(1);
+    expect(emits[0]!.msg.text).toBe("hello wechat");
+    expect(emits[0]!.msg.conversation.id).toBe("wechat:user:alice");
+    expect(emits[0]!.msg.sender.id).toBe("wechat:user:alice");
+    expect(emits[0]!.providerEventId).toBe("wechat:gw_wc_unit:wc_client_1");
+    expect(cursors[0]).toEqual({ buf: "buf-1" });
+  });
+
+  it("rejects senders not in allowedSenderIds", async () => {
+    let pollCount = 0;
+    const fetchImpl = (async (url: string, init?: RequestInit) => {
+      if (url.endsWith("/ilink/bot/getupdates")) {
+        pollCount += 1;
+        if (pollCount === 1) {
+          return new Response(
+            JSON.stringify({
+              ret: 0,
+              get_updates_buf: "buf-2",
+              msgs: [
+                {
+                  message_type: 1,
+                  from_user_id: "eve",
+                  context_token: "ctx-tok-2",
+                  client_id: "wc_client_2",
+                  item_list: [{ type: 1, text_item: { text: "blocked" } }],
+                },
+              ],
+            }),
+            { status: 200 },
+          );
+        }
+        return new Promise<Response>((_res, rej) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => rej(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        });
+      }
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const provider = createWechatProvider({
+      gatewayId: conn.id,
+      fetchImpl,
+    });
+    const abort = new AbortController();
+    const { ctx, emits, cursors } = makeCtx({ botToken: "tok" }, abort);
+    const running = provider.start(ctx);
+    const deadline = Date.now() + 1_000;
+    while (Date.now() < deadline && cursors.length === 0) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    abort.abort();
+    await running;
+    expect(emits).toHaveLength(0);
+    // Cursor still advances — the orchestrator's dedupe / allowlist filter
+    // dropped the message, but iLink saw it delivered.
+    expect(cursors[0]).toEqual({ buf: "buf-2" });
+  });
+
+  it("send() reuses cached context_token and posts to sendmessage", async () => {
+    let pollCount = 0;
+    const sendBodies: unknown[] = [];
+    const fetchImpl = (async (url: string, init?: RequestInit) => {
+      if (url.endsWith("/ilink/bot/getupdates")) {
+        pollCount += 1;
+        if (pollCount === 1) {
+          return new Response(
+            JSON.stringify({
+              ret: 0,
+              get_updates_buf: "buf-3",
+              msgs: [
+                {
+                  message_type: 1,
+                  from_user_id: "alice",
+                  context_token: "ctx-tok-3",
+                  client_id: "wc_client_3",
+                  item_list: [{ type: 1, text_item: { text: "ping" } }],
+                },
+              ],
+            }),
+            { status: 200 },
+          );
+        }
+        return new Promise<Response>((_res, rej) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => rej(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        });
+      }
+      if (url.endsWith("/ilink/bot/sendmessage")) {
+        sendBodies.push(JSON.parse(init?.body as string));
+        return new Response(JSON.stringify({ ret: 0 }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const provider = createWechatProvider({
+      gatewayId: conn.id,
+      fetchImpl,
+    });
+    const abort = new AbortController();
+    const { ctx, emits } = makeCtx({ botToken: "tok" }, abort);
+    const running = provider.start(ctx);
+    const deadline = Date.now() + 1_000;
+    while (Date.now() < deadline && emits.length === 0) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+
+    const result = await provider.send({
+      gatewayId: conn.id,
+      conversationId: "wechat:user:alice",
+      text: "pong",
+      final: true,
+    });
+
+    abort.abort();
+    await running;
+
+    expect(result.providerMessageId).not.toBeNull();
+    expect(sendBodies).toHaveLength(1);
+    const body = sendBodies[0] as { msg: Record<string, unknown> };
+    expect(body.msg).toMatchObject({
+      to_user_id: "alice",
+      context_token: "ctx-tok-3",
+      message_type: 2,
+      message_state: 2,
+    });
+    expect(body.msg.item_list).toEqual([
+      { type: 1, text_item: { text: "pong" } },
+    ]);
+  });
+
+  it("send() throws when no trace is cached for the conversation", async () => {
+    const fetchImpl = (async (_url: string, init?: RequestInit) => {
+      // Hold the poll open so loop survives until abort.
+      return new Promise<Response>((_res, rej) => {
+        init?.signal?.addEventListener(
+          "abort",
+          () => rej(new DOMException("Aborted", "AbortError")),
+          { once: true },
+        );
+      });
+    }) as unknown as typeof fetch;
+
+    const provider = createWechatProvider({
+      gatewayId: conn.id,
+      fetchImpl,
+    });
+    const abort = new AbortController();
+    const { ctx } = makeCtx({ botToken: "tok" }, abort);
+    const running = provider.start(ctx);
+    // Let start() install config + open poll.
+    await new Promise((r) => setTimeout(r, 30));
+
+    await expect(
+      provider.send({
+        gatewayId: conn.id,
+        conversationId: "wechat:user:nobody",
+        text: "hi",
+        final: true,
+      }),
+    ).rejects.toThrow(/no context_token/);
+
+    abort.abort();
+    await running;
+  });
+});

--- a/packages/gateway-ingress/src/orchestrator.ts
+++ b/packages/gateway-ingress/src/orchestrator.ts
@@ -14,10 +14,10 @@ import type { IngressLogger } from "./log.js";
 import { RuntimeSessionManager } from "./runtime/session.js";
 import type { ProviderAdapter } from "./providers/types.js";
 import type { IngressStore } from "./storage/store.js";
+import type { GatewayInboundMessage } from "@botcord/protocol-core";
 import type {
   GatewayConnection,
   InboundEvent,
-  NormalizedInboundMessage,
   OutboundSendRequest,
 } from "./types.js";
 
@@ -80,7 +80,7 @@ export class IngressOrchestrator {
    */
   async ingest(
     gatewayId: string,
-    message: NormalizedInboundMessage,
+    message: GatewayInboundMessage,
     providerEventId: string,
   ): Promise<boolean> {
     const connection = this.opts.store.getConnection(gatewayId);

--- a/packages/gateway-ingress/src/provider-runner.ts
+++ b/packages/gateway-ingress/src/provider-runner.ts
@@ -3,7 +3,8 @@ import type { IngressOrchestrator } from "./orchestrator.js";
 import type { ProviderAdapter, ProviderAdapterFactory, ProviderRuntimeContext } from "./providers/types.js";
 import type { IngressSecretStore } from "./storage/secrets.js";
 import type { IngressStore } from "./storage/store.js";
-import type { GatewayConnection, NormalizedInboundMessage } from "./types.js";
+import type { GatewayInboundMessage } from "@botcord/protocol-core";
+import type { GatewayConnection } from "./types.js";
 
 /**
  * Spins up one provider adapter per `GatewayConnection`, wiring it to
@@ -64,7 +65,7 @@ export class ProviderRunner {
       secret: secret as Record<string, unknown>,
       log: this.opts.log,
       abortSignal: abort.signal,
-      emit: async (message: NormalizedInboundMessage, providerEventId: string) =>
+      emit: async (message: GatewayInboundMessage, providerEventId: string) =>
         this.opts.orchestrator.ingest(conn.id, message, providerEventId),
       persistCursor: (cursor) => {
         this.opts.store.updateState(conn.id, { cursor });

--- a/packages/gateway-ingress/src/providers/feishu.ts
+++ b/packages/gateway-ingress/src/providers/feishu.ts
@@ -1,0 +1,414 @@
+import * as Lark from "@larksuiteoapi/node-sdk";
+
+import { sanitizeUntrustedContent, splitText } from "@botcord/protocol-core";
+import type { GatewayInboundMessage } from "@botcord/protocol-core";
+
+import type { OutboundSendRequest, OutboundSendResult } from "../types.js";
+import type {
+  ProviderAdapter,
+  ProviderAdapterFactory,
+  ProviderRuntimeContext,
+} from "./types.js";
+
+/**
+ * Feishu / Lark event-WS adapter for the cloud gateway ingress.
+ *
+ * Ported from `packages/daemon/src/gateway/channels/feishu.ts` to the
+ * ingress `ProviderAdapter` contract. Architecture-level changes versus
+ * the daemon source:
+ *
+ *   - cursor/dedupe: dropped. The orchestrator deduplicates via
+ *     `providerEventId` (= `feishu:${message_id}`) and durably writes
+ *     accepted events. Adapters stay stateless.
+ *   - secret store: dropped. `appSecret` is resolved by the runner
+ *     through `ctx.secret`. The Hub never sees the secret.
+ *   - state-store file: dropped. `seenMessageIds` lived only to guard
+ *     against re-delivery on daemon restart; the orchestrator now owns
+ *     that invariant.
+ *   - typing reaction (im.v1 reactions API): omitted from MVP. The
+ *     ingress runtime has no `typing` concept yet — phase 4 can re-add.
+ *   - attachment uploads: omitted from MVP. The runtime frame contract
+ *     carries text only; richer outbound shapes land alongside
+ *     streaming (`gateway_outbound_delta`).
+ *
+ * Inbound semantics (kept identical):
+ *
+ *   - subscribe to `im.message.receive_v1` over the lark WS client;
+ *   - skip own-bot echoes when `botOpenId` is known (probe on start);
+ *   - allowlist by chat id and/or sender open id (default-allow when
+ *     unset, matching the ingress Telegram adapter);
+ *   - extract text content; non-text message types surface as a short
+ *     `[type message]` summary so the runtime still sees something;
+ *   - normalize into `GatewayInboundMessage` with conversation id
+ *     `feishu:user:{chatId}` (p2p) or `feishu:chat:{chatId}` (group).
+ *
+ * Outbound semantics:
+ *
+ *   - resolve chat id from `conversationId` prefix;
+ *   - split text on the canonical 4000-char Feishu limit;
+ *   - send via `/open-apis/im/v1/messages` (no reply chain — the
+ *     OutboundSendRequest contract has no replyTo today).
+ */
+const FEISHU_PROVIDER = "feishu" as const;
+const DEFAULT_SPLIT_AT = 4000;
+
+export type FeishuDomain = "feishu" | "lark";
+
+interface FeishuSecret {
+  appSecret?: string;
+}
+
+interface FeishuConnectionConfig {
+  appId?: string;
+  domain?: FeishuDomain;
+  allowedSenderIds?: string[];
+  allowedChatIds?: string[];
+  splitAt?: number;
+}
+
+interface FeishuEventSender {
+  sender_id?: {
+    open_id?: string;
+    user_id?: string;
+    union_id?: string;
+  };
+  sender_type?: string;
+  tenant_key?: string;
+}
+
+interface FeishuEventMessage {
+  message_id?: string;
+  root_id?: string;
+  parent_id?: string;
+  create_time?: string;
+  chat_id?: string;
+  chat_type?: string;
+  message_type?: string;
+  content?: string;
+  mentions?: Array<{ id?: { open_id?: string; user_id?: string }; name?: string }>;
+}
+
+interface FeishuMessageEvent {
+  sender?: FeishuEventSender;
+  message?: FeishuEventMessage;
+}
+
+interface FeishuApiResponse {
+  code?: number;
+  msg?: string;
+  data?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+type FeishuClient = { request(args: unknown): Promise<unknown> };
+
+function sdkDomain(domain: FeishuDomain | undefined): unknown {
+  const sdk = Lark as unknown as { Domain?: { Feishu?: unknown; Lark?: unknown } };
+  return domain === "lark" ? sdk.Domain?.Lark : sdk.Domain?.Feishu;
+}
+
+function parseMessageContent(content: string | undefined): Record<string, unknown> | null {
+  if (!content) return null;
+  try {
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return { text: content };
+  }
+}
+
+function parseInboundText(message: FeishuEventMessage): string | null {
+  const parsed = parseMessageContent(message.content);
+  if (!parsed) return null;
+  if (typeof parsed.text === "string") return parsed.text;
+  if (message.message_type === "image" && typeof parsed.image_key === "string") {
+    return `[image: ${parsed.image_key}]`;
+  }
+  if (message.message_type === "file" && typeof parsed.file_key === "string") {
+    const name = typeof parsed.file_name === "string" ? ` ${parsed.file_name}` : "";
+    return `[file${name}: ${parsed.file_key}]`;
+  }
+  if (message.message_type === "audio" && typeof parsed.file_key === "string") {
+    return `[audio: ${parsed.file_key}]`;
+  }
+  if (message.message_type === "media" && typeof parsed.file_key === "string") {
+    return `[video: ${parsed.file_key}]`;
+  }
+  if (message.message_type) return `[${message.message_type} message]`;
+  return null;
+}
+
+function senderLabel(event: FeishuMessageEvent): string | undefined {
+  const mentions = event.message?.mentions ?? [];
+  const senderOpenId = event.sender?.sender_id?.open_id;
+  const hit = mentions.find((m) => m.id?.open_id && m.id.open_id === senderOpenId);
+  return typeof hit?.name === "string" && hit.name ? hit.name : undefined;
+}
+
+function chatIdFromConversation(conversationId: string): string | null {
+  if (conversationId.startsWith("feishu:user:")) {
+    return conversationId.slice("feishu:user:".length);
+  }
+  if (conversationId.startsWith("feishu:chat:")) {
+    return conversationId.slice("feishu:chat:".length);
+  }
+  return null;
+}
+
+export interface FeishuProviderOptions {
+  gatewayId: string;
+  /** Test hook: bypass the lark SDK entirely. */
+  sdkOverride?: {
+    createClient(args: Record<string, unknown>): FeishuClient;
+    createWsClient(args: Record<string, unknown>): {
+      start(opts: unknown): unknown;
+      close(opts?: unknown): unknown;
+    };
+    createDispatcher(): {
+      register(handlers: Record<string, (data: unknown) => unknown>): void;
+    };
+  };
+}
+
+export function createFeishuProvider(opts: FeishuProviderOptions): ProviderAdapter {
+  const sdkOverride = opts.sdkOverride;
+
+  let wsClient: { start(opts: unknown): unknown; close(opts?: unknown): unknown } | null = null;
+  let client: FeishuClient | null = null;
+  let activeCtx: ProviderRuntimeContext | null = null;
+  let botOpenId: string | undefined;
+
+  let appId: string | undefined;
+  let appSecret: string | undefined;
+  let domain: FeishuDomain | undefined;
+  let splitAt = DEFAULT_SPLIT_AT;
+  let allowedSenderIds = new Set<string>();
+  let allowedChatIds = new Set<string>();
+
+  function ensureClient(): FeishuClient {
+    if (client) return client;
+    if (!appId || !appSecret) throw new Error("feishu appId/appSecret not loaded");
+    if (sdkOverride) {
+      client = sdkOverride.createClient({
+        appId,
+        appSecret,
+        domain: sdkDomain(domain),
+      });
+      return client;
+    }
+    const sdk = Lark as unknown as {
+      Client: new (args: Record<string, unknown>) => FeishuClient;
+      AppType?: { SelfBuild?: unknown };
+    };
+    client = new sdk.Client({
+      appId,
+      appSecret,
+      appType: sdk.AppType?.SelfBuild,
+      domain: sdkDomain(domain),
+    });
+    return client;
+  }
+
+  async function callFeishu(args: unknown): Promise<FeishuApiResponse> {
+    const res = (await ensureClient().request(args)) as FeishuApiResponse;
+    if (res.code !== undefined && res.code !== 0) {
+      throw new Error(res.msg || `feishu api failed: code=${res.code}`);
+    }
+    return res;
+  }
+
+  async function probe(): Promise<void> {
+    const res = (await callFeishu({
+      method: "POST",
+      url: "/open-apis/bot/v1/openclaw_bot/ping",
+      data: { needBotInfo: true },
+    })) as { data?: { pingBotInfo?: { botID?: string } } };
+    botOpenId = res.data?.pingBotInfo?.botID;
+  }
+
+  function normalizeMessage(
+    event: FeishuMessageEvent,
+    accountId: string,
+    channelId: string,
+  ): { message: GatewayInboundMessage; providerEventId: string } | null {
+    const message = event.message;
+    const sender = event.sender;
+    if (!message || !sender) return null;
+    const chatId = message.chat_id;
+    const messageId = message.message_id;
+    const senderOpenId = sender.sender_id?.open_id;
+    if (!chatId || !messageId || !senderOpenId) return null;
+    if (botOpenId && senderOpenId === botOpenId) return null;
+
+    if (allowedChatIds.size > 0 && !allowedChatIds.has(chatId)) return null;
+    if (allowedSenderIds.size > 0 && !allowedSenderIds.has(senderOpenId)) return null;
+
+    const text = parseInboundText(message);
+    if (text === null) return null;
+    const chatType = message.chat_type ?? "";
+    const conversationKind: "direct" | "group" = chatType === "p2p" ? "direct" : "group";
+    const conversationId =
+      conversationKind === "direct" ? `feishu:user:${chatId}` : `feishu:chat:${chatId}`;
+    const receivedAt = Number(message.create_time) || Date.now();
+    const name = senderLabel(event);
+
+    const normalized: GatewayInboundMessage = {
+      id: `feishu:${messageId}`,
+      channel: channelId,
+      accountId,
+      conversation: {
+        id: conversationId,
+        kind: conversationKind,
+        threadId: message.root_id || message.parent_id || null,
+      },
+      sender: {
+        id: `feishu:user:${senderOpenId}`,
+        ...(name ? { name } : {}),
+        kind: "user",
+      },
+      text: sanitizeUntrustedContent(text),
+      replyTo: messageId,
+      mentioned: true,
+      receivedAt,
+      trace: { id: `feishu:${messageId}`, streamable: true },
+    };
+    return { message: normalized, providerEventId: `feishu:${messageId}` };
+  }
+
+  async function start(ctx: ProviderRuntimeContext): Promise<void> {
+    activeCtx = ctx;
+    const secret = ctx.secret as FeishuSecret;
+    const config = ctx.connection.config as FeishuConnectionConfig;
+    appId = config.appId;
+    appSecret = secret.appSecret;
+    domain = config.domain;
+    if (config.splitAt && config.splitAt > 0) splitAt = config.splitAt;
+    allowedSenderIds = new Set((config.allowedSenderIds ?? []).map(String));
+    allowedChatIds = new Set((config.allowedChatIds ?? []).map(String));
+
+    if (!appId || !appSecret) {
+      ctx.markActivity({ lastError: "missing_credential" });
+      ctx.log.error("feishu missing appId/appSecret", { gatewayId: ctx.connection.id });
+      return;
+    }
+
+    try {
+      await probe();
+    } catch (err) {
+      ctx.markActivity({ lastError: redact(err) });
+      ctx.log.warn("feishu probe failed, continuing without botOpenId", { err: redact(err) });
+    }
+
+    const dispatcher = sdkOverride
+      ? sdkOverride.createDispatcher()
+      : new (Lark as unknown as {
+          EventDispatcher: new (args?: Record<string, unknown>) => {
+            register(handlers: Record<string, (data: unknown) => unknown>): void;
+          };
+        }).EventDispatcher({});
+
+    dispatcher.register({
+      "im.message.receive_v1": async (data: unknown) => {
+        const normalized = normalizeMessage(
+          data as FeishuMessageEvent,
+          ctx.connection.agentId,
+          ctx.connection.id,
+        );
+        if (!normalized) return;
+        ctx.markActivity({ lastInboundAt: Date.now() });
+        try {
+          await ctx.emit(normalized.message, normalized.providerEventId);
+        } catch (err) {
+          ctx.log.error("feishu emit threw", { err: redact(err) });
+        }
+      },
+    });
+
+    wsClient = sdkOverride
+      ? sdkOverride.createWsClient({ appId, appSecret, domain: sdkDomain(domain) })
+      : new (Lark as unknown as {
+          WSClient: new (args: Record<string, unknown>) => {
+            start(opts: unknown): unknown;
+            close(opts?: unknown): unknown;
+          };
+          LoggerLevel?: { info?: unknown };
+        }).WSClient({
+          appId,
+          appSecret,
+          domain: sdkDomain(domain),
+          loggerLevel: (Lark as unknown as { LoggerLevel?: { info?: unknown } }).LoggerLevel?.info,
+        });
+
+    ctx.markActivity({ lastPollAt: Date.now(), lastError: null });
+    Promise.resolve(wsClient.start({ eventDispatcher: dispatcher })).catch((err) => {
+      ctx.markActivity({ lastError: redact(err) });
+      ctx.log.warn("feishu ws client failed", { err: redact(err) });
+    });
+
+    await new Promise<void>((resolve) => {
+      if (ctx.abortSignal.aborted) return resolve();
+      ctx.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+    });
+
+    try {
+      wsClient?.close({ force: true });
+    } catch {
+      // best effort
+    }
+    wsClient = null;
+  }
+
+  async function send(request: OutboundSendRequest): Promise<OutboundSendResult> {
+    const chatId = chatIdFromConversation(request.conversationId);
+    if (!chatId) {
+      throw new Error(`feishu send: unrecognized conversationId "${request.conversationId}"`);
+    }
+    const chunks = request.text.length > 0 ? splitText(request.text, splitAt) : [];
+    let lastMessageId: string | null = null;
+    for (const chunk of chunks) {
+      const res = await callFeishu({
+        method: "POST",
+        url: "/open-apis/im/v1/messages",
+        params: { receive_id_type: "chat_id" },
+        data: {
+          receive_id: chatId,
+          msg_type: "text",
+          content: JSON.stringify({ text: chunk }),
+        },
+      });
+      const id = resultMessageId(res);
+      if (id) lastMessageId = `feishu:${id}`;
+    }
+    if (activeCtx) activeCtx.markActivity({ lastInboundAt: undefined });
+    return { providerMessageId: lastMessageId };
+  }
+
+  return {
+    gatewayId: opts.gatewayId,
+    provider: FEISHU_PROVIDER,
+    start,
+    async stop(_reason) {
+      try {
+        wsClient?.close({ force: true });
+      } catch {
+        // best effort
+      }
+      wsClient = null;
+    },
+    send,
+  };
+}
+
+function resultMessageId(res: FeishuApiResponse): string | undefined {
+  return (
+    (typeof res.data?.message_id === "string" ? res.data.message_id : undefined) ??
+    (typeof res.message_id === "string" ? res.message_id : undefined)
+  );
+}
+
+function redact(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export const feishuProviderFactory: ProviderAdapterFactory = (gatewayId) =>
+  createFeishuProvider({ gatewayId });

--- a/packages/gateway-ingress/src/providers/registry.ts
+++ b/packages/gateway-ingress/src/providers/registry.ts
@@ -1,5 +1,7 @@
 import type { ProviderAdapterFactory } from "./types.js";
+import { feishuProviderFactory } from "./feishu.js";
 import { telegramProviderFactory } from "./telegram.js";
+import { wechatProviderFactory } from "./wechat.js";
 
 /**
  * Default provider factory table — the CLI seeds the `ProviderRunner`
@@ -8,4 +10,6 @@ import { telegramProviderFactory } from "./telegram.js";
  */
 export const DEFAULT_PROVIDER_FACTORIES: Record<string, ProviderAdapterFactory> = {
   telegram: telegramProviderFactory,
+  feishu: feishuProviderFactory,
+  wechat: wechatProviderFactory,
 };

--- a/packages/gateway-ingress/src/providers/telegram.ts
+++ b/packages/gateway-ingress/src/providers/telegram.ts
@@ -1,4 +1,5 @@
-import type { NormalizedInboundMessage, OutboundSendRequest, OutboundSendResult } from "../types.js";
+import type { GatewayInboundMessage } from "@botcord/protocol-core";
+import type { OutboundSendRequest, OutboundSendResult } from "../types.js";
 import type { ProviderAdapter, ProviderAdapterFactory, ProviderRuntimeContext } from "./types.js";
 
 /**
@@ -123,7 +124,7 @@ export function createTelegramProvider(opts: TelegramProviderOptions): ProviderA
     update: TelegramUpdate,
     accountId: string,
     channelId: string,
-  ): NormalizedInboundMessage | null {
+  ): GatewayInboundMessage | null {
     const msg = update.message;
     if (!msg) return null;
     const text = typeof msg.text === "string" ? msg.text : null;
@@ -146,7 +147,7 @@ export function createTelegramProvider(opts: TelegramProviderOptions): ProviderA
       from.username ?? from.first_name ?? undefined;
     const messageId = `telegram:${chatId}:${msg.message_id}`;
 
-    const normalized: NormalizedInboundMessage = {
+    const normalized: GatewayInboundMessage = {
       id: messageId,
       channel: channelId,
       accountId,
@@ -313,7 +314,10 @@ export const telegramProviderFactory: ProviderAdapterFactory = (gatewayId) =>
   createTelegramProvider({ gatewayId });
 
 // ---------------------------------------------------------------------------
-// Local helpers — copied from daemon to avoid cross-package coupling.
+// Local helpers — paragraph-aware splitter (different algorithm from the
+// canonical `splitText` in `@botcord/protocol-core`, which cuts on single
+// newlines). Kept local because Telegram replies benefit from preserving
+// paragraph boundaries when the daemon-style cutter would break mid-paragraph.
 // ---------------------------------------------------------------------------
 
 function splitText(text: string, limit: number): string[] {

--- a/packages/gateway-ingress/src/providers/types.ts
+++ b/packages/gateway-ingress/src/providers/types.ts
@@ -1,7 +1,7 @@
+import type { GatewayInboundMessage } from "@botcord/protocol-core";
 import type { IngressLogger } from "../log.js";
 import type {
   GatewayConnection,
-  NormalizedInboundMessage,
   OutboundSendRequest,
   OutboundSendResult,
 } from "../types.js";
@@ -44,7 +44,7 @@ export interface ProviderRuntimeContext {
    * write succeeded), `false` if the message was a duplicate, or
    * throws when ingestion failed and the cursor must NOT advance.
    */
-  emit(message: NormalizedInboundMessage, providerEventId: string): Promise<boolean>;
+  emit(message: GatewayInboundMessage, providerEventId: string): Promise<boolean>;
   /**
    * Persist a provider cursor blob. Called only after `emit` succeeded
    * for every message in the batch — never before.

--- a/packages/gateway-ingress/src/providers/wechat.ts
+++ b/packages/gateway-ingress/src/providers/wechat.ts
@@ -1,0 +1,478 @@
+import { randomBytes, randomUUID } from "node:crypto";
+
+import { sanitizeUntrustedContent, splitText } from "@botcord/protocol-core";
+import type { GatewayInboundMessage } from "@botcord/protocol-core";
+
+import type { OutboundSendRequest, OutboundSendResult } from "../types.js";
+import type {
+  ProviderAdapter,
+  ProviderAdapterFactory,
+  ProviderRuntimeContext,
+} from "./types.js";
+
+/**
+ * WeChat (iLink Bot API) adapter for the cloud gateway ingress.
+ *
+ * Ported from `packages/daemon/src/gateway/channels/wechat.ts`. The
+ * iLink server has no native streaming or message-edit; the adapter
+ * long-polls `ilink/bot/getupdates` with `get_updates_buf` as the
+ * cursor, and sends replies via `ilink/bot/sendmessage`.
+ *
+ * Architecture-level changes versus the daemon source:
+ *
+ *   - cursor: still persisted, but through `ctx.persistCursor` instead
+ *     of the daemon file-backed state-store. Schema is `{ buf: string }`.
+ *   - secret: resolved by the runner through `ctx.secret.botToken`.
+ *   - dedupe: dropped from the adapter — orchestrator deduplicates by
+ *     `providerEventId` derived from `client_id` (or a synthetic id
+ *     when iLink omits it). `seenMessageIds` was never needed here
+ *     anyway because the iLink cursor advances monotonically.
+ *   - trace cache: kept, in-memory only. Maps `traceId → context_token`
+ *     for outbound `sendmessage`. iLink does NOT accept unsolicited
+ *     replies — outbound must reuse the inbound `context_token`, so
+ *     this cache is load-bearing. TTL 30 min mirrors daemon doc.
+ *   - typing (`sendtyping`): omitted from MVP. Phase 4 can re-add when
+ *     the ingress contract has a typing concept.
+ *   - media upload (encrypted CDN flow, AES-128-ECB): omitted from
+ *     MVP. iLink media is text-only-aware for now.
+ *
+ * Allowlist is default-allow when `allowedSenderIds` is empty (matches
+ * Telegram). The daemon adapter defaulted to deny because BotCord room
+ * permissions don't apply to third-party direct conversations — for
+ * cloud Cloud Agent gateways the user owns the bot and the dashboard
+ * gates who can bind it, so default-allow is the right ergonomic.
+ */
+const WECHAT_PROVIDER = "wechat" as const;
+const DEFAULT_BASE_URL = "https://ilinkai.weixin.qq.com";
+const DEFAULT_SPLIT_AT = 1800;
+/** iLink server holds getupdates ≤35 s; allow slack on the client side. */
+const POLL_TIMEOUT_S = 60;
+const POLL_BACKOFF_MS = 3000;
+const TRANSIENT_BACKOFF_MS = 1000;
+const TRACE_CONTEXT_TTL_MS = 30 * 60 * 1000;
+const TRACE_CONTEXT_SWEEP_MS = 5 * 60 * 1000;
+const TRACE_CONTEXT_MAX = 5000;
+const WECHAT_CHANNEL_VERSION = "1.0.2";
+const WECHAT_BASE_INFO = { channel_version: WECHAT_CHANNEL_VERSION } as const;
+
+interface WechatSecret {
+  botToken?: string;
+}
+
+interface WechatConnectionConfig {
+  baseUrl?: string;
+  allowedSenderIds?: string[];
+  splitAt?: number;
+  traceContextMax?: number;
+}
+
+interface WechatTextItem {
+  type?: number;
+  text_item?: { text?: string };
+  [k: string]: unknown;
+}
+
+interface WechatInboundMsg {
+  message_type?: number;
+  from_user_id?: string;
+  context_token?: string;
+  client_id?: unknown;
+  item_list?: WechatTextItem[];
+  [k: string]: unknown;
+}
+
+interface WechatGetUpdatesResp {
+  ret?: number;
+  get_updates_buf?: string;
+  msgs?: WechatInboundMsg[];
+}
+
+interface WechatGenericResp {
+  ret?: number;
+  [k: string]: unknown;
+}
+
+interface TraceContext {
+  contextToken: string;
+  fromUserId: string;
+  updatedAt: number;
+}
+
+/** `X-WECHAT-UIN: base64(str(random uint32))` — fresh per request, anti-replay. */
+function wechatUinHeader(): string {
+  const n = randomBytes(4).readUInt32BE(0);
+  return Buffer.from(String(n), "utf8").toString("base64");
+}
+
+function wechatHeaders(botToken: string): Record<string, string> {
+  return {
+    "Content-Type": "application/json",
+    AuthorizationType: "ilink_bot_token",
+    "X-WECHAT-UIN": wechatUinHeader(),
+    Authorization: `Bearer ${botToken}`,
+  };
+}
+
+function redactToken(input: string, token: string | undefined): string {
+  if (!token || !input) return input;
+  return input.split(token).join("[REDACTED]");
+}
+
+export interface WechatProviderOptions {
+  gatewayId: string;
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+}
+
+export function createWechatProvider(opts: WechatProviderOptions): ProviderAdapter {
+  const fetchImpl: typeof fetch = opts.fetchImpl ?? globalThis.fetch.bind(globalThis);
+  const now: () => number = opts.now ?? (() => Date.now());
+
+  let activeCtx: ProviderRuntimeContext | null = null;
+  let botToken: string | undefined;
+  let baseUrl = DEFAULT_BASE_URL;
+  let splitAt = DEFAULT_SPLIT_AT;
+  let allowedSenderIds = new Set<string>();
+  let traceContextMax = TRACE_CONTEXT_MAX;
+  let stopController: AbortController | null = null;
+  let sweepTimer: ReturnType<typeof setInterval> | null = null;
+  const traceContexts = new Map<string, TraceContext>();
+
+  function pruneTraceContexts(): void {
+    const cutoff = now() - TRACE_CONTEXT_TTL_MS;
+    for (const [k, v] of traceContexts) {
+      if (v.updatedAt < cutoff) traceContexts.delete(k);
+    }
+  }
+
+  function rememberTrace(traceId: string, ctx: TraceContext): void {
+    if (traceContexts.size >= traceContextMax) {
+      let oldestKey: string | undefined;
+      let oldestAt = Infinity;
+      for (const [k, v] of traceContexts) {
+        if (v.updatedAt < oldestAt) {
+          oldestAt = v.updatedAt;
+          oldestKey = k;
+        }
+      }
+      if (oldestKey !== undefined) traceContexts.delete(oldestKey);
+    }
+    traceContexts.set(traceId, ctx);
+  }
+
+  function lookupTrace(traceId: string | null | undefined): TraceContext | null {
+    if (!traceId) return null;
+    const hit = traceContexts.get(traceId);
+    if (!hit) return null;
+    if (now() - hit.updatedAt > TRACE_CONTEXT_TTL_MS) {
+      traceContexts.delete(traceId);
+      return null;
+    }
+    return hit;
+  }
+
+  function lookupTraceByConversation(conversationId: string): TraceContext | null {
+    if (!conversationId.startsWith("wechat:user:")) return null;
+    const fromUid = conversationId.slice("wechat:user:".length);
+    pruneTraceContexts();
+    let best: TraceContext | null = null;
+    for (const v of traceContexts.values()) {
+      if (v.fromUserId !== fromUid) continue;
+      if (!best || v.updatedAt > best.updatedAt) best = v;
+    }
+    return best;
+  }
+
+  async function callApi<T = WechatGenericResp>(
+    path: string,
+    body: Record<string, unknown>,
+    timeoutMs: number,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    if (!botToken) throw new Error("wechat bot token not loaded");
+    const url = `${baseUrl}/${path.replace(/^\/+/, "")}`;
+    const payload = { ...body, base_info: { ...WECHAT_BASE_INFO } };
+    const lease = createTimeoutSignal(timeoutMs, signal);
+    let resp: Response;
+    try {
+      resp = await fetchImpl(url, {
+        method: "POST",
+        headers: wechatHeaders(botToken),
+        body: JSON.stringify(payload),
+        signal: lease.signal,
+      });
+    } finally {
+      lease.cleanup();
+    }
+    const raw = await resp.text();
+    if (!raw) return {} as T;
+    try {
+      return JSON.parse(raw) as T;
+    } catch {
+      return {} as T;
+    }
+  }
+
+  function extractText(msg: WechatInboundMsg): string {
+    const parts: string[] = [];
+    for (const item of msg.item_list ?? []) {
+      if (item?.type === 1) {
+        const t = item.text_item?.text;
+        if (typeof t === "string" && t.length > 0) parts.push(t);
+      }
+    }
+    return parts.join("\n").trim();
+  }
+
+  function normalizeInbound(
+    msg: WechatInboundMsg,
+    accountId: string,
+    channelId: string,
+  ): { message: GatewayInboundMessage; providerEventId: string } | null {
+    if (msg.message_type !== 1) return null;
+    const fromUid = typeof msg.from_user_id === "string" ? msg.from_user_id : "";
+    const contextToken = typeof msg.context_token === "string" ? msg.context_token : "";
+    if (!fromUid || !contextToken) return null;
+    const text = extractText(msg);
+    if (!text) return null;
+    if (allowedSenderIds.size > 0 && !allowedSenderIds.has(fromUid)) return null;
+
+    const sanitized = sanitizeUntrustedContent(text);
+    const receivedAt = now();
+    const clientId =
+      typeof msg.client_id === "string" && msg.client_id.length > 0
+        ? msg.client_id
+        : `wechat:${fromUid}:${receivedAt}:${randomUUID()}`;
+    const traceId = `wechat:${fromUid}:${receivedAt}:${randomUUID()}`;
+
+    rememberTrace(traceId, {
+      contextToken,
+      fromUserId: fromUid,
+      updatedAt: receivedAt,
+    });
+
+    const normalized: GatewayInboundMessage = {
+      id: clientId,
+      channel: channelId,
+      accountId,
+      conversation: { id: `wechat:user:${fromUid}`, kind: "direct" },
+      sender: { id: `wechat:user:${fromUid}`, kind: "user" },
+      text: sanitized,
+      replyTo: null,
+      mentioned: false,
+      receivedAt,
+      trace: { id: traceId, streamable: false },
+    };
+    return { message: normalized, providerEventId: `wechat:${channelId}:${clientId}` };
+  }
+
+  async function loop(ctx: ProviderRuntimeContext): Promise<void> {
+    activeCtx = ctx;
+    const secret = ctx.secret as WechatSecret;
+    botToken = secret.botToken;
+    const config = ctx.connection.config as WechatConnectionConfig;
+    if (config.baseUrl) baseUrl = config.baseUrl.replace(/\/+$/, "");
+    if (config.splitAt && config.splitAt > 0) splitAt = config.splitAt;
+    if (config.traceContextMax && config.traceContextMax > 0) {
+      traceContextMax = config.traceContextMax;
+    }
+    allowedSenderIds = new Set((config.allowedSenderIds ?? []).map(String));
+
+    if (!botToken) {
+      ctx.markActivity({ lastError: "missing_secret" });
+      ctx.log.error("wechat missing bot token", { gatewayId: ctx.connection.id });
+      return;
+    }
+
+    stopController = new AbortController();
+    const abortAggregate = new AbortController();
+    if (ctx.abortSignal.aborted) abortAggregate.abort();
+    else ctx.abortSignal.addEventListener("abort", () => abortAggregate.abort(), { once: true });
+    stopController.signal.addEventListener("abort", () => abortAggregate.abort(), { once: true });
+
+    sweepTimer = setInterval(() => {
+      try {
+        pruneTraceContexts();
+      } catch {
+        // best-effort
+      }
+    }, TRACE_CONTEXT_SWEEP_MS);
+    if (typeof sweepTimer.unref === "function") sweepTimer.unref();
+
+    let updatesBuf = String((ctx.loadCursor() as { buf?: string }).buf ?? "");
+
+    while (!abortAggregate.signal.aborted) {
+      try {
+        const resp = await callApi<WechatGetUpdatesResp>(
+          "ilink/bot/getupdates",
+          { get_updates_buf: updatesBuf },
+          (POLL_TIMEOUT_S + 10) * 1000,
+          abortAggregate.signal,
+        );
+        ctx.markActivity({ lastPollAt: Date.now() });
+        const msgs = Array.isArray(resp.msgs) ? resp.msgs : [];
+        const nextBuf =
+          typeof resp.get_updates_buf === "string" ? resp.get_updates_buf : updatesBuf;
+
+        if (msgs.length === 0) {
+          if (nextBuf !== updatesBuf) {
+            updatesBuf = nextBuf;
+            ctx.persistCursor({ buf: updatesBuf });
+          }
+          await sleep(0, abortAggregate.signal);
+          continue;
+        }
+
+        let emitFailed = false;
+        for (const msg of msgs) {
+          const normalized = normalizeInbound(msg, ctx.connection.agentId, ctx.connection.id);
+          if (!normalized) continue;
+          ctx.markActivity({ lastInboundAt: Date.now() });
+          try {
+            await ctx.emit(normalized.message, normalized.providerEventId);
+          } catch (err) {
+            emitFailed = true;
+            ctx.log.error("wechat emit threw — leaving cursor unchanged", {
+              err: redactToken(String(err), botToken),
+            });
+            break;
+          }
+        }
+        if (!emitFailed && nextBuf !== updatesBuf) {
+          updatesBuf = nextBuf;
+          ctx.persistCursor({ buf: updatesBuf });
+        }
+      } catch (err) {
+        if (abortAggregate.signal.aborted) break;
+        const name = (err as Error)?.name ?? "";
+        if (name === "AbortError" || name === "TimeoutError") {
+          await sleep(TRANSIENT_BACKOFF_MS, abortAggregate.signal);
+          continue;
+        }
+        const errStr = redactToken(String(err), botToken);
+        ctx.log.error("wechat poll failed", { err: errStr });
+        ctx.markActivity({ lastError: errStr });
+        await sleep(POLL_BACKOFF_MS, abortAggregate.signal);
+      }
+    }
+
+    if (sweepTimer) {
+      clearInterval(sweepTimer);
+      sweepTimer = null;
+    }
+  }
+
+  async function send(request: OutboundSendRequest): Promise<OutboundSendResult> {
+    if (!botToken) throw new Error("wechat bot token not loaded");
+    // OutboundSendRequest carries no traceId today, so fall back to a
+    // best-effort lookup by conversation. iLink rejects sends without a
+    // matching context_token — if no trace is cached this throws and the
+    // orchestrator surfaces the failure.
+    const trace = lookupTraceByConversation(request.conversationId);
+    if (!trace) {
+      throw new Error(
+        `wechat send: no context_token for conversation ${request.conversationId} ` +
+          `(expired or never bound — iLink does not support unsolicited replies)`,
+      );
+    }
+    const chunks = request.text.length > 0 ? splitText(request.text, splitAt) : [];
+    let lastClientId: string | null = null;
+    for (const chunk of chunks) {
+      const clientId = `botcord-${randomUUID()}`;
+      const body = {
+        msg: {
+          from_user_id: "",
+          to_user_id: trace.fromUserId,
+          client_id: clientId,
+          message_type: 2,
+          message_state: 2,
+          context_token: trace.contextToken,
+          item_list: [{ type: 1, text_item: { text: chunk } }],
+        },
+      };
+      const resp = await callApi<WechatGenericResp>(
+        "ilink/bot/sendmessage",
+        body,
+        15_000,
+      );
+      if (resp.ret !== 0 && resp.ret !== undefined) {
+        throw new Error(
+          redactToken(`wechat sendmessage failed: ret=${resp.ret}`, botToken),
+        );
+      }
+      lastClientId = `wechat:${trace.fromUserId}:${clientId}`;
+    }
+    if (activeCtx) activeCtx.markActivity({ lastInboundAt: undefined });
+    return { providerMessageId: lastClientId };
+  }
+
+  return {
+    gatewayId: opts.gatewayId,
+    provider: WECHAT_PROVIDER,
+    async start(ctx) {
+      await loop(ctx);
+    },
+    async stop(_reason) {
+      stopController?.abort();
+    },
+    send,
+  };
+}
+
+export const wechatProviderFactory: ProviderAdapterFactory = (gatewayId) =>
+  createWechatProvider({ gatewayId });
+
+// ---------------------------------------------------------------------------
+// Local helpers
+// ---------------------------------------------------------------------------
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function createTimeoutSignal(
+  timeoutMs: number,
+  parent?: AbortSignal,
+): { signal: AbortSignal; cleanup: () => void } {
+  const controller = new AbortController();
+  let settled = false;
+  const abort = (reason?: unknown) => {
+    if (settled) return;
+    settled = true;
+    try {
+      controller.abort(reason);
+    } catch {
+      controller.abort();
+    }
+  };
+  const timer = setTimeout(
+    () => abort(new DOMException("Timeout", "TimeoutError")),
+    timeoutMs,
+  );
+  const onParent = () => abort(parent?.reason);
+  if (parent) {
+    if (parent.aborted) onParent();
+    else parent.addEventListener("abort", onParent, { once: true });
+  }
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      clearTimeout(timer);
+      if (parent) parent.removeEventListener("abort", onParent);
+    },
+  };
+}

--- a/packages/gateway-ingress/src/types.ts
+++ b/packages/gateway-ingress/src/types.ts
@@ -1,4 +1,13 @@
-import type { RuntimeGatewayProvider } from "@botcord/protocol-core";
+import type {
+  GatewayInboundMessage,
+  RuntimeGatewayProvider,
+} from "@botcord/protocol-core";
+
+// Canonical normalized inbound shape lives in `@botcord/protocol-core` so
+// daemon channel adapters and ingress provider adapters share one
+// definition. Re-exported here for backwards-compat with existing
+// `from "./types.js"` imports across the ingress package.
+export type { GatewayInboundMessage } from "@botcord/protocol-core";
 
 /**
  * Local types describing on-disk + in-memory shapes for the ingress
@@ -61,7 +70,7 @@ export interface InboundEvent {
   providerEventId: string;
   conversationId: string;
   senderId: string;
-  normalizedMessage: NormalizedInboundMessage;
+  normalizedMessage: GatewayInboundMessage;
   status: InboundEventStatus;
   attemptCount: number;
   lastError?: string | null;
@@ -69,37 +78,9 @@ export interface InboundEvent {
   updatedAt: number;
 }
 
-/**
- * Normalized message payload mirroring the runtime-frame
- * `RuntimeGatewayInboundPayload`. Kept duplicated rather than imported
- * because the ingress writes this before any runtime frame is built,
- * and tests would otherwise depend on the shared package's compiled
- * output.
- */
-export interface NormalizedInboundMessage {
-  id: string;
-  channel: string;
-  accountId: string;
-  conversation: {
-    id: string;
-    kind: "direct" | "group";
-    title?: string;
-    threadId?: string | null;
-  };
-  sender: {
-    id: string;
-    name?: string;
-    kind: "user" | "agent" | "system";
-  };
-  text?: string;
-  replyTo?: string | null;
-  mentioned?: boolean;
-  receivedAt: number;
-  trace?: {
-    id: string;
-    streamable?: boolean;
-  };
-}
+// `NormalizedInboundMessage` was a local copy of the canonical
+// `GatewayInboundMessage` shape; both are now re-exported from
+// `@botcord/protocol-core`. See the top of this file.
 
 export type DeliveryStatus = "streaming" | "sent" | "failed";
 

--- a/packages/protocol-core/src/gateway-message.ts
+++ b/packages/protocol-core/src/gateway-message.ts
@@ -1,0 +1,79 @@
+/**
+ * Canonical gateway message shapes shared by `packages/daemon` channel
+ * adapters and `packages/gateway-ingress` provider adapters.
+ *
+ * The wire-level subset of {@link GatewayInboundMessage} is
+ * `RuntimeGatewayInboundPayload` (see runtime-frame.ts) — the runtime WS
+ * carries the trimmed shape (no `raw` field) because cloud daemons should
+ * not depend on provider-original payloads. Local daemon channel adapters
+ * can still attach `raw` for debug/logging when they consume their own
+ * upstream events.
+ *
+ * Keep this file free of imports from individual provider SDKs; only
+ * primitive types and re-exports.
+ */
+
+import type { RuntimeGatewayInboundPayload } from "./runtime-frame.js";
+
+/**
+ * Normalized inbound message produced by any gateway channel/provider
+ * adapter. Identical to {@link RuntimeGatewayInboundPayload} plus an
+ * optional `raw` field that local daemon adapters use to keep the
+ * provider-original payload for debugging. The runtime WS still only
+ * carries the wire subset; do not put non-serializable values in `raw`.
+ */
+export interface GatewayInboundMessage extends RuntimeGatewayInboundPayload {
+  /**
+   * Provider-original event payload. Optional because the wire-level
+   * shape (`RuntimeGatewayInboundPayload`) omits it. Daemon adapters
+   * populate it for telemetry; ingress adapters typically leave it
+   * unset since the orchestrator does not need it.
+   */
+  raw?: unknown;
+}
+
+/**
+ * Outbound attachment passed alongside a reply. Either `filePath` (local
+ * file readable by the daemon) or `data` (in-memory bytes) must be set;
+ * `filename` and `contentType` are advisory. `kind` lets adapters dispatch
+ * the upload through provider-specific paths (image vs file vs video).
+ */
+export interface GatewayOutboundAttachment {
+  filePath?: string;
+  data?: Uint8Array;
+  filename?: string;
+  contentType?: string;
+  kind?: "image" | "file" | "video";
+}
+
+/**
+ * Outbound reply envelope produced by the dispatcher and consumed by a
+ * channel/provider adapter. Ingress's per-call `OutboundSendRequest` is
+ * a strict subset of this — adapters that need richer fields (replyTo,
+ * attachments, traceId) read them off here.
+ */
+export interface GatewayOutboundMessage {
+  channel: string;
+  accountId: string;
+  conversationId: string;
+  threadId?: string | null;
+  type?: "message" | "error";
+  text: string;
+  attachments?: GatewayOutboundAttachment[];
+  replyTo?: string | null;
+  traceId?: string | null;
+}
+
+/**
+ * Inbound envelope wrapping a normalized message with optional upstream
+ * ack callbacks. The daemon uses this through `ChannelAdapter.emit`; the
+ * ingress orchestrator does its own durable-write + boolean handshake
+ * and does not consume the `ack` field.
+ */
+export interface GatewayInboundEnvelope {
+  message: GatewayInboundMessage;
+  ack?: {
+    accept(): Promise<void>;
+    reject?(reason: string): Promise<void>;
+  };
+}

--- a/packages/protocol-core/src/gateway-sanitize.ts
+++ b/packages/protocol-core/src/gateway-sanitize.ts
@@ -1,0 +1,68 @@
+/**
+ * Sanitize untrusted inbound content before handing it off to a local runtime.
+ *
+ * Lifted from `packages/daemon/src/gateway/channels/sanitize.ts` so both
+ * the daemon channel adapters and the `gateway-ingress` provider adapters
+ * use the same neutralization rules.
+ *
+ * Neutralizes:
+ *   - BotCord structural markers the channel itself emits (so peers can't forge them).
+ *   - Common LLM prompt-injection patterns (<system>, [INST], <<SYS>>, <|im_start|>, etc.).
+ *   - Wrapper XML tags the channel uses to frame inbound content
+ *     (<agent-message>, <human-message>, <room-rule>).
+ */
+
+export function sanitizeUntrustedContent(text: string): string {
+  let s = text;
+  s = s.replace(
+    /<\/?a[\s]*g[\s]*e[\s]*n[\s]*t[\s]*-[\s]*m[\s]*e[\s]*s[\s]*s[\s]*a[\s]*g[\s]*e[\s\S]*?>/gi,
+    "[⚠ stripped: agent-message tag]",
+  );
+  s = s.replace(
+    /<\/?h[\s]*u[\s]*m[\s]*a[\s]*n[\s]*-[\s]*m[\s]*e[\s]*s[\s]*s[\s]*a[\s]*g[\s]*e[\s\S]*?>/gi,
+    "[⚠ stripped: human-message tag]",
+  );
+  s = s.replace(
+    /<\/?r[\s]*o[\s]*o[\s]*m[\s]*-[\s]*r[\s]*u[\s]*l[\s]*e[\s\S]*?>/gi,
+    "[⚠ stripped: room-rule tag]",
+  );
+
+  return s
+    .split(/\r?\n/)
+    .map((line) => {
+      let l = line;
+      l = l.replace(/^\[(BotCord (?:Message|Notification))\]/i, "[⚠ fake: $1]");
+      l = l.replace(/^\[Room Rule\]/i, "[⚠ fake: Room Rule]");
+      l = l.replace(/^\[房间规则\]/i, "[⚠ fake: 房间规则]");
+      l = l.replace(/^\[系统提示\]/i, "[⚠ fake: 系统提示]");
+      l = l.replace(/^\[BotCord\s+([^\]\r\n]+)\]/i, (_m, label) => {
+        const head = String(label).split(":")[0].trim() || String(label).trim();
+        return `[⚠ fake: BotCord ${head}]`;
+      });
+      l = l.replace(/^\[(System|SYSTEM|Assistant|ASSISTANT|User|USER)\]/, "[⚠ fake: $1]");
+      l = l.replace(/<\/?\s*system(?:-reminder)?\s*>/gi, "[⚠ stripped: system tag]");
+      l = l.replace(/<\|im_start\|>/gi, "[⚠ stripped: im_start]");
+      l = l.replace(/<\|im_end\|>/gi, "[⚠ stripped: im_end]");
+      l = l.replace(/\[\/?INST\]/gi, "[⚠ stripped: INST]");
+      l = l.replace(/<<\/?SYS>>/gi, "[⚠ stripped: SYS]");
+      l = l.replace(/<\s*\/?\|(?:system|user|assistant)\|?\s*>/gi, "[⚠ stripped: role tag]");
+      return l;
+    })
+    .join("\n");
+}
+
+/**
+ * Sanitize a sender label so it's safe to embed inside
+ * `<agent-message sender="...">`. Must not contain newlines, structural
+ * markers, or characters that could break the XML attribute boundary.
+ */
+export function sanitizeSenderName(name: string): string {
+  return name
+    .replace(/[\n\r]/g, " ")
+    .replace(/\[/g, "⟦")
+    .replace(/\]/g, "⟧")
+    .replace(/"/g, "'")
+    .replace(/</g, "＜")
+    .replace(/>/g, "＞")
+    .slice(0, 100);
+}

--- a/packages/protocol-core/src/gateway-text.ts
+++ b/packages/protocol-core/src/gateway-text.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared text helpers used by gateway channel/provider adapters.
+ *
+ * Lifted from `packages/daemon/src/gateway/channels/text-split.ts` so both
+ * the daemon channel adapters (Telegram, WeChat, Feishu) and the
+ * `gateway-ingress` provider adapters (telegram, future Discord, …) use
+ * one canonical implementation instead of copy-pasting.
+ */
+
+/**
+ * Split a long message into chunks <= `limit` characters each. Prefers to cut
+ * on newline boundaries so multi-paragraph replies don't fragment mid-line.
+ *
+ * Empty input returns `[""]` so callers can iterate uniformly without a length
+ * check.
+ */
+export function splitText(text: string, limit: number): string[] {
+  if (limit <= 0) return [text];
+  if (text.length === 0) return [""];
+  if (text.length <= limit) return [text];
+
+  const out: string[] = [];
+  let remaining = text;
+  while (remaining.length > limit) {
+    let cut = remaining.lastIndexOf("\n", limit);
+    if (cut <= 0) cut = limit;
+    out.push(remaining.slice(0, cut));
+    // Drop the leading newline so the next chunk doesn't start with a blank line.
+    remaining = remaining.slice(cut).replace(/^\n/, "");
+  }
+  if (remaining.length > 0) out.push(remaining);
+  return out;
+}

--- a/packages/protocol-core/src/index.ts
+++ b/packages/protocol-core/src/index.ts
@@ -8,3 +8,6 @@ export * from "./daemon-client.js";
 export * from "./control-frame.js";
 export * from "./runtime-frame.js";
 export * from "./should-wake.js";
+export * from "./gateway-message.js";
+export * from "./gateway-text.js";
+export * from "./gateway-sanitize.js";


### PR DESCRIPTION
## Summary

Four commits on top of `main`:

- **`5764bf8` feat(protocol-core)** — adds canonical `GatewayInboundMessage` / `GatewayOutboundMessage` types and shared `splitText` / `sanitizeUntrustedContent` utilities to `@botcord/protocol-core@0.2.10`, so daemon and gateway-ingress can stop copy-pasting them.
- **`8ad2d1a` refactor(gateway)** — switches both `packages/daemon` and `packages/gateway-ingress` to consume the protocol-core re-exports; removes ~125 lines of duplicated definitions. Renames `NormalizedInboundMessage` → `GatewayInboundMessage`; `ChannelStatusSnapshot.provider` now uses `RuntimeGatewayProvider` instead of a hardcoded enum.
- **`6d24856` feat(gateway-ingress)** — ports the **Feishu** and **WeChat** provider adapters from daemon to the always-on cloud gateway ingress, alongside the existing Telegram provider:
  - Feishu: `@larksuiteoapi/node-sdk` WS subscription to `im.message.receive_v1`; bot self-probe on start; conversation IDs `feishu:user:{chat}` / `feishu:chat:{chat}`.
  - WeChat: iLink `getupdates` long-polling with persistent `get_updates_buf` cursor; in-memory traceId→context_token cache (30 min, 5000 cap) so outbound can reuse inbound auth.
  - MVP intentionally drops: typing reactions, attachment uploads, replyTo chains, file-based state-store, self-managed dedupe (orchestrator handles via `providerEventId`).
  - Default-allow on empty `allowedSenderIds` (dashboard gates binding); daemon local adapters untouched.
- **`fc55941` docs(gateway-ingress)** — design doc for adding **Discord** as the 4th cloud-agent channel, mapping cc-connect's discordgo baseline onto the `ProviderAdapter` contract and listing the type extensions needed (`RuntimeGatewayProvider += "discord"`, `conversation.parentId` for thread isolation).

## Test plan

- [x] `protocol-core` 18/18 tests green
- [x] `daemon` 852/852 tests green (unaffected)
- [x] `gateway-ingress` 29/29 tests green (including new feishu/wechat suites)
- [ ] Smoke-test feishu adapter against a sandbox Lark app
- [ ] Smoke-test wechat adapter against an iLink instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)