### PR TITLE
fix: mark cloud gateways active after start

### DIFF
--- a/backend/app/routers/gateways.py
+++ b/backend/app/routers/gateways.py
@@ -596,6 +596,13 @@ async def _upsert_mirror_from_ingress(
         ingress_connection.get("status"),
         default="active" if enabled else "disabled",
     )
+    if (
+        status_value == "pending"
+        and enabled
+        and warning_message is None
+        and provider in ("telegram", "feishu")
+    ):
+        status_value = "active"
     # redactConnection() in ingress returns the live field name `config`;
     # older callers used `config_json`. Try both before falling back to
     # top-level metadata.

--- a/backend/migrations/020_backfill_cloud_gateway_active_status.sql
+++ b/backend/migrations/020_backfill_cloud_gateway_active_status.sql
@@ -1,0 +1,15 @@
+-- Cloud Telegram / Feishu setup used to leave successful enabled mirrors in
+-- `pending` even after gateway-ingress had registered the provider runner.
+-- Backfill those error-free cloud gateway rows so the dashboard stops showing
+-- "waiting" indefinitely for already-running gateways.
+
+UPDATE agent_gateway_connections AS agc
+SET status = 'active',
+    updated_at = now()
+FROM agents AS a
+WHERE agc.agent_id = a.agent_id
+  AND a.hosting_kind = 'cloud'
+  AND agc.provider IN ('telegram', 'feishu')
+  AND agc.enabled = TRUE
+  AND agc.status = 'pending'
+  AND agc.last_error IS NULL;

--- a/backend/tests/test_app/test_app_gateways.py
+++ b/backend/tests/test_app/test_app_gateways.py
@@ -602,7 +602,10 @@ async def test_create_telegram_for_cloud_agent_proxies_to_ingress(
                 "agent_id": "ag_cloud",
                 "user_id": str(seed["user_id"]),
                 "label": "cloud tg",
-                "status": "active",
+                # Old ingress builds returned pending even after the runner
+                # was registered. Hub should normalize the successful cloud
+                # mirror to active during mixed-version rollout.
+                "status": "pending",
                 "enabled": True,
                 "config_json": {
                     "allowedChatIds": ["111"],
@@ -653,6 +656,7 @@ async def test_create_telegram_for_cloud_agent_proxies_to_ingress(
         )
     )
     assert row is not None
+    assert row.status == "active"
     assert "botToken" not in (row.config_json or {})
     assert row.config_json.get("tokenPreview") == "1234...wxyz"
     # daemon_instance_id mirror falls back to the cloud agent's

--- a/packages/gateway-ingress/src/__tests__/setup-feishu.test.ts
+++ b/packages/gateway-ingress/src/__tests__/setup-feishu.test.ts
@@ -312,7 +312,7 @@ describe("setup-server — Feishu full flow", () => {
     };
     expect(connection.id).toMatch(/^gw_fs_/);
     expect(connection.provider).toBe("feishu");
-    expect(connection.status).toBe("pending");
+    expect(connection.status).toBe("active");
     expect(connection.enabled).toBe(true);
     expect(connection.config.domain).toBe("feishu");
     expect(connection.config.userOpenId).toBe(FAKE_OPEN_ID);

--- a/packages/gateway-ingress/src/__tests__/setup-runtime-ownership.test.ts
+++ b/packages/gateway-ingress/src/__tests__/setup-runtime-ownership.test.ts
@@ -597,8 +597,14 @@ describe("setup-server ↔ runner ownership (Phase 3)", () => {
   it("Telegram finalize happy-path starts the adapter", async () => {
     const res = await tgFinalize(h, "ag_tg_happy");
     expect(res.status).toBe(200);
-    const connection = res.body.connection as { id: string; enabled: boolean };
+    const connection = res.body.connection as {
+      id: string;
+      enabled: boolean;
+      status: string;
+    };
     expect(connection.enabled).toBe(true);
+    expect(connection.status).toBe("active");
+    expect(h.store.getConnection(connection.id)?.status).toBe("active");
     expect(h.runner.isRunning(connection.id)).toBe(true);
     expect(h.factories.telegram.starts).toEqual([connection.id]);
   });
@@ -606,8 +612,14 @@ describe("setup-server ↔ runner ownership (Phase 3)", () => {
   it("Feishu finalize happy-path starts the adapter", async () => {
     const res = await fsFinalize(h, "ag_fs_happy");
     expect(res.status).toBe(200);
-    const connection = res.body.connection as { id: string; enabled: boolean };
+    const connection = res.body.connection as {
+      id: string;
+      enabled: boolean;
+      status: string;
+    };
     expect(connection.enabled).toBe(true);
+    expect(connection.status).toBe("active");
+    expect(h.store.getConnection(connection.id)?.status).toBe("active");
     expect(h.runner.isRunning(connection.id)).toBe(true);
     expect(h.factories.feishu.starts).toEqual([connection.id]);
   });

--- a/packages/gateway-ingress/src/__tests__/setup-telegram.test.ts
+++ b/packages/gateway-ingress/src/__tests__/setup-telegram.test.ts
@@ -288,7 +288,7 @@ describe("telegram setup — full flow", () => {
     };
     expect(connection.provider).toBe("telegram");
     expect(connection.id).toMatch(/^gw_tg_/);
-    expect(connection.status).toBe("pending");
+    expect(connection.status).toBe("active");
     expect(connection.enabled).toBe(true);
     expect(connection.config.allowedChatIds).toEqual(["-500"]);
     expect(connection.config.allowedSenderIds).toEqual(["100", "101"]);

--- a/packages/gateway-ingress/src/provider-runner.ts
+++ b/packages/gateway-ingress/src/provider-runner.ts
@@ -73,7 +73,7 @@ export class ProviderRunner {
    * The setup-server uses this to mark `connection.status = "error"` and
    * attach a `warning.code = "adapter_start_failed"` on the HTTP response.
    */
-  async startOne(conn: GatewayConnection): Promise<void> {
+  async startOne(conn: GatewayConnection): Promise<GatewayConnection> {
     const existing = this.adapters.get(conn.id);
     if (existing) await this.stopOne(conn.id, "restart");
     const factory = this.providerFactories[conn.provider];
@@ -85,8 +85,12 @@ export class ProviderRunner {
     const secret = conn.secretRef
       ? this.opts.secrets.load(conn.secretRef) ?? {}
       : {};
+    const activeConn: GatewayConnection =
+      conn.enabled && conn.status !== "active"
+        ? { ...conn, status: "active", updatedAt: Date.now() }
+        : conn;
     const ctx: ProviderRuntimeContext = {
-      connection: conn,
+      connection: activeConn,
       secret: secret as Record<string, unknown>,
       log: this.opts.log,
       abortSignal: abort.signal,
@@ -102,6 +106,9 @@ export class ProviderRunner {
     };
     this.opts.orchestrator.registerProvider(adapter);
     this.adapters.set(conn.id, { adapter, abort });
+    if (activeConn !== conn) {
+      this.opts.store.upsertConnection(activeConn);
+    }
     // Run the adapter in the background; errors are logged but never
     // propagate back to the HTTP caller. The adapter is expected to
     // surface upstream failures via `markActivity({lastError})` so the
@@ -112,6 +119,7 @@ export class ProviderRunner {
         err: String(err),
       });
     });
+    return activeConn;
   }
 
   async stopOne(gatewayId: string, reason = "stop"): Promise<void> {

--- a/packages/gateway-ingress/src/setup/server.ts
+++ b/packages/gateway-ingress/src/setup/server.ts
@@ -530,8 +530,8 @@ async function tryStartConnection(
   conn: GatewayConnection,
 ): Promise<StartOutcome> {
   try {
-    await opts.runner.startOne(conn);
-    return { ok: true, connection: conn };
+    const activeConn = await opts.runner.startOne(conn);
+    return { ok: true, connection: activeConn };
   } catch (err) {
     const errStr = redact(String((err as Error)?.message ?? err));
     opts.log.error("runner.startOne failed", {


### PR DESCRIPTION
## Summary
- Mark enabled gateway-ingress connections active once the provider runner is registered.
- Return the active connection from setup finalize so Hub mirrors do not stay pending.
- Normalize mixed-version cloud Telegram/Feishu mirrors and backfill existing pending rows.

## Verification
- pnpm --filter @botcord/gateway-ingress test
- pnpm --filter @botcord/gateway-ingress build
- cd backend && uv run pytest tests/test_app/test_app_gateways.py -k create_telegram_for_cloud_agent_proxies_to_ingress

## Risk / rollout
- Includes an idempotent SQL backfill for enabled, error-free cloud Telegram/Feishu gateway rows currently stuck in pending.