### PR TITLE
fix: suppress message entrance animation replay on room switch

### DIFF
--- a/frontend/src/components/dashboard/MessageList.tsx
+++ b/frontend/src/components/dashboard/MessageList.tsx
@@ -107,6 +107,18 @@ function messageRenderKey(message: DashboardMessage): string {
   return message.msg_id || message.hub_msg_id;
 }
 
+// Quiet window after opening a room: deltas merged by the initial poll /
+// forced reloads land right after the cached list painted, so animating them
+// reads as the whole page jittering instead of "new message arrived".
+const MESSAGE_ENTRANCE_SETTLE_MS = 1200;
+
+function messageSeenIds(message: DashboardMessage): string[] {
+  const ids: string[] = [];
+  if (message.msg_id) ids.push(message.msg_id);
+  if (message.hub_msg_id) ids.push(message.hub_msg_id);
+  return ids;
+}
+
 export function TopicCard({
   group,
   currentAgentId,
@@ -322,6 +334,7 @@ export default function MessageList({
   const messageAnimationRoomRef = useRef<string | null>(null);
   const messageAnimationPrimedRef = useRef(false);
   const animatedMessageKeysRef = useRef<Set<string>>(new Set());
+  const roomOpenedAtRef = useRef(0);
   const [showScrollToBottomButton, setShowScrollToBottomButton] = useState(false);
   const showScrollToBottomButtonRef = useRef(false);
   const wasNearBottomRef = useRef(true);
@@ -447,6 +460,7 @@ export default function MessageList({
     messageAnimationRoomRef.current = roomId;
     messageAnimationPrimedRef.current = false;
     animatedMessageKeysRef.current = new Set();
+    roomOpenedAtRef.current = performance.now();
     showScrollToBottomButtonRef.current = false;
     setShowScrollToBottomButton(false);
   }, [roomId, setOpenedTopicId]);
@@ -511,18 +525,24 @@ export default function MessageList({
       animatedMessageKeysRef.current = new Set();
     }
 
-    const keys = messages.map(messageRenderKey);
-    if (keys.length === 0) return;
+    if (messages.length === 0) return;
+    const seenIds = animatedMessageKeysRef.current;
 
     if (!messageAnimationPrimedRef.current) {
-      animatedMessageKeysRef.current = new Set(keys);
+      for (const msg of messages) for (const id of messageSeenIds(msg)) seenIds.add(id);
       messageAnimationPrimedRef.current = true;
       return;
     }
 
-    const newlyVisibleKeys = keys.filter((key) => !animatedMessageKeysRef.current.has(key));
-    for (const key of keys) animatedMessageKeysRef.current.add(key);
-    if (newlyVisibleKeys.length === 0 || isLoadingMore.current) return;
+    // A message only counts as new if none of its ids were seen before —
+    // identity patches (tmp_/hub_msg_id → msg_id) change the render key but
+    // must not replay the entrance animation.
+    const newlyVisible = messages.filter((msg) => messageSeenIds(msg).every((id) => !seenIds.has(id)));
+    for (const msg of messages) for (const id of messageSeenIds(msg)) seenIds.add(id);
+    if (newlyVisible.length === 0 || isLoadingMore.current) return;
+    if (performance.now() - roomOpenedAtRef.current < MESSAGE_ENTRANCE_SETTLE_MS) return;
+
+    const newlyVisibleKeys = newlyVisible.map(messageRenderKey);
 
     requestAnimationFrame(() => {
       const container = containerRef.current;


### PR DESCRIPTION
## Summary
- switching to a room replayed the new-message entrance animation (opacity/translateY on the last 6 bubbles) for deltas merged by the initial `pollNewMessages` / forced `loadRoomMessages`, so busy rooms visibly jittered on every switch
- add a 1.2s settle window after room switch: keys discovered during initial sync are absorbed into the seen set without animating; realtime messages after settle animate as before
- track both `msg_id` and `hub_msg_id` as seen ids, so identity patches (`tmp_`/`hub_msg_id` → `msg_id`) no longer re-trigger the entrance animation

## Verification
- `cd frontend && pnpm exec vitest run src/components/dashboard/MessageList.test.ts src/components/dashboard/MessageComposer.test.ts` — 14 passed
- `cd frontend && NEXT_PUBLIC_SUPABASE_URL=... NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy pnpm run build` — passes
- `tsc --noEmit` error count unchanged vs baseline (21 pre-existing stale-test errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)