### PR TITLE
fix: speed up dashboard room messages

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -11,9 +11,10 @@ import os
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, UploadFile
 from pydantic import BaseModel, Field
-from sqlalchemy import func, select, text
+from sqlalchemy import exists, func, select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
 
 from app.auth import RequestContext, require_active_agent, require_user, require_user_with_optional_agent
 from app.auth_room import (
@@ -2291,20 +2292,21 @@ async def get_room_messages(
         if room.visibility != RoomVisibility.public:
             raise HTTPException(status_code=403, detail="Room is not public")
 
-    # Deduplicated message query
-    dedup_sub = (
-        select(
-            MessageRecord.msg_id,
-            func.min(MessageRecord.id).label("min_id"),
+    # Room fan-out creates one MessageRecord per receiver with the same msg_id.
+    # Use the earliest row as the representative, but avoid grouping the whole
+    # room on every page load; this lets the database walk recent room rows and
+    # stop once it has enough representative messages.
+    duplicate = aliased(MessageRecord)
+    representative_filter = ~exists(
+        select(1).where(
+            duplicate.room_id == MessageRecord.room_id,
+            duplicate.msg_id == MessageRecord.msg_id,
+            duplicate.id < MessageRecord.id,
         )
-        .where(MessageRecord.room_id == room_id)
-        .group_by(MessageRecord.msg_id)
-        .subquery()
     )
-
-    stmt = (
-        select(MessageRecord)
-        .where(MessageRecord.id.in_(select(dedup_sub.c.min_id)))
+    stmt = select(MessageRecord).where(
+        MessageRecord.room_id == room_id,
+        representative_filter,
     )
 
     if before is not None:
@@ -2312,7 +2314,7 @@ async def get_room_messages(
             select(MessageRecord.id).where(
                 MessageRecord.hub_msg_id == before,
                 MessageRecord.room_id == room_id,
-                MessageRecord.id.in_(select(dedup_sub.c.min_id)),
+                representative_filter,
             )
         )
         cursor_id = cursor_result.scalar_one_or_none()
@@ -2324,7 +2326,7 @@ async def get_room_messages(
             select(MessageRecord.id).where(
                 MessageRecord.hub_msg_id == after,
                 MessageRecord.room_id == room_id,
-                MessageRecord.id.in_(select(dedup_sub.c.min_id)),
+                representative_filter,
             )
         )
         cursor_id = cursor_result.scalar_one_or_none()

--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -484,6 +484,8 @@ class MessageRecord(Base):
         UniqueConstraint("msg_id", "receiver_id"),
         Index("ix_message_records_retry", "state", "next_retry_at"),
         Index("ix_message_records_room_id_created_at_id", "room_id", "created_at", "id"),
+        Index("ix_message_records_room_id_id", "room_id", "id"),
+        Index("ix_message_records_room_msg_id_id", "room_id", "msg_id", "id"),
         Index("ix_message_records_sender_created_room", "sender_id", "created_at", "room_id"),
         Index("ix_message_records_receiver_created_room", "receiver_id", "created_at", "room_id"),
     )

--- a/backend/migrations/016_dashboard_room_messages_indexes.sql
+++ b/backend/migrations/016_dashboard_room_messages_indexes.sql
@@ -1,0 +1,12 @@
+-- Speed up dashboard room history pagination.
+--
+-- The dashboard reads one representative row per logical message because room
+-- fan-out stores one MessageRecord per receiver with the same msg_id. These
+-- indexes support scanning recent rows by room and checking whether a row is
+-- the first representative for its msg_id.
+
+CREATE INDEX IF NOT EXISTS ix_message_records_room_id_id
+    ON message_records (room_id, id);
+
+CREATE INDEX IF NOT EXISTS ix_message_records_room_msg_id_id
+    ON message_records (room_id, msg_id, id);


### PR DESCRIPTION
## Summary
- avoid full-room GROUP BY when loading dashboard room messages
- add composite message_records indexes for room history pagination and representative-row checks
- add production migration for the new indexes

## Tests
- cd backend && uv run pytest tests/test_app/test_app_dashboard.py tests/test_dashboard_rooms_human_send.py -q