### PR TITLE
Add agent skills drawer

### DIFF
--- a/backend/app/routers/runtime_skills.py
+++ b/backend/app/routers/runtime_skills.py
@@ -1,0 +1,262 @@
+"""
+[INPUT]: Authenticated user + owned daemon-hosted agent id
+[OUTPUT]: GET/POST /api/agents/{agent_id}/runtime-skills — read stored skill
+          snapshot or ask daemon to re-scan runtime/workspace skills.
+[POS]: BFF surface for the dashboard agent settings Skills tab.
+[PROTOCOL]: Hub authorizes ownership; daemon resolves agent-local skill dirs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import logging
+import time
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import RequestContext, require_user
+from hub.database import get_db
+from hub.models import Agent, CloudAgentInstance
+from hub.routers.cloud_daemon_control import (
+    CloudDaemonDispatchError,
+    is_cloud_daemon_online,
+    send_cloud_control_frame,
+)
+from hub.routers.daemon_control import (
+    _persist_agent_skill_snapshot,
+    is_daemon_online,
+    send_control_frame,
+)
+from hub.services.cloud_agent import CloudAgentError, CloudAgentService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/agents", tags=["app-runtime-skills"])
+
+_CLOUD_SKILLS_RESUME_WAIT_SECONDS = 20.0
+_CLOUD_SKILLS_RESUME_POLL_SECONDS = 0.5
+_REFRESH_SKILLS_TIMEOUT_MS = 5000
+
+
+class AgentRuntimeSkillOut(BaseModel):
+    name: str
+    source: str
+    description: str | None = None
+    mtimeMs: float
+    mtimeAt: str | None = None
+
+
+class AgentRuntimeSkillsOut(BaseModel):
+    agent_id: str
+    agentId: str
+    daemon_instance_id: str | None = None
+    skills: list[AgentRuntimeSkillOut] | None = None
+    runtime: str | None = None
+    sniffed_at: datetime.datetime | None = None
+    skills_probed_at: datetime.datetime | None = None
+
+
+class _RuntimeSkillsHost(BaseModel):
+    daemon_instance_id: str
+    cloud_daemon_instance_id: str | None = None
+
+
+async def _load_owned_agent(db: AsyncSession, ctx: RequestContext, agent_id: str) -> Agent:
+    result = await db.execute(
+        select(Agent).where(
+            Agent.agent_id == agent_id,
+            Agent.user_id == ctx.user_id,
+            Agent.status == "active",
+        )
+    )
+    agent = result.scalar_one_or_none()
+    if agent is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    return agent
+
+
+async def _load_runtime_skills_host(
+    db: AsyncSession,
+    ctx: RequestContext,
+    agent: Agent,
+) -> _RuntimeSkillsHost:
+    if agent.hosting_kind == "cloud":
+        if not agent.daemon_instance_id:
+            raise HTTPException(status_code=409, detail="agent_not_daemon_hosted")
+        binding = await db.scalar(
+            select(CloudAgentInstance).where(
+                CloudAgentInstance.agent_id == agent.agent_id,
+                CloudAgentInstance.user_id == ctx.user_id,
+                CloudAgentInstance.status.notin_(("deleting", "deleted")),
+            )
+        )
+        if binding is None:
+            raise HTTPException(status_code=409, detail="agent_not_daemon_hosted")
+        return _RuntimeSkillsHost(
+            daemon_instance_id=binding.daemon_instance_id,
+            cloud_daemon_instance_id=binding.cloud_daemon_instance_id,
+        )
+
+    if not agent.daemon_instance_id:
+        raise HTTPException(status_code=409, detail="agent_not_daemon_hosted")
+    return _RuntimeSkillsHost(daemon_instance_id=agent.daemon_instance_id)
+
+
+async def _ensure_cloud_runtime_skills_host_online(
+    db: AsyncSession,
+    ctx: RequestContext,
+    agent: Agent,
+    host: _RuntimeSkillsHost,
+) -> None:
+    cloud_daemon_instance_id = host.cloud_daemon_instance_id
+    if not cloud_daemon_instance_id:
+        return
+    if is_cloud_daemon_online(cloud_daemon_instance_id):
+        return
+
+    try:
+        await CloudAgentService().resume_cloud_agent(
+            db,
+            user_id=ctx.user_id,
+            agent_id=agent.agent_id,
+        )
+    except CloudAgentError as exc:
+        logger.warning(
+            "cloud runtime skills resume failed: agent=%s cloud=%s code=%s err=%s",
+            agent.agent_id,
+            cloud_daemon_instance_id,
+            exc.code,
+            exc.message,
+        )
+        raise HTTPException(
+            status_code=409 if exc.http_status == 409 else exc.http_status,
+            detail="daemon_offline" if exc.http_status == 409 else exc.code,
+        ) from exc
+
+    deadline = time.monotonic() + _CLOUD_SKILLS_RESUME_WAIT_SECONDS
+    while time.monotonic() < deadline:
+        if is_cloud_daemon_online(cloud_daemon_instance_id):
+            return
+        await asyncio.sleep(_CLOUD_SKILLS_RESUME_POLL_SECONDS)
+
+    raise HTTPException(status_code=409, detail="daemon_offline")
+
+
+async def _send_runtime_skills_control_frame(
+    host: _RuntimeSkillsHost,
+    params: dict[str, Any],
+    *,
+    db: AsyncSession,
+    ctx: RequestContext,
+    agent: Agent,
+) -> dict[str, Any]:
+    if host.cloud_daemon_instance_id:
+        await _ensure_cloud_runtime_skills_host_online(db, ctx, agent, host)
+        try:
+            return await send_cloud_control_frame(
+                host.cloud_daemon_instance_id,
+                "list_agent_skills",
+                params,
+                timeout_ms=_REFRESH_SKILLS_TIMEOUT_MS,
+            )
+        except CloudDaemonDispatchError as exc:
+            if exc.code in {
+                "cloud_daemon_offline",
+                "cloud_daemon_disconnected",
+                "cloud_daemon_send_failed",
+            }:
+                raise HTTPException(status_code=409, detail="daemon_offline") from exc
+            if exc.code == "cloud_daemon_ack_timeout":
+                raise HTTPException(status_code=504, detail="daemon_ack_timeout") from exc
+            raise HTTPException(
+                status_code=502,
+                detail={"code": exc.code, "daemon_message": exc.message},
+            ) from exc
+
+    if not is_daemon_online(host.daemon_instance_id):
+        raise HTTPException(status_code=409, detail="daemon_offline")
+    return await send_control_frame(
+        host.daemon_instance_id,
+        "list_agent_skills",
+        params,
+        timeout_ms=_REFRESH_SKILLS_TIMEOUT_MS,
+    )
+
+
+def _stored_response(agent: Agent) -> AgentRuntimeSkillsOut:
+    return AgentRuntimeSkillsOut(
+        agent_id=agent.agent_id,
+        agentId=agent.agent_id,
+        daemon_instance_id=agent.daemon_instance_id,
+        skills=agent.skills_json if agent.skills_json else None,
+        runtime=agent.runtime,
+        sniffed_at=agent.skills_probed_at,
+        skills_probed_at=agent.skills_probed_at,
+    )
+
+
+@router.get("/{agent_id}/skills", response_model=AgentRuntimeSkillsOut)
+@router.get("/{agent_id}/runtime-skills", response_model=AgentRuntimeSkillsOut)
+async def get_agent_runtime_skills(
+    agent_id: str,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+) -> AgentRuntimeSkillsOut:
+    agent = await _load_owned_agent(db, ctx, agent_id)
+    return _stored_response(agent)
+
+
+@router.post("/{agent_id}/skills/refresh", response_model=AgentRuntimeSkillsOut)
+@router.post("/{agent_id}/runtime-skills/refresh", response_model=AgentRuntimeSkillsOut)
+async def refresh_agent_runtime_skills(
+    agent_id: str,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+) -> AgentRuntimeSkillsOut:
+    agent = await _load_owned_agent(db, ctx, agent_id)
+    host = await _load_runtime_skills_host(db, ctx, agent)
+
+    ack = await _send_runtime_skills_control_frame(
+        host,
+        {"agentId": agent.agent_id},
+        db=db,
+        ctx=ctx,
+        agent=agent,
+    )
+    if not isinstance(ack, dict) or not ack.get("ok"):
+        err = ack.get("error") if isinstance(ack, dict) else None
+        code = (err or {}).get("code") if isinstance(err, dict) else None
+        message = (err or {}).get("message") if isinstance(err, dict) else None
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "code": "daemon_runtime_skills_failed",
+                "daemon_code": code,
+                "daemon_message": message,
+            },
+        )
+
+    result = ack.get("result") if isinstance(ack.get("result"), dict) else None
+    persisted = None
+    if result is not None:
+        persisted = await _persist_agent_skill_snapshot(
+            db,
+            daemon_instance_id=host.daemon_instance_id,
+            params=result,
+        )
+    if persisted is None:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "code": "daemon_runtime_skills_malformed",
+                "daemon_message": "list_agent_skills returned malformed result",
+            },
+        )
+    await db.commit()
+    await db.refresh(agent)
+    return _stored_response(agent)

--- a/backend/hub/main.py
+++ b/backend/hub/main.py
@@ -74,6 +74,7 @@ from app.routers.policy import router as app_policy_router
 from app.routers.gateways import router as app_gateways_router
 from app.routers.prompts import router as app_prompts_router
 from app.routers.runtime_files import router as app_runtime_files_router
+from app.routers.runtime_skills import router as app_runtime_skills_router
 from app.routers.schedules import router as app_schedules_router
 from app.routers.auth import router as app_auth_router
 from app.routers.telegram import router as app_telegram_router
@@ -311,6 +312,7 @@ app.include_router(app_cloud_agents_router, dependencies=_beta_gate)
 app.include_router(app_gateways_router, dependencies=_beta_gate)
 app.include_router(app_telegram_router, dependencies=_beta_gate)
 app.include_router(app_runtime_files_router, dependencies=_beta_gate)
+app.include_router(app_runtime_skills_router, dependencies=_beta_gate)
 app.include_router(app_schedules_router, dependencies=_beta_gate)
 app.include_router(app_prompts_router)
 app.include_router(app_presence_router, dependencies=_beta_gate)

--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -141,6 +141,13 @@ class Agent(Base):
     runtime_model: Mapped[str | None] = mapped_column(String(128), nullable=True)
     reasoning_effort: Mapped[str | None] = mapped_column(String(64), nullable=True)
     thinking: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    # Latest per-agent runtime/workspace soft-skill snapshot reported by the
+    # hosting daemon. Stored on the agent because skill sources are scoped by
+    # agent workspace/runtime home, not by device alone.
+    skills_json: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    skills_probed_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     signing_keys: Mapped[list["SigningKey"]] = relationship(back_populates="agent")
     challenges: Mapped[list["Challenge"]] = relationship(back_populates="agent")

--- a/backend/hub/routers/cloud_daemon_control.py
+++ b/backend/hub/routers/cloud_daemon_control.py
@@ -36,7 +36,9 @@ from hub.routers.daemon_control import (
     _build_signed_frame,
     _load_agent_identity_snapshot,
     _now,
+    _parse_agent_skill_snapshot_params,
     _parse_runtime_snapshot_params,
+    _persist_agent_skill_snapshot,
     _persist_runtime_snapshot,
 )
 
@@ -277,6 +279,7 @@ _DAEMON_INITIATED_TYPES = {
     # typing indicator before the final reply arrives. See
     # ``cloud_gateway_internal._INFLIGHT_RUNTIME_WS``.
     "cloud_gateway_runtime_status",
+    "agent_skill_snapshot",
 }
 
 
@@ -504,6 +507,22 @@ async def _handle_cloud_daemon_event(
             except Exception:
                 pass
             return
+    if msg_type == "agent_skill_snapshot":
+        parsed = _parse_agent_skill_snapshot_params(params)
+        if parsed is None:
+            err = {
+                "id": msg_id,
+                "ok": False,
+                "error": {
+                    "code": "bad_params",
+                    "message": "agent_skill_snapshot requires {agentId:str, skills:list, probedAt:int}",
+                },
+            }
+            try:
+                await conn.ws.send_text(json.dumps(err))
+            except Exception:
+                pass
+            return
 
     if msg_type == "cloud_gateway_runtime_status":
         # Best-effort relay to the live ingress runtime WS. Late import
@@ -541,6 +560,12 @@ async def _handle_cloud_daemon_event(
                 daemon_row.last_seen_at = now
                 if msg_type == "runtime_snapshot":
                     await _persist_runtime_snapshot(db, daemon_row, params)  # type: ignore[arg-type]
+                if msg_type == "agent_skill_snapshot":
+                    await _persist_agent_skill_snapshot(
+                        db,
+                        daemon_instance_id=conn.daemon_instance_id,
+                        params=params,  # type: ignore[arg-type]
+                    )
             if cloud_row is not None:
                 cloud_row.last_seen_at = now
             await db.commit()

--- a/backend/hub/routers/daemon_control.py
+++ b/backend/hub/routers/daemon_control.py
@@ -86,6 +86,10 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["daemon-control"])
 
+# Skill snapshots are expected to contain the daemon's full discovered list.
+# Keep only an abuse guard here; per-field truncation below controls row bloat.
+MAX_AGENT_SKILL_SNAPSHOT_ITEMS = 10_000
+
 
 # ---------------------------------------------------------------------------
 # Hub control-plane signing key (Ed25519)
@@ -889,6 +893,7 @@ _ALLOWED_DISPATCH_TYPES = {
     "reload_config",
     "list_agents",
     "list_agent_files",
+    "list_agent_skills",
     "set_route",
     "ping",
     "list_runtimes",
@@ -1613,6 +1618,7 @@ _DAEMON_INITIATED_TYPES = {
     "agent_revoked",
     "pong",
     "runtime_snapshot",
+    "agent_skill_snapshot",
 }
 
 
@@ -1704,6 +1710,88 @@ async def _persist_runtime_snapshot(
     return runtimes, probed_dt
 
 
+def _parse_agent_skill_snapshot_params(
+    params: Any,
+) -> tuple[str, list[dict[str, Any]], datetime.datetime] | None:
+    """Validate a ``agent_skill_snapshot`` / ``list_agent_skills`` payload."""
+    if not isinstance(params, dict):
+        return None
+    agent_id = params.get("agentId")
+    skills = params.get("skills")
+    probed_at = params.get("probedAt")
+    if not isinstance(agent_id, str) or not agent_id:
+        return None
+    if not isinstance(skills, list) or len(skills) > MAX_AGENT_SKILL_SNAPSHOT_ITEMS:
+        return None
+    out: list[dict[str, Any]] = []
+    for raw in skills:
+        if not isinstance(raw, dict):
+            return None
+        name = raw.get("name")
+        source = raw.get("source")
+        mtime_ms = raw.get("mtimeMs")
+        if not isinstance(name, str) or not name:
+            return None
+        if not isinstance(source, str) or not source:
+            return None
+        if not isinstance(mtime_ms, (int, float)) or isinstance(mtime_ms, bool):
+            return None
+        entry: dict[str, Any] = {
+            "name": name[:128],
+            "source": source[:64],
+            "mtimeMs": mtime_ms,
+        }
+        try:
+            entry["mtimeAt"] = datetime.datetime.fromtimestamp(
+                mtime_ms / 1000, tz=datetime.timezone.utc
+            ).isoformat()
+        except (OverflowError, OSError, ValueError):
+            pass
+        description = raw.get("description")
+        if isinstance(description, str) and description:
+            entry["description"] = description[:500]
+        out.append(entry)
+    if not isinstance(probed_at, (int, float)) or isinstance(probed_at, bool):
+        return None
+    if probed_at <= 0:
+        return None
+    try:
+        probed_dt = datetime.datetime.fromtimestamp(
+            probed_at / 1000, tz=datetime.timezone.utc
+        )
+    except (OverflowError, OSError, ValueError):
+        return None
+    upper_bound = _now() + datetime.timedelta(minutes=5)
+    if probed_dt > upper_bound:
+        return None
+    return agent_id, out, probed_dt
+
+
+async def _persist_agent_skill_snapshot(
+    db: AsyncSession,
+    *,
+    daemon_instance_id: str,
+    params: dict[str, Any],
+) -> tuple[str, list[dict[str, Any]], datetime.datetime] | None:
+    """Persist a validated per-agent skill snapshot if the agent is hosted here."""
+    parsed = _parse_agent_skill_snapshot_params(params)
+    if parsed is None:
+        return None
+    agent_id, skills, probed_dt = parsed
+    agent = await db.scalar(
+        select(Agent).where(
+            Agent.agent_id == agent_id,
+            Agent.daemon_instance_id == daemon_instance_id,
+            Agent.status == "active",
+        )
+    )
+    if agent is None:
+        return None
+    agent.skills_json = skills
+    agent.skills_probed_at = probed_dt
+    return agent_id, skills, probed_dt
+
+
 async def _load_agent_identity_snapshot(
     daemon_instance_id: str,
 ) -> list[dict[str, Any]]:
@@ -1769,8 +1857,8 @@ async def _handle_daemon_event(conn: _DaemonConn, msg: dict[str, Any]) -> None:
             pass
         return
 
-    # For runtime_snapshot we need to validate params *before* the DB touch so
-    # we can bail with bad_params without writing anything.
+    # Validate snapshot params *before* the DB touch so we can bail with
+    # bad_params without writing anything.
     params = msg.get("params")
     if msg_type == "runtime_snapshot":
         parsed = _parse_runtime_snapshot_params(params)
@@ -1781,6 +1869,22 @@ async def _handle_daemon_event(conn: _DaemonConn, msg: dict[str, Any]) -> None:
                 "error": {
                     "code": "bad_params",
                     "message": "runtime_snapshot requires {runtimes:list, probedAt:int}",
+                },
+            }
+            try:
+                await conn.ws.send_text(json.dumps(err))
+            except Exception:
+                pass
+            return
+    if msg_type == "agent_skill_snapshot":
+        parsed = _parse_agent_skill_snapshot_params(params)
+        if parsed is None:
+            err = {
+                "id": msg_id,
+                "ok": False,
+                "error": {
+                    "code": "bad_params",
+                    "message": "agent_skill_snapshot requires {agentId:str, skills:list, probedAt:int}",
                 },
             }
             try:
@@ -1801,6 +1905,12 @@ async def _handle_daemon_event(conn: _DaemonConn, msg: dict[str, Any]) -> None:
                 if msg_type == "runtime_snapshot":
                     # params already validated above; ignore return value.
                     await _persist_runtime_snapshot(db, instance, params)  # type: ignore[arg-type]
+                if msg_type == "agent_skill_snapshot":
+                    await _persist_agent_skill_snapshot(
+                        db,
+                        daemon_instance_id=conn.daemon_instance_id,
+                        params=params,  # type: ignore[arg-type]
+                    )
                 await db.commit()
     except Exception as exc:  # noqa: BLE001
         logger.debug("daemon event persist failed: %s", exc)

--- a/backend/migrations/017_agent_skill_snapshots.sql
+++ b/backend/migrations/017_agent_skill_snapshots.sql
@@ -1,0 +1,5 @@
+ALTER TABLE agents
+  ADD COLUMN IF NOT EXISTS skills_json JSON;
+
+ALTER TABLE agents
+  ADD COLUMN IF NOT EXISTS skills_probed_at TIMESTAMPTZ;

--- a/backend/tests/test_app/test_app_policy.py
+++ b/backend/tests/test_app/test_app_policy.py
@@ -266,6 +266,105 @@ async def test_runtime_files_for_owned_daemon_agent_dispatches_control_frame(
 
 
 @pytest.mark.asyncio
+async def test_runtime_skills_get_returns_stored_snapshot(client, seed, db_session):
+    row = await db_session.execute(select(Agent).where(Agent.agent_id == "ag_owned"))
+    agent = row.scalar_one()
+    agent.daemon_instance_id = "dm_skills"
+    agent.runtime = "codex"
+    agent.skills_json = [
+        {
+            "name": "workspace-skill",
+            "source": "workspace",
+            "description": "Workspace skill",
+            "mtimeMs": 1710000000000,
+            "mtimeAt": "2024-03-09T16:00:00+00:00",
+        }
+    ]
+    agent.skills_probed_at = datetime.datetime.now(datetime.timezone.utc)
+    await db_session.commit()
+
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    r = await client.get("/api/agents/ag_owned/skills", headers=headers)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["agent_id"] == "ag_owned"
+    assert body["daemon_instance_id"] == "dm_skills"
+    assert body["runtime"] == "codex"
+    assert body["skills"][0]["source"] == "workspace"
+    assert body["sniffed_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_runtime_skills_refresh_dispatches_persists_and_returns(
+    client, seed, db_session, monkeypatch
+):
+    from app.routers import runtime_skills as runtime_skills_mod
+
+    row = await db_session.execute(select(Agent).where(Agent.agent_id == "ag_owned"))
+    agent = row.scalar_one()
+    agent.daemon_instance_id = "dm_skills"
+    agent.runtime = "codex"
+    await db_session.commit()
+
+    monkeypatch.setattr(runtime_skills_mod, "is_daemon_online", lambda _id: True)
+
+    calls = []
+    probed_at = int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000)
+
+    async def fake_send(daemon_instance_id, type_, params=None, timeout_ms=None):
+        calls.append({
+            "daemon_instance_id": daemon_instance_id,
+            "type": type_,
+            "params": params,
+            "timeout_ms": timeout_ms,
+        })
+        return {
+            "ok": True,
+            "result": {
+                "agentId": "ag_owned",
+                "skills": [
+                    {
+                        "name": f"global-skill-{i}",
+                        "source": "runtime-global",
+                        "description": "Global skill",
+                        "mtimeMs": probed_at,
+                    }
+                    for i in range(129)
+                ],
+                "probedAt": probed_at,
+            },
+        }
+
+    monkeypatch.setattr(runtime_skills_mod, "send_control_frame", fake_send)
+
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    r = await client.post("/api/agents/ag_owned/skills/refresh", headers=headers)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert len(body["skills"]) == 129
+    assert body["skills"][0]["name"] == "global-skill-0"
+    assert body["skills"][-1]["name"] == "global-skill-128"
+    assert body["skills"][0]["source"] == "runtime-global"
+    assert body["sniffed_at"] is not None
+    assert calls == [
+        {
+            "daemon_instance_id": "dm_skills",
+            "type": "list_agent_skills",
+            "params": {"agentId": "ag_owned"},
+            "timeout_ms": 5000,
+        }
+    ]
+
+    refreshed = await db_session.scalar(select(Agent).where(Agent.agent_id == "ag_owned"))
+    assert refreshed is not None
+    assert len(refreshed.skills_json) == 129
+    assert refreshed.skills_json[0]["name"] == "global-skill-0"
+    assert refreshed.skills_json[-1]["name"] == "global-skill-128"
+    assert refreshed.skills_json[0]["mtimeAt"]
+    assert refreshed.skills_probed_at is not None
+
+
+@pytest.mark.asyncio
 async def test_runtime_files_for_owned_cloud_agent_dispatches_cloud_control_frame(
     client, seed, db_session, monkeypatch
 ):

--- a/backend/tests/test_app/test_daemon_control.py
+++ b/backend/tests/test_app/test_daemon_control.py
@@ -1186,6 +1186,58 @@ async def test_runtime_snapshot_caps_nested_models(
 
 
 @pytest.mark.asyncio
+async def test_agent_skill_snapshot_accepts_and_persists_full_list_over_128(
+    client: AsyncClient, seed_user, db_session: AsyncSession
+):
+    from sqlalchemy import select
+
+    from hub.routers.daemon_control import _DaemonConn, _handle_daemon_event
+
+    bundle = await _provision_instance_via_device_code(client, seed_user)
+    instance_id = bundle["daemon_instance_id"]
+    await _seed_hosted_agent(
+        db_session,
+        user_id=seed_user["user_id"],
+        daemon_instance_id=instance_id,
+        agent_id="ag_many_skills",
+    )
+
+    fake_ws = _FakeWS()
+    conn = _DaemonConn(
+        ws=fake_ws,  # type: ignore[arg-type]
+        user_id=str(seed_user["user_id"]),
+        daemon_instance_id=instance_id,
+        pending_acks={},
+    )
+
+    skills = [
+        {"name": f"skill-{i}", "source": "runtime-global", "mtimeMs": _probed_now_ms()}
+        for i in range(129)
+    ]
+    await _handle_daemon_event(
+        conn,
+        {
+            "id": "frm_skills_many",
+            "type": "agent_skill_snapshot",
+            "params": {
+                "agentId": "ag_many_skills",
+                "skills": skills,
+                "probedAt": _probed_now_ms(),
+            },
+        },
+    )
+    ack = json.loads(fake_ws.sent[-1])
+    assert ack == {"id": "frm_skills_many", "ok": True}
+
+    await db_session.commit()
+    agent = await db_session.scalar(select(Agent).where(Agent.agent_id == "ag_many_skills"))
+    assert agent is not None
+    assert len(agent.skills_json) == 129
+    assert agent.skills_json[-1]["name"] == "skill-128"
+    assert agent.skills_probed_at is not None
+
+
+@pytest.mark.asyncio
 async def test_list_instances_without_runtimes_returns_none(
     client: AsyncClient, seed_user
 ):

--- a/frontend/src/components/dashboard/AgentSettingsDrawer.tsx
+++ b/frontend/src/components/dashboard/AgentSettingsDrawer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { Bell, Bot, Clock, FileText, Loader2, MessageSquare, Plug, RefreshCw, Shield, Trash2, User, UserRound, X } from "lucide-react";
+import { Bell, Bot, Clock, FileText, Loader2, MessageSquare, Plug, RefreshCw, Shield, Sparkles, Trash2, User, UserRound, X } from "lucide-react";
 import { apiFetch, userApi } from "@/lib/api";
 import { useLanguage } from "@/lib/i18n";
 import { botDetailDrawer } from "@/lib/i18n/translations/dashboard";
@@ -20,6 +20,7 @@ import AgentChannelsTab from "./AgentChannelsTab";
 import AgentSchedulesTab from "./AgentSchedulesTab";
 import { AGENT_AVATAR_URLS } from "@/lib/agent-avatars";
 import BotRuntimeCapabilitiesPanel from "./BotRuntimeCapabilitiesPanel";
+import AgentSkillsTab from "./AgentSkillsTab";
 
 interface AgentSettingsDrawerProps {
   agentId: string;
@@ -36,7 +37,7 @@ interface AgentSettingsDrawerProps {
   onSaved?: () => void;
 }
 
-type Tab = "profile" | "policy" | "schedules" | "gateways" | "files";
+type Tab = "profile" | "policy" | "schedules" | "gateways" | "skills" | "files";
 type BotDetailDrawerCopy = typeof botDetailDrawer["en"];
 
 interface AgentRuntimeFile {
@@ -294,6 +295,7 @@ export default function AgentSettingsDrawer({
     deleteAgent: locale === "zh" ? "删除 Agent" : "Delete Agent",
     policyTab: locale === "zh" ? "权限与回复" : "Permissions",
     filesTab: locale === "zh" ? "文件/记忆" : "Files / Memory",
+    skillsTab: locale === "zh" ? "Skills" : "Skills",
     directContact: locale === "zh" ? "直接联系" : "Direct contact",
     allowedSources: locale === "zh" ? "允许来源" : "Allowed sources",
     allOff: locale === "zh" ? "全部关闭" : "All off",
@@ -447,7 +449,7 @@ export default function AgentSettingsDrawer({
 
         {/* Tabs */}
         <div className="flex flex-nowrap overflow-x-auto border-b border-glass-border/60 px-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-          {(["profile", "policy", "schedules", "gateways", "files"] as Tab[]).map((t) => (
+          {(["profile", "policy", "schedules", "gateways", "skills", "files"] as Tab[]).map((t) => (
             <button
               key={t}
               type="button"
@@ -466,6 +468,8 @@ export default function AgentSettingsDrawer({
                 <Plug className="h-3.5 w-3.5" />
               ) : t === "schedules" ? (
                 <Clock className="h-3.5 w-3.5" />
+              ) : t === "skills" ? (
+                <Sparkles className="h-3.5 w-3.5" />
               ) : (
                 <FileText className="h-3.5 w-3.5" />
               )}
@@ -477,7 +481,9 @@ export default function AgentSettingsDrawer({
                     ? botDetailDrawer[locale].settings.autonomy
                     : t === "gateways"
                       ? botDetailDrawer[locale].settings.channels
-                      : labels.filesTab}
+                      : t === "skills"
+                        ? labels.skillsTab
+                        : labels.filesTab}
             </button>
           ))}
         </div>
@@ -740,6 +746,8 @@ export default function AgentSettingsDrawer({
           )}
 
           {tab === "schedules" && <AgentSchedulesTab agentId={agentId} />}
+
+          {tab === "skills" && <AgentSkillsTab agentId={agentId} />}
 
           {tab === "files" && (
             <div className="space-y-4">

--- a/frontend/src/components/dashboard/AgentSkillsTab.tsx
+++ b/frontend/src/components/dashboard/AgentSkillsTab.tsx
@@ -1,0 +1,310 @@
+"use client";
+
+/**
+ * [INPUT]: agentId + Hub skill snapshot API
+ * [OUTPUT]: AgentSkillsTab — lists daemon-sniffed runtime-global/workspace skills and refreshes the snapshot
+ * [POS]: Bot Settings / My Bots drawer Skills tab content
+ * [PROTOCOL]: update header on changes
+ */
+
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { FolderKanban, Globe2, Loader2, RefreshCw, Sparkles } from "lucide-react";
+import { userApi } from "@/lib/api";
+import {
+  createAgentSkillsRequestGuard,
+  groupAgentSkills,
+  normalizeAgentSkillSnapshot,
+  type AgentSkill,
+  type AgentSkillSnapshot,
+  type AgentSkillSource,
+} from "@/lib/agent-skills";
+import { useLanguage } from "@/lib/i18n";
+
+const COPY = {
+  en: {
+    title: "Skills",
+    subtitle: "Daemon-sniffed skills snapshotted for this Bot",
+    runtimeGlobal: "Runtime-global",
+    workspace: "Workspace",
+    refresh: "Refresh skills",
+    loading: "Loading skills...",
+    refreshing: "Refreshing...",
+    empty: "No skills found in the latest snapshot",
+    loadFailed: "Failed to load skills",
+    daemonUnavailable: "Daemon is offline or this Bot is not daemon-hosted",
+    lastSniffed: "Last sniffed",
+    runtime: "Runtime",
+    noDescription: "No description provided",
+  },
+  zh: {
+    title: "Skills",
+    subtitle: "Daemon 已嗅探并为此 Bot 快照的技能",
+    runtimeGlobal: "运行时全局",
+    workspace: "工作区",
+    refresh: "刷新技能",
+    loading: "正在加载技能...",
+    refreshing: "刷新中...",
+    empty: "最新快照中没有发现技能",
+    loadFailed: "读取技能失败",
+    daemonUnavailable: "Daemon 未在线或此 Bot 未由 daemon 托管",
+    lastSniffed: "上次嗅探",
+    runtime: "运行环境",
+    noDescription: "暂无描述",
+  },
+} as const;
+
+function skillsErrorMessage(err: unknown, fallback: string, daemonUnavailable: string): string {
+  const message = err instanceof Error ? err.message : String(err || fallback);
+  if (message === "daemon_offline" || message === "agent_not_daemon_hosted") {
+    return daemonUnavailable;
+  }
+  return message || fallback;
+}
+
+function formatTimestamp(value?: string | null): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatMillis(value?: number): string | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  return formatTimestamp(new Date(value).toISOString());
+}
+
+function sourceIcon(source: AgentSkillSource) {
+  return source === "runtime-global" ? (
+    <Globe2 className="h-3.5 w-3.5" />
+  ) : (
+    <FolderKanban className="h-3.5 w-3.5" />
+  );
+}
+
+function SkillCard({ skill, sourceLabel }: { skill: AgentSkill; sourceLabel: string }) {
+  return (
+    <li className="rounded-xl border border-glass-border bg-glass-bg/35 px-3 py-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate text-sm font-semibold text-text-primary">{skill.name}</span>
+            <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-neon-cyan/25 bg-neon-cyan/5 px-2 py-0.5 text-[10px] font-medium text-neon-cyan">
+              {sourceIcon(skill.source)}
+              {sourceLabel}
+            </span>
+          </div>
+          <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-text-secondary/80">
+            {skill.description}
+          </p>
+        </div>
+      </div>
+      <div className="mt-2 flex flex-wrap gap-1.5">
+        {skill.runtime ? (
+          <span className="rounded border border-glass-border bg-deep-black/30 px-1.5 py-0.5 font-mono text-[10px] text-text-secondary">
+            {skill.runtime}
+          </span>
+        ) : null}
+        {skill.path ? (
+          <span className="max-w-full truncate rounded border border-glass-border bg-deep-black/30 px-1.5 py-0.5 font-mono text-[10px] text-text-secondary">
+            {skill.path}
+          </span>
+        ) : null}
+        {skill.updatedAt || skill.mtimeMs ? (
+          <span className="rounded border border-glass-border bg-deep-black/30 px-1.5 py-0.5 text-[10px] text-text-secondary">
+            {formatTimestamp(skill.updatedAt) ?? formatMillis(skill.mtimeMs)}
+          </span>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+export default function AgentSkillsTab({ agentId }: { agentId: string }) {
+  const locale = useLanguage();
+  const copy = COPY[locale];
+  const [snapshot, setSnapshot] = useState<AgentSkillSnapshot | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const requestGuardRef = useRef(createAgentSkillsRequestGuard(agentId));
+  const visibleSnapshot = snapshot?.agentId === agentId ? snapshot : null;
+
+  const grouped = useMemo(
+    () => groupAgentSkills(visibleSnapshot?.skills ?? []),
+    [visibleSnapshot?.skills],
+  );
+  const total = visibleSnapshot?.skills.length ?? 0;
+  const sniffedAt = formatTimestamp(visibleSnapshot?.sniffedAt);
+
+  const loadSkills = async () => {
+    const requestAgentId = agentId;
+    const requestToken = requestGuardRef.current.begin(requestAgentId, "load");
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await userApi.listAgentSkills(requestAgentId);
+      const nextSnapshot = normalizeAgentSkillSnapshot(data, requestAgentId);
+      if (!requestGuardRef.current.canCommit(requestToken) || nextSnapshot.agentId !== requestAgentId) return;
+      setSnapshot(nextSnapshot);
+      setLoaded(true);
+    } catch (err) {
+      if (!requestGuardRef.current.canCommit(requestToken)) return;
+      setError(skillsErrorMessage(err, copy.loadFailed, copy.daemonUnavailable));
+      setLoaded(true);
+    } finally {
+      if (requestGuardRef.current.canFinishOperation(requestToken)) {
+        setLoading(false);
+      }
+    }
+  };
+
+  const refreshSkills = async () => {
+    const requestAgentId = agentId;
+    const requestToken = requestGuardRef.current.begin(requestAgentId, "refresh");
+    setRefreshing(true);
+    setError(null);
+    try {
+      const data = await userApi.refreshAgentSkills(requestAgentId);
+      const nextSnapshot = normalizeAgentSkillSnapshot(data, requestAgentId);
+      if (!requestGuardRef.current.canCommit(requestToken) || nextSnapshot.agentId !== requestAgentId) return;
+      setSnapshot(nextSnapshot);
+      setLoaded(true);
+    } catch (err) {
+      if (!requestGuardRef.current.canCommit(requestToken)) return;
+      setError(skillsErrorMessage(err, copy.loadFailed, copy.daemonUnavailable));
+    } finally {
+      if (requestGuardRef.current.canFinishOperation(requestToken)) {
+        setRefreshing(false);
+      }
+    }
+  };
+
+  useLayoutEffect(() => {
+    requestGuardRef.current.setAgentId(agentId);
+    setSnapshot(null);
+    setLoaded(false);
+    setError(null);
+    setLoading(false);
+    setRefreshing(false);
+    return () => {
+      requestGuardRef.current.invalidate();
+    };
+  }, [agentId]);
+
+  useEffect(() => {
+    if (!loaded && !loading) {
+      void loadSkills();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agentId, loaded, loading]);
+
+  const sections: Array<{ key: AgentSkillSource; label: string; skills: AgentSkill[] }> = [
+    { key: "runtime-global", label: copy.runtimeGlobal, skills: grouped["runtime-global"] },
+    { key: "workspace", label: copy.workspace, skills: grouped.workspace },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="flex items-center gap-2 text-sm font-semibold text-text-primary">
+            <Sparkles className="h-4 w-4 text-neon-cyan" />
+            {copy.title}
+          </h3>
+          <p className="mt-0.5 text-xs text-text-secondary">{copy.subtitle}</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void refreshSkills()}
+          disabled={loading || refreshing}
+          className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-glass-border bg-glass-bg text-text-secondary transition-colors hover:text-text-primary disabled:opacity-60"
+          title={copy.refresh}
+          aria-label={copy.refresh}
+        >
+          {refreshing ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <RefreshCw className="h-4 w-4" />
+          )}
+        </button>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <div className="rounded-xl border border-glass-border bg-glass-bg/30 px-3 py-2">
+          <div className="text-[10px] uppercase tracking-normal text-text-secondary/65">{copy.title}</div>
+          <div className="mt-1 text-lg font-semibold text-text-primary">{total}</div>
+        </div>
+        <div className="rounded-xl border border-glass-border bg-glass-bg/30 px-3 py-2">
+          <div className="text-[10px] uppercase tracking-normal text-text-secondary/65">
+            {visibleSnapshot?.runtime ? copy.runtime : copy.lastSniffed}
+          </div>
+          <div className="mt-1 truncate font-mono text-xs text-text-primary">
+            {visibleSnapshot?.runtime ?? sniffedAt ?? "-"}
+          </div>
+        </div>
+      </div>
+
+      {sniffedAt ? (
+        <p className="text-[11px] text-text-secondary/65">
+          {copy.lastSniffed}: {sniffedAt}
+        </p>
+      ) : null}
+
+      {error ? (
+        <div className="rounded-xl border border-red-400/20 bg-red-400/5 px-4 py-3 text-sm text-red-300">
+          {error}
+        </div>
+      ) : null}
+
+      {loading && total === 0 ? (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-20 animate-pulse rounded-xl bg-glass-bg/60" />
+          ))}
+        </div>
+      ) : total === 0 ? (
+        <div className="rounded-xl border border-glass-border bg-glass-bg/40 px-4 py-8 text-center text-sm text-text-secondary">
+          {copy.empty}
+        </div>
+      ) : (
+        <div className="space-y-5">
+          {sections.map((section) => (
+            <section key={section.key} className="space-y-2">
+              <div className="flex items-center justify-between gap-2 text-[11px] font-semibold uppercase tracking-normal text-text-secondary/70">
+                <span className="flex items-center gap-1.5">
+                  {sourceIcon(section.key)}
+                  {section.label}
+                </span>
+                <span>{section.skills.length}</span>
+              </div>
+              {section.skills.length > 0 ? (
+                <ul className="space-y-2">
+                  {section.skills.map((skill) => (
+                    <SkillCard
+                      key={skill.id}
+                      skill={{
+                        ...skill,
+                        description: skill.description || copy.noDescription,
+                      }}
+                      sourceLabel={section.label}
+                    />
+                  ))}
+                </ul>
+              ) : (
+                <div className="rounded-xl border border-glass-border/70 bg-glass-bg/20 px-3 py-3 text-xs text-text-secondary/60">
+                  {copy.empty}
+                </div>
+              )}
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/BotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/BotDetailDrawer.tsx
@@ -11,6 +11,7 @@ import {
   Pencil,
   RefreshCw,
   Settings2,
+  Sparkles,
   Trash2,
   Wallet as WalletIcon,
   X,
@@ -41,14 +42,16 @@ import BotAvatar from "./BotAvatar";
 import { CompositeAvatar } from "./CompositeAvatar";
 import BotWalletTab from "./BotWalletTab";
 import DashboardSelect from "./DashboardSelect";
+import AgentSkillsTab from "./AgentSkillsTab";
 
-type TabKey = "overview" | "wallet" | "settings" | "files";
+type TabKey = "overview" | "wallet" | "settings" | "skills" | "files";
 type BotDetailDrawerCopy = typeof botDetailDrawer["en"];
 
 const TABS: { key: TabKey; icon: React.ComponentType<{ className?: string }> }[] = [
   { key: "overview", icon: Eye },
   { key: "wallet", icon: WalletIcon },
   { key: "settings", icon: Settings2 },
+  { key: "skills", icon: Sparkles },
   { key: "files", icon: FileText },
 ];
 
@@ -265,7 +268,7 @@ export default function BotDetailDrawer() {
         </div>
 
         {/* Tab strip */}
-        <div className="grid grid-cols-4 border-b border-glass-border">
+        <div className="grid grid-cols-5 border-b border-glass-border">
           {TABS.map(({ key, icon: Icon }) => {
             const active = tab === key;
             return (
@@ -317,6 +320,7 @@ export default function BotDetailDrawer() {
               t={t}
             />
           )}
+          {tab === "skills" && <AgentSkillsTab agentId={bot.agent_id} />}
           {tab === "files" && <FilesTab agentId={bot.agent_id} t={t} />}
           {tab === "wallet" && <BotWalletTab agentId={bot.agent_id} displayName={bot.display_name} />}
         </div>

--- a/frontend/src/lib/agent-skills.test.ts
+++ b/frontend/src/lib/agent-skills.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import {
+  createAgentSkillsRequestGuard,
+  groupAgentSkills,
+  normalizeAgentSkillSnapshot,
+} from "./agent-skills";
+
+describe("normalizeAgentSkillSnapshot", () => {
+  it("keeps runtime-global and workspace skills from Hub snapshots", () => {
+    const snapshot = normalizeAgentSkillSnapshot(
+      {
+        agent_id: "ag_1",
+        daemon_instance_id: "dm_1",
+        runtime: "codex",
+        sniffed_at: "2026-05-27T00:00:00Z",
+        skills: [
+          {
+            id: "skill_global",
+            name: "openai-docs",
+            source: "runtime_global",
+            description: "OpenAI API docs helper",
+            path: "/home/user/.codex/skills/openai-docs/SKILL.md",
+          },
+          {
+            name: "botcord",
+            source: "workspace",
+            updated_at: "2026-05-26T00:00:00Z",
+          },
+          {
+            name: "ignored",
+            source: "memory",
+          },
+        ],
+      },
+      "ag_fallback",
+    );
+
+    expect(snapshot.agentId).toBe("ag_1");
+    expect(snapshot.daemonInstanceId).toBe("dm_1");
+    expect(snapshot.runtime).toBe("codex");
+    expect(snapshot.sniffedAt).toBe("2026-05-27T00:00:00Z");
+    expect(snapshot.skills).toHaveLength(2);
+    expect(snapshot.skills[0]).toMatchObject({
+      id: "skill_global",
+      name: "openai-docs",
+      source: "runtime-global",
+      description: "OpenAI API docs helper",
+    });
+    expect(snapshot.skills[1]).toMatchObject({
+      name: "botcord",
+      source: "workspace",
+      updatedAt: "2026-05-26T00:00:00Z",
+    });
+  });
+
+  it("accepts alternate item response shape and builds stable fallback ids", () => {
+    const snapshot = normalizeAgentSkillSnapshot(
+      {
+        agentId: "ag_2",
+        items: [
+          {
+            slug: "custom-skill",
+            kind: "global",
+          },
+        ],
+      },
+      "ag_fallback",
+    );
+
+    expect(snapshot.skills).toEqual([
+      {
+        id: "runtime-global:custom-skill:0",
+        name: "custom-skill",
+        source: "runtime-global",
+        description: undefined,
+        runtime: undefined,
+        path: undefined,
+        file: undefined,
+        updatedAt: undefined,
+        mtimeMs: undefined,
+      },
+    ]);
+  });
+});
+
+describe("groupAgentSkills", () => {
+  it("splits skills by display source", () => {
+    const grouped = groupAgentSkills([
+      { id: "a", name: "A", source: "runtime-global" },
+      { id: "b", name: "B", source: "workspace" },
+    ]);
+
+    expect(grouped["runtime-global"].map((skill) => skill.name)).toEqual(["A"]);
+    expect(grouped.workspace.map((skill) => skill.name)).toEqual(["B"]);
+  });
+});
+
+describe("createAgentSkillsRequestGuard", () => {
+  it("rejects a completed request after the current agent changes", () => {
+    const guard = createAgentSkillsRequestGuard("ag_old");
+    const oldRequest = guard.begin("ag_old", "load");
+
+    guard.setAgentId("ag_new");
+    const newRequest = guard.begin("ag_new", "load");
+
+    expect(guard.canCommit(oldRequest)).toBe(false);
+    expect(guard.canFinishOperation(oldRequest)).toBe(false);
+    expect(guard.canCommit(newRequest)).toBe(true);
+    expect(guard.canFinishOperation(newRequest)).toBe(true);
+  });
+
+  it("lets a committed lifecycle update invalidate previous-agent loading and finally paths", () => {
+    const guard = createAgentSkillsRequestGuard("ag_old");
+    const oldRequest = guard.begin("ag_old", "load");
+
+    guard.setAgentId("ag_new");
+
+    expect(guard.canCommit(oldRequest)).toBe(false);
+    expect(guard.canFinishOperation(oldRequest)).toBe(false);
+  });
+
+  it("lets a new request establish the current agent without render-time mutation", () => {
+    const guard = createAgentSkillsRequestGuard("ag_old");
+    const oldRequest = guard.begin("ag_old", "load");
+    const newRequest = guard.begin("ag_new", "load");
+
+    expect(guard.canCommit(oldRequest)).toBe(false);
+    expect(guard.canFinishOperation(oldRequest)).toBe(false);
+    expect(guard.canCommit(newRequest)).toBe(true);
+    expect(guard.canFinishOperation(newRequest)).toBe(true);
+  });
+
+  it("lets cleanup invalidate same-agent success, error, and finally paths", () => {
+    const guard = createAgentSkillsRequestGuard("ag_1");
+    const request = guard.begin("ag_1", "load");
+
+    guard.invalidate();
+
+    expect(guard.canCommit(request)).toBe(false);
+    expect(guard.canFinishOperation(request)).toBe(false);
+  });
+
+  it("only accepts the newest request for the same agent", () => {
+    const guard = createAgentSkillsRequestGuard("ag_1");
+    const initialLoad = guard.begin("ag_1", "load");
+    const refresh = guard.begin("ag_1", "refresh");
+
+    expect(guard.canCommit(initialLoad)).toBe(false);
+    expect(guard.canCommit(refresh)).toBe(true);
+  });
+
+  it("lets older load cleanup run after a newer refresh request starts", () => {
+    const guard = createAgentSkillsRequestGuard("ag_1");
+    const load = guard.begin("ag_1", "load");
+    const refresh = guard.begin("ag_1", "refresh");
+
+    expect(guard.canCommit(load)).toBe(false);
+    expect(guard.canFinishOperation(load)).toBe(true);
+    expect(guard.canCommit(refresh)).toBe(true);
+    expect(guard.canFinishOperation(refresh)).toBe(true);
+  });
+
+  it("does not let older same-operation cleanup clear a newer busy state", () => {
+    const guard = createAgentSkillsRequestGuard("ag_1");
+    const firstRefresh = guard.begin("ag_1", "refresh");
+    const secondRefresh = guard.begin("ag_1", "refresh");
+
+    expect(guard.canCommit(firstRefresh)).toBe(false);
+    expect(guard.canFinishOperation(firstRefresh)).toBe(false);
+    expect(guard.canCommit(secondRefresh)).toBe(true);
+    expect(guard.canFinishOperation(secondRefresh)).toBe(true);
+  });
+});

--- a/frontend/src/lib/agent-skills.ts
+++ b/frontend/src/lib/agent-skills.ts
@@ -1,0 +1,194 @@
+/**
+ * [INPUT]: Raw Hub agent skill snapshot payloads
+ * [OUTPUT]: Normalized AgentSkillSnapshot used by dashboard Skills tabs
+ * [POS]: frontend typed boundary for daemon-sniffed skills snapshotted to DB
+ * [PROTOCOL]: update header on changes
+ */
+
+export type AgentSkillSource = "runtime-global" | "workspace";
+
+export interface AgentSkill {
+  id: string;
+  name: string;
+  source: AgentSkillSource;
+  description?: string;
+  runtime?: string;
+  path?: string;
+  file?: string;
+  updatedAt?: string;
+  mtimeMs?: number;
+}
+
+export interface AgentSkillSnapshot {
+  agentId: string;
+  daemonInstanceId?: string | null;
+  runtime?: string | null;
+  skills: AgentSkill[];
+  sniffedAt?: string | null;
+}
+
+export interface AgentSkillsResponse {
+  agent_id?: string;
+  agentId?: string;
+  daemon_instance_id?: string | null;
+  daemonInstanceId?: string | null;
+  runtime?: string | null;
+  skills?: unknown[];
+  items?: unknown[];
+  snapshot?: unknown;
+  sniffed_at?: string | null;
+  sniffedAt?: string | null;
+}
+
+export type AgentSkillsOperation = "load" | "refresh";
+
+export interface AgentSkillsRequestToken {
+  agentId: string;
+  operation: AgentSkillsOperation;
+  requestId: number;
+  operationRequestId: number;
+}
+
+export interface AgentSkillsRequestGuard {
+  setAgentId: (agentId: string) => void;
+  invalidate: () => void;
+  begin: (agentId: string, operation: AgentSkillsOperation) => AgentSkillsRequestToken;
+  canCommit: (token: AgentSkillsRequestToken) => boolean;
+  canFinishOperation: (token: AgentSkillsRequestToken) => boolean;
+}
+
+export function createAgentSkillsRequestGuard(initialAgentId: string): AgentSkillsRequestGuard {
+  let currentAgentId = initialAgentId;
+  let latestRequestId = 0;
+  const latestOperationRequestIds: Record<AgentSkillsOperation, number> = {
+    load: 0,
+    refresh: 0,
+  };
+
+  const invalidateAll = () => {
+    latestRequestId += 1;
+    latestOperationRequestIds.load += 1;
+    latestOperationRequestIds.refresh += 1;
+  };
+
+  return {
+    setAgentId(agentId: string) {
+      if (agentId !== currentAgentId) {
+        currentAgentId = agentId;
+        invalidateAll();
+      }
+    },
+    invalidate() {
+      invalidateAll();
+    },
+    begin(agentId: string, operation: AgentSkillsOperation) {
+      if (agentId !== currentAgentId) {
+        currentAgentId = agentId;
+      }
+      latestRequestId += 1;
+      latestOperationRequestIds[operation] += 1;
+      return {
+        agentId,
+        operation,
+        requestId: latestRequestId,
+        operationRequestId: latestOperationRequestIds[operation],
+      };
+    },
+    canCommit(token: AgentSkillsRequestToken) {
+      return token.agentId === currentAgentId && token.requestId === latestRequestId;
+    },
+    canFinishOperation(token: AgentSkillsRequestToken) {
+      return (
+        token.agentId === currentAgentId &&
+        token.operationRequestId === latestOperationRequestIds[token.operation]
+      );
+    },
+  };
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function asNullableString(value: unknown): string | null | undefined {
+  if (value === null) return null;
+  return asString(value);
+}
+
+function normalizeSource(value: unknown): AgentSkillSource | null {
+  if (value === "runtime-global" || value === "runtime_global" || value === "global") {
+    return "runtime-global";
+  }
+  if (value === "workspace") return "workspace";
+  return null;
+}
+
+export function normalizeAgentSkill(raw: unknown, index: number): AgentSkill | null {
+  if (!raw || typeof raw !== "object") return null;
+  const item = raw as Record<string, unknown>;
+  const source = normalizeSource(item.source ?? item.scope ?? item.kind);
+  if (!source) return null;
+
+  const name = asString(item.name) ?? asString(item.id) ?? asString(item.slug);
+  if (!name) return null;
+
+  const id =
+    asString(item.id) ??
+    asString(item.skill_id) ??
+    `${source}:${name}:${asString(item.path) ?? index}`;
+
+  return {
+    id,
+    name,
+    source,
+    description: asString(item.description),
+    runtime: asString(item.runtime),
+    path: asString(item.path),
+    file: asString(item.file) ?? asString(item.skill_md),
+    updatedAt:
+      asString(item.updated_at) ??
+      asString(item.updatedAt) ??
+      asString(item.mtime_at) ??
+      asString(item.mtimeAt),
+    mtimeMs: typeof item.mtimeMs === "number"
+      ? item.mtimeMs
+      : typeof item.mtime_ms === "number"
+        ? item.mtime_ms
+        : undefined,
+  };
+}
+
+export function normalizeAgentSkillSnapshot(raw: unknown, fallbackAgentId: string): AgentSkillSnapshot {
+  const outer = raw && typeof raw === "object" ? raw as AgentSkillsResponse : {};
+  const data = outer.snapshot && typeof outer.snapshot === "object"
+    ? outer.snapshot as AgentSkillsResponse
+    : outer;
+  const rawSkills = Array.isArray(data.skills)
+    ? data.skills
+    : Array.isArray(data.items)
+      ? data.items
+      : [];
+
+  return {
+    agentId: asString(data.agent_id) ?? asString(data.agentId) ?? fallbackAgentId,
+    daemonInstanceId:
+      asNullableString(data.daemon_instance_id) ??
+      asNullableString(data.daemonInstanceId) ??
+      null,
+    runtime: asNullableString(data.runtime) ?? null,
+    skills: rawSkills
+      .map((item, index) => normalizeAgentSkill(item, index))
+      .filter((item): item is AgentSkill => item !== null),
+    sniffedAt:
+      asNullableString(data.sniffed_at) ??
+      asNullableString(data.sniffedAt) ??
+      null,
+  };
+}
+
+export function groupAgentSkills(skills: AgentSkill[]): Record<AgentSkillSource, AgentSkill[]> {
+  return {
+    "runtime-global": skills.filter((skill) => skill.source === "runtime-global"),
+    workspace: skills.filter((skill) => skill.source === "workspace"),
+  };
+}

--- a/frontend/src/lib/api.agent-skills.test.ts
+++ b/frontend/src/lib/api.agent-skills.test.ts
@@ -1,0 +1,58 @@
+/**
+ * [INPUT]: vitest mock Supabase session + global.fetch
+ * [OUTPUT]: userApi agent skills client contract tests
+ * [POS]: frontend/lib API guard for Bot Settings Skills tab endpoints
+ * [PROTOCOL]: update header on changes
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    auth: {
+      getSession: async () => ({
+        data: { session: { access_token: "test-access-token" } },
+      }),
+    },
+  }),
+}));
+
+process.env.NEXT_PUBLIC_HUB_BASE_URL = "https://api.example.test";
+
+describe("userApi agent skills", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ agent_id: "ag_1", skills: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("loads the snapshotted skill list for an agent", async () => {
+    const { userApi } = await import("./api");
+    await userApi.listAgentSkills("ag_1");
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.example.test/api/agents/ag_1/runtime-skills");
+    expect(init.method).toBeUndefined();
+    expect(new Headers(init.headers).get("Authorization")).toBe("Bearer test-access-token");
+  });
+
+  it("requests a daemon skill re-sniff for an agent", async () => {
+    const { userApi } = await import("./api");
+    await userApi.refreshAgentSkills("ag_1");
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.example.test/api/agents/ag_1/runtime-skills/refresh");
+    expect(init.method).toBe("POST");
+    expect(new Headers(init.headers).get("Authorization")).toBe("Bearer test-access-token");
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -77,6 +77,7 @@ import type {
 } from "./types";
 
 import { createClient } from "@/lib/supabase/client";
+import type { AgentSkillsResponse } from "@/lib/agent-skills";
 import type { AgentPresenceSnapshotPayload } from "@/store/usePresenceStore";
 
 /**
@@ -1066,6 +1067,14 @@ const userApi = {
     return apiGet<{ runs: any[] }>(
       `/api/agents/${encodeURIComponent(agentId)}/schedules/${encodeURIComponent(scheduleId)}/runs`,
     );
+  },
+
+  listAgentSkills(agentId: string): Promise<AgentSkillsResponse> {
+    return apiGet<AgentSkillsResponse>(`/api/agents/${encodeURIComponent(agentId)}/runtime-skills`);
+  },
+
+  refreshAgentSkills(agentId: string): Promise<AgentSkillsResponse> {
+    return apiPost<AgentSkillsResponse>(`/api/agents/${encodeURIComponent(agentId)}/runtime-skills/refresh`);
   },
 };
 

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -3510,6 +3510,7 @@ export const botDetailDrawer: TranslationMap<{
     overview: string
     wallet: string
     settings: string
+    skills: string
     files: string
   }
   overview: {
@@ -3586,6 +3587,7 @@ export const botDetailDrawer: TranslationMap<{
       overview: 'Overview',
       wallet: 'Wallet',
       settings: 'Settings',
+      skills: 'Skills',
       files: 'Files',
     },
     overview: {
@@ -3676,6 +3678,7 @@ export const botDetailDrawer: TranslationMap<{
       overview: '概览',
       wallet: '钱包',
       settings: '设置',
+      skills: 'Skills',
       files: '文件',
     },
     overview: {

--- a/packages/daemon/src/__tests__/cloud-daemon.test.ts
+++ b/packages/daemon/src/__tests__/cloud-daemon.test.ts
@@ -20,6 +20,7 @@ import type { CloudModeConfig } from "../cloud-mode.js";
 import { ControlChannel } from "../control-channel.js";
 import type { DaemonConfig } from "../config.js";
 import type { Gateway, GatewayChannelConfig } from "../gateway/index.js";
+import type { OnAgentInstalledHook } from "../provision.js";
 
 class FakeWebSocket extends EventEmitter {
   public readyState = 0;
@@ -73,6 +74,10 @@ function makeDaemonCfg(): DaemonConfig {
     routes: [],
     streamBlocks: true,
   };
+}
+
+function sentFrames(ws: FakeWebSocket): Array<{ type?: string; params?: any }> {
+  return ws.sent.map((raw) => JSON.parse(raw));
 }
 
 describe("startCloudDaemon", () => {
@@ -168,6 +173,80 @@ describe("startCloudDaemon", () => {
       expect(callArgs.gateway).toBeDefined();
       expect(callArgs.onAgentInstalled).toBeInstanceOf(Function);
       expect(callArgs.policyResolver).toBeDefined();
+    } finally {
+      await handle.stop("test");
+    }
+  });
+
+  it("pushes skill snapshots for agents installed before control-channel startup completes", async () => {
+    const ctor = makeFakeCtor();
+    class TestControlChannel extends ControlChannel {
+      constructor(opts: ConstructorParameters<typeof ControlChannel>[0]) {
+        super({ ...opts, webSocketCtor: ctor, hubPublicKey: null });
+      }
+    }
+    const handle = await startCloudDaemon({
+      cloudConfig: makeCfg(),
+      config: makeDaemonCfg(),
+      configPath: "(cloud-mode)",
+      controlChannelFactory: TestControlChannel as unknown as typeof ControlChannel,
+      provisionerFactory: ((args: { onAgentInstalled: OnAgentInstalledHook }) => {
+        args.onAgentInstalled({
+          agentId: "ag_preinstalled",
+          credentialsFile: path.join(tmpDir, "ag_preinstalled.json"),
+          hubUrl: "http://localhost:9000",
+        });
+        return vi.fn();
+      }) as unknown as typeof import("../provision.js").createProvisioner,
+      sessionStorePath: path.join(tmpDir, "sessions.json"),
+      snapshotPath: path.join(tmpDir, "snapshot.json"),
+      snapshotIntervalMs: 60_000,
+    });
+    try {
+      await new Promise((r) => setImmediate(r));
+      const ws = FakeWebSocket.instances[0]!;
+      const skillFrames = sentFrames(ws).filter((frame) => frame.type === "agent_skill_snapshot");
+      expect(skillFrames).toHaveLength(1);
+      expect(skillFrames[0]!.params.agentId).toBe("ag_preinstalled");
+      expect(Array.isArray(skillFrames[0]!.params.skills)).toBe(true);
+    } finally {
+      await handle.stop("test");
+    }
+  });
+
+  it("pushes a skill snapshot when a cloud agent is installed after startup", async () => {
+    let onAgentInstalled: OnAgentInstalledHook | undefined;
+    const ctor = makeFakeCtor();
+    class TestControlChannel extends ControlChannel {
+      constructor(opts: ConstructorParameters<typeof ControlChannel>[0]) {
+        super({ ...opts, webSocketCtor: ctor, hubPublicKey: null });
+      }
+    }
+    const handle = await startCloudDaemon({
+      cloudConfig: makeCfg(),
+      config: makeDaemonCfg(),
+      configPath: "(cloud-mode)",
+      controlChannelFactory: TestControlChannel as unknown as typeof ControlChannel,
+      provisionerFactory: ((args: { onAgentInstalled: OnAgentInstalledHook }) => {
+        onAgentInstalled = args.onAgentInstalled;
+        return vi.fn();
+      }) as unknown as typeof import("../provision.js").createProvisioner,
+      sessionStorePath: path.join(tmpDir, "sessions.json"),
+      snapshotPath: path.join(tmpDir, "snapshot.json"),
+      snapshotIntervalMs: 60_000,
+    });
+    try {
+      await new Promise((r) => setImmediate(r));
+      onAgentInstalled!({
+        agentId: "ag_hot_installed",
+        credentialsFile: path.join(tmpDir, "ag_hot_installed.json"),
+        hubUrl: "http://localhost:9000",
+      });
+      const ws = FakeWebSocket.instances[0]!;
+      const skillFrames = sentFrames(ws).filter((frame) => frame.type === "agent_skill_snapshot");
+      expect(skillFrames).toHaveLength(1);
+      expect(skillFrames[0]!.params.agentId).toBe("ag_hot_installed");
+      expect(Array.isArray(skillFrames[0]!.params.skills)).toBe(true);
     } finally {
       await handle.stop("test");
     }

--- a/packages/daemon/src/__tests__/runtime-discovery.test.ts
+++ b/packages/daemon/src/__tests__/runtime-discovery.test.ts
@@ -40,7 +40,7 @@ beforeEach(() => {
   // mocked runtime list between cases, so reset before each.
   clearRuntimeProbeCache();
 });
-const { pushRuntimeSnapshot } = await import("../daemon.js");
+const { pushAgentSkillSnapshot, pushRuntimeSnapshot } = await import("../daemon.js");
 const { CONTROL_FRAME_TYPES } = await import("@botcord/protocol-core");
 import type { GatewayChannelConfig, GatewayRuntimeSnapshot } from "../gateway/index.js";
 
@@ -471,6 +471,22 @@ describe("pushRuntimeSnapshot (first-connect push)", () => {
         lastError: "Failed to authenticate",
       }),
     ]);
+  });
+});
+
+describe("pushAgentSkillSnapshot", () => {
+  it("sends an agent_skill_snapshot frame", () => {
+    const frames: any[] = [];
+    const ok = pushAgentSkillSnapshot(
+      { send: (frame) => { frames.push(frame); return true; } },
+      "ag_skills",
+    );
+    expect(ok).toBe(true);
+    expect(frames).toHaveLength(1);
+    expect(frames[0].type).toBe("agent_skill_snapshot");
+    expect(frames[0].params.agentId).toBe("ag_skills");
+    expect(Array.isArray(frames[0].params.skills)).toBe(true);
+    expect(typeof frames[0].params.probedAt).toBe("number");
   });
 });
 

--- a/packages/daemon/src/__tests__/skill-index.test.ts
+++ b/packages/daemon/src/__tests__/skill-index.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  agentCodexHomeDir,
+  agentWorkspaceDir,
+} from "../agent-workspace.js";
+import {
+  buildSoftSkillIndexPrompt,
+  collectAgentSkillSnapshot,
+  scanSoftSkills,
+} from "../skill-index.js";
+
+let tmpDir = "";
+let prevHome: string | undefined;
+
+function writeSkill(dir: string, name: string, description: string): void {
+  const skillDir = path.join(dir, name);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(
+    path.join(skillDir, "SKILL.md"),
+    `---\nname: ${name}\ndescription: "${description}"\n---\n\n# ${name}\n`,
+  );
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(path.join(tmpdir(), "skill-index-"));
+  prevHome = process.env.HOME;
+  process.env.HOME = tmpDir;
+});
+
+afterEach(() => {
+  if (prevHome === undefined) delete process.env.HOME;
+  else process.env.HOME = prevHome;
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("skill snapshots", () => {
+  it("scans agent workspace/runtime-global skills and maps UI source buckets", () => {
+    const agentId = "ag_skilltest";
+    writeSkill(path.join(agentWorkspaceDir(agentId), ".claude", "skills"), "workspace-skill", "Workspace skill");
+    writeSkill(path.join(agentCodexHomeDir(agentId), "skills"), "codex-skill", "Codex skill");
+    writeSkill(path.join(tmpDir, ".codex", "skills"), "global-skill", "Global skill");
+
+    const scanned = scanSoftSkills(agentId);
+    expect(scanned.map((s) => s.name).sort()).toEqual([
+      "codex-skill",
+      "global-skill",
+      "workspace-skill",
+    ]);
+
+    const snapshot = collectAgentSkillSnapshot(agentId);
+    expect(snapshot.agentId).toBe(agentId);
+    expect(snapshot.skills).toHaveLength(3);
+    expect(snapshot.skills.find((s) => s.name === "workspace-skill")?.source)
+      .toBe("workspace");
+    expect(snapshot.skills.find((s) => s.name === "codex-skill")?.source)
+      .toBe("workspace");
+    expect(snapshot.skills.find((s) => s.name === "global-skill")?.source)
+      .toBe("runtime-global");
+    expect(snapshot.probedAt).toBeGreaterThan(0);
+  });
+
+  it("returns complete snapshots while keeping the prompt soft index capped", () => {
+    const agentId = "ag_manyskills";
+    const workspaceSkills = path.join(agentWorkspaceDir(agentId), ".claude", "skills");
+    for (let i = 0; i < 30; i += 1) {
+      const name = `skill-${String(i).padStart(2, "0")}`;
+      writeSkill(workspaceSkills, name, `Skill ${i}`);
+    }
+
+    const scanned = scanSoftSkills(agentId);
+    expect(scanned).toHaveLength(30);
+    expect(scanned.map((s) => s.name)).toEqual(
+      Array.from({ length: 30 }, (_, i) => `skill-${String(i).padStart(2, "0")}`),
+    );
+
+    const snapshot = collectAgentSkillSnapshot(agentId);
+    expect(snapshot.skills).toHaveLength(30);
+
+    const prompt = buildSoftSkillIndexPrompt(agentId);
+    expect(prompt).not.toBeNull();
+    const skillLines = prompt
+      ?.split("\n")
+      .filter((line) => line.startsWith("- skill-"));
+    expect(skillLines).toHaveLength(24);
+    expect(skillLines?.at(0)).toContain("skill-00");
+    expect(skillLines?.at(-1)).toContain("skill-23");
+  });
+});

--- a/packages/daemon/src/cloud-daemon.ts
+++ b/packages/daemon/src/cloud-daemon.ts
@@ -27,7 +27,7 @@ import { ControlChannel } from "./control-channel.js";
 import { toGatewayConfig } from "./daemon-config-map.js";
 import { log as daemonLog } from "./log.js";
 import { createProvisioner } from "./provision.js";
-import { createDaemonChannel, pushRuntimeSnapshot } from "./daemon.js";
+import { createDaemonChannel, pushAgentSkillSnapshot, pushRuntimeSnapshot } from "./daemon.js";
 import { SnapshotWriter } from "./snapshot-writer.js";
 import { createDaemonSystemContextBuilder } from "./system-context.js";
 import { readWorkingMemorySnapshot } from "./working-memory.js";
@@ -234,7 +234,20 @@ export async function startCloudDaemon(
     });
   };
 
+  const installedAgentIds = new Set<string>();
+  let controlChannel: ControlChannel | null = null;
+  const pushInstalledAgentSkillSnapshot = (agentId: string, reason: string): void => {
+    if (!controlChannel) return;
+    const pushed = pushAgentSkillSnapshot(controlChannel, agentId);
+    logger.info("cloud control-channel: agent_skill_snapshot pushed", {
+      agentId,
+      reason,
+      ok: pushed,
+    });
+  };
+
   const onAgentInstalled: OnAgentInstalledHook = (info: InstalledAgentInfo) => {
+    installedAgentIds.add(info.agentId);
     credentialPathByAgentId.set(info.agentId, info.credentialsFile);
     if (info.hubUrl) hubUrlByAgentId.set(info.agentId, info.hubUrl);
     if (info.displayName) displayNameByAgent.set(info.agentId, info.displayName);
@@ -251,6 +264,7 @@ export async function startCloudDaemon(
         }),
       );
     }
+    pushInstalledAgentSkillSnapshot(info.agentId, "agent_installed");
   };
 
   const gateway = new Gateway({
@@ -281,7 +295,6 @@ export async function startCloudDaemon(
   await gateway.start();
   logger.info("cloud daemon gateway started (zero agents at boot)");
 
-  let controlChannel: ControlChannel | null = null;
   if (!opts.disableControlChannel) {
     const auth = asUserAuthManager(new CloudAuthManager(cloudCfg));
     const provisionerFactory = opts.provisionerFactory ?? createProvisioner;
@@ -330,6 +343,9 @@ export async function startCloudDaemon(
       logger.info("cloud control-channel started; runtime_snapshot pushed", {
         ok: pushed,
       });
+      for (const agentId of installedAgentIds) {
+        pushInstalledAgentSkillSnapshot(agentId, "control_channel_started");
+      }
     } catch (err) {
       logger.warn("cloud control-channel start failed; daemon will retry", {
         error: err instanceof Error ? err.message : String(err),

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -52,6 +52,7 @@ import { PolicyResolver, type DaemonAttentionPolicy } from "./gateway/policy-res
 import { scanMention } from "./mention-scan.js";
 import { createDiagnosticBundle, uploadDiagnosticBundle } from "./diagnostics.js";
 import { createAttentionPolicyFetcher } from "./attention-policy-fetcher.js";
+import { collectAgentSkillSnapshot } from "./skill-index.js";
 
 /**
  * Default hard cap for a single runtime turn. Long-running coding/research
@@ -240,6 +241,26 @@ export function pushRuntimeSnapshot(
   if (!ok) {
     daemonLog.warn("runtime-snapshot: control-channel send returned false", {
       runtimes: snap.runtimes.length,
+    });
+  }
+  return ok;
+}
+
+export function pushAgentSkillSnapshot(
+  sink: RuntimeSnapshotSink,
+  agentId: string,
+): boolean {
+  const snap = collectAgentSkillSnapshot(agentId);
+  const ok = sink.send({
+    id: `skill_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+    type: "agent_skill_snapshot",
+    params: snap as unknown as Record<string, unknown>,
+    ts: Date.now(),
+  });
+  if (!ok) {
+    daemonLog.warn("agent-skill-snapshot: control-channel send returned false", {
+      agentId,
+      skills: snap.skills.length,
     });
   }
   return ok;
@@ -648,6 +669,13 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
       logger.info("control-channel: initial runtime_snapshot push", {
         ok: pushed,
       });
+      for (const agentId of agentIds) {
+        const skillsPushed = pushAgentSkillSnapshot(controlChannel, agentId);
+        logger.info("control-channel: initial agent_skill_snapshot push", {
+          agentId,
+          ok: skillsPushed,
+        });
+      }
     } catch (err) {
       logger.warn("control-channel failed to start; continuing without it", {
         error: err instanceof Error ? err.message : String(err),

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -74,6 +74,7 @@ import { log as daemonLog } from "./log.js";
 import { discoverAgentCredentials } from "./agent-discovery.js";
 import { resolveMemoryDir } from "./working-memory.js";
 import { discoverRuntimeModelCatalog } from "./runtime-models.js";
+import { collectAgentSkillSnapshot } from "./skill-index.js";
 import {
   buildRuntimeSelectionExtraArgs,
   mergeRuntimeExtraArgs,
@@ -82,6 +83,10 @@ import {
   handleCloudGatewayRuntimeInbound,
   type CloudGatewayTypingEmitter,
 } from "./cloud-gateway-runtime.js";
+
+interface ListAgentSkillsParams {
+  agentId: string;
+}
 
 /**
  * Information passed to {@link OnAgentInstalledHook} after a successful
@@ -482,6 +487,32 @@ export function createProvisioner(opts: ProvisionerOptions): (
           agentId: params.agentId,
           fileId: params.fileId ?? null,
           count: result.files.length,
+        });
+        return { ok: true, result };
+      }
+
+      case "list_agent_skills": {
+        const params = (frame.params ?? {}) as unknown as ListAgentSkillsParams;
+        if (!params.agentId) {
+          return {
+            ok: false,
+            error: { code: "bad_params", message: "list_agent_skills requires params.agentId" },
+          };
+        }
+        const channels = gateway.snapshot().channels;
+        if (!channels[params.agentId]) {
+          return {
+            ok: false,
+            error: {
+              code: "agent_not_loaded",
+              message: `agent ${params.agentId} is not loaded in daemon gateway`,
+            },
+          };
+        }
+        const result = collectAgentSkillSnapshot(params.agentId);
+        daemonLog.debug("list_agent_skills", {
+          agentId: params.agentId,
+          count: result.skills.length,
         });
         return { ok: true, result };
       }

--- a/packages/daemon/src/skill-index.ts
+++ b/packages/daemon/src/skill-index.ts
@@ -23,6 +23,19 @@ export interface SoftSkillEntry {
   mtimeMs: number;
 }
 
+export interface AgentSkillSnapshotEntry {
+  name: string;
+  source: string;
+  description?: string;
+  mtimeMs: number;
+}
+
+export interface AgentSkillSnapshot {
+  agentId: string;
+  skills: AgentSkillSnapshotEntry[];
+  probedAt: number;
+}
+
 export interface SkillIndexOptions {
   extraDirs?: string[];
   includeGlobal?: boolean;
@@ -70,7 +83,7 @@ export function scanSoftSkills(
     if (!existsSync(root.dir)) continue;
     let children: string[];
     try {
-      children = readdirSync(root.dir);
+      children = readdirSync(root.dir).sort((a, b) => a.localeCompare(b));
     } catch {
       continue;
     }
@@ -105,15 +118,30 @@ export function scanSoftSkills(
   }
 
   return Array.from(byName.values())
-    .sort((a, b) => a.name.localeCompare(b.name))
-    .slice(0, MAX_SKILLS);
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function collectAgentSkillSnapshot(
+  agentId: string,
+  opts: SkillIndexOptions = {},
+): AgentSkillSnapshot {
+  return {
+    agentId,
+    skills: scanSoftSkills(agentId, opts).map((skill) => ({
+      name: skill.name,
+      source: skill.source.startsWith("agent-") ? "workspace" : "runtime-global",
+      ...(skill.description ? { description: skill.description } : {}),
+      mtimeMs: skill.mtimeMs,
+    })),
+    probedAt: Date.now(),
+  };
 }
 
 export function buildSoftSkillIndexPrompt(
   agentId: string,
   opts: SkillIndexOptions = {},
 ): string | null {
-  const skills = scanSoftSkills(agentId, opts);
+  const skills = scanSoftSkills(agentId, opts).slice(0, MAX_SKILLS);
   if (skills.length === 0) return null;
 
   const lines = [

--- a/packages/protocol-core/src/control-frame.ts
+++ b/packages/protocol-core/src/control-frame.ts
@@ -81,6 +81,13 @@ export const CONTROL_FRAME_TYPES = {
    */
   LIST_AGENT_FILES: "list_agent_files",
   /**
+   * Hub→daemon: scan the BotCord agent's runtime/workspace skill directories
+   * and return the current soft-skill snapshot. The Hub authorizes ownership
+   * before sending this frame; daemon accepts only `agentId` and resolves
+   * all paths from its local agent layout.
+   */
+  LIST_AGENT_SKILLS: "list_agent_skills",
+  /**
    * Daemon→Hub: event frame carrying the latest runtime-probe snapshot.
    * Pushed on first control-WS connect (P0) and on reconnect/diff (P1).
    * Hub persists the payload onto `daemon_instances.runtimes_json` so the
@@ -88,6 +95,12 @@ export const CONTROL_FRAME_TYPES = {
    * daemon is offline. Plan §8.5 "push" path.
    */
   RUNTIME_SNAPSHOT: "runtime_snapshot",
+  /**
+   * Daemon→Hub: event frame carrying the latest per-agent soft-skill
+   * snapshot. Hub persists the payload onto the owning agent row so the
+   * dashboard can render the Skills tab while the daemon is offline.
+   */
+  AGENT_SKILL_SNAPSHOT: "agent_skill_snapshot",
   /**
    * Hub→daemon: invalidate the daemon's cached attention policy for a given
    * agent (and optionally a single room override). Sent by the BFF after
@@ -401,6 +414,27 @@ export interface ListAgentFilesResult {
   agentId: string;
   runtime?: string;
   files: AgentRuntimeFile[];
+}
+
+/** Payload shape for `list_agent_skills`. */
+export interface ListAgentSkillsParams {
+  agentId: string;
+}
+
+export interface AgentSkillProbe {
+  /** Skill manifest name, usually from SKILL.md frontmatter. */
+  name: string;
+  /** UI-facing source bucket: agent workspace or runtime-global skill dir. */
+  source: string;
+  description?: string;
+  /** SKILL.md mtime as unix milliseconds. */
+  mtimeMs: number;
+}
+
+export interface ListAgentSkillsResult {
+  agentId: string;
+  skills: AgentSkillProbe[];
+  probedAt: number;
 }
 
 /** Payload shape for `revoke_agent`. */


### PR DESCRIPTION
## Summary
- add Agent Settings Skills tab backed by daemon-snapshotted runtime/workspace skills
- persist skill snapshots in Hub and support manual refresh via daemon control frames
- push proactive skill snapshots from local and cloud daemons
- guard the Skills tab against stale agent responses and load/refresh busy-state races

## Tests
- backend/.venv/bin/python -m pytest backend/tests/test_app/test_daemon_control.py::test_agent_skill_snapshot_accepts_and_persists_full_list_over_128 backend/tests/test_app/test_app_policy.py -q
- pnpm --dir packages/daemon exec vitest run src/__tests__/cloud-daemon.test.ts src/__tests__/skill-index.test.ts src/__tests__/runtime-discovery.test.ts
- npm run test -- src/lib/agent-skills.test.ts src/lib/api.agent-skills.test.ts