### PR TITLE
fix: bump daemon protocol-core dependency

### DIFF
--- a/packages/daemon/package-lock.json
+++ b/packages/daemon/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@botcord/cli": "^0.1.7",
-        "@botcord/protocol-core": "^0.2.12",
+        "@botcord/protocol-core": "^0.2.13",
         "@larksuiteoapi/node-sdk": "^1.63.1",
         "ws": "^8.20.1"
       },
@@ -29,7 +29,7 @@
     },
     "../protocol-core": {
       "name": "@botcord/protocol-core",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@botcord/cli": "^0.1.7",
-    "@botcord/protocol-core": "^0.2.12",
+    "@botcord/protocol-core": "^0.2.13",
     "@larksuiteoapi/node-sdk": "^1.63.1",
     "ws": "^8.20.1"
   },

--- a/packages/daemon/pnpm-lock.yaml
+++ b/packages/daemon/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.1.7
         version: 0.1.9
       '@botcord/protocol-core':
-        specifier: ^0.2.2
-        version: 0.2.2
+        specifier: ^0.2.13
+        version: 0.2.13
       ws:
         specifier: ^8.18.0
         version: 8.20.0
@@ -38,8 +38,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@botcord/protocol-core@0.2.2':
-    resolution: {integrity: sha512-YNhyGCiC9r0zfwCGaJkB8uX25l2mJVp7TTnUU8OZtfQCjQskA+MMNjVMw+yGAM+40DKSdNpJ+f9IICQeZhMR2w==}
+  '@botcord/protocol-core@0.2.13':
+    resolution: {integrity: sha512-Q4Fz/DmDuCd5odgf2DY4cLmvoxpse7bkld4flC5USBAGGFgLmGmamiZxDmVnSH7GVJCS33vKS7hSjd8HuM0ZXw==}
     engines: {node: '>=18'}
 
   '@emnapi/core@1.10.0':
@@ -498,9 +498,9 @@ snapshots:
 
   '@botcord/cli@0.1.9':
     dependencies:
-      '@botcord/protocol-core': 0.2.2
+      '@botcord/protocol-core': 0.2.13
 
-  '@botcord/protocol-core@0.2.2': {}
+  '@botcord/protocol-core@0.2.13': {}
 
   '@emnapi/core@1.10.0':
     dependencies:


### PR DESCRIPTION
## Summary
- bump @botcord/daemon's @botcord/protocol-core dependency to ^0.2.13
- sync daemon npm and pnpm lockfiles to protocol-core 0.2.13

## Verification
- npm view @botcord/protocol-core version --json -> 0.2.13
- cd packages/protocol-core && npm install --ignore-scripts && npm run build
- cd packages/daemon && npm ci --ignore-scripts && npm install ../protocol-core --ignore-scripts --no-save --package-lock=false && npm run build
- cd packages/daemon && npm test (failed once: existing cloud-daemon.test.ts timeout)
- cd packages/daemon && npx vitest run src/__tests__/cloud-daemon.test.ts

## Risk / rollout
- dependency-only daemon package update; no runtime code changes