### PR TITLE
feat: add agent credential management CLI

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -13,6 +13,7 @@ import datetime
 import logging
 import uuid as _uuid
 from dataclasses import dataclass, field
+from urllib.parse import urlencode
 
 import jwt
 from jwt import PyJWKClient
@@ -20,9 +21,10 @@ from fastapi import Depends, Header, HTTPException
 from sqlalchemy import func as sa_func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from hub.config import SUPABASE_JWT_SECRET
+from hub.auth import assert_current_agent_token, verify_agent_token
+from hub.config import FRONTEND_BASE_URL, SUPABASE_JWT_SECRET
 from hub.database import get_db
-from hub.models import User, UserRole, Role
+from hub.models import Agent, AgentManagementGrant, User, UserRole, Role
 
 _logger = logging.getLogger(__name__)
 
@@ -48,6 +50,22 @@ class RequestContext:
     human_id: str | None = None
     # The User's display name, convenience for building viewer descriptors.
     user_display_name: str | None = None
+    # "user" for Supabase-authenticated humans, "agent" for owner-granted
+    # BotCord agent credentials.
+    auth_kind: str = "user"
+
+
+MANAGEMENT_SCOPE_CLOUD_AGENTS_CREATE = "cloud_agents:create"
+MANAGEMENT_SCOPE_TEAM_ORCHESTRATION_PROVISION = "team_orchestration:provision"
+MANAGEMENT_SCOPE_DAEMON_AGENTS_PROVISION = "daemon_agents:provision"
+MANAGEMENT_SCOPE_RUNTIME_SKILLS_INSTALL = "runtime_skills:install"
+
+ALLOWED_MANAGEMENT_SCOPES = {
+    MANAGEMENT_SCOPE_CLOUD_AGENTS_CREATE,
+    MANAGEMENT_SCOPE_TEAM_ORCHESTRATION_PROVISION,
+    MANAGEMENT_SCOPE_DAEMON_AGENTS_PROVISION,
+    MANAGEMENT_SCOPE_RUNTIME_SKILLS_INSTALL,
+}
 
 
 def _get_jwks_client(issuer: str) -> PyJWKClient:
@@ -266,6 +284,273 @@ async def require_user(
         supabase_user_id=supabase_user_id,
         roles=roles,
     )
+
+
+def _management_authorize_url(
+    agent_id: str,
+    scopes: list[str],
+    *,
+    daemon_instance_id: str | None = None,
+) -> str:
+    query_params = {"scopes": ",".join(scopes)}
+    if daemon_instance_id:
+        query_params["daemon_instance_id"] = daemon_instance_id
+    query = urlencode(query_params)
+    return (
+        f"{FRONTEND_BASE_URL.rstrip('/')}/settings/agents/"
+        f"{agent_id}/cli-permissions?{query}"
+    )
+
+
+def _normalise_required_scopes(required_scopes: list[str] | tuple[str, ...]) -> list[str]:
+    scopes = list(dict.fromkeys(required_scopes))
+    unknown = [scope for scope in scopes if scope not in ALLOWED_MANAGEMENT_SCOPES]
+    if unknown:
+        raise RuntimeError(f"unknown management scope(s): {', '.join(unknown)}")
+    return scopes
+
+
+def _ensure_beta_access(user: User) -> None:
+    from hub.config import BETA_GATE_ENABLED
+
+    if BETA_GATE_ENABLED and not user.beta_access:
+        raise HTTPException(status_code=403, detail="Beta access required")
+
+
+async def _context_from_user_token(token: str, db: AsyncSession) -> RequestContext:
+    jwt_payload = _decode_supabase_token(token)
+    supabase_user_id = jwt_payload["sub"]
+    user, roles = await _load_user_and_roles(supabase_user_id, db, jwt_payload=jwt_payload)
+    _ensure_beta_access(user)
+    return RequestContext(
+        user_id=user.id,
+        supabase_user_id=supabase_user_id,
+        roles=roles,
+        human_id=user.human_id,
+        user_display_name=user.display_name,
+        auth_kind="user",
+    )
+
+
+async def _context_from_agent_token(token: str, db: AsyncSession) -> RequestContext:
+    try:
+        agent_id = verify_agent_token(token)
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=401, detail="Token expired")
+    except jwt.InvalidTokenError:
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+    agent = await db.scalar(select(Agent).where(Agent.agent_id == agent_id))
+    if agent is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    assert_current_agent_token(agent, token)
+    if agent.claimed_at is None or agent.user_id is None:
+        raise HTTPException(status_code=403, detail="Agent is not bound to a user")
+
+    user = await db.scalar(select(User).where(User.id == agent.user_id))
+    if user is None:
+        raise HTTPException(status_code=403, detail="Agent owner not found")
+    _ensure_beta_access(user)
+
+    return RequestContext(
+        user_id=user.id,
+        supabase_user_id=str(user.supabase_user_id),
+        roles=[],
+        active_agent_id=agent.agent_id,
+        human_id=user.human_id,
+        user_display_name=user.display_name,
+        auth_kind="agent",
+    )
+
+
+async def require_user_or_agent_owner(
+    authorization: str | None = Header(default=None),
+    db: AsyncSession = Depends(get_db),
+) -> RequestContext:
+    """Accept either Supabase user auth or a bound BotCord agent token."""
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+    token = authorization[len("Bearer "):]
+    try:
+        return await _context_from_agent_token(token, db)
+    except HTTPException as agent_exc:
+        try:
+            return await _context_from_user_token(token, db)
+        except HTTPException as user_exc:
+            if user_exc.status_code != 401:
+                raise user_exc
+            raise agent_exc
+
+
+def _grant_is_current(
+    grant: AgentManagementGrant,
+    *,
+    daemon_instance_id: str | None,
+    now: datetime.datetime,
+    allow_global_daemon_grant: bool = True,
+) -> bool:
+    if grant.revoked_at is not None:
+        return False
+    expires_at = grant.expires_at
+    if expires_at is not None:
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=datetime.timezone.utc)
+        if expires_at <= now:
+            return False
+    limits = grant.limits_json or {}
+    max_uses = limits.get("max_uses")
+    if isinstance(max_uses, int) and max_uses >= 0 and grant.use_count >= max_uses:
+        return False
+    if daemon_instance_id is None:
+        return grant.daemon_instance_id is None
+    if allow_global_daemon_grant and grant.daemon_instance_id is None:
+        return True
+    return grant.daemon_instance_id == daemon_instance_id
+
+
+async def missing_agent_management_scopes(
+    db: AsyncSession,
+    *,
+    ctx: RequestContext,
+    required_scopes: list[str] | tuple[str, ...],
+    daemon_instance_id: str | None = None,
+    allow_global_daemon_grant: bool = True,
+) -> list[str]:
+    scopes = _normalise_required_scopes(required_scopes)
+    if ctx.auth_kind != "agent":
+        return []
+    if not ctx.active_agent_id:
+        return scopes
+
+    result = await db.execute(
+        select(AgentManagementGrant).where(
+            AgentManagementGrant.user_id == ctx.user_id,
+            AgentManagementGrant.agent_id == ctx.active_agent_id,
+            AgentManagementGrant.scope.in_(scopes),
+        )
+    )
+    now = datetime.datetime.now(datetime.timezone.utc)
+    granted = {
+        grant.scope
+        for grant in result.scalars().all()
+        if _grant_is_current(
+            grant,
+            daemon_instance_id=daemon_instance_id,
+            now=now,
+            allow_global_daemon_grant=allow_global_daemon_grant,
+        )
+    }
+    return [scope for scope in scopes if scope not in granted]
+
+
+async def require_agent_management_scopes(
+    db: AsyncSession,
+    *,
+    ctx: RequestContext,
+    required_scopes: list[str] | tuple[str, ...],
+    daemon_instance_id: str | None = None,
+    allow_global_daemon_grant: bool = True,
+) -> None:
+    missing = await missing_agent_management_scopes(
+        db,
+        ctx=ctx,
+        required_scopes=required_scopes,
+        daemon_instance_id=daemon_instance_id,
+        allow_global_daemon_grant=allow_global_daemon_grant,
+    )
+    if not missing:
+        return
+    agent_id = ctx.active_agent_id or ""
+    raise HTTPException(
+        status_code=403,
+        detail={
+            "code": "management_permission_required",
+            "message": "This agent needs an owner-granted management permission.",
+            "agent_id": agent_id,
+            "required_scopes": missing,
+            "authorize_url": _management_authorize_url(
+                agent_id,
+                missing,
+                daemon_instance_id=daemon_instance_id,
+            )
+            if agent_id
+            else None,
+        },
+    )
+
+
+def require_user_or_agent_management(
+    required_scopes: list[str] | tuple[str, ...],
+):
+    scopes = _normalise_required_scopes(required_scopes)
+
+    async def _dependency(
+        ctx: RequestContext = Depends(require_user_or_agent_owner),
+        db: AsyncSession = Depends(get_db),
+    ) -> RequestContext:
+        await require_agent_management_scopes(db, ctx=ctx, required_scopes=scopes)
+        return ctx
+
+    return _dependency
+
+
+async def active_agent_management_grants(
+    db: AsyncSession,
+    *,
+    ctx: RequestContext,
+    required_scopes: list[str] | tuple[str, ...],
+    daemon_instance_id: str | None = None,
+    allow_global_daemon_grant: bool = True,
+) -> dict[str, AgentManagementGrant]:
+    scopes = _normalise_required_scopes(required_scopes)
+    if ctx.auth_kind != "agent" or not ctx.active_agent_id:
+        return {}
+    result = await db.execute(
+        select(AgentManagementGrant).where(
+            AgentManagementGrant.user_id == ctx.user_id,
+            AgentManagementGrant.agent_id == ctx.active_agent_id,
+            AgentManagementGrant.scope.in_(scopes),
+        )
+    )
+    now = datetime.datetime.now(datetime.timezone.utc)
+    grants: dict[str, AgentManagementGrant] = {}
+    for grant in result.scalars().all():
+        if not _grant_is_current(
+            grant,
+            daemon_instance_id=daemon_instance_id,
+            now=now,
+            allow_global_daemon_grant=allow_global_daemon_grant,
+        ):
+            continue
+        # Prefer daemon-specific grants over global grants when both exist.
+        current = grants.get(grant.scope)
+        if current is None or (
+            daemon_instance_id is not None
+            and current.daemon_instance_id is None
+            and grant.daemon_instance_id == daemon_instance_id
+        ):
+            grants[grant.scope] = grant
+    return grants
+
+
+async def record_agent_management_scope_use(
+    db: AsyncSession,
+    *,
+    ctx: RequestContext,
+    scopes: list[str] | tuple[str, ...],
+    daemon_instance_id: str | None = None,
+    allow_global_daemon_grant: bool = True,
+) -> None:
+    grants = await active_agent_management_grants(
+        db,
+        ctx=ctx,
+        required_scopes=scopes,
+        daemon_instance_id=daemon_instance_id,
+        allow_global_daemon_grant=allow_global_daemon_grant,
+    )
+    for grant in grants.values():
+        grant.use_count += 1
 
 
 async def require_beta_user(

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -18,7 +18,7 @@ from urllib.parse import urlencode
 import jwt
 from jwt import PyJWKClient
 from fastapi import Depends, Header, HTTPException
-from sqlalchemy import func as sa_func, select
+from sqlalchemy import func as sa_func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from hub.auth import assert_current_agent_token, verify_agent_token
@@ -53,6 +53,13 @@ class RequestContext:
     # "user" for Supabase-authenticated humans, "agent" for owner-granted
     # BotCord agent credentials.
     auth_kind: str = "user"
+
+
+@dataclass(frozen=True)
+class ReservedAgentManagementGrant:
+    id: _uuid.UUID
+    scope: str
+    limits_json: dict
 
 
 MANAGEMENT_SCOPE_CLOUD_AGENTS_CREATE = "cloud_agents:create"
@@ -400,7 +407,12 @@ def _grant_is_current(
             return False
     limits = grant.limits_json or {}
     max_uses = limits.get("max_uses")
-    if isinstance(max_uses, int) and max_uses >= 0 and grant.use_count >= max_uses:
+    if (
+        isinstance(max_uses, int)
+        and not isinstance(max_uses, bool)
+        and max_uses >= 0
+        and grant.use_count >= max_uses
+    ):
         return False
     if daemon_instance_id is None:
         return grant.daemon_instance_id is None
@@ -462,7 +474,20 @@ async def require_agent_management_scopes(
     if not missing:
         return
     agent_id = ctx.active_agent_id or ""
-    raise HTTPException(
+    raise _management_permission_required(
+        agent_id=agent_id,
+        missing=missing,
+        daemon_instance_id=daemon_instance_id,
+    )
+
+
+def _management_permission_required(
+    *,
+    agent_id: str,
+    missing: list[str],
+    daemon_instance_id: str | None,
+) -> HTTPException:
+    return HTTPException(
         status_code=403,
         detail={
             "code": "management_permission_required",
@@ -534,23 +559,167 @@ async def active_agent_management_grants(
     return grants
 
 
-async def record_agent_management_scope_use(
+async def reserve_agent_management_scope_uses(
     db: AsyncSession,
     *,
     ctx: RequestContext,
     scopes: list[str] | tuple[str, ...],
     daemon_instance_id: str | None = None,
     allow_global_daemon_grant: bool = True,
-) -> None:
-    grants = await active_agent_management_grants(
-        db,
-        ctx=ctx,
-        required_scopes=scopes,
-        daemon_instance_id=daemon_instance_id,
-        allow_global_daemon_grant=allow_global_daemon_grant,
+) -> dict[str, ReservedAgentManagementGrant]:
+    """Atomically reserve management grant uses before a side effect runs."""
+    required_scopes = _normalise_required_scopes(scopes)
+    if ctx.auth_kind != "agent":
+        return {}
+    agent_id = ctx.active_agent_id or ""
+    if not agent_id:
+        raise _management_permission_required(
+            agent_id=agent_id,
+            missing=required_scopes,
+            daemon_instance_id=daemon_instance_id,
+        )
+
+    reserved: dict[str, ReservedAgentManagementGrant] = {}
+    missing: list[str] = []
+    now = datetime.datetime.now(datetime.timezone.utc)
+    for scope in required_scopes:
+        grant = await _reserve_agent_management_scope_use(
+            db,
+            ctx=ctx,
+            scope=scope,
+            daemon_instance_id=daemon_instance_id,
+            allow_global_daemon_grant=allow_global_daemon_grant,
+            now=now,
+        )
+        if grant is None:
+            missing.append(scope)
+        else:
+            reserved[scope] = grant
+
+    if missing:
+        await db.rollback()
+        raise _management_permission_required(
+            agent_id=agent_id,
+            missing=missing,
+            daemon_instance_id=daemon_instance_id,
+        )
+
+    await db.commit()
+    return reserved
+
+
+async def _reserve_agent_management_scope_use(
+    db: AsyncSession,
+    *,
+    ctx: RequestContext,
+    scope: str,
+    daemon_instance_id: str | None,
+    allow_global_daemon_grant: bool,
+    now: datetime.datetime,
+) -> ReservedAgentManagementGrant | None:
+    result = await db.execute(
+        select(AgentManagementGrant)
+        .where(
+            AgentManagementGrant.user_id == ctx.user_id,
+            AgentManagementGrant.agent_id == ctx.active_agent_id,
+            AgentManagementGrant.scope == scope,
+        )
+        .with_for_update()
     )
-    for grant in grants.values():
-        grant.use_count += 1
+    candidates = [
+        grant
+        for grant in result.scalars().all()
+        if _grant_is_current(
+            grant,
+            daemon_instance_id=daemon_instance_id,
+            now=now,
+            allow_global_daemon_grant=allow_global_daemon_grant,
+        )
+    ]
+    candidates.sort(
+        key=lambda grant: (
+            0
+            if daemon_instance_id is not None
+            and grant.daemon_instance_id == daemon_instance_id
+            else 1,
+            grant.created_at
+            or datetime.datetime.min.replace(tzinfo=datetime.timezone.utc),
+        )
+    )
+
+    for grant in candidates:
+        conditions = [
+            AgentManagementGrant.id == grant.id,
+            AgentManagementGrant.revoked_at.is_(None),
+            or_(
+                AgentManagementGrant.expires_at.is_(None),
+                AgentManagementGrant.expires_at > now,
+            ),
+        ]
+        if daemon_instance_id is None:
+            conditions.append(AgentManagementGrant.daemon_instance_id.is_(None))
+        elif allow_global_daemon_grant:
+            conditions.append(
+                or_(
+                    AgentManagementGrant.daemon_instance_id.is_(None),
+                    AgentManagementGrant.daemon_instance_id == daemon_instance_id,
+                )
+            )
+        else:
+            conditions.append(
+                AgentManagementGrant.daemon_instance_id == daemon_instance_id
+            )
+
+        limits = grant.limits_json or {}
+        max_uses = limits.get("max_uses")
+        if (
+            isinstance(max_uses, int)
+            and not isinstance(max_uses, bool)
+            and max_uses >= 0
+        ):
+            conditions.append(AgentManagementGrant.use_count < max_uses)
+
+        reserved_id = (
+            await db.execute(
+                update(AgentManagementGrant)
+                .where(*conditions)
+                .values(use_count=AgentManagementGrant.use_count + 1)
+                .returning(AgentManagementGrant.id)
+                .execution_options(synchronize_session=False)
+            )
+        ).scalar_one_or_none()
+        if reserved_id is not None:
+            return ReservedAgentManagementGrant(
+                id=grant.id,
+                scope=grant.scope,
+                limits_json=grant.limits_json or {},
+            )
+    return None
+
+
+async def release_agent_management_scope_uses(
+    db: AsyncSession,
+    grants: (
+        dict[str, ReservedAgentManagementGrant]
+        | list[ReservedAgentManagementGrant]
+        | tuple[ReservedAgentManagementGrant, ...]
+    ),
+) -> None:
+    grant_values = grants.values() if isinstance(grants, dict) else grants
+    grant_ids = [grant.id for grant in grant_values]
+    if not grant_ids:
+        return
+    await db.rollback()
+    await db.execute(
+        update(AgentManagementGrant)
+        .where(
+            AgentManagementGrant.id.in_(grant_ids),
+            AgentManagementGrant.use_count > 0,
+        )
+        .values(use_count=AgentManagementGrant.use_count - 1)
+        .execution_options(synchronize_session=False)
+    )
+    await db.commit()
 
 
 async def require_beta_user(

--- a/backend/app/routers/agent_management.py
+++ b/backend/app/routers/agent_management.py
@@ -1,0 +1,227 @@
+"""Authenticated app API for owner-granted agent management permissions."""
+
+from __future__ import annotations
+
+import datetime
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field, field_validator
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import (
+    ALLOWED_MANAGEMENT_SCOPES,
+    MANAGEMENT_SCOPE_DAEMON_AGENTS_PROVISION,
+    RequestContext,
+    require_user,
+)
+from hub.database import get_db
+from hub.models import Agent, AgentManagementGrant, DaemonInstance
+
+router = APIRouter(prefix="/api/agent-management", tags=["app-agent-management"])
+
+
+class GrantCreateIn(BaseModel):
+    agent_id: str = Field(min_length=1, max_length=32)
+    scopes: list[str] = Field(min_length=1, max_length=10)
+    expires_in_days: int = Field(default=30, ge=1, le=365)
+    daemon_instance_id: str | None = Field(default=None, max_length=32)
+    limits: dict[str, Any] | None = None
+
+    @field_validator("scopes")
+    @classmethod
+    def _validate_scopes(cls, value: list[str]) -> list[str]:
+        scopes = list(dict.fromkeys(value))
+        unknown = [scope for scope in scopes if scope not in ALLOWED_MANAGEMENT_SCOPES]
+        if unknown:
+            raise ValueError(f"unsupported management scope(s): {', '.join(unknown)}")
+        return scopes
+
+    @field_validator("limits")
+    @classmethod
+    def _validate_limits(cls, value: dict[str, Any] | None) -> dict[str, Any] | None:
+        if value is None:
+            return None
+        allowed = {"max_uses", "max_role_count", "allow_start_runs"}
+        unknown = sorted(set(value) - allowed)
+        if unknown:
+            raise ValueError(f"unsupported limit key(s): {', '.join(unknown)}")
+        max_uses = value.get("max_uses")
+        if max_uses is not None and (
+            not isinstance(max_uses, int) or isinstance(max_uses, bool) or max_uses < 0
+        ):
+            raise ValueError("limits.max_uses must be a non-negative integer")
+        max_role_count = value.get("max_role_count")
+        if max_role_count is not None and (
+            not isinstance(max_role_count, int)
+            or isinstance(max_role_count, bool)
+            or max_role_count < 1
+            or max_role_count > 5
+        ):
+            raise ValueError("limits.max_role_count must be an integer between 1 and 5")
+        allow_start_runs = value.get("allow_start_runs")
+        if allow_start_runs is not None and not isinstance(allow_start_runs, bool):
+            raise ValueError("limits.allow_start_runs must be a boolean")
+        return value
+
+
+class GrantOut(BaseModel):
+    id: uuid.UUID
+    user_id: uuid.UUID
+    agent_id: str
+    scope: str
+    daemon_instance_id: str | None
+    limits: dict[str, Any]
+    use_count: int
+    expires_at: datetime.datetime | None
+    revoked_at: datetime.datetime | None
+    created_at: datetime.datetime | None
+
+
+class GrantListOut(BaseModel):
+    grants: list[GrantOut]
+
+
+def _grant_out(grant: AgentManagementGrant) -> GrantOut:
+    return GrantOut(
+        id=grant.id,
+        user_id=grant.user_id,
+        agent_id=grant.agent_id,
+        scope=grant.scope,
+        daemon_instance_id=grant.daemon_instance_id,
+        limits=grant.limits_json or {},
+        use_count=grant.use_count,
+        expires_at=grant.expires_at,
+        revoked_at=grant.revoked_at,
+        created_at=grant.created_at,
+    )
+
+
+async def _load_owned_agent(
+    db: AsyncSession,
+    *,
+    ctx: RequestContext,
+    agent_id: str,
+) -> Agent:
+    agent = await db.scalar(
+        select(Agent).where(
+            Agent.agent_id == agent_id,
+            Agent.user_id == ctx.user_id,
+            Agent.status == "active",
+        )
+    )
+    if agent is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    if agent.claimed_at is None:
+        raise HTTPException(status_code=409, detail="Agent is not bound to this user")
+    return agent
+
+
+async def _ensure_owned_daemon(
+    db: AsyncSession,
+    *,
+    ctx: RequestContext,
+    daemon_instance_id: str | None,
+) -> None:
+    if daemon_instance_id is None:
+        return
+    daemon = await db.scalar(
+        select(DaemonInstance).where(
+            DaemonInstance.id == daemon_instance_id,
+            DaemonInstance.user_id == ctx.user_id,
+        )
+    )
+    if daemon is None or daemon.revoked_at is not None:
+        raise HTTPException(status_code=404, detail="daemon_instance_not_found")
+
+
+@router.get("/grants", response_model=GrantListOut)
+async def list_agent_management_grants(
+    agent_id: str | None = None,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+) -> GrantListOut:
+    conditions = [AgentManagementGrant.user_id == ctx.user_id]
+    if agent_id:
+        conditions.append(AgentManagementGrant.agent_id == agent_id)
+    result = await db.execute(
+        select(AgentManagementGrant)
+        .where(*conditions)
+        .order_by(AgentManagementGrant.created_at.desc())
+    )
+    return GrantListOut(grants=[_grant_out(grant) for grant in result.scalars().all()])
+
+
+@router.post("/grants", response_model=GrantListOut, status_code=201)
+async def create_agent_management_grant(
+    body: GrantCreateIn,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+) -> GrantListOut:
+    if (
+        MANAGEMENT_SCOPE_DAEMON_AGENTS_PROVISION in body.scopes
+        and body.daemon_instance_id is None
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="daemon_agents:provision requires daemon_instance_id",
+        )
+    await _load_owned_agent(db, ctx=ctx, agent_id=body.agent_id)
+    await _ensure_owned_daemon(db, ctx=ctx, daemon_instance_id=body.daemon_instance_id)
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    expires_at = now + datetime.timedelta(days=body.expires_in_days)
+    grants: list[AgentManagementGrant] = []
+    for scope in body.scopes:
+        conditions = [
+            AgentManagementGrant.user_id == ctx.user_id,
+            AgentManagementGrant.agent_id == body.agent_id,
+            AgentManagementGrant.scope == scope,
+            AgentManagementGrant.revoked_at.is_(None),
+        ]
+        if body.daemon_instance_id is None:
+            conditions.append(AgentManagementGrant.daemon_instance_id.is_(None))
+        else:
+            conditions.append(AgentManagementGrant.daemon_instance_id == body.daemon_instance_id)
+        grant = await db.scalar(select(AgentManagementGrant).where(*conditions))
+        if grant is None:
+            grant = AgentManagementGrant(
+                user_id=ctx.user_id,
+                agent_id=body.agent_id,
+                scope=scope,
+                daemon_instance_id=body.daemon_instance_id,
+                created_by_user_id=ctx.user_id,
+            )
+            db.add(grant)
+        grant.expires_at = expires_at
+        grant.limits_json = body.limits or {}
+        grant.use_count = 0
+        grants.append(grant)
+
+    await db.commit()
+    for grant in grants:
+        await db.refresh(grant)
+    return GrantListOut(grants=[_grant_out(grant) for grant in grants])
+
+
+@router.delete("/grants/{grant_id}", response_model=GrantOut)
+async def revoke_agent_management_grant(
+    grant_id: uuid.UUID,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+) -> GrantOut:
+    grant = await db.scalar(
+        select(AgentManagementGrant).where(
+            AgentManagementGrant.id == grant_id,
+            AgentManagementGrant.user_id == ctx.user_id,
+        )
+    )
+    if grant is None:
+        raise HTTPException(status_code=404, detail="Grant not found")
+    if grant.revoked_at is None:
+        grant.revoked_at = datetime.datetime.now(datetime.timezone.utc)
+        await db.commit()
+        await db.refresh(grant)
+    return _grant_out(grant)

--- a/backend/app/routers/cloud_agents.py
+++ b/backend/app/routers/cloud_agents.py
@@ -14,7 +14,13 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth import RequestContext, require_user
+from app.auth import (
+    MANAGEMENT_SCOPE_CLOUD_AGENTS_CREATE,
+    RequestContext,
+    record_agent_management_scope_use,
+    require_user,
+    require_user_or_agent_management,
+)
 from hub.database import get_db
 from hub.services.cloud_agent import (
     CloudAgentError,
@@ -217,7 +223,9 @@ class CloudAgentUsageOut(BaseModel):
 @router.post("", status_code=201, response_model=CloudAgentOut)
 async def create_cloud_agent(
     body: CreateCloudAgentRequest,
-    ctx: RequestContext = Depends(require_user),
+    ctx: RequestContext = Depends(
+        require_user_or_agent_management([MANAGEMENT_SCOPE_CLOUD_AGENTS_CREATE])
+    ),
     db: AsyncSession = Depends(get_db),
     service: CloudAgentService = Depends(get_cloud_agent_service),
 ) -> CloudAgentOut:
@@ -235,6 +243,12 @@ async def create_cloud_agent(
                 thinking=body.thinking,
             ),
         )
+        await record_agent_management_scope_use(
+            db,
+            ctx=ctx,
+            scopes=[MANAGEMENT_SCOPE_CLOUD_AGENTS_CREATE],
+        )
+        await db.commit()
     except CloudAgentError as exc:
         raise _handle_service_error(exc) from exc
     return CloudAgentOut.from_view(view)

--- a/backend/app/routers/cloud_agents.py
+++ b/backend/app/routers/cloud_agents.py
@@ -17,7 +17,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.auth import (
     MANAGEMENT_SCOPE_CLOUD_AGENTS_CREATE,
     RequestContext,
-    record_agent_management_scope_use,
+    release_agent_management_scope_uses,
+    reserve_agent_management_scope_uses,
     require_user,
     require_user_or_agent_management,
 )
@@ -229,6 +230,11 @@ async def create_cloud_agent(
     db: AsyncSession = Depends(get_db),
     service: CloudAgentService = Depends(get_cloud_agent_service),
 ) -> CloudAgentOut:
+    reserved_grants = await reserve_agent_management_scope_uses(
+        db,
+        ctx=ctx,
+        scopes=[MANAGEMENT_SCOPE_CLOUD_AGENTS_CREATE],
+    )
     try:
         view = await service.create_cloud_agent(
             db,
@@ -243,14 +249,13 @@ async def create_cloud_agent(
                 thinking=body.thinking,
             ),
         )
-        await record_agent_management_scope_use(
-            db,
-            ctx=ctx,
-            scopes=[MANAGEMENT_SCOPE_CLOUD_AGENTS_CREATE],
-        )
         await db.commit()
     except CloudAgentError as exc:
+        await release_agent_management_scope_uses(db, reserved_grants)
         raise _handle_service_error(exc) from exc
+    except Exception:
+        await release_agent_management_scope_uses(db, reserved_grants)
+        raise
     return CloudAgentOut.from_view(view)
 
 

--- a/backend/app/routers/team_orchestration.py
+++ b/backend/app/routers/team_orchestration.py
@@ -10,9 +10,9 @@ from app.auth import (
     MANAGEMENT_SCOPE_RUNTIME_SKILLS_INSTALL,
     MANAGEMENT_SCOPE_TEAM_ORCHESTRATION_PROVISION,
     RequestContext,
-    active_agent_management_grants,
-    record_agent_management_scope_use,
     require_agent_management_scopes,
+    release_agent_management_scope_uses,
+    reserve_agent_management_scope_uses,
     require_user,
     require_user_or_agent_management,
 )
@@ -251,65 +251,71 @@ async def provision_team(
     cloud_agent_service: CloudAgentService = Depends(get_cloud_agent_service),
 ) -> TeamProvisionOut:
     service = _service(cloud_agent_service)
-    team_grants = await active_agent_management_grants(
-        db,
-        ctx=ctx,
-        required_scopes=[MANAGEMENT_SCOPE_TEAM_ORCHESTRATION_PROVISION],
-    )
-    team_grant = team_grants.get(MANAGEMENT_SCOPE_TEAM_ORCHESTRATION_PROVISION)
-    if team_grant is not None:
-        limits = team_grant.limits_json or {}
-        max_role_count = limits.get("max_role_count")
-        requested_role_count = body.role_count or (len(body.roles) if body.roles else 3)
-        if (
-            isinstance(max_role_count, int)
-            and requested_role_count is not None
-            and requested_role_count > max_role_count
-        ):
-            raise HTTPException(
-                status_code=403,
-                detail={
-                    "code": "management_limit_exceeded",
-                    "scope": MANAGEMENT_SCOPE_TEAM_ORCHESTRATION_PROVISION,
-                    "limit": "max_role_count",
-                    "max_role_count": max_role_count,
-                },
-            )
-        if limits.get("allow_start_runs") is False and body.start_runs:
-            raise HTTPException(
-                status_code=403,
-                detail={
-                    "code": "management_limit_exceeded",
-                    "scope": MANAGEMENT_SCOPE_TEAM_ORCHESTRATION_PROVISION,
-                    "limit": "allow_start_runs",
-                },
-            )
-    if any(role.skills for role in body.roles or []):
+    roles = _roles_from_in(body.roles)
+    plan = service.build_plan(goal=body.goal, roles=roles, role_count=body.role_count)
+    has_role_skills = any(role.skills for role in plan.roles)
+    required_scopes = [MANAGEMENT_SCOPE_TEAM_ORCHESTRATION_PROVISION]
+    if has_role_skills:
+        required_scopes.append(MANAGEMENT_SCOPE_RUNTIME_SKILLS_INSTALL)
         await require_agent_management_scopes(
             db,
             ctx=ctx,
             required_scopes=[MANAGEMENT_SCOPE_RUNTIME_SKILLS_INSTALL],
         )
 
-    async def _install_role_skills(
-        role: TeamRolePlan,
-        cloud_agent: CloudAgentView,
-    ) -> None:
-        for skill in role.skills or []:
-            await install_agent_runtime_skill_for_agent(
-                agent_id=cloud_agent.agent_id,
-                body=AgentRuntimeSkillInstallIn.model_validate(skill),
-                ctx=ctx,
-                db=db,
-            )
+    reserved_grants = await reserve_agent_management_scope_uses(
+        db,
+        ctx=ctx,
+        scopes=required_scopes,
+    )
 
     try:
+        team_grant = reserved_grants.get(MANAGEMENT_SCOPE_TEAM_ORCHESTRATION_PROVISION)
+        if team_grant is not None:
+            limits = team_grant.limits_json or {}
+            max_role_count = limits.get("max_role_count")
+            requested_role_count = len(plan.roles)
+            if (
+                isinstance(max_role_count, int)
+                and requested_role_count > max_role_count
+            ):
+                raise HTTPException(
+                    status_code=403,
+                    detail={
+                        "code": "management_limit_exceeded",
+                        "scope": MANAGEMENT_SCOPE_TEAM_ORCHESTRATION_PROVISION,
+                        "limit": "max_role_count",
+                        "max_role_count": max_role_count,
+                    },
+                )
+            if limits.get("allow_start_runs") is False and body.start_runs:
+                raise HTTPException(
+                    status_code=403,
+                    detail={
+                        "code": "management_limit_exceeded",
+                        "scope": MANAGEMENT_SCOPE_TEAM_ORCHESTRATION_PROVISION,
+                        "limit": "allow_start_runs",
+                    },
+                )
+
+        async def _install_role_skills(
+            role: TeamRolePlan,
+            cloud_agent: CloudAgentView,
+        ) -> None:
+            for skill in role.skills or []:
+                await install_agent_runtime_skill_for_agent(
+                    agent_id=cloud_agent.agent_id,
+                    body=AgentRuntimeSkillInstallIn.model_validate(skill),
+                    ctx=ctx,
+                    db=db,
+                )
+
         result = await service.provision_team(
             db,
             user_id=ctx.user_id,
-            goal=body.goal,
-            roles=_roles_from_in(body.roles),
-            role_count=body.role_count,
+            goal=plan.goal,
+            roles=plan.roles,
+            role_count=None,
             room_name=body.room_name,
             start_runs=body.start_runs,
             run_budget=RunBudget(
@@ -320,21 +326,17 @@ async def provision_team(
             else None,
             role_skill_installer=_install_role_skills,
         )
-        await record_agent_management_scope_use(
-            db,
-            ctx=ctx,
-            scopes=[MANAGEMENT_SCOPE_TEAM_ORCHESTRATION_PROVISION],
-        )
-        if any(role.skills for role in body.roles or []):
-            await record_agent_management_scope_use(
-                db,
-                ctx=ctx,
-                scopes=[MANAGEMENT_SCOPE_RUNTIME_SKILLS_INSTALL],
-            )
         await db.commit()
+    except HTTPException:
+        await release_agent_management_scope_uses(db, reserved_grants)
+        raise
     except CloudAgentError as exc:
+        await release_agent_management_scope_uses(db, reserved_grants)
         raise HTTPException(
             status_code=exc.http_status,
             detail={"code": exc.code, "message": exc.message},
         ) from exc
+    except Exception:
+        await release_agent_management_scope_uses(db, reserved_grants)
+        raise
     return _provision_out(result)

--- a/backend/app/routers/team_orchestration.py
+++ b/backend/app/routers/team_orchestration.py
@@ -6,7 +6,16 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth import RequestContext, require_user
+from app.auth import (
+    MANAGEMENT_SCOPE_RUNTIME_SKILLS_INSTALL,
+    MANAGEMENT_SCOPE_TEAM_ORCHESTRATION_PROVISION,
+    RequestContext,
+    active_agent_management_grants,
+    record_agent_management_scope_use,
+    require_agent_management_scopes,
+    require_user,
+    require_user_or_agent_management,
+)
 from app.routers.cloud_agents import CloudAgentOut, RunBudgetIn, RunBudgetOut
 from app.routers.cloud_agents import get_cloud_agent_service
 from app.routers.runtime_skills import (
@@ -235,11 +244,52 @@ async def plan_team(
 @router.post("/provision", response_model=TeamProvisionOut, status_code=201)
 async def provision_team(
     body: TeamProvisionRequest,
-    ctx: RequestContext = Depends(require_user),
+    ctx: RequestContext = Depends(
+        require_user_or_agent_management([MANAGEMENT_SCOPE_TEAM_ORCHESTRATION_PROVISION])
+    ),
     db: AsyncSession = Depends(get_db),
     cloud_agent_service: CloudAgentService = Depends(get_cloud_agent_service),
 ) -> TeamProvisionOut:
     service = _service(cloud_agent_service)
+    team_grants = await active_agent_management_grants(
+        db,
+        ctx=ctx,
+        required_scopes=[MANAGEMENT_SCOPE_TEAM_ORCHESTRATION_PROVISION],
+    )
+    team_grant = team_grants.get(MANAGEMENT_SCOPE_TEAM_ORCHESTRATION_PROVISION)
+    if team_grant is not None:
+        limits = team_grant.limits_json or {}
+        max_role_count = limits.get("max_role_count")
+        requested_role_count = body.role_count or (len(body.roles) if body.roles else 3)
+        if (
+            isinstance(max_role_count, int)
+            and requested_role_count is not None
+            and requested_role_count > max_role_count
+        ):
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "code": "management_limit_exceeded",
+                    "scope": MANAGEMENT_SCOPE_TEAM_ORCHESTRATION_PROVISION,
+                    "limit": "max_role_count",
+                    "max_role_count": max_role_count,
+                },
+            )
+        if limits.get("allow_start_runs") is False and body.start_runs:
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "code": "management_limit_exceeded",
+                    "scope": MANAGEMENT_SCOPE_TEAM_ORCHESTRATION_PROVISION,
+                    "limit": "allow_start_runs",
+                },
+            )
+    if any(role.skills for role in body.roles or []):
+        await require_agent_management_scopes(
+            db,
+            ctx=ctx,
+            required_scopes=[MANAGEMENT_SCOPE_RUNTIME_SKILLS_INSTALL],
+        )
 
     async def _install_role_skills(
         role: TeamRolePlan,
@@ -270,6 +320,18 @@ async def provision_team(
             else None,
             role_skill_installer=_install_role_skills,
         )
+        await record_agent_management_scope_use(
+            db,
+            ctx=ctx,
+            scopes=[MANAGEMENT_SCOPE_TEAM_ORCHESTRATION_PROVISION],
+        )
+        if any(role.skills for role in body.roles or []):
+            await record_agent_management_scope_use(
+                db,
+                ctx=ctx,
+                scopes=[MANAGEMENT_SCOPE_RUNTIME_SKILLS_INSTALL],
+            )
+        await db.commit()
     except CloudAgentError as exc:
         raise HTTPException(
             status_code=exc.http_status,

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -23,7 +23,14 @@ from sqlalchemy.orm.attributes import flag_modified
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth import RequestContext, require_user
+from app.auth import (
+    MANAGEMENT_SCOPE_DAEMON_AGENTS_PROVISION,
+    RequestContext,
+    record_agent_management_scope_use,
+    require_agent_management_scopes,
+    require_user,
+    require_user_or_agent_owner,
+)
 from hub import config as hub_config
 from hub.auth import create_agent_token, verify_agent_token
 from hub.agent_avatars import normalize_agent_avatar_url, random_agent_avatar_url
@@ -1861,7 +1868,7 @@ def _mark_daemon_runtime_snapshot_bound(
 )
 async def provision_agent(
     body: ProvisionAgentBody,
-    ctx: RequestContext = Depends(require_user),
+    ctx: RequestContext = Depends(require_user_or_agent_owner),
     db: AsyncSession = Depends(get_db),
 ) -> ProvisionAgentResponse:
     """Create a new agent on one of the user's daemons.
@@ -1880,6 +1887,13 @@ async def provision_agent(
         raise HTTPException(status_code=400, detail="runtime is required")
     runtime_model = _clean_runtime_option(body.runtime_model)
     reasoning_effort = _clean_runtime_option(body.reasoning_effort)
+    await require_agent_management_scopes(
+        db,
+        ctx=ctx,
+        required_scopes=[MANAGEMENT_SCOPE_DAEMON_AGENTS_PROVISION],
+        daemon_instance_id=body.daemon_instance_id,
+        allow_global_daemon_grant=False,
+    )
 
     result = await db.execute(
         select(DaemonInstance).where(DaemonInstance.id == body.daemon_instance_id)
@@ -2071,6 +2085,13 @@ async def provision_agent(
         hermes_profile=body.hermes_profile,
     )
 
+    await record_agent_management_scope_use(
+        db,
+        ctx=ctx,
+        scopes=[MANAGEMENT_SCOPE_DAEMON_AGENTS_PROVISION],
+        daemon_instance_id=body.daemon_instance_id,
+        allow_global_daemon_grant=False,
+    )
     await db.commit()
     await db.refresh(agent)
 

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -26,8 +26,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.auth import (
     MANAGEMENT_SCOPE_DAEMON_AGENTS_PROVISION,
     RequestContext,
-    record_agent_management_scope_use,
     require_agent_management_scopes,
+    release_agent_management_scope_uses,
+    reserve_agent_management_scope_uses,
     require_user,
     require_user_or_agent_owner,
 )
@@ -1949,150 +1950,160 @@ async def provision_agent(
     if dup_result.scalar_one_or_none() is not None:
         raise HTTPException(status_code=500, detail="agent_id_collision")
 
-    # --- Insert Agent + SigningKey in one transaction -------------------
-    now = datetime.datetime.now(datetime.timezone.utc)
-    key_id = generate_key_id()
-    agent = Agent(
-        agent_id=agent_id,
-        display_name=label,
-        bio=body.bio,
-        avatar_url=random_agent_avatar_url(),
-        user_id=ctx.user_id,
-        is_default=is_first,
-        claimed_at=now,
-        runtime=runtime,
-        runtime_model=runtime_model,
-        reasoning_effort=reasoning_effort,
-        thinking=body.thinking,
-        daemon_instance_id=body.daemon_instance_id,
-        hosting_kind="daemon",
-    )
-    db.add(agent)
-    db.add(
-        SigningKey(
-            agent_id=agent_id,
-            key_id=key_id,
-            pubkey=f"ed25519:{pubkey_b64}",
-            state=KeyState.active,
-        )
-    )
-    # Flush so FKs satisfy subsequent writes; commit happens after the
-    # daemon ack so we can roll back on dispatch failure.
-    await db.flush()
-
-    agent_token, token_expires_at = create_agent_token(agent_id)
-    agent.agent_token = agent_token
-    agent.token_expires_at = datetime.datetime.fromtimestamp(
-        token_expires_at, tz=datetime.timezone.utc
-    )
-    await get_or_create_wallet(db, agent_id)
-    await _ensure_agent_owner_role(db, ctx.user_id)
-    await db.flush()
-
-    # --- Dispatch provision_agent to the daemon, wait for ack -----------
-    frame_params: dict = {
-        "name": label,
-        "runtime": runtime,
-        "credentials": {
-            "agentId": agent_id,
-            "keyId": key_id,
-            "privateKey": private_key_b64,
-            "publicKey": pubkey_b64,
-            "hubUrl": hub_config.HUB_PUBLIC_BASE_URL,
-            "displayName": label,
-            "token": agent_token,
-            "tokenExpiresAt": token_expires_at,
-            "runtime": runtime,
-        },
-    }
-    if runtime_model:
-        frame_params["runtimeModel"] = runtime_model
-        frame_params["credentials"]["runtimeModel"] = runtime_model
-    if reasoning_effort:
-        frame_params["reasoningEffort"] = reasoning_effort
-        frame_params["credentials"]["reasoningEffort"] = reasoning_effort
-    if body.thinking is not None:
-        frame_params["thinking"] = body.thinking
-        frame_params["credentials"]["thinking"] = body.thinking
-    if body.cwd:
-        frame_params["cwd"] = body.cwd
-        frame_params["credentials"]["cwd"] = body.cwd
-    if body.bio:
-        frame_params["bio"] = body.bio
-    if body.openclaw_gateway:
-        # Top-level nested form (RFC §3.9.2).
-        oc: dict[str, str] = {"gateway": body.openclaw_gateway}
-        if body.openclaw_agent:
-            oc["agent"] = body.openclaw_agent
-        frame_params["openclaw"] = oc
-        # Mirror onto the flat credentials envelope so daemon's offline reload
-        # path picks the same gateway without seeing the top-level field.
-        frame_params["credentials"]["openclawGateway"] = body.openclaw_gateway
-        if body.openclaw_agent:
-            frame_params["credentials"]["openclawAgent"] = body.openclaw_agent
-    if body.hermes_profile:
-        # Same dual-write pattern as openclaw — top-level nested form for the
-        # daemon's runtime selector, flat credentials mirror for the offline
-        # reload path.
-        frame_params["hermes"] = {"profile": body.hermes_profile}
-        frame_params["credentials"]["hermesProfile"] = body.hermes_profile
-
-    # Seed the daemon's policyResolver with the agent's default attention so
-    # it has a real policy from message zero (no first-message refetch race).
-    # `attention_keywords` is JSON-encoded TEXT in the DB.
-    try:
-        _seed_kw = json.loads(agent.attention_keywords or "[]")
-        if not isinstance(_seed_kw, list):
-            _seed_kw = []
-    except (json.JSONDecodeError, TypeError):
-        _seed_kw = []
-    _attn = agent.default_attention
-    frame_params["defaultAttention"] = _attn.value if hasattr(_attn, "value") else str(_attn)
-    frame_params["attentionKeywords"] = [str(x) for x in _seed_kw if isinstance(x, str)]
-
-    try:
-        ack = await send_control_frame(
-            body.daemon_instance_id, "provision_agent", frame_params
-        )
-    except HTTPException:
-        # Roll back the uncommitted Agent / SigningKey so Hub doesn't get
-        # stuck with a phantom agent row while the daemon is offline or
-        # misbehaving (plan §8.4 事务性与回滚: step b fail → ack error, no state).
-        await db.rollback()
-        raise
-
-    if not isinstance(ack, dict) or not ack.get("ok"):
-        err = ack.get("error") if isinstance(ack, dict) else None
-        code = (err or {}).get("code") if isinstance(err, dict) else None
-        message = (err or {}).get("message") if isinstance(err, dict) else None
-        await db.rollback()
-        raise HTTPException(
-            status_code=502,
-            detail={
-                "code": "daemon_provision_failed",
-                "daemon_code": code,
-                "daemon_message": message,
-            },
-        )
-
-    _mark_daemon_runtime_snapshot_bound(
-        instance,
-        runtime=runtime,
-        agent_id=agent.agent_id,
-        display_name=agent.display_name,
-        openclaw_gateway=body.openclaw_gateway,
-        openclaw_agent=body.openclaw_agent,
-        hermes_profile=body.hermes_profile,
-    )
-
-    await record_agent_management_scope_use(
+    reserved_grants = await reserve_agent_management_scope_uses(
         db,
         ctx=ctx,
         scopes=[MANAGEMENT_SCOPE_DAEMON_AGENTS_PROVISION],
         daemon_instance_id=body.daemon_instance_id,
         allow_global_daemon_grant=False,
     )
-    await db.commit()
+
+    try:
+        # --- Insert Agent + SigningKey in one transaction -------------------
+        now = datetime.datetime.now(datetime.timezone.utc)
+        key_id = generate_key_id()
+        agent = Agent(
+            agent_id=agent_id,
+            display_name=label,
+            bio=body.bio,
+            avatar_url=random_agent_avatar_url(),
+            user_id=ctx.user_id,
+            is_default=is_first,
+            claimed_at=now,
+            runtime=runtime,
+            runtime_model=runtime_model,
+            reasoning_effort=reasoning_effort,
+            thinking=body.thinking,
+            daemon_instance_id=body.daemon_instance_id,
+            hosting_kind="daemon",
+        )
+        db.add(agent)
+        db.add(
+            SigningKey(
+                agent_id=agent_id,
+                key_id=key_id,
+                pubkey=f"ed25519:{pubkey_b64}",
+                state=KeyState.active,
+            )
+        )
+        # Flush so FKs satisfy subsequent writes; commit happens after the
+        # daemon ack so we can roll back on dispatch failure.
+        await db.flush()
+
+        agent_token, token_expires_at = create_agent_token(agent_id)
+        agent.agent_token = agent_token
+        agent.token_expires_at = datetime.datetime.fromtimestamp(
+            token_expires_at, tz=datetime.timezone.utc
+        )
+        await get_or_create_wallet(db, agent_id)
+        await _ensure_agent_owner_role(db, ctx.user_id)
+        await db.flush()
+
+        # --- Dispatch provision_agent to the daemon, wait for ack -----------
+        frame_params: dict = {
+            "name": label,
+            "runtime": runtime,
+            "credentials": {
+                "agentId": agent_id,
+                "keyId": key_id,
+                "privateKey": private_key_b64,
+                "publicKey": pubkey_b64,
+                "hubUrl": hub_config.HUB_PUBLIC_BASE_URL,
+                "displayName": label,
+                "token": agent_token,
+                "tokenExpiresAt": token_expires_at,
+                "runtime": runtime,
+            },
+        }
+        if runtime_model:
+            frame_params["runtimeModel"] = runtime_model
+            frame_params["credentials"]["runtimeModel"] = runtime_model
+        if reasoning_effort:
+            frame_params["reasoningEffort"] = reasoning_effort
+            frame_params["credentials"]["reasoningEffort"] = reasoning_effort
+        if body.thinking is not None:
+            frame_params["thinking"] = body.thinking
+            frame_params["credentials"]["thinking"] = body.thinking
+        if body.cwd:
+            frame_params["cwd"] = body.cwd
+            frame_params["credentials"]["cwd"] = body.cwd
+        if body.bio:
+            frame_params["bio"] = body.bio
+        if body.openclaw_gateway:
+            # Top-level nested form (RFC §3.9.2).
+            oc: dict[str, str] = {"gateway": body.openclaw_gateway}
+            if body.openclaw_agent:
+                oc["agent"] = body.openclaw_agent
+            frame_params["openclaw"] = oc
+            # Mirror onto the flat credentials envelope so daemon's offline reload
+            # path picks the same gateway without seeing the top-level field.
+            frame_params["credentials"]["openclawGateway"] = body.openclaw_gateway
+            if body.openclaw_agent:
+                frame_params["credentials"]["openclawAgent"] = body.openclaw_agent
+        if body.hermes_profile:
+            # Same dual-write pattern as openclaw — top-level nested form for the
+            # daemon's runtime selector, flat credentials mirror for the offline
+            # reload path.
+            frame_params["hermes"] = {"profile": body.hermes_profile}
+            frame_params["credentials"]["hermesProfile"] = body.hermes_profile
+
+        # Seed the daemon's policyResolver with the agent's default attention so
+        # it has a real policy from message zero (no first-message refetch race).
+        # `attention_keywords` is JSON-encoded TEXT in the DB.
+        try:
+            _seed_kw = json.loads(agent.attention_keywords or "[]")
+            if not isinstance(_seed_kw, list):
+                _seed_kw = []
+        except (json.JSONDecodeError, TypeError):
+            _seed_kw = []
+        _attn = agent.default_attention
+        frame_params["defaultAttention"] = (
+            _attn.value if hasattr(_attn, "value") else str(_attn)
+        )
+        frame_params["attentionKeywords"] = [
+            str(x) for x in _seed_kw if isinstance(x, str)
+        ]
+
+        try:
+            ack = await send_control_frame(
+                body.daemon_instance_id, "provision_agent", frame_params
+            )
+        except HTTPException:
+            # Roll back the uncommitted Agent / SigningKey so Hub doesn't get
+            # stuck with a phantom agent row while the daemon is offline or
+            # misbehaving (plan §8.4 事务性与回滚: step b fail → ack error, no state).
+            await db.rollback()
+            raise
+
+        if not isinstance(ack, dict) or not ack.get("ok"):
+            err = ack.get("error") if isinstance(ack, dict) else None
+            code = (err or {}).get("code") if isinstance(err, dict) else None
+            message = (err or {}).get("message") if isinstance(err, dict) else None
+            await db.rollback()
+            raise HTTPException(
+                status_code=502,
+                detail={
+                    "code": "daemon_provision_failed",
+                    "daemon_code": code,
+                    "daemon_message": message,
+                },
+            )
+
+        _mark_daemon_runtime_snapshot_bound(
+            instance,
+            runtime=runtime,
+            agent_id=agent.agent_id,
+            display_name=agent.display_name,
+            openclaw_gateway=body.openclaw_gateway,
+            openclaw_agent=body.openclaw_agent,
+            hermes_profile=body.hermes_profile,
+        )
+
+        await db.commit()
+    except Exception:
+        await release_agent_management_scope_uses(db, reserved_grants)
+        raise
+
     await db.refresh(agent)
 
     return ProvisionAgentResponse(

--- a/backend/hub/main.py
+++ b/backend/hub/main.py
@@ -79,6 +79,7 @@ from app.routers.schedules import router as app_schedules_router
 from app.routers.auth import router as app_auth_router
 from app.routers.telegram import router as app_telegram_router
 from app.routers.team_orchestration import router as app_team_orchestration_router
+from app.routers.agent_management import router as app_agent_management_router
 from app.auth import require_beta_user
 
 logging.basicConfig(level=logging.INFO)
@@ -325,6 +326,7 @@ app.include_router(app_runtime_files_router, dependencies=_beta_gate)
 app.include_router(app_runtime_skills_router, dependencies=_beta_gate)
 app.include_router(app_schedules_router, dependencies=_beta_gate)
 app.include_router(app_team_orchestration_router, dependencies=_beta_gate)
+app.include_router(app_agent_management_router, dependencies=_beta_gate)
 app.include_router(app_prompts_router)
 app.include_router(app_presence_router, dependencies=_beta_gate)
 app.include_router(app_presence_status_router, dependencies=_beta_gate)

--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -163,6 +163,41 @@ class Agent(Base):
         return self.status == "active" and self.user_id is not None
 
 
+class AgentManagementGrant(Base):
+    """Owner-granted management capability for one BotCord agent."""
+
+    __tablename__ = "agent_management_grants"
+    __table_args__ = (
+        Index("ix_agent_management_grants_user_agent", "user_id", "agent_id"),
+        Index("ix_agent_management_grants_agent_scope", "agent_id", "scope"),
+        Index("ix_agent_management_grants_scope_active", "scope", "revoked_at", "expires_at"),
+    )
+
+    id: Mapped[_uuid.UUID] = mapped_column(Uuid, primary_key=True, default=_uuid.uuid4)
+    user_id: Mapped[_uuid.UUID] = mapped_column(Uuid, nullable=False, index=True)
+    agent_id: Mapped[str] = mapped_column(
+        String(32),
+        ForeignKey("agents.agent_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    scope: Mapped[str] = mapped_column(String(64), nullable=False)
+    daemon_instance_id: Mapped[str | None] = mapped_column(String(32), nullable=True, index=True)
+    limits_json: Mapped[dict] = mapped_column(
+        JSONB().with_variant(JSON(), "sqlite"),
+        nullable=False,
+        default=dict,
+        server_default="{}",
+    )
+    use_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    expires_at: Mapped[datetime.datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    revoked_at: Mapped[datetime.datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_by_user_id: Mapped[_uuid.UUID | None] = mapped_column(Uuid, nullable=True)
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+
 class SigningKey(Base):
     __tablename__ = "signing_keys"
 

--- a/backend/migrations/021_agent_management_grants.sql
+++ b/backend/migrations/021_agent_management_grants.sql
@@ -1,0 +1,33 @@
+-- Owner-granted management capabilities for agent-credential API access.
+
+CREATE TABLE IF NOT EXISTS agent_management_grants (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL,
+    agent_id VARCHAR(32) NOT NULL REFERENCES agents(agent_id) ON DELETE CASCADE,
+    scope VARCHAR(64) NOT NULL,
+    daemon_instance_id VARCHAR(32),
+    limits_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+    use_count INTEGER NOT NULL DEFAULT 0,
+    expires_at TIMESTAMPTZ,
+    revoked_at TIMESTAMPTZ,
+    created_by_user_id UUID,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS ix_agent_management_grants_user_id
+    ON agent_management_grants (user_id);
+
+CREATE INDEX IF NOT EXISTS ix_agent_management_grants_agent_id
+    ON agent_management_grants (agent_id);
+
+CREATE INDEX IF NOT EXISTS ix_agent_management_grants_daemon_instance_id
+    ON agent_management_grants (daemon_instance_id);
+
+CREATE INDEX IF NOT EXISTS ix_agent_management_grants_user_agent
+    ON agent_management_grants (user_id, agent_id);
+
+CREATE INDEX IF NOT EXISTS ix_agent_management_grants_agent_scope
+    ON agent_management_grants (agent_id, scope);
+
+CREATE INDEX IF NOT EXISTS ix_agent_management_grants_scope_active
+    ON agent_management_grants (scope, revoked_at, expires_at);

--- a/backend/tests/test_app/test_agent_provision.py
+++ b/backend/tests/test_app/test_agent_provision.py
@@ -437,6 +437,58 @@ async def test_provision_accepts_agent_token_with_daemon_scoped_grant(
 
 
 @pytest.mark.asyncio
+async def test_daemon_management_grant_use_is_refunded_when_daemon_rejects(
+    client: AsyncClient,
+    seed_user,
+    seed_manager_agent,
+    db_session: AsyncSession,
+):
+    instance_id = await _provision_instance(client, seed_user)
+    grant = AgentManagementGrant(
+        user_id=seed_user["user_id"],
+        agent_id=seed_manager_agent["agent_id"],
+        scope=MANAGEMENT_SCOPE_DAEMON_AGENTS_PROVISION,
+        daemon_instance_id=instance_id,
+        limits_json={"max_uses": 1},
+        expires_at=datetime.datetime.now(datetime.timezone.utc)
+        + datetime.timedelta(days=1),
+    )
+    db_session.add(grant)
+    await db_session.commit()
+    conn, fake_ws, registry = await _with_connected_daemon(
+        instance_id,
+        seed_user["user_id"],
+        runtimes_snapshot=[{"id": "claude-code", "available": True}],
+        db_session=db_session,
+    )
+    try:
+        err_task = asyncio.create_task(
+            _auto_ack(
+                conn,
+                fake_ws,
+                ok=False,
+                err={"code": "keypair_mismatch", "message": "bad"},
+            )
+        )
+        r = await client.post(
+            "/api/users/me/agents/provision",
+            json={
+                "daemon_instance_id": instance_id,
+                "label": "writer",
+                "runtime": "claude-code",
+            },
+            headers={"Authorization": f"Bearer {seed_manager_agent['token']}"},
+        )
+        await err_task
+        assert r.status_code == 502
+        assert r.json()["detail"]["code"] == "daemon_provision_failed"
+        await db_session.refresh(grant)
+        assert grant.use_count == 0
+    finally:
+        await registry.unregister(conn)
+
+
+@pytest.mark.asyncio
 async def test_provision_dispatches_runtime_model_options(
     client: AsyncClient, seed_user, db_session: AsyncSession
 ):

--- a/backend/tests/test_app/test_agent_provision.py
+++ b/backend/tests/test_app/test_agent_provision.py
@@ -21,7 +21,18 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from hub.models import Agent, Base, DaemonInstance, Role, SigningKey, User, UserRole
+from app.auth import MANAGEMENT_SCOPE_DAEMON_AGENTS_PROVISION
+from hub.auth import create_agent_token
+from hub.models import (
+    Agent,
+    AgentManagementGrant,
+    Base,
+    DaemonInstance,
+    Role,
+    SigningKey,
+    User,
+    UserRole,
+)
 
 
 TEST_SUPABASE_SECRET = "test-supabase-jwt-secret-for-agent-provision"
@@ -123,6 +134,27 @@ async def seed_user(db_session: AsyncSession):
         "supabase_uid": str(supabase_uuid),
         "token": _supabase_token(str(supabase_uuid)),
     }
+
+
+@pytest_asyncio.fixture
+async def seed_manager_agent(db_session: AsyncSession, seed_user: dict):
+    agent_id = "ag_daemonmgr01"
+    token, expires_at = create_agent_token(agent_id)
+    db_session.add(
+        Agent(
+            agent_id=agent_id,
+            display_name="Daemon Manager",
+            user_id=seed_user["user_id"],
+            agent_token=token,
+            token_expires_at=datetime.datetime.fromtimestamp(
+                expires_at, tz=datetime.timezone.utc
+            ),
+            claimed_at=datetime.datetime.now(datetime.timezone.utc),
+            status="active",
+        )
+    )
+    await db_session.commit()
+    return {"agent_id": agent_id, "token": token}
 
 
 class _FakeWS:
@@ -267,6 +299,139 @@ async def test_provision_happy_path_writes_runtime_and_dispatches_frame(
         sk = key_res.scalar_one()
         assert sk.state.value == "active"
         assert agent.agent_token
+    finally:
+        await registry.unregister(conn)
+
+
+@pytest.mark.asyncio
+async def test_provision_with_agent_token_requires_daemon_management_grant(
+    client: AsyncClient,
+    seed_user,
+    seed_manager_agent,
+    db_session: AsyncSession,
+):
+    instance_id = await _provision_instance(client, seed_user)
+    conn, _, registry = await _with_connected_daemon(
+        instance_id,
+        seed_user["user_id"],
+        runtimes_snapshot=[{"id": "claude-code", "available": True}],
+        db_session=db_session,
+    )
+    try:
+        r = await client.post(
+            "/api/users/me/agents/provision",
+            json={
+                "daemon_instance_id": instance_id,
+                "label": "writer",
+                "runtime": "claude-code",
+            },
+            headers={"Authorization": f"Bearer {seed_manager_agent['token']}"},
+        )
+        assert r.status_code == 403
+        body = r.json()
+        assert body["detail"]["code"] == "management_permission_required"
+        assert body["detail"]["required_scopes"] == [
+            MANAGEMENT_SCOPE_DAEMON_AGENTS_PROVISION
+        ]
+    finally:
+        await registry.unregister(conn)
+
+
+@pytest.mark.asyncio
+async def test_provision_with_agent_token_requires_matching_daemon_grant(
+    client: AsyncClient,
+    seed_user,
+    seed_manager_agent,
+    db_session: AsyncSession,
+):
+    instance_id = await _provision_instance(client, seed_user)
+    db_session.add(
+        AgentManagementGrant(
+            user_id=seed_user["user_id"],
+            agent_id=seed_manager_agent["agent_id"],
+            scope=MANAGEMENT_SCOPE_DAEMON_AGENTS_PROVISION,
+            daemon_instance_id="dm_otherdaemon",
+            expires_at=datetime.datetime.now(datetime.timezone.utc)
+            + datetime.timedelta(days=1),
+        )
+    )
+    await db_session.commit()
+    conn, _, registry = await _with_connected_daemon(
+        instance_id,
+        seed_user["user_id"],
+        runtimes_snapshot=[{"id": "claude-code", "available": True}],
+        db_session=db_session,
+    )
+    try:
+        r = await client.post(
+            "/api/users/me/agents/provision",
+            json={
+                "daemon_instance_id": instance_id,
+                "label": "writer",
+                "runtime": "claude-code",
+            },
+            headers={"Authorization": f"Bearer {seed_manager_agent['token']}"},
+        )
+        assert r.status_code == 403
+        detail = r.json()["detail"]
+        assert detail["code"] == "management_permission_required"
+        assert f"daemon_instance_id={instance_id}" in detail["authorize_url"]
+    finally:
+        await registry.unregister(conn)
+
+
+@pytest.mark.asyncio
+async def test_provision_accepts_agent_token_with_daemon_scoped_grant(
+    client: AsyncClient,
+    seed_user,
+    seed_manager_agent,
+    db_session: AsyncSession,
+):
+    instance_id = await _provision_instance(client, seed_user)
+    grant = AgentManagementGrant(
+        user_id=seed_user["user_id"],
+        agent_id=seed_manager_agent["agent_id"],
+        scope=MANAGEMENT_SCOPE_DAEMON_AGENTS_PROVISION,
+        daemon_instance_id=instance_id,
+        limits_json={"max_uses": 1},
+        expires_at=datetime.datetime.now(datetime.timezone.utc)
+        + datetime.timedelta(days=1),
+    )
+    db_session.add(grant)
+    await db_session.commit()
+    conn, fake_ws, registry = await _with_connected_daemon(
+        instance_id,
+        seed_user["user_id"],
+        runtimes_snapshot=[{"id": "claude-code", "available": True}],
+        db_session=db_session,
+    )
+    try:
+        ack_task = asyncio.create_task(_auto_ack(conn, fake_ws))
+        r = await client.post(
+            "/api/users/me/agents/provision",
+            json={
+                "daemon_instance_id": instance_id,
+                "label": "writer",
+                "runtime": "claude-code",
+            },
+            headers={"Authorization": f"Bearer {seed_manager_agent['token']}"},
+        )
+        await ack_task
+        assert r.status_code == 201, r.text
+        await db_session.refresh(grant)
+        assert grant.use_count == 1
+
+        r = await client.post(
+            "/api/users/me/agents/provision",
+            json={
+                "daemon_instance_id": instance_id,
+                "label": "second",
+                "runtime": "claude-code",
+            },
+            headers={"Authorization": f"Bearer {seed_manager_agent['token']}"},
+        )
+        assert r.status_code == 403
+        assert r.json()["detail"]["code"] == "management_permission_required"
     finally:
         await registry.unregister(conn)
 

--- a/backend/tests/test_app/test_cloud_agents.py
+++ b/backend/tests/test_app/test_cloud_agents.py
@@ -339,6 +339,36 @@ async def test_reapproving_management_grant_resets_use_count(
 
 
 @pytest.mark.asyncio
+async def test_agent_management_grant_use_is_refunded_when_cloud_create_fails(
+    client_factory,
+    seed_user,
+    seed_manager_agent,
+    db_session: AsyncSession,
+):
+    grant = AgentManagementGrant(
+        user_id=seed_user["user_id"],
+        agent_id=seed_manager_agent["agent_id"],
+        scope=MANAGEMENT_SCOPE_CLOUD_AGENTS_CREATE,
+        limits_json={"max_uses": 1},
+        expires_at=datetime.datetime.now(datetime.timezone.utc)
+        + datetime.timedelta(days=1),
+    )
+    db_session.add(grant)
+    await db_session.commit()
+    client, _ = await client_factory(force_create_failure=True)
+
+    r = await client.post(
+        "/api/cloud-agents",
+        json={"name": "Failing Bot"},
+        headers={"Authorization": f"Bearer {seed_manager_agent['token']}"},
+    )
+    assert r.status_code == 502
+    assert r.json()["detail"]["code"] == "fake_create_failed"
+    await db_session.refresh(grant)
+    assert grant.use_count == 0
+
+
+@pytest.mark.asyncio
 async def test_daemon_provision_grant_requires_daemon_scope(
     client_factory,
     seed_user,

--- a/backend/tests/test_app/test_cloud_agents.py
+++ b/backend/tests/test_app/test_cloud_agents.py
@@ -12,7 +12,12 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from hub.models import Base, CloudAgentInstance, Role, User, UserRole
+from app.auth import (
+    MANAGEMENT_SCOPE_CLOUD_AGENTS_CREATE,
+    MANAGEMENT_SCOPE_DAEMON_AGENTS_PROVISION,
+)
+from hub.auth import create_agent_token
+from hub.models import Agent, AgentManagementGrant, Base, CloudAgentInstance, Role, User, UserRole
 from hub.services.cloud_agent import CloudAgentService, CreateCloudAgentInput
 from hub.services.cloud_daemon_provider import FakeCloudDaemonProvider
 from tests.test_app.conftest import create_test_engine
@@ -73,6 +78,27 @@ async def seed_user(db_session: AsyncSession):
         "supabase_uid": str(supabase_uuid),
         "token": _make_supabase_token(str(supabase_uuid)),
     }
+
+
+@pytest_asyncio.fixture
+async def seed_manager_agent(db_session: AsyncSession, seed_user: dict):
+    agent_id = "ag_manager0001"
+    token, expires_at = create_agent_token(agent_id)
+    db_session.add(
+        Agent(
+            agent_id=agent_id,
+            display_name="Manager Agent",
+            user_id=seed_user["user_id"],
+            agent_token=token,
+            token_expires_at=datetime.datetime.fromtimestamp(
+                expires_at, tz=datetime.timezone.utc
+            ),
+            claimed_at=datetime.datetime.now(datetime.timezone.utc),
+            status="active",
+        )
+    )
+    await db_session.commit()
+    return {"agent_id": agent_id, "token": token}
 
 
 @pytest_asyncio.fixture
@@ -164,6 +190,171 @@ async def test_create_requires_auth(client_factory):
     client, _ = await client_factory()
     r = await client.post("/api/cloud-agents", json={"name": "Bot"})
     assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_create_with_agent_token_requires_management_grant(
+    client_factory,
+    seed_manager_agent,
+):
+    client, _ = await client_factory()
+    r = await client.post(
+        "/api/cloud-agents",
+        json={"name": "Bot"},
+        headers={"Authorization": f"Bearer {seed_manager_agent['token']}"},
+    )
+    assert r.status_code == 403
+    body = r.json()
+    assert body["detail"]["code"] == "management_permission_required"
+    assert body["detail"]["required_scopes"] == [MANAGEMENT_SCOPE_CLOUD_AGENTS_CREATE]
+    assert "/cli-permissions" in body["detail"]["authorize_url"]
+
+
+@pytest.mark.asyncio
+async def test_create_accepts_agent_token_with_management_grant(
+    client_factory,
+    seed_user,
+    seed_manager_agent,
+    db_session: AsyncSession,
+):
+    db_session.add(
+        AgentManagementGrant(
+            user_id=seed_user["user_id"],
+            agent_id=seed_manager_agent["agent_id"],
+            scope=MANAGEMENT_SCOPE_CLOUD_AGENTS_CREATE,
+            expires_at=datetime.datetime.now(datetime.timezone.utc)
+            + datetime.timedelta(days=1),
+        )
+    )
+    await db_session.commit()
+    client, _ = await client_factory()
+
+    r = await client.post(
+        "/api/cloud-agents",
+        json={"name": "Agent-Created Bot", "runtime": "deepseek-tui"},
+        headers={"Authorization": f"Bearer {seed_manager_agent['token']}"},
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["name"] == "Agent-Created Bot"
+    assert body["hosting_kind"] == "cloud"
+
+
+@pytest.mark.asyncio
+async def test_user_can_create_list_and_revoke_management_grant(
+    client_factory,
+    seed_user,
+    seed_manager_agent,
+):
+    client, _ = await client_factory()
+    headers = {"Authorization": f"Bearer {seed_user['token']}"}
+
+    r = await client.post(
+        "/api/agent-management/grants",
+        json={
+            "agent_id": seed_manager_agent["agent_id"],
+            "scopes": [MANAGEMENT_SCOPE_CLOUD_AGENTS_CREATE],
+            "expires_in_days": 7,
+        },
+        headers=headers,
+    )
+    assert r.status_code == 201, r.text
+    grant = r.json()["grants"][0]
+    assert grant["agent_id"] == seed_manager_agent["agent_id"]
+    assert grant["scope"] == MANAGEMENT_SCOPE_CLOUD_AGENTS_CREATE
+    assert grant["revoked_at"] is None
+
+    r = await client.get(
+        f"/api/agent-management/grants?agent_id={seed_manager_agent['agent_id']}",
+        headers=headers,
+    )
+    assert r.status_code == 200
+    assert [item["id"] for item in r.json()["grants"]] == [grant["id"]]
+
+    r = await client.delete(f"/api/agent-management/grants/{grant['id']}", headers=headers)
+    assert r.status_code == 200
+    assert r.json()["revoked_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_reapproving_management_grant_resets_use_count(
+    client_factory,
+    seed_user,
+    seed_manager_agent,
+    db_session: AsyncSession,
+):
+    client, _ = await client_factory()
+    user_headers = {"Authorization": f"Bearer {seed_user['token']}"}
+    agent_headers = {"Authorization": f"Bearer {seed_manager_agent['token']}"}
+    grant_body = {
+        "agent_id": seed_manager_agent["agent_id"],
+        "scopes": [MANAGEMENT_SCOPE_CLOUD_AGENTS_CREATE],
+        "expires_in_days": 7,
+        "limits": {"max_uses": 1},
+    }
+
+    r = await client.post(
+        "/api/agent-management/grants",
+        json=grant_body,
+        headers=user_headers,
+    )
+    assert r.status_code == 201, r.text
+    grant_id = r.json()["grants"][0]["id"]
+
+    r = await client.post(
+        "/api/cloud-agents",
+        json={"name": "First Bot"},
+        headers=agent_headers,
+    )
+    assert r.status_code == 201, r.text
+
+    grant = await db_session.get(AgentManagementGrant, uuid.UUID(grant_id))
+    assert grant is not None
+    assert grant.use_count == 1
+
+    r = await client.post(
+        "/api/cloud-agents",
+        json={"name": "Blocked Bot"},
+        headers=agent_headers,
+    )
+    assert r.status_code == 403
+    assert r.json()["detail"]["code"] == "management_permission_required"
+
+    r = await client.post(
+        "/api/agent-management/grants",
+        json=grant_body,
+        headers=user_headers,
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["grants"][0]["use_count"] == 0
+    await db_session.refresh(grant)
+    assert grant.use_count == 0
+
+    r = await client.post(
+        "/api/cloud-agents",
+        json={"name": "Second Bot"},
+        headers=agent_headers,
+    )
+    assert r.status_code == 201, r.text
+
+
+@pytest.mark.asyncio
+async def test_daemon_provision_grant_requires_daemon_scope(
+    client_factory,
+    seed_user,
+    seed_manager_agent,
+):
+    client, _ = await client_factory()
+    r = await client.post(
+        "/api/agent-management/grants",
+        json={
+            "agent_id": seed_manager_agent["agent_id"],
+            "scopes": [MANAGEMENT_SCOPE_DAEMON_AGENTS_PROVISION],
+        },
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert r.status_code == 400
+    assert r.json()["detail"] == "daemon_agents:provision requires daemon_instance_id"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_app/test_team_orchestration.py
+++ b/backend/tests/test_app/test_team_orchestration.py
@@ -13,9 +13,12 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from app.auth import MANAGEMENT_SCOPE_TEAM_ORCHESTRATION_PROVISION
+from hub.auth import create_agent_token
 from hub.enums import ParticipantType
 from hub.models import (
     Agent,
+    AgentManagementGrant,
     Base,
     CloudAgentInstance,
     CloudDaemonInstance,
@@ -90,6 +93,27 @@ async def seed_user(db_session: AsyncSession):
 
 
 @pytest_asyncio.fixture
+async def seed_manager_agent(db_session: AsyncSession, seed_user: dict):
+    agent_id = "ag_teammanager"
+    token, expires_at = create_agent_token(agent_id)
+    db_session.add(
+        Agent(
+            agent_id=agent_id,
+            display_name="Team Manager",
+            user_id=seed_user["user_id"],
+            agent_token=token,
+            token_expires_at=datetime.datetime.fromtimestamp(
+                expires_at, tz=datetime.timezone.utc
+            ),
+            claimed_at=datetime.datetime.now(datetime.timezone.utc),
+            status="active",
+        )
+    )
+    await db_session.commit()
+    return {"agent_id": agent_id, "token": token}
+
+
+@pytest_asyncio.fixture
 async def client_factory(db_session: AsyncSession, monkeypatch):
     import app.auth
     import app.routers.cloud_agents as cloud_agents_router
@@ -146,6 +170,130 @@ async def test_plan_requires_auth(client_factory):
         json={"goal": "Ship the billing dashboard"},
     )
     assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_provision_with_agent_token_requires_management_grant(
+    client_factory,
+    seed_manager_agent,
+):
+    client = await client_factory()
+    response = await client.post(
+        "/api/team-orchestration/provision",
+        json={"goal": "Build an agent-token team", "role_count": 1},
+        headers={"Authorization": f"Bearer {seed_manager_agent['token']}"},
+    )
+    assert response.status_code == 403
+    body = response.json()
+    assert body["detail"]["code"] == "management_permission_required"
+    assert body["detail"]["required_scopes"] == [
+        MANAGEMENT_SCOPE_TEAM_ORCHESTRATION_PROVISION
+    ]
+
+
+@pytest.mark.asyncio
+async def test_provision_accepts_agent_token_with_management_grant(
+    client_factory,
+    seed_user,
+    seed_manager_agent,
+    db_session: AsyncSession,
+):
+    db_session.add(
+        AgentManagementGrant(
+            user_id=seed_user["user_id"],
+            agent_id=seed_manager_agent["agent_id"],
+            scope=MANAGEMENT_SCOPE_TEAM_ORCHESTRATION_PROVISION,
+            expires_at=datetime.datetime.now(datetime.timezone.utc)
+            + datetime.timedelta(days=1),
+        )
+    )
+    await db_session.commit()
+    client = await client_factory()
+
+    response = await client.post(
+        "/api/team-orchestration/provision",
+        json={
+            "goal": "Build an agent-token team",
+            "role_count": 1,
+            "start_runs": False,
+        },
+        headers={"Authorization": f"Bearer {seed_manager_agent['token']}"},
+    )
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert body["room"]["owner_type"] == "human"
+    assert len(body["roles"]) == 1
+    assert body["roles"][0]["cloud_agent"]["hosting_kind"] == "cloud"
+
+
+@pytest.mark.asyncio
+async def test_provision_enforces_agent_management_role_count_limit(
+    client_factory,
+    seed_user,
+    seed_manager_agent,
+    db_session: AsyncSession,
+):
+    db_session.add(
+        AgentManagementGrant(
+            user_id=seed_user["user_id"],
+            agent_id=seed_manager_agent["agent_id"],
+            scope=MANAGEMENT_SCOPE_TEAM_ORCHESTRATION_PROVISION,
+            limits_json={"max_role_count": 1},
+            expires_at=datetime.datetime.now(datetime.timezone.utc)
+            + datetime.timedelta(days=1),
+        )
+    )
+    await db_session.commit()
+    client = await client_factory()
+
+    response = await client.post(
+        "/api/team-orchestration/provision",
+        json={
+            "goal": "Build an oversized team",
+            "role_count": 2,
+            "start_runs": False,
+        },
+        headers={"Authorization": f"Bearer {seed_manager_agent['token']}"},
+    )
+    assert response.status_code == 403
+    body = response.json()
+    assert body["detail"]["code"] == "management_limit_exceeded"
+    assert body["detail"]["limit"] == "max_role_count"
+
+
+@pytest.mark.asyncio
+async def test_provision_enforces_agent_management_start_runs_limit(
+    client_factory,
+    seed_user,
+    seed_manager_agent,
+    db_session: AsyncSession,
+):
+    db_session.add(
+        AgentManagementGrant(
+            user_id=seed_user["user_id"],
+            agent_id=seed_manager_agent["agent_id"],
+            scope=MANAGEMENT_SCOPE_TEAM_ORCHESTRATION_PROVISION,
+            limits_json={"allow_start_runs": False},
+            expires_at=datetime.datetime.now(datetime.timezone.utc)
+            + datetime.timedelta(days=1),
+        )
+    )
+    await db_session.commit()
+    client = await client_factory()
+
+    response = await client.post(
+        "/api/team-orchestration/provision",
+        json={
+            "goal": "Build a team without starting runs",
+            "role_count": 1,
+            "start_runs": True,
+        },
+        headers={"Authorization": f"Bearer {seed_manager_agent['token']}"},
+    )
+    assert response.status_code == 403
+    body = response.json()
+    assert body["detail"]["code"] == "management_limit_exceeded"
+    assert body["detail"]["limit"] == "allow_start_runs"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_app/test_team_orchestration.py
+++ b/backend/tests/test_app/test_team_orchestration.py
@@ -233,16 +233,15 @@ async def test_provision_enforces_agent_management_role_count_limit(
     seed_manager_agent,
     db_session: AsyncSession,
 ):
-    db_session.add(
-        AgentManagementGrant(
-            user_id=seed_user["user_id"],
-            agent_id=seed_manager_agent["agent_id"],
-            scope=MANAGEMENT_SCOPE_TEAM_ORCHESTRATION_PROVISION,
-            limits_json={"max_role_count": 1},
-            expires_at=datetime.datetime.now(datetime.timezone.utc)
-            + datetime.timedelta(days=1),
-        )
+    grant = AgentManagementGrant(
+        user_id=seed_user["user_id"],
+        agent_id=seed_manager_agent["agent_id"],
+        scope=MANAGEMENT_SCOPE_TEAM_ORCHESTRATION_PROVISION,
+        limits_json={"max_role_count": 1},
+        expires_at=datetime.datetime.now(datetime.timezone.utc)
+        + datetime.timedelta(days=1),
     )
+    db_session.add(grant)
     await db_session.commit()
     client = await client_factory()
 
@@ -259,6 +258,80 @@ async def test_provision_enforces_agent_management_role_count_limit(
     body = response.json()
     assert body["detail"]["code"] == "management_limit_exceeded"
     assert body["detail"]["limit"] == "max_role_count"
+    await db_session.refresh(grant)
+    assert grant.use_count == 0
+
+
+@pytest.mark.asyncio
+async def test_provision_checks_role_limit_against_normalized_plan(
+    client_factory,
+    seed_user,
+    seed_manager_agent,
+    db_session: AsyncSession,
+):
+    grant = AgentManagementGrant(
+        user_id=seed_user["user_id"],
+        agent_id=seed_manager_agent["agent_id"],
+        scope=MANAGEMENT_SCOPE_TEAM_ORCHESTRATION_PROVISION,
+        limits_json={"max_role_count": 1},
+        expires_at=datetime.datetime.now(datetime.timezone.utc)
+        + datetime.timedelta(days=1),
+    )
+    db_session.add(grant)
+    await db_session.commit()
+    client = await client_factory()
+
+    response = await client.post(
+        "/api/team-orchestration/provision",
+        json={
+            "goal": "Build a bounded team",
+            "role_count": 1,
+            "roles": [
+                {"key": "one", "name": "One", "brief": "First role."},
+                {"key": "two", "name": "Two", "brief": "Second role."},
+            ],
+            "start_runs": False,
+        },
+        headers={"Authorization": f"Bearer {seed_manager_agent['token']}"},
+    )
+    assert response.status_code == 201, response.text
+    assert len(response.json()["roles"]) == 1
+    await db_session.refresh(grant)
+    assert grant.use_count == 1
+
+
+@pytest.mark.asyncio
+async def test_team_management_grant_use_is_refunded_when_provision_fails(
+    client_factory,
+    seed_user,
+    seed_manager_agent,
+    db_session: AsyncSession,
+):
+    grant = AgentManagementGrant(
+        user_id=seed_user["user_id"],
+        agent_id=seed_manager_agent["agent_id"],
+        scope=MANAGEMENT_SCOPE_TEAM_ORCHESTRATION_PROVISION,
+        limits_json={"max_uses": 1},
+        expires_at=datetime.datetime.now(datetime.timezone.utc)
+        + datetime.timedelta(days=1),
+    )
+    db_session.add(grant)
+    await db_session.commit()
+    client = await client_factory(force_create_failure=True)
+
+    response = await client.post(
+        "/api/team-orchestration/provision",
+        json={
+            "goal": "Fail after reserving permission",
+            "role_count": 1,
+            "start_runs": False,
+        },
+        headers={"Authorization": f"Bearer {seed_manager_agent['token']}"},
+    )
+    assert response.status_code == 502, response.text
+    assert response.json()["detail"]["code"] == "fake_create_failed"
+    await db_session.refresh(grant)
+    assert grant.use_count == 0
 
 
 @pytest.mark.asyncio

--- a/cli/README.md
+++ b/cli/README.md
@@ -59,6 +59,8 @@ All commands output JSON. Use `--help` on any command for details.
 | `botcord token` | Fetch current JWT token |
 | `botcord env` | View or switch hub environment (`stable` / `beta` / `test`) |
 | `botcord bind` | Bind agent to a dashboard account |
+| `botcord bot create` | Create a cloud or daemon-hosted bot with an owner-granted agent management permission |
+| `botcord team create` | Provision a small Cloud Agent team with an owner-granted agent management permission |
 
 ### Messaging
 
@@ -113,6 +115,23 @@ All commands output JSON. Use `--help` on any command for details.
 | `botcord schedule run` | Trigger a schedule immediately |
 | `botcord schedule runs` | List recent runs |
 | `botcord schedule delete` | Delete a schedule |
+
+### Creating bots from CLI
+
+`botcord bot create` and `botcord team create` use the current agent credentials.
+The owner must first approve the required management permission in the dashboard.
+When a permission is missing, the command returns JSON containing an `authorize_url`.
+
+```bash
+botcord bot create --name "Research Analyst" --runtime codex
+botcord team create --goal "Research the competitor landscape" --role-count 3
+```
+
+Daemon-hosted bot creation requires a daemon-scoped permission:
+
+```bash
+botcord bot create --daemon dm_xxxxxxxxxxxx --name "Local Codex Bot" --runtime codex
+```
 
 ## Credentials
 

--- a/cli/src/commands/bot.ts
+++ b/cli/src/commands/bot.ts
@@ -1,0 +1,133 @@
+import type { ParsedArgs } from "../args.js";
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials } from "../credentials.js";
+import { normalizeAndValidateHubUrl } from "../hub-url.js";
+import { outputError, outputErrorObject, outputJson } from "../output.js";
+
+function optionalString(value: string | boolean | undefined): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function optionalBool(name: string, value: string | boolean | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === "boolean") return value;
+  const normalized = value.trim().toLowerCase();
+  if (["true", "1", "yes", "on"].includes(normalized)) return true;
+  if (["false", "0", "no", "off"].includes(normalized)) return false;
+  outputError(`--${name} must be true or false`);
+}
+
+async function appPost(
+  hubUrl: string,
+  token: string,
+  path: string,
+  body: Record<string, unknown>,
+  action: string,
+): Promise<unknown> {
+  const resp = await fetch(`${hubUrl.replace(/\/+$/, "")}${path}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(60000),
+  });
+  if (resp.ok) return await resp.json();
+
+  const json = await resp.json().catch(() => null) as Record<string, unknown> | null;
+  const detail = json && typeof json.detail === "object" && json.detail !== null
+    ? json.detail as Record<string, unknown>
+    : null;
+  if (detail) {
+    outputErrorObject({
+      error: detail.code || `${action}_failed`,
+      status: resp.status,
+      ...detail,
+    });
+  }
+  const text = json ? JSON.stringify(json) : await resp.text().catch(() => "");
+  outputError(`${action} failed (${resp.status}): ${text || resp.statusText}`);
+}
+
+export async function botCommand(
+  args: ParsedArgs,
+  globalHub?: string,
+  globalAgent?: string,
+): Promise<void> {
+  if (args.flags["help"] || args.subcommand !== "create") {
+    console.log(`Usage: botcord bot create --name <name> [options]
+
+Create a BotCord bot using the current agent credential.
+
+Options:
+  --name <name>                  Bot display name (required)
+  --bio <text>                   Bot bio
+  --cloud                        Create a cloud-hosted bot (default)
+  --daemon <daemon_instance_id>  Create on a local daemon instead of cloud
+  --runtime <id>                 Runtime id (required for --daemon)
+  --model-profile <id>           Cloud model profile
+  --runtime-model <id>           Runtime model id/alias
+  --reasoning-effort <value>     Runtime reasoning effort
+  --thinking <true|false>        Runtime thinking toggle
+  --cwd <path>                   Local daemon working directory
+  --openclaw-gateway <name>      OpenClaw gateway selection
+  --openclaw-agent <id>          OpenClaw agent selection
+  --hermes-profile <name>        Hermes profile selection`);
+    return;
+  }
+
+  const name = optionalString(args.flags["name"]);
+  if (!name) outputError("--name is required");
+
+  const daemonId = optionalString(args.flags["daemon"]);
+  if (daemonId && args.flags["cloud"] === true) {
+    outputError("--cloud and --daemon cannot be used together");
+  }
+
+  const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+  const hubUrl = normalizeAndValidateHubUrl(globalHub || creds.hubUrl);
+  const client = new BotCordClient({
+    hubUrl,
+    agentId: creds.agentId,
+    keyId: creds.keyId,
+    privateKey: creds.privateKey,
+    token: creds.token,
+    tokenExpiresAt: creds.tokenExpiresAt,
+  });
+  const token = await client.ensureToken();
+
+  const runtime = optionalString(args.flags["runtime"]);
+  const body: Record<string, unknown> = {
+    bio: optionalString(args.flags["bio"]),
+    runtime,
+    runtime_model: optionalString(args.flags["runtime-model"]),
+    reasoning_effort: optionalString(args.flags["reasoning-effort"]),
+    thinking: optionalBool("thinking", args.flags["thinking"]),
+  };
+  for (const key of Object.keys(body)) {
+    if (body[key] === undefined) delete body[key];
+  }
+
+  if (daemonId) {
+    if (!runtime) outputError("--runtime is required when --daemon is used");
+    body.daemon_instance_id = daemonId;
+    body.label = name;
+    body.cwd = optionalString(args.flags["cwd"]);
+    body.openclaw_gateway = optionalString(args.flags["openclaw-gateway"]);
+    body.openclaw_agent = optionalString(args.flags["openclaw-agent"]);
+    body.hermes_profile = optionalString(args.flags["hermes-profile"]);
+    for (const key of Object.keys(body)) {
+      if (body[key] === undefined) delete body[key];
+    }
+    outputJson(await appPost(hubUrl, token, "/api/users/me/agents/provision", body, "bot_create"));
+    return;
+  }
+
+  body.name = name;
+  body.model_profile = optionalString(args.flags["model-profile"]);
+  for (const key of Object.keys(body)) {
+    if (body[key] === undefined) delete body[key];
+  }
+  outputJson(await appPost(hubUrl, token, "/api/cloud-agents", body, "bot_create"));
+}

--- a/cli/src/commands/team.ts
+++ b/cli/src/commands/team.ts
@@ -1,0 +1,112 @@
+import type { ParsedArgs } from "../args.js";
+import { BotCordClient } from "../client.js";
+import { loadDefaultCredentials } from "../credentials.js";
+import { normalizeAndValidateHubUrl } from "../hub-url.js";
+import { outputError, outputErrorObject, outputJson } from "../output.js";
+
+function optionalString(value: string | boolean | undefined): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function optionalInt(name: string, value: string | boolean | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") outputError(`--${name} requires a number`);
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) outputError(`--${name} requires a number`);
+  return parsed;
+}
+
+function optionalBool(name: string, value: string | boolean | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === "boolean") return value;
+  const normalized = value.trim().toLowerCase();
+  if (["true", "1", "yes", "on"].includes(normalized)) return true;
+  if (["false", "0", "no", "off"].includes(normalized)) return false;
+  outputError(`--${name} must be true or false`);
+}
+
+async function appPost(
+  hubUrl: string,
+  token: string,
+  path: string,
+  body: Record<string, unknown>,
+): Promise<unknown> {
+  const resp = await fetch(`${hubUrl.replace(/\/+$/, "")}${path}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(60000),
+  });
+  if (resp.ok) return await resp.json();
+
+  const json = await resp.json().catch(() => null) as Record<string, unknown> | null;
+  const detail = json && typeof json.detail === "object" && json.detail !== null
+    ? json.detail as Record<string, unknown>
+    : null;
+  if (detail) {
+    outputErrorObject({
+      error: detail.code || "team_create_failed",
+      status: resp.status,
+      ...detail,
+    });
+  }
+  const text = json ? JSON.stringify(json) : await resp.text().catch(() => "");
+  outputError(`team create failed (${resp.status}): ${text || resp.statusText}`);
+}
+
+export async function teamCommand(
+  args: ParsedArgs,
+  globalHub?: string,
+  globalAgent?: string,
+): Promise<void> {
+  if (args.flags["help"] || args.subcommand !== "create") {
+    console.log(`Usage: botcord team create --goal <goal> [options]
+
+Provision a small Cloud Agent team using the current agent credential.
+
+Options:
+  --goal <text>                 Team goal (required)
+  --role-count <n>              Number of default roles, 1-5
+  --room-name <name>            Room name
+  --start-runs <true|false>     Start kickoff runs (default: true)
+  --max-wall-time <seconds>     Run budget wall-clock seconds
+  --max-tool-calls <n>          Run budget tool-call limit`);
+    return;
+  }
+
+  const goal = optionalString(args.flags["goal"]);
+  if (!goal) outputError("--goal is required");
+
+  const body: Record<string, unknown> = { goal };
+  const roleCount = optionalInt("role-count", args.flags["role-count"]);
+  if (roleCount !== undefined) body.role_count = roleCount;
+  const roomName = optionalString(args.flags["room-name"]);
+  if (roomName) body.room_name = roomName;
+  const startRuns = optionalBool("start-runs", args.flags["start-runs"]);
+  if (startRuns !== undefined) body.start_runs = startRuns;
+  const maxWallTime = optionalInt("max-wall-time", args.flags["max-wall-time"]);
+  const maxToolCalls = optionalInt("max-tool-calls", args.flags["max-tool-calls"]);
+  if (maxWallTime !== undefined || maxToolCalls !== undefined) {
+    body.budget = {
+      ...(maxWallTime !== undefined ? { max_wall_time_seconds: maxWallTime } : {}),
+      ...(maxToolCalls !== undefined ? { max_tool_calls: maxToolCalls } : {}),
+    };
+  }
+
+  const creds = loadDefaultCredentials(typeof globalAgent === "string" ? globalAgent : undefined);
+  const hubUrl = normalizeAndValidateHubUrl(globalHub || creds.hubUrl);
+  const client = new BotCordClient({
+    hubUrl,
+    agentId: creds.agentId,
+    keyId: creds.keyId,
+    privateKey: creds.privateKey,
+    token: creds.token,
+    tokenExpiresAt: creds.tokenExpiresAt,
+  });
+  const token = await client.ensureToken();
+
+  outputJson(await appPost(hubUrl, token, "/api/team-orchestration/provision", body));
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -25,6 +25,8 @@ import { envCommand } from "./commands/env.js";
 import { memoryCommand } from "./commands/memory.js";
 import { scheduleCommand } from "./commands/schedule.js";
 import { gatewayCommand } from "./commands/gateway.js";
+import { botCommand } from "./commands/bot.js";
+import { teamCommand } from "./commands/team.js";
 
 const VERSION = "0.1.0";
 
@@ -57,6 +59,8 @@ Commands:
   memory            Manage working memory
   schedule          Manage proactive schedules
   gateway           Send through third-party gateways
+  bot               Create BotCord bots
+  team              Create Cloud Agent teams
 
 Global options:
   --agent <id>      Use specific agent credentials
@@ -159,6 +163,12 @@ async function main(): Promise<void> {
         break;
       case "gateway":
         await gatewayCommand(args, globalHub, globalAgent);
+        break;
+      case "bot":
+        await botCommand(args, globalHub, globalAgent);
+        break;
+      case "team":
+        await teamCommand(args, globalHub, globalAgent);
         break;
       default:
         outputError(`unknown command: ${args.command}. Run "botcord --help" for usage.`);

--- a/cli/src/output.ts
+++ b/cli/src/output.ts
@@ -6,3 +6,8 @@ export function outputError(message: string): never {
   console.error(JSON.stringify({ error: message }));
   process.exit(1);
 }
+
+export function outputErrorObject(data: Record<string, unknown>): never {
+  console.error(JSON.stringify(data, null, 2));
+  process.exit(1);
+}

--- a/frontend/src/app/(dashboard)/settings/agents/[agentId]/cli-permissions/CliPermissionsClient.tsx
+++ b/frontend/src/app/(dashboard)/settings/agents/[agentId]/cli-permissions/CliPermissionsClient.tsx
@@ -1,0 +1,588 @@
+"use client";
+
+/**
+ * [INPUT]: CLI-requested agent management scopes and optional daemon_instance_id
+ * [OUTPUT]: Owner approval UI that creates management grants through the BFF
+ * [POS]: dashboard settings client for CLI agent credential authorization
+ * [PROTOCOL]: update header on changes
+ */
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Clock3,
+  Hash,
+  Loader2,
+  ShieldCheck,
+  Terminal,
+  XCircle,
+} from "lucide-react";
+
+const DAEMON_PROVISION_SCOPE = "daemon_agents:provision";
+
+const EXPIRATION_OPTIONS = [
+  { value: 7, label: "7 days" },
+  { value: 30, label: "30 days" },
+  { value: 90, label: "90 days" },
+];
+
+const USAGE_LIMIT_OPTIONS: Array<{ value: number | null; label: string }> = [
+  { value: 1, label: "Single use" },
+  { value: 5, label: "5 uses" },
+  { value: null, label: "No limit" },
+];
+
+const SCOPE_COPY: Record<string, { label: string; description: string }> = {
+  "cloud_agents:create": {
+    label: "Create cloud bots",
+    description: "Allows this CLI credential to create cloud-hosted BotCord agents.",
+  },
+  "team_orchestration:provision": {
+    label: "Provision teams",
+    description: "Allows this CLI credential to create team-orchestration agents and runs.",
+  },
+  [DAEMON_PROVISION_SCOPE]: {
+    label: "Provision daemon bots",
+    description: "Allows this CLI credential to create bots on one specific daemon.",
+  },
+  "runtime_skills:install": {
+    label: "Install runtime skills",
+    description: "Allows this CLI credential to install skills during provisioning.",
+  },
+};
+
+interface AgentManagementGrant {
+  id: string;
+  agent_id: string;
+  scope: string;
+  daemon_instance_id: string | null;
+  limits: Record<string, unknown>;
+  use_count: number;
+  expires_at: string | null;
+  revoked_at: string | null;
+  created_at: string | null;
+}
+
+interface GrantListResponse {
+  grants: AgentManagementGrant[];
+}
+
+function parseScopes(scopeParams: string[]): string[] {
+  return Array.from(
+    new Set(
+      scopeParams
+        .flatMap((value) => value.split(","))
+        .map((value) => value.trim())
+        .filter(Boolean),
+    ),
+  );
+}
+
+function scopeLabel(scope: string): string {
+  return SCOPE_COPY[scope]?.label ?? scope;
+}
+
+function scopeDescription(scope: string): string {
+  return SCOPE_COPY[scope]?.description ?? "Allows the requested management action.";
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return "No expiration";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}
+
+function isCurrentGrant(grant: AgentManagementGrant): boolean {
+  if (grant.revoked_at) return false;
+  const maxUses = grant.limits.max_uses;
+  if (
+    typeof maxUses === "number" &&
+    Number.isInteger(maxUses) &&
+    maxUses >= 0 &&
+    grant.use_count >= maxUses
+  ) {
+    return false;
+  }
+  if (!grant.expires_at) return true;
+  const expiresAt = new Date(grant.expires_at).getTime();
+  if (Number.isNaN(expiresAt) || expiresAt <= Date.now()) return false;
+  return true;
+}
+
+function mergeGrants(
+  next: AgentManagementGrant[],
+  previous: AgentManagementGrant[],
+): AgentManagementGrant[] {
+  const grantsById = new Map<string, AgentManagementGrant>();
+  for (const grant of next) {
+    grantsById.set(grant.id, grant);
+  }
+  for (const grant of previous) {
+    if (!grantsById.has(grant.id)) {
+      grantsById.set(grant.id, grant);
+    }
+  }
+  return Array.from(grantsById.values());
+}
+
+function usageLimitLabel(value: number | null): string {
+  return USAGE_LIMIT_OPTIONS.find((option) => option.value === value)?.label ?? `${value} uses`;
+}
+
+async function apiErrorMessage(res: Response): Promise<string> {
+  const text = await res.text().catch(() => "");
+  if (!text) return res.statusText || `HTTP ${res.status}`;
+  try {
+    const data = JSON.parse(text) as Record<string, unknown>;
+    if (typeof data.error === "string") return data.error;
+    if (typeof data.message === "string") return data.message;
+    if (typeof data.detail === "string") return data.detail;
+    if (Array.isArray(data.detail)) {
+      return data.detail
+        .map((item) => {
+          if (item && typeof item === "object" && "msg" in item) {
+            return String((item as { msg: unknown }).msg);
+          }
+          return JSON.stringify(item);
+        })
+        .join("; ");
+    }
+    if (data.detail && typeof data.detail === "object") {
+      const detail = data.detail as Record<string, unknown>;
+      if (typeof detail.message === "string") return detail.message;
+      if (typeof detail.code === "string") return detail.code;
+    }
+  } catch {
+    return text;
+  }
+  return res.statusText || `HTTP ${res.status}`;
+}
+
+async function fetchGrants(agentId: string): Promise<AgentManagementGrant[]> {
+  const params = new URLSearchParams({ agent_id: agentId });
+  const res = await fetch(`/api/agent-management/grants?${params.toString()}`, {
+    cache: "no-store",
+  });
+  if (!res.ok) throw new Error(await apiErrorMessage(res));
+  const data = (await res.json()) as GrantListResponse;
+  return data.grants ?? [];
+}
+
+async function createGrants(body: {
+  agent_id: string;
+  scopes: string[];
+  expires_in_days: number;
+  daemon_instance_id?: string;
+  limits?: Record<string, unknown>;
+}): Promise<AgentManagementGrant[]> {
+  const res = await fetch("/api/agent-management/grants", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(await apiErrorMessage(res));
+  const data = (await res.json()) as GrantListResponse;
+  return data.grants ?? [];
+}
+
+function Notice({
+  tone,
+  icon,
+  children,
+}: {
+  tone: "error" | "warning" | "success";
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  const classes =
+    tone === "success"
+      ? "border-neon-green/25 bg-neon-green/10 text-neon-green"
+      : tone === "warning"
+        ? "border-yellow-400/25 bg-yellow-400/10 text-yellow-200"
+        : "border-red-400/25 bg-red-400/10 text-red-300";
+  return (
+    <div className={`mb-4 flex items-start gap-2 rounded-lg border px-4 py-3 text-sm ${classes}`}>
+      <span className="mt-0.5 shrink-0">{icon}</span>
+      <div className="min-w-0">{children}</div>
+    </div>
+  );
+}
+
+function ScopeList({
+  scopes,
+  activeScopes,
+  daemonInstanceId,
+}: {
+  scopes: string[];
+  activeScopes?: Set<string>;
+  daemonInstanceId: string | null;
+}) {
+  return (
+    <div className="space-y-2">
+      {scopes.map((scope) => {
+        const active = activeScopes?.has(scope) ?? false;
+        const isDaemonScope = scope === DAEMON_PROVISION_SCOPE;
+        return (
+          <div
+            key={scope}
+            className="rounded-lg border border-glass-border bg-deep-black/30 px-3 py-3"
+          >
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-sm font-medium text-text-primary">
+                {scopeLabel(scope)}
+              </span>
+              <span className="rounded border border-glass-border bg-glass-bg px-1.5 py-0.5 font-mono text-[11px] text-text-secondary">
+                {scope}
+              </span>
+              {active ? (
+                <span className="rounded-full bg-neon-green/10 px-2 py-0.5 text-[11px] text-neon-green">
+                  Active
+                </span>
+              ) : null}
+            </div>
+            <p className="mt-1 text-xs text-text-secondary">
+              {scopeDescription(scope)}
+            </p>
+            {isDaemonScope && daemonInstanceId ? (
+              <p className="mt-2 font-mono text-[11px] text-text-tertiary">
+                daemon_instance_id: {daemonInstanceId}
+              </p>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function CliPermissionsClient({
+  agentId,
+  scopeParams,
+  daemonInstanceId,
+}: {
+  agentId: string;
+  scopeParams: string[];
+  daemonInstanceId: string | null;
+}) {
+  const requestedScopes = useMemo(() => parseScopes(scopeParams), [scopeParams]);
+  const [expiresInDays, setExpiresInDays] = useState(30);
+  const [maxUses, setMaxUses] = useState<number | null>(1);
+  const [loading, setLoading] = useState(true);
+  const [existingGrants, setExistingGrants] = useState<AgentManagementGrant[]>([]);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [createdGrants, setCreatedGrants] = useState<AgentManagementGrant[] | null>(null);
+
+  const hasScopes = requestedScopes.length > 0;
+  const needsDaemonId =
+    requestedScopes.includes(DAEMON_PROVISION_SCOPE) && !daemonInstanceId;
+
+  const activeScopes = useMemo(() => {
+    const active = new Set<string>();
+    for (const grant of existingGrants) {
+      if (!requestedScopes.includes(grant.scope) || !isCurrentGrant(grant)) {
+        continue;
+      }
+      if (grant.scope === DAEMON_PROVISION_SCOPE) {
+        if (daemonInstanceId && grant.daemon_instance_id === daemonInstanceId) {
+          active.add(grant.scope);
+        }
+        continue;
+      }
+      if (grant.daemon_instance_id === null) {
+        active.add(grant.scope);
+      }
+    }
+    return active;
+  }, [daemonInstanceId, existingGrants, requestedScopes]);
+
+  const load = useCallback(async () => {
+    if (!agentId) return;
+    setLoading(true);
+    setLoadError(null);
+    try {
+      setExistingGrants(await fetchGrants(agentId));
+    } catch (err) {
+      setLoadError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [agentId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const approve = useCallback(async () => {
+    if (!hasScopes || needsDaemonId || submitting) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    setCreatedGrants(null);
+    try {
+      const limits = maxUses === null ? undefined : { max_uses: maxUses };
+      const globalScopes = requestedScopes.filter(
+        (scope) => scope !== DAEMON_PROVISION_SCOPE,
+      );
+      const daemonScopes = requestedScopes.filter(
+        (scope) => scope === DAEMON_PROVISION_SCOPE,
+      );
+      const grants: AgentManagementGrant[] = [];
+
+      if (globalScopes.length > 0) {
+        grants.push(
+          ...(await createGrants({
+            agent_id: agentId,
+            scopes: globalScopes,
+            expires_in_days: expiresInDays,
+            limits,
+          })),
+        );
+      }
+
+      if (daemonScopes.length > 0 && daemonInstanceId) {
+        grants.push(
+          ...(await createGrants({
+            agent_id: agentId,
+            scopes: daemonScopes,
+            expires_in_days: expiresInDays,
+            daemon_instance_id: daemonInstanceId,
+            limits,
+          })),
+        );
+      }
+
+      setCreatedGrants(grants);
+      setExistingGrants((prev) => mergeGrants(grants, prev));
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }, [
+    agentId,
+    daemonInstanceId,
+    expiresInDays,
+    hasScopes,
+    maxUses,
+    needsDaemonId,
+    requestedScopes,
+    submitting,
+  ]);
+
+  return (
+    <div className="max-w-3xl">
+      <header className="mb-6 flex items-start justify-between gap-4">
+        <div className="flex items-start gap-3">
+          <ShieldCheck className="mt-0.5 h-5 w-5 text-neon-cyan" />
+          <div>
+            <h1 className="text-lg font-semibold text-text-primary">
+              CLI management permission
+            </h1>
+            <p className="mt-1 text-xs text-text-secondary">
+              Approve a BotCord CLI credential to perform selected management actions.
+            </p>
+          </div>
+        </div>
+        <Link
+          href="/chats/messages"
+          className="rounded-lg border border-glass-border px-3 py-1.5 text-xs text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
+        >
+          Dashboard
+        </Link>
+      </header>
+
+      <section className="mb-4 rounded-lg border border-glass-border bg-glass-bg/40 p-5">
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <div className="text-xs font-medium uppercase tracking-normal text-text-secondary">
+              Agent
+            </div>
+            <div className="mt-1 font-mono text-sm text-text-primary">{agentId}</div>
+          </div>
+          {loading ? (
+            <div className="flex items-center gap-2 text-xs text-text-secondary">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              Checking existing grants
+            </div>
+          ) : null}
+        </div>
+
+        {!hasScopes ? (
+          <Notice tone="error" icon={<XCircle className="h-4 w-4" />}>
+            This authorization link did not include any requested scopes. Return to
+            the CLI and retry the command that generated it.
+          </Notice>
+        ) : null}
+
+        {needsDaemonId ? (
+          <Notice tone="warning" icon={<AlertTriangle className="h-4 w-4" />}>
+            <div className="font-medium">Daemon-specific approval required</div>
+            <div className="mt-1 text-yellow-100/80">
+              The requested scope includes <span className="font-mono">{DAEMON_PROVISION_SCOPE}</span>,
+              but this link has no <span className="font-mono">daemon_instance_id</span>.
+              No global daemon grant will be created.
+            </div>
+          </Notice>
+        ) : null}
+
+        {loadError ? (
+          <Notice tone="error" icon={<XCircle className="h-4 w-4" />}>
+            Could not load existing grants: {loadError}
+            <button
+              type="button"
+              onClick={() => void load()}
+              className="ml-3 rounded border border-red-400/40 px-2 py-0.5 text-xs text-red-200 hover:bg-red-400/10"
+            >
+              Retry
+            </button>
+          </Notice>
+        ) : null}
+
+        {hasScopes ? (
+          <>
+            <div className="mb-2 text-xs font-medium uppercase tracking-normal text-text-secondary">
+              Requested scopes
+            </div>
+            <ScopeList
+              scopes={requestedScopes}
+              activeScopes={activeScopes}
+              daemonInstanceId={daemonInstanceId}
+            />
+          </>
+        ) : null}
+      </section>
+
+      {createdGrants ? (
+        <section className="mb-4 rounded-lg border border-neon-green/25 bg-neon-green/10 p-5">
+          <div className="mb-3 flex items-center gap-2 text-neon-green">
+            <CheckCircle2 className="h-5 w-5" />
+            <h2 className="text-sm font-semibold">Permission approved</h2>
+          </div>
+          <ScopeList
+            scopes={createdGrants.map((grant) => grant.scope)}
+            activeScopes={new Set(createdGrants.map((grant) => grant.scope))}
+            daemonInstanceId={daemonInstanceId}
+          />
+          <div className="mt-3 space-y-1 text-xs text-neon-green/80">
+            {createdGrants.map((grant) => (
+              <div key={grant.id}>
+                {scopeLabel(grant.scope)} expires {formatDate(grant.expires_at)}
+              </div>
+            ))}
+          </div>
+          <div className="mt-4 rounded-lg border border-neon-green/20 bg-deep-black/30 px-3 py-3 text-sm text-neon-green">
+            <div className="mb-1 flex items-center gap-2 font-medium">
+              <Terminal className="h-4 w-4" />
+              Return to CLI
+            </div>
+            <p className="text-xs text-neon-green/80">
+              Re-run the command that printed this authorization link.
+            </p>
+          </div>
+        </section>
+      ) : (
+        <section className="rounded-lg border border-glass-border bg-glass-bg/40 p-5">
+          <div className="mb-4 flex items-center gap-2">
+            <Clock3 className="h-4 w-4 text-text-secondary" />
+            <div>
+              <h2 className="text-sm font-semibold text-text-primary">
+                Expiration
+              </h2>
+              <p className="text-xs text-text-secondary">
+                The CLI credential can use these permissions until the grant expires.
+              </p>
+            </div>
+          </div>
+
+          <div className="mb-5 inline-flex rounded-lg border border-glass-border bg-deep-black/30 p-1">
+            {EXPIRATION_OPTIONS.map((option) => {
+              const active = expiresInDays === option.value;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => setExpiresInDays(option.value)}
+                  disabled={submitting}
+                  className={`rounded-md px-3 py-1.5 text-sm transition-colors disabled:opacity-50 ${
+                    active
+                      ? "bg-neon-cyan/15 text-neon-cyan"
+                      : "text-text-secondary hover:bg-glass-bg hover:text-text-primary"
+                  }`}
+                >
+                  {option.label}
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="mb-4 flex items-center gap-2">
+            <Hash className="h-4 w-4 text-text-secondary" />
+            <div>
+              <h2 className="text-sm font-semibold text-text-primary">
+                Usage limit
+              </h2>
+              <p className="text-xs text-text-secondary">
+                The grant is consumed after successful management calls from this CLI credential.
+              </p>
+            </div>
+          </div>
+
+          <div className="mb-5 inline-flex rounded-lg border border-glass-border bg-deep-black/30 p-1">
+            {USAGE_LIMIT_OPTIONS.map((option) => {
+              const active = maxUses === option.value;
+              return (
+                <button
+                  key={option.label}
+                  type="button"
+                  onClick={() => setMaxUses(option.value)}
+                  disabled={submitting}
+                  className={`rounded-md px-3 py-1.5 text-sm transition-colors disabled:opacity-50 ${
+                    active
+                      ? "bg-neon-cyan/15 text-neon-cyan"
+                      : "text-text-secondary hover:bg-glass-bg hover:text-text-primary"
+                  }`}
+                >
+                  {option.label}
+                </button>
+              );
+            })}
+          </div>
+
+          {submitError ? (
+            <Notice tone="error" icon={<XCircle className="h-4 w-4" />}>
+              Approval failed: {submitError}
+            </Notice>
+          ) : null}
+
+          {activeScopes.size === requestedScopes.length && requestedScopes.length > 0 ? (
+            <Notice tone="success" icon={<CheckCircle2 className="h-4 w-4" />}>
+              All requested scopes already have active grants. Approving again extends
+              their expiration.
+            </Notice>
+          ) : null}
+
+          <button
+            type="button"
+            onClick={() => void approve()}
+            disabled={!hasScopes || needsDaemonId || submitting}
+            className="inline-flex items-center gap-2 rounded-lg bg-neon-cyan px-4 py-2 text-sm font-semibold text-deep-black transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {submitting ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <ShieldCheck className="h-4 w-4" />
+            )}
+            Approve
+          </button>
+          <span className="ml-3 align-middle text-xs text-text-secondary">
+            {usageLimitLabel(maxUses)}
+          </span>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/(dashboard)/settings/agents/[agentId]/cli-permissions/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/agents/[agentId]/cli-permissions/page.tsx
@@ -1,0 +1,39 @@
+/**
+ * [INPUT]: agentId route param and CLI authorization query params
+ * [OUTPUT]: /settings/agents/[agentId]/cli-permissions approval page
+ * [POS]: dashboard entry point for owner-approved CLI management grants
+ * [PROTOCOL]: update header on changes
+ */
+
+import CliPermissionsClient from "./CliPermissionsClient";
+
+export const dynamic = "force-dynamic";
+
+type PageSearchParams = Record<string, string | string[] | undefined>;
+
+function paramValues(value: string | string[] | undefined): string[] {
+  if (Array.isArray(value)) return value;
+  return value ? [value] : [];
+}
+
+function firstParam(value: string | string[] | undefined): string | null {
+  return paramValues(value)[0] ?? null;
+}
+
+export default async function Page({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ agentId: string }>;
+  searchParams: Promise<PageSearchParams>;
+}) {
+  const [{ agentId }, query] = await Promise.all([params, searchParams]);
+
+  return (
+    <CliPermissionsClient
+      agentId={agentId}
+      scopeParams={paramValues(query.scopes)}
+      daemonInstanceId={firstParam(query.daemon_instance_id)}
+    />
+  );
+}

--- a/frontend/src/app/api/agent-management/grants/[grantId]/route.ts
+++ b/frontend/src/app/api/agent-management/grants/[grantId]/route.ts
@@ -1,0 +1,22 @@
+/**
+ * [INPUT]: grantId from path; Supabase session via proxyHub
+ * [OUTPUT]: DELETE /api/agent-management/grants/[grantId] — revokes a grant via Hub
+ * [POS]: BFF endpoint for future settings grant-management actions
+ * [PROTOCOL]: update header on changes
+ */
+
+import { NextResponse } from "next/server";
+import { proxyHub } from "../../../_lib/proxy-hub";
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ grantId: string }> },
+) {
+  const { grantId } = await params;
+  if (!grantId) {
+    return NextResponse.json({ error: "missing_grant_id" }, { status: 400 });
+  }
+  return proxyHub(`/api/agent-management/grants/${encodeURIComponent(grantId)}`, {
+    method: "DELETE",
+  });
+}

--- a/frontend/src/app/api/agent-management/grants/route.ts
+++ b/frontend/src/app/api/agent-management/grants/route.ts
@@ -1,0 +1,29 @@
+/**
+ * [INPUT]: Supabase session via proxyHub; optional agent_id query, JSON grant create body
+ * [OUTPUT]: GET/POST /api/agent-management/grants — proxies to Hub grant APIs
+ * [POS]: BFF endpoint for CLI management-permission approval pages
+ * [PROTOCOL]: update header on changes
+ */
+
+import { proxyHub } from "../../_lib/proxy-hub";
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const query = url.searchParams.toString();
+  return proxyHub(`/api/agent-management/grants${query ? `?${query}` : ""}`, {
+    method: "GET",
+  });
+}
+
+export async function POST(req: Request) {
+  let body: unknown = {};
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  return proxyHub("/api/agent-management/grants", {
+    method: "POST",
+    body,
+  });
+}


### PR DESCRIPTION
## Summary
- add owner-managed agent management grants with scoped limits and usage counting
- allow agent credentials to create cloud bots, provision daemon bots, and create Cloud Agent teams after owner approval
- add CLI `bot create` and `team create` commands plus dashboard approval UI/BFF routes
- address review findings by reserving grant uses atomically before side effects, refunding failed reservations, and enforcing team role limits against the normalized plan

## Verification
- `cd backend && uv run pytest tests/test_app/test_cloud_agents.py tests/test_app/test_team_orchestration.py tests/test_app/test_agent_provision.py -q`
- `pnpm --dir /Users/zhejianzhang/botcord-agent-credential-management --filter ./cli build`
- `cd frontend && NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=anon-key NEXT_PUBLIC_HUB_BASE_URL=http://localhost:8000 NEXT_PUBLIC_APP_URL=http://localhost:3000 NEXT_PUBLIC_BETA_GATE_ENABLED=false SUPABASE_DB_URL=postgresql://postgres:postgres@localhost:5432/postgres STRIPE_SECRET_KEY=sk_test_xxx npm run build`
- `git diff --check origin/main..HEAD`

## Risk / rollout
- requires applying migration `021_agent_management_grants.sql` before enabling agent-credential management actions in production
- CLI users must approve requested management scopes in the dashboard before the agent token can perform these actions