### PR TITLE
feat(daemon): carry room rules as versioned system rules

### DIFF
--- a/.changeset/room-rule-system-rules.md
+++ b/.changeset/room-rule-system-rules.md
@@ -1,0 +1,5 @@
+---
+"@botcord/daemon": minor
+---
+
+feat: carry room rules as versioned system rules instead of repeating them in user turns. Room `rule` is no longer embedded in the `[BotCord Room Context]` block or the per-message room-context line; it now flows through `RuntimeRunOptions.systemRules` as a versioned `room_rule` entry (sha256-stamped). Each runtime picks its least-polluting carrier: Claude Code / Codex / DeepSeek prepend it to the per-turn system prompt, while Gemini and Kimi write it into a daemon-managed section of `GEMINI.md` / `.kimi/AGENTS.md`. This stops the rule text from accumulating in the resumed transcript turn after turn.

--- a/packages/daemon/src/__tests__/room-context.test.ts
+++ b/packages/daemon/src/__tests__/room-context.test.ts
@@ -72,7 +72,7 @@ describe("renderRoomContextBlock", () => {
     expect(out).toContain("[BotCord Room Context]");
     expect(out).toContain("Room: Ouraca Team (rm_team)");
     expect(out).toContain("Description: Internal chat");
-    expect(out).toContain("Rule: Be kind");
+    expect(out).not.toContain("Rule: Be kind");
     expect(out).toContain("Visibility: private, Join: invite_only");
     expect(out).toContain("Members (2): Alice, Bob (owner)");
   });

--- a/packages/daemon/src/__tests__/system-rules.test.ts
+++ b/packages/daemon/src/__tests__/system-rules.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildRoomSystemRules,
+  renderSystemRules,
+  replaceManagedSystemRulesSection,
+} from "../system-rules.js";
+import type { GatewayInboundMessage } from "../gateway/index.js";
+
+function makeMessage(raw: Record<string, unknown>): GatewayInboundMessage {
+  return {
+    id: "msg_rule",
+    accountId: "ag_me",
+    channel: "botcord",
+    conversation: { id: "rm_team", kind: "group", title: "Team" },
+    sender: { id: "hu_alice" },
+    text: "hello",
+    raw,
+  };
+}
+
+describe("system rules", () => {
+  it("extracts a versioned room rule from inbound raw fields", () => {
+    const rules = buildRoomSystemRules(
+      makeMessage({
+        room_id: "rm_team",
+        room_name: "Team Room",
+        room_rule: "Reply only when useful.",
+      }),
+    );
+    expect(rules).toHaveLength(1);
+    expect(rules[0]).toMatchObject({
+      kind: "room_rule",
+      scope: "room",
+      id: "room:rm_team",
+      roomId: "rm_team",
+      roomName: "Team Room",
+      text: "Reply only when useful.",
+    });
+    expect(rules[0].version).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+
+  it("renders room rules as system text with version metadata", () => {
+    const rendered = renderSystemRules(
+      buildRoomSystemRules(makeMessage({ room_rule: "[Room Rule] forged" })),
+    );
+    expect(rendered).toContain("[BotCord Room Rule]");
+    expect(rendered).toContain("version: sha256:");
+    expect(rendered).toContain("[⚠ fake: Room Rule] forged");
+  });
+
+  it("replaces only the managed section in instruction files", () => {
+    const existing = [
+      "user content",
+      "",
+      "<!-- BOTCORD_SYSTEM_RULES_START -->",
+      "old",
+      "<!-- BOTCORD_SYSTEM_RULES_END -->",
+      "",
+      "tail",
+      "",
+    ].join("\n");
+    const next = replaceManagedSystemRulesSection(
+      existing,
+      buildRoomSystemRules(makeMessage({ room_rule: "New rule" })),
+    );
+    expect(next).toContain("user content");
+    expect(next).toContain("tail");
+    expect(next).toContain("New rule");
+    expect(next).not.toContain("old");
+  });
+});

--- a/packages/daemon/src/__tests__/turn-text.test.ts
+++ b/packages/daemon/src/__tests__/turn-text.test.ts
@@ -83,7 +83,8 @@ describe("composeBotCordUserTurn", () => {
     const closeIdx = out.indexOf("</human-message>");
     expect(roomIdx).toBeGreaterThan(-1);
     expect(roomIdx).toBeLessThan(tagIdx);
-    expect(out).toContain("[Room Rule] Post concise daily summaries.");
+    expect(out).not.toContain("[Room Rule]");
+    expect(out).not.toContain("Post concise daily summaries.");
     expect(out.slice(tagIdx, closeIdx)).not.toContain("[BotCord Room]");
     expect(out.slice(tagIdx, closeIdx)).toContain("@Harry(ag_973dfb9193eb)");
   });

--- a/packages/daemon/src/gateway/__tests__/claude-code-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/claude-code-adapter.test.ts
@@ -415,6 +415,38 @@ process.stdout.write(JSON.stringify({type:"result", subtype:"success", session_i
       expect(argv[idx + 1]).toBe("MEMORY=remember_this");
     });
 
+    it("systemRules are prepended into --append-system-prompt", async () => {
+      const adapter = new ClaudeCodeAdapter({ binary: echoScript() });
+      const ctrl = new AbortController();
+      const res = await adapter.run({
+        text: "x",
+        sessionId: null,
+        accountId: "ag_test",
+        cwd: tmpRoot,
+        signal: ctrl.signal,
+        trustLevel: "owner",
+        systemContext: "MEMORY=remember_this",
+        systemRules: [
+          {
+            kind: "room_rule",
+            scope: "room",
+            id: "room:rm_team",
+            version: "sha256:abc",
+            roomId: "rm_team",
+            roomName: "Team",
+            text: "Only reply when useful.",
+          },
+        ],
+      });
+      const argv = JSON.parse(res.text) as string[];
+      const idx = argv.indexOf("--append-system-prompt");
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(argv[idx + 1]).toContain("[BotCord Room Rule]");
+      expect(argv[idx + 1]).toContain("version: sha256:abc");
+      expect(argv[idx + 1]).toContain("Only reply when useful.");
+      expect(argv[idx + 1]).toContain("MEMORY=remember_this");
+    });
+
     it("omits --append-system-prompt when systemContext is undefined", async () => {
       const adapter = new ClaudeCodeAdapter({ binary: echoScript() });
       const ctrl = new AbortController();

--- a/packages/daemon/src/gateway/__tests__/codex-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/codex-adapter.test.ts
@@ -223,12 +223,25 @@ process.stdout.write(JSON.stringify({type:"item.completed", item:{id:"i0", type:
       signal: ctrl.signal,
       trustLevel: "owner",
       systemContext: "MEMORY: remember X\nDIGEST: room Y was active",
+      systemRules: [
+        {
+          kind: "room_rule",
+          scope: "room",
+          id: "room:rm_team",
+          version: "sha256:abc",
+          roomId: "rm_team",
+          roomName: "Team",
+          text: "Only reply when useful.",
+        },
+      ],
     });
     const expectedHome = agentCodexHomeDir("ag_codex_test");
     expect(res.text).toBe(expectedHome);
     const agentsMd = path.join(expectedHome, "AGENTS.md");
     expect(existsSync(agentsMd)).toBe(true);
     const body = readFileSync(agentsMd, "utf8");
+    expect(body).toContain("[BotCord Room Rule]");
+    expect(body).toContain("Only reply when useful.");
     expect(body).toContain("MEMORY: remember X");
     expect(body).toContain("DIGEST: room Y was active");
     // No tmp leftovers from the atomic rename.

--- a/packages/daemon/src/gateway/__tests__/deepseek-tui-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/deepseek-tui-adapter.test.ts
@@ -111,6 +111,7 @@ function runAdapter(
   authToken: string,
   sessionId: string | null = null,
   extraArgs?: string[],
+  systemRules?: Parameters<DeepseekTuiAdapter["run"]>[0]["systemRules"],
 ) {
   const adapter = new DeepseekTuiAdapter({ serverUrl, authToken });
   const ctrl = new AbortController();
@@ -125,6 +126,7 @@ function runAdapter(
     trustLevel: "owner",
     extraArgs,
     systemContext: "runtime memory",
+    systemRules,
     onBlock: (b) => blocks.push(b.kind),
     onStatus: (e) => {
       if (e.kind === "thinking") status.push({ phase: e.phase, label: e.label });
@@ -151,6 +153,31 @@ describe("DeepseekTuiAdapter", () => {
         system_prompt: "runtime memory",
         auto_approve: true,
       });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("sends systemRules in the thread system_prompt", async () => {
+    const server = await startMockDeepseekServer();
+    try {
+      await runAdapter(server.baseUrl, server.token, null, undefined, [
+        {
+          kind: "room_rule",
+          scope: "room",
+          id: "room:rm_team",
+          version: "sha256:abc",
+          roomId: "rm_team",
+          roomName: "Team",
+          text: "Only reply when useful.",
+        },
+      ]).result;
+      const createCall = server.calls.find(
+        (c) => c.method === "POST" && c.url === "/v1/threads",
+      );
+      expect(createCall?.body.system_prompt).toContain("[BotCord Room Rule]");
+      expect(createCall?.body.system_prompt).toContain("Only reply when useful.");
+      expect(createCall?.body.system_prompt).toContain("runtime memory");
     } finally {
       await server.close();
     }

--- a/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
+++ b/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
@@ -1722,6 +1722,50 @@ describe("Dispatcher", () => {
     expect(observed).toEqual(["hello-context"]);
   });
 
+  it("passes room_rule as versioned systemRules instead of user prompt text", async () => {
+    let observed: RuntimeRunOptions | null = null;
+    const runtime = new FakeRuntime({
+      newSessionId: "sid",
+      observeRun: (opts) => {
+        observed = opts;
+      },
+    });
+    const { store, dir } = await makeStore();
+    tempDirs.push(dir);
+    const channel = new FakeChannel();
+    const dispatcher = new Dispatcher({
+      config: baseConfig(),
+      channels: new Map<string, ChannelAdapter>([[channel.id, channel]]),
+      runtime: () => runtime,
+      sessionStore: store,
+      log: silentLogger(),
+    });
+
+    await dispatcher.handle(
+      makeEnvelope({
+        id: "msg_rule",
+        conversation: { id: "rm_team", kind: "group", title: "Team" },
+        raw: {
+          room_id: "rm_team",
+          room_name: "Team",
+          room_rule: "Only reply when useful.",
+        },
+      }),
+    );
+
+    expect(observed?.systemRules).toHaveLength(1);
+    expect(observed?.systemRules?.[0]).toMatchObject({
+      kind: "room_rule",
+      id: "room:rm_team",
+      roomId: "rm_team",
+      roomName: "Team",
+      text: "Only reply when useful.",
+    });
+    expect(observed?.systemRules?.[0]?.version).toMatch(/^sha256:/);
+    expect(observed?.text).not.toContain("[Room Rule]");
+    expect(observed?.text).not.toContain("Only reply when useful.");
+  });
+
   it("buildSystemContext: hook is awaited before runtime.run runs", async () => {
     const order: string[] = [];
     const runtime = new FakeRuntime({

--- a/packages/daemon/src/gateway/__tests__/gemini-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/gemini-adapter.test.ts
@@ -1,9 +1,10 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { GeminiAdapter } from "../runtimes/gemini.js";
 import { geminiModule } from "../runtimes/registry.js";
+import type { RuntimeRunOptions } from "../types.js";
 
 // The adapter spawns whatever binary we point it at; we point it at a small
 // Node script so we control stdout/stderr/exit precisely without needing the
@@ -36,6 +37,7 @@ function runAdapter(
   opts: {
     sessionId?: string | null;
     systemContext?: string;
+    systemRules?: RuntimeRunOptions["systemRules"];
     extraArgs?: string[];
     onBlock?: (kind: string) => void;
     onStatus?: (e: { phase: string; label?: string }) => void;
@@ -51,6 +53,7 @@ function runAdapter(
     signal: ctrl.signal,
     trustLevel: "owner",
     systemContext: opts.systemContext,
+    systemRules: opts.systemRules,
     extraArgs: opts.extraArgs,
     onBlock: opts.onBlock ? (b) => opts.onBlock!(b.kind) : undefined,
     onStatus: opts.onStatus
@@ -219,6 +222,40 @@ process.stdout.write(JSON.stringify({type:"result", status:"success", stats:{}})
     );
     const res = await runAdapter(script, { systemContext: "   \n\n  " });
     expect(res.text).toBe("hi");
+  });
+
+  it("writes systemRules to a managed GEMINI.md section without adding them to -p", async () => {
+    const script = makeScript(
+      "echo-rule-prompt.js",
+      `
+const argv = process.argv.slice(2);
+const pIdx = argv.indexOf("-p");
+const prompt = pIdx >= 0 ? argv[pIdx + 1] : "";
+process.stdout.write(JSON.stringify({type:"init", session_id:"s-rule"}) + "\\n");
+process.stdout.write(JSON.stringify({type:"message", role:"assistant", content:prompt, delta:true}) + "\\n");
+process.stdout.write(JSON.stringify({type:"result", status:"success", stats:{}}) + "\\n");
+`,
+    );
+    writeFileSync(path.join(tmpRoot, "GEMINI.md"), "existing instructions\n", "utf8");
+    const res = await runAdapter(script, {
+      systemRules: [
+        {
+          kind: "room_rule",
+          scope: "room",
+          id: "room:rm_team",
+          version: "sha256:abc",
+          roomId: "rm_team",
+          roomName: "Team",
+          text: "Only reply when useful.",
+        },
+      ],
+    });
+    expect(res.text).toBe("hi");
+    const geminiMd = readFileSync(path.join(tmpRoot, "GEMINI.md"), "utf8");
+    expect(geminiMd).toContain("existing instructions");
+    expect(geminiMd).toContain("BOTCORD_SYSTEM_RULES_START");
+    expect(geminiMd).toContain("[BotCord Room Rule]");
+    expect(geminiMd).toContain("Only reply when useful.");
   });
 
   it("does not double-add --yolo when extraArgs already supplies --approval-mode", async () => {

--- a/packages/daemon/src/gateway/__tests__/kimi-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/kimi-adapter.test.ts
@@ -1,9 +1,10 @@
 import { afterAll, describe, expect, it } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, chmodSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, chmodSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { KimiAdapter } from "../runtimes/kimi.js";
 import { createRuntime, envVarForRuntime, listRuntimeIds } from "../runtimes/registry.js";
+import type { RuntimeRunOptions } from "../types.js";
 
 const tmpRoot = mkdtempSync(path.join(os.tmpdir(), "gateway-kimi-"));
 
@@ -18,7 +19,12 @@ afterAll(() => {
   rmSync(tmpRoot, { recursive: true, force: true });
 });
 
-function runAdapter(script: string, sessionId: string | null = null, extraArgs?: string[]) {
+function runAdapter(
+  script: string,
+  sessionId: string | null = null,
+  extraArgs?: string[],
+  systemRules?: RuntimeRunOptions["systemRules"],
+) {
   const adapter = new KimiAdapter({ binary: script });
   const ctrl = new AbortController();
   return adapter.run({
@@ -29,6 +35,7 @@ function runAdapter(script: string, sessionId: string | null = null, extraArgs?:
     signal: ctrl.signal,
     trustLevel: "owner",
     extraArgs,
+    systemRules,
   });
 }
 
@@ -189,6 +196,33 @@ process.stdout.write(JSON.stringify({role:"assistant", content:prompt}) + "\\n")
     expect(res.text).toContain("<system-reminder>");
     expect(res.text).toContain("MEMORY: remember X");
     expect(res.text).toContain("do the thing");
+  });
+
+  it("writes systemRules to .kimi/AGENTS.md without adding them to --prompt", async () => {
+    const script = makeScript(
+      "echo-rule-prompt.js",
+      `
+const argv = process.argv.slice(2);
+const prompt = argv[argv.indexOf("--prompt") + 1];
+process.stdout.write(JSON.stringify({role:"assistant", content:prompt}) + "\\n");
+`,
+    );
+    const res = await runAdapter(script, null, undefined, [
+      {
+        kind: "room_rule",
+        scope: "room",
+        id: "room:rm_team",
+        version: "sha256:abc",
+        roomId: "rm_team",
+        roomName: "Team",
+        text: "Only reply when useful.",
+      },
+    ]);
+    expect(res.text).toBe("hi");
+    const body = readFileSync(path.join(tmpRoot, ".kimi", "AGENTS.md"), "utf8");
+    expect(body).toContain("[BotCord Room Rule]");
+    expect(body).toContain("version: sha256:abc");
+    expect(body).toContain("Only reply when useful.");
   });
 
   it("recognizes tool_use and tool_result blocks", async () => {

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -20,6 +20,7 @@ import {
 import { resolveRoute } from "./router.js";
 import { sessionKey, type SessionStore } from "./session-store.js";
 import { clearWaitMarker, consumeWaitMarker, resolveWaitMarkerPath, MAX_WAIT_MS } from "./wait-marker.js";
+import { buildRoomSystemRules } from "../system-rules.js";
 import {
   truncateTextField,
   type DeliveryStatus,
@@ -1712,6 +1713,7 @@ export class Dispatcher {
         });
       }
     }
+    const systemRules = buildRoomSystemRules(msg);
 
     if (this.buildMemoryContext) {
       try {
@@ -1767,6 +1769,7 @@ export class Dispatcher {
             signal: controller.signal,
             trustLevel,
             systemContext,
+            ...(systemRules.length > 0 ? { systemRules } : {}),
             onBlock,
             onStatus,
             context: {

--- a/packages/daemon/src/gateway/runtimes/claude-code.ts
+++ b/packages/daemon/src/gateway/runtimes/claude-code.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { NdjsonStreamAdapter, type NdjsonEventCtx } from "./ndjson-stream.js";
 import { consoleLogger } from "../log.js";
 import { looksLikeRuntimeAuthFailure } from "../runtime-errors.js";
+import { prependSystemRules } from "../../system-rules.js";
 import {
   firstExistingPath,
   readCommandVersion,
@@ -268,8 +269,9 @@ export class ClaudeCodeAdapter extends NdjsonStreamAdapter {
     // Claude Code's `--append-system-prompt` is applied per invocation and NOT
     // persisted in the resumed session transcript — ideal for memory / digest
     // content that should re-evaluate every turn.
-    if (opts.systemContext && !extraArgs.includes("--append-system-prompt")) {
-      args.push("--append-system-prompt", opts.systemContext);
+    const systemPrompt = prependSystemRules(opts.systemContext, opts.systemRules);
+    if (systemPrompt && !extraArgs.includes("--append-system-prompt")) {
+      args.push("--append-system-prompt", systemPrompt);
     }
     if (extraArgs.length) args.push(...extraArgs);
     return args;

--- a/packages/daemon/src/gateway/runtimes/codex.ts
+++ b/packages/daemon/src/gateway/runtimes/codex.ts
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, renameSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { agentCodexHomeDir, ensureAgentCodexHome } from "../../agent-workspace.js";
+import { prependSystemRules } from "../../system-rules.js";
 import { buildCliEnv } from "../cli-resolver.js";
 import { NdjsonStreamAdapter, type NdjsonEventCtx } from "./ndjson-stream.js";
 import {
@@ -194,7 +195,7 @@ export class CodexAdapter extends NdjsonStreamAdapter {
     if (opts.accountId) {
       try {
         ensureAgentCodexHome(opts.accountId);
-        writeCodexAgentsMd(opts.accountId, opts.systemContext);
+        writeCodexAgentsMd(opts.accountId, prependSystemRules(opts.systemContext, opts.systemRules));
       } catch (err) {
         // Writing AGENTS.md should never abort the turn — log and fall
         // through. The child will spawn without the dynamic systemContext,

--- a/packages/daemon/src/gateway/runtimes/deepseek-tui.ts
+++ b/packages/daemon/src/gateway/runtimes/deepseek-tui.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import net from "node:net";
 import { buildCliEnv } from "../cli-resolver.js";
 import { consoleLogger } from "../log.js";
+import { prependSystemRules } from "../../system-rules.js";
 import {
   readCommandVersion,
   resolveCommandOnPath,
@@ -125,12 +126,12 @@ export class DeepseekTuiAdapter implements RuntimeAdapter {
 
       if (!threadId) {
         threadId = await this.createThread(handle.baseUrl, headers, opts, turnAbort.signal);
-      } else if (opts.systemContext !== undefined) {
+      } else if (opts.systemContext !== undefined || opts.systemRules?.length) {
         await this.patchThreadSystemContext(
           handle.baseUrl,
           headers,
           threadId,
-          opts.systemContext,
+          prependSystemRules(opts.systemContext, opts.systemRules),
           turnAbort.signal,
         );
       }
@@ -267,7 +268,8 @@ export class DeepseekTuiAdapter implements RuntimeAdapter {
     const selection = parseDeepseekRuntimeSelection(opts.extraArgs);
     if (selection.model) body.model = selection.model;
     if (selection.reasoningEffort) body.reasoning_effort = selection.reasoningEffort;
-    if (opts.systemContext) body.system_prompt = opts.systemContext;
+    const systemPrompt = prependSystemRules(opts.systemContext, opts.systemRules);
+    if (systemPrompt) body.system_prompt = systemPrompt;
     const res = await this.requestJson<any>(`${baseUrl}/v1/threads`, {
       method: "POST",
       headers,

--- a/packages/daemon/src/gateway/runtimes/gemini.ts
+++ b/packages/daemon/src/gateway/runtimes/gemini.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+import { writeManagedSystemRulesFile } from "../../system-rules.js";
 import { NdjsonStreamAdapter, type NdjsonEventCtx } from "./ndjson-stream.js";
 import {
   readCommandVersion,
@@ -128,12 +130,12 @@ export function probeGemini(deps: ProbeDeps = {}): RuntimeProbeResult {
  * Gemini's headless mode has no `--append-system-prompt` equivalent and
  * `GEMINI_SYSTEM_MD` replaces the entire core system prompt (which would
  * brick the agent — that core prompt scaffolds tool use). For v1 the
- * adapter prepends `systemContext` directly to the positional prompt. Each
- * turn re-injects the dynamic context so memory / digest updates take
+ * adapter prepends dynamic `systemContext` directly to the positional prompt.
+ * Each turn re-injects the dynamic context so memory / digest updates take
  * effect immediately; the trade-off is the resumed session transcript
- * accumulates one prompt prefix per turn. Acceptable while we ship the
- * connectivity layer — a follow-up can move systemContext into a
- * daemon-managed `GEMINI.md` once we decide where to isolate it.
+ * accumulates one prompt prefix per turn. Stable BotCord `systemRules` (room
+ * rules) are different: they are written into a daemon-managed section of
+ * `<cwd>/GEMINI.md` before spawn so they do not repeat in user messages.
  *
  * ## Session continuity
  *
@@ -167,6 +169,7 @@ export class GeminiAdapter extends NdjsonStreamAdapter {
     if (opts.sessionId && !isValidGeminiSessionId(opts.sessionId)) {
       throw new Error(invalidGeminiSessionIdError(opts.sessionId));
     }
+    writeGeminiSystemRules(opts);
     return super.run(opts);
   }
 
@@ -291,6 +294,18 @@ export class GeminiAdapter extends NdjsonStreamAdapter {
 function composePrompt(text: string, systemContext: string | undefined): string {
   if (!systemContext || !systemContext.trim()) return text;
   return `${systemContext.trim()}\n\n---\n\n${text}`;
+}
+
+function writeGeminiSystemRules(opts: RuntimeRunOptions): void {
+  if (!opts.systemRules?.length) return;
+  try {
+    writeManagedSystemRulesFile(path.join(opts.cwd, "GEMINI.md"), opts.systemRules, {
+      mergeWithExisting: true,
+    });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn("gemini: failed to write BotCord system rules to GEMINI.md", err);
+  }
 }
 
 /**

--- a/packages/daemon/src/gateway/runtimes/kimi.ts
+++ b/packages/daemon/src/gateway/runtimes/kimi.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { writeManagedSystemRulesFile } from "../../system-rules.js";
 import { buildCliEnv } from "../cli-resolver.js";
 import { NdjsonStreamAdapter, type NdjsonEventCtx } from "./ndjson-stream.js";
 import {
@@ -154,7 +156,9 @@ export function probeKimi(deps: ProbeDeps = {}): RuntimeProbeResult {
  * that id, so the adapter generates a UUID on first turn and persists it for
  * later turns. Kimi does not expose a Codex-style per-invocation AGENTS.md
  * carrier, so dynamic `systemContext` is sent as a system-reminder prefix on
- * the user prompt.
+ * the user prompt. Stable BotCord `systemRules` (room rules) are written to
+ * `<cwd>/.kimi/AGENTS.md` before spawn; Kimi freezes the system prompt per
+ * session, so rule updates may require a fresh session to take effect.
  */
 export class KimiAdapter extends NdjsonStreamAdapter {
   readonly id = "kimi-cli" as const;
@@ -175,6 +179,7 @@ export class KimiAdapter extends NdjsonStreamAdapter {
     if (opts.sessionId && !isValidKimiSessionId(opts.sessionId)) {
       return { text: "", newSessionId: "", error: invalidKimiSessionIdError() };
     }
+    writeKimiSystemRules(opts);
     const sessionId = opts.sessionId || randomUUID();
     return super.run({ ...opts, sessionId });
   }
@@ -277,6 +282,16 @@ type KimiStreamJsonEvent = {
 function promptWithSystemContext(text: string, systemContext: string | undefined): string {
   if (!systemContext) return text;
   return `<system-reminder>\n${systemContext}\n</system-reminder>\n\n${text}`;
+}
+
+function writeKimiSystemRules(opts: RuntimeRunOptions): void {
+  if (!opts.systemRules?.length) return;
+  try {
+    writeManagedSystemRulesFile(path.join(opts.cwd, ".kimi", "AGENTS.md"), opts.systemRules);
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn("kimi-cli: failed to write BotCord system rules to .kimi/AGENTS.md", err);
+  }
 }
 
 function extractText(content: KimiStreamJsonEvent["content"]): string {

--- a/packages/daemon/src/gateway/types.ts
+++ b/packages/daemon/src/gateway/types.ts
@@ -344,6 +344,16 @@ export type RuntimeStatusEvent =
       raw?: unknown;
     };
 
+export interface RuntimeSystemRule {
+  kind: "room_rule";
+  scope: "room";
+  id: string;
+  version: string;
+  roomId: string;
+  roomName?: string;
+  text: string;
+}
+
 /** Options passed to a runtime adapter for a single turn. */
 export interface RuntimeRunOptions {
   text: string;
@@ -378,6 +388,12 @@ export interface RuntimeRunOptions {
   trustLevel: TrustLevel;
   /** System-level context injected alongside the user turn (memory, digest, room info). */
   systemContext?: string;
+  /**
+   * Stable system rules that must not be persisted as user messages. Runtimes
+   * choose the least-polluting carrier they support: per-turn system prompt,
+   * thread system prompt, or daemon-managed instruction files.
+   */
+  systemRules?: RuntimeSystemRule[];
   /** Channel-agnostic bag for dispatch-time data (traceId, channel, conversation, etc.). */
   context?: Record<string, unknown>;
   /**

--- a/packages/daemon/src/room-context-fetcher.ts
+++ b/packages/daemon/src/room-context-fetcher.ts
@@ -91,9 +91,6 @@ export function createRoomContextFetcher(
           ...(typeof room.description === "string"
             ? { description: room.description }
             : {}),
-          ...(typeof room.rule === "string" || room.rule === null
-            ? { rule: (room.rule as string | null) ?? null }
-            : {}),
           ...(typeof room.visibility === "string"
             ? { visibility: room.visibility }
             : {}),

--- a/packages/daemon/src/room-context.ts
+++ b/packages/daemon/src/room-context.ts
@@ -1,6 +1,8 @@
 /**
- * Room static context builder — injects room name, description, rule, and
- * member list into the system prompt for group conversations. Mirrors
+ * Room static context builder — injects room name, description, and member
+ * list into the system prompt for group conversations. Room rules are carried
+ * separately as versioned runtime system rules so they do not repeat in user
+ * messages. Mirrors
  * `plugin/src/room-context.ts#buildRoomStaticContext` so Claude Code in
  * daemon-mode carries the same awareness as when hosted by OpenClaw.
  *
@@ -20,7 +22,6 @@ export interface RoomInfoSnapshot {
   room_id: string;
   name?: string;
   description?: string;
-  rule?: string | null;
   visibility?: string;
   join_policy?: string;
   member_count?: number;
@@ -83,9 +84,6 @@ export function renderRoomContextBlock(
   ];
   if (room.description) {
     lines.push(`Description: ${sanitizeUntrustedContent(room.description)}`);
-  }
-  if (room.rule) {
-    lines.push(`Rule: ${sanitizeUntrustedContent(room.rule)}`);
   }
   if (room.visibility || room.join_policy) {
     const visibility = room.visibility ?? "unknown";

--- a/packages/daemon/src/system-context.ts
+++ b/packages/daemon/src/system-context.ts
@@ -9,7 +9,8 @@
  *   1. `[BotCord Identity]` (read fresh from workspace/identity.md each turn)
  *   2. `[BotCord Scene: Owner Chat]` (owner-trust turns only)
  *   3. `[BotCord Working Memory]`
- *   4. `[BotCord Room Context]` (group rooms, via optional async fetcher)
+ *   4. `[BotCord Room Context]` (group rooms, via optional async fetcher;
+ *      room rules are carried separately as `RuntimeRunOptions.systemRules`)
  *   5. `[BotCord Cross-Room Awareness]` (optional activity tracker)
  *   6. `[BotCord Daemon Skill Index]` (soft skill hot-reload index)
  *
@@ -83,7 +84,7 @@ export interface SystemContextDeps {
   /**
    * Optional per-turn room-context fetcher. When wired, group-room turns
    * receive the `[BotCord Room Context]` block (room name, description,
-   * rule, members). Omitting keeps the builder synchronous and the block
+   * members). Omitting keeps the builder synchronous and the block
    * is skipped.
    */
   roomContextBuilder?: RoomStaticContextBuilder;

--- a/packages/daemon/src/system-rules.ts
+++ b/packages/daemon/src/system-rules.ts
@@ -1,0 +1,138 @@
+import { createHash } from "crypto";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "fs";
+import path from "path";
+import { sanitizeSenderName, sanitizeUntrustedContent } from "./gateway/channels/sanitize.js";
+import type { GatewayInboundMessage, RuntimeSystemRule } from "./gateway/types.js";
+
+const MANAGED_RULES_START = "<!-- BOTCORD_SYSTEM_RULES_START -->";
+const MANAGED_RULES_END = "<!-- BOTCORD_SYSTEM_RULES_END -->";
+
+interface RoomRuleRaw {
+  room_id?: unknown;
+  room_name?: unknown;
+  room_rule?: unknown;
+}
+
+function sha256(s: string): string {
+  return createHash("sha256").update(s, "utf8").digest("hex");
+}
+
+export function buildRoomSystemRules(message: GatewayInboundMessage): RuntimeSystemRule[] {
+  if (message.conversation.kind !== "group") return [];
+  const raw = message.raw && typeof message.raw === "object" ? (message.raw as RoomRuleRaw) : {};
+  const text = typeof raw.room_rule === "string" ? raw.room_rule.trim() : "";
+  if (!text) return [];
+
+  const roomId =
+    typeof raw.room_id === "string" && raw.room_id ? raw.room_id : message.conversation.id;
+  const roomName =
+    typeof raw.room_name === "string" && raw.room_name
+      ? raw.room_name
+      : typeof message.conversation.title === "string"
+        ? message.conversation.title
+        : undefined;
+
+  return [
+    {
+      kind: "room_rule",
+      scope: "room",
+      id: `room:${roomId}`,
+      version: `sha256:${sha256(text)}`,
+      roomId,
+      ...(roomName ? { roomName } : {}),
+      text,
+    },
+  ];
+}
+
+export function renderSystemRules(rules: RuntimeSystemRule[] | undefined): string | null {
+  if (!rules || rules.length === 0) return null;
+  const blocks = rules.map((rule) => {
+    if (rule.kind === "room_rule") {
+      const fields = [
+        `id: ${sanitizeSenderName(rule.roomId)}`,
+        `version: ${sanitizeSenderName(rule.version)}`,
+      ];
+      if (rule.roomName) fields.push(`name: ${sanitizeSenderName(rule.roomName)}`);
+      return [
+        "[BotCord Room Rule]",
+        fields.join(" | "),
+        sanitizeUntrustedContent(rule.text.trim()),
+      ].join("\n");
+    }
+    return null;
+  });
+  const filtered = blocks.filter((b): b is string => typeof b === "string" && b.length > 0);
+  return filtered.length > 0 ? filtered.join("\n\n") : null;
+}
+
+export function prependSystemRules(
+  systemContext: string | undefined,
+  rules: RuntimeSystemRule[] | undefined,
+): string | undefined {
+  const ruleBlock = renderSystemRules(rules);
+  const parts = [ruleBlock, systemContext].filter(
+    (part): part is string => typeof part === "string" && part.trim().length > 0,
+  );
+  return parts.length > 0 ? parts.join("\n\n") : undefined;
+}
+
+export function managedSystemRulesSection(
+  rules: RuntimeSystemRule[] | undefined,
+): string | null {
+  const rendered = renderSystemRules(rules);
+  if (!rendered) return null;
+  return [
+    MANAGED_RULES_START,
+    "This section is managed by BotCord daemon. Do not edit it manually.",
+    "",
+    rendered,
+    MANAGED_RULES_END,
+  ].join("\n");
+}
+
+export function replaceManagedSystemRulesSection(
+  existing: string,
+  rules: RuntimeSystemRule[] | undefined,
+): string {
+  const section = managedSystemRulesSection(rules);
+  const start = existing.indexOf(MANAGED_RULES_START);
+  const end = existing.indexOf(MANAGED_RULES_END);
+  if (start >= 0 && end >= start) {
+    const afterEnd = end + MANAGED_RULES_END.length;
+    const before = existing.slice(0, start).trimEnd();
+    const after = existing.slice(afterEnd).trimStart();
+    const parts = [before, section, after].filter(
+      (part): part is string => typeof part === "string" && part.length > 0,
+    );
+    return parts.length > 0 ? `${parts.join("\n\n")}\n` : "";
+  }
+  if (!section) return existing;
+  const trimmed = existing.trimEnd();
+  return trimmed ? `${trimmed}\n\n${section}\n` : `${section}\n`;
+}
+
+export function writeManagedSystemRulesFile(
+  filePath: string,
+  rules: RuntimeSystemRule[] | undefined,
+  opts: { mergeWithExisting?: boolean } = {},
+): void {
+  const existing =
+    opts.mergeWithExisting
+      ? (() => {
+          try {
+            return readFileSync(filePath, "utf8");
+          } catch {
+            return "";
+          }
+        })()
+      : "";
+  const next = opts.mergeWithExisting
+    ? replaceManagedSystemRulesSection(existing, rules)
+    : `${managedSystemRulesSection(rules) ?? ""}\n`;
+  if (existing === next) return;
+  mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  const tmp = path.join(path.dirname(filePath), `.${path.basename(filePath)}.${process.pid}.tmp`);
+  writeFileSync(tmp, next, { mode: 0o600 });
+  renameSync(tmp, filePath);
+}

--- a/packages/daemon/src/turn-text.ts
+++ b/packages/daemon/src/turn-text.ts
@@ -134,7 +134,6 @@ interface ReplyPreviewRaw {
 interface RoomContextRaw {
   room_id?: unknown;
   room_name?: unknown;
-  room_rule?: unknown;
   room_member_count?: unknown;
   room_member_names?: unknown;
   my_role?: unknown;
@@ -270,11 +269,7 @@ function formatRoomContext(raw: unknown, fallback: { id: string; title?: string 
   if (role) parts.push(`role: ${sanitizeSenderName(role)}`);
   if (canSend !== undefined) parts.push(`can_send: ${canSend ? "true" : "false"}`);
 
-  const lines = [`[BotCord Room] | ${parts.join(" | ")}`];
-  if (typeof r.room_rule === "string" && r.room_rule.trim()) {
-    lines.push(`[Room Rule] ${sanitizeUntrustedContent(r.room_rule.trim())}`);
-  }
-  return lines;
+  return [`[BotCord Room] | ${parts.join(" | ")}`];
 }
 
 /**


### PR DESCRIPTION
## Summary

Room rules used to ride inside the `[BotCord Room Context]` system block and the per-message room-context line. Because group turns re-inject context and resume the same session, the rule text re-accumulated in the transcript turn after turn.

This change extracts room rules into a dedicated, versioned channel and lets each runtime pick the least-polluting carrier it supports.

## What changed

- **New `system-rules.ts`** — `buildRoomSystemRules(message)` produces a `RuntimeSystemRule` (`kind: "room_rule"`, sha256-stamped `version`) from the inbound `room_rule`. Also owns rendering (`renderSystemRules`/`prependSystemRules`) and the daemon-managed file write path (`writeManagedSystemRulesFile`, atomic temp+rename, `0o600`).
- **`types.ts`** — adds `RuntimeSystemRule` and `RuntimeRunOptions.systemRules`.
- **`dispatcher.ts`** — builds `systemRules` per turn and passes them through.
- **Runtimes**:
  - Claude Code / Codex / DeepSeek — prepend rules to the per-turn system prompt (`--append-system-prompt` / `AGENTS.md` / thread `system_prompt`).
  - Gemini / Kimi — write a daemon-managed section into `GEMINI.md` / `.kimi/AGENTS.md` before spawn (no per-turn system-prompt carrier available).
- **`room-context.ts` / `room-context-fetcher.ts` / `system-context.ts` / `turn-text.ts`** — stop emitting the rule, so it no longer repeats in user-facing turns.

## Test plan

- `pnpm --filter @botcord/daemon build` — clean
- `pnpm --filter @botcord/daemon test` — **1026 passed (76 files)**, including new `system-rules.test.ts` and updated adapter/context tests.

Changeset: `@botcord/daemon` minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)