### PR TITLE
fix: harden cloud gateway setup ownership

### DIFF
--- a/backend/tests/test_app/test_app_gateways.py
+++ b/backend/tests/test_app/test_app_gateways.py
@@ -810,6 +810,153 @@ async def test_cloud_agent_does_not_require_cloud_daemon_online(
     assert r.status_code == 200, r.text
 
 
+@pytest.mark.parametrize(
+    ("path", "request_body", "expected_ingress_suffix", "response_check"),
+    [
+        (
+            "/api/agents/ag_cloud/gateways/wechat/login/start",
+            {},
+            "/internal/gateway-ingress/agents/ag_cloud/gateways/wechat/login/start",
+            lambda body: body["loginId"] == "wxl_cloud"
+            and body["qrcode"] == "QR"
+            and body["qrcodeUrl"] == "https://qr",
+        ),
+        (
+            "/api/agents/ag_cloud/gateways/wechat/login/status",
+            {"loginId": "wxl_cloud"},
+            "/internal/gateway-ingress/agents/ag_cloud/gateways/wechat/login/status",
+            lambda body: body["status"] == "confirmed"
+            and body["tokenPreview"] == "tok...view",
+        ),
+        (
+            "/api/agents/ag_cloud/gateways/wechat/senders",
+            {"loginId": "wxl_cloud", "timeoutSeconds": 1},
+            "/internal/gateway-ingress/agents/ag_cloud/gateways/wechat/discover",
+            lambda body: body["senders"] == [{"senderId": "alice", "preview": "hi"}],
+        ),
+        (
+            "/api/agents/ag_cloud/gateways/feishu/login/start",
+            {"domain": "feishu"},
+            "/internal/gateway-ingress/agents/ag_cloud/gateways/feishu/login/start",
+            lambda body: body["loginId"] == "fsl_cloud"
+            and body["qrcodeUrl"] == "https://accounts.feishu.cn/verify",
+        ),
+        (
+            "/api/agents/ag_cloud/gateways/feishu/login/status",
+            {"loginId": "fsl_cloud"},
+            "/internal/gateway-ingress/agents/ag_cloud/gateways/feishu/login/status",
+            lambda body: body["status"] == "confirmed"
+            and body["appId"] == "cli_cloud"
+            and body["tokenPreview"] == "fei...view",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_cloud_agent_login_setup_routes_never_dispatch_daemon_or_lifecycle(
+    client,
+    seed,
+    monkeypatch,
+    path,
+    request_body,
+    expected_ingress_suffix,
+    response_check,
+):
+    """Cloud-hosted setup is owned by gateway-ingress.
+
+    Login/discovery setup must not wake the runtime sandbox and must not send
+    daemon gateway_login_* control frames. Runtime lifecycle stays behind
+    /internal/cloud-gateway/.../ensure-running and is used only after provider
+    inbound events exist.
+    """
+
+    def responder(method, url, body):
+        assert method == "POST"
+        assert url.endswith(expected_ingress_suffix)
+        assert "/internal/cloud-gateway/" not in url
+        assert body["user_id"] == str(seed["user_id"])
+        assert body["hosting_kind"] == "cloud"
+        if url.endswith("/wechat/login/start"):
+            return _FakeIngressResponse(
+                200,
+                {
+                    "loginId": "wxl_cloud",
+                    "expiresAt": 1700000000,
+                    "publicPayload": {
+                        "qrcode": "QR",
+                        "qrcodeUrl": "https://qr",
+                    },
+                },
+            )
+        if url.endswith("/wechat/login/status"):
+            return _FakeIngressResponse(
+                200,
+                {
+                    "loginId": "wxl_cloud",
+                    "status": "confirmed",
+                    "expiresAt": 1700000000,
+                    "publicPayload": {
+                        "baseUrl": "https://ilinkai.weixin.qq.com",
+                        "tokenPreview": "tok...view",
+                    },
+                },
+            )
+        if url.endswith("/wechat/discover"):
+            return _FakeIngressResponse(
+                200,
+                {"candidates": [{"senderId": "alice", "preview": "hi"}]},
+            )
+        if url.endswith("/feishu/login/start"):
+            return _FakeIngressResponse(
+                200,
+                {
+                    "loginId": "fsl_cloud",
+                    "expiresAt": 1700000000,
+                    "publicPayload": {
+                        "qrcodeUrl": "https://accounts.feishu.cn/verify",
+                    },
+                },
+            )
+        if url.endswith("/feishu/login/status"):
+            return _FakeIngressResponse(
+                200,
+                {
+                    "loginId": "fsl_cloud",
+                    "status": "confirmed",
+                    "expiresAt": 1700000000,
+                    "publicPayload": {
+                        "appId": "cli_cloud",
+                        "domain": "feishu",
+                        "userOpenId": "ou_cloud",
+                        "tokenPreview": "fei...view",
+                    },
+                },
+            )
+        raise AssertionError(f"unexpected ingress url: {url}")
+
+    fake = _install_ingress(monkeypatch, responder)
+
+    def _no_daemon_control(*a, **k):
+        raise AssertionError("cloud setup must not dispatch daemon control frames")
+
+    def _no_lifecycle(*a, **k):
+        raise AssertionError("setup must not call cloud runtime lifecycle")
+
+    monkeypatch.setattr("app.routers.gateways.send_control_frame", _no_daemon_control)
+    monkeypatch.setattr("app.routers.gateways.send_cloud_control_frame", _no_daemon_control)
+    monkeypatch.setattr("app.routers.gateways.is_cloud_daemon_online", _no_lifecycle)
+    monkeypatch.setattr(
+        "app.routers.gateways.CloudAgentService.resume_cloud_agent",
+        _no_lifecycle,
+    )
+
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    r = await client.post(path, headers=headers, json=request_body)
+
+    assert r.status_code == 200, r.text
+    assert response_check(r.json())
+    assert len(fake.calls) == 1
+
+
 @pytest.mark.asyncio
 async def test_create_telegram_requires_bot_token(client, seed, monkeypatch):
     _patch_daemon(monkeypatch, online=True)

--- a/docs/cloud-gateway-ingress-remediation-plan.md
+++ b/docs/cloud-gateway-ingress-remediation-plan.md
@@ -7,7 +7,7 @@
 
 # Cloud Gateway Ingress 整改技术方案
 
-> 状态: 待实现
+> 状态: P0 setup ownership 已落地；runtime ingress / relay 仍在整改
 > 日期: 2026-05-25
 > 范围: Cloud Agent 的微信、飞书/Lark、Telegram 第三方接入配置闭环与运行时消息接入
 
@@ -15,7 +15,7 @@
 
 Cloud Agent 的 sandbox 会按 idle 策略 pause。Paused 后，cloud daemon 进程不运行，因此它不能继续轮询第三方平台，也不能持有一个可靠的临时扫码登录 session。
 
-当前 Cloud Agent 第三方接入存在职责错位:
+历史 Cloud Agent 第三方接入存在职责错位:
 
 - 保存前的微信/飞书扫码登录由 Hub 控制帧转发给 cloud daemon。
 - 临时 `loginId -> provider credential` 存在 cloud daemon 内存中。
@@ -23,6 +23,13 @@ Cloud Agent 的 sandbox 会按 idle 策略 pause。Paused 后，cloud daemon 进
 - 如果 cloud daemon 在 5 分钟 TTL 内被 pause、resume、重启、替换，或后续请求路由到另一个 cloud daemon，前端仍持有的 `loginId` 会在 daemon 内存里找不到，表现为 `login session "... " not found or expired`。
 
 这不是单纯的超时问题，而是 Cloud Agent provider credential 的所有权边界错误。
+
+当前实现状态:
+
+- Cloud Agent 的 WeChat / Feishu setup start/status、WeChat sender discovery、Telegram token validation + create、gateway create/patch/delete/test 已由 Hub 代理到 `gateway-ingress`，不再通过 cloud daemon gateway login control frame。
+- `gateway-ingress` setup API 拥有 setup session、provider secret store 和 adapter lifecycle，响应只返回 public payload、masked preview 和 safe connection metadata。
+- Hub 只保留 Cloud Agent gateway mirror row；raw provider secret 不进入 Hub DB。
+- Runtime wake / delivery 仍是下一阶段收敛重点，尤其是 runtime relay 与 long-running control ack 的职责边界。
 
 ## 2. 整改目标
 
@@ -162,6 +169,12 @@ POST /internal/cloud-gateway/agents/{agent_id}/touch
 ```
 
 `gateway-ingress` setup/config APIs manage provider connection state. `cloud-gateway` lifecycle APIs manage Cloud Agent runtime state.
+
+Contract invariant:
+
+- Setup routes must never call `ensure-running`, `runtime`, or `touch`.
+- Setup routes must never dispatch `gateway_login_start`, `gateway_login_status`, or `gateway_recent_senders` to a cloud daemon for `hosting_kind="cloud"`.
+- Runtime lifecycle is triggered only after a provider inbound event has been durably accepted by `gateway-ingress`.
 
 ## 5. Provider 整改方案
 
@@ -421,6 +434,7 @@ Runtime delivery failures:
 
 ### Phase 0: Stop making the bug worse
 
+- Status: complete for setup-path diagnostics.
 - For Cloud Agent gateway setup, add explicit logs for target host and setup owner:
   - `agent_id`
   - `provider`
@@ -434,6 +448,7 @@ Runtime delivery failures:
 
 ### Phase 1: gateway-ingress setup API
 
+- Status: complete for P0 setup ownership.
 - Add setup session store and provider secret store support in `gateway-ingress`.
 - Implement WeChat login start/status/discover/create in `gateway-ingress`.
 - Implement Telegram validate/discover/create in `gateway-ingress`.
@@ -442,6 +457,7 @@ Runtime delivery failures:
 
 ### Phase 2: Hub route split
 
+- Status: complete for Cloud Agent setup/config routes; keep local daemon routes unchanged.
 - Change Hub gateway routes:
   - local daemon agents continue using daemon control frames;
   - cloud agents proxy setup/config operations to `gateway-ingress`.
@@ -450,6 +466,7 @@ Runtime delivery failures:
 
 ### Phase 3: Runtime ingress ownership
 
+- Status: in progress.
 - Ensure cloud gateway provider adapters run only in `gateway-ingress`.
 - Disable cloud daemon provider channel creation for cloud-hosted third-party gateway configs.
 - Wire `gateway-ingress` provider adapters to durable inbound queue and Hub `ensure-running`.
@@ -466,10 +483,11 @@ Runtime delivery failures:
 
 Backend / Hub:
 
-- Cloud Agent WeChat login start proxies to `gateway-ingress`, not cloud daemon.
+- Cloud Agent WeChat / Feishu login start/status and WeChat sender discovery proxy to `gateway-ingress`, not cloud daemon.
 - Local daemon WeChat login start still dispatches control frame to daemon.
 - Cloud Agent create gateway never persists raw provider secret in Hub DB.
 - Hub mirror updates after gateway-ingress create/patch/delete.
+- Cloud Agent setup/config routes do not call cloud lifecycle `ensure-running`; lifecycle remains event-driven runtime wake.
 - Cloud gateway ensure-running resumes paused agent and returns runtime metadata.
 
 gateway-ingress:
@@ -480,6 +498,7 @@ gateway-ingress:
 - Telegram validate rejects invalid bot token and never logs token.
 - Telegram getUpdates offset is advanced only after durable inbound event write.
 - Feishu registration stores `appSecret` only in ingress secret store.
+- WeChat / Telegram / Feishu setup responses never contain raw provider credentials or `secretRef`.
 - Feishu event dedupe prevents duplicate runtime deliveries.
 - Runtime delivery queues event when Hub reports `provisioning`, then retries.
 - Runtime outbound frame sends provider reply and marks delivery.

--- a/docs/cloud-gateway-ingress-technical-design.md
+++ b/docs/cloud-gateway-ingress-technical-design.md
@@ -7,7 +7,7 @@
 
 # Cloud Gateway Ingress 技术设计
 
-> 状态: 方案确认，待实现
+> 状态: 方案确认；P0 setup ownership 已落地，runtime relay 仍在收敛
 > 日期: 2026-05-22
 > 范围: Cloud Agent 第三方直连接入、gateway-ingress 常驻服务、微信/飞书/Telegram 入站和出站、Hub thin resume/lifecycle API
 
@@ -31,6 +31,20 @@ gateway-ingress = always-on observer + provider sender
 cloud daemon    = runtime executor
 Hub             = cloud lifecycle control plane
 ```
+
+## 1.1 当前实现对齐状态
+
+已对齐:
+
+- Cloud Agent 的 provider setup/config path 由 Hub BFF 代理到 `gateway-ingress` setup API；local daemon agent 继续走 daemon control frames。
+- `gateway-ingress` setup API 持有 WeChat / Feishu / Telegram 的临时 setup session 和长期 provider secret store。
+- Hub Cloud Agent gateway mirror 只保存 safe metadata、masked preview 和 allowlist/config，不保存 raw bot token / app secret。
+- setup/config path 不触发 runtime lifecycle resume；`ensure-running` 只属于 provider inbound event 之后的 runtime wake path。
+
+仍需收敛:
+
+- Runtime transport 当前仍可能通过 Hub relay / cloud daemon control WS 实现，和本文“Hub 不在第三方正文语义 data path 上”的目标存在实现差距。允许短期作为 payload-opaque transport，但不得把 provider secret、setup session 或 provider-specific behavior 放进 Hub。
+- Runtime streaming 合同已定义 `gateway_outbound_start/delta/complete/error`，但 MVP 可以先 final-only；代码与文档必须清楚标注是否已经真正 streaming。
 
 ## 2. 已确认决策
 
@@ -236,6 +250,12 @@ Hub validation:
 
 Hub must not require or receive third-party message content.
 
+Setup separation:
+
+- `ensure-running` is not part of login/start, login/status, discover, create, patch, delete, or test setup routes.
+- Hub setup routes for `hosting_kind="cloud"` must proxy only to `/internal/gateway-ingress/...`.
+- Daemon control frame types such as `gateway_login_start`, `gateway_login_status`, and `gateway_recent_senders` remain valid for local daemon agents only.
+
 ### 7.2 runtime metadata
 
 Used when `gateway-ingress` needs to reconnect to an already-running runtime session without forcing resume.
@@ -282,6 +302,11 @@ Cons:
 - Need clear logs and privacy boundary to avoid accidental message persistence.
 
 MVP recommendation: use Option B if E2B networking makes direct inbound to sandbox awkward; otherwise use Option A.
+
+Current implementation note:
+
+- If Option B is implemented on top of existing Hub/cloud-daemon control transport, keep the relay path narrow: correlate by event/session ids, treat runtime frame bodies as opaque transport payloads, and avoid setup/provider-specific branches in Hub.
+- Do not reuse long-running daemon control acks as the stable runtime execution model. Runtime accept (`gateway_inbound_ack`) and terminal outbound (`gateway_outbound_complete` / `gateway_outbound_error`) should be separate protocol events so Hub lifecycle availability is not tied to a single blocking control-frame timeout.
 
 ### 8.1 Frame Shape
 
@@ -507,12 +532,14 @@ Ingress can continue receiving provider events into queue but cannot resume new 
 
 ### Phase 0: Contract Extraction
 
+- Status: mostly implemented in `@botcord/protocol-core` (`runtime-frame.ts`) for runtime and lifecycle frame contracts.
 - Extract or duplicate minimal `GatewayInboundMessage` / `GatewayOutboundMessage` types into a shared package usable by `gateway-ingress`.
 - Define runtime direct session frame schema.
 - Add Hub internal `ensure-running` API that does not accept message payload.
 
 ### Phase 1: gateway-ingress Skeleton
 
+- Status: implemented for P0 setup/runtime package skeleton.
 - New module/package `gateway-ingress`.
 - Service config, health check, DB/secret store abstraction.
 - Hub service auth client.
@@ -528,7 +555,7 @@ Recommended first provider: Telegram or Feishu.
 
 Deliver:
 
-- Login/config creation path for cloud gateway.
+- Login/config creation path for cloud gateway. Status: implemented for WeChat, Telegram, and Feishu setup ownership.
 - Inbound receive -> queue -> ensure-running -> runtime delivery.
 - Final text outbound delivery.
 
@@ -573,4 +600,3 @@ Cloud lifecycle control: Hub thin API
 ```
 
 This keeps Hub out of third-party message semantics while preserving the one capability paused Cloud Agents still need from Hub: reliable sandbox resume and runtime metadata.
-

--- a/packages/gateway-ingress/src/__tests__/setup-runtime-ownership.test.ts
+++ b/packages/gateway-ingress/src/__tests__/setup-runtime-ownership.test.ts
@@ -611,4 +611,28 @@ describe("setup-server ↔ runner ownership (Phase 3)", () => {
     expect(h.runner.isRunning(connection.id)).toBe(true);
     expect(h.factories.feishu.starts).toEqual([connection.id]);
   });
+
+  it("setup responses across providers never expose raw provider secrets", async () => {
+    const wx = await wechatFinalize(h, "ag_wx_no_secret_leak");
+    expect(wx.status).toBe(200);
+    const tg = await tgFinalize(h, "ag_tg_no_secret_leak");
+    expect(tg.status).toBe(200);
+    const fs = await fsFinalize(h, "ag_fs_no_secret_leak");
+    expect(fs.status).toBe(200);
+
+    const rawResponses = h.responses.join("\n");
+    expect(rawResponses).not.toContain(FAKE_BOT_TOKEN);
+    expect(rawResponses).not.toContain(FAKE_TG_TOKEN);
+    expect(rawResponses).not.toContain(FAKE_FS_APP_SECRET);
+
+    const wxConn = wx.body.connection as { id: string };
+    const tgConn = tg.body.connection as { id: string };
+    const fsConn = fs.body.connection as { id: string };
+    expect(JSON.stringify(wx.body)).not.toContain("secretRef");
+    expect(JSON.stringify(tg.body)).not.toContain("secretRef");
+    expect(JSON.stringify(fs.body)).not.toContain("secretRef");
+    expect(h.secrets.load(wxConn.id)).not.toBeNull();
+    expect(h.secrets.load(tgConn.id)).not.toBeNull();
+    expect(h.secrets.load(fsConn.id)).not.toBeNull();
+  });
 });

--- a/packages/gateway-ingress/src/__tests__/setup-server.test.ts
+++ b/packages/gateway-ingress/src/__tests__/setup-server.test.ts
@@ -246,6 +246,18 @@ describe("setup-server — WeChat full flow", () => {
       { senderId: "alice", preview: "hello" },
     ]);
 
+    // Hub route split may call this "senders"; keep it as a setup alias.
+    const senders = await call(
+      h.url,
+      `/internal/gateway-ingress/agents/${agentId}/gateways/wechat/senders`,
+      { body: { ...baseCtx, loginId } },
+      h.responses,
+    );
+    expect(senders.status).toBe(200);
+    expect((senders.body.candidates as Array<{ senderId: string }>)).toEqual([
+      { senderId: "alice", preview: "hello" },
+    ]);
+
     // create
     const create = await call(
       h.url,

--- a/packages/gateway-ingress/src/setup/server.ts
+++ b/packages/gateway-ingress/src/setup/server.ts
@@ -6,6 +6,7 @@
  *   POST   /agents/{agentId}/gateways/{provider}/login/start
  *   POST   /agents/{agentId}/gateways/{provider}/login/status
  *   POST   /agents/{agentId}/gateways/{provider}/discover
+ *   POST   /agents/{agentId}/gateways/{provider}/senders
  *   POST   /agents/{agentId}/gateways
  *   PATCH  /agents/{agentId}/gateways/{gatewayId}
  *   DELETE /agents/{agentId}/gateways/{gatewayId}
@@ -181,11 +182,12 @@ async function handle(
     }
 
     // POST /agents/{agentId}/gateways/{provider}/discover
+    // POST /agents/{agentId}/gateways/{provider}/senders
     if (
       parts.length === 5 &&
       parts[0] === "agents" &&
       parts[2] === "gateways" &&
-      parts[4] === "discover" &&
+      (parts[4] === "discover" || parts[4] === "senders") &&
       method === "POST"
     ) {
       const agentId = parts[1]!;


### PR DESCRIPTION
## Summary
- add a gateway-ingress setup /senders alias for sender discovery compatibility
- add backend contract coverage that cloud-hosted setup routes proxy to gateway-ingress without daemon control frames or lifecycle resume
- add gateway-ingress contract coverage that setup responses do not expose raw provider secrets or secretRef
- update cloud gateway ingress docs to mark P0 setup ownership as landed and call out remaining runtime relay/streaming work

## Verification
- cd backend && uv run pytest tests/test_app/test_app_gateways.py -q
- cd packages/gateway-ingress && npm run build && npm test
- git diff --check

## Risk / rollout
- Low runtime risk: implementation change is a setup API alias plus tests/docs.
- Remaining known gap is P1 runtime transport: Hub relay/control-WS behavior still needs separate follow-up to avoid long-running control acks and clarify streaming semantics.