### PR TITLE
fix: refresh recallable optimistic messages

### DIFF
--- a/frontend/src/components/dashboard/MessageBubble.tsx
+++ b/frontend/src/components/dashboard/MessageBubble.tsx
@@ -476,6 +476,7 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
     && Boolean(message.room_id)
     && Boolean(message.msg_id)
     && !message.hub_msg_id?.startsWith("tmp_")
+    && !message.msg_id?.startsWith("tmp_")
     && !isRecalled;
 
   const roomSummary = message.room_id ? getRoomSummary(message.room_id) : null;

--- a/frontend/src/lib/message-recall.test.ts
+++ b/frontend/src/lib/message-recall.test.ts
@@ -69,6 +69,18 @@ describe("canRecallDashboardMessage", () => {
     })).toBe(false);
   });
 
+  it("does not expose recall while only the hub id has been persisted", () => {
+    expect(canRecallDashboardMessage({
+      message: message({ hub_msg_id: "h_real", msg_id: "tmp_1" }),
+      room: room(),
+      isOwn: true,
+      ownedAgentIds: [],
+      humanId: "hu_1",
+      userId: "user_1",
+      nowMs: Date.parse("2026-05-29T08:01:00.000Z"),
+    })).toBe(false);
+  });
+
   it("allows the owner of the room owner bot to recall any room message", () => {
     expect(canRecallDashboardMessage({
       message: message({

--- a/frontend/src/lib/message-recall.ts
+++ b/frontend/src/lib/message-recall.ts
@@ -50,6 +50,7 @@ export function canRecallDashboardMessage({
     || !message.msg_id
     || message.room_id.startsWith("rm_oc_")
     || message.hub_msg_id?.startsWith("tmp_")
+    || message.msg_id.startsWith("tmp_")
     || isDashboardMessageRecalled(message)
   ) {
     return false;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -189,7 +189,7 @@ export interface DashboardMessage {
 
 export interface RoomHumanSendResponse {
   hub_msg_id: string;
-  msg_id: string;
+  msg_id?: string;
   room_id: string;
   status: string;
   topic_id?: string | null;

--- a/frontend/src/store/useDashboardChatStore.test.ts
+++ b/frontend/src/store/useDashboardChatStore.test.ts
@@ -224,6 +224,91 @@ describe("useDashboardChatStore message polling", () => {
     });
   });
 
+  it("does not wipe the optimistic msg id when send returns no canonical msg id", () => {
+    useDashboardChatStore.getState().insertMessage("rm_empty", {
+      hub_msg_id: "tmp_1",
+      msg_id: "tmp_1",
+      sender_id: "hu_1",
+      sender_name: "Human",
+      type: "message",
+      text: "hello",
+      payload: { text: "hello" },
+      room_id: "rm_empty",
+      topic: null,
+      topic_id: null,
+      goal: null,
+      state: "queued",
+      state_counts: null,
+      created_at: "2026-05-11T08:00:00Z",
+      is_mine: true,
+    });
+
+    useDashboardChatStore.getState().patchMessageIdentity("rm_empty", "tmp_1", {
+      hub_msg_id: "h_real",
+      msg_id: undefined,
+    });
+
+    expect(useDashboardChatStore.getState().messages.rm_empty[0]).toMatchObject({
+      hub_msg_id: "h_real",
+      msg_id: "tmp_1",
+    });
+  });
+
+  it("reloads an expected sent message when the cached row still has a temporary msg id", async () => {
+    mocks.getRoomMessages.mockResolvedValue({
+      messages: [{
+        hub_msg_id: "h_real",
+        msg_id: "msg_real",
+        sender_id: "hu_1",
+        sender_name: "Human",
+        type: "message",
+        text: "hello",
+        payload: { text: "hello" },
+        room_id: "rm_empty",
+        topic: null,
+        topic_id: null,
+        goal: null,
+        state: "queued",
+        state_counts: null,
+        created_at: "2026-05-11T08:00:00Z",
+        is_mine: true,
+      }],
+      has_more: false,
+    });
+    useDashboardChatStore.setState({
+      messages: {
+        rm_empty: [{
+          hub_msg_id: "h_real",
+          msg_id: "tmp_1",
+          sender_id: "hu_1",
+          sender_name: "Human",
+          type: "message",
+          text: "hello",
+          payload: { text: "hello" },
+          room_id: "rm_empty",
+          topic: null,
+          topic_id: null,
+          goal: null,
+          state: "queued",
+          state_counts: null,
+          created_at: "2026-05-11T08:00:00Z",
+          is_mine: true,
+        }],
+      },
+    });
+
+    await useDashboardChatStore.getState().pollNewMessages("rm_empty", {
+      expectedHubMsgId: "h_real",
+      retries: 4,
+    });
+
+    expect(mocks.getRoomMessages).toHaveBeenCalledWith("rm_empty", { limit: 50 });
+    expect(useDashboardChatStore.getState().messages.rm_empty[0]).toMatchObject({
+      hub_msg_id: "h_real",
+      msg_id: "msg_real",
+    });
+  });
+
   it("clears the opened room and cached messages after leaving the current room", async () => {
     const overviewAfterLeave = { ...makeOverview(), rooms: [] };
     mocks.leaveRoom.mockResolvedValue(undefined);

--- a/frontend/src/store/useDashboardChatStore.ts
+++ b/frontend/src/store/useDashboardChatStore.ts
@@ -262,7 +262,7 @@ interface DashboardChatState {
   bumpRoomMembersVersion: (roomId: string) => void;
 
   insertMessage: (roomId: string, message: DashboardMessage) => void;
-  patchMessageIdentity: (roomId: string, temporaryId: string, patch: Pick<DashboardMessage, "hub_msg_id" | "msg_id"> & Partial<Pick<DashboardMessage, "topic_id">>) => void;
+  patchMessageIdentity: (roomId: string, temporaryId: string, patch: Partial<Pick<DashboardMessage, "hub_msg_id" | "msg_id" | "topic_id">>) => void;
   markMessageRecalled: (roomId: string, msgId: string, patch?: { recalled_at?: string | null; recalled_by_id?: string | null; recalled_by_type?: "agent" | "human" | null }) => void;
   recallMessage: (roomId: string, msgId: string) => Promise<void>;
   loadRoomMessages: (roomId: string, opts?: { force?: boolean }) => Promise<void>;
@@ -450,11 +450,16 @@ export const useDashboardChatStore = create<DashboardChatState>()(
         set((state) => {
           const current = state.messages[roomId];
           if (!current) return state;
+          const definedPatch: Partial<Pick<DashboardMessage, "hub_msg_id" | "msg_id" | "topic_id">> = {};
+          if (patch.hub_msg_id !== undefined) definedPatch.hub_msg_id = patch.hub_msg_id;
+          if (patch.msg_id !== undefined) definedPatch.msg_id = patch.msg_id;
+          if (patch.topic_id !== undefined) definedPatch.topic_id = patch.topic_id;
+          if (Object.keys(definedPatch).length === 0) return state;
           let changed = false;
           const nextMessages = current.map((message) => {
             if (message.hub_msg_id !== temporaryId && message.msg_id !== temporaryId) return message;
             changed = true;
-            return { ...message, ...patch };
+            return { ...message, ...definedPatch };
           });
           if (!changed) return state;
           return {
@@ -674,6 +679,13 @@ export const useDashboardChatStore = create<DashboardChatState>()(
               await get().loadRoomMessages(roomId, { force: Boolean(opts?.expectedHubMsgId) });
             }
           } else {
+            if (opts?.expectedHubMsgId) {
+              const expectedMessage = existing.find((message) => message.hub_msg_id === opts.expectedHubMsgId);
+              if (expectedMessage && (!expectedMessage.msg_id || expectedMessage.msg_id.startsWith("tmp_"))) {
+                await get().loadRoomMessages(roomId, { force: true });
+                return;
+              }
+            }
             const newestPersisted = [...existing].reverse().find(
               (m) => m.hub_msg_id && !m.hub_msg_id.startsWith("tmp_"),
             );


### PR DESCRIPTION
## Summary
- keep temporary msg ids from being overwritten by missing send-response fields
- force-refresh a just-sent room message when the hub id is persisted but canonical msg_id is still temporary
- prevent recall/quote actions from appearing while msg_id is still temporary

## Verification
- cd frontend && npm test -- --run src/lib/message-recall.test.ts src/store/useDashboardChatStore.test.ts src/components/dashboard/RoomHumanComposer.test.ts
- cd frontend && NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build

## Risk / rollout
- Frontend-only compatibility fix for preview/backend rollout skew; no migration.