### PR TITLE
chore: release daemon replying status support

### DIFF
--- a/.changeset/quick-masks-reply.md
+++ b/.changeset/quick-masks-reply.md
@@ -1,0 +1,5 @@
+---
+"@botcord/daemon": patch
+---
+
+Publish the BotCord group-room replying status reaction runtime support.


### PR DESCRIPTION
## Summary
- add a changeset to publish @botcord/daemon patch with merged PR #921 replying status reaction runtime support

## Validation
- corepack pnpm --filter @botcord/daemon build
- corepack pnpm --filter @botcord/daemon test -- src/gateway/__tests__/dispatcher.test.ts src/gateway/__tests__/botcord-channel.test.ts
- npm pack --dry-run --json in packages/daemon
- npm view @botcord/daemon version => 0.3.0

## Notes
No daemon logic changes in this PR. Main already contains PR #921 implementation in src and dist; preview cloud daemons still install @botcord/daemon@latest, and npm latest remains 0.3.0 without that implementation.