### PR TITLE
feat(backend): same-owner bypass for direct admission

### DIFF
--- a/backend/hub/policy.py
+++ b/backend/hub/policy.py
@@ -9,6 +9,7 @@
 
 import datetime
 import json
+import uuid as _uuid
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -24,7 +25,7 @@ from hub.enums import (
     RoomInvitePolicy,
 )
 from hub.i18n import I18nHTTPException
-from hub.models import Agent, AgentRoomPolicyOverride, Block, Contact, RoomMember
+from hub.models import Agent, AgentRoomPolicyOverride, Block, Contact, RoomMember, User
 
 
 @dataclass(frozen=True)
@@ -89,6 +90,38 @@ async def _shares_room(
         )
     )
     return result.first() is not None
+
+
+async def _owning_user_id(db: AsyncSession, principal: Principal) -> _uuid.UUID | None:
+    """Resolve the human user who owns a principal, or None if unowned.
+
+    Agents map through ``Agent.user_id`` (NULL until claimed); humans map
+    through ``User.human_id`` to their own ``User.id``."""
+    if principal.type == ParticipantType.agent:
+        return await db.scalar(
+            select(Agent.user_id).where(Agent.agent_id == principal.id)
+        )
+    if principal.type == ParticipantType.human:
+        return await db.scalar(
+            select(User.id).where(User.human_id == principal.id)
+        )
+    return None
+
+
+async def _same_owner(
+    db: AsyncSession,
+    *,
+    receiver: Agent,
+    sender: Principal,
+) -> bool:
+    """True iff sender and receiver belong to the same human owner. Lets a
+    user's own agents (and the user themselves) reach each other without a
+    contacts edge. Unowned principals (``user_id`` NULL) never match — two
+    unclaimed agents are not implicitly related."""
+    if receiver.user_id is None:
+        return False
+    sender_owner = await _owning_user_id(db, sender)
+    return sender_owner is not None and sender_owner == receiver.user_id
 
 
 def _effective_contact_policy(agent: Agent) -> ContactPolicy:
@@ -161,6 +194,8 @@ async def check_direct_admission(
     if policy == ContactPolicy.contacts_only:
         if await _is_contact(db, owner_id=receiver.agent_id, peer=sender):
             return
+        if await _same_owner(db, receiver=receiver, sender=sender):
+            return
         if allow_same_room_bypass and await _shares_room(
             db, receiver_agent_id=receiver.agent_id, sender=sender
         ):
@@ -169,6 +204,8 @@ async def check_direct_admission(
     if policy == ContactPolicy.whitelist:
         # Reuse contacts as the whitelist source — see design doc §8.1.
         if await _is_contact(db, owner_id=receiver.agent_id, peer=sender):
+            return
+        if await _same_owner(db, receiver=receiver, sender=sender):
             return
         raise I18nHTTPException(status_code=403, message_key="not_in_whitelist")
     if policy == ContactPolicy.closed:

--- a/backend/tests/test_policy_helpers.py
+++ b/backend/tests/test_policy_helpers.py
@@ -27,7 +27,9 @@ from hub.enums import (
     RoomInvitePolicy,
 )
 from hub.i18n import I18nHTTPException
-from hub.models import Agent, AgentRoomPolicyOverride, Base, Block, Contact
+import uuid as _uuid
+
+from hub.models import Agent, AgentRoomPolicyOverride, Base, Block, Contact, User
 from hub.policy import (
     Principal,
     check_direct_admission,
@@ -208,6 +210,93 @@ async def test_direct_allow_human_sender_off(session):
     with pytest.raises(I18nHTTPException) as exc:
         await check_direct_admission(session, sender=_human_principal(), receiver=receiver)
     assert exc.value.message_key == "human_senders_disabled"
+
+
+# ---------------------------------------------------------------------------
+# Same-owner bypass — a user's own agents (and the user) reach each other
+# without a contacts edge.
+# ---------------------------------------------------------------------------
+
+
+def _owned_sender(agent_id: str, user_id: _uuid.UUID) -> Agent:
+    return Agent(
+        agent_id=agent_id,
+        display_name="Sender",
+        bio="x",
+        message_policy=MessagePolicy.contacts_only,
+        contact_policy=ContactPolicy.contacts_only,
+        room_invite_policy=RoomInvitePolicy.contacts_only,
+        default_attention=AttentionMode.always,
+        attention_keywords="[]",
+        user_id=user_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_direct_same_owner_agent_bypasses_contacts_only(session):
+    owner = _uuid.uuid4()
+    receiver = _agent(contact_policy=ContactPolicy.contacts_only)
+    receiver.user_id = owner
+    sender = _owned_sender("ag_sender", owner)
+    await _add(session, receiver, sender)
+    # No contacts edge, not co-members — same owner alone admits the send.
+    await check_direct_admission(session, sender=_agent_principal(), receiver=receiver)
+
+
+@pytest.mark.asyncio
+async def test_direct_different_owner_agent_still_blocked(session):
+    receiver = _agent(contact_policy=ContactPolicy.contacts_only)
+    receiver.user_id = _uuid.uuid4()
+    sender = _owned_sender("ag_sender", _uuid.uuid4())
+    await _add(session, receiver, sender)
+    with pytest.raises(I18nHTTPException) as exc:
+        await check_direct_admission(session, sender=_agent_principal(), receiver=receiver)
+    assert exc.value.message_key == "not_in_contacts"
+
+
+@pytest.mark.asyncio
+async def test_direct_unclaimed_agents_not_implicitly_related(session):
+    """Two agents with NULL user_id must not be treated as same-owner."""
+    receiver = _agent(contact_policy=ContactPolicy.contacts_only)  # user_id None
+    sender = Agent(
+        agent_id="ag_sender",
+        display_name="Sender",
+        bio="x",
+        message_policy=MessagePolicy.contacts_only,
+        contact_policy=ContactPolicy.contacts_only,
+        room_invite_policy=RoomInvitePolicy.contacts_only,
+        default_attention=AttentionMode.always,
+        attention_keywords="[]",
+    )  # user_id None
+    await _add(session, receiver, sender)
+    with pytest.raises(I18nHTTPException) as exc:
+        await check_direct_admission(session, sender=_agent_principal(), receiver=receiver)
+    assert exc.value.message_key == "not_in_contacts"
+
+
+@pytest.mark.asyncio
+async def test_direct_owner_human_reaches_own_agent(session):
+    owner = _uuid.uuid4()
+    receiver = _agent(contact_policy=ContactPolicy.contacts_only)
+    receiver.user_id = owner
+    user = User(
+        id=owner,
+        display_name="Owner",
+        supabase_user_id=_uuid.uuid4(),
+        human_id="hu_sender",
+    )
+    await _add(session, receiver, user)
+    await check_direct_admission(session, sender=_human_principal(), receiver=receiver)
+
+
+@pytest.mark.asyncio
+async def test_direct_same_owner_bypasses_whitelist(session):
+    owner = _uuid.uuid4()
+    receiver = _agent(contact_policy=ContactPolicy.whitelist)
+    receiver.user_id = owner
+    sender = _owned_sender("ag_sender", owner)
+    await _add(session, receiver, sender)
+    await check_direct_admission(session, sender=_agent_principal(), receiver=receiver)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 问题

自己创建的多个 bot 之间、以及 owner 本人发给自己的 bot,在 receiver 保持默认 `contacts_only` 策略时会被拒(`NOT_IN_CONTACTS`)。

根因:`check_direct_admission` 只看 receiver 自身的 contacts / blocks / 是否同 room,**完全没有 owner 维度**。要求同一个人名下的资源互相手动加好友,是反直觉的摩擦——类比你自己的多台设备/多个 API key 不需要互加好友。

代码里已有先例承认「准入不该只看 contact」——`allow_same_room_bypass`(同 room 放行)。本 PR 补上同性质的 same-owner bypass。

## 改动

- `_owning_user_id()`:把 Principal 解析成所属 user UUID(`ag_*` 走 `Agent.user_id`,`hu_*` 走 `User.human_id → User.id`)。
- `_same_owner()`:receiver 与 sender 同属一个**非空** owner 时放行。
- 接入 `check_direct_admission` 的 `contacts_only` 和 `whitelist` 分支,与既有 `_shares_room` bypass 并列。

## 边界

- **block 优先**:在函数最前,拉黑自己名下的 bot 仍挡得住。
- **未 claim 不互通**:`user_id` 为 NULL 时返回 False,避免「都是 NULL」误判为同主人。
- **`closed` 未动**:最强的显式封闭策略,保持不放行。

## 测试

- `test_policy_helpers.py` 25 passed(新增 5 个 same-owner 用例:agent↔agent 放行、不同 owner 仍挡、未 claim 不互通、human→自己 bot、whitelist 放行)
- `test_contacts.py` + `test_contact_requests.py` + `test_room.py` 172 passed / 1 skipped,无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)