### PR TITLE
fix: scope ingress runtime sessions by gateway

### DIFF
--- a/packages/gateway-ingress/src/__tests__/orchestrator.test.ts
+++ b/packages/gateway-ingress/src/__tests__/orchestrator.test.ts
@@ -135,6 +135,43 @@ describe("IngressOrchestrator", () => {
     expect(events[0]!.status).toBe("delivering");
   });
 
+  it("does not reuse a runtime WS across gateway token scopes", async () => {
+    const wechatConn: GatewayConnection = {
+      id: "gw_wc_alpha",
+      agentId: CONN.agentId,
+      provider: "wechat",
+      status: "active",
+      enabled: true,
+      config: {},
+      createdAt: 2,
+      updatedAt: 2,
+    };
+    const wechatMessage: GatewayInboundMessage = {
+      ...NORMALIZED,
+      id: "wechat:alice:1",
+      channel: wechatConn.id,
+      conversation: { id: "wechat:user:alice", kind: "direct" },
+      sender: { id: "wechat:user:alice", name: "alice", kind: "user" },
+      text: "hi from wechat",
+    };
+    h.store.upsertConnection(wechatConn);
+
+    await h.orchestrator.ingest(CONN.id, NORMALIZED, "tg:gw:scope");
+    await waitFor(() => h.socketFactory.sockets.length === 1);
+    await h.orchestrator.ingest(wechatConn.id, wechatMessage, "wechat:gw:scope");
+    await waitFor(() => h.socketFactory.sockets.length === 2);
+
+    await waitFor(() => h.socketFactory.sockets.every((sock) => sock.sent.length === 1));
+    const firstFrame = JSON.parse(h.socketFactory.sockets[0]!.sent[0]!) as GatewayInboundFrame;
+    const secondFrame = JSON.parse(h.socketFactory.sockets[1]!.sent[0]!) as GatewayInboundFrame;
+    expect(firstFrame.gateway_id).toBe(CONN.id);
+    expect(secondFrame.gateway_id).toBe(wechatConn.id);
+    expect(h.hub.ensureRunningCalls.map((c) => c.body.gateway_id)).toEqual([
+      CONN.id,
+      wechatConn.id,
+    ]);
+  });
+
   it("dedupes by providerEventId", async () => {
     await h.orchestrator.ingest(CONN.id, NORMALIZED, "tg:gw:dup");
     const second = await h.orchestrator.ingest(CONN.id, NORMALIZED, "tg:gw:dup");

--- a/packages/gateway-ingress/src/orchestrator.ts
+++ b/packages/gateway-ingress/src/orchestrator.ts
@@ -198,7 +198,7 @@ export class IngressOrchestrator {
     }
 
     try {
-      await this.opts.runtime.ensureSession(connection.agentId, runtimeMeta);
+      await this.opts.runtime.ensureSession(connection.agentId, connection.id, runtimeMeta);
     } catch (err) {
       this.opts.store.updateEvent(event.eventId, {
         status: "queued",

--- a/packages/gateway-ingress/src/runtime/session.ts
+++ b/packages/gateway-ingress/src/runtime/session.ts
@@ -64,7 +64,9 @@ export interface RuntimeSessionManagerOptions {
 }
 
 interface ActiveSession {
+  key: string;
   agentId: string;
+  gatewayId: string;
   socket: RuntimeSocketLike;
   metadata: RuntimeSessionMetadata;
   // Reject any send() attempts after the socket closes; resolved
@@ -92,15 +94,21 @@ export class RuntimeSessionManager {
 
   constructor(private readonly opts: RuntimeSessionManagerOptions) {}
 
+  private sessionKey(agentId: string, gatewayId: string): string {
+    return `${agentId}:${gatewayId}`;
+  }
+
   /** Open or reuse the session for one agent. */
   async ensureSession(
     agentId: string,
+    gatewayId: string,
     metadata: RuntimeSessionMetadata,
   ): Promise<void> {
-    const current = this.sessions.get(agentId);
+    const key = this.sessionKey(agentId, gatewayId);
+    const current = this.sessions.get(key);
     if (current && current.socket.readyState === RUNTIME_SOCKET_STATE.OPEN) return;
 
-    if (current) await this.closeSession(agentId, "stale_socket");
+    if (current) await this.closeSession(agentId, gatewayId, "stale_socket");
 
     const socket = await this.opts.socketFactory(
       metadata.session_endpoint,
@@ -120,7 +128,7 @@ export class RuntimeSessionManager {
     });
 
     socket.on("open", () => {
-      this.opts.log.debug("runtime session open", { agentId });
+      this.opts.log.debug("runtime session open", { agentId, gatewayId });
       resolveReady();
     });
 
@@ -131,35 +139,37 @@ export class RuntimeSessionManager {
       try {
         frame = JSON.parse(raw) as RuntimeOutboundFrame;
       } catch (err) {
-        this.opts.log.warn("runtime session bad frame", { agentId, err: String(err) });
+        this.opts.log.warn("runtime session bad frame", { agentId, gatewayId, err: String(err) });
         return;
       }
       Promise.resolve(this.opts.hooks.onFrame(agentId, frame)).catch((err) => {
-        this.opts.log.error("runtime hook threw", { agentId, err: String(err) });
+        this.opts.log.error("runtime hook threw", { agentId, gatewayId, err: String(err) });
       });
     });
 
     socket.on("close", (code, reason) => {
-      this.opts.log.info("runtime session closed", { agentId, code, reason: String(reason ?? "") });
-      this.sessions.delete(agentId);
+      this.opts.log.info("runtime session closed", { agentId, gatewayId, code, reason: String(reason ?? "") });
+      this.sessions.delete(key);
       this.opts.hooks.onClose(agentId, `code=${code}`);
       resolveClosed();
     });
 
     socket.on("error", (err) => {
-      this.opts.log.warn("runtime session error", { agentId, err: String(err) });
+      this.opts.log.warn("runtime session error", { agentId, gatewayId, err: String(err) });
       rejectReady(err instanceof Error ? err : new Error(String(err)));
     });
 
     const session: ActiveSession = {
+      key,
       agentId,
+      gatewayId,
       socket,
       metadata,
       ready,
       closed,
       resolveClosed,
     };
-    this.sessions.set(agentId, session);
+    this.sessions.set(key, session);
     // If the socket reports OPEN already (test fakes commonly do), resolve immediately.
     if (socket.readyState === RUNTIME_SOCKET_STATE.OPEN) resolveReady();
     await ready;
@@ -167,37 +177,39 @@ export class RuntimeSessionManager {
 
   /** Push a `gateway_inbound` frame down the session. */
   async sendInbound(frame: GatewayInboundFrame): Promise<void> {
-    const session = this.sessions.get(frame.agent_id);
+    const session = this.sessions.get(this.sessionKey(frame.agent_id, frame.gateway_id));
     if (!session) {
-      throw new Error(`no runtime session for ${frame.agent_id}`);
+      throw new Error(`no runtime session for ${frame.agent_id}/${frame.gateway_id}`);
     }
     await session.ready;
     if (session.socket.readyState !== RUNTIME_SOCKET_STATE.OPEN) {
-      throw new Error(`runtime session for ${frame.agent_id} is not open`);
+      throw new Error(`runtime session for ${frame.agent_id}/${frame.gateway_id} is not open`);
     }
     session.socket.send(JSON.stringify(frame));
   }
 
   hasSession(agentId: string): boolean {
-    const s = this.sessions.get(agentId);
-    return !!s && s.socket.readyState === RUNTIME_SOCKET_STATE.OPEN;
+    for (const s of this.sessions.values()) {
+      if (s.agentId === agentId && s.socket.readyState === RUNTIME_SOCKET_STATE.OPEN) return true;
+    }
+    return false;
   }
 
-  async closeSession(agentId: string, reason: string): Promise<void> {
-    const session = this.sessions.get(agentId);
+  async closeSession(agentId: string, gatewayId: string, reason: string): Promise<void> {
+    const session = this.sessions.get(this.sessionKey(agentId, gatewayId));
     if (!session) return;
     try {
       session.socket.close(1000, reason);
     } catch {
       // ignore
     }
-    this.sessions.delete(agentId);
+    this.sessions.delete(session.key);
     session.resolveClosed();
   }
 
   async closeAll(reason: string): Promise<void> {
-    for (const id of [...this.sessions.keys()]) {
-      await this.closeSession(id, reason);
+    for (const session of [...this.sessions.values()]) {
+      await this.closeSession(session.agentId, session.gatewayId, reason);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Scope gateway-ingress runtime WS sessions by agent and gateway id instead of agent only.
- Prevent one gateway from reusing a runtime token/session minted for another gateway.
- Add regression coverage for same-agent Telegram and WeChat deliveries using separate runtime sessions.

## Verification
- cd packages/gateway-ingress && npm test -- --run src/__tests__/orchestrator.test.ts
- cd packages/gateway-ingress && npm run build
- cd packages/gateway-ingress && npm test

## Risk / rollout
- Low risk; narrows runtime session reuse to match Hub token scope. Existing same-gateway reuse is preserved.