### PR TITLE
Fix Feishu discovery cleanup handling

### DIFF
--- a/packages/daemon/src/__tests__/feishu-channel.test.ts
+++ b/packages/daemon/src/__tests__/feishu-channel.test.ts
@@ -6,6 +6,9 @@ import {
 } from "../gateway/channels/feishu.js";
 
 describe("feishu chat discovery parser", () => {
+  const timeoutAfter = (ms: number, message: string) =>
+    new Promise<never>((_, reject) => setTimeout(() => reject(new Error(message)), ms));
+
   it("captures a group chat_id from the registered sender", () => {
     const hit = feishuDiscoveryChatFromEvent(
       {
@@ -82,10 +85,96 @@ describe("feishu chat discovery parser", () => {
           createDispatcher: () => ({ register: () => {} }),
           createWsClient: () => ({
             start: () => Promise.reject(new Error("ws start failed")),
-            close: () => {},
+            close: () => {
+              throw new Error("close failed");
+            },
           }),
         },
       }),
+    ).rejects.toThrow("ws start failed");
+  });
+
+  it("returns empty chats when listen succeeds with no matching message and close throws", async () => {
+    const chats = await discoverFeishuChats({
+      appId: "cli_123",
+      appSecret: "secret_123",
+      domain: "feishu",
+      userOpenId: "ou_alice",
+      timeoutSeconds: 0,
+      sdkOverride: {
+        createDispatcher: () => ({ register: () => {} }),
+        createWsClient: () => ({
+          start: () => undefined,
+          close: () => {
+            throw new Error("close failed");
+          },
+        }),
+      },
+    });
+
+    expect(chats).toEqual([]);
+  });
+
+  it("returns empty chats when listen succeeds with no matching message and close rejects", async () => {
+    const chats = await discoverFeishuChats({
+      appId: "cli_123",
+      appSecret: "secret_123",
+      domain: "feishu",
+      userOpenId: "ou_alice",
+      timeoutSeconds: 0,
+      sdkOverride: {
+        createDispatcher: () => ({ register: () => {} }),
+        createWsClient: () => ({
+          start: () => undefined,
+          close: () => Promise.reject(new Error("close failed")),
+        }),
+      },
+    });
+
+    expect(chats).toEqual([]);
+  });
+
+  it("returns empty chats when listen succeeds with no matching message and close never settles", async () => {
+    const chats = await Promise.race([
+      discoverFeishuChats({
+        appId: "cli_123",
+        appSecret: "secret_123",
+        domain: "feishu",
+        userOpenId: "ou_alice",
+        timeoutSeconds: 0,
+        sdkOverride: {
+          createDispatcher: () => ({ register: () => {} }),
+          createWsClient: () => ({
+            start: () => undefined,
+            close: () => new Promise<never>(() => {}),
+          }),
+        },
+      }),
+      timeoutAfter(100, "discovery waited for close"),
+    ]);
+
+    expect(chats).toEqual([]);
+  });
+
+  it("surfaces start failure when close never settles", async () => {
+    await expect(
+      Promise.race([
+        discoverFeishuChats({
+          appId: "cli_123",
+          appSecret: "secret_123",
+          domain: "feishu",
+          userOpenId: "ou_alice",
+          timeoutSeconds: 0,
+          sdkOverride: {
+            createDispatcher: () => ({ register: () => {} }),
+            createWsClient: () => ({
+              start: () => Promise.reject(new Error("ws start failed")),
+              close: () => new Promise<never>(() => {}),
+            }),
+          },
+        }),
+        timeoutAfter(100, "discovery waited for close"),
+      ]),
     ).rejects.toThrow("ws start failed");
   });
 });

--- a/packages/daemon/src/gateway/channels/feishu.ts
+++ b/packages/daemon/src/gateway/channels/feishu.ts
@@ -236,7 +236,20 @@ export async function discoverFeishuChats(
     await Promise.race([startFailure, delay(0)]);
     await Promise.race([startFailure, delay(timeoutSeconds * 1000)]);
   } finally {
-    wsClient.close({ force: true });
+    try {
+      const closeResult = wsClient.close({ force: true });
+      if (
+        closeResult &&
+        (typeof closeResult === "object" || typeof closeResult === "function") &&
+        typeof (closeResult as PromiseLike<unknown>).then === "function"
+      ) {
+        void Promise.resolve(closeResult).catch(() => {
+          // best effort
+        });
+      }
+    } catch {
+      // best effort
+    }
   }
   return [...chats.values()].sort((a, b) => b.lastSeenAt - a.lastSeenAt);
 }

--- a/packages/gateway-ingress/src/__tests__/setup-feishu.test.ts
+++ b/packages/gateway-ingress/src/__tests__/setup-feishu.test.ts
@@ -219,6 +219,9 @@ async function call(
   return { status: res.status, body, raw };
 }
 
+const timeoutAfter = (ms: number, message: string) =>
+  new Promise<never>((_, reject) => setTimeout(() => reject(new Error(message)), ms));
+
 describe("setup-server — Feishu full flow", () => {
   let h: Harness;
 
@@ -442,7 +445,9 @@ describe("setup-server — Feishu full flow", () => {
               },
             });
           },
-          close: () => {},
+          close: () => {
+            throw new Error("close failed");
+          },
         }),
       },
     });
@@ -609,7 +614,7 @@ describe("setup-server — Feishu error semantics", () => {
     expect((wrongUserFinalize.body.error as { code: string }).code).toBe("unauthorized");
   });
 
-  it("returns provider_unreachable when Feishu discovery websocket start fails", async () => {
+  it("returns provider_unreachable when Feishu discovery websocket start fails and close never settles", async () => {
     await h.server.close();
     rmSync(h.dir, { recursive: true, force: true });
     h = await buildHarness({
@@ -617,11 +622,55 @@ describe("setup-server — Feishu error semantics", () => {
         createDispatcher: () => ({ register: () => {} }),
         createWsClient: () => ({
           start: () => Promise.reject(new Error("ws start failed")),
-          close: () => {},
+          close: () => new Promise<never>(() => {}),
         }),
       },
     });
     const agentId = "ag_fs_ws_start_fail";
+    const baseCtx = { user_id: "u", hosting_kind: "cloud" } as const;
+    const start = await call(
+      h.url,
+      `/internal/gateway-ingress/agents/${agentId}/gateways/feishu/login/start`,
+      { body: { ...baseCtx } },
+      h.responses,
+    );
+    const loginId = start.body.loginId as string;
+    h.state.phase = "confirmed";
+    await call(
+      h.url,
+      `/internal/gateway-ingress/agents/${agentId}/gateways/feishu/login/status`,
+      { body: { ...baseCtx, loginId } },
+      h.responses,
+    );
+
+    const discover = await Promise.race([
+      call(
+        h.url,
+        `/internal/gateway-ingress/agents/${agentId}/gateways/feishu/discover`,
+        { body: { ...baseCtx, loginId, timeoutSeconds: 0 } },
+        h.responses,
+      ),
+      timeoutAfter(100, "discovery waited for close"),
+    ]);
+
+    expect(discover.status).toBe(502);
+    expect((discover.body.error as { code: string }).code).toBe("provider_unreachable");
+    expect(JSON.stringify(discover.body)).not.toContain(FAKE_APP_SECRET);
+  });
+
+  it("returns empty discovery results when listen succeeds with no matching message and close rejects", async () => {
+    await h.server.close();
+    rmSync(h.dir, { recursive: true, force: true });
+    h = await buildHarness({
+      feishuSdkOverride: {
+        createDispatcher: () => ({ register: () => {} }),
+        createWsClient: () => ({
+          start: () => undefined,
+          close: () => Promise.reject(new Error("close failed")),
+        }),
+      },
+    });
+    const agentId = "ag_fs_empty_close_reject";
     const baseCtx = { user_id: "u", hosting_kind: "cloud" } as const;
     const start = await call(
       h.url,
@@ -645,9 +694,96 @@ describe("setup-server — Feishu error semantics", () => {
       h.responses,
     );
 
-    expect(discover.status).toBe(502);
-    expect((discover.body.error as { code: string }).code).toBe("provider_unreachable");
-    expect(JSON.stringify(discover.body)).not.toContain(FAKE_APP_SECRET);
+    expect(discover.status).toBe(200);
+    expect(discover.body.chats).toEqual([]);
+    expect(discover.body.candidates).toEqual([]);
+  });
+
+  it("returns empty discovery results when listen succeeds with no matching message and close throws", async () => {
+    await h.server.close();
+    rmSync(h.dir, { recursive: true, force: true });
+    h = await buildHarness({
+      feishuSdkOverride: {
+        createDispatcher: () => ({ register: () => {} }),
+        createWsClient: () => ({
+          start: () => undefined,
+          close: () => {
+            throw new Error("close failed");
+          },
+        }),
+      },
+    });
+    const agentId = "ag_fs_empty_close_throw";
+    const baseCtx = { user_id: "u", hosting_kind: "cloud" } as const;
+    const start = await call(
+      h.url,
+      `/internal/gateway-ingress/agents/${agentId}/gateways/feishu/login/start`,
+      { body: { ...baseCtx } },
+      h.responses,
+    );
+    const loginId = start.body.loginId as string;
+    h.state.phase = "confirmed";
+    await call(
+      h.url,
+      `/internal/gateway-ingress/agents/${agentId}/gateways/feishu/login/status`,
+      { body: { ...baseCtx, loginId } },
+      h.responses,
+    );
+
+    const discover = await call(
+      h.url,
+      `/internal/gateway-ingress/agents/${agentId}/gateways/feishu/discover`,
+      { body: { ...baseCtx, loginId, timeoutSeconds: 0 } },
+      h.responses,
+    );
+
+    expect(discover.status).toBe(200);
+    expect(discover.body.chats).toEqual([]);
+    expect(discover.body.candidates).toEqual([]);
+  });
+
+  it("returns empty discovery results when listen succeeds with no matching message and close never settles", async () => {
+    await h.server.close();
+    rmSync(h.dir, { recursive: true, force: true });
+    h = await buildHarness({
+      feishuSdkOverride: {
+        createDispatcher: () => ({ register: () => {} }),
+        createWsClient: () => ({
+          start: () => undefined,
+          close: () => new Promise<never>(() => {}),
+        }),
+      },
+    });
+    const agentId = "ag_fs_empty_close_never";
+    const baseCtx = { user_id: "u", hosting_kind: "cloud" } as const;
+    const start = await call(
+      h.url,
+      `/internal/gateway-ingress/agents/${agentId}/gateways/feishu/login/start`,
+      { body: { ...baseCtx } },
+      h.responses,
+    );
+    const loginId = start.body.loginId as string;
+    h.state.phase = "confirmed";
+    await call(
+      h.url,
+      `/internal/gateway-ingress/agents/${agentId}/gateways/feishu/login/status`,
+      { body: { ...baseCtx, loginId } },
+      h.responses,
+    );
+
+    const discover = await Promise.race([
+      call(
+        h.url,
+        `/internal/gateway-ingress/agents/${agentId}/gateways/feishu/discover`,
+        { body: { ...baseCtx, loginId, timeoutSeconds: 0 } },
+        h.responses,
+      ),
+      timeoutAfter(100, "discovery waited for close"),
+    ]);
+
+    expect(discover.status).toBe(200);
+    expect(discover.body.chats).toEqual([]);
+    expect(discover.body.candidates).toEqual([]);
   });
 
   it("returns gateway_conflict when the same appId is already owned by an active gateway", async () => {

--- a/packages/gateway-ingress/src/setup/providers/feishu.ts
+++ b/packages/gateway-ingress/src/setup/providers/feishu.ts
@@ -371,7 +371,16 @@ export function createFeishuSetupAdapter(
       throw new SetupError("provider_unreachable", "feishu discovery endpoint unreachable");
     } finally {
       try {
-        wsClient.close({ force: true });
+        const closeResult = wsClient.close({ force: true });
+        if (
+          closeResult &&
+          (typeof closeResult === "object" || typeof closeResult === "function") &&
+          typeof (closeResult as PromiseLike<unknown>).then === "function"
+        ) {
+          void Promise.resolve(closeResult).catch(() => {
+            // best effort
+          });
+        }
       } catch {
         // best effort
       }


### PR DESCRIPTION
## Summary
- make Feishu temporary discovery close cleanup truly best-effort in daemon and gateway-ingress
- do not await close promises, so pending SDK cleanup cannot block empty-success or original start-failure results
- add regression coverage for close throw, reject, and never-settling cleanup

## Verification
- MISE_TRUSTED_CONFIG_PATHS=$PWD pnpm --filter @botcord/daemon test -- --run src/__tests__/feishu-channel.test.ts
- MISE_TRUSTED_CONFIG_PATHS=$PWD pnpm --filter @botcord/gateway-ingress test -- --run src/__tests__/setup-feishu.test.ts
- git diff --check

Code Reviewer: No findings.