### PR TITLE
fix(daemon): refresh stale JWT on 401 for typing/stream-block

### DIFF
--- a/.changeset/fix-typing-streamblock-token-refresh.md
+++ b/.changeset/fix-typing-streamblock-token-refresh.md
@@ -1,0 +1,13 @@
+---
+"@botcord/daemon": patch
+---
+
+fix(daemon): refresh stale JWT on 401 for typing/stream-block control requests
+
+`typing()` and `streamBlock()` in the BotCord channel called `ensureToken()` +
+raw `fetch()`, bypassing `hubFetch`'s 401→refresh retry. When a token was
+invalidated (e.g. a Hub JWT secret rotation) but not yet expired, `ensureToken()`
+kept returning the stale token, so presence/streaming pings 401'd in a loop until
+the next actual message send happened to refresh it — the conversation showed no
+typing indicator or live stream. Both now route through a shared
+`postControlWithRefresh` helper that refreshes the token once and retries on 401.

--- a/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
+++ b/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
@@ -1347,6 +1347,44 @@ describe("createBotCordChannel — typing()", () => {
       globalThis.fetch = realFetch;
     }
   });
+
+  it("refreshes the token and retries once on 401 (stale-token recovery)", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('{"code":"invalid_token"}', { status: 401 }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    try {
+      const client = makeClient({
+        getHubUrl: vi.fn().mockReturnValue("https://hub.example.com"),
+      });
+      const channel = createBotCordChannel({
+        id: "botcord-main",
+        accountId: "ag_self",
+        agentId: "ag_self",
+        client,
+        hubBaseUrl: "https://hub.example.com",
+      });
+      await channel.typing!({
+        traceId: "trace_401",
+        accountId: "ag_self",
+        conversationId: "rm_oc_42",
+        log: silentLog,
+      });
+      expect(client.refreshToken).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      // First attempt uses the stale token; the retry uses the refreshed one.
+      expect((fetchSpy.mock.calls[0][1].headers as Record<string, string>).Authorization).toBe(
+        "Bearer test-token",
+      );
+      expect((fetchSpy.mock.calls[1][1].headers as Record<string, string>).Authorization).toBe(
+        "Bearer test-token-2",
+      );
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
 });
 
 describe("createBotCordChannel — websocket logging", () => {

--- a/packages/daemon/src/gateway/channels/botcord.ts
+++ b/packages/daemon/src/gateway/channels/botcord.ts
@@ -309,6 +309,41 @@ function normalizeInboxBatch(
 }
 
 /**
+ * Fire-and-forget authenticated POST for presence/streaming control requests
+ * (`/hub/typing`, `/hub/stream-block`). Mirrors `BotCordClient.hubFetch`'s 401
+ * handling: a stale-but-unexpired token (e.g. after a Hub JWT secret rotation,
+ * which `ensureToken()` won't refresh because it only refreshes near expiry) is
+ * refreshed once and the request retried. Without this, typing/stream-block
+ * silently 401 in a loop until the next actual message send happens to refresh
+ * the token — leaving the conversation with no typing indicator or live stream.
+ */
+async function postControlWithRefresh(
+  client: BotCordChannelClient,
+  hubUrl: string,
+  path: string,
+  body: unknown,
+): Promise<Response> {
+  let token = await client.ensureToken();
+  for (let attempt = 0; attempt <= 1; attempt++) {
+    const resp = await fetch(`${hubUrl}${path}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (resp.status === 401 && attempt === 0) {
+      token = await client.refreshToken();
+      continue;
+    }
+    return resp;
+  }
+  throw new Error("postControlWithRefresh: exhausted retries");
+}
+
+/**
  * Construct a BotCord channel adapter.
  *
  * `start()` connects to Hub WS, drains `/hub/inbox` on every `inbox_update`,
@@ -895,21 +930,12 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
       const client = ensureClient();
       const hubUrl = options.hubBaseUrl ?? client.getHubUrl();
       try {
-        const token = await client.ensureToken();
         const block = ctx.block as { raw?: unknown; kind?: string; seq?: number } | undefined;
         const seq = typeof block?.seq === "number" ? block.seq : 0;
-        const resp = await fetch(`${hubUrl}/hub/stream-block`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify({
-            trace_id: ctx.traceId,
-            seq,
-            block: normalizeBlockForHub(block, seq),
-          }),
-          signal: AbortSignal.timeout(10_000),
+        const resp = await postControlWithRefresh(client, hubUrl, "/hub/stream-block", {
+          trace_id: ctx.traceId,
+          seq,
+          block: normalizeBlockForHub(block, seq),
         });
         if (!resp.ok && resp.status !== 204) {
           const body = await resp.text().catch(() => "");
@@ -927,15 +953,8 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
       const client = ensureClient();
       const hubUrl = options.hubBaseUrl ?? client.getHubUrl();
       try {
-        const token = await client.ensureToken();
-        const resp = await fetch(`${hubUrl}/hub/typing`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify({ room_id: ctx.conversationId }),
-          signal: AbortSignal.timeout(10_000),
+        const resp = await postControlWithRefresh(client, hubUrl, "/hub/typing", {
+          room_id: ctx.conversationId,
         });
         if (!resp.ok && resp.status !== 204) {
           const body = await resp.text().catch(() => "");


### PR DESCRIPTION
## 问题

`typing()` / `streamBlock()`（`packages/daemon/src/gateway/channels/botcord.ts`）用 `ensureToken()` + 裸 `fetch()` 发请求，**绕过了** `BotCordClient.hubFetch` 的 401→refresh 重试逻辑。

当某个 agent 的 JWT 被 Hub secret 轮换作废、但**还没过期**时，`ensureToken()`（只在临近过期时刷新）会一直返回那个失效的 token：

- `/hub/typing` 和 `/hub/stream-block` 持续 401（`invalid_token` / "signed with a different secret"），每隔几秒刷屏；
- 直到下一次真正 `sendMessage`（走 `hubFetch`）才触发刷新自愈；
- 期间会话**没有"正在输入"提示、也没有流式输出**，对用户像是 agent 卡死了。

线上实测复现：某 agent 在一次 ~14 分钟的长 turn 期间 typing 一直 401，直到长 turn 结束发出回复时 send 路径才把 token 刷新好。

## 改动

- 新增共享 helper `postControlWithRefresh(client, hubUrl, path, body)`，对齐 `hubFetch` 的 401 处理：401 时 `refreshToken()` 刷新一次并重试。
- `typing()` 和 `streamBlock()` 改走它，顺带去掉两处重复 fetch 样板。
- 保留原 fire-and-forget 语义（warn-not-throw、10s 超时、各自的 non-ok 日志标签）。

## 验证

- `tsc` build 通过（protocol-core + daemon）
- 新增测试：`typing() refreshes the token and retries once on 401`
- daemon 全套 **941 tests / 67 files 全绿**
- changeset：`@botcord/daemon` patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)