### PR TITLE
fix: honor transitive bot ownership in human room join & member listing

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -3268,6 +3268,22 @@ async def get_room_members(
                 )
                 if mem.scalar_one_or_none() is not None:
                     is_member = True
+
+            # Transitive visibility: the viewer may not be a member directly,
+            # but a bot they own can be (e.g. the bot owns/joined the room).
+            # Mirror the rest of the BFF, which honors this relationship.
+            if not is_member:
+                owned_agent_ids = await load_owned_agent_ids(db, user.id)
+                if owned_agent_ids:
+                    owned_mem = await db.execute(
+                        select(RoomMember.agent_id).where(
+                            RoomMember.room_id == room_id,
+                            RoomMember.participant_type == ParticipantType.agent,
+                            RoomMember.agent_id.in_(owned_agent_ids),
+                        )
+                    )
+                    if owned_mem.first() is not None:
+                        is_member = True
         except Exception:
             pass
 

--- a/backend/app/routers/humans.py
+++ b/backend/app/routers/humans.py
@@ -24,7 +24,12 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import RequestContext, require_user
-from app.auth_room import effective_human_can_invite, effective_human_room_role, load_owned_agent_ids
+from app.auth_room import (
+    effective_human_can_invite,
+    effective_human_room_role,
+    load_owned_agent_ids,
+    viewer_can_admin_room,
+)
 from app.routers.dashboard import _build_rooms_from_sql
 from hub.database import get_db
 from hub.enums import (
@@ -909,7 +914,11 @@ async def join_room_as_human(
     if existing_member is not None:
         raise HTTPException(status_code=409, detail="Already a member")
 
-    if (
+    # Owners/admins (including transitively, via a bot owned by the same user)
+    # may seat their Human identity in any room regardless of visibility /
+    # join_policy — mirrors the rest of the BFF, which honors this relationship.
+    can_admin = await viewer_can_admin_room(db, ctx, room)
+    if can_admin is None and (
         room.visibility != RoomVisibility.public
         or room.join_policy != RoomJoinPolicy.open
     ):
@@ -922,7 +931,9 @@ async def join_room_as_human(
         is_owner_self_seat = (
             room.owner_type == ParticipantType.human and room.owner_id == me
         )
-        if not is_owner_self_seat:
+        # Owners/admins (incl. via an owned bot) are not subscribers — let them
+        # seat their Human identity in their own subscription-gated room.
+        if not is_owner_self_seat and can_admin is None:
             raise HTTPException(
                 status_code=403,
                 detail="subscription-gated rooms do not yet support human members",

--- a/backend/tests/test_app/test_app_dashboard_rooms.py
+++ b/backend/tests/test_app/test_app_dashboard_rooms.py
@@ -425,3 +425,31 @@ async def test_inbox_basic(client: AsyncClient, seed: dict, db_session: AsyncSes
     )
     assert resp3.status_code == 200
     assert resp3.json()["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_room_members_visible_to_human_owner_via_owned_bot(
+    client: AsyncClient, seed: dict
+):
+    """A Human viewer (no X-Active-Agent) can list members of a private room
+    when a bot they own owns it — transitive ownership, not direct membership."""
+    resp = await client.get(
+        "/api/dashboard/rooms/rm_priv0001/members",
+        headers={"Authorization": f"Bearer {seed['token1']}"},
+    )
+    assert resp.status_code == 200, resp.text
+    member_ids = {m["agent_id"] for m in resp.json()["members"]}
+    assert "ag_owner001" in member_ids
+
+
+@pytest.mark.asyncio
+async def test_room_members_private_hidden_from_stranger(
+    client: AsyncClient, seed: dict
+):
+    """A Human viewer who neither belongs to nor owns the room sees the private
+    room masked as 404."""
+    resp = await client.get(
+        "/api/dashboard/rooms/rm_priv0001/members",
+        headers={"Authorization": f"Bearer {seed['token2']}"},
+    )
+    assert resp.status_code == 404

--- a/backend/tests/test_app/test_app_humans.py
+++ b/backend/tests/test_app/test_app_humans.py
@@ -293,6 +293,92 @@ async def test_human_member_of_room_owned_by_their_agent_sees_owner_role(
 
 
 @pytest.mark.asyncio
+async def test_human_can_join_room_owned_by_their_agent(
+    client, seed, db_session: AsyncSession
+):
+    """A Human may self-join a private/invite-only room when a bot they own is
+    its owner — transitive ownership bypasses the public+open self-join gate."""
+    agent = Agent(
+        agent_id="ag_alice00099",
+        display_name="Alice Bot",
+        message_policy=MessagePolicy.open,
+        user_id=seed["user_id"],
+    )
+    room = Room(
+        room_id="rm_agent_owned",
+        name="Agent Den",
+        owner_id="ag_alice00099",
+        owner_type=ParticipantType.agent,
+        visibility=RoomVisibility.private,
+        join_policy=RoomJoinPolicy.invite_only,
+    )
+    db_session.add_all([agent, room])
+    await db_session.flush()
+    db_session.add(
+        RoomMember(
+            room_id="rm_agent_owned",
+            agent_id="ag_alice00099",
+            participant_type=ParticipantType.agent,
+            role=RoomRole.owner,
+        )
+    )
+    await db_session.commit()
+
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    resp = await client.post("/api/humans/me/rooms/rm_agent_owned/join", headers=headers)
+    assert resp.status_code == 201, resp.text
+
+    seat = await db_session.execute(
+        select(RoomMember).where(
+            RoomMember.room_id == "rm_agent_owned",
+            RoomMember.agent_id == seed["human_id"],
+            RoomMember.participant_type == ParticipantType.human,
+        )
+    )
+    assert seat.scalar_one_or_none() is not None
+
+
+@pytest.mark.asyncio
+async def test_human_cannot_join_private_room_they_do_not_own(
+    client, seed, db_session: AsyncSession
+):
+    """Without any owned identity in the room, the public+open gate still
+    applies — a private/invite-only room rejects the self-join."""
+    other_agent = Agent(
+        agent_id="ag_stranger99",
+        display_name="Stranger Bot",
+        message_policy=MessagePolicy.open,
+        user_id=uuid.uuid4(),
+    )
+    room = Room(
+        room_id="rm_stranger_owned",
+        name="Stranger Den",
+        owner_id="ag_stranger99",
+        owner_type=ParticipantType.agent,
+        visibility=RoomVisibility.private,
+        join_policy=RoomJoinPolicy.invite_only,
+    )
+    db_session.add_all([other_agent, room])
+    await db_session.flush()
+    db_session.add(
+        RoomMember(
+            room_id="rm_stranger_owned",
+            agent_id="ag_stranger99",
+            participant_type=ParticipantType.agent,
+            role=RoomRole.owner,
+        )
+    )
+    await db_session.commit()
+
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    resp = await client.post(
+        "/api/humans/me/rooms/rm_stranger_owned/join", headers=headers
+    )
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "self_join_public_open_only"
+
+
+@pytest.mark.asyncio
 async def test_human_effective_role_uses_highest_owned_bot_role(
     client, seed, db_session: AsyncSession
 ):


### PR DESCRIPTION
## 问题

Human 点击「加入」自己 bot 拥有的群失败,报 `self_join_public_open_only`;查成员也失败(前端 fallback 到 public 接口报 `Room not found`)。

## 根因

BFF 早有一套「传递性 bot 所有权」语义(`app/auth_room.py` 的 `viewer_can_admin_room` / `effective_human_room_role`)——用户拥有的 bot 是房间 owner 时,用户继承 owner 角色。房间改设置/发消息/邀请都认这套。但 `join_room_as_human` 和 `get_room_members` 各自手写了死板判断,**唯独漏了这层关系**,导致 bot-owner 掉进缝里。

## 改动

- `app/routers/humans.py` — `join_room_as_human`:public+open 门禁(及订阅门禁)前先查 `viewer_can_admin_room`,owner/admin(含经 bot 传递)直接放行。
- `app/routers/dashboard.py` — `get_room_members`:`is_member` 增加「名下任一 bot 是房间成员」判断。
- 测试:`test_app_humans.py` +2、`test_app_dashboard_rooms.py` +2(正/负向各覆盖)。

前端无需改动——它本就先调认证版再 fallback,后端修好后不再走到报错的 public 路径。

## 验证

`uv run pytest tests/test_app/test_app_humans.py tests/test_app/test_app_dashboard_rooms.py tests/test_app/test_human_owner_subscription.py tests/test_app/test_app_subscriptions.py tests/test_policy_helpers.py` 全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)