### PR TITLE
fix: prevent duplicate cloud gateway replies

### DIFF
--- a/packages/gateway-ingress/src/__tests__/orchestrator.test.ts
+++ b/packages/gateway-ingress/src/__tests__/orchestrator.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { noopLogger } from "../log.js";
-import { IngressOrchestrator } from "../orchestrator.js";
+import { IngressOrchestrator, type OrchestratorOptions } from "../orchestrator.js";
 import { HubClientError } from "../hub-client.js";
 import { RuntimeSessionManager } from "../runtime/session.js";
 import { FileSystemIngressStore } from "../storage/store.js";
@@ -56,7 +56,12 @@ interface Harness {
   providerSends: { gatewayId: string; text: string; turnId?: string }[];
 }
 
-function makeHarness(): Harness {
+type HarnessOptions = Pick<
+  Partial<OrchestratorOptions>,
+  "retryBaseDelayMs" | "retryMaxDelayMs" | "retryIntervalMs" | "now"
+>;
+
+function makeHarness(options: HarnessOptions = {}): Harness {
   const dir = tmp();
   const store = new FileSystemIngressStore(dir);
   store.upsertConnection(CONN);
@@ -78,6 +83,7 @@ function makeHarness(): Harness {
     hub,
     runtime,
     log: noopLogger,
+    ...options,
   });
   const providerSends: Harness["providerSends"] = [];
   orchestrator.registerProvider({
@@ -134,6 +140,23 @@ describe("IngressOrchestrator", () => {
     const events = h.store.listEventsByStatus("delivering");
     expect(events).toHaveLength(1);
     expect(events[0]!.status).toBe("delivering");
+  });
+
+  it("does not retry an in-flight delivering event during the normal retry loop", async () => {
+    rmSync(h.dir, { recursive: true, force: true });
+    h = makeHarness({ retryBaseDelayMs: 0, retryMaxDelayMs: 0 });
+
+    await h.orchestrator.ingest(CONN.id, NORMALIZED, "tg:gw:in-flight");
+    await waitFor(() => h.socketFactory.sockets.length === 1);
+    const sock = h.socketFactory.sockets[0]!;
+    await waitFor(() => sock.sent.length === 1);
+
+    const dispatched = await h.orchestrator.retryPending();
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(dispatched).toBe(0);
+    expect(sock.sent).toHaveLength(1);
+    expect(h.hub.ensureRunningCalls).toHaveLength(1);
   });
 
   it("does not reuse a runtime WS across gateway token scopes", async () => {
@@ -311,6 +334,81 @@ describe("IngressOrchestrator", () => {
     // Touch was called after the outbound send.
     expect(h.hub.touchCalls).toHaveLength(1);
     expect(h.hub.touchCalls[0]!.body.gateway_id).toBe(CONN.id);
+  });
+
+  it("ignores duplicate outbound complete after an event is delivered", async () => {
+    await h.orchestrator.ingest(CONN.id, NORMALIZED, "tg:gw:dup-complete");
+    await waitFor(() => h.socketFactory.sockets.length === 1);
+    const sock = h.socketFactory.sockets[0]!;
+    await waitFor(() => sock.sent.length === 1);
+    const inboundFrame = JSON.parse(sock.sent[0]!) as GatewayInboundFrame;
+    const complete = {
+      type: RUNTIME_FRAME_TYPES.GATEWAY_OUTBOUND_COMPLETE,
+      event_id: inboundFrame.event_id,
+      turn_id: "turn_dup",
+      gateway_id: CONN.id,
+      agent_id: CONN.agentId,
+      conversation_id: NORMALIZED.conversation.id,
+      final_text: "only once",
+    } as const;
+
+    sock.incoming(complete);
+    await waitFor(() => h.store.listEventsByStatus("delivered").length === 1);
+    sock.incoming(complete);
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(h.providerSends).toHaveLength(1);
+    expect(h.providerSends[0]!.text).toBe("only once");
+  });
+
+  it("coalesces duplicate outbound complete while provider send is still running", async () => {
+    let sendCalls = 0;
+    let releaseSend: (() => void) | null = null;
+    let sendStarted: (() => void) | null = null;
+    const sendStartedPromise = new Promise<void>((resolve) => {
+      sendStarted = resolve;
+    });
+    const releaseSendPromise = new Promise<void>((resolve) => {
+      releaseSend = resolve;
+    });
+
+    h.orchestrator.registerProvider({
+      gatewayId: CONN.id,
+      provider: "telegram",
+      async start() {},
+      async stop() {},
+      async send() {
+        sendCalls += 1;
+        sendStarted?.();
+        await releaseSendPromise;
+        return { providerMessageId: "telegram:42:slow" };
+      },
+    });
+
+    await h.orchestrator.ingest(CONN.id, NORMALIZED, "tg:gw:complete-race");
+    await waitFor(() => h.socketFactory.sockets.length === 1);
+    const sock = h.socketFactory.sockets[0]!;
+    await waitFor(() => sock.sent.length === 1);
+    const inboundFrame = JSON.parse(sock.sent[0]!) as GatewayInboundFrame;
+    const complete = {
+      type: RUNTIME_FRAME_TYPES.GATEWAY_OUTBOUND_COMPLETE,
+      event_id: inboundFrame.event_id,
+      turn_id: "turn_race",
+      gateway_id: CONN.id,
+      agent_id: CONN.agentId,
+      conversation_id: NORMALIZED.conversation.id,
+      final_text: "slow send",
+    } as const;
+
+    sock.incoming(complete);
+    await sendStartedPromise;
+    sock.incoming(complete);
+    await new Promise((r) => setTimeout(r, 20));
+    expect(sendCalls).toBe(1);
+
+    releaseSend?.();
+    await waitFor(() => h.store.listEventsByStatus("delivered").length === 1);
+    expect(sendCalls).toBe(1);
   });
 
   it("requeues delivering events on runtime close", async () => {

--- a/packages/gateway-ingress/src/orchestrator.ts
+++ b/packages/gateway-ingress/src/orchestrator.ts
@@ -18,6 +18,7 @@ import type { GatewayInboundMessage } from "@botcord/protocol-core";
 import type {
   GatewayConnection,
   InboundEvent,
+  InboundEventStatus,
   OutboundSendRequest,
 } from "./types.js";
 
@@ -54,6 +55,7 @@ export class IngressOrchestrator {
   private retryTimer: ReturnType<typeof setInterval> | null = null;
   private retryRunning = false;
   private readonly dispatchingEvents = new Set<string>();
+  private readonly completingEvents = new Set<string>();
   private readonly ensureRunningByAgent = new Map<string, Promise<EnsureRunningResponse>>();
   /** Track provider adapters so we can call their `send()` for outbound. */
   private readonly providers = new Map<string, ProviderAdapter>();
@@ -174,7 +176,10 @@ export class IngressOrchestrator {
     let dispatched = 0;
     try {
       const now = this.now();
-      for (const event of this.opts.store.listEventsByStatus("queued", "delivering")) {
+      const statuses: InboundEventStatus[] = opts.force
+        ? ["queued", "delivering"]
+        : ["queued"];
+      for (const event of this.opts.store.listEventsByStatus(...statuses)) {
         if (!opts.force && !this.isDue(event, now)) continue;
         await this.dispatchEvent(event.eventId);
         dispatched += 1;
@@ -446,6 +451,25 @@ export class IngressOrchestrator {
         return;
       }
       case RUNTIME_FRAME_TYPES.GATEWAY_OUTBOUND_COMPLETE: {
+        const event = this.opts.store.getEvent(frame.event_id);
+        if (
+          event &&
+          (event.status === "delivered" ||
+            event.status === "failed" ||
+            event.status === "dead_letter")
+        ) {
+          this.opts.log.debug("outbound complete skipped — event already terminal", {
+            eventId: frame.event_id,
+            status: event.status,
+          });
+          return;
+        }
+        if (this.completingEvents.has(frame.event_id)) {
+          this.opts.log.debug("outbound complete skipped — send already in progress", {
+            eventId: frame.event_id,
+          });
+          return;
+        }
         const provider = this.providers.get(frame.gateway_id);
         if (!provider) {
           this.opts.log.error("no provider for outbound complete", {
@@ -472,6 +496,7 @@ export class IngressOrchestrator {
           final: true,
         };
 
+        this.completingEvents.add(frame.event_id);
         try {
           const result = await provider.send(sendRequest);
           this.opts.store.updateDelivery(delivery.deliveryId, {
@@ -500,6 +525,8 @@ export class IngressOrchestrator {
             status: "failed",
             lastError: `provider_send_failed: ${String(err)}`,
           });
+        } finally {
+          this.completingEvents.delete(frame.event_id);
         }
         return;
       }


### PR DESCRIPTION
## Summary
- stop the normal ingress retry worker from re-dispatching in-flight `delivering` events
- make outbound complete handling idempotent so duplicate runtime complete frames only send once
- add regression coverage for in-flight retry and duplicate complete frames

## Verification
- `pnpm exec vitest run src/__tests__/orchestrator.test.ts` (packages/gateway-ingress)
- `pnpm test` (packages/gateway-ingress)
- `pnpm --filter @botcord/protocol-core build`
- `pnpm build` (packages/gateway-ingress)

## Risk / rollout
- Low-risk gateway-ingress change; deployed ingress processes need restart/redeploy for the fix to take effect.
