### PR TITLE
feat(daemon): auto-update runtime CLIs at startup and every 24h

### DIFF
--- a/.changeset/runtime-autoupdate.md
+++ b/.changeset/runtime-autoupdate.md
@@ -1,0 +1,5 @@
+---
+"@botcord/daemon": minor
+---
+
+Background runtime auto-update: the daemon now updates runtime CLIs with a known update channel (Claude Code via `claude update`, OpenClaw via `openclaw update --yes --no-restart`, Codex/Gemini via `npm install -g` when npm-managed) once at startup and every 24h, pushing a fresh `runtime_snapshot` when any version changed. Configure with `BOTCORD_DISABLE_RUNTIME_AUTOUPDATE=1`, `BOTCORD_RUNTIME_UPDATE_INTERVAL_MS`, and `BOTCORD_RUNTIME_AUTOUPDATE_SKIP=<id,id>`.

--- a/packages/daemon/src/__tests__/runtime-update.test.ts
+++ b/packages/daemon/src/__tests__/runtime-update.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import {
+  startRuntimeAutoUpdate,
+  updateAllRuntimes,
+  type RuntimeUpdateDeps,
+} from "../runtime-update.js";
+import type { RuntimeModule } from "../gateway/runtimes/registry.js";
+import type { GatewayLogger } from "../gateway/log.js";
+
+function makeLogger(): GatewayLogger {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+}
+
+/** Build a fake runtime module whose probe version flips after `bump()`. */
+function fakeModule(
+  id: string,
+  opts: {
+    update?: RuntimeModule["update"];
+    available?: boolean;
+    path?: string;
+    versions?: [string, string];
+  } = {},
+): { mod: RuntimeModule; bump: () => void } {
+  const versions = opts.versions ?? ["1.0.0", "1.0.0"];
+  let probeCount = 0;
+  let bumped = false;
+  const mod: RuntimeModule = {
+    id,
+    displayName: id,
+    binary: id,
+    probe: () => {
+      probeCount += 1;
+      if (opts.available === false) return { available: false };
+      return {
+        available: true,
+        path: opts.path ?? `/usr/local/bin/${id}`,
+        version: bumped ? versions[1] : versions[0],
+      };
+    },
+    create: () => {
+      throw new Error("not used in tests");
+    },
+    update: opts.update,
+  };
+  return { mod, bump: () => (bumped = true) };
+}
+
+const baseEnv: NodeJS.ProcessEnv = {};
+
+describe("updateAllRuntimes", () => {
+  it("runs a self-update command with the probed binary path", async () => {
+    const { mod } = fakeModule("claude-code", {
+      update: { kind: "self", args: ["update"] },
+      path: "/opt/claude/claude",
+    });
+    const exec = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
+    const results = await updateAllRuntimes({
+      modules: [mod],
+      execFileFn: exec,
+      realpathFn: (p) => p,
+      env: baseEnv,
+    });
+    expect(exec).toHaveBeenCalledWith(
+      "/opt/claude/claude",
+      ["update"],
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
+    expect(results[0]).toMatchObject({ id: "claude-code", status: "unchanged" });
+  });
+
+  it("reports `updated` when the probed version changes", async () => {
+    const { mod, bump } = fakeModule("claude-code", {
+      update: { kind: "self", args: ["update"] },
+      versions: ["1.0.0", "2.0.0"],
+    });
+    const exec = vi.fn().mockImplementation(async () => {
+      bump();
+      return { stdout: "", stderr: "" };
+    });
+    const results = await updateAllRuntimes({
+      modules: [mod],
+      execFileFn: exec,
+      realpathFn: (p) => p,
+      env: baseEnv,
+    });
+    expect(results[0]).toMatchObject({
+      status: "updated",
+      versionBefore: "1.0.0",
+      versionAfter: "2.0.0",
+    });
+  });
+
+  it("updates npm-managed installs via npm install -g", async () => {
+    const { mod } = fakeModule("codex", {
+      update: { kind: "npm", pkg: "@openai/codex" },
+      path: "/Users/me/.nvm/versions/node/v20/bin/codex",
+    });
+    const exec = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
+    const results = await updateAllRuntimes({
+      modules: [mod],
+      execFileFn: exec,
+      realpathFn: () => "/Users/me/.nvm/versions/node/v20/lib/node_modules/@openai/codex/bin/codex.js",
+      env: baseEnv,
+    });
+    expect(exec).toHaveBeenCalledWith(
+      "npm",
+      ["install", "-g", "@openai/codex@latest"],
+      expect.anything(),
+    );
+    expect(results[0]).toMatchObject({ id: "codex", status: "unchanged" });
+  });
+
+  it("skips npm updates for non-npm installs (e.g. brew)", async () => {
+    const { mod } = fakeModule("gemini", {
+      update: { kind: "npm", pkg: "@google/gemini-cli" },
+      path: "/opt/homebrew/bin/gemini",
+    });
+    const exec = vi.fn();
+    const results = await updateAllRuntimes({
+      modules: [mod],
+      execFileFn: exec,
+      realpathFn: () => "/opt/homebrew/Cellar/gemini-cli/1.0/bin/gemini",
+      env: baseEnv,
+    });
+    expect(exec).not.toHaveBeenCalled();
+    expect(results[0]).toMatchObject({
+      status: "skipped",
+      detail: "not an npm-managed install",
+    });
+  });
+
+  it("serializes npm updates but keeps self-updates parallel", async () => {
+    const order: string[] = [];
+    let inFlightNpm = 0;
+    const { mod: codex } = fakeModule("codex", {
+      update: { kind: "npm", pkg: "@openai/codex" },
+    });
+    const { mod: gemini } = fakeModule("gemini", {
+      update: { kind: "npm", pkg: "@google/gemini-cli" },
+    });
+    const exec = vi.fn().mockImplementation(async (cmd: string, args: string[]) => {
+      if (cmd === "npm") {
+        inFlightNpm += 1;
+        expect(inFlightNpm).toBe(1);
+        await new Promise((r) => setTimeout(r, 5));
+        inFlightNpm -= 1;
+      }
+      order.push(args.join(" "));
+      return { stdout: "", stderr: "" };
+    });
+    await updateAllRuntimes({
+      modules: [codex, gemini],
+      execFileFn: exec,
+      realpathFn: (p) => `/x/node_modules/${p}`,
+      env: baseEnv,
+    });
+    expect(order).toHaveLength(2);
+  });
+
+  it("skips runtimes that are not installed or have no channel", async () => {
+    const { mod: missing } = fakeModule("kimi-cli", {
+      update: { kind: "self", args: ["update"] },
+      available: false,
+    });
+    const { mod: noChannel } = fakeModule("hermes-agent", {});
+    const exec = vi.fn();
+    const results = await updateAllRuntimes({
+      modules: [missing, noChannel],
+      execFileFn: exec,
+      realpathFn: (p) => p,
+      env: baseEnv,
+    });
+    expect(exec).not.toHaveBeenCalled();
+    expect(results[0]).toMatchObject({ status: "skipped", detail: "not installed" });
+    expect(results[1]).toMatchObject({ status: "skipped", detail: "no auto-update channel" });
+  });
+
+  it("honors BOTCORD_RUNTIME_AUTOUPDATE_SKIP", async () => {
+    const { mod } = fakeModule("openclaw-acp", {
+      update: { kind: "self", args: ["update", "--yes", "--no-restart"] },
+    });
+    const exec = vi.fn();
+    const results = await updateAllRuntimes({
+      modules: [mod],
+      execFileFn: exec,
+      realpathFn: (p) => p,
+      env: { BOTCORD_RUNTIME_AUTOUPDATE_SKIP: "openclaw-acp, codex" },
+    });
+    expect(exec).not.toHaveBeenCalled();
+    expect(results[0]).toMatchObject({ status: "skipped" });
+  });
+
+  it("turns an exec failure into a failed result without rejecting", async () => {
+    const { mod } = fakeModule("claude-code", {
+      update: { kind: "self", args: ["update"] },
+    });
+    const exec = vi.fn().mockRejectedValue(new Error("network down"));
+    const results = await updateAllRuntimes({
+      modules: [mod],
+      execFileFn: exec,
+      realpathFn: (p) => p,
+      env: baseEnv,
+    });
+    expect(results[0]).toMatchObject({ status: "failed", detail: "network down" });
+  });
+});
+
+describe("startRuntimeAutoUpdate", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("runs a startup round and reports results via onCompleted", async () => {
+    const { mod, bump } = fakeModule("claude-code", {
+      update: { kind: "self", args: ["update"] },
+      versions: ["1.0.0", "2.0.0"],
+    });
+    const exec = vi.fn().mockImplementation(async () => {
+      bump();
+      return { stdout: "", stderr: "" };
+    });
+    const onCompleted = vi.fn();
+    const handle = startRuntimeAutoUpdate(
+      { log: makeLogger(), onCompleted },
+      { modules: [mod], execFileFn: exec, realpathFn: (p) => p, env: baseEnv },
+    );
+    await vi.waitFor(() => expect(onCompleted).toHaveBeenCalledTimes(1));
+    expect(onCompleted.mock.calls[0][0][0]).toMatchObject({ status: "updated" });
+    handle.stop();
+  });
+
+  it("is a no-op when BOTCORD_DISABLE_RUNTIME_AUTOUPDATE=1", () => {
+    const exec = vi.fn();
+    const handle = startRuntimeAutoUpdate(
+      { log: makeLogger() },
+      { execFileFn: exec, env: { BOTCORD_DISABLE_RUNTIME_AUTOUPDATE: "1" } },
+    );
+    expect(exec).not.toHaveBeenCalled();
+    handle.stop();
+  });
+
+  it("is a no-op under NODE_ENV=test so daemon unit tests never run real updates", () => {
+    const exec = vi.fn();
+    const handle = startRuntimeAutoUpdate(
+      { log: makeLogger() },
+      { execFileFn: exec, env: { NODE_ENV: "test" } },
+    );
+    expect(exec).not.toHaveBeenCalled();
+    handle.stop();
+  });
+
+  it("schedules interval rounds at the configured cadence", async () => {
+    vi.useFakeTimers();
+    const { mod } = fakeModule("claude-code", {
+      update: { kind: "self", args: ["update"] },
+    });
+    const exec = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
+    const onCompleted = vi.fn();
+    const handle = startRuntimeAutoUpdate(
+      { log: makeLogger(), onCompleted },
+      {
+        modules: [mod],
+        execFileFn: exec,
+        realpathFn: (p) => p,
+        env: { BOTCORD_RUNTIME_UPDATE_INTERVAL_MS: "1000" },
+      },
+    );
+    await vi.advanceTimersByTimeAsync(0); // flush the startup round
+    expect(onCompleted).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(onCompleted).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(onCompleted).toHaveBeenCalledTimes(3);
+    handle.stop();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(onCompleted).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/daemon/src/daemon.ts
+++ b/packages/daemon/src/daemon.ts
@@ -29,10 +29,12 @@ import { log as daemonLog } from "./log.js";
 import {
   adoptDiscoveredOpenclawAgents,
   attachRuntimeHealth,
+  clearRuntimeProbeCache,
   collectRuntimeSnapshot,
   createProvisioner,
   type OnAgentInstalledHook,
 } from "./provision.js";
+import { startRuntimeAutoUpdate } from "./runtime-update.js";
 import { openclawAutoProvisionEnabled } from "./openclaw-discovery.js";
 import { SnapshotWriter } from "./snapshot-writer.js";
 import { createDaemonSystemContextBuilder } from "./system-context.js";
@@ -734,6 +736,20 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
     });
   }
 
+  // Background runtime auto-update: one round now (async, never blocks
+  // startup), then every 24h. When a round actually changed a version,
+  // refresh the probe cache and push a live runtime_snapshot so the Hub
+  // sees the new versions without a daemon restart.
+  const runtimeUpdater = startRuntimeAutoUpdate({
+    log: logger,
+    onCompleted: (results) => {
+      if (results.some((r) => r.status === "updated")) {
+        clearRuntimeProbeCache();
+        pushLiveRuntimeSnapshot();
+      }
+    },
+  });
+
   const snapshotWriter = new SnapshotWriter({
     path: opts.snapshotPath ?? SNAPSHOT_PATH,
     intervalMs: opts.snapshotIntervalMs ?? resolveSnapshotIntervalMs(),
@@ -746,6 +762,7 @@ export async function startDaemon(opts: DaemonRuntimeOptions): Promise<DaemonHan
   const stop = (reason?: string): Promise<void> => {
     if (stopping) return stopping;
     logger.info("daemon stopping", { reason: reason ?? null });
+    runtimeUpdater.stop();
     snapshotWriter.stop();
     // Write one final snapshot so `status` doesn't briefly see stale data,
     // then delete the file on the way out.

--- a/packages/daemon/src/gateway/runtimes/registry.ts
+++ b/packages/daemon/src/gateway/runtimes/registry.ts
@@ -8,6 +8,19 @@ import { OpenclawAcpAdapter, probeOpenclaw } from "./openclaw-acp.js";
 import type { RuntimeAdapter, RuntimeProbeResult } from "../types.js";
 
 /**
+ * How a runtime CLI can be brought up to date without user interaction.
+ * - `self`: the binary ships its own updater — run `<binary> <args>`.
+ * - `npm`: no self-updater; when the installed binary is npm-managed,
+ *   run `npm install -g <pkg>@latest`. Non-npm installs (brew, native)
+ *   are skipped rather than guessed at.
+ * Runtimes without a spec (pip-installed, unknown channel) are never
+ * auto-updated.
+ */
+export type RuntimeUpdateSpec =
+  | { kind: "self"; args: string[] }
+  | { kind: "npm"; pkg: string };
+
+/**
  * Metadata + factory for a single runtime adapter, used by the registry.
  * Add a new runtime by exporting one of these from the adapter file and
  * registering it in `REGISTRY` below.
@@ -36,6 +49,8 @@ export interface RuntimeModule {
    * probes as unavailable. Helps users recover without reading source.
    */
   installHint?: string;
+  /** Auto-update channel for this runtime; absent → never auto-updated. */
+  update?: RuntimeUpdateSpec;
 }
 
 /** Built-in runtime module entry for Claude Code. */
@@ -46,6 +61,7 @@ export const claudeCodeModule: RuntimeModule = {
   envVar: "BOTCORD_CLAUDE_BIN",
   probe: () => probeClaude(),
   create: () => new ClaudeCodeAdapter(),
+  update: { kind: "self", args: ["update"] },
 };
 
 /** Built-in runtime module entry for Codex. */
@@ -55,6 +71,7 @@ export const codexModule: RuntimeModule = {
   binary: "codex",
   probe: () => probeCodex(),
   create: () => new CodexAdapter(),
+  update: { kind: "npm", pkg: "@openai/codex" },
 };
 
 /** Built-in runtime module entry for DeepSeek TUI. */
@@ -101,6 +118,7 @@ export const geminiModule: RuntimeModule = {
   create: () => new GeminiAdapter(),
   installHint:
     "Install with `npm install -g @google/gemini-cli` (or `brew install gemini-cli`) and run `gemini` once to complete authentication. Override the binary with BOTCORD_GEMINI_BIN.",
+  update: { kind: "npm", pkg: "@google/gemini-cli" },
 };
 
 /** Built-in runtime module entry for OpenClaw (ACP). */
@@ -111,6 +129,9 @@ export const openclawAcpModule: RuntimeModule = {
   envVar: "BOTCORD_OPENCLAW_BIN",
   probe: () => probeOpenclaw(),
   create: () => new OpenclawAcpAdapter(),
+  // --no-restart: the daemon must never bounce a user's openclaw gateway
+  // service as a side effect; the new version applies on next restart.
+  update: { kind: "self", args: ["update", "--yes", "--no-restart"] },
 };
 
 /**

--- a/packages/daemon/src/runtime-update.ts
+++ b/packages/daemon/src/runtime-update.ts
@@ -1,0 +1,323 @@
+import { execFile } from "node:child_process";
+import { realpathSync } from "node:fs";
+import {
+  RUNTIME_MODULES,
+  type RuntimeModule,
+} from "./gateway/runtimes/registry.js";
+import type { GatewayLogger } from "./gateway/log.js";
+import type { RuntimeProbeResult } from "./gateway/types.js";
+
+/**
+ * Default cadence for the background runtime-update loop. Override via
+ * `BOTCORD_RUNTIME_UPDATE_INTERVAL_MS`; disable the whole feature with
+ * `BOTCORD_DISABLE_RUNTIME_AUTOUPDATE=1`.
+ */
+const DEFAULT_UPDATE_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Hard cap for a single runtime's update command. Self-updaters download a
+ * binary and npm installs resolve a dependency tree — minutes, not seconds —
+ * but a wedged updater must not pin the loop forever.
+ */
+const DEFAULT_UPDATE_TIMEOUT_MS = 5 * 60 * 1000;
+
+export interface RuntimeUpdateResult {
+  id: string;
+  /**
+   * - `updated`: command succeeded and the probed version changed.
+   * - `unchanged`: command succeeded, same version (already latest).
+   * - `skipped`: no update channel applies (not installed, not npm-managed,
+   *   or excluded via BOTCORD_RUNTIME_AUTOUPDATE_SKIP).
+   * - `failed`: command errored or timed out.
+   */
+  status: "updated" | "unchanged" | "skipped" | "failed";
+  versionBefore?: string;
+  versionAfter?: string;
+  detail?: string;
+}
+
+/** Injection seam so tests don't shell out or touch the filesystem. */
+export interface RuntimeUpdateDeps {
+  modules?: readonly RuntimeModule[];
+  execFileFn?: (
+    cmd: string,
+    args: string[],
+    opts: { timeout: number; env: NodeJS.ProcessEnv },
+  ) => Promise<{ stdout: string; stderr: string }>;
+  realpathFn?: (p: string) => string;
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+}
+
+function defaultExecFile(
+  cmd: string,
+  args: string[],
+  opts: { timeout: number; env: NodeJS.ProcessEnv },
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      cmd,
+      args,
+      {
+        timeout: opts.timeout,
+        env: opts.env,
+        maxBuffer: 10 * 1024 * 1024,
+        stdio: ["ignore", "pipe", "pipe"],
+      } as Parameters<typeof execFile>[2],
+      (err, stdout, stderr) => {
+        if (err) {
+          reject(
+            new Error(
+              `${err.message}${stderr ? `\n${String(stderr).slice(0, 2000)}` : ""}`,
+            ),
+          );
+          return;
+        }
+        resolve({ stdout: String(stdout), stderr: String(stderr) });
+      },
+    );
+  });
+}
+
+function parseSkipList(env: NodeJS.ProcessEnv): Set<string> {
+  const raw = env.BOTCORD_RUNTIME_AUTOUPDATE_SKIP;
+  if (!raw) return new Set();
+  return new Set(
+    raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean),
+  );
+}
+
+function safeProbe(mod: RuntimeModule): RuntimeProbeResult {
+  try {
+    return mod.probe();
+  } catch {
+    return { available: false };
+  }
+}
+
+/**
+ * Run one module's update command and classify the outcome by re-probing
+ * the version afterwards. Never throws — every failure mode collapses into
+ * a `failed`/`skipped` result so one broken updater can't sink the round.
+ */
+async function updateOneRuntime(
+  mod: RuntimeModule,
+  deps: Required<Pick<RuntimeUpdateDeps, "execFileFn" | "realpathFn" | "env" | "timeoutMs">>,
+): Promise<RuntimeUpdateResult> {
+  const spec = mod.update;
+  if (!spec) {
+    return { id: mod.id, status: "skipped", detail: "no auto-update channel" };
+  }
+  const before = safeProbe(mod);
+  if (!before.available) {
+    return { id: mod.id, status: "skipped", detail: "not installed" };
+  }
+
+  let cmd: string;
+  let args: string[];
+  if (spec.kind === "self") {
+    cmd = before.path ?? mod.binary;
+    args = spec.args;
+  } else {
+    // npm channel: only touch installs we can prove npm owns. A brew or
+    // native install resolves outside node_modules — skip those instead of
+    // clobbering them with a parallel npm copy.
+    let real = before.path ?? "";
+    try {
+      if (real) real = deps.realpathFn(real);
+    } catch {
+      // fall through with the unresolved path
+    }
+    if (!real.includes("node_modules")) {
+      return {
+        id: mod.id,
+        status: "skipped",
+        versionBefore: before.version,
+        detail: "not an npm-managed install",
+      };
+    }
+    cmd = "npm";
+    args = ["install", "-g", `${spec.pkg}@latest`];
+  }
+
+  try {
+    await deps.execFileFn(cmd, args, {
+      timeout: deps.timeoutMs,
+      env: deps.env,
+    });
+  } catch (err) {
+    return {
+      id: mod.id,
+      status: "failed",
+      versionBefore: before.version,
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  const after = safeProbe(mod);
+  const changed =
+    after.version !== undefined && after.version !== before.version;
+  return {
+    id: mod.id,
+    status: changed ? "updated" : "unchanged",
+    versionBefore: before.version,
+    versionAfter: after.version,
+  };
+}
+
+/**
+ * Update every runtime that declares an update channel. Self-updaters run
+ * in parallel (independent binaries); npm-channel updates run sequentially
+ * because concurrent `npm install -g` invocations race on the same global
+ * tree. Resolves with one result per registered module, in registry order.
+ */
+export async function updateAllRuntimes(
+  deps: RuntimeUpdateDeps = {},
+): Promise<RuntimeUpdateResult[]> {
+  const modules = deps.modules ?? RUNTIME_MODULES;
+  const env = deps.env ?? process.env;
+  const resolved = {
+    execFileFn: deps.execFileFn ?? defaultExecFile,
+    realpathFn: deps.realpathFn ?? realpathSync,
+    env,
+    timeoutMs: deps.timeoutMs ?? DEFAULT_UPDATE_TIMEOUT_MS,
+  };
+  const skip = parseSkipList(env);
+
+  const results = new Array<RuntimeUpdateResult>(modules.length);
+  const npmQueue: Array<{ index: number; mod: RuntimeModule }> = [];
+  const parallel: Array<Promise<void>> = [];
+
+  modules.forEach((mod, index) => {
+    if (skip.has(mod.id)) {
+      results[index] = {
+        id: mod.id,
+        status: "skipped",
+        detail: "excluded via BOTCORD_RUNTIME_AUTOUPDATE_SKIP",
+      };
+      return;
+    }
+    if (mod.update?.kind === "npm") {
+      npmQueue.push({ index, mod });
+      return;
+    }
+    parallel.push(
+      updateOneRuntime(mod, resolved).then((r) => {
+        results[index] = r;
+      }),
+    );
+  });
+
+  const npmChain = (async () => {
+    for (const { index, mod } of npmQueue) {
+      results[index] = await updateOneRuntime(mod, resolved);
+    }
+  })();
+
+  await Promise.all([...parallel, npmChain]);
+  return results;
+}
+
+/** Handle returned by {@link startRuntimeAutoUpdate}. */
+export interface RuntimeAutoUpdateHandle {
+  stop: () => void;
+}
+
+export interface RuntimeAutoUpdateOptions {
+  log: GatewayLogger;
+  /**
+   * Called after every completed round with all results — wire this to
+   * `clearRuntimeProbeCache()` + a live `runtime_snapshot` push so the
+   * dashboard sees new versions without waiting for a restart.
+   */
+  onCompleted?: (results: RuntimeUpdateResult[]) => void;
+}
+
+function resolveIntervalMs(env: NodeJS.ProcessEnv): number {
+  const raw = env.BOTCORD_RUNTIME_UPDATE_INTERVAL_MS;
+  if (!raw) return DEFAULT_UPDATE_INTERVAL_MS;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_UPDATE_INTERVAL_MS;
+  return n;
+}
+
+function autoUpdateDisabled(env: NodeJS.ProcessEnv): boolean {
+  // Keep unit tests that boot a full daemon from running real CLI updates
+  // on the developer's machine (same pattern as runtime-models.ts).
+  if (env.NODE_ENV === "test") return true;
+  const raw = (env.BOTCORD_DISABLE_RUNTIME_AUTOUPDATE ?? "").toLowerCase();
+  return raw === "1" || raw === "true";
+}
+
+/**
+ * Fire-and-forget runtime auto-update loop: one round immediately at daemon
+ * startup, then one every 24h (configurable). Rounds never block startup or
+ * throw; results are logged and handed to `onCompleted`.
+ */
+export function startRuntimeAutoUpdate(
+  opts: RuntimeAutoUpdateOptions,
+  deps: RuntimeUpdateDeps = {},
+): RuntimeAutoUpdateHandle {
+  const env = deps.env ?? process.env;
+  if (autoUpdateDisabled(env)) {
+    opts.log.info("runtime-update: disabled via BOTCORD_DISABLE_RUNTIME_AUTOUPDATE");
+    return { stop: () => undefined };
+  }
+
+  let stopped = false;
+  let running = false;
+
+  const runRound = async (trigger: "startup" | "interval"): Promise<void> => {
+    if (running) {
+      // A 24h cadence should never lap a 5-minute-capped round, but a
+      // pathological hang (timeout disabled via deps) must not stack rounds.
+      opts.log.warn("runtime-update: previous round still running; skipping", {
+        trigger,
+      });
+      return;
+    }
+    running = true;
+    try {
+      const results = await updateAllRuntimes(deps);
+      if (stopped) return;
+      const updated = results.filter((r) => r.status === "updated");
+      const failed = results.filter((r) => r.status === "failed");
+      opts.log.info("runtime-update: round completed", {
+        trigger,
+        updated: updated.map((r) => `${r.id} ${r.versionBefore ?? "?"} -> ${r.versionAfter ?? "?"}`),
+        failed: failed.map((r) => r.id),
+        results: results.map((r) => ({ id: r.id, status: r.status })),
+      });
+      for (const r of failed) {
+        opts.log.warn("runtime-update: runtime update failed", {
+          id: r.id,
+          detail: r.detail,
+        });
+      }
+      opts.onCompleted?.(results);
+    } catch (err) {
+      opts.log.warn("runtime-update: round crashed", {
+        trigger,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      running = false;
+    }
+  };
+
+  void runRound("startup");
+  const timer = setInterval(() => {
+    void runRound("interval");
+  }, resolveIntervalMs(env));
+  timer.unref?.();
+
+  return {
+    stop: () => {
+      stopped = true;
+      clearInterval(timer);
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Add a background runtime auto-update loop to the daemon: one round at startup (async, never blocks boot) + one every 24h (`BOTCORD_RUNTIME_UPDATE_INTERVAL_MS`).
- Per-runtime update channels declared on `RuntimeModule` in the gateway registry:
  - **claude-code**: `claude update` (self-update)
  - **openclaw-acp**: `openclaw update --yes --no-restart` — never bounces the user's gateway service as a side effect
  - **codex / gemini**: `npm install -g <pkg>@latest`, only when the resolved binary is provably npm-managed (realpath under `node_modules`); brew/native installs are skipped
  - kimi-cli / deepseek-tui / hermes-agent: no safe channel → skipped with a logged reason
- Self-updates run in parallel; npm updates are serialized (concurrent `npm install -g` races on the global tree).
- When a round actually changes a version, the daemon clears the runtime probe cache and pushes a live `runtime_snapshot` so the dashboard shows new versions without a restart.
- Escape hatches: `BOTCORD_DISABLE_RUNTIME_AUTOUPDATE=1` (global), `BOTCORD_RUNTIME_AUTOUPDATE_SKIP=openclaw-acp,codex` (per-runtime). Disabled automatically under `NODE_ENV=test` so daemon unit tests never run real updates.

## Test plan
- [x] 12 new unit tests in `runtime-update.test.ts` (self/npm channels, brew skip, npm serialization, skip list, failure isolation, interval scheduling, disable flags)
- [x] Full `@botcord/daemon` suite: 77 files / 1051 tests pass
- [x] `pnpm --filter @botcord/daemon build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)