### PR TITLE
fix: include workspace skills in daemon snapshots

### DIFF
--- a/packages/daemon/src/__tests__/skill-index.test.ts
+++ b/packages/daemon/src/__tests__/skill-index.test.ts
@@ -79,6 +79,12 @@ describe("skill snapshots", () => {
 
   it("scans Codex .system skills and prefers Codex copies for Codex agents", () => {
     const agentId = "ag_codex_system";
+    writeSkill(path.join(agentWorkspaceDir(agentId), "skills"), "shared", "Generic workspace copy");
+    writeSkill(
+      path.join(agentWorkspaceDir(agentId), "skills"),
+      "workspace-only",
+      "Generic workspace skill",
+    );
     writeSkill(path.join(agentWorkspaceDir(agentId), ".claude", "skills"), "shared", "Claude copy");
     writeSkill(path.join(agentCodexHomeDir(agentId), "skills"), "shared", "Codex copy");
     writeSkill(
@@ -97,10 +103,16 @@ describe("skill snapshots", () => {
       "agent-system",
       "imagegen",
       "shared",
+      "workspace-only",
     ]);
     expect(codexScanned.find((s) => s.name === "shared")).toMatchObject({
       source: "agent-codex",
       description: "Codex copy",
+    });
+    expect(codexScanned.find((s) => s.name === "workspace-only")).toMatchObject({
+      source: "agent-workspace",
+      runtime: "codex",
+      description: "Generic workspace skill",
     });
 
     const claudeScanned = scanSoftSkills(agentId, { runtime: "claude-code" });
@@ -114,6 +126,47 @@ describe("skill snapshots", () => {
       .toBe("workspace");
     expect(snapshot.skills.find((s) => s.name === "imagegen")?.source)
       .toBe("runtime-global");
+    expect(snapshot.skills.find((s) => s.name === "workspace-only"))
+      .toMatchObject({
+        source: "workspace",
+        sourceDetail: "agent-workspace",
+        runtime: "codex",
+        path: path.join(agentWorkspaceDir(agentId), "skills", "workspace-only", "SKILL.md"),
+      });
+  });
+
+  it("scans generic workspace skills and keeps Claude-native copies ahead", () => {
+    const agentId = "ag_claude_workspace";
+    const genericSkills = path.join(agentWorkspaceDir(agentId), "skills");
+    const claudeSkills = path.join(agentWorkspaceDir(agentId), ".claude", "skills");
+    writeSkill(genericSkills, "shared", "Generic workspace copy");
+    writeSkill(genericSkills, "workspace-only", "Generic workspace skill");
+    writeSkill(claudeSkills, "shared", "Claude copy");
+
+    const claudeScanned = scanSoftSkills(agentId, { runtime: "claude-code" });
+    expect(claudeScanned.map((s) => s.name)).toEqual([
+      "shared",
+      "workspace-only",
+    ]);
+    expect(claudeScanned.find((s) => s.name === "shared")).toMatchObject({
+      source: "agent-claude",
+      runtime: "claude-code",
+      description: "Claude copy",
+    });
+    expect(claudeScanned.find((s) => s.name === "workspace-only")).toMatchObject({
+      source: "agent-workspace",
+      runtime: "claude-code",
+      description: "Generic workspace skill",
+    });
+
+    const snapshot = collectAgentSkillSnapshot(agentId, { runtime: "claude-code" });
+    expect(snapshot.skills.find((s) => s.name === "workspace-only"))
+      .toMatchObject({
+        source: "workspace",
+        sourceDetail: "agent-workspace",
+        runtime: "claude-code",
+        path: path.join(genericSkills, "workspace-only", "SKILL.md"),
+      });
   });
 
   it("scans Hermes home/profile skills without mixing Claude or Codex dirs", () => {

--- a/packages/daemon/src/skill-index.ts
+++ b/packages/daemon/src/skill-index.ts
@@ -69,6 +69,11 @@ export function defaultSkillDirs(
     source: "agent-claude",
     runtime: "claude-code",
   };
+  const agentWorkspace = {
+    dir: path.join(agentWorkspaceDir(agentId), "skills"),
+    source: "agent-workspace",
+    ...(opts.runtime ? { runtime: opts.runtime } : {}),
+  };
   const agentCodex = {
     dir: path.join(agentCodexHomeDir(agentId), "skills"),
     source: "agent-codex",
@@ -92,6 +97,7 @@ export function defaultSkillDirs(
   switch (runtimeFamily(opts.runtime)) {
     case "codex":
       dirs.push(agentCodex);
+      dirs.push(agentWorkspace);
       if (includeGlobal) {
         dirs.push({
           dir: path.join(homedir(), ".codex", "skills"),
@@ -102,9 +108,11 @@ export function defaultSkillDirs(
       break;
     case "hermes":
       dirs.push(agentHermes);
+      dirs.push(agentWorkspace);
       break;
     case "gemini":
       dirs.push(...agentGemini);
+      dirs.push(agentWorkspace);
       if (includeGlobal) {
         dirs.push(
           {
@@ -122,6 +130,7 @@ export function defaultSkillDirs(
       break;
     case "claude":
       dirs.push(agentClaude);
+      dirs.push(agentWorkspace);
       if (includeGlobal) {
         dirs.push({
           dir: path.join(homedir(), ".claude", "skills"),
@@ -131,6 +140,7 @@ export function defaultSkillDirs(
       }
       break;
     case "other":
+      dirs.push(agentWorkspace);
       break;
   }
 


### PR DESCRIPTION
## Summary
- scan generic per-agent workspace skills at agent workspace skills directory
- map agent-workspace snapshot entries to the dashboard workspace bucket
- preserve runtime-native same-name precedence for Codex and Claude skills

## Tests
- MISE_TRUSTED_CONFIG_PATHS=$PWD pnpm --filter @botcord/daemon test -- --run src/__tests__/skill-index.test.ts
- git diff --check -- packages/daemon/src/skill-index.ts packages/daemon/src/__tests__/skill-index.test.ts

Code Reviewer reviewed the original worktree with no findings; clean latest-main worktree review was requested and acknowledged before merge.