### PR TITLE
fix(ci): release default 'both' now deploys gateway-ingress too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
         default: 'main'
         type: string
       targets:
-        description: 'What to deploy'
+        description: 'What to deploy (both/all = backend + frontend + gateway-ingress)'
         required: false
         default: 'both'
         type: choice
@@ -185,7 +185,7 @@ jobs:
     if: |
       always() &&
       needs.prepare.result == 'success' &&
-      (inputs.targets == 'all' || inputs.targets == 'gateway-ingress')
+      (inputs.targets == 'both' || inputs.targets == 'all' || inputs.targets == 'gateway-ingress')
     uses: ./.github/workflows/deploy-gateway-ingress.yml
     with:
       env_name: prod


### PR DESCRIPTION
## Summary
- `release.yml` default `targets=both` previously deployed only backend + frontend, silently skipping gateway-ingress on every prod release unless the operator remembered to switch to `all`.
- Treat `both` as a superset (backend + frontend + gateway-ingress), making it equivalent to `all`.
- Updated the input description to reflect the new semantics.

## Test plan
- [ ] Trigger workflow_dispatch with default `targets=both` and confirm `Deploy Gateway Ingress (prod)` now runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)