### PR TITLE
fix: detect deepseek reasoning effort options

### DIFF
--- a/packages/daemon/src/__tests__/runtime-models.test.ts
+++ b/packages/daemon/src/__tests__/runtime-models.test.ts
@@ -199,6 +199,56 @@ describe("runtime model discovery parsers", () => {
     ]);
   });
 
+  it("reads DeepSeek reasoning effort choices from the installed runtime template", () => {
+    const tmp = mkdtempSync(path.join(tmpdir(), "daemon-deepseek-catalog-"));
+    const prevHome = process.env.HOME;
+    const prevCacheDir = process.env.BOTCORD_RUNTIME_CATALOG_CACHE_DIR;
+    try {
+      const home = path.join(tmp, "home");
+      mkdirSync(path.join(home, ".deepseek"), { recursive: true });
+      process.env.HOME = home;
+      process.env.BOTCORD_RUNTIME_CATALOG_CACHE_DIR = path.join(tmp, "catalog-cache");
+      writeFileSync(
+        path.join(home, ".deepseek", "config.toml"),
+        'default_text_model = "deepseek-v4-pro"\nreasoning_effort = "turbo"\n',
+      );
+      const fakeDeepseek = path.join(tmp, "deepseek");
+      writeFileSync(
+        fakeDeepseek,
+        [
+          "binary prefix",
+          "# Thinking mode (DeepSeek V4 reasoning effort):",
+          '# "adaptive" | "disabled" | "turbo"',
+          'reasoning_effort = "adaptive"',
+        ].join("\n"),
+      );
+
+      const catalog = discoverRuntimeModelCatalog({
+        id: "deepseek-tui",
+        displayName: "DeepSeek TUI",
+        binary: "deepseek",
+        supportsRun: true,
+        result: { available: true, path: fakeDeepseek },
+      });
+
+      expect(catalog.parameters).toContainEqual({
+        id: "reasoning_effort",
+        displayName: "Reasoning effort",
+        type: "enum",
+        flag: "--reasoning-effort",
+        values: ["adaptive", "disabled", "turbo"],
+        defaultValue: "turbo",
+        source: "config",
+      });
+    } finally {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      if (prevCacheDir === undefined) delete process.env.BOTCORD_RUNTIME_CATALOG_CACHE_DIR;
+      else process.env.BOTCORD_RUNTIME_CATALOG_CACHE_DIR = prevCacheDir;
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("parses Kimi models from config.toml", () => {
     expect(
       parseKimiConfigModels(

--- a/packages/daemon/src/runtime-models.ts
+++ b/packages/daemon/src/runtime-models.ts
@@ -7,7 +7,7 @@ import type { RuntimeProbeEntry } from "./adapters/runtimes.js";
 
 const MODEL_LIST_TIMEOUT_MS = 5000;
 const MODEL_LIST_MAX_BUFFER = 16 * 1024 * 1024;
-const RUNTIME_CATALOG_CACHE_VERSION = 1;
+const RUNTIME_CATALOG_CACHE_VERSION = 2;
 const RUNTIME_CATALOG_CACHE_FRESH_MS = 10 * 60 * 1000;
 const DEFAULT_RUNTIME_CATALOG_CACHE_DIR = path.join(
   homedir(),
@@ -136,7 +136,7 @@ function runtimeCatalogStrategy(entry: RuntimeProbeEntry): RuntimeCatalogStrateg
         discoverFresh: () => discoverDeepseekCatalog(entry.result.path),
         fallback: () => ({
           models: DEEPSEEK_FALLBACK_MODELS.slice(),
-          parameters: discoverDeepseekParameters(),
+          parameters: discoverDeepseekParameters(entry.result.path),
         }),
       };
     case "kimi-cli":
@@ -433,7 +433,7 @@ function discoverCodexParameters(rawCatalog: string | null): RuntimeParameterPro
 function discoverDeepseekCatalog(command: string | undefined): RuntimeModelDiscovery {
   return {
     models: discoverDeepseekModels(command),
-    parameters: discoverDeepseekParameters(),
+    parameters: discoverDeepseekParameters(command),
   };
 }
 
@@ -457,8 +457,9 @@ export function parseDeepseekModelList(raw: string): RuntimeModelProbe[] | undef
   return out.length ? out : undefined;
 }
 
-function discoverDeepseekParameters(): RuntimeParameterProbe[] {
+function discoverDeepseekParameters(command?: string): RuntimeParameterProbe[] {
   const config = readConfigScalars(path.join(homedir(), ".deepseek", "config.toml"));
+  const reasoningEffortValues = discoverDeepseekReasoningEffortValues(command);
   return [
     compactParameter({
       id: "model",
@@ -480,8 +481,9 @@ function discoverDeepseekParameters(): RuntimeParameterProbe[] {
     compactParameter({
       id: "reasoning_effort",
       displayName: "Reasoning effort",
-      type: "string",
-      flag: "reasoning_effort",
+      type: reasoningEffortValues.length > 0 ? "enum" : "string",
+      flag: "--reasoning-effort",
+      values: reasoningEffortValues.length > 0 ? reasoningEffortValues : undefined,
       defaultValue: config.reasoning_effort,
       source: config.reasoning_effort ? "config" : "cli",
     }),
@@ -502,6 +504,44 @@ function discoverDeepseekParameters(): RuntimeParameterProbe[] {
       source: config.sandbox_mode ? "config" : "cli",
     }),
   ];
+}
+
+function discoverDeepseekReasoningEffortValues(command: string | undefined): string[] {
+  const candidates = deepseekRuntimeTemplateCandidates(command);
+  const values = new Set<string>();
+  for (const candidate of candidates) {
+    try {
+      const raw = readFileSync(candidate)
+        .toString("latin1")
+        .replace(/[^\x20-\x7E]+/g, "\n");
+      const templateRe =
+        /Thinking mode \(DeepSeek V4 reasoning effort\):[\s\S]{0,256}?#\s*((?:"[^"]+"\s*(?:\|\s*)?)+)/g;
+      for (const match of raw.matchAll(templateRe)) {
+        const line = match[1] ?? "";
+        for (const valueMatch of line.matchAll(/"([^"]+)"/g)) {
+          const value = valueMatch[1]?.trim();
+          if (value && /^[A-Za-z0-9_.-]+$/.test(value)) values.add(value);
+        }
+      }
+    } catch {
+      // Try the next candidate; runtime discovery should stay best-effort.
+    }
+  }
+  return Array.from(values);
+}
+
+function deepseekRuntimeTemplateCandidates(command: string | undefined): string[] {
+  if (!command) return [];
+  const candidates = new Set<string>();
+  if (existsSync(command)) candidates.add(command);
+  const dir = path.dirname(command);
+  for (const candidate of [
+    path.join(dir, "deepseek-tui"),
+    path.join(dir, "downloads", "deepseek-tui"),
+  ]) {
+    if (existsSync(candidate)) candidates.add(candidate);
+  }
+  return Array.from(candidates);
 }
 
 function discoverKimiCatalog(): RuntimeModelDiscovery {


### PR DESCRIPTION
## Summary
- detect DeepSeek reasoning effort options from the installed runtime template instead of hardcoding them in BotCord
- report DeepSeek reasoning effort as an enum only when values are actually discovered
- bump the runtime catalog cache version so stale string-shaped DeepSeek parameter snapshots are ignored

## Verification
- cd packages/daemon && npm test -- runtime-models.test.ts
- cd packages/protocol-core && npm run build
- cd packages/daemon && npm run build

## Risk / rollout
- DeepSeek installs that do not expose the template continue to fall back to the previous free-text input behavior.