### PR TITLE
Fix Supabase JWT auth error normalization

### DIFF
--- a/backend/hub/auth.py
+++ b/backend/hub/auth.py
@@ -4,10 +4,11 @@ import logging
 import jwt
 from fastapi import Depends, Header, HTTPException
 from jwt import PyJWKClient
+from jwt.exceptions import PyJWKClientConnectionError, PyJWKClientError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from hub.config import FRONTEND_BASE_URL, JWT_ALGORITHM, JWT_EXPIRE_HOURS, JWT_SECRET, SUPABASE_JWT_SECRET, SUPABASE_JWT_JWKS_URL
+from hub.config import FRONTEND_BASE_URL, JWT_ALGORITHM, JWT_EXPIRE_HOURS, JWT_SECRET, SUPABASE_JWT_SECRET, SUPABASE_JWT_JWKS_URL, SUPABASE_URL
 from hub.database import get_db
 from hub.i18n import I18nHTTPException
 from hub.models import Agent, User
@@ -18,6 +19,18 @@ _logger = logging.getLogger(__name__)
 _jwks_client: PyJWKClient | None = None
 if SUPABASE_JWT_JWKS_URL:
     _jwks_client = PyJWKClient(SUPABASE_JWT_JWKS_URL, cache_keys=True)
+
+_SUPABASE_HS_ALGORITHMS = ["HS256"]
+_SUPABASE_ASYMMETRIC_ALGORITHMS = ["ES256", "RS256"]
+_SUPABASE_JWKS_SUFFIX = "/.well-known/jwks.json"
+
+
+def _expected_supabase_issuer() -> str | None:
+    if SUPABASE_URL:
+        return f"{SUPABASE_URL.rstrip('/')}/auth/v1"
+    if SUPABASE_JWT_JWKS_URL and SUPABASE_JWT_JWKS_URL.endswith(_SUPABASE_JWKS_SUFFIX):
+        return SUPABASE_JWT_JWKS_URL[: -len(_SUPABASE_JWKS_SUFFIX)].rstrip("/")
+    return None
 
 
 def create_agent_token(agent_id: str) -> tuple[str, int]:
@@ -121,18 +134,52 @@ def verify_supabase_token(token: str) -> str:
     if not SUPABASE_JWT_SECRET and not _jwks_client:
         raise jwt.InvalidTokenError("Supabase auth not configured")
 
-    if _jwks_client:
-        signing_key = _jwks_client.get_signing_key_from_jwt(token)
-        payload = jwt.decode(
-            token,
-            signing_key.key,
-            algorithms=["ES256", "RS256"],
-            audience="authenticated",
-        )
-    else:
-        payload = jwt.decode(
-            token, SUPABASE_JWT_SECRET, algorithms=["HS256"], audience="authenticated",
-        )
+    try:
+        header = jwt.get_unverified_header(token)
+    except jwt.PyJWTError as exc:
+        raise jwt.InvalidTokenError("Invalid token header") from exc
+
+    alg = header.get("alg")
+    if not isinstance(alg, str):
+        raise jwt.InvalidTokenError("Missing token algorithm")
+
+    expected_issuer = _expected_supabase_issuer()
+    decode_kwargs = {"audience": "authenticated"}
+    if expected_issuer:
+        decode_kwargs["issuer"] = expected_issuer
+
+    try:
+        if alg == "HS256":
+            if not SUPABASE_JWT_SECRET:
+                raise jwt.InvalidTokenError("Supabase HS256 auth not configured")
+            payload = jwt.decode(
+                token,
+                SUPABASE_JWT_SECRET,
+                algorithms=_SUPABASE_HS_ALGORITHMS,
+                **decode_kwargs,
+            )
+        elif alg in _SUPABASE_ASYMMETRIC_ALGORITHMS:
+            if not _jwks_client:
+                raise jwt.InvalidTokenError("Supabase JWKS auth not configured")
+            signing_key = _jwks_client.get_signing_key_from_jwt(token)
+            payload = jwt.decode(
+                token,
+                signing_key.key,
+                algorithms=[alg],
+                **decode_kwargs,
+            )
+        else:
+            raise jwt.InvalidTokenError("Unsupported token algorithm")
+    except jwt.InvalidTokenError as exc:
+        raise jwt.InvalidTokenError("Invalid token") from exc
+    except (
+        PyJWKClientConnectionError,
+        PyJWKClientError,
+        jwt.PyJWTError,
+        ValueError,
+        TypeError,
+    ) as exc:
+        raise jwt.InvalidTokenError("Invalid token") from exc
 
     sub = payload.get("sub")
     if not sub:

--- a/backend/tests/test_hub_auth.py
+++ b/backend/tests/test_hub_auth.py
@@ -1,0 +1,177 @@
+import base64
+import json
+
+import jwt
+import pytest
+from jwt.exceptions import PyJWKClientError
+
+from hub import auth
+from hub.i18n import I18nHTTPException
+
+
+def _unsigned_token(header: dict, payload: dict | None = None) -> str:
+    def enc(value: dict) -> str:
+        raw = json.dumps(value, separators=(",", ":")).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+    return f"{enc(header)}.{enc(payload or {})}.sig"
+
+
+def test_supabase_hs256_secret_wins_when_jwks_is_configured(monkeypatch):
+    secret = "test-supabase-secret-32-bytes-ok"
+
+    class FailingJwksClient:
+        def get_signing_key_from_jwt(self, token: str):  # pragma: no cover - must not be called
+            raise AssertionError("JWKS should not be used for HS256")
+
+    monkeypatch.setattr(auth, "SUPABASE_URL", None)
+    monkeypatch.setattr(auth, "SUPABASE_JWT_JWKS_URL", None)
+    monkeypatch.setattr(auth, "SUPABASE_JWT_SECRET", secret)
+    monkeypatch.setattr(auth, "_jwks_client", FailingJwksClient())
+    token = jwt.encode(
+        {"sub": "user-123", "aud": "authenticated"},
+        secret,
+        algorithm="HS256",
+    )
+
+    assert auth.verify_supabase_token(token) == "user-123"
+
+
+def test_supabase_hs256_token_with_expected_issuer_passes(monkeypatch):
+    secret = "test-supabase-secret-32-bytes-ok"
+    monkeypatch.setattr(auth, "SUPABASE_URL", "https://project-ref.supabase.co")
+    monkeypatch.setattr(auth, "SUPABASE_JWT_JWKS_URL", None)
+    monkeypatch.setattr(auth, "SUPABASE_JWT_SECRET", secret)
+    monkeypatch.setattr(auth, "_jwks_client", None)
+    token = jwt.encode(
+        {
+            "sub": "user-123",
+            "aud": "authenticated",
+            "iss": "https://project-ref.supabase.co/auth/v1",
+        },
+        secret,
+        algorithm="HS256",
+    )
+
+    assert auth.verify_supabase_token(token) == "user-123"
+
+
+def test_supabase_hs256_missing_issuer_fails_when_expected(monkeypatch):
+    secret = "test-supabase-secret-32-bytes-ok"
+    monkeypatch.setattr(auth, "JWT_SECRET", "botcord-test-secret-32-bytes-okx")
+    monkeypatch.setattr(auth, "SUPABASE_URL", "https://project-ref.supabase.co")
+    monkeypatch.setattr(auth, "SUPABASE_JWT_JWKS_URL", None)
+    monkeypatch.setattr(auth, "SUPABASE_JWT_SECRET", secret)
+    monkeypatch.setattr(auth, "_jwks_client", None)
+    token = jwt.encode(
+        {"sub": "user-123", "aud": "authenticated"},
+        secret,
+        algorithm="HS256",
+    )
+
+    with pytest.raises(I18nHTTPException) as exc:
+        auth._parse_dashboard_token(f"Bearer {token}", "ag_123")
+
+    assert exc.value.status_code == 401
+    assert exc.value.message_key == "invalid_token"
+
+
+def test_supabase_hs256_wrong_issuer_fails_when_expected(monkeypatch):
+    secret = "test-supabase-secret-32-bytes-ok"
+    monkeypatch.setattr(auth, "JWT_SECRET", "botcord-test-secret-32-bytes-okx")
+    monkeypatch.setattr(auth, "SUPABASE_URL", "https://project-ref.supabase.co")
+    monkeypatch.setattr(auth, "SUPABASE_JWT_JWKS_URL", None)
+    monkeypatch.setattr(auth, "SUPABASE_JWT_SECRET", secret)
+    monkeypatch.setattr(auth, "_jwks_client", None)
+    token = jwt.encode(
+        {
+            "sub": "user-123",
+            "aud": "authenticated",
+            "iss": "https://other-project.supabase.co/auth/v1",
+        },
+        secret,
+        algorithm="HS256",
+    )
+
+    with pytest.raises(I18nHTTPException) as exc:
+        auth._parse_dashboard_token(f"Bearer {token}", "ag_123")
+
+    assert exc.value.status_code == 401
+    assert exc.value.message_key == "invalid_token"
+
+
+def test_supabase_issuer_derives_from_jwks_url(monkeypatch):
+    monkeypatch.setattr(auth, "SUPABASE_URL", None)
+    monkeypatch.setattr(
+        auth,
+        "SUPABASE_JWT_JWKS_URL",
+        "https://project-ref.supabase.co/auth/v1/.well-known/jwks.json",
+    )
+
+    assert auth._expected_supabase_issuer() == "https://project-ref.supabase.co/auth/v1"
+
+
+def test_supabase_malformed_token_maps_to_invalid_token(monkeypatch):
+    monkeypatch.setattr(auth, "SUPABASE_URL", None)
+    monkeypatch.setattr(auth, "SUPABASE_JWT_JWKS_URL", None)
+    monkeypatch.setattr(auth, "SUPABASE_JWT_SECRET", None)
+    monkeypatch.setattr(auth, "_jwks_client", object())
+
+    with pytest.raises(I18nHTTPException) as exc:
+        auth._parse_dashboard_token("Bearer not-a-jwt", "ag_123")
+
+    assert exc.value.status_code == 401
+    assert exc.value.message_key == "invalid_token"
+
+
+def test_invalid_botcord_jwt_with_jwks_configured_maps_to_invalid_token(monkeypatch):
+    monkeypatch.setattr(auth, "JWT_SECRET", "botcord-test-secret-32-bytes-okx")
+    monkeypatch.setattr(auth, "SUPABASE_URL", None)
+    monkeypatch.setattr(auth, "SUPABASE_JWT_JWKS_URL", None)
+    monkeypatch.setattr(auth, "SUPABASE_JWT_SECRET", None)
+    monkeypatch.setattr(auth, "_jwks_client", object())
+    token = jwt.encode(
+        {"agent_id": "ag_123", "iss": "botcord"},
+        "wrong-botcord-test-secret-32-okx",
+        algorithm="HS256",
+    )
+
+    with pytest.raises(I18nHTTPException) as exc:
+        auth._parse_dashboard_token(f"Bearer {token}", "ag_123")
+
+    assert exc.value.status_code == 401
+    assert exc.value.message_key == "invalid_token"
+
+
+def test_supabase_jwks_client_error_maps_to_invalid_token(monkeypatch):
+    class FailingJwksClient:
+        def get_signing_key_from_jwt(self, token: str):
+            raise PyJWKClientError("missing kid")
+
+    monkeypatch.setattr(auth, "SUPABASE_URL", None)
+    monkeypatch.setattr(auth, "SUPABASE_JWT_JWKS_URL", None)
+    monkeypatch.setattr(auth, "SUPABASE_JWT_SECRET", None)
+    monkeypatch.setattr(auth, "_jwks_client", FailingJwksClient())
+    token = _unsigned_token({"alg": "RS256"}, {"sub": "user-123", "aud": "authenticated"})
+
+    with pytest.raises(I18nHTTPException) as exc:
+        auth._parse_dashboard_token(f"Bearer {token}", "ag_123")
+
+    assert exc.value.status_code == 401
+    assert exc.value.message_key == "invalid_token"
+
+
+def test_supabase_hs256_missing_sub_still_invalid(monkeypatch):
+    secret = "test-supabase-secret-32-bytes-ok"
+    monkeypatch.setattr(auth, "SUPABASE_URL", None)
+    monkeypatch.setattr(auth, "SUPABASE_JWT_JWKS_URL", None)
+    monkeypatch.setattr(auth, "SUPABASE_JWT_SECRET", secret)
+    monkeypatch.setattr(auth, "_jwks_client", None)
+    token = jwt.encode(
+        {"aud": "authenticated"},
+        secret,
+        algorithm="HS256",
+    )
+
+    with pytest.raises(jwt.InvalidTokenError, match="Missing sub claim"):
+        auth.verify_supabase_token(token)


### PR DESCRIPTION
## Summary
- normalize malformed/no-kid Supabase JWT and JWKS client errors to 401 invalid_token instead of bubbling as production 500s
- route HS256 Supabase tokens through SUPABASE_JWT_SECRET even when JWKS is configured
- validate Supabase issuer for HS256 and RS/ES tokens when configured
- add focused hub auth regressions

## Production issue
- /hub/inbox verify_supabase_token raised PyJWKClientError: Unable to find a signing key that matches None
- Expected behavior is 401 invalid_token for invalid/stale/no-kid tokens

## Verification
- backend/.venv/bin/python -m pytest backend/tests/test_hub_auth.py -q
- git diff --check

Code Reviewer: No findings.