### PR TITLE
fix: harden chat composer autofill suppression

### DIFF
--- a/frontend/src/components/dashboard/MessageComposer.test.ts
+++ b/frontend/src/components/dashboard/MessageComposer.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import MessageComposer, {
   getClipboardFiles,
   isImeComposing,
+  MESSAGE_COMPOSER_TEXTAREA_ARIA_AUTOCOMPLETE,
   MESSAGE_COMPOSER_TEXTAREA_AUTOCOMPLETE,
   MESSAGE_COMPOSER_TEXTAREA_ID_PREFIX,
   MESSAGE_COMPOSER_TEXTAREA_NAME,
@@ -16,6 +17,7 @@ describe("message composer autofill metadata", () => {
 
     expect(identifiers).not.toMatch(/pass(word)?|passwd|token|secret|credential|auth|login/i);
     expect(MESSAGE_COMPOSER_TEXTAREA_AUTOCOMPLETE).toBe("off");
+    expect(MESSAGE_COMPOSER_TEXTAREA_ARIA_AUTOCOMPLETE).toBe("none");
   });
 
   it("applies autofill suppression metadata to the rendered textarea", () => {
@@ -32,6 +34,11 @@ describe("message composer autofill metadata", () => {
     expect(getAttribute("autoCapitalize")).toBe("sentences");
     expect(getAttribute("autoCorrect")).toBe("on");
     expect(getAttribute("spellCheck")).toBe("true");
+    expect(getAttribute("data-lpignore")).toBe("true");
+    expect(getAttribute("data-1p-ignore")).toBe("true");
+    expect(getAttribute("data-bwignore")).toBe("true");
+    expect(getAttribute("data-protonpass-ignore")).toBe("true");
+    expect(getAttribute("aria-autocomplete")).toBe("none");
   });
 });
 

--- a/frontend/src/components/dashboard/MessageComposer.tsx
+++ b/frontend/src/components/dashboard/MessageComposer.tsx
@@ -46,6 +46,7 @@ const MESSAGE_MAX_LENGTH = 8000;
 export const MESSAGE_COMPOSER_TEXTAREA_ID_PREFIX = "botcord-conversation-composer";
 export const MESSAGE_COMPOSER_TEXTAREA_NAME = "botcord_conversation_body";
 export const MESSAGE_COMPOSER_TEXTAREA_AUTOCOMPLETE = "off";
+export const MESSAGE_COMPOSER_TEXTAREA_ARIA_AUTOCOMPLETE = "none";
 
 function detectMention(text: string, cursor: number): MentionMatch | null {
   for (let i = cursor - 1; i >= 0; i--) {
@@ -483,6 +484,11 @@ export default function MessageComposer({
           inputMode="text"
           spellCheck={true}
           data-form-type="other"
+          data-lpignore="true"
+          data-1p-ignore="true"
+          data-bwignore="true"
+          data-protonpass-ignore="true"
+          aria-autocomplete={MESSAGE_COMPOSER_TEXTAREA_ARIA_AUTOCOMPLETE}
           className={`flex-1 bg-zinc-900 border rounded-lg px-3 py-2 text-sm text-zinc-200 placeholder-zinc-500 resize-none focus:outline-none focus:border-cyan-500/50 transition-all ${
             hasLengthError
               ? "border-red-500/70 focus:border-red-500/80"


### PR DESCRIPTION
## Summary
- harden the room chat composer textarea against mobile Chrome/password-manager autofill heuristics
- add passive password-manager ignore data attributes directly on the focused textarea
- keep neutral field identifiers and add `aria-autocomplete="none"`
- extend rendered DOM regression coverage for the new attributes

## Verification
- `MISE_TRUSTED_CONFIG_PATHS=$PWD pnpm --dir frontend exec vitest run src/components/dashboard/MessageComposer.test.ts` => 1 file / 10 tests passed
- `git diff --check` => passed

## Context
PR #858 was released to production, but the user still saw the mobile Chrome password/password-manager bar on the room chat input. This v2 keeps the first fix and adds common vendor ignore hints (`data-lpignore`, `data-1p-ignore`, `data-bwignore`, `data-protonpass-ignore`) as passive metadata.

## Review
- Code Reviewer found no findings on the v2 worktree.
