### PR TITLE
fix: allow recalling error messages

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -127,6 +127,7 @@ class ChatAttachment(BaseModel):
 
 
 _RECEIPT_TYPES = frozenset({"ack", "result", "error"})
+_RECALLABLE_MESSAGE_TYPES = frozenset({"message", "error"})
 _MESSAGE_RECALL_WINDOW = datetime.timedelta(minutes=2)
 _RECALLED_MESSAGE_PREVIEW = "Message recalled"
 
@@ -2525,8 +2526,8 @@ async def recall_room_message(
 
     target = records[0]
     parsed = extract_text_from_envelope(target.envelope_json)
-    if parsed["type"] != "message":
-        raise HTTPException(status_code=400, detail="Only message records can be recalled")
+    if parsed["type"] not in _RECALLABLE_MESSAGE_TYPES:
+        raise HTTPException(status_code=400, detail="Only message and error records can be recalled")
 
     capability = await viewer_can_admin_room(db, ctx, room)
     owned_agent_ids = (

--- a/backend/tests/test_app/test_app_dashboard.py
+++ b/backend/tests/test_app/test_app_dashboard.py
@@ -420,6 +420,83 @@ async def test_dashboard_owner_can_recall_any_room_message(
 
 
 @pytest.mark.asyncio
+async def test_dashboard_owner_can_recall_error_room_message(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    seed_data: dict,
+):
+    db_session.add(MessageRecord(
+        hub_msg_id="hm_recall_error",
+        msg_id="msg_recall_error",
+        sender_id="ag_other00001",
+        receiver_id="ag_dashtest001",
+        room_id="rm_testroom001",
+        envelope_json='{"from":"ag_other00001","type":"error","payload":{"error":{"code":"agent_error","message":"tool failed"}}}',
+        state=MessageState.queued,
+        ttl_sec=3600,
+        created_at=datetime.datetime.now(datetime.timezone.utc),
+    ))
+    await db_session.commit()
+
+    headers = {
+        "Authorization": f"Bearer {seed_data['token']}",
+        "X-Active-Agent": "ag_dashtest001",
+    }
+    resp = await client.post(
+        "/api/dashboard/rooms/rm_testroom001/messages/msg_recall_error/recall",
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["is_recalled"] is True
+
+    messages_resp = await client.get(
+        "/api/dashboard/rooms/rm_testroom001/messages",
+        headers=headers,
+    )
+    assert messages_resp.status_code == 200, messages_resp.text
+    recalled = next(
+        message for message in messages_resp.json()["messages"]
+        if message["msg_id"] == "msg_recall_error"
+    )
+    assert recalled["type"] == "error"
+    assert recalled["text"] == ""
+    assert recalled["payload"]["recalled"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("msg_type", ["ack", "result"])
+async def test_dashboard_recall_rejects_non_error_receipts(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    seed_data: dict,
+    msg_type: str,
+):
+    msg_id = f"msg_recall_{msg_type}"
+    db_session.add(MessageRecord(
+        hub_msg_id=f"hm_recall_{msg_type}",
+        msg_id=msg_id,
+        sender_id="ag_other00001",
+        receiver_id="ag_dashtest001",
+        room_id="rm_testroom001",
+        envelope_json=f'{{"from":"ag_other00001","type":"{msg_type}","payload":{{"text":"receipt"}}}}',
+        state=MessageState.queued,
+        ttl_sec=3600,
+        created_at=datetime.datetime.now(datetime.timezone.utc),
+    ))
+    await db_session.commit()
+
+    resp = await client.post(
+        f"/api/dashboard/rooms/rm_testroom001/messages/{msg_id}/recall",
+        headers={
+            "Authorization": f"Bearer {seed_data['token']}",
+            "X-Active-Agent": "ag_dashtest001",
+        },
+    )
+    assert resp.status_code == 400
+    assert "Only message and error records can be recalled" in resp.text
+
+
+@pytest.mark.asyncio
 async def test_dashboard_member_recall_respects_two_minute_window(
     client: AsyncClient,
     db_session: AsyncSession,

--- a/frontend/src/lib/message-recall.test.ts
+++ b/frontend/src/lib/message-recall.test.ts
@@ -57,6 +57,36 @@ describe("canRecallDashboardMessage", () => {
     })).toBe(true);
   });
 
+  it("allows fresh own error messages to be recalled", () => {
+    expect(canRecallDashboardMessage({
+      message: message({
+        type: "error",
+        payload: { error: { code: "agent_error", message: "failed" } },
+        text: "failed",
+      }),
+      room: room(),
+      isOwn: true,
+      ownedAgentIds: [],
+      humanId: "hu_1",
+      userId: "user_1",
+      nowMs: Date.parse("2026-05-29T08:01:00.000Z"),
+    })).toBe(true);
+  });
+
+  it("does not allow non-error receipt messages to be recalled", () => {
+    for (const type of ["ack", "result"]) {
+      expect(canRecallDashboardMessage({
+        message: message({ type }),
+        room: room(),
+        isOwn: true,
+        ownedAgentIds: [],
+        humanId: "hu_1",
+        userId: "user_1",
+        nowMs: Date.parse("2026-05-29T08:01:00.000Z"),
+      })).toBe(false);
+    }
+  });
+
   it("does not expose recall on temporary optimistic ids", () => {
     expect(canRecallDashboardMessage({
       message: message({ hub_msg_id: "tmp_1", msg_id: "tmp_1" }),

--- a/frontend/src/lib/message-recall.ts
+++ b/frontend/src/lib/message-recall.ts
@@ -1,6 +1,7 @@
 import type { DashboardMessage, DashboardRoom } from "@/lib/types";
 
 const MESSAGE_RECALL_WINDOW_MS = 2 * 60 * 1000;
+const RECALLABLE_DASHBOARD_MESSAGE_TYPES = new Set(["message", "error"]);
 
 export function isDashboardMessageRecalled(message: Pick<DashboardMessage, "is_recalled" | "recalled_at" | "payload">): boolean {
   return Boolean(
@@ -45,7 +46,7 @@ export function canRecallDashboardMessage({
   nowMs?: number;
 }): boolean {
   if (
-    message.type !== "message"
+    !RECALLABLE_DASHBOARD_MESSAGE_TYPES.has(message.type)
     || !message.room_id
     || !message.msg_id
     || message.room_id.startsWith("rm_oc_")


### PR DESCRIPTION
## Summary
- Allow dashboard room message recall for `error` typed messages in addition to normal messages.
- Keep `ack` and `result` receipt messages non-recallable.
- Add frontend and backend regression coverage for error-message recall.

## Verification
- `cd frontend && npm test -- --run src/lib/message-recall.test.ts`
- `cd frontend && npm run build`
- `cd backend && uv run pytest tests/test_app/test_app_dashboard.py -k "recall"`
- `cd backend && uv run pytest tests/test_app/test_app_dashboard.py`

## Risk / rollout
- Low: scoped to dashboard recall eligibility and API validation for message types.
