### PR TITLE
fix: scan Gemini skill roots

### DIFF
--- a/packages/daemon/src/__tests__/skill-index.test.ts
+++ b/packages/daemon/src/__tests__/skill-index.test.ts
@@ -149,6 +149,47 @@ describe("skill snapshots", () => {
     });
   });
 
+  it("scans Gemini workspace and user skill roots without mixing Claude or Codex dirs", () => {
+    const agentId = "ag_gemini_skills";
+    const workspaceGemini = path.join(agentWorkspaceDir(agentId), ".gemini", "skills");
+    const workspaceAgents = path.join(agentWorkspaceDir(agentId), ".agents", "skills");
+    writeSkill(workspaceGemini, "workspace-gemini", "Workspace Gemini skill");
+    writeSkill(workspaceAgents, "workspace-agent", "Workspace shared-agent skill");
+    writeSkill(path.join(tmpDir, ".gemini", "skills"), "global-gemini", "Global Gemini skill");
+    writeSkill(path.join(tmpDir, ".agents", "skills"), "global-agent", "Global shared-agent skill");
+    writeSkill(path.join(agentWorkspaceDir(agentId), ".claude", "skills"), "claude-only", "Claude only");
+    writeSkill(path.join(agentCodexHomeDir(agentId), "skills"), "codex-only", "Codex only");
+
+    const geminiScanned = scanSoftSkills(agentId, { runtime: "gemini" });
+    expect(geminiScanned.map((s) => s.name)).toEqual([
+      "global-agent",
+      "global-gemini",
+      "workspace-agent",
+      "workspace-gemini",
+    ]);
+    expect(geminiScanned.every((s) => s.runtime === "gemini")).toBe(true);
+
+    const snapshot = collectAgentSkillSnapshot(agentId, { runtime: "gemini" });
+    expect(snapshot.runtime).toBe("gemini");
+    expect(snapshot.skills.find((s) => s.name === "workspace-gemini"))
+      .toMatchObject({
+        source: "workspace",
+        sourceDetail: "agent-gemini",
+        runtime: "gemini",
+        path: path.join(workspaceGemini, "workspace-gemini", "SKILL.md"),
+      });
+    expect(snapshot.skills.find((s) => s.name === "workspace-agent"))
+      .toMatchObject({
+        source: "workspace",
+        sourceDetail: "agent-agents",
+      });
+    expect(snapshot.skills.find((s) => s.name === "global-agent"))
+      .toMatchObject({
+        source: "runtime-global",
+        sourceDetail: "global-agents",
+      });
+  });
+
   it("keeps same-device workspace skills scoped by agent id", () => {
     writeSkill(
       path.join(agentWorkspaceDir("ag_workspace_a"), ".claude", "skills"),

--- a/packages/daemon/src/skill-index.ts
+++ b/packages/daemon/src/skill-index.ts
@@ -74,6 +74,18 @@ export function defaultSkillDirs(
     source: "agent-codex",
     runtime: "codex",
   };
+  const agentGemini = [
+    {
+      dir: path.join(agentWorkspaceDir(agentId), ".gemini", "skills"),
+      source: "agent-gemini",
+      runtime: "gemini",
+    },
+    {
+      dir: path.join(agentWorkspaceDir(agentId), ".agents", "skills"),
+      source: "agent-agents",
+      runtime: "gemini",
+    },
+  ];
   const agentHermes = hermesSkillRoot(agentId, opts.hermesProfile);
 
   const dirs: SkillRoot[] = [];
@@ -90,6 +102,23 @@ export function defaultSkillDirs(
       break;
     case "hermes":
       dirs.push(agentHermes);
+      break;
+    case "gemini":
+      dirs.push(...agentGemini);
+      if (includeGlobal) {
+        dirs.push(
+          {
+            dir: path.join(homedir(), ".gemini", "skills"),
+            source: "global-gemini",
+            runtime: "gemini",
+          },
+          {
+            dir: path.join(homedir(), ".agents", "skills"),
+            source: "global-agents",
+            runtime: "gemini",
+          },
+        );
+      }
       break;
     case "claude":
       dirs.push(agentClaude);
@@ -308,8 +337,9 @@ function hermesSkillRoot(agentId: string, profile: string | undefined): SkillRoo
   };
 }
 
-function runtimeFamily(runtime: string | undefined): "codex" | "claude" | "hermes" | "other" {
+function runtimeFamily(runtime: string | undefined): "codex" | "claude" | "gemini" | "hermes" | "other" {
   if (runtime === "codex") return "codex";
+  if (runtime === "gemini") return "gemini";
   if (runtime === "hermes-agent") return "hermes";
   if (!runtime) return "claude";
   if (runtime === "claude-code") return "claude";
@@ -317,18 +347,9 @@ function runtimeFamily(runtime: string | undefined): "codex" | "claude" | "herme
 }
 
 function priority(source: string, _runtime: string | undefined): number {
-  switch (source) {
-    case "agent-claude":
-    case "agent-codex":
-    case "agent-hermes":
-    case "agent-hermes-profile":
-      return 0;
-    case "global-claude":
-    case "global-codex":
-      return 1;
-    default:
-      return 2;
-  }
+  if (source.startsWith("agent-")) return 0;
+  if (source.startsWith("global-")) return 1;
+  return 2;
 }
 
 function snapshotSource(source: string): "workspace" | "runtime-global" {


### PR DESCRIPTION
## Summary
- classify the gemini runtime in the daemon skill scanner instead of falling through to other
- scan Gemini-visible workspace and user skill roots: .gemini/skills and .agents/skills
- add coverage that Gemini snapshots do not mix Claude/Codex skill directories

## Verification
- pnpm test -- --run src/__tests__/skill-index.test.ts (packages/daemon)
- pnpm --filter @botcord/protocol-core build && pnpm --filter @botcord/daemon build

## Risk / rollout
- No DB migration. Daemons need the updated package and restart/reconnect to push refreshed skill snapshots.