### PR TITLE
fix: tighten shared room landing preview

### DIFF
--- a/frontend/src/components/share/SharedRoomView.test.ts
+++ b/frontend/src/components/share/SharedRoomView.test.ts
@@ -1,6 +1,25 @@
 import { describe, expect, it } from "vitest";
 import type { SharedMessage } from "@/lib/types";
-import { getSharedRoomOpenHref, getSharedRoomPreviewMessages } from "./SharedRoomView";
+import {
+  getSharedRoomMessageText,
+  getSharedRoomOpenHref,
+  getSharedRoomPreviewMessages,
+  truncateSharedRoomMessageText,
+} from "./SharedRoomView";
+
+function makeMessage(index: number, overrides: Partial<SharedMessage> = {}): SharedMessage {
+  return {
+    hub_msg_id: `hub_${index}`,
+    msg_id: `msg_${index}`,
+    sender_id: "ag_sender",
+    sender_name: "Sender",
+    type: "message",
+    text: `message ${index}`,
+    payload: {},
+    created_at: new Date(2026, 0, 1, 0, index).toISOString(),
+    ...overrides,
+  };
+}
 
 describe("getSharedRoomOpenHref", () => {
   it("opens public room shares directly without forcing login", () => {
@@ -24,22 +43,34 @@ describe("getSharedRoomOpenHref", () => {
 });
 
 describe("getSharedRoomPreviewMessages", () => {
-  it("keeps only the latest 30 messages in chronological order", () => {
-    const messages = Array.from({ length: 35 }, (_, index) => ({
-      hub_msg_id: `hub_${index}`,
-      msg_id: `msg_${index}`,
-      sender_id: "ag_sender",
-      sender_name: "Sender",
-      type: "message",
-      text: `message ${index}`,
-      payload: {},
-      created_at: new Date(2026, 0, 1, 0, index).toISOString(),
-    })) satisfies SharedMessage[];
+  it("keeps only the latest 3 messages in chronological order", () => {
+    const messages = Array.from({ length: 8 }, (_, index) => makeMessage(index));
 
     const preview = getSharedRoomPreviewMessages(messages);
 
-    expect(preview).toHaveLength(30);
+    expect(preview).toHaveLength(3);
     expect(preview[0].text).toBe("message 5");
-    expect(preview.at(-1)?.text).toBe("message 34");
+    expect(preview.at(-1)?.text).toBe("message 7");
+  });
+});
+
+describe("getSharedRoomMessageText", () => {
+  it("prefers text-like payload fields over the fallback message text", () => {
+    expect(getSharedRoomMessageText(makeMessage(1, {
+      text: "fallback",
+      payload: { body: "payload body" },
+    }))).toBe("payload body");
+  });
+});
+
+describe("truncateSharedRoomMessageText", () => {
+  it("collapses whitespace and truncates long previews", () => {
+    const text = "First line\n\nSecond line with extra spaces   and a long ending";
+
+    expect(truncateSharedRoomMessageText(text, 30)).toBe("First line Second line with...");
+  });
+
+  it("leaves short preview text untouched after whitespace compaction", () => {
+    expect(truncateSharedRoomMessageText("  compact\nmessage  ", 80)).toBe("compact message");
   });
 });

--- a/frontend/src/components/share/SharedRoomView.tsx
+++ b/frontend/src/components/share/SharedRoomView.tsx
@@ -1,23 +1,24 @@
 "use client";
 
 /**
- * [INPUT]: 依赖 api/getSharedRoom 拉取共享快照，依赖 next/link 提供站内返回入口，依赖 BotCordLoadingScreen 与 SharedMessageBubble 渲染加载态和消息内容
- * [OUTPUT]: 对外提供 SharedRoomView 组件，负责共享房间最新 30 条预览、品牌加载、错误态与只读消息列表展示
- * [POS]: share 模块的页面主体，被 /share/[shareId] 路由消费，是外部访问共享快照的只读容器
+ * [INPUT]: 依赖 api/getSharedRoom 拉取共享快照，依赖 next/link 提供站内返回入口，依赖 BotCordLoadingScreen 渲染加载态
+ * [OUTPUT]: 对外提供 SharedRoomView 组件，负责共享房间落地页、紧凑消息预览、品牌加载与错误态展示
+ * [POS]: share 模块的页面主体，被 /share/[shareId] 路由消费，是外部访问共享快照的转化落地页
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
 
-import { useState, useEffect, useMemo, useRef } from "react";
+import { useState, useEffect, useMemo } from "react";
 import Link from "next/link";
-import { ArrowUpRight, Clock, MessageSquareText, Users } from "lucide-react";
+import { ArrowDown, ArrowUpRight, Clock, LockKeyhole, MessageSquareText, Users } from "lucide-react";
 import { api, ApiError } from "@/lib/api";
 import type { SharedMessage, SharedRoomResponse } from "@/lib/types";
 import { BotCordLoadingScreen } from "@/components/ui/BotCordLoader";
-import SharedMessageBubble from "./SharedMessageBubble";
 import { useLanguage } from "@/lib/i18n";
 import { sharedRoomView } from "@/lib/i18n/translations/dashboard";
+import { formatMessageTimestamp } from "@/lib/message-time";
 
-const SHARED_ROOM_PREVIEW_LIMIT = 30;
+const SHARED_ROOM_PREVIEW_LIMIT = 3;
+const SHARED_ROOM_TEASER_TEXT_LIMIT = 220;
 
 export function getSharedRoomOpenHref(data: Pick<SharedRoomResponse, "continue_url" | "entry_type">): string {
   const continuePath = data.continue_url.replace(/^https?:\/\/[^/]+/, "");
@@ -29,13 +30,23 @@ export function getSharedRoomPreviewMessages(messages: SharedMessage[]): SharedM
   return messages.slice(-SHARED_ROOM_PREVIEW_LIMIT);
 }
 
+export function getSharedRoomMessageText(message: Pick<SharedMessage, "text" | "payload">): string {
+  const textContent = message.payload?.text || message.payload?.body || message.payload?.message;
+  return typeof textContent === "string" ? textContent : message.text;
+}
+
+export function truncateSharedRoomMessageText(text: string, maxLength = SHARED_ROOM_TEASER_TEXT_LIMIT): string {
+  const compactText = text.replace(/\s+/g, " ").trim();
+  if (compactText.length <= maxLength) return compactText;
+  return `${compactText.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`;
+}
+
 export default function SharedRoomView({ shareId }: { shareId: string }) {
   const locale = useLanguage();
   const t = sharedRoomView[locale];
   const [data, setData] = useState<SharedRoomResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const messagesEndRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (!shareId) {
@@ -60,14 +71,6 @@ export default function SharedRoomView({ shareId }: { shareId: string }) {
     data ? getSharedRoomPreviewMessages(data.messages) : []
   ), [data]);
 
-  useEffect(() => {
-    if (!data || previewMessages.length === 0) return;
-    const frame = window.requestAnimationFrame(() => {
-      messagesEndRef.current?.scrollIntoView({ block: "end" });
-    });
-    return () => window.cancelAnimationFrame(frame);
-  }, [data, previewMessages.length]);
-
   if (loading) {
     return <BotCordLoadingScreen label={t.loading} />;
   }
@@ -90,77 +93,139 @@ export default function SharedRoomView({ shareId }: { shareId: string }) {
   const openHref = getSharedRoomOpenHref(data);
   const sharedDate = new Date(data.shared_at).toLocaleDateString();
   const messageCount = previewMessages.length;
+  const hiddenMessageCount = Math.max(0, data.messages.length - messageCount);
 
   return (
-    <div className="min-h-screen bg-[linear-gradient(180deg,#0a0a0f_0%,#12121a_48%,#0a0a0f_100%)] px-4 pb-10 pt-16">
-      <div className="mx-auto flex max-w-4xl flex-col gap-5">
-        <header className="overflow-hidden rounded-lg border border-white/10 bg-white/[0.06] shadow-2xl shadow-black/30">
-          <div className="border-b border-white/10 bg-[linear-gradient(135deg,rgba(0,240,255,0.12),rgba(139,92,246,0.10)_48%,rgba(16,185,129,0.10))] px-5 py-5 sm:px-6">
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-              <div className="min-w-0">
-                <p className="mb-2 inline-flex items-center rounded-full border border-neon-cyan/30 bg-neon-cyan/10 px-2.5 py-1 text-xs font-medium text-neon-cyan">
-                  {t.previewBadge}
+    <div className="min-h-screen bg-[radial-gradient(circle_at_15%_10%,rgba(0,240,255,0.10),transparent_28%),linear-gradient(180deg,#07070b_0%,#101018_54%,#07070b_100%)] px-4 pb-10 pt-8 sm:pt-12">
+      <div className="mx-auto flex max-w-5xl flex-col gap-6">
+        <header className="overflow-hidden rounded-lg border border-white/10 bg-white/[0.055] shadow-2xl shadow-black/30">
+          <div className="grid gap-6 px-5 py-6 sm:px-7 sm:py-8 lg:grid-cols-[minmax(0,1fr)_320px] lg:items-center">
+            <div className="min-w-0">
+              <p className="mb-3 inline-flex items-center rounded-full border border-neon-cyan/30 bg-neon-cyan/10 px-2.5 py-1 text-xs font-medium text-neon-cyan">
+                {t.previewBadge}
+              </p>
+              <h1 className="break-words text-3xl font-semibold leading-tight text-text-primary sm:text-4xl">
+                {data.room.name}
+              </h1>
+              {data.room.description && (
+                <p className="mt-3 max-w-2xl break-words text-sm leading-6 text-text-secondary sm:text-base">
+                  {data.room.description}
                 </p>
-                <h1 className="text-2xl font-semibold text-text-primary sm:text-3xl">{data.room.name}</h1>
-                {data.room.description && (
-                  <p className="mt-2 max-w-2xl text-sm leading-6 text-text-secondary">{data.room.description}</p>
-                )}
+              )}
+              <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+                <Link
+                  href={openHref}
+                  className="inline-flex min-h-11 max-w-full items-center justify-center gap-2 rounded-lg border border-neon-cyan/50 bg-neon-cyan px-4 py-2.5 text-sm font-semibold leading-5 text-deep-black transition hover:bg-text-primary"
+                >
+                  <LockKeyhole className="h-4 w-4 shrink-0" aria-hidden="true" />
+                  <span className="min-w-0 text-center">{t.unlockCta}</span>
+                  <ArrowUpRight className="h-4 w-4 shrink-0" aria-hidden="true" />
+                </Link>
+                <a
+                  href="#room-preview"
+                  className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg border border-white/15 bg-white/[0.04] px-4 py-2.5 text-sm font-medium text-text-primary transition hover:border-white/25 hover:bg-white/[0.08]"
+                >
+                  <ArrowDown className="h-4 w-4 shrink-0" aria-hidden="true" />
+                  {t.previewCta}
+                </a>
               </div>
-              <Link
-                href={openHref}
-                className="inline-flex shrink-0 items-center justify-center gap-2 rounded-lg border border-neon-cyan/50 bg-neon-cyan px-4 py-2.5 text-sm font-semibold text-deep-black transition hover:bg-text-primary"
-              >
-                {t.openInBotcord}
-                <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
-              </Link>
             </div>
-          </div>
 
-          <div className="grid gap-3 px-5 py-4 text-sm text-text-secondary sm:grid-cols-3 sm:px-6">
-            <div className="flex items-center gap-2">
-              <Users className="h-4 w-4 text-neon-green" aria-hidden="true" />
-              <span>{data.room.member_count} {data.room.member_count === 1 ? t.member : t.members}</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <MessageSquareText className="h-4 w-4 text-neon-purple" aria-hidden="true" />
-              <span>{t.latestMessages.replace("{count}", String(messageCount))}</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <Clock className="h-4 w-4 text-neon-cyan" aria-hidden="true" />
-              <span>{t.sharedBy} {data.shared_by} · {sharedDate}</span>
+            <div className="grid gap-3 border-t border-white/10 pt-4 text-sm text-text-secondary lg:border-l lg:border-t-0 lg:pl-5 lg:pt-0">
+              <div className="flex min-w-0 items-center gap-2">
+                <Users className="h-4 w-4 shrink-0 text-neon-green" aria-hidden="true" />
+                <span className="min-w-0 truncate">
+                  {data.room.member_count} {data.room.member_count === 1 ? t.member : t.members}
+                </span>
+              </div>
+              <div className="flex min-w-0 items-center gap-2">
+                <MessageSquareText className="h-4 w-4 shrink-0 text-neon-purple" aria-hidden="true" />
+                <span className="min-w-0 truncate">{t.latestMessages.replace("{count}", String(messageCount))}</span>
+              </div>
+              <div className="flex min-w-0 items-center gap-2">
+                <Clock className="h-4 w-4 shrink-0 text-neon-cyan" aria-hidden="true" />
+                <span className="min-w-0 truncate">{t.sharedBy} {data.shared_by} · {sharedDate}</span>
+              </div>
             </div>
           </div>
         </header>
 
-        <main className="overflow-hidden rounded-lg border border-white/10 bg-deep-black-light/80 shadow-2xl shadow-black/20">
-          <div className="sticky top-0 z-10 border-b border-white/10 bg-deep-black-light/95 px-4 py-3 backdrop-blur sm:px-5">
-            <Link
-              href={openHref}
-              className="group flex items-center justify-between gap-3 rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2.5 text-sm text-text-secondary transition hover:border-neon-cyan/40 hover:bg-neon-cyan/10 hover:text-text-primary"
-            >
-              <span>{t.showMore}</span>
-              <span className="inline-flex items-center gap-1 font-medium text-neon-cyan">
-                {t.jumpToRoom}
-                <ArrowUpRight className="h-4 w-4 transition group-hover:translate-x-0.5 group-hover:-translate-y-0.5" aria-hidden="true" />
-              </span>
-            </Link>
-          </div>
+        <main id="room-preview" className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_320px] lg:items-start">
+          <section className="min-w-0 space-y-3" aria-labelledby="room-preview-title">
+            <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+              <div className="min-w-0">
+                <h2 id="room-preview-title" className="text-lg font-semibold text-text-primary">
+                  {t.previewTitle}
+                </h2>
+                <p className="mt-1 text-sm text-text-secondary">{t.previewSubtitle}</p>
+              </div>
+              {hiddenMessageCount > 0 && (
+                <p className="text-xs font-medium text-neon-cyan">
+                  {t.hiddenMessages.replace("{count}", String(hiddenMessageCount))}
+                </p>
+              )}
+            </div>
 
-          <div className="px-3 py-4 sm:px-5 sm:py-5">
             {previewMessages.length === 0 ? (
-              <p className="py-12 text-center text-sm text-text-secondary">{t.noMessages}</p>
+              <p className="rounded-lg border border-white/10 bg-white/[0.045] px-4 py-10 text-center text-sm text-text-secondary">
+                {t.noMessages}
+              </p>
             ) : (
               <div className="space-y-3">
-                {previewMessages.map((msg) => (
-                  <SharedMessageBubble key={msg.hub_msg_id} message={msg} />
-                ))}
-                <div ref={messagesEndRef} aria-hidden="true" />
+                {previewMessages.map((msg) => {
+                  const text = truncateSharedRoomMessageText(getSharedRoomMessageText(msg));
+                  const senderInitial = (msg.sender_name || msg.sender_id || "?").trim().slice(0, 1).toUpperCase();
+                  const attachments = msg.payload?.attachments;
+                  const hasAttachments = Array.isArray(attachments) && attachments.length > 0;
+                  return (
+                    <article
+                      key={msg.hub_msg_id}
+                      className="flex min-w-0 gap-3 rounded-lg border border-white/10 bg-white/[0.045] px-3.5 py-3.5 shadow-lg shadow-black/10"
+                    >
+                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-white/10 bg-[linear-gradient(135deg,rgba(0,240,255,0.20),rgba(139,92,246,0.20))] text-xs font-semibold text-text-primary">
+                        {senderInitial}
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+                          <span className="max-w-full truncate text-sm font-semibold text-text-primary">
+                            {msg.sender_name}
+                          </span>
+                          <span className="font-mono text-[10px] text-text-secondary/50">
+                            {formatMessageTimestamp(msg.created_at)}
+                          </span>
+                        </div>
+                        <p className="mt-1 line-clamp-2 break-words text-sm leading-6 text-text-secondary">
+                          {text || (hasAttachments ? t.attachmentPreview : t.messageFallback)}
+                        </p>
+                      </div>
+                    </article>
+                  );
+                })}
               </div>
             )}
-          </div>
+          </section>
+
+          <section className="rounded-lg border border-neon-cyan/25 bg-neon-cyan/[0.08] px-4 py-4 shadow-2xl shadow-black/20">
+            <div className="flex items-start gap-3">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-neon-cyan/30 bg-neon-cyan/15 text-neon-cyan">
+                <LockKeyhole className="h-5 w-5" aria-hidden="true" />
+              </div>
+              <div className="min-w-0">
+                <h2 className="text-base font-semibold text-text-primary">{t.unlockTitle}</h2>
+                <p className="mt-2 text-sm leading-6 text-text-secondary">{t.unlockBody}</p>
+                <Link
+                  href={openHref}
+                  className="mt-4 inline-flex min-h-10 w-full items-center justify-center gap-2 rounded-lg border border-neon-cyan/50 bg-neon-cyan px-3 py-2 text-sm font-semibold text-deep-black transition hover:bg-text-primary"
+                >
+                  {t.unlockCta}
+                  <ArrowUpRight className="h-4 w-4 shrink-0" aria-hidden="true" />
+                </Link>
+              </div>
+            </div>
+          </section>
         </main>
 
-        <p className="text-center text-xs text-text-secondary">
+        <p className="text-center text-xs leading-5 text-text-secondary">
           {data.entry_type === "paid_room"
             ? t.paidHint
             : data.entry_type === "private_room"

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -2674,9 +2674,18 @@ export const sharedRoomView: TranslationMap<{
   previewBadge: string
   sharedBy: string
   latestMessages: string
+  previewCta: string
+  previewTitle: string
+  previewSubtitle: string
+  hiddenMessages: string
   showMore: string
   jumpToRoom: string
   openInBotcord: string
+  unlockCta: string
+  unlockTitle: string
+  unlockBody: string
+  messageFallback: string
+  attachmentPreview: string
   copyInvitePrompt: string
   promptCopied: string
   copyPromptFailed: string
@@ -2697,10 +2706,19 @@ export const sharedRoomView: TranslationMap<{
     goHome: 'Go Home',
     previewBadge: 'Latest room preview',
     sharedBy: 'Shared by',
-    latestMessages: '{count} latest messages',
+    latestMessages: '{count} message teaser',
+    previewCta: 'Preview messages',
+    previewTitle: 'Latest preview',
+    previewSubtitle: 'A compact teaser from the room conversation.',
+    hiddenMessages: 'Unlock {count} more messages in BotCord',
     showMore: 'Show more messages',
     jumpToRoom: 'Open room',
     openInBotcord: 'Open in BotCord',
+    unlockCta: 'Log in / open BotCord to unlock and enter room',
+    unlockTitle: 'Unlock the full conversation',
+    unlockBody: 'Open BotCord to read the complete thread, join or continue in this room, and reply with your account.',
+    messageFallback: 'Message preview unavailable.',
+    attachmentPreview: 'Attachment shared in the room.',
     copyInvitePrompt: 'Copy invite prompt',
     promptCopied: 'Prompt copied',
     copyPromptFailed: 'Failed to copy invite prompt.',
@@ -2721,10 +2739,19 @@ export const sharedRoomView: TranslationMap<{
     goHome: '返回首页',
     previewBadge: '最新房间预览',
     sharedBy: '分享者',
-    latestMessages: '最新 {count} 条消息',
+    latestMessages: '{count} 条消息预览',
+    previewCta: '预览消息',
+    previewTitle: '最新预览',
+    previewSubtitle: '这里展示房间对话的精简片段。',
+    hiddenMessages: '还有 {count} 条消息可在 BotCord 解锁',
     showMore: '显示更多消息',
     jumpToRoom: '进入房间',
     openInBotcord: '在 BotCord 中打开',
+    unlockCta: '登录/打开 BotCord 解锁完整内容并进入房间',
+    unlockTitle: '解锁完整对话',
+    unlockBody: '打开 BotCord 后即可阅读完整内容，加入或继续这个房间，并使用你的账号回复。',
+    messageFallback: '暂无可预览的消息内容。',
+    attachmentPreview: '房间内分享了附件。',
     copyInvitePrompt: '复制邀请 Prompt',
     promptCopied: 'Prompt 已复制',
     copyPromptFailed: '复制邀请 Prompt 失败。',


### PR DESCRIPTION
## Summary
- rework shared room pages into a conversion-focused landing view with stronger unlock/join CTAs
- replace the full 30-message transcript with 3 compact teaser messages and text truncation
- add an unlock section for logging in/opening BotCord to enter the room and read the full conversation
- remove the share page auto-scroll-to-bottom behavior

## Verification
- corepack pnpm --dir frontend test src/components/share/SharedRoomView.test.ts
- corepack pnpm --dir frontend test
- git diff --check
- local dev route returned 200 for /share/sh_5dbbbc6e936347a1ba469d34

## Notes
- corepack pnpm --dir frontend exec tsc --noEmit still fails on pre-existing frontend test/API route typing issues outside this change.
- Playwright is not installed in frontend, and no Chrome binary is available in this environment, so I could not capture an automated browser screenshot.