### PR TITLE
fix: pause chat autoscroll when reading history

### DIFF
--- a/frontend/src/components/dashboard/MessageList.tsx
+++ b/frontend/src/components/dashboard/MessageList.tsx
@@ -2,7 +2,7 @@
 
 /**
  * [INPUT]: 依赖 chat/ui/session/unread store 的消息状态与增量加载动作，依赖共享时间工具更新已读水位，依赖 MessageBubble 渲染单条消息，依赖滚动位置判定已读水位
- * [OUTPUT]: 对外提供 MessageList 组件，渲染消息流、话题分组、历史加载与“新消息”提示
+ * [OUTPUT]: 对外提供 MessageList 组件，渲染消息流、话题分组、历史加载与滚动追随控制
  * [POS]: dashboard 聊天正文区的消息阅读器，负责把实时追加消息转成可见阅读状态
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
@@ -11,9 +11,10 @@ import { useEffect, useRef, useCallback, useMemo, useState } from "react";
 import { useLanguage } from '@/lib/i18n';
 import { messageList } from '@/lib/i18n/translations/dashboard';
 import { useShallow } from "zustand/react/shallow";
-import { Bot, Settings, UserPlus } from "lucide-react";
+import { ArrowDown, Bot, Settings, UserPlus } from "lucide-react";
 import MessageBubble from "./MessageBubble";
 import { JUMP_TO_MESSAGE_EVENT, type JumpToMessageDetail } from "./messageNavigation";
+import { isNearScrollBottom } from "./messageScroll";
 import type { Attachment, DashboardMessage, PublicRoomMember, TopicInfo } from "@/lib/types";
 import type { MentionTextCandidate } from "@/components/ui/MarkdownContent";
 import { getLatestSeenAtForRoom } from "@/store/dashboard-shared";
@@ -192,10 +193,6 @@ export function TopicCard({
   );
 }
 
-function isNearBottom(el: HTMLElement, threshold = 150): boolean {
-  return el.scrollHeight - el.scrollTop - el.clientHeight < threshold;
-}
-
 function EmptyRoomGuide({
   room,
 }: {
@@ -315,8 +312,8 @@ export default function MessageList({
   const bottomRef = useRef<HTMLDivElement>(null);
   const prevLengthRef = useRef(0);
   const isLoadingMore = useRef(false);
-  const [showNewMessagesBanner, setShowNewMessagesBanner] = useState(false);
-  const showBannerRef = useRef(false);
+  const [showScrollToBottomButton, setShowScrollToBottomButton] = useState(false);
+  const showScrollToBottomButtonRef = useRef(false);
   const wasNearBottomRef = useRef(true);
   const initialScrollDoneRef = useRef(false);
 
@@ -415,7 +412,8 @@ export default function MessageList({
     prevLengthRef.current = 0;
     wasNearBottomRef.current = true;
     initialScrollDoneRef.current = false;
-    setShowNewMessagesBanner(false);
+    showScrollToBottomButtonRef.current = false;
+    setShowScrollToBottomButton(false);
   }, [roomId, setOpenedTopicId]);
 
   const topicsMap = useMemo(() => {
@@ -448,9 +446,11 @@ export default function MessageList({
 
   const timelineItems = useMemo(() => buildTimelineItems(messages, topicsMap), [messages, topicsMap]);
 
-  const scrollToBottom = useCallback(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "auto" });
-    setShowNewMessagesBanner(false);
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = "auto") => {
+    wasNearBottomRef.current = true;
+    showScrollToBottomButtonRef.current = false;
+    setShowScrollToBottomButton(false);
+    bottomRef.current?.scrollIntoView({ behavior });
     if (roomId) {
       commitRoomSeen(roomId);
     }
@@ -458,7 +458,7 @@ export default function MessageList({
 
   const scrollToBottomAfterLayout = useCallback(() => {
     requestAnimationFrame(() => {
-      requestAnimationFrame(scrollToBottom);
+      requestAnimationFrame(() => scrollToBottom());
     });
   }, [scrollToBottom]);
 
@@ -468,20 +468,22 @@ export default function MessageList({
     scrollToBottomAfterLayout();
   }, [roomId, isRoomMessagesLoading, messages.length, scrollToBottomAfterLayout]);
 
-  // Auto-scroll or show "new messages" banner when new messages arrive.
+  // Auto-scroll or show the follow button when new messages arrive.
   // Uses wasNearBottomRef (snapshotted on scroll events, before DOM changes)
-  // to decide whether to auto-scroll or show the banner.
+  // to decide whether to auto-scroll or let the user resume manually.
   useEffect(() => {
     if (messages.length > prevLengthRef.current && !isLoadingMore.current) {
       if (wasNearBottomRef.current) {
         scrollToBottomAfterLayout();
-        setShowNewMessagesBanner(false);
+        showScrollToBottomButtonRef.current = false;
+        setShowScrollToBottomButton(false);
         if (roomId) {
           commitRoomSeen(roomId);
         }
       } else if (prevLengthRef.current > 0) {
-        // User is reading history — show banner instead of auto-scrolling
-        setShowNewMessagesBanner(true);
+        // User is reading history, so expose an explicit way to resume following.
+        showScrollToBottomButtonRef.current = true;
+        setShowScrollToBottomButton(true);
       }
     }
     prevLengthRef.current = messages.length;
@@ -490,15 +492,20 @@ export default function MessageList({
 
   // Keep ref in sync with state for use in scroll handler
   useEffect(() => {
-    showBannerRef.current = showNewMessagesBanner;
-  }, [showNewMessagesBanner]);
+    showScrollToBottomButtonRef.current = showScrollToBottomButton;
+  }, [showScrollToBottomButton]);
 
   // Track scroll position & handle infinite scroll up
   const handleScroll = useCallback(() => {
     if (!containerRef.current || !roomId) return;
 
     // Snapshot scroll position for use by the auto-scroll effect
-    wasNearBottomRef.current = isNearBottom(containerRef.current);
+    wasNearBottomRef.current = isNearScrollBottom(containerRef.current);
+    if (showScrollToBottomButtonRef.current === wasNearBottomRef.current) {
+      const shouldShow = !wasNearBottomRef.current;
+      showScrollToBottomButtonRef.current = shouldShow;
+      setShowScrollToBottomButton(shouldShow);
+    }
 
     // Infinite scroll up
     if (hasMore && !isLoadingMore.current && containerRef.current.scrollTop < 100) {
@@ -506,18 +513,15 @@ export default function MessageList({
       loadMoreMessages(roomId);
     }
 
-    // Dismiss banner when scrolled near bottom
-    if (showBannerRef.current && wasNearBottomRef.current) {
-      setShowNewMessagesBanner(false);
-    }
     if (wasNearBottomRef.current) {
       commitRoomSeen(roomId);
     }
   }, [roomId, hasMore, loadMoreMessages, commitRoomSeen]);
 
-  // Reset banner on room change
+  // Reset follow control on room change
   useEffect(() => {
-    setShowNewMessagesBanner(false);
+    showScrollToBottomButtonRef.current = false;
+    setShowScrollToBottomButton(false);
   }, [roomId]);
 
   if (!roomId) return null;
@@ -543,12 +547,15 @@ export default function MessageList({
     return <EmptyRoomGuide room={currentRoom} />;
   }
 
-  const newMessagesBanner = showNewMessagesBanner && (
+  const scrollToBottomButton = showScrollToBottomButton && (
     <button
-      onClick={scrollToBottom}
-      className="absolute bottom-4 left-1/2 -translate-x-1/2 z-20 rounded-full bg-neon-cyan/90 px-4 py-1.5 text-xs font-medium text-deep-black shadow-lg shadow-neon-cyan/20 transition-all hover:bg-neon-cyan animate-bounce max-md:bottom-6"
+      type="button"
+      onClick={() => scrollToBottom("auto")}
+      aria-label={t.scrollToLatest}
+      title={t.scrollToLatest}
+      className="absolute bottom-4 left-1/2 z-20 flex h-9 w-9 -translate-x-1/2 items-center justify-center rounded-full border border-neon-cyan/40 bg-deep-black-light/95 text-neon-cyan shadow-lg shadow-black/30 backdrop-blur transition-colors hover:bg-neon-cyan/15 hover:text-neon-cyan max-md:bottom-6"
     >
-      {t.newMessages}
+      <ArrowDown className="h-4 w-4" />
     </button>
   );
 
@@ -602,7 +609,7 @@ export default function MessageList({
         })}
         <div ref={bottomRef} />
       </div>
-      {newMessagesBanner}
+      {scrollToBottomButton}
     </div>
   );
 }

--- a/frontend/src/components/dashboard/MessageList.tsx
+++ b/frontend/src/components/dashboard/MessageList.tsx
@@ -14,7 +14,11 @@ import { useShallow } from "zustand/react/shallow";
 import { ArrowDown, Bot, Settings, UserPlus } from "lucide-react";
 import MessageBubble from "./MessageBubble";
 import { JUMP_TO_MESSAGE_EVENT, type JumpToMessageDetail } from "./messageNavigation";
-import { isNearScrollBottom } from "./messageScroll";
+import {
+  isNearScrollBottom,
+  scrollToLatestVisibleAfterScroll,
+  shouldShowScrollToLatestForNewContent,
+} from "./messageScroll";
 import type { Attachment, DashboardMessage, PublicRoomMember, TopicInfo } from "@/lib/types";
 import type { MentionTextCandidate } from "@/components/ui/MarkdownContent";
 import { getLatestSeenAtForRoom } from "@/store/dashboard-shared";
@@ -480,7 +484,11 @@ export default function MessageList({
         if (roomId) {
           commitRoomSeen(roomId);
         }
-      } else if (prevLengthRef.current > 0) {
+      } else if (shouldShowScrollToLatestForNewContent({
+        wasNearBottom: wasNearBottomRef.current,
+        hadPreviousContent: prevLengthRef.current > 0,
+        isLoadingMore: isLoadingMore.current,
+      })) {
         // User is reading history, so expose an explicit way to resume following.
         showScrollToBottomButtonRef.current = true;
         setShowScrollToBottomButton(true);
@@ -501,8 +509,11 @@ export default function MessageList({
 
     // Snapshot scroll position for use by the auto-scroll effect
     wasNearBottomRef.current = isNearScrollBottom(containerRef.current);
-    if (showScrollToBottomButtonRef.current === wasNearBottomRef.current) {
-      const shouldShow = !wasNearBottomRef.current;
+    const shouldShow = scrollToLatestVisibleAfterScroll(
+      showScrollToBottomButtonRef.current,
+      wasNearBottomRef.current,
+    );
+    if (showScrollToBottomButtonRef.current !== shouldShow) {
       showScrollToBottomButtonRef.current = shouldShow;
       setShowScrollToBottomButton(shouldShow);
     }

--- a/frontend/src/components/dashboard/README.md
+++ b/frontend/src/components/dashboard/README.md
@@ -25,7 +25,7 @@ dashboard/
 ├── AddRoomMemberModal.tsx    # 群成员手动添加弹窗：从好友与自有 Agent 中选人，调用人类侧 members API 入群
 ├── ContactList.tsx           # 联系人列表
 ├── RoomHeader.tsx            # 房间头部信息与未加入时的 join 入口
-├── MessageList.tsx           # 消息流（历史加载 + 已读水位 + 新消息提示）
+├── MessageList.tsx           # 消息流（历史加载 + 已读水位 + 滚动追随控制）
 ├── PaidRoomPreview.tsx       # 付费群未订阅橱窗：固定展示最近 3 条消息摘要与订阅入口
 ├── MessageBubble.tsx         # 单条消息气泡
 ├── AccountMenu.tsx           # 左下角统一账号入口，只展示“当前身份”列表与基础账户动作；无 agent 时弱提示跳转创建
@@ -77,6 +77,7 @@ dashboard/
 
 ## 变更日志
 
+- 2026-06-03: `MessageList.tsx` 与 `UserChatPane.tsx` 的消息滚动改为用户上滑后暂停自动追随，并显示紧凑的回到底部图标按钮；点击后恢复追随最新内容。
 - 2026-06-01: `MessageList.tsx` 的消息 React key 改为优先使用跨 fan-out 稳定的 `msg_id`，配合附件图片固定占位，减少后台同步时图片预览闪烁。
 - 2026-06-01: `DocumentPreviewPane.tsx` 的右侧附件预览支持桌面端拖拽左边缘调整宽度，并记住最近一次宽度。
 - 2026-05-30: `MessageBubble.tsx` 的消息操作菜单改为 fixed portal 定位，底部空间不足时自动向上展开，避免被消息滚动区或输入栏裁剪。

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import { ArrowLeft, Bot, Check, Copy, CornerUpLeft, Forward, Loader2, MessageSquare, MoreHorizontal, AlertCircle, AlertTriangle, RotateCcw, Bell, PanelLeftOpen, Settings2, User, X } from "lucide-react";
+import { ArrowDown, ArrowLeft, Bot, Check, Copy, CornerUpLeft, Forward, Loader2, MessageSquare, MoreHorizontal, AlertCircle, AlertTriangle, RotateCcw, Bell, PanelLeftOpen, Settings2, User, X } from "lucide-react";
 import { useRouter } from "nextjs-toploader/app";
 import { api } from "@/lib/api";
 import { useLanguage } from "@/lib/i18n";
@@ -22,6 +22,7 @@ import { useMentionCandidates } from "@/hooks/useMentionCandidates";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import { useOwnerChatStore } from "@/store/useOwnerChatStore";
 import { useOwnerChatWs } from "@/hooks/useOwnerChatWs";
+import { messageList } from "@/lib/i18n/translations/dashboard";
 import DashboardMessagePaneSkeleton from "./DashboardMessagePaneSkeleton";
 import MarkdownContent, { normalizeMessageContent } from "@/components/ui/MarkdownContent";
 import AttachmentItem from "@/components/ui/AttachmentItem";
@@ -39,6 +40,7 @@ import {
   canShowOwnerChatMessageActions,
   ownerChatReplyTargetId,
 } from "@/lib/owner-chat-actions";
+import { isNearScrollBottom } from "./messageScroll";
 
 // ---------------------------------------------------------------------------
 // TypewriterText
@@ -114,6 +116,7 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
   const forwardLabel = locale === "zh" ? "转发" : "Forward";
   const copyLabel = locale === "zh" ? "复制" : "Copy";
   const copiedLabel = locale === "zh" ? "已复制" : "Copied";
+  const scrollToLatestLabel = messageList[locale].scrollToLatest;
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const animatedRef = useRef<Set<string>>(new Set());
@@ -121,17 +124,29 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
   const isLoadingMore = useRef(false);
   const prevLengthRef = useRef(0);
   const wasNearBottomRef = useRef(true);
+  const showScrollToBottomButtonRef = useRef(false);
+  const [showScrollToBottomButton, setShowScrollToBottomButton] = useState(false);
   const [, forceRender] = useState(0);
 
-  const scrollToBottom = useCallback(() => {
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = "auto") => {
     const el = scrollContainerRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
+    if (!el) return;
+    wasNearBottomRef.current = true;
+    showScrollToBottomButtonRef.current = false;
+    setShowScrollToBottomButton(false);
+    el.scrollTo({ top: el.scrollHeight, behavior });
   }, []);
 
   const scrollToBottomAfterLayout = useCallback(() => {
     requestAnimationFrame(() => {
-      requestAnimationFrame(scrollToBottom);
+      requestAnimationFrame(() => scrollToBottom());
     });
+  }, [scrollToBottom]);
+
+  const scrollToBottomIfFollowing = useCallback(() => {
+    if (wasNearBottomRef.current) {
+      scrollToBottom();
+    }
   }, [scrollToBottom]);
 
   // WS hook authenticates the selected owner-chat target explicitly.
@@ -152,6 +167,9 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
     setInitializingRoom(true);
     initialLoadRef.current = true;
     prevLengthRef.current = 0;
+    wasNearBottomRef.current = true;
+    showScrollToBottomButtonRef.current = false;
+    setShowScrollToBottomButton(false);
     animatedRef.current.clear();
     setPreviewAttachment(null);
     useOwnerChatStore.getState().reset();
@@ -200,6 +218,10 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
   useEffect(() => {
     if (messages.length > prevLengthRef.current && !isLoadingMore.current) {
       if (wasNearBottomRef.current) scrollToBottom();
+      else {
+        showScrollToBottomButtonRef.current = true;
+        setShowScrollToBottomButton(true);
+      }
     }
     prevLengthRef.current = messages.length;
     isLoadingMore.current = false;
@@ -208,7 +230,12 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
   const handleScroll = useCallback(() => {
     const el = scrollContainerRef.current;
     if (!el) return;
-    wasNearBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 150;
+    wasNearBottomRef.current = isNearScrollBottom(el);
+    if (showScrollToBottomButtonRef.current === wasNearBottomRef.current) {
+      const shouldShow = !wasNearBottomRef.current;
+      showScrollToBottomButtonRef.current = shouldShow;
+      setShowScrollToBottomButton(shouldShow);
+    }
     if (hasMore && !isLoadingMore.current && el.scrollTop < 100) {
       isLoadingMore.current = true;
       useOwnerChatStore.getState().loadMore();
@@ -582,7 +609,7 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
                   blocks={msg.streamBlocks}
                   defaultExpanded
                   showComposing
-                  onScrollRequest={wasNearBottomRef.current ? scrollToBottom : undefined}
+                  onScrollRequest={scrollToBottomIfFollowing}
                 />
               </div>
             );
@@ -726,7 +753,7 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
                       return (
                         <TypewriterText
                           text={msg.text || ""}
-                          onTick={scrollToBottom}
+                          onTick={scrollToBottomIfFollowing}
                           onComplete={() => {
                             animatedRef.current.add(msg.clientId);
                             forceRender((n) => n + 1);
@@ -790,6 +817,17 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
           />
         </div>
       </div>
+      {showScrollToBottomButton && (
+        <button
+          type="button"
+          onClick={() => scrollToBottom("auto")}
+          aria-label={scrollToLatestLabel}
+          title={scrollToLatestLabel}
+          className="absolute bottom-[5.25rem] left-1/2 z-20 flex h-9 w-9 -translate-x-1/2 items-center justify-center rounded-full border border-neon-cyan/40 bg-deep-black-light/95 text-neon-cyan shadow-lg shadow-black/30 backdrop-blur transition-colors hover:bg-neon-cyan/15 hover:text-neon-cyan max-md:bottom-[5.75rem]"
+        >
+          <ArrowDown className="h-4 w-4" />
+        </button>
+      )}
       </div>
       {previewAttachment && (
         <DocumentPreviewPane

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -9,7 +9,7 @@
  *   - Rendering: status-driven (optimistic / streaming / delivered / failed)
  */
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useLayoutEffect, useMemo } from "react";
 import { ArrowDown, ArrowLeft, Bot, Check, Copy, CornerUpLeft, Forward, Loader2, MessageSquare, MoreHorizontal, AlertCircle, AlertTriangle, RotateCcw, Bell, PanelLeftOpen, Settings2, User, X } from "lucide-react";
 import { useRouter } from "nextjs-toploader/app";
 import { api } from "@/lib/api";
@@ -40,7 +40,11 @@ import {
   canShowOwnerChatMessageActions,
   ownerChatReplyTargetId,
 } from "@/lib/owner-chat-actions";
-import { isNearScrollBottom } from "./messageScroll";
+import {
+  isNearScrollBottom,
+  scrollToLatestVisibleAfterScroll,
+  shouldShowScrollToLatestForNewContent,
+} from "./messageScroll";
 
 // ---------------------------------------------------------------------------
 // TypewriterText
@@ -123,6 +127,7 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
   const initialLoadRef = useRef(true);
   const isLoadingMore = useRef(false);
   const prevLengthRef = useRef(0);
+  const prevMessageContentSignatureRef = useRef("");
   const wasNearBottomRef = useRef(true);
   const showScrollToBottomButtonRef = useRef(false);
   const [showScrollToBottomButton, setShowScrollToBottomButton] = useState(false);
@@ -167,6 +172,7 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
     setInitializingRoom(true);
     initialLoadRef.current = true;
     prevLengthRef.current = 0;
+    prevMessageContentSignatureRef.current = "";
     wasNearBottomRef.current = true;
     showScrollToBottomButtonRef.current = false;
     setShowScrollToBottomButton(false);
@@ -215,10 +221,29 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
 
   // ------ Scroll helpers ------
 
+  const messageContentSignature = useMemo(() => {
+    return messages.map((msg) => {
+      const blockSignature = msg.streamBlocks
+        .map((entry) => `${entry.trace_id}:${entry.seq}:${entry.block.kind}`)
+        .join(",");
+      return [
+        msg.clientId,
+        msg.status,
+        msg.text,
+        msg.attachments?.length ?? 0,
+        blockSignature,
+      ].join(":");
+    }).join("|");
+  }, [messages]);
+
   useEffect(() => {
     if (messages.length > prevLengthRef.current && !isLoadingMore.current) {
       if (wasNearBottomRef.current) scrollToBottom();
-      else {
+      else if (shouldShowScrollToLatestForNewContent({
+        wasNearBottom: wasNearBottomRef.current,
+        hadPreviousContent: prevLengthRef.current > 0,
+        isLoadingMore: isLoadingMore.current,
+      })) {
         showScrollToBottomButtonRef.current = true;
         setShowScrollToBottomButton(true);
       }
@@ -227,12 +252,32 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
     isLoadingMore.current = false;
   }, [messages.length, scrollToBottom]);
 
+  useLayoutEffect(() => {
+    const previousSignature = prevMessageContentSignatureRef.current;
+    prevMessageContentSignatureRef.current = messageContentSignature;
+    if (!previousSignature || previousSignature === messageContentSignature || isLoadingMore.current) return;
+
+    if (wasNearBottomRef.current) {
+      scrollToBottomAfterLayout();
+    } else if (shouldShowScrollToLatestForNewContent({
+      wasNearBottom: wasNearBottomRef.current,
+      hadPreviousContent: true,
+      isLoadingMore: isLoadingMore.current,
+    })) {
+      showScrollToBottomButtonRef.current = true;
+      setShowScrollToBottomButton(true);
+    }
+  }, [messageContentSignature, scrollToBottomAfterLayout]);
+
   const handleScroll = useCallback(() => {
     const el = scrollContainerRef.current;
     if (!el) return;
     wasNearBottomRef.current = isNearScrollBottom(el);
-    if (showScrollToBottomButtonRef.current === wasNearBottomRef.current) {
-      const shouldShow = !wasNearBottomRef.current;
+    const shouldShow = scrollToLatestVisibleAfterScroll(
+      showScrollToBottomButtonRef.current,
+      wasNearBottomRef.current,
+    );
+    if (showScrollToBottomButtonRef.current !== shouldShow) {
       showScrollToBottomButtonRef.current = shouldShow;
       setShowScrollToBottomButton(shouldShow);
     }
@@ -687,6 +732,7 @@ export default function UserChatPane({ agentId }: { agentId?: string | null }) {
                   key={`${msg.clientId}-delivered`}
                   blocks={msg.streamBlocks}
                   showComposing
+                  onScrollRequest={scrollToBottomIfFollowing}
                 />
               )}
               {hasVisibleBubble && (

--- a/frontend/src/components/dashboard/messageScroll.test.ts
+++ b/frontend/src/components/dashboard/messageScroll.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { CHAT_SCROLL_BOTTOM_THRESHOLD, isNearScrollBottom, type ScrollMetrics } from "./messageScroll";
+
+function metrics(overrides: Partial<ScrollMetrics> = {}): ScrollMetrics {
+  return {
+    clientHeight: 500,
+    scrollHeight: 2000,
+    scrollTop: 1500,
+    ...overrides,
+  };
+}
+
+describe("isNearScrollBottom", () => {
+  it("treats the viewport as near bottom within the chat threshold", () => {
+    expect(isNearScrollBottom(metrics({
+      scrollTop: 2000 - 500 - CHAT_SCROLL_BOTTOM_THRESHOLD,
+    }))).toBe(true);
+  });
+
+  it("treats upward scrolling past the threshold as away from bottom", () => {
+    expect(isNearScrollBottom(metrics({
+      scrollTop: 2000 - 500 - CHAT_SCROLL_BOTTOM_THRESHOLD - 1,
+    }))).toBe(false);
+  });
+});

--- a/frontend/src/components/dashboard/messageScroll.test.ts
+++ b/frontend/src/components/dashboard/messageScroll.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { CHAT_SCROLL_BOTTOM_THRESHOLD, isNearScrollBottom, type ScrollMetrics } from "./messageScroll";
+import {
+  CHAT_SCROLL_BOTTOM_THRESHOLD,
+  isNearScrollBottom,
+  scrollToLatestVisibleAfterScroll,
+  shouldShowScrollToLatestForNewContent,
+  type ScrollMetrics,
+} from "./messageScroll";
 
 function metrics(overrides: Partial<ScrollMetrics> = {}): ScrollMetrics {
   return {
@@ -21,5 +27,42 @@ describe("isNearScrollBottom", () => {
     expect(isNearScrollBottom(metrics({
       scrollTop: 2000 - 500 - CHAT_SCROLL_BOTTOM_THRESHOLD - 1,
     }))).toBe(false);
+  });
+});
+
+describe("scrollToLatestVisibleAfterScroll", () => {
+  it("keeps the button hidden when the user only scrolls away from bottom", () => {
+    expect(scrollToLatestVisibleAfterScroll(false, false)).toBe(false);
+  });
+
+  it("keeps an already visible button visible while the user remains away from bottom", () => {
+    expect(scrollToLatestVisibleAfterScroll(true, false)).toBe(true);
+  });
+
+  it("hides the button once the user returns near bottom", () => {
+    expect(scrollToLatestVisibleAfterScroll(true, true)).toBe(false);
+  });
+});
+
+describe("shouldShowScrollToLatestForNewContent", () => {
+  it("reveals the button for new content while auto-follow is paused", () => {
+    expect(shouldShowScrollToLatestForNewContent({
+      wasNearBottom: false,
+      hadPreviousContent: true,
+      isLoadingMore: false,
+    })).toBe(true);
+  });
+
+  it("does not reveal the button for initial content or history pagination", () => {
+    expect(shouldShowScrollToLatestForNewContent({
+      wasNearBottom: false,
+      hadPreviousContent: false,
+      isLoadingMore: false,
+    })).toBe(false);
+    expect(shouldShowScrollToLatestForNewContent({
+      wasNearBottom: false,
+      hadPreviousContent: true,
+      isLoadingMore: true,
+    })).toBe(false);
   });
 });

--- a/frontend/src/components/dashboard/messageScroll.ts
+++ b/frontend/src/components/dashboard/messageScroll.ts
@@ -1,0 +1,10 @@
+export const CHAT_SCROLL_BOTTOM_THRESHOLD = 150;
+
+export type ScrollMetrics = Pick<HTMLElement, "clientHeight" | "scrollHeight" | "scrollTop">;
+
+export function isNearScrollBottom(
+  metrics: ScrollMetrics,
+  threshold = CHAT_SCROLL_BOTTOM_THRESHOLD,
+): boolean {
+  return metrics.scrollHeight - metrics.scrollTop - metrics.clientHeight <= threshold;
+}

--- a/frontend/src/components/dashboard/messageScroll.ts
+++ b/frontend/src/components/dashboard/messageScroll.ts
@@ -8,3 +8,22 @@ export function isNearScrollBottom(
 ): boolean {
   return metrics.scrollHeight - metrics.scrollTop - metrics.clientHeight <= threshold;
 }
+
+export function scrollToLatestVisibleAfterScroll(
+  currentlyVisible: boolean,
+  nearBottom: boolean,
+): boolean {
+  return nearBottom ? false : currentlyVisible;
+}
+
+export function shouldShowScrollToLatestForNewContent({
+  wasNearBottom,
+  hadPreviousContent,
+  isLoadingMore,
+}: {
+  wasNearBottom: boolean;
+  hadPreviousContent: boolean;
+  isLoadingMore: boolean;
+}): boolean {
+  return !isLoadingMore && hadPreviousContent && !wasNearBottom;
+}

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -2067,6 +2067,7 @@ export const messageList: TranslationMap<{
   msg: string
   msgs: string
   newMessages: string
+  scrollToLatest: string
   topic: string
   viewThread: string
   moreInThread: string
@@ -2092,6 +2093,7 @@ export const messageList: TranslationMap<{
     msg: 'msg',
     msgs: 'msgs',
     newMessages: 'New messages ↓',
+    scrollToLatest: 'Scroll to latest message',
     topic: 'Topic',
     viewThread: 'View thread',
     moreInThread: 'more in thread',
@@ -2117,6 +2119,7 @@ export const messageList: TranslationMap<{
     msg: '条消息',
     msgs: '条消息',
     newMessages: '有新消息 ↓',
+    scrollToLatest: '滚动到最新消息',
     topic: '话题',
     viewThread: '查看话题',
     moreInThread: '条消息在话题中',


### PR DESCRIPTION
## Summary
- pause chat auto-follow when the user scrolls away from the bottom during long agent responses
- show a compact floating down-arrow control to jump back to the latest message and resume auto-follow
- apply the behavior to both room message lists and owner chat streaming/typewriter updates

## Verification
- corepack pnpm --dir frontend test src/components/dashboard/messageScroll.test.ts src/components/dashboard/MessageList.test.ts
- corepack pnpm --dir frontend test
- git diff --check

## Notes
- corepack pnpm --dir frontend exec tsc --noEmit still fails on pre-existing frontend test/API route typing issues outside this change: missing tests/api route imports, older fixture shape errors, and MessageList.test null fixture typing.