### PR TITLE
Fix cloud run usage reservation CI failures

### DIFF
--- a/backend/hub/services/cloud_agent.py
+++ b/backend/hub/services/cloud_agent.py
@@ -67,7 +67,7 @@ from hub.routers.cloud_daemon_control import (
     is_cloud_daemon_online,
     send_cloud_control_frame,
 )
-from hub.services.cloud_agent_usage import UsageService
+from hub.services.cloud_agent_usage import UsageError, UsageService
 from hub.services.cloud_daemon_provider import (
     CloudDaemonHandle,
     CloudDaemonProvider,
@@ -1446,77 +1446,108 @@ class CloudAgentService:
 
         await self._ensure_new_api_balance_for_run(db, user_id=user_id)
 
-        # Auto-resume paused agents only after token balance preflight. A user
-        # with an exhausted new-api token must not wake a paused sandbox.
-        if cai.status == "paused":
-            await self.resume_cloud_agent(db, user_id=user_id, agent_id=agent_id)
-            cai, agent, cdi = await self._load_owned(
-                db, user_id=user_id, agent_id=agent_id
-            )
-
         run_id = generate_cloud_agent_run_id()
-
-        room_id = await self._resolve_run_room(
-            db,
-            user_id=user_id,
-            agent_id=agent_id,
-            agent_display_name=agent.display_name,
-            preferred_room_id=body.room_id,
+        reserved_credits = self._usage.estimate_run_credits(
+            max_wall_time_seconds=budget.max_wall_time_seconds,
+            max_tool_calls=budget.max_tool_calls,
         )
-
-        hub_msg_id = generate_hub_msg_id()
-        msg_id = str(uuid.uuid4())
-        ts = int(time.time())
-
-        payload = {
-            "text": prompt,
-            "cloud_run": {
-                "run_id": run_id,
-                "settle_usage": False,
-                "budget": {
+        reserved_sandbox_seconds = self._usage.estimate_run_sandbox_seconds(
+            max_wall_time_seconds=budget.max_wall_time_seconds
+        )
+        try:
+            await self._usage.reserve(
+                db,
+                user_id=user_id,
+                agent_id=agent_id,
+                run_id=run_id,
+                credits=reserved_credits,
+                sandbox_seconds=reserved_sandbox_seconds,
+                metadata={
+                    "source": "cloud_agent_run",
                     "max_wall_time_seconds": budget.max_wall_time_seconds,
                     "max_tool_calls": budget.max_tool_calls,
                 },
-            },
-        }
-        envelope = {
-            "v": "a2a/0.1",
-            "msg_id": msg_id,
-            "ts": ts,
-            "from": agent_id,
-            "to": agent_id,
-            # ``cloud_run`` is a custom envelope type the daemon recognises
-            # alongside the standard ``message`` flow. Keeping it distinct
-            # from ``message`` lets the daemon route runs differently from
-            # plain owner-chat without sniffing payload internals.
-            "type": "cloud_run",
-            "reply_to": None,
-            "ttl_sec": budget.max_wall_time_seconds,
-            "payload": payload,
-            "payload_hash": "",
-            "sig": {"alg": "ed25519", "key_id": "cloud-run", "value": ""},
-            "topic": body.topic,
-        }
+            )
+        except UsageError as exc:
+            raise CloudAgentError(
+                exc.code,
+                exc.message,
+                http_status=402,
+            ) from exc
 
-        record = MessageRecord(
-            hub_msg_id=hub_msg_id,
-            msg_id=msg_id,
-            sender_id=agent_id,
-            receiver_id=agent_id,
-            room_id=room_id,
-            topic=body.topic,
-            state=MessageState.queued,
-            envelope_json=json.dumps(envelope),
-            ttl_sec=budget.max_wall_time_seconds,
-            mentioned=True,
-            source_type="cloud_agent_run",
-            source_user_id=str(user_id),
-            source_session_kind="cloud_run",
-        )
-        db.add(record)
-        cai.last_run_at = _now()
+        try:
+            # Auto-resume paused agents only after all quota preflights. A user
+            # with exhausted quota must not wake a paused sandbox/provider.
+            if cai.status == "paused":
+                await self.resume_cloud_agent(db, user_id=user_id, agent_id=agent_id)
+                cai, agent, cdi = await self._load_owned(
+                    db, user_id=user_id, agent_id=agent_id
+                )
 
-        await db.commit()
+            room_id = await self._resolve_run_room(
+                db,
+                user_id=user_id,
+                agent_id=agent_id,
+                agent_display_name=agent.display_name,
+                preferred_room_id=body.room_id,
+            )
+
+            hub_msg_id = generate_hub_msg_id()
+            msg_id = str(uuid.uuid4())
+            ts = int(time.time())
+
+            payload = {
+                "text": prompt,
+                "cloud_run": {
+                    "run_id": run_id,
+                    "settle_usage": True,
+                    "budget": {
+                        "max_wall_time_seconds": budget.max_wall_time_seconds,
+                        "max_tool_calls": budget.max_tool_calls,
+                    },
+                },
+            }
+            envelope = {
+                "v": "a2a/0.1",
+                "msg_id": msg_id,
+                "ts": ts,
+                "from": agent_id,
+                "to": agent_id,
+                # ``cloud_run`` is a custom envelope type the daemon recognises
+                # alongside the standard ``message`` flow. Keeping it distinct
+                # from ``message`` lets the daemon route runs differently from
+                # plain owner-chat without sniffing payload internals.
+                "type": "cloud_run",
+                "reply_to": None,
+                "ttl_sec": budget.max_wall_time_seconds,
+                "payload": payload,
+                "payload_hash": "",
+                "sig": {"alg": "ed25519", "key_id": "cloud-run", "value": ""},
+                "topic": body.topic,
+            }
+
+            record = MessageRecord(
+                hub_msg_id=hub_msg_id,
+                msg_id=msg_id,
+                sender_id=agent_id,
+                receiver_id=agent_id,
+                room_id=room_id,
+                topic=body.topic,
+                state=MessageState.queued,
+                envelope_json=json.dumps(envelope),
+                ttl_sec=budget.max_wall_time_seconds,
+                mentioned=True,
+                source_type="cloud_agent_run",
+                source_user_id=str(user_id),
+                source_session_kind="cloud_run",
+            )
+            db.add(record)
+            cai.last_run_at = _now()
+
+            await db.commit()
+        except Exception:
+            await self._release_run_usage_reservation_durably(db, run_id=run_id)
+            raise
 
         # Wake the agent's inbox; cloud daemon's per-agent inbox session
         # picks the run up on the same channel as any other message.
@@ -1542,6 +1573,24 @@ class CloudAgentService:
     # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------
+
+    async def _release_run_usage_reservation_durably(
+        self,
+        db: AsyncSession,
+        *,
+        run_id: str,
+    ) -> None:
+        try:
+            await db.rollback()
+            await self._usage.release(db, run_id=run_id)
+            await db.commit()
+        except Exception as exc:  # noqa: BLE001
+            await db.rollback()
+            logger.warning(
+                "cloud agent run usage reservation release failed: run=%s err=%s",
+                run_id,
+                exc,
+            )
 
     async def _resolve_run_room(
         self,
@@ -2053,7 +2102,7 @@ async def _notify_inbox(agent_id: str, db: AsyncSession) -> int:
     """
     from hub.routers.hub import notify_inbox
 
-    return await notify_inbox(agent_id, db=db)
+    return await notify_inbox(agent_id, db=db, resume_cloud=False)
 
 
 async def resume_cloud_agent_for_inbox(

--- a/backend/migrations/011_agent_hosting_kind_openclaw.sql
+++ b/backend/migrations/011_agent_hosting_kind_openclaw.sql
@@ -1,6 +1,11 @@
 ALTER TABLE agents
     DROP CONSTRAINT IF EXISTS ck_agents_hosting_kind;
 
+UPDATE agents
+SET hosting_kind = NULL
+WHERE hosting_kind IS NOT NULL
+  AND hosting_kind NOT IN ('daemon', 'openclaw', 'cli', 'cloud');
+
 ALTER TABLE agents
     ADD CONSTRAINT ck_agents_hosting_kind
-    CHECK (hosting_kind IS NULL OR hosting_kind IN ('daemon', 'openclaw', 'cli'));
+    CHECK (hosting_kind IS NULL OR hosting_kind IN ('daemon', 'openclaw', 'cli', 'cloud'));

--- a/backend/tests/test_app/test_cloud_agents.py
+++ b/backend/tests/test_app/test_cloud_agents.py
@@ -913,7 +913,7 @@ async def test_run_with_custom_budget(client_factory, seed_user):
 
 
 @pytest.mark.asyncio
-async def test_run_does_not_reserve_botcord_usage(client_factory, seed_user):
+async def test_run_reserves_botcord_usage(client_factory, seed_user):
     client, _ = await client_factory()
     headers = {"Authorization": f"Bearer {seed_user['token']}"}
     create = await client.post(
@@ -932,8 +932,8 @@ async def test_run_does_not_reserve_botcord_usage(client_factory, seed_user):
     body = usage.json()
     assert body["agent_id"] == agent_id
     assert body["included_credits"] >= body["reserved_credits"]
-    assert body["reserved_credits"] == 0
-    assert body["reserved_sandbox_seconds"] == 0
+    assert body["reserved_credits"] > 0
+    assert body["reserved_sandbox_seconds"] == 600
     assert body["events"] == []
 
 

--- a/backend/tests/test_cloud_agent_runs.py
+++ b/backend/tests/test_cloud_agent_runs.py
@@ -18,6 +18,7 @@ from hub.models import (
     MessageRecord,
     Room,
     RoomMember,
+    UsageBalance,
     UsageReservation,
     User,
 )
@@ -28,6 +29,7 @@ from hub.services.cloud_agent import (
     CreateRunInput,
     RunBudget,
 )
+from hub.services.cloud_agent_usage import UsageService
 from hub.services.cloud_daemon_provider import FakeCloudDaemonProvider
 from tests.test_app.conftest import create_test_engine
 
@@ -105,12 +107,39 @@ class _RunNewApiService:
         )()
 
 
+class _FailingResumeProvider(FakeCloudDaemonProvider):
+    async def create_or_resume(self, **kwargs):
+        cloud_daemon_instance_id = kwargs["cloud_daemon_instance_id"]
+        if cloud_daemon_instance_id in self.all_sandboxes():
+            raise RuntimeError("resume failed after provisioning commit")
+        return await super().create_or_resume(**kwargs)
+
+
 async def _create_ready_agent(svc: CloudAgentService, db, user) -> "CloudAgentView":
     return await svc.create_cloud_agent(
         db,
         user_id=user.id,
         body=CreateCloudAgentInput(name=f"Cloud-{uuid.uuid4().hex[:4]}"),
     )
+
+
+async def _fresh_run_usage_state(db: AsyncSession, *, user_id: uuid.UUID):
+    factory = async_sessionmaker(
+        db.bind, class_=AsyncSession, expire_on_commit=False
+    )
+    async with factory() as fresh:
+        active_reservations = (
+            await fresh.execute(
+                select(UsageReservation).where(UsageReservation.state == "active")
+            )
+        ).scalars().all()
+        balance = await fresh.scalar(
+            select(UsageBalance).where(UsageBalance.user_id == user_id)
+        )
+        run_message = await fresh.scalar(
+            select(MessageRecord).where(MessageRecord.source_type == "cloud_agent_run")
+        )
+        return active_reservations, balance, run_message
 
 
 # ---------------------------------------------------------------------------
@@ -150,12 +179,15 @@ async def test_create_run_inserts_message_record_and_returns_run_id(db_session):
     assert MessageEnvelope(**envelope).type.value == "cloud_run"
     assert envelope["payload"]["text"] == "Summarise the workspace"
     assert envelope["payload"]["cloud_run"]["run_id"] == run.run_id
-    assert envelope["payload"]["cloud_run"]["settle_usage"] is False
+    assert envelope["payload"]["cloud_run"]["settle_usage"] is True
     assert envelope["payload"]["cloud_run"]["budget"]["max_wall_time_seconds"] == 600
     reservation = await db_session.scalar(
         select(UsageReservation).where(UsageReservation.run_id == run.run_id)
     )
-    assert reservation is None
+    assert reservation is not None
+    assert reservation.state == "active"
+    assert reservation.reserved_credits > 0
+    assert reservation.reserved_sandbox_seconds == 600
 
 
 @pytest.mark.asyncio
@@ -284,6 +316,51 @@ async def test_create_run_preflights_balance_before_resuming_paused_agent(db_ses
     assert run_message is None
 
 
+@pytest.mark.asyncio
+async def test_create_run_reserves_usage_before_resuming_paused_agent(db_session):
+    provider = FakeCloudDaemonProvider()
+    svc = CloudAgentService(
+        provider=provider,
+        feature_enabled=True,
+        max_per_user=3,
+        max_agents_per_daemon=2,
+        usage_service=UsageService(
+            free_credits_per_period=1,
+            free_sandbox_seconds_per_period=3600,
+        ),
+    )
+    user = await _seed_user(db_session)
+    cloud_agent = await _create_ready_agent(svc, db_session, user)
+    await svc.pause_cloud_agent(
+        db_session, user_id=user.id, agent_id=cloud_agent.agent_id
+    )
+    calls_before = provider.calls(cloud_agent.cloud_daemon_instance_id)
+
+    with pytest.raises(CloudAgentError) as excinfo:
+        await svc.create_run(
+            db_session,
+            user_id=user.id,
+            agent_id=cloud_agent.agent_id,
+            body=CreateRunInput(prompt="quota blocked"),
+        )
+
+    assert excinfo.value.code == "quota_credits_exceeded"
+    assert excinfo.value.http_status == 402
+    assert provider.calls(cloud_agent.cloud_daemon_instance_id) == calls_before
+    refreshed = await db_session.scalar(
+        select(CloudAgentInstance).where(
+            CloudAgentInstance.agent_id == cloud_agent.agent_id
+        )
+    )
+    assert refreshed.status == "paused"
+    run_message = await db_session.scalar(
+        select(MessageRecord).where(MessageRecord.source_type == "cloud_agent_run")
+    )
+    assert run_message is None
+    reservations = (await db_session.execute(select(UsageReservation))).scalars().all()
+    assert reservations == []
+
+
 # ---------------------------------------------------------------------------
 # Auto-resume + state machine
 # ---------------------------------------------------------------------------
@@ -311,6 +388,69 @@ async def test_create_run_auto_resumes_paused_agent(db_session):
         )
     )
     assert refreshed.status == "ready"
+
+
+@pytest.mark.asyncio
+async def test_create_run_releases_usage_when_paused_resume_provider_fails(
+    db_session,
+):
+    provider = _FailingResumeProvider()
+    svc = _service(provider=provider)
+    user = await _seed_user(db_session)
+    user_id = user.id
+    cloud_agent = await _create_ready_agent(svc, db_session, user)
+    await svc.pause_cloud_agent(
+        db_session, user_id=user.id, agent_id=cloud_agent.agent_id
+    )
+
+    with pytest.raises(RuntimeError, match="resume failed"):
+        await svc.create_run(
+            db_session,
+            user_id=user.id,
+            agent_id=cloud_agent.agent_id,
+            body=CreateRunInput(prompt="wake then fail"),
+        )
+
+    active_reservations, balance, run_message = await _fresh_run_usage_state(
+        db_session, user_id=user_id
+    )
+    assert active_reservations == []
+    assert balance is not None
+    assert balance.reserved_credits == 0
+    assert balance.reserved_sandbox_seconds == 0
+    assert run_message is None
+
+
+@pytest.mark.asyncio
+async def test_create_run_releases_usage_when_room_resolution_fails_after_resume(
+    db_session,
+):
+    provider = FakeCloudDaemonProvider()
+    svc = _service(provider=provider)
+    user = await _seed_user(db_session)
+    user_id = user.id
+    cloud_agent = await _create_ready_agent(svc, db_session, user)
+    await svc.pause_cloud_agent(
+        db_session, user_id=user.id, agent_id=cloud_agent.agent_id
+    )
+
+    with pytest.raises(CloudAgentError) as excinfo:
+        await svc.create_run(
+            db_session,
+            user_id=user.id,
+            agent_id=cloud_agent.agent_id,
+            body=CreateRunInput(prompt="wake then bad room", room_id="rm_missing"),
+        )
+
+    assert excinfo.value.code == "room_not_found"
+    active_reservations, balance, run_message = await _fresh_run_usage_state(
+        db_session, user_id=user_id
+    )
+    assert active_reservations == []
+    assert balance is not None
+    assert balance.reserved_credits == 0
+    assert balance.reserved_sandbox_seconds == 0
+    assert run_message is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_cloud_agent_schema.py
+++ b/backend/tests/test_cloud_agent_schema.py
@@ -2,6 +2,7 @@
 
 import datetime
 import uuid
+from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -25,6 +26,11 @@ from hub.models import (
 )
 
 TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
+MIGRATION_011 = (
+    Path(__file__).resolve().parents[1]
+    / "migrations"
+    / "011_agent_hosting_kind_openclaw.sql"
+)
 
 
 @pytest_asyncio.fixture
@@ -111,6 +117,16 @@ async def _make_cloud_agent(
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
+
+def test_hosting_kind_openclaw_migration_normalizes_legacy_values_before_check():
+    sql = MIGRATION_011.read_text()
+    normalize_pos = sql.index("UPDATE agents")
+    constraint_pos = sql.index("ADD CONSTRAINT ck_agents_hosting_kind")
+
+    assert normalize_pos < constraint_pos
+    assert "hosting_kind NOT IN ('daemon', 'openclaw', 'cli', 'cloud')" in sql
+    assert "hosting_kind IN ('daemon', 'openclaw', 'cli', 'cloud')" in sql
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- reserve BotCord cloud-run usage before paused auto-resume/provider dispatch, while keeping new-api balance preflight before wakeup
- durably release run usage reservations on any post-reservation failure before the run message commit
- prevent run-created inbox wakeups from recursively resuming cloud agents
- normalize historical agents.hosting_kind values in migration 011 before rebuilding the check constraint and allow current cloud values

## Tests
- backend/.venv/bin/python -m pytest backend/tests/test_cloud_agent_runs.py -q
- backend/.venv/bin/python -m pytest backend/tests/test_cloud_agent_usage.py backend/tests/test_cloud_agent_runs.py backend/tests/test_cloud_agent_schema.py -q
- backend/.venv/bin/python -m pytest backend/tests/test_app/test_cloud_agents.py::test_inbox_notification_resumes_paused_cloud_agent backend/tests/test_app/test_cloud_agents.py::test_run_reserves_botcord_usage -q
- git diff --check

Code Reviewer re-review: no blocking findings after durability fix.
