### PR TITLE
fix(cloud-gateway): repair ingress contract mismatches from PR #794

### DIFF
--- a/backend/app/routers/gateways.py
+++ b/backend/app/routers/gateways.py
@@ -596,10 +596,14 @@ async def _upsert_mirror_from_ingress(
         ingress_connection.get("status"),
         default="active" if enabled else "disabled",
     )
-    config = _filter_mirror_config(ingress_connection.get("config_json"))
+    # redactConnection() in ingress returns the live field name `config`;
+    # older callers used `config_json`. Try both before falling back to
+    # top-level metadata.
+    config_source = ingress_connection.get("config_json")
+    if not isinstance(config_source, dict):
+        config_source = ingress_connection.get("config")
+    config = _filter_mirror_config(config_source if isinstance(config_source, dict) else None)
     if not config:
-        # ingress may inline safe metadata at the top level instead of nesting
-        # it under config_json — pick those up so the dashboard sees them.
         config = _filter_mirror_config(ingress_connection)
 
     # ``daemon_instance_id`` is NOT NULL with an FK to ``daemon_instances``.
@@ -947,23 +951,48 @@ async def create_gateway(
     # ----- Cloud agent: proxy create to gateway-ingress -----
     if agent.hosting_kind == "cloud":
         _require_whitelist(body.provider, config)
+
+        login_id_for_create = body.login_id
+        # Telegram cloud path: the dashboard posts botToken directly (there is
+        # no scan-then-confirm flow). Ingress finalize requires a loginId, so
+        # mint one server-side by running login_start (which validates the
+        # token via getMe and creates a setup session). The botToken stays
+        # inside gateway-ingress' setup session + secret store — never the Hub.
+        if body.provider == "telegram":
+            try:
+                start_result = await ingress_client.login_start(
+                    agent_id,
+                    "telegram",
+                    user_id=ctx.user_id,
+                    request_id=_request_id_for(ctx),
+                    body={"botToken": body.bot_token},
+                )
+            except HTTPException as exc:
+                _log_setup_event(
+                    agent=agent, host=None, provider=body.provider,
+                    login_id=None, outcome="error",
+                    error_code=_extract_error_code(exc), ctx=ctx,
+                    setup_owner="gateway-ingress",
+                )
+                raise
+            login_id_for_create = start_result.get("loginId") if isinstance(start_result.get("loginId"), str) else None
+            if not login_id_for_create:
+                raise HTTPException(
+                    status_code=502,
+                    detail={"code": "cloud_gateway_ingress_unavailable"},
+                )
+
         ingress_body: dict[str, Any] = {
             "provider": body.provider,
             "label": body.label,
             "enabled": body.enabled,
             "config": dict(config),
+            "loginId": login_id_for_create,
         }
-        # Telegram: fresh botToken submitted by frontend — never persisted in
-        # Hub. We forward it to ingress over the authenticated server-to-
-        # server channel; the ingress secret store owns it after this.
-        if body.provider == "telegram":
-            ingress_body["secret"] = {"botToken": body.bot_token}
-        if body.provider in ("wechat", "feishu"):
-            ingress_body["loginId"] = body.login_id
 
         _log_setup_event(
             agent=agent, host=None, provider=body.provider,
-            login_id=body.login_id, outcome="started", ctx=ctx,
+            login_id=login_id_for_create, outcome="started", ctx=ctx,
             setup_owner="gateway-ingress",
         )
         try:
@@ -976,7 +1005,7 @@ async def create_gateway(
         except HTTPException as exc:
             _log_setup_event(
                 agent=agent, host=None, provider=body.provider,
-                login_id=body.login_id, outcome="error",
+                login_id=login_id_for_create, outcome="error",
                 error_code=_extract_error_code(exc), ctx=ctx,
                 setup_owner="gateway-ingress",
             )
@@ -993,7 +1022,7 @@ async def create_gateway(
         )
         _log_setup_event(
             agent=agent, host=None, provider=body.provider,
-            login_id=body.login_id, outcome="ok", ctx=ctx,
+            login_id=login_id_for_create, outcome="ok", ctx=ctx,
             setup_owner="gateway-ingress",
         )
         return _serialize(row)
@@ -1443,10 +1472,14 @@ async def wechat_login_start(
             login_id=login_id, outcome="ok", ctx=ctx,
             setup_owner="gateway-ingress",
         )
+        # ingress wraps provider-specific fields under publicPayload; the
+        # daemon path returned them flat, so unwrap here to keep the
+        # dashboard contract identical across hosting kinds.
+        public = result.get("publicPayload") if isinstance(result.get("publicPayload"), dict) else {}
         return {
             "loginId": result.get("loginId"),
-            "qrcode": result.get("qrcode"),
-            "qrcodeUrl": result.get("qrcodeUrl"),
+            "qrcode": public.get("qrcode"),
+            "qrcodeUrl": public.get("qrcodeUrl"),
             "expiresAt": result.get("expiresAt"),
         }
 
@@ -1536,10 +1569,11 @@ async def wechat_login_status(
             login_id=body.login_id, outcome="ok", ctx=ctx,
             setup_owner="gateway-ingress",
         )
+        public = result.get("publicPayload") if isinstance(result.get("publicPayload"), dict) else {}
         return {
             "status": result.get("status"),
-            "baseUrl": result.get("baseUrl"),
-            "tokenPreview": result.get("tokenPreview"),
+            "baseUrl": public.get("baseUrl"),
+            "tokenPreview": public.get("tokenPreview"),
         }
 
     agent, host = await _load_gateway_host_or_422(db, ctx, agent_id)
@@ -1622,10 +1656,11 @@ async def feishu_login_start(
             login_id=login_id, outcome="ok", ctx=ctx,
             setup_owner="gateway-ingress",
         )
+        public = result.get("publicPayload") if isinstance(result.get("publicPayload"), dict) else {}
         return {
             "loginId": result.get("loginId"),
-            "qrcode": result.get("qrcode"),
-            "qrcodeUrl": result.get("qrcodeUrl"),
+            "qrcode": public.get("qrcode"),
+            "qrcodeUrl": public.get("qrcodeUrl"),
             "expiresAt": result.get("expiresAt"),
         }
 
@@ -1714,12 +1749,13 @@ async def feishu_login_status(
             login_id=body.login_id, outcome="ok", ctx=ctx,
             setup_owner="gateway-ingress",
         )
+        public = result.get("publicPayload") if isinstance(result.get("publicPayload"), dict) else {}
         return {
             "status": result.get("status"),
-            "appId": result.get("appId"),
-            "domain": result.get("domain"),
-            "userOpenId": result.get("userOpenId"),
-            "tokenPreview": result.get("tokenPreview"),
+            "appId": public.get("appId"),
+            "domain": public.get("domain"),
+            "userOpenId": public.get("userOpenId"),
+            "tokenPreview": public.get("tokenPreview"),
         }
 
     agent, host = await _load_gateway_host_or_422(db, ctx, agent_id)
@@ -1807,7 +1843,11 @@ async def wechat_recent_senders(
             login_id=body.login_id, outcome="ok", ctx=ctx,
             setup_owner="gateway-ingress",
         )
-        senders = result.get("senders")
+        # ingress returns `candidates` (DiscoverResult shape); daemon path used
+        # `senders` / legacy `users`. Try ingress first, then fall back.
+        senders = result.get("candidates")
+        if not isinstance(senders, list):
+            senders = result.get("senders")
         if not isinstance(senders, list):
             senders = result.get("users")
         return {"senders": senders if isinstance(senders, list) else []}

--- a/backend/tests/test_app/test_app_gateways.py
+++ b/backend/tests/test_app/test_app_gateways.py
@@ -569,12 +569,31 @@ async def test_create_telegram_for_cloud_agent_proxies_to_ingress(
 
     def responder(method, url, body):
         assert method == "POST"
-        assert "/internal/gateway-ingress/agents/ag_cloud/gateways" in url
-        # Body must carry the safe envelope + the new botToken (transient
-        # forward, not persisted in Hub).
+        # Hub now drives Telegram cloud setup via loginStart→finalize so the
+        # bot token never crosses the Hub mirror table. The first call mints
+        # a loginId; the second uses it to finalize the connection.
+        if "/gateways/telegram/login/start" in url:
+            assert body["user_id"] == str(seed["user_id"])
+            assert body["hosting_kind"] == "cloud"
+            assert body["botToken"] == "1234:abcd"
+            return _FakeIngressResponse(
+                200,
+                {
+                    "ok": True,
+                    "loginId": "tgl_cloud01",
+                    "expiresAt": 1700000000,
+                    "publicPayload": {
+                        "tokenPreview": "1234...wxyz",
+                        "botInfo": {"id": 99, "is_bot": True},
+                    },
+                },
+            )
+        assert url.endswith("/internal/gateway-ingress/agents/ag_cloud/gateways")
         assert body["user_id"] == str(seed["user_id"])
         assert body["hosting_kind"] == "cloud"
-        assert body["secret"] == {"botToken": "1234:abcd"}
+        assert body["loginId"] == "tgl_cloud01"
+        # Hub no longer forwards the raw token here — ingress already holds it.
+        assert "secret" not in body
         return _FakeIngressResponse(
             200,
             {
@@ -624,7 +643,8 @@ async def test_create_telegram_for_cloud_agent_proxies_to_ingress(
     assert body["provider"] == "telegram"
     assert body["status"] == "active"
     assert body["config"]["tokenPreview"] == "1234...wxyz"
-    assert len(fake.calls) == 1
+    # loginStart + create
+    assert len(fake.calls) == 2
 
     # Mirror row: only safe fields, never a botToken / secret payload.
     row = await db_session.scalar(
@@ -1762,6 +1782,16 @@ async def test_create_cloud_gateway_writes_ingress_warning_to_last_error(
     gw._RATE_BUCKETS.clear()
 
     def responder(method, url, body):
+        if "/gateways/telegram/login/start" in url:
+            return _FakeIngressResponse(
+                200,
+                {
+                    "ok": True,
+                    "loginId": "tgl_warn1",
+                    "expiresAt": 1700000000,
+                    "publicPayload": {"tokenPreview": "1234...wxyz"},
+                },
+            )
         return _FakeIngressResponse(
             200,
             {
@@ -1829,6 +1859,16 @@ async def test_create_cloud_gateway_redacts_token_in_warning_message(
     leaked = "1234567890:AAEhBP0av5cYbnP9aFv7nPaUkUTabcdefghij"
 
     def responder(method, url, body):
+        if "/gateways/telegram/login/start" in url:
+            return _FakeIngressResponse(
+                200,
+                {
+                    "ok": True,
+                    "loginId": "tgl_warn2",
+                    "expiresAt": 1700000000,
+                    "publicPayload": {"tokenPreview": "1234...wxyz"},
+                },
+            )
         return _FakeIngressResponse(
             200,
             {

--- a/packages/gateway-ingress/src/setup/providers/feishu.ts
+++ b/packages/gateway-ingress/src/setup/providers/feishu.ts
@@ -280,7 +280,7 @@ export function createFeishuSetupAdapter(
     };
 
     const now = ctx.now();
-    const enabled = (req as unknown as { enabled?: unknown }).enabled !== false;
+    const enabled = req.enabled !== false;
     const connection: GatewayConnection = {
       id: gatewayId,
       agentId: req.agentId,

--- a/packages/gateway-ingress/src/setup/providers/telegram.ts
+++ b/packages/gateway-ingress/src/setup/providers/telegram.ts
@@ -40,6 +40,8 @@ import {
   type LoginStatusRequest,
   type LoginStatusResult,
   type ProviderSetupAdapter,
+  type RotateSecretRequest,
+  type RotateSecretResult,
   type SetupContext,
   type TestRequest,
   type TestResult,
@@ -398,14 +400,15 @@ export function createTelegramSetupAdapter(
     };
 
     const now = ctx.now();
+    const enabled = req.enabled !== false;
     const connection: GatewayConnection = {
       id: gatewayId,
       agentId: req.agentId,
       ...(req.userId ? { userId: req.userId } : {}),
       provider: "telegram",
       ...(req.label ? { label: req.label } : {}),
-      status: "pending",
-      enabled: true,
+      status: enabled ? "pending" : "disabled",
+      enabled,
       config: safeConfig,
       secretRef: gatewayId,
       createdAt: now,
@@ -414,6 +417,77 @@ export function createTelegramSetupAdapter(
     ctx.store.upsertConnection(connection);
     ctx.sessions.delete(req.loginId);
     return { connection };
+  }
+
+  async function rotateSecret(
+    req: RotateSecretRequest,
+    ctx: SetupContext,
+  ): Promise<RotateSecretResult> {
+    const conn = ctx.store.getConnection(req.gatewayId);
+    if (!conn || conn.provider !== "telegram") {
+      throw new SetupError("not_found", "gateway not found");
+    }
+    const rawToken =
+      typeof req.secret.botToken === "string"
+        ? req.secret.botToken
+        : typeof req.secret.bot_token === "string"
+          ? (req.secret.bot_token as string)
+          : "";
+    const newToken = rawToken.trim();
+    if (!newToken) {
+      throw new SetupError("bad_request", "botToken is required");
+    }
+    const stored = conn.secretRef
+      ? ctx.secrets.load<{ botToken?: string; baseUrl?: string }>(conn.secretRef)
+      : null;
+    const baseUrl =
+      typeof req.secret.baseUrl === "string" && req.secret.baseUrl.length > 0
+        ? pickBaseUrl({ baseUrl: req.secret.baseUrl })
+        : stored?.baseUrl ?? defaultBaseUrl;
+
+    // Validate the new token live before mutating any state.
+    let resp: TelegramApiResult<TelegramUser>;
+    try {
+      resp = await callApi<TelegramUser>(baseUrl, newToken, "getMe", {}, 5_000);
+    } catch (err) {
+      ctx.log.warn("telegram rotateSecret getMe failed", {
+        gatewayId: req.gatewayId,
+        err: redactToken(String((err as Error)?.message ?? err), newToken),
+      });
+      throw new SetupError("provider_unreachable", "telegram getMe unreachable");
+    }
+    if (!resp.ok) {
+      const code = resp.error_code;
+      if (code === 401 || code === 403 || code === 404) {
+        throw new SetupError("provider_auth_failed", "telegram bot token rejected");
+      }
+      throw new SetupError("provider_unreachable", "telegram getMe returned non-ok");
+    }
+
+    // Conflict detection: refuse if any OTHER active telegram connection
+    // already owns this token fingerprint. Self-rotation to the same token is
+    // a no-op fingerprint match against the current row and is allowed.
+    const fingerprint = tokenFingerprint(newToken);
+    for (const existing of ctx.store.listConnections()) {
+      if (existing.id === conn.id) continue;
+      if (existing.provider !== "telegram") continue;
+      if (!existing.enabled) continue;
+      if (existing.status === "disabled") continue;
+      const existingFp =
+        typeof (existing.config as Record<string, unknown>).tokenFingerprint === "string"
+          ? ((existing.config as Record<string, unknown>).tokenFingerprint as string)
+          : undefined;
+      if (existingFp && existingFp === fingerprint) {
+        throw new SetupError(
+          "gateway_conflict",
+          "telegram bot token already bound to another gateway",
+        );
+      }
+    }
+
+    const secretRef = conn.secretRef ?? conn.id;
+    ctx.secrets.write(secretRef, { botToken: newToken, baseUrl });
+    return { configPatch: { tokenFingerprint: fingerprint, baseUrl } };
   }
 
   async function test(
@@ -453,6 +527,7 @@ export function createTelegramSetupAdapter(
     discover,
     finalize,
     test,
+    rotateSecret,
   };
 }
 

--- a/packages/gateway-ingress/src/setup/providers/wechat.ts
+++ b/packages/gateway-ingress/src/setup/providers/wechat.ts
@@ -211,14 +211,15 @@ export function createWechatSetupAdapter(
       ...(typeof cfg.splitAt === "number" ? { splitAt: cfg.splitAt } : {}),
     };
     const now = ctx.now();
+    const enabled = req.enabled !== false;
     const connection: GatewayConnection = {
       id: gatewayId,
       agentId: req.agentId,
       ...(req.userId ? { userId: req.userId } : {}),
       provider: "wechat",
       ...(req.label ? { label: req.label } : {}),
-      status: "active",
-      enabled: true,
+      status: enabled ? "active" : "disabled",
+      enabled,
       config: safeConfig,
       secretRef: gatewayId,
       createdAt: now,

--- a/packages/gateway-ingress/src/setup/server.ts
+++ b/packages/gateway-ingress/src/setup/server.ts
@@ -220,6 +220,7 @@ async function handle(
           loginId,
           ...(typeof body.label === "string" ? { label: body.label } : {}),
           config: (body.config as Record<string, unknown>) ?? {},
+          ...(typeof body.enabled === "boolean" ? { enabled: body.enabled } : {}),
         },
         ctx,
       );
@@ -240,7 +241,7 @@ async function handle(
       const agentId = parts[1]!;
       const gatewayId = parts[3]!;
       const body = await readJsonBody(req);
-      parseRequestContext(body, agentId);
+      const reqCtx = parseRequestContext(body, agentId);
       const conn = opts.store.getConnection(gatewayId);
       if (!conn || conn.agentId !== agentId) {
         throw new SetupError("not_found", "gateway not found");
@@ -256,6 +257,38 @@ async function handle(
         }
         next.config = allowed;
       }
+
+      // Provider-specific secret rotation. Adapters that implement
+      // `rotateSecret` (currently telegram) validate the new credential
+      // upstream, run conflict guards, and mutate the secret store. Any
+      // `configPatch` they return (e.g. updated tokenFingerprint) is merged
+      // before we persist.
+      if (body.secret && typeof body.secret === "object" && !Array.isArray(body.secret)) {
+        const adapter = requireAdapter(opts.adapters, conn.provider);
+        if (!adapter.rotateSecret) {
+          throw new SetupError(
+            "bad_request",
+            "secret rotation not supported for this provider",
+          );
+        }
+        const rotation = await adapter.rotateSecret(
+          {
+            ...reqCtx,
+            gatewayId,
+            secret: body.secret as Record<string, unknown>,
+          },
+          ctx,
+        );
+        if (rotation.configPatch) {
+          const allowedRotationKeys = ["tokenFingerprint", "baseUrl"];
+          const merged: Record<string, unknown> = { ...next.config };
+          for (const key of allowedRotationKeys) {
+            if (key in rotation.configPatch) merged[key] = rotation.configPatch[key];
+          }
+          next.config = merged;
+        }
+      }
+
       opts.store.upsertConnection(next);
       // Phase 3: align runner state with the updated `enabled` flag.
       //   prev.enabled && !next.enabled  → stop (idempotent)
@@ -267,6 +300,14 @@ async function handle(
         return;
       }
       if (!conn.enabled && next.enabled) {
+        const outcome = await tryStartConnection(opts, next);
+        sendJson(res, 200, buildConnectionResponse(outcome));
+        return;
+      }
+      // Token rotation on an already-running connection: bounce the runner so
+      // the provider polls/listens with the new credential. startOne is
+      // idempotent — it stops the existing run first.
+      if (next.enabled && opts.runner.isRunning(gatewayId) && body.secret) {
         const outcome = await tryStartConnection(opts, next);
         sendJson(res, 200, buildConnectionResponse(outcome));
         return;

--- a/packages/gateway-ingress/src/setup/types.ts
+++ b/packages/gateway-ingress/src/setup/types.ts
@@ -67,6 +67,12 @@ export interface FinalizeRequest extends SetupRequestContext {
   /** Provider-specific config (label, allowedSenderIds, allowedChatIds, ...). */
   config?: Record<string, unknown>;
   label?: string;
+  /**
+   * Whether the new connection should be started immediately. Defaults to
+   * true when omitted. Adapters must honor this in `connection.enabled`
+   * and pick the right initial `status` ("disabled" when false).
+   */
+  enabled?: boolean;
 }
 
 export interface FinalizeResult {
@@ -81,6 +87,22 @@ export interface TestResult {
   ok: boolean;
   /** Optional provider-specific diagnostic payload. Must NOT include secrets. */
   details?: Record<string, unknown>;
+}
+
+export interface RotateSecretRequest extends SetupRequestContext {
+  gatewayId: string;
+  /**
+   * Provider-specific secret material supplied by the caller. Adapters MUST
+   * validate against the live provider before mutating the secret store and
+   * MUST run any duplicate-token / conflict guards expected at create time.
+   */
+  secret: Record<string, unknown>;
+}
+
+export interface RotateSecretResult {
+  /** Adapter-managed config delta to persist alongside the stored connection
+   *  (e.g. Telegram's `tokenFingerprint`). Does NOT include secrets. */
+  configPatch?: Record<string, unknown>;
 }
 
 export interface SetupContext {
@@ -109,6 +131,13 @@ export interface ProviderSetupAdapter {
    * contract is "did this credential still work?" without leaking it.
    */
   test?(req: TestRequest, ctx: SetupContext): Promise<TestResult>;
+  /**
+   * Provider-specific secret rotation (e.g. Telegram bot-token swap). Adapters
+   * MUST validate the new secret against the upstream provider before
+   * touching the secret store, MUST detect conflicts with other active
+   * connections, and MUST NOT leak the secret into responses or logs.
+   */
+  rotateSecret?(req: RotateSecretRequest, ctx: SetupContext): Promise<RotateSecretResult>;
 }
 
 export type ProviderSetupAdapterFactory = () => ProviderSetupAdapter;


### PR DESCRIPTION
## Summary

Post-merge review of #794 surfaced 5 contract mismatches between Hub and the new `gateway-ingress` setup server. This PR fixes all of them.

- **P0** Hub now reads provider fields from `result.publicPayload` (WeChat/Feishu login_start + login_status) and `result.candidates` (WeChat senders) — matching the actual ingress response envelope (it was reading flat top-level keys).
- **P0** Cloud Telegram create no longer 400s. Hub runs `login_start` first to validate the token via `getMe` and mint a `loginId`, then finalizes with it. Bot token still never touches the Hub mirror.
- **P1** `_upsert_mirror_from_ingress` reads both `config_json` and `config` (the field name actually returned by `redactConnection`), so dashboard allowlists no longer disappear into an empty mirror config.
- **P1** `FinalizeRequest.enabled` is threaded from `server.ts` through every adapter; wechat/telegram stop hard-coding `enabled:true` and choose the right initial status. Feishu's `as unknown as` shim drops away.
- **P1** Telegram PATCH honors `secret.botToken` rotation via a new `ProviderSetupAdapter.rotateSecret` hook — validates via `getMe`, runs the fingerprint conflict guard, swaps the secret-store entry, and bounces the runner if the connection is already running.

## Test plan

- [x] `npm test` in `packages/gateway-ingress` — 68/68 green
- [x] `uv run pytest backend/tests/test_app/test_app_gateways.py backend/tests/test_cloud_gateway_internal.py` — 81/81 green (3 cloud-Telegram fixtures updated for the new loginStart→finalize sequence)
- [ ] Manual smoke against staging: cloud WeChat scan-to-login receives qr/qrcodeUrl in dashboard
- [ ] Manual smoke: cloud Telegram create succeeds end-to-end
- [ ] Manual smoke: PATCH a cloud Telegram gateway with a rotated bot token and verify the new token is in effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)