### PR TITLE
fix: parse DeepSeek TUI stream events

### DIFF
--- a/frontend/src/components/dashboard/StreamBlocksView.tsx
+++ b/frontend/src/components/dashboard/StreamBlocksView.tsx
@@ -165,6 +165,11 @@ function blockDetails(raw: unknown, payload?: Record<string, unknown>): string {
     typeof rawAny?.text === "string" ? rawAny.text
     : typeof rawAny?.message === "string" ? rawAny.message
     : typeof rawAny?.summary === "string" ? rawAny.summary
+    : typeof rawAny?.payload?.delta === "string" ? rawAny.payload.delta
+    : typeof rawAny?.payload?.item?.detail === "string" ? rawAny.payload.item.detail
+    : typeof rawAny?.payload?.item?.summary === "string" ? rawAny.payload.item.summary
+    : typeof rawAny?.payload?.payload?.item?.detail === "string" ? rawAny.payload.payload.item.detail
+    : typeof rawAny?.payload?.payload?.item?.summary === "string" ? rawAny.payload.payload.item.summary
     : "";
   if (direct) return direct;
   const contentText = extractContentText(rawAny?.content ?? rawAny?.message?.content ?? rawAny?.params?.update?.content);
@@ -264,8 +269,13 @@ function extractDeepseekToolCall(raw: any): { name: string; params?: unknown; id
     };
   }
 
-  if (payload.event === "item.started") {
-    const inner = payload.payload && typeof payload.payload === "object" ? payload.payload : {};
+  if (raw?.event === "item.started" || payload.event === "item.started") {
+    const inner =
+      raw?.event === "item.started"
+        ? payload
+        : payload.payload && typeof payload.payload === "object"
+          ? payload.payload
+          : {};
     const item = inner.item && typeof inner.item === "object" ? inner.item : undefined;
     const tool = inner.tool && typeof inner.tool === "object" ? inner.tool : item?.tool;
     return {
@@ -344,8 +354,18 @@ function extractDeepseekToolResult(raw: any): { name?: string; result: string; i
     };
   }
 
-  if (payload.event === "item.completed" || payload.event === "item.failed") {
-    const inner = payload.payload && typeof payload.payload === "object" ? payload.payload : {};
+  if (
+    raw?.event === "item.completed" ||
+    raw?.event === "item.failed" ||
+    payload.event === "item.completed" ||
+    payload.event === "item.failed"
+  ) {
+    const inner =
+      raw?.event === "item.completed" || raw?.event === "item.failed"
+        ? payload
+        : payload.payload && typeof payload.payload === "object"
+          ? payload.payload
+          : {};
     const item = inner.item && typeof inner.item === "object" ? inner.item : undefined;
     const result =
       item?.output ??
@@ -777,6 +797,20 @@ export default function StreamBlocksView({
         const raw = b.block.raw as any;
         if (k === "assistant_text" && typeof raw?.item?.text === "string") {
           parts.push(raw.item.text);
+          continue;
+        }
+        if (
+          k === "assistant_text" &&
+          raw?.event === "item.delta" &&
+          (raw?.payload?.kind === "agent_message" || raw?.payload?.payload?.kind === "agent_message")
+        ) {
+          parts.push(
+            typeof raw?.payload?.delta === "string"
+              ? raw.payload.delta
+              : typeof raw?.payload?.payload?.delta === "string"
+                ? raw.payload.payload.delta
+                : "",
+          );
           continue;
         }
         const contents = raw?.message?.content;

--- a/frontend/src/store/useOwnerChatStore.ts
+++ b/frontend/src/store/useOwnerChatStore.ts
@@ -51,6 +51,21 @@ function extractAssistantText(blocks: StreamBlockEntry[]): string {
         parts.push(raw.item.text);
         continue;
       }
+      // DeepSeek TUI: raw { event: "item.delta", payload: { kind: "agent_message", delta } }
+      if (
+        kind === "assistant_text" &&
+        raw?.event === "item.delta" &&
+        (raw?.payload?.kind === "agent_message" || raw?.payload?.payload?.kind === "agent_message")
+      ) {
+        parts.push(
+          typeof raw?.payload?.delta === "string"
+            ? raw.payload.delta
+            : typeof raw?.payload?.payload?.delta === "string"
+              ? raw.payload.payload.delta
+              : "",
+        );
+        continue;
+      }
       // Claude-code: raw.message.content[*].text where type === "text"
       const contents = raw?.message?.content;
       if (Array.isArray(contents)) {

--- a/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
+++ b/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
@@ -925,6 +925,103 @@ describe("createBotCordChannel — streamBlock()", () => {
     }
   });
 
+  it("normalizes current DeepSeek item.delta assistant text", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    try {
+      const client = makeClient({
+        getHubUrl: vi.fn().mockReturnValue("https://hub.example.com"),
+      });
+      const channel = createBotCordChannel({
+        id: "botcord-main",
+        accountId: "ag_self",
+        agentId: "ag_self",
+        client,
+        hubBaseUrl: "https://hub.example.com",
+      });
+      await channel.streamBlock!({
+        traceId: "m_trace",
+        accountId: "ag_self",
+        conversationId: "rm_oc_1",
+        block: {
+          kind: "assistant_text",
+          seq: 6,
+          raw: {
+            event: "item.delta",
+            payload: { thread_id: "thr_1", turn_id: "turn_1", kind: "agent_message", delta: "hello" },
+          },
+        },
+        log: silentLog,
+      });
+      const [, init] = fetchSpy.mock.calls[0];
+      const body = JSON.parse(init.body as string);
+      expect(body.block).toEqual({
+        kind: "assistant",
+        seq: 6,
+        payload: { text: "hello" },
+      });
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  it("normalizes current DeepSeek item.started tool input", () => {
+    expect(
+      __normalizeBlockForHubForTests(
+        {
+          kind: "tool_use",
+          seq: 7,
+          raw: {
+            event: "item.started",
+            payload: {
+              item: { id: "item_tool", kind: "tool_call", status: "in_progress" },
+              tool: { id: "call_1", name: "web_search", input: { query: "上海天气" } },
+            },
+          },
+        },
+        7,
+      ),
+    ).toEqual({
+      kind: "tool_call",
+      seq: 7,
+      payload: {
+        id: "call_1",
+        name: "web_search",
+        params: { query: "上海天气" },
+        status: "in_progress",
+      },
+    });
+  });
+
+  it("normalizes current DeepSeek agent_reasoning details", () => {
+    expect(
+      __normalizeBlockForHubForTests(
+        {
+          kind: "thinking",
+          seq: 8,
+          raw: {
+            event: "item.completed",
+            payload: {
+              item: {
+                id: "item_reasoning",
+                kind: "agent_reasoning",
+                status: "completed",
+                summary: "I should answer briefly.",
+                detail: "I should answer briefly.",
+              },
+            },
+          },
+        },
+        8,
+      ),
+    ).toEqual({
+      kind: "thinking",
+      seq: 8,
+      payload: { details: "I should answer briefly." },
+    });
+  });
+
   it("marks DeepSeek terminal events for owner-chat stream cleanup", async () => {
     const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
     const realFetch = globalThis.fetch;

--- a/packages/daemon/src/gateway/__tests__/deepseek-tui-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/deepseek-tui-adapter.test.ts
@@ -175,6 +175,183 @@ describe("DeepseekTuiAdapter", () => {
     }
   });
 
+  it("parses current DeepSeek item.delta agent_message events as assistant text", async () => {
+    const server = await startMockDeepseekServer({
+      events: [
+        {
+          event: "turn.started",
+          data: {
+            seq: 1,
+            thread_id: "thr_test",
+            turn_id: "turn_test",
+            event: "turn.started",
+            payload: { turn: { status: "in_progress" } },
+          },
+        },
+        {
+          event: "item.started",
+          data: {
+            seq: 2,
+            thread_id: "thr_test",
+            turn_id: "turn_test",
+            item_id: "item_msg",
+            event: "item.started",
+            payload: { item: { id: "item_msg", kind: "agent_message", status: "in_progress" } },
+          },
+        },
+        {
+          event: "item.delta",
+          data: {
+            seq: 3,
+            thread_id: "thr_test",
+            turn_id: "turn_test",
+            item_id: "item_msg",
+            event: "item.delta",
+            payload: { kind: "agent_message", delta: "hello " },
+          },
+        },
+        {
+          event: "item.delta",
+          data: {
+            seq: 4,
+            thread_id: "thr_test",
+            turn_id: "turn_test",
+            item_id: "item_msg",
+            event: "item.delta",
+            payload: { kind: "agent_message", delta: "deepseek" },
+          },
+        },
+        {
+          event: "turn.completed",
+          data: {
+            seq: 5,
+            thread_id: "thr_test",
+            turn_id: "turn_test",
+            event: "turn.completed",
+            payload: { turn: { status: "completed" } },
+          },
+        },
+      ],
+    });
+    try {
+      const { result, blocks, status } = runAdapter(server.baseUrl, server.token);
+      const res = await result;
+      expect(res).toEqual({ text: "hello deepseek", newSessionId: server.threadId });
+      expect(blocks).toContain("assistant_text");
+      expect(status.at(-1)).toEqual({ phase: "stopped", label: undefined });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("parses current DeepSeek item.started/item.completed tool events", async () => {
+    const server = await startMockDeepseekServer({
+      events: [
+        {
+          event: "turn.started",
+          data: { thread_id: "thr_test", turn_id: "turn_test", event: "turn.started" },
+        },
+        {
+          event: "item.started",
+          data: {
+            thread_id: "thr_test",
+            turn_id: "turn_test",
+            event: "item.started",
+            payload: {
+              item: { id: "item_tool", kind: "tool_call", status: "in_progress" },
+              tool: { id: "call_1", name: "web_search", input: { query: "Shanghai weather" } },
+            },
+          },
+        },
+        {
+          event: "item.completed",
+          data: {
+            thread_id: "thr_test",
+            turn_id: "turn_test",
+            event: "item.completed",
+            payload: {
+              item: {
+                id: "item_tool",
+                kind: "tool_call",
+                status: "completed",
+                detail: "Found 5 result(s)",
+              },
+            },
+          },
+        },
+        {
+          event: "item.delta",
+          data: {
+            thread_id: "thr_test",
+            turn_id: "turn_test",
+            event: "item.delta",
+            payload: { kind: "agent_message", delta: "done" },
+          },
+        },
+        {
+          event: "turn.completed",
+          data: { thread_id: "thr_test", turn_id: "turn_test", event: "turn.completed" },
+        },
+      ],
+    });
+    try {
+      const { result, blocks, status } = runAdapter(server.baseUrl, server.token);
+      await expect(result).resolves.toMatchObject({ text: "done" });
+      expect(blocks).toEqual(expect.arrayContaining(["tool_use", "tool_result", "assistant_text"]));
+      expect(status).toContainEqual({ phase: "updated", label: "web_search" });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("emits current DeepSeek agent_reasoning completions as thinking blocks", async () => {
+    const server = await startMockDeepseekServer({
+      events: [
+        {
+          event: "turn.started",
+          data: { thread_id: "thr_test", turn_id: "turn_test", event: "turn.started" },
+        },
+        {
+          event: "item.completed",
+          data: {
+            thread_id: "thr_test",
+            turn_id: "turn_test",
+            event: "item.completed",
+            payload: {
+              item: {
+                id: "item_reasoning",
+                kind: "agent_reasoning",
+                status: "completed",
+                summary: "I should answer briefly.",
+                detail: "I should answer briefly.",
+              },
+            },
+          },
+        },
+        {
+          event: "item.delta",
+          data: {
+            thread_id: "thr_test",
+            turn_id: "turn_test",
+            event: "item.delta",
+            payload: { kind: "agent_message", delta: "hi" },
+          },
+        },
+        {
+          event: "turn.completed",
+          data: { thread_id: "thr_test", turn_id: "turn_test", event: "turn.completed" },
+        },
+      ],
+    });
+    try {
+      const { result, blocks } = runAdapter(server.baseUrl, server.token);
+      await expect(result).resolves.toMatchObject({ text: "hi" });
+      expect(blocks).toContain("thinking");
+    } finally {
+      await server.close();
+    }
+  });
+
   it("reuses an existing DeepSeek thread id and patches per-turn system context", async () => {
     const server = await startMockDeepseekServer({ threadId: "thr_existing" });
     try {

--- a/packages/daemon/src/gateway/channels/botcord.ts
+++ b/packages/daemon/src/gateway/channels/botcord.ts
@@ -986,7 +986,7 @@ function normalizeBlockForHub(
     // Claude Code: {type:"assistant", message:{content:[{type:"text",text}]}}
     // Codex:       {type:"item.completed", item:{type:"agent_message", text}}
     // DeepSeek:    {event:"message.delta", payload:{content}} or
-    //              {event:"item.delta", payload:{payload:{kind:"agent_message", delta}}}
+    //              {event:"item.delta", payload:{kind:"agent_message", delta}}
     let text = "";
     const contents = Array.isArray(raw?.message?.content) ? raw.message.content : [];
     for (const c of contents) {
@@ -999,10 +999,14 @@ function normalizeBlockForHub(
     if (
       !text &&
       raw?.event === "item.delta" &&
-      raw?.payload?.payload?.kind === "agent_message" &&
-      typeof raw?.payload?.payload?.delta === "string"
+      (raw?.payload?.kind === "agent_message" || raw?.payload?.payload?.kind === "agent_message")
     ) {
-      text = raw.payload.payload.delta;
+      text =
+        typeof raw?.payload?.delta === "string"
+          ? raw.payload.delta
+          : typeof raw?.payload?.payload?.delta === "string"
+            ? raw.payload.payload.delta
+            : "";
     }
     return { kind: "assistant", seq, payload: { text } };
   }
@@ -1200,8 +1204,13 @@ function extractDeepseekToolCall(raw: any): { name: string; params?: unknown; id
     };
   }
 
-  if (payload.event === "item.started") {
-    const inner = payload.payload && typeof payload.payload === "object" ? payload.payload : {};
+  if (raw?.event === "item.started" || payload.event === "item.started") {
+    const inner =
+      raw?.event === "item.started"
+        ? payload
+        : payload.payload && typeof payload.payload === "object"
+          ? payload.payload
+          : {};
     const item = inner.item && typeof inner.item === "object" ? inner.item : undefined;
     const tool = inner.tool && typeof inner.tool === "object" ? inner.tool : item?.tool;
     return {
@@ -1240,8 +1249,18 @@ function extractDeepseekToolResult(raw: any): { name?: string; result: string; i
     };
   }
 
-  if (payload.event === "item.completed" || payload.event === "item.failed") {
-    const inner = payload.payload && typeof payload.payload === "object" ? payload.payload : {};
+  if (
+    raw?.event === "item.completed" ||
+    raw?.event === "item.failed" ||
+    payload.event === "item.completed" ||
+    payload.event === "item.failed"
+  ) {
+    const inner =
+      raw?.event === "item.completed" || raw?.event === "item.failed"
+        ? payload
+        : payload.payload && typeof payload.payload === "object"
+          ? payload.payload
+          : {};
     const item = inner.item && typeof inner.item === "object" ? inner.item : undefined;
     const result =
       item?.output ??
@@ -1273,6 +1292,11 @@ function formatBlockDetails(raw: unknown): string {
     : typeof r.message === "string" ? r.message
     : typeof r.summary === "string" ? r.summary
     : typeof r.label === "string" ? r.label
+    : typeof r.payload?.delta === "string" ? r.payload.delta
+    : typeof r.payload?.item?.detail === "string" ? r.payload.item.detail
+    : typeof r.payload?.item?.summary === "string" ? r.payload.item.summary
+    : typeof r.payload?.payload?.item?.detail === "string" ? r.payload.payload.item.detail
+    : typeof r.payload?.payload?.item?.summary === "string" ? r.payload.payload.item.summary
     : "";
   if (direct) return direct;
 

--- a/packages/daemon/src/gateway/runtimes/deepseek-tui.ts
+++ b/packages/daemon/src/gateway/runtimes/deepseek-tui.ts
@@ -383,13 +383,17 @@ export class DeepseekTuiAdapter implements RuntimeAdapter {
         if (extractedError) errorText = extractedError;
         if (eventName === "message.delta") {
           append(stringField(payload, "content") ?? "");
-        } else if (eventName === "item.delta" && payload?.payload?.kind === "agent_message") {
-          append(stringField(payload.payload, "delta") ?? "");
+        } else if (eventName === "item.delta" && isAgentMessageDelta(payload)) {
+          append(extractDeepseekDelta(payload));
         }
         if (eventName === "turn.started" || embeddedDeepseekEvent(payload) === "turn.started") {
           opts.onStatus?.({ kind: "thinking", phase: "started", label: "Thinking" });
-        } else if (eventName === "tool.started" || isToolStarted(payload)) {
-          const label = stringField(payload, "name") ?? stringField(payload?.payload?.tool, "name") ?? "tool";
+        } else if (eventName === "tool.started" || isToolStarted(eventName, payload)) {
+          const label =
+            stringField(payload, "name") ??
+            stringField(payload?.tool, "name") ??
+            stringField(payload?.payload?.tool, "name") ??
+            "tool";
           opts.onStatus?.({ kind: "thinking", phase: "updated", label });
         } else if (isDeepseekTerminalEvent(eventName, payload)) {
           opts.onStatus?.({ kind: "thinking", phase: "stopped" });
@@ -449,14 +453,17 @@ function normalizeDeepseekEvent(eventName: string, payload: any, seq: number): S
   if (eventName === "message.delta") {
     return { raw: { event: eventName, payload }, kind: "assistant_text", seq };
   }
-  if (eventName === "tool.started" || isToolStarted(payload)) {
+  if (eventName === "tool.started" || isToolStarted(eventName, payload)) {
     return { raw: { event: eventName, payload }, kind: "tool_use", seq };
   }
-  if (eventName === "tool.completed" || isToolCompleted(payload)) {
+  if (eventName === "tool.completed" || isToolCompleted(eventName, payload)) {
     return { raw: { event: eventName, payload }, kind: "tool_result", seq };
   }
-  if (eventName === "item.delta" && payload?.payload?.kind === "agent_message") {
+  if (eventName === "item.delta" && isAgentMessageDelta(payload)) {
     return { raw: { event: eventName, payload }, kind: "assistant_text", seq };
+  }
+  if (eventName === "item.completed" && isAgentReasoningItem(payload)) {
+    return { raw: { event: eventName, payload }, kind: "thinking", seq };
   }
   if (eventName === "turn.started" || eventName === "status" || embeddedDeepseekEvent(payload) === "turn.started") {
     return { raw: { event: eventName, payload }, kind: "system", seq };
@@ -485,16 +492,34 @@ function isDeepseekTerminalEvent(eventName: string, payload: any): boolean {
   );
 }
 
-function isToolStarted(payload: any): boolean {
-  return payload?.event === "item.started" && !!payload?.payload?.tool;
+function isToolStarted(eventName: string, payload: any): boolean {
+  return (
+    (eventName === "item.started" && (!!payload?.tool || payload?.item?.kind === "tool_call")) ||
+    (payload?.event === "item.started" && !!payload?.payload?.tool)
+  );
 }
 
-function isToolCompleted(payload: any): boolean {
-  const kind = payload?.payload?.item?.kind;
+function isToolCompleted(eventName: string, payload: any): boolean {
+  const kind = payload?.payload?.item?.kind ?? payload?.item?.kind;
   return (
-    (payload?.event === "item.completed" || payload?.event === "item.failed") &&
+    (eventName === "item.completed" ||
+      eventName === "item.failed" ||
+      payload?.event === "item.completed" ||
+      payload?.event === "item.failed") &&
     (kind === "tool_call" || kind === "file_change" || kind === "command_execution")
   );
+}
+
+function isAgentMessageDelta(payload: any): boolean {
+  return payload?.kind === "agent_message" || payload?.payload?.kind === "agent_message";
+}
+
+function isAgentReasoningItem(payload: any): boolean {
+  return payload?.item?.kind === "agent_reasoning" || payload?.payload?.item?.kind === "agent_reasoning";
+}
+
+function extractDeepseekDelta(payload: any): string {
+  return stringField(payload, "delta") ?? stringField(payload?.payload, "delta") ?? "";
 }
 
 function extractDeepseekError(eventName: string, payload: any): string | undefined {


### PR DESCRIPTION
## Summary
- parse current DeepSeek TUI `item.delta` agent_message events as assistant text
- normalize current DeepSeek tool and reasoning event shapes for owner-chat stream blocks
- preserve reasoning details in expanded dashboard thinking blocks

## Verification
- `cd packages/daemon && npm test -- --run src/gateway/__tests__/deepseek-tui-adapter.test.ts src/gateway/__tests__/botcord-channel.test.ts`
- `cd packages/daemon && npm run build`

## Risk / rollout
- Low risk; scoped to DeepSeek TUI stream parsing and dashboard stream-block normalization.
- Cloud agents using deepseek-tui need the updated daemon/runtime image to see the fix.