### PR TITLE
fix: keep BotCord inbox drain responsive

### DIFF
--- a/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
+++ b/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
@@ -705,6 +705,77 @@ describe("createBotCordChannel — ack + dedup", () => {
     }
   });
 
+  it("keeps draining new inbox updates after a slow turn is accepted", async () => {
+    const server = await startAuthOkServer();
+    try {
+      const slow = makeInbox({ hub_msg_id: "m_slow", room_id: "rm_group_slow" });
+      const owner = makeInbox({
+        hub_msg_id: "m_owner",
+        room_id: "rm_oc_owner",
+        text: "hi",
+        envelope: {
+          from: "ag_self",
+          payload: { text: "hi" },
+        } as InboxMessage["envelope"],
+      });
+      const poll = vi
+        .fn()
+        .mockResolvedValueOnce({ messages: [slow], count: 1, has_more: false })
+        .mockResolvedValueOnce({ messages: [owner], count: 1, has_more: false })
+        .mockResolvedValue({ messages: [], count: 0, has_more: false });
+      const client = makeClient({
+        pollInbox: poll,
+        getHubUrl: vi.fn().mockReturnValue(server.url),
+      });
+      const channel = createBotCordChannel({
+        id: "botcord-main",
+        accountId: "ag_self",
+        agentId: "ag_self",
+        client,
+        hubBaseUrl: server.url,
+        pollIntervalMs: 0,
+      });
+      const abort = new AbortController();
+      const emits: GatewayInboundEnvelope[] = [];
+      let releaseSlow!: () => void;
+      const slowDone = new Promise<void>((resolve) => {
+        releaseSlow = resolve;
+      });
+      let slowAccepted!: () => void;
+      const slowAcceptedPromise = new Promise<void>((resolve) => {
+        slowAccepted = resolve;
+      });
+
+      const startP = channel.start({
+        config: stubConfig,
+        accountId: "ag_self",
+        abortSignal: abort.signal,
+        log: silentLog,
+        emit: async (env) => {
+          emits.push(env);
+          await env.ack?.accept();
+          if (env.message.id === "m_slow") {
+            slowAccepted();
+            await slowDone;
+          }
+        },
+        setStatus: () => {},
+      });
+
+      await slowAcceptedPromise;
+      server.connections[0]!.send(JSON.stringify({ type: "inbox_update" }));
+
+      await vi.waitFor(() => expect(poll).toHaveBeenCalledTimes(2));
+      await vi.waitFor(() => expect(emits.map((e) => e.message.id)).toEqual(["m_slow", "m_owner"]));
+
+      releaseSlow();
+      abort.abort();
+      await startP;
+    } finally {
+      await server.close();
+    }
+  });
+
   it("locally revokes the channel when Hub reports the agent is unclaimed", async () => {
     const server = await startAuthOkServer();
     try {

--- a/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
+++ b/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
@@ -776,6 +776,96 @@ describe("createBotCordChannel — ack + dedup", () => {
     }
   });
 
+  it("keeps same room handoffs ordered while other rooms continue draining", async () => {
+    const server = await startAuthOkServer();
+    try {
+      const slow = makeInbox({
+        hub_msg_id: "m_slow",
+        room_id: "rm_group_same",
+        topic_id: "tp_same",
+      });
+      const sameRoomNext = makeInbox({
+        hub_msg_id: "m_same_next",
+        room_id: "rm_group_same",
+        topic_id: "tp_same",
+        text: "same room next",
+        envelope: {
+          msg_id: "env_same_next",
+          payload: { text: "same room next" },
+        } as InboxMessage["envelope"],
+      });
+      const otherRoom = makeInbox({
+        hub_msg_id: "m_other",
+        room_id: "rm_group_other",
+        text: "other room",
+        envelope: {
+          msg_id: "env_other",
+          payload: { text: "other room" },
+        } as InboxMessage["envelope"],
+      });
+      const poll = vi
+        .fn()
+        .mockResolvedValueOnce({ messages: [slow], count: 1, has_more: false })
+        .mockResolvedValueOnce({ messages: [sameRoomNext, otherRoom], count: 2, has_more: false })
+        .mockResolvedValueOnce({ messages: [sameRoomNext], count: 1, has_more: false })
+        .mockResolvedValue({ messages: [], count: 0, has_more: false });
+      const client = makeClient({
+        pollInbox: poll,
+        getHubUrl: vi.fn().mockReturnValue(server.url),
+      });
+      const channel = createBotCordChannel({
+        id: "botcord-main",
+        accountId: "ag_self",
+        agentId: "ag_self",
+        client,
+        hubBaseUrl: server.url,
+        pollIntervalMs: 0,
+      });
+      const abort = new AbortController();
+      const emits: GatewayInboundEnvelope[] = [];
+      let releaseSlow!: () => void;
+      const slowDone = new Promise<void>((resolve) => {
+        releaseSlow = resolve;
+      });
+
+      const startP = channel.start({
+        config: stubConfig,
+        accountId: "ag_self",
+        abortSignal: abort.signal,
+        log: silentLog,
+        emit: async (env) => {
+          emits.push(env);
+          await env.ack?.accept();
+          if (env.message.id === "m_slow") {
+            await slowDone;
+          }
+        },
+        setStatus: () => {},
+      });
+
+      await vi.waitFor(() => expect(emits.map((e) => e.message.id)).toEqual(["m_slow"]));
+      server.connections[0]!.send(JSON.stringify({ type: "inbox_update" }));
+
+      await vi.waitFor(() => expect(poll).toHaveBeenCalledTimes(2));
+      await vi.waitFor(() => expect(emits.map((e) => e.message.id)).toEqual(["m_slow", "m_other"]));
+      expect(client.ackMessages).not.toHaveBeenCalledWith(["m_same_next"]);
+
+      server.connections[0]!.send(JSON.stringify({ type: "inbox_update" }));
+      await vi.waitFor(() => expect(poll).toHaveBeenCalledTimes(3));
+      expect(client.ackMessages).not.toHaveBeenCalledWith(["m_same_next"]);
+
+      releaseSlow();
+      await vi.waitFor(() =>
+        expect(emits.map((e) => e.message.id)).toEqual(["m_slow", "m_other", "m_same_next"]),
+      );
+      await vi.waitFor(() => expect(client.ackMessages).toHaveBeenCalledWith(["m_same_next"]));
+      abort.abort();
+      await startP;
+    } finally {
+      await server.close();
+    }
+  });
+
   it("locally revokes the channel when Hub reports the agent is unclaimed", async () => {
     const server = await startAuthOkServer();
     try {

--- a/packages/daemon/src/gateway/channels/botcord.ts
+++ b/packages/daemon/src/gateway/channels/botcord.ts
@@ -541,13 +541,12 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
       else groups.set(key, [msg]);
     }
 
-    // Emit groups in parallel: each `(room_id, topic)` group is an independent
+    // Hand groups off independently: each `(room_id, topic)` group is its own
     // conversation thread, and the dispatcher already keys its per-turn queue
     // by `(channel, accountId, roomId, threadId)` (see `buildQueueKey` in
-    // dispatcher.ts). Awaiting groups serially here forced a slow turn in
-    // room A to block room B's turn from starting; running them concurrently
-    // lets the dispatcher's per-room queues actually run in parallel.
-    const emitTasks: Promise<void>[] = [];
+    // dispatcher.ts). Do not await runtime completion here; one slow room turn
+    // must not hold the channel-wide inbox drain and starve newer messages
+    // from other rooms.
     for (const group of groups.values()) {
       const normalized = normalizeInboxBatch(group, {
         channelId: options.id,
@@ -573,21 +572,25 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
           },
         },
       };
-      emitTasks.push(
-        emit(envelope).then(
-          () => {
-            emittedGroups += 1;
-          },
-          (err) => {
-            log.error("botcord emit threw", {
-              hubMsgIds: hubIds,
-              err: String(err),
-            });
-          },
-        ),
-      );
+      emittedGroups += 1;
+      // Fire and continue draining. The dispatcher acks after it accepts
+      // ownership, and the seen-cache suppresses any duplicate observations
+      // before that ack reaches Hub. Awaiting the runtime here would make one
+      // long room turn starve newer inbox messages from other rooms.
+      try {
+        void emit(envelope).catch((err) => {
+          log.error("botcord emit threw", {
+            hubMsgIds: hubIds,
+            err: String(err),
+          });
+        });
+      } catch (err) {
+        log.error("botcord emit threw", {
+          hubMsgIds: hubIds,
+          err: String(err),
+        });
+      }
     }
-    await Promise.all(emitTasks);
     logDrain();
     return { hasMore: Boolean(resp.has_more) };
   }

--- a/packages/daemon/src/gateway/channels/botcord.ts
+++ b/packages/daemon/src/gateway/channels/botcord.ts
@@ -426,6 +426,8 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
   const factory = options.clientFactory ?? defaultClientFactory;
   let clientRef: BotCordChannelClient | null = options.client ?? null;
   const seenMessages = new Set<string>();
+  const pendingHandoffMessages = new Set<string>();
+  const handoffTails = new Map<string, Promise<void>>();
   let stopCallback: (() => void) | null = null;
 
   let statusSnapshot: ChannelStatusSnapshot = {
@@ -445,6 +447,29 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
       if (first) seenMessages.delete(first);
     }
     return true;
+  }
+
+  function forgetSeen(hubMsgIds: string[]): void {
+    for (const hubMsgId of hubMsgIds) {
+      seenMessages.delete(hubMsgId);
+      pendingHandoffMessages.delete(hubMsgId);
+    }
+  }
+
+  function inboxGroupKey(msg: InboxMessage): string {
+    const topic = msg.topic_id ?? msg.topic ?? "";
+    return `${options.id}:${options.accountId}:${msg.room_id ?? ""}:${topic}`;
+  }
+
+  function queueGroupHandoff(groupKey: string, run: () => Promise<void>): void {
+    const previous = handoffTails.get(groupKey) ?? Promise.resolve();
+    const current = previous.catch(() => undefined).then(run);
+    handoffTails.set(groupKey, current);
+    void current.finally(() => {
+      if (handoffTails.get(groupKey) === current) {
+        handoffTails.delete(groupKey);
+      }
+    });
   }
 
   function ensureClient(): BotCordChannelClient {
@@ -500,6 +525,10 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
     // same conversation thread folds into one turn so the agent sees all
     // new messages at once instead of running N turns back-to-back.
     for (const msg of msgs) {
+      if (pendingHandoffMessages.has(msg.hub_msg_id)) {
+        duplicateCount += 1;
+        continue;
+      }
       if (!rememberSeen(msg.hub_msg_id)) {
         duplicateCount += 1;
         try {
@@ -534,8 +563,7 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
     // iterating the map yields groups with the same external chronology.
     const groups = new Map<string, InboxMessage[]>();
     for (const msg of eligible) {
-      const topic = msg.topic_id ?? msg.topic ?? "";
-      const key = `${msg.room_id ?? ""}:${topic}`;
+      const key = inboxGroupKey(msg);
       const list = groups.get(key);
       if (list) list.push(msg);
       else groups.set(key, [msg]);
@@ -555,6 +583,13 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
       if (!normalized) continue;
 
       const hubIds = group.map((m) => m.hub_msg_id);
+      for (const hubId of hubIds) pendingHandoffMessages.add(hubId);
+      let accepted = false;
+      const markAccepted = () => {
+        if (accepted) return;
+        accepted = true;
+        for (const hubId of hubIds) pendingHandoffMessages.delete(hubId);
+      };
       const envelope: GatewayInboundEnvelope = {
         message: normalized,
         ack: {
@@ -568,28 +603,29 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
                 hubMsgIds: hubIds,
                 err: String(err),
               });
+            } finally {
+              markAccepted();
             }
           },
         },
       };
       emittedGroups += 1;
-      // Fire and continue draining. The dispatcher acks after it accepts
-      // ownership, and the seen-cache suppresses any duplicate observations
-      // before that ack reaches Hub. Awaiting the runtime here would make one
-      // long room turn starve newer inbox messages from other rooms.
-      try {
-        void emit(envelope).catch((err) => {
+      // Fire and continue draining, but preserve ordering per room/topic.
+      // Different conversation threads can run independently; a newer message
+      // in the same thread must not overtake an older handoff before the
+      // dispatcher has processed it.
+      queueGroupHandoff(inboxGroupKey(group[0]!), async () => {
+        try {
+          await emit(envelope);
+          markAccepted();
+        } catch (err) {
+          if (!accepted) forgetSeen(hubIds);
           log.error("botcord emit threw", {
             hubMsgIds: hubIds,
             err: String(err),
           });
-        });
-      } catch (err) {
-        log.error("botcord emit threw", {
-          hubMsgIds: hubIds,
-          err: String(err),
-        });
-      }
+        }
+      });
     }
     logDrain();
     return { hasMore: Boolean(resp.has_more) };


### PR DESCRIPTION
## Summary
- Stop BotCord channel inbox drains from awaiting full dispatcher/runtime completion after handing off an inbox envelope.
- Keep per-room dispatcher queues responsible for runtime execution while the channel continues draining newer inbox updates.
- Add a regression test for a slow group turn followed by an owner-chat inbox update.

## Verification
- `cd packages/daemon && pnpm test -- src/gateway/__tests__/botcord-channel.test.ts`
- `cd packages/daemon && pnpm build`
- `git diff --check origin/main..HEAD`

## Risk / rollout
- Daemon users need an updated daemon build/restart for the fix to take effect.
- Duplicate observations before Hub ack are still suppressed by the existing seen-cache; dispatcher ack ownership remains unchanged.