### PR TITLE
feat: add runtime error diagnostics

### DIFF
--- a/packages/daemon/src/__tests__/debug-runtime-error-cli.test.ts
+++ b/packages/daemon/src/__tests__/debug-runtime-error-cli.test.ts
@@ -1,0 +1,186 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { transcriptFilePath } from "../gateway/index.js";
+
+describe("debug runtime-error CLI", () => {
+  const tempDirs: string[] = [];
+  const originalArgv = process.argv;
+  const originalHome = process.env.HOME;
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    process.argv = originalArgv;
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    for (const dir of tempDirs.splice(0)) {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("prints runtime failure details selected by error ref", async () => {
+    const home = await mkdtemp(path.join(tmpdir(), "botcord-debug-runtime-error-"));
+    tempDirs.push(home);
+    process.env.HOME = home;
+
+    const file = transcriptFilePath(
+      path.join(home, ".botcord", "agents"),
+      "ag_1",
+      "rm_1",
+      "tp_1",
+    );
+    await mkdir(path.dirname(file), { recursive: true });
+    await writeFile(
+      file,
+      `${JSON.stringify({
+        ts: "2026-05-31T00:00:00.000Z",
+        kind: "turn_error",
+        agentId: "ag_1",
+        roomId: "rm_1",
+        topicId: "tp_1",
+        turnId: "turn_2",
+        errorRef: "err_abc",
+        runtime: "codex",
+        error: "codex failed",
+        runtimeFailure: {
+          agent_id: "ag_1",
+          room_id: "rm_1",
+          topic_id: "tp_1",
+          turn_id: "turn_2",
+          runtime: "codex",
+          error_message: "codex failed",
+        },
+      })}\n`,
+    );
+
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("unexpected process.exit");
+    }) as typeof process.exit);
+
+    process.argv = [
+      process.execPath,
+      "botcord-daemon",
+      "debug",
+      "runtime-error",
+      "--agent",
+      "ag_1",
+      "--room",
+      "rm_1",
+      "--topic",
+      "tp_1",
+      "--error-ref",
+      "err_abc",
+    ];
+
+    await import("../index.js");
+
+    expect(exit).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(log.mock.calls[0]![0] as string)).toMatchObject({
+      turn_id: "turn_2",
+      error_ref: "err_abc",
+      runtime: "codex",
+      message: "codex failed",
+      failure: {
+        turn_id: "turn_2",
+        error_message: "codex failed",
+      },
+    });
+  });
+
+  it("prints runtime failure details selected by turn id", async () => {
+    const home = await mkdtemp(path.join(tmpdir(), "botcord-debug-runtime-error-"));
+    tempDirs.push(home);
+    process.env.HOME = home;
+
+    const file = transcriptFilePath(
+      path.join(home, ".botcord", "agents"),
+      "ag_1",
+      "rm_1",
+      "tp_1",
+    );
+    await mkdir(path.dirname(file), { recursive: true });
+    await writeFile(
+      file,
+      `${JSON.stringify({
+        ts: "2026-05-31T00:00:00.000Z",
+        kind: "turn_error",
+        agentId: "ag_1",
+        roomId: "rm_1",
+        topicId: "tp_1",
+        turnId: "turn_1",
+        errorRef: "err_decoy",
+        runtime: "codex",
+        error: "decoy failure",
+        runtimeFailure: {
+          agent_id: "ag_1",
+          room_id: "rm_1",
+          topic_id: "tp_1",
+          turn_id: "turn_1",
+          runtime: "codex",
+          error_message: "decoy failure",
+        },
+      })}\n${JSON.stringify({
+        ts: "2026-05-31T00:00:01.000Z",
+        kind: "turn_error",
+        agentId: "ag_1",
+        roomId: "rm_1",
+        topicId: "tp_1",
+        turnId: "turn_2",
+        errorRef: "err_abc",
+        runtime: "codex",
+        error: "codex failed",
+        runtimeFailure: {
+          agent_id: "ag_1",
+          room_id: "rm_1",
+          topic_id: "tp_1",
+          turn_id: "turn_2",
+          runtime: "codex",
+          error_message: "codex failed",
+        },
+      })}\n`,
+    );
+
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("unexpected process.exit");
+    }) as typeof process.exit);
+
+    process.argv = [
+      process.execPath,
+      "botcord-daemon",
+      "debug",
+      "runtime-error",
+      "--agent",
+      "ag_1",
+      "--room",
+      "rm_1",
+      "--topic",
+      "tp_1",
+      "--turn-id",
+      "turn_2",
+    ];
+
+    await import("../index.js");
+
+    expect(exit).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(log.mock.calls[0]![0] as string)).toMatchObject({
+      turn_id: "turn_2",
+      error_ref: "err_abc",
+      runtime: "codex",
+      message: "codex failed",
+      failure: {
+        turn_id: "turn_2",
+        error_message: "codex failed",
+      },
+    });
+  });
+});

--- a/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
+++ b/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
@@ -223,6 +223,36 @@ describe("createBotCordChannel — send()", () => {
     expect(client.sendMessage).not.toHaveBeenCalled();
     expect(result.providerMessageId).toBe("m_provider_typed");
   });
+
+  it("forwards runtime diagnostic error refs to BotCord typed error envelopes", async () => {
+    const client = makeClient();
+    const channel = createBotCordChannel({
+      id: "botcord-main",
+      accountId: "ag_self",
+      agentId: "ag_self",
+      client,
+    });
+    await channel.send({
+      message: {
+        channel: "botcord",
+        accountId: "ag_self",
+        conversationId: "rm_group_a",
+        threadId: "tp_42",
+        replyTo: "env_source",
+        type: "error",
+        text: "Runtime error: boom",
+        errorRef: "err_abc123",
+      },
+      log: silentLog,
+    });
+
+    expect(client.sendTypedMessage).toHaveBeenCalledWith("rm_group_a", "error", "Runtime error: boom", {
+      topic: "tp_42",
+      replyTo: "env_source",
+      errorRef: "err_abc123",
+    });
+    expect(client.sendMessage).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
+++ b/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
@@ -20,6 +20,7 @@ import type {
   StreamBlock,
 } from "../types.js";
 import type { GatewayLogger } from "../log.js";
+import type { TranscriptRecord, TranscriptWriter } from "../transcript.js";
 
 function silentLogger(): GatewayLogger {
   return { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
@@ -159,6 +160,15 @@ class FakeRuntime implements RuntimeAdapter {
   }
 }
 
+class CaptureTranscript implements TranscriptWriter {
+  readonly enabled = true;
+  readonly rootDir = "";
+  readonly records: TranscriptRecord[] = [];
+  write(rec: TranscriptRecord): void {
+    this.records.push(rec);
+  }
+}
+
 function makeMessage(partial: Partial<GatewayInboundMessage> = {}): GatewayInboundMessage {
   return {
     id: partial.id ?? "hub_msg_abc",
@@ -245,6 +255,7 @@ describe("Dispatcher", () => {
     runtimeAuthFailureThreshold?: number;
     runtimeAuthFailureCooldownMs?: number;
     buildRuntimeRecoveryContext?: (message: GatewayInboundMessage) => Promise<string | null> | string | null;
+    transcript?: TranscriptWriter;
   }) {
     const { store, dir } = await makeStore();
     tempDirs.push(dir);
@@ -260,6 +271,7 @@ describe("Dispatcher", () => {
       runtimeAuthFailureThreshold: args.runtimeAuthFailureThreshold,
       runtimeAuthFailureCooldownMs: args.runtimeAuthFailureCooldownMs,
       buildRuntimeRecoveryContext: args.buildRuntimeRecoveryContext,
+      transcript: args.transcript,
     });
     return { dispatcher, channel, store };
   }
@@ -710,10 +722,15 @@ describe("Dispatcher", () => {
     expect(store.all().length).toBe(0);
   });
 
-  it("runtime empty text with error: sends owner-chat error reply", async () => {
-    const runtime = new FakeRuntime({ reply: "", newSessionId: "", errorText: "missing openclawAgent" });
+  it("runtime empty text with error: sends redacted owner-chat error reply", async () => {
+    const runtime = new FakeRuntime({
+      reply: "",
+      newSessionId: "",
+      errorText: "missing openclawAgent token=abc123 drt_liveSECRET",
+    });
     const channel = new FakeChannel();
-    const { dispatcher } = await scaffold({ channel, runtimeFactory: () => runtime });
+    const transcript = new CaptureTranscript();
+    const { dispatcher } = await scaffold({ channel, runtimeFactory: () => runtime, transcript });
 
     await dispatcher.handle(makeEnvelope({ id: "msg_error" }));
 
@@ -721,6 +738,26 @@ describe("Dispatcher", () => {
     expect(channel.sends[0].message.type).toBe("error");
     expect(channel.sends[0].message.text).toContain("Runtime error");
     expect(channel.sends[0].message.text).toContain("missing openclawAgent");
+    expect(channel.sends[0].message.text).toContain("token=[REDACTED]");
+    expect(channel.sends[0].message.text).toContain("drt_[REDACTED]");
+    expect(channel.sends[0].message.text).not.toContain("abc123");
+    expect(channel.sends[0].message.text).not.toContain("liveSECRET");
+    expect(channel.sends[0].message.errorRef).toMatch(/^err_/);
+    const err = transcript.records.find((r) => r.kind === "turn_error");
+    expect(err).toMatchObject({
+      kind: "turn_error",
+      phase: "runtime",
+      errorRef: channel.sends[0].message.errorRef,
+      runtime: "claude-code",
+      runtimeFailure: expect.objectContaining({
+        agent_id: "ag_me",
+        room_id: "rm_oc_1",
+        runtime: "claude-code",
+        error_message: "missing openclawAgent token=[REDACTED] drt_[REDACTED]",
+      }),
+    });
+    expect(JSON.stringify(err)).not.toContain("abc123");
+    expect(JSON.stringify(err)).not.toContain("liveSECRET");
   });
 
   it("cancel-previous: prior turn is aborted and does not write session, new turn writes", async () => {
@@ -1520,16 +1557,34 @@ describe("Dispatcher", () => {
     });
   });
 
-  it("runtime throws: sends error reply, does not write session", async () => {
-    const runtime = new FakeRuntime({ throwError: "boom" });
+  it("runtime throws: sends redacted error reply, does not write session", async () => {
+    const runtime = new FakeRuntime({ throwError: "boom Authorization: Bearer secret-token token=abc123" });
     const channel = new FakeChannel();
-    const { dispatcher, store } = await scaffold({ channel, runtimeFactory: () => runtime });
+    const transcript = new CaptureTranscript();
+    const { dispatcher, store } = await scaffold({ channel, runtimeFactory: () => runtime, transcript });
 
     await dispatcher.handle(makeEnvelope({ id: "m1" }));
     expect(channel.sends.length).toBe(1);
     expect(channel.sends[0].message.type).toBe("error");
     expect(channel.sends[0].message.text).toContain("Runtime error");
     expect(channel.sends[0].message.text).toContain("boom");
+    expect(channel.sends[0].message.text).toContain("Authorization: Bearer [REDACTED]");
+    expect(channel.sends[0].message.text).toContain("token=[REDACTED]");
+    expect(channel.sends[0].message.text).not.toContain("secret-token");
+    expect(channel.sends[0].message.text).not.toContain("abc123");
+    expect(channel.sends[0].message.errorRef).toMatch(/^err_/);
+    const err = transcript.records.find((r) => r.kind === "turn_error");
+    expect(err).toMatchObject({
+      kind: "turn_error",
+      phase: "runtime",
+      errorRef: channel.sends[0].message.errorRef,
+      runtimeFailure: expect.objectContaining({
+        error_name: "Error",
+        error_message: "boom Authorization: Bearer [REDACTED] token=[REDACTED]",
+      }),
+    });
+    expect(JSON.stringify(err)).not.toContain("secret-token");
+    expect(JSON.stringify(err)).not.toContain("abc123");
     expect(store.all().length).toBe(0);
   });
 

--- a/packages/daemon/src/gateway/__tests__/runtime-failure.test.ts
+++ b/packages/daemon/src/gateway/__tests__/runtime-failure.test.ts
@@ -1,0 +1,66 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { lookupRuntimeFailureTranscript, sanitizeRuntimeFailureText } from "../runtime-failure.js";
+import { transcriptFilePath } from "../transcript-paths.js";
+
+describe("runtime failure observability", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    for (const dir of tempDirs.splice(0)) {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("finds runtime failures by turn id and error ref while ignoring malformed lines", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "runtime-failure-"));
+    tempDirs.push(root);
+    const file = transcriptFilePath(root, "ag_1", "rm_1", null);
+    await mkdir(path.dirname(file), { recursive: true });
+    await writeFile(
+      file,
+      [
+        "{bad json",
+        JSON.stringify({ kind: "inbound", turnId: "turn_1" }),
+        JSON.stringify({
+          ts: "2026-05-31T00:00:00.000Z",
+          kind: "turn_error",
+          turnId: "turn_2",
+          errorRef: "err_abc",
+          runtime: "codex",
+          error: "codex failed",
+          runtimeFailure: {
+            agent_id: "ag_1",
+            room_id: "rm_1",
+            turn_id: "turn_2",
+            runtime: "codex",
+            error_message: "codex failed",
+          },
+        }),
+      ].join("\n"),
+    );
+
+    expect(lookupRuntimeFailureTranscript({
+      rootDir: root,
+      agentId: "ag_1",
+      roomId: "rm_1",
+      turnId: "turn_2",
+    })?.record.errorRef).toBe("err_abc");
+
+    expect(lookupRuntimeFailureTranscript({
+      rootDir: root,
+      agentId: "ag_1",
+      roomId: "rm_1",
+      errorRef: "err_abc",
+    })?.record.turnId).toBe("turn_2");
+  });
+
+  it("redacts obvious token-like values from captured tails", () => {
+    expect(sanitizeRuntimeFailureText("Authorization: Bearer secret-token token=abc123 drt_live")).toBe(
+      "Authorization: Bearer [REDACTED] token=[REDACTED] drt_[REDACTED]",
+    );
+  });
+});

--- a/packages/daemon/src/gateway/channels/botcord.ts
+++ b/packages/daemon/src/gateway/channels/botcord.ts
@@ -78,7 +78,7 @@ export interface BotCordChannelClient {
     to: string,
     type: "result" | "error",
     text: string,
-    options?: { replyTo?: string; topic?: string; attachments?: MessageAttachment[] },
+    options?: { replyTo?: string; topic?: string; attachments?: MessageAttachment[]; errorRef?: string },
   ): Promise<{ hub_msg_id?: string; message_id?: string } & Record<string, unknown>>;
   getHubUrl(): string;
   onTokenRefresh?: (token: string, expiresAt: number) => void;
@@ -982,9 +982,15 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
     async send(ctx: ChannelSendContext): Promise<ChannelSendResult> {
       const client = ensureClient();
       const { message } = ctx;
-      const options: { replyTo?: string; topic?: string; attachments?: MessageAttachment[] } = {};
+      const options: {
+        replyTo?: string;
+        topic?: string;
+        attachments?: MessageAttachment[];
+        errorRef?: string;
+      } = {};
       if (message.replyTo) options.replyTo = message.replyTo;
       if (message.threadId) options.topic = message.threadId;
+      if (message.errorRef) options.errorRef = message.errorRef;
       const upload = await uploadOutboundAttachments(client, message.attachments ?? [], ctx.log);
       if (upload.attachments.length > 0) options.attachments = upload.attachments;
       const text = rewriteUploadedAttachmentPaths(message.text, upload.replacements);

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -3,6 +3,14 @@ import { realpathSync, statSync } from "node:fs";
 import path from "node:path";
 
 import type { GatewayLogger } from "./log.js";
+import {
+  errorInfo,
+  makeRuntimeErrorRef,
+  safeCommand,
+  sanitizeRuntimeFailureText,
+  tailText,
+  type RuntimeFailureSummary,
+} from "./runtime-failure.js";
 import { looksLikeRuntimeAuthFailure } from "./runtime-errors.js";
 import { resolveRoute } from "./router.js";
 import { sessionKey, type SessionStore } from "./session-store.js";
@@ -1884,26 +1892,12 @@ export class Dispatcher {
       }
 
       if (threw) {
-        const errMsg = threw instanceof Error ? threw.message : String(threw);
-        this.log.error("dispatcher: runtime threw", {
-          agentId: msg.accountId,
-          roomId: msg.conversation.id,
-          topicId: msg.conversation.threadId ?? null,
+        const failure = this.captureRuntimeFailure({
+          msg,
+          route,
           turnId,
-          queueKey,
-          runtime: route.runtime,
-          error: errMsg,
-        });
-        this.transcript.write({
-          ts: nowIso(),
-          kind: "turn_error",
-          turnId,
-          agentId: msg.accountId,
-          roomId: msg.conversation.id,
-          topicId: msg.conversation.threadId ?? null,
-          phase: "runtime",
-          error: errMsg,
-          durationMs: Date.now() - slot.dispatchedAt,
+          startedAt: slot.dispatchedAt,
+          error: threw,
         });
         if (canDeliverRuntimeDiagnostics) {
           await this.sendReply(channel, {
@@ -1912,7 +1906,8 @@ export class Dispatcher {
             conversationId: msg.conversation.id,
             threadId: msg.conversation.threadId ?? null,
             type: "error",
-            text: `⚠️ Runtime error: ${truncate(errMsg, 500)}`,
+            text: `⚠️ Runtime error: ${truncate(failure.safeMessage, 500)} [error_ref: ${failure.errorRef}]`,
+            errorRef: failure.errorRef,
             replyTo: this.providerReplyTo(msg),
             traceId: msg.trace?.id ?? null,
           }, turnId);
@@ -2023,13 +2018,13 @@ export class Dispatcher {
 
       if (!replyText) {
         if (effectiveError) {
-          this.log.warn("dispatcher: runtime returned error without reply text", {
-            agentId: msg.accountId,
-            roomId: msg.conversation.id,
-            topicId: msg.conversation.threadId ?? null,
+          const failure = this.captureRuntimeFailure({
+            msg,
+            route,
             turnId,
-            runtime: route.runtime,
+            startedAt: slot.dispatchedAt,
             error: effectiveError,
+            result,
           });
           if (canDeliverRuntimeDiagnostics) {
             const sendResult = await this.sendReply(channel, {
@@ -2038,7 +2033,8 @@ export class Dispatcher {
               conversationId: msg.conversation.id,
               threadId: msg.conversation.threadId ?? null,
               type: "error",
-              text: `⚠️ Runtime error: ${truncate(effectiveError, 500)}`,
+              text: `⚠️ Runtime error: ${truncate(failure.safeMessage, 500)} [error_ref: ${failure.errorRef}]`,
+              errorRef: failure.errorRef,
               replyTo: this.providerReplyTo(msg),
               traceId: msg.trace?.id ?? null,
             }, turnId);
@@ -2274,6 +2270,84 @@ export class Dispatcher {
     if (args.blocks.length > 0) rec.blocks = args.blocks;
     if (args.finalText.truncated) rec.truncated = { finalText: true };
     this.transcript.write(rec);
+  }
+
+  private captureRuntimeFailure(args: {
+    msg: GatewayInboundMessage;
+    route: GatewayRoute;
+    turnId: string;
+    startedAt: number;
+    error: unknown;
+    result?: RuntimeRunResult;
+  }): { errorRef: string; summary: RuntimeFailureSummary; safeMessage: string } {
+    const info = errorInfo(args.error);
+    const resultFailure = args.result?.runtimeFailure ?? {};
+    const safeMessage =
+      sanitizeRuntimeFailureText(
+        info.error_message || String(args.result?.error ?? "runtime error"),
+        2048,
+      ) || "runtime error";
+    const summary: RuntimeFailureSummary = {
+      agent_id: args.msg.accountId,
+      room_id: args.msg.conversation.id,
+      topic_id: args.msg.conversation.threadId ?? null,
+      turn_id: args.turnId,
+      runtime: args.route.runtime,
+      cwd: typeof resultFailure.cwd === "string" ? resultFailure.cwd : args.route.cwd,
+      command: safeCommand(resultFailure.command ?? null),
+      exit_code: typeof resultFailure.exit_code === "number" ? resultFailure.exit_code : null,
+      signal: typeof resultFailure.signal === "string" ? resultFailure.signal : null,
+      duration_ms:
+        typeof resultFailure.duration_ms === "number"
+          ? resultFailure.duration_ms
+          : Date.now() - args.startedAt,
+      stderr_tail:
+        typeof resultFailure.stderr_tail === "string"
+          ? tailText(sanitizeRuntimeFailureText(resultFailure.stderr_tail))
+          : null,
+      stdout_tail:
+        typeof resultFailure.stdout_tail === "string"
+          ? tailText(sanitizeRuntimeFailureText(resultFailure.stdout_tail))
+          : null,
+      error_name:
+        typeof resultFailure.error_name === "string"
+          ? resultFailure.error_name
+          : info.error_name,
+      error_message:
+        typeof resultFailure.error_message === "string"
+          ? sanitizeRuntimeFailureText(resultFailure.error_message, 2048)
+          : safeMessage,
+    };
+    const errorRef = makeRuntimeErrorRef(summary);
+    this.log.error("dispatcher: runtime failure captured", {
+      errorRef,
+      agentId: summary.agent_id,
+      roomId: summary.room_id,
+      topicId: summary.topic_id ?? null,
+      turnId: summary.turn_id,
+      runtime: summary.runtime,
+      cwd: summary.cwd ?? null,
+      exitCode: summary.exit_code ?? null,
+      signal: summary.signal ?? null,
+      durationMs: summary.duration_ms ?? null,
+      errorName: summary.error_name ?? null,
+      errorMessage: summary.error_message ?? null,
+    });
+    this.transcript.write({
+      ts: nowIso(),
+      kind: "turn_error",
+      turnId: args.turnId,
+      agentId: args.msg.accountId,
+      roomId: args.msg.conversation.id,
+      topicId: args.msg.conversation.threadId ?? null,
+      phase: "runtime",
+      error: safeMessage,
+      durationMs: summary.duration_ms ?? Date.now() - args.startedAt,
+      errorRef,
+      runtime: args.route.runtime,
+      runtimeFailure: summary,
+    });
+    return { errorRef, summary, safeMessage };
   }
 }
 

--- a/packages/daemon/src/gateway/index.ts
+++ b/packages/daemon/src/gateway/index.ts
@@ -34,6 +34,13 @@ export {
   transcriptAgentRoot,
 } from "./transcript-paths.js";
 export {
+  lookupRuntimeFailureTranscript,
+  makeRuntimeErrorRef,
+  sanitizeRuntimeFailureText,
+  type RuntimeFailureSummary,
+  type RuntimeFailureLookupResult,
+} from "./runtime-failure.js";
+export {
   ClaudeCodeAdapter,
   probeClaude,
   resolveClaudeCommand,

--- a/packages/daemon/src/gateway/runtime-failure.ts
+++ b/packages/daemon/src/gateway/runtime-failure.ts
@@ -1,0 +1,156 @@
+import { createHash, randomBytes } from "node:crypto";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+import { transcriptFilePath, transcriptRoomDir } from "./transcript-paths.js";
+
+export const RUNTIME_FAILURE_TAIL_LIMIT = 8 * 1024;
+
+const SECRET_VALUE_PATTERNS: Array<[RegExp, string]> = [
+  [/(Authorization:\s*Bearer\s+)[^\s"']+/gi, "$1[REDACTED]"],
+  [/\b(token|access_token|refresh_token|api_key|apikey|password|secret)=([^\s"']+)/gi, "$1=[REDACTED]"],
+  [/\b(drt_|dit_|gho_|ghp_|sk-)[A-Za-z0-9_-]+/g, "$1[REDACTED]"],
+];
+
+export interface RuntimeFailureSummary {
+  agent_id: string;
+  room_id: string;
+  topic_id?: string | null;
+  turn_id: string;
+  runtime: string;
+  cwd?: string | null;
+  command?: string[] | null;
+  exit_code?: number | null;
+  signal?: string | null;
+  duration_ms?: number | null;
+  stderr_tail?: string | null;
+  stdout_tail?: string | null;
+  error_name?: string | null;
+  error_message?: string | null;
+}
+
+export interface RuntimeFailureLookupResult {
+  file: string;
+  record: {
+    ts?: string;
+    kind: string;
+    turnId?: string;
+    errorRef?: string;
+    runtime?: string;
+    error?: string;
+    runtimeFailure?: RuntimeFailureSummary;
+  };
+}
+
+export function makeRuntimeErrorRef(summary: Partial<RuntimeFailureSummary>): string {
+  const material = JSON.stringify({
+    turn_id: summary.turn_id,
+    runtime: summary.runtime,
+    message: summary.error_message,
+    exit_code: summary.exit_code,
+    nonce: randomBytes(6).toString("hex"),
+  });
+  return "err_" + createHash("sha256").update(material).digest("hex").slice(0, 12);
+}
+
+export function sanitizeRuntimeFailureText(value: string, limit = RUNTIME_FAILURE_TAIL_LIMIT): string {
+  let out = value;
+  for (const [pattern, replacement] of SECRET_VALUE_PATTERNS) {
+    out = out.replace(pattern, replacement);
+  }
+  return tailText(out, limit) ?? "";
+}
+
+export function tailText(value: string | undefined | null, limit = RUNTIME_FAILURE_TAIL_LIMIT): string | null {
+  if (!value) return null;
+  return value.length > limit ? value.slice(-limit) : value;
+}
+
+export function safeCommand(command: string[] | undefined | null): string[] | null {
+  if (!command || command.length === 0) return null;
+  return command.map((part) => sanitizeRuntimeFailureText(part, 512));
+}
+
+export function errorInfo(err: unknown): { error_name: string | null; error_message: string | null } {
+  if (err instanceof Error) {
+    return {
+      error_name: err.name || "Error",
+      error_message: sanitizeRuntimeFailureText(err.message, 2048),
+    };
+  }
+  return {
+    error_name: null,
+    error_message: sanitizeRuntimeFailureText(String(err), 2048),
+  };
+}
+
+export function lookupRuntimeFailureTranscript(args: {
+  rootDir: string;
+  agentId: string;
+  roomId: string;
+  topicId?: string | null;
+  turnId?: string | null;
+  errorRef?: string | null;
+}): RuntimeFailureLookupResult | null {
+  const files = runtimeFailureTranscriptFiles(args.rootDir, args.agentId, args.roomId, args.topicId ?? null);
+  for (const file of files) {
+    const found = scanRuntimeFailureFile(file, args.turnId ?? null, args.errorRef ?? null);
+    if (found) return { file, record: found };
+  }
+  return null;
+}
+
+function runtimeFailureTranscriptFiles(
+  rootDir: string,
+  agentId: string,
+  roomId: string,
+  topicId: string | null,
+): string[] {
+  if (topicId !== null) {
+    const file = transcriptFilePath(rootDir, agentId, roomId, topicId);
+    return existsSync(file) ? [file] : [];
+  }
+  const dir = transcriptRoomDir(rootDir, agentId, roomId);
+  if (!existsSync(dir)) return [];
+  try {
+    return readdirSync(dir)
+      .map((entry) => path.join(dir, entry))
+      .filter((file) => file.endsWith(".jsonl") && isFile(file));
+  } catch {
+    return [];
+  }
+}
+
+function isFile(file: string): boolean {
+  try {
+    return statSync(file).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function scanRuntimeFailureFile(
+  file: string,
+  turnId: string | null,
+  errorRef: string | null,
+): RuntimeFailureLookupResult["record"] | null {
+  if (!existsSync(file)) return null;
+  const raw = readFileSync(file, "utf8");
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!parsed || typeof parsed !== "object") continue;
+    const rec = parsed as RuntimeFailureLookupResult["record"];
+    if (rec.kind !== "turn_error" && rec.kind !== "runtime_failure") continue;
+    if (!rec.errorRef && !rec.runtimeFailure) continue;
+    if (turnId && rec.turnId !== turnId) continue;
+    if (errorRef && rec.errorRef !== errorRef) continue;
+    return rec;
+  }
+  return null;
+}

--- a/packages/daemon/src/gateway/runtimes/ndjson-stream.ts
+++ b/packages/daemon/src/gateway/runtimes/ndjson-stream.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { buildCliEnv } from "../cli-resolver.js";
 import { consoleLogger } from "../log.js";
+import { safeCommand, sanitizeRuntimeFailureText, tailText } from "../runtime-failure.js";
 import type {
   RuntimeAdapter,
   RuntimeProbeResult,
@@ -117,6 +118,7 @@ export abstract class NdjsonStreamAdapter implements RuntimeAdapter {
       argv: args,
     });
 
+    const startedAt = Date.now();
     const child = spawn(binary, args, {
       cwd: opts.cwd,
       env: this.spawnEnv(opts),
@@ -173,9 +175,10 @@ export abstract class NdjsonStreamAdapter implements RuntimeAdapter {
     };
 
     let stderrTail = "";
+    let stdoutTail = "";
     child.stderr?.setEncoding("utf8");
     child.stderr?.on("data", (chunk: string) => {
-      stderrTail = (stderrTail + chunk).slice(-STDERR_TAIL_CAP);
+      stderrTail = sanitizeRuntimeFailureText(stderrTail + chunk);
     });
 
     let seq = 0;
@@ -211,6 +214,7 @@ export abstract class NdjsonStreamAdapter implements RuntimeAdapter {
     };
 
     child.stdout!.on("data", (chunk: string) => {
+      stdoutTail = sanitizeRuntimeFailureText(stdoutTail + chunk);
       stdoutBuf += chunk;
       let idx: number;
       while ((idx = stdoutBuf.indexOf("\n")) !== -1) {
@@ -220,12 +224,13 @@ export abstract class NdjsonStreamAdapter implements RuntimeAdapter {
       }
     });
 
-    let code = 0;
+    let code: number | null = 0;
+    let signal: NodeJS.Signals | null = null;
     try {
-      code = await new Promise<number>((resolve, reject) => {
+      ({ code, signal } = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
         child.on("error", reject);
-        child.on("close", (c) => resolve(c ?? 0));
-      });
+        child.on("close", (c, s) => resolve({ code: c, signal: s }));
+      }));
     } finally {
       opts.signal.removeEventListener("abort", onAbort);
       if (killTimer) clearTimeout(killTimer);
@@ -248,6 +253,21 @@ export abstract class NdjsonStreamAdapter implements RuntimeAdapter {
       newSessionId: state.newSessionId,
       ...(state.costUsd !== undefined ? { costUsd: state.costUsd } : {}),
       ...(state.errorText ? { error: state.errorText } : {}),
+      ...(state.errorText
+        ? {
+            runtimeFailure: {
+              runtime: this.id,
+              cwd: opts.cwd,
+              command: safeCommand([binary, ...args]),
+              exit_code: code,
+              signal,
+              duration_ms: Date.now() - startedAt,
+              stderr_tail: tailText(stderrTail),
+              stdout_tail: tailText(stdoutTail),
+              error_message: sanitizeRuntimeFailureText(state.errorText, 2048),
+            },
+          }
+        : {}),
     };
   }
 }

--- a/packages/daemon/src/gateway/transcript.ts
+++ b/packages/daemon/src/gateway/transcript.ts
@@ -3,6 +3,7 @@ import { homedir } from "node:os";
 import path from "node:path";
 
 import type { GatewayLogger } from "./log.js";
+import type { RuntimeFailureSummary } from "./runtime-failure.js";
 import { transcriptFilePath } from "./transcript-paths.js";
 
 /**
@@ -117,6 +118,9 @@ export interface TurnErrorTranscriptRecord extends TranscriptRecordBase {
   phase: "runtime" | "timeout" | "budget";
   error: string;
   durationMs: number;
+  errorRef?: string;
+  runtime?: string;
+  runtimeFailure?: RuntimeFailureSummary;
 }
 
 export interface AttentionSkippedTranscriptRecord extends TranscriptRecordBase {

--- a/packages/daemon/src/gateway/types.ts
+++ b/packages/daemon/src/gateway/types.ts
@@ -1,4 +1,5 @@
 import type { GatewayLogger } from "./log.js";
+import type { RuntimeFailureSummary } from "./runtime-failure.js";
 import type {
   GatewayInboundEnvelope as CanonicalGatewayInboundEnvelope,
   GatewayInboundMessage as CanonicalGatewayInboundMessage,
@@ -418,6 +419,8 @@ export interface RuntimeRunResult {
   costUsd?: number;
   /** Populated when the runtime reported a hard error. */
   error?: string;
+  /** Safe local-only summary used to correlate owner-visible error refs. */
+  runtimeFailure?: Partial<RuntimeFailureSummary>;
   /**
    * Optional token-count breakdown reported by the runtime. Used by the
    * cloud daemon's ``cloud_run`` settle hook to charge a run against the

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -30,6 +30,7 @@ import {
 import { resolveBootAgents } from "./agent-discovery.js";
 import {
   defaultTranscriptRoot,
+  lookupRuntimeFailureTranscript,
   resolveTranscriptEnabled,
   transcriptAgentRoot,
   transcriptFilePath,
@@ -166,6 +167,10 @@ Commands:
   memory clear [--agent <ag_xxx>]         Wipe all working memory
                                           (--agent required if the daemon runs
                                            more than one; optional otherwise)
+  debug runtime-error --agent <ag_xxx> --room <rm_xxx> [--topic <tp>]
+                      (--turn-id <turnId> | --error-ref <errorRef>) [--json]
+                                          Resolve a local runtime error ref from
+                                          transcript JSONL.
 
 Env:
   BOTCORD_<RUNTIME>_BIN   Override CLI path per runtime (e.g. BOTCORD_CODEX_BIN)
@@ -194,6 +199,7 @@ const BOOLEAN_FLAGS = new Set([
   "h",
   "mentioned",
   "relogin",
+  "yes",
 ]);
 
 /** Flags that may be repeated on the command line; all values are collected. */
@@ -1086,6 +1092,44 @@ function cmdTranscriptPrune(args: ParsedArgs): void {
   console.log(`removed ${removed} rotated transcript file(s)`);
 }
 
+function cmdDebug(args: ParsedArgs): void {
+  if (args.sub !== "runtime-error") {
+    console.error("usage: botcord-daemon debug runtime-error --agent <ag_xxx> --room <rm_xxx> [--topic <tp>] (--turn-id <turnId> | --error-ref <errorRef>) [--json]");
+    process.exit(1);
+  }
+  const agent = transcriptStringFlag(args, "agent");
+  const room = transcriptStringFlag(args, "room");
+  const topic = transcriptStringFlag(args, "topic");
+  const turnId = transcriptStringFlag(args, "turn-id");
+  const errorRef = transcriptStringFlag(args, "error-ref");
+  if (!agent || !room || (!turnId && !errorRef)) {
+    console.error("debug runtime-error requires --agent <ag_xxx> --room <rm_xxx> and --turn-id <turnId> or --error-ref <errorRef>");
+    process.exit(1);
+  }
+  const found = lookupRuntimeFailureTranscript({
+    rootDir: defaultTranscriptRoot(),
+    agentId: agent,
+    roomId: room,
+    topicId: topic,
+    turnId,
+    errorRef,
+  });
+  if (!found) {
+    console.error("no runtime failure found for the supplied selector");
+    process.exit(1);
+  }
+  const summary = {
+    file: found.file,
+    ts: found.record.ts ?? null,
+    turn_id: found.record.turnId ?? null,
+    error_ref: found.record.errorRef ?? null,
+    runtime: found.record.runtime ?? found.record.runtimeFailure?.runtime ?? null,
+    message: found.record.error ?? found.record.runtimeFailure?.error_message ?? null,
+    failure: found.record.runtimeFailure ?? null,
+  };
+  console.log(JSON.stringify(summary, null, 2));
+}
+
 function formatRouteMatch(m: RouteRuleMatch): string {
   const parts: string[] = [];
   if (m.channel) parts.push(`channel=${m.channel}`);
@@ -1486,6 +1530,9 @@ async function main(): Promise<void> {
         break;
       case "memory":
         await cmdMemory(args);
+        break;
+      case "debug":
+        cmdDebug(args);
         break;
       default:
         console.error(`unknown command: ${args.cmd}`);

--- a/packages/protocol-core/src/__tests__/client.test.ts
+++ b/packages/protocol-core/src/__tests__/client.test.ts
@@ -67,4 +67,35 @@ describe("BotCordClient token refresh", () => {
     expect(inboxRequests[0].authorization).toBe("Bearer old-token");
     expect(inboxRequests[1].authorization).toBe("Bearer new-token");
   });
+
+  it("includes structured error_ref on typed error messages", async () => {
+    let sentBody: any;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        sentBody = JSON.parse(String(init?.body));
+        return Response.json({ hub_msg_id: "hub_1" });
+      }),
+    );
+
+    const client = new BotCordClient({
+      hubUrl: "https://hub.example",
+      agentId: "ag_test",
+      keyId: "k_test",
+      privateKey,
+      token: "cached-token",
+      tokenExpiresAt: Math.floor(Date.now() / 1000) + 3600,
+    });
+
+    await client.sendTypedMessage("rm_1", "error", "Runtime error: codex error", {
+      errorRef: "err_abc123",
+    });
+
+    expect(sentBody.type).toBe("error");
+    expect(sentBody.payload.error).toMatchObject({
+      code: "agent_error",
+      message: "Runtime error: codex error",
+      error_ref: "err_abc123",
+    });
+  });
 });

--- a/packages/protocol-core/src/client.ts
+++ b/packages/protocol-core/src/client.ts
@@ -237,10 +237,18 @@ export class BotCordClient {
     to: string,
     type: "result" | "error",
     text: string,
-    options?: { replyTo?: string; topic?: string; attachments?: MessageAttachment[] },
+    options?: { replyTo?: string; topic?: string; attachments?: MessageAttachment[]; errorRef?: string },
   ): Promise<SendResponse> {
     const payload: Record<string, unknown> =
-      type === "error" ? { error: { code: "agent_error", message: text } } : { text };
+      type === "error"
+        ? {
+            error: {
+              code: "agent_error",
+              message: text,
+              ...(options?.errorRef ? { error_ref: options.errorRef } : {}),
+            },
+          }
+        : { text };
     if (options?.attachments && options.attachments.length > 0) {
       payload.attachments = options.attachments;
     }

--- a/packages/protocol-core/src/gateway-message.ts
+++ b/packages/protocol-core/src/gateway-message.ts
@@ -64,6 +64,7 @@ export interface GatewayOutboundMessage {
   threadId?: string | null;
   type?: "message" | "error";
   text: string;
+  errorRef?: string | null;
   attachments?: GatewayOutboundAttachment[];
   replyTo?: string | null;
   traceId?: string | null;


### PR DESCRIPTION
## Summary
- capture runtime adapter failures with structured diagnostics and safe error refs
- write transcript turn_error records with redacted runtime failure summaries
- include error_ref in BotCord typed error payloads and add debug runtime-error CLI lookup

## Verification
- MISE_TRUSTED_CONFIG_PATHS=$PWD pnpm --filter @botcord/daemon test -- --run src/gateway/__tests__/botcord-channel.test.ts src/gateway/__tests__/runtime-failure.test.ts src/__tests__/debug-runtime-error-cli.test.ts src/gateway/__tests__/dispatcher.test.ts src/gateway/__tests__/transcript.test.ts
- MISE_TRUSTED_CONFIG_PATHS=$PWD pnpm --filter @botcord/protocol-core test -- --run src/__tests__/client.test.ts
- MISE_TRUSTED_CONFIG_PATHS=$PWD pnpm --filter @botcord/daemon build
- MISE_TRUSTED_CONFIG_PATHS=$PWD pnpm --filter @botcord/protocol-core build
- git diff --check

Code Reviewer final review: no findings.