### PR TITLE
fix: pin cloud daemon startup version

### DIFF
--- a/backend/hub/config.py
+++ b/backend/hub/config.py
@@ -358,11 +358,12 @@ E2B_SANDBOX_TIMEOUT_SECONDS: int = int(os.getenv("E2B_SANDBOX_TIMEOUT_SECONDS", 
 
 # Command Hub runs inside a freshly-created or resumed cloud daemon instance.
 # The default prefers the Hub-selected npm package so paused/resumed sandboxes
-# do not keep running an older daemon baked into the E2B template. Set
-# ``CLOUD_DAEMON_NPM_SPEC=bundled`` to force a purpose-built image's
-# preinstalled ``botcord-daemon`` instead.
+# do not keep running an older daemon baked into the E2B template. Keep this
+# at a minimum version that supports cloud-mode third-party gateway channels
+# (telegram/wechat/feishu). Set ``CLOUD_DAEMON_NPM_SPEC=bundled`` only for a
+# purpose-built image whose preinstalled ``botcord-daemon`` is known fresh.
 CLOUD_DAEMON_NPM_SPEC: str = os.getenv(
-    "CLOUD_DAEMON_NPM_SPEC", "@botcord/daemon@latest"
+    "CLOUD_DAEMON_NPM_SPEC", "@botcord/daemon@^0.2.78"
 )
 CLOUD_DAEMON_STARTUP_COMMAND: str = os.getenv(
     "CLOUD_DAEMON_STARTUP_COMMAND",
@@ -375,10 +376,7 @@ CLOUD_DAEMON_STARTUP_COMMAND: str = os.getenv(
         "fi; "
         ";; "
         "\"\") "
-        "if command -v botcord-daemon >/dev/null 2>&1; then "
-        "exec botcord-daemon start --foreground; "
-        "fi; "
-        "exec npx --yes --package @botcord/daemon@latest "
+        "exec npx --yes --package @botcord/daemon@^0.2.78 "
         "botcord-daemon start --foreground; "
         ";; "
         "*) "
@@ -386,7 +384,7 @@ CLOUD_DAEMON_STARTUP_COMMAND: str = os.getenv(
         "botcord-daemon start --foreground; "
         ";; "
         "esac; "
-        "exec npx --yes --package @botcord/daemon@latest "
+        "exec npx --yes --package @botcord/daemon@^0.2.78 "
         "botcord-daemon start --foreground"
         "'"
     ),

--- a/backend/tests/test_cloud_daemon_provider_e2b.py
+++ b/backend/tests/test_cloud_daemon_provider_e2b.py
@@ -41,7 +41,7 @@ def _make_provider(
     client: FakeE2BSandboxClient | None = None,
     deepseek_api_key: str | None = "ds-secret",
     startup_command: str = CLOUD_DAEMON_STARTUP_COMMAND,
-    daemon_npm_spec: str = "@botcord/daemon@0.2.75",
+    daemon_npm_spec: str = "@botcord/daemon@^0.2.78",
 ) -> tuple[E2BCloudDaemonProvider, FakeE2BSandboxClient]:
     client = client or FakeE2BSandboxClient()
     provider = E2BCloudDaemonProvider(
@@ -65,10 +65,14 @@ def _make_provider(
 def test_default_startup_command_prefers_configured_npm_spec():
     """Default launch should not prefer a stale daemon baked into the template."""
     assert "case \"${CLOUD_DAEMON_NPM_SPEC:-}\"" in CLOUD_DAEMON_STARTUP_COMMAND
+    assert "exec npx --yes --package @botcord/daemon@^0.2.78" in (
+        CLOUD_DAEMON_STARTUP_COMMAND
+    )
     assert "exec npx --yes --package \"$CLOUD_DAEMON_NPM_SPEC\"" in (
         CLOUD_DAEMON_STARTUP_COMMAND
     )
     assert "bundled)" in CLOUD_DAEMON_STARTUP_COMMAND
+    assert "\"\") if command -v botcord-daemon" not in CLOUD_DAEMON_STARTUP_COMMAND
 
 
 @pytest.mark.asyncio
@@ -99,7 +103,7 @@ async def test_create_or_resume_starts_sandbox_and_injects_env():
     assert env["BOTCORD_CLOUD_DAEMON_INSTANCE_ID"] == "cloud_dm_aaa"
     assert env["BOTCORD_DAEMON_INSTANCE_ID"] == "dm_bbb"
     assert env["DEEPSEEK_API_KEY"] == "ds-secret"
-    assert env["CLOUD_DAEMON_NPM_SPEC"] == "@botcord/daemon@0.2.75"
+    assert env["CLOUD_DAEMON_NPM_SPEC"] == "@botcord/daemon@^0.2.78"
 
     # And the injected access token is a valid cloud-daemon-access JWT.
     claims = _verify_cloud_daemon_access_token(env["BOTCORD_CLOUD_DAEMON_ACCESS_TOKEN"])

--- a/e2b/entrypoint.sh
+++ b/e2b/entrypoint.sh
@@ -60,8 +60,10 @@ fi
 # shellcheck disable=SC2206
 extra=( ${BOTCORD_DAEMON_EXTRA_ARGS:-} )
 
-if [[ -n "${CLOUD_DAEMON_NPM_SPEC:-}" && "${CLOUD_DAEMON_NPM_SPEC}" != "bundled" ]]; then
-  exec npx --yes --package "$CLOUD_DAEMON_NPM_SPEC" botcord-daemon start "${extra[@]}"
+daemon_npm_spec="${CLOUD_DAEMON_NPM_SPEC:-@botcord/daemon@^0.2.78}"
+
+if [[ "$daemon_npm_spec" != "bundled" ]]; then
+  exec npx --yes --package "$daemon_npm_spec" botcord-daemon start "${extra[@]}"
 fi
 
 exec botcord-daemon start "${extra[@]}"


### PR DESCRIPTION
## Summary
- pin cloud daemon npm startup spec to @botcord/daemon@^0.2.78 so cloud mode supports telegram/wechat/feishu gateway channels
- avoid falling back to stale bundled daemon when CLOUD_DAEMON_NPM_SPEC is unset
- update E2B provider tests to guard the startup command behavior

## Tests
- cd backend && uv run pytest tests/test_cloud_daemon_provider_e2b.py
- cd packages/daemon && npm test -- --run src/__tests__/cloud-daemon.test.ts src/__tests__/gateway-control.test.ts src/__tests__/third-party-gateway.test.ts
- bash -n e2b/entrypoint.sh