### PR TITLE
feat: polish dashboard animations

### DIFF
--- a/frontend/src/components/dashboard/AgentCardModal.tsx
+++ b/frontend/src/components/dashboard/AgentCardModal.tsx
@@ -2,18 +2,19 @@
 
 /**
  * [INPUT]: 依赖 agent 资料与联系人关系状态，依赖 i18n 提供文案
- * [OUTPUT]: 对外提供 AgentCardModal 统一 agent 详情模态框
+ * [OUTPUT]: 对外提供带 animejs 进出场动效的 AgentCardModal 统一 agent 详情模态框
  * [POS]: dashboard 通用弹层组件，被 Explore 与成员列表等入口复用
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
 
 import CopyableId from "@/components/ui/CopyableId";
 import { MobileBotCordLoading } from "@/components/ui/BotCordLoader";
+import { animeStagger, cleanupAnime, createTimelineIfMotion } from "@/lib/anime";
 import { useLanguage } from "@/lib/i18n";
 import { exploreUi } from "@/lib/i18n/translations/dashboard";
 import type { AgentProfile } from "@/lib/types";
 import { Loader2 } from "lucide-react";
-import { useEffect } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { usePresenceStore } from "@/store/usePresenceStore";
 import { PresenceDot } from "./PresenceDot";
 import BotAvatar from "./BotAvatar";
@@ -34,6 +35,12 @@ interface AgentCardModalProps {
   isOwnAgent?: boolean;
 }
 
+const PROFILE_MODAL_PART_SELECTOR = "[data-profile-modal-part]";
+
+function getModalParts(panel: HTMLElement | null): HTMLElement[] {
+  return panel ? Array.from(panel.querySelectorAll<HTMLElement>(PROFILE_MODAL_PART_SELECTOR)) : [];
+}
+
 export default function AgentCardModal({
   isOpen,
   agent,
@@ -52,18 +59,192 @@ export default function AgentCardModal({
   const locale = useLanguage();
   const t = exploreUi[locale];
   const messagePolicyLabel = getMessagePolicyLabel(agent?.message_policy, t.messagePolicyLabels);
+  const [shouldRender, setShouldRender] = useState(isOpen);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const animationRef = useRef<ReturnType<typeof createTimelineIfMotion>>(null);
+  const closingRef = useRef(false);
+  const closeRequestedRef = useRef(false);
+
+  const playExit = useCallback((afterClose?: () => void) => {
+    if (closingRef.current) return;
+
+    const overlay = overlayRef.current;
+    const panel = panelRef.current;
+    const parts = getModalParts(panel);
+
+    const finishClose = () => {
+      closingRef.current = false;
+      animationRef.current = null;
+      setShouldRender(false);
+      afterClose?.();
+    };
+
+    if (!panel) {
+      finishClose();
+      return;
+    }
+
+    closingRef.current = true;
+    animationRef.current?.pause();
+
+    const timeline = createTimelineIfMotion({
+      onComplete: finishClose,
+    });
+    animationRef.current = timeline;
+
+    if (!timeline) {
+      finishClose();
+      return;
+    }
+
+    if (parts.length) {
+      timeline.add(parts, {
+        opacity: 0,
+        translateY: -4,
+        duration: 110,
+        delay: animeStagger(10, { reversed: true }),
+        ease: "in(2)",
+      }, 0);
+    }
+
+    timeline.add(panel, {
+      opacity: 0,
+      scale: 0.98,
+      translateY: 8,
+      duration: 170,
+      ease: "in(2)",
+    }, parts.length ? 35 : 0);
+
+    if (overlay) {
+      timeline.add(overlay, {
+        opacity: 0,
+        duration: 140,
+        ease: "linear",
+      }, parts.length ? 35 : 0);
+    }
+  }, []);
+
+  const handleClose = useCallback(() => {
+    closeRequestedRef.current = true;
+    playExit(onClose);
+  }, [onClose, playExit]);
+
+  useLayoutEffect(() => {
+    if (isOpen && !shouldRender && !closeRequestedRef.current) {
+      setShouldRender(true);
+    }
+  }, [isOpen, shouldRender]);
+
+  useLayoutEffect(() => {
+    if (!shouldRender || !isOpen || closeRequestedRef.current) return;
+
+    closingRef.current = false;
+    cleanupAnime(animationRef.current);
+
+    const overlay = overlayRef.current;
+    const panel = panelRef.current;
+    const parts = getModalParts(panel);
+    if (!panel) return;
+
+    if (overlay) overlay.style.opacity = "0";
+    panel.style.opacity = "0";
+    panel.style.transform = "translateY(14px) scale(0.96)";
+    parts.forEach((part) => {
+      part.style.opacity = "0";
+      part.style.transform = "translateY(8px)";
+    });
+
+    const timeline = createTimelineIfMotion({
+      onComplete: () => {
+        if (animationRef.current === timeline) animationRef.current = null;
+      },
+    });
+    animationRef.current = timeline;
+
+    if (!timeline) {
+      if (overlay) overlay.style.opacity = "1";
+      panel.style.opacity = "1";
+      panel.style.transform = "translateY(0px) scale(1)";
+      parts.forEach((part) => {
+        part.style.opacity = "1";
+        part.style.transform = "translateY(0px)";
+      });
+      return;
+    }
+
+    if (overlay) {
+      timeline.add(overlay, {
+        opacity: [0, 1],
+        duration: 180,
+        ease: "linear",
+      }, 0);
+    }
+
+    timeline.add(panel, {
+      opacity: [0, 1],
+      scale: [0.96, 1],
+      translateY: [14, 0],
+      duration: 260,
+      ease: "out(3)",
+    }, 0);
+
+    if (parts.length) {
+      timeline.add(parts, {
+        opacity: [0, 1],
+        translateY: [8, 0],
+        duration: 210,
+        delay: animeStagger(24),
+        ease: "out(3)",
+      }, 75);
+    }
+
+    return () => cleanupAnime(timeline);
+  }, [shouldRender, isOpen]);
+
+  useLayoutEffect(() => {
+    if (!isOpen) {
+      closeRequestedRef.current = false;
+      if (shouldRender) playExit();
+    }
+  }, [isOpen, playExit, shouldRender]);
+
+  useEffect(() => {
+    if (!shouldRender) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") handleClose();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleClose, shouldRender]);
+
+  useEffect(() => () => cleanupAnime(animationRef.current), []);
 
   useEffect(() => {
     if (!agent) return;
     usePresenceStore.getState().seed([{ agentId: agent.agent_id, online: Boolean(agent.online) }]);
   }, [agent]);
 
-  if (!isOpen) return null;
+  if (!shouldRender) return null;
 
   return (
-    <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/60 p-4">
-      <div className="w-full max-w-md rounded-2xl border border-glass-border bg-deep-black-light p-5">
-        <div className="mb-3 flex items-start justify-between gap-3">
+    <div
+      ref={overlayRef}
+      className="fixed inset-0 z-40 flex items-center justify-center bg-black/60 p-4"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) handleClose();
+      }}
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        className="w-full max-w-md rounded-2xl border border-glass-border bg-deep-black-light p-5"
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <div data-profile-modal-part className="mb-3 flex items-start justify-between gap-3">
           <div className="flex min-w-0 items-start gap-3">
             {agent ? (
               <BotAvatar agentId={agent.agent_id} avatarUrl={agent.avatar_url} size={44} alt={agent.display_name} />
@@ -77,14 +258,14 @@ export default function AgentCardModal({
             </div>
           </div>
           <button
-            onClick={onClose}
+            onClick={handleClose}
             className="rounded border border-glass-border px-2 py-0.5 text-xs text-text-secondary hover:text-text-primary"
           >
             {t.close}
           </button>
         </div>
         {loading ? (
-          <div className="space-y-3 py-2">
+          <div data-profile-modal-part className="space-y-3 py-2">
             <p className="text-sm text-text-secondary">{agent?.bio || t.noBio}</p>
             <div className="flex items-center gap-2">
               {agent && <CopyableId value={agent.agent_id} />}
@@ -99,7 +280,7 @@ export default function AgentCardModal({
             />
           </div>
         ) : error ? (
-          <div className="space-y-3 py-2">
+          <div data-profile-modal-part className="space-y-3 py-2">
             <p className="text-sm text-red-400">{error}</p>
             <button
               onClick={onRetry}
@@ -110,9 +291,9 @@ export default function AgentCardModal({
           </div>
         ) : (
           <>
-            <p className="mb-3 text-sm text-text-secondary">{agent?.bio || t.noBio}</p>
+            <p data-profile-modal-part className="mb-3 text-sm text-text-secondary">{agent?.bio || t.noBio}</p>
             {agent?.owner_human_id && agent.owner_display_name ? (
-              <div className="mb-3 text-xs text-text-secondary">
+              <div data-profile-modal-part className="mb-3 text-xs text-text-secondary">
                 <span className="text-text-secondary/70">Human owner: </span>
                 <button
                   type="button"
@@ -126,7 +307,7 @@ export default function AgentCardModal({
                 </button>
               </div>
             ) : null}
-            <div className="mb-4 flex items-center gap-2">
+            <div data-profile-modal-part className="mb-4 flex items-center gap-2">
               {agent && <CopyableId value={agent.agent_id} />}
               <span className="rounded border border-glass-border px-1.5 py-0.5 text-[10px] text-text-secondary">
                 {messagePolicyLabel}
@@ -134,6 +315,7 @@ export default function AgentCardModal({
             </div>
             {isOwnAgent ? (
               <button
+                data-profile-modal-part
                 onClick={onSendMessage}
                 className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-green/40 bg-neon-green/10 py-2 text-xs font-medium text-neon-green transition-colors hover:bg-neon-green/20"
               >
@@ -141,15 +323,17 @@ export default function AgentCardModal({
               </button>
             ) : alreadyInContacts ? (
               <button
+                data-profile-modal-part
                 onClick={onSendMessage}
                 className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-green/40 bg-neon-green/10 py-2 text-xs font-medium text-neon-green transition-colors hover:bg-neon-green/20"
               >
                 {t.sendMessage}
               </button>
             ) : requestAlreadyPending ? (
-              <p className="text-xs text-neon-cyan">{t.friendRequestAlreadyPending}</p>
+              <p data-profile-modal-part className="text-xs text-neon-cyan">{t.friendRequestAlreadyPending}</p>
             ) : (
               <button
+                data-profile-modal-part
                 onClick={onSendFriendRequest}
                 disabled={sendingFriendRequest}
                 className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 py-2 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20 disabled:cursor-not-allowed disabled:opacity-60"

--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -44,6 +44,7 @@ import StripeReturnBanner from "./StripeReturnBanner";
 import UserChatPane from "./UserChatPane";
 import WalletPanel from "./WalletPanel";
 import ActivityPanel from "./ActivityPanel";
+import { animateIfMotion, cleanupAnime } from "@/lib/anime";
 
 const USER_CHAT_SUBTAB = "__user-chat__";
 type DashboardSidebarTab = "home" | "messages" | "contacts" | "explore" | "wallet" | "activity" | "bots";
@@ -138,10 +139,29 @@ export default function DashboardApp() {
   const initResolvedRef = useRef(false);
   const lastAccessTokenRef = useRef<string | null>(null);
   const lastMessagesDirectorySyncRef = useRef(0);
+  const mainContentRef = useRef<HTMLDivElement | null>(null);
+  const mainContentAnimationRef = useRef<ReturnType<typeof animateIfMotion>>(null);
+  const previousMainContentKeyRef = useRef<string | null>(null);
   const pathnameParts = useMemo(() => pathname.split("/").filter(Boolean), [pathname]);
   const routeSidebarTab = useMemo(() => getSidebarTabFromPathParts(pathnameParts), [pathnameParts]);
   const userChatAgentIdFromQuery = searchParams.get("agent_id");
   const shouldShowBootstrapSkeleton = !sessionStore.authResolved || sessionStore.authBootstrapping;
+  const primaryNavigationPending = Boolean(
+    uiStore.pendingPrimaryNavigation && pathname !== uiStore.pendingPrimaryNavigation.path,
+  );
+  const visibleSidebarTab = primaryNavigationPending
+    ? uiStore.pendingPrimaryNavigation?.tab ?? uiStore.sidebarTab
+    : routeSidebarTab;
+  const mainContentAnimationKey = [
+    primaryNavigationPending ? "pending" : "ready",
+    visibleSidebarTab,
+    uiStore.messagesPane,
+    uiStore.messagesShowRequests ? "requests" : "",
+    uiStore.openedRoomId ?? "",
+    uiStore.selectedContactKey ?? "",
+    uiStore.exploreView,
+    uiStore.contactsView,
+  ].join(":");
   // Human-first: never force-block on "no agent". Authed users always proceed
   // into /chats as their Human identity; creating an Agent is a later,
   // optional CTA. AgentGateModal is kept for manual entry points (account
@@ -207,6 +227,31 @@ export default function DashboardApp() {
       delete target.botcordDebugRealtime;
     };
   }, [supabase]);
+
+  useEffect(() => {
+    if (shouldShowBootstrapSkeleton) return;
+    const content = mainContentRef.current;
+    if (!content || previousMainContentKeyRef.current === mainContentAnimationKey) return;
+
+    previousMainContentKeyRef.current = mainContentAnimationKey;
+    cleanupAnime(mainContentAnimationRef.current);
+
+    let animation: ReturnType<typeof animateIfMotion> = null;
+    const frameId = window.requestAnimationFrame(() => {
+      animation = animateIfMotion(content, {
+        opacity: [0, 1],
+        translateY: [8, 0],
+        duration: 220,
+        ease: "out(3)",
+      });
+      mainContentAnimationRef.current = animation;
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      cleanupAnime(animation);
+    };
+  }, [mainContentAnimationKey, shouldShowBootstrapSkeleton]);
 
   useEffect(() => {
     let cancelled = false;
@@ -1069,13 +1114,6 @@ export default function DashboardApp() {
     || mobileMessagesShowsMain
     || mobileContactsShowsMain;
   const mainPaneClass = `min-h-0 min-w-0 flex-1 ${mobileShowsMain ? "" : "max-md:hidden"}`;
-  const primaryNavigationPending = Boolean(
-    uiStore.pendingPrimaryNavigation && pathname !== uiStore.pendingPrimaryNavigation.path,
-  );
-  const visibleSidebarTab = primaryNavigationPending
-    ? uiStore.pendingPrimaryNavigation?.tab ?? uiStore.sidebarTab
-    : routeSidebarTab;
-
   return (
     <div className="fixed inset-0 flex overflow-hidden bg-deep-black max-md:flex-col-reverse">
       <Sidebar
@@ -1084,7 +1122,7 @@ export default function DashboardApp() {
         mobileSecondaryOpen={uiStore.mobileSidebarOpen}
         onMobileSecondaryClose={uiStore.closeMobileSidebar}
       />
-      <div className={mainPaneClass}>
+      <div ref={mainContentRef} className={mainPaneClass}>
         {primaryNavigationPending ? (
           <DashboardTabSkeleton variant={visibleSidebarTab} />
         ) : visibleSidebarTab === "home" ? (

--- a/frontend/src/components/dashboard/DashboardMultiSelect.tsx
+++ b/frontend/src/components/dashboard/DashboardMultiSelect.tsx
@@ -2,13 +2,14 @@
 
 /**
  * [INPUT]: 受控的 option/value/onChange 与可选分组、搜索文案
- * [OUTPUT]: 对外提供 DashboardMultiSelect，渲染 BotCord dashboard 风格的可搜索多选下拉
+ * [OUTPUT]: 对外提供 DashboardMultiSelect，渲染带受控动效的 BotCord dashboard 风格可搜索多选下拉
  * [POS]: dashboard 表单和弹窗里的统一多选控件，替代分散的原生/临时多选列表
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
 
-import { type ReactNode, useEffect, useId, useMemo, useRef, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Check, ChevronDown, Search, X } from "lucide-react";
+import { animatePop, animateIfMotion, animeStagger, cleanupAnime } from "@/lib/anime";
 
 export interface DashboardMultiSelectOption {
   value: string;
@@ -60,7 +61,16 @@ export default function DashboardMultiSelect({
 }: DashboardMultiSelectProps) {
   const id = useId();
   const rootRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
+  const chipRefs = useRef(new Map<string, HTMLSpanElement>());
+  const selectedCheckRefs = useRef(new Map<string, HTMLSpanElement>());
+  const overflowChipRef = useRef<HTMLSpanElement>(null);
+  const selectedCountRef = useRef<HTMLSpanElement>(null);
+  const panelAnimationRef = useRef<ReturnType<typeof animateIfMotion>>(null);
+  const optionAnimationRef = useRef<ReturnType<typeof animateIfMotion>>(null);
+  const selectionAnimationRefs = useRef<Array<ReturnType<typeof animatePop>>>([]);
+  const previousValueRef = useRef(value);
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
 
@@ -100,6 +110,16 @@ export default function DashboardMultiSelect({
   }, [normalizedGroups, query]);
 
   const visibleCount = filteredGroups.reduce((sum, group) => sum + group.options.length, 0);
+  const visibleOptionKey = useMemo(
+    () => filteredGroups.flatMap((group) => group.options.map((option) => option.value)).join("\u0000"),
+    [filteredGroups],
+  );
+  const valueKey = useMemo(() => value.join("\u0000"), [value]);
+
+  const cleanupSelectionAnimations = useCallback(() => {
+    selectionAnimationRefs.current.forEach(cleanupAnime);
+    selectionAnimationRefs.current = [];
+  }, []);
 
   useEffect(() => {
     if (!open) return;
@@ -121,6 +141,122 @@ export default function DashboardMultiSelect({
     if (open) window.setTimeout(() => searchRef.current?.focus(), 0);
     else setQuery("");
   }, [open]);
+
+  useEffect(() => {
+    return () => {
+      cleanupAnime(panelAnimationRef.current);
+      cleanupAnime(optionAnimationRef.current);
+      cleanupSelectionAnimations();
+    };
+  }, [cleanupSelectionAnimations]);
+
+  useLayoutEffect(() => {
+    if (!open) {
+      cleanupAnime(panelAnimationRef.current);
+      cleanupAnime(optionAnimationRef.current);
+      panelAnimationRef.current = null;
+      optionAnimationRef.current = null;
+      return;
+    }
+
+    let panelAnimation: ReturnType<typeof animateIfMotion> = null;
+    const frameId = window.requestAnimationFrame(() => {
+      const panel = panelRef.current;
+      if (!panel) return;
+
+      cleanupAnime(panelAnimationRef.current);
+
+      panel.style.opacity = "0";
+      panel.style.transform = "translateY(6px) scale(0.985)";
+      panel.style.transformOrigin = "top center";
+
+      panelAnimation = animateIfMotion(panel, {
+        opacity: [0, 1],
+        translateY: [6, 0],
+        scale: [0.985, 1],
+        duration: 180,
+        ease: "out(3)",
+      });
+
+      if (!panelAnimation) {
+        panel.style.opacity = "1";
+        panel.style.transform = "translateY(0px) scale(1)";
+      }
+
+      panelAnimationRef.current = panelAnimation;
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      cleanupAnime(panelAnimation);
+      if (panelAnimationRef.current === panelAnimation) panelAnimationRef.current = null;
+    };
+  }, [open]);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+
+    let optionAnimation: ReturnType<typeof animateIfMotion> = null;
+    const frameId = window.requestAnimationFrame(() => {
+      const panel = panelRef.current;
+      if (!panel) return;
+
+      cleanupAnime(optionAnimationRef.current);
+
+      const optionNodes = Array.from(
+        panel.querySelectorAll<HTMLElement>("[data-dashboard-multi-option]"),
+      ).slice(0, 16);
+
+      if (optionNodes.length > 0) {
+        optionAnimation = animateIfMotion(optionNodes, {
+          opacity: [0, 1],
+          translateY: [4, 0],
+          scale: [0.985, 1],
+          delay: animeStagger(12, { start: 35 }),
+          duration: 170,
+          ease: "out(3)",
+        });
+
+        if (!optionAnimation) {
+          optionNodes.forEach((optionNode) => {
+            optionNode.style.opacity = "1";
+            optionNode.style.transform = "translateY(0px) scale(1)";
+          });
+        }
+      }
+
+      optionAnimationRef.current = optionAnimation;
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      cleanupAnime(optionAnimation);
+      if (optionAnimationRef.current === optionAnimation) optionAnimationRef.current = null;
+    };
+  }, [open, visibleOptionKey]);
+
+  useEffect(() => {
+    const previousValue = previousValueRef.current;
+    const previousSet = new Set(previousValue);
+    const addedValue = value.find((selectedValue) => !previousSet.has(selectedValue)) ?? null;
+    previousValueRef.current = value;
+
+    if (!addedValue) return;
+
+    const frameId = window.requestAnimationFrame(() => {
+      cleanupSelectionAnimations();
+
+      const targets = [
+        chipRefs.current.get(addedValue) ?? overflowChipRef.current,
+        selectedCountRef.current,
+        selectedCheckRefs.current.get(addedValue),
+      ].filter((target): target is HTMLElement => Boolean(target));
+
+      selectionAnimationRefs.current = targets.map((target) => animatePop(target));
+    });
+
+    return () => window.cancelAnimationFrame(frameId);
+  }, [cleanupSelectionAnimations, value, valueKey]);
 
   const toggle = (optionValue: string) => {
     const next = new Set(selectedSet);
@@ -150,13 +286,20 @@ export default function DashboardMultiSelect({
               {selectedOptions.slice(0, 3).map((option) => (
                 <span
                   key={option.value}
-                  className="max-w-[11rem] truncate rounded border border-neon-cyan/20 bg-neon-cyan/10 px-2 py-0.5 text-xs text-neon-cyan"
+                  ref={(node) => {
+                    if (node) chipRefs.current.set(option.value, node);
+                    else chipRefs.current.delete(option.value);
+                  }}
+                  className="inline-block max-w-[11rem] origin-center truncate rounded border border-neon-cyan/20 bg-neon-cyan/10 px-2 py-0.5 text-xs text-neon-cyan"
                 >
                   {option.label}
                 </span>
               ))}
               {selectedOptions.length > 3 ? (
-                <span className="rounded border border-glass-border bg-deep-black-light px-2 py-0.5 text-xs text-text-secondary">
+                <span
+                  ref={overflowChipRef}
+                  className="inline-block origin-center rounded border border-glass-border bg-deep-black-light px-2 py-0.5 text-xs text-text-secondary"
+                >
                   +{selectedOptions.length - 3}
                 </span>
               ) : null}
@@ -164,13 +307,16 @@ export default function DashboardMultiSelect({
           )}
         </span>
         <span className="flex shrink-0 items-center gap-2">
-          <span className="text-[11px] text-text-secondary">{selectedLabel(selectedOptions.length)}</span>
+          <span ref={selectedCountRef} className="min-w-[4.5rem] origin-center text-right text-[11px] text-text-secondary">
+            {selectedLabel(selectedOptions.length)}
+          </span>
           <ChevronDown className={`h-4 w-4 text-text-secondary transition-transform ${open ? "rotate-180" : ""}`} />
         </span>
       </button>
 
       {open ? (
         <div
+          ref={panelRef}
           id={`${id}-panel`}
           className={`absolute left-0 right-0 z-40 mt-2 overflow-hidden rounded-xl border border-glass-border bg-deep-black-light shadow-2xl shadow-black/40 ${panelClassName}`}
         >
@@ -217,12 +363,17 @@ export default function DashboardMultiSelect({
                         role="option"
                         aria-selected={selected}
                         onClick={() => toggle(option.value)}
+                        data-dashboard-multi-option
                         className={`flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors ${
                           selected ? "bg-neon-cyan/10 text-neon-cyan" : "text-text-primary hover:bg-glass-bg"
                         }`}
                       >
                         <span
-                          className={`flex h-4 w-4 shrink-0 items-center justify-center rounded border ${
+                          ref={(node) => {
+                            if (node && selected) selectedCheckRefs.current.set(option.value, node);
+                            else selectedCheckRefs.current.delete(option.value);
+                          }}
+                          className={`flex h-4 w-4 shrink-0 origin-center items-center justify-center rounded border ${
                             selected
                               ? "border-neon-cyan bg-neon-cyan text-deep-black"
                               : "border-glass-border bg-deep-black-light"

--- a/frontend/src/components/dashboard/DashboardSelect.tsx
+++ b/frontend/src/components/dashboard/DashboardSelect.tsx
@@ -2,13 +2,14 @@
 
 /**
  * [INPUT]: 受控 value/options/onChange 与可选图标、占位文案
- * [OUTPUT]: DashboardSelect — dashboard 风格的单选下拉控件，替代弹窗中的原生 select
+ * [OUTPUT]: DashboardSelect — 带受控动效的 dashboard 风格单选下拉控件，替代弹窗中的原生 select
  * [POS]: dashboard 表单和弹窗里的统一单选控件
  * [PROTOCOL]: 变更时更新此头部
  */
 
-import { type ReactNode, useEffect, useId, useMemo, useRef, useState } from "react";
+import { type ReactNode, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Check, ChevronDown } from "lucide-react";
+import { animatePop, animateIfMotion, animeStagger, cleanupAnime, prefersReducedMotion } from "@/lib/anime";
 
 export interface DashboardSelectOption {
   value: string;
@@ -43,12 +44,19 @@ export default function DashboardSelect({
   const id = useId();
   const rootRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const selectedCheckRef = useRef<HTMLSpanElement>(null);
+  const panelAnimationRef = useRef<ReturnType<typeof animateIfMotion>>(null);
+  const optionAnimationRef = useRef<ReturnType<typeof animateIfMotion>>(null);
+  const checkAnimationRef = useRef<ReturnType<typeof animatePop>>(null);
+  const selectCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [open, setOpen] = useState(false);
 
   const selected = useMemo(
     () => options.find((option) => option.value === value) ?? null,
     [options, value],
   );
+  const optionKey = useMemo(() => options.map((option) => option.value).join("\u0000"), [options]);
 
   useEffect(() => {
     if (!open) return;
@@ -68,6 +76,124 @@ export default function DashboardSelect({
       document.removeEventListener("keydown", handleKeyDown);
     };
   }, [open]);
+
+  useEffect(() => {
+    if (open || !selectCloseTimerRef.current) return;
+    clearTimeout(selectCloseTimerRef.current);
+    selectCloseTimerRef.current = null;
+  }, [open]);
+
+  useEffect(() => {
+    return () => {
+      if (selectCloseTimerRef.current) clearTimeout(selectCloseTimerRef.current);
+      cleanupAnime(panelAnimationRef.current);
+      cleanupAnime(optionAnimationRef.current);
+      cleanupAnime(checkAnimationRef.current);
+    };
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!open) {
+      cleanupAnime(panelAnimationRef.current);
+      cleanupAnime(optionAnimationRef.current);
+      panelAnimationRef.current = null;
+      optionAnimationRef.current = null;
+      return;
+    }
+
+    let panelAnimation: ReturnType<typeof animateIfMotion> = null;
+    let optionAnimation: ReturnType<typeof animateIfMotion> = null;
+    const frameId = window.requestAnimationFrame(() => {
+      const panel = panelRef.current;
+      if (!panel) return;
+
+      cleanupAnime(panelAnimationRef.current);
+      cleanupAnime(optionAnimationRef.current);
+
+      panel.style.opacity = "0";
+      panel.style.transform = "translateY(6px) scale(0.985)";
+      panel.style.transformOrigin = "top center";
+
+      panelAnimation = animateIfMotion(panel, {
+        opacity: [0, 1],
+        translateY: [6, 0],
+        scale: [0.985, 1],
+        duration: 180,
+        ease: "out(3)",
+      });
+
+      if (!panelAnimation) {
+        panel.style.opacity = "1";
+        panel.style.transform = "translateY(0px) scale(1)";
+      }
+
+      const optionNodes = Array.from(
+        panel.querySelectorAll<HTMLElement>("[data-dashboard-select-option]"),
+      ).slice(0, 14);
+
+      if (optionNodes.length > 0) {
+        optionAnimation = animateIfMotion(optionNodes, {
+          opacity: [0, 1],
+          translateY: [4, 0],
+          scale: [0.985, 1],
+          delay: animeStagger(12, { start: 35 }),
+          duration: 170,
+          ease: "out(3)",
+        });
+
+        if (!optionAnimation) {
+          optionNodes.forEach((optionNode) => {
+            optionNode.style.opacity = "1";
+            optionNode.style.transform = "translateY(0px) scale(1)";
+          });
+        }
+      }
+
+      panelAnimationRef.current = panelAnimation;
+      optionAnimationRef.current = optionAnimation;
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      cleanupAnime(panelAnimation);
+      cleanupAnime(optionAnimation);
+      if (panelAnimationRef.current === panelAnimation) panelAnimationRef.current = null;
+      if (optionAnimationRef.current === optionAnimation) optionAnimationRef.current = null;
+    };
+  }, [open, optionKey]);
+
+  useEffect(() => {
+    if (!open || !value) return;
+
+    const frameId = window.requestAnimationFrame(() => {
+      const selectedCheck = selectedCheckRef.current;
+      if (!selectedCheck) return;
+
+      cleanupAnime(checkAnimationRef.current);
+      checkAnimationRef.current = animatePop(selectedCheck);
+    });
+
+    return () => window.cancelAnimationFrame(frameId);
+  }, [open, value]);
+
+  const closeAfterSelection = (delayForCheckPop: boolean) => {
+    if (selectCloseTimerRef.current) {
+      clearTimeout(selectCloseTimerRef.current);
+      selectCloseTimerRef.current = null;
+    }
+
+    if (!delayForCheckPop) {
+      setOpen(false);
+      buttonRef.current?.focus();
+      return;
+    }
+
+    selectCloseTimerRef.current = setTimeout(() => {
+      selectCloseTimerRef.current = null;
+      setOpen(false);
+      buttonRef.current?.focus();
+    }, 130);
+  };
 
   return (
     <div ref={rootRef} className={`relative ${className}`}>
@@ -99,6 +225,7 @@ export default function DashboardSelect({
 
       {open ? (
         <div
+          ref={panelRef}
           id={`${id}-panel`}
           role="listbox"
           className={`absolute left-0 right-0 z-50 mt-2 max-h-64 overflow-y-auto rounded-xl border border-glass-border bg-deep-black-light py-1 shadow-2xl shadow-black/40 ${panelClassName}`}
@@ -117,15 +244,19 @@ export default function DashboardSelect({
                   disabled={option.disabled}
                   onClick={() => {
                     if (option.disabled) return;
+                    const shouldDelayClose = option.value !== value && !prefersReducedMotion();
                     onChange(option.value);
-                    setOpen(false);
-                    buttonRef.current?.focus();
+                    closeAfterSelection(shouldDelayClose);
                   }}
+                  data-dashboard-select-option
                   className={`flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-45 ${
                     isSelected ? "bg-neon-cyan/10 text-neon-cyan" : "text-text-primary hover:bg-glass-bg"
                   }`}
                 >
-                  <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+                  <span
+                    ref={isSelected ? selectedCheckRef : undefined}
+                    className="flex h-4 w-4 shrink-0 origin-center items-center justify-center"
+                  >
                     {isSelected ? <Check className="h-3.5 w-3.5" /> : null}
                   </span>
                   <span className="min-w-0 flex-1">

--- a/frontend/src/components/dashboard/ForwardModal.tsx
+++ b/frontend/src/components/dashboard/ForwardModal.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { FileArchive, Loader2, MessageSquare, Users, User, X } from "lucide-react";
+import { CheckCircle2, FileArchive, Loader2, MessageSquare, Users, User, X } from "lucide-react";
 import { api, apiFetch, getActiveIdentity } from "@/lib/api";
+import { animatePop, cleanupAnime, createTimelineIfMotion } from "@/lib/anime";
 import type { Attachment } from "@/lib/types";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
@@ -30,10 +31,18 @@ interface ForwardModalProps {
 }
 
 export default function ForwardModal({ quoteText, sourceFile, onClose }: ForwardModalProps) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const statusRef = useRef<HTMLParagraphElement>(null);
+  const modalAnimationRef = useRef<ReturnType<typeof createTimelineIfMotion>>(null);
+  const successAnimationRef = useRef<ReturnType<typeof animatePop>>(null);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const closingRef = useRef(false);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [sending, setSending] = useState(false);
   const [done, setDone] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [closing, setClosing] = useState(false);
   const router = useRouter();
   const {
     setFocusedRoomId,
@@ -74,6 +83,124 @@ export default function ForwardModal({ quoteText, sourceFile, onClose }: Forward
         sublabel: r.room_id,
       })),
   ];
+
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+      cleanupAnime(modalAnimationRef.current);
+      cleanupAnime(successAnimationRef.current);
+    };
+  }, []);
+
+  useLayoutEffect(() => {
+    const overlay = overlayRef.current;
+    const panel = panelRef.current;
+    if (!overlay || !panel) return;
+
+    overlay.style.opacity = "0";
+    panel.style.opacity = "0";
+    panel.style.transform = "translateY(10px) scale(0.985)";
+    panel.style.transformOrigin = "center center";
+
+    const timeline = createTimelineIfMotion({
+      onComplete: () => {
+        if (modalAnimationRef.current === timeline) modalAnimationRef.current = null;
+      },
+    });
+    modalAnimationRef.current = timeline;
+
+    if (!timeline) {
+      overlay.style.opacity = "1";
+      panel.style.opacity = "1";
+      panel.style.transform = "translateY(0px) scale(1)";
+      return;
+    }
+
+    timeline.add(overlay, {
+      opacity: [0, 1],
+      duration: 150,
+      ease: "linear",
+    }, 0);
+    timeline.add(panel, {
+      opacity: [0, 1],
+      translateY: [10, 0],
+      scale: [0.985, 1],
+      duration: 220,
+      ease: "out(3)",
+    }, 20);
+
+    return () => cleanupAnime(timeline);
+  }, []);
+
+  const closeModal = useCallback(() => {
+    if (closingRef.current) return;
+
+    const overlay = overlayRef.current;
+    const panel = panelRef.current;
+    if (!overlay || !panel) {
+      onClose();
+      return;
+    }
+
+    closingRef.current = true;
+    setClosing(true);
+    if (closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+    modalAnimationRef.current?.pause();
+
+    const finishClose = () => {
+      modalAnimationRef.current = null;
+      onClose();
+    };
+
+    const timeline = createTimelineIfMotion({
+      onComplete: finishClose,
+    });
+    modalAnimationRef.current = timeline;
+
+    if (!timeline) {
+      finishClose();
+      return;
+    }
+
+    timeline.add(panel, {
+      opacity: 0,
+      translateY: 8,
+      scale: 0.985,
+      duration: 150,
+      ease: "in(2)",
+    }, 0);
+    timeline.add(overlay, {
+      opacity: 0,
+      duration: 140,
+      ease: "linear",
+    }, 0);
+  }, [onClose]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") closeModal();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [closeModal]);
+
+  useEffect(() => {
+    if (!done) return;
+
+    const frameId = window.requestAnimationFrame(() => {
+      const status = statusRef.current;
+      if (!status) return;
+
+      cleanupAnime(successAnimationRef.current);
+      successAnimationRef.current = animatePop(status);
+    });
+
+    return () => window.cancelAnimationFrame(frameId);
+  }, [done]);
 
   const handleSend = async () => {
     if (selected.size === 0 || sending) return;
@@ -126,7 +253,7 @@ export default function ForwardModal({ quoteText, sourceFile, onClose }: Forward
         setOpenedRoomId(roomId);
         router.push("/chats/messages");
       }
-      setTimeout(onClose, 800);
+      closeTimerRef.current = setTimeout(closeModal, 800);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "发送失败");
       setSending(false);
@@ -135,17 +262,28 @@ export default function ForwardModal({ quoteText, sourceFile, onClose }: Forward
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      ref={overlayRef}
+      className={`fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`}
       onClick={(e) => {
         e.stopPropagation();
-        if (e.target === e.currentTarget) onClose();
+        if (e.target === e.currentTarget) closeModal();
       }}
     >
-      <div className="w-full max-w-sm rounded-xl border border-zinc-700 bg-zinc-900 shadow-2xl">
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        className="w-full max-w-sm rounded-xl border border-zinc-700 bg-zinc-900 shadow-2xl"
+      >
         {/* Header */}
         <div className="flex items-center justify-between border-b border-zinc-800 px-4 py-3">
           <span className="text-sm font-medium text-zinc-200">转发消息</span>
-          <button type="button" onClick={onClose} className="text-zinc-500 hover:text-zinc-300 transition-colors">
+          <button
+            type="button"
+            onClick={closeModal}
+            className="text-zinc-500 hover:text-zinc-300 transition-colors"
+            aria-label="Close forward modal"
+          >
             <X className="h-4 w-4" />
           </button>
         </div>
@@ -203,7 +341,12 @@ export default function ForwardModal({ quoteText, sourceFile, onClose }: Forward
         {/* Footer */}
         <div className="flex items-center justify-between border-t border-zinc-800 px-4 py-3">
           {error && <p className="text-[11px] text-red-400">{error}</p>}
-          {done && <p className="text-[11px] text-emerald-400">已发送</p>}
+          {done && (
+            <p ref={statusRef} className="flex origin-center items-center gap-1.5 text-[11px] text-emerald-400">
+              <CheckCircle2 className="h-3.5 w-3.5" />
+              已发送
+            </p>
+          )}
           {!error && !done && (
             <span className="text-[11px] text-zinc-500">
               {selected.size > 0 ? `已选 ${selected.size} 个` : "选择发送目标"}

--- a/frontend/src/components/dashboard/HumanCardModal.tsx
+++ b/frontend/src/components/dashboard/HumanCardModal.tsx
@@ -2,16 +2,18 @@
 
 /**
  * [INPUT]: 依赖 human 资料与联系人关系状态，依赖 i18n 提供文案
- * [OUTPUT]: 对外提供 HumanCardModal 统一 human 详情模态框
+ * [OUTPUT]: 对外提供带 animejs 进出场动效的 HumanCardModal 统一 human 详情模态框
  * [POS]: dashboard 通用弹层组件，被 Explore humans 目录复用
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
 
 import { useLanguage } from "@/lib/i18n";
 import { MobileBotCordLoading } from "@/components/ui/BotCordLoader";
+import { animeStagger, cleanupAnime, createTimelineIfMotion } from "@/lib/anime";
 import { exploreUi } from "@/lib/i18n/translations/dashboard";
 import type { PublicHumanProfile } from "@/lib/types";
 import { Loader2 } from "lucide-react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 
 interface HumanCardModalProps {
   isOpen: boolean;
@@ -27,6 +29,12 @@ interface HumanCardModalProps {
   onSendFriendRequest: () => void;
   onSendMessage?: () => void;
   onRetry?: () => void;
+}
+
+const PROFILE_MODAL_PART_SELECTOR = "[data-profile-modal-part]";
+
+function getModalParts(panel: HTMLElement | null): HTMLElement[] {
+  return panel ? Array.from(panel.querySelectorAll<HTMLElement>(PROFILE_MODAL_PART_SELECTOR)) : [];
 }
 
 export default function HumanCardModal({
@@ -46,15 +54,189 @@ export default function HumanCardModal({
 }: HumanCardModalProps) {
   const locale = useLanguage();
   const t = exploreUi[locale];
+  const [shouldRender, setShouldRender] = useState(isOpen);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const animationRef = useRef<ReturnType<typeof createTimelineIfMotion>>(null);
+  const closingRef = useRef(false);
+  const closeRequestedRef = useRef(false);
 
-  if (!isOpen) return null;
+  const playExit = useCallback((afterClose?: () => void) => {
+    if (closingRef.current) return;
+
+    const overlay = overlayRef.current;
+    const panel = panelRef.current;
+    const parts = getModalParts(panel);
+
+    const finishClose = () => {
+      closingRef.current = false;
+      animationRef.current = null;
+      setShouldRender(false);
+      afterClose?.();
+    };
+
+    if (!panel) {
+      finishClose();
+      return;
+    }
+
+    closingRef.current = true;
+    animationRef.current?.pause();
+
+    const timeline = createTimelineIfMotion({
+      onComplete: finishClose,
+    });
+    animationRef.current = timeline;
+
+    if (!timeline) {
+      finishClose();
+      return;
+    }
+
+    if (parts.length) {
+      timeline.add(parts, {
+        opacity: 0,
+        translateY: -4,
+        duration: 110,
+        delay: animeStagger(10, { reversed: true }),
+        ease: "in(2)",
+      }, 0);
+    }
+
+    timeline.add(panel, {
+      opacity: 0,
+      scale: 0.98,
+      translateY: 8,
+      duration: 170,
+      ease: "in(2)",
+    }, parts.length ? 35 : 0);
+
+    if (overlay) {
+      timeline.add(overlay, {
+        opacity: 0,
+        duration: 140,
+        ease: "linear",
+      }, parts.length ? 35 : 0);
+    }
+  }, []);
+
+  const handleClose = useCallback(() => {
+    closeRequestedRef.current = true;
+    playExit(onClose);
+  }, [onClose, playExit]);
+
+  useLayoutEffect(() => {
+    if (isOpen && !shouldRender && !closeRequestedRef.current) {
+      setShouldRender(true);
+    }
+  }, [isOpen, shouldRender]);
+
+  useLayoutEffect(() => {
+    if (!shouldRender || !isOpen || closeRequestedRef.current) return;
+
+    closingRef.current = false;
+    cleanupAnime(animationRef.current);
+
+    const overlay = overlayRef.current;
+    const panel = panelRef.current;
+    const parts = getModalParts(panel);
+    if (!panel) return;
+
+    if (overlay) overlay.style.opacity = "0";
+    panel.style.opacity = "0";
+    panel.style.transform = "translateY(14px) scale(0.96)";
+    parts.forEach((part) => {
+      part.style.opacity = "0";
+      part.style.transform = "translateY(8px)";
+    });
+
+    const timeline = createTimelineIfMotion({
+      onComplete: () => {
+        if (animationRef.current === timeline) animationRef.current = null;
+      },
+    });
+    animationRef.current = timeline;
+
+    if (!timeline) {
+      if (overlay) overlay.style.opacity = "1";
+      panel.style.opacity = "1";
+      panel.style.transform = "translateY(0px) scale(1)";
+      parts.forEach((part) => {
+        part.style.opacity = "1";
+        part.style.transform = "translateY(0px)";
+      });
+      return;
+    }
+
+    if (overlay) {
+      timeline.add(overlay, {
+        opacity: [0, 1],
+        duration: 180,
+        ease: "linear",
+      }, 0);
+    }
+
+    timeline.add(panel, {
+      opacity: [0, 1],
+      scale: [0.96, 1],
+      translateY: [14, 0],
+      duration: 260,
+      ease: "out(3)",
+    }, 0);
+
+    if (parts.length) {
+      timeline.add(parts, {
+        opacity: [0, 1],
+        translateY: [8, 0],
+        duration: 210,
+        delay: animeStagger(24),
+        ease: "out(3)",
+      }, 75);
+    }
+
+    return () => cleanupAnime(timeline);
+  }, [shouldRender, isOpen]);
+
+  useLayoutEffect(() => {
+    if (!isOpen) {
+      closeRequestedRef.current = false;
+      if (shouldRender) playExit();
+    }
+  }, [isOpen, playExit, shouldRender]);
+
+  useEffect(() => {
+    if (!shouldRender) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") handleClose();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleClose, shouldRender]);
+
+  useEffect(() => () => cleanupAnime(animationRef.current), []);
+
+  if (!shouldRender) return null;
 
   const initials = human?.display_name?.slice(0, 1).toUpperCase() ?? "H";
 
   return (
-    <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/60 p-4">
-      <div className="w-full max-w-md rounded-2xl border border-glass-border bg-deep-black-light p-5">
-        <div className="mb-3 flex items-start justify-between">
+    <div
+      ref={overlayRef}
+      className="fixed inset-0 z-40 flex items-center justify-center bg-black/60 p-4"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) handleClose();
+      }}
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        className="w-full max-w-md rounded-2xl border border-glass-border bg-deep-black-light p-5"
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <div data-profile-modal-part className="mb-3 flex items-start justify-between">
           <div className="flex items-center gap-3">
             {human?.avatar_url ? (
               // eslint-disable-next-line @next/next/no-img-element
@@ -74,7 +256,7 @@ export default function HumanCardModal({
             </div>
           </div>
           <button
-            onClick={onClose}
+            onClick={handleClose}
             className="rounded border border-glass-border px-2 py-0.5 text-xs text-text-secondary hover:text-text-primary"
           >
             {t.close}
@@ -82,7 +264,7 @@ export default function HumanCardModal({
         </div>
 
         {loading ? (
-          <div className="space-y-3 py-2">
+          <div data-profile-modal-part className="space-y-3 py-2">
             <MobileBotCordLoading
               label="Loading profile..."
               className="justify-start"
@@ -90,7 +272,7 @@ export default function HumanCardModal({
             />
           </div>
         ) : error ? (
-          <div className="space-y-3 py-2">
+          <div data-profile-modal-part className="space-y-3 py-2">
             <p className="text-sm text-red-400">{error}</p>
             <button
               onClick={onRetry}
@@ -102,20 +284,22 @@ export default function HumanCardModal({
         ) : (
           <>
             {isSelf ? (
-              <p className="text-xs text-text-secondary">{t.thisIsYou}</p>
+              <p data-profile-modal-part className="text-xs text-text-secondary">{t.thisIsYou}</p>
             ) : requestSent ? (
-              <p className="text-xs text-neon-green">{t.friendRequestSent}</p>
+              <p data-profile-modal-part className="text-xs text-neon-green">{t.friendRequestSent}</p>
             ) : alreadyInContacts ? (
               <button
+                data-profile-modal-part
                 onClick={onSendMessage}
                 className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-green/40 bg-neon-green/10 py-2 text-xs font-medium text-neon-green transition-colors hover:bg-neon-green/20"
               >
                 {t.sendMessage}
               </button>
             ) : requestAlreadyPending ? (
-              <p className="text-xs text-neon-cyan">{t.friendRequestAlreadyPending}</p>
+              <p data-profile-modal-part className="text-xs text-neon-cyan">{t.friendRequestAlreadyPending}</p>
             ) : (
               <button
+                data-profile-modal-part
                 onClick={onSendFriendRequest}
                 disabled={sendingFriendRequest}
                 className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-green/40 bg-neon-green/10 py-2 text-xs font-medium text-neon-green transition-colors hover:bg-neon-green/20 disabled:cursor-not-allowed disabled:opacity-60"

--- a/frontend/src/components/dashboard/MessageBubble.tsx
+++ b/frontend/src/components/dashboard/MessageBubble.tsx
@@ -9,6 +9,7 @@ import ForwardModal from "./ForwardModal";
 import ReplyQuoteBlock from "./ReplyQuoteBlock";
 import { emitJumpToMessage } from "./messageNavigation";
 import RuntimeErrorDetailsDialog from "./RuntimeErrorDetailsDialog";
+import { animateIfMotion, animeStagger, cleanupAnime } from "@/lib/anime";
 import type { DashboardMessage, Attachment, MessageStatusReaction } from "@/lib/types";
 import { canReplyToDashboardMessage } from "@/lib/dashboard-message-actions";
 import { useLanguage } from '@/lib/i18n';
@@ -66,9 +67,45 @@ const ACTION_MENU_ITEM_HEIGHT = 30;
 const ACTION_MENU_VERTICAL_PADDING = 8;
 const ACTION_MENU_GAP = 6;
 const ACTION_MENU_VIEWPORT_PADDING = 8;
+const ACTION_MENU_ITEM_SELECTOR = "[data-message-action-item]";
+
+type MotionAnimation = ReturnType<typeof animateIfMotion>;
 
 function shouldCollapseMessage(text: string): boolean {
   return text.length > COLLAPSE_TEXT_LENGTH || text.split(/\r\n|\r|\n/).length > COLLAPSE_LINE_COUNT;
+}
+
+function runStatusBadgeMotion(
+  target: HTMLElement,
+  animationRef: { current: MotionAnimation },
+  failed: boolean,
+) {
+  cleanupAnime(animationRef.current);
+  const animation = animateIfMotion(target, failed ? {
+    translateX: [0, -3, 3, -2, 2, 0],
+    scale: [1, 1.04, 1],
+    boxShadow: [
+      "0 0 0 rgba(248, 113, 113, 0)",
+      "0 0 14px rgba(248, 113, 113, 0.34)",
+      "0 0 0 rgba(248, 113, 113, 0)",
+    ],
+    duration: 360,
+    ease: "out(3)",
+    onComplete: (finishedAnimation) => {
+      cleanupAnime(finishedAnimation);
+      if (animationRef.current === finishedAnimation) animationRef.current = null;
+    },
+  } : {
+    scale: [1, 1.08, 1],
+    translateY: [0, -2, 0],
+    duration: 260,
+    ease: "out(3)",
+    onComplete: (finishedAnimation) => {
+      cleanupAnime(finishedAnimation);
+      if (animationRef.current === finishedAnimation) animationRef.current = null;
+    },
+  });
+  animationRef.current = animation;
 }
 
 function CollapsibleMessageBody({
@@ -139,6 +176,42 @@ function useStateConfig() {
   return config;
 }
 
+function MessageStateBadge({
+  state,
+  label,
+  color,
+  icon,
+}: {
+  state: string;
+  label: string;
+  color: string;
+  icon: string;
+}) {
+  const badgeRef = useRef<HTMLSpanElement>(null);
+  const previousStateRef = useRef(state);
+  const animationRef = useRef<MotionAnimation>(null);
+
+  useEffect(() => {
+    if (previousStateRef.current === state) return;
+    previousStateRef.current = state;
+    const badge = badgeRef.current;
+    if (!badge) return;
+    runStatusBadgeMotion(badge, animationRef, state === "failed");
+  }, [state]);
+
+  useEffect(() => () => cleanupAnime(animationRef.current), []);
+
+  return (
+    <span
+      ref={badgeRef}
+      className={`inline-flex items-center gap-0.5 rounded border px-1 py-px text-[10px] font-medium ${color}`}
+    >
+      <span className="text-[8px]">{icon}</span>
+      {label}
+    </span>
+  );
+}
+
 function StateCountsBadges({ counts }: { counts: Record<string, number> }) {
   const stateConfig = useStateConfig();
   const total = Object.values(counts).reduce((a, b) => a + b, 0);
@@ -146,9 +219,31 @@ function StateCountsBadges({ counts }: { counts: Record<string, number> }) {
   const entries = order
     .filter((s) => counts[s] && counts[s] > 0)
     .map((s) => ({ state: s, count: counts[s] }));
+  const signature = entries.map(({ state, count }) => `${state}:${count}/${total}`).join("|");
+  const failedCount = counts.failed ?? 0;
+  const groupRef = useRef<HTMLSpanElement>(null);
+  const previousSignatureRef = useRef(signature);
+  const previousFailedCountRef = useRef(failedCount);
+  const animationRef = useRef<MotionAnimation>(null);
+
+  useEffect(() => {
+    if (previousSignatureRef.current === signature) {
+      previousFailedCountRef.current = failedCount;
+      return;
+    }
+
+    const shouldShake = failedCount > previousFailedCountRef.current;
+    previousSignatureRef.current = signature;
+    previousFailedCountRef.current = failedCount;
+    const group = groupRef.current;
+    if (!group) return;
+    runStatusBadgeMotion(group, animationRef, shouldShake);
+  }, [failedCount, signature]);
+
+  useEffect(() => () => cleanupAnime(animationRef.current), []);
 
   return (
-    <span className="inline-flex items-center gap-1">
+    <span ref={groupRef} className="inline-flex items-center gap-1">
       {entries.map(({ state, count }) => {
         const sc = stateConfig[state];
         if (!sc) return null;
@@ -241,7 +336,11 @@ function MentionChip({
   onSelectHuman: (humanId: string, displayName: string) => void;
 }) {
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const tooltipRef = useRef<HTMLSpanElement>(null);
+  const tooltipAnimationRef = useRef<MotionAnimation>(null);
+  const tooltipOpenedRef = useRef(false);
   const [tooltipPosition, setTooltipPosition] = useState<{ left: number; top: number } | null>(null);
+  const tooltipOpen = Boolean(tooltipPosition);
   const isHuman = id.startsWith("hu_");
   const isAgent = id.startsWith("ag_");
   const ownedAgents = useDashboardSessionStore((state) => state.ownedAgents);
@@ -304,6 +403,46 @@ function MentionChip({
     };
   }, [tooltipPosition, updateTooltipPosition]);
 
+  useLayoutEffect(() => {
+    if (!tooltipOpen) {
+      tooltipOpenedRef.current = false;
+      cleanupAnime(tooltipAnimationRef.current);
+      tooltipAnimationRef.current = null;
+      return;
+    }
+
+    if (tooltipOpenedRef.current) return;
+    const tooltip = tooltipRef.current;
+    if (!tooltip) return;
+
+    tooltipOpenedRef.current = true;
+    cleanupAnime(tooltipAnimationRef.current);
+    tooltip.style.opacity = "0";
+    tooltip.style.transform = "translateY(4px) scale(0.98)";
+    tooltip.style.transformOrigin = "top left";
+
+    const animation = animateIfMotion(tooltip, {
+      opacity: [0, 1],
+      translateY: [4, 0],
+      scale: [0.98, 1],
+      duration: 170,
+      ease: "out(3)",
+    });
+    tooltipAnimationRef.current = animation;
+
+    if (!animation) {
+      tooltip.style.opacity = "1";
+      tooltip.style.transform = "translateY(0px) scale(1)";
+      return;
+    }
+
+    return () => {
+      tooltipOpenedRef.current = false;
+      cleanupAnime(tooltipAnimationRef.current);
+      tooltipAnimationRef.current = null;
+    };
+  }, [tooltipOpen]);
+
   const handleClick = () => {
     if (isHuman) {
       onSelectHuman(id, displayName);
@@ -334,6 +473,7 @@ function MentionChip({
       </button>
       {tooltipPosition && typeof document !== "undefined" && createPortal(
         <span
+          ref={tooltipRef}
           className="pointer-events-none fixed z-[9999] w-64 rounded-lg border border-glass-border bg-zinc-950/95 p-3 text-left shadow-xl shadow-black/30"
           style={{ left: tooltipPosition.left, top: tooltipPosition.top }}
         >
@@ -434,6 +574,9 @@ function MessageBubble({
   const [recallPending, setRecallPending] = useState(false);
   const moreButtonRef = useRef<HTMLButtonElement>(null);
   const actionMenuRef = useRef<HTMLDivElement>(null);
+  const actionMenuAnimationRef = useRef<MotionAnimation>(null);
+  const actionMenuItemsAnimationRef = useRef<MotionAnimation>(null);
+  const actionMenuOpenedRef = useRef(false);
   const locale = useLanguage();
   const selectAgent = useDashboardChatStore((state) => state.selectAgent);
   const getRoomSummary = useDashboardChatStore((state) => state.getRoomSummary);
@@ -702,6 +845,76 @@ function MessageBubble({
     };
   }, [menuOpen]);
 
+  const menuVisible = menuOpen && Boolean(menuPosition);
+
+  useLayoutEffect(() => {
+    if (!menuVisible) {
+      actionMenuOpenedRef.current = false;
+      cleanupAnime(actionMenuAnimationRef.current);
+      cleanupAnime(actionMenuItemsAnimationRef.current);
+      actionMenuAnimationRef.current = null;
+      actionMenuItemsAnimationRef.current = null;
+      return;
+    }
+
+    if (actionMenuOpenedRef.current) return;
+    const menu = actionMenuRef.current;
+    if (!menu) return;
+
+    actionMenuOpenedRef.current = true;
+    cleanupAnime(actionMenuAnimationRef.current);
+    cleanupAnime(actionMenuItemsAnimationRef.current);
+    menu.style.opacity = "0";
+    menu.style.transform = "translateY(-4px) scale(0.98)";
+    menu.style.transformOrigin = isOwn ? "top right" : "top left";
+
+    const items = Array.from(menu.querySelectorAll<HTMLElement>(ACTION_MENU_ITEM_SELECTOR));
+    items.forEach((item) => {
+      item.style.opacity = "0";
+      item.style.transform = "translateY(3px) scale(0.98)";
+    });
+
+    const menuAnimation = animateIfMotion(menu, {
+      opacity: [0, 1],
+      translateY: [-4, 0],
+      scale: [0.98, 1],
+      duration: 170,
+      ease: "out(3)",
+    });
+    actionMenuAnimationRef.current = menuAnimation;
+
+    const itemsAnimation = items.length > 0
+      ? animateIfMotion(items, {
+        opacity: [0, 1],
+        translateY: [3, 0],
+        scale: [0.98, 1],
+        delay: animeStagger(16, { start: 28 }),
+        duration: 180,
+        ease: "out(3)",
+      })
+      : null;
+    actionMenuItemsAnimationRef.current = itemsAnimation;
+
+    if (!menuAnimation) {
+      menu.style.opacity = "1";
+      menu.style.transform = "translateY(0px) scale(1)";
+    }
+    if (!itemsAnimation) {
+      items.forEach((item) => {
+        item.style.opacity = "1";
+        item.style.transform = "translateY(0px) scale(1)";
+      });
+    }
+
+    return () => {
+      actionMenuOpenedRef.current = false;
+      cleanupAnime(actionMenuAnimationRef.current);
+      cleanupAnime(actionMenuItemsAnimationRef.current);
+      actionMenuAnimationRef.current = null;
+      actionMenuItemsAnimationRef.current = null;
+    };
+  }, [isOwn, menuVisible]);
+
   const sideAvatar = !fullWidth && (
     <SenderAvatar
       senderId={message.sender_id}
@@ -742,6 +955,7 @@ function MessageBubble({
         >
           {canQuoteReply && (
             <button
+              data-message-action-item
               type="button"
               onMouseDown={(e) => { e.preventDefault(); handleReplyClick(); }}
               className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100 transition-colors"
@@ -752,6 +966,7 @@ function MessageBubble({
           )}
           {displayText && (
             <button
+              data-message-action-item
               type="button"
               onMouseDown={(e) => { e.preventDefault(); handleForwardClick(); }}
               className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100 transition-colors"
@@ -762,6 +977,7 @@ function MessageBubble({
           )}
           {canRecall && (
             <button
+              data-message-action-item
               type="button"
               disabled={recallPending}
               onMouseDown={(e) => { e.preventDefault(); void handleRecallClick(); }}
@@ -773,6 +989,7 @@ function MessageBubble({
           )}
           {displayText && (
             <button
+              data-message-action-item
               type="button"
               onMouseDown={(e) => { e.preventDefault(); void handleCopyClick(); }}
               className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100 transition-colors"
@@ -959,10 +1176,12 @@ function MessageBubble({
               {message.state_counts && Object.keys(message.state_counts).length > 0 ? (
                 <StateCountsBadges counts={message.state_counts} />
               ) : sc ? (
-                <span className={`inline-flex items-center gap-0.5 rounded border px-1 py-px text-[10px] font-medium ${sc.color}`}>
-                  <span className="text-[8px]">{sc.icon}</span>
-                  {sc.label}
-                </span>
+                <MessageStateBadge
+                  state={message.state}
+                  label={sc.label}
+                  color={sc.color}
+                  icon={sc.icon}
+                />
               ) : null}
             </>
           )}

--- a/frontend/src/components/dashboard/sidebar/NavButtons.tsx
+++ b/frontend/src/components/dashboard/sidebar/NavButtons.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import type { ReactNode } from "react";
+import { animateIfMotion, cleanupAnime } from "@/lib/anime";
 
 export interface PrimaryNavButtonProps {
   active: boolean;
@@ -27,9 +29,52 @@ export function PrimaryNavButton({
     ? "bg-neon-purple/15 text-neon-purple"
     : "bg-neon-cyan/15 text-neon-cyan";
   const indicatorClass = activeTone === "purple" ? "bg-neon-purple" : "bg-neon-cyan";
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const previousActiveRef = useRef(active);
+  const previousBadgeTextRef = useRef("");
+
+  useEffect(() => {
+    if (!active || previousActiveRef.current === active) {
+      previousActiveRef.current = active;
+      return;
+    }
+
+    const button = buttonRef.current;
+    previousActiveRef.current = active;
+    if (!button) return;
+
+    const animation = animateIfMotion(button, {
+      scale: [0.98, 1.045, 1],
+      duration: 260,
+      ease: "out(3)",
+    });
+    return () => cleanupAnime(animation);
+  }, [active]);
+
+  useEffect(() => {
+    const button = buttonRef.current;
+    const badgeNode = button?.querySelector<HTMLElement>("[data-primary-nav-badge]");
+    const badgeText = badgeNode?.textContent ?? "";
+
+    if (!badgeNode || badgeText === previousBadgeTextRef.current) {
+      previousBadgeTextRef.current = badgeText;
+      return;
+    }
+
+    previousBadgeTextRef.current = badgeText;
+    const animation = animateIfMotion(badgeNode, {
+      opacity: [0, 1],
+      scale: [0.72, 1.18, 1],
+      translateY: [2, -1, 0],
+      duration: 300,
+      ease: "out(3)",
+    });
+    return () => cleanupAnime(animation);
+  }, [badge]);
 
   return (
     <button
+      ref={buttonRef}
       onClick={onClick}
       className={`group relative flex h-12 w-12 flex-col items-center justify-center rounded-xl transition-all duration-200 max-md:h-12 max-md:min-w-0 max-md:flex-1 max-md:px-1 ${
         disabled
@@ -40,6 +85,12 @@ export function PrimaryNavButton({
       }`}
       title={title}
     >
+      <span
+        aria-hidden="true"
+        className={`pointer-events-none absolute left-0 top-1/2 h-5 w-0.5 -translate-y-1/2 rounded-r-full ${indicatorClass} transition-opacity duration-200 max-md:bottom-0 max-md:left-1/2 max-md:top-auto max-md:h-0.5 max-md:w-5 max-md:-translate-x-1/2 max-md:translate-y-0 ${
+          active ? "opacity-100" : "opacity-0"
+        }`}
+      />
       {badge}
       {icon}
       <span className="mt-0.5 max-w-full truncate text-[9px] font-medium leading-none">{label}</span>

--- a/frontend/src/components/dashboard/sidebar/index.tsx
+++ b/frontend/src/components/dashboard/sidebar/index.tsx
@@ -339,14 +339,20 @@ function Sidebar({
             let badge: ReactNode = null;
             if (item.key === "messages" && unreadMessageCount > 0 && !requiresLogin) {
               badge = (
-                <span className="absolute -right-1 -top-1 flex h-4 min-w-[16px] items-center justify-center rounded-full bg-neon-cyan px-1 text-[9px] font-bold leading-none text-black shadow-[0_0_12px_rgba(34,211,238,0.45)]">
+                <span
+                  data-primary-nav-badge
+                  className="absolute -right-1 -top-1 flex h-4 min-w-[16px] items-center justify-center rounded-full bg-neon-cyan px-1 text-[9px] font-bold leading-none text-black shadow-[0_0_12px_rgba(34,211,238,0.45)]"
+                >
                   {formatBadgeCount(unreadMessageCount)}
                 </span>
               );
             }
             if (item.key === "contacts" && pendingContactRequests > 0 && !requiresLogin) {
               badge = (
-                <span className="absolute -right-1 -top-1 flex h-4 min-w-[16px] items-center justify-center rounded-full bg-neon-cyan px-1 text-[9px] font-bold text-black shadow-[0_0_12px_rgba(34,211,238,0.45)]">
+                <span
+                  data-primary-nav-badge
+                  className="absolute -right-1 -top-1 flex h-4 min-w-[16px] items-center justify-center rounded-full bg-neon-cyan px-1 text-[9px] font-bold text-black shadow-[0_0_12px_rgba(34,211,238,0.45)]"
+                >
                   {formatBadgeCount(pendingContactRequests)}
                 </span>
               );


### PR DESCRIPTION
## Summary
- add animejs enter/exit motion to profile modals, forward modal, select popovers, and message action surfaces
- add restrained feedback for nav tab changes, unread badges, selected checks/chips, forward success, and message status changes
- keep motion routed through reduced-motion-aware helpers and preserve existing dashboard behavior

## Verification
- git diff --check
- cd frontend && pnpm exec vitest run src/components/dashboard/MessageComposer.test.ts src/components/dashboard/MessageList.test.ts
- cd frontend && NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy pnpm run build

## Risk / rollout
- frontend-only animation polish; behavior should be unchanged beyond visual feedback
- profile/forward modals now support animated backdrop and Escape close paths
