### PR TITLE
chore(release): version packages

### DIFF
--- a/.changeset/quick-masks-reply.md
+++ b/.changeset/quick-masks-reply.md
@@ -1,5 +1,0 @@
----
-"@botcord/daemon": patch
----
-
-Publish the BotCord group-room replying status reaction runtime support.

--- a/packages/daemon/CHANGELOG.md
+++ b/packages/daemon/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @botcord/daemon
 
+## 0.3.1
+
+### Patch Changes
+
+- 7a775a6: Publish the BotCord group-room replying status reaction runtime support.
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botcord/daemon",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "BotCord local daemon — bridges Hub inbox push to local Claude Code / Codex / Gemini CLIs",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Run `corepack pnpm exec changeset version` after Release Packages workflow run 27184526371 could not create the version PR.
- Bump `@botcord/daemon` from 0.3.0 to 0.3.1 and consume `.changeset/quick-masks-reply.md`.
- No npm publish, deploy, restart, prod, or stable changes.

## Validation
- `corepack pnpm install --frozen-lockfile`
- `git diff --check`
- `node -e "...package/changelog sanity..."`

## Caveats
- `corepack pnpm install --frozen-lockfile` reports existing bin-link warnings because CLI dist is not built in this checkout.
- `corepack pnpm exec changeset status --since=origin/main` is not applicable after versioning because the version PR intentionally consumes the changeset file.