### PR TITLE
fix(ci): ignore workspace when installing frontend deps

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -46,7 +46,11 @@ jobs:
           cache-dependency-path: frontend/pnpm-lock.yaml
 
       - name: Install deps
-        run: pnpm install --frozen-lockfile
+        # --ignore-workspace: frontend/ is intentionally NOT a pnpm workspace member
+        # (it has its own pnpm-lock.yaml and is deployed via Vercel). Without this
+        # flag, pnpm walks up to the repo-root pnpm-workspace.yaml and installs
+        # workspace members instead of frontend's own deps, leaving Next.js missing.
+        run: pnpm install --frozen-lockfile --ignore-workspace
 
       - name: Install Vercel CLI
         run: pnpm add -g vercel@latest


### PR DESCRIPTION
## Summary

After #826 (`3254b8830`) introduced `pnpm-workspace.yaml` at the repo root, `pnpm install --frozen-lockfile` inside `frontend/` started walking up to the workspace declaration and installing **workspace members only** (`cli` + `packages/*`) — frontend's own deps (including `next`) were silently skipped, and `vercel build` then failed with `No Next.js version detected`.

This broke today's prod release ([run 26555374130](https://github.com/botlearn-ai/botcord/actions/runs/26555374130)). It went undetected on preview only because no commit after #826 touched `frontend/**`, so `dorny/paths-filter` skipped the preview frontend job entirely.

Fix: add `--ignore-workspace` so `pnpm install` treats `frontend/` as a standalone project (which is what it actually is — it has its own `frontend/pnpm-lock.yaml` and is deployed via Vercel, not via the workspace's changesets flow).

## Test plan

- [x] Local: `cd frontend && pnpm install --frozen-lockfile --ignore-workspace` installs 329 packages including `next@16.1.7` (verified `frontend/node_modules/next/package.json`).
- [ ] CI: this PR's preview frontend deploy succeeds (touches `.github/workflows/deploy-frontend.yml` → triggers paths-filter).
- [ ] Re-trigger prod release from main after merge and confirm `Deploy Frontend (prod) / Vercel Deploy` step passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)