### PR TITLE
fix: keep actions on dashboard topic messages

### DIFF
--- a/frontend/src/components/dashboard/MessageBubble.tsx
+++ b/frontend/src/components/dashboard/MessageBubble.tsx
@@ -408,6 +408,10 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
     || publicHuman?.avatar_url
     || message.sender_avatar_url
     || null;
+  const effectiveRoomId = message.room_id || (sourceId?.startsWith("rm_") ? sourceId : null);
+  const actionMessage = effectiveRoomId && effectiveRoomId !== message.room_id
+    ? { ...message, room_id: effectiveRoomId }
+    : message;
 
   if (message.type === "system") {
     const joinParticipant = getSystemJoinParticipant(message.payload);
@@ -474,11 +478,11 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
     if (displayText) setForwardQuote(buildQuote());
   };
 
-  const canQuoteReply = canReplyToDashboardMessage(message);
+  const canQuoteReply = canReplyToDashboardMessage(actionMessage);
 
-  const roomSummary = message.room_id ? getRoomSummary(message.room_id) : null;
+  const roomSummary = effectiveRoomId ? getRoomSummary(effectiveRoomId) : null;
   const canRecall = canRecallDashboardMessage({
-    message,
+    message: actionMessage,
     room: roomSummary,
     isOwn,
     ownedAgentIds: ownedAgents.map((agent) => agent.agent_id),
@@ -488,13 +492,13 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
 
   const handleReplyClick = () => {
     setMenuOpen(false);
-    if (!canQuoteReply || !message.room_id) return;
-    setReplyingTo(message.room_id, message);
+    if (!canQuoteReply || !effectiveRoomId) return;
+    setReplyingTo(effectiveRoomId, actionMessage);
   };
 
   const handleRecallClick = async () => {
     setMenuOpen(false);
-    if (!canRecall || !message.room_id) return;
+    if (!canRecall || !effectiveRoomId) return;
     const ok = await confirm({
       title: locale === "zh" ? "撤回这条消息？" : "Recall this message?",
       tone: "danger",
@@ -502,7 +506,7 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
     if (!ok) return;
     setRecallPending(true);
     try {
-      await recallMessage(message.room_id, message.msg_id);
+      await recallMessage(effectiveRoomId, message.msg_id);
     } catch {
       /* error toast is handled by the chat store */
     } finally {
@@ -511,7 +515,7 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
   };
 
   const handleJumpToReplyTarget = (targetMsgId: string) => {
-    emitJumpToMessage({ msgId: targetMsgId, roomId: message.room_id ?? undefined });
+    emitJumpToMessage({ msgId: targetMsgId, roomId: effectiveRoomId ?? undefined });
   };
 
   const handleCopyClick = useCallback(async () => {

--- a/frontend/src/components/dashboard/MessageList.test.ts
+++ b/frontend/src/components/dashboard/MessageList.test.ts
@@ -1,0 +1,65 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import type { DashboardMessage } from "@/lib/types";
+import { TopicCard } from "./MessageList";
+
+vi.mock("@/lib/i18n", () => ({
+  useLanguage: () => "zh",
+}));
+
+vi.mock("./MessageBubble", async () => {
+  const React = await import("react");
+  return {
+    default: ({ message }: { message: DashboardMessage }) => (
+      React.createElement("article", { "data-message-bubble": message.msg_id }, message.text)
+    ),
+  };
+});
+
+function message(overrides: Partial<DashboardMessage> = {}): DashboardMessage {
+  return {
+    hub_msg_id: "hub_1",
+    msg_id: "msg_1",
+    sender_id: "ag_sender",
+    sender_name: "Sender",
+    type: "message",
+    text: "hello",
+    payload: { text: "hello" },
+    room_id: "rm_1",
+    topic: "Topic",
+    topic_id: "topic_1",
+    goal: null,
+    state: "delivered",
+    state_counts: null,
+    created_at: "2026-05-29T12:00:00Z",
+    source_type: null,
+    ...overrides,
+  };
+}
+
+describe("TopicCard", () => {
+  it("renders every topic message through MessageBubble so message actions stay available", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(TopicCard, {
+        group: {
+          topicId: "topic_1",
+          topicInfo: null,
+          topicName: "Topic",
+          messages: [
+            message({ hub_msg_id: "hub_1", msg_id: "msg_1", text: "first" }),
+            message({ hub_msg_id: "hub_2", msg_id: "msg_2", text: "bot reply", sender_id: "ag_owned_bot" }),
+            message({ hub_msg_id: "hub_3", msg_id: "msg_3", text: "history" }),
+          ],
+        },
+        currentAgentId: "ag_current",
+        onOpen: () => {},
+      }),
+    );
+
+    expect(html.match(/data-message-bubble=/g)).toHaveLength(3);
+    expect(html).toContain("first");
+    expect(html).toContain("bot reply");
+    expect(html).toContain("history");
+  });
+});

--- a/frontend/src/components/dashboard/MessageList.tsx
+++ b/frontend/src/components/dashboard/MessageList.tsx
@@ -10,7 +10,6 @@
 import { useEffect, useRef, useCallback, useMemo, useState } from "react";
 import { useLanguage } from '@/lib/i18n';
 import { messageList } from '@/lib/i18n/translations/dashboard';
-import { isDashboardMessageRecalled, recalledMessageLabel } from "@/lib/message-recall";
 import { useShallow } from "zustand/react/shallow";
 import { Bot, Settings, UserPlus } from "lucide-react";
 import MessageBubble from "./MessageBubble";
@@ -94,22 +93,11 @@ function buildTimelineItems(
   return items;
 }
 
-const TOPIC_PREVIEW_COUNT = 2;
 const PREFILL_ROOM_COMPOSER_EVENT = "botcord:prefill-room-composer";
 const OPEN_ROOM_ADD_MEMBER_EVENT = "botcord:open-room-add-member";
 const OPEN_ROOM_SETTINGS_EVENT = "botcord:open-room-settings";
 
-function messagePreviewText(msg: DashboardMessage, locale: string): string {
-  if (isDashboardMessageRecalled(msg)) return recalledMessageLabel(locale);
-  if (msg.text) return msg.text;
-  if (typeof msg.payload === "object" && msg.payload && "text" in msg.payload) {
-    const text = (msg.payload as { text?: unknown }).text;
-    if (typeof text === "string") return text;
-  }
-  return "";
-}
-
-function TopicCard({
+export function TopicCard({
   group,
   currentAgentId,
   sourceName,
@@ -128,16 +116,6 @@ function TopicCard({
   const locale = useLanguage();
   const t = messageList[locale];
   const sc = group.topicInfo ? topicStatusConfig[group.topicInfo.status] : null;
-
-  const total = group.messages.length;
-  const firstMsg = group.messages[0];
-  // Show the first message as a full bubble, and up to TOPIC_PREVIEW_COUNT of
-  // the most recent messages as compact preview rows (excluding the first).
-  const recentPreview = group.messages
-    .slice(-TOPIC_PREVIEW_COUNT)
-    .filter((m) => !firstMsg || m.hub_msg_id !== firstMsg.hub_msg_id);
-  const shownCount = (firstMsg ? 1 : 0) + recentPreview.length;
-  const hiddenCount = total - shownCount;
 
   return (
     <div className="mb-4">
@@ -160,16 +138,23 @@ function TopicCard({
         )}
       </div>
 
-      {/* The first message renders as a normal bubble — no outer wrapper. */}
-      {firstMsg && (
-        <MessageBubble
-          message={firstMsg}
-          isOwn={firstMsg.sender_id === currentAgentId}
-          sourceName={sourceName}
-          sourceId={sourceId}
-          mentionCandidates={mentionCandidates}
-        />
-      )}
+      <div className="space-y-2">
+        {group.messages.map((msg) => (
+          <div
+            key={msg.hub_msg_id}
+            data-msg-id={msg.msg_id}
+            className="scroll-mt-4 transition-shadow"
+          >
+            <MessageBubble
+              message={msg}
+              isOwn={msg.sender_id === currentAgentId}
+              sourceName={sourceName}
+              sourceId={sourceId}
+              mentionCandidates={mentionCandidates}
+            />
+          </div>
+        ))}
+      </div>
 
       {/* Inline thread footer — merged into the same visual layer as the
           message above, like Feishu's "回复话题" row. Clicking opens the drawer. */}
@@ -184,46 +169,17 @@ function TopicCard({
           }
         }}
         className={`group ml-3 mt-1 cursor-pointer rounded-md px-2 py-1.5 transition-colors hover:bg-glass-bg/60 ${
-          firstMsg?.sender_id === currentAgentId ? "mr-3 ml-auto max-w-[70%]" : "max-w-[70%]"
+          group.messages[0]?.sender_id === currentAgentId ? "mr-3 ml-auto max-w-[70%]" : "max-w-[70%]"
         }`}
       >
-        {recentPreview.length > 0 ? (
-          <div className="space-y-0.5 border-l-2 border-neon-cyan/30 pl-2">
-            {recentPreview.map((msg) => {
-              const text = messagePreviewText(msg, locale);
-              const isOwn = msg.sender_id === currentAgentId;
-              const senderLabel = isOwn
-                ? (locale === "zh" ? "你" : "You")
-                : (msg.display_sender_name || msg.sender_name || msg.sender_id);
-              return (
-                <div key={msg.hub_msg_id} className="flex gap-2 text-[11px] leading-tight">
-                  <span className="shrink-0 font-medium text-text-secondary/80 max-w-[96px] truncate">
-                    {senderLabel}
-                  </span>
-                  <span className="truncate text-text-primary/70">
-                    {text || <em className="text-text-secondary/50">…</em>}
-                  </span>
-                </div>
-              );
-            })}
-            <div className="flex items-center gap-1 pt-0.5 text-[11px] text-neon-cyan/70 transition-colors group-hover:text-neon-cyan">
-              <span>💬</span>
-              <span>
-                {hiddenCount > 0
-                  ? `${hiddenCount} ${t.moreInThread} · ${t.viewThread}`
-                  : t.viewThread}
-              </span>
-              <span>→</span>
-            </div>
-          </div>
-        ) : (
-          <div className="flex items-center gap-1 text-[11px] text-neon-cyan/70 transition-colors group-hover:text-neon-cyan">
-            <span>💬</span>
-            <span>{t.viewThread}</span>
-            <span className="text-text-secondary/50">· {total} {total !== 1 ? t.msgs : t.msg}</span>
-            <span>→</span>
-          </div>
-        )}
+        <div className="flex items-center gap-1 text-[11px] text-neon-cyan/70 transition-colors group-hover:text-neon-cyan">
+          <span>💬</span>
+          <span>{t.viewThread}</span>
+          <span className="text-text-secondary/50">
+            · {group.messages.length} {group.messages.length !== 1 ? t.msgs : t.msg}
+          </span>
+          <span>→</span>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- render every topic-grouped room message through MessageBubble so reply/recall actions stay available for bot and history messages
- fall back to the current room source id for message actions when older message payloads do not include room_id
- add coverage that topic cards render each message through MessageBubble

## Verification
- npm test -- --run src/components/dashboard/MessageList.test.ts src/lib/dashboard-message-actions.test.ts src/lib/message-recall.test.ts
- NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build

## Risk / rollout
- Main room topic groups are less compact because visible topic messages now render as normal bubbles; this keeps per-message actions consistent.