### PR TITLE
fix: preserve leading spaces in chat messages

### DIFF
--- a/frontend/src/components/dashboard/MessageComposer.test.ts
+++ b/frontend/src/components/dashboard/MessageComposer.test.ts
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import MessageComposer, {
   getClipboardFiles,
+  getSendableMessageText,
   isImeComposing,
   MESSAGE_COMPOSER_TEXTAREA_ARIA_AUTOCOMPLETE,
   MESSAGE_COMPOSER_TEXTAREA_AUTOCOMPLETE,
@@ -39,6 +40,20 @@ describe("message composer autofill metadata", () => {
     expect(getAttribute("data-bwignore")).toBe("true");
     expect(getAttribute("data-protonpass-ignore")).toBe("true");
     expect(getAttribute("aria-autocomplete")).toBe("none");
+  });
+});
+
+describe("getSendableMessageText", () => {
+  it("preserves leading spaces in text sent to the callback", () => {
+    expect(getSendableMessageText("  hello", false)).toBe("  hello");
+  });
+
+  it("blocks whitespace-only messages when there are no files", () => {
+    expect(getSendableMessageText("   \n\t", false)).toBeNull();
+  });
+
+  it("allows file-only sends with an empty text payload", () => {
+    expect(getSendableMessageText("   \n\t", true)).toBe("");
   });
 });
 

--- a/frontend/src/components/dashboard/MessageComposer.tsx
+++ b/frontend/src/components/dashboard/MessageComposer.tsx
@@ -99,6 +99,11 @@ export function getClipboardFiles(
     .filter((file): file is File => Boolean(file));
 }
 
+export function getSendableMessageText(text: string, hasFiles: boolean): string | null {
+  if (text.trim().length > 0) return text;
+  return hasFiles ? "" : null;
+}
+
 export default function MessageComposer({
   onSend,
   onTransfer,
@@ -270,10 +275,10 @@ export default function MessageComposer({
   }, [pickedMentions, text, mentionCandidates]);
 
   const handleSend = useCallback(async () => {
-    const trimmed = text.trim();
     const hasFiles = files.length > 0;
     const hasLengthError = text.length > MESSAGE_MAX_LENGTH || showLengthError;
-    if ((!trimmed && !hasFiles) || disabled || hasLengthError) return;
+    const sendText = getSendableMessageText(text, hasFiles);
+    if (sendText === null || disabled || hasLengthError) return;
 
     const raw = files.map((pf) => pf.file);
     for (const pf of files) { if (pf.preview) URL.revokeObjectURL(pf.preview); }
@@ -287,7 +292,7 @@ export default function MessageComposer({
       inputRef.current.style.height = "auto";
     }
 
-    await onSend(trimmed, raw, mentions.length > 0 ? mentions : undefined);
+    await onSend(sendText, raw, mentions.length > 0 ? mentions : undefined);
   }, [text, files, disabled, showLengthError, activeMentions, onSend]);
 
   const handleKeyDown = (e: ReactKeyboardEvent<HTMLTextAreaElement>) => {


### PR DESCRIPTION
## Summary
- preserve original chat composer text when sending non-empty messages
- keep whitespace-only messages blocked when there are no attachments
- keep file-only sends using an empty text payload

## Verification
- MISE_TRUSTED_CONFIG_PATHS=/home/zhejianzhang/.botcord/agents/ag_6ed83830e906/workspace/botcord-preserve-leading-spaces pnpm test -- src/components/dashboard/MessageComposer.test.ts
- git diff --check

Code Reviewer: no findings.