### PR TITLE
fix: restore DeepSeek and Kimi runtime logos

### DIFF
--- a/frontend/src/components/dashboard/BotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/BotDetailDrawer.tsx
@@ -562,7 +562,9 @@ type RuntimeLogoEntry =
 const RUNTIME_LOGO: Record<string, RuntimeLogoEntry> = {
   "claude-code": { kind: "img", src: "/runtime-logos/Claude.png", classes: "border-glass-border bg-glass-bg/40" },
   codex: { kind: "img", src: "/runtime-logos/Codex.png", classes: "border-glass-border bg-glass-bg/40" },
+  "deepseek-tui": { kind: "img", src: "/runtime-logos/Deepseek.png", classes: "border-glass-border bg-glass-bg/40" },
   gemini: { kind: "img", src: "/runtime-logos/Gemini.png", classes: "border-glass-border bg-glass-bg/40" },
+  "kimi-cli": { kind: "img", src: "/runtime-logos/Kimi.png", classes: "border-glass-border bg-glass-bg/40" },
   "openclaw-acp": { kind: "img", src: "/runtime-logos/Openclaw.png", classes: "border-glass-border bg-glass-bg/40" },
   qclaw: { kind: "img", src: "/runtime-logos/Qclaw.png", classes: "border-glass-border bg-glass-bg/40" },
   "hermes-agent": { kind: "img", src: "/runtime-logos/Hermes.png", classes: "border-glass-border bg-glass-bg/40" },

--- a/frontend/src/components/dashboard/CreateAgentDialog.tsx
+++ b/frontend/src/components/dashboard/CreateAgentDialog.tsx
@@ -1269,7 +1269,9 @@ type RuntimeLogoEntry =
 const RUNTIME_LOGO: Record<string, RuntimeLogoEntry> = {
   "claude-code": { kind: "img", src: "/runtime-logos/Claude.png", classes: "border-glass-border bg-glass-bg/40" },
   codex: { kind: "img", src: "/runtime-logos/Codex.png", classes: "border-glass-border bg-glass-bg/40" },
+  "deepseek-tui": { kind: "img", src: "/runtime-logos/Deepseek.png", classes: "border-glass-border bg-glass-bg/40" },
   gemini: { kind: "img", src: "/runtime-logos/Gemini.png", classes: "border-glass-border bg-glass-bg/40" },
+  "kimi-cli": { kind: "img", src: "/runtime-logos/Kimi.png", classes: "border-glass-border bg-glass-bg/40" },
   "openclaw-acp": { kind: "img", src: "/runtime-logos/Openclaw.png", classes: "border-glass-border bg-glass-bg/40" },
   qclaw: { kind: "img", src: "/runtime-logos/Qclaw.png", classes: "border-glass-border bg-glass-bg/40" },
   "hermes-agent": { kind: "img", src: "/runtime-logos/Hermes.png", classes: "border-glass-border bg-glass-bg/40" },


### PR DESCRIPTION
## Summary
- Map `deepseek-tui` to the existing Deepseek runtime logo.
- Map `kimi-cli` to the existing Kimi runtime logo in the create dialog and bot detail runtime chip.

## Verification
- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build`

## Risk / rollout
- Low risk: frontend-only runtime logo mapping change using existing static assets.
