### PR TITLE
fix: chunk activity stats batch requests

### DIFF
--- a/frontend/src/lib/api.activity-stats.test.ts
+++ b/frontend/src/lib/api.activity-stats.test.ts
@@ -1,0 +1,90 @@
+/**
+ * [INPUT]: vitest mock Supabase session + global.fetch
+ * [OUTPUT]: api activity stats batch client contract tests
+ * [POS]: frontend/lib API guard for dashboard activity stats batching
+ * [PROTOCOL]: update header on changes
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    auth: {
+      getSession: async () => ({
+        data: { session: { access_token: "test-access-token" } },
+      }),
+    },
+  }),
+}));
+
+function toUrl(input: string | URL | Request): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.toString();
+  return input.url;
+}
+
+describe("api.getActivityStatsBatch", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_HUB_BASE_URL = "https://api.example.test";
+    vi.resetModules();
+    fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = new URL(toUrl(input));
+      const agentIds = url.searchParams.get("agent_ids")?.split(",").filter(Boolean) ?? [];
+      const stats = Object.fromEntries(
+        agentIds.map((agentId) => [
+          agentId,
+          {
+            messages_sent: Number(agentId.replace("ag_", "")),
+            messages_received: 0,
+            topics_open: 0,
+            topics_completed: 0,
+            active_rooms: 0,
+          },
+        ]),
+      );
+
+      return new Response(JSON.stringify({ stats }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it("splits requests into backend-sized batches and merges the stats", async () => {
+    const { api } = await import("./api");
+    const agentIds = Array.from({ length: 25 }, (_, index) =>
+      `ag_${String(index + 1).padStart(2, "0")}`,
+    );
+
+    const result = await api.getActivityStatsBatch(agentIds, "7d");
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const urls = fetchMock.mock.calls.map(([input]) => new URL(toUrl(input as string | URL | Request)));
+    expect(urls.map((url) => url.searchParams.get("period"))).toEqual(["7d", "7d", "7d"]);
+    expect(urls.map((url) => url.searchParams.get("agent_ids")?.split(","))).toEqual([
+      agentIds.slice(0, 12),
+      agentIds.slice(12, 24),
+      agentIds.slice(24),
+    ]);
+    expect(new Headers((fetchMock.mock.calls[0][1] as RequestInit).headers).get("Authorization")).toBe(
+      "Bearer test-access-token",
+    );
+    expect(Object.keys(result.stats)).toEqual(agentIds);
+    expect(result.stats.ag_25.messages_sent).toBe(25);
+  });
+
+  it("returns an empty stats map without issuing a backend request", async () => {
+    const { api } = await import("./api");
+
+    await expect(api.getActivityStatsBatch(["", "  "], "7d")).resolves.toEqual({ stats: {} });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -94,6 +94,8 @@ const API_BASE =
 const ACTIVE_AGENT_KEY = "botcord_active_agent_id";
 const ACTIVE_IDENTITY_KEY = "botcord_active_identity";
 const ME_CACHE_TTL_MS = 10_000;
+const ACTIVITY_STATS_BATCH_AGENT_LIMIT = 12;
+const ACTIVITY_STATS_BATCH_REQUEST_CONCURRENCY = 3;
 
 export type ActiveIdentity =
   | { type: "human"; id: string }
@@ -171,6 +173,40 @@ function extractErrorMessage(body: Record<string, unknown>, fallback: string): s
     return detail.map((d: { msg?: string }) => d.msg ?? JSON.stringify(d)).join("; ");
   }
   return fallback;
+}
+
+function uniqueNonEmptyValues(values: string[]): string[] {
+  return Array.from(new Set(values.map((value) => value.trim()).filter(Boolean)));
+}
+
+function chunkValues<T>(values: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < values.length; index += size) {
+    chunks.push(values.slice(index, index + size));
+  }
+  return chunks;
+}
+
+async function mapWithConcurrency<T, R>(
+  values: T[],
+  concurrency: number,
+  mapper: (value: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(values.length);
+  let nextIndex = 0;
+  const workerCount = Math.min(concurrency, values.length);
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (nextIndex < values.length) {
+        const currentIndex = nextIndex;
+        nextIndex += 1;
+        results[currentIndex] = await mapper(values[currentIndex]);
+      }
+    }),
+  );
+
+  return results;
 }
 
 class ApiError extends Error {
@@ -887,14 +923,30 @@ export const api = {
     return apiGet<ActivityStats>("/api/dashboard/activity/stats", { period }, identityOverride);
   },
 
-  getActivityStatsBatch(
+  async getActivityStatsBatch(
     agentIds: string[],
     period: "today" | "7d" | "30d" = "today",
-  ) {
-    return apiGet<ActivityStatsBatchResponse>("/api/dashboard/activity/stats/batch", {
-      period,
-      agent_ids: agentIds.join(","),
+  ): Promise<ActivityStatsBatchResponse> {
+    const requestedIds = uniqueNonEmptyValues(agentIds);
+    if (requestedIds.length === 0) {
+      return { stats: {} };
+    }
+
+    const batches = chunkValues(requestedIds, ACTIVITY_STATS_BATCH_AGENT_LIMIT);
+    const responses = await mapWithConcurrency(
+      batches,
+      ACTIVITY_STATS_BATCH_REQUEST_CONCURRENCY,
+      (batch) =>
+        apiGet<ActivityStatsBatchResponse>("/api/dashboard/activity/stats/batch", {
+          period,
+          agent_ids: batch.join(","),
+        }),
+    );
+    const stats: Record<string, ActivityStats> = {};
+    responses.forEach((response) => {
+      Object.assign(stats, response.stats);
     });
+    return { stats };
   },
 
   getActivityFeed(opts?: { period?: string; limit?: number; offset?: number }) {


### PR DESCRIPTION
## Summary
- split dashboard activity stats batch requests into backend-sized groups of 12 agent ids
- cap client-side batch request concurrency at 3 and merge returned stats for callers
- add Vitest coverage for 25-agent chunking and empty input behavior

## Verification
- npm test -- --run src/lib/api.activity-stats.test.ts
- NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key npm run build

## Risk / rollout
- Low risk frontend API wrapper change; backend contract stays unchanged.
- Bare npm run build still requires Supabase env for /admin/codes prerendering.