### PR TITLE
fix(daemon): surface usage/rate-limit errors with a calm reset-time message

### DIFF
--- a/.changeset/friendly-usage-limit-errors.md
+++ b/.changeset/friendly-usage-limit-errors.md
@@ -1,0 +1,15 @@
+---
+"@botcord/daemon": patch
+---
+
+fix(daemon): show usage/rate-limit errors as a calm message with reset time
+
+Quota-exhaustion errors from the Claude Code / Codex / Gemini runtimes were
+delivered through the generic runtime-error path — wrapped as
+`⚠️ Runtime error: … (exit code 1) [error_ref: …]`, and for Codex sometimes a
+raw JSON blob — which buried the one thing the user needs: when access comes
+back. The dispatcher now detects usage/rate-limit exhaustion and surfaces a
+clean line that lifts the runtime's own reset time verbatim (so the timezone /
+window stays correct), e.g. "Claude Code usage limit reached — resets at 2pm
+(America/New_York)." or "Codex usage limit reached — resets in 3h 42m." The
+`error_ref` is still attached to the message payload for diagnostics.

--- a/packages/daemon/src/gateway/__tests__/runtime-errors.test.ts
+++ b/packages/daemon/src/gateway/__tests__/runtime-errors.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractUsageLimitReset,
+  formatUsageLimitMessage,
+  looksLikeUsageLimit,
+} from "../runtime-errors.js";
+
+// Real-world samples observed from each runtime's error output.
+const CLAUDE_ABSOLUTE = "Claude usage limit reached. Your limit will reset at 2pm (America/New_York)";
+const CLAUDE_APPROX =
+  "You've hit your usage limit. Your limit will reset at approximately 11:00 PM Europe/Berlin time.";
+const CLAUDE_PIPE = "Claude AI usage limit reached|1719345600";
+const CODEX_RELATIVE = "You've reached your 5-hour message limit. Try again in 3h 42m.";
+const CODEX_JSON = '{"type":"error","error":{"type":"usage_limit_reached","code":"insufficient_quota"}}';
+const RATE_LIMIT = "API Error: rate_limit_exceeded — please slow down";
+
+describe("looksLikeUsageLimit", () => {
+  it("matches every runtime's quota-exhaustion phrasing", () => {
+    expect(looksLikeUsageLimit(CLAUDE_ABSOLUTE)).toBe(true);
+    expect(looksLikeUsageLimit(CLAUDE_APPROX)).toBe(true);
+    expect(looksLikeUsageLimit(CLAUDE_PIPE)).toBe(true);
+    expect(looksLikeUsageLimit(CODEX_RELATIVE)).toBe(true);
+    expect(looksLikeUsageLimit(CODEX_JSON)).toBe(true);
+    expect(looksLikeUsageLimit(RATE_LIMIT)).toBe(true);
+  });
+
+  it("does not reclassify ordinary runtime failures", () => {
+    expect(looksLikeUsageLimit("")).toBe(false);
+    expect(looksLikeUsageLimit("TypeError: cannot read property 'x' of undefined")).toBe(false);
+    expect(looksLikeUsageLimit("codex exited with code 1: segfault")).toBe(false);
+    expect(looksLikeUsageLimit("Connection reset by peer")).toBe(false);
+  });
+});
+
+describe("extractUsageLimitReset", () => {
+  it("lifts an absolute clock time verbatim (timezone stays in the runtime's words)", () => {
+    expect(extractUsageLimitReset(CLAUDE_ABSOLUTE)).toBe("2pm (America/New_York)");
+  });
+
+  it("drops the trailing 'time' and 'approximately' filler", () => {
+    expect(extractUsageLimitReset(CLAUDE_APPROX)).toBe("11:00 PM Europe/Berlin");
+  });
+
+  it("keeps a relative duration with an 'in' prefix", () => {
+    expect(extractUsageLimitReset(CODEX_RELATIVE)).toBe("in 3h 42m");
+    expect(extractUsageLimitReset("please try again after 5 minutes")).toBe("in 5 minutes");
+  });
+
+  it("renders the legacy epoch-pipe form as a UTC stamp", () => {
+    expect(extractUsageLimitReset(CLAUDE_PIPE)).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC$/);
+  });
+
+  it("returns null when the runtime gave no hint", () => {
+    expect(extractUsageLimitReset(CODEX_JSON)).toBeNull();
+    expect(extractUsageLimitReset("")).toBeNull();
+  });
+});
+
+describe("formatUsageLimitMessage", () => {
+  it("composes a calm line with the reset time and runtime label", () => {
+    expect(formatUsageLimitMessage(CLAUDE_ABSOLUTE, "claude-code")).toBe(
+      "Claude Code usage limit reached — resets at 2pm (America/New_York).",
+    );
+    expect(formatUsageLimitMessage(CODEX_RELATIVE, "codex")).toBe(
+      "Codex usage limit reached — resets in 3h 42m.",
+    );
+  });
+
+  it("falls back gracefully when no reset time is present", () => {
+    expect(formatUsageLimitMessage(CODEX_JSON, "codex")).toBe(
+      "Codex usage limit reached — please try again later.",
+    );
+  });
+
+  it("uses a neutral label for unknown runtimes", () => {
+    expect(formatUsageLimitMessage(CODEX_JSON, undefined)).toBe(
+      "Agent runtime usage limit reached — please try again later.",
+    );
+  });
+});

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -12,7 +12,11 @@ import {
   tailText,
   type RuntimeFailureSummary,
 } from "./runtime-failure.js";
-import { looksLikeRuntimeAuthFailure } from "./runtime-errors.js";
+import {
+  formatUsageLimitMessage,
+  looksLikeRuntimeAuthFailure,
+  looksLikeUsageLimit,
+} from "./runtime-errors.js";
 import { resolveRoute } from "./router.js";
 import { sessionKey, type SessionStore } from "./session-store.js";
 import { clearWaitMarker, consumeWaitMarker, resolveWaitMarkerPath, MAX_WAIT_MS } from "./wait-marker.js";
@@ -1018,7 +1022,9 @@ export class Dispatcher {
         conversationId: msg.conversation.id,
         threadId: msg.conversation.threadId ?? null,
         type: "error",
-        text: `⚠️ Runtime error: ${truncate(error, 500)}`,
+        text: looksLikeUsageLimit(error)
+          ? formatUsageLimitMessage(error, route.runtime)
+          : `⚠️ Runtime error: ${truncate(error, 500)}`,
         replyTo: this.providerReplyTo(msg),
         traceId: msg.trace?.id ?? null,
       }, turnId);
@@ -1956,7 +1962,9 @@ export class Dispatcher {
             conversationId: msg.conversation.id,
             threadId: msg.conversation.threadId ?? null,
             type: "error",
-            text: `⚠️ Runtime error: ${truncate(failure.safeMessage, 500)} [error_ref: ${failure.errorRef}]`,
+            text:
+              failure.usageLimitText ??
+              `⚠️ Runtime error: ${truncate(failure.safeMessage, 500)} [error_ref: ${failure.errorRef}]`,
             errorRef: failure.errorRef,
             replyTo: this.providerReplyTo(msg),
             traceId: msg.trace?.id ?? null,
@@ -2084,7 +2092,9 @@ export class Dispatcher {
               conversationId: msg.conversation.id,
               threadId: msg.conversation.threadId ?? null,
               type: "error",
-              text: `⚠️ Runtime error: ${truncate(failure.safeMessage, 500)} [error_ref: ${failure.errorRef}]`,
+              text:
+                failure.usageLimitText ??
+                `⚠️ Runtime error: ${truncate(failure.safeMessage, 500)} [error_ref: ${failure.errorRef}]`,
               errorRef: failure.errorRef,
               replyTo: this.providerReplyTo(msg),
               traceId: msg.trace?.id ?? null,
@@ -2447,7 +2457,12 @@ export class Dispatcher {
     error: unknown;
     result?: RuntimeRunResult;
     hubUrl?: string;
-  }): { errorRef: string; summary: RuntimeFailureSummary; safeMessage: string } {
+  }): {
+    errorRef: string;
+    summary: RuntimeFailureSummary;
+    safeMessage: string;
+    usageLimitText: string | null;
+  } {
     const info = errorInfo(args.error);
     const resultFailure = args.result?.runtimeFailure ?? {};
     const baseMessage =
@@ -2464,6 +2479,11 @@ export class Dispatcher {
       failureExitCode !== null && !baseMessage.includes(`code ${failureExitCode}`)
         ? `${baseMessage} (exit code ${failureExitCode})`
         : baseMessage;
+    // Quota exhaustion is not a crash to debug — surface a calm line with the
+    // runtime's own reset time instead of the exit-code/error_ref envelope.
+    const usageLimitText = looksLikeUsageLimit(baseMessage)
+      ? formatUsageLimitMessage(baseMessage, args.route.runtime)
+      : null;
     const summary: RuntimeFailureSummary = {
       agent_id: args.msg.accountId,
       room_id: args.msg.conversation.id,
@@ -2535,7 +2555,7 @@ export class Dispatcher {
       }),
       this.log,
     );
-    return { errorRef, summary, safeMessage };
+    return { errorRef, summary, safeMessage, usageLimitText };
   }
 }
 

--- a/packages/daemon/src/gateway/runtime-errors.ts
+++ b/packages/daemon/src/gateway/runtime-errors.ts
@@ -13,3 +13,85 @@ export function looksLikeRuntimeAuthFailure(text: string): boolean {
     /^(Unauthorized|Forbidden)(?:\b|:)/i.test(s)
   );
 }
+
+/**
+ * Usage / rate-limit exhaustion is reported by runtimes as ordinary error text,
+ * not a distinct status. Claude Code emits "Claude usage limit reached. Your
+ * limit will reset at 2pm (America/New_York)"; Codex emits "You've reached your
+ * 5-hour message limit. Try again in 3h 42m." or a bare
+ * `{"type":"error","error":{"type":"usage_limit_reached",...}}` blob. Detect it
+ * so the dispatcher can surface a calm, reset-time-forward sentence instead of a
+ * red "Runtime error" wrapped in an exit code and an error_ref.
+ */
+const USAGE_LIMIT_PATTERNS: RegExp[] = [
+  /usage[_\s-]?limit[_\s-]?reached/i,
+  /\b\d+-hour (?:message )?limit\b/i,
+  /you'?ve (?:hit|reached) your (?:usage |message |daily |weekly )*limit/i,
+  /\binsufficient_quota\b/i,
+  /\bquota (?:exceeded|exhausted|reached)\b/i,
+  /\brate[_\s-]?limit(?:_?(?:exceeded|error)|ed|\s+(?:reached|exceeded|hit))/i,
+];
+
+export function looksLikeUsageLimit(text: string): boolean {
+  const s = text?.trim();
+  if (!s) return false;
+  return USAGE_LIMIT_PATTERNS.some((re) => re.test(s));
+}
+
+/**
+ * Pull the reset hint straight out of the runtime's own words — never compute it
+ * locally, since the runtime already knows the user's plan window and timezone
+ * and we do not. Returns a ready-to-render fragment: an absolute clock time like
+ * "2pm (America/New_York)", a relative "in 3h 42m", or null when the runtime
+ * gave no hint.
+ */
+export function extractUsageLimitReset(text: string): string | null {
+  const s = (text ?? "").trim();
+  if (!s) return null;
+  // Absolute: "...reset at 2pm (America/New_York)" /
+  //           "reset at approximately 11:00 PM Europe/Berlin time"
+  const at = s.match(/reset(?:s|ting)?\s+at\s+(?:approximately\s+)?(.+?)(?:\s+time\b)?\s*(?:[.,\n]|$)/i);
+  if (at?.[1]) return collapseWs(at[1]);
+  // Relative: "Try again in 3h 42m" / "please try again after 5 minutes"
+  const rel = s.match(/try again (?:in|after)\s+(.+?)\s*(?:[.,\n]|$)/i);
+  if (rel?.[1]) return `in ${collapseWs(rel[1])}`;
+  // Legacy Claude headless pipe form: "...reached|1719345600"
+  const pipe = s.match(/reached\s*\|\s*(\d{10,13})/);
+  if (pipe?.[1]) {
+    const ms = pipe[1].length >= 13 ? Number(pipe[1]) : Number(pipe[1]) * 1000;
+    if (Number.isFinite(ms)) return `${new Date(ms).toISOString().replace("T", " ").slice(0, 16)} UTC`;
+  }
+  return null;
+}
+
+/**
+ * Compose the calm, user-facing line for a usage/rate-limit error. Callers
+ * should gate on {@link looksLikeUsageLimit} first.
+ */
+export function formatUsageLimitMessage(text: string, runtime?: string): string {
+  const who = runtimeLabel(runtime);
+  const reset = extractUsageLimitReset(text);
+  if (reset) {
+    const when = /^in\s/i.test(reset) ? `resets ${reset}` : `resets at ${reset}`;
+    return `${who} usage limit reached — ${when}.`;
+  }
+  return `${who} usage limit reached — please try again later.`;
+}
+
+function runtimeLabel(runtime?: string): string {
+  switch ((runtime ?? "").toLowerCase()) {
+    case "claude-code":
+    case "claude":
+      return "Claude Code";
+    case "codex":
+      return "Codex";
+    case "gemini":
+      return "Gemini";
+    default:
+      return "Agent runtime";
+  }
+}
+
+function collapseWs(s: string): string {
+  return s.replace(/\s+/g, " ").trim();
+}


### PR DESCRIPTION
## 问题

runtime（Claude Code / Codex / Gemini）配额耗尽（usage/rate limit）时，daemon 把它当成普通 runtime crash 处理，正文被包成 `⚠️ Runtime error: … (exit code 1) [error_ref: …]`，Codex 有时还是一坨原始 JSON（`{"type":"error","error":{"type":"usage_limit_reached",…}}`）。用户最需要的信息——**什么时候恢复**——被噪音淹没。

## 改动（仅 daemon，沿用现有报错气泡）

- 新增 `looksLikeUsageLimit` / `extractUsageLimitReset` / `formatUsageLimitMessage`（`runtime-errors.ts`），与现有 `looksLikeRuntimeAuthFailure` 同风格。
- **刷新时间直接从 runtime 原文里摘**，不本地计算——runtime 自己知道用户的时区/窗口，我们不知道。支持三种来源：
  - 绝对时间：`reset at 2pm (America/New_York)`
  - 相对时长：`Try again in 3h 42m`
  - 旧 headless 管道格式：`…reached|<unix>` → UTC 时间戳
- dispatcher 三处错误发送点：命中 usage limit → 发干净一句话，**去掉 exit code / error_ref 噪音**；否则完全保持原样。`error_ref` 仍挂在消息 payload 上，详情对话框 / debug 不受影响；transcript 仍记技术原文。

## 效果

| 场景 | 旧 | 新 |
|---|---|---|
| Claude 绝对时间 | `⚠️ Runtime error: Claude usage limit reached… (exit code 1) [error_ref: err_…]` | `Claude Code usage limit reached — resets at 2pm (America/New_York).` |
| Codex 相对 | `⚠️ Runtime error: You've reached your 5-hour… (exit code 1) [error_ref: …]` | `Codex usage limit reached — resets in 3h 42m.` |
| Codex JSON 无时间 | `⚠️ Runtime error: {"type":"error",…} (exit code 1) [error_ref: …]` | `Codex usage limit reached — please try again later.` |

## 测试

- 新增 `runtime-errors.test.ts`，10 例覆盖三家 runtime 真实格式 + 负例（普通错误不被误判）。
- 全量 daemon 测试 75 文件 / 1015 例全过；`tsc` 干净。
- 含 changeset（`@botcord/daemon` patch）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)