### PR TITLE
fix(daemon): preserve discovery-loaded agents when provisioning

### DIFF
--- a/.changeset/preserve-discovery-agents.md
+++ b/.changeset/preserve-discovery-agents.md
@@ -1,0 +1,5 @@
+---
+"@botcord/daemon": patch
+---
+
+fix: preserve discovery-loaded agents when provisioning. When the daemon booted via credential discovery (empty `config.agents`), provisioning a single agent persisted `agents: [newId]` and silently dropped every other discovered agent on the next restart — surfacing later as `agent_not_loaded` when their schedules fired. `addAgentToConfig` now folds the gateway's currently-loaded agent channels into the persisted list.

--- a/packages/daemon/src/__tests__/provision.test.ts
+++ b/packages/daemon/src/__tests__/provision.test.ts
@@ -72,6 +72,26 @@ describe("addAgentToConfig / removeAgentFromConfig", () => {
     expect(addAgentToConfig(cfg, "ag_a")).toBeNull();
   });
 
+  it("preserves gateway-loaded agents when provisioning in discovery mode", () => {
+    // config.agents is empty (daemon booted via credential discovery); the
+    // already-running agents arrive only via the gateway-snapshot baseline.
+    const cfg = baseConfig();
+    const next = addAgentToConfig(cfg, "ag_new", ["ag_disc1", "ag_disc2"]);
+    expect(next?.agents).toEqual(["ag_disc1", "ag_disc2", "ag_new"]);
+  });
+
+  it("no-ops when a loaded agent is re-provisioned in discovery mode", () => {
+    const cfg = baseConfig();
+    expect(addAgentToConfig(cfg, "ag_disc1", ["ag_disc1", "ag_disc2"])).toBeNull();
+  });
+
+  it("merges explicit agents, legacy scalar, and loaded baseline without dupes", () => {
+    const cfg = baseConfig({ agents: ["ag_a"], agentId: "ag_a" });
+    const next = addAgentToConfig(cfg, "ag_new", ["ag_a", "ag_b"]);
+    expect(next?.agents).toEqual(["ag_a", "ag_b", "ag_new"]);
+    expect(next?.agentId).toBeUndefined();
+  });
+
   it("absorbs a legacy scalar agentId into the new agents array", () => {
     const cfg = baseConfig({ agentId: "ag_legacy" });
     const next = addAgentToConfig(cfg, "ag_new");

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -1178,7 +1178,7 @@ async function installLocalAgent(
   }
 
   try {
-    const updated = addAgentToConfig(cfg, credentials.agentId);
+    const updated = addAgentToConfig(cfg, credentials.agentId, loadedBotcordAgentIds(ctx.gateway));
     if (updated) saveConfig(updated);
   } catch (err) {
     // Rollback the credentials file if we can't persist config — the
@@ -1335,7 +1335,7 @@ async function installExistingOpenclawBinding(
   const credentialsFile = defaultCredentialsFile(agentId);
   const credentials = loadStoredCredentials(credentialsFile);
   const cfg = loadConfig();
-  const updated = addAgentToConfig(cfg, credentials.agentId);
+  const updated = addAgentToConfig(cfg, credentials.agentId, loadedBotcordAgentIds(ctx.gateway));
   if (updated) saveConfig(updated);
   const snap = ctx.gateway.snapshot();
   if (!snap.channels[credentials.agentId]) {
@@ -1937,13 +1937,41 @@ function assertSafeCwd(cwd: string | undefined): void {
 }
 
 /**
+ * BotCord agent ids currently live in the gateway. Used as a baseline for
+ * {@link addAgentToConfig} so that persisting one provisioned agent never
+ * drops the others. Gateway channels for third-party gateways (`gw_*`) are
+ * excluded — only `ag_*` agent channels belong in the daemon `agents` list.
+ */
+export function loadedBotcordAgentIds(gateway: {
+  snapshot(): { channels: Record<string, unknown> };
+}): string[] {
+  return Object.keys(gateway.snapshot().channels).filter((id) => id.startsWith("ag_"));
+}
+
+/**
  * Append `agentId` to the daemon config if not already present. Returns a
  * new config object or `null` if nothing changed (so callers can skip the
  * disk write).
+ *
+ * `loadedAgents` carries the ids already live in the gateway — typically the
+ * agents discovered from the credentials dir at boot, which never made it
+ * into `cfg.agents` because discovery keeps the on-disk list empty. Folding
+ * them in before writing prevents the footgun where provisioning a single
+ * agent in discovery mode persists `agents: [newId]` and silently drops
+ * every discovered agent on the next restart (agent_not_loaded).
  */
-export function addAgentToConfig(cfg: DaemonConfig, agentId: string): DaemonConfig | null {
-  const list = Array.isArray(cfg.agents) ? cfg.agents.slice() : [];
-  if (cfg.agentId && !list.includes(cfg.agentId)) list.push(cfg.agentId);
+export function addAgentToConfig(
+  cfg: DaemonConfig,
+  agentId: string,
+  loadedAgents: string[] = [],
+): DaemonConfig | null {
+  const list: string[] = [];
+  const add = (id: string | undefined | null): void => {
+    if (typeof id === "string" && id.length > 0 && !list.includes(id)) list.push(id);
+  };
+  if (Array.isArray(cfg.agents)) for (const id of cfg.agents) add(id);
+  add(cfg.agentId);
+  for (const id of loadedAgents) add(id);
   if (list.includes(agentId)) return null;
   list.push(agentId);
   const next: DaemonConfig = { ...cfg, agents: list };


### PR DESCRIPTION
## 背景（生产事故）

botcord-dev 单 daemon 今天 06:17 因 daemon 包紧急发布被 SIGTERM、systemd 重启后,**只加载了 1 个 agent**,其余 14 个全部丢失。15:16 `ag_e18e42e6f37d` 的 A 股报告 schedule 触发 `wake_agent` 时报:

```
agent_not_loaded: agent ag_e18e42e6f37d is not loaded in daemon gateway
```

(生产侧已手动把 14 个 agent append 回 `config.json` 并重启恢复。)

## 根因

daemon 通过 credential discovery 启动时(`config.json` 无 `agents` 字段),发现的 agent 只进 gateway 运行时,**从未写回 `cfg.agents`**(内存里始终是 `undefined`)。

`addAgentToConfig(cfg, agentId)` 以 `cfg.agents`(空)为基准 append,于是任何一次 `provision_agent` 都会把 `agents` 持久化成 `[newId]` —— 丢掉全部 discovery agent,并因 `agents` 变非空而**永久关闭下次 discovery**。下次重启就只剩这一个 agent。

本次正是 02:29 provision `Botcord-Ops` 触发,把 `agents` 缩成 `["ag_d6fab393194f"]`,埋下 06:17 重启丢 14 个 agent 的雷。

## 修复

`addAgentToConfig` 新增 `loadedAgents` baseline 参数;两个 provision 调用点传入 gateway 当前已加载的 `ag_*` channel。持久化时以「完整运行时列表 + 新 agent」为准,而非残缺的 `cfg.agents`。

- 仅在确有新 agent(需写盘)时生效;re-provision 已加载 agent 仍 `return null` → **drop 场景之外零行为变化**。
- 新增 helper `loadedBotcordAgentIds(gateway)` 过滤出 `ag_*` agent channel(排除 `gw_*` 第三方网关)。

## 测试

`pnpm --filter @botcord/daemon test` → **74 files / 1008 tests passed**,含新增 3 个用例:
- discovery 模式下 provision 保留 gateway baseline 的其它 agent
- re-provision 已加载 agent → no-op
- 显式 agents + legacy scalar + baseline 合并去重

🤖 Generated with [Claude Code](https://claude.com/claude-code)