### PR TITLE
feat: add team skill orchestration MVP

### DIFF
--- a/backend/app/routers/runtime_skills.py
+++ b/backend/app/routers/runtime_skills.py
@@ -15,7 +15,7 @@ import time
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -41,6 +41,15 @@ router = APIRouter(prefix="/api/agents", tags=["app-runtime-skills"])
 _CLOUD_SKILLS_RESUME_WAIT_SECONDS = 20.0
 _CLOUD_SKILLS_RESUME_POLL_SECONDS = 0.5
 _REFRESH_SKILLS_TIMEOUT_MS = 5000
+_INSTALL_SKILL_TIMEOUT_MS = 30000
+_INSTALL_SKILL_AGENT_LOAD_WAIT_SECONDS = 10.0
+_INSTALL_SKILL_AGENT_LOAD_POLL_SECONDS = 0.5
+_SUPPORTED_SKILL_TARGET_RUNTIMES = {"claude-code", "codex"}
+_TRUSTED_VERCEL_PACKAGE_SPECS = {
+    "https://github.com/vercel-labs/skills",
+    "github:vercel-labs/skills",
+    "vercel-labs/skills",
+}
 
 
 class AgentRuntimeSkillOut(BaseModel):
@@ -65,9 +74,81 @@ class AgentRuntimeSkillsOut(BaseModel):
     skills_probed_at: datetime.datetime | None = None
 
 
+class AgentRuntimeSkillFileIn(BaseModel):
+    path: str = Field(min_length=1, max_length=512)
+    content: str | None = Field(default=None, max_length=262144)
+    sourcePath: str | None = Field(default=None, max_length=512)
+
+
+class AgentRuntimeSkillManifestIn(BaseModel):
+    name: str | None = Field(default=None, max_length=80)
+    id: str | None = Field(default=None, max_length=80)
+    description: str | None = Field(default=None, max_length=4096)
+    skillMd: str | None = Field(default=None, max_length=262144)
+    markdown: str | None = Field(default=None, max_length=262144)
+    files: list[AgentRuntimeSkillFileIn] | None = Field(default=None, max_length=32)
+    targetRuntimes: list[str] | None = Field(default=None, max_length=4)
+
+    @field_validator("targetRuntimes")
+    @classmethod
+    def _validate_target_runtimes(cls, value: list[str] | None) -> list[str] | None:
+        return _validate_skill_target_runtimes(value)
+
+
+class AgentRuntimeSkillArchiveManifestIn(BaseModel):
+    name: str | None = Field(default=None, max_length=80)
+    id: str | None = Field(default=None, max_length=80)
+    description: str | None = Field(default=None, max_length=4096)
+    skillMd: str | None = Field(default=None, max_length=262144)
+    markdown: str | None = Field(default=None, max_length=262144)
+    files: list[AgentRuntimeSkillFileIn] | None = Field(default=None, max_length=32)
+    skills: list[AgentRuntimeSkillManifestIn] | None = Field(default=None, max_length=16)
+    targetRuntimes: list[str] | None = Field(default=None, max_length=4)
+
+    @field_validator("targetRuntimes")
+    @classmethod
+    def _validate_target_runtimes(cls, value: list[str] | None) -> list[str] | None:
+        return _validate_skill_target_runtimes(value)
+
+
+class AgentRuntimeSkillVercelIn(BaseModel):
+    packageSpec: str = Field(min_length=1, max_length=256)
+    skills: list[str] | None = Field(default=None, max_length=32)
+
+    @field_validator("packageSpec")
+    @classmethod
+    def _validate_package_spec(cls, value: str) -> str:
+        cleaned = value.strip()
+        if cleaned not in _TRUSTED_VERCEL_PACKAGE_SPECS:
+            raise ValueError("unsupported vercel skills packageSpec")
+        return cleaned
+
+
+class AgentRuntimeSkillInstallIn(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    manifest: AgentRuntimeSkillManifestIn | None = None
+    archiveManifest: AgentRuntimeSkillArchiveManifestIn | None = None
+    vercel: AgentRuntimeSkillVercelIn | None = None
+
+
 class _RuntimeSkillsHost(BaseModel):
     daemon_instance_id: str
     cloud_daemon_instance_id: str | None = None
+
+
+def _validate_skill_target_runtimes(value: list[str] | None) -> list[str] | None:
+    if value is None:
+        return None
+    normalized: list[str] = []
+    for item in value:
+        if item not in _SUPPORTED_SKILL_TARGET_RUNTIMES:
+            raise ValueError(f"unsupported skill target runtime: {item}")
+        if item not in normalized:
+            normalized.append(item)
+    if not normalized:
+        raise ValueError("at least one target runtime is required")
+    return normalized
 
 
 async def _load_owned_agent(db: AsyncSession, ctx: RequestContext, agent_id: str) -> Agent:
@@ -153,20 +234,22 @@ async def _ensure_cloud_runtime_skills_host_online(
 
 async def _send_runtime_skills_control_frame(
     host: _RuntimeSkillsHost,
+    frame_type: str,
     params: dict[str, Any],
     *,
     db: AsyncSession,
     ctx: RequestContext,
     agent: Agent,
+    timeout_ms: int = _REFRESH_SKILLS_TIMEOUT_MS,
 ) -> dict[str, Any]:
     if host.cloud_daemon_instance_id:
         await _ensure_cloud_runtime_skills_host_online(db, ctx, agent, host)
         try:
             return await send_cloud_control_frame(
                 host.cloud_daemon_instance_id,
-                "list_agent_skills",
+                frame_type,
                 params,
-                timeout_ms=_REFRESH_SKILLS_TIMEOUT_MS,
+                timeout_ms=timeout_ms,
             )
         except CloudDaemonDispatchError as exc:
             if exc.code in {
@@ -186,10 +269,92 @@ async def _send_runtime_skills_control_frame(
         raise HTTPException(status_code=409, detail="daemon_offline")
     return await send_control_frame(
         host.daemon_instance_id,
-        "list_agent_skills",
+        frame_type,
         params,
-        timeout_ms=_REFRESH_SKILLS_TIMEOUT_MS,
+        timeout_ms=timeout_ms,
     )
+
+
+def _install_params(agent_id: str, body: AgentRuntimeSkillInstallIn) -> dict[str, Any]:
+    modes = [body.manifest, body.archiveManifest, body.vercel]
+    if len([mode for mode in modes if mode is not None]) != 1:
+        raise HTTPException(
+            status_code=400,
+            detail="exactly one of manifest, archiveManifest, or vercel is required",
+        )
+    params: dict[str, Any] = {"agentId": agent_id}
+    if body.manifest is not None:
+        params["manifest"] = body.manifest.model_dump(exclude_none=True)
+    if body.archiveManifest is not None:
+        params["archiveManifest"] = body.archiveManifest.model_dump(exclude_none=True)
+    if body.vercel is not None:
+        params["vercel"] = body.vercel.model_dump(exclude_none=True)
+    return params
+
+
+async def install_agent_runtime_skill_for_agent(
+    *,
+    agent_id: str,
+    body: AgentRuntimeSkillInstallIn,
+    ctx: RequestContext,
+    db: AsyncSession,
+) -> AgentRuntimeSkillsOut:
+    agent = await _load_owned_agent(db, ctx, agent_id)
+    host = await _load_runtime_skills_host(db, ctx, agent)
+
+    params = _install_params(agent.agent_id, body)
+    deadline = time.monotonic() + _INSTALL_SKILL_AGENT_LOAD_WAIT_SECONDS
+    while True:
+        ack = await _send_runtime_skills_control_frame(
+            host,
+            "install_agent_skill",
+            params,
+            db=db,
+            ctx=ctx,
+            agent=agent,
+            timeout_ms=_INSTALL_SKILL_TIMEOUT_MS,
+        )
+        err = ack.get("error") if isinstance(ack, dict) else None
+        code = (err or {}).get("code") if isinstance(err, dict) else None
+        if isinstance(ack, dict) and ack.get("ok"):
+            break
+        if code != "agent_not_loaded" or time.monotonic() >= deadline:
+            break
+        await asyncio.sleep(_INSTALL_SKILL_AGENT_LOAD_POLL_SECONDS)
+
+    if not isinstance(ack, dict) or not ack.get("ok"):
+        err = ack.get("error") if isinstance(ack, dict) else None
+        code = (err or {}).get("code") if isinstance(err, dict) else None
+        message = (err or {}).get("message") if isinstance(err, dict) else None
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "code": "daemon_runtime_skill_install_failed",
+                "daemon_code": code,
+                "daemon_message": message,
+            },
+        )
+
+    result = ack.get("result") if isinstance(ack.get("result"), dict) else None
+    snapshot = result.get("snapshot") if isinstance(result, dict) else None
+    persisted = None
+    if isinstance(snapshot, dict):
+        persisted = await _persist_agent_skill_snapshot(
+            db,
+            daemon_instance_id=host.daemon_instance_id,
+            params=snapshot,
+        )
+    if persisted is None:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "code": "daemon_runtime_skill_install_malformed",
+                "daemon_message": "install_agent_skill returned malformed result",
+            },
+        )
+    await db.commit()
+    await db.refresh(agent)
+    return _stored_response(agent)
 
 
 def _stored_response(agent: Agent) -> AgentRuntimeSkillsOut:
@@ -227,6 +392,7 @@ async def refresh_agent_runtime_skills(
 
     ack = await _send_runtime_skills_control_frame(
         host,
+        "list_agent_skills",
         {"agentId": agent.agent_id},
         db=db,
         ctx=ctx,
@@ -264,3 +430,19 @@ async def refresh_agent_runtime_skills(
     await db.commit()
     await db.refresh(agent)
     return _stored_response(agent)
+
+
+@router.post("/{agent_id}/skills/install", response_model=AgentRuntimeSkillsOut)
+@router.post("/{agent_id}/runtime-skills/install", response_model=AgentRuntimeSkillsOut)
+async def install_agent_runtime_skill(
+    agent_id: str,
+    body: AgentRuntimeSkillInstallIn,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+) -> AgentRuntimeSkillsOut:
+    return await install_agent_runtime_skill_for_agent(
+        agent_id=agent_id,
+        body=body,
+        ctx=ctx,
+        db=db,
+    )

--- a/backend/app/routers/team_orchestration.py
+++ b/backend/app/routers/team_orchestration.py
@@ -1,0 +1,278 @@
+"""Authenticated app API for MVP team orchestration."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import RequestContext, require_user
+from app.routers.cloud_agents import CloudAgentOut, RunBudgetIn, RunBudgetOut
+from app.routers.cloud_agents import get_cloud_agent_service
+from app.routers.runtime_skills import (
+    AgentRuntimeSkillInstallIn,
+    install_agent_runtime_skill_for_agent,
+)
+from hub.database import get_db
+from hub.services.cloud_agent import (
+    CloudAgentError,
+    CloudAgentService,
+    CloudAgentView,
+    RunBudget,
+)
+from hub.services.team_orchestration import (
+    TeamOrchestrationService,
+    TeamPlan,
+    TeamProvisionResult,
+    TeamRolePlan,
+)
+
+
+router = APIRouter(prefix="/api/team-orchestration", tags=["app-team-orchestration"])
+
+
+class TeamRoleIn(BaseModel):
+    key: str | None = Field(default=None, max_length=64)
+    name: str = Field(min_length=1, max_length=128)
+    brief: str = Field(min_length=1, max_length=2048)
+    runtime: str | None = Field(default=None, max_length=64)
+    runtime_model: str | None = Field(default=None, max_length=128)
+    reasoning_effort: str | None = Field(default=None, max_length=64)
+    thinking: bool | None = None
+    skills: list[AgentRuntimeSkillInstallIn] | None = Field(default=None, max_length=5)
+
+
+class TeamPlanRequest(BaseModel):
+    goal: str = Field(min_length=1, max_length=4096)
+    roles: list[TeamRoleIn] | None = Field(default=None, max_length=5)
+    role_count: int | None = Field(default=None, ge=1, le=5)
+
+
+class TeamProvisionRequest(TeamPlanRequest):
+    room_name: str | None = Field(default=None, max_length=128)
+    start_runs: bool = True
+    budget: RunBudgetIn | None = None
+
+
+class TeamRoleOut(BaseModel):
+    key: str
+    name: str
+    brief: str
+    runtime: str | None = None
+    runtime_model: str | None = None
+    reasoning_effort: str | None = None
+    thinking: bool | None = None
+    skills: list[AgentRuntimeSkillInstallIn] | None = None
+
+
+class TeamPlanOut(BaseModel):
+    goal: str
+    roles: list[TeamRoleOut]
+    kickoff_prompt: str
+
+
+class TeamRoomOut(BaseModel):
+    room_id: str
+    name: str
+    owner_id: str
+    owner_type: str
+    member_count: int
+
+
+class TeamTopicOut(BaseModel):
+    topic_id: str
+    room_id: str
+    title: str
+    goal: str | None
+
+
+class TeamRoleProvisionOut(BaseModel):
+    role: TeamRoleOut
+    cloud_agent: CloudAgentOut
+    run_id: str | None = None
+    run_status: str | None = None
+    run_error: str | None = Field(
+        default=None,
+        description=(
+            "Best-effort kickoff run error code. Team, room, topic, and agents "
+            "remain provisioned when this is set."
+        ),
+    )
+    budget: RunBudgetOut | None = None
+
+
+class TeamProvisionOut(BaseModel):
+    plan: TeamPlanOut
+    room: TeamRoomOut
+    topic: TeamTopicOut
+    roles: list[TeamRoleProvisionOut]
+
+
+def _service(cloud_agent_service: CloudAgentService) -> TeamOrchestrationService:
+    return TeamOrchestrationService(cloud_agent_service=cloud_agent_service)
+
+
+def _role_from_in(role: TeamRoleIn) -> TeamRolePlan:
+    return TeamRolePlan(
+        key=role.key or role.name,
+        name=role.name,
+        brief=role.brief,
+        runtime=role.runtime,
+        runtime_model=role.runtime_model,
+        reasoning_effort=role.reasoning_effort,
+        thinking=role.thinking,
+        skills=[skill.model_dump(exclude_none=True) for skill in role.skills]
+        if role.skills
+        else None,
+    )
+
+
+def _roles_from_in(roles: list[TeamRoleIn] | None) -> list[TeamRolePlan] | None:
+    if roles is None:
+        return None
+    return [_role_from_in(role) for role in roles]
+
+
+def _plan_out(plan: TeamPlan) -> TeamPlanOut:
+    return TeamPlanOut(
+        goal=plan.goal,
+        roles=[
+            TeamRoleOut(
+                key=role.key,
+                name=role.name,
+                brief=role.brief,
+                runtime=role.runtime,
+                runtime_model=role.runtime_model,
+                reasoning_effort=role.reasoning_effort,
+                thinking=role.thinking,
+                skills=[
+                    AgentRuntimeSkillInstallIn.model_validate(skill)
+                    for skill in role.skills
+                ]
+                if role.skills
+                else None,
+            )
+            for role in plan.roles
+        ],
+        kickoff_prompt=plan.kickoff_prompt,
+    )
+
+
+def _provision_out(result: TeamProvisionResult) -> TeamProvisionOut:
+    role_outputs: list[TeamRoleProvisionOut] = []
+    for item in result.roles:
+        budget = None
+        if item.run is not None:
+            budget = RunBudgetOut(
+                max_wall_time_seconds=item.run.budget.max_wall_time_seconds,
+                max_tool_calls=item.run.budget.max_tool_calls,
+            )
+        role_outputs.append(
+            TeamRoleProvisionOut(
+                role=TeamRoleOut(
+                    key=item.role.key,
+                    name=item.role.name,
+                    brief=item.role.brief,
+                    runtime=item.role.runtime,
+                    runtime_model=item.role.runtime_model,
+                    reasoning_effort=item.role.reasoning_effort,
+                    thinking=item.role.thinking,
+                    skills=[
+                        AgentRuntimeSkillInstallIn.model_validate(skill)
+                        for skill in item.role.skills
+                    ]
+                    if item.role.skills
+                    else None,
+                ),
+                cloud_agent=CloudAgentOut.from_view(item.cloud_agent),
+                run_id=item.run.run_id if item.run else None,
+                run_status=item.run.status if item.run else None,
+                run_error=item.run_error,
+                budget=budget,
+            )
+        )
+
+    return TeamProvisionOut(
+        plan=_plan_out(result.plan),
+        room=TeamRoomOut(
+            room_id=result.room.room_id,
+            name=result.room.name,
+            owner_id=result.room.owner_id,
+            owner_type=(
+                result.room.owner_type.value
+                if hasattr(result.room.owner_type, "value")
+                else str(result.room.owner_type)
+            ),
+            member_count=len(result.roles) + 1,
+        ),
+        topic=TeamTopicOut(
+            topic_id=result.topic.topic_id,
+            room_id=result.topic.room_id,
+            title=result.topic.title,
+            goal=result.topic.goal,
+        ),
+        roles=role_outputs,
+    )
+
+
+@router.post("/plan", response_model=TeamPlanOut)
+async def plan_team(
+    body: TeamPlanRequest,
+    ctx: RequestContext = Depends(require_user),
+    cloud_agent_service: CloudAgentService = Depends(get_cloud_agent_service),
+) -> TeamPlanOut:
+    del ctx
+    service = _service(cloud_agent_service)
+    return _plan_out(
+        service.build_plan(
+            goal=body.goal,
+            roles=_roles_from_in(body.roles),
+            role_count=body.role_count,
+        )
+    )
+
+
+@router.post("/provision", response_model=TeamProvisionOut, status_code=201)
+async def provision_team(
+    body: TeamProvisionRequest,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+    cloud_agent_service: CloudAgentService = Depends(get_cloud_agent_service),
+) -> TeamProvisionOut:
+    service = _service(cloud_agent_service)
+
+    async def _install_role_skills(
+        role: TeamRolePlan,
+        cloud_agent: CloudAgentView,
+    ) -> None:
+        for skill in role.skills or []:
+            await install_agent_runtime_skill_for_agent(
+                agent_id=cloud_agent.agent_id,
+                body=AgentRuntimeSkillInstallIn.model_validate(skill),
+                ctx=ctx,
+                db=db,
+            )
+
+    try:
+        result = await service.provision_team(
+            db,
+            user_id=ctx.user_id,
+            goal=body.goal,
+            roles=_roles_from_in(body.roles),
+            role_count=body.role_count,
+            room_name=body.room_name,
+            start_runs=body.start_runs,
+            run_budget=RunBudget(
+                max_wall_time_seconds=body.budget.max_wall_time_seconds,
+                max_tool_calls=body.budget.max_tool_calls,
+            )
+            if body.budget
+            else None,
+            role_skill_installer=_install_role_skills,
+        )
+    except CloudAgentError as exc:
+        raise HTTPException(
+            status_code=exc.http_status,
+            detail={"code": exc.code, "message": exc.message},
+        ) from exc
+    return _provision_out(result)

--- a/backend/hub/main.py
+++ b/backend/hub/main.py
@@ -78,6 +78,7 @@ from app.routers.runtime_skills import router as app_runtime_skills_router
 from app.routers.schedules import router as app_schedules_router
 from app.routers.auth import router as app_auth_router
 from app.routers.telegram import router as app_telegram_router
+from app.routers.team_orchestration import router as app_team_orchestration_router
 from app.auth import require_beta_user
 
 logging.basicConfig(level=logging.INFO)
@@ -314,6 +315,7 @@ app.include_router(app_telegram_router, dependencies=_beta_gate)
 app.include_router(app_runtime_files_router, dependencies=_beta_gate)
 app.include_router(app_runtime_skills_router, dependencies=_beta_gate)
 app.include_router(app_schedules_router, dependencies=_beta_gate)
+app.include_router(app_team_orchestration_router, dependencies=_beta_gate)
 app.include_router(app_prompts_router)
 app.include_router(app_presence_router, dependencies=_beta_gate)
 app.include_router(app_presence_status_router, dependencies=_beta_gate)

--- a/backend/hub/services/cloud_agent.py
+++ b/backend/hub/services/cloud_agent.py
@@ -111,6 +111,7 @@ class CreateCloudAgentInput:
     runtime_model: str | None = None
     reasoning_effort: str | None = None
     thinking: bool | None = None
+    provisioning_context: dict[str, Any] | None = None
 
 
 @dataclass
@@ -408,6 +409,11 @@ class CloudAgentService:
             model_profile=model_profile,
             status="provisioning",
             metadata_json={
+                **(
+                    {"provisioning_context": body.provisioning_context}
+                    if body.provisioning_context
+                    else {}
+                ),
                 "provisioning": {
                     "private_key_b64": private_key_b64,
                     "public_key_b64": pubkey_b64,

--- a/backend/hub/services/team_orchestration.py
+++ b/backend/hub/services/team_orchestration.py
@@ -1,0 +1,524 @@
+"""MVP service for planning and provisioning small Cloud Agent teams."""
+
+from __future__ import annotations
+
+import logging
+import re
+import uuid
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
+
+from fastapi import HTTPException
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from hub.enums import (
+    ParticipantType,
+    RoomJoinPolicy,
+    RoomRole,
+    RoomVisibility,
+    TopicStatus,
+)
+from hub.id_generators import generate_human_id, generate_room_id, generate_topic_id
+from hub.models import (
+    Agent,
+    CloudAgentInstance,
+    MessageRecord,
+    Room,
+    RoomMember,
+    Topic,
+    User,
+)
+from hub.services.cloud_agent import (
+    CloudAgentError,
+    CloudAgentRunView,
+    CloudAgentService,
+    CloudAgentView,
+    CreateCloudAgentInput,
+    CreateRunInput,
+    RunBudget,
+)
+
+
+_ROLE_KEY_RE = re.compile(r"[^a-z0-9]+")
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TeamRolePlan:
+    key: str
+    name: str
+    brief: str
+    runtime: str | None = None
+    runtime_model: str | None = None
+    reasoning_effort: str | None = None
+    thinking: bool | None = None
+    skills: list[dict[str, Any]] | None = None
+
+
+@dataclass(frozen=True)
+class TeamPlan:
+    goal: str
+    roles: list[TeamRolePlan]
+    kickoff_prompt: str
+
+
+@dataclass(frozen=True)
+class TeamProvisionRole:
+    role: TeamRolePlan
+    cloud_agent: CloudAgentView
+    run: CloudAgentRunView | None
+    run_error: str | None = None
+
+
+@dataclass(frozen=True)
+class TeamProvisionResult:
+    plan: TeamPlan
+    room: Room
+    topic: Topic
+    roles: list[TeamProvisionRole]
+
+
+class TeamOrchestrationService:
+    """Compose existing Cloud Agent, Room, and Topic primitives."""
+
+    def __init__(self, cloud_agent_service: CloudAgentService | None = None) -> None:
+        self._cloud_agents = cloud_agent_service or CloudAgentService()
+
+    def build_plan(
+        self,
+        *,
+        goal: str,
+        roles: list[TeamRolePlan] | None = None,
+        role_count: int | None = None,
+    ) -> TeamPlan:
+        cleaned_goal = _clean_goal(goal)
+        planned_roles = _normalize_roles(roles, role_count=role_count)
+        return TeamPlan(
+            goal=cleaned_goal,
+            roles=planned_roles,
+            kickoff_prompt=_build_kickoff_prompt(cleaned_goal, planned_roles),
+        )
+
+    async def provision_team(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: uuid.UUID,
+        goal: str,
+        roles: list[TeamRolePlan] | None = None,
+        role_count: int | None = None,
+        room_name: str | None = None,
+        start_runs: bool = True,
+        run_budget: RunBudget | None = None,
+        role_skill_installer: Callable[[TeamRolePlan, CloudAgentView], Awaitable[None]]
+        | None = None,
+    ) -> TeamProvisionResult:
+        plan = self.build_plan(goal=goal, roles=roles, role_count=role_count)
+        user = await _load_user_with_human_id(db, user_id)
+
+        created_agents: list[CloudAgentView] = []
+        provision_id = f"team_{uuid.uuid4().hex}"
+        room_id: str | None = None
+        topic_id: str | None = None
+        try:
+            for role in plan.roles:
+                created_agents.append(
+                    await self._cloud_agents.create_cloud_agent(
+                        db,
+                        user_id=user_id,
+                        body=CreateCloudAgentInput(
+                            name=role.name,
+                            bio=role.brief,
+                            runtime=role.runtime,
+                            runtime_model=role.runtime_model,
+                            reasoning_effort=role.reasoning_effort,
+                            thinking=role.thinking,
+                            provisioning_context={
+                                "kind": "team_orchestration",
+                                "provision_id": provision_id,
+                                "role_key": role.key,
+                            },
+                        ),
+                    )
+                )
+
+            if role_skill_installer is not None:
+                for role, cloud_agent in zip(plan.roles, created_agents, strict=True):
+                    await role_skill_installer(role, cloud_agent)
+
+            room = await _create_team_room(
+                db,
+                user=user,
+                name=_clean_room_name(room_name, plan.goal),
+                goal=plan.goal,
+                agent_ids=[agent.agent_id for agent in created_agents],
+            )
+            room_id = room.room_id
+            topic = await _create_team_topic(
+                db,
+                room_id=room.room_id,
+                creator_id=created_agents[0].agent_id,
+                goal=plan.goal,
+            )
+            topic_id = topic.topic_id
+
+            provisioned_roles: list[TeamProvisionRole] = []
+            for role, cloud_agent in zip(plan.roles, created_agents, strict=True):
+                run: CloudAgentRunView | None = None
+                run_error: str | None = None
+                if start_runs:
+                    try:
+                        run = await self._cloud_agents.create_run(
+                            db,
+                            user_id=user_id,
+                            agent_id=cloud_agent.agent_id,
+                            body=CreateRunInput(
+                                prompt=_build_role_kickoff_prompt(plan.goal, role),
+                                room_id=room.room_id,
+                                topic=topic.title,
+                                budget=run_budget,
+                            ),
+                        )
+                    except CloudAgentError as exc:
+                        # Team creation is the durable unit for the MVP.
+                        # Kickoff runs are best-effort and callers get a
+                        # per-role run_error they can surface or retry from.
+                        run_error = exc.code
+                provisioned_roles.append(
+                    TeamProvisionRole(
+                        role=role,
+                        cloud_agent=cloud_agent,
+                        run=run,
+                        run_error=run_error,
+                    )
+                )
+
+            return TeamProvisionResult(
+                plan=plan,
+                room=room,
+                topic=topic,
+                roles=provisioned_roles,
+            )
+        except Exception:
+            await _compensate_failed_provision(
+                db,
+                cloud_agents=self._cloud_agents,
+                user_id=user_id,
+                created_agents=created_agents,
+                provision_id=provision_id,
+                room_id=room_id,
+                topic_id=topic_id,
+            )
+            raise
+
+
+async def _compensate_failed_provision(
+    db: AsyncSession,
+    *,
+    cloud_agents: CloudAgentService,
+    user_id: uuid.UUID,
+    created_agents: list[CloudAgentView],
+    provision_id: str,
+    room_id: str | None,
+    topic_id: str | None,
+) -> None:
+    try:
+        await db.rollback()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("team provision rollback failed before cleanup: err=%s", exc)
+
+    if room_id is not None:
+        try:
+            await db.execute(
+                delete(MessageRecord).where(MessageRecord.room_id == room_id)
+            )
+            if topic_id is not None:
+                await db.execute(delete(Topic).where(Topic.topic_id == topic_id))
+            await db.execute(delete(RoomMember).where(RoomMember.room_id == room_id))
+            await db.execute(delete(Topic).where(Topic.room_id == room_id))
+            await db.execute(delete(Room).where(Room.room_id == room_id))
+            await db.commit()
+        except Exception as exc:  # noqa: BLE001
+            await db.rollback()
+            logger.warning(
+                "team provision room cleanup failed: room=%s topic=%s err=%s",
+                room_id,
+                topic_id,
+                exc,
+            )
+    elif created_agents:
+        created_agent_ids = [agent.agent_id for agent in created_agents]
+        leaked_room_ids = (
+            await db.execute(
+                select(RoomMember.room_id).where(
+                    RoomMember.agent_id.in_(created_agent_ids),
+                    RoomMember.participant_type == ParticipantType.agent,
+                )
+            )
+        ).scalars().all()
+        for leaked_room_id in set(leaked_room_ids):
+            try:
+                await db.execute(
+                    delete(MessageRecord).where(MessageRecord.room_id == leaked_room_id)
+                )
+                await db.execute(
+                    delete(RoomMember).where(RoomMember.room_id == leaked_room_id)
+                )
+                await db.execute(delete(Topic).where(Topic.room_id == leaked_room_id))
+                await db.execute(delete(Room).where(Room.room_id == leaked_room_id))
+                await db.commit()
+            except Exception as exc:  # noqa: BLE001
+                await db.rollback()
+                logger.warning(
+                    "team provision leaked room cleanup failed: room=%s err=%s",
+                    leaked_room_id,
+                    exc,
+                )
+
+    cleanup_agent_ids = list(dict.fromkeys(agent.agent_id for agent in created_agents))
+    marked_agent_ids = await _find_marked_team_provision_agent_ids(
+        db,
+        user_id=user_id,
+        provision_id=provision_id,
+    )
+    cleanup_agent_ids.extend(
+        agent_id for agent_id in marked_agent_ids if agent_id not in cleanup_agent_ids
+    )
+
+    for agent_id in reversed(cleanup_agent_ids):
+        try:
+            await cloud_agents.delete_cloud_agent(
+                db,
+                user_id=user_id,
+                agent_id=agent_id,
+            )
+        except Exception as exc:  # noqa: BLE001
+            await db.rollback()
+            logger.warning(
+                "team provision cloud agent cleanup failed: agent=%s err=%s",
+                agent_id,
+                exc,
+            )
+
+
+async def _find_marked_team_provision_agent_ids(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    provision_id: str,
+) -> list[str]:
+    rows = (
+        await db.execute(
+            select(CloudAgentInstance.agent_id, CloudAgentInstance.metadata_json).where(
+                CloudAgentInstance.user_id == user_id,
+                CloudAgentInstance.status != "deleted",
+            )
+        )
+    ).all()
+    agent_ids: list[str] = []
+    for agent_id, metadata in rows:
+        context = (metadata or {}).get("provisioning_context")
+        if not isinstance(context, dict):
+            continue
+        if (
+            context.get("kind") == "team_orchestration"
+            and context.get("provision_id") == provision_id
+        ):
+            agent_ids.append(agent_id)
+    return agent_ids
+
+
+def _clean_goal(goal: str) -> str:
+    cleaned = (goal or "").strip()
+    if not cleaned:
+        raise HTTPException(status_code=400, detail="goal is required")
+    return cleaned
+
+
+def _normalize_roles(
+    roles: list[TeamRolePlan] | None,
+    *,
+    role_count: int | None,
+) -> list[TeamRolePlan]:
+    if roles:
+        normalized = [
+            TeamRolePlan(
+                key=_role_key(role.key or role.name),
+                name=role.name.strip(),
+                brief=role.brief.strip(),
+                runtime=role.runtime,
+                runtime_model=role.runtime_model,
+                reasoning_effort=role.reasoning_effort,
+                thinking=role.thinking,
+                skills=role.skills,
+            )
+            for role in roles
+            if role.name.strip() and role.brief.strip()
+        ]
+    else:
+        normalized = list(_default_roles())
+
+    if role_count is not None:
+        normalized = normalized[:role_count]
+
+    if not normalized:
+        raise HTTPException(status_code=400, detail="at least one role is required")
+    if len(normalized) > 5:
+        raise HTTPException(status_code=400, detail="at most five roles are supported")
+
+    seen: set[str] = set()
+    unique: list[TeamRolePlan] = []
+    for role in normalized:
+        key = role.key
+        if key in seen:
+            suffix = 2
+            while f"{key}-{suffix}" in seen:
+                suffix += 1
+            key = f"{key}-{suffix}"
+            role = TeamRolePlan(
+                key=key,
+                name=role.name,
+                brief=role.brief,
+                runtime=role.runtime,
+                runtime_model=role.runtime_model,
+                reasoning_effort=role.reasoning_effort,
+                thinking=role.thinking,
+                skills=role.skills,
+            )
+        seen.add(key)
+        unique.append(role)
+    return unique
+
+
+def _default_roles() -> tuple[TeamRolePlan, ...]:
+    return (
+        TeamRolePlan(
+            key="planner",
+            name="Team Planner",
+            brief="Breaks the goal into milestones, dependencies, and acceptance checks.",
+        ),
+        TeamRolePlan(
+            key="builder",
+            name="Implementation Lead",
+            brief="Executes the main implementation work and reports concrete progress.",
+        ),
+        TeamRolePlan(
+            key="reviewer",
+            name="Quality Reviewer",
+            brief="Reviews outputs for correctness, gaps, and follow-up work.",
+        ),
+    )
+
+
+def _role_key(value: str) -> str:
+    key = _ROLE_KEY_RE.sub("-", value.strip().lower()).strip("-")
+    return key or "role"
+
+
+def _build_kickoff_prompt(goal: str, roles: list[TeamRolePlan]) -> str:
+    role_lines = "\n".join(f"- {role.name}: {role.brief}" for role in roles)
+    return (
+        f"Goal: {goal}\n\n"
+        f"Team roles:\n{role_lines}\n\n"
+        "Coordinate in this room and keep updates concise."
+    )
+
+
+def _build_role_kickoff_prompt(goal: str, role: TeamRolePlan) -> str:
+    return (
+        f"Team goal: {goal}\n\n"
+        f"Your role: {role.name}\n"
+        f"Role brief: {role.brief}\n\n"
+        "Start by posting your initial plan, assumptions, and first concrete action."
+    )
+
+
+def _clean_room_name(room_name: str | None, goal: str) -> str:
+    name = (room_name or "").strip()
+    if not name:
+        name = f"Team: {goal[:80]}"
+    return name[:128]
+
+
+async def _load_user_with_human_id(db: AsyncSession, user_id: uuid.UUID) -> User:
+    user = await db.scalar(select(User).where(User.id == user_id))
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    if not user.human_id:
+        user.human_id = generate_human_id()
+        await db.flush()
+    return user
+
+
+async def _create_team_room(
+    db: AsyncSession,
+    *,
+    user: User,
+    name: str,
+    goal: str,
+    agent_ids: list[str],
+) -> Room:
+    room = Room(
+        room_id=generate_room_id(),
+        name=name,
+        description=goal,
+        rule=(
+            "Coordinate on the stated goal. Keep messages task-focused and "
+            "explicit about blockers."
+        ),
+        owner_id=user.human_id,
+        owner_type=ParticipantType.human,
+        visibility=RoomVisibility.private,
+        join_policy=RoomJoinPolicy.invite_only,
+        default_send=True,
+        default_invite=False,
+        max_members=len(agent_ids) + 1,
+    )
+    db.add(room)
+    await db.flush()
+    db.add(
+        RoomMember(
+            room_id=room.room_id,
+            agent_id=user.human_id,
+            participant_type=ParticipantType.human,
+            role=RoomRole.owner,
+        )
+    )
+    for agent_id in agent_ids:
+        exists = await db.scalar(select(Agent.agent_id).where(Agent.agent_id == agent_id))
+        if exists is None:
+            raise HTTPException(status_code=400, detail=f"agent {agent_id} not found")
+        db.add(
+            RoomMember(
+                room_id=room.room_id,
+                agent_id=agent_id,
+                participant_type=ParticipantType.agent,
+                role=RoomRole.member,
+            )
+        )
+    await db.commit()
+    await db.refresh(room)
+    return room
+
+
+async def _create_team_topic(
+    db: AsyncSession,
+    *,
+    room_id: str,
+    creator_id: str,
+    goal: str,
+) -> Topic:
+    topic = Topic(
+        topic_id=generate_topic_id(),
+        room_id=room_id,
+        title="Team kickoff",
+        description=goal,
+        status=TopicStatus.open,
+        creator_id=creator_id,
+        goal=goal,
+    )
+    db.add(topic)
+    await db.commit()
+    await db.refresh(topic)
+    return topic

--- a/backend/tests/test_app/test_team_orchestration.py
+++ b/backend/tests/test_app/test_team_orchestration.py
@@ -1,0 +1,804 @@
+"""Tests for /api/team-orchestration."""
+
+from __future__ import annotations
+
+import datetime
+import uuid
+
+import jwt
+import pytest
+import pytest_asyncio
+from fastapi import HTTPException
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from hub.enums import ParticipantType
+from hub.models import (
+    Agent,
+    Base,
+    CloudAgentInstance,
+    CloudDaemonInstance,
+    MessageRecord,
+    Role,
+    Room,
+    RoomMember,
+    Topic,
+    User,
+    UserRole,
+)
+from hub.services.cloud_agent import CloudAgentError, CloudAgentService
+from hub.services.cloud_daemon_provider import FakeCloudDaemonProvider
+from tests.test_app.conftest import create_test_engine
+
+TEST_SUPABASE_SECRET = "test-supabase-jwt-secret-for-team-orchestration"
+
+
+def _make_supabase_token(sub: str, secret: str = TEST_SUPABASE_SECRET) -> str:
+    payload = {
+        "sub": sub,
+        "aud": "authenticated",
+        "exp": datetime.datetime.now(datetime.timezone.utc)
+        + datetime.timedelta(hours=1),
+        "iss": "supabase",
+    }
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_test_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def seed_user(db_session: AsyncSession):
+    supabase_uuid = uuid.uuid4()
+    user_id = uuid.uuid4()
+    user = User(
+        id=user_id,
+        display_name="Team Owner",
+        email="team@example.com",
+        status="active",
+        supabase_user_id=supabase_uuid,
+        max_agents=30,
+    )
+    db_session.add(user)
+    role = Role(
+        id=uuid.uuid4(),
+        name="member",
+        display_name="Member",
+        is_system=True,
+        priority=0,
+    )
+    db_session.add(role)
+    await db_session.flush()
+    db_session.add(UserRole(user_id=user_id, role_id=role.id))
+    await db_session.commit()
+    return {
+        "user_id": user_id,
+        "supabase_uid": str(supabase_uuid),
+        "token": _make_supabase_token(str(supabase_uuid)),
+    }
+
+
+@pytest_asyncio.fixture
+async def client_factory(db_session: AsyncSession, monkeypatch):
+    import app.auth
+    import app.routers.cloud_agents as cloud_agents_router
+    import hub.config
+
+    monkeypatch.setattr(hub.config, "SUPABASE_JWT_SECRET", TEST_SUPABASE_SECRET)
+    monkeypatch.setattr(app.auth, "SUPABASE_JWT_SECRET", TEST_SUPABASE_SECRET)
+
+    from hub.database import get_db
+    from hub.main import app
+
+    async def _override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    clients: list[AsyncClient] = []
+
+    async def _make(
+        *,
+        feature_enabled: bool = True,
+        force_create_failure: bool = False,
+    ) -> AsyncClient:
+        service = CloudAgentService(
+            provider=FakeCloudDaemonProvider(force_create_failure=force_create_failure),
+            feature_enabled=feature_enabled,
+            max_per_user=5,
+            max_agents_per_daemon=3,
+        )
+        app.dependency_overrides[cloud_agents_router.get_cloud_agent_service] = (
+            lambda: service
+        )
+        client = AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        )
+        await client.__aenter__()
+        clients.append(client)
+        return client
+
+    try:
+        yield _make
+    finally:
+        for client in clients:
+            await client.__aexit__(None, None, None)
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_plan_requires_auth(client_factory):
+    client = await client_factory()
+    response = await client.post(
+        "/api/team-orchestration/plan",
+        json={"goal": "Ship the billing dashboard"},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_plan_returns_default_roles(client_factory, seed_user):
+    client = await client_factory()
+    response = await client.post(
+        "/api/team-orchestration/plan",
+        json={"goal": "Ship the billing dashboard", "role_count": 2},
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["goal"] == "Ship the billing dashboard"
+    assert [role["key"] for role in body["roles"]] == ["planner", "builder"]
+    assert "Ship the billing dashboard" in body["kickoff_prompt"]
+
+
+@pytest.mark.asyncio
+async def test_provision_creates_agents_room_topic_and_kickoff_runs(
+    client_factory,
+    seed_user,
+    db_session: AsyncSession,
+):
+    client = await client_factory()
+    response = await client.post(
+        "/api/team-orchestration/provision",
+        json={
+            "goal": "Build a team orchestration MVP",
+            "role_count": 2,
+            "room_name": "Orchestration MVP",
+            "budget": {"max_wall_time_seconds": 300, "max_tool_calls": 12},
+        },
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert body["room"]["name"] == "Orchestration MVP"
+    assert body["room"]["owner_type"] == "human"
+    assert body["room"]["member_count"] == 3
+    assert body["topic"]["title"] == "Team kickoff"
+    assert len(body["roles"]) == 2
+    assert all(item["cloud_agent"]["status"] == "ready" for item in body["roles"])
+    assert all(item["run_status"] == "queued" for item in body["roles"])
+    assert all(item["budget"]["max_wall_time_seconds"] == 300 for item in body["roles"])
+
+    room_id = body["room"]["room_id"]
+    room = await db_session.scalar(select(Room).where(Room.room_id == room_id))
+    assert room is not None
+    assert room.owner_id.startswith("hu_")
+
+    member_count = await db_session.scalar(
+        select(func.count(RoomMember.id)).where(RoomMember.room_id == room_id)
+    )
+    assert member_count == 3
+    agent_members = (
+        await db_session.execute(
+            select(RoomMember.agent_id).where(
+                RoomMember.room_id == room_id,
+                RoomMember.participant_type == ParticipantType.agent,
+            )
+        )
+    ).scalars().all()
+    assert set(agent_members) == {
+        item["cloud_agent"]["agent_id"] for item in body["roles"]
+    }
+
+    topic = await db_session.scalar(select(Topic).where(Topic.room_id == room_id))
+    assert topic is not None
+    assert topic.goal == "Build a team orchestration MVP"
+
+    run_count = await db_session.scalar(
+        select(func.count(MessageRecord.id)).where(
+            MessageRecord.room_id == room_id,
+            MessageRecord.source_type == "cloud_agent_run",
+        )
+    )
+    assert run_count == 2
+
+
+@pytest.mark.asyncio
+async def test_provision_can_skip_kickoff_runs(
+    client_factory,
+    seed_user,
+    db_session: AsyncSession,
+):
+    client = await client_factory()
+    response = await client.post(
+        "/api/team-orchestration/provision",
+        json={
+            "goal": "Prepare launch checklist",
+            "role_count": 1,
+            "start_runs": False,
+        },
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert body["roles"][0]["run_id"] is None
+    room_id = body["room"]["room_id"]
+
+    run_count = await db_session.scalar(
+        select(func.count(MessageRecord.id)).where(
+            MessageRecord.room_id == room_id,
+            MessageRecord.source_type == "cloud_agent_run",
+        )
+    )
+    assert run_count == 0
+
+
+@pytest.mark.asyncio
+async def test_provision_cleans_up_agents_room_and_topic_when_team_create_fails(
+    client_factory,
+    seed_user,
+    db_session: AsyncSession,
+    monkeypatch,
+):
+    original_create = CloudAgentService.create_cloud_agent
+    calls = 0
+
+    async def create_then_fail(self, *args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise CloudAgentError(
+                "provider_create_failed",
+                "simulated second agent failure",
+                http_status=502,
+            )
+        return await original_create(self, *args, **kwargs)
+
+    monkeypatch.setattr(CloudAgentService, "create_cloud_agent", create_then_fail)
+
+    client = await client_factory()
+    response = await client.post(
+        "/api/team-orchestration/provision",
+        json={
+            "goal": "Fail midway through team provisioning",
+            "role_count": 2,
+            "room_name": "Failed Team",
+        },
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+
+    assert response.status_code == 502, response.text
+    assert response.json()["detail"]["code"] == "provider_create_failed"
+
+    active_cloud_agents = await db_session.scalar(
+        select(func.count(CloudAgentInstance.id)).where(
+            CloudAgentInstance.status != "deleted"
+        )
+    )
+    active_agents = await db_session.scalar(
+        select(func.count(Agent.agent_id)).where(Agent.status != "deleted")
+    )
+    active_cloud_daemons = await db_session.scalar(
+        select(func.count(CloudDaemonInstance.id)).where(
+            CloudDaemonInstance.status != "deleted"
+        )
+    )
+    room_count = await db_session.scalar(select(func.count(Room.id)))
+    member_count = await db_session.scalar(select(func.count(RoomMember.id)))
+    topic_count = await db_session.scalar(select(func.count(Topic.id)))
+    run_count = await db_session.scalar(select(func.count(MessageRecord.id)))
+
+    assert active_cloud_agents == 0
+    assert active_agents == 0
+    assert active_cloud_daemons == 0
+    assert room_count == 0
+    assert member_count == 0
+    assert topic_count == 0
+    assert run_count == 0
+
+
+async def _assert_no_active_team_artifacts(db_session: AsyncSession) -> None:
+    active_cloud_agents = await db_session.scalar(
+        select(func.count(CloudAgentInstance.id)).where(
+            CloudAgentInstance.status != "deleted"
+        )
+    )
+    active_agents = await db_session.scalar(
+        select(func.count(Agent.agent_id)).where(Agent.status != "deleted")
+    )
+    active_cloud_daemons = await db_session.scalar(
+        select(func.count(CloudDaemonInstance.id)).where(
+            CloudDaemonInstance.status != "deleted"
+        )
+    )
+    room_count = await db_session.scalar(select(func.count(Room.id)))
+    member_count = await db_session.scalar(select(func.count(RoomMember.id)))
+    topic_count = await db_session.scalar(select(func.count(Topic.id)))
+    run_count = await db_session.scalar(select(func.count(MessageRecord.id)))
+
+    assert active_cloud_agents == 0
+    assert active_agents == 0
+    assert active_cloud_daemons == 0
+    assert room_count == 0
+    assert member_count == 0
+    assert topic_count == 0
+    assert run_count == 0
+
+
+@pytest.mark.asyncio
+async def test_provision_cleans_up_when_role_skill_install_fails(
+    client_factory,
+    seed_user,
+    db_session: AsyncSession,
+    monkeypatch,
+):
+    import app.routers.team_orchestration as team_mod
+
+    async def fail_install_agent_runtime_skill_for_agent(*args, **kwargs):
+        del args, kwargs
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "code": "daemon_runtime_skill_install_failed",
+                "daemon_code": "skill_install_failed",
+            },
+        )
+
+    monkeypatch.setattr(
+        team_mod,
+        "install_agent_runtime_skill_for_agent",
+        fail_install_agent_runtime_skill_for_agent,
+    )
+
+    client = await client_factory()
+    response = await client.post(
+        "/api/team-orchestration/provision",
+        json={
+            "goal": "Fail during skill installation",
+            "roles": [
+                {
+                    "key": "builder",
+                    "name": "Builder",
+                    "brief": "Builds the thing.",
+                    "skills": [
+                        {
+                            "manifest": {
+                                "name": "build-kit",
+                                "skillMd": "---\nname: build-kit\n---\nBuild.",
+                            }
+                        }
+                    ],
+                }
+            ],
+        },
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+
+    assert response.status_code == 502, response.text
+    await _assert_no_active_team_artifacts(db_session)
+
+
+@pytest.mark.asyncio
+async def test_provision_cleans_up_marked_cloud_agent_when_create_persists_then_raises(
+    client_factory,
+    seed_user,
+    db_session: AsyncSession,
+):
+    client = await client_factory(force_create_failure=True)
+    response = await client.post(
+        "/api/team-orchestration/provision",
+        json={
+            "goal": "Fail after cloud agent rows were persisted",
+            "role_count": 1,
+            "room_name": "Persisted Failure Team",
+        },
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+
+    assert response.status_code == 502, response.text
+    assert response.json()["detail"]["code"] == "fake_create_failed"
+    await _assert_no_active_team_artifacts(db_session)
+
+
+@pytest.mark.asyncio
+async def test_provision_cleans_up_room_topic_and_runs_when_topic_create_fails(
+    client_factory,
+    seed_user,
+    db_session: AsyncSession,
+    monkeypatch,
+):
+    import hub.services.team_orchestration as service_mod
+
+    original_create_team_topic = service_mod._create_team_topic
+
+    async def create_topic_then_fail(*args, **kwargs):
+        await original_create_team_topic(*args, **kwargs)
+        raise RuntimeError("simulated topic follow-up failure")
+
+    monkeypatch.setattr(service_mod, "_create_team_topic", create_topic_then_fail)
+
+    client = await client_factory()
+    with pytest.raises(RuntimeError, match="simulated topic follow-up failure"):
+        await client.post(
+            "/api/team-orchestration/provision",
+            json={
+                "goal": "Fail after topic creation",
+                "role_count": 1,
+                "room_name": "Leaked Team",
+            },
+            headers={"Authorization": f"Bearer {seed_user['token']}"},
+        )
+    await _assert_no_active_team_artifacts(db_session)
+
+
+@pytest.mark.asyncio
+async def test_provision_keeps_team_and_reports_run_error_when_best_effort_kickoff_fails(
+    client_factory,
+    seed_user,
+    db_session: AsyncSession,
+    monkeypatch,
+):
+    async def create_run_failure(self, *args, **kwargs):
+        del self, args, kwargs
+        raise CloudAgentError(
+            "kickoff_not_ready",
+            "simulated kickoff run failure",
+            http_status=409,
+        )
+
+    monkeypatch.setattr(CloudAgentService, "create_run", create_run_failure)
+
+    client = await client_factory()
+    response = await client.post(
+        "/api/team-orchestration/provision",
+        json={
+            "goal": "Create the team even if kickoff cannot start",
+            "role_count": 1,
+            "room_name": "Best Effort Kickoff",
+        },
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert body["roles"][0]["run_id"] is None
+    assert body["roles"][0]["run_status"] is None
+    assert body["roles"][0]["run_error"] == "kickoff_not_ready"
+
+    room_id = body["room"]["room_id"]
+    assert await db_session.scalar(select(func.count(Room.id))) == 1
+    assert await db_session.scalar(select(func.count(Topic.id))) == 1
+    assert await db_session.scalar(
+        select(func.count(CloudAgentInstance.id)).where(
+            CloudAgentInstance.status == "ready"
+        )
+    ) == 1
+    assert await db_session.scalar(
+        select(func.count(MessageRecord.id)).where(
+            MessageRecord.room_id == room_id,
+            MessageRecord.source_type == "cloud_agent_run",
+        )
+    ) == 0
+
+
+@pytest.mark.asyncio
+async def test_runtime_skills_install_dispatches_daemon_and_persists_snapshot(
+    client_factory,
+    seed_user,
+    db_session: AsyncSession,
+    monkeypatch,
+):
+    import app.routers.runtime_skills as runtime_skills_mod
+
+    agent = Agent(
+        agent_id="ag_skill_target",
+        display_name="Skill Target",
+        user_id=seed_user["user_id"],
+        status="active",
+        hosting_kind="daemon",
+        daemon_instance_id="dm_skill_target",
+        runtime="codex",
+    )
+    db_session.add(agent)
+    await db_session.commit()
+
+    monkeypatch.setattr(runtime_skills_mod, "is_daemon_online", lambda _id: True)
+    calls = []
+    probed_at = int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000)
+
+    async def fake_send(daemon_instance_id, type_, params=None, timeout_ms=None):
+        calls.append(
+            {
+                "daemon_instance_id": daemon_instance_id,
+                "type": type_,
+                "params": params,
+                "timeout_ms": timeout_ms,
+            }
+        )
+        return {
+            "ok": True,
+            "result": {
+                "agentId": "ag_skill_target",
+                "installed": [{"name": "review-kit", "targets": ["codex"], "paths": []}],
+                "snapshot": {
+                    "agentId": "ag_skill_target",
+                    "skills": [
+                        {
+                            "name": "review-kit",
+                            "source": "runtime-global",
+                            "description": "Review support",
+                            "mtimeMs": probed_at,
+                        }
+                    ],
+                    "probedAt": probed_at,
+                },
+            },
+        }
+
+    monkeypatch.setattr(runtime_skills_mod, "send_control_frame", fake_send)
+
+    client = await client_factory()
+    response = await client.post(
+        "/api/agents/ag_skill_target/runtime-skills/install",
+        json={
+            "manifest": {
+                "name": "review-kit",
+                "skillMd": "---\nname: review-kit\n---\nUse review checks.",
+            }
+        },
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["skills"][0]["name"] == "review-kit"
+    assert calls == [
+        {
+            "daemon_instance_id": "dm_skill_target",
+            "type": "install_agent_skill",
+            "params": {
+                "agentId": "ag_skill_target",
+                "manifest": {
+                    "name": "review-kit",
+                    "skillMd": "---\nname: review-kit\n---\nUse review checks.",
+                },
+            },
+            "timeout_ms": 30000,
+        }
+    ]
+
+    refreshed = await db_session.scalar(
+        select(Agent).where(Agent.agent_id == "ag_skill_target")
+    )
+    assert refreshed is not None
+    assert refreshed.skills_json[0]["name"] == "review-kit"
+    assert refreshed.skills_probed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_runtime_skills_install_rejects_invalid_target_runtime_at_api_boundary(
+    client_factory,
+    seed_user,
+):
+    client = await client_factory()
+    response = await client.post(
+        "/api/team-orchestration/provision",
+        json={
+            "goal": "Reject invalid skill target",
+            "roles": [
+                {
+                    "key": "bad-target",
+                    "name": "Bad Target",
+                    "brief": "Uses an invalid target.",
+                    "skills": [
+                        {
+                            "manifest": {
+                                "name": "bad-target-skill",
+                                "targetRuntimes": ["not-a-runtime"],
+                            }
+                        }
+                    ],
+                }
+            ],
+        },
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+
+    assert response.status_code == 422, response.text
+
+
+@pytest.mark.asyncio
+async def test_runtime_skills_install_rejects_untrusted_vercel_package_at_api_boundary(
+    client_factory,
+    seed_user,
+):
+    client = await client_factory()
+    response = await client.post(
+        "/api/team-orchestration/provision",
+        json={
+            "goal": "Reject untrusted package",
+            "roles": [
+                {
+                    "key": "bad-package",
+                    "name": "Bad Package",
+                    "brief": "Uses an untrusted skill package.",
+                    "skills": [
+                        {
+                            "vercel": {
+                                "packageSpec": "attacker/skills",
+                                "skills": ["anything"],
+                            }
+                        }
+                    ],
+                }
+            ],
+        },
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+
+    assert response.status_code == 422, response.text
+
+
+@pytest.mark.asyncio
+async def test_provision_installs_role_skills_before_starting_runs(
+    client_factory,
+    seed_user,
+    monkeypatch,
+):
+    import app.routers.team_orchestration as team_mod
+
+    events = []
+
+    async def fake_install_agent_runtime_skill_for_agent(*, agent_id, body, ctx, db):
+        del ctx, db
+        events.append(("install", agent_id, body.manifest.name))
+
+    monkeypatch.setattr(
+        team_mod,
+        "install_agent_runtime_skill_for_agent",
+        fake_install_agent_runtime_skill_for_agent,
+    )
+
+    client = await client_factory()
+    response = await client.post(
+        "/api/team-orchestration/provision",
+        json={
+            "goal": "Coordinate release readiness",
+            "roles": [
+                {
+                    "key": "reviewer",
+                    "name": "Release Reviewer",
+                    "brief": "Checks release criteria.",
+                    "skills": [
+                        {
+                            "manifest": {
+                                "name": "release-checks",
+                                "skillMd": "---\nname: release-checks\n---\nCheck the release.",
+                            }
+                        }
+                    ],
+                }
+            ],
+            "start_runs": True,
+        },
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert response.status_code == 201, response.text
+    body = response.json()
+    agent_id = body["roles"][0]["cloud_agent"]["agent_id"]
+    assert events == [("install", agent_id, "release-checks")]
+    assert body["roles"][0]["run_status"] == "queued"
+    assert body["roles"][0]["role"]["skills"][0]["manifest"]["name"] == "release-checks"
+
+
+@pytest.mark.asyncio
+async def test_provision_retries_role_skill_install_until_cloud_agent_is_loaded(
+    client_factory,
+    seed_user,
+    monkeypatch,
+):
+    import app.routers.runtime_skills as runtime_skills_mod
+
+    monkeypatch.setattr(runtime_skills_mod, "is_cloud_daemon_online", lambda _id: True)
+
+    async def no_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr(runtime_skills_mod.asyncio, "sleep", no_sleep)
+
+    calls = 0
+    probed_at = int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000)
+
+    async def fake_send_cloud_control_frame(
+        cloud_daemon_instance_id,
+        type_,
+        params=None,
+        timeout_ms=None,
+    ):
+        nonlocal calls
+        del cloud_daemon_instance_id, timeout_ms
+        calls += 1
+        assert type_ == "install_agent_skill"
+        if calls == 1:
+            return {
+                "ok": False,
+                "error": {
+                    "code": "agent_not_loaded",
+                    "message": "agent is still loading",
+                },
+            }
+        return {
+            "ok": True,
+            "result": {
+                "agentId": params["agentId"],
+                "installed": [{"name": "release-checks", "targets": ["codex"], "paths": []}],
+                "snapshot": {
+                    "agentId": params["agentId"],
+                    "skills": [
+                        {
+                            "name": "release-checks",
+                            "source": "runtime-global",
+                            "description": "Release support",
+                            "mtimeMs": probed_at,
+                        }
+                    ],
+                    "probedAt": probed_at,
+                },
+            },
+        }
+
+    monkeypatch.setattr(
+        runtime_skills_mod,
+        "send_cloud_control_frame",
+        fake_send_cloud_control_frame,
+    )
+
+    client = await client_factory()
+    response = await client.post(
+        "/api/team-orchestration/provision",
+        json={
+            "goal": "Coordinate release readiness",
+            "roles": [
+                {
+                    "key": "reviewer",
+                    "name": "Release Reviewer",
+                    "brief": "Checks release criteria.",
+                    "runtime": "codex",
+                    "skills": [
+                        {
+                            "manifest": {
+                                "name": "release-checks",
+                                "skillMd": "---\nname: release-checks\n---\nCheck the release.",
+                            }
+                        }
+                    ],
+                }
+            ],
+            "start_runs": False,
+        },
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+
+    assert response.status_code == 201, response.text
+    assert calls == 2

--- a/packages/daemon/src/__tests__/skill-installer.test.ts
+++ b/packages/daemon/src/__tests__/skill-installer.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  agentCodexHomeDir,
+  agentWorkspaceDir,
+} from "../agent-workspace.js";
+import {
+  buildVercelSkillsArgs,
+  installAgentSkillManifest,
+  installBotLearnArchiveManifest,
+  installVercelSkillsForAgent,
+} from "../skill-installer.js";
+
+let tmpHome = "";
+let prevHome: string | undefined;
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(path.join(tmpdir(), "skill-installer-"));
+  prevHome = process.env.HOME;
+  process.env.HOME = tmpHome;
+});
+
+afterEach(() => {
+  if (prevHome === undefined) delete process.env.HOME;
+  else process.env.HOME = prevHome;
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe("skill installer", () => {
+  it("installs a manifest into the loaded agent runtime path and returns a refreshed snapshot", () => {
+    const result = installAgentSkillManifest(
+      "ag_manifest",
+      {
+        name: "review-helper",
+        description: "Review pull requests",
+        files: [{ path: "references/checklist.md", content: "Check tests\n" }],
+      },
+      { runtime: "codex" },
+    );
+
+    const skillDir = path.join(agentCodexHomeDir("ag_manifest"), "skills", "review-helper");
+    expect(readFileSync(path.join(skillDir, "SKILL.md"), "utf8")).toContain("name: review-helper");
+    expect(readFileSync(path.join(skillDir, "references", "checklist.md"), "utf8")).toBe("Check tests\n");
+    expect(result.installed).toEqual([
+      {
+        name: "review-helper",
+        targets: ["codex"],
+        paths: [skillDir],
+      },
+    ]);
+    expect(result.snapshot.skills.map((s) => s.name)).toContain("review-helper");
+  });
+
+  it("installs BotLearn archive-style manifests containing multiple skills", () => {
+    const result = installBotLearnArchiveManifest(
+      "ag_archive",
+      {
+        targetRuntimes: ["claude-code"],
+        skills: [
+          {
+            id: "planner",
+            description: "Plan work",
+            skillMd: "---\nname: planner\ndescription: Plan work\n---\n\n# Planner\n",
+          },
+          {
+            name: "tester",
+            markdown: "---\nname: tester\n---\n\n# Tester\n",
+          },
+        ],
+      },
+      { runtime: "claude-code" },
+    );
+
+    const skillsRoot = path.join(agentWorkspaceDir("ag_archive"), ".claude", "skills");
+    expect(existsSync(path.join(skillsRoot, "planner", "SKILL.md"))).toBe(true);
+    expect(existsSync(path.join(skillsRoot, "tester", "SKILL.md"))).toBe(true);
+    expect(result.installed.map((skill) => skill.name)).toEqual(["planner", "tester"]);
+    expect(result.snapshot.skills.map((skill) => skill.name).sort()).toEqual(["planner", "tester"]);
+  });
+
+  it("rejects unsafe names and file paths before writing", () => {
+    expect(() => installAgentSkillManifest("ag_unsafe_name", {
+      name: "../bad",
+    })).toThrow(/unsafe skill name/);
+
+    expect(() => installAgentSkillManifest("ag_unsafe_file", {
+      name: "safe",
+      files: [{ path: "../escape.txt", content: "no" }],
+    })).toThrow(/unsafe skill file path/);
+  });
+
+  it("does not leave a partial skill dir when source file validation fails", () => {
+    const sourceRoot = mkdtempSync(path.join(tmpdir(), "skill-source-"));
+    try {
+      expect(() => installAgentSkillManifest("ag_missing_source", {
+        name: "missing-source",
+        files: [{ path: "references/missing.md", sourcePath: "missing.md" }],
+      }, {
+        runtime: "codex",
+        sourceRoot,
+      })).toThrow();
+
+      const skillDir = path.join(agentCodexHomeDir("ag_missing_source"), "skills", "missing-source");
+      expect(existsSync(skillDir)).toBe(false);
+    } finally {
+      rmSync(sourceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("does not leave a partial skill dir when an inline file is oversized", () => {
+    const oversized = "x".repeat((256 * 1024) + 1);
+
+    expect(() => installAgentSkillManifest("ag_oversized", {
+      name: "oversized",
+      files: [{ path: "references/large.md", content: oversized }],
+    }, {
+      runtime: "codex",
+    })).toThrow(/skill file too large/);
+
+    const skillDir = path.join(agentCodexHomeDir("ag_oversized"), "skills", "oversized");
+    expect(existsSync(skillDir)).toBe(false);
+  });
+
+  it("builds a non-interactive vercel-labs/skills command for injected execution", () => {
+    expect(buildVercelSkillsArgs("https://github.com/vercel-labs/skills", ["frontend-design"], ["codex"]))
+      .toEqual([
+        "--yes",
+        "skills",
+        "add",
+        "https://github.com/vercel-labs/skills",
+        "--global",
+        "--copy",
+        "--yes",
+        "--skill",
+        "frontend-design",
+        "--agent",
+        "codex",
+      ]);
+  });
+
+  it("imports skills produced by an injected vercel-labs/skills executor without network", async () => {
+    const executor = vi.fn(async (_command, _args, options) => {
+      const home = options.env?.HOME as string;
+      const namespaced = path.join(home, ".codex", "skills", "vercel-labs", "find-skills");
+      mkdirSync(namespaced, { recursive: true });
+      writeFileSync(
+        path.join(namespaced, "SKILL.md"),
+        "---\nname: find-skills\ndescription: Find skills\n---\n\n# Find Skills\n",
+      );
+    });
+
+    const result = await installVercelSkillsForAgent({
+      agentId: "ag_vercel",
+      packageSpec: "https://github.com/vercel-labs/skills",
+      skills: ["find-skills"],
+      runtime: "codex",
+      executor,
+    });
+
+    const installed = path.join(agentCodexHomeDir("ag_vercel"), "skills", "find-skills", "SKILL.md");
+    expect(existsSync(installed)).toBe(true);
+    expect(result.installed).toEqual([
+      {
+        name: "find-skills",
+        targets: ["codex"],
+        paths: [path.dirname(installed)],
+      },
+    ]);
+    expect(result.snapshot.skills.map((skill) => skill.name)).toContain("find-skills");
+    expect(executor).toHaveBeenCalledWith(
+      "npx",
+      expect.arrayContaining(["skills", "add", "https://github.com/vercel-labs/skills"]),
+      expect.objectContaining({ cwd: agentWorkspaceDir("ag_vercel") }),
+    );
+  });
+
+  it("rejects untrusted vercel package specs", async () => {
+    await expect(installVercelSkillsForAgent({
+      agentId: "ag_untrusted_vercel",
+      packageSpec: "attacker/skills",
+      runtime: "codex",
+      executor: vi.fn(),
+    })).rejects.toThrow(/unsupported vercel skills packageSpec/);
+  });
+
+  it("rejects symlinked files from vercel skill import without installing a skill dir", async () => {
+    const outside = mkdtempSync(path.join(tmpdir(), "skill-outside-"));
+    try {
+      writeFileSync(path.join(outside, "secret.txt"), "do not copy");
+      const executor = vi.fn(async (_command, _args, options) => {
+        const home = options.env?.HOME as string;
+        const skillDir = path.join(home, ".codex", "skills", "vercel-labs", "linked-skill");
+        mkdirSync(skillDir, { recursive: true });
+        writeFileSync(
+          path.join(skillDir, "SKILL.md"),
+          "---\nname: linked-skill\n---\n\n# Linked Skill\n",
+        );
+        symlinkSync(path.join(outside, "secret.txt"), path.join(skillDir, "secret.txt"));
+      });
+
+      await expect(installVercelSkillsForAgent({
+        agentId: "ag_vercel_symlink",
+        packageSpec: "https://github.com/vercel-labs/skills",
+        runtime: "codex",
+        executor,
+      })).rejects.toThrow(/rejects symlink/);
+
+      const skillDir = path.join(agentCodexHomeDir("ag_vercel_symlink"), "skills", "linked-skill");
+      expect(existsSync(skillDir)).toBe(false);
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -28,6 +28,8 @@ import {
   type StoredBotCordCredentials,
   type UpdateAgentParams,
   type GatewayInboundFrame,
+  type InstallAgentSkillParams,
+  type ListAgentSkillsParams,
 } from "@botcord/protocol-core";
 import type { Gateway } from "./gateway/index.js";
 import type { GatewayInboundMessage } from "./gateway/index.js";
@@ -77,6 +79,11 @@ import { resolveMemoryDir } from "./working-memory.js";
 import { discoverRuntimeModelCatalog } from "./runtime-models.js";
 import { collectAgentSkillSnapshot, type SkillIndexOptions } from "./skill-index.js";
 import {
+  installAgentSkillManifest,
+  installBotLearnArchiveManifest,
+  installVercelSkillsForAgent,
+} from "./skill-installer.js";
+import {
   buildRuntimeSelectionExtraArgs,
   mergeRuntimeExtraArgs,
 } from "./runtime-route-options.js";
@@ -84,10 +91,6 @@ import {
   handleCloudGatewayRuntimeInbound,
   type CloudGatewayTypingEmitter,
 } from "./cloud-gateway-runtime.js";
-
-interface ListAgentSkillsParams {
-  agentId: string;
-}
 
 function skillIndexOptionsForLoadedAgent(gateway: Gateway, agentId: string): SkillIndexOptions {
   const route = gateway.listManagedRoutes()
@@ -535,6 +538,66 @@ export function createProvisioner(opts: ProvisionerOptions): (
           runtime: skillIndexOptions.runtime,
           hermesProfile: skillIndexOptions.hermesProfile ?? null,
           count: result.skills.length,
+        });
+        return { ok: true, result };
+      }
+
+      case CONTROL_FRAME_TYPES.INSTALL_AGENT_SKILL: {
+        const params = (frame.params ?? {}) as unknown as InstallAgentSkillParams;
+        if (!params.agentId) {
+          return {
+            ok: false,
+            error: { code: "bad_params", message: "install_agent_skill requires params.agentId" },
+          };
+        }
+        const channels = gateway.snapshot().channels;
+        if (!channels[params.agentId]) {
+          return {
+            ok: false,
+            error: {
+              code: "agent_not_loaded",
+              message: `agent ${params.agentId} is not loaded in daemon gateway`,
+            },
+          };
+        }
+        const skillIndexOptions = skillIndexOptionsForLoadedAgent(gateway, params.agentId);
+        const runtime = skillIndexOptions.runtime;
+        const modes = [params.manifest, params.archiveManifest, params.vercel].filter(Boolean).length;
+        if (modes !== 1) {
+          return {
+            ok: false,
+            error: {
+              code: "bad_params",
+              message: "install_agent_skill requires exactly one of manifest, archiveManifest, or vercel",
+            },
+          };
+        }
+        let result;
+        try {
+          result = params.vercel
+            ? await installVercelSkillsForAgent({
+              agentId: params.agentId,
+              packageSpec: params.vercel.packageSpec,
+              skills: params.vercel.skills,
+              runtime,
+            })
+            : params.archiveManifest
+              ? installBotLearnArchiveManifest(params.agentId, params.archiveManifest, { runtime })
+              : installAgentSkillManifest(params.agentId, params.manifest!, { runtime });
+        } catch (err) {
+          return {
+            ok: false,
+            error: {
+              code: "skill_install_failed",
+              message: err instanceof Error ? err.message : String(err),
+            },
+          };
+        }
+        daemonLog.debug("install_agent_skill", {
+          agentId: params.agentId,
+          runtime,
+          installed: result.installed.map((s) => s.name),
+          snapshotCount: result.snapshot.skills.length,
         });
         return { ok: true, result };
       }

--- a/packages/daemon/src/skill-installer.ts
+++ b/packages/daemon/src/skill-installer.ts
@@ -1,0 +1,472 @@
+import { execFile, type ExecFileOptions } from "node:child_process";
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import {
+  agentCodexHomeDir,
+  agentWorkspaceDir,
+} from "./agent-workspace.js";
+import {
+  collectAgentSkillSnapshot,
+  type AgentSkillSnapshot,
+} from "./skill-index.js";
+
+const execFileAsync = promisify(execFile);
+
+const SAFE_SKILL_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/;
+const MAX_INLINE_FILE_BYTES = 256 * 1024;
+const TRUSTED_VERCEL_PACKAGE_SPECS = new Set([
+  "https://github.com/vercel-labs/skills",
+  "github:vercel-labs/skills",
+  "vercel-labs/skills",
+]);
+
+export type SkillInstallTarget = "claude-code" | "codex";
+
+export interface SkillFileManifest {
+  path: string;
+  content?: string;
+  sourcePath?: string;
+}
+
+export interface SkillManifestInput {
+  name?: string;
+  id?: string;
+  description?: string;
+  skillMd?: string;
+  markdown?: string;
+  files?: SkillFileManifest[];
+  targetRuntimes?: SkillInstallTarget[];
+}
+
+export interface SkillArchiveManifestInput {
+  name?: string;
+  id?: string;
+  description?: string;
+  skillMd?: string;
+  markdown?: string;
+  files?: SkillFileManifest[];
+  skills?: SkillManifestInput[];
+  targetRuntimes?: SkillInstallTarget[];
+}
+
+export interface NormalizedSkillManifest {
+  name: string;
+  description?: string;
+  skillMd: string;
+  files: SkillFileManifest[];
+  targetRuntimes?: SkillInstallTarget[];
+}
+
+export interface InstalledSkillRecord {
+  name: string;
+  targets: SkillInstallTarget[];
+  paths: string[];
+}
+
+export interface AgentSkillInstallResult {
+  agentId: string;
+  installed: InstalledSkillRecord[];
+  snapshot: AgentSkillSnapshot;
+}
+
+export interface InstallAgentSkillManifestOptions {
+  runtime?: string;
+  sourceRoot?: string;
+}
+
+export interface VercelSkillsInstallOptions {
+  agentId: string;
+  packageSpec: string;
+  skills?: string[];
+  runtime?: string;
+  executor?: VercelSkillsExecutor;
+}
+
+export type VercelSkillsExecutor = (
+  command: string,
+  args: string[],
+  options: ExecFileOptions,
+) => Promise<void>;
+
+export function normalizeSkillManifest(input: SkillManifestInput): NormalizedSkillManifest {
+  const rawName = input.name ?? input.id;
+  if (!rawName) throw new Error("skill manifest requires name or id");
+  const name = assertSafeSkillName(rawName);
+  const description = sanitizeInline(input.description ?? "");
+  const skillMd = input.skillMd ?? input.markdown ?? renderSkillMarkdown(name, description);
+  if (!skillMd.trim()) throw new Error(`skill ${name} has empty SKILL.md content`);
+  return {
+    name,
+    ...(description ? { description } : {}),
+    skillMd,
+    files: input.files ?? [],
+    ...(input.targetRuntimes ? { targetRuntimes: normalizeTargets(input.targetRuntimes) } : {}),
+  };
+}
+
+export function installAgentSkillManifest(
+  agentId: string,
+  manifest: SkillManifestInput,
+  opts: InstallAgentSkillManifestOptions = {},
+): AgentSkillInstallResult {
+  const normalized = normalizeSkillManifest(manifest);
+  const installed = [
+    installNormalizedSkill(agentId, normalized, opts),
+  ];
+  return {
+    agentId,
+    installed,
+    snapshot: collectAgentSkillSnapshot(agentId, { runtime: opts.runtime }),
+  };
+}
+
+export function installBotLearnArchiveManifest(
+  agentId: string,
+  archive: SkillArchiveManifestInput,
+  opts: InstallAgentSkillManifestOptions = {},
+): AgentSkillInstallResult {
+  const skills = archive.skills && archive.skills.length > 0
+    ? archive.skills
+    : [archive];
+  const installed = skills.map((skill) => installNormalizedSkill(
+    agentId,
+    normalizeSkillManifest({
+      ...skill,
+      targetRuntimes: skill.targetRuntimes ?? archive.targetRuntimes,
+    }),
+    opts,
+  ));
+  return {
+    agentId,
+    installed,
+    snapshot: collectAgentSkillSnapshot(agentId, { runtime: opts.runtime }),
+  };
+}
+
+export async function installVercelSkillsForAgent(
+  opts: VercelSkillsInstallOptions,
+): Promise<AgentSkillInstallResult> {
+  const packageSpec = normalizeTrustedVercelPackageSpec(opts.packageSpec);
+  const workspace = agentWorkspaceDir(opts.agentId);
+  const tempHome = mkdtempSync(path.join(tmpdir(), "botcord-skills-"));
+  const targets = targetsForRuntime(opts.runtime);
+  const executor = opts.executor ?? defaultVercelSkillsExecutor;
+  const args = buildVercelSkillsArgs(packageSpec, opts.skills, targets);
+  try {
+    await executor("npx", args, {
+      cwd: workspace,
+      env: {
+        ...process.env,
+        HOME: tempHome,
+        USERPROFILE: tempHome,
+      },
+    });
+    const installed = importVercelInstalledSkills(opts.agentId, tempHome, targets);
+    return {
+      agentId: opts.agentId,
+      installed,
+      snapshot: collectAgentSkillSnapshot(opts.agentId, { runtime: opts.runtime }),
+    };
+  } finally {
+    rmSync(tempHome, { recursive: true, force: true });
+  }
+}
+
+export function buildVercelSkillsArgs(
+  packageSpec: string,
+  skills: string[] | undefined,
+  targets: SkillInstallTarget[],
+): string[] {
+  const normalizedPackageSpec = normalizeTrustedVercelPackageSpec(packageSpec);
+  const args = ["--yes", "skills", "add", normalizedPackageSpec, "--global", "--copy", "--yes"];
+  for (const skill of skills ?? []) {
+    if (!skill.trim()) continue;
+    args.push("--skill", skill);
+  }
+  for (const target of targets) {
+    args.push("--agent", target === "codex" ? "codex" : "claude-code");
+  }
+  return args;
+}
+
+function installNormalizedSkill(
+  agentId: string,
+  manifest: NormalizedSkillManifest,
+  opts: InstallAgentSkillManifestOptions,
+): InstalledSkillRecord {
+  const targets = manifest.targetRuntimes ?? targetsForRuntime(opts.runtime);
+  validateSkillFiles(manifest.files, opts.sourceRoot);
+  const paths: string[] = [];
+  for (const target of targets) {
+    const skillDir = path.join(skillRootForTarget(agentId, target), manifest.name);
+    writeSkillDir(skillDir, manifest, opts.sourceRoot);
+    paths.push(skillDir);
+  }
+  return { name: manifest.name, targets, paths };
+}
+
+function writeSkillDir(
+  skillDir: string,
+  manifest: NormalizedSkillManifest,
+  sourceRoot: string | undefined,
+): void {
+  const parent = path.dirname(skillDir);
+  mkdirSync(parent, { recursive: true, mode: 0o700 });
+  const tempDir = mkdtempSync(path.join(parent, `.${path.basename(skillDir)}-tmp-`));
+  try {
+    writeFileSync(path.join(tempDir, "SKILL.md"), manifest.skillMd, { mode: 0o600 });
+    for (const file of manifest.files) {
+      const relativePath = assertSafeRelativePath(file.path);
+      const dest = path.join(tempDir, relativePath);
+      mkdirSync(path.dirname(dest), { recursive: true, mode: 0o700 });
+      if (file.content !== undefined) {
+        writeFileSync(dest, file.content, { mode: 0o600 });
+        continue;
+      }
+      copySafeSourcePath(sourceRoot!, file.sourcePath!, dest);
+    }
+    rmSync(skillDir, { recursive: true, force: true });
+    renameSync(tempDir, skillDir);
+  } catch (err) {
+    rmSync(tempDir, { recursive: true, force: true });
+    throw err;
+  }
+}
+
+function importVercelInstalledSkills(
+  agentId: string,
+  tempHome: string,
+  targets: SkillInstallTarget[],
+): InstalledSkillRecord[] {
+  const byName = new Map<string, InstalledSkillRecord>();
+  for (const target of targets) {
+    const sourceRoot = target === "codex"
+      ? path.join(tempHome, ".codex", "skills")
+      : path.join(tempHome, ".claude", "skills");
+    if (!existsSync(sourceRoot)) continue;
+    for (const sourceSkillDir of findSkillDirs(sourceRoot)) {
+      const name = assertSafeSkillName(readSkillName(sourceSkillDir));
+      const dest = path.join(skillRootForTarget(agentId, target), name);
+      copySafeSkillDir(sourceSkillDir, dest);
+      const existing = byName.get(name);
+      if (existing) {
+        existing.targets.push(target);
+        existing.paths.push(dest);
+      } else {
+        byName.set(name, { name, targets: [target], paths: [dest] });
+      }
+    }
+  }
+  return Array.from(byName.values()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function findSkillDirs(root: string): string[] {
+  const out: string[] = [];
+  const visit = (dir: string, depth: number): void => {
+    if (depth > 3) return;
+    const skillMd = path.join(dir, "SKILL.md");
+    if (existsSync(skillMd) && lstatSync(skillMd).isFile()) {
+      out.push(dir);
+      return;
+    }
+    let children: string[];
+    try {
+      children = readdirSync(dir).sort((a, b) => a.localeCompare(b));
+    } catch {
+      return;
+    }
+    for (const child of children) {
+      const childPath = path.join(dir, child);
+      try {
+        const childStat = lstatSync(childPath);
+        if (childStat.isSymbolicLink()) continue;
+        if (childStat.isDirectory()) visit(childPath, depth + 1);
+      } catch {
+        /* skip unreadable entries */
+      }
+    }
+  };
+  visit(root, 0);
+  return out;
+}
+
+function readSkillName(skillDir: string): string {
+  const fallback = path.basename(skillDir);
+  let raw = "";
+  try {
+    raw = readFileSync(path.join(skillDir, "SKILL.md"), "utf8").slice(0, 8192);
+  } catch {
+    return fallback;
+  }
+  const fm = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  const name = fm?.[1]?.match(/^name:\s*(.+?)\s*$/m)?.[1];
+  return name ? unquote(name).trim() : fallback;
+}
+
+function targetsForRuntime(runtime: string | undefined): SkillInstallTarget[] {
+  if (runtime === "codex") return ["codex"];
+  if (runtime === "claude-code") return ["claude-code"];
+  return ["claude-code", "codex"];
+}
+
+function normalizeTargets(targets: SkillInstallTarget[]): SkillInstallTarget[] {
+  const out: SkillInstallTarget[] = [];
+  for (const target of targets) {
+    if (target !== "claude-code" && target !== "codex") {
+      throw new Error(`unsupported skill target: ${String(target)}`);
+    }
+    if (!out.includes(target)) out.push(target);
+  }
+  if (out.length === 0) throw new Error("at least one target runtime is required");
+  return out;
+}
+
+function normalizeTrustedVercelPackageSpec(packageSpec: string): string {
+  const cleaned = packageSpec.trim();
+  if (!cleaned) throw new Error("packageSpec is required");
+  if (!TRUSTED_VERCEL_PACKAGE_SPECS.has(cleaned)) {
+    throw new Error(`unsupported vercel skills packageSpec: ${cleaned}`);
+  }
+  return cleaned;
+}
+
+function validateSkillFiles(files: SkillFileManifest[], sourceRoot: string | undefined): void {
+  for (const file of files) {
+    assertSafeRelativePath(file.path);
+    if (file.content !== undefined) {
+      if (Buffer.byteLength(file.content, "utf8") > MAX_INLINE_FILE_BYTES) {
+        throw new Error(`skill file too large: ${file.path}`);
+      }
+      continue;
+    }
+    if (!sourceRoot || !file.sourcePath) {
+      throw new Error(`skill file ${file.path} requires content or sourcePath with sourceRoot`);
+    }
+    resolveSafeSourcePath(sourceRoot, file.sourcePath);
+  }
+}
+
+function resolveSafeSourcePath(sourceRoot: string, relativeSourcePath: string): string {
+  const safeRelativePath = assertSafeRelativePath(relativeSourcePath);
+  const rootReal = realpathSync(sourceRoot);
+  const sourcePath = path.resolve(sourceRoot, safeRelativePath);
+  if (lstatSync(sourcePath).isSymbolicLink()) {
+    throw new Error(`unsafe source path symlink: ${relativeSourcePath}`);
+  }
+  const sourceReal = realpathSync(sourcePath);
+  if (sourceReal !== rootReal && !sourceReal.startsWith(`${rootReal}${path.sep}`)) {
+    throw new Error(`unsafe source path: ${relativeSourcePath}`);
+  }
+  return sourceReal;
+}
+
+function copySafeSourcePath(sourceRoot: string, relativeSourcePath: string, dest: string): void {
+  const source = resolveSafeSourcePath(sourceRoot, relativeSourcePath);
+  copyNoSymlinks(source, dest);
+}
+
+function copySafeSkillDir(sourceSkillDir: string, dest: string): void {
+  const parent = path.dirname(dest);
+  mkdirSync(parent, { recursive: true, mode: 0o700 });
+  const tempDir = mkdtempSync(path.join(parent, `.${path.basename(dest)}-tmp-`));
+  try {
+    copyNoSymlinks(sourceSkillDir, tempDir);
+    rmSync(dest, { recursive: true, force: true });
+    renameSync(tempDir, dest);
+  } catch (err) {
+    rmSync(tempDir, { recursive: true, force: true });
+    throw err;
+  }
+}
+
+function copyNoSymlinks(source: string, dest: string): void {
+  const sourceStat = lstatSync(source);
+  if (sourceStat.isSymbolicLink()) {
+    throw new Error(`skill import rejects symlink: ${source}`);
+  }
+  if (sourceStat.isDirectory()) {
+    mkdirSync(dest, { recursive: true, mode: 0o700 });
+    for (const child of readdirSync(source)) {
+      copyNoSymlinks(path.join(source, child), path.join(dest, child));
+    }
+    return;
+  }
+  if (!sourceStat.isFile()) {
+    throw new Error(`skill import supports only files and directories: ${source}`);
+  }
+  cpSync(source, dest, { force: true, dereference: false });
+}
+
+function skillRootForTarget(agentId: string, target: SkillInstallTarget): string {
+  return target === "codex"
+    ? path.join(agentCodexHomeDir(agentId), "skills")
+    : path.join(agentWorkspaceDir(agentId), ".claude", "skills");
+}
+
+function assertSafeSkillName(value: string): string {
+  const name = value.trim();
+  if (!SAFE_SKILL_NAME.test(name) || name === "." || name === "..") {
+    throw new Error(`unsafe skill name: ${JSON.stringify(value)}`);
+  }
+  return name;
+}
+
+function assertSafeRelativePath(value: string): string {
+  const normalized = path.normalize(value);
+  if (
+    !value ||
+    path.isAbsolute(value) ||
+    normalized === "." ||
+    normalized.startsWith("..") ||
+    normalized.split(path.sep).includes("..")
+  ) {
+    throw new Error(`unsafe skill file path: ${JSON.stringify(value)}`);
+  }
+  return normalized;
+}
+
+function renderSkillMarkdown(name: string, description?: string): string {
+  const desc = description ? `description: "${description.replace(/"/g, '\\"')}"\n` : "";
+  return `---\nname: ${name}\n${desc}---\n\n# ${name}\n`;
+}
+
+function sanitizeInline(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function unquote(value: string): string {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith("\"") && trimmed.endsWith("\"")) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+async function defaultVercelSkillsExecutor(
+  command: string,
+  args: string[],
+  options: ExecFileOptions,
+): Promise<void> {
+  await execFileAsync(command, args, {
+    ...options,
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+  });
+}

--- a/packages/protocol-core/src/control-frame.ts
+++ b/packages/protocol-core/src/control-frame.ts
@@ -88,6 +88,13 @@ export const CONTROL_FRAME_TYPES = {
    */
   LIST_AGENT_SKILLS: "list_agent_skills",
   /**
+   * Hub→daemon: install one skill manifest/archive into a BotCord agent's
+   * runtime-specific skill directory, then return the refreshed per-agent
+   * skill snapshot. Used by team orchestration role skill assignment and the
+   * runtime skills API.
+   */
+  INSTALL_AGENT_SKILL: "install_agent_skill",
+  /**
    * Daemon→Hub: event frame carrying the latest runtime-probe snapshot.
    * Pushed on first control-WS connect (P0) and on reconnect/diff (P1).
    * Hub persists the payload onto `daemon_instances.runtimes_json` so the
@@ -445,6 +452,46 @@ export interface ListAgentSkillsResult {
   runtime?: string;
   skills: AgentSkillProbe[];
   probedAt: number;
+}
+
+export type SkillInstallTarget = "claude-code" | "codex";
+
+export interface AgentSkillFileManifest {
+  path: string;
+  content?: string;
+  sourcePath?: string;
+}
+
+export interface AgentSkillManifestInput {
+  name?: string;
+  id?: string;
+  description?: string;
+  skillMd?: string;
+  markdown?: string;
+  files?: AgentSkillFileManifest[];
+  targetRuntimes?: SkillInstallTarget[];
+}
+
+export interface AgentSkillArchiveManifestInput {
+  name?: string;
+  id?: string;
+  description?: string;
+  skillMd?: string;
+  markdown?: string;
+  files?: AgentSkillFileManifest[];
+  skills?: AgentSkillManifestInput[];
+  targetRuntimes?: SkillInstallTarget[];
+}
+
+/** Payload shape for `install_agent_skill`. */
+export interface InstallAgentSkillParams {
+  agentId: string;
+  manifest?: AgentSkillManifestInput;
+  archiveManifest?: AgentSkillArchiveManifestInput;
+  vercel?: {
+    packageSpec: string;
+    skills?: string[];
+  };
 }
 
 /** Payload shape for `revoke_agent`. */


### PR DESCRIPTION
## Summary
- add team orchestration plan/provision APIs for creating role cloud agents, rooms/topics, and kickoff runs
- add runtime skill install API plus daemon `install_agent_skill` handling for inline/archive/vercel-labs skills
- add compensation cleanup for failed provisioning paths, including persisted-then-raise cloud agent creation and skill/room/topic failures
- harden skill install with target runtime validation, trusted Vercel package specs, atomic writes, and symlink rejection

## Verification
- `backend/.venv/bin/python -m pytest backend/tests/test_app/test_team_orchestration.py backend/tests/test_app/test_cloud_agents.py -q` => 35 passed, known JWT warnings
- `MISE_TRUSTED_CONFIG_PATHS=$PWD pnpm --dir packages/daemon exec vitest run src/__tests__/provision.test.ts src/__tests__/skill-installer.test.ts` => 74 passed
- `MISE_TRUSTED_CONFIG_PATHS=$PWD pnpm --dir packages/daemon exec tsc -p tsconfig.build.json` => passed
- `MISE_TRUSTED_CONFIG_PATHS=$PWD pnpm --dir packages/protocol-core exec tsc` => passed

## Review
- Code Reviewer reported no blocking findings after rollback blocker re-review.
