### PR TITLE
Fix Feishu gateway chat ID edits

### DIFF
--- a/backend/tests/test_app/test_app_gateways.py
+++ b/backend/tests/test_app/test_app_gateways.py
@@ -1273,6 +1273,31 @@ async def _seed_one_connection(db_session: AsyncSession, seed: dict) -> str:
     return gw_id
 
 
+async def _seed_feishu_connection(db_session: AsyncSession, seed: dict) -> str:
+    gw_id = "gw_feishu_aaaaaa111111"
+    row = AgentGatewayConnection(
+        id=gw_id,
+        user_id=seed["user_id"],
+        agent_id="ag_daemon",
+        daemon_instance_id=seed["daemon_id"],
+        provider="feishu",
+        label="feishu",
+        enabled=True,
+        status="active",
+        config_json={
+            "allowedChatIds": ["oc_team"],
+            "allowedSenderIds": ["ou_alice"],
+            "tokenPreview": "feis...7890",
+            "appId": "cli_feishu_123",
+            "domain": "feishu",
+            "userOpenId": "ou_alice",
+        },
+    )
+    db_session.add(row)
+    await db_session.commit()
+    return gw_id
+
+
 @pytest.mark.asyncio
 async def test_patch_updates_settings_without_token(client, seed, db_session, monkeypatch):
     gw_id = await _seed_one_connection(db_session, seed)
@@ -1299,6 +1324,43 @@ async def test_patch_updates_settings_without_token(client, seed, db_session, mo
     assert body["config"]["tokenPreview"] == "1234...wxyz"
     # `secret` was NOT forwarded (no rotation requested).
     assert "secret" not in captured["params"]
+
+
+@pytest.mark.asyncio
+async def test_patch_feishu_settings_without_login_id(client, seed, db_session, monkeypatch):
+    gw_id = await _seed_feishu_connection(db_session, seed)
+
+    captured: dict = {}
+
+    async def fake_send(daemon_instance_id, type_, params=None, timeout_ms=None):
+        captured["type"] = type_
+        captured["params"] = params
+        return {"ok": True, "result": {"status": {"running": True}}}
+
+    _patch_daemon(monkeypatch, online=True, send=fake_send)
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    r = await client.patch(
+        f"/api/agents/ag_daemon/gateways/{gw_id}",
+        headers=headers,
+        json={
+            "label": "renamed feishu",
+            "config": {
+                "allowedChatIds": ["oc_other"],
+                "allowedSenderIds": ["ou_bob"],
+            },
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["label"] == "renamed feishu"
+    assert body["config"]["allowedChatIds"] == ["oc_other"]
+    assert body["config"]["allowedSenderIds"] == ["ou_bob"]
+    assert body["config"]["appId"] == "cli_feishu_123"
+    assert captured["type"] == "upsert_gateway"
+    assert captured["params"]["type"] == "feishu"
+    assert "loginId" not in captured["params"]
+    assert captured["params"]["settings"]["allowedChatIds"] == ["oc_other"]
+    assert captured["params"]["settings"]["allowedSenderIds"] == ["ou_bob"]
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/dashboard/AgentChannelsTab.tsx
+++ b/frontend/src/components/dashboard/AgentChannelsTab.tsx
@@ -515,6 +515,16 @@ function csvToList(raw: string): string[] {
     .filter(Boolean);
 }
 
+function normalizeFeishuChatIds(ids: string[]): string[] {
+  return ids.map((id) =>
+    id.startsWith("feishu:user:")
+      ? id.slice("feishu:user:".length)
+      : id.startsWith("feishu:chat:")
+        ? id.slice("feishu:chat:".length)
+        : id,
+  );
+}
+
 function TelegramAddForm({
   agentId,
   daemonOffline,
@@ -1099,7 +1109,7 @@ function FeishuAddForm({
   }
 
   const allowedSenderIds = csvToList(senderIds);
-  const allowedChatIds = csvToList(chatIds);
+  const allowedChatIds = normalizeFeishuChatIds(csvToList(chatIds));
   const canSave =
     phase === "ready" &&
     !!loginId &&
@@ -1859,7 +1869,10 @@ function GatewayEditForm({
     }
   }, [wechatLoginExpired, wechatStatus]);
 
-  const allowedChatIds = csvToList(chatIds);
+  const allowedChatIds =
+    gateway.provider === "feishu"
+      ? normalizeFeishuChatIds(csvToList(chatIds))
+      : csvToList(chatIds);
   const allowedSenderIds = csvToList(senderIds);
   const whitelistIncomplete =
     gateway.provider === "telegram"

--- a/packages/daemon/src/__tests__/gateway-control.test.ts
+++ b/packages/daemon/src/__tests__/gateway-control.test.ts
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import path from "node:path";
 
 import type { DaemonConfig } from "../config.js";
+import { saveGatewaySecret } from "../gateway/channels/secret-store.js";
 import { LoginSessionStore } from "../gateway/channels/login-session.js";
 import { createGatewayControl } from "../gateway-control.js";
 
@@ -324,6 +325,129 @@ describe("gateway_login_start / status", () => {
     const secretPath = trackSecret(gwId);
     const secret = JSON.parse(readFileSync(secretPath, "utf8")) as { appSecret?: string };
     expect(secret.appSecret).toBe("feishu-secret-1234567890");
+
+    const updateAck = await ctrl.handleUpsert({
+      id: gwId,
+      type: "feishu",
+      accountId: "ag_alice",
+      enabled: true,
+      settings: {
+        allowedSenderIds: ["ou_bob"],
+        allowedChatIds: ["oc_team"],
+        domain: "feishu",
+      },
+    });
+    expect(updateAck.ok).toBe(true);
+    expect(state.cfg.thirdPartyGateways?.[0]).toMatchObject({
+      id: gwId,
+      type: "feishu",
+      appId: "cli_feishu_123",
+      allowedSenderIds: ["ou_bob"],
+      allowedChatIds: ["oc_team"],
+    });
+    expect(gw.addChannel).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        id: gwId,
+        type: "feishu",
+        appId: "cli_feishu_123",
+        allowedChatIds: ["oc_team"],
+      }),
+    );
+  });
+
+  it("rejects changing Feishu domain without a fresh loginId", async () => {
+    const gw = makeFakeGateway();
+    const { io } = makeConfigIO(baseCfg());
+    const sessions = new LoginSessionStore();
+    const ctrl = createGatewayControl({
+      gateway: gw as any,
+      configIO: io,
+      loginSessions: sessions,
+    });
+    const gwId = uniqId("fs-domain");
+    trackSecret(gwId);
+
+    sessions.create({
+      loginId: "fsl_domain_seed",
+      accountId: "ag_alice",
+      provider: "feishu",
+      appId: "cli_domain_seed",
+      appSecret: "feishu-domain-secret-seed",
+      domain: "feishu",
+      userOpenId: "ou_domain_seed",
+    });
+    const installAck = await ctrl.handleUpsert({
+      id: gwId,
+      type: "feishu",
+      accountId: "ag_alice",
+      enabled: true,
+      loginId: "fsl_domain_seed",
+      settings: { domain: "feishu" },
+    });
+    expect(installAck.ok).toBe(true);
+
+    const updateAck = await ctrl.handleUpsert({
+      id: gwId,
+      type: "feishu",
+      accountId: "ag_alice",
+      enabled: true,
+      settings: { domain: "lark" },
+    });
+    expect(updateAck.ok).toBe(false);
+    expect(updateAck.error?.code).toBe("bad_params");
+    expect(updateAck.error?.message).toContain("domain change requires a fresh loginId");
+  });
+
+  it("rejects changing Feishu domain without loginId when saved profile omits domain (implicit feishu)", async () => {
+    const gw = makeFakeGateway();
+    const { state, io } = makeConfigIO(baseCfg());
+    const sessions = new LoginSessionStore();
+    const ctrl = createGatewayControl({
+      gateway: gw as any,
+      configIO: io,
+      loginSessions: sessions,
+    });
+    const gwId = uniqId("fs-domain-implicit");
+    trackSecret(gwId);
+
+    sessions.create({
+      loginId: "fsl_domain_implicit_seed",
+      accountId: "ag_alice",
+      provider: "feishu",
+      appId: "cli_domain_implicit_seed",
+      appSecret: "feishu-domain-implicit-secret-seed",
+      domain: "feishu",
+      userOpenId: "ou_domain_implicit_seed",
+    });
+    const installAck = await ctrl.handleUpsert({
+      id: gwId,
+      type: "feishu",
+      accountId: "ag_alice",
+      enabled: true,
+      loginId: "fsl_domain_implicit_seed",
+      settings: { domain: "feishu" },
+    });
+    expect(installAck.ok).toBe(true);
+
+    // Simulate legacy/missing persisted domain. The daemon should treat this
+    // as implicit "feishu" when validating no-login domain changes.
+    const saved = state.cfg.thirdPartyGateways?.find((g) => g.id === gwId);
+    expect(saved).toBeDefined();
+    if (saved) {
+      delete saved.domain;
+      io.save(state.cfg);
+    }
+
+    const updateAck = await ctrl.handleUpsert({
+      id: gwId,
+      type: "feishu",
+      accountId: "ag_alice",
+      enabled: true,
+      settings: { domain: "lark" },
+    });
+    expect(updateAck.ok).toBe(false);
+    expect(updateAck.error?.code).toBe("bad_params");
+    expect(updateAck.error?.message).toContain("domain change requires a fresh loginId");
   });
 
   it("discovers recent WeChat senders from a confirmed login session", async () => {
@@ -584,6 +708,170 @@ describe("W6: UPDATE rollback on addChannel failure", () => {
       expect(onDisk.botToken).toBe("old-token:123456789012345");
     }
   });
+
+  it("restores previous Feishu secret/config and re-adds old channel when update addChannel fails", async () => {
+    const gw = makeFakeGateway();
+    const { state, io } = makeConfigIO({ ...baseCfg(), agents: ["ag_alice", "ag_bob"] });
+    const sessions = new LoginSessionStore();
+    const ctrl = createGatewayControl({
+      gateway: gw as any,
+      configIO: io,
+      loginSessions: sessions,
+    });
+    const gwId = uniqId("w6fs");
+    trackSecret(gwId);
+
+    sessions.create({
+      loginId: "fsl_w6_old",
+      accountId: "ag_alice",
+      provider: "feishu",
+      appId: "cli_old",
+      appSecret: "old-feishu-secret-12345",
+      userOpenId: "ou_old",
+      domain: "feishu",
+    });
+    const firstAck = await ctrl.handleUpsert({
+      id: gwId,
+      type: "feishu",
+      accountId: "ag_alice",
+      enabled: true,
+      loginId: "fsl_w6_old",
+      settings: { allowedChatIds: ["oc_old"], domain: "feishu" },
+    });
+    expect(firstAck.ok).toBe(true);
+
+    sessions.create({
+      loginId: "fsl_w6_new",
+      accountId: "ag_bob",
+      provider: "feishu",
+      appId: "cli_new",
+      appSecret: "new-feishu-secret-ABCDE",
+      userOpenId: "ou_new",
+      domain: "lark",
+    });
+
+    let addCallCount = 0;
+    gw.addChannel = vi.fn(async (cfg: { id: string; accountId: string }) => {
+      addCallCount += 1;
+      if (addCallCount === 1) throw new Error("simulated feishu update failure");
+      gw.channels.set(cfg.id, {
+        id: cfg.id,
+        status: { channel: cfg.id, accountId: cfg.accountId, running: true, connected: true, authorized: true, lastPollAt: Date.now() },
+      });
+    });
+
+    const updateAck = await ctrl.handleUpsert({
+      id: gwId,
+      type: "feishu",
+      accountId: "ag_bob",
+      enabled: true,
+      loginId: "fsl_w6_new",
+      settings: { allowedChatIds: ["oc_new"], domain: "lark" },
+    });
+    expect(updateAck.ok).toBe(false);
+    expect(updateAck.error?.code).toBe("addChannel_failed");
+    expect(addCallCount).toBe(2);
+
+    const profile = state.cfg.thirdPartyGateways?.find((g) => g.id === gwId);
+    expect(profile).toMatchObject({
+      id: gwId,
+      type: "feishu",
+      appId: "cli_old",
+      domain: "feishu",
+      userOpenId: "ou_old",
+      allowedChatIds: ["oc_old"],
+    });
+
+    const secretPath = trackSecret(gwId);
+    const onDisk = JSON.parse(readFileSync(secretPath, "utf8")) as { appSecret?: string };
+    expect(onDisk.appSecret).toBe("old-feishu-secret-12345");
+    expect(gw.addChannel).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        id: gwId,
+        type: "feishu",
+        accountId: "ag_alice",
+        appId: "cli_old",
+        domain: "feishu",
+        allowedChatIds: ["oc_old"],
+      }),
+    );
+  });
+
+  it("replaces previous Feishu profile on rollback so failed update fields are removed", async () => {
+    const gw = makeFakeGateway();
+    const gwId = uniqId("w6fs-replace");
+    trackSecret(gwId);
+    saveGatewaySecret(gwId, { appSecret: "old-feishu-secret-replace" });
+    const { state, io } = makeConfigIO({
+      ...baseCfg(),
+      agents: ["ag_alice", "ag_bob"],
+      thirdPartyGateways: [
+        {
+          id: gwId,
+          type: "feishu",
+          accountId: "ag_alice",
+          enabled: true,
+          appId: "cli_old_replace",
+        },
+      ],
+    });
+    const sessions = new LoginSessionStore();
+    const ctrl = createGatewayControl({
+      gateway: gw as any,
+      configIO: io,
+      loginSessions: sessions,
+    });
+
+    sessions.create({
+      loginId: "fsl_w6_replace_new",
+      accountId: "ag_bob",
+      provider: "feishu",
+      appId: "cli_new_replace",
+      appSecret: "new-feishu-secret-replace",
+      userOpenId: "ou_new_replace",
+      domain: "lark",
+    });
+
+    let addCallCount = 0;
+    gw.addChannel = vi.fn(async (cfg: { id: string; accountId: string }) => {
+      addCallCount += 1;
+      if (addCallCount === 1) throw new Error("simulated feishu update failure");
+      gw.channels.set(cfg.id, {
+        id: cfg.id,
+        status: { channel: cfg.id, accountId: cfg.accountId, running: true, connected: true, authorized: true, lastPollAt: Date.now() },
+      });
+    });
+
+    const updateAck = await ctrl.handleUpsert({
+      id: gwId,
+      type: "feishu",
+      accountId: "ag_bob",
+      enabled: true,
+      loginId: "fsl_w6_replace_new",
+      settings: {
+        allowedSenderIds: ["ou_new_replace"],
+        allowedChatIds: ["oc_new_replace"],
+        splitAt: 2000,
+        domain: "lark",
+      },
+    });
+
+    expect(updateAck.ok).toBe(false);
+    expect(updateAck.error?.code).toBe("addChannel_failed");
+    expect(addCallCount).toBe(2);
+    expect(state.cfg.thirdPartyGateways).toEqual([
+      {
+        id: gwId,
+        type: "feishu",
+        accountId: "ag_alice",
+        enabled: true,
+        appId: "cli_old_replace",
+      },
+    ]);
+
+    const onDisk = JSON.parse(readFileSync(trackSecret(gwId), "utf8")) as { appSecret?: string };
+    expect(onDisk.appSecret).toBe("old-feishu-secret-replace");
+  });
 });
 
 describe("list_gateways", () => {
@@ -679,6 +967,90 @@ describe("gateway_send", () => {
       agentId: "ag_alice",
       gatewayId: gwId,
       conversationId: "feishu:chat:oc_other",
+      text: "hello",
+    });
+
+    expect(ack.ok).toBe(false);
+    expect(ack.error?.code).toBe("conversation_not_allowed");
+    expect(gw.sendOutbound).not.toHaveBeenCalled();
+  });
+
+  it("allows Feishu outbound when allowedChatIds is empty", async () => {
+    const gw = makeFakeGateway();
+    const gwId = uniqId("send-fs-allow-all");
+    const { io } = makeConfigIO({
+      ...baseCfg(),
+      thirdPartyGateways: [
+        {
+          id: gwId,
+          type: "feishu",
+          accountId: "ag_alice",
+          enabled: true,
+          allowedChatIds: [],
+        },
+      ],
+    });
+    const ctrl = createGatewayControl({ gateway: gw as any, configIO: io });
+
+    const ack = await ctrl.handleSend({
+      agentId: "ag_alice",
+      gatewayId: gwId,
+      conversationId: "feishu:chat:oc_any",
+      text: "hello",
+    });
+
+    expect(ack.ok).toBe(true);
+    expect(gw.sendOutbound).toHaveBeenCalledOnce();
+  });
+
+  it("allows Feishu outbound when allowedChatIds is omitted", async () => {
+    const gw = makeFakeGateway();
+    const gwId = uniqId("send-fs-allow-omitted");
+    const { io } = makeConfigIO({
+      ...baseCfg(),
+      thirdPartyGateways: [
+        {
+          id: gwId,
+          type: "feishu",
+          accountId: "ag_alice",
+          enabled: true,
+        },
+      ],
+    });
+    const ctrl = createGatewayControl({ gateway: gw as any, configIO: io });
+
+    const ack = await ctrl.handleSend({
+      agentId: "ag_alice",
+      gatewayId: gwId,
+      conversationId: "feishu:chat:oc_any",
+      text: "hello",
+    });
+
+    expect(ack.ok).toBe(true);
+    expect(gw.sendOutbound).toHaveBeenCalledOnce();
+  });
+
+  it("denies Telegram outbound when allowedChatIds is empty", async () => {
+    const gw = makeFakeGateway();
+    const gwId = uniqId("send-tg-deny-empty");
+    const { io } = makeConfigIO({
+      ...baseCfg(),
+      thirdPartyGateways: [
+        {
+          id: gwId,
+          type: "telegram",
+          accountId: "ag_alice",
+          enabled: true,
+          allowedChatIds: [],
+        },
+      ],
+    });
+    const ctrl = createGatewayControl({ gateway: gw as any, configIO: io });
+
+    const ack = await ctrl.handleSend({
+      agentId: "ag_alice",
+      gatewayId: gwId,
+      conversationId: "telegram:group:-100123",
       text: "hello",
     });
 

--- a/packages/daemon/src/gateway-control.ts
+++ b/packages/daemon/src/gateway-control.ts
@@ -271,6 +271,9 @@ export function createGatewayControl(ctx: GatewayControlContext) {
     }
 
     const cfg = cfgIO.load();
+    const existingProfiles = cfg.thirdPartyGateways ?? [];
+    const prevProfile = existingProfiles.find((g) => g.id === params.id);
+    const hadExistingProfile = prevProfile !== undefined;
 
     // accountId must belong to a daemon-bound agent. An empty agent set
     // (no agents provisioned yet) is itself a hard reject — otherwise we
@@ -349,43 +352,66 @@ export function createGatewayControl(ctx: GatewayControlContext) {
     } else if (params.type === "feishu") {
       const loginId = params.loginId;
       if (!loginId) {
-        return badParams("upsert_gateway: feishu requires loginId");
+        if (
+          !prevProfile ||
+          prevProfile.type !== "feishu" ||
+          prevProfile.accountId !== params.accountId ||
+          !prevProfile.appId
+        ) {
+          return badParams("upsert_gateway: feishu requires loginId");
+        }
+        const existing = loadGatewaySecret<{ appSecret?: string }>(params.id);
+        if (!existing?.appSecret) {
+          return badParams("upsert_gateway: feishu requires loginId");
+        }
+        if (
+          params.settings?.domain !== undefined &&
+          params.settings.domain !== (prevProfile.domain ?? "feishu")
+        ) {
+          return badParams("upsert_gateway: feishu domain change requires a fresh loginId");
+        }
+        secretPayload = { appSecret: existing.appSecret };
+        tokenPreviewSource = existing.appSecret;
+        feishuAppId = prevProfile.appId;
+        feishuDomain = params.settings?.domain ?? prevProfile.domain ?? "feishu";
+        feishuUserOpenId = prevProfile.userOpenId;
+      } else {
+        const resolved = sessions.resolve(loginId);
+        if (resolved.state !== "live") {
+          return {
+            ok: false,
+            error:
+              resolved.state === "missing"
+                ? { code: "login_missing", message: `feishu login session "${loginId}" not found` }
+                : { code: "login_expired", message: `feishu login session "${loginId}" expired` },
+          };
+        }
+        const session = resolved.session!;
+        if (session.provider !== "feishu") {
+          return badParams(`upsert_gateway: login session provider "${session.provider}" != "feishu"`);
+        }
+        if (session.accountId !== params.accountId) {
+          return {
+            ok: false,
+            error: {
+              code: "login_account_mismatch",
+              message: "feishu login session accountId does not match upsert request",
+            },
+          };
+        }
+        if (!session.appId || !session.appSecret) {
+          return {
+            ok: false,
+            error: { code: "login_unconfirmed", message: "feishu login session has no app credentials yet" },
+          };
+        }
+        secretPayload = { appSecret: session.appSecret };
+        tokenPreviewSource = session.appSecret;
+        feishuAppId = session.appId;
+        feishuDomain = session.domain ?? params.settings?.domain ?? "feishu";
+        feishuUserOpenId = session.userOpenId;
+        sessions.update(loginId, { gatewayId: params.id });
       }
-      const resolved = sessions.resolve(loginId);
-      if (resolved.state !== "live") {
-        return {
-          ok: false,
-          error:
-            resolved.state === "missing"
-              ? { code: "login_missing", message: `feishu login session "${loginId}" not found` }
-              : { code: "login_expired", message: `feishu login session "${loginId}" expired` },
-        };
-      }
-      const session = resolved.session!;
-      if (session.provider !== "feishu") {
-        return badParams(`upsert_gateway: login session provider "${session.provider}" != "feishu"`);
-      }
-      if (session.accountId !== params.accountId) {
-        return {
-          ok: false,
-          error: {
-            code: "login_account_mismatch",
-            message: "feishu login session accountId does not match upsert request",
-          },
-        };
-      }
-      if (!session.appId || !session.appSecret) {
-        return {
-          ok: false,
-          error: { code: "login_unconfirmed", message: "feishu login session has no app credentials yet" },
-        };
-      }
-      secretPayload = { appSecret: session.appSecret };
-      tokenPreviewSource = session.appSecret;
-      feishuAppId = session.appId;
-      feishuDomain = session.domain ?? params.settings?.domain ?? "feishu";
-      feishuUserOpenId = session.userOpenId;
-      sessions.update(loginId, { gatewayId: params.id });
     } else {
       return badParams(`upsert_gateway: unknown provider "${(params as { type: string }).type}"`);
     }
@@ -393,12 +419,9 @@ export function createGatewayControl(ctx: GatewayControlContext) {
     // W3/W6: remember whether a profile already exists for this id BEFORE we
     // write the secret/config. For UPDATE path, capture previous profile +
     // previous secret so addChannel failure can restore prior state.
-    const existingProfiles = cfg.thirdPartyGateways ?? [];
-    const hadExistingProfile = existingProfiles.some((g) => g.id === params.id);
-    const prevProfile = existingProfiles.find((g) => g.id === params.id);
     // W6: load the previous secret for UPDATE rollback BEFORE overwriting.
     const prevSecret = hadExistingProfile
-      ? loadGatewaySecret<{ botToken?: string }>(params.id)
+      ? loadGatewaySecret<{ botToken?: string; appSecret?: string }>(params.id)
       : null;
 
     // Persist secret first (so a config write that succeeds is never
@@ -458,20 +481,27 @@ export function createGatewayControl(ctx: GatewayControlContext) {
           }
           try {
             if (prevProfile) {
-              cfgIO.save(upsertProfileInConfig(cfgIO.load(), prevProfile));
+              cfgIO.save(replaceProfileInConfig(cfgIO.load(), prevProfile));
             }
           } catch {
             // best-effort
           }
           try {
-            if (prevProfile && prevSecret?.botToken) {
+            if (
+              prevProfile &&
+              ((prevProfile.type === "telegram" && prevSecret?.botToken) ||
+                (prevProfile.type === "feishu" && prevSecret?.appSecret))
+            ) {
               await ctx.gateway.addChannel(
                 buildChannelConfig(
                   {
                     ...params,
                     type: prevProfile.type as typeof params.type,
+                    accountId: prevProfile.accountId,
                     enabled: prevProfile.enabled !== false,
-                    secret: { botToken: prevSecret.botToken },
+                    ...(prevProfile.type === "telegram"
+                      ? { secret: { botToken: prevSecret.botToken } }
+                      : {}),
                     settings: {
                       baseUrl: prevProfile.baseUrl,
                       allowedSenderIds: prevProfile.allowedSenderIds,
@@ -1074,6 +1104,9 @@ function validateOutboundConversation(
       },
     };
   }
+  if (profile.type === "feishu" && (profile.allowedChatIds ?? []).length === 0) {
+    return null;
+  }
   const allowed = new Set((profile.allowedChatIds ?? []).map(String));
   if (!allowed.has(chatId)) {
     return {
@@ -1155,6 +1188,21 @@ function upsertProfileInConfig(
   const compact = compactProfile(patch);
   if (idx >= 0) {
     list[idx] = { ...list[idx], ...compact };
+  } else {
+    list.push(compact);
+  }
+  return { ...cfg, thirdPartyGateways: list };
+}
+
+function replaceProfileInConfig(
+  cfg: DaemonConfig,
+  profile: ThirdPartyGatewayProfile,
+): DaemonConfig {
+  const list = (cfg.thirdPartyGateways ?? []).slice();
+  const idx = list.findIndex((g) => g.id === profile.id);
+  const compact = compactProfile(profile);
+  if (idx >= 0) {
+    list[idx] = compact;
   } else {
     list.push(compact);
   }


### PR DESCRIPTION
## Summary
- allow existing Feishu gateway settings updates without requiring a fresh loginId by reusing saved app/profile secret
- normalize Feishu chat IDs from prefixed values to bare IDs in the dashboard
- make Feishu outbound empty/missing allowedChatIds allow-all while preserving Telegram deny-empty behavior
- harden Feishu update rollback to restore old secret/config/channel and replace the old compact profile

## Verification
- MISE_TRUSTED_CONFIG_PATHS=$PWD pnpm --filter @botcord/daemon test -- --run src/__tests__/gateway-control.test.ts
- backend/.venv/bin/python -m pytest backend/tests/test_app/test_app_gateways.py -k 'patch_feishu_settings_without_login_id or patch_updates_settings_without_token' -q
- git diff --check