### PR TITLE
fix: mirror inbound allowlist semantics for gateway outbound send

### DIFF
--- a/backend/hub/routers/hub.py
+++ b/backend/hub/routers/hub.py
@@ -626,7 +626,14 @@ def _conversation_allowed(provider: str, config: dict[str, Any], conversation_id
     if not chat_id:
         return False
     allowed = config.get("allowedChatIds")
-    return isinstance(allowed, list) and chat_id in {str(v) for v in allowed}
+    allowed_set = {str(v) for v in allowed} if isinstance(allowed, list) else set()
+    # Mirror each provider's inbound allowlist semantics so outbound stays
+    # symmetric with inbound. Feishu inbound is allow-all on an empty list
+    # (packages/gateway-ingress/src/providers/feishu.ts); Telegram inbound is
+    # default-deny even when empty (packages/daemon/src/gateway/channels/telegram.ts).
+    if not allowed_set:
+        return provider == "feishu"
+    return chat_id in allowed_set
 
 
 @router.post("/gateways/{gateway_id}/send", response_model=GatewaySendResponse)

--- a/backend/tests/test_app/test_app_gateways.py
+++ b/backend/tests/test_app/test_app_gateways.py
@@ -399,6 +399,59 @@ async def test_agent_gateway_send_rejects_unallowed_conversation(
     fake_send.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_agent_gateway_send_feishu_empty_allowlist_allows(
+    client, seed, db_session, monkeypatch
+):
+    # Feishu inbound is allow-all on an empty allowlist; outbound mirrors it.
+    token, _ = create_agent_token("ag_daemon")
+    await _insert_gateway(
+        db_session,
+        gateway_id="gw_feishu_send",
+        provider="feishu",
+        user_id=seed["user_id"],
+        config={"allowedChatIds": [], "allowedSenderIds": []},
+    )
+    fake_send = AsyncMock(return_value={"ok": True, "result": {}})
+    _patch_hub_gateway_send(monkeypatch, online=True, send=fake_send)
+
+    r = await client.post(
+        "/hub/gateways/gw_feishu_send/send",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"conversationId": "feishu:user:oc_cdbee73a39d", "text": "hi"},
+    )
+
+    assert r.status_code == 200, r.text
+    fake_send.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_agent_gateway_send_telegram_empty_allowlist_denies(
+    client, seed, db_session, monkeypatch
+):
+    # Telegram inbound is default-deny on an empty allowlist; outbound mirrors it.
+    token, _ = create_agent_token("ag_daemon")
+    await _insert_gateway(
+        db_session,
+        gateway_id="gw_tg_empty",
+        provider="telegram",
+        user_id=seed["user_id"],
+        config={"allowedChatIds": [], "allowedSenderIds": []},
+    )
+    fake_send = AsyncMock()
+    _patch_hub_gateway_send(monkeypatch, online=True, send=fake_send)
+
+    r = await client.post(
+        "/hub/gateways/gw_tg_empty/send",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"conversationId": "telegram:group:-1001", "text": "hi"},
+    )
+
+    assert r.status_code == 403
+    assert r.json()["detail"] == "gateway_conversation_not_allowed"
+    fake_send.assert_not_awaited()
+
+
 # ---------------------------------------------------------------------------
 # Create — Telegram happy path
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 问题

主动通过飞书 gateway 发消息(`POST /gateways/{id}/send`)报 `gateway_conversation_not_allowed`（403, not retryable）。

根因是出站校验和入站校验的 allowlist 语义不对称:

- **飞书入站**(`gateway-ingress/src/providers/feishu.ts:257`):空 `allowedChatIds` = 放行所有
- **Hub 出站**(`backend/hub/routers/hub.py` `_conversation_allowed`):空 `allowedChatIds` = 拒绝所有

结果:owner 私聊 bot、被动回复一切正常(入站 allow-all 掩盖了空名单),但一旦主动 `gateway send` 就被 Hub 直接 403。这不是新 bug,是主动发送路径从一开始就被默认拒绝挡着。

## 改动

让出站镜像各 provider 的入站语义:

- **飞书**:空 allowlist → 放行(对齐入站)
- **Telegram**:空 allowlist → 拒绝(对齐其 default-deny 入站,见 `telegram.ts:87`)

非空 allowlist 行为不变(仍须在名单内)。**没有**把 telegram 一起放开,避免制造反向不对称、放松安全边界。

## 测试

- `test_agent_gateway_send_feishu_empty_allowlist_allows` — 飞书空名单出站放行
- `test_agent_gateway_send_telegram_empty_allowlist_denies` — telegram 空名单出站仍拒

`uv run pytest tests/test_app/test_app_gateways.py` → 74 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)