### PR TITLE
fix: scope runtime skill snapshots by runtime

### DIFF
--- a/backend/app/routers/runtime_skills.py
+++ b/backend/app/routers/runtime_skills.py
@@ -46,6 +46,10 @@ _REFRESH_SKILLS_TIMEOUT_MS = 5000
 class AgentRuntimeSkillOut(BaseModel):
     name: str
     source: str
+    sourceDetail: str | None = None
+    runtime: str | None = None
+    path: str | None = None
+    profile: str | None = None
     description: str | None = None
     mtimeMs: float
     mtimeAt: str | None = None

--- a/backend/hub/routers/daemon_control.py
+++ b/backend/hub/routers/daemon_control.py
@@ -1750,6 +1750,18 @@ def _parse_agent_skill_snapshot_params(
         description = raw.get("description")
         if isinstance(description, str) and description:
             entry["description"] = description[:500]
+        runtime = raw.get("runtime")
+        if isinstance(runtime, str) and runtime:
+            entry["runtime"] = runtime[:64]
+        path = raw.get("path")
+        if isinstance(path, str) and path:
+            entry["path"] = path[:1024]
+        source_detail = raw.get("sourceDetail") or raw.get("source_detail")
+        if isinstance(source_detail, str) and source_detail:
+            entry["sourceDetail"] = source_detail[:128]
+        profile = raw.get("profile")
+        if isinstance(profile, str) and profile:
+            entry["profile"] = profile[:128]
         out.append(entry)
     if not isinstance(probed_at, (int, float)) or isinstance(probed_at, bool):
         return None

--- a/backend/tests/test_app/test_app_policy.py
+++ b/backend/tests/test_app/test_app_policy.py
@@ -326,6 +326,9 @@ async def test_runtime_skills_refresh_dispatches_persists_and_returns(
                     {
                         "name": f"global-skill-{i}",
                         "source": "runtime-global",
+                        "sourceDetail": "global-codex",
+                        "runtime": "codex",
+                        "path": f"/home/test/.codex/skills/global-skill-{i}/SKILL.md",
                         "description": "Global skill",
                         "mtimeMs": probed_at,
                     }
@@ -345,6 +348,9 @@ async def test_runtime_skills_refresh_dispatches_persists_and_returns(
     assert body["skills"][0]["name"] == "global-skill-0"
     assert body["skills"][-1]["name"] == "global-skill-128"
     assert body["skills"][0]["source"] == "runtime-global"
+    assert body["skills"][0]["sourceDetail"] == "global-codex"
+    assert body["skills"][0]["runtime"] == "codex"
+    assert body["skills"][0]["path"].endswith("/global-skill-0/SKILL.md")
     assert body["sniffed_at"] is not None
     assert calls == [
         {
@@ -360,6 +366,9 @@ async def test_runtime_skills_refresh_dispatches_persists_and_returns(
     assert len(refreshed.skills_json) == 129
     assert refreshed.skills_json[0]["name"] == "global-skill-0"
     assert refreshed.skills_json[-1]["name"] == "global-skill-128"
+    assert refreshed.skills_json[0]["sourceDetail"] == "global-codex"
+    assert refreshed.skills_json[0]["runtime"] == "codex"
+    assert refreshed.skills_json[0]["path"].endswith("/global-skill-0/SKILL.md")
     assert refreshed.skills_json[0]["mtimeAt"]
     assert refreshed.skills_probed_at is not None
 

--- a/frontend/src/components/dashboard/AgentSkillsTab.tsx
+++ b/frontend/src/components/dashboard/AgentSkillsTab.tsx
@@ -8,11 +8,11 @@
  */
 
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { FolderKanban, Globe2, Loader2, RefreshCw, Sparkles } from "lucide-react";
+import { Cpu, FolderKanban, Globe2, Loader2, RefreshCw, Sparkles } from "lucide-react";
 import { userApi } from "@/lib/api";
 import {
   createAgentSkillsRequestGuard,
-  groupAgentSkills,
+  groupAgentSkillsByRuntime,
   normalizeAgentSkillSnapshot,
   type AgentSkill,
   type AgentSkillSnapshot,
@@ -26,6 +26,8 @@ const COPY = {
     subtitle: "Daemon-sniffed skills snapshotted for this Bot",
     runtimeGlobal: "Runtime-global",
     workspace: "Workspace",
+    sourceDetail: "Source",
+    unknownRuntime: "unknown",
     refresh: "Refresh skills",
     loading: "Loading skills...",
     refreshing: "Refreshing...",
@@ -41,6 +43,8 @@ const COPY = {
     subtitle: "Daemon 已嗅探并为此 Bot 快照的技能",
     runtimeGlobal: "运行时全局",
     workspace: "工作区",
+    sourceDetail: "来源",
+    unknownRuntime: "未知",
     refresh: "刷新技能",
     loading: "正在加载技能...",
     refreshing: "刷新中...",
@@ -86,7 +90,15 @@ function sourceIcon(source: AgentSkillSource) {
   );
 }
 
-function SkillCard({ skill, sourceLabel }: { skill: AgentSkill; sourceLabel: string }) {
+function SkillCard({
+  skill,
+  sourceLabel,
+  sourceDetailLabel,
+}: {
+  skill: AgentSkill;
+  sourceLabel: string;
+  sourceDetailLabel: string;
+}) {
   return (
     <li className="rounded-xl border border-glass-border bg-glass-bg/35 px-3 py-3">
       <div className="flex items-start justify-between gap-3">
@@ -107,6 +119,16 @@ function SkillCard({ skill, sourceLabel }: { skill: AgentSkill; sourceLabel: str
         {skill.runtime ? (
           <span className="rounded border border-glass-border bg-deep-black/30 px-1.5 py-0.5 font-mono text-[10px] text-text-secondary">
             {skill.runtime}
+          </span>
+        ) : null}
+        {skill.sourceDetail ? (
+          <span className="rounded border border-glass-border bg-deep-black/30 px-1.5 py-0.5 font-mono text-[10px] text-text-secondary">
+            {sourceDetailLabel}: {skill.sourceDetail}
+          </span>
+        ) : null}
+        {skill.profile ? (
+          <span className="rounded border border-glass-border bg-deep-black/30 px-1.5 py-0.5 font-mono text-[10px] text-text-secondary">
+            {skill.profile}
           </span>
         ) : null}
         {skill.path ? (
@@ -135,9 +157,13 @@ export default function AgentSkillsTab({ agentId }: { agentId: string }) {
   const requestGuardRef = useRef(createAgentSkillsRequestGuard(agentId));
   const visibleSnapshot = snapshot?.agentId === agentId ? snapshot : null;
 
-  const grouped = useMemo(
-    () => groupAgentSkills(visibleSnapshot?.skills ?? []),
-    [visibleSnapshot?.skills],
+  const runtimeGroups = useMemo(
+    () =>
+      groupAgentSkillsByRuntime(
+        visibleSnapshot?.skills ?? [],
+        visibleSnapshot?.runtime ?? copy.unknownRuntime,
+      ),
+    [copy.unknownRuntime, visibleSnapshot?.runtime, visibleSnapshot?.skills],
   );
   const total = visibleSnapshot?.skills.length ?? 0;
   const sniffedAt = formatTimestamp(visibleSnapshot?.sniffedAt);
@@ -204,10 +230,10 @@ export default function AgentSkillsTab({ agentId }: { agentId: string }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agentId, loaded, loading]);
 
-  const sections: Array<{ key: AgentSkillSource; label: string; skills: AgentSkill[] }> = [
-    { key: "runtime-global", label: copy.runtimeGlobal, skills: grouped["runtime-global"] },
-    { key: "workspace", label: copy.workspace, skills: grouped.workspace },
-  ];
+  const sourceLabels: Record<AgentSkillSource, string> = {
+    "runtime-global": copy.runtimeGlobal,
+    workspace: copy.workspace,
+  };
 
   return (
     <div className="space-y-4">
@@ -274,35 +300,51 @@ export default function AgentSkillsTab({ agentId }: { agentId: string }) {
         </div>
       ) : (
         <div className="space-y-5">
-          {sections.map((section) => (
-            <section key={section.key} className="space-y-2">
-              <div className="flex items-center justify-between gap-2 text-[11px] font-semibold uppercase tracking-normal text-text-secondary/70">
-                <span className="flex items-center gap-1.5">
-                  {sourceIcon(section.key)}
-                  {section.label}
+          {runtimeGroups.map((group) => (
+            <section key={group.runtime} className="space-y-3">
+              <div className="flex items-center justify-between gap-2 border-b border-glass-border/70 pb-2 text-[11px] font-semibold uppercase tracking-normal text-text-secondary/70">
+                <span className="flex min-w-0 items-center gap-1.5">
+                  <Cpu className="h-3.5 w-3.5 text-neon-cyan" />
+                  <span className="truncate font-mono">{group.runtime}</span>
                 </span>
-                <span>{section.skills.length}</span>
+                <span>{group.skills.length}</span>
               </div>
-              {section.skills.length > 0 ? (
-                <ul className="space-y-2">
-                  {section.skills.map((skill) => (
-                    <SkillCard
-                      key={skill.id}
-                      skill={{
-                        ...skill,
-                        description: skill.description || copy.noDescription,
-                      }}
-                      sourceLabel={section.label}
-                    />
-                  ))}
-                </ul>
-              ) : (
-                <div className="rounded-xl border border-glass-border/70 bg-glass-bg/20 px-3 py-3 text-xs text-text-secondary/60">
-                  {copy.empty}
-                </div>
-              )}
+              {(["workspace", "runtime-global"] as AgentSkillSource[]).map((source) => {
+                const skills = group.sources[source];
+                if (skills.length === 0) return null;
+                const label = sourceLabels[source];
+                return (
+                  <div key={`${group.runtime}:${source}`} className="space-y-2">
+                    <div className="flex items-center justify-between gap-2 text-[11px] font-semibold uppercase tracking-normal text-text-secondary/70">
+                      <span className="flex items-center gap-1.5">
+                        {sourceIcon(source)}
+                        {label}
+                      </span>
+                      <span>{skills.length}</span>
+                    </div>
+                    <ul className="space-y-2">
+                      {skills.map((skill) => (
+                        <SkillCard
+                          key={skill.id}
+                          skill={{
+                            ...skill,
+                            description: skill.description || copy.noDescription,
+                          }}
+                          sourceLabel={label}
+                          sourceDetailLabel={copy.sourceDetail}
+                        />
+                      ))}
+                    </ul>
+                  </div>
+                );
+              })}
             </section>
           ))}
+          {runtimeGroups.length === 0 ? (
+            <div className="rounded-xl border border-glass-border/70 bg-glass-bg/20 px-3 py-3 text-xs text-text-secondary/60">
+              {copy.empty}
+            </div>
+          ) : null}
         </div>
       )}
     </div>

--- a/frontend/src/lib/agent-skills.test.ts
+++ b/frontend/src/lib/agent-skills.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   createAgentSkillsRequestGuard,
   groupAgentSkills,
+  groupAgentSkillsByRuntime,
   normalizeAgentSkillSnapshot,
 } from "./agent-skills";
 
@@ -18,6 +19,8 @@ describe("normalizeAgentSkillSnapshot", () => {
             id: "skill_global",
             name: "openai-docs",
             source: "runtime_global",
+            sourceDetail: "global-codex",
+            runtime: "codex",
             description: "OpenAI API docs helper",
             path: "/home/user/.codex/skills/openai-docs/SKILL.md",
           },
@@ -44,11 +47,14 @@ describe("normalizeAgentSkillSnapshot", () => {
       id: "skill_global",
       name: "openai-docs",
       source: "runtime-global",
+      sourceDetail: "global-codex",
+      runtime: "codex",
       description: "OpenAI API docs helper",
     });
     expect(snapshot.skills[1]).toMatchObject({
       name: "botcord",
       source: "workspace",
+      runtime: "codex",
       updatedAt: "2026-05-26T00:00:00Z",
     });
   });
@@ -72,14 +78,34 @@ describe("normalizeAgentSkillSnapshot", () => {
         id: "runtime-global:custom-skill:0",
         name: "custom-skill",
         source: "runtime-global",
+        sourceDetail: undefined,
         description: undefined,
         runtime: undefined,
         path: undefined,
         file: undefined,
+        profile: undefined,
         updatedAt: undefined,
         mtimeMs: undefined,
       },
     ]);
+  });
+});
+
+describe("groupAgentSkillsByRuntime", () => {
+  it("splits skills by runtime and display source", () => {
+    const grouped = groupAgentSkillsByRuntime(
+      [
+        { id: "codex-a", name: "Codex A", source: "workspace", runtime: "codex" },
+        { id: "claude-a", name: "Claude A", source: "runtime-global", runtime: "claude-code" },
+        { id: "codex-b", name: "Codex B", source: "runtime-global", runtime: "codex" },
+      ],
+      "codex",
+    );
+
+    expect(grouped.map((group) => group.runtime)).toEqual(["codex", "claude-code"]);
+    expect(grouped[0].sources.workspace.map((skill) => skill.name)).toEqual(["Codex A"]);
+    expect(grouped[0].sources["runtime-global"].map((skill) => skill.name)).toEqual(["Codex B"]);
+    expect(grouped[1].sources["runtime-global"].map((skill) => skill.name)).toEqual(["Claude A"]);
   });
 });
 

--- a/frontend/src/lib/agent-skills.ts
+++ b/frontend/src/lib/agent-skills.ts
@@ -11,10 +11,12 @@ export interface AgentSkill {
   id: string;
   name: string;
   source: AgentSkillSource;
+  sourceDetail?: string;
   description?: string;
   runtime?: string;
   path?: string;
   file?: string;
+  profile?: string;
   updatedAt?: string;
   mtimeMs?: number;
 }
@@ -38,6 +40,12 @@ export interface AgentSkillsResponse {
   snapshot?: unknown;
   sniffed_at?: string | null;
   sniffedAt?: string | null;
+}
+
+export interface AgentSkillRuntimeGroup {
+  runtime: string;
+  skills: AgentSkill[];
+  sources: Record<AgentSkillSource, AgentSkill[]>;
 }
 
 export type AgentSkillsOperation = "load" | "refresh";
@@ -123,7 +131,11 @@ function normalizeSource(value: unknown): AgentSkillSource | null {
   return null;
 }
 
-export function normalizeAgentSkill(raw: unknown, index: number): AgentSkill | null {
+export function normalizeAgentSkill(
+  raw: unknown,
+  index: number,
+  fallbackRuntime?: string,
+): AgentSkill | null {
   if (!raw || typeof raw !== "object") return null;
   const item = raw as Record<string, unknown>;
   const source = normalizeSource(item.source ?? item.scope ?? item.kind);
@@ -131,20 +143,28 @@ export function normalizeAgentSkill(raw: unknown, index: number): AgentSkill | n
 
   const name = asString(item.name) ?? asString(item.id) ?? asString(item.slug);
   if (!name) return null;
+  const runtime = asString(item.runtime) ?? fallbackRuntime;
+  const path = asString(item.path);
+  const sourceDetail =
+    asString(item.sourceDetail) ??
+    asString(item.source_detail) ??
+    asString(item.source_detail_id);
 
   const id =
     asString(item.id) ??
     asString(item.skill_id) ??
-    `${source}:${name}:${asString(item.path) ?? index}`;
+    `${runtime ? `${runtime}:` : ""}${source}:${name}:${path ?? index}`;
 
   return {
     id,
     name,
     source,
+    sourceDetail,
     description: asString(item.description),
-    runtime: asString(item.runtime),
-    path: asString(item.path),
+    runtime,
+    path,
     file: asString(item.file) ?? asString(item.skill_md),
+    profile: asString(item.profile),
     updatedAt:
       asString(item.updated_at) ??
       asString(item.updatedAt) ??
@@ -168,6 +188,7 @@ export function normalizeAgentSkillSnapshot(raw: unknown, fallbackAgentId: strin
     : Array.isArray(data.items)
       ? data.items
       : [];
+  const runtime = asNullableString(data.runtime) ?? null;
 
   return {
     agentId: asString(data.agent_id) ?? asString(data.agentId) ?? fallbackAgentId,
@@ -175,9 +196,9 @@ export function normalizeAgentSkillSnapshot(raw: unknown, fallbackAgentId: strin
       asNullableString(data.daemon_instance_id) ??
       asNullableString(data.daemonInstanceId) ??
       null,
-    runtime: asNullableString(data.runtime) ?? null,
+    runtime,
     skills: rawSkills
-      .map((item, index) => normalizeAgentSkill(item, index))
+      .map((item, index) => normalizeAgentSkill(item, index, runtime ?? undefined))
       .filter((item): item is AgentSkill => item !== null),
     sniffedAt:
       asNullableString(data.sniffed_at) ??
@@ -191,4 +212,29 @@ export function groupAgentSkills(skills: AgentSkill[]): Record<AgentSkillSource,
     "runtime-global": skills.filter((skill) => skill.source === "runtime-global"),
     workspace: skills.filter((skill) => skill.source === "workspace"),
   };
+}
+
+export function groupAgentSkillsByRuntime(
+  skills: AgentSkill[],
+  fallbackRuntime?: string | null,
+): AgentSkillRuntimeGroup[] {
+  const groups = new Map<string, AgentSkill[]>();
+  const unknownRuntime = fallbackRuntime || "unknown";
+  for (const skill of skills) {
+    const runtime = skill.runtime || unknownRuntime;
+    groups.set(runtime, [...(groups.get(runtime) ?? []), skill]);
+  }
+  return Array.from(groups.entries())
+    .map(([runtime, runtimeSkills]) => ({
+      runtime,
+      skills: runtimeSkills,
+      sources: groupAgentSkills(runtimeSkills),
+    }))
+    .sort((a, b) => {
+      if (fallbackRuntime && a.runtime !== b.runtime) {
+        if (a.runtime === fallbackRuntime) return -1;
+        if (b.runtime === fallbackRuntime) return 1;
+      }
+      return a.runtime.localeCompare(b.runtime);
+    });
 }

--- a/packages/daemon/src/__tests__/skill-index.test.ts
+++ b/packages/daemon/src/__tests__/skill-index.test.ts
@@ -4,8 +4,10 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import {
   agentCodexHomeDir,
+  agentHermesHomeDir,
   agentWorkspaceDir,
 } from "../agent-workspace.js";
+import { hermesProfileHomeDir } from "../gateway/runtimes/hermes-agent.js";
 import {
   buildSoftSkillIndexPrompt,
   collectAgentSkillSnapshot,
@@ -37,27 +39,40 @@ afterEach(() => {
 });
 
 describe("skill snapshots", () => {
-  it("scans agent workspace/runtime-global skills and maps UI source buckets", () => {
+  it("scopes scans to the selected runtime and maps UI source buckets", () => {
     const agentId = "ag_skilltest";
-    writeSkill(path.join(agentWorkspaceDir(agentId), ".claude", "skills"), "workspace-skill", "Workspace skill");
-    writeSkill(path.join(agentCodexHomeDir(agentId), "skills"), "codex-skill", "Codex skill");
-    writeSkill(path.join(tmpDir, ".codex", "skills"), "global-skill", "Global skill");
+    const claudePath = path.join(agentWorkspaceDir(agentId), ".claude", "skills");
+    const codexPath = path.join(agentCodexHomeDir(agentId), "skills");
+    writeSkill(claudePath, "claude-skill", "Claude skill");
+    writeSkill(codexPath, "codex-skill", "Codex skill");
+    writeSkill(path.join(tmpDir, ".claude", "skills"), "global-claude", "Global Claude");
+    writeSkill(path.join(tmpDir, ".codex", "skills"), "global-codex", "Global Codex");
 
-    const scanned = scanSoftSkills(agentId);
-    expect(scanned.map((s) => s.name).sort()).toEqual([
-      "codex-skill",
-      "global-skill",
-      "workspace-skill",
+    const claudeScanned = scanSoftSkills(agentId, { runtime: "claude-code" });
+    expect(claudeScanned.map((s) => s.name).sort()).toEqual([
+      "claude-skill",
+      "global-claude",
     ]);
+    expect(claudeScanned.every((s) => s.runtime === "claude-code")).toBe(true);
 
-    const snapshot = collectAgentSkillSnapshot(agentId);
+    const codexScanned = scanSoftSkills(agentId, { runtime: "codex" });
+    expect(codexScanned.map((s) => s.name).sort()).toEqual([
+      "codex-skill",
+      "global-codex",
+    ]);
+    expect(codexScanned.every((s) => s.runtime === "codex")).toBe(true);
+
+    const snapshot = collectAgentSkillSnapshot(agentId, { runtime: "codex" });
     expect(snapshot.agentId).toBe(agentId);
-    expect(snapshot.skills).toHaveLength(3);
-    expect(snapshot.skills.find((s) => s.name === "workspace-skill")?.source)
-      .toBe("workspace");
+    expect(snapshot.runtime).toBe("codex");
+    expect(snapshot.skills).toHaveLength(2);
     expect(snapshot.skills.find((s) => s.name === "codex-skill")?.source)
       .toBe("workspace");
-    expect(snapshot.skills.find((s) => s.name === "global-skill")?.source)
+    expect(snapshot.skills.find((s) => s.name === "codex-skill")?.sourceDetail)
+      .toBe("agent-codex");
+    expect(snapshot.skills.find((s) => s.name === "codex-skill")?.path)
+      .toBe(path.join(codexPath, "codex-skill", "SKILL.md"));
+    expect(snapshot.skills.find((s) => s.name === "global-codex")?.source)
       .toBe("runtime-global");
     expect(snapshot.probedAt).toBeGreaterThan(0);
   });
@@ -99,6 +114,67 @@ describe("skill snapshots", () => {
       .toBe("workspace");
     expect(snapshot.skills.find((s) => s.name === "imagegen")?.source)
       .toBe("runtime-global");
+  });
+
+  it("scans Hermes home/profile skills without mixing Claude or Codex dirs", () => {
+    const agentId = "ag_hermes_skills";
+    writeSkill(path.join(agentWorkspaceDir(agentId), ".claude", "skills"), "claude-only", "Claude only");
+    writeSkill(path.join(agentCodexHomeDir(agentId), "skills"), "codex-only", "Codex only");
+    writeSkill(path.join(agentHermesHomeDir(agentId), "skills"), "hermes-only", "Hermes only");
+
+    const isolated = scanSoftSkills(agentId, { runtime: "hermes-agent" });
+    expect(isolated.map((s) => s.name)).toEqual(["hermes-only"]);
+    expect(isolated[0]).toMatchObject({
+      source: "agent-hermes",
+      runtime: "hermes-agent",
+    });
+
+    const profileAgentId = "ag_hermes_profile";
+    writeSkill(
+      path.join(hermesProfileHomeDir("writer"), "skills"),
+      "profile-skill",
+      "Hermes profile skill",
+    );
+    const profile = collectAgentSkillSnapshot(profileAgentId, {
+      runtime: "hermes-agent",
+      hermesProfile: "writer",
+    });
+    expect(profile.skills).toHaveLength(1);
+    expect(profile.skills[0]).toMatchObject({
+      name: "profile-skill",
+      source: "workspace",
+      sourceDetail: "agent-hermes-profile",
+      runtime: "hermes-agent",
+      profile: "writer",
+    });
+  });
+
+  it("keeps same-device workspace skills scoped by agent id", () => {
+    writeSkill(
+      path.join(agentWorkspaceDir("ag_workspace_a"), ".claude", "skills"),
+      "agent-local",
+      "Skill for agent A",
+    );
+    writeSkill(
+      path.join(agentWorkspaceDir("ag_workspace_b"), ".claude", "skills"),
+      "agent-local",
+      "Skill for agent B",
+    );
+
+    expect(scanSoftSkills("ag_workspace_a", { runtime: "claude-code" })).toEqual([
+      expect.objectContaining({
+        name: "agent-local",
+        description: "Skill for agent A",
+        source: "agent-claude",
+      }),
+    ]);
+    expect(scanSoftSkills("ag_workspace_b", { runtime: "claude-code" })).toEqual([
+      expect.objectContaining({
+        name: "agent-local",
+        description: "Skill for agent B",
+        source: "agent-claude",
+      }),
+    ]);
   });
 
   it("returns complete snapshots while keeping the prompt soft index capped", () => {

--- a/packages/daemon/src/cloud-daemon.ts
+++ b/packages/daemon/src/cloud-daemon.ts
@@ -42,6 +42,7 @@ import { CloudAuthManager, asUserAuthManager } from "./cloud-auth.js";
 import type { CloudModeConfig } from "./cloud-mode.js";
 import { buildCloudRunSettleHook } from "./cloud-settle.js";
 import type { InstalledAgentInfo, OnAgentInstalledHook } from "./provision.js";
+import type { SkillIndexOptions } from "./skill-index.js";
 
 // Cloud daemons follow the same cadence as local — keeps dashboard
 // "runtimes last detected" behavior identical across both kinds.
@@ -125,6 +126,15 @@ export async function startCloudDaemon(
   const credentialPathByAgentId = new Map<string, string>();
   const hubUrlByAgentId = new Map<string, string>();
   const displayNameByAgent = new Map<string, string>();
+  const runtimeByAgentId = new Map<string, string>();
+  const hermesProfileByAgentId = new Map<string, string>();
+  const skillIndexOptionsForAgent = (agentId: string): SkillIndexOptions => {
+    const hermesProfile = hermesProfileByAgentId.get(agentId);
+    return {
+      runtime: runtimeByAgentId.get(agentId) ?? opts.config.defaultRoute.adapter,
+      ...(hermesProfile ? { hermesProfile } : {}),
+    };
+  };
   // Seed each per-agent hub URL with the cloud-mode value so that even
   // before the first credential file is written the room-context fetcher
   // has somewhere sensible to point.
@@ -235,15 +245,15 @@ export async function startCloudDaemon(
   };
 
   const installedAgentIds = new Set<string>();
-  const runtimeByAgentId = new Map<string, string>();
   let controlChannel: ControlChannel | null = null;
   const pushInstalledAgentSkillSnapshot = (agentId: string, reason: string): void => {
     if (!controlChannel) return;
-    const runtime = runtimeByAgentId.get(agentId) ?? opts.config.defaultRoute.adapter;
-    const pushed = pushAgentSkillSnapshot(controlChannel, agentId, { runtime });
+    const skillIndexOptions = skillIndexOptionsForAgent(agentId);
+    const pushed = pushAgentSkillSnapshot(controlChannel, agentId, skillIndexOptions);
     logger.info("cloud control-channel: agent_skill_snapshot pushed", {
       agentId,
-      runtime,
+      runtime: skillIndexOptions.runtime,
+      hermesProfile: skillIndexOptions.hermesProfile ?? null,
       reason,
       ok: pushed,
     });
@@ -252,6 +262,8 @@ export async function startCloudDaemon(
   const onAgentInstalled: OnAgentInstalledHook = (info: InstalledAgentInfo) => {
     installedAgentIds.add(info.agentId);
     if (info.runtime) runtimeByAgentId.set(info.agentId, info.runtime);
+    if (info.hermesProfile) hermesProfileByAgentId.set(info.agentId, info.hermesProfile);
+    else if (info.runtime) hermesProfileByAgentId.delete(info.agentId);
     credentialPathByAgentId.set(info.agentId, info.credentialsFile);
     if (info.hubUrl) hubUrlByAgentId.set(info.agentId, info.hubUrl);
     if (info.displayName) displayNameByAgent.set(info.agentId, info.displayName);
@@ -262,6 +274,7 @@ export async function startCloudDaemon(
           agentId: info.agentId,
           activityTracker,
           roomContextBuilder,
+          skillIndexOptions: () => skillIndexOptionsForAgent(info.agentId),
           // Cloud daemons run isolated — no loop-risk guard wired in PR1;
           // the runtime adapter's wall-time budget enforces the equivalent.
           loopRiskBuilder: () => null,

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -52,7 +52,7 @@ import { PolicyResolver, type DaemonAttentionPolicy } from "./gateway/policy-res
 import { scanMention } from "./mention-scan.js";
 import { createDiagnosticBundle, uploadDiagnosticBundle } from "./diagnostics.js";
 import { createAttentionPolicyFetcher } from "./attention-policy-fetcher.js";
-import { collectAgentSkillSnapshot } from "./skill-index.js";
+import { collectAgentSkillSnapshot, type SkillIndexOptions } from "./skill-index.js";
 
 /**
  * Default hard cap for a single runtime turn. Long-running coding/research
@@ -249,7 +249,7 @@ export function pushRuntimeSnapshot(
 export function pushAgentSkillSnapshot(
   sink: RuntimeSnapshotSink,
   agentId: string,
-  opts: { runtime?: string } = {},
+  opts: SkillIndexOptions = {},
 ): boolean {
   const snap = collectAgentSkillSnapshot(agentId, opts);
   const ok = sink.send({
@@ -354,6 +354,13 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
   );
 
   const gwConfig = toGatewayConfig(opts.config, { agentIds, agentRuntimes });
+  const skillIndexOptionsForAgent = (agentId: string): SkillIndexOptions => {
+    const meta = agentRuntimes[agentId];
+    return {
+      runtime: meta?.runtime ?? opts.config.defaultRoute.adapter,
+      ...(meta?.hermesProfile ? { hermesProfile: meta.hermesProfile } : {}),
+    };
+  };
 
   // Per-agent hub URL — read from each credential file at boot. Used to
   // populate `BOTCORD_HUB` for runtime CLI subprocesses so the bundled
@@ -420,6 +427,7 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
         activityTracker,
         roomContextBuilder,
         loopRiskBuilder,
+        skillIndexOptions: () => skillIndexOptionsForAgent(aid),
       }),
     );
   }
@@ -530,11 +538,16 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
     // next room-context fetch re-loads the BotCordClient against the new
     // credential file.
     credentialPathByAgentId.set(info.agentId, info.credentialsFile);
-    if (info.runtime) {
-      agentRuntimes[info.agentId] = {
+    if (info.runtime || info.hermesProfile) {
+      const next = {
         ...(agentRuntimes[info.agentId] ?? {}),
-        runtime: info.runtime,
+        ...(info.runtime ? { runtime: info.runtime } : {}),
+        ...(info.hermesProfile ? { hermesProfile: info.hermesProfile } : {}),
       };
+      if (info.runtime && !info.hermesProfile) {
+        delete next.hermesProfile;
+      }
+      agentRuntimes[info.agentId] = next;
     }
     if (info.hubUrl) hubUrlByAgentId.set(info.agentId, info.hubUrl);
     if (info.displayName) displayNameByAgent.set(info.agentId, info.displayName);
@@ -546,6 +559,7 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
           activityTracker,
           roomContextBuilder,
           loopRiskBuilder,
+          skillIndexOptions: () => skillIndexOptionsForAgent(info.agentId),
         }),
       );
     }
@@ -677,11 +691,12 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
         ok: pushed,
       });
       for (const agentId of agentIds) {
-        const runtime = agentRuntimes[agentId]?.runtime ?? opts.config.defaultRoute.adapter;
-        const skillsPushed = pushAgentSkillSnapshot(controlChannel, agentId, { runtime });
+        const skillIndexOptions = skillIndexOptionsForAgent(agentId);
+        const skillsPushed = pushAgentSkillSnapshot(controlChannel, agentId, skillIndexOptions);
         logger.info("control-channel: initial agent_skill_snapshot push", {
           agentId,
-          runtime,
+          runtime: skillIndexOptions.runtime,
+          hermesProfile: skillIndexOptions.hermesProfile ?? null,
           ok: skillsPushed,
         });
       }

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -75,7 +75,7 @@ import { log as daemonLog } from "./log.js";
 import { discoverAgentCredentials } from "./agent-discovery.js";
 import { resolveMemoryDir } from "./working-memory.js";
 import { discoverRuntimeModelCatalog } from "./runtime-models.js";
-import { collectAgentSkillSnapshot } from "./skill-index.js";
+import { collectAgentSkillSnapshot, type SkillIndexOptions } from "./skill-index.js";
 import {
   buildRuntimeSelectionExtraArgs,
   mergeRuntimeExtraArgs,
@@ -89,10 +89,21 @@ interface ListAgentSkillsParams {
   agentId: string;
 }
 
-function runtimeForLoadedAgent(gateway: Gateway, agentId: string): string | undefined {
-  return gateway.listManagedRoutes()
-    .find((route) => route.match?.accountId === agentId)
-    ?.runtime;
+function skillIndexOptionsForLoadedAgent(gateway: Gateway, agentId: string): SkillIndexOptions {
+  const route = gateway.listManagedRoutes()
+    .find((entry) => entry.match?.accountId === agentId);
+  let credentials: StoredBotCordCredentials | null = null;
+  try {
+    credentials = loadStoredCredentials(defaultCredentialsFile(agentId));
+  } catch {
+    credentials = null;
+  }
+  const runtime = route?.runtime ?? credentials?.runtime;
+  const hermesProfile = route?.hermesProfile ?? credentials?.hermesProfile;
+  return {
+    ...(runtime ? { runtime } : {}),
+    ...(hermesProfile ? { hermesProfile } : {}),
+  };
 }
 
 /**
@@ -108,6 +119,7 @@ export interface InstalledAgentInfo {
   hubUrl: string;
   displayName?: string;
   runtime?: string;
+  hermesProfile?: string;
 }
 
 /**
@@ -516,11 +528,12 @@ export function createProvisioner(opts: ProvisionerOptions): (
             },
           };
         }
-        const runtime = runtimeForLoadedAgent(gateway, params.agentId);
-        const result = collectAgentSkillSnapshot(params.agentId, { runtime });
+        const skillIndexOptions = skillIndexOptionsForLoadedAgent(gateway, params.agentId);
+        const result = collectAgentSkillSnapshot(params.agentId, skillIndexOptions);
         daemonLog.debug("list_agent_skills", {
           agentId: params.agentId,
-          runtime,
+          runtime: skillIndexOptions.runtime,
+          hermesProfile: skillIndexOptions.hermesProfile ?? null,
           count: result.skills.length,
         });
         return { ok: true, result };
@@ -1118,6 +1131,7 @@ async function installLocalAgent(
         hubUrl: credentials.hubUrl,
         ...(credentials.displayName ? { displayName: credentials.displayName } : {}),
         ...(credentials.runtime ? { runtime: credentials.runtime } : {}),
+        ...(credentials.hermesProfile ? { hermesProfile: credentials.hermesProfile } : {}),
       });
     } catch (err) {
       // Hook misbehavior must not fail the install — the agent is already
@@ -1212,6 +1226,7 @@ async function installExistingOpenclawBinding(
         hubUrl: credentials.hubUrl,
         ...(credentials.displayName ? { displayName: credentials.displayName } : {}),
         ...(credentials.runtime ? { runtime: credentials.runtime } : {}),
+        ...(credentials.hermesProfile ? { hermesProfile: credentials.hermesProfile } : {}),
       });
     } catch (err) {
       daemonLog.error("provision.onAgentInstalled threw — caches may be stale", {

--- a/packages/daemon/src/skill-index.ts
+++ b/packages/daemon/src/skill-index.ts
@@ -8,8 +8,10 @@ import { homedir } from "node:os";
 import path from "node:path";
 import {
   agentCodexHomeDir,
+  agentHermesHomeDir,
   agentWorkspaceDir,
 } from "./agent-workspace.js";
+import { hermesProfileHomeDir } from "./gateway/runtimes/hermes-agent.js";
 
 const MAX_SKILLS = 24;
 const MAX_DESCRIPTION_CHARS = 260;
@@ -19,6 +21,8 @@ export interface SoftSkillEntry {
   name: string;
   path: string;
   source: string;
+  runtime?: string;
+  profile?: string;
   description?: string;
   mtimeMs: number;
 }
@@ -26,53 +30,89 @@ export interface SoftSkillEntry {
 export interface AgentSkillSnapshotEntry {
   name: string;
   source: string;
+  sourceDetail?: string;
+  runtime?: string;
+  path?: string;
+  profile?: string;
   description?: string;
   mtimeMs: number;
 }
 
 export interface AgentSkillSnapshot {
   agentId: string;
+  runtime?: string;
   skills: AgentSkillSnapshotEntry[];
   probedAt: number;
 }
 
 export interface SkillIndexOptions {
   extraDirs?: string[];
+  hermesProfile?: string;
   includeGlobal?: boolean;
   runtime?: string;
+}
+
+interface SkillRoot {
+  dir: string;
+  source: string;
+  runtime?: string;
+  profile?: string;
 }
 
 export function defaultSkillDirs(
   agentId: string,
   opts: SkillIndexOptions = {},
-): Array<{ dir: string; source: string }> {
+): SkillRoot[] {
   const includeGlobal = opts.includeGlobal !== false;
   const agentClaude = {
     dir: path.join(agentWorkspaceDir(agentId), ".claude", "skills"),
     source: "agent-claude",
+    runtime: "claude-code",
   };
   const agentCodex = {
     dir: path.join(agentCodexHomeDir(agentId), "skills"),
     source: "agent-codex",
+    runtime: "codex",
   };
-  const dirs: Array<{ dir: string; source: string }> =
-    runtimeFamily(opts.runtime) === "codex"
-      ? [agentCodex, agentClaude]
-      : [agentClaude, agentCodex];
+  const agentHermes = hermesSkillRoot(agentId, opts.hermesProfile);
 
-  if (includeGlobal) {
-    const globalClaude = { dir: path.join(homedir(), ".claude", "skills"), source: "global-claude" };
-    const globalCodex = { dir: path.join(homedir(), ".codex", "skills"), source: "global-codex" };
-    dirs.push(
-      ...(runtimeFamily(opts.runtime) === "codex"
-        ? [globalCodex, globalClaude]
-        : [globalClaude, globalCodex]),
-    );
+  const dirs: SkillRoot[] = [];
+  switch (runtimeFamily(opts.runtime)) {
+    case "codex":
+      dirs.push(agentCodex);
+      if (includeGlobal) {
+        dirs.push({
+          dir: path.join(homedir(), ".codex", "skills"),
+          source: "global-codex",
+          runtime: "codex",
+        });
+      }
+      break;
+    case "hermes":
+      dirs.push(agentHermes);
+      break;
+    case "claude":
+      dirs.push(agentClaude);
+      if (includeGlobal) {
+        dirs.push({
+          dir: path.join(homedir(), ".claude", "skills"),
+          source: "global-claude",
+          runtime: "claude-code",
+        });
+      }
+      break;
+    case "other":
+      break;
   }
 
   const envDirs = parseSkillDirsEnv(process.env.BOTCORD_SKILL_DIRS);
   for (const dir of [...envDirs, ...(opts.extraDirs ?? [])]) {
-    dirs.push({ dir, source: "external" });
+    dirs.push({
+      dir,
+      source: "external",
+      ...(opts.runtime ? { runtime: opts.runtime } : {}),
+      ...(opts.hermesProfile ? { profile: opts.hermesProfile } : {}),
+    });
   }
 
   return dedupeDirs(expandSkillRoots(dirs));
@@ -114,6 +154,8 @@ export function scanSoftSkills(
         name: parsed.name,
         path: skillMd,
         source: root.source,
+        ...(root.runtime ? { runtime: root.runtime } : {}),
+        ...(root.profile ? { profile: root.profile } : {}),
         description: parsed.description,
         mtimeMs: st.mtimeMs,
       };
@@ -133,9 +175,14 @@ export function collectAgentSkillSnapshot(
 ): AgentSkillSnapshot {
   return {
     agentId,
+    ...(opts.runtime ? { runtime: opts.runtime } : {}),
     skills: scanSoftSkills(agentId, opts).map((skill) => ({
       name: skill.name,
-      source: skill.source.startsWith("agent-") ? "workspace" : "runtime-global",
+      source: snapshotSource(skill.source),
+      sourceDetail: skill.source,
+      ...(skill.runtime ? { runtime: skill.runtime } : {}),
+      path: skill.path,
+      ...(skill.profile ? { profile: skill.profile } : {}),
       ...(skill.description ? { description: skill.description } : {}),
       mtimeMs: skill.mtimeMs,
     })),
@@ -217,66 +264,75 @@ function parseSkillDirsEnv(value: string | undefined): string[] {
 }
 
 function dedupeDirs(
-  dirs: Array<{ dir: string; source: string }>,
-): Array<{ dir: string; source: string }> {
+  dirs: SkillRoot[],
+): SkillRoot[] {
   const seen = new Set<string>();
-  const out: Array<{ dir: string; source: string }> = [];
+  const out: SkillRoot[] = [];
   for (const entry of dirs) {
     const resolved = path.resolve(entry.dir);
     if (seen.has(resolved)) continue;
     seen.add(resolved);
-    out.push({ dir: resolved, source: entry.source });
+    out.push({ ...entry, dir: resolved });
   }
   return out;
 }
 
-function expandSkillRoots(
-  dirs: Array<{ dir: string; source: string }>,
-): Array<{ dir: string; source: string }> {
-  const out: Array<{ dir: string; source: string }> = [];
+function expandSkillRoots(dirs: SkillRoot[]): SkillRoot[] {
+  const out: SkillRoot[] = [];
   for (const entry of dirs) {
     out.push(entry);
     if (entry.source.includes("codex")) {
-      out.push({ dir: path.join(entry.dir, ".system"), source: entry.source });
+      out.push({ ...entry, dir: path.join(entry.dir, ".system") });
     }
   }
   return out;
 }
 
-function runtimeFamily(runtime: string | undefined): "codex" | "claude" | "other" {
+function hermesSkillRoot(agentId: string, profile: string | undefined): SkillRoot {
+  if (profile) {
+    try {
+      return {
+        dir: path.join(hermesProfileHomeDir(profile), "skills"),
+        source: "agent-hermes-profile",
+        runtime: "hermes-agent",
+        profile,
+      };
+    } catch {
+      // Corrupt legacy credentials should not make the whole skill snapshot fail.
+    }
+  }
+  return {
+    dir: path.join(agentHermesHomeDir(agentId), "skills"),
+    source: "agent-hermes",
+    runtime: "hermes-agent",
+  };
+}
+
+function runtimeFamily(runtime: string | undefined): "codex" | "claude" | "hermes" | "other" {
   if (runtime === "codex") return "codex";
+  if (runtime === "hermes-agent") return "hermes";
+  if (!runtime) return "claude";
   if (runtime === "claude-code") return "claude";
   return "other";
 }
 
-function priority(source: string, runtime: string | undefined): number {
-  if (runtimeFamily(runtime) === "codex") {
-    switch (source) {
-      case "agent-codex":
-        return 0;
-      case "global-codex":
-        return 1;
-      case "agent-claude":
-        return 2;
-      case "global-claude":
-        return 3;
-      default:
-        return 4;
-    }
-  }
-
+function priority(source: string, _runtime: string | undefined): number {
   switch (source) {
     case "agent-claude":
-      return 0;
     case "agent-codex":
-      return 1;
+    case "agent-hermes":
+    case "agent-hermes-profile":
+      return 0;
     case "global-claude":
-      return 2;
     case "global-codex":
-      return 3;
+      return 1;
     default:
-      return 4;
+      return 2;
   }
+}
+
+function snapshotSource(source: string): "workspace" | "runtime-global" {
+  return source.startsWith("agent-") ? "workspace" : "runtime-global";
 }
 
 function unquote(value: string): string {

--- a/packages/daemon/src/system-context.ts
+++ b/packages/daemon/src/system-context.ts
@@ -32,6 +32,7 @@ import { readIdentity } from "./agent-workspace.js";
 import { classifyActivitySender } from "./sender-classify.js";
 import { log } from "./log.js";
 import { buildSoftSkillIndexPrompt } from "./skill-index.js";
+import type { SkillIndexOptions } from "./skill-index.js";
 
 /**
  * Async per-turn room-context builder (see `room-context.ts`). Returns the
@@ -94,6 +95,11 @@ export interface SystemContextDeps {
    * dirs each turn. Return null to suppress the block.
    */
   skillIndexBuilder?: (message: GatewayInboundMessage) => string | null;
+  /**
+   * Runtime/profile options for the default soft skill scanner. Kept lazy so
+   * hot-provisioned runtime changes are visible without rebuilding this closure.
+   */
+  skillIndexOptions?: (message: GatewayInboundMessage) => SkillIndexOptions;
 }
 
 function safeReadWorkingMemory(agentId: string) {
@@ -194,7 +200,7 @@ export function createDaemonSystemContextBuilder(
   const buildSkillIndex = (message: GatewayInboundMessage): string | null => {
     try {
       if (deps.skillIndexBuilder) return deps.skillIndexBuilder(message);
-      return buildSoftSkillIndexPrompt(deps.agentId);
+      return buildSoftSkillIndexPrompt(deps.agentId, deps.skillIndexOptions?.(message) ?? {});
     } catch (err) {
       log.warn("system-context: skill index build failed — skipping skill block", {
         agentId: deps.agentId,

--- a/packages/protocol-core/src/control-frame.ts
+++ b/packages/protocol-core/src/control-frame.ts
@@ -427,6 +427,14 @@ export interface AgentSkillProbe {
   name: string;
   /** UI-facing source bucket: agent workspace or runtime-global skill dir. */
   source: string;
+  /** Daemon-side source detail, e.g. agent-codex, global-claude, agent-hermes. */
+  sourceDetail?: string;
+  /** Runtime whose skill loader can see this skill. */
+  runtime?: string;
+  /** Absolute SKILL.md path on the daemon host. Owner-visible diagnostics only. */
+  path?: string;
+  /** Runtime profile name when the skill belongs to a profile-backed runtime. */
+  profile?: string;
   description?: string;
   /** SKILL.md mtime as unix milliseconds. */
   mtimeMs: number;
@@ -434,6 +442,7 @@ export interface AgentSkillProbe {
 
 export interface ListAgentSkillsResult {
   agentId: string;
+  runtime?: string;
   skills: AgentSkillProbe[];
   probedAt: number;
 }


### PR DESCRIPTION
## Summary
- Scope daemon skill sniffing to the selected agent runtime instead of mixing Claude, Codex, and Hermes skill roots.
- Preserve runtime/source detail/path/profile fields through Hub snapshots and protocol types.
- Group dashboard Skills tab entries by runtime, then workspace/runtime-global source.

## Verification
- `pnpm test -- --run src/__tests__/skill-index.test.ts` from `packages/daemon`
- `pnpm --filter @botcord/protocol-core build && pnpm --filter @botcord/daemon build`
- `uv run pytest tests/test_app/test_app_policy.py::test_runtime_skills_refresh_dispatches_persists_and_returns tests/test_app/test_daemon_control.py::test_agent_skill_snapshot_accepts_and_persists_full_list_over_128` from `backend`
- `pnpm test -- --run src/lib/agent-skills.test.ts` from `frontend`
- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key pnpm build` from `frontend`

## Risk / rollout
- Existing stored snapshots remain compatible because `source` still uses `workspace` / `runtime-global`; new fields are additive.
- Daemons should refresh or restart to publish runtime-scoped skill snapshots.