### PR TITLE
feat(cloud-gateway): plumb typing presence through ingress

### DIFF
--- a/backend/hub/routers/cloud_daemon_control.py
+++ b/backend/hub/routers/cloud_daemon_control.py
@@ -271,6 +271,12 @@ _DAEMON_INITIATED_TYPES = {
     "agent_revoked",
     "pong",
     "runtime_snapshot",
+    # Best-effort in-flight presence hint emitted while a
+    # cloud_gateway_runtime_inbound dispatch is running. Forwarded to the
+    # matching ingress runtime WS so the third-party provider can render a
+    # typing indicator before the final reply arrives. See
+    # ``cloud_gateway_internal._INFLIGHT_RUNTIME_WS``.
+    "cloud_gateway_runtime_status",
 }
 
 
@@ -498,6 +504,24 @@ async def _handle_cloud_daemon_event(
             except Exception:
                 pass
             return
+
+    if msg_type == "cloud_gateway_runtime_status":
+        # Best-effort relay to the live ingress runtime WS. Late import
+        # avoids the cloud_daemon_control <-> cloud_gateway_internal cycle.
+        from hub.routers.cloud_gateway_internal import (
+            relay_runtime_status_to_ingress,
+        )
+
+        await relay_runtime_status_to_ingress(
+            cloud_daemon_instance_id=conn.cloud_daemon_instance_id,
+            params=params if isinstance(params, dict) else {},
+        )
+        ack = {"id": msg_id, "ok": True}
+        try:
+            await conn.ws.send_text(json.dumps(ack))
+        except Exception:
+            pass
+        return
 
     # Bump last_seen on both rows; persist snapshot when applicable.
     try:

--- a/backend/hub/routers/cloud_gateway_internal.py
+++ b/backend/hub/routers/cloud_gateway_internal.py
@@ -33,6 +33,7 @@ contract.
 
 from __future__ import annotations
 
+import asyncio
 import datetime
 import json
 import logging
@@ -195,6 +196,84 @@ class TouchResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# In-flight runtime WS registry
+#
+# Holds the live ingress runtime WS for every event currently being
+# processed by a cloud daemon. The cloud daemon emits a best-effort
+# ``cloud_gateway_runtime_status`` control frame mid-turn (e.g. typing);
+# the cloud_daemon_control handler looks the WS up here and forwards the
+# matching ``gateway_outbound_typing`` frame so the third-party provider
+# can render a typing indicator before the final reply arrives.
+#
+# Keyed on (cloud_daemon_instance_id, event_id) — both come from the
+# ingress runtime token so collisions across daemons are impossible.
+# ---------------------------------------------------------------------------
+
+
+_InflightKey = tuple[str, str]
+_INFLIGHT_RUNTIME_WS: dict[_InflightKey, WebSocket] = {}
+_INFLIGHT_LOCK = asyncio.Lock()
+
+
+async def _register_inflight_runtime_ws(
+    key: _InflightKey, ws: WebSocket
+) -> None:
+    async with _INFLIGHT_LOCK:
+        _INFLIGHT_RUNTIME_WS[key] = ws
+
+
+async def _unregister_inflight_runtime_ws(
+    key: _InflightKey, ws: WebSocket
+) -> None:
+    async with _INFLIGHT_LOCK:
+        current = _INFLIGHT_RUNTIME_WS.get(key)
+        if current is ws:
+            _INFLIGHT_RUNTIME_WS.pop(key, None)
+
+
+async def relay_runtime_status_to_ingress(
+    *, cloud_daemon_instance_id: str, params: dict[str, Any]
+) -> bool:
+    """Forward a daemon-emitted runtime status frame to the live ingress WS.
+
+    Best-effort: returns ``False`` silently if the event has already
+    finished, the WS has been torn down, or required fields are missing.
+    """
+    event_id = str(params.get("eventId") or "")
+    kind = str(params.get("kind") or "")
+    if not event_id or kind != "typing":
+        return False
+    async with _INFLIGHT_LOCK:
+        ws = _INFLIGHT_RUNTIME_WS.get((cloud_daemon_instance_id, event_id))
+    if ws is None:
+        return False
+    phase = str(params.get("phase") or "started")
+    if phase not in ("started", "stopped"):
+        phase = "started"
+    frame = {
+        "type": "gateway_outbound_typing",
+        "event_id": event_id,
+        "turn_id": str(params.get("turnId") or f"turn_{event_id}"),
+        "gateway_id": str(params.get("gatewayId") or ""),
+        "agent_id": str(params.get("agentId") or ""),
+        "conversation_id": str(params.get("conversationId") or ""),
+        "phase": phase,
+        "trace_id": params.get("traceId"),
+    }
+    try:
+        await ws.send_text(json.dumps(frame))
+        return True
+    except Exception as exc:  # noqa: BLE001 — relay is best-effort
+        logger.debug(
+            "cloud-gateway runtime status relay failed: cloud=%s event=%s err=%s",
+            cloud_daemon_instance_id,
+            event_id,
+            exc,
+        )
+        return False
+
+
+# ---------------------------------------------------------------------------
 # Runtime relay WebSocket
 # ---------------------------------------------------------------------------
 
@@ -269,6 +348,9 @@ async def cloud_gateway_runtime_ws(ws: WebSocket) -> None:
                 )
                 continue
 
+            inflight_key = (cloud_daemon_instance_id, event_id) if event_id else None
+            if inflight_key is not None:
+                await _register_inflight_runtime_ws(inflight_key, ws)
             try:
                 ack = await send_cloud_control_frame(
                     cloud_daemon_instance_id,
@@ -291,6 +373,11 @@ async def cloud_gateway_runtime_ws(ws: WebSocket) -> None:
                     message=str(exc),
                 )
                 continue
+            finally:
+                # Deregister as soon as the daemon ack returns (or fails):
+                # typing frames after this point belong to a different turn.
+                if inflight_key is not None:
+                    await _unregister_inflight_runtime_ws(inflight_key, ws)
 
             result = ack.get("result") if isinstance(ack, dict) else None
             if not isinstance(ack, dict) or ack.get("ok") is not True or not isinstance(result, dict):

--- a/backend/tests/test_cloud_gateway_internal.py
+++ b/backend/tests/test_cloud_gateway_internal.py
@@ -527,6 +527,72 @@ async def test_touch_updates_last_run_at(
 
 
 @pytest.mark.asyncio
+async def test_relay_runtime_status_forwards_typing_to_registered_ws():
+    """Daemon-emitted typing status reaches the live ingress runtime WS."""
+    import json
+
+    from hub.routers.cloud_gateway_internal import (
+        _register_inflight_runtime_ws,
+        _unregister_inflight_runtime_ws,
+        relay_runtime_status_to_ingress,
+    )
+
+    sent: list[str] = []
+
+    class _FakeWs:
+        async def send_text(self, payload: str) -> None:
+            sent.append(payload)
+
+    ws = _FakeWs()
+    key = ("cloud_inst_typing", "evt_typing")
+    await _register_inflight_runtime_ws(key, ws)
+    try:
+        ok = await relay_runtime_status_to_ingress(
+            cloud_daemon_instance_id="cloud_inst_typing",
+            params={
+                "eventId": "evt_typing",
+                "turnId": "turn_typing",
+                "gatewayId": "gw_wc",
+                "agentId": "ag_typing",
+                "conversationId": "wechat:user:alice",
+                "kind": "typing",
+                "phase": "started",
+                "traceId": "wechat:alice:1",
+            },
+        )
+    finally:
+        await _unregister_inflight_runtime_ws(key, ws)
+    assert ok is True
+    assert len(sent) == 1
+    frame = json.loads(sent[0])
+    assert frame["type"] == "gateway_outbound_typing"
+    assert frame["event_id"] == "evt_typing"
+    assert frame["gateway_id"] == "gw_wc"
+    assert frame["agent_id"] == "ag_typing"
+    assert frame["conversation_id"] == "wechat:user:alice"
+    assert frame["phase"] == "started"
+    assert frame["trace_id"] == "wechat:alice:1"
+
+
+@pytest.mark.asyncio
+async def test_relay_runtime_status_drops_when_no_registered_ws():
+    """No registered WS for the event → relay is a silent no-op."""
+    from hub.routers.cloud_gateway_internal import (
+        relay_runtime_status_to_ingress,
+    )
+
+    ok = await relay_runtime_status_to_ingress(
+        cloud_daemon_instance_id="cloud_inst_missing",
+        params={
+            "eventId": "evt_missing",
+            "kind": "typing",
+            "phase": "started",
+        },
+    )
+    assert ok is False
+
+
+@pytest.mark.asyncio
 async def test_runtime_session_token_rejects_wrong_kind():
     import jwt as pyjwt
 

--- a/packages/daemon/src/__tests__/cloud-gateway-runtime.test.ts
+++ b/packages/daemon/src/__tests__/cloud-gateway-runtime.test.ts
@@ -4,7 +4,10 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { RUNTIME_FRAME_TYPES, type GatewayInboundFrame } from "@botcord/protocol-core";
 
-import { handleCloudGatewayRuntimeInbound } from "../cloud-gateway-runtime.js";
+import {
+  handleCloudGatewayRuntimeInbound,
+  type CloudGatewayTypingEvent,
+} from "../cloud-gateway-runtime.js";
 import { Gateway, type ChannelAdapter } from "../gateway/index.js";
 
 describe("cloud gateway runtime inbound", () => {
@@ -64,6 +67,64 @@ describe("cloud gateway runtime inbound", () => {
     expect(result.gatewayId).toBe("gw_tg_1");
     expect(result.conversationId).toBe("telegram:user:1");
     expect(result.outbound?.finalText).toBe("hello from runtime");
+  });
+
+  it("invokes the typing emitter when the dispatcher fires typing.started", async () => {
+    const typingEvents: CloudGatewayTypingEvent[] = [];
+    const gateway = new Gateway({
+      config: {
+        channels: [],
+        defaultRoute: { runtime: "fake", cwd: tmpDir },
+      },
+      sessionStorePath: path.join(tmpDir, "sessions.json"),
+      createChannel: (cfg) => stubChannel(cfg.id, cfg.type, cfg.accountId),
+      createRuntime: () => ({
+        id: "fake",
+        async run() {
+          return { text: "ok", newSessionId: "sess_typing" };
+        },
+      }),
+      transcriptEnabled: false,
+    });
+    await gateway.start();
+
+    const frame: GatewayInboundFrame = {
+      type: RUNTIME_FRAME_TYPES.GATEWAY_INBOUND,
+      event_id: "evt_typing",
+      gateway_id: "gw_wc_1",
+      agent_id: "ag_typing",
+      provider: "wechat",
+      message: {
+        id: "wechat:alice:t1",
+        channel: "gw_wc_1",
+        accountId: "ag_typing",
+        conversation: { id: "wechat:user:alice", kind: "direct" },
+        sender: { id: "wechat:user:alice", kind: "user" },
+        text: "ping",
+        replyTo: null,
+        mentioned: true,
+        receivedAt: Date.now(),
+        trace: { id: "wechat:alice:t1", streamable: false },
+      },
+    };
+
+    const result = await handleCloudGatewayRuntimeInbound(
+      gateway,
+      frame,
+      undefined,
+      (event) => typingEvents.push(event),
+    );
+    await gateway.stop("test");
+
+    expect(result.accepted).toBe(true);
+    expect(typingEvents.length).toBeGreaterThanOrEqual(1);
+    const first = typingEvents[0]!;
+    expect(first.eventId).toBe("evt_typing");
+    expect(first.gatewayId).toBe("gw_wc_1");
+    expect(first.agentId).toBe("ag_typing");
+    expect(first.conversationId).toBe("wechat:user:alice");
+    expect(first.phase).toBe("started");
+    expect(first.traceId).toBe("wechat:alice:t1");
   });
 
   it("rejects frames outside the token scope", async () => {

--- a/packages/daemon/src/__tests__/daemon-singleton.test.ts
+++ b/packages/daemon/src/__tests__/daemon-singleton.test.ts
@@ -45,6 +45,17 @@ describe("daemon singleton pid helpers", () => {
     expect(readFileSync(pidPath, "utf8")).toBe("12345");
   });
 
+  it("creates the parent directory if missing (cloud-mode first boot)", () => {
+    // Cloud-mode start writes the PID file before `saveConfig` runs, so
+    // ~/.botcord/daemon/ may not exist yet. Without the mkdir the daemon
+    // crashes immediately with ENOENT.
+    const pidPath = path.join(tmpDir, "fresh-cloud-home", "daemon", "daemon.pid");
+
+    writeCurrentPid({ pidPath, currentPid: 7890 });
+
+    expect(readPid(pidPath)).toBe(7890);
+  });
+
   it("does not report the current process as another daemon", () => {
     const pidPath = path.join(tmpDir, "daemon.pid");
     writeCurrentPid({ pidPath, currentPid: process.pid });

--- a/packages/daemon/src/cloud-daemon.ts
+++ b/packages/daemon/src/cloud-daemon.ts
@@ -9,7 +9,8 @@
  *
  * See ``docs/cloud-agent-technical-design.md`` §4 + §6.
  */
-import { shouldWake, type AttentionPolicy } from "@botcord/protocol-core";
+import { CONTROL_FRAME_TYPES, shouldWake, type AttentionPolicy } from "@botcord/protocol-core";
+import type { CloudGatewayTypingEmitter } from "./cloud-gateway-runtime.js";
 import {
   Gateway,
   resolveTranscriptEnabled,
@@ -284,10 +285,33 @@ export async function startCloudDaemon(
   if (!opts.disableControlChannel) {
     const auth = asUserAuthManager(new CloudAuthManager(cloudCfg));
     const provisionerFactory = opts.provisionerFactory ?? createProvisioner;
+    // Forward-declare controlChannel-bound emitter: the provisioner is
+    // built before the channel exists, so the closure captures the slot
+    // and reads it back lazily once cloud-daemon assigns the instance.
+    const cloudGatewayTypingEmitter: CloudGatewayTypingEmitter = (event) => {
+      const ch = controlChannel;
+      if (!ch) return;
+      ch.send({
+        id: `cgrs_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+        type: CONTROL_FRAME_TYPES.CLOUD_GATEWAY_RUNTIME_STATUS,
+        params: {
+          eventId: event.eventId,
+          turnId: event.turnId,
+          gatewayId: event.gatewayId,
+          agentId: event.agentId,
+          conversationId: event.conversationId,
+          kind: "typing",
+          phase: event.phase,
+          traceId: event.traceId ?? null,
+        },
+        ts: Date.now(),
+      });
+    };
     const provisioner = provisionerFactory({
       gateway,
       policyResolver,
       onAgentInstalled,
+      cloudGatewayTypingEmitter,
     });
     const ControlChannelCtor = opts.controlChannelFactory ?? ControlChannel;
     controlChannel = new ControlChannelCtor({

--- a/packages/daemon/src/cloud-gateway-runtime.ts
+++ b/packages/daemon/src/cloud-gateway-runtime.ts
@@ -8,10 +8,30 @@ import type {
   ChannelSendContext,
   ChannelSendResult,
   ChannelStatusSnapshot,
+  ChannelTypingContext,
   Gateway,
   GatewayInboundMessage,
   GatewayLogger,
 } from "./gateway/index.js";
+
+/**
+ * Fire-and-forget hook invoked when the dispatcher signals "typing" while
+ * a cloud-gateway runtime turn is in flight. The cloud daemon wires this
+ * to a control-plane `cloud_gateway_runtime_status` push so the Hub can
+ * relay it to the ingress runtime WS and the third-party provider can
+ * render a typing indicator.
+ */
+export interface CloudGatewayTypingEvent {
+  eventId: string;
+  turnId: string;
+  gatewayId: string;
+  agentId: string;
+  conversationId: string;
+  phase: "started" | "stopped";
+  traceId?: string | null;
+}
+
+export type CloudGatewayTypingEmitter = (event: CloudGatewayTypingEvent) => void;
 
 export interface CloudGatewayRuntimeResult {
   accepted: boolean;
@@ -44,6 +64,7 @@ export async function handleCloudGatewayRuntimeInbound(
   gateway: Gateway,
   frame: GatewayInboundFrame,
   log?: GatewayLogger,
+  onTyping?: CloudGatewayTypingEmitter,
 ): Promise<CloudGatewayRuntimeResult> {
   if (frame.type !== RUNTIME_FRAME_TYPES.GATEWAY_INBOUND) {
     return rejected(frame, "bad_frame_type", `unsupported frame type "${frame.type}"`);
@@ -61,6 +82,7 @@ export async function handleCloudGatewayRuntimeInbound(
   let accepted = false;
   let outboundText: string | null = null;
   let providerMessageId: string | null | undefined;
+  const turnId = `turn_${frame.event_id}`;
   const channel = createRuntimeRelayChannel({
     id: frame.gateway_id,
     provider: frame.provider,
@@ -70,6 +92,28 @@ export async function handleCloudGatewayRuntimeInbound(
       providerMessageId = ctx.message.traceId ?? null;
       return { providerMessageId };
     },
+    onTyping: onTyping
+      ? (ctx) => {
+          try {
+            onTyping({
+              eventId: frame.event_id,
+              turnId,
+              gatewayId: frame.gateway_id,
+              agentId: frame.agent_id,
+              conversationId: frame.message.conversation.id,
+              phase: "started",
+              traceId: ctx.traceId ?? null,
+            });
+          } catch (err) {
+            log?.warn?.("cloud gateway typing emit failed", {
+              eventId: frame.event_id,
+              gatewayId: frame.gateway_id,
+              agentId: frame.agent_id,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+      : undefined,
   });
 
   const message: GatewayInboundMessage = {
@@ -105,7 +149,7 @@ export async function handleCloudGatewayRuntimeInbound(
     gatewayId: frame.gateway_id,
     agentId: frame.agent_id,
     conversationId: frame.message.conversation.id,
-    turnId: `turn_${frame.event_id}`,
+    turnId,
     ...(outboundText !== null
       ? {
           outbound: {
@@ -125,9 +169,10 @@ function createRuntimeRelayChannel(opts: {
   provider: string;
   accountId: string;
   onSend: (ctx: ChannelSendContext) => Promise<ChannelSendResult>;
+  onTyping?: (ctx: ChannelTypingContext) => void;
 }): ChannelAdapter {
   let lastSendAt: number | undefined;
-  return {
+  const adapter: ChannelAdapter = {
     id: opts.id,
     type: opts.provider,
     async start() {
@@ -152,6 +197,12 @@ function createRuntimeRelayChannel(opts: {
       };
     },
   };
+  if (opts.onTyping) {
+    adapter.typing = async (ctx) => {
+      opts.onTyping!(ctx);
+    };
+  }
+  return adapter;
 }
 
 function rejected(

--- a/packages/daemon/src/daemon-singleton.ts
+++ b/packages/daemon/src/daemon-singleton.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import path from "node:path";
 import { PID_PATH } from "./config.js";
 
 export interface SingletonLogger {
@@ -182,7 +183,16 @@ export function writeCurrentPid(
     currentPid?: number;
   } = {},
 ): void {
-  writeFileSync(opts.pidPath ?? PID_PATH, String(opts.currentPid ?? process.pid), { mode: 0o600 });
+  const pidPath = opts.pidPath ?? PID_PATH;
+  // Cloud-mode startup writes the PID file before `saveConfig` runs, so
+  // the daemon dir may not exist yet. mkdir its parent (0700) so the
+  // first write doesn't crash with ENOENT.
+  try {
+    mkdirSync(path.dirname(pidPath), { recursive: true, mode: 0o700 });
+  } catch {
+    // best-effort — writeFileSync below will surface the real error
+  }
+  writeFileSync(pidPath, String(opts.currentPid ?? process.pid), { mode: 0o600 });
 }
 
 export function removePidFile(pidPath = PID_PATH): void {

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -78,7 +78,10 @@ import {
   buildRuntimeSelectionExtraArgs,
   mergeRuntimeExtraArgs,
 } from "./runtime-route-options.js";
-import { handleCloudGatewayRuntimeInbound } from "./cloud-gateway-runtime.js";
+import {
+  handleCloudGatewayRuntimeInbound,
+  type CloudGatewayTypingEmitter,
+} from "./cloud-gateway-runtime.js";
 
 /**
  * Information passed to {@link OnAgentInstalledHook} after a successful
@@ -136,6 +139,13 @@ export interface ProvisionerOptions {
    * spin up a default in-memory store.
    */
   loginSessions?: LoginSessionStore;
+  /**
+   * Optional callback invoked when an in-flight `cloud_gateway_runtime_inbound`
+   * fires a typing event. The cloud daemon wires this to its control-plane
+   * connection so the Hub can relay the hint to the live ingress runtime WS.
+   * Absent for local daemons (no ingress path).
+   */
+  cloudGatewayTypingEmitter?: CloudGatewayTypingEmitter;
 }
 
 /** The value a frame handler returns (minus the `id` which the channel fills in). */
@@ -153,6 +163,7 @@ export function createProvisioner(opts: ProvisionerOptions): (
   const register = opts.register ?? BotCordClient.register;
   const policyResolver = opts.policyResolver;
   const onAgentInstalled = opts.onAgentInstalled;
+  const cloudGatewayTypingEmitter = opts.cloudGatewayTypingEmitter;
   const gatewayControl = createGatewayControl({
     gateway,
     ...(opts.loginSessions ? { loginSessions: opts.loginSessions } : {}),
@@ -440,7 +451,12 @@ export function createProvisioner(opts: ProvisionerOptions): (
             },
           };
         }
-        const result = await handleCloudGatewayRuntimeInbound(gateway, runtimeFrame);
+        const result = await handleCloudGatewayRuntimeInbound(
+          gateway,
+          runtimeFrame,
+          undefined,
+          cloudGatewayTypingEmitter,
+        );
         return result.accepted
           ? { ok: true, result }
           : {

--- a/packages/gateway-ingress/src/__tests__/orchestrator.test.ts
+++ b/packages/gateway-ingress/src/__tests__/orchestrator.test.ts
@@ -263,6 +263,60 @@ describe("IngressOrchestrator", () => {
     expect(e.lastError).toContain("runtime_failed");
   });
 
+  it("outbound typing frame routes to provider.typing()", async () => {
+    const typingCalls: {
+      gatewayId: string;
+      conversationId: string;
+      turnId: string;
+      phase: string;
+      traceId?: string | null;
+    }[] = [];
+    // Re-register the provider with a typing() method — the default
+    // harness adapter intentionally omits it so other tests stay terse.
+    h.orchestrator.registerProvider({
+      gatewayId: CONN.id,
+      provider: "telegram",
+      async start() {},
+      async stop() {},
+      async send() {
+        return { providerMessageId: null };
+      },
+      async typing(request) {
+        typingCalls.push({
+          gatewayId: request.gatewayId,
+          conversationId: request.conversationId,
+          turnId: request.turnId,
+          phase: request.phase,
+          traceId: request.traceId,
+        });
+      },
+    });
+
+    await h.orchestrator.ingest(CONN.id, NORMALIZED, "tg:gw:typing");
+    await waitFor(() => h.socketFactory.sockets.length === 1);
+    const sock = h.socketFactory.sockets[0]!;
+    await waitFor(() => sock.sent.length === 1);
+    const inboundFrame = JSON.parse(sock.sent[0]!) as GatewayInboundFrame;
+    sock.incoming({
+      type: RUNTIME_FRAME_TYPES.GATEWAY_OUTBOUND_TYPING,
+      event_id: inboundFrame.event_id,
+      turn_id: "turn_typing",
+      gateway_id: CONN.id,
+      agent_id: CONN.agentId,
+      conversation_id: NORMALIZED.conversation.id,
+      phase: "started",
+      trace_id: "telegram:42:1",
+    });
+    await waitFor(() => typingCalls.length === 1);
+    expect(typingCalls[0]).toEqual({
+      gatewayId: CONN.id,
+      conversationId: NORMALIZED.conversation.id,
+      turnId: "turn_typing",
+      phase: "started",
+      traceId: "telegram:42:1",
+    });
+  });
+
   it("hub failure surfaces as failed event", async () => {
     h.hub.ensureResponse = () => ({
       agent_id: CONN.agentId,

--- a/packages/gateway-ingress/src/__tests__/wechat.test.ts
+++ b/packages/gateway-ingress/src/__tests__/wechat.test.ts
@@ -236,6 +236,135 @@ describe("WeChat provider adapter", () => {
     ]);
   });
 
+  it("typing() fetches typing_ticket via getconfig and posts sendtyping", async () => {
+    let pollCount = 0;
+    const getConfigBodies: unknown[] = [];
+    const sendTypingBodies: unknown[] = [];
+    const fetchImpl = (async (url: string, init?: RequestInit) => {
+      if (url.endsWith("/ilink/bot/getupdates")) {
+        pollCount += 1;
+        if (pollCount === 1) {
+          return new Response(
+            JSON.stringify({
+              ret: 0,
+              get_updates_buf: "buf-typing",
+              msgs: [
+                {
+                  message_type: 1,
+                  from_user_id: "alice",
+                  context_token: "ctx-tok-typing",
+                  client_id: "wc_client_typing",
+                  item_list: [{ type: 1, text_item: { text: "hi" } }],
+                },
+              ],
+            }),
+            { status: 200 },
+          );
+        }
+        return new Promise<Response>((_res, rej) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => rej(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        });
+      }
+      if (url.endsWith("/ilink/bot/getconfig")) {
+        getConfigBodies.push(JSON.parse(init?.body as string));
+        return new Response(
+          JSON.stringify({ ret: 0, typing_ticket: "ticket-xyz" }),
+          { status: 200 },
+        );
+      }
+      if (url.endsWith("/ilink/bot/sendtyping")) {
+        sendTypingBodies.push(JSON.parse(init?.body as string));
+        return new Response(JSON.stringify({ ret: 0 }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const provider = createWechatProvider({
+      gatewayId: conn.id,
+      fetchImpl,
+    });
+    const abort = new AbortController();
+    const { ctx, emits } = makeCtx({ botToken: "tok" }, abort);
+    const running = provider.start(ctx);
+    const deadline = Date.now() + 1_000;
+    while (Date.now() < deadline && emits.length === 0) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+
+    // First typing call hits getconfig + sendtyping.
+    await provider.typing!({
+      gatewayId: conn.id,
+      conversationId: "wechat:user:alice",
+      turnId: "turn_t1",
+      phase: "started",
+    });
+    // Second call reuses the cached typing_ticket — only one getconfig.
+    await provider.typing!({
+      gatewayId: conn.id,
+      conversationId: "wechat:user:alice",
+      turnId: "turn_t2",
+      phase: "started",
+    });
+
+    abort.abort();
+    await running;
+
+    expect(getConfigBodies).toHaveLength(1);
+    expect((getConfigBodies[0] as { ilink_user_id: string }).ilink_user_id).toBe("alice");
+    expect(sendTypingBodies).toHaveLength(2);
+    for (const body of sendTypingBodies) {
+      expect(body).toMatchObject({
+        ilink_user_id: "alice",
+        typing_ticket: "ticket-xyz",
+        status: 1,
+      });
+    }
+  });
+
+  it("typing() is a no-op when no trace exists for the conversation", async () => {
+    let sendTypingCalls = 0;
+    let getConfigCalls = 0;
+    const fetchImpl = (async (url: string, init?: RequestInit) => {
+      if (url.endsWith("/ilink/bot/getupdates")) {
+        return new Promise<Response>((_res, rej) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => rej(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        });
+      }
+      if (url.endsWith("/ilink/bot/getconfig")) getConfigCalls += 1;
+      if (url.endsWith("/ilink/bot/sendtyping")) sendTypingCalls += 1;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const provider = createWechatProvider({
+      gatewayId: conn.id,
+      fetchImpl,
+    });
+    const abort = new AbortController();
+    const { ctx } = makeCtx({ botToken: "tok" }, abort);
+    const running = provider.start(ctx);
+    await new Promise((r) => setTimeout(r, 30));
+
+    await provider.typing!({
+      gatewayId: conn.id,
+      conversationId: "wechat:user:nobody",
+      turnId: "turn_x",
+      phase: "started",
+    });
+
+    abort.abort();
+    await running;
+    expect(getConfigCalls).toBe(0);
+    expect(sendTypingCalls).toBe(0);
+  });
+
   it("send() throws when no trace is cached for the conversation", async () => {
     const fetchImpl = (async (_url: string, init?: RequestInit) => {
       // Hold the poll open so loop survives until abort.

--- a/packages/gateway-ingress/src/orchestrator.ts
+++ b/packages/gateway-ingress/src/orchestrator.ts
@@ -376,6 +376,26 @@ export class IngressOrchestrator {
         }
         return;
       }
+      case RUNTIME_FRAME_TYPES.GATEWAY_OUTBOUND_TYPING: {
+        const provider = this.providers.get(frame.gateway_id);
+        if (!provider || typeof provider.typing !== "function") return;
+        try {
+          await provider.typing({
+            gatewayId: frame.gateway_id,
+            conversationId: frame.conversation_id,
+            turnId: frame.turn_id,
+            phase: frame.phase,
+            traceId: frame.trace_id ?? null,
+          });
+        } catch (err) {
+          this.opts.log.warn("provider typing failed", {
+            gatewayId: frame.gateway_id,
+            eventId: frame.event_id,
+            err: String(err),
+          });
+        }
+        return;
+      }
       case RUNTIME_FRAME_TYPES.RUNTIME_HEARTBEAT: {
         // Heartbeats are observed only.
         return;

--- a/packages/gateway-ingress/src/providers/feishu.ts
+++ b/packages/gateway-ingress/src/providers/feishu.ts
@@ -5,6 +5,7 @@ import type { GatewayInboundMessage } from "@botcord/protocol-core";
 
 import type { OutboundSendRequest, OutboundSendResult } from "../types.js";
 import type {
+  OutboundTypingRequest,
   ProviderAdapter,
   ProviderAdapterFactory,
   ProviderRuntimeContext,
@@ -25,8 +26,12 @@ import type {
  *   - state-store file: dropped. `seenMessageIds` lived only to guard
  *     against re-delivery on daemon restart; the orchestrator now owns
  *     that invariant.
- *   - typing reaction (im.v1 reactions API): omitted from MVP. The
- *     ingress runtime has no `typing` concept yet — phase 4 can re-add.
+
+ *   - typing reaction (im.v1 reactions API): fired from `typing()` when
+ *     the daemon emits a `gateway_outbound_typing` runtime frame. Uses
+ *     the inbound message id (extracted from the trace id) to attach a
+ *     "Typing" emoji reaction; the reaction is removed when `send()`
+ *     posts the reply for the matching turn.
  *   - attachment uploads: omitted from MVP. The runtime frame contract
  *     carries text only; richer outbound shapes land alongside
  *     streaming (`gateway_outbound_delta`).
@@ -51,6 +56,7 @@ import type {
  */
 const FEISHU_PROVIDER = "feishu" as const;
 const DEFAULT_SPLIT_AT = 4000;
+const TYPING_EMOJI = "Typing" as const;
 
 export type FeishuDomain = "feishu" | "lark";
 
@@ -184,6 +190,12 @@ export function createFeishuProvider(opts: FeishuProviderOptions): ProviderAdapt
   let splitAt = DEFAULT_SPLIT_AT;
   let allowedSenderIds = new Set<string>();
   let allowedChatIds = new Set<string>();
+  /**
+   * Active Typing reactions, keyed by turnId so `send()` for the same turn
+   * can clean up the reaction once the visible reply lands. Second map is
+   * a parallel index by messageId for cleanup on `stop()`.
+   */
+  const typingReactionsByTurn = new Map<string, { messageId: string; reactionId: string }>();
 
   function ensureClient(): FeishuClient {
     if (client) return client;
@@ -380,7 +392,48 @@ export function createFeishuProvider(opts: FeishuProviderOptions): ProviderAdapt
       if (id) lastMessageId = `feishu:${id}`;
     }
     if (activeCtx) activeCtx.markActivity({ lastInboundAt: undefined });
+    // Drop the Typing reaction for this turn now that the visible reply
+    // has landed. Best-effort — if the cleanup call fails, the reaction
+    // is left dangling but the user has already seen the reply.
+    if (request.turnId) void removeTypingForTurn(request.turnId);
     return { providerMessageId: lastMessageId };
+  }
+
+  async function typing(request: OutboundTypingRequest): Promise<void> {
+    if (!appId || !appSecret) return;
+    if (request.phase !== "started") return;
+    const messageId = messageIdFromTrace(request.traceId);
+    if (!messageId) return;
+    // Idempotent — repeated typing pings on the same turn keep the
+    // single existing reaction.
+    if (typingReactionsByTurn.has(request.turnId)) return;
+    try {
+      const res = await callFeishu({
+        method: "POST",
+        url: `/open-apis/im/v1/messages/${encodeURIComponent(messageId)}/reactions`,
+        data: { reaction_type: { emoji_type: TYPING_EMOJI } },
+      });
+      const reactionId = resultReactionId(res);
+      if (reactionId) {
+        typingReactionsByTurn.set(request.turnId, { messageId, reactionId });
+      }
+    } catch (err) {
+      activeCtx?.log.debug("feishu typing reaction failed", { err: redact(err) });
+    }
+  }
+
+  async function removeTypingForTurn(turnId: string): Promise<void> {
+    const entry = typingReactionsByTurn.get(turnId);
+    if (!entry) return;
+    typingReactionsByTurn.delete(turnId);
+    try {
+      await callFeishu({
+        method: "DELETE",
+        url: `/open-apis/im/v1/messages/${encodeURIComponent(entry.messageId)}/reactions/${encodeURIComponent(entry.reactionId)}`,
+      });
+    } catch (err) {
+      activeCtx?.log.debug("feishu typing reaction cleanup failed", { err: redact(err) });
+    }
   }
 
   return {
@@ -394,9 +447,30 @@ export function createFeishuProvider(opts: FeishuProviderOptions): ProviderAdapt
         // best effort
       }
       wsClient = null;
+      const pending = Array.from(typingReactionsByTurn.keys());
+      typingReactionsByTurn.clear();
+      await Promise.allSettled(pending.map(removeTypingForTurn));
     },
     send,
+    typing,
   };
+}
+
+function resultReactionId(res: FeishuApiResponse): string | undefined {
+  const data = res.data;
+  if (data && typeof data === "object" && typeof (data as Record<string, unknown>).reaction_id === "string") {
+    return (data as Record<string, string>).reaction_id;
+  }
+  if (typeof (res as Record<string, unknown>).reaction_id === "string") {
+    return (res as Record<string, string>).reaction_id;
+  }
+  return undefined;
+}
+
+function messageIdFromTrace(traceId: string | null | undefined): string | null {
+  if (!traceId || !traceId.startsWith("feishu:")) return null;
+  const rest = traceId.slice("feishu:".length);
+  return rest.length > 0 ? rest : null;
 }
 
 function resultMessageId(res: FeishuApiResponse): string | undefined {

--- a/packages/gateway-ingress/src/providers/telegram.ts
+++ b/packages/gateway-ingress/src/providers/telegram.ts
@@ -1,6 +1,11 @@
 import type { GatewayInboundMessage } from "@botcord/protocol-core";
 import type { OutboundSendRequest, OutboundSendResult } from "../types.js";
-import type { ProviderAdapter, ProviderAdapterFactory, ProviderRuntimeContext } from "./types.js";
+import type {
+  OutboundTypingRequest,
+  ProviderAdapter,
+  ProviderAdapterFactory,
+  ProviderRuntimeContext,
+} from "./types.js";
 
 /**
  * Telegram getUpdates polling adapter for the cloud gateway ingress.
@@ -296,6 +301,18 @@ export function createTelegramProvider(opts: TelegramProviderOptions): ProviderA
     return { providerMessageId: lastMessageId };
   }
 
+  async function typing(request: OutboundTypingRequest): Promise<void> {
+    if (!botToken) return;
+    if (request.phase !== "started") return;
+    const chatId = chatIdFromConversation(request.conversationId);
+    if (!chatId) return;
+    try {
+      await callApi("sendChatAction", { chat_id: chatId, action: "typing" }, 10_000);
+    } catch (err) {
+      activeCtx?.log.debug("telegram typing failed", { err: redactToken(String(err)) });
+    }
+  }
+
   return {
     gatewayId: opts.gatewayId,
     provider: "telegram",
@@ -306,6 +323,7 @@ export function createTelegramProvider(opts: TelegramProviderOptions): ProviderA
       stopController?.abort();
     },
     send,
+    typing,
   };
 }
 

--- a/packages/gateway-ingress/src/providers/types.ts
+++ b/packages/gateway-ingress/src/providers/types.ts
@@ -22,6 +22,25 @@ export interface ProviderAdapter {
   start(ctx: ProviderRuntimeContext): Promise<void>;
   stop(reason?: string): Promise<void>;
   send(request: OutboundSendRequest): Promise<OutboundSendResult>;
+  /**
+   * Optional ephemeral "agent is responding" hint. Called when the runtime
+   * has accepted the inbound but hasn't streamed any visible reply yet.
+   * Implementations must be fire-and-forget: errors are logged and
+   * swallowed so a flaky provider can't fail the turn.
+   */
+  typing?(request: OutboundTypingRequest): Promise<void>;
+}
+
+/**
+ * Payload handed to {@link ProviderAdapter.typing}. Mirrors the
+ * `gateway_outbound_typing` runtime frame minus framing fields.
+ */
+export interface OutboundTypingRequest {
+  gatewayId: string;
+  conversationId: string;
+  turnId: string;
+  phase: "started" | "stopped";
+  traceId?: string | null;
 }
 
 /**

--- a/packages/gateway-ingress/src/providers/wechat.ts
+++ b/packages/gateway-ingress/src/providers/wechat.ts
@@ -5,6 +5,7 @@ import type { GatewayInboundMessage } from "@botcord/protocol-core";
 
 import type { OutboundSendRequest, OutboundSendResult } from "../types.js";
 import type {
+  OutboundTypingRequest,
   ProviderAdapter,
   ProviderAdapterFactory,
   ProviderRuntimeContext,
@@ -31,8 +32,9 @@ import type {
  *     for outbound `sendmessage`. iLink does NOT accept unsolicited
  *     replies — outbound must reuse the inbound `context_token`, so
  *     this cache is load-bearing. TTL 30 min mirrors daemon doc.
- *   - typing (`sendtyping`): omitted from MVP. Phase 4 can re-add when
- *     the ingress contract has a typing concept.
+ *   - typing (`sendtyping`): fired from `typing()` when the daemon emits
+ *     a `gateway_outbound_typing` runtime frame. Per-user `typing_ticket`
+ *     is fetched via `getconfig` and cached in-process keyed by ilink uid.
  *   - media upload (encrypted CDN flow, AES-128-ECB): omitted from
  *     MVP. iLink media is text-only-aware for now.
  *
@@ -137,6 +139,10 @@ export function createWechatProvider(opts: WechatProviderOptions): ProviderAdapt
   let stopController: AbortController | null = null;
   let sweepTimer: ReturnType<typeof setInterval> | null = null;
   const traceContexts = new Map<string, TraceContext>();
+  /** Per-ilink-user typing_ticket cache. iLink returns the same ticket for
+   * the lifetime of a context_token, so caching avoids an extra round-trip
+   * before every typing ping. */
+  const typingTickets = new Map<string, string>();
 
   function pruneTraceContexts(): void {
     const cutoff = now() - TRACE_CONTEXT_TTL_MS;
@@ -362,6 +368,51 @@ export function createWechatProvider(opts: WechatProviderOptions): ProviderAdapt
     }
   }
 
+  async function getTypingTicket(userId: string, contextToken: string): Promise<string> {
+    const cached = typingTickets.get(userId);
+    if (cached) return cached;
+    try {
+      const resp = await callApi<{ ret?: number; typing_ticket?: string }>(
+        "ilink/bot/getconfig",
+        { ilink_user_id: userId, context_token: contextToken },
+        10_000,
+      );
+      const ticket = typeof resp.typing_ticket === "string" ? resp.typing_ticket : "";
+      if (ticket) typingTickets.set(userId, ticket);
+      return ticket;
+    } catch {
+      return "";
+    }
+  }
+
+  async function typing(request: OutboundTypingRequest): Promise<void> {
+    // Best-effort: a stale trace, missing token, or iLink hiccup must not
+    // break the turn. Errors are logged at debug level inside the adapter.
+    if (!botToken) return;
+    if (request.phase !== "started") return;
+    const trace =
+      lookupTrace(request.traceId ?? undefined) ??
+      lookupTraceByConversation(request.conversationId);
+    if (!trace) return;
+    try {
+      const ticket = await getTypingTicket(trace.fromUserId, trace.contextToken);
+      if (!ticket) return;
+      await callApi(
+        "ilink/bot/sendtyping",
+        {
+          ilink_user_id: trace.fromUserId,
+          typing_ticket: ticket,
+          status: 1,
+        },
+        10_000,
+      );
+    } catch (err) {
+      activeCtx?.log.debug("wechat typing failed", {
+        err: redactToken(String(err), botToken),
+      });
+    }
+  }
+
   async function send(request: OutboundSendRequest): Promise<OutboundSendResult> {
     if (!botToken) throw new Error("wechat bot token not loaded");
     // OutboundSendRequest carries no traceId today, so fall back to a
@@ -416,6 +467,7 @@ export function createWechatProvider(opts: WechatProviderOptions): ProviderAdapt
       stopController?.abort();
     },
     send,
+    typing,
   };
 }
 

--- a/packages/protocol-core/src/control-frame.ts
+++ b/packages/protocol-core/src/control-frame.ts
@@ -140,7 +140,37 @@ export const CONTROL_FRAME_TYPES = {
    * before the gateway row is saved.
    */
   GATEWAY_RECENT_SENDERS: "gateway_recent_senders",
+  /**
+   * Daemon→Hub: in-flight runtime status hint emitted while the cloud
+   * gateway runtime is processing one ingress-originated turn. The Hub
+   * looks up the live ingress runtime WS by `eventId` and forwards a
+   * matching `gateway_outbound_typing` frame so the third-party provider
+   * can render a typing indicator before the final reply arrives.
+   *
+   * Best-effort: dropped silently if the runtime WS has already closed
+   * or no such event is in flight.
+   */
+  CLOUD_GATEWAY_RUNTIME_STATUS: "cloud_gateway_runtime_status",
 } as const;
+
+/**
+ * Payload shape for {@link CONTROL_FRAME_TYPES.CLOUD_GATEWAY_RUNTIME_STATUS}.
+ * Emitted by the cloud daemon while one `cloud_gateway_runtime_inbound`
+ * dispatch is mid-flight.
+ */
+export interface CloudGatewayRuntimeStatusParams {
+  eventId: string;
+  turnId: string;
+  gatewayId: string;
+  agentId: string;
+  conversationId: string;
+  /** `typing` is the only kind today; reserved for richer presence later. */
+  kind: "typing";
+  /** Mirrors {@link GatewayOutboundTypingFrame.phase}. */
+  phase: "started" | "stopped";
+  /** Provider trace id, when available — e.g. the inbound message id. */
+  traceId?: string | null;
+}
 
 export type ControlFrameType = (typeof CONTROL_FRAME_TYPES)[keyof typeof CONTROL_FRAME_TYPES];
 

--- a/packages/protocol-core/src/runtime-frame.ts
+++ b/packages/protocol-core/src/runtime-frame.ts
@@ -185,6 +185,27 @@ export interface RuntimeHeartbeatFrame {
 }
 
 /**
+ * Ephemeral presence hint: the runtime is "thinking" / about to reply.
+ * ingress maps this to the provider's typing affordance (Telegram
+ * `sendChatAction`, WeChat `sendtyping`, Feishu reaction). There is no
+ * paired `stopped` frame on the wire — provider typing states naturally
+ * clear when the outbound complete/error arrives, and most providers
+ * (WeChat especially) treat typing as a short-lived one-shot.
+ */
+export interface GatewayOutboundTypingFrame {
+  type: "gateway_outbound_typing";
+  event_id: string;
+  turn_id: string;
+  gateway_id: string;
+  agent_id: string;
+  conversation_id: string;
+  /** `started` is the only value emitted today; reserved for future stop semantics. */
+  phase: "started" | "stopped";
+  /** Provider trace id (iLink `context_token` lookup, Feishu message id, …). */
+  trace_id?: string | null;
+}
+
+/**
  * Union of all outbound (cloud daemon → ingress) frames the ingress
  * reads on the runtime WS. Each frame is line-delimited JSON.
  */
@@ -194,6 +215,7 @@ export type RuntimeOutboundFrame =
   | GatewayOutboundDeltaFrame
   | GatewayOutboundCompleteFrame
   | GatewayOutboundErrorFrame
+  | GatewayOutboundTypingFrame
   | RuntimeHeartbeatFrame;
 
 /**
@@ -211,6 +233,7 @@ export const RUNTIME_FRAME_TYPES = {
   GATEWAY_OUTBOUND_DELTA: "gateway_outbound_delta",
   GATEWAY_OUTBOUND_COMPLETE: "gateway_outbound_complete",
   GATEWAY_OUTBOUND_ERROR: "gateway_outbound_error",
+  GATEWAY_OUTBOUND_TYPING: "gateway_outbound_typing",
   RUNTIME_HEARTBEAT: "runtime_heartbeat",
 } as const;
 


### PR DESCRIPTION
## Summary
- End-to-end typing path for the cloud-gateway runtime so WeChat / Telegram / Feishu render a typing indicator while the agent is processing an inbound turn (previously the cloud path silently dropped the dispatcher's typing event).
- Adds a daemon→Hub control frame (\`cloud_gateway_runtime_status\`) and a runtime frame (\`gateway_outbound_typing\`); the Hub forwards best-effort to the live ingress WS, ingress dispatches to a new optional \`ProviderAdapter.typing()\`.
- Provider implementations: WeChat \`sendtyping\` with cached \`typing_ticket\`; Telegram \`sendChatAction\`; Feishu \`Typing\` reaction (cleaned up on reply).

## Test plan
- [x] \`protocol-core\` build
- [x] \`packages/daemon\` vitest (885 passed — incl. new emitter test)
- [x] \`packages/gateway-ingress\` vitest (73 passed — incl. new wechat typing + orchestrator routing tests)
- [x] \`backend\` pytest full suite (1287 passed — incl. 2 new relay tests)
- [ ] Smoke: trigger an inbound message in WeChat against a cloud-gateway bot and confirm the typing indicator appears before the reply lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)