### PR TITLE
feat: add schedule session policy

### DIFF
--- a/backend/app/routers/schedules.py
+++ b/backend/app/routers/schedules.py
@@ -17,11 +17,13 @@ from hub.services.agent_schedules import (
     compute_next_fire_at,
     create_schedule,
     dispatch_schedule_run,
+    LEGACY_SESSION_POLICY,
     now_utc,
     serialize_run,
     serialize_schedule,
     validate_payload_json,
     validate_schedule_json,
+    validate_session_policy,
 )
 
 router = APIRouter(prefix="/api/agents", tags=["agent-schedules"])
@@ -32,6 +34,7 @@ class ScheduleBody(BaseModel):
     enabled: bool = True
     schedule: dict[str, Any]
     payload: dict[str, Any] | None = None
+    session_policy: str | None = None
 
 
 class SchedulePatchBody(BaseModel):
@@ -39,6 +42,7 @@ class SchedulePatchBody(BaseModel):
     enabled: bool | None = None
     schedule: dict[str, Any] | None = None
     payload: dict[str, Any] | None = None
+    session_policy: str | None = None
 
 
 async def _load_owned_agent(db: AsyncSession, ctx: RequestContext, agent_id: str) -> Agent:
@@ -97,6 +101,7 @@ async def create_agent_schedule(
         name=body.name,
         schedule_json=body.schedule,
         payload_json=body.payload,
+        session_policy=body.session_policy,
         enabled=body.enabled,
         created_by="owner",
     )
@@ -121,13 +126,27 @@ async def patch_agent_schedule(
 ) -> dict[str, Any]:
     row = await _load_owned_schedule(db, ctx, agent_id, schedule_id)
     schedule_changed = False
+    session_changed = False
     if body.name is not None:
         row.name = body.name.strip()
     if body.schedule is not None:
-        row.schedule_json = validate_schedule_json(body.schedule)
+        schedule_json = validate_schedule_json(body.schedule)
+        if schedule_json != row.schedule_json:
+            session_changed = True
+        row.schedule_json = schedule_json
         schedule_changed = True
     if body.payload is not None:
-        row.payload_json = validate_payload_json(body.payload)
+        payload_json = validate_payload_json(body.payload)
+        if payload_json != row.payload_json:
+            session_changed = True
+        row.payload_json = payload_json
+    if body.session_policy is not None:
+        policy = validate_session_policy(body.session_policy)
+        current_policy = validate_session_policy(row.session_policy, default=LEGACY_SESSION_POLICY)
+        if policy != current_policy:
+            session_changed = True
+        if row.session_policy is not None or policy != LEGACY_SESSION_POLICY:
+            row.session_policy = policy
     if body.enabled is not None:
         row.enabled = body.enabled
         schedule_changed = True
@@ -135,6 +154,8 @@ async def patch_agent_schedule(
         row.next_fire_at = compute_next_fire_at(row.schedule_json) if row.enabled else None
         row.locked_until = None
         row.locked_by = None
+    if session_changed:
+        row.session_epoch = (row.session_epoch or 1) + 1
     try:
         await db.commit()
     except Exception as exc:  # noqa: BLE001

--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -1479,6 +1479,11 @@ class AgentSchedule(Base):
     __tablename__ = "agent_schedules"
     __table_args__ = (
         UniqueConstraint("agent_id", "name", name="uq_agent_schedules_agent_name"),
+        CheckConstraint(
+            "session_policy IS NULL OR session_policy IN ('fresh_per_run', 'reuse_per_schedule')",
+            name="ck_agent_schedules_session_policy",
+        ),
+        CheckConstraint("session_epoch >= 1", name="ck_agent_schedules_session_epoch"),
         Index("ix_agent_schedules_due", "enabled", "next_fire_at"),
         Index("ix_agent_schedules_agent", "agent_id"),
     )
@@ -1492,6 +1497,8 @@ class AgentSchedule(Base):
     enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default=sa_text("TRUE"))
     schedule_json: Mapped[dict] = mapped_column(JSON, nullable=False)
     payload_json: Mapped[dict] = mapped_column(JSON, nullable=False)
+    session_policy: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    session_epoch: Mapped[int] = mapped_column(Integer, nullable=False, default=1, server_default="1")
     created_by: Mapped[str] = mapped_column(String(16), nullable=False, default="owner", server_default="owner")
     next_fire_at: Mapped[datetime.datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, index=True)
     last_fire_at: Mapped[datetime.datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/hub/routers/agent_schedules.py
+++ b/backend/hub/routers/agent_schedules.py
@@ -17,11 +17,13 @@ from hub.services.agent_schedules import (
     compute_next_fire_at,
     create_schedule,
     dispatch_schedule_run,
+    LEGACY_SESSION_POLICY,
     now_utc,
     serialize_run,
     serialize_schedule,
     validate_payload_json,
     validate_schedule_json,
+    validate_session_policy,
 )
 
 router = APIRouter(prefix="/hub/schedules", tags=["agent-schedules"])
@@ -32,6 +34,7 @@ class ScheduleBody(BaseModel):
     enabled: bool = True
     schedule: dict[str, Any]
     payload: dict[str, Any] | None = None
+    session_policy: str | None = None
 
 
 class SchedulePatchBody(BaseModel):
@@ -39,6 +42,7 @@ class SchedulePatchBody(BaseModel):
     enabled: bool | None = None
     schedule: dict[str, Any] | None = None
     payload: dict[str, Any] | None = None
+    session_policy: str | None = None
 
 
 async def _load_self_agent(db: AsyncSession, agent_id: str) -> Agent:
@@ -96,6 +100,7 @@ async def create_self_schedule(
         name=body.name,
         schedule_json=body.schedule,
         payload_json=body.payload,
+        session_policy=body.session_policy,
         enabled=body.enabled,
         created_by="agent",
     )
@@ -119,13 +124,27 @@ async def patch_self_schedule(
 ) -> dict[str, Any]:
     row = await _load_self_schedule(db, current_agent, schedule_id)
     schedule_changed = False
+    session_changed = False
     if body.name is not None:
         row.name = body.name.strip()
     if body.schedule is not None:
-        row.schedule_json = validate_schedule_json(body.schedule)
+        schedule_json = validate_schedule_json(body.schedule)
+        if schedule_json != row.schedule_json:
+            session_changed = True
+        row.schedule_json = schedule_json
         schedule_changed = True
     if body.payload is not None:
-        row.payload_json = validate_payload_json(body.payload)
+        payload_json = validate_payload_json(body.payload)
+        if payload_json != row.payload_json:
+            session_changed = True
+        row.payload_json = payload_json
+    if body.session_policy is not None:
+        policy = validate_session_policy(body.session_policy)
+        current_policy = validate_session_policy(row.session_policy, default=LEGACY_SESSION_POLICY)
+        if policy != current_policy:
+            session_changed = True
+        if row.session_policy is not None or policy != LEGACY_SESSION_POLICY:
+            row.session_policy = policy
     if body.enabled is not None:
         row.enabled = body.enabled
         schedule_changed = True
@@ -133,6 +152,8 @@ async def patch_self_schedule(
         row.next_fire_at = compute_next_fire_at(row.schedule_json) if row.enabled else None
         row.locked_until = None
         row.locked_by = None
+    if session_changed:
+        row.session_epoch = (row.session_epoch or 1) + 1
     try:
         await db.commit()
     except Exception as exc:  # noqa: BLE001

--- a/backend/hub/services/agent_schedules.py
+++ b/backend/hub/services/agent_schedules.py
@@ -23,6 +23,9 @@ logger = logging.getLogger(__name__)
 MIN_EVERY_MS = 5 * 60 * 1000
 MAX_EVERY_MS = 30 * 24 * 60 * 60 * 1000
 DEFAULT_PROACTIVE_MESSAGE = "【BotCord 自主任务】执行本轮工作目标。"
+DEFAULT_SESSION_POLICY = "fresh_per_run"
+LEGACY_SESSION_POLICY = "reuse_per_schedule"
+SESSION_POLICIES = {DEFAULT_SESSION_POLICY, LEGACY_SESSION_POLICY}
 _BACKGROUND_RUNS: set[asyncio.Task] = set()
 WEEKDAYS = set(range(7))
 
@@ -109,6 +112,13 @@ def validate_payload_json(value: dict[str, Any] | None) -> dict[str, Any]:
     return {"kind": "agent_turn", "message": message}
 
 
+def validate_session_policy(value: str | None, *, default: str = DEFAULT_SESSION_POLICY) -> str:
+    policy = default if value is None else value
+    if policy not in SESSION_POLICIES:
+        raise HTTPException(status_code=400, detail="session_policy_invalid")
+    return policy
+
+
 def compute_next_fire_at(
     schedule_json: dict[str, Any],
     base: datetime.datetime | None = None,
@@ -148,6 +158,7 @@ def serialize_schedule(row: AgentSchedule) -> dict[str, Any]:
         "enabled": row.enabled,
         "schedule": row.schedule_json,
         "payload": row.payload_json,
+        "session_policy": validate_session_policy(row.session_policy, default=LEGACY_SESSION_POLICY),
         "created_by": row.created_by,
         "next_fire_at": aware(row.next_fire_at).isoformat() if row.next_fire_at else None,
         "last_fire_at": aware(row.last_fire_at).isoformat() if row.last_fire_at else None,
@@ -194,6 +205,7 @@ async def create_schedule(
     name: str,
     schedule_json: dict[str, Any],
     payload_json: dict[str, Any] | None,
+    session_policy: str | None = None,
     enabled: bool = True,
     created_by: str = "owner",
 ) -> AgentSchedule:
@@ -204,6 +216,7 @@ async def create_schedule(
         raise HTTPException(status_code=400, detail="name_too_long")
     schedule = validate_schedule_json(schedule_json)
     payload = validate_payload_json(payload_json)
+    policy = validate_session_policy(session_policy)
     row = AgentSchedule(
         id=generate_agent_schedule_id(),
         agent_id=agent.agent_id,
@@ -212,6 +225,8 @@ async def create_schedule(
         enabled=enabled,
         schedule_json=schedule,
         payload_json=payload,
+        session_policy=policy,
+        session_epoch=1,
         created_by=created_by,
         next_fire_at=compute_next_fire_at(schedule) if enabled else None,
     )
@@ -243,6 +258,8 @@ async def dispatch_schedule_run(
     db.add(run)
     await db.flush()
 
+    session_policy = validate_session_policy(schedule.session_policy, default=LEGACY_SESSION_POLICY)
+    session_epoch = schedule.session_epoch or 1
     params = {
         "agent_id": schedule.agent_id,
         "reason": "manual" if manual else "scheduled",
@@ -254,6 +271,9 @@ async def dispatch_schedule_run(
         "run_id": run.id,
         "dedupe_key": run.dedupe_key,
     }
+    if schedule.session_policy is not None or session_epoch > 1:
+        params["session_policy"] = session_policy
+        params["session_epoch"] = session_epoch
 
     try:
         if agent.hosting_kind == "daemon" and agent.daemon_instance_id:

--- a/backend/migrations/004_agent_schedules.sql
+++ b/backend/migrations/004_agent_schedules.sql
@@ -6,6 +6,8 @@ CREATE TABLE IF NOT EXISTS agent_schedules (
   enabled boolean NOT NULL DEFAULT true,
   schedule_json json NOT NULL,
   payload_json json NOT NULL,
+  session_policy varchar(32) NOT NULL DEFAULT 'fresh_per_run',
+  session_epoch integer NOT NULL DEFAULT 1,
   created_by varchar(16) NOT NULL DEFAULT 'owner',
   next_fire_at timestamptz NULL,
   last_fire_at timestamptz NULL,
@@ -13,7 +15,9 @@ CREATE TABLE IF NOT EXISTS agent_schedules (
   locked_by varchar(64) NULL,
   created_at timestamptz DEFAULT now(),
   updated_at timestamptz DEFAULT now(),
-  CONSTRAINT uq_agent_schedules_agent_name UNIQUE (agent_id, name)
+  CONSTRAINT uq_agent_schedules_agent_name UNIQUE (agent_id, name),
+  CONSTRAINT ck_agent_schedules_session_policy CHECK (session_policy IN ('fresh_per_run', 'reuse_per_schedule')),
+  CONSTRAINT ck_agent_schedules_session_epoch CHECK (session_epoch >= 1)
 );
 
 CREATE INDEX IF NOT EXISTS ix_agent_schedules_due

--- a/backend/migrations/023_agent_schedule_session_policy.sql
+++ b/backend/migrations/023_agent_schedule_session_policy.sql
@@ -1,0 +1,30 @@
+ALTER TABLE agent_schedules
+  ADD COLUMN IF NOT EXISTS session_policy varchar(32) NULL;
+
+ALTER TABLE agent_schedules
+  ADD COLUMN IF NOT EXISTS session_epoch integer NOT NULL DEFAULT 1;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'ck_agent_schedules_session_policy'
+      AND conrelid = 'agent_schedules'::regclass
+  ) THEN
+    ALTER TABLE agent_schedules
+      ADD CONSTRAINT ck_agent_schedules_session_policy
+      CHECK (session_policy IS NULL OR session_policy IN ('fresh_per_run', 'reuse_per_schedule'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'ck_agent_schedules_session_epoch'
+      AND conrelid = 'agent_schedules'::regclass
+  ) THEN
+    ALTER TABLE agent_schedules
+      ADD CONSTRAINT ck_agent_schedules_session_epoch
+      CHECK (session_epoch >= 1);
+  END IF;
+END $$;

--- a/backend/tests/test_app/test_agent_schedules.py
+++ b/backend/tests/test_app/test_agent_schedules.py
@@ -37,11 +37,13 @@ async def test_dashboard_can_create_patch_run_and_delete_schedule(
     created = create_resp.json()
     assert created["name"] == "botcord-auto"
     assert created["schedule"]["every_ms"] == 300000
+    assert created["session_policy"] == "fresh_per_run"
     assert created["next_fire_at"]
 
     list_resp = await client.get("/api/agents/ag_agent001/schedules", headers=headers)
     assert list_resp.status_code == 200
     assert [row["id"] for row in list_resp.json()["schedules"]] == [created["id"]]
+    assert list_resp.json()["schedules"][0]["session_policy"] == "fresh_per_run"
 
     patch_resp = await client.patch(
         f"/api/agents/ag_agent001/schedules/{created['id']}",
@@ -94,6 +96,26 @@ async def test_schedule_rejects_too_short_interval(
     )
     assert resp.status_code == 400
     assert resp.json()["detail"] == "schedule_interval_too_short"
+
+
+@pytest.mark.asyncio
+async def test_schedule_rejects_invalid_session_policy(
+    client: AsyncClient,
+    seed_user: dict,
+):
+    resp = await client.post(
+        "/api/agents/ag_agent001/schedules",
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+        json={
+            "name": "bad-policy",
+            "enabled": True,
+            "schedule": {"kind": "every", "every_ms": 300000},
+            "payload": {"kind": "agent_turn", "message": "tick"},
+            "session_policy": "guess_from_message",
+        },
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "session_policy_invalid"
 
 
 @pytest.mark.asyncio
@@ -189,10 +211,19 @@ async def test_manual_run_records_failed_ack(
             "enabled": True,
             "schedule": {"kind": "every", "every_ms": 300000},
             "payload": {"kind": "agent_turn", "message": "tick"},
+            "session_policy": "reuse_per_schedule",
         },
     )
     assert create_resp.status_code == 201
     schedule_id = create_resp.json()["id"]
+    assert create_resp.json()["session_policy"] == "reuse_per_schedule"
+
+    patch_resp = await client.patch(
+        f"/api/agents/ag_agent001/schedules/{schedule_id}",
+        headers=headers,
+        json={"payload": {"kind": "agent_turn", "message": "next tick"}},
+    )
+    assert patch_resp.status_code == 200
 
     run_resp = await client.post(
         f"/api/agents/ag_agent001/schedules/{schedule_id}/run",
@@ -207,7 +238,61 @@ async def test_manual_run_records_failed_ack(
     params = captured["params"]
     assert params["schedule_id"] == schedule_id
     assert params["run_id"] == body["id"]
+    assert params["message"] == "next tick"
+    assert params["session_policy"] == "reuse_per_schedule"
+    assert params["session_epoch"] == 2
     assert params["scheduled_for"]
     assert params["dispatched_at"]
     datetime.datetime.fromisoformat(params["scheduled_for"])
     datetime.datetime.fromisoformat(params["dispatched_at"])
+
+
+@pytest.mark.asyncio
+async def test_legacy_schedule_omits_session_policy_params(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    seed_user: dict,
+    monkeypatch,
+):
+    import hub.routers.openclaw_control as openclaw_control
+
+    captured: dict = {}
+
+    async def fake_send_host_control_frame(host_id, frame_type, params, **_kwargs):
+        captured.update({"host_id": host_id, "frame_type": frame_type, "params": params})
+        return {"id": "frame_1", "ok": True}
+
+    monkeypatch.setattr(openclaw_control, "send_host_control_frame", fake_send_host_control_frame)
+    seed_user["agent1"].hosting_kind = "openclaw"
+    seed_user["agent1"].openclaw_host_id = "oc_test"
+    await db_session.commit()
+
+    headers = {"Authorization": f"Bearer {seed_user['token']}"}
+    create_resp = await client.post(
+        "/api/agents/ag_agent001/schedules",
+        headers=headers,
+        json={
+            "name": "legacy",
+            "enabled": True,
+            "schedule": {"kind": "every", "every_ms": 300000},
+            "payload": {"kind": "agent_turn", "message": "tick"},
+        },
+    )
+    assert create_resp.status_code == 201
+    schedule_id = create_resp.json()["id"]
+
+    row = await db_session.get(AgentSchedule, schedule_id)
+    assert row is not None
+    row.session_policy = None
+    row.session_epoch = 1
+    await db_session.commit()
+
+    run_resp = await client.post(
+        f"/api/agents/ag_agent001/schedules/{schedule_id}/run",
+        headers=headers,
+    )
+    assert run_resp.status_code == 200
+    assert run_resp.json()["status"] == "dispatched"
+    params = captured["params"]
+    assert "session_policy" not in params
+    assert "session_epoch" not in params

--- a/cli/README.md
+++ b/cli/README.md
@@ -109,8 +109,8 @@ All commands output JSON. Use `--help` on any command for details.
 | Command | Description |
 |---------|-------------|
 | `botcord schedule list` | List proactive schedules |
-| `botcord schedule add` | Create an interval or calendar schedule |
-| `botcord schedule edit` | Edit schedule name, cadence, message, or enabled state |
+| `botcord schedule add` | Create an interval or calendar schedule; use `--session-policy fresh_per_run\|reuse_per_schedule` to control runtime session reuse |
+| `botcord schedule edit` | Edit schedule name, cadence, message, enabled state, or session policy |
 | `botcord schedule pause` / `resume` | Pause or resume a schedule |
 | `botcord schedule run` | Trigger a schedule immediately |
 | `botcord schedule runs` | List recent runs |

--- a/cli/skills/botcord/SKILL.md
+++ b/cli/skills/botcord/SKILL.md
@@ -120,10 +120,11 @@ Use `--type result` and `--type error` only as explicit Topic termination signal
 ### Proactive Schedules
 
 - List schedules: `botcord schedule list`
-- Create interval schedule: `botcord schedule add --name botcord-auto --every-minutes 30 [--message "..."]`
+- Create interval schedule: `botcord schedule add --name botcord-auto --every-minutes 30 [--message "..."] [--session-policy fresh_per_run|reuse_per_schedule]`
 - Create daily calendar schedule: `botcord schedule add --name daily-brief --frequency daily --time 09:30 --timezone Asia/Shanghai`
 - Create weekly calendar schedule: `botcord schedule add --name weekly-review --frequency weekly --time 09:30 --timezone Asia/Shanghai --weekdays 0,2`
-- Edit schedule: `botcord schedule edit --id sch_xxx [--name NAME] [--message TEXT] [--enabled true|false] [schedule options]`
+- Edit schedule: `botcord schedule edit --id sch_xxx [--name NAME] [--message TEXT] [--enabled true|false] [--session-policy fresh_per_run|reuse_per_schedule] [schedule options]`
+- Session policy: `fresh_per_run` starts an independent runtime session for each run (default for new schedules); `reuse_per_schedule` keeps one runtime session per schedule until schedule instructions or policy change.
 - Pause or resume: `botcord schedule pause --id sch_xxx`, `botcord schedule resume --id sch_xxx`
 - Run now: `botcord schedule run --id sch_xxx`
 - View runs: `botcord schedule runs --id sch_xxx`

--- a/cli/src/commands/schedule.ts
+++ b/cli/src/commands/schedule.ts
@@ -5,17 +5,21 @@ import { outputJson, outputError } from "../output.js";
 import { normalizeAndValidateHubUrl } from "../hub-url.js";
 
 const DEFAULT_MESSAGE = "【BotCord 自主任务】执行本轮工作目标。";
+const DEFAULT_SESSION_POLICY = "fresh_per_run";
 
 type AgentScheduleSpec =
   | { kind: "every"; every_ms: number }
   | { kind: "calendar"; frequency: "daily"; time: string; timezone: string }
   | { kind: "calendar"; frequency: "weekly"; time: string; timezone: string; weekdays: number[] };
 
+type AgentScheduleSessionPolicy = "fresh_per_run" | "reuse_per_schedule";
+
 type SchedulePatchBody = {
   name?: string;
   enabled?: boolean;
   schedule?: AgentScheduleSpec;
   payload?: { kind: "agent_turn"; message: string };
+  session_policy?: AgentScheduleSessionPolicy;
 };
 
 function parsePositiveInt(value: unknown, flag: string): number {
@@ -41,6 +45,12 @@ function parseWeekdays(value: unknown): number[] {
     outputError("--weekdays must be comma-separated integers from 0 to 6, Monday=0");
   }
   return [...new Set(weekdays)].sort((a, b) => a - b);
+}
+
+function parseSessionPolicy(value: unknown, defaultValue?: AgentScheduleSessionPolicy): AgentScheduleSessionPolicy | undefined {
+  if (value === undefined) return defaultValue;
+  if (value === "fresh_per_run" || value === "reuse_per_schedule") return value;
+  outputError("--session-policy must be fresh_per_run or reuse_per_schedule");
 }
 
 function buildSchedule(args: ParsedArgs): AgentScheduleSpec {
@@ -124,7 +134,8 @@ Schedule options:
   --frequency daily|weekly --time HH:MM     Calendar schedule
   --timezone <tz>                           IANA timezone, default UTC
   --weekdays <0,2>                          Weekly only; Monday=0, Sunday=6
-  --message <text>                          Proactive turn message`);
+  --message <text>                          Proactive turn message
+  --session-policy <policy>                 fresh_per_run (default) or reuse_per_schedule`);
     if (!sub && !args.flags["help"]) process.exit(1);
     return;
   }
@@ -154,6 +165,7 @@ Schedule options:
         enabled: parseBoolean(args.flags["enabled"], true),
         schedule: buildSchedule(args),
         payload: { kind: "agent_turn", message },
+        session_policy: parseSessionPolicy(args.flags["session-policy"], DEFAULT_SESSION_POLICY),
       });
       outputJson(result);
       break;
@@ -166,6 +178,9 @@ Schedule options:
       if (args.flags["enabled"] !== undefined) body.enabled = parseBoolean(args.flags["enabled"], true);
       if (typeof args.flags["message"] === "string") {
         body.payload = { kind: "agent_turn", message: args.flags["message"] };
+      }
+      if (args.flags["session-policy"] !== undefined) {
+        body.session_policy = parseSessionPolicy(args.flags["session-policy"]);
       }
       if (
         args.flags["every-minutes"] !== undefined ||

--- a/frontend/src/components/dashboard/AgentSchedulesTab.tsx
+++ b/frontend/src/components/dashboard/AgentSchedulesTab.tsx
@@ -17,6 +17,7 @@ interface AgentSchedule {
     | { kind: "calendar"; frequency: "daily"; time: string; timezone: string }
     | { kind: "calendar"; frequency: "weekly"; time: string; timezone: string; weekdays: number[] };
   payload: { kind: "agent_turn"; message: string };
+  session_policy?: ScheduleSessionPolicy;
   created_by: string;
   next_fire_at?: string | null;
   last_fire_at?: string | null;
@@ -42,6 +43,13 @@ const WEEKDAYS = [
 ];
 const TIME_PATTERN = /^\d{2}:\d{2}$/;
 type ScheduleMode = "every" | "daily" | "weekly";
+type ScheduleSessionPolicy = "fresh_per_run" | "reuse_per_schedule";
+const DEFAULT_SESSION_POLICY: ScheduleSessionPolicy = "fresh_per_run";
+const LEGACY_SESSION_POLICY: ScheduleSessionPolicy = "reuse_per_schedule";
+const SESSION_POLICY_OPTIONS: Array<{ value: ScheduleSessionPolicy; label: string }> = [
+  { value: "fresh_per_run", label: "每次独立" },
+  { value: "reuse_per_schedule", label: "持续工作流" },
+];
 
 function formatTime(value?: string | null): string {
   if (!value) return "未安排";
@@ -75,6 +83,11 @@ function scheduleLabel(schedule: AgentSchedule["schedule"]): string {
   return `${labels || "每周"} ${schedule.time}`;
 }
 
+function sessionPolicyLabel(policy?: ScheduleSessionPolicy): string {
+  const value = policy ?? LEGACY_SESSION_POLICY;
+  return SESSION_POLICY_OPTIONS.find((item) => item.value === value)?.label ?? "持续工作流";
+}
+
 function statusClass(status?: string): string {
   if (status === "dispatched") return "border-green-400/20 bg-green-400/10 text-green-300";
   if (status === "offline") return "border-yellow-400/20 bg-yellow-400/10 text-yellow-300";
@@ -96,6 +109,7 @@ export default function AgentSchedulesTab({ agentId }: AgentSchedulesTabProps) {
   const [time, setTime] = useState("09:00");
   const [weekdays, setWeekdays] = useState<number[]>([0]);
   const [message, setMessage] = useState(DEFAULT_MESSAGE);
+  const [sessionPolicy, setSessionPolicy] = useState<ScheduleSessionPolicy>(DEFAULT_SESSION_POLICY);
 
   const canSaveForm = useMemo(
     () =>
@@ -147,6 +161,7 @@ export default function AgentSchedulesTab({ agentId }: AgentSchedulesTabProps) {
     setTime("09:00");
     setWeekdays([0]);
     setMessage(DEFAULT_MESSAGE);
+    setSessionPolicy(DEFAULT_SESSION_POLICY);
   }
 
   function buildScheduleBody() {
@@ -160,6 +175,7 @@ export default function AgentSchedulesTab({ agentId }: AgentSchedulesTabProps) {
             ? { kind: "calendar" as const, frequency: "daily" as const, time, timezone }
             : { kind: "calendar" as const, frequency: "weekly" as const, time, timezone, weekdays },
       payload: { kind: "agent_turn" as const, message: message.trim() },
+      session_policy: sessionPolicy,
     };
   }
 
@@ -167,6 +183,7 @@ export default function AgentSchedulesTab({ agentId }: AgentSchedulesTabProps) {
     setEditingScheduleId(schedule.id);
     setName(schedule.name);
     setMessage(schedule.payload.message);
+    setSessionPolicy(schedule.session_policy ?? LEGACY_SESSION_POLICY);
     if (schedule.schedule.kind === "every") {
       setScheduleMode("every");
       setEveryMinutes(Math.max(5, Math.round(schedule.schedule.every_ms / 60000)));
@@ -294,7 +311,7 @@ export default function AgentSchedulesTab({ agentId }: AgentSchedulesTabProps) {
                       </span>
                     </div>
                     <p className="mt-1 text-xs text-text-secondary">
-                      {scheduleLabel(schedule.schedule)} · 下次 {formatTime(schedule.next_fire_at)}
+                      {scheduleLabel(schedule.schedule)} · {sessionPolicyLabel(schedule.session_policy)} · 下次 {formatTime(schedule.next_fire_at)}
                     </p>
                     <p className="mt-2 line-clamp-2 text-xs text-text-secondary">{schedule.payload.message}</p>
                   </div>
@@ -437,6 +454,25 @@ export default function AgentSchedulesTab({ agentId }: AgentSchedulesTabProps) {
               ) : null}
             </div>
           )}
+          <div className="grid gap-1">
+            <div className="text-xs text-text-secondary">运行方式</div>
+            <div className="grid grid-cols-2 gap-2">
+              {SESSION_POLICY_OPTIONS.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => setSessionPolicy(option.value)}
+                  className={`rounded-lg border px-3 py-2 text-sm ${
+                    sessionPolicy === option.value
+                      ? "border-neon-cyan/50 bg-neon-cyan/10 text-neon-cyan"
+                      : "border-glass-border bg-deep-black/40 text-text-secondary hover:text-text-primary"
+                  }`}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </div>
           <textarea
             value={message}
             onChange={(e) => setMessage(e.target.value)}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1114,6 +1114,7 @@ const userApi = {
         | { kind: "calendar"; frequency: "daily"; time: string; timezone: string }
         | { kind: "calendar"; frequency: "weekly"; time: string; timezone: string; weekdays: number[] };
       payload: { kind: "agent_turn"; message: string };
+      session_policy: "fresh_per_run" | "reuse_per_schedule";
     },
   ): Promise<any> {
     return apiPost<any>(`/api/agents/${encodeURIComponent(agentId)}/schedules`, body);
@@ -1130,6 +1131,7 @@ const userApi = {
         | { kind: "calendar"; frequency: "daily"; time: string; timezone: string }
         | { kind: "calendar"; frequency: "weekly"; time: string; timezone: string; weekdays: number[] };
       payload?: { kind: "agent_turn"; message: string };
+      session_policy?: "fresh_per_run" | "reuse_per_schedule";
     },
   ): Promise<any> {
     return apiPatch<any>(

--- a/packages/daemon/src/__tests__/provision.test.ts
+++ b/packages/daemon/src/__tests__/provision.test.ts
@@ -333,7 +333,78 @@ describe("wake_agent handler", () => {
       dispatched_at: "2026-05-19T01:30:02+00:00",
       run_id: "sr_test",
       dedupe_key: "sch_test:1:auto",
+      session_policy: "reuse_per_schedule",
     });
+  });
+
+  it("uses a per-run thread for fresh_per_run scheduled turns", async () => {
+    const gw = makeFakeGateway(["ag_wake"]);
+    const handler = createProvisioner({ gateway: gw as any });
+    const res = await handler({
+      id: "req_wake_fresh",
+      type: "wake_agent",
+      params: {
+        agent_id: "ag_wake",
+        message: "tick",
+        run_id: "sr_fresh",
+        schedule_id: "sch_fresh",
+        session_policy: "fresh_per_run",
+        session_epoch: 3,
+      },
+    });
+
+    expect(res.ok).toBe(true);
+    const msg = gw.injectInbound.mock.calls[0][0];
+    expect(msg.conversation.threadId).toBe("sch_fresh:run:sr_fresh");
+    expect(msg.raw).toMatchObject({
+      session_policy: "fresh_per_run",
+      session_epoch: 3,
+    });
+  });
+
+  it("uses schedule epoch for reuse_per_schedule scheduled turns", async () => {
+    const gw = makeFakeGateway(["ag_wake"]);
+    const handler = createProvisioner({ gateway: gw as any });
+    const res = await handler({
+      id: "req_wake_reuse",
+      type: "wake_agent",
+      params: {
+        agent_id: "ag_wake",
+        message: "tick",
+        run_id: "sr_reuse",
+        schedule_id: "sch_reuse",
+        session_policy: "reuse_per_schedule",
+        session_epoch: 2,
+      },
+    });
+
+    expect(res.ok).toBe(true);
+    const msg = gw.injectInbound.mock.calls[0][0];
+    expect(msg.conversation.threadId).toBe("sch_reuse:v2");
+    expect(msg.raw).toMatchObject({
+      session_policy: "reuse_per_schedule",
+      session_epoch: 2,
+    });
+  });
+
+  it("rejects malformed schedule session policy", async () => {
+    const gw = makeFakeGateway(["ag_wake"]);
+    const handler = createProvisioner({ gateway: gw as any });
+    const res = await handler({
+      id: "req_wake_bad_policy",
+      type: "wake_agent",
+      params: {
+        agent_id: "ag_wake",
+        message: "tick",
+        run_id: "sr_bad_policy",
+        schedule_id: "sch_bad_policy",
+        session_policy: "guess",
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.error?.code).toBe("bad_params");
+    expect(gw.injectInbound).not.toHaveBeenCalled();
   });
 
   it("acks wake_agent after queueing instead of waiting for the turn to finish", async () => {

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -670,6 +670,34 @@ interface WakeAgentParams {
   dispatchedAt?: string;
   dedupe_key?: string;
   dedupeKey?: string;
+  session_policy?: string;
+  sessionPolicy?: string;
+  session_epoch?: number;
+  sessionEpoch?: number;
+}
+
+type ScheduleSessionPolicy = "fresh_per_run" | "reuse_per_schedule";
+
+function parseScheduleSessionPolicy(value: unknown): ScheduleSessionPolicy | null | undefined {
+  if (value === undefined) return null;
+  if (value === "fresh_per_run" || value === "reuse_per_schedule") return value;
+  return undefined;
+}
+
+function scheduleThreadId(args: {
+  scheduleId?: string;
+  runId: string;
+  sessionPolicy: ScheduleSessionPolicy;
+  sessionEpoch?: number;
+}): string | null {
+  if (args.sessionPolicy === "fresh_per_run") {
+    return args.scheduleId ? `${args.scheduleId}:run:${args.runId}` : args.runId;
+  }
+  if (!args.scheduleId) return null;
+  if (Number.isInteger(args.sessionEpoch) && args.sessionEpoch! > 0) {
+    return `${args.scheduleId}:v${args.sessionEpoch}`;
+  }
+  return args.scheduleId;
 }
 
 async function handleWakeAgent(gateway: Gateway, raw: unknown): Promise<AckBody> {
@@ -708,6 +736,27 @@ async function handleWakeAgent(gateway: Gateway, raw: unknown): Promise<AckBody>
   const scheduledFor = params.scheduled_for || params.scheduledFor;
   const dispatchedAt = params.dispatched_at || params.dispatchedAt;
   const dedupeKey = params.dedupe_key || params.dedupeKey;
+  const rawSessionPolicy = params.session_policy ?? params.sessionPolicy;
+  const parsedSessionPolicy = parseScheduleSessionPolicy(rawSessionPolicy);
+  if (parsedSessionPolicy === undefined) {
+    return {
+      ok: false,
+      error: {
+        code: "bad_params",
+        message: "wake_agent params.session_policy must be fresh_per_run or reuse_per_schedule",
+      },
+    };
+  }
+  const rawSessionEpoch = params.session_epoch ?? params.sessionEpoch;
+  if (rawSessionEpoch !== undefined && (!Number.isInteger(rawSessionEpoch) || rawSessionEpoch <= 0)) {
+    return {
+      ok: false,
+      error: { code: "bad_params", message: "wake_agent params.session_epoch must be a positive integer" },
+    };
+  }
+  const sessionPolicy = parsedSessionPolicy ?? "reuse_per_schedule";
+  const sessionEpoch = rawSessionEpoch;
+  const threadId = scheduleThreadId({ scheduleId, runId, sessionPolicy, sessionEpoch });
   const conversationId = `rm_schedule_${agentId}`;
   const msg: GatewayInboundMessage = {
     id: runId,
@@ -717,7 +766,7 @@ async function handleWakeAgent(gateway: Gateway, raw: unknown): Promise<AckBody>
       id: conversationId,
       kind: "direct",
       title: "BotCord Scheduler",
-      threadId: scheduleId ?? null,
+      threadId,
     },
     sender: {
       id: "hub",
@@ -732,6 +781,8 @@ async function handleWakeAgent(gateway: Gateway, raw: unknown): Promise<AckBody>
       dispatched_at: dispatchedAt,
       run_id: runId,
       dedupe_key: dedupeKey,
+      session_policy: sessionPolicy,
+      session_epoch: sessionEpoch,
     },
     mentioned: true,
     receivedAt: Date.now(),

--- a/packages/protocol-core/src/client.ts
+++ b/packages/protocol-core/src/client.ts
@@ -1043,6 +1043,7 @@ export class BotCordClient {
     enabled?: boolean;
     schedule: AgentScheduleSpec;
     payload?: AgentSchedulePayload;
+    session_policy?: AgentSchedule["session_policy"];
   }): Promise<AgentSchedule> {
     const resp = await this.hubFetch("/hub/schedules", {
       method: "POST",
@@ -1051,6 +1052,7 @@ export class BotCordClient {
         enabled: params.enabled ?? true,
         schedule: params.schedule,
         payload: params.payload,
+        session_policy: params.session_policy,
       }),
     });
     return (await resp.json()) as AgentSchedule;
@@ -1063,6 +1065,7 @@ export class BotCordClient {
       enabled?: boolean;
       schedule?: AgentScheduleSpec;
       payload?: AgentSchedulePayload;
+      session_policy?: AgentSchedule["session_policy"];
     },
   ): Promise<AgentSchedule> {
     const resp = await this.hubFetch(`/hub/schedules/${encodeURIComponent(scheduleId)}`, {

--- a/packages/protocol-core/src/types.ts
+++ b/packages/protocol-core/src/types.ts
@@ -355,6 +355,8 @@ export type AgentSchedulePayload = {
   message: string;
 };
 
+export type AgentScheduleSessionPolicy = "fresh_per_run" | "reuse_per_schedule";
+
 export type AgentSchedule = {
   id: string;
   agent_id: string;
@@ -362,6 +364,7 @@ export type AgentSchedule = {
   enabled: boolean;
   schedule: AgentScheduleSpec;
   payload: AgentSchedulePayload;
+  session_policy: AgentScheduleSessionPolicy;
   created_by: "owner" | "agent" | string;
   next_fire_at: string | null;
   last_fire_at: string | null;


### PR DESCRIPTION
## Summary
- add explicit schedule runtime session policy: `fresh_per_run` and `reuse_per_schedule`
- persist policy/epoch through Hub APIs and pass them to daemon `wake_agent`
- add Dashboard selector and CLI `--session-policy` option, including `cli/skills/botcord/SKILL.md`
- preserve legacy schedule behavior when existing rows have no policy

## Verification
- `uv run pytest tests/test_app/test_agent_schedules.py`
- `pnpm --filter @botcord/protocol-core build`
- `pnpm --filter @botcord/cli build`
- `pnpm --filter @botcord/daemon build`
- `pnpm --filter @botcord/daemon test -- src/__tests__/provision.test.ts`
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy pnpm build` in `frontend/`

## Risk / rollout
- migration adds nullable `session_policy` for existing rows and keeps old daemon session keys until schedules are edited or given an explicit policy
- new schedules default to `fresh_per_run`; users can opt into `reuse_per_schedule`
