### PR TITLE
fix: attach owner chat artifacts

### DIFF
--- a/backend/hub/routers/hub.py
+++ b/backend/hub/routers/hub.py
@@ -1563,11 +1563,13 @@ async def _send_room_message(
     if is_owner_chat and (_self_delivery or owner_chat_human_receivers):
         from hub.routers.owner_chat_ws import notify_oc_ws_message
         _oc_text = (envelope.payload or {}).get("text", "")
+        _oc_attachments = (envelope.payload or {}).get("attachments")
         await notify_oc_ws_message(
             room_id=room_id,
             hub_msg_id=first_hub_msg_id or "",
             sender_id=envelope.from_,
             text=_oc_text,
+            attachments=_oc_attachments if isinstance(_oc_attachments, list) else None,
             reply_preview=(
                 _reply_preview_room.model_dump(mode="json")
                 if _reply_preview_room is not None

--- a/backend/hub/routers/owner_chat_ws.py
+++ b/backend/hub/routers/owner_chat_ws.py
@@ -207,6 +207,7 @@ async def notify_oc_ws_message(
     sender_id: str,
     text: str,
     created_at: datetime.datetime | None = None,
+    attachments: list[dict[str, Any]] | None = None,
     reply_preview: dict[str, Any] | None = None,
 ) -> None:
     """Push an agent reply to connected owner-chat WS clients.
@@ -256,6 +257,8 @@ async def notify_oc_ws_message(
     ext: dict[str, Any] = {}
     if trace_id:
         ext["trace_id"] = trace_id
+    if attachments:
+        ext["attachments"] = attachments
     if reply_preview is not None:
         ext["reply_preview"] = reply_preview
     if ext:

--- a/backend/tests/test_dashboard_chat.py
+++ b/backend/tests/test_dashboard_chat.py
@@ -404,6 +404,7 @@ async def test_dashboard_chat_inbox_includes_source_type(
 async def test_agent_reply_to_owner_chat_creates_record(
     client: AsyncClient,
     db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     """When an agent sends a reply to its owner-chat room (rm_oc_*), a delivered
     MessageRecord is created for the human owner so the dashboard can display it."""
@@ -453,12 +454,20 @@ async def test_agent_reply_to_owner_chat_creates_record(
     }
 
     # Agent sends a reply back to this room via /hub/send
+    notify_mock = AsyncMock()
+    monkeypatch.setattr("hub.routers.owner_chat_ws.notify_oc_ws_message", notify_mock)
+    attachment = {
+        "filename": "xhs-01-cover.png",
+        "url": "https://api.botcord.chat/hub/files/f_cover",
+        "content_type": "image/png",
+        "size_bytes": 1234,
+    }
     envelope = _build_envelope(
         sk=sk,
         key_id=key_id,
         from_id=agent_id,
         to_id=room_id,
-        payload={"text": "Hello, owner!"},
+        payload={"text": "Hello, owner!", "attachments": [attachment]},
     )
 
     resp = await client.post("/hub/send", json=envelope, headers=headers)
@@ -478,6 +487,8 @@ async def test_agent_reply_to_owner_chat_creates_record(
     assert record.room_id == room_id
     assert record.sender_id == agent_id
     assert record.receiver_id == owner_human_id
+    notify_mock.assert_awaited_once()
+    assert notify_mock.await_args.kwargs["attachments"] == [attachment]
     # Crucially: state is 'delivered' (not 'queued') so it never appears in
     # inbox polling — the agent must not re-process its own reply.
     assert record.state.value == "delivered"

--- a/frontend/src/components/ui/MarkdownContent.test.ts
+++ b/frontend/src/components/ui/MarkdownContent.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { normalizeMessageContent, splitPlainMentionText } from "./MarkdownContent";
+import {
+  isPreviewableMarkdownImageSrc,
+  normalizeMessageContent,
+  splitPlainMentionText,
+} from "./MarkdownContent";
 
 function mentionProps(node: unknown) {
   return (node as { properties?: Record<string, unknown> }).properties;
@@ -43,5 +47,15 @@ describe("normalizeMessageContent", () => {
 
   it("preserves existing real line breaks", () => {
     expect(normalizeMessageContent("line one\nline two")).toBe("line one\nline two");
+  });
+});
+
+describe("isPreviewableMarkdownImageSrc", () => {
+  it("allows only absolute http(s) image URLs", () => {
+    expect(isPreviewableMarkdownImageSrc("https://example.com/card.png")).toBe(true);
+    expect(isPreviewableMarkdownImageSrc("http://example.com/card.png")).toBe(true);
+    expect(isPreviewableMarkdownImageSrc("output/xhs-01-cover.png")).toBe(false);
+    expect(isPreviewableMarkdownImageSrc("social-card-botcord-agent-hub/index.html")).toBe(false);
+    expect(isPreviewableMarkdownImageSrc("/hub/files/f_123")).toBe(false);
   });
 });

--- a/frontend/src/components/ui/MarkdownContent.tsx
+++ b/frontend/src/components/ui/MarkdownContent.tsx
@@ -47,6 +47,18 @@ export function normalizeMessageContent(content: string): string {
     .replace(/\\r/g, "\n");
 }
 
+export function isPreviewableMarkdownImageSrc(src: unknown): src is string {
+  if (typeof src !== "string") return false;
+  const trimmed = src.trim();
+  if (!trimmed) return false;
+  try {
+    const parsed = new URL(trimmed);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 function isMentionStartBoundary(value: string, index: number): boolean {
   if (index === 0) return true;
   return /[\s([{'"“‘]/.test(value[index - 1]);
@@ -266,6 +278,25 @@ function createComponents(renderMention?: MarkdownContentProps["renderMention"])
         {children}
       </a>
     ),
+    img: ({ src, alt }) => {
+      const rawSrc = typeof src === "string" ? src : "";
+      if (!isPreviewableMarkdownImageSrc(rawSrc)) {
+        return (
+          <code className="rounded border border-glass-border bg-black/30 px-1.5 py-0.5 font-mono text-xs text-neon-cyan/90">
+            {alt ? `${alt} (${rawSrc})` : rawSrc}
+          </code>
+        );
+      }
+      return (
+        <img
+          src={rawSrc}
+          alt={alt ?? ""}
+          className="my-2 max-h-72 max-w-full rounded-lg border border-glass-border object-contain"
+          loading="lazy"
+          decoding="async"
+        />
+      );
+    },
     ul: ({ children }) => (
       <ul className="mb-2 ml-4 list-disc last:mb-0 [&>li]:mb-0.5">{children}</ul>
     ),

--- a/packages/daemon/src/__tests__/system-context.test.ts
+++ b/packages/daemon/src/__tests__/system-context.test.ts
@@ -305,6 +305,8 @@ describe("createDaemonSystemContextBuilder", () => {
     expect(typeof out).toBe("string");
     expect(out).toContain("[BotCord Scene: Owner Chat]");
     expect(out).toContain("full administrative authority");
+    expect(out).toContain("cannot open this machine's local filesystem paths");
+    expect(out).toContain("upload or attach it through the BotCord file/attachment mechanism");
   });
 
   it("injects the owner-chat scene for dashboard_user_chat regardless of room prefix", () => {

--- a/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
+++ b/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
@@ -123,6 +123,56 @@ describe("createBotCordChannel — send()", () => {
     expect(result.providerMessageId).toBe("m_provider");
   });
 
+  it("uploads outbound attachments and includes them in sendMessage", async () => {
+    const client = makeClient({
+      uploadFile: vi.fn().mockResolvedValue({
+        original_filename: "xhs-01-cover.png",
+        url: "https://hub.test/hub/files/f_1",
+        content_type: "image/png",
+        size_bytes: 1234,
+      }),
+    });
+    const channel = createBotCordChannel({
+      id: "botcord-main",
+      accountId: "ag_self",
+      agentId: "ag_self",
+      client,
+    });
+    await channel.send({
+      message: {
+        channel: "botcord",
+        accountId: "ag_self",
+        conversationId: "rm_oc_1",
+        text: "done: output/xhs-01-cover.png",
+        attachments: [{
+          filePath: "/tmp/work/output/xhs-01-cover.png",
+          filename: "xhs-01-cover.png",
+          contentType: "image/png",
+          sourcePath: "output/xhs-01-cover.png",
+        }],
+      },
+      log: silentLog,
+    });
+
+    expect(client.uploadFile).toHaveBeenCalledWith(
+      "/tmp/work/output/xhs-01-cover.png",
+      "xhs-01-cover.png",
+      "image/png",
+    );
+    expect(client.sendMessage).toHaveBeenCalledWith(
+      "rm_oc_1",
+      "done: https://hub.test/hub/files/f_1",
+      {
+        attachments: [{
+          filename: "xhs-01-cover.png",
+          url: "https://hub.test/hub/files/f_1",
+          content_type: "image/png",
+          size_bytes: 1234,
+        }],
+      },
+    );
+  });
+
   it("omits topic/replyTo when not provided and returns null when response lacks ids", async () => {
     const client = makeClient({
       sendMessage: vi.fn().mockResolvedValue({ queued: true, status: "queued" }),

--- a/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
+++ b/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -2220,6 +2220,53 @@ describe("Dispatcher", () => {
   // ─────────────────────────────────────────────────────────────────────
   // Owner-chat reply gating
   // ─────────────────────────────────────────────────────────────────────
+
+  it("owner-chat reply auto-attaches generated local artifacts mentioned by relative path", async () => {
+    const workDir = await mkdtemp(path.join(tmpdir(), "dispatcher-artifacts-"));
+    tempDirs.push(workDir);
+    await mkdir(path.join(workDir, "output"), { recursive: true });
+    await mkdir(path.join(workDir, "social-card-botcord-agent-hub"), { recursive: true });
+    await writeFile(path.join(workDir, "output", "xhs-01-cover.png"), "png-bytes");
+    await writeFile(path.join(workDir, "social-card-botcord-agent-hub", "index.html"), "<html></html>");
+
+    const runtime = new FakeRuntime({
+      reply: [
+        "成品路径：",
+        "",
+        "output/xhs-01-cover.png",
+        "",
+        "项目文件在：",
+        "",
+        "social-card-botcord-agent-hub/index.html",
+      ].join("\n"),
+      newSessionId: "sid-1",
+    });
+    const { dispatcher, channel } = await scaffold({
+      config: baseConfig({ defaultRoute: { runtime: "claude-code", cwd: workDir } }),
+      runtimeFactory: () => runtime,
+    });
+
+    await dispatcher.handle(makeEnvelope({ conversation: { id: "rm_oc_1", kind: "direct" } }));
+
+    const realWorkDir = await realpath(workDir);
+    expect(channel.sends.length).toBe(1);
+    expect(channel.sends[0].message.attachments).toEqual([
+      {
+        filePath: path.join(realWorkDir, "output", "xhs-01-cover.png"),
+        filename: "xhs-01-cover.png",
+        contentType: "image/png",
+        sourcePath: "output/xhs-01-cover.png",
+        kind: "image",
+      },
+      {
+        filePath: path.join(realWorkDir, "social-card-botcord-agent-hub", "index.html"),
+        filename: "index.html",
+        contentType: "text/html",
+        sourcePath: "social-card-botcord-agent-hub/index.html",
+        kind: "file",
+      },
+    ]);
+  });
 
   it("non-owner-chat room: discards result.text, agent must use botcord_send", async () => {
     const runtime = new FakeRuntime({ reply: "would-be-reply", newSessionId: "sid-1" });

--- a/packages/daemon/src/gateway/channels/botcord.ts
+++ b/packages/daemon/src/gateway/channels/botcord.ts
@@ -1,3 +1,4 @@
+import { basename } from "node:path";
 import WebSocket from "ws";
 import {
   BotCordClient,
@@ -6,6 +7,7 @@ import {
   loadStoredCredentials,
   updateCredentialsToken,
   type InboxMessage,
+  type MessageAttachment,
 } from "@botcord/protocol-core";
 import type {
   ChannelAdapter,
@@ -57,16 +59,26 @@ export interface BotCordChannelClient {
     roomId?: string;
   }): Promise<{ messages: InboxMessage[]; count: number; has_more: boolean }>;
   ackMessages(messageIds: string[]): Promise<void>;
+  uploadFile?(
+    filePath: string,
+    filename: string,
+    contentType?: string,
+  ): Promise<{
+    original_filename: string;
+    url: string;
+    content_type?: string;
+    size_bytes?: number;
+  }>;
   sendMessage(
     to: string,
     text: string,
-    options?: { replyTo?: string; topic?: string },
+    options?: { replyTo?: string; topic?: string; attachments?: MessageAttachment[] },
   ): Promise<{ hub_msg_id?: string; message_id?: string } & Record<string, unknown>>;
   sendTypedMessage?(
     to: string,
     type: "result" | "error",
     text: string,
-    options?: { replyTo?: string; topic?: string },
+    options?: { replyTo?: string; topic?: string; attachments?: MessageAttachment[] },
   ): Promise<{ hub_msg_id?: string; message_id?: string } & Record<string, unknown>>;
   getHubUrl(): string;
   onTokenRefresh?: (token: string, expiresAt: number) => void;
@@ -116,6 +128,65 @@ function isUnclaimedAgentError(err: unknown): boolean {
     message.includes("agent_not_claimed_generic") ||
     message.includes("agent_not_claimed")
   );
+}
+
+async function uploadOutboundAttachments(
+  client: BotCordChannelClient,
+  attachments: NonNullable<ChannelSendContext["message"]["attachments"]>,
+  log: GatewayLogger,
+): Promise<{ attachments: MessageAttachment[]; replacements: Array<{ sourcePath: string; url: string }> }> {
+  if (attachments.length === 0) return { attachments: [], replacements: [] };
+  if (!client.uploadFile) {
+    log.warn("botcord send: outbound attachments skipped because uploadFile is unavailable", {
+      count: attachments.length,
+    });
+    return { attachments: [], replacements: [] };
+  }
+
+  const uploaded: MessageAttachment[] = [];
+  const replacements: Array<{ sourcePath: string; url: string }> = [];
+  for (const attachment of attachments) {
+    if (!attachment.filePath) {
+      log.warn("botcord send: attachment without filePath skipped", {
+        filename: attachment.filename ?? null,
+      });
+      continue;
+    }
+    try {
+      const resp = await client.uploadFile(
+        attachment.filePath,
+        attachment.filename ?? basename(attachment.filePath),
+        attachment.contentType,
+      );
+      if (attachment.sourcePath) {
+        replacements.push({ sourcePath: attachment.sourcePath, url: resp.url });
+      }
+      uploaded.push({
+        filename: resp.original_filename,
+        url: resp.url,
+        ...(resp.content_type ? { content_type: resp.content_type } : {}),
+        ...(typeof resp.size_bytes === "number" ? { size_bytes: resp.size_bytes } : {}),
+      });
+    } catch (err) {
+      log.warn("botcord send: attachment upload failed; continuing without it", {
+        filename: attachment.filename ?? attachment.filePath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return { attachments: uploaded, replacements };
+}
+
+function rewriteUploadedAttachmentPaths(
+  text: string,
+  replacements: Array<{ sourcePath: string; url: string }>,
+): string {
+  let out = text;
+  for (const { sourcePath, url } of replacements) {
+    if (!sourcePath || !url) continue;
+    out = out.replaceAll(sourcePath, url);
+  }
+  return out;
 }
 
 /** Default factory: wrap `loadStoredCredentials` + `new BotCordClient`. */
@@ -911,13 +982,16 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
     async send(ctx: ChannelSendContext): Promise<ChannelSendResult> {
       const client = ensureClient();
       const { message } = ctx;
-      const options: { replyTo?: string; topic?: string } = {};
+      const options: { replyTo?: string; topic?: string; attachments?: MessageAttachment[] } = {};
       if (message.replyTo) options.replyTo = message.replyTo;
       if (message.threadId) options.topic = message.threadId;
+      const upload = await uploadOutboundAttachments(client, message.attachments ?? [], ctx.log);
+      if (upload.attachments.length > 0) options.attachments = upload.attachments;
+      const text = rewriteUploadedAttachmentPaths(message.text, upload.replacements);
       const resp =
         message.type === "error" && client.sendTypedMessage
-          ? await client.sendTypedMessage(message.conversationId, "error", message.text, options)
-          : await client.sendMessage(message.conversationId, message.text, options);
+          ? await client.sendTypedMessage(message.conversationId, "error", text, options)
+          : await client.sendMessage(message.conversationId, text, options);
       const providerMessageId =
         (resp && typeof resp.hub_msg_id === "string" && resp.hub_msg_id) ||
         (resp && typeof (resp as { message_id?: unknown }).message_id === "string"

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from "node:crypto";
+import { realpathSync, statSync } from "node:fs";
+import path from "node:path";
 
 import type { GatewayLogger } from "./log.js";
 import { looksLikeRuntimeAuthFailure } from "./runtime-errors.js";
@@ -74,6 +76,31 @@ const TYPING_REFRESH_MS = 4000;
 
 /** LRU cap on the typing-recency map so long-running daemons don't grow unbounded. */
 const TYPING_RECENCY_CAP = 1024;
+const AUTO_ATTACHMENT_LIMIT = 10;
+const AUTO_ATTACHMENT_MAX_BYTES = 25 * 1024 * 1024;
+const AUTO_ATTACHMENT_EXTENSIONS = new Set([
+  ".avif",
+  ".bmp",
+  ".csv",
+  ".doc",
+  ".docx",
+  ".gif",
+  ".htm",
+  ".html",
+  ".jpeg",
+  ".jpg",
+  ".pdf",
+  ".png",
+  ".ppt",
+  ".pptx",
+  ".svg",
+  ".webp",
+  ".xls",
+  ".xlsx",
+  ".zip",
+]);
+const REPLY_LOCAL_PATH_RE =
+  /(^|[\s([{"'`])((?:\/|\.{1,2}\/)?(?:[\w@+.-]+\/)+[\w@+.-]+\.(?:avif|bmp|csv|docx?|gif|html?|jpe?g|pdf|png|pptx?|svg|webp|xlsx?|zip))(?=$|[\s)\]}"'`,.!?:;])/gi;
 
 function transcriptBlocksVerbose(): boolean {
   return process.env.BOTCORD_TRANSCRIPT_BLOCKS === "verbose" ||
@@ -2083,12 +2110,27 @@ export class Dispatcher {
         return;
       }
 
+      const attachments =
+        (isOwnerChat && isBotCordChannel(channel)
+          ? collectOwnerChatReplyAttachments(replyText, route.cwd)
+          : undefined) ?? [];
+      if (attachments.length > 0) {
+        this.log.info("dispatcher: attaching owner-chat reply artifacts", {
+          agentId: msg.accountId,
+          roomId: msg.conversation.id,
+          topicId: msg.conversation.threadId ?? null,
+          turnId,
+          count: attachments.length,
+        });
+      }
+
       const sendResult = await this.sendReply(channel, {
         channel: msg.channel,
         accountId: msg.accountId,
         conversationId: msg.conversation.id,
         threadId: msg.conversation.threadId ?? null,
         text: replyText,
+        attachments: attachments.length > 0 ? attachments : undefined,
         replyTo: this.providerReplyTo(msg),
         traceId: msg.trace?.id ?? null,
       }, turnId);
@@ -2237,6 +2279,100 @@ export class Dispatcher {
 
 function nowIso(): string {
   return new Date().toISOString();
+}
+
+function collectOwnerChatReplyAttachments(text: string, cwd: string): GatewayOutboundMessage["attachments"] {
+  const baseDir = safeRealpath(cwd);
+  if (!baseDir) return undefined;
+
+  const out: NonNullable<GatewayOutboundMessage["attachments"]> = [];
+  const seen = new Set<string>();
+  REPLY_LOCAL_PATH_RE.lastIndex = 0;
+
+  for (const match of text.matchAll(REPLY_LOCAL_PATH_RE)) {
+    const rawPath = match[2];
+    if (!rawPath || looksLikeUrl(rawPath)) continue;
+
+    const resolved = path.isAbsolute(rawPath)
+      ? path.resolve(rawPath)
+      : path.resolve(baseDir, rawPath);
+    const realPath = safeRealpath(resolved);
+    if (!realPath || seen.has(realPath) || !isPathInside(baseDir, realPath)) continue;
+
+    const ext = path.extname(realPath).toLowerCase();
+    if (!AUTO_ATTACHMENT_EXTENSIONS.has(ext)) continue;
+
+    let size = 0;
+    try {
+      const stat = statSync(realPath);
+      if (!stat.isFile()) continue;
+      size = stat.size;
+    } catch {
+      continue;
+    }
+    if (size <= 0 || size > AUTO_ATTACHMENT_MAX_BYTES) continue;
+
+    const contentType = contentTypeForExtension(ext);
+    out.push({
+      filePath: realPath,
+      filename: path.basename(realPath),
+      sourcePath: rawPath,
+      ...(contentType ? { contentType } : {}),
+      ...(contentType?.startsWith("image/") ? { kind: "image" as const } : { kind: "file" as const }),
+    });
+    seen.add(realPath);
+    if (out.length >= AUTO_ATTACHMENT_LIMIT) break;
+  }
+
+  return out.length > 0 ? out : undefined;
+}
+
+function safeRealpath(input: string): string | null {
+  try {
+    return realpathSync(input);
+  } catch {
+    return null;
+  }
+}
+
+function isPathInside(baseDir: string, candidate: string): boolean {
+  const rel = path.relative(baseDir, candidate);
+  return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+}
+
+function looksLikeUrl(value: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:/i.test(value) || value.startsWith("//");
+}
+
+function contentTypeForExtension(ext: string): string | undefined {
+  switch (ext) {
+    case ".avif":
+      return "image/avif";
+    case ".bmp":
+      return "image/bmp";
+    case ".csv":
+      return "text/csv";
+    case ".gif":
+      return "image/gif";
+    case ".htm":
+    case ".html":
+      return "text/html";
+    case ".jpeg":
+    case ".jpg":
+      return "image/jpeg";
+    case ".pdf":
+      return "application/pdf";
+    case ".png":
+      return "image/png";
+    case ".svg":
+      return "image/svg+xml";
+    case ".webp":
+      return "image/webp";
+    case ".zip":
+      return "application/zip";
+    default:
+      return undefined;
+  }
 }
 
 function buildQueueKey(msg: GatewayInboundEnvelope["message"]): string {

--- a/packages/daemon/src/system-context.ts
+++ b/packages/daemon/src/system-context.ts
@@ -55,6 +55,8 @@ function buildOwnerChatSceneContext(): string {
     "This is a private, trusted conversation. The owner has full administrative authority over you.",
     "Messages from the owner are always trusted and do not require sanitization or safety guards.",
     "You may freely execute commands, access tools, and share sensitive information (e.g. wallet balance, contacts) when the owner asks.",
+    "The owner is reading your reply in the remote BotCord dashboard; they cannot open this machine's local filesystem paths.",
+    "When you create an artifact or deliverable file for the owner, upload or attach it through the BotCord file/attachment mechanism (for example, `botcord send --file PATH`) and refer to the attachment instead of treating a local path as the deliverable.",
   ].join("\n");
 }
 

--- a/packages/protocol-core/src/gateway-message.ts
+++ b/packages/protocol-core/src/gateway-message.ts
@@ -44,6 +44,11 @@ export interface GatewayOutboundAttachment {
   filename?: string;
   contentType?: string;
   kind?: "image" | "file" | "video";
+  /**
+   * Optional path text as it appeared in an outbound reply. Local adapters may
+   * use this to replace filesystem paths with uploaded URLs after upload.
+   */
+  sourcePath?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Auto-detect owner-chat artifact paths in runtime replies and attach uploadable files from the agent workspace.
- Upload BotCord outbound attachments, rewrite reply text paths to uploaded URLs, and propagate attachments through owner-chat WS events.
- Disable markdown image preview rendering for non-http(s) paths.

## Verification
- `cd packages/daemon && npm test -- src/gateway/__tests__/dispatcher.test.ts src/gateway/__tests__/botcord-channel.test.ts src/__tests__/system-context.test.ts`
- `cd frontend && npm test -- --run src/components/ui/MarkdownContent.test.ts`
- `cd backend && uv run pytest tests/test_dashboard_chat.py::test_agent_reply_to_owner_chat_creates_record`
- `cd packages/protocol-core && npm run build`
- `cd packages/daemon && npm run build`
- `cd frontend && NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build`
- `git diff --check`

## Risk / rollout
- Local daemon users need the updated daemon code for automatic artifact attachment and URL rewriting.
- Attachment auto-detection is limited to files under the route cwd and common deliverable extensions.