### PR TITLE
fix: add markdown image preview overlay

### DIFF
--- a/frontend/src/components/ui/AttachmentItem.tsx
+++ b/frontend/src/components/ui/AttachmentItem.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createPortal } from "react-dom";
-import { ExternalLink, FileText, X } from "lucide-react";
+import { FileText } from "lucide-react";
 import type { Attachment } from "@/lib/types";
 import { isPreviewableAttachment } from "@/lib/attachment-preview";
+import ImagePreviewOverlay from "@/components/ui/ImagePreviewOverlay";
 
 const HUB_BASE_URL =
   process.env.NEXT_PUBLIC_HUB_BASE_URL ||
@@ -49,84 +49,6 @@ export function rememberFailedAttachmentImageUrl(url: string): void {
 export function hasFailedAttachmentImageUrl(url: string): boolean {
   const key = attachmentImageFailureKey(url);
   return key ? failedAttachmentImageUrls.has(key) : false;
-}
-
-function ImagePreviewOverlay({
-  src,
-  title,
-  onClose,
-  onImageError,
-}: {
-  src: string;
-  title: string;
-  onClose: () => void;
-  onImageError: () => void;
-}) {
-  useEffect(() => {
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        onClose();
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.body.style.overflow = previousOverflow;
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [onClose]);
-
-  return createPortal(
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-label={title}
-      className="fixed inset-0 z-[9999] flex flex-col bg-black/90 backdrop-blur-sm"
-      onClick={(event) => {
-        if (event.target === event.currentTarget) onClose();
-      }}
-    >
-      <div className="flex min-h-14 items-center justify-between gap-3 border-b border-glass-border bg-deep-black/85 px-3 py-2 sm:px-5">
-        <span className="min-w-0 truncate text-sm font-medium text-text-primary">{title}</span>
-        <div className="flex shrink-0 items-center gap-1.5">
-          <a
-            href={src}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex h-9 w-9 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-white/10 hover:text-text-primary"
-            aria-label="Open original image"
-            onClick={(event) => event.stopPropagation()}
-          >
-            <ExternalLink className="h-4 w-4" />
-          </a>
-          <button
-            type="button"
-            onClick={(event) => {
-              event.stopPropagation();
-              onClose();
-            }}
-            className="inline-flex h-9 w-9 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-white/10 hover:text-text-primary"
-            aria-label="Close image preview"
-          >
-            <X className="h-5 w-5" />
-          </button>
-        </div>
-      </div>
-      <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto p-3 sm:p-6">
-        <img
-          src={src}
-          alt={title}
-          className="max-h-[calc(100vh-6.5rem)] max-w-full object-contain shadow-2xl"
-          onError={onImageError}
-        />
-      </div>
-    </div>,
-    document.body,
-  );
 }
 
 interface AttachmentItemProps {

--- a/frontend/src/components/ui/ImagePreviewOverlay.tsx
+++ b/frontend/src/components/ui/ImagePreviewOverlay.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useEffect } from "react";
+import { createPortal } from "react-dom";
+import { ExternalLink, X } from "lucide-react";
+
+interface ImagePreviewOverlayProps {
+  src: string;
+  title: string;
+  onClose: () => void;
+  onImageError: () => void;
+}
+
+export default function ImagePreviewOverlay({
+  src,
+  title,
+  onClose,
+  onImageError,
+}: ImagePreviewOverlayProps) {
+  useEffect(() => {
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose]);
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+      className="fixed inset-0 z-[9999] flex flex-col bg-black/90 backdrop-blur-sm"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <div className="flex min-h-14 items-center justify-between gap-3 border-b border-glass-border bg-deep-black/85 px-3 py-2 sm:px-5">
+        <span className="min-w-0 truncate text-sm font-medium text-text-primary">{title}</span>
+        <div className="flex shrink-0 items-center gap-1.5">
+          <a
+            href={src}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-white/10 hover:text-text-primary"
+            aria-label="Open original image"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <ExternalLink className="h-4 w-4" />
+          </a>
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              onClose();
+            }}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-white/10 hover:text-text-primary"
+            aria-label="Close image preview"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+      </div>
+      <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto p-3 sm:p-6">
+        <img
+          src={src}
+          alt={title}
+          className="max-h-[calc(100vh-6.5rem)] max-w-full object-contain shadow-2xl"
+          onError={onImageError}
+        />
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/frontend/src/components/ui/MarkdownContent.test.ts
+++ b/frontend/src/components/ui/MarkdownContent.test.ts
@@ -1,5 +1,7 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
-import {
+import MarkdownContent, {
   hasFailedMarkdownImageSrc,
   isPreviewableMarkdownImageSrc,
   normalizeMessageContent,
@@ -59,6 +61,20 @@ describe("isPreviewableMarkdownImageSrc", () => {
     expect(isPreviewableMarkdownImageSrc("output/xhs-01-cover.png")).toBe(false);
     expect(isPreviewableMarkdownImageSrc("social-card-botcord-agent-hub/index.html")).toBe(false);
     expect(isPreviewableMarkdownImageSrc("/hub/files/f_123")).toBe(false);
+  });
+});
+
+describe("MarkdownContent images", () => {
+  it("renders previewable markdown images as zoomable preview buttons", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(MarkdownContent, {
+        content: "![cover](https://example.com/card.png)",
+      }),
+    );
+
+    expect(html).toContain('aria-label="Preview cover"');
+    expect(html).toContain('src="https://example.com/card.png"');
+    expect(html).toContain("cursor-zoom-in");
   });
 });
 

--- a/frontend/src/components/ui/MarkdownContent.tsx
+++ b/frontend/src/components/ui/MarkdownContent.tsx
@@ -7,6 +7,7 @@ import ReactMarkdown from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import type { Components } from "react-markdown";
+import ImagePreviewOverlay from "@/components/ui/ImagePreviewOverlay";
 
 interface MarkdownContentProps {
   content: string;
@@ -274,27 +275,54 @@ function MarkdownImageFallback({ src, alt }: { src: string; alt?: string }) {
 function MarkdownImage({ src, alt }: { src?: string; alt?: string }) {
   const rawSrc = typeof src === "string" ? src : "";
   const [failed, setFailed] = useState(() => (rawSrc ? hasFailedMarkdownImageSrc(rawSrc) : false));
+  const [previewOpen, setPreviewOpen] = useState(false);
 
   useEffect(() => {
+    setPreviewOpen(false);
     setFailed(rawSrc ? hasFailedMarkdownImageSrc(rawSrc) : false);
   }, [rawSrc]);
+
+  const handleImageError = () => {
+    rememberFailedMarkdownImageSrc(rawSrc);
+    setPreviewOpen(false);
+    setFailed(true);
+  };
 
   if (!isPreviewableMarkdownImageSrc(rawSrc) || failed) {
     return <MarkdownImageFallback src={rawSrc} alt={alt} />;
   }
 
+  const title = alt || "Markdown image";
+
   return (
-    <img
-      src={rawSrc}
-      alt={alt ?? ""}
-      className="my-2 max-h-72 max-w-full rounded-lg border border-glass-border object-contain"
-      loading="lazy"
-      decoding="async"
-      onError={() => {
-        rememberFailedMarkdownImageSrc(rawSrc);
-        setFailed(true);
-      }}
-    />
+    <>
+      <button
+        type="button"
+        onClick={(event) => {
+          event.stopPropagation();
+          setPreviewOpen(true);
+        }}
+        className="group my-2 inline-flex max-w-full items-center justify-center overflow-hidden rounded-lg border border-glass-border bg-black/20 text-left"
+        aria-label={`Preview ${title}`}
+      >
+        <img
+          src={rawSrc}
+          alt={alt ?? ""}
+          className="block max-h-72 max-w-full cursor-zoom-in object-contain transition-opacity group-hover:opacity-80"
+          loading="lazy"
+          decoding="async"
+          onError={handleImageError}
+        />
+      </button>
+      {previewOpen && (
+        <ImagePreviewOverlay
+          src={rawSrc}
+          title={title}
+          onClose={() => setPreviewOpen(false)}
+          onImageError={handleImageError}
+        />
+      )}
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- Extract the existing image preview modal into a shared UI component.
- Make Markdown-rendered images clickable so message body images can open the same full-screen preview as attachment images.
- Keep attachment image preview behavior unchanged while reusing the shared overlay.

## Verification
- npm run test -- --run src/components/ui/MarkdownContent.test.ts src/components/ui/AttachmentItem.test.ts
- NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key npm run build

## Risk / rollout
- Low-risk frontend-only change; affects image rendering in Markdown message bodies and shared attachment preview overlay.