### PR TITLE
Discover Feishu chat IDs during setup

### DIFF
--- a/backend/app/routers/gateways.py
+++ b/backend/app/routers/gateways.py
@@ -1899,3 +1899,93 @@ async def wechat_recent_senders(
     if not isinstance(senders, list):
         senders = result.get("users")
     return {"senders": senders if isinstance(senders, list) else []}
+
+
+@router.post("/{agent_id}/gateways/feishu/chats")
+async def feishu_recent_chats(
+    agent_id: str,
+    body: WechatSenderDiscoveryIn,
+    ctx: RequestContext = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Proxy temporary Feishu chat_id discovery to the daemon login session.
+
+    Called after Feishu registration confirms and before saving the gateway, so
+    the daemon can listen with the freshly confirmed app credentials and capture
+    the chat_id from a message sent by the registered user.
+    """
+    _rate_limit(ctx.user_id, "feishu-login")
+    agent = await _load_owned_agent(db, ctx, agent_id)
+
+    if agent.hosting_kind == "cloud":
+        _log_setup_event(
+            agent=agent, host=None, provider="feishu",
+            login_id=body.login_id, outcome="started", ctx=ctx,
+            setup_owner="gateway-ingress",
+        )
+        try:
+            result = await ingress_client.discover(
+                agent_id, "feishu",
+                user_id=ctx.user_id,
+                request_id=_request_id_for(ctx),
+                body={
+                    "loginId": body.login_id,
+                    "timeoutSeconds": body.timeout_seconds,
+                },
+            )
+        except HTTPException as exc:
+            _log_setup_event(
+                agent=agent, host=None, provider="feishu",
+                login_id=body.login_id, outcome="error",
+                error_code=_extract_error_code(exc), ctx=ctx,
+                setup_owner="gateway-ingress",
+            )
+            raise
+        _log_setup_event(
+            agent=agent, host=None, provider="feishu",
+            login_id=body.login_id, outcome="ok", ctx=ctx,
+            setup_owner="gateway-ingress",
+        )
+        chats = result.get("chats")
+        if not isinstance(chats, list):
+            chats = result.get("candidates")
+        return {"chats": chats if isinstance(chats, list) else []}
+
+    agent, host = await _load_gateway_host_or_422(db, ctx, agent_id)
+    await _ensure_gateway_host_online(db, ctx, agent, host)
+
+    _log_setup_event(
+        agent=agent, host=host, provider="feishu",
+        login_id=body.login_id, outcome="started", ctx=ctx,
+    )
+
+    try:
+        ack = await _send_gateway_control_frame(
+            host,
+            "gateway_recent_senders",
+            {
+                "provider": "feishu",
+                "loginId": body.login_id,
+                "accountId": agent_id,
+                "timeoutSeconds": body.timeout_seconds,
+            },
+            db=db,
+            ctx=ctx,
+            agent=agent,
+            retry_cloud_disconnect=True,
+        )
+        result = _ack_or_raise(ack)
+    except HTTPException as exc:
+        _log_setup_event(
+            agent=agent, host=host, provider="feishu",
+            login_id=body.login_id, outcome="error",
+            error_code=_extract_error_code(exc), ctx=ctx,
+        )
+        raise
+
+    _log_setup_event(
+        agent=agent, host=host, provider="feishu",
+        login_id=body.login_id, outcome="ok", ctx=ctx,
+    )
+    chats = result.get("chats")
+    return {"chats": chats if isinstance(chats, list) else []}

--- a/backend/tests/test_app/test_app_gateways.py
+++ b/backend/tests/test_app/test_app_gateways.py
@@ -1610,6 +1610,51 @@ async def test_wechat_recent_senders_proxies(client, seed, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_feishu_recent_chats_proxies(client, seed, monkeypatch):
+    async def fake_send(daemon_instance_id, type_, params=None, timeout_ms=None):
+        assert type_ == "gateway_recent_senders"
+        assert params == {
+            "provider": "feishu",
+            "loginId": "fsl_xyz",
+            "accountId": "ag_daemon",
+            "timeoutSeconds": 6,
+        }
+        return {
+            "ok": True,
+            "result": {
+                "chats": [
+                    {
+                        "chatId": "oc_team",
+                        "senderOpenId": "ou_alice",
+                        "kind": "group",
+                        "label": "Alice",
+                        "lastSeenAt": 1700000000000,
+                    },
+                ],
+            },
+        }
+
+    _patch_daemon(monkeypatch, online=True, send=fake_send)
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    r = await client.post(
+        "/api/agents/ag_daemon/gateways/feishu/chats",
+        headers=headers,
+        json={"loginId": "fsl_xyz", "timeoutSeconds": 6},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["chats"] == [
+        {
+            "chatId": "oc_team",
+            "senderOpenId": "ou_alice",
+            "kind": "group",
+            "label": "Alice",
+            "lastSeenAt": 1700000000000,
+        },
+    ]
+
+
+@pytest.mark.asyncio
 async def test_wechat_login_start_offline_returns_409(client, seed, monkeypatch, caplog):
     _patch_daemon(monkeypatch, online=False)
     headers = {"Authorization": f"Bearer {seed['token']}"}

--- a/frontend/src/app/api/agents/[agentId]/gateways/feishu/chats/route.ts
+++ b/frontend/src/app/api/agents/[agentId]/gateways/feishu/chats/route.ts
@@ -1,0 +1,28 @@
+/**
+ * [INPUT]: agentId from path; POST body { loginId, timeoutSeconds? }
+ * [OUTPUT]: POST /api/agents/[agentId]/gateways/feishu/chats — proxies to Hub
+ * [POS]: BFF helper for discovering Feishu chat_id after registration
+ * [PROTOCOL]: update header on changes
+ */
+
+import { NextResponse } from "next/server";
+import { proxyHub } from "../../../../../_lib/proxy-hub";
+
+type Params = { params: Promise<{ agentId: string }> };
+
+export async function POST(req: Request, { params }: Params) {
+  const { agentId } = await params;
+  if (!agentId) {
+    return NextResponse.json({ error: "missing_agent_id" }, { status: 400 });
+  }
+  let body: unknown = {};
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  return proxyHub(
+    `/api/agents/${encodeURIComponent(agentId)}/gateways/feishu/chats`,
+    { method: "POST", body },
+  );
+}

--- a/frontend/src/components/dashboard/AgentChannelsTab.tsx
+++ b/frontend/src/components/dashboard/AgentChannelsTab.tsx
@@ -1026,6 +1026,7 @@ function FeishuAddForm({
 }) {
   const startFeishuLogin = useAgentGatewayStore((s) => s.startFeishuLogin);
   const pollFeishuLogin = useAgentGatewayStore((s) => s.pollFeishuLogin);
+  const discoverFeishuChats = useAgentGatewayStore((s) => s.discoverFeishuChats);
   const create = useAgentGatewayStore((s) => s.create);
   const [domain, setDomain] = useState<"feishu" | "lark">("feishu");
   const [phase, setPhase] = useState<"idle" | "scanning" | "ready">("idle");
@@ -1038,15 +1039,43 @@ function FeishuAddForm({
   const [label, setLabel] = useState("");
   const [senderIds, setSenderIds] = useState("");
   const [chatIds, setChatIds] = useState("");
+  const [chatIdsTouched, setChatIdsTouched] = useState(false);
+  const [discoveredChats, setDiscoveredChats] = useState<
+    Array<{ chatId: string; senderOpenId: string; kind?: "direct" | "group" | null; label?: string | null; lastSeenAt?: number | null }>
+  >([]);
+  const [discoveringChats, setDiscoveringChats] = useState(false);
+  const [chatDiscoverySkipped, setChatDiscoverySkipped] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const chatIdsRef = useRef("");
+  const chatIdsTouchedRef = useRef(false);
+  const chatDiscoveryRequestRef = useRef(0);
 
   useEffect(() => {
     return () => {
       if (pollTimer.current) clearInterval(pollTimer.current);
     };
   }, []);
+
+  useEffect(() => {
+    chatIdsRef.current = chatIds;
+  }, [chatIds]);
+
+  useEffect(() => {
+    chatIdsTouchedRef.current = chatIdsTouched;
+  }, [chatIdsTouched]);
+
+  function resetChatDiscoveryState() {
+    chatDiscoveryRequestRef.current += 1;
+    chatIdsRef.current = "";
+    chatIdsTouchedRef.current = false;
+    setChatIds("");
+    setChatIdsTouched(false);
+    setDiscoveredChats([]);
+    setDiscoveringChats(false);
+    setChatDiscoverySkipped(false);
+  }
 
   async function doPoll(id: string) {
     try {
@@ -1066,6 +1095,7 @@ function FeishuAddForm({
       } else if (r.status === "expired" || r.status === "failed") {
         if (pollTimer.current) clearInterval(pollTimer.current);
         pollTimer.current = null;
+        resetChatDiscoveryState();
       }
     } catch (err) {
       if (!isAckTimeoutError(err)) {
@@ -1079,6 +1109,7 @@ function FeishuAddForm({
   async function handleStart() {
     setBusy(true);
     setError(null);
+    resetChatDiscoveryState();
     try {
       const r = await startFeishuLogin(agentId, { domain });
       setLoginId(r.loginId);
@@ -1097,6 +1128,7 @@ function FeishuAddForm({
           setLoginId(null);
           setQrcodeUrl(null);
           setStatus("expired");
+          resetChatDiscoveryState();
           if (pollTimer.current) clearInterval(pollTimer.current);
           pollTimer.current = null;
         } else {
@@ -1146,6 +1178,7 @@ function FeishuAddForm({
           setAppId(null);
           setUserOpenId(null);
           setTokenPreview(null);
+          resetChatDiscoveryState();
           if (pollTimer.current) clearInterval(pollTimer.current);
           pollTimer.current = null;
         } else {
@@ -1154,6 +1187,51 @@ function FeishuAddForm({
       }
     } finally {
       setBusy(false);
+    }
+  }
+
+  async function handleDiscoverChats() {
+    if (!loginId) return;
+    const requestId = chatDiscoveryRequestRef.current + 1;
+    chatDiscoveryRequestRef.current = requestId;
+    setDiscoveringChats(true);
+    setError(null);
+    setChatDiscoverySkipped(false);
+    try {
+      const r = await discoverFeishuChats(agentId, loginId, { timeoutSeconds: 6 });
+      if (chatDiscoveryRequestRef.current !== requestId) return;
+      setDiscoveredChats(r.chats);
+      if (
+        r.chats[0] &&
+        !chatIdsTouchedRef.current &&
+        chatIdsRef.current.trim().length === 0
+      ) {
+        chatIdsRef.current = r.chats[0].chatId;
+        setChatIds(r.chats[0].chatId);
+      }
+    } catch (err) {
+      if (chatDiscoveryRequestRef.current !== requestId) return;
+      if (!isAckTimeoutError(err)) {
+        if (isLoginExpiredError(err)) {
+          setError(loginExpiredMessage("feishu"));
+          setPhase("idle");
+          setLoginId(null);
+          setQrcodeUrl(null);
+          setStatus("expired");
+          setAppId(null);
+          setUserOpenId(null);
+          setTokenPreview(null);
+          resetChatDiscoveryState();
+          if (pollTimer.current) clearInterval(pollTimer.current);
+          pollTimer.current = null;
+        } else {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      }
+    } finally {
+      if (chatDiscoveryRequestRef.current === requestId) {
+        setDiscoveringChats(false);
+      }
     }
   }
 
@@ -1222,6 +1300,58 @@ function FeishuAddForm({
       {phase === "ready" && (
         <StepSection
           step={2}
+          title="发现飞书 chat_id"
+          description="在目标单聊或群聊里给 Bot 发一条消息，daemon 会临时监听并填入 chat_id。"
+          complete={allowedChatIds.length > 0 || chatDiscoverySkipped}
+        >
+          <div className="space-y-3">
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={handleDiscoverChats}
+                disabled={discoveringChats || busy || !loginId}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-neon-cyan/50 bg-neon-cyan/15 px-3 py-2 text-xs font-semibold text-neon-cyan hover:bg-neon-cyan/25 disabled:opacity-50"
+              >
+                {discoveringChats ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Search className="h-3.5 w-3.5" />}
+                {discoveringChats ? "监听中" : "刷新"}
+              </button>
+              <button
+                type="button"
+                onClick={() => setChatDiscoverySkipped(true)}
+                disabled={discoveringChats || busy}
+                className="rounded-lg border border-glass-border px-3 py-2 text-xs text-text-secondary hover:text-text-primary disabled:opacity-50"
+              >
+                跳过
+              </button>
+            </div>
+            {discoveredChats.length > 0 ? (
+              <div className="space-y-1">
+                {discoveredChats.slice(0, 5).map((chat) => (
+                  <button
+                    key={`${chat.chatId}:${chat.senderOpenId}`}
+                    type="button"
+                    onClick={() => {
+                      chatIdsRef.current = chat.chatId;
+                      chatIdsTouchedRef.current = true;
+                      setChatIds(chat.chatId);
+                      setChatIdsTouched(true);
+                      setChatDiscoverySkipped(false);
+                    }}
+                    className="flex w-full items-center justify-between rounded-lg border border-glass-border bg-deep-black/40 px-3 py-2 text-left text-xs text-text-secondary hover:border-neon-cyan/40 hover:text-text-primary"
+                  >
+                    <span className="min-w-0 truncate font-mono">{chat.chatId}</span>
+                    <span className="ml-3 shrink-0 text-[11px]">{chat.kind === "direct" ? "单聊" : "群聊"}</span>
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        </StepSection>
+      )}
+
+      {phase === "ready" && (
+        <StepSection
+          step={3}
           title="设置允许的飞书用户"
           description="默认只允许扫码创建者触发，也可以追加其他 open_id。群聊可选填 chat_id。"
           complete={allowedSenderIds.length > 0}
@@ -1246,7 +1376,14 @@ function FeishuAddForm({
             <Field label="允许的群 chat_id（可选）">
               <textarea
                 value={chatIds}
-                onChange={(e) => setChatIds(e.target.value)}
+                onChange={(e) => {
+                  const next = e.target.value;
+                  chatIdsRef.current = next;
+                  chatIdsTouchedRef.current = true;
+                  setChatIds(next);
+                  setChatIdsTouched(true);
+                  setChatDiscoverySkipped(false);
+                }}
                 rows={2}
                 placeholder="oc_xxxxx"
                 className="w-full resize-none rounded-lg border border-glass-border bg-deep-black/40 px-3 py-2 font-mono text-xs text-text-primary outline-none focus:border-neon-cyan/40"

--- a/frontend/src/store/useAgentGatewayStore.ts
+++ b/frontend/src/store/useAgentGatewayStore.ts
@@ -108,6 +108,18 @@ export interface WechatSenderDiscoveryResponse {
   senders: WechatSenderDiscoveryItem[];
 }
 
+export interface FeishuChatDiscoveryItem {
+  chatId: string;
+  senderOpenId: string;
+  kind?: "direct" | "group" | null;
+  label?: string | null;
+  lastSeenAt?: number | null;
+}
+
+export interface FeishuChatDiscoveryResponse {
+  chats: FeishuChatDiscoveryItem[];
+}
+
 export interface GatewayTestResult {
   ok: boolean;
   message?: string | null;
@@ -230,6 +242,11 @@ interface AgentGatewayState {
     domain?: "feishu" | "lark" | null;
     userOpenId?: string | null;
   }>;
+  discoverFeishuChats: (
+    agentId: string,
+    loginId: string,
+    opts?: { timeoutSeconds?: number },
+  ) => Promise<FeishuChatDiscoveryResponse>;
 }
 
 function base(agentId: string): string {
@@ -538,5 +555,42 @@ export const useAgentGatewayStore = create<AgentGatewayState>((set, get) => ({
       domain: json.domain ?? null,
       userOpenId: json.userOpenId ?? null,
     };
+  },
+
+  async discoverFeishuChats(agentId, loginId, opts) {
+    const res = await apiFetch(`${base(agentId)}/feishu/chats`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        loginId,
+        timeoutSeconds: opts?.timeoutSeconds ?? 4,
+      }),
+    });
+    if (!res.ok) {
+      const err = await readErr(res);
+      if (err.status === 409) {
+        set((s) => ({ daemonOffline: { ...s.daemonOffline, [agentId]: true } }));
+      }
+      throw err;
+    }
+    const json = (await res.json()) as { chats?: unknown[] };
+    const chats: FeishuChatDiscoveryItem[] = [];
+    if (Array.isArray(json.chats)) {
+      for (const item of json.chats) {
+        if (!item || typeof item !== "object") continue;
+        const raw = item as Record<string, unknown>;
+        const chatId = typeof raw.chatId === "string" ? raw.chatId : "";
+        const senderOpenId = typeof raw.senderOpenId === "string" ? raw.senderOpenId : "";
+        if (!chatId || !senderOpenId) continue;
+        chats.push({
+          chatId,
+          senderOpenId,
+          kind: raw.kind === "direct" || raw.kind === "group" ? raw.kind : null,
+          label: typeof raw.label === "string" ? raw.label : null,
+          lastSeenAt: typeof raw.lastSeenAt === "number" ? raw.lastSeenAt : null,
+        });
+      }
+    }
+    return { chats };
   },
 }));

--- a/packages/daemon/src/__tests__/feishu-channel.test.ts
+++ b/packages/daemon/src/__tests__/feishu-channel.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  discoverFeishuChats,
+  feishuDiscoveryChatFromEvent,
+} from "../gateway/channels/feishu.js";
+
+describe("feishu chat discovery parser", () => {
+  it("captures a group chat_id from the registered sender", () => {
+    const hit = feishuDiscoveryChatFromEvent(
+      {
+        sender: { sender_id: { open_id: "ou_alice" } },
+        message: {
+          message_id: "om_1",
+          chat_id: "oc_team",
+          chat_type: "group",
+          create_time: "1700000000000",
+          mentions: [{ id: { open_id: "ou_alice" }, name: "Alice" }],
+        },
+      },
+      "ou_alice",
+      () => 1,
+    );
+
+    expect(hit).toEqual({
+      chatId: "oc_team",
+      senderOpenId: "ou_alice",
+      kind: "group",
+      label: "Alice",
+      lastSeenAt: 1700000000000,
+    });
+  });
+
+  it("marks p2p chat_type as direct", () => {
+    const hit = feishuDiscoveryChatFromEvent(
+      {
+        sender: { sender_id: { open_id: "ou_alice" } },
+        message: {
+          message_id: "om_2",
+          chat_id: "oc_direct",
+          chat_type: "p2p",
+        },
+      },
+      "ou_alice",
+      () => 1700000000001,
+    );
+
+    expect(hit).toMatchObject({
+      chatId: "oc_direct",
+      senderOpenId: "ou_alice",
+      kind: "direct",
+      lastSeenAt: 1700000000001,
+    });
+  });
+
+  it("ignores messages from a different sender", () => {
+    const hit = feishuDiscoveryChatFromEvent(
+      {
+        sender: { sender_id: { open_id: "ou_bob" } },
+        message: {
+          message_id: "om_3",
+          chat_id: "oc_team",
+          chat_type: "group",
+        },
+      },
+      "ou_alice",
+      () => 1,
+    );
+
+    expect(hit).toBeNull();
+  });
+
+  it("surfaces temporary discovery websocket start failure", async () => {
+    await expect(
+      discoverFeishuChats({
+        appId: "cli_123",
+        appSecret: "secret_123",
+        domain: "feishu",
+        userOpenId: "ou_alice",
+        timeoutSeconds: 0,
+        sdkOverride: {
+          createDispatcher: () => ({ register: () => {} }),
+          createWsClient: () => ({
+            start: () => Promise.reject(new Error("ws start failed")),
+            close: () => {},
+          }),
+        },
+      }),
+    ).rejects.toThrow("ws start failed");
+  });
+});

--- a/packages/daemon/src/__tests__/gateway-control.test.ts
+++ b/packages/daemon/src/__tests__/gateway-control.test.ts
@@ -530,6 +530,127 @@ describe("gateway_login_start / status", () => {
     expect(ack.ok).toBe(false);
     expect(ack.error?.code).toBe("login_unconfirmed");
   });
+
+  it("discovers Feishu chats from a confirmed login session owned by the account", async () => {
+    const gw = makeFakeGateway();
+    const { io } = makeConfigIO(baseCfg());
+    const sessions = new LoginSessionStore();
+    sessions.create({
+      loginId: "fsl_discover",
+      accountId: "ag_alice",
+      provider: "feishu",
+      qrcode: "DEVICE",
+      appId: "cli_feishu_123",
+      appSecret: "feishu-secret-1234567890",
+      domain: "feishu",
+      userOpenId: "ou_alice",
+    });
+    const discoverChats = vi.fn(async (opts) => {
+      expect(opts).toEqual({
+        appId: "cli_feishu_123",
+        appSecret: "feishu-secret-1234567890",
+        domain: "feishu",
+        userOpenId: "ou_alice",
+        timeoutSeconds: 6,
+      });
+      return [
+        {
+          chatId: "oc_team",
+          senderOpenId: "ou_alice",
+          kind: "group" as const,
+          label: "Alice",
+          lastSeenAt: 1700000000000,
+        },
+      ];
+    });
+    const ctrl = createGatewayControl({
+      gateway: gw as any,
+      configIO: io,
+      loginSessions: sessions,
+      feishuDiscoveryClient: { discoverChats },
+    });
+
+    const ack = await ctrl.handleRecentSenders({
+      provider: "feishu",
+      loginId: "fsl_discover",
+      accountId: "ag_alice",
+      timeoutSeconds: 6,
+    });
+
+    expect(ack.ok).toBe(true);
+    expect(ack.result).toEqual({
+      chats: [
+        {
+          chatId: "oc_team",
+          senderOpenId: "ou_alice",
+          kind: "group",
+          label: "Alice",
+          lastSeenAt: 1700000000000,
+        },
+      ],
+    });
+  });
+
+  it("rejects Feishu chat discovery for a different accountId", async () => {
+    const gw = makeFakeGateway();
+    const { io } = makeConfigIO(baseCfg());
+    const sessions = new LoginSessionStore();
+    sessions.create({
+      loginId: "fsl_wrong_owner",
+      accountId: "ag_alice",
+      provider: "feishu",
+      qrcode: "DEVICE",
+      appId: "cli_feishu_123",
+      appSecret: "feishu-secret-1234567890",
+      domain: "feishu",
+      userOpenId: "ou_alice",
+    });
+    const discoverChats = vi.fn(async () => []);
+    const ctrl = createGatewayControl({
+      gateway: gw as any,
+      configIO: io,
+      loginSessions: sessions,
+      feishuDiscoveryClient: { discoverChats },
+    });
+
+    const ack = await ctrl.handleRecentSenders({
+      provider: "feishu",
+      loginId: "fsl_wrong_owner",
+      accountId: "ag_other",
+    });
+
+    expect(ack.ok).toBe(false);
+    expect(ack.error?.code).toBe("forbidden");
+    expect(discoverChats).not.toHaveBeenCalled();
+  });
+
+  it("rejects Feishu chat discovery before registration is confirmed", async () => {
+    const gw = makeFakeGateway();
+    const { io } = makeConfigIO(baseCfg());
+    const sessions = new LoginSessionStore();
+    sessions.create({
+      loginId: "fsl_pending",
+      accountId: "ag_alice",
+      provider: "feishu",
+      qrcode: "DEVICE",
+      domain: "feishu",
+    });
+    const ctrl = createGatewayControl({
+      gateway: gw as any,
+      configIO: io,
+      loginSessions: sessions,
+      feishuDiscoveryClient: { discoverChats: vi.fn(async () => []) },
+    });
+
+    const ack = await ctrl.handleRecentSenders({
+      provider: "feishu",
+      loginId: "fsl_pending",
+      accountId: "ag_alice",
+    });
+
+    expect(ack.ok).toBe(false);
+    expect(ack.error?.code).toBe("login_unconfirmed");
+  });
 });
 
 describe("frame schema validation", () => {

--- a/packages/daemon/src/gateway-control.ts
+++ b/packages/daemon/src/gateway-control.ts
@@ -38,6 +38,10 @@ import {
   startFeishuRegistration,
   type FeishuDomain,
 } from "./gateway/channels/feishu-registration.js";
+import {
+  discoverFeishuChats,
+  type FeishuDiscoveredChat,
+} from "./gateway/channels/feishu.js";
 import { WECHAT_BASE_INFO, wechatHeaders } from "./gateway/channels/wechat-http.js";
 import { assertSafeBaseUrl, UnsafeBaseUrlError } from "./gateway/channels/url-guard.js";
 import { log as daemonLog } from "./log.js";
@@ -172,8 +176,17 @@ interface GatewayRecentSender {
   label?: string | null;
 }
 
+interface GatewayRecentFeishuChat {
+  chatId: string;
+  senderOpenId: string;
+  kind: "direct" | "group";
+  label?: string | null;
+  lastSeenAt: number;
+}
+
 interface GatewayRecentSendersResult {
-  senders: GatewayRecentSender[];
+  senders?: GatewayRecentSender[];
+  chats?: GatewayRecentFeishuChat[];
 }
 
 interface GatewaySendParams {
@@ -213,6 +226,9 @@ export interface GatewayControlContext {
     startFeishuRegistration: typeof startFeishuRegistration;
     pollFeishuRegistration: typeof pollFeishuRegistration;
   };
+  feishuDiscoveryClient?: {
+    discoverChats: typeof discoverFeishuChats;
+  };
   /** Override the global fetch — used by `test_gateway` for Telegram getMe. */
   fetchImpl?: FetchLike;
 }
@@ -228,6 +244,7 @@ export function createGatewayControl(ctx: GatewayControlContext) {
   const wechatLogin = ctx.wechatLoginClient ?? { getBotQrcode, getQrcodeStatus };
   const feishuLogin =
     ctx.feishuLoginClient ?? { startFeishuRegistration, pollFeishuRegistration };
+  const feishuDiscovery = ctx.feishuDiscoveryClient ?? { discoverChats: discoverFeishuChats };
   // W7: validate fetch availability at construction so a missing global is
   // diagnosed at startup, not during the first control frame. Tests inject
   // `ctx.fetchImpl` explicitly and bypass the global lookup entirely.
@@ -898,7 +915,7 @@ export function createGatewayControl(ctx: GatewayControlContext) {
     if (!isProvider(params.provider)) {
       return badParams(`gateway_recent_senders: unknown provider "${String(params.provider)}"`);
     }
-    if (params.provider !== "wechat") {
+    if (params.provider !== "wechat" && params.provider !== "feishu") {
       return badParams(`gateway_recent_senders: provider "${params.provider}" not supported`);
     }
     if (!params.loginId) {
@@ -913,12 +930,12 @@ export function createGatewayControl(ctx: GatewayControlContext) {
         ok: false,
         error:
           resolved.state === "missing"
-            ? { code: "login_missing", message: `wechat login session "${params.loginId}" not found` }
-            : { code: "login_expired", message: `wechat login session "${params.loginId}" expired` },
+            ? { code: "login_missing", message: `${params.provider} login session "${params.loginId}" not found` }
+            : { code: "login_expired", message: `${params.provider} login session "${params.loginId}" expired` },
       };
     }
     const session = resolved.session!;
-    if (session.provider !== "wechat") {
+    if (session.provider !== params.provider) {
       return badParams("gateway_recent_senders: provider does not match login session");
     }
     if (session.accountId !== params.accountId) {
@@ -929,6 +946,43 @@ export function createGatewayControl(ctx: GatewayControlContext) {
           message: "gateway_recent_senders: accountId does not match login session",
         },
       };
+    }
+    if (params.provider === "feishu") {
+      if (!session.appId || !session.appSecret || !session.userOpenId) {
+        return {
+          ok: false,
+          error: {
+            code: "login_unconfirmed",
+            message: "feishu login session has no app credentials yet",
+          },
+        };
+      }
+      try {
+        const chats = await feishuDiscovery.discoverChats({
+          appId: session.appId,
+          appSecret: session.appSecret,
+          domain: session.domain ?? "feishu",
+          userOpenId: session.userOpenId,
+          timeoutSeconds: params.timeoutSeconds,
+        });
+        const result: GatewayRecentSendersResult = {
+          chats: chats.map((c: FeishuDiscoveredChat) => ({
+            chatId: c.chatId,
+            senderOpenId: c.senderOpenId,
+            kind: c.kind,
+            label: c.label ?? null,
+            lastSeenAt: c.lastSeenAt,
+          })),
+        };
+        return { ok: true, result };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        daemonLog.warn("gateway_recent_senders.feishu discovery failed", { error: message });
+        return {
+          ok: false,
+          error: { code: "provider_unreachable", message },
+        };
+      }
     }
     if (!session.botToken) {
       return {

--- a/packages/daemon/src/gateway/channels/feishu.ts
+++ b/packages/daemon/src/gateway/channels/feishu.ts
@@ -70,6 +70,31 @@ interface FeishuMessageEvent {
   message?: FeishuEventMessage;
 }
 
+export interface FeishuDiscoveredChat {
+  chatId: string;
+  senderOpenId: string;
+  kind: "direct" | "group";
+  label?: string | null;
+  lastSeenAt: number;
+}
+
+export interface FeishuChatDiscoveryOptions {
+  appId: string;
+  appSecret: string;
+  domain?: FeishuDomain;
+  userOpenId: string;
+  timeoutSeconds?: number;
+  sdkOverride?: {
+    createWsClient(args: Record<string, unknown>): {
+      start(opts: unknown): unknown;
+      close(opts?: unknown): unknown;
+    };
+    createDispatcher(): {
+      register(handlers: Record<string, (data: unknown) => unknown>): void;
+    };
+  };
+}
+
 interface FeishuProviderState {
   seenMessageIds?: Record<string, number>;
 }
@@ -130,6 +155,90 @@ function senderLabel(event: FeishuMessageEvent): string | undefined {
   const senderOpenId = event.sender?.sender_id?.open_id;
   const hit = mentions.find((m) => m.id?.open_id && m.id.open_id === senderOpenId);
   return typeof hit?.name === "string" && hit.name ? hit.name : undefined;
+}
+
+export function feishuDiscoveryChatFromEvent(
+  event: FeishuMessageEvent,
+  allowedSenderOpenId: string,
+  now: () => number = () => Date.now(),
+): FeishuDiscoveredChat | null {
+  const message = event.message;
+  const senderOpenId = event.sender?.sender_id?.open_id;
+  const chatId = message?.chat_id;
+  if (!message || !senderOpenId || !chatId) return null;
+  if (senderOpenId !== allowedSenderOpenId) return null;
+  const chatType = message.chat_type ?? "";
+  const kind: "direct" | "group" = chatType === "p2p" ? "direct" : "group";
+  const label = senderLabel(event) ?? null;
+  return {
+    chatId,
+    senderOpenId,
+    kind,
+    label,
+    lastSeenAt: Number(message.create_time) || now(),
+  };
+}
+
+export async function discoverFeishuChats(
+  opts: FeishuChatDiscoveryOptions,
+): Promise<FeishuDiscoveredChat[]> {
+  const timeoutSeconds =
+    typeof opts.timeoutSeconds === "number"
+      ? Math.min(Math.max(Math.floor(opts.timeoutSeconds), 0), 10)
+      : 0;
+  const chats = new Map<string, FeishuDiscoveredChat>();
+  const sdk = Lark as unknown as {
+    EventDispatcher: new (args?: Record<string, unknown>) => {
+      register(handlers: Record<string, (data: unknown) => unknown>): void;
+    };
+    WSClient: new (args: Record<string, unknown>) => {
+      start(opts: unknown): unknown;
+      close(opts?: unknown): unknown;
+    };
+    LoggerLevel?: { info?: unknown };
+  };
+  const dispatcher = opts.sdkOverride
+    ? opts.sdkOverride.createDispatcher()
+    : new sdk.EventDispatcher({});
+  dispatcher.register({
+    "im.message.receive_v1": (data: unknown) => {
+      const discovered = feishuDiscoveryChatFromEvent(
+        data as FeishuMessageEvent,
+        opts.userOpenId,
+      );
+      if (!discovered) return;
+      const previous = chats.get(discovered.chatId);
+      chats.set(discovered.chatId, {
+        ...previous,
+        ...discovered,
+        label: discovered.label ?? previous?.label ?? null,
+        lastSeenAt: Math.max(previous?.lastSeenAt ?? 0, discovered.lastSeenAt),
+      });
+    },
+  });
+  const wsClientArgs = {
+    appId: opts.appId,
+    appSecret: opts.appSecret,
+    domain: sdkDomain(opts.domain),
+    loggerLevel: sdk.LoggerLevel?.info,
+  };
+  const wsClient = opts.sdkOverride
+    ? opts.sdkOverride.createWsClient(wsClientArgs)
+    : new sdk.WSClient(wsClientArgs);
+  try {
+    const startFailure = Promise.resolve()
+      .then(() => wsClient.start({ eventDispatcher: dispatcher }))
+      .then(
+        () => new Promise<never>(() => {}),
+        (err) => Promise.reject(err),
+      );
+    const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+    await Promise.race([startFailure, delay(0)]);
+    await Promise.race([startFailure, delay(timeoutSeconds * 1000)]);
+  } finally {
+    wsClient.close({ force: true });
+  }
+  return [...chats.values()].sort((a, b) => b.lastSeenAt - a.lastSeenAt);
 }
 
 export function createFeishuChannel(opts: FeishuChannelOptions): ChannelAdapter {

--- a/packages/gateway-ingress/src/__tests__/setup-feishu.test.ts
+++ b/packages/gateway-ingress/src/__tests__/setup-feishu.test.ts
@@ -33,6 +33,9 @@ const DEVICE_CODE = "dc_alpha_beta_gamma_12345";
 const VERIFICATION_URL = "https://accounts.feishu.cn/personal_agent?code=dc_alpha";
 
 type RegistrationPhase = "pending" | "confirmed" | "denied" | "expired" | "fail";
+type FeishuSdkOverride = NonNullable<
+  Parameters<typeof createFeishuSetupAdapter>[0]
+>["sdkOverride"];
 
 interface Harness {
   dir: string;
@@ -50,6 +53,7 @@ async function buildHarness(
   opts: {
     adapters?: Record<string, ProviderSetupAdapter>;
     ttlMs?: number;
+    feishuSdkOverride?: FeishuSdkOverride;
   } = {},
 ): Promise<Harness> {
   const dir = mkdtempSync(join(tmpdir(), "ingress-setup-feishu-"));
@@ -112,7 +116,10 @@ async function buildHarness(
   }) as never;
 
   const adapters: Record<string, ProviderSetupAdapter> = {
-    feishu: createFeishuSetupAdapter({ fetchImpl }),
+    feishu: createFeishuSetupAdapter({
+      fetchImpl,
+      ...(opts.feishuSdkOverride ? { sdkOverride: opts.feishuSdkOverride } : {}),
+    }),
     ...(opts.adapters ?? {}),
   };
 
@@ -405,6 +412,81 @@ describe("setup-server — Feishu full flow", () => {
     const connection = create.body.connection as { config: Record<string, unknown> };
     expect(connection.config.allowedSenderIds).toEqual([FAKE_OPEN_ID]);
   });
+
+  it("discovers Feishu chat_id from the registered user before finalize", async () => {
+    await h.server.close();
+    rmSync(h.dir, { recursive: true, force: true });
+    let handlers: Record<string, (data: unknown) => unknown> = {};
+    const starts: Record<string, unknown>[] = [];
+    h = await buildHarness({
+      feishuSdkOverride: {
+        createDispatcher: () => ({
+          register: (next) => {
+            handlers = next;
+          },
+        }),
+        createWsClient: (args) => ({
+          start: () => {
+            starts.push(args);
+            handlers["im.message.receive_v1"]?.({
+              sender: { sender_id: { open_id: "ou_intruder" } },
+              message: { chat_id: "oc_wrong", chat_type: "group", create_time: "1" },
+            });
+            handlers["im.message.receive_v1"]?.({
+              sender: { sender_id: { open_id: FAKE_OPEN_ID } },
+              message: {
+                chat_id: "oc_team",
+                chat_type: "group",
+                create_time: "1700000000123",
+                mentions: [{ id: { open_id: FAKE_OPEN_ID }, name: "Alice" }],
+              },
+            });
+          },
+          close: () => {},
+        }),
+      },
+    });
+
+    const agentId = "ag_fs_discover";
+    const baseCtx = { user_id: "u", hosting_kind: "cloud" } as const;
+    const start = await call(
+      h.url,
+      `/internal/gateway-ingress/agents/${agentId}/gateways/feishu/login/start`,
+      { body: { ...baseCtx } },
+      h.responses,
+    );
+    const loginId = start.body.loginId as string;
+    h.state.phase = "confirmed";
+    await call(
+      h.url,
+      `/internal/gateway-ingress/agents/${agentId}/gateways/feishu/login/status`,
+      { body: { ...baseCtx, loginId } },
+      h.responses,
+    );
+
+    const discover = await call(
+      h.url,
+      `/internal/gateway-ingress/agents/${agentId}/gateways/feishu/discover`,
+      { body: { ...baseCtx, loginId, timeoutSeconds: 1 } },
+      h.responses,
+    );
+
+    expect(discover.status).toBe(200);
+    expect(starts).toHaveLength(1);
+    expect(starts[0]?.appId).toBe(FAKE_APP_ID);
+    expect(starts[0]?.appSecret).toBe(FAKE_APP_SECRET);
+    expect(discover.body.chats).toEqual([
+      {
+        chatId: "oc_team",
+        senderOpenId: FAKE_OPEN_ID,
+        kind: "group",
+        label: "Alice",
+        lastSeenAt: 1700000000123,
+      },
+    ]);
+    expect(discover.body.candidates).toEqual(discover.body.chats);
+    expect(JSON.stringify(discover.body)).not.toContain(FAKE_APP_SECRET);
+  });
 });
 
 describe("setup-server — Feishu error semantics", () => {
@@ -469,6 +551,103 @@ describe("setup-server — Feishu error semantics", () => {
     );
     expect(res.status).toBe(409);
     expect((res.body.error as { code: string }).code).toBe("login_unconfirmed");
+  });
+
+  it("rejects Feishu setup session access from a mismatched agent or user", async () => {
+    const agentId = "ag_owner";
+    const baseCtx = { user_id: "owner", hosting_kind: "cloud" } as const;
+    const start = await call(
+      h.url,
+      `/internal/gateway-ingress/agents/${agentId}/gateways/feishu/login/start`,
+      { body: { ...baseCtx } },
+      h.responses,
+    );
+    const loginId = start.body.loginId as string;
+
+    const wrongStatus = await call(
+      h.url,
+      `/internal/gateway-ingress/agents/${agentId}/gateways/feishu/login/status`,
+      { body: { user_id: "intruder", hosting_kind: "cloud", loginId } },
+      h.responses,
+    );
+    expect(wrongStatus.status).toBe(401);
+    expect((wrongStatus.body.error as { code: string }).code).toBe("unauthorized");
+
+    h.state.phase = "confirmed";
+    const confirmed = await call(
+      h.url,
+      `/internal/gateway-ingress/agents/${agentId}/gateways/feishu/login/status`,
+      { body: { ...baseCtx, loginId } },
+      h.responses,
+    );
+    expect(confirmed.status).toBe(200);
+
+    const wrongAgentDiscover = await call(
+      h.url,
+      `/internal/gateway-ingress/agents/ag_other/gateways/feishu/discover`,
+      { body: { ...baseCtx, loginId, timeoutSeconds: 0 } },
+      h.responses,
+    );
+    expect(wrongAgentDiscover.status).toBe(401);
+    expect((wrongAgentDiscover.body.error as { code: string }).code).toBe("unauthorized");
+
+    const wrongUserFinalize = await call(
+      h.url,
+      `/internal/gateway-ingress/agents/${agentId}/gateways`,
+      {
+        body: {
+          user_id: "intruder",
+          hosting_kind: "cloud",
+          provider: "feishu",
+          loginId,
+          config: {},
+        },
+      },
+      h.responses,
+    );
+    expect(wrongUserFinalize.status).toBe(401);
+    expect((wrongUserFinalize.body.error as { code: string }).code).toBe("unauthorized");
+  });
+
+  it("returns provider_unreachable when Feishu discovery websocket start fails", async () => {
+    await h.server.close();
+    rmSync(h.dir, { recursive: true, force: true });
+    h = await buildHarness({
+      feishuSdkOverride: {
+        createDispatcher: () => ({ register: () => {} }),
+        createWsClient: () => ({
+          start: () => Promise.reject(new Error("ws start failed")),
+          close: () => {},
+        }),
+      },
+    });
+    const agentId = "ag_fs_ws_start_fail";
+    const baseCtx = { user_id: "u", hosting_kind: "cloud" } as const;
+    const start = await call(
+      h.url,
+      `/internal/gateway-ingress/agents/${agentId}/gateways/feishu/login/start`,
+      { body: { ...baseCtx } },
+      h.responses,
+    );
+    const loginId = start.body.loginId as string;
+    h.state.phase = "confirmed";
+    await call(
+      h.url,
+      `/internal/gateway-ingress/agents/${agentId}/gateways/feishu/login/status`,
+      { body: { ...baseCtx, loginId } },
+      h.responses,
+    );
+
+    const discover = await call(
+      h.url,
+      `/internal/gateway-ingress/agents/${agentId}/gateways/feishu/discover`,
+      { body: { ...baseCtx, loginId, timeoutSeconds: 0 } },
+      h.responses,
+    );
+
+    expect(discover.status).toBe(502);
+    expect((discover.body.error as { code: string }).code).toBe("provider_unreachable");
+    expect(JSON.stringify(discover.body)).not.toContain(FAKE_APP_SECRET);
   });
 
   it("returns gateway_conflict when the same appId is already owned by an active gateway", async () => {

--- a/packages/gateway-ingress/src/__tests__/setup-server.test.ts
+++ b/packages/gateway-ingress/src/__tests__/setup-server.test.ts
@@ -326,6 +326,63 @@ describe("setup-server — WeChat full flow", () => {
       expect(raw).not.toContain(FAKE_BOT_TOKEN);
     }
   });
+
+  it("merges top-level discover options without overriding nested options", async () => {
+    const seen: Array<Record<string, unknown> | undefined> = [];
+    await h.server.close();
+    rmSync(h.dir, { recursive: true, force: true });
+    h = await buildHarness({
+      adapters: {
+        telegram: {
+          provider: "telegram",
+          discover: async (req) => {
+            seen.push(req.options);
+            return { candidates: [] };
+          },
+          finalize: async () => {
+            throw new Error("not used");
+          },
+        },
+      },
+    });
+
+    const agentId = "ag_discover_options";
+    const topLevel = await call(
+      h.url,
+      `/internal/gateway-ingress/agents/${agentId}/gateways/telegram/discover`,
+      {
+        body: {
+          user_id: "usr_1",
+          hosting_kind: "cloud",
+          loginId: "tgl_options",
+          timeoutSeconds: 6,
+          options: { mode: "top-level-timeout" },
+        },
+      },
+      h.responses,
+    );
+    const nested = await call(
+      h.url,
+      `/internal/gateway-ingress/agents/${agentId}/gateways/telegram/discover`,
+      {
+        body: {
+          user_id: "usr_1",
+          hosting_kind: "cloud",
+          loginId: "tgl_options",
+          timeoutSeconds: 6,
+          options: { timeoutSeconds: 2, mode: "nested-wins" },
+        },
+      },
+      h.responses,
+    );
+
+    expect(topLevel.status).toBe(200);
+    expect(nested.status).toBe(200);
+    expect(seen).toEqual([
+      { timeoutSeconds: 6, mode: "top-level-timeout" },
+      { timeoutSeconds: 2, mode: "nested-wins" },
+    ]);
+  });
 });
 
 describe("setup-server — auth", () => {

--- a/packages/gateway-ingress/src/setup/providers/feishu.ts
+++ b/packages/gateway-ingress/src/setup/providers/feishu.ts
@@ -10,16 +10,19 @@
  *
  * See `docs/cloud-gateway-ingress-remediation-plan.md` §5.2.
  *
- * Feishu is event-subscription oriented, so `discover` is not
- * implemented at the MVP stage: the user's own `userOpenId` is captured
- * at registration time and can default into `allowedSenderIds`, and the
- * `allowedChatIds` allowlist is filled in by the user at finalize time.
+ * After registration confirms, `discover` temporarily opens the Feishu
+ * event websocket with the setup-session app credentials and captures
+ * chat_id values only from the registered userOpenId.
  */
+
+import * as Lark from "@larksuiteoapi/node-sdk";
 
 import type { GatewayConnection } from "../../types.js";
 import { maskTokenPreview, mintGatewayId, mintLoginId } from "../sessions.js";
 import {
   SetupError,
+  type DiscoverRequest,
+  type DiscoverResult,
   type FinalizeRequest,
   type FinalizeResult,
   type LoginStartRequest,
@@ -41,10 +44,97 @@ import {
 
 export interface FeishuSetupAdapterOptions {
   fetchImpl?: FetchLike;
+  /** Test hook: bypass the lark SDK for temporary discovery sockets. */
+  sdkOverride?: FeishuDiscoverySdkOverride;
 }
 
 function parseDomain(raw: unknown): FeishuDomain {
   return raw === "lark" ? "lark" : "feishu";
+}
+
+interface FeishuEventSender {
+  sender_id?: {
+    open_id?: string;
+    user_id?: string;
+    union_id?: string;
+  };
+  sender_type?: string;
+  tenant_key?: string;
+}
+
+interface FeishuEventMessage {
+  message_id?: string;
+  create_time?: string;
+  chat_id?: string;
+  chat_type?: string;
+  mentions?: Array<{ id?: { open_id?: string; user_id?: string }; name?: string }>;
+}
+
+interface FeishuMessageEvent {
+  sender?: FeishuEventSender;
+  message?: FeishuEventMessage;
+}
+
+interface FeishuDiscoveredChat {
+  chatId: string;
+  senderOpenId: string;
+  kind: "direct" | "group";
+  label?: string | null;
+  lastSeenAt: number;
+}
+
+export interface FeishuDiscoverySdkOverride {
+  createWsClient(args: Record<string, unknown>): {
+    start(opts: unknown): unknown;
+    close(opts?: unknown): unknown;
+  };
+  createDispatcher(): {
+    register(handlers: Record<string, (data: unknown) => unknown>): void;
+  };
+}
+
+function sdkDomain(domain: FeishuDomain | undefined): unknown {
+  const sdk = Lark as unknown as { Domain?: { Feishu?: unknown; Lark?: unknown } };
+  return domain === "lark" ? sdk.Domain?.Lark : sdk.Domain?.Feishu;
+}
+
+function senderLabel(event: FeishuMessageEvent): string | undefined {
+  const mentions = event.message?.mentions ?? [];
+  const senderOpenId = event.sender?.sender_id?.open_id;
+  const hit = mentions.find((m) => m.id?.open_id && m.id.open_id === senderOpenId);
+  return typeof hit?.name === "string" && hit.name ? hit.name : undefined;
+}
+
+function discoveryChatFromEvent(
+  event: FeishuMessageEvent,
+  allowedSenderOpenId: string,
+  now: () => number,
+): FeishuDiscoveredChat | null {
+  const message = event.message;
+  const senderOpenId = event.sender?.sender_id?.open_id;
+  const chatId = message?.chat_id;
+  if (!message || !senderOpenId || !chatId) return null;
+  if (senderOpenId !== allowedSenderOpenId) return null;
+  return {
+    chatId,
+    senderOpenId,
+    kind: message.chat_type === "p2p" ? "direct" : "group",
+    label: senderLabel(event) ?? null,
+    lastSeenAt: Number(message.create_time) || now(),
+  };
+}
+
+function parseTimeoutSeconds(raw: unknown): number {
+  return typeof raw === "number" ? Math.min(Math.max(Math.floor(raw), 0), 10) : 0;
+}
+
+function assertSessionOwner(
+  session: { agentId: string; userId?: string },
+  req: { agentId: string; userId: string },
+): void {
+  if (session.agentId !== req.agentId || (session.userId && session.userId !== req.userId)) {
+    throw new SetupError("unauthorized", "login session does not belong to this requester");
+  }
 }
 
 /**
@@ -66,6 +156,7 @@ export function createFeishuSetupAdapter(
   opts: FeishuSetupAdapterOptions = {},
 ): ProviderSetupAdapter {
   const fetchImpl = opts.fetchImpl;
+  const sdkOverride = opts.sdkOverride;
 
   async function loginStart(
     req: LoginStartRequest,
@@ -121,6 +212,7 @@ export function createFeishuSetupAdapter(
     if (!session || session.provider !== "feishu") {
       throw new SetupError("login_missing", "login id is unknown");
     }
+    assertSessionOwner(session, req);
 
     // Already confirmed: return cached preview, never re-poll, never
     // surface appSecret. The dashboard polls this endpoint on a timer
@@ -212,6 +304,87 @@ export function createFeishuSetupAdapter(
     };
   }
 
+  async function discover(
+    req: DiscoverRequest,
+    ctx: SetupContext,
+  ): Promise<DiscoverResult> {
+    const { state, session } = ctx.sessions.resolve(req.loginId);
+    if (state === "missing") throw new SetupError("login_missing", "login id is unknown");
+    if (state === "expired") throw new SetupError("login_expired", "login session expired");
+    if (!session || session.provider !== "feishu") {
+      throw new SetupError("login_missing", "login id is unknown");
+    }
+    assertSessionOwner(session, req);
+    const { appId, appSecret, domain, userOpenId } = session.secretPayload;
+    if (
+      session.status !== "confirmed" ||
+      !appId ||
+      !appSecret ||
+      !userOpenId
+    ) {
+      throw new SetupError("login_unconfirmed", "feishu login is not confirmed yet");
+    }
+
+    const chats = new Map<string, FeishuDiscoveredChat>();
+    const dispatcher = createDiscoveryDispatcher();
+    dispatcher.register({
+      "im.message.receive_v1": (data: unknown) => {
+        const discovered = discoveryChatFromEvent(
+          data as FeishuMessageEvent,
+          userOpenId,
+          ctx.now,
+        );
+        if (!discovered) return;
+        const previous = chats.get(discovered.chatId);
+        chats.set(discovered.chatId, {
+          ...previous,
+          ...discovered,
+          label: discovered.label ?? previous?.label ?? null,
+          lastSeenAt: Math.max(previous?.lastSeenAt ?? 0, discovered.lastSeenAt),
+        });
+      },
+    });
+    const wsClient = createDiscoveryWsClient({
+      appId,
+      appSecret,
+      domain: sdkDomain(domain),
+    });
+    try {
+      const startFailure = Promise.resolve()
+        .then(() => wsClient.start({ eventDispatcher: dispatcher }))
+        .then(
+          () => new Promise<never>(() => {}),
+          (err) => Promise.reject(err),
+        );
+      const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+      await Promise.race([startFailure, delay(0)]);
+      await Promise.race([
+        startFailure,
+        delay(parseTimeoutSeconds(req.options?.timeoutSeconds) * 1000),
+      ]);
+    } catch (err) {
+      ctx.log.warn("feishu discover failed", {
+        agentId: req.agentId,
+        loginId: req.loginId,
+        err: redact(String(err), appSecret),
+      });
+      throw new SetupError("provider_unreachable", "feishu discovery endpoint unreachable");
+    } finally {
+      try {
+        wsClient.close({ force: true });
+      } catch {
+        // best effort
+      }
+    }
+    const values = [...chats.values()]
+      .sort((a, b) => b.lastSeenAt - a.lastSeenAt)
+      .map((chat) => ({ ...chat }));
+    return {
+      candidates: values,
+      chats: values,
+    };
+  }
+
   async function finalize(
     req: FinalizeRequest,
     ctx: SetupContext,
@@ -222,6 +395,7 @@ export function createFeishuSetupAdapter(
     if (!session || session.provider !== "feishu") {
       throw new SetupError("login_missing", "login id is unknown");
     }
+    assertSessionOwner(session, req);
     const { appId, appSecret, domain, userOpenId } = session.secretPayload;
     if (
       session.status !== "confirmed" ||
@@ -343,10 +517,41 @@ export function createFeishuSetupAdapter(
     }
   }
 
+  function createDiscoveryDispatcher(): {
+    register(handlers: Record<string, (data: unknown) => unknown>): void;
+  } {
+    if (sdkOverride) return sdkOverride.createDispatcher();
+    const sdk = Lark as unknown as {
+      EventDispatcher: new (args?: Record<string, unknown>) => {
+        register(handlers: Record<string, (data: unknown) => unknown>): void;
+      };
+    };
+    return new sdk.EventDispatcher({});
+  }
+
+  function createDiscoveryWsClient(args: Record<string, unknown>): {
+    start(opts: unknown): unknown;
+    close(opts?: unknown): unknown;
+  } {
+    if (sdkOverride) return sdkOverride.createWsClient(args);
+    const sdk = Lark as unknown as {
+      WSClient: new (args: Record<string, unknown>) => {
+        start(opts: unknown): unknown;
+        close(opts?: unknown): unknown;
+      };
+      LoggerLevel?: { info?: unknown };
+    };
+    return new sdk.WSClient({
+      ...args,
+      loggerLevel: sdk.LoggerLevel?.info,
+    });
+  }
+
   return {
     provider: "feishu",
     loginStart,
     loginStatus,
+    discover,
     finalize,
     test,
   };

--- a/packages/gateway-ingress/src/setup/server.ts
+++ b/packages/gateway-ingress/src/setup/server.ts
@@ -198,7 +198,7 @@ async function handle(
       if (!adapter.discover) throw new SetupError("not_found", "discover not supported");
       const loginId = requireString(body, "loginId");
       const out = await adapter.discover(
-        { ...reqCtx, loginId, options: pick(body, "options") },
+        { ...reqCtx, loginId, options: mergeDiscoverOptions(body) },
         ctx,
       );
       sendJson(res, 200, { ok: true, ...out });
@@ -474,6 +474,18 @@ function pick(body: Record<string, unknown>, key: string): Record<string, unknow
   const v = body[key];
   if (v && typeof v === "object" && !Array.isArray(v)) return v as Record<string, unknown>;
   return undefined;
+}
+
+function mergeDiscoverOptions(body: Record<string, unknown>): Record<string, unknown> | undefined {
+  const merged: Record<string, unknown> = {};
+  for (const key of ["timeoutSeconds"]) {
+    if (key in body) merged[key] = body[key];
+  }
+  const nested = pick(body, "options");
+  if (nested) {
+    for (const [k, v] of Object.entries(nested)) merged[k] = v;
+  }
+  return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
 /**

--- a/packages/gateway-ingress/src/setup/types.ts
+++ b/packages/gateway-ingress/src/setup/types.ts
@@ -60,6 +60,8 @@ export interface DiscoverRequest extends SetupRequestContext {
 export interface DiscoverResult {
   /** Sender / chat candidates for allowlist UI. Shape is provider-defined. */
   candidates: Array<Record<string, unknown>>;
+  /** Provider-specific chat candidates. Present for Feishu chat_id discovery. */
+  chats?: Array<Record<string, unknown>>;
 }
 
 export interface FinalizeRequest extends SetupRequestContext {

--- a/packages/protocol-core/src/control-frame.ts
+++ b/packages/protocol-core/src/control-frame.ts
@@ -950,6 +950,15 @@ export interface GatewayRecentSender {
   label?: string | null;
 }
 
+export interface GatewayRecentFeishuChat {
+  chatId: string;
+  senderOpenId: string;
+  kind: "direct" | "group";
+  label?: string | null;
+  lastSeenAt: number;
+}
+
 export interface GatewayRecentSendersResult {
-  senders: GatewayRecentSender[];
+  senders?: GatewayRecentSender[];
+  chats?: GatewayRecentFeishuChat[];
 }


### PR DESCRIPTION
## Summary
- add Feishu setup chat discovery so users can send a message after QR registration and auto-fill allowed chat IDs
- carry discovered Feishu chats through daemon, gateway-ingress, backend, frontend store, and setup UI
- protect setup discovery/finalize ownership and guard frontend auto-fill races/manual edits

## Verification
- MISE_TRUSTED_CONFIG_PATHS=$PWD pnpm --filter @botcord/daemon test -- --run src/__tests__/gateway-control.test.ts src/__tests__/feishu-channel.test.ts
- MISE_TRUSTED_CONFIG_PATHS=$PWD pnpm --filter @botcord/gateway-ingress test -- --run src/__tests__/setup-feishu.test.ts src/__tests__/setup-server.test.ts
- backend/.venv/bin/python -m pytest backend/tests/test_app/test_app_gateways.py -q -k "feishu_recent_chats or wechat_recent_senders"
- git diff --check

Code Reviewer: No findings after re-review.