### PR TITLE
fix: harden runtime control retries

### DIFF
--- a/backend/app/routers/runtime_files.py
+++ b/backend/app/routers/runtime_files.py
@@ -41,6 +41,10 @@ _CLOUD_RUNTIME_FILES_DISPATCH_RETRY_CODES = {
     "cloud_daemon_disconnected",
     "cloud_daemon_send_failed",
 }
+_CLOUD_RUNTIME_FILES_DAEMON_RETRY_CODES = {
+    "agent_credentials_missing",
+    "agent_not_loaded",
+}
 
 
 class AgentRuntimeFileOut(BaseModel):
@@ -158,6 +162,15 @@ async def _send_runtime_files_control_frame(
             }:
                 raise HTTPException(status_code=409, detail="daemon_offline") from exc
             if exc.code == "cloud_daemon_ack_timeout":
+                logger.warning(
+                    "runtime files daemon ack timeout: agent=%s daemon=%s cloud=%s "
+                    "frame=%s timeout_ms=%s",
+                    agent.agent_id,
+                    host.daemon_instance_id,
+                    host.cloud_daemon_instance_id,
+                    "list_agent_files",
+                    5000,
+                )
                 raise HTTPException(status_code=504, detail="daemon_ack_timeout") from exc
             raise HTTPException(
                 status_code=502,
@@ -166,12 +179,25 @@ async def _send_runtime_files_control_frame(
 
     if not is_daemon_online(host.daemon_instance_id):
         raise HTTPException(status_code=409, detail="daemon_offline")
-    return await send_control_frame(
-        host.daemon_instance_id,
-        "list_agent_files",
-        params,
-        timeout_ms=5000,
-    )
+    try:
+        return await send_control_frame(
+            host.daemon_instance_id,
+            "list_agent_files",
+            params,
+            timeout_ms=5000,
+        )
+    except HTTPException as exc:
+        if exc.status_code == 504 and exc.detail == "daemon_ack_timeout":
+            logger.warning(
+                "runtime files daemon ack timeout: agent=%s daemon=%s cloud=%s "
+                "frame=%s timeout_ms=%s",
+                agent.agent_id,
+                host.daemon_instance_id,
+                host.cloud_daemon_instance_id,
+                "list_agent_files",
+                5000,
+            )
+        raise
 
 
 async def _ensure_cloud_runtime_files_host_online(
@@ -241,17 +267,49 @@ async def get_agent_runtime_files(
     if not isinstance(ack, dict) or not ack.get("ok"):
         err = ack.get("error") if isinstance(ack, dict) else None
         code = (err or {}).get("code") if isinstance(err, dict) else None
+        if (
+            host.cloud_daemon_instance_id
+            and code in _CLOUD_RUNTIME_FILES_DAEMON_RETRY_CODES
+        ):
+            logger.warning(
+                "cloud runtime files daemon returned %s; forcing resume and retry: "
+                "agent=%s daemon=%s cloud=%s",
+                code,
+                agent.agent_id,
+                host.daemon_instance_id,
+                host.cloud_daemon_instance_id,
+            )
+            await _ensure_cloud_runtime_files_host_online(
+                db,
+                ctx,
+                agent,
+                host,
+                force_resume=True,
+            )
+            ack = await _send_runtime_files_control_frame(
+                host,
+                params,
+                db=db,
+                ctx=ctx,
+                agent=agent,
+            )
+            err = ack.get("error") if isinstance(ack, dict) else None
+            code = (err or {}).get("code") if isinstance(err, dict) else None
         message = (err or {}).get("message") if isinstance(err, dict) else None
-        raise HTTPException(
-            status_code=502,
-            detail={
-                "code": "daemon_runtime_files_failed",
-                "daemon_code": code,
-                "daemon_message": message,
-            },
-        )
+        if isinstance(ack, dict) and ack.get("ok"):
+            result = ack.get("result")
+        else:
+            raise HTTPException(
+                status_code=502,
+                detail={
+                    "code": "daemon_runtime_files_failed",
+                    "daemon_code": code,
+                    "daemon_message": message,
+                },
+            )
+    else:
+        result = ack.get("result")
 
-    result = ack.get("result")
     if not isinstance(result, dict) or not isinstance(result.get("files"), list):
         raise HTTPException(
             status_code=502,

--- a/backend/app/routers/runtime_skills.py
+++ b/backend/app/routers/runtime_skills.py
@@ -40,6 +40,12 @@ router = APIRouter(prefix="/api/agents", tags=["app-runtime-skills"])
 
 _CLOUD_SKILLS_RESUME_WAIT_SECONDS = 20.0
 _CLOUD_SKILLS_RESUME_POLL_SECONDS = 0.5
+_CLOUD_SKILLS_DISPATCH_RETRY_CODES = {
+    "cloud_daemon_offline",
+    "cloud_daemon_disconnected",
+    "cloud_daemon_send_failed",
+}
+_CLOUD_SKILLS_DISPATCH_RETRY_FRAME_TYPES = {"list_agent_skills"}
 _REFRESH_SKILLS_TIMEOUT_MS = 5000
 _INSTALL_SKILL_TIMEOUT_MS = 30000
 _INSTALL_SKILL_AGENT_LOAD_WAIT_SECONDS = 10.0
@@ -197,11 +203,13 @@ async def _ensure_cloud_runtime_skills_host_online(
     ctx: RequestContext,
     agent: Agent,
     host: _RuntimeSkillsHost,
+    *,
+    force_resume: bool = False,
 ) -> None:
     cloud_daemon_instance_id = host.cloud_daemon_instance_id
     if not cloud_daemon_instance_id:
         return
-    if is_cloud_daemon_online(cloud_daemon_instance_id):
+    if not force_resume and is_cloud_daemon_online(cloud_daemon_instance_id):
         return
 
     try:
@@ -252,13 +260,48 @@ async def _send_runtime_skills_control_frame(
                 timeout_ms=timeout_ms,
             )
         except CloudDaemonDispatchError as exc:
-            if exc.code in {
-                "cloud_daemon_offline",
-                "cloud_daemon_disconnected",
-                "cloud_daemon_send_failed",
-            }:
+            can_retry_dispatch = (
+                frame_type in _CLOUD_SKILLS_DISPATCH_RETRY_FRAME_TYPES
+                and exc.code in _CLOUD_SKILLS_DISPATCH_RETRY_CODES
+            )
+            if can_retry_dispatch:
+                logger.warning(
+                    "cloud runtime skills dispatch lost connection; attempting resume and retry: "
+                    "agent=%s cloud=%s frame=%s code=%s err=%s",
+                    agent.agent_id,
+                    host.cloud_daemon_instance_id,
+                    frame_type,
+                    exc.code,
+                    exc.message,
+                )
+                await _ensure_cloud_runtime_skills_host_online(
+                    db,
+                    ctx,
+                    agent,
+                    host,
+                    force_resume=True,
+                )
+                try:
+                    return await send_cloud_control_frame(
+                        host.cloud_daemon_instance_id,
+                        frame_type,
+                        params,
+                        timeout_ms=timeout_ms,
+                    )
+                except CloudDaemonDispatchError as retry_exc:
+                    exc = retry_exc
+            if exc.code in _CLOUD_SKILLS_DISPATCH_RETRY_CODES:
                 raise HTTPException(status_code=409, detail="daemon_offline") from exc
             if exc.code == "cloud_daemon_ack_timeout":
+                logger.warning(
+                    "runtime skills daemon ack timeout: agent=%s daemon=%s cloud=%s "
+                    "frame=%s timeout_ms=%s",
+                    agent.agent_id,
+                    host.daemon_instance_id,
+                    host.cloud_daemon_instance_id,
+                    frame_type,
+                    timeout_ms,
+                )
                 raise HTTPException(status_code=504, detail="daemon_ack_timeout") from exc
             raise HTTPException(
                 status_code=502,
@@ -267,12 +310,25 @@ async def _send_runtime_skills_control_frame(
 
     if not is_daemon_online(host.daemon_instance_id):
         raise HTTPException(status_code=409, detail="daemon_offline")
-    return await send_control_frame(
-        host.daemon_instance_id,
-        frame_type,
-        params,
-        timeout_ms=timeout_ms,
-    )
+    try:
+        return await send_control_frame(
+            host.daemon_instance_id,
+            frame_type,
+            params,
+            timeout_ms=timeout_ms,
+        )
+    except HTTPException as exc:
+        if exc.status_code == 504 and exc.detail == "daemon_ack_timeout":
+            logger.warning(
+                "runtime skills daemon ack timeout: agent=%s daemon=%s cloud=%s "
+                "frame=%s timeout_ms=%s",
+                agent.agent_id,
+                host.daemon_instance_id,
+                host.cloud_daemon_instance_id,
+                frame_type,
+                timeout_ms,
+            )
+        raise
 
 
 def _install_params(agent_id: str, body: AgentRuntimeSkillInstallIn) -> dict[str, Any]:
@@ -401,17 +457,46 @@ async def refresh_agent_runtime_skills(
     if not isinstance(ack, dict) or not ack.get("ok"):
         err = ack.get("error") if isinstance(ack, dict) else None
         code = (err or {}).get("code") if isinstance(err, dict) else None
+        if host.cloud_daemon_instance_id and code == "agent_not_loaded":
+            logger.warning(
+                "cloud runtime skills daemon returned agent_not_loaded; forcing resume and retry: "
+                "agent=%s daemon=%s cloud=%s",
+                agent.agent_id,
+                host.daemon_instance_id,
+                host.cloud_daemon_instance_id,
+            )
+            await _ensure_cloud_runtime_skills_host_online(
+                db,
+                ctx,
+                agent,
+                host,
+                force_resume=True,
+            )
+            ack = await _send_runtime_skills_control_frame(
+                host,
+                "list_agent_skills",
+                {"agentId": agent.agent_id},
+                db=db,
+                ctx=ctx,
+                agent=agent,
+            )
+            err = ack.get("error") if isinstance(ack, dict) else None
+            code = (err or {}).get("code") if isinstance(err, dict) else None
         message = (err or {}).get("message") if isinstance(err, dict) else None
-        raise HTTPException(
-            status_code=502,
-            detail={
-                "code": "daemon_runtime_skills_failed",
-                "daemon_code": code,
-                "daemon_message": message,
-            },
-        )
+        if isinstance(ack, dict) and ack.get("ok"):
+            result = ack.get("result") if isinstance(ack.get("result"), dict) else None
+        else:
+            raise HTTPException(
+                status_code=502,
+                detail={
+                    "code": "daemon_runtime_skills_failed",
+                    "daemon_code": code,
+                    "daemon_message": message,
+                },
+            )
+    else:
+        result = ack.get("result") if isinstance(ack.get("result"), dict) else None
 
-    result = ack.get("result") if isinstance(ack.get("result"), dict) else None
     persisted = None
     if result is not None:
         persisted = await _persist_agent_skill_snapshot(

--- a/backend/tests/test_app/test_app_policy.py
+++ b/backend/tests/test_app/test_app_policy.py
@@ -374,6 +374,201 @@ async def test_runtime_skills_refresh_dispatches_persists_and_returns(
 
 
 @pytest.mark.asyncio
+async def test_runtime_skills_refresh_retries_cloud_dispatch_loss_and_persists(
+    client, seed, db_session, monkeypatch
+):
+    from app.routers import runtime_skills as runtime_skills_mod
+
+    row = await db_session.execute(select(Agent).where(Agent.agent_id == "ag_owned"))
+    agent = row.scalar_one()
+    agent.hosting_kind = "cloud"
+    agent.daemon_instance_id = "dm_cloud_retry_skills"
+    agent.runtime = "codex"
+    daemon = DaemonInstance(
+        id="dm_cloud_retry_skills",
+        user_id=agent.user_id,
+        kind="cloud",
+        refresh_token_hash="hash",
+    )
+    cloud_daemon = CloudDaemonInstance(
+        id="cloud_dm_retry_skills",
+        user_id=agent.user_id,
+        daemon_instance_id=daemon.id,
+        provider="e2b",
+        status="ready",
+        runtime="codex",
+        max_agents=1,
+        active_agent_count=1,
+    )
+    cloud_binding = CloudAgentInstance(
+        id="cloud_ag_retry_skills",
+        user_id=agent.user_id,
+        agent_id=agent.agent_id,
+        cloud_daemon_instance_id=cloud_daemon.id,
+        daemon_instance_id=daemon.id,
+        runtime="codex",
+        model_profile="default",
+        status="ready",
+    )
+    db_session.add_all([daemon, cloud_daemon, cloud_binding])
+    await db_session.commit()
+
+    monkeypatch.setattr(runtime_skills_mod, "is_cloud_daemon_online", lambda _id: True)
+
+    resume_calls = []
+
+    class FakeCloudAgentService:
+        async def resume_cloud_agent(self, db, *, user_id, agent_id):
+            resume_calls.append({"user_id": user_id, "agent_id": agent_id})
+            return None
+
+    monkeypatch.setattr(runtime_skills_mod, "CloudAgentService", FakeCloudAgentService)
+
+    dispatch_calls = []
+    probed_at = int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000)
+
+    async def fake_send_cloud(cloud_daemon_instance_id, type_, params=None, timeout_ms=None):
+        dispatch_calls.append({
+            "cloud_daemon_instance_id": cloud_daemon_instance_id,
+            "type": type_,
+            "params": params,
+            "timeout_ms": timeout_ms,
+        })
+        if len(dispatch_calls) == 1:
+            raise runtime_skills_mod.CloudDaemonDispatchError(
+                "cloud_daemon_disconnected",
+                "connection closed",
+            )
+        return {
+            "ok": True,
+            "result": {
+                "agentId": "ag_owned",
+                "skills": [
+                    {
+                        "name": "cloud-skill",
+                        "source": "runtime-global",
+                        "description": "Cloud skill",
+                        "mtimeMs": probed_at,
+                    }
+                ],
+                "probedAt": probed_at,
+            },
+        }
+
+    monkeypatch.setattr(runtime_skills_mod, "send_cloud_control_frame", fake_send_cloud)
+
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    r = await client.post("/api/agents/ag_owned/skills/refresh", headers=headers)
+    assert r.status_code == 200, r.text
+    assert r.json()["skills"][0]["name"] == "cloud-skill"
+    assert resume_calls == [{"user_id": agent.user_id, "agent_id": "ag_owned"}]
+    assert len(dispatch_calls) == 2
+
+    refreshed = await db_session.scalar(select(Agent).where(Agent.agent_id == "ag_owned"))
+    assert refreshed is not None
+    assert refreshed.skills_json[0]["name"] == "cloud-skill"
+
+
+@pytest.mark.asyncio
+async def test_runtime_skills_install_does_not_retry_cloud_dispatch_loss(
+    client, seed, db_session, monkeypatch
+):
+    from app.routers import runtime_skills as runtime_skills_mod
+
+    row = await db_session.execute(select(Agent).where(Agent.agent_id == "ag_owned"))
+    agent = row.scalar_one()
+    agent.hosting_kind = "cloud"
+    agent.daemon_instance_id = "dm_cloud_install_skills"
+    agent.runtime = "codex"
+    daemon = DaemonInstance(
+        id="dm_cloud_install_skills",
+        user_id=agent.user_id,
+        kind="cloud",
+        refresh_token_hash="hash",
+    )
+    cloud_daemon = CloudDaemonInstance(
+        id="cloud_dm_install_skills",
+        user_id=agent.user_id,
+        daemon_instance_id=daemon.id,
+        provider="e2b",
+        status="ready",
+        runtime="codex",
+        max_agents=1,
+        active_agent_count=1,
+    )
+    cloud_binding = CloudAgentInstance(
+        id="cloud_ag_install_skills",
+        user_id=agent.user_id,
+        agent_id=agent.agent_id,
+        cloud_daemon_instance_id=cloud_daemon.id,
+        daemon_instance_id=daemon.id,
+        runtime="codex",
+        model_profile="default",
+        status="ready",
+    )
+    db_session.add_all([daemon, cloud_daemon, cloud_binding])
+    await db_session.commit()
+
+    monkeypatch.setattr(runtime_skills_mod, "is_cloud_daemon_online", lambda _id: True)
+
+    resume_calls = []
+
+    class FakeCloudAgentService:
+        async def resume_cloud_agent(self, db, *, user_id, agent_id):
+            resume_calls.append({"user_id": user_id, "agent_id": agent_id})
+            return None
+
+    monkeypatch.setattr(runtime_skills_mod, "CloudAgentService", FakeCloudAgentService)
+
+    dispatch_calls = []
+
+    async def fake_send_cloud(cloud_daemon_instance_id, type_, params=None, timeout_ms=None):
+        dispatch_calls.append({
+            "cloud_daemon_instance_id": cloud_daemon_instance_id,
+            "type": type_,
+            "params": params,
+            "timeout_ms": timeout_ms,
+        })
+        raise runtime_skills_mod.CloudDaemonDispatchError(
+            "cloud_daemon_disconnected",
+            "connection closed after send",
+        )
+
+    monkeypatch.setattr(runtime_skills_mod, "send_cloud_control_frame", fake_send_cloud)
+
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    r = await client.post(
+        "/api/agents/ag_owned/skills/install",
+        headers=headers,
+        json={
+            "manifest": {
+                "name": "cloud-install-skill",
+                "skillMd": "# Cloud install skill\n",
+                "targetRuntimes": ["codex"],
+            }
+        },
+    )
+    assert r.status_code == 409, r.text
+    assert r.json()["detail"] == "daemon_offline"
+    assert resume_calls == []
+    assert dispatch_calls == [
+        {
+            "cloud_daemon_instance_id": "cloud_dm_install_skills",
+            "type": "install_agent_skill",
+            "params": {
+                "agentId": "ag_owned",
+                "manifest": {
+                    "name": "cloud-install-skill",
+                    "skillMd": "# Cloud install skill\n",
+                    "targetRuntimes": ["codex"],
+                },
+            },
+            "timeout_ms": 30000,
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_runtime_files_for_owned_cloud_agent_dispatches_cloud_control_frame(
     client, seed, db_session, monkeypatch
 ):
@@ -562,6 +757,100 @@ async def test_runtime_files_for_cloud_agent_resumes_sandbox_before_dispatch(
             "timeout_ms": 5000,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_runtime_files_for_cloud_agent_retries_after_missing_credentials_ack(
+    client, seed, db_session, monkeypatch
+):
+    from app.routers import runtime_files as runtime_files_mod
+
+    row = await db_session.execute(select(Agent).where(Agent.agent_id == "ag_owned"))
+    agent = row.scalar_one()
+    agent.hosting_kind = "cloud"
+    agent.daemon_instance_id = "dm_cloud_retry_files"
+    agent.runtime = "codex"
+    daemon = DaemonInstance(
+        id="dm_cloud_retry_files",
+        user_id=agent.user_id,
+        kind="cloud",
+        refresh_token_hash="hash",
+    )
+    cloud_daemon = CloudDaemonInstance(
+        id="cloud_dm_retry_files",
+        user_id=agent.user_id,
+        daemon_instance_id=daemon.id,
+        provider="e2b",
+        status="ready",
+        runtime="codex",
+        max_agents=1,
+        active_agent_count=1,
+    )
+    cloud_binding = CloudAgentInstance(
+        id="cloud_ag_retry_files",
+        user_id=agent.user_id,
+        agent_id=agent.agent_id,
+        cloud_daemon_instance_id=cloud_daemon.id,
+        daemon_instance_id=daemon.id,
+        runtime="codex",
+        model_profile="default",
+        status="ready",
+    )
+    db_session.add_all([daemon, cloud_daemon, cloud_binding])
+    await db_session.commit()
+
+    monkeypatch.setattr(runtime_files_mod, "is_cloud_daemon_online", lambda _id: True)
+
+    resume_calls = []
+
+    class FakeCloudAgentService:
+        async def resume_cloud_agent(self, db, *, user_id, agent_id):
+            resume_calls.append({"user_id": user_id, "agent_id": agent_id})
+            return None
+
+    monkeypatch.setattr(runtime_files_mod, "CloudAgentService", FakeCloudAgentService)
+
+    dispatch_calls = []
+
+    async def fake_send_cloud(cloud_daemon_instance_id, type_, params=None, timeout_ms=None):
+        dispatch_calls.append({
+            "cloud_daemon_instance_id": cloud_daemon_instance_id,
+            "type": type_,
+            "params": params,
+            "timeout_ms": timeout_ms,
+        })
+        if len(dispatch_calls) == 1:
+            return {
+                "ok": False,
+                "error": {
+                    "code": "agent_credentials_missing",
+                    "message": "agent credentials are missing or unreadable",
+                },
+            }
+        return {
+            "ok": True,
+            "result": {
+                "agentId": "ag_owned",
+                "runtime": "codex",
+                "files": [
+                    {
+                        "id": "workspace:AGENTS.md",
+                        "name": "workspace/AGENTS.md",
+                        "scope": "workspace",
+                        "content": "# rules\n",
+                    }
+                ],
+            },
+        }
+
+    monkeypatch.setattr(runtime_files_mod, "send_cloud_control_frame", fake_send_cloud)
+
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    r = await client.get("/api/agents/ag_owned/runtime-files", headers=headers)
+    assert r.status_code == 200, r.text
+    assert r.json()["files"][0]["content"] == "# rules\n"
+    assert resume_calls == [{"user_id": agent.user_id, "agent_id": "ag_owned"}]
+    assert len(dispatch_calls) == 2
 
 
 @pytest.mark.asyncio

--- a/packages/daemon/src/__tests__/provision.test.ts
+++ b/packages/daemon/src/__tests__/provision.test.ts
@@ -170,6 +170,36 @@ function makeFakeGateway(initialChannelIds: string[] = []): FakeGateway {
 }
 
 describe("list_agent_files handler", () => {
+  it("returns sanitized agent_credentials_missing when credentials are missing", async () => {
+    const os = await import("node:os");
+    const fs = await import("node:fs");
+    const nodePath = await import("node:path");
+
+    const tmp = fs.mkdtempSync(nodePath.join(os.tmpdir(), "daemon-runtime-files-missing-"));
+    const prevHome = process.env.HOME;
+    process.env.HOME = tmp;
+    try {
+      const handler = createProvisioner({ gateway: makeFakeGateway() as any });
+      const res = await handler({
+        id: "req_missing_credentials",
+        type: "list_agent_files",
+        params: { agentId: "ag_missing_creds" },
+      });
+
+      expect(res.ok).toBe(false);
+      expect(res.error?.code).toBe("agent_credentials_missing");
+      expect(res.error?.message).toBe("agent credentials are missing or unreadable");
+      expect(res.error?.message).not.toContain(tmp);
+      expect(res.error?.message).not.toContain(".botcord");
+      expect(res.error?.message).not.toContain("/credentials/");
+      expect(res.error?.message).not.toContain("~");
+    } finally {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("returns allowlisted workspace and attached hermes profile files for the requested agent", async () => {
     const os = await import("node:os");
     const fs = await import("node:fs");

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -519,7 +519,21 @@ export function createProvisioner(opts: ProvisionerOptions): (
             error: { code: "bad_params", message: "list_agent_files requires params.agentId" },
           };
         }
-        const result = listAgentRuntimeFiles(params);
+        let result: ListAgentFilesResult;
+        try {
+          result = listAgentRuntimeFiles(params);
+        } catch (err) {
+          if (!(err instanceof AgentCredentialsMissingError)) {
+            throw err;
+          }
+          return {
+            ok: false,
+            error: {
+              code: "agent_credentials_missing",
+              message: "agent credentials are missing or unreadable",
+            },
+          };
+        }
         daemonLog.debug("list_agent_files", {
           agentId: params.agentId,
           fileId: params.fileId ?? null,
@@ -858,6 +872,13 @@ const openclawProvisionLocks = new Map<string, Promise<unknown>>();
 
 const RUNTIME_FILE_READ_CAP_BYTES = 128 * 1024;
 
+class AgentCredentialsMissingError extends Error {
+  constructor() {
+    super("agent credentials are missing or unreadable");
+    this.name = "AgentCredentialsMissingError";
+  }
+}
+
 interface ListAgentFilesParams {
   agentId: string;
   fileId?: string;
@@ -895,7 +916,12 @@ interface RuntimeFileCandidate {
 
 function listAgentRuntimeFiles(params: ListAgentFilesParams): ListAgentFilesResult {
   const agentId = params.agentId;
-  const credentials = loadStoredCredentials(defaultCredentialsFile(agentId));
+  let credentials: StoredBotCordCredentials;
+  try {
+    credentials = loadStoredCredentials(defaultCredentialsFile(agentId));
+  } catch {
+    throw new AgentCredentialsMissingError();
+  }
   const candidates = runtimeFileCandidates(credentials);
   const selected = params.fileId
     ? candidates.filter((candidate) => candidate.id === params.fileId)


### PR DESCRIPTION
## Summary
- harden runtime_files retry behavior after missing credentials / agent-not-loaded daemon responses
- restrict runtime_skills cloud dispatch-loss retry to list_agent_skills read/idempotent path
- sanitize daemon list_agent_files missing-credentials responses and cover retry/no-retry behavior in tests

## Validation
- git diff --check
- uv run pytest tests/test_app/test_app_policy.py -q -k "runtime_files or runtime_skills"
- corepack pnpm --filter @botcord/daemon test -- src/__tests__/provision.test.ts

## Release note
Prod runtime remains untouched by this PR. After merge/release/deploy, hand to Botcord-Ops for prod runtime validation before incident closure.