### PR TITLE
fix: bind device reconnect install tickets

### DIFF
--- a/backend/hub/routers/daemon_control.py
+++ b/backend/hub/routers/daemon_control.py
@@ -279,12 +279,14 @@ _BACKGROUND_CLEANUPS: set[asyncio.Task] = set()
 
 class _InstallTicketRequest(BaseModel):
     label: str | None = Field(default=None, max_length=64)
+    daemon_instance_id: str | None = Field(default=None, max_length=32)
 
 
 class _InstallTicketResponse(BaseModel):
     install_token: str
     expires_in: int
     expires_at: datetime.datetime
+    daemon_instance_id: str | None = None
 
 
 @router.post("/daemon/auth/install-ticket", response_model=_InstallTicketResponse)
@@ -300,12 +302,33 @@ async def issue_install_ticket(
         if isinstance(body.label, str) and body.label.strip()
         else None
     )
+    daemon_instance_id = (
+        body.daemon_instance_id.strip()
+        if isinstance(body.daemon_instance_id, str)
+        and body.daemon_instance_id.strip()
+        else None
+    )
+    if daemon_instance_id:
+        result = await db.execute(
+            select(DaemonInstance).where(DaemonInstance.id == daemon_instance_id)
+        )
+        instance = result.scalar_one_or_none()
+        if instance is None or str(instance.user_id) != str(ctx.user_id):
+            raise HTTPException(status_code=404, detail="daemon_instance_not_found")
+        if instance.revoked_at is not None:
+            raise HTTPException(status_code=409, detail="daemon_revoked")
+        if instance.kind != "local":
+            raise HTTPException(status_code=400, detail="daemon_not_local")
+        if label is None:
+            label = instance.label
+
     row = DaemonInstallTicket(
         id=generate_daemon_install_ticket_id(),
         user_id=ctx.user_id,
         token_hash=_hash_install_token(install_token),
         label=label,
         expires_at=expires_at,
+        daemon_instance_id=daemon_instance_id,
     )
     db.add(row)
     await db.commit()
@@ -313,6 +336,7 @@ async def issue_install_ticket(
         install_token=install_token,
         expires_in=DAEMON_INSTALL_TICKET_TTL_SECONDS,
         expires_at=expires_at,
+        daemon_instance_id=daemon_instance_id,
     )
 
 
@@ -344,7 +368,7 @@ async def redeem_install_token(
         if isinstance(body.label, str) and body.label.strip()
         else row.label
     )
-    requested_daemon_id = (
+    requested_daemon_id = row.daemon_instance_id or (
         body.daemon_instance_id.strip()
         if isinstance(body.daemon_instance_id, str) and body.daemon_instance_id.strip()
         else None

--- a/backend/tests/test_app/test_daemon_control.py
+++ b/backend/tests/test_app/test_daemon_control.py
@@ -314,6 +314,64 @@ async def test_install_ticket_can_reauthorize_existing_daemon_instance(
 
 
 @pytest.mark.asyncio
+async def test_install_ticket_can_be_bound_to_existing_daemon_instance(
+    client: AsyncClient, seed_user, db_session: AsyncSession
+):
+    bundle = await _provision_instance_via_device_code(
+        client, seed_user, label="MacBook"
+    )
+    instance_id = bundle["daemon_instance_id"]
+    old_refresh = bundle["refresh_token"]
+    other_bundle = await _provision_instance_via_device_code(
+        client, seed_user, label="Other MacBook"
+    )
+
+    r = await client.post(
+        "/daemon/auth/install-ticket",
+        json={"daemon_instance_id": instance_id, "label": "MacBook Reloaded"},
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert r.status_code == 200, r.text
+    issued = r.json()
+    assert issued["install_token"].startswith("dit_")
+    assert issued["daemon_instance_id"] == instance_id
+
+    # The daemon running the install command may have no local user-auth file,
+    # or it may still have a stale auth file for another local device. The
+    # ticket-bound target wins either way.
+    r = await client.post(
+        "/daemon/auth/install-token",
+        json={
+            "install_token": issued["install_token"],
+            "daemon_instance_id": other_bundle["daemon_instance_id"],
+        },
+    )
+    assert r.status_code == 200, r.text
+    rebound = r.json()
+    assert rebound["daemon_instance_id"] == instance_id
+    assert rebound["refresh_token"].startswith("drt_")
+    assert rebound["refresh_token"] != old_refresh
+
+    from sqlalchemy import select
+
+    res = await db_session.execute(
+        select(DaemonInstance).where(DaemonInstance.id == instance_id)
+    )
+    inst = res.scalar_one()
+    assert inst.label == "MacBook Reloaded"
+
+    res = await db_session.execute(
+        select(DaemonInstallTicket).where(
+            DaemonInstallTicket.token_hash
+            == hashlib.sha256(issued["install_token"].encode("utf-8")).hexdigest()
+        )
+    )
+    ticket = res.scalar_one()
+    assert ticket.consumed_at is not None
+    assert ticket.daemon_instance_id == instance_id
+
+
+@pytest.mark.asyncio
 async def test_install_ticket_requires_user_auth(client: AsyncClient):
     r = await client.post("/daemon/auth/install-ticket", json={})
     assert r.status_code == 401

--- a/frontend/src/app/api/daemon/auth/install-ticket/route.ts
+++ b/frontend/src/app/api/daemon/auth/install-ticket/route.ts
@@ -1,23 +1,28 @@
 /**
- * [INPUT]: Supabase user session, optional JSON { label }
+ * [INPUT]: Supabase user session, optional JSON { label, daemon_instance_id }
  * [OUTPUT]: POST /api/daemon/auth/install-ticket — proxies to Hub /daemon/auth/install-ticket
  * [POS]: BFF endpoint for non-interactive daemon install command generation
  * [PROTOCOL]: update header on changes
  */
 
-import { NextResponse } from "next/server";
 import { proxyDaemon } from "../../_lib/proxy";
 
 export async function POST(req: Request) {
-  let body: { label?: string } = {};
+  let body: { label?: string; daemon_instance_id?: string } = {};
   try {
     body = await req.json();
   } catch {
     body = {};
   }
-  const payload: { label?: string } = {};
+  const payload: { label?: string; daemon_instance_id?: string } = {};
   if (typeof body.label === "string" && body.label.trim()) {
     payload.label = body.label.trim();
+  }
+  if (
+    typeof body.daemon_instance_id === "string" &&
+    body.daemon_instance_id.trim()
+  ) {
+    payload.daemon_instance_id = body.daemon_instance_id.trim();
   }
   return proxyDaemon("/daemon/auth/install-ticket", {
     method: "POST",

--- a/frontend/src/components/daemon/DaemonInstallCommand.tsx
+++ b/frontend/src/components/daemon/DaemonInstallCommand.tsx
@@ -49,6 +49,8 @@ export interface DaemonInstallCommandLabels {
 
 interface DaemonInstallCommandProps {
   labels: DaemonInstallCommandLabels;
+  /** Bind the generated install ticket to an existing daemon instance. */
+  targetDaemonId?: string;
   /** Optional outer-state spinner — combined with internal token-loading state. */
   busy?: boolean;
   /** Optional callback fired in addition to refreshing the install token. */
@@ -57,6 +59,7 @@ interface DaemonInstallCommandProps {
 
 export default function DaemonInstallCommand({
   labels,
+  targetDaemonId,
   busy,
   onRefresh,
 }: DaemonInstallCommandProps) {
@@ -74,9 +77,10 @@ export default function DaemonInstallCommand({
         copyTimerRef.current = null;
       }
     };
-    // Run once on mount — manual refresh handles retries.
+    // Refresh when switching from a generic install command to a device-bound
+    // reconnect command. Manual refresh handles token retries.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [targetDaemonId]);
 
   async function refreshInstallCommand(): Promise<void> {
     setTokenLoading(true);
@@ -85,7 +89,9 @@ export default function DaemonInstallCommand({
       const res = await apiFetch("/daemon/auth/install-ticket", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
+        body: JSON.stringify({
+          ...(targetDaemonId ? { daemon_instance_id: targetDaemonId } : {}),
+        }),
       });
       if (!res.ok) {
         throw new Error(await res.text());

--- a/frontend/src/components/dashboard/DeviceDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/DeviceDetailDrawer.tsx
@@ -389,9 +389,10 @@ export default function DeviceDetailDrawer() {
         {showInstall ? (
           <div className="mt-3">
             <DaemonInstallCommand
+              targetDaemonId={device.id}
               labels={{
                 title: "重新启动 BotCord Daemon",
-                hint: "在这台同一设备的终端运行；daemon 会使用本机保存的设备 ID 重新连接。",
+                hint: "在这台设备的终端运行；此命令会恢复当前设备 ID，即使本机凭据已丢失。",
                 copy: "复制",
                 copied: "已复制",
                 refresh: "刷新",

--- a/frontend/src/components/dashboard/sidebar/DeviceSettingsModal.tsx
+++ b/frontend/src/components/dashboard/sidebar/DeviceSettingsModal.tsx
@@ -170,11 +170,12 @@ export default function DeviceSettingsModal({
             {showInstall && (
               <div className="mt-2">
                 <DaemonInstallCommand
+                  targetDaemonId={daemonId}
                   labels={{
                     title: locale === "zh" ? "重新启动 BotCord Daemon" : "Restart BotCord Daemon",
                     hint: locale === "zh"
-                      ? "在这台同一设备的终端运行；daemon 会使用本机保存的设备 ID 重新连接"
-                      : "Run this in the terminal on this same device; the daemon will reconnect using the device ID saved locally.",
+                      ? "在这台设备的终端运行；此命令会恢复当前设备 ID，即使本机凭据已丢失。"
+                      : "Run this in the terminal on this device; this command restores this device ID even if local credentials are missing.",
                     copy: locale === "zh" ? "复制" : "Copy",
                     copied: locale === "zh" ? "已复制" : "Copied",
                     refresh: locale === "zh" ? "刷新" : "Refresh",


### PR DESCRIPTION
## Summary
- Allow daemon install tickets to be bound to an existing local daemon instance so a reconnect command can restore that exact device ID without local credentials.
- Forward `daemon_instance_id` through the dashboard BFF and have device restart command panels request device-bound tickets.
- Keep the copied shell command token-only; the daemon ID stays bound server-side to the one-time ticket.

## Verification
- `cd backend && uv run pytest tests/test_app/test_daemon_control.py -k 'install_ticket'`
- `cd frontend && NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key npm run build`

## Risk / rollout
- Existing generic add-device install tickets remain unchanged when no target daemon ID is provided.
- Device-bound tickets only restore non-revoked local daemon instances owned by the requesting user.