### PR TITLE
fix: normalize daemon token expiry

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1987,7 +1987,7 @@ async def provision_agent(
             "hubUrl": hub_config.HUB_PUBLIC_BASE_URL,
             "displayName": label,
             "token": agent_token,
-            "tokenExpiresAt": token_expires_at * 1000,
+            "tokenExpiresAt": token_expires_at,
             "runtime": runtime,
         },
     }

--- a/backend/hub/services/cloud_agent.py
+++ b/backend/hub/services/cloud_agent.py
@@ -92,6 +92,16 @@ class CloudAgentError(Exception):
         self.http_status = http_status
 
 
+def _agent_token_expires_at_seconds(
+    expires_at: datetime.datetime | None,
+) -> int | None:
+    if expires_at is None:
+        return None
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=datetime.timezone.utc)
+    return int(expires_at.timestamp())
+
+
 @dataclass
 class CreateCloudAgentInput:
     name: str
@@ -1366,11 +1376,7 @@ class CloudAgentService:
             await db.commit()
             return
 
-        token_expires_at_ms = (
-            int(agent.token_expires_at.timestamp() * 1000)
-            if agent.token_expires_at is not None
-            else None
-        )
+        token_expires_at = _agent_token_expires_at_seconds(agent.token_expires_at)
         params: dict[str, Any] = {
             "name": agent.display_name,
             "runtime": cai.runtime,
@@ -1382,7 +1388,7 @@ class CloudAgentService:
                 "hubUrl": HUB_PUBLIC_BASE_URL,
                 "displayName": agent.display_name,
                 "token": agent.agent_token,
-                "tokenExpiresAt": token_expires_at_ms,
+                "tokenExpiresAt": token_expires_at,
                 "runtime": cai.runtime,
             },
         }

--- a/backend/tests/test_app/test_agent_provision.py
+++ b/backend/tests/test_app/test_agent_provision.py
@@ -257,6 +257,10 @@ async def test_provision_happy_path_writes_runtime_and_dispatches_frame(
         assert agent.user_id == seed_user["user_id"]
 
         # Signing key activated + hub-issued token stored.
+        assert agent.token_expires_at is not None
+        token_expires_at = agent.token_expires_at.replace(tzinfo=datetime.timezone.utc)
+        assert creds["tokenExpiresAt"] == int(token_expires_at.timestamp())
+        assert creds["tokenExpiresAt"] < 10_000_000_000
         key_res = await db_session.execute(
             select(SigningKey).where(SigningKey.agent_id == body["agent_id"])
         )

--- a/backend/tests/test_cloud_agent_provisioning.py
+++ b/backend/tests/test_cloud_agent_provisioning.py
@@ -8,6 +8,7 @@ ack on ``/cloud/daemon/ws``.
 from __future__ import annotations
 
 import asyncio
+import datetime
 import json
 import uuid
 
@@ -287,6 +288,11 @@ async def test_provision_pending_dispatches_provision_agent_and_marks_ready(
             assert creds["keyId"]
             assert creds["hubUrl"].startswith("http")
             assert creds["token"]
+            token_expires_at = agent.token_expires_at.replace(
+                tzinfo=datetime.timezone.utc
+            )
+            assert creds["tokenExpiresAt"] == int(token_expires_at.timestamp())
+            assert creds["tokenExpiresAt"] < 10_000_000_000
             assert creds["runtime"] == "deepseek-tui"
             assert params["runtime"] == "deepseek-tui"
             assert params["name"] == "A"

--- a/backend/tests/test_cloud_agent_token_expiry.py
+++ b/backend/tests/test_cloud_agent_token_expiry.py
@@ -1,0 +1,20 @@
+import datetime
+
+from hub.services.cloud_agent import _agent_token_expires_at_seconds
+
+
+def test_agent_token_expires_at_seconds_uses_unix_seconds() -> None:
+    expires_at = datetime.datetime(2026, 5, 27, 4, 41, 28, tzinfo=datetime.timezone.utc)
+
+    assert _agent_token_expires_at_seconds(expires_at) == int(expires_at.timestamp())
+
+
+def test_agent_token_expires_at_seconds_treats_naive_as_utc() -> None:
+    expires_at = datetime.datetime(2026, 5, 27, 4, 41, 28)
+    expected = int(expires_at.replace(tzinfo=datetime.timezone.utc).timestamp())
+
+    assert _agent_token_expires_at_seconds(expires_at) == expected
+
+
+def test_agent_token_expires_at_seconds_accepts_none() -> None:
+    assert _agent_token_expires_at_seconds(None) is None

--- a/packages/daemon/src/__tests__/provision.test.ts
+++ b/packages/daemon/src/__tests__/provision.test.ts
@@ -719,6 +719,48 @@ describe("provision_agent handler writes runtime + cwd", () => {
     }
   });
 
+  it("normalizes Hub-supplied millisecond tokenExpiresAt before writing credentials", async () => {
+    const os = await import("node:os");
+    const fs = await import("node:fs");
+    const nodePath = await import("node:path");
+
+    const tmp = fs.mkdtempSync(nodePath.join(os.tmpdir(), "daemon-provision-"));
+    const prevHome = process.env.HOME;
+    process.env.HOME = tmp;
+    try {
+      const gw = makeFakeGateway();
+      const provisioner = createProvisioner({
+        gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+      });
+      const privateKey = Buffer.alloc(32, 9).toString("base64");
+
+      const ack = await provisioner({
+        id: "req_token_expiry",
+        type: CONTROL_FRAME_TYPES.PROVISION_AGENT,
+        params: {
+          runtime: "codex",
+          credentials: {
+            agentId: "ag_token_expiry",
+            keyId: "k_token_expiry",
+            privateKey,
+            hubUrl: "https://hub.example",
+            token: "agent-token",
+            tokenExpiresAt: 1_779_856_985_546,
+          },
+        },
+      });
+
+      expect(ack.ok).toBe(true);
+      const credFile = nodePath.join(tmp, ".botcord", "credentials", "ag_token_expiry.json");
+      const saved = JSON.parse(fs.readFileSync(credFile, "utf8")) as Record<string, unknown>;
+      expect(saved.tokenExpiresAt).toBe(1_779_856_985);
+    } finally {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("rejects unknown runtime ids before touching disk", async () => {
     const gw = makeFakeGateway();
     const provisioner = createProvisioner({

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -13,6 +13,7 @@ import {
   defaultCredentialsFile,
   derivePublicKey,
   loadStoredCredentials,
+  normalizeTokenExpiresAt,
   writeCredentialsFile,
   type AgentIdentitySnapshot,
   type ControlAck,
@@ -1227,7 +1228,8 @@ async function materializeCredentials(
     };
     if (c.displayName) record.displayName = c.displayName;
     if (c.token) record.token = c.token;
-    if (typeof c.tokenExpiresAt === "number") record.tokenExpiresAt = c.tokenExpiresAt;
+    const tokenExpiresAt = normalizeTokenExpiresAt(c.tokenExpiresAt);
+    if (tokenExpiresAt !== undefined) record.tokenExpiresAt = tokenExpiresAt;
     if (runtime) record.runtime = runtime;
     const runtimeSelection = pickRuntimeSelection(params);
     if (runtimeSelection.runtimeModel) record.runtimeModel = runtimeSelection.runtimeModel;

--- a/packages/protocol-core/src/__tests__/client.test.ts
+++ b/packages/protocol-core/src/__tests__/client.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BotCordClient } from "../client.js";
+
+const privateKey = Buffer.alloc(32, 2).toString("base64");
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("BotCordClient token refresh", () => {
+  it("normalizes millisecond tokenExpiresAt config values", () => {
+    const client = new BotCordClient({
+      hubUrl: "https://hub.example",
+      agentId: "ag_test",
+      keyId: "k_test",
+      privateKey,
+      token: "cached-token",
+      tokenExpiresAt: 1_779_856_985_546,
+    });
+
+    expect(client.getTokenExpiresAt()).toBe(1_779_856_985);
+  });
+
+  it("retries a 401 response with the refreshed token", async () => {
+    const requests: Array<{ url: string; authorization?: string }> = [];
+    let inboxAttempts = 0;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const headers = (init?.headers ?? {}) as Record<string, string>;
+        requests.push({ url, authorization: headers.Authorization });
+
+        if (url === "https://hub.example/hub/inbox?limit=50") {
+          inboxAttempts += 1;
+          if (inboxAttempts === 1) {
+            return new Response("expired", { status: 401 });
+          }
+          return Response.json({ messages: [], count: 0, has_more: false });
+        }
+
+        if (url === "https://hub.example/registry/agents/ag_test/token/refresh") {
+          return Response.json({
+            agent_token: "new-token",
+            expires_at: Math.floor(Date.now() / 1000) + 3600,
+          });
+        }
+
+        return new Response("not found", { status: 404 });
+      }),
+    );
+
+    const client = new BotCordClient({
+      hubUrl: "https://hub.example",
+      agentId: "ag_test",
+      keyId: "k_test",
+      privateKey,
+      token: "old-token",
+      tokenExpiresAt: Math.floor(Date.now() / 1000) + 3600,
+    });
+
+    await client.pollInbox({ limit: 50 });
+
+    const inboxRequests = requests.filter((req) => req.url === "https://hub.example/hub/inbox?limit=50");
+    expect(inboxRequests).toHaveLength(2);
+    expect(inboxRequests[0].authorization).toBe("Bearer old-token");
+    expect(inboxRequests[1].authorization).toBe("Bearer new-token");
+  });
+});

--- a/packages/protocol-core/src/__tests__/credentials.test.ts
+++ b/packages/protocol-core/src/__tests__/credentials.test.ts
@@ -1,0 +1,37 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { loadStoredCredentials, normalizeTokenExpiresAt } from "../credentials.js";
+
+describe("credentials token expiry", () => {
+  it("normalizes millisecond timestamps to seconds", () => {
+    expect(normalizeTokenExpiresAt(1_779_856_985_546)).toBe(1_779_856_985);
+  });
+
+  it("preserves second timestamps", () => {
+    expect(normalizeTokenExpiresAt(1_779_856_985)).toBe(1_779_856_985);
+  });
+
+  it("normalizes legacy millisecond tokenExpiresAt values when loading credentials", () => {
+    const tmp = mkdtempSync(path.join(os.tmpdir(), "protocol-creds-"));
+    const file = path.join(tmp, "ag_test.json");
+    try {
+      writeFileSync(
+        file,
+        JSON.stringify({
+          hubUrl: "https://hub.example",
+          agentId: "ag_test",
+          keyId: "k_test",
+          privateKey: Buffer.alloc(32, 1).toString("base64"),
+          token: "old-token",
+          tokenExpiresAt: 1_779_856_985_546,
+        }),
+      );
+
+      expect(loadStoredCredentials(file).tokenExpiresAt).toBe(1_779_856_985);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/protocol-core/src/client.ts
+++ b/packages/protocol-core/src/client.ts
@@ -5,6 +5,7 @@
 import { randomBytes } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { buildSignedEnvelope, derivePublicKey, generateKeypair, signChallenge } from "./crypto.js";
+import { normalizeTokenExpiresAt } from "./credentials.js";
 import { normalizeAndValidateHubUrl } from "./hub-url.js";
 import type {
   BotCordMessageEnvelope,
@@ -64,7 +65,7 @@ export class BotCordClient {
     this.privateKey = config.privateKey;
     if (config.token) {
       this.jwtToken = config.token;
-      this.tokenExpiresAt = config.tokenExpiresAt ?? 0;
+      this.tokenExpiresAt = normalizeTokenExpiresAt(config.tokenExpiresAt) ?? 0;
     }
   }
 
@@ -115,7 +116,7 @@ export class BotCordClient {
   // ── Authenticated fetch with rate-limit retry ─────────────────
 
   private async hubFetch(path: string, init: RequestInit = {}): Promise<Response> {
-    const token = await this.ensureToken();
+    let token = await this.ensureToken();
 
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
       const headers: Record<string, string> = {
@@ -135,7 +136,7 @@ export class BotCordClient {
       if (resp.ok) return resp;
 
       if (resp.status === 401 && attempt === 0) {
-        await this.refreshToken();
+        token = await this.refreshToken();
         continue;
       }
 

--- a/packages/protocol-core/src/control-frame.ts
+++ b/packages/protocol-core/src/control-frame.ts
@@ -222,6 +222,7 @@ export interface ProvisionAgentParams {
     privateKey: string;
     publicKey?: string;
     token?: string;
+    /** Unix timestamp in seconds. Daemons normalize older millisecond values. */
     tokenExpiresAt?: number;
     hubUrl?: string;
     displayName?: string;

--- a/packages/protocol-core/src/credentials.ts
+++ b/packages/protocol-core/src/credentials.ts
@@ -61,6 +61,16 @@ function normalizeCredentialValue(raw: any, keys: string[]): string | undefined 
   return undefined;
 }
 
+const TOKEN_EXPIRES_AT_MILLISECONDS_THRESHOLD = 10_000_000_000;
+
+export function normalizeTokenExpiresAt(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  if (value > TOKEN_EXPIRES_AT_MILLISECONDS_THRESHOLD) {
+    return Math.floor(value / 1000);
+  }
+  return value;
+}
+
 export function resolveCredentialsFilePath(credentialsFile: string): string {
   if (credentialsFile === "~") return os.homedir();
   if (credentialsFile.startsWith("~/")) {
@@ -95,11 +105,9 @@ export function loadStoredCredentials(credentialsFile: string): StoredBotCordCre
   const displayName = normalizeCredentialValue(raw, ["displayName", "display_name"]);
   const savedAt = normalizeCredentialValue(raw, ["savedAt", "saved_at"]);
   const token = normalizeCredentialValue(raw, ["token"]);
-  const tokenExpiresAt = typeof raw.tokenExpiresAt === "number"
-    ? raw.tokenExpiresAt
-    : typeof raw.token_expires_at === "number"
-      ? raw.token_expires_at
-      : undefined;
+  const tokenExpiresAt = normalizeTokenExpiresAt(
+    typeof raw.tokenExpiresAt === "number" ? raw.tokenExpiresAt : raw.token_expires_at,
+  );
 
   if (!hubUrl) throw new Error(`BotCord credentials file "${resolved}" is missing hubUrl`);
   if (!agentId) throw new Error(`BotCord credentials file "${resolved}" is missing agentId`);


### PR DESCRIPTION
## Summary
- send daemon provisioning tokenExpiresAt as Unix seconds from both local and cloud agent paths
- normalize legacy millisecond tokenExpiresAt values when loading/writing daemon credentials
- retry REST 401s with the newly refreshed agent token

## Verification
- cd backend && uv run pytest tests/test_cloud_agent_token_expiry.py tests/test_cloud_agent_provisioning.py::test_provision_pending_dispatches_provision_agent_and_marks_ready tests/test_app/test_agent_provision.py::test_provision_happy_path_writes_runtime_and_dispatches_frame
- cd packages/protocol-core && npm test -- src/__tests__/client.test.ts src/__tests__/credentials.test.ts
- cd packages/protocol-core && npm run build
- cd packages/daemon && npm test -- src/__tests__/provision.test.ts
- cd packages/daemon && npm run build

## Risk / rollout
- Existing credentials with millisecond tokenExpiresAt are normalized on load; refreshed tokens are persisted in seconds.
- Daemons should be restarted or upgraded to pick up the protocol-core retry/normalization fix.