### PR TITLE
fix: use latest daemon for e2b resume

### DIFF
--- a/backend/hub/config.py
+++ b/backend/hub/config.py
@@ -382,11 +382,11 @@ E2B_SANDBOX_TIMEOUT_SECONDS: int = int(os.getenv("E2B_SANDBOX_TIMEOUT_SECONDS", 
 # Command Hub runs inside a freshly-created or resumed cloud daemon instance.
 # The default prefers the Hub-selected npm package so paused/resumed sandboxes
 # do not keep running an older daemon baked into the E2B template. Keep this
-# at a minimum version that supports cloud-mode third-party gateway channels
-# (telegram/wechat/feishu). Set ``CLOUD_DAEMON_NPM_SPEC=bundled`` only for a
-# purpose-built image whose preinstalled ``botcord-daemon`` is known fresh.
+# at ``latest`` so every create/resume picks up the current published daemon.
+# Set ``CLOUD_DAEMON_NPM_SPEC=bundled`` only for a purpose-built image whose
+# preinstalled ``botcord-daemon`` is known fresh.
 CLOUD_DAEMON_NPM_SPEC: str = os.getenv(
-    "CLOUD_DAEMON_NPM_SPEC", "@botcord/daemon@^0.2.79"
+    "CLOUD_DAEMON_NPM_SPEC", "@botcord/daemon@latest"
 )
 CLOUD_DAEMON_STARTUP_COMMAND: str = os.getenv(
     "CLOUD_DAEMON_STARTUP_COMMAND",
@@ -399,7 +399,7 @@ CLOUD_DAEMON_STARTUP_COMMAND: str = os.getenv(
         "fi; "
         ";; "
         "\"\") "
-        "exec npx --yes --package @botcord/daemon@^0.2.79 "
+        "exec npx --yes --package @botcord/daemon@latest "
         "botcord-daemon start --foreground; "
         ";; "
         "*) "
@@ -407,7 +407,7 @@ CLOUD_DAEMON_STARTUP_COMMAND: str = os.getenv(
         "botcord-daemon start --foreground; "
         ";; "
         "esac; "
-        "exec npx --yes --package @botcord/daemon@^0.2.79 "
+        "exec npx --yes --package @botcord/daemon@latest "
         "botcord-daemon start --foreground"
         "'"
     ),

--- a/backend/tests/test_cloud_daemon_provider_e2b.py
+++ b/backend/tests/test_cloud_daemon_provider_e2b.py
@@ -41,7 +41,7 @@ def _make_provider(
     client: FakeE2BSandboxClient | None = None,
     deepseek_api_key: str | None = "ds-secret",
     startup_command: str = CLOUD_DAEMON_STARTUP_COMMAND,
-    daemon_npm_spec: str = "@botcord/daemon@^0.2.79",
+    daemon_npm_spec: str = "@botcord/daemon@latest",
 ) -> tuple[E2BCloudDaemonProvider, FakeE2BSandboxClient]:
     client = client or FakeE2BSandboxClient()
     provider = E2BCloudDaemonProvider(
@@ -65,7 +65,7 @@ def _make_provider(
 def test_default_startup_command_prefers_configured_npm_spec():
     """Default launch should not prefer a stale daemon baked into the template."""
     assert "case \"${CLOUD_DAEMON_NPM_SPEC:-}\"" in CLOUD_DAEMON_STARTUP_COMMAND
-    assert "exec npx --yes --package @botcord/daemon@^0.2.79" in (
+    assert "exec npx --yes --package @botcord/daemon@latest" in (
         CLOUD_DAEMON_STARTUP_COMMAND
     )
     assert "exec npx --yes --package \"$CLOUD_DAEMON_NPM_SPEC\"" in (
@@ -103,7 +103,7 @@ async def test_create_or_resume_starts_sandbox_and_injects_env():
     assert env["BOTCORD_CLOUD_DAEMON_INSTANCE_ID"] == "cloud_dm_aaa"
     assert env["BOTCORD_DAEMON_INSTANCE_ID"] == "dm_bbb"
     assert env["DEEPSEEK_API_KEY"] == "ds-secret"
-    assert env["CLOUD_DAEMON_NPM_SPEC"] == "@botcord/daemon@^0.2.79"
+    assert env["CLOUD_DAEMON_NPM_SPEC"] == "@botcord/daemon@latest"
 
     # And the injected access token is a valid cloud-daemon-access JWT.
     claims = _verify_cloud_daemon_access_token(env["BOTCORD_CLOUD_DAEMON_ACCESS_TOKEN"])
@@ -164,6 +164,14 @@ async def test_resume_uses_existing_sandbox_when_provider_sandbox_id_supplied():
     assert second.provider_sandbox_id == first.provider_sandbox_id
     # Only one sandbox record exists — resume reuses it.
     assert len(client.all()) == 1
+    sandbox = client.get(first.provider_sandbox_id)
+    assert sandbox is not None
+    # Resume still relaunches the daemon in the existing sandbox so it can
+    # replace the paused process with the currently published npm package.
+    assert sandbox.commands == [
+        CLOUD_DAEMON_STARTUP_COMMAND,
+        CLOUD_DAEMON_STARTUP_COMMAND,
+    ]
 
 
 @pytest.mark.asyncio

--- a/e2b/entrypoint.sh
+++ b/e2b/entrypoint.sh
@@ -60,7 +60,7 @@ fi
 # shellcheck disable=SC2206
 extra=( ${BOTCORD_DAEMON_EXTRA_ARGS:-} )
 
-daemon_npm_spec="${CLOUD_DAEMON_NPM_SPEC:-@botcord/daemon@^0.2.78}"
+daemon_npm_spec="${CLOUD_DAEMON_NPM_SPEC:-@botcord/daemon@latest}"
 
 if [[ "$daemon_npm_spec" != "bundled" ]]; then
   exec npx --yes --package "$daemon_npm_spec" botcord-daemon start "${extra[@]}"


### PR DESCRIPTION
## Summary
- default E2B cloud daemon launches to @botcord/daemon@latest instead of a semver floor
- align the E2B image entrypoint fallback with the Hub startup command
- assert resume relaunches the daemon in the existing sandbox

## Verification
- cd backend && uv run pytest tests/test_cloud_daemon_provider_e2b.py

## Risk / rollout
- Existing Hub env CLOUD_DAEMON_NPM_SPEC still overrides the default; set it to @botcord/daemon@latest or unset it in deployment.
- Already-connected cloud daemons need a daemon restart to pick up the new package; paused/offline sandboxes pick it up on resume.