### PR TITLE
fix(daemon): mkdir PID file parent in cloud-mode first boot

### DIFF
--- a/packages/daemon/src/__tests__/daemon-singleton.test.ts
+++ b/packages/daemon/src/__tests__/daemon-singleton.test.ts
@@ -45,6 +45,17 @@ describe("daemon singleton pid helpers", () => {
     expect(readFileSync(pidPath, "utf8")).toBe("12345");
   });
 
+  it("creates the parent directory if missing (cloud-mode first boot)", () => {
+    // Cloud-mode start writes the PID file before `saveConfig` runs, so
+    // ~/.botcord/daemon/ may not exist yet. Without the mkdir the daemon
+    // crashes immediately with ENOENT.
+    const pidPath = path.join(tmpDir, "fresh-cloud-home", "daemon", "daemon.pid");
+
+    writeCurrentPid({ pidPath, currentPid: 7890 });
+
+    expect(readPid(pidPath)).toBe(7890);
+  });
+
   it("does not report the current process as another daemon", () => {
     const pidPath = path.join(tmpDir, "daemon.pid");
     writeCurrentPid({ pidPath, currentPid: process.pid });

--- a/packages/daemon/src/daemon-singleton.ts
+++ b/packages/daemon/src/daemon-singleton.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import path from "node:path";
 import { PID_PATH } from "./config.js";
 
 export interface SingletonLogger {
@@ -182,7 +183,16 @@ export function writeCurrentPid(
     currentPid?: number;
   } = {},
 ): void {
-  writeFileSync(opts.pidPath ?? PID_PATH, String(opts.currentPid ?? process.pid), { mode: 0o600 });
+  const pidPath = opts.pidPath ?? PID_PATH;
+  // Cloud-mode startup writes the PID file before `saveConfig` runs, so
+  // the daemon dir may not exist yet. mkdir its parent (0700) so the
+  // first write doesn't crash with ENOENT.
+  try {
+    mkdirSync(path.dirname(pidPath), { recursive: true, mode: 0o700 });
+  } catch {
+    // best-effort — writeFileSync below will surface the real error
+  }
+  writeFileSync(pidPath, String(opts.currentPid ?? process.pid), { mode: 0o600 });
 }
 
 export function removePidFile(pidPath = PID_PATH): void {


### PR DESCRIPTION
## Summary

In cloud mode the daemon writes its PID file (\`~/.botcord/daemon/daemon.pid\`) before \`saveConfig\` runs — and on a fresh sandbox the \`~/.botcord/daemon/\` directory doesn't exist yet (only \`~/.botcord/logs/\` is mkdir'd by the logger). \`writeFileSync\` crashes with:

\`\`\`
ENOENT: no such file or directory, open '/home/user/.botcord/daemon/daemon.pid'
\`\`\`

The daemon exits before it can register its control WS, so Hub sees \`is_cloud_daemon_online = false\` forever and ensure-running keeps replying \`status=provisioning\`. Surfaced once #813 let the daemon get past its earlier wrapper-kill mode.

Observed in a fresh sandbox's \`/home/user/.botcord/logs/daemon.log\`:
\`\`\`
[INFO] cmd start (cloud mode) ...
[INFO] cmd start (cloud mode) ...
(daemon dies — no further log lines, ps shows no daemon process)
\`\`\`

Manual reproduction inside the sandbox:
\`\`\`
$ node .../daemon/dist/index.js start --foreground
[INFO] cmd start (cloud mode) ...
ENOENT: no such file or directory, open '/home/user/.botcord/daemon/daemon.pid'
\`\`\`

## Fix

\`packages/daemon/src/daemon-singleton.ts\` — \`writeCurrentPid\` now \`mkdirSync(parentDir, { recursive: true, mode: 0o700 })\` before writing. Self-sufficient PID write, so no caller has to remember the ordering relative to \`saveConfig\`.

## Test plan

- [x] \`packages/daemon\` vitest: 9/9 pass; new test asserts \`writeCurrentPid\` works against a non-existent parent path.
- [x] \`npm run build\` clean.
- [ ] Post-merge: release daemon 0.2.83, kill the stuck preview sandbox, confirm daemon stays alive past first boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)