### PR TITLE
fix: show full dates for older message timestamps

### DIFF
--- a/frontend/src/components/dashboard/MessageBubble.tsx
+++ b/frontend/src/components/dashboard/MessageBubble.tsx
@@ -20,6 +20,7 @@ import MarkdownContent from "@/components/ui/MarkdownContent";
 import type { MentionTextCandidate } from "@/components/ui/MarkdownContent";
 import SystemMessageNotice from "@/components/ui/SystemMessageNotice";
 import TransferCard, { parseTransferText, parseTransferNotice } from "@/components/dashboard/TransferCard";
+import { formatMessageTimestamp } from "@/lib/message-time";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
@@ -161,24 +162,6 @@ function StateCountsBadges({ counts }: { counts: Record<string, number> }) {
       })}
     </span>
   );
-}
-
-function formatMessageTimestamp(isoTime: string): string {
-  const date = new Date(isoTime);
-  if (Number.isNaN(date.getTime())) return "";
-
-  const ageMs = Date.now() - date.getTime();
-  if (ageMs >= 0 && ageMs < 24 * 60 * 60 * 1000) {
-    return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-  }
-
-  return date.toLocaleString([], {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
 }
 
 function MentionChip({

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -14,6 +14,7 @@ import { ArrowLeft, Bot, Check, Copy, CornerUpLeft, Forward, Loader2, MessageSqu
 import { useRouter } from "nextjs-toploader/app";
 import { api } from "@/lib/api";
 import { useLanguage } from "@/lib/i18n";
+import { formatMessageTimestamp } from "@/lib/message-time";
 import type { Attachment, OwnerChatMessage } from "@/lib/types";
 import type { WsAttachment } from "@/lib/owner-chat-ws";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
@@ -512,7 +513,7 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
                   <div>
                     <MarkdownContent content={msg.text || ""} />
                     <div className="text-amber-500/60 mt-1 text-right">
-                      {new Date(msg.createdAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+                      {formatMessageTimestamp(msg.createdAt)}
                     </div>
                   </div>
                 </div>
@@ -552,7 +553,7 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
                     </button>
                     <div className="mt-1 flex items-center gap-1.5">
                       <span className="text-[10px] text-zinc-500">
-                        {new Date(msg.createdAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+                        {formatMessageTimestamp(msg.createdAt)}
                       </span>
                       <span className="rounded bg-amber-400/10 px-1 font-mono text-[10px] text-amber-300/80">
                         error
@@ -746,7 +747,7 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
                       </div>
                     )}
                     <div className="text-xs text-zinc-500 mt-1 text-right">
-                      {new Date(msg.createdAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+                      {formatMessageTimestamp(msg.createdAt)}
                     </div>
                   </div>
                   {!isUser && renderMessageActions(msg, false)}

--- a/frontend/src/components/share/SharedMessageBubble.tsx
+++ b/frontend/src/components/share/SharedMessageBubble.tsx
@@ -7,6 +7,7 @@ import SystemMessageNotice from "@/components/ui/SystemMessageNotice";
 import TransferCard, { parseTransferText, parseTransferNotice } from "@/components/dashboard/TransferCard";
 import { useLanguage } from "@/lib/i18n";
 import { isDashboardMessageRecalled, recalledMessageLabel } from "@/lib/message-recall";
+import { formatMessageTimestamp } from "@/lib/message-time";
 
 interface SharedMessageBubbleProps {
   message: SharedMessage;
@@ -17,10 +18,7 @@ export default function SharedMessageBubble({ message }: SharedMessageBubbleProp
   const textContent = message.payload?.text || message.payload?.body || message.payload?.message;
   const displayText = typeof textContent === "string" ? textContent : message.text;
   const isRecalled = isDashboardMessageRecalled(message);
-  const timestampLabel = new Date(message.created_at).toLocaleTimeString([], {
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+  const timestampLabel = formatMessageTimestamp(message.created_at);
   const senderInitial = (message.sender_name || message.sender_id || "?").trim().slice(0, 1).toUpperCase();
 
   if (message.type === "system") {

--- a/frontend/src/lib/message-time.test.ts
+++ b/frontend/src/lib/message-time.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { formatMessageTimestamp, isSameLocalDate } from "./message-time";
+
+const timeOnlyOptions: Intl.DateTimeFormatOptions = {
+  hour: "2-digit",
+  minute: "2-digit",
+};
+
+const dateTimeOptions: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+};
+
+describe("formatMessageTimestamp", () => {
+  it("shows only the time for messages from the current local day", () => {
+    const now = new Date(2026, 5, 2, 10, 0);
+    const messageDate = new Date(2026, 5, 2, 8, 15);
+
+    expect(formatMessageTimestamp(messageDate.toISOString(), now)).toBe(
+      messageDate.toLocaleTimeString([], timeOnlyOptions),
+    );
+  });
+
+  it("shows date and time for yesterday even when it is within 24 hours", () => {
+    const now = new Date(2026, 5, 2, 10, 0);
+    const messageDate = new Date(2026, 5, 1, 23, 30);
+
+    expect(isSameLocalDate(messageDate, now)).toBe(false);
+    expect(now.getTime() - messageDate.getTime()).toBeLessThan(24 * 60 * 60 * 1000);
+    expect(formatMessageTimestamp(messageDate.toISOString(), now)).toBe(
+      messageDate.toLocaleString([], dateTimeOptions),
+    );
+  });
+
+  it("returns an empty string for invalid timestamps", () => {
+    expect(formatMessageTimestamp("not-a-date")).toBe("");
+  });
+});

--- a/frontend/src/lib/message-time.ts
+++ b/frontend/src/lib/message-time.ts
@@ -1,0 +1,31 @@
+const timeOnlyOptions: Intl.DateTimeFormatOptions = {
+  hour: "2-digit",
+  minute: "2-digit",
+};
+
+const dateTimeOptions: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+};
+
+export function isSameLocalDate(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear()
+    && a.getMonth() === b.getMonth()
+    && a.getDate() === b.getDate()
+  );
+}
+
+export function formatMessageTimestamp(isoTime: string, now = new Date()): string {
+  const date = new Date(isoTime);
+  if (Number.isNaN(date.getTime())) return "";
+
+  if (isSameLocalDate(date, now)) {
+    return date.toLocaleTimeString([], timeOnlyOptions);
+  }
+
+  return date.toLocaleString([], dateTimeOptions);
+}


### PR DESCRIPTION
## Summary
- Add a shared message timestamp formatter that compares local calendar dates instead of a rolling 24-hour window.
- Use the shared formatter in dashboard message bubbles, owner chat, and shared room previews so yesterday and older messages show full date + time.
- Add regression coverage for the yesterday-within-24-hours boundary.

## Verification
- cd frontend && npm run test -- src/lib/message-time.test.ts
- cd frontend && npm run build
- git diff --check origin/main..HEAD

## Risk / rollout
- Low-risk frontend display-only change. Uses existing locale-sensitive date/time formatting.