### PR TITLE
Fix expired file cleanup storage marker

### DIFF
--- a/backend/hub/cleanup.py
+++ b/backend/hub/cleanup.py
@@ -63,6 +63,7 @@ async def _cleanup_expired_files() -> int:
                 record.disk_path = None
             elif record.storage_backend == "supabase":
                 record.storage_object_key = None
+            record.storage_backend = None
             cleaned += 1
         if records:
             await session.commit()

--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -829,7 +829,7 @@ class FileRecord(Base):
     original_filename: Mapped[str] = mapped_column(String(256), nullable=False)
     content_type: Mapped[str] = mapped_column(String(128), nullable=False)
     size_bytes: Mapped[int] = mapped_column(Integer, nullable=False)
-    storage_backend: Mapped[str] = mapped_column(String(32), nullable=False, default="disk", index=True)
+    storage_backend: Mapped[str | None] = mapped_column(String(32), nullable=True, default="disk", index=True)
     disk_path: Mapped[str | None] = mapped_column(Text, nullable=True)
     storage_bucket: Mapped[str | None] = mapped_column(String(128), nullable=True)
     storage_object_key: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/migrations/026_file_records_nullable_storage_backend.sql
+++ b/backend/migrations/026_file_records_nullable_storage_backend.sql
@@ -1,0 +1,24 @@
+-- Expired file cleanup clears storage coordinates after deleting the backing
+-- object. A NULL storage_backend marks records whose storage has already been
+-- cleaned while preserving expires_at so downloads keep returning file_expired.
+
+DO $$
+BEGIN
+  IF to_regclass('public.file_records') IS NULL THEN
+    RETURN;
+  END IF;
+
+  ALTER TABLE file_records
+    ALTER COLUMN storage_backend DROP NOT NULL;
+
+  UPDATE file_records
+    SET storage_backend = NULL
+    WHERE storage_backend = 'expired';
+
+  ALTER TABLE file_records
+    DROP CONSTRAINT IF EXISTS ck_file_records_storage_backend;
+
+  ALTER TABLE file_records
+    ADD CONSTRAINT ck_file_records_storage_backend
+    CHECK (storage_backend IS NULL OR storage_backend IN ('disk', 'supabase'));
+END $$;

--- a/backend/tests/test_files.py
+++ b/backend/tests/test_files.py
@@ -524,14 +524,14 @@ async def test_cleanup_removes_expired_files(client: AsyncClient, db_session: As
         cleaned = await hub_cleanup._cleanup_expired_files()
     assert cleaned == 1
 
-    # Verify disk file is gone but DB record is kept with storage coordinates cleared
+    # Verify disk file is gone but DB record is kept with storage marked cleaned
     assert not os.path.isfile(disk_path)
     result = await db_session.execute(
         sa_select(FileRecord).where(FileRecord.file_id == file_id)
     )
     kept_record = result.scalar_one_or_none()
     assert kept_record is not None
-    assert kept_record.storage_backend == "disk"
+    assert kept_record.storage_backend is None
     assert kept_record.disk_path is None
     assert kept_record.storage_object_key is None
 
@@ -585,7 +585,7 @@ async def test_cleanup_removes_expired_supabase_files(client: AsyncClient, db_se
     )
     kept_record = result.scalar_one_or_none()
     assert kept_record is not None
-    assert kept_record.storage_backend == "supabase"
+    assert kept_record.storage_backend is None
     assert kept_record.disk_path is None
     assert kept_record.storage_object_key is None
 
@@ -758,7 +758,7 @@ async def test_cleanup_preserves_mismatched_object_key_after_disk_delete(
         sa_select(FileRecord).where(FileRecord.file_id == record.file_id)
     )
     kept_record = result.scalar_one()
-    assert kept_record.storage_backend == "disk"
+    assert kept_record.storage_backend is None
     assert kept_record.disk_path is None
     assert kept_record.storage_object_key == "orphan/both.txt"
 


### PR DESCRIPTION
## Summary
- allow cleaned file records to use `storage_backend = NULL` as the no-backing-object marker
- clear `storage_backend` after successful expired backing-object cleanup while preserving `expires_at` for `file_expired` downloads
- add migration 026 to drop the NOT NULL constraint, normalize legacy `expired` values to NULL, and enforce NULL/disk/supabase

## Review
- Sub-agent implemented the patch per room rule.
- Code Reviewer reported no blocking findings; noted migration 026 must be included, which this commit includes.

## Tests
- `cd backend && uv run pytest tests/test_files.py -k cleanup`
- `cd backend && uv run pytest tests/test_files.py`
- `git diff --check`