### PR TITLE
fix: retry cloud gateway ingress wakeups

### DIFF
--- a/backend/hub/services/cloud_agent.py
+++ b/backend/hub/services/cloud_agent.py
@@ -201,6 +201,7 @@ class CloudAgentUsageView:
 # envelope wire size. Generous default — model context is the real cap.
 _RUN_PROMPT_MAX_CHARS = 64 * 1024
 _ACTIVE_CLOUD_DAEMON_STATUSES = ("creating", "starting", "ready", "paused")
+_RESUME_START_COALESCE_SECONDS = 30
 
 
 def _now() -> datetime.datetime:
@@ -231,6 +232,28 @@ def _cloud_agent_last_activity_at(
         _as_aware_utc(cdi.created_at),
     ]
     return max(ts for ts in candidates if ts is not None)
+
+
+def _cloud_daemon_start_requested_at(
+    cdi: CloudDaemonInstance,
+) -> datetime.datetime | None:
+    return _as_aware_utc(cdi.last_started_at) or _as_aware_utc(cdi.created_at)
+
+
+def _is_recent_inflight_start(
+    cdi: CloudDaemonInstance,
+    *,
+    now: datetime.datetime,
+) -> bool:
+    if cdi.status != "starting" or not cdi.provider_sandbox_id:
+        return False
+    started_at = _cloud_daemon_start_requested_at(cdi)
+    if started_at is None:
+        return False
+    return (
+        now - started_at
+        <= datetime.timedelta(seconds=_RESUME_START_COALESCE_SECONDS)
+    )
 
 
 def _placeholder_refresh_hash() -> str:
@@ -445,6 +468,8 @@ class CloudAgentService:
             ) from exc
 
         _apply_handle_to_rows(cloud_daemon, handle)
+        if handle.status == "starting":
+            cloud_daemon.last_started_at = _now()
         if handle.status == "ready":
             # Fake-provider shortcut: the in-memory provider stands in for
             # the full sandbox+WS dance, so we mark ready immediately and
@@ -633,6 +658,18 @@ class CloudAgentService:
                 user_id=user_id,
                 cloud_daemon_instance_id=cdi.id,
             )
+            if _is_recent_inflight_start(cdi, now=_now()):
+                _ensure_provisioning_metadata(db, cai, agent)
+                cai.status = "provisioning"
+                cai.error_code = None
+                cai.error_message = None
+                cdi.error_code = None
+                cdi.error_message = None
+                await db.commit()
+                await db.refresh(cai)
+                await db.refresh(cdi)
+                await db.refresh(agent)
+                return _make_view(agent, cai, cdi)
             if not daemon_online:
                 _ensure_provisioning_metadata(db, cai, agent)
                 cai.status = "provisioning"

--- a/backend/tests/test_cloud_agent_provisioning.py
+++ b/backend/tests/test_cloud_agent_provisioning.py
@@ -132,10 +132,14 @@ async def _ack_frame_when_sent(
     raise AssertionError("no frame was dispatched")
 
 
-def _make_e2b_service(*, max_agents_per_daemon: int = 2) -> CloudAgentService:
+def _make_e2b_service(
+    *,
+    client: FakeE2BSandboxClient | None = None,
+    max_agents_per_daemon: int = 2,
+) -> CloudAgentService:
     return CloudAgentService(
         provider=E2BCloudDaemonProvider(
-            client=FakeE2BSandboxClient(),
+            client=client or FakeE2BSandboxClient(),
             template_id="tpl_test",
             default_region="us-east-1",
             sandbox_timeout_seconds=120,
@@ -435,6 +439,48 @@ async def test_resume_ready_agent_offline_rotates_key_for_reprovision(db_session
     assert provisioning["private_key_b64"]
     assert provisioning["public_key_b64"]
     assert provisioning["key_id"]
+
+
+@pytest.mark.asyncio
+async def test_resume_while_starting_reuses_inflight_start(db_session):
+    client = FakeE2BSandboxClient()
+    service = _make_e2b_service(client=client)
+    user_id = uuid.uuid4()
+    view = await service.create_cloud_agent(
+        db_session, user_id=user_id, body=CreateCloudAgentInput(name="A")
+    )
+
+    conn, ws = await _register_fake_conn(view.cloud_daemon_instance_id, "dm_once")
+    try:
+        t = asyncio.create_task(
+            _ack_frame_when_sent(conn, ws, expected_type="provision_agent")
+        )
+        await service.provision_pending_for_cloud_daemon(
+            db_session, cloud_daemon_instance_id=view.cloud_daemon_instance_id
+        )
+        await t
+    finally:
+        await _registry_for_tests().unregister(conn)
+
+    sandbox_id = view.provider_sandbox_id
+    assert sandbox_id is not None
+    sandbox = client.get(sandbox_id)
+    assert sandbox is not None
+    assert len(sandbox.commands) == 1
+
+    first_resume = await service.resume_cloud_agent(
+        db_session, user_id=user_id, agent_id=view.agent_id
+    )
+    assert first_resume.status == "provisioning"
+    assert first_resume.cloud_daemon_status == "starting"
+    assert len(sandbox.commands) == 2
+
+    second_resume = await service.resume_cloud_agent(
+        db_session, user_id=user_id, agent_id=view.agent_id
+    )
+    assert second_resume.status == "provisioning"
+    assert second_resume.cloud_daemon_status == "starting"
+    assert len(sandbox.commands) == 2
 
 
 @pytest.mark.asyncio

--- a/packages/gateway-ingress/src/__tests__/fixtures.ts
+++ b/packages/gateway-ingress/src/__tests__/fixtures.ts
@@ -17,6 +17,7 @@ import { RUNTIME_SOCKET_STATE, type RuntimeSocketLike } from "../runtime/session
 
 export class FakeHubClient implements HubClient {
   ensureRunningCalls: { agentId: string; body: EnsureRunningRequest }[] = [];
+  getRuntimeCalls: { agentId: string; params: { gatewayId: string; eventId?: string } }[] = [];
   touchCalls: { agentId: string; body: TouchRuntimeRequest }[] = [];
   ensureResponse: (req: EnsureRunningRequest) => EnsureRunningResponse = () => ({
     agent_id: "ag_test",
@@ -24,6 +25,7 @@ export class FakeHubClient implements HubClient {
     cloud_daemon_instance_id: "cloud_dm_fake",
     runtime: this.defaultRuntime(),
   });
+  runtimeResponse?: (params: { gatewayId: string; eventId?: string }) => EnsureRunningResponse;
 
   defaultRuntime(): RuntimeSessionMetadata {
     return {
@@ -42,6 +44,8 @@ export class FakeHubClient implements HubClient {
   }
 
   async getRuntime(agentId: string, params: { gatewayId: string; eventId?: string }): Promise<EnsureRunningResponse> {
+    this.getRuntimeCalls.push({ agentId, params });
+    if (this.runtimeResponse) return this.runtimeResponse(params);
     return this.ensureResponse({
       gateway_id: params.gatewayId,
       reason: "manual_resume",

--- a/packages/gateway-ingress/src/__tests__/orchestrator.test.ts
+++ b/packages/gateway-ingress/src/__tests__/orchestrator.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { noopLogger } from "../log.js";
 import { IngressOrchestrator } from "../orchestrator.js";
+import { HubClientError } from "../hub-client.js";
 import { RuntimeSessionManager } from "../runtime/session.js";
 import { FileSystemIngressStore } from "../storage/store.js";
 import type { GatewayInboundMessage } from "@botcord/protocol-core";
@@ -185,10 +186,90 @@ describe("IngressOrchestrator", () => {
       cloud_daemon_instance_id: "cloud_dm_fake",
     });
     await h.orchestrator.ingest(CONN.id, NORMALIZED, "tg:gw:slow");
-    await waitFor(() => h.store.listEventsByStatus("queued").length === 1);
+    await waitFor(() => h.store.listEventsByStatus("queued")[0]?.attemptCount === 1);
     const e = h.store.listEventsByStatus("queued")[0]!;
     expect(e.attemptCount).toBe(1);
+    expect(e.nextAttemptAt).toBeGreaterThan(Date.now());
     expect(e.lastError).toContain("hub_status_provisioning");
+  });
+
+  it("retries a provisioning event by polling runtime metadata", async () => {
+    h.hub.ensureResponse = () => ({
+      agent_id: CONN.agentId,
+      status: "provisioning",
+      cloud_daemon_instance_id: "cloud_dm_fake",
+    });
+    await h.orchestrator.ingest(CONN.id, NORMALIZED, "tg:gw:retry-ready");
+    await waitFor(() => h.store.listEventsByStatus("queued")[0]?.attemptCount === 1);
+    const queued = h.store.listEventsByStatus("queued")[0]!;
+
+    h.hub.runtimeResponse = (params) => ({
+      agent_id: CONN.agentId,
+      status: "ready",
+      cloud_daemon_instance_id: "cloud_dm_fake",
+      runtime: {
+        ...h.hub.defaultRuntime(),
+        session_token: `tok_${params.eventId}`,
+      },
+    });
+
+    await h.orchestrator.retryPending({ force: true });
+    await waitFor(() => h.socketFactory.sockets.length === 1);
+    const sock = h.socketFactory.sockets[0]!;
+    await waitFor(() => sock.sent.length === 1);
+    const frame = JSON.parse(sock.sent[0]!) as GatewayInboundFrame;
+
+    expect(frame.event_id).toBe(queued.eventId);
+    expect(h.hub.ensureRunningCalls).toHaveLength(1);
+    expect(h.hub.getRuntimeCalls).toEqual([
+      {
+        agentId: CONN.agentId,
+        params: { gatewayId: CONN.id, eventId: queued.eventId },
+      },
+    ]);
+    expect(h.store.getEvent(queued.eventId)?.status).toBe("delivering");
+  });
+
+  it("uses runtime polling for new events while the agent is already provisioning", async () => {
+    h.hub.ensureResponse = () => ({
+      agent_id: CONN.agentId,
+      status: "provisioning",
+      cloud_daemon_instance_id: "cloud_dm_fake",
+    });
+    await h.orchestrator.ingest(CONN.id, NORMALIZED, "tg:gw:first-provisioning");
+    await waitFor(() => h.store.listEventsByStatus("queued")[0]?.attemptCount === 1);
+
+    h.hub.runtimeResponse = () => ({
+      agent_id: CONN.agentId,
+      status: "provisioning",
+      cloud_daemon_instance_id: "cloud_dm_fake",
+    });
+    await h.orchestrator.ingest(CONN.id, {
+      ...NORMALIZED,
+      id: "telegram:42:2",
+      text: "second while booting",
+    }, "tg:gw:second-provisioning");
+    await waitFor(() => h.store.listEventsByStatus("queued").length === 2);
+    await waitFor(() =>
+      h.store
+        .listEventsByStatus("queued")
+        .some((event) => event.providerEventId === "tg:gw:second-provisioning" && event.attemptCount === 1),
+    );
+
+    expect(h.hub.ensureRunningCalls).toHaveLength(1);
+    expect(h.hub.getRuntimeCalls).toHaveLength(1);
+    expect(h.hub.getRuntimeCalls[0]!.params.gatewayId).toBe(CONN.id);
+  });
+
+  it("marks non-retryable Hub lookup failures as failed", async () => {
+    h.hub.ensureResponse = () => {
+      throw new HubClientError(404, "not_found", "agent missing");
+    };
+    await h.orchestrator.ingest(CONN.id, NORMALIZED, "tg:gw:not-found");
+    await waitFor(() => h.store.listEventsByStatus("failed").length === 1);
+    const e = h.store.listEventsByStatus("failed")[0]!;
+    expect(e.lastError).toContain("ensure_running_failed: not_found");
+    expect(h.store.listEventsByStatus("queued")).toHaveLength(0);
   });
 
   it("e2e: ack → outbound complete → provider sent → delivered", async () => {

--- a/packages/gateway-ingress/src/orchestrator.ts
+++ b/packages/gateway-ingress/src/orchestrator.ts
@@ -9,7 +9,7 @@ import type {
 } from "@botcord/protocol-core";
 import { RUNTIME_FRAME_TYPES } from "@botcord/protocol-core";
 
-import type { HubClient } from "./hub-client.js";
+import { HubClientError, type HubClient } from "./hub-client.js";
 import type { IngressLogger } from "./log.js";
 import { RuntimeSessionManager } from "./runtime/session.js";
 import type { ProviderAdapter } from "./providers/types.js";
@@ -33,14 +33,28 @@ export interface OrchestratorOptions {
   runtime: RuntimeSessionManager;
   log: IngressLogger;
   dedupeCapacity?: number;
+  retryIntervalMs?: number;
+  retryBaseDelayMs?: number;
+  retryMaxDelayMs?: number;
   /**
    * Optional clock override for tests. Defaults to `Date.now`.
    */
   now?: () => number;
 }
 
+const DEFAULT_RETRY_INTERVAL_MS = 1000;
+const DEFAULT_RETRY_BASE_DELAY_MS = 1000;
+const DEFAULT_RETRY_MAX_DELAY_MS = 30_000;
+
 export class IngressOrchestrator {
   private readonly now: () => number;
+  private readonly retryBaseDelayMs: number;
+  private readonly retryMaxDelayMs: number;
+  private readonly retryIntervalMs: number;
+  private retryTimer: ReturnType<typeof setInterval> | null = null;
+  private retryRunning = false;
+  private readonly dispatchingEvents = new Set<string>();
+  private readonly ensureRunningByAgent = new Map<string, Promise<EnsureRunningResponse>>();
   /** Track provider adapters so we can call their `send()` for outbound. */
   private readonly providers = new Map<string, ProviderAdapter>();
   /** Pending acks keyed by event id. */
@@ -51,6 +65,9 @@ export class IngressOrchestrator {
 
   constructor(private readonly opts: OrchestratorOptions) {
     this.now = opts.now ?? (() => Date.now());
+    this.retryIntervalMs = opts.retryIntervalMs ?? DEFAULT_RETRY_INTERVAL_MS;
+    this.retryBaseDelayMs = opts.retryBaseDelayMs ?? DEFAULT_RETRY_BASE_DELAY_MS;
+    this.retryMaxDelayMs = opts.retryMaxDelayMs ?? DEFAULT_RETRY_MAX_DELAY_MS;
   }
 
   // -------------------------------------------------------------------
@@ -129,82 +146,193 @@ export class IngressOrchestrator {
   /**
    * Resume queued events that were left in `queued` / `delivering` on
    * boot. Each event triggers a fresh ensure-running + runtime delivery
-   * attempt. Failures move the event to `failed` after a single retry.
+   * attempt. Retryable failures stay queued with backoff.
    */
   async resumePending(): Promise<void> {
-    for (const event of this.opts.store.listEventsByStatus("queued", "delivering")) {
-      await this.dispatchEvent(event.eventId);
+    await this.retryPending({ force: true });
+  }
+
+  startRetryWorker(): void {
+    if (this.retryTimer) return;
+    this.retryTimer = setInterval(() => {
+      void this.retryPending().catch((err) => {
+        this.opts.log.error("retryPending failed", { err: String(err) });
+      });
+    }, this.retryIntervalMs);
+    this.retryTimer.unref?.();
+  }
+
+  stopRetryWorker(): void {
+    if (!this.retryTimer) return;
+    clearInterval(this.retryTimer);
+    this.retryTimer = null;
+  }
+
+  async retryPending(opts: { force?: boolean } = {}): Promise<number> {
+    if (this.retryRunning) return 0;
+    this.retryRunning = true;
+    let dispatched = 0;
+    try {
+      const now = this.now();
+      for (const event of this.opts.store.listEventsByStatus("queued", "delivering")) {
+        if (!opts.force && !this.isDue(event, now)) continue;
+        await this.dispatchEvent(event.eventId);
+        dispatched += 1;
+      }
+      return dispatched;
+    } finally {
+      this.retryRunning = false;
     }
   }
 
-  /**
-   * Core delivery path:
-   *
-   * 1. ensure-running (Hub API) — refreshes the sandbox + runtime
-   *    metadata.
-   * 2. Open / reuse the runtime WS session.
-   * 3. Send the `gateway_inbound` frame.
-   * 4. Wait for the daemon's `gateway_inbound_ack` and mark the event
-   *    as `delivering`. Outbound completion frames will move it
-   *    further along.
-   */
-  async dispatchEvent(eventId: string): Promise<void> {
+  private isDue(event: InboundEvent, now: number): boolean {
+    if (this.dispatchingEvents.has(event.eventId)) return false;
+    if (event.nextAttemptAt != null) return event.nextAttemptAt <= now;
+    if (event.attemptCount <= 0) return true;
+    return event.updatedAt + this.retryDelayMs(event.attemptCount) <= now;
+  }
+
+  private retryDelayMs(attemptCount: number): number {
+    const exponent = Math.max(0, Math.min(attemptCount - 1, 8));
+    return Math.min(this.retryMaxDelayMs, this.retryBaseDelayMs * 2 ** exponent);
+  }
+
+  private requeueEvent(event: InboundEvent, lastError: string): void {
+    const attemptCount = event.attemptCount + 1;
+    this.opts.store.updateEvent(event.eventId, {
+      status: "queued",
+      attemptCount,
+      nextAttemptAt: this.now() + this.retryDelayMs(attemptCount),
+      lastError,
+    });
+  }
+
+  private failEvent(eventId: string, lastError: string): void {
+    this.opts.store.updateEvent(eventId, {
+      status: "failed",
+      nextAttemptAt: null,
+      lastError,
+    });
+  }
+
+  private async ensureRunningForEvent(
+    connection: GatewayConnection,
+    event: InboundEvent,
+  ): Promise<EnsureRunningResponse> {
+    const existing = this.ensureRunningByAgent.get(connection.agentId);
+    if (existing) {
+      const first = await existing;
+      if (first.status === "ready") {
+        return this.opts.hub.getRuntime(connection.agentId, {
+          gatewayId: connection.id,
+          eventId: event.eventId,
+        });
+      }
+      return first;
+    }
+
+    const promise = this.opts.hub.ensureRunning(connection.agentId, {
+      gateway_id: connection.id,
+      reason: "third_party_inbound",
+      event_id: event.eventId,
+    });
+    this.ensureRunningByAgent.set(connection.agentId, promise);
+    try {
+      return await promise;
+    } finally {
+      if (this.ensureRunningByAgent.get(connection.agentId) === promise) {
+        this.ensureRunningByAgent.delete(connection.agentId);
+      }
+    }
+  }
+
+  private async resolveRuntimeMetadata(
+    connection: GatewayConnection,
+    event: InboundEvent,
+  ): Promise<EnsureRunningResponse> {
+    if (this.shouldPollRuntimeFirst(event)) {
+      const runtime = await this.opts.hub.getRuntime(connection.agentId, {
+        gatewayId: connection.id,
+        eventId: event.eventId,
+      });
+      if (runtime.status !== "paused") return runtime;
+    }
+    return this.ensureRunningForEvent(connection, event);
+  }
+
+  private shouldPollRuntimeFirst(event: InboundEvent): boolean {
+    if (event.lastError?.startsWith("hub_status_provisioning")) return true;
+    return this.opts.store
+      .listEventsByStatus("queued", "delivering")
+      .some(
+        (other) =>
+          other.eventId !== event.eventId &&
+          other.agentId === event.agentId &&
+          other.lastError?.startsWith("hub_status_provisioning"),
+      );
+  }
+
+  private shouldFailHubClientError(err: unknown): err is HubClientError {
+    return err instanceof HubClientError && (err.status === 404 || err.status === 409);
+  }
+
+  private hubErrorCode(err: unknown): string {
+    if (err instanceof HubClientError) return `${err.code || `http_${err.status}`}`;
+    return String(err);
+  }
+
+  private async dispatchEventLocked(eventId: string): Promise<void> {
     const event = this.opts.store.getEvent(eventId);
     if (!event) return;
-    if (event.status === "delivered") return;
+    if (
+      event.status === "delivered" ||
+      event.status === "failed" ||
+      event.status === "dead_letter"
+    ) {
+      return;
+    }
 
     const connection = this.opts.store.getConnection(event.gatewayId);
     if (!connection) {
-      this.opts.store.updateEvent(event.eventId, {
-        status: "failed",
-        lastError: "gateway_not_found",
-      });
+      this.failEvent(event.eventId, "gateway_not_found");
       return;
     }
 
     let runtimeMeta: RuntimeSessionMetadata | null = null;
     let cloudDaemonInstanceId: string | undefined;
     try {
-      const res = await this.opts.hub.ensureRunning(connection.agentId, {
-        gateway_id: connection.id,
-        reason: "third_party_inbound",
-        event_id: event.eventId,
-      });
+      const res = await this.resolveRuntimeMetadata(connection, event);
       ({ runtime: runtimeMeta = null, cloud_daemon_instance_id: cloudDaemonInstanceId } =
         res as EnsureRunningResponse & { runtime?: RuntimeSessionMetadata | null });
-      if (res.status === "failed") {
-        this.opts.store.updateEvent(event.eventId, {
-          status: "failed",
-          lastError: `hub_status_failed:${res.error?.code ?? "unknown"}`,
-        });
+      if (res.status === "failed" || res.status === "deleted") {
+        this.failEvent(
+          event.eventId,
+          res.status === "failed"
+            ? `hub_status_failed:${res.error?.code ?? "unknown"}`
+            : "hub_status_deleted",
+        );
         return;
       }
       if (res.status !== "ready" || !runtimeMeta) {
-        // Sandbox not ready yet — leave queued for the next pass.
-        this.opts.store.updateEvent(event.eventId, {
-          status: "queued",
-          attemptCount: event.attemptCount + 1,
-          lastError: `hub_status_${res.status}`,
-        });
+        // Sandbox not ready yet. Keep the durable event and let the retry worker
+        // poll `/runtime` instead of repeatedly kicking E2B start.
+        this.requeueEvent(event, `hub_status_${res.status}`);
         return;
       }
     } catch (err) {
-      this.opts.store.updateEvent(event.eventId, {
-        status: "queued",
-        attemptCount: event.attemptCount + 1,
-        lastError: `ensure_running_failed: ${String(err)}`,
-      });
+      const lastError = `ensure_running_failed: ${this.hubErrorCode(err)}`;
+      if (this.shouldFailHubClientError(err)) {
+        this.failEvent(event.eventId, lastError);
+        return;
+      }
+      this.requeueEvent(event, lastError);
       return;
     }
 
     try {
       await this.opts.runtime.ensureSession(connection.agentId, connection.id, runtimeMeta);
     } catch (err) {
-      this.opts.store.updateEvent(event.eventId, {
-        status: "queued",
-        attemptCount: event.attemptCount + 1,
-        lastError: `runtime_session_failed: ${String(err)}`,
-      });
+      this.requeueEvent(event, `runtime_session_failed: ${String(err)}`);
       return;
     }
 
@@ -238,15 +366,13 @@ export class IngressOrchestrator {
     this.opts.store.updateEvent(event.eventId, {
       status: "delivering",
       attemptCount: event.attemptCount + 1,
+      nextAttemptAt: null,
     });
 
     try {
       await this.opts.runtime.sendInbound(frame);
     } catch (err) {
-      this.opts.store.updateEvent(event.eventId, {
-        status: "queued",
-        lastError: `send_failed: ${String(err)}`,
-      });
+      this.requeueEvent(event, `send_failed: ${String(err)}`);
       return;
     }
 
@@ -256,6 +382,21 @@ export class IngressOrchestrator {
         eventId: event.eventId,
         cloudDaemonInstanceId,
       });
+    }
+  }
+
+  /**
+   * Drive one durable event through ensure-running → runtime delivery.
+   * Retryable failures stay queued with backoff unless the Hub reports a
+   * terminal agent/gateway state.
+   */
+  async dispatchEvent(eventId: string): Promise<void> {
+    if (this.dispatchingEvents.has(eventId)) return;
+    this.dispatchingEvents.add(eventId);
+    try {
+      await this.dispatchEventLocked(eventId);
+    } finally {
+      this.dispatchingEvents.delete(eventId);
     }
   }
 

--- a/packages/gateway-ingress/src/service.ts
+++ b/packages/gateway-ingress/src/service.ts
@@ -186,6 +186,7 @@ export async function buildIngressService(
     config: opts.config,
     log,
     async shutdown(reason = "shutdown"): Promise<void> {
+      orchestrator.stopRetryWorker();
       await runner.stopAll(reason);
       await runtime.closeAll(reason);
       await setup?.close();
@@ -199,8 +200,9 @@ export async function buildIngressService(
 /** Convenience: build + start providers + resume queue. */
 export async function startIngress(opts: BuildIngressOptions): Promise<IngressService> {
   const service = await buildIngressService(opts);
-  await service.orchestrator.resumePending();
   await service.runner.startAll();
+  await service.orchestrator.resumePending();
+  service.orchestrator.startRetryWorker();
   return service;
 }
 

--- a/packages/gateway-ingress/src/types.ts
+++ b/packages/gateway-ingress/src/types.ts
@@ -73,6 +73,7 @@ export interface InboundEvent {
   normalizedMessage: GatewayInboundMessage;
   status: InboundEventStatus;
   attemptCount: number;
+  nextAttemptAt?: number | null;
   lastError?: string | null;
   createdAt: number;
   updatedAt: number;


### PR DESCRIPTION
## Summary
- add gateway-ingress retry worker with backoff for queued/provisioning inbound events
- poll runtime metadata after provisioning instead of repeatedly calling ensure-running
- coalesce recent Hub resume attempts while an E2B sandbox is already starting

## Verification
- pnpm --filter @botcord/gateway-ingress build
- pnpm --filter @botcord/gateway-ingress exec vitest run --no-file-parallelism
- cd backend && uv run pytest tests/test_cloud_agent_provisioning.py -q
- cd backend && uv run pytest tests/test_app/test_cloud_agents.py -q
- git diff --check

## Risk / rollout
- Low-to-medium: changes retry timing and resume coalescing for cloud gateway ingress wakeups; rollout should restart gateway-ingress and Hub so the retry worker and resume guard are active.