### PR TITLE
fix: make Codex skill snapshots runtime-aware

### DIFF
--- a/packages/daemon/src/__tests__/skill-index.test.ts
+++ b/packages/daemon/src/__tests__/skill-index.test.ts
@@ -62,6 +62,45 @@ describe("skill snapshots", () => {
     expect(snapshot.probedAt).toBeGreaterThan(0);
   });
 
+  it("scans Codex .system skills and prefers Codex copies for Codex agents", () => {
+    const agentId = "ag_codex_system";
+    writeSkill(path.join(agentWorkspaceDir(agentId), ".claude", "skills"), "shared", "Claude copy");
+    writeSkill(path.join(agentCodexHomeDir(agentId), "skills"), "shared", "Codex copy");
+    writeSkill(
+      path.join(agentCodexHomeDir(agentId), "skills", ".system"),
+      "agent-system",
+      "Agent Codex system skill",
+    );
+    writeSkill(
+      path.join(tmpDir, ".codex", "skills", ".system"),
+      "imagegen",
+      "Codex global system skill",
+    );
+
+    const codexScanned = scanSoftSkills(agentId, { runtime: "codex" });
+    expect(codexScanned.map((s) => s.name).sort()).toEqual([
+      "agent-system",
+      "imagegen",
+      "shared",
+    ]);
+    expect(codexScanned.find((s) => s.name === "shared")).toMatchObject({
+      source: "agent-codex",
+      description: "Codex copy",
+    });
+
+    const claudeScanned = scanSoftSkills(agentId, { runtime: "claude-code" });
+    expect(claudeScanned.find((s) => s.name === "shared")).toMatchObject({
+      source: "agent-claude",
+      description: "Claude copy",
+    });
+
+    const snapshot = collectAgentSkillSnapshot(agentId, { runtime: "codex" });
+    expect(snapshot.skills.find((s) => s.name === "agent-system")?.source)
+      .toBe("workspace");
+    expect(snapshot.skills.find((s) => s.name === "imagegen")?.source)
+      .toBe("runtime-global");
+  });
+
   it("returns complete snapshots while keeping the prompt soft index capped", () => {
     const agentId = "ag_manyskills";
     const workspaceSkills = path.join(agentWorkspaceDir(agentId), ".claude", "skills");

--- a/packages/daemon/src/cloud-daemon.ts
+++ b/packages/daemon/src/cloud-daemon.ts
@@ -235,12 +235,15 @@ export async function startCloudDaemon(
   };
 
   const installedAgentIds = new Set<string>();
+  const runtimeByAgentId = new Map<string, string>();
   let controlChannel: ControlChannel | null = null;
   const pushInstalledAgentSkillSnapshot = (agentId: string, reason: string): void => {
     if (!controlChannel) return;
-    const pushed = pushAgentSkillSnapshot(controlChannel, agentId);
+    const runtime = runtimeByAgentId.get(agentId) ?? opts.config.defaultRoute.adapter;
+    const pushed = pushAgentSkillSnapshot(controlChannel, agentId, { runtime });
     logger.info("cloud control-channel: agent_skill_snapshot pushed", {
       agentId,
+      runtime,
       reason,
       ok: pushed,
     });
@@ -248,6 +251,7 @@ export async function startCloudDaemon(
 
   const onAgentInstalled: OnAgentInstalledHook = (info: InstalledAgentInfo) => {
     installedAgentIds.add(info.agentId);
+    if (info.runtime) runtimeByAgentId.set(info.agentId, info.runtime);
     credentialPathByAgentId.set(info.agentId, info.credentialsFile);
     if (info.hubUrl) hubUrlByAgentId.set(info.agentId, info.hubUrl);
     if (info.displayName) displayNameByAgent.set(info.agentId, info.displayName);

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -249,8 +249,9 @@ export function pushRuntimeSnapshot(
 export function pushAgentSkillSnapshot(
   sink: RuntimeSnapshotSink,
   agentId: string,
+  opts: { runtime?: string } = {},
 ): boolean {
-  const snap = collectAgentSkillSnapshot(agentId);
+  const snap = collectAgentSkillSnapshot(agentId, opts);
   const ok = sink.send({
     id: `skill_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
     type: "agent_skill_snapshot",
@@ -529,6 +530,12 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
     // next room-context fetch re-loads the BotCordClient against the new
     // credential file.
     credentialPathByAgentId.set(info.agentId, info.credentialsFile);
+    if (info.runtime) {
+      agentRuntimes[info.agentId] = {
+        ...(agentRuntimes[info.agentId] ?? {}),
+        runtime: info.runtime,
+      };
+    }
     if (info.hubUrl) hubUrlByAgentId.set(info.agentId, info.hubUrl);
     if (info.displayName) displayNameByAgent.set(info.agentId, info.displayName);
     if (!scBuilders.has(info.agentId)) {
@@ -670,9 +677,11 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
         ok: pushed,
       });
       for (const agentId of agentIds) {
-        const skillsPushed = pushAgentSkillSnapshot(controlChannel, agentId);
+        const runtime = agentRuntimes[agentId]?.runtime ?? opts.config.defaultRoute.adapter;
+        const skillsPushed = pushAgentSkillSnapshot(controlChannel, agentId, { runtime });
         logger.info("control-channel: initial agent_skill_snapshot push", {
           agentId,
+          runtime,
           ok: skillsPushed,
         });
       }

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -89,6 +89,12 @@ interface ListAgentSkillsParams {
   agentId: string;
 }
 
+function runtimeForLoadedAgent(gateway: Gateway, agentId: string): string | undefined {
+  return gateway.listManagedRoutes()
+    .find((route) => route.match?.accountId === agentId)
+    ?.runtime;
+}
+
 /**
  * Information passed to {@link OnAgentInstalledHook} after a successful
  * provision. Mirrors the credential fields the daemon's per-agent caches
@@ -510,9 +516,11 @@ export function createProvisioner(opts: ProvisionerOptions): (
             },
           };
         }
-        const result = collectAgentSkillSnapshot(params.agentId);
+        const runtime = runtimeForLoadedAgent(gateway, params.agentId);
+        const result = collectAgentSkillSnapshot(params.agentId, { runtime });
         daemonLog.debug("list_agent_skills", {
           agentId: params.agentId,
+          runtime,
           count: result.skills.length,
         });
         return { ok: true, result };

--- a/packages/daemon/src/skill-index.ts
+++ b/packages/daemon/src/skill-index.ts
@@ -39,6 +39,7 @@ export interface AgentSkillSnapshot {
 export interface SkillIndexOptions {
   extraDirs?: string[];
   includeGlobal?: boolean;
+  runtime?: string;
 }
 
 export function defaultSkillDirs(
@@ -46,21 +47,26 @@ export function defaultSkillDirs(
   opts: SkillIndexOptions = {},
 ): Array<{ dir: string; source: string }> {
   const includeGlobal = opts.includeGlobal !== false;
-  const dirs: Array<{ dir: string; source: string }> = [
-    {
-      dir: path.join(agentWorkspaceDir(agentId), ".claude", "skills"),
-      source: "agent-claude",
-    },
-    {
-      dir: path.join(agentCodexHomeDir(agentId), "skills"),
-      source: "agent-codex",
-    },
-  ];
+  const agentClaude = {
+    dir: path.join(agentWorkspaceDir(agentId), ".claude", "skills"),
+    source: "agent-claude",
+  };
+  const agentCodex = {
+    dir: path.join(agentCodexHomeDir(agentId), "skills"),
+    source: "agent-codex",
+  };
+  const dirs: Array<{ dir: string; source: string }> =
+    runtimeFamily(opts.runtime) === "codex"
+      ? [agentCodex, agentClaude]
+      : [agentClaude, agentCodex];
 
   if (includeGlobal) {
+    const globalClaude = { dir: path.join(homedir(), ".claude", "skills"), source: "global-claude" };
+    const globalCodex = { dir: path.join(homedir(), ".codex", "skills"), source: "global-codex" };
     dirs.push(
-      { dir: path.join(homedir(), ".claude", "skills"), source: "global-claude" },
-      { dir: path.join(homedir(), ".codex", "skills"), source: "global-codex" },
+      ...(runtimeFamily(opts.runtime) === "codex"
+        ? [globalCodex, globalClaude]
+        : [globalClaude, globalCodex]),
     );
   }
 
@@ -69,7 +75,7 @@ export function defaultSkillDirs(
     dirs.push({ dir, source: "external" });
   }
 
-  return dedupeDirs(dirs);
+  return dedupeDirs(expandSkillRoots(dirs));
 }
 
 export function scanSoftSkills(
@@ -111,7 +117,7 @@ export function scanSoftSkills(
         description: parsed.description,
         mtimeMs: st.mtimeMs,
       };
-      if (!existing || priority(root.source) < priority(existing.source)) {
+      if (!existing || priority(root.source, opts.runtime) < priority(existing.source, opts.runtime)) {
         byName.set(entry.name, entry);
       }
     }
@@ -224,7 +230,41 @@ function dedupeDirs(
   return out;
 }
 
-function priority(source: string): number {
+function expandSkillRoots(
+  dirs: Array<{ dir: string; source: string }>,
+): Array<{ dir: string; source: string }> {
+  const out: Array<{ dir: string; source: string }> = [];
+  for (const entry of dirs) {
+    out.push(entry);
+    if (entry.source.includes("codex")) {
+      out.push({ dir: path.join(entry.dir, ".system"), source: entry.source });
+    }
+  }
+  return out;
+}
+
+function runtimeFamily(runtime: string | undefined): "codex" | "claude" | "other" {
+  if (runtime === "codex") return "codex";
+  if (runtime === "claude-code") return "claude";
+  return "other";
+}
+
+function priority(source: string, runtime: string | undefined): number {
+  if (runtimeFamily(runtime) === "codex") {
+    switch (source) {
+      case "agent-codex":
+        return 0;
+      case "global-codex":
+        return 1;
+      case "agent-claude":
+        return 2;
+      case "global-claude":
+        return 3;
+      default:
+        return 4;
+    }
+  }
+
   switch (source) {
     case "agent-claude":
       return 0;


### PR DESCRIPTION
## Summary
- Include Codex `.system` skill directories in daemon skill snapshots.
- Pass agent runtime into snapshot generation so Codex agents prefer Codex skill roots over `.claude/skills`.
- Preserve runtime-aware behavior for local, cloud, and refresh-triggered skill snapshot paths.

## Verification
- `pnpm --filter @botcord/protocol-core build`
- `pnpm --filter @botcord/cli build`
- `pnpm --filter @botcord/daemon build`
- `pnpm --filter @botcord/daemon test -- src/__tests__/skill-index.test.ts`
- `pnpm --filter @botcord/daemon test -- src/__tests__/runtime-discovery.test.ts`
- `pnpm --filter @botcord/daemon test -- src/__tests__/cloud-daemon.test.ts`
- `pnpm --filter @botcord/daemon test -- src/__tests__/daemon.test.ts`
- `pnpm --filter @botcord/daemon test -- src/__tests__/provision.test.ts`
- `git diff --check`

## Risk / rollout
- Low daemon-only change. Existing snapshots refresh after daemon upgrade/restart or manual Skills refresh.
- Codex agents may now surface additional `.system` skills in the dashboard, matching Codex native discovery more closely.