### PR TITLE
feat(daemon): agent-driven `botcord wait` defer for group rooms

### DIFF
--- a/cli/src/commands/wait.ts
+++ b/cli/src/commands/wait.ts
@@ -1,0 +1,70 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { ParsedArgs } from "../args.js";
+import { outputJson, outputError } from "../output.js";
+
+/** Marker filename — kept in sync with the daemon's wait-marker module
+ *  (packages/daemon/src/gateway/wait-marker.ts). */
+const WAIT_MARKER_FILENAME = ".botcord-wait.json";
+/** Hard ceiling on a single park request. The daemon clamps to the same value. */
+const MAX_WAIT_SECONDS = 30;
+
+/**
+ * `botcord wait <seconds> [--reason <r>]`
+ *
+ * Defer this turn's decision in a group room: write a local park marker that
+ * the BotCord daemon reads at the turn boundary and uses to re-wake this agent
+ * after `seconds` (or sooner, if a new message arrives meanwhile). Purely local
+ * — no Hub call. Only meaningful when invoked inside a daemon-hosted group-room
+ * turn; a no-op anywhere else (the marker is simply never consumed).
+ */
+export async function waitCommand(args: ParsedArgs): Promise<void> {
+  if (args.flags["help"]) {
+    console.log(`Usage: botcord wait <seconds> [--reason <r>]
+
+Defer your decision in a group room. The daemon re-wakes you after <seconds>,
+or sooner if a new message arrives — letting you re-decide with the newer
+context (e.g. skip replying if another agent already answered).
+
+Arguments:
+  <seconds>        How long to wait, 1-${MAX_WAIT_SECONDS} (clamped)
+
+Options:
+  --reason <r>     Optional note recorded for debugging`);
+    return;
+  }
+
+  // `parseArgs` treats the first bare token after the command as `subcommand`,
+  // so `botcord wait 8` lands the seconds there, not in `positionals`.
+  const rawSeconds =
+    args.subcommand ??
+    args.positionals[0] ??
+    (typeof args.flags["seconds"] === "string" ? args.flags["seconds"] : undefined);
+  const seconds = Number(rawSeconds);
+  if (!rawSeconds || !Number.isFinite(seconds) || seconds <= 0) {
+    outputError("usage: botcord wait <seconds> (1-30)");
+    return;
+  }
+  const clamped = Math.min(Math.ceil(seconds), MAX_WAIT_SECONDS);
+  const reason = typeof args.flags["reason"] === "string" ? args.flags["reason"] : undefined;
+
+  const target =
+    process.env.BOTCORD_WAIT_FILE ||
+    path.join(process.cwd(), WAIT_MARKER_FILENAME);
+
+  const marker = {
+    deadlineMs: Date.now() + clamped * 1000,
+    seconds: clamped,
+    writtenAt: Date.now(),
+    ...(reason ? { reason } : {}),
+  };
+
+  try {
+    fs.writeFileSync(target, JSON.stringify(marker), "utf8");
+  } catch (err) {
+    outputError(`failed to write wait marker: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
+
+  outputJson({ ok: true, waitSeconds: clamped, marker: target });
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -2,6 +2,7 @@
 import { parseArgs } from "./args.js";
 import { outputError } from "./output.js";
 import { sendCommand } from "./commands/send.js";
+import { waitCommand } from "./commands/wait.js";
 import { refreshCommand } from "./commands/refresh.js";
 import { resolveCommand } from "./commands/resolve.js";
 import { statusCommand } from "./commands/status.js";
@@ -36,6 +37,7 @@ Usage: botcord <command> [options]
 
 Commands:
   send              Send a signed message
+  wait              Defer a group-room turn (re-wake later)
   upload            Upload files to the hub
   inbox             Poll inbox for new messages
   history           Query message history
@@ -94,6 +96,9 @@ async function main(): Promise<void> {
     switch (args.command) {
       case "send":
         await sendCommand(args, globalHub, globalAgent);
+        break;
+      case "wait":
+        await waitCommand(args);
         break;
       case "upload":
         await uploadCommand(args, globalHub, globalAgent);

--- a/packages/daemon/src/gateway/__tests__/dispatcher-park.test.ts
+++ b/packages/daemon/src/gateway/__tests__/dispatcher-park.test.ts
@@ -2,10 +2,10 @@
  * Integration tests for the agent-driven `botcord wait` park / re-wake path.
  *
  * A group-room turn can write a park marker (here simulated via the fake
- * runtime's `observeRun`, standing in for the `botcord wait` CLI). The
- * dispatcher reads it at the turn boundary and re-dispatches the same message
- * after the (clamped) wait — unless a new message arrives first, or the
- * per-queue caps are hit.
+ * runtime's `observeRun`, standing in for the `botcord wait` CLI writing to
+ * `BOTCORD_WAIT_FILE` = `opts.waitMarkerFile`). The dispatcher reads it at the
+ * turn boundary and re-dispatches the same message after the (clamped) wait —
+ * unless a new message arrives first, or the per-queue caps are hit.
  */
 import { writeFileSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
@@ -54,17 +54,18 @@ class FakeRuntime implements RuntimeAdapter {
   }
 }
 
-/** Write a park marker into the runtime cwd, as `botcord wait <s>` would. */
-function writeMarker(cwd: string, deadlineFromNowMs: number): void {
-  writeFileSync(
-    path.join(cwd, WAIT_MARKER_FILENAME),
-    JSON.stringify({ deadlineMs: Date.now() + deadlineFromNowMs }),
-    "utf8",
-  );
+/** Simulate `botcord wait <s>`: write a park marker to the path the dispatcher
+ *  handed the subprocess via `BOTCORD_WAIT_FILE` (`opts.waitMarkerFile`). Falls
+ *  back to the legacy cwd path when unset, so non-eligible rooms still "write"
+ *  somewhere the dispatcher will never consume. */
+function writeMarker(opts: RuntimeRunOptions, deadlineFromNowMs: number): void {
+  const target = opts.waitMarkerFile ?? path.join(opts.cwd, WAIT_MARKER_FILENAME);
+  writeFileSync(target, JSON.stringify({ deadlineMs: Date.now() + deadlineFromNowMs }), "utf8");
 }
 
 const GROUP_CONVO = { id: "rm_grp1", kind: "group" as const };
 const OWNER_CONVO = { id: "rm_oc_1", kind: "group" as const };
+const DM_CONVO = { id: "rm_dm_1", kind: "direct" as const };
 
 function makeEnvelope(partial: Partial<GatewayInboundMessage> = {}): GatewayInboundEnvelope {
   return {
@@ -117,14 +118,14 @@ describe("Dispatcher — botcord wait park/re-wake", () => {
   }
 
   it("re-wakes a group-room turn after the marker deadline", async () => {
-    // Park only on the first turn; the re-wake turn answers normally.
     const runtime = new FakeRuntime((opts, callNo) => {
-      if (callNo === 1) writeMarker(opts.cwd, 40);
+      if (callNo === 1) writeMarker(opts, 40);
     });
     const { dispatcher } = await scaffold(runtime);
 
     await dispatcher.handle(makeEnvelope());
     expect(runtime.calls.length).toBe(1);
+    expect(runtime.calls[0]!.waitMarkerFile).toBeTruthy(); // env wired for group room
 
     await sleep(140);
     expect(runtime.calls.length).toBe(2); // original + one re-wake
@@ -132,40 +133,73 @@ describe("Dispatcher — botcord wait park/re-wake", () => {
 
   it("a new inbound during the park cancels the scheduled re-wake", async () => {
     const runtime = new FakeRuntime((opts, callNo) => {
-      if (callNo === 1) writeMarker(opts.cwd, 300); // long park
+      if (callNo === 1) writeMarker(opts, 300);
     });
     const { dispatcher } = await scaffold(runtime);
 
     await dispatcher.handle(makeEnvelope({ id: "m1" }));
     expect(runtime.calls.length).toBe(1);
-    // New message arrives well before the 300ms park elapses.
     await dispatcher.handle(makeEnvelope({ id: "m2", text: "never mind, solved it" }));
     expect(runtime.calls.length).toBe(2);
 
     await sleep(380);
-    // The park timer was superseded by m2 — no phantom third turn.
-    expect(runtime.calls.length).toBe(2);
+    expect(runtime.calls.length).toBe(2); // no phantom third turn
   });
 
   it("stops re-waking after MAX_PARKS consecutive parks", async () => {
-    // Park on every turn — the dispatcher must cap it.
-    const runtime = new FakeRuntime((opts) => writeMarker(opts.cwd, 30));
+    const runtime = new FakeRuntime((opts) => writeMarker(opts, 30));
     const { dispatcher } = await scaffold(runtime);
 
     await dispatcher.handle(makeEnvelope());
-    await sleep(360); // enough for several 30ms re-wakes to chain
+    await sleep(360);
+    expect(runtime.calls.length).toBe(4); // 1 original + MAX_PARKS (3) re-wakes
+  });
 
-    // 1 original + MAX_PARKS (3) re-wakes, then the 4th turn's park is ignored.
+  it("isolates concurrent group-room turns for the same agent/cwd", async () => {
+    // Two different group rooms → two queues → two markers under one workspace.
+    // Each parks once; neither clobbers the other.
+    const parked = new Set<string>();
+    const runtime = new FakeRuntime((opts) => {
+      const room = String(opts.context?.roomId ?? "");
+      if (!parked.has(room)) {
+        parked.add(room);
+        writeMarker(opts, 40);
+      }
+    });
+    const { dispatcher } = await scaffold(runtime);
+
+    await Promise.all([
+      dispatcher.handle(makeEnvelope({ id: "a1", conversation: { id: "rm_gA", kind: "group" } })),
+      dispatcher.handle(makeEnvelope({ id: "b1", conversation: { id: "rm_gB", kind: "group" } })),
+    ]);
+    expect(runtime.calls.length).toBe(2);
+    // Distinct per-queue marker paths.
+    expect(runtime.calls[0]!.waitMarkerFile).not.toBe(runtime.calls[1]!.waitMarkerFile);
+
+    await sleep(160);
+    // Both rooms re-woke exactly once → 4 total, not 2 (one swallowed) or 3.
     expect(runtime.calls.length).toBe(4);
+    const reWokenRooms = runtime.calls.map((c) => c.context?.roomId).sort();
+    expect(reWokenRooms).toEqual(["rm_gA", "rm_gA", "rm_gB", "rm_gB"]);
   });
 
   it("ignores the marker in an owner-chat room", async () => {
-    const runtime = new FakeRuntime((opts) => writeMarker(opts.cwd, 40));
+    const runtime = new FakeRuntime((opts) => writeMarker(opts, 40));
     const { dispatcher } = await scaffold(runtime);
 
     await dispatcher.handle(makeEnvelope({ conversation: OWNER_CONVO }));
+    expect(runtime.calls[0]!.waitMarkerFile).toBeUndefined(); // not park-eligible
     await sleep(140);
-    // Owner-chat is not a deferrable room — no re-wake.
+    expect(runtime.calls.length).toBe(1);
+  });
+
+  it("ignores the marker in a non-group (DM) room", async () => {
+    const runtime = new FakeRuntime((opts) => writeMarker(opts, 40));
+    const { dispatcher } = await scaffold(runtime);
+
+    await dispatcher.handle(makeEnvelope({ conversation: DM_CONVO }));
+    expect(runtime.calls[0]!.waitMarkerFile).toBeUndefined();
+    await sleep(140);
     expect(runtime.calls.length).toBe(1);
   });
 });

--- a/packages/daemon/src/gateway/__tests__/dispatcher-park.test.ts
+++ b/packages/daemon/src/gateway/__tests__/dispatcher-park.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Integration tests for the agent-driven `botcord wait` park / re-wake path.
+ *
+ * A group-room turn can write a park marker (here simulated via the fake
+ * runtime's `observeRun`, standing in for the `botcord wait` CLI). The
+ * dispatcher reads it at the turn boundary and re-dispatches the same message
+ * after the (clamped) wait — unless a new message arrives first, or the
+ * per-queue caps are hit.
+ */
+import { writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Dispatcher, type RuntimeFactory } from "../dispatcher.js";
+import { SessionStore } from "../session-store.js";
+import { WAIT_MARKER_FILENAME } from "../wait-marker.js";
+import type {
+  ChannelAdapter,
+  ChannelSendContext,
+  ChannelSendResult,
+  GatewayConfig,
+  GatewayInboundEnvelope,
+  GatewayInboundMessage,
+  RuntimeAdapter,
+  RuntimeRunOptions,
+  RuntimeRunResult,
+} from "../types.js";
+import type { GatewayLogger } from "../log.js";
+
+function silentLogger(): GatewayLogger {
+  return { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+}
+
+class FakeChannel implements ChannelAdapter {
+  readonly id = "botcord";
+  readonly type = "botcord";
+  readonly sends: ChannelSendContext[] = [];
+  async start(): Promise<void> {}
+  async send(ctx: ChannelSendContext): Promise<ChannelSendResult> {
+    this.sends.push(ctx);
+    return {};
+  }
+}
+
+class FakeRuntime implements RuntimeAdapter {
+  readonly id = "claude-code";
+  readonly calls: RuntimeRunOptions[] = [];
+  constructor(private readonly observeRun?: (opts: RuntimeRunOptions, callNo: number) => void) {}
+  async run(options: RuntimeRunOptions): Promise<RuntimeRunResult> {
+    this.calls.push(options);
+    this.observeRun?.(options, this.calls.length);
+    return { text: "NO_REPLY", newSessionId: "sid-1" };
+  }
+}
+
+/** Write a park marker into the runtime cwd, as `botcord wait <s>` would. */
+function writeMarker(cwd: string, deadlineFromNowMs: number): void {
+  writeFileSync(
+    path.join(cwd, WAIT_MARKER_FILENAME),
+    JSON.stringify({ deadlineMs: Date.now() + deadlineFromNowMs }),
+    "utf8",
+  );
+}
+
+const GROUP_CONVO = { id: "rm_grp1", kind: "group" as const };
+const OWNER_CONVO = { id: "rm_oc_1", kind: "group" as const };
+
+function makeEnvelope(partial: Partial<GatewayInboundMessage> = {}): GatewayInboundEnvelope {
+  return {
+    message: {
+      id: partial.id ?? "hub_msg_1",
+      channel: "botcord",
+      accountId: "ag_me",
+      conversation: partial.conversation ?? GROUP_CONVO,
+      sender: partial.sender ?? { id: "ag_peer", name: "peer", kind: "agent" },
+      text: partial.text ?? "anyone know how to fix this?",
+      raw: {},
+      replyTo: null,
+      receivedAt: Date.now(),
+    },
+  };
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("Dispatcher — botcord wait park/re-wake", () => {
+  let cwd: string;
+  let storeDir: string;
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(path.join(tmpdir(), "park-cwd-"));
+    storeDir = await mkdtemp(path.join(tmpdir(), "park-store-"));
+  });
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true });
+    await rm(storeDir, { recursive: true, force: true });
+  });
+
+  async function scaffold(runtime: FakeRuntime) {
+    const store = new SessionStore({ path: path.join(storeDir, "sessions.json") });
+    await store.load();
+    const channel = new FakeChannel();
+    const config: GatewayConfig = {
+      channels: [{ id: "botcord", type: "botcord", accountId: "ag_me" }],
+      defaultRoute: { runtime: "claude-code", cwd },
+      routes: [],
+    };
+    const dispatcher = new Dispatcher({
+      config,
+      channels: new Map<string, ChannelAdapter>([[channel.id, channel]]),
+      runtime: (() => runtime) as RuntimeFactory,
+      sessionStore: store,
+      log: silentLogger(),
+    });
+    return { dispatcher };
+  }
+
+  it("re-wakes a group-room turn after the marker deadline", async () => {
+    // Park only on the first turn; the re-wake turn answers normally.
+    const runtime = new FakeRuntime((opts, callNo) => {
+      if (callNo === 1) writeMarker(opts.cwd, 40);
+    });
+    const { dispatcher } = await scaffold(runtime);
+
+    await dispatcher.handle(makeEnvelope());
+    expect(runtime.calls.length).toBe(1);
+
+    await sleep(140);
+    expect(runtime.calls.length).toBe(2); // original + one re-wake
+  });
+
+  it("a new inbound during the park cancels the scheduled re-wake", async () => {
+    const runtime = new FakeRuntime((opts, callNo) => {
+      if (callNo === 1) writeMarker(opts.cwd, 300); // long park
+    });
+    const { dispatcher } = await scaffold(runtime);
+
+    await dispatcher.handle(makeEnvelope({ id: "m1" }));
+    expect(runtime.calls.length).toBe(1);
+    // New message arrives well before the 300ms park elapses.
+    await dispatcher.handle(makeEnvelope({ id: "m2", text: "never mind, solved it" }));
+    expect(runtime.calls.length).toBe(2);
+
+    await sleep(380);
+    // The park timer was superseded by m2 — no phantom third turn.
+    expect(runtime.calls.length).toBe(2);
+  });
+
+  it("stops re-waking after MAX_PARKS consecutive parks", async () => {
+    // Park on every turn — the dispatcher must cap it.
+    const runtime = new FakeRuntime((opts) => writeMarker(opts.cwd, 30));
+    const { dispatcher } = await scaffold(runtime);
+
+    await dispatcher.handle(makeEnvelope());
+    await sleep(360); // enough for several 30ms re-wakes to chain
+
+    // 1 original + MAX_PARKS (3) re-wakes, then the 4th turn's park is ignored.
+    expect(runtime.calls.length).toBe(4);
+  });
+
+  it("ignores the marker in an owner-chat room", async () => {
+    const runtime = new FakeRuntime((opts) => writeMarker(opts.cwd, 40));
+    const { dispatcher } = await scaffold(runtime);
+
+    await dispatcher.handle(makeEnvelope({ conversation: OWNER_CONVO }));
+    await sleep(140);
+    // Owner-chat is not a deferrable room — no re-wake.
+    expect(runtime.calls.length).toBe(1);
+  });
+});

--- a/packages/daemon/src/gateway/__tests__/wait-marker.test.ts
+++ b/packages/daemon/src/gateway/__tests__/wait-marker.test.ts
@@ -7,40 +7,41 @@ import {
   WAIT_MARKER_FILENAME,
   MAX_WAIT_MS,
   waitMarkerPath,
+  resolveWaitMarkerPath,
   clearWaitMarker,
   consumeWaitMarker,
 } from "../wait-marker.js";
 
 describe("wait-marker", () => {
   let dir: string;
+  let marker: string;
 
   beforeEach(async () => {
     dir = await mkdtemp(path.join(tmpdir(), "wait-marker-"));
+    marker = waitMarkerPath(dir);
   });
   afterEach(async () => {
     await rm(dir, { recursive: true, force: true });
   });
 
-  const write = (obj: unknown) =>
-    writeFile(waitMarkerPath(dir), JSON.stringify(obj), "utf8");
+  const write = (obj: unknown, at: string = marker) =>
+    writeFile(at, JSON.stringify(obj), "utf8");
 
   it("returns null when no marker exists", () => {
-    expect(consumeWaitMarker(dir)).toBeNull();
+    expect(consumeWaitMarker(marker)).toBeNull();
   });
 
   it("reads a valid marker, clamps to the deadline, and deletes the file", async () => {
     const now = 1_000_000;
     await write({ deadlineMs: now + 8_000, seconds: 8 });
-    const marker = consumeWaitMarker(dir, now);
-    expect(marker).toEqual({ deadlineMs: now + 8_000 });
-    // File consumed.
-    expect(existsSync(waitMarkerPath(dir))).toBe(false);
+    expect(consumeWaitMarker(marker, now)).toEqual({ deadlineMs: now + 8_000 });
+    expect(existsSync(marker)).toBe(false);
   });
 
   it("preserves a reason string when present", async () => {
     const now = 1_000_000;
     await write({ deadlineMs: now + 5_000, reason: "letting alice answer" });
-    expect(consumeWaitMarker(dir, now)).toEqual({
+    expect(consumeWaitMarker(marker, now)).toEqual({
       deadlineMs: now + 5_000,
       reason: "letting alice answer",
     });
@@ -49,32 +50,40 @@ describe("wait-marker", () => {
   it("clamps a deadline beyond MAX_WAIT_MS down to now + MAX_WAIT_MS", async () => {
     const now = 1_000_000;
     await write({ deadlineMs: now + 10 * MAX_WAIT_MS });
-    expect(consumeWaitMarker(dir, now)).toEqual({ deadlineMs: now + MAX_WAIT_MS });
+    expect(consumeWaitMarker(marker, now)).toEqual({ deadlineMs: now + MAX_WAIT_MS });
   });
 
   it("returns null for a past deadline (and still deletes the file)", async () => {
     const now = 1_000_000;
     await write({ deadlineMs: now - 1 });
-    expect(consumeWaitMarker(dir, now)).toBeNull();
-    expect(existsSync(waitMarkerPath(dir))).toBe(false);
+    expect(consumeWaitMarker(marker, now)).toBeNull();
+    expect(existsSync(marker)).toBe(false);
   });
 
   it("returns null for malformed / non-numeric markers", async () => {
     await write({ nope: true });
-    expect(consumeWaitMarker(dir)).toBeNull();
-    await writeFile(waitMarkerPath(dir), "{ not json", "utf8");
-    expect(consumeWaitMarker(dir)).toBeNull();
+    expect(consumeWaitMarker(marker)).toBeNull();
+    await writeFile(marker, "{ not json", "utf8");
+    expect(consumeWaitMarker(marker)).toBeNull();
   });
 
   it("clearWaitMarker removes a stale marker and is a no-op when absent", async () => {
     await write({ deadlineMs: Date.now() + 5_000 });
-    clearWaitMarker(dir);
-    expect(existsSync(waitMarkerPath(dir))).toBe(false);
-    // No throw on a clean dir.
-    expect(() => clearWaitMarker(dir)).not.toThrow();
+    clearWaitMarker(marker);
+    expect(existsSync(marker)).toBe(false);
+    expect(() => clearWaitMarker(marker)).not.toThrow();
   });
 
-  it("uses the documented filename", () => {
+  it("scopes the path per queue and sanitizes the queue key", () => {
+    const p = resolveWaitMarkerPath(dir, "botcord:ag_me:rm_g1:tp_x");
+    expect(p).toBe(path.join(dir, ".botcord-wait.botcord_ag_me_rm_g1_tp_x.json"));
+    // Distinct queues → distinct files (the core of the concurrency fix).
+    expect(resolveWaitMarkerPath(dir, "botcord:ag_me:rm_g1:")).not.toBe(
+      resolveWaitMarkerPath(dir, "botcord:ag_me:rm_g2:"),
+    );
+  });
+
+  it("uses the documented legacy filename", () => {
     expect(WAIT_MARKER_FILENAME).toBe(".botcord-wait.json");
     expect(waitMarkerPath(dir)).toBe(path.join(dir, ".botcord-wait.json"));
   });

--- a/packages/daemon/src/gateway/__tests__/wait-marker.test.ts
+++ b/packages/daemon/src/gateway/__tests__/wait-marker.test.ts
@@ -1,0 +1,81 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  WAIT_MARKER_FILENAME,
+  MAX_WAIT_MS,
+  waitMarkerPath,
+  clearWaitMarker,
+  consumeWaitMarker,
+} from "../wait-marker.js";
+
+describe("wait-marker", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "wait-marker-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const write = (obj: unknown) =>
+    writeFile(waitMarkerPath(dir), JSON.stringify(obj), "utf8");
+
+  it("returns null when no marker exists", () => {
+    expect(consumeWaitMarker(dir)).toBeNull();
+  });
+
+  it("reads a valid marker, clamps to the deadline, and deletes the file", async () => {
+    const now = 1_000_000;
+    await write({ deadlineMs: now + 8_000, seconds: 8 });
+    const marker = consumeWaitMarker(dir, now);
+    expect(marker).toEqual({ deadlineMs: now + 8_000 });
+    // File consumed.
+    expect(existsSync(waitMarkerPath(dir))).toBe(false);
+  });
+
+  it("preserves a reason string when present", async () => {
+    const now = 1_000_000;
+    await write({ deadlineMs: now + 5_000, reason: "letting alice answer" });
+    expect(consumeWaitMarker(dir, now)).toEqual({
+      deadlineMs: now + 5_000,
+      reason: "letting alice answer",
+    });
+  });
+
+  it("clamps a deadline beyond MAX_WAIT_MS down to now + MAX_WAIT_MS", async () => {
+    const now = 1_000_000;
+    await write({ deadlineMs: now + 10 * MAX_WAIT_MS });
+    expect(consumeWaitMarker(dir, now)).toEqual({ deadlineMs: now + MAX_WAIT_MS });
+  });
+
+  it("returns null for a past deadline (and still deletes the file)", async () => {
+    const now = 1_000_000;
+    await write({ deadlineMs: now - 1 });
+    expect(consumeWaitMarker(dir, now)).toBeNull();
+    expect(existsSync(waitMarkerPath(dir))).toBe(false);
+  });
+
+  it("returns null for malformed / non-numeric markers", async () => {
+    await write({ nope: true });
+    expect(consumeWaitMarker(dir)).toBeNull();
+    await writeFile(waitMarkerPath(dir), "{ not json", "utf8");
+    expect(consumeWaitMarker(dir)).toBeNull();
+  });
+
+  it("clearWaitMarker removes a stale marker and is a no-op when absent", async () => {
+    await write({ deadlineMs: Date.now() + 5_000 });
+    clearWaitMarker(dir);
+    expect(existsSync(waitMarkerPath(dir))).toBe(false);
+    // No throw on a clean dir.
+    expect(() => clearWaitMarker(dir)).not.toThrow();
+  });
+
+  it("uses the documented filename", () => {
+    expect(WAIT_MARKER_FILENAME).toBe(".botcord-wait.json");
+    expect(waitMarkerPath(dir)).toBe(path.join(dir, ".botcord-wait.json"));
+  });
+});

--- a/packages/daemon/src/gateway/cli-resolver.ts
+++ b/packages/daemon/src/gateway/cli-resolver.ts
@@ -77,10 +77,12 @@ export function buildCliEnv(opts: {
   hubUrl?: string;
   accountId?: string;
   basePath?: string | undefined;
+  waitMarkerFile?: string;
 }): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {};
   if (opts.hubUrl) env.BOTCORD_HUB = opts.hubUrl;
   if (opts.accountId) env.BOTCORD_AGENT_ID = opts.accountId;
+  if (opts.waitMarkerFile) env.BOTCORD_WAIT_FILE = opts.waitMarkerFile;
   const cli = resolveBundledCliBin();
   if (cli) {
     const existing = opts.basePath ?? "";

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -6,7 +6,7 @@ import type { GatewayLogger } from "./log.js";
 import { looksLikeRuntimeAuthFailure } from "./runtime-errors.js";
 import { resolveRoute } from "./router.js";
 import { sessionKey, type SessionStore } from "./session-store.js";
-import { clearWaitMarker, consumeWaitMarker, MAX_WAIT_MS } from "./wait-marker.js";
+import { clearWaitMarker, consumeWaitMarker, resolveWaitMarkerPath, MAX_WAIT_MS } from "./wait-marker.js";
 import {
   truncateTextField,
   type DeliveryStatus,
@@ -1333,9 +1333,20 @@ export class Dispatcher {
     };
     q.current = slot;
 
-    // Drop any stale park marker so that whatever `botcord wait` writes during
-    // this turn is unambiguously from this turn (read back in `finally`).
-    clearWaitMarker(route.cwd);
+    // Agent-driven `botcord wait` is offered only in non-owner BotCord group
+    // rooms (kind === "group"). When eligible, scope the park marker per queue
+    // (concurrent group-room turns share one agent workspace) and expose its
+    // path to the CLI subprocess via `BOTCORD_WAIT_FILE`.
+    const parkEligible =
+      isBotCordChannel(channel) &&
+      !isOwnerChatRoom(msg) &&
+      msg.conversation.kind === "group";
+    const waitMarkerFile = parkEligible
+      ? resolveWaitMarkerPath(route.cwd, queueKey)
+      : undefined;
+    // Drop any stale marker so that whatever `botcord wait` writes during this
+    // turn is unambiguously from this turn (read back in `finally`).
+    if (waitMarkerFile) clearWaitMarker(waitMarkerFile);
 
     // Dispatched record — marks "this turn entered runtime".
     {
@@ -1728,6 +1739,7 @@ export class Dispatcher {
             cwd: route.cwd,
             accountId: msg.accountId,
             hubUrl: this.resolveHubUrl?.(msg.accountId),
+            ...(waitMarkerFile ? { waitMarkerFile } : {}),
             extraArgs: route.extraArgs,
             signal: controller.signal,
             trustLevel,
@@ -2189,7 +2201,7 @@ export class Dispatcher {
       if (q.current === slot) q.current = null;
       // Agent-driven defer: a group-room turn may have run `botcord wait` to
       // park its decision. Honor it now (timer lives here, not in the runtime).
-      this.maybeSchedulePark(queueKey, route, msg, channel, slot, controller);
+      this.maybeSchedulePark(queueKey, route, msg, channel, slot, controller, waitMarkerFile);
       resolveDone();
     }
   }
@@ -2214,9 +2226,11 @@ export class Dispatcher {
    * and, if present and within the per-queue caps ({@link MAX_PARKS} /
    * {@link MAX_WAIT_MS} total), schedule a re-wake that re-dispatches the same
    * message after the (clamped) wait. A turn that ends without a marker — or in
-   * a non-group room, or aborted/timed-out — resets the consecutive-park
-   * counters. New messages arriving during the wait cancel it via
-   * {@link supersedePendingPark} (the agent then re-decides with fresh context).
+   * a non-deferrable room (`waitMarkerFile` unset), or aborted/timed-out —
+   * resets the consecutive-park counters. New messages arriving during the wait
+   * cancel it via {@link supersedePendingPark} (the agent then re-decides with
+   * fresh context). `waitMarkerFile` is the per-queue marker path resolved at
+   * dispatch (undefined when the room is not park-eligible).
    */
   private maybeSchedulePark(
     queueKey: string,
@@ -2225,20 +2239,20 @@ export class Dispatcher {
     channel: ChannelAdapter,
     slot: TurnSlot,
     controller: AbortController,
+    waitMarkerFile: string | undefined,
   ): void {
     const q = this.queues.get(queueKey);
     if (!q) return;
 
-    const isGroupRoom = isBotCordChannel(channel) && !isOwnerChatRoom(msg);
-    if (!isGroupRoom || slot.timedOut || controller.signal.aborted) {
+    if (!waitMarkerFile || slot.timedOut || controller.signal.aborted) {
       // Not eligible / unclean completion — never honor a marker here.
-      clearWaitMarker(route.cwd);
+      if (waitMarkerFile) clearWaitMarker(waitMarkerFile);
       q.parkCount = 0;
       q.parkAccumMs = 0;
       return;
     }
 
-    const marker = consumeWaitMarker(route.cwd);
+    const marker = consumeWaitMarker(waitMarkerFile);
     if (!marker) {
       q.parkCount = 0;
       q.parkAccumMs = 0;

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -6,6 +6,7 @@ import type { GatewayLogger } from "./log.js";
 import { looksLikeRuntimeAuthFailure } from "./runtime-errors.js";
 import { resolveRoute } from "./router.js";
 import { sessionKey, type SessionStore } from "./session-store.js";
+import { clearWaitMarker, consumeWaitMarker, MAX_WAIT_MS } from "./wait-marker.js";
 import {
   truncateTextField,
   type DeliveryStatus,
@@ -51,6 +52,11 @@ const SECRET_KEY_RE = /token|secret|private.?key|api.?key|authorization|password
 
 /** Maximum number of buffered serial entries per queue. Excess entries drop oldest. */
 const MAX_BATCH_BUFFER_ENTRIES = 40;
+
+/** Max consecutive agent-driven `botcord wait` parks on one queue before the
+ *  next turn is forced to produce a real decision. Total accumulated wait is
+ *  separately bounded by {@link MAX_WAIT_MS}. */
+const MAX_PARKS = 3;
 
 /**
  * Soft cap on the total characters across raw.batch members in a merged
@@ -430,6 +436,19 @@ interface QueueState {
   serialBuffer: BufferedSerialEntry[];
   /** True when the serial-drain worker is actively running (or about to). */
   serialWorkerActive: boolean;
+  /**
+   * Active re-wake timer scheduled when a group-room turn ran `botcord wait`.
+   * Null when no park is pending. An external arrival on this queue clears it
+   * (the new message supersedes the scheduled re-wake); the timer callback
+   * nulls it itself before re-dispatching.
+   */
+  park: NodeJS.Timeout | null;
+  /** Consecutive parks on this queue; reset when a turn ends without one (or
+   *  an external message arrives). Capped by {@link MAX_PARKS}. */
+  parkCount: number;
+  /** Total park time accumulated across consecutive parks (ms). Capped by
+   *  {@link MAX_WAIT_MS}. */
+  parkAccumMs: number;
 }
 
 interface CloudRunBudgetCaps {
@@ -801,6 +820,9 @@ export class Dispatcher {
         cancelGen: 0,
         serialBuffer: [],
         serialWorkerActive: false,
+        park: null,
+        parkCount: 0,
+        parkAccumMs: 0,
       };
       this.queues.set(key, q);
     }
@@ -1008,6 +1030,7 @@ export class Dispatcher {
     mergedFromTurnIds: string[] = [],
   ): Promise<void> {
     const q = this.getQueue(queueKey);
+    this.supersedePendingPark(q);
     // Bump the generation on every arrival. Older arrivals still awaiting
     // the prior turn's teardown will observe `myGen !== q.cancelGen` when
     // they resume and drop out, so only the newest message reaches runTurn.
@@ -1096,6 +1119,7 @@ export class Dispatcher {
     mergedFromTurnIds: string[] = [],
   ): Promise<void> {
     const q = this.getQueue(queueKey);
+    this.supersedePendingPark(q);
     q.serialBuffer.push({ route, msg, channel, turnId });
     while (q.serialBuffer.length > MAX_BATCH_BUFFER_ENTRIES) {
       const dropped = q.serialBuffer.shift()!;
@@ -1308,6 +1332,10 @@ export class Dispatcher {
       blocks: [],
     };
     q.current = slot;
+
+    // Drop any stale park marker so that whatever `botcord wait` writes during
+    // this turn is unambiguously from this turn (read back in `finally`).
+    clearWaitMarker(route.cwd);
 
     // Dispatched record — marks "this turn entered runtime".
     {
@@ -2159,8 +2187,122 @@ export class Dispatcher {
       // newer arrival should find `q.current === slot`, call `abort()`, and
       // let our abort-checks above drop this turn silently.
       if (q.current === slot) q.current = null;
+      // Agent-driven defer: a group-room turn may have run `botcord wait` to
+      // park its decision. Honor it now (timer lives here, not in the runtime).
+      this.maybeSchedulePark(queueKey, route, msg, channel, slot, controller);
       resolveDone();
     }
+  }
+
+  /**
+   * Clear a pending re-wake timer because an external message just arrived on
+   * the queue (it supersedes the scheduled re-wake and restarts the dithering
+   * budget). No-op when the timer-fire path already nulled `q.park` — so a
+   * re-wake does NOT reset the consecutive-park counters, keeping the caps
+   * effective across re-wakes.
+   */
+  private supersedePendingPark(q: QueueState): void {
+    if (!q.park) return;
+    clearTimeout(q.park);
+    q.park = null;
+    q.parkCount = 0;
+    q.parkAccumMs = 0;
+  }
+
+  /**
+   * Read the park marker a group-room turn may have written via `botcord wait`
+   * and, if present and within the per-queue caps ({@link MAX_PARKS} /
+   * {@link MAX_WAIT_MS} total), schedule a re-wake that re-dispatches the same
+   * message after the (clamped) wait. A turn that ends without a marker — or in
+   * a non-group room, or aborted/timed-out — resets the consecutive-park
+   * counters. New messages arriving during the wait cancel it via
+   * {@link supersedePendingPark} (the agent then re-decides with fresh context).
+   */
+  private maybeSchedulePark(
+    queueKey: string,
+    route: GatewayRoute,
+    msg: GatewayInboundEnvelope["message"],
+    channel: ChannelAdapter,
+    slot: TurnSlot,
+    controller: AbortController,
+  ): void {
+    const q = this.queues.get(queueKey);
+    if (!q) return;
+
+    const isGroupRoom = isBotCordChannel(channel) && !isOwnerChatRoom(msg);
+    if (!isGroupRoom || slot.timedOut || controller.signal.aborted) {
+      // Not eligible / unclean completion — never honor a marker here.
+      clearWaitMarker(route.cwd);
+      q.parkCount = 0;
+      q.parkAccumMs = 0;
+      return;
+    }
+
+    const marker = consumeWaitMarker(route.cwd);
+    if (!marker) {
+      q.parkCount = 0;
+      q.parkAccumMs = 0;
+      return;
+    }
+
+    if (q.parkCount >= MAX_PARKS || q.parkAccumMs >= MAX_WAIT_MS) {
+      this.log.info("dispatcher: park request ignored — cap reached", {
+        agentId: msg.accountId,
+        roomId: msg.conversation.id,
+        topicId: msg.conversation.threadId ?? null,
+        queueKey,
+        parkCount: q.parkCount,
+        parkAccumMs: q.parkAccumMs,
+      });
+      q.parkCount = 0;
+      q.parkAccumMs = 0;
+      return;
+    }
+
+    const remainingBudget = MAX_WAIT_MS - q.parkAccumMs;
+    const waitMs = Math.max(0, Math.min(marker.deadlineMs - Date.now(), remainingBudget));
+    if (waitMs <= 0) {
+      q.parkCount = 0;
+      q.parkAccumMs = 0;
+      return;
+    }
+
+    q.parkCount += 1;
+    q.parkAccumMs += waitMs;
+    this.log.info("dispatcher: parking group-room turn (botcord wait)", {
+      agentId: msg.accountId,
+      roomId: msg.conversation.id,
+      topicId: msg.conversation.threadId ?? null,
+      queueKey,
+      waitMs,
+      parkCount: q.parkCount,
+      reason: marker.reason ?? null,
+    });
+
+    const timer = setTimeout(() => {
+      q.park = null;
+      this.log.info("dispatcher: park elapsed — re-waking", {
+        agentId: msg.accountId,
+        roomId: msg.conversation.id,
+        topicId: msg.conversation.threadId ?? null,
+        queueKey,
+      });
+      void this.runSerial(
+        queueKey,
+        route,
+        this.recomposeUserTurn(msg),
+        msg,
+        channel,
+        randomUUID(),
+      ).catch((err) => {
+        this.log.warn("dispatcher: park re-wake failed", {
+          queueKey,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }, waitMs);
+    if (typeof timer.unref === "function") timer.unref();
+    q.park = timer;
   }
 
   private async sendReply(

--- a/packages/daemon/src/gateway/runtimes/codex.ts
+++ b/packages/daemon/src/gateway/runtimes/codex.ts
@@ -269,6 +269,7 @@ export class CodexAdapter extends NdjsonStreamAdapter {
       hubUrl: opts.hubUrl,
       accountId: opts.accountId,
       basePath: process.env.PATH,
+      waitMarkerFile: opts.waitMarkerFile,
     });
     const env: NodeJS.ProcessEnv = {
       ...process.env,

--- a/packages/daemon/src/gateway/runtimes/deepseek-tui.ts
+++ b/packages/daemon/src/gateway/runtimes/deepseek-tui.ts
@@ -237,6 +237,7 @@ export class DeepseekTuiAdapter implements RuntimeAdapter {
         hubUrl: opts.hubUrl,
         accountId: opts.accountId,
         basePath: process.env.PATH,
+        waitMarkerFile: opts.waitMarkerFile,
       }),
       FORCE_COLOR: "0",
       NO_COLOR: "1",

--- a/packages/daemon/src/gateway/runtimes/hermes-agent.ts
+++ b/packages/daemon/src/gateway/runtimes/hermes-agent.ts
@@ -267,6 +267,7 @@ export class HermesAgentAdapter extends AcpRuntimeAdapter {
       hubUrl: opts.hubUrl,
       accountId: opts.accountId,
       basePath: process.env.PATH,
+      waitMarkerFile: opts.waitMarkerFile,
     });
     const env: NodeJS.ProcessEnv = {
       ...process.env,

--- a/packages/daemon/src/gateway/runtimes/kimi.ts
+++ b/packages/daemon/src/gateway/runtimes/kimi.ts
@@ -210,6 +210,7 @@ export class KimiAdapter extends NdjsonStreamAdapter {
       hubUrl: opts.hubUrl,
       accountId: opts.accountId,
       basePath: process.env.PATH,
+      waitMarkerFile: opts.waitMarkerFile,
     });
     return {
       ...process.env,

--- a/packages/daemon/src/gateway/runtimes/ndjson-stream.ts
+++ b/packages/daemon/src/gateway/runtimes/ndjson-stream.ts
@@ -95,6 +95,7 @@ export abstract class NdjsonStreamAdapter implements RuntimeAdapter {
         hubUrl: opts.hubUrl,
         accountId: opts.accountId,
         basePath: process.env.PATH,
+        waitMarkerFile: opts.waitMarkerFile,
       }),
     };
   }

--- a/packages/daemon/src/gateway/types.ts
+++ b/packages/daemon/src/gateway/types.ts
@@ -364,6 +364,14 @@ export interface RuntimeRunOptions {
    * unspecified and the bundled CLI falls back to its own default.
    */
   hubUrl?: string;
+  /**
+   * Absolute path the spawned CLI should write a `botcord wait` park marker to,
+   * exposed to the subprocess as `BOTCORD_WAIT_FILE`. Scoped per queue by the
+   * dispatcher so concurrent group-room turns sharing one workspace don't
+   * clobber each other. Unset for non-deferrable rooms (owner-chat / DM /
+   * non-group), in which case `botcord wait` is a harmless no-op.
+   */
+  waitMarkerFile?: string;
   signal: AbortSignal;
   extraArgs?: string[];
   trustLevel: TrustLevel;

--- a/packages/daemon/src/gateway/wait-marker.ts
+++ b/packages/daemon/src/gateway/wait-marker.ts
@@ -1,0 +1,85 @@
+/**
+ * Workspace park-marker transport for the agent-driven `botcord wait` defer.
+ *
+ * In non-owner BotCord group rooms the dispatcher discards the runtime's final
+ * text (the agent replies out-of-band via the `botcord send` CLI → Hub), so a
+ * "please re-wake me later" signal cannot ride back on the turn result. Instead
+ * the bundled `botcord wait <seconds>` CLI drops a tiny JSON marker into the
+ * agent's workspace (`route.cwd`); the dispatcher reads it at the turn boundary
+ * and schedules a re-wake. This keeps the *decision* to wait in the agent (it
+ * judges relevance/urgency) while the *timer* lives cheaply in the daemon — no
+ * runtime session is held open during the wait.
+ *
+ * Local daemon-hosted agents only: the marker rides the shared filesystem of
+ * `route.cwd`. Cloud (sandboxed) agents need a networked transport — out of
+ * scope here.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+/** Marker filename written under the agent workspace. Kept in sync with the
+ *  `botcord wait` CLI command (cli/src/commands/wait.ts). */
+export const WAIT_MARKER_FILENAME = ".botcord-wait.json";
+
+/** Hard ceiling on a single park request (mirrors the CLI clamp). Also used by
+ *  the dispatcher as the total accumulated-park budget across consecutive
+ *  re-waks on one queue. */
+export const MAX_WAIT_MS = 30_000;
+
+export interface WaitMarker {
+  /** Absolute unix millis the agent wants to be re-woken by (already clamped). */
+  deadlineMs: number;
+  reason?: string;
+}
+
+export function waitMarkerPath(cwd: string): string {
+  return path.join(cwd, WAIT_MARKER_FILENAME);
+}
+
+/** Best-effort delete of any pre-existing marker. Called before a turn runs so
+ *  that whatever is present afterward was written by *this* turn. */
+export function clearWaitMarker(cwd: string): void {
+  try {
+    fs.rmSync(waitMarkerPath(cwd), { force: true });
+  } catch {
+    // A leftover marker only costs one wasted park-check next turn — never
+    // let cleanup failure abort the dispatch path.
+  }
+}
+
+/**
+ * Read + delete the marker a turn may have written via `botcord wait`, and
+ * return the validated request (or null). Always removes the file so the next
+ * turn starts clean. `now` is injectable for tests.
+ *
+ * A deadline in the past — or beyond {@link MAX_WAIT_MS} — is clamped; a
+ * non-positive remaining wait yields null (treated as "no wait").
+ */
+export function consumeWaitMarker(cwd: string, now: number = Date.now()): WaitMarker | null {
+  const p = waitMarkerPath(cwd);
+  let raw: string;
+  try {
+    raw = fs.readFileSync(p, "utf8");
+  } catch {
+    return null; // no marker (ENOENT) or unreadable
+  }
+  try {
+    fs.rmSync(p, { force: true });
+  } catch {
+    // ignore — the pre-turn clear will catch it next time
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const obj = parsed as Record<string, unknown>;
+  const deadlineMs = typeof obj.deadlineMs === "number" ? obj.deadlineMs : NaN;
+  if (!Number.isFinite(deadlineMs)) return null;
+  const clamped = Math.min(deadlineMs, now + MAX_WAIT_MS);
+  if (clamped <= now) return null;
+  const reason = typeof obj.reason === "string" ? obj.reason : undefined;
+  return reason !== undefined ? { deadlineMs: clamped, reason } : { deadlineMs: clamped };
+}

--- a/packages/daemon/src/gateway/wait-marker.ts
+++ b/packages/daemon/src/gateway/wait-marker.ts
@@ -5,10 +5,16 @@
  * text (the agent replies out-of-band via the `botcord send` CLI → Hub), so a
  * "please re-wake me later" signal cannot ride back on the turn result. Instead
  * the bundled `botcord wait <seconds>` CLI drops a tiny JSON marker into the
- * agent's workspace (`route.cwd`); the dispatcher reads it at the turn boundary
- * and schedules a re-wake. This keeps the *decision* to wait in the agent (it
- * judges relevance/urgency) while the *timer* lives cheaply in the daemon — no
- * runtime session is held open during the wait.
+ * agent's workspace; the dispatcher reads it at the turn boundary and schedules
+ * a re-wake. This keeps the *decision* to wait in the agent (it judges
+ * relevance/urgency) while the *timer* lives cheaply in the daemon — no runtime
+ * session is held open during the wait.
+ *
+ * The marker path is scoped per **queue** (channel:agent:room:thread): the
+ * dispatcher serializes turns within a queue but NOT across queues that share
+ * one agent workspace (`route.cwd`), so two concurrent group-room turns for the
+ * same agent would otherwise clobber each other's marker. The dispatcher passes
+ * the resolved path to the CLI subprocess via `BOTCORD_WAIT_FILE`.
  *
  * Local daemon-hosted agents only: the marker rides the shared filesystem of
  * `route.cwd`. Cloud (sandboxed) agents need a networked transport — out of
@@ -17,13 +23,16 @@
 import fs from "node:fs";
 import path from "node:path";
 
-/** Marker filename written under the agent workspace. Kept in sync with the
- *  `botcord wait` CLI command (cli/src/commands/wait.ts). */
-export const WAIT_MARKER_FILENAME = ".botcord-wait.json";
+/** Filename stem for park markers. */
+export const WAIT_MARKER_PREFIX = ".botcord-wait";
+/** Legacy unscoped marker name — the CLI's fallback when `BOTCORD_WAIT_FILE`
+ *  is unset. Never consumed by the dispatcher (which always scopes per queue),
+ *  so an unscoped write is a harmless no-op. */
+export const WAIT_MARKER_FILENAME = `${WAIT_MARKER_PREFIX}.json`;
 
 /** Hard ceiling on a single park request (mirrors the CLI clamp). Also used by
  *  the dispatcher as the total accumulated-park budget across consecutive
- *  re-waks on one queue. */
+ *  re-wakes on one queue. */
 export const MAX_WAIT_MS = 30_000;
 
 export interface WaitMarker {
@@ -32,15 +41,23 @@ export interface WaitMarker {
   reason?: string;
 }
 
+/** Legacy unscoped path under `cwd` (CLI fallback / tests). */
 export function waitMarkerPath(cwd: string): string {
   return path.join(cwd, WAIT_MARKER_FILENAME);
 }
 
-/** Best-effort delete of any pre-existing marker. Called before a turn runs so
- *  that whatever is present afterward was written by *this* turn. */
-export function clearWaitMarker(cwd: string): void {
+/** Per-queue marker path under the agent workspace. */
+export function resolveWaitMarkerPath(cwd: string, queueKey: string): string {
+  const safe = queueKey.replace(/[^a-zA-Z0-9._-]/g, "_");
+  return path.join(cwd, `${WAIT_MARKER_PREFIX}.${safe}.json`);
+}
+
+/** Best-effort delete of any pre-existing marker at `markerPath`. Called before
+ *  a turn runs so that whatever `botcord wait` writes during this turn is
+ *  unambiguously from this turn. */
+export function clearWaitMarker(markerPath: string): void {
   try {
-    fs.rmSync(waitMarkerPath(cwd), { force: true });
+    fs.rmSync(markerPath, { force: true });
   } catch {
     // A leftover marker only costs one wasted park-check next turn — never
     // let cleanup failure abort the dispatch path.
@@ -55,16 +72,15 @@ export function clearWaitMarker(cwd: string): void {
  * A deadline in the past — or beyond {@link MAX_WAIT_MS} — is clamped; a
  * non-positive remaining wait yields null (treated as "no wait").
  */
-export function consumeWaitMarker(cwd: string, now: number = Date.now()): WaitMarker | null {
-  const p = waitMarkerPath(cwd);
+export function consumeWaitMarker(markerPath: string, now: number = Date.now()): WaitMarker | null {
   let raw: string;
   try {
-    raw = fs.readFileSync(p, "utf8");
+    raw = fs.readFileSync(markerPath, "utf8");
   } catch {
     return null; // no marker (ENOENT) or unreadable
   }
   try {
-    fs.rmSync(p, { force: true });
+    fs.rmSync(markerPath, { force: true });
   } catch {
     // ignore — the pre-turn clear will catch it next time
   }

--- a/packages/daemon/src/loop-risk.ts
+++ b/packages/daemon/src/loop-risk.ts
@@ -91,6 +91,7 @@ export function stripBotCordPromptScaffolding(text: string): string {
       if (line.startsWith("keyword, sender rule")) return false;
       if (line.startsWith("you do not reply to the group")) return false;
       if (line.startsWith("Before replying NO_REPLY in a non-owner group room")) return false;
+      if (line.startsWith("If you might have something useful to add")) return false;
       if (line.startsWith("match a memory-backed monitoring rule")) return false;
       if (line.startsWith("or owner-approved workflow. If needed")) return false;
       if (line.startsWith("[If the conversation has naturally concluded")) return false;

--- a/packages/daemon/src/turn-text.ts
+++ b/packages/daemon/src/turn-text.ts
@@ -43,6 +43,11 @@ const GROUP_HINT =
   "match a memory-backed monitoring rule, automation goal, pending task, keyword, sender rule, " +
   "or owner-approved workflow. If needed, use the botcord_memory skill to retrieve or update " +
   "working memory.\n\n" +
+  "If you might have something useful to add but another participant (human or agent) may answer " +
+  "first, you may run `botcord wait <seconds>` (1-30) via Bash instead of replying now. You will " +
+  "be re-woken after the wait — or sooner if a new message arrives — so you can re-decide with " +
+  "the newer context (for example, stay silent if someone already covered it). Prefer this over " +
+  "racing to answer an unaddressed question.\n\n" +
   'If no group reply and no background action is needed, reply exactly "NO_REPLY".]';
 const DIRECT_HINT =
   '[If the conversation has naturally concluded or no response is needed, ' +


### PR DESCRIPTION
## What

Lets a group-room agent **defer its decision** instead of racing to answer an unaddressed message. The agent runs a new `botcord wait <seconds>` CLI command; the daemon re-wakes it after the (clamped) wait — or **sooner if a new message arrives**, so it can re-decide with the newer context (e.g. stay silent if another agent already answered).

## Why

In a multi-agent group room, every eligible agent currently decides to speak **in parallel and blind to each other**, so an unaddressed question ("anyone know how to fix this?") can trigger several simultaneous answers. The root cause is synchronous fan-out: an agent can't see that a better-suited peer is already answering.

This restores the human "hear others before you speak" affordance **without any central arbiter**:
- The **wait decision stays in the agent** (it judges relevance/urgency). The more-relevant agent picks a short wait (or doesn't wait) and answers first; others, watching, see the answer during their wait and fold. Speaking order emerges from each agent's self-chosen wait.
- Only the **timer lives in the daemon**, so no runtime/LLM session is held open while waiting — the turn ends and a fresh turn is dispatched on re-wake.

## How

- **`botcord wait <seconds>`** (cli) writes a small park marker JSON into the agent workspace — purely local, no Hub call.
- The **dispatcher** clears any stale marker before a turn, reads it at the turn boundary, and schedules a re-wake that re-dispatches the same message. A new inbound on the queue supersedes the pending re-wake (the agent re-decides with fresh context). Caps: **3 consecutive parks / 30s total** per queue.
- **`GROUP_HINT`** advertises the tool; **loop-risk** strips the new hint so it doesn't pollute echo detection.

## Scope

- **Local daemon-hosted group rooms only.** Transport is a workspace marker file, which doesn't cross the E2B sandbox boundary — cloud-agent transport (a Hub control frame) is deliberately out of scope for this PR.
- Owner-chat / DM rooms do **not** expose the tool (they want immediate response).

## Tests

- `wait-marker.test.ts` — marker read/write/clear, clamp to 30s, past-deadline → null, malformed → null.
- `dispatcher-park.test.ts` — parks + re-wakes a group-room turn; new inbound cancels the re-wake; stops after `MAX_PARKS`; ignores the marker in owner-chat.
- Full daemon suite: **973 passing** (no regressions) + 12 new. protocol-core / cli / daemon all typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)