### PR TITLE
test: update daemon runtime snapshot assertions

### DIFF
--- a/backend/tests/test_app/test_daemon_control.py
+++ b/backend/tests/test_app/test_daemon_control.py
@@ -1401,6 +1401,9 @@ async def test_load_agent_identity_snapshot_returns_active_bound_agents(
                 display_name="Keep One",
                 bio="Bio one",
                 runtime="claude-code",
+                runtime_model="opus",
+                reasoning_effort="high",
+                thinking=True,
                 user_id=seed_user["user_id"],
                 daemon_instance_id=instance_id,
                 message_policy=MessagePolicy.contacts_only,
@@ -1442,8 +1445,16 @@ async def test_load_agent_identity_snapshot_returns_active_bound_agents(
     assert by_id["ag_keep1"]["displayName"] == "Keep One"
     assert by_id["ag_keep1"]["bio"] == "Bio one"
     assert by_id["ag_keep2"]["bio"] is None
-    # runtime is intentionally not on the wire — it's cached locally on the daemon.
-    assert "runtime" not in by_id["ag_keep1"]
+    # Runtime selectors are mirrored so offline daemons can reconcile
+    # credentials and managed routes on next hello.
+    assert by_id["ag_keep1"]["runtime"] == "claude-code"
+    assert by_id["ag_keep1"]["runtimeModel"] == "opus"
+    assert by_id["ag_keep1"]["reasoningEffort"] == "high"
+    assert by_id["ag_keep1"]["thinking"] is True
+    assert by_id["ag_keep2"]["runtime"] == "codex"
+    assert "runtimeModel" not in by_id["ag_keep2"]
+    assert "reasoningEffort" not in by_id["ag_keep2"]
+    assert "thinking" not in by_id["ag_keep2"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- update daemon identity snapshot test to expect runtime selector fields emitted in hello snapshots
- keep coverage for omitting unset optional runtime selector fields

## Tests
- uv run pytest tests/test_app/test_daemon_control.py::test_load_agent_identity_snapshot_returns_active_bound_agents