### PR TITLE
feat: make bot runtime settings editable

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -96,6 +96,9 @@ class PatchAgentBody(BaseModel):
     display_name: str | None = Field(default=None, min_length=1, max_length=128)
     bio: str | None = Field(default=None, max_length=4000)
     avatar_url: str | None = None
+    runtime_model: str | None = Field(default=None, max_length=128)
+    reasoning_effort: str | None = Field(default=None, max_length=64)
+    thinking: bool | None = None
 
 
 class ClaimResolveBody(BaseModel):
@@ -144,6 +147,12 @@ def _agent_meta(agent: Agent) -> dict:
         "avatar_url": agent.avatar_url,
         "is_default": agent.is_default,
         "claimed_at": agent.claimed_at.isoformat() if agent.claimed_at else None,
+        "daemon_instance_id": agent.daemon_instance_id,
+        "hosting_kind": agent.hosting_kind,
+        "runtime": agent.runtime,
+        "runtime_model": agent.runtime_model,
+        "reasoning_effort": agent.reasoning_effort,
+        "thinking": agent.thinking,
     }
 
 
@@ -958,6 +967,9 @@ async def get_me(
                 "daemon_instance_id": a.daemon_instance_id,
                 "hosting_kind": a.hosting_kind,
                 "runtime": a.runtime,
+                "runtime_model": a.runtime_model,
+                "reasoning_effort": a.reasoning_effort,
+                "thinking": a.thinking,
             }
             for a in agents
         ],
@@ -995,6 +1007,9 @@ async def get_my_agents(
                 "daemon_instance_id": a.daemon_instance_id,
                 "hosting_kind": a.hosting_kind,
                 "runtime": a.runtime,
+                "runtime_model": a.runtime_model,
+                "reasoning_effort": a.reasoning_effort,
+                "thinking": a.thinking,
             }
             for a in agents
         ],
@@ -1076,7 +1091,7 @@ async def patch_agent(
     ctx: RequestContext = Depends(require_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Update agent attributes (is_default, display_name, bio, avatar_url)."""
+    """Update agent attributes and daemon runtime selector options."""
     result = await db.execute(
         select(Agent).where(
             Agent.agent_id == agent_id,
@@ -1087,6 +1102,11 @@ async def patch_agent(
     agent = result.scalar_one_or_none()
     if agent is None:
         raise HTTPException(status_code=404, detail="Agent not found")
+
+    body_fields_raw = getattr(body, "model_fields_set", None)
+    if body_fields_raw is None:
+        body_fields_raw = getattr(body, "__fields_set__", set())
+    body_fields = set(body_fields_raw)
 
     if body.is_default is True:
         # Unset default on all other agents for this user
@@ -1110,9 +1130,9 @@ async def patch_agent(
             agent.display_name = name
             identity_changed = True
 
-    if body.bio is not None:
+    if "bio" in body_fields:
         # Normalise empty string to NULL so it reads as "no bio" downstream.
-        bio = body.bio.strip() or None
+        bio = (body.bio.strip() or None) if body.bio is not None else None
         if agent.bio != bio:
             agent.bio = bio
             identity_changed = True
@@ -1125,18 +1145,68 @@ async def patch_agent(
         if agent.avatar_url != avatar_url:
             agent.avatar_url = avatar_url
 
+    runtime_option_fields = {"runtime_model", "reasoning_effort", "thinking"}
+    runtime_options_requested = bool(body_fields & runtime_option_fields)
+    if runtime_options_requested:
+        if not agent.runtime:
+            raise HTTPException(status_code=409, detail="runtime_unavailable")
+        if not agent.daemon_instance_id:
+            raise HTTPException(status_code=409, detail="daemon_instance_not_found")
+
+        daemon_result = await db.execute(
+            select(DaemonInstance).where(DaemonInstance.id == agent.daemon_instance_id)
+        )
+        instance = daemon_result.scalar_one_or_none()
+        if instance is None or str(instance.user_id) != str(ctx.user_id):
+            raise HTTPException(status_code=409, detail="daemon_instance_not_found")
+
+        next_runtime_model = agent.runtime_model
+        next_reasoning_effort = agent.reasoning_effort
+        next_thinking = agent.thinking
+        if "runtime_model" in body_fields:
+            next_runtime_model = _clean_runtime_option(body.runtime_model)
+        if "reasoning_effort" in body_fields:
+            next_reasoning_effort = _clean_runtime_option(body.reasoning_effort)
+        if "thinking" in body_fields:
+            next_thinking = body.thinking
+
+        if not _daemon_lists_runtime(
+            instance,
+            agent.runtime,
+            next_runtime_model,
+            next_reasoning_effort,
+            next_thinking,
+        ):
+            raise HTTPException(status_code=409, detail="runtime_unavailable")
+
+        if agent.runtime_model != next_runtime_model:
+            agent.runtime_model = next_runtime_model
+        if agent.reasoning_effort != next_reasoning_effort:
+            agent.reasoning_effort = next_reasoning_effort
+        if agent.thinking != next_thinking:
+            agent.thinking = next_thinking
+
     await db.commit()
     await db.refresh(agent)
 
     # Best-effort live push to the daemon — fire-and-forget so a slow or
     # half-open daemon WS can never inflate this PATCH's latency. Offline
     # daemons reconcile via the `hello.agents` snapshot on next reconnect.
-    if identity_changed and agent.daemon_instance_id and is_daemon_online(agent.daemon_instance_id):
+    should_push_update = identity_changed or runtime_options_requested
+    if should_push_update and agent.daemon_instance_id and is_daemon_online(agent.daemon_instance_id):
         params: dict[str, object | None] = {"agentId": agent.agent_id}
         if body.display_name is not None:
             params["displayName"] = agent.display_name
-        if body.bio is not None:
+        if "bio" in body_fields:
             params["bio"] = agent.bio
+        if runtime_options_requested:
+            params["runtime"] = agent.runtime
+            if "runtime_model" in body_fields:
+                params["runtimeModel"] = agent.runtime_model
+            if "reasoning_effort" in body_fields:
+                params["reasoningEffort"] = agent.reasoning_effort
+            if "thinking" in body_fields:
+                params["thinking"] = agent.thinking
         task = asyncio.create_task(
             _push_update_agent_frame(agent.daemon_instance_id, agent.agent_id, params)
         )
@@ -1581,8 +1651,18 @@ class ProvisionAgentResponse(BaseModel):
     display_name: str
     avatar_url: str | None = None
     runtime: str
+    runtime_model: str | None = None
+    reasoning_effort: str | None = None
+    thinking: bool | None = None
     daemon_instance_id: str
     is_default: bool
+
+
+def _clean_runtime_option(value: str | None) -> str | None:
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None
 
 
 def _daemon_lists_runtime(
@@ -1798,6 +1878,8 @@ async def provision_agent(
     runtime = (body.runtime or "").strip()
     if not runtime:
         raise HTTPException(status_code=400, detail="runtime is required")
+    runtime_model = _clean_runtime_option(body.runtime_model)
+    reasoning_effort = _clean_runtime_option(body.reasoning_effort)
 
     result = await db.execute(
         select(DaemonInstance).where(DaemonInstance.id == body.daemon_instance_id)
@@ -1812,8 +1894,8 @@ async def provision_agent(
     if not _daemon_lists_runtime(
         instance,
         runtime,
-        body.runtime_model,
-        body.reasoning_effort,
+        runtime_model,
+        reasoning_effort,
         body.thinking,
         body.openclaw_gateway,
         body.hermes_profile,
@@ -1865,6 +1947,9 @@ async def provision_agent(
         is_default=is_first,
         claimed_at=now,
         runtime=runtime,
+        runtime_model=runtime_model,
+        reasoning_effort=reasoning_effort,
+        thinking=body.thinking,
         daemon_instance_id=body.daemon_instance_id,
         hosting_kind="daemon",
     )
@@ -1906,12 +1991,12 @@ async def provision_agent(
             "runtime": runtime,
         },
     }
-    if body.runtime_model:
-        frame_params["runtimeModel"] = body.runtime_model
-        frame_params["credentials"]["runtimeModel"] = body.runtime_model
-    if body.reasoning_effort:
-        frame_params["reasoningEffort"] = body.reasoning_effort
-        frame_params["credentials"]["reasoningEffort"] = body.reasoning_effort
+    if runtime_model:
+        frame_params["runtimeModel"] = runtime_model
+        frame_params["credentials"]["runtimeModel"] = runtime_model
+    if reasoning_effort:
+        frame_params["reasoningEffort"] = reasoning_effort
+        frame_params["credentials"]["reasoningEffort"] = reasoning_effort
     if body.thinking is not None:
         frame_params["thinking"] = body.thinking
         frame_params["credentials"]["thinking"] = body.thinking
@@ -1994,6 +2079,9 @@ async def provision_agent(
         display_name=agent.display_name,
         avatar_url=agent.avatar_url,
         runtime=runtime,
+        runtime_model=agent.runtime_model,
+        reasoning_effort=agent.reasoning_effort,
+        thinking=agent.thinking,
         daemon_instance_id=body.daemon_instance_id,
         is_default=agent.is_default,
     )

--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -136,6 +136,11 @@ class Agent(Base):
     # Runtime selected at creation (claude-code / codex / gemini / ...).
     # Null for agents created via bind_code.
     runtime: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    # Optional runtime selector fields cached by Hub and mirrored into the
+    # daemon's credentials file / managed route.
+    runtime_model: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    reasoning_effort: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    thinking: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
 
     signing_keys: Mapped[list["SigningKey"]] = relationship(back_populates="agent")
     challenges: Mapped[list["Challenge"]] = relationship(back_populates="agent")

--- a/backend/hub/routers/daemon_control.py
+++ b/backend/hub/routers/daemon_control.py
@@ -1587,17 +1587,25 @@ async def _load_agent_identity_snapshot(
             exc,
         )
         return []
-    # Only fields the daemon's `applyAgentIdentity` actually consumes ship
-    # on the wire — runtime is already cached locally in the credentials
-    # file and re-sending it here would just bloat the hello payload.
-    return [
-        {
+    # Ship the Hub source-of-truth for both identity.md fields and runtime
+    # selector fields. Offline daemons reconcile these into credentials and
+    # managed routes on the next hello.
+    agents: list[dict[str, Any]] = []
+    for row in rows:
+        entry: dict[str, Any] = {
             "agentId": row.agent_id,
             "displayName": row.display_name,
             "bio": row.bio,
+            "runtime": row.runtime,
         }
-        for row in rows
-    ]
+        if row.runtime_model is not None:
+            entry["runtimeModel"] = row.runtime_model
+        if row.reasoning_effort is not None:
+            entry["reasoningEffort"] = row.reasoning_effort
+        if row.thinking is not None:
+            entry["thinking"] = row.thinking
+        agents.append(entry)
+    return agents
 
 
 async def _handle_daemon_event(conn: _DaemonConn, msg: dict[str, Any]) -> None:

--- a/backend/migrations/015_agent_runtime_options.sql
+++ b/backend/migrations/015_agent_runtime_options.sql
@@ -1,0 +1,12 @@
+-- Persist per-agent runtime selector options chosen from daemon-discovered
+-- model catalogs. These mirror into local daemon credentials and managed
+-- routes, while Hub remains the source of truth for dashboard edits.
+
+ALTER TABLE agents
+    ADD COLUMN IF NOT EXISTS runtime_model VARCHAR(128);
+
+ALTER TABLE agents
+    ADD COLUMN IF NOT EXISTS reasoning_effort VARCHAR(64);
+
+ALTER TABLE agents
+    ADD COLUMN IF NOT EXISTS thinking BOOLEAN;

--- a/backend/tests/test_app/test_app_user_agents.py
+++ b/backend/tests/test_app/test_app_user_agents.py
@@ -30,6 +30,7 @@ from hub.models import (
     AgentSubscription,
     Base,
     DaemonAgentCleanup,
+    DaemonInstance,
     KeyState,
     MessagePolicy,
     Role,
@@ -813,6 +814,127 @@ async def test_patch_agent_pushes_update_when_daemon_online(
     assert captured["params"]["agentId"] == "ag_agent001"
     assert captured["params"]["displayName"] == "Renamed"
     assert captured["params"]["bio"] == "Fresh bio"
+
+
+@pytest.mark.asyncio
+async def test_patch_agent_updates_runtime_options_when_daemon_online(
+    client: AsyncClient, db_session: AsyncSession, seed_user: dict, monkeypatch
+):
+    seed_user["agent1"].daemon_instance_id = "di_runtime"
+    seed_user["agent1"].runtime = "codex"
+    db_session.add(
+        DaemonInstance(
+            id="di_runtime",
+            user_id=seed_user["user_id"],
+            label="runtime machine",
+            refresh_token_hash="ab" * 32,
+            runtimes_json=[
+                {
+                    "id": "codex",
+                    "available": True,
+                    "models": [
+                        {
+                            "id": "gpt-5.2",
+                            "parameters": [
+                                {
+                                    "id": "reasoning_effort",
+                                    "type": "string",
+                                    "values": ["minimal", "high"],
+                                },
+                                {"id": "thinking", "type": "boolean"},
+                            ],
+                        }
+                    ],
+                }
+            ],
+        )
+    )
+    await db_session.commit()
+
+    import app.routers.users as users_mod
+    import asyncio as _asyncio
+
+    monkeypatch.setattr(users_mod, "is_daemon_online", lambda _id: True)
+    captured: dict = {}
+    sent = _asyncio.Event()
+
+    async def fake_send(daemon_id, type_, params, timeout_ms=None):
+        captured["daemon_id"] = daemon_id
+        captured["type"] = type_
+        captured["params"] = params
+        sent.set()
+        return {"id": "x", "ok": True}
+
+    monkeypatch.setattr(users_mod, "send_control_frame", fake_send)
+
+    resp = await client.patch(
+        "/api/users/me/agents/ag_agent001",
+        json={
+            "runtime_model": "gpt-5.2",
+            "reasoning_effort": "high",
+            "thinking": True,
+        },
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["runtime_model"] == "gpt-5.2"
+    assert body["reasoning_effort"] == "high"
+    assert body["thinking"] is True
+
+    await _asyncio.wait_for(sent.wait(), timeout=2.0)
+    assert captured["daemon_id"] == "di_runtime"
+    assert captured["type"] == "update_agent"
+    assert captured["params"] == {
+        "agentId": "ag_agent001",
+        "runtime": "codex",
+        "runtimeModel": "gpt-5.2",
+        "reasoningEffort": "high",
+        "thinking": True,
+    }
+
+    await db_session.refresh(seed_user["agent1"])
+    assert seed_user["agent1"].runtime_model == "gpt-5.2"
+    assert seed_user["agent1"].reasoning_effort == "high"
+    assert seed_user["agent1"].thinking is True
+
+
+@pytest.mark.asyncio
+async def test_patch_agent_rejects_unsupported_runtime_options(
+    client: AsyncClient, db_session: AsyncSession, seed_user: dict
+):
+    seed_user["agent1"].daemon_instance_id = "di_runtime_reject"
+    seed_user["agent1"].runtime = "codex"
+    db_session.add(
+        DaemonInstance(
+            id="di_runtime_reject",
+            user_id=seed_user["user_id"],
+            label="runtime machine",
+            refresh_token_hash="cd" * 32,
+            runtimes_json=[
+                {
+                    "id": "codex",
+                    "available": True,
+                    "parameters": [
+                        {
+                            "id": "reasoning_effort",
+                            "type": "string",
+                            "values": ["minimal", "low"],
+                        }
+                    ],
+                }
+            ],
+        )
+    )
+    await db_session.commit()
+
+    resp = await client.patch(
+        "/api/users/me/agents/ag_agent001",
+        json={"reasoning_effort": "high"},
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "runtime_unavailable"
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/dashboard/AgentSettingsDrawer.tsx
+++ b/frontend/src/components/dashboard/AgentSettingsDrawer.tsx
@@ -6,6 +6,7 @@ import { apiFetch, userApi } from "@/lib/api";
 import { useLanguage } from "@/lib/i18n";
 import { botDetailDrawer } from "@/lib/i18n/translations/dashboard";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
+import { useDaemonStore } from "@/store/useDaemonStore";
 import {
   usePolicyStore,
   type AgentPolicy,
@@ -18,6 +19,7 @@ import UnbindAgentDialog from "./UnbindAgentDialog";
 import AgentChannelsTab from "./AgentChannelsTab";
 import AgentSchedulesTab from "./AgentSchedulesTab";
 import { AGENT_AVATAR_URLS } from "@/lib/agent-avatars";
+import BotRuntimeCapabilitiesPanel from "./BotRuntimeCapabilitiesPanel";
 
 interface AgentSettingsDrawerProps {
   agentId: string;
@@ -25,6 +27,11 @@ interface AgentSettingsDrawerProps {
   bio?: string | null;
   avatarUrl?: string | null;
   hostingKind?: string | null;
+  daemonInstanceId?: string | null;
+  runtime?: string | null;
+  runtimeModel?: string | null;
+  reasoningEffort?: string | null;
+  thinking?: boolean | null;
   onClose: () => void;
   onSaved?: () => void;
 }
@@ -267,6 +274,11 @@ export default function AgentSettingsDrawer({
   bio,
   avatarUrl,
   hostingKind,
+  daemonInstanceId,
+  runtime,
+  runtimeModel,
+  reasoningEffort,
+  thinking,
   onClose,
   onSaved,
 }: AgentSettingsDrawerProps) {
@@ -299,6 +311,10 @@ export default function AgentSettingsDrawer({
       : "DMs always wake the Bot. Room messages use room-level overrides first, then inherit this default policy.",
   };
   const refreshUserProfile = useDashboardSessionStore((s) => s.refreshUserProfile);
+  const daemons = useDaemonStore((s) => s.daemons);
+  const daemon = daemonInstanceId
+    ? daemons.find((entry) => entry.id === daemonInstanceId) ?? null
+    : null;
 
   const [tab, setTab] = useState<Tab>("profile");
   const [showUnbind, setShowUnbind] = useState(false);
@@ -526,6 +542,16 @@ export default function AgentSettingsDrawer({
                   className="w-full resize-none rounded-lg border border-glass-border bg-glass-bg px-3 py-2 text-sm text-text-primary outline-none transition-colors focus:border-neon-cyan/50 disabled:opacity-60"
                 />
               </div>
+
+              <BotRuntimeCapabilitiesPanel
+                agentId={agentId}
+                daemon={daemon}
+                runtimeId={runtime}
+                runtimeModel={runtimeModel}
+                reasoningEffort={reasoningEffort}
+                thinking={thinking}
+                onSaved={refreshUserProfile}
+              />
 
               {profileError && (
                 <p className="rounded-lg border border-red-400/20 bg-red-400/10 p-2 text-xs text-red-400">

--- a/frontend/src/components/dashboard/BotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/BotDetailDrawer.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/store/usePolicyStore";
 import AgentChannelsTab from "./AgentChannelsTab";
 import AgentSchedulesTab from "./AgentSchedulesTab";
+import BotRuntimeCapabilitiesPanel from "./BotRuntimeCapabilitiesPanel";
 import BotAvatar from "./BotAvatar";
 import { CompositeAvatar } from "./CompositeAvatar";
 import BotWalletTab from "./BotWalletTab";
@@ -117,6 +118,7 @@ export default function BotDetailDrawer() {
     })),
   );
   const ownedAgents = useDashboardSessionStore((s) => s.ownedAgents);
+  const refreshUserProfile = useDashboardSessionStore((s) => s.refreshUserProfile);
   const daemons = useDaemonStore((s) => s.daemons);
   const { loadOwnedAgentRooms, ownedAgentRooms, upsertOptimisticOwnerChatRoom } = useDashboardChatStore(
     useShallow((s) => ({
@@ -306,6 +308,12 @@ export default function BotDetailDrawer() {
             <SettingsTab
               agentId={bot.agent_id}
               hostingKind={bot.hosting_kind ?? null}
+              daemon={device}
+              runtimeId={getBotRuntimeId(bot, device)}
+              runtimeModel={bot.runtime_model ?? null}
+              reasoningEffort={bot.reasoning_effort ?? null}
+              thinking={bot.thinking ?? null}
+              onRuntimeSaved={refreshUserProfile}
               t={t}
             />
           )}
@@ -712,14 +720,36 @@ function ProfileEditor({
 function SettingsTab({
   agentId,
   hostingKind,
+  daemon,
+  runtimeId,
+  runtimeModel,
+  reasoningEffort,
+  thinking,
+  onRuntimeSaved,
   t,
 }: {
   agentId: string;
   hostingKind?: string | null;
+  daemon: DaemonInstance | null;
+  runtimeId: string | null;
+  runtimeModel?: string | null;
+  reasoningEffort?: string | null;
+  thinking?: boolean | null;
+  onRuntimeSaved: () => Promise<void>;
   t: BotDetailDrawerCopy;
 }) {
   return (
     <div className="space-y-6">
+      <BotRuntimeCapabilitiesPanel
+        agentId={agentId}
+        daemon={daemon}
+        runtimeId={runtimeId}
+        runtimeModel={runtimeModel}
+        reasoningEffort={reasoningEffort}
+        thinking={thinking}
+        onSaved={onRuntimeSaved}
+      />
+
       <section className="space-y-3">
         <h3 className="text-[11px] font-semibold uppercase tracking-wider text-text-secondary/70">
           {t.settings.conversation}

--- a/frontend/src/components/dashboard/BotRuntimeCapabilitiesPanel.tsx
+++ b/frontend/src/components/dashboard/BotRuntimeCapabilitiesPanel.tsx
@@ -1,0 +1,442 @@
+"use client";
+
+import { Bot, Brain, Check, Cpu, Loader2, Save, Sparkles } from "lucide-react";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { userApi } from "@/lib/api";
+import { useLanguage } from "@/lib/i18n";
+import type {
+  DaemonInstance,
+  DaemonRuntime,
+  DaemonRuntimeModel,
+  DaemonRuntimeParameter,
+  DaemonRuntimeParameterValue,
+} from "@/store/useDaemonStore";
+import DashboardSelect from "./DashboardSelect";
+
+interface BotRuntimeCapabilitiesPanelProps {
+  agentId: string;
+  daemon: DaemonInstance | null;
+  runtimeId?: string | null;
+  runtimeModel?: string | null;
+  reasoningEffort?: string | null;
+  thinking?: boolean | null;
+  className?: string;
+  onSaved?: () => Promise<void> | void;
+}
+
+const REASONING_PARAM_IDS = new Set(["reasoning_effort", "effort"]);
+const THINKING_PARAM_IDS = new Set(["thinking"]);
+
+function parameterValueKey(value: DaemonRuntimeParameterValue): string {
+  return typeof value === "boolean" ? (value ? "true" : "false") : String(value);
+}
+
+function modelLabel(model: DaemonRuntimeModel): string {
+  return model.displayName && model.displayName !== model.id
+    ? `${model.displayName} (${model.id})`
+    : model.id;
+}
+
+function runtimeMatches(candidateId: string, runtimeId: string): boolean {
+  return (
+    candidateId === runtimeId ||
+    (candidateId === "qclaw" && runtimeId === "openclaw-acp") ||
+    (candidateId === "openclaw-acp" && runtimeId === "qclaw")
+  );
+}
+
+function findRuntimeForAgent(
+  agentId: string,
+  daemon: DaemonInstance | null,
+  runtimeId?: string | null,
+): DaemonRuntime | null {
+  const runtimes = daemon?.runtimes ?? [];
+  if (runtimeId) {
+    const direct = runtimes.find((runtime) => runtimeMatches(runtime.id, runtimeId));
+    if (direct) return direct;
+  }
+  return (
+    runtimes.find((runtime) =>
+      runtime.profiles?.some((profile) => profile.occupiedBy === agentId) ||
+      runtime.endpoints?.some((endpoint) =>
+        endpoint.agents?.some((profile) => profile.botcordBinding?.agentId === agentId),
+      ),
+    ) ?? null
+  );
+}
+
+function findRuntimeParameter(
+  runtime: DaemonRuntime | null,
+  model: DaemonRuntimeModel | null,
+  ids: Set<string>,
+): DaemonRuntimeParameter | null {
+  return (
+    model?.parameters?.find((param) => ids.has(param.id)) ??
+    runtime?.parameters?.find((param) => ids.has(param.id)) ??
+    null
+  );
+}
+
+function defaultModelId(runtime: DaemonRuntime | null): string | null {
+  const models = runtime?.models ?? [];
+  return models.find((model) => model.isDefault)?.id ?? models[0]?.id ?? null;
+}
+
+function resolveModelId(runtime: DaemonRuntime | null, value?: string | null): string | null {
+  const models = runtime?.models ?? [];
+  if (models.length === 0) return null;
+  if (value && models.some((model) => model.id === value)) return value;
+  return defaultModelId(runtime);
+}
+
+function resolveReasoningValue(
+  param: DaemonRuntimeParameter | null,
+  value?: string | null,
+): string | null {
+  if (!param) return null;
+  const values = param.values?.map(parameterValueKey) ?? [];
+  if (value && (values.length === 0 || values.includes(value))) return value;
+  const defaultValue =
+    param.defaultValue === undefined ? null : parameterValueKey(param.defaultValue);
+  if (values.length > 0) {
+    return defaultValue && values.includes(defaultValue) ? defaultValue : values[0] ?? null;
+  }
+  return defaultValue;
+}
+
+function resolveThinkingValue(
+  param: DaemonRuntimeParameter | null,
+  value?: boolean | null,
+): boolean | null {
+  if (param?.type !== "boolean") return null;
+  if (typeof value === "boolean") return value;
+  return typeof param.defaultValue === "boolean" ? param.defaultValue : true;
+}
+
+function FieldRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <div>
+      <div className="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-text-secondary/70">
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function EmptyText({ children }: { children: ReactNode }) {
+  return <p className="text-xs leading-5 text-text-secondary/60">{children}</p>;
+}
+
+function Chip({
+  children,
+  title,
+  tone = "neutral",
+}: {
+  children: ReactNode;
+  title?: string;
+  tone?: "neutral" | "cyan";
+}) {
+  return (
+    <span
+      title={title}
+      className={`inline-flex max-w-full items-center gap-1 rounded-lg border px-2 py-1 text-[11px] leading-4 ${
+        tone === "cyan"
+          ? "border-neon-cyan/35 bg-neon-cyan/10 text-neon-cyan"
+          : "border-glass-border bg-deep-black/40 text-text-primary"
+      }`}
+    >
+      {children}
+    </span>
+  );
+}
+
+export default function BotRuntimeCapabilitiesPanel({
+  agentId,
+  daemon,
+  runtimeId,
+  runtimeModel,
+  reasoningEffort,
+  thinking,
+  className,
+  onSaved,
+}: BotRuntimeCapabilitiesPanelProps) {
+  const locale = useLanguage();
+  const labels = locale === "zh"
+    ? {
+        title: "运行配置",
+        subtitle: "来自 daemon 最近一次嗅探",
+        model: "模型",
+        reasoning: "推理强度",
+        thinking: "Thinking",
+        unknownRuntime: "未知运行环境",
+        noDevice: "未找到此 Bot 绑定设备的 runtime 数据。",
+        noSnapshot: "daemon 尚未上报 runtime snapshot。",
+        unavailable: "此 runtime 当前不可用。",
+        noEditable: "此 runtime 未上报可配置的模型或推理参数。",
+        modelPlaceholder: "选择模型",
+        reasoningPlaceholder: "选择推理强度",
+        default: "默认",
+        save: "保存运行配置",
+        saving: "保存中",
+        saved: "已保存",
+        saveFailed: "保存运行配置失败",
+      }
+    : {
+        title: "Runtime settings",
+        subtitle: "From the daemon's latest probe",
+        model: "Model",
+        reasoning: "Reasoning effort",
+        thinking: "Thinking",
+        unknownRuntime: "Unknown runtime",
+        noDevice: "No runtime data found for this Bot's device.",
+        noSnapshot: "The daemon has not reported a runtime snapshot yet.",
+        unavailable: "This runtime is currently unavailable.",
+        noEditable: "This runtime did not report configurable model or reasoning parameters.",
+        modelPlaceholder: "Select model",
+        reasoningPlaceholder: "Select reasoning effort",
+        default: "default",
+        save: "Save runtime settings",
+        saving: "Saving",
+        saved: "Saved",
+        saveFailed: "Failed to save runtime settings",
+      };
+
+  const runtime = findRuntimeForAgent(agentId, daemon, runtimeId);
+  const displayRuntimeId = runtime?.id ?? runtimeId ?? null;
+  const hasSnapshot = daemon?.runtimes !== null && daemon?.runtimes !== undefined;
+  const canShowCapabilities = !!runtime && runtime.available !== false;
+  const models = runtime?.models ?? [];
+
+  const initialModelId = useMemo(
+    () => resolveModelId(runtime, runtimeModel),
+    [runtime, runtimeModel],
+  );
+  const [selectedModelId, setSelectedModelId] = useState<string | null>(initialModelId);
+
+  useEffect(() => {
+    setSelectedModelId(initialModelId);
+  }, [initialModelId]);
+
+  const selectedModel = useMemo(
+    () => models.find((model) => model.id === selectedModelId) ?? null,
+    [models, selectedModelId],
+  );
+  const reasoningParam = useMemo(
+    () => findRuntimeParameter(runtime, selectedModel, REASONING_PARAM_IDS),
+    [runtime, selectedModel],
+  );
+  const thinkingParam = useMemo(
+    () => findRuntimeParameter(runtime, selectedModel, THINKING_PARAM_IDS),
+    [runtime, selectedModel],
+  );
+  const reasoningValues = reasoningParam?.values?.map(parameterValueKey) ?? [];
+  const hasReasoning =
+    !!reasoningParam &&
+    (reasoningValues.length > 0 || reasoningParam.type === "string");
+  const hasThinking = thinkingParam?.type === "boolean";
+
+  const initialReasoningValue = useMemo(
+    () => resolveReasoningValue(reasoningParam, reasoningEffort),
+    [reasoningParam, reasoningEffort],
+  );
+  const initialThinkingValue = useMemo(
+    () => resolveThinkingValue(thinkingParam, thinking),
+    [thinkingParam, thinking],
+  );
+
+  const [selectedReasoning, setSelectedReasoning] = useState<string | null>(initialReasoningValue);
+  const [selectedThinking, setSelectedThinking] = useState<boolean | null>(initialThinkingValue);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSelectedReasoning(initialReasoningValue);
+  }, [initialReasoningValue]);
+
+  useEffect(() => {
+    setSelectedThinking(initialThinkingValue);
+  }, [initialThinkingValue]);
+
+  const modelOptions = useMemo(
+    () =>
+      models.map((model) => ({
+        value: model.id,
+        label: modelLabel(model),
+        sublabel: [
+          model.provider,
+          model.isDefault ? labels.default : null,
+          model.source,
+        ].filter(Boolean).join(" · "),
+      })),
+    [models, labels.default],
+  );
+
+  const dirty =
+    canShowCapabilities &&
+    (
+      (models.length > 0 && selectedModelId !== initialModelId) ||
+      (hasReasoning && selectedReasoning !== initialReasoningValue) ||
+      (hasThinking && selectedThinking !== initialThinkingValue)
+    );
+  const hasEditableFields = models.length > 0 || hasReasoning || hasThinking;
+
+  async function handleSave() {
+    if (!dirty || saving) return;
+    setSaving(true);
+    setSaved(false);
+    setError(null);
+    try {
+      await userApi.updateAgent(agentId, {
+        ...(models.length > 0 ? { runtime_model: selectedModelId } : {}),
+        ...(hasReasoning ? { reasoning_effort: selectedReasoning } : {}),
+        ...(hasThinking ? { thinking: selectedThinking } : {}),
+      });
+      await onSaved?.();
+      setSaved(true);
+      window.setTimeout(() => setSaved(false), 1800);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : labels.saveFailed);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section className={`rounded-2xl border border-glass-border bg-glass-bg/30 p-4 ${className ?? ""}`}>
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 text-sm font-semibold text-text-primary">
+            <Cpu className="h-4 w-4 text-neon-cyan" />
+            {labels.title}
+          </div>
+          <p className="mt-0.5 text-xs text-text-secondary/60">{labels.subtitle}</p>
+        </div>
+        <Chip title={displayRuntimeId ?? labels.unknownRuntime} tone="cyan">
+          <Bot className="h-3 w-3 shrink-0" />
+          <span className="truncate font-mono">{displayRuntimeId ?? labels.unknownRuntime}</span>
+        </Chip>
+      </div>
+
+      <div className="space-y-4">
+        {!daemon ? (
+          <EmptyText>{labels.noDevice}</EmptyText>
+        ) : !hasSnapshot ? (
+          <EmptyText>{labels.noSnapshot}</EmptyText>
+        ) : !runtime ? (
+          <EmptyText>{labels.noDevice}</EmptyText>
+        ) : runtime.available === false ? (
+          <EmptyText>{runtime.error || labels.unavailable}</EmptyText>
+        ) : canShowCapabilities && !hasEditableFields ? (
+          <EmptyText>{labels.noEditable}</EmptyText>
+        ) : null}
+
+        {canShowCapabilities && hasEditableFields ? (
+          <>
+            {models.length > 0 ? (
+              <FieldRow label={labels.model}>
+                <DashboardSelect
+                  disabled={saving}
+                  value={selectedModelId}
+                  onChange={setSelectedModelId}
+                  placeholder={labels.modelPlaceholder}
+                  options={modelOptions}
+                  leadingIcon={<Bot className="h-4 w-4 text-neon-cyan" />}
+                />
+              </FieldRow>
+            ) : null}
+
+            {hasReasoning ? (
+              <FieldRow label={labels.reasoning}>
+                {reasoningValues.length > 0 ? (
+                  <DashboardSelect
+                    disabled={saving}
+                    value={selectedReasoning}
+                    onChange={setSelectedReasoning}
+                    placeholder={labels.reasoningPlaceholder}
+                    options={reasoningValues.map((value) => ({
+                      value,
+                      label: value,
+                      sublabel:
+                        reasoningParam?.defaultValue !== undefined &&
+                        parameterValueKey(reasoningParam.defaultValue) === value
+                          ? labels.default
+                          : undefined,
+                    }))}
+                    leadingIcon={<Brain className="h-4 w-4 text-neon-cyan" />}
+                  />
+                ) : (
+                  <div className="flex min-h-10 items-center gap-2 rounded-xl border border-glass-border bg-deep-black px-3">
+                    <Brain className="h-4 w-4 shrink-0 text-neon-cyan" />
+                    <input
+                      disabled={saving}
+                      type="text"
+                      value={selectedReasoning ?? ""}
+                      placeholder={labels.reasoningPlaceholder}
+                      onChange={(event) => setSelectedReasoning(event.target.value.trim() || null)}
+                      className="min-w-0 flex-1 bg-transparent text-sm text-text-primary outline-none placeholder:text-text-secondary/60 disabled:opacity-50"
+                    />
+                  </div>
+                )}
+              </FieldRow>
+            ) : null}
+
+            {hasThinking ? (
+              <FieldRow label={labels.thinking}>
+                <button
+                  type="button"
+                  disabled={saving}
+                  onClick={() => setSelectedThinking((value) => value !== true)}
+                  className="flex min-h-10 w-full items-center justify-between gap-3 rounded-xl border border-glass-border bg-deep-black px-3 text-sm text-text-primary transition-colors hover:border-neon-cyan/45 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <span className="flex items-center gap-2">
+                    <Sparkles className="h-4 w-4 text-neon-cyan" />
+                    {labels.thinking}
+                  </span>
+                  <span
+                    className={`flex h-5 w-9 items-center rounded-full border px-0.5 transition-colors ${
+                      selectedThinking === true
+                        ? "justify-end border-neon-cyan/40 bg-neon-cyan/20"
+                        : "justify-start border-glass-border bg-glass-bg"
+                    }`}
+                  >
+                    <span className="h-3.5 w-3.5 rounded-full bg-text-primary" />
+                  </span>
+                </button>
+              </FieldRow>
+            ) : null}
+
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-h-4 text-xs">
+                {error ? (
+                  <span className="text-red-300">{error}</span>
+                ) : saved ? (
+                  <span className="inline-flex items-center gap-1 text-neon-green">
+                    <Check className="h-3 w-3" />
+                    {labels.saved}
+                  </span>
+                ) : null}
+              </div>
+              <button
+                type="button"
+                disabled={!dirty || saving}
+                onClick={() => void handleSave()}
+                className="inline-flex min-h-9 items-center gap-2 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
+                {saving ? labels.saving : labels.save}
+              </button>
+            </div>
+          </>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -376,6 +376,11 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
           bio={ownedAgent.bio ?? null}
           avatarUrl={ownedAgent.avatar_url ?? null}
           hostingKind={ownedAgent.hosting_kind ?? null}
+          daemonInstanceId={ownedAgent.daemon_instance_id ?? null}
+          runtime={ownedAgent.runtime ?? null}
+          runtimeModel={ownedAgent.runtime_model ?? null}
+          reasoningEffort={ownedAgent.reasoning_effort ?? null}
+          thinking={ownedAgent.thinking ?? null}
           onClose={() => setAgentSettingsOpen(false)}
         />
       )}

--- a/frontend/src/components/dashboard/sidebar/BotsPanel.tsx
+++ b/frontend/src/components/dashboard/sidebar/BotsPanel.tsx
@@ -310,6 +310,11 @@ export default function BotsPanel({
           bio={agentSettingsBot.bio ?? null}
           avatarUrl={agentSettingsBot.avatar_url ?? null}
           hostingKind={agentSettingsBot.hosting_kind ?? null}
+          daemonInstanceId={agentSettingsBot.daemon_instance_id ?? null}
+          runtime={agentSettingsBot.runtime ?? null}
+          runtimeModel={agentSettingsBot.runtime_model ?? null}
+          reasoningEffort={agentSettingsBot.reasoning_effort ?? null}
+          thinking={agentSettingsBot.thinking ?? null}
           onClose={() => setAgentSettingsBot(null)}
           onSaved={() => setAgentSettingsBot(null)}
         />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -951,7 +951,15 @@ const userApi = {
 
   async updateAgent(
     agentId: string,
-    patch: { display_name?: string; bio?: string | null; avatar_url?: string | null; is_default?: boolean },
+    patch: {
+      display_name?: string;
+      bio?: string | null;
+      avatar_url?: string | null;
+      is_default?: boolean;
+      runtime_model?: string | null;
+      reasoning_effort?: string | null;
+      thinking?: boolean | null;
+    },
   ): Promise<{
     agent_id: string;
     display_name: string;
@@ -959,6 +967,12 @@ const userApi = {
     avatar_url: string | null;
     is_default: boolean;
     claimed_at: string | null;
+    daemon_instance_id?: string | null;
+    hosting_kind?: string | null;
+    runtime?: string | null;
+    runtime_model?: string | null;
+    reasoning_effort?: string | null;
+    thinking?: boolean | null;
   }> {
     const result = await apiPatch<{
       agent_id: string;
@@ -967,6 +981,12 @@ const userApi = {
       avatar_url: string | null;
       is_default: boolean;
       claimed_at: string | null;
+      daemon_instance_id?: string | null;
+      hosting_kind?: string | null;
+      runtime?: string | null;
+      runtime_model?: string | null;
+      reasoning_effort?: string | null;
+      thinking?: boolean | null;
     }>(`/api/users/me/agents/${agentId}`, patch);
     invalidateMeCache();
     return result;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -854,6 +854,9 @@ export interface UserAgent {
   daemon_instance_id?: string | null;
   hosting_kind?: "daemon" | "openclaw" | "cli" | "cloud" | string | null;
   runtime?: string | null;
+  runtime_model?: string | null;
+  reasoning_effort?: string | null;
+  thinking?: boolean | null;
 }
 
 // --- Activity / Observability types ---

--- a/packages/daemon/src/__tests__/provision.test.ts
+++ b/packages/daemon/src/__tests__/provision.test.ts
@@ -1736,6 +1736,71 @@ describe("update_agent handler", () => {
     });
   });
 
+  it("updates runtime selectors in credentials and managed route", async () => {
+    await withSandboxHome(async ({ tmp, fs, path: nodePath }) => {
+      mockState.cfg = {
+        defaultRoute: {
+          adapter: "codex",
+          cwd: tmp,
+          extraArgs: ["--skip-git-repo-check"],
+        },
+        routes: [],
+        streamBlocks: true,
+      };
+      const credDir = nodePath.join(tmp, ".botcord", "credentials");
+      fs.mkdirSync(credDir, { recursive: true });
+      fs.writeFileSync(
+        nodePath.join(credDir, "ag_runtime.json"),
+        JSON.stringify({
+          version: 1,
+          hubUrl: "https://hub.example",
+          agentId: "ag_runtime",
+          keyId: "k_runtime",
+          privateKey: Buffer.alloc(32, 24).toString("base64"),
+          savedAt: new Date().toISOString(),
+        }),
+      );
+
+      const gw = makeFakeGateway();
+      const provisioner = createProvisioner({
+        gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+      });
+      const ack = await provisioner({
+        id: "req_update_runtime",
+        type: CONTROL_FRAME_TYPES.UPDATE_AGENT,
+        params: {
+          agentId: "ag_runtime",
+          runtime: "codex",
+          runtimeModel: "gpt-5.2",
+          reasoningEffort: "high",
+          thinking: true,
+        },
+      });
+
+      expect(ack.ok).toBe(true);
+      expect((ack.result as { changed: boolean }).changed).toBe(true);
+
+      const saved = JSON.parse(
+        fs.readFileSync(nodePath.join(credDir, "ag_runtime.json"), "utf8"),
+      ) as Record<string, unknown>;
+      expect(saved.runtime).toBe("codex");
+      expect(saved.runtimeModel).toBe("gpt-5.2");
+      expect(saved.reasoningEffort).toBe("high");
+      expect(saved.thinking).toBe(true);
+      expect(gw.listManagedRoutes()[0]).toMatchObject({
+        match: { accountId: "ag_runtime" },
+        runtime: "codex",
+        extraArgs: [
+          "--skip-git-repo-check",
+          "--model",
+          "gpt-5.2",
+          "-c",
+          'model_reasoning_effort="high"',
+        ],
+      });
+    });
+  });
+
   it("rejects update_agent without agentId", async () => {
     const gw = makeFakeGateway();
     const provisioner = createProvisioner({

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -164,7 +164,7 @@ export function createProvisioner(opts: ProvisionerOptions): (
 
       case CONTROL_FRAME_TYPES.HELLO: {
         const params = (frame.params ?? {}) as unknown as HelloParams;
-        const result = applyHelloIdentitySnapshot(params.agents);
+        const result = applyHelloIdentitySnapshot(params.agents, { gateway });
         daemonLog.debug("hello: identity snapshot applied", {
           frameId: frame.id,
           received: params.agents?.length ?? 0,
@@ -186,12 +186,19 @@ export function createProvisioner(opts: ProvisionerOptions): (
           displayName: params.displayName,
           bio: params.bio,
         });
+        const runtimeResult = applyAgentRuntimeSnapshot(params, { gateway });
+        const combined = {
+          changed: result.changed || runtimeResult.changed,
+          identity: result,
+          runtime: runtimeResult,
+        };
         daemonLog.info("update_agent applied", {
           agentId: params.agentId,
-          changed: result.changed,
-          skipped: result.skipped ?? null,
+          changed: combined.changed,
+          identitySkipped: result.skipped ?? null,
+          runtimeSkipped: runtimeResult.skipped ?? null,
         });
-        return { ok: true, result };
+        return { ok: true, result: combined };
       }
 
       case CONTROL_FRAME_TYPES.PROVISION_AGENT: {
@@ -2410,10 +2417,100 @@ interface HelloIdentityResult {
   skipped: number;
 }
 
+interface RuntimeSnapshotResult {
+  changed: boolean;
+  skipped?: string;
+  routeUpdated?: boolean;
+}
+
+interface RuntimeSnapshotCtx {
+  gateway?: Gateway;
+}
+
+function hasOwnField(obj: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+function cleanNullableString(value: string | null | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function applyAgentRuntimeSnapshot(
+  snapshot: AgentIdentitySnapshot,
+  ctx: RuntimeSnapshotCtx = {},
+): RuntimeSnapshotResult {
+  const hasRuntimeFields = (
+    hasOwnField(snapshot, "runtime") ||
+    hasOwnField(snapshot, "runtimeModel") ||
+    hasOwnField(snapshot, "reasoningEffort") ||
+    hasOwnField(snapshot, "thinking")
+  );
+  if (!hasRuntimeFields) return { changed: false, skipped: "no_runtime_fields" };
+
+  const credentialsFile = defaultCredentialsFile(snapshot.agentId);
+  if (!existsSync(credentialsFile)) {
+    return { changed: false, skipped: "credentials_missing" };
+  }
+
+  const credentials = loadStoredCredentials(credentialsFile);
+  let changed = false;
+
+  if (hasOwnField(snapshot, "runtime")) {
+    const runtime = cleanNullableString(snapshot.runtime);
+    if (runtime !== credentials.runtime) {
+      if (runtime) credentials.runtime = runtime;
+      else delete credentials.runtime;
+      changed = true;
+    }
+  }
+
+  if (hasOwnField(snapshot, "runtimeModel")) {
+    const runtimeModel = cleanNullableString(snapshot.runtimeModel);
+    if (runtimeModel !== credentials.runtimeModel) {
+      if (runtimeModel) credentials.runtimeModel = runtimeModel;
+      else delete credentials.runtimeModel;
+      changed = true;
+    }
+  }
+
+  if (hasOwnField(snapshot, "reasoningEffort")) {
+    const reasoningEffort = cleanNullableString(snapshot.reasoningEffort);
+    if (reasoningEffort !== credentials.reasoningEffort) {
+      if (reasoningEffort) credentials.reasoningEffort = reasoningEffort;
+      else delete credentials.reasoningEffort;
+      changed = true;
+    }
+  }
+
+  if (hasOwnField(snapshot, "thinking")) {
+    if (typeof snapshot.thinking === "boolean") {
+      if (credentials.thinking !== snapshot.thinking) {
+        credentials.thinking = snapshot.thinking;
+        changed = true;
+      }
+    } else if (typeof credentials.thinking === "boolean") {
+      delete credentials.thinking;
+      changed = true;
+    }
+  }
+
+  if (!changed) return { changed: false };
+
+  writeCredentialsFile(credentialsFile, credentials);
+  if (ctx.gateway) {
+    upsertManagedRouteForCredentials(credentials, loadConfig(), ctx.gateway);
+    return { changed: true, routeUpdated: true };
+  }
+  return { changed: true };
+}
+
 /**
  * Reconcile every agent identity carried by the `hello.agents` snapshot
- * against the on-disk `identity.md`. Best-effort: a malformed entry or a
- * file-system error for one agent never aborts the rest.
+ * against the on-disk `identity.md` and credentials runtime selectors.
+ * Best-effort: a malformed entry or a file-system error for one agent never
+ * aborts the rest.
  *
  * Identity-snapshot semantics intentionally only touch the metadata
  * line + Bio body — Role/Boundaries paragraphs the user authored locally
@@ -2423,6 +2520,7 @@ interface HelloIdentityResult {
  */
 export function applyHelloIdentitySnapshot(
   snapshot: AgentIdentitySnapshot[] | undefined,
+  ctx: RuntimeSnapshotCtx = {},
 ): HelloIdentityResult {
   const out: HelloIdentityResult = { updated: 0, skipped: 0 };
   if (!Array.isArray(snapshot)) return out;
@@ -2436,7 +2534,8 @@ export function applyHelloIdentitySnapshot(
         displayName: entry.displayName,
         bio: entry.bio,
       });
-      if (result.changed) out.updated += 1;
+      const runtimeResult = applyAgentRuntimeSnapshot(entry, ctx);
+      if (result.changed || runtimeResult.changed) out.updated += 1;
       else out.skipped += 1;
     } catch (err) {
       out.skipped += 1;

--- a/packages/protocol-core/src/control-frame.ts
+++ b/packages/protocol-core/src/control-frame.ts
@@ -305,6 +305,9 @@ export interface AgentIdentitySnapshot {
   displayName?: string;
   bio?: string | null;
   runtime?: string | null;
+  runtimeModel?: string | null;
+  reasoningEffort?: string | null;
+  thinking?: boolean | null;
 }
 
 /**

--- a/packages/protocol-core/src/credentials.ts
+++ b/packages/protocol-core/src/credentials.ts
@@ -122,6 +122,17 @@ export function loadStoredCredentials(credentialsFile: string): StoredBotCordCre
 
   const onboardedAt = normalizeCredentialValue(raw, ["onboardedAt", "onboarded_at"]);
   const runtime = normalizeCredentialValue(raw, ["runtime"]);
+  const runtimeModel = normalizeCredentialValue(raw, ["runtimeModel", "runtime_model"]);
+  const reasoningEffort = normalizeCredentialValue(raw, [
+    "reasoningEffort",
+    "reasoning_effort",
+  ]);
+  const thinking =
+    typeof raw.thinking === "boolean"
+      ? raw.thinking
+      : typeof raw.thinking_enabled === "boolean"
+        ? raw.thinking_enabled
+        : undefined;
   const cwd = normalizeCredentialValue(raw, ["cwd"]);
   const openclawGateway = normalizeCredentialValue(raw, ["openclawGateway", "openclaw_gateway"]);
   const openclawAgent = normalizeCredentialValue(raw, ["openclawAgent", "openclaw_agent"]);
@@ -140,6 +151,9 @@ export function loadStoredCredentials(credentialsFile: string): StoredBotCordCre
     tokenExpiresAt,
     onboardedAt,
     runtime,
+    runtimeModel,
+    reasoningEffort,
+    thinking,
     cwd,
     openclawGateway,
     openclawAgent,


### PR DESCRIPTION
## Summary
- persist per-agent runtime model, reasoning effort, and thinking selections in Hub
- sync runtime setting edits to online daemons and reconcile offline daemons via hello snapshots
- add editable runtime settings UI in bot settings drawers

## Tests
- cd backend && uv run pytest tests/test_app/test_app_user_agents.py tests/test_app/test_agent_provision.py -q
- cd packages/daemon && npm test -- src/__tests__/provision.test.ts
- cd packages/daemon && npm run build
- cd packages/protocol-core && npm run build && npm test -- --run
- cd frontend && npm run build