### PR TITLE
feat: add anime dashboard interactions

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.99.2",
     "@vercel/analytics": "^1.6.1",
+    "animejs": "^4.4.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.1",
     "framer-motion": "^12.38.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@vercel/analytics':
         specifier: ^1.6.1
         version: 1.6.1(next@16.1.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+      animejs:
+        specifier: ^4.4.1
+        version: 4.4.1
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1299,6 +1302,9 @@ packages:
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  animejs@4.4.1:
+    resolution: {integrity: sha512-XimhJw4vPb6tAd6Zaoa6BaspJ8UteQMKvL7Pvrt6MW/6u2UvJs0TB/LLqR1sigaiYvpVPC3Tokr9emcCMhWFhw==}
 
   '@tailwindcss/node@4.2.2':
     resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
@@ -2678,6 +2684,8 @@ snapshots:
   '@babel/runtime@7.29.2': {}
 
   '@drizzle-team/brocli@0.10.2': {}
+
+  animejs@4.4.1: {}
 
   '@emnapi/core@1.9.1':
     dependencies:

--- a/frontend/src/components/dashboard/MessageComposer.tsx
+++ b/frontend/src/components/dashboard/MessageComposer.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import type { ChangeEvent, ClipboardEvent, DragEvent, FormEvent, KeyboardEvent as ReactKeyboardEvent } from "react";
 import { AtSign, Bot, Coins, FileText, FileUp, Hash, Plus, Send, User, X } from "lucide-react";
+import { animateIfMotion, animeStagger, cleanupAnime } from "@/lib/anime";
 
 interface PendingFile {
   file: File;
@@ -128,7 +129,17 @@ export default function MessageComposer({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const mentionListRef = useRef<HTMLDivElement>(null);
   const mentionOptionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const sendButtonRef = useRef<HTMLButtonElement>(null);
+  const sendIconRef = useRef<SVGSVGElement>(null);
   const compositionActiveRef = useRef(false);
+  const mentionOpenRef = useRef(false);
+  const lengthErrorVisibleRef = useRef(showLengthError);
+  const mentionListAnimationRef = useRef<ReturnType<typeof animateIfMotion>>(null);
+  const mentionOptionsAnimationRef = useRef<ReturnType<typeof animateIfMotion>>(null);
+  const inputPulseAnimationRef = useRef<ReturnType<typeof animateIfMotion>>(null);
+  const inputShakeAnimationRef = useRef<ReturnType<typeof animateIfMotion>>(null);
+  const sendButtonAnimationRef = useRef<ReturnType<typeof animateIfMotion>>(null);
+  const sendIconAnimationRef = useRef<ReturnType<typeof animateIfMotion>>(null);
   const inputId = `${MESSAGE_COMPOSER_TEXTAREA_ID_PREFIX}-${useId().replace(/:/g, "")}`;
 
   const mentionEnabled = !!mentionCandidates && mentionCandidates.length > 0;
@@ -194,6 +205,81 @@ export default function MessageComposer({
       list.scrollTop = optionBottom - list.clientHeight;
     }
   }, [mentionMatch, mentionIndex, suggestions.length]);
+
+  useEffect(() => {
+    return () => {
+      cleanupAnime(mentionListAnimationRef.current);
+      cleanupAnime(mentionOptionsAnimationRef.current);
+      cleanupAnime(inputPulseAnimationRef.current);
+      cleanupAnime(inputShakeAnimationRef.current);
+      cleanupAnime(sendButtonAnimationRef.current);
+      cleanupAnime(sendIconAnimationRef.current);
+    };
+  }, []);
+
+  useEffect(() => {
+    const isOpen = !!mentionMatch && suggestions.length > 0;
+
+    if (!isOpen) {
+      mentionOpenRef.current = false;
+      cleanupAnime(mentionListAnimationRef.current);
+      cleanupAnime(mentionOptionsAnimationRef.current);
+      mentionListAnimationRef.current = null;
+      mentionOptionsAnimationRef.current = null;
+      return;
+    }
+
+    if (mentionOpenRef.current) return;
+    mentionOpenRef.current = true;
+
+    const list = mentionListRef.current;
+    if (list) {
+      cleanupAnime(mentionListAnimationRef.current);
+      mentionListAnimationRef.current = animateIfMotion(list, {
+        opacity: [0, 1],
+        translateY: [4, 0],
+        scale: [0.985, 1],
+        duration: 170,
+        ease: "out(3)",
+      });
+    }
+
+    const options = mentionOptionRefs.current
+      .filter((node): node is HTMLButtonElement => Boolean(node))
+      .slice(0, 12);
+
+    if (options.length > 0) {
+      cleanupAnime(mentionOptionsAnimationRef.current);
+      mentionOptionsAnimationRef.current = animateIfMotion(options, {
+        opacity: [0, 1],
+        translateY: [3, 0],
+        scale: [0.985, 1],
+        delay: animeStagger(14, { start: 30 }),
+        duration: 180,
+        ease: "out(3)",
+      });
+    }
+
+    const input = inputRef.current;
+    if (input) {
+      cleanupAnime(inputPulseAnimationRef.current);
+      inputPulseAnimationRef.current = animateIfMotion(input, {
+        boxShadow: [
+          "0 0 0 rgba(34, 211, 238, 0)",
+          "0 0 0 3px rgba(34, 211, 238, 0.12), 0 0 14px rgba(34, 211, 238, 0.18)",
+          "0 0 0 rgba(34, 211, 238, 0)",
+        ],
+        duration: 460,
+        ease: "out(3)",
+        onComplete: (animation) => {
+          cleanupAnime(animation);
+          if (inputPulseAnimationRef.current === animation) {
+            inputPulseAnimationRef.current = null;
+          }
+        },
+      });
+    }
+  }, [mentionMatch, suggestions.length]);
 
   const autoResize = useCallback(() => {
     const el = inputRef.current;
@@ -382,6 +468,48 @@ export default function MessageComposer({
   const canSend = !disabled && !hasLengthError && (text.trim().length > 0 || files.length > 0);
   const showActionMenu = allowAttachments || !!onTransfer;
 
+  useEffect(() => {
+    if (hasLengthError && !lengthErrorVisibleRef.current) {
+      const input = inputRef.current;
+      if (input) {
+        cleanupAnime(inputShakeAnimationRef.current);
+        inputShakeAnimationRef.current = animateIfMotion(input, {
+          translateX: [0, -4, 4, -3, 3, 0],
+          duration: 220,
+          ease: "out(3)",
+        });
+      }
+    }
+    lengthErrorVisibleRef.current = hasLengthError;
+  }, [hasLengthError]);
+
+  const handleSendClick = useCallback(() => {
+    if (canSend) {
+      const button = sendButtonRef.current;
+      if (button) {
+        cleanupAnime(sendButtonAnimationRef.current);
+        sendButtonAnimationRef.current = animateIfMotion(button, {
+          scale: [1, 0.97, 1.05, 1],
+          duration: 240,
+          ease: "out(3)",
+        });
+      }
+
+      const icon = sendIconRef.current;
+      if (icon) {
+        cleanupAnime(sendIconAnimationRef.current);
+        sendIconAnimationRef.current = animateIfMotion(icon, {
+          translateX: [0, 3, 0],
+          scale: [1, 0.94, 1.08, 1],
+          duration: 240,
+          ease: "out(3)",
+        });
+      }
+    }
+
+    void handleSend();
+  }, [canSend, handleSend]);
+
   return (
     <div onDrop={handleDrop} onDragOver={handleDragOver}>
       {hasLengthError && (
@@ -535,7 +663,7 @@ export default function MessageComposer({
         {mentionMatch && suggestions.length > 0 && (
           <div
             ref={mentionListRef}
-            className="absolute left-0 right-12 bottom-full mb-1 z-20 max-h-56 overflow-y-auto rounded-lg border border-zinc-700 bg-zinc-900 shadow-xl"
+            className="absolute left-0 right-12 bottom-full mb-1 z-20 max-h-56 origin-bottom overflow-y-auto rounded-lg border border-zinc-700 bg-zinc-900 shadow-xl"
             role="listbox"
           >
             {suggestions.map((s, i) => {
@@ -589,13 +717,14 @@ export default function MessageComposer({
           </div>
         )}
         <button
+          ref={sendButtonRef}
           type="button"
-          onClick={() => void handleSend()}
+          onClick={handleSendClick}
           disabled={!canSend}
           className="flex items-center justify-center w-9 h-9 rounded-lg bg-cyan-500/20 text-cyan-400 hover:bg-cyan-500/30 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           aria-label="Send message"
         >
-          <Send className="w-4 h-4" />
+          <Send ref={sendIconRef} className="w-4 h-4" />
         </button>
       </div>
     </div>

--- a/frontend/src/components/dashboard/MessageList.tsx
+++ b/frontend/src/components/dashboard/MessageList.tsx
@@ -27,6 +27,7 @@ import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import { useDashboardUnreadStore } from "@/store/useDashboardUnreadStore";
 import { usePresenceStore } from "@/store/usePresenceStore";
+import { animateIfMotion, animatePop, cleanupAnime } from "@/lib/anime";
 
 const topicStatusColors: Record<string, { color: string; icon: string }> = {
   open:      { color: "text-neon-cyan bg-neon-cyan/10 border-neon-cyan/30",       icon: "●" },
@@ -153,6 +154,7 @@ export function TopicCard({
         {group.messages.map((msg) => (
           <div
             key={messageRenderKey(msg)}
+            data-msg-key={messageRenderKey(msg)}
             data-msg-id={msg.msg_id}
             className="scroll-mt-4 transition-shadow"
           >
@@ -314,8 +316,12 @@ export default function MessageList({
   const markRoomSeen = useDashboardUnreadStore((state) => state.markRoomSeen);
   const containerRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
+  const scrollToBottomButtonRef = useRef<HTMLButtonElement>(null);
   const prevLengthRef = useRef(0);
   const isLoadingMore = useRef(false);
+  const messageAnimationRoomRef = useRef<string | null>(null);
+  const messageAnimationPrimedRef = useRef(false);
+  const animatedMessageKeysRef = useRef<Set<string>>(new Set());
   const [showScrollToBottomButton, setShowScrollToBottomButton] = useState(false);
   const showScrollToBottomButtonRef = useRef(false);
   const wasNearBottomRef = useRef(true);
@@ -376,10 +382,32 @@ export default function MessageList({
       );
       if (!el) return;
       el.scrollIntoView({ behavior: "smooth", block: "center" });
-      el.classList.add("ring-2", "ring-neon-cyan/70", "rounded-xl");
-      window.setTimeout(() => {
-        el.classList.remove("ring-2", "ring-neon-cyan/70", "rounded-xl");
-      }, 1500);
+      el.classList.add("rounded-xl");
+      const highlight = animateIfMotion(el, {
+        backgroundColor: [
+          "rgba(0, 240, 255, 0.16)",
+          "rgba(0, 240, 255, 0.08)",
+          "rgba(0, 240, 255, 0)",
+        ],
+        boxShadow: [
+          "0 0 0 0 rgba(0, 240, 255, 0)",
+          "0 0 0 2px rgba(0, 240, 255, 0.72)",
+          "0 0 24px rgba(0, 240, 255, 0)",
+        ],
+        duration: 1200,
+        ease: "out(3)",
+        onComplete: () => {
+          el.style.backgroundColor = "";
+          el.style.boxShadow = "";
+          el.classList.remove("rounded-xl");
+        },
+      });
+      if (!highlight) {
+        el.classList.add("ring-2", "ring-neon-cyan/70");
+        window.setTimeout(() => {
+          el.classList.remove("ring-2", "ring-neon-cyan/70", "rounded-xl");
+        }, 1000);
+      }
     };
     window.addEventListener(JUMP_TO_MESSAGE_EVENT, handler);
     return () => window.removeEventListener(JUMP_TO_MESSAGE_EVENT, handler);
@@ -416,6 +444,9 @@ export default function MessageList({
     prevLengthRef.current = 0;
     wasNearBottomRef.current = true;
     initialScrollDoneRef.current = false;
+    messageAnimationRoomRef.current = roomId;
+    messageAnimationPrimedRef.current = false;
+    animatedMessageKeysRef.current = new Set();
     showScrollToBottomButtonRef.current = false;
     setShowScrollToBottomButton(false);
   }, [roomId, setOpenedTopicId]);
@@ -472,6 +503,47 @@ export default function MessageList({
     scrollToBottomAfterLayout();
   }, [roomId, isRoomMessagesLoading, messages.length, scrollToBottomAfterLayout]);
 
+  useEffect(() => {
+    if (!roomId) return;
+    if (messageAnimationRoomRef.current !== roomId) {
+      messageAnimationRoomRef.current = roomId;
+      messageAnimationPrimedRef.current = false;
+      animatedMessageKeysRef.current = new Set();
+    }
+
+    const keys = messages.map(messageRenderKey);
+    if (keys.length === 0) return;
+
+    if (!messageAnimationPrimedRef.current) {
+      animatedMessageKeysRef.current = new Set(keys);
+      messageAnimationPrimedRef.current = true;
+      return;
+    }
+
+    const newlyVisibleKeys = keys.filter((key) => !animatedMessageKeysRef.current.has(key));
+    for (const key of keys) animatedMessageKeysRef.current.add(key);
+    if (newlyVisibleKeys.length === 0 || isLoadingMore.current) return;
+
+    requestAnimationFrame(() => {
+      const container = containerRef.current;
+      if (!container) return;
+      newlyVisibleKeys.slice(-6).forEach((key, index) => {
+        const el = container.querySelector<HTMLElement>(
+          `[data-msg-key="${CSS.escape(key)}"]`,
+        );
+        if (!el) return;
+        animateIfMotion(el, {
+          opacity: [0, 1],
+          translateY: [10, 0],
+          scale: [0.985, 1],
+          duration: 340,
+          delay: index * 24,
+          ease: "out(3)",
+        });
+      });
+    });
+  }, [messages, roomId]);
+
   // Auto-scroll or show the follow button when new messages arrive.
   // Uses wasNearBottomRef (snapshotted on scroll events, before DOM changes)
   // to decide whether to auto-scroll or let the user resume manually.
@@ -501,6 +573,12 @@ export default function MessageList({
   // Keep ref in sync with state for use in scroll handler
   useEffect(() => {
     showScrollToBottomButtonRef.current = showScrollToBottomButton;
+  }, [showScrollToBottomButton]);
+
+  useEffect(() => {
+    if (!showScrollToBottomButton || !scrollToBottomButtonRef.current) return;
+    const animation = animatePop(scrollToBottomButtonRef.current);
+    return () => cleanupAnime(animation);
   }, [showScrollToBottomButton]);
 
   // Track scroll position & handle infinite scroll up
@@ -560,6 +638,7 @@ export default function MessageList({
 
   const scrollToBottomButton = showScrollToBottomButton && (
     <button
+      ref={scrollToBottomButtonRef}
       type="button"
       onClick={() => scrollToBottom("auto")}
       aria-label={t.scrollToLatest}
@@ -588,6 +667,7 @@ export default function MessageList({
             return (
               <div
                 key={messageRenderKey(msg)}
+                data-msg-key={messageRenderKey(msg)}
                 data-msg-id={msg.msg_id}
                 className="scroll-mt-4 transition-shadow"
               >

--- a/frontend/src/components/dashboard/RoomList.tsx
+++ b/frontend/src/components/dashboard/RoomList.tsx
@@ -2,17 +2,18 @@
 
 /**
  * [INPUT]: 依赖 ui/chat/unread/owner-chat store 的会话状态、缓存消息与后端未读标记，依赖 nextjs-toploader/app 做带进度反馈的路由跳转
- * [OUTPUT]: 对外提供 RoomList 组件，渲染消息会话列表项与刷新骨架（头像 + 最后一条消息预览 + 未读数量）
+ * [OUTPUT]: 对外提供 RoomList 组件，渲染消息会话列表项与刷新骨架，并提供受 reduced-motion 约束的列表入场/未读/引导动效
  * [POS]: dashboard 左侧消息导航区的会话列表渲染器，被 Sidebar 组合使用
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useLanguage } from '@/lib/i18n';
 import { roomList, messagesGrouping } from '@/lib/i18n/translations/dashboard';
 import { useRouter } from "nextjs-toploader/app";
 import { useShallow } from "zustand/react/shallow";
 
+import { animateIfMotion, animatePop, animeStagger, cleanupAnime } from "@/lib/anime";
 import { ContactInfo, DashboardMessage, DashboardRoom } from "@/lib/types";
 import { isDashboardMessageRecalled, recalledMessageLabel } from "@/lib/message-recall";
 import { getIsoTimestampValue, getRoomActivityTimestamp, humanRoomToDashboardRoom, isOwnerChatRoom } from "@/store/dashboard-shared";
@@ -88,6 +89,27 @@ function formatUnreadCount(count: number): string {
   return count > 99 ? "99+" : String(count);
 }
 
+function UnreadBadge({ count }: { count: number }) {
+  const badgeRef = useRef<HTMLSpanElement | null>(null);
+
+  useEffect(() => {
+    const badge = badgeRef.current;
+    if (!badge) return;
+
+    const animation = animatePop(badge);
+    return () => cleanupAnime(animation);
+  }, [count]);
+
+  return (
+    <span
+      ref={badgeRef}
+      className="flex h-5 min-w-[20px] items-center justify-center rounded-full bg-neon-cyan px-1.5 text-[10px] font-bold leading-none text-black shadow-[0_0_10px_rgba(34,211,238,0.55)]"
+    >
+      {formatUnreadCount(count)}
+    </span>
+  );
+}
+
 export default function RoomList({
   rooms: propsRooms,
   loading = false,
@@ -96,6 +118,10 @@ export default function RoomList({
   roomMeta,
 }: RoomListProps) {
   const router = useRouter();
+  const roomListRef = useRef<HTMLDivElement | null>(null);
+  const userChatEntryRef = useRef<HTMLDivElement | null>(null);
+  const previousDisplayStateRef = useRef({ loading: true, count: 0 });
+  const wasOwnerChatEmptyRef = useRef(false);
   const locale = useLanguage();
   const t = roomList[locale];
   const tGroup = messagesGrouping[locale];
@@ -198,6 +224,80 @@ export default function RoomList({
       .sort((a, b) => b.activity - a.activity || a.index - b.index)
       .map((entry) => entry.room);
   }, [cachedLatestMessages, ownerChatLatestMessage, ownerChatRoomId, rooms]);
+  const displayRoomKey = useMemo(() => displayRooms.map((room) => room.room_id).join("\n"), [displayRooms]);
+
+  useEffect(() => {
+    if (loading) {
+      previousDisplayStateRef.current = { loading: true, count: 0 };
+      return;
+    }
+
+    const previousDisplayState = previousDisplayStateRef.current;
+    if (
+      displayRooms.length === 0 ||
+      (!previousDisplayState.loading && previousDisplayState.count > 0)
+    ) {
+      previousDisplayStateRef.current = { loading: false, count: displayRooms.length };
+      return;
+    }
+
+    let animation: ReturnType<typeof animateIfMotion> = null;
+    const frameId = window.requestAnimationFrame(() => {
+      previousDisplayStateRef.current = { loading: false, count: displayRooms.length };
+
+      const roomRows = Array.from(
+        roomListRef.current?.querySelectorAll<HTMLElement>("[data-room-list-row]") ?? [],
+      );
+      if (roomRows.length === 0) return;
+
+      animation = animateIfMotion(roomRows, {
+        opacity: [0, 1],
+        translateY: [8, 0],
+        scale: [0.985, 1],
+        delay: animeStagger(45),
+        duration: 420,
+        ease: "out(3)",
+      });
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      cleanupAnime(animation);
+    };
+  }, [displayRoomKey, displayRooms.length, loading]);
+
+  useEffect(() => {
+    const shouldPulseOnboarding = showUserChatEntry && isOwnerChatEmpty;
+    if (!shouldPulseOnboarding) {
+      wasOwnerChatEmptyRef.current = false;
+      return;
+    }
+    if (wasOwnerChatEmptyRef.current) return;
+
+    let animation: ReturnType<typeof animateIfMotion> = null;
+    const frameId = window.requestAnimationFrame(() => {
+      wasOwnerChatEmptyRef.current = true;
+
+      const onboardingRow = userChatEntryRef.current;
+      if (!onboardingRow) return;
+
+      animation = animateIfMotion(onboardingRow, {
+        scale: [1, 1.012, 1],
+        boxShadow: [
+          "0 0 0 rgba(34, 211, 238, 0)",
+          "0 0 12px rgba(34, 211, 238, 0.32)",
+          "0 0 0 rgba(34, 211, 238, 0)",
+        ],
+        duration: 640,
+        ease: "out(3)",
+      });
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      cleanupAnime(animation);
+    };
+  }, [isOwnerChatEmpty, showUserChatEntry]);
 
   const handleSelect = async (room: DashboardRoom) => {
     if (isOwnerChatRoom(room.room_id)) {
@@ -271,9 +371,10 @@ export default function RoomList({
   }
 
   return (
-    <div className="py-1">
+    <div ref={roomListRef} className="py-1">
       {showUserChatEntry && (
         <div
+          ref={userChatEntryRef}
           role="button"
           tabIndex={0}
           aria-label={t.userChatAriaLabel}
@@ -285,7 +386,7 @@ export default function RoomList({
             messagesPane === "user-chat"
               ? "border-neon-cyan bg-neon-cyan/10"
               : isOwnerChatEmpty
-                ? "border-neon-cyan/50 bg-neon-cyan/[0.06] animate-[pulse-border_2s_ease-in-out_infinite]"
+                ? "border-neon-cyan/50 bg-neon-cyan/[0.06]"
                 : "border-transparent hover:bg-glass-bg"
           }`}
         >
@@ -294,7 +395,7 @@ export default function RoomList({
               isOwnerChatEmpty ? "border-neon-cyan/50 bg-neon-cyan/15" : "border-neon-cyan/30 bg-neon-cyan/10"
             }`}>
               {isOwnerChatEmpty && (
-                <div className="absolute inset-0 rounded-xl bg-neon-cyan/20 blur-md animate-pulse" />
+                <div className="absolute inset-0 rounded-xl bg-neon-cyan/15 blur-md" />
               )}
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" className="relative h-5 w-5">
                 <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z" />
@@ -308,7 +409,7 @@ export default function RoomList({
                     {t.userChatBadge}
                   </span>
                   {isOwnerChatEmpty && (
-                    <span className="rounded-full bg-neon-green/20 border border-neon-green/40 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-neon-green animate-pulse">
+                    <span className="rounded-full bg-neon-green/20 border border-neon-green/40 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-neon-green">
                       {t.userChatOnboardingBadge}
                     </span>
                   )}
@@ -373,6 +474,7 @@ export default function RoomList({
         return (
           <div
             key={room.room_id}
+            data-room-list-row="true"
             role="button"
             tabIndex={0}
             aria-label={`Open room ${displayName}`}
@@ -435,9 +537,7 @@ export default function RoomList({
                   </span>
                   <div className="flex shrink-0 items-center gap-2">
                     {unreadCount > 0 && (
-                      <span className="flex h-5 min-w-[20px] items-center justify-center rounded-full bg-neon-cyan px-1.5 text-[10px] font-bold leading-none text-black shadow-[0_0_10px_rgba(34,211,238,0.55)]">
-                        {formatUnreadCount(unreadCount)}
-                      </span>
+                      <UnreadBadge count={unreadCount} />
                     )}
                     {messageTime && (
                       <span className="text-[11px] text-text-secondary/80">

--- a/frontend/src/components/dashboard/TopicDrawer.tsx
+++ b/frontend/src/components/dashboard/TopicDrawer.tsx
@@ -2,14 +2,15 @@
 
 /**
  * [INPUT]: 依赖 chat/ui/session store 的消息和焦点状态，复用 MessageBubble 和 RoomHumanComposer 渲染话题线程
- * [OUTPUT]: 对外提供 TopicDrawer 组件，作为从右侧滑出的话题详情面板
+ * [OUTPUT]: 对外提供带 animejs 进出场动效的 TopicDrawer 组件，作为从右侧滑出的话题详情面板
  * [POS]: dashboard 聊天正文区的话题线程查看/回复面板，避免话题消息在主列表铺开造成视觉杂乱
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
 
-import { useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from "react";
 import { X } from "lucide-react";
 import { useShallow } from "zustand/react/shallow";
+import { animeStagger, cleanupAnime, createTimelineIfMotion } from "@/lib/anime";
 import { useLanguage } from "@/lib/i18n";
 import { messageList } from "@/lib/i18n/translations/dashboard";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
@@ -27,6 +28,11 @@ const topicStatusColors: Record<string, { color: string; icon: string }> = {
 };
 
 const EMPTY_MESSAGES: DashboardMessage[] = [];
+const DRAWER_PART_SELECTOR = "[data-topic-drawer-part]";
+
+function getDrawerParts(drawer: HTMLElement | null): HTMLElement[] {
+  return drawer ? Array.from(drawer.querySelectorAll<HTMLElement>(DRAWER_PART_SELECTOR)) : [];
+}
 
 export default function TopicDrawer() {
   const locale = useLanguage();
@@ -44,7 +50,11 @@ export default function TopicDrawer() {
   );
   const activeAgentId = useDashboardSessionStore((s) => s.activeAgentId);
 
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const drawerRef = useRef<HTMLElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
+  const animationRef = useRef<ReturnType<typeof createTimelineIfMotion>>(null);
+  const closingRef = useRef(false);
 
   const { topicMessages, topicName, topicStatus, topicGoal } = useMemo(() => {
     if (!openedRoomId || !openedTopicId) {
@@ -66,15 +76,136 @@ export default function TopicDrawer() {
     }
   }, [openedTopicId, topicMessages.length]);
 
+  useLayoutEffect(() => {
+    if (!openedRoomId || !openedTopicId) return;
+
+    closingRef.current = false;
+    cleanupAnime(animationRef.current);
+
+    const overlay = overlayRef.current;
+    const drawer = drawerRef.current;
+    const parts = getDrawerParts(drawer);
+    if (!drawer) return;
+
+    if (overlay) overlay.style.opacity = "0";
+    drawer.style.opacity = "0";
+    drawer.style.transform = "translateX(32px)";
+    parts.forEach((part) => {
+      part.style.opacity = "0";
+      part.style.transform = "translateY(8px)";
+    });
+
+    const timeline = createTimelineIfMotion({
+      onComplete: () => {
+        if (animationRef.current === timeline) animationRef.current = null;
+      },
+    });
+    animationRef.current = timeline;
+
+    if (!timeline) {
+      if (overlay) overlay.style.opacity = "1";
+      drawer.style.opacity = "1";
+      drawer.style.transform = "translateX(0px)";
+      parts.forEach((part) => {
+        part.style.opacity = "1";
+        part.style.transform = "translateY(0px)";
+      });
+      return;
+    }
+
+    if (overlay) {
+      timeline.add(overlay, {
+        opacity: [0, 1],
+        duration: 180,
+        ease: "linear",
+      }, 0);
+    }
+
+    timeline.add(drawer, {
+      opacity: [0, 1],
+      translateX: [32, 0],
+      duration: 280,
+      ease: "out(3)",
+    }, 0);
+
+    if (parts.length) {
+      timeline.add(parts, {
+        opacity: [0, 1],
+        translateY: [8, 0],
+        duration: 220,
+        delay: animeStagger(28),
+        ease: "out(3)",
+      }, 90);
+    }
+
+    return () => cleanupAnime(timeline);
+  }, [openedRoomId, openedTopicId]);
+
+  const closeDrawer = useCallback(() => {
+    if (closingRef.current) return;
+
+    const overlay = overlayRef.current;
+    const drawer = drawerRef.current;
+    const parts = getDrawerParts(drawer);
+    if (!drawer) {
+      setOpenedTopicId(null);
+      return;
+    }
+
+    closingRef.current = true;
+    animationRef.current?.pause();
+
+    const finishClose = () => {
+      closingRef.current = false;
+      animationRef.current = null;
+      setOpenedTopicId(null);
+    };
+
+    const timeline = createTimelineIfMotion({
+      onComplete: finishClose,
+    });
+    animationRef.current = timeline;
+
+    if (!timeline) {
+      finishClose();
+      return;
+    }
+
+    if (parts.length) {
+      timeline.add(parts, {
+        opacity: 0,
+        translateY: -4,
+        duration: 110,
+        delay: animeStagger(12, { reversed: true }),
+        ease: "in(2)",
+      }, 0);
+    }
+
+    timeline.add(drawer, {
+      opacity: 0,
+      translateX: 36,
+      duration: 180,
+      ease: "in(2)",
+    }, parts.length ? 35 : 0);
+
+    if (overlay) {
+      timeline.add(overlay, {
+        opacity: 0,
+        duration: 140,
+        ease: "linear",
+      }, parts.length ? 35 : 0);
+    }
+  }, [setOpenedTopicId]);
+
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpenedTopicId(null);
+      if (e.key === "Escape") closeDrawer();
     };
     if (openedTopicId) {
       window.addEventListener("keydown", onKey);
       return () => window.removeEventListener("keydown", onKey);
     }
-  }, [openedTopicId, setOpenedTopicId]);
+  }, [closeDrawer, openedTopicId]);
 
   if (!openedRoomId || !openedTopicId) return null;
 
@@ -86,11 +217,15 @@ export default function TopicDrawer() {
   return (
     <>
       <div
-        onClick={() => setOpenedTopicId(null)}
+        ref={overlayRef}
+        onClick={closeDrawer}
         className="fixed inset-0 z-30 bg-black/40 backdrop-blur-sm md:hidden"
       />
-      <aside className="fixed right-0 top-0 z-40 flex h-full w-full max-w-[480px] flex-col border-l border-glass-border bg-deep-black shadow-2xl md:w-[440px]">
-        <header className="flex items-start gap-2 border-b border-glass-border/60 px-4 py-3">
+      <aside
+        ref={drawerRef}
+        className="fixed right-0 top-0 z-40 flex h-full w-full max-w-[480px] flex-col border-l border-glass-border bg-deep-black shadow-2xl md:w-[440px]"
+      >
+        <header data-topic-drawer-part className="flex items-start gap-2 border-b border-glass-border/60 px-4 py-3">
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
               <span className="text-xs uppercase tracking-wide text-text-secondary/60">{t.topic || "Topic"}</span>
@@ -107,7 +242,7 @@ export default function TopicDrawer() {
             )}
           </div>
           <button
-            onClick={() => setOpenedTopicId(null)}
+            onClick={closeDrawer}
             className="rounded-md p-1 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
             aria-label="Close topic"
           >
@@ -115,7 +250,7 @@ export default function TopicDrawer() {
           </button>
         </header>
 
-        <div className="flex-1 overflow-y-auto px-3 py-3">
+        <div data-topic-drawer-part className="flex-1 overflow-y-auto px-3 py-3">
           {topicMessages.length === 0 ? (
             <div className="flex h-full items-center justify-center text-sm text-text-secondary">
               {t.noMessages}
@@ -134,7 +269,7 @@ export default function TopicDrawer() {
           <div ref={bottomRef} />
         </div>
 
-        <div className="border-t border-glass-border/60 px-3 py-3">
+        <div data-topic-drawer-part className="border-t border-glass-border/60 px-3 py-3">
           <RoomHumanComposer roomId={openedRoomId} topicId={openedTopicId} />
         </div>
       </aside>

--- a/frontend/src/lib/anime.ts
+++ b/frontend/src/lib/anime.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { animate, createTimeline, utils } from "animejs";
+import type { JSAnimation, Timeline } from "animejs";
+
+type AnimeHandle = JSAnimation | Timeline | null | undefined;
+
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+export function prefersReducedMotion(): boolean {
+  return typeof window !== "undefined" && window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+
+export function cleanupAnime(handle: AnimeHandle): void {
+  handle?.revert();
+}
+
+export function animateIfMotion(
+  target: Parameters<typeof animate>[0],
+  params: Parameters<typeof animate>[1],
+): JSAnimation | null {
+  if (prefersReducedMotion()) return null;
+  return animate(target, params);
+}
+
+export function createTimelineIfMotion(
+  params?: Parameters<typeof createTimeline>[0],
+): Timeline | null {
+  if (prefersReducedMotion()) return null;
+  return createTimeline(params);
+}
+
+export const animeStagger = utils.stagger;
+
+export function animatePulse(target: HTMLElement, color = "rgba(0, 240, 255, 0.52)"): JSAnimation | null {
+  return animateIfMotion(target, {
+    scale: [1, 1.025, 1],
+    boxShadow: [
+      "0 0 0 rgba(0, 240, 255, 0)",
+      `0 0 18px ${color}`,
+      "0 0 0 rgba(0, 240, 255, 0)",
+    ],
+    duration: 520,
+    ease: "out(3)",
+  });
+}
+
+export function animatePop(target: HTMLElement): JSAnimation | null {
+  return animateIfMotion(target, {
+    opacity: [0, 1],
+    scale: [0.88, 1.04, 1],
+    translateY: [6, -1, 0],
+    duration: 360,
+    ease: "out(3)",
+  });
+}


### PR DESCRIPTION
## Summary
- Add a shared animejs helper layer with reduced-motion handling and animation cleanup.
- Add dashboard microinteractions for message entry/highlight, composer mention/send feedback, room-list unread/list states, and topic drawer presence.
- Add animejs to the frontend package and lockfile.

## Verification
- `pnpm install --frozen-lockfile --ignore-workspace`
- `pnpm exec vitest run src/components/dashboard/MessageComposer.test.ts src/components/dashboard/MessageList.test.ts`
- `git diff --check`
- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy pnpm run build`
- `curl -I --max-time 20 http://localhost:3000/chats` returned 200 during local smoke check

## Risk / rollout
- Frontend-only interaction polish; business logic and message/send semantics are unchanged.
- Animations are guarded by prefers-reduced-motion via the shared helper.
- Standalone `pnpm exec tsc --noEmit` still reports pre-existing test/API fixture errors, but Next production build passes.