### PR TITLE
fix: keep message action menus visible

### DIFF
--- a/frontend/src/components/dashboard/MessageBubble.tsx
+++ b/frontend/src/components/dashboard/MessageBubble.tsx
@@ -12,6 +12,7 @@ import type { DashboardMessage, Attachment } from "@/lib/types";
 import { canReplyToDashboardMessage } from "@/lib/dashboard-message-actions";
 import { useLanguage } from '@/lib/i18n';
 import { messageBubble } from '@/lib/i18n/translations/dashboard';
+import { getActionMenuPosition } from "@/lib/message-action-menu";
 import { canRecallDashboardMessage, isDashboardMessageRecalled, recalledMessageLabel } from "@/lib/message-recall";
 import AttachmentItem from "@/components/ui/AttachmentItem";
 import CopyableId from "@/components/ui/CopyableId";
@@ -56,6 +57,11 @@ const showMessageStatus = (() => {
 
 const COLLAPSE_TEXT_LENGTH = 700;
 const COLLAPSE_LINE_COUNT = 10;
+const ACTION_MENU_WIDTH = 112;
+const ACTION_MENU_ITEM_HEIGHT = 30;
+const ACTION_MENU_VERTICAL_PADDING = 8;
+const ACTION_MENU_GAP = 6;
+const ACTION_MENU_VIEWPORT_PADDING = 8;
 
 function shouldCollapseMessage(text: string): boolean {
   return text.length > COLLAPSE_TEXT_LENGTH || text.split(/\r\n|\r|\n/).length > COLLAPSE_LINE_COUNT;
@@ -352,10 +358,13 @@ function SenderAvatar({
 export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = false, sourceName, sourceId, mentionCandidates }: MessageBubbleProps) {
   const [hovered, setHovered] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [menuPosition, setMenuPosition] = useState<{ left: number; top: number } | null>(null);
   const [copied, setCopied] = useState(false);
   const [forwardQuote, setForwardQuote] = useState<string | null>(null);
   const [showErrorDetails, setShowErrorDetails] = useState(false);
   const [recallPending, setRecallPending] = useState(false);
+  const moreButtonRef = useRef<HTMLButtonElement>(null);
+  const actionMenuRef = useRef<HTMLDivElement>(null);
   const locale = useLanguage();
   const selectAgent = useDashboardChatStore((state) => state.selectAgent);
   const getRoomSummary = useDashboardChatStore((state) => state.getRoomSummary);
@@ -529,6 +538,72 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
     }
   }, [displayText]);
 
+  const actionMenuItemCount =
+    (canQuoteReply ? 1 : 0)
+    + (displayText ? 1 : 0)
+    + (canRecall ? 1 : 0)
+    + (displayText ? 1 : 0);
+
+  const updateActionMenuPosition = useCallback(() => {
+    const trigger = moreButtonRef.current;
+    if (!trigger || typeof window === "undefined") return;
+
+    const rect = trigger.getBoundingClientRect();
+    const menuRect = actionMenuRef.current?.getBoundingClientRect();
+    const menuWidth = menuRect?.width ?? ACTION_MENU_WIDTH;
+    const menuHeight = menuRect?.height ?? (actionMenuItemCount * ACTION_MENU_ITEM_HEIGHT + ACTION_MENU_VERTICAL_PADDING);
+    const { left, top } = getActionMenuPosition({
+      anchorRect: rect,
+      menuWidth,
+      menuHeight,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+      alignRight: isOwn,
+      gap: ACTION_MENU_GAP,
+      viewportPadding: ACTION_MENU_VIEWPORT_PADDING,
+    });
+
+    setMenuPosition((prev) => (
+      prev && prev.left === left && prev.top === top ? prev : { left, top }
+    ));
+  }, [actionMenuItemCount, isOwn]);
+
+  useLayoutEffect(() => {
+    if (!menuOpen) {
+      setMenuPosition(null);
+      return;
+    }
+
+    updateActionMenuPosition();
+    window.addEventListener("resize", updateActionMenuPosition);
+    window.addEventListener("scroll", updateActionMenuPosition, true);
+
+    return () => {
+      window.removeEventListener("resize", updateActionMenuPosition);
+      window.removeEventListener("scroll", updateActionMenuPosition, true);
+    };
+  }, [menuOpen, updateActionMenuPosition]);
+
+  useLayoutEffect(() => {
+    if (!menuOpen) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node;
+      if (moreButtonRef.current?.contains(target) || actionMenuRef.current?.contains(target)) return;
+      setMenuOpen(false);
+    };
+    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key === "Escape") setMenuOpen(false);
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [menuOpen]);
+
   const sideAvatar = !fullWidth && (
     <SenderAvatar
       senderId={message.sender_id}
@@ -543,15 +618,30 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
   const moreButton = !isRecalled && (displayText || canQuoteReply || canRecall) && (
     <div className="relative shrink-0">
       <button
+        ref={moreButtonRef}
         type="button"
-        onClick={() => setMenuOpen((v) => !v)}
+        onClick={(event) => {
+          event.stopPropagation();
+          if (menuOpen) {
+            setMenuOpen(false);
+            return;
+          }
+          updateActionMenuPosition();
+          setMenuOpen(true);
+        }}
         className={`flex h-6 w-6 items-center justify-center rounded text-zinc-500 hover:bg-zinc-800 hover:text-zinc-300 transition-colors ${hovered || menuOpen ? "opacity-100" : "opacity-0 pointer-events-none"}`}
         aria-label="More actions"
+        aria-expanded={menuOpen}
       >
         <MoreHorizontal className="h-3.5 w-3.5" />
       </button>
-      {menuOpen && (
-        <div className={`absolute top-full mt-1 z-30 min-w-[80px] rounded-lg border border-zinc-700 bg-zinc-900 py-1 shadow-xl ${isOwn ? "right-0" : "left-0"}`}>
+      {menuOpen && menuPosition && typeof document !== "undefined" && createPortal(
+        <div
+          ref={actionMenuRef}
+          className="fixed z-[9999] min-w-[112px] rounded-lg border border-zinc-700 bg-zinc-900 py-1 shadow-xl"
+          style={{ left: menuPosition.left, top: menuPosition.top }}
+          onMouseDown={(event) => event.stopPropagation()}
+        >
           {canQuoteReply && (
             <button
               type="button"
@@ -597,7 +687,8 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
               {copied ? "已复制" : "复制"}
             </button>
           )}
-        </div>
+        </div>,
+        document.body,
       )}
     </div>
   );
@@ -613,7 +704,7 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
     <div
       className={`flex items-start gap-2 ${isOwn && !fullWidth ? "justify-end" : "justify-start"} mb-2`}
       onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => { setHovered(false); setMenuOpen(false); }}
+      onMouseLeave={() => setHovered(false)}
     >
       {/* For own messages: button left of bubble */}
       {isOwn && !fullWidth && actionButtons}

--- a/frontend/src/components/dashboard/README.md
+++ b/frontend/src/components/dashboard/README.md
@@ -77,6 +77,7 @@ dashboard/
 
 ## 变更日志
 
+- 2026-05-30: `MessageBubble.tsx` 的消息操作菜单改为 fixed portal 定位，底部空间不足时自动向上展开，避免被消息滚动区或输入栏裁剪。
 - 2026-05-25: `DashboardShellSkeleton.tsx` 的冷启动品牌位接入 `BotCordLoader`，让 `/chats` 首屏等待态和全站 loading 动效保持一致。
 - 2026-05-24: `ContactRequestsInbox.tsx` 在收到的好友申请、Bot 审批申请和已发送申请卡片上统一显示发起时间，避免申请列表只展示对象和消息却无法判断先后。
 - 2026-05-19: `/chats/messages` 刷新不再预取其它 tab 的 RSC 路由，也不再后台预热公开目录和钱包接口；MessagesPanel 复用 Sidebar 的联系人请求加载，避免 received/sent/pending-approvals 重复请求。

--- a/frontend/src/lib/message-action-menu.test.ts
+++ b/frontend/src/lib/message-action-menu.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { getActionMenuPosition } from "./message-action-menu";
+
+const defaults = {
+  menuWidth: 112,
+  menuHeight: 128,
+  viewportWidth: 1024,
+  viewportHeight: 760,
+  gap: 6,
+  viewportPadding: 8,
+};
+
+describe("getActionMenuPosition", () => {
+  it("places the action menu above the trigger when the bottom of the viewport is tight", () => {
+    const pos = getActionMenuPosition({
+      ...defaults,
+      anchorRect: { left: 850, right: 874, top: 704, bottom: 728 },
+      alignRight: true,
+    });
+
+    expect(pos.placement).toBe("above");
+    expect(pos.top).toBe(570);
+    expect(pos.top + defaults.menuHeight).toBeLessThan(704);
+  });
+
+  it("keeps the action menu below the trigger when there is room", () => {
+    const pos = getActionMenuPosition({
+      ...defaults,
+      anchorRect: { left: 220, right: 244, top: 220, bottom: 244 },
+      alignRight: false,
+    });
+
+    expect(pos).toMatchObject({
+      placement: "below",
+      left: 220,
+      top: 250,
+    });
+  });
+
+  it("clamps the menu horizontally inside the viewport", () => {
+    const pos = getActionMenuPosition({
+      ...defaults,
+      viewportWidth: 160,
+      anchorRect: { left: 130, right: 154, top: 220, bottom: 244 },
+      alignRight: false,
+    });
+
+    expect(pos.left).toBe(40);
+  });
+});

--- a/frontend/src/lib/message-action-menu.ts
+++ b/frontend/src/lib/message-action-menu.ts
@@ -1,0 +1,53 @@
+export interface ActionMenuAnchorRect {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
+export interface ActionMenuPositionOptions {
+  anchorRect: ActionMenuAnchorRect;
+  menuWidth: number;
+  menuHeight: number;
+  viewportWidth: number;
+  viewportHeight: number;
+  alignRight: boolean;
+  gap: number;
+  viewportPadding: number;
+}
+
+export interface ActionMenuPosition {
+  left: number;
+  top: number;
+  placement: "above" | "below";
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function getActionMenuPosition({
+  anchorRect,
+  menuWidth,
+  menuHeight,
+  viewportWidth,
+  viewportHeight,
+  alignRight,
+  gap,
+  viewportPadding,
+}: ActionMenuPositionOptions): ActionMenuPosition {
+  const maxLeft = Math.max(viewportPadding, viewportWidth - menuWidth - viewportPadding);
+  const rawLeft = alignRight ? anchorRect.right - menuWidth : anchorRect.left;
+  const left = clamp(rawLeft, viewportPadding, maxLeft);
+
+  const spaceBelow = viewportHeight - anchorRect.bottom - viewportPadding;
+  const spaceAbove = anchorRect.top - viewportPadding;
+  const placeAbove = spaceBelow < menuHeight + gap && spaceAbove > spaceBelow;
+  const rawTop = placeAbove
+    ? anchorRect.top - menuHeight - gap
+    : anchorRect.bottom + gap;
+  const maxTop = Math.max(viewportPadding, viewportHeight - menuHeight - viewportPadding);
+  const top = clamp(rawTop, viewportPadding, maxTop);
+
+  return { left, top, placement: placeAbove ? "above" : "below" };
+}


### PR DESCRIPTION
## Summary
- Render dashboard message action menus through a fixed-position portal so they are not clipped by the scroll container or composer.
- Flip the menu above the trigger when a bottom-row message has insufficient space below.
- Add unit coverage for menu positioning and document the dashboard change.

## Verification
- npm run test -- src/lib/message-action-menu.test.ts
- NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build

## Risk / rollout
- Low-risk frontend-only positioning change. Direct browser verification was limited because the in-app browser backend was unavailable in this session.