### PR TITLE
feat: add cloud gateway ingress runtime

### DIFF
--- a/backend/app/routers/gateways.py
+++ b/backend/app/routers/gateways.py
@@ -25,12 +25,14 @@ import time
 from typing import Any, Literal
 from urllib.parse import urlparse
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, Response
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import RequestContext, require_user
+from hub import config as hub_config
 from hub.database import get_db
 from hub.id_generators import generate_gateway_connection_id
 from hub.models import Agent, AgentGatewayConnection, CloudAgentInstance
@@ -531,6 +533,101 @@ def _build_settings(config: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
+def _ingress_sync_secret() -> str | None:
+    return hub_config.CLOUD_GATEWAY_INGRESS_SECRET or hub_config.INTERNAL_API_SECRET
+
+
+async def _sync_cloud_gateway_ingress_upsert(
+    host: _GatewayHost,
+    *,
+    gateway_id: str,
+    user_id: Any,
+    agent_id: str,
+    provider: str,
+    label: str | None,
+    enabled: bool,
+    status: str,
+    config: dict[str, Any],
+    secret: dict[str, Any] | None = None,
+) -> None:
+    if not host.cloud_daemon_instance_id or not hub_config.CLOUD_GATEWAY_INGRESS_ADMIN_URL:
+        return
+    auth_secret = _ingress_sync_secret()
+    if not auth_secret:
+        raise HTTPException(status_code=500, detail="ingress_sync_secret_missing")
+    payload: dict[str, Any] = {
+        "id": gateway_id,
+        "agentId": agent_id,
+        "userId": str(user_id),
+        "provider": provider,
+        "label": label,
+        "enabled": enabled,
+        "status": status,
+        "config": config,
+    }
+    if secret is not None:
+        payload["secret"] = secret
+    url = f"{hub_config.CLOUD_GATEWAY_INGRESS_ADMIN_URL}/admin/gateways/{gateway_id}"
+    try:
+        async with httpx.AsyncClient(
+            timeout=hub_config.CLOUD_GATEWAY_INGRESS_ADMIN_TIMEOUT_SECONDS
+        ) as client:
+            resp = await client.put(
+                url,
+                headers={"Authorization": f"Bearer {auth_secret}"},
+                json=payload,
+            )
+    except httpx.HTTPError as exc:
+        logger.warning(
+            "cloud gateway ingress upsert sync failed: gateway=%s err=%s",
+            gateway_id,
+            exc,
+        )
+        raise HTTPException(status_code=502, detail="ingress_sync_failed") from exc
+    if resp.status_code >= 400:
+        logger.warning(
+            "cloud gateway ingress upsert sync rejected: gateway=%s status=%s",
+            gateway_id,
+            resp.status_code,
+        )
+        raise HTTPException(status_code=502, detail="ingress_sync_rejected")
+
+
+async def _sync_cloud_gateway_ingress_delete(
+    host: _GatewayHost,
+    *,
+    gateway_id: str,
+) -> None:
+    if not host.cloud_daemon_instance_id or not hub_config.CLOUD_GATEWAY_INGRESS_ADMIN_URL:
+        return
+    auth_secret = _ingress_sync_secret()
+    if not auth_secret:
+        raise HTTPException(status_code=500, detail="ingress_sync_secret_missing")
+    url = f"{hub_config.CLOUD_GATEWAY_INGRESS_ADMIN_URL}/admin/gateways/{gateway_id}"
+    try:
+        async with httpx.AsyncClient(
+            timeout=hub_config.CLOUD_GATEWAY_INGRESS_ADMIN_TIMEOUT_SECONDS
+        ) as client:
+            resp = await client.delete(
+                url,
+                headers={"Authorization": f"Bearer {auth_secret}"},
+            )
+    except httpx.HTTPError as exc:
+        logger.warning(
+            "cloud gateway ingress delete sync failed: gateway=%s err=%s",
+            gateway_id,
+            exc,
+        )
+        raise HTTPException(status_code=502, detail="ingress_sync_failed") from exc
+    if resp.status_code >= 400:
+        logger.warning(
+            "cloud gateway ingress delete sync rejected: gateway=%s status=%s",
+            gateway_id,
+            resp.status_code,
+        )
+        raise HTTPException(status_code=502, detail="ingress_sync_rejected")
+
+
 def _list_has_value(config: dict[str, Any], key: str) -> bool:
     value = config.get(key)
     return isinstance(value, list) and any(
@@ -648,6 +745,22 @@ async def create_gateway(
     if isinstance(daemon_status, dict) and daemon_status.get("running") is False and body.enabled:
         status_value = "pending"
 
+    sync_secret: dict[str, Any] | None = None
+    if body.provider == "telegram" and body.bot_token:
+        sync_secret = {"botToken": body.bot_token}
+    await _sync_cloud_gateway_ingress_upsert(
+        host,
+        gateway_id=gateway_id,
+        user_id=ctx.user_id,
+        agent_id=agent_id,
+        provider=body.provider,
+        label=body.label,
+        enabled=body.enabled,
+        status=status_value,
+        config=config,
+        secret=sync_secret,
+    )
+
     row = AgentGatewayConnection(
         id=gateway_id,
         user_id=ctx.user_id,
@@ -738,6 +851,22 @@ async def patch_gateway(
     else:
         row.status = "active" if row.enabled else "disabled"
 
+    sync_secret: dict[str, Any] | None = None
+    if row.provider == "telegram" and body.bot_token:
+        sync_secret = {"botToken": body.bot_token}
+    await _sync_cloud_gateway_ingress_upsert(
+        host,
+        gateway_id=row.id,
+        user_id=ctx.user_id,
+        agent_id=row.agent_id,
+        provider=row.provider,
+        label=row.label,
+        enabled=row.enabled,
+        status=row.status,
+        config=config,
+        secret=sync_secret,
+    )
+
     try:
         # trade-off: rare commit failure leaves Hub stale; daemon hot-plug already applied. list_gateways will reconcile on next refresh.
         await db.commit()
@@ -778,6 +907,7 @@ async def delete_gateway(
         )
         _ack_or_raise(ack)
 
+    await _sync_cloud_gateway_ingress_delete(host, gateway_id=row.id)
     await db.delete(row)
     await db.commit()
     return Response(status_code=204)

--- a/backend/hub/config.py
+++ b/backend/hub/config.py
@@ -88,6 +88,15 @@ CLOUD_GATEWAY_RUNTIME_TOKEN_TTL_SECONDS: int = int(
 CLOUD_GATEWAY_RUNTIME_ENDPOINT: str = os.getenv(
     "CLOUD_GATEWAY_RUNTIME_ENDPOINT", "wss://hub.botcord.chat/cloud-gateway/runtime"
 )
+# Optional admin endpoint for pushing dashboard-managed cloud gateway
+# connection metadata into the always-on gateway-ingress service. When unset,
+# dashboard gateway CRUD keeps the existing daemon-control behavior only.
+CLOUD_GATEWAY_INGRESS_ADMIN_URL: str | None = (
+    os.getenv("CLOUD_GATEWAY_INGRESS_ADMIN_URL", "").strip().rstrip("/") or None
+)
+CLOUD_GATEWAY_INGRESS_ADMIN_TIMEOUT_SECONDS: float = float(
+    os.getenv("CLOUD_GATEWAY_INGRESS_ADMIN_TIMEOUT_SECONDS", "5")
+)
 
 # Supabase JWT verification (optional — set ONE of these)
 # Option 1: symmetric HS256 secret (legacy Supabase projects)

--- a/backend/hub/main.py
+++ b/backend/hub/main.py
@@ -53,6 +53,7 @@ from hub.routers.wallet import internal_router as wallet_internal_router
 from hub.routers.wallet import router as wallet_router
 from hub.routers.cloud_agent_internal import internal_router as cloud_agent_internal_router
 from hub.routers.cloud_gateway_internal import internal_router as cloud_gateway_internal_router
+from hub.routers.cloud_gateway_internal import runtime_router as cloud_gateway_runtime_router
 from hub.storage import storage_requires_local_disk
 
 from app.routers.humans import router as app_humans_router
@@ -279,6 +280,7 @@ app.include_router(wallet_router)
 app.include_router(wallet_internal_router)
 app.include_router(cloud_agent_internal_router)
 app.include_router(cloud_gateway_internal_router)
+app.include_router(cloud_gateway_runtime_router)
 app.include_router(stripe_router)
 app.include_router(subscriptions_router)
 app.include_router(subscriptions_internal_router)

--- a/backend/hub/routers/cloud_gateway_internal.py
+++ b/backend/hub/routers/cloud_gateway_internal.py
@@ -34,12 +34,13 @@ contract.
 from __future__ import annotations
 
 import datetime
+import json
 import logging
 import time
 from typing import Any
 
 import jwt as pyjwt
-from fastapi import APIRouter, Depends, Header
+from fastapi import APIRouter, Depends, Header, WebSocket, WebSocketDisconnect
 from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -49,6 +50,7 @@ from hub.database import get_db
 from hub.i18n import I18nHTTPException
 from hub.models import Agent, CloudAgentInstance, CloudDaemonInstance
 from hub.routers.cloud_daemon_control import is_cloud_daemon_online
+from hub.routers.cloud_daemon_control import send_cloud_control_frame
 from hub.services.cloud_agent import (
     CloudAgentError,
     CloudAgentService,
@@ -60,6 +62,7 @@ logger = logging.getLogger(__name__)
 internal_router = APIRouter(
     prefix="/internal/cloud-gateway", tags=["cloud-gateway-internal"]
 )
+runtime_router = APIRouter(tags=["cloud-gateway-runtime"])
 
 
 # ---------------------------------------------------------------------------
@@ -129,6 +132,33 @@ def verify_runtime_session_token(token: str) -> dict[str, Any]:
     return claims
 
 
+def _runtime_ws_token(ws: WebSocket) -> str | None:
+    auth_header = ws.headers.get("authorization") or ws.headers.get("Authorization")
+    if auth_header and auth_header.lower().startswith("bearer "):
+        return auth_header[len("Bearer ") :].strip()
+    token = ws.query_params.get("token")
+    return token.strip() if token else None
+
+
+async def _send_runtime_rejection(
+    ws: WebSocket,
+    *,
+    event_id: str,
+    code: str,
+    message: str,
+) -> None:
+    await ws.send_text(
+        json.dumps(
+            {
+                "type": "gateway_inbound_ack",
+                "event_id": event_id,
+                "accepted": False,
+                "error": {"code": code, "message": message},
+            }
+        )
+    )
+
+
 # ---------------------------------------------------------------------------
 # DTOs (mirror packages/protocol-core/src/runtime-frame.ts)
 # ---------------------------------------------------------------------------
@@ -162,6 +192,169 @@ class TouchRequest(BaseModel):
 class TouchResponse(BaseModel):
     agent_id: str
     acknowledged_at: int
+
+
+# ---------------------------------------------------------------------------
+# Runtime relay WebSocket
+# ---------------------------------------------------------------------------
+
+
+@runtime_router.websocket("/cloud-gateway/runtime")
+async def cloud_gateway_runtime_ws(ws: WebSocket) -> None:
+    """Relay gateway-ingress runtime frames to the online cloud daemon.
+
+    This is the MVP transport for the design's "runtime direct session"
+    contract. The Hub authenticates the short-lived runtime token and then
+    relays payloads through the cloud daemon control connection without
+    storing or inspecting provider message bodies beyond the frame metadata
+    needed for routing and validation.
+    """
+    token = _runtime_ws_token(ws)
+    if not token:
+        await ws.close(code=4401, reason="missing bearer")
+        return
+    try:
+        claims = verify_runtime_session_token(token)
+    except ValueError as exc:
+        await ws.close(code=4401, reason=str(exc))
+        return
+
+    agent_id = str(claims["agent_id"])
+    gateway_id = str(claims["gateway_id"])
+    cloud_daemon_instance_id = str(claims["cloud_daemon_instance_id"])
+    token_event_id = claims.get("event_id")
+
+    await ws.accept()
+    try:
+        while True:
+            raw = await ws.receive_text()
+            try:
+                frame = json.loads(raw)
+            except json.JSONDecodeError:
+                await _send_runtime_rejection(
+                    ws,
+                    event_id=str(token_event_id or ""),
+                    code="bad_json",
+                    message="runtime frame must be JSON",
+                )
+                continue
+
+            if not isinstance(frame, dict):
+                await _send_runtime_rejection(
+                    ws,
+                    event_id=str(token_event_id or ""),
+                    code="bad_frame",
+                    message="runtime frame must be an object",
+                )
+                continue
+            frame_type = frame.get("type")
+            if frame_type == "runtime_heartbeat":
+                await ws.send_text(json.dumps({"type": "runtime_heartbeat", "ts": int(time.time() * 1000)}))
+                continue
+            event_id = str(frame.get("event_id") or token_event_id or "")
+            if frame_type != "gateway_inbound":
+                await _send_runtime_rejection(
+                    ws,
+                    event_id=event_id,
+                    code="bad_frame_type",
+                    message=f"unsupported runtime frame type {frame_type!r}",
+                )
+                continue
+            if frame.get("agent_id") != agent_id or frame.get("gateway_id") != gateway_id:
+                await _send_runtime_rejection(
+                    ws,
+                    event_id=event_id,
+                    code="runtime_token_scope_mismatch",
+                    message="runtime frame does not match token scope",
+                )
+                continue
+
+            try:
+                ack = await send_cloud_control_frame(
+                    cloud_daemon_instance_id,
+                    "cloud_gateway_runtime_inbound",
+                    {"frame": frame},
+                    timeout_ms=30 * 60 * 1000,
+                )
+            except Exception as exc:  # noqa: BLE001 - transport-specific failures become frame errors
+                logger.warning(
+                    "cloud-gateway runtime relay failed: cloud=%s agent=%s gateway=%s err=%s",
+                    cloud_daemon_instance_id,
+                    agent_id,
+                    gateway_id,
+                    exc,
+                )
+                await _send_runtime_rejection(
+                    ws,
+                    event_id=event_id,
+                    code="cloud_daemon_unavailable",
+                    message=str(exc),
+                )
+                continue
+
+            result = ack.get("result") if isinstance(ack, dict) else None
+            if not isinstance(ack, dict) or ack.get("ok") is not True or not isinstance(result, dict):
+                err = ack.get("error") if isinstance(ack, dict) else None
+                code = err.get("code") if isinstance(err, dict) else "daemon_rejected"
+                message = err.get("message") if isinstance(err, dict) else "daemon rejected runtime frame"
+                await _send_runtime_rejection(
+                    ws,
+                    event_id=event_id,
+                    code=str(code),
+                    message=str(message),
+                )
+                continue
+
+            turn_id = str(result.get("turnId") or f"turn_{event_id}")
+            conversation_id = str(
+                result.get("conversationId")
+                or (frame.get("message") or {}).get("conversation", {}).get("id")
+                or ""
+            )
+            await ws.send_text(
+                json.dumps(
+                    {
+                        "type": "gateway_inbound_ack",
+                        "event_id": event_id,
+                        "accepted": bool(result.get("accepted", True)),
+                        "runtime_session_id": turn_id,
+                    }
+                )
+            )
+            outbound = result.get("outbound")
+            if isinstance(outbound, dict):
+                await ws.send_text(
+                    json.dumps(
+                        {
+                            "type": "gateway_outbound_complete",
+                            "event_id": event_id,
+                            "turn_id": turn_id,
+                            "gateway_id": gateway_id,
+                            "agent_id": agent_id,
+                            "conversation_id": conversation_id,
+                            "final_text": str(outbound.get("finalText") or ""),
+                            "provider_message_id": outbound.get("providerMessageId"),
+                        }
+                    )
+                )
+            else:
+                await ws.send_text(
+                    json.dumps(
+                        {
+                            "type": "gateway_outbound_error",
+                            "event_id": event_id,
+                            "turn_id": turn_id,
+                            "gateway_id": gateway_id,
+                            "agent_id": agent_id,
+                            "conversation_id": conversation_id,
+                            "code": "no_outbound",
+                            "message": "runtime completed without an outbound message",
+                            "retryable": False,
+                        }
+                    )
+                )
+    except WebSocketDisconnect:
+        return
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/components/dashboard/AgentChannelsTab.tsx
+++ b/frontend/src/components/dashboard/AgentChannelsTab.tsx
@@ -46,6 +46,8 @@ type AddMode = null | "telegram" | "wechat" | "feishu";
 type TelegramDiscoveryChat = { id: string; type: string | null; label: string | null };
 type TelegramDiscoverySender = { id: string; label: string | null };
 
+const PROVIDER_OPTIONS: GatewayProvider[] = ["feishu", "wechat", "telegram"];
+
 const STATUS_LABELS: Record<GatewayStatus, string> = {
   active: "运行中",
   disabled: "已停用",
@@ -268,6 +270,18 @@ export default function AgentChannelsTab({ agentId, hostingKind }: Props) {
         </div>
       )}
 
+      {isCloudAgent && !daemonOffline && (
+        <div className="flex items-start gap-2 rounded-xl border border-neon-cyan/30 bg-neon-cyan/10 px-3 py-2.5 text-xs text-neon-cyan">
+          <Info className="mt-0.5 h-4 w-4 shrink-0" />
+          <div>
+            <div className="font-semibold">云端接入会自动恢复运行环境</div>
+            <div className="text-neon-cyan/80">
+              创建、扫码、启用或停用第三方接入时会自动唤醒云端 agent；恢复可能需要几秒，超时后稍后刷新即可确认状态。
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Connected gateways. */}
       <section className="space-y-2">
         <div className="flex items-center justify-between">
@@ -418,7 +432,7 @@ export default function AgentChannelsTab({ agentId, hostingKind }: Props) {
           </div>
           {/* provider segmented control */}
           <div className="mb-4 inline-flex rounded-lg border border-glass-border bg-deep-black/40 p-0.5">
-            {(["feishu", "wechat", "telegram"] as const).map((p) => (
+            {PROVIDER_OPTIONS.map((p) => (
               <button
                 key={p}
                 type="button"
@@ -1708,6 +1722,7 @@ function GatewayEditForm({
     allowedChatIds?: unknown;
     allowedSenderIds?: unknown;
     baseUrl?: unknown;
+    domain?: unknown;
   };
   const initialChatIds = Array.isArray(cfg.allowedChatIds)
     ? cfg.allowedChatIds.filter((id): id is string => typeof id === "string").join("\n")
@@ -1715,9 +1730,11 @@ function GatewayEditForm({
   const initialSenderIds = Array.isArray(cfg.allowedSenderIds)
     ? cfg.allowedSenderIds.filter((id): id is string => typeof id === "string").join("\n")
     : "";
+  const initialFeishuDomain = cfg.domain === "lark" ? "lark" : "feishu";
   const [label, setLabel] = useState(gateway.label ?? "");
   const [chatIds, setChatIds] = useState(initialChatIds);
   const [senderIds, setSenderIds] = useState(initialSenderIds);
+  const [feishuDomain, setFeishuDomain] = useState<"feishu" | "lark">(initialFeishuDomain);
   const [token, setToken] = useState("");
   const [saving, setSaving] = useState(false);
   const [discoveringChats, setDiscoveringChats] = useState(false);
@@ -1774,14 +1791,28 @@ function GatewayEditForm({
     setSaving(true);
     onError(null);
     try {
+      const config =
+        gateway.provider === "telegram"
+          ? {
+              label: label.trim() || undefined,
+              allowedChatIds,
+              allowedSenderIds,
+            }
+          : gateway.provider === "feishu"
+            ? {
+                label: label.trim() || undefined,
+                domain: feishuDomain,
+                allowedSenderIds,
+                allowedChatIds,
+              }
+            : {
+                label: label.trim() || undefined,
+                allowedSenderIds,
+                ...(typeof cfg.baseUrl === "string" ? { baseUrl: cfg.baseUrl } : {}),
+              };
       await patch(agentId, gateway.id, {
         label: label.trim() || null,
-        config: {
-          label: label.trim() || undefined,
-          ...(gateway.provider === "telegram" ? { allowedChatIds } : {}),
-          allowedSenderIds,
-          ...(typeof cfg.baseUrl === "string" ? { baseUrl: cfg.baseUrl } : {}),
-        },
+        config,
         ...(gateway.provider === "telegram" && token.trim()
           ? { secret: { botToken: token.trim() } }
           : {}),
@@ -1994,7 +2025,13 @@ function GatewayEditForm({
           value={label}
           onChange={(e) => setLabel(e.target.value)}
           disabled={saving}
-          placeholder={gateway.provider === "wechat" ? "例如：我的微信" : "例如：客服 Bot"}
+          placeholder={
+            gateway.provider === "wechat"
+              ? "例如：我的微信"
+              : gateway.provider === "feishu"
+                ? "例如：飞书助手"
+                : "例如：客服 Bot"
+          }
           className="w-full rounded-lg border border-glass-border bg-deep-black/40 px-3 py-2 text-xs text-text-primary outline-none focus:border-neon-cyan/40 disabled:opacity-50"
         />
       </Field>
@@ -2110,11 +2147,46 @@ function GatewayEditForm({
           </Field>
         </>
       )}
+      {gateway.provider === "feishu" && (
+        <>
+          <Field label="飞书域">
+            <div className="inline-flex rounded-lg border border-glass-border bg-deep-black/40 p-0.5">
+              {(["feishu", "lark"] as const).map((d) => (
+                <button
+                  key={d}
+                  type="button"
+                  onClick={() => setFeishuDomain(d)}
+                  disabled={saving}
+                  className={`rounded-md px-3 py-1 text-xs transition-colors ${
+                    feishuDomain === d
+                      ? "bg-neon-cyan/20 text-neon-cyan"
+                      : "text-text-secondary hover:text-text-primary"
+                  } disabled:opacity-50`}
+                >
+                  {d === "feishu" ? "飞书" : "Lark"}
+                </button>
+              ))}
+            </div>
+          </Field>
+          <Field label="允许的飞书群 chat_id（可选，逗号或换行分隔）">
+            <textarea
+              value={chatIds}
+              onChange={(e) => setChatIds(e.target.value)}
+              disabled={saving}
+              rows={2}
+              placeholder="oc_xxxxx"
+              className="w-full resize-none rounded-lg border border-glass-border bg-deep-black/40 px-3 py-2 font-mono text-xs text-text-primary outline-none focus:border-neon-cyan/40 disabled:opacity-50"
+            />
+          </Field>
+        </>
+      )}
       <Field
         label={
           gateway.provider === "wechat"
             ? "允许的微信用户 ID（逗号或换行分隔）"
-            : "允许的发送者 user id（逗号或换行分隔）"
+            : gateway.provider === "feishu"
+              ? "允许的飞书用户 open_id（逗号或换行分隔）"
+              : "允许的发送者 user id（逗号或换行分隔）"
         }
       >
         <textarea
@@ -2122,7 +2194,13 @@ function GatewayEditForm({
           onChange={(e) => setSenderIds(e.target.value)}
           disabled={saving}
           rows={2}
-          placeholder={gateway.provider === "wechat" ? "xxx@im.wechat" : "123456789"}
+          placeholder={
+            gateway.provider === "wechat"
+              ? "xxx@im.wechat"
+              : gateway.provider === "feishu"
+                ? "ou_xxxxx"
+                : "123456789"
+          }
           className="w-full resize-none rounded-lg border border-glass-border bg-deep-black/40 px-3 py-2 font-mono text-xs text-text-primary outline-none focus:border-neon-cyan/40 disabled:opacity-50"
         />
         {gateway.provider === "wechat" && (
@@ -2256,7 +2334,9 @@ function GatewayEditForm({
         <p className="rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-[11px] text-amber-200">
           {gateway.provider === "telegram"
             ? "必须同时保留允许的 chat id 和发送者 user id，才能保存修改。"
-            : "必须保留至少一个允许的微信用户 ID，才能保存修改。"}
+            : gateway.provider === "feishu"
+              ? "必须保留至少一个允许的飞书用户 open_id，才能保存修改。"
+              : "必须保留至少一个允许的微信用户 ID，才能保存修改。"}
         </p>
       )}
       <div className="flex justify-end gap-2">

--- a/packages/daemon/src/__tests__/cloud-gateway-runtime.test.ts
+++ b/packages/daemon/src/__tests__/cloud-gateway-runtime.test.ts
@@ -1,0 +1,127 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { RUNTIME_FRAME_TYPES, type GatewayInboundFrame } from "@botcord/protocol-core";
+
+import { handleCloudGatewayRuntimeInbound } from "../cloud-gateway-runtime.js";
+import { Gateway, type ChannelAdapter } from "../gateway/index.js";
+
+describe("cloud gateway runtime inbound", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), "cloud-gateway-runtime-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("injects a gateway_inbound frame and captures the runtime reply", async () => {
+    const gateway = new Gateway({
+      config: {
+        channels: [],
+        defaultRoute: { runtime: "fake", cwd: tmpDir },
+      },
+      sessionStorePath: path.join(tmpDir, "sessions.json"),
+      createChannel: (cfg) => stubChannel(cfg.id, cfg.type, cfg.accountId),
+      createRuntime: () => ({
+        id: "fake",
+        async run() {
+          return { text: "hello from runtime", newSessionId: "sess_1" };
+        },
+      }),
+      transcriptEnabled: false,
+    });
+    await gateway.start();
+
+    const frame: GatewayInboundFrame = {
+      type: RUNTIME_FRAME_TYPES.GATEWAY_INBOUND,
+      event_id: "evt_1",
+      gateway_id: "gw_tg_1",
+      agent_id: "ag_1",
+      provider: "telegram",
+      message: {
+        id: "telegram:1:2",
+        channel: "gw_tg_1",
+        accountId: "ag_1",
+        conversation: { id: "telegram:user:1", kind: "direct" },
+        sender: { id: "telegram:user:1", kind: "user" },
+        text: "hi",
+        replyTo: null,
+        mentioned: true,
+        receivedAt: Date.now(),
+        trace: { id: "telegram:1:2", streamable: false },
+      },
+    };
+
+    const result = await handleCloudGatewayRuntimeInbound(gateway, frame);
+    await gateway.stop("test");
+
+    expect(result.accepted).toBe(true);
+    expect(result.eventId).toBe("evt_1");
+    expect(result.gatewayId).toBe("gw_tg_1");
+    expect(result.conversationId).toBe("telegram:user:1");
+    expect(result.outbound?.finalText).toBe("hello from runtime");
+  });
+
+  it("rejects frames outside the token scope", async () => {
+    const gateway = new Gateway({
+      config: {
+        channels: [],
+        defaultRoute: { runtime: "fake", cwd: tmpDir },
+      },
+      sessionStorePath: path.join(tmpDir, "sessions.json"),
+      createChannel: (cfg) => stubChannel(cfg.id, cfg.type, cfg.accountId),
+      createRuntime: () => ({
+        id: "fake",
+        async run() {
+          return { text: "unused", newSessionId: "sess_1" };
+        },
+      }),
+      transcriptEnabled: false,
+    });
+
+    const result = await handleCloudGatewayRuntimeInbound(gateway, {
+      type: RUNTIME_FRAME_TYPES.GATEWAY_INBOUND,
+      event_id: "evt_bad",
+      gateway_id: "gw_tg_1",
+      agent_id: "ag_1",
+      provider: "telegram",
+      message: {
+        id: "telegram:1:2",
+        channel: "gw_other",
+        accountId: "ag_1",
+        conversation: { id: "telegram:user:1", kind: "direct" },
+        sender: { id: "telegram:user:1", kind: "user" },
+        text: "hi",
+        replyTo: null,
+        mentioned: true,
+        receivedAt: Date.now(),
+      },
+    });
+
+    expect(result.accepted).toBe(false);
+    expect(result.error?.code).toBe("channel_mismatch");
+  });
+});
+
+function stubChannel(id: string, type: string, accountId: string): ChannelAdapter {
+  return {
+    id,
+    type,
+    async start() {
+      return undefined;
+    },
+    async stop() {
+      return undefined;
+    },
+    async send() {
+      return {};
+    },
+    status() {
+      return { channel: id, accountId, running: true };
+    },
+  };
+}

--- a/packages/daemon/src/cloud-gateway-runtime.ts
+++ b/packages/daemon/src/cloud-gateway-runtime.ts
@@ -1,0 +1,171 @@
+import {
+  RUNTIME_FRAME_TYPES,
+  type GatewayInboundFrame,
+} from "@botcord/protocol-core";
+
+import type {
+  ChannelAdapter,
+  ChannelSendContext,
+  ChannelSendResult,
+  ChannelStatusSnapshot,
+  Gateway,
+  GatewayInboundMessage,
+  GatewayLogger,
+} from "./gateway/index.js";
+
+export interface CloudGatewayRuntimeResult {
+  accepted: boolean;
+  eventId: string;
+  gatewayId: string;
+  agentId: string;
+  conversationId: string;
+  turnId: string;
+  outbound?: {
+    finalText: string;
+    providerMessageId?: string | null;
+  };
+  error?: {
+    code: string;
+    message: string;
+  };
+}
+
+/**
+ * Execute one ingress-originated runtime frame through the normal Gateway
+ * dispatcher while keeping provider I/O outside the cloud sandbox.
+ *
+ * The temporary channel is scoped to this call and implements only the
+ * dispatcher-facing send/status surface. Its send() method captures the
+ * final runtime reply; the Hub relay converts that into
+ * gateway_outbound_complete for gateway-ingress, which then calls the real
+ * provider API.
+ */
+export async function handleCloudGatewayRuntimeInbound(
+  gateway: Gateway,
+  frame: GatewayInboundFrame,
+  log?: GatewayLogger,
+): Promise<CloudGatewayRuntimeResult> {
+  if (frame.type !== RUNTIME_FRAME_TYPES.GATEWAY_INBOUND) {
+    return rejected(frame, "bad_frame_type", `unsupported frame type "${frame.type}"`);
+  }
+  if (!frame.gateway_id || !frame.agent_id || !frame.event_id) {
+    return rejected(frame, "bad_frame", "gateway_id, agent_id and event_id are required");
+  }
+  if (frame.message.accountId !== frame.agent_id) {
+    return rejected(frame, "account_mismatch", "message.accountId does not match frame.agent_id");
+  }
+  if (frame.message.channel !== frame.gateway_id) {
+    return rejected(frame, "channel_mismatch", "message.channel does not match frame.gateway_id");
+  }
+
+  let accepted = false;
+  let outboundText: string | null = null;
+  let providerMessageId: string | null | undefined;
+  const channel = createRuntimeRelayChannel({
+    id: frame.gateway_id,
+    provider: frame.provider,
+    accountId: frame.agent_id,
+    onSend: async (ctx) => {
+      outboundText = ctx.message.text ?? "";
+      providerMessageId = ctx.message.traceId ?? null;
+      return { providerMessageId };
+    },
+  });
+
+  const message: GatewayInboundMessage = {
+    ...frame.message,
+    raw: {
+      source_type: "cloud_gateway_ingress",
+      provider: frame.provider,
+      event_id: frame.event_id,
+      gateway_id: frame.gateway_id,
+    },
+  };
+
+  try {
+    await gateway.injectInboundThrough(message, channel, {
+      accept: async () => {
+        accepted = true;
+      },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log?.warn("cloud gateway runtime dispatch failed", {
+      eventId: frame.event_id,
+      gatewayId: frame.gateway_id,
+      agentId: frame.agent_id,
+      error: message,
+    });
+    return rejected(frame, "dispatch_failed", message);
+  }
+
+  return {
+    accepted,
+    eventId: frame.event_id,
+    gatewayId: frame.gateway_id,
+    agentId: frame.agent_id,
+    conversationId: frame.message.conversation.id,
+    turnId: `turn_${frame.event_id}`,
+    ...(outboundText !== null
+      ? {
+          outbound: {
+            finalText: outboundText,
+            providerMessageId: providerMessageId ?? null,
+          },
+        }
+      : {}),
+    ...(!accepted
+      ? { error: { code: "not_accepted", message: "dispatcher did not accept inbound" } }
+      : {}),
+  };
+}
+
+function createRuntimeRelayChannel(opts: {
+  id: string;
+  provider: string;
+  accountId: string;
+  onSend: (ctx: ChannelSendContext) => Promise<ChannelSendResult>;
+}): ChannelAdapter {
+  let lastSendAt: number | undefined;
+  return {
+    id: opts.id,
+    type: opts.provider,
+    async start() {
+      return undefined;
+    },
+    async stop() {
+      return undefined;
+    },
+    async send(ctx) {
+      lastSendAt = Date.now();
+      return opts.onSend(ctx);
+    },
+    status(): ChannelStatusSnapshot {
+      return {
+        channel: opts.id,
+        accountId: opts.accountId,
+        running: true,
+        connected: true,
+        authorized: true,
+        provider: opts.provider as ChannelStatusSnapshot["provider"],
+        ...(lastSendAt ? { lastSendAt } : {}),
+      };
+    },
+  };
+}
+
+function rejected(
+  frame: Partial<GatewayInboundFrame>,
+  code: string,
+  message: string,
+): CloudGatewayRuntimeResult {
+  return {
+    accepted: false,
+    eventId: frame.event_id ?? "",
+    gatewayId: frame.gateway_id ?? "",
+    agentId: frame.agent_id ?? "",
+    conversationId: frame.message?.conversation.id ?? "",
+    turnId: frame.event_id ? `turn_${frame.event_id}` : "turn_unknown",
+    error: { code, message },
+  };
+}

--- a/packages/daemon/src/gateway/gateway.ts
+++ b/packages/daemon/src/gateway/gateway.ts
@@ -296,6 +296,28 @@ export class Gateway {
   }
 
   /**
+   * Inject an inbound message while routing replies through a caller-owned
+   * channel adapter. Cloud gateway runtime sessions use this to execute a
+   * provider message without loading provider credentials inside the sandbox:
+   * the temporary adapter captures the runtime's final reply and the always-on
+   * ingress service performs the provider send.
+   */
+  async injectInboundThrough(
+    message: GatewayInboundMessage,
+    channel: ChannelAdapter,
+    ack?: { accept: () => Promise<void> },
+  ): Promise<void> {
+    const previous = this.channelMap.get(channel.id);
+    this.channelMap.set(channel.id, channel);
+    try {
+      await this.dispatcher.handle({ message, ...(ack ? { ack } : {}) });
+    } finally {
+      if (previous) this.channelMap.set(channel.id, previous);
+      else this.channelMap.delete(channel.id);
+    }
+  }
+
+  /**
    * Send a daemon-control initiated outbound message through a registered
    * channel. Used by proactive third-party gateway sends where the runtime
    * explicitly targets an external provider conversation.

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -26,6 +26,7 @@ import {
   type RuntimeProbeResult,
   type StoredBotCordCredentials,
   type UpdateAgentParams,
+  type GatewayInboundFrame,
 } from "@botcord/protocol-core";
 import type { Gateway } from "./gateway/index.js";
 import type { GatewayInboundMessage } from "./gateway/index.js";
@@ -77,6 +78,7 @@ import {
   buildRuntimeSelectionExtraArgs,
   mergeRuntimeExtraArgs,
 } from "./runtime-route-options.js";
+import { handleCloudGatewayRuntimeInbound } from "./cloud-gateway-runtime.js";
 
 /**
  * Information passed to {@link OnAgentInstalledHook} after a successful
@@ -424,6 +426,31 @@ export function createProvisioner(opts: ProvisionerOptions): (
         return gatewayControl.handleSend(
           v.params as unknown as Parameters<typeof gatewayControl.handleSend>[0],
         );
+      }
+
+      case "cloud_gateway_runtime_inbound": {
+        const params = (frame.params ?? {}) as { frame?: unknown };
+        const runtimeFrame = params.frame as GatewayInboundFrame | undefined;
+        if (!runtimeFrame || typeof runtimeFrame !== "object") {
+          return {
+            ok: false,
+            error: {
+              code: "bad_params",
+              message: "cloud_gateway_runtime_inbound requires params.frame",
+            },
+          };
+        }
+        const result = await handleCloudGatewayRuntimeInbound(gateway, runtimeFrame);
+        return result.accepted
+          ? { ok: true, result }
+          : {
+              ok: false,
+              result,
+              error: result.error ?? {
+                code: "runtime_inbound_rejected",
+                message: "cloud gateway runtime inbound was rejected",
+              },
+            };
       }
 
       case "list_agent_files": {

--- a/packages/gateway-ingress/src/__tests__/admin-sync.test.ts
+++ b/packages/gateway-ingress/src/__tests__/admin-sync.test.ts
@@ -1,0 +1,192 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { loadConfigFromEnv } from "../config.js";
+import { noopLogger } from "../log.js";
+import { buildIngressService, type IngressService } from "../service.js";
+import { MemorySecretStore } from "../storage/secrets.js";
+import { FileSystemIngressStore } from "../storage/store.js";
+import { FakeHubClient, FakeSocketFactory } from "./fixtures.js";
+
+describe("admin sync server", () => {
+  let dir: string;
+  let service: IngressService;
+  let starts: string[];
+  let stops: string[];
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "ingress-admin-"));
+    starts = [];
+    stops = [];
+    const config = loadConfigFromEnv({
+      BOTCORD_INGRESS_HUB_URL: "http://test",
+      BOTCORD_INGRESS_SECRET: "sync-secret",
+      BOTCORD_INGRESS_DATA_DIR: dir,
+      BOTCORD_INGRESS_SECRET_DIR: join(dir, "secrets"),
+      BOTCORD_INGRESS_HEALTH_PORT: "0",
+      BOTCORD_INGRESS_ADMIN_PORT: "0",
+    });
+    service = await buildIngressService({
+      config,
+      log: noopLogger,
+      store: new FileSystemIngressStore(dir),
+      secrets: new MemorySecretStore(),
+      hub: new FakeHubClient(),
+      socketFactory: new FakeSocketFactory().factory,
+      startAdmin: true,
+      factories: {
+        telegram: (gatewayId) => ({
+          gatewayId,
+          provider: "telegram" as const,
+          async start() {
+            starts.push(gatewayId);
+          },
+          async stop(reason) {
+            stops.push(`${gatewayId}:${reason}`);
+          },
+          async send() {
+            return {};
+          },
+        }),
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await service.shutdown();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function url(path: string): string {
+    if (!service.admin) throw new Error("admin server not started");
+    return `${service.admin.url}${path}`;
+  }
+
+  it("authenticates and stores connection metadata plus secrets", async () => {
+    const unauthorized = await fetch(url("/admin/gateways/gw_tg_sync"), {
+      method: "PUT",
+      body: "{}",
+    });
+    expect(unauthorized.status).toBe(401);
+
+    const res = await fetch(url("/admin/gateways/gw_tg_sync"), {
+      method: "PUT",
+      headers: {
+        authorization: "Bearer sync-secret",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        id: "gw_tg_sync",
+        agentId: "ag_cloud",
+        userId: "user_1",
+        provider: "telegram",
+        label: "Cloud Telegram",
+        enabled: true,
+        status: "active",
+        config: { allowedChatIds: ["111"], allowedSenderIds: ["111"] },
+        secret: { botToken: "1234:abcd" },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: true,
+      gateway: { id: "gw_tg_sync", agentId: "ag_cloud", hasSecret: true },
+    });
+    expect(service.store.getConnection("gw_tg_sync")).toMatchObject({
+      id: "gw_tg_sync",
+      agentId: "ag_cloud",
+      userId: "user_1",
+      provider: "telegram",
+      enabled: true,
+      secretRef: "gw_tg_sync",
+    });
+    expect(service.secrets.load("gw_tg_sync")).toEqual({ botToken: "1234:abcd" });
+    expect(starts).toEqual(["gw_tg_sync"]);
+  });
+
+  it("applies disabled updates and deletes local secret state", async () => {
+    await fetch(url("/admin/gateways/gw_tg_sync"), {
+      method: "PUT",
+      headers: {
+        authorization: "Bearer sync-secret",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        agentId: "ag_cloud",
+        provider: "telegram",
+        enabled: true,
+        config: { allowedChatIds: ["111"], allowedSenderIds: ["111"] },
+        secret: { botToken: "1234:abcd" },
+      }),
+    });
+    await fetch(url("/admin/gateways/gw_tg_sync"), {
+      method: "PUT",
+      headers: {
+        authorization: "Bearer sync-secret",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        agentId: "ag_cloud",
+        provider: "telegram",
+        enabled: false,
+        status: "disabled",
+        config: { allowedChatIds: ["111"], allowedSenderIds: ["222"] },
+      }),
+    });
+
+    expect(service.store.getConnection("gw_tg_sync")).toMatchObject({
+      enabled: false,
+      status: "disabled",
+      config: { allowedChatIds: ["111"], allowedSenderIds: ["222"] },
+    });
+    expect(service.secrets.load("gw_tg_sync")).toEqual({ botToken: "1234:abcd" });
+    expect(stops).toContain("gw_tg_sync:admin-sync-disabled");
+
+    const del = await fetch(url("/admin/gateways/gw_tg_sync"), {
+      method: "DELETE",
+      headers: { authorization: "Bearer sync-secret" },
+    });
+    expect(del.status).toBe(200);
+    expect(service.store.getConnection("gw_tg_sync")).toBeNull();
+    expect(service.secrets.load("gw_tg_sync")).toBeNull();
+    // The disabled update already stopped the adapter; delete is still
+    // responsible for removing persisted metadata and secret state.
+    expect(stops).toContain("gw_tg_sync:admin-sync-disabled");
+  });
+
+  it("stores enabled gateways without starting providers until a secret is present", async () => {
+    const res = await fetch(url("/admin/gateways/gw_feishu_sync"), {
+      method: "PUT",
+      headers: {
+        authorization: "Bearer sync-secret",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        agentId: "ag_cloud",
+        provider: "feishu",
+        enabled: true,
+        status: "pending",
+        config: { allowedSenderIds: ["ou_1"] },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: true,
+      gateway: { id: "gw_feishu_sync", agentId: "ag_cloud", hasSecret: false },
+    });
+    expect(service.store.getConnection("gw_feishu_sync")).toMatchObject({
+      id: "gw_feishu_sync",
+      agentId: "ag_cloud",
+      provider: "feishu",
+      enabled: true,
+      secretRef: "gw_feishu_sync",
+    });
+    expect(service.secrets.load("gw_feishu_sync")).toBeNull();
+    expect(starts).toEqual([]);
+  });
+});

--- a/packages/gateway-ingress/src/admin-sync.ts
+++ b/packages/gateway-ingress/src/admin-sync.ts
@@ -1,0 +1,251 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+
+import type { IngressLogger } from "./log.js";
+import type { ProviderRunner } from "./provider-runner.js";
+import type { IngressSecretStore } from "./storage/secrets.js";
+import type { IngressStore } from "./storage/store.js";
+import type { GatewayConnection, GatewayStatus } from "./types.js";
+
+export interface AdminSyncServerOptions {
+  host: string;
+  port: number;
+  ingressSecret: string;
+  log: IngressLogger;
+  store: IngressStore;
+  secrets: IngressSecretStore;
+  runner: ProviderRunner;
+}
+
+export interface AdminSyncServer {
+  url: string;
+  close(): Promise<void>;
+}
+
+type Provider = GatewayConnection["provider"];
+
+interface GatewaySyncBody {
+  id?: unknown;
+  agentId?: unknown;
+  userId?: unknown;
+  provider?: unknown;
+  label?: unknown;
+  status?: unknown;
+  enabled?: unknown;
+  config?: unknown;
+  secret?: unknown;
+  secretRef?: unknown;
+}
+
+const PROVIDERS = new Set<Provider>(["telegram", "wechat", "feishu"]);
+const STATUSES = new Set<GatewayStatus>(["active", "disabled", "pending", "error"]);
+const MAX_BODY_BYTES = 64 * 1024;
+
+function sendJson(res: ServerResponse, status: number, body: object): void {
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+function gatewayIdFromUrl(url: string | undefined): string | null {
+  if (!url) return null;
+  const parsed = new URL(url, "http://ingress.local");
+  const m = /^\/admin\/gateways\/([^/]+)$/.exec(parsed.pathname);
+  return m ? decodeURIComponent(m[1]!) : null;
+}
+
+function requireAuth(req: IncomingMessage, ingressSecret: string): boolean {
+  if (!ingressSecret) return false;
+  const header = req.headers.authorization;
+  return header === `Bearer ${ingressSecret}`;
+}
+
+async function readBody(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of req) {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    total += buf.length;
+    if (total > MAX_BODY_BYTES) throw new Error("body_too_large");
+    chunks.push(buf);
+  }
+  const raw = Buffer.concat(chunks).toString("utf8").trim();
+  if (!raw) return {};
+  return JSON.parse(raw);
+}
+
+function stringOrUndefined(v: unknown): string | undefined {
+  return typeof v === "string" && v.trim() ? v.trim() : undefined;
+}
+
+function normalizeBody(gatewayId: string, body: GatewaySyncBody): GatewayConnection {
+  if (body.id !== undefined && body.id !== gatewayId) {
+    throw new Error("gateway_id_mismatch");
+  }
+  const agentId = stringOrUndefined(body.agentId);
+  if (!agentId) throw new Error("missing_agent_id");
+  if (!PROVIDERS.has(body.provider as Provider)) throw new Error("unsupported_provider");
+
+  const enabled = typeof body.enabled === "boolean" ? body.enabled : true;
+  const status =
+    STATUSES.has(body.status as GatewayStatus)
+      ? (body.status as GatewayStatus)
+      : enabled
+        ? "active"
+        : "disabled";
+  const config =
+    body.config && typeof body.config === "object" && !Array.isArray(body.config)
+      ? (body.config as Record<string, unknown>)
+      : {};
+  const now = Date.now();
+
+  return {
+    id: gatewayId,
+    agentId,
+    ...(stringOrUndefined(body.userId) ? { userId: stringOrUndefined(body.userId) } : {}),
+    provider: body.provider as Provider,
+    ...(stringOrUndefined(body.label) ? { label: stringOrUndefined(body.label) } : {}),
+    status,
+    enabled,
+    config,
+    ...(stringOrUndefined(body.secretRef) ? { secretRef: stringOrUndefined(body.secretRef) } : {}),
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function mergeConnection(
+  gatewayId: string,
+  current: GatewayConnection | null,
+  body: GatewaySyncBody,
+): GatewayConnection {
+  const incoming = normalizeBody(gatewayId, body);
+  return {
+    ...incoming,
+    createdAt: current?.createdAt ?? incoming.createdAt,
+    updatedAt: Date.now(),
+    secretRef: incoming.secretRef ?? current?.secretRef ?? gatewayId,
+  };
+}
+
+async function handleUpsert(
+  opts: AdminSyncServerOptions,
+  gatewayId: string,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  const parsed = await readBody(req);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    sendJson(res, 400, { ok: false, error: "invalid_body" });
+    return;
+  }
+  const body = parsed as GatewaySyncBody;
+  const current = opts.store.getConnection(gatewayId);
+  const next = mergeConnection(gatewayId, current, body);
+
+  if (body.secret !== undefined) {
+    if (body.secret === null) {
+      opts.secrets.delete(next.secretRef ?? gatewayId);
+      next.secretRef = undefined;
+    } else if (typeof body.secret === "object" && !Array.isArray(body.secret)) {
+      opts.secrets.write(next.secretRef ?? gatewayId, body.secret);
+    } else {
+      sendJson(res, 400, { ok: false, error: "invalid_secret" });
+      return;
+    }
+  } else if (!next.secretRef && current?.secretRef) {
+    next.secretRef = current.secretRef;
+  }
+
+  opts.store.upsertConnection(next);
+  const hasSecret = Boolean(next.secretRef && opts.secrets.load(next.secretRef));
+  if (next.enabled && hasSecret) {
+    await opts.runner.startOne(next);
+  } else if (next.enabled) {
+    await opts.runner.stopOne(gatewayId, "admin-sync-missing-secret");
+  } else {
+    await opts.runner.stopOne(gatewayId, "admin-sync-disabled");
+  }
+  opts.log.info("gateway sync upserted", {
+    gatewayId,
+    provider: next.provider,
+    agentId: next.agentId,
+    enabled: next.enabled,
+  });
+  sendJson(res, 200, {
+    ok: true,
+    gateway: {
+      id: next.id,
+      agentId: next.agentId,
+      provider: next.provider,
+      status: next.status,
+      enabled: next.enabled,
+      hasSecret,
+    },
+  });
+}
+
+async function handleDelete(
+  opts: AdminSyncServerOptions,
+  gatewayId: string,
+  res: ServerResponse,
+): Promise<void> {
+  const current = opts.store.getConnection(gatewayId);
+  await opts.runner.stopOne(gatewayId, "admin-sync-delete");
+  if (current?.secretRef) opts.secrets.delete(current.secretRef);
+  opts.store.deleteConnection(gatewayId);
+  opts.log.info("gateway sync deleted", { gatewayId });
+  sendJson(res, 200, { ok: true, deleted: true });
+}
+
+export async function startAdminSyncServer(
+  opts: AdminSyncServerOptions,
+): Promise<AdminSyncServer> {
+  const server: Server = createServer((req, res) => {
+    void (async () => {
+      if (!requireAuth(req, opts.ingressSecret)) {
+        sendJson(res, 401, { ok: false, error: "unauthorized" });
+        return;
+      }
+      const gatewayId = gatewayIdFromUrl(req.url);
+      if (!gatewayId) {
+        sendJson(res, 404, { ok: false, error: "not_found" });
+        return;
+      }
+      try {
+        if (req.method === "PUT") {
+          await handleUpsert(opts, gatewayId, req, res);
+          return;
+        }
+        if (req.method === "DELETE") {
+          await handleDelete(opts, gatewayId, res);
+          return;
+        }
+        sendJson(res, 405, { ok: false, error: "method_not_allowed" });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "sync_failed";
+        const status = message === "body_too_large" ? 413 : 400;
+        opts.log.warn("gateway sync request failed", { gatewayId, err: message });
+        sendJson(res, status, { ok: false, error: message });
+      }
+    })();
+  });
+
+  const url = await new Promise<string>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(opts.port, opts.host, () => {
+      const addr = server.address();
+      if (addr && typeof addr === "object") {
+        resolve(`http://${opts.host}:${addr.port}`);
+      } else {
+        resolve(`http://${opts.host}:${opts.port}`);
+      }
+    });
+  });
+
+  opts.log.info("ingress admin sync server", { url });
+  return {
+    url,
+    async close(): Promise<void> {
+      await new Promise<void>((res) => server.close(() => res()));
+    },
+  };
+}

--- a/packages/gateway-ingress/src/cli.ts
+++ b/packages/gateway-ingress/src/cli.ts
@@ -15,6 +15,7 @@ async function main(): Promise<void> {
     hubUrl: config.hubUrl,
     dataDir: config.dataDir,
     healthPort: config.healthPort,
+    adminPort: config.adminPort,
   });
   const service = await startIngress({ config });
 

--- a/packages/gateway-ingress/src/config.ts
+++ b/packages/gateway-ingress/src/config.ts
@@ -18,6 +18,10 @@ export interface IngressConfig {
   healthPort: number;
   /** Health server bind host. */
   healthHost: string;
+  /** Admin sync server bind port; 0 to disable. */
+  adminPort: number;
+  /** Admin sync server bind host. */
+  adminHost: string;
   /** Optional override for the runtime WS endpoint advertised by Hub. */
   runtimeEndpointOverride?: string;
   /**
@@ -39,6 +43,8 @@ export function loadConfigFromEnv(env: NodeJS.ProcessEnv = process.env): Ingress
   const secretDir = resolve(env.BOTCORD_INGRESS_SECRET_DIR ?? join(home, DEFAULT_SECRET_DIR));
   const healthPort = Number(env.BOTCORD_INGRESS_HEALTH_PORT ?? "9100");
   const healthHost = env.BOTCORD_INGRESS_HEALTH_HOST ?? "127.0.0.1";
+  const adminPort = Number(env.BOTCORD_INGRESS_ADMIN_PORT ?? "0");
+  const adminHost = env.BOTCORD_INGRESS_ADMIN_HOST ?? "127.0.0.1";
   const runtimeEndpointOverride = env.BOTCORD_INGRESS_RUNTIME_ENDPOINT;
   const dedupeCapacity = Number(env.BOTCORD_INGRESS_DEDUPE_CAPACITY ?? "1024");
   return {
@@ -48,6 +54,8 @@ export function loadConfigFromEnv(env: NodeJS.ProcessEnv = process.env): Ingress
     secretDir,
     healthPort: Number.isFinite(healthPort) ? healthPort : 0,
     healthHost,
+    adminPort: Number.isFinite(adminPort) ? adminPort : 0,
+    adminHost,
     ...(runtimeEndpointOverride ? { runtimeEndpointOverride } : {}),
     dedupeCapacity: Number.isFinite(dedupeCapacity) && dedupeCapacity > 0 ? dedupeCapacity : 1024,
   };

--- a/packages/gateway-ingress/src/index.ts
+++ b/packages/gateway-ingress/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./admin-sync.js";
 export * from "./config.js";
 export * from "./hub-client.js";
 export * from "./log.js";

--- a/packages/gateway-ingress/src/service.ts
+++ b/packages/gateway-ingress/src/service.ts
@@ -1,4 +1,5 @@
 import type { IngressConfig } from "./config.js";
+import { startAdminSyncServer, type AdminSyncServer } from "./admin-sync.js";
 import { createHubClient } from "./hub-client.js";
 import type { HubClient } from "./hub-client.js";
 import { startHealthServer, type HealthServer } from "./health.js";
@@ -24,6 +25,7 @@ export interface IngressService {
   orchestrator: IngressOrchestrator;
   runner: ProviderRunner;
   health: HealthServer | null;
+  admin: AdminSyncServer | null;
   config: IngressConfig;
   log: IngressLogger;
   shutdown(reason?: string): Promise<void>;
@@ -39,6 +41,8 @@ export interface BuildIngressOptions {
   factories?: Record<string, ProviderAdapterFactory>;
   /** Start the HTTP health server. Defaults to true when `config.healthPort > 0`. */
   startHealth?: boolean;
+  /** Start the HTTP admin sync server. Defaults to true when `config.adminPort > 0`. */
+  startAdmin?: boolean;
 }
 
 /** Construct the service graph without starting any provider loops. */
@@ -117,6 +121,20 @@ export async function buildIngressService(
     });
   }
 
+  const startAdmin = opts.startAdmin ?? opts.config.adminPort > 0;
+  let admin: AdminSyncServer | null = null;
+  if (startAdmin) {
+    admin = await startAdminSyncServer({
+      host: opts.config.adminHost,
+      port: opts.config.adminPort,
+      ingressSecret: opts.config.ingressSecret,
+      log,
+      store,
+      secrets,
+      runner,
+    });
+  }
+
   const service: IngressService = {
     store,
     secrets,
@@ -125,12 +143,14 @@ export async function buildIngressService(
     orchestrator,
     runner,
     health,
+    admin,
     config: opts.config,
     log,
     async shutdown(reason = "shutdown"): Promise<void> {
       await runner.stopAll(reason);
       await runtime.closeAll(reason);
       await health?.close();
+      await admin?.close();
     },
   };
   return service;


### PR DESCRIPTION
## Summary
- add Hub runtime WebSocket relay for cloud gateway ingress frames
- add daemon runtime inbound injection path through the existing gateway dispatcher
- add gateway-ingress admin sync server for cloud gateway metadata/secret mirroring
- improve cloud channel UI copy and Feishu edit config handling

## Tests
- cd packages/gateway-ingress && npm test -- --run
- cd packages/gateway-ingress && npm run build
- cd packages/daemon && npm test -- --run src/__tests__/cloud-gateway-runtime.test.ts src/__tests__/cloud-daemon.test.ts src/__tests__/gateway-control.test.ts
- cd packages/daemon && npm run build
- cd backend && uv run pytest tests/test_cloud_gateway_internal.py tests/test_app/test_app_gateways.py
- cd frontend && NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy-anon-key npm run build
- git diff --check