### PR TITLE
feat: prefetch message room cache

### DIFF
--- a/frontend/src/components/dashboard/RoomList.tsx
+++ b/frontend/src/components/dashboard/RoomList.tsx
@@ -215,7 +215,18 @@ export default function RoomList({
     setFocusedRoomId(room.room_id);
     setOpenedRoomId(room.room_id);
     closeMobileSidebar();
+    const chatStore = useDashboardChatStore.getState();
+    if (Object.prototype.hasOwnProperty.call(chatStore.messages, room.room_id)) {
+      void chatStore.pollNewMessages(room.room_id);
+    } else {
+      void chatStore.loadRoomMessages(room.room_id);
+    }
     router.push("/chats/messages");
+  };
+
+  const prefetchRoom = (room: DashboardRoom) => {
+    if (isOwnerChatRoom(room.room_id)) return;
+    void useDashboardChatStore.getState().prefetchRoomMessages(room.room_id);
   };
 
   const handleRoomKeyDown = (event: React.KeyboardEvent<HTMLDivElement>, room: DashboardRoom) => {
@@ -362,6 +373,8 @@ export default function RoomList({
             aria-label={`Open room ${displayName}`}
             aria-current={isSelected ? "page" : undefined}
             onClick={() => void handleSelect(room)}
+            onMouseEnter={() => prefetchRoom(room)}
+            onFocus={() => prefetchRoom(room)}
             onKeyDown={(event) => handleRoomKeyDown(event, room)}
             className={`w-full border-l-2 px-4 py-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-cyan/60 ${
               isSelected

--- a/frontend/src/components/dashboard/sidebar/MessagesPanel.tsx
+++ b/frontend/src/components/dashboard/sidebar/MessagesPanel.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { startTransition, useMemo, useState } from "react";
+import { startTransition, useEffect, useMemo, useState } from "react";
 // messagesFilter is in useDashboardUIStore so ChatPane can also read it.
 import { useRouter } from "nextjs-toploader/app";
 import { useLanguage } from "@/lib/i18n";
 import { sidebar } from "@/lib/i18n/translations/dashboard";
 import { useShallow } from "zustand/react/shallow";
-import { buildVisibleMessageRooms } from "@/store/dashboard-shared";
+import { buildVisibleMessageRooms, isOwnerChatRoom } from "@/store/dashboard-shared";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
@@ -24,6 +24,16 @@ interface MessagesPanelProps {
   isGuest: boolean;
   onCreateRoom: () => void;
   onAddFriend: () => void;
+}
+
+const PREFETCH_VISIBLE_ROOM_LIMIT = 6;
+
+function rankPrefetchRooms(a: DashboardRoom, b: DashboardRoom): number {
+  const unreadDelta = Number(Boolean(b.has_unread)) - Number(Boolean(a.has_unread));
+  if (unreadDelta !== 0) return unreadDelta;
+  const bTime = b.last_message_at ? Date.parse(b.last_message_at) : 0;
+  const aTime = a.last_message_at ? Date.parse(a.last_message_at) : 0;
+  return (Number.isNaN(bTime) ? 0 : bTime) - (Number.isNaN(aTime) ? 0 : aTime);
 }
 
 export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: MessagesPanelProps) {
@@ -112,10 +122,41 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
     });
   }, [messages, normalizedMessageQuery, categorizedRooms]);
 
-  // (filter chips moved into MessagesGroupingSidebar as expandable children)
-
   const showOverviewSkeleton = sessionMode === "authed-ready" && !overview && sidebarTab === "messages";
   const showRoomListSkeleton = showOverviewSkeleton;
+
+  useEffect(() => {
+    if (isGuest || sidebarTab !== "messages" || showOverviewSkeleton) return;
+    if (messagesShowRequests || messagesPane === "user-chat") return;
+
+    const candidateRooms = (normalizedMessageQuery ? filteredMessageRooms : categorizedRooms)
+      .filter((room) => !isOwnerChatRoom(room.room_id) && (room.last_message_at || room.has_unread))
+      .slice()
+      .sort(rankPrefetchRooms)
+      .slice(0, PREFETCH_VISIBLE_ROOM_LIMIT);
+
+    if (candidateRooms.length === 0) return;
+
+    const timer = window.setTimeout(() => {
+      const { prefetchRoomMessages } = useDashboardChatStore.getState();
+      for (const room of candidateRooms) {
+        void prefetchRoomMessages(room.room_id);
+      }
+    }, 250);
+
+    return () => window.clearTimeout(timer);
+  }, [
+    categorizedRooms,
+    filteredMessageRooms,
+    isGuest,
+    messagesPane,
+    messagesShowRequests,
+    normalizedMessageQuery,
+    showOverviewSkeleton,
+    sidebarTab,
+  ]);
+
+  // (filter chips moved into MessagesGroupingSidebar as expandable children)
 
   // When the search toggles off, clear the query so the room list isn't accidentally
   // left filtered behind the scenes.

--- a/frontend/src/store/useDashboardChatStore.test.ts
+++ b/frontend/src/store/useDashboardChatStore.test.ts
@@ -136,6 +136,16 @@ describe("useDashboardChatStore message polling", () => {
     expect(mocks.getRoomMessages).toHaveBeenCalledTimes(2);
   });
 
+  it("prefetches messages only when a room has no cached page", async () => {
+    mocks.getRoomMessages.mockResolvedValue({ messages: [], has_more: false });
+
+    await useDashboardChatStore.getState().prefetchRoomMessages("rm_empty");
+    await useDashboardChatStore.getState().prefetchRoomMessages("rm_empty");
+
+    expect(mocks.getRoomMessages).toHaveBeenCalledTimes(1);
+    expect(useDashboardChatStore.getState().messages.rm_empty).toEqual([]);
+  });
+
   it("clears the opened room and cached messages after leaving the current room", async () => {
     const overviewAfterLeave = { ...makeOverview(), rooms: [] };
     mocks.leaveRoom.mockResolvedValue(undefined);

--- a/frontend/src/store/useDashboardChatStore.ts
+++ b/frontend/src/store/useDashboardChatStore.ts
@@ -237,6 +237,7 @@ interface DashboardChatState {
 
   insertMessage: (roomId: string, message: DashboardMessage) => void;
   loadRoomMessages: (roomId: string, opts?: { force?: boolean }) => Promise<void>;
+  prefetchRoomMessages: (roomId: string) => Promise<void>;
   pollNewMessages: (roomId: string, opts?: { expectedHubMsgId?: string | null; retries?: number }) => Promise<void>;
   loadMoreMessages: (roomId: string) => Promise<void>;
   loadRoomMembers: (roomId: string, opts?: { force?: boolean }) => Promise<PublicRoomMember[]>;
@@ -525,6 +526,13 @@ export const useDashboardChatStore = create<DashboardChatState>()(
             void get().loadRoomMessages(roomId, { force: true });
           }
         }
+      },
+
+      prefetchRoomMessages: async (roomId: string) => {
+        const state = get();
+        if (Object.prototype.hasOwnProperty.call(state.messages, roomId)) return;
+        if (state.messagesLoading[roomId] || roomMessagesInFlight.has(roomId)) return;
+        await get().loadRoomMessages(roomId);
       },
 
       pollNewMessages: async (roomId: string, opts) => {


### PR DESCRIPTION
## Summary
- add a store-level room message prefetch action that skips cached and in-flight rooms
- prefetch a small ranked set of recent/unread message rooms after the Messages panel settles
- warm a room on hover/focus and revalidate cached rooms on click

## Verification
- npm run test -- useDashboardChatStore.test.ts
- NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build

## Risk / rollout
- Limits automatic prefetch to six recent/unread rooms and skips owner-chat pseudo rooms to avoid broad request fan-out.
