### PR TITLE
fix: reprovision cloud agents on resume

### DIFF
--- a/backend/hub/services/cloud_agent.py
+++ b/backend/hub/services/cloud_agent.py
@@ -602,8 +602,17 @@ class CloudAgentService:
                 http_status=409,
             )
         daemon_online = is_cloud_daemon_online(cdi.id)
-        if cai.status == "ready" and daemon_online:
-            return _make_view(agent, cai, cdi)
+        if cdi.status == "ready" and daemon_online:
+            handled = await self._ensure_agent_loaded_in_online_daemon(
+                db, cai, agent, cdi
+            )
+            if handled:
+                await db.refresh(cai)
+                await db.refresh(cdi)
+                await db.refresh(agent)
+                return _make_view(agent, cai, cdi)
+            if cai.status == "ready":
+                return _make_view(agent, cai, cdi)
 
         provider = self._get_provider()
         if cdi.status != "ready" or not daemon_online:
@@ -642,6 +651,48 @@ class CloudAgentService:
         await db.refresh(cai)
         await db.refresh(cdi)
         return _make_view(agent, cai, cdi)
+
+    async def _ensure_agent_loaded_in_online_daemon(
+        self,
+        db: AsyncSession,
+        cai: CloudAgentInstance,
+        agent: Agent,
+        cdi: CloudDaemonInstance,
+    ) -> bool:
+        """Ensure an online cloud daemon has the target agent channel loaded.
+
+        Cloud sandboxes boot with an empty daemon config. A resumed daemon can
+        therefore be online while the Hub DB still says the agent is ``ready``.
+        Probe the live daemon before treating resume as complete; if the agent
+        is missing, rotate provisioning metadata and dispatch ``provision_agent``.
+
+        Returns ``False`` only when the live-agent probe failed, in which case
+        callers keep the previous best-effort behavior instead of risking a
+        duplicate install on a merely flaky control channel.
+        """
+        live_agent_ids = await self._list_cloud_daemon_agent_ids(cdi.id)
+        if live_agent_ids is None:
+            return False
+
+        if cai.agent_id in live_agent_ids:
+            cai.status = "ready"
+            cai.error_code = None
+            cai.error_message = None
+            _scrub_provisioning_metadata(cai)
+            if cdi.status != "ready":
+                cdi.status = "ready"
+                cdi.last_started_at = _now()
+                cdi.last_seen_at = _now()
+            await db.commit()
+            return True
+
+        _ensure_provisioning_metadata(db, cai, agent)
+        cai.status = "provisioning"
+        cai.error_code = None
+        cai.error_message = None
+        await db.flush()
+        await self._provision_one(db, cai, agent, cdi)
+        return True
 
     async def restart_cloud_daemon(
         self,

--- a/backend/tests/test_app/test_cloud_agents.py
+++ b/backend/tests/test_app/test_cloud_agents.py
@@ -412,6 +412,134 @@ async def test_cloud_daemon_reconnect_skips_agent_already_loaded(
 
 
 @pytest.mark.asyncio
+async def test_resume_ready_online_agent_reprovisions_missing_daemon_channel(
+    db_session, seed_user, monkeypatch
+):
+    import hub.services.cloud_agent as cloud_agent_mod
+
+    provider = FakeCloudDaemonProvider()
+    service = CloudAgentService(provider=provider, feature_enabled=True)
+    created = await service.create_cloud_agent(
+        db_session,
+        user_id=seed_user["user_id"],
+        body=CreateCloudAgentInput(name="Bot"),
+    )
+
+    monkeypatch.setattr(
+        cloud_agent_mod,
+        "is_cloud_daemon_online",
+        lambda cloud_daemon_instance_id: (
+            cloud_daemon_instance_id == created.cloud_daemon_instance_id
+        ),
+    )
+    calls: list[tuple[str, dict | None]] = []
+
+    async def fake_send_cloud_control_frame(
+        _cloud_daemon_instance_id: str,
+        type_: str,
+        params: dict | None = None,
+        timeout_ms: int | None = None,
+    ) -> dict:
+        calls.append((type_, params))
+        if type_ == "list_agents":
+            return {"ok": True, "result": {"agents": []}}
+        if type_ == "provision_agent":
+            assert params is not None
+            assert params["credentials"]["agentId"] == created.agent_id
+            assert params["credentials"]["privateKey"]
+            return {"ok": True, "result": {"agentId": created.agent_id}}
+        raise AssertionError(f"unexpected frame {type_}")
+
+    monkeypatch.setattr(
+        cloud_agent_mod,
+        "send_cloud_control_frame",
+        fake_send_cloud_control_frame,
+    )
+
+    resumed = await service.resume_cloud_agent(
+        db_session,
+        user_id=seed_user["user_id"],
+        agent_id=created.agent_id,
+    )
+
+    assert [call[0] for call in calls] == ["list_agents", "provision_agent"]
+    assert resumed.status == "ready"
+    row = await db_session.scalar(
+        select(CloudAgentInstance).where(
+            CloudAgentInstance.agent_id == created.agent_id
+        )
+    )
+    assert row is not None
+    assert row.status == "ready"
+    assert "provisioning" not in (row.metadata_json or {})
+
+
+@pytest.mark.asyncio
+async def test_resume_paused_online_agent_reprovisions_missing_daemon_channel(
+    db_session, seed_user, monkeypatch
+):
+    import hub.services.cloud_agent as cloud_agent_mod
+
+    provider = FakeCloudDaemonProvider()
+    service = CloudAgentService(provider=provider, feature_enabled=True)
+    created = await service.create_cloud_agent(
+        db_session,
+        user_id=seed_user["user_id"],
+        body=CreateCloudAgentInput(name="Bot"),
+    )
+
+    row = await db_session.scalar(
+        select(CloudAgentInstance).where(
+            CloudAgentInstance.agent_id == created.agent_id
+        )
+    )
+    assert row is not None
+    row.status = "paused"
+    await db_session.commit()
+
+    monkeypatch.setattr(
+        cloud_agent_mod,
+        "is_cloud_daemon_online",
+        lambda cloud_daemon_instance_id: (
+            cloud_daemon_instance_id == created.cloud_daemon_instance_id
+        ),
+    )
+    calls: list[tuple[str, dict | None]] = []
+
+    async def fake_send_cloud_control_frame(
+        _cloud_daemon_instance_id: str,
+        type_: str,
+        params: dict | None = None,
+        timeout_ms: int | None = None,
+    ) -> dict:
+        calls.append((type_, params))
+        if type_ == "list_agents":
+            return {"ok": True, "result": {"agents": []}}
+        if type_ == "provision_agent":
+            assert params is not None
+            assert params["credentials"]["agentId"] == created.agent_id
+            assert params["credentials"]["privateKey"]
+            return {"ok": True, "result": {"agentId": created.agent_id}}
+        raise AssertionError(f"unexpected frame {type_}")
+
+    monkeypatch.setattr(
+        cloud_agent_mod,
+        "send_cloud_control_frame",
+        fake_send_cloud_control_frame,
+    )
+
+    resumed = await service.resume_cloud_agent(
+        db_session,
+        user_id=seed_user["user_id"],
+        agent_id=created.agent_id,
+    )
+
+    assert [call[0] for call in calls] == ["list_agents", "provision_agent"]
+    assert resumed.status == "ready"
+    assert provider.calls(created.cloud_daemon_instance_id)["create"] == 1
+
+
+@pytest.mark.asyncio
 async def test_delete_removes_from_list(client_factory, seed_user):
     client, provider = await client_factory()
     headers = {"Authorization": f"Bearer {seed_user['token']}"}


### PR DESCRIPTION
## Summary
- probe online cloud daemons during Cloud Agent resume before treating DB ready as sufficient
- reissue provisioning metadata and dispatch provision_agent when the target agent channel is missing
- add regressions for ready/paused DB state with an online but empty daemon

## Verification
- cd backend && uv run pytest tests/test_app/test_cloud_agents.py -q
- cd backend && uv run pytest tests/test_cloud_agent_provisioning.py tests/test_cloud_agent_service.py -q

## Risk / rollout
- Cloud Agent resume now performs one list_agents control-frame probe when the cloud daemon is already online; if the probe fails, it preserves the previous best-effort ready behavior to avoid duplicate installs.