### PR TITLE
feat(backend): BotLearn first-party browser integration (PR 9)

### DIFF
--- a/backend/app/botlearn_auth.py
+++ b/backend/app/botlearn_auth.py
@@ -1,0 +1,285 @@
+"""BotLearn first-party integration auth.
+
+Two token families live here:
+
+1. **BotLearn login token** — issued by BotLearn's own auth provider. The Hub
+   *verifies* it (issuer / audience / signature / expiry / email_verified) but
+   never mints it. Supports HS256 (shared secret / same Supabase tenant) and
+   RS256/ES256 (issuer JWKS).
+2. **BotCord integration session token** — minted by the Hub, short-lived,
+   scoped to one user + one default Cloud Agent + a small scope set. This is
+   the only BotCord credential the BotLearn browser ever holds, and it decays
+   within ``BOTLEARN_SESSION_TTL_SECONDS``.
+
+The browser never receives a long-term BotCord API key. See
+``docs/cloud-agent-technical-design.md`` §3.4 / §4.5 / §6.4.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import uuid as _uuid
+from dataclasses import dataclass
+
+import jwt as pyjwt
+from jwt import PyJWKClient
+
+from hub.config import (
+    BOTLEARN_ALLOWED_ORIGINS,
+    BOTLEARN_AUDIENCE,
+    BOTLEARN_INTEGRATION_ENABLED,
+    BOTLEARN_ISSUER,
+    BOTLEARN_JWKS_URL,
+    BOTLEARN_JWT_SECRET,
+    BOTLEARN_REQUIRE_EMAIL_VERIFIED,
+    BOTLEARN_SESSION_TTL_SECONDS,
+    JWT_ALGORITHM,
+    JWT_SECRET,
+)
+
+logger = logging.getLogger(__name__)
+
+# Namespace for deriving a stable BotCord ``supabase_user_id`` UUID from a
+# non-UUID BotLearn subject. Fixed forever — changing it would orphan every
+# JIT-created BotLearn user.
+BOTLEARN_USER_NAMESPACE = _uuid.UUID("b07c0ad0-b07e-1ea7-0000-b07c0a9eb07c")
+
+# Session token envelope identity.
+BOTLEARN_SESSION_TOKEN_KIND = "botlearn-integration-session"
+BOTLEARN_SESSION_ISSUER = "botcord-hub"
+BOTLEARN_SESSION_AUDIENCE = "botlearn"
+
+# Scopes granted to a fresh session. Kept minimal — the Cloud Run public
+# subset only.
+BOTLEARN_SCOPE_RUNS_CREATE = "cloud_runs:create"
+BOTLEARN_SCOPE_RUNS_READ = "cloud_runs:read"
+BOTLEARN_SCOPE_RUNS_STREAM = "cloud_runs:stream"
+BOTLEARN_SCOPE_RUNS_CANCEL = "cloud_runs:cancel"
+
+DEFAULT_BOTLEARN_SCOPES: list[str] = [
+    BOTLEARN_SCOPE_RUNS_CREATE,
+    BOTLEARN_SCOPE_RUNS_READ,
+    BOTLEARN_SCOPE_RUNS_STREAM,
+    BOTLEARN_SCOPE_RUNS_CANCEL,
+]
+
+# WS method -> required scope. The Hub rejects any method not in this map
+# (this is the allowlist) and any method whose scope the session lacks.
+BOTLEARN_METHOD_REQUIRED_SCOPE: dict[str, str] = {
+    "cloud_agent.get": BOTLEARN_SCOPE_RUNS_READ,
+    "cloud_run.create": BOTLEARN_SCOPE_RUNS_CREATE,
+    "cloud_run.get": BOTLEARN_SCOPE_RUNS_READ,
+    "cloud_run.cancel": BOTLEARN_SCOPE_RUNS_CANCEL,
+    "cloud_usage.get": BOTLEARN_SCOPE_RUNS_READ,
+}
+
+BOTLEARN_WS_PROTOCOL = "botcord-agent-session/0.1"
+
+
+class BotlearnAuthError(Exception):
+    """Raised for BotLearn token / origin failures.
+
+    The HTTP layer maps :attr:`http_status`; the WS layer maps to a close
+    code. Service code never raises ``HTTPException`` directly.
+    """
+
+    def __init__(self, code: str, message: str, *, http_status: int = 401) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.http_status = http_status
+
+
+@dataclass(frozen=True)
+class BotlearnIdentity:
+    subject: str
+    email: str | None
+    email_verified: bool
+    name: str | None
+
+
+def _now() -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+# JWKS clients keyed by URL — lazily created, long-lived (mirrors app.auth).
+_jwks_clients: dict[str, PyJWKClient] = {}
+
+
+def _get_jwks_client(jwks_url: str) -> PyJWKClient:
+    if jwks_url not in _jwks_clients:
+        _jwks_clients[jwks_url] = PyJWKClient(jwks_url, cache_keys=True)
+    return _jwks_clients[jwks_url]
+
+
+def is_botlearn_origin_allowed(origin: str | None) -> bool:
+    """Origin allowlist gate for the session + WS endpoints.
+
+    Deny by default: an empty allowlist (unconfigured) closes the integration,
+    and a missing Origin header is rejected.
+    """
+    if not BOTLEARN_ALLOWED_ORIGINS:
+        return False
+    if not origin:
+        return False
+    return origin.rstrip("/") in set(BOTLEARN_ALLOWED_ORIGINS)
+
+
+def verify_botlearn_id_token(token: str) -> BotlearnIdentity:
+    """Verify a BotLearn login token and return the caller's identity.
+
+    Raises :class:`BotlearnAuthError` on any verification failure.
+    """
+    if not BOTLEARN_INTEGRATION_ENABLED:
+        raise BotlearnAuthError(
+            "botlearn_disabled",
+            "BotLearn integration is not enabled",
+            http_status=403,
+        )
+
+    try:
+        header = pyjwt.get_unverified_header(token)
+    except pyjwt.PyJWTError:
+        raise BotlearnAuthError("invalid_token", "Invalid BotLearn token")
+
+    alg = header.get("alg", "RS256")
+    options: dict[str, bool] = {}
+    decode_kwargs: dict = {"algorithms": [alg]}
+    if BOTLEARN_AUDIENCE:
+        decode_kwargs["audience"] = BOTLEARN_AUDIENCE
+    else:
+        options["verify_aud"] = False
+    if BOTLEARN_ISSUER:
+        decode_kwargs["issuer"] = BOTLEARN_ISSUER
+
+    try:
+        if alg.startswith("HS"):
+            if not BOTLEARN_JWT_SECRET:
+                raise BotlearnAuthError(
+                    "botlearn_not_configured",
+                    "BotLearn HS256 verification is not configured",
+                    http_status=503,
+                )
+            payload = pyjwt.decode(
+                token, BOTLEARN_JWT_SECRET, options=options, **decode_kwargs
+            )
+        else:
+            if not BOTLEARN_JWKS_URL:
+                raise BotlearnAuthError(
+                    "botlearn_not_configured",
+                    "BotLearn JWKS verification is not configured",
+                    http_status=503,
+                )
+            signing_key = _get_jwks_client(BOTLEARN_JWKS_URL).get_signing_key_from_jwt(
+                token
+            )
+            payload = pyjwt.decode(
+                token, signing_key.key, options=options, **decode_kwargs
+            )
+    except pyjwt.ExpiredSignatureError:
+        raise BotlearnAuthError("token_expired", "BotLearn token expired")
+    except pyjwt.InvalidIssuerError:
+        raise BotlearnAuthError("invalid_issuer", "BotLearn token issuer not allowed")
+    except pyjwt.InvalidAudienceError:
+        raise BotlearnAuthError(
+            "invalid_audience", "BotLearn token audience not allowed"
+        )
+    except BotlearnAuthError:
+        raise
+    except pyjwt.InvalidTokenError as exc:
+        logger.debug("BotLearn token verification failed: %s", exc)
+        raise BotlearnAuthError("invalid_token", "Invalid BotLearn token")
+
+    subject = payload.get("sub")
+    if not subject:
+        raise BotlearnAuthError("invalid_token", "BotLearn token missing sub claim")
+
+    email = payload.get("email")
+    email = email.strip().lower() if isinstance(email, str) and email.strip() else None
+    email_verified = bool(payload.get("email_verified", False))
+    if BOTLEARN_REQUIRE_EMAIL_VERIFIED and not email_verified:
+        raise BotlearnAuthError(
+            "email_not_verified",
+            "BotLearn account email is not verified",
+            http_status=403,
+        )
+
+    name = payload.get("name") or payload.get("full_name") or None
+    return BotlearnIdentity(
+        subject=str(subject),
+        email=email,
+        email_verified=email_verified,
+        name=name if isinstance(name, str) else None,
+    )
+
+
+def botcord_supabase_id_for_botlearn(subject: str) -> _uuid.UUID:
+    """Map a BotLearn subject to the BotCord ``supabase_user_id`` UUID.
+
+    When BotLearn shares the Supabase tenant the subject *is* the Supabase
+    UUID, so it maps onto the same ``users`` row the dashboard would create.
+    Otherwise derive a stable UUID5 so re-login lands on the same user.
+    """
+    try:
+        return _uuid.UUID(subject)
+    except (ValueError, AttributeError):
+        return _uuid.uuid5(BOTLEARN_USER_NAMESPACE, subject)
+
+
+def issue_botlearn_session_token(
+    *,
+    user_id: _uuid.UUID,
+    botlearn_subject: str,
+    agent_id: str,
+    installation_id: str,
+    scopes: list[str],
+) -> tuple[str, int]:
+    """Mint a short-lived BotCord integration session token.
+
+    Returns ``(token, expires_in_seconds)``.
+    """
+    now = _now()
+    exp = now + datetime.timedelta(seconds=BOTLEARN_SESSION_TTL_SECONDS)
+    payload = {
+        "kind": BOTLEARN_SESSION_TOKEN_KIND,
+        "iss": BOTLEARN_SESSION_ISSUER,
+        "aud": BOTLEARN_SESSION_AUDIENCE,
+        "sub": str(user_id),
+        "botlearn_sub": botlearn_subject,
+        "user_id": str(user_id),
+        "agent_id": agent_id,
+        "installation_id": installation_id,
+        "scopes": list(scopes),
+        "iat": now,
+        "exp": exp,
+    }
+    token = pyjwt.encode(payload, JWT_SECRET, algorithm=JWT_ALGORITHM)
+    return token, BOTLEARN_SESSION_TTL_SECONDS
+
+
+def verify_botlearn_session_token(token: str) -> dict:
+    """Decode + validate a BotCord integration session token.
+
+    Raises :class:`BotlearnAuthError` on any failure. Guards against a token
+    of another kind being replayed here.
+    """
+    try:
+        payload = pyjwt.decode(
+            token,
+            JWT_SECRET,
+            algorithms=[JWT_ALGORITHM],
+            audience=BOTLEARN_SESSION_AUDIENCE,
+            issuer=BOTLEARN_SESSION_ISSUER,
+        )
+    except pyjwt.ExpiredSignatureError:
+        raise BotlearnAuthError("token_expired", "Session token expired")
+    except pyjwt.InvalidTokenError:
+        raise BotlearnAuthError("invalid_token", "Invalid session token")
+    if payload.get("kind") != BOTLEARN_SESSION_TOKEN_KIND:
+        raise BotlearnAuthError("invalid_token", "Wrong token kind")
+    if not payload.get("user_id") or not payload.get("agent_id"):
+        raise BotlearnAuthError("invalid_token", "Session token missing claims")
+    if not payload.get("installation_id"):
+        raise BotlearnAuthError("invalid_token", "Session token missing installation")
+    return payload

--- a/backend/app/routers/botlearn.py
+++ b/backend/app/routers/botlearn.py
@@ -1,0 +1,528 @@
+"""BotLearn first-party browser integration (PR 9).
+
+Two surfaces, both gated by ``BOTLEARN_INTEGRATION_ENABLED`` and an Origin
+allowlist:
+
+- ``POST /api/integrations/botlearn/session`` — verify a BotLearn login token,
+  JIT-create/bind the BotCord user, select/create a default Cloud Agent, record
+  the ``botlearn_installations`` authorization, and mint a short-lived session
+  token. The browser never receives a long-term BotCord API key.
+- ``GET /api/integrations/botlearn/ws`` — ``botcord-agent-session/0.1`` WS that
+  accepts the session token and exposes only the Cloud Run public subset.
+  ``cloud_run.create`` reuses ``CloudAgentService.create_run`` so it cannot
+  bypass quota preflight / reservation / settlement.
+
+See docs/cloud-agent-technical-design.md §3.4 / §4.5 / §6.4.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import logging
+import uuid as _uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Request, WebSocket
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import _load_user_and_roles
+from app.botlearn_auth import (
+    BOTLEARN_METHOD_REQUIRED_SCOPE,
+    BOTLEARN_WS_PROTOCOL,
+    DEFAULT_BOTLEARN_SCOPES,
+    BotlearnAuthError,
+    BotlearnIdentity,
+    botcord_supabase_id_for_botlearn,
+    is_botlearn_origin_allowed,
+    issue_botlearn_session_token,
+    verify_botlearn_id_token,
+    verify_botlearn_session_token,
+)
+from app.routers import cloud_agents as _cloud_agents_router
+from hub.config import (
+    BOTLEARN_INTEGRATION_ENABLED,
+    BOTLEARN_WS_URL,
+    HUB_PUBLIC_BASE_URL,
+)
+from hub.database import async_session, get_db
+from hub.id_generators import generate_botlearn_installation_id
+from hub.models import BotlearnInstallation, User
+from hub.services.cloud_agent import (
+    CloudAgentError,
+    CloudAgentService,
+    CreateCloudAgentInput,
+    CreateRunInput,
+    RunBudget,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/integrations/botlearn", tags=["botlearn-integration"])
+
+_INACTIVE_CLOUD_AGENT_STATUSES = {"deleted", "deleting", "failed"}
+
+
+def _now() -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def _botlearn_ws_url() -> str:
+    if BOTLEARN_WS_URL:
+        return BOTLEARN_WS_URL
+    base = HUB_PUBLIC_BASE_URL
+    if base.startswith("https://"):
+        base = "wss://" + base[len("https://"):]
+    elif base.startswith("http://"):
+        base = "ws://" + base[len("http://"):]
+    return base.rstrip("/") + "/api/integrations/botlearn/ws"
+
+
+def _auth_error_to_http(exc: BotlearnAuthError) -> HTTPException:
+    return HTTPException(
+        status_code=exc.http_status,
+        detail={"code": exc.code, "message": exc.message},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Session exchange
+# ---------------------------------------------------------------------------
+
+
+class BotlearnSessionOut(BaseModel):
+    access_token: str
+    expires_in: int
+    agent_id: str
+    installation_id: str
+    ws_url: str
+
+
+async def _find_or_create_user(
+    db: AsyncSession, identity: BotlearnIdentity
+) -> User:
+    """JIT-create or reattach the BotCord user behind a BotLearn identity.
+
+    Reuses ``app.auth._load_user_and_roles`` so the email-reattach + member
+    role + beta handling stays identical to the dashboard login path.
+    """
+    supabase_id = botcord_supabase_id_for_botlearn(identity.subject)
+    jwt_payload = {
+        "email": identity.email,
+        "email_verified": identity.email_verified,
+        "user_metadata": {
+            "full_name": identity.name,
+            "email_verified": identity.email_verified,
+        },
+        "app_metadata": {"provider": "email"} if identity.email_verified else {},
+    }
+    user, _roles = await _load_user_and_roles(
+        str(supabase_id), db, jwt_payload=jwt_payload
+    )
+    return user
+
+
+async def _select_default_cloud_agent(
+    db: AsyncSession, service: CloudAgentService, user: User
+) -> str:
+    """Return the user's default Cloud Agent, creating one when needed.
+
+    Failures (quota, feature flag, provisioning) propagate as
+    ``CloudAgentError`` so the session exchange returns a 4xx/5xx and never
+    hands out a usable session token.
+    """
+    views = await service.list_cloud_agents(db, user_id=user.id)
+    active = [v for v in views if v.status not in _INACTIVE_CLOUD_AGENT_STATUSES]
+    if active:
+        chosen = next((v for v in active if v.status == "ready"), active[0])
+        return chosen.agent_id
+    view = await service.create_cloud_agent(
+        db,
+        user_id=user.id,
+        body=CreateCloudAgentInput(name="BotLearn Agent"),
+    )
+    return view.agent_id
+
+
+async def _upsert_installation(
+    db: AsyncSession,
+    *,
+    user: User,
+    identity: BotlearnIdentity,
+    agent_id: str,
+) -> BotlearnInstallation:
+    existing = await db.scalar(
+        select(BotlearnInstallation).where(
+            BotlearnInstallation.botlearn_subject == identity.subject,
+            BotlearnInstallation.agent_id == agent_id,
+        )
+    )
+    now = _now()
+    if existing is not None:
+        existing.user_id = user.id
+        existing.botlearn_email = identity.email
+        existing.scopes_json = list(DEFAULT_BOTLEARN_SCOPES)
+        existing.last_used_at = now
+        existing.revoked_at = None
+        return existing
+    installation = BotlearnInstallation(
+        id=generate_botlearn_installation_id(),
+        user_id=user.id,
+        botlearn_subject=identity.subject,
+        botlearn_email=identity.email,
+        agent_id=agent_id,
+        scopes_json=list(DEFAULT_BOTLEARN_SCOPES),
+        limits_json={},
+        last_used_at=now,
+    )
+    db.add(installation)
+    return installation
+
+
+@router.post("/session", response_model=BotlearnSessionOut)
+async def create_botlearn_session(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    service: CloudAgentService = Depends(
+        _cloud_agents_router.get_cloud_agent_service
+    ),
+) -> BotlearnSessionOut:
+    if not BOTLEARN_INTEGRATION_ENABLED:
+        raise HTTPException(
+            status_code=403,
+            detail={"code": "botlearn_disabled", "message": "BotLearn integration is not enabled"},
+        )
+
+    origin = request.headers.get("origin")
+    if not is_botlearn_origin_allowed(origin):
+        raise HTTPException(
+            status_code=403,
+            detail={"code": "origin_not_allowed", "message": "Origin not allowed"},
+        )
+
+    authorization = request.headers.get("authorization")
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(
+            status_code=401,
+            detail={"code": "unauthorized", "message": "Missing BotLearn token"},
+        )
+
+    try:
+        identity = verify_botlearn_id_token(authorization[len("Bearer "):])
+    except BotlearnAuthError as exc:
+        raise _auth_error_to_http(exc) from exc
+
+    user = await _find_or_create_user(db, identity)
+
+    # Default Cloud Agent (create on first use). Quota / feature failures must
+    # abort before any token is issued.
+    try:
+        agent_id = await _select_default_cloud_agent(db, service, user)
+    except CloudAgentError as exc:
+        await db.rollback()
+        raise HTTPException(
+            status_code=exc.http_status,
+            detail={"code": exc.code, "message": exc.message},
+        ) from exc
+
+    installation = await _upsert_installation(
+        db, user=user, identity=identity, agent_id=agent_id
+    )
+    await db.commit()
+
+    access_token, expires_in = issue_botlearn_session_token(
+        user_id=user.id,
+        botlearn_subject=identity.subject,
+        agent_id=agent_id,
+        installation_id=installation.id,
+        scopes=list(installation.scopes_json or DEFAULT_BOTLEARN_SCOPES),
+    )
+    return BotlearnSessionOut(
+        access_token=access_token,
+        expires_in=expires_in,
+        agent_id=agent_id,
+        installation_id=installation.id,
+        ws_url=_botlearn_ws_url(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# App-facing WebSocket — botcord-agent-session/0.1
+# ---------------------------------------------------------------------------
+
+
+_WS_HEARTBEAT_INTERVAL = 30  # seconds
+_WS_AUTH_TIMEOUT = 10  # seconds
+
+
+async def _installation_is_active(installation_id: str) -> BotlearnInstallation | None:
+    """Re-read the installation and return it only if still authorized."""
+    async with async_session() as db:
+        inst = await db.scalar(
+            select(BotlearnInstallation).where(
+                BotlearnInstallation.id == installation_id
+            )
+        )
+        if inst is None or inst.revoked_at is not None:
+            return None
+        return inst
+
+
+def _res(req_id, *, ok: bool, result=None, code: str | None = None, message: str | None = None) -> dict:
+    frame: dict = {"type": "res", "id": req_id, "ok": ok}
+    if ok:
+        frame["result"] = result or {}
+    else:
+        frame["error"] = {"code": code or "error", "message": message or ""}
+    return frame
+
+
+async def _dispatch_method(
+    *,
+    service: CloudAgentService,
+    method: str,
+    params: dict,
+    user_id: _uuid.UUID,
+    agent_id: str,
+) -> dict:
+    """Run one Cloud Run public-subset method against a fresh DB session.
+
+    Returns the ``result`` payload. Raises ``CloudAgentError`` on a handled
+    service-level failure (mapped to a ``res ok=false`` by the caller).
+    """
+    async with async_session() as db:
+        if method == "cloud_agent.get":
+            view = await service.get_cloud_agent(db, user_id=user_id, agent_id=agent_id)
+            return {
+                "agent_id": view.agent_id,
+                "name": view.name,
+                "status": view.status,
+                "runtime": view.runtime,
+                "model_profile": view.model_profile,
+            }
+        if method == "cloud_run.create":
+            budget_in = params.get("budget") or {}
+            budget = None
+            if budget_in:
+                budget = RunBudget(
+                    max_wall_time_seconds=int(
+                        budget_in.get("max_wall_time_seconds", 600)
+                    ),
+                    max_tool_calls=int(budget_in.get("max_tool_calls", 30)),
+                )
+            view = await service.create_run(
+                db,
+                user_id=user_id,
+                agent_id=agent_id,
+                body=CreateRunInput(
+                    prompt=str(params.get("prompt", "")),
+                    room_id=params.get("room_id"),
+                    topic=params.get("topic"),
+                    budget=budget,
+                ),
+            )
+            return {
+                "run_id": view.run_id,
+                "agent_id": view.agent_id,
+                "room_id": view.room_id,
+                "status": view.status,
+                "budget": {
+                    "max_wall_time_seconds": view.budget.max_wall_time_seconds,
+                    "max_tool_calls": view.budget.max_tool_calls,
+                },
+            }
+        if method == "cloud_run.get":
+            run_id = str(params.get("run_id", ""))
+            view = await service.get_run(
+                db, user_id=user_id, agent_id=agent_id, run_id=run_id
+            )
+            return _run_status_payload(view)
+        if method == "cloud_run.cancel":
+            run_id = str(params.get("run_id", ""))
+            view = await service.cancel_run(
+                db, user_id=user_id, agent_id=agent_id, run_id=run_id
+            )
+            return _run_status_payload(view)
+        if method == "cloud_usage.get":
+            view = await service.get_usage(db, user_id=user_id, agent_id=agent_id)
+            return {
+                "agent_id": view.agent_id,
+                "included_credits": view.included_credits,
+                "used_credits": view.used_credits,
+                "reserved_credits": view.reserved_credits,
+                "available_credits": view.available_credits,
+                "included_sandbox_seconds": view.included_sandbox_seconds,
+                "used_sandbox_seconds": view.used_sandbox_seconds,
+                "available_sandbox_seconds": view.available_sandbox_seconds,
+            }
+        raise CloudAgentError("method_not_allowed", f"unknown method {method!r}", http_status=400)
+
+
+def _run_status_payload(view) -> dict:
+    return {
+        "run_id": view.run_id,
+        "agent_id": view.agent_id,
+        "status": view.status,
+        "reserved_credits": view.reserved_credits,
+        "reserved_sandbox_seconds": view.reserved_sandbox_seconds,
+        "credits_charged": view.credits_charged,
+    }
+
+
+@router.websocket("/ws")
+async def botlearn_ws(ws: WebSocket):
+    """``botcord-agent-session/0.1`` — Cloud Run public subset for BotLearn.
+
+    The session token rides in the first ``hello`` frame (browser WebSocket
+    clients cannot set an Authorization header). Origin allowlist is enforced
+    before the upgrade.
+    """
+    origin = ws.headers.get("origin")
+    if not BOTLEARN_INTEGRATION_ENABLED or not is_botlearn_origin_allowed(origin):
+        await ws.close(code=4003, reason="Origin not allowed")
+        return
+
+    await ws.accept()
+
+    # --- hello / auth ---
+    try:
+        hello = await asyncio.wait_for(ws.receive_json(), timeout=_WS_AUTH_TIMEOUT)
+    except (asyncio.TimeoutError, Exception):
+        await ws.close(code=4001, reason="Auth timeout")
+        return
+
+    if not isinstance(hello, dict) or hello.get("type") != "hello":
+        await ws.close(code=4001, reason="Expected hello")
+        return
+
+    token = hello.get("token") or ""
+    if not token:
+        await ws.close(code=4001, reason="Missing token")
+        return
+
+    try:
+        claims = verify_botlearn_session_token(token)
+    except BotlearnAuthError:
+        await ws.close(code=4001, reason="Invalid session token")
+        return
+
+    installation_id = claims["installation_id"]
+    inst = await _installation_is_active(installation_id)
+    if inst is None:
+        await ws.close(code=4001, reason="Installation revoked")
+        return
+
+    try:
+        user_id = _uuid.UUID(str(claims["user_id"]))
+    except ValueError:
+        await ws.close(code=4001, reason="Invalid session token")
+        return
+    agent_id = str(claims["agent_id"])
+    scopes = set(claims.get("scopes") or [])
+
+    await ws.send_json(
+        {
+            "type": "hello_ok",
+            "protocol": BOTLEARN_WS_PROTOCOL,
+            "agent_id": agent_id,
+            "scopes": sorted(scopes),
+        }
+    )
+    logger.info(
+        "BotLearn WS connected: installation=%s user=%s agent=%s",
+        installation_id,
+        user_id,
+        agent_id,
+    )
+
+    service = _cloud_agents_router.get_cloud_agent_service()
+
+    # --- request loop ---
+    try:
+        while True:
+            try:
+                msg = await asyncio.wait_for(
+                    ws.receive_json(), timeout=_WS_HEARTBEAT_INTERVAL
+                )
+            except asyncio.TimeoutError:
+                await ws.send_json({"type": "event", "event": "heartbeat"})
+                continue
+
+            if not isinstance(msg, dict):
+                continue
+            msg_type = msg.get("type")
+
+            if msg_type == "ping":
+                await ws.send_json({"type": "pong"})
+                continue
+            if msg_type != "req":
+                continue
+
+            req_id = msg.get("id")
+            method = msg.get("method")
+            params = msg.get("params") or {}
+            if not isinstance(params, dict):
+                params = {}
+
+            required_scope = BOTLEARN_METHOD_REQUIRED_SCOPE.get(method)
+            if required_scope is None:
+                await ws.send_json(
+                    _res(req_id, ok=False, code="method_not_allowed", message=f"method {method!r} not allowed")
+                )
+                continue
+            if required_scope not in scopes:
+                await ws.send_json(
+                    _res(req_id, ok=False, code="insufficient_scope", message=f"missing scope {required_scope}")
+                )
+                continue
+
+            # Re-check revocation on every privileged call so a revoke takes
+            # effect mid-session, not just at connect.
+            if await _installation_is_active(installation_id) is None:
+                await ws.send_json(
+                    _res(req_id, ok=False, code="installation_revoked", message="installation revoked")
+                )
+                await ws.close(code=4001, reason="Installation revoked")
+                return
+
+            try:
+                result = await _dispatch_method(
+                    service=service,
+                    method=method,
+                    params=params,
+                    user_id=user_id,
+                    agent_id=agent_id,
+                )
+            except CloudAgentError as exc:
+                await ws.send_json(
+                    _res(req_id, ok=False, code=exc.code, message=exc.message)
+                )
+                continue
+            except Exception as exc:  # noqa: BLE001
+                logger.exception(
+                    "BotLearn WS method failed: method=%s err=%s", method, exc
+                )
+                await ws.send_json(
+                    _res(req_id, ok=False, code="internal_error", message="internal error")
+                )
+                continue
+
+            await ws.send_json(_res(req_id, ok=True, result=result))
+
+            # Surface a coarse lifecycle event for run creation so the
+            # frontend can show "started" without polling immediately. Live
+            # output deltas are retrieved via cloud_run.get (no daemon stream
+            # bridge in this PR).
+            if method == "cloud_run.create":
+                await ws.send_json(
+                    {
+                        "type": "event",
+                        "event": "run.started",
+                        "run_id": result.get("run_id"),
+                    }
+                )
+    except Exception as exc:  # noqa: BLE001 — WebSocketDisconnect & friends
+        logger.info(
+            "BotLearn WS closed: installation=%s err=%s", installation_id, exc
+        )

--- a/backend/app/routers/botlearn.py
+++ b/backend/app/routers/botlearn.py
@@ -164,7 +164,6 @@ async def _upsert_installation(
         existing.botlearn_email = identity.email
         existing.scopes_json = list(DEFAULT_BOTLEARN_SCOPES)
         existing.last_used_at = now
-        existing.revoked_at = None
         return existing
     installation = BotlearnInstallation(
         id=generate_botlearn_installation_id(),
@@ -178,6 +177,22 @@ async def _upsert_installation(
     )
     db.add(installation)
     return installation
+
+
+async def _find_revoked_installation_for_subject(
+    db: AsyncSession,
+    *,
+    identity: BotlearnIdentity,
+) -> BotlearnInstallation | None:
+    return await db.scalar(
+        select(BotlearnInstallation)
+        .where(
+            BotlearnInstallation.botlearn_subject == identity.subject,
+            BotlearnInstallation.revoked_at.is_not(None),
+        )
+        .order_by(BotlearnInstallation.revoked_at.desc())
+        .limit(1)
+    )
 
 
 @router.post("/session", response_model=BotlearnSessionOut)
@@ -213,6 +228,16 @@ async def create_botlearn_session(
     except BotlearnAuthError as exc:
         raise _auth_error_to_http(exc) from exc
 
+    revoked_installation = await _find_revoked_installation_for_subject(
+        db, identity=identity
+    )
+    if revoked_installation is not None:
+        await db.rollback()
+        raise HTTPException(
+            status_code=403,
+            detail={"code": "installation_revoked", "message": "BotLearn installation is revoked"},
+        )
+
     user = await _find_or_create_user(db, identity)
 
     # Default Cloud Agent (create on first use). Quota / feature failures must
@@ -229,6 +254,12 @@ async def create_botlearn_session(
     installation = await _upsert_installation(
         db, user=user, identity=identity, agent_id=agent_id
     )
+    if installation.revoked_at is not None:
+        await db.rollback()
+        raise HTTPException(
+            status_code=403,
+            detail={"code": "installation_revoked", "message": "BotLearn installation is revoked"},
+        )
     await db.commit()
 
     access_token, expires_in = issue_botlearn_session_token(

--- a/backend/hub/config.py
+++ b/backend/hub/config.py
@@ -507,3 +507,42 @@ CREDIT_MILLIS_PER_SANDBOX_SECOND: int = int(
 CLOUD_AGENT_RUN_CREDIT_RESERVATION_FLOOR: int = int(
     os.getenv("CLOUD_AGENT_RUN_CREDIT_RESERVATION_FLOOR", "5")
 )
+
+# ---------------------------------------------------------------------------
+# BotLearn first-party browser integration (PR 9)
+#
+# BotLearn has no backend service holding a long-term secret. The Hub verifies
+# BotLearn's login token directly, JIT-creates/binds a BotCord user, and hands
+# the browser a short-lived, agent-scoped session token. None of these are
+# long-lived browser-visible credentials. See
+# docs/cloud-agent-technical-design.md §3.4 / §6.4.
+# ---------------------------------------------------------------------------
+BOTLEARN_INTEGRATION_ENABLED: bool = os.getenv(
+    "BOTLEARN_INTEGRATION_ENABLED", "false"
+).lower() in ("true", "1", "yes")
+# Expected ``iss`` claim on the BotLearn login token (None disables the check).
+BOTLEARN_ISSUER: str | None = os.getenv("BOTLEARN_ISSUER") or None
+# Expected ``aud`` claim (None disables the check).
+BOTLEARN_AUDIENCE: str | None = os.getenv("BOTLEARN_AUDIENCE") or None
+# JWKS endpoint for asymmetric (RS256/ES256) BotLearn tokens.
+BOTLEARN_JWKS_URL: str | None = os.getenv("BOTLEARN_JWKS_URL") or None
+# Shared secret for HS256 BotLearn tokens (dev / same Supabase tenant).
+BOTLEARN_JWT_SECRET: str | None = os.getenv("BOTLEARN_JWT_SECRET") or None
+# Origin allowlist for the session-exchange + app-facing WS endpoints. Empty
+# means the integration is effectively closed (deny by default).
+BOTLEARN_ALLOWED_ORIGINS: list[str] = [
+    o.strip().rstrip("/")
+    for o in os.getenv("BOTLEARN_ALLOWED_ORIGINS", "").split(",")
+    if o.strip()
+]
+# Short-lived integration session token TTL (seconds). Default 15 minutes.
+BOTLEARN_SESSION_TTL_SECONDS: int = int(
+    os.getenv("BOTLEARN_SESSION_TTL_SECONDS", "900")
+)
+# Require ``email_verified=true`` on the BotLearn login token.
+BOTLEARN_REQUIRE_EMAIL_VERIFIED: bool = os.getenv(
+    "BOTLEARN_REQUIRE_EMAIL_VERIFIED", "true"
+).lower() in ("true", "1", "yes")
+# Public WS URL advertised to the BotLearn frontend after session exchange.
+# Falls back to ``HUB_PUBLIC_BASE_URL`` (ws/wss) when unset.
+BOTLEARN_WS_URL: str | None = os.getenv("BOTLEARN_WS_URL") or None

--- a/backend/hub/id_generators.py
+++ b/backend/hub/id_generators.py
@@ -128,6 +128,11 @@ def generate_cloud_agent_run_id() -> str:
     return "crun_" + secrets.token_hex(8)
 
 
+def generate_botlearn_installation_id() -> str:
+    """Generate BotLearn installation ID: 'bli_' + 12 random hex chars."""
+    return "bli_" + secrets.token_hex(6)
+
+
 def generate_gateway_connection_id(provider: str) -> str:
     """Generate third-party gateway connection ID: 'gw_<provider>_<12 hex>'.
 

--- a/backend/hub/main.py
+++ b/backend/hub/main.py
@@ -70,6 +70,7 @@ from app.routers.beta import router as app_beta_router
 from app.routers.admin_beta import router as app_admin_beta_router
 from app.routers.activity import router as app_activity_router
 from app.routers.cloud_agents import router as app_cloud_agents_router
+from app.routers.botlearn import router as app_botlearn_router
 from app.routers.policy import router as app_policy_router
 from app.routers.gateways import router as app_gateways_router
 from app.routers.prompts import router as app_prompts_router
@@ -320,6 +321,9 @@ app.include_router(app_beta_router)
 app.include_router(app_admin_beta_router)
 app.include_router(app_policy_router, dependencies=_beta_gate)
 app.include_router(app_cloud_agents_router, dependencies=_beta_gate)
+# BotLearn integration carries its own auth (BotLearn login token + short-lived
+# session token), so it is NOT behind the Supabase beta gate.
+app.include_router(app_botlearn_router)
 app.include_router(app_gateways_router, dependencies=_beta_gate)
 app.include_router(app_telegram_router, dependencies=_beta_gate)
 app.include_router(app_runtime_files_router, dependencies=_beta_gate)

--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -30,7 +30,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
-from hub.id_generators import generate_human_id
+from hub.id_generators import generate_botlearn_installation_id, generate_human_id
 from hub.enums import (  # noqa: F401 — re-exported for backward compatibility
     ApprovalKind,
     ApprovalState,
@@ -2186,4 +2186,66 @@ class UsageReservation(Base):
     )
     released_at: Mapped[datetime.datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
+    )
+
+
+class BotlearnInstallation(Base):
+    """First-party authorization binding: a BotLearn login identity to a
+    BotCord user + default Cloud Agent.
+
+    This is NOT a long-term API key. BotLearn frontend exchanges its login
+    token for a short-lived ``botlearn-integration-session`` token; this row
+    records the durable authorization (which user, which default agent, what
+    scopes/limits) and supports revocation. See
+    ``docs/cloud-agent-technical-design.md`` §5.6.
+    """
+
+    __tablename__ = "botlearn_installations"
+    __table_args__ = (
+        UniqueConstraint(
+            "botlearn_subject", "agent_id", name="uq_botlearn_subject_agent"
+        ),
+        Index("ix_botlearn_installations_user", "user_id"),
+        Index("ix_botlearn_installations_subject", "botlearn_subject"),
+        {"schema": "public"},
+    )
+
+    id: Mapped[str] = mapped_column(
+        String(32), primary_key=True, default=generate_botlearn_installation_id
+    )
+    # Plain Uuid (no FK) to mirror the cloud-agent usage tables, which keep
+    # ``user_id`` unconstrained so the rows survive cross-schema test setups.
+    user_id: Mapped[_uuid.UUID] = mapped_column(Uuid, nullable=False)
+    # Stable ``sub`` from the BotLearn login token.
+    botlearn_subject: Mapped[str] = mapped_column(String(256), nullable=False)
+    botlearn_email: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    # The default Cloud Agent this installation operates. Nullable so the row
+    # survives the agent being deleted; a later session exchange re-selects one.
+    agent_id: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    scopes_json: Mapped[list] = mapped_column(
+        JSONB().with_variant(JSON(), "sqlite"),
+        nullable=False,
+        default=list,
+        server_default="[]",
+    )
+    limits_json: Mapped[dict] = mapped_column(
+        JSONB().with_variant(JSON(), "sqlite"),
+        nullable=False,
+        default=dict,
+        server_default="{}",
+    )
+    last_used_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    revoked_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
     )

--- a/backend/hub/services/cloud_agent.py
+++ b/backend/hub/services/cloud_agent.py
@@ -1247,6 +1247,10 @@ class CloudAgentService:
             raise CloudAgentError(
                 "run_not_found", f"run {run_id!r} not found", http_status=404
             )
+        if event is not None and event.agent_id != agent_id:
+            raise CloudAgentError(
+                "run_not_found", f"run {run_id!r} not found", http_status=404
+            )
 
         # Only an active reservation (run not yet settled) can be cancelled.
         if event is None and reservation is not None and reservation.state == "active":

--- a/backend/hub/services/cloud_agent.py
+++ b/backend/hub/services/cloud_agent.py
@@ -171,6 +171,26 @@ class CloudAgentRunView:
 
 
 @dataclass
+class CloudAgentRunStatusView:
+    """Best-effort run state derived from the usage ledger.
+
+    There is no dedicated run-state table (see PR 9 decision); status is
+    inferred from the per-run :class:`UsageReservation` and any settled
+    :class:`UsageEvent`. ``status`` is one of ``running`` / ``completed`` /
+    ``cancelled`` / ``unknown``.
+    """
+
+    run_id: str
+    agent_id: str
+    status: str
+    reserved_credits: int
+    reserved_sandbox_seconds: int
+    credits_charged: int | None
+    created_at: datetime.datetime
+    settled_at: datetime.datetime | None = None
+
+
+@dataclass
 class CloudAgentUsageEventView:
     run_id: str
     provider: str
@@ -1151,6 +1171,165 @@ class CloudAgentService:
                 for row in rows
             ],
         )
+
+    async def get_run(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: uuid.UUID,
+        agent_id: str,
+        run_id: str,
+    ) -> CloudAgentRunStatusView:
+        """Best-effort run status from the usage ledger.
+
+        No dedicated run-state table exists; status is inferred from the
+        per-run reservation and any settled usage event. Raises
+        ``CloudAgentError`` if the run is unknown for this owned agent.
+        """
+        self._require_feature_enabled()
+        # Ownership gate — raises not_found (404) if the user doesn't own it.
+        await self._load_owned(db, user_id=user_id, agent_id=agent_id)
+
+        reservation = await db.scalar(
+            select(UsageReservation).where(UsageReservation.run_id == run_id)
+        )
+        event = await db.scalar(
+            select(UsageEvent)
+            .where(UsageEvent.run_id == run_id)
+            .order_by(UsageEvent.created_at.desc(), UsageEvent.id.desc())
+        )
+        if reservation is None and event is None:
+            raise CloudAgentError(
+                "run_not_found", f"run {run_id!r} not found", http_status=404
+            )
+        # Cross-check the run actually belongs to this agent.
+        if reservation is not None and reservation.agent_id != agent_id:
+            raise CloudAgentError(
+                "run_not_found", f"run {run_id!r} not found", http_status=404
+            )
+        if event is not None and event.agent_id != agent_id:
+            raise CloudAgentError(
+                "run_not_found", f"run {run_id!r} not found", http_status=404
+            )
+
+        return self._run_status_view(run_id, agent_id, reservation, event)
+
+    async def cancel_run(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: uuid.UUID,
+        agent_id: str,
+        run_id: str,
+    ) -> CloudAgentRunStatusView:
+        """Cancel an in-flight run: release its reservation and fail the
+        still-queued trigger message (best-effort).
+
+        Already-settled runs are returned as-is. Idempotent — cancelling a
+        run twice is safe.
+        """
+        self._require_feature_enabled()
+        await self._load_owned(db, user_id=user_id, agent_id=agent_id)
+
+        reservation = await db.scalar(
+            select(UsageReservation).where(UsageReservation.run_id == run_id)
+        )
+        event = await db.scalar(
+            select(UsageEvent)
+            .where(UsageEvent.run_id == run_id)
+            .order_by(UsageEvent.created_at.desc(), UsageEvent.id.desc())
+        )
+        if reservation is None and event is None:
+            raise CloudAgentError(
+                "run_not_found", f"run {run_id!r} not found", http_status=404
+            )
+        if reservation is not None and reservation.agent_id != agent_id:
+            raise CloudAgentError(
+                "run_not_found", f"run {run_id!r} not found", http_status=404
+            )
+
+        # Only an active reservation (run not yet settled) can be cancelled.
+        if event is None and reservation is not None and reservation.state == "active":
+            await self._release_run_usage_reservation_durably(db, run_id=run_id)
+            await self._fail_queued_run_message(db, agent_id=agent_id, run_id=run_id)
+            reservation = await db.scalar(
+                select(UsageReservation).where(UsageReservation.run_id == run_id)
+            )
+
+        return self._run_status_view(run_id, agent_id, reservation, event)
+
+    @staticmethod
+    def _run_status_view(
+        run_id: str,
+        agent_id: str,
+        reservation: "UsageReservation | None",
+        event: "UsageEvent | None",
+    ) -> CloudAgentRunStatusView:
+        if event is not None:
+            status = "completed"
+        elif reservation is not None and reservation.state == "active":
+            status = "running"
+        elif reservation is not None and reservation.state == "settled":
+            status = "completed"
+        elif reservation is not None and reservation.state == "released":
+            status = "cancelled"
+        else:
+            status = "unknown"
+        created_at = (
+            event.created_at
+            if event is not None
+            else (reservation.created_at if reservation is not None else _now())
+        )
+        return CloudAgentRunStatusView(
+            run_id=run_id,
+            agent_id=agent_id,
+            status=status,
+            reserved_credits=(
+                reservation.reserved_credits if reservation is not None else 0
+            ),
+            reserved_sandbox_seconds=(
+                reservation.reserved_sandbox_seconds if reservation is not None else 0
+            ),
+            credits_charged=event.credits_charged if event is not None else None,
+            created_at=created_at,
+            settled_at=(reservation.settled_at if reservation is not None else None),
+        )
+
+    async def _fail_queued_run_message(
+        self,
+        db: AsyncSession,
+        *,
+        agent_id: str,
+        run_id: str,
+    ) -> None:
+        """Mark the still-queued ``cloud_agent_run`` trigger message failed.
+
+        Best-effort: the run_id lives inside ``envelope_json`` (not a column),
+        so this scans the agent's queued cloud-run messages and matches on the
+        parsed payload. If the daemon already dequeued it, there is nothing to
+        fail and the released reservation is the meaningful cancellation.
+        """
+        rows = (
+            await db.execute(
+                select(MessageRecord).where(
+                    MessageRecord.receiver_id == agent_id,
+                    MessageRecord.source_type == "cloud_agent_run",
+                    MessageRecord.state == MessageState.queued,
+                )
+            )
+        ).scalars().all()
+        changed = False
+        for record in rows:
+            try:
+                envelope = json.loads(record.envelope_json or "{}")
+                run = (envelope.get("payload") or {}).get("cloud_run") or {}
+            except (ValueError, AttributeError):
+                continue
+            if run.get("run_id") == run_id:
+                record.state = MessageState.failed
+                changed = True
+        if changed:
+            await db.commit()
 
     async def provision_pending_for_cloud_daemon(
         self,

--- a/backend/migrations/031_botlearn_installations.sql
+++ b/backend/migrations/031_botlearn_installations.sql
@@ -1,0 +1,30 @@
+-- PR 9: BotLearn first-party browser integration.
+--
+-- One row per BotLearn login identity bound to a BotCord user + default
+-- Cloud Agent. This is the durable authorization record behind the
+-- short-lived ``botlearn-integration-session`` token — NOT a long-term API
+-- key. BotLearn browsers never hold a long-lived BotCord credential; they
+-- exchange their login token for a session token scoped to this row.
+--
+-- See docs/cloud-agent-technical-design.md §5.6.
+
+CREATE TABLE IF NOT EXISTS public.botlearn_installations (
+    id VARCHAR(32) PRIMARY KEY,
+    user_id UUID NOT NULL,
+    botlearn_subject VARCHAR(256) NOT NULL,
+    botlearn_email VARCHAR(256),
+    agent_id VARCHAR(32),
+    scopes_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+    limits_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+    last_used_at TIMESTAMPTZ,
+    revoked_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT uq_botlearn_subject_agent UNIQUE (botlearn_subject, agent_id)
+);
+
+CREATE INDEX IF NOT EXISTS ix_botlearn_installations_user
+    ON public.botlearn_installations (user_id);
+
+CREATE INDEX IF NOT EXISTS ix_botlearn_installations_subject
+    ON public.botlearn_installations (botlearn_subject);

--- a/backend/tests/test_app/test_botlearn_session.py
+++ b/backend/tests/test_app/test_botlearn_session.py
@@ -1,0 +1,345 @@
+"""Tests for POST /api/integrations/botlearn/session — PR 9 session exchange.
+
+Covers the no-backend-secret flow: BotLearn login token in, short-lived
+BotCord session token out, with JIT user + default Cloud Agent creation and
+the security gates (origin allowlist, issuer/audience, email_verified, expiry,
+quota failure → no token).
+"""
+
+from __future__ import annotations
+
+import datetime
+import uuid
+
+import jwt
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.botlearn_auth import (
+    BOTLEARN_SESSION_AUDIENCE,
+    BOTLEARN_SESSION_ISSUER,
+    BOTLEARN_SESSION_TOKEN_KIND,
+    botcord_supabase_id_for_botlearn,
+)
+from hub.config import JWT_ALGORITHM, JWT_SECRET
+from hub.models import Base, BotlearnInstallation, Role, User
+from hub.services.cloud_agent import CloudAgentService
+from hub.services.cloud_daemon_provider import FakeCloudDaemonProvider
+from tests.test_app.conftest import create_test_engine
+
+BOTLEARN_SECRET = "test-botlearn-shared-secret"
+BOTLEARN_ISSUER = "https://botlearn.example"
+ALLOWED_ORIGIN = "https://app.botlearn.ai"
+
+
+def _now() -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def _botlearn_token(
+    sub: str,
+    *,
+    email: str | None = "person@botlearn.ai",
+    email_verified: bool = True,
+    secret: str = BOTLEARN_SECRET,
+    issuer: str = BOTLEARN_ISSUER,
+    audience: str | None = None,
+    exp_delta_seconds: int = 3600,
+) -> str:
+    payload: dict = {
+        "sub": sub,
+        "email_verified": email_verified,
+        "iss": issuer,
+        "exp": _now() + datetime.timedelta(seconds=exp_delta_seconds),
+        "iat": _now(),
+    }
+    if email is not None:
+        payload["email"] = email
+    if audience is not None:
+        payload["aud"] = audience
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+def _configure_botlearn(
+    monkeypatch,
+    *,
+    enabled: bool = True,
+    origins: list[str] | None = None,
+    audience: str | None = None,
+    require_email_verified: bool = True,
+    issuer: str | None = BOTLEARN_ISSUER,
+) -> None:
+    import app.botlearn_auth as ba
+    import app.routers.botlearn as br
+
+    monkeypatch.setattr(ba, "BOTLEARN_INTEGRATION_ENABLED", enabled)
+    monkeypatch.setattr(br, "BOTLEARN_INTEGRATION_ENABLED", enabled)
+    monkeypatch.setattr(ba, "BOTLEARN_JWT_SECRET", BOTLEARN_SECRET)
+    monkeypatch.setattr(ba, "BOTLEARN_ISSUER", issuer)
+    monkeypatch.setattr(ba, "BOTLEARN_AUDIENCE", audience)
+    monkeypatch.setattr(ba, "BOTLEARN_REQUIRE_EMAIL_VERIFIED", require_email_verified)
+    monkeypatch.setattr(
+        ba,
+        "BOTLEARN_ALLOWED_ORIGINS",
+        origins if origins is not None else [ALLOWED_ORIGIN],
+    )
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_test_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        # The member role is optional but mirrors production seeding.
+        session.add(
+            Role(id=uuid.uuid4(), name="member", display_name="Member", is_system=True)
+        )
+        await session.commit()
+        yield session
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client_factory(db_session: AsyncSession):
+    """Build an AsyncClient with an injected (fake-provider) CloudAgentService."""
+    import app.routers.cloud_agents as cloud_agents_router
+
+    from hub.database import get_db
+    from hub.main import app
+
+    async def _override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_get_db
+    original_service = cloud_agents_router.get_cloud_agent_service()
+
+    clients: list[AsyncClient] = []
+
+    async def _make(*, feature_enabled: bool = True) -> tuple[AsyncClient, CloudAgentService]:
+        provider = FakeCloudDaemonProvider()
+        service = CloudAgentService(
+            provider=provider,
+            feature_enabled=feature_enabled,
+            max_per_user=3,
+            max_agents_per_daemon=2,
+        )
+        cloud_agents_router._set_default_service_for_tests(service)
+        transport = ASGITransport(app=app)
+        client = AsyncClient(transport=transport, base_url="http://test")
+        await client.__aenter__()
+        clients.append(client)
+        return client, service
+
+    try:
+        yield _make
+    finally:
+        for c in clients:
+            await c.__aexit__(None, None, None)
+        cloud_agents_router._set_default_service_for_tests(original_service)
+        app.dependency_overrides.clear()
+
+
+def _headers(token: str, *, origin: str | None = ALLOWED_ORIGIN) -> dict:
+    headers = {"Authorization": f"Bearer {token}"}
+    if origin is not None:
+        headers["Origin"] = origin
+    return headers
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_session_exchange_creates_user_agent_and_token(
+    client_factory, db_session, monkeypatch
+):
+    _configure_botlearn(monkeypatch)
+    client, _service = await client_factory()
+
+    r = await client.post(
+        "/api/integrations/botlearn/session",
+        headers=_headers(_botlearn_token("botlearn-user-1")),
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["agent_id"].startswith("ag_")
+    assert body["installation_id"].startswith("bli_")
+    assert body["expires_in"] == 900
+    assert body["ws_url"].endswith("/api/integrations/botlearn/ws")
+
+    # Session token is a verifiable, short-lived BotCord token of the right kind.
+    claims = jwt.decode(
+        body["access_token"],
+        JWT_SECRET,
+        algorithms=[JWT_ALGORITHM],
+        audience=BOTLEARN_SESSION_AUDIENCE,
+        issuer=BOTLEARN_SESSION_ISSUER,
+    )
+    assert claims["kind"] == BOTLEARN_SESSION_TOKEN_KIND
+    assert claims["agent_id"] == body["agent_id"]
+    assert claims["botlearn_sub"] == "botlearn-user-1"
+    assert "cloud_runs:create" in claims["scopes"]
+
+    # JIT user + installation persisted.
+    derived = botcord_supabase_id_for_botlearn("botlearn-user-1")
+    user = await db_session.scalar(
+        select(User).where(User.supabase_user_id == derived)
+    )
+    assert user is not None
+    inst = await db_session.scalar(
+        select(BotlearnInstallation).where(BotlearnInstallation.id == body["installation_id"])
+    )
+    assert inst is not None
+    assert inst.agent_id == body["agent_id"]
+    assert inst.revoked_at is None
+
+
+@pytest.mark.asyncio
+async def test_session_exchange_is_idempotent_reuses_agent_and_installation(
+    client_factory, db_session, monkeypatch
+):
+    _configure_botlearn(monkeypatch)
+    client, _service = await client_factory()
+    token = _botlearn_token("botlearn-user-2")
+
+    r1 = await client.post(
+        "/api/integrations/botlearn/session", headers=_headers(token)
+    )
+    r2 = await client.post(
+        "/api/integrations/botlearn/session", headers=_headers(token)
+    )
+    assert r1.status_code == 200 and r2.status_code == 200
+    assert r1.json()["agent_id"] == r2.json()["agent_id"]
+    assert r1.json()["installation_id"] == r2.json()["installation_id"]
+
+    rows = (
+        await db_session.execute(
+            select(BotlearnInstallation).where(
+                BotlearnInstallation.botlearn_subject == "botlearn-user-2"
+            )
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# Security gates
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_session_rejected_when_disabled(client_factory, monkeypatch):
+    _configure_botlearn(monkeypatch, enabled=False)
+    client, _ = await client_factory()
+    r = await client.post(
+        "/api/integrations/botlearn/session",
+        headers=_headers(_botlearn_token("u")),
+    )
+    assert r.status_code == 403
+    assert r.json()["detail"]["code"] == "botlearn_disabled"
+
+
+@pytest.mark.asyncio
+async def test_session_rejected_for_disallowed_origin(client_factory, monkeypatch):
+    _configure_botlearn(monkeypatch)
+    client, _ = await client_factory()
+    r = await client.post(
+        "/api/integrations/botlearn/session",
+        headers=_headers(_botlearn_token("u"), origin="https://evil.example"),
+    )
+    assert r.status_code == 403
+    assert r.json()["detail"]["code"] == "origin_not_allowed"
+
+
+@pytest.mark.asyncio
+async def test_session_rejected_for_missing_origin(client_factory, monkeypatch):
+    _configure_botlearn(monkeypatch)
+    client, _ = await client_factory()
+    r = await client.post(
+        "/api/integrations/botlearn/session",
+        headers=_headers(_botlearn_token("u"), origin=None),
+    )
+    assert r.status_code == 403
+    assert r.json()["detail"]["code"] == "origin_not_allowed"
+
+
+@pytest.mark.asyncio
+async def test_session_rejected_for_bad_issuer(client_factory, monkeypatch):
+    _configure_botlearn(monkeypatch)
+    client, _ = await client_factory()
+    r = await client.post(
+        "/api/integrations/botlearn/session",
+        headers=_headers(_botlearn_token("u", issuer="https://attacker.example")),
+    )
+    assert r.status_code == 401
+    assert r.json()["detail"]["code"] == "invalid_issuer"
+
+
+@pytest.mark.asyncio
+async def test_session_rejected_for_audience_mismatch(client_factory, monkeypatch):
+    _configure_botlearn(monkeypatch, audience="botcord-cloud")
+    client, _ = await client_factory()
+    # Token carries the wrong audience.
+    r = await client.post(
+        "/api/integrations/botlearn/session",
+        headers=_headers(_botlearn_token("u", audience="someone-else")),
+    )
+    assert r.status_code == 401
+    assert r.json()["detail"]["code"] == "invalid_audience"
+
+
+@pytest.mark.asyncio
+async def test_session_rejected_for_expired_token(client_factory, monkeypatch):
+    _configure_botlearn(monkeypatch)
+    client, _ = await client_factory()
+    r = await client.post(
+        "/api/integrations/botlearn/session",
+        headers=_headers(_botlearn_token("u", exp_delta_seconds=-10)),
+    )
+    assert r.status_code == 401
+    assert r.json()["detail"]["code"] == "token_expired"
+
+
+@pytest.mark.asyncio
+async def test_session_rejected_for_unverified_email(client_factory, monkeypatch):
+    _configure_botlearn(monkeypatch)
+    client, _ = await client_factory()
+    r = await client.post(
+        "/api/integrations/botlearn/session",
+        headers=_headers(_botlearn_token("u", email_verified=False)),
+    )
+    assert r.status_code == 403
+    assert r.json()["detail"]["code"] == "email_not_verified"
+
+
+@pytest.mark.asyncio
+async def test_session_no_token_when_cloud_agent_feature_disabled(
+    client_factory, db_session, monkeypatch
+):
+    _configure_botlearn(monkeypatch)
+    # Cloud Agent feature off → default-agent creation fails → no session token.
+    client, _ = await client_factory(feature_enabled=False)
+    r = await client.post(
+        "/api/integrations/botlearn/session",
+        headers=_headers(_botlearn_token("botlearn-user-3")),
+    )
+    assert r.status_code >= 400
+    assert "access_token" not in r.json()
+    # No installation persisted on the failed path.
+    rows = (
+        await db_session.execute(
+            select(BotlearnInstallation).where(
+                BotlearnInstallation.botlearn_subject == "botlearn-user-3"
+            )
+        )
+    ).scalars().all()
+    assert rows == []

--- a/backend/tests/test_app/test_botlearn_session.py
+++ b/backend/tests/test_app/test_botlearn_session.py
@@ -25,7 +25,7 @@ from app.botlearn_auth import (
     botcord_supabase_id_for_botlearn,
 )
 from hub.config import JWT_ALGORITHM, JWT_SECRET
-from hub.models import Base, BotlearnInstallation, Role, User
+from hub.models import Base, BotlearnInstallation, CloudAgentInstance, Role, User
 from hub.services.cloud_agent import CloudAgentService
 from hub.services.cloud_daemon_provider import FakeCloudDaemonProvider
 from tests.test_app.conftest import create_test_engine
@@ -229,6 +229,155 @@ async def test_session_exchange_is_idempotent_reuses_agent_and_installation(
         )
     ).scalars().all()
     assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_session_exchange_rejects_revoked_installation(
+    client_factory, db_session, monkeypatch
+):
+    _configure_botlearn(monkeypatch)
+    client, _service = await client_factory()
+    token = _botlearn_token("botlearn-user-revoked")
+
+    r1 = await client.post(
+        "/api/integrations/botlearn/session", headers=_headers(token)
+    )
+    assert r1.status_code == 200, r1.text
+    installation_id = r1.json()["installation_id"]
+
+    inst = await db_session.scalar(
+        select(BotlearnInstallation).where(BotlearnInstallation.id == installation_id)
+    )
+    assert inst is not None
+    revoked_at = _now()
+    inst.revoked_at = revoked_at
+    await db_session.commit()
+
+    r2 = await client.post(
+        "/api/integrations/botlearn/session", headers=_headers(token)
+    )
+    assert r2.status_code == 403
+    assert r2.json()["detail"]["code"] == "installation_revoked"
+    assert "access_token" not in r2.json()
+
+    await db_session.refresh(inst)
+    assert inst.revoked_at is not None
+    assert inst.revoked_at.replace(tzinfo=datetime.timezone.utc) == revoked_at
+
+
+@pytest.mark.asyncio
+async def test_session_exchange_rejects_revoked_subject_before_default_agent_selection(
+    client_factory, db_session, monkeypatch
+):
+    _configure_botlearn(monkeypatch)
+    client, _service = await client_factory()
+    token = _botlearn_token("botlearn-user-revoked-stale-agent")
+
+    r1 = await client.post(
+        "/api/integrations/botlearn/session", headers=_headers(token)
+    )
+    assert r1.status_code == 200, r1.text
+    body = r1.json()
+
+    inst = await db_session.scalar(
+        select(BotlearnInstallation).where(
+            BotlearnInstallation.id == body["installation_id"]
+        )
+    )
+    assert inst is not None
+    user_id = inst.user_id
+    revoked_at = _now()
+    inst.revoked_at = revoked_at
+
+    cloud_agent = await db_session.scalar(
+        select(CloudAgentInstance).where(
+            CloudAgentInstance.agent_id == body["agent_id"]
+        )
+    )
+    assert cloud_agent is not None
+    cloud_agent.status = "deleted"
+    await db_session.commit()
+
+    r2 = await client.post(
+        "/api/integrations/botlearn/session", headers=_headers(token)
+    )
+    assert r2.status_code == 403
+    assert r2.json()["detail"]["code"] == "installation_revoked"
+    assert "access_token" not in r2.json()
+
+    installations = (
+        await db_session.execute(
+            select(BotlearnInstallation).where(
+                BotlearnInstallation.botlearn_subject
+                == "botlearn-user-revoked-stale-agent"
+            )
+        )
+    ).scalars().all()
+    assert [row.id for row in installations] == [body["installation_id"]]
+
+    cloud_agents = (
+        await db_session.execute(
+            select(CloudAgentInstance).where(CloudAgentInstance.user_id == user_id)
+        )
+    ).scalars().all()
+    assert [row.agent_id for row in cloud_agents] == [body["agent_id"]]
+
+    await db_session.refresh(inst)
+    assert inst.revoked_at is not None
+    assert inst.revoked_at.replace(tzinfo=datetime.timezone.utc) == revoked_at
+
+
+@pytest.mark.asyncio
+async def test_session_exchange_rejects_stale_revoked_subject_before_user_creation(
+    client_factory, db_session, monkeypatch
+):
+    _configure_botlearn(monkeypatch)
+    client, _service = await client_factory()
+    subject = "botlearn-user-revoked-orphan"
+    stale_installation = BotlearnInstallation(
+        id="bli_revoked_orphan",
+        user_id=uuid.uuid4(),
+        botlearn_subject=subject,
+        botlearn_email="orphan@botlearn.ai",
+        agent_id="ag_revoked_orphan",
+        scopes_json=["cloud_runs:create"],
+        limits_json={},
+        last_used_at=_now(),
+        revoked_at=_now(),
+    )
+    db_session.add(stale_installation)
+    await db_session.commit()
+
+    derived_supabase_id = botcord_supabase_id_for_botlearn(subject)
+    assert await db_session.scalar(
+        select(User).where(User.supabase_user_id == derived_supabase_id)
+    ) is None
+
+    r = await client.post(
+        "/api/integrations/botlearn/session",
+        headers=_headers(_botlearn_token(subject, email="orphan@botlearn.ai")),
+    )
+    assert r.status_code == 403
+    assert r.json()["detail"]["code"] == "installation_revoked"
+    assert "access_token" not in r.json()
+
+    assert await db_session.scalar(
+        select(User).where(User.supabase_user_id == derived_supabase_id)
+    ) is None
+    assert (await db_session.execute(select(User))).scalars().all() == []
+    assert (await db_session.execute(select(CloudAgentInstance))).scalars().all() == []
+
+    installations = (
+        await db_session.execute(
+            select(BotlearnInstallation).where(
+                BotlearnInstallation.botlearn_subject == subject
+            )
+        )
+    ).scalars().all()
+    assert [row.id for row in installations] == [stale_installation.id]
+
+    await db_session.refresh(stale_installation)
+    assert stale_installation.revoked_at is not None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_app/test_botlearn_ws.py
+++ b/backend/tests/test_app/test_botlearn_ws.py
@@ -1,0 +1,344 @@
+"""Tests for GET /api/integrations/botlearn/ws — botcord-agent-session/0.1.
+
+Verifies the app-facing Cloud Run public subset: hello/auth, scope + method
+allowlists, origin gate, revocation, and that cloud_run.create flows through
+CloudAgentService (so it cannot bypass quota/reservation/settlement).
+"""
+
+from __future__ import annotations
+
+import datetime
+import uuid
+from contextlib import asynccontextmanager
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.botlearn_auth import (
+    BOTLEARN_SCOPE_RUNS_CANCEL,
+    BOTLEARN_SCOPE_RUNS_CREATE,
+    BOTLEARN_SCOPE_RUNS_READ,
+    botcord_supabase_id_for_botlearn,
+    issue_botlearn_session_token,
+)
+from hub.models import (
+    Base,
+    BotlearnInstallation,
+    CloudAgentInstance,
+    Role,
+    User,
+)
+from hub.services.cloud_agent import CloudAgentService, CreateCloudAgentInput
+from hub.services.cloud_daemon_provider import FakeCloudDaemonProvider
+from tests.test_app.conftest import create_test_engine
+
+ALLOWED_ORIGIN = "https://app.botlearn.ai"
+
+
+def _now() -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def _configure_botlearn(monkeypatch, *, enabled: bool = True) -> None:
+    import app.botlearn_auth as ba
+    import app.routers.botlearn as br
+
+    monkeypatch.setattr(ba, "BOTLEARN_INTEGRATION_ENABLED", enabled)
+    monkeypatch.setattr(br, "BOTLEARN_INTEGRATION_ENABLED", enabled)
+    monkeypatch.setattr(ba, "BOTLEARN_ALLOWED_ORIGINS", [ALLOWED_ORIGIN])
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_test_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        session.add(
+            Role(id=uuid.uuid4(), name="member", display_name="Member", is_system=True)
+        )
+        await session.commit()
+        yield session
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def shared_session_for_ws(db_session: AsyncSession, monkeypatch):
+    """Make ``async_session()`` inside the WS handler reuse the test session."""
+    import app.routers.botlearn as br
+
+    @asynccontextmanager
+    async def _shared():
+        yield db_session
+
+    monkeypatch.setattr(br, "async_session", _shared)
+    return db_session
+
+
+@pytest_asyncio.fixture
+async def service(db_session: AsyncSession):
+    import app.routers.cloud_agents as cloud_agents_router
+
+    original = cloud_agents_router.get_cloud_agent_service()
+    svc = CloudAgentService(
+        provider=FakeCloudDaemonProvider(),
+        feature_enabled=True,
+        max_per_user=3,
+        max_agents_per_daemon=2,
+    )
+    cloud_agents_router._set_default_service_for_tests(svc)
+    yield svc
+    cloud_agents_router._set_default_service_for_tests(original)
+
+
+@pytest_asyncio.fixture
+async def app_with_shared_session(db_session, shared_session_for_ws):
+    from hub.database import get_db
+    from hub.main import app
+
+    async def _override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_get_db
+    try:
+        yield app
+    finally:
+        app.dependency_overrides.clear()
+
+
+async def _seed_cloud_agent(db: AsyncSession, service: CloudAgentService) -> dict:
+    """Create a user + a ready Cloud Agent, return identifiers for the WS."""
+    supabase_id = botcord_supabase_id_for_botlearn("ws-user")
+    user = User(
+        id=uuid.uuid4(),
+        display_name="WS User",
+        email="ws@botlearn.ai",
+        status="active",
+        supabase_user_id=supabase_id,
+        max_agents=30,
+    )
+    db.add(user)
+    await db.commit()
+    view = await service.create_cloud_agent(
+        db, user_id=user.id, body=CreateCloudAgentInput(name="WS Agent")
+    )
+    await db.commit()
+    inst = BotlearnInstallation(
+        id="bli_ws000001",
+        user_id=user.id,
+        botlearn_subject="ws-user",
+        botlearn_email="ws@botlearn.ai",
+        agent_id=view.agent_id,
+        scopes_json=[
+            BOTLEARN_SCOPE_RUNS_CREATE,
+            BOTLEARN_SCOPE_RUNS_READ,
+            BOTLEARN_SCOPE_RUNS_CANCEL,
+        ],
+    )
+    db.add(inst)
+    await db.commit()
+    return {"user_id": user.id, "agent_id": view.agent_id, "installation": inst}
+
+
+def _session_token(user_id, agent_id, installation_id, scopes):
+    token, _ = issue_botlearn_session_token(
+        user_id=user_id,
+        botlearn_subject="ws-user",
+        agent_id=agent_id,
+        installation_id=installation_id,
+        scopes=scopes,
+    )
+    return token
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ws_rejects_disallowed_origin(app_with_shared_session, monkeypatch):
+    from starlette.testclient import TestClient
+    from starlette.websockets import WebSocketDisconnect
+
+    _configure_botlearn(monkeypatch)
+    with TestClient(app_with_shared_session) as tc:
+        with pytest.raises(WebSocketDisconnect) as exc:
+            with tc.websocket_connect(
+                "/api/integrations/botlearn/ws",
+                headers={"origin": "https://evil.example"},
+            ):
+                pass
+        assert exc.value.code == 4003
+
+
+@pytest.mark.asyncio
+async def test_ws_hello_and_cloud_run_create_uses_service(
+    app_with_shared_session, db_session, service, monkeypatch
+):
+    from starlette.testclient import TestClient
+
+    _configure_botlearn(monkeypatch)
+    seeded = await _seed_cloud_agent(db_session, service)
+    token = _session_token(
+        seeded["user_id"],
+        seeded["agent_id"],
+        seeded["installation"].id,
+        [BOTLEARN_SCOPE_RUNS_CREATE, BOTLEARN_SCOPE_RUNS_READ],
+    )
+
+    with TestClient(app_with_shared_session) as tc:
+        with tc.websocket_connect(
+            "/api/integrations/botlearn/ws",
+            headers={"origin": ALLOWED_ORIGIN},
+        ) as ws:
+            ws.send_json({"type": "hello", "token": token})
+            hello_ok = ws.receive_json()
+            assert hello_ok["type"] == "hello_ok"
+            assert hello_ok["protocol"] == "botcord-agent-session/0.1"
+            assert hello_ok["agent_id"] == seeded["agent_id"]
+
+            ws.send_json(
+                {
+                    "type": "req",
+                    "id": "r1",
+                    "method": "cloud_run.create",
+                    "params": {"prompt": "Summarize the workspace"},
+                }
+            )
+            res = ws.receive_json()
+            assert res["type"] == "res"
+            assert res["ok"] is True, res
+            run_id = res["result"]["run_id"]
+            assert run_id.startswith("crun_")
+            assert res["result"]["status"] == "queued"
+
+            event = ws.receive_json()
+            assert event["type"] == "event"
+            assert event["event"] == "run.started"
+            assert event["run_id"] == run_id
+
+    # The run went through CloudAgentService: a reservation row exists.
+    from hub.models import UsageReservation
+
+    reservation = await db_session.scalar(
+        select(UsageReservation).where(UsageReservation.run_id == run_id)
+    )
+    assert reservation is not None
+    assert reservation.agent_id == seeded["agent_id"]
+
+
+@pytest.mark.asyncio
+async def test_ws_rejects_method_outside_scope(
+    app_with_shared_session, db_session, service, monkeypatch
+):
+    from starlette.testclient import TestClient
+
+    _configure_botlearn(monkeypatch)
+    seeded = await _seed_cloud_agent(db_session, service)
+    # Read-only scope: cloud_run.create requires cloud_runs:create.
+    token = _session_token(
+        seeded["user_id"],
+        seeded["agent_id"],
+        seeded["installation"].id,
+        [BOTLEARN_SCOPE_RUNS_READ],
+    )
+
+    with TestClient(app_with_shared_session) as tc:
+        with tc.websocket_connect(
+            "/api/integrations/botlearn/ws",
+            headers={"origin": ALLOWED_ORIGIN},
+        ) as ws:
+            ws.send_json({"type": "hello", "token": token})
+            assert ws.receive_json()["type"] == "hello_ok"
+
+            ws.send_json(
+                {"type": "req", "id": "r1", "method": "cloud_run.create", "params": {"prompt": "x"}}
+            )
+            res = ws.receive_json()
+            assert res["ok"] is False
+            assert res["error"]["code"] == "insufficient_scope"
+
+
+@pytest.mark.asyncio
+async def test_ws_rejects_disallowed_method(
+    app_with_shared_session, db_session, service, monkeypatch
+):
+    from starlette.testclient import TestClient
+
+    _configure_botlearn(monkeypatch)
+    seeded = await _seed_cloud_agent(db_session, service)
+    token = _session_token(
+        seeded["user_id"],
+        seeded["agent_id"],
+        seeded["installation"].id,
+        [BOTLEARN_SCOPE_RUNS_CREATE, BOTLEARN_SCOPE_RUNS_READ],
+    )
+
+    with TestClient(app_with_shared_session) as tc:
+        with tc.websocket_connect(
+            "/api/integrations/botlearn/ws",
+            headers={"origin": ALLOWED_ORIGIN},
+        ) as ws:
+            ws.send_json({"type": "hello", "token": token})
+            assert ws.receive_json()["type"] == "hello_ok"
+
+            # An internal control-plane frame must never be reachable here.
+            ws.send_json(
+                {"type": "req", "id": "r1", "method": "provision_agent", "params": {}}
+            )
+            res = ws.receive_json()
+            assert res["ok"] is False
+            assert res["error"]["code"] == "method_not_allowed"
+
+
+@pytest.mark.asyncio
+async def test_ws_rejects_revoked_installation(
+    app_with_shared_session, db_session, service, monkeypatch
+):
+    from starlette.testclient import TestClient
+    from starlette.websockets import WebSocketDisconnect
+
+    _configure_botlearn(monkeypatch)
+    seeded = await _seed_cloud_agent(db_session, service)
+    token = _session_token(
+        seeded["user_id"],
+        seeded["agent_id"],
+        seeded["installation"].id,
+        [BOTLEARN_SCOPE_RUNS_READ],
+    )
+    # Revoke before connecting.
+    seeded["installation"].revoked_at = _now()
+    await db_session.commit()
+
+    with TestClient(app_with_shared_session) as tc:
+        with pytest.raises(WebSocketDisconnect) as exc:
+            with tc.websocket_connect(
+                "/api/integrations/botlearn/ws",
+                headers={"origin": ALLOWED_ORIGIN},
+            ) as ws:
+                ws.send_json({"type": "hello", "token": token})
+                ws.receive_json()
+        assert exc.value.code == 4001
+
+
+@pytest.mark.asyncio
+async def test_ws_rejects_bad_token(app_with_shared_session, monkeypatch):
+    from starlette.testclient import TestClient
+    from starlette.websockets import WebSocketDisconnect
+
+    _configure_botlearn(monkeypatch)
+    with TestClient(app_with_shared_session) as tc:
+        with pytest.raises(WebSocketDisconnect) as exc:
+            with tc.websocket_connect(
+                "/api/integrations/botlearn/ws",
+                headers={"origin": ALLOWED_ORIGIN},
+            ) as ws:
+                ws.send_json({"type": "hello", "token": "not-a-real-token"})
+                ws.receive_json()
+        assert exc.value.code == 4001

--- a/backend/tests/test_cloud_agent_run_status.py
+++ b/backend/tests/test_cloud_agent_run_status.py
@@ -1,0 +1,182 @@
+"""Tests for CloudAgentService.get_run / cancel_run — PR 9 best-effort run state.
+
+There is no dedicated run-state table; status is inferred from the per-run
+UsageReservation and any settled UsageEvent. These tests exercise that
+inference plus the cancellation path (release reservation + fail the queued
+trigger message).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from hub.enums import MessageState
+from hub.models import (
+    Base,
+    MessageRecord,
+    UsageEvent,
+    UsageReservation,
+    User,
+)
+from hub.services.cloud_agent import CloudAgentError, CloudAgentService, CreateCloudAgentInput
+from hub.services.cloud_daemon_provider import FakeCloudDaemonProvider
+
+TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(TEST_DB_URL)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def service():
+    return CloudAgentService(
+        provider=FakeCloudDaemonProvider(),
+        feature_enabled=True,
+        max_per_user=3,
+        max_agents_per_daemon=2,
+    )
+
+
+async def _seed_agent(db: AsyncSession, service: CloudAgentService) -> dict:
+    user = User(
+        id=uuid.uuid4(),
+        display_name="Run User",
+        email="run@example.com",
+        status="active",
+        supabase_user_id=uuid.uuid4(),
+        max_agents=30,
+    )
+    db.add(user)
+    await db.commit()
+    view = await service.create_cloud_agent(
+        db, user_id=user.id, body=CreateCloudAgentInput(name="Run Agent")
+    )
+    await db.commit()
+    return {"user_id": user.id, "agent_id": view.agent_id}
+
+
+@pytest.mark.asyncio
+async def test_get_run_reports_running_then_cancelled(db_session, service):
+    from hub.services.cloud_agent import CreateRunInput
+
+    seeded = await _seed_agent(db_session, service)
+    run = await service.create_run(
+        db_session,
+        user_id=seeded["user_id"],
+        agent_id=seeded["agent_id"],
+        body=CreateRunInput(prompt="do the thing"),
+    )
+
+    status = await service.get_run(
+        db_session,
+        user_id=seeded["user_id"],
+        agent_id=seeded["agent_id"],
+        run_id=run.run_id,
+    )
+    assert status.status == "running"
+    assert status.reserved_credits > 0
+
+    cancelled = await service.cancel_run(
+        db_session,
+        user_id=seeded["user_id"],
+        agent_id=seeded["agent_id"],
+        run_id=run.run_id,
+    )
+    assert cancelled.status == "cancelled"
+
+    # The queued trigger message was marked failed.
+    record = await db_session.scalar(
+        select(MessageRecord).where(MessageRecord.hub_msg_id == run.hub_msg_id)
+    )
+    assert record is not None
+    assert record.state == MessageState.failed
+
+    # Idempotent: cancelling again stays cancelled.
+    again = await service.cancel_run(
+        db_session,
+        user_id=seeded["user_id"],
+        agent_id=seeded["agent_id"],
+        run_id=run.run_id,
+    )
+    assert again.status == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_get_run_reports_completed_when_usage_event_exists(db_session, service):
+    seeded = await _seed_agent(db_session, service)
+    run_id = "crun_completed01"
+    db_session.add(
+        UsageEvent(
+            user_id=seeded["user_id"],
+            agent_id=seeded["agent_id"],
+            run_id=run_id,
+            provider="fake",
+            model="deepseek-v4-flash",
+            output_tokens=100,
+            credits_charged=42,
+            idempotency_key=f"{run_id}:settle",
+        )
+    )
+    await db_session.commit()
+
+    status = await service.get_run(
+        db_session,
+        user_id=seeded["user_id"],
+        agent_id=seeded["agent_id"],
+        run_id=run_id,
+    )
+    assert status.status == "completed"
+    assert status.credits_charged == 42
+
+
+@pytest.mark.asyncio
+async def test_get_run_unknown_run_raises_404(db_session, service):
+    seeded = await _seed_agent(db_session, service)
+    with pytest.raises(CloudAgentError) as exc:
+        await service.get_run(
+            db_session,
+            user_id=seeded["user_id"],
+            agent_id=seeded["agent_id"],
+            run_id="crun_doesnotexist",
+        )
+    assert exc.value.http_status == 404
+
+
+@pytest.mark.asyncio
+async def test_get_run_rejects_run_of_other_agent(db_session, service):
+    seeded = await _seed_agent(db_session, service)
+    # Reservation owned by a different agent id.
+    db_session.add(
+        UsageReservation(
+            user_id=seeded["user_id"],
+            agent_id="ag_someoneelse",
+            run_id="crun_foreign01",
+            reserved_credits=5,
+            reserved_sandbox_seconds=60,
+            state="active",
+        )
+    )
+    await db_session.commit()
+    with pytest.raises(CloudAgentError) as exc:
+        await service.get_run(
+            db_session,
+            user_id=seeded["user_id"],
+            agent_id=seeded["agent_id"],
+            run_id="crun_foreign01",
+        )
+    assert exc.value.http_status == 404

--- a/backend/tests/test_cloud_agent_run_status.py
+++ b/backend/tests/test_cloud_agent_run_status.py
@@ -180,3 +180,31 @@ async def test_get_run_rejects_run_of_other_agent(db_session, service):
             run_id="crun_foreign01",
         )
     assert exc.value.http_status == 404
+
+
+@pytest.mark.asyncio
+async def test_cancel_run_rejects_settled_run_of_other_agent(db_session, service):
+    seeded = await _seed_agent(db_session, service)
+    # Settled runs may only have a UsageEvent left; cancellation must still
+    # apply the same agent ownership gate as get_run.
+    db_session.add(
+        UsageEvent(
+            user_id=seeded["user_id"],
+            agent_id="ag_someoneelse",
+            run_id="crun_foreign_settled",
+            provider="fake",
+            model="deepseek-v4-flash",
+            output_tokens=100,
+            credits_charged=42,
+            idempotency_key="crun_foreign_settled:settle",
+        )
+    )
+    await db_session.commit()
+    with pytest.raises(CloudAgentError) as exc:
+        await service.cancel_run(
+            db_session,
+            user_id=seeded["user_id"],
+            agent_id=seeded["agent_id"],
+            run_id="crun_foreign_settled",
+        )
+    assert exc.value.http_status == 404

--- a/docs/cloud-agent-subscription-implementation-plan.md
+++ b/docs/cloud-agent-subscription-implementation-plan.md
@@ -55,6 +55,7 @@ MVP 暂不做:
 - BYOK。
 - 团队共享 workspace。
 - marketplace。
+- BotLearn first-party browser integration。
 - 无限常驻 sandbox。
 - 不受限 shell / 网络访问。
 - Hub-side DeepSeek HTTP task adapter。
@@ -142,6 +143,24 @@ MVP 暂不做:
 - 普通用户月成本稳定低于免费内测预算线。
 - 重度用户触发额度墙，不会继续产生无限 E2B 或模型成本。
 - 产出是否进入公开付费、继续免费 beta 或改成 BYOK 的决策依据。
+
+### Gate 5: BotLearn first-party browser integration
+
+> 状态: 已实现 (2026-06-09, 分支 `feat/botlearn-first-party-integration`)。除"rate limit / budget clamp / 审计日志"留待硬化阶段外，其余验收项均已落地并有单测覆盖。WS 暂以 `run.started` 事件 + `cloud_run.get` 轮询替代实时 output delta 流。
+
+目标: BotLearn 没有后端服务时，BotLearn frontend 可以基于 BotLearn 登录态直接使用 BotCord Cloud Agent，但不持有长期 BotCord API key。
+
+验收:
+
+- BotCord 可以验证 BotLearn 登录 token 的 issuer、audience、signature、expiry、subject 和 email_verified。
+- 首次使用时，BotCord 可以按需创建 / 绑定 BotCord user。
+- BotCord 可以为该 user 创建或选择默认 Cloud Agent。
+- `botlearn_installations` 记录 user、BotLearn subject、默认 agent、scopes、limits 和 revoke 状态。
+- BotLearn frontend 只能获得短期 `botlearn-integration-session` token，默认 TTL 15 分钟。
+- BotLearn WebSocket 使用 `botcord-agent-session/0.1`，只开放 Cloud Run 公共子集。
+- `cloud_run.create` 复用 CloudAgentService run path，不绕过 quota、resume、usage reservation 和 settlement。
+- 用户可以在 BotCord 或 BotLearn 设置中撤销 BotLearn 绑定。
+- Origin allowlist、rate limit、budget clamp 和审计日志生效。
 
 ## 4. PR 拆解
 
@@ -311,7 +330,38 @@ MVP 暂不做:
 - 内测用户可以不借助后台脚本完成 Cloud Agent 基础操作。
 - UI 不承诺尚未实现的套餐、BYOK、fallback 或无限能力。
 
-### PR 9: 后置付费商业化
+### PR 9: BotLearn first-party browser integration
+
+> 状态: 已实现 (2026-06-09)。落地: `botlearn_installations` 表 + migration `031`、`POST /api/integrations/botlearn/session`、`GET /api/integrations/botlearn/ws` (`botcord-agent-session/0.1`, 五个公共方法)、`CloudAgentService.get_run` / `cancel_run` (基于 usage ledger 推导 run 状态)。`cloud_run.create` 复用 `CloudAgentService.create_run`。token 过期 / scope mismatch / quota-不足-不发 token / Origin 拒绝 / revoke 后拒绝全套单测通过。BotLearn 认证模块见 `backend/app/botlearn_auth.py`，路由见 `backend/app/routers/botlearn.py`。
+
+范围:
+
+- 新增 `botlearn_installations`。
+- 新增 `POST /api/integrations/botlearn/session`。
+- 校验 BotLearn 登录 token，并白名单 issuer、audience 和 Origin。
+- JIT 创建 / 绑定 BotCord user。
+- 创建或选择默认 Cloud Agent。
+- 签发短期 `botlearn-integration-session` token。
+- 新增 `GET /api/integrations/botlearn/ws`。
+- 实现 `botcord-agent-session/0.1` 的 `req` / `res` / `event` 协议。
+- 第一版只允许 `cloud_agent.get`、`cloud_run.create`、`cloud_run.get`、`cloud_run.cancel`、`cloud_usage.get`。
+- 增加 token 过期、scope mismatch、quota 不足、Origin 拒绝和 revoke 后拒绝的测试。
+
+暂不做:
+
+- 通用第三方 developer app / marketplace。
+- BotLearn 后端长期 API key。
+- 浏览器可见的长期 BotCord API key。
+- 完整 daemon control plane 暴露。
+
+验收:
+
+- Gate 5 通过。
+- BotLearn frontend 可以无 BotCord Connect 页面完成 Cloud Agent run。
+- BotLearn session exchange 失败时不会创建可用 session token。
+- BotLearn WebSocket 的 run 创建路径不会绕过 CloudAgentService。
+
+### PR 10: 后置付费商业化
 
 范围:
 
@@ -364,12 +414,20 @@ PR 6 前已确认 (2026-05-20):
 
 - Cloud trust policy 如何传给 daemon runtime adapter(daemon-side 修改,Hub 侧只透传 budget)。
 
-进入 PR 9 前需要确认:
+进入 PR 10 前需要确认:
 
 - Lite / Pro 的真实价格和额度。
 - E2B Pro 是否需要购买。
 - BYOK 是否作为重度用户分流入口。
 - 免费功能是否继续保留，还是转为限时 trial。
+
+PR 9 前已确认 (2026-06-09):
+
+- BotLearn 是 first-party app，但当前按无后端 public client 处理。
+- 不要求 BotLearn 打开独立 BotCord Connect 授权页。
+- BotCord 通过 BotLearn 登录 token 做 session exchange，并在首次使用时 JIT 创建 / 绑定 user。
+- BotLearn frontend 只拿短期 BotCord integration session token，不拿长期 API key。
+- WebSocket 采用 daemon 风格 `req` / `res` / `event`，协议名 `botcord-agent-session/0.1`，只开放 Cloud Run 公共子集。
 
 ## 6. 风险控制
 

--- a/docs/cloud-agent-technical-design.md
+++ b/docs/cloud-agent-technical-design.md
@@ -9,7 +9,7 @@
 
 > 状态: 方案确认，待实现
 > 日期: 2026-05-20
-> 范围: Cloud Agent MVP、正式 API、Cloud daemon WebSocket、E2B sandbox、DeepSeek TUI runtime、独立 Cloud Credits
+> 范围: Cloud Agent MVP、正式 API、Cloud daemon WebSocket、E2B sandbox、DeepSeek TUI runtime、独立 Cloud Credits、BotLearn first-party browser integration
 
 ## 1. 已确认决策
 
@@ -21,6 +21,9 @@ Cloud Agent 的 MVP 按以下约束实现:
 - Cloud Agent 允许在 E2B sandbox 内执行 shell，但必须有明确预算和安全边界。
 - Cloud Credits 独立于现有 `COIN` / wallet 体系。
 - 直接建设正式 API，不先做独立 prototype script；正式实现必须有 fake provider 以保证测试和灰度。
+- BotLearn 作为 first-party public client 集成时，不要求用户打开独立 BotCord Connect 授权页；BotCord 通过 BotLearn 登录 token 自动 JIT 创建 / 绑定 BotCord user，并下发短期 BotCord integration session token。
+- BotLearn 浏览器端不持有长期 API key；所有 run 调用使用短期、agent-scoped、scope-limited session token。
+- BotLearn 与 BotCord 的实时通信可以采用 daemon 风格的 `req` / `res` / `event` WebSocket 协议，但只开放 Cloud Run 公共子集，不暴露 cloud daemon 内部 control frame。
 
 Cloud Agent 本质是 BotCord 托管的 daemon 实例，而不是 Hub 直接调用 DeepSeek:
 
@@ -55,6 +58,9 @@ MVP 不做:
 - Claude Code / Codex 默认云端托管。
 - 不受限 shell、无限网络访问或长期常驻 sandbox。
 - Hub-side DeepSeek HTTP task adapter。
+- 通用第三方开发者平台、marketplace 或任意 app 自助注册。
+- 浏览器可见的长期 API key / installation key。
+- 向 BotLearn 或其他外部 app 开放完整 daemon control plane。
 
 ## 3. 系统边界
 
@@ -100,6 +106,25 @@ E2B sandbox 负责:
 - `botcord-daemon` 和 `deepseek-tui` 运行环境。
 
 MVP 推荐使用已验证的 Ubuntu 24.04 / glibc 2.39 template，避免在默认 Debian 12 base 中启动时编译 DeepSeek TUI。
+
+### 3.4 BotLearn first-party integration
+
+BotLearn 是 BotCord first-party app，但当前假设没有独立后端服务承接长期 secret。因此集成边界是:
+
+- BotLearn frontend 持有 BotLearn 登录态 token。
+- BotCord Hub 验证 BotLearn token 的 issuer、audience、signature、expiry 和用户身份 claim。
+- BotCord Hub 按需创建 / 绑定 BotCord user，并为该 user 创建或选择默认 Cloud Agent。
+- BotCord Hub 返回短期 BotCord integration session token 给 BotLearn frontend。
+- BotLearn frontend 用短期 token 连接 BotCord app-facing WebSocket 或 HTTP API。
+
+BotLearn frontend 不负责:
+
+- 持有 BotCord 长期 API key。
+- 持有 cloud daemon access token。
+- 调用 `/cloud/daemon/ws`。
+- 触发 `provision_agent`、`revoke_agent`、`reload_config` 等内部控制面 frame。
+
+BotLearn 登录态必须是 BotCord 可验证的 JWT / OIDC token。优先选择 BotLearn 与 BotCord 共用 Supabase/OIDC 租户；如果不是同一租户，BotCord 通过 BotLearn issuer 的 JWKS 验证签名，并白名单 `iss` / `aud` / allowed origin。
 
 ## 4. WebSocket 设计
 
@@ -186,6 +211,70 @@ cloud daemon registry:
 ```
 
 Cloud service dispatch 时优先使用 `cloud_daemon_instance_id`，底层 frame 仍可携带 `daemon_instance_id` 以复用现有 agent 绑定字段。
+
+### 4.5 BotLearn app-facing WebSocket
+
+BotLearn 不连接 `/cloud/daemon/ws`。新增 app-facing endpoint:
+
+```text
+GET /api/integrations/botlearn/ws
+Authorization: Bearer <botlearn-integration-session-token>
+```
+
+session token 由 `POST /api/integrations/botlearn/session` 签发。推荐 JWT claims:
+
+```json
+{
+  "kind": "botlearn-integration-session",
+  "iss": "botcord-hub",
+  "aud": "botlearn",
+  "sub": "botcord-user-uuid",
+  "botlearn_sub": "botlearn-user-id",
+  "user_id": "uuid",
+  "agent_id": "ag_xxx",
+  "installation_id": "bli_xxx",
+  "scopes": ["cloud_runs:create", "cloud_runs:read", "cloud_runs:stream"],
+  "iat": 1234567890,
+  "exp": 1234568790
+}
+```
+
+要求:
+
+- 默认 TTL 15 分钟。
+- token 只授权一个 user + 一个默认 agent + 一组 scopes。
+- token 不能用作 agent token、cloud daemon token、runtime session token 或 Dashboard user token。
+- CORS / WebSocket Origin 必须限制为 BotLearn allowlist。
+- token 泄露后的损失必须被 TTL、scope、rate limit、run budget 和 usage quota 限制。
+
+BotLearn WebSocket 复用 daemon 协议风格，但使用独立协议名:
+
+```json
+{ "type": "hello", "protocol": "botcord-agent-session/0.1" }
+{ "type": "req", "id": "req_1", "method": "cloud_run.create", "params": { "prompt": "...", "budget": {} } }
+{ "type": "res", "id": "req_1", "ok": true, "result": { "run_id": "car_xxx" } }
+{ "type": "event", "event": "run.started", "run_id": "car_xxx" }
+{ "type": "event", "event": "run.output.delta", "run_id": "car_xxx", "text": "..." }
+{ "type": "event", "event": "run.completed", "run_id": "car_xxx", "usage": {} }
+```
+
+第一版允许的方法:
+
+```text
+cloud_agent.get
+cloud_run.create
+cloud_run.get
+cloud_run.cancel
+cloud_usage.get
+```
+
+明确禁止的方法 / frame:
+
+```text
+cloud_daemon_hello/provision_agent/revoke_agent/reload_config/list_runtimes/list_agent_files/set_route/policy_updated/gateway_send/runtime_snapshot
+```
+
+实现上，`cloud_run.create` 必须调用 `CloudAgentService.create_run` 或等价 service path，不能绕过 entitlement、quota preflight、usage reservation、sandbox resume、message/inbox 注入和 settlement。
 
 ## 5. 数据模型
 
@@ -306,6 +395,32 @@ usage_balances
 
 Cloud Credits 不复用 `COIN`。Cloud Credits 的业务语义是模型 token、sandbox active seconds 和平台 buffer 的统一成本单位。
 
+### 5.6 botlearn_installations
+
+一条记录表示 BotLearn 用户身份到 BotCord user / 默认 Cloud Agent 的 first-party 授权绑定。它不是长期 API key。
+
+```text
+botlearn_installations
+  id                         # bli_<random>
+  user_id                    # FK users.id
+  botlearn_subject           # stable sub from BotLearn token
+  botlearn_email
+  agent_id                   # default Cloud Agent
+  scopes_json                # allowed BotLearn scopes
+  limits_json                # per-session / per-day run limits, budget clamps
+  last_used_at
+  revoked_at
+  created_at
+  updated_at
+```
+
+约束:
+
+- `(botlearn_subject, agent_id)` 唯一，避免重复安装。
+- 若 BotLearn 与 BotCord 共用 auth provider，可用同一 `users` row；否则使用 `botlearn_subject` 做外部身份映射。
+- 不存明文 BotLearn token。
+- 不存浏览器可长期复用的 BotCord API key。
+
 ## 6. Backend API
 
 第一批正式 API:
@@ -415,6 +530,44 @@ Delete:
 - cleanup E2B sandbox。
 - 标记 cloud agent / daemon 为 deleted。
 
+### 6.4 BotLearn Session Exchange
+
+`POST /api/integrations/botlearn/session`
+
+Header:
+
+```text
+Authorization: Bearer <botlearn-id-token>
+```
+
+输出:
+
+```json
+{
+  "access_token": "botcord-short-lived-session-token",
+  "expires_in": 900,
+  "agent_id": "ag_xxx",
+  "installation_id": "bli_xxx",
+  "ws_url": "wss://hub.example.com/api/integrations/botlearn/ws"
+}
+```
+
+流程:
+
+```text
+1. 校验 BotLearn token 的 issuer、audience、signature、expiry、subject 和 email_verified。
+2. 通过 botlearn_subject 查找 BotCord user；不存在则 JIT 创建 user。
+3. 查找或创建该 user 的默认 Cloud Agent。
+4. 创建或更新 botlearn_installations 授权记录。
+5. 校验 entitlement、Cloud Agent 数量限制和免费 / 付费 quota。
+6. 签发短期 botlearn-integration-session token。
+7. 返回 agent_id、installation_id 和 WebSocket URL。
+```
+
+JIT 创建默认 Cloud Agent 时必须复用 `CloudAgentService.create_cloud_agent` 或等价 service path。若 quota 不足或 Cloud Agent 创建失败，session exchange 返回明确 4xx / 5xx，不应下发可用 session token。
+
+BotLearn 无需打开 BotCord Connect 授权页；授权默认由 first-party 信任关系 + BotLearn 登录身份完成。但用户必须能在 BotCord 或 BotLearn 设置中查看并 revoke 该 `botlearn_installation`。
+
 ## 7. Service / Provider 分层
 
 ### 7.1 CloudAgentService
@@ -479,6 +632,9 @@ MVP 允许 shell，但只允许在 E2B sandbox 内执行。
 - secret 最小注入，尽量短期有效。
 - 日志脱敏。
 - 删除 agent 时 revoke token、删除 secret、清理 workspace。
+- BotLearn browser session 只拿短期 token，不能拿长期 API key。
+- BotLearn app-facing WebSocket 只接受 Cloud Run 公共子协议。
+- BotLearn session exchange 必须验证 BotLearn issuer / audience / Origin allowlist。
 
 DeepSeek adapter 必须显式接收 Cloud trust policy。不能让 cloud agent 默认继承本地 daemon 的完全信任语义。
 
@@ -553,6 +709,7 @@ MVP 通过条件:
 - quota 不足时不会启动新的 E2B / 模型成本。
 - idle 后 sandbox 自动 pause。
 - 删除 Cloud Agent 会 revoke token 并触发 cleanup。
+- BotLearn 集成不阻塞 Cloud Agent MVP；进入 first-party 集成阶段时，BotLearn frontend 可以通过 session exchange 获得短期 token，并使用 `botcord-agent-session/0.1` 创建和监听 Cloud Run。
 
 ## 12. 实现顺序
 
@@ -603,6 +760,14 @@ PR 8: Dashboard MVP
   - 状态
   - 剩余额度
   - pause / delete
+
+PR 9: BotLearn first-party browser integration
+  - 验证 BotLearn 登录 token
+  - JIT 创建 / 绑定 BotCord user
+  - 创建或选择默认 Cloud Agent
+  - botlearn_installations
+  - 短期 integration session token
+  - botcord-agent-session/0.1 WebSocket 子协议
 ```
 
 ## 13. 待实现前确认
@@ -619,3 +784,19 @@ PR 4 前已确认 (2026-05-20):
 - DeepSeek provider key 通过 Hub env `DEEPSEEK_API_KEY` 注入 sandbox。完整 secret manager 集成留待生产硬化阶段。
 - E2B template 默认 `botcord-deepseek-tui-ubuntu2404-dev2` (ID `z0f20u29zdgx7cxnuzcu`),通过 env `E2B_TEMPLATE_ID` 覆盖。
 - sandbox 启动命令通过 Hub env `CLOUD_DAEMON_STARTUP_COMMAND` 覆盖。默认命令优先用 `npx --package "$CLOUD_DAEMON_NPM_SPEC"` 启动，避免复用模板中已过期的预装 daemon；设置 `CLOUD_DAEMON_NPM_SPEC=bundled` 时才强制使用镜像内置 `botcord-daemon`。注入 env: `BOTCORD_HUB_URL` / `BOTCORD_CLOUD_DAEMON_INSTANCE_ID` / `BOTCORD_DAEMON_INSTANCE_ID` / `BOTCORD_CLOUD_DAEMON_ACCESS_TOKEN` / `CLOUD_DAEMON_NPM_SPEC` / `DEEPSEEK_API_KEY`。
+
+BotLearn first-party 集成已确认 (2026-06-09):
+
+- BotLearn 没有后端服务时，不发放浏览器可见的长期 BotCord API key。
+- BotCord 通过 BotLearn 登录 token 做 session exchange；如用户不存在则 JIT 创建 BotCord user。
+- 不要求用户打开独立 BotCord Connect 页面；授权记录由 first-party `botlearn_installations` 表承载。
+- BotLearn frontend 只拿短期 `botlearn-integration-session` token，默认 TTL 15 分钟。
+- BotLearn WebSocket 采用 daemon 风格 `req` / `res` / `event`，协议名 `botcord-agent-session/0.1`，只开放 Cloud Run 公共子集。
+
+BotLearn first-party 集成已实现 (2026-06-09, 分支 `feat/botlearn-first-party-integration`):
+
+- token 验证 + session 签发: `backend/app/botlearn_auth.py` (HS256 共享密钥 / RS256/ES256 JWKS 双路径，issuer/audience/expiry/email_verified 校验)。
+- 路由: `backend/app/routers/botlearn.py` (`POST /session` + `GET /ws`)；config 见 `BOTLEARN_*` env。
+- 数据模型: `public.botlearn_installations` (migration `031`)。
+- run 状态: `CloudAgentService.get_run` / `cancel_run` 基于 usage ledger (`usage_reservations` / `usage_events`) 推导，无独立 run 状态表。
+- 未做 (留待硬化): WS 实时 output delta 流 (现以 `run.started` 事件 + `cloud_run.get` 轮询替代)、per-session/day rate limit、budget clamp、审计日志。

--- a/packages/daemon/src/__tests__/provision.test.ts
+++ b/packages/daemon/src/__tests__/provision.test.ts
@@ -1006,6 +1006,42 @@ describe("provision_agent seeds workspace + hot-adds managed route", () => {
     });
   });
 
+  it("hot-adds the managed route before starting the channel", async () => {
+    await withSandboxHome(async () => {
+      const gw = makeFakeGateway();
+      const events: string[] = [];
+      gw.upsertManagedRoute.mockImplementation((accountId: string, route: GatewayRoute) => {
+        events.push(`route:${accountId}:${route.runtime}:${route.cwd}`);
+      });
+      gw.addChannel.mockImplementation(async (cfg: GatewayChannelConfig) => {
+        events.push(`channel:${cfg.id}`);
+      });
+      const provisioner = createProvisioner({
+        gateway: gw as unknown as Parameters<typeof createProvisioner>[0]["gateway"],
+      });
+      const privateKey = Buffer.alloc(32, 17).toString("base64");
+
+      const ack = await provisioner({
+        id: "req_order",
+        type: CONTROL_FRAME_TYPES.PROVISION_AGENT,
+        params: {
+          runtime: "codex",
+          credentials: {
+            agentId: "ag_order",
+            keyId: "k_order",
+            privateKey,
+            hubUrl: "https://hub.example",
+          },
+        },
+      });
+
+      expect(ack.ok).toBe(true);
+      expect(events).toHaveLength(2);
+      expect(events[0]).toMatch(/^route:ag_order:codex:/);
+      expect(events[1]).toBe("channel:ag_order");
+    });
+  });
+
   it("binds OpenClaw default agent when provisioning only specifies a loopback gateway", async () => {
     await withSandboxHome(async ({ tmp, fs, path: nodePath }) => {
       mockState.cfg = {
@@ -1231,10 +1267,11 @@ describe("provision_agent seeds workspace + hot-adds managed route", () => {
           },
         }),
       ).rejects.toThrow(/channel boom/);
-      // Credentials unlinked; managed route never added (addChannel threw
-      // before the upsert step).
+      // Credentials unlinked; pre-published managed route removed after the
+      // channel failed to start.
       const credFile = nodePath.join(tmp, ".botcord", "credentials", "ag_chfail.json");
       expect(fs.existsSync(credFile)).toBe(false);
+      expect(gw.removeManagedRoute).toHaveBeenCalledWith("ag_chfail");
       expect(gw.listManagedRoutes()).toHaveLength(0);
     });
   });

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -1195,17 +1195,17 @@ async function installLocalAgent(
     throw err;
   }
 
+  // Hot-add the synthesized per-agent managed route before starting the
+  // channel. `Gateway.addChannel()` launches the BotCord channel immediately;
+  // on cloud cold-start it may drain an already-delivered inbox message before
+  // this function returns. The route must therefore exist before the channel
+  // can emit its first envelope.
   try {
-    await ctx.gateway.addChannel({
-      id: credentials.agentId,
-      type: BOTCORD_CHANNEL_TYPE,
-      accountId: credentials.agentId,
-      agentId: credentials.agentId,
-    });
+    upsertManagedRouteForCredentials(credentials, cfg, ctx.gateway);
   } catch (err) {
-    // Best-effort rollback: drop the new agent from config and remove the
-    // credentials file. Log loudly so operators notice the partial state.
-    daemonLog.error("provision.addChannel failed, rolling back", {
+    // Rollback config + credentials on managed-route failure (shouldn't
+    // happen — pure map op — but keeps the invariant tight).
+    daemonLog.error("provision.upsertManagedRoute failed, rolling back", {
       agentId: credentials.agentId,
       error: err instanceof Error ? err.message : String(err),
     });
@@ -1223,19 +1223,22 @@ async function installLocalAgent(
     throw err;
   }
 
-  // Hot-add the synthesized per-agent managed route so the next turn picks
-  // the agent's runtime + workspace cwd without waiting for reload_config.
   try {
-    upsertManagedRouteForCredentials(credentials, cfg, ctx.gateway);
+    await ctx.gateway.addChannel({
+      id: credentials.agentId,
+      type: BOTCORD_CHANNEL_TYPE,
+      accountId: credentials.agentId,
+      agentId: credentials.agentId,
+    });
   } catch (err) {
-    // Rollback the channel + config + credentials on managed-route failure
-    // (shouldn't happen — pure map op — but keeps the invariant tight).
-    daemonLog.error("provision.upsertManagedRoute failed, rolling back", {
+    // Best-effort rollback: drop the pre-published route, new agent config,
+    // and credentials file. Log loudly so operators notice the partial state.
+    daemonLog.error("provision.addChannel failed, rolling back", {
       agentId: credentials.agentId,
       error: err instanceof Error ? err.message : String(err),
     });
     try {
-      await ctx.gateway.removeChannel(credentials.agentId, "provision rollback");
+      ctx.gateway.removeManagedRoute(credentials.agentId);
     } catch {
       // ignore
     }


### PR DESCRIPTION
## 背景

实现 Cloud Agent 设计文档中的 **PR 9 / Gate 5**：BotLearn 没有后端长期 secret 时，BotLearn 前端可凭 BotLearn 登录态直接使用 BotCord Cloud Agent，且**浏览器不持有任何长期 BotCord API key**。

PR 1–8（cloud agent 数据模型、`/cloud/daemon/ws`、CloudAgentService、E2B provider、usage ledger、BFF、idle pause）此前已合入；本 PR 补齐唯一缺失的 first-party 集成层。

## 实现

```
BotLearn 浏览器
  → POST /api/integrations/botlearn/session  (Bearer <BotLearn 登录 token>)
     · 验证 issuer/audience/signature/expiry/email_verified（HS256 共享密钥 或 RS256/ES256 JWKS）
     · JIT 创建/绑定 BotCord user（subject → 稳定 supabase_user_id UUID 映射）
     · 选择或创建默认 Cloud Agent（复用 CloudAgentService）
     · 写 botlearn_installations 授权记录
     · 签发短期 botlearn-integration-session token（默认 TTL 900s）
  → GET /api/integrations/botlearn/ws  (botcord-agent-session/0.1, 首帧 hello 带 token)
     · cloud_agent.get / cloud_run.create / cloud_run.get / cloud_run.cancel / cloud_usage.get
     · 每请求校验 scope + installation 未 revoke
     · cloud_run.create 复用 CloudAgentService.create_run（不绕过 quota / reservation / settlement）
     · 两个端点均强制 Origin allowlist
```

### 变更
- **新增** `backend/app/botlearn_auth.py` — token 验证双路径 + session token 签发/校验 + scope/origin 网关
- **新增** `backend/app/routers/botlearn.py` — `POST /session` + `GET /ws`
- **新增** `backend/migrations/031_botlearn_installations.sql` + `models.py` 的 `BotlearnInstallation`（`public` schema）
- **改动** `hub/services/cloud_agent.py` — 补 `get_run` / `cancel_run`，基于 usage ledger（`usage_reservations` / `usage_events`）推导 run 状态，**无独立 run 状态表**
- **改动** `config.py`（`BOTLEARN_*` env）、`main.py`（路由注册，自带鉴权，不走 beta gate）
- **改动** 两份设计文档：标注 PR 9 / Gate 5 已实现

## 取舍（已在文档标注）
- WS **实时 output delta 流未做**：现以 `run.started` 事件 + `cloud_run.get` 轮询替代（需桥接 daemon stream-block，留待后续）
- per-session/day rate limit、budget clamp、审计日志留待硬化阶段

## 测试
- 新增 20 用例：session exchange (10) + WS (6) + run status (4)，覆盖 token 过期 / scope mismatch / quota-不足-不发-token / Origin 拒绝 / revoke 后拒绝
- **全量后端套件 1463 passed / 30 skipped / 0 failed**，无回归

## 配置（生产启用前）
需设置：`BOTLEARN_INTEGRATION_ENABLED=true`、`BOTLEARN_ISSUER`、`BOTLEARN_AUDIENCE`、`BOTLEARN_JWKS_URL`（或 `BOTLEARN_JWT_SECRET`）、`BOTLEARN_ALLOWED_ORIGINS`、可选 `BOTLEARN_WS_URL` / `BOTLEARN_SESSION_TTL_SECONDS`。默认关闭、空 Origin allowlist 即拒绝（deny-by-default）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)