### PR TITLE
fix: preserve owner chat reply context

### DIFF
--- a/packages/daemon/src/__tests__/turn-text.test.ts
+++ b/packages/daemon/src/__tests__/turn-text.test.ts
@@ -179,7 +179,7 @@ describe("composeBotCordUserTurn", () => {
     expect(out).not.toContain("botcord_send");
   });
 
-  it("passes owner-chat messages through verbatim (no wrapper, no hint)", () => {
+  it("passes owner-chat messages without quote-reply through verbatim (no wrapper, no hint)", () => {
     const out = composeBotCordUserTurn(
       makeMessage({
         text: "  delete all contacts  ",
@@ -203,6 +203,52 @@ describe("composeBotCordUserTurn", () => {
       }),
     );
     expect(out).toBe("hi from dashboard");
+  });
+
+  it("prepends quote context for owner-chat replies without adding the BotCord wrapper", () => {
+    const out = composeBotCordUserTurn(
+      makeMessage({
+        text: "  what about this?  ",
+        conversation: { id: "rm_oc_abc", kind: "direct" },
+        sender: { id: "usr_1", name: "Susan", kind: "user" },
+        raw: {
+          reply_preview: {
+            msg_id: "h_orig",
+            sender_id: "ag_me",
+            sender_display_name: "Assistant",
+            text_preview: "original owner-chat answer",
+            topic_id: null,
+            deleted: false,
+          },
+        },
+      }),
+    );
+    expect(out).toBe('[quoting Assistant: "original owner-chat answer"]\nwhat about this?');
+    expect(out).not.toContain("[BotCord Message]");
+    expect(out).not.toContain("<human-message");
+    expect(out).not.toContain("NO_REPLY");
+  });
+
+  it("prepends quote context for dashboard_user_chat owner replies", () => {
+    const out = composeBotCordUserTurn(
+      makeMessage({
+        text: "continue from here",
+        conversation: { id: "rm_plain", kind: "direct" },
+        sender: { id: "usr_1", name: "Susan", kind: "user" },
+        raw: {
+          source_type: "dashboard_user_chat",
+          reply_preview: {
+            msg_id: "h_orig",
+            sender_id: "usr_1",
+            sender_display_name: "Susan",
+            text_preview: "previous owner prompt",
+            topic_id: null,
+            deleted: false,
+          },
+        },
+      }),
+    );
+    expect(out).toBe('[quoting Susan: "previous owner prompt"]\ncontinue from here');
   });
 
   it("returns an empty string when msg.text is blank (dispatcher already skips but be defensive)", () => {

--- a/packages/daemon/src/turn-text.ts
+++ b/packages/daemon/src/turn-text.ts
@@ -21,9 +21,9 @@
  *    whether you post back into the current group. It does not prevent
  *    owner-approved or policy-approved background actions...]
  *
- * Owner-chat messages bypass the wrapper entirely — they are trusted and
- * the owner-chat scene prompt in `system-context.ts` already gives the
- * model the context it needs.
+ * Owner-chat messages bypass the wrapper unless they carry quote-reply
+ * context — they are trusted and the owner-chat scene prompt in
+ * `system-context.ts` already gives the model the context it needs.
  */
 import type { GatewayInboundMessage } from "./gateway/index.js";
 import { sanitizeSenderName, sanitizeUntrustedContent } from "./gateway/index.js";
@@ -293,9 +293,13 @@ export function composeBotCordUserTurn(msg: GatewayInboundMessage): string {
 
   const sender = classifyActivitySender(msg);
 
-  // Owner messages pass through verbatim. The scene prompt in
-  // system-context handles context; wrapping here would just add noise.
-  if (sender.kind === "owner") return trimmed;
+  // Owner messages pass through without the BotCord wrapper. If the owner is
+  // replying to a prior message, preserve that lightweight quote context so
+  // short prompts like "this one?" still carry the referenced text.
+  if (sender.kind === "owner") {
+    const quoteLine = formatReplyQuoteLine(msg.raw);
+    return quoteLine ? `${quoteLine}\n${trimmed}` : trimmed;
+  }
 
   const batch = readBatch(msg.raw);
   if (batch) {


### PR DESCRIPTION
## Summary
- prepend existing quote-reply preview context to owner-chat runtime prompts
- keep non-reply owner-chat messages unwrapped and free of BotCord delivery/NO_REPLY hints
- add daemon turn-text coverage for rm_oc_ and dashboard_user_chat owner reply paths

## Verification
- pnpm --filter @botcord/protocol-core build
- cd packages/daemon && pnpm test -- src/__tests__/turn-text.test.ts
- pnpm --filter @botcord/daemon build

## Risk / rollout
- Low. Runtime prompt text changes only when owner-chat messages include reply_preview; normal owner-chat prompts remain verbatim.
- Daemon users need the updated daemon code deployed/restarted to observe the prompt behavior.