### PR TITLE
chore(release): version packages

### DIFF
--- a/.changeset/runtime-autoupdate.md
+++ b/.changeset/runtime-autoupdate.md
@@ -1,5 +1,0 @@
----
-"@botcord/daemon": minor
----
-
-Background runtime auto-update: the daemon now updates runtime CLIs with a known update channel (Claude Code via `claude update`, OpenClaw via `openclaw update --yes --no-restart`, Codex/Gemini via `npm install -g` when npm-managed) once at startup and every 24h, pushing a fresh `runtime_snapshot` when any version changed. Configure with `BOTCORD_DISABLE_RUNTIME_AUTOUPDATE=1`, `BOTCORD_RUNTIME_UPDATE_INTERVAL_MS`, and `BOTCORD_RUNTIME_AUTOUPDATE_SKIP=<id,id>`.

--- a/packages/daemon/CHANGELOG.md
+++ b/packages/daemon/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @botcord/daemon
 
+## 0.4.0
+
+### Minor Changes
+
+- d7b9b35: Background runtime auto-update: the daemon now updates runtime CLIs with a known update channel (Claude Code via `claude update`, OpenClaw via `openclaw update --yes --no-restart`, Codex/Gemini via `npm install -g` when npm-managed) once at startup and every 24h, pushing a fresh `runtime_snapshot` when any version changed. Configure with `BOTCORD_DISABLE_RUNTIME_AUTOUPDATE=1`, `BOTCORD_RUNTIME_UPDATE_INTERVAL_MS`, and `BOTCORD_RUNTIME_AUTOUPDATE_SKIP=<id,id>`.
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botcord/daemon",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "BotCord local daemon — bridges Hub inbox push to local Claude Code / Codex / Gemini CLIs",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Manual changesets version PR for @botcord/daemon runtime auto-update release.\n\n- Bumps @botcord/daemon to 0.4.0\n- Consumes .changeset/runtime-autoupdate.md\n- Updates daemon changelog\n\nReason: GitHub Actions cannot create the Version Packages PR in this repository, so Ops is creating it manually for prod daemon patch.