### PR TITLE
fix(daemon): recover codex sessions with room context

### DIFF
--- a/packages/daemon/src/cloud-daemon.ts
+++ b/packages/daemon/src/cloud-daemon.ts
@@ -32,6 +32,7 @@ import { createDaemonSystemContextBuilder } from "./system-context.js";
 import { readWorkingMemorySnapshot } from "./working-memory.js";
 import { createRoomStaticContextBuilder } from "./room-context.js";
 import { createRoomContextFetcher } from "./room-context-fetcher.js";
+import { createRecentRoomMessagesRecoveryBuilder } from "./room-recovery-context.js";
 import { composeBotCordUserTurn } from "./turn-text.js";
 import { PolicyResolver, type DaemonAttentionPolicy } from "./gateway/policy-resolver.js";
 import { scanMention } from "./mention-scan.js";
@@ -141,6 +142,12 @@ export async function startCloudDaemon(
   });
   const roomContextBuilder = createRoomStaticContextBuilder({
     fetchRoomInfo: roomContextFetcher,
+    log: logger,
+  });
+  const buildRuntimeRecoveryContext = createRecentRoomMessagesRecoveryBuilder({
+    credentialPathByAgentId,
+    hubBaseUrl: cloudCfg.hubUrl,
+    limit: 20,
     log: logger,
   });
 
@@ -258,6 +265,7 @@ export async function startCloudDaemon(
     turnTimeoutMs: DEFAULT_TURN_TIMEOUT_MS,
     buildSystemContext,
     buildMemoryContext,
+    buildRuntimeRecoveryContext,
     onInbound,
     onTurnComplete,
     composeUserTurn: composeBotCordUserTurn,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -39,6 +39,7 @@ import { createDaemonSystemContextBuilder } from "./system-context.js";
 import { readWorkingMemorySnapshot } from "./working-memory.js";
 import { createRoomStaticContextBuilder } from "./room-context.js";
 import { createRoomContextFetcher } from "./room-context-fetcher.js";
+import { createRecentRoomMessagesRecoveryBuilder } from "./room-recovery-context.js";
 import {
   buildLoopRiskPrompt,
   loopRiskSessionKey,
@@ -365,6 +366,13 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
     fetchRoomInfo: roomContextFetcher,
     log: logger,
   });
+  const buildRuntimeRecoveryContext = createRecentRoomMessagesRecoveryBuilder({
+    credentialPathByAgentId,
+    ...(opts.credentialsPath ? { defaultCredentialsPath: opts.credentialsPath } : {}),
+    ...(opts.hubBaseUrl ? { hubBaseUrl: opts.hubBaseUrl } : {}),
+    limit: 20,
+    log: logger,
+  });
 
   // Cache one system-context builder per configured agentId. The gateway
   // calls this with each inbound message and we pick the right builder by
@@ -536,6 +544,7 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
     turnTimeoutMs: DEFAULT_TURN_TIMEOUT_MS,
     buildSystemContext,
     buildMemoryContext,
+    buildRuntimeRecoveryContext,
     onInbound,
     onOutbound,
     onRuntimeCircuitBreakerChange: pushLiveRuntimeSnapshot,

--- a/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
+++ b/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
@@ -244,6 +244,7 @@ describe("Dispatcher", () => {
     turnTimeoutMs?: number;
     runtimeAuthFailureThreshold?: number;
     runtimeAuthFailureCooldownMs?: number;
+    buildRuntimeRecoveryContext?: (message: GatewayInboundMessage) => Promise<string | null> | string | null;
   }) {
     const { store, dir } = await makeStore();
     tempDirs.push(dir);
@@ -258,6 +259,7 @@ describe("Dispatcher", () => {
       turnTimeoutMs: args.turnTimeoutMs,
       runtimeAuthFailureThreshold: args.runtimeAuthFailureThreshold,
       runtimeAuthFailureCooldownMs: args.runtimeAuthFailureCooldownMs,
+      buildRuntimeRecoveryContext: args.buildRuntimeRecoveryContext,
     });
     return { dispatcher, channel, store };
   }
@@ -458,6 +460,60 @@ describe("Dispatcher", () => {
 
     expect(store.all().length).toBe(0);
     expect(channel.sends[0].message.type).toBe("error");
+  });
+
+  it("codex: retries a poisoned resumed session in a fresh session with recent room context", async () => {
+    let factoryCall = 0;
+    const recoveryRuntime: RuntimeAdapter = {
+      id: "codex",
+      run: vi.fn(async (opts: RuntimeRunOptions): Promise<RuntimeRunResult> => {
+        if ((recoveryRuntime.run as any).mock.calls.length === 1) {
+          expect(opts.sessionId).toBe("sid-1");
+          return {
+            text: "",
+            newSessionId: "sid-1",
+            error: "Codex context compaction failed: maximum context length exceeded",
+          };
+        }
+        expect(opts.sessionId).toBe(null);
+        expect(opts.text).toContain("[BotCord Runtime Recovery Notice]");
+        expect(opts.text).toContain("[Recent Room Messages]");
+        expect(opts.text).toContain("Alice: deploy is failing");
+        expect(opts.text).toContain("[Current User Turn]");
+        expect(opts.text).toContain("continue");
+        return { text: "recovered", newSessionId: "sid-2" };
+      }) as RuntimeAdapter["run"],
+    };
+    const runtimeFactory: RuntimeFactory = () => {
+      factoryCall += 1;
+      if (factoryCall === 1) {
+        return new FakeRuntime({ id: "codex", reply: "ok", newSessionId: "sid-1" });
+      }
+      return recoveryRuntime;
+    };
+    const { dispatcher, store, channel } = await scaffold({
+      config: baseConfig({ defaultRoute: { runtime: "codex", cwd: "/tmp/default" } }),
+      runtimeFactory,
+      buildRuntimeRecoveryContext: () =>
+        "[Recent Room Messages]\n- Alice: deploy is failing\n- Bot: I am checking logs",
+    });
+
+    await dispatcher.handle(
+      makeEnvelope({ id: "msg_1", conversation: { id: "rm_oc_recover", kind: "direct" } }),
+    );
+    expect(store.all()[0].runtimeSessionId).toBe("sid-1");
+
+    await dispatcher.handle(
+      makeEnvelope({
+        id: "msg_2",
+        text: "continue",
+        conversation: { id: "rm_oc_recover", kind: "direct" },
+      }),
+    );
+
+    expect(recoveryRuntime.run).toHaveBeenCalledTimes(2);
+    expect(store.all()[0].runtimeSessionId).toBe("sid-2");
+    expect(channel.sends.map((s) => s.message.text)).toEqual(["ok", "recovered"]);
   });
 
   it("treats auth failure text as an error and does not persist the failed session", async () => {

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -23,6 +23,7 @@ import type {
   OutboundObserver,
   QueueMode,
   RuntimeAdapter,
+  RuntimeRecoveryContextBuilder,
   RuntimeRunResult,
   RuntimeCircuitBreakerSnapshot,
   RuntimeStatusEvent,
@@ -182,6 +183,31 @@ function extractCloudRunBudget(msg: GatewayInboundMessage): CloudRunBudgetCaps |
   return out.maxWallTimeMs !== undefined || out.maxToolCalls !== undefined ? out : undefined;
 }
 
+function looksLikeRecoverableSessionFailure(error: string): boolean {
+  return /compact|compaction|context|token limit|maximum context|too many tokens|conversation found|session .*not found|resume/i
+    .test(error);
+}
+
+function buildRuntimeRecoveryPrompt(args: {
+  userTurn: string;
+  error: string;
+  recoveryContext?: string | null;
+}): string {
+  return [
+    "[BotCord Runtime Recovery Notice]",
+    "The previous Codex runtime session for this room became unrecoverable while resuming or compacting context.",
+    `Previous runtime error: ${truncate(args.error, 1000)}`,
+    "You are now running in a fresh Codex session.",
+    "Use the recent room messages below, current filesystem state, and available BotCord memory/context tools to reconstruct the active task.",
+    "Continue the original user request without asking the user to repeat information unless it is missing from those sources.",
+    "",
+    args.recoveryContext?.trim() || "[Recent Room Messages]\n(unavailable)",
+    "",
+    "[Current User Turn]",
+    args.userTurn,
+  ].join("\n");
+}
+
 /** Factory signature for building a runtime adapter at turn dispatch time. */
 export type RuntimeFactory = (
   runtimeId: string,
@@ -217,6 +243,11 @@ export interface DispatcherOptions {
    * keep following stale memory.
    */
   buildMemoryContext?: MemoryContextBuilder;
+  /**
+   * Optional hook that returns recent room context for a fresh-session retry
+   * after a runtime resume session becomes unrecoverable.
+   */
+  buildRuntimeRecoveryContext?: RuntimeRecoveryContextBuilder;
   /**
    * Optional side-effect hook invoked after ack, before the turn runs.
    * Intended for bookkeeping (e.g. activity tracking). Errors are logged
@@ -381,6 +412,7 @@ export class Dispatcher {
   private readonly runtimeAuthFailureCooldownMs: number;
   private readonly buildSystemContext?: SystemContextBuilder;
   private readonly buildMemoryContext?: MemoryContextBuilder;
+  private readonly buildRuntimeRecoveryContext?: RuntimeRecoveryContextBuilder;
   private readonly onInbound?: InboundObserver;
   private readonly onOutbound?: OutboundObserver;
   private readonly onTurnComplete?: DispatcherOptions["onTurnComplete"];
@@ -415,6 +447,7 @@ export class Dispatcher {
       opts.runtimeAuthFailureCooldownMs ?? DEFAULT_RUNTIME_AUTH_FAILURE_COOLDOWN_MS;
     this.buildSystemContext = opts.buildSystemContext;
     this.buildMemoryContext = opts.buildMemoryContext;
+    this.buildRuntimeRecoveryContext = opts.buildRuntimeRecoveryContext;
     this.onInbound = opts.onInbound;
     this.onOutbound = opts.onOutbound;
     this.onTurnComplete = opts.onTurnComplete;
@@ -1604,33 +1637,96 @@ export class Dispatcher {
     const runtime = this.runtimeFactory(route.runtime, route.extraArgs);
     let result: RuntimeRunResult | undefined;
     let threw: unknown;
+    let activeSessionId: string | null = sessionId;
     const turnStartedAt = Date.now();
     try {
       try {
-        result = await runtime.run({
-          text: runtimeText,
-          sessionId,
-          cwd: route.cwd,
-          accountId: msg.accountId,
-          hubUrl: this.resolveHubUrl?.(msg.accountId),
-          extraArgs: route.extraArgs,
-          signal: controller.signal,
-          trustLevel,
-          systemContext,
-          onBlock,
-          onStatus,
-          context: {
-            turnId,
-            messageId: msg.id,
+        const runRuntime = (textForRun: string, sessionIdForRun: string | null) =>
+          runtime.run({
+            text: textForRun,
+            sessionId: sessionIdForRun,
+            cwd: route.cwd,
+            accountId: msg.accountId,
+            hubUrl: this.resolveHubUrl?.(msg.accountId),
+            extraArgs: route.extraArgs,
+            signal: controller.signal,
+            trustLevel,
+            systemContext,
+            onBlock,
+            onStatus,
+            context: {
+              turnId,
+              messageId: msg.id,
+              roomId: msg.conversation.id,
+              topicId: msg.conversation.threadId ?? null,
+              channel: msg.channel,
+              conversationKind: msg.conversation.kind,
+            },
+            ...(cloudRunBudget ? { budget: cloudRunBudget } : {}),
+            gateway: route.gateway,
+            ...(route.hermesProfile ? { hermesProfile: route.hermesProfile } : {}),
+          });
+
+        result = await runRuntime(runtimeText, sessionId);
+        const firstError = result.error ?? "";
+        const firstReply = (result.text || "").trim();
+        const shouldRetryFresh =
+          route.runtime === "codex" &&
+          !!sessionId &&
+          !!firstError &&
+          !firstReply &&
+          !looksLikeRuntimeAuthFailure(firstError) &&
+          looksLikeRecoverableSessionFailure(firstError) &&
+          !controller.signal.aborted &&
+          !slot.timedOut &&
+          !slot.budgetExceeded;
+
+        if (shouldRetryFresh) {
+          try {
+            await this.sessionStore.delete(key);
+            this.log.info("dispatcher: dropped unrecoverable runtime session before fresh retry", {
+              key,
+              prevRuntimeSessionId: sessionId,
+              runtime: route.runtime,
+              error: firstError,
+            });
+          } catch (err) {
+            this.log.warn("dispatcher: session-store.delete failed before fresh retry", {
+              key,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+
+          let recoveryContext: string | null | undefined;
+          if (this.buildRuntimeRecoveryContext) {
+            try {
+              recoveryContext = await this.buildRuntimeRecoveryContext(msg);
+            } catch (err) {
+              this.log.warn("dispatcher: buildRuntimeRecoveryContext threw — retrying without recent room context", {
+                agentId: msg.accountId,
+                roomId: msg.conversation.id,
+                topicId: msg.conversation.threadId ?? null,
+                turnId,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            }
+          }
+
+          activeSessionId = null;
+          runtimeText = buildRuntimeRecoveryPrompt({
+            userTurn: text,
+            error: firstError,
+            recoveryContext,
+          });
+          this.log.info("dispatcher: retrying codex turn in a fresh session with recovery context", {
+            agentId: msg.accountId,
             roomId: msg.conversation.id,
             topicId: msg.conversation.threadId ?? null,
-            channel: msg.channel,
-            conversationKind: msg.conversation.kind,
-          },
-          ...(cloudRunBudget ? { budget: cloudRunBudget } : {}),
-          gateway: route.gateway,
-          ...(route.hermesProfile ? { hermesProfile: route.hermesProfile } : {}),
-        });
+            turnId,
+            queueKey,
+          });
+          result = await runRuntime(runtimeText, null);
+        }
       } catch (err) {
         threw = err;
       } finally {
@@ -1814,12 +1910,12 @@ export class Dispatcher {
       //                                 even when the adapter echoes that id back
       //   result.newSessionId truthy  → upsert the entry
       //   otherwise                   → no-op (e.g. codex intentionally never persists)
-      if (sessionId && effectiveError && !replyText) {
+      if (activeSessionId && effectiveError && !replyText) {
         try {
           await this.sessionStore.delete(key);
           this.log.info("dispatcher: dropped stale runtime session", {
             key,
-            prevRuntimeSessionId: sessionId,
+            prevRuntimeSessionId: activeSessionId,
             nextRuntimeSessionId: result.newSessionId || null,
             error: effectiveError,
           });
@@ -1844,7 +1940,7 @@ export class Dispatcher {
           updatedAt: Date.now(),
         };
         try {
-          const prevRuntimeSessionId = sessionId;
+          const prevRuntimeSessionId = activeSessionId;
           await this.sessionStore.set(session);
           this.log.debug("dispatcher: persisted runtime session", {
             key,
@@ -1857,12 +1953,12 @@ export class Dispatcher {
             error: err instanceof Error ? err.message : String(err),
           });
         }
-      } else if (sessionId && effectiveError) {
+      } else if (activeSessionId && effectiveError) {
         try {
           await this.sessionStore.delete(key);
           this.log.info("dispatcher: dropped stale runtime session", {
             key,
-            prevRuntimeSessionId: sessionId,
+            prevRuntimeSessionId: activeSessionId,
             error: effectiveError,
           });
         } catch (err) {

--- a/packages/daemon/src/gateway/gateway.ts
+++ b/packages/daemon/src/gateway/gateway.ts
@@ -23,6 +23,7 @@ import type {
   InboundObserver,
   MemoryContextBuilder,
   OutboundObserver,
+  RuntimeRecoveryContextBuilder,
   SystemContextBuilder,
   UserTurnBuilder,
 } from "./types.js";
@@ -49,6 +50,11 @@ export interface GatewayBootOptions {
    * resumed runtime sessions get an explicit prompt when memory changes.
    */
   buildMemoryContext?: MemoryContextBuilder;
+  /**
+   * Recent room context provider used by dispatcher when it must discard a
+   * broken runtime session and retry the same turn in a fresh session.
+   */
+  buildRuntimeRecoveryContext?: RuntimeRecoveryContextBuilder;
   /**
    * Observer called after the dispatcher acks each inbound message. Useful
    * for activity tracking or metrics. Errors are logged and swallowed.
@@ -178,6 +184,7 @@ export class Gateway {
       turnTimeoutMs: opts.turnTimeoutMs,
       buildSystemContext: opts.buildSystemContext,
       buildMemoryContext: opts.buildMemoryContext,
+      buildRuntimeRecoveryContext: opts.buildRuntimeRecoveryContext,
       onInbound: opts.onInbound,
       composeUserTurn: opts.composeUserTurn,
       onOutbound: opts.onOutbound,

--- a/packages/daemon/src/gateway/types.ts
+++ b/packages/daemon/src/gateway/types.ts
@@ -154,6 +154,15 @@ export type MemoryContextBuilder = (
 ) => Promise<MemoryContextSnapshot | null | undefined> | MemoryContextSnapshot | null | undefined;
 
 /**
+ * Optional hook used after a runtime session is discarded and retried fresh.
+ * The daemon implementation can pull recent room messages from Hub; gateway
+ * core treats the returned string as opaque recovery context.
+ */
+export type RuntimeRecoveryContextBuilder = (
+  message: GatewayInboundMessage,
+) => Promise<string | null | undefined> | string | null | undefined;
+
+/**
  * Optional hook fired after the dispatcher dispatches a reply to a channel.
  * Intended for outbound bookkeeping (loop-risk tracking, metrics). Errors
  * are caught and logged so observer failures never break the turn.

--- a/packages/daemon/src/room-recovery-context.ts
+++ b/packages/daemon/src/room-recovery-context.ts
@@ -1,0 +1,131 @@
+/**
+ * Build a compact, deterministic recovery block from recent Hub room messages.
+ * Used when a runtime-native session is discarded and the same turn is retried
+ * in a fresh session.
+ */
+import { BotCordClient, loadStoredCredentials } from "@botcord/protocol-core";
+import { sanitizeUntrustedContent } from "./gateway/index.js";
+import type { GatewayInboundMessage } from "./gateway/index.js";
+
+interface CachedClient {
+  client: BotCordClient;
+  credentialsPath: string;
+}
+
+export interface RecentRoomMessagesRecoveryOptions {
+  credentialPathByAgentId: Map<string, string>;
+  defaultCredentialsPath?: string;
+  hubBaseUrl?: string;
+  limit?: number;
+  log?: {
+    warn: (msg: string, meta?: Record<string, unknown>) => void;
+  };
+}
+
+interface RoomMessage {
+  from?: string;
+  from_name?: string;
+  text?: string;
+  type?: string;
+  ts?: string;
+  topic_id?: string | null;
+  topic_title?: string | null;
+}
+
+const DEFAULT_RECENT_LIMIT = 20;
+const MAX_MESSAGE_TEXT_CHARS = 1200;
+
+function stripNewlines(s: string): string {
+  return s.replace(/[\r\n]+/g, " ");
+}
+
+function messageLabel(m: RoomMessage): string {
+  const name = typeof m.from_name === "string" && m.from_name.trim()
+    ? m.from_name
+    : typeof m.from === "string" && m.from.trim()
+      ? m.from
+      : "unknown";
+  return sanitizeUntrustedContent(stripNewlines(name));
+}
+
+function formatRecentMessages(messages: RoomMessage[]): string {
+  if (messages.length === 0) return "[Recent Room Messages]\n(none)";
+  const chronological = [...messages].reverse();
+  const lines = ["[Recent Room Messages]"];
+  for (const m of chronological) {
+    const text = typeof m.text === "string" ? m.text.trim() : "";
+    if (!text) continue;
+    const ts = typeof m.ts === "string" ? m.ts : "";
+    const topic = typeof m.topic_title === "string" && m.topic_title.trim()
+      ? ` topic=${sanitizeUntrustedContent(stripNewlines(m.topic_title))}`
+      : typeof m.topic_id === "string" && m.topic_id
+        ? ` topic=${sanitizeUntrustedContent(stripNewlines(m.topic_id))}`
+        : "";
+    const safeText = sanitizeUntrustedContent(
+      text.length > MAX_MESSAGE_TEXT_CHARS
+        ? `${text.slice(0, MAX_MESSAGE_TEXT_CHARS)}...`
+        : text,
+    );
+    lines.push(`- ${ts ? `${ts} ` : ""}${messageLabel(m)}${topic}: ${safeText}`);
+  }
+  return lines.join("\n");
+}
+
+export function createRecentRoomMessagesRecoveryBuilder(
+  opts: RecentRoomMessagesRecoveryOptions,
+): (message: GatewayInboundMessage) => Promise<string | null> {
+  const clients = new Map<string, CachedClient>();
+  const limit = opts.limit ?? DEFAULT_RECENT_LIMIT;
+
+  function getClient(accountId: string): BotCordClient | null {
+    const existing = clients.get(accountId);
+    if (existing) return existing.client;
+
+    const credsPath =
+      opts.credentialPathByAgentId.get(accountId) ?? opts.defaultCredentialsPath;
+    if (!credsPath) {
+      opts.log?.warn("daemon.recovery-context.no-credentials", { accountId });
+      return null;
+    }
+
+    try {
+      const creds = loadStoredCredentials(credsPath);
+      const client = new BotCordClient({
+        hubUrl: opts.hubBaseUrl ?? creds.hubUrl,
+        agentId: creds.agentId,
+        keyId: creds.keyId,
+        privateKey: creds.privateKey,
+        ...(creds.token ? { token: creds.token } : {}),
+        ...(creds.tokenExpiresAt !== undefined
+          ? { tokenExpiresAt: creds.tokenExpiresAt }
+          : {}),
+      });
+      clients.set(accountId, { client, credentialsPath: credsPath });
+      return client;
+    } catch (err) {
+      opts.log?.warn("daemon.recovery-context.client-init-failed", {
+        accountId,
+        credsPath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
+  }
+
+  return async (message) => {
+    const client = getClient(message.accountId);
+    if (!client) return null;
+    try {
+      const body = await client.roomMessages(message.conversation.id, { limit });
+      const messages = Array.isArray(body?.messages) ? body.messages as RoomMessage[] : [];
+      return formatRecentMessages(messages);
+    } catch (err) {
+      opts.log?.warn("daemon.recovery-context.fetch-failed", {
+        accountId: message.accountId,
+        roomId: message.conversation.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- Retry Codex turns in a fresh session when a resumed session fails with context/compact/session recovery errors.
- Fetch and inject the current room's recent 20 Hub messages as recovery context for the fresh session.
- Wire the recovery context builder into local and cloud daemons, with dispatcher coverage for the retry path.

## Verification
- cd packages/daemon && npm test -- --run src/gateway/__tests__/dispatcher.test.ts
- cd packages/daemon && npm run build

## Risk / rollout
- Recovery is limited to Codex resumed-session failures that look context/session related and excludes auth failures.
- Daemon must have usable agent credentials to fetch recent room messages; if unavailable, it still retries with an explicit unavailable context marker.