### PR TITLE
fix: add owner chat reply action

### DIFF
--- a/backend/hub/routers/owner_chat_ws.py
+++ b/backend/hub/routers/owner_chat_ws.py
@@ -32,8 +32,10 @@ from hub.routers.dashboard_chat import (
     _OWNER_CHAT_ROOM_PREFIX,
 )
 from hub.routers.hub import (
-    notify_inbox,
+    _load_reply_previews,
+    _load_reply_target,
     build_message_realtime_event,
+    notify_inbox,
 )
 from hub.services.cloud_agent import resume_cloud_agent_for_inbox
 from hub.validators import normalize_file_url
@@ -406,6 +408,10 @@ async def owner_chat_ws(ws: WebSocket):
             elif msg_type == "send":
                 text = (msg.get("text") or "").strip()
                 client_msg_id = msg.get("client_msg_id") or None
+                raw_reply_to = msg.get("reply_to") or msg.get("replyTo") or None
+                reply_to_value = str(raw_reply_to).strip() if raw_reply_to is not None else None
+                if reply_to_value == "":
+                    reply_to_value = None
 
                 # Optional attachments (pre-uploaded via /api/dashboard/upload).
                 # URLs are normalized to absolute `HUB_PUBLIC_BASE_URL + /hub/files/f_*`;
@@ -447,50 +453,77 @@ async def owner_chat_ws(ws: WebSocket):
                         err_resp2["client_msg_id"] = str(client_msg_id)[:64]
                     await ws.send_json(err_resp2)
                     continue
+                if reply_to_value is not None and len(reply_to_value) > 64:
+                    err_resp3: dict = {"type": "error", "message": "Reply target is too long"}
+                    if client_msg_id:
+                        err_resp3["client_msg_id"] = str(client_msg_id)[:64]
+                    await ws.send_json(err_resp3)
+                    continue
 
                 logger.info("Owner-chat WS recv: user=%s agent=%s text_len=%d attachments=%d", user_id, agent_id, len(text), len(attachments))
 
                 cloud_resume_ok = False
-
-                # Create MessageRecord (same logic as dashboard_chat.send_chat_message)
-                msg_id = str(uuid.uuid4())
-                ts = int(time.time())
                 payload: dict = {"text": text}
                 if attachments:
                     payload["attachments"] = attachments
-                envelope_data = {
-                    "v": "a2a/0.1",
-                    "msg_id": msg_id,
-                    "ts": ts,
-                    "from": agent_id,
-                    "to": agent_id,
-                    "type": "message",
-                    "reply_to": None,
-                    "ttl_sec": 3600,
-                    "payload": payload,
-                    "payload_hash": "",
-                    "sig": {"alg": "ed25519", "key_id": "dashboard", "value": ""},
-                }
-                envelope_json = json.dumps(envelope_data)
-
-                hub_msg_id = generate_hub_msg_id()
-                record = MessageRecord(
-                    hub_msg_id=hub_msg_id,
-                    msg_id=msg_id,
-                    sender_id=agent_id,
-                    receiver_id=agent_id,
-                    room_id=room_id,
-                    state=MessageState.queued,
-                    envelope_json=envelope_json,
-                    ttl_sec=3600,
-                    mentioned=True,
-                    source_type="dashboard_user_chat",
-                    source_user_id=user_id,
-                    source_session_kind="owner_chat",
-                )
+                canonical_reply_msg_id: str | None = None
+                reply_preview = None
 
                 async with async_session() as db:
+                    if reply_to_value is not None:
+                        try:
+                            target = await _load_reply_target(
+                                db,
+                                room_id=room_id,
+                                reply_to_value=reply_to_value,
+                            )
+                        except HTTPException as exc:
+                            detail = exc.detail if isinstance(exc.detail, str) else "Invalid reply target"
+                            reply_err: dict = {"type": "error", "message": detail}
+                            if client_msg_id:
+                                reply_err["client_msg_id"] = str(client_msg_id)[:64]
+                            await ws.send_json(reply_err)
+                            continue
+                        canonical_reply_msg_id = target.msg_id
+                        previews = await _load_reply_previews(db, {canonical_reply_msg_id})
+                        reply_preview = previews.get(canonical_reply_msg_id)
+
                     cloud_resume_ok = await resume_cloud_agent_for_inbox(db, agent_id)
+
+                    # Create MessageRecord (same logic as dashboard_chat.send_chat_message)
+                    msg_id = str(uuid.uuid4())
+                    ts = int(time.time())
+                    envelope_data = {
+                        "v": "a2a/0.1",
+                        "msg_id": msg_id,
+                        "ts": ts,
+                        "from": agent_id,
+                        "to": agent_id,
+                        "type": "message",
+                        "reply_to": canonical_reply_msg_id,
+                        "ttl_sec": 3600,
+                        "payload": payload,
+                        "payload_hash": "",
+                        "sig": {"alg": "ed25519", "key_id": "dashboard", "value": ""},
+                    }
+                    envelope_json = json.dumps(envelope_data)
+
+                    hub_msg_id = generate_hub_msg_id()
+                    record = MessageRecord(
+                        hub_msg_id=hub_msg_id,
+                        msg_id=msg_id,
+                        sender_id=agent_id,
+                        receiver_id=agent_id,
+                        room_id=room_id,
+                        state=MessageState.queued,
+                        envelope_json=envelope_json,
+                        ttl_sec=3600,
+                        mentioned=True,
+                        source_type="dashboard_user_chat",
+                        source_user_id=user_id,
+                        source_session_kind="owner_chat",
+                        reply_to_msg_id=canonical_reply_msg_id,
+                    )
 
                     try:
                         async with db.begin_nested():
@@ -531,6 +564,8 @@ async def owner_chat_ws(ws: WebSocket):
                             created_at=record.created_at,
                             payload=payload,
                             sender_name=display_name,
+                            reply_to=canonical_reply_msg_id,
+                            reply_preview=reply_preview,
                         ),
                         resume_cloud=not cloud_resume_ok,
                     )
@@ -560,8 +595,13 @@ async def owner_chat_ws(ws: WebSocket):
                 }
                 if client_msg_id:
                     echo["client_msg_id"] = str(client_msg_id)[:64]
+                ext: dict[str, Any] = {}
                 if attachments:
-                    echo["ext"] = {"attachments": attachments}
+                    ext["attachments"] = attachments
+                if reply_preview is not None:
+                    ext["reply_preview"] = reply_preview.model_dump(mode="json")
+                if ext:
+                    echo["ext"] = ext
                 await ws.send_json(echo)
 
     except WebSocketDisconnect:

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import { ArrowLeft, Bot, Check, Copy, Forward, Loader2, MessageSquare, MoreHorizontal, AlertCircle, AlertTriangle, RotateCcw, Bell, FileText, PanelLeftOpen, Settings2, User } from "lucide-react";
+import { ArrowLeft, Bot, Check, Copy, CornerUpLeft, Forward, Loader2, MessageSquare, MoreHorizontal, AlertCircle, AlertTriangle, RotateCcw, Bell, FileText, PanelLeftOpen, Settings2, User, X } from "lucide-react";
 import { useRouter } from "nextjs-toploader/app";
 import { api } from "@/lib/api";
 import { useLanguage } from "@/lib/i18n";
@@ -29,7 +29,13 @@ import CopyableId from "@/components/ui/CopyableId";
 import MessageComposer from "./MessageComposer";
 import ReplyQuoteBlock from "./ReplyQuoteBlock";
 import ForwardModal from "./ForwardModal";
-import { buildOwnerChatForwardQuote, canShowOwnerChatMessageActions } from "@/lib/owner-chat-actions";
+import {
+  buildOwnerChatForwardQuote,
+  buildOwnerChatReplyPreview,
+  canReplyToOwnerChatMessage,
+  canShowOwnerChatMessageActions,
+  ownerChatReplyTargetId,
+} from "@/lib/owner-chat-actions";
 
 const HUB_BASE_URL =
   process.env.NEXT_PUBLIC_HUB_BASE_URL ||
@@ -93,6 +99,7 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
   const agentTyping = useOwnerChatStore((s) => s.agentTyping);
   const activeTraceId = useOwnerChatStore((s) => s.activeTraceId);
   const roomId = useOwnerChatStore((s) => s.roomId);
+  const replyingTo = useOwnerChatStore((s) => s.replyingTo);
 
   const [chatRoomName, setChatRoomName] = useState("");
   const [initializingRoom, setInitializingRoom] = useState(false);
@@ -103,6 +110,7 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
   const [copiedMessageId, setCopiedMessageId] = useState<string | null>(null);
   const [forwardQuote, setForwardQuote] = useState<string | null>(null);
   const settingsLabel = locale === "zh" ? "Bot 设置" : "Bot settings";
+  const replyLabel = locale === "zh" ? "回复" : "Reply";
   const forwardLabel = locale === "zh" ? "转发" : "Forward";
   const copyLabel = locale === "zh" ? "复制" : "Copy";
   const copiedLabel = locale === "zh" ? "已复制" : "Copied";
@@ -231,20 +239,25 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
 
   // ------ Send message ------
 
-  const sendMessage = useCallback(async (text: string, clientId: string, attachments?: Attachment[]) => {
+  const sendMessage = useCallback(async (
+    text: string,
+    clientId: string,
+    attachments?: Attachment[],
+    replyTo?: string | null,
+  ) => {
     const wsAtts: WsAttachment[] | undefined = attachments?.map((a) => ({
       filename: a.filename, url: a.url, content_type: a.content_type, size_bytes: a.size_bytes,
     }));
 
     // Try WS first
     if (wsClientRef.current && wsConnected) {
-      const sent = wsClientRef.current.send(text, wsAtts, clientId);
+      const sent = wsClientRef.current.send(text, wsAtts, clientId, replyTo);
       if (sent) return;
     }
 
     // HTTP fallback
     try {
-      const result = await api.sendUserChatMessage(text, attachments, chatAgentId || undefined);
+      const result = await api.sendUserChatMessage(text, attachments, chatAgentId || undefined, replyTo);
       useOwnerChatStore.getState().confirmOptimistic(clientId, result.hub_msg_id, new Date().toISOString(), attachments);
     } catch (err: any) {
       useOwnerChatStore.getState().failOptimistic(clientId, err?.message || "Failed to send");
@@ -256,6 +269,10 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
 
     const clientId = crypto.randomUUID();
     const displayText = text || (rawFiles.length > 0 ? `[${rawFiles.length} file(s)]` : "");
+    const replyTargetMsgId = replyingTo ? ownerChatReplyTargetId(replyingTo) : null;
+    const optimisticReplyPreview = replyingTo && replyTargetMsgId
+      ? buildOwnerChatReplyPreview(replyingTo)
+      : null;
 
     const optimisticMsg: OwnerChatMessage = {
       clientId,
@@ -269,17 +286,22 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
       type: "message",
       sendText: text,
       retryFiles: rawFiles.length > 0 ? rawFiles : undefined,
+      retryReplyTo: replyTargetMsgId,
+      replyPreview: optimisticReplyPreview ?? undefined,
     };
     useOwnerChatStore.getState().addOptimistic(optimisticMsg);
+    if (replyTargetMsgId) {
+      useOwnerChatStore.getState().setReplyingTo(null);
+    }
     scrollToBottom();
 
     try {
       const attachments = rawFiles.length > 0 ? await uploadFiles(rawFiles) : undefined;
-      await sendMessage(text, clientId, attachments);
+      await sendMessage(text, clientId, attachments, replyTargetMsgId);
     } catch (err: any) {
       useOwnerChatStore.getState().failOptimistic(clientId, err?.message || "Upload failed");
     }
-  }, [roomId, sendMessage, uploadFiles, scrollToBottom]);
+  }, [roomId, replyingTo, sendMessage, uploadFiles, scrollToBottom]);
 
   const handleRetry = useCallback(async (msg: OwnerChatMessage) => {
     useOwnerChatStore.getState().resetForRetry(msg.clientId);
@@ -288,11 +310,17 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
       if (!attachments && msg.retryFiles && msg.retryFiles.length > 0) {
         attachments = await uploadFiles(msg.retryFiles);
       }
-      await sendMessage(msg.sendText || msg.text, msg.clientId, attachments);
+      await sendMessage(msg.sendText || msg.text, msg.clientId, attachments, msg.retryReplyTo);
     } catch (err: any) {
       useOwnerChatStore.getState().failOptimistic(msg.clientId, err?.message || "Retry failed");
     }
   }, [sendMessage, uploadFiles]);
+
+  const handleReply = useCallback((msg: OwnerChatMessage) => {
+    setActionMenuOpenId(null);
+    if (!canReplyToOwnerChatMessage(msg)) return;
+    useOwnerChatStore.getState().setReplyingTo(msg);
+  }, []);
 
   const handleForward = useCallback((msg: OwnerChatMessage) => {
     setActionMenuOpenId(null);
@@ -316,6 +344,7 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
     const menuOpen = actionMenuOpenId === msg.clientId;
     const visible = hoveredActionId === msg.clientId || menuOpen;
     const copied = copiedMessageId === msg.clientId;
+    const canReply = canReplyToOwnerChatMessage(msg);
     return (
       <div className="relative shrink-0 self-start pt-1">
         <button
@@ -327,7 +356,17 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
           <MoreHorizontal className="h-3.5 w-3.5" />
         </button>
         {menuOpen && (
-          <div className={`absolute top-full mt-1 z-30 min-w-[80px] rounded-lg border border-zinc-700 bg-zinc-900 py-1 shadow-xl ${alignRight ? "right-0" : "left-0"}`}>
+          <div className={`absolute top-full mt-1 z-30 min-w-[96px] rounded-lg border border-zinc-700 bg-zinc-900 py-1 shadow-xl ${alignRight ? "right-0" : "left-0"}`}>
+            {canReply && (
+              <button
+                type="button"
+                onMouseDown={(event) => { event.preventDefault(); handleReply(msg); }}
+                className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100 transition-colors"
+              >
+                <CornerUpLeft className="h-3.5 w-3.5 text-zinc-500" />
+                {replyLabel}
+              </button>
+            )}
             <button
               type="button"
               onMouseDown={(event) => { event.preventDefault(); handleForward(msg); }}
@@ -754,16 +793,61 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
 
       {/* Input */}
       <div className="border-t border-zinc-800 px-4 py-3">
-        <MessageComposer
-          onSend={handleSend}
-          allowAttachments
-          placeholder="输入消息，@ 可引用联系人或房间..."
-          mentionCandidates={mentionCandidates}
-        />
+        <div className="flex flex-col gap-1">
+          {replyingTo && (
+            <OwnerChatReplyingToBar
+              target={replyingTo}
+              locale={locale}
+              onCancel={() => useOwnerChatStore.getState().setReplyingTo(null)}
+            />
+          )}
+          <MessageComposer
+            onSend={handleSend}
+            allowAttachments
+            placeholder="输入消息，@ 可引用联系人或房间..."
+            mentionCandidates={mentionCandidates}
+          />
+        </div>
       </div>
       {forwardQuote && (
         <ForwardModal quoteText={forwardQuote} onClose={() => setForwardQuote(null)} />
       )}
+    </div>
+  );
+}
+
+interface OwnerChatReplyingToBarProps {
+  target: OwnerChatMessage;
+  locale: "zh" | "en";
+  onCancel: () => void;
+}
+
+function OwnerChatReplyingToBar({ target, locale, onCancel }: OwnerChatReplyingToBarProps) {
+  const name = target.senderName || (locale === "zh" ? "消息" : "Message");
+  const preview = (target.text || "").slice(0, 80);
+  const replyingLabel = locale === "zh" ? "正在回复" : "Replying to";
+  const cancelLabel = locale === "zh" ? "取消引用" : "Cancel reply";
+
+  return (
+    <div className="mx-1 flex items-start gap-2 rounded-md border-l-2 border-neon-cyan/60 bg-glass-bg/60 pl-2 pr-1 py-1.5 text-xs">
+      <CornerUpLeft className="mt-0.5 h-3 w-3 shrink-0 text-neon-cyan/80" />
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-[11px] font-medium text-neon-cyan/90">
+          {replyingLabel} · {name}
+        </div>
+        {preview && (
+          <div className="truncate text-[11px] text-text-secondary/80">{preview}</div>
+        )}
+      </div>
+      <button
+        type="button"
+        onClick={onCancel}
+        className="rounded p-0.5 text-text-secondary/60 hover:bg-glass-bg hover:text-text-secondary transition-colors"
+        aria-label={cancelLabel}
+        title={cancelLabel}
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
     </div>
   );
 }

--- a/frontend/src/lib/owner-chat-actions.test.ts
+++ b/frontend/src/lib/owner-chat-actions.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import type { OwnerChatMessage } from "@/lib/types";
-import { buildOwnerChatForwardQuote, canShowOwnerChatMessageActions } from "@/lib/owner-chat-actions";
+import {
+  buildOwnerChatForwardQuote,
+  buildOwnerChatReplyPreview,
+  canReplyToOwnerChatMessage,
+  canShowOwnerChatMessageActions,
+  ownerChatReplyTargetId,
+} from "@/lib/owner-chat-actions";
 
 function message(overrides: Partial<OwnerChatMessage> = {}): OwnerChatMessage {
   return {
@@ -26,6 +32,29 @@ describe("owner chat message actions", () => {
     expect(canShowOwnerChatMessageActions(message({ status: "streaming" }))).toBe(false);
     expect(canShowOwnerChatMessageActions(message({ text: "   " }))).toBe(false);
     expect(canShowOwnerChatMessageActions(message({ type: "notification" }))).toBe(false);
+  });
+
+  it("allows replies only after a server message id exists", () => {
+    expect(canReplyToOwnerChatMessage(message({ hubMsgId: "h_123", status: "delivered" }))).toBe(true);
+    expect(canReplyToOwnerChatMessage(message({ hubMsgId: "h_123", status: "confirmed" }))).toBe(true);
+    expect(canReplyToOwnerChatMessage(message({ hubMsgId: null, status: "optimistic" }))).toBe(false);
+    expect(canReplyToOwnerChatMessage(message({ hubMsgId: null, status: "failed" }))).toBe(false);
+  });
+
+  it("uses hub_msg_id as the owner-chat reply target", () => {
+    expect(ownerChatReplyTargetId(message({ hubMsgId: "h_reply" }))).toBe("h_reply");
+    expect(ownerChatReplyTargetId(message({ hubMsgId: null }))).toBeNull();
+  });
+
+  it("builds a local reply preview for optimistic owner-chat sends", () => {
+    expect(buildOwnerChatReplyPreview(message({ hubMsgId: "h_reply" }))).toEqual({
+      msg_id: "h_reply",
+      sender_id: null,
+      sender_display_name: "Alice",
+      text_preview: "hello\nworld",
+      topic_id: null,
+      deleted: false,
+    });
   });
 
   it("builds a quote suitable for forwarding", () => {

--- a/frontend/src/lib/owner-chat-actions.ts
+++ b/frontend/src/lib/owner-chat-actions.ts
@@ -1,11 +1,40 @@
-import type { OwnerChatMessage } from "@/lib/types";
+import type { OwnerChatMessage, ReplyPreview } from "@/lib/types";
 
-type OwnerChatActionMessage = Pick<OwnerChatMessage, "createdAt" | "senderName" | "status" | "text" | "type">;
+type OwnerChatActionMessage = Pick<OwnerChatMessage, "createdAt" | "hubMsgId" | "senderName" | "status" | "text" | "type">;
+
+export function ownerChatReplyTargetId(
+  message: Pick<OwnerChatMessage, "hubMsgId">,
+): string | null {
+  return message.hubMsgId || null;
+}
 
 export function canShowOwnerChatMessageActions(message: OwnerChatActionMessage): boolean {
   return message.type === "message"
     && message.status !== "streaming"
     && message.text.trim().length > 0;
+}
+
+export function canReplyToOwnerChatMessage(message: OwnerChatActionMessage): boolean {
+  return message.type === "message"
+    && (message.status === "confirmed" || message.status === "delivered")
+    && message.text.trim().length > 0
+    && Boolean(ownerChatReplyTargetId(message));
+}
+
+export function buildOwnerChatReplyPreview(
+  message: Pick<OwnerChatMessage, "hubMsgId" | "senderName" | "text">,
+): ReplyPreview | null {
+  const msgId = ownerChatReplyTargetId(message);
+  if (!msgId) return null;
+
+  return {
+    msg_id: msgId,
+    sender_id: null,
+    sender_display_name: message.senderName || null,
+    text_preview: (message.text || "").slice(0, 120) || null,
+    topic_id: null,
+    deleted: false,
+  };
 }
 
 export function buildOwnerChatForwardQuote(

--- a/frontend/src/lib/owner-chat-ws.ts
+++ b/frontend/src/lib/owner-chat-ws.ts
@@ -26,7 +26,7 @@ export interface WsAttachment {
 }
 
 export interface OwnerChatWsClient {
-  send: (text: string, attachments?: WsAttachment[], clientMsgId?: string) => boolean;
+  send: (text: string, attachments?: WsAttachment[], clientMsgId?: string, replyTo?: string | null) => boolean;
   close: () => void;
 }
 
@@ -154,7 +154,7 @@ export function createOwnerChatWs(opts: OwnerChatWsOptions): OwnerChatWsClient {
     }, delay);
   }
 
-  function send(text: string, attachments?: WsAttachment[], clientMsgId?: string): boolean {
+  function send(text: string, attachments?: WsAttachment[], clientMsgId?: string, replyTo?: string | null): boolean {
     if (!ws || !authenticated || ws.readyState !== WebSocket.OPEN) {
       opts.onSendFailed?.(text, clientMsgId);
       return false;
@@ -166,6 +166,9 @@ export function createOwnerChatWs(opts: OwnerChatWsOptions): OwnerChatWsClient {
       }
       if (clientMsgId) {
         msg.client_msg_id = clientMsgId;
+      }
+      if (replyTo) {
+        msg.reply_to = replyTo;
       }
       ws.send(JSON.stringify(msg));
       return true;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -297,6 +297,8 @@ export interface OwnerChatMessage {
   sendText?: string;
   /** Unsent files preserved for retry. */
   retryFiles?: File[];
+  /** Reply target preserved for retry after upload or send failures. */
+  retryReplyTo?: string | null;
   /** Links streaming placeholder to its final delivered message. */
   traceId?: string;
   /** Quote-reply target preview (mirrors backend reply_preview). */

--- a/frontend/src/store/useOwnerChatStore.ts
+++ b/frontend/src/store/useOwnerChatStore.ts
@@ -327,7 +327,7 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
     set((state) => ({
       messages: state.messages.map((m) =>
         m.clientId === clientId
-          ? { ...m, hubMsgId, status: "confirmed" as const, createdAt, attachments: attachments ?? m.attachments, sendText: undefined, retryFiles: undefined }
+          ? { ...m, hubMsgId, status: "confirmed" as const, createdAt, attachments: attachments ?? m.attachments, sendText: undefined, retryFiles: undefined, retryReplyTo: undefined }
           : m
       ),
     }));
@@ -374,6 +374,8 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
           attachments: msg.attachments ?? m.attachments,
           sendText: undefined,
           retryFiles: undefined,
+          retryReplyTo: undefined,
+          replyPreview: msg.replyPreview ?? m.replyPreview,
         });
 
         const optimistic = state.messages.find((m) =>
@@ -448,6 +450,8 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
               error: undefined,
               sendText: undefined,
               retryFiles: undefined,
+              retryReplyTo: undefined,
+              replyPreview: match.replyPreview ?? m.replyPreview,
             };
           }
           return m;


### PR DESCRIPTION
## Summary
- Add Reply to the owner-chat message action menu.
- Show a replying-to bar above the owner-chat composer and send reply_to over both WebSocket and REST fallback.
- Persist and echo owner-chat reply previews from the WebSocket send path.

## Verification
- npm run test -- owner-chat-actions.test.ts --run
- NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key npm run build
- uv run pytest tests/test_dashboard_chat.py -q

## Risk / rollout
- Low risk; scoped to owner-chat reply UI and owner-chat WebSocket send handling.