### PR TITLE
fix: enforce cloud daemon singleton safety

### DIFF
--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -1773,6 +1773,17 @@ class CloudDaemonInstance(Base):
             name="ck_cloud_daemon_instances_active_agent_count",
         ),
         UniqueConstraint("daemon_instance_id", name="uq_cloud_daemon_instances_daemon_instance_id"),
+        Index(
+            "uq_cloud_daemon_instances_user_active",
+            "user_id",
+            unique=True,
+            postgresql_where=sa_text(
+                "status IN ('creating', 'starting', 'ready', 'paused')"
+            ),
+            sqlite_where=sa_text(
+                "status IN ('creating', 'starting', 'ready', 'paused')"
+            ),
+        ),
         Index("ix_cloud_daemon_instances_user", "user_id"),
         Index("ix_cloud_daemon_instances_status", "status"),
     )

--- a/backend/hub/services/cloud_agent.py
+++ b/backend/hub/services/cloud_agent.py
@@ -200,6 +200,7 @@ class CloudAgentUsageView:
 # Cap on the prompt so a misuse doesn't fill the column / blow the
 # envelope wire size. Generous default — model context is the real cap.
 _RUN_PROMPT_MAX_CHARS = 64 * 1024
+_ACTIVE_CLOUD_DAEMON_STATUSES = ("creating", "starting", "ready", "paused")
 
 
 def _now() -> datetime.datetime:
@@ -604,6 +605,7 @@ class CloudAgentService:
         user_id: uuid.UUID,
         agent_id: str,
     ) -> CloudAgentView:
+        await _lock_cloud_daemon_lifecycle(db, user_id)
         cai, agent, cdi = await self._load_owned(db, user_id=user_id, agent_id=agent_id)
         if cai.status in {"deleted", "deleting"}:
             raise CloudAgentError(
@@ -626,6 +628,11 @@ class CloudAgentService:
 
         provider = self._get_provider()
         if cdi.status != "ready" or not daemon_online:
+            await _ensure_no_other_active_cloud_daemon(
+                db,
+                user_id=user_id,
+                cloud_daemon_instance_id=cdi.id,
+            )
             if not daemon_online:
                 _ensure_provisioning_metadata(db, cai, agent)
                 cai.status = "provisioning"
@@ -718,6 +725,7 @@ class CloudAgentService:
         marked for reprovisioning before the provider relaunches the process.
         """
         self._require_feature_enabled()
+        await _lock_cloud_daemon_lifecycle(db, user_id)
         row = (
             await db.execute(
                 select(CloudDaemonInstance, DaemonInstance)
@@ -751,6 +759,11 @@ class CloudAgentService:
                 "cannot restart cloud daemon while a cloud agent run is active",
                 http_status=409,
             )
+        await _ensure_no_other_active_cloud_daemon(
+            db,
+            user_id=user_id,
+            cloud_daemon_instance_id=cdi.id,
+        )
 
         agent_rows = (
             await db.execute(
@@ -1584,20 +1597,14 @@ class CloudAgentService:
         this sandbox instead of creating a second per-runtime sandbox; the
         per-agent runtime is still recorded on ``cloud_agent_instances``.
         """
-        if db.bind is not None and db.bind.dialect.name == "postgresql":
-            await db.execute(
-                sa_text("SELECT pg_advisory_xact_lock(hashtext(:lock_key))"),
-                {"lock_key": f"cloud_agent_sandbox:{user_id}"},
-            )
+        await _lock_cloud_daemon_lifecycle(db, user_id)
         await self._enforce_per_user_quota(db, user_id)
 
         stmt = (
             select(CloudDaemonInstance)
             .where(
                 CloudDaemonInstance.user_id == user_id,
-                CloudDaemonInstance.status.in_(
-                    ("creating", "starting", "ready", "paused")
-                ),
+                CloudDaemonInstance.status.in_(_ACTIVE_CLOUD_DAEMON_STATUSES),
             )
             .order_by(CloudDaemonInstance.created_at.asc())
             .limit(1)
@@ -1684,6 +1691,47 @@ class CloudAgentService:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+async def _lock_cloud_daemon_lifecycle(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+) -> None:
+    """Serialize cloud daemon allocation/resume/restart per user on Postgres.
+
+    The transaction-scoped advisory lock closes the race where two independent
+    control paths both decide to relaunch the same sandbox. SQLite test runs
+    skip it because they do not support advisory locks.
+    """
+    if db.bind is None or db.bind.dialect.name != "postgresql":
+        return
+    await db.execute(
+        sa_text("SELECT pg_advisory_xact_lock(hashtext(:lock_key))"),
+        {"lock_key": f"cloud_agent_sandbox:{user_id}"},
+    )
+
+
+async def _ensure_no_other_active_cloud_daemon(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    cloud_daemon_instance_id: str,
+) -> None:
+    other = await db.scalar(
+        select(CloudDaemonInstance.id)
+        .where(
+            CloudDaemonInstance.user_id == user_id,
+            CloudDaemonInstance.id != cloud_daemon_instance_id,
+            CloudDaemonInstance.status.in_(_ACTIVE_CLOUD_DAEMON_STATUSES),
+        )
+        .limit(1)
+    )
+    if other is not None:
+        raise CloudAgentError(
+            "active_sandbox_exists",
+            "user already has another active cloud daemon sandbox",
+            http_status=409,
+        )
 
 
 async def _notify_inbox(agent_id: str, db: AsyncSession) -> int:

--- a/backend/migrations/018_cloud_daemon_active_user_unique.sql
+++ b/backend/migrations/018_cloud_daemon_active_user_unique.sql
@@ -1,0 +1,7 @@
+-- Enforce the product invariant: one active cloud daemon sandbox per user.
+-- Terminal/failed rows remain historical records and do not block creating a
+-- fresh active sandbox.
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_cloud_daemon_instances_user_active
+    ON cloud_daemon_instances (user_id)
+    WHERE status IN ('creating', 'starting', 'ready', 'paused');

--- a/packages/daemon/src/__tests__/daemon-singleton.test.ts
+++ b/packages/daemon/src/__tests__/daemon-singleton.test.ts
@@ -1,9 +1,10 @@
 import { spawn, type ChildProcess } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  acquireDaemonSingletonLock,
   ensureNoOtherDaemonFromPidFile,
   isBotCordDaemonStartCommand,
   parseDaemonProcesses,
@@ -77,6 +78,63 @@ describe("daemon singleton pid helpers", () => {
     expect(existsSync(pidPath)).toBe(false);
     await waitForExit(child);
     expect(child.exitCode === null && child.signalCode === null).toBe(false);
+  });
+
+  it("holds an atomic singleton lock until release", async () => {
+    const pidPath = path.join(tmpDir, "daemon.pid");
+    const lockPath = `${pidPath}.lock`;
+
+    const lock = await acquireDaemonSingletonLock({
+      pidPath,
+      lockPath,
+      currentPid: process.pid,
+    });
+
+    expect(existsSync(lockPath)).toBe(true);
+    expect(readPid(path.join(lockPath, "owner.pid"))).toBe(process.pid);
+
+    lock.release();
+
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("removes stale singleton locks", async () => {
+    const pidPath = path.join(tmpDir, "daemon.pid");
+    const lockPath = `${pidPath}.lock`;
+    mkdirSync(lockPath, { recursive: true });
+    writeCurrentPid({ pidPath: path.join(lockPath, "owner.pid"), currentPid: 99999999 });
+
+    const lock = await acquireDaemonSingletonLock({
+      pidPath,
+      lockPath,
+      currentPid: process.pid,
+    });
+
+    expect(readPid(path.join(lockPath, "owner.pid"))).toBe(process.pid);
+    lock.release();
+  });
+
+  it("terminates a live singleton lock owner before acquiring", async () => {
+    const pidPath = path.join(tmpDir, "daemon.pid");
+    const lockPath = `${pidPath}.lock`;
+    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      stdio: "ignore",
+    });
+    children.push(child);
+    await waitForPid(child);
+    mkdirSync(lockPath, { recursive: true });
+    writeCurrentPid({ pidPath: path.join(lockPath, "owner.pid"), currentPid: child.pid! });
+
+    const lock = await acquireDaemonSingletonLock({
+      pidPath,
+      lockPath,
+      currentPid: process.pid,
+    });
+
+    await waitForExit(child);
+    expect(child.exitCode === null && child.signalCode === null).toBe(false);
+    expect(readPid(path.join(lockPath, "owner.pid"))).toBe(process.pid);
+    lock.release();
   });
 
   it("removes stale pid files", () => {

--- a/packages/daemon/src/daemon-singleton.ts
+++ b/packages/daemon/src/daemon-singleton.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { PID_PATH } from "./config.js";
 
@@ -17,11 +17,27 @@ const noopLogger: SingletonLogger = {
   },
 };
 
+const DEFAULT_LOCK_WAIT_MS = 15_000;
+const DEFAULT_LOCK_RETRY_MS = 50;
+
+export interface DaemonSingletonLock {
+  lockPath: string;
+  release(): void;
+}
+
+export function defaultLockPath(pidPath = PID_PATH): string {
+  return `${pidPath}.lock`;
+}
+
 export function readPid(pidPath = PID_PATH): number | null {
   if (!existsSync(pidPath)) return null;
   const raw = readFileSync(pidPath, "utf8").trim();
   const pid = Number(raw);
   return Number.isFinite(pid) && pid > 0 ? pid : null;
+}
+
+function readLockOwner(lockPath: string): number | null {
+  return readPid(path.join(lockPath, "owner.pid"));
 }
 
 export function pidAlive(pid: number): boolean {
@@ -127,6 +143,78 @@ export async function stopDaemonFromPidFileForRestart(
   }
 }
 
+export async function acquireDaemonSingletonLock(
+  opts: {
+    lockPath?: string;
+    pidPath?: string;
+    currentPid?: number;
+    logger?: SingletonLogger;
+    timeoutMs?: number;
+  } = {},
+): Promise<DaemonSingletonLock> {
+  const pidPath = opts.pidPath ?? PID_PATH;
+  const lockPath = opts.lockPath ?? defaultLockPath(pidPath);
+  const currentPid = opts.currentPid ?? process.pid;
+  const logger = opts.logger ?? noopLogger;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_LOCK_WAIT_MS;
+  const deadline = Date.now() + timeoutMs;
+
+  ensureParentDir(lockPath);
+  while (true) {
+    try {
+      mkdirSync(lockPath, { mode: 0o700 });
+      writeFileSync(path.join(lockPath, "owner.pid"), String(currentPid), { mode: 0o600 });
+      return {
+        lockPath,
+        release() {
+          const owner = readLockOwner(lockPath);
+          if (owner !== null && owner !== currentPid) return;
+          try {
+            rmSync(lockPath, { recursive: true, force: true });
+          } catch {
+            // ignore
+          }
+        },
+      };
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "EEXIST") throw err;
+    }
+
+    const owner = readLockOwner(lockPath);
+    if (owner === currentPid) {
+      return {
+        lockPath,
+        release() {
+          try {
+            rmSync(lockPath, { recursive: true, force: true });
+          } catch {
+            // ignore
+          }
+        },
+      };
+    }
+    if (owner !== null && pidAlive(owner)) {
+      logger.info("daemon singleton lock owner found; restarting", { pid: owner });
+      await stopExistingDaemonForRestart(owner, { pidPath, currentPid, logger });
+    }
+
+    const refreshedOwner = readLockOwner(lockPath);
+    if (refreshedOwner === null || !pidAlive(refreshedOwner)) {
+      try {
+        rmSync(lockPath, { recursive: true, force: true });
+      } catch {
+        // another starter may have removed/recreated it
+      }
+    }
+
+    if (Date.now() >= deadline) {
+      throw new Error(`timed out acquiring daemon singleton lock at ${lockPath}`);
+    }
+    await delay(DEFAULT_LOCK_RETRY_MS);
+  }
+}
+
 export async function stopOtherDaemonProcessesForRestart(
   opts: {
     currentPid?: number;
@@ -187,11 +275,7 @@ export function writeCurrentPid(
   // Cloud-mode startup writes the PID file before `saveConfig` runs, so
   // the daemon dir may not exist yet. mkdir its parent (0700) so the
   // first write doesn't crash with ENOENT.
-  try {
-    mkdirSync(path.dirname(pidPath), { recursive: true, mode: 0o700 });
-  } catch {
-    // best-effort — writeFileSync below will surface the real error
-  }
+  ensureParentDir(pidPath);
   writeFileSync(pidPath, String(opts.currentPid ?? process.pid), { mode: 0o600 });
 }
 
@@ -230,4 +314,12 @@ export function isBotCordDaemonStartCommand(command: string): boolean {
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function ensureParentDir(filePath: string): void {
+  try {
+    mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  } catch {
+    // best-effort — the next filesystem operation will surface real errors
+  }
 }

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -17,6 +17,7 @@ import {
   type RouteRuleMatch,
 } from "./config.js";
 import {
+  acquireDaemonSingletonLock,
   ensureNoOtherDaemonFromPidFile,
   findOtherDaemonProcesses,
   pidAlive,
@@ -625,13 +626,22 @@ async function cmdStart(args: ParsedArgs): Promise<void> {
   }
 
   // Foreground: we ARE the daemon.
+  const singletonLock = await acquireDaemonSingletonLock({ logger: log });
   writeCurrentPid();
-  const handle = await startDaemon({ config: cfg, configPath: CONFIG_FILE_PATH });
+  let handle: Awaited<ReturnType<typeof startDaemon>>;
+  try {
+    handle = await startDaemon({ config: cfg, configPath: CONFIG_FILE_PATH });
+  } catch (err) {
+    removePidFile();
+    singletonLock.release();
+    throw err;
+  }
 
   const shutdown = async (sig: string) => {
     log.info("signal received", { sig });
     await handle.stop(sig);
     removePidFile();
+    singletonLock.release();
     process.exit(0);
   };
   process.on("SIGTERM", () => shutdown("SIGTERM"));
@@ -661,6 +671,7 @@ async function cmdStartCloud(_args: ParsedArgs): Promise<void> {
     daemonInstanceId: cloudConfig.daemonInstanceId,
     hubUrl: cloudConfig.hubUrl,
   });
+  const singletonLock = await acquireDaemonSingletonLock({ logger: log });
   await stopDaemonFromPidFileForRestart({ logger: log });
   await stopOtherDaemonProcessesForRestart({ logger: log });
   writeCurrentPid();
@@ -676,16 +687,24 @@ async function cmdStartCloud(_args: ParsedArgs): Promise<void> {
   saveConfig(cfg);
   log.info("cloud mode config initialized", { configPath: CONFIG_FILE_PATH });
 
-  const handle = await startCloudDaemon({
-    cloudConfig,
-    config: cfg,
-    configPath: CONFIG_FILE_PATH,
-  });
+  let handle: Awaited<ReturnType<typeof startCloudDaemon>>;
+  try {
+    handle = await startCloudDaemon({
+      cloudConfig,
+      config: cfg,
+      configPath: CONFIG_FILE_PATH,
+    });
+  } catch (err) {
+    removePidFile();
+    singletonLock.release();
+    throw err;
+  }
 
   const shutdown = async (sig: string): Promise<void> => {
     log.info("signal received", { sig });
     await handle.stop(sig);
     removePidFile();
+    singletonLock.release();
     process.exit(0);
   };
   process.on("SIGTERM", () => void shutdown("SIGTERM"));


### PR DESCRIPTION
## Summary
- add a DB-level partial unique index so each user can have only one active cloud daemon sandbox
- serialize cloud daemon allocate/resume/restart paths with the same Postgres advisory lock and return a controlled conflict when another active sandbox exists
- add an atomic daemon singleton lock held for the foreground/cloud daemon lifecycle, with stale/live-owner handling and tests

## Verification
- cd backend && uv run pytest tests/test_cloud_agent_service.py -q
- cd backend && uv run pytest tests/test_app/test_daemon_control.py -q
- cd packages/protocol-core && npm ci && npm run build
- cd packages/daemon && npm ci && npm test -- daemon-singleton
- cd packages/daemon && npm run build
- git diff --check

## Risk / rollout
- migration adds a partial unique index on active cloud daemon statuses; existing duplicate active rows for a user must be cleaned before applying in prod
- cloud daemon startup now keeps a lock directory next to the pid file and removes stale locks when the owner process is gone