### PR TITLE
fix: dedupe dashboard bootstrap requests

### DIFF
--- a/frontend/src/store/README.md
+++ b/frontend/src/store/README.md
@@ -32,6 +32,7 @@ useDashboardSubscriptionStore.ts: Subscription 业务域 store，负责当前 ag
 - 进入房间并真正看到最新位置后，必须通过 BFF 写回 `last_viewed_at`；前端本地未读数量只能做短暂覆盖，不能替代后端状态。
 
 变更日志
+- 2026-05-26: `session/chat/contact` store 为鉴权初始化、Human 房间、overview、owned-agent rooms 与联系人请求增加 in-flight 合并，避免首屏多个 effect/StrictMode 同时触发同一接口。
 - 2026-05-14: 移除 dashboard 前端的 Bot 身份切换能力；`userChatAgentId` 只作为 owner-chat 目标，`useDashboardChatStore.ts` 不再按 Bot 边界清空消息列表。
 - 2026-05-11: `useDashboardRealtimeStore.ts` 在 `room_member_added/room_member_removed` 事件后推进 `useDashboardChatStore.ts` 的房间成员刷新版本，打开中的房间会重新拉取成员，让 @ 候选人与 presence 种子及时包含新成员。
 - 2026-04-28: overview 房间摘要新增 `unread_count`，Messages 一级 tab 与 room 列表使用数量徽标替代未读蓝点。

--- a/frontend/src/store/useDashboardChatStore.test.ts
+++ b/frontend/src/store/useDashboardChatStore.test.ts
@@ -195,6 +195,21 @@ describe("useDashboardChatStore message polling", () => {
     expect(useDashboardChatStore.getState().overviewErrored).toBe(false);
   });
 
+  it("deduplicates concurrent overview refreshes", async () => {
+    let resolveOverview!: (overview: DashboardOverview) => void;
+    mocks.getOverview.mockReturnValue(new Promise<DashboardOverview>((resolve) => {
+      resolveOverview = resolve;
+    }));
+
+    const first = useDashboardChatStore.getState().refreshOverview();
+    const second = useDashboardChatStore.getState().refreshOverview();
+
+    expect(mocks.getOverview).toHaveBeenCalledTimes(1);
+    resolveOverview(makeOverview("2026-05-11T08:00:00Z"));
+    await Promise.all([first, second]);
+    expect(useDashboardChatStore.getState().overview?.rooms[0].last_message_at).toBe("2026-05-11T08:00:00Z");
+  });
+
   it("inserts an optimistic owner-chat room immediately", () => {
     useDashboardChatStore.getState().upsertOptimisticOwnerChatRoom({
       agent_id: "ag_bot",
@@ -225,6 +240,21 @@ describe("useDashboardChatStore message polling", () => {
     const state = useDashboardChatStore.getState();
     expect(state.optimisticOwnerChatRooms).toEqual({});
     expect(state.ownedAgentRooms.map((room) => room.room_id)).toEqual(["rm_oc_real_123"]);
+  });
+
+  it("deduplicates concurrent owner-chat room loads", async () => {
+    let resolveRooms!: (result: { rooms: HumanAgentRoomSummary[] }) => void;
+    mocks.listAgentRooms.mockReturnValue(new Promise<{ rooms: HumanAgentRoomSummary[] }>((resolve) => {
+      resolveRooms = resolve;
+    }));
+
+    const first = useDashboardChatStore.getState().loadOwnedAgentRooms();
+    const second = useDashboardChatStore.getState().loadOwnedAgentRooms();
+
+    expect(mocks.listAgentRooms).toHaveBeenCalledTimes(1);
+    resolveRooms({ rooms: [makeOwnedAgentRoom({ room_id: "rm_oc_deduped" })] });
+    await Promise.all([first, second]);
+    expect(useDashboardChatStore.getState().ownedAgentRooms.map((room) => room.room_id)).toEqual(["rm_oc_deduped"]);
   });
 
   it("keeps an owner-chat row for a new owned bot when the backend has no room yet", async () => {

--- a/frontend/src/store/useDashboardChatStore.ts
+++ b/frontend/src/store/useDashboardChatStore.ts
@@ -321,6 +321,8 @@ function hasTransientChatState(state: DashboardChatState): boolean {
 }
 
 let _errorTimerId: ReturnType<typeof setTimeout> | null = null;
+let overviewInFlight: Promise<void> | null = null;
+let ownedAgentRoomsInFlight: Promise<void> | null = null;
 
 export const useDashboardChatStore = create<DashboardChatState>()(
   persist(
@@ -686,6 +688,9 @@ export const useDashboardChatStore = create<DashboardChatState>()(
       },
 
       refreshOverview: async (opts) => {
+        if (!opts?.reloadOpenedRoom && overviewInFlight) {
+          return overviewInFlight;
+        }
         const { token } = useDashboardSessionStore.getState();
         const openedRoomId = opts?.reloadOpenedRoom
           ? useDashboardUIStore.getState().openedRoomId
@@ -697,26 +702,36 @@ export const useDashboardChatStore = create<DashboardChatState>()(
         }
         // Human-first: /overview resolves the viewer from the Supabase JWT.
 
-        set({ overviewRefreshing: true, overviewErrored: false });
-        try {
-          const overview = await api.getOverview();
-          get().replaceOverview(overview);
-          if (openedRoomId) {
-            void get().loadRoomMessages(openedRoomId);
+        const request = (async () => {
+          set({ overviewRefreshing: true, overviewErrored: false });
+          try {
+            const overview = await api.getOverview();
+            get().replaceOverview(overview);
+            if (openedRoomId) {
+              void get().loadRoomMessages(openedRoomId);
+            }
+          } catch (error: any) {
+            if (isAuthError(error)) {
+              console.warn("[ChatStore] Background overview auth refresh failed:", error);
+              set({ overviewRefreshing: false, overviewErrored: false });
+              return;
+            }
+            if (get().overview && isFetchNetworkError(error)) {
+              console.warn("[ChatStore] Background overview refresh failed:", error);
+              set({ overviewRefreshing: false, overviewErrored: false });
+              return;
+            }
+            set({ error: error?.message || "Failed to refresh", overviewRefreshing: false, overviewErrored: true });
           }
-        } catch (error: any) {
-          if (isAuthError(error)) {
-            console.warn("[ChatStore] Background overview auth refresh failed:", error);
-            set({ overviewRefreshing: false, overviewErrored: false });
-            return;
+        })().finally(() => {
+          if (overviewInFlight === request) {
+            overviewInFlight = null;
           }
-          if (get().overview && isFetchNetworkError(error)) {
-            console.warn("[ChatStore] Background overview refresh failed:", error);
-            set({ overviewRefreshing: false, overviewErrored: false });
-            return;
-          }
-          set({ error: error?.message || "Failed to refresh", overviewRefreshing: false, overviewErrored: true });
+        });
+        if (!opts?.reloadOpenedRoom) {
+          overviewInFlight = request;
         }
+        return request;
       },
 
       loadDiscoverRooms: async () => {
@@ -854,38 +869,46 @@ export const useDashboardChatStore = create<DashboardChatState>()(
       },
 
       loadOwnedAgentRooms: async () => {
+        if (ownedAgentRoomsInFlight) {
+          return ownedAgentRoomsInFlight;
+        }
         const { token, activeIdentity, ownedAgents } = useDashboardSessionStore.getState();
         if (!token || activeIdentity?.type !== "human") {
           set({ ownedAgentRooms: [], ownedAgentRoomsLoading: false, ownedAgentRoomsLoaded: true });
           return;
         }
-        set({ ownedAgentRoomsLoading: true });
-        try {
-          const result = await humansApi.listAgentRooms();
-          const optimisticOwnerChatRooms = reconcileOptimisticOwnerChatRooms(
-            result.rooms,
-            get().optimisticOwnerChatRooms,
-          );
-          set({
-            ownedAgentRooms: ensureOwnerChatRoomsForOwnedAgents(
-              mergeOptimisticOwnerChatRooms(result.rooms, optimisticOwnerChatRooms),
-              ownedAgents,
-            ),
-            optimisticOwnerChatRooms,
-            ownedAgentRoomsLoading: false,
-            ownedAgentRoomsLoaded: true,
-          });
-        } catch (error) {
-          set({
-            ownedAgentRooms: ensureOwnerChatRoomsForOwnedAgents(
-              get().ownedAgentRooms,
-              ownedAgents,
-            ),
-            ownedAgentRoomsLoading: false,
-            ownedAgentRoomsLoaded: true,
-          });
-          get().setError(error instanceof Error ? error.message : "Failed to load bot rooms");
-        }
+        ownedAgentRoomsInFlight = (async () => {
+          set({ ownedAgentRoomsLoading: true });
+          try {
+            const result = await humansApi.listAgentRooms();
+            const optimisticOwnerChatRooms = reconcileOptimisticOwnerChatRooms(
+              result.rooms,
+              get().optimisticOwnerChatRooms,
+            );
+            set({
+              ownedAgentRooms: ensureOwnerChatRoomsForOwnedAgents(
+                mergeOptimisticOwnerChatRooms(result.rooms, optimisticOwnerChatRooms),
+                ownedAgents,
+              ),
+              optimisticOwnerChatRooms,
+              ownedAgentRoomsLoading: false,
+              ownedAgentRoomsLoaded: true,
+            });
+          } catch (error) {
+            set({
+              ownedAgentRooms: ensureOwnerChatRoomsForOwnedAgents(
+                get().ownedAgentRooms,
+                ownedAgents,
+              ),
+              ownedAgentRoomsLoading: false,
+              ownedAgentRoomsLoaded: true,
+            });
+            get().setError(error instanceof Error ? error.message : "Failed to load bot rooms");
+          }
+        })().finally(() => {
+          ownedAgentRoomsInFlight = null;
+        });
+        return ownedAgentRoomsInFlight;
       },
 
       upsertOptimisticOwnerChatRoom: (agent, roomId) => {

--- a/frontend/src/store/useDashboardContactStore.ts
+++ b/frontend/src/store/useDashboardContactStore.ts
@@ -39,6 +39,8 @@ const initialContactState = {
   sendingContactRequestAgentId: null,
 };
 
+let contactRequestsInFlight: Promise<void> | null = null;
+
 function isHumanContactSurface() {
   const { activeIdentity, viewMode } = useDashboardSessionStore.getState();
   return activeIdentity?.type === "human" || viewMode === "human";
@@ -82,6 +84,9 @@ export const useDashboardContactStore = create<DashboardContactState>()((set, ge
   resetContactState: () => set({ ...initialContactState }),
 
   loadContactRequests: async () => {
+    if (contactRequestsInFlight) {
+      return contactRequestsInFlight;
+    }
     if (!hasReadyContactIdentity()) {
       set({
         contactRequestsReceived: [],
@@ -91,37 +96,42 @@ export const useDashboardContactStore = create<DashboardContactState>()((set, ge
       });
       return;
     }
-    set({ contactRequestsLoading: true });
-    try {
-      const [received, sent, botApprovalCount] = isHumanContactSurface()
-        ? await Promise.all([
-            humansApi.listReceivedContactRequests(),
-            humansApi.listSentContactRequests(),
-            humansApi.listPendingApprovals(),
-          ]).then(([receivedRes, sentRes, approvalsRes]) => [
-            { requests: receivedRes.requests.map(normalizeHumanContactRequest) },
-            { requests: sentRes.requests.map(normalizeHumanContactRequest) },
-            approvalsRes.approvals.filter((approval) => (
-              approval.kind === "contact_request" && !approval.id.startsWith("cr_")
-            )).length,
-          ] as const)
-        : await Promise.all([
-            api.getContactRequestsReceived(),
-            api.getContactRequestsSent(),
-          ]).then(([receivedRes, sentRes]) => [receivedRes, sentRes, 0] as const);
-      const pendingSentTargets = sent.requests
-        .filter((item) => item.state === "pending")
-        .map((item) => item.to_agent_id);
-      set({
-        contactRequestsReceived: received.requests,
-        contactRequestsSent: sent.requests,
-        contactRequestsBotApprovalCount: botApprovalCount,
-        pendingFriendRequests: Array.from(new Set([...get().pendingFriendRequests, ...pendingSentTargets])),
-        contactRequestsLoading: false,
-      });
-    } catch {
-      set({ contactRequestsLoading: false });
-    }
+    contactRequestsInFlight = (async () => {
+      set({ contactRequestsLoading: true });
+      try {
+        const [received, sent, botApprovalCount] = isHumanContactSurface()
+          ? await Promise.all([
+              humansApi.listReceivedContactRequests(),
+              humansApi.listSentContactRequests(),
+              humansApi.listPendingApprovals(),
+            ]).then(([receivedRes, sentRes, approvalsRes]) => [
+              { requests: receivedRes.requests.map(normalizeHumanContactRequest) },
+              { requests: sentRes.requests.map(normalizeHumanContactRequest) },
+              approvalsRes.approvals.filter((approval) => (
+                approval.kind === "contact_request" && !approval.id.startsWith("cr_")
+              )).length,
+            ] as const)
+          : await Promise.all([
+              api.getContactRequestsReceived(),
+              api.getContactRequestsSent(),
+            ]).then(([receivedRes, sentRes]) => [receivedRes, sentRes, 0] as const);
+        const pendingSentTargets = sent.requests
+          .filter((item) => item.state === "pending")
+          .map((item) => item.to_agent_id);
+        set({
+          contactRequestsReceived: received.requests,
+          contactRequestsSent: sent.requests,
+          contactRequestsBotApprovalCount: botApprovalCount,
+          pendingFriendRequests: Array.from(new Set([...get().pendingFriendRequests, ...pendingSentTargets])),
+          contactRequestsLoading: false,
+        });
+      } catch {
+        set({ contactRequestsLoading: false });
+      }
+    })().finally(() => {
+      contactRequestsInFlight = null;
+    });
+    return contactRequestsInFlight;
   },
 
   sendContactRequest: async (toAgentId: string, message?: string) => {

--- a/frontend/src/store/useDashboardSessionStore.ts
+++ b/frontend/src/store/useDashboardSessionStore.ts
@@ -85,6 +85,8 @@ function deriveIdentityFromHuman(human: HumanInfo | null): ActiveIdentity | null
 }
 
 let authInitRequestId = 0;
+let authInitInFlight: { token: string; promise: Promise<void> } | null = null;
+let humanRoomsInFlight: Promise<void> | null = null;
 
 function resolveDefaultAgentId(user: UserProfile): string | null {
   const defaultAgent = user.agents.find((agent) => agent.is_default) || user.agents[0];
@@ -179,6 +181,9 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
   },
 
   initAuth: async (token: string) => {
+    if (authInitInFlight?.token === token) {
+      return authInitInFlight.promise;
+    }
     const requestId = ++authInitRequestId;
     const current = get();
     const shouldShowBootstrap = !current.authResolved;
@@ -189,75 +194,91 @@ export const useDashboardSessionStore = create<DashboardSessionState>()((set, ge
       token,
     });
 
-    try {
-      const [user, human, humanRoomsRes] = await Promise.all([
-        userApi.getMe(),
-        // Idempotent — the first call mints the Human identity for brand-new
-        // users; subsequent calls return the existing record. Failure here is
-        // non-fatal: Human-first features degrade but Agent flows keep working.
-        humansApi.createOrGet().catch((err) => {
-          console.warn("[SessionStore] Failed to load Human identity:", err);
-          return null;
-        }),
-        humansApi.listRooms().catch((err) => {
-          console.warn("[SessionStore] Failed to load Human rooms:", err);
-          return { rooms: [] as HumanRoomSummary[] };
-        }),
-      ]);
-      if (requestId !== authInitRequestId) {
-        return;
-      }
-      const activeId = resolveDefaultAgentId(user);
-      const activeIdentity = deriveIdentityFromHuman(human);
-      setStoredActiveIdentity(activeIdentity);
-      syncOwnedAgentsPresence(user.agents);
-      set({
-        authResolved: true,
-        authBootstrapping: false,
-        token,
-        user,
-        human,
-        humanRooms: humanRoomsRes.rooms,
-        ownedAgents: user.agents,
-        activeAgentId: activeId,
-        activeIdentity,
-        viewMode: "human",
-        sessionMode: resolveSessionMode(token, activeId),
-      });
-    } catch (err: any) {
-      if (requestId !== authInitRequestId) {
-        return;
-      }
-      if (err?.status === 401 || err?.status === 403) {
-        setStoredActiveIdentity(null);
+    const promise = (async () => {
+      try {
+        const [user, human, humanRoomsRes] = await Promise.all([
+          userApi.getMe(),
+          // Idempotent — the first call mints the Human identity for brand-new
+          // users; subsequent calls return the existing record. Failure here is
+          // non-fatal: Human-first features degrade but Agent flows keep working.
+          humansApi.createOrGet().catch((err) => {
+            console.warn("[SessionStore] Failed to load Human identity:", err);
+            return null;
+          }),
+          humansApi.listRooms().catch((err) => {
+            console.warn("[SessionStore] Failed to load Human rooms:", err);
+            return { rooms: [] as HumanRoomSummary[] };
+          }),
+        ]);
+        if (requestId !== authInitRequestId) {
+          return;
+        }
+        const activeId = resolveDefaultAgentId(user);
+        const activeIdentity = deriveIdentityFromHuman(human);
+        setStoredActiveIdentity(activeIdentity);
+        syncOwnedAgentsPresence(user.agents);
         set({
-          ...initialSessionState,
           authResolved: true,
           authBootstrapping: false,
+          token,
+          user,
+          human,
+          humanRooms: humanRoomsRes.rooms,
+          ownedAgents: user.agents,
+          activeAgentId: activeId,
+          activeIdentity,
+          viewMode: "human",
+          sessionMode: resolveSessionMode(token, activeId),
         });
-        return;
+      } catch (err: any) {
+        if (requestId !== authInitRequestId) {
+          return;
+        }
+        if (err?.status === 401 || err?.status === 403) {
+          setStoredActiveIdentity(null);
+          set({
+            ...initialSessionState,
+            authResolved: true,
+            authBootstrapping: false,
+          });
+          return;
+        }
+        setStoredActiveIdentity(null);
+        set({
+          authResolved: true,
+          authBootstrapping: false,
+          token,
+          user: null,
+          ownedAgents: [],
+          activeAgentId: null,
+          activeIdentity: null,
+          sessionMode: "authed-no-agent",
+        });
       }
-      setStoredActiveIdentity(null);
-      set({
-        authResolved: true,
-        authBootstrapping: false,
-        token,
-        user: null,
-        ownedAgents: [],
-        activeAgentId: null,
-        activeIdentity: null,
-        sessionMode: "authed-no-agent",
-      });
-    }
+    })().finally(() => {
+      if (authInitInFlight?.token === token) {
+        authInitInFlight = null;
+      }
+    });
+    authInitInFlight = { token, promise };
+    return promise;
   },
 
   refreshHumanRooms: async () => {
-    try {
-      const res = await humansApi.listRooms();
-      set({ humanRooms: res.rooms });
-    } catch (err) {
-      console.warn("[SessionStore] refreshHumanRooms failed:", err);
+    if (humanRoomsInFlight) {
+      return humanRoomsInFlight;
     }
+    humanRoomsInFlight = (async () => {
+      try {
+        const res = await humansApi.listRooms();
+        set({ humanRooms: res.rooms });
+      } catch (err) {
+        console.warn("[SessionStore] refreshHumanRooms failed:", err);
+      }
+    })().finally(() => {
+      humanRoomsInFlight = null;
+    });
+    return humanRoomsInFlight;
   },
 
   refreshUserProfile: async () => {


### PR DESCRIPTION
## Summary
- Add in-flight request coalescing for dashboard auth bootstrap, Human rooms, overview, owned-agent rooms, and contact request loaders.
- Add focused tests for concurrent overview and owned-agent room loads.
- Document the store-level request coalescing decision.

## Verification
- npm run test -- useDashboardChatStore useDashboardUIStore usePolicyStore
- npm run build reached compile/TypeScript/static generation, then failed because local Supabase URL/API key env vars are not configured for prerendering /admin/codes.

## Risk / rollout
- Low frontend state-store change; repeated callers now share the same Promise while a request is in flight.
- The existing reloadOpenedRoom overview path still bypasses the generic overview coalescer so explicit room reload behavior is preserved.