### PR TITLE
fix(gateway-ingress): load Feishu app id from secret

### DIFF
--- a/packages/gateway-ingress/src/__tests__/feishu.test.ts
+++ b/packages/gateway-ingress/src/__tests__/feishu.test.ts
@@ -22,7 +22,11 @@ const conn: GatewayConnection = {
   updatedAt: 1,
 };
 
-function makeCtx(secret: Record<string, unknown>, abort: AbortController) {
+function makeCtx(
+  secret: Record<string, unknown>,
+  abort: AbortController,
+  connection: GatewayConnection = conn,
+) {
   const emits: { msg: GatewayInboundMessage; providerEventId: string }[] = [];
   const cursors: Record<string, unknown>[] = [];
   const activity: {
@@ -31,7 +35,7 @@ function makeCtx(secret: Record<string, unknown>, abort: AbortController) {
     lastError?: string | null;
   }[] = [];
   const ctx: ProviderRuntimeContext = {
-    connection: conn,
+    connection,
     secret,
     log: noopLogger,
     abortSignal: abort.signal,
@@ -124,6 +128,54 @@ function makeSdkOverride(opts: {
 }
 
 describe("Feishu provider adapter", () => {
+  it("loads appId from the secret store when setup-owned config omits it", async () => {
+    const finalizedConn: GatewayConnection = {
+      ...conn,
+      config: {
+        domain: "feishu",
+        allowedSenderIds: ["ou_alice"],
+        allowedChatIds: ["oc_chat"],
+      },
+    };
+    let clientArgs: Record<string, unknown> | null = null;
+    let wsArgs: Record<string, unknown> | null = null;
+    const harness = makeSdkOverride({ probeBotId: "ou_bot" });
+    const sdkOverride = {
+      ...harness.sdkOverride,
+      createClient(args: Record<string, unknown>) {
+        clientArgs = args;
+        return harness.sdkOverride.createClient(args);
+      },
+      createWsClient(args: Record<string, unknown>) {
+        wsArgs = args;
+        return harness.sdkOverride.createWsClient(args);
+      },
+    };
+    const provider = createFeishuProvider({
+      gatewayId: finalizedConn.id,
+      sdkOverride,
+    });
+    const abort = new AbortController();
+    const { ctx, activity } = makeCtx(
+      { appId: "cli_from_secret", appSecret: "shh" },
+      abort,
+      finalizedConn,
+    );
+
+    const running = provider.start(ctx);
+    const deadline = Date.now() + 1_000;
+    while (Date.now() < deadline && harness.wsStarted.length === 0) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+
+    abort.abort();
+    await running;
+
+    expect(clientArgs).toMatchObject({ appId: "cli_from_secret", appSecret: "shh" });
+    expect(wsArgs).toMatchObject({ appId: "cli_from_secret", appSecret: "shh" });
+    expect(activity.some((a) => a.lastError === "missing_credential")).toBe(false);
+  });
+
   it("probes botOpenId on start and normalizes a p2p message", async () => {
     const harness = makeSdkOverride({ probeBotId: "ou_bot" });
     const provider = createFeishuProvider({

--- a/packages/gateway-ingress/src/providers/feishu.ts
+++ b/packages/gateway-ingress/src/providers/feishu.ts
@@ -61,7 +61,9 @@ const TYPING_EMOJI = "Typing" as const;
 export type FeishuDomain = "feishu" | "lark";
 
 interface FeishuSecret {
+  appId?: string;
   appSecret?: string;
+  domain?: FeishuDomain;
 }
 
 interface FeishuConnectionConfig {
@@ -291,9 +293,9 @@ export function createFeishuProvider(opts: FeishuProviderOptions): ProviderAdapt
     activeCtx = ctx;
     const secret = ctx.secret as FeishuSecret;
     const config = ctx.connection.config as FeishuConnectionConfig;
-    appId = config.appId;
+    appId = config.appId ?? secret.appId;
     appSecret = secret.appSecret;
-    domain = config.domain;
+    domain = config.domain ?? secret.domain;
     if (config.splitAt && config.splitAt > 0) splitAt = config.splitAt;
     allowedSenderIds = new Set((config.allowedSenderIds ?? []).map(String));
     allowedChatIds = new Set((config.allowedChatIds ?? []).map(String));


### PR DESCRIPTION
## Summary
- Load Feishu appId/domain from the ingress secret payload when setup-owned connection config omits them.
- Add a Feishu provider regression test for finalized setup sessions whose config only contains safe metadata.

## Verification
- pnpm --filter @botcord/protocol-core build
- pnpm --filter @botcord/gateway-ingress build
- pnpm --filter @botcord/gateway-ingress test

## Risk / rollout
- Low risk; narrows credential resolution to match the existing setup-owned secret store contract.
- Preview gateway-ingress needs redeploy after merge for Feishu cloud gateways to recover.