### PR TITLE
fix: lock gateway-ingress out of npm + guard release workflow

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -57,8 +57,38 @@ jobs:
       - name: Build packages
         run: pnpm -r --filter "./packages/*" --filter "./cli" build
 
+      # Guard against surprise auto-publish.
+      #
+      # changesets/action falls back to `changeset publish` whenever no
+      # pending changesets exist; that scans every workspace package and
+      # publishes anything whose local version is missing from npm — which
+      # silently first-published @botcord/gateway-ingress on the migration
+      # commit (see incident on 2026-05-27). Only run the action when
+      # either:
+      #   - pending changesets exist (→ open/update Version PR), OR
+      #   - this push merged the Version PR (→ publish bumped versions).
+      - name: Decide whether to run changesets action
+        id: decide
+        run: |
+          HAS_CHANGESETS=false
+          if ls .changeset/*.md 2>/dev/null | grep -v -E '/README\.md$' | grep -q .; then
+            HAS_CHANGESETS=true
+          fi
+          IS_RELEASE_COMMIT=false
+          if git log -1 --pretty=%s | grep -q "^chore(release): version packages"; then
+            IS_RELEASE_COMMIT=true
+          fi
+          if [ "$HAS_CHANGESETS" = "true" ] || [ "$IS_RELEASE_COMMIT" = "true" ]; then
+            echo "run=true" >> $GITHUB_OUTPUT
+          else
+            echo "run=false" >> $GITHUB_OUTPUT
+          fi
+          echo "has_changesets=$HAS_CHANGESETS" >> $GITHUB_OUTPUT
+          echo "is_release_commit=$IS_RELEASE_COMMIT" >> $GITHUB_OUTPUT
+
       - name: Create Release PR or Publish
         id: changesets
+        if: steps.decide.outputs.run == 'true'
         uses: changesets/action@v1
         with:
           version: pnpm exec changeset version

--- a/packages/gateway-ingress/package.json
+++ b/packages/gateway-ingress/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@botcord/gateway-ingress",
   "version": "0.1.0",
-  "description": "Always-on observer service that bridges third-party providers (Telegram / WeChat / Feishu) to Cloud Agents over a payload-opaque runtime WS — see docs/cloud-gateway-ingress-technical-design.md",
+  "private": true,
+  "description": "Always-on observer service that bridges third-party providers (Telegram / WeChat / Feishu) to Cloud Agents over a payload-opaque runtime WS — see docs/cloud-gateway-ingress-technical-design.md. Deployed as a Docker image — NOT published to npm.",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -16,23 +17,14 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "prepublishOnly": "tsc -p tsconfig.build.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "start": "node dist/cli.js"
   },
-  "files": [
-    "dist/",
-    "src/",
-    "README.md"
-  ],
   "engines": {
     "node": ">=18"
   },
   "license": "MIT",
-  "publishConfig": {
-    "access": "public"
-  },
   "dependencies": {
     "@botcord/protocol-core": "workspace:^",
     "@larksuiteoapi/node-sdk": "^1.63.1",


### PR DESCRIPTION
## Incident

The migration commit on main (#826) triggered `release-packages.yml`. With no changesets present, `changesets/action` fell into its "publish unpublished local versions" fallback path and silently first-published `@botcord/gateway-ingress@0.1.0` to npm — a server (docker container), not a library, never meant to be on npm.

That version has been unpublished out-of-band via `npm unpublish @botcord/gateway-ingress@0.1.0 --force`. The package name is locked from new publishes for 24h per npm policy.

## Fix (two layers, both needed)

### 1. `packages/gateway-ingress/package.json`: `private: true`

`pnpm publish` (and `changeset publish`) skip packages with `"private": true` unconditionally. This is the load-bearing fix — even if a workflow misfires again, npm won't accept it. Also drops `publishConfig`, `files`, `prepublishOnly` since they're meaningless for an unpublishable package.

### 2. `.github/workflows/release-packages.yml`: gate the action

Pre-check before invoking `changesets/action@v1`:
- pending changesets (`.changeset/*.md` excluding README) → run (opens/updates Version PR), OR
- last commit subject starts with `chore(release): version packages` → run (publishes the merged Version PR)

Any other push to main (a normal feature merge with no release intent) → skip. Prevents `changeset publish`'s opportunistic auto-publish path from running at all.

## Test plan

- [x] `pnpm --filter @botcord/gateway-ingress publish --dry-run` → "There are no new packages that should be published"
- [x] `pnpm --filter @botcord/gateway-ingress build` → ok
- [x] `pnpm --filter @botcord/gateway-ingress test` → 73/73
- [ ] After merge: `release-packages.yml` on this PR's merge commit should skip the changesets action entirely (decide.run=false, since no changesets and not a release commit)

## Notes

- The 24h republish lock on `@botcord/gateway-ingress` only applies if we tried to publish it again, which we won't.
- Other npm packages (cli, daemon, protocol-core) unchanged — they still go through the normal changesets release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)