### PR TITLE
feat: add cloud device restart control

### DIFF
--- a/backend/hub/routers/daemon_control.py
+++ b/backend/hub/routers/daemon_control.py
@@ -616,7 +616,7 @@ async def list_instances(
         select(DaemonInstance)
         .where(
             DaemonInstance.user_id == ctx.user_id,
-            DaemonInstance.kind == "local",
+            DaemonInstance.kind.in_(("local", "cloud")),
         )
         .order_by(DaemonInstance.created_at.desc())
     )
@@ -653,6 +653,34 @@ async def rename_instance(
     new_label = body.label.strip() if isinstance(body.label, str) else None
     instance.label = new_label or None
     await db.commit()
+    await db.refresh(instance)
+    return _instance_to_view(instance)
+
+
+@router.post("/daemon/instances/{daemon_instance_id}/restart", response_model=_InstanceView)
+async def restart_instance(
+    daemon_instance_id: str,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+) -> _InstanceView:
+    instance = await _load_owned_instance(db, ctx.user_id, daemon_instance_id)
+    if instance.kind != "cloud":
+        raise HTTPException(status_code=409, detail="restart_only_supported_for_cloud_daemon")
+
+    from hub.services.cloud_agent import CloudAgentError, CloudAgentService
+
+    try:
+        await CloudAgentService().restart_cloud_daemon(
+            db,
+            user_id=ctx.user_id,
+            daemon_instance_id=daemon_instance_id,
+        )
+    except CloudAgentError as exc:
+        raise HTTPException(
+            status_code=exc.http_status,
+            detail={"code": exc.code, "message": exc.message},
+        ) from exc
+
     await db.refresh(instance)
     return _instance_to_view(instance)
 

--- a/backend/hub/services/cloud_agent.py
+++ b/backend/hub/services/cloud_agent.py
@@ -630,6 +630,136 @@ class CloudAgentService:
         await db.refresh(cdi)
         return _make_view(agent, cai, cdi)
 
+    async def restart_cloud_daemon(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: uuid.UUID,
+        daemon_instance_id: str,
+    ) -> None:
+        """Restart the cloud daemon/sandbox owned by ``user_id``.
+
+        This is a daemon-level operation: one cloud daemon can host multiple
+        Cloud Agents, so all ready/provisioning agents on the sandbox are
+        marked for reprovisioning before the provider relaunches the process.
+        """
+        self._require_feature_enabled()
+        row = (
+            await db.execute(
+                select(CloudDaemonInstance, DaemonInstance)
+                .join(
+                    DaemonInstance,
+                    DaemonInstance.id == CloudDaemonInstance.daemon_instance_id,
+                )
+                .where(
+                    CloudDaemonInstance.daemon_instance_id == daemon_instance_id,
+                    CloudDaemonInstance.user_id == user_id,
+                    DaemonInstance.user_id == user_id,
+                )
+            )
+        ).one_or_none()
+        if row is None:
+            raise CloudAgentError(
+                "not_found",
+                f"cloud daemon for daemon instance {daemon_instance_id!r} not found",
+                http_status=404,
+            )
+        cdi, daemon_row = row
+        if cdi.status in {"deleted", "deleting"}:
+            raise CloudAgentError(
+                "invalid_state",
+                f"cannot restart cloud daemon in status {cdi.status!r}",
+                http_status=409,
+            )
+        if await self._cloud_daemon_has_active_run(db, cdi.id):
+            raise CloudAgentError(
+                "active_run",
+                "cannot restart cloud daemon while a cloud agent run is active",
+                http_status=409,
+            )
+
+        agent_rows = (
+            await db.execute(
+                select(CloudAgentInstance, Agent)
+                .join(Agent, Agent.agent_id == CloudAgentInstance.agent_id)
+                .where(
+                    CloudAgentInstance.cloud_daemon_instance_id == cdi.id,
+                    CloudAgentInstance.user_id == user_id,
+                    CloudAgentInstance.status.notin_(("deleted", "deleting")),
+                )
+            )
+        ).all()
+        if not agent_rows:
+            raise CloudAgentError(
+                "no_agents",
+                "cloud daemon has no active agents to restart",
+                http_status=409,
+            )
+
+        for cai, agent in agent_rows:
+            if cai.status in {"ready", "provisioning", "failed", "paused"}:
+                _ensure_provisioning_metadata(db, cai, agent)
+                cai.status = "provisioning"
+                cai.error_code = None
+                cai.error_message = None
+        cdi.status = "starting"
+        cdi.error_code = None
+        cdi.error_message = None
+        await db.commit()
+
+        provider = self._get_provider()
+        try:
+            handle = await provider.create_or_resume(
+                cloud_daemon_instance_id=cdi.id,
+                daemon_instance_id=daemon_row.id,
+                user_id=str(user_id),
+                runtime=cdi.runtime,
+                provider_sandbox_id=cdi.provider_sandbox_id,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception(
+                "cloud daemon restart failed: cloud=%s err=%s",
+                cdi.id,
+                exc,
+            )
+            cdi.status = "failed"
+            cdi.error_code = "provider_restart_failed"
+            cdi.error_message = str(exc)
+            for cai, _agent in agent_rows:
+                cai.status = "failed"
+                cai.error_code = "provider_restart_failed"
+                cai.error_message = str(exc)
+            await db.commit()
+            raise CloudAgentError(
+                "provider_restart_failed",
+                f"cloud daemon provider failed: {exc}",
+                http_status=502,
+            ) from exc
+
+        _apply_handle_to_rows(cdi, handle)
+        cdi.last_started_at = _now()
+        if handle.status == "failed":
+            for cai, _agent in agent_rows:
+                cai.status = "failed"
+                cai.error_code = handle.error_code
+                cai.error_message = handle.error_message
+                _scrub_provisioning_metadata(cai)
+        elif handle.status == "ready":
+            for cai, _agent in agent_rows:
+                cai.status = "ready"
+                cai.error_code = None
+                cai.error_message = None
+                _scrub_provisioning_metadata(cai)
+        await db.commit()
+
+        if handle.status == "failed":
+            raise CloudAgentError(
+                handle.error_code or "provider_restart_failed",
+                handle.error_message
+                or "cloud daemon provider reported restart failure",
+                http_status=502,
+            )
+
     async def delete_cloud_agent(
         self,
         db: AsyncSession,

--- a/backend/tests/test_app/test_daemon_control.py
+++ b/backend/tests/test_app/test_daemon_control.py
@@ -421,7 +421,7 @@ async def test_list_instances(client: AsyncClient, seed_user):
 
 
 @pytest.mark.asyncio
-async def test_list_instances_hides_cloud_daemons(
+async def test_list_instances_includes_cloud_daemons(
     client: AsyncClient, seed_user, db_session: AsyncSession
 ):
     local_bundle = await _provision_instance_via_device_code(client, seed_user)
@@ -452,8 +452,56 @@ async def test_list_instances_hides_cloud_daemons(
         headers={"Authorization": f"Bearer {seed_user['token']}"},
     )
     assert r.status_code == 200, r.text
-    ids = [entry["id"] for entry in r.json()["instances"]]
-    assert ids == [local_bundle["daemon_instance_id"]]
+    by_id = {entry["id"]: entry for entry in r.json()["instances"]}
+    assert set(by_id) == {cloud_daemon_row.id, local_bundle["daemon_instance_id"]}
+    assert by_id[cloud_daemon_row.id]["kind"] == "cloud"
+    assert by_id[local_bundle["daemon_instance_id"]]["kind"] == "local"
+
+
+@pytest.mark.asyncio
+async def test_restart_cloud_daemon_instance(
+    client: AsyncClient, seed_user, db_session: AsyncSession, monkeypatch
+):
+    cloud_daemon_row = DaemonInstance(
+        id="dm_cloudrestart",
+        user_id=seed_user["user_id"],
+        label="cloud-deepseek-tui",
+        kind="cloud",
+        refresh_token_hash="z" * 64,
+    )
+    db_session.add(cloud_daemon_row)
+    db_session.add(
+        CloudDaemonInstance(
+            id="cloud_dm_restart",
+            user_id=seed_user["user_id"],
+            daemon_instance_id=cloud_daemon_row.id,
+            provider="fake",
+            runtime="deepseek-tui",
+            status="ready",
+            max_agents=3,
+            active_agent_count=1,
+        )
+    )
+    await db_session.commit()
+
+    calls = []
+
+    class FakeCloudAgentService:
+        async def restart_cloud_daemon(self, db, *, user_id, daemon_instance_id):
+            calls.append((user_id, daemon_instance_id))
+
+    import hub.services.cloud_agent as cloud_agent_mod
+
+    monkeypatch.setattr(cloud_agent_mod, "CloudAgentService", FakeCloudAgentService)
+
+    r = await client.post(
+        f"/daemon/instances/{cloud_daemon_row.id}/restart",
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["id"] == cloud_daemon_row.id
+    assert r.json()["kind"] == "cloud"
+    assert calls == [(seed_user["user_id"], cloud_daemon_row.id)]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_cloud_agent_service.py
+++ b/backend/tests/test_cloud_agent_service.py
@@ -349,6 +349,43 @@ async def test_pause_then_resume_round_trip(db_session):
 
 
 @pytest.mark.asyncio
+async def test_restart_cloud_daemon_restarts_shared_sandbox(db_session):
+    user_id = uuid.uuid4()
+    svc, fake = _make_service(max_per_user=4, max_agents_per_daemon=2)
+    a = await svc.create_cloud_agent(
+        db_session, user_id=user_id, body=CreateCloudAgentInput(name="A")
+    )
+    b = await svc.create_cloud_agent(
+        db_session, user_id=user_id, body=CreateCloudAgentInput(name="B")
+    )
+    assert a.cloud_daemon_instance_id == b.cloud_daemon_instance_id
+    assert fake.calls(a.cloud_daemon_instance_id)["create"] == 2
+    daemon_instance_id = await db_session.scalar(
+        select(CloudDaemonInstance.daemon_instance_id).where(
+            CloudDaemonInstance.id == a.cloud_daemon_instance_id
+        )
+    )
+    assert daemon_instance_id is not None
+
+    await svc.restart_cloud_daemon(
+        db_session,
+        user_id=user_id,
+        daemon_instance_id=daemon_instance_id,
+    )
+
+    rows = (
+        await db_session.execute(
+            select(CloudAgentInstance).where(
+                CloudAgentInstance.cloud_daemon_instance_id == a.cloud_daemon_instance_id
+            )
+        )
+    ).scalars().all()
+    assert {row.agent_id for row in rows} == {a.agent_id, b.agent_id}
+    assert {row.status for row in rows} == {"ready"}
+    assert fake.calls(a.cloud_daemon_instance_id)["create"] == 3
+
+
+@pytest.mark.asyncio
 async def test_pause_idempotent(db_session):
     user_id = uuid.uuid4()
     svc, fake = _make_service()

--- a/frontend/src/components/dashboard/DeviceDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/DeviceDetailDrawer.tsx
@@ -6,6 +6,7 @@ import {
   Check,
   ChevronDown,
   ChevronRight,
+  Cloud,
   Cpu,
   Download,
   FileArchive,
@@ -35,9 +36,11 @@ export default function DeviceDetailDrawer() {
     diagnosticResults,
     collectingDiagnosticsId,
     removingId,
+    restartingId,
     refresh,
     rename,
     removeDevice,
+    restartDevice,
     refreshRuntimes,
     collectDiagnostics,
   } = useDaemonStore(
@@ -46,9 +49,11 @@ export default function DeviceDetailDrawer() {
       diagnosticResults: s.diagnosticResults,
       collectingDiagnosticsId: s.collectingDiagnosticsId,
       removingId: s.removingId,
+      restartingId: s.restartingId,
       refresh: s.refresh,
       rename: s.rename,
       removeDevice: s.removeDevice,
+      restartDevice: s.restartDevice,
       refreshRuntimes: s.refreshRuntimes,
       collectDiagnostics: s.collectDiagnostics,
     })),
@@ -104,6 +109,8 @@ export default function DeviceDetailDrawer() {
   if (!open || !device) return null;
 
   const online = device.status === "online";
+  const isCloud = device.kind === "cloud";
+  const DeviceIcon = isCloud ? Cloud : Cpu;
   const statusLabel =
     device.status === "online" ? "在线"
     : device.status === "offline" ? "离线"
@@ -121,7 +128,11 @@ export default function DeviceDetailDrawer() {
   const handleRefresh = async () => {
     setIsRefreshing(true);
     try {
-      await refreshRuntimes(device.id);
+      if (isCloud) {
+        await refresh({ quiet: true });
+      } else {
+        await refreshRuntimes(device.id);
+      }
     } finally {
       setIsRefreshing(false);
     }
@@ -142,6 +153,15 @@ export default function DeviceDetailDrawer() {
     ]);
     setSelectedDeviceId(null);
   };
+  const handleRestartDevice = async () => {
+    const ok = await restartDevice(device.id);
+    if (ok) {
+      await Promise.all([
+        refresh({ quiet: true }),
+        refreshUserProfile(),
+      ]);
+    }
+  };
 
   return (
     <>
@@ -160,13 +180,18 @@ export default function DeviceDetailDrawer() {
         {/* Drawer header */}
         <div className="flex items-center gap-3 border-b border-glass-border px-5 py-4">
           <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-glass-border bg-glass-bg/60 text-text-secondary">
-            <Cpu className="h-5 w-5" />
+            <DeviceIcon className="h-5 w-5" />
           </div>
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
               <h2 className="truncate text-base font-semibold text-text-primary">
-                {device.label || device.id}
+                {device.label || (isCloud ? "BotCord Cloud Device" : device.id)}
               </h2>
+              {isCloud ? (
+                <span className="rounded-full border border-neon-cyan/30 bg-neon-cyan/10 px-1.5 py-px text-[10px] text-neon-cyan">
+                  Cloud
+                </span>
+              ) : null}
               <span
                 className={`flex items-center gap-1 rounded-full border px-1.5 py-px text-[10px] ${
                   online
@@ -276,8 +301,38 @@ export default function DeviceDetailDrawer() {
               </span>
             </Row>
           ) : null}
+          {isCloud ? (
+            <Row label="托管类型">
+              <span className="text-xs text-neon-cyan">BotCord Cloud</span>
+            </Row>
+          ) : null}
         </div>
       </section>
+
+      {isCloud ? (
+        <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
+          <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-wider text-text-secondary/70">
+            云设备操作
+          </h3>
+          <div className="space-y-3">
+            <p className="text-[11px] leading-relaxed text-text-secondary/65">
+              重启会重新启动这台云设备上的 daemon，并重新连接所有托管 Bot。
+            </p>
+            <button
+              onClick={() => void handleRestartDevice()}
+              disabled={restartingId === device.id}
+              className="inline-flex items-center gap-2 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-2 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/15 disabled:opacity-50"
+            >
+              {restartingId === device.id ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <RefreshCw className="h-3.5 w-3.5" />
+              )}
+              {restartingId === device.id ? "重启中..." : "重启云设备"}
+            </button>
+          </div>
+        </section>
+      ) : null}
 
       {/* Rename */}
       <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
@@ -309,6 +364,7 @@ export default function DeviceDetailDrawer() {
       </section>
 
       {/* Restart command (collapsible) */}
+      {!isCloud ? (
       <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
         <button
           onClick={() => setShowInstall((v) => !v)}
@@ -336,8 +392,10 @@ export default function DeviceDetailDrawer() {
           </div>
         ) : null}
       </section>
+      ) : null}
 
       {/* Diagnostic log (collapsible) */}
+      {!isCloud ? (
       <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
         <button
           onClick={() => setShowLogs((v) => !v)}
@@ -405,8 +463,10 @@ export default function DeviceDetailDrawer() {
           </div>
         ) : null}
       </section>
+      ) : null}
 
       {/* Danger zone */}
+      {!isCloud ? (
       <section className="rounded-2xl border border-red-500/25 bg-red-500/5 p-5">
         <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-wider text-red-300/85">
           危险操作
@@ -460,6 +520,7 @@ export default function DeviceDetailDrawer() {
           </div>
         )}
       </section>
+      ) : null}
       </>)}
       </div>
       </aside>

--- a/frontend/src/components/dashboard/MyDevicesView.tsx
+++ b/frontend/src/components/dashboard/MyDevicesView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import { ChevronRight, Cpu } from "lucide-react";
+import { ChevronRight, Cloud, Cpu } from "lucide-react";
 import { useShallow } from "zustand/shallow";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
@@ -51,7 +51,9 @@ export default function MyDevicesView() {
         <div className="flex flex-col gap-3">
           {visibleDaemons.map((device) => {
             const online = device.status === "online";
+            const isCloud = device.kind === "cloud";
             const bots = botsByDevice.get(device.id) ?? [];
+            const DeviceIcon = isCloud ? Cloud : Cpu;
             return (
               <button
                 key={device.id}
@@ -61,13 +63,18 @@ export default function MyDevicesView() {
                 <div className="flex items-start justify-between gap-4">
                   <div className="flex min-w-0 items-start gap-3">
                     <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-glass-border bg-glass-bg/60 text-text-secondary">
-                      <Cpu className="h-5 w-5" />
+                      <DeviceIcon className="h-5 w-5" />
                     </div>
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-2">
                         <h2 className="truncate text-base font-semibold text-text-primary">
-                          {device.label || device.id}
+                          {device.label || (isCloud ? "BotCord Cloud Device" : device.id)}
                         </h2>
+                        {isCloud ? (
+                          <span className="rounded-full border border-neon-cyan/30 bg-neon-cyan/10 px-1.5 py-px text-[10px] text-neon-cyan">
+                            Cloud
+                          </span>
+                        ) : null}
                         <span
                           className={`flex items-center gap-1 rounded-full border px-1.5 py-px text-[10px] ${
                             online

--- a/frontend/src/store/useDaemonStore.ts
+++ b/frontend/src/store/useDaemonStore.ts
@@ -187,6 +187,7 @@ interface DaemonState {
   error: string | null;
   revokingId: string | null;
   removingId: string | null;
+  restartingId: string | null;
   renamingId: string | null;
   refreshingRuntimesId: string | null;
   collectingDiagnosticsId: string | null;
@@ -201,6 +202,7 @@ interface DaemonState {
     id: string,
     opts?: { forgetIfOffline?: boolean; reason?: string },
   ) => Promise<RemoveDeviceResult>;
+  restartDevice: (id: string) => Promise<boolean>;
   rename: (id: string, label: string | null) => Promise<boolean>;
   refreshRuntimes: (id: string, opts?: { quiet?: boolean }) => Promise<void>;
   collectDiagnostics: (id: string) => Promise<DiagnosticBundleResult | null>;
@@ -218,6 +220,7 @@ const initialState = {
   error: null as string | null,
   revokingId: null as string | null,
   removingId: null as string | null,
+  restartingId: null as string | null,
   renamingId: null as string | null,
   refreshingRuntimesId: null as string | null,
   collectingDiagnosticsId: null as string | null,
@@ -723,6 +726,43 @@ export const useDaemonStore = create<DaemonState>()((set, get) => ({
         error: state.error ?? err.message,
       }));
       throw err;
+    }
+  },
+
+  restartDevice: async (id) => {
+    set({ restartingId: id, error: null });
+    try {
+      const res = await apiFetch(
+        `/daemon/instances/${encodeURIComponent(id)}/restart`,
+        { method: "POST" },
+      );
+      if (!res.ok) {
+        const msg = await parseError(res);
+        set({ restartingId: null, error: msg });
+        return false;
+      }
+      const data = (await res.json().catch(() => null)) as
+        | Record<string, unknown>
+        | null;
+      const next = data ? normalizeDaemon(data) : null;
+      set((state) => ({
+        daemons: state.daemons.map((d) =>
+          d.id === id
+            ? next
+              ? { ...d, ...next }
+              : { ...d, status: "offline" }
+            : d,
+        ),
+        restartingId: null,
+      }));
+      void get().refresh({ quiet: true });
+      return true;
+    } catch (err) {
+      set({
+        restartingId: null,
+        error: err instanceof Error ? err.message : "Failed to restart device",
+      });
+      return false;
     }
   },
 


### PR DESCRIPTION
## Summary
- include cloud daemon devices in the dashboard device list
- add a cloud daemon restart endpoint that relaunches the sandbox daemon via the provider
- add a cloud device restart button in device details

## Tests
- cd backend && uv run pytest tests/test_cloud_agent_service.py -q
- cd backend && uv run pytest tests/test_app/test_daemon_control.py::test_restart_cloud_daemon_instance tests/test_app/test_daemon_control.py::test_list_instances_includes_cloud_daemons tests/test_cloud_agent_service.py::test_restart_cloud_daemon_restarts_shared_sandbox -q
- cd frontend && NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy pnpm build