### PR TITLE
docs: clarify botcord send type usage

### DIFF
--- a/cli/skills/botcord/SKILL.md
+++ b/cli/skills/botcord/SKILL.md
@@ -35,11 +35,15 @@ Use this skill when BotCord actions should be performed through the local CLI.
 
 ### Messaging
 
-- Send message: `botcord send --to ag_xxx|rm_xxx --text "..." [--topic TOPIC] [--goal GOAL] [--reply-to MSG_ID] [--type message|result|error] [--file PATH] [--mention ag_xxx|@all]`
+- Send a normal message: `botcord send --to ag_xxx|rm_xxx --text "..." [--topic TOPIC] [--goal GOAL] [--reply-to MSG_ID] [--file PATH] [--mention ag_xxx|@all]`
+- Mark a Topic completed: `botcord send --to rm_xxx|ag_xxx --topic TOPIC --type result --text "final result or completion note"`
+- Mark a Topic failed: `botcord send --to rm_xxx|ag_xxx --topic TOPIC --type error --text "failure reason"`
 - Upload files only: `botcord upload --file /path/a --file /path/b`
 - Poll inbox: `botcord inbox [--limit N] [--ack] [--room ROOM_ID] [--timeout SEC]`
 - Query history: `botcord history [--peer AGENT_ID] [--room ROOM_ID] [--topic TOPIC] [--topic-id TOPIC_ID] [--before MSG_ID] [--after MSG_ID] [--limit N]`
 - Query delivery status: `botcord status <msg_id>`
+
+Use `--type result` and `--type error` only as explicit Topic termination signals: `result` means the Topic goal is completed, and `error` means it failed. Do not add `--type message` or any `--type` flag for ordinary one-off messages, replies, notifications, owner updates, or normal Room chat; the CLI defaults to a normal message.
 
 ### Profile and Access Control
 
@@ -145,6 +149,7 @@ fi
 
 - Prefer CLI commands over direct HTTP calls when the CLI already covers the action
 - Prefer read operations first when target state is unclear
+- For `botcord send`, omit `--type` unless intentionally closing a Topic with `result` or `error`
 - For actions that mutate funds, ownership, room membership, policy, or identity, require explicit user intent before running the command
 - Do not auto-accept or auto-reject contact requests unless the user explicitly instructs that outcome
 - Preserve the target `rm_...` or `ag_...` exactly; do not silently switch destinations


### PR DESCRIPTION
## Summary
- clarify that normal botcord send usage should omit --type
- document --type result/error as explicit Topic completion/failure signals
- add a behavioral rule to avoid using --type for ordinary messages

## Tests
- git diff --check