### PR TITLE
feat(daemon): proactively rotate runtime sessions to cap Codex context growth

### DIFF
--- a/packages/daemon/scripts/session-usage-report.mjs
+++ b/packages/daemon/scripts/session-usage-report.mjs
@@ -1,0 +1,301 @@
+#!/usr/bin/env node
+// Codex session token-usage report for BotCord daemon hosts.
+//
+// Scans local Codex rollout transcripts under
+//   <root>/agents/<agentId>/codex-home/sessions/**/*.jsonl
+// and reports token usage per agent / room / session, joining the daemon's
+// session map (<root>/daemon/sessions.json) to attach the BotCord room each
+// session belongs to. Built to answer "which session/room/agent is burning
+// tokens" and to alert (non-zero exit) when a session crosses a threshold.
+//
+// Each Codex `token_count` event carries `info.total_token_usage` (cumulative
+// for the session so far) and `info.last_token_usage` (the most recent model
+// call). We take the LAST token_count event for a session's cumulative total
+// and track the PEAK `last_token_usage.input_tokens` — the latter is the same
+// signal the daemon's proactive rotation watches, so this surfaces sessions
+// that should have rotated.
+//
+// Usage:
+//   node session-usage-report.mjs [--since=24h] [--top=20] [--by-room]
+//     [--alert-last-input=160000] [--alert-total=5000000] [--root=~/.botcord]
+//     [--json]
+//
+// Exit codes: 0 = ok, 2 = at least one session tripped an alert threshold.
+
+import { createReadStream } from "node:fs";
+import { readFile, readdir, stat } from "node:fs/promises";
+import { createInterface } from "node:readline";
+import os from "node:os";
+import path from "node:path";
+
+function parseArgs(argv) {
+  const out = {
+    since: "24h",
+    top: 20,
+    byRoom: false,
+    alertLastInput: 160_000,
+    alertTotal: 5_000_000,
+    root: path.join(os.homedir(), ".botcord"),
+    json: false,
+  };
+  for (const arg of argv) {
+    const m = /^--([a-z-]+)(?:=(.*))?$/.exec(arg);
+    if (!m) continue;
+    const [, key, val] = m;
+    switch (key) {
+      case "since": out.since = val ?? out.since; break;
+      case "top": out.top = Number(val) || out.top; break;
+      case "by-room": out.byRoom = true; break;
+      case "alert-last-input": out.alertLastInput = Number(val) || 0; break;
+      case "alert-total": out.alertTotal = Number(val) || 0; break;
+      case "root": out.root = val ? expandHome(val) : out.root; break;
+      case "json": out.json = true; break;
+      default: break;
+    }
+  }
+  return out;
+}
+
+function expandHome(p) {
+  return p.startsWith("~") ? path.join(os.homedir(), p.slice(1)) : p;
+}
+
+/** Parse a `--since` value (`24h`, `7d`, `90m`, or an ISO date) to an epoch ms cutoff. */
+function sinceCutoff(since) {
+  const rel = /^(\d+)([mhd])$/.exec(since);
+  if (rel) {
+    const n = Number(rel[1]);
+    const unit = { m: 60_000, h: 3_600_000, d: 86_400_000 }[rel[2]];
+    return Date.now() - n * unit;
+  }
+  const t = Date.parse(since);
+  return Number.isFinite(t) ? t : Date.now() - 86_400_000;
+}
+
+/** Recursively collect *.jsonl files under dir. */
+async function findJsonl(dir) {
+  const found = [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return found;
+  }
+  for (const e of entries) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) found.push(...(await findJsonl(full)));
+    else if (e.isFile() && e.name.endsWith(".jsonl")) found.push(full);
+  }
+  return found;
+}
+
+/** Load <root>/daemon/sessions.json into a runtimeSessionId -> entry map. */
+async function loadSessionMap(root) {
+  const map = new Map();
+  try {
+    const raw = await readFile(path.join(root, "daemon", "sessions.json"), "utf8");
+    const parsed = JSON.parse(raw);
+    for (const entry of Object.values(parsed.entries ?? {})) {
+      if (entry?.runtimeSessionId) map.set(entry.runtimeSessionId, entry);
+    }
+  } catch {
+    // No map (or unreadable) — sessions just report room=unknown.
+  }
+  return map;
+}
+
+const EMPTY = { input_tokens: 0, cached_input_tokens: 0, output_tokens: 0, reasoning_output_tokens: 0, total_tokens: 0 };
+
+/**
+ * Stream one rollout file, extracting the session id, the final cumulative
+ * usage, the peak single-turn input, the last activity timestamp, and the
+ * subagent flag. Streams line-by-line so multi-MB transcripts stay cheap.
+ */
+async function scanFile(file) {
+  const rl = createInterface({ input: createReadStream(file), crlfDelay: Infinity });
+  let sessionId = null;
+  let subagent = false;
+  let cwd = null;
+  let total = { ...EMPTY };
+  let peakLastInput = 0;
+  let contextWindow = null;
+  let lastTs = null;
+  for await (const line of rl) {
+    if (!line) continue;
+    let o;
+    try { o = JSON.parse(line); } catch { continue; }
+    if (o.timestamp) lastTs = o.timestamp;
+    if (o.type === "session_meta") {
+      sessionId = o.payload?.id ?? sessionId;
+      cwd = o.payload?.cwd ?? cwd;
+      subagent = o.payload?.thread_source === "subagent";
+      continue;
+    }
+    if (o.type === "event_msg" && o.payload?.type === "token_count") {
+      const info = o.payload.info ?? {};
+      if (info.total_token_usage) total = info.total_token_usage;
+      const li = info.last_token_usage?.input_tokens ?? 0;
+      if (li > peakLastInput) peakLastInput = li;
+      if (info.model_context_window) contextWindow = info.model_context_window;
+    }
+  }
+  return {
+    file,
+    sessionId,
+    subagent,
+    cwd,
+    total,
+    peakLastInput,
+    contextWindow,
+    lastTs: lastTs ? Date.parse(lastTs) : null,
+  };
+}
+
+/** Extract the agent id from a sessions path: .../agents/<agentId>/codex-home/... */
+function agentIdFromPath(file) {
+  const m = /\/agents\/([^/]+)\/codex-home\//.exec(file);
+  return m ? m[1] : "unknown";
+}
+
+function fmt(n) {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+function pad(s, w) {
+  s = String(s);
+  return s.length >= w ? s : s + " ".repeat(w - s.length);
+}
+
+/** Fixed-width cell: truncate over-long values (with an ellipsis) so columns align. */
+function clip(s, w) {
+  s = String(s);
+  if (s.length > w - 1) s = `${s.slice(0, w - 2)}… `;
+  return pad(s, w);
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const cutoff = sinceCutoff(opts.since);
+  const agentsDir = path.join(opts.root, "agents");
+  const sessionMap = await loadSessionMap(opts.root);
+
+  const files = await findJsonl(agentsDir);
+  const scanned = [];
+  for (const file of files) {
+    // Cheap pre-filter on mtime so we don't stream ancient transcripts.
+    let mtime = 0;
+    try { mtime = (await stat(file)).mtimeMs; } catch { /* ignore */ }
+    if (mtime && mtime < cutoff) continue;
+    const r = await scanFile(file);
+    const ts = r.lastTs ?? mtime;
+    if (ts && ts < cutoff) continue;
+    const entry = r.sessionId ? sessionMap.get(r.sessionId) : undefined;
+    scanned.push({
+      ...r,
+      ts,
+      agentId: agentIdFromPath(file),
+      roomId: entry?.conversationId ?? (r.subagent ? "(subagent)" : "(rotated/unknown)"),
+      turnCount: entry?.turnCount ?? null,
+    });
+  }
+
+  scanned.sort((a, b) => (b.total.total_tokens ?? 0) - (a.total.total_tokens ?? 0));
+
+  // Aggregate per agent and (optionally) per room.
+  const byAgent = new Map();
+  const byRoom = new Map();
+  for (const s of scanned) {
+    const a = byAgent.get(s.agentId) ?? { sessions: 0, total: 0, output: 0, peakInput: 0 };
+    a.sessions += 1;
+    a.total += s.total.total_tokens ?? 0;
+    a.output += s.total.output_tokens ?? 0;
+    a.peakInput = Math.max(a.peakInput, s.peakLastInput);
+    byAgent.set(s.agentId, a);
+
+    const rk = `${s.agentId}::${s.roomId}`;
+    const r = byRoom.get(rk) ?? { agentId: s.agentId, roomId: s.roomId, sessions: 0, total: 0, peakInput: 0 };
+    r.sessions += 1;
+    r.total += s.total.total_tokens ?? 0;
+    r.peakInput = Math.max(r.peakInput, s.peakLastInput);
+    byRoom.set(rk, r);
+  }
+
+  const alerts = scanned.filter(
+    (s) =>
+      (opts.alertTotal > 0 && (s.total.total_tokens ?? 0) >= opts.alertTotal) ||
+      (opts.alertLastInput > 0 && s.peakLastInput >= opts.alertLastInput),
+  );
+
+  if (opts.json) {
+    console.log(JSON.stringify({
+      generatedAt: new Date().toISOString(),
+      since: opts.since,
+      thresholds: { alertTotal: opts.alertTotal, alertLastInput: opts.alertLastInput },
+      sessionsScanned: scanned.length,
+      byAgent: [...byAgent.entries()].map(([agentId, v]) => ({ agentId, ...v })),
+      byRoom: [...byRoom.values()],
+      topSessions: scanned.slice(0, opts.top).map((s) => ({
+        agentId: s.agentId,
+        roomId: s.roomId,
+        sessionId: s.sessionId,
+        subagent: s.subagent,
+        turnCount: s.turnCount,
+        totalTokens: s.total.total_tokens ?? 0,
+        cachedInputTokens: s.total.cached_input_tokens ?? 0,
+        outputTokens: s.total.output_tokens ?? 0,
+        peakLastInputTokens: s.peakLastInput,
+        contextWindow: s.contextWindow,
+        lastActivity: s.ts ? new Date(s.ts).toISOString() : null,
+      })),
+      alerts: alerts.map((s) => ({
+        agentId: s.agentId,
+        roomId: s.roomId,
+        sessionId: s.sessionId,
+        totalTokens: s.total.total_tokens ?? 0,
+        peakLastInputTokens: s.peakLastInput,
+      })),
+    }, null, 2));
+    process.exit(alerts.length ? 2 : 0);
+  }
+
+  console.log(`BotCord Codex session usage — since ${opts.since} (${scanned.length} sessions)\n`);
+
+  console.log("Per agent (by total tokens):");
+  console.log(`  ${pad("agent", 18)}${pad("sessions", 10)}${pad("total", 10)}${pad("output", 10)}peak-1turn-input`);
+  for (const [agentId, v] of [...byAgent.entries()].sort((a, b) => b[1].total - a[1].total)) {
+    console.log(`  ${pad(agentId, 18)}${pad(v.sessions, 10)}${pad(fmt(v.total), 10)}${pad(fmt(v.output), 10)}${fmt(v.peakInput)}`);
+  }
+
+  if (opts.byRoom) {
+    console.log("\nPer room (by total tokens):");
+    console.log(`  ${pad("agent", 18)}${pad("room", 24)}${pad("sessions", 10)}${pad("total", 10)}peak-1turn-input`);
+    for (const r of [...byRoom.values()].sort((a, b) => b.total - a.total)) {
+      console.log(`  ${pad(r.agentId, 18)}${clip(r.roomId, 24)}${pad(r.sessions, 10)}${pad(fmt(r.total), 10)}${fmt(r.peakInput)}`);
+    }
+  }
+
+  console.log(`\nTop ${opts.top} sessions:`);
+  console.log(`  ${pad("agent", 18)}${pad("room", 22)}${pad("turns", 7)}${pad("total", 9)}${pad("peak-in", 9)}${pad("ctx%", 6)}session`);
+  for (const s of scanned.slice(0, opts.top)) {
+    const ctxPct = s.contextWindow ? `${Math.round((s.peakLastInput / s.contextWindow) * 100)}%` : "-";
+    const flag = (opts.alertTotal > 0 && (s.total.total_tokens ?? 0) >= opts.alertTotal)
+      || (opts.alertLastInput > 0 && s.peakLastInput >= opts.alertLastInput) ? " ⚠" : "";
+    console.log(`  ${pad(s.agentId, 18)}${clip(s.roomId, 22)}${pad(s.turnCount ?? "-", 7)}${pad(fmt(s.total.total_tokens ?? 0), 9)}${pad(fmt(s.peakLastInput), 9)}${pad(ctxPct, 6)}${s.sessionId ?? "?"}${flag}`);
+  }
+
+  if (alerts.length) {
+    console.log(`\n⚠ ${alerts.length} session(s) over threshold (total>=${fmt(opts.alertTotal)} or peak-input>=${fmt(opts.alertLastInput)}):`);
+    for (const s of alerts) {
+      console.log(`  ${s.agentId} ${s.roomId} ${s.sessionId} total=${fmt(s.total.total_tokens ?? 0)} peak-input=${fmt(s.peakLastInput)}`);
+    }
+  }
+
+  process.exit(alerts.length ? 2 : 0);
+}
+
+main().catch((err) => {
+  console.error("session-usage-report failed:", err);
+  process.exit(1);
+});

--- a/packages/daemon/src/gateway/__tests__/codex-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/codex-adapter.test.ts
@@ -77,6 +77,45 @@ process.exit(0);
     expect(res.error).toBeUndefined();
   });
 
+  it("maps turn.completed.usage onto cache hit/miss + output tokens", async () => {
+    const script = makeScript(
+      "usage.js",
+      `
+const lines = [
+  {type:"thread.started", thread_id:"01234567-89ab-7def-8123-456789abcdef"},
+  {type:"item.completed", item:{id:"i0", type:"agent_message", text:"ok"}},
+  {type:"turn.completed", usage:{input_tokens:100000, cached_input_tokens:90000, output_tokens:500}},
+];
+for (const l of lines) process.stdout.write(JSON.stringify(l) + "\\n");
+process.exit(0);
+`,
+    );
+    const res = await runAdapter(script);
+    expect(res.inputCacheHitTokens).toBe(90000);
+    // miss = input_tokens - cached_input_tokens
+    expect(res.inputCacheMissTokens).toBe(10000);
+    expect(res.outputTokens).toBe(500);
+  });
+
+  it("leaves usage fields undefined when the turn reports none", async () => {
+    const script = makeScript(
+      "no-usage.js",
+      `
+const lines = [
+  {type:"thread.started", thread_id:"01234567-89ab-7def-8123-456789abcdef"},
+  {type:"item.completed", item:{id:"i0", type:"agent_message", text:"ok"}},
+  {type:"turn.completed"},
+];
+for (const l of lines) process.stdout.write(JSON.stringify(l) + "\\n");
+process.exit(0);
+`,
+    );
+    const res = await runAdapter(script);
+    expect(res.inputCacheHitTokens).toBeUndefined();
+    expect(res.inputCacheMissTokens).toBeUndefined();
+    expect(res.outputTokens).toBeUndefined();
+  });
+
   it("emits tool_use/tool_result StreamBlocks for command_execution items", async () => {
     const script = makeScript(
       "toolblock.js",

--- a/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
+++ b/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
@@ -93,6 +93,9 @@ interface FakeRuntimeOptions {
   >;
   hang?: boolean;
   observeRun?: (opts: RuntimeRunOptions) => void;
+  inputCacheHitTokens?: number;
+  inputCacheMissTokens?: number;
+  outputTokens?: number;
 }
 
 class FakeRuntime implements RuntimeAdapter {
@@ -156,6 +159,15 @@ class FakeRuntime implements RuntimeAdapter {
       text: this.opts.reply ?? "hello back",
       newSessionId,
       ...(this.opts.errorText ? { error: this.opts.errorText } : {}),
+      ...(this.opts.inputCacheHitTokens !== undefined
+        ? { inputCacheHitTokens: this.opts.inputCacheHitTokens }
+        : {}),
+      ...(this.opts.inputCacheMissTokens !== undefined
+        ? { inputCacheMissTokens: this.opts.inputCacheMissTokens }
+        : {}),
+      ...(this.opts.outputTokens !== undefined
+        ? { outputTokens: this.opts.outputTokens }
+        : {}),
     };
   }
 }
@@ -256,6 +268,8 @@ describe("Dispatcher", () => {
     runtimeAuthFailureCooldownMs?: number;
     buildRuntimeRecoveryContext?: (message: GatewayInboundMessage) => Promise<string | null> | string | null;
     transcript?: TranscriptWriter;
+    maxResumeInputTokens?: number;
+    maxResumeTurns?: number;
   }) {
     const { store, dir } = await makeStore();
     tempDirs.push(dir);
@@ -272,6 +286,12 @@ describe("Dispatcher", () => {
       runtimeAuthFailureCooldownMs: args.runtimeAuthFailureCooldownMs,
       buildRuntimeRecoveryContext: args.buildRuntimeRecoveryContext,
       transcript: args.transcript,
+      ...(args.maxResumeInputTokens !== undefined
+        ? { maxResumeInputTokens: args.maxResumeInputTokens }
+        : {}),
+      ...(args.maxResumeTurns !== undefined
+        ? { maxResumeTurns: args.maxResumeTurns }
+        : {}),
     });
     return { dispatcher, channel, store };
   }
@@ -326,6 +346,98 @@ describe("Dispatcher", () => {
     expect(store.all().length).toBe(1);
     expect(store.all()[0].runtimeSessionId).toBe("new-sid");
     expect(store.all()[0].threadId).toBe("t_1");
+  });
+
+  it("persists turnCount and reported input tokens on the session entry", async () => {
+    const runtime = new FakeRuntime({
+      reply: "ok",
+      newSessionId: "sid-x",
+      inputCacheHitTokens: 9000,
+      inputCacheMissTokens: 1000,
+    });
+    const { dispatcher, store } = await scaffold({ runtimeFactory: () => runtime });
+
+    await dispatcher.handle(makeEnvelope({ id: "m1" }));
+
+    const entry = store.all()[0];
+    expect(entry.turnCount).toBe(1);
+    expect(entry.lastInputTokens).toBe(10000);
+  });
+
+  it("increments turnCount across resumes below the thresholds", async () => {
+    const runtime = new FakeRuntime({ reply: "ok", newSessionId: "sid-1" });
+    const { dispatcher, store } = await scaffold({
+      runtimeFactory: () => runtime,
+      maxResumeTurns: 10,
+      maxResumeInputTokens: 0,
+    });
+
+    await dispatcher.handle(makeEnvelope({ id: "m1" }));
+    await dispatcher.handle(makeEnvelope({ id: "m2" }));
+
+    // Second turn resumed the existing session rather than rotating.
+    const secondCall = runtime.calls[runtime.calls.length - 1];
+    expect(secondCall.sessionId).toBe("sid-1");
+    expect(store.all()[0].turnCount).toBe(2);
+  });
+
+  it("rotates to a fresh session when turnCount reaches the threshold", async () => {
+    const runtime = new FakeRuntime({ reply: "ok", newSessionId: "sid-1" });
+    const { dispatcher, store } = await scaffold({
+      runtimeFactory: () => runtime,
+      maxResumeTurns: 3,
+      maxResumeInputTokens: 0,
+      buildRuntimeRecoveryContext: () => "[Recent Room Messages]\n- peer: hi",
+    });
+
+    await dispatcher.handle(makeEnvelope({ id: "m1" }));
+    // Force the stored session over the turn threshold.
+    await store.set({ ...store.all()[0], turnCount: 3 });
+
+    await dispatcher.handle(makeEnvelope({ id: "m2" }));
+
+    const lastCall = runtime.calls[runtime.calls.length - 1];
+    expect(lastCall.sessionId).toBeNull();
+    expect(lastCall.text).toContain("[BotCord Runtime Recovery Notice]");
+    expect(lastCall.text).toContain("[Recent Room Messages]");
+    // Fresh session resets the counter.
+    expect(store.all()[0].turnCount).toBe(1);
+  });
+
+  it("rotates when the last turn's input tokens reach the threshold", async () => {
+    const runtime = new FakeRuntime({ reply: "ok", newSessionId: "sid-1" });
+    const { dispatcher, store } = await scaffold({
+      runtimeFactory: () => runtime,
+      maxResumeInputTokens: 1000,
+      maxResumeTurns: 0,
+      buildRuntimeRecoveryContext: () => "[Recent Room Messages]\n- x",
+    });
+
+    await dispatcher.handle(makeEnvelope({ id: "m1" }));
+    await store.set({ ...store.all()[0], lastInputTokens: 2000 });
+
+    await dispatcher.handle(makeEnvelope({ id: "m2" }));
+
+    const lastCall = runtime.calls[runtime.calls.length - 1];
+    expect(lastCall.sessionId).toBeNull();
+    expect(lastCall.text).toContain("[BotCord Runtime Recovery Notice]");
+  });
+
+  it("never rotates when both thresholds are disabled", async () => {
+    const runtime = new FakeRuntime({ reply: "ok", newSessionId: "sid-1" });
+    const { dispatcher, store } = await scaffold({
+      runtimeFactory: () => runtime,
+      maxResumeTurns: 0,
+      maxResumeInputTokens: 0,
+    });
+
+    await dispatcher.handle(makeEnvelope({ id: "m1" }));
+    await store.set({ ...store.all()[0], turnCount: 9999, lastInputTokens: 9_000_000 });
+
+    await dispatcher.handle(makeEnvelope({ id: "m2" }));
+
+    const lastCall = runtime.calls[runtime.calls.length - 1];
+    expect(lastCall.sessionId).toBe("sid-1");
   });
 
   it("cloud_run: forwards budget caps to the runtime", async () => {

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -55,6 +55,34 @@ const DEFAULT_RUNTIME_AUTH_FAILURE_THRESHOLD = 3;
 const DEFAULT_RUNTIME_AUTH_FAILURE_COOLDOWN_MS = 10 * 60 * 1000;
 
 /**
+ * Proactive session-rotation thresholds. A resumed runtime session replays its
+ * full transcript every turn (notably Codex `exec resume`), so input tokens —
+ * and cost — climb without bound the longer a room reuses one session. When a
+ * session crosses either threshold we drop it and start a fresh one, seeded
+ * with recent-room-message recovery context so the agent keeps continuity.
+ *
+ * - input-token threshold: fires once the previous turn's reported input
+ *   (cache hit + miss) got large enough that the transcript is clearly heavy.
+ *   Only effective for runtimes that report usage (Codex today).
+ * - turn-count threshold: a runtime-agnostic backstop for sessions whose
+ *   runtime doesn't report usage. Self-compacting runtimes (Claude Code)
+ *   rarely trip the token threshold, so this bounds them too.
+ *
+ * Either threshold set to 0 disables that judge. Tunable per deployment via
+ * the BOTCORD_GATEWAY_MAX_RESUME_* env vars.
+ */
+const DEFAULT_MAX_RESUME_INPUT_TOKENS = 160_000;
+const DEFAULT_MAX_RESUME_TURNS = 25;
+
+/** Parse a non-negative integer env var, falling back to `fallback` when unset/invalid. */
+function envNonNegativeInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? Math.floor(n) : fallback;
+}
+
+/**
  * Owner-chat room prefix. Reply-text gating: only rooms with this prefix get
  * `result.text` forwarded to the channel; in every other room the runtime's
  * plain text output is discarded — agents must use the `botcord_send` tool
@@ -237,14 +265,22 @@ function looksLikeRecoverableSessionFailure(error: string): boolean {
 
 function buildRuntimeRecoveryPrompt(args: {
   userTurn: string;
-  error: string;
+  runtimeLabel: string;
+  /** Human sentence describing why the prior session ended (failure or rotation). */
+  reason: string;
+  /** Prior runtime error, when the fresh start was triggered by a failure. */
+  error?: string | null;
   recoveryContext?: string | null;
 }): string {
-  return [
+  const lines = [
     "[BotCord Runtime Recovery Notice]",
-    "The previous Codex runtime session for this room became unrecoverable while resuming or compacting context.",
-    `Previous runtime error: ${truncate(args.error, 1000)}`,
-    "You are now running in a fresh Codex session.",
+    `The previous ${args.runtimeLabel} runtime session for this room ${args.reason}.`,
+  ];
+  if (args.error) {
+    lines.push(`Previous runtime error: ${truncate(args.error, 1000)}`);
+  }
+  lines.push(
+    `You are now running in a fresh ${args.runtimeLabel} session.`,
     "Use the recent room messages below, current filesystem state, and available BotCord memory/context tools to reconstruct the active task.",
     "Continue the original user request without asking the user to repeat information unless it is missing from those sources.",
     "",
@@ -252,7 +288,21 @@ function buildRuntimeRecoveryPrompt(args: {
     "",
     "[Current User Turn]",
     args.userTurn,
-  ].join("\n");
+  );
+  return lines.join("\n");
+}
+
+/** Phrase the recovery-notice reason for a failure-triggered fresh start. */
+const RECOVERY_REASON_FAILURE =
+  "became unrecoverable while resuming or compacting context";
+
+/** Phrase the recovery-notice reason for a proactive rotation. */
+function rotationReason(args: { turns: number; inputTokens?: number }): string {
+  const detail =
+    args.inputTokens !== undefined
+      ? `prev turn input ≈ ${args.inputTokens} tokens across ${args.turns} turn(s)`
+      : `${args.turns} turn(s)`;
+  return `was rotated to a fresh session to control context growth (${detail})`;
 }
 
 /**
@@ -296,6 +346,18 @@ export interface DispatcherOptions {
   turnTimeoutMs?: number;
   runtimeAuthFailureThreshold?: number;
   runtimeAuthFailureCooldownMs?: number;
+  /**
+   * Rotate to a fresh runtime session once the previous turn's reported input
+   * tokens reach this value. 0 disables. Defaults to
+   * {@link DEFAULT_MAX_RESUME_INPUT_TOKENS} / `BOTCORD_GATEWAY_MAX_RESUME_INPUT_TOKENS`.
+   */
+  maxResumeInputTokens?: number;
+  /**
+   * Rotate to a fresh runtime session once it has served this many turns.
+   * 0 disables. Defaults to {@link DEFAULT_MAX_RESUME_TURNS} /
+   * `BOTCORD_GATEWAY_MAX_RESUME_TURNS`.
+   */
+  maxResumeTurns?: number;
   /**
    * Live reference to the Gateway's managed-route map. Dispatcher reads
    * `values()` on every `resolveRoute` call so hot-add/remove take effect
@@ -500,6 +562,8 @@ export class Dispatcher {
   private readonly turnTimeoutMs: number;
   private readonly runtimeAuthFailureThreshold: number;
   private readonly runtimeAuthFailureCooldownMs: number;
+  private readonly maxResumeInputTokens: number;
+  private readonly maxResumeTurns: number;
   private readonly buildSystemContext?: SystemContextBuilder;
   private readonly buildMemoryContext?: MemoryContextBuilder;
   private readonly buildRuntimeRecoveryContext?: RuntimeRecoveryContextBuilder;
@@ -536,6 +600,15 @@ export class Dispatcher {
       opts.runtimeAuthFailureThreshold ?? DEFAULT_RUNTIME_AUTH_FAILURE_THRESHOLD;
     this.runtimeAuthFailureCooldownMs =
       opts.runtimeAuthFailureCooldownMs ?? DEFAULT_RUNTIME_AUTH_FAILURE_COOLDOWN_MS;
+    this.maxResumeInputTokens =
+      opts.maxResumeInputTokens ??
+      envNonNegativeInt(
+        "BOTCORD_GATEWAY_MAX_RESUME_INPUT_TOKENS",
+        DEFAULT_MAX_RESUME_INPUT_TOKENS,
+      );
+    this.maxResumeTurns =
+      opts.maxResumeTurns ??
+      envNonNegativeInt("BOTCORD_GATEWAY_MAX_RESUME_TURNS", DEFAULT_MAX_RESUME_TURNS);
     this.buildSystemContext = opts.buildSystemContext;
     this.buildMemoryContext = opts.buildMemoryContext;
     this.buildRuntimeRecoveryContext = opts.buildRuntimeRecoveryContext;
@@ -549,6 +622,63 @@ export class Dispatcher {
     this.attentionGate = opts.attentionGate;
     this.resolveHubUrl = opts.resolveHubUrl;
     this.transcript = opts.transcript ?? NOOP_TRANSCRIPT;
+  }
+
+  /**
+   * Decide whether a resumable session has grown large enough to rotate to a
+   * fresh one. Returns a short reason string when rotation should happen, or
+   * null to keep resuming. Either threshold being 0 disables that judge.
+   */
+  private rotationDecision(entry: GatewaySessionEntry | undefined): {
+    reason: string;
+  } | null {
+    if (!entry) return null;
+    const tokens = entry.lastInputTokens;
+    if (
+      this.maxResumeInputTokens > 0 &&
+      typeof tokens === "number" &&
+      tokens >= this.maxResumeInputTokens
+    ) {
+      return {
+        reason: rotationReason({
+          turns: entry.turnCount ?? 0,
+          inputTokens: tokens,
+        }),
+      };
+    }
+    const turns = entry.turnCount;
+    if (
+      this.maxResumeTurns > 0 &&
+      typeof turns === "number" &&
+      turns >= this.maxResumeTurns
+    ) {
+      return { reason: rotationReason({ turns }) };
+    }
+    return null;
+  }
+
+  /**
+   * Best-effort fetch of recent-room-message recovery context for a fresh
+   * session start. Never throws — failures degrade to no context.
+   */
+  private async fetchRecoveryContext(
+    msg: GatewayInboundMessage,
+  ): Promise<string | null | undefined> {
+    if (!this.buildRuntimeRecoveryContext) return undefined;
+    try {
+      return await this.buildRuntimeRecoveryContext(msg);
+    } catch (err) {
+      this.log.warn(
+        "dispatcher: buildRuntimeRecoveryContext threw — fresh start without recent room context",
+        {
+          agentId: msg.accountId,
+          roomId: msg.conversation.id,
+          topicId: msg.conversation.threadId ?? null,
+          error: err instanceof Error ? err.message : String(err),
+        },
+      );
+      return undefined;
+    }
   }
 
   /** Consume one inbound envelope, ack it once ownership is decided, then run its turn. */
@@ -1785,12 +1915,53 @@ export class Dispatcher {
             ...(route.hermesProfile ? { hermesProfile: route.hermesProfile } : {}),
           });
 
-        result = await runRuntime(runtimeText, sessionId);
+        // Proactive session rotation: a resumed session replays its whole
+        // transcript every turn, so once it crosses the size/age thresholds we
+        // drop it and start fresh with recovery context instead of resuming an
+        // ever-growing (and ever-more-expensive) history. Only when there is an
+        // existing session to rotate away from.
+        if (activeSessionId) {
+          const rotation = this.rotationDecision(entry);
+          if (rotation) {
+            try {
+              await this.sessionStore.delete(key);
+            } catch (err) {
+              this.log.warn("dispatcher: session-store.delete failed before rotation", {
+                key,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            }
+            const recoveryContext = await this.fetchRecoveryContext(msg);
+            runtimeText = buildRuntimeRecoveryPrompt({
+              userTurn: text,
+              runtimeLabel: route.runtime,
+              reason: rotation.reason,
+              recoveryContext,
+            });
+            this.log.info("dispatcher: rotated runtime session to control context growth", {
+              key,
+              prevRuntimeSessionId: activeSessionId,
+              runtime: route.runtime,
+              prevTurnCount: entry?.turnCount ?? null,
+              prevInputTokens: entry?.lastInputTokens ?? null,
+              maxResumeInputTokens: this.maxResumeInputTokens,
+              maxResumeTurns: this.maxResumeTurns,
+              agentId: msg.accountId,
+              roomId: msg.conversation.id,
+              topicId: msg.conversation.threadId ?? null,
+              turnId,
+              queueKey,
+            });
+            activeSessionId = null;
+          }
+        }
+
+        result = await runRuntime(runtimeText, activeSessionId);
         const firstError = result.error ?? "";
         const firstReply = (result.text || "").trim();
         const shouldRetryFresh =
           route.runtime === "codex" &&
-          !!sessionId &&
+          !!activeSessionId &&
           !!firstError &&
           !firstReply &&
           !looksLikeRuntimeAuthFailure(firstError) &&
@@ -1804,7 +1975,7 @@ export class Dispatcher {
             await this.sessionStore.delete(key);
             this.log.info("dispatcher: dropped unrecoverable runtime session before fresh retry", {
               key,
-              prevRuntimeSessionId: sessionId,
+              prevRuntimeSessionId: activeSessionId,
               runtime: route.runtime,
               error: firstError,
             });
@@ -1815,24 +1986,13 @@ export class Dispatcher {
             });
           }
 
-          let recoveryContext: string | null | undefined;
-          if (this.buildRuntimeRecoveryContext) {
-            try {
-              recoveryContext = await this.buildRuntimeRecoveryContext(msg);
-            } catch (err) {
-              this.log.warn("dispatcher: buildRuntimeRecoveryContext threw — retrying without recent room context", {
-                agentId: msg.accountId,
-                roomId: msg.conversation.id,
-                topicId: msg.conversation.threadId ?? null,
-                turnId,
-                error: err instanceof Error ? err.message : String(err),
-              });
-            }
-          }
+          const recoveryContext = await this.fetchRecoveryContext(msg);
 
           activeSessionId = null;
           runtimeText = buildRuntimeRecoveryPrompt({
             userTurn: text,
+            runtimeLabel: route.runtime,
+            reason: RECOVERY_REASON_FAILURE,
             error: firstError,
             recoveryContext,
           });
@@ -2034,6 +2194,18 @@ export class Dispatcher {
           });
         }
       } else if (result.newSessionId && !authFailureError) {
+        // Carry the turn counter forward only when we actually resumed the same
+        // stored session this turn; a fresh start (no prior id, rotation, or
+        // failure-retry) resets it to 1 so rotation windows are measured from
+        // the new session's birth.
+        const resumedSameSession =
+          !!activeSessionId && entry?.runtimeSessionId === activeSessionId;
+        const nextTurnCount = resumedSameSession ? (entry?.turnCount ?? 0) + 1 : 1;
+        const reportedInputTokens =
+          result.inputCacheHitTokens !== undefined ||
+          result.inputCacheMissTokens !== undefined
+            ? (result.inputCacheHitTokens ?? 0) + (result.inputCacheMissTokens ?? 0)
+            : undefined;
         const session: GatewaySessionEntry = {
           key,
           runtime: route.runtime,
@@ -2046,6 +2218,10 @@ export class Dispatcher {
           threadId: msg.conversation.threadId ?? null,
           cwd: route.cwd,
           updatedAt: Date.now(),
+          turnCount: nextTurnCount,
+          ...(reportedInputTokens !== undefined
+            ? { lastInputTokens: reportedInputTokens }
+            : {}),
         };
         try {
           const prevRuntimeSessionId = activeSessionId;

--- a/packages/daemon/src/gateway/runtimes/codex.ts
+++ b/packages/daemon/src/gateway/runtimes/codex.ts
@@ -28,6 +28,13 @@ function extraFlagName(arg: string): string {
   return eq === -1 ? arg : arg.slice(0, eq);
 }
 
+/** Coerce an untrusted JSON value to a finite non-negative number, else undefined. */
+function numOrUndefined(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : undefined;
+}
+
 function nextExtraValue(args: string[], index: number): string | undefined {
   const next = args[index + 1];
   if (typeof next !== "string") return undefined;
@@ -292,6 +299,11 @@ export class CodexAdapter extends NdjsonStreamAdapter {
       item?: { type?: string; text?: string };
       error?: { message?: string } | string;
       turn?: { status?: string; error?: { message?: string } };
+      usage?: {
+        input_tokens?: number;
+        cached_input_tokens?: number;
+        output_tokens?: number;
+      };
     };
 
     // Emit a thinking lifecycle hint BEFORE the block so the dispatcher's
@@ -321,11 +333,34 @@ export class CodexAdapter extends NdjsonStreamAdapter {
       return;
     }
 
-    if (obj.type === "turn.completed" && obj.turn?.status === "failed") {
-      ctx.state.errorText =
-        obj.turn.error?.message?.trim() ||
-        summarizeCodexErrorEvent(raw) ||
-        "codex turn failed";
+    if (obj.type === "turn.completed") {
+      // `usage` is reported on both successful and failed turns. Map Codex's
+      // {input_tokens, cached_input_tokens, output_tokens} onto the cache
+      // hit/miss split the cloud-settle hook and session-rotation judge expect:
+      // input_tokens is the full prompt size (cached + uncached), so the miss
+      // portion is input_tokens - cached_input_tokens.
+      const usage = obj.usage;
+      if (usage && typeof usage === "object") {
+        const input = numOrUndefined(usage.input_tokens);
+        const cached = numOrUndefined(usage.cached_input_tokens);
+        const output = numOrUndefined(usage.output_tokens);
+        const hit = cached;
+        const miss =
+          input !== undefined ? Math.max(0, input - (cached ?? 0)) : undefined;
+        if (hit !== undefined || miss !== undefined || output !== undefined) {
+          ctx.state.usage = {
+            ...(hit !== undefined ? { inputCacheHitTokens: hit } : {}),
+            ...(miss !== undefined ? { inputCacheMissTokens: miss } : {}),
+            ...(output !== undefined ? { outputTokens: output } : {}),
+          };
+        }
+      }
+      if (obj.turn?.status === "failed") {
+        ctx.state.errorText =
+          obj.turn.error?.message?.trim() ||
+          summarizeCodexErrorEvent(raw) ||
+          "codex turn failed";
+      }
       return;
     }
 

--- a/packages/daemon/src/gateway/runtimes/ndjson-stream.ts
+++ b/packages/daemon/src/gateway/runtimes/ndjson-stream.ts
@@ -28,6 +28,17 @@ export interface NdjsonRunState {
   assistantTextCapped: boolean;
   costUsd?: number;
   errorText?: string;
+  /**
+   * Per-turn token usage, populated by adapters whose CLI reports it (e.g.
+   * Codex `turn.completed.usage`). Surfaced on the RuntimeRunResult so the
+   * cloud-settle hook can charge usage and the dispatcher can size sessions
+   * for rotation. Adapters that don't report usage leave this undefined.
+   */
+  usage?: {
+    inputCacheHitTokens?: number;
+    inputCacheMissTokens?: number;
+    outputTokens?: number;
+  };
 }
 
 /** Per-event context handed to subclasses from the ndjson dispatch loop. */
@@ -253,6 +264,15 @@ export abstract class NdjsonStreamAdapter implements RuntimeAdapter {
       text,
       newSessionId: state.newSessionId,
       ...(state.costUsd !== undefined ? { costUsd: state.costUsd } : {}),
+      ...(state.usage?.inputCacheHitTokens !== undefined
+        ? { inputCacheHitTokens: state.usage.inputCacheHitTokens }
+        : {}),
+      ...(state.usage?.inputCacheMissTokens !== undefined
+        ? { inputCacheMissTokens: state.usage.inputCacheMissTokens }
+        : {}),
+      ...(state.usage?.outputTokens !== undefined
+        ? { outputTokens: state.usage.outputTokens }
+        : {}),
       ...(state.errorText ? { error: state.errorText } : {}),
       ...(state.errorText
         ? {

--- a/packages/daemon/src/gateway/types.ts
+++ b/packages/daemon/src/gateway/types.ts
@@ -498,4 +498,16 @@ export interface GatewaySessionEntry {
   threadId?: string | null;
   cwd: string;
   updatedAt: number;
+  /**
+   * Number of turns served on this runtime session since it was (re)started.
+   * Used by the dispatcher to proactively rotate to a fresh session before the
+   * resumed transcript grows unboundedly. Reset to 1 on a fresh/rotated start.
+   */
+  turnCount?: number;
+  /**
+   * Total input tokens (cache hit + miss) the runtime reported for the most
+   * recent turn on this session, when available. The rotation judge uses this
+   * as a direct proxy for how large the replayed transcript has become.
+   */
+  lastInputTokens?: number;
 }


### PR DESCRIPTION
## Problem

A resumed runtime session replays its **whole transcript every turn** (notably Codex `exec resume`), so input tokens — and cost — climb without bound the longer a room reuses one session. Claude Code self-compacts and stays cheap; Codex does not.

Observed on prod hosts (2026-06-04): Codex sessions hitting **240k+ input tokens (93–96% of the 258400 context window)** and **10M+ total tokens per session**, single agents burning 30–43M tokens/day, dominated by `cached_input_tokens`.

## Change

**Layer 1 — proactive session rotation (the fix):**
- Parse Codex `turn.completed.usage` (`input_tokens`/`cached_input_tokens`/`output_tokens`) into the `RuntimeRunResult` token fields in the ndjson base adapter. These were previously dropped — so this also fixes **cloud-settle undercounting Codex usage**.
- Track `turnCount` + `lastInputTokens` on each `GatewaySessionEntry`.
- Before resuming, rotate to a **fresh session** (reusing the existing recovery-context fresh-start machinery — recent room messages + working memory + filesystem) once the previous turn's input reaches `BOTCORD_GATEWAY_MAX_RESUME_INPUT_TOKENS` (default **160000**) **or** the session has served `BOTCORD_GATEWAY_MAX_RESUME_TURNS` turns (default **25**). Either threshold `0` disables that judge. Runtime-agnostic; the token judge naturally only fires for runtimes that report usage (Codex), turn-count is the backstop.

**Layer 3 — observability:**
- `packages/daemon/scripts/session-usage-report.mjs`: zero-dep node script that scans `agents/*/codex-home/sessions/**/*.jsonl`, aggregates token usage per agent/room/session (joining `daemon/sessions.json` for room attribution), and exits non-zero on threshold breach so it can run from cron. Supports `--since/--top/--by-room/--json` + tunable alert thresholds aligned with the rotation defaults.

## Testing

- `tsc -p tsconfig.build.json`: clean on all touched files.
- Vitest: new tests for Codex usage parsing (2) and dispatcher rotation (5: persist counters, resume-below-threshold increments, turn-count rotation, token rotation, both-disabled). Full affected suites: 108 passing.
- Report script verified against real local rollout data.

## Rollout notes

The 160k input threshold is a first cut (real sessions peak at 240k ≈ 96% ctx). Suggest merging, running on **botcord-dev** for a week, watching the `dispatcher: rotated runtime session to control context growth` log line + the report script for rotation frequency, then tuning via env (no code change). Lower → more rotations (more recovery-context refetch, less continuity); higher → less savings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)