### PR TITLE
fix(daemon): kill deepseek-tui process group on shutdown to stop server leak

### DIFF
--- a/.changeset/deepseek-tui-process-leak.md
+++ b/.changeset/deepseek-tui-process-leak.md
@@ -1,0 +1,5 @@
+---
+"@botcord/daemon": patch
+---
+
+Fix deepseek-tui server process leak: spawn `deepseek serve` in its own process group and SIGTERM the whole group on shutdown (the resolved binary is a dispatcher that re-spawns the real deepseek-tui server, which previously survived); also kill all pooled servers on daemon exit so restarts no longer orphan them.

--- a/packages/daemon/src/gateway/runtimes/deepseek-tui.ts
+++ b/packages/daemon/src/gateway/runtimes/deepseek-tui.ts
@@ -47,6 +47,24 @@ interface DeepseekAdapterDeps {
 
 const PROCESS_POOL = new Map<string, DeepseekProcessHandle>();
 
+let exitCleanupHookInstalled = false;
+
+/**
+ * Kill any pooled deepseek servers when the daemon exits. The pool is
+ * in-memory, so without this a daemon restart orphans the spawned servers.
+ * Installed lazily on first spawn to keep module import side-effect free.
+ */
+function installExitCleanupHook(): void {
+  if (exitCleanupHookInstalled) return;
+  exitCleanupHookInstalled = true;
+  process.once("exit", () => {
+    for (const [key, handle] of PROCESS_POOL.entries()) {
+      shutdownHandle(handle, "daemon-exit");
+      PROCESS_POOL.delete(key);
+    }
+  });
+}
+
 /** Resolve the `deepseek` dispatcher CLI on PATH. */
 export function resolveDeepseekCommand(deps: ProbeDeps = {}): string | null {
   const explicit = (deps.env ?? process.env).BOTCORD_DEEPSEEK_TUI_BIN;
@@ -201,8 +219,13 @@ export class DeepseekTuiAdapter implements RuntimeAdapter {
         cwd: opts.cwd,
         env: this.spawnEnv(opts),
         stdio: ["ignore", "pipe", "pipe"],
+        // Own process group: the resolved binary may be a dispatcher that
+        // re-spawns the real deepseek-tui server, so shutdown must signal
+        // the whole group, not just the direct child.
+        detached: true,
       },
     );
+    installExitCleanupHook();
 
     const handle: DeepseekProcessHandle = {
       child,
@@ -658,9 +681,20 @@ function shutdownHandle(handle: DeepseekProcessHandle, reason: string): void {
   handle.closed = true;
   if (handle.idleTimer) clearTimeout(handle.idleTimer);
   try {
-    handle.child.kill("SIGTERM");
+    const pid = handle.child.pid;
+    if (typeof pid === "number" && pid > 0) {
+      // Negative pid signals the process group (see detached spawn above),
+      // killing the dispatcher and the deepseek-tui server it re-spawned.
+      process.kill(-pid, "SIGTERM");
+    } else {
+      handle.child.kill("SIGTERM");
+    }
   } catch {
-    // no-op
+    try {
+      handle.child.kill("SIGTERM");
+    } catch {
+      // no-op
+    }
   }
   try {
     handle.child.stdout?.destroy();


### PR DESCRIPTION
## 问题

在 e2b cloud sandbox(`botcord-cloud-agent-dev3`)上观察到 16 个孤儿 `deepseek-tui serve` 进程挂在 PID 1 下,约每 6 分钟泄漏一个,持续吃掉 sandbox 内存。

## 根因(已在 sandbox 实测确认)

1. `resolveDeepseekCommand` 解析到的可执行文件是 `.../downloads/deepseek` **dispatcher**,它启动后会再 spawn 真正的 `deepseek-tui` server 作为自己的子进程。`shutdownHandle` 的 `child.kill("SIGTERM")` 只杀到 dispatcher 一层,内层 server 存活并被过继给 PID 1 —— 每轮「使用 + 5 分钟 idle timeout」泄漏一个。实测对一对进程发 SIGTERM:dispatcher 死、内层活,与孤儿形态完全一致。
2. `PROCESS_POOL` 是纯内存的且无退出钩子,daemon 重启时 wrapper + 内层一起泄漏。

## 修复

- spawn 时加 `detached: true` 让 server 自成进程组,shutdown 改为 `process.kill(-pid, "SIGTERM")` 杀整个进程组(失败时回退 `child.kill`)
- 首次 spawn 时安装 `process.once("exit")` 钩子,daemon 退出时清空进程池

## 验证

- `pnpm --filter @botcord/daemon test`:77 files / 1057 tests 全部通过
- 本地模拟 dispatcher→inner 两层进程结构,确认 `kill(-pgid)` 一次杀干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)