### PR TITLE
fix: enforce attention policy after daemon restart

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -65,6 +65,7 @@ from hub.routers.hub import (
     is_agent_ws_online,
     notify_inbox,
 )
+from hub.services.cloud_agent_activity import maybe_bump_for_inbound_many
 from hub.share_payloads import SHARE_MESSAGE_PREVIEW_LIMIT, share_create_payload
 from hub.validators import normalize_file_url
 
@@ -2885,6 +2886,19 @@ async def human_room_send(
             if first_hub_msg_id is None:
                 first_hub_msg_id = existing.hub_msg_id
 
+    waking_agent_receivers: set[str] = set()
+    agent_receiver_ids = {rid for rid in receiver_ids if rid.startswith("ag_")}
+    if agent_receiver_ids:
+        waking_agent_receivers = await maybe_bump_for_inbound_many(
+            db,
+            receiver_ids=agent_receiver_ids,
+            sender_id=sender_id,
+            room_id=room_id,
+            text=text,
+            mentioned_set=mentioned_set,
+            message_type="message",
+        )
+
     await db.commit()
 
     # Fetch user display name for realtime event
@@ -2908,7 +2922,13 @@ async def human_room_send(
                 source_user_id=source_user_id_str,
                 source_user_name=user_display_name,
             )
-            await notify_inbox(receiver_id, db=db, realtime_event=rt_event)
+            await notify_inbox(
+                receiver_id,
+                db=db,
+                realtime_event=rt_event,
+                resume_cloud=room_id.startswith("rm_oc_")
+                or receiver_id in waking_agent_receivers,
+            )
         except Exception as exc:
             _logger.error(
                 "Human room fan-out notify failed receiver=%s room=%s err=%s",

--- a/backend/hub/routers/hub.py
+++ b/backend/hub/routers/hub.py
@@ -66,7 +66,7 @@ from hub.models import (
 )
 from hub.routers.daemon_control import is_daemon_online, send_control_frame
 from hub.enums import ApprovalKind, ApprovalState, ParticipantType
-from hub.policy import Principal, check_direct_admission
+from hub.policy import Principal, check_direct_admission, resolve_effective_attention
 from hub.prompt_guard import scan_content, InjectionRisk
 from hub.schemas import (
     HistoryMessage,
@@ -86,6 +86,17 @@ from hub.schemas import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/hub", tags=["hub"])
+
+
+def _wire_attention_policy(eff) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "mode": eff.mode.value if hasattr(eff.mode, "value") else str(eff.mode),
+        "keywords": list(eff.keywords or []),
+        "allowedSenderIds": list(eff.allowed_sender_ids or []),
+    }
+    if eff.muted_until is not None:
+        payload["muted_until"] = int(eff.muted_until.timestamp() * 1000)
+    return payload
 
 # ---------------------------------------------------------------------------
 # In-memory rate-limit state: agent_id → deque of timestamps
@@ -533,6 +544,24 @@ async def notify_inbox(
         await _publish_agent_realtime_event(db, realtime_event)
 
     return notified
+
+
+@router.get("/attention-policy")
+async def get_attention_policy(
+    room_id: str | None = Query(default=None),
+    db: AsyncSession = Depends(get_db),
+    current_agent: str = Depends(get_current_claimed_agent),
+):
+    """Return the effective daemon attention policy for the authenticated agent.
+
+    Local daemons use this on policy-cache misses so a daemon restart after a
+    dashboard-side policy change does not silently fall back to ``always``.
+    """
+    agent = await db.scalar(select(Agent).where(Agent.agent_id == current_agent))
+    if agent is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    eff = await resolve_effective_attention(db, agent=agent, room_id=room_id)
+    return _wire_attention_policy(eff)
 
 
 # ---------------------------------------------------------------------------
@@ -1264,8 +1293,9 @@ async def _send_room_message(
         and not (_self_delivery and rid == envelope.from_)
         and rid not in owner_chat_human_receivers
     }
+    waking_agent_receivers: set[str] = set()
     if _agent_receivers:
-        await maybe_bump_for_inbound_many(
+        waking_agent_receivers = await maybe_bump_for_inbound_many(
             db,
             receiver_ids=_agent_receivers,
             sender_id=envelope.from_,
@@ -1304,7 +1334,12 @@ async def _send_room_message(
                 # Dedicated owner-chat WS handles immediate dashboard delivery.
                 pass
             else:
-                await notify_inbox(receiver_id, db=db, realtime_event=rt_event)
+                await notify_inbox(
+                    receiver_id,
+                    db=db,
+                    realtime_event=rt_event,
+                    resume_cloud=is_owner_chat or receiver_id in waking_agent_receivers,
+                )
         except Exception as exc:
             logger.error(
                 "Room fan-out notify failed: receiver=%s room=%s msg_id=%s err=%s",

--- a/backend/hub/services/cloud_agent.py
+++ b/backend/hub/services/cloud_agent.py
@@ -1192,6 +1192,10 @@ class CloudAgentService:
                 "runtime": cai.runtime,
             },
         }
+        params["defaultAttention"] = _attention_mode_value(agent.default_attention)
+        params["attentionKeywords"] = _decode_attention_keywords(
+            agent.attention_keywords
+        )
         runtime_options = _cloud_agent_runtime_options(cai)
         runtime_model = runtime_options.get("runtime_model")
         reasoning_effort = runtime_options.get("reasoning_effort")
@@ -1552,6 +1556,24 @@ def _scrub_provisioning_metadata(cai: CloudAgentInstance) -> None:
     # when we mutate-in-place; assigning a fresh dict above already
     # triggers it, but flag_modified is the safer pattern here.
     flag_modified(cai, "metadata_json")
+
+
+def _decode_attention_keywords(raw: str | None) -> list[str]:
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [str(x) for x in parsed if isinstance(x, str)]
+
+
+def _attention_mode_value(raw: Any) -> str:
+    if raw is None:
+        return "always"
+    return raw.value if hasattr(raw, "value") else str(raw)
 
 
 def _clean_runtime_option(value: Any) -> str | None:

--- a/backend/hub/services/cloud_agent_activity.py
+++ b/backend/hub/services/cloud_agent_activity.py
@@ -153,7 +153,7 @@ async def maybe_bump_for_inbound(
     text: str | None,
     mentioned: bool,
     message_type: str | None,
-) -> None:
+) -> bool:
     """Inbound messages count as activity only when the agent's attention
     policy would actually wake the runtime (design §4.2).
 
@@ -163,13 +163,13 @@ async def maybe_bump_for_inbound(
     when the policy is unclear.
     """
     if not receiver_id:
-        return
+        return False
     try:
         agent = await db.scalar(
             select(Agent).where(Agent.agent_id == receiver_id)
         )
         if agent is None or agent.hosting_kind != "cloud":
-            return
+            return False
         if not await would_wake_runtime(
             db,
             receiver=agent,
@@ -179,14 +179,15 @@ async def maybe_bump_for_inbound(
             sender_id=sender_id,
             message_type=message_type,
         ):
-            return
-        await _stamp_active(db, receiver_id)
+            return False
+        return await _stamp_active(db, receiver_id)
     except Exception as exc:  # noqa: BLE001
         logger.warning(
             "cloud activity bump (inbound) failed: receiver=%s err=%s",
             receiver_id,
             exc,
         )
+        return False
 
 
 async def maybe_bump_for_inbound_many(
@@ -198,18 +199,19 @@ async def maybe_bump_for_inbound_many(
     text: str | None,
     mentioned_set: set[str] | None,
     message_type: str | None,
-) -> None:
+) -> set[str]:
     """Room fan-out variant: one ``would_wake_runtime`` evaluation per
     receiver. Receivers outside ``mentioned_set`` (and ``@all`` if present)
     are treated as not mentioned."""
+    waking_receivers: set[str] = set()
     if not receiver_ids:
-        return
+        return waking_receivers
     has_all_mention = bool(mentioned_set and "@all" in mentioned_set)
     for rid in receiver_ids:
         per_mentioned = has_all_mention or (
             bool(mentioned_set) and rid in mentioned_set
         )
-        await maybe_bump_for_inbound(
+        if await maybe_bump_for_inbound(
             db,
             receiver_id=rid,
             sender_id=sender_id,
@@ -217,4 +219,6 @@ async def maybe_bump_for_inbound_many(
             text=text,
             mentioned=per_mentioned,
             message_type=message_type,
-        )
+        ):
+            waking_receivers.add(rid)
+    return waking_receivers

--- a/backend/tests/test_cloud_agent_activity.py
+++ b/backend/tests/test_cloud_agent_activity.py
@@ -273,7 +273,7 @@ async def test_bump_handles_missing_agent(db_session):
 @pytest.mark.asyncio
 async def test_inbound_stamps_when_attention_wakes(db_session):
     view = await _make_cloud_agent(db_session, uuid.uuid4())
-    await maybe_bump_for_inbound(
+    woke = await maybe_bump_for_inbound(
         db_session,
         receiver_id=view.agent_id,
         sender_id="ag_other",
@@ -283,6 +283,7 @@ async def test_inbound_stamps_when_attention_wakes(db_session):
         message_type="message",
     )
     await db_session.commit()
+    assert woke is True
     assert await _read_last_active(db_session, view.agent_id) is not None
 
 
@@ -295,7 +296,7 @@ async def test_inbound_skips_when_attention_filters_out(db_session):
     agent.default_attention = AttentionMode.mention_only
     await db_session.commit()
 
-    await maybe_bump_for_inbound(
+    woke = await maybe_bump_for_inbound(
         db_session,
         receiver_id=view.agent_id,
         sender_id="ag_other",
@@ -305,6 +306,7 @@ async def test_inbound_skips_when_attention_filters_out(db_session):
         message_type="message",
     )
     await db_session.commit()
+    assert woke is False
     assert await _read_last_active(db_session, view.agent_id) is None
 
 
@@ -322,7 +324,7 @@ async def test_inbound_many_per_receiver_mention(db_session):
         ag.default_attention = AttentionMode.mention_only
     await db_session.commit()
 
-    await maybe_bump_for_inbound_many(
+    waking_receivers = await maybe_bump_for_inbound_many(
         db_session,
         receiver_ids={a.agent_id, b.agent_id},
         sender_id="ag_sender",
@@ -333,6 +335,7 @@ async def test_inbound_many_per_receiver_mention(db_session):
     )
     await db_session.commit()
 
+    assert waking_receivers == {a.agent_id}
     assert await _read_last_active(db_session, a.agent_id) is not None
     assert await _read_last_active(db_session, b.agent_id) is None
 

--- a/backend/tests/test_cloud_agent_provisioning.py
+++ b/backend/tests/test_cloud_agent_provisioning.py
@@ -16,6 +16,7 @@ import pytest_asyncio
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from hub.enums import AttentionMode
 from hub.models import (
     Agent,
     Base,
@@ -260,6 +261,13 @@ async def test_provision_pending_dispatches_provision_agent_and_marks_ready(
     view = await service.create_cloud_agent(
         db_session, user_id=user_id, body=CreateCloudAgentInput(name="A")
     )
+    agent = await db_session.scalar(
+        select(Agent).where(Agent.agent_id == view.agent_id)
+    )
+    assert agent is not None
+    agent.default_attention = AttentionMode.mention_only
+    agent.attention_keywords = '["alpha", "beta"]'
+    await db_session.commit()
 
     conn, ws = await _register_fake_conn(
         view.cloud_daemon_instance_id, "dm_unused"
@@ -282,6 +290,8 @@ async def test_provision_pending_dispatches_provision_agent_and_marks_ready(
             assert creds["runtime"] == "deepseek-tui"
             assert params["runtime"] == "deepseek-tui"
             assert params["name"] == "A"
+            assert params["defaultAttention"] == "mention_only"
+            assert params["attentionKeywords"] == ["alpha", "beta"]
 
         ack_task = asyncio.create_task(_ack_when_sent())
         await service.provision_pending_for_cloud_daemon(

--- a/backend/tests/test_dashboard_rooms_human_send.py
+++ b/backend/tests/test_dashboard_rooms_human_send.py
@@ -793,6 +793,40 @@ async def test_mentions_set_mentioned_flag_per_receiver(
 
 
 @pytest.mark.asyncio
+async def test_room_send_does_not_resume_cloud_when_attention_filters(
+    client: AsyncClient, seed: dict, monkeypatch
+):
+    import app.routers.dashboard as dashboard_mod
+
+    bump_calls: list[dict] = []
+    notify_calls: list[tuple[str, bool]] = []
+
+    async def fake_bump_many(db, **kwargs):
+        bump_calls.append(kwargs)
+        return set()
+
+    async def fake_notify_inbox(
+        agent_id, *, db=None, realtime_event=None, resume_cloud=True
+    ):
+        notify_calls.append((agent_id, resume_cloud))
+        return 0
+
+    monkeypatch.setattr(dashboard_mod, "maybe_bump_for_inbound_many", fake_bump_many)
+    monkeypatch.setattr(dashboard_mod, "notify_inbox", fake_notify_inbox)
+
+    r = await client.post(
+        "/api/dashboard/rooms/rm_humanroom/send",
+        headers=_h(seed["token1"], seed["agent1"]),
+        json={"text": "plain group chatter"},
+    )
+    assert r.status_code == 202, r.text
+
+    assert bump_calls
+    assert bump_calls[0]["mentioned_set"] == set()
+    assert dict(notify_calls)["ag_user3___"] is False
+
+
+@pytest.mark.asyncio
 async def test_mentions_filter_non_member_agent_ids(
     client: AsyncClient, seed: dict, db_session: AsyncSession
 ):

--- a/packages/daemon/src/__tests__/attention-policy-fetcher.test.ts
+++ b/packages/daemon/src/__tests__/attention-policy-fetcher.test.ts
@@ -1,0 +1,67 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { generateKeypair } from "@botcord/protocol-core";
+import { createAttentionPolicyFetcher } from "../attention-policy-fetcher.js";
+
+function writeCredentials(agentId: string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "botcord-policy-"));
+  const file = path.join(dir, `${agentId}.json`);
+  const keys = generateKeypair();
+  writeFileSync(
+    file,
+    JSON.stringify({
+      version: 1,
+      hubUrl: "https://hub.test",
+      agentId,
+      keyId: "key_1",
+      privateKey: keys.privateKey,
+      publicKey: keys.publicKey,
+      savedAt: new Date().toISOString(),
+      token: "jwt",
+      tokenExpiresAt: Math.floor(Date.now() / 1000) + 3600,
+    }),
+  );
+  return file;
+}
+
+describe("createAttentionPolicyFetcher", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("fetches effective room attention policy with agent credentials", async () => {
+    const credentialsPath = writeCredentials("ag_policy");
+    const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      expect(String(url)).toBe(
+        "https://hub.test/hub/attention-policy?room_id=rm_1",
+      );
+      expect((init?.headers as Record<string, string>).Authorization).toBe(
+        "Bearer jwt",
+      );
+      return new Response(
+        JSON.stringify({
+          mode: "mention_only",
+          keywords: [],
+          allowedSenderIds: [],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const fetchPolicy = createAttentionPolicyFetcher({
+      credentialPathByAgentId: new Map([["ag_policy", credentialsPath]]),
+    });
+
+    await expect(
+      fetchPolicy({ agentId: "ag_policy", roomId: "rm_1" }),
+    ).resolves.toEqual({
+      mode: "mention_only",
+      keywords: [],
+      allowedSenderIds: [],
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/daemon/src/attention-policy-fetcher.ts
+++ b/packages/daemon/src/attention-policy-fetcher.ts
@@ -1,0 +1,87 @@
+import {
+  BotCordClient,
+  defaultCredentialsFile,
+  loadStoredCredentials,
+  updateCredentialsToken,
+} from "@botcord/protocol-core";
+import type { DaemonAttentionPolicy } from "./gateway/policy-resolver.js";
+
+interface CachedClient {
+  client: BotCordClient;
+  credentialsPath: string;
+}
+
+export interface AttentionPolicyFetcherOptions {
+  credentialPathByAgentId: Map<string, string>;
+  defaultCredentialsPath?: string;
+  hubBaseUrl?: string;
+  log?: {
+    warn: (msg: string, meta?: Record<string, unknown>) => void;
+  };
+}
+
+export type AttentionPolicyFetcher = (args: {
+  agentId: string;
+  roomId?: string | null;
+}) => Promise<DaemonAttentionPolicy | undefined>;
+
+export function createAttentionPolicyFetcher(
+  opts: AttentionPolicyFetcherOptions,
+): AttentionPolicyFetcher {
+  const clients = new Map<string, CachedClient>();
+
+  function getClient(agentId: string): BotCordClient | null {
+    const existing = clients.get(agentId);
+    if (existing) return existing.client;
+
+    const credentialsPath =
+      opts.credentialPathByAgentId.get(agentId) ??
+      opts.defaultCredentialsPath ??
+      defaultCredentialsFile(agentId);
+
+    try {
+      const creds = loadStoredCredentials(credentialsPath);
+      const client = new BotCordClient({
+        hubUrl: opts.hubBaseUrl ?? creds.hubUrl,
+        agentId: creds.agentId,
+        keyId: creds.keyId,
+        privateKey: creds.privateKey,
+        ...(creds.token ? { token: creds.token } : {}),
+        ...(creds.tokenExpiresAt !== undefined
+          ? { tokenExpiresAt: creds.tokenExpiresAt }
+          : {}),
+      });
+      client.onTokenRefresh = (token, expiresAt) => {
+        try {
+          updateCredentialsToken(credentialsPath, token, expiresAt);
+        } catch {
+          // Persistence failures are non-fatal; the next refresh retries.
+        }
+      };
+      clients.set(agentId, { client, credentialsPath });
+      return client;
+    } catch (err) {
+      opts.log?.warn("daemon.attention-policy.client-init-failed", {
+        agentId,
+        credentialsPath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
+  }
+
+  return async ({ agentId, roomId }) => {
+    const client = getClient(agentId);
+    if (!client) return undefined;
+    try {
+      return await client.getAttentionPolicy({ roomId });
+    } catch (err) {
+      opts.log?.warn("daemon.attention-policy.fetch-failed", {
+        agentId,
+        roomId: roomId ?? null,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return undefined;
+    }
+  };
+}

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -50,6 +50,7 @@ import { UserAuthManager } from "./user-auth.js";
 import { PolicyResolver, type DaemonAttentionPolicy } from "./gateway/policy-resolver.js";
 import { scanMention } from "./mention-scan.js";
 import { createDiagnosticBundle, uploadDiagnosticBundle } from "./diagnostics.js";
+import { createAttentionPolicyFetcher } from "./attention-policy-fetcher.js";
 
 /**
  * Default hard cap for a single runtime turn. Long-running coding/research
@@ -442,13 +443,20 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
     });
   };
 
-  // Per-agent attention policy cache (PR3, design §4.2 / §5). Seeded from
-  // the optional `defaultAttention` / `attentionKeywords` carried by
-  // `provision_agent`, refreshed in-place by the `policy_updated` control
-  // frame. PR2 will plug per-room overrides into `fetchEffective`; PR3
-  // leaves it absent so the resolver collapses to per-agent state.
+  // Per-agent attention policy cache (design §4.2 / §5). It is seeded from
+  // `provision_agent` / `policy_updated` frames when available and falls back
+  // to Hub on cold misses, so daemon restarts preserve dashboard policy.
+  const fetchAttentionPolicy = createAttentionPolicyFetcher({
+    credentialPathByAgentId,
+    defaultCredentialsPath: opts.credentialsPath,
+    hubBaseUrl: opts.hubBaseUrl,
+    log: logger,
+  });
   const policyResolver = new PolicyResolver({
-    fetchGlobal: async (_agentId: string) => undefined,
+    fetchGlobal: async (agentId: string) =>
+      fetchAttentionPolicy({ agentId, roomId: null }),
+    fetchEffective: async (agentId: string, roomId: string) =>
+      fetchAttentionPolicy({ agentId, roomId }),
   });
 
   // Display-name lookup for the mention text-fallback. Populated from boot

--- a/packages/protocol-core/src/client.ts
+++ b/packages/protocol-core/src/client.ts
@@ -29,6 +29,7 @@ import type {
   AgentScheduleSpec,
   AgentSchedulePayload,
 } from "./types.js";
+import type { AttentionPolicy } from "./should-wake.js";
 
 const MAX_RETRIES = 2;
 const RETRY_BASE_MS = 1000;
@@ -373,6 +374,16 @@ export class BotCordClient {
       method: "PATCH",
       body: JSON.stringify({ message_policy: policy }),
     });
+  }
+
+  async getAttentionPolicy(options?: {
+    roomId?: string | null;
+  }): Promise<AttentionPolicy> {
+    const params = new URLSearchParams();
+    if (options?.roomId) params.set("room_id", options.roomId);
+    const q = params.toString();
+    const resp = await this.hubFetch(`/hub/attention-policy${q ? `?${q}` : ""}`);
+    return (await resp.json()) as AttentionPolicy;
   }
 
   // ── Profile ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add a Hub attention-policy endpoint for daemon cold-cache resolution
- fetch effective per-room attention policy from local daemon before waking runtimes
- resume cloud agents only when inbound fan-out would actually wake them

## Tests
- cd packages/daemon && npm test -- --run src/__tests__/policy-resolver.test.ts src/__tests__/attention-policy-fetcher.test.ts src/gateway/__tests__/dispatcher.test.ts
- cd packages/protocol-core && npm test -- --run src/__tests__/should-wake.test.ts
- cd backend && uv run pytest tests/test_dashboard_rooms_human_send.py -k 'mention or policy'