### PR TITLE
feat: surface daemon package version

### DIFF
--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -1377,6 +1377,7 @@ class DaemonInstance(Base):
     runtimes_probed_at: Mapped[datetime.datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    daemon_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
 
 class DaemonAgentCleanup(Base):

--- a/backend/hub/routers/daemon_control.py
+++ b/backend/hub/routers/daemon_control.py
@@ -587,6 +587,7 @@ class _InstanceView(BaseModel):
     online: bool
     runtimes: list[dict[str, Any]] | None = None
     runtimes_probed_at: datetime.datetime | None = None
+    daemon_version: str | None = None
 
 
 def _instance_status(instance: DaemonInstance) -> str:
@@ -630,6 +631,7 @@ def _instance_to_view(instance: DaemonInstance) -> _InstanceView:
         online=_instance_online(instance),
         runtimes=instance.runtimes_json if instance.runtimes_json else None,
         runtimes_probed_at=instance.runtimes_probed_at,
+        daemon_version=instance.daemon_version,
     )
 
 
@@ -1160,6 +1162,7 @@ async def dispatch_to_instance(
 class _RefreshRuntimesResponse(BaseModel):
     runtimes: list[dict[str, Any]]
     runtimes_probed_at: datetime.datetime
+    daemon_version: str | None = None
 
 
 _REFRESH_RUNTIMES_TIMEOUT_MS = 10000
@@ -1296,6 +1299,7 @@ async def refresh_instance_runtimes(
         return _RefreshRuntimesResponse(
             runtimes=runtimes,
             runtimes_probed_at=probed_dt,
+            daemon_version=instance.daemon_version,
         )
 
     conn = _REGISTRY.get(daemon_instance_id)
@@ -1357,6 +1361,7 @@ async def refresh_instance_runtimes(
     return _RefreshRuntimesResponse(
         runtimes=runtimes,
         runtimes_probed_at=probed_dt,
+        daemon_version=instance.daemon_version,
     )
 
 
@@ -1669,11 +1674,11 @@ _DAEMON_INITIATED_TYPES = {
 
 def _parse_runtime_snapshot_params(
     params: Any,
-) -> tuple[list[dict[str, Any]], datetime.datetime] | None:
+) -> tuple[list[dict[str, Any]], datetime.datetime, str | None] | None:
     """Validate a ``runtime_snapshot`` / ``list_runtimes`` ack payload.
 
-    Returns ``(runtimes, probed_at_utc)`` on success, ``None`` on malformed
-    input (caller should respond with ``bad_params``).
+    Returns ``(runtimes, probed_at_utc, daemon_version)`` on success, ``None``
+    on malformed input (caller should respond with ``bad_params``).
     """
     if not isinstance(params, dict):
         return None
@@ -1732,7 +1737,12 @@ def _parse_runtime_snapshot_params(
     upper_bound = _now() + datetime.timedelta(minutes=5)
     if probed_dt > upper_bound:
         return None
-    return runtimes, probed_dt
+    daemon_version = params.get("daemonVersion")
+    if daemon_version is not None:
+        if not isinstance(daemon_version, str) or len(daemon_version) > 64:
+            return None
+        daemon_version = daemon_version.strip() or None
+    return runtimes, probed_dt, daemon_version
 
 
 async def _persist_runtime_snapshot(
@@ -1749,9 +1759,11 @@ async def _persist_runtime_snapshot(
     parsed = _parse_runtime_snapshot_params(params)
     if parsed is None:
         return None
-    runtimes, probed_dt = parsed
+    runtimes, probed_dt, daemon_version = parsed
     instance.runtimes_json = runtimes
     instance.runtimes_probed_at = probed_dt
+    if daemon_version is not None:
+        instance.daemon_version = daemon_version
     return runtimes, probed_dt
 
 

--- a/backend/migrations/028_daemon_instance_version.sql
+++ b/backend/migrations/028_daemon_instance_version.sql
@@ -1,0 +1,4 @@
+-- Persist the running @botcord/daemon package version learned from runtime snapshots.
+
+ALTER TABLE daemon_instances
+  ADD COLUMN IF NOT EXISTS daemon_version VARCHAR(64);

--- a/backend/tests/test_app/test_daemon_control.py
+++ b/backend/tests/test_app/test_daemon_control.py
@@ -1057,7 +1057,11 @@ async def test_runtime_snapshot_event_persists_to_db(
         {
             "id": "frm_rs_1",
             "type": "runtime_snapshot",
-            "params": {"runtimes": runtimes, "probedAt": probed_at},
+            "params": {
+                "runtimes": runtimes,
+                "probedAt": probed_at,
+                "daemonVersion": "0.2.96",
+            },
         },
     )
 
@@ -1078,6 +1082,7 @@ async def test_runtime_snapshot_event_persists_to_db(
         stored = json.loads(stored)
     assert stored == runtimes
     assert inst.runtimes_probed_at is not None
+    assert inst.daemon_version == "0.2.96"
 
     # list_instances surfaces it.
     r = await client.get(
@@ -1089,6 +1094,7 @@ async def test_runtime_snapshot_event_persists_to_db(
     entry = next(it for it in payload["instances"] if it["id"] == instance_id)
     assert entry["runtimes"] == runtimes
     assert entry["runtimes_probed_at"] is not None
+    assert entry["daemon_version"] == "0.2.96"
 
 
 @pytest.mark.asyncio
@@ -1427,7 +1433,11 @@ async def test_refresh_runtimes_success_persists_and_returns(
             ack = {
                 "id": sent["id"],
                 "ok": True,
-                "result": {"runtimes": runtimes, "probedAt": probed_at},
+                "result": {
+                    "runtimes": runtimes,
+                    "probedAt": probed_at,
+                    "daemonVersion": "0.2.97",
+                },
             }
             fut = conn.pending_acks.get(sent["id"])
             assert fut is not None
@@ -1443,6 +1453,7 @@ async def test_refresh_runtimes_success_persists_and_returns(
         body = r.json()
         assert body["runtimes"] == runtimes
         assert body["runtimes_probed_at"]
+        assert body["daemon_version"] == "0.2.97"
 
         # DB is updated.
         await db_session.commit()
@@ -1455,6 +1466,7 @@ async def test_refresh_runtimes_success_persists_and_returns(
             stored = json.loads(stored)
         assert stored == runtimes
         assert inst.runtimes_probed_at is not None
+        assert inst.daemon_version == "0.2.97"
     finally:
         await registry.unregister(conn)
 

--- a/frontend/src/components/daemon/DaemonsSettingsPage.tsx
+++ b/frontend/src/components/daemon/DaemonsSettingsPage.tsx
@@ -138,6 +138,17 @@ function RuntimeChip({ runtime }: { runtime: DaemonRuntime }) {
   );
 }
 
+function DaemonVersionChip({ version }: { version?: string | null }) {
+  return (
+    <span
+      title="Running botcord-daemon version"
+      className="inline-flex items-center rounded-full border border-glass-border bg-glass-bg px-2 py-0.5 font-mono text-[10px] text-text-secondary"
+    >
+      daemon {version || "--"}
+    </span>
+  );
+}
+
 function RuntimesBlock({
   daemon,
   refreshing,
@@ -189,6 +200,7 @@ function RuntimesBlock({
             </span>
           ) : null}
         </div>
+        <DaemonVersionChip version={daemon.daemon_version} />
         <button
           type="button"
           onClick={onRefresh}

--- a/frontend/src/components/dashboard/sidebar/BotsPanel.tsx
+++ b/frontend/src/components/dashboard/sidebar/BotsPanel.tsx
@@ -278,6 +278,7 @@ export default function BotsPanel({
           label={settingsDaemon?.label ?? ""}
           status={settingsDaemon?.status ?? "offline"}
           lastSeen={settingsDaemon?.last_seen_at ?? null}
+          daemonVersion={settingsDaemon?.daemon_version ?? null}
           hostedAgentCount={(byDaemon.get(deviceSettingsId) ?? []).length}
           isRenaming={renamingId === deviceSettingsId}
           isRefreshing={refreshingBots}

--- a/frontend/src/components/dashboard/sidebar/DeviceSettingsModal.tsx
+++ b/frontend/src/components/dashboard/sidebar/DeviceSettingsModal.tsx
@@ -12,6 +12,7 @@ interface DeviceSettingsModalProps {
   label: string;
   status: "online" | "offline" | "revoked" | "removal_pending";
   lastSeen: string | null;
+  daemonVersion?: string | null;
   hostedAgentCount: number;
   isRenaming: boolean;
   isRefreshing: boolean;
@@ -32,6 +33,7 @@ export default function DeviceSettingsModal({
   label,
   status,
   lastSeen,
+  daemonVersion,
   hostedAgentCount,
   isRenaming,
   isRefreshing,
@@ -133,6 +135,15 @@ export default function DeviceSettingsModal({
               </span>
             </div>
           )}
+
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-text-secondary/60">
+              {locale === "zh" ? "Daemon 版本" : "Daemon version"}
+            </span>
+            <span className="font-mono text-[11px] text-text-secondary/70">
+              {daemonVersion || "--"}
+            </span>
+          </div>
 
           {/* Rename */}
           <div className="space-y-1.5">

--- a/frontend/src/store/useDaemonStore.test.ts
+++ b/frontend/src/store/useDaemonStore.test.ts
@@ -14,6 +14,56 @@ describe("useDaemonStore", () => {
     });
   });
 
+  it("normalizes daemon package version from the instance list", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          instances: [
+            {
+              id: "dm_1",
+              label: "workstation",
+              kind: "local",
+              status: "active",
+              online: true,
+              created_at: "2026-06-05T00:00:00Z",
+              last_seen_at: "2026-06-05T00:01:00Z",
+              revoked_at: null,
+              removal_requested_at: null,
+              cleanup_completed_at: null,
+              runtimes: null,
+              runtimes_probed_at: null,
+              daemon_version: "0.2.96",
+            },
+            {
+              id: "dm_2",
+              label: null,
+              kind: "local",
+              status: "active",
+              online: false,
+              created_at: "2026-06-05T00:00:00Z",
+              last_seen_at: null,
+              revoked_at: null,
+              removal_requested_at: null,
+              cleanup_completed_at: null,
+              runtimes: null,
+              runtimes_probed_at: null,
+              daemon_version: "",
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    await useDaemonStore.getState().refresh();
+
+    expect(useDaemonStore.getState().daemons[0]?.daemon_version).toBe("0.2.96");
+    expect(useDaemonStore.getState().daemons[1]?.daemon_version).toBeNull();
+  });
+
   it("surfaces daemon diagnostics failure details from Hub", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(

--- a/frontend/src/store/useDaemonStore.ts
+++ b/frontend/src/store/useDaemonStore.ts
@@ -123,6 +123,7 @@ export interface DaemonInstance {
   cleanup_completed_at: string | null;
   runtimes?: DaemonRuntime[] | null;
   runtimes_probed_at?: string | null;
+  daemon_version?: string | null;
 }
 
 export interface RemoveDeviceResult {
@@ -545,6 +546,10 @@ function normalizeDaemon(raw: Record<string, unknown>): DaemonInstance {
     cleanup_completed_at: cleanupCompletedAt,
     runtimes: normalizeRuntimes(raw.runtimes),
     runtimes_probed_at: (raw.runtimes_probed_at as string | null) ?? null,
+    daemon_version:
+      typeof raw.daemon_version === "string" && raw.daemon_version.trim()
+        ? raw.daemon_version
+        : null,
   };
 }
 
@@ -872,10 +877,14 @@ export const useDaemonStore = create<DaemonState>()((set, get) => ({
         typeof data?.runtimes_probed_at === "string"
           ? data.runtimes_probed_at
           : new Date().toISOString();
+      const daemonVersion =
+        typeof data?.daemon_version === "string" && data.daemon_version.trim()
+          ? data.daemon_version
+          : null;
       set({
         daemons: get().daemons.map((d) =>
           d.id === id
-            ? { ...d, runtimes, runtimes_probed_at: probedAt }
+            ? { ...d, runtimes, runtimes_probed_at: probedAt, daemon_version: daemonVersion }
             : d,
         ),
         ...(quiet ? {} : { refreshingRuntimesId: null }),

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -6,6 +6,7 @@
  */
 import { existsSync, lstatSync, readdirSync, readFileSync, rmSync, statSync, unlinkSync } from "node:fs";
 import { homedir } from "node:os";
+import { createRequire } from "node:module";
 import path from "node:path";
 import {
   BotCordClient,
@@ -92,6 +93,8 @@ import {
   type CloudGatewayTypingEmitter,
 } from "./cloud-gateway-runtime.js";
 import { scheduleDaemonSelfRestart } from "./self-restart.js";
+
+const require = createRequire(import.meta.url);
 
 function skillIndexOptionsForLoadedAgent(gateway: Gateway, agentId: string): SkillIndexOptions {
   const route = gateway.listManagedRoutes()
@@ -2011,6 +2014,27 @@ export function removeAgentFromConfig(
 const RUNTIME_PROBE_CACHE_TTL_MS = 30_000;
 
 let _runtimeProbeCache: { at: number; value: ListRuntimesResult } | null = null;
+let _daemonPackageVersionCache: string | null | undefined;
+
+function daemonPackageVersion(): string | undefined {
+  if (_daemonPackageVersionCache !== undefined) {
+    return _daemonPackageVersionCache ?? undefined;
+  }
+  try {
+    const pkgPath = require.resolve("@botcord/daemon/package.json");
+    const parsed = JSON.parse(readFileSync(pkgPath, "utf8")) as unknown;
+    _daemonPackageVersionCache =
+      parsed &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed) &&
+      typeof (parsed as { version?: unknown }).version === "string"
+        ? (parsed as { version: string }).version
+        : null;
+  } catch {
+    _daemonPackageVersionCache = null;
+  }
+  return _daemonPackageVersionCache ?? undefined;
+}
 
 /** Drop the cache (e.g. before a `doctor`-style interactive re-probe). */
 export function clearRuntimeProbeCache(): void {
@@ -2083,6 +2107,8 @@ export function collectRuntimeSnapshot(opts: { force?: boolean } = {}): ListRunt
     return record;
   });
   const value: ListRuntimesResult = { runtimes, probedAt: Date.now() };
+  const version = daemonPackageVersion();
+  if (version) value.daemonVersion = version;
   _runtimeProbeCache = { at: Date.now(), value };
   return value;
 }

--- a/packages/protocol-core/src/control-frame.ts
+++ b/packages/protocol-core/src/control-frame.ts
@@ -757,6 +757,7 @@ export interface RuntimeEndpointProbe {
 export interface RuntimeSnapshotParams {
   runtimes: RuntimeProbeResult[];
   probedAt: number;
+  daemonVersion?: string;
 }
 
 /**
@@ -768,6 +769,7 @@ export interface RuntimeSnapshotParams {
 export interface ListRuntimesResult {
   runtimes: RuntimeProbeResult[];
   probedAt: number;
+  daemonVersion?: string;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- persist daemon package version from runtime snapshots
- expose daemon_version in daemon instance APIs and store state
- display daemon version in daemon settings surfaces

## Verification
- git diff --check
- cd backend && uv run pytest tests/test_app/test_daemon_control.py
- cd frontend && npm run test -- src/store/useDaemonStore.test.ts --run
- cd packages/protocol-core && npm run build
- cd packages/daemon && npm run build
- cd frontend && NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build