### PR TITLE
fix: owner-chat stream cache — register trace on REST send + stop fanout connection leak

### DIFF
--- a/backend/hub/owner_chat_cache.py
+++ b/backend/hub/owner_chat_cache.py
@@ -58,10 +58,17 @@ def get_redis() -> Any:
             import redis.asyncio as redis_asyncio
 
             # TLS is handled automatically by the rediss:// scheme.
+            # health_check_interval + keepalive keep idle connections alive
+            # (ElastiCache/NLB drop silent idle sockets), and retry_on_timeout
+            # lets one-shot commands survive a transient read timeout instead of
+            # surfacing as a write failure.
             _redis_client = redis_asyncio.from_url(
                 hub_config.BOTCORD_REDIS_URL,
                 encoding="utf-8",
                 decode_responses=True,
+                socket_keepalive=True,
+                health_check_interval=30,
+                retry_on_timeout=True,
             )
         except Exception as exc:  # noqa: BLE001
             _redis_init_failed = True
@@ -362,15 +369,25 @@ async def owner_chat_fanout_loop() -> None:
         client = get_redis()
         if client is None:
             return
+        pubsub = client.pubsub()
         try:
-            pubsub = client.pubsub()
             await pubsub.subscribe(hub_config.OWNER_CHAT_FANOUT_CHANNEL)
             logger.info(
                 "owner_chat_cache: fanout subscribed channel=%s instance=%s",
                 hub_config.OWNER_CHAT_FANOUT_CHANNEL,
                 INSTANCE_ID,
             )
-            async for message in pubsub.listen():
+            while True:
+                # Block up to `timeout`s for a message; None means idle, which
+                # is NOT an error. Using get_message(timeout=...) instead of
+                # listen() avoids the socket read-timeout churn that made the
+                # loop reconnect every few seconds against ElastiCache (and
+                # leak a subscribe connection on each reconnect).
+                message = await pubsub.get_message(
+                    ignore_subscribe_messages=True, timeout=30.0
+                )
+                if message is None:
+                    continue
                 if message.get("type") != "message":
                     continue
                 try:
@@ -384,7 +401,14 @@ async def owner_chat_fanout_loop() -> None:
             raise
         except Exception as exc:  # noqa: BLE001
             logger.warning("owner_chat_cache.fanout_loop error: %s", exc)
-            await asyncio.sleep(1.0)
+        finally:
+            # Always release the pubsub connection before reconnecting so a
+            # transient error never leaks a subscribe connection.
+            try:
+                await pubsub.aclose()
+            except Exception:  # noqa: BLE001
+                pass
+        await asyncio.sleep(1.0)
 
 
 async def _deliver_fanout_event(event: dict) -> None:

--- a/backend/hub/routers/dashboard_chat.py
+++ b/backend/hub/routers/dashboard_chat.py
@@ -329,6 +329,20 @@ async def send_chat_message(
 
     await db.commit()
 
+    # Register the in-flight trace + cache run metadata, exactly as the owner-chat
+    # WS send path does. The dashboard sends over the WS when connected and falls
+    # back to this REST endpoint otherwise (e.g. during WS reconnect after a page
+    # refresh); without this, REST-sent messages would never route streamed blocks
+    # to the owner's WS nor get cached for refresh/restore.
+    from hub.routers.owner_chat_ws import register_owner_chat_run
+
+    await register_owner_chat_run(
+        hub_msg_id=hub_msg_id,
+        user_id=user_id,
+        agent_id=agent_id,
+        room_id=room_id,
+    )
+
     # Notify inbox listeners so connected agents pick up the message.
     # Skip Supabase realtime event — the dedicated owner-chat WS path
     # handles real-time delivery to the dashboard frontend.

--- a/backend/hub/routers/owner_chat_ws.py
+++ b/backend/hub/routers/owner_chat_ws.py
@@ -153,6 +153,32 @@ def _cleanup_trace(trace_id: str) -> None:
     _oc_trace_block_count.pop(trace_id, None)
 
 
+async def register_owner_chat_run(
+    *,
+    hub_msg_id: str,
+    user_id: str,
+    agent_id: str,
+    room_id: str,
+) -> None:
+    """Register an in-flight owner-chat trace and write its Redis run metadata.
+
+    Shared by both the owner-chat WS ``send`` path and the REST
+    ``/dashboard/chat/send`` path. The dashboard sends over the WS when it is
+    connected and falls back to REST otherwise; both must register the trace so
+    streamed blocks route to the owner's WS (and get cached for refresh/restore).
+    ``trace_id`` is the ``hub_msg_id`` of the trigger message.
+    """
+    _oc_trace_subs[hub_msg_id] = (user_id, agent_id)
+    _oc_trace_block_count[hub_msg_id] = 0
+    await owner_chat_cache.write_run_metadata(
+        hub_msg_id,
+        user_id=user_id,
+        agent_id=agent_id,
+        room_id=room_id,
+        trigger_msg_id=hub_msg_id,
+    )
+
+
 # Retry backoff schedule (seconds) for notify_inbox when no WS connections are active.
 _NOTIFY_RETRY_DELAYS: Sequence[float] = (1, 2, 4, 8)
 
@@ -484,17 +510,12 @@ async def owner_chat_ws(ws: WebSocket):
                     await db.commit()
 
                     # Register trace subscription so streamed blocks route here
-                    _oc_trace_subs[hub_msg_id] = (user_id, agent_id)
-                    _oc_trace_block_count[hub_msg_id] = 0
-
-                    # Write the in-flight run metadata to Redis (no-op if Redis
-                    # disabled). trace_id == hub_msg_id of the trigger message.
-                    await owner_chat_cache.write_run_metadata(
-                        hub_msg_id,
+                    # and cache the in-flight run for refresh/restore.
+                    await register_owner_chat_run(
+                        hub_msg_id=hub_msg_id,
                         user_id=user_id,
                         agent_id=agent_id,
                         room_id=room_id,
-                        trigger_msg_id=hub_msg_id,
                     )
 
                     # Notify agent inbox

--- a/backend/tests/test_dashboard_chat.py
+++ b/backend/tests/test_dashboard_chat.py
@@ -213,6 +213,56 @@ async def test_dashboard_chat_send_and_room_creation(
 
 
 @pytest.mark.asyncio
+async def test_rest_send_registers_trace_for_streaming(
+    client: AsyncClient,
+    db_session: AsyncSession,
+):
+    """REST /dashboard/chat/send must register the in-flight trace (parity with
+    the WS send path) so streamed blocks route to the owner's WS and get cached
+    for refresh/restore. The dashboard falls back to REST when the WS isn't
+    connected, so without this the whole stream-cache path silently no-ops."""
+    from hub.routers import owner_chat_ws
+    import uuid as _uuid
+    from sqlalchemy import update
+
+    agent_id, token, _sk, _kid = await _register_and_verify(client, "TraceAgent")
+    user_id = str(_uuid.uuid4())
+    owner = User(
+        id=_uuid.UUID(user_id),
+        display_name="Owner User",
+        email="trace-owner@example.com",
+        status="active",
+        supabase_user_id=_uuid.uuid4(),
+        human_id="hu_tracereg01",
+    )
+    db_session.add(owner)
+    await db_session.execute(
+        update(Agent)
+        .where(Agent.agent_id == agent_id)
+        .values(
+            user_id=_uuid.UUID(user_id),
+            claimed_at=datetime.datetime.now(datetime.timezone.utc),
+        )
+    )
+    await db_session.commit()
+
+    headers = _auth_header(token)
+    resp = await client.post(
+        "/dashboard/chat/send",
+        json={"text": "stream me"},
+        headers=headers,
+    )
+    assert resp.status_code == 202
+    hub_msg_id = resp.json()["hub_msg_id"]
+
+    try:
+        assert hub_msg_id in owner_chat_ws._oc_trace_subs
+        assert owner_chat_ws._oc_trace_subs[hub_msg_id] == (user_id, agent_id)
+    finally:
+        owner_chat_ws._cleanup_trace(hub_msg_id)
+
+
+@pytest.mark.asyncio
 async def test_dashboard_chat_room_is_stable(
     client: AsyncClient,
     db_session: AsyncSession,


### PR DESCRIPTION
Follow-up to #851. Found while validating the owner-chat stream cache on **preview** (real ElastiCache): refreshing mid-run lost the intermediate stream blocks (the final reply still arrived). Root-caused via live Redis inspection + preview container logs.

## Bug 1 — REST send never registered the trace (main cause)
The dashboard sends over the owner-chat **WS when connected**, and **falls back to REST `/dashboard/chat/send`** otherwise (e.g. during WS reconnect right after a page refresh — exactly the restore scenario). Only the WS send path registered the in-flight trace (`_oc_trace_subs`) and wrote Redis run metadata.

So a REST-sent message:
- had its streamed blocks dropped at `/hub/stream-block` (`if not sub: return`, silent) → no live mid-stream **and** nothing cached;
- left the restore endpoint returning empty → **intermediate progress vanished on refresh**, while the final reply (delivered via `notify_oc_ws_message`, room-keyed, not trace-keyed) still showed up. Matches the reported symptom exactly.

Fix: extract `register_owner_chat_run()` and call it from **both** the WS send and REST send paths. (Also fixes a pre-existing gap: REST-sent messages previously got no live mid-stream blocks at all.)

## Bug 2 — fanout loop leaked Redis connections
`owner_chat_fanout_loop` used `pubsub.listen()`, which raised `TimeoutError: Timeout reading from ...` on idle against ElastiCache every ~6s. The loop reconnected **without closing the old pubsub**, leaking one `subscribe` connection each time — observed **100+** live subscribe connections from the preview host on the cache.

Fix:
- `get_message(timeout=30)` instead of `listen()` — idle returns `None`, not an error.
- `finally: await pubsub.aclose()` before every reconnect.
- `health_check_interval=30` + `socket_keepalive=True` + `retry_on_timeout=True` on the client.

## Tests
`tests/test_dashboard_chat.py` + `tests/test_owner_chat_cache.py`: **23 passed**. New `test_rest_send_registers_trace_for_streaming` guards Bug 1.

## Validation plan
Merge → CI builds `:preview` → deploy preview → confirm db1 gets `owner_chat_run:*` on send, subscribe connections stay at 1, and refresh restores mid-run blocks → then deploy prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)