### PR TITLE
fix: improve stream block tool details

### DIFF
--- a/frontend/src/components/dashboard/StreamBlocksView.test.ts
+++ b/frontend/src/components/dashboard/StreamBlocksView.test.ts
@@ -92,6 +92,42 @@ describe("StreamBlocksView", () => {
     expect(html).toContain("botcord-daemon status");
   });
 
+  it("prefers wrapped DeepSeek raw tool input over generic payload details", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(StreamBlocksView, {
+        defaultExpanded: true,
+        blocks: [{
+          trace_id: "tr_2b",
+          seq: 1,
+          created_at: "2026-05-25T00:00:00.000Z",
+          block: {
+            kind: "tool_call",
+            payload: { details: "exec_shell" },
+            raw: {
+              event: "item.started",
+              payload: {
+                seq: 922,
+                event: "item.started",
+                payload: {
+                  item: {
+                    id: "item_exec",
+                    kind: "tool_call",
+                    status: "in_progress",
+                    summary: "exec_shell started",
+                    detail: "{\"cmd\":\"botcord-daemon status\"}",
+                  },
+                },
+              },
+            },
+          },
+        }],
+      }),
+    );
+
+    expect(html).toContain("exec_shell");
+    expect(html).toContain("botcord-daemon status");
+  });
+
   it("falls back to raw tool output when normalized result is empty", () => {
     const html = renderToStaticMarkup(
       React.createElement(StreamBlocksView, {
@@ -121,5 +157,38 @@ describe("StreamBlocksView", () => {
 
     expect(html).toContain("exec_shell");
     expect(html).toContain("daemon: pid 49616");
+  });
+
+  it("hides system stream blocks", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(StreamBlocksView, {
+        defaultExpanded: true,
+        blocks: [
+          {
+            trace_id: "tr_4",
+            seq: 1,
+            created_at: "2026-05-25T00:00:00.000Z",
+            block: {
+              kind: "system",
+              payload: { details: "{\"event\":\"turn.started\"}" },
+              raw: { event: "turn.started" },
+            },
+          },
+          {
+            trace_id: "tr_4",
+            seq: 2,
+            created_at: "2026-05-25T00:00:01.000Z",
+            block: {
+              kind: "tool_call",
+              payload: { name: "exec_shell", params: { cmd: "pwd" } },
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(html).not.toContain("turn.started");
+    expect(html).toContain("exec_shell");
+    expect(html).toContain("pwd");
   });
 });

--- a/frontend/src/components/dashboard/StreamBlocksView.tsx
+++ b/frontend/src/components/dashboard/StreamBlocksView.tsx
@@ -269,26 +269,45 @@ function extractToolCall(raw: any): { name: string; params?: unknown; id?: strin
 function extractDeepseekToolCall(raw: any): { name: string; params?: unknown; id?: string } | null {
   const payload = raw?.payload;
   if (!payload || typeof payload !== "object") return null;
+  const innerPayload = unwrapDeepseekPayload(raw);
+  const event = stringField(raw, "event") ?? stringField(payload, "event");
 
-  if (raw?.event === "tool.started") {
-    const tool = payload.tool && typeof payload.tool === "object" ? payload.tool : undefined;
+  if (event === "tool.started") {
+    const tool = innerPayload?.tool && typeof innerPayload.tool === "object" ? innerPayload.tool : undefined;
     return {
-      name: stringField(payload, "name") ?? stringField(tool, "name") ?? "tool",
-      params: parseMaybeJson(payload.input ?? payload.arguments ?? payload.params ?? tool?.input ?? tool?.rawInput),
-      id: stringField(payload, "id") ?? stringField(tool, "id"),
+      name: stringField(innerPayload, "name") ?? stringField(tool, "name") ?? "tool",
+      params: parseMaybeJson(
+        innerPayload?.input ??
+          innerPayload?.arguments ??
+          innerPayload?.params ??
+          tool?.input ??
+          tool?.rawInput ??
+          tool?.arguments ??
+          tool?.params,
+      ),
+      id: stringField(innerPayload, "id") ?? stringField(tool, "id"),
     };
   }
 
-  if (raw?.event === "item.started" || payload.event === "item.started") {
-    const inner =
-      raw?.event === "item.started"
-        ? payload
-        : payload.payload && typeof payload.payload === "object"
-          ? payload.payload
-          : {};
+  if (event === "item.started") {
+    const inner = innerPayload ?? {};
     const item = inner.item && typeof inner.item === "object" ? inner.item : undefined;
     const tool = inner.tool && typeof inner.tool === "object" ? inner.tool : item?.tool;
-    const itemParams = parseMaybeJson(item?.input ?? item?.arguments ?? item?.detail);
+    const metadata = item?.metadata && typeof item.metadata === "object" ? item.metadata : undefined;
+    const metadataCommand =
+      metadata && (metadata.command ?? metadata.cmd)
+        ? { [metadata.command ? "command" : "cmd"]: metadata.command ?? metadata.cmd }
+        : undefined;
+    const itemParams = parseMaybeJson(
+      item?.input ??
+        item?.arguments ??
+        item?.params ??
+        metadata?.input ??
+        metadata?.arguments ??
+        metadata?.params ??
+        metadataCommand ??
+        item?.detail,
+    );
     return {
       name:
         stringField(tool, "name") ??
@@ -301,11 +320,23 @@ function extractDeepseekToolCall(raw: any): { name: string; params?: unknown; id
         tool?.input ??
           tool?.rawInput ??
           tool?.arguments ??
+          tool?.params ??
           inner.input ??
+          inner.arguments ??
+          inner.params ??
           item?.input ??
-          item?.arguments,
+          item?.arguments ??
+          item?.params ??
+          metadata?.input ??
+          metadata?.arguments ??
+          metadata?.params ??
+          metadataCommand,
       ) ?? itemParams ?? tool ?? item,
-      id: stringField(tool, "id") ?? stringField(inner, "id") ?? stringField(item, "id"),
+      id:
+        stringField(tool, "id") ??
+        stringField(inner, "id") ??
+        stringField(item, "id") ??
+        stringField(payload, "item_id"),
     };
   }
 
@@ -356,28 +387,26 @@ function extractToolResult(raw: any): { name?: string; result: string; id?: stri
 function extractDeepseekToolResult(raw: any): { name?: string; result: string; id?: string } | null {
   const payload = raw?.payload;
   if (!payload || typeof payload !== "object") return null;
+  const innerPayload = unwrapDeepseekPayload(raw);
+  const event = stringField(raw, "event") ?? stringField(payload, "event");
 
-  if (raw?.event === "tool.completed") {
-    const result = payload.output ?? payload.result ?? payload.content ?? payload.error ?? payload;
+  if (event === "tool.completed") {
+    const result =
+      innerPayload?.output ??
+      innerPayload?.result ??
+      innerPayload?.content ??
+      innerPayload?.error ??
+      innerPayload ??
+      payload;
     return {
-      name: stringField(payload, "name"),
+      name: stringField(innerPayload, "name"),
       result: stringifyDetails(result),
-      id: stringField(payload, "id"),
+      id: stringField(innerPayload, "id"),
     };
   }
 
-  if (
-    raw?.event === "item.completed" ||
-    raw?.event === "item.failed" ||
-    payload.event === "item.completed" ||
-    payload.event === "item.failed"
-  ) {
-    const inner =
-      raw?.event === "item.completed" || raw?.event === "item.failed"
-        ? payload
-        : payload.payload && typeof payload.payload === "object"
-          ? payload.payload
-          : {};
+  if (event === "item.completed" || event === "item.failed") {
+    const inner = innerPayload ?? {};
     const item = inner.item && typeof inner.item === "object" ? inner.item : undefined;
     const result =
       item?.output ??
@@ -398,11 +427,33 @@ function extractDeepseekToolResult(raw: any): { name?: string; result: string; i
         stringField(inner, "name") ??
         stringField(item, "type"),
       result: stringifyDetails(result),
-      id: stringField(item, "id") ?? stringField(inner, "id"),
+      id: stringField(item, "id") ?? stringField(inner, "id") ?? stringField(payload, "item_id"),
     };
   }
 
   return null;
+}
+
+function unwrapDeepseekPayload(raw: any): any {
+  const payload = raw?.payload;
+  if (!payload || typeof payload !== "object") return undefined;
+  const nested = payload.payload;
+  if (nested && typeof nested === "object") {
+    const outerEvent = stringField(payload, "event");
+    if (
+      outerEvent ||
+      nested.item ||
+      nested.tool ||
+      nested.turn ||
+      nested.kind ||
+      nested.output ||
+      nested.result ||
+      nested.error
+    ) {
+      return nested;
+    }
+  }
+  return payload;
 }
 
 function normalizeBlock(
@@ -419,8 +470,8 @@ function normalizeBlock(
       payload?.params ??
       payload?.input ??
       payload?.arguments ??
-      payload?.details ??
-      rawCall?.params;
+      rawCall?.params ??
+      payload?.details;
     return {
       kind: "tool_call",
       toolName: (payload?.name as string) || rawCall?.name || "tool",
@@ -800,8 +851,11 @@ export default function StreamBlocksView({
 
   // Build tool_use_id → name map so tool_result rows can show the real tool name.
   const toolNameById = buildToolNameById(blocks);
+  const displayBlocks = executionBlocks.filter(
+    (b) => normalizeBlock(b.block, { toolNameById }).kind !== "system",
+  );
 
-  const normalized = executionBlocks.map((b) => normalizeBlock(b.block, { toolNameById }).kind);
+  const normalized = displayBlocks.map((b) => normalizeBlock(b.block, { toolNameById }).kind);
   const toolCallCount = normalized.filter((k) => k === "tool_call").length;
   const reasoningCount = normalized.filter((k) => k === "reasoning").length;
 
@@ -859,17 +913,17 @@ export default function StreamBlocksView({
     }
   }, [composingText]);
 
-  if (blocks.length === 0) return null;
+  if (blocks.length === 0 || displayBlocks.length === 0) return null;
 
   const summaryParts: string[] = [];
   if (toolCallCount > 0) summaryParts.push(`${toolCallCount} tool call${toolCallCount !== 1 ? "s" : ""}`);
   if (reasoningCount > 0) summaryParts.push(`${reasoningCount} reasoning`);
-  if (summaryParts.length === 0) summaryParts.push(`${executionBlocks.length} step${executionBlocks.length !== 1 ? "s" : ""}`);
+  if (summaryParts.length === 0) summaryParts.push(`${displayBlocks.length} step${displayBlocks.length !== 1 ? "s" : ""}`);
 
   return (
     <div className="flex justify-start">
       <div className="max-w-[85%] space-y-2">
-        {executionBlocks.length > 0 && (
+        {displayBlocks.length > 0 && (
           <div className="rounded-lg border border-zinc-700/40 bg-zinc-900/40 overflow-hidden">
             <button
               onClick={() => setExpanded(!expanded)}
@@ -885,7 +939,7 @@ export default function StreamBlocksView({
             </button>
             {expanded && (
               <div className="border-t border-zinc-800/60 px-3 py-1 divide-y divide-zinc-800/40">
-                {executionBlocks.map((block) => (
+                {displayBlocks.map((block) => (
                   <StreamBlockItem
                     key={`${block.trace_id}-${block.seq}`}
                     block={block}

--- a/frontend/src/store/useOwnerChatStore.test.ts
+++ b/frontend/src/store/useOwnerChatStore.test.ts
@@ -185,6 +185,24 @@ describe("useOwnerChatStore empty message handling", () => {
 
     expect(useOwnerChatStore.getState().messages).toHaveLength(1);
   });
+
+  it("drops delivered messages that only have hidden system stream blocks", () => {
+    useOwnerChatStore.getState().upsertMessage(makeOwnerChatMessage({
+      hubMsgId: "msg_1",
+      sender: "agent",
+      text: "",
+      status: "delivered",
+      senderName: "Owned bot",
+      streamBlocks: [{
+        trace_id: "tr_1",
+        seq: 1,
+        created_at: "2026-05-19T03:00:00.000Z",
+        block: { kind: "system", payload: { details: "{\"event\":\"turn.started\"}" } },
+      }],
+    }));
+
+    expect(useOwnerChatStore.getState().messages).toHaveLength(0);
+  });
 });
 
 describe("useOwnerChatStore stream terminal handling", () => {

--- a/frontend/src/store/useOwnerChatStore.ts
+++ b/frontend/src/store/useOwnerChatStore.ts
@@ -103,7 +103,7 @@ function hasVisibleOwnerChatContent(msg: OwnerChatMessage): boolean {
   if (msg.status === "streaming" || msg.status === "optimistic" || msg.status === "failed") return true;
   if (msg.text.trim()) return true;
   if ((msg.attachments?.length ?? 0) > 0) return true;
-  return msg.streamBlocks.length > 0;
+  return visibleExecutionBlocks(msg.streamBlocks).length > 0;
 }
 
 function isTerminalStreamBlock(entry: StreamBlockEntry): boolean {
@@ -112,7 +112,12 @@ function isTerminalStreamBlock(entry: StreamBlockEntry): boolean {
 }
 
 function visibleExecutionBlocks(blocks: StreamBlockEntry[]): StreamBlockEntry[] {
-  return blocks.filter((b) => b.block.kind !== "assistant" && b.block.kind !== "assistant_text");
+  return blocks.filter(
+    (b) =>
+      b.block.kind !== "assistant" &&
+      b.block.kind !== "assistant_text" &&
+      b.block.kind !== "system",
+  );
 }
 
 /** In-flight guard + request token to prevent stale loadInitial responses. */

--- a/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
+++ b/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
@@ -793,6 +793,85 @@ describe("createBotCordChannel — streamBlock()", () => {
     });
   });
 
+  it("normalizes wrapped DeepSeek item.started tool input from the runtime event stream", () => {
+    expect(
+      __normalizeBlockForHubForTests(
+        {
+          kind: "tool_use",
+          seq: 5,
+          raw: {
+            event: "item.started",
+            payload: {
+              seq: 922,
+              thread_id: "thr_test",
+              turn_id: "turn_test",
+              item_id: "item_exec",
+              event: "item.started",
+              payload: {
+                item: {
+                  id: "item_exec",
+                  kind: "tool_call",
+                  status: "in_progress",
+                  summary: "exec_shell started",
+                  detail: "{\"cmd\":\"botcord-daemon status\"}",
+                },
+              },
+            },
+          },
+        },
+        5,
+      ),
+    ).toMatchObject({
+      kind: "tool_call",
+      seq: 5,
+      payload: {
+        id: "item_exec",
+        name: "exec_shell",
+        params: { cmd: "botcord-daemon status" },
+        status: "in_progress",
+      },
+    });
+  });
+
+  it("normalizes wrapped DeepSeek item.completed output without showing the event envelope", () => {
+    expect(
+      __normalizeBlockForHubForTests(
+        {
+          kind: "tool_result",
+          seq: 6,
+          raw: {
+            event: "item.completed",
+            payload: {
+              seq: 955,
+              thread_id: "thr_test",
+              turn_id: "turn_test",
+              item_id: "item_exec",
+              event: "item.completed",
+              payload: {
+                item: {
+                  id: "item_exec",
+                  kind: "command_execution",
+                  status: "completed",
+                  summary: "exec_shell: daemon: pid 49616",
+                  detail: "daemon: pid 49616 (alive)",
+                },
+              },
+            },
+          },
+        },
+        6,
+      ),
+    ).toMatchObject({
+      kind: "tool_result",
+      seq: 6,
+      payload: {
+        name: "exec_shell",
+        result: "daemon: pid 49616 (alive)",
+        tool_use_id: "item_exec",
+      },
+    });
+  });
+
   it("POSTs to /hub/stream-block with the right trace_id + block", async () => {
     const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
     const realFetch = globalThis.fetch;

--- a/packages/daemon/src/gateway/__tests__/deepseek-tui-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/deepseek-tui-adapter.test.ts
@@ -353,6 +353,55 @@ describe("DeepseekTuiAdapter", () => {
     }
   });
 
+  it("treats DeepSeek command_execution item.started events as tool blocks", async () => {
+    const server = await startMockDeepseekServer({
+      events: [
+        {
+          event: "turn.started",
+          data: { thread_id: "thr_test", turn_id: "turn_test", event: "turn.started" },
+        },
+        {
+          event: "item.started",
+          data: {
+            thread_id: "thr_test",
+            turn_id: "turn_test",
+            event: "item.started",
+            payload: {
+              item: {
+                id: "item_exec",
+                kind: "command_execution",
+                status: "in_progress",
+                summary: "exec_shell started",
+                detail: "{\"cmd\":\"date\"}",
+              },
+            },
+          },
+        },
+        {
+          event: "item.delta",
+          data: {
+            thread_id: "thr_test",
+            turn_id: "turn_test",
+            event: "item.delta",
+            payload: { kind: "agent_message", delta: "done" },
+          },
+        },
+        {
+          event: "turn.completed",
+          data: { thread_id: "thr_test", turn_id: "turn_test", event: "turn.completed" },
+        },
+      ],
+    });
+    try {
+      const { result, blocks, status } = runAdapter(server.baseUrl, server.token);
+      await expect(result).resolves.toMatchObject({ text: "done" });
+      expect(blocks).toEqual(expect.arrayContaining(["tool_use", "assistant_text"]));
+      expect(status).toContainEqual({ phase: "updated", label: "exec_shell" });
+    } finally {
+      await server.close();
+    }
+  });
+
   it("emits current DeepSeek agent_reasoning completions as thinking blocks", async () => {
     const server = await startMockDeepseekServer({
       events: [

--- a/packages/daemon/src/gateway/channels/botcord.ts
+++ b/packages/daemon/src/gateway/channels/botcord.ts
@@ -1196,27 +1196,46 @@ function extractToolResult(raw: any): { name?: string; result: string; id?: stri
 function extractDeepseekToolCall(raw: any): { name: string; params?: unknown; id?: string; status?: string } | null {
   const payload = raw?.payload;
   if (!payload || typeof payload !== "object") return null;
+  const innerPayload = unwrapDeepseekPayload(raw);
+  const event = stringField(raw, "event") ?? stringField(payload, "event");
 
-  if (raw?.event === "tool.started") {
-    const tool = payload.tool && typeof payload.tool === "object" ? payload.tool : undefined;
+  if (event === "tool.started") {
+    const tool = innerPayload?.tool && typeof innerPayload.tool === "object" ? innerPayload.tool : undefined;
     return {
-      name: stringField(payload, "name") ?? stringField(tool, "name") ?? "tool",
-      params: parseMaybeJson(payload.input ?? payload.arguments ?? payload.params ?? tool?.input ?? tool?.rawInput),
-      id: stringField(payload, "id") ?? stringField(tool, "id"),
-      status: stringField(payload, "status") ?? stringField(tool, "status"),
+      name: stringField(innerPayload, "name") ?? stringField(tool, "name") ?? "tool",
+      params: parseMaybeJson(
+        innerPayload?.input ??
+          innerPayload?.arguments ??
+          innerPayload?.params ??
+          tool?.input ??
+          tool?.rawInput ??
+          tool?.arguments ??
+          tool?.params,
+      ),
+      id: stringField(innerPayload, "id") ?? stringField(tool, "id"),
+      status: stringField(innerPayload, "status") ?? stringField(tool, "status"),
     };
   }
 
-  if (raw?.event === "item.started" || payload.event === "item.started") {
-    const inner =
-      raw?.event === "item.started"
-        ? payload
-        : payload.payload && typeof payload.payload === "object"
-          ? payload.payload
-          : {};
+  if (event === "item.started") {
+    const inner = innerPayload ?? {};
     const item = inner.item && typeof inner.item === "object" ? inner.item : undefined;
     const tool = inner.tool && typeof inner.tool === "object" ? inner.tool : item?.tool;
-    const itemParams = parseMaybeJson(item?.input ?? item?.arguments ?? item?.detail);
+    const metadata = item?.metadata && typeof item.metadata === "object" ? item.metadata : undefined;
+    const metadataCommand =
+      metadata && (metadata.command ?? metadata.cmd)
+        ? { [metadata.command ? "command" : "cmd"]: metadata.command ?? metadata.cmd }
+        : undefined;
+    const itemParams = parseMaybeJson(
+      item?.input ??
+        item?.arguments ??
+        item?.params ??
+        metadata?.input ??
+        metadata?.arguments ??
+        metadata?.params ??
+        metadataCommand ??
+        item?.detail,
+    );
     const detailParams =
       itemParams !== undefined
         ? itemParams
@@ -1240,9 +1259,18 @@ function extractDeepseekToolCall(raw: any): { name: string; params?: unknown; id
           inner.arguments ??
           inner.params ??
           item?.input ??
-          item?.arguments,
+          item?.arguments ??
+          item?.params ??
+          metadata?.input ??
+          metadata?.arguments ??
+          metadata?.params ??
+          metadataCommand,
       ) ?? detailParams ?? tool ?? item,
-      id: stringField(tool, "id") ?? stringField(inner, "id") ?? stringField(item, "id"),
+      id:
+        stringField(tool, "id") ??
+        stringField(inner, "id") ??
+        stringField(item, "id") ??
+        stringField(payload, "item_id"),
       status: stringField(tool, "status") ?? stringField(inner, "status") ?? stringField(item, "status"),
     };
   }
@@ -1253,28 +1281,26 @@ function extractDeepseekToolCall(raw: any): { name: string; params?: unknown; id
 function extractDeepseekToolResult(raw: any): { name?: string; result: string; id?: string } | null {
   const payload = raw?.payload;
   if (!payload || typeof payload !== "object") return null;
+  const innerPayload = unwrapDeepseekPayload(raw);
+  const event = stringField(raw, "event") ?? stringField(payload, "event");
 
-  if (raw?.event === "tool.completed") {
-    const result = payload.output ?? payload.result ?? payload.content ?? payload.error ?? payload;
+  if (event === "tool.completed") {
+    const result =
+      innerPayload?.output ??
+      innerPayload?.result ??
+      innerPayload?.content ??
+      innerPayload?.error ??
+      innerPayload ??
+      payload;
     return {
-      name: stringField(payload, "name"),
+      name: stringField(innerPayload, "name"),
       result: stringifyToolResult(result),
-      id: stringField(payload, "id"),
+      id: stringField(innerPayload, "id"),
     };
   }
 
-  if (
-    raw?.event === "item.completed" ||
-    raw?.event === "item.failed" ||
-    payload.event === "item.completed" ||
-    payload.event === "item.failed"
-  ) {
-    const inner =
-      raw?.event === "item.completed" || raw?.event === "item.failed"
-        ? payload
-        : payload.payload && typeof payload.payload === "object"
-          ? payload.payload
-          : {};
+  if (event === "item.completed" || event === "item.failed") {
+    const inner = innerPayload ?? {};
     const item = inner.item && typeof inner.item === "object" ? inner.item : undefined;
     const result =
       item?.output ??
@@ -1295,11 +1321,33 @@ function extractDeepseekToolResult(raw: any): { name?: string; result: string; i
         stringField(inner, "name") ??
         stringField(item, "type"),
       result: stringifyToolResult(result),
-      id: stringField(item, "id") ?? stringField(inner, "id"),
+      id: stringField(item, "id") ?? stringField(inner, "id") ?? stringField(payload, "item_id"),
     };
   }
 
   return null;
+}
+
+function unwrapDeepseekPayload(raw: any): any {
+  const payload = raw?.payload;
+  if (!payload || typeof payload !== "object") return undefined;
+  const nested = payload.payload;
+  if (nested && typeof nested === "object") {
+    const outerEvent = stringField(payload, "event");
+    if (
+      outerEvent ||
+      nested.item ||
+      nested.tool ||
+      nested.turn ||
+      nested.kind ||
+      nested.output ||
+      nested.result ||
+      nested.error
+    ) {
+      return nested;
+    }
+  }
+  return payload;
 }
 
 function formatBlockDetails(raw: unknown): string {

--- a/packages/daemon/src/gateway/runtimes/deepseek-tui.ts
+++ b/packages/daemon/src/gateway/runtimes/deepseek-tui.ts
@@ -497,9 +497,15 @@ function isDeepseekTerminalEvent(eventName: string, payload: any): boolean {
 }
 
 function isToolStarted(eventName: string, payload: any): boolean {
+  const itemKind = payload?.payload?.item?.kind ?? payload?.item?.kind;
   return (
     (eventName === "item.started" &&
-      (!!payload?.tool || payload?.item?.kind === "tool_call" || payload?.payload?.item?.kind === "tool_call")) ||
+      (
+        !!payload?.tool ||
+        itemKind === "tool_call" ||
+        itemKind === "command_execution" ||
+        itemKind === "file_change"
+      )) ||
     (payload?.event === "item.started" && !!payload?.payload?.tool)
   );
 }


### PR DESCRIPTION
## Summary
- Hide system stream blocks from the owner-chat execution timeline and finalized stream history.
- Preserve DeepSeek wrapped tool call input/output so tool rows show names and expandable parameters instead of only labels or raw event envelopes.
- Treat DeepSeek command_execution/file_change item starts as tool-use progress.

## Verification
- git diff --check
- cd packages/daemon && npm test -- src/gateway/__tests__/botcord-channel.test.ts src/gateway/__tests__/deepseek-tui-adapter.test.ts
- cd packages/daemon && npm run build
- cd frontend && pnpm test -- src/components/dashboard/StreamBlocksView.test.ts src/store/useOwnerChatStore.test.ts
- cd frontend && NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key pnpm build

## Risk / rollout
- Low-risk display/normalization change. Existing reasoning and raw result display behavior remains intact; system blocks are filtered from the default UI.