### PR TITLE
fix: show DeepSeek TUI tool details

### DIFF
--- a/frontend/src/components/dashboard/StreamBlocksView.tsx
+++ b/frontend/src/components/dashboard/StreamBlocksView.tsx
@@ -202,6 +202,16 @@ function stringField(obj: any, key: string): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
+function inferDeepseekToolName(item: any): string | undefined {
+  const candidates = [stringField(item, "summary"), stringField(item, "detail")];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const match = candidate.match(/^([A-Za-z0-9_.:-]+)\s*(?:started|completed|failed|returned|:)/);
+    if (match?.[1] && match[1] !== "tool_call") return match[1];
+  }
+  return undefined;
+}
+
 function extractToolCall(raw: any): { name: string; params?: unknown; id?: string } | null {
   const contents = Array.isArray(raw?.message?.content) ? raw.message.content : [];
   const tu = contents.find((c: any) => c?.type === "tool_use");
@@ -278,11 +288,13 @@ function extractDeepseekToolCall(raw: any): { name: string; params?: unknown; id
           : {};
     const item = inner.item && typeof inner.item === "object" ? inner.item : undefined;
     const tool = inner.tool && typeof inner.tool === "object" ? inner.tool : item?.tool;
+    const itemParams = parseMaybeJson(item?.input ?? item?.arguments ?? item?.detail);
     return {
       name:
         stringField(tool, "name") ??
         stringField(inner, "name") ??
         stringField(item, "name") ??
+        inferDeepseekToolName(item) ??
         stringField(item, "type") ??
         "tool",
       params: parseMaybeJson(
@@ -292,7 +304,7 @@ function extractDeepseekToolCall(raw: any): { name: string; params?: unknown; id
           inner.input ??
           item?.input ??
           item?.arguments,
-      ) ?? tool ?? item,
+      ) ?? itemParams ?? tool ?? item,
       id: stringField(tool, "id") ?? stringField(inner, "id") ?? stringField(item, "id"),
     };
   }
@@ -380,7 +392,11 @@ function extractDeepseekToolResult(raw: any): { name?: string; result: string; i
       item ??
       inner;
     return {
-      name: stringField(item, "name") ?? stringField(item, "type") ?? stringField(inner, "name"),
+      name:
+        stringField(item, "name") ??
+        inferDeepseekToolName(item) ??
+        stringField(inner, "name") ??
+        stringField(item, "type"),
       result: stringifyDetails(result),
       id: stringField(item, "id") ?? stringField(inner, "id"),
     };

--- a/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
+++ b/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
@@ -994,6 +994,71 @@ describe("createBotCordChannel — streamBlock()", () => {
     });
   });
 
+  it("infers current DeepSeek tool input from item summary and detail", () => {
+    expect(
+      __normalizeBlockForHubForTests(
+        {
+          kind: "tool_use",
+          seq: 8,
+          raw: {
+            event: "item.started",
+            payload: {
+              item: {
+                id: "item_exec",
+                kind: "tool_call",
+                status: "in_progress",
+                summary: "exec_shell started",
+                detail: "{\"cmd\":\"botcord-daemon --version\"}",
+              },
+            },
+          },
+        },
+        8,
+      ),
+    ).toEqual({
+      kind: "tool_call",
+      seq: 8,
+      payload: {
+        id: "item_exec",
+        name: "exec_shell",
+        params: { cmd: "botcord-daemon --version" },
+        status: "in_progress",
+      },
+    });
+  });
+
+  it("infers current DeepSeek tool result name from item summary", () => {
+    expect(
+      __normalizeBlockForHubForTests(
+        {
+          kind: "tool_result",
+          seq: 9,
+          raw: {
+            event: "item.completed",
+            payload: {
+              item: {
+                id: "item_exec",
+                kind: "tool_call",
+                status: "completed",
+                summary: "exec_shell: botcord-daemon 0.2.78",
+                detail: "botcord-daemon 0.2.78",
+              },
+            },
+          },
+        },
+        9,
+      ),
+    ).toEqual({
+      kind: "tool_result",
+      seq: 9,
+      payload: {
+        name: "exec_shell",
+        result: "botcord-daemon 0.2.78",
+        tool_use_id: "item_exec",
+      },
+    });
+  });
+
   it("normalizes current DeepSeek agent_reasoning details", () => {
     expect(
       __normalizeBlockForHubForTests(

--- a/packages/daemon/src/gateway/__tests__/deepseek-tui-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/deepseek-tui-adapter.test.ts
@@ -304,6 +304,55 @@ describe("DeepseekTuiAdapter", () => {
     }
   });
 
+  it("infers current DeepSeek tool status labels without a payload.tool object", async () => {
+    const server = await startMockDeepseekServer({
+      events: [
+        {
+          event: "turn.started",
+          data: { thread_id: "thr_test", turn_id: "turn_test", event: "turn.started" },
+        },
+        {
+          event: "item.started",
+          data: {
+            thread_id: "thr_test",
+            turn_id: "turn_test",
+            event: "item.started",
+            payload: {
+              item: {
+                id: "item_exec",
+                kind: "tool_call",
+                status: "in_progress",
+                summary: "exec_shell started",
+                detail: "{\"cmd\":\"botcord-daemon --version\"}",
+              },
+            },
+          },
+        },
+        {
+          event: "item.delta",
+          data: {
+            thread_id: "thr_test",
+            turn_id: "turn_test",
+            event: "item.delta",
+            payload: { kind: "agent_message", delta: "done" },
+          },
+        },
+        {
+          event: "turn.completed",
+          data: { thread_id: "thr_test", turn_id: "turn_test", event: "turn.completed" },
+        },
+      ],
+    });
+    try {
+      const { result, blocks, status } = runAdapter(server.baseUrl, server.token);
+      await expect(result).resolves.toMatchObject({ text: "done" });
+      expect(blocks).toEqual(expect.arrayContaining(["tool_use", "assistant_text"]));
+      expect(status).toContainEqual({ phase: "updated", label: "exec_shell" });
+    } finally {
+      await server.close();
+    }
+  });
+
   it("emits current DeepSeek agent_reasoning completions as thinking blocks", async () => {
     const server = await startMockDeepseekServer({
       events: [

--- a/packages/daemon/src/gateway/channels/botcord.ts
+++ b/packages/daemon/src/gateway/channels/botcord.ts
@@ -1213,11 +1213,13 @@ function extractDeepseekToolCall(raw: any): { name: string; params?: unknown; id
           : {};
     const item = inner.item && typeof inner.item === "object" ? inner.item : undefined;
     const tool = inner.tool && typeof inner.tool === "object" ? inner.tool : item?.tool;
+    const itemParams = parseMaybeJson(item?.input ?? item?.arguments ?? item?.detail);
     return {
       name:
         stringField(tool, "name") ??
         stringField(inner, "name") ??
         stringField(item, "name") ??
+        inferDeepseekToolName(item) ??
         stringField(item, "type") ??
         "tool",
       params: parseMaybeJson(
@@ -1227,7 +1229,7 @@ function extractDeepseekToolCall(raw: any): { name: string; params?: unknown; id
           inner.input ??
           item?.input ??
           item?.arguments,
-      ) ?? tool ?? item,
+      ) ?? itemParams ?? tool ?? item,
       id: stringField(tool, "id") ?? stringField(inner, "id") ?? stringField(item, "id"),
       status: stringField(tool, "status") ?? stringField(inner, "status") ?? stringField(item, "status"),
     };
@@ -1275,7 +1277,11 @@ function extractDeepseekToolResult(raw: any): { name?: string; result: string; i
       item ??
       inner;
     return {
-      name: stringField(item, "name") ?? stringField(item, "type") ?? stringField(inner, "name"),
+      name:
+        stringField(item, "name") ??
+        inferDeepseekToolName(item) ??
+        stringField(inner, "name") ??
+        stringField(item, "type"),
       result: stringifyToolResult(result),
       id: stringField(item, "id") ?? stringField(inner, "id"),
     };
@@ -1390,6 +1396,16 @@ function parseMaybeJson(value: unknown): unknown {
   } catch {
     return value;
   }
+}
+
+function inferDeepseekToolName(item: any): string | undefined {
+  const candidates = [stringField(item, "summary"), stringField(item, "detail")];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const match = candidate.match(/^([A-Za-z0-9_.:-]+)\s*(?:started|completed|failed|returned|:)/);
+    if (match?.[1] && match[1] !== "tool_call") return match[1];
+  }
+  return undefined;
 }
 
 function isEmptyRecord(value: unknown): boolean {

--- a/packages/daemon/src/gateway/runtimes/deepseek-tui.ts
+++ b/packages/daemon/src/gateway/runtimes/deepseek-tui.ts
@@ -396,6 +396,7 @@ export class DeepseekTuiAdapter implements RuntimeAdapter {
             stringField(payload, "name") ??
             stringField(payload?.tool, "name") ??
             stringField(payload?.payload?.tool, "name") ??
+            inferDeepseekToolName(payload?.item ?? payload?.payload?.item) ??
             "tool";
           opts.onStatus?.({ kind: "thinking", phase: "updated", label });
         } else if (isDeepseekTerminalEvent(eventName, payload)) {
@@ -497,7 +498,8 @@ function isDeepseekTerminalEvent(eventName: string, payload: any): boolean {
 
 function isToolStarted(eventName: string, payload: any): boolean {
   return (
-    (eventName === "item.started" && (!!payload?.tool || payload?.item?.kind === "tool_call")) ||
+    (eventName === "item.started" &&
+      (!!payload?.tool || payload?.item?.kind === "tool_call" || payload?.payload?.item?.kind === "tool_call")) ||
     (payload?.event === "item.started" && !!payload?.payload?.tool)
   );
 }
@@ -523,6 +525,16 @@ function isAgentReasoningItem(payload: any): boolean {
 
 function extractDeepseekDelta(payload: any): string {
   return stringField(payload, "delta") ?? stringField(payload?.payload, "delta") ?? "";
+}
+
+function inferDeepseekToolName(item: any): string | undefined {
+  const candidates = [stringField(item, "summary"), stringField(item, "detail")];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const match = candidate.match(/^([A-Za-z0-9_.:-]+)\s*(?:started|completed|failed|returned|:)/);
+    if (match?.[1] && match[1] !== "tool_call") return match[1];
+  }
+  return undefined;
 }
 
 function emptyCompletionError(stderrTail: string): string {


### PR DESCRIPTION
## Summary
- infer DeepSeek TUI tool names from `item.summary/detail` when `payload.tool` is absent
- parse JSON tool arguments from DeepSeek `item.detail` so expanded tool rows show inputs
- infer tool result names from item summaries in daemon and dashboard normalization

## Verification
- `cd packages/daemon && npm test -- --run src/gateway/__tests__/deepseek-tui-adapter.test.ts src/gateway/__tests__/botcord-channel.test.ts`
- `cd packages/daemon && npm run build`

## Risk / rollout
- Low risk; scoped to DeepSeek TUI stream display metadata.
- Cloud agents need the updated daemon/runtime image for the dashboard to show the improved tool names and params.