### PR TITLE
fix: preview image attachments

### DIFF
--- a/frontend/src/components/dashboard/DocumentPreviewPane.tsx
+++ b/frontend/src/components/dashboard/DocumentPreviewPane.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { ExternalLink, FileText, Loader2, X } from "lucide-react";
+import { Download, FileText, Loader2, X } from "lucide-react";
 import type { Attachment } from "@/lib/types";
 import {
   DOCUMENT_PREVIEW_MAX_BYTES,
@@ -38,10 +38,10 @@ export default function DocumentPreviewPane({ attachment, onClose }: DocumentPre
   const [content, setContent] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const tooLarge = attachment.size_bytes != null && attachment.size_bytes > DOCUMENT_PREVIEW_MAX_BYTES;
+  const tooLarge = kind !== "image" && attachment.size_bytes != null && attachment.size_bytes > DOCUMENT_PREVIEW_MAX_BYTES;
 
   useEffect(() => {
-    if (!kind || tooLarge) {
+    if (!kind || tooLarge || kind === "image") {
       setContent("");
       setError(null);
       setLoading(false);
@@ -109,6 +109,19 @@ export default function DocumentPreviewPane({ attachment, onClose }: DocumentPre
     if (error) {
       return <PreviewStateMessage title="Preview failed" detail={error} />;
     }
+    if (kind === "image") {
+      return (
+        <div className="flex min-h-full items-center justify-center p-3 sm:p-6">
+          <img
+            src={sourceUrl}
+            alt={title}
+            className="max-h-full max-w-full object-contain shadow-2xl"
+            loading="lazy"
+            decoding="async"
+          />
+        </div>
+      );
+    }
     if (kind === "markdown") {
       return (
         <div className="min-h-full px-4 py-3">
@@ -149,11 +162,12 @@ export default function DocumentPreviewPane({ attachment, onClose }: DocumentPre
           href={sourceUrl}
           target="_blank"
           rel="noopener noreferrer"
+          download={title}
           className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-white/10 hover:text-text-primary"
-          aria-label="Open original"
-          title="Open original"
+          aria-label="Download attachment"
+          title="Download"
         >
-          <ExternalLink className="h-4 w-4" />
+          <Download className="h-4 w-4" />
         </a>
         <button
           type="button"

--- a/frontend/src/components/ui/AttachmentItem.tsx
+++ b/frontend/src/components/ui/AttachmentItem.tsx
@@ -185,6 +185,7 @@ export default function AttachmentItem({ attachment, onPreview }: AttachmentItem
   const attachmentUrl = resolveAttachmentUrl(attachment.url);
   const [previewOpen, setPreviewOpen] = useState(false);
   const [imageFailed, setImageFailed] = useState(() => hasFailedAttachmentImageUrl(attachmentUrl));
+  const imageAttachment = isImageAttachment(attachment);
 
   useEffect(() => {
     setPreviewOpen(false);
@@ -197,7 +198,7 @@ export default function AttachmentItem({ attachment, onPreview }: AttachmentItem
     setImageFailed(true);
   };
 
-  if (isImageAttachment(attachment) && !imageFailed) {
+  if (imageAttachment && !imageFailed) {
     const title = attachment.filename || "Image attachment";
 
     return (
@@ -207,7 +208,11 @@ export default function AttachmentItem({ attachment, onPreview }: AttachmentItem
             type="button"
             onClick={(event) => {
               event.stopPropagation();
-              setPreviewOpen(true);
+              if (onPreview) {
+                onPreview(attachment);
+              } else {
+                setPreviewOpen(true);
+              }
             }}
             className="group block max-w-full text-left"
             aria-label={`Preview ${title}`}
@@ -225,7 +230,7 @@ export default function AttachmentItem({ attachment, onPreview }: AttachmentItem
             <span className="mt-0.5 block text-[10px] text-text-secondary/60">{attachment.filename}</span>
           )}
         </div>
-        {previewOpen && (
+        {!onPreview && previewOpen && (
           <ImagePreviewOverlay
             src={attachmentUrl}
             title={title}
@@ -237,5 +242,11 @@ export default function AttachmentItem({ attachment, onPreview }: AttachmentItem
     );
   }
 
-  return <AttachmentFileLink attachment={attachment} attachmentUrl={attachmentUrl} onPreview={onPreview} />;
+  return (
+    <AttachmentFileLink
+      attachment={attachment}
+      attachmentUrl={attachmentUrl}
+      onPreview={imageAttachment ? undefined : onPreview}
+    />
+  );
 }

--- a/frontend/src/lib/attachment-preview.test.ts
+++ b/frontend/src/lib/attachment-preview.test.ts
@@ -8,7 +8,8 @@ import {
 } from "./attachment-preview";
 
 describe("attachment preview helpers", () => {
-  it("detects markdown, html, json, and text attachments", () => {
+  it("detects image, markdown, html, json, and text attachments", () => {
+    expect(getAttachmentPreviewKind({ filename: "cover.png", url: "/hub/files/f_png" })).toBe("image");
     expect(getAttachmentPreviewKind({ filename: "notes.md", url: "/hub/files/f_md" })).toBe("markdown");
     expect(getAttachmentPreviewKind({ filename: "page.html", url: "/hub/files/f_html" })).toBe("html");
     expect(getAttachmentPreviewKind({ filename: "data.bin", url: "/hub/files/f_json", content_type: "application/json" })).toBe("json");

--- a/frontend/src/lib/attachment-preview.ts
+++ b/frontend/src/lib/attachment-preview.ts
@@ -1,6 +1,6 @@
 import type { Attachment } from "@/lib/types";
 
-export type AttachmentPreviewKind = "markdown" | "html" | "json" | "text";
+export type AttachmentPreviewKind = "image" | "markdown" | "html" | "json" | "text";
 
 export const DOCUMENT_PREVIEW_MAX_BYTES = 1024 * 1024;
 
@@ -8,6 +8,7 @@ const BOTCORD_FILE_PATH_RE = /^\/hub\/files\/(f_[a-zA-Z0-9_-]+)$/;
 
 const TEXT_EXTENSION_RE = /\.(csv|env|ini|log|sql|toml|tsv|txt|xml|ya?ml)$/i;
 const CODE_EXTENSION_RE = /\.(css|go|java|js|jsx|jsonl|kt|mjs|php|py|rb|rs|sh|tsx?|vue)$/i;
+const IMAGE_EXTENSION_RE = /\.(avif|bmp|gif|jpe?g|png|svg|webp)$/i;
 
 function lowerContentType(attachment: Attachment): string {
   return (attachment.content_type || "").split(";")[0]?.trim().toLowerCase() || "";
@@ -21,6 +22,9 @@ export function getAttachmentPreviewKind(attachment: Attachment): AttachmentPrev
   const contentType = lowerContentType(attachment);
   const name = lowerFilename(attachment);
 
+  if (contentType.startsWith("image/") || IMAGE_EXTENSION_RE.test(name)) {
+    return "image";
+  }
   if (contentType === "text/markdown" || contentType === "text/x-markdown" || /\.mdx?$/i.test(name)) {
     return "markdown";
   }
@@ -44,7 +48,9 @@ export function getAttachmentPreviewKind(attachment: Attachment): AttachmentPrev
 }
 
 export function isPreviewableAttachment(attachment: Attachment): boolean {
-  if (!getAttachmentPreviewKind(attachment)) return false;
+  const kind = getAttachmentPreviewKind(attachment);
+  if (!kind) return false;
+  if (kind === "image") return true;
   return attachment.size_bytes == null || attachment.size_bytes <= DOCUMENT_PREVIEW_MAX_BYTES;
 }
 


### PR DESCRIPTION
## Summary
- Change the document preview header action from external-link semantics to a download icon/action.
- Include image attachments in the right-side preview pane so owner-chat image thumbnails open correctly.
- Keep the legacy full-screen image overlay for contexts without a right-side preview handler.

## Verification
- cd frontend && npm test -- --run src/lib/attachment-preview.test.ts src/components/ui/AttachmentItem.test.ts src/components/ui/MarkdownContent.test.ts src/components/dashboard/MessageList.test.ts
- cd frontend && NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build
- git diff --check

## Risk / rollout
- Low risk UI behavior change scoped to attachment preview actions.