### PR TITLE
fix: classify BotLearn JWKS key misses

### DIFF
--- a/backend/app/botlearn_auth.py
+++ b/backend/app/botlearn_auth.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass
 
 import jwt as pyjwt
 from jwt import PyJWKClient
+from jwt.exceptions import PyJWKClientError
 
 from hub.config import (
     BOTLEARN_ALLOWED_ORIGINS,
@@ -113,6 +114,10 @@ def _get_jwks_client(jwks_url: str) -> PyJWKClient:
     return _jwks_clients[jwks_url]
 
 
+def _is_unknown_jwks_kid_error(exc: PyJWKClientError) -> bool:
+    return str(exc).startswith("Unable to find a signing key that matches:")
+
+
 def is_botlearn_origin_allowed(origin: str | None) -> bool:
     """Origin allowlist gate for the session + WS endpoints.
 
@@ -187,6 +192,16 @@ def verify_botlearn_id_token(token: str) -> BotlearnIdentity:
         )
     except BotlearnAuthError:
         raise
+    except PyJWKClientError as exc:
+        if _is_unknown_jwks_kid_error(exc):
+            logger.debug("BotLearn JWKS key lookup failed: %s", exc)
+            raise BotlearnAuthError("invalid_token", "Invalid BotLearn token")
+        logger.warning("BotLearn JWKS verification unavailable: %s", exc)
+        raise BotlearnAuthError(
+            "botlearn_jwks_unavailable",
+            "BotLearn JWKS verification is unavailable",
+            http_status=503,
+        )
     except pyjwt.InvalidTokenError as exc:
         logger.debug("BotLearn token verification failed: %s", exc)
         raise BotlearnAuthError("invalid_token", "Invalid BotLearn token")

--- a/backend/tests/test_app/test_botlearn_session.py
+++ b/backend/tests/test_app/test_botlearn_session.py
@@ -8,13 +8,16 @@ quota failure → no token).
 
 from __future__ import annotations
 
+import base64
 import datetime
+import json
 import uuid
 
 import jwt
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
+from jwt.exceptions import PyJWKClientError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -61,6 +64,14 @@ def _botlearn_token(
     if audience is not None:
         payload["aud"] = audience
     return jwt.encode(payload, secret, algorithm="HS256")
+
+
+def _unsigned_token(header: dict, payload: dict | None = None) -> str:
+    def enc(value: dict) -> str:
+        raw = json.dumps(value, separators=(",", ":")).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+    return f"{enc(header)}.{enc(payload or {})}.sig"
 
 
 def _configure_botlearn(
@@ -456,6 +467,79 @@ async def test_session_rejected_for_expired_token(client_factory, monkeypatch):
     )
     assert r.status_code == 401
     assert r.json()["detail"]["code"] == "token_expired"
+
+
+@pytest.mark.asyncio
+async def test_session_rejected_when_jwks_kid_is_unknown(client_factory, monkeypatch):
+    class MissingKidJwksClient:
+        def get_signing_key_from_jwt(self, token: str):
+            raise PyJWKClientError(
+                "Unable to find a signing key that matches: "
+                "a5d8f98e-fbd2-40f4-9317-ba02ebaf3e3b"
+            )
+
+    _configure_botlearn(monkeypatch)
+
+    import app.botlearn_auth as ba
+
+    monkeypatch.setattr(ba, "BOTLEARN_JWKS_URL", "https://botlearn.example/jwks.json")
+    monkeypatch.setattr(ba, "_get_jwks_client", lambda jwks_url: MissingKidJwksClient())
+    token = _unsigned_token(
+        {"alg": "RS256", "kid": "a5d8f98e-fbd2-40f4-9317-ba02ebaf3e3b"},
+        {
+            "sub": "u",
+            "email_verified": True,
+            "iss": BOTLEARN_ISSUER,
+            "exp": int((_now() + datetime.timedelta(hours=1)).timestamp()),
+            "iat": int(_now().timestamp()),
+        },
+    )
+
+    client, _ = await client_factory()
+    r = await client.post(
+        "/api/integrations/botlearn/session",
+        headers=_headers(token),
+    )
+
+    assert r.status_code == 401
+    assert r.json()["detail"]["code"] == "invalid_token"
+
+
+@pytest.mark.asyncio
+async def test_session_jwks_provider_failure_is_service_error(
+    client_factory, monkeypatch
+):
+    class FailingJwksClient:
+        def get_signing_key_from_jwt(self, token: str):
+            raise PyJWKClientError(
+                'Fail to fetch data from the url, err: "timed out"'
+            )
+
+    _configure_botlearn(monkeypatch)
+
+    import app.botlearn_auth as ba
+
+    monkeypatch.setattr(ba, "BOTLEARN_JWKS_URL", "https://botlearn.example/jwks.json")
+    monkeypatch.setattr(ba, "_get_jwks_client", lambda jwks_url: FailingJwksClient())
+    token = _unsigned_token(
+        {"alg": "RS256", "kid": "botlearn-key-1"},
+        {
+            "sub": "u",
+            "email_verified": True,
+            "iss": BOTLEARN_ISSUER,
+            "exp": int((_now() + datetime.timedelta(hours=1)).timestamp()),
+            "iat": int(_now().timestamp()),
+        },
+    )
+
+    client, _ = await client_factory()
+    r = await client.post(
+        "/api/integrations/botlearn/session",
+        headers=_headers(token),
+    )
+
+    assert r.status_code == 503
+    assert r.json()["detail"]["code"] == "botlearn_jwks_unavailable"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- map only PyJWT no-matching-signing-key JWKS lookup failures to `invalid_token` / 401
- map other `PyJWKClientError` cases to `botlearn_jwks_unavailable` / 503
- add regression coverage for unknown kid vs JWKS provider failure

## Verification
- Code Reviewer re-review: APPROVE / no blocking findings in Botcord dev team-cloud
- `backend/.venv/bin/python -m pytest backend/tests/test_app/test_botlearn_session.py -q` -> 15 passed, warnings only

## Ops follow-up
After preview deploy, validate unknown/no-matching JWKS kid returns controlled 401 `invalid_token`, JWKS provider/fetch/malformed failures return 503 `botlearn_jwks_unavailable`, and preview backend logs/Sentry show no new unhandled 500 traceback.