### PR TITLE
fix(frontend): highlight bare agent/human-id mentions in chat

### DIFF
--- a/frontend/src/components/ui/MarkdownContent.test.ts
+++ b/frontend/src/components/ui/MarkdownContent.test.ts
@@ -41,6 +41,28 @@ describe("splitPlainMentionText", () => {
 
     expect(mentionProps(nodes[0])?.["data-mention-id"]).toBe("ag_long");
   });
+
+  it("highlights bare agent-id mentions even without candidates", () => {
+    const nodes = splitPlainMentionText("@ag_17b5d5e1b071 Ops hourly triage");
+
+    expect(mentionProps(nodes[0])?.["data-mention-id"]).toBe("ag_17b5d5e1b071");
+    expect(mentionProps(nodes[0])?.["data-mention-label"]).toBe("ag_17b5d5e1b071");
+    expect(nodes[1]).toEqual({ type: "text", value: " Ops hourly triage" });
+  });
+
+  it("highlights bare human-id mentions and respects end boundaries", () => {
+    const nodes = splitPlainMentionText("cc @hu_0123456789ab, thanks");
+
+    expect(nodes[0]).toEqual({ type: "text", value: "cc " });
+    expect(mentionProps(nodes[1])?.["data-mention-id"]).toBe("hu_0123456789ab");
+    expect(nodes[2]).toEqual({ type: "text", value: ", thanks" });
+  });
+
+  it("does not treat malformed ids (wrong length) as mentions", () => {
+    const nodes = splitPlainMentionText("see @ag_17b5d5e1b071beef next");
+
+    expect(nodes).toEqual([{ type: "text", value: "see @ag_17b5d5e1b071beef next" }]);
+  });
 });
 
 describe("normalizeMessageContent", () => {

--- a/frontend/src/components/ui/MarkdownContent.tsx
+++ b/frontend/src/components/ui/MarkdownContent.tsx
@@ -40,6 +40,11 @@ interface HastRootNode {
 type HastNode = HastTextNode | HastElementNode | HastRootNode | { type?: string; [key: string]: unknown };
 
 const MENTION_WITH_ID_RE = /@([^\n@]*?)\(((?:ag|hu)_[^)]+)\)/g;
+// Bare agent/human id mention, e.g. "@ag_17b5d5e1b071" — the form agents/bots
+// emit when addressing by id instead of the composer's "@Name(ag_id)". Anchored
+// (non-global) so exec() always matches at the start of the slice. Ids are a
+// fixed prefix + 12 lowercase hex chars (see hub/id_generators.py).
+const BARE_MENTION_ID_RE = /^(?:ag|hu)_[0-9a-f]{12}/;
 const failedMarkdownImageSrcs = new Set<string>();
 
 export function normalizeMessageContent(content: string): string {
@@ -92,13 +97,29 @@ export function splitPlainMentionText(value: string, candidates: MentionTextCand
     .filter((candidate) => candidate.id && candidate.label)
     .sort((a, b) => b.label.length - a.label.length);
 
-  if (sortedCandidates.length === 0) {
-    return [{ type: "text", value }];
-  }
-
   const nodes: HastNode[] = [];
   let cursor = 0;
   let textStart = 0;
+
+  // Emit the pending plain text (if any) then a mention span, advancing the cursor
+  // past the matched `@...` run. label is rendered as `@${label}`; MentionChip
+  // resolves the display name from the id, so a bare id falls back to itself.
+  const pushMention = (id: string, label: string, runLength: number) => {
+    if (cursor > textStart) {
+      nodes.push({ type: "text", value: value.slice(textStart, cursor) });
+    }
+    nodes.push({
+      type: "element",
+      tagName: "span",
+      properties: {
+        "data-mention-id": id,
+        "data-mention-label": label,
+      },
+      children: [{ type: "text", value: `@${label}` }],
+    });
+    cursor += runLength;
+    textStart = cursor;
+  };
 
   while (cursor < value.length) {
     if (value[cursor] !== "@" || !isMentionStartBoundary(value, cursor)) {
@@ -106,7 +127,17 @@ export function splitPlainMentionText(value: string, candidates: MentionTextCand
       continue;
     }
 
-    const restLower = value.slice(cursor + 1).toLowerCase();
+    const rest = value.slice(cursor + 1);
+
+    // Prefer a bare id mention (`@ag_xxx` / `@hu_xxx`). Ids never collide with
+    // display-name candidates, and this works even with no candidates loaded.
+    const idMatch = BARE_MENTION_ID_RE.exec(rest);
+    if (idMatch && isMentionEndBoundary(value, cursor + 1 + idMatch[0].length)) {
+      pushMention(idMatch[0], idMatch[0], 1 + idMatch[0].length);
+      continue;
+    }
+
+    const restLower = rest.toLowerCase();
     const match = sortedCandidates.find((candidate) => {
       if (!restLower.startsWith(candidate.label.toLowerCase())) return false;
       return isMentionEndBoundary(value, cursor + 1 + candidate.label.length);
@@ -117,20 +148,7 @@ export function splitPlainMentionText(value: string, candidates: MentionTextCand
       continue;
     }
 
-    if (cursor > textStart) {
-      nodes.push({ type: "text", value: value.slice(textStart, cursor) });
-    }
-    nodes.push({
-      type: "element",
-      tagName: "span",
-      properties: {
-        "data-mention-id": match.id,
-        "data-mention-label": match.label,
-      },
-      children: [{ type: "text", value: `@${match.label}` }],
-    });
-    cursor = cursor + 1 + match.label.length;
-    textStart = cursor;
+    pushMention(match.id, match.label, 1 + match.label.length);
   }
 
   if (textStart < value.length) {


### PR DESCRIPTION
## 问题

聊天里 agent/bot 发的消息(如 Botcord-Ops 的 hourly triage)用**裸 agent ID** 寻址,比如 `@ag_17b5d5e1b071`,而不是 composer 产出的 `@Name(ag_id)` 结构化格式。生产数据确认:`ag_17b5d5e1b071` = "Botcord CTO",本该高亮成 `@Botcord CTO`,实际却渲染成裸 ID 纯文本(见下图场景)。

mention 解析器(`MarkdownContent.tsx`)只匹配两种格式:
- 结构化 `@Label(ag_id)`(带括号);
- 纯文本 `@DisplayName`(按 display_name 匹配 `mentionCandidates`)。

裸 `@ag_id` 两条都命中不了 → 当普通文本渲染,无高亮/无 tooltip/不可点。

## 修复

- 新增 `BARE_MENTION_ID_RE = /^(?:ag|hu)_[0-9a-f]{12}/`(锚定、非全局),识别裸 ID(前缀 + 12 hex,见 `hub/id_generators.py`)。
- `splitPlainMentionText` 在每个 `@` 边界**优先**尝试裸 ID 匹配,命中即 emit 带 `data-mention-id` 的 span。`MentionChip`(`MessageBubble.tsx:188-191`)已会按 id 反查 display_name,所以高亮/tooltip/点击跳转全自动生效。
- 去掉「无 candidates 早返回」分支,使裸 ID 在房间成员未加载时也能高亮。
- 抽出 `pushMention` 复用三条路径逻辑。

无回归:`renderMention` 缺省时 span 回退为原文(marketing 等用法不受影响);email `me@example.com` 仍靠 start-boundary 拦截。

## 测试

- 新增 3 个用例:裸 agent ID(无 candidates)、裸 human ID + 边界、错误长度 ID 不误判。
- 完整前端套件:**190 passed (37 files)**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)