### PR TITLE
fix: queue proactive schedule runs

### DIFF
--- a/backend/hub/routers/daemon_control.py
+++ b/backend/hub/routers/daemon_control.py
@@ -670,22 +670,42 @@ async def restart_instance(
     db: AsyncSession = Depends(get_db),
 ) -> _InstanceView:
     instance = await _load_owned_instance(db, ctx.user_id, daemon_instance_id)
-    if instance.kind != "cloud":
-        raise HTTPException(status_code=409, detail="restart_only_supported_for_cloud_daemon")
+    if instance.revoked_at is not None:
+        raise HTTPException(status_code=409, detail="daemon_revoked")
 
-    from hub.services.cloud_agent import CloudAgentError, CloudAgentService
+    if instance.kind == "cloud":
+        from hub.services.cloud_agent import CloudAgentError, CloudAgentService
 
-    try:
-        await CloudAgentService().restart_cloud_daemon(
-            db,
-            user_id=ctx.user_id,
-            daemon_instance_id=daemon_instance_id,
+        try:
+            await CloudAgentService().restart_cloud_daemon(
+                db,
+                user_id=ctx.user_id,
+                daemon_instance_id=daemon_instance_id,
+            )
+        except CloudAgentError as exc:
+            raise HTTPException(
+                status_code=exc.http_status,
+                detail={"code": exc.code, "message": exc.message},
+            ) from exc
+    else:
+        ack = await send_control_frame(
+            daemon_instance_id,
+            "restart_daemon",
+            {"update": True},
+            timeout_ms=10000,
         )
-    except CloudAgentError as exc:
-        raise HTTPException(
-            status_code=exc.http_status,
-            detail={"code": exc.code, "message": exc.message},
-        ) from exc
+        if not isinstance(ack, dict) or not ack.get("ok"):
+            err = ack.get("error") if isinstance(ack, dict) else None
+            code = (err or {}).get("code") if isinstance(err, dict) else None
+            message = (err or {}).get("message") if isinstance(err, dict) else None
+            raise HTTPException(
+                status_code=502,
+                detail={
+                    "code": "upstream_error",
+                    "daemon_code": code,
+                    "daemon_message": message,
+                },
+            )
 
     await db.refresh(instance)
     return _instance_to_view(instance)
@@ -897,6 +917,7 @@ _ALLOWED_DISPATCH_TYPES = {
     "set_route",
     "ping",
     "list_runtimes",
+    "restart_daemon",
     "collect_diagnostics",
     # PR3: BFF fans this out from PATCH /api/agents/{id}/policy and the
     # per-room override endpoints (the latter ship in PR2). Daemon handler

--- a/backend/tests/test_app/test_daemon_control.py
+++ b/backend/tests/test_app/test_daemon_control.py
@@ -505,6 +505,72 @@ async def test_restart_cloud_daemon_instance(
     assert calls == [(seed_user["user_id"], cloud_daemon_row.id)]
 
 
+@pytest.mark.asyncio
+async def test_restart_local_daemon_dispatches_restart_frame(
+    client: AsyncClient, seed_user
+):
+    bundle = await _provision_instance_via_device_code(client, seed_user)
+    instance_id = bundle["daemon_instance_id"]
+
+    from hub.routers.daemon_control import _DaemonConn, _registry_for_tests
+
+    fake_ws = _FakeWS()
+    conn = _DaemonConn(
+        ws=fake_ws,  # type: ignore[arg-type]
+        user_id=str(seed_user["user_id"]),
+        daemon_instance_id=instance_id,
+        pending_acks={},
+    )
+    registry = _registry_for_tests()
+    await registry.register(conn)
+    try:
+        async def _reply_when_sent() -> None:
+            for _ in range(50):
+                if fake_ws.sent:
+                    break
+                await asyncio.sleep(0.01)
+            assert fake_ws.sent, "restart dispatch never wrote to fake WS"
+            sent_frame = json.loads(fake_ws.sent[0])
+            assert sent_frame["type"] == "restart_daemon"
+            assert sent_frame["params"] == {"update": True}
+            assert sent_frame["sig"]
+            fut = conn.pending_acks.get(sent_frame["id"])
+            assert fut is not None
+            fut.set_result(
+                {
+                    "id": sent_frame["id"],
+                    "ok": True,
+                    "result": {"scheduled": True, "updateRequested": True},
+                }
+            )
+
+        reply_task = asyncio.create_task(_reply_when_sent())
+        r = await client.post(
+            f"/daemon/instances/{instance_id}/restart",
+            headers={"Authorization": f"Bearer {seed_user['token']}"},
+        )
+        await reply_task
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["id"] == instance_id
+        assert body["kind"] == "local"
+    finally:
+        await registry.unregister(conn)
+
+
+@pytest.mark.asyncio
+async def test_restart_local_daemon_offline_returns_409(client: AsyncClient, seed_user):
+    bundle = await _provision_instance_via_device_code(client, seed_user)
+    instance_id = bundle["daemon_instance_id"]
+
+    r = await client.post(
+        f"/daemon/instances/{instance_id}/restart",
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert r.status_code == 409
+    assert r.json()["detail"] == "daemon_offline"
+
+
 # ---------------------------------------------------------------------------
 # Rename (label update)
 # ---------------------------------------------------------------------------

--- a/frontend/src/app/api/daemon/instances/[id]/restart/route.ts
+++ b/frontend/src/app/api/daemon/instances/[id]/restart/route.ts
@@ -1,0 +1,23 @@
+/**
+ * [INPUT]: Supabase user session, daemon instance id from path
+ * [OUTPUT]: POST /api/daemon/instances/[id]/restart — restart/update a daemon instance
+ * [POS]: BFF endpoint for Dashboard device restart actions
+ * [PROTOCOL]: update header on changes
+ */
+
+import { NextResponse } from "next/server";
+import { proxyDaemon } from "../../../_lib/proxy";
+
+export async function POST(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  if (!id) {
+    return NextResponse.json({ error: "missing_id" }, { status: 400 });
+  }
+  return proxyDaemon(
+    `/daemon/instances/${encodeURIComponent(id)}/restart`,
+    { method: "POST" },
+  );
+}

--- a/frontend/src/components/daemon/DaemonsSettingsPage.tsx
+++ b/frontend/src/components/daemon/DaemonsSettingsPage.tsx
@@ -400,6 +400,7 @@ export default function DaemonsSettingsPage() {
   const loaded = useDaemonStore((s) => s.loaded);
   const error = useDaemonStore((s) => s.error);
   const revokingId = useDaemonStore((s) => s.revokingId);
+  const restartingId = useDaemonStore((s) => s.restartingId);
   const renamingId = useDaemonStore((s) => s.renamingId);
   const renameErrors = useDaemonStore((s) => s.renameErrors);
   const refreshingRuntimesId = useDaemonStore((s) => s.refreshingRuntimesId);
@@ -409,6 +410,7 @@ export default function DaemonsSettingsPage() {
   const diagnosticResults = useDaemonStore((s) => s.diagnosticResults);
   const refresh = useDaemonStore((s) => s.refresh);
   const revoke = useDaemonStore((s) => s.revoke);
+  const restartDevice = useDaemonStore((s) => s.restartDevice);
   const rename = useDaemonStore((s) => s.rename);
   const refreshRuntimes = useDaemonStore((s) => s.refreshRuntimes);
   const collectDiagnostics = useDaemonStore((s) => s.collectDiagnostics);
@@ -556,15 +558,38 @@ export default function DaemonsSettingsPage() {
                       </td>
                       <td className="px-4 pt-3 text-right">
                         {d.status !== "revoked" && (
-                          <button
-                            type="button"
-                            onClick={() => setConfirmTarget(d)}
-                            disabled={revokingId === d.id}
-                            className="inline-flex items-center gap-1 text-xs text-text-secondary transition-colors hover:text-red-300 disabled:opacity-50"
-                          >
-                            <XCircle className="h-3.5 w-3.5" />
-                            Revoke
-                          </button>
+                          <div className="flex justify-end gap-3">
+                            <button
+                              type="button"
+                              onClick={() => void restartDevice(d.id)}
+                              disabled={
+                                restartingId === d.id ||
+                                (d.kind !== "cloud" && d.status !== "online")
+                              }
+                              title={
+                                d.status === "online" || d.kind === "cloud"
+                                  ? "Pull latest daemon and reconnect"
+                                  : "Daemon must be online to restart remotely"
+                              }
+                              className="inline-flex items-center gap-1 text-xs text-text-secondary transition-colors hover:text-neon-cyan disabled:opacity-50"
+                            >
+                              {restartingId === d.id ? (
+                                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                              ) : (
+                                <RefreshCcw className="h-3.5 w-3.5" />
+                              )}
+                              Restart
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => setConfirmTarget(d)}
+                              disabled={revokingId === d.id}
+                              className="inline-flex items-center gap-1 text-xs text-text-secondary transition-colors hover:text-red-300 disabled:opacity-50"
+                            >
+                              <XCircle className="h-3.5 w-3.5" />
+                              Revoke
+                            </button>
+                          </div>
                         )}
                       </td>
                     </tr>

--- a/frontend/src/components/dashboard/AgentSchedulesTab.tsx
+++ b/frontend/src/components/dashboard/AgentSchedulesTab.tsx
@@ -87,6 +87,7 @@ export default function AgentSchedulesTab({ agentId }: AgentSchedulesTabProps) {
   const [runsBySchedule, setRunsBySchedule] = useState<Record<string, AgentScheduleRun[]>>({});
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [runningScheduleId, setRunningScheduleId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [editingScheduleId, setEditingScheduleId] = useState<string | null>(null);
   const [name, setName] = useState("botcord-auto");
@@ -230,7 +231,7 @@ export default function AgentSchedulesTab({ agentId }: AgentSchedulesTabProps) {
   }
 
   async function runSchedule(scheduleId: string) {
-    setSaving(true);
+    setRunningScheduleId(scheduleId);
     setError(null);
     try {
       await userApi.runAgentSchedule(agentId, scheduleId);
@@ -238,7 +239,7 @@ export default function AgentSchedulesTab({ agentId }: AgentSchedulesTabProps) {
     } catch (err) {
       setError(err instanceof Error ? err.message : "运行失败");
     } finally {
-      setSaving(false);
+      setRunningScheduleId(null);
     }
   }
 
@@ -280,6 +281,7 @@ export default function AgentSchedulesTab({ agentId }: AgentSchedulesTabProps) {
         <div className="space-y-3">
           {schedules.map((schedule) => {
             const lastRun = runsBySchedule[schedule.id]?.[0];
+            const isRunningThisSchedule = runningScheduleId === schedule.id;
             return (
               <section key={schedule.id} className="rounded-xl border border-glass-border bg-glass-bg/40 p-4">
                 <div className="flex items-start justify-between gap-3">
@@ -318,11 +320,15 @@ export default function AgentSchedulesTab({ agentId }: AgentSchedulesTabProps) {
                     <button
                       type="button"
                       onClick={() => void runSchedule(schedule.id)}
-                      disabled={saving}
+                      disabled={saving || isRunningThisSchedule}
                       className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-glass-border bg-deep-black/40 text-text-secondary hover:text-text-primary disabled:opacity-60"
-                      title="立即运行"
+                      title={isRunningThisSchedule ? "正在运行" : "立即运行"}
                     >
-                      <CirclePlay className="h-3.5 w-3.5" />
+                      {isRunningThisSchedule ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <CirclePlay className="h-3.5 w-3.5" />
+                      )}
                     </button>
                     <button
                       type="button"

--- a/frontend/src/components/dashboard/DeviceDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/DeviceDetailDrawer.tsx
@@ -309,30 +309,39 @@ export default function DeviceDetailDrawer() {
         </div>
       </section>
 
-      {isCloud ? (
-        <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
-          <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-wider text-text-secondary/70">
-            云设备操作
-          </h3>
-          <div className="space-y-3">
-            <p className="text-[11px] leading-relaxed text-text-secondary/65">
-              重启会重新启动这台云设备上的 daemon，并重新连接所有托管 Bot。
+      <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
+        <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-wider text-text-secondary/70">
+          {isCloud ? "云设备操作" : "设备操作"}
+        </h3>
+        <div className="space-y-3">
+          <p className="text-[11px] leading-relaxed text-text-secondary/65">
+            {isCloud
+              ? "重启会重新启动这台云设备上的 daemon，并重新连接所有托管 Bot。"
+              : "重启会让在线 daemon 拉取最新版本，然后重新连接所有托管 Bot。"}
+          </p>
+          <button
+            onClick={() => void handleRestartDevice()}
+            disabled={restartingId === device.id || (!isCloud && !online)}
+            className="inline-flex items-center gap-2 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-2 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/15 disabled:opacity-50"
+          >
+            {restartingId === device.id ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <RefreshCw className="h-3.5 w-3.5" />
+            )}
+            {restartingId === device.id
+              ? "重启中..."
+              : isCloud
+                ? "重启云设备"
+                : "更新并重启 daemon"}
+          </button>
+          {!isCloud && !online ? (
+            <p className="text-[11px] text-text-secondary/55">
+              设备离线时，请在该设备终端运行下方重新启动命令。
             </p>
-            <button
-              onClick={() => void handleRestartDevice()}
-              disabled={restartingId === device.id}
-              className="inline-flex items-center gap-2 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-2 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/15 disabled:opacity-50"
-            >
-              {restartingId === device.id ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              ) : (
-                <RefreshCw className="h-3.5 w-3.5" />
-              )}
-              {restartingId === device.id ? "重启中..." : "重启云设备"}
-            </button>
-          </div>
-        </section>
-      ) : null}
+          ) : null}
+        </div>
+      </section>
 
       {/* Rename */}
       <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">

--- a/packages/daemon/src/__tests__/provision.test.ts
+++ b/packages/daemon/src/__tests__/provision.test.ts
@@ -336,6 +336,29 @@ describe("wake_agent handler", () => {
     });
   });
 
+  it("acks wake_agent after queueing instead of waiting for the turn to finish", async () => {
+    const gw = makeFakeGateway(["ag_wake"]);
+    gw.injectInbound.mockImplementation(() => new Promise(() => undefined));
+    const handler = createProvisioner({ gateway: gw as any });
+
+    const res = await Promise.race([
+      handler({
+        id: "req_wake_pending",
+        type: "wake_agent",
+        params: {
+          agent_id: "ag_wake",
+          message: "tick",
+          run_id: "sr_pending",
+        },
+      }),
+      new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 20)),
+    ]);
+
+    expect(res).not.toBe("timeout");
+    expect(res).toMatchObject({ ok: true, result: { agent_id: "ag_wake", queued: true } });
+    expect(gw.injectInbound).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects wake_agent for an unloaded agent", async () => {
     const gw = makeFakeGateway(["ag_loaded"]);
     const handler = createProvisioner({ gateway: gw as any });

--- a/packages/daemon/src/__tests__/self-restart.test.ts
+++ b/packages/daemon/src/__tests__/self-restart.test.ts
@@ -1,0 +1,57 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { findDaemonInstallPrefix } from "../self-restart.js";
+
+describe("self restart install prefix detection", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), "botcord-self-restart-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("finds the npm install prefix for a managed @botcord/daemon entrypoint", () => {
+    const prefix = path.join(tmpDir, ".botcord", "daemon");
+    const packageRoot = path.join(prefix, "node_modules", "@botcord", "daemon");
+    const entrypoint = path.join(packageRoot, "dist", "index.js");
+    mkdirSync(path.dirname(entrypoint), { recursive: true });
+    writeFileSync(path.join(packageRoot, "package.json"), '{"name":"@botcord/daemon"}');
+    writeFileSync(entrypoint, "");
+
+    expect(findDaemonInstallPrefix(entrypoint)).toBe(prefix);
+  });
+
+  it("resolves npm .bin symlinks before looking for the package root", () => {
+    const prefix = path.join(tmpDir, ".botcord", "daemon");
+    const packageRoot = path.join(prefix, "node_modules", "@botcord", "daemon");
+    const entrypoint = path.join(packageRoot, "dist", "index.js");
+    const bin = path.join(prefix, "node_modules", ".bin", "botcord-daemon");
+    mkdirSync(path.dirname(entrypoint), { recursive: true });
+    mkdirSync(path.dirname(bin), { recursive: true });
+    writeFileSync(path.join(packageRoot, "package.json"), '{"name":"@botcord/daemon"}');
+    writeFileSync(entrypoint, "");
+    symlinkSync(entrypoint, bin);
+
+    expect(findDaemonInstallPrefix(bin)).toBe(realpathSync(prefix));
+  });
+
+  it("does not treat a monorepo development entrypoint as self-updatable", () => {
+    const entrypoint = path.join(tmpDir, "packages", "daemon", "dist", "index.js");
+    mkdirSync(path.dirname(entrypoint), { recursive: true });
+    writeFileSync(entrypoint, "");
+
+    expect(findDaemonInstallPrefix(entrypoint)).toBeNull();
+  });
+});

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -91,6 +91,7 @@ import {
   handleCloudGatewayRuntimeInbound,
   type CloudGatewayTypingEmitter,
 } from "./cloud-gateway-runtime.js";
+import { scheduleDaemonSelfRestart } from "./self-restart.js";
 
 function skillIndexOptionsForLoadedAgent(gateway: Gateway, agentId: string): SkillIndexOptions {
   const route = gateway.listManagedRoutes()
@@ -395,6 +396,17 @@ export function createProvisioner(opts: ProvisionerOptions): (
         );
         daemonLog.debug("list_runtimes", { count: snapshot.runtimes.length });
         return { ok: true, result: snapshot };
+      }
+
+      case CONTROL_FRAME_TYPES.RESTART_DAEMON: {
+        const plan = scheduleDaemonSelfRestart({ update: true });
+        daemonLog.warn("restart_daemon: scheduled self restart", {
+          updateRequested: plan.updateRequested,
+          updateSupported: plan.updateSupported,
+          installPrefix: plan.installPrefix,
+          packageSpec: plan.packageSpec,
+        });
+        return { ok: true, result: plan };
       }
 
       case "list_gateways":
@@ -729,8 +741,15 @@ async function handleWakeAgent(gateway: Gateway, raw: unknown): Promise<AckBody>
     },
   };
 
-  await gateway.injectInbound(msg);
-  return { ok: true, result: { agent_id: agentId } };
+  void gateway.injectInbound(msg).catch((err) => {
+    daemonLog.error("wake_agent: async inject failed", {
+      agentId,
+      scheduleId: scheduleId ?? null,
+      runId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  });
+  return { ok: true, result: { agent_id: agentId, queued: true } };
 }
 
 // W8: hand-written runtime validator for the third-party gateway frame

--- a/packages/daemon/src/self-restart.ts
+++ b/packages/daemon/src/self-restart.ts
@@ -1,0 +1,218 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync, realpathSync } from "node:fs";
+import path from "node:path";
+
+const DEFAULT_DAEMON_PACKAGE = "@botcord/daemon@latest";
+const DEFAULT_SHUTDOWN_DELAY_MS = 750;
+const DEFAULT_FORCE_EXIT_MS = 10_000;
+const DEFAULT_PARENT_EXIT_WAIT_MS = 30_000;
+const DEFAULT_INSTALL_TIMEOUT_MS = 120_000;
+
+export interface DaemonRestartPlan {
+  scheduled: boolean;
+  updateRequested: boolean;
+  updateSupported: boolean;
+  installPrefix: string | null;
+  packageSpec: string;
+}
+
+export interface ScheduleDaemonSelfRestartOptions {
+  update?: boolean;
+  packageSpec?: string;
+  delayMs?: number;
+  forceExitAfterMs?: number;
+  entrypoint?: string;
+  restartArgs?: string[];
+}
+
+export interface ScheduleDaemonSelfRestartDeps {
+  spawn?: typeof spawn;
+  setTimeout?: typeof setTimeout;
+  kill?: (pid: number, signal: NodeJS.Signals) => void;
+  exit?: (code?: number) => never;
+  pid?: number;
+  execPath?: string;
+  argv?: string[];
+  env?: NodeJS.ProcessEnv;
+}
+
+export function findDaemonInstallPrefix(entrypoint?: string): string | null {
+  if (!entrypoint) return null;
+  const candidates = [entrypoint, safeRealpath(entrypoint)];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const prefix = installPrefixFromPath(candidate);
+    if (prefix) return prefix;
+  }
+  return null;
+}
+
+export function resolveNpmBin(nodePath = process.execPath): string {
+  const name = process.platform === "win32" ? "npm.cmd" : "npm";
+  const sibling = path.join(path.dirname(nodePath), name);
+  return existsSync(sibling) ? sibling : name;
+}
+
+export function scheduleDaemonSelfRestart(
+  opts: ScheduleDaemonSelfRestartOptions = {},
+  deps: ScheduleDaemonSelfRestartDeps = {},
+): DaemonRestartPlan {
+  const env = deps.env ?? process.env;
+  const argv = deps.argv ?? process.argv;
+  const entrypoint = opts.entrypoint ?? argv[1];
+  if (!entrypoint) {
+    throw new Error("cannot restart daemon: process entrypoint is unknown");
+  }
+
+  const updateRequested = opts.update !== false;
+  const installPrefix = updateRequested ? findDaemonInstallPrefix(entrypoint) : null;
+  const packageSpec = opts.packageSpec ?? env.BOTCORD_DAEMON_PACKAGE ?? DEFAULT_DAEMON_PACKAGE;
+  const execPath = deps.execPath ?? process.execPath;
+  const pid = deps.pid ?? process.pid;
+  const restartArgs = opts.restartArgs ?? ["start", "--foreground"];
+  const supervisorEnv: NodeJS.ProcessEnv = {
+    ...env,
+    BOTCORD_DAEMON_CHILD: "1",
+    BOTCORD_RESTART_PARENT_PID: String(pid),
+    BOTCORD_RESTART_ENTRYPOINT: entrypoint,
+    BOTCORD_RESTART_ARGS_JSON: JSON.stringify(restartArgs),
+    BOTCORD_RESTART_NODE: execPath,
+    BOTCORD_RESTART_NPM_BIN: resolveNpmBin(execPath),
+    BOTCORD_RESTART_UPDATE: updateRequested && installPrefix ? "1" : "0",
+    BOTCORD_RESTART_INSTALL_PREFIX: installPrefix ?? "",
+    BOTCORD_RESTART_PACKAGE: packageSpec,
+    BOTCORD_RESTART_PARENT_EXIT_WAIT_MS: String(DEFAULT_PARENT_EXIT_WAIT_MS),
+    BOTCORD_RESTART_INSTALL_TIMEOUT_MS: String(DEFAULT_INSTALL_TIMEOUT_MS),
+  };
+
+  const spawnImpl = deps.spawn ?? spawn;
+  const child = spawnImpl(execPath, ["-e", RESTART_SUPERVISOR_SCRIPT], {
+    detached: true,
+    stdio: "ignore",
+    env: supervisorEnv,
+  }) as ChildProcess;
+  child.unref();
+
+  const setTimer = deps.setTimeout ?? setTimeout;
+  const kill = deps.kill ?? process.kill.bind(process);
+  const exit = deps.exit ?? process.exit.bind(process);
+  const delayMs = opts.delayMs ?? DEFAULT_SHUTDOWN_DELAY_MS;
+  const forceExitAfterMs = opts.forceExitAfterMs ?? DEFAULT_FORCE_EXIT_MS;
+  const shutdownTimer = setTimer(() => {
+    try {
+      kill(pid, "SIGTERM");
+    } catch {
+      exit(0);
+      return;
+    }
+    const exitTimer = setTimer(() => exit(0), forceExitAfterMs);
+    unrefTimer(exitTimer);
+  }, delayMs);
+  unrefTimer(shutdownTimer);
+
+  return {
+    scheduled: true,
+    updateRequested,
+    updateSupported: installPrefix !== null,
+    installPrefix,
+    packageSpec,
+  };
+}
+
+function safeRealpath(input: string): string | null {
+  try {
+    return realpathSync(input);
+  } catch {
+    return null;
+  }
+}
+
+function installPrefixFromPath(input: string): string | null {
+  const parts = path.resolve(input).split(path.sep);
+  for (let i = parts.length - 3; i >= 0; i--) {
+    if (
+      parts[i] !== "node_modules" ||
+      parts[i + 1] !== "@botcord" ||
+      parts[i + 2] !== "daemon"
+    ) {
+      continue;
+    }
+    const prefix = parts.slice(0, i).join(path.sep) || path.sep;
+    const packageJson = path.join(
+      prefix,
+      "node_modules",
+      "@botcord",
+      "daemon",
+      "package.json",
+    );
+    return existsSync(packageJson) ? prefix : null;
+  }
+  return null;
+}
+
+function unrefTimer(timer: ReturnType<typeof setTimeout>): void {
+  const maybe = timer as { unref?: () => void };
+  if (typeof maybe.unref === "function") {
+    maybe.unref();
+  }
+}
+
+const RESTART_SUPERVISOR_SCRIPT = `
+const cp = require("node:child_process");
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function alive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  const parentPid = Number(process.env.BOTCORD_RESTART_PARENT_PID || "0");
+  const waitMs = Number(process.env.BOTCORD_RESTART_PARENT_EXIT_WAIT_MS || "30000");
+  const deadline = Date.now() + waitMs;
+  while (parentPid > 0 && alive(parentPid) && Date.now() < deadline) {
+    await sleep(250);
+  }
+
+  const update = process.env.BOTCORD_RESTART_UPDATE === "1";
+  const installPrefix = process.env.BOTCORD_RESTART_INSTALL_PREFIX || "";
+  if (update && installPrefix) {
+    const npmBin = process.env.BOTCORD_RESTART_NPM_BIN || "npm";
+    const packageSpec = process.env.BOTCORD_RESTART_PACKAGE || "${DEFAULT_DAEMON_PACKAGE}";
+    const timeout = Number(process.env.BOTCORD_RESTART_INSTALL_TIMEOUT_MS || "120000");
+    cp.spawnSync(npmBin, ["install", "--prefix", installPrefix, packageSpec], {
+      stdio: "ignore",
+      env: process.env,
+      timeout,
+    });
+  }
+
+  const node = process.env.BOTCORD_RESTART_NODE || process.execPath;
+  const entrypoint = process.env.BOTCORD_RESTART_ENTRYPOINT;
+  if (!entrypoint) process.exit(1);
+  let args = ["start", "--foreground"];
+  try {
+    const parsed = JSON.parse(process.env.BOTCORD_RESTART_ARGS_JSON || "[]");
+    if (Array.isArray(parsed) && parsed.every((item) => typeof item === "string")) {
+      args = parsed;
+    }
+  } catch {
+    // keep default args
+  }
+  const child = cp.spawn(node, [entrypoint, ...args], {
+    detached: true,
+    stdio: "ignore",
+    env: { ...process.env, BOTCORD_DAEMON_CHILD: "1" },
+  });
+  child.unref();
+}
+
+main().catch(() => process.exit(1));
+`;

--- a/packages/protocol-core/src/control-frame.ts
+++ b/packages/protocol-core/src/control-frame.ts
@@ -73,6 +73,12 @@ export const CONTROL_FRAME_TYPES = {
    */
   LIST_RUNTIMES: "list_runtimes",
   /**
+   * Hub→daemon: schedule a self-update/restart for the local daemon. The
+   * daemon acks first, then a detached supervisor pulls the latest managed
+   * package (when installed under npm) and starts a fresh control connection.
+   */
+  RESTART_DAEMON: "restart_daemon",
+  /**
    * Hub→daemon: list/read the small allowlisted Markdown files that belong to
    * one BotCord agent's local runtime/profile binding. The Hub authorizes the
    * dashboard user before sending this frame; the daemon accepts only


### PR DESCRIPTION
## Summary
- Add a per-schedule running spinner for manual proactive schedule runs instead of greying out the whole schedule row.
- Queue daemon `wake_agent` injections asynchronously so Hub control-frame ack does not wait for the runtime turn and hit `daemon_ack_timeout`.
- Add local daemon restart/update dispatch support across Hub, BFF, daemon control frame handling, and dashboard device actions.

## Verification
- `uv run pytest tests/test_app/test_daemon_control.py tests/test_app/test_agent_schedules.py`
- `pnpm --filter @botcord/daemon test -- src/__tests__/provision.test.ts src/__tests__/self-restart.test.ts`
- `pnpm --filter @botcord/protocol-core build`
- `pnpm --filter @botcord/daemon build`
- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key npm run build`
- `git diff --cached --check`

## Risk / rollout
- Local daemon restart requires the daemon to be online; offline devices still show the local restart command fallback.
- Schedule runs now mark Hub dispatch success after daemon queues the wakeup, while actual runtime failures remain daemon-side/log-side behavior.