### PR TITLE
feat(daemon): publish built-in Gemini model catalog

### DIFF
--- a/packages/daemon/src/__tests__/runtime-discovery.test.ts
+++ b/packages/daemon/src/__tests__/runtime-discovery.test.ts
@@ -147,11 +147,14 @@ describe("collectRuntimeSnapshot", () => {
   });
 
   it("omits optional fields rather than emitting explicit undefineds", () => {
+    // Use a synthetic runtime id with no catalog strategy so the snapshot
+    // doesn't pick up a `models` field. Switching to "gemini" here would
+    // attach the built-in gemini model list.
     setRuntimes([
       {
-        id: "gemini",
-        displayName: "Gemini",
-        binary: "gemini",
+        id: "unknown-runtime",
+        displayName: "Unknown",
+        binary: "unknown",
         supportsRun: true,
         result: { available: true },
       },

--- a/packages/daemon/src/__tests__/runtime-models.test.ts
+++ b/packages/daemon/src/__tests__/runtime-models.test.ts
@@ -380,4 +380,57 @@ describe("runtime model discovery parsers", () => {
       },
     ]);
   });
+
+  it("returns the built-in Gemini catalog and caches it under gemini.json", () => {
+    const tmp = mkdtempSync(path.join(tmpdir(), "daemon-gemini-catalog-"));
+    const prevHome = process.env.HOME;
+    const prevCacheDir = process.env.BOTCORD_RUNTIME_CATALOG_CACHE_DIR;
+    try {
+      const home = path.join(tmp, "home");
+      const cacheDir = path.join(tmp, "catalog-cache");
+      mkdirSync(home, { recursive: true });
+      process.env.HOME = home;
+      process.env.BOTCORD_RUNTIME_CATALOG_CACHE_DIR = cacheDir;
+
+      const catalog = discoverRuntimeModelCatalog({
+        id: "gemini",
+        displayName: "Gemini CLI",
+        binary: "gemini",
+        supportsRun: true,
+        result: { available: true, path: path.join(tmp, "missing-gemini") },
+      });
+
+      const ids = catalog.models?.map((m) => m.id) ?? [];
+      // `auto` is the default — wizard should pre-select it.
+      expect(catalog.models?.find((m) => m.isDefault)?.id).toBe("auto");
+      // Spot-check the documented family is present.
+      expect(ids).toEqual(
+        expect.arrayContaining([
+          "auto",
+          "pro",
+          "flash",
+          "flash-lite",
+          "gemini-2.5-pro",
+          "gemini-2.5-flash",
+          "gemini-3-pro-preview",
+          "gemini-3.1-pro-preview",
+        ]),
+      );
+      // No per-turn parameters yet (thinkingLevel / thinkingBudget aren't
+      // exposed as CLI flags; we can't safely route them through `extraArgs`).
+      expect(catalog.parameters ?? []).toEqual([]);
+
+      // Cache persisted so subsequent calls don't re-touch settings.json.
+      expect(readdirSync(cacheDir)).toEqual(["gemini.json"]);
+      const payload = JSON.parse(readFileSync(path.join(cacheDir, "gemini.json"), "utf8"));
+      expect(payload.runtimeId).toBe("gemini");
+      expect(payload.catalog.models.map((m: { id: string }) => m.id)).toContain("gemini-2.5-flash");
+    } finally {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      if (prevCacheDir === undefined) delete process.env.BOTCORD_RUNTIME_CATALOG_CACHE_DIR;
+      else process.env.BOTCORD_RUNTIME_CATALOG_CACHE_DIR = prevCacheDir;
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/daemon/src/runtime-models.ts
+++ b/packages/daemon/src/runtime-models.ts
@@ -68,6 +68,37 @@ const KIMI_FALLBACK_MODELS: RuntimeModelProbe[] = [
   { id: "kimi-k2-0711", displayName: "kimi-k2-0711", provider: "kimi", source: "builtin" },
 ];
 
+// Gemini CLI has no `gemini models list` command — the model set is
+// hard-coded inside the bundle's `VALID_GEMINI_MODELS` (see `@google/gemini-cli`
+// bundle `chunk-BE42OOYM.js:275832`). We mirror the documented user-facing
+// names here as a static catalog; the actual availability depends on the
+// user's auth tier (gcloud ADC / Vertex / GEMINI_API_KEY) and project quota.
+// The `auto` alias is the default — it lets gemini pick the best model.
+const GEMINI_FALLBACK_MODELS: RuntimeModelProbe[] = [
+  { id: "auto", displayName: "Auto (let Gemini pick)", provider: "google", source: "builtin", isDefault: true },
+  { id: "pro", displayName: "Pro alias", provider: "google", source: "builtin" },
+  { id: "flash", displayName: "Flash alias", provider: "google", source: "builtin" },
+  { id: "flash-lite", displayName: "Flash Lite alias", provider: "google", source: "builtin" },
+  { id: "gemini-2.5-pro", displayName: "Gemini 2.5 Pro", provider: "google", source: "builtin" },
+  { id: "gemini-2.5-flash", displayName: "Gemini 2.5 Flash", provider: "google", source: "builtin" },
+  { id: "gemini-2.5-flash-lite", displayName: "Gemini 2.5 Flash Lite", provider: "google", source: "builtin" },
+  { id: "gemini-3-pro-preview", displayName: "Gemini 3 Pro (preview)", provider: "google", source: "builtin" },
+  { id: "gemini-3-flash-preview", displayName: "Gemini 3 Flash (preview)", provider: "google", source: "builtin" },
+  { id: "gemini-3.1-pro-preview", displayName: "Gemini 3.1 Pro (preview)", provider: "google", source: "builtin" },
+  {
+    id: "gemini-3.1-pro-preview-customtools",
+    displayName: "Gemini 3.1 Pro Custom Tools (preview)",
+    provider: "google",
+    source: "builtin",
+  },
+  {
+    id: "gemini-3.1-flash-lite-preview",
+    displayName: "Gemini 3.1 Flash Lite (preview)",
+    provider: "google",
+    source: "builtin",
+  },
+];
+
 export interface RuntimeModelDiscovery {
   models?: RuntimeModelProbe[];
   parameters?: RuntimeParameterProbe[];
@@ -159,6 +190,22 @@ function runtimeCatalogStrategy(entry: RuntimeProbeEntry): RuntimeCatalogStrateg
             },
           ],
         }),
+      };
+    case "gemini":
+      // Gemini CLI exposes no runtime discovery command and its thinking
+      // budget / level (see bundle `ThinkingLevel`, `thinkingBudget`) is
+      // configured per-installation in `~/.gemini/settings.json`, not via
+      // any CLI flag — so we ship a static model catalog with no parameter
+      // controls. settings.json + BOTCORD_GEMINI_BIN feed the cache key so
+      // user-side reconfig (e.g. switching auth type) busts the cache.
+      return {
+        id: entry.id,
+        contextKey: runtimeCatalogContextKey(entry, {
+          settings: fileStatKey(path.join(homedir(), ".gemini", "settings.json")),
+          env: pickEnv(["BOTCORD_GEMINI_BIN", "GEMINI_CLI_HOME"]),
+        }),
+        discoverFresh: () => ({ models: GEMINI_FALLBACK_MODELS.slice() }),
+        fallback: () => ({ models: GEMINI_FALLBACK_MODELS.slice() }),
       };
     default:
       return null;


### PR DESCRIPTION
## Summary
- Add a `case "gemini"` arm to `runtime-models.ts:runtimeCatalogStrategy` so the daemon now reports a model catalog for gemini routes — same plumbing claude / codex / kimi / deepseek already use.
- Catalog is **static** (12 entries: `auto` default, aliases, stable `gemini-2.5-*`, and five `gemini-3-*` previews) because gemini CLI has no `gemini models list` command and the model set is hard-coded inside the bundle's `VALID_GEMINI_MODELS` constant.
- Skipping per-turn reasoning-effort wiring: `thinkingLevel` / `thinkingBudget` are only settable via `~/.gemini/settings.json`, never per-CLI-invocation, so there is no surface to route a per-route parameter through.

## Why this matters
PR #843 added the gemini adapter but the create-agent wizard had no models to offer for gemini, so users couldn't pin a specific model — every turn rode whatever the user's `selectedType` happened to resolve. With this PR the dashboard renders the standard model dropdown (defaulting to `auto`).

## Verification
- New unit test `runtime-models.test.ts` — asserts catalog content, default model, empty parameters, and that the catalog gets cached at `<cache>/gemini.json`
- Existing `runtime-discovery.test.ts:omits optional fields...` updated: the test used `id: "gemini"` as a no-catalog placeholder; switched to a synthetic id since gemini now has a catalog
- Full daemon suite: **924 / 924** green
- Probed all 12 listed models against the real `gemini` 0.44.0 + gcloud ADC + Vertex AI on the development machine: 11 returned success, only `gemini-2.5-pro` hit a 45s timeout (inconclusive — kept in the catalog because that's a tier/quota artefact)

## Test plan
- [ ] CI green
- [ ] Manual: in the dashboard, create or edit a gemini agent → model dropdown shows the 12 entries with `auto` pre-selected
- [ ] Manual: pin a non-default model (e.g. `gemini-2.5-flash`) and confirm a follow-up DM uses it (check daemon logs / `argv`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)