### PR TITLE
fix(deepseek-tui): surface empty turn completion as diagnostic error

### DIFF
--- a/backend/hub/config.py
+++ b/backend/hub/config.py
@@ -386,7 +386,7 @@ E2B_SANDBOX_TIMEOUT_SECONDS: int = int(os.getenv("E2B_SANDBOX_TIMEOUT_SECONDS", 
 # (telegram/wechat/feishu). Set ``CLOUD_DAEMON_NPM_SPEC=bundled`` only for a
 # purpose-built image whose preinstalled ``botcord-daemon`` is known fresh.
 CLOUD_DAEMON_NPM_SPEC: str = os.getenv(
-    "CLOUD_DAEMON_NPM_SPEC", "@botcord/daemon@^0.2.78"
+    "CLOUD_DAEMON_NPM_SPEC", "@botcord/daemon@^0.2.79"
 )
 CLOUD_DAEMON_STARTUP_COMMAND: str = os.getenv(
     "CLOUD_DAEMON_STARTUP_COMMAND",
@@ -399,7 +399,7 @@ CLOUD_DAEMON_STARTUP_COMMAND: str = os.getenv(
         "fi; "
         ";; "
         "\"\") "
-        "exec npx --yes --package @botcord/daemon@^0.2.78 "
+        "exec npx --yes --package @botcord/daemon@^0.2.79 "
         "botcord-daemon start --foreground; "
         ";; "
         "*) "
@@ -407,7 +407,7 @@ CLOUD_DAEMON_STARTUP_COMMAND: str = os.getenv(
         "botcord-daemon start --foreground; "
         ";; "
         "esac; "
-        "exec npx --yes --package @botcord/daemon@^0.2.78 "
+        "exec npx --yes --package @botcord/daemon@^0.2.79 "
         "botcord-daemon start --foreground"
         "'"
     ),

--- a/backend/tests/test_cloud_daemon_provider_e2b.py
+++ b/backend/tests/test_cloud_daemon_provider_e2b.py
@@ -41,7 +41,7 @@ def _make_provider(
     client: FakeE2BSandboxClient | None = None,
     deepseek_api_key: str | None = "ds-secret",
     startup_command: str = CLOUD_DAEMON_STARTUP_COMMAND,
-    daemon_npm_spec: str = "@botcord/daemon@^0.2.78",
+    daemon_npm_spec: str = "@botcord/daemon@^0.2.79",
 ) -> tuple[E2BCloudDaemonProvider, FakeE2BSandboxClient]:
     client = client or FakeE2BSandboxClient()
     provider = E2BCloudDaemonProvider(
@@ -65,7 +65,7 @@ def _make_provider(
 def test_default_startup_command_prefers_configured_npm_spec():
     """Default launch should not prefer a stale daemon baked into the template."""
     assert "case \"${CLOUD_DAEMON_NPM_SPEC:-}\"" in CLOUD_DAEMON_STARTUP_COMMAND
-    assert "exec npx --yes --package @botcord/daemon@^0.2.78" in (
+    assert "exec npx --yes --package @botcord/daemon@^0.2.79" in (
         CLOUD_DAEMON_STARTUP_COMMAND
     )
     assert "exec npx --yes --package \"$CLOUD_DAEMON_NPM_SPEC\"" in (
@@ -103,7 +103,7 @@ async def test_create_or_resume_starts_sandbox_and_injects_env():
     assert env["BOTCORD_CLOUD_DAEMON_INSTANCE_ID"] == "cloud_dm_aaa"
     assert env["BOTCORD_DAEMON_INSTANCE_ID"] == "dm_bbb"
     assert env["DEEPSEEK_API_KEY"] == "ds-secret"
-    assert env["CLOUD_DAEMON_NPM_SPEC"] == "@botcord/daemon@^0.2.78"
+    assert env["CLOUD_DAEMON_NPM_SPEC"] == "@botcord/daemon@^0.2.79"
 
     # And the injected access token is a valid cloud-daemon-access JWT.
     claims = _verify_cloud_daemon_access_token(env["BOTCORD_CLOUD_DAEMON_ACCESS_TOKEN"])

--- a/packages/daemon/package-lock.json
+++ b/packages/daemon/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@botcord/daemon",
-  "version": "0.2.78",
+  "version": "0.2.79",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@botcord/daemon",
-      "version": "0.2.78",
+      "version": "0.2.79",
       "license": "MIT",
       "dependencies": {
         "@botcord/cli": "^0.1.7",

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botcord/daemon",
-  "version": "0.2.78",
+  "version": "0.2.79",
   "description": "BotCord local daemon — bridges Hub inbox push to local Claude Code / Codex / Gemini CLIs",
   "type": "module",
   "bin": {

--- a/packages/daemon/src/gateway/__tests__/deepseek-tui-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/deepseek-tui-adapter.test.ts
@@ -410,6 +410,43 @@ describe("DeepseekTuiAdapter", () => {
     }
   });
 
+  it("surfaces a diagnostic error when DeepSeek completes a turn with no assistant_message", async () => {
+    const server = await startMockDeepseekServer({
+      events: [
+        { event: "turn.started", data: { thread_id: "thr_test", turn_id: "turn_test" } },
+        {
+          event: "item.completed",
+          data: {
+            thread_id: "thr_test",
+            turn_id: "turn_test",
+            event: "item.completed",
+            payload: {
+              item: {
+                id: "item_reasoning",
+                kind: "agent_reasoning",
+                status: "completed",
+                summary: "thinking...",
+              },
+            },
+          },
+        },
+        {
+          event: "turn.completed",
+          data: { thread_id: "thr_test", turn_id: "turn_test", payload: { turn: { status: "completed" } } },
+        },
+      ],
+    });
+    try {
+      const { result } = runAdapter(server.baseUrl, server.token);
+      const res = await result;
+      expect(res.text).toBe("");
+      expect(res.newSessionId).toBe("thr_test");
+      expect(res.error).toMatch(/no assistant_message/);
+    } finally {
+      await server.close();
+    }
+  });
+
   it("returns a runtime error when DeepSeek completes the turn as failed", async () => {
     const server = await startMockDeepseekServer({
       events: [

--- a/packages/daemon/src/gateway/runtimes/deepseek-tui.ts
+++ b/packages/daemon/src/gateway/runtimes/deepseek-tui.ts
@@ -143,11 +143,14 @@ export class DeepseekTuiAdapter implements RuntimeAdapter {
         signal: turnAbort.signal,
       });
       const text = runResult.text;
+      const error =
+        runResult.error ??
+        (text === "" ? emptyCompletionError(handle.stderrTail) : undefined);
 
       return {
         text,
         newSessionId: threadId,
-        ...(runResult.error ? { error: runResult.error } : {}),
+        ...(error ? { error } : {}),
       };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -520,6 +523,16 @@ function isAgentReasoningItem(payload: any): boolean {
 
 function extractDeepseekDelta(payload: any): string {
   return stringField(payload, "delta") ?? stringField(payload?.payload, "delta") ?? "";
+}
+
+function emptyCompletionError(stderrTail: string): string {
+  const tail = stderrTail.trim();
+  if (!tail) {
+    return "deepseek runtime completed with no assistant_message (check DEEPSEEK_API_KEY / model availability)";
+  }
+  const lines = tail.split(/\r?\n/).filter((line) => line.trim().length > 0);
+  const lastLines = lines.slice(-5).join("\n").slice(-500);
+  return `deepseek runtime completed with no assistant_message; stderr tail: ${lastLines}`;
 }
 
 function extractDeepseekError(eventName: string, payload: any): string | undefined {


### PR DESCRIPTION
## Summary
- DeepSeek TUI runtime was finishing turns with no `agent_message` (likely DEEPSEEK_API_KEY/quota/model issues in the cloud sandbox); the adapter silently returned empty text and the dashboard rendered only thinking + system + other blocks, no reply text.
- Treat a successful turn that produced zero assistant text as a diagnostic error, attaching the tail of `deepseek serve` stderr when available so operators can tell auth/quota/network failures apart from genuine empty completions.
- Bump daemon to 0.2.79 to ship together with the SSE parser repair from #805.

## Test plan
- [x] `npx vitest --run src/gateway/__tests__/deepseek-tui-adapter.test.ts` — 10 tests pass, including new "surfaces a diagnostic error when DeepSeek completes a turn with no assistant_message"
- [x] Full daemon vitest suite — 874 tests pass
- [x] Production tsc build (`tsconfig.build.json`) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)