### PR TITLE
Add daemon error reporting

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -30,6 +30,7 @@
     "@botcord/cli": "workspace:^",
     "@botcord/protocol-core": "workspace:^",
     "@larksuiteoapi/node-sdk": "^1.63.1",
+    "@sentry/node": "^10.56.0",
     "ws": "^8.20.1"
   },
   "overrides": {

--- a/packages/daemon/src/__tests__/cloud-daemon.test.ts
+++ b/packages/daemon/src/__tests__/cloud-daemon.test.ts
@@ -148,6 +148,23 @@ describe("startCloudDaemon", () => {
     }
   });
 
+  it("removes the process fatal hook when startup fails after hook install", async () => {
+    const beforeMonitor = process.listenerCount("uncaughtExceptionMonitor");
+
+    await expect(startCloudDaemon({
+      cloudConfig: makeCfg(),
+      config: makeDaemonCfg(),
+      configPath: "(cloud-mode)",
+      disableControlChannel: true,
+      sessionStorePath: path.join(tmpDir, "sessions.json"),
+      snapshotPath: path.join(tmpDir, "snapshot.json"),
+      snapshotIntervalMs: 60_000,
+      failAfterProcessErrorHooks: new Error("forced cloud startup failure"),
+    })).rejects.toThrow("forced cloud startup failure");
+
+    expect(process.listenerCount("uncaughtExceptionMonitor")).toBe(beforeMonitor);
+  });
+
   it("uses the provided provisioner factory", async () => {
     const provisionerSpy = vi.fn();
     const factorySpy = vi.fn(() => provisionerSpy);

--- a/packages/daemon/src/__tests__/daemon.test.ts
+++ b/packages/daemon/src/__tests__/daemon.test.ts
@@ -13,6 +13,7 @@ import {
   backfillBootAgents,
   classifyActivitySender,
   createActivityRecorder,
+  startDaemon,
 } from "../daemon.js";
 import type { DiscoveredAgentCredential } from "../agent-discovery.js";
 import { agentWorkspaceDir } from "../agent-workspace.js";
@@ -295,5 +296,44 @@ describe("backfillBootAgents", () => {
       backfillBootAgents([bootAgent("ag_one")], { logger: silentLogger() }),
     ).not.toThrow();
     expect(existsSync("/fake/ag_one.json")).toBe(false);
+  });
+});
+
+describe("startDaemon process error hooks", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), "botcord-daemon-hooks-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("removes the process fatal hook when startup fails after hook install", async () => {
+    const beforeMonitor = process.listenerCount("uncaughtExceptionMonitor");
+    await expect(startDaemon({
+      config: {
+        defaultRoute: { adapter: "codex", cwd: tmpDir },
+        routes: [],
+        streamBlocks: true,
+      },
+      configPath: "(test)",
+      bootAgents: {
+        agents: [],
+        source: "config",
+        credentialsDir: tmpDir,
+        warnings: [],
+      },
+      userAuth: null,
+      disableControlChannel: true,
+      sessionStorePath: path.join(tmpDir, "sessions.json"),
+      snapshotPath: path.join(tmpDir, "snapshot.json"),
+      snapshotIntervalMs: 60_000,
+      log: silentLogger(),
+      failAfterProcessErrorHooks: new Error("forced startup failure"),
+    })).rejects.toThrow("forced startup failure");
+
+    expect(process.listenerCount("uncaughtExceptionMonitor")).toBe(beforeMonitor);
   });
 });

--- a/packages/daemon/src/__tests__/error-reporting.test.ts
+++ b/packages/daemon/src/__tests__/error-reporting.test.ts
@@ -9,6 +9,7 @@ import {
   noopErrorReporter,
   reportErrorSafely,
   resolveErrorReporterConfig,
+  SentryErrorReporter,
   type DaemonErrorReport,
   type ErrorReporter,
 } from "../error-reporting.js";
@@ -49,6 +50,24 @@ describe("daemon error reporting", () => {
       },
       log: silentLogger(),
     })).toBeInstanceOf(BoundedDedupeErrorReporter);
+  });
+
+  it("initializes Sentry without adding process exception or rejection handlers", async () => {
+    const beforeUnhandled = process.listenerCount("unhandledRejection");
+    const beforeUncaught = process.listenerCount("uncaughtException");
+    const reporter = new SentryErrorReporter({
+      enabled: true,
+      dsn: "https://public@example.com/1",
+    }, silentLogger());
+
+    try {
+      await reporter.init();
+      expect(process.listenerCount("unhandledRejection")).toBe(beforeUnhandled);
+      expect(process.listenerCount("uncaughtException")).toBe(beforeUncaught);
+    } finally {
+      const Sentry = await import("@sentry/node");
+      await Sentry.close(0);
+    }
   });
 
   it("dedupes repeated events by bounded key", () => {

--- a/packages/daemon/src/__tests__/error-reporting.test.ts
+++ b/packages/daemon/src/__tests__/error-reporting.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  BoundedDedupeErrorReporter,
+  buildProcessFatalErrorReport,
+  createDaemonErrorReporter,
+  initializeErrorReporterSafely,
+  installProcessErrorReportingHooks,
+  noopErrorReporter,
+  reportErrorSafely,
+  resolveErrorReporterConfig,
+  type DaemonErrorReport,
+  type ErrorReporter,
+} from "../error-reporting.js";
+import type { GatewayLogger } from "../gateway/log.js";
+
+function silentLogger(): GatewayLogger {
+  return { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+}
+
+describe("daemon error reporting", () => {
+  it("resolves env config and keeps disabled/no-DSN reporting cheap", () => {
+    expect(resolveErrorReporterConfig({}).enabled).toBe(true);
+    expect(resolveErrorReporterConfig({ BOTCORD_DAEMON_ERROR_REPORTING_ENABLED: "0" }).enabled)
+      .toBe(false);
+    expect(resolveErrorReporterConfig({
+      BOTCORD_DAEMON_ERROR_REPORTING_ENABLED: "1",
+      BOTCORD_DAEMON_SENTRY_DSN: " https://sentry.example/1 ",
+      BOTCORD_DAEMON_ENVIRONMENT: "production",
+      BOTCORD_DAEMON_RELEASE: "v1",
+    })).toEqual({
+      enabled: true,
+      dsn: "https://sentry.example/1",
+      environment: "production",
+      release: "v1",
+    });
+
+    expect(createDaemonErrorReporter({ env: {} })).toBe(noopErrorReporter);
+    expect(createDaemonErrorReporter({
+      env: {
+        BOTCORD_DAEMON_ERROR_REPORTING_ENABLED: "0",
+        BOTCORD_DAEMON_SENTRY_DSN: "https://sentry.example/1",
+      },
+    })).toBe(noopErrorReporter);
+    expect(createDaemonErrorReporter({
+      env: {
+        BOTCORD_DAEMON_ERROR_REPORTING_ENABLED: "1",
+        BOTCORD_DAEMON_SENTRY_DSN: "https://sentry.example/1",
+      },
+      log: silentLogger(),
+    })).toBeInstanceOf(BoundedDedupeErrorReporter);
+  });
+
+  it("dedupes repeated events by bounded key", () => {
+    const reports: DaemonErrorReport[] = [];
+    const inner: ErrorReporter = { report: (event) => reports.push(event) };
+    const reporter = new BoundedDedupeErrorReporter(inner, 2);
+
+    reporter.report({ type: "runtime_failure", message: "one", dedupeKey: "err_1:turn_1" });
+    reporter.report({ type: "runtime_failure", message: "duplicate", dedupeKey: "err_1:turn_1" });
+    reporter.report({ type: "runtime_failure", message: "two", dedupeKey: "err_2:turn_2" });
+    reporter.report({ type: "runtime_failure", message: "three", dedupeKey: "err_3:turn_3" });
+    reporter.report({ type: "runtime_failure", message: "one-again-after-evict", dedupeKey: "err_1:turn_1" });
+
+    expect(reports.map((event) => event.message)).toEqual([
+      "one",
+      "two",
+      "three",
+      "one-again-after-evict",
+    ]);
+  });
+
+  it("logs and suppresses reporter exceptions", async () => {
+    const warn = vi.fn();
+    const logger: GatewayLogger = { info: () => {}, warn, error: () => {}, debug: () => {} };
+    reportErrorSafely(
+      { report: () => { throw new Error("sentry down"); } },
+      { type: "runtime_failure", message: "failed" },
+      logger,
+    );
+    expect(warn).toHaveBeenCalledWith("daemon error reporter failed", {
+      eventType: "runtime_failure",
+      error: "sentry down",
+    });
+
+    reportErrorSafely(
+      { report: async () => { throw new Error("async down"); } },
+      { type: "runtime_failure", message: "failed" },
+      logger,
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(warn).toHaveBeenCalledWith("daemon error reporter failed", {
+      eventType: "runtime_failure",
+      error: "async down",
+    });
+  });
+
+  it("logs and suppresses reporter init exceptions", async () => {
+    const warn = vi.fn();
+    const logger: GatewayLogger = { info: () => {}, warn, error: () => {}, debug: () => {} };
+    await initializeErrorReporterSafely(
+      { init: async () => { throw new Error("init down"); }, report: () => {} },
+      logger,
+    );
+
+    expect(warn).toHaveBeenCalledWith("daemon error reporter init failed", {
+      error: "init down",
+    });
+  });
+
+  it("installs only an uncaughtExceptionMonitor hook and removes it", () => {
+    const beforeMonitor = process.listenerCount("uncaughtExceptionMonitor");
+    const beforeUnhandled = process.listenerCount("unhandledRejection");
+    const uninstall = installProcessErrorReportingHooks({
+      reporter: noopErrorReporter,
+      log: silentLogger(),
+    });
+
+    try {
+      expect(process.listenerCount("uncaughtExceptionMonitor")).toBe(beforeMonitor + 1);
+      expect(process.listenerCount("unhandledRejection")).toBe(beforeUnhandled);
+    } finally {
+      uninstall();
+    }
+
+    expect(process.listenerCount("uncaughtExceptionMonitor")).toBe(beforeMonitor);
+    expect(process.listenerCount("unhandledRejection")).toBe(beforeUnhandled);
+  });
+
+  it("sanitizes process fatal reports", () => {
+    const report = buildProcessFatalErrorReport(
+      new Error("boom token=abc123 Authorization: Bearer secret"),
+      {
+        mechanism: "uncaught_exception",
+        daemonInstanceId: "di_1",
+        hubUrl: "https://hub.test",
+      },
+    );
+
+    expect(report.type).toBe("process_fatal");
+    expect(report.message).toContain("token=[REDACTED]");
+    expect(report.message).toContain("Authorization: Bearer [REDACTED]");
+    expect(report.tags?.daemon_instance_id).toBe("di_1");
+    expect(report.tags?.hub_url).toBe("https://hub.test");
+    expect(report.fingerprint).toContain("uncaught_exception");
+  });
+});

--- a/packages/daemon/src/cloud-daemon.ts
+++ b/packages/daemon/src/cloud-daemon.ts
@@ -89,6 +89,8 @@ export interface CloudDaemonRuntimeOptions {
   provisionerFactory?: typeof createProvisioner;
   /** Test hook: inject daemon error reporter instead of resolving from env. */
   errorReporter?: ErrorReporter;
+  /** Test hook: force a post-process-hook startup failure. */
+  failAfterProcessErrorHooks?: Error;
 }
 
 /** Handle returned by {@link startCloudDaemon}. */
@@ -127,6 +129,8 @@ export async function startCloudDaemon(
     hubUrl: cloudCfg.hubUrl,
     daemonInstanceId: cloudCfg.daemonInstanceId,
   });
+  try {
+  if (opts.failAfterProcessErrorHooks) throw opts.failAfterProcessErrorHooks;
 
   logger.info("cloud daemon starting", {
     cloudDaemonInstanceId: cloudCfg.cloudDaemonInstanceId,
@@ -425,4 +429,8 @@ export async function startCloudDaemon(
     stop,
     snapshot: () => gateway.snapshot(),
   };
+  } catch (err) {
+    uninstallProcessErrorHooks();
+    throw err;
+  }
 }

--- a/packages/daemon/src/cloud-daemon.ts
+++ b/packages/daemon/src/cloud-daemon.ts
@@ -43,6 +43,12 @@ import type { CloudModeConfig } from "./cloud-mode.js";
 import { buildCloudRunSettleHook } from "./cloud-settle.js";
 import type { InstalledAgentInfo, OnAgentInstalledHook } from "./provision.js";
 import type { SkillIndexOptions } from "./skill-index.js";
+import {
+  createDaemonErrorReporter,
+  initializeErrorReporterSafely,
+  installProcessErrorReportingHooks,
+  type ErrorReporter,
+} from "./error-reporting.js";
 
 // Cloud daemons follow the same cadence as local — keeps dashboard
 // "runtimes last detected" behavior identical across both kinds.
@@ -81,6 +87,8 @@ export interface CloudDaemonRuntimeOptions {
    * `createProvisioner({ gateway, policyResolver, onAgentInstalled })`.
    */
   provisionerFactory?: typeof createProvisioner;
+  /** Test hook: inject daemon error reporter instead of resolving from env. */
+  errorReporter?: ErrorReporter;
 }
 
 /** Handle returned by {@link startCloudDaemon}. */
@@ -111,6 +119,14 @@ export async function startCloudDaemon(
 ): Promise<CloudDaemonHandle> {
   const logger = buildLogger(opts.log);
   const cloudCfg = opts.cloudConfig;
+  const errorReporter = opts.errorReporter ?? createDaemonErrorReporter({ log: logger });
+  await initializeErrorReporterSafely(errorReporter, logger);
+  const uninstallProcessErrorHooks = installProcessErrorReportingHooks({
+    reporter: errorReporter,
+    log: logger,
+    hubUrl: cloudCfg.hubUrl,
+    daemonInstanceId: cloudCfg.daemonInstanceId,
+  });
 
   logger.info("cloud daemon starting", {
     cloudDaemonInstanceId: cloudCfg.cloudDaemonInstanceId,
@@ -307,6 +323,7 @@ export async function startCloudDaemon(
     buildRuntimeRecoveryContext,
     onInbound,
     onTurnComplete,
+    errorReporter,
     composeUserTurn: composeBotCordUserTurn,
     attentionGate,
     resolveHubUrl,
@@ -391,6 +408,7 @@ export async function startCloudDaemon(
     logger.info("cloud daemon stopping", { reason: reason ?? null });
     snapshotWriter.stop();
     snapshotWriter.writeFinal();
+    uninstallProcessErrorHooks();
     const controlStopP = controlChannel
       ? controlChannel.stop().catch(() => undefined)
       : Promise.resolve();

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -53,6 +53,12 @@ import { scanMention } from "./mention-scan.js";
 import { createDiagnosticBundle, uploadDiagnosticBundle } from "./diagnostics.js";
 import { createAttentionPolicyFetcher } from "./attention-policy-fetcher.js";
 import { collectAgentSkillSnapshot, type SkillIndexOptions } from "./skill-index.js";
+import {
+  createDaemonErrorReporter,
+  initializeErrorReporterSafely,
+  installProcessErrorReportingHooks,
+  type ErrorReporter,
+} from "./error-reporting.js";
 
 /**
  * Default hard cap for a single runtime turn. Long-running coding/research
@@ -297,6 +303,8 @@ export interface DaemonRuntimeOptions {
   userAuth?: UserAuthManager | null;
   /** Skip the control channel even when user-auth is available. Test hook. */
   disableControlChannel?: boolean;
+  /** Test hook: inject daemon error reporter instead of resolving from env. */
+  errorReporter?: ErrorReporter;
 }
 
 /** Handle returned by {@link startDaemon}. */
@@ -333,6 +341,14 @@ function buildDaemonLogger(): GatewayLogger {
  */
 export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHandle> {
   const logger = opts.log ?? buildDaemonLogger();
+  const errorReporter = opts.errorReporter ?? createDaemonErrorReporter({ log: logger });
+  await initializeErrorReporterSafely(errorReporter, logger);
+  const uninstallProcessErrorHooks = installProcessErrorReportingHooks({
+    reporter: errorReporter,
+    log: logger,
+    hubUrl: opts.hubBaseUrl ?? null,
+    daemonInstanceId: process.env.BOTCORD_DAEMON_INSTANCE_ID ?? null,
+  });
   const userAuth =
     opts.userAuth === undefined
       ? tryLoadUserAuth(logger)
@@ -590,6 +606,7 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
     onInbound,
     onOutbound,
     onRuntimeCircuitBreakerChange: pushLiveRuntimeSnapshot,
+    errorReporter,
     composeUserTurn: composeBotCordUserTurn,
     attentionGate,
     resolveHubUrl,
@@ -729,6 +746,7 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
     // Write one final snapshot so `status` doesn't briefly see stale data,
     // then delete the file on the way out.
     snapshotWriter.writeFinal();
+    uninstallProcessErrorHooks();
     const controlStopP = controlChannel
       ? controlChannel.stop().catch(() => undefined)
       : Promise.resolve();

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -305,6 +305,8 @@ export interface DaemonRuntimeOptions {
   disableControlChannel?: boolean;
   /** Test hook: inject daemon error reporter instead of resolving from env. */
   errorReporter?: ErrorReporter;
+  /** Test hook: force a post-process-hook startup failure. */
+  failAfterProcessErrorHooks?: Error;
 }
 
 /** Handle returned by {@link startDaemon}. */
@@ -349,6 +351,8 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
     hubUrl: opts.hubBaseUrl ?? null,
     daemonInstanceId: process.env.BOTCORD_DAEMON_INSTANCE_ID ?? null,
   });
+  try {
+  if (opts.failAfterProcessErrorHooks) throw opts.failAfterProcessErrorHooks;
   const userAuth =
     opts.userAuth === undefined
       ? tryLoadUserAuth(logger)
@@ -763,6 +767,10 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
     stop,
     snapshot: () => gateway.snapshot(),
   };
+  } catch (err) {
+    uninstallProcessErrorHooks();
+    throw err;
+  }
 }
 
 /**

--- a/packages/daemon/src/error-reporting.ts
+++ b/packages/daemon/src/error-reporting.ts
@@ -124,7 +124,7 @@ export class SentryErrorReporter implements ErrorReporter {
   private async loadSentry(): Promise<SentryModule> {
     if (!this.sentry) {
       this.sentry = import("@sentry/node").then((Sentry) => {
-        Sentry.init({
+        Sentry.initWithoutDefaultIntegrations({
           dsn: this.config.dsn,
           environment: this.config.environment,
           release: this.config.release,

--- a/packages/daemon/src/error-reporting.ts
+++ b/packages/daemon/src/error-reporting.ts
@@ -1,0 +1,284 @@
+import type { GatewayLogger } from "./gateway/log.js";
+import { errorInfo, sanitizeRuntimeFailureText } from "./gateway/runtime-failure.js";
+
+const DEFAULT_DEDUPE_LIMIT = 1024;
+
+export type ErrorReportType = "runtime_failure" | "process_fatal";
+
+export interface DaemonErrorReport {
+  type: ErrorReportType;
+  message: string;
+  tags?: Record<string, string | number | boolean | null | undefined>;
+  context?: Record<string, unknown>;
+  fingerprint?: string[];
+  dedupeKey?: string;
+}
+
+export interface ErrorReporter {
+  init?(): Promise<void> | void;
+  report(event: DaemonErrorReport): Promise<void> | void;
+}
+
+export interface ErrorReporterConfig {
+  enabled: boolean;
+  dsn?: string;
+  environment?: string;
+  release?: string;
+}
+
+export interface CreateErrorReporterOptions {
+  env?: NodeJS.ProcessEnv;
+  log?: GatewayLogger;
+  dedupeLimit?: number;
+}
+
+type SentryModule = typeof import("@sentry/node");
+
+export const noopErrorReporter: ErrorReporter = {
+  report: () => {},
+};
+
+export function resolveErrorReporterConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): ErrorReporterConfig {
+  return {
+    enabled: parseEnabled(env.BOTCORD_DAEMON_ERROR_REPORTING_ENABLED),
+    dsn: nonEmpty(env.BOTCORD_DAEMON_SENTRY_DSN),
+    environment: nonEmpty(env.BOTCORD_DAEMON_ENVIRONMENT),
+    release: nonEmpty(env.BOTCORD_DAEMON_RELEASE),
+  };
+}
+
+export function createDaemonErrorReporter(
+  opts: CreateErrorReporterOptions = {},
+): ErrorReporter {
+  const config = resolveErrorReporterConfig(opts.env);
+  if (!config.enabled || !config.dsn) return noopErrorReporter;
+  return new BoundedDedupeErrorReporter(
+    new SentryErrorReporter(config, opts.log),
+    opts.dedupeLimit,
+  );
+}
+
+export class BoundedDedupeErrorReporter implements ErrorReporter {
+  private readonly seen = new Set<string>();
+  private readonly limit: number;
+
+  constructor(
+    private readonly inner: ErrorReporter,
+    limit = DEFAULT_DEDUPE_LIMIT,
+  ) {
+    this.limit = Math.max(1, Math.floor(limit));
+  }
+
+  init(): Promise<void> | void {
+    return this.inner.init?.();
+  }
+
+  report(event: DaemonErrorReport): Promise<void> | void {
+    const key = event.dedupeKey;
+    if (key) {
+      if (this.seen.has(key)) return;
+      this.seen.add(key);
+      if (this.seen.size > this.limit) {
+        const oldest = this.seen.values().next().value;
+        if (oldest !== undefined) this.seen.delete(oldest);
+      }
+    }
+    return this.inner.report(event);
+  }
+}
+
+export class SentryErrorReporter implements ErrorReporter {
+  private sentry: Promise<SentryModule> | null = null;
+
+  constructor(
+    private readonly config: ErrorReporterConfig,
+    private readonly log?: GatewayLogger,
+  ) {}
+
+  async init(): Promise<void> {
+    await this.loadSentry();
+  }
+
+  async report(event: DaemonErrorReport): Promise<void> {
+    const Sentry = await this.loadSentry();
+    Sentry.withScope((scope) => {
+      scope.setLevel("error");
+      if (event.fingerprint && event.fingerprint.length > 0) {
+        scope.setFingerprint(event.fingerprint);
+      }
+      for (const [key, value] of Object.entries(event.tags ?? {})) {
+        if (value === undefined || value === null) continue;
+        scope.setTag(key, String(value));
+      }
+      scope.setTag("event_type", event.type);
+      scope.setContext("botcord_daemon", {
+        type: event.type,
+        ...(event.context ?? {}),
+      });
+      Sentry.captureMessage(event.message);
+    });
+  }
+
+  private async loadSentry(): Promise<SentryModule> {
+    if (!this.sentry) {
+      this.sentry = import("@sentry/node").then((Sentry) => {
+        Sentry.init({
+          dsn: this.config.dsn,
+          environment: this.config.environment,
+          release: this.config.release,
+        });
+        this.log?.info("daemon error reporting initialized", {
+          provider: "sentry",
+          environment: this.config.environment ?? null,
+          release: this.config.release ?? null,
+        });
+        return Sentry;
+      });
+    }
+    return this.sentry;
+  }
+}
+
+export function reportErrorSafely(
+  reporter: ErrorReporter | undefined,
+  event: DaemonErrorReport,
+  log?: GatewayLogger,
+): void {
+  if (!reporter) return;
+  try {
+    const result = reporter.report(event);
+    if (result && typeof (result as Promise<void>).catch === "function") {
+      (result as Promise<void>).catch((err) => {
+        log?.warn("daemon error reporter failed", {
+          eventType: event.type,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }
+  } catch (err) {
+    log?.warn("daemon error reporter failed", {
+      eventType: event.type,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+export async function initializeErrorReporterSafely(
+  reporter: ErrorReporter | undefined,
+  log?: GatewayLogger,
+): Promise<void> {
+  if (!reporter?.init) return;
+  try {
+    await reporter.init();
+  } catch (err) {
+    log?.warn("daemon error reporter init failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+export interface ProcessErrorHookOptions {
+  reporter: ErrorReporter;
+  log?: GatewayLogger;
+  daemonInstanceId?: string | null;
+  hubUrl?: string | null;
+}
+
+export function installProcessErrorReportingHooks(
+  opts: ProcessErrorHookOptions,
+): () => void {
+  const reportFatal = (
+    reason: unknown,
+    mechanism: "uncaught_exception",
+    extra: Record<string, unknown> = {},
+  ): void => {
+    reportErrorSafely(
+      opts.reporter,
+      buildProcessFatalErrorReport(reason, {
+        mechanism,
+        daemonInstanceId: opts.daemonInstanceId,
+        hubUrl: opts.hubUrl,
+        extra,
+      }),
+      opts.log,
+    );
+  };
+
+  const onUncaughtExceptionMonitor = (
+    error: Error,
+    origin: NodeJS.UncaughtExceptionOrigin,
+  ): void => {
+    // Do not install an `unhandledRejection` listener here: that changes
+    // Node's default rejection semantics. In default throw/strict modes,
+    // unhandled rejections surface through this monitor with origin
+    // "unhandledRejection".
+    reportFatal(error, "uncaught_exception", { origin });
+  };
+
+  process.on("uncaughtExceptionMonitor", onUncaughtExceptionMonitor);
+
+  return () => {
+    process.off("uncaughtExceptionMonitor", onUncaughtExceptionMonitor);
+  };
+}
+
+export function buildProcessFatalErrorReport(
+  reason: unknown,
+  opts: {
+    mechanism: "uncaught_exception";
+    daemonInstanceId?: string | null;
+    hubUrl?: string | null;
+    extra?: Record<string, unknown>;
+  },
+): DaemonErrorReport {
+  const info = errorInfo(reason);
+  const message = sanitizeRuntimeFailureText(
+    info.error_message || "daemon process fatal error",
+    2048,
+  );
+  const stack = reason instanceof Error && reason.stack
+    ? sanitizeRuntimeFailureText(reason.stack, 8192)
+    : null;
+  const tags = {
+    mechanism: opts.mechanism,
+    daemon_instance_id: opts.daemonInstanceId ?? null,
+    hub_url: opts.hubUrl ?? null,
+    error_name: info.error_name,
+  };
+  return {
+    type: "process_fatal",
+    message,
+    tags,
+    context: {
+      mechanism: opts.mechanism,
+      daemon_instance_id: opts.daemonInstanceId ?? null,
+      hub_url: opts.hubUrl ?? null,
+      error_name: info.error_name,
+      error_message: message,
+      stack,
+      ...(opts.extra ?? {}),
+    },
+    fingerprint: [
+      "botcord-daemon",
+      "process_fatal",
+      opts.mechanism,
+      info.error_name ?? "Error",
+      message,
+    ],
+    dedupeKey: `process_fatal:${opts.mechanism}:${info.error_name ?? "Error"}:${message}`,
+  };
+}
+
+function parseEnabled(value: string | undefined): boolean {
+  if (value === undefined || value.trim() === "") return true;
+  if (/^(0|false|no|off|disabled)$/i.test(value.trim())) return false;
+  if (/^(1|true|yes|on|enabled)$/i.test(value.trim())) return true;
+  return true;
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}

--- a/packages/daemon/src/gateway/__tests__/dispatcher-error-reporting.test.ts
+++ b/packages/daemon/src/gateway/__tests__/dispatcher-error-reporting.test.ts
@@ -71,13 +71,33 @@ class ErrorRuntime implements RuntimeAdapter {
       error: "codex failed OPENAI_API_KEY=secret-openai",
       runtimeFailure: {
         cwd: "/repo",
-        command: ["codex", "--api-key", "secret-api-value", "--token", "secret-token-value", "run"],
+        command: [
+          "codex",
+          "--api-key",
+          "secret-api-value",
+          "--token",
+          "secret-token-value",
+          '{"args":["--api-key","secret-json-command"]}',
+          "run",
+        ],
         exit_code: 2,
         duration_ms: 1234,
-        stderr_tail: "stderr Authorization: Bearer secret\nx-api-key: secret-header\n--api-key secret-cli\nsk-live-secret",
-        stdout_tail: "stdout ANTHROPIC_API_KEY=secret-anthropic password: secret-password",
+        stderr_tail: [
+          "stderr Authorization: Bearer secret",
+          "x-api-key: secret-header",
+          '{"x-api-key":"secret-json-header"}',
+          "{'password': 'secret-json-password'}",
+          "--api-key secret-cli",
+          "sk-live-secret",
+        ].join("\n"),
+        stdout_tail: [
+          "stdout ANTHROPIC_API_KEY=secret-anthropic password: secret-password",
+          '{"OPENAI_API_KEY":"secret-json-openai"}',
+          '{"ANTHROPIC_API_KEY" : "secret-json-anthropic"}',
+          '{"args":["--token", "secret-json-token"]}',
+        ].join("\n"),
         error_name: "RuntimeExitError",
-        error_message: "runtime failed OPENAI_API_KEY=secret-openai",
+        error_message: 'runtime failed OPENAI_API_KEY=secret-openai {"OPENAI_API_KEY":"secret-json-message"}',
       },
     };
   }
@@ -193,20 +213,40 @@ describe("dispatcher error reporting", () => {
     ]);
 
     const failure = (report.context?.runtime_failure ?? {}) as Record<string, unknown>;
-    expect(failure.command).toEqual(["codex", "--api-key", "[REDACTED]", "--token", "[REDACTED]", "run"]);
+    expect(failure.command).toEqual([
+      "codex",
+      "--api-key",
+      "[REDACTED]",
+      "--token",
+      "[REDACTED]",
+      '{"args":["--api-key","[REDACTED]"]}',
+      "run",
+    ]);
     expect(failure.stderr_tail).toContain("Authorization: Bearer [REDACTED]");
     expect(failure.stderr_tail).toContain("x-api-key: [REDACTED]");
+    expect(failure.stderr_tail).toContain('"x-api-key":"[REDACTED]"');
+    expect(failure.stderr_tail).toContain("'password': '[REDACTED]'");
     expect(failure.stderr_tail).toContain("--api-key [REDACTED]");
     expect(failure.stderr_tail).toContain("sk-[REDACTED]");
     expect(failure.stdout_tail).toContain("ANTHROPIC_API_KEY=[REDACTED]");
     expect(failure.stdout_tail).toContain("password: [REDACTED]");
-    expect(failure.error_message).toBe("runtime failed OPENAI_API_KEY=[REDACTED]");
+    expect(failure.stdout_tail).toContain('"OPENAI_API_KEY":"[REDACTED]"');
+    expect(failure.stdout_tail).toContain('"ANTHROPIC_API_KEY" : "[REDACTED]"');
+    expect(failure.stdout_tail).toContain('"args":["--token", "[REDACTED]"]');
+    expect(failure.error_message).toBe('runtime failed OPENAI_API_KEY=[REDACTED] {"OPENAI_API_KEY":"[REDACTED]"}');
     expect(JSON.stringify(report)).not.toContain("secret-openai");
     expect(JSON.stringify(report)).not.toContain("secret-api-value");
     expect(JSON.stringify(report)).not.toContain("secret-token-value");
+    expect(JSON.stringify(report)).not.toContain("secret-json-command");
     expect(JSON.stringify(report)).not.toContain("secret-header");
+    expect(JSON.stringify(report)).not.toContain("secret-json-header");
+    expect(JSON.stringify(report)).not.toContain("secret-json-password");
     expect(JSON.stringify(report)).not.toContain("secret-cli");
     expect(JSON.stringify(report)).not.toContain("secret-anthropic");
+    expect(JSON.stringify(report)).not.toContain("secret-json-openai");
+    expect(JSON.stringify(report)).not.toContain("secret-json-anthropic");
+    expect(JSON.stringify(report)).not.toContain("secret-json-token");
+    expect(JSON.stringify(report)).not.toContain("secret-json-message");
     expect(JSON.stringify(report)).not.toContain("secret-password");
     expect(JSON.stringify(report)).not.toContain("Bearer secret");
 

--- a/packages/daemon/src/gateway/__tests__/dispatcher-error-reporting.test.ts
+++ b/packages/daemon/src/gateway/__tests__/dispatcher-error-reporting.test.ts
@@ -68,16 +68,16 @@ class ErrorRuntime implements RuntimeAdapter {
     return {
       text: "",
       newSessionId: "sid_1",
-      error: "codex failed token=secret123",
+      error: "codex failed OPENAI_API_KEY=secret-openai",
       runtimeFailure: {
         cwd: "/repo",
-        command: ["codex", "--token=secret123", "run"],
+        command: ["codex", "--api-key", "secret-api-value", "--token", "secret-token-value", "run"],
         exit_code: 2,
         duration_ms: 1234,
-        stderr_tail: "stderr Authorization: Bearer secret\nsk-live-secret",
-        stdout_tail: "stdout token=secret123",
+        stderr_tail: "stderr Authorization: Bearer secret\nx-api-key: secret-header\n--api-key secret-cli\nsk-live-secret",
+        stdout_tail: "stdout ANTHROPIC_API_KEY=secret-anthropic password: secret-password",
         error_name: "RuntimeExitError",
-        error_message: "runtime failed token=secret123",
+        error_message: "runtime failed OPENAI_API_KEY=secret-openai",
       },
     };
   }
@@ -193,12 +193,21 @@ describe("dispatcher error reporting", () => {
     ]);
 
     const failure = (report.context?.runtime_failure ?? {}) as Record<string, unknown>;
-    expect(failure.command).toEqual(["codex", "--token=[REDACTED]", "run"]);
+    expect(failure.command).toEqual(["codex", "--api-key", "[REDACTED]", "--token", "[REDACTED]", "run"]);
     expect(failure.stderr_tail).toContain("Authorization: Bearer [REDACTED]");
+    expect(failure.stderr_tail).toContain("x-api-key: [REDACTED]");
+    expect(failure.stderr_tail).toContain("--api-key [REDACTED]");
     expect(failure.stderr_tail).toContain("sk-[REDACTED]");
-    expect(failure.stdout_tail).toContain("token=[REDACTED]");
-    expect(failure.error_message).toBe("runtime failed token=[REDACTED]");
-    expect(JSON.stringify(report)).not.toContain("secret123");
+    expect(failure.stdout_tail).toContain("ANTHROPIC_API_KEY=[REDACTED]");
+    expect(failure.stdout_tail).toContain("password: [REDACTED]");
+    expect(failure.error_message).toBe("runtime failed OPENAI_API_KEY=[REDACTED]");
+    expect(JSON.stringify(report)).not.toContain("secret-openai");
+    expect(JSON.stringify(report)).not.toContain("secret-api-value");
+    expect(JSON.stringify(report)).not.toContain("secret-token-value");
+    expect(JSON.stringify(report)).not.toContain("secret-header");
+    expect(JSON.stringify(report)).not.toContain("secret-cli");
+    expect(JSON.stringify(report)).not.toContain("secret-anthropic");
+    expect(JSON.stringify(report)).not.toContain("secret-password");
     expect(JSON.stringify(report)).not.toContain("Bearer secret");
 
     const turnError = transcript.records.find((rec) => rec.kind === "turn_error");

--- a/packages/daemon/src/gateway/__tests__/dispatcher-error-reporting.test.ts
+++ b/packages/daemon/src/gateway/__tests__/dispatcher-error-reporting.test.ts
@@ -1,0 +1,228 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { Dispatcher, type RuntimeFactory } from "../dispatcher.js";
+import { SessionStore } from "../session-store.js";
+import type { GatewayLogger } from "../log.js";
+import type {
+  ChannelAdapter,
+  ChannelSendContext,
+  ChannelSendResult,
+  GatewayConfig,
+  GatewayInboundEnvelope,
+  GatewayInboundMessage,
+  RuntimeAdapter,
+  RuntimeRunOptions,
+  RuntimeRunResult,
+} from "../types.js";
+import type { TranscriptRecord, TranscriptWriter } from "../transcript.js";
+import type { DaemonErrorReport, ErrorReporter } from "../../error-reporting.js";
+
+function silentLogger(): GatewayLogger {
+  return { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+}
+
+class FakeChannel implements ChannelAdapter {
+  readonly id = "botcord";
+  readonly type = "botcord";
+  readonly sends: ChannelSendContext[] = [];
+
+  async start(): Promise<void> {}
+
+  async send(ctx: ChannelSendContext): Promise<ChannelSendResult> {
+    this.sends.push(ctx);
+    return {};
+  }
+}
+
+class CaptureTranscript implements TranscriptWriter {
+  readonly enabled = true;
+  readonly rootDir = "";
+  readonly records: TranscriptRecord[] = [];
+
+  write(rec: TranscriptRecord): void {
+    this.records.push(rec);
+  }
+}
+
+class CaptureReporter implements ErrorReporter {
+  readonly reports: DaemonErrorReport[] = [];
+
+  report(event: DaemonErrorReport): void {
+    this.reports.push(event);
+  }
+}
+
+class FailingReporter implements ErrorReporter {
+  report(): void {
+    throw new Error("reporter unavailable");
+  }
+}
+
+class ErrorRuntime implements RuntimeAdapter {
+  readonly id = "codex";
+
+  async run(_opts: RuntimeRunOptions): Promise<RuntimeRunResult> {
+    return {
+      text: "",
+      newSessionId: "sid_1",
+      error: "codex failed token=secret123",
+      runtimeFailure: {
+        cwd: "/repo",
+        command: ["codex", "--token=secret123", "run"],
+        exit_code: 2,
+        duration_ms: 1234,
+        stderr_tail: "stderr Authorization: Bearer secret\nsk-live-secret",
+        stdout_tail: "stdout token=secret123",
+        error_name: "RuntimeExitError",
+        error_message: "runtime failed token=secret123",
+      },
+    };
+  }
+}
+
+function baseConfig(): GatewayConfig {
+  return {
+    channels: [{ id: "botcord", type: "botcord", accountId: "ag_me" }],
+    defaultRoute: {
+      runtime: "codex",
+      cwd: "/repo",
+    },
+    routes: [],
+  };
+}
+
+function makeMessage(partial: Partial<GatewayInboundMessage> = {}): GatewayInboundMessage {
+  return {
+    id: partial.id ?? "hub_msg_1",
+    channel: partial.channel ?? "botcord",
+    accountId: partial.accountId ?? "ag_me",
+    conversation: partial.conversation ?? {
+      id: "rm_oc_1",
+      kind: "direct",
+      threadId: "tp_1",
+    },
+    sender: partial.sender ?? { id: "hu_1", name: "owner", kind: "user" },
+    text: partial.text ?? "run this",
+    raw: partial.raw ?? {
+      envelope: {
+        type: "inbox_message",
+        msg_id: "wire_msg_1",
+      },
+    },
+    replyTo: partial.replyTo ?? null,
+    mentioned: partial.mentioned,
+    receivedAt: partial.receivedAt ?? Date.now(),
+    trace: partial.trace,
+  };
+}
+
+function makeEnvelope(partial: Partial<GatewayInboundMessage> = {}): GatewayInboundEnvelope {
+  return { message: makeMessage(partial) };
+}
+
+describe("dispatcher error reporting", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    for (const dir of tempDirs.splice(0)) {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  async function scaffold(args: {
+    errorReporter?: ErrorReporter;
+    log?: GatewayLogger;
+  } = {}): Promise<{
+    dispatcher: Dispatcher;
+    channel: FakeChannel;
+    transcript: CaptureTranscript;
+  }> {
+    const dir = await mkdtemp(path.join(tmpdir(), "dispatcher-error-reporting-"));
+    tempDirs.push(dir);
+    const store = new SessionStore({ path: path.join(dir, "sessions.json") });
+    await store.load();
+    const channel = new FakeChannel();
+    const transcript = new CaptureTranscript();
+    const runtimeFactory: RuntimeFactory = () => new ErrorRuntime();
+    const dispatcher = new Dispatcher({
+      config: baseConfig(),
+      channels: new Map([[channel.id, channel]]),
+      runtime: runtimeFactory,
+      sessionStore: store,
+      log: args.log ?? silentLogger(),
+      transcript,
+      errorReporter: args.errorReporter,
+      resolveHubUrl: () => "https://hub.test",
+    });
+    return { dispatcher, channel, transcript };
+  }
+
+  it("reports runtime failures with sanitized details and error_ref correlation", async () => {
+    const reporter = new CaptureReporter();
+    const { dispatcher, channel, transcript } = await scaffold({ errorReporter: reporter });
+
+    await dispatcher.handle(makeEnvelope());
+
+    expect(channel.sends).toHaveLength(1);
+    const outbound = channel.sends[0]!.message;
+    expect(outbound.type).toBe("error");
+    expect(outbound.errorRef).toMatch(/^err_[0-9a-f]{12}$/);
+    expect(outbound.text).toContain(`[error_ref: ${outbound.errorRef}]`);
+
+    expect(reporter.reports).toHaveLength(1);
+    const report = reporter.reports[0]!;
+    expect(report.type).toBe("runtime_failure");
+    expect(report.tags?.error_ref).toBe(outbound.errorRef);
+    expect(report.tags?.agent_id).toBe("ag_me");
+    expect(report.tags?.room_id).toBe("rm_oc_1");
+    expect(report.tags?.topic_id).toBe("tp_1");
+    expect(report.tags?.turn_id).toEqual(expect.any(String));
+    expect(report.tags?.runtime).toBe("codex");
+    expect(report.tags?.hub_url).toBe("https://hub.test");
+    expect(report.tags?.message_id).toBe("hub_msg_1");
+    expect(report.tags?.control_frame_type).toBe("inbox_message");
+    expect(report.tags?.control_message_id).toBe("wire_msg_1");
+    expect(report.fingerprint).toEqual([
+      "botcord-daemon",
+      "runtime_failure",
+      "codex",
+      outbound.errorRef,
+    ]);
+
+    const failure = (report.context?.runtime_failure ?? {}) as Record<string, unknown>;
+    expect(failure.command).toEqual(["codex", "--token=[REDACTED]", "run"]);
+    expect(failure.stderr_tail).toContain("Authorization: Bearer [REDACTED]");
+    expect(failure.stderr_tail).toContain("sk-[REDACTED]");
+    expect(failure.stdout_tail).toContain("token=[REDACTED]");
+    expect(failure.error_message).toBe("runtime failed token=[REDACTED]");
+    expect(JSON.stringify(report)).not.toContain("secret123");
+    expect(JSON.stringify(report)).not.toContain("Bearer secret");
+
+    const turnError = transcript.records.find((rec) => rec.kind === "turn_error");
+    expect(turnError && "errorRef" in turnError ? turnError.errorRef : undefined)
+      .toBe(outbound.errorRef);
+  });
+
+  it("suppresses reporter exceptions without breaking dispatcher error replies", async () => {
+    const warnMessages: string[] = [];
+    const logger: GatewayLogger = {
+      info: () => {},
+      warn: (msg) => warnMessages.push(msg),
+      error: () => {},
+      debug: () => {},
+    };
+    const { dispatcher, channel } = await scaffold({
+      errorReporter: new FailingReporter(),
+      log: logger,
+    });
+
+    await dispatcher.handle(makeEnvelope());
+
+    expect(channel.sends).toHaveLength(1);
+    expect(channel.sends[0]!.message.errorRef).toMatch(/^err_[0-9a-f]{12}$/);
+    expect(warnMessages).toContain("daemon error reporter failed");
+  });
+});

--- a/packages/daemon/src/gateway/__tests__/runtime-failure.test.ts
+++ b/packages/daemon/src/gateway/__tests__/runtime-failure.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { lookupRuntimeFailureTranscript, sanitizeRuntimeFailureText } from "../runtime-failure.js";
+import { lookupRuntimeFailureTranscript, safeCommand, sanitizeRuntimeFailureText } from "../runtime-failure.js";
 import { transcriptFilePath } from "../transcript-paths.js";
 
 describe("runtime failure observability", () => {
@@ -62,5 +62,55 @@ describe("runtime failure observability", () => {
     expect(sanitizeRuntimeFailureText("Authorization: Bearer secret-token token=abc123 drt_live")).toBe(
       "Authorization: Bearer [REDACTED] token=[REDACTED] drt_[REDACTED]",
     );
+  });
+
+  it("redacts common API key and password forms from captured tails", () => {
+    const sanitized = sanitizeRuntimeFailureText(
+      [
+        "OPENAI_API_KEY=openai-secret",
+        "ANTHROPIC_API_KEY=anthropic-secret",
+        "x-api-key: header-secret",
+        "password: pw-secret",
+        "--api-key cli-secret",
+        "--token token-secret",
+      ].join(" "),
+    );
+
+    for (const secret of [
+      "openai-secret",
+      "anthropic-secret",
+      "header-secret",
+      "pw-secret",
+      "cli-secret",
+      "token-secret",
+    ]) {
+      expect(sanitized).not.toContain(secret);
+    }
+    expect(sanitized).toContain("OPENAI_API_KEY=[REDACTED]");
+    expect(sanitized).toContain("ANTHROPIC_API_KEY=[REDACTED]");
+    expect(sanitized).toContain("x-api-key: [REDACTED]");
+    expect(sanitized).toContain("password: [REDACTED]");
+    expect(sanitized).toContain("--api-key [REDACTED]");
+    expect(sanitized).toContain("--token [REDACTED]");
+  });
+
+  it("redacts command arguments that pass secret values in the following argv token", () => {
+    expect(safeCommand([
+      "codex",
+      "--api-key",
+      "cli-secret",
+      "--token",
+      "token-secret",
+      "--password=pass-secret",
+      "run",
+    ])).toEqual([
+      "codex",
+      "--api-key",
+      "[REDACTED]",
+      "--token",
+      "[REDACTED]",
+      "--password=[REDACTED]",
+      "run",
+    ]);
   });
 });

--- a/packages/daemon/src/gateway/__tests__/runtime-failure.test.ts
+++ b/packages/daemon/src/gateway/__tests__/runtime-failure.test.ts
@@ -94,6 +94,36 @@ describe("runtime failure observability", () => {
     expect(sanitized).toContain("--token [REDACTED]");
   });
 
+  it("redacts quoted JSON secret values and serialized argv secrets from captured tails", () => {
+    const sanitized = sanitizeRuntimeFailureText(
+      [
+        '{"OPENAI_API_KEY":"openai-json-secret"}',
+        '{"ANTHROPIC_API_KEY" : "anthropic-json-secret"}',
+        '{"x-api-key":"header-json-secret"}',
+        "{'password': 'password-json-secret'}",
+        '{"args":["--api-key","cli-json-secret"]}',
+        '{"args":["--token", "token-json-secret"]}',
+      ].join(" "),
+    );
+
+    for (const secret of [
+      "openai-json-secret",
+      "anthropic-json-secret",
+      "header-json-secret",
+      "password-json-secret",
+      "cli-json-secret",
+      "token-json-secret",
+    ]) {
+      expect(sanitized).not.toContain(secret);
+    }
+    expect(sanitized).toContain('"OPENAI_API_KEY":"[REDACTED]"');
+    expect(sanitized).toContain('"ANTHROPIC_API_KEY" : "[REDACTED]"');
+    expect(sanitized).toContain('"x-api-key":"[REDACTED]"');
+    expect(sanitized).toContain("'password': '[REDACTED]'");
+    expect(sanitized).toContain('"args":["--api-key","[REDACTED]"]');
+    expect(sanitized).toContain('"args":["--token", "[REDACTED]"]');
+  });
+
   it("redacts command arguments that pass secret values in the following argv token", () => {
     expect(safeCommand([
       "codex",
@@ -102,6 +132,7 @@ describe("runtime failure observability", () => {
       "--token",
       "token-secret",
       "--password=pass-secret",
+      '{"args":["--api-key","json-cli-secret"]}',
       "run",
     ])).toEqual([
       "codex",
@@ -110,6 +141,7 @@ describe("runtime failure observability", () => {
       "--token",
       "[REDACTED]",
       "--password=[REDACTED]",
+      '{"args":["--api-key","[REDACTED]"]}',
       "run",
     ]);
   });

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -3,6 +3,7 @@ import { realpathSync, statSync } from "node:fs";
 import path from "node:path";
 
 import type { GatewayLogger } from "./log.js";
+import { reportErrorSafely, type ErrorReporter } from "../error-reporting.js";
 import {
   errorInfo,
   makeRuntimeErrorRef,
@@ -335,6 +336,11 @@ export interface DispatcherOptions {
   onOutbound?: OutboundObserver;
   onRuntimeCircuitBreakerChange?: () => void;
   /**
+   * Optional daemon error reporter. Used for runtime_failure events only in
+   * gateway core; process-level fatal hooks are installed by daemon startup.
+   */
+  errorReporter?: ErrorReporter;
+  /**
    * Optional observer fired exactly once per turn after ``runtime.run``
    * resolves (or throws / times out). Receives the inbound message, the
    * raw runtime result (may be undefined on throw), the elapsed wall
@@ -496,6 +502,7 @@ export class Dispatcher {
   private readonly onOutbound?: OutboundObserver;
   private readonly onTurnComplete?: DispatcherOptions["onTurnComplete"];
   private readonly onRuntimeCircuitBreakerChange?: () => void;
+  private readonly errorReporter?: ErrorReporter;
   private readonly composeUserTurn?: UserTurnBuilder;
   private readonly managedRoutes?: Map<string, GatewayRoute>;
   private readonly attentionGate?: (
@@ -531,6 +538,7 @@ export class Dispatcher {
     this.onOutbound = opts.onOutbound;
     this.onTurnComplete = opts.onTurnComplete;
     this.onRuntimeCircuitBreakerChange = opts.onRuntimeCircuitBreakerChange;
+    this.errorReporter = opts.errorReporter;
     this.composeUserTurn = opts.composeUserTurn;
     this.managedRoutes = opts.managedRoutes;
     this.attentionGate = opts.attentionGate;
@@ -1738,6 +1746,7 @@ export class Dispatcher {
     let threw: unknown;
     let activeSessionId: string | null = sessionId;
     const turnStartedAt = Date.now();
+    const hubUrl = this.resolveHubUrl?.(msg.accountId);
     try {
       try {
         const runRuntime = (textForRun: string, sessionIdForRun: string | null) =>
@@ -1746,7 +1755,7 @@ export class Dispatcher {
             sessionId: sessionIdForRun,
             cwd: route.cwd,
             accountId: msg.accountId,
-            hubUrl: this.resolveHubUrl?.(msg.accountId),
+            hubUrl,
             ...(waitMarkerFile ? { waitMarkerFile } : {}),
             extraArgs: route.extraArgs,
             signal: controller.signal,
@@ -1938,6 +1947,7 @@ export class Dispatcher {
           turnId,
           startedAt: slot.dispatchedAt,
           error: threw,
+          hubUrl,
         });
         if (canDeliverRuntimeDiagnostics) {
           await this.sendReply(channel, {
@@ -2065,6 +2075,7 @@ export class Dispatcher {
             startedAt: slot.dispatchedAt,
             error: effectiveError,
             result,
+            hubUrl,
           });
           if (canDeliverRuntimeDiagnostics) {
             const sendResult = await this.sendReply(channel, {
@@ -2435,6 +2446,7 @@ export class Dispatcher {
     startedAt: number;
     error: unknown;
     result?: RuntimeRunResult;
+    hubUrl?: string;
   }): { errorRef: string; summary: RuntimeFailureSummary; safeMessage: string } {
     const info = errorInfo(args.error);
     const resultFailure = args.result?.runtimeFailure ?? {};
@@ -2512,8 +2524,79 @@ export class Dispatcher {
       runtime: args.route.runtime,
       runtimeFailure: summary,
     });
+    reportErrorSafely(
+      this.errorReporter,
+      buildRuntimeFailureReport({
+        summary,
+        errorRef,
+        safeMessage,
+        msg: args.msg,
+        hubUrl: args.hubUrl,
+      }),
+      this.log,
+    );
     return { errorRef, summary, safeMessage };
   }
+}
+
+function buildRuntimeFailureReport(args: {
+  summary: RuntimeFailureSummary;
+  errorRef: string;
+  safeMessage: string;
+  msg: GatewayInboundMessage;
+  hubUrl?: string;
+}): import("../error-reporting.js").DaemonErrorReport {
+  const raw = args.msg.raw as {
+    envelope?: {
+      type?: unknown;
+      msg_id?: unknown;
+      message_id?: unknown;
+    };
+  } | null | undefined;
+  const controlFrameType =
+    typeof raw?.envelope?.type === "string" ? raw.envelope.type : undefined;
+  const controlMessageId =
+    typeof raw?.envelope?.msg_id === "string"
+      ? raw.envelope.msg_id
+      : typeof raw?.envelope?.message_id === "string"
+        ? raw.envelope.message_id
+        : undefined;
+
+  return {
+    type: "runtime_failure",
+    message: args.safeMessage,
+    tags: {
+      agent_id: args.summary.agent_id,
+      room_id: args.summary.room_id,
+      topic_id: args.summary.topic_id ?? null,
+      turn_id: args.summary.turn_id,
+      runtime: args.summary.runtime,
+      error_ref: args.errorRef,
+      hub_url: args.hubUrl ?? null,
+      message_id: args.msg.id,
+      control_frame_type: controlFrameType,
+      control_message_id: controlMessageId,
+      exit_code: args.summary.exit_code ?? null,
+      signal: args.summary.signal ?? null,
+      error_name: args.summary.error_name ?? null,
+    },
+    context: {
+      runtime_failure: args.summary,
+      error_ref: args.errorRef,
+      hub_url: args.hubUrl ?? null,
+      runtime_cwd: args.summary.cwd ?? null,
+      message_id: args.msg.id,
+      control_frame_type: controlFrameType ?? null,
+      control_message_id: controlMessageId ?? null,
+    },
+    fingerprint: [
+      "botcord-daemon",
+      "runtime_failure",
+      args.summary.runtime,
+      args.errorRef,
+    ],
+    dedupeKey: `${args.errorRef}:${args.summary.turn_id}`,
+  };
 }
 
 function nowIso(): string {

--- a/packages/daemon/src/gateway/gateway.ts
+++ b/packages/daemon/src/gateway/gateway.ts
@@ -27,6 +27,7 @@ import type {
   SystemContextBuilder,
   UserTurnBuilder,
 } from "./types.js";
+import type { ErrorReporter } from "../error-reporting.js";
 
 /** Constructor options for `Gateway`. */
 export interface GatewayBootOptions {
@@ -72,6 +73,11 @@ export interface GatewayBootOptions {
    */
   onOutbound?: OutboundObserver;
   onRuntimeCircuitBreakerChange?: () => void;
+  /**
+   * Optional daemon error reporter. Forwarded to dispatcher for runtime
+   * failure reporting; reporter errors are logged and suppressed.
+   */
+  errorReporter?: ErrorReporter;
   /**
    * Optional observer fired after each runtime turn resolves. Forwarded
    * to the dispatcher verbatim — see {@link Dispatcher} for semantics.
@@ -190,6 +196,7 @@ export class Gateway {
       onOutbound: opts.onOutbound,
       onTurnComplete: opts.onTurnComplete,
       onRuntimeCircuitBreakerChange: opts.onRuntimeCircuitBreakerChange,
+      errorReporter: opts.errorReporter,
       managedRoutes: this.managedRoutes,
       attentionGate: opts.attentionGate,
       resolveHubUrl: opts.resolveHubUrl,

--- a/packages/daemon/src/gateway/index.ts
+++ b/packages/daemon/src/gateway/index.ts
@@ -41,6 +41,20 @@ export {
   type RuntimeFailureLookupResult,
 } from "./runtime-failure.js";
 export {
+  BoundedDedupeErrorReporter,
+  SentryErrorReporter,
+  buildProcessFatalErrorReport,
+  createDaemonErrorReporter,
+  initializeErrorReporterSafely,
+  installProcessErrorReportingHooks,
+  noopErrorReporter,
+  reportErrorSafely,
+  resolveErrorReporterConfig,
+  type DaemonErrorReport,
+  type ErrorReporter,
+  type ErrorReporterConfig,
+} from "../error-reporting.js";
+export {
   ClaudeCodeAdapter,
   probeClaude,
   resolveClaudeCommand,

--- a/packages/daemon/src/gateway/runtime-failure.ts
+++ b/packages/daemon/src/gateway/runtime-failure.ts
@@ -8,9 +8,24 @@ export const RUNTIME_FAILURE_TAIL_LIMIT = 8 * 1024;
 
 const SECRET_VALUE_PATTERNS: Array<[RegExp, string]> = [
   [/(Authorization:\s*Bearer\s+)[^\s"']+/gi, "$1[REDACTED]"],
-  [/\b(token|access_token|refresh_token|api_key|apikey|password|secret)=([^\s"']+)/gi, "$1=[REDACTED]"],
+  [/(^|[\s])(--(?:api-key|api_key|apikey|token|access-token|access_token|refresh-token|refresh_token|password|secret))=([^\s"']+)/gi, "$1$2=[REDACTED]"],
+  [/(^|[\s])(--(?:api-key|api_key|apikey|token|access-token|access_token|refresh-token|refresh_token|password|secret))(\s+)([^\s"']+)/gi, "$1$2$3[REDACTED]"],
+  [/\b((?:openai|anthropic)[_-]?api[_-]?key|x-api-key|access[_-]?token|refresh[_-]?token|api[_-]?key|apikey|password|secret|token)(\s*[:=]\s*)[^\s"']+/gi, "$1$2[REDACTED]"],
   [/\b(drt_|dit_|gho_|ghp_|sk-)[A-Za-z0-9_-]+/g, "$1[REDACTED]"],
 ];
+
+const SECRET_VALUE_FLAGS = new Set([
+  "--api-key",
+  "--api_key",
+  "--apikey",
+  "--token",
+  "--access-token",
+  "--access_token",
+  "--refresh-token",
+  "--refresh_token",
+  "--password",
+  "--secret",
+]);
 
 export interface RuntimeFailureSummary {
   agent_id: string;
@@ -68,7 +83,16 @@ export function tailText(value: string | undefined | null, limit = RUNTIME_FAILU
 
 export function safeCommand(command: string[] | undefined | null): string[] | null {
   if (!command || command.length === 0) return null;
-  return command.map((part) => sanitizeRuntimeFailureText(part, 512));
+  const out: string[] = [];
+  for (let i = 0; i < command.length; i++) {
+    const part = command[i]!;
+    out.push(sanitizeRuntimeFailureText(part, 512));
+    if (SECRET_VALUE_FLAGS.has(part.toLowerCase()) && i + 1 < command.length) {
+      out.push("[REDACTED]");
+      i++;
+    }
+  }
+  return out;
 }
 
 export function errorInfo(err: unknown): { error_name: string | null; error_message: string | null } {

--- a/packages/daemon/src/gateway/runtime-failure.ts
+++ b/packages/daemon/src/gateway/runtime-failure.ts
@@ -6,6 +6,22 @@ import { transcriptFilePath, transcriptRoomDir } from "./transcript-paths.js";
 
 export const RUNTIME_FAILURE_TAIL_LIMIT = 8 * 1024;
 
+const SECRET_KEY_NAME_SOURCE =
+  "(?:openai[_-]?api[_-]?key|anthropic[_-]?api[_-]?key|x-api-key|access[_-]?token|refresh[_-]?token|api[_-]?key|apikey|password|secret|token)";
+
+const SECRET_FLAG_SOURCE =
+  "--(?:api-key|api_key|apikey|token|access-token|access_token|refresh-token|refresh_token|password|secret)";
+
+const QUOTED_JSON_SECRET_PATTERN = new RegExp(
+  `(["'])(${SECRET_KEY_NAME_SOURCE})\\1(\\s*:\\s*)(["'])([^"'\\\\]*(?:\\\\.[^"'\\\\]*)*)\\4`,
+  "gi",
+);
+
+const QUOTED_ARGV_SECRET_PATTERN = new RegExp(
+  `(["'])(${SECRET_FLAG_SOURCE})\\1(\\s*,\\s*)(["'])([^"'\\\\]*(?:\\\\.[^"'\\\\]*)*)\\4`,
+  "gi",
+);
+
 const SECRET_VALUE_PATTERNS: Array<[RegExp, string]> = [
   [/(Authorization:\s*Bearer\s+)[^\s"']+/gi, "$1[REDACTED]"],
   [/(^|[\s])(--(?:api-key|api_key|apikey|token|access-token|access_token|refresh-token|refresh_token|password|secret))=([^\s"']+)/gi, "$1$2=[REDACTED]"],
@@ -70,6 +86,16 @@ export function makeRuntimeErrorRef(summary: Partial<RuntimeFailureSummary>): st
 
 export function sanitizeRuntimeFailureText(value: string, limit = RUNTIME_FAILURE_TAIL_LIMIT): string {
   let out = value;
+  out = out.replace(
+    QUOTED_JSON_SECRET_PATTERN,
+    (_match, keyQuote: string, key: string, colon: string, valueQuote: string) =>
+      `${keyQuote}${key}${keyQuote}${colon}${valueQuote}[REDACTED]${valueQuote}`,
+  );
+  out = out.replace(
+    QUOTED_ARGV_SECRET_PATTERN,
+    (_match, flagQuote: string, flag: string, comma: string, valueQuote: string) =>
+      `${flagQuote}${flag}${flagQuote}${comma}${valueQuote}[REDACTED]${valueQuote}`,
+  );
   for (const [pattern, replacement] of SECRET_VALUE_PATTERNS) {
     out = out.replace(pattern, replacement);
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@larksuiteoapi/node-sdk':
         specifier: ^1.63.1
         version: 1.66.0
+      '@sentry/node':
+        specifier: ^10.56.0
+        version: 10.56.0
       ws:
         specifier: ^8.20.1
         version: 8.21.0
@@ -51,7 +54,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.1.7(@types/node@20.19.41)(vite@8.0.14(@types/node@20.19.41))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@20.19.41)(vite@8.0.14(@types/node@20.19.41))
 
   packages/gateway-ingress:
     dependencies:
@@ -76,7 +79,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.1.7(@types/node@20.19.41)(vite@8.0.14(@types/node@20.19.41))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@20.19.41)(vite@8.0.14(@types/node@20.19.41))
 
   packages/protocol-core:
     devDependencies:
@@ -88,7 +91,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.7(@types/node@20.19.41)(vite@8.0.14(@types/node@20.19.41))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@20.19.41)(vite@8.0.14(@types/node@20.19.41))
 
 packages:
 
@@ -198,6 +201,42 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@opentelemetry/api-logs@0.214.0':
+    resolution: {integrity: sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.7.1':
+    resolution: {integrity: sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/instrumentation@0.214.0':
+    resolution: {integrity: sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.7.1':
+    resolution: {integrity: sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.7.1':
+    resolution: {integrity: sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.41.1':
+    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
+    engines: {node: '>=14'}
 
   '@oxc-project/types@0.132.0':
     resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
@@ -324,6 +363,51 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@sentry-internal/server-utils@10.56.0':
+    resolution: {integrity: sha512-6kuZI/vAjyVKMm1cTzc2pdUmVR4Px4etMG6wnCPyFnwEaGbUKQnTynUBFpTuo/q6Js6QBQvhLNoAnO4YsOfW4w==}
+    engines: {node: '>=18'}
+
+  '@sentry/core@10.56.0':
+    resolution: {integrity: sha512-L+u1dIz5SANrmST5jhIwETtt4apILgKrylv12X4hKJU0PvZl+NorjeV/ty3MwzpKQPg6b6q6qMOSLc1rLpy3iQ==}
+    engines: {node: '>=18'}
+
+  '@sentry/node-core@10.56.0':
+    resolution: {integrity: sha512-61lD2Wjtv5Lw2F3lJarcD0ORjR4GlVxrEd6w6Of/uF3DH73dD6K3n/3wXEeCIRfV/kgiCFIrCIq76nz0LVgE5g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/core':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-http':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      '@opentelemetry/semantic-conventions':
+        optional: true
+
+  '@sentry/node@10.56.0':
+    resolution: {integrity: sha512-qvgtXHkcR4CH3fh0VEVyw4Ysc6MMiAnm727NdTTm0yU5e53erCeo2521+yfJkqmRTGiOSgwA7B5Bs+ot9j0vFQ==}
+    engines: {node: '>=18'}
+
+  '@sentry/opentelemetry@10.56.0':
+    resolution: {integrity: sha512-PtMudApHMHvttjos3b7JZ2gJ+nstHAOYE3vKPYB5o0WQO95ldiaYnpLKMCRIGZWF3Dk7ynrqqnBpn8LZLt+Mrg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -377,6 +461,16 @@ packages:
   '@vitest/utils@4.1.7':
     resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
 
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -428,6 +522,9 @@ packages:
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -438,6 +535,15 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -597,6 +703,10 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  import-in-the-middle@3.0.1:
+    resolution: {integrity: sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==}
+    engines: {node: '>=18'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -743,9 +853,15 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
@@ -844,6 +960,10 @@ packages:
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
+
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -1293,6 +1413,41 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@opentelemetry/api-logs@0.214.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.214.0
+      import-in-the-middle: 3.0.1
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/semantic-conventions@1.41.1': {}
+
   '@oxc-project/types@0.132.0': {}
 
   '@protobufjs/aspromise@1.1.2': {}
@@ -1368,6 +1523,48 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@sentry-internal/server-utils@10.56.0':
+    dependencies:
+      '@sentry/core': 10.56.0
+
+  '@sentry/core@10.56.0': {}
+
+  '@sentry/node-core@10.56.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)':
+    dependencies:
+      '@sentry/core': 10.56.0
+      '@sentry/opentelemetry': 10.56.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
+      import-in-the-middle: 3.0.1
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@sentry/node@10.56.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@sentry-internal/server-utils': 10.56.0
+      '@sentry/core': 10.56.0
+      '@sentry/node-core': 10.56.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
+      '@sentry/opentelemetry': 10.56.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
+      import-in-the-middle: 3.0.1
+    transitivePeerDependencies:
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
+
+  '@sentry/opentelemetry@10.56.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@sentry/core': 10.56.0
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tybys/wasm-util@0.10.2':
@@ -1435,6 +1632,12 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  acorn-import-attributes@1.9.5(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
   ansi-colors@4.1.3: {}
 
   ansi-regex@5.0.1: {}
@@ -1481,6 +1684,8 @@ snapshots:
 
   chardet@2.1.1: {}
 
+  cjs-module-lexer@2.2.0: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
@@ -1492,6 +1697,10 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
 
   delayed-stream@1.0.0: {}
 
@@ -1646,6 +1855,13 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  import-in-the-middle@3.0.1:
+    dependencies:
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 2.2.0
+      module-details-from-path: 1.0.4
+
   is-extglob@2.1.1: {}
 
   is-glob@4.0.3:
@@ -1757,7 +1973,11 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  module-details-from-path@1.0.4: {}
+
   mri@1.2.0: {}
+
+  ms@2.1.3: {}
 
   nanoid@3.3.12: {}
 
@@ -1842,6 +2062,13 @@ snapshots:
       js-yaml: 3.14.2
       pify: 4.0.1
       strip-bom: 3.0.0
+
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   resolve-from@5.0.0: {}
 
@@ -1972,7 +2199,7 @@ snapshots:
       '@types/node': 20.19.41
       fsevents: 2.3.3
 
-  vitest@4.1.7(@types/node@20.19.41)(vite@8.0.14(@types/node@20.19.41)):
+  vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@20.19.41)(vite@8.0.14(@types/node@20.19.41)):
     dependencies:
       '@vitest/expect': 4.1.7
       '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@20.19.41))
@@ -1995,6 +2222,7 @@ snapshots:
       vite: 8.0.14(@types/node@20.19.41)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 20.19.41
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
## Summary
- add a daemon error reporter abstraction with noop, bounded dedupe, and Sentry-backed implementations
- wire runtime failure reports from the dispatcher with sanitized command/stdout/stderr, error_ref fingerprinting, and searchable BotCord tags/context
- install process fatal reporting hooks for local and cloud daemon startup without adding an unhandledRejection listener
- expose env config: BOTCORD_DAEMON_SENTRY_DSN, BOTCORD_DAEMON_ENVIRONMENT, BOTCORD_DAEMON_RELEASE, BOTCORD_DAEMON_ERROR_REPORTING_ENABLED

## Tests
- corepack pnpm --dir packages/daemon exec vitest run src/__tests__/error-reporting.test.ts src/gateway/__tests__/dispatcher-error-reporting.test.ts src/gateway/__tests__/runtime-failure.test.ts src/gateway/__tests__/dispatcher.test.ts src/__tests__/dispatcher-reply-to.test.ts
- corepack pnpm --dir packages/daemon build
- git diff --check

## Full suite note
- corepack pnpm --dir packages/daemon test currently fails in this environment on pre-existing/unrelated cases: missing unzip for diagnostics zip inspection, and local OpenClaw systemd candidate discovery leaking ws://127.0.0.1:16200 into openclaw-discovery expectations.