### PR TITLE
fix: prevent mobile password autofill on chat composer

### DIFF
--- a/frontend/src/components/dashboard/MessageComposer.test.ts
+++ b/frontend/src/components/dashboard/MessageComposer.test.ts
@@ -1,5 +1,39 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
-import { getClipboardFiles, isImeComposing, textHasMention } from "./MessageComposer";
+import MessageComposer, {
+  getClipboardFiles,
+  isImeComposing,
+  MESSAGE_COMPOSER_TEXTAREA_AUTOCOMPLETE,
+  MESSAGE_COMPOSER_TEXTAREA_ID_PREFIX,
+  MESSAGE_COMPOSER_TEXTAREA_NAME,
+  textHasMention,
+} from "./MessageComposer";
+
+describe("message composer autofill metadata", () => {
+  it("uses neutral field identifiers so password managers do not infer credentials", () => {
+    const identifiers = `${MESSAGE_COMPOSER_TEXTAREA_ID_PREFIX} ${MESSAGE_COMPOSER_TEXTAREA_NAME}`;
+
+    expect(identifiers).not.toMatch(/pass(word)?|passwd|token|secret|credential|auth|login/i);
+    expect(MESSAGE_COMPOSER_TEXTAREA_AUTOCOMPLETE).toBe("off");
+  });
+
+  it("applies autofill suppression metadata to the rendered textarea", () => {
+    const markup = renderToStaticMarkup(React.createElement(MessageComposer, { onSend: () => undefined }));
+    const textarea = markup.match(/<textarea\b[^>]*>/)?.[0] ?? "";
+    const getAttribute = (name: string) => textarea.match(new RegExp(`\\b${name}="([^"]*)"`))?.[1];
+
+    expect(textarea).not.toBe("");
+    expect(getAttribute("id")).toMatch(new RegExp(`^${MESSAGE_COMPOSER_TEXTAREA_ID_PREFIX}-`));
+    expect(getAttribute("name")).toBe(MESSAGE_COMPOSER_TEXTAREA_NAME);
+    expect(getAttribute("autoComplete")).toBe("off");
+    expect(getAttribute("data-form-type")).toBe("other");
+    expect(getAttribute("inputMode")).toBe("text");
+    expect(getAttribute("autoCapitalize")).toBe("sentences");
+    expect(getAttribute("autoCorrect")).toBe("on");
+    expect(getAttribute("spellCheck")).toBe("true");
+  });
+});
 
 describe("textHasMention", () => {
   it("keeps structured @Name(agentId) mentions active", () => {

--- a/frontend/src/components/dashboard/MessageComposer.tsx
+++ b/frontend/src/components/dashboard/MessageComposer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import type { ChangeEvent, ClipboardEvent, DragEvent, FormEvent, KeyboardEvent as ReactKeyboardEvent } from "react";
 import { AtSign, Bot, Coins, FileText, FileUp, Hash, Plus, Send, User, X } from "lucide-react";
 
@@ -43,6 +43,9 @@ interface MessageComposerProps {
 
 const MAX_SUGGESTIONS = 2000;
 const MESSAGE_MAX_LENGTH = 8000;
+export const MESSAGE_COMPOSER_TEXTAREA_ID_PREFIX = "botcord-conversation-composer";
+export const MESSAGE_COMPOSER_TEXTAREA_NAME = "botcord_conversation_body";
+export const MESSAGE_COMPOSER_TEXTAREA_AUTOCOMPLETE = "off";
 
 function detectMention(text: string, cursor: number): MentionMatch | null {
   for (let i = cursor - 1; i >= 0; i--) {
@@ -120,6 +123,7 @@ export default function MessageComposer({
   const mentionListRef = useRef<HTMLDivElement>(null);
   const mentionOptionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const compositionActiveRef = useRef(false);
+  const inputId = `${MESSAGE_COMPOSER_TEXTAREA_ID_PREFIX}-${useId().replace(/:/g, "")}`;
 
   const mentionEnabled = !!mentionCandidates && mentionCandidates.length > 0;
 
@@ -471,6 +475,14 @@ export default function MessageComposer({
         )}
         <textarea
           ref={inputRef}
+          id={inputId}
+          name={MESSAGE_COMPOSER_TEXTAREA_NAME}
+          autoComplete={MESSAGE_COMPOSER_TEXTAREA_AUTOCOMPLETE}
+          autoCapitalize="sentences"
+          autoCorrect="on"
+          inputMode="text"
+          spellCheck={true}
+          data-form-type="other"
           className={`flex-1 bg-zinc-900 border rounded-lg px-3 py-2 text-sm text-zinc-200 placeholder-zinc-500 resize-none focus:outline-none focus:border-cyan-500/50 transition-all ${
             hasLengthError
               ? "border-red-500/70 focus:border-red-500/80"


### PR DESCRIPTION
## Summary
- add neutral id/name and mobile text-entry hints to the room chat composer textarea
- suppress credential/password-manager heuristics with `autoComplete="off"` and `data-form-type="other"`
- add regression coverage that renders `MessageComposer` and verifies the textarea attributes are applied

## Verification
- `MISE_TRUSTED_CONFIG_PATHS=$PWD pnpm --dir frontend exec vitest run src/components/dashboard/MessageComposer.test.ts` => 1 file / 10 tests passed
- `git diff --check` => passed
- `MISE_TRUSTED_CONFIG_PATHS=$PWD pnpm --dir frontend exec tsc --noEmit --pretty false` => fails on existing unrelated `tests/api/...` alias/type errors and `tests/usePolicyStore.test.ts` type issue

## Review
- Code Reviewer found no blocking issues after DOM regression test was added.
