### PR TITLE
fix: inject hub control public key into cloud daemon env

### DIFF
--- a/backend/hub/services/cloud_daemon_provider_e2b.py
+++ b/backend/hub/services/cloud_daemon_provider_e2b.py
@@ -43,6 +43,7 @@ from hub.config import (
     HUB_PUBLIC_BASE_URL,
 )
 from hub.routers.cloud_daemon_control import _create_cloud_daemon_access_token
+from hub.routers.daemon_control import HUB_CONTROL_PUBLIC_KEY_B64
 from hub.services.cloud_daemon_provider import CloudDaemonHandle
 
 logger = logging.getLogger(__name__)
@@ -670,6 +671,7 @@ class E2BCloudDaemonProvider:
             "BOTCORD_CLOUD_DAEMON_INSTANCE_ID": cloud_daemon_instance_id,
             "BOTCORD_DAEMON_INSTANCE_ID": daemon_instance_id,
             "BOTCORD_CLOUD_DAEMON_ACCESS_TOKEN": access_token,
+            "BOTCORD_HUB_CONTROL_PUBLIC_KEY": HUB_CONTROL_PUBLIC_KEY_B64,
             "CLOUD_DAEMON_NPM_SPEC": self._daemon_npm_spec,
         }
         if self._deepseek_api_key:

--- a/backend/tests/test_cloud_daemon_provider_e2b.py
+++ b/backend/tests/test_cloud_daemon_provider_e2b.py
@@ -13,6 +13,7 @@ from hub.routers.cloud_daemon_control import (
     _create_cloud_daemon_access_token,
     _verify_cloud_daemon_access_token,
 )
+from hub.routers.daemon_control import HUB_CONTROL_PUBLIC_KEY_B64
 from hub.services.cloud_agent import (
     CloudAgentService,
     CreateCloudAgentInput,
@@ -115,6 +116,7 @@ async def test_create_or_resume_starts_sandbox_and_injects_env():
     assert env["BOTCORD_HUB_URL"] == "https://hub.test"
     assert env["BOTCORD_CLOUD_DAEMON_INSTANCE_ID"] == "cloud_dm_aaa"
     assert env["BOTCORD_DAEMON_INSTANCE_ID"] == "dm_bbb"
+    assert env["BOTCORD_HUB_CONTROL_PUBLIC_KEY"] == HUB_CONTROL_PUBLIC_KEY_B64
     assert env["DEEPSEEK_API_KEY"] == "ds-secret"
     assert env["CLOUD_DAEMON_NPM_SPEC"] == "@botcord/daemon@latest"
 
@@ -178,6 +180,22 @@ async def test_create_or_resume_injects_extra_runtime_env():
     assert sandbox.env["OPENAI_API_KEY"] == "sk-user"
     assert sandbox.env["OPENAI_BASE_URL"] == "https://new-api.test/v1"
     assert sandbox.env["DEEPSEEK_API_KEY"] == "sk-user"
+
+
+@pytest.mark.asyncio
+async def test_create_or_resume_allows_public_key_override():
+    """Explicit runtime env still wins over provider defaults."""
+    provider, client = _make_provider()
+    handle = await provider.create_or_resume(
+        cloud_daemon_instance_id="cloud_dm_key_override",
+        daemon_instance_id="dm_key_override",
+        user_id=str(uuid.uuid4()),
+        runtime="deepseek-tui",
+        extra_env={"BOTCORD_HUB_CONTROL_PUBLIC_KEY": "override-public-key"},
+    )
+    sandbox = client.get(handle.provider_sandbox_id)
+    assert sandbox is not None
+    assert sandbox.env["BOTCORD_HUB_CONTROL_PUBLIC_KEY"] == "override-public-key"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- inject BOTCORD_HUB_CONTROL_PUBLIC_KEY into E2B cloud daemon sandbox env from backend daemon_control.HUB_CONTROL_PUBLIC_KEY_B64
- keep explicit extra_env override semantics intact
- add cloud daemon provider tests for default public key injection and override behavior

## Context
Preview cloud-agent resume/provision was blocked by bad_signature: preview backend signs hub→daemon control frames with its configured private key, but sandbox daemons were not receiving the matching public key and fell back to the daemon package embedded key.

## Verification
- git diff --check origin/main...HEAD
- cd backend && uv run pytest tests/test_cloud_daemon_provider_e2b.py
