### PR TITLE
fix: log feishu inbound allowlist drops

### DIFF
--- a/packages/daemon/src/gateway/__tests__/feishu-channel.test.ts
+++ b/packages/daemon/src/gateway/__tests__/feishu-channel.test.ts
@@ -3,10 +3,10 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createFeishuChannel } from "../channels/feishu.js";
+import type { GatewayLogger } from "../log.js";
 import type {
   ChannelStartContext,
   GatewayInboundEnvelope,
-  GatewayLogger,
 } from "../types.js";
 
 const larkMock = vi.hoisted(() => ({
@@ -67,17 +67,26 @@ function makeStartCtx(abort: AbortController): {
   ctx: ChannelStartContext;
   envelopes: GatewayInboundEnvelope[];
   statuses: Array<Record<string, unknown>>;
+  logs: Array<{ message: string; meta?: Record<string, unknown> }>;
 } {
   const envelopes: GatewayInboundEnvelope[] = [];
   const statuses: Array<Record<string, unknown>> = [];
+  const logs: Array<{ message: string; meta?: Record<string, unknown> }> = [];
+  const log: GatewayLogger = {
+    ...SILENT_LOG,
+    debug: (message, meta) => {
+      logs.push({ message, meta });
+    },
+  };
   return {
     envelopes,
     statuses,
+    logs,
     ctx: {
       config: stubConfig,
       accountId: "ag_self",
       abortSignal: abort.signal,
-      log: SILENT_LOG,
+      log,
       emit: async (env) => {
         envelopes.push(env);
       },
@@ -142,6 +151,80 @@ describe("createFeishuChannel", () => {
     expect(envelopes).toHaveLength(1);
     expect(envelopes[0]!.message.text).toBe("[image: img_v2_x]");
     expect(envelopes[0]!.message.conversation.id).toBe("feishu:chat:oc_chat");
+  });
+
+  it("logs Feishu allowlist drops before emitting", async () => {
+    larkMock.responses.push({
+      code: 0,
+      data: { pingBotInfo: { botID: "ou_bot", botName: "Bot" } },
+    });
+    const adapter = createFeishuChannel({
+      id: "gw_fs",
+      accountId: "ag_self",
+      appId: "cli_a",
+      appSecret: "sec",
+      allowedSenderIds: ["ou_alice"],
+      allowedChatIds: ["oc_chat"],
+      stateFile: path.join(tmp, "state.json"),
+      stateDebounceMs: 0,
+    });
+    const abort = new AbortController();
+    const { ctx, envelopes, logs } = makeStartCtx(abort);
+    const started = adapter.start(ctx);
+    await vi.waitUntil(() => typeof larkMock.handlers["im.message.receive_v1"] === "function");
+
+    await larkMock.handlers["im.message.receive_v1"]!({
+      sender: { sender_id: { open_id: "ou_alice" }, sender_type: "user" },
+      message: {
+        message_id: "om_wrong_chat",
+        chat_id: "oc_other",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "blocked by chat" }),
+      },
+    });
+    await larkMock.handlers["im.message.receive_v1"]!({
+      sender: { sender_id: { open_id: "ou_eve" }, sender_type: "user" },
+      message: {
+        message_id: "om_wrong_sender",
+        chat_id: "oc_chat",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "blocked by sender" }),
+      },
+    });
+
+    abort.abort();
+    await started;
+
+    expect(envelopes).toHaveLength(0);
+    const chatDrop = logs.find((entry) => entry.meta?.reason === "chat_not_allowed");
+    expect(chatDrop?.message).toBe("feishu inbound dropped");
+    expect(chatDrop?.meta).toMatchObject({
+      provider: "feishu",
+      channel: "gw_fs",
+      accountId: "ag_self",
+      reason: "chat_not_allowed",
+      messageId: "om_wrong_chat",
+      chatId: "oc_other",
+      chatType: "group",
+      messageType: "text",
+      senderOpenId: "ou_alice",
+      senderType: "user",
+      allowedChatIds: ["oc_chat"],
+    });
+    const senderDrop = logs.find((entry) => entry.meta?.reason === "sender_not_allowed");
+    expect(senderDrop?.message).toBe("feishu inbound dropped");
+    expect(senderDrop?.meta).toMatchObject({
+      provider: "feishu",
+      channel: "gw_fs",
+      accountId: "ag_self",
+      reason: "sender_not_allowed",
+      messageId: "om_wrong_sender",
+      chatId: "oc_chat",
+      senderOpenId: "ou_eve",
+      allowedSenderIds: ["ou_alice"],
+    });
   });
 
   it("sends text replies through Feishu reply API with thread mode", async () => {

--- a/packages/daemon/src/gateway/channels/feishu.ts
+++ b/packages/daemon/src/gateway/channels/feishu.ts
@@ -1,6 +1,7 @@
 import * as Lark from "@larksuiteoapi/node-sdk";
 import { readFileSync } from "node:fs";
 import path from "node:path";
+import type { GatewayLogger } from "../log.js";
 import type {
   ChannelAdapter,
   ChannelSendContext,
@@ -319,6 +320,35 @@ export function createFeishuChannel(opts: FeishuChannelOptions): ChannelAdapter 
     return appSecret;
   }
 
+  function compactMeta(meta: Record<string, unknown>): Record<string, unknown> {
+    return Object.fromEntries(
+      Object.entries(meta).filter(([, value]) => value !== undefined),
+    );
+  }
+
+  function logInboundDrop(
+    log: GatewayLogger,
+    reason: string,
+    event: FeishuMessageEvent,
+    extra: Record<string, unknown> = {},
+  ): void {
+    const message = event.message;
+    const sender = event.sender;
+    log.debug("feishu inbound dropped", compactMeta({
+      provider: FEISHU_PROVIDER,
+      channel: opts.id,
+      accountId: opts.accountId,
+      reason,
+      messageId: message?.message_id,
+      chatId: message?.chat_id,
+      chatType: message?.chat_type,
+      messageType: message?.message_type,
+      senderOpenId: sender?.sender_id?.open_id,
+      senderType: sender?.sender_type,
+      ...extra,
+    }));
+  }
+
   function ensureClient(): FeishuClient {
     if (client) return client;
     if (!opts.appId || !loadSecretIfNeeded()) {
@@ -358,22 +388,57 @@ export function createFeishuChannel(opts: FeishuChannelOptions): ChannelAdapter 
     botName = res.data?.pingBotInfo?.botName;
   }
 
-  function normalizeMessage(event: FeishuMessageEvent): GatewayInboundMessage | null {
+  function normalizeMessage(
+    event: FeishuMessageEvent,
+    log: GatewayLogger,
+  ): GatewayInboundMessage | null {
     const message = event.message;
     const sender = event.sender;
-    if (!message || !sender) return null;
+    if (!message || !sender) {
+      logInboundDrop(log, "missing_event_fields", event, {
+        hasMessage: Boolean(message),
+        hasSender: Boolean(sender),
+      });
+      return null;
+    }
     const chatId = message.chat_id;
     const messageId = message.message_id;
     const senderOpenId = sender.sender_id?.open_id;
-    if (!chatId || !messageId || !senderOpenId) return null;
-    if (botOpenId && senderOpenId === botOpenId) return null;
-    if (hasSeenMessage(messageId)) return null;
+    if (!chatId || !messageId || !senderOpenId) {
+      logInboundDrop(log, "missing_message_fields", event, {
+        hasChatId: Boolean(chatId),
+        hasMessageId: Boolean(messageId),
+        hasSenderOpenId: Boolean(senderOpenId),
+      });
+      return null;
+    }
+    if (botOpenId && senderOpenId === botOpenId) {
+      logInboundDrop(log, "self_echo", event, { botOpenId });
+      return null;
+    }
+    if (hasSeenMessage(messageId)) {
+      logInboundDrop(log, "duplicate_message", event);
+      return null;
+    }
 
-    if (allowedChatIds.size > 0 && !allowedChatIds.has(chatId)) return null;
-    if (!allowedSenderIds.has(senderOpenId)) return null;
+    if (allowedChatIds.size > 0 && !allowedChatIds.has(chatId)) {
+      logInboundDrop(log, "chat_not_allowed", event, {
+        allowedChatIds: Array.from(allowedChatIds),
+      });
+      return null;
+    }
+    if (!allowedSenderIds.has(senderOpenId)) {
+      logInboundDrop(log, "sender_not_allowed", event, {
+        allowedSenderIds: Array.from(allowedSenderIds),
+      });
+      return null;
+    }
 
     const text = parseInboundText(message);
-    if (text === null) return null;
+    if (text === null) {
+      logInboundDrop(log, "unsupported_or_empty_content", event);
+      return null;
+    }
     rememberMessage(messageId);
     const chatType = message.chat_type ?? "";
     const conversationKind: "direct" | "group" =
@@ -431,7 +496,7 @@ export function createFeishuChannel(opts: FeishuChannelOptions): ChannelAdapter 
       const dispatcher = new sdk.EventDispatcher({});
       dispatcher.register({
         "im.message.receive_v1": async (data: unknown) => {
-          const normalized = normalizeMessage(data as FeishuMessageEvent);
+          const normalized = normalizeMessage(data as FeishuMessageEvent, ctx.log);
           if (!normalized) return;
           markStatus({ lastInboundAt: Date.now(), connected: true, authorized: true });
           await ctx.emit({ message: normalized });

--- a/packages/gateway-ingress/src/__tests__/feishu.test.ts
+++ b/packages/gateway-ingress/src/__tests__/feishu.test.ts
@@ -34,10 +34,16 @@ function makeCtx(
     lastInboundAt?: number;
     lastError?: string | null;
   }[] = [];
+  const logs: Array<{ message: string; meta?: Record<string, unknown> }> = [];
   const ctx: ProviderRuntimeContext = {
     connection,
     secret,
-    log: noopLogger,
+    log: {
+      ...noopLogger,
+      debug(message, meta) {
+        logs.push({ message, meta });
+      },
+    },
     abortSignal: abort.signal,
     async emit(msg, id) {
       emits.push({ msg, providerEventId: id });
@@ -53,7 +59,7 @@ function makeCtx(
       activity.push(patch);
     },
   };
-  return { ctx, emits, cursors, activity };
+  return { ctx, emits, cursors, activity, logs };
 }
 
 interface FakeRequest {
@@ -262,7 +268,7 @@ describe("Feishu provider adapter", () => {
       sdkOverride: harness.sdkOverride,
     });
     const abort = new AbortController();
-    const { ctx, emits } = makeCtx({ appSecret: "shh" }, abort);
+    const { ctx, emits, logs } = makeCtx({ appSecret: "shh" }, abort);
 
     const running = provider.start(ctx);
     const deadline = Date.now() + 1_000;
@@ -284,6 +290,67 @@ describe("Feishu provider adapter", () => {
     abort.abort();
     await running;
     expect(emits).toHaveLength(0);
+    const drop = logs.find((entry) => entry.meta?.reason === "sender_not_allowed");
+    expect(drop?.message).toBe("feishu inbound dropped");
+    expect(drop?.meta).toMatchObject({
+      provider: "feishu",
+      gatewayId: "gw_fs_unit",
+      agentId: "ag_unit",
+      reason: "sender_not_allowed",
+      messageId: "om_blocked",
+      chatId: "oc_chat",
+      chatType: "p2p",
+      messageType: "text",
+      senderOpenId: "ou_eve",
+      allowedSenderIds: ["ou_alice"],
+    });
+  });
+
+  it("logs messages rejected by allowedChatIds", async () => {
+    const harness = makeSdkOverride({ probeBotId: "ou_bot" });
+    const provider = createFeishuProvider({
+      gatewayId: conn.id,
+      sdkOverride: harness.sdkOverride,
+    });
+    const abort = new AbortController();
+    const { ctx, emits, logs } = makeCtx({ appSecret: "shh" }, abort);
+
+    const running = provider.start(ctx);
+    const deadline = Date.now() + 1_000;
+    while (Date.now() < deadline && harness.wsStarted.length === 0) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+
+    await harness.fireMessageEvent({
+      sender: { sender_id: { open_id: "ou_alice" }, sender_type: "user" },
+      message: {
+        message_id: "om_wrong_chat",
+        chat_id: "oc_elsewhere",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "blocked by chat" }),
+      },
+    });
+
+    abort.abort();
+    await running;
+
+    expect(emits).toHaveLength(0);
+    const drop = logs.find((entry) => entry.meta?.reason === "chat_not_allowed");
+    expect(drop?.message).toBe("feishu inbound dropped");
+    expect(drop?.meta).toMatchObject({
+      provider: "feishu",
+      gatewayId: "gw_fs_unit",
+      agentId: "ag_unit",
+      reason: "chat_not_allowed",
+      messageId: "om_wrong_chat",
+      chatId: "oc_elsewhere",
+      chatType: "group",
+      messageType: "text",
+      senderOpenId: "ou_alice",
+      senderType: "user",
+      allowedChatIds: ["oc_chat"],
+    });
   });
 
   it("send() posts text and returns the provider message id", async () => {

--- a/packages/gateway-ingress/src/providers/feishu.ts
+++ b/packages/gateway-ingress/src/providers/feishu.ts
@@ -240,25 +240,84 @@ export function createFeishuProvider(opts: FeishuProviderOptions): ProviderAdapt
     botOpenId = res.data?.pingBotInfo?.botID;
   }
 
+  function compactMeta(meta: Record<string, unknown>): Record<string, unknown> {
+    return Object.fromEntries(
+      Object.entries(meta).filter(([, value]) => value !== undefined),
+    );
+  }
+
+  function logInboundDrop(
+    ctx: ProviderRuntimeContext,
+    reason: string,
+    event: FeishuMessageEvent,
+    extra: Record<string, unknown> = {},
+  ): void {
+    const message = event.message;
+    const sender = event.sender;
+    ctx.log.debug("feishu inbound dropped", compactMeta({
+      provider: FEISHU_PROVIDER,
+      gatewayId: ctx.connection.id,
+      agentId: ctx.connection.agentId,
+      reason,
+      messageId: message?.message_id,
+      chatId: message?.chat_id,
+      chatType: message?.chat_type,
+      messageType: message?.message_type,
+      senderOpenId: sender?.sender_id?.open_id,
+      senderType: sender?.sender_type,
+      ...extra,
+    }));
+  }
+
   function normalizeMessage(
     event: FeishuMessageEvent,
     accountId: string,
     channelId: string,
+    ctx: ProviderRuntimeContext,
   ): { message: GatewayInboundMessage; providerEventId: string } | null {
     const message = event.message;
     const sender = event.sender;
-    if (!message || !sender) return null;
+    if (!message || !sender) {
+      logInboundDrop(ctx, "missing_event_fields", event, {
+        hasMessage: Boolean(message),
+        hasSender: Boolean(sender),
+      });
+      return null;
+    }
     const chatId = message.chat_id;
     const messageId = message.message_id;
     const senderOpenId = sender.sender_id?.open_id;
-    if (!chatId || !messageId || !senderOpenId) return null;
-    if (botOpenId && senderOpenId === botOpenId) return null;
+    if (!chatId || !messageId || !senderOpenId) {
+      logInboundDrop(ctx, "missing_message_fields", event, {
+        hasChatId: Boolean(chatId),
+        hasMessageId: Boolean(messageId),
+        hasSenderOpenId: Boolean(senderOpenId),
+      });
+      return null;
+    }
+    if (botOpenId && senderOpenId === botOpenId) {
+      logInboundDrop(ctx, "self_echo", event, { botOpenId });
+      return null;
+    }
 
-    if (allowedChatIds.size > 0 && !allowedChatIds.has(chatId)) return null;
-    if (allowedSenderIds.size > 0 && !allowedSenderIds.has(senderOpenId)) return null;
+    if (allowedChatIds.size > 0 && !allowedChatIds.has(chatId)) {
+      logInboundDrop(ctx, "chat_not_allowed", event, {
+        allowedChatIds: Array.from(allowedChatIds),
+      });
+      return null;
+    }
+    if (allowedSenderIds.size > 0 && !allowedSenderIds.has(senderOpenId)) {
+      logInboundDrop(ctx, "sender_not_allowed", event, {
+        allowedSenderIds: Array.from(allowedSenderIds),
+      });
+      return null;
+    }
 
     const text = parseInboundText(message);
-    if (text === null) return null;
+    if (text === null) {
+      logInboundDrop(ctx, "unsupported_or_empty_content", event);
+      return null;
+    }
     const chatType = message.chat_type ?? "";
     const conversationKind: "direct" | "group" = chatType === "p2p" ? "direct" : "group";
     const conversationId =
@@ -327,6 +386,7 @@ export function createFeishuProvider(opts: FeishuProviderOptions): ProviderAdapt
           data as FeishuMessageEvent,
           ctx.connection.agentId,
           ctx.connection.id,
+          ctx,
         );
         if (!normalized) return;
         ctx.markActivity({ lastInboundAt: Date.now() });


### PR DESCRIPTION
## Summary
- Add debug logs when Feishu inbound events are dropped before emission in local daemon and gateway-ingress.
- Include structured drop reasons for allowlist blocks, self echoes, duplicate messages, malformed events, and unsupported content.
- Cover allowedChatIds and allowedSenderIds drop logging in daemon and ingress tests.

## Verification
- pnpm --filter @botcord/protocol-core build
- pnpm --filter @botcord/daemon build
- pnpm --filter @botcord/gateway-ingress build
- pnpm --filter @botcord/daemon test -- src/gateway/__tests__/feishu-channel.test.ts
- pnpm --filter @botcord/gateway-ingress test -- src/__tests__/feishu.test.ts
- git diff --check

## Risk / rollout
- Low risk: debug-only logging path, no message body logged.
- Local daemon users need debug logging enabled to see these drops in daemon logs.