### PR TITLE
feat: show replying status as stacked agent avatars with pulse ring

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -171,61 +171,21 @@ body {
   animation-delay: 0.28s;
 }
 
-.replying-hourglass {
+.replying-avatar {
   position: relative;
   display: inline-flex;
-  height: 0.85rem;
-  width: 0.68rem;
-  flex: 0 0 0.68rem;
-  transform-origin: 50% 50%;
-  animation: replying-hourglass-turn 2.2s ease-in-out infinite;
+  border-radius: 9999px;
 }
 
-.replying-hourglass-frame-icon {
+.replying-avatar::after {
+  content: "";
   position: absolute;
-  inset: 0;
-  height: 100%;
-  width: 100%;
-  color: rgb(250, 204, 21);
-  filter: drop-shadow(0 0 3px rgba(250, 204, 21, 0.28));
-}
-
-.replying-hourglass-top-sand,
-.replying-hourglass-bottom-sand,
-.replying-hourglass-stream {
-  position: absolute;
-  left: 50%;
-  background: rgb(253, 224, 71);
-  box-shadow: 0 0 4px rgba(253, 224, 71, 0.35);
-}
-
-.replying-hourglass-top-sand {
-  top: 0.18rem;
-  height: 0.26rem;
-  width: 0.38rem;
-  transform: translateX(-50%);
-  transform-origin: 50% 100%;
-  clip-path: polygon(0 0, 100% 0, 56% 100%, 44% 100%);
-  animation: replying-hourglass-top-sand 2.2s linear infinite;
-}
-
-.replying-hourglass-stream {
-  top: 0.39rem;
-  height: 0.22rem;
-  width: 1px;
-  transform: translateX(-50%);
-  transform-origin: 50% 0;
-  animation: replying-hourglass-stream 2.2s linear infinite;
-}
-
-.replying-hourglass-bottom-sand {
-  bottom: 0.17rem;
-  height: 0.24rem;
-  width: 0.38rem;
-  transform: translateX(-50%);
-  transform-origin: 50% 100%;
-  clip-path: polygon(44% 0, 56% 0, 100% 100%, 0 100%);
-  animation: replying-hourglass-bottom-sand 2.2s linear infinite;
+  inset: -2px;
+  border-radius: 9999px;
+  border: 1.5px solid rgba(250, 204, 21, 0.75);
+  box-shadow: 0 0 6px rgba(250, 204, 21, 0.3);
+  animation: replying-avatar-pulse 1.6s ease-out infinite;
+  pointer-events: none;
 }
 
 @keyframes fade-in {
@@ -327,102 +287,15 @@ body {
   }
 }
 
-@keyframes replying-hourglass-turn {
-  0%,
-  46% {
-    transform: rotate(0deg);
-  }
-
-  58%,
-  88% {
-    transform: rotate(180deg);
-  }
-
-  100% {
-    transform: rotate(360deg);
-  }
-}
-
-@keyframes replying-hourglass-top-sand {
-  0%,
-  8% {
-    opacity: 0.95;
-    transform: translateX(-50%) scaleY(1);
-  }
-
-  42% {
-    opacity: 0.42;
-    transform: translateX(-50%) scaleY(0.18);
-  }
-
-  48%,
-  58% {
-    opacity: 0.18;
-    transform: translateX(-50%) scaleY(0.08);
-  }
-
-  66%,
-  100% {
-    opacity: 0.95;
-    transform: translateX(-50%) scaleY(1);
-  }
-}
-
-@keyframes replying-hourglass-stream {
-  0%,
-  6% {
-    opacity: 0;
-    transform: translateX(-50%) scaleY(0.2);
-  }
-
-  14%,
-  40% {
+@keyframes replying-avatar-pulse {
+  0% {
+    transform: scale(0.92);
     opacity: 0.9;
-    transform: translateX(-50%) scaleY(1);
-  }
-
-  50%,
-  61% {
-    opacity: 0;
-    transform: translateX(-50%) scaleY(0.15);
   }
 
   70%,
-  92% {
-    opacity: 0.9;
-    transform: translateX(-50%) scaleY(1);
-  }
-
   100% {
+    transform: scale(1.35);
     opacity: 0;
-    transform: translateX(-50%) scaleY(0.2);
-  }
-}
-
-@keyframes replying-hourglass-bottom-sand {
-  0% {
-    opacity: 0.4;
-    transform: translateX(-50%) scaleY(0.16);
-  }
-
-  42% {
-    opacity: 0.95;
-    transform: translateX(-50%) scaleY(1);
-  }
-
-  50%,
-  58% {
-    opacity: 0.95;
-    transform: translateX(-50%) scaleY(1);
-  }
-
-  66% {
-    opacity: 0.4;
-    transform: translateX(-50%) scaleY(0.16);
-  }
-
-  100% {
-    opacity: 0.95;
-    transform: translateX(-50%) scaleY(1);
   }
 }

--- a/frontend/src/components/dashboard/MessageBubble.tsx
+++ b/frontend/src/components/dashboard/MessageBubble.tsx
@@ -4,12 +4,12 @@ import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState } from 
 import type { KeyboardEvent, ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { useShallow } from "zustand/react/shallow";
-import { AlertTriangle, Bot, Check, ChevronDown, ChevronUp, Copy, CornerUpLeft, Forward, Hourglass, MoreHorizontal, RotateCcw, User } from "lucide-react";
+import { AlertTriangle, Bot, Check, ChevronDown, ChevronUp, Copy, CornerUpLeft, Forward, MoreHorizontal, RotateCcw, User } from "lucide-react";
 import ForwardModal from "./ForwardModal";
 import ReplyQuoteBlock from "./ReplyQuoteBlock";
 import { emitJumpToMessage } from "./messageNavigation";
 import RuntimeErrorDetailsDialog from "./RuntimeErrorDetailsDialog";
-import type { DashboardMessage, Attachment } from "@/lib/types";
+import type { DashboardMessage, Attachment, MessageStatusReaction } from "@/lib/types";
 import { canReplyToDashboardMessage } from "@/lib/dashboard-message-actions";
 import { useLanguage } from '@/lib/i18n';
 import { messageBubble } from '@/lib/i18n/translations/dashboard';
@@ -166,13 +166,63 @@ function StateCountsBadges({ counts }: { counts: Record<string, number> }) {
   );
 }
 
-function ReplyingStatusIcon() {
+const MAX_REPLYING_AVATARS = 3;
+
+function ReplyingAvatarStack({ reactions }: { reactions: MessageStatusReaction[] }) {
+  const ownedAgents = useDashboardSessionStore((state) => state.ownedAgents);
+  // Narrow subscription: resolve only these actors' avatars and return a plain
+  // id → url map, so the stack re-renders only when one of *its* actors'
+  // avatars changes — not on every overview / publicAgents churn.
+  const actorKey = reactions.map((reaction) => reaction.actor_id).join(",");
+  const avatarByActor = useDashboardChatStore(
+    useShallow((state) => {
+      const map: Record<string, string | null> = {};
+      for (const actorId of actorKey.split(",")) {
+        if (!actorId) continue;
+        const currentAgent = state.overview?.agent?.agent_id === actorId ? state.overview.agent : null;
+        const contactAgent = state.overview?.contacts.find((item) => item.contact_agent_id === actorId);
+        const publicAgent = state.publicAgents.find((item) => item.agent_id === actorId);
+        map[actorId] = currentAgent?.avatar_url || contactAgent?.avatar_url || publicAgent?.avatar_url || null;
+      }
+      return map;
+    }),
+  );
+  if (reactions.length === 0) return null;
+  const shown = reactions.slice(0, MAX_REPLYING_AVATARS);
+  const extra = reactions.length - shown.length;
+  const names = reactions.map((reaction) => reaction.actor_name || reaction.actor_id).join("、");
   return (
-    <span className="replying-hourglass" aria-hidden="true">
-      <Hourglass className="replying-hourglass-frame-icon" strokeWidth={2.2} />
-      <span className="replying-hourglass-top-sand" />
-      <span className="replying-hourglass-stream" />
-      <span className="replying-hourglass-bottom-sand" />
+    <span className="inline-flex items-center gap-1" title={`${names} replying`}>
+      <span className="inline-flex items-center">
+        {shown.map((reaction, index) => {
+          const ownedAvatar = ownedAgents.find((item) => item.agent_id === reaction.actor_id)?.avatar_url;
+          return (
+            <span
+              key={reaction.actor_id}
+              className={`replying-avatar ${index > 0 ? "-ml-1.5" : ""}`}
+              style={{ zIndex: shown.length - index }}
+            >
+              <BotAvatar
+                agentId={reaction.actor_id}
+                avatarUrl={ownedAvatar || avatarByActor[reaction.actor_id]}
+                alt={reaction.actor_name || reaction.actor_id}
+                size={18}
+                className="ring-yellow-400/40"
+              />
+            </span>
+          );
+        })}
+        {extra > 0 && (
+          <span className="z-0 -ml-1.5 inline-flex h-[18px] w-[18px] items-center justify-center rounded-full border border-yellow-400/40 bg-[#1a1a24] text-[9px] font-medium text-yellow-200">
+            +{extra}
+          </span>
+        )}
+      </span>
+      {reactions.length === 1 && (
+        <span className="max-w-[96px] truncate text-[10px] font-medium text-yellow-200/90">
+          {reactions[0].actor_name || reactions[0].actor_id}
+        </span>
+      )}
     </span>
   );
 }
@@ -893,17 +943,14 @@ function MessageBubble({
               {message.type}
             </span>
           )}
-          {activeStatusReactions.map((reaction) => (
+          <ReplyingAvatarStack reactions={activeStatusReactions.filter((reaction) => reaction.kind === "replying")} />
+          {activeStatusReactions.filter((reaction) => reaction.kind !== "replying").map((reaction) => (
             <span
               key={`${reaction.actor_id}:${reaction.kind}`}
               className="inline-flex items-center gap-1 rounded border border-yellow-400/25 bg-yellow-400/10 px-1 py-px text-[10px] font-medium text-yellow-200"
               title={`${reaction.actor_name || reaction.actor_id} replying`}
             >
-              {reaction.kind === "replying" ? (
-                <ReplyingStatusIcon />
-              ) : (
-                <span className="text-[11px] leading-none">{reaction.emoji}</span>
-              )}
+              <span className="text-[11px] leading-none">{reaction.emoji}</span>
               <span className="max-w-[96px] truncate">{reaction.actor_name || reaction.actor_id}</span>
             </span>
           ))}


### PR DESCRIPTION
## Summary
- Replace the per-agent hourglass chips on message status reactions with an avatar stack: each replying agent renders an 18px avatar wrapped in a yellow breathing pulse ring
- Up to 3 avatars overlap with a +N overflow badge; single-agent keeps the truncated name label; hover title lists all replying actors
- Avatars resolve client-side from owned/contact/public agent stores (narrow `useShallow` subscription) with BotAvatar generated fallback — no backend/protocol change
- Remove the now-unused hourglass animation CSS (4 keyframe sets) in favor of one pulse keyframe

## Test plan
- `pnpm build` passes
- `pnpm test` 196/196 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)