### PR TITLE
fix(ci): ignore workspace for remaining frontend pnpm installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,8 @@ jobs:
           node-version: '24'
           cache: 'pnpm'
           cache-dependency-path: frontend/pnpm-lock.yaml
-      - run: pnpm install --frozen-lockfile
+      # --ignore-workspace: frontend/ is not a workspace member; see deploy-frontend.yml.
+      - run: pnpm install --frozen-lockfile --ignore-workspace
       - name: Run vitest
         run: pnpm test -- --run
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
       - name: frontend tests
         working-directory: frontend
         run: |
-          pnpm install --frozen-lockfile
+          pnpm install --frozen-lockfile --ignore-workspace
           pnpm test -- --run
 
   # ── E2E tests (only when base_url is provided) ───────────────────────────────


### PR DESCRIPTION
## Summary

Follow-up to #837. That PR only fixed `deploy-frontend.yml`, but two more workflows hit the same workspace trap when running `pnpm install` from `frontend/`:

- `ci.yml` → `Frontend CI` (vitest) — failed today on main with `sh: line 1: vitest: command not found` ([run 26557248542](https://github.com/botlearn-ai/botcord/actions/runs/26557248542))
- `test.yml` → `Node Tests` — same shape, but only triggered manually so hasn't broken yet

Both add `--ignore-workspace` so `pnpm install` treats `frontend/` as a standalone project. `Packages CI` and `Gateway Ingress CI` are intentionally left in workspace mode since they use `pnpm --filter` against workspace members.

## Test plan

- [ ] This PR's `Frontend CI` job passes (touches `.github/workflows/ci.yml` → paths-filter triggers frontend job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)