### PR TITLE
perf(dashboard): cut needless re-renders of the chats workspace

### DIFF
--- a/frontend/src/components/dashboard/ActivityPanel.tsx
+++ b/frontend/src/components/dashboard/ActivityPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, memo } from "react";
 import { api } from "@/lib/api";
 import type { ActivityStats, ActivityFeedItem } from "@/lib/types";
 import { useLanguage } from "@/lib/i18n";
@@ -174,7 +174,9 @@ function FeedItem({ item, zh }: { item: ActivityFeedItem; zh: boolean }) {
 // Main panel
 // ---------------------------------------------------------------------------
 
-export default function ActivityPanel() {
+export default memo(ActivityPanel);
+
+function ActivityPanel() {
   const locale = useLanguage();
   const zh = locale === "zh";
   const t = sidebar[locale];

--- a/frontend/src/components/dashboard/AgentBrowser.tsx
+++ b/frontend/src/components/dashboard/AgentBrowser.tsx
@@ -7,7 +7,7 @@
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
 
-import { useEffect, useState } from "react";
+import { memo, useEffect, useState } from "react";
 import SubscriptionBadge from "./SubscriptionBadge";
 import { useLanguage } from '@/lib/i18n';
 import { agentBrowser } from '@/lib/i18n/translations/dashboard';
@@ -30,7 +30,9 @@ import AddRoomMemberModal from "./AddRoomMemberModal";
 import TransferOwnershipDialog from "./TransferOwnershipDialog";
 import { roomList as roomListI18n } from "@/lib/i18n/translations/dashboard";
 
-export default function AgentBrowser() {
+export default memo(AgentBrowser);
+
+function AgentBrowser() {
   const router = useRouter();
   const locale = useLanguage();
   const t = agentBrowser[locale];

--- a/frontend/src/components/dashboard/BotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/BotDetailDrawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { memo, useEffect, useState } from "react";
 import { useRouter } from "nextjs-toploader/app";
 import {
   Bot,
@@ -86,7 +86,9 @@ interface BotFriendRoom {
  * Right-side drawer for a single owned bot.
  * Top-level tabs keep the drawer compact: 概览 / 钱包 / 设置 / 文件.
  */
-export default function BotDetailDrawer() {
+export default memo(BotDetailDrawer);
+
+function BotDetailDrawer() {
   const router = useRouter();
   const locale = useLanguage();
   const t = botDetailDrawer[locale];

--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -25,6 +25,7 @@ import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import { useDashboardUnreadStore } from "@/store/useDashboardUnreadStore";
 import { useDashboardWalletStore } from "@/store/useDashboardWalletStore";
 import { usePresenceStore } from "@/store/usePresenceStore";
+import { useShallow } from "zustand/react/shallow";
 import AgentBrowser from "./AgentBrowser";
 import AgentCardModal from "./AgentCardModal";
 import AgentGateModal from "./AgentGateModal";
@@ -98,11 +99,30 @@ export default function DashboardApp() {
   const sessionStore = useDashboardSessionStore();
   const uiStore = useDashboardUIStore();
   const chatStore = useDashboardChatStore();
-  const realtimeStore = useDashboardRealtimeStore();
-  const unreadStore = useDashboardUnreadStore();
+  // realtime/unread/subscription: the root only ever calls their actions (stable
+  // refs), never reads churning data — so select just the actions via useShallow.
+  // Subscribing to the whole store here re-rendered DashboardApp (and its entire
+  // subtree) on every inbound message / realtime event / unread tick.
+  const realtimeStore = useDashboardRealtimeStore(
+    useShallow((s) => ({
+      resetRealtimeState: s.resetRealtimeState,
+      setRealtimeStatus: s.setRealtimeStatus,
+      syncRealtimeEvent: s.syncRealtimeEvent,
+    })),
+  );
+  const unreadStore = useDashboardUnreadStore(
+    useShallow((s) => ({
+      applyRealtimeEvent: s.applyRealtimeEvent,
+      resetUnreadState: s.resetUnreadState,
+    })),
+  );
   const walletStore = useDashboardWalletStore();
   const contactStore = useDashboardContactStore();
-  const subscriptionStore = useDashboardSubscriptionStore();
+  const subscriptionStore = useDashboardSubscriptionStore(
+    useShallow((s) => ({
+      resetSubscriptionState: s.resetSubscriptionState,
+    })),
+  );
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();

--- a/frontend/src/components/dashboard/DeviceDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/DeviceDetailDrawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { memo, useEffect, useState } from "react";
 import {
   ArrowLeft,
   Check,
@@ -30,7 +30,9 @@ import BotAvatar from "./BotAvatar";
  * Right-edge slide-out drawer for one device's details + settings.
  * Driven by `selectedDeviceId` in the UI store; close = set it to null.
  */
-export default function DeviceDetailDrawer() {
+export default memo(DeviceDetailDrawer);
+
+function DeviceDetailDrawer() {
   const {
     daemons,
     diagnosticResults,

--- a/frontend/src/components/dashboard/HomePanel.tsx
+++ b/frontend/src/components/dashboard/HomePanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { forwardRef, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { forwardRef, memo, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { useRouter } from "nextjs-toploader/app";
 import {
@@ -703,7 +703,9 @@ function PersonCard({
   );
 }
 
-export default function HomePanel() {
+export default memo(HomePanel);
+
+function HomePanel() {
   const router = useRouter();
   const locale = useLanguage();
   const t = homePanelI18n[locale];

--- a/frontend/src/components/dashboard/MyBotsPanel.tsx
+++ b/frontend/src/components/dashboard/MyBotsPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
 import { Plus } from "lucide-react";
 import { useShallow } from "zustand/shallow";
 import { api } from "@/lib/api";
@@ -16,7 +16,9 @@ import { useDaemonStore } from "@/store/useDaemonStore";
 import { useLanguage } from "@/lib/i18n";
 import { myBotsPanel as myBotsPanelI18n } from "@/lib/i18n/translations/dashboard";
 
-export default function MyBotsPanel() {
+export default memo(MyBotsPanel);
+
+function MyBotsPanel() {
   const t = myBotsPanelI18n[useLanguage()];
   const SUB_TABS = [
     { key: "bots" as const, label: t.botsTabLabel },

--- a/frontend/src/components/dashboard/PeerBotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/PeerBotDetailDrawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { memo, useEffect } from "react";
 import { useRouter } from "nextjs-toploader/app";
 import { MessageCircle, UserCheck, UserPlus, X } from "lucide-react";
 import { useShallow } from "zustand/shallow";
@@ -28,7 +28,9 @@ function formatDate(iso?: string): string {
  * Right-side drawer for a peer (non-owned) bot. Shows public info only.
  * No tabs — flat sections.
  */
-export default function PeerBotDetailDrawer() {
+export default memo(PeerBotDetailDrawer);
+
+function PeerBotDetailDrawer() {
   const router = useRouter();
   const {
     peerBotAgentId,

--- a/frontend/src/components/dashboard/StripeReturnBanner.tsx
+++ b/frontend/src/components/dashboard/StripeReturnBanner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, memo } from "react";
 import { api } from "@/lib/api";
 import type { StripeSessionStatusResponse } from "@/lib/types";
 import { useShallow } from "zustand/react/shallow";
@@ -13,7 +13,9 @@ import {
 
 type BannerMode = "success_polling" | "cancelled";
 
-export default function StripeReturnBanner() {
+export default memo(StripeReturnBanner);
+
+function StripeReturnBanner() {
   // Relaxed from `authed-ready` to any authenticated session: human-only
   // (`authed-no-agent`) sessions can also start a topup and need the same
   // post-redirect polling.

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -9,7 +9,7 @@
  *   - Rendering: status-driven (optimistic / streaming / delivered / failed)
  */
 
-import { useState, useEffect, useRef, useCallback, useLayoutEffect, useMemo } from "react";
+import { useState, useEffect, useRef, useCallback, useLayoutEffect, useMemo, memo } from "react";
 import { ArrowDown, ArrowLeft, Bot, Check, Copy, CornerUpLeft, Forward, Loader2, MessageSquare, MoreHorizontal, AlertCircle, AlertTriangle, RotateCcw, Bell, PanelLeftOpen, Settings2, User, X } from "lucide-react";
 import { useRouter } from "nextjs-toploader/app";
 import { api } from "@/lib/api";
@@ -82,7 +82,9 @@ function TypewriterText({
 // Main component
 // ---------------------------------------------------------------------------
 
-export default function UserChatPane({ agentId }: { agentId?: string | null }) {
+export default memo(UserChatPane);
+
+function UserChatPane({ agentId }: { agentId?: string | null }) {
   const locale = useLanguage();
   const router = useRouter();
   const { activeAgentId } = useDashboardSessionStore();

--- a/frontend/src/components/dashboard/WalletPanel.tsx
+++ b/frontend/src/components/dashboard/WalletPanel.tsx
@@ -7,7 +7,7 @@
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
 
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo, memo } from "react";
 import { useLanguage } from "@/lib/i18n";
 import { walletPanel } from "@/lib/i18n/translations/dashboard";
 import { common } from "@/lib/i18n/translations/common";
@@ -52,7 +52,9 @@ function sumMinor(values: Array<string | null | undefined>): string {
   return String(total);
 }
 
-export default function WalletPanel() {
+export default memo(WalletPanel);
+
+function WalletPanel() {
   const locale = useLanguage();
   const t = walletPanel[locale];
   const tc = common[locale];

--- a/frontend/src/components/dashboard/sidebar/index.tsx
+++ b/frontend/src/components/dashboard/sidebar/index.tsx
@@ -7,7 +7,7 @@
  * [PROTOCOL]: update header on changes
  */
 
-import { startTransition, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, startTransition, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import Link from "next/link";
 import { useRouter } from "nextjs-toploader/app";
@@ -114,7 +114,9 @@ interface SidebarProps {
   sidebarTabOverride?: DashboardUIState["sidebarTab"];
 }
 
-export default function Sidebar({
+export default memo(Sidebar);
+
+function Sidebar({
   mobileHideSecondary = false,
   mobileSecondaryOpen = false,
   onMobileSecondaryClose,

--- a/frontend/src/store/useDashboardChatStore.ts
+++ b/frontend/src/store/useDashboardChatStore.ts
@@ -38,6 +38,20 @@ let publicRoomsRequestSeq = 0;
 let publicAgentsRequestSeq = 0;
 let publicHumansRequestSeq = 0;
 const emptyRoomMessageSnapshot = new Map<string, string | null>();
+
+/**
+ * Structural equality for overview snapshots. `DashboardOverview` is plain JSON
+ * (no functions/Dates), so a stringify compare is correct. Used to keep the
+ * stored reference stable across background polls that return identical data —
+ * otherwise every 5s poll hands subscribers a fresh object and re-renders them.
+ */
+function overviewEqual(a: DashboardOverview, b: DashboardOverview): boolean {
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    return false;
+  }
+}
 const roomMembersInFlight = new Map<string, Promise<PublicRoomMember[]>>();
 const recalledPreviewText = "Message recalled";
 
@@ -622,6 +636,15 @@ export const useDashboardChatStore = create<DashboardChatState>()(
         })),
 
       replaceOverview: (overview) => {
+        const current = get().overview;
+        if (current && overviewEqual(current, overview)) {
+          // Identical to what we already hold — keep the existing reference so no
+          // subscriber re-renders. Only touch state if a loading/error flag is set.
+          if (get().overviewRefreshing || get().overviewErrored) {
+            set({ overviewRefreshing: false, overviewErrored: false });
+          }
+          return;
+        }
         set({ overview, overviewRefreshing: false, overviewErrored: false });
         useDashboardUnreadStore.getState().reconcileUnreadRooms(overview.rooms);
       },
@@ -912,8 +935,14 @@ export const useDashboardChatStore = create<DashboardChatState>()(
         }
         // Human-first: /overview resolves the viewer from the Supabase JWT.
 
+        const hasOverview = Boolean(get().overview);
         const request = (async () => {
-          set({ overviewRefreshing: true, overviewErrored: false });
+          // Only flip the loading flag on first load (nothing to show yet).
+          // Background polls keep the existing overview on screen, so toggling
+          // overviewRefreshing every 5s just churns re-renders for no UI change.
+          if (!hasOverview) {
+            set({ overviewRefreshing: true, overviewErrored: false });
+          }
           try {
             const overview = await api.getOverview();
             get().replaceOverview(overview);


### PR DESCRIPTION
## 背景

`/chats` 的持久壳层 `DashboardApp` 根组件订阅了 **8 个完整 Zustand store(无 selector)**,而 dashboard 组件 **零 `React.memo`**。结果是任意 store 的任意字段变化都会重渲染这个 1158 行的根组件并 reconcile 整棵子树:

- overview 轮询每 5s 触发 **2 次**全树 re-render(`overviewRefreshing` 翻转 + `overview` 换新引用)
- 每条 realtime 消息 / 未读变化各再触发一次

切 tab / 收消息时的卡顿来自这个常驻的全树重渲染,与路由无关。

## 改动

**P1 — action-only store 改 `useShallow`(`DashboardApp.tsx`)**
`realtime`/`unread`/`subscription` 三个 store 根组件只用到 action(稳定引用),改成只 select action → 消息 / realtime / 未读变化不再重渲染根组件。

**P2 — chat store 源头降 churn(`useDashboardChatStore.ts`)**
- `refreshOverview`:已有 overview 的后台轮询不再翻 `overviewRefreshing`
- `replaceOverview`:结构相等守卫,数据未变保持旧引用、完全不 `set`
- → 常态轮询从「每 5s 两次重渲染」降到 **0 次**

**P0 — 11 个重组件加 `React.memo`**
无 props 的 panel/drawer(`WalletPanel`/`HomePanel`/`ActivityPanel`/`MyBotsPanel`/`AgentBrowser`/`BotDetailDrawer`/`DeviceDetailDrawer`/`PeerBotDetailDrawer`/`StripeReturnBanner`)+ 引用稳定 props 的 `Sidebar`/`UserChatPane` → 即使根组件因真实数据变化重渲染,这些子树也跳过 reconcile。

**刻意未做**:`ChatPane` 的 memo。其内联 `onHumanOpen` 的 handler 链依赖会变的 `chatStore.overview` 且本身是 effect 依赖,稳定化需连带重构整条链,超出本 PR 范围;且 ChatPane 本就随聊天数据重渲染,memo 边际收益小。

## 验证
- ✅ `vitest run`:37 文件 / **186 测试全过**
- ✅ `next build`:**exit 0**,TypeScript + 编译全过

🤖 Generated with [Claude Code](https://claude.com/claude-code)