### PR TITLE
fix: show structured mentions in dashboard messages

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -170,6 +170,18 @@ def _display_content_for_record(rec: MessageRecord, parsed: dict) -> tuple[str |
     )
 
 
+def _extract_mentions_from_envelope(envelope_json: str | None) -> list[str] | None:
+    try:
+        data = json.loads(envelope_json or "{}")
+    except (json.JSONDecodeError, TypeError):
+        return None
+    mentions = data.get("mentions")
+    if not isinstance(mentions, list):
+        return None
+    values = [mention for mention in mentions if isinstance(mention, str) and mention]
+    return values or None
+
+
 def _preview_for_record(rec: MessageRecord) -> tuple[str, str | None, str]:
     sender_id, preview, msg_type = _extract_text_preview(rec.envelope_json)
     if rec.recalled_at is not None:
@@ -2472,6 +2484,7 @@ async def get_room_messages(
             "topic": rec.topic,
             "topic_id": rec.topic_id,
             "topic_title": topic_info.get(rec.topic_id, {}).get("title") if rec.topic_id else None,
+            "mentions": _extract_mentions_from_envelope(rec.envelope_json),
             "created_at": rec.created_at.isoformat() if rec.created_at else None,
             "source_type": rec.source_type,
             "reply_preview": rp.model_dump(mode="json") if rp else None,

--- a/backend/hub/routers/dashboard.py
+++ b/backend/hub/routers/dashboard.py
@@ -98,6 +98,14 @@ def _extract_text_from_envelope(envelope_data: dict) -> tuple[str, str, dict]:
     return sender_id, text, payload
 
 
+def _extract_mentions_from_envelope(envelope_data: dict) -> list[str] | None:
+    mentions = envelope_data.get("mentions")
+    if not isinstance(mentions, list):
+        return None
+    values = [mention for mention in mentions if isinstance(mention, str) and mention]
+    return values or None
+
+
 _RECALLED_MESSAGE_PREVIEW = "Message recalled"
 
 
@@ -562,6 +570,7 @@ async def get_room_messages(
                 goal=rec.goal,
                 state=rec.state.value,
                 state_counts=counts,
+                mentions=_extract_mentions_from_envelope(envelope_data),
                 created_at=ca,
                 source_type=rec.source_type,
                 **_recalled_message_fields(rec),

--- a/backend/hub/schemas.py
+++ b/backend/hub/schemas.py
@@ -653,6 +653,7 @@ class DashboardMessage(BaseModel):
     topic_id: str | None = None
     state: str
     state_counts: dict[str, int] | None = None
+    mentions: list[str] | None = None
     created_at: datetime.datetime
     is_recalled: bool = False
     recalled_at: datetime.datetime | None = None

--- a/backend/tests/test_dashboard_rooms_human_send.py
+++ b/backend/tests/test_dashboard_rooms_human_send.py
@@ -796,6 +796,27 @@ async def test_mentions_set_mentioned_flag_per_receiver(
 
 
 @pytest.mark.asyncio
+async def test_messages_response_includes_mentions(client: AsyncClient, seed: dict):
+    r = await client.post(
+        "/api/dashboard/rooms/rm_humanroom/send",
+        headers=_h(seed["token1"], seed["agent1"]),
+        json={"text": "帮我看一下这个方案", "mentions": ["ag_user3___"]},
+    )
+    assert r.status_code == 202, r.text
+
+    r2 = await client.get(
+        "/api/dashboard/rooms/rm_humanroom/messages",
+        headers=_h(seed["token1"], seed["agent1"]),
+    )
+    assert r2.status_code == 200, r2.text
+    messages = r2.json()["messages"]
+    human_msgs = [m for m in messages if m.get("source_type") == "dashboard_human_room"]
+    assert human_msgs, f"no human message found; got={messages}"
+    assert human_msgs[0]["text"] == "帮我看一下这个方案"
+    assert human_msgs[0]["mentions"] == ["ag_user3___"]
+
+
+@pytest.mark.asyncio
 async def test_room_send_does_not_resume_cloud_when_attention_filters(
     client: AsyncClient, seed: dict, monkeypatch
 ):

--- a/frontend/src/components/dashboard/MessageBubble.tsx
+++ b/frontend/src/components/dashboard/MessageBubble.tsx
@@ -14,6 +14,7 @@ import { canReplyToDashboardMessage } from "@/lib/dashboard-message-actions";
 import { useLanguage } from '@/lib/i18n';
 import { messageBubble } from '@/lib/i18n/translations/dashboard';
 import { getActionMenuPosition } from "@/lib/message-action-menu";
+import { resolveMessageMentionTargets } from "@/lib/message-mentions";
 import { canRecallDashboardMessage, isDashboardMessageRecalled, recalledMessageLabel } from "@/lib/message-recall";
 import AttachmentItem from "@/components/ui/AttachmentItem";
 import CopyableId from "@/components/ui/CopyableId";
@@ -413,6 +414,7 @@ function MessageBubble({
   const errorCode = typeof errorPayload?.code === "string" ? errorPayload.code : null;
   const textContent = message.payload?.text || message.payload?.body || message.payload?.message;
   const displayText = typeof textContent === "string" ? textContent : message.text || errorMessage;
+  const metadataMentions = resolveMessageMentionTargets(message.mentions, mentionCandidates ?? [], displayText);
   const isRecalled = isDashboardMessageRecalled(message);
   const isErrorMessage = message.type === "error";
   const errorTitle = locale === "zh" ? "运行错误" : "Runtime error";
@@ -772,6 +774,20 @@ function MessageBubble({
           <div className="mb-1.5 flex items-start gap-1.5 rounded-lg border border-neon-purple/20 bg-neon-purple/5 px-2 py-1.5">
             <span className="mt-px text-xs text-neon-purple/70">🎯</span>
             <span className="text-xs leading-relaxed text-neon-purple/90">{message.goal}</span>
+          </div>
+        )}
+
+        {!isRecalled && metadataMentions.length > 0 && (
+          <div className="mb-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
+            {metadataMentions.map((mention) => (
+              <MentionChip
+                key={mention.id}
+                id={mention.id}
+                label={mention.label}
+                onSelectAgent={selectAgent}
+                onSelectHuman={requestOpenHuman}
+              />
+            ))}
           </div>
         )}
 

--- a/frontend/src/components/dashboard/RoomHumanComposer.tsx
+++ b/frontend/src/components/dashboard/RoomHumanComposer.tsx
@@ -361,6 +361,7 @@ export default function RoomHumanComposer({ roomId, topicId = null }: RoomHumanC
       goal: null,
       state: "queued",
       state_counts: null,
+      mentions: mentions ?? null,
       created_at: now,
       source_type: "dashboard_human_room",
       sender_kind: "human",

--- a/frontend/src/lib/message-mentions.test.ts
+++ b/frontend/src/lib/message-mentions.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeMessageMentions,
+  resolveMessageMentionTargets,
+} from "./message-mentions";
+
+describe("normalizeMessageMentions", () => {
+  it("keeps unique non-empty mention ids", () => {
+    expect(normalizeMessageMentions(["ag_a", "", " ag_b ", "ag_a", 123])).toEqual(["ag_a", "ag_b"]);
+  });
+});
+
+describe("resolveMessageMentionTargets", () => {
+  const candidates = [
+    { id: "ag_harry", label: "Harry" },
+    { id: "hu_alice", label: "Alice Zhang" },
+  ];
+
+  it("returns display labels for metadata mentions missing from the body", () => {
+    expect(resolveMessageMentionTargets(["ag_harry", "hu_alice"], candidates, "帮我看一下这个方案")).toEqual([
+      { id: "ag_harry", label: "Harry" },
+      { id: "hu_alice", label: "Alice Zhang" },
+    ]);
+  });
+
+  it("does not duplicate mentions already visible in plain text", () => {
+    expect(resolveMessageMentionTargets(["ag_harry"], candidates, "@Harry 帮我看一下")).toEqual([]);
+  });
+
+  it("does not duplicate mentions already visible in structured text", () => {
+    expect(resolveMessageMentionTargets(["ag_harry"], candidates, "@Harry(ag_harry) 帮我看一下")).toEqual([]);
+  });
+
+  it("supports @all metadata", () => {
+    expect(resolveMessageMentionTargets(["@all"], candidates, "大家看一下")).toEqual([
+      { id: "@all", label: "all" },
+    ]);
+    expect(resolveMessageMentionTargets(["@all"], candidates, "@all 大家看一下")).toEqual([]);
+  });
+});

--- a/frontend/src/lib/message-mentions.ts
+++ b/frontend/src/lib/message-mentions.ts
@@ -1,0 +1,71 @@
+export interface MessageMentionTarget {
+  id: string;
+  label: string;
+}
+
+export interface MessageMentionCandidate {
+  id: string;
+  label: string;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isMentionBoundaryPattern(label: string): RegExp {
+  return new RegExp(`(^|[\\s([{'"“‘])@${escapeRegExp(label)}(?=$|[\\s.,!?;:()[\\]{}'"“”‘’])`, "i");
+}
+
+export function normalizeMessageMentions(mentions: unknown): string[] {
+  if (!Array.isArray(mentions)) return [];
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const mention of mentions) {
+    if (typeof mention !== "string") continue;
+    const id = mention.trim();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    result.push(id);
+  }
+
+  return result;
+}
+
+export function messageTextContainsMentionTarget(
+  text: string,
+  target: MessageMentionTarget,
+): boolean {
+  if (!text) return false;
+  if (target.id !== "@all" && text.includes(`(${target.id})`)) return true;
+
+  const labels = new Set<string>();
+  if (target.id === "@all") {
+    labels.add("all");
+  } else {
+    labels.add(target.label);
+    labels.add(target.id);
+  }
+
+  for (const label of labels) {
+    if (label && isMentionBoundaryPattern(label).test(text)) return true;
+  }
+  return false;
+}
+
+export function resolveMessageMentionTargets(
+  mentions: unknown,
+  candidates: MessageMentionCandidate[] = [],
+  text: string = "",
+): MessageMentionTarget[] {
+  const normalized = normalizeMessageMentions(mentions);
+  if (normalized.length === 0) return [];
+
+  return normalized
+    .map((id) => {
+      if (id === "@all") return { id, label: "all" };
+      const candidate = candidates.find((item) => item.id === id);
+      return { id, label: candidate?.label || id };
+    })
+    .filter((target) => !messageTextContainsMentionTarget(text, target));
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -172,6 +172,7 @@ export interface DashboardMessage {
   topic_closed_at?: string | null;
   state: string;
   state_counts: Record<string, number> | null;
+  mentions?: string[] | null;
   created_at: string;
   source_type?: string;
   sender_kind?: "agent" | "human";


### PR DESCRIPTION
## Summary
- expose envelope-level `mentions` in dashboard message APIs
- render missing structured mentions as clickable mention chips before the message body
- keep optimistic human room messages and duplicate-mention filtering in sync

## Verification
- `cd backend && uv run pytest tests/test_dashboard_rooms_human_send.py::test_mentions_set_mentioned_flag_per_receiver tests/test_dashboard_rooms_human_send.py::test_messages_response_includes_mentions`
- `cd frontend && npm run test -- message-mentions.test.ts`
- `cd frontend && NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon-key npm run build`

## Risk / rollout
- Low risk; additive response field and display-only UI change. Existing message text, copy, and routing behavior are unchanged.