### PR TITLE
fix: refresh cloud daemon runtimes

### DIFF
--- a/backend/hub/routers/daemon_control.py
+++ b/backend/hub/routers/daemon_control.py
@@ -73,6 +73,7 @@ from hub.id_generators import (
 )
 from hub.models import (
     Agent,
+    CloudDaemonInstance,
     DaemonAgentCleanup,
     DaemonDiagnosticBundle,
     DaemonDeviceCode,
@@ -1132,6 +1133,71 @@ async def refresh_instance_runtimes(
     instance = await _load_owned_instance(db, ctx.user_id, daemon_instance_id)
     if instance.revoked_at is not None:
         raise HTTPException(status_code=409, detail="daemon_revoked")
+
+    if instance.kind == "cloud":
+        cloud_row = await db.scalar(
+            select(CloudDaemonInstance).where(
+                CloudDaemonInstance.daemon_instance_id == daemon_instance_id,
+                CloudDaemonInstance.user_id == ctx.user_id,
+            )
+        )
+        if cloud_row is None:
+            raise HTTPException(status_code=409, detail="daemon_offline")
+
+        from hub.routers.cloud_daemon_control import (
+            CloudDaemonDispatchError,
+            send_cloud_control_frame,
+        )
+
+        try:
+            ack = await send_cloud_control_frame(
+                cloud_row.id,
+                "list_runtimes",
+                {},
+                timeout_ms=_REFRESH_RUNTIMES_TIMEOUT_MS,
+            )
+        except CloudDaemonDispatchError as exc:
+            if exc.code == "cloud_daemon_offline":
+                raise HTTPException(status_code=409, detail="daemon_offline") from exc
+            if exc.code == "cloud_daemon_ack_timeout":
+                raise HTTPException(status_code=504, detail="daemon_ack_timeout") from exc
+            raise HTTPException(
+                status_code=502,
+                detail={"code": exc.code, "daemon_message": exc.message},
+            ) from exc
+
+        if not isinstance(ack, dict) or not ack.get("ok"):
+            err = ack.get("error") if isinstance(ack, dict) else None
+            code = (err or {}).get("code") if isinstance(err, dict) else None
+            message = (err or {}).get("message") if isinstance(err, dict) else None
+            raise HTTPException(
+                status_code=502,
+                detail={
+                    "code": "upstream_error",
+                    "daemon_code": code,
+                    "daemon_message": message,
+                },
+            )
+
+        result = ack.get("result") if isinstance(ack.get("result"), dict) else None
+        persisted = None
+        if result is not None:
+            persisted = await _persist_runtime_snapshot(db, instance, result)
+        if persisted is None:
+            raise HTTPException(
+                status_code=502,
+                detail={
+                    "code": "upstream_error",
+                    "daemon_message": "malformed runtime snapshot",
+                },
+            )
+        await db.commit()
+
+        runtimes, probed_dt = persisted
+        return _RefreshRuntimesResponse(
+            runtimes=runtimes,
+            runtimes_probed_at=probed_dt,
+        )
 
     conn = _REGISTRY.get(daemon_instance_id)
     if conn is None:

--- a/backend/tests/test_app/test_daemon_control.py
+++ b/backend/tests/test_app/test_daemon_control.py
@@ -1283,6 +1283,97 @@ async def test_refresh_runtimes_success_persists_and_returns(
 
 
 @pytest.mark.asyncio
+async def test_refresh_runtimes_cloud_daemon_uses_cloud_registry(
+    client: AsyncClient, seed_user, db_session: AsyncSession
+):
+    from sqlalchemy import select
+
+    from hub.routers.cloud_daemon_control import (
+        _CloudDaemonConn,
+        _registry_for_tests as _cloud_registry_for_tests,
+    )
+
+    bundle = await _provision_instance_via_device_code(client, seed_user)
+    instance_id = bundle["daemon_instance_id"]
+    cloud_id = "cloud_dm_refresh_test"
+    daemon = await db_session.scalar(
+        select(DaemonInstance).where(DaemonInstance.id == instance_id)
+    )
+    assert daemon is not None
+    daemon.kind = "cloud"
+    db_session.add(
+        CloudDaemonInstance(
+            id=cloud_id,
+            user_id=seed_user["user_id"],
+            daemon_instance_id=instance_id,
+            provider="e2b",
+            runtime="deepseek-tui",
+            status="ready",
+            max_agents=3,
+        )
+    )
+    await db_session.commit()
+
+    fake_ws = _FakeWS()
+    conn = _CloudDaemonConn(
+        ws=fake_ws,  # type: ignore[arg-type]
+        user_id=str(seed_user["user_id"]),
+        cloud_daemon_instance_id=cloud_id,
+        daemon_instance_id=instance_id,
+        pending_acks={},
+    )
+    registry = _cloud_registry_for_tests()
+    await registry.register(conn)
+    try:
+        probed_at = _probed_now_ms()
+        runtimes = [
+            {
+                "id": "deepseek-tui",
+                "available": True,
+                "models": [{"id": "deepseek-v4-flash", "source": "builtin"}],
+                "parameters": [{"id": "reasoning_effort", "type": "string"}],
+            },
+        ]
+
+        async def _reply_when_sent() -> None:
+            for _ in range(100):
+                if fake_ws.sent:
+                    break
+                await asyncio.sleep(0.01)
+            assert fake_ws.sent
+            sent = json.loads(fake_ws.sent[0])
+            assert sent["type"] == "list_runtimes"
+            fut = conn.pending_acks.get(sent["id"])
+            assert fut is not None
+            fut.set_result(
+                {
+                    "id": sent["id"],
+                    "ok": True,
+                    "result": {"runtimes": runtimes, "probedAt": probed_at},
+                }
+            )
+
+        reply_task = asyncio.create_task(_reply_when_sent())
+        r = await client.post(
+            f"/daemon/instances/{instance_id}/refresh-runtimes",
+            headers={"Authorization": f"Bearer {seed_user['token']}"},
+        )
+        await reply_task
+        assert r.status_code == 200, r.text
+        assert r.json()["runtimes"] == runtimes
+
+        await db_session.commit()
+        refreshed = await db_session.scalar(
+            select(DaemonInstance).where(DaemonInstance.id == instance_id)
+        )
+        assert refreshed is not None
+        assert refreshed.runtimes_json == runtimes
+        assert refreshed.runtimes_probed_at is not None
+    finally:
+        await registry.unregister(conn)
+
+
+@pytest.mark.asyncio
 async def test_refresh_runtimes_daemon_ack_error_returns_502(
     client: AsyncClient, seed_user
 ):


### PR DESCRIPTION
## Summary
- route runtime refresh for cloud daemon instances through the cloud daemon control registry
- persist the returned runtime snapshot so DeepSeek model/parameter catalogs can be refreshed without restarting the sandbox
- add regression coverage for cloud daemon runtime refresh

## Tests
- cd backend && uv run pytest tests/test_app/test_daemon_control.py -k "refresh_runtimes"