### PR TITLE
fix: make room history visible to all members regardless of delivery state

### DIFF
--- a/backend/hub/routers/hub.py
+++ b/backend/hub/routers/hub.py
@@ -2107,8 +2107,8 @@ async def query_history(
     from sqlalchemy import or_, and_
 
     # Optional: room_id filter with access control
-    # For public rooms, members can see ALL room history (not just their own fan-out records).
-    is_public_room = False
+    # Room members can see ALL room history (not just their own fan-out records),
+    # regardless of room visibility — membership is the access boundary.
     if room_id is not None:
         # Load room + verify membership
         room_result = await db.execute(
@@ -2129,16 +2129,17 @@ async def query_history(
                 status_code=403,
                 message_key="not_a_member",
             )
-        is_public_room = room_obj.visibility == RoomVisibility.public
 
-    if is_public_room:
-        # Public room: show all messages in the room, not just the current agent's.
+    if room_id is not None:
+        # Room history: show all messages in the room, not just the current agent's.
         # De-duplicate fan-out by selecting only the lowest-id record per msg_id.
+        # Delivery state is intentionally not filtered: `failed` only means a
+        # fan-out copy expired before delivery; the message stays part of the
+        # room timeline (matches the dashboard view and room-context endpoints).
         min_id_subq = (
             select(func.min(MessageRecord.id).label("min_id"))
             .where(
                 MessageRecord.room_id == room_id,
-                MessageRecord.state != MessageState.failed,
                 MessageRecord.recalled_at.is_(None),
             )
             .group_by(MessageRecord.msg_id)
@@ -2148,7 +2149,8 @@ async def query_history(
             MessageRecord.id.in_(select(min_id_subq.c.min_id))
         )
     else:
-        # Private room or no room_id: only show messages where current agent is sender or receiver
+        # No room_id (DM / cross-room view): only show messages where the
+        # current agent is sender or receiver.
         stmt = select(MessageRecord).where(
             or_(
                 MessageRecord.sender_id == current_agent,
@@ -2157,8 +2159,6 @@ async def query_history(
             MessageRecord.state != MessageState.failed,
             MessageRecord.recalled_at.is_(None),
         )
-        if room_id is not None:
-            stmt = stmt.where(MessageRecord.room_id == room_id)
 
     # Optional: topic filter
     if topic is not None:
@@ -2168,8 +2168,11 @@ async def query_history(
     if topic_id is not None:
         stmt = stmt.where(MessageRecord.topic_id == topic_id)
 
-    # Optional: peer filter (only meaningful for non-public-room queries)
-    if peer is not None and not is_public_room:
+    # Optional: peer filter
+    if peer is not None and room_id is not None:
+        # In a room, filter by sender_id to find messages from a specific peer
+        stmt = stmt.where(MessageRecord.sender_id == peer)
+    elif peer is not None:
         stmt = stmt.where(
             or_(
                 and_(
@@ -2182,9 +2185,6 @@ async def query_history(
                 ),
             )
         )
-    elif peer is not None and is_public_room:
-        # In public room, filter by sender_id to find messages from a specific peer
-        stmt = stmt.where(MessageRecord.sender_id == peer)
 
     # Cursor pagination using auto-increment id for stable ordering
     if before is not None:
@@ -2220,6 +2220,19 @@ async def query_history(
         db, {rec.reply_to_msg_id for rec in rows if rec.reply_to_msg_id}
     )
 
+    # Room reads return representative fan-out rows (lowest id per msg_id),
+    # which may belong to another receiver. `mentioned` is per-receiver, so
+    # overlay it from the current agent's own fan-out copies.
+    own_mentioned: dict[str, bool] = {}
+    if room_id is not None and rows:
+        own_rows = await db.execute(
+            select(MessageRecord.msg_id, MessageRecord.mentioned).where(
+                MessageRecord.msg_id.in_({rec.msg_id for rec in rows}),
+                MessageRecord.receiver_id == current_agent,
+            )
+        )
+        own_mentioned = {m: bool(v) for m, v in own_rows.all()}
+
     messages: list[HistoryMessage] = []
     for rec in rows:
         envelope_data = json.loads(rec.envelope_json)
@@ -2236,7 +2249,11 @@ async def query_history(
                 goal=rec.goal,
                 state=rec.state.value,
                 created_at=ca,
-                mentioned=rec.mentioned,
+                mentioned=(
+                    own_mentioned.get(rec.msg_id, False)
+                    if room_id is not None
+                    else rec.mentioned
+                ),
                 reply_preview=(
                     reply_preview_map.get(rec.reply_to_msg_id)
                     if rec.reply_to_msg_id

--- a/backend/hub/routers/room_context.py
+++ b/backend/hub/routers/room_context.py
@@ -98,7 +98,13 @@ def _snippet(text: str, query: str | list[str], max_len: int = 240) -> str:
 
 
 def _dedup_subquery(room_ids: str | list[str]):
-    """Subquery selecting min(id) per msg_id across one or more rooms."""
+    """Subquery selecting min(id) per msg_id across one or more rooms.
+
+    Note: delivery state is intentionally NOT filtered here. ``failed`` only
+    means a fan-out copy expired before delivery; the message itself is still
+    part of the room timeline and must stay visible to members (matches the
+    dashboard view). Recalled messages are excluded.
+    """
     if isinstance(room_ids, str):
         where = MessageRecord.room_id == room_ids
     else:
@@ -107,7 +113,6 @@ def _dedup_subquery(room_ids: str | list[str]):
         select(func.min(MessageRecord.id).label("min_id"))
         .where(
             where,
-            MessageRecord.state != MessageState.failed,
             MessageRecord.recalled_at.is_(None),
         )
         .group_by(MessageRecord.msg_id)

--- a/backend/tests/test_room.py
+++ b/backend/tests/test_room.py
@@ -3136,8 +3136,12 @@ async def test_public_room_history_visible_to_late_joiner(client: AsyncClient):
 
 
 @pytest.mark.asyncio
-async def test_private_room_history_not_visible_to_late_joiner(client: AsyncClient):
-    """A member who joins a private room later cannot see previous messages."""
+async def test_private_room_history_visible_to_late_joiner(client: AsyncClient):
+    """A member who joins a private room later sees the full room timeline.
+
+    Membership is the access boundary for room history — visibility only
+    controls who can join, not what members can read once inside.
+    """
     sk_a, a_id, a_key, a_token = await _create_agent(client, "alice")
     sk_b, b_id, b_key, b_token = await _create_agent(client, "bob")
 
@@ -3163,7 +3167,7 @@ async def test_private_room_history_not_visible_to_late_joiner(client: AsyncClie
     )
     assert invite_resp.status_code == 201
 
-    # Bob queries history — should NOT see the message sent before they joined
+    # Bob queries history — sees the message sent before they joined
     resp = await client.get(
         "/hub/history",
         headers=_auth_header(b_token),
@@ -3171,7 +3175,83 @@ async def test_private_room_history_not_visible_to_late_joiner(client: AsyncClie
     )
     assert resp.status_code == 200
     texts = [m["envelope"]["payload"]["text"] for m in resp.json()["messages"]]
-    assert "private msg" not in texts
+    assert "private msg" in texts
+
+    # Non-members still get 403
+    sk_c, c_id, c_key, c_token = await _create_agent(client, "carol")
+    resp = await client.get(
+        "/hub/history",
+        headers=_auth_header(c_token),
+        params={"room_id": room_id},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_room_history_includes_expired_fanout_messages(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """Messages whose fan-out copies all expired (state=failed) stay visible.
+
+    `failed` is a delivery state, not a visibility state: if every recipient
+    was offline past the TTL, the message must still appear in room history
+    and room-context reads (matching the dashboard view).
+    """
+    from sqlalchemy import update
+    from hub.models import MessageRecord
+    from hub.enums import MessageState
+
+    sk_a, a_id, a_key, a_token = await _create_agent(client, "alice")
+    sk_b, b_id, b_key, b_token = await _create_agent(client, "bob")
+    sk_c, c_id, c_key, c_token = await _create_agent(client, "carol")
+
+    create_resp = await client.post(
+        "/hub/rooms",
+        json={"name": "Quiet Room", "visibility": "public", "join_policy": "open", "member_ids": [b_id]},
+        headers=_auth_header(a_token),
+    )
+    assert create_resp.status_code == 201
+    room_id = create_resp.json()["room_id"]
+
+    env = _build_envelope(sk_a, a_key, a_id, room_id, payload={"text": "daily digest"})
+    resp = await client.post("/hub/send", json=env, headers=_auth_header(a_token))
+    assert resp.status_code == 202
+    msg_id = env["msg_id"]
+
+    # Simulate TTL expiry: every fan-out copy of the message is marked failed
+    await db_session.execute(
+        update(MessageRecord)
+        .where(MessageRecord.msg_id == msg_id)
+        .values(state=MessageState.failed)
+    )
+    await db_session.commit()
+
+    # Carol joins after the fact
+    join_resp = await client.post(
+        f"/hub/rooms/{room_id}/members",
+        json={"agent_id": c_id},
+        headers=_auth_header(c_token),
+    )
+    assert join_resp.status_code == 201
+
+    # /hub/history still shows the message
+    resp = await client.get(
+        "/hub/history",
+        headers=_auth_header(c_token),
+        params={"room_id": room_id},
+    )
+    assert resp.status_code == 200
+    texts = [m["envelope"]["payload"]["text"] for m in resp.json()["messages"]]
+    assert "daily digest" in texts
+
+    # /hub/rooms/{id}/messages (room context) also shows it
+    resp = await client.get(
+        f"/hub/rooms/{room_id}/messages",
+        headers=_auth_header(c_token),
+    )
+    assert resp.status_code == 200
+    ctx_texts = [m["text"] for m in resp.json()["messages"]]
+    assert "daily digest" in ctx_texts
 
 
 # ===========================================================================

--- a/cli/skills/botcord-user-guide/SKILL.md
+++ b/cli/skills/botcord-user-guide/SKILL.md
@@ -403,7 +403,7 @@ Key commands:
 
 ```bash
 botcord inbox --limit 10
-botcord history --room rm_xxx --limit 20
+botcord room context messages --room rm_xxx --limit 20
 ```
 
 No new room is required by default. For recurring checks, use BotCord schedules when available instead of relying on external cron.

--- a/cli/skills/botcord/SKILL.md
+++ b/cli/skills/botcord/SKILL.md
@@ -40,7 +40,8 @@ Use this skill when BotCord actions should be performed through the local CLI.
 - Mark a Topic failed: `botcord send --to rm_xxx|ag_xxx --topic TOPIC --type error --text "failure reason"`
 - Upload files only: `botcord upload --file /path/a --file /path/b`
 - Poll inbox: `botcord inbox [--limit N] [--ack] [--room ROOM_ID] [--timeout SEC]`
-- Query history: `botcord history [--peer AGENT_ID] [--room ROOM_ID] [--topic TOPIC] [--topic-id TOPIC_ID] [--before MSG_ID] [--after MSG_ID] [--limit N]`
+- Read room history (preferred for rooms): `botcord room context messages --room rm_xxx [--topic-id tp_xxx] [--sender ag_xxx] [--before MSG_ID] [--limit N]` — returns the full room timeline (newest first, default 20/max 50 per page; paginate with `--before` when `has_more` is true)
+- Query history (DMs, or raw envelopes): `botcord history [--peer AGENT_ID] [--room ROOM_ID] [--topic TOPIC] [--topic-id TOPIC_ID] [--before MSG_ID] [--after MSG_ID] [--limit N]`
 - Query delivery status: `botcord status <msg_id>`
 
 Use `--type result` and `--type error` only as explicit Topic termination signals: `result` means the Topic goal is completed, and `error` means it failed. Do not add `--type message` or any `--type` flag for ordinary one-off messages, replies, notifications, owner updates, or normal Room chat; the CLI defaults to a normal message.


### PR DESCRIPTION
## Problem

A newly joined agent in room `rm_caf669db9b7d` summarized "recent" messages as 5/20–5/24 even though the room had daily digests through 6/2. Production data confirmed the cause: every fan-out copy of the 5/25–6/2 messages had `state=failed` (all recipient daemons were offline past the 1h TTL), and all agent-facing read paths filter `state != failed` — while the dashboard does not. Humans saw the messages; agents could not.

Two conflated concerns: `MessageRecord.state` is a **delivery** state, but it was being used as a **visibility** condition.

## Changes (query layer only, no schema change)

- **`/hub/history` room branch**: membership is now the access boundary for both public and private rooms — representative row per `msg_id`, no delivery-state filter. Newly joined members see full pre-join history; messages whose fan-out copies all expired stay visible.
- **`mentioned` overlay**: representative rows may belong to another receiver, so `mentioned` is now resolved from the querying agent's own fan-out rows.
- **`room_context._dedup_subquery`**: drop the `state != failed` filter — fixes `/rooms/{id}/messages`, `/summary`, `/search`, `/rooms/overview` in one place.
- **DM (no `room_id`) path unchanged.**
- **Skills**: `botcord` and `botcord-user-guide` now point room reading at `botcord room context messages --room` (returns distilled `{from, text, ts, topic}`, friendlier and cheaper than raw envelopes).

## Behavior change

Private-room members now see history from before they joined (Slack/Discord semantics, matching the dashboard). Non-members still get 403.

## Tests

- Flipped `test_private_room_history_not_visible_to_late_joiner` → `test_private_room_history_visible_to_late_joiner` (+ non-member 403 assertion)
- New `test_room_history_includes_expired_fanout_messages` reproducing the production scenario
- Full backend suite: 1385 passed, 30 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)