### PR TITLE
fix: allow replies and recall for owned bot messages

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -20,6 +20,7 @@ from app.auth import RequestContext, require_active_agent, require_user, require
 from app.auth_room import (
     effective_human_room_role,
     effective_human_send_member,
+    load_owned_agent_ids,
     resolve_provider_agent_for_room,
     viewer_can_admin_room,
 )
@@ -2528,6 +2529,12 @@ async def recall_room_message(
         raise HTTPException(status_code=400, detail="Only message records can be recalled")
 
     capability = await viewer_can_admin_room(db, ctx, room)
+    owned_agent_ids = (
+        await load_owned_agent_ids(db, ctx.user_id)
+        if actor_type == ParticipantType.human
+        else set()
+    )
+    is_owned_bot_sender = target.sender_id in owned_agent_ids
     member = (
         await db.execute(
             select(RoomMember).where(
@@ -2537,7 +2544,7 @@ async def recall_room_message(
             )
         )
     ).scalar_one_or_none()
-    if capability is None and member is None:
+    if capability is None and member is None and not is_owned_bot_sender:
         raise HTTPException(status_code=403, detail="Not a member of this room")
 
     source_user_id = str(ctx.user_id) if ctx.user_id is not None else None
@@ -2546,6 +2553,9 @@ async def recall_room_message(
         and target.source_type == "dashboard_human_room"
         and source_user_id is not None
         and str(target.source_user_id) == source_user_id
+    ) or (
+        actor_type == ParticipantType.human
+        and is_owned_bot_sender
     )
     if capability is None and not is_sender:
         raise HTTPException(status_code=403, detail="Only the sender or room admins can recall this message")

--- a/backend/tests/test_app/test_app_dashboard.py
+++ b/backend/tests/test_app/test_app_dashboard.py
@@ -465,6 +465,51 @@ async def test_dashboard_member_recall_respects_two_minute_window(
 
 
 @pytest.mark.asyncio
+async def test_human_owner_can_recall_fresh_owned_bot_message(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    seed_data: dict,
+):
+    room = Room(
+        room_id="rm_owned_bot_recall",
+        name="Owned Bot Recall",
+        description="",
+        owner_id="ag_other00001",
+        visibility=RoomVisibility.private,
+        join_policy=RoomJoinPolicy.invite_only,
+    )
+    db_session.add(room)
+    db_session.add(RoomMember(
+        room_id="rm_owned_bot_recall",
+        agent_id="ag_dashtest001",
+        participant_type=ParticipantType.agent,
+        role=RoomRole.member,
+    ))
+    db_session.add(MessageRecord(
+        hub_msg_id="hm_owned_bot_recall",
+        msg_id="msg_owned_bot_recall",
+        sender_id="ag_dashtest001",
+        receiver_id="ag_dashtest001",
+        room_id="rm_owned_bot_recall",
+        envelope_json='{"from":"ag_dashtest001","type":"message","payload":{"text":"owned bot fresh"}}',
+        state=MessageState.queued,
+        ttl_sec=3600,
+        created_at=datetime.datetime.now(datetime.timezone.utc),
+    ))
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/dashboard/rooms/rm_owned_bot_recall/messages/msg_owned_bot_recall/recall",
+        headers={"Authorization": f"Bearer {seed_data['token']}"},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["is_recalled"] is True
+    assert data["recalled_by_id"] == seed_data["user"].human_id
+    assert data["recalled_by_type"] == "human"
+
+
+@pytest.mark.asyncio
 async def test_dashboard_overview_human_mode(
     client: AsyncClient, seed_data: dict
 ):

--- a/frontend/src/components/dashboard/MessageBubble.tsx
+++ b/frontend/src/components/dashboard/MessageBubble.tsx
@@ -9,6 +9,7 @@ import ReplyQuoteBlock from "./ReplyQuoteBlock";
 import { emitJumpToMessage } from "./messageNavigation";
 import RuntimeErrorDetailsDialog from "./RuntimeErrorDetailsDialog";
 import type { DashboardMessage, Attachment } from "@/lib/types";
+import { canReplyToDashboardMessage } from "@/lib/dashboard-message-actions";
 import { useLanguage } from '@/lib/i18n';
 import { messageBubble } from '@/lib/i18n/translations/dashboard';
 import { canRecallDashboardMessage, isDashboardMessageRecalled, recalledMessageLabel } from "@/lib/message-recall";
@@ -473,13 +474,7 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
     if (displayText) setForwardQuote(buildQuote());
   };
 
-  const canQuoteReply =
-    message.type === "message"
-    && Boolean(message.room_id)
-    && Boolean(message.msg_id)
-    && !message.hub_msg_id?.startsWith("tmp_")
-    && !message.msg_id?.startsWith("tmp_")
-    && !isRecalled;
+  const canQuoteReply = canReplyToDashboardMessage(message);
 
   const roomSummary = message.room_id ? getRoomSummary(message.room_id) : null;
   const canRecall = canRecallDashboardMessage({
@@ -541,7 +536,7 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
     />
   );
 
-  const moreButton = !isRecalled && (displayText || canRecall) && (
+  const moreButton = !isRecalled && (displayText || canQuoteReply || canRecall) && (
     <div className="relative shrink-0">
       <button
         type="button"
@@ -560,7 +555,7 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
               className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100 transition-colors"
             >
               <CornerUpLeft className="h-3.5 w-3.5 text-zinc-500" />
-              引用回复
+              {locale === "zh" ? "回复" : "Reply"}
             </button>
           )}
           {displayText && (

--- a/frontend/src/components/dashboard/RoomHumanComposer.tsx
+++ b/frontend/src/components/dashboard/RoomHumanComposer.tsx
@@ -10,6 +10,7 @@ import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardWalletStore } from "@/store/useDashboardWalletStore";
 import { useShallow } from "zustand/react/shallow";
 import MessageComposer from "./MessageComposer";
+import { dashboardReplyTargetId } from "@/lib/dashboard-message-actions";
 import { useMentionCandidates } from "@/hooks/useMentionCandidates";
 import { CornerUpLeft, Loader2, X } from "lucide-react";
 import DashboardSelect from "./DashboardSelect";
@@ -334,10 +335,10 @@ export default function RoomHumanComposer({ roomId, topicId = null }: RoomHumanC
     const clientTempId = `tmp_${crypto.randomUUID()}`;
     const now = new Date().toISOString();
     const displayText = text || (attachments ? `[${attachments.length} file(s)]` : "");
-    const replyTargetMsgId = replyingTo?.msg_id ?? null;
-    const optimisticReplyPreview = replyingTo
+    const replyTargetMsgId = replyingTo ? dashboardReplyTargetId(replyingTo) : null;
+    const optimisticReplyPreview = replyingTo && replyTargetMsgId
       ? {
-          msg_id: replyingTo.msg_id,
+          msg_id: replyTargetMsgId,
           sender_id: replyingTo.sender_id,
           sender_display_name:
             replyingTo.display_sender_name || replyingTo.sender_name || null,

--- a/frontend/src/lib/dashboard-message-actions.test.ts
+++ b/frontend/src/lib/dashboard-message-actions.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import type { DashboardMessage } from "@/lib/types";
+import { canReplyToDashboardMessage, dashboardReplyTargetId } from "@/lib/dashboard-message-actions";
+
+function message(overrides: Partial<DashboardMessage> = {}): DashboardMessage {
+  return {
+    hub_msg_id: "hub_1",
+    msg_id: "msg_1",
+    sender_id: "ag_sender",
+    sender_name: "Sender",
+    type: "message",
+    text: "hello",
+    payload: { text: "hello" },
+    room_id: "rm_1",
+    topic: null,
+    topic_id: null,
+    goal: null,
+    state: "queued",
+    state_counts: null,
+    created_at: "2026-05-29T08:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("dashboard message actions", () => {
+  it("uses canonical msg_id as the reply target when available", () => {
+    expect(dashboardReplyTargetId(message())).toBe("msg_1");
+  });
+
+  it("falls back to hub_msg_id so realtime bot messages can be replied to", () => {
+    expect(dashboardReplyTargetId(message({ msg_id: "tmp_local", hub_msg_id: "hub_real" }))).toBe("hub_real");
+  });
+
+  it("allows replies to any persisted non-system room message", () => {
+    expect(canReplyToDashboardMessage(message({ type: "result", msg_id: "msg_result" }))).toBe(true);
+    expect(canReplyToDashboardMessage(message({ type: "error", msg_id: "msg_error" }))).toBe(true);
+  });
+
+  it("does not allow replies to system, recalled, or temporary messages", () => {
+    expect(canReplyToDashboardMessage(message({ type: "system" }))).toBe(false);
+    expect(canReplyToDashboardMessage(message({ is_recalled: true }))).toBe(false);
+    expect(canReplyToDashboardMessage(message({ hub_msg_id: "tmp_1", msg_id: "tmp_1" }))).toBe(false);
+  });
+});

--- a/frontend/src/lib/dashboard-message-actions.ts
+++ b/frontend/src/lib/dashboard-message-actions.ts
@@ -1,0 +1,25 @@
+import type { DashboardMessage } from "@/lib/types";
+import { isDashboardMessageRecalled } from "@/lib/message-recall";
+
+function isTemporaryMessageId(id: string | null | undefined): boolean {
+  return !id || id.startsWith("tmp_");
+}
+
+export function dashboardReplyTargetId(
+  message: Pick<DashboardMessage, "hub_msg_id" | "msg_id">,
+): string | null {
+  if (!isTemporaryMessageId(message.msg_id)) return message.msg_id;
+  if (!isTemporaryMessageId(message.hub_msg_id)) return message.hub_msg_id;
+  return null;
+}
+
+export function canReplyToDashboardMessage(
+  message: Pick<DashboardMessage, "hub_msg_id" | "is_recalled" | "msg_id" | "payload" | "recalled_at" | "room_id" | "type">,
+): boolean {
+  return Boolean(
+    message.room_id
+      && message.type !== "system"
+      && dashboardReplyTargetId(message)
+      && !isDashboardMessageRecalled(message),
+  );
+}

--- a/frontend/src/lib/message-recall.test.ts
+++ b/frontend/src/lib/message-recall.test.ts
@@ -96,4 +96,20 @@ describe("canRecallDashboardMessage", () => {
       nowMs: Date.parse("2026-05-29T08:01:00.000Z"),
     })).toBe(true);
   });
+
+  it("allows the human owner to recall their own bot's fresh room message", () => {
+    expect(canRecallDashboardMessage({
+      message: message({
+        sender_id: "ag_owned",
+        source_user_id: null,
+        created_at: "2026-05-29T08:00:00.000Z",
+      }),
+      room: room({ owner_id: "ag_other", owner_type: "agent", my_role: "member" }),
+      isOwn: false,
+      ownedAgentIds: ["ag_owned"],
+      humanId: "hu_1",
+      userId: "user_1",
+      nowMs: Date.parse("2026-05-29T08:01:00.000Z"),
+    })).toBe(true);
+  });
 });

--- a/frontend/src/lib/message-recall.ts
+++ b/frontend/src/lib/message-recall.ts
@@ -60,6 +60,7 @@ export function canRecallDashboardMessage({
   const isViewerAuthored =
     isOwn
     || Boolean(humanId && message.sender_id === humanId)
+    || ownedAgentIds.includes(message.sender_id)
     || Boolean(userId && message.source_user_id === userId);
   if (!isViewerAuthored) return false;
 


### PR DESCRIPTION
## Summary
- rename the room message action from 引用回复 to 回复
- allow reply actions for any persisted non-system room message, falling back to hub_msg_id when canonical msg_id is not available yet
- allow human owners to recall fresh messages sent by their owned bots, preserving the normal two-minute recall window

## Verification
- cd frontend && npm test -- --run src/lib/dashboard-message-actions.test.ts src/lib/message-recall.test.ts src/store/useDashboardChatStore.test.ts src/components/dashboard/RoomHumanComposer.test.ts
- cd frontend && NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build
- cd backend && uv run pytest tests/test_app/test_app_dashboard.py::test_human_owner_can_recall_fresh_owned_bot_message tests/test_app/test_app_dashboard.py::test_dashboard_member_recall_respects_two_minute_window tests/test_app/test_app_dashboard.py::test_dashboard_owner_can_recall_any_room_message -q

## Risk / rollout
- Small frontend/backend permission alignment change; no migration.