### PR TITLE
chore(daemon): bump @botcord/protocol-core to ^0.2.12

### DIFF
--- a/packages/daemon/package-lock.json
+++ b/packages/daemon/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@botcord/cli": "^0.1.7",
-        "@botcord/protocol-core": "^0.2.11",
+        "@botcord/protocol-core": "^0.2.12",
         "@larksuiteoapi/node-sdk": "^1.63.1",
         "ws": "^8.20.1"
       },
@@ -29,7 +29,7 @@
     },
     "../protocol-core": {
       "name": "@botcord/protocol-core",
-      "version": "0.2.10",
+      "version": "0.2.12",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@botcord/cli": "^0.1.7",
-    "@botcord/protocol-core": "^0.2.11",
+    "@botcord/protocol-core": "^0.2.12",
     "@larksuiteoapi/node-sdk": "^1.63.1",
     "ws": "^8.20.1"
   },


### PR DESCRIPTION
## Summary
- Bumps the daemon's \`@botcord/protocol-core\` dependency to ^0.2.12 (released in 39e6fc8bd) so it picks up the \`gateway_outbound_typing\` runtime frame and \`cloud_gateway_runtime_status\` control frame schemas added in #816.

## Test plan
- [x] \`npm install --package-lock-only\` cleanly resolves to 0.2.12
- [x] \`npm run build\` (daemon)
- [x] \`npm test\` (daemon — 885 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)