### PR TITLE
feat: add message status reactions

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -73,6 +73,7 @@ from hub.routers.hub import (
 )
 from hub.schemas import ReplyPreview
 from hub.services.cloud_agent_activity import maybe_bump_for_inbound_many
+from hub.services import message_status_reactions
 from hub.share_payloads import SHARE_MESSAGE_PREVIEW_LIMIT, share_create_payload
 from hub.validators import normalize_file_url
 
@@ -2458,6 +2459,11 @@ async def get_room_messages(
     reply_preview_map = await _load_reply_previews(
         db, {rec.reply_to_msg_id for rec in records if rec.reply_to_msg_id}
     )
+    msg_ids = [rec.msg_id for rec in records]
+    status_reactions_map = await message_status_reactions.load_active_status_reactions(
+        room_id,
+        msg_ids,
+    )
 
     messages = []
     for rec in records:
@@ -2488,6 +2494,7 @@ async def get_room_messages(
             "created_at": rec.created_at.isoformat() if rec.created_at else None,
             "source_type": rec.source_type,
             "reply_preview": rp.model_dump(mode="json") if rp else None,
+            "status_reactions": status_reactions_map.get(rec.msg_id, []),
             **_recalled_message_fields(rec),
             **extra,
         }

--- a/backend/hub/dashboard_schemas.py
+++ b/backend/hub/dashboard_schemas.py
@@ -1,6 +1,8 @@
 import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+from hub.schemas import MessageStatusReaction
 
 
 class DashboardAgentProfile(BaseModel):
@@ -78,6 +80,7 @@ class DashboardMessage(BaseModel):
     goal: str | None = None
     state: str
     state_counts: dict[str, int] | None = None
+    status_reactions: list[MessageStatusReaction] = Field(default_factory=list)
     created_at: datetime.datetime
     is_recalled: bool = False
     recalled_at: datetime.datetime | None = None

--- a/backend/hub/routers/dashboard.py
+++ b/backend/hub/routers/dashboard.py
@@ -65,6 +65,7 @@ from hub.share_payloads import (
     share_create_payload,
     share_public_payload,
 )
+from hub.services import message_status_reactions
 
 router = APIRouter(prefix="/dashboard", tags=["dashboard"])
 
@@ -529,6 +530,10 @@ async def get_room_messages(
         )
         for mid, st, cnt in sc_result.all():
             state_counts_map.setdefault(mid, {})[st.value if hasattr(st, "value") else st] = cnt
+    status_reactions_map = await message_status_reactions.load_active_status_reactions(
+        room_id,
+        msg_ids,
+    )
 
     # Build response messages
     messages: list[DashboardMessage] = []
@@ -570,6 +575,7 @@ async def get_room_messages(
                 goal=rec.goal,
                 state=rec.state.value,
                 state_counts=counts,
+                status_reactions=status_reactions_map.get(rec.msg_id, []),
                 mentions=_extract_mentions_from_envelope(envelope_data),
                 created_at=ca,
                 source_type=rec.source_type,

--- a/backend/hub/routers/hub.py
+++ b/backend/hub/routers/hub.py
@@ -77,12 +77,15 @@ from hub.schemas import (
     InboxPollResponse,
     MessageEnvelope,
     MessageStatusResponse,
+    MessageStatusReactionClearRequest,
+    MessageStatusReactionRequest,
     MessageType,
     ReceiptResponse,
     ReplyPreview,
     SendResponse,
     TypingRequest,
 )
+from hub.services import message_status_reactions
 
 logger = logging.getLogger(__name__)
 
@@ -2267,6 +2270,119 @@ async def query_history(
         count=len(messages),
         has_more=has_more,
     )
+
+
+# ---------------------------------------------------------------------------
+# Message status reactions - ephemeral message-level state
+# ---------------------------------------------------------------------------
+
+
+async def _load_status_reaction_room(
+    *,
+    db: AsyncSession,
+    room_id: str,
+    msg_id: str,
+    current_agent: str,
+) -> Room:
+    room_result = await db.execute(
+        select(Room)
+        .options(selectinload(Room.members))
+        .where(Room.room_id == room_id)
+    )
+    room = room_result.scalar_one_or_none()
+    if room is None:
+        raise I18nHTTPException(status_code=404, message_key="room_not_found")
+    if not any(m.agent_id == current_agent for m in room.members):
+        raise I18nHTTPException(status_code=403, message_key="not_a_member")
+    target_id = await db.scalar(
+        select(MessageRecord.id)
+        .where(MessageRecord.room_id == room_id, MessageRecord.msg_id == msg_id)
+        .limit(1)
+    )
+    if target_id is None:
+        raise I18nHTTPException(status_code=404, message_key="message_not_found")
+    return room
+
+
+async def _broadcast_message_status_reaction(
+    db: AsyncSession,
+    *,
+    room: Room,
+    payload: dict[str, Any],
+) -> None:
+    for member in room.members:
+        if member.muted:
+            continue
+        event = build_agent_realtime_event(
+            type="message_status_reaction",
+            agent_id=member.agent_id,
+            room_id=room.room_id,
+            ext=payload,
+        )
+        try:
+            await _publish_agent_realtime_event(db, event)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "message status reaction realtime publish failed for %s: %s",
+                member.agent_id,
+                exc,
+            )
+
+
+@router.post("/messages/{msg_id}/status-reactions", status_code=204)
+async def set_message_status_reaction(
+    msg_id: str,
+    body: MessageStatusReactionRequest,
+    current_agent: str = Depends(get_current_claimed_agent),
+    db: AsyncSession = Depends(get_db),
+):
+    room = await _load_status_reaction_room(
+        db=db,
+        room_id=body.room_id,
+        msg_id=msg_id,
+        current_agent=current_agent,
+    )
+    actor_name = await db.scalar(
+        select(Agent.display_name).where(Agent.agent_id == current_agent)
+    )
+    payload = await message_status_reactions.set_status_reaction(
+        room_id=body.room_id,
+        msg_id=msg_id,
+        actor_id=current_agent,
+        actor_name=actor_name or current_agent,
+        kind=body.kind,
+        emoji=body.emoji,
+        turn_id=body.turn_id,
+        ttl_sec=body.ttl_sec,
+    )
+    await _broadcast_message_status_reaction(db, room=room, payload=payload)
+
+
+@router.delete("/messages/{msg_id}/status-reactions/{kind}", status_code=204)
+async def clear_message_status_reaction(
+    msg_id: str,
+    kind: str,
+    body: MessageStatusReactionClearRequest,
+    current_agent: str = Depends(get_current_claimed_agent),
+    db: AsyncSession = Depends(get_db),
+):
+    if kind != message_status_reactions.REPLYING_KIND:
+        raise HTTPException(status_code=400, detail="unsupported status reaction kind")
+    room = await _load_status_reaction_room(
+        db=db,
+        room_id=body.room_id,
+        msg_id=msg_id,
+        current_agent=current_agent,
+    )
+    payload = await message_status_reactions.clear_status_reaction(
+        room_id=body.room_id,
+        msg_id=msg_id,
+        actor_id=current_agent,
+        kind=kind,
+        turn_id=body.turn_id,
+    )
+    if payload is not None:
+        await _broadcast_message_status_reaction(db, room=room, payload=payload)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/hub/schemas.py
+++ b/backend/hub/schemas.py
@@ -640,6 +640,18 @@ class DashboardOverviewResponse(BaseModel):
     pending_requests: int
 
 
+class MessageStatusReaction(BaseModel):
+    room_id: str
+    msg_id: str
+    actor_id: str
+    actor_name: str | None = None
+    kind: Literal["replying"]
+    emoji: str
+    state: Literal["active", "cleared", "expired"] = "active"
+    turn_id: str | None = None
+    expires_at: datetime.datetime | None = None
+
+
 class DashboardMessage(BaseModel):
     hub_msg_id: str
     msg_id: str
@@ -653,6 +665,7 @@ class DashboardMessage(BaseModel):
     topic_id: str | None = None
     state: str
     state_counts: dict[str, int] | None = None
+    status_reactions: list[MessageStatusReaction] = Field(default_factory=list)
     mentions: list[str] | None = None
     created_at: datetime.datetime
     is_recalled: bool = False
@@ -808,6 +821,19 @@ class RoomsOverviewResponse(BaseModel):
 
 class TypingRequest(BaseModel):
     room_id: str = Field(..., description="Room ID where the agent is typing", pattern=r"^rm_")
+
+
+class MessageStatusReactionRequest(BaseModel):
+    room_id: str = Field(..., description="Room ID containing the target message", pattern=r"^rm_")
+    kind: Literal["replying"] = "replying"
+    emoji: str = Field(default="⏳", min_length=1, max_length=16)
+    turn_id: str = Field(..., min_length=1, max_length=128)
+    ttl_sec: int = Field(default=180, ge=5, le=600)
+
+
+class MessageStatusReactionClearRequest(BaseModel):
+    room_id: str = Field(..., description="Room ID containing the target message", pattern=r"^rm_")
+    turn_id: str = Field(..., min_length=1, max_length=128)
 
 
 # --- File upload schemas ---

--- a/backend/hub/services/message_status_reactions.py
+++ b/backend/hub/services/message_status_reactions.py
@@ -1,0 +1,187 @@
+"""Ephemeral message-level status reactions backed by Redis.
+
+Used for short-lived BotCord internal room states such as "agent is
+replying". These are not durable user reactions; losing them on Redis restart
+is acceptable and preferable to a stuck UI.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+from typing import Any
+
+from hub.owner_chat_cache import get_redis
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_STATUS_TTL_SECONDS = 180
+MIN_STATUS_TTL_SECONDS = 5
+MAX_STATUS_TTL_SECONDS = 600
+DEFAULT_REPLYING_EMOJI = "⏳"
+REPLYING_KIND = "replying"
+
+
+def clamp_ttl(ttl_sec: int | None) -> int:
+    raw = ttl_sec if isinstance(ttl_sec, int) else DEFAULT_STATUS_TTL_SECONDS
+    return max(MIN_STATUS_TTL_SECONDS, min(MAX_STATUS_TTL_SECONDS, raw))
+
+
+def _now() -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def _reaction_key(room_id: str, msg_id: str, actor_id: str, kind: str) -> str:
+    return f"message_status_reaction:{room_id}:{msg_id}:{actor_id}:{kind}"
+
+
+def _room_index_key(room_id: str) -> str:
+    return f"message_status_reactions:room:{room_id}"
+
+
+def _json_loads(raw: str | bytes | None) -> dict[str, Any] | None:
+    if raw is None:
+        return None
+    try:
+        data = json.loads(raw.decode("utf-8") if isinstance(raw, bytes) else raw)
+    except (TypeError, ValueError, UnicodeDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+async def set_status_reaction(
+    *,
+    room_id: str,
+    msg_id: str,
+    actor_id: str,
+    actor_name: str | None,
+    kind: str,
+    emoji: str,
+    turn_id: str,
+    ttl_sec: int | None = None,
+) -> dict[str, Any]:
+    ttl = clamp_ttl(ttl_sec)
+    expires_at = _now() + datetime.timedelta(seconds=ttl)
+    payload: dict[str, Any] = {
+        "room_id": room_id,
+        "msg_id": msg_id,
+        "actor_id": actor_id,
+        "actor_name": actor_name,
+        "kind": kind,
+        "emoji": emoji,
+        "state": "active",
+        "turn_id": turn_id,
+        "expires_at": expires_at.isoformat(),
+    }
+
+    client = get_redis()
+    if client is None:
+        return payload
+
+    key = _reaction_key(room_id, msg_id, actor_id, kind)
+    index_key = _room_index_key(room_id)
+    try:
+        await client.set(key, json.dumps(payload, ensure_ascii=False), ex=ttl)
+        await client.sadd(index_key, key)
+        await client.expire(index_key, ttl + 60)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "message_status_reactions.set failed room=%s msg=%s actor=%s kind=%s: %s",
+            room_id,
+            msg_id,
+            actor_id,
+            kind,
+            exc,
+        )
+    return payload
+
+
+async def clear_status_reaction(
+    *,
+    room_id: str,
+    msg_id: str,
+    actor_id: str,
+    kind: str,
+    turn_id: str,
+) -> dict[str, Any] | None:
+    payload: dict[str, Any] = {
+        "room_id": room_id,
+        "msg_id": msg_id,
+        "actor_id": actor_id,
+        "kind": kind,
+        "state": "cleared",
+        "turn_id": turn_id,
+    }
+
+    client = get_redis()
+    if client is None:
+        return payload
+
+    key = _reaction_key(room_id, msg_id, actor_id, kind)
+    index_key = _room_index_key(room_id)
+    try:
+        existing = _json_loads(await client.get(key))
+        if existing is not None and existing.get("turn_id") != turn_id:
+            return None
+        await client.delete(key)
+        await client.srem(index_key, key)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "message_status_reactions.clear failed room=%s msg=%s actor=%s kind=%s: %s",
+            room_id,
+            msg_id,
+            actor_id,
+            kind,
+            exc,
+        )
+    return payload
+
+
+async def load_active_status_reactions(
+    room_id: str,
+    msg_ids: list[str],
+) -> dict[str, list[dict[str, Any]]]:
+    if not msg_ids:
+        return {}
+    client = get_redis()
+    if client is None:
+        return {}
+
+    requested = set(msg_ids)
+    index_key = _room_index_key(room_id)
+    stale_keys: list[str] = []
+    out: dict[str, list[dict[str, Any]]] = {}
+    try:
+        keys = list(await client.smembers(index_key))
+        if not keys:
+            return {}
+        raws = await client.mget(keys)
+        now = _now()
+        for key, raw in zip(keys, raws, strict=False):
+            data = _json_loads(raw)
+            if data is None:
+                stale_keys.append(key)
+                continue
+            msg_id = data.get("msg_id")
+            if data.get("room_id") != room_id or msg_id not in requested:
+                continue
+            expires_raw = data.get("expires_at")
+            try:
+                expires_at = (
+                    datetime.datetime.fromisoformat(expires_raw)
+                    if isinstance(expires_raw, str)
+                    else None
+                )
+            except ValueError:
+                expires_at = None
+            if expires_at is None or expires_at <= now:
+                stale_keys.append(key)
+                continue
+            out.setdefault(str(msg_id), []).append(data)
+        if stale_keys:
+            await client.srem(index_key, *stale_keys)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("message_status_reactions.load failed room=%s: %s", room_id, exc)
+        return {}
+    return out

--- a/backend/tests/test_app/test_app_dashboard_rooms.py
+++ b/backend/tests/test_app/test_app_dashboard_rooms.py
@@ -283,6 +283,86 @@ async def test_room_messages_as_member(client: AsyncClient, seed: dict):
 
 
 @pytest.mark.asyncio
+async def test_room_messages_include_active_status_reactions_on_initial_load(
+    client: AsyncClient,
+    seed: dict,
+    monkeypatch,
+):
+    from hub.services import message_status_reactions
+
+    async def fake_load_active_status_reactions(room_id: str, msg_ids: list[str]):
+        assert room_id == "rm_pubopen01"
+        assert set(msg_ids) == {"m_rm_msg000", "m_rm_msg001", "m_rm_msg002"}
+        return {
+            "m_rm_msg001": [
+                {
+                    "room_id": "rm_pubopen01",
+                    "msg_id": "m_rm_msg001",
+                    "actor_id": "ag_joiner01",
+                    "actor_name": "Joiner Agent",
+                    "kind": "replying",
+                    "emoji": "⏳",
+                    "state": "active",
+                    "turn_id": "turn_status_1",
+                    "expires_at": "2026-06-09T02:40:00+00:00",
+                }
+            ]
+        }
+
+    monkeypatch.setattr(
+        message_status_reactions,
+        "load_active_status_reactions",
+        fake_load_active_status_reactions,
+    )
+
+    resp = await client.get(
+        "/api/dashboard/rooms/rm_pubopen01/messages",
+        headers=_h(seed["token1"], seed["agent1"]),
+    )
+    assert resp.status_code == 200
+    by_msg_id = {message["msg_id"]: message for message in resp.json()["messages"]}
+    assert by_msg_id["m_rm_msg001"]["status_reactions"] == [
+        {
+            "room_id": "rm_pubopen01",
+            "msg_id": "m_rm_msg001",
+            "actor_id": "ag_joiner01",
+            "actor_name": "Joiner Agent",
+            "kind": "replying",
+            "emoji": "⏳",
+            "state": "active",
+            "turn_id": "turn_status_1",
+            "expires_at": "2026-06-09T02:40:00+00:00",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_room_messages_default_to_empty_status_reactions(
+    client: AsyncClient,
+    seed: dict,
+    monkeypatch,
+):
+    from hub.services import message_status_reactions
+
+    async def fake_load_active_status_reactions(room_id: str, msg_ids: list[str]):
+        return {}
+
+    monkeypatch.setattr(
+        message_status_reactions,
+        "load_active_status_reactions",
+        fake_load_active_status_reactions,
+    )
+
+    resp = await client.get(
+        "/api/dashboard/rooms/rm_pubopen01/messages",
+        headers=_h(seed["token1"], seed["agent1"]),
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert all(message["status_reactions"] == [] for message in data["messages"])
+
+
+@pytest.mark.asyncio
 async def test_room_messages_public_no_auth(client: AsyncClient, seed: dict):
     resp = await client.get("/api/dashboard/rooms/rm_pubopen01/messages")
     assert resp.status_code == 200

--- a/backend/tests/test_message_status_reactions.py
+++ b/backend/tests/test_message_status_reactions.py
@@ -1,0 +1,112 @@
+import pytest
+
+from hub.services import message_status_reactions
+
+
+class FakeRedis:
+    def __init__(self):
+        self.values = {}
+        self.sets = {}
+        self.ttls = {}
+
+    async def set(self, key, value, ex=None):
+        self.values[key] = value
+        if ex is not None:
+            self.ttls[key] = ex
+
+    async def get(self, key):
+        return self.values.get(key)
+
+    async def delete(self, key):
+        self.values.pop(key, None)
+
+    async def sadd(self, key, *values):
+        self.sets.setdefault(key, set()).update(values)
+
+    async def srem(self, key, *values):
+        current = self.sets.setdefault(key, set())
+        for value in values:
+            current.discard(value)
+
+    async def smembers(self, key):
+        return set(self.sets.get(key, set()))
+
+    async def mget(self, keys):
+        return [self.values.get(key) for key in keys]
+
+    async def expire(self, key, ttl):
+        self.ttls[key] = ttl
+
+
+@pytest.mark.asyncio
+async def test_status_reaction_set_load_and_clear(monkeypatch):
+    fake = FakeRedis()
+    monkeypatch.setattr(message_status_reactions, "get_redis", lambda: fake)
+
+    payload = await message_status_reactions.set_status_reaction(
+        room_id="rm_1",
+        msg_id="msg_1",
+        actor_id="ag_bot",
+        actor_name="Bot",
+        kind="replying",
+        emoji="⏳",
+        turn_id="turn_1",
+        ttl_sec=60,
+    )
+
+    assert payload["state"] == "active"
+    assert payload["expires_at"]
+
+    loaded = await message_status_reactions.load_active_status_reactions("rm_1", ["msg_1"])
+    assert loaded["msg_1"][0]["actor_id"] == "ag_bot"
+    assert loaded["msg_1"][0]["turn_id"] == "turn_1"
+
+    cleared = await message_status_reactions.clear_status_reaction(
+        room_id="rm_1",
+        msg_id="msg_1",
+        actor_id="ag_bot",
+        kind="replying",
+        turn_id="turn_1",
+    )
+    assert cleared is not None
+    assert cleared["state"] == "cleared"
+    assert await message_status_reactions.load_active_status_reactions("rm_1", ["msg_1"]) == {}
+
+
+@pytest.mark.asyncio
+async def test_status_reaction_clear_ignores_stale_turn(monkeypatch):
+    fake = FakeRedis()
+    monkeypatch.setattr(message_status_reactions, "get_redis", lambda: fake)
+
+    await message_status_reactions.set_status_reaction(
+        room_id="rm_1",
+        msg_id="msg_1",
+        actor_id="ag_bot",
+        actor_name="Bot",
+        kind="replying",
+        emoji="⏳",
+        turn_id="turn_new",
+        ttl_sec=60,
+    )
+
+    cleared = await message_status_reactions.clear_status_reaction(
+        room_id="rm_1",
+        msg_id="msg_1",
+        actor_id="ag_bot",
+        kind="replying",
+        turn_id="turn_old",
+    )
+
+    assert cleared is None
+    loaded = await message_status_reactions.load_active_status_reactions("rm_1", ["msg_1"])
+    assert loaded["msg_1"][0]["turn_id"] == "turn_new"
+
+
+@pytest.mark.asyncio
+async def test_status_reaction_load_drops_missing_index_members(monkeypatch):
+    fake = FakeRedis()
+    monkeypatch.setattr(message_status_reactions, "get_redis", lambda: fake)
+    await fake.sadd("message_status_reactions:room:rm_1", "missing_key")
+
+    assert await message_status_reactions.load_active_status_reactions("rm_1", ["msg_1"]) == {}
+    assert fake.sets["message_status_reactions:room:rm_1"] == set()

--- a/frontend/src/components/dashboard/MessageBubble.tsx
+++ b/frontend/src/components/dashboard/MessageBubble.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useCallback, useLayoutEffect, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { KeyboardEvent, ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { useShallow } from "zustand/react/shallow";
@@ -475,6 +475,26 @@ function MessageBubble({
     : [];
 
   const sc = stateConfig[message.state];
+  const [, forceStatusReactionRender] = useState(0);
+  const nowMs = Date.now();
+  const activeStatusReactions = (message.status_reactions ?? []).filter((reaction) => {
+    if (reaction.state && reaction.state !== "active") return false;
+    if (!reaction.expires_at) return true;
+    const expiresAt = Date.parse(reaction.expires_at);
+    return Number.isNaN(expiresAt) || expiresAt > nowMs;
+  });
+  useEffect(() => {
+    const expiries = (message.status_reactions ?? [])
+      .filter((reaction) => !reaction.state || reaction.state === "active")
+      .map((reaction) => reaction.expires_at ? Date.parse(reaction.expires_at) : Number.NaN)
+      .filter((value) => Number.isFinite(value) && value > Date.now());
+    if (expiries.length === 0) return;
+    const nextExpiry = Math.min(...expiries);
+    const timer = window.setTimeout(() => {
+      forceStatusReactionRender((value) => value + 1);
+    }, Math.max(0, nextExpiry - Date.now() + 50));
+    return () => window.clearTimeout(timer);
+  }, [message.status_reactions]);
   const handleSelectSender = () => {
     if (isHuman) {
       requestOpenHuman(message.sender_id, senderDisplayName);
@@ -862,6 +882,16 @@ function MessageBubble({
               {message.type}
             </span>
           )}
+          {activeStatusReactions.map((reaction) => (
+            <span
+              key={`${reaction.actor_id}:${reaction.kind}`}
+              className="inline-flex items-center gap-1 rounded border border-yellow-400/25 bg-yellow-400/10 px-1 py-px text-[10px] font-medium text-yellow-200"
+              title={`${reaction.actor_name || reaction.actor_id} replying`}
+            >
+              <span className="text-[11px] leading-none">{reaction.emoji}</span>
+              <span className="max-w-[96px] truncate">{reaction.actor_name || reaction.actor_id}</span>
+            </span>
+          ))}
           {showMessageStatus && (
             <>
               {message.state_counts && Object.keys(message.state_counts).length > 0 ? (

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -172,6 +172,7 @@ export interface DashboardMessage {
   topic_closed_at?: string | null;
   state: string;
   state_counts: Record<string, number> | null;
+  status_reactions?: MessageStatusReaction[];
   mentions?: string[] | null;
   created_at: string;
   source_type?: string;
@@ -186,6 +187,18 @@ export interface DashboardMessage {
   recalled_at?: string | null;
   recalled_by_id?: string | null;
   recalled_by_type?: ParticipantType | null;
+}
+
+export interface MessageStatusReaction {
+  room_id: string;
+  msg_id: string;
+  actor_id: string;
+  actor_name?: string | null;
+  kind: "replying";
+  emoji: string;
+  state?: "active" | "cleared" | "expired";
+  turn_id?: string | null;
+  expires_at?: string | null;
 }
 
 export interface RoomHumanSendResponse {
@@ -425,6 +438,7 @@ export type RealtimeMetaEventType =
   | "error"
   | "system"
   | "typing"
+  | "message_status_reaction"
   | "agent_status_changed";
 
 export interface RealtimeMetaEvent {

--- a/frontend/src/store/useDashboardChatStore.ts
+++ b/frontend/src/store/useDashboardChatStore.ts
@@ -18,6 +18,7 @@ import type {
   PublicHumanProfile,
   PublicRoom,
   RealtimeMetaEvent,
+  MessageStatusReaction,
   UserAgent,
 } from "@/lib/types";
 import { api, humansApi } from "@/lib/api";
@@ -118,6 +119,45 @@ function buildRecalledMessagePatch(patch?: {
     recalled_by_id: patch?.recalled_by_id ?? null,
     recalled_by_type: patch?.recalled_by_type ?? null,
   };
+}
+
+function messageStatusReactionFromEvent(event: RealtimeMetaEvent): MessageStatusReaction | null {
+  const ext = event.ext || {};
+  const msgId = typeof ext.msg_id === "string" ? ext.msg_id : null;
+  const actorId = typeof ext.actor_id === "string" ? ext.actor_id : null;
+  const kind = ext.kind === "replying" ? "replying" : null;
+  const state =
+    ext.state === "active" || ext.state === "cleared" || ext.state === "expired"
+      ? ext.state
+      : null;
+  if (!event.room_id || !msgId || !actorId || !kind || !state) return null;
+  return {
+    room_id: event.room_id,
+    msg_id: msgId,
+    actor_id: actorId,
+    actor_name: typeof ext.actor_name === "string" ? ext.actor_name : null,
+    kind,
+    emoji: typeof ext.emoji === "string" && ext.emoji ? ext.emoji : "⏳",
+    state,
+    turn_id: typeof ext.turn_id === "string" ? ext.turn_id : null,
+    expires_at: typeof ext.expires_at === "string" ? ext.expires_at : null,
+  };
+}
+
+function upsertStatusReaction(
+  current: MessageStatusReaction[] | undefined,
+  incoming: MessageStatusReaction,
+): MessageStatusReaction[] {
+  const existing = current ?? [];
+  const key = `${incoming.actor_id}:${incoming.kind}`;
+  const filtered = existing.filter((item) => {
+    if (`${item.actor_id}:${item.kind}` !== key) return true;
+    if (incoming.state === "active") return false;
+    if (!incoming.turn_id) return false;
+    return item.turn_id !== incoming.turn_id;
+  });
+  if (incoming.state !== "active") return filtered;
+  return [...filtered, { ...incoming, state: "active" }];
 }
 
 function dashboardMessageStableId(message: Pick<DashboardMessage, "hub_msg_id" | "msg_id">): string {
@@ -337,6 +377,7 @@ interface DashboardChatState {
   insertMessage: (roomId: string, message: DashboardMessage) => void;
   patchMessageIdentity: (roomId: string, temporaryId: string, patch: Partial<Pick<DashboardMessage, "hub_msg_id" | "msg_id" | "topic_id">>) => void;
   markMessageRecalled: (roomId: string, msgId: string, patch?: { recalled_at?: string | null; recalled_by_id?: string | null; recalled_by_type?: "agent" | "human" | null }) => void;
+  applyMessageStatusReaction: (event: RealtimeMetaEvent) => void;
   recallMessage: (roomId: string, msgId: string) => Promise<void>;
   loadRoomMessages: (roomId: string, opts?: { force?: boolean }) => Promise<void>;
   prefetchRoomMessages: (roomId: string) => Promise<void>;
@@ -582,6 +623,33 @@ export const useDashboardChatStore = create<DashboardChatState>()(
               : state.publicRoomDetails,
             recentVisitedRooms: state.recentVisitedRooms.map(patchRoomSummary),
             ownedAgentRooms: state.ownedAgentRooms.map(patchRoomSummary),
+          };
+        }),
+
+      applyMessageStatusReaction: (event) =>
+        set((state) => {
+          if (!event.room_id) return state;
+          const reaction = messageStatusReactionFromEvent(event);
+          if (!reaction) return state;
+          const current = state.messages[event.room_id];
+          if (!current) return state;
+          let changed = false;
+          const nextMessages = current.map((message) => {
+            if (message.msg_id !== reaction.msg_id && message.hub_msg_id !== reaction.msg_id) {
+              return message;
+            }
+            changed = true;
+            return {
+              ...message,
+              status_reactions: upsertStatusReaction(message.status_reactions, reaction),
+            };
+          });
+          if (!changed) return state;
+          return {
+            messages: {
+              ...state.messages,
+              [event.room_id]: nextMessages,
+            },
           };
         }),
 

--- a/frontend/src/store/useDashboardRealtimeStore.ts
+++ b/frontend/src/store/useDashboardRealtimeStore.ts
@@ -32,6 +32,10 @@ function isMessageRecallRealtimeEvent(type: RealtimeMetaEvent["type"]): boolean 
   return type === "message_recalled";
 }
 
+function isMessageStatusReactionRealtimeEvent(type: RealtimeMetaEvent["type"]): boolean {
+  return type === "message_status_reaction";
+}
+
 function isTypingRealtimeEvent(type: RealtimeMetaEvent["type"]): boolean {
   return type === "typing";
 }
@@ -127,6 +131,12 @@ export const useDashboardRealtimeStore = create<DashboardRealtimeState>()((set) 
         }
 
         const chatStore = useDashboardChatStore.getState();
+        if (currentEvent?.room_id && isMessageStatusReactionRealtimeEvent(currentEvent.type)) {
+          chatStore.applyMessageStatusReaction(currentEvent);
+          nextEvent = queuedRealtimeEvent;
+          continue;
+        }
+
         if (currentEvent?.room_id && isMessageRecallRealtimeEvent(currentEvent.type)) {
           const msgId = typeof currentEvent.ext.msg_id === "string"
             ? currentEvent.ext.msg_id

--- a/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
+++ b/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
@@ -2,10 +2,11 @@ import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { Dispatcher, type RuntimeFactory } from "../dispatcher.js";
+import { Dispatcher, pickMessageStatusTarget, type RuntimeFactory } from "../dispatcher.js";
 import { SessionStore } from "../session-store.js";
 import type {
   ChannelAdapter,
+  ChannelMessageStatusContext,
   ChannelSendContext,
   ChannelSendResult,
   ChannelStreamBlockContext,
@@ -31,9 +32,11 @@ interface FakeChannelOptions {
   type?: string;
   withStream?: boolean;
   withTyping?: boolean;
+  withMessageStatus?: boolean;
   sendImpl?: (ctx: ChannelSendContext) => Promise<ChannelSendResult> | ChannelSendResult;
   streamImpl?: (ctx: ChannelStreamBlockContext) => Promise<void> | void;
   typingImpl?: (ctx: ChannelTypingContext) => Promise<void> | void;
+  messageStatusImpl?: (ctx: ChannelMessageStatusContext) => Promise<void> | void;
 }
 
 class FakeChannel implements ChannelAdapter {
@@ -42,11 +45,14 @@ class FakeChannel implements ChannelAdapter {
   readonly sends: ChannelSendContext[] = [];
   readonly streams: ChannelStreamBlockContext[] = [];
   readonly typings: ChannelTypingContext[] = [];
+  readonly messageStatuses: ChannelMessageStatusContext[] = [];
   private readonly sendImpl?: FakeChannelOptions["sendImpl"];
   private readonly streamImpl?: FakeChannelOptions["streamImpl"];
   private readonly typingImpl?: FakeChannelOptions["typingImpl"];
+  private readonly messageStatusImpl?: FakeChannelOptions["messageStatusImpl"];
   streamBlock?: (ctx: ChannelStreamBlockContext) => Promise<void>;
   typing?: (ctx: ChannelTypingContext) => Promise<void>;
+  messageStatus?: (ctx: ChannelMessageStatusContext) => Promise<void>;
 
   constructor(opts: FakeChannelOptions = {}) {
     this.id = opts.id ?? "botcord";
@@ -54,6 +60,7 @@ class FakeChannel implements ChannelAdapter {
     this.sendImpl = opts.sendImpl;
     this.streamImpl = opts.streamImpl;
     this.typingImpl = opts.typingImpl;
+    this.messageStatusImpl = opts.messageStatusImpl;
     if (opts.withStream !== false) {
       this.streamBlock = async (ctx) => {
         this.streams.push(ctx);
@@ -64,6 +71,12 @@ class FakeChannel implements ChannelAdapter {
       this.typing = async (ctx) => {
         this.typings.push(ctx);
         if (this.typingImpl) await this.typingImpl(ctx);
+      };
+    }
+    if (opts.withMessageStatus) {
+      this.messageStatus = async (ctx) => {
+        this.messageStatuses.push(ctx);
+        if (this.messageStatusImpl) await this.messageStatusImpl(ctx);
       };
     }
   }
@@ -209,6 +222,37 @@ function makeEnvelope(
 ): GatewayInboundEnvelope {
   return { message: makeMessage(partial), ack };
 }
+
+describe("pickMessageStatusTarget", () => {
+  it("uses the latest mentioned batch entry", () => {
+    const msg = makeMessage({
+      raw: {
+        envelope: { msg_id: "msg_latest" },
+        batch: [
+          { hub_msg_id: "h1", mentioned: true, envelope: { msg_id: "msg_1" } },
+          { hub_msg_id: "h2", mentioned: false, envelope: { msg_id: "msg_2" } },
+          { hub_msg_id: "h3", mentioned: true, envelope: { msg_id: "msg_3" } },
+        ],
+      },
+    });
+
+    expect(pickMessageStatusTarget(msg)).toBe("msg_3");
+  });
+
+  it("falls back to the latest batch entry", () => {
+    const msg = makeMessage({
+      raw: {
+        envelope: { msg_id: "msg_latest" },
+        batch: [
+          { hub_msg_id: "h1", mentioned: false, envelope: { msg_id: "msg_1" } },
+          { hub_msg_id: "h2", mentioned: false, envelope: { msg_id: "msg_2" } },
+        ],
+      },
+    });
+
+    expect(pickMessageStatusTarget(msg)).toBe("msg_2");
+  });
+});
 
 function cloudRunRaw(
   budget: { max_wall_time_seconds?: number; max_tool_calls?: number },
@@ -1177,6 +1221,53 @@ describe("Dispatcher", () => {
     );
     expect(channel.sends.length).toBe(1);
     expect(channel.sends[0].message.text).toBe("ok");
+  });
+
+  it("message status: marks BotCord group trigger before runtime and clears after completion", async () => {
+    const channel = new FakeChannel({ type: "botcord", withMessageStatus: true });
+    const observed: string[][] = [];
+    const runtime = new FakeRuntime({
+      observeRun: () => {
+        observed.push(channel.messageStatuses.map((ctx) => ctx.phase));
+      },
+      reply: "ok",
+      newSessionId: "sid",
+    });
+    const { dispatcher } = await scaffold({ channel, runtimeFactory: () => runtime });
+
+    await dispatcher.handle(
+      makeEnvelope({
+        conversation: { id: "rm_team", kind: "group" },
+        raw: { envelope: { msg_id: "msg_trigger" } },
+        trace: { id: "trace_group", streamable: false },
+      }),
+    );
+
+    expect(observed[0]).toEqual(["started"]);
+    expect(channel.messageStatuses.map((ctx) => ctx.phase)).toEqual(["started", "cleared"]);
+    expect(channel.messageStatuses[0].conversationId).toBe("rm_team");
+    expect(channel.messageStatuses[0].messageId).toBe("msg_trigger");
+    expect(channel.messageStatuses[0].kind).toBe("replying");
+    expect(channel.messageStatuses[0].emoji).toBe("⏳");
+    expect(channel.messageStatuses[1].turnId).toBe(channel.messageStatuses[0].turnId);
+  });
+
+  it("message status: skips owner-chat rooms", async () => {
+    const channel = new FakeChannel({ type: "botcord", withMessageStatus: true });
+    const { dispatcher } = await scaffold({
+      channel,
+      runtimeFactory: () => new FakeRuntime({ reply: "ok", newSessionId: "sid" }),
+    });
+
+    await dispatcher.handle(
+      makeEnvelope({
+        conversation: { id: "rm_oc_team", kind: "group" },
+        raw: { envelope: { msg_id: "msg_owner_chat" } },
+        trace: { id: "trace_owner", streamable: true },
+      }),
+    );
+
+    expect(channel.messageStatuses.length).toBe(0);
   });
 
   it("thinking: synthesized before first non-assistant block", async () => {

--- a/packages/daemon/src/gateway/channels/botcord.ts
+++ b/packages/daemon/src/gateway/channels/botcord.ts
@@ -11,6 +11,7 @@ import {
 } from "@botcord/protocol-core";
 import type {
   ChannelAdapter,
+  ChannelMessageStatusContext,
   ChannelSendContext,
   ChannelSendResult,
   ChannelStartContext,
@@ -35,6 +36,7 @@ const OWNER_CHAT_PREFIX = "rm_oc_";
 const DM_ROOM_PREFIX = "rm_dm_";
 const INBOX_POLL_LIMIT = 50;
 const CHANNEL_PERMANENT_STOP = "channel_permanent_stop";
+const DEFAULT_REPLYING_STATUS_EMOJI = "⏳";
 
 function withReconnectJitter(delayMs: number): { delayMs: number; jitterMs: number } {
   const jitterMs = Math.floor(Math.random() * delayMs * RECONNECT_JITTER_RATIO);
@@ -393,11 +395,12 @@ async function postControlWithRefresh(
   hubUrl: string,
   path: string,
   body: unknown,
+  method = "POST",
 ): Promise<Response> {
   let token = await client.ensureToken();
   for (let attempt = 0; attempt <= 1; attempt++) {
     const resp = await fetch(`${hubUrl}${path}`, {
-      method: "POST",
+      method,
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${token}`,
@@ -1084,6 +1087,46 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
         }
       } catch (err) {
         ctx.log.warn("botcord typing failed", { err: String(err) });
+      }
+    },
+
+    async messageStatus(ctx: ChannelMessageStatusContext): Promise<void> {
+      const client = ensureClient();
+      const hubUrl = options.hubBaseUrl ?? client.getHubUrl();
+      const body = {
+        room_id: ctx.conversationId,
+        turn_id: ctx.turnId,
+      };
+      try {
+        const path = `/hub/messages/${encodeURIComponent(ctx.messageId)}/status-reactions`;
+        const resp = ctx.phase === "started"
+          ? await postControlWithRefresh(client, hubUrl, path, {
+              ...body,
+              kind: ctx.kind,
+              emoji: ctx.emoji || DEFAULT_REPLYING_STATUS_EMOJI,
+              ttl_sec: 180,
+            })
+          : await postControlWithRefresh(
+              client,
+              hubUrl,
+              `${path}/${encodeURIComponent(ctx.kind)}`,
+              body,
+              "DELETE",
+            );
+        if (!resp.ok && resp.status !== 204) {
+          const respBody = await resp.text().catch(() => "");
+          ctx.log.warn("botcord message status non-ok", {
+            phase: ctx.phase,
+            status: resp.status,
+            body: respBody.slice(0, 200),
+          });
+        }
+      } catch (err) {
+        ctx.log.warn("botcord message status failed", {
+          phase: ctx.phase,
+          messageId: ctx.messageId,
+          err: String(err),
+        });
       }
     },
 

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -89,6 +89,7 @@ function envNonNegativeInt(name: string, fallback: number): number {
  * (or `botcord send` CLI via Bash) to actually deliver replies.
  */
 const OWNER_CHAT_ROOM_PREFIX = "rm_oc_";
+const REPLYING_STATUS_EMOJI = "⏳";
 const TRANSCRIPT_BLOCK_RAW_LIMIT = 16 * 1024;
 const SECRET_KEY_RE = /token|secret|private.?key|api.?key|authorization|password/i;
 
@@ -328,6 +329,36 @@ export function pickReplyToTarget(msg: GatewayInboundMessage): string {
       ? raw.envelope.msg_id
       : null;
   return envMsgId ?? msg.id;
+}
+
+function rawEntryMsgId(entry: unknown): string | null {
+  if (!entry || typeof entry !== "object") return null;
+  const env = (entry as { envelope?: { msg_id?: unknown } }).envelope;
+  return typeof env?.msg_id === "string" && env.msg_id ? env.msg_id : null;
+}
+
+/**
+ * Pick the BotCord room message that should carry the ephemeral "replying"
+ * status reaction for a turn. Batched turns prefer the latest mentioned
+ * message, otherwise the latest batch member.
+ */
+export function pickMessageStatusTarget(msg: GatewayInboundMessage): string | null {
+  const raw = msg.raw as { batch?: unknown; mentioned?: unknown } | null | undefined;
+  const batch = raw && Array.isArray(raw.batch) ? raw.batch : null;
+  if (batch && batch.length > 0) {
+    for (let i = batch.length - 1; i >= 0; i -= 1) {
+      const entry = batch[i] as { mentioned?: unknown } | undefined;
+      if (entry?.mentioned === true) {
+        const msgId = rawEntryMsgId(entry);
+        if (msgId) return msgId;
+      }
+    }
+    for (let i = batch.length - 1; i >= 0; i -= 1) {
+      const msgId = rawEntryMsgId(batch[i]);
+      if (msgId) return msgId;
+    }
+  }
+  return rawEntryMsgId(raw) ?? null;
 }
 
 /** Factory signature for building a runtime adapter at turn dispatch time. */
@@ -1574,6 +1605,39 @@ export class Dispatcher {
       (streamable || !isBotCordChannel(channel));
     const canStream =
       streamable && typeof traceId === "string" && typeof channel.streamBlock === "function";
+    const messageStatusTargetId =
+      isBotCordChannel(channel) &&
+      msg.conversation.kind === "group" &&
+      !isOwnerChatRoom(msg) &&
+      typeof channel.messageStatus === "function"
+        ? pickMessageStatusTarget(msg)
+        : null;
+    let messageStatusStarted = false;
+    const sendReplyingStatus = async (phase: "started" | "cleared"): Promise<void> => {
+      if (!messageStatusTargetId || typeof channel.messageStatus !== "function") return;
+      if (phase === "cleared" && !messageStatusStarted) return;
+      if (phase === "started") messageStatusStarted = true;
+      try {
+        await channel.messageStatus({
+          traceId: traceId ?? null,
+          accountId: msg.accountId,
+          conversationId: msg.conversation.id,
+          messageId: messageStatusTargetId,
+          turnId,
+          kind: "replying",
+          emoji: REPLYING_STATUS_EMOJI,
+          phase,
+          log: this.log,
+        });
+      } catch (err) {
+        this.log.warn("dispatcher: channel.messageStatus failed", {
+          phase,
+          messageId: messageStatusTargetId,
+          turnId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    };
     const recordBlock = (block: StreamBlock): void => {
       if (block.kind === "tool_use" && cloudRunBudget?.maxToolCalls !== undefined) {
         observedToolCalls += 1;
@@ -1824,6 +1888,7 @@ export class Dispatcher {
     // Eagerly fire typing.started before runtime.run so the user sees
     // "agent is responding" within ~one round-trip even if the runtime takes
     // seconds before its first block.
+    await sendReplyingStatus("started");
     fireTypingIfNeeded();
 
     // Compute systemContext right before dispatch. The builder must NOT block
@@ -2389,6 +2454,7 @@ export class Dispatcher {
       // (timeout, error, gated reply). Skipped on cancel-previous: the
       // superseder is about to run its own typing/thinking lifecycle.
       finalizeThinkingIfActive();
+      await sendReplyingStatus("cleared");
       // Clear slot ownership AFTER the reply has been sent (or skipped).
       // Only then do cancel-previous arrivals stop finding this slot — which
       // is exactly what we want: while we're in the post-runtime window, a

--- a/packages/daemon/src/gateway/types.ts
+++ b/packages/daemon/src/gateway/types.ts
@@ -287,6 +287,19 @@ export interface ChannelTypingContext {
   log: GatewayLogger;
 }
 
+/** Context passed to `ChannelAdapter.messageStatus()` for message-level ephemeral state. */
+export interface ChannelMessageStatusContext {
+  traceId: string | null;
+  accountId: string;
+  conversationId: string;
+  messageId: string;
+  turnId: string;
+  kind: "replying";
+  emoji: string;
+  phase: "started" | "cleared";
+  log: GatewayLogger;
+}
+
 /** Upstream messaging surface such as BotCord, Telegram, or WeChat. */
 export interface ChannelAdapter {
   readonly id: string;
@@ -302,6 +315,11 @@ export interface ChannelAdapter {
    * this undefined.
    */
   typing?(ctx: ChannelTypingContext): Promise<void>;
+  /**
+   * Optional message-level status reaction hook. BotCord internal rooms use
+   * this to attach a short-lived "replying" emoji to the triggering message.
+   */
+  messageStatus?(ctx: ChannelMessageStatusContext): Promise<void>;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add Redis-backed ephemeral message status reactions for BotCord internal rooms, including set/clear Hub APIs and dashboard message hydration.
- Have the daemon mark the triggering BotCord group-room message with a replying emoji at turn start, then clear it in the turn finalizer with turn-id stale-clear protection.
- Sync `message_status_reaction` realtime events into the dashboard store and render active reactions on message bubbles with TTL fallback hiding.

## Verification
- `cd backend && uv run pytest tests/test_message_status_reactions.py tests/test_typing.py tests/test_dashboard.py`
- `pnpm --filter @botcord/protocol-core build`
- `pnpm --filter @botcord/daemon build`
- `pnpm --filter @botcord/daemon test -- src/gateway/__tests__/dispatcher.test.ts`
- `cd frontend && NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build`
- `cd backend && uv run python - <<'PY' ... from hub.main import app ... PY`
- `git diff --check`

## Risk / rollout
- Requires Redis for cross-process persistence/hydration; without Redis, status reactions degrade to best-effort realtime events and remain non-durable.
- Daemons need this version to emit start/clear status calls; older daemons continue without message-level status reactions.
