### PR TITLE
fix: align mobile loading and bot settings drawer

### DIFF
--- a/frontend/src/components/dashboard/ActivityPanel.tsx
+++ b/frontend/src/components/dashboard/ActivityPanel.tsx
@@ -6,6 +6,7 @@ import type { ActivityStats, ActivityFeedItem } from "@/lib/types";
 import { useLanguage } from "@/lib/i18n";
 import { sidebar } from "@/lib/i18n/translations/dashboard";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
+import { BotCordLoader } from "@/components/ui/BotCordLoader";
 import { DashboardMainSkeleton } from "./DashboardTabSkeleton";
 
 type Period = "today" | "7d" | "30d";
@@ -340,11 +341,23 @@ export default function ActivityPanel() {
                     <button
                       onClick={loadMore}
                       disabled={loadingMore}
-                      className="mt-2 w-full rounded-lg border border-glass-border py-2 text-xs text-text-secondary hover:text-text-primary transition-colors disabled:opacity-50"
+                      className="mt-2 flex w-full items-center justify-center gap-2 rounded-lg border border-glass-border py-2 text-xs text-text-secondary transition-colors hover:text-text-primary disabled:opacity-50"
                     >
-                      {loadingMore
-                        ? (zh ? "\u52A0\u8F7D\u4E2D\u2026" : "Loading\u2026")
-                        : (zh ? "\u52A0\u8F7D\u66F4\u591A" : "Load more")}
+                      {loadingMore ? (
+                        <>
+                          <BotCordLoader
+                            label={zh ? "\u52A0\u8F7D\u4E2D\u2026" : "Loading\u2026"}
+                            size="xs"
+                            showLabel={false}
+                            className="md:hidden"
+                          />
+                          <span className="hidden md:inline">
+                            {zh ? "\u52A0\u8F7D\u4E2D\u2026" : "Loading\u2026"}
+                          </span>
+                        </>
+                      ) : (
+                        zh ? "\u52A0\u8F7D\u66F4\u591A" : "Load more"
+                      )}
                     </button>
                   )}
                 </div>

--- a/frontend/src/components/dashboard/AgentBrowser.tsx
+++ b/frontend/src/components/dashboard/AgentBrowser.tsx
@@ -13,6 +13,7 @@ import { useLanguage } from '@/lib/i18n';
 import { agentBrowser } from '@/lib/i18n/translations/dashboard';
 import SearchBar from "./SearchBar";
 import CopyableId from "@/components/ui/CopyableId";
+import { MobileBotCordLoading } from "@/components/ui/BotCordLoader";
 import { useRouter } from "nextjs-toploader/app";
 import { useShallow } from "zustand/react/shallow";
 import { api, humansApi } from "@/lib/api";
@@ -222,7 +223,11 @@ export default function AgentBrowser() {
               )}
             </div>
             {roomMembersLoading ? (
-              <p className="text-xs text-text-secondary animate-pulse">{t.loadingMembers}</p>
+              <MobileBotCordLoading
+                label={t.loadingMembers}
+                className="justify-start"
+                textClassName="text-xs text-text-secondary animate-pulse"
+              />
             ) : roomMembersError ? (
               <p className="text-xs text-red-400">{roomMembersError}</p>
             ) : roomMembers.length === 0 ? (

--- a/frontend/src/components/dashboard/AgentCardModal.tsx
+++ b/frontend/src/components/dashboard/AgentCardModal.tsx
@@ -8,6 +8,7 @@
  */
 
 import CopyableId from "@/components/ui/CopyableId";
+import { MobileBotCordLoading } from "@/components/ui/BotCordLoader";
 import { useLanguage } from "@/lib/i18n";
 import { exploreUi } from "@/lib/i18n/translations/dashboard";
 import type { AgentProfile } from "@/lib/types";
@@ -91,7 +92,11 @@ export default function AgentCardModal({
                 {messagePolicyLabel}
               </span>
             </div>
-            <p className="text-xs text-text-secondary animate-pulse">Loading profile...</p>
+            <MobileBotCordLoading
+              label="Loading profile..."
+              className="justify-start"
+              textClassName="text-xs text-text-secondary animate-pulse"
+            />
           </div>
         ) : error ? (
           <div className="space-y-3 py-2">

--- a/frontend/src/components/dashboard/AgentChannelsTab.tsx
+++ b/frontend/src/components/dashboard/AgentChannelsTab.tsx
@@ -36,6 +36,7 @@ import {
   type GatewayStatus,
   type WechatLoginStatus,
 } from "@/store/useAgentGatewayStore";
+import { MobileBotCordLoading } from "@/components/ui/BotCordLoader";
 
 interface Props {
   agentId: string;
@@ -319,7 +320,12 @@ export default function AgentChannelsTab({ agentId, hostingKind }: Props) {
 
         {loading && list.length === 0 ? (
           <div className="rounded-xl border border-glass-border bg-glass-bg/40 p-4 text-xs text-text-secondary">
-            加载中…
+            <MobileBotCordLoading
+              label="加载中…"
+              size="sm"
+              className="justify-start"
+              textClassName="text-xs text-text-secondary"
+            />
           </div>
         ) : list.length === 0 ? (
           <div className="rounded-xl border border-dashed border-glass-border/60 bg-transparent p-4 text-center text-xs text-text-tertiary">

--- a/frontend/src/components/dashboard/BotWalletTab.tsx
+++ b/frontend/src/components/dashboard/BotWalletTab.tsx
@@ -16,6 +16,7 @@ import { common } from "@/lib/i18n/translations/common";
 import { api, ApiError, type ActiveIdentity } from "@/lib/api";
 import { useDashboardWalletStore } from "@/store/useDashboardWalletStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
+import { BotCordLoader, MobileBotCordLoading } from "@/components/ui/BotCordLoader";
 import TransferDialog from "./TransferDialog";
 import TopupDialog from "./TopupDialog";
 import WithdrawDialog from "./WithdrawDialog";
@@ -129,7 +130,10 @@ export default function BotWalletTab({
             </button>
           </>
         ) : (
-          <div className="text-neon-cyan animate-pulse text-sm">{tc.loading}</div>
+          <MobileBotCordLoading
+            label={tc.loading}
+            textClassName="animate-pulse text-sm text-neon-cyan"
+          />
         )}
       </div>
     );
@@ -249,10 +253,22 @@ export default function BotWalletTab({
             <button
               onClick={() => void loadWalletLedger(true)}
               disabled={walletLoading}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-glass-border px-3 py-1 text-[10px] text-text-secondary hover:text-text-primary disabled:opacity-60"
+              className="inline-flex min-w-[5.5rem] items-center justify-center gap-1.5 rounded-lg border border-glass-border px-3 py-1 text-[10px] text-text-secondary hover:text-text-primary disabled:opacity-60"
             >
-              {walletLoading ? <Loader2 className="h-3 w-3 animate-spin" /> : null}
-              {walletLoading ? t.loadingMore : t.loadMore}
+              {walletLoading ? (
+                <>
+                  <BotCordLoader
+                    label={t.loadingMore}
+                    size="xs"
+                    showLabel={false}
+                    className="md:hidden"
+                  />
+                  <Loader2 className="hidden h-3 w-3 animate-spin md:inline" />
+                  <span className="hidden md:inline">{t.loadingMore}</span>
+                </>
+              ) : (
+                t.loadMore
+              )}
             </button>
           </div>
         ) : null}
@@ -338,7 +354,11 @@ function BotWithdrawals({
         </button>
       </div>
       {!loaded && loading ? (
-        <div className="text-xs text-text-secondary">{t.loadingWithdrawals}</div>
+        <MobileBotCordLoading
+          label={t.loadingWithdrawals}
+          className="py-2"
+          textClassName="text-xs text-text-secondary"
+        />
       ) : error && items.length === 0 ? (
         <div className="rounded-lg border border-red-400/30 bg-red-400/10 p-2 text-xs text-red-300">{error}</div>
       ) : items.length === 0 ? (

--- a/frontend/src/components/dashboard/ContactRequestsInbox.tsx
+++ b/frontend/src/components/dashboard/ContactRequestsInbox.tsx
@@ -16,6 +16,7 @@ import { useLanguage } from "@/lib/i18n";
 import { chatPane } from "@/lib/i18n/translations/dashboard";
 import { humansApi } from "@/lib/api";
 import type { ContactRequestItem, PendingApproval } from "@/lib/types";
+import { MobileBotCordLoading } from "@/components/ui/BotCordLoader";
 import BotAvatar from "./BotAvatar";
 
 type Tab = "received" | "sent";
@@ -182,7 +183,11 @@ export default function ContactRequestsInbox({
       <div className="flex-1 overflow-y-auto px-5 py-4">
         {tab === "received" ? (
           receivedLoading && receivedCount === 0 ? (
-            <p className="animate-pulse text-xs text-text-secondary">...</p>
+            <MobileBotCordLoading
+              label="..."
+              className="justify-start"
+              textClassName="animate-pulse text-xs text-text-secondary"
+            />
           ) : receivedCount === 0 ? (
             <p className="text-xs text-text-secondary">
               {emptyHint ?? t.noPendingRequests}

--- a/frontend/src/components/dashboard/CreateAgentDialog.tsx
+++ b/frontend/src/components/dashboard/CreateAgentDialog.tsx
@@ -49,6 +49,7 @@ import {
 } from "@/store/useOpenclawHostStore";
 import InstallCommandPanel from "./InstallCommandPanel";
 import DaemonInstallCommand from "@/components/daemon/DaemonInstallCommand";
+import { MobileBotCordLoading } from "@/components/ui/BotCordLoader";
 import { DeviceConnectPanel } from "./HomePanel";
 import DashboardSelect from "./DashboardSelect";
 
@@ -844,7 +845,10 @@ export default function CreateAgentDialog({
 
         {!loaded && loading ? (
           <div className="flex items-center justify-center py-10 text-text-secondary">
-            <Loader2 className="h-5 w-5 animate-spin" />
+            <MobileBotCordLoading
+              label={locale === "zh" ? "正在加载设备..." : "Loading devices..."}
+              textClassName="text-sm text-text-secondary"
+            />
           </div>
         ) : showEmptyState ? (
           <DeviceConnectPanel
@@ -1832,7 +1836,12 @@ function OpenclawBranch({ onSuccess, onClose }: OpenclawBranchProps) {
           </button>
         </div>
         {!loaded && (
-          <p className="mt-2 text-[11px] text-text-tertiary">Loading registered hosts…</p>
+          <MobileBotCordLoading
+            label="Loading registered hosts…"
+            size="sm"
+            className="mt-2 justify-start"
+            textClassName="text-[11px] text-text-tertiary"
+          />
         )}
       </div>
 

--- a/frontend/src/components/dashboard/DiscoverRoomList.tsx
+++ b/frontend/src/components/dashboard/DiscoverRoomList.tsx
@@ -14,6 +14,7 @@ import { useShallow } from "zustand/react/shallow";
 import { Loader2 } from "lucide-react";
 import { api } from "@/lib/api";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
+import { MobileBotCordLoading } from "@/components/ui/BotCordLoader";
 import SubscriptionBadge from "./SubscriptionBadge";
 
 export default function DiscoverRoomList() {
@@ -40,9 +41,11 @@ export default function DiscoverRoomList() {
 
   if (discoverLoading && discoverRooms.length === 0) {
     return (
-      <div className="p-4 text-center text-xs text-text-secondary animate-pulse">
-        {t.loadingRooms}
-      </div>
+      <MobileBotCordLoading
+        label={t.loadingRooms}
+        className="p-4"
+        textClassName="text-center text-xs text-text-secondary animate-pulse"
+      />
     );
   }
 

--- a/frontend/src/components/dashboard/HumanCardModal.tsx
+++ b/frontend/src/components/dashboard/HumanCardModal.tsx
@@ -8,6 +8,7 @@
  */
 
 import { useLanguage } from "@/lib/i18n";
+import { MobileBotCordLoading } from "@/components/ui/BotCordLoader";
 import { exploreUi } from "@/lib/i18n/translations/dashboard";
 import type { PublicHumanProfile } from "@/lib/types";
 import { Loader2 } from "lucide-react";
@@ -82,7 +83,11 @@ export default function HumanCardModal({
 
         {loading ? (
           <div className="space-y-3 py-2">
-            <p className="text-xs text-text-secondary animate-pulse">Loading profile...</p>
+            <MobileBotCordLoading
+              label="Loading profile..."
+              className="justify-start"
+              textClassName="text-xs text-text-secondary animate-pulse"
+            />
           </div>
         ) : error ? (
           <div className="space-y-3 py-2">

--- a/frontend/src/components/dashboard/JoinRequestsPanel.tsx
+++ b/frontend/src/components/dashboard/JoinRequestsPanel.tsx
@@ -12,6 +12,7 @@ import { useLanguage } from "@/lib/i18n";
 import { roomList } from "@/lib/i18n/translations/dashboard";
 import type { JoinRequestItem } from "@/lib/types";
 import CopyableId from "@/components/ui/CopyableId";
+import { MobileBotCordLoading } from "@/components/ui/BotCordLoader";
 import { Loader2 } from "lucide-react";
 
 interface JoinRequestsPanelProps {
@@ -72,9 +73,11 @@ export default function JoinRequestsPanel({ roomId }: JoinRequestsPanelProps) {
 
   if (loading) {
     return (
-      <p className="px-2 py-1 text-xs text-text-secondary animate-pulse">
-        {t.joinRequests}...
-      </p>
+      <MobileBotCordLoading
+        label={`${t.joinRequests}...`}
+        className="px-2 py-1 justify-start"
+        textClassName="text-xs text-text-secondary animate-pulse"
+      />
     );
   }
 

--- a/frontend/src/components/dashboard/LedgerList.tsx
+++ b/frontend/src/components/dashboard/LedgerList.tsx
@@ -9,6 +9,7 @@
 
 import { useShallow } from "zustand/react/shallow";
 import { useDashboardWalletStore } from "@/store/useDashboardWalletStore";
+import { BotCordLoader, MobileBotCordLoading } from "@/components/ui/BotCordLoader";
 
 function formatCoinAmount(minorStr: string): string {
   const minor = parseInt(minorStr, 10);
@@ -52,7 +53,10 @@ export default function LedgerList() {
   if (walletLoading && walletLedger.length === 0) {
     return (
       <div className="flex items-center justify-center py-12">
-        <div className="text-neon-cyan animate-pulse text-sm">Loading ledger...</div>
+        <MobileBotCordLoading
+          label="Loading ledger..."
+          textClassName="animate-pulse text-sm text-neon-cyan"
+        />
       </div>
     );
   }
@@ -148,9 +152,21 @@ export default function LedgerList() {
           <button
             onClick={() => loadWalletLedger(true)}
             disabled={walletLoading}
-            className="rounded-lg border border-glass-border px-4 py-2 text-xs font-medium text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-40"
+            className="inline-flex min-w-[5.5rem] items-center justify-center rounded-lg border border-glass-border px-4 py-2 text-xs font-medium text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-40"
           >
-            {walletLoading ? "Loading..." : "Load more"}
+            {walletLoading ? (
+              <>
+                <BotCordLoader
+                  label="Loading..."
+                  size="xs"
+                  showLabel={false}
+                  className="md:hidden"
+                />
+                <span className="hidden md:inline">Loading...</span>
+              </>
+            ) : (
+              "Load more"
+            )}
           </button>
         </div>
       )}

--- a/frontend/src/components/dashboard/PaidRoomPreview.tsx
+++ b/frontend/src/components/dashboard/PaidRoomPreview.tsx
@@ -8,11 +8,12 @@
  */
 
 import { useEffect, useMemo, useState } from "react";
-import { Lock, Loader2 } from "lucide-react";
+import { Lock } from "lucide-react";
 import { api } from "@/lib/api";
 import type { PublicRoomMessagePreview } from "@/lib/types";
 import { useLanguage } from "@/lib/i18n";
 import { chatPane } from "@/lib/i18n/translations/dashboard";
+import { MobileBotCordLoading } from "@/components/ui/BotCordLoader";
 import SubscriptionBadge from "./SubscriptionBadge";
 
 const PREVIEW_LIMIT = 3;
@@ -100,8 +101,11 @@ export default function PaidRoomPreview({
 
           {loading ? (
             <div className="flex items-center justify-center rounded-lg border border-glass-border bg-deep-black-light px-3 py-5 text-xs text-text-secondary">
-              <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
-              {t.loadingPreviewMessages}
+              <MobileBotCordLoading
+                label={t.loadingPreviewMessages}
+                size="sm"
+                textClassName="text-xs text-text-secondary"
+              />
             </div>
           ) : previewMessages.length > 0 ? (
             <div className="space-y-2">

--- a/frontend/src/components/dashboard/PendingApprovalsPanel.tsx
+++ b/frontend/src/components/dashboard/PendingApprovalsPanel.tsx
@@ -18,6 +18,7 @@ import { humansApi } from "@/lib/api";
 import { useLanguage } from "@/lib/i18n";
 import { pendingApprovalsPanel } from "@/lib/i18n/translations/dashboard";
 import type { PendingApproval } from "@/lib/types";
+import { MobileBotCordLoading } from "@/components/ui/BotCordLoader";
 
 type ActionState = { id: string; decision: "approve" | "reject" } | null;
 
@@ -67,10 +68,12 @@ export default function PendingApprovalsPanel() {
   if (loading && approvals.length === 0) {
     return (
       <div className="mb-4 rounded-2xl border border-glass-border bg-deep-black-light px-4 py-3">
-        <div className="flex items-center gap-2 text-xs text-text-secondary">
-          <Loader2 className="h-3 w-3 animate-spin" />
-          <span>{t.loading}</span>
-        </div>
+        <MobileBotCordLoading
+          label={t.loading}
+          size="sm"
+          className="justify-start"
+          textClassName="text-xs text-text-secondary"
+        />
       </div>
     );
   }

--- a/frontend/src/components/dashboard/PublicAgentList.tsx
+++ b/frontend/src/components/dashboard/PublicAgentList.tsx
@@ -5,6 +5,7 @@ import { useShallow } from "zustand/react/shallow";
 import { useEffect } from "react";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { usePresenceStore } from "@/store/usePresenceStore";
+import { MobileBotCordLoading } from "@/components/ui/BotCordLoader";
 import { PresenceDot } from "./PresenceDot";
 
 export default function PublicAgentList() {
@@ -26,9 +27,11 @@ export default function PublicAgentList() {
 
   if (publicAgentsLoading) {
     return (
-      <div className="p-4 text-center text-xs text-text-secondary animate-pulse">
-        Loading agents...
-      </div>
+      <MobileBotCordLoading
+        label="Loading agents..."
+        className="p-4"
+        textClassName="animate-pulse text-center text-xs text-text-secondary"
+      />
     );
   }
 

--- a/frontend/src/components/dashboard/PublicRoomList.tsx
+++ b/frontend/src/components/dashboard/PublicRoomList.tsx
@@ -13,6 +13,7 @@ import { useRouter } from "nextjs-toploader/app";
 import { useShallow } from "zustand/react/shallow";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
+import { MobileBotCordLoading } from "@/components/ui/BotCordLoader";
 import SubscriptionBadge from "./SubscriptionBadge";
 
 export default function PublicRoomList() {
@@ -49,9 +50,11 @@ export default function PublicRoomList() {
 
   if (publicRoomsLoading) {
     return (
-      <div className="p-4 text-center text-xs text-text-secondary animate-pulse">
-        {t.loadingRooms}
-      </div>
+      <MobileBotCordLoading
+        label={t.loadingRooms}
+        className="p-4"
+        textClassName="animate-pulse text-center text-xs text-text-secondary"
+      />
     );
   }
 

--- a/frontend/src/components/dashboard/RoomPolicyModal.tsx
+++ b/frontend/src/components/dashboard/RoomPolicyModal.tsx
@@ -21,6 +21,7 @@ import { createPortal } from "react-dom";
 import { Bell, Loader2, RotateCcw, X } from "lucide-react";
 import { api } from "@/lib/api";
 import type { PublicRoomMember } from "@/lib/types";
+import { MobileBotCordLoading } from "@/components/ui/BotCordLoader";
 import {
   usePolicyStore,
   type AttentionMode,
@@ -181,8 +182,12 @@ export default function RoomPolicyModal({
 
         {loading && !data ? (
           <div className="flex items-center gap-2 rounded-xl border border-glass-border bg-glass-bg/40 px-3 py-3 text-sm text-text-secondary">
-            <Loader2 className="h-4 w-4 animate-spin" />
-            加载中…
+            <MobileBotCordLoading
+              label="加载中…"
+              size="sm"
+              className="justify-start"
+              textClassName="text-sm text-text-secondary"
+            />
           </div>
         ) : error && !data ? (
           <div className="rounded-xl border border-red-400/20 bg-red-400/5 px-3 py-3 text-sm text-red-300">
@@ -499,8 +504,12 @@ function OverrideForm({
         <div className="mt-3 rounded-xl border border-glass-border bg-deep-black/30 p-2">
           {membersLoading ? (
             <div className="flex items-center gap-2 px-1 py-2 text-xs text-text-secondary">
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              加载成员中…
+              <MobileBotCordLoading
+                label="加载成员中…"
+                size="sm"
+                className="justify-start"
+                textClassName="text-xs text-text-secondary"
+              />
             </div>
           ) : members.length === 0 ? (
             <p className="px-1 py-2 text-xs text-text-tertiary">未能加载房间成员</p>

--- a/frontend/src/components/dashboard/RoomSettingsModal.tsx
+++ b/frontend/src/components/dashboard/RoomSettingsModal.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { ChevronDown, Loader2, Search, Trash2, X } from "lucide-react";
 import { useRouter } from "nextjs-toploader/app";
 import CopyableId from "@/components/ui/CopyableId";
+import { MobileBotCordLoading } from "@/components/ui/BotCordLoader";
 import { api, humansApi, userApi } from "@/lib/api";
 import { useLanguage } from "@/lib/i18n";
 import {
@@ -782,7 +783,11 @@ export default function RoomSettingsModal({
 
                 <div className="max-h-72 overflow-y-auto rounded-xl border border-glass-border bg-deep-black/40">
                   {membersLoading ? (
-                    <p className="px-4 py-4 text-xs text-text-secondary animate-pulse">{tm.loadingMembers}</p>
+                    <MobileBotCordLoading
+                      label={tm.loadingMembers}
+                      className="px-4 py-4 justify-start"
+                      textClassName="text-xs text-text-secondary animate-pulse"
+                    />
                   ) : membersError ? (
                     <p className="px-4 py-4 text-xs text-red-400">{membersError}</p>
                   ) : filteredMembers.length === 0 ? (

--- a/frontend/src/components/dashboard/SubscriptionBadge.tsx
+++ b/frontend/src/components/dashboard/SubscriptionBadge.tsx
@@ -15,6 +15,7 @@ import { api } from "@/lib/api";
 import type { SubscriptionProduct } from "@/lib/types";
 import { useShallow } from "zustand/react/shallow";
 import { Loader2 } from "lucide-react";
+import { MobileBotCordLoading } from "@/components/ui/BotCordLoader";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardSubscriptionStore } from "@/store/useDashboardSubscriptionStore";
@@ -281,9 +282,11 @@ export default function SubscriptionBadge({
             </h2>
 
             {loading ? (
-              <div className="py-8 text-center text-sm text-text-secondary animate-pulse">
-                {t.loading}
-              </div>
+              <MobileBotCordLoading
+                label={t.loading}
+                className="py-8"
+                textClassName="text-center text-sm text-text-secondary animate-pulse"
+              />
             ) : productData ? (
               <div className="space-y-4">
                 <div className="flex items-start justify-between gap-3">

--- a/frontend/src/components/dashboard/TopupDialog.tsx
+++ b/frontend/src/components/dashboard/TopupDialog.tsx
@@ -8,6 +8,7 @@ import type { StripePackageItem } from "@/lib/types";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { saveStripeTopupContext } from "@/lib/stripe-topup-context";
 import { Loader2 } from "lucide-react";
+import { MobileBotCordLoading } from "@/components/ui/BotCordLoader";
 import WalletAccountSelector from "./WalletAccountSelector";
 
 function formatCoin(minorStr: string): string {
@@ -126,9 +127,11 @@ export default function TopupDialog({ viewer, onClose, onSuccess }: TopupDialogP
         <WalletAccountSelector value={selectedViewer} onChange={setSelectedViewer} />
 
         {packagesLoading ? (
-          <div className="py-8 text-center text-sm text-text-secondary animate-pulse">
-            {t.loadingPackages}
-          </div>
+          <MobileBotCordLoading
+            label={t.loadingPackages}
+            className="py-8"
+            textClassName="animate-pulse text-center text-sm text-text-secondary"
+          />
         ) : packagesError ? (
           <div className="py-8 text-center text-sm text-red-400">{packagesError}</div>
         ) : packages.length === 0 ? (

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -12,7 +12,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { ArrowLeft, Bot, Loader2, MessageSquare, AlertCircle, AlertTriangle, RotateCcw, Bell, FileText, PanelLeftOpen, Settings2, User } from "lucide-react";
 import { useRouter } from "nextjs-toploader/app";
-import AgentSettingsDrawer from "./AgentSettingsDrawer";
 import { api } from "@/lib/api";
 import { useLanguage } from "@/lib/i18n";
 import type { Attachment, OwnerChatMessage } from "@/lib/types";
@@ -74,7 +73,7 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
   const { activeAgentId } = useDashboardSessionStore();
   const ownedAgents = useDashboardSessionStore((s) => s.ownedAgents);
   const chatAgentId = agentId || activeAgentId || null;
-  const { openMobileSidebar, setMessagesPane, setSelectedBotAgentId, setUserChatRoomId } = useDashboardUIStore();
+  const { openMobileSidebar, setMessagesPane, setSelectedBotAgentId, setUserChatRoomId, setBotDetailAgentId } = useDashboardUIStore();
   const ownedAgent = chatAgentId
     ? ownedAgents.find((a) => a.agent_id === chatAgentId) ?? null
     : null;
@@ -94,7 +93,6 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
   const [chatRoomName, setChatRoomName] = useState("");
   const [initializingRoom, setInitializingRoom] = useState(false);
   const [initError, setInitError] = useState<string | null>(null);
-  const [agentSettingsOpen, setAgentSettingsOpen] = useState(false);
   const [errorDetailsId, setErrorDetailsId] = useState<string | null>(null);
   const settingsLabel = locale === "zh" ? "Bot 设置" : "Bot settings";
 
@@ -357,7 +355,7 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
           {ownedAgent && (
             <button
               type="button"
-              onClick={() => setAgentSettingsOpen(true)}
+              onClick={() => setBotDetailAgentId(ownedAgent.agent_id)}
               title={settingsLabel}
               aria-label={settingsLabel}
               className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-neon-cyan/30 bg-neon-cyan/10 px-2.5 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20"
@@ -368,22 +366,6 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
           )}
         </div>
       </div>
-
-      {agentSettingsOpen && ownedAgent && (
-        <AgentSettingsDrawer
-          agentId={ownedAgent.agent_id}
-          displayName={ownedAgent.display_name}
-          bio={ownedAgent.bio ?? null}
-          avatarUrl={ownedAgent.avatar_url ?? null}
-          hostingKind={ownedAgent.hosting_kind ?? null}
-          daemonInstanceId={ownedAgent.daemon_instance_id ?? null}
-          runtime={ownedAgent.runtime ?? null}
-          runtimeModel={ownedAgent.runtime_model ?? null}
-          reasoningEffort={ownedAgent.reasoning_effort ?? null}
-          thinking={ownedAgent.thinking ?? null}
-          onClose={() => setAgentSettingsOpen(false)}
-        />
-      )}
 
       {/* Messages */}
       <div ref={scrollContainerRef} onScroll={handleScroll} className="flex-1 overflow-y-auto px-4 py-3 space-y-3">

--- a/frontend/src/components/dashboard/WalletPanel.tsx
+++ b/frontend/src/components/dashboard/WalletPanel.tsx
@@ -15,6 +15,7 @@ import { api, ApiError, type ActiveIdentity } from "@/lib/api";
 import type { WithdrawalResponse } from "@/lib/types";
 import { useShallow } from "zustand/react/shallow";
 import { ChevronRight, Eye, EyeOff, Loader2 } from "lucide-react";
+import { BotCordLoader, MobileBotCordLoading } from "@/components/ui/BotCordLoader";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import {
   useDashboardWalletStore,
@@ -529,10 +530,22 @@ function MergedLedgerSection({
           <button
             onClick={onLoadMore}
             disabled={loading}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-glass-border px-4 py-1.5 text-[11px] text-text-secondary transition-colors hover:text-text-primary disabled:opacity-60"
+            className="inline-flex min-w-[5.5rem] items-center justify-center gap-1.5 rounded-lg border border-glass-border px-4 py-1.5 text-[11px] text-text-secondary transition-colors hover:text-text-primary disabled:opacity-60"
           >
-            {loading ? <Loader2 className="h-3 w-3 animate-spin" /> : null}
-            {loading ? loadingMoreLabel : loadMoreLabel}
+            {loading ? (
+              <>
+                <BotCordLoader
+                  label={loadingMoreLabel}
+                  size="xs"
+                  showLabel={false}
+                  className="md:hidden"
+                />
+                <Loader2 className="hidden h-3 w-3 animate-spin md:inline" />
+                <span className="hidden md:inline">{loadingMoreLabel}</span>
+              </>
+            ) : (
+              loadMoreLabel
+            )}
           </button>
         </div>
       ) : null}
@@ -601,7 +614,11 @@ function RecentWithdrawals({
       </div>
 
       {loading && items.length === 0 ? (
-        <div className="text-sm text-text-secondary">{t.loadingWithdrawals}</div>
+        <MobileBotCordLoading
+          label={t.loadingWithdrawals}
+          className="justify-start"
+          textClassName="text-sm text-text-secondary"
+        />
       ) : error && items.length === 0 ? (
         <div className="rounded-xl border border-red-400/30 bg-red-400/10 p-3 text-sm text-red-300">
           {error}

--- a/frontend/src/components/share/InviteLinkView.tsx
+++ b/frontend/src/components/share/InviteLinkView.tsx
@@ -14,6 +14,7 @@ import type { InvitePreviewResponse } from "@/lib/types";
 import { createClient } from "@/lib/supabase/client";
 import { useLanguage } from "@/lib/i18n";
 import { inviteLanding } from "@/lib/i18n/translations/dashboard";
+import { MobileBotCordLoading } from "@/components/ui/BotCordLoader";
 
 export default function InviteLinkView({ inviteCode }: { inviteCode: string }) {
   const locale = useLanguage();
@@ -97,7 +98,11 @@ export default function InviteLinkView({ inviteCode }: { inviteCode: string }) {
   if (loading) {
     return (
       <div className="flex min-h-[60vh] items-center justify-center">
-        <div className="animate-pulse text-lg text-neon-cyan">{t.loading}</div>
+        <MobileBotCordLoading
+          label={t.loading}
+          size="md"
+          textClassName="animate-pulse text-lg text-neon-cyan"
+        />
       </div>
     );
   }

--- a/frontend/src/components/ui/BotCordLoader.tsx
+++ b/frontend/src/components/ui/BotCordLoader.tsx
@@ -1,6 +1,6 @@
 /**
  * [INPUT]: 依赖 /logo.svg、全局 botcord-loader CSS 动效与 clsx 组合外部样式
- * [OUTPUT]: 对外提供 BotCordLoader 与 BotCordLoadingScreen，统一品牌加载动效
+ * [OUTPUT]: 对外提供 BotCordLoader、BotCordLoadingScreen 与移动端品牌加载状态，统一品牌加载动效
  * [POS]: ui 基础加载原语，供 App Router、dashboard 冷启动与公开分享页复用
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
@@ -9,7 +9,7 @@
 
 import { clsx } from "clsx";
 
-type BotCordLoaderSize = "sm" | "md" | "lg";
+type BotCordLoaderSize = "xs" | "sm" | "md" | "lg";
 
 interface BotCordLoaderProps {
   label?: string;
@@ -23,13 +23,22 @@ interface BotCordLoadingScreenProps {
   className?: string;
 }
 
+interface MobileBotCordLoadingProps {
+  label: string;
+  size?: BotCordLoaderSize;
+  className?: string;
+  textClassName?: string;
+}
+
 const visualSize: Record<BotCordLoaderSize, string> = {
+  xs: "h-5 w-5",
   sm: "h-10 w-10",
   md: "h-16 w-16",
   lg: "h-24 w-24",
 };
 
 const coreSize: Record<BotCordLoaderSize, string> = {
+  xs: "h-3 w-3",
   sm: "h-5 w-5",
   md: "h-8 w-8",
   lg: "h-12 w-12",
@@ -78,6 +87,20 @@ export function BotCordLoadingScreen({
   return (
     <div className={clsx("flex min-h-[60vh] items-center justify-center", className)}>
       <BotCordLoader label={label} size="lg" />
+    </div>
+  );
+}
+
+export function MobileBotCordLoading({
+  label,
+  size = "sm",
+  className,
+  textClassName,
+}: MobileBotCordLoadingProps) {
+  return (
+    <div className={clsx("flex items-center justify-center", className)}>
+      <BotCordLoader label={label} size={size} className="md:hidden" />
+      <span className={clsx("hidden md:inline-flex", textClassName)}>{label}</span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Route mobile standalone and load-more loading states through the BotCord logo loader path.
- Reuse the global BotDetailDrawer for owner-chat bot settings so it matches the My Bots entry point.
- Keep unrelated daemon/workspace lockfile changes out of this PR.

## Verification
- NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key pnpm --dir frontend build
- Code Reviewer final review: No findings