### PR TITLE
fix: improve attachment previews

### DIFF
--- a/frontend/src/app/api/files/[fileId]/route.ts
+++ b/frontend/src/app/api/files/[fileId]/route.ts
@@ -1,0 +1,55 @@
+/**
+ * [INPUT]: public BotCord file id from path
+ * [OUTPUT]: GET /api/files/[fileId] — same-origin proxy for previewing Hub files
+ * [POS]: Dashboard attachment preview fetch path; avoids browser CORS for /hub/files/f_*
+ * [PROTOCOL]: keep this route restricted to BotCord file ids only
+ */
+
+import { NextResponse } from "next/server";
+
+const HUB_BASE_URL =
+  process.env.NEXT_PUBLIC_HUB_BASE_URL ||
+  (process.env.NODE_ENV === "development"
+    ? "http://localhost:8000"
+    : "https://api.botcord.chat");
+
+const FILE_ID_RE = /^f_[a-zA-Z0-9_-]+$/;
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ fileId: string }> },
+) {
+  const { fileId } = await params;
+  if (!FILE_ID_RE.test(fileId)) {
+    return NextResponse.json({ error: "invalid_file_id" }, { status: 400 });
+  }
+
+  const url = new URL(`/hub/files/${encodeURIComponent(fileId)}`, HUB_BASE_URL).toString();
+  const res = await fetch(url, {
+    method: "GET",
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    return new NextResponse(text || res.statusText, {
+      status: res.status,
+      headers: { "Content-Type": res.headers.get("Content-Type") || "text/plain" },
+    });
+  }
+
+  const headers = new Headers({
+    "Cache-Control": "no-store",
+    "Content-Type": res.headers.get("Content-Type") || "application/octet-stream",
+    "X-Content-Type-Options": "nosniff",
+  });
+  const contentLength = res.headers.get("Content-Length");
+  if (contentLength) {
+    headers.set("Content-Length", contentLength);
+  }
+
+  return new NextResponse(res.body, {
+    status: 200,
+    headers,
+  });
+}

--- a/frontend/src/components/dashboard/ChatPane.tsx
+++ b/frontend/src/components/dashboard/ChatPane.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 /**
- * [INPUT]: 依赖 session/ui/chat/contact store、可选路由 tab 覆盖值与 RoomHeader/MessageList/PaidRoomPreview/ExploreEntityCard 等内容组件
+ * [INPUT]: 依赖 session/ui/chat/contact store、可选路由 tab 覆盖值与 RoomHeader/MessageList/PaidRoomPreview/DocumentPreviewPane/ExploreEntityCard 等内容组件
  * [OUTPUT]: 对外提供 ChatPane 组件，渲染 explore/contacts/message 三类主内容视图，并把公开目录搜索委托给远端查询
  * [POS]: dashboard 第三栏主工作区，承载会话浏览与消息阅读；无 agent 准入由 DashboardApp 顶层统一处理
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
@@ -23,11 +23,12 @@ import MessageList from "./MessageList";
 import PaidRoomPreview from "./PaidRoomPreview";
 import RoomHumanComposer from "./RoomHumanComposer";
 import TopicDrawer from "./TopicDrawer";
+import DocumentPreviewPane from "./DocumentPreviewPane";
 import FriendInviteModal from "./FriendInviteModal";
 import ContactRequestsInbox from "./ContactRequestsInbox";
 import SearchBar from "./SearchBar";
 import ExploreEntityCard from "./ExploreEntityCard";
-import { PublicHumanProfile, PublicRoom } from "@/lib/types";
+import type { Attachment, PublicHumanProfile, PublicRoom } from "@/lib/types";
 import { api } from "@/lib/api";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardContactStore } from "@/store/useDashboardContactStore";
@@ -642,6 +643,7 @@ export default function ChatPane({ onHumanOpen, sidebarTabOverride }: ChatPanePr
     getRoomSummary: state.getRoomSummary,
   })));
   const effectiveSidebarTab = sidebarTabOverride ?? sidebarTab;
+  const [previewAttachment, setPreviewAttachment] = useState<Attachment | null>(null);
   const visibleMessageRooms = useMemo(
     () => buildVisibleMessageRooms({ overview, recentVisitedRooms, token, humanRooms }),
     [overview, recentVisitedRooms, token, humanRooms],
@@ -650,6 +652,10 @@ export default function ChatPane({ onHumanOpen, sidebarTabOverride }: ChatPanePr
   const isAuthedReady = sessionMode === "authed-ready";
   const isAuthedHuman = sessionMode === "authed-no-agent";
   const showLoginModal = () => router.push("/login");
+
+  useEffect(() => {
+    setPreviewAttachment(null);
+  }, [effectiveSidebarTab, openedRoomId]);
 
   if (effectiveSidebarTab === "explore") {
     return <ExploreMainPane onHumanOpen={onHumanOpen} />;
@@ -690,55 +696,65 @@ export default function ChatPane({ onHumanOpen, sidebarTabOverride }: ChatPanePr
   return (
     <div className="flex flex-1 flex-col bg-deep-black overflow-hidden">
       {openedRoomId && <RoomHeader />}
-      <div className="flex-1 overflow-hidden flex flex-col">
-        {openedRoomId ? (
-          isPaidAndNotJoined && openedRoom?.required_subscription_product_id ? (
-            <PaidRoomPreview
-              roomId={openedRoomId}
-              productId={openedRoom.required_subscription_product_id}
-              isGuest={isGuest}
-              loginHref={loginHref}
-            />
-          ) : (
-            <MessageList />
-          )
-        ) : (
-          <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-text-secondary">
-            {t.selectRoom}
+      <div className="min-h-0 flex-1 overflow-hidden flex">
+        <div className="min-w-0 flex-1 overflow-hidden flex flex-col">
+          <div className="flex-1 overflow-hidden flex flex-col">
+            {openedRoomId ? (
+              isPaidAndNotJoined && openedRoom?.required_subscription_product_id ? (
+                <PaidRoomPreview
+                  roomId={openedRoomId}
+                  productId={openedRoom.required_subscription_product_id}
+                  isGuest={isGuest}
+                  loginHref={loginHref}
+                />
+              ) : (
+                <MessageList onPreviewAttachment={setPreviewAttachment} />
+              )
+            ) : (
+              <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-text-secondary">
+                {t.selectRoom}
+              </div>
+            )}
           </div>
+          {openedRoomId && !isPaidAndNotJoined && (
+            <>
+              {originAgent ? (
+                <div className="border-t border-glass-border bg-glass-bg/30 px-4 py-2.5">
+                  <p className="text-center text-xs text-text-secondary/70">
+                    由 {originAgent.display_name} 代为发言 · 你是 owner，可观察不可发
+                  </p>
+                </div>
+              ) : isGuest ? (
+                <div className="border-t border-glass-border px-4 py-2">
+                  <div className="flex items-center justify-center gap-2">
+                    <p className="text-center text-xs text-text-secondary/50">{t.readOnlyGuest}</p>
+                    <button
+                      onClick={showLoginModal}
+                      className="rounded border border-neon-cyan/30 px-2 py-0.5 text-[10px] font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/10"
+                    >
+                      {t.loginToParticipate}
+                    </button>
+                  </div>
+                </div>
+              ) : (isAuthedReady || isAuthedHuman) && isJoinedRoom && openedRoomId && humanSendAllowed ? (
+                <div className="border-t border-glass-border px-4 py-2">
+                  <RoomHumanComposer roomId={openedRoomId} />
+                </div>
+              ) : (isAuthedReady || isAuthedHuman) && isJoinedRoom && !humanSendAllowed ? (
+                <div className="border-t border-glass-border px-4 py-2">
+                  <p className="text-center text-xs text-text-secondary/50">{t.humanSendDisabled}</p>
+                </div>
+              ) : null}
+            </>
+          )}
+        </div>
+        {previewAttachment && (
+          <DocumentPreviewPane
+            attachment={previewAttachment}
+            onClose={() => setPreviewAttachment(null)}
+          />
         )}
       </div>
-      {openedRoomId && !isPaidAndNotJoined && (
-        <>
-          {originAgent ? (
-            <div className="border-t border-glass-border bg-glass-bg/30 px-4 py-2.5">
-              <p className="text-center text-xs text-text-secondary/70">
-                由 {originAgent.display_name} 代为发言 · 你是 owner，可观察不可发
-              </p>
-            </div>
-          ) : isGuest ? (
-            <div className="border-t border-glass-border px-4 py-2">
-              <div className="flex items-center justify-center gap-2">
-                <p className="text-center text-xs text-text-secondary/50">{t.readOnlyGuest}</p>
-                <button
-                  onClick={showLoginModal}
-                  className="rounded border border-neon-cyan/30 px-2 py-0.5 text-[10px] font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/10"
-                >
-                  {t.loginToParticipate}
-                </button>
-              </div>
-            </div>
-          ) : (isAuthedReady || isAuthedHuman) && isJoinedRoom && openedRoomId && humanSendAllowed ? (
-            <div className="border-t border-glass-border px-4 py-2">
-              <RoomHumanComposer roomId={openedRoomId} />
-            </div>
-          ) : (isAuthedReady || isAuthedHuman) && isJoinedRoom && !humanSendAllowed ? (
-            <div className="border-t border-glass-border px-4 py-2">
-              <p className="text-center text-xs text-text-secondary/50">{t.humanSendDisabled}</p>
-            </div>
-          ) : null}
-        </>
-      )}
       <TopicDrawer />
     </div>
   );

--- a/frontend/src/components/dashboard/DocumentPreviewPane.tsx
+++ b/frontend/src/components/dashboard/DocumentPreviewPane.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { ExternalLink, FileText, Loader2, X } from "lucide-react";
+import type { Attachment } from "@/lib/types";
+import {
+  DOCUMENT_PREVIEW_MAX_BYTES,
+  getAttachmentPreviewFetchUrl,
+  getAttachmentPreviewKind,
+} from "@/lib/attachment-preview";
+import MarkdownContent from "@/components/ui/MarkdownContent";
+import { resolveAttachmentUrl } from "@/components/ui/AttachmentItem";
+
+interface DocumentPreviewPaneProps {
+  attachment: Attachment;
+  onClose: () => void;
+}
+
+function formatPreviewSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function normalizeJsonPreview(raw: string): string {
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return raw;
+  }
+}
+
+export default function DocumentPreviewPane({ attachment, onClose }: DocumentPreviewPaneProps) {
+  const kind = getAttachmentPreviewKind(attachment);
+  const title = attachment.filename || "Attachment";
+  const sourceUrl = resolveAttachmentUrl(attachment.url);
+  const fetchUrl = useMemo(() => getAttachmentPreviewFetchUrl(attachment), [attachment]);
+  const [content, setContent] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const tooLarge = attachment.size_bytes != null && attachment.size_bytes > DOCUMENT_PREVIEW_MAX_BYTES;
+
+  useEffect(() => {
+    if (!kind || tooLarge) {
+      setContent("");
+      setError(null);
+      setLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    setContent("");
+    setError(null);
+    setLoading(true);
+
+    fetch(fetchUrl, {
+      cache: "no-store",
+      signal: controller.signal,
+    })
+      .then(async (res) => {
+        if (!res.ok) {
+          throw new Error(`Preview failed (${res.status})`);
+        }
+        const length = Number(res.headers.get("Content-Length") || "0");
+        if (length > DOCUMENT_PREVIEW_MAX_BYTES) {
+          throw new Error(`Preview is larger than ${formatPreviewSize(DOCUMENT_PREVIEW_MAX_BYTES)}`);
+        }
+        return res.text();
+      })
+      .then((text) => {
+        if (!controller.signal.aborted) {
+          setContent(text);
+          setLoading(false);
+        }
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return;
+        setError(err instanceof Error ? err.message : "Preview failed");
+        setLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [fetchUrl, kind, tooLarge]);
+
+  const renderedBody = (() => {
+    if (!kind) {
+      return (
+        <PreviewStateMessage
+          title="Preview unavailable"
+          detail="This attachment type cannot be shown inline."
+        />
+      );
+    }
+    if (tooLarge) {
+      return (
+        <PreviewStateMessage
+          title="Preview too large"
+          detail={`This file is larger than ${formatPreviewSize(DOCUMENT_PREVIEW_MAX_BYTES)}.`}
+        />
+      );
+    }
+    if (loading) {
+      return (
+        <div className="flex h-full items-center justify-center text-text-secondary">
+          <Loader2 className="h-5 w-5 animate-spin" />
+        </div>
+      );
+    }
+    if (error) {
+      return <PreviewStateMessage title="Preview failed" detail={error} />;
+    }
+    if (kind === "markdown") {
+      return (
+        <div className="min-h-full px-4 py-3">
+          <MarkdownContent content={content} />
+        </div>
+      );
+    }
+    if (kind === "html") {
+      return (
+        <iframe
+          title={title}
+          sandbox="allow-popups"
+          srcDoc={content}
+          className="h-full w-full border-0 bg-white"
+        />
+      );
+    }
+
+    const displayContent = kind === "json" ? normalizeJsonPreview(content) : content;
+    return (
+      <pre className="min-h-full whitespace-pre-wrap break-words px-4 py-3 font-mono text-xs leading-5 text-text-primary">
+        {displayContent}
+      </pre>
+    );
+  })();
+
+  return (
+    <aside className="flex h-full w-[min(42vw,560px)] min-w-[360px] shrink-0 flex-col border-l border-glass-border bg-deep-black shadow-2xl shadow-black/40 max-md:absolute max-md:inset-0 max-md:z-40 max-md:w-full max-md:min-w-0">
+      <div className="flex min-h-14 items-center gap-2 border-b border-glass-border px-3">
+        <FileText className="h-4 w-4 shrink-0 text-neon-cyan" />
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-medium text-text-primary">{title}</div>
+          <div className="truncate text-[11px] text-text-secondary/70">
+            {attachment.size_bytes != null ? formatPreviewSize(attachment.size_bytes) : "Document preview"}
+          </div>
+        </div>
+        <a
+          href={sourceUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-white/10 hover:text-text-primary"
+          aria-label="Open original"
+          title="Open original"
+        >
+          <ExternalLink className="h-4 w-4" />
+        </a>
+        <button
+          type="button"
+          onClick={onClose}
+          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-white/10 hover:text-text-primary"
+          aria-label="Close preview"
+          title="Close preview"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto bg-zinc-950/30">
+        {renderedBody}
+      </div>
+    </aside>
+  );
+}
+
+function PreviewStateMessage({ title, detail }: { title: string; detail: string }) {
+  return (
+    <div className="flex h-full items-center justify-center px-6 text-center">
+      <div className="max-w-xs">
+        <div className="text-sm font-medium text-text-primary">{title}</div>
+        <div className="mt-1 text-xs leading-5 text-text-secondary">{detail}</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/MessageBubble.tsx
+++ b/frontend/src/components/dashboard/MessageBubble.tsx
@@ -38,6 +38,7 @@ interface MessageBubbleProps {
   sourceId?: string;
   /** Known participants used to resolve plain-text @display-name mentions. */
   mentionCandidates?: MentionTextCandidate[];
+  onPreviewAttachment?: (attachment: Attachment) => void;
 }
 
 const stateColors: Record<string, { color: string; icon: string }> = {
@@ -355,7 +356,15 @@ function SenderAvatar({
   );
 }
 
-export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = false, sourceName, sourceId, mentionCandidates }: MessageBubbleProps) {
+export default function MessageBubble({
+  message,
+  isOwn: isOwnProp,
+  fullWidth = false,
+  sourceName,
+  sourceId,
+  mentionCandidates,
+  onPreviewAttachment,
+}: MessageBubbleProps) {
   const [hovered, setHovered] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const [menuPosition, setMenuPosition] = useState<{ left: number; top: number } | null>(null);
@@ -812,7 +821,11 @@ export default function MessageBubble({ message, isOwn: isOwnProp, fullWidth = f
         {!isRecalled && attachments.length > 0 && (
           <div className="mt-1.5 flex flex-col gap-1.5">
             {attachments.map((att, i) => (
-              <AttachmentItem key={`${att.filename}-${i}`} attachment={att} />
+              <AttachmentItem
+                key={`${att.filename}-${att.url}-${i}`}
+                attachment={att}
+                onPreview={onPreviewAttachment}
+              />
             ))}
           </div>
         )}

--- a/frontend/src/components/dashboard/MessageList.tsx
+++ b/frontend/src/components/dashboard/MessageList.tsx
@@ -14,7 +14,7 @@ import { useShallow } from "zustand/react/shallow";
 import { Bot, Settings, UserPlus } from "lucide-react";
 import MessageBubble from "./MessageBubble";
 import { JUMP_TO_MESSAGE_EVENT, type JumpToMessageDetail } from "./messageNavigation";
-import type { DashboardMessage, PublicRoomMember, TopicInfo } from "@/lib/types";
+import type { Attachment, DashboardMessage, PublicRoomMember, TopicInfo } from "@/lib/types";
 import type { MentionTextCandidate } from "@/components/ui/MarkdownContent";
 import { getLatestSeenAtForRoom } from "@/store/dashboard-shared";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
@@ -103,6 +103,7 @@ export function TopicCard({
   sourceName,
   sourceId,
   mentionCandidates,
+  onPreviewAttachment,
   onOpen,
 }: {
   group: TopicGroup;
@@ -110,6 +111,7 @@ export function TopicCard({
   sourceName?: string;
   sourceId?: string;
   mentionCandidates?: MentionTextCandidate[];
+  onPreviewAttachment?: (attachment: Attachment) => void;
   onOpen: () => void;
 }) {
   const topicStatusConfig = useTopicStatusConfig();
@@ -151,6 +153,7 @@ export function TopicCard({
               sourceName={sourceName}
               sourceId={sourceId}
               mentionCandidates={mentionCandidates}
+              onPreviewAttachment={onPreviewAttachment}
             />
           </div>
         ))}
@@ -273,7 +276,11 @@ function EmptyRoomGuide({
   );
 }
 
-export default function MessageList() {
+export default function MessageList({
+  onPreviewAttachment,
+}: {
+  onPreviewAttachment?: (attachment: Attachment) => void;
+} = {}) {
   const locale = useLanguage();
   const t = messageList[locale];
   const { openedRoomId, setOpenedTopicId } = useDashboardUIStore(useShallow((state) => ({
@@ -568,6 +575,7 @@ export default function MessageList() {
                   sourceName={currentRoomName}
                   sourceId={roomId}
                   mentionCandidates={mentionCandidates}
+                  onPreviewAttachment={onPreviewAttachment}
                 />
               </div>
             );
@@ -583,6 +591,7 @@ export default function MessageList() {
               sourceName={currentRoomName}
               sourceId={roomId}
               mentionCandidates={mentionCandidates}
+              onPreviewAttachment={onPreviewAttachment}
               onOpen={() => group.topicId && setOpenedTopicId(group.topicId)}
             />
           );

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import { ArrowLeft, Bot, Check, Copy, CornerUpLeft, Forward, Loader2, MessageSquare, MoreHorizontal, AlertCircle, AlertTriangle, RotateCcw, Bell, FileText, PanelLeftOpen, Settings2, User, X } from "lucide-react";
+import { ArrowLeft, Bot, Check, Copy, CornerUpLeft, Forward, Loader2, MessageSquare, MoreHorizontal, AlertCircle, AlertTriangle, RotateCcw, Bell, PanelLeftOpen, Settings2, User, X } from "lucide-react";
 import { useRouter } from "nextjs-toploader/app";
 import { api } from "@/lib/api";
 import { useLanguage } from "@/lib/i18n";
@@ -23,7 +23,9 @@ import { useOwnerChatStore } from "@/store/useOwnerChatStore";
 import { useOwnerChatWs } from "@/hooks/useOwnerChatWs";
 import DashboardMessagePaneSkeleton from "./DashboardMessagePaneSkeleton";
 import MarkdownContent, { normalizeMessageContent } from "@/components/ui/MarkdownContent";
+import AttachmentItem from "@/components/ui/AttachmentItem";
 import StreamBlocksView from "./StreamBlocksView";
+import DocumentPreviewPane from "./DocumentPreviewPane";
 import RuntimeErrorDetailsDialog from "./RuntimeErrorDetailsDialog";
 import CopyableId from "@/components/ui/CopyableId";
 import MessageComposer from "./MessageComposer";
@@ -36,10 +38,6 @@ import {
   canShowOwnerChatMessageActions,
   ownerChatReplyTargetId,
 } from "@/lib/owner-chat-actions";
-
-const HUB_BASE_URL =
-  process.env.NEXT_PUBLIC_HUB_BASE_URL ||
-  (process.env.NODE_ENV === "development" ? "http://localhost:8000" : "https://api.botcord.chat");
 
 // ---------------------------------------------------------------------------
 // TypewriterText
@@ -109,6 +107,7 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
   const [actionMenuOpenId, setActionMenuOpenId] = useState<string | null>(null);
   const [copiedMessageId, setCopiedMessageId] = useState<string | null>(null);
   const [forwardQuote, setForwardQuote] = useState<string | null>(null);
+  const [previewAttachment, setPreviewAttachment] = useState<Attachment | null>(null);
   const settingsLabel = locale === "zh" ? "Bot 设置" : "Bot settings";
   const replyLabel = locale === "zh" ? "回复" : "Reply";
   const forwardLabel = locale === "zh" ? "转发" : "Forward";
@@ -153,6 +152,7 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
     initialLoadRef.current = true;
     prevLengthRef.current = 0;
     animatedRef.current.clear();
+    setPreviewAttachment(null);
     useOwnerChatStore.getState().reset();
 
     (async () => {
@@ -436,7 +436,8 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
   };
 
   return (
-    <div className="relative flex flex-col h-full">
+    <div className="relative flex h-full min-w-0">
+      <div className="flex min-w-0 flex-1 flex-col">
       {/* Header */}
       <div className="flex items-center gap-2 px-4 py-3 border-b border-zinc-800 max-md:px-3">
         <button
@@ -735,34 +736,13 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
                     {/* Attachments */}
                     {msg.attachments && msg.attachments.length > 0 && (
                       <div className="mt-2 space-y-1.5">
-                        {msg.attachments.map((att, idx) => {
-                          const fullUrl = att.url.startsWith("/") ? `${HUB_BASE_URL}${att.url}` : att.url;
-                          const isImage = att.content_type?.startsWith("image/");
-                          if (isImage) {
-                            return (
-                              <a key={idx} href={fullUrl} target="_blank" rel="noopener noreferrer" className="block">
-                                <img
-                                  src={fullUrl}
-                                  alt={att.filename || "Image"}
-                                  className="max-h-48 max-w-full rounded border border-zinc-600 object-cover hover:opacity-80 transition-opacity"
-                                />
-                                <span className="mt-0.5 block text-[10px] text-zinc-500">{att.filename}</span>
-                              </a>
-                            );
-                          }
-                          return (
-                            <a
-                              key={idx}
-                              href={fullUrl}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="flex items-center gap-1.5 text-xs text-cyan-400 hover:text-cyan-300 transition-colors"
-                            >
-                              <FileText className="w-3.5 h-3.5 shrink-0" />
-                              <span className="truncate">{att.filename || "Attachment"}</span>
-                            </a>
-                          );
-                        })}
+                        {msg.attachments.map((att, idx) => (
+                          <AttachmentItem
+                            key={`${att.filename}-${att.url}-${idx}`}
+                            attachment={att}
+                            onPreview={setPreviewAttachment}
+                          />
+                        ))}
                       </div>
                     )}
                     <div className="text-xs text-zinc-500 mt-1 text-right">
@@ -809,6 +789,13 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
           />
         </div>
       </div>
+      </div>
+      {previewAttachment && (
+        <DocumentPreviewPane
+          attachment={previewAttachment}
+          onClose={() => setPreviewAttachment(null)}
+        />
+      )}
       {forwardQuote && (
         <ForwardModal quoteText={forwardQuote} onClose={() => setForwardQuote(null)} />
       )}

--- a/frontend/src/components/ui/AttachmentItem.test.ts
+++ b/frontend/src/components/ui/AttachmentItem.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { isImageAttachment, resolveAttachmentUrl } from "./AttachmentItem";
+import {
+  hasFailedAttachmentImageUrl,
+  isImageAttachment,
+  rememberFailedAttachmentImageUrl,
+  resolveAttachmentUrl,
+} from "./AttachmentItem";
 
 describe("AttachmentItem helpers", () => {
   it("resolves hub-relative attachment URLs", () => {
@@ -22,5 +27,15 @@ describe("AttachmentItem helpers", () => {
       filename: "report.pdf",
       url: "/hub/files/f_789",
     })).toBe(false);
+  });
+
+  it("remembers failed image attachment URLs for the current session", () => {
+    const attachmentUrl = "https://api.botcord.chat/hub/files/f_failed_session_test";
+
+    expect(hasFailedAttachmentImageUrl(attachmentUrl)).toBe(false);
+
+    rememberFailedAttachmentImageUrl(` ${attachmentUrl} `);
+
+    expect(hasFailedAttachmentImageUrl(attachmentUrl)).toBe(true);
   });
 });

--- a/frontend/src/components/ui/AttachmentItem.tsx
+++ b/frontend/src/components/ui/AttachmentItem.tsx
@@ -2,12 +2,15 @@
 
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
-import { ExternalLink, X } from "lucide-react";
+import { ExternalLink, FileText, X } from "lucide-react";
 import type { Attachment } from "@/lib/types";
+import { isPreviewableAttachment } from "@/lib/attachment-preview";
 
 const HUB_BASE_URL =
   process.env.NEXT_PUBLIC_HUB_BASE_URL ||
   (process.env.NODE_ENV === "development" ? "http://localhost:8000" : "https://api.botcord.chat");
+
+const failedAttachmentImageUrls = new Set<string>();
 
 function formatFileSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -32,14 +35,32 @@ export function isImageAttachment(attachment: Attachment): boolean {
   return /\.(avif|bmp|gif|jpe?g|png|svg|webp)$/i.test(name);
 }
 
+function attachmentImageFailureKey(url: string): string {
+  return url.trim();
+}
+
+export function rememberFailedAttachmentImageUrl(url: string): void {
+  const key = attachmentImageFailureKey(url);
+  if (key) {
+    failedAttachmentImageUrls.add(key);
+  }
+}
+
+export function hasFailedAttachmentImageUrl(url: string): boolean {
+  const key = attachmentImageFailureKey(url);
+  return key ? failedAttachmentImageUrls.has(key) : false;
+}
+
 function ImagePreviewOverlay({
   src,
   title,
   onClose,
+  onImageError,
 }: {
   src: string;
   title: string;
   onClose: () => void;
+  onImageError: () => void;
 }) {
   useEffect(() => {
     const previousOverflow = document.body.style.overflow;
@@ -100,6 +121,7 @@ function ImagePreviewOverlay({
           src={src}
           alt={title}
           className="max-h-[calc(100vh-6.5rem)] max-w-full object-contain shadow-2xl"
+          onError={onImageError}
         />
       </div>
     </div>,
@@ -107,11 +129,75 @@ function ImagePreviewOverlay({
   );
 }
 
-export default function AttachmentItem({ attachment }: { attachment: Attachment }) {
+interface AttachmentItemProps {
+  attachment: Attachment;
+  onPreview?: (attachment: Attachment) => void;
+}
+
+function AttachmentFileLink({
+  attachment,
+  attachmentUrl,
+  onPreview,
+}: {
+  attachment: Attachment;
+  attachmentUrl: string;
+  onPreview?: (attachment: Attachment) => void;
+}) {
+  const canPreview = Boolean(onPreview && isPreviewableAttachment(attachment));
+  const content = (
+    <>
+      <FileText className="h-4 w-4 shrink-0 text-text-secondary" />
+      <span className="truncate">{attachment.filename || "Attachment"}</span>
+      {attachment.size_bytes != null && (
+        <span className="shrink-0 text-text-secondary/50">{formatFileSize(attachment.size_bytes)}</span>
+      )}
+    </>
+  );
+
+  if (canPreview) {
+    return (
+      <button
+        type="button"
+        onClick={(event) => {
+          event.stopPropagation();
+          onPreview?.(attachment);
+        }}
+        className="flex max-w-full items-center gap-2 rounded-lg border border-glass-border bg-glass-bg/50 px-2.5 py-1.5 text-left text-xs text-text-primary hover:border-neon-cyan/30 transition-colors"
+      >
+        {content}
+      </button>
+    );
+  }
+
+  return (
+    <a
+      href={attachmentUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex items-center gap-2 rounded-lg border border-glass-border bg-glass-bg/50 px-2.5 py-1.5 text-xs text-text-primary hover:border-neon-cyan/30 transition-colors"
+    >
+      {content}
+    </a>
+  );
+}
+
+export default function AttachmentItem({ attachment, onPreview }: AttachmentItemProps) {
   const attachmentUrl = resolveAttachmentUrl(attachment.url);
   const [previewOpen, setPreviewOpen] = useState(false);
+  const [imageFailed, setImageFailed] = useState(() => hasFailedAttachmentImageUrl(attachmentUrl));
 
-  if (isImageAttachment(attachment)) {
+  useEffect(() => {
+    setPreviewOpen(false);
+    setImageFailed(hasFailedAttachmentImageUrl(attachmentUrl));
+  }, [attachmentUrl]);
+
+  const handleImageError = () => {
+    rememberFailedAttachmentImageUrl(attachmentUrl);
+    setPreviewOpen(false);
+    setImageFailed(true);
+  };
+
+  if (isImageAttachment(attachment) && !imageFailed) {
     const title = attachment.filename || "Image attachment";
 
     return (
@@ -132,6 +218,7 @@ export default function AttachmentItem({ attachment }: { attachment: Attachment 
               className="max-h-48 max-w-full cursor-zoom-in rounded-lg border border-glass-border object-contain transition-opacity group-hover:opacity-80"
               loading="lazy"
               decoding="async"
+              onError={handleImageError}
             />
           </button>
           {attachment.filename && (
@@ -143,36 +230,12 @@ export default function AttachmentItem({ attachment }: { attachment: Attachment 
             src={attachmentUrl}
             title={title}
             onClose={() => setPreviewOpen(false)}
+            onImageError={handleImageError}
           />
         )}
       </>
     );
   }
 
-  return (
-    <a
-      href={attachmentUrl}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="flex items-center gap-2 rounded-lg border border-glass-border bg-glass-bg/50 px-2.5 py-1.5 text-xs text-text-primary hover:border-neon-cyan/30 transition-colors"
-    >
-      <svg
-        className="h-4 w-4 shrink-0 text-text-secondary"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={1.5}
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
-        />
-      </svg>
-      <span className="truncate">{attachment.filename || "Attachment"}</span>
-      {attachment.size_bytes != null && (
-        <span className="shrink-0 text-text-secondary/50">{formatFileSize(attachment.size_bytes)}</span>
-      )}
-    </a>
-  );
+  return <AttachmentFileLink attachment={attachment} attachmentUrl={attachmentUrl} onPreview={onPreview} />;
 }

--- a/frontend/src/components/ui/MarkdownContent.test.ts
+++ b/frontend/src/components/ui/MarkdownContent.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  hasFailedMarkdownImageSrc,
   isPreviewableMarkdownImageSrc,
   normalizeMessageContent,
+  rememberFailedMarkdownImageSrc,
   splitPlainMentionText,
 } from "./MarkdownContent";
 
@@ -57,5 +59,16 @@ describe("isPreviewableMarkdownImageSrc", () => {
     expect(isPreviewableMarkdownImageSrc("output/xhs-01-cover.png")).toBe(false);
     expect(isPreviewableMarkdownImageSrc("social-card-botcord-agent-hub/index.html")).toBe(false);
     expect(isPreviewableMarkdownImageSrc("/hub/files/f_123")).toBe(false);
+  });
+});
+
+describe("failed markdown image tracking", () => {
+  it("remembers failed image URLs for the current session", () => {
+    const imageUrl = "https://example.com/card-session-failure.png";
+    expect(hasFailedMarkdownImageSrc(imageUrl)).toBe(false);
+
+    rememberFailedMarkdownImageSrc(` ${imageUrl} `);
+
+    expect(hasFailedMarkdownImageSrc(imageUrl)).toBe(true);
   });
 });

--- a/frontend/src/components/ui/MarkdownContent.tsx
+++ b/frontend/src/components/ui/MarkdownContent.tsx
@@ -39,6 +39,7 @@ interface HastRootNode {
 type HastNode = HastTextNode | HastElementNode | HastRootNode | { type?: string; [key: string]: unknown };
 
 const MENTION_WITH_ID_RE = /@([^\n@]*?)\(((?:ag|hu)_[^)]+)\)/g;
+const failedMarkdownImageSrcs = new Set<string>();
 
 export function normalizeMessageContent(content: string): string {
   return content
@@ -57,6 +58,22 @@ export function isPreviewableMarkdownImageSrc(src: unknown): src is string {
   } catch {
     return false;
   }
+}
+
+function imageFailureKey(src: string): string {
+  return src.trim();
+}
+
+export function rememberFailedMarkdownImageSrc(src: string): void {
+  const key = imageFailureKey(src);
+  if (key) {
+    failedMarkdownImageSrcs.add(key);
+  }
+}
+
+export function hasFailedMarkdownImageSrc(src: string): boolean {
+  const key = imageFailureKey(src);
+  return key ? failedMarkdownImageSrcs.has(key) : false;
 }
 
 function isMentionStartBoundary(value: string, index: number): boolean {
@@ -246,6 +263,41 @@ function MarkdownCodeBlock({ children }: { children: ReactNode }) {
   );
 }
 
+function MarkdownImageFallback({ src, alt }: { src: string; alt?: string }) {
+  return (
+    <code className="rounded border border-glass-border bg-black/30 px-1.5 py-0.5 font-mono text-xs text-neon-cyan/90">
+      {alt ? `${alt} (${src})` : src}
+    </code>
+  );
+}
+
+function MarkdownImage({ src, alt }: { src?: string; alt?: string }) {
+  const rawSrc = typeof src === "string" ? src : "";
+  const [failed, setFailed] = useState(() => (rawSrc ? hasFailedMarkdownImageSrc(rawSrc) : false));
+
+  useEffect(() => {
+    setFailed(rawSrc ? hasFailedMarkdownImageSrc(rawSrc) : false);
+  }, [rawSrc]);
+
+  if (!isPreviewableMarkdownImageSrc(rawSrc) || failed) {
+    return <MarkdownImageFallback src={rawSrc} alt={alt} />;
+  }
+
+  return (
+    <img
+      src={rawSrc}
+      alt={alt ?? ""}
+      className="my-2 max-h-72 max-w-full rounded-lg border border-glass-border object-contain"
+      loading="lazy"
+      decoding="async"
+      onError={() => {
+        rememberFailedMarkdownImageSrc(rawSrc);
+        setFailed(true);
+      }}
+    />
+  );
+}
+
 function createComponents(renderMention?: MarkdownContentProps["renderMention"]): Components {
   return {
     p: ({ children }) => (
@@ -278,25 +330,9 @@ function createComponents(renderMention?: MarkdownContentProps["renderMention"])
         {children}
       </a>
     ),
-    img: ({ src, alt }) => {
-      const rawSrc = typeof src === "string" ? src : "";
-      if (!isPreviewableMarkdownImageSrc(rawSrc)) {
-        return (
-          <code className="rounded border border-glass-border bg-black/30 px-1.5 py-0.5 font-mono text-xs text-neon-cyan/90">
-            {alt ? `${alt} (${rawSrc})` : rawSrc}
-          </code>
-        );
-      }
-      return (
-        <img
-          src={rawSrc}
-          alt={alt ?? ""}
-          className="my-2 max-h-72 max-w-full rounded-lg border border-glass-border object-contain"
-          loading="lazy"
-          decoding="async"
-        />
-      );
-    },
+    img: ({ src, alt }) => (
+      <MarkdownImage src={typeof src === "string" ? src : undefined} alt={alt ?? undefined} />
+    ),
     ul: ({ children }) => (
       <ul className="mb-2 ml-4 list-disc last:mb-0 [&>li]:mb-0.5">{children}</ul>
     ),

--- a/frontend/src/lib/attachment-preview.test.ts
+++ b/frontend/src/lib/attachment-preview.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  DOCUMENT_PREVIEW_MAX_BYTES,
+  getAttachmentPreviewFetchUrl,
+  getAttachmentPreviewKind,
+  getBotCordFileIdFromUrl,
+  isPreviewableAttachment,
+} from "./attachment-preview";
+
+describe("attachment preview helpers", () => {
+  it("detects markdown, html, json, and text attachments", () => {
+    expect(getAttachmentPreviewKind({ filename: "notes.md", url: "/hub/files/f_md" })).toBe("markdown");
+    expect(getAttachmentPreviewKind({ filename: "page.html", url: "/hub/files/f_html" })).toBe("html");
+    expect(getAttachmentPreviewKind({ filename: "data.bin", url: "/hub/files/f_json", content_type: "application/json" })).toBe("json");
+    expect(getAttachmentPreviewKind({ filename: "agent.log", url: "/hub/files/f_log" })).toBe("text");
+  });
+
+  it("does not preview binary or oversized files", () => {
+    expect(isPreviewableAttachment({ filename: "archive.zip", url: "/hub/files/f_zip" })).toBe(false);
+    expect(isPreviewableAttachment({
+      filename: "large.md",
+      url: "/hub/files/f_large",
+      size_bytes: DOCUMENT_PREVIEW_MAX_BYTES + 1,
+    })).toBe(false);
+  });
+
+  it("extracts BotCord file IDs and maps them to the preview proxy", () => {
+    expect(getBotCordFileIdFromUrl("/hub/files/f_abc123")).toBe("f_abc123");
+    expect(getBotCordFileIdFromUrl("https://api.botcord.chat/hub/files/f_xyz")).toBe("f_xyz");
+    expect(getBotCordFileIdFromUrl("https://example.com/not-files/f_xyz")).toBeNull();
+
+    expect(getAttachmentPreviewFetchUrl({
+      filename: "notes.md",
+      url: "https://api.botcord.chat/hub/files/f_abc123",
+    })).toBe("/api/files/f_abc123");
+  });
+});

--- a/frontend/src/lib/attachment-preview.ts
+++ b/frontend/src/lib/attachment-preview.ts
@@ -1,0 +1,69 @@
+import type { Attachment } from "@/lib/types";
+
+export type AttachmentPreviewKind = "markdown" | "html" | "json" | "text";
+
+export const DOCUMENT_PREVIEW_MAX_BYTES = 1024 * 1024;
+
+const BOTCORD_FILE_PATH_RE = /^\/hub\/files\/(f_[a-zA-Z0-9_-]+)$/;
+
+const TEXT_EXTENSION_RE = /\.(csv|env|ini|log|sql|toml|tsv|txt|xml|ya?ml)$/i;
+const CODE_EXTENSION_RE = /\.(css|go|java|js|jsx|jsonl|kt|mjs|php|py|rb|rs|sh|tsx?|vue)$/i;
+
+function lowerContentType(attachment: Attachment): string {
+  return (attachment.content_type || "").split(";")[0]?.trim().toLowerCase() || "";
+}
+
+function lowerFilename(attachment: Attachment): string {
+  return (attachment.filename || attachment.url.split("?")[0] || "").toLowerCase();
+}
+
+export function getAttachmentPreviewKind(attachment: Attachment): AttachmentPreviewKind | null {
+  const contentType = lowerContentType(attachment);
+  const name = lowerFilename(attachment);
+
+  if (contentType === "text/markdown" || contentType === "text/x-markdown" || /\.mdx?$/i.test(name)) {
+    return "markdown";
+  }
+  if (contentType === "text/html" || /\.html?$/i.test(name)) {
+    return "html";
+  }
+  if (contentType === "application/json" || contentType.endsWith("+json") || /\.json$/i.test(name)) {
+    return "json";
+  }
+  if (
+    contentType.startsWith("text/") ||
+    contentType === "application/xml" ||
+    contentType.endsWith("+xml") ||
+    TEXT_EXTENSION_RE.test(name) ||
+    CODE_EXTENSION_RE.test(name)
+  ) {
+    return "text";
+  }
+
+  return null;
+}
+
+export function isPreviewableAttachment(attachment: Attachment): boolean {
+  if (!getAttachmentPreviewKind(attachment)) return false;
+  return attachment.size_bytes == null || attachment.size_bytes <= DOCUMENT_PREVIEW_MAX_BYTES;
+}
+
+export function getBotCordFileIdFromUrl(url: string): string | null {
+  const raw = url.trim();
+  if (!raw) return null;
+
+  try {
+    const parsed = new URL(raw, "https://botcord.local");
+    return parsed.pathname.match(BOTCORD_FILE_PATH_RE)?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function getAttachmentPreviewFetchUrl(attachment: Attachment): string {
+  const fileId = getBotCordFileIdFromUrl(attachment.url);
+  if (fileId) {
+    return `/api/files/${encodeURIComponent(fileId)}`;
+  }
+  return attachment.url;
+}

--- a/packages/daemon/src/__tests__/system-context.test.ts
+++ b/packages/daemon/src/__tests__/system-context.test.ts
@@ -306,7 +306,9 @@ describe("createDaemonSystemContextBuilder", () => {
     expect(out).toContain("[BotCord Scene: Owner Chat]");
     expect(out).toContain("full administrative authority");
     expect(out).toContain("cannot open this machine's local filesystem paths");
-    expect(out).toContain("upload or attach it through the BotCord file/attachment mechanism");
+    expect(out).toContain("share it as a BotCord attachment or an uploaded BotCord URL");
+    expect(out).toContain("Do not use local or relative paths such as `output/card.png`");
+    expect(out).toContain("upload/attach the file first");
   });
 
   it("injects the owner-chat scene for dashboard_user_chat regardless of room prefix", () => {

--- a/packages/daemon/src/system-context.ts
+++ b/packages/daemon/src/system-context.ts
@@ -56,7 +56,8 @@ function buildOwnerChatSceneContext(): string {
     "Messages from the owner are always trusted and do not require sanitization or safety guards.",
     "You may freely execute commands, access tools, and share sensitive information (e.g. wallet balance, contacts) when the owner asks.",
     "The owner is reading your reply in the remote BotCord dashboard; they cannot open this machine's local filesystem paths.",
-    "When you create an artifact or deliverable file for the owner, upload or attach it through the BotCord file/attachment mechanism (for example, `botcord send --file PATH`) and refer to the attachment instead of treating a local path as the deliverable.",
+    "When you create an image, report, or other deliverable file for the owner, share it as a BotCord attachment or an uploaded BotCord URL. Do not use local or relative paths such as `output/card.png`, `/tmp/card.png`, or Markdown image links to those paths as if the owner can open them.",
+    "If a reply needs to include an image or attachment, upload/attach the file first through the available BotCord file/attachment mechanism, then refer to the uploaded attachment/URL. If upload is unavailable, clearly label any path as a local workspace path rather than a usable deliverable link.",
   ].join("\n");
 }
 


### PR DESCRIPTION
## Summary
- Add a right-side document preview pane for Markdown, HTML, JSON, and text-like attachments in room chat and owner-chat.
- Stop repeatedly retrying failed image previews; failed image URLs fall back to a file link/text fallback for the current session.
- Clarify owner-chat daemon prompt guidance so generated images/files are attached or uploaded before referencing URLs.

## Verification
- cd frontend && npm test -- --run src/lib/attachment-preview.test.ts src/components/ui/AttachmentItem.test.ts src/components/ui/MarkdownContent.test.ts src/components/dashboard/MessageList.test.ts
- cd frontend && NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build
- cd packages/daemon && npm test -- src/__tests__/system-context.test.ts
- git diff --check

## Risk / rollout
- HTML previews are rendered in a sandboxed iframe without script permission.
- Document preview is capped at 1 MiB and falls back to opening the original attachment for unsupported or failed previews.