### PR TITLE
fix: preserve stream-block structure in owner-chat cache (restored view matched live)

### DIFF
--- a/backend/hub/owner_chat_cache.py
+++ b/backend/hub/owner_chat_cache.py
@@ -109,12 +109,43 @@ def _preview(value: Any, limit: int = 280) -> str:
     return text
 
 
-def compact_block(block: dict) -> dict:
-    """Normalize a stream block into a compact payload per PRD rules.
+# Max length for any single string field; long tool params / reasoning text /
+# tool output get truncated to this. The overall per-event byte cap is enforced
+# separately by _enforce_event_byte_cap.
+_MAX_STR_FIELD = 4000
+# Max items kept from a list before truncating (avoids huge arrays).
+_MAX_LIST_ITEMS = 100
 
-    Keep assistant text; tool_call -> name + compact params; tool_result ->
-    status + short preview; reasoning -> short summary/metadata only; drop
-    unknown oversized fields.
+
+def _truncate_deep(value: Any, str_limit: int = _MAX_STR_FIELD) -> Any:
+    """Recursively truncate long strings / large lists while PRESERVING the
+    original structure and types.
+
+    The restored stream view must render identically to the live view, so we
+    keep the block's payload shape (dicts stay dicts, params stay objects) and
+    only shrink oversized leaves — rather than reshaping per-kind or stringifying
+    structured payloads (which produced double-escaped, mis-rendered blocks).
+    """
+    if isinstance(value, str):
+        return value if len(value) <= str_limit else value[:str_limit] + "…"
+    if isinstance(value, dict):
+        return {k: _truncate_deep(v, str_limit) for k, v in value.items()}
+    if isinstance(value, list):
+        truncated = [_truncate_deep(v, str_limit) for v in value[:_MAX_LIST_ITEMS]]
+        if len(value) > _MAX_LIST_ITEMS:
+            truncated.append(f"… (+{len(value) - _MAX_LIST_ITEMS} more)")
+        return truncated
+    # int / float / bool / None — keep as-is.
+    return value
+
+
+def compact_block(block: dict) -> dict:
+    """Normalize a stream block for caching while preserving its structure.
+
+    Keeps the original ``kind``/``seq`` and the full payload shape, recursively
+    truncating only oversized string/list leaves so the restored view matches
+    the live stream exactly. The overall per-event byte cap is enforced by
+    ``_enforce_event_byte_cap``.
     """
     if not isinstance(block, dict):
         return {"kind": "unknown"}
@@ -124,29 +155,7 @@ def compact_block(block: dict) -> dict:
     payload = block.get("payload")
     payload = payload if isinstance(payload, dict) else {}
 
-    out_payload: dict[str, Any]
-    if kind == "assistant":
-        out_payload = {"text": _preview(payload.get("text", ""), 4000)}
-    elif kind == "tool_call":
-        out_payload = {"name": payload.get("name")}
-        params = payload.get("params") or payload.get("input")
-        if params is not None:
-            out_payload["params"] = _preview(params, 1000)
-    elif kind == "tool_result":
-        out_payload = {"status": payload.get("status")}
-        result = payload.get("result") or payload.get("output") or payload.get("content")
-        if result is not None:
-            out_payload["preview"] = _preview(result, 1000)
-    elif kind == "reasoning":
-        summary = payload.get("summary") or payload.get("text")
-        out_payload = {"summary": _preview(summary, 500)} if summary else {}
-    elif kind == "system":
-        out_payload = {"text": _preview(payload.get("text", ""), 1000)}
-    else:
-        # Unknown kind: drop oversized fields, keep a small preview.
-        out_payload = {"preview": _preview(payload, 500)} if payload else {}
-
-    compact: dict[str, Any] = {"kind": kind, "payload": out_payload}
+    compact: dict[str, Any] = {"kind": kind, "payload": _truncate_deep(payload)}
     if seq is not None:
         compact["seq"] = seq
     return compact

--- a/backend/tests/test_owner_chat_cache.py
+++ b/backend/tests/test_owner_chat_cache.py
@@ -167,27 +167,45 @@ def fake_redis(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_compact_tool_call():
-    block = {"kind": "tool_call", "seq": 3, "payload": {"name": "web_search", "params": {"q": "x" * 5000}}}
+def test_compact_tool_call_preserves_param_structure():
+    # Params must stay a dict (not be stringified) so the restored view renders
+    # the same as the live stream; only long string leaves get truncated.
+    block = {"kind": "tool_call", "seq": 3, "payload": {"name": "web_search", "params": {"q": "x" * 9000}}}
     out = owner_chat_cache.compact_block(block)
     assert out["kind"] == "tool_call"
     assert out["payload"]["name"] == "web_search"
-    assert len(out["payload"]["params"]) <= 1000
+    assert isinstance(out["payload"]["params"], dict)
+    assert len(out["payload"]["params"]["q"]) <= owner_chat_cache._MAX_STR_FIELD + 1
     assert out["seq"] == 3
 
 
-def test_compact_tool_result_preview():
+def test_compact_tool_result_preserves_structure():
     block = {"kind": "tool_result", "payload": {"status": "ok", "result": "z" * 9000}}
     out = owner_chat_cache.compact_block(block)
     assert out["payload"]["status"] == "ok"
-    assert len(out["payload"]["preview"]) <= 1000
+    assert isinstance(out["payload"]["result"], str)
+    assert len(out["payload"]["result"]) <= owner_chat_cache._MAX_STR_FIELD + 1
 
 
-def test_compact_reasoning_summary_only():
-    block = {"kind": "reasoning", "payload": {"text": "long hidden reasoning " * 100}}
+def test_compact_thinking_keeps_payload_shape():
+    # `thinking` (codex runtime) must NOT fall through to a stringified preview.
+    block = {
+        "kind": "thinking",
+        "seq": 2,
+        "payload": {"phase": "updated", "label": "Searching web", "source": "runtime"},
+    }
     out = owner_chat_cache.compact_block(block)
-    assert "summary" in out["payload"]
-    assert len(out["payload"]["summary"]) <= 500
+    assert out["kind"] == "thinking"
+    assert out["payload"] == {"phase": "updated", "label": "Searching web", "source": "runtime"}
+    assert out["seq"] == 2
+
+
+def test_compact_truncates_long_string_in_place():
+    block = {"kind": "reasoning", "payload": {"text": "r" * 9000}}
+    out = owner_chat_cache.compact_block(block)
+    # structure preserved (still under payload.text), long string truncated
+    assert "text" in out["payload"]
+    assert len(out["payload"]["text"]) <= owner_chat_cache._MAX_STR_FIELD + 1
 
 
 def test_byte_cap_truncates(monkeypatch):


### PR DESCRIPTION
Follow-up to #851/#852. On preview, the **restored** mid-run blocks rendered wrong (garbled, double-escaped JSON; `thinking` blocks showing `{"preview":"{\"phase\":...}"}`; `web_search` params reduced to a stringified blob).

## Cause
`compact_block` reshaped each payload per-kind and ran structured data through `_preview()`, which `json.dumps`-es non-strings:
- `tool_call` params → a JSON **string** (lost object structure → frontend renders it differently than the live block).
- codex runtime's `thinking` kind wasn't recognized → fell through to the `else` branch as `{"preview": "<double-escaped json>"}`.

So the restored view never matched the live view.

## Fix
Replace per-kind reshaping with `_truncate_deep()`: keep the original `kind`/`seq` and the **full payload shape**, recursively truncating only oversized string (>4000 chars) / list (>100 items) leaves. Overall per-event size is still bounded by `_enforce_event_byte_cap` (8 KB). Restored blocks now equal the live blocks the frontend already renders.

## Tests
`tests/test_owner_chat_cache.py`: **16 passed**. Updated assertions to the structure-preserving contract; added `test_compact_thinking_keeps_payload_shape` (the exact regression seen on preview) + truncation-in-place tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)