### PR TITLE
test: drop stale migration file assertions

### DIFF
--- a/backend/tests/test_cloud_agent_schema.py
+++ b/backend/tests/test_cloud_agent_schema.py
@@ -2,7 +2,6 @@
 
 import datetime
 import uuid
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -26,11 +25,6 @@ from hub.models import (
 )
 
 TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
-MIGRATION_011 = (
-    Path(__file__).resolve().parents[1]
-    / "migrations"
-    / "011_agent_hosting_kind_openclaw.sql"
-)
 
 
 @pytest_asyncio.fixture
@@ -117,16 +111,6 @@ async def _make_cloud_agent(
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
-
-
-def test_hosting_kind_openclaw_migration_normalizes_legacy_values_before_check():
-    sql = MIGRATION_011.read_text()
-    normalize_pos = sql.index("UPDATE agents")
-    constraint_pos = sql.index("ADD CONSTRAINT ck_agents_hosting_kind")
-
-    assert normalize_pos < constraint_pos
-    assert "hosting_kind NOT IN ('daemon', 'openclaw', 'cli', 'cloud')" in sql
-    assert "hosting_kind IN ('daemon', 'openclaw', 'cli', 'cloud')" in sql
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_files.py
+++ b/backend/tests/test_files.py
@@ -7,7 +7,6 @@ import os
 import time
 import uuid
 from contextlib import asynccontextmanager
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -22,13 +21,6 @@ from unittest.mock import AsyncMock, patch
 from hub.models import Base, FileRecord
 
 TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
-MIGRATIONS_DIR = Path(__file__).resolve().parents[1] / "migrations"
-FORWARD_REPAIR_MIGRATION = (
-    MIGRATIONS_DIR / "029_file_records_forward_storage_location_repair.sql"
-)
-LEGACY_STORAGE_COLUMNS_MIGRATION = (
-    MIGRATIONS_DIR / "030_file_records_legacy_storage_columns.sql"
-)
 
 
 @pytest_asyncio.fixture
@@ -915,92 +907,6 @@ async def test_file_records_storage_location_migration_normalizes_dirty_legacy_r
             and storage_bucket is not None
             and storage_object_key is not None
         )
-
-
-def test_file_records_forward_repair_migration_uses_next_number_and_search_path():
-    migration_names = sorted(path.name for path in MIGRATIONS_DIR.glob("*.sql"))
-    migration_numbers = [name.split("_", 1)[0] for name in migration_names]
-
-    assert "027_file_records_cleaned_storage_location.sql" in migration_names
-    assert FORWARD_REPAIR_MIGRATION.name in migration_names
-    assert LEGACY_STORAGE_COLUMNS_MIGRATION.name in migration_names
-    assert migration_names.index(
-        "027_file_records_cleaned_storage_location.sql"
-    ) < migration_names.index(FORWARD_REPAIR_MIGRATION.name)
-    assert migration_names.index(
-        FORWARD_REPAIR_MIGRATION.name
-    ) < migration_names.index(LEGACY_STORAGE_COLUMNS_MIGRATION.name)
-    assert all(number.isdigit() and len(number) == 3 for number in migration_numbers)
-    assert migration_numbers == sorted(migration_numbers)
-
-    for migration_path in [
-        FORWARD_REPAIR_MIGRATION,
-        LEGACY_STORAGE_COLUMNS_MIGRATION,
-    ]:
-        sql = migration_path.read_text()
-
-        assert "to_regclass('file_records')" in sql
-        assert "public.file_records" not in sql
-        assert "information_schema" not in sql
-        assert "table_schema = 'public'" not in sql
-        assert "_botcord_schema_migrations" not in sql
-
-
-def test_file_records_forward_repair_migration_has_branch_safe_legacy_path():
-    sql = FORWARD_REPAIR_MIGRATION.read_text()
-
-    assert "IF has_storage_backend THEN" in sql
-    assert "ELSIF has_storage_location THEN" in sql
-    assert "ALTER COLUMN storage_backend DROP NOT NULL" in sql
-    assert "ALTER COLUMN storage_location DROP NOT NULL" in sql
-    assert (
-        "CHECK (storage_backend IS NULL OR storage_backend IN ('disk', 'supabase'))"
-        in sql
-    )
-    assert (
-        "CHECK (storage_location IS NULL OR storage_location IN ('disk', 'supabase'))"
-        in sql
-    )
-
-    legacy_branch = sql.split("ELSIF has_storage_location THEN", 1)[1]
-    legacy_branch = legacy_branch.split("END IF;", 1)[0]
-
-    assert "storage_backend" not in legacy_branch
-
-
-def test_file_records_legacy_storage_columns_migration_upgrades_legacy_shape():
-    sql = LEGACY_STORAGE_COLUMNS_MIGRATION.read_text()
-    normalized_sql = " ".join(sql.split())
-
-    assert "IF has_storage_backend THEN" in sql
-    assert "RETURN;" in sql.split("IF has_storage_backend THEN", 1)[1].split(
-        "END IF;", 1
-    )[0]
-    assert "IF NOT has_storage_location THEN" in sql
-    assert "ADD COLUMN IF NOT EXISTS storage_backend VARCHAR(32)" in sql
-    assert "ADD COLUMN IF NOT EXISTS disk_path TEXT" in sql
-    assert "ADD COLUMN IF NOT EXISTS storage_bucket VARCHAR(128)" in sql
-    assert "ADD COLUMN IF NOT EXISTS storage_object_key TEXT" in sql
-    assert (
-        "CHECK (storage_backend IS NULL OR storage_backend IN ('disk', 'supabase'))"
-        in sql
-    )
-    assert (
-        "AND storage_backend = 'disk' AND disk_path IS NOT NULL "
-        "AND storage_object_key IS NULL"
-        in normalized_sql
-    )
-    assert (
-        "AND storage_backend = 'supabase' AND disk_path IS NULL "
-        "AND storage_bucket IS NOT NULL AND storage_object_key IS NOT NULL"
-        in normalized_sql
-    )
-
-    add_columns_sql = sql.split(
-        "ADD COLUMN IF NOT EXISTS storage_backend VARCHAR(32)", 1
-    )[0]
-    assert "SET storage_backend" not in add_columns_sql
-    assert "storage_backend IN ('disk', 'supabase')" not in add_columns_sql
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_new_api_service.py
+++ b/backend/tests/test_new_api_service.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import uuid
-from pathlib import Path
 
 import httpx
 import pytest
@@ -13,13 +12,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from hub.models import Base, NewApiCredential, User
 from hub.services.new_api import NewApiError, NewApiService
 from tests.test_app.conftest import create_test_engine
-
-
-MIGRATION_025 = (
-    Path(__file__).resolve().parents[1]
-    / "migrations"
-    / "025_new_api_credentials_constraints.sql"
-)
 
 
 @pytest_asyncio.fixture
@@ -73,22 +65,6 @@ def _new_api_response(
         "message": "",
         "data": data,
     }
-
-
-def test_constraints_migration_remediates_invalid_remote_ids_before_checks():
-    sql = MIGRATION_025.read_text()
-    delete_pos = sql.index("DELETE FROM new_api_credentials")
-    user_constraint_pos = sql.index(
-        "ADD CONSTRAINT ck_new_api_credentials_user_id_positive"
-    )
-    token_constraint_pos = sql.index(
-        "ADD CONSTRAINT ck_new_api_credentials_token_id_positive"
-    )
-
-    assert "RAISE EXCEPTION" not in sql
-    assert "new_api_user_id <= 0 OR token_id <= 0" in sql
-    assert delete_pos < user_constraint_pos
-    assert delete_pos < token_constraint_pos
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- remove stale backend tests that read legacy migration SQL files deleted by the 2026-06-10 migration baseline reset
- keep current live schema/service behavior tests intact
- unblock main Backend CI so BOTCORD-BACKEND-37 preview deploy can proceed

## Verification
- Code Reviewer review: APPROVE / no blocking findings in Botcord dev team-cloud
- `git diff --check` -> PASS
- `backend/.venv/bin/python -m pytest backend/tests/test_cloud_agent_schema.py backend/tests/test_files.py backend/tests/test_new_api_service.py -q` -> 55 passed, 38 warnings
- `backend/.venv/bin/python -m pytest backend/tests -q` -> 1480 passed, 30 skipped, 2929 warnings

## Context
Main CI run 27342020739 failed before preview deploy because these tests referenced removed migrations 011/025/027/029/030. The migration reset is documented in `backend/migrations/README.md` and current `backend/migrations` contains only that README.