### PR TITLE
fix: surface dashboard recall action

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -3196,6 +3196,7 @@ async def human_room_send(
 
     return {
         "hub_msg_id": first_hub_msg_id,
+        "msg_id": msg_id,
         "room_id": room_id,
         "status": "queued",
         "topic_id": topic_id,

--- a/backend/tests/test_dashboard_rooms_human_send.py
+++ b/backend/tests/test_dashboard_rooms_human_send.py
@@ -366,11 +366,14 @@ async def test_happy_path_fanout(client: AsyncClient, seed: dict, db_session: As
     body = r.json()
     assert body["room_id"] == "rm_humanroom"
     assert body["status"] == "queued"
+    assert body["hub_msg_id"].startswith("h_")
+    assert body["msg_id"]
 
     # Verify persistence: fan-out rows for all non-muted members (a1 + a3). a2 is muted.
     rows = (await db_session.execute(
         select(MessageRecord).where(MessageRecord.room_id == "rm_humanroom")
     )).scalars().all()
+    assert {row.msg_id for row in rows} == {body["msg_id"]}
     receiver_ids = {r.receiver_id for r in rows}
     assert "ag_user1___" in receiver_ids  # active agent included (PRD §6.3)
     assert "ag_user3___" in receiver_ids

--- a/frontend/src/components/dashboard/MessageBubble.tsx
+++ b/frontend/src/components/dashboard/MessageBubble.tsx
@@ -11,7 +11,7 @@ import RuntimeErrorDetailsDialog from "./RuntimeErrorDetailsDialog";
 import type { DashboardMessage, Attachment } from "@/lib/types";
 import { useLanguage } from '@/lib/i18n';
 import { messageBubble } from '@/lib/i18n/translations/dashboard';
-import { isDashboardMessageRecalled, recalledMessageLabel } from "@/lib/message-recall";
+import { canRecallDashboardMessage, isDashboardMessageRecalled, recalledMessageLabel } from "@/lib/message-recall";
 import AttachmentItem from "@/components/ui/AttachmentItem";
 import CopyableId from "@/components/ui/CopyableId";
 import MarkdownContent from "@/components/ui/MarkdownContent";
@@ -479,15 +479,15 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
     && !isRecalled;
 
   const roomSummary = message.room_id ? getRoomSummary(message.room_id) : null;
-  const canAdminRecall = roomSummary?.my_role === "owner" || roomSummary?.my_role === "admin";
-  const canRecall =
-    message.type === "message"
-    && Boolean(message.room_id)
-    && Boolean(message.msg_id)
-    && !message.room_id?.startsWith("rm_oc_")
-    && !message.hub_msg_id?.startsWith("tmp_")
-    && !isRecalled
-    && (isOwn || canAdminRecall);
+  const recallLabel = locale === "zh" ? "撤回消息" : "Recall message";
+  const canRecall = canRecallDashboardMessage({
+    message,
+    room: roomSummary,
+    isOwn,
+    ownedAgentIds: ownedAgents.map((agent) => agent.agent_id),
+    humanId: human?.human_id,
+    userId: user?.id,
+  });
 
   const handleReplyClick = () => {
     setMenuOpen(false);
@@ -536,8 +536,21 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
     />
   );
 
+  const recallButton = canRecall && (
+    <button
+      type="button"
+      disabled={recallPending}
+      onMouseDown={(e) => { e.preventDefault(); void handleRecallClick(); }}
+      className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-zinc-500 transition-colors hover:bg-zinc-800 hover:text-zinc-100 disabled:cursor-not-allowed disabled:opacity-60"
+      aria-label={recallLabel}
+      title={recallLabel}
+    >
+      <RotateCcw className="h-3.5 w-3.5" />
+    </button>
+  );
+
   const moreButton = !isRecalled && (displayText || canRecall) && (
-    <div className="relative self-start pt-1 shrink-0">
+    <div className="relative shrink-0">
       <button
         type="button"
         onClick={() => setMenuOpen((v) => !v)}
@@ -598,6 +611,13 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
     </div>
   );
 
+  const actionButtons = (recallButton || moreButton) && (
+    <div className="flex shrink-0 items-center gap-1 self-start pt-1">
+      {recallButton}
+      {moreButton}
+    </div>
+  );
+
   return (
     <>
     <div
@@ -606,7 +626,7 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
       onMouseLeave={() => { setHovered(false); setMenuOpen(false); }}
     >
       {/* For own messages: button left of bubble */}
-      {isOwn && !fullWidth && moreButton}
+      {isOwn && !fullWidth && actionButtons}
       {!isOwn && sideAvatar}
       <div
         className={`${fullWidth ? "w-full" : "max-w-[70%]"} rounded-xl px-3 py-2 ${
@@ -742,7 +762,7 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
       </div>
       {isOwn && sideAvatar}
       {/* For others' messages: button right of bubble */}
-      {(!isOwn || fullWidth) && moreButton}
+      {(!isOwn || fullWidth) && actionButtons}
     </div>
     {forwardQuote && (
       <ForwardModal quoteText={forwardQuote} onClose={() => setForwardQuote(null)} />

--- a/frontend/src/components/dashboard/RoomHumanComposer.tsx
+++ b/frontend/src/components/dashboard/RoomHumanComposer.tsx
@@ -225,8 +225,9 @@ export default function RoomHumanComposer({ roomId, topicId = null }: RoomHumanC
     human: s.human,
     viewMode: s.viewMode,
   })));
-  const { insertMessage, patchRoom, pollNewMessages, refreshOverview } = useDashboardChatStore(useShallow((s) => ({
+  const { insertMessage, patchMessageIdentity, patchRoom, pollNewMessages, refreshOverview } = useDashboardChatStore(useShallow((s) => ({
     insertMessage: s.insertMessage,
+    patchMessageIdentity: s.patchMessageIdentity,
     patchRoom: s.patchRoom,
     pollNewMessages: s.pollNewMessages,
     refreshOverview: s.refreshOverview,
@@ -379,6 +380,11 @@ export default function RoomHumanComposer({ roomId, topicId = null }: RoomHumanC
       const result = await api.sendRoomHumanMessage(
         roomId, text, mentions, topicId, attachments, replyTargetMsgId,
       );
+      patchMessageIdentity(roomId, clientTempId, {
+        hub_msg_id: result.hub_msg_id,
+        msg_id: result.msg_id,
+        topic_id: result.topic_id ?? topicId,
+      });
       patchRoom(roomId, {
         last_message_preview: displayText,
         last_message_at: now,
@@ -397,7 +403,7 @@ export default function RoomHumanComposer({ roomId, topicId = null }: RoomHumanC
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Failed to send");
     }
-  }, [uploadAgentId, senderId, displayName, user?.id, roomId, topicId, viewMode, insertMessage, patchRoom, pollNewMessages, refreshOverview, refreshHumanRooms, hasRoomInOverview, hasRoomInHumanRooms, replyingTo, setReplyingTo, human?.avatar_url, user?.avatar_url]);
+  }, [uploadAgentId, senderId, displayName, user?.id, roomId, topicId, viewMode, insertMessage, patchMessageIdentity, patchRoom, pollNewMessages, refreshOverview, refreshHumanRooms, hasRoomInOverview, hasRoomInHumanRooms, replyingTo, setReplyingTo, human?.avatar_url, user?.avatar_url]);
 
   if (sendDenied) {
     return (

--- a/frontend/src/lib/message-recall.test.ts
+++ b/frontend/src/lib/message-recall.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import type { DashboardMessage, DashboardRoom } from "@/lib/types";
+import { canRecallDashboardMessage } from "@/lib/message-recall";
+
+function message(overrides: Partial<DashboardMessage> = {}): DashboardMessage {
+  return {
+    hub_msg_id: "h_1",
+    msg_id: "msg_1",
+    sender_id: "hu_1",
+    sender_name: "Alice",
+    type: "message",
+    text: "hello",
+    payload: { text: "hello" },
+    room_id: "rm_1",
+    topic: null,
+    topic_id: null,
+    goal: null,
+    state: "queued",
+    state_counts: null,
+    created_at: "2026-05-29T08:00:00.000Z",
+    source_type: "dashboard_human_room",
+    source_user_id: "user_1",
+    is_mine: true,
+    ...overrides,
+  };
+}
+
+function room(overrides: Partial<DashboardRoom> = {}): DashboardRoom {
+  return {
+    room_id: "rm_1",
+    name: "Room",
+    description: "",
+    owner_id: "ag_owner",
+    owner_type: "agent",
+    visibility: "private",
+    member_count: 2,
+    my_role: "member",
+    rule: null,
+    has_unread: false,
+    last_message_preview: null,
+    last_message_at: null,
+    last_sender_name: null,
+    ...overrides,
+  };
+}
+
+describe("canRecallDashboardMessage", () => {
+  it("allows a freshly persisted own message even when is_mine is missing", () => {
+    expect(canRecallDashboardMessage({
+      message: message({ is_mine: undefined }),
+      room: room(),
+      isOwn: false,
+      ownedAgentIds: [],
+      humanId: "hu_1",
+      userId: "user_1",
+      nowMs: Date.parse("2026-05-29T08:01:00.000Z"),
+    })).toBe(true);
+  });
+
+  it("does not expose recall on temporary optimistic ids", () => {
+    expect(canRecallDashboardMessage({
+      message: message({ hub_msg_id: "tmp_1", msg_id: "tmp_1" }),
+      room: room(),
+      isOwn: true,
+      ownedAgentIds: [],
+      humanId: "hu_1",
+      userId: "user_1",
+      nowMs: Date.parse("2026-05-29T08:01:00.000Z"),
+    })).toBe(false);
+  });
+
+  it("allows the owner of the room owner bot to recall any room message", () => {
+    expect(canRecallDashboardMessage({
+      message: message({
+        sender_id: "ag_other",
+        source_user_id: null,
+        created_at: "2026-05-29T07:00:00.000Z",
+      }),
+      room: room({ owner_id: "ag_owner", owner_type: "agent", my_role: "member" }),
+      isOwn: false,
+      ownedAgentIds: ["ag_owner"],
+      humanId: "hu_1",
+      userId: "user_1",
+      nowMs: Date.parse("2026-05-29T08:01:00.000Z"),
+    })).toBe(true);
+  });
+});

--- a/frontend/src/lib/message-recall.ts
+++ b/frontend/src/lib/message-recall.ts
@@ -1,4 +1,6 @@
-import type { DashboardMessage } from "@/lib/types";
+import type { DashboardMessage, DashboardRoom } from "@/lib/types";
+
+const MESSAGE_RECALL_WINDOW_MS = 2 * 60 * 1000;
 
 export function isDashboardMessageRecalled(message: Pick<DashboardMessage, "is_recalled" | "recalled_at" | "payload">): boolean {
   return Boolean(
@@ -11,4 +13,56 @@ export function isDashboardMessageRecalled(message: Pick<DashboardMessage, "is_r
 
 export function recalledMessageLabel(locale: string): string {
   return locale === "zh" ? "消息已撤回" : "Message recalled";
+}
+
+export function hasDashboardRecallAdminCapability(
+  room: Pick<DashboardRoom, "my_role" | "owner_id" | "owner_type"> | null | undefined,
+  ownedAgentIds: readonly string[],
+  humanId?: string | null,
+): boolean {
+  if (!room) return false;
+  if (room.my_role === "owner" || room.my_role === "admin") return true;
+  if (room.owner_type === "human" && humanId && room.owner_id === humanId) return true;
+  if (room.owner_type === "agent" && ownedAgentIds.includes(room.owner_id)) return true;
+  return false;
+}
+
+export function canRecallDashboardMessage({
+  message,
+  room,
+  isOwn,
+  ownedAgentIds,
+  humanId,
+  userId,
+  nowMs = Date.now(),
+}: {
+  message: DashboardMessage;
+  room: Pick<DashboardRoom, "my_role" | "owner_id" | "owner_type"> | null | undefined;
+  isOwn: boolean;
+  ownedAgentIds: readonly string[];
+  humanId?: string | null;
+  userId?: string | null;
+  nowMs?: number;
+}): boolean {
+  if (
+    message.type !== "message"
+    || !message.room_id
+    || !message.msg_id
+    || message.room_id.startsWith("rm_oc_")
+    || message.hub_msg_id?.startsWith("tmp_")
+    || isDashboardMessageRecalled(message)
+  ) {
+    return false;
+  }
+
+  if (hasDashboardRecallAdminCapability(room, ownedAgentIds, humanId)) return true;
+  const isViewerAuthored =
+    isOwn
+    || Boolean(humanId && message.sender_id === humanId)
+    || Boolean(userId && message.source_user_id === userId);
+  if (!isViewerAuthored) return false;
+
+  const createdMs = Date.parse(message.created_at);
+  if (Number.isNaN(createdMs)) return true;
+  return nowMs - createdMs <= MESSAGE_RECALL_WINDOW_MS;
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -189,6 +189,7 @@ export interface DashboardMessage {
 
 export interface RoomHumanSendResponse {
   hub_msg_id: string;
+  msg_id: string;
   room_id: string;
   status: string;
   topic_id?: string | null;

--- a/frontend/src/store/useDashboardChatStore.test.ts
+++ b/frontend/src/store/useDashboardChatStore.test.ts
@@ -192,6 +192,38 @@ describe("useDashboardChatStore message polling", () => {
     expect(useDashboardChatStore.getState().overview?.rooms[0].last_message_preview).toBe("Message recalled");
   });
 
+  it("patches an optimistic message with persisted ids after send returns", () => {
+    useDashboardChatStore.getState().insertMessage("rm_empty", {
+      hub_msg_id: "tmp_1",
+      msg_id: "tmp_1",
+      sender_id: "hu_1",
+      sender_name: "Human",
+      type: "message",
+      text: "hello",
+      payload: { text: "hello" },
+      room_id: "rm_empty",
+      topic: null,
+      topic_id: null,
+      goal: null,
+      state: "queued",
+      state_counts: null,
+      created_at: "2026-05-11T08:00:00Z",
+      is_mine: true,
+    });
+
+    useDashboardChatStore.getState().patchMessageIdentity("rm_empty", "tmp_1", {
+      hub_msg_id: "h_real",
+      msg_id: "msg_real",
+      topic_id: "tp_real",
+    });
+
+    expect(useDashboardChatStore.getState().messages.rm_empty[0]).toMatchObject({
+      hub_msg_id: "h_real",
+      msg_id: "msg_real",
+      topic_id: "tp_real",
+    });
+  });
+
   it("clears the opened room and cached messages after leaving the current room", async () => {
     const overviewAfterLeave = { ...makeOverview(), rooms: [] };
     mocks.leaveRoom.mockResolvedValue(undefined);

--- a/frontend/src/store/useDashboardChatStore.ts
+++ b/frontend/src/store/useDashboardChatStore.ts
@@ -262,6 +262,7 @@ interface DashboardChatState {
   bumpRoomMembersVersion: (roomId: string) => void;
 
   insertMessage: (roomId: string, message: DashboardMessage) => void;
+  patchMessageIdentity: (roomId: string, temporaryId: string, patch: Pick<DashboardMessage, "hub_msg_id" | "msg_id"> & Partial<Pick<DashboardMessage, "topic_id">>) => void;
   markMessageRecalled: (roomId: string, msgId: string, patch?: { recalled_at?: string | null; recalled_by_id?: string | null; recalled_by_type?: "agent" | "human" | null }) => void;
   recallMessage: (roomId: string, msgId: string) => Promise<void>;
   loadRoomMessages: (roomId: string, opts?: { force?: boolean }) => Promise<void>;
@@ -442,6 +443,22 @@ export const useDashboardChatStore = create<DashboardChatState>()(
           if (current.some((m) => m.hub_msg_id === message.hub_msg_id)) return state;
           return {
             messages: { ...state.messages, [roomId]: [...current, message] },
+          };
+        }),
+
+      patchMessageIdentity: (roomId, temporaryId, patch) =>
+        set((state) => {
+          const current = state.messages[roomId];
+          if (!current) return state;
+          let changed = false;
+          const nextMessages = current.map((message) => {
+            if (message.hub_msg_id !== temporaryId && message.msg_id !== temporaryId) return message;
+            changed = true;
+            return { ...message, ...patch };
+          });
+          if (!changed) return state;
+          return {
+            messages: { ...state.messages, [roomId]: nextMessages },
           };
         }),
 


### PR DESCRIPTION
## Summary
- Return `msg_id` from dashboard room sends so optimistic messages can be patched with recallable ids immediately.
- Add a visible recall icon next to recallable messages and keep the menu action as a secondary entry.
- Broaden frontend recall eligibility to handle human-authored messages and human owners of room-owner bots.

## Verification
- cd backend && uv run pytest tests/test_dashboard_rooms_human_send.py::test_happy_path_fanout tests/test_app/test_app_dashboard.py -q
- cd frontend && npm test -- --run src/lib/message-recall.test.ts src/store/useDashboardChatStore.test.ts src/components/dashboard/RoomHumanComposer.test.ts
- cd frontend && NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build

## Risk / rollout
- Frontend-only visibility fix plus additive response field on room send.