### PR TITLE
fix: keep composing prose coupled to tool card expand state

### DIFF
--- a/frontend/src/components/dashboard/StreamBlocksView.test.ts
+++ b/frontend/src/components/dashboard/StreamBlocksView.test.ts
@@ -24,21 +24,40 @@ function mixedToolUseBlock(): StreamBlockEntry {
 }
 
 describe("StreamBlocksView", () => {
-  it("does not render composing text for delivered execution blocks by default", () => {
+  it("hides composing text when the tool card is collapsed (default)", () => {
     const html = renderToStaticMarkup(
-      React.createElement(StreamBlocksView, { blocks: [mixedToolUseBlock()] }),
+      React.createElement(StreamBlocksView, {
+        blocks: [mixedToolUseBlock()],
+        showComposing: true,
+      }),
     );
 
     expect(html).not.toContain("Composing");
     expect(html).not.toContain("draft answer");
   });
 
-  it("renders composing text when explicitly used for an active stream", () => {
+  it("renders composing text inside the expanded tool card", () => {
     const html = renderToStaticMarkup(
-      React.createElement(StreamBlocksView, { blocks: [mixedToolUseBlock()], showComposing: true }),
+      React.createElement(StreamBlocksView, {
+        blocks: [mixedToolUseBlock()],
+        showComposing: true,
+        defaultExpanded: true,
+      }),
     );
 
     expect(html).toContain("Composing");
     expect(html).toContain("draft answer");
+  });
+
+  it("does not render composing text when showComposing is off, even if expanded", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(StreamBlocksView, {
+        blocks: [mixedToolUseBlock()],
+        defaultExpanded: true,
+      }),
+    );
+
+    expect(html).not.toContain("Composing");
+    expect(html).not.toContain("draft answer");
   });
 });

--- a/frontend/src/components/dashboard/StreamBlocksView.tsx
+++ b/frontend/src/components/dashboard/StreamBlocksView.tsx
@@ -835,18 +835,17 @@ export default function StreamBlocksView({
                     toolNameById={toolNameById}
                   />
                 ))}
+                {composingText && (
+                  <div className="py-2">
+                    <div className="mb-1 flex items-center gap-1.5">
+                      <Bot className="w-3 h-3 text-zinc-400" />
+                      <span className="text-xs text-zinc-400">Composing...</span>
+                    </div>
+                    <MarkdownContent content={composingText} />
+                  </div>
+                )}
               </div>
             )}
-          </div>
-        )}
-
-        {composingText && (
-          <div className="rounded-lg px-3 py-2 bg-zinc-800 border border-zinc-700 text-sm text-zinc-200">
-            <div className="mb-1 flex items-center gap-1.5">
-              <Bot className="w-3 h-3 text-zinc-400" />
-              <span className="text-xs text-zinc-400">Composing...</span>
-            </div>
-            <MarkdownContent content={composingText} />
           </div>
         )}
       </div>

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -553,7 +553,11 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
             <div key={msg.clientId} className="space-y-1.5">
               {/* Finalized execution blocks above agent message */}
               {!isUser && msg.streamBlocks.length > 0 && (
-                <StreamBlocksView key={`${msg.clientId}-delivered`} blocks={msg.streamBlocks} />
+                <StreamBlocksView
+                  key={`${msg.clientId}-delivered`}
+                  blocks={msg.streamBlocks}
+                  showComposing
+                />
               )}
               {hasVisibleBubble && (
                 <div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>


### PR DESCRIPTION
## Summary

- Move the owner-chat composing prose into the expandable tool card body so it shares the same expand/collapse state as `tool_call`/`tool_result` rows
- Pass `showComposing` to the delivered `<StreamBlocksView>` in `UserChatPane` so users can still see the full prose-with-tool-calls trace when they expand a finalized message
- Update `StreamBlocksView.test.ts` to reflect the new coupling (collapsed → no composing, expanded + `showComposing` → composing inside the tool panel)

## Why

PR #788 (`864f94b5f fix: hide owner-chat composing after final message`) hid composing prose unconditionally for delivered owner-chat messages and the delivered `<StreamBlocksView>` doesn't pass `defaultExpanded`. After finalization the user only saw a collapsed `"N tool calls"` summary plus the final answer bubble — looked like the entire intermediate runtime trace (assistant text + tool calls + tool results) had disappeared.

Coupling composing to the card's expanded state restores the trace when the user opens the panel while still preventing the double-rendering of the final answer that #788 originally fixed.

## Test plan

- [x] `pnpm vitest run src/components/dashboard/StreamBlocksView.test.ts` — 3 tests pass
- [ ] Manual: send an owner-chat message that triggers tool calls; verify (a) streaming view shows composing alongside tool blocks, (b) on finalize the card auto-collapses and composing hides with it, (c) clicking the collapsed `"N tool calls"` chip re-reveals both tool rows and composing prose

🤖 Generated with [Claude Code](https://claude.com/claude-code)