### PR TITLE
fix: merge owner chat stream traces with replies

### DIFF
--- a/backend/hub/routers/dashboard.py
+++ b/backend/hub/routers/dashboard.py
@@ -82,6 +82,11 @@ def _extract_text_from_envelope(envelope_data: dict) -> tuple[str, str, dict]:
     payload = envelope_data.get("payload", {})
     if not isinstance(payload, dict):
         payload = {}
+    else:
+        payload = dict(payload)
+    trace_id = envelope_data.get("trace_id")
+    if isinstance(trace_id, str) and trace_id:
+        payload.setdefault("trace_id", trace_id)
 
     text = payload.get("text") or payload.get("body") or payload.get("message") or ""
     if text is not None and not isinstance(text, str):

--- a/backend/hub/routers/hub.py
+++ b/backend/hub/routers/hub.py
@@ -1459,7 +1459,17 @@ async def _send_room_message(
         "ROOM fan-out msg_id=%s from=%s room=%s topic=%s receivers=%s owner_chat_self=%s",
         envelope.msg_id, envelope.from_, room_id, topic, receivers, _self_delivery,
     )
-    envelope_json = json.dumps(envelope.model_dump(by_alias=True))
+    envelope_data = envelope.model_dump(by_alias=True)
+    if is_owner_chat:
+        from hub.routers.owner_chat_ws import current_owner_chat_trace_id
+
+        owner_chat_trace_id = current_owner_chat_trace_id(
+            room_id=room_id,
+            agent_id=envelope.from_,
+        )
+        if owner_chat_trace_id:
+            envelope_data["trace_id"] = owner_chat_trace_id
+    envelope_json = json.dumps(envelope_data)
 
     first_hub_msg_id: str | None = None
     receiver_hub_msg_ids: dict[str, str] = {}

--- a/backend/hub/routers/owner_chat_ws.py
+++ b/backend/hub/routers/owner_chat_ws.py
@@ -181,6 +181,16 @@ async def register_owner_chat_run(
     )
 
 
+def current_owner_chat_trace_id(*, room_id: str, agent_id: str) -> str | None:
+    """Return the latest active owner-chat trace for a room/agent pair."""
+    matched_traces: list[str] = []
+    for tid, sub in list(_oc_trace_subs.items()):
+        user_id, sub_agent_id = sub
+        if sub_agent_id == agent_id and _build_owner_chat_room_id(user_id, sub_agent_id) == room_id:
+            matched_traces.append(tid)
+    return matched_traces[-1] if matched_traces else None
+
+
 # Retry backoff schedule (seconds) for notify_inbox when no WS connections are active.
 _NOTIFY_RETRY_DELAYS: Sequence[float] = (1, 2, 4, 8)
 

--- a/backend/tests/test_dashboard_chat.py
+++ b/backend/tests/test_dashboard_chat.py
@@ -3,6 +3,7 @@
 import base64
 import datetime
 import hashlib
+import json
 import time
 import uuid
 
@@ -454,8 +455,13 @@ async def test_agent_reply_to_owner_chat_creates_record(
     }
 
     # Agent sends a reply back to this room via /hub/send
+    from hub.routers import owner_chat_ws
+
     notify_mock = AsyncMock()
     monkeypatch.setattr("hub.routers.owner_chat_ws.notify_oc_ws_message", notify_mock)
+    trace_id = "h_trace_reply"
+    owner_chat_ws._oc_trace_subs[trace_id] = (user_id, agent_id)
+    owner_chat_ws._oc_trace_block_count[trace_id] = 0
     attachment = {
         "filename": "xhs-01-cover.png",
         "url": "https://api.botcord.chat/hub/files/f_cover",
@@ -487,6 +493,7 @@ async def test_agent_reply_to_owner_chat_creates_record(
     assert record.room_id == room_id
     assert record.sender_id == agent_id
     assert record.receiver_id == owner_human_id
+    assert json.loads(record.envelope_json)["trace_id"] == trace_id
     notify_mock.assert_awaited_once()
     assert notify_mock.await_args.kwargs["attachments"] == [attachment]
     # Crucially: state is 'delivered' (not 'queued') so it never appears in
@@ -499,6 +506,16 @@ async def test_agent_reply_to_owner_chat_creates_record(
     inbox_msgs = inbox_resp.json()["messages"]
     self_reply_ids = [m["hub_msg_id"] for m in inbox_msgs if m["hub_msg_id"] == send_data["hub_msg_id"]]
     assert len(self_reply_ids) == 0, "Self-delivery record must not appear in inbox"
+
+    messages_resp = await client.get(
+        f"/dashboard/rooms/{room_id}/messages",
+        headers=headers,
+    )
+    assert messages_resp.status_code == 200
+    messages = messages_resp.json()["messages"]
+    reply_msg = next(m for m in messages if m["hub_msg_id"] == send_data["hub_msg_id"])
+    assert reply_msg["payload"]["trace_id"] == trace_id
+    owner_chat_ws._cleanup_trace(trace_id)
 
 
 @pytest.mark.asyncio

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -320,6 +320,11 @@ export interface OwnerChatMessage {
 }
 
 /** Convert a DashboardMessage (from API) into an OwnerChatMessage. */
+function dashboardMessageTraceId(msg: DashboardMessage): string | undefined {
+  const traceId = msg.payload?.trace_id ?? msg.payload?.traceId;
+  return typeof traceId === "string" && traceId.length > 0 ? traceId : undefined;
+}
+
 export function dashboardMsgToOwnerChat(
   msg: DashboardMessage,
   agentName: string,
@@ -342,6 +347,7 @@ export function dashboardMsgToOwnerChat(
         : msg.type === "error"
           ? "error"
           : "message",
+    traceId: !isUser ? dashboardMessageTraceId(msg) : undefined,
     replyPreview: msg.reply_preview ?? undefined,
   };
 }

--- a/frontend/src/store/useOwnerChatStore.test.ts
+++ b/frontend/src/store/useOwnerChatStore.test.ts
@@ -281,6 +281,64 @@ describe("useOwnerChatStore stream terminal handling", () => {
       streamBlocks: [{ block: { kind: "other" } }],
     });
   });
+
+  it("merges a traced API final message into an existing stream placeholder", () => {
+    useOwnerChatStore.getState().appendStreamBlock({
+      trace_id: "msg_trace",
+      seq: 1,
+      created_at: "2026-05-19T09:00:00.000Z",
+      block: { kind: "thinking", payload: { phase: "updated", label: "Thinking" } },
+    });
+
+    useOwnerChatStore.getState().mergeApiMessages([
+      makeDashboardMessage({
+        hub_msg_id: "msg_final",
+        msg_id: "msg_final",
+        sender_id: "ag_bot",
+        source_type: "agent",
+        text: "final answer",
+        payload: { trace_id: "msg_trace", text: "final answer" },
+        created_at: "2026-05-19T09:00:02.000Z",
+      }),
+    ], "append");
+
+    const msgs = useOwnerChatStore.getState().messages;
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]).toMatchObject({
+      hubMsgId: "msg_final",
+      traceId: "msg_trace",
+      text: "final answer",
+      status: "delivered",
+      streamBlocks: [{ block: { kind: "thinking" } }],
+    });
+  });
+
+  it("merges late stream blocks into an already delivered traced message", () => {
+    useOwnerChatStore.getState().upsertMessage(makeOwnerChatMessage({
+      clientId: "msg_final",
+      hubMsgId: "msg_final",
+      sender: "agent",
+      text: "final answer",
+      status: "delivered",
+      senderName: "Owned bot",
+      traceId: "msg_trace",
+    }));
+
+    useOwnerChatStore.getState().appendStreamBlock({
+      trace_id: "msg_trace",
+      seq: 1,
+      created_at: "2026-05-19T09:00:01.000Z",
+      block: { kind: "thinking", payload: { phase: "updated", label: "Thinking" } },
+    });
+
+    const msgs = useOwnerChatStore.getState().messages;
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]).toMatchObject({
+      hubMsgId: "msg_final",
+      text: "final answer",
+      streamBlocks: [{ block: { kind: "thinking" } }],
+    });
+  });
 });
 
 describe("useOwnerChatStore stream-cache restore", () => {
@@ -415,6 +473,38 @@ describe("useOwnerChatStore stream-cache restore", () => {
     await useOwnerChatStore.getState().restoreActiveRuns("ag_bot");
 
     expect(mocks.getRunStreamBlocks).not.toHaveBeenCalled();
+  });
+
+  it("restoreActiveRuns skips API agent replies whose payload carries the trace id", async () => {
+    mocks.getRoomMessages.mockResolvedValue({
+      messages: [
+        makeDashboardMessage({
+          hub_msg_id: "msg_final",
+          msg_id: "msg_final",
+          sender_id: "ag_bot",
+          source_type: "agent",
+          text: "done",
+          payload: { trace_id: "msg_trace", text: "done" },
+          created_at: "2026-05-19T09:00:02.000Z",
+        }),
+        makeDashboardMessage({
+          hub_msg_id: "msg_trace",
+          msg_id: "msg_trace",
+          sender_id: "ag_bot",
+          source_type: "dashboard_user_chat",
+          text: "do a thing",
+          payload: { text: "do a thing" },
+          created_at: "2026-05-19T09:00:00.000Z",
+        }),
+      ],
+      has_more: false,
+    });
+
+    await useOwnerChatStore.getState().loadInitial("rm_oc_real");
+    await useOwnerChatStore.getState().restoreActiveRuns("ag_bot");
+
+    expect(mocks.getRunStreamBlocks).not.toHaveBeenCalled();
+    expect(useOwnerChatStore.getState().messages.map((m) => m.traceId)).toContain("msg_trace");
   });
 
   it("restoreActiveRuns degrades gracefully when the fetch fails", async () => {

--- a/frontend/src/store/useOwnerChatStore.ts
+++ b/frontend/src/store/useOwnerChatStore.ts
@@ -117,6 +117,40 @@ function visibleExecutionBlocks(blocks: StreamBlockEntry[]): StreamBlockEntry[] 
   );
 }
 
+function mergeStreamedAndFinalText(streamedText: string, finalText: string): string {
+  if (streamedText.length > finalText.length) {
+    return finalText && !streamedText.includes(finalText)
+      ? `${streamedText}\n\n${finalText}`
+      : streamedText;
+  }
+  return finalText;
+}
+
+function mergeFinalAgentMessage(
+  existing: OwnerChatMessage,
+  finalMsg: OwnerChatMessage,
+): OwnerChatMessage | null {
+  const streamedText = extractAssistantText(existing.streamBlocks) || existing.text;
+  const mergedText = mergeStreamedAndFinalText(streamedText, finalMsg.text || "");
+  const visibleStreamBlocks = visibleExecutionBlocks(existing.streamBlocks);
+  const attachments = finalMsg.attachments ?? existing.attachments;
+
+  if (!mergedText.trim() && (attachments?.length ?? 0) === 0 && visibleStreamBlocks.length === 0) {
+    return null;
+  }
+
+  return {
+    ...existing,
+    ...finalMsg,
+    text: mergedText,
+    attachments,
+    status: "delivered",
+    streamBlocks: visibleStreamBlocks,
+    traceId: finalMsg.traceId ?? existing.traceId,
+    replyPreview: finalMsg.replyPreview ?? existing.replyPreview ?? undefined,
+  };
+}
+
 /** In-flight guard + request token to prevent stale loadInitial responses. */
 let loadInFlight = false;
 let loadRequestId = 0;
@@ -231,24 +265,39 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
       set((state) => {
         // Build lookup for existing messages by hubMsgId
         const existingByHubId = new Map<string, OwnerChatMessage>();
+        const existingByTraceId = new Map<string, OwnerChatMessage>();
         for (const m of state.messages) {
           if (m.hubMsgId) existingByHubId.set(m.hubMsgId, m);
+          if (m.sender === "agent" && m.traceId) existingByTraceId.set(m.traceId, m);
         }
 
         const merged: OwnerChatMessage[] = [];
         const seenHubIds = new Set<string>();
+        const seenTraceIds = new Set<string>();
 
         // Start with API messages (authoritative ordering)
         for (const apiMsg of apiMsgs) {
           if (apiMsg.hubMsgId) seenHubIds.add(apiMsg.hubMsgId);
-          // Prefer local version if it has richer state (e.g., streamBlocks)
+          if (apiMsg.traceId) seenTraceIds.add(apiMsg.traceId);
+
+          // Prefer local version if it has richer state (e.g., streamBlocks),
+          // including the common reconnect case where the API final message
+          // has a hub id but the local stream placeholder only has traceId.
           const local = apiMsg.hubMsgId ? existingByHubId.get(apiMsg.hubMsgId) : undefined;
-          merged.push(local && local.streamBlocks.length > 0 ? local : apiMsg);
+          const traceLocal = apiMsg.traceId ? existingByTraceId.get(apiMsg.traceId) : undefined;
+          if (traceLocal && traceLocal.streamBlocks.length > 0) {
+            merged.push(mergeFinalAgentMessage(traceLocal, apiMsg) ?? apiMsg);
+          } else if (local && local.streamBlocks.length > 0) {
+            merged.push(mergeFinalAgentMessage(local, apiMsg) ?? apiMsg);
+          } else {
+            merged.push(apiMsg);
+          }
         }
 
         // Append any existing messages not in the API response
         for (const existing of state.messages) {
           if (existing.hubMsgId && seenHubIds.has(existing.hubMsgId)) continue;
+          if (existing.traceId && seenTraceIds.has(existing.traceId)) continue;
           // Keep optimistic/failed messages (they have no hubMsgId or a different one)
           if (existing.status === "optimistic" || existing.status === "failed") {
             merged.push(existing);
@@ -358,6 +407,22 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
         return state;
       }
 
+      if (msg.sender === "agent" && msg.traceId) {
+        const traceIdx = state.messages.findIndex(
+          (m) => m.sender === "agent" && m.traceId === msg.traceId,
+        );
+        if (traceIdx !== -1) {
+          const merged = mergeFinalAgentMessage(state.messages[traceIdx], msg);
+          const nextMessages = [...state.messages];
+          if (merged) {
+            nextMessages[traceIdx] = merged;
+          } else {
+            nextMessages.splice(traceIdx, 1);
+          }
+          return { messages: nextMessages };
+        }
+      }
+
       // Match optimistic user message by clientId (sent as client_msg_id via WS)
       if (msg.sender === "user" && msg.hubMsgId) {
         const confirmUpdate = (m: OwnerChatMessage): OwnerChatMessage => ({
@@ -419,6 +484,9 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
       const existingIds = new Set(
         state.messages.filter((m) => m.hubMsgId).map((m) => m.hubMsgId!)
       );
+      const existingTraceIds = new Set(
+        state.messages.filter((m) => m.sender === "agent" && m.traceId).map((m) => m.traceId!)
+      );
 
       // Reconcile: if a server message matches a failed optimistic message, confirm it
       const failedUserMsgs = state.messages.filter(
@@ -453,11 +521,36 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
         });
       }
 
-      const deduped = converted.filter(
-        (m) => m.hubMsgId && !existingIds.has(m.hubMsgId) && !reconciledServerIds.has(m.hubMsgId)
-      );
-      if (deduped.length === 0 && reconciled === state.messages) return state;
-      return { messages: deduped.length > 0 ? [...reconciled, ...deduped] : reconciled };
+      let nextMessages = reconciled;
+      let changed = reconciled !== state.messages;
+
+      for (const msg of converted) {
+        if (!msg.hubMsgId || existingIds.has(msg.hubMsgId) || reconciledServerIds.has(msg.hubMsgId)) {
+          continue;
+        }
+
+        if (msg.sender === "agent" && msg.traceId && existingTraceIds.has(msg.traceId)) {
+          const traceIdx = nextMessages.findIndex((m) => m.sender === "agent" && m.traceId === msg.traceId);
+          if (traceIdx !== -1) {
+            const merged = mergeFinalAgentMessage(nextMessages[traceIdx], msg);
+            const copy = [...nextMessages];
+            if (merged) copy[traceIdx] = merged;
+            else copy.splice(traceIdx, 1);
+            nextMessages = copy;
+            changed = true;
+            existingIds.add(msg.hubMsgId);
+            continue;
+          }
+        }
+
+        nextMessages = [...nextMessages, msg];
+        existingIds.add(msg.hubMsgId);
+        if (msg.traceId) existingTraceIds.add(msg.traceId);
+        changed = true;
+      }
+
+      if (!changed) return state;
+      return { messages: nextMessages };
     });
     syncOwnerChatRoomSummary(get().roomId, get().messages);
   },
@@ -470,7 +563,7 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
 
       // Find existing streaming message for this trace
       const idx = state.messages.findIndex(
-        (m) => m.traceId === traceId && (m.status === "streaming" || (m.sender === "agent" && !m.hubMsgId))
+        (m) => m.traceId === traceId && (m.status === "streaming" || m.sender === "agent")
       );
 
       if (idx === -1) {
@@ -507,7 +600,9 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
       const updatedMsg: OwnerChatMessage = {
         ...existing,
         streamBlocks: finalized ? visibleExecutionBlocks(updatedBlocks) : updatedBlocks,
-        text: updatedText || existing.text,
+        text: finalized
+          ? mergeStreamedAndFinalText(updatedText, existing.text)
+          : updatedText || existing.text,
         status: existing.status,
       };
 
@@ -631,41 +726,26 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
 
       // Upgrade streaming placeholder to delivered
       const existing = state.messages[idx];
-      // Preserve the streamed assistant text if it is richer than the final
-      // `message` text (e.g. Codex streams long intermediate reasoning/answer
-      // segments but only sends a short summary via botcord_send).
-      const streamedText = extractAssistantText(existing.streamBlocks) || existing.text;
-      const finalText = finalData.text || "";
-      let mergedText: string;
-      if (streamedText.length > finalText.length) {
-        mergedText =
-          finalText && !streamedText.includes(finalText)
-            ? `${streamedText}\n\n${finalText}`
-            : streamedText;
-      } else {
-        mergedText = finalText;
-      }
-      const visibleStreamBlocks = visibleExecutionBlocks(existing.streamBlocks);
-      if (!mergedText.trim() && (finalData.attachments?.length ?? 0) === 0 && visibleStreamBlocks.length === 0) {
+      const finalMsg: OwnerChatMessage = {
+        ...existing,
+        hubMsgId: finalData.hubMsgId,
+        text: finalData.text,
+        senderName: finalData.senderName,
+        createdAt: finalData.createdAt,
+        attachments: finalData.attachments,
+        status: "delivered",
+        streamBlocks: [],
+        traceId,
+        replyPreview: finalData.replyPreview ?? undefined,
+      };
+      const finalizedMsg = mergeFinalAgentMessage(existing, finalMsg);
+      if (!finalizedMsg) {
         const newMessages = state.messages.filter((_, i) => i !== idx);
         return {
           messages: newMessages,
           activeTraceId: null,
         };
       }
-
-      const finalizedMsg: OwnerChatMessage = {
-        ...existing,
-        hubMsgId: finalData.hubMsgId,
-        text: mergedText,
-        senderName: finalData.senderName,
-        createdAt: finalData.createdAt,
-        attachments: finalData.attachments,
-        status: "delivered",
-        // Keep only execution blocks (assistant text now lives in `text`)
-        streamBlocks: visibleStreamBlocks,
-        replyPreview: finalData.replyPreview ?? existing.replyPreview ?? undefined,
-      };
 
       const newMessages = [...state.messages];
       newMessages[idx] = finalizedMsg;
@@ -740,6 +820,9 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
         const existingHubIds = new Set(
           state.messages.filter((m) => m.hubMsgId).map((m) => m.hubMsgId!)
         );
+        const existingTraceIds = new Set(
+          state.messages.filter((m) => m.sender === "agent" && m.traceId).map((m) => m.traceId!)
+        );
 
         const updatedMessages = state.messages.map((m) => {
           // Only reconcile disconnect-failed user messages
@@ -767,17 +850,39 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
           return m;
         });
 
-        // Append any new server messages not already in our list
-        const newServerMsgs = serverMsgs.filter(
-          (sm) => sm.hubMsgId && !existingHubIds.has(sm.hubMsgId)
-            // Skip messages we just reconciled above
-            && !updatedMessages.some((m) => m.hubMsgId === sm.hubMsgId)
-        );
+        let nextMessages = updatedMessages;
+
+        // Append any new server messages not already in our list, merging agent
+        // finals into same-trace stream placeholders when reconnect races.
+        for (const sm of serverMsgs) {
+          if (
+            !sm.hubMsgId ||
+            existingHubIds.has(sm.hubMsgId) ||
+            updatedMessages.some((m) => m.hubMsgId === sm.hubMsgId)
+          ) {
+            continue;
+          }
+
+          if (sm.sender === "agent" && sm.traceId && existingTraceIds.has(sm.traceId)) {
+            const traceIdx = nextMessages.findIndex((m) => m.sender === "agent" && m.traceId === sm.traceId);
+            if (traceIdx !== -1) {
+              const merged = mergeFinalAgentMessage(nextMessages[traceIdx], sm);
+              const copy = [...nextMessages];
+              if (merged) copy[traceIdx] = merged;
+              else copy.splice(traceIdx, 1);
+              nextMessages = copy;
+              existingHubIds.add(sm.hubMsgId);
+              continue;
+            }
+          }
+
+          nextMessages = [...nextMessages, sm];
+          existingHubIds.add(sm.hubMsgId);
+          if (sm.traceId) existingTraceIds.add(sm.traceId);
+        }
 
         return {
-          messages: newServerMsgs.length > 0
-            ? [...updatedMessages, ...newServerMsgs]
-            : updatedMessages,
+          messages: nextMessages,
         };
       });
     } catch (err) {


### PR DESCRIPTION
## Summary
- persist owner-chat trace ids on agent replies so refreshed history can link finals back to their stream runs
- merge final agent replies with same-trace stream placeholders across initial load, realtime API merges, reconnect reconciliation, and late stream-block delivery
- add frontend and backend regression coverage for traced owner-chat replies

## Verification
- cd backend && uv run pytest tests/test_dashboard_chat.py tests/test_owner_chat_cache.py
- cd frontend && npm test -- useOwnerChatStore.test.ts --run
- cd frontend && NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build

## Risk / rollout
- Low risk; only owner-chat trace association and frontend merge paths are changed. Existing messages without trace ids keep current behavior.