### PR TITLE
fix: avoid restarting online cloud daemon on agent create

### DIFF
--- a/backend/hub/services/cloud_agent.py
+++ b/backend/hub/services/cloud_agent.py
@@ -390,6 +390,19 @@ class CloudAgentService:
         cloud_daemon.active_agent_count = (cloud_daemon.active_agent_count or 0) + 1
         await db.flush()
 
+        if is_cloud_daemon_online(cloud_daemon.id):
+            cloud_daemon.status = "ready"
+            cloud_daemon.error_code = None
+            cloud_daemon.error_message = None
+            cloud_daemon.last_seen_at = _now()
+            await db.commit()
+
+            await self._provision_one(db, cloud_agent, agent, cloud_daemon)
+            await db.refresh(cloud_agent)
+            await db.refresh(cloud_daemon)
+            await db.refresh(agent)
+            return _make_view(agent, cloud_agent, cloud_daemon)
+
         # Hand off to the provider. The fake provider returns ready
         # synchronously; the E2B provider will return ``starting`` and
         # transition to ``ready`` once the daemon's hello frame lands.

--- a/backend/tests/test_cloud_agent_service.py
+++ b/backend/tests/test_cloud_agent_service.py
@@ -10,6 +10,7 @@ import pytest_asyncio
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+import hub.services.cloud_agent as cloud_agent_service
 from hub.auth import assert_current_agent_token
 from hub.enums import KeyState, MessageState
 from hub.i18n import I18nHTTPException
@@ -171,6 +172,52 @@ async def test_two_agents_share_a_cloud_daemon(db_session):
     # treats it as a no-op create).
     calls = fake.calls(a.cloud_daemon_instance_id)
     assert calls["create"] == 2
+
+
+@pytest.mark.asyncio
+async def test_create_agent_on_online_cloud_daemon_provisions_without_restart(
+    db_session, monkeypatch
+):
+    user_id = uuid.uuid4()
+    svc, fake = _make_service(max_per_user=4, max_agents_per_daemon=3)
+    first = await svc.create_cloud_agent(
+        db_session, user_id=user_id, body=CreateCloudAgentInput(name="A")
+    )
+
+    sent_frames: list[tuple[str, str, dict]] = []
+
+    async def fake_send_cloud_control_frame(
+        cloud_daemon_instance_id: str,
+        type_: str,
+        params: dict | None = None,
+        timeout_ms: int | None = None,
+    ) -> dict:
+        sent_frames.append((cloud_daemon_instance_id, type_, params or {}))
+        agent_id = (params or {}).get("credentials", {}).get("agentId")
+        return {"ok": True, "result": {"agentId": agent_id}}
+
+    monkeypatch.setattr(
+        cloud_agent_service,
+        "is_cloud_daemon_online",
+        lambda cloud_daemon_instance_id: cloud_daemon_instance_id
+        == first.cloud_daemon_instance_id,
+    )
+    monkeypatch.setattr(
+        cloud_agent_service,
+        "send_cloud_control_frame",
+        fake_send_cloud_control_frame,
+    )
+
+    second = await svc.create_cloud_agent(
+        db_session, user_id=user_id, body=CreateCloudAgentInput(name="B")
+    )
+
+    assert second.status == "ready"
+    assert second.cloud_daemon_instance_id == first.cloud_daemon_instance_id
+    assert fake.calls(first.cloud_daemon_instance_id)["create"] == 1
+    assert [frame[1] for frame in sent_frames] == ["provision_agent"]
+    assert sent_frames[0][0] == first.cloud_daemon_instance_id
+    assert sent_frames[0][2]["credentials"]["agentId"] == second.agent_id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- provision new cloud agents directly when their shared cloud daemon is already online
- avoid calling the E2B provider/startup command for the online add-agent path
- add regression coverage that verifies only `provision_agent` is sent and provider create is not called again

## Verification
- `cd backend && uv run pytest tests/test_cloud_agent_service.py tests/test_cloud_daemon_provider_e2b.py -q`

## Risk / rollout
- Reduces duplicate cloud daemon startup risk for shared sandboxes.
- Existing offline/resume flow still uses provider create_or_resume.