### PR TITLE
fix(daemon): surface real cause in codex runtime errors

### DIFF
--- a/packages/daemon/src/gateway/__tests__/codex-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/codex-adapter.test.ts
@@ -295,6 +295,26 @@ for (const l of lines) process.stdout.write(JSON.stringify(l) + "\\n");
     expect(res.error).toMatch(/rate limited/);
   });
 
+  it("surfaces the raw error event payload when it lacks a message", async () => {
+    const script = makeScript(
+      "errnomsg.js",
+      `
+const lines = [
+  {type:"thread.started", thread_id:"01234567-89ab-7def-8123-456789abcde6"},
+  {type:"error", error:{type:"usage_limit_reached", code:"insufficient_quota"}},
+];
+for (const l of lines) process.stdout.write(JSON.stringify(l) + "\\n");
+process.exit(1);
+`,
+    );
+    const res = await runAdapter(script);
+    expect(res.error).toBeDefined();
+    // Must not collapse to the opaque "codex error" — the type/code survive.
+    expect(res.error).not.toBe("codex error");
+    expect(res.error).toMatch(/usage_limit_reached/);
+    expect(res.error).toMatch(/insufficient_quota/);
+  });
+
   it("surfaces non-zero exit + stderr as error", async () => {
     const script = makeScript(
       "boom.js",

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -2438,11 +2438,20 @@ export class Dispatcher {
   }): { errorRef: string; summary: RuntimeFailureSummary; safeMessage: string } {
     const info = errorInfo(args.error);
     const resultFailure = args.result?.runtimeFailure ?? {};
-    const safeMessage =
+    const baseMessage =
       sanitizeRuntimeFailureText(
         info.error_message || String(args.result?.error ?? "runtime error"),
         2048,
       ) || "runtime error";
+    // Surface the process exit code alongside the adapter message so opaque
+    // errors (e.g. a bare "codex error") still say *how* the runtime died
+    // without needing a separate `debug runtime-error` lookup.
+    const failureExitCode =
+      typeof resultFailure.exit_code === "number" ? resultFailure.exit_code : null;
+    const safeMessage =
+      failureExitCode !== null && !baseMessage.includes(`code ${failureExitCode}`)
+        ? `${baseMessage} (exit code ${failureExitCode})`
+        : baseMessage;
     const summary: RuntimeFailureSummary = {
       agent_id: args.msg.accountId,
       room_id: args.msg.conversation.id,

--- a/packages/daemon/src/gateway/runtimes/codex.ts
+++ b/packages/daemon/src/gateway/runtimes/codex.ts
@@ -321,17 +321,37 @@ export class CodexAdapter extends NdjsonStreamAdapter {
     }
 
     if (obj.type === "turn.completed" && obj.turn?.status === "failed") {
-      const msg = obj.turn.error?.message;
-      if (typeof msg === "string" && msg) ctx.state.errorText = msg;
+      ctx.state.errorText =
+        obj.turn.error?.message?.trim() ||
+        summarizeCodexErrorEvent(raw) ||
+        "codex turn failed";
       return;
     }
 
     if (obj.type === "error") {
+      const err = obj.error;
+      const fromMessage =
+        typeof err === "string" ? err.trim() : err?.message?.trim() ?? "";
       ctx.state.errorText =
-        typeof obj.error === "string"
-          ? obj.error
-          : obj.error?.message ?? "codex error";
+        fromMessage || summarizeCodexErrorEvent(raw) || "codex error";
     }
+  }
+}
+
+/**
+ * Best-effort summary of a codex `error` / failed-`turn.completed` event for
+ * the surfaced runtime error. Codex doesn't always populate `error.message`;
+ * when it doesn't, fall back to a compact JSON of the raw event so the error is
+ * diagnosable instead of an opaque "codex error". Capped to keep the chat reply
+ * and transcript bounded.
+ */
+function summarizeCodexErrorEvent(raw: unknown): string {
+  try {
+    const json = JSON.stringify(raw);
+    if (!json || json === "{}" || json === "null") return "";
+    return json.length > 800 ? `${json.slice(0, 800)}…` : json;
+  } catch {
+    return "";
   }
 }
 


### PR DESCRIPTION
## 背景

生产上看到的 codex runtime 报错形如：

```
⚠️ Runtime error: codex error [error_ref: err_c642dd3ce94b]
```

完全看不出原因。排查发现 codex CLI 发来 `type:"error"` 事件但 `error` 里没有 `.message` 时，adapter 直接把它塌成字面量 `"codex error"`，把 `error` 对象里真正的 type/code/detail 全丢了；而 dispatcher 发到聊天 + 写进 transcript 的 `safeMessage` 也只用错误字符串，没带 exit code。

> 注：根因（同一 agent 跨房间并发的 codex 进程竞争写 `$CODEX_HOME/config.toml` 的 `[projects]` trust 块，导致 TOML `duplicate key`）本次**不处理**，只优化错误可观测性。

## 改动

- **`runtimes/codex.ts`** — `error` / 失败的 `turn.completed` 事件无 message 时，回退到原始事件的紧凑 JSON（截断 800 字符），保留 type/code/detail；新增 helper `summarizeCodexErrorEvent()`。
- **`dispatcher.ts`（`captureRuntimeFailure`）** — `safeMessage` 追加进程 exit code，对所有 runtime（codex/claude-code/gemini）通用。
- **测试** — 锁住"无 message 的 error 事件必须透出原始 payload，不能是 `codex error`"。

## 效果

之前：
```
⚠️ Runtime error: codex error [error_ref: ...]
```
之后（示例）：
```
⚠️ Runtime error: {"type":"error","error":{"type":"usage_limit_reached","code":"insufficient_quota"}} (exit code 1) [error_ref: ...]
```

## 验证

- `tsc -p tsconfig.build.json` 通过
- 全量测试 991 passed（含新增用例），codex-adapter 20/20

🤖 Generated with [Claude Code](https://claude.com/claude-code)