### PR TITLE
feat: owner-chat in-flight stream cache (Redis) + multi-hub fanout

### DIFF
--- a/backend/hub/config.py
+++ b/backend/hub/config.py
@@ -208,6 +208,27 @@ STRIPE_TOPUP_PACKAGES: list[dict] = _parse_stripe_packages()
 # Message expiry settings (replaces retry loop)
 MESSAGE_EXPIRY_POLL_INTERVAL_SECONDS: float = float(os.getenv("MESSAGE_EXPIRY_POLL_INTERVAL_SECONDS", "30"))
 
+# ---------------------------------------------------------------------------
+# Owner-chat in-flight stream cache (Redis)
+#   See docs/owner-chat-stream-cache-prd.md
+#
+# When BOTCORD_REDIS_URL is unset/empty, Redis is DISABLED and all owner-chat
+# cache + fanout operations become graceful no-ops. Live WebSocket streaming
+# does not depend on Redis. TLS is enabled automatically via the rediss://
+# scheme in the URL.
+# ---------------------------------------------------------------------------
+BOTCORD_REDIS_URL: str | None = os.getenv("BOTCORD_REDIS_URL", "").strip() or None
+OWNER_CHAT_RUN_TTL_SECONDS: int = int(os.getenv("OWNER_CHAT_RUN_TTL_SECONDS", "3600"))
+OWNER_CHAT_RUN_COMPLETED_TTL_SECONDS: int = int(
+    os.getenv("OWNER_CHAT_RUN_COMPLETED_TTL_SECONDS", "300")
+)
+OWNER_CHAT_RUN_FAILED_TTL_SECONDS: int = int(
+    os.getenv("OWNER_CHAT_RUN_FAILED_TTL_SECONDS", "600")
+)
+OWNER_CHAT_MAX_CACHED_EVENTS: int = int(os.getenv("OWNER_CHAT_MAX_CACHED_EVENTS", "200"))
+OWNER_CHAT_MAX_EVENT_BYTES: int = int(os.getenv("OWNER_CHAT_MAX_EVENT_BYTES", "8192"))
+OWNER_CHAT_FANOUT_CHANNEL: str = os.getenv("OWNER_CHAT_FANOUT_CHANNEL", "owner_chat_events")
+
 # Secret used to HMAC-sign bind tickets for cryptographic agent binding.
 # Falls back to JWT_SECRET if not explicitly set.
 BIND_PROOF_SECRET: str | None = os.getenv("BIND_PROOF_SECRET") or os.getenv("BOTCORD_BIND_PROOF_SECRET")

--- a/backend/hub/main.py
+++ b/backend/hub/main.py
@@ -127,6 +127,7 @@ async def lifespan(app: FastAPI):
     presence_task = None
     agent_schedule_task = None
     cloud_agent_idle_task = None
+    owner_chat_fanout_task = None
     if not test_db_override:
         # Background message expiry loop
         expiry_task = asyncio.create_task(message_expiry_loop())
@@ -140,11 +141,19 @@ async def lifespan(app: FastAPI):
         agent_schedule_task = asyncio.create_task(agent_schedule_loop())
         # Background Cloud Agent idle sandbox pause loop
         cloud_agent_idle_task = asyncio.create_task(cloud_agent_idle_pause_loop())
+        # Owner-chat Redis fanout subscriber (multi-instance WS delivery).
+        # No-op start when Redis is disabled.
+        from hub import owner_chat_cache
+        if owner_chat_cache.redis_enabled():
+            owner_chat_fanout_task = asyncio.create_task(
+                owner_chat_cache.owner_chat_fanout_loop()
+            )
 
     yield
 
     # Shutdown
     for task in (
+        owner_chat_fanout_task,
         cloud_agent_idle_task,
         agent_schedule_task,
         presence_task,

--- a/backend/hub/owner_chat_cache.py
+++ b/backend/hub/owner_chat_cache.py
@@ -1,0 +1,417 @@
+"""Owner-chat in-flight stream cache — the ONLY module that talks to Redis.
+
+Short-lived Redis cache + pub/sub fanout for owner-chat stream blocks. The
+cache lets the dashboard restore in-flight streaming UI across refresh /
+reconnect; the fanout lets multiple Hub instances deliver live events to
+whichever process holds the browser WebSocket.
+
+Every public function is a graceful no-op when Redis is disabled
+(``BOTCORD_REDIS_URL`` unset) or when any Redis operation raises. Live
+WebSocket streaming MUST keep working with Redis off.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import json
+import logging
+import uuid
+from typing import Any, Awaitable, Callable
+
+from hub import config as hub_config
+
+logger = logging.getLogger(__name__)
+
+# Module instance id — generated once at import, used to tag fanout origin so
+# the publishing process can skip its own fanout events (it delivers locally
+# directly to avoid round-trip latency).
+INSTANCE_ID: str = uuid.uuid4().hex
+
+_redis_client: Any = None
+_redis_init_failed = False
+
+# Local-delivery callback registered by owner_chat_ws.py to avoid a circular
+# import. Signature: async (user_id, agent_id, data: dict) -> None.
+_fanout_delivery: Callable[[str, str, dict], Awaitable[None]] | None = None
+
+
+def register_fanout_delivery(
+    fn: Callable[[str, str, dict], Awaitable[None]],
+) -> None:
+    """Register the local WS delivery callback used by the fanout subscriber."""
+    global _fanout_delivery
+    _fanout_delivery = fn
+
+
+def redis_enabled() -> bool:
+    return bool(getattr(hub_config, "BOTCORD_REDIS_URL", None))
+
+
+def get_redis() -> Any:
+    """Return a lazily-created async Redis client, or None if disabled/unavailable."""
+    global _redis_client, _redis_init_failed
+    if not redis_enabled() or _redis_init_failed:
+        return None
+    if _redis_client is None:
+        try:
+            import redis.asyncio as redis_asyncio
+
+            # TLS is handled automatically by the rediss:// scheme.
+            _redis_client = redis_asyncio.from_url(
+                hub_config.BOTCORD_REDIS_URL,
+                encoding="utf-8",
+                decode_responses=True,
+            )
+        except Exception as exc:  # noqa: BLE001
+            _redis_init_failed = True
+            logger.warning("owner_chat_cache: redis client init failed: %s", exc)
+            return None
+    return _redis_client
+
+
+# ---------------------------------------------------------------------------
+# Key helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_key(trace_id: str) -> str:
+    return f"owner_chat_run:{trace_id}"
+
+
+def _events_key(trace_id: str) -> str:
+    return f"owner_chat_run:{trace_id}:events"
+
+
+def _now_iso() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Block compaction
+# ---------------------------------------------------------------------------
+
+
+def _preview(value: Any, limit: int = 280) -> str:
+    try:
+        text = value if isinstance(value, str) else json.dumps(value, ensure_ascii=False)
+    except (TypeError, ValueError):
+        text = str(value)
+    if len(text) > limit:
+        return text[:limit]
+    return text
+
+
+def compact_block(block: dict) -> dict:
+    """Normalize a stream block into a compact payload per PRD rules.
+
+    Keep assistant text; tool_call -> name + compact params; tool_result ->
+    status + short preview; reasoning -> short summary/metadata only; drop
+    unknown oversized fields.
+    """
+    if not isinstance(block, dict):
+        return {"kind": "unknown"}
+
+    kind = block.get("kind")
+    seq = block.get("seq")
+    payload = block.get("payload")
+    payload = payload if isinstance(payload, dict) else {}
+
+    out_payload: dict[str, Any]
+    if kind == "assistant":
+        out_payload = {"text": _preview(payload.get("text", ""), 4000)}
+    elif kind == "tool_call":
+        out_payload = {"name": payload.get("name")}
+        params = payload.get("params") or payload.get("input")
+        if params is not None:
+            out_payload["params"] = _preview(params, 1000)
+    elif kind == "tool_result":
+        out_payload = {"status": payload.get("status")}
+        result = payload.get("result") or payload.get("output") or payload.get("content")
+        if result is not None:
+            out_payload["preview"] = _preview(result, 1000)
+    elif kind == "reasoning":
+        summary = payload.get("summary") or payload.get("text")
+        out_payload = {"summary": _preview(summary, 500)} if summary else {}
+    elif kind == "system":
+        out_payload = {"text": _preview(payload.get("text", ""), 1000)}
+    else:
+        # Unknown kind: drop oversized fields, keep a small preview.
+        out_payload = {"preview": _preview(payload, 500)} if payload else {}
+
+    compact: dict[str, Any] = {"kind": kind, "payload": out_payload}
+    if seq is not None:
+        compact["seq"] = seq
+    return compact
+
+
+def _enforce_event_byte_cap(compact: dict) -> tuple[dict, bool, int]:
+    """Return (compact_block, truncated, size_bytes). Drop raw payload if oversized."""
+    max_bytes = hub_config.OWNER_CHAT_MAX_EVENT_BYTES
+    encoded = json.dumps(compact, ensure_ascii=False)
+    size_bytes = len(encoded.encode("utf-8"))
+    if size_bytes <= max_bytes:
+        return compact, False, size_bytes
+
+    # Too large: keep a short preview, drop the full payload.
+    truncated = {
+        "kind": compact.get("kind"),
+        "truncated": True,
+        "payload": {"preview": _preview(compact.get("payload"), 280)},
+    }
+    if "seq" in compact:
+        truncated["seq"] = compact["seq"]
+    encoded = json.dumps(truncated, ensure_ascii=False)
+    return truncated, True, len(encoded.encode("utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Cache writes
+# ---------------------------------------------------------------------------
+
+
+async def write_run_metadata(
+    trace_id: str,
+    *,
+    user_id: str,
+    agent_id: str,
+    room_id: str,
+    trigger_msg_id: str,
+) -> None:
+    """Create the run hash with status=running and the running TTL."""
+    client = get_redis()
+    if client is None:
+        return
+    try:
+        key = _run_key(trace_id)
+        await client.hset(
+            key,
+            mapping={
+                "trace_id": trace_id,
+                "user_id": user_id,
+                "agent_id": agent_id,
+                "room_id": room_id,
+                "trigger_msg_id": trigger_msg_id,
+                "status": "running",
+                "started_at": _now_iso(),
+                "completed_at": "",
+                "final_msg_id": "",
+                "event_count": 0,
+                "last_seq": 0,
+            },
+        )
+        await client.expire(key, hub_config.OWNER_CHAT_RUN_TTL_SECONDS)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("owner_chat_cache.write_run_metadata failed trace=%s: %s", trace_id, exc)
+
+
+async def append_event(trace_id: str, seq: int, block: dict) -> dict | None:
+    """Compact + cache a stream block. Returns the compact block to broadcast.
+
+    Returns None if dropped (Redis disabled, cap exceeded, or on error — in
+    which case the caller falls back to broadcasting the raw block itself).
+    """
+    client = get_redis()
+    if client is None:
+        return None
+    try:
+        run_key = _run_key(trace_id)
+        # Enforce per-trace event cap using the run hash's event_count.
+        raw_count = await client.hget(run_key, "event_count")
+        count = int(raw_count) if raw_count is not None else 0
+        if count >= hub_config.OWNER_CHAT_MAX_CACHED_EVENTS:
+            return None
+
+        compact = compact_block(block)
+        compact, truncated, size_bytes = _enforce_event_byte_cap(compact)
+        created_at = _now_iso()
+
+        await client.xadd(
+            _events_key(trace_id),
+            {
+                "seq": seq,
+                "kind": str(compact.get("kind") or ""),
+                "created_at": created_at,
+                "payload_compact": json.dumps(compact, ensure_ascii=False),
+                "truncated": "1" if truncated else "0",
+                "size_bytes": size_bytes,
+            },
+            maxlen=hub_config.OWNER_CHAT_MAX_CACHED_EVENTS,
+            approximate=True,
+        )
+        await client.hset(
+            run_key,
+            mapping={"event_count": count + 1, "last_seq": seq},
+        )
+        await client.expire(run_key, hub_config.OWNER_CHAT_RUN_TTL_SECONDS)
+        await client.expire(_events_key(trace_id), hub_config.OWNER_CHAT_RUN_TTL_SECONDS)
+        return compact
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("owner_chat_cache.append_event failed trace=%s: %s", trace_id, exc)
+        return None
+
+
+async def mark_run_completed(trace_id: str, *, final_msg_id: str) -> None:
+    """Mark a run completed and shorten both keys to the completed TTL."""
+    client = get_redis()
+    if client is None:
+        return
+    try:
+        run_key = _run_key(trace_id)
+        if not await client.exists(run_key):
+            return
+        await client.hset(
+            run_key,
+            mapping={
+                "status": "completed",
+                "completed_at": _now_iso(),
+                "final_msg_id": final_msg_id,
+            },
+        )
+        ttl = hub_config.OWNER_CHAT_RUN_COMPLETED_TTL_SECONDS
+        await client.expire(run_key, ttl)
+        await client.expire(_events_key(trace_id), ttl)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("owner_chat_cache.mark_run_completed failed trace=%s: %s", trace_id, exc)
+
+
+async def mark_run_failed(trace_id: str) -> None:
+    """Mark a run failed and shorten both keys to the failed TTL."""
+    client = get_redis()
+    if client is None:
+        return
+    try:
+        run_key = _run_key(trace_id)
+        if not await client.exists(run_key):
+            return
+        await client.hset(run_key, mapping={"status": "failed"})
+        ttl = hub_config.OWNER_CHAT_RUN_FAILED_TTL_SECONDS
+        await client.expire(run_key, ttl)
+        await client.expire(_events_key(trace_id), ttl)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("owner_chat_cache.mark_run_failed failed trace=%s: %s", trace_id, exc)
+
+
+async def load_run(trace_id: str) -> dict | None:
+    """Read run hash + events stream. Returns None when missing/disabled/error."""
+    client = get_redis()
+    if client is None:
+        return None
+    try:
+        run_key = _run_key(trace_id)
+        meta = await client.hgetall(run_key)
+        if not meta:
+            return None
+
+        entries = await client.xrange(_events_key(trace_id))
+        events: list[dict] = []
+        for _entry_id, fields in entries:
+            try:
+                block = json.loads(fields.get("payload_compact") or "{}")
+            except (TypeError, ValueError):
+                block = {}
+            events.append(
+                {
+                    "seq": int(fields["seq"]) if fields.get("seq") else None,
+                    "kind": fields.get("kind") or block.get("kind"),
+                    "created_at": fields.get("created_at"),
+                    "block": block,
+                }
+            )
+
+        return {
+            "status": meta.get("status", "completed"),
+            "room_id": meta.get("room_id"),
+            "agent_id": meta.get("agent_id"),
+            "user_id": meta.get("user_id"),
+            "events": events,
+        }
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("owner_chat_cache.load_run failed trace=%s: %s", trace_id, exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Pub/Sub fanout
+# ---------------------------------------------------------------------------
+
+
+async def publish_fanout(event: dict) -> None:
+    """Publish a fanout event tagged with this instance's origin id."""
+    client = get_redis()
+    if client is None:
+        return
+    try:
+        payload = dict(event)
+        payload["origin"] = INSTANCE_ID
+        await client.publish(
+            hub_config.OWNER_CHAT_FANOUT_CHANNEL,
+            json.dumps(payload, ensure_ascii=False),
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("owner_chat_cache.publish_fanout failed: %s", exc)
+
+
+async def owner_chat_fanout_loop() -> None:
+    """Subscribe to the fanout channel and deliver events to local WS.
+
+    Skips events originating from this instance (it delivers locally directly).
+    Runs until cancelled. Reconnects on transient errors.
+    """
+    while True:
+        client = get_redis()
+        if client is None:
+            return
+        try:
+            pubsub = client.pubsub()
+            await pubsub.subscribe(hub_config.OWNER_CHAT_FANOUT_CHANNEL)
+            logger.info(
+                "owner_chat_cache: fanout subscribed channel=%s instance=%s",
+                hub_config.OWNER_CHAT_FANOUT_CHANNEL,
+                INSTANCE_ID,
+            )
+            async for message in pubsub.listen():
+                if message.get("type") != "message":
+                    continue
+                try:
+                    event = json.loads(message["data"])
+                except (TypeError, ValueError, KeyError):
+                    continue
+                if event.get("origin") == INSTANCE_ID:
+                    continue
+                await _deliver_fanout_event(event)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("owner_chat_cache.fanout_loop error: %s", exc)
+            await asyncio.sleep(1.0)
+
+
+async def _deliver_fanout_event(event: dict) -> None:
+    """Deliver a remote fanout event to the local WS delivery callback."""
+    if _fanout_delivery is None:
+        return
+    user_id = event.get("user_id")
+    agent_id = event.get("agent_id")
+    if not user_id or not agent_id:
+        return
+
+    etype = event.get("type")
+    data: dict[str, Any]
+    if etype == "stream_block":
+        data = {
+            "type": "stream_block",
+            "trace_id": event.get("trace_id"),
+            "seq": event.get("seq"),
+            "block": event.get("block"),
+            "created_at": event.get("created_at"),
+        }
+    else:
+        # message / typing / run_status — forward the carried payload as-is.
+        data = event.get("data") or {}
+        if not data:
+            return
+    try:
+        await _fanout_delivery(user_id, agent_id, data)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("owner_chat_cache: fanout delivery failed: %s", exc)

--- a/backend/hub/routers/dashboard_chat.py
+++ b/backend/hub/routers/dashboard_chat.py
@@ -64,6 +64,21 @@ class ChatRoomResponse(BaseModel):
     agent_id: str
 
 
+class StreamBlockEvent(BaseModel):
+    seq: int | None = None
+    kind: str | None = None
+    created_at: str | None = None
+    block: dict
+
+
+class RunStreamBlocksResponse(BaseModel):
+    trace_id: str
+    status: str
+    room_id: str | None = None
+    agent_id: str | None = None
+    events: list[StreamBlockEvent]
+
+
 # ---------------------------------------------------------------------------
 # Owner-agent chat room helpers
 # ---------------------------------------------------------------------------
@@ -332,4 +347,52 @@ async def send_chat_message(
         hub_msg_id=hub_msg_id,
         room_id=room_id,
         status="queued",
+    )
+
+
+@router.get(
+    "/runs/{trace_id}/stream-blocks",
+    response_model=RunStreamBlocksResponse,
+)
+async def get_run_stream_blocks(
+    trace_id: str,
+    agent_and_user: tuple[str, str | None] = Depends(get_dashboard_agent_with_user),
+):
+    """Restore in-flight owner-chat stream blocks for a trace from the Redis cache.
+
+    Degrades gracefully: when Redis is disabled, the run is missing/expired, or
+    the run does not belong to this owner's owner-chat room, returns 200 with
+    status="completed" and an empty events list (never 404), so the frontend
+    simply waits for the final message.
+    """
+    from hub import owner_chat_cache
+
+    agent_id, user_id = agent_and_user
+
+    empty = RunStreamBlocksResponse(
+        trace_id=trace_id,
+        status="completed",
+        room_id=None,
+        agent_id=agent_id,
+        events=[],
+    )
+
+    if not user_id:
+        return empty
+
+    run = await owner_chat_cache.load_run(trace_id)
+    if run is None:
+        return empty
+
+    # Authorization: the run must belong to this agent and this owner's room.
+    expected_room = _build_owner_chat_room_id(user_id, agent_id)
+    if run.get("agent_id") != agent_id or run.get("room_id") != expected_room:
+        return empty
+
+    return RunStreamBlocksResponse(
+        trace_id=trace_id,
+        status=run.get("status", "completed"),
+        room_id=run.get("room_id"),
+        agent_id=run.get("agent_id"),
+        events=[StreamBlockEvent(**ev) for ev in run.get("events", [])],
     )

--- a/backend/hub/routers/owner_chat_ws.py
+++ b/backend/hub/routers/owner_chat_ws.py
@@ -37,6 +37,7 @@ from hub.routers.hub import (
 )
 from hub.services.cloud_agent import resume_cloud_agent_for_inbox
 from hub.validators import normalize_file_url
+from hub import owner_chat_cache
 
 import jwt as pyjwt
 
@@ -140,6 +141,12 @@ async def _send_to_oc_ws(
         )
 
 
+# Register the local-delivery callback used by the Redis fanout subscriber.
+# Other Hub instances' stream blocks arrive via the fanout loop and are
+# delivered to local WS connections through this hook.
+owner_chat_cache.register_fanout_delivery(_send_to_oc_ws)
+
+
 def _cleanup_trace(trace_id: str) -> None:
     """Remove a trace subscription and its block counter."""
     _oc_trace_subs.pop(trace_id, None)
@@ -228,6 +235,11 @@ async def notify_oc_ws_message(
 
     for uid, aid in target_keys:
         await _send_to_oc_ws(uid, aid, msg_data)
+
+    # Mark matched in-flight runs completed in Redis and shorten their TTL
+    # (no-op when Redis is disabled).
+    for tid in matched_traces:
+        await owner_chat_cache.mark_run_completed(tid, final_msg_id=hub_msg_id)
 
 
 async def notify_oc_ws_typing(*, agent_id: str, room_id: str) -> None:
@@ -475,6 +487,16 @@ async def owner_chat_ws(ws: WebSocket):
                     _oc_trace_subs[hub_msg_id] = (user_id, agent_id)
                     _oc_trace_block_count[hub_msg_id] = 0
 
+                    # Write the in-flight run metadata to Redis (no-op if Redis
+                    # disabled). trace_id == hub_msg_id of the trigger message.
+                    await owner_chat_cache.write_run_metadata(
+                        hub_msg_id,
+                        user_id=user_id,
+                        agent_id=agent_id,
+                        room_id=room_id,
+                        trigger_msg_id=hub_msg_id,
+                    )
+
                     # Notify agent inbox
                     notified = await notify_inbox(
                         agent_id,
@@ -584,20 +606,50 @@ async def receive_stream_block(
     if sub_agent_id != agent_id:
         return
 
-    # W7: Enforce per-trace block count cap.
+    # W7: Enforce per-trace block count cap (in-memory live cap, independent
+    # of the Redis cache cap).
     count = _oc_trace_block_count.get(body.trace_id, 0)
     if count >= _MAX_STREAM_BLOCKS_PER_TRACE:
         return
     _oc_trace_block_count[body.trace_id] = count + 1
 
     now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+    # Ordering: write the Redis cache FIRST so refresh/reconnect can recover
+    # even if WS delivery fails. append_event returns the compacted block to
+    # broadcast (or None when Redis is disabled / capped / errored, in which
+    # case we broadcast the raw block to preserve live behavior).
+    broadcast_block = body.block
+    if owner_chat_cache.redis_enabled():
+        compact = await owner_chat_cache.append_event(
+            body.trace_id, body.seq, body.block,
+        )
+        if compact is not None:
+            broadcast_block = compact
+
+    # Always deliver locally first (low latency, no self-skip wait).
     await _send_to_oc_ws(user_id, sub_agent_id, {
         "type": "stream_block",
         "trace_id": body.trace_id,
         "seq": body.seq,
-        "block": body.block,
+        "block": broadcast_block,
         "created_at": now,
     })
+
+    # When Redis is enabled, also publish fanout so other Hub instances holding
+    # the browser WS can deliver. The subscriber loop skips events whose origin
+    # == this instance, so there is no double-send on the originating instance.
+    if owner_chat_cache.redis_enabled():
+        await owner_chat_cache.publish_fanout({
+            "type": "stream_block",
+            "trace_id": body.trace_id,
+            "user_id": user_id,
+            "agent_id": sub_agent_id,
+            "room_id": _build_owner_chat_room_id(user_id, sub_agent_id),
+            "seq": body.seq,
+            "block": broadcast_block,
+            "created_at": now,
+        })
 
 
 # ---------------------------------------------------------------------------

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "cryptography>=46.0.5",
     "sentry-sdk[fastapi]>=2.0,<3",
     "e2b>=2.21,<3",
+    "redis>=5",
 ]
 
 [project.scripts]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,3 +11,4 @@ python-multipart>=0.0.9,<1
 cachetools>=7.0.5
 httpx>=0.27
 stripe>=8.0,<10
+redis>=5

--- a/backend/tests/test_owner_chat_cache.py
+++ b/backend/tests/test_owner_chat_cache.py
@@ -1,0 +1,421 @@
+"""Tests for the owner-chat in-flight stream cache (hub.owner_chat_cache).
+
+These tests run on in-memory SQLite and MUST pass with Redis DISABLED
+(BOTCORD_REDIS_URL unset). For cache-write/compaction/restore unit tests we
+monkeypatch a small in-memory fake Redis client — no running Redis server.
+"""
+
+import base64
+import datetime
+import uuid as _uuid
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from nacl.signing import SigningKey
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from unittest.mock import AsyncMock
+
+from hub import owner_chat_cache
+from hub.models import Agent, Base, User
+
+TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
+
+
+# ---------------------------------------------------------------------------
+# DB / client fixtures (mirror tests/test_dashboard_chat.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(TEST_DB_URL)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client(db_session: AsyncSession):
+    from hub.main import app
+    from hub.database import get_db
+
+    async def _override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.state.http_client = AsyncMock(spec=AsyncClient)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+def _make_keypair():
+    sk = SigningKey.generate()
+    pub_b64 = base64.b64encode(bytes(sk.verify_key)).decode()
+    return sk, f"ed25519:{pub_b64}"
+
+
+async def _register_and_verify(client: AsyncClient, display_name: str = "TestAgent"):
+    sk, pubkey = _make_keypair()
+    resp = await client.post("/registry/agents", json={
+        "display_name": display_name, "pubkey": pubkey, "bio": "test agent",
+    })
+    assert resp.status_code == 201
+    data = resp.json()
+    agent_id, key_id, challenge = data["agent_id"], data["key_id"], data["challenge"]
+    signed = sk.sign(base64.b64decode(challenge))
+    sig_b64 = base64.b64encode(signed.signature).decode()
+    resp = await client.post(f"/registry/agents/{agent_id}/verify", json={
+        "key_id": key_id, "challenge": challenge, "sig": sig_b64,
+    })
+    assert resp.status_code == 200
+    return agent_id, resp.json()["agent_token"]
+
+
+async def _claim_agent(db_session, agent_id, human_suffix="01"):
+    user_id = str(_uuid.uuid4())
+    db_session.add(User(
+        id=_uuid.UUID(user_id),
+        display_name="Owner",
+        email=f"owner{human_suffix}@example.com",
+        status="active",
+        supabase_user_id=_uuid.uuid4(),
+        human_id=f"hu_owner{human_suffix}",
+    ))
+    await db_session.execute(
+        update(Agent).where(Agent.agent_id == agent_id).values(
+            user_id=_uuid.UUID(user_id),
+            claimed_at=datetime.datetime.now(datetime.timezone.utc),
+        )
+    )
+    await db_session.commit()
+    return user_id
+
+
+# ---------------------------------------------------------------------------
+# Fake async Redis client
+# ---------------------------------------------------------------------------
+
+
+class FakeRedis:
+    """Minimal in-memory async stand-in for the Redis operations we use."""
+
+    def __init__(self):
+        self.hashes: dict[str, dict] = {}
+        self.streams: dict[str, list[tuple[str, dict]]] = {}
+        self.ttls: dict[str, int] = {}
+        self.published: list[tuple[str, str]] = []
+        self._seq = 0
+
+    async def hset(self, key, mapping=None, **kwargs):
+        h = self.hashes.setdefault(key, {})
+        if mapping:
+            h.update({k: str(v) for k, v in mapping.items()})
+        return 1
+
+    async def hget(self, key, field):
+        return self.hashes.get(key, {}).get(field)
+
+    async def hgetall(self, key):
+        return dict(self.hashes.get(key, {}))
+
+    async def expire(self, key, ttl):
+        self.ttls[key] = ttl
+        return True
+
+    async def exists(self, key):
+        return 1 if key in self.hashes else 0
+
+    async def xadd(self, key, fields, maxlen=None, approximate=True):
+        self._seq += 1
+        entry_id = f"{self._seq}-0"
+        stream = self.streams.setdefault(key, [])
+        stream.append((entry_id, {k: str(v) for k, v in fields.items()}))
+        if maxlen is not None and len(stream) > maxlen:
+            del stream[: len(stream) - maxlen]
+        return entry_id
+
+    async def xrange(self, key):
+        return list(self.streams.get(key, []))
+
+    async def publish(self, channel, payload):
+        self.published.append((channel, payload))
+        return 1
+
+
+@pytest.fixture
+def fake_redis(monkeypatch):
+    fake = FakeRedis()
+    monkeypatch.setattr(owner_chat_cache, "_redis_client", fake)
+    monkeypatch.setattr(owner_chat_cache, "_redis_init_failed", False)
+    # Force redis_enabled() True regardless of env.
+    monkeypatch.setattr(owner_chat_cache.hub_config, "BOTCORD_REDIS_URL", "redis://fake")
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# Compaction unit tests (no Redis needed)
+# ---------------------------------------------------------------------------
+
+
+def test_compact_tool_call():
+    block = {"kind": "tool_call", "seq": 3, "payload": {"name": "web_search", "params": {"q": "x" * 5000}}}
+    out = owner_chat_cache.compact_block(block)
+    assert out["kind"] == "tool_call"
+    assert out["payload"]["name"] == "web_search"
+    assert len(out["payload"]["params"]) <= 1000
+    assert out["seq"] == 3
+
+
+def test_compact_tool_result_preview():
+    block = {"kind": "tool_result", "payload": {"status": "ok", "result": "z" * 9000}}
+    out = owner_chat_cache.compact_block(block)
+    assert out["payload"]["status"] == "ok"
+    assert len(out["payload"]["preview"]) <= 1000
+
+
+def test_compact_reasoning_summary_only():
+    block = {"kind": "reasoning", "payload": {"text": "long hidden reasoning " * 100}}
+    out = owner_chat_cache.compact_block(block)
+    assert "summary" in out["payload"]
+    assert len(out["payload"]["summary"]) <= 500
+
+
+def test_byte_cap_truncates(monkeypatch):
+    monkeypatch.setattr(owner_chat_cache.hub_config, "OWNER_CHAT_MAX_EVENT_BYTES", 100)
+    compact = {"kind": "assistant", "seq": 1, "payload": {"text": "y" * 4000}}
+    out, truncated, size = owner_chat_cache._enforce_event_byte_cap(compact)
+    assert truncated is True
+    assert out["truncated"] is True
+    assert "preview" in out["payload"]
+    # Full 4000-char payload dropped; only a short (<=280) preview kept.
+    assert len(out["payload"]["preview"]) <= 280
+    assert size < 600
+
+
+# ---------------------------------------------------------------------------
+# Cache write / restore unit tests (fake redis)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_write_run_metadata(fake_redis):
+    await owner_chat_cache.write_run_metadata(
+        "h_trace1", user_id="usr1", agent_id="ag_1", room_id="rm_oc_x", trigger_msg_id="h_trace1",
+    )
+    h = fake_redis.hashes["owner_chat_run:h_trace1"]
+    assert h["status"] == "running"
+    assert h["agent_id"] == "ag_1"
+    assert h["event_count"] == "0"
+    assert fake_redis.ttls["owner_chat_run:h_trace1"] == owner_chat_cache.hub_config.OWNER_CHAT_RUN_TTL_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_append_event_bumps_counts(fake_redis):
+    await owner_chat_cache.write_run_metadata(
+        "h_t2", user_id="usr1", agent_id="ag_1", room_id="rm_oc_x", trigger_msg_id="h_t2",
+    )
+    out = await owner_chat_cache.append_event("h_t2", 1, {"kind": "tool_call", "payload": {"name": "ls"}})
+    assert out["kind"] == "tool_call"
+    h = fake_redis.hashes["owner_chat_run:h_t2"]
+    assert h["event_count"] == "1"
+    assert h["last_seq"] == "1"
+    assert len(fake_redis.streams["owner_chat_run:h_t2:events"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_append_event_respects_cap(fake_redis, monkeypatch):
+    monkeypatch.setattr(owner_chat_cache.hub_config, "OWNER_CHAT_MAX_CACHED_EVENTS", 2)
+    await owner_chat_cache.write_run_metadata(
+        "h_t3", user_id="usr1", agent_id="ag_1", room_id="rm_oc_x", trigger_msg_id="h_t3",
+    )
+    assert await owner_chat_cache.append_event("h_t3", 1, {"kind": "assistant", "payload": {"text": "a"}})
+    assert await owner_chat_cache.append_event("h_t3", 2, {"kind": "assistant", "payload": {"text": "b"}})
+    # Third exceeds cap -> dropped (None).
+    assert await owner_chat_cache.append_event("h_t3", 3, {"kind": "assistant", "payload": {"text": "c"}}) is None
+
+
+@pytest.mark.asyncio
+async def test_mark_completed_shortens_ttl(fake_redis):
+    await owner_chat_cache.write_run_metadata(
+        "h_t4", user_id="usr1", agent_id="ag_1", room_id="rm_oc_x", trigger_msg_id="h_t4",
+    )
+    await owner_chat_cache.mark_run_completed("h_t4", final_msg_id="h_final")
+    h = fake_redis.hashes["owner_chat_run:h_t4"]
+    assert h["status"] == "completed"
+    assert h["final_msg_id"] == "h_final"
+    assert fake_redis.ttls["owner_chat_run:h_t4"] == owner_chat_cache.hub_config.OWNER_CHAT_RUN_COMPLETED_TTL_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_load_run_shapes_events(fake_redis):
+    await owner_chat_cache.write_run_metadata(
+        "h_t5", user_id="usr1", agent_id="ag_1", room_id="rm_oc_x", trigger_msg_id="h_t5",
+    )
+    await owner_chat_cache.append_event("h_t5", 1, {"kind": "tool_call", "payload": {"name": "ls"}})
+    run = await owner_chat_cache.load_run("h_t5")
+    assert run["status"] == "running"
+    assert run["agent_id"] == "ag_1"
+    assert run["room_id"] == "rm_oc_x"
+    assert len(run["events"]) == 1
+    ev = run["events"][0]
+    assert ev["seq"] == 1
+    assert ev["kind"] == "tool_call"
+    assert ev["block"]["payload"]["name"] == "ls"
+
+
+@pytest.mark.asyncio
+async def test_publish_fanout_tags_origin(fake_redis):
+    await owner_chat_cache.publish_fanout({"type": "stream_block", "trace_id": "h_x"})
+    assert len(fake_redis.published) == 1
+    import json
+    channel, payload = fake_redis.published[0]
+    assert channel == owner_chat_cache.hub_config.OWNER_CHAT_FANOUT_CHANNEL
+    assert json.loads(payload)["origin"] == owner_chat_cache.INSTANCE_ID
+
+
+# ---------------------------------------------------------------------------
+# Redis-DISABLED graceful no-op tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_disabled_ops_are_noops(monkeypatch):
+    monkeypatch.setattr(owner_chat_cache.hub_config, "BOTCORD_REDIS_URL", None)
+    monkeypatch.setattr(owner_chat_cache, "_redis_client", None)
+    assert owner_chat_cache.redis_enabled() is False
+    assert owner_chat_cache.get_redis() is None
+    # None of these raise.
+    await owner_chat_cache.write_run_metadata("h_d", user_id="u", agent_id="a", room_id="r", trigger_msg_id="h_d")
+    assert await owner_chat_cache.append_event("h_d", 1, {"kind": "assistant"}) is None
+    await owner_chat_cache.mark_run_completed("h_d", final_msg_id="x")
+    await owner_chat_cache.mark_run_failed("h_d")
+    assert await owner_chat_cache.load_run("h_d") is None
+    await owner_chat_cache.publish_fanout({"type": "stream_block"})
+
+
+# ---------------------------------------------------------------------------
+# Restore endpoint — Redis DISABLED returns empty-completed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_restore_endpoint_redis_disabled_empty_completed(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch,
+):
+    monkeypatch.setattr(owner_chat_cache.hub_config, "BOTCORD_REDIS_URL", None)
+    monkeypatch.setattr(owner_chat_cache, "_redis_client", None)
+
+    agent_id, token = await _register_and_verify(client, "RestoreAgent")
+    await _claim_agent(db_session, agent_id, "rd")
+
+    resp = await client.get(
+        f"/dashboard/chat/runs/h_sometrace/stream-blocks",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["trace_id"] == "h_sometrace"
+    assert data["status"] == "completed"
+    assert data["events"] == []
+
+
+# ---------------------------------------------------------------------------
+# Restore endpoint — running run via fake redis + auth scoping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_restore_endpoint_running_run(
+    client: AsyncClient, db_session: AsyncSession, fake_redis,
+):
+    from hub.routers.dashboard_chat import _build_owner_chat_room_id
+
+    agent_id, token = await _register_and_verify(client, "RunAgent")
+    user_id = await _claim_agent(db_session, agent_id, "rr")
+    room_id = _build_owner_chat_room_id(user_id, agent_id)
+
+    await owner_chat_cache.write_run_metadata(
+        "h_run", user_id=user_id, agent_id=agent_id, room_id=room_id, trigger_msg_id="h_run",
+    )
+    await owner_chat_cache.append_event("h_run", 1, {"kind": "tool_call", "payload": {"name": "web_search"}})
+
+    resp = await client.get(
+        "/dashboard/chat/runs/h_run/stream-blocks",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "running"
+    assert data["agent_id"] == agent_id
+    assert data["room_id"] == room_id
+    assert len(data["events"]) == 1
+    assert data["events"][0]["kind"] == "tool_call"
+    assert data["events"][0]["block"]["payload"]["name"] == "web_search"
+
+
+@pytest.mark.asyncio
+async def test_restore_endpoint_wrong_owner_returns_empty(
+    client: AsyncClient, db_session: AsyncSession, fake_redis,
+):
+    """A run owned by a different agent/room must not leak; returns empty-completed."""
+    agent_id, token = await _register_and_verify(client, "OwnerScopeAgent")
+    await _claim_agent(db_session, agent_id, "os")
+
+    # Run belongs to a different agent / room.
+    await owner_chat_cache.write_run_metadata(
+        "h_other", user_id="usrX", agent_id="ag_other", room_id="rm_oc_other", trigger_msg_id="h_other",
+    )
+
+    resp = await client.get(
+        "/dashboard/chat/runs/h_other/stream-blocks",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "completed"
+    assert data["events"] == []
+
+
+# ---------------------------------------------------------------------------
+# /hub/stream-block still works with Redis OFF (live WS unaffected)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_block_works_redis_disabled(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch,
+):
+    monkeypatch.setattr(owner_chat_cache.hub_config, "BOTCORD_REDIS_URL", None)
+    monkeypatch.setattr(owner_chat_cache, "_redis_client", None)
+
+    from hub.routers import owner_chat_ws
+
+    agent_id, token = await _register_and_verify(client, "StreamAgent")
+    user_id = await _claim_agent(db_session, agent_id, "sb")
+
+    # Register an in-memory trace subscription as the WS path would.
+    trace_id = "h_streamtrace"
+    owner_chat_ws._oc_trace_subs[trace_id] = (user_id, agent_id)
+    owner_chat_ws._oc_trace_block_count[trace_id] = 0
+    try:
+        resp = await client.post(
+            "/hub/stream-block",
+            json={"trace_id": trace_id, "seq": 1, "block": {"kind": "assistant", "payload": {"text": "hi"}}},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        # No WS connected, but the endpoint must succeed (204) without Redis.
+        assert resp.status_code == 204
+        assert owner_chat_ws._oc_trace_block_count[trace_id] == 1
+    finally:
+        owner_chat_ws._oc_trace_subs.pop(trace_id, None)
+        owner_chat_ws._oc_trace_block_count.pop(trace_id, None)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -108,6 +108,7 @@ dependencies = [
     { name = "pynacl" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
+    { name = "redis" },
     { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "stripe" },
@@ -135,6 +136,7 @@ requires-dist = [
     { name = "pynacl", specifier = ">=1.5,<2" },
     { name = "python-dotenv", specifier = ">=1.0,<2" },
     { name = "python-multipart", specifier = ">=0.0.9,<1" },
+    { name = "redis", specifier = ">=5" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.0,<3" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0,<3" },
     { name = "stripe", specifier = ">=8.0,<10" },
@@ -939,6 +941,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "redis"
+version = "8.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/ae/ed461cca5780b5fc8b9fe8ca0ed98d89508645fb9d880c24cc42c087678f/redis-8.0.0.tar.gz", hash = "sha256:a00c5355432051ac14e593b8b197fc76c887ee12d55a0984f69328a1115fdc49", size = 5101591, upload-time = "2026-05-28T12:45:13.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/e3/b519734372d305bd547534a9f32e4ce9f98552af753dce72cf3483a0ff0b/redis-8.0.0-py3-none-any.whl", hash = "sha256:c938c18338585009f0bc310f4c7e4e4b4d37639356c4ac072cedf3af570c8dc7", size = 499870, upload-time = "2026-05-28T12:45:11.697Z" },
 ]
 
 [[package]]

--- a/docs/owner-chat-stream-cache-prd.md
+++ b/docs/owner-chat-stream-cache-prd.md
@@ -1,0 +1,409 @@
+# Owner Chat In-Flight Stream Cache PRD
+
+## Summary
+
+Owner-chat streaming is currently delivered over WebSocket only. If the owner refreshes the page, switches pages, or reconnects before the final assistant reply is produced, intermediate stream blocks are lost from the frontend state.
+
+This PRD proposes a short-lived Redis cache for in-flight owner-chat stream blocks. The cache is not a long-term trace store. It exists only to restore the streaming UI while a run is still active, and expires shortly after the final reply is delivered.
+
+## Problem
+
+The current owner-chat path has real-time streaming, but the stream state is volatile:
+
+- The Hub keeps trace routing in process memory.
+- Stream blocks are forwarded to connected WebSocket clients.
+- The frontend stores stream blocks in local UI state.
+- Final replies are persisted as normal messages, but intermediate blocks are not recoverable after refresh.
+
+This creates a bad experience for longer runs:
+
+- The owner sees useful execution progress.
+- They refresh or navigate away.
+- They return before the final answer exists.
+- The UI loses the in-progress execution state and appears blank, stuck, or less informative.
+
+## Goals
+
+- Preserve in-flight owner-chat stream blocks across page refresh, page navigation, and short WebSocket reconnects.
+- Keep storage bounded with short TTLs and per-run caps.
+- Avoid storing full raw runtime output, long reasoning traces, or large tool results by default.
+- Preserve current real-time WebSocket behavior.
+- Keep Postgres as the source of truth for final chat messages, not transient stream state.
+
+## Non-Goals
+
+- Do not build a permanent execution trace/audit system in this phase.
+- Do not persist full token streams.
+- Do not persist full raw tool outputs by default.
+- Do not expose Redis to daemon processes.
+- Do not make Redis availability required for live streaming.
+
+## Current Flow
+
+```text
+Owner dashboard
+  -> WebSocket send
+  -> Hub creates owner-chat MessageRecord
+  -> Hub registers in-memory trace subscription
+  -> Hub notifies daemon inbox
+  -> daemon executes runtime
+  -> daemon POST /hub/stream-block
+  -> Hub forwards stream_block over owner-chat WebSocket
+  -> frontend stores blocks in local state
+  -> daemon POST /hub/send final reply
+  -> Hub persists final reply as MessageRecord
+```
+
+Current limitation: if the frontend reloads before the final reply, only the final message path is durable. Stream blocks live in memory/UI state only.
+
+## Proposed Flow
+
+The daemon should not dual-write. It should continue sending stream blocks only to the Hub.
+
+The Hub should dual-output each stream block:
+
+```text
+Runtime
+  -> daemon normalizes stream block
+  -> daemon POST /hub/stream-block
+  -> Hub validates trace ownership
+  -> Hub compacts/truncates block
+  -> Hub writes Redis in-flight cache
+  -> Hub pushes stream_block over WebSocket
+```
+
+When the final assistant reply is delivered:
+
+```text
+daemon POST /hub/send
+  -> Hub persists final MessageRecord
+  -> Hub pushes final owner-chat message over WebSocket
+  -> Hub marks Redis run completed
+  -> Hub shortens Redis TTL
+```
+
+## Multi-Hub Fanout
+
+Introducing Redis also gives us a clean path to support multiple Hub instances for owner-chat streaming.
+
+Today, WebSocket connections are process-local. If the owner dashboard connects to Hub instance A, but a stream block request lands on Hub instance B, instance B cannot directly see the WebSocket held by instance A.
+
+Redis should solve this with broadcast fanout, not by moving WebSocket ownership out of the Hub process.
+
+```text
+Browser owner-chat WS
+  -> connected to Hub A
+
+daemon POST /hub/stream-block
+  -> load balancer routes request to Hub B
+  -> Hub B validates trace ownership
+  -> Hub B writes Redis in-flight cache
+  -> Hub B publishes Redis fanout event
+  -> all Hub instances receive the fanout event
+  -> Hub A sees it has the local WebSocket
+  -> Hub A sends stream_block to Browser
+```
+
+Redis responsibilities:
+
+- **Cache**: short-lived replay data for refresh/reconnect recovery.
+- **Pub/Sub fanout**: broadcast live owner-chat events to every Hub instance so the instance holding the WebSocket can deliver them.
+
+Hub process responsibilities:
+
+- Keep actual WebSocket objects in local memory.
+- Subscribe to owner-chat Redis fanout events.
+- On each event, check local `(user_id, agent_id)` WebSocket connections.
+- Deliver the event only if this process has matching local connections.
+
+This does not require sticky sessions for correctness. Sticky sessions may still reduce connection churn, but live event delivery should not depend on a stream-block HTTP request landing on the same Hub instance as the browser WebSocket.
+
+### Fanout channels
+
+MVP options:
+
+```text
+owner_chat_events
+```
+
+or sharded by agent:
+
+```text
+owner_chat_events:{agent_id}
+```
+
+Start with one channel if traffic is low and operational simplicity matters. Move to sharded channels when event volume requires it.
+
+The fanout payload should include enough routing context:
+
+```json
+{
+  "type": "stream_block",
+  "trace_id": "h_...",
+  "user_id": "usr_...",
+  "agent_id": "ag_...",
+  "room_id": "rm_oc_...",
+  "seq": 12,
+  "block": {
+    "kind": "tool_call",
+    "seq": 12,
+    "payload": {
+      "name": "web_search"
+    }
+  },
+  "created_at": "2026-05-29T..."
+}
+```
+
+Final owner-chat message, typing, and run status events can use the same fanout path:
+
+- `stream_block`
+- `message`
+- `typing`
+- `run_status`
+
+### Ordering and dedupe
+
+Write cache before publish:
+
+```text
+receive block -> compact -> write Redis cache -> publish fanout
+```
+
+This ensures that if WebSocket delivery fails, refresh/reconnect can still recover from Redis.
+
+Every event must include `trace_id + seq` or `hub_msg_id` so frontend and Hub listeners can de-duplicate repeated events.
+
+### Why not Redis consumer groups?
+
+Redis consumer groups are queue-like: each event is delivered to one consumer in the group. Owner-chat fanout needs broadcast semantics because only the Hub process that owns the local WebSocket can send to that browser. Therefore each Hub instance should receive the event and decide locally whether to deliver it.
+
+Redis Streams can still be used for replay/cache. Pub/Sub or a broadcast-style Stream reader should be used for live multi-instance fanout.
+
+## Redis Data Model
+
+Use Redis only for short-lived run state.
+
+### Run metadata
+
+Key:
+
+```text
+owner_chat_run:{trace_id}
+```
+
+Type: hash
+
+Fields:
+
+- `trace_id`
+- `user_id`
+- `agent_id`
+- `room_id`
+- `trigger_msg_id`
+- `status`: `running | completed | failed`
+- `started_at`
+- `completed_at`
+- `final_msg_id`
+- `event_count`
+- `last_seq`
+
+Default TTL while running: 30-60 minutes.
+
+TTL after completion: 2-5 minutes.
+
+### Stream events
+
+Key:
+
+```text
+owner_chat_run:{trace_id}:events
+```
+
+Type: Redis Stream preferred, Redis List acceptable for MVP.
+
+Each event stores:
+
+- `seq`
+- `kind`
+- `created_at`
+- `payload_compact`
+- `truncated`
+- `size_bytes`
+
+Redis Stream is preferred because it has natural append-only event IDs and reconnect semantics. A List is simpler if the frontend only needs full replay on refresh.
+
+## Block Compaction
+
+Before writing Redis, the Hub should normalize stream blocks into compact payloads.
+
+Suggested defaults:
+
+- Keep `assistant` text chunks only while the run is active.
+- Keep `tool_call` name and compact parameters.
+- Keep `tool_result` status and short result preview.
+- Keep `reasoning` as metadata or short summary only, not full hidden reasoning.
+- Keep `system` blocks only when useful for UX/debugging.
+- Drop unknown oversized fields.
+
+Caps:
+
+- Max events per trace: reuse the current 200-block cap, or lower to 100 for persisted cache.
+- Max compact payload per event: 4-8 KB.
+- Max total cached bytes per run: configurable, e.g. 256 KB or 1 MB.
+
+If a block exceeds the limit:
+
+- Store `truncated: true`.
+- Store a short preview.
+- Do not store the full raw payload.
+
+## API Changes
+
+### Restore in-flight run
+
+Add an owner-authenticated dashboard endpoint:
+
+```text
+GET /api/dashboard/chat/runs/{trace_id}/stream-blocks
+```
+
+Response:
+
+```json
+{
+  "trace_id": "h_...",
+  "status": "running",
+  "room_id": "rm_oc_...",
+  "agent_id": "ag_...",
+  "events": [
+    {
+      "seq": 1,
+      "kind": "tool_call",
+      "created_at": "2026-05-29T...",
+      "block": {
+        "kind": "tool_call",
+        "seq": 1,
+        "payload": {
+          "name": "web_search"
+        }
+      }
+    }
+  ]
+}
+```
+
+Authorization rules:
+
+- The requester must own the `agent_id`.
+- The run must belong to the owner's owner-chat room.
+- If Redis has expired the run, return `404` or an empty completed response.
+
+### Optional active runs endpoint
+
+If the frontend cannot reliably infer which trace to restore from local state or recent messages, add:
+
+```text
+GET /api/dashboard/chat/active-runs?agent_id=ag_...
+```
+
+This returns recent running owner-chat traces for the owner and agent.
+
+## Frontend Behavior
+
+On page load or owner-chat pane mount:
+
+1. Load normal owner-chat messages.
+2. Identify recent user messages without a final assistant reply, or call `active-runs`.
+3. Fetch cached stream blocks for active traces.
+4. Recreate streaming placeholders from cached events.
+5. Continue receiving new blocks over WebSocket.
+6. When the final assistant message arrives, merge it with the placeholder as today.
+
+If cache restore fails, the UI should degrade gracefully and wait for the final message.
+
+## Failure Modes
+
+### Redis write fails
+
+Live streaming should continue.
+
+Behavior:
+
+- Log warning.
+- Push WS block if a client is connected.
+- Do not fail `/hub/stream-block`.
+
+Impact: refresh recovery may lose blocks during Redis outage.
+
+### WebSocket push fails
+
+Redis already has the block if write happens first.
+
+Behavior:
+
+- Keep Redis cache.
+- Frontend can recover after reconnect.
+
+### Hub process restarts
+
+In-memory trace subscriptions are lost, but Redis run metadata can recover enough context for restore. A follow-up can replace in-memory trace routing with Redis-backed routing if needed.
+
+### Final reply never arrives
+
+Run expires automatically after the running TTL.
+
+Optional enhancement:
+
+- Mark stale runs `failed` before expiry if no block arrives for N minutes.
+
+## Storage Policy
+
+This feature should be explicitly short-lived.
+
+Recommended defaults:
+
+- Running TTL: 60 minutes.
+- Completed TTL: 5 minutes.
+- Failed/stale TTL: 10 minutes.
+- Max persisted events per run: 100-200.
+- Max compact event payload: 4-8 KB.
+- Max total cache bytes per run: configurable.
+
+This keeps storage proportional to active runs, not historical traffic.
+
+## Rollout Plan
+
+### Phase 1: Hub cache write
+
+- Add Redis helper for owner-chat stream cache.
+- Write run metadata when owner-chat WS creates a trigger message.
+- Write compact stream events in `/hub/stream-block`.
+- Shorten TTL when final owner-chat message arrives.
+
+### Phase 2: Restore API
+
+- Add `GET /api/dashboard/chat/runs/{trace_id}/stream-blocks`.
+- Add tests for auth, running restore, completed TTL behavior, and expired runs.
+
+### Phase 3: Frontend restore
+
+- On owner-chat mount, restore active cached stream blocks.
+- Merge restored blocks with live WebSocket blocks by `trace_id + seq`.
+- Preserve existing final-message merge behavior.
+
+### Phase 4: Hardening
+
+- Add payload byte caps.
+- Add Redis failure fallback tests.
+- Add metrics for cache writes, restore hits, restore misses, and truncation.
+
+## Acceptance Criteria
+
+- Refreshing the owner-chat page during an active run restores previously streamed blocks.
+- Switching away and back during an active run restores previously streamed blocks.
+- Final assistant replies are still persisted through the existing message path.
+- Redis cache expires shortly after final reply delivery.
+- Redis outage does not break live WebSocket streaming.
+- Cached events are compact/truncated and bounded by per-run limits.
+- No daemon process needs Redis access.

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -155,6 +155,9 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
         }
         initialLoadRef.current = false;
         scrollToBottomAfterLayout();
+        // Restore in-flight stream blocks for any user message still awaiting a
+        // final reply (refresh/reconnect recovery). Best-effort; never throws.
+        void useOwnerChatStore.getState().restoreActiveRuns(chatAgentId);
       } catch (err: any) {
         if (cancelled) return;
         setInitError(err?.message || "Failed to initialize chat");

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -49,6 +49,7 @@ import type {
   SubscriptionProduct,
   UserChatRoom,
   UserChatSendResponse,
+  RunStreamBlocksResponse,
   RoomHumanSendResponse,
   CreateJoinRequestResponse,
   JoinRequestListResponse,
@@ -853,6 +854,23 @@ export const api = {
       "/api/dashboard/chat/room",
       agentId ? { agent_id: agentId } : undefined,
     );
+  },
+
+  /** Restore cached in-flight stream blocks for an owner-chat run.
+   *  `traceId` is the hub_msg_id of the triggering user message.
+   *  The Hub route (`/dashboard/chat/runs/{trace_id}/stream-blocks`) resolves the
+   *  owner via the Supabase JWT and the `X-Active-Agent` header, so the
+   *  owner-chat agent must be supplied explicitly. */
+  async getRunStreamBlocks(traceId: string, agentId: string): Promise<RunStreamBlocksResponse> {
+    const res = await apiFetch(
+      `/dashboard/chat/runs/${encodeURIComponent(traceId)}/stream-blocks`,
+      { method: "GET", headers: { "X-Active-Agent": agentId }, cache: "no-store" },
+    );
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({ error: res.statusText }));
+      throw new ApiError(res.status, extractErrorMessage(body, res.statusText));
+    }
+    return res.json();
   },
 
   sendUserChatMessage(

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -228,6 +228,27 @@ export interface StreamBlockEntry {
   created_at: string;
 }
 
+/** One cached in-flight stream event, as returned by the run restore endpoint.
+ *  Mirrors a live WS `stream_block` so the same store handler can ingest it.
+ *  Fields are nullable to match the Hub's lenient cache shape. */
+export interface RunStreamBlockEvent {
+  seq: number | null;
+  kind: string | null;
+  created_at: string | null;
+  block: StreamBlockEntry["block"];
+}
+
+/** Response of GET /dashboard/chat/runs/{trace_id}/stream-blocks.
+ *  Used to restore streaming placeholders after refresh/reconnect. Expired or
+ *  unauthorized runs come back as status="completed" with empty events. */
+export interface RunStreamBlocksResponse {
+  trace_id: string;
+  status: "running" | "completed" | "failed";
+  room_id: string | null;
+  agent_id: string | null;
+  events: RunStreamBlockEvent[];
+}
+
 // --- Owner-chat unified message model ---
 
 export type OwnerChatMessageStatus =

--- a/frontend/src/store/useOwnerChatStore.test.ts
+++ b/frontend/src/store/useOwnerChatStore.test.ts
@@ -1,13 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { DashboardMessage, HumanAgentRoomSummary, OwnerChatMessage } from "@/lib/types";
+import type {
+  DashboardMessage,
+  HumanAgentRoomSummary,
+  OwnerChatMessage,
+  RunStreamBlocksResponse,
+} from "@/lib/types";
 
 const mocks = vi.hoisted(() => ({
   getRoomMessages: vi.fn(),
+  getRunStreamBlocks: vi.fn(),
 }));
 
 vi.mock("@/lib/api", () => ({
   api: {
     getRoomMessages: mocks.getRoomMessages,
+    getRunStreamBlocks: mocks.getRunStreamBlocks,
   },
   humansApi: {
     listAgentRooms: vi.fn(),
@@ -269,5 +276,159 @@ describe("useOwnerChatStore stream terminal handling", () => {
       text: "streamed answer",
       status: "delivered",
     });
+  });
+});
+
+describe("useOwnerChatStore stream-cache restore", () => {
+  beforeEach(() => {
+    mocks.getRoomMessages.mockReset();
+    mocks.getRunStreamBlocks.mockReset();
+    useOwnerChatStore.getState().reset();
+    useDashboardChatStore.setState({
+      ownedAgentRooms: [makeOwnedAgentRoom()],
+      optimisticOwnerChatRooms: {},
+    });
+    useOwnerChatStore.getState().setRoom("rm_oc_real", "Owned bot");
+  });
+
+  function runningRun(overrides: Partial<RunStreamBlocksResponse> = {}): RunStreamBlocksResponse {
+    return {
+      trace_id: "msg_trace",
+      status: "running",
+      room_id: "rm_oc_real",
+      agent_id: "ag_bot",
+      events: [
+        {
+          seq: 1,
+          kind: "tool_call",
+          created_at: "2026-05-19T09:00:00.000Z",
+          block: { kind: "tool_call", payload: { name: "web_search" } },
+        },
+        {
+          seq: 2,
+          kind: "assistant",
+          created_at: "2026-05-19T09:00:01.000Z",
+          block: { kind: "assistant", payload: { text: "partial" } },
+        },
+      ],
+      ...overrides,
+    };
+  }
+
+  it("restoreStreamBlocks recreates a streaming placeholder from cached events", () => {
+    useOwnerChatStore.getState().restoreStreamBlocks(runningRun());
+
+    const msgs = useOwnerChatStore.getState().messages;
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]).toMatchObject({
+      traceId: "msg_trace",
+      status: "streaming",
+      hubMsgId: null,
+      text: "partial",
+    });
+    expect(msgs[0].streamBlocks.map((b) => b.seq)).toEqual([1, 2]);
+    expect(useOwnerChatStore.getState().activeTraceId).toBe("msg_trace");
+  });
+
+  it("dedupes by (trace_id, seq) when a live block re-arrives after restore", () => {
+    useOwnerChatStore.getState().restoreStreamBlocks(runningRun());
+
+    // Live WS re-delivers seq 2 (duplicate) and adds a new seq 3.
+    useOwnerChatStore.getState().appendStreamBlock({
+      trace_id: "msg_trace",
+      seq: 2,
+      created_at: "2026-05-19T09:00:01.000Z",
+      block: { kind: "assistant", payload: { text: "partial" } },
+    });
+    useOwnerChatStore.getState().appendStreamBlock({
+      trace_id: "msg_trace",
+      seq: 3,
+      created_at: "2026-05-19T09:00:02.000Z",
+      block: { kind: "tool_call", payload: { name: "read_file" } },
+    });
+
+    const msgs = useOwnerChatStore.getState().messages;
+    expect(msgs).toHaveLength(1);
+    // seq 2 not duplicated; seq 3 appended.
+    expect(msgs[0].streamBlocks.map((b) => b.seq)).toEqual([1, 2, 3]);
+  });
+
+  it("does nothing for a completed/empty run (graceful degrade)", () => {
+    useOwnerChatStore
+      .getState()
+      .restoreStreamBlocks(runningRun({ status: "completed", events: [] }));
+
+    expect(useOwnerChatStore.getState().messages).toHaveLength(0);
+    expect(useOwnerChatStore.getState().activeTraceId).toBeNull();
+  });
+
+  it("restoreActiveRuns fetches + restores only uncovered user-message traces", async () => {
+    // A confirmed user message whose reply is still in flight.
+    useOwnerChatStore.getState().upsertMessage(
+      makeOwnerChatMessage({
+        clientId: "u1",
+        hubMsgId: "msg_trace",
+        sender: "user",
+        status: "confirmed",
+        text: "do a thing",
+      }),
+    );
+    mocks.getRunStreamBlocks.mockResolvedValue(runningRun());
+
+    await useOwnerChatStore.getState().restoreActiveRuns("ag_bot");
+
+    expect(mocks.getRunStreamBlocks).toHaveBeenCalledTimes(1);
+    expect(mocks.getRunStreamBlocks).toHaveBeenCalledWith("msg_trace", "ag_bot");
+    const streaming = useOwnerChatStore
+      .getState()
+      .messages.find((m) => m.traceId === "msg_trace" && m.status === "streaming");
+    expect(streaming).toBeTruthy();
+  });
+
+  it("restoreActiveRuns skips user messages that already have an agent reply", async () => {
+    useOwnerChatStore.getState().upsertMessage(
+      makeOwnerChatMessage({
+        clientId: "u1",
+        hubMsgId: "msg_trace",
+        sender: "user",
+        status: "confirmed",
+        text: "do a thing",
+      }),
+    );
+    // Agent final reply already linked to that trace.
+    useOwnerChatStore.getState().upsertMessage(
+      makeOwnerChatMessage({
+        clientId: "a1",
+        hubMsgId: "msg_final",
+        sender: "agent",
+        status: "delivered",
+        text: "done",
+        senderName: "Owned bot",
+        traceId: "msg_trace",
+      }),
+    );
+
+    await useOwnerChatStore.getState().restoreActiveRuns("ag_bot");
+
+    expect(mocks.getRunStreamBlocks).not.toHaveBeenCalled();
+  });
+
+  it("restoreActiveRuns degrades gracefully when the fetch fails", async () => {
+    useOwnerChatStore.getState().upsertMessage(
+      makeOwnerChatMessage({
+        clientId: "u1",
+        hubMsgId: "msg_trace",
+        sender: "user",
+        status: "confirmed",
+        text: "do a thing",
+      }),
+    );
+    mocks.getRunStreamBlocks.mockRejectedValue(new Error("network"));
+
+    await expect(useOwnerChatStore.getState().restoreActiveRuns("ag_bot")).resolves.toBeUndefined();
+    // No streaming placeholder created.
+    expect(
+      useOwnerChatStore.getState().messages.some((m) => m.status === "streaming"),
+    ).toBe(false);
   });
 });

--- a/frontend/src/store/useOwnerChatStore.ts
+++ b/frontend/src/store/useOwnerChatStore.ts
@@ -19,6 +19,7 @@ import type {
   ReplyPreview,
   StreamBlockEntry,
   DashboardMessage,
+  RunStreamBlocksResponse,
 } from "@/lib/types";
 import { dashboardMsgToOwnerChat } from "@/lib/types";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
@@ -159,6 +160,12 @@ export interface OwnerChatState {
 
   // Streaming
   appendStreamBlock: (entry: StreamBlockEntry) => void;
+  /** Restore cached in-flight stream blocks (refresh/reconnect recovery).
+   *  Replays each event through the live append/dedupe path. */
+  restoreStreamBlocks: (run: RunStreamBlocksResponse) => void;
+  /** Fetch + restore active runs for the current room (no final reply yet).
+   *  `agentId` is the owner-chat agent (needed for the X-Active-Agent header). */
+  restoreActiveRuns: (agentId: string) => Promise<void>;
   finalizeStream: (traceId: string, finalData: {
     hubMsgId: string;
     text: string;
@@ -514,6 +521,74 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
       };
     });
     syncOwnerChatRoomSummary(get().roomId, get().messages);
+  },
+
+  restoreStreamBlocks: (run) => {
+    // Only running runs have replayable in-flight state. A completed/failed or
+    // expired run (status !== "running" or empty events) means "nothing to
+    // restore" — degrade gracefully and wait for live WS / final message.
+    if (run.status !== "running") return;
+    if (!run.events || run.events.length === 0) return;
+
+    const append = get().appendStreamBlock;
+    for (const ev of run.events) {
+      // Live WS blocks always carry a numeric seq; skip malformed cache rows.
+      if (typeof ev.seq !== "number") continue;
+      // Replay through the live path so placeholder creation, ordering, and
+      // (trace_id, seq) dedupe all match the WS stream_block handler exactly.
+      append({
+        trace_id: run.trace_id,
+        seq: ev.seq,
+        block: ev.block,
+        created_at: ev.created_at ?? new Date().toISOString(),
+      });
+    }
+  },
+
+  restoreActiveRuns: async (agentId) => {
+    if (!agentId) return;
+    const { messages } = get();
+
+    // Trace ids already covered by a streaming placeholder or a finalized
+    // agent reply — never re-restore those.
+    const coveredTraceIds = new Set<string>();
+    for (const m of messages) {
+      if (m.sender === "agent" && m.traceId) coveredTraceIds.add(m.traceId);
+      if (m.status === "streaming" && m.traceId) coveredTraceIds.add(m.traceId);
+    }
+
+    // Candidate in-flight traces: confirmed/delivered user messages whose
+    // hub_msg_id (== trace_id) has no agent reply or streaming placeholder yet.
+    const candidates = messages
+      .filter(
+        (m) =>
+          m.sender === "user" &&
+          m.hubMsgId &&
+          (m.status === "confirmed" || m.status === "delivered") &&
+          !coveredTraceIds.has(m.hubMsgId),
+      )
+      .map((m) => m.hubMsgId!);
+
+    if (candidates.length === 0) return;
+
+    await Promise.all(
+      candidates.map(async (traceId) => {
+        try {
+          const run = await api.getRunStreamBlocks(traceId, agentId);
+          // Discard stale result if the trace got covered while we were fetching.
+          const covered = get().messages.some(
+            (m) =>
+              (m.sender === "agent" && m.traceId === traceId) ||
+              (m.status === "streaming" && m.traceId === traceId),
+          );
+          if (covered) return;
+          get().restoreStreamBlocks(run);
+        } catch (err) {
+          // Network error / missing run — degrade gracefully, never throw.
+          console.error("[OwnerChatStore] Failed to restore run:", traceId, err);
+        }
+      }),
+    );
   },
 
   finalizeStream: (traceId, finalData) => {


### PR DESCRIPTION
## What

Implements the [Owner Chat In-Flight Stream Cache PRD](docs/owner-chat-stream-cache-prd.md): a short-lived Redis cache so owner-chat streaming UI survives page refresh / navigation / short WS reconnects while a run is still active. Postgres remains the source of truth for final messages.

## Backend
- New `hub/owner_chat_cache.py` — the **only** Redis touchpoint. Run metadata hash `owner_chat_run:{trace_id}` + per-run Redis Stream `:events` of **compacted** blocks (assistant text / tool_call name+params / tool_result status+preview / reasoning summary), with per-run event + byte caps and short TTLs (running 60m / completed 5m / failed 10m).
- **Multi-hub fanout**: Redis pub/sub channel `owner_chat_events`, origin-tagged to avoid double-send, so any Hub replica can deliver to the instance holding the WS — unblocks multi-replica owner-chat (HPA was pinned to 1 for this reason).
- Restore endpoint `GET /dashboard/chat/runs/{trace_id}/stream-blocks` (owner-authed via Supabase JWT + `X-Active-Agent`). Returns empty-`completed` when Redis off / run expired.
- **Graceful degradation**: all Redis ops are no-ops when `BOTCORD_REDIS_URL` is unset or on any error — live WS streaming never depends on Redis. **Daemon unchanged** (still only POSTs `/hub/stream-block`).

## Frontend
- On owner-chat mount, fetch cached blocks for in-flight traces and replay through the existing `appendStreamBlock` path. Dedupe by `(trace_id, seq)`; degrade gracefully on empty/error.

## Config
`BOTCORD_REDIS_URL` (default unset → disabled) + `OWNER_CHAT_RUN_TTL_SECONDS` / `_COMPLETED_` / `_FAILED_` / `MAX_CACHED_EVENTS` / `MAX_EVENT_BYTES` / `FANOUT_CHANNEL`.

## Infra (separate repo: aibrary-devops, branch `feat/botcord-redis`)
- Provisioned ElastiCache **Valkey 8.0** `botcord-cache-prod` (us-east-1, TLS + auth, cluster-mode off). Verified reachable from EKS prod. Env isolation by DB index: **prod=/0, preview=/1**.

## Tests
- Backend: full suite **1336 passed / 30 skipped**; `test_owner_chat_cache.py` 15 passed (no live Redis).
- Frontend: **130 passed**, `next build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)