### PR TITLE
fix: hide owner-chat composing after final message

### DIFF
--- a/frontend/src/components/dashboard/StreamBlocksView.test.ts
+++ b/frontend/src/components/dashboard/StreamBlocksView.test.ts
@@ -1,0 +1,44 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import StreamBlocksView from "./StreamBlocksView";
+import type { StreamBlockEntry } from "@/lib/types";
+
+function mixedToolUseBlock(): StreamBlockEntry {
+  return {
+    trace_id: "tr_1",
+    seq: 1,
+    created_at: "2026-05-25T00:00:00.000Z",
+    block: {
+      kind: "tool_use",
+      raw: {
+        message: {
+          content: [
+            { type: "text", text: "draft answer" },
+            { type: "tool_use", id: "tool_1", name: "Read", input: { file_path: "README.md" } },
+          ],
+        },
+      },
+    },
+  };
+}
+
+describe("StreamBlocksView", () => {
+  it("does not render composing text for delivered execution blocks by default", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(StreamBlocksView, { blocks: [mixedToolUseBlock()] }),
+    );
+
+    expect(html).not.toContain("Composing");
+    expect(html).not.toContain("draft answer");
+  });
+
+  it("renders composing text when explicitly used for an active stream", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(StreamBlocksView, { blocks: [mixedToolUseBlock()], showComposing: true }),
+    );
+
+    expect(html).toContain("Composing");
+    expect(html).toContain("draft answer");
+  });
+});

--- a/frontend/src/components/dashboard/StreamBlocksView.tsx
+++ b/frontend/src/components/dashboard/StreamBlocksView.tsx
@@ -741,10 +741,12 @@ function StreamBlockItem({
 export default function StreamBlocksView({
   blocks,
   defaultExpanded,
+  showComposing = false,
   onScrollRequest,
 }: {
   blocks: StreamBlockEntry[];
   defaultExpanded?: boolean;
+  showComposing?: boolean;
   onScrollRequest?: () => void;
 }) {
   const [expanded, setExpanded] = useState(defaultExpanded ?? false);
@@ -787,7 +789,7 @@ export default function StreamBlocksView({
     }
     return parts.join("");
   }
-  const composingText = buildComposingText();
+  const composingText = showComposing ? buildComposingText() : "";
 
   useEffect(() => {
     onScrollRequest?.();

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -484,6 +484,7 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
                   key={`${msg.clientId}-streaming`}
                   blocks={msg.streamBlocks}
                   defaultExpanded
+                  showComposing
                   onScrollRequest={wasNearBottomRef.current ? scrollToBottom : undefined}
                 />
               </div>


### PR DESCRIPTION
## Summary
- gate owner-chat composing text behind an explicit active-stream prop
- only show composing while the owner-chat message is still streaming
- add regression coverage for delivered execution blocks carrying text inside mixed tool_use events

## Tests
- pnpm test -- StreamBlocksView useOwnerChatStore
- NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key pnpm build