### PR TITLE
fix: install frontend deps with --ignore-workspace on Vercel

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,3 +1,4 @@
 {
-  "framework": "nextjs"
+  "framework": "nextjs",
+  "installCommand": "pnpm install --ignore-workspace"
 }


### PR DESCRIPTION
## Summary
- frontend/ is not part of the root pnpm workspace, so Vercel's default install ran the root workspace install and never installed frontend's own dependencies
- deploys survived on stale build cache until `animejs` was added in #940 — every deployment since (#940, #941, current main) fails with `Module not found: Can't resolve 'animejs'`
- set `installCommand: pnpm install --ignore-workspace` in frontend/vercel.json so Vercel installs from frontend's own lockfile

## Verification
- this exact change already built green as a preview on Vercel (branch `fix/messagelist-room-switch-jitter` post-#942-merge, 40s build, Ready), while the same code without it failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)