### PR TITLE
fix(daemon): don't kill shell wrappers in singleton check

### DIFF
--- a/backend/hub/config.py
+++ b/backend/hub/config.py
@@ -391,16 +391,14 @@ CLOUD_DAEMON_NPM_SPEC: str = os.getenv(
 CLOUD_DAEMON_STARTUP_COMMAND: str = os.getenv(
     "CLOUD_DAEMON_STARTUP_COMMAND",
     (
+        # Singleton enforcement lives in the daemon itself (see
+        # `packages/daemon/src/daemon-singleton.ts`): the new daemon stops
+        # any prior daemon via PID file + ps scan before claiming the slot.
+        # Doing a shell-level `ps | grep | kill` here in addition is unsafe
+        # because the grep pattern matches the surrounding shell command
+        # line — the shell ends up killing its own parent. Trust the
+        # daemon's singleton and just exec.
         "sh -lc '"
-        "old_pids=$(ps -eo pid=,args= | "
-        "awk -v self=$$ '\\''$1 != self && "
-        "$0 ~ /botcord-daemon start --foreground|daemon\\/dist\\/index\\.js start --foreground/ "
-        "{print $1}'\\''); "
-        "if [ -n \"$old_pids\" ]; then "
-        "kill -TERM $old_pids 2>/dev/null || true; "
-        "sleep 2; "
-        "kill -KILL $old_pids 2>/dev/null || true; "
-        "fi; "
         "export npm_config_prefer_online=true; "
         "export npm_config_cache=/tmp/botcord-npm-cache; "
         "case \"${CLOUD_DAEMON_NPM_SPEC:-}\" in "

--- a/backend/tests/test_cloud_daemon_provider_e2b.py
+++ b/backend/tests/test_cloud_daemon_provider_e2b.py
@@ -64,11 +64,12 @@ def _make_provider(
 
 def test_default_startup_command_prefers_configured_npm_spec():
     """Default launch should not prefer a stale daemon baked into the template."""
-    assert "old_pids=$(ps -eo pid=,args=" in CLOUD_DAEMON_STARTUP_COMMAND
-    assert "botcord-daemon start --foreground|daemon\\/dist\\/index\\.js start --foreground" in (
-        CLOUD_DAEMON_STARTUP_COMMAND
-    )
-    assert "kill -TERM $old_pids" in CLOUD_DAEMON_STARTUP_COMMAND
+    # Shell-level `ps | grep | kill` is intentionally NOT present: its
+    # grep pattern matches the wrapping shell's own command line, so it
+    # ends up killing its own parent. The daemon's in-process singleton
+    # (`packages/daemon/src/daemon-singleton.ts`) is the source of truth.
+    assert "old_pids=" not in CLOUD_DAEMON_STARTUP_COMMAND
+    assert "kill -TERM" not in CLOUD_DAEMON_STARTUP_COMMAND
     assert "npm_config_prefer_online=true" in CLOUD_DAEMON_STARTUP_COMMAND
     assert "case \"${CLOUD_DAEMON_NPM_SPEC:-}\"" in CLOUD_DAEMON_STARTUP_COMMAND
     assert "exec npm exec --yes --package @botcord/daemon@latest --" in (

--- a/packages/daemon/src/__tests__/daemon-singleton.test.ts
+++ b/packages/daemon/src/__tests__/daemon-singleton.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   ensureNoOtherDaemonFromPidFile,
+  isBotCordDaemonStartCommand,
   parseDaemonProcesses,
   readPid,
   removePidFile,
@@ -88,6 +89,38 @@ describe("daemon singleton pid helpers", () => {
     );
 
     expect(out.map((p) => p.pid)).toEqual([111, 222]);
+  });
+
+  it("does not match shell wrappers whose argv mentions botcord-daemon as a literal", () => {
+    // These are the wrapper command lines we observed in cloud sandboxes;
+    // they must NOT be classified as the daemon, otherwise the singleton
+    // check kills the wrapper and takes the actual daemon down with it.
+    const wrappers = [
+      "npm exec --yes --package @botcord/daemon@latest -- botcord-daemon start --foreground",
+      "npx --yes --package @botcord/daemon@latest -- botcord-daemon start --foreground",
+      "sh -c botcord-daemon start --foreground",
+      "/bin/bash -l -c export npm_config_cache=/tmp/c; npm exec --yes --package @botcord/daemon@latest -- botcord-daemon start --foreground",
+      "timeout 30 npm exec --yes --package @botcord/daemon@latest -- botcord-daemon start --foreground",
+    ];
+    for (const cmd of wrappers) {
+      expect(isBotCordDaemonStartCommand(cmd), `wrongly matched wrapper: ${cmd}`).toBe(false);
+    }
+  });
+
+  it("matches the actual daemon entry processes", () => {
+    const matches = [
+      // node running the published daemon (npx / npm exec resolution under _npx)
+      "node /tmp/botcord-npm-cache/_npx/abc123/node_modules/@botcord/daemon/dist/index.js start --foreground",
+      // node running the resolved bin shim
+      "node /Users/me/.botcord/daemon/node_modules/.bin/botcord-daemon start --foreground",
+      // direct invocation of the bin
+      "/usr/local/bin/botcord-daemon start --foreground",
+      // monorepo dev: node running packages/daemon/dist/index.js
+      "node /home/dev/botcord/packages/daemon/dist/index.js start --foreground",
+    ];
+    for (const cmd of matches) {
+      expect(isBotCordDaemonStartCommand(cmd), `failed to match daemon: ${cmd}`).toBe(true);
+    }
   });
 
   it("terminates extra daemon processes discovered outside the pid file", async () => {

--- a/packages/daemon/src/daemon-singleton.ts
+++ b/packages/daemon/src/daemon-singleton.ts
@@ -193,12 +193,28 @@ export function removePidFile(pidPath = PID_PATH): void {
   }
 }
 
-function isBotCordDaemonStartCommand(command: string): boolean {
+export function isBotCordDaemonStartCommand(command: string): boolean {
   if (!/\bstart\b/.test(command)) return false;
+  // Only treat a row as "the daemon" when argv[0] is the real entry point:
+  // either the node interpreter (running `dist/index.js`) or the resolved
+  // `botcord-daemon` bin shim. Reject shell wrappers (`sh`, `bash`, `npm`,
+  // `npx`, `timeout`, ...) — their argv mentions `botcord-daemon` only as a
+  // literal arg, not as the executable being run. Killing a wrapper takes
+  // out the actual daemon it started, which is exactly the bug we want
+  // to avoid in cloud sandboxes.
+  const exe = (command.trim().split(/\s+/, 1)[0] ?? "").split("/").pop() ?? "";
+  const isNode = /^node(\d.*)?$/.test(exe);
+  const isDaemonBin = exe === "botcord-daemon";
+  if (!isNode && !isDaemonBin) return false;
   return (
-    command.includes("botcord-daemon") ||
-    /(?:^|\s)\S*botcord\S*\/daemon\/dist\/index\.js(?:\s|$)/.test(command) ||
-    /(?:^|\s)\S*packages\/daemon\/dist\/index\.js(?:\s|$)/.test(command)
+    // node-resolved bin shim, e.g. .../node_modules/.bin/botcord-daemon
+    /\/\.?bin\/botcord-daemon(?:\s|$)/.test(command) ||
+    // direct bin invocation, e.g. /usr/local/bin/botcord-daemon or argv[0]=botcord-daemon
+    /(?:^|\s)\S*botcord-daemon(?:\s|$)/.test(command) ||
+    // node running the published daemon entry script
+    /\bbotcord\S*\/daemon\/dist\/index\.js(?:\s|$)/.test(command) ||
+    // node running the in-repo daemon entry script (dev / monorepo)
+    /\bpackages\/daemon\/dist\/index\.js(?:\s|$)/.test(command)
   );
 }
 


### PR DESCRIPTION
## Summary

The cloud daemon's singleton check scans \`ps\` and SIGTERM/SIGKILLs anything looking like "another daemon" on startup. The match was \`command.includes(\"botcord-daemon\")\`, which **matches the surrounding shell command line** — e.g. \`npm exec --yes --package @botcord/daemon@latest -- botcord-daemon start --foreground\` — because the wrapper's argv contains \"botcord-daemon\" as a literal arg. The daemon ended up killing its own parent \`npm exec\` / \`sh\` / \`bash\`, taking the actual daemon down with it.

In cloud sandboxes this surfaced as an endless fight: each new \`ensure-running\` triggered \`run_command(startup_command, background=True)\` on Hub side; the freshly spawned daemon killed the previous daemon's wrapper; no daemon ever stayed alive long enough to register its control WS with the Hub. Result: \`is_cloud_daemon_online\` was always false, ensure-running responded \`status=provisioning\` forever, and gateway messages stalled with \`daemon_rejected\` / \`code=1012\`.

Observed in a sandbox's \`/home/user/.botcord/logs/daemon.log\`:
\`\`\`
[INFO] cmd start (cloud mode) ...
[INFO] additional daemon process found; restarting pid=1429
       command=\"npm exec botcord-daemon start --foreground\"   ← wrapper, not daemon
[INFO] cmd start (cloud mode) ...                              ← next ensure-running spawns again
[WARN] additional daemon did not stop after SIGTERM; sending SIGKILL pid=1480
\`\`\`

## Fix

\`packages/daemon/src/daemon-singleton.ts\` — gate \`isBotCordDaemonStartCommand\` on argv[0]:
- Accept only \`node\` (running the daemon entry script) or the resolved \`botcord-daemon\` bin.
- Reject shell wrappers (\`sh\`, \`bash\`, \`npm\`, \`npx\`, \`timeout\`, ...) even when their argv contains \"botcord-daemon\" as a literal.

\`backend/hub/config.py\` — remove the duplicate shell-level \`ps | awk | kill\` block that had the same false-positive (its grep pattern matched the wrapping bash's own command line). The in-process singleton is now the sole source of truth.

## Test plan

- [x] \`packages/daemon\` vitest: 8/8 pass, new cases cover npm exec / npx / sh -c / bash -lc / timeout wrappers being rejected, and node-running-daemon / direct bin invocation being matched.
- [x] \`backend/tests/test_cloud_daemon_provider_e2b.py\`: 20/20 pass after asserting the shell-kill block is gone.
- [ ] Post-merge: release daemon 0.2.82, kill the stuck preview sandbox(es), confirm daemon stays alive and Hub flips \`is_cloud_daemon_online\` true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)