### PR TITLE
feat(frontend): replace native confirm/alert with themed dialog

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -11,6 +11,7 @@ import NextTopLoader from "nextjs-toploader";
 import { inter, jetbrainsMono } from "@/lib/fonts";
 import { getAppBaseUrl } from "@/lib/share-metadata";
 import { GoogleAnalytics } from "@/components/analytics/GoogleAnalytics";
+import ConfirmDialog from "@/components/ui/ConfirmDialog";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -55,6 +56,7 @@ export default function RootLayout({
           zIndex={2000}
         />
         {children}
+        <ConfirmDialog />
         <Analytics />
         <GoogleAnalytics />
       </body>

--- a/frontend/src/components/admin/AdminCodesPage.tsx
+++ b/frontend/src/components/admin/AdminCodesPage.tsx
@@ -8,8 +8,10 @@
 import { useCallback, useEffect, useState } from "react";
 import { Loader2, Plus, XCircle } from "lucide-react";
 import { adminBetaApi, type BetaInviteCode } from "@/lib/api";
+import { useConfirm } from "@/store/useConfirmStore";
 
 export default function AdminCodesPage() {
+  const confirm = useConfirm();
   const [codes, setCodes] = useState<BetaInviteCode[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -54,7 +56,14 @@ export default function AdminCodesPage() {
   }
 
   async function handleRevoke(id: string) {
-    if (!confirm("确认撤销此邀请码？撤销后无法继续使用。")) return;
+    if (
+      !(await confirm({
+        title: "确认撤销此邀请码？",
+        message: "撤销后无法继续使用。",
+        tone: "danger",
+      }))
+    )
+      return;
     try {
       await adminBetaApi.revokeCode(id);
       await fetchCodes();

--- a/frontend/src/components/admin/AdminWaitlistPage.tsx
+++ b/frontend/src/components/admin/AdminWaitlistPage.tsx
@@ -8,10 +8,12 @@
 import { useCallback, useEffect, useState } from "react";
 import { Loader2, CheckCircle, XCircle, Copy } from "lucide-react";
 import { adminBetaApi, type BetaWaitlistEntry } from "@/lib/api";
+import { useConfirm } from "@/store/useConfirmStore";
 
 type StatusFilter = "pending" | "approved" | "rejected";
 
 export default function AdminWaitlistPage() {
+  const confirm = useConfirm();
   const [entries, setEntries] = useState<BetaWaitlistEntry[]>([]);
   const [filter, setFilter] = useState<StatusFilter>("pending");
   const [loading, setLoading] = useState(true);
@@ -57,7 +59,7 @@ export default function AdminWaitlistPage() {
   }
 
   async function handleReject(id: string) {
-    if (!confirm("确认拒绝此申请？")) return;
+    if (!(await confirm({ title: "确认拒绝此申请？", tone: "danger" }))) return;
     setPendingAction(id);
     try {
       await adminBetaApi.rejectWaitlist(id);

--- a/frontend/src/components/dashboard/BotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/BotDetailDrawer.tsx
@@ -26,6 +26,7 @@ import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import { isOwnerChatRoom } from "@/store/dashboard-shared";
 import { useDaemonStore, type DaemonInstance } from "@/store/useDaemonStore";
+import { useConfirm } from "@/store/useConfirmStore";
 import { useLanguage } from "@/lib/i18n";
 import { botDetailDrawer } from "@/lib/i18n/translations/dashboard";
 import {
@@ -378,6 +379,7 @@ function OverviewTab({
   onOpenChat: () => void;
 }) {
   const runtimeId = getBotRuntimeId(bot, device);
+  const confirm = useConfirm();
   return (
     <div className="space-y-4">
       <ProfileEditor
@@ -538,8 +540,8 @@ function OverviewTab({
 
       <section className="rounded-2xl border border-red-500/25 bg-red-500/5 p-4">
         <button
-          onClick={() => {
-            if (window.confirm(t.overview.deleteConfirm)) {
+          onClick={async () => {
+            if (await confirm({ title: t.overview.deleteConfirm, tone: "danger" })) {
               void userApi.unbindAgent(bot.agent_id).then(() => window.location.reload());
             }
           }}

--- a/frontend/src/components/dashboard/BotWalletTab.tsx
+++ b/frontend/src/components/dashboard/BotWalletTab.tsx
@@ -16,6 +16,7 @@ import { common } from "@/lib/i18n/translations/common";
 import { api, ApiError, type ActiveIdentity } from "@/lib/api";
 import { useDashboardWalletStore } from "@/store/useDashboardWalletStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
+import { useConfirm } from "@/store/useConfirmStore";
 import { BotCordLoader, MobileBotCordLoading } from "@/components/ui/BotCordLoader";
 import TransferDialog from "./TransferDialog";
 import TopupDialog from "./TopupDialog";
@@ -320,24 +321,25 @@ function BotWithdrawals({
 }) {
   const locale = useLanguage();
   const t = walletPanel[locale];
+  const confirm = useConfirm();
   const [cancellingId, setCancellingId] = useState<string | null>(null);
 
   const handleCancel = useCallback(
     async (withdrawalId: string) => {
-      if (!window.confirm(t.cancelWithdrawalConfirm)) return;
+      if (!(await confirm({ title: t.cancelWithdrawalConfirm, tone: "danger" }))) return;
       setCancellingId(withdrawalId);
       try {
         await api.cancelWithdrawal(withdrawalId, viewer);
-        window.alert(t.cancelWithdrawalSuccess);
+        await confirm({ title: t.cancelWithdrawalSuccess, alert: true });
         onCancelled();
       } catch (err) {
-        if (err instanceof ApiError) window.alert(err.message);
-        else window.alert(t.cancelWithdrawalFailed);
+        if (err instanceof ApiError) await confirm({ title: err.message, alert: true });
+        else await confirm({ title: t.cancelWithdrawalFailed, alert: true });
       } finally {
         setCancellingId(null);
       }
     },
-    [onCancelled, t, viewer],
+    [confirm, onCancelled, t, viewer],
   );
 
   return (

--- a/frontend/src/components/dashboard/MemberActionsMenu.tsx
+++ b/frontend/src/components/dashboard/MemberActionsMenu.tsx
@@ -12,6 +12,7 @@ import type { PublicRoomMember } from "@/lib/types";
 import { humansApi } from "@/lib/api";
 import { useLanguage } from "@/lib/i18n";
 import { agentBrowser } from "@/lib/i18n/translations/dashboard";
+import { useConfirm } from "@/store/useConfirmStore";
 
 interface Props {
   roomId: string;
@@ -28,6 +29,7 @@ export default function MemberActionsMenu({
 }: Props) {
   const locale = useLanguage();
   const t = agentBrowser[locale];
+  const confirm = useConfirm();
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
   const [permOpen, setPermOpen] = useState(false);
@@ -62,7 +64,7 @@ export default function MemberActionsMenu({
   });
 
   const doRemove = () => guard(async () => {
-    if (!window.confirm(t.removeMemberConfirm)) return;
+    if (!(await confirm({ title: t.removeMemberConfirm, tone: "danger" }))) return;
     try {
       await humansApi.removeRoomMember(roomId, member.agent_id);
       onMutated();

--- a/frontend/src/components/dashboard/MessageBubble.tsx
+++ b/frontend/src/components/dashboard/MessageBubble.tsx
@@ -21,6 +21,7 @@ import TransferCard, { parseTransferText, parseTransferNotice } from "@/componen
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
+import { useConfirm } from "@/store/useConfirmStore";
 import BotAvatar from "./BotAvatar";
 import { PresenceDot } from "./PresenceDot";
 
@@ -358,6 +359,7 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
   const selectAgent = useDashboardChatStore((state) => state.selectAgent);
   const getRoomSummary = useDashboardChatStore((state) => state.getRoomSummary);
   const recallMessage = useDashboardChatStore((state) => state.recallMessage);
+  const confirm = useConfirm();
   const overview = useDashboardChatStore((state) => state.overview);
   const publicAgents = useDashboardChatStore((state) => state.publicAgents);
   const publicHumans = useDashboardChatStore((state) => state.publicHumans);
@@ -499,7 +501,10 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
   const handleRecallClick = async () => {
     setMenuOpen(false);
     if (!canRecall || !message.room_id) return;
-    const ok = window.confirm(locale === "zh" ? "撤回这条消息？" : "Recall this message?");
+    const ok = await confirm({
+      title: locale === "zh" ? "撤回这条消息？" : "Recall this message?",
+      tone: "danger",
+    });
     if (!ok) return;
     setRecallPending(true);
     try {

--- a/frontend/src/components/dashboard/WalletPanel.tsx
+++ b/frontend/src/components/dashboard/WalletPanel.tsx
@@ -22,6 +22,7 @@ import {
   type MergedLedgerEntry,
 } from "@/store/useDashboardWalletStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
+import { useConfirm } from "@/store/useConfirmStore";
 import BotAvatar from "./BotAvatar";
 import TransferDialog from "./TransferDialog";
 import TopupDialog from "./TopupDialog";
@@ -572,28 +573,29 @@ function RecentWithdrawals({
 }) {
   const locale = useLanguage();
   const t = walletPanel[locale];
+  const confirm = useConfirm();
   const [cancellingId, setCancellingId] = useState<string | null>(null);
   const isRefreshing = loading && items.length > 0;
 
   const handleCancel = useCallback(
     async (withdrawalId: string) => {
-      if (!window.confirm(t.cancelWithdrawalConfirm)) return;
+      if (!(await confirm({ title: t.cancelWithdrawalConfirm, tone: "danger" }))) return;
       setCancellingId(withdrawalId);
       try {
         await api.cancelWithdrawal(withdrawalId, viewer);
-        window.alert(t.cancelWithdrawalSuccess);
+        await confirm({ title: t.cancelWithdrawalSuccess, alert: true });
         onCancelled();
       } catch (err) {
         if (err instanceof ApiError) {
-          window.alert(err.message);
+          await confirm({ title: err.message, alert: true });
         } else {
-          window.alert(t.cancelWithdrawalFailed);
+          await confirm({ title: t.cancelWithdrawalFailed, alert: true });
         }
       } finally {
         setCancellingId(null);
       }
     },
-    [onCancelled, t, viewer],
+    [confirm, onCancelled, t, viewer],
   );
 
   return (

--- a/frontend/src/components/dashboard/WithdrawDialog.tsx
+++ b/frontend/src/components/dashboard/WithdrawDialog.tsx
@@ -80,7 +80,7 @@ export default function WithdrawDialog({ viewer, onClose, onSuccess, availableBa
 
     const amountMinor = Math.round(amountNum * 100);
     if (amountMinor < MIN_WITHDRAWAL_MINOR) {
-      window.alert(t.minimumWithdrawAmount);
+      setError(t.minimumWithdrawAmount);
       return;
     }
 

--- a/frontend/src/components/ui/ConfirmDialog.tsx
+++ b/frontend/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,109 @@
+/**
+ * [INPUT]: 订阅 useConfirmStore 的当前请求，依赖 useLanguage 决定按钮文案语言
+ * [OUTPUT]: 全局唯一的主题化确认/提示对话框宿主，挂载一次即覆盖全站 window.confirm/alert 场景
+ * [POS]: 在 RootLayout body 末尾挂载，是 marketing 与 dashboard 共用的确认弹窗出口
+ * [PROTOCOL]: 与 store/useConfirmStore.ts 成对维护，新增选项字段时两侧同步
+ */
+"use client";
+
+import { useEffect, useRef } from "react";
+import { AlertTriangle, X } from "lucide-react";
+import { useLanguage } from "@/lib/i18n";
+import { confirmDialog } from "@/lib/i18n/translations/common";
+import { useConfirmStore } from "@/store/useConfirmStore";
+
+export default function ConfirmDialog() {
+  const current = useConfirmStore((s) => s.current);
+  const close = useConfirmStore((s) => s.close);
+  const locale = useLanguage();
+  const t = confirmDialog[locale];
+  const confirmButtonRef = useRef<HTMLButtonElement>(null);
+
+  const isAlert = current?.alert ?? false;
+  const isDanger = current?.tone === "danger";
+
+  // Escape 取消（alert 模式下等同于关闭），并把焦点移到主操作按钮。
+  useEffect(() => {
+    if (!current) return;
+    confirmButtonRef.current?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        close(isAlert);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [current, close, isAlert]);
+
+  if (!current) return null;
+
+  const confirmLabel =
+    current.confirmLabel ?? (isAlert ? t.ok : t.confirm);
+  const cancelLabel = current.cancelLabel ?? t.cancel;
+
+  const confirmClasses = isDanger
+    ? "border-red-500/40 bg-red-500/10 text-red-300 hover:bg-red-500/20"
+    : "border-neon-cyan/40 bg-neon-cyan/10 text-neon-cyan hover:bg-neon-cyan/20";
+
+  return (
+    <div
+      className="fixed inset-0 z-[120] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm"
+      role="presentation"
+      onClick={() => close(isAlert)}
+    >
+      <div
+        role="alertdialog"
+        aria-modal="true"
+        aria-label={current.title}
+        className="relative w-full max-w-md rounded-2xl border border-glass-border bg-deep-black-light p-5 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          type="button"
+          onClick={() => close(isAlert)}
+          className="absolute right-4 top-4 rounded-full p-1.5 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
+          aria-label={cancelLabel}
+        >
+          <X className="h-5 w-5" />
+        </button>
+
+        <div className="flex gap-3 pr-8">
+          {isDanger ? (
+            <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-red-500/30 bg-red-500/10 text-red-300">
+              <AlertTriangle className="h-5 w-5" />
+            </span>
+          ) : null}
+          <div className="min-w-0">
+            <h3 className="text-lg font-bold text-text-primary">{current.title}</h3>
+            {current.message ? (
+              <p className="mt-2 whitespace-pre-line text-sm text-text-secondary">
+                {current.message}
+              </p>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="mt-5 flex justify-end gap-2">
+          {isAlert ? null : (
+            <button
+              type="button"
+              onClick={() => close(false)}
+              className="rounded-lg border border-glass-border px-3 py-1.5 text-sm text-text-secondary transition-colors hover:bg-glass-bg"
+            >
+              {cancelLabel}
+            </button>
+          )}
+          <button
+            ref={confirmButtonRef}
+            type="button"
+            onClick={() => close(true)}
+            className={`rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors ${confirmClasses}`}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/i18n/translations/common.ts
+++ b/frontend/src/lib/i18n/translations/common.ts
@@ -91,3 +91,20 @@ export const common: TranslationMap<{
     showLess: '收起',
   },
 }
+
+export const confirmDialog: TranslationMap<{
+  confirm: string
+  cancel: string
+  ok: string
+}> = {
+  en: {
+    confirm: 'Confirm',
+    cancel: 'Cancel',
+    ok: 'OK',
+  },
+  zh: {
+    confirm: '确认',
+    cancel: '取消',
+    ok: '知道了',
+  },
+}

--- a/frontend/src/store/useConfirmStore.ts
+++ b/frontend/src/store/useConfirmStore.ts
@@ -1,0 +1,70 @@
+/**
+ * [INPUT]: 依赖 zustand 维护全局唯一的确认/提示请求队列槽位
+ * [OUTPUT]: 对外提供 useConfirmStore（原子状态）与 useConfirm hook（promise-based 调用入口）
+ * [POS]: 全局确认对话框的状态中枢，取代散落各处的 window.confirm / window.alert
+ * [PROTOCOL]: 与 components/ui/ConfirmDialog.tsx（渲染宿主）成对维护，变更选项字段时两侧同步
+ */
+"use client";
+
+import { useCallback } from "react";
+import { create } from "zustand";
+
+export type ConfirmTone = "default" | "danger";
+
+export interface ConfirmOptions {
+  /** 主标题，必填。 */
+  title: string;
+  /** 可选的补充说明，渲染在标题下方。 */
+  message?: string;
+  /** 确认按钮文案，缺省按语言回退为「确认 / Confirm」（alert 模式下为「知道了 / OK」）。 */
+  confirmLabel?: string;
+  /** 取消按钮文案，缺省按语言回退为「取消 / Cancel」。 */
+  cancelLabel?: string;
+  /** danger 时确认按钮使用红色危险样式。 */
+  tone?: ConfirmTone;
+  /** 单按钮告知模式（取代 window.alert），仅展示确认按钮。 */
+  alert?: boolean;
+}
+
+interface ConfirmRequest extends ConfirmOptions {
+  resolve: (value: boolean) => void;
+}
+
+interface ConfirmState {
+  current: ConfirmRequest | null;
+  open: (request: ConfirmRequest) => void;
+  /** 关闭当前对话框并回传结果（确认 true / 取消 false）。 */
+  close: (result: boolean) => void;
+}
+
+export const useConfirmStore = create<ConfirmState>((set, get) => ({
+  current: null,
+  open: (request) => {
+    // 若已有未决请求，先以「取消」结算，避免 promise 悬挂。
+    const previous = get().current;
+    if (previous) previous.resolve(false);
+    set({ current: request });
+  },
+  close: (result) => {
+    const request = get().current;
+    if (request) request.resolve(result);
+    set({ current: null });
+  },
+}));
+
+/**
+ * Promise-based 确认入口。用法：
+ *   const confirm = useConfirm();
+ *   if (!(await confirm({ title: "删除此 Agent？", tone: "danger" }))) return;
+ * alert 形式：await confirm({ title: "提交成功", alert: true });
+ */
+export function useConfirm() {
+  const open = useConfirmStore((s) => s.open);
+  return useCallback(
+    (options: ConfirmOptions) =>
+      new Promise<boolean>((resolve) => {
+        open({ ...options, resolve });
+      }),
+    [open],
+  );
+}


### PR DESCRIPTION
## What

Replaces all browser-native `window.confirm` / `window.alert` calls in the dashboard with a **global promise-based confirmation system** styled to match our theme (deep-black glass surface, neon-cyan / red-danger accents, `rounded-2xl`).

## How

- **`store/useConfirmStore.ts`** — zustand slot + `useConfirm()` hook returning `Promise<boolean>`. Supports `tone: "danger"` and single-button `alert` mode.
- **`components/ui/ConfirmDialog.tsx`** — single host mounted once in `RootLayout`. Escape-to-cancel, backdrop dismiss, autofocus, accessible `role="alertdialog"`.
- **i18n** — `confirmDialog` labels (confirm / cancel / ok) in `common.ts` (en/zh).

Call sites become one-liners:
```ts
const confirm = useConfirm();
if (!(await confirm({ title: "...", tone: "danger" }))) return;  // confirm
await confirm({ title: "...", alert: true });                     // alert
```

## Replaced (15 sites)

`window.confirm` → themed danger dialog: AdminWaitlistPage, AdminCodesPage, BotDetailDrawer (delete agent), WalletPanel / BotWalletTab (cancel withdrawal), MemberActionsMenu (remove member), MessageBubble (recall).

`window.alert` → themed alert dialog: WalletPanel / BotWalletTab success/failure/API-error notices.

WithdrawDialog's min-amount `alert` → existing inline `setError` (consistent with its other form validations; a modal is overkill there).

## Test

`next build` TypeScript compile passes. (Static prerender of `/admin/codes` fails only due to missing Supabase env vars in the build sandbox — unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)