### PR TITLE
fix(frontend): keep owner chat composing stream open

### DIFF
--- a/frontend/src/components/dashboard/StreamBlocksView.tsx
+++ b/frontend/src/components/dashboard/StreamBlocksView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import { Search, FileText, CheckCircle2, Code2, Brain, HelpCircle, Wrench, ChevronDown, ChevronRight, Bot, AlertTriangle, ListTodo, Info } from "lucide-react";
 import type { StreamBlockEntry } from "@/lib/types";
 import MarkdownContent from "@/components/ui/MarkdownContent";
@@ -844,7 +844,6 @@ export default function StreamBlocksView({
   onScrollRequest?: () => void;
 }) {
   const [expanded, setExpanded] = useState(defaultExpanded ?? false);
-  const autoCollapsedRef = useRef(false);
 
   const isAssistant = (k: string) => k === "assistant" || k === "assistant_text";
   const executionBlocks = blocks.filter((b) => !isAssistant(b.block.kind));
@@ -905,13 +904,6 @@ export default function StreamBlocksView({
   useEffect(() => {
     onScrollRequest?.();
   }, [blocks.length, onScrollRequest]);
-
-  useEffect(() => {
-    if (composingText && !autoCollapsedRef.current) {
-      autoCollapsedRef.current = true;
-      setExpanded(false);
-    }
-  }, [composingText]);
 
   if (blocks.length === 0 || displayBlocks.length === 0) return null;
 

--- a/frontend/src/store/useOwnerChatStore.test.ts
+++ b/frontend/src/store/useOwnerChatStore.test.ts
@@ -223,7 +223,7 @@ describe("useOwnerChatStore stream terminal handling", () => {
     useOwnerChatStore.getState().setRoom("rm_oc_real", "Owned bot");
   });
 
-  it("settles a streaming placeholder when a terminal block arrives before the final message", () => {
+  it("keeps a streaming placeholder open when a terminal block arrives before the final message", () => {
     useOwnerChatStore.getState().appendStreamBlock({
       trace_id: "msg_trace",
       seq: 1,
@@ -241,15 +241,18 @@ describe("useOwnerChatStore stream terminal handling", () => {
       {
         traceId: "msg_trace",
         text: "done",
-        status: "delivered",
+        status: "streaming",
         hubMsgId: null,
-        streamBlocks: [{ block: { kind: "other" } }],
+        streamBlocks: [
+          { block: { kind: "assistant" } },
+          { block: { kind: "other" } },
+        ],
       },
     ]);
-    expect(useOwnerChatStore.getState().activeTraceId).toBeNull();
+    expect(useOwnerChatStore.getState().activeTraceId).toBe("msg_trace");
   });
 
-  it("upgrades a terminal-settled placeholder when the final traced message arrives", () => {
+  it("finalizes a terminal-observed placeholder when the final traced message arrives", () => {
     useOwnerChatStore.getState().appendStreamBlock({
       trace_id: "msg_trace",
       seq: 1,
@@ -275,6 +278,7 @@ describe("useOwnerChatStore stream terminal handling", () => {
       hubMsgId: "msg_final",
       text: "streamed answer",
       status: "delivered",
+      streamBlocks: [{ block: { kind: "other" } }],
     });
   });
 });

--- a/frontend/src/store/useOwnerChatStore.ts
+++ b/frontend/src/store/useOwnerChatStore.ts
@@ -108,11 +108,6 @@ function hasVisibleOwnerChatContent(msg: OwnerChatMessage): boolean {
   return visibleExecutionBlocks(msg.streamBlocks).length > 0;
 }
 
-function isTerminalStreamBlock(entry: StreamBlockEntry): boolean {
-  const payload = entry.block.payload;
-  return entry.block.kind === "other" && payload?.terminal === true;
-}
-
 function visibleExecutionBlocks(blocks: StreamBlockEntry[]): StreamBlockEntry[] {
   return blocks.filter(
     (b) =>
@@ -472,7 +467,6 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
   appendStreamBlock: (entry) => {
     set((state) => {
       const traceId = entry.trace_id;
-      const terminal = isTerminalStreamBlock(entry);
 
       // Find existing streaming message for this trace
       const idx = state.messages.findIndex(
@@ -480,14 +474,16 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
       );
 
       if (idx === -1) {
-        // Create a new streaming placeholder
+        // Create a streaming placeholder. A terminal runtime block is not the
+        // final chat response; the placeholder remains streaming until the
+        // traced agent message arrives via finalizeStream().
         const streamingMsg: OwnerChatMessage = {
           clientId: `stream_${traceId}`,
           hubMsgId: null,
           sender: "agent",
           text: extractAssistantText([entry]),
-          streamBlocks: terminal ? visibleExecutionBlocks([entry]) : [entry],
-          status: terminal ? "delivered" : "streaming",
+          streamBlocks: [entry],
+          status: "streaming",
           createdAt: entry.created_at,
           senderName: state.agentName,
           type: "message",
@@ -495,7 +491,7 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
         };
         return {
           messages: [...state.messages, streamingMsg],
-          activeTraceId: terminal ? null : traceId,
+          activeTraceId: traceId,
           agentTyping: false,
         };
       }
@@ -507,12 +503,12 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
 
       const updatedBlocks = [...existing.streamBlocks, entry].sort((a, b) => a.seq - b.seq);
       const updatedText = extractAssistantText(updatedBlocks);
-      const finalized = terminal || existing.status === "delivered";
+      const finalized = existing.status === "delivered";
       const updatedMsg: OwnerChatMessage = {
         ...existing,
         streamBlocks: finalized ? visibleExecutionBlocks(updatedBlocks) : updatedBlocks,
         text: updatedText || existing.text,
-        status: terminal ? "delivered" : existing.status,
+        status: existing.status,
       };
 
       const newMessages = [...state.messages];
@@ -520,7 +516,7 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
 
       return {
         messages: newMessages,
-        activeTraceId: terminal ? null : traceId,
+        activeTraceId: traceId,
         agentTyping: false,
       };
     });


### PR DESCRIPTION
## Summary
- Keep owner-chat stream placeholders in `streaming` state until the final traced agent message arrives.
- Stop auto-collapsing `StreamBlocksView` when composing text starts rendering.
- Update terminal-block tests so terminal runtime blocks no longer settle the chat message early.

## Verification
- `cd frontend && npm run test -- --run src/store/useOwnerChatStore.test.ts src/components/dashboard/StreamBlocksView.test.ts`
- `cd frontend && npm run build`

## Risk / rollout
- Low-risk frontend state/rendering change scoped to owner-chat streaming UI.