### PR TITLE
feat: add dashboard message recall

### DIFF
--- a/backend/app/routers/activity.py
+++ b/backend/app/routers/activity.py
@@ -37,6 +37,8 @@ _not_owner_chat = or_(
     ~MessageRecord.room_id.startswith(_OWNER_CHAT_ROOM_PREFIX),
 )
 
+_RECALLED_MESSAGE_PREVIEW = "Message recalled"
+
 
 def _period_start(period: str) -> datetime.datetime:
     now = datetime.datetime.now(datetime.timezone.utc)
@@ -65,6 +67,12 @@ def _extract_preview(envelope_json: str | None, max_len: int = 60) -> str | None
         return text or None
     except (json.JSONDecodeError, AttributeError):
         return None
+
+
+def _activity_preview(envelope_json: str | None, recalled_at: datetime.datetime | None) -> str | None:
+    if recalled_at is not None:
+        return _RECALLED_MESSAGE_PREVIEW
+    return _extract_preview(envelope_json)
 
 
 # ---------------------------------------------------------------------------
@@ -311,6 +319,7 @@ async def get_activity_feed(
             ReceiverAgent.c.display_name.label("other_name"),
             Room.name.label("room_name"),
             MessageRecord.envelope_json,
+            MessageRecord.recalled_at,
             MessageRecord.state,
             MessageRecord.last_error,
         )
@@ -328,7 +337,7 @@ async def get_activity_feed(
             "agent_name": row.other_name,
             "room_id": row.room_id,
             "room_name": row.room_name,
-            "preview": _extract_preview(row.envelope_json),
+            "preview": _activity_preview(row.envelope_json, row.recalled_at),
             "count": row.msg_count,
             "meta": {"error": (row.last_error or "delivery failed").split("\n")[0][:120]} if etype == "message_failed" else None,
         })
@@ -361,6 +370,7 @@ async def get_activity_feed(
             SenderAgent.c.display_name.label("other_name"),
             Room.name.label("room_name"),
             MessageRecord.envelope_json,
+            MessageRecord.recalled_at,
         )
         .join(MessageRecord, MessageRecord.id == recv_grp.c.latest_id)
         .outerjoin(SenderAgent, SenderAgent.c.agent_id == recv_grp.c.sender_id)
@@ -374,7 +384,7 @@ async def get_activity_feed(
             "agent_name": row.other_name,
             "room_id": row.room_id,
             "room_name": row.room_name,
-            "preview": _extract_preview(row.envelope_json),
+            "preview": _activity_preview(row.envelope_json, row.recalled_at),
             "count": row.msg_count,
             "meta": None,
         })

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -11,7 +11,7 @@ import os
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, UploadFile
 from pydantic import BaseModel, ConfigDict, Field
-from sqlalchemy import exists, func, select, text
+from sqlalchemy import exists, func, select, text, update as sa_update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
@@ -64,6 +64,7 @@ from hub.routers.hub import (
     _load_reply_previews,
     _load_reply_target,
     _record_slow_mode_send,
+    build_agent_realtime_event,
     build_message_realtime_event,
     is_agent_ws_online,
     notify_inbox,
@@ -124,6 +125,53 @@ class ChatAttachment(BaseModel):
 
 
 _RECEIPT_TYPES = frozenset({"ack", "result", "error"})
+_MESSAGE_RECALL_WINDOW = datetime.timedelta(minutes=2)
+_RECALLED_MESSAGE_PREVIEW = "Message recalled"
+
+
+def _datetime_to_iso(value: datetime.datetime | None) -> str | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=datetime.timezone.utc)
+    return value.isoformat()
+
+
+def _recalled_message_fields(rec: MessageRecord) -> dict:
+    recalled_by_type = rec.recalled_by_type
+    return {
+        "is_recalled": rec.recalled_at is not None,
+        "recalled_at": _datetime_to_iso(rec.recalled_at),
+        "recalled_by_id": rec.recalled_by_id,
+        "recalled_by_type": (
+            recalled_by_type.value
+            if hasattr(recalled_by_type, "value")
+            else str(recalled_by_type)
+            if recalled_by_type is not None
+            else None
+        ),
+    }
+
+
+def _display_content_for_record(rec: MessageRecord, parsed: dict) -> tuple[str | None, dict, str | None]:
+    if rec.recalled_at is None:
+        return parsed["text"], parsed["payload"], parsed["type"]
+    return (
+        "",
+        {
+            "recalled": True,
+            "recalled_at": _datetime_to_iso(rec.recalled_at),
+            "recalled_by_id": rec.recalled_by_id,
+        },
+        parsed["type"] or "message",
+    )
+
+
+def _preview_for_record(rec: MessageRecord) -> tuple[str, str | None, str]:
+    sender_id, preview, msg_type = _extract_text_preview(rec.envelope_json)
+    if rec.recalled_at is not None:
+        return sender_id or rec.sender_id, _RECALLED_MESSAGE_PREVIEW, msg_type
+    return sender_id, preview, msg_type
 
 
 async def _effective_dashboard_member_role(
@@ -245,7 +293,9 @@ async def _build_rooms_from_sql(
             if fallback is None:
                 continue
             for key in fill_keys:
-                if key not in item or item.get(key) is None:
+                if key in {"last_message_preview", "last_message_at", "last_sender_name"}:
+                    item[key] = fallback.get(key)
+                elif key not in item or item.get(key) is None:
                     item[key] = fallback.get(key)
         missing_rooms = [room for room in orm_rooms if room["room_id"] not in sql_room_ids]
         combined = mapped if not missing_rooms else _sort_room_previews(mapped + missing_rooms)
@@ -316,9 +366,11 @@ async def _build_room_unread_counts(
         room_id = rec.room_id
         if not room_id or room_id not in counts:
             continue
+        if rec.recalled_at is not None:
+            continue
         if rec.sender_id == viewer_id:
             continue
-        _, _, msg_type = _extract_text_preview(rec.envelope_json)
+        _, _, msg_type = _preview_for_record(rec)
         if msg_type in _RECEIPT_TYPES:
             continue
         last_viewed_at = last_viewed_by_room.get(room_id)
@@ -452,7 +504,7 @@ async def _build_rooms_from_membership(
     for rec in last_msg_result.scalars().all():
         if not rec.room_id:
             continue
-        _, _, msg_type = _extract_text_preview(rec.envelope_json)
+        _, _, msg_type = _preview_for_record(rec)
         if msg_type in _RECEIPT_TYPES:
             receipt_room_ids.append(rec.room_id)
         else:
@@ -479,7 +531,7 @@ async def _build_rooms_from_membership(
         for rec in fallback_result.scalars().all():
             rid = rec.room_id
             if rid and rid not in last_messages:
-                _, _, mt = _extract_text_preview(rec.envelope_json)
+                _, _, mt = _preview_for_record(rec)
                 if mt not in _RECEIPT_TYPES:
                     last_messages[rid] = rec
 
@@ -504,7 +556,7 @@ async def _build_rooms_from_membership(
         last_at = None
         last_sender = None
         if last_rec:
-            sid, preview, _mt = _extract_text_preview(last_rec.envelope_json)
+            sid, preview, _mt = _preview_for_record(last_rec)
             last_preview = preview
             last_at = last_rec.created_at
             if last_at is not None and last_at.tzinfo is None:
@@ -2384,6 +2436,7 @@ async def get_room_messages(
     messages = []
     for rec in records:
         parsed = extract_text_from_envelope(rec.envelope_json)
+        display_text, display_payload, display_type = _display_content_for_record(rec, parsed)
         extra = derive_sender_fields(
             rec,
             agent_name_map=sender_names,
@@ -2399,15 +2452,16 @@ async def get_room_messages(
             "msg_id": rec.msg_id,
             "sender_id": rec.sender_id,
             "sender_name": sender_names.get(rec.sender_id),
-            "text": parsed["text"],
-            "type": parsed["type"],
-            "payload": parsed["payload"],
+            "text": display_text,
+            "type": display_type,
+            "payload": display_payload,
             "topic": rec.topic,
             "topic_id": rec.topic_id,
             "topic_title": topic_info.get(rec.topic_id, {}).get("title") if rec.topic_id else None,
             "created_at": rec.created_at.isoformat() if rec.created_at else None,
             "source_type": rec.source_type,
             "reply_preview": rp.model_dump(mode="json") if rp else None,
+            **_recalled_message_fields(rec),
             **extra,
         }
         if is_member:
@@ -2415,6 +2469,169 @@ async def get_room_messages(
         messages.append(msg)
 
     return {"messages": messages, "has_more": has_more}
+
+
+@router.post("/rooms/{room_id}/messages/{msg_id}/recall")
+async def recall_room_message(
+    room_id: str,
+    msg_id: str,
+    ctx: RequestContext = Depends(require_user_with_optional_agent),
+    db: AsyncSession = Depends(get_db),
+):
+    """Soft-recall a dashboard room message.
+
+    Owner-chat rooms are intentionally excluded: a recalled UI bubble cannot
+    guarantee that a runtime has not already consumed the message as context.
+    """
+    if room_id.startswith("rm_oc_"):
+        raise HTTPException(status_code=400, detail="Owner-chat messages cannot be recalled")
+
+    room = (
+        await db.execute(select(Room).where(Room.room_id == room_id))
+    ).scalar_one_or_none()
+    if room is None:
+        raise HTTPException(status_code=404, detail="Room not found")
+
+    actor_id = ctx.active_agent_id or ctx.human_id
+    actor_type = ParticipantType.agent if ctx.active_agent_id else ParticipantType.human
+    if not actor_id:
+        raise HTTPException(status_code=403, detail="Missing viewer identity")
+
+    records = list((
+        await db.execute(
+            select(MessageRecord)
+            .where(
+                MessageRecord.room_id == room_id,
+                MessageRecord.msg_id == msg_id,
+            )
+            .order_by(MessageRecord.id.asc())
+        )
+    ).scalars().all())
+    if not records:
+        raise HTTPException(status_code=404, detail="Message not found")
+
+    target = records[0]
+    parsed = extract_text_from_envelope(target.envelope_json)
+    if parsed["type"] != "message":
+        raise HTTPException(status_code=400, detail="Only message records can be recalled")
+
+    capability = await viewer_can_admin_room(db, ctx, room)
+    member = (
+        await db.execute(
+            select(RoomMember).where(
+                RoomMember.room_id == room_id,
+                RoomMember.agent_id == actor_id,
+                RoomMember.participant_type == actor_type,
+            )
+        )
+    ).scalar_one_or_none()
+    if capability is None and member is None:
+        raise HTTPException(status_code=403, detail="Not a member of this room")
+
+    source_user_id = str(ctx.user_id) if ctx.user_id is not None else None
+    is_sender = target.sender_id == actor_id or (
+        actor_type == ParticipantType.human
+        and target.source_type == "dashboard_human_room"
+        and source_user_id is not None
+        and str(target.source_user_id) == source_user_id
+    )
+    if capability is None and not is_sender:
+        raise HTTPException(status_code=403, detail="Only the sender or room admins can recall this message")
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    if capability is None:
+        created_at = target.created_at
+        if created_at is None:
+            raise HTTPException(status_code=403, detail="Message is outside the recall window")
+        if created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=datetime.timezone.utc)
+        if now - created_at > _MESSAGE_RECALL_WINDOW:
+            raise HTTPException(status_code=403, detail="Message is outside the recall window")
+
+    if target.recalled_at is None:
+        await db.execute(
+            sa_update(MessageRecord)
+            .where(
+                MessageRecord.room_id == room_id,
+                MessageRecord.msg_id == msg_id,
+            )
+            .values(
+                recalled_at=now,
+                recalled_by_id=actor_id,
+                recalled_by_type=actor_type,
+            )
+        )
+        await db.execute(
+            sa_update(ShareMessage)
+            .where(ShareMessage.msg_id == msg_id)
+            .values(
+                text="",
+                payload_json=json.dumps({
+                    "recalled": True,
+                    "is_recalled": True,
+                    "recalled_at": now.isoformat(),
+                    "recalled_by_id": actor_id,
+                    "recalled_by_type": actor_type.value,
+                }),
+            )
+        )
+        await db.commit()
+        target.recalled_at = now
+        target.recalled_by_id = actor_id
+        target.recalled_by_type = actor_type
+
+    member_ids = list((
+        await db.execute(
+            select(RoomMember.agent_id).where(RoomMember.room_id == room_id)
+        )
+    ).scalars().all())
+    for receiver_id in member_ids:
+        try:
+            recalled_fields = _recalled_message_fields(target)
+            await notify_inbox(
+                receiver_id,
+                db=db,
+                realtime_event=build_agent_realtime_event(
+                    type="message_recalled",
+                    agent_id=receiver_id,
+                    room_id=room_id,
+                    hub_msg_id=target.hub_msg_id,
+                    created_at=target.recalled_at,
+                    ext={
+                        "msg_id": msg_id,
+                        "recalled_at": recalled_fields["recalled_at"],
+                        "recalled_by_id": recalled_fields["recalled_by_id"],
+                        "recalled_by_type": recalled_fields["recalled_by_type"],
+                        "preview": _RECALLED_MESSAGE_PREVIEW,
+                    },
+                ),
+                resume_cloud=False,
+            )
+        except Exception as exc:
+            _logger.error(
+                "message recall notify failed receiver=%s room=%s msg=%s err=%s",
+                receiver_id,
+                room_id,
+                msg_id,
+                exc,
+                exc_info=True,
+            )
+
+    return {
+        "room_id": room_id,
+        "msg_id": msg_id,
+        "hub_msg_id": target.hub_msg_id,
+        "is_recalled": True,
+        "recalled_at": _datetime_to_iso(target.recalled_at),
+        "recalled_by_id": target.recalled_by_id,
+        "recalled_by_type": (
+            target.recalled_by_type.value
+            if hasattr(target.recalled_by_type, "value")
+            else str(target.recalled_by_type)
+            if target.recalled_by_type is not None
+            else None
+        ),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -3163,6 +3380,7 @@ async def create_share(
 
     for rec in records:
         parsed = extract_text_from_envelope(rec.envelope_json)
+        display_text, display_payload, display_type = _display_content_for_record(rec, parsed)
         if (rec.source_type or "") == "dashboard_human_room":
             _snap_sender_name = (
                 share_user_name_map.get(rec.source_user_id) if rec.source_user_id else None
@@ -3175,9 +3393,12 @@ async def create_share(
             msg_id=rec.msg_id,
             sender_id=rec.sender_id,
             sender_name=_snap_sender_name,
-            type=parsed["type"] or "message",
-            text=parsed["text"] or "",
-            payload_json=json.dumps(parsed["payload"]),
+            type=display_type or "message",
+            text=display_text or "",
+            payload_json=json.dumps({
+                **display_payload,
+                **_recalled_message_fields(rec),
+            }),
             created_at=rec.created_at or datetime.datetime.now(datetime.timezone.utc),
         )
         db.add(sm)
@@ -3208,6 +3429,7 @@ async def _fetch_inbox(
         .where(
             MessageRecord.receiver_id == agent_id,
             MessageRecord.state == MessageState.queued,
+            MessageRecord.recalled_at.is_(None),
         )
         .order_by(MessageRecord.created_at.asc())
         .limit(limit)

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -26,6 +26,7 @@ from app.auth_room import (
 from app.helpers import escape_like, extract_text_from_envelope
 from hub.database import get_db
 from hub.dashboard_message_shaping import (
+    HUMAN_SOURCE_TYPES,
     derive_sender_fields,
     load_agent_display_names,
     load_agent_profiles,
@@ -535,14 +536,19 @@ async def _build_rooms_from_membership(
                 if mt not in _RECEIPT_TYPES:
                     last_messages[rid] = rec
 
-    sender_ids = {rec.sender_id for rec in last_messages.values()}
-    sender_names: dict[str, str] = {}
-    if sender_ids:
-        agent_result = await db.execute(
-            select(Agent.agent_id, Agent.display_name)
-            .where(Agent.agent_id.in_(sender_ids))
-        )
-        sender_names = dict(agent_result.all())
+    agent_sender_ids: set[str] = set()
+    user_sender_ids: set[str] = set()
+    for rec in last_messages.values():
+        source_type = rec.source_type or ""
+        if source_type in HUMAN_SOURCE_TYPES or (rec.sender_id or "").startswith("hu_"):
+            if rec.source_user_id:
+                user_sender_ids.add(rec.source_user_id)
+            if (rec.sender_id or "").startswith("hu_"):
+                user_sender_ids.add(rec.sender_id)
+        elif rec.sender_id:
+            agent_sender_ids.add(rec.sender_id)
+    sender_names = await load_agent_display_names(db, agent_sender_ids)
+    user_sender_names = await load_user_display_names(db, user_sender_ids)
 
     unread_counts = await _build_room_unread_counts(agent_id, db, room_ids)
 
@@ -561,7 +567,13 @@ async def _build_rooms_from_membership(
             last_at = last_rec.created_at
             if last_at is not None and last_at.tzinfo is None:
                 last_at = last_at.replace(tzinfo=datetime.timezone.utc)
-            last_sender = sender_names.get(sid)
+            if (last_rec.source_type or "") in HUMAN_SOURCE_TYPES or (last_rec.sender_id or "").startswith("hu_"):
+                last_sender = (
+                    user_sender_names.get(last_rec.source_user_id)
+                    if last_rec.source_user_id else None
+                ) or user_sender_names.get(sid) or "User"
+            else:
+                last_sender = sender_names.get(sid)
 
         role_val = memberships.get(rid)
         my_role = role_val.value if hasattr(role_val, "value") else str(role_val) if role_val else "member"

--- a/backend/app/routers/humans.py
+++ b/backend/app/routers/humans.py
@@ -1047,6 +1047,17 @@ async def create_room_share_as_human(
 
     for rec in records:
         parsed = _extract_text_from_envelope(rec.envelope_json)
+        if rec.recalled_at is not None:
+            parsed = {
+                "type": parsed["type"] or "message",
+                "text": "",
+                "payload": {
+                    "recalled": True,
+                    "is_recalled": True,
+                    "recalled_at": rec.recalled_at.isoformat(),
+                    "recalled_by_id": rec.recalled_by_id,
+                },
+            }
         sender_name = rec.sender_id
         if (rec.source_type or "") == "dashboard_human_room" and rec.source_user_id:
             if rec.sender_id not in human_name_cache:

--- a/backend/app/routers/public.py
+++ b/backend/app/routers/public.py
@@ -149,7 +149,7 @@ async def _get_public_room_previews(
             if rec.room_id:
                 parsed = extract_text_from_envelope(rec.envelope_json)
                 last_msg_map[rec.room_id] = {
-                    "last_message_preview": parsed["text"],
+                    "last_message_preview": "Message recalled" if rec.recalled_at else parsed["text"],
                     "last_message_at": rec.created_at.isoformat() if rec.created_at else None,
                     "last_sender_id": parsed["sender_id"],
                 }
@@ -401,13 +401,22 @@ async def get_public_room_messages(
     messages = []
     for rec in records:
         parsed = extract_text_from_envelope(rec.envelope_json)
+        is_recalled = rec.recalled_at is not None
         messages.append({
             "msg_id": rec.msg_id,
             "sender_id": rec.sender_id,
             "sender_display_name": sender_names.get(rec.sender_id),
             "sender_avatar_url": sender_avatars.get(rec.sender_id),
-            "text": parsed["text"],
+            "text": "" if is_recalled else parsed["text"],
             "type": parsed["type"],
+            "payload": {
+                "recalled": True,
+                "recalled_at": rec.recalled_at.isoformat() if rec.recalled_at else None,
+                "recalled_by_id": rec.recalled_by_id,
+            } if is_recalled else parsed["payload"],
+            "is_recalled": is_recalled,
+            "recalled_at": rec.recalled_at.isoformat() if rec.recalled_at else None,
+            "recalled_by_id": rec.recalled_by_id,
             "topic": rec.topic,
             "topic_id": rec.topic_id,
             "topic_title": topic_info.get(rec.topic_id, {}).get("title") if rec.topic_id else None,
@@ -468,6 +477,8 @@ async def get_subscription_room_message_previews(
 
     previews = []
     for rec in records:
+        if rec.recalled_at is not None:
+            continue
         parsed = extract_text_from_envelope(rec.envelope_json)
         preview = _compact_preview_text(parsed["text"])
         if not preview:

--- a/backend/app/routers/share.py
+++ b/backend/app/routers/share.py
@@ -74,6 +74,7 @@ async def get_share(
                 payload = json.loads(sm.payload_json)
             except (json.JSONDecodeError, TypeError):
                 pass
+        is_recalled = bool(payload.get("is_recalled") or payload.get("recalled"))
 
         messages.append({
             "hub_msg_id": sm.hub_msg_id,
@@ -81,8 +82,11 @@ async def get_share(
             "sender_id": sm.sender_id,
             "sender_name": sm.sender_name,
             "type": sm.type,
-            "text": sm.text or "",
+            "text": "" if is_recalled else sm.text or "",
             "payload": payload,
+            "is_recalled": is_recalled,
+            "recalled_at": payload.get("recalled_at") if is_recalled else None,
+            "recalled_by_id": payload.get("recalled_by_id") if is_recalled else None,
             "created_at": sm.created_at.isoformat() if sm.created_at else None,
         })
 

--- a/backend/hub/dashboard_schemas.py
+++ b/backend/hub/dashboard_schemas.py
@@ -79,6 +79,9 @@ class DashboardMessage(BaseModel):
     state: str
     state_counts: dict[str, int] | None = None
     created_at: datetime.datetime
+    is_recalled: bool = False
+    recalled_at: datetime.datetime | None = None
+    recalled_by_id: str | None = None
     source_type: str = "agent"
     sender_kind: str = "agent"
     display_sender_name: str = ""

--- a/backend/hub/expiry.py
+++ b/backend/hub/expiry.py
@@ -126,6 +126,7 @@ async def _expire_batch() -> None:
             select(MessageRecord)
             .where(
                 MessageRecord.state == MessageState.queued,
+                MessageRecord.recalled_at.is_(None),
                 expired_cond.bindparams(now_ts=now_epoch),
             )
             .order_by(MessageRecord.created_at.asc())

--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -571,6 +571,13 @@ class MessageRecord(Base):
     acked_at: Mapped[datetime.datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    recalled_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    recalled_by_id: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    recalled_by_type: Mapped[ParticipantType | None] = mapped_column(
+        Enum(ParticipantType, name="participanttype"), nullable=True
+    )
     mentioned: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     source_type: Mapped[str] = mapped_column(
         String(32), nullable=False, default="agent", server_default="agent"

--- a/backend/hub/retry.py
+++ b/backend/hub/retry.py
@@ -223,6 +223,7 @@ async def _retry_batch(http_client: httpx.AsyncClient) -> None:
             .where(
                 MessageRecord.state == MessageState.queued,
                 MessageRecord.next_retry_at <= now,
+                MessageRecord.recalled_at.is_(None),
             )
             .limit(50)
         )

--- a/backend/hub/routers/dashboard.py
+++ b/backend/hub/routers/dashboard.py
@@ -97,6 +97,46 @@ def _extract_text_from_envelope(envelope_data: dict) -> tuple[str, str, dict]:
                 text = str(text)
     return sender_id, text, payload
 
+
+_RECALLED_MESSAGE_PREVIEW = "Message recalled"
+
+
+def _recalled_message_fields(rec: MessageRecord) -> dict:
+    return {
+        "is_recalled": rec.recalled_at is not None,
+        "recalled_at": rec.recalled_at,
+        "recalled_by_id": rec.recalled_by_id,
+    }
+
+
+def _display_content_for_record(
+    rec: MessageRecord,
+    text: str,
+    payload: dict,
+    msg_type: str,
+) -> tuple[str, dict, str]:
+    if rec.recalled_at is None:
+        return text, payload, msg_type
+    return (
+        "",
+        {
+            "recalled": True,
+            "recalled_at": rec.recalled_at.isoformat() if rec.recalled_at else None,
+            "recalled_by_id": rec.recalled_by_id,
+        },
+        msg_type or "message",
+    )
+
+
+def _preview_for_record(rec: MessageRecord) -> tuple[str, str | None, str]:
+    envelope_data = json.loads(rec.envelope_json)
+    sender_id, text, _ = _extract_text_from_envelope(envelope_data)
+    msg_type = envelope_data.get("type", "message")
+    if rec.recalled_at is not None:
+        return sender_id or rec.sender_id, _RECALLED_MESSAGE_PREVIEW, msg_type
+    return sender_id, text[:200] if text else None, msg_type
+
+
 async def _build_dashboard_rooms(
     room_ids: list[str],
     current_agent: str,
@@ -226,9 +266,7 @@ async def _build_dashboard_rooms(
         last_at = None
         last_sender: str | None = None
         if last_rec:
-            envelope_data = json.loads(last_rec.envelope_json)
-            sid, text, _ = _extract_text_from_envelope(envelope_data)
-            last_preview = text[:200] if text else None
+            sid, last_preview, _ = _preview_for_record(last_rec)
             last_at = last_rec.created_at
             if last_at is not None and last_at.tzinfo is None:
                 last_at = last_at.replace(tzinfo=datetime.timezone.utc)
@@ -490,6 +528,9 @@ async def get_room_messages(
         envelope_data = json.loads(rec.envelope_json)
         sid, text, payload = _extract_text_from_envelope(envelope_data)
         msg_type = envelope_data.get("type", "message")
+        display_text, display_payload, display_type = _display_content_for_record(
+            rec, text, payload, msg_type
+        )
 
         ca = rec.created_at
         if ca is not None and ca.tzinfo is None:
@@ -512,9 +553,9 @@ async def get_room_messages(
                 msg_id=rec.msg_id,
                 sender_id=sid,
                 sender_name=sender_names.get(sid, sid),
-                type=msg_type,
-                text=text,
-                payload=payload,
+                type=display_type,
+                text=display_text,
+                payload=display_payload,
                 room_id=rec.room_id,
                 topic=rec.topic,
                 topic_id=rec.topic_id,
@@ -523,6 +564,7 @@ async def get_room_messages(
                 state_counts=counts,
                 created_at=ca,
                 source_type=rec.source_type,
+                **_recalled_message_fields(rec),
                 **extra,
             )
         )
@@ -737,6 +779,9 @@ async def create_share(
         envelope_data = json.loads(rec.envelope_json)
         sid, text, payload = _extract_text_from_envelope(envelope_data)
         msg_type = envelope_data.get("type", "message")
+        display_text, display_payload, display_type = _display_content_for_record(
+            rec, text, payload, msg_type
+        )
 
         ca = rec.created_at
         if ca is not None and ca.tzinfo is None:
@@ -748,9 +793,9 @@ async def create_share(
             msg_id=rec.msg_id,
             sender_id=sid,
             sender_name=sender_names.get(sid, sid),
-            type=msg_type,
-            text=text,
-            payload_json=json.dumps(payload),
+            type=display_type,
+            text=display_text,
+            payload_json=json.dumps(display_payload),
             created_at=ca,
         ))
 

--- a/backend/hub/routers/hub.py
+++ b/backend/hub/routers/hub.py
@@ -1876,6 +1876,7 @@ async def _fetch_queued_messages(
         .where(
             MessageRecord.receiver_id == agent_id,
             MessageRecord.state == MessageState.queued,
+            MessageRecord.recalled_at.is_(None),
         )
         .order_by(MessageRecord.created_at.asc())
         .limit(limit)

--- a/backend/hub/routers/hub.py
+++ b/backend/hub/routers/hub.py
@@ -961,6 +961,9 @@ async def _load_reply_previews(
         if target is None:
             previews[reply_id] = ReplyPreview(msg_id=reply_id, deleted=True)
             continue
+        if target.recalled_at is not None:
+            previews[reply_id] = ReplyPreview(msg_id=reply_id, deleted=True)
+            continue
         raw_text = _extract_envelope_text(target.envelope_json)
         preview_text = raw_text[:_REPLY_PREVIEW_MAX_CHARS] if raw_text else None
         previews[reply_id] = ReplyPreview(
@@ -2134,6 +2137,7 @@ async def query_history(
             .where(
                 MessageRecord.room_id == room_id,
                 MessageRecord.state != MessageState.failed,
+                MessageRecord.recalled_at.is_(None),
             )
             .group_by(MessageRecord.msg_id)
             .subquery()
@@ -2149,6 +2153,7 @@ async def query_history(
                 MessageRecord.receiver_id == current_agent,
             ),
             MessageRecord.state != MessageState.failed,
+            MessageRecord.recalled_at.is_(None),
         )
         if room_id is not None:
             stmt = stmt.where(MessageRecord.room_id == room_id)

--- a/backend/hub/routers/public.py
+++ b/backend/hub/routers/public.py
@@ -28,7 +28,13 @@ from hub.models import (
     SubscriptionProduct,
     User,
 )
-from hub.routers.dashboard import _extract_text_from_envelope, get_platform_stats
+from hub.routers.dashboard import (
+    _display_content_for_record,
+    _extract_text_from_envelope,
+    _preview_for_record,
+    _recalled_message_fields,
+    get_platform_stats,
+)
 from hub.routers.hub import is_agent_ws_online
 
 from pydantic import BaseModel
@@ -184,9 +190,7 @@ async def _build_public_rooms(
         last_sender: str | None = None
         # Hide message preview for subscription-gated rooms
         if last_rec and not is_gated:
-            envelope_data = json.loads(last_rec.envelope_json)
-            sid, text, _ = _extract_text_from_envelope(envelope_data)
-            last_preview = text[:200] if text else None
+            sid, last_preview, _ = _preview_for_record(last_rec)
             last_at = _ensure_utc(last_rec.created_at)
             last_sender = sender_names.get(sid)
 
@@ -436,6 +440,9 @@ async def public_room_messages(
         envelope_data = json.loads(rec.envelope_json)
         sid, text, payload = _extract_text_from_envelope(envelope_data)
         msg_type = envelope_data.get("type", "message")
+        display_text, display_payload, display_type = _display_content_for_record(
+            rec, text, payload, msg_type
+        )
 
         messages.append(
             DashboardMessage(
@@ -443,15 +450,16 @@ async def public_room_messages(
                 msg_id=rec.msg_id,
                 sender_id=sid,
                 sender_name=sender_names.get(sid, sid),
-                type=msg_type,
-                text=text,
-                payload=payload,
+                type=display_type,
+                text=display_text,
+                payload=display_payload,
                 room_id=rec.room_id,
                 topic=rec.topic,
                 topic_id=rec.topic_id,
                 state=rec.state.value,
                 created_at=_ensure_utc(rec.created_at),
                 sender_avatar_url=sender_avatars.get(sid),
+                **_recalled_message_fields(rec),
             )
         )
 

--- a/backend/hub/routers/registry.py
+++ b/backend/hub/routers/registry.py
@@ -205,6 +205,7 @@ async def register_endpoint(
                 select(MessageRecord).where(
                     MessageRecord.receiver_id == agent_id,
                     MessageRecord.state == MessageState.queued,
+                    MessageRecord.recalled_at.is_(None),
                     MessageRecord.last_error == "ENDPOINT_UNREACHABLE",
                     MessageRecord.next_retry_at.is_(None),
                 )
@@ -331,6 +332,7 @@ async def endpoint_status(
         select(func.count(MessageRecord.id)).where(
             MessageRecord.receiver_id == agent_id,
             MessageRecord.state == MessageState.queued,
+            MessageRecord.recalled_at.is_(None),
         )
     )
     queued_count = queued_result.scalar() or 0

--- a/backend/hub/routers/room_context.py
+++ b/backend/hub/routers/room_context.py
@@ -105,7 +105,11 @@ def _dedup_subquery(room_ids: str | list[str]):
         where = MessageRecord.room_id.in_(room_ids)
     return (
         select(func.min(MessageRecord.id).label("min_id"))
-        .where(where, MessageRecord.state != MessageState.failed)
+        .where(
+            where,
+            MessageRecord.state != MessageState.failed,
+            MessageRecord.recalled_at.is_(None),
+        )
         .group_by(MessageRecord.msg_id)
         .subquery()
     )
@@ -323,6 +327,7 @@ async def rooms_overview(
         .where(
             MessageRecord.room_id.in_(my_room_ids),
             MessageRecord.state != MessageState.failed,
+            MessageRecord.recalled_at.is_(None),
             MessageRecord.created_at >= cutoff_24h,
         )
         .group_by(MessageRecord.room_id, MessageRecord.msg_id)
@@ -352,6 +357,7 @@ async def rooms_overview(
         .where(
             MessageRecord.room_id.in_(my_room_ids),
             MessageRecord.state != MessageState.failed,
+            MessageRecord.recalled_at.is_(None),
         )
         .group_by(MessageRecord.room_id, MessageRecord.msg_id)
         .subquery()
@@ -478,6 +484,7 @@ async def room_summary(
         .where(
             MessageRecord.room_id == room_id,
             MessageRecord.state != MessageState.failed,
+            MessageRecord.recalled_at.is_(None),
             MessageRecord.created_at >= cutoff_24h,
         )
         .group_by(MessageRecord.msg_id)
@@ -492,6 +499,7 @@ async def room_summary(
         .where(
             MessageRecord.room_id == room_id,
             MessageRecord.state != MessageState.failed,
+            MessageRecord.recalled_at.is_(None),
             MessageRecord.created_at >= cutoff_24h,
         )
         .group_by(MessageRecord.sender_id)

--- a/backend/hub/schemas.py
+++ b/backend/hub/schemas.py
@@ -654,6 +654,9 @@ class DashboardMessage(BaseModel):
     state: str
     state_counts: dict[str, int] | None = None
     created_at: datetime.datetime
+    is_recalled: bool = False
+    recalled_at: datetime.datetime | None = None
+    recalled_by_id: str | None = None
 
 
 class DashboardMessageResponse(BaseModel):

--- a/backend/migrations/022_message_recall.sql
+++ b/backend/migrations/022_message_recall.sql
@@ -1,0 +1,15 @@
+-- Dashboard message recall: keep logical messages in place while redacting
+-- sender-authored content after a recall.
+
+ALTER TABLE message_records
+    ADD COLUMN IF NOT EXISTS recalled_at TIMESTAMPTZ;
+
+ALTER TABLE message_records
+    ADD COLUMN IF NOT EXISTS recalled_by_id VARCHAR(32);
+
+ALTER TABLE message_records
+    ADD COLUMN IF NOT EXISTS recalled_by_type participanttype;
+
+CREATE INDEX IF NOT EXISTS ix_message_records_room_msg_recalled
+    ON message_records (room_id, msg_id, recalled_at)
+    WHERE recalled_at IS NOT NULL;

--- a/backend/tests/test_app/test_app_activity_stats.py
+++ b/backend/tests/test_app/test_app_activity_stats.py
@@ -242,3 +242,40 @@ async def test_activity_stats_batch_rejects_unowned_agent(client: AsyncClient, s
 
     assert resp.status_code == 403
     assert resp.json()["detail"] == "Agent not owned by user"
+
+
+@pytest.mark.asyncio
+async def test_activity_feed_redacts_recalled_preview(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    seed_activity: dict,
+):
+    now = datetime.datetime.now(datetime.timezone.utc)
+    db_session.add(
+        MessageRecord(
+            hub_msg_id="h_stats_recalled",
+            msg_id="m_stats_recalled",
+            sender_id="ag_stats001",
+            receiver_id="ag_stats002",
+            room_id="rm_stats_main",
+            state=MessageState.done,
+            envelope_json=json.dumps({"payload": {"text": "secret activity preview"}}),
+            ttl_sec=3600,
+            created_at=now,
+            recalled_at=now,
+        )
+    )
+    await db_session.commit()
+
+    resp = await client.get(
+        "/api/dashboard/activity/feed?period=7d",
+        headers={
+            "Authorization": f"Bearer {seed_activity['token']}",
+            "X-Active-Agent": "ag_stats001",
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    previews = [event.get("preview") for event in resp.json()["items"]]
+    assert "secret activity preview" not in previews
+    assert "Message recalled" in previews

--- a/backend/tests/test_app/test_app_dashboard.py
+++ b/backend/tests/test_app/test_app_dashboard.py
@@ -20,6 +20,7 @@ from hub.models import (
     ContactRequest,
     ContactRequestState,
     MessageRecord,
+    MessageState,
     MessagePolicy,
     Role,
     Room,
@@ -346,6 +347,121 @@ async def test_dashboard_overview_includes_members_preview_for_group_room(
         {"agent_id": "ag_groupmate01", "avatar_url": None, "display_name": "Group Mate"},
         {"agent_id": None, "avatar_url": "https://example.test/human.png", "display_name": "Human Mate"},
     ]
+
+
+@pytest.mark.asyncio
+async def test_dashboard_owner_can_recall_any_room_message(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    seed_data: dict,
+):
+    old_created_at = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=1)
+    db_session.add_all([
+        MessageRecord(
+            hub_msg_id="hm_recall_owner_a",
+            msg_id="msg_recall_owner",
+            sender_id="ag_other00001",
+            receiver_id="ag_dashtest001",
+            room_id="rm_testroom001",
+            envelope_json='{"from":"ag_other00001","type":"message","payload":{"text":"remove me","attachments":[{"filename":"secret.txt","url":"https://example.test/secret.txt"}]}}',
+            state=MessageState.queued,
+            ttl_sec=3600,
+            created_at=old_created_at,
+        ),
+        MessageRecord(
+            hub_msg_id="hm_recall_owner_b",
+            msg_id="msg_recall_owner",
+            sender_id="ag_other00001",
+            receiver_id="ag_other00001",
+            room_id="rm_testroom001",
+            envelope_json='{"from":"ag_other00001","type":"message","payload":{"text":"remove me","attachments":[{"filename":"secret.txt","url":"https://example.test/secret.txt"}]}}',
+            state=MessageState.queued,
+            ttl_sec=3600,
+            created_at=old_created_at,
+        ),
+    ])
+    await db_session.commit()
+
+    headers = {
+        "Authorization": f"Bearer {seed_data['token']}",
+        "X-Active-Agent": "ag_dashtest001",
+    }
+    resp = await client.post(
+        "/api/dashboard/rooms/rm_testroom001/messages/msg_recall_owner/recall",
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["is_recalled"] is True
+    assert data["recalled_by_id"] == "ag_dashtest001"
+
+    rows = (
+        await db_session.execute(
+            select(MessageRecord).where(MessageRecord.msg_id == "msg_recall_owner")
+        )
+    ).scalars().all()
+    assert len(rows) == 2
+    assert all(row.recalled_at is not None for row in rows)
+    assert all(row.recalled_by_id == "ag_dashtest001" for row in rows)
+
+    messages_resp = await client.get(
+        "/api/dashboard/rooms/rm_testroom001/messages",
+        headers=headers,
+    )
+    assert messages_resp.status_code == 200, messages_resp.text
+    recalled = next(
+        message for message in messages_resp.json()["messages"]
+        if message["msg_id"] == "msg_recall_owner"
+    )
+    assert recalled["is_recalled"] is True
+    assert recalled["text"] == ""
+    assert recalled["payload"]["recalled"] is True
+    assert "attachments" not in recalled["payload"]
+
+
+@pytest.mark.asyncio
+async def test_dashboard_member_recall_respects_two_minute_window(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    seed_data: dict,
+):
+    room = Room(
+        room_id="rm_member_recall",
+        name="Member Recall",
+        description="",
+        owner_id="ag_other00001",
+        visibility=RoomVisibility.private,
+        join_policy=RoomJoinPolicy.invite_only,
+    )
+    db_session.add(room)
+    db_session.add(RoomMember(
+        room_id="rm_member_recall",
+        agent_id="ag_dashtest001",
+        participant_type=ParticipantType.agent,
+        role=RoomRole.member,
+    ))
+    db_session.add(MessageRecord(
+        hub_msg_id="hm_recall_old",
+        msg_id="msg_recall_old",
+        sender_id="ag_dashtest001",
+        receiver_id="ag_dashtest001",
+        room_id="rm_member_recall",
+        envelope_json='{"from":"ag_dashtest001","type":"message","payload":{"text":"too old"}}',
+        state=MessageState.queued,
+        ttl_sec=3600,
+        created_at=datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(minutes=3),
+    ))
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/dashboard/rooms/rm_member_recall/messages/msg_recall_old/recall",
+        headers={
+            "Authorization": f"Bearer {seed_data['token']}",
+            "X-Active-Agent": "ag_dashtest001",
+        },
+    )
+    assert resp.status_code == 403
+    assert "recall window" in resp.text
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_app/test_app_humans.py
+++ b/backend/tests/test_app/test_app_humans.py
@@ -759,6 +759,95 @@ async def test_sql_room_preview_nulls_are_filled_from_orm_fallback(
     assert rooms[0]["last_sender_name"] == "Preview Fill Bot"
 
 
+@pytest.mark.asyncio
+async def test_sql_room_preview_human_sender_name_is_filled_from_orm_fallback(
+    seed, db_session: AsyncSession, monkeypatch
+):
+    from app.routers.dashboard import _build_rooms_from_sql
+
+    agent = Agent(
+        agent_id="ag_previewhuman1",
+        display_name="Preview Human Bot",
+        message_policy=MessagePolicy.open,
+        user_id=seed["user_id"],
+    )
+    room = Room(
+        room_id="rm_previewhuman1",
+        name="Preview Human",
+        description="Preview human fallback",
+        owner_id="ag_previewhuman1",
+        owner_type=ParticipantType.agent,
+        visibility=RoomVisibility.private,
+        join_policy=RoomJoinPolicy.invite_only,
+    )
+    db_session.add_all([
+        agent,
+        room,
+        RoomMember(
+            room_id="rm_previewhuman1",
+            agent_id="ag_previewhuman1",
+            participant_type=ParticipantType.agent,
+            role=RoomRole.owner,
+        ),
+        RoomMember(
+            room_id="rm_previewhuman1",
+            agent_id=seed["human_id"],
+            participant_type=ParticipantType.human,
+            role=RoomRole.member,
+        ),
+        MessageRecord(
+            hub_msg_id="hm_previewhuman1",
+            msg_id="msg_previewhuman1",
+            sender_id=seed["human_id"],
+            receiver_id="ag_previewhuman1",
+            room_id="rm_previewhuman1",
+            envelope_json=json.dumps({
+                "from": seed["human_id"],
+                "type": "message",
+                "payload": {"text": "human fallback text"},
+            }),
+            state=MessageState.delivered,
+            ttl_sec=3600,
+            source_type="dashboard_human_room",
+            source_user_id=str(seed["user_id"]),
+        ),
+    ])
+    await db_session.commit()
+
+    real_execute = db_session.execute
+
+    class _MappingsResult:
+        def mappings(self):
+            return self
+
+        def all(self):
+            return [{
+                "room_id": "rm_previewhuman1",
+                "room_name": "Preview Human",
+                "room_description": "Preview human fallback",
+                "owner_id": "ag_previewhuman1",
+                "visibility": "private",
+                "member_count": 2,
+                "my_role": "owner",
+                "last_message_preview": "stale sql preview",
+                "last_message_at": None,
+                "last_sender_name": "stale sql sender",
+            }]
+
+    async def execute_with_stale_sql_preview(statement, *args, **kwargs):
+        if isinstance(statement, TextClause) and "get_agent_room_previews" in str(statement):
+            return _MappingsResult()
+        return await real_execute(statement, *args, **kwargs)
+
+    monkeypatch.setattr(db_session, "execute", execute_with_stale_sql_preview)
+
+    rooms = await _build_rooms_from_sql("ag_previewhuman1", db_session)
+    assert rooms[0]["room_id"] == "rm_previewhuman1"
+    assert rooms[0]["last_message_preview"] == "human fallback text"
+    assert rooms[0]["last_message_at"] is not None
+    assert rooms[0]["last_sender_name"] == "Alice"
+
+
 # ---------------------------------------------------------------------------
 # Contact request → Agent (claimed)
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_quote_reply.py
+++ b/backend/tests/test_quote_reply.py
@@ -8,6 +8,7 @@ Covers:
 """
 
 import base64
+import datetime
 import hashlib
 import json
 import time
@@ -407,3 +408,47 @@ async def test_history_deleted_target_renders_tombstone(
     assert rp["deleted"] is True
     assert rp["text_preview"] is None
     assert rp["sender_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_history_recalled_message_is_omitted_and_reply_preview_tombstoned(
+    client: AsyncClient,
+    db_session: AsyncSession,
+):
+    sk_a, a_id, a_key, a_tok = await _create_agent(client, "alice")
+    sk_b, b_id, b_key, b_tok = await _create_agent(client, "bob")
+    room_id = await _create_room(client, a_tok, [b_id])
+
+    _, orig_msg_id = await _send_room(
+        client, sk_a, a_key, a_id, room_id, a_tok, text="secret original text"
+    )
+    _, reply_msg_id = await _send_room(
+        client, sk_b, b_key, b_id, room_id, b_tok, reply_to=orig_msg_id, text="reply",
+    )
+
+    recalled_rows = (
+        await db_session.execute(
+            select(MessageRecord).where(MessageRecord.msg_id == orig_msg_id)
+        )
+    ).scalars().all()
+    assert recalled_rows
+    recalled_at = datetime.datetime.now(datetime.timezone.utc)
+    for row in recalled_rows:
+        row.recalled_at = recalled_at
+    await db_session.commit()
+
+    resp = await client.get(
+        f"/hub/history?room_id={room_id}", headers=_auth(a_tok),
+    )
+    assert resp.status_code == 200, resp.text
+    msgs = resp.json()["messages"]
+    assert all(m["envelope"]["msg_id"] != orig_msg_id for m in msgs)
+    assert "secret original text" not in json.dumps(msgs)
+
+    reply_rows = [m for m in msgs if m["envelope"]["msg_id"] == reply_msg_id]
+    assert reply_rows
+    rp = reply_rows[0]["reply_preview"]
+    assert rp is not None
+    assert rp["msg_id"] == orig_msg_id
+    assert rp["deleted"] is True
+    assert rp["text_preview"] is None

--- a/backend/tests/test_room_context.py
+++ b/backend/tests/test_room_context.py
@@ -1,6 +1,7 @@
 """Tests for room context endpoints (summary, messages, search, overview, global search)."""
 
 import base64
+import datetime
 import hashlib
 import time
 import uuid
@@ -15,7 +16,7 @@ from unittest.mock import AsyncMock
 
 from sqlalchemy import select
 
-from hub.models import Base
+from hub.models import Base, MessageRecord
 
 TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
 
@@ -289,6 +290,61 @@ async def test_room_messages_with_messages(client: AsyncClient, db_session: Asyn
     assert len(data["messages"]) == 3
     # Newest first
     assert "message 2" in data["messages"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_room_context_filters_recalled_records(
+    client: AsyncClient,
+    db_session: AsyncSession,
+):
+    """Agent-facing context endpoints should not return recalled message text."""
+    sk, agent_id, key_id, token = await _create_agent(client, "owner", db_session)
+    room = await _create_room(client, token, "Recall Context Room")
+    room_id = room["room_id"]
+
+    visible_resp = await _send_msg_with_token(
+        client, sk, key_id, agent_id, room_id, token, text="visible context"
+    )
+    assert visible_resp.status_code == 202
+    secret_resp = await _send_msg_with_token(
+        client, sk, key_id, agent_id, room_id, token, text="secret recalled context"
+    )
+    assert secret_resp.status_code == 202
+
+    secret_rows = (
+        await db_session.execute(
+            select(MessageRecord).where(MessageRecord.hub_msg_id == secret_resp.json()["hub_msg_id"])
+        )
+    ).scalars().all()
+    assert secret_rows
+    recalled_at = datetime.datetime.now(datetime.timezone.utc)
+    for row in secret_rows:
+        row.recalled_at = recalled_at
+    await db_session.commit()
+
+    messages_resp = await client.get(f"/hub/rooms/{room_id}/messages", headers=_auth_header(token))
+    assert messages_resp.status_code == 200, messages_resp.text
+    messages_payload = messages_resp.json()
+    assert [message["text"] for message in messages_payload["messages"]] == ["visible context"]
+
+    search_resp = await client.get(
+        f"/hub/rooms/{room_id}/search?q=secret",
+        headers=_auth_header(token),
+    )
+    assert search_resp.status_code == 200, search_resp.text
+    assert search_resp.json()["results"] == []
+
+    summary_resp = await client.get(f"/hub/rooms/{room_id}/summary", headers=_auth_header(token))
+    assert summary_resp.status_code == 200, summary_resp.text
+    summary = summary_resp.json()
+    assert summary["stats"]["total_messages"] == 1
+    assert [message["text"] for message in summary["recent_messages"]] == ["visible context"]
+
+    overview_resp = await client.get("/hub/rooms/overview", headers=_auth_header(token))
+    assert overview_resp.status_code == 200, overview_resp.text
+    overview_room = overview_resp.json()["rooms"][0]
+    assert overview_room["message_count_24h"] == 1
+    assert overview_room["latest_message_preview"] == "visible context"
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/dashboard/MessageBubble.tsx
+++ b/frontend/src/components/dashboard/MessageBubble.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useLayoutEffect, useRef, useState } from "react";
 import type { KeyboardEvent, ReactNode } from "react";
 import { createPortal } from "react-dom";
-import { AlertTriangle, Bot, Check, ChevronDown, ChevronUp, Copy, CornerUpLeft, Forward, MoreHorizontal, User } from "lucide-react";
+import { AlertTriangle, Bot, Check, ChevronDown, ChevronUp, Copy, CornerUpLeft, Forward, MoreHorizontal, RotateCcw, User } from "lucide-react";
 import ForwardModal from "./ForwardModal";
 import ReplyQuoteBlock from "./ReplyQuoteBlock";
 import { emitJumpToMessage } from "./messageNavigation";
@@ -11,6 +11,7 @@ import RuntimeErrorDetailsDialog from "./RuntimeErrorDetailsDialog";
 import type { DashboardMessage, Attachment } from "@/lib/types";
 import { useLanguage } from '@/lib/i18n';
 import { messageBubble } from '@/lib/i18n/translations/dashboard';
+import { isDashboardMessageRecalled, recalledMessageLabel } from "@/lib/message-recall";
 import AttachmentItem from "@/components/ui/AttachmentItem";
 import CopyableId from "@/components/ui/CopyableId";
 import MarkdownContent from "@/components/ui/MarkdownContent";
@@ -352,8 +353,11 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
   const [copied, setCopied] = useState(false);
   const [forwardQuote, setForwardQuote] = useState<string | null>(null);
   const [showErrorDetails, setShowErrorDetails] = useState(false);
+  const [recallPending, setRecallPending] = useState(false);
   const locale = useLanguage();
   const selectAgent = useDashboardChatStore((state) => state.selectAgent);
+  const getRoomSummary = useDashboardChatStore((state) => state.getRoomSummary);
+  const recallMessage = useDashboardChatStore((state) => state.recallMessage);
   const overview = useDashboardChatStore((state) => state.overview);
   const publicAgents = useDashboardChatStore((state) => state.publicAgents);
   const publicHumans = useDashboardChatStore((state) => state.publicHumans);
@@ -376,6 +380,7 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
   const errorCode = typeof errorPayload?.code === "string" ? errorPayload.code : null;
   const textContent = message.payload?.text || message.payload?.body || message.payload?.message;
   const displayText = typeof textContent === "string" ? textContent : message.text || errorMessage;
+  const isRecalled = isDashboardMessageRecalled(message);
   const isErrorMessage = message.type === "error";
   const errorTitle = locale === "zh" ? "运行错误" : "Runtime error";
   const errorDetailsLabel = locale === "zh" ? "详情" : "Details";
@@ -470,12 +475,39 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
     message.type === "message"
     && Boolean(message.room_id)
     && Boolean(message.msg_id)
-    && !message.hub_msg_id?.startsWith("tmp_");
+    && !message.hub_msg_id?.startsWith("tmp_")
+    && !isRecalled;
+
+  const roomSummary = message.room_id ? getRoomSummary(message.room_id) : null;
+  const canAdminRecall = roomSummary?.my_role === "owner" || roomSummary?.my_role === "admin";
+  const canRecall =
+    message.type === "message"
+    && Boolean(message.room_id)
+    && Boolean(message.msg_id)
+    && !message.room_id?.startsWith("rm_oc_")
+    && !message.hub_msg_id?.startsWith("tmp_")
+    && !isRecalled
+    && (isOwn || canAdminRecall);
 
   const handleReplyClick = () => {
     setMenuOpen(false);
     if (!canQuoteReply || !message.room_id) return;
     setReplyingTo(message.room_id, message);
+  };
+
+  const handleRecallClick = async () => {
+    setMenuOpen(false);
+    if (!canRecall || !message.room_id) return;
+    const ok = window.confirm(locale === "zh" ? "撤回这条消息？" : "Recall this message?");
+    if (!ok) return;
+    setRecallPending(true);
+    try {
+      await recallMessage(message.room_id, message.msg_id);
+    } catch {
+      /* error toast is handled by the chat store */
+    } finally {
+      setRecallPending(false);
+    }
   };
 
   const handleJumpToReplyTarget = (targetMsgId: string) => {
@@ -504,7 +536,7 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
     />
   );
 
-  const moreButton = displayText && (
+  const moreButton = !isRecalled && (displayText || canRecall) && (
     <div className="relative self-start pt-1 shrink-0">
       <button
         type="button"
@@ -526,26 +558,41 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
               引用回复
             </button>
           )}
-          <button
-            type="button"
-            onMouseDown={(e) => { e.preventDefault(); handleForwardClick(); }}
-            className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100 transition-colors"
-          >
-            <Forward className="h-3.5 w-3.5 text-zinc-500" />
-            转发
-          </button>
-          <button
-            type="button"
-            onMouseDown={(e) => { e.preventDefault(); void handleCopyClick(); }}
-            className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100 transition-colors"
-          >
-            {copied ? (
-              <Check className="h-3.5 w-3.5 text-emerald-400" />
-            ) : (
-              <Copy className="h-3.5 w-3.5 text-zinc-500" />
-            )}
-            {copied ? "已复制" : "复制"}
-          </button>
+          {displayText && (
+            <button
+              type="button"
+              onMouseDown={(e) => { e.preventDefault(); handleForwardClick(); }}
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100 transition-colors"
+            >
+              <Forward className="h-3.5 w-3.5 text-zinc-500" />
+              转发
+            </button>
+          )}
+          {canRecall && (
+            <button
+              type="button"
+              disabled={recallPending}
+              onMouseDown={(e) => { e.preventDefault(); void handleRecallClick(); }}
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100 disabled:cursor-not-allowed disabled:opacity-60 transition-colors"
+            >
+              <RotateCcw className="h-3.5 w-3.5 text-zinc-500" />
+              {locale === "zh" ? "撤回" : "Recall"}
+            </button>
+          )}
+          {displayText && (
+            <button
+              type="button"
+              onMouseDown={(e) => { e.preventDefault(); void handleCopyClick(); }}
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100 transition-colors"
+            >
+              {copied ? (
+                <Check className="h-3.5 w-3.5 text-emerald-400" />
+              ) : (
+                <Copy className="h-3.5 w-3.5 text-zinc-500" />
+              )}
+              {copied ? "已复制" : "复制"}
+            </button>
+          )}
         </div>
       )}
     </div>
@@ -600,19 +647,23 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
         </div>
 
         {/* Quote-reply preview */}
-        {message.reply_preview && (
+        {!isRecalled && message.reply_preview && (
           <ReplyQuoteBlock preview={message.reply_preview} onJump={handleJumpToReplyTarget} />
         )}
 
         {/* Goal badge */}
-        {message.goal && (
+        {!isRecalled && message.goal && (
           <div className="mb-1.5 flex items-start gap-1.5 rounded-lg border border-neon-purple/20 bg-neon-purple/5 px-2 py-1.5">
             <span className="mt-px text-xs text-neon-purple/70">🎯</span>
             <span className="text-xs leading-relaxed text-neon-purple/90">{message.goal}</span>
           </div>
         )}
 
-        {isErrorMessage ? (
+        {isRecalled ? (
+          <p className="mt-1 text-sm italic text-text-secondary/70">
+            {recalledMessageLabel(locale)}
+          </p>
+        ) : isErrorMessage ? (
           <button
             type="button"
             onClick={(event) => {
@@ -657,7 +708,7 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
           )
         )}
 
-        {attachments.length > 0 && (
+        {!isRecalled && attachments.length > 0 && (
           <div className="mt-1.5 flex flex-col gap-1.5">
             {attachments.map((att, i) => (
               <AttachmentItem key={`${att.filename}-${i}`} attachment={att} />

--- a/frontend/src/components/dashboard/MessageList.tsx
+++ b/frontend/src/components/dashboard/MessageList.tsx
@@ -10,6 +10,7 @@
 import { useEffect, useRef, useCallback, useMemo, useState } from "react";
 import { useLanguage } from '@/lib/i18n';
 import { messageList } from '@/lib/i18n/translations/dashboard';
+import { isDashboardMessageRecalled, recalledMessageLabel } from "@/lib/message-recall";
 import { useShallow } from "zustand/react/shallow";
 import { Bot, Settings, UserPlus } from "lucide-react";
 import MessageBubble from "./MessageBubble";
@@ -98,7 +99,8 @@ const PREFILL_ROOM_COMPOSER_EVENT = "botcord:prefill-room-composer";
 const OPEN_ROOM_ADD_MEMBER_EVENT = "botcord:open-room-add-member";
 const OPEN_ROOM_SETTINGS_EVENT = "botcord:open-room-settings";
 
-function messagePreviewText(msg: DashboardMessage): string {
+function messagePreviewText(msg: DashboardMessage, locale: string): string {
+  if (isDashboardMessageRecalled(msg)) return recalledMessageLabel(locale);
   if (msg.text) return msg.text;
   if (typeof msg.payload === "object" && msg.payload && "text" in msg.payload) {
     const text = (msg.payload as { text?: unknown }).text;
@@ -188,7 +190,7 @@ function TopicCard({
         {recentPreview.length > 0 ? (
           <div className="space-y-0.5 border-l-2 border-neon-cyan/30 pl-2">
             {recentPreview.map((msg) => {
-              const text = messagePreviewText(msg);
+              const text = messagePreviewText(msg, locale);
               const isOwn = msg.sender_id === currentAgentId;
               const senderLabel = isOwn
                 ? (locale === "zh" ? "你" : "You")

--- a/frontend/src/components/dashboard/RoomList.tsx
+++ b/frontend/src/components/dashboard/RoomList.tsx
@@ -14,6 +14,7 @@ import { useRouter } from "nextjs-toploader/app";
 import { useShallow } from "zustand/react/shallow";
 
 import { ContactInfo, DashboardMessage, DashboardRoom } from "@/lib/types";
+import { isDashboardMessageRecalled, recalledMessageLabel } from "@/lib/message-recall";
 import { getIsoTimestampValue, getRoomActivityTimestamp, humanRoomToDashboardRoom, isOwnerChatRoom } from "@/store/dashboard-shared";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
@@ -339,10 +340,14 @@ export default function RoomList({
           previewText = ownerChatLatestForRoom.text || (ownerChatLatestForRoom.attachments?.length ? "[Attachment]" : t.noMessagesYet);
           previewSender = ownerChatLatestForRoom.senderName || "";
         } else if (room.last_message_preview != null || room.last_sender_name != null) {
-          previewText = room.last_message_preview ?? t.noMessagesYet;
+          previewText = room.last_message_preview === "Message recalled"
+            ? recalledMessageLabel(locale)
+            : room.last_message_preview ?? t.noMessagesYet;
           previewSender = room.last_sender_name ?? "";
         } else if (cachedLatestMessage) {
-          previewText = cachedLatestMessage.text || t.noMessagesYet;
+          previewText = isDashboardMessageRecalled(cachedLatestMessage)
+            ? recalledMessageLabel(locale)
+            : cachedLatestMessage.text || t.noMessagesYet;
           previewSender = cachedLatestMessage.sender_name || "";
         } else {
           previewText = t.noMessagesYet;

--- a/frontend/src/components/share/SharedMessageBubble.tsx
+++ b/frontend/src/components/share/SharedMessageBubble.tsx
@@ -5,14 +5,18 @@ import AttachmentItem from "@/components/ui/AttachmentItem";
 import MarkdownContent from "@/components/ui/MarkdownContent";
 import SystemMessageNotice from "@/components/ui/SystemMessageNotice";
 import TransferCard, { parseTransferText, parseTransferNotice } from "@/components/dashboard/TransferCard";
+import { useLanguage } from "@/lib/i18n";
+import { isDashboardMessageRecalled, recalledMessageLabel } from "@/lib/message-recall";
 
 interface SharedMessageBubbleProps {
   message: SharedMessage;
 }
 
 export default function SharedMessageBubble({ message }: SharedMessageBubbleProps) {
+  const locale = useLanguage();
   const textContent = message.payload?.text || message.payload?.body || message.payload?.message;
   const displayText = typeof textContent === "string" ? textContent : message.text;
+  const isRecalled = isDashboardMessageRecalled(message);
   const timestampLabel = new Date(message.created_at).toLocaleTimeString([], {
     hour: "2-digit",
     minute: "2-digit",
@@ -41,12 +45,14 @@ export default function SharedMessageBubble({ message }: SharedMessageBubbleProp
           <span className="text-sm font-semibold text-text-primary">{message.sender_name}</span>
           <span className="font-mono text-[10px] text-text-secondary/50">{message.sender_id}</span>
         </div>
-        {transferInfo ? (
+        {isRecalled ? (
+          <p className="text-sm italic text-text-secondary/70">{recalledMessageLabel(locale)}</p>
+        ) : transferInfo ? (
           <TransferCard info={transferInfo} isNotice={displayText?.startsWith("[BotCord Notice]")} />
         ) : (
           displayText && <MarkdownContent content={displayText} />
         )}
-        {attachments.length > 0 && (
+        {!isRecalled && attachments.length > 0 && (
           <div className="mt-1.5 flex flex-col gap-1.5">
             {attachments.map((att, i) => (
               <AttachmentItem key={`${att.filename}-${i}`} attachment={att} />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -51,6 +51,7 @@ import type {
   UserChatSendResponse,
   RunStreamBlocksResponse,
   RoomHumanSendResponse,
+  MessageRecallResponse,
   CreateJoinRequestResponse,
   JoinRequestListResponse,
   MyJoinRequestResponse,
@@ -906,6 +907,12 @@ export const api = {
     if (attachments && attachments.length > 0) body.attachments = attachments;
     if (replyTo) body.reply_to = replyTo;
     return apiPost<RoomHumanSendResponse>(`/api/dashboard/rooms/${roomId}/send`, body);
+  },
+
+  recallRoomMessage(roomId: string, msgId: string) {
+    return apiPost<MessageRecallResponse>(
+      `/api/dashboard/rooms/${roomId}/messages/${encodeURIComponent(msgId)}/recall`,
+    );
   },
 
   openDmRoom(peerId: string) {

--- a/frontend/src/lib/message-recall.ts
+++ b/frontend/src/lib/message-recall.ts
@@ -1,0 +1,14 @@
+import type { DashboardMessage } from "@/lib/types";
+
+export function isDashboardMessageRecalled(message: Pick<DashboardMessage, "is_recalled" | "recalled_at" | "payload">): boolean {
+  return Boolean(
+    message.is_recalled
+      || message.recalled_at
+      || message.payload?.recalled
+      || message.payload?.is_recalled,
+  );
+}
+
+export function recalledMessageLabel(locale: string): string {
+  return locale === "zh" ? "消息已撤回" : "Message recalled";
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -181,6 +181,10 @@ export interface DashboardMessage {
   source_user_name?: string | null;
   is_mine?: boolean;
   reply_preview?: ReplyPreview | null;
+  is_recalled?: boolean;
+  recalled_at?: string | null;
+  recalled_by_id?: string | null;
+  recalled_by_type?: ParticipantType | null;
 }
 
 export interface RoomHumanSendResponse {
@@ -188,6 +192,16 @@ export interface RoomHumanSendResponse {
   room_id: string;
   status: string;
   topic_id?: string | null;
+}
+
+export interface MessageRecallResponse {
+  room_id: string;
+  msg_id: string;
+  hub_msg_id: string;
+  is_recalled: boolean;
+  recalled_at: string | null;
+  recalled_by_id: string | null;
+  recalled_by_type?: ParticipantType | null;
 }
 
 // --- User Chat types ---
@@ -396,6 +410,7 @@ export interface InboxPollResponse {
 
 export type RealtimeMetaEventType =
   | "message"
+  | "message_recalled"
   | "contact_request"
   | "contact_request_response"
   | "contact_removed"
@@ -518,6 +533,9 @@ export interface SharedMessage {
   text: string;
   payload: Record<string, unknown>;
   created_at: string;
+  is_recalled?: boolean;
+  recalled_at?: string | null;
+  recalled_by_id?: string | null;
 }
 
 export interface SharedRoomInfo {

--- a/frontend/src/store/useDashboardChatStore.test.ts
+++ b/frontend/src/store/useDashboardChatStore.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   leaveRoom: vi.fn(),
   getOverview: vi.fn(),
   getPublicRoom: vi.fn(),
+  recallRoomMessage: vi.fn(),
   listAgentRooms: vi.fn(),
 }));
 
@@ -15,6 +16,7 @@ vi.mock("@/lib/api", () => ({
     leaveRoom: mocks.leaveRoom,
     getOverview: mocks.getOverview,
     getPublicRoom: mocks.getPublicRoom,
+    recallRoomMessage: mocks.recallRoomMessage,
   },
   humansApi: {
     listAgentRooms: mocks.listAgentRooms,
@@ -88,6 +90,7 @@ describe("useDashboardChatStore message polling", () => {
     mocks.leaveRoom.mockReset();
     mocks.getOverview.mockReset();
     mocks.getPublicRoom.mockReset();
+    mocks.recallRoomMessage.mockReset();
     mocks.listAgentRooms.mockReset();
     useDashboardSessionStore.setState({
       token: "test-token",
@@ -144,6 +147,49 @@ describe("useDashboardChatStore message polling", () => {
 
     expect(mocks.getRoomMessages).toHaveBeenCalledTimes(1);
     expect(useDashboardChatStore.getState().messages.rm_empty).toEqual([]);
+  });
+
+  it("marks a cached message recalled after the backend confirms recall", async () => {
+    mocks.recallRoomMessage.mockResolvedValue({
+      room_id: "rm_empty",
+      msg_id: "msg_1",
+      hub_msg_id: "hub_1",
+      is_recalled: true,
+      recalled_at: "2026-05-11T08:01:00Z",
+      recalled_by_id: "hu_1",
+      recalled_by_type: "human",
+    });
+    useDashboardChatStore.setState({
+      overview: makeOverview("2026-05-11T08:00:00Z"),
+      messages: {
+        rm_empty: [{
+          hub_msg_id: "hub_1",
+          msg_id: "msg_1",
+          sender_id: "hu_1",
+          sender_name: "Human",
+          type: "message",
+          text: "hello",
+          payload: { text: "hello" },
+          room_id: "rm_empty",
+          topic: null,
+          topic_id: null,
+          goal: null,
+          state: "queued",
+          state_counts: null,
+          created_at: "2026-05-11T08:00:00Z",
+          is_mine: true,
+        }],
+      },
+    });
+
+    await useDashboardChatStore.getState().recallMessage("rm_empty", "msg_1");
+
+    const message = useDashboardChatStore.getState().messages.rm_empty[0];
+    expect(message.is_recalled).toBe(true);
+    expect(message.text).toBe("");
+    expect(message.payload.recalled).toBe(true);
+    expect(message.recalled_at).toBe("2026-05-11T08:01:00Z");
+    expect(useDashboardChatStore.getState().overview?.rooms[0].last_message_preview).toBe("Message recalled");
   });
 
   it("clears the opened room and cached messages after leaving the current room", async () => {

--- a/frontend/src/store/useDashboardChatStore.ts
+++ b/frontend/src/store/useDashboardChatStore.ts
@@ -39,6 +39,7 @@ let publicAgentsRequestSeq = 0;
 let publicHumansRequestSeq = 0;
 const emptyRoomMessageSnapshot = new Map<string, string | null>();
 const roomMembersInFlight = new Map<string, Promise<PublicRoomMember[]>>();
+const recalledPreviewText = "Message recalled";
 
 function isFetchNetworkError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
@@ -81,6 +82,28 @@ function applyRealtimeRoomHint<T extends {
 
 function getRoomMessageSnapshot(room: DashboardRoom | null): string | null {
   return room?.last_message_at ?? null;
+}
+
+function buildRecalledMessagePatch(patch?: {
+  recalled_at?: string | null;
+  recalled_by_id?: string | null;
+  recalled_by_type?: "agent" | "human" | null;
+}): Partial<DashboardMessage> {
+  const recalledAt = patch?.recalled_at ?? new Date().toISOString();
+  return {
+    text: "",
+    payload: {
+      recalled: true,
+      is_recalled: true,
+      recalled_at: recalledAt,
+      recalled_by_id: patch?.recalled_by_id ?? null,
+      recalled_by_type: patch?.recalled_by_type ?? null,
+    },
+    is_recalled: true,
+    recalled_at: recalledAt,
+    recalled_by_id: patch?.recalled_by_id ?? null,
+    recalled_by_type: patch?.recalled_by_type ?? null,
+  };
 }
 
 function ownerChatRoomIdForOptimistic(agentId: string): string {
@@ -239,6 +262,8 @@ interface DashboardChatState {
   bumpRoomMembersVersion: (roomId: string) => void;
 
   insertMessage: (roomId: string, message: DashboardMessage) => void;
+  markMessageRecalled: (roomId: string, msgId: string, patch?: { recalled_at?: string | null; recalled_by_id?: string | null; recalled_by_type?: "agent" | "human" | null }) => void;
+  recallMessage: (roomId: string, msgId: string) => Promise<void>;
   loadRoomMessages: (roomId: string, opts?: { force?: boolean }) => Promise<void>;
   prefetchRoomMessages: (roomId: string) => Promise<void>;
   pollNewMessages: (roomId: string, opts?: { expectedHubMsgId?: string | null; retries?: number }) => Promise<void>;
@@ -419,6 +444,79 @@ export const useDashboardChatStore = create<DashboardChatState>()(
             messages: { ...state.messages, [roomId]: [...current, message] },
           };
         }),
+
+      markMessageRecalled: (roomId, msgId, patch) =>
+        set((state) => {
+          const current = state.messages[roomId];
+          if (!current) return state;
+          let changed = false;
+          const recalledPatch = buildRecalledMessagePatch(patch);
+          const nextMessages = current.map((message) => {
+            if (message.msg_id !== msgId && message.hub_msg_id !== msgId) return message;
+            changed = true;
+            return { ...message, ...recalledPatch };
+          });
+          if (!changed) return state;
+
+          const latestMessage = [...nextMessages].reverse().find(
+            (message) => message.type !== "ack" && message.type !== "result" && message.type !== "error",
+          );
+          const shouldPatchRoomPreview = latestMessage?.msg_id === msgId || latestMessage?.hub_msg_id === msgId;
+          const patchRoomSummary = <T extends {
+            room_id: string;
+            last_message_preview: string | null;
+          }>(room: T): T => (
+            shouldPatchRoomPreview && room.room_id === roomId
+              ? { ...room, last_message_preview: recalledPreviewText }
+              : room
+          );
+
+          return {
+            messages: { ...state.messages, [roomId]: nextMessages },
+            overview: state.overview
+              ? {
+                ...state.overview,
+                rooms: state.overview.rooms.map(patchRoomSummary),
+              }
+              : state.overview,
+            publicRoomDetails: state.publicRoomDetails[roomId]
+              ? {
+                ...state.publicRoomDetails,
+                [roomId]: patchRoomSummary(state.publicRoomDetails[roomId]),
+              }
+              : state.publicRoomDetails,
+            recentVisitedRooms: state.recentVisitedRooms.map(patchRoomSummary),
+            ownedAgentRooms: state.ownedAgentRooms.map(patchRoomSummary),
+          };
+        }),
+
+      recallMessage: async (roomId, msgId) => {
+        const previous = get().messages[roomId]?.find(
+          (message) => message.msg_id === msgId || message.hub_msg_id === msgId,
+        );
+        get().markMessageRecalled(roomId, msgId);
+        try {
+          const result = await api.recallRoomMessage(roomId, msgId);
+          get().markMessageRecalled(roomId, msgId, {
+            recalled_at: result.recalled_at,
+            recalled_by_id: result.recalled_by_id,
+            recalled_by_type: result.recalled_by_type ?? null,
+          });
+        } catch (error) {
+          if (previous) {
+            set((state) => ({
+              messages: {
+                ...state.messages,
+                [roomId]: (state.messages[roomId] || []).map((message) =>
+                  message.msg_id === msgId || message.hub_msg_id === msgId ? previous : message,
+                ),
+              },
+            }));
+          }
+          get().setError(error instanceof Error ? error.message : "Failed to recall message");
+          throw error;
+        }
+      },
 
       applyRealtimeEventHint: (event) =>
         set((state) => ({

--- a/frontend/src/store/useDashboardRealtimeStore.ts
+++ b/frontend/src/store/useDashboardRealtimeStore.ts
@@ -28,6 +28,10 @@ function isMessageRealtimeEvent(type: RealtimeMetaEvent["type"]): boolean {
   return type === "message" || type === "ack" || type === "result" || type === "error" || type === "system";
 }
 
+function isMessageRecallRealtimeEvent(type: RealtimeMetaEvent["type"]): boolean {
+  return type === "message_recalled";
+}
+
 function isTypingRealtimeEvent(type: RealtimeMetaEvent["type"]): boolean {
   return type === "typing";
 }
@@ -123,6 +127,24 @@ export const useDashboardRealtimeStore = create<DashboardRealtimeState>()((set) 
         }
 
         const chatStore = useDashboardChatStore.getState();
+        if (currentEvent?.room_id && isMessageRecallRealtimeEvent(currentEvent.type)) {
+          const msgId = typeof currentEvent.ext.msg_id === "string"
+            ? currentEvent.ext.msg_id
+            : currentEvent.hub_msg_id;
+          if (msgId) {
+            chatStore.markMessageRecalled(currentEvent.room_id, msgId, {
+              recalled_at: typeof currentEvent.ext.recalled_at === "string"
+                ? currentEvent.ext.recalled_at
+                : currentEvent.created_at,
+              recalled_by_id: typeof currentEvent.ext.recalled_by_id === "string"
+                ? currentEvent.ext.recalled_by_id
+                : null,
+              recalled_by_type: currentEvent.ext.recalled_by_type === "agent" || currentEvent.ext.recalled_by_type === "human"
+                ? currentEvent.ext.recalled_by_type
+                : null,
+            });
+          }
+        }
         if (currentEvent?.room_id && isRoomMemberRealtimeEvent(currentEvent.type)) {
           chatStore.bumpRoomMembersVersion(currentEvent.room_id);
         }


### PR DESCRIPTION
## Summary
- Add dashboard room message recall with owner/admin unlimited recall and member 2-minute self-recall.
- Redact recalled messages across dashboard/public/share/activity read paths and exclude them from agent-facing context/history delivery surfaces.
- Fix room preview fallback so human-sent last messages keep a sender name.

## Verification
- cd backend && uv run pytest tests/test_app/test_app_dashboard.py tests/test_app/test_app_activity_stats.py tests/test_app/test_app_humans.py -q
- cd backend && uv run pytest tests/test_room_context.py tests/test_quote_reply.py -q
- cd backend && uv run pytest tests/test_m3_hub.py::test_history_basic tests/test_m3_hub.py::test_history_room_filter tests/test_m3_hub.py::test_history_pagination_before tests/test_m3_hub.py::test_history_pagination_after -q
- cd backend && uv run pytest tests/test_dashboard.py tests/test_public.py tests/test_app/test_app_public.py tests/test_share.py -q
- cd frontend && npm test -- --run src/store/useDashboardChatStore.test.ts
- cd frontend && NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build

## Risk / rollout
- Migration adds nullable recall metadata to message_records. Recalled content remains in storage for audit/idempotency, but read and delivery surfaces now redacts or filters it.