### PR TITLE
fix: render escaped newlines in frontend messages

### DIFF
--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -22,7 +22,7 @@ import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import { useOwnerChatStore } from "@/store/useOwnerChatStore";
 import { useOwnerChatWs } from "@/hooks/useOwnerChatWs";
 import DashboardMessagePaneSkeleton from "./DashboardMessagePaneSkeleton";
-import MarkdownContent from "@/components/ui/MarkdownContent";
+import MarkdownContent, { normalizeMessageContent } from "@/components/ui/MarkdownContent";
 import StreamBlocksView from "./StreamBlocksView";
 import RuntimeErrorDetailsDialog from "./RuntimeErrorDetailsDialog";
 import CopyableId from "@/components/ui/CopyableId";
@@ -45,7 +45,8 @@ function TypewriterText({
   onComplete?: () => void;
   onTick?: () => void;
 }) {
-  const tokens = text.split(/(\s+)/);
+  const normalizedText = normalizeMessageContent(text);
+  const tokens = normalizedText.split(/(\s+)/);
   const [count, setCount] = useState(0);
 
   useEffect(() => {
@@ -60,7 +61,7 @@ function TypewriterText({
     return () => clearTimeout(timer);
   }, [count, tokens.length, onComplete, onTick]);
 
-  return <>{tokens.slice(0, count).join("")}</>;
+  return <span className="whitespace-pre-wrap">{tokens.slice(0, count).join("")}</span>;
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/components/ui/MarkdownContent.test.ts
+++ b/frontend/src/components/ui/MarkdownContent.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { splitPlainMentionText } from "./MarkdownContent";
+import { normalizeMessageContent, splitPlainMentionText } from "./MarkdownContent";
 
 function mentionProps(node: unknown) {
   return (node as { properties?: Record<string, unknown> }).properties;
@@ -32,5 +32,16 @@ describe("splitPlainMentionText", () => {
     ]);
 
     expect(mentionProps(nodes[0])?.["data-mention-id"]).toBe("ag_long");
+  });
+});
+
+describe("normalizeMessageContent", () => {
+  it("converts escaped line breaks from message payloads", () => {
+    expect(normalizeMessageContent("line one\\nline two")).toBe("line one\nline two");
+    expect(normalizeMessageContent("line one\\r\\nline two")).toBe("line one\nline two");
+  });
+
+  it("preserves existing real line breaks", () => {
+    expect(normalizeMessageContent("line one\nline two")).toBe("line one\nline two");
   });
 });

--- a/frontend/src/components/ui/MarkdownContent.tsx
+++ b/frontend/src/components/ui/MarkdownContent.tsx
@@ -40,6 +40,13 @@ type HastNode = HastTextNode | HastElementNode | HastRootNode | { type?: string;
 
 const MENTION_WITH_ID_RE = /@([^\n@]*?)\(((?:ag|hu)_[^)]+)\)/g;
 
+export function normalizeMessageContent(content: string): string {
+  return content
+    .replace(/\\r\\n/g, "\n")
+    .replace(/\\n/g, "\n")
+    .replace(/\\r/g, "\n");
+}
+
 function isMentionStartBoundary(value: string, index: number): boolean {
   if (index === 0) return true;
   return /[\s([{'"“‘]/.test(value[index - 1]);
@@ -319,6 +326,8 @@ function createComponents(renderMention?: MarkdownContentProps["renderMention"])
 }
 
 export default function MarkdownContent({ content, renderMention, mentionCandidates }: MarkdownContentProps) {
+  const normalizedContent = normalizeMessageContent(content);
+
   return (
     <div className="break-words text-sm text-text-primary [&>*:first-child]:mt-0">
       <ReactMarkdown
@@ -326,7 +335,7 @@ export default function MarkdownContent({ content, renderMention, mentionCandida
         rehypePlugins={[[rehypeMentions, { candidates: mentionCandidates ?? [] }]]}
         components={createComponents(renderMention)}
       >
-        {content}
+        {normalizedContent}
       </ReactMarkdown>
     </div>
   );


### PR DESCRIPTION
## Summary
- normalize escaped line break sequences in shared Markdown message rendering
- reuse the same normalization during owner-chat typewriter rendering
- add coverage for escaped and real newline handling

## Verification
- pnpm test -- MarkdownContent.test.ts
- NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key pnpm build

## Risk / rollout
- low risk; scoped to frontend message text rendering
- build requires Supabase env values for /admin/codes prerendering, so verification used placeholder values