### PR TITLE
fix: read Supabase generate_link action_link from response root

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -241,8 +241,14 @@ async def signup(request: Request) -> JSONResponse:
         return _json_error("signup_failed", status_code, message)
 
     properties = data.get("properties") if isinstance(data.get("properties"), dict) else {}
-    confirm_url = properties.get("action_link") or properties.get("actionLink")
+    confirm_url = (
+        properties.get("action_link")
+        or properties.get("actionLink")
+        or data.get("action_link")
+        or data.get("actionLink")
+    )
     if not isinstance(confirm_url, str) or not confirm_url:
+        logger.warning("supabase generate_link returned no action_link: %s", data)
         return _json_error("confirmation_link_missing", 502)
 
     try:
@@ -250,7 +256,7 @@ async def signup(request: Request) -> JSONResponse:
     except Exception as exc:
         logger.exception("failed to send signup confirmation email")
         user = data.get("user") if isinstance(data.get("user"), dict) else {}
-        user_id = user.get("id")
+        user_id = user.get("id") or data.get("id")
         if isinstance(user_id, str) and user_id:
             await _delete_supabase_user(user_id)
         return _json_error("confirmation_email_failed", 502, str(exc))


### PR DESCRIPTION
## Summary
- `backend/app/routers/auth.py` was reading `action_link` only from a `properties` nested object, but Supabase's `admin/generate_link` returns it at the response root. Every preview signup hit this path and returned `confirmation_link_missing`.
- Accept both shapes (root and nested) so we work with whichever Supabase variant returns.
- Log the raw Supabase response when neither shape yields a link so the next regression is debuggable from logs.
- Apply the same root-vs-nested fallback to the cleanup branch's `user_id` lookup.

Root cause confirmed by direct probe against the preview Supabase project (`fzchrymqyrzolvkfwgds`) — response shape is `{id, email, action_link, email_otp, hashed_token, ...}` with no `properties` wrapper.

## Test plan
- [ ] After deploy to preview, sign up with a fresh email and confirm the email arrives via Resend.
- [ ] Sign up with an existing-but-unconfirmed email and confirm a new confirmation link is generated and emailed (no 502).
- [ ] Sign up with an already-confirmed email and confirm we still surface `signup_failed` (409) — that path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)