### PR TITLE
fix(daemon): require protocol-core ^0.2.11

### DIFF
--- a/packages/daemon/package-lock.json
+++ b/packages/daemon/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@botcord/cli": "^0.1.7",
-        "@botcord/protocol-core": "^0.2.10",
+        "@botcord/protocol-core": "^0.2.11",
         "@larksuiteoapi/node-sdk": "^1.63.1",
         "ws": "^8.20.1"
       },

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@botcord/cli": "^0.1.7",
-    "@botcord/protocol-core": "^0.2.10",
+    "@botcord/protocol-core": "^0.2.11",
     "@larksuiteoapi/node-sdk": "^1.63.1",
     "ws": "^8.20.1"
   },


### PR DESCRIPTION
## Summary
- daemon@0.2.80 imports `sanitizeUntrustedContent` / `sanitizeSenderName` from `@botcord/protocol-core`, but its dep range `^0.2.10` permits npm to keep a cached `0.2.10` (predates `gateway-sanitize.ts`), causing `SyntaxError: does not provide an export named 'sanitizeUntrustedContent'` on fresh installs that still see the old transitive.
- Bump the range to `^0.2.11` so installs are forced to resolve `0.2.11+`.

## Test plan
- [ ] Merge → trigger `Publish Package` workflow (package=daemon, bump=patch, channel=stable) → publishes daemon `0.2.81`
- [ ] Re-run `https://api.botcord.chat/daemon/install.sh` on a clean box and confirm daemon starts without the `sanitizeUntrustedContent` import error

🤖 Generated with [Claude Code](https://claude.com/claude-code)