### PR TITLE
fix(ci): drop pnpm/action-setup version (use packageManager)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v5
-        with:
-          version: '9'
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -109,8 +107,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v5
-        with:
-          version: '9'
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -131,8 +127,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v5
-        with:
-          version: '9'
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -39,8 +39,6 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
 
       - uses: pnpm/action-setup@v5
-        with:
-          version: '9'
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -43,8 +43,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
-        with:
-          version: '9'
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

Fix CI breakage introduced by #826: `pnpm/action-setup@v5` errors when both `version:` and root `packageManager` are set.

Failed run: https://github.com/botlearn-ai/botcord/actions/runs/26501749849/job/78043700647

> Error: Multiple versions of pnpm specified:
>   - version 9 in the GitHub Action config with the key \"version\"
>   - version pnpm@9.15.4 in the package.json with the key \"packageManager\"

The root `package.json` now pins pnpm via `packageManager` field (canonical source for corepack + local dev). Removing the redundant `version: '9'` from each workflow's `pnpm/action-setup@v5` block.

Affects: `ci.yml`, `deploy-frontend.yml`, `release-packages.yml`.

## Test plan

- [ ] `Release Packages` workflow runs green on this PR
- [ ] `CI` workflow runs green
- [ ] `Deploy Frontend (preview)` runs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)