### PR TITLE
feat: extend dashboard motion continuity

### DIFF
--- a/frontend/src/components/dashboard/AddDeviceDialog.tsx
+++ b/frontend/src/components/dashboard/AddDeviceDialog.tsx
@@ -7,8 +7,9 @@
  * [PROTOCOL]: update header on changes
  */
 
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Cpu, X } from "lucide-react";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from "@/lib/anime";
 import { useDaemonStore } from "@/store/useDaemonStore";
 import { useLanguage } from "@/lib/i18n";
 import { DeviceConnectPanel } from "./HomePanel";
@@ -23,6 +24,10 @@ export default function AddDeviceDialog({ onClose }: AddDeviceDialogProps) {
   const loading = useDaemonStore((s) => s.loading);
   const refresh = useDaemonStore((s) => s.refresh);
   const existingIdsRef = useRef<Set<string> | null>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
+  const [closing, setClosing] = useState(false);
 
   if (existingIdsRef.current === null) {
     existingIdsRef.current = new Set(daemons.map((d) => d.id));
@@ -39,22 +44,38 @@ export default function AddDeviceDialog({ onClose }: AddDeviceDialogProps) {
     return () => window.clearInterval(id);
   }, [refresh]);
 
+  const closeWithMotion = useCallback(() => {
+    if (closing) return;
+    setClosing(true);
+    cleanupAnime(animationRef.current);
+    animationRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      onComplete: onClose,
+    });
+  }, [closing, onClose]);
+
+  useEffect(() => {
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current);
+    return () => cleanupAnime(animationRef.current);
+  }, []);
+
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") onClose();
+      if (event.key === "Escape") closeWithMotion();
     }
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [onClose]);
+  }, [closeWithMotion]);
 
   return (
     <div
-      className="fixed inset-0 z-[110] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm"
+      ref={overlayRef}
+      className={`fixed inset-0 z-[110] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`}
       onMouseDown={(event) => {
-        if (event.target === event.currentTarget) onClose();
+        if (event.target === event.currentTarget) closeWithMotion();
       }}
     >
       <div
+        ref={panelRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="add-device-title"
@@ -70,7 +91,7 @@ export default function AddDeviceDialog({ onClose }: AddDeviceDialogProps) {
           </h3>
           <button
             type="button"
-            onClick={onClose}
+            onClick={closeWithMotion}
             aria-label={locale === "zh" ? "关闭" : "Close"}
             className="shrink-0 rounded-full p-1.5 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
           >

--- a/frontend/src/components/dashboard/AddFriendModal.tsx
+++ b/frontend/src/components/dashboard/AddFriendModal.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ArrowLeft, Check, Copy, Loader2, Search } from "lucide-react";
 import { api, humansApi } from "@/lib/api";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, animatePop, cleanupAnime } from "@/lib/anime";
 import { useLanguage } from "@/lib/i18n";
 import { common } from "@/lib/i18n/translations/common";
 import { addFriendModal } from "@/lib/i18n/translations/dashboard";
@@ -33,13 +34,41 @@ export default function AddFriendModal({ onClose }: AddFriendModalProps) {
   const t = addFriendModal[locale];
   const tc = common[locale];
   const [tab, setTab] = useState<TabKey>("search");
+  const [closing, setClosing] = useState(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
+
+  const closeWithMotion = useCallback(() => {
+    if (closing) return;
+    setClosing(true);
+    cleanupAnime(animationRef.current);
+    animationRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      onComplete: onClose,
+    });
+  }, [closing, onClose]);
+
+  useEffect(() => {
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current);
+    return () => cleanupAnime(animationRef.current);
+  }, []);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") closeWithMotion();
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [closeWithMotion]);
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4"
-      onClick={onClose}
+      ref={overlayRef}
+      className={`fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4 ${closing ? "pointer-events-none" : ""}`}
+      onClick={closeWithMotion}
     >
       <div
+        ref={panelRef}
         className="flex max-h-[90vh] w-full max-w-lg flex-col overflow-hidden rounded-xl border border-glass-border bg-deep-black"
         onClick={(e) => e.stopPropagation()}
       >
@@ -63,12 +92,12 @@ export default function AddFriendModal({ onClose }: AddFriendModalProps) {
         </div>
 
         <div className="flex-1 overflow-y-auto px-6 py-4">
-          {tab === "search" ? <SearchPane onClose={onClose} /> : <InvitePane />}
+          {tab === "search" ? <SearchPane onClose={closeWithMotion} /> : <InvitePane />}
         </div>
 
         <div className="flex justify-end gap-2 border-t border-glass-border px-6 py-3">
           <button
-            onClick={onClose}
+            onClick={closeWithMotion}
             className="rounded border border-glass-border px-4 py-2 text-sm text-text-secondary hover:text-text-primary"
           >
             {t.close}
@@ -119,6 +148,9 @@ function SearchPane({ onClose }: { onClose: () => void }) {
   const [message, setMessage] = useState("");
   const [sending, setSending] = useState(false);
   const [status, setStatus] = useState<"idle" | "sent" | "exists" | "pending">("idle");
+  const statusRef = useRef<HTMLDivElement>(null);
+  const errorRef = useRef<HTMLDivElement>(null);
+  const feedbackAnimationRef = useRef<ReturnType<typeof animatePop>>(null);
 
   useEffect(() => {
     const q = query.trim();
@@ -211,6 +243,21 @@ function SearchPane({ onClose }: { onClose: () => void }) {
     }
   }
 
+  useEffect(() => {
+    const target = status === "idle" ? null : statusRef.current;
+    if (!target) return;
+    cleanupAnime(feedbackAnimationRef.current);
+    feedbackAnimationRef.current = animatePop(target);
+    return () => cleanupAnime(feedbackAnimationRef.current);
+  }, [status]);
+
+  useEffect(() => {
+    if (!error || !errorRef.current) return;
+    cleanupAnime(feedbackAnimationRef.current);
+    feedbackAnimationRef.current = animatePop(errorRef.current);
+    return () => cleanupAnime(feedbackAnimationRef.current);
+  }, [error]);
+
   if (selected) {
     const isContact = contactIds.has(selected.id);
     return (
@@ -239,15 +286,15 @@ function SearchPane({ onClose }: { onClose: () => void }) {
         </div>
 
         {status === "sent" ? (
-          <div className="rounded border border-neon-green/40 bg-neon-green/10 px-3 py-2 text-sm text-neon-green">
+          <div ref={statusRef} className="rounded border border-neon-green/40 bg-neon-green/10 px-3 py-2 text-sm text-neon-green">
             {t.requestSent}
           </div>
         ) : status === "exists" ? (
-          <div className="rounded border border-glass-border px-3 py-2 text-sm text-text-secondary">
+          <div ref={statusRef} className="rounded border border-glass-border px-3 py-2 text-sm text-text-secondary">
             {t.alreadyContact}
           </div>
         ) : status === "pending" ? (
-          <div className="rounded border border-glass-border px-3 py-2 text-sm text-text-secondary">
+          <div ref={statusRef} className="rounded border border-glass-border px-3 py-2 text-sm text-text-secondary">
             {t.alreadyRequested}
           </div>
         ) : isContact ? (
@@ -265,7 +312,7 @@ function SearchPane({ onClose }: { onClose: () => void }) {
               className="w-full resize-none rounded border border-glass-border bg-glass-bg px-3 py-2 text-sm text-text-primary outline-none focus:border-neon-cyan/60"
             />
             {error && (
-              <div className="rounded border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-400">
+              <div ref={errorRef} className="rounded border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-400">
                 {error}
               </div>
             )}
@@ -299,7 +346,7 @@ function SearchPane({ onClose }: { onClose: () => void }) {
       </div>
 
       {error && (
-        <div className="rounded border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-400">
+        <div ref={errorRef} className="rounded border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-400">
           {error}
         </div>
       )}
@@ -354,6 +401,9 @@ function InvitePane() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState<"link" | "prompt" | null>(null);
+  const errorRef = useRef<HTMLDivElement>(null);
+  const copyRef = useRef<HTMLButtonElement>(null);
+  const feedbackAnimationRef = useRef<ReturnType<typeof animatePop>>(null);
 
   async function create() {
     setLoading(true);
@@ -379,12 +429,26 @@ function InvitePane() {
     setTimeout(() => setCopied(null), 1500);
   }
 
+  useEffect(() => {
+    if (!error || !errorRef.current) return;
+    cleanupAnime(feedbackAnimationRef.current);
+    feedbackAnimationRef.current = animatePop(errorRef.current);
+    return () => cleanupAnime(feedbackAnimationRef.current);
+  }, [error]);
+
+  useEffect(() => {
+    if (!copied || !copyRef.current) return;
+    cleanupAnime(feedbackAnimationRef.current);
+    feedbackAnimationRef.current = animatePop(copyRef.current);
+    return () => cleanupAnime(feedbackAnimationRef.current);
+  }, [copied]);
+
   return (
     <div className="space-y-4">
       <p className="text-sm text-text-secondary">{t.inviteDescription}</p>
 
       {error && (
-        <div className="rounded border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-400">
+        <div ref={errorRef} className="rounded border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-400">
           {error}
         </div>
       )}
@@ -405,6 +469,7 @@ function InvitePane() {
               {t.invitePrompt}
             </span>
             <button
+              ref={copyRef}
               onClick={() => copy("prompt")}
               className="inline-flex items-center gap-1 rounded border border-neon-cyan/50 bg-neon-cyan/10 px-2.5 py-1 text-xs text-neon-cyan hover:bg-neon-cyan/20"
             >

--- a/frontend/src/components/dashboard/AddRoomMemberModal.tsx
+++ b/frontend/src/components/dashboard/AddRoomMemberModal.tsx
@@ -6,9 +6,10 @@
  */
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Loader2, X } from "lucide-react";
 import { humansApi } from "@/lib/api";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, animatePop, cleanupAnime } from "@/lib/anime";
 import { useLanguage } from "@/lib/i18n";
 import { agentBrowser } from "@/lib/i18n/translations/dashboard";
 import DashboardMultiSelect from "./DashboardMultiSelect";
@@ -48,6 +49,12 @@ export default function AddRoomMemberModal({
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [closing, setClosing] = useState(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const errorRef = useRef<HTMLDivElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
+  const errorAnimationRef = useRef<ReturnType<typeof animatePop>>(null);
 
   const candidates = useMemo(() => {
     const existing = new Set(existingMemberIds);
@@ -85,7 +92,7 @@ export default function AddRoomMemberModal({
         await humansApi.addRoomMember(roomId, { participant_id: participantId, role: "member" });
       }
       await onAdded();
-      onClose();
+      closeWithMotion();
     } catch (err) {
       setError(err instanceof Error ? err.message : t.addMemberFailed);
     } finally {
@@ -93,9 +100,39 @@ export default function AddRoomMemberModal({
     }
   };
 
+  const closeWithMotion = useCallback(() => {
+    if (saving || closing) return;
+    setClosing(true);
+    cleanupAnime(animationRef.current);
+    animationRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      onComplete: onClose,
+    });
+  }, [closing, onClose, saving]);
+
+  useEffect(() => {
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current);
+    return () => cleanupAnime(animationRef.current);
+  }, []);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") closeWithMotion();
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [closeWithMotion]);
+
+  useEffect(() => {
+    if (!error || !errorRef.current) return;
+    cleanupAnime(errorAnimationRef.current);
+    errorAnimationRef.current = animatePop(errorRef.current);
+    return () => cleanupAnime(errorAnimationRef.current);
+  }, [error]);
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4" onClick={onClose}>
+    <div ref={overlayRef} className={`fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 ${closing ? "pointer-events-none" : ""}`} onClick={closeWithMotion}>
       <div
+        ref={panelRef}
         className="flex h-[min(760px,calc(100dvh-2rem))] w-full max-w-2xl flex-col overflow-hidden rounded-xl border border-glass-border bg-deep-black"
         onClick={(e) => e.stopPropagation()}
       >
@@ -105,7 +142,7 @@ export default function AddRoomMemberModal({
             <p className="mt-1 text-xs text-text-secondary">{t.addMemberDescription}</p>
           </div>
           <button
-            onClick={onClose}
+            onClick={closeWithMotion}
             className="rounded p-1.5 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
             aria-label={t.closeAddMemberModal}
             title={t.closeAddMemberModal}
@@ -116,7 +153,7 @@ export default function AddRoomMemberModal({
 
         <div className="flex-1 space-y-4 overflow-y-auto px-6 py-4">
           {error ? (
-            <div className="rounded border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-400">
+            <div ref={errorRef} className="rounded border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-400">
               {error}
             </div>
           ) : null}
@@ -152,7 +189,7 @@ export default function AddRoomMemberModal({
 
         <div className="flex items-center justify-end gap-2 border-t border-glass-border px-6 py-4">
           <button
-            onClick={onClose}
+            onClick={closeWithMotion}
             disabled={saving}
             className="rounded border border-glass-border px-4 py-2 text-sm text-text-secondary transition-colors hover:text-text-primary disabled:opacity-50"
           >

--- a/frontend/src/components/dashboard/AgentChannelsTab.tsx
+++ b/frontend/src/components/dashboard/AgentChannelsTab.tsx
@@ -37,6 +37,7 @@ import {
   type WechatLoginStatus,
 } from "@/store/useAgentGatewayStore";
 import { MobileBotCordLoading } from "@/components/ui/BotCordLoader";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from "@/lib/anime";
 
 interface Props {
   agentId: string;
@@ -946,16 +947,46 @@ function TelegramAddForm({
 }
 
 function TelegramTokenGuideDialog({ onClose }: { onClose: () => void }) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
+
+  const closeWithMotion = useCallback(() => {
+    cleanupAnime(animationRef.current);
+    animationRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      contentSelector: "[data-motion-item]",
+      onComplete: onClose,
+    });
+  }, [onClose]);
+
+  useEffect(() => {
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current, {
+      contentSelector: "[data-motion-item]",
+    });
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") closeWithMotion();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      cleanupAnime(animationRef.current);
+    };
+  }, [closeWithMotion]);
+
   return (
     <div
+      ref={overlayRef}
       className="fixed inset-0 z-[70] flex items-center justify-center bg-black/70 px-4 backdrop-blur-sm"
-      onClick={onClose}
+      onClick={closeWithMotion}
     >
       <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
         className="w-full max-w-md rounded-2xl border border-glass-border bg-deep-black p-5 shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="mb-4 flex items-start justify-between gap-3">
+        <div data-motion-item className="mb-4 flex items-start justify-between gap-3">
           <div>
             <h3 className="text-base font-semibold text-text-primary">
               从 BotFather 获取 Bot token
@@ -966,7 +997,7 @@ function TelegramTokenGuideDialog({ onClose }: { onClose: () => void }) {
           </div>
           <button
             type="button"
-            onClick={onClose}
+            onClick={closeWithMotion}
             aria-label="关闭"
             className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-glass-border text-text-secondary hover:border-neon-cyan/35 hover:text-neon-cyan"
           >
@@ -974,35 +1005,35 @@ function TelegramTokenGuideDialog({ onClose }: { onClose: () => void }) {
           </button>
         </div>
         <ol className="space-y-3 text-xs text-text-secondary">
-          <li className="flex gap-3">
+          <li data-motion-item className="flex gap-3">
             <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-neon-cyan/35 bg-neon-cyan/10 text-[10px] font-semibold text-neon-cyan">
               1
             </span>
             <span>打开 Telegram，搜索并进入官方账号 @BotFather。</span>
           </li>
-          <li className="flex gap-3">
+          <li data-motion-item className="flex gap-3">
             <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-neon-cyan/35 bg-neon-cyan/10 text-[10px] font-semibold text-neon-cyan">
               2
             </span>
             <span>发送 /newbot，按提示填写 bot 显示名称和以 bot 结尾的用户名。</span>
           </li>
-          <li className="flex gap-3">
+          <li data-motion-item className="flex gap-3">
             <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-neon-cyan/35 bg-neon-cyan/10 text-[10px] font-semibold text-neon-cyan">
               3
             </span>
             <span>BotFather 会返回一串 HTTP API token，格式通常类似 123456:ABC-...。</span>
           </li>
-          <li className="flex gap-3">
+          <li data-motion-item className="flex gap-3">
             <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-neon-cyan/35 bg-neon-cyan/10 text-[10px] font-semibold text-neon-cyan">
               4
             </span>
             <span>复制 token，粘贴到 Bot token 输入框；不要把 token 发到群聊或提交到代码仓库。</span>
           </li>
         </ol>
-        <div className="mt-5 flex justify-end">
+        <div data-motion-item className="mt-5 flex justify-end">
           <button
             type="button"
-            onClick={onClose}
+            onClick={closeWithMotion}
             className="rounded-md border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-1.5 text-xs font-medium text-neon-cyan hover:bg-neon-cyan/20"
           >
             知道了
@@ -2633,30 +2664,60 @@ function DeleteConfirmDialog({
   onCancel: () => void;
   onConfirm: () => void;
 }) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
+
+  const closeWithMotion = useCallback(() => {
+    cleanupAnime(animationRef.current);
+    animationRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      contentSelector: "[data-motion-item]",
+      onComplete: onCancel,
+    });
+  }, [onCancel]);
+
+  useEffect(() => {
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current, {
+      contentSelector: "[data-motion-item]",
+    });
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") closeWithMotion();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      cleanupAnime(animationRef.current);
+    };
+  }, [closeWithMotion]);
+
   return (
     <div
+      ref={overlayRef}
       className="fixed inset-0 z-[60] flex items-center justify-center bg-black/70 px-4"
-      onClick={onCancel}
+      onClick={closeWithMotion}
     >
       <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
         className="w-full max-w-sm rounded-2xl border border-glass-border bg-deep-black p-5 shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
-        <h3 className="mb-2 text-base font-semibold text-text-primary">
+        <h3 data-motion-item className="mb-2 text-base font-semibold text-text-primary">
           删除接入
         </h3>
-        <p className="text-xs text-text-secondary">
+        <p data-motion-item className="text-xs text-text-secondary">
           即将删除 <span className="text-text-primary">{gateway.label || providerName(gateway.provider)}</span>。
         </p>
-        <ul className="mt-3 list-disc space-y-1 pl-5 text-[11px] text-text-secondary">
+        <ul data-motion-item className="mt-3 list-disc space-y-1 pl-5 text-[11px] text-text-secondary">
           <li>仅移除第三方接入。</li>
           <li>不会删除 BotCord agent。</li>
           <li>不会删除 agent workspace、memory 或 runtime 配置。</li>
         </ul>
-        <div className="mt-5 flex justify-end gap-2">
+        <div data-motion-item className="mt-5 flex justify-end gap-2">
           <button
             type="button"
-            onClick={onCancel}
+            onClick={closeWithMotion}
             disabled={busy}
             className="rounded-md border border-glass-border bg-glass-bg/60 px-3 py-1.5 text-xs text-text-secondary hover:text-text-primary disabled:opacity-50"
           >

--- a/frontend/src/components/dashboard/AgentGateModal.tsx
+++ b/frontend/src/components/dashboard/AgentGateModal.tsx
@@ -7,12 +7,13 @@
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { userApi } from "@/lib/api";
 import type { UserAgent } from "@/lib/types";
 import { useLanguage } from "@/lib/i18n";
 import { agentGateModal } from "@/lib/i18n/translations/dashboard";
+import { animateOverlayPanelEnter, cleanupAnime } from "@/lib/anime";
 
 interface AgentGateModalProps {
   onAgentReady: (agentId: string) => Promise<void> | void;
@@ -32,6 +33,9 @@ export default function AgentGateModal({ onAgentReady }: AgentGateModalProps) {
   const [error, setError] = useState<string | null>(null);
   const pollRef = useRef<NodeJS.Timeout | null>(null);
   const readyRef = useRef(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
 
   const resolveAgents = useCallback(async () => {
     if (readyRef.current) {
@@ -69,10 +73,25 @@ export default function AgentGateModal({ onAgentReady }: AgentGateModalProps) {
     };
   }, [resolveAgents]);
 
+  useLayoutEffect(() => {
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current, {
+      contentSelector: "[data-agent-gate-part]",
+      onComplete: () => {
+        animationRef.current = null;
+      },
+    });
+    return () => cleanupAnime(animationRef.current);
+  }, []);
+
   return (
-    <div className="fixed inset-0 z-[90] flex items-center justify-center bg-black/80 p-4 backdrop-blur-md">
-      <div className="w-full max-w-2xl rounded-[28px] border border-glass-border bg-deep-black-light p-8 shadow-2xl">
-        <div className="mx-auto max-w-xl text-center">
+    <div ref={overlayRef} className="fixed inset-0 z-[90] flex items-center justify-center bg-black/80 p-4 backdrop-blur-md">
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        className="w-full max-w-2xl rounded-[28px] border border-glass-border bg-deep-black-light p-8 shadow-2xl"
+      >
+        <div data-agent-gate-part className="mx-auto max-w-xl text-center">
           <p className="text-[11px] font-bold uppercase tracking-[0.32em] text-neon-cyan/80">
             {t.communityGate}
           </p>
@@ -84,7 +103,7 @@ export default function AgentGateModal({ onAgentReady }: AgentGateModalProps) {
           </p>
         </div>
 
-        <div className="mt-6 rounded-2xl border border-glass-border bg-deep-black p-4">
+        <div data-agent-gate-part className="mt-6 rounded-2xl border border-glass-border bg-deep-black p-4">
           {isResolving ? (
             <div className="flex items-center gap-3 text-sm text-text-secondary">
               <Loader2 className="h-4 w-4 animate-spin text-neon-cyan" />

--- a/frontend/src/components/dashboard/AgentProfileEditModal.tsx
+++ b/frontend/src/components/dashboard/AgentProfileEditModal.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Loader2, Settings, Trash2, X } from "lucide-react";
 import { userApi } from "@/lib/api";
 import { useLanguage } from "@/lib/i18n";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import UnbindAgentDialog from "./UnbindAgentDialog";
 import { AGENT_AVATAR_URLS } from "@/lib/agent-avatars";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, animatePop, cleanupAnime } from "@/lib/anime";
 
 interface AgentProfileEditModalProps {
   agentId: string;
@@ -34,6 +35,12 @@ export default function AgentProfileEditModal({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showUnbind, setShowUnbind] = useState(false);
+  const [closing, setClosing] = useState(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const errorRef = useRef<HTMLParagraphElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
+  const errorAnimationRef = useRef<ReturnType<typeof animatePop>>(null);
 
   useEffect(() => {
     setDisplayName(initialDisplayName);
@@ -47,6 +54,44 @@ export default function AgentProfileEditModal({
   const avatarChanged = avatarUrl !== (initialAvatarUrl ?? "");
   const canSave = !saving && trimmedName.length > 0 && (nameChanged || bioChanged || avatarChanged);
 
+  const closeWithMotion = useCallback((force = false) => {
+    if ((saving && !force) || closing) return;
+    setClosing(true);
+    cleanupAnime(animationRef.current);
+    animationRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      onComplete: onClose,
+    });
+  }, [closing, onClose, saving]);
+
+  useLayoutEffect(() => {
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current, {
+      contentSelector: "[data-agent-profile-modal-part]",
+      onComplete: () => {
+        animationRef.current = null;
+      },
+    });
+    return () => cleanupAnime(animationRef.current);
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !showUnbind) closeWithMotion();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [closeWithMotion, showUnbind]);
+
+  useEffect(() => {
+    if (!error || !errorRef.current) return;
+    cleanupAnime(errorAnimationRef.current);
+    errorAnimationRef.current = animatePop(errorRef.current);
+  }, [error]);
+
+  useEffect(() => () => {
+    cleanupAnime(animationRef.current);
+    cleanupAnime(errorAnimationRef.current);
+  }, []);
+
   async function handleSave() {
     if (!canSave) return;
     setSaving(true);
@@ -59,7 +104,7 @@ export default function AgentProfileEditModal({
       await userApi.updateAgent(agentId, patch);
       await refreshUserProfile();
       onSaved?.();
-      onClose();
+      closeWithMotion(true);
     } catch (err: any) {
       setError(err?.message || (locale === "zh" ? "保存失败" : "Failed to save"));
       setSaving(false);
@@ -77,17 +122,29 @@ export default function AgentProfileEditModal({
   const tDelete = locale === "zh" ? "删除 Bot" : "Delete Bot";
 
   return (
-    <div className="fixed inset-0 z-[110] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm">
-      <div className="relative w-full max-w-md rounded-2xl border border-glass-border bg-deep-black-light p-5 shadow-2xl">
+    <div
+      ref={overlayRef}
+      className={`fixed inset-0 z-[110] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`}
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) closeWithMotion();
+      }}
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        className="relative w-full max-w-md rounded-2xl border border-glass-border bg-deep-black-light p-5 shadow-2xl"
+        onMouseDown={(event) => event.stopPropagation()}
+      >
         <button
-          onClick={onClose}
+          onClick={() => closeWithMotion()}
           disabled={saving}
           className="absolute right-4 top-4 rounded-full p-1.5 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
         >
           <X className="h-5 w-5" />
         </button>
 
-        <div className="mb-5 pr-8">
+        <div data-agent-profile-modal-part className="mb-5 pr-8">
           <h3 className="flex items-center gap-2 text-xl font-bold text-text-primary">
             <Settings className="h-5 w-5 text-neon-cyan" />
             {tTitle}
@@ -96,7 +153,7 @@ export default function AgentProfileEditModal({
           <p className="mt-1 font-mono text-[10px] text-text-secondary/60">{agentId}</p>
         </div>
 
-        <div className="mb-3">
+        <div data-agent-profile-modal-part className="mb-3">
           <span className="mb-2 block text-xs font-medium text-text-secondary">
             {locale === "zh" ? "头像" : "Avatar"}
           </span>
@@ -124,7 +181,7 @@ export default function AgentProfileEditModal({
           </div>
         </div>
 
-        <label className="mb-3 block">
+        <label data-agent-profile-modal-part className="mb-3 block">
           <span className="mb-1 block text-xs font-medium text-text-secondary">{tNameLabel}</span>
           <input
             type="text"
@@ -136,7 +193,7 @@ export default function AgentProfileEditModal({
           />
         </label>
 
-        <label className="block">
+        <label data-agent-profile-modal-part className="block">
           <span className="mb-1 block text-xs font-medium text-text-secondary">{tBioLabel}</span>
           <textarea
             value={bio}
@@ -150,14 +207,14 @@ export default function AgentProfileEditModal({
         </label>
 
         {error && (
-          <p className="mt-3 rounded-lg border border-red-400/20 bg-red-400/10 p-2 text-xs text-red-400">
+          <p ref={errorRef} className="mt-3 rounded-lg border border-red-400/20 bg-red-400/10 p-2 text-xs text-red-400">
             {error}
           </p>
         )}
 
-        <div className="mt-6 flex items-center justify-end gap-3">
+        <div data-agent-profile-modal-part className="mt-6 flex items-center justify-end gap-3">
           <button
-            onClick={onClose}
+            onClick={() => closeWithMotion()}
             disabled={saving}
             className="rounded-xl border border-glass-border px-4 py-2.5 text-sm font-medium text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
           >
@@ -179,7 +236,7 @@ export default function AgentProfileEditModal({
           </button>
         </div>
 
-        <div className="mt-6 border-t border-glass-border pt-4">
+        <div data-agent-profile-modal-part className="mt-6 border-t border-glass-border pt-4">
           <button
             onClick={() => setShowUnbind(true)}
             disabled={saving}
@@ -199,7 +256,7 @@ export default function AgentProfileEditModal({
           onUnbound={async () => {
             await refreshUserProfile();
             onSaved?.();
-            onClose();
+            closeWithMotion(true);
           }}
         />
       )}

--- a/frontend/src/components/dashboard/AgentSettingsDrawer.tsx
+++ b/frontend/src/components/dashboard/AgentSettingsDrawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Bell, Bot, Clock, FileText, Loader2, MessageSquare, Plug, RefreshCw, Shield, Sparkles, Trash2, User, UserRound, X } from "lucide-react";
 import { apiFetch, userApi } from "@/lib/api";
 import { useLanguage } from "@/lib/i18n";
@@ -21,6 +21,7 @@ import AgentSchedulesTab from "./AgentSchedulesTab";
 import { AGENT_AVATAR_URLS } from "@/lib/agent-avatars";
 import BotRuntimeCapabilitiesPanel from "./BotRuntimeCapabilitiesPanel";
 import AgentSkillsTab from "./AgentSkillsTab";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from "@/lib/anime";
 
 interface AgentSettingsDrawerProps {
   agentId: string;
@@ -326,6 +327,9 @@ export default function AgentSettingsDrawer({
   const [filesLoading, setFilesLoading] = useState(false);
   const [filesLoaded, setFilesLoaded] = useState(false);
   const [filesError, setFilesError] = useState<string | null>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const drawerRef = useRef<HTMLDivElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
 
   // --- Profile state ---
   const [nameVal, setNameVal] = useState(displayName);
@@ -424,9 +428,34 @@ export default function AgentSettingsDrawer({
 
   const selectedFile = runtimeFiles.find((file) => file.id === selectedFileId) ?? null;
 
+  const closeWithMotion = useCallback(() => {
+    cleanupAnime(animationRef.current);
+    animationRef.current = animateOverlayPanelExit(overlayRef.current, drawerRef.current, {
+      direction: "right",
+      onComplete: onClose,
+    });
+  }, [onClose]);
+
+  useEffect(() => {
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, drawerRef.current, {
+      direction: "right",
+    });
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") closeWithMotion();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      cleanupAnime(animationRef.current);
+    };
+  }, [closeWithMotion]);
+
   return (
-    <div className="fixed inset-0 z-50 bg-black/60" onClick={onClose}>
+    <div ref={overlayRef} className="fixed inset-0 z-50 bg-black/60" onClick={closeWithMotion}>
       <div
+        ref={drawerRef}
+        role="dialog"
+        aria-modal="true"
         className="ml-auto flex h-full w-full max-w-[480px] flex-col overflow-hidden border-l border-glass-border bg-deep-black shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
@@ -440,7 +469,7 @@ export default function AgentSettingsDrawer({
           </div>
           <button
             type="button"
-            onClick={onClose}
+            onClick={closeWithMotion}
             className="ml-4 rounded-full p-2 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
           >
             <X className="h-5 w-5" />
@@ -856,7 +885,7 @@ export default function AgentSettingsDrawer({
           onUnbound={async () => {
             await refreshUserProfile();
             onSaved?.();
-            onClose();
+            closeWithMotion();
           }}
         />
       )}

--- a/frontend/src/components/dashboard/BotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/BotDetailDrawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useEffect, useState } from "react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "nextjs-toploader/app";
 import {
   Bot,
@@ -28,6 +28,7 @@ import { isOwnerChatRoom } from "@/store/dashboard-shared";
 import { useDaemonStore, type DaemonInstance } from "@/store/useDaemonStore";
 import { useConfirm } from "@/store/useConfirmStore";
 import { useLanguage } from "@/lib/i18n";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from "@/lib/anime";
 import { botDetailDrawer } from "@/lib/i18n/translations/dashboard";
 import {
   usePolicyStore,
@@ -142,11 +143,27 @@ function BotDetailDrawer() {
 
   const [tab, setTab] = useState<TabKey>("overview");
   const [stats, setStats] = useState<ActivityStats | null>(null);
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+  const panelRef = useRef<HTMLElement | null>(null);
+  const motionRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
+  const closingRef = useRef(false);
+
+  const closeDrawer = useCallback(() => {
+    if (closingRef.current) return;
+    closingRef.current = true;
+    cleanupAnime(motionRef.current);
+    motionRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      direction: "right",
+      contentSelector: "[data-overlay-section]",
+      onComplete: () => setBotDetailAgentId(null),
+    });
+  }, [setBotDetailAgentId]);
 
   // Reset state when opening on a different bot. Honour an optional
   // initial-tab hint when the drawer is opened via openBotDetail() (e.g.
   // from the wallet overview's bot row).
   useEffect(() => {
+    closingRef.current = false;
     const legacySettingsTabs = new Set(["policy", "auto", "gateways"]);
     if (botDetailInitialTab && TABS.some((t) => t.key === botDetailInitialTab)) {
       setTab(botDetailInitialTab as TabKey);
@@ -180,11 +197,20 @@ function BotDetailDrawer() {
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setBotDetailAgentId(null);
+      if (e.key === "Escape") closeDrawer();
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [open, setBotDetailAgentId]);
+  }, [closeDrawer, open]);
+
+  useEffect(() => {
+    if (!open || !bot) return;
+    motionRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current, {
+      direction: "right",
+      contentSelector: "[data-overlay-section]",
+    });
+    return () => cleanupAnime(motionRef.current);
+  }, [bot?.agent_id, open]);
 
   if (!open || !bot) return null;
 
@@ -233,17 +259,20 @@ function BotDetailDrawer() {
   return (
     <>
       <div
+        ref={overlayRef}
         className="fixed inset-0 z-40 bg-black/40 backdrop-blur-[2px]"
-        onClick={() => setBotDetailAgentId(null)}
+        onClick={closeDrawer}
         aria-hidden
       />
       <aside
+        ref={panelRef}
         className="fixed inset-y-0 right-0 z-50 flex w-full max-w-md flex-col border-l border-glass-border bg-deep-black-light shadow-2xl shadow-black/50"
         role="dialog"
+        aria-modal="true"
         aria-label={t.ariaLabel}
       >
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-glass-border px-5 py-4">
+        <div className="flex items-center justify-between border-b border-glass-border px-5 py-4" data-overlay-section>
           <div className="flex min-w-0 items-center gap-3">
             <BotAvatar agentId={bot.agent_id} avatarUrl={bot.avatar_url} size={40} alt={bot.display_name} />
             <div className="min-w-0">
@@ -261,7 +290,7 @@ function BotDetailDrawer() {
             </div>
           </div>
           <button
-            onClick={() => setBotDetailAgentId(null)}
+            onClick={closeDrawer}
             title={t.close}
             aria-label={t.close}
             className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-secondary/70 transition-colors hover:bg-glass-bg hover:text-text-primary"
@@ -271,7 +300,7 @@ function BotDetailDrawer() {
         </div>
 
         {/* Tab strip */}
-        <div className="grid grid-cols-5 border-b border-glass-border">
+        <div className="grid grid-cols-5 border-b border-glass-border" data-overlay-section>
           {TABS.map(({ key, icon: Icon }) => {
             const active = tab === key;
             return (
@@ -292,7 +321,7 @@ function BotDetailDrawer() {
         </div>
 
         {/* Tab content */}
-        <div className="flex-1 overflow-y-auto px-5 py-4">
+        <div className="flex-1 overflow-y-auto px-5 py-4" data-overlay-section>
           {tab === "overview" && (
             <OverviewTab
               t={t}

--- a/frontend/src/components/dashboard/ChatPane.tsx
+++ b/frontend/src/components/dashboard/ChatPane.tsx
@@ -7,7 +7,7 @@
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
 
-import { startTransition, useEffect, useMemo, useState } from "react";
+import { startTransition, useEffect, useMemo, useRef, useState } from "react";
 import { useLanguage } from '@/lib/i18n';
 import { chatPane, exploreUi, messagesGrouping } from '@/lib/i18n/translations/dashboard';
 import { useRouter } from "nextjs-toploader/app";
@@ -30,6 +30,7 @@ import SearchBar from "./SearchBar";
 import ExploreEntityCard from "./ExploreEntityCard";
 import type { Attachment, PublicHumanProfile, PublicRoom } from "@/lib/types";
 import { api } from "@/lib/api";
+import { animateIfMotion, animeStagger, cleanupAnime } from "@/lib/anime";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardContactStore } from "@/store/useDashboardContactStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
@@ -46,6 +47,71 @@ type ChatPaneTab = "messages" | "contacts" | "explore";
 
 function GridSkeletonCards() {
   return <DashboardMainSkeleton variant="explore" />;
+}
+
+function MotionGrid({
+  children,
+  className,
+  motionKey,
+}: {
+  children: React.ReactNode;
+  className: string;
+  motionKey: string;
+}) {
+  const gridRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    let animation: ReturnType<typeof animateIfMotion> = null;
+    const frameId = window.requestAnimationFrame(() => {
+      const items = Array.from(
+        gridRef.current?.querySelectorAll<HTMLElement>("[data-motion-grid-item]") ?? [],
+      );
+      if (items.length === 0) return;
+
+      animation = animateIfMotion(items, {
+        opacity: [0, 1],
+        translateY: [10, 0],
+        scale: [0.985, 1],
+        delay: animeStagger(35),
+        duration: 320,
+        ease: "out(3)",
+      });
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      cleanupAnime(animation);
+    };
+  }, [motionKey]);
+
+  return (
+    <div ref={gridRef} className={className}>
+      {children}
+    </div>
+  );
+}
+
+function MotionEmptyText({ children, motionKey }: { children: React.ReactNode; motionKey: string }) {
+  const emptyRef = useRef<HTMLParagraphElement | null>(null);
+
+  useEffect(() => {
+    const animation = emptyRef.current
+      ? animateIfMotion(emptyRef.current, {
+          opacity: [0, 1],
+          translateY: [6, 0],
+          duration: 220,
+          ease: "out(3)",
+        })
+      : null;
+
+    return () => cleanupAnime(animation);
+  }, [motionKey]);
+
+  return (
+    <p ref={emptyRef} className="text-xs text-text-secondary">
+      {children}
+    </p>
+  );
 }
 
 function ContactsMainPane({ onHumanOpen }: { onHumanOpen?: (human: PublicHumanProfile) => void }) {
@@ -153,6 +219,16 @@ function ContactsMainPane({ onHumanOpen }: { onHumanOpen?: (human: PublicHumanPr
       : isCreatedView
         ? filteredCreatedRooms
         : filteredContacts;
+  const resultsMotionKey = [
+    contactsView,
+    normalized,
+    pageItems.length,
+    isRoomsView
+      ? filteredJoinedRooms.map((room) => room.room_id).join("|")
+      : isCreatedView
+        ? filteredCreatedRooms.map((room) => room.room_id).join("|")
+        : filteredContacts.map((contact) => contact.contact_agent_id).join("|"),
+  ].join(":");
 
   const openJoinedRoom = (roomId: string) => {
     const path = "/chats/messages";
@@ -219,12 +295,13 @@ function ContactsMainPane({ onHumanOpen }: { onHumanOpen?: (human: PublicHumanPr
           !overview ? (
             <DashboardMainSkeleton variant="contacts" />
           ) : pageItems.length === 0 ? (
-            <p className="text-xs text-text-secondary">{t.noJoinedRoomsFound}</p>
+            <MotionEmptyText motionKey={resultsMotionKey}>{t.noJoinedRoomsFound}</MotionEmptyText>
           ) : (
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+            <MotionGrid className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3" motionKey={resultsMotionKey}>
               {(pageItems as typeof filteredJoinedRooms).map((room) => (
                 <button
                   key={room.room_id}
+                  data-motion-grid-item
                   onClick={() => openJoinedRoom(room.room_id)}
                   className="rounded-2xl border border-glass-border bg-deep-black-light p-4 text-left transition-all hover:border-neon-cyan/60 hover:bg-glass-bg"
                 >
@@ -245,18 +322,19 @@ function ContactsMainPane({ onHumanOpen }: { onHumanOpen?: (human: PublicHumanPr
                   )}
                 </button>
               ))}
-            </div>
+            </MotionGrid>
           )
         ) : isCreatedView ? (
           !overview ? (
             <DashboardMainSkeleton variant="contacts" />
           ) : pageItems.length === 0 ? (
-            <p className="text-xs text-text-secondary">{t.noCreatedRoomsFound}</p>
+            <MotionEmptyText motionKey={resultsMotionKey}>{t.noCreatedRoomsFound}</MotionEmptyText>
           ) : (
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+            <MotionGrid className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3" motionKey={resultsMotionKey}>
               {(pageItems as typeof filteredCreatedRooms).map((room) => (
                 <button
                   key={room.room_id}
+                  data-motion-grid-item
                   onClick={() => openJoinedRoom(room.room_id)}
                   className="rounded-2xl border border-glass-border bg-deep-black-light p-4 text-left transition-all hover:border-neon-cyan/60 hover:bg-glass-bg"
                 >
@@ -277,14 +355,14 @@ function ContactsMainPane({ onHumanOpen }: { onHumanOpen?: (human: PublicHumanPr
                   )}
                 </button>
               ))}
-            </div>
+            </MotionGrid>
           )
         ) : !overview ? (
           <DashboardMainSkeleton variant="contacts" />
         ) : pageItems.length === 0 ? (
-          <p className="text-xs text-text-secondary">{t.noContactsFound}</p>
+          <MotionEmptyText motionKey={resultsMotionKey}>{t.noContactsFound}</MotionEmptyText>
         ) : (
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+          <MotionGrid className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3" motionKey={resultsMotionKey}>
             {(pageItems as typeof filteredContacts).map((contact) => {
               const isHuman = contact.peer_type === "human" || contact.contact_agent_id.startsWith("hu_");
               const primaryName = contact.alias || contact.display_name;
@@ -297,6 +375,7 @@ function ContactsMainPane({ onHumanOpen }: { onHumanOpen?: (human: PublicHumanPr
               return (
                 <button
                   key={contact.contact_agent_id}
+                  data-motion-grid-item
                   onClick={async () => {
                     if (isHuman) {
                       try {
@@ -350,7 +429,7 @@ function ContactsMainPane({ onHumanOpen }: { onHumanOpen?: (human: PublicHumanPr
                 </button>
               );
             })}
-          </div>
+          </MotionGrid>
         )}
       </div>
       )}
@@ -479,6 +558,15 @@ function ExploreMainPane({ onHumanOpen }: ChatPaneProps) {
   const searchPlaceholder = isRoomsView ? t.searchRooms : isAgentsView ? t.searchAgents : t.searchHumans;
   const loading = isRoomsView ? publicRoomsLoading : isAgentsView ? publicAgentsLoading : publicHumansLoading;
   const emptyText = isRoomsView ? t.noRoomsFound : isAgentsView ? t.noAgentsFound : t.noHumansFound;
+  const exploreMotionKey = [
+    exploreView,
+    query.trim().toLowerCase(),
+    isRoomsView
+      ? publicRooms.map((room) => room.room_id).join("|")
+      : isAgentsView
+        ? publicAgents.map((agent) => agent.agent_id).join("|")
+        : publicHumans.map((human) => human.human_id).join("|"),
+  ].join(":");
 
   const exploreTabs: Array<{ key: "rooms" | "agents" | "humans"; label: string }> = [
     { key: "rooms", label: locale === "zh" ? "群组" : "Groups" },
@@ -526,51 +614,54 @@ function ExploreMainPane({ onHumanOpen }: ChatPaneProps) {
           <GridSkeletonCards />
         ) : isRoomsView ? (
           publicRooms.length === 0 ? (
-            <p className="text-xs text-text-secondary">{emptyText}</p>
+            <MotionEmptyText motionKey={exploreMotionKey}>{emptyText}</MotionEmptyText>
           ) : (
-            <div className={EXPLORE_GRID_CLASS}>
+            <MotionGrid className={EXPLORE_GRID_CLASS} motionKey={exploreMotionKey}>
               {publicRooms.map((room) => (
-                <ExploreEntityCard
-                  key={room.room_id}
-                  kind="room"
-                  id={room.room_id}
-                  roomsById={publicRoomsById}
-                  onRoomOpen={openRoomFromExplore}
-                />
+                <div key={room.room_id} data-motion-grid-item>
+                  <ExploreEntityCard
+                    kind="room"
+                    id={room.room_id}
+                    roomsById={publicRoomsById}
+                    onRoomOpen={openRoomFromExplore}
+                  />
+                </div>
               ))}
-            </div>
+            </MotionGrid>
           )
         ) : isAgentsView ? (
           publicAgents.length === 0 ? (
-            <p className="text-xs text-text-secondary">{emptyText}</p>
+            <MotionEmptyText motionKey={exploreMotionKey}>{emptyText}</MotionEmptyText>
           ) : (
-            <div className={EXPLORE_GRID_CLASS}>
+            <MotionGrid className={EXPLORE_GRID_CLASS} motionKey={exploreMotionKey}>
               {publicAgents.map((agent) => (
-                <ExploreEntityCard
-                  key={agent.agent_id}
-                  kind="agent"
-                  data={publicAgentsById[agent.agent_id]}
-                  agentsById={publicAgentsById}
-                  onAgentOpen={(a) => selectAgent(a.agent_id)}
-                  onAgentOwnerOpen={(humanId) => void openHumanOwnerFromAgent(humanId)}
-                />
+                <div key={agent.agent_id} data-motion-grid-item>
+                  <ExploreEntityCard
+                    kind="agent"
+                    data={publicAgentsById[agent.agent_id]}
+                    agentsById={publicAgentsById}
+                    onAgentOpen={(a) => selectAgent(a.agent_id)}
+                    onAgentOwnerOpen={(humanId) => void openHumanOwnerFromAgent(humanId)}
+                  />
+                </div>
               ))}
-            </div>
+            </MotionGrid>
           )
         ) : publicHumans.length === 0 ? (
-          <p className="text-xs text-text-secondary">{emptyText}</p>
+          <MotionEmptyText motionKey={exploreMotionKey}>{emptyText}</MotionEmptyText>
         ) : (
-          <div className={EXPLORE_GRID_CLASS}>
+          <MotionGrid className={EXPLORE_GRID_CLASS} motionKey={exploreMotionKey}>
             {publicHumans.map((human) => (
-              <ExploreEntityCard
-                key={human.human_id}
-                kind="human"
-                data={publicHumansById[human.human_id]}
-                humansById={publicHumansById}
-                onHumanOpen={onHumanOpen}
-              />
+              <div key={human.human_id} data-motion-grid-item>
+                <ExploreEntityCard
+                  kind="human"
+                  data={publicHumansById[human.human_id]}
+                  humansById={publicHumansById}
+                  onHumanOpen={onHumanOpen}
+                />
+              </div>
             ))}
-          </div>
+          </MotionGrid>
         )}
       </div>
     </div>

--- a/frontend/src/components/dashboard/CreateAgentDialog.tsx
+++ b/frontend/src/components/dashboard/CreateAgentDialog.tsx
@@ -7,7 +7,7 @@
  * [PROTOCOL]: update header on changes
  */
 
-import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import {
   ArrowLeft,
   Bot,
@@ -52,6 +52,7 @@ import DaemonInstallCommand from "@/components/daemon/DaemonInstallCommand";
 import { MobileBotCordLoading } from "@/components/ui/BotCordLoader";
 import { DeviceConnectPanel } from "./HomePanel";
 import DashboardSelect from "./DashboardSelect";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from "@/lib/anime";
 
 interface CreateAgentDialogProps {
   onClose: () => void;
@@ -329,10 +330,14 @@ export default function CreateAgentDialog({
   const [error, setError] = useState<string | null>(null);
   const [addingDevice, setAddingDevice] = useState(false);
   const [justConnected, setJustConnected] = useState(false);
+  const [closing, setClosing] = useState(false);
   const prevHadOnlineRef = useRef<boolean | null>(null);
   const addDeviceExistingIdsRef = useRef<Set<string>>(new Set());
   const autoFilledNameRef = useRef<string | null>(null);
   const lastRandomIdxRef = useRef<number | undefined>(undefined);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
 
   function handleRandomize(): void {
     const pick = pickRandomAgentIdentity(locale, lastRandomIdxRef.current);
@@ -343,17 +348,35 @@ export default function CreateAgentDialog({
     if (error === t.nameRequired) setError(null);
   }
 
+  const closeWithMotion = useCallback((force = false) => {
+    if ((submitting && !force) || closing) return;
+    setClosing(true);
+    cleanupAnime(animationRef.current);
+    animationRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      onComplete: onClose,
+    });
+  }, [closing, onClose, submitting]);
+
   useEffect(() => {
     if (!loaded && !loading) void refresh();
   }, [loaded, loading, refresh]);
 
+  useLayoutEffect(() => {
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current, {
+      onComplete: () => {
+        animationRef.current = null;
+      },
+    });
+    return () => cleanupAnime(animationRef.current);
+  }, []);
+
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape" && !submitting) onClose();
+      if (event.key === "Escape") closeWithMotion();
     }
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [onClose, submitting]);
+  }, [closeWithMotion]);
 
   // Brief celebratory state when a daemon transitions from offline to online
   // while the user is staring at step 1. Without this, the dialog snaps to
@@ -373,11 +396,11 @@ export default function CreateAgentDialog({
 
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape" && !submitting) onClose();
+      if (event.key === "Escape") closeWithMotion();
     }
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [onClose, submitting]);
+  }, [closeWithMotion]);
 
   // Brief celebratory state when a daemon transitions from offline to online
   // while the user is staring at step 1. Without this, the dialog snaps to
@@ -688,9 +711,9 @@ export default function CreateAgentDialog({
             ...(selectedRuntimeId === "hermes-agent" && selectedHermesProfile
               ? { hermesProfile: selectedHermesProfile }
               : {}),
-          });
+      });
       await onSuccess(res.agentId);
-      onClose();
+      closeWithMotion(true);
     } catch (err) {
       setError(translateError(err));
     } finally {
@@ -771,12 +794,14 @@ export default function CreateAgentDialog({
 
   return (
     <div
-      className="fixed inset-0 z-[110] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm"
+      ref={overlayRef}
+      className={`fixed inset-0 z-[110] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`}
       onMouseDown={(event) => {
-        if (event.target === event.currentTarget && !submitting) onClose();
+        if (event.target === event.currentTarget) closeWithMotion();
       }}
     >
       <div
+        ref={panelRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="create-agent-title"
@@ -813,7 +838,7 @@ export default function CreateAgentDialog({
                 </div>
                 <button
                   type="button"
-                  onClick={onClose}
+                  onClick={() => closeWithMotion()}
                   disabled={submitting}
                   aria-label={t.cancel}
                   className="shrink-0 rounded-full p-1.5 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
@@ -1093,7 +1118,7 @@ export default function CreateAgentDialog({
                 <div className="flex shrink-0 items-center justify-end gap-3 border-t border-glass-border/40 px-4 py-3 sm:px-5">
                   <button
                     type="button"
-                    onClick={onClose}
+                    onClick={() => closeWithMotion()}
                     disabled={submitting}
                     className="rounded-xl border border-glass-border px-4 py-2 text-sm font-medium text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
                   >

--- a/frontend/src/components/dashboard/CreateRoomModal.tsx
+++ b/frontend/src/components/dashboard/CreateRoomModal.tsx
@@ -7,9 +7,10 @@
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
 
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { humansApi } from "@/lib/api";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, animatePop, cleanupAnime } from "@/lib/anime";
 import { useLanguage } from "@/lib/i18n";
 import { common } from "@/lib/i18n/translations/common";
 import { createRoomModal } from "@/lib/i18n/translations/dashboard";
@@ -47,6 +48,12 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [closing, setClosing] = useState(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const errorRef = useRef<HTMLDivElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
+  const errorAnimationRef = useRef<ReturnType<typeof animatePop>>(null);
 
   const memberGroups = useMemo<DashboardMultiSelectGroup[]>(() => {
     const groups: DashboardMultiSelectGroup[] = [];
@@ -103,7 +110,7 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
       const room = await humansApi.createRoom(body);
       await Promise.all([refreshOverview(), refreshHumanRooms()]);
       onCreated?.(room);
-      onClose();
+      closeWithMotion();
     } catch (err) {
       // ApiError.message already carries the 400/403 body ("detail" field)
       // via extractErrorMessage in lib/api.ts, so surface it verbatim.
@@ -113,12 +120,43 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
     }
   }
 
+  const closeWithMotion = useCallback(() => {
+    if (saving || closing) return;
+    setClosing(true);
+    cleanupAnime(animationRef.current);
+    animationRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      onComplete: onClose,
+    });
+  }, [closing, onClose, saving]);
+
+  useEffect(() => {
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current);
+    return () => cleanupAnime(animationRef.current);
+  }, []);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") closeWithMotion();
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [closeWithMotion]);
+
+  useEffect(() => {
+    if (!error || !errorRef.current) return;
+    cleanupAnime(errorAnimationRef.current);
+    errorAnimationRef.current = animatePop(errorRef.current);
+    return () => cleanupAnime(errorAnimationRef.current);
+  }, [error]);
+
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4"
-      onClick={onClose}
+      ref={overlayRef}
+      className={`fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4 ${closing ? "pointer-events-none" : ""}`}
+      onClick={closeWithMotion}
     >
       <div
+        ref={panelRef}
         className="flex max-h-[90vh] w-full max-w-lg flex-col overflow-hidden rounded-xl border border-glass-border bg-deep-black"
         onClick={(e) => e.stopPropagation()}
       >
@@ -187,7 +225,7 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
           </section>
 
           {error && (
-            <div className="rounded border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-400">
+            <div ref={errorRef} className="rounded border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-400">
               {error}
             </div>
           )}
@@ -195,7 +233,7 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
 
         <div className="flex justify-end gap-2 border-t border-glass-border px-6 py-3">
           <button
-            onClick={onClose}
+            onClick={closeWithMotion}
             disabled={saving}
             className="rounded border border-glass-border px-4 py-2 text-sm text-text-secondary hover:text-text-primary disabled:opacity-50"
           >

--- a/frontend/src/components/dashboard/CredentialResetDialog.tsx
+++ b/frontend/src/components/dashboard/CredentialResetDialog.tsx
@@ -7,8 +7,9 @@
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { userApi } from "@/lib/api";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, animatePop, cleanupAnime } from "@/lib/anime";
 import { useLanguage } from "@/lib/i18n";
 import { credentialResetDialog } from "@/lib/i18n/translations/dashboard";
 import { buildResetCredentialPrompt, getHubApiBaseUrl } from "@/lib/onboarding";
@@ -30,6 +31,13 @@ export default function CredentialResetDialog({
   const [resetCode, setResetCode] = useState("");
   const [expiresAt, setExpiresAt] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
+  const [closing, setClosing] = useState(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const copyButtonRef = useRef<HTMLButtonElement>(null);
+  const errorRef = useRef<HTMLParagraphElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
+  const feedbackAnimationRef = useRef<ReturnType<typeof animatePop>>(null);
 
   useEffect(() => {
     let mounted = true;
@@ -72,11 +80,41 @@ export default function CredentialResetDialog({
     }
   }
 
+  const closeWithMotion = useCallback(() => {
+    if (closing) return;
+    setClosing(true);
+    cleanupAnime(animationRef.current);
+    animationRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      onComplete: onClose,
+    });
+  }, [closing, onClose]);
+
+  useEffect(() => {
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current);
+    return () => cleanupAnime(animationRef.current);
+  }, []);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") closeWithMotion();
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [closeWithMotion]);
+
+  useEffect(() => {
+    const target = copied ? copyButtonRef.current : error ? errorRef.current : null;
+    if (!target) return;
+    cleanupAnime(feedbackAnimationRef.current);
+    feedbackAnimationRef.current = animatePop(target);
+    return () => cleanupAnime(feedbackAnimationRef.current);
+  }, [copied, error]);
+
   return (
-    <div className="fixed inset-0 z-[110] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm">
-      <div className="relative w-full max-w-xl rounded-2xl border border-glass-border bg-deep-black-light p-5 shadow-2xl">
+    <div ref={overlayRef} className={`fixed inset-0 z-[110] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`} onMouseDown={(event) => { if (event.target === event.currentTarget) closeWithMotion(); }}>
+      <div ref={panelRef} className="relative w-full max-w-xl rounded-2xl border border-glass-border bg-deep-black-light p-5 shadow-2xl">
         <button
-          onClick={onClose}
+          onClick={closeWithMotion}
           className="absolute right-4 top-4 rounded-full p-1.5 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
         >
           <X className="h-5 w-5" />
@@ -96,6 +134,7 @@ export default function CredentialResetDialog({
               {t.prompt}
             </p>
             <button
+              ref={copyButtonRef}
               onClick={handleCopyPrompt}
               disabled={!promptText}
               className="flex items-center gap-2 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-1.5 text-xs font-semibold text-neon-cyan transition-all hover:bg-neon-cyan/20 disabled:opacity-60"
@@ -135,14 +174,14 @@ export default function CredentialResetDialog({
         </div>
 
         {error ? (
-          <p className="mt-4 rounded-lg border border-red-400/20 bg-red-400/10 p-2 text-xs text-red-400">
+          <p ref={errorRef} className="mt-4 rounded-lg border border-red-400/20 bg-red-400/10 p-2 text-xs text-red-400">
             {error}
           </p>
         ) : null}
 
         <div className="mt-6 flex items-center justify-center">
           <button
-            onClick={onClose}
+            onClick={closeWithMotion}
             className="min-h-11 rounded-xl border border-neon-cyan/50 bg-neon-cyan px-5 py-3 text-sm font-bold text-black transition-all hover:bg-neon-cyan/90"
           >
             {t.close}

--- a/frontend/src/components/dashboard/DMSettingsModal.tsx
+++ b/frontend/src/components/dashboard/DMSettingsModal.tsx
@@ -7,8 +7,9 @@
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
 
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Loader2 } from "lucide-react";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, animatePop, cleanupAnime } from "@/lib/anime";
 import { useLanguage } from "@/lib/i18n";
 import { dmSettingsModal } from "@/lib/i18n/translations/dashboard";
 import { api } from "@/lib/api";
@@ -39,6 +40,13 @@ export default function DMSettingsModal({
   const [removing, setRemoving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [confirming, setConfirming] = useState(false);
+  const [closing, setClosing] = useState(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const errorRef = useRef<HTMLDivElement>(null);
+  const removeButtonRef = useRef<HTMLButtonElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
+  const feedbackAnimationRef = useRef<ReturnType<typeof animatePop>>(null);
 
   const isOwnAgent = contact === null;
   const title = isOwnAgent ? t.titleMyAgent : t.titleFriend;
@@ -54,7 +62,7 @@ export default function DMSettingsModal({
     try {
       await api.removeContact(contact.contact_agent_id);
       onContactRemoved?.();
-      onClose();
+      closeWithMotion();
     } catch (err) {
       setError(err instanceof Error ? err.message : t.removeFriendFailed);
       setConfirming(false);
@@ -63,9 +71,40 @@ export default function DMSettingsModal({
     }
   };
 
+  const closeWithMotion = useCallback(() => {
+    if (removing || closing) return;
+    setClosing(true);
+    cleanupAnime(animationRef.current);
+    animationRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      onComplete: onClose,
+    });
+  }, [closing, onClose, removing]);
+
+  useEffect(() => {
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current);
+    return () => cleanupAnime(animationRef.current);
+  }, []);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") closeWithMotion();
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [closeWithMotion]);
+
+  useEffect(() => {
+    const target = error ? errorRef.current : confirming ? removeButtonRef.current : null;
+    if (!target) return;
+    cleanupAnime(feedbackAnimationRef.current);
+    feedbackAnimationRef.current = animatePop(target);
+    return () => cleanupAnime(feedbackAnimationRef.current);
+  }, [confirming, error]);
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4" onClick={onClose}>
+    <div ref={overlayRef} className={`fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4 ${closing ? "pointer-events-none" : ""}`} onClick={closeWithMotion}>
       <div
+        ref={panelRef}
         className="flex max-h-[90vh] w-full max-w-sm flex-col overflow-hidden rounded-xl border border-glass-border bg-deep-black"
         onClick={(e) => e.stopPropagation()}
       >
@@ -75,7 +114,7 @@ export default function DMSettingsModal({
 
         <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4">
           {error && (
-            <div className="rounded border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-400">
+            <div ref={errorRef} className="rounded border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-400">
               {error}
             </div>
           )}
@@ -116,6 +155,7 @@ export default function DMSettingsModal({
         <div className="flex justify-between gap-2 border-t border-glass-border px-6 py-3">
           {!isOwnAgent && (
             <button
+              ref={removeButtonRef}
               onClick={() => void handleRemove()}
               disabled={removing}
               className="inline-flex items-center gap-1.5 rounded border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-400 hover:bg-red-500/20 disabled:opacity-50"
@@ -127,7 +167,7 @@ export default function DMSettingsModal({
             </button>
           )}
           <button
-            onClick={onClose}
+            onClick={closeWithMotion}
             className="ml-auto rounded border border-glass-border px-4 py-2 text-sm text-text-secondary hover:text-text-primary"
           >
             {t.close}

--- a/frontend/src/components/dashboard/DeviceDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/DeviceDetailDrawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useEffect, useState } from "react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 import {
   ArrowLeft,
   Check,
@@ -24,6 +24,7 @@ import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import DaemonInstallCommand from "@/components/daemon/DaemonInstallCommand";
 import ForwardModal from "@/components/dashboard/ForwardModal";
 import { downloadApiFile } from "@/lib/api";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from "@/lib/anime";
 import BotAvatar from "./BotAvatar";
 
 /**
@@ -86,6 +87,21 @@ function DeviceDetailDrawer() {
   const [forwardLogs, setForwardLogs] = useState(false);
   /** Nested view — when set, drawer shows that bot's detail instead of device sections. */
   const [viewingBotId, setViewingBotId] = useState<string | null>(null);
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+  const panelRef = useRef<HTMLElement | null>(null);
+  const motionRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
+  const closingRef = useRef(false);
+
+  const closeDrawer = useCallback(() => {
+    if (closingRef.current) return;
+    closingRef.current = true;
+    cleanupAnime(motionRef.current);
+    motionRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      direction: "right",
+      contentSelector: "[data-overlay-section]",
+      onComplete: () => setSelectedDeviceId(null),
+    });
+  }, [setSelectedDeviceId]);
 
   // Reset local state when the drawer opens against a different device.
   useEffect(() => {
@@ -96,17 +112,27 @@ function DeviceDetailDrawer() {
     setShowLogs(false);
     setForwardLogs(false);
     setViewingBotId(null);
+    closingRef.current = false;
   }, [device?.id]);
 
   // Close on Escape.
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setSelectedDeviceId(null);
+      if (e.key === "Escape") closeDrawer();
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [open, setSelectedDeviceId]);
+  }, [closeDrawer, open]);
+
+  useEffect(() => {
+    if (!open || !device) return;
+    motionRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current, {
+      direction: "right",
+      contentSelector: "[data-overlay-section]",
+    });
+    return () => cleanupAnime(motionRef.current);
+  }, [device?.id, open]);
 
   if (!open || !device) return null;
 
@@ -169,18 +195,21 @@ function DeviceDetailDrawer() {
     <>
       {/* Backdrop */}
       <div
+        ref={overlayRef}
         className="fixed inset-0 z-40 bg-black/40 backdrop-blur-[2px] transition-opacity"
-        onClick={() => setSelectedDeviceId(null)}
+        onClick={closeDrawer}
         aria-hidden
       />
       {/* Drawer */}
       <aside
+        ref={panelRef}
         className="fixed inset-y-0 right-0 z-50 flex w-full max-w-md flex-col border-l border-glass-border bg-deep-black-light shadow-2xl shadow-black/50"
         role="dialog"
+        aria-modal="true"
         aria-label="设备详情"
       >
         {/* Drawer header */}
-        <div className="flex items-center gap-3 border-b border-glass-border px-5 py-4">
+        <div className="flex items-center gap-3 border-b border-glass-border px-5 py-4" data-overlay-section>
           <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-glass-border bg-glass-bg/60 text-text-secondary">
             <DeviceIcon className="h-5 w-5" />
           </div>
@@ -217,7 +246,7 @@ function DeviceDetailDrawer() {
           <RefreshCw className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`} />
         </button>
         <button
-          onClick={() => setSelectedDeviceId(null)}
+          onClick={closeDrawer}
           title="关闭"
           aria-label="关闭"
           className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-secondary/70 transition-colors hover:bg-glass-bg hover:text-text-primary"
@@ -227,7 +256,7 @@ function DeviceDetailDrawer() {
       </div>
 
       {/* Scrollable content */}
-      <div className="flex-1 space-y-4 overflow-y-auto px-5 py-4">
+      <div className="flex-1 space-y-4 overflow-y-auto px-5 py-4" data-overlay-section>
 
       {viewingBotId ? (
         <BotDetailNested

--- a/frontend/src/components/dashboard/DocumentPreviewPane.tsx
+++ b/frontend/src/components/dashboard/DocumentPreviewPane.tsx
@@ -12,6 +12,7 @@ import {
 } from "react";
 import { Download, FileText, Loader2, X } from "lucide-react";
 import type { Attachment } from "@/lib/types";
+import { cleanupAnime, createTimelineIfMotion } from "@/lib/anime";
 import {
   DOCUMENT_PREVIEW_MAX_BYTES,
   getAttachmentPreviewFetchUrl,
@@ -24,6 +25,8 @@ interface DocumentPreviewPaneProps {
   attachment: Attachment;
   onClose: () => void;
 }
+
+type MotionTimeline = ReturnType<typeof createTimelineIfMotion>;
 
 export const DOCUMENT_PREVIEW_MIN_WIDTH = 360;
 export const DOCUMENT_PREVIEW_MAX_WIDTH = 960;
@@ -67,6 +70,9 @@ export default function DocumentPreviewPane({ attachment, onClose }: DocumentPre
   const [paneWidth, setPaneWidth] = useState(DOCUMENT_PREVIEW_DEFAULT_WIDTH);
   const [paneWidthReady, setPaneWidthReady] = useState(false);
   const [resizing, setResizing] = useState(false);
+  const paneRef = useRef<HTMLElement | null>(null);
+  const paneAnimationRef = useRef<MotionTimeline>(null);
+  const closingRef = useRef(false);
   const resizeStartRef = useRef({
     x: 0,
     width: DOCUMENT_PREVIEW_DEFAULT_WIDTH,
@@ -168,6 +174,40 @@ export default function DocumentPreviewPane({ attachment, onClose }: DocumentPre
   const paneStyle = {
     "--document-preview-pane-width": `${paneWidth}px`,
   } as CSSProperties;
+
+  useEffect(() => {
+    return () => cleanupAnime(paneAnimationRef.current);
+  }, []);
+
+  useEffect(() => {
+    const pane = paneRef.current;
+    if (!pane) return;
+
+    pane.style.opacity = "0";
+    pane.style.transform = "translateX(28px)";
+    if (window.matchMedia("(max-width: 767px)").matches) {
+      pane.style.transform = "translateY(18px)";
+    }
+
+    const direction = window.matchMedia("(max-width: 767px)").matches ? "bottom" : "right";
+    const animation = createTimelineIfMotion();
+    paneAnimationRef.current = animation;
+
+    if (!animation) {
+      pane.style.opacity = "1";
+      pane.style.transform = "translate3d(0, 0, 0)";
+      return;
+    }
+
+    animation.add(pane, {
+      opacity: [0, 1],
+      ...(direction === "bottom" ? { translateY: [18, 0] } : { translateX: [28, 0] }),
+      duration: 240,
+      ease: "out(3)",
+    }, 0);
+
+    return () => cleanupAnime(animation);
+  }, []);
 
   useEffect(() => {
     if (!kind || tooLarge || kind === "image") {
@@ -277,10 +317,45 @@ export default function DocumentPreviewPane({ attachment, onClose }: DocumentPre
     );
   })();
 
+  const handleClose = useCallback(() => {
+    if (closingRef.current) return;
+
+    const pane = paneRef.current;
+    if (!pane) {
+      onClose();
+      return;
+    }
+
+    closingRef.current = true;
+    cleanupAnime(paneAnimationRef.current);
+
+    const finishClose = () => {
+      paneAnimationRef.current = null;
+      onClose();
+    };
+
+    const direction = window.matchMedia("(max-width: 767px)").matches ? "bottom" : "right";
+    const animation = createTimelineIfMotion({ onComplete: finishClose });
+    paneAnimationRef.current = animation;
+
+    if (!animation) {
+      finishClose();
+      return;
+    }
+
+    animation.add(pane, {
+      opacity: 0,
+      ...(direction === "bottom" ? { translateY: 18 } : { translateX: 24 }),
+      duration: 160,
+      ease: "in(2)",
+    }, 0);
+  }, [onClose]);
+
   return (
     <aside
+      ref={paneRef}
       style={paneStyle}
-      className="relative flex h-full w-[var(--document-preview-pane-width)] max-w-[78vw] min-w-[360px] shrink-0 flex-col border-l border-glass-border bg-deep-black shadow-2xl shadow-black/40 max-md:absolute max-md:inset-0 max-md:z-40 max-md:w-full max-md:max-w-none max-md:min-w-0"
+      className="relative flex h-full w-[var(--document-preview-pane-width)] max-w-[78vw] min-w-[360px] shrink-0 flex-col border-l border-glass-border bg-deep-black shadow-2xl shadow-black/40 will-change-transform max-md:absolute max-md:inset-0 max-md:z-40 max-md:w-full max-md:max-w-none max-md:min-w-0"
     >
       {resizing && (
         <div className="fixed inset-0 z-[80] cursor-col-resize max-md:hidden" aria-hidden="true" />
@@ -322,7 +397,7 @@ export default function DocumentPreviewPane({ attachment, onClose }: DocumentPre
         </a>
         <button
           type="button"
-          onClick={onClose}
+          onClick={handleClose}
           className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-white/10 hover:text-text-primary"
           aria-label="Close preview"
           title="Close preview"

--- a/frontend/src/components/dashboard/FriendInviteModal.tsx
+++ b/frontend/src/components/dashboard/FriendInviteModal.tsx
@@ -7,8 +7,9 @@
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
 
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { api, humansApi } from "@/lib/api";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, animatePop, cleanupAnime } from "@/lib/anime";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { common } from "@/lib/i18n/translations/common";
 import { useLanguage } from "@/lib/i18n";
@@ -26,6 +27,13 @@ export default function FriendInviteModal({ onClose }: { onClose: () => void }) 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState<"link" | "prompt" | null>(null);
+  const [closing, setClosing] = useState(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const copyButtonRef = useRef<HTMLButtonElement>(null);
+  const errorRef = useRef<HTMLDivElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
+  const feedbackAnimationRef = useRef<ReturnType<typeof animatePop>>(null);
 
   async function handleCreate() {
     setLoading(true);
@@ -54,9 +62,40 @@ export default function FriendInviteModal({ onClose }: { onClose: () => void }) 
     }
   }
 
+  const closeWithMotion = useCallback(() => {
+    if (closing) return;
+    setClosing(true);
+    cleanupAnime(animationRef.current);
+    animationRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      onComplete: onClose,
+    });
+  }, [closing, onClose]);
+
+  useEffect(() => {
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current);
+    return () => cleanupAnime(animationRef.current);
+  }, []);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") closeWithMotion();
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [closeWithMotion]);
+
+  useEffect(() => {
+    const target = copied ? copyButtonRef.current : error ? errorRef.current : null;
+    if (!target) return;
+    cleanupAnime(feedbackAnimationRef.current);
+    feedbackAnimationRef.current = animatePop(target);
+    return () => cleanupAnime(feedbackAnimationRef.current);
+  }, [copied, error]);
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={onClose}>
+    <div ref={overlayRef} className={`fixed inset-0 z-50 flex items-center justify-center bg-black/60 ${closing ? "pointer-events-none" : ""}`} onClick={closeWithMotion}>
       <div
+        ref={panelRef}
         className="mx-4 w-full max-w-md rounded-xl border border-glass-border bg-deep-black p-6"
         onClick={(event) => event.stopPropagation()}
       >
@@ -66,7 +105,7 @@ export default function FriendInviteModal({ onClose }: { onClose: () => void }) 
         </p>
 
         {error ? (
-          <div className="mb-4 rounded border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-400">
+          <div ref={errorRef} className="mb-4 rounded border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-400">
             {error}
           </div>
         ) : null}
@@ -74,7 +113,7 @@ export default function FriendInviteModal({ onClose }: { onClose: () => void }) 
         {!invite ? (
           <div className="flex justify-end gap-2">
             <button
-              onClick={onClose}
+              onClick={closeWithMotion}
               className="rounded border border-glass-border px-4 py-2 text-sm text-text-secondary hover:text-text-primary"
             >
               {tc.cancel}
@@ -96,6 +135,7 @@ export default function FriendInviteModal({ onClose }: { onClose: () => void }) 
                   {t.invitePrompt}
                 </p>
                 <button
+                  ref={copyButtonRef}
                   onClick={() => copyField("prompt")}
                   className="shrink-0 rounded border border-neon-cyan/50 bg-neon-cyan/10 px-3 py-1 text-xs text-neon-cyan hover:bg-neon-cyan/20"
                 >
@@ -111,7 +151,7 @@ export default function FriendInviteModal({ onClose }: { onClose: () => void }) 
             </div>
             <div className="flex justify-end">
               <button
-                onClick={onClose}
+                onClick={closeWithMotion}
                 className="rounded border border-glass-border px-4 py-2 text-sm text-text-secondary hover:text-text-primary"
               >
                 {tc.done}

--- a/frontend/src/components/dashboard/HumanProfileEditModal.tsx
+++ b/frontend/src/components/dashboard/HumanProfileEditModal.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Loader2, UserRound, X } from "lucide-react";
 import { humansApi } from "@/lib/api";
 import { useLanguage } from "@/lib/i18n";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, animatePop, cleanupAnime } from "@/lib/anime";
 
 interface HumanProfileEditModalProps {
   onClose: () => void;
@@ -19,6 +20,12 @@ export default function HumanProfileEditModal({ onClose }: HumanProfileEditModal
   const [avatarUrl, setAvatarUrl] = useState(human?.avatar_url ?? "");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [closing, setClosing] = useState(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const errorRef = useRef<HTMLParagraphElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
+  const errorAnimationRef = useRef<ReturnType<typeof animatePop>>(null);
 
   useEffect(() => {
     setDisplayName(human?.display_name ?? "");
@@ -31,6 +38,44 @@ export default function HumanProfileEditModal({ onClose }: HumanProfileEditModal
   const avatarChanged = trimmedAvatar !== (human?.avatar_url ?? "").trim();
   const canSave = !saving && trimmedName.length > 0 && (nameChanged || avatarChanged);
 
+  const closeWithMotion = useCallback((force = false) => {
+    if ((saving && !force) || closing) return;
+    setClosing(true);
+    cleanupAnime(animationRef.current);
+    animationRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      onComplete: onClose,
+    });
+  }, [closing, onClose, saving]);
+
+  useLayoutEffect(() => {
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current, {
+      contentSelector: "[data-human-profile-modal-part]",
+      onComplete: () => {
+        animationRef.current = null;
+      },
+    });
+    return () => cleanupAnime(animationRef.current);
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") closeWithMotion();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [closeWithMotion]);
+
+  useEffect(() => {
+    if (!error || !errorRef.current) return;
+    cleanupAnime(errorAnimationRef.current);
+    errorAnimationRef.current = animatePop(errorRef.current);
+  }, [error]);
+
+  useEffect(() => () => {
+    cleanupAnime(animationRef.current);
+    cleanupAnime(errorAnimationRef.current);
+  }, []);
+
   async function handleSave() {
     if (!canSave) return;
     setSaving(true);
@@ -41,7 +86,7 @@ export default function HumanProfileEditModal({ onClose }: HumanProfileEditModal
       if (avatarChanged) patch.avatar_url = trimmedAvatar || null;
       const updated = await humansApi.updateProfile(patch);
       setHuman(updated);
-      onClose();
+      closeWithMotion(true);
     } catch (err: any) {
       setError(err?.message || (locale === "zh" ? "保存失败" : "Failed to save"));
       setSaving(false);
@@ -58,17 +103,29 @@ export default function HumanProfileEditModal({ onClose }: HumanProfileEditModal
   const tSaving = locale === "zh" ? "保存中..." : "Saving...";
 
   return (
-    <div className="fixed inset-0 z-[110] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm">
-      <div className="relative w-full max-w-md rounded-2xl border border-glass-border bg-deep-black-light p-5 shadow-2xl">
+    <div
+      ref={overlayRef}
+      className={`fixed inset-0 z-[110] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`}
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) closeWithMotion();
+      }}
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        className="relative w-full max-w-md rounded-2xl border border-glass-border bg-deep-black-light p-5 shadow-2xl"
+        onMouseDown={(event) => event.stopPropagation()}
+      >
         <button
-          onClick={onClose}
+          onClick={() => closeWithMotion()}
           disabled={saving}
           className="absolute right-4 top-4 rounded-full p-1.5 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
         >
           <X className="h-5 w-5" />
         </button>
 
-        <div className="mb-5 pr-8">
+        <div data-human-profile-modal-part className="mb-5 pr-8">
           <h3 className="flex items-center gap-2 text-xl font-bold text-text-primary">
             <UserRound className="h-5 w-5 text-neon-purple" />
             {tTitle}
@@ -79,7 +136,7 @@ export default function HumanProfileEditModal({ onClose }: HumanProfileEditModal
           )}
         </div>
 
-        <label className="mb-3 block">
+        <label data-human-profile-modal-part className="mb-3 block">
           <span className="mb-1 block text-xs font-medium text-text-secondary">{tNameLabel}</span>
           <input
             type="text"
@@ -91,7 +148,7 @@ export default function HumanProfileEditModal({ onClose }: HumanProfileEditModal
           />
         </label>
 
-        <label className="block">
+        <label data-human-profile-modal-part className="block">
           <span className="mb-1 block text-xs font-medium text-text-secondary">{tAvatarLabel}</span>
           <input
             type="url"
@@ -105,7 +162,7 @@ export default function HumanProfileEditModal({ onClose }: HumanProfileEditModal
         </label>
 
         {trimmedAvatar && (
-          <div className="mt-3 flex items-center gap-2 rounded-lg border border-glass-border bg-glass-bg p-2">
+          <div data-human-profile-modal-part className="mt-3 flex items-center gap-2 rounded-lg border border-glass-border bg-glass-bg p-2">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
               src={trimmedAvatar}
@@ -120,14 +177,14 @@ export default function HumanProfileEditModal({ onClose }: HumanProfileEditModal
         )}
 
         {error && (
-          <p className="mt-3 rounded-lg border border-red-400/20 bg-red-400/10 p-2 text-xs text-red-400">
+          <p ref={errorRef} className="mt-3 rounded-lg border border-red-400/20 bg-red-400/10 p-2 text-xs text-red-400">
             {error}
           </p>
         )}
 
-        <div className="mt-6 flex items-center justify-end gap-3">
+        <div data-human-profile-modal-part className="mt-6 flex items-center justify-end gap-3">
           <button
-            onClick={onClose}
+            onClick={() => closeWithMotion()}
             disabled={saving}
             className="rounded-xl border border-glass-border px-4 py-2.5 text-sm font-medium text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
           >

--- a/frontend/src/components/dashboard/MemberActionsMenu.tsx
+++ b/frontend/src/components/dashboard/MemberActionsMenu.tsx
@@ -7,9 +7,10 @@
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
 
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { PublicRoomMember } from "@/lib/types";
 import { humansApi } from "@/lib/api";
+import { animateIfMotion, animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from "@/lib/anime";
 import { useLanguage } from "@/lib/i18n";
 import { agentBrowser } from "@/lib/i18n/translations/dashboard";
 import { useConfirm } from "@/store/useConfirmStore";
@@ -33,6 +34,8 @@ export default function MemberActionsMenu({
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
   const [permOpen, setPermOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const menuAnimationRef = useRef<ReturnType<typeof animateIfMotion>>(null);
 
   const isOwner = viewerRole === "owner";
   const isOwnerTarget = member.role === "owner";
@@ -44,6 +47,19 @@ export default function MemberActionsMenu({
   // Already surfaced by the outer ✕ — this menu focuses on role + perms;
   // include Remove here too for a single unified surface.
   const canRemove = !isOwnerTarget && (isOwner || (viewerRole === "admin" && !isAdminTarget));
+
+  useEffect(() => {
+    if (!open || !menuRef.current) return;
+    cleanupAnime(menuAnimationRef.current);
+    menuAnimationRef.current = animateIfMotion(menuRef.current, {
+      opacity: [0, 1],
+      translateY: [-4, 0],
+      scale: [0.98, 1],
+      duration: 150,
+      ease: "out(3)",
+    });
+    return () => cleanupAnime(menuAnimationRef.current);
+  }, [open]);
 
   if (!canPromoteDemote && !canEditPerms && !canRemove) return null;
 
@@ -84,7 +100,7 @@ export default function MemberActionsMenu({
         ⋯
       </button>
       {open && (
-        <div className="absolute right-0 z-20 mt-1 min-w-[140px] rounded-md border border-glass-border bg-deep-black-light p-1 shadow-lg">
+        <div ref={menuRef} className="absolute right-0 z-20 mt-1 min-w-[140px] rounded-md border border-glass-border bg-deep-black-light p-1 shadow-lg">
           {canPromoteDemote && (
             <button
               onClick={toggleRole}
@@ -145,6 +161,10 @@ function PermissionsDialog({
   const [canSend, setCanSend] = useState<boolean | null>(member.can_send ?? null);
   const [canInvite, setCanInvite] = useState<boolean | null>(member.can_invite ?? null);
   const [saving, setSaving] = useState(false);
+  const [closing, setClosing] = useState(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
 
   const save = async () => {
     if (saving) return;
@@ -155,7 +175,7 @@ function PermissionsDialog({
         can_invite: canInvite,
       });
       onSaved();
-      onClose();
+      closeWithMotion();
     } catch (e: any) {
       onError(e?.message || t.permSaveFailed);
     } finally {
@@ -163,12 +183,36 @@ function PermissionsDialog({
     }
   };
 
+  const closeWithMotion = useCallback(() => {
+    if (saving || closing) return;
+    setClosing(true);
+    cleanupAnime(animationRef.current);
+    animationRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      onComplete: onClose,
+    });
+  }, [closing, onClose, saving]);
+
+  useEffect(() => {
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current);
+    return () => cleanupAnime(animationRef.current);
+  }, []);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") closeWithMotion();
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [closeWithMotion]);
+
   return (
     <div
-      className="fixed inset-0 z-30 flex items-center justify-center bg-black/60"
-      onClick={onClose}
+      ref={overlayRef}
+      className={`fixed inset-0 z-30 flex items-center justify-center bg-black/60 ${closing ? "pointer-events-none" : ""}`}
+      onClick={closeWithMotion}
     >
       <div
+        ref={panelRef}
         className="w-[320px] rounded-lg border border-glass-border bg-deep-black-light p-4"
         onClick={(e) => e.stopPropagation()}
       >
@@ -179,7 +223,7 @@ function PermissionsDialog({
         <TriToggle label={t.permCanInvite} value={canInvite} onChange={setCanInvite} t={t} />
         <div className="mt-4 flex justify-end gap-2">
           <button
-            onClick={onClose}
+            onClick={closeWithMotion}
             disabled={saving}
             className="rounded border border-glass-border px-3 py-1.5 text-[11px] text-text-secondary hover:bg-glass-bg"
           >

--- a/frontend/src/components/dashboard/PeerBotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/PeerBotDetailDrawer.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { memo, useEffect } from "react";
+import { memo, useCallback, useEffect, useRef } from "react";
 import { useRouter } from "nextjs-toploader/app";
 import { MessageCircle, UserCheck, UserPlus, X } from "lucide-react";
 import { useShallow } from "zustand/shallow";
 import { humansApi } from "@/lib/api";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from "@/lib/anime";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import BotAvatar from "./BotAvatar";
@@ -60,15 +61,40 @@ function PeerBotDetailDrawer() {
         (c) => c.contact_agent_id === peerBotAgentId && (c.peer_type ?? "agent") === "agent",
       ) ?? null
     : null;
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+  const panelRef = useRef<HTMLElement | null>(null);
+  const motionRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
+  const closingRef = useRef(false);
+
+  const closeDrawer = useCallback(() => {
+    if (closingRef.current) return;
+    closingRef.current = true;
+    cleanupAnime(motionRef.current);
+    motionRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      direction: "right",
+      contentSelector: "[data-overlay-section]",
+      onComplete: () => setPeerBotAgentId(null),
+    });
+  }, [setPeerBotAgentId]);
 
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setPeerBotAgentId(null);
+      if (e.key === "Escape") closeDrawer();
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [open, setPeerBotAgentId]);
+  }, [closeDrawer, open]);
+
+  useEffect(() => {
+    closingRef.current = false;
+    if (!open || (!peer && !contact)) return;
+    motionRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current, {
+      direction: "right",
+      contentSelector: "[data-overlay-section]",
+    });
+    return () => cleanupAnime(motionRef.current);
+  }, [contact?.contact_agent_id, open, peer?.agent_id]);
 
   if (!open || (!peer && !contact)) return null;
 
@@ -104,17 +130,20 @@ function PeerBotDetailDrawer() {
   return (
     <>
       <div
+        ref={overlayRef}
         className="fixed inset-0 z-40 bg-black/40 backdrop-blur-[2px]"
-        onClick={() => setPeerBotAgentId(null)}
+        onClick={closeDrawer}
         aria-hidden
       />
       <aside
+        ref={panelRef}
         className="fixed inset-y-0 right-0 z-50 flex w-full max-w-md flex-col border-l border-glass-border bg-deep-black-light shadow-2xl shadow-black/50"
         role="dialog"
+        aria-modal="true"
         aria-label="Bot 详情"
       >
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-glass-border px-5 py-4">
+        <div className="flex items-center justify-between border-b border-glass-border px-5 py-4" data-overlay-section>
           <div className="flex min-w-0 items-center gap-3">
             <BotAvatar agentId={agentId} size={40} alt={displayName} />
             <div className="min-w-0">
@@ -130,7 +159,7 @@ function PeerBotDetailDrawer() {
             </div>
           </div>
           <button
-            onClick={() => setPeerBotAgentId(null)}
+            onClick={closeDrawer}
             title="关闭"
             aria-label="关闭"
             className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-secondary/70 transition-colors hover:bg-glass-bg hover:text-text-primary"
@@ -140,7 +169,7 @@ function PeerBotDetailDrawer() {
         </div>
 
         {/* Body */}
-        <div className="flex-1 space-y-4 overflow-y-auto px-5 py-4">
+        <div className="flex-1 space-y-4 overflow-y-auto px-5 py-4" data-overlay-section>
           <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
             <p className="font-mono text-[11px] text-text-secondary/55">{agentId}</p>
             {bio ? (
@@ -162,7 +191,7 @@ function PeerBotDetailDrawer() {
         </div>
 
         {/* Footer actions */}
-        <div className="grid grid-cols-2 gap-2 border-t border-glass-border px-5 py-4">
+        <div className="grid grid-cols-2 gap-2 border-t border-glass-border px-5 py-4" data-overlay-section>
           <button
             onClick={handleMessage}
             className="col-span-2 inline-flex items-center justify-center gap-1.5 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-2 text-sm font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20"

--- a/frontend/src/components/dashboard/PlanChangeConfirmDialog.tsx
+++ b/frontend/src/components/dashboard/PlanChangeConfirmDialog.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Loader2, X } from "lucide-react";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from "@/lib/anime";
 import { useLanguage } from "@/lib/i18n";
 import { roomAdvancedSettings } from "@/lib/i18n/translations/dashboard";
 
@@ -23,6 +25,10 @@ export default function PlanChangeConfirmDialog({
 }: PlanChangeConfirmDialogProps) {
   const locale = useLanguage();
   const ta = roomAdvancedSettings[locale];
+  const [closing, setClosing] = useState(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
 
   const fromTo = ta.planChangeFromTo
     .replace("{from}", fromLabel)
@@ -32,18 +38,42 @@ export default function PlanChangeConfirmDialog({
     String(affectedCount),
   );
 
+  const closeWithMotion = useCallback(() => {
+    if (loading || closing) return;
+    setClosing(true);
+    cleanupAnime(animationRef.current);
+    animationRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      onComplete: onClose,
+    });
+  }, [closing, loading, onClose]);
+
+  useEffect(() => {
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current);
+    return () => cleanupAnime(animationRef.current);
+  }, []);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") closeWithMotion();
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [closeWithMotion]);
+
   return (
     <div
-      className="fixed inset-0 z-[80] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm"
-      onClick={onClose}
+      ref={overlayRef}
+      className={`fixed inset-0 z-[80] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`}
+      onClick={closeWithMotion}
     >
       <div
+        ref={panelRef}
         className="relative w-full max-w-md rounded-2xl border border-glass-border bg-deep-black-light p-5 shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
         <button
           type="button"
-          onClick={onClose}
+          onClick={closeWithMotion}
           disabled={loading}
           className="absolute right-4 top-4 rounded-full p-1.5 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
           aria-label={ta.planChangeCancel}
@@ -65,7 +95,7 @@ export default function PlanChangeConfirmDialog({
         <div className="mt-5 flex justify-end gap-2">
           <button
             type="button"
-            onClick={onClose}
+            onClick={closeWithMotion}
             disabled={loading}
             className="rounded-lg border border-glass-border px-3 py-1.5 text-sm text-text-secondary transition-colors hover:bg-glass-bg disabled:opacity-50"
           >

--- a/frontend/src/components/dashboard/RoomHeader.tsx
+++ b/frontend/src/components/dashboard/RoomHeader.tsx
@@ -24,6 +24,7 @@ import RoomSettingsModal from "./RoomSettingsModal";
 import DMSettingsModal from "./DMSettingsModal";
 import AddRoomMemberModal from "./AddRoomMemberModal";
 import { dmPeerId, resolveDmDisplayName } from "./dmRoom";
+import { animateIfMotion, cleanupAnime } from "@/lib/anime";
 
 const OPEN_ROOM_ADD_MEMBER_EVENT = "botcord:open-room-add-member";
 const OPEN_ROOM_SETTINGS_EVENT = "botcord:open-room-settings";
@@ -38,6 +39,10 @@ export default function RoomHeader() {
   const [addMemberLoading, setAddMemberLoading] = useState(false);
   const [humanJoining, setHumanJoining] = useState(false);
   const rulePopoverRef = useRef<HTMLDivElement>(null);
+  const rulePopoverPanelRef = useRef<HTMLDivElement>(null);
+  const rulePopoverBackdropRef = useRef<HTMLButtonElement>(null);
+  const rulePopoverAnimationRef = useRef<ReturnType<typeof animateIfMotion>>(null);
+  const rulePopoverBackdropAnimationRef = useRef<ReturnType<typeof animateIfMotion>>(null);
   const locale = useLanguage();
   const router = useRouter();
   const t = roomList[locale];
@@ -118,6 +123,29 @@ export default function RoomHeader() {
       : `you are ${myRole}`
     : null;
 
+  const closeRulePopover = useCallback(() => {
+    cleanupAnime(rulePopoverAnimationRef.current);
+    cleanupAnime(rulePopoverBackdropAnimationRef.current);
+    if (rulePopoverBackdropRef.current) {
+      rulePopoverBackdropAnimationRef.current = animateIfMotion(rulePopoverBackdropRef.current, {
+        opacity: [1, 0],
+        duration: 120,
+        ease: "linear",
+      });
+    }
+    if (rulePopoverPanelRef.current) {
+      rulePopoverAnimationRef.current = animateIfMotion(rulePopoverPanelRef.current, {
+        opacity: [1, 0],
+        scale: [1, 0.98],
+        translateY: [0, 6],
+        duration: 140,
+        ease: "in(2)",
+        onComplete: () => setShowRulePopover(false),
+      });
+    }
+    if (!rulePopoverAnimationRef.current) setShowRulePopover(false);
+  }, []);
+
   useEffect(() => {
     if (!canActAsCurrentViewer || !room?.room_id || isJoined || !isInviteOnly) return;
     setJoinRequestStatus("idle");
@@ -135,14 +163,41 @@ export default function RoomHeader() {
   // Close rule popover on outside click
   useEffect(() => {
     if (!showRulePopover) return;
+    cleanupAnime(rulePopoverAnimationRef.current);
+    cleanupAnime(rulePopoverBackdropAnimationRef.current);
+    if (rulePopoverBackdropRef.current) {
+      rulePopoverBackdropAnimationRef.current = animateIfMotion(rulePopoverBackdropRef.current, {
+        opacity: [0, 1],
+        duration: 150,
+        ease: "linear",
+      });
+    }
+    if (rulePopoverPanelRef.current) {
+      rulePopoverAnimationRef.current = animateIfMotion(rulePopoverPanelRef.current, {
+        opacity: [0, 1],
+        scale: [0.97, 1],
+        translateY: [8, 0],
+        duration: 210,
+        ease: "out(3)",
+      });
+    }
     const onClick = (e: MouseEvent) => {
       if (rulePopoverRef.current && !rulePopoverRef.current.contains(e.target as Node)) {
-        setShowRulePopover(false);
+        closeRulePopover();
       }
     };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") closeRulePopover();
+    };
     document.addEventListener("mousedown", onClick);
-    return () => document.removeEventListener("mousedown", onClick);
-  }, [showRulePopover]);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onClick);
+      document.removeEventListener("keydown", onKeyDown);
+      cleanupAnime(rulePopoverAnimationRef.current);
+      cleanupAnime(rulePopoverBackdropAnimationRef.current);
+    };
+  }, [closeRulePopover, showRulePopover]);
 
   useLayoutEffect(() => {
     const el = ruleRef.current;
@@ -321,7 +376,10 @@ export default function RoomHeader() {
             {hasInfo && (
               <div className="relative" ref={rulePopoverRef}>
                 <button
-                  onClick={() => setShowRulePopover((v) => !v)}
+                  onClick={() => {
+                    if (showRulePopover) closeRulePopover();
+                    else setShowRulePopover(true);
+                  }}
                   className={`${iconBtn} text-neon-cyan`}
                   title={t.viewRoomInfo}
                   aria-label={t.viewRoomInfo}
@@ -331,18 +389,22 @@ export default function RoomHeader() {
                 {showRulePopover && (
                   <>
                     <button
+                      ref={rulePopoverBackdropRef}
                       type="button"
                       aria-label="Close"
-                      onClick={() => setShowRulePopover(false)}
+                      onClick={closeRulePopover}
                       className="fixed inset-0 z-40 hidden bg-black/70 backdrop-blur-sm max-md:block"
                     />
                     <div
+                      ref={rulePopoverPanelRef}
+                      role="dialog"
+                      aria-modal="true"
                       className="absolute left-0 top-full z-50 mt-1 w-[min(32rem,calc(100vw-2rem))] space-y-3 rounded-lg border border-glass-border bg-deep-black p-3 shadow-xl
                         max-md:fixed max-md:inset-x-4 max-md:top-1/2 max-md:mt-0 max-md:w-auto max-md:max-h-[75vh] max-md:-translate-y-1/2 max-md:space-y-4 max-md:overflow-y-auto max-md:rounded-2xl max-md:border-glass-border max-md:bg-deep-black-light max-md:p-5 max-md:pt-12 max-md:shadow-2xl"
                     >
                       <button
                         type="button"
-                        onClick={() => setShowRulePopover(false)}
+                        onClick={closeRulePopover}
                         className="absolute right-3 top-3 hidden h-7 w-7 items-center justify-center rounded text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary max-md:inline-flex"
                         aria-label="Close"
                       >

--- a/frontend/src/components/dashboard/RoomHumanComposer.tsx
+++ b/frontend/src/components/dashboard/RoomHumanComposer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { api, ApiError, type ActiveIdentity } from "@/lib/api";
 import { useLanguage, chatPane } from "@/lib/i18n";
 import { transferDialog } from "@/lib/i18n/translations/dashboard";
@@ -14,6 +14,7 @@ import { dashboardReplyTargetId } from "@/lib/dashboard-message-actions";
 import { useMentionCandidates } from "@/hooks/useMentionCandidates";
 import { CornerUpLeft, Loader2, X } from "lucide-react";
 import DashboardSelect from "./DashboardSelect";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from "@/lib/anime";
 
 interface RoomHumanComposerProps {
   roomId: string;
@@ -40,6 +41,9 @@ function RoomTransferDialog({ roomId, members, senderIdentity, onClose, onSucces
   const [memo, setMemo] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
 
   const recipientOptions = useMemo(() => {
     const seen = new Set<string>();
@@ -58,6 +62,28 @@ function RoomTransferDialog({ roomId, members, senderIdentity, onClose, onSucces
         };
       });
   }, [members, senderId]);
+
+  const closeWithMotion = useCallback((afterClose?: () => void) => {
+    cleanupAnime(animationRef.current);
+    animationRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      onComplete: () => {
+        onClose();
+        afterClose?.();
+      },
+    });
+  }, [onClose]);
+
+  useEffect(() => {
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current);
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") closeWithMotion();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      cleanupAnime(animationRef.current);
+    };
+  }, [closeWithMotion]);
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -92,7 +118,7 @@ function RoomTransferDialog({ roomId, members, senderIdentity, onClose, onSucces
         room_id: roomId,
         idempotency_key: crypto.randomUUID(),
       }, senderIdentity);
-      onSuccess();
+      closeWithMotion(onSuccess);
     } catch (err) {
       setError(err instanceof ApiError ? err.message : t.transferFailed);
     } finally {
@@ -102,16 +128,20 @@ function RoomTransferDialog({ roomId, members, senderIdentity, onClose, onSucces
 
   return (
     <div
+      ref={overlayRef}
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4 backdrop-blur-sm"
-      onClick={onClose}
+      onClick={() => closeWithMotion()}
     >
       <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
         className="relative w-full max-w-md rounded-xl border border-glass-border bg-glass-bg p-5 backdrop-blur-xl"
         onClick={(event) => event.stopPropagation()}
       >
         <button
           type="button"
-          onClick={onClose}
+          onClick={() => closeWithMotion()}
           className="absolute right-3 top-3 rounded p-1 text-text-secondary hover:text-text-primary"
           aria-label="Close transfer dialog"
         >
@@ -176,7 +206,7 @@ function RoomTransferDialog({ roomId, members, senderIdentity, onClose, onSucces
           <div className="flex items-center justify-end gap-2 pt-1">
             <button
               type="button"
-              onClick={onClose}
+              onClick={() => closeWithMotion()}
               disabled={submitting}
               className="rounded-lg border border-glass-border px-4 py-2 text-sm text-text-secondary transition-colors hover:text-text-primary disabled:opacity-40"
             >

--- a/frontend/src/components/dashboard/RoomMemberSettingsModal.tsx
+++ b/frontend/src/components/dashboard/RoomMemberSettingsModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { useRouter } from "nextjs-toploader/app";
 import { useShallow } from "zustand/react/shallow";
@@ -8,6 +8,7 @@ import { useLanguage } from "@/lib/i18n";
 import { roomMemberSettingsModal } from "@/lib/i18n/translations/dashboard";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSubscriptionStore } from "@/store/useDashboardSubscriptionStore";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from "@/lib/anime";
 
 interface RoomMemberSettingsModalProps {
   roomId: string;
@@ -44,6 +45,9 @@ export default function RoomMemberSettingsModal({
   const [error, setError] = useState<string | null>(null);
   const [cancellingSubscription, setCancellingSubscription] = useState(false);
   const [confirmingLeave, setConfirmingLeave] = useState(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
 
   const isOwner = myRole === "owner";
   const isLeaving = leavingRoomId === roomId;
@@ -51,6 +55,28 @@ export default function RoomMemberSettingsModal({
     ? getActiveSubscription(requiredSubscriptionProductId)
     : null;
   const isSubscriptionRoom = Boolean(requiredSubscriptionProductId);
+
+  const closeWithMotion = useCallback((afterClose?: () => void) => {
+    cleanupAnime(animationRef.current);
+    animationRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      onComplete: () => {
+        onClose();
+        afterClose?.();
+      },
+    });
+  }, [onClose]);
+
+  useEffect(() => {
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current);
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") closeWithMotion();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      cleanupAnime(animationRef.current);
+    };
+  }, [closeWithMotion]);
 
   const handleLeave = async () => {
     if (isOwner) return;
@@ -61,8 +87,7 @@ export default function RoomMemberSettingsModal({
     setError(null);
     try {
       await leaveRoom(roomId);
-      onClose();
-      router.push("/chats/messages");
+      closeWithMotion(() => router.push("/chats/messages"));
     } catch (err) {
       setError(err instanceof Error ? err.message : t.leaveRoomFailed);
       setConfirmingLeave(false);
@@ -75,7 +100,7 @@ export default function RoomMemberSettingsModal({
     setCancellingSubscription(true);
     try {
       await cancelSubscription(activeSubscription.subscription_id);
-      onClose();
+      closeWithMotion();
     } catch (err) {
       setError(err instanceof Error ? err.message : t.cancelSubscriptionFailed);
     } finally {
@@ -84,8 +109,11 @@ export default function RoomMemberSettingsModal({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4" onClick={onClose}>
+    <div ref={overlayRef} className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4" onClick={() => closeWithMotion()}>
       <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
         className="flex max-h-[90vh] w-full max-w-sm flex-col overflow-hidden rounded-xl border border-glass-border bg-deep-black"
         onClick={(e) => e.stopPropagation()}
       >
@@ -157,7 +185,7 @@ export default function RoomMemberSettingsModal({
             )
           )}
           <button
-            onClick={onClose}
+            onClick={() => closeWithMotion()}
             className="ml-auto rounded border border-glass-border px-4 py-2 text-sm text-text-secondary hover:text-text-primary"
           >
             {t.close}

--- a/frontend/src/components/dashboard/RoomPolicyModal.tsx
+++ b/frontend/src/components/dashboard/RoomPolicyModal.tsx
@@ -16,7 +16,7 @@
  * [PROTOCOL]: update header on changes
  */
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Bell, Loader2, RotateCcw, X } from "lucide-react";
 import { api } from "@/lib/api";
@@ -27,6 +27,7 @@ import {
   type AttentionMode,
   type RoomPolicyEffective,
 } from "@/store/usePolicyStore";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from "@/lib/anime";
 
 const ATTENTION_OPTIONS: { value: AttentionMode; label: string; hint: string }[] = [
   { value: "always", label: "所有消息", hint: "本房间任何新消息都会唤醒 Bot" },
@@ -77,6 +78,9 @@ export default function RoomPolicyModal({
   const [members, setMembers] = useState<PublicRoomMember[]>([]);
   const [membersLoading, setMembersLoading] = useState(false);
   const [mounted, setMounted] = useState(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
 
   useEffect(() => {
     setMounted(true);
@@ -150,16 +154,43 @@ export default function RoomPolicyModal({
     [],
   );
 
+  const closeWithMotion = useCallback(() => {
+    cleanupAnime(animationRef.current);
+    animationRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      contentSelector: "[data-motion-item]",
+      onComplete: onClose,
+    });
+  }, [onClose]);
+
+  useEffect(() => {
+    if (!mounted) return;
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current, {
+      contentSelector: "[data-motion-item]",
+    });
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") closeWithMotion();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      cleanupAnime(animationRef.current);
+    };
+  }, [closeWithMotion, mounted]);
+
   const modal = (
     <div
+      ref={overlayRef}
       className="fixed inset-0 z-[80] flex items-center justify-center bg-black/70 px-4 py-6 backdrop-blur"
-      onClick={onClose}
+      onClick={closeWithMotion}
     >
       <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
         className="max-h-[calc(100vh-48px)] w-full max-w-lg overflow-y-auto rounded-2xl border border-glass-border bg-deep-black-light p-5 shadow-2xl"
         onClick={(event) => event.stopPropagation()}
       >
-        <div className="mb-4 flex items-start justify-between">
+        <div data-motion-item className="mb-4 flex items-start justify-between">
           <div className="min-w-0">
             <div className="mb-1 flex items-center gap-2">
               <Bell className="h-4 w-4 text-neon-cyan" />
@@ -172,7 +203,7 @@ export default function RoomPolicyModal({
           </div>
           <button
             type="button"
-            onClick={onClose}
+            onClick={closeWithMotion}
             className="rounded p-1 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
             aria-label="关闭"
           >
@@ -181,7 +212,7 @@ export default function RoomPolicyModal({
         </div>
 
         {loading && !data ? (
-          <div className="flex items-center gap-2 rounded-xl border border-glass-border bg-glass-bg/40 px-3 py-3 text-sm text-text-secondary">
+          <div data-motion-item className="flex items-center gap-2 rounded-xl border border-glass-border bg-glass-bg/40 px-3 py-3 text-sm text-text-secondary">
             <MobileBotCordLoading
               label="加载中…"
               size="sm"
@@ -190,12 +221,12 @@ export default function RoomPolicyModal({
             />
           </div>
         ) : error && !data ? (
-          <div className="rounded-xl border border-red-400/20 bg-red-400/5 px-3 py-3 text-sm text-red-300">
+          <div data-motion-item className="rounded-xl border border-red-400/20 bg-red-400/5 px-3 py-3 text-sm text-red-300">
             加载失败：{error}
           </div>
         ) : data && effective ? (
           isDM ? (
-            <div className="rounded-xl border border-neon-cyan/25 bg-neon-cyan/5 px-4 py-4">
+            <div data-motion-item className="rounded-xl border border-neon-cyan/25 bg-neon-cyan/5 px-4 py-4">
               <div className="text-sm font-medium text-neon-cyan">私聊始终唤醒</div>
               <p className="mt-1 text-xs text-text-secondary">
                 DM 房间当前强制使用所有消息唤醒，不能在房间级静音或覆盖。
@@ -205,7 +236,7 @@ export default function RoomPolicyModal({
             <>
               <EffectiveBadge effective={effective} hasOverride={hasOverride} />
 
-              <div className="mt-4">
+              <div data-motion-item className="mt-4">
                 <div className="mb-2 text-xs font-medium uppercase tracking-normal text-text-secondary">
                   快速静音
                 </div>
@@ -257,7 +288,7 @@ export default function RoomPolicyModal({
                 </div>
               </div>
 
-              <div className="mt-4 rounded-xl border border-glass-border bg-glass-bg/30 p-3">
+              <div data-motion-item className="mt-4 rounded-xl border border-glass-border bg-glass-bg/30 p-3">
                 <button
                   type="button"
                   onClick={() => setExpanded((v) => !v)}
@@ -289,7 +320,7 @@ export default function RoomPolicyModal({
               </div>
 
               {hasOverride ? (
-                <div className="mt-4">
+                <div data-motion-item className="mt-4">
                   <button
                     type="button"
                     onClick={() =>

--- a/frontend/src/components/dashboard/RoomSettingsModal.tsx
+++ b/frontend/src/components/dashboard/RoomSettingsModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChevronDown, Loader2, Search, Trash2, X } from "lucide-react";
 import { useRouter } from "nextjs-toploader/app";
 import CopyableId from "@/components/ui/CopyableId";
@@ -23,6 +23,7 @@ import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardSubscriptionStore } from "@/store/useDashboardSubscriptionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import DashboardSelect from "./DashboardSelect";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from "@/lib/anime";
 
 interface RoomSettingsModalProps {
   roomId: string;
@@ -251,6 +252,10 @@ export default function RoomSettingsModal({
   const [dissolveConfirmText, setDissolveConfirmText] = useState("");
   const [cancellingSubscription, setCancellingSubscription] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const motionRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
+  const closingRef = useRef(false);
   const groupInitial = name.trim().charAt(0).toUpperCase() || "G";
   const persistedRoomName = initialName.trim();
   const dissolveConfirmArmed = dissolveConfirmText.trim() === persistedRoomName;
@@ -273,6 +278,33 @@ export default function RoomSettingsModal({
     [roomMemberIds, sessionOwnedAgents],
   );
   const selectedPolicyAgent = roomOwnedAgents.find((agent) => agent.agent_id === policyAgentId) ?? null;
+
+  const closeWithAnimation = useCallback(() => {
+    if (closingRef.current) return;
+    closingRef.current = true;
+    cleanupAnime(motionRef.current);
+    motionRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      direction: "right",
+      contentSelector: "[data-overlay-section]",
+      onComplete: onClose,
+    });
+  }, [onClose]);
+
+  useEffect(() => {
+    motionRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current, {
+      direction: "right",
+      contentSelector: "[data-overlay-section]",
+    });
+    return () => cleanupAnime(motionRef.current);
+  }, []);
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") closeWithAnimation();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [closeWithAnimation]);
 
   useEffect(() => {
     let cancelled = false;
@@ -645,16 +677,20 @@ export default function RoomSettingsModal({
   };
 
   return (
-    <div className="fixed inset-0 z-50 bg-black/60" onClick={onClose}>
+    <div ref={overlayRef} className="fixed inset-0 z-50 bg-black/60" onClick={closeWithAnimation}>
       <div
+        ref={panelRef}
         className="ml-auto flex h-full w-full max-w-[520px] flex-col overflow-hidden border-l border-glass-border bg-deep-black shadow-2xl"
         onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="room-settings-title"
       >
         <div className="flex items-center justify-between border-b border-glass-border px-6 py-4">
-          <h2 className="text-xl font-semibold text-text-primary">{t.title}</h2>
+          <h2 id="room-settings-title" className="text-xl font-semibold text-text-primary">{t.title}</h2>
           <button
             type="button"
-            onClick={onClose}
+            onClick={closeWithAnimation}
             className="rounded-full p-2 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
             aria-label={t.cancel}
           >
@@ -670,7 +706,7 @@ export default function RoomSettingsModal({
           )}
 
           <div className="divide-y divide-glass-border/80">
-            <section className="py-5">
+            <section className="py-5" data-overlay-section>
               <div className="flex items-start gap-4">
                 <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full border border-neon-cyan/30 bg-neon-cyan/10 text-2xl font-semibold text-neon-cyan">
                   {groupInitial}
@@ -751,7 +787,7 @@ export default function RoomSettingsModal({
               </div>
             </section>
 
-            <section className="py-5">
+            <section className="py-5" data-overlay-section>
               <div className="flex items-center justify-between py-1">
                 <div>
                   <p className="text-lg font-semibold text-text-primary">{t.membersSection}</p>
@@ -929,7 +965,7 @@ export default function RoomSettingsModal({
               </section>
             ) : null}
 
-            <section className="py-5">
+            <section className="py-5" data-overlay-section>
               <button
                 type="button"
                 onClick={() => setAdvancedOpen((v) => !v)}
@@ -1020,7 +1056,7 @@ export default function RoomSettingsModal({
               )}
             </section>
 
-            <section className="py-5">
+            <section className="py-5" data-overlay-section>
               <button
                 type="button"
                 onClick={() => setSubscriptionOpen((v) => !v)}
@@ -1152,7 +1188,7 @@ export default function RoomSettingsModal({
               )}
             </section>
 
-            {(viewerRole || isOwner) && <section className="py-5">
+            {(viewerRole || isOwner) && <section className="py-5" data-overlay-section>
               <div>
                 <p className="text-lg font-semibold text-text-primary">{t.actionsSection}</p>
               </div>
@@ -1229,7 +1265,7 @@ export default function RoomSettingsModal({
 
         <div className="flex justify-end gap-2 border-t border-glass-border px-6 py-4">
           <button
-            onClick={onClose}
+            onClick={closeWithAnimation}
             disabled={saving}
             className="rounded-xl border border-glass-border px-4 py-2.5 text-sm text-text-secondary hover:text-text-primary disabled:opacity-50"
           >

--- a/frontend/src/components/dashboard/RuntimeErrorDetailsDialog.tsx
+++ b/frontend/src/components/dashboard/RuntimeErrorDetailsDialog.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Copy, X } from "lucide-react";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, animatePop, cleanupAnime } from "@/lib/anime";
 
 interface RuntimeErrorDetailsDialogProps {
   title?: string;
@@ -25,6 +27,12 @@ export default function RuntimeErrorDetailsDialog({
   payload,
   onClose,
 }: RuntimeErrorDetailsDialogProps) {
+  const [closing, setClosing] = useState(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const copyButtonRef = useRef<HTMLButtonElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
+  const copyAnimationRef = useRef<ReturnType<typeof animatePop>>(null);
   const raw = prettyJson(payload);
   const copyText = [
     title,
@@ -33,12 +41,36 @@ export default function RuntimeErrorDetailsDialog({
     raw ? `Payload:\n${raw}` : null,
   ].filter(Boolean).join("\n\n");
 
+  const closeWithMotion = useCallback(() => {
+    if (closing) return;
+    setClosing(true);
+    cleanupAnime(animationRef.current);
+    animationRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      onComplete: onClose,
+    });
+  }, [closing, onClose]);
+
+  useEffect(() => {
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current);
+    return () => cleanupAnime(animationRef.current);
+  }, []);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") closeWithMotion();
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [closeWithMotion]);
+
   return (
     <div
-      className="fixed inset-0 z-[80] flex items-center justify-center bg-black/60 px-4 backdrop-blur-sm"
-      onClick={onClose}
+      ref={overlayRef}
+      className={`fixed inset-0 z-[80] flex items-center justify-center bg-black/60 px-4 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`}
+      onClick={closeWithMotion}
     >
       <div
+        ref={panelRef}
         className="w-full max-w-lg rounded-xl border border-amber-400/25 bg-zinc-950 shadow-2xl"
         onClick={(event) => event.stopPropagation()}
       >
@@ -49,7 +81,7 @@ export default function RuntimeErrorDetailsDialog({
           </div>
           <button
             type="button"
-            onClick={onClose}
+            onClick={closeWithMotion}
             className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-zinc-500 transition-colors hover:bg-zinc-800 hover:text-zinc-200"
             aria-label="Close"
           >
@@ -78,7 +110,14 @@ export default function RuntimeErrorDetailsDialog({
         <div className="flex justify-end gap-2 border-t border-amber-400/15 px-4 py-3">
           <button
             type="button"
-            onClick={() => void navigator.clipboard?.writeText(copyText)}
+            ref={copyButtonRef}
+            onClick={() => {
+              void navigator.clipboard?.writeText(copyText);
+              if (copyButtonRef.current) {
+                cleanupAnime(copyAnimationRef.current);
+                copyAnimationRef.current = animatePop(copyButtonRef.current);
+              }
+            }}
             className="inline-flex items-center gap-1.5 rounded-lg border border-zinc-700 px-3 py-1.5 text-xs text-zinc-300 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
           >
             <Copy className="h-3.5 w-3.5" />
@@ -86,7 +125,7 @@ export default function RuntimeErrorDetailsDialog({
           </button>
           <button
             type="button"
-            onClick={onClose}
+            onClick={closeWithMotion}
             className="rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-1.5 text-xs font-medium text-amber-200 transition-colors hover:bg-amber-400/20"
           >
             Close

--- a/frontend/src/components/dashboard/SearchBar.tsx
+++ b/frontend/src/components/dashboard/SearchBar.tsx
@@ -10,6 +10,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useLanguage } from '@/lib/i18n';
 import { searchBar } from '@/lib/i18n/translations/dashboard';
+import { animateIfMotion, cleanupAnime } from "@/lib/anime";
 
 interface SearchBarProps {
   onSearch: (query: string) => void;
@@ -21,7 +22,9 @@ export default function SearchBar({ onSearch, placeholder }: SearchBarProps) {
   const t = searchBar[locale];
   const resolvedPlaceholder = placeholder || t.placeholder;
   const [value, setValue] = useState("");
+  const inputRef = useRef<HTMLInputElement | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const feedbackAnimationRef = useRef<ReturnType<typeof animateIfMotion>>(null);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const v = e.target.value;
@@ -30,15 +33,36 @@ export default function SearchBar({ onSearch, placeholder }: SearchBarProps) {
     timerRef.current = setTimeout(() => onSearch(v), 300);
   };
 
-  useEffect(() => () => clearTimeout(timerRef.current), []);
+  const handleFocus = () => {
+    const input = inputRef.current;
+    if (!input) return;
+
+    cleanupAnime(feedbackAnimationRef.current);
+    feedbackAnimationRef.current = animateIfMotion(input, {
+      boxShadow: [
+        "0 0 0 rgba(34, 211, 238, 0)",
+        "0 0 14px rgba(34, 211, 238, 0.18)",
+        "0 0 0 rgba(34, 211, 238, 0)",
+      ],
+      duration: 420,
+      ease: "out(3)",
+    });
+  };
+
+  useEffect(() => () => {
+    clearTimeout(timerRef.current);
+    cleanupAnime(feedbackAnimationRef.current);
+  }, []);
 
   return (
     <input
+      ref={inputRef}
       type="text"
       value={value}
       onChange={handleChange}
+      onFocus={handleFocus}
       placeholder={resolvedPlaceholder}
-      className="w-full rounded-lg border border-glass-border bg-deep-black-light px-3 py-2 text-sm text-text-primary placeholder-text-secondary/50 outline-none focus:border-neon-cyan/50"
+      className="w-full rounded-lg border border-glass-border bg-deep-black-light px-3 py-2 text-sm text-text-primary placeholder-text-secondary/50 outline-none transition-colors focus:border-neon-cyan/50"
     />
   );
 }

--- a/frontend/src/components/dashboard/SettingsModal.tsx
+++ b/frontend/src/components/dashboard/SettingsModal.tsx
@@ -8,26 +8,64 @@
  */
 
 import PolicySettingsClient from "@/app/(dashboard)/settings/policy/PolicySettingsClient";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from "@/lib/anime";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 
 interface SettingsModalProps {
   onClose: () => void;
 }
 
 export default function SettingsModal({ onClose }: SettingsModalProps) {
+  const [closing, setClosing] = useState(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
+
+  const closeWithMotion = useCallback(() => {
+    if (closing) return;
+    setClosing(true);
+    cleanupAnime(animationRef.current);
+    animationRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      onComplete: onClose,
+    });
+  }, [closing, onClose]);
+
+  useLayoutEffect(() => {
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current, {
+      contentSelector: "[data-settings-modal-part]",
+      onComplete: () => {
+        animationRef.current = null;
+      },
+    });
+    return () => cleanupAnime(animationRef.current);
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") closeWithMotion();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [closeWithMotion]);
+
   return (
     <div
-      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/60 backdrop-blur-sm py-8 px-4"
-      onClick={onClose}
+      ref={overlayRef}
+      className={`fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/60 backdrop-blur-sm py-8 px-4 ${closing ? "pointer-events-none" : ""}`}
+      onClick={closeWithMotion}
     >
       <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
         className="relative w-full max-w-2xl rounded-2xl border border-glass-border bg-deep-black-light shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between border-b border-glass-border/50 px-6 py-4">
+        <div data-settings-modal-part className="flex items-center justify-between border-b border-glass-border/50 px-6 py-4">
           <span className="text-sm font-semibold text-text-primary">设置</span>
           <button
             type="button"
-            onClick={onClose}
+            onClick={closeWithMotion}
             className="flex h-7 w-7 items-center justify-center rounded-lg text-text-secondary/60 transition-colors hover:bg-glass-bg hover:text-text-primary"
           >
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="h-4 w-4">
@@ -35,7 +73,7 @@ export default function SettingsModal({ onClose }: SettingsModalProps) {
             </svg>
           </button>
         </div>
-        <div className="px-6 py-6">
+        <div data-settings-modal-part className="px-6 py-6">
           <PolicySettingsClient />
         </div>
       </div>

--- a/frontend/src/components/dashboard/ShareModal.tsx
+++ b/frontend/src/components/dashboard/ShareModal.tsx
@@ -6,7 +6,7 @@
  */
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLanguage } from "@/lib/i18n";
 import { shareModal } from "@/lib/i18n/translations/dashboard";
 import { common } from "@/lib/i18n/translations/common";
@@ -15,6 +15,7 @@ import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import type { CreateShareResponse, InvitePreviewResponse, PublicRoomMember } from "@/lib/types";
 import { Globe2, Link2, Loader2, Lock, Sparkles, X } from "lucide-react";
 import { initialsFromName, themeFromRoomName } from "./roomVisualTheme";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from "@/lib/anime";
 
 interface ShareModalProps {
   roomId: string;
@@ -36,6 +37,37 @@ export default function ShareModal({ roomId, roomName, roomVisibility, canInvite
   const [members, setMembers] = useState<PublicRoomMember[]>([]);
   const [memberTotal, setMemberTotal] = useState(0);
   const [membersLoading, setMembersLoading] = useState(true);
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const motionRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
+  const closingRef = useRef(false);
+
+  const closeWithAnimation = useCallback(() => {
+    if (closingRef.current) return;
+    closingRef.current = true;
+    cleanupAnime(motionRef.current);
+    motionRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      direction: "center",
+      contentSelector: "[data-overlay-section]",
+      onComplete: onClose,
+    });
+  }, [onClose]);
+
+  useEffect(() => {
+    motionRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current, {
+      direction: "center",
+      contentSelector: "[data-overlay-section]",
+    });
+    return () => cleanupAnime(motionRef.current);
+  }, []);
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") closeWithAnimation();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [closeWithAnimation]);
 
   useEffect(() => {
     let cancelled = false;
@@ -125,14 +157,22 @@ export default function ShareModal({ roomId, roomName, roomVisibility, canInvite
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4 py-6 backdrop-blur-sm" onClick={onClose}>
+    <div
+      ref={overlayRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4 py-6 backdrop-blur-sm"
+      onClick={closeWithAnimation}
+    >
       <div
+        ref={panelRef}
         className="relative w-full max-w-2xl overflow-hidden rounded-[28px] shadow-[0_32px_120px_rgba(0,0,0,0.45)]"
         onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="share-modal-title"
       >
         <div className="relative flex max-h-[90vh] flex-col overflow-hidden">
           <button
-            onClick={onClose}
+            onClick={closeWithAnimation}
             className="absolute right-3 top-3 z-10 rounded-full bg-black/25 p-2 text-text-secondary transition-colors hover:bg-white/10 hover:text-text-primary"
             aria-label={common[locale].close}
             title={common[locale].close}
@@ -147,7 +187,7 @@ export default function ShareModal({ roomId, roomName, roomVisibility, canInvite
               </div>
             ) : null}
 
-            <section className="w-full">
+            <section className="w-full" data-overlay-section>
               <div
                 className="relative h-56 overflow-hidden rounded-[28px] border border-white/10"
                 style={{ backgroundImage: roomVisualTheme.patternUrl, backgroundRepeat: "repeat" }}
@@ -172,7 +212,7 @@ export default function ShareModal({ roomId, roomName, roomVisibility, canInvite
                         {roomInitials}
                       </div>
                       <div className="min-w-0">
-                        <h2 className="truncate text-[34px] font-semibold leading-none text-white">{roomName}</h2>
+                        <h2 id="share-modal-title" className="truncate text-[34px] font-semibold leading-none text-white">{roomName}</h2>
                         <p className="mt-3 text-sm leading-6 text-white/72">{t.createShareAssets}</p>
                       </div>
                     </div>
@@ -208,7 +248,7 @@ export default function ShareModal({ roomId, roomName, roomVisibility, canInvite
                 </div>
               </div>
 
-              <div className="space-y-4 px-1 pt-5">
+              <div className="space-y-4 px-1 pt-5" data-overlay-section>
                 {!canInvite ? (
                   <div className="space-y-3">
                     <button

--- a/frontend/src/components/dashboard/StreamBlocksView.tsx
+++ b/frontend/src/components/dashboard/StreamBlocksView.tsx
@@ -1,10 +1,14 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Search, FileText, CheckCircle2, Code2, Brain, HelpCircle, Wrench, ChevronDown, ChevronRight, Bot, AlertTriangle, ListTodo, Info } from "lucide-react";
 import type { StreamBlockEntry } from "@/lib/types";
+import { animateFadeUp, animateIfMotion, animeStagger, cleanupAnime, createTimelineIfMotion } from "@/lib/anime";
 import MarkdownContent from "@/components/ui/MarkdownContent";
 import ToolResultContent from "./ToolResultContent";
+
+type MotionAnimation = ReturnType<typeof animateIfMotion>;
+type MotionTimeline = ReturnType<typeof createTimelineIfMotion>;
 
 /** Icon for a tool_call based on tool name heuristics. */
 function ToolCallIcon({ name }: { name: string }) {
@@ -844,6 +848,13 @@ export default function StreamBlocksView({
   onScrollRequest?: () => void;
 }) {
   const [expanded, setExpanded] = useState(defaultExpanded ?? false);
+  const [renderExpandedContent, setRenderExpandedContent] = useState(defaultExpanded ?? false);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const rowAnimationRef = useRef<MotionAnimation>(null);
+  const panelAnimationRef = useRef<MotionTimeline>(null);
+  const composingAnimationRef = useRef<MotionAnimation>(null);
+  const previousRowKeysRef = useRef<Set<string>>(new Set());
+  const previousComposingTextRef = useRef("");
 
   const isAssistant = (k: string) => k === "assistant" || k === "assistant_text";
   const executionBlocks = blocks.filter((b) => !isAssistant(b.block.kind));
@@ -857,6 +868,8 @@ export default function StreamBlocksView({
   const normalized = displayBlocks.map((b) => normalizeBlock(b.block, { toolNameById }).kind);
   const toolCallCount = normalized.filter((k) => k === "tool_call").length;
   const reasoningCount = normalized.filter((k) => k === "reasoning").length;
+  const displayBlockKeys = displayBlocks.map((block) => `${block.trace_id}-${block.seq}`);
+  const displayBlockKeySignature = displayBlockKeys.join("|");
 
   /** Compose the streamed prose by walking every block — covers mixed
    *  Claude-code blocks where the daemon labelled the block as `tool_use`
@@ -905,6 +918,143 @@ export default function StreamBlocksView({
     onScrollRequest?.();
   }, [blocks.length, onScrollRequest]);
 
+  useEffect(() => () => {
+    cleanupAnime(rowAnimationRef.current);
+    cleanupAnime(panelAnimationRef.current);
+    cleanupAnime(composingAnimationRef.current);
+  }, []);
+
+  useEffect(() => {
+    if (expanded) {
+      cleanupAnime(panelAnimationRef.current);
+      panelAnimationRef.current = null;
+      setRenderExpandedContent(true);
+      return;
+    }
+
+    const content = contentRef.current;
+    cleanupAnime(panelAnimationRef.current);
+
+    if (!content) {
+      setRenderExpandedContent(false);
+      return;
+    }
+
+    const animation = createTimelineIfMotion({
+      onComplete: () => {
+        panelAnimationRef.current = null;
+        setRenderExpandedContent(false);
+      },
+    });
+    panelAnimationRef.current = animation;
+
+    if (!animation) {
+      setRenderExpandedContent(false);
+      return;
+    }
+
+    animation.add(content, {
+      opacity: 0,
+      translateY: -4,
+      duration: 120,
+      ease: "in(2)",
+    }, 0);
+  }, [expanded]);
+
+  useEffect(() => {
+    if (!renderExpandedContent) return;
+
+    const frameId = window.requestAnimationFrame(() => {
+      const content = contentRef.current;
+      if (!content) return;
+
+      cleanupAnime(panelAnimationRef.current);
+      panelAnimationRef.current = createTimelineIfMotion();
+      if (panelAnimationRef.current) {
+        panelAnimationRef.current.add(content, {
+          opacity: [0, 1],
+          translateY: [6, 0],
+          duration: 180,
+          ease: "out(3)",
+        }, 0);
+      } else {
+        content.style.opacity = "1";
+        content.style.transform = "translateY(0)";
+      }
+    });
+
+    return () => window.cancelAnimationFrame(frameId);
+  }, [renderExpandedContent]);
+
+  useEffect(() => {
+    if (!renderExpandedContent) {
+      previousRowKeysRef.current = new Set(displayBlockKeys);
+      previousComposingTextRef.current = composingText;
+      return;
+    }
+
+    const frameId = window.requestAnimationFrame(() => {
+      const content = contentRef.current;
+      if (!content) return;
+
+      const previousKeys = previousRowKeysRef.current;
+      const rows = Array.from(content.querySelectorAll<HTMLElement>("[data-stream-block-row]"));
+      const enteringRows = rows.filter((row) => {
+        const rowKey = row.dataset.streamBlockKey;
+        return !!rowKey && !previousKeys.has(rowKey);
+      });
+
+      cleanupAnime(rowAnimationRef.current);
+      if (enteringRows.length > 0) {
+        enteringRows.forEach((row) => {
+          row.style.opacity = "0";
+          row.style.transform = "translateY(6px)";
+        });
+        const rowAnimation = animateIfMotion(enteringRows, {
+          opacity: [0, 1],
+          translateY: [6, 0],
+          duration: 210,
+          delay: animeStagger(24),
+          ease: "out(3)",
+        });
+        rowAnimationRef.current = rowAnimation;
+        if (!rowAnimation) {
+          enteringRows.forEach((row) => {
+            row.style.opacity = "1";
+            row.style.transform = "translateY(0)";
+          });
+        }
+      }
+
+      previousRowKeysRef.current = new Set(displayBlockKeys);
+    });
+
+    return () => window.cancelAnimationFrame(frameId);
+  }, [renderExpandedContent, displayBlockKeySignature]);
+
+  useEffect(() => {
+    const hadComposingText = previousComposingTextRef.current.length > 0;
+    if (!renderExpandedContent || !composingText || hadComposingText) {
+      previousComposingTextRef.current = composingText;
+      return;
+    }
+
+    const frameId = window.requestAnimationFrame(() => {
+      const composing = contentRef.current?.querySelector<HTMLElement>("[data-stream-composing]");
+      if (!composing) return;
+
+      cleanupAnime(composingAnimationRef.current);
+      composingAnimationRef.current = animateFadeUp(composing, 20);
+      if (!composingAnimationRef.current) {
+        composing.style.opacity = "1";
+        composing.style.transform = "translateY(0)";
+      }
+      previousComposingTextRef.current = composingText;
+    });
+
+    return () => window.cancelAnimationFrame(frameId);
+  }, [renderExpandedContent, composingText]);
+
   if (blocks.length === 0 || displayBlocks.length === 0) return null;
 
   const summaryParts: string[] = [];
@@ -921,25 +1071,32 @@ export default function StreamBlocksView({
               onClick={() => setExpanded(!expanded)}
               className="flex items-center gap-1.5 w-full px-3 py-1.5 text-xs text-zinc-400 hover:text-zinc-300 transition-colors"
             >
-              {expanded ? (
-                <ChevronDown className="w-3 h-3" />
-              ) : (
-                <ChevronRight className="w-3 h-3" />
-              )}
+              <ChevronRight className={`w-3 h-3 transition-transform duration-200 ${expanded ? "rotate-90" : ""}`} />
               <Wrench className="w-3 h-3" />
               <span>{summaryParts.join(", ")}</span>
             </button>
-            {expanded && (
-              <div className="border-t border-zinc-800/60 px-3 py-1 divide-y divide-zinc-800/40">
-                {displayBlocks.map((block) => (
-                  <StreamBlockItem
-                    key={`${block.trace_id}-${block.seq}`}
-                    block={block}
-                    toolNameById={toolNameById}
-                  />
-                ))}
+            {renderExpandedContent && (
+              <div
+                ref={contentRef}
+                className="border-t border-zinc-800/60 px-3 py-1 divide-y divide-zinc-800/40 will-change-transform"
+              >
+                {displayBlocks.map((block) => {
+                  const blockKey = `${block.trace_id}-${block.seq}`;
+                  return (
+                    <div
+                      key={blockKey}
+                      data-stream-block-row
+                      data-stream-block-key={blockKey}
+                    >
+                      <StreamBlockItem
+                        block={block}
+                        toolNameById={toolNameById}
+                      />
+                    </div>
+                  );
+                })}
                 {composingText && (
-                  <div className="py-2">
+                  <div data-stream-composing className="py-2 will-change-transform">
                     <div className="mb-1 flex items-center gap-1.5">
                       <Bot className="w-3 h-3 text-zinc-400" />
                       <span className="text-xs text-zinc-400">Composing...</span>

--- a/frontend/src/components/dashboard/SubscriptionBadge.tsx
+++ b/frontend/src/components/dashboard/SubscriptionBadge.tsx
@@ -7,7 +7,7 @@
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useLanguage } from "@/lib/i18n";
 import { subscriptionBadge } from "@/lib/i18n/translations/dashboard";
@@ -20,6 +20,7 @@ import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardSubscriptionStore } from "@/store/useDashboardSubscriptionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from "@/lib/anime";
 
 interface SubscriptionBadgeProps {
   productId?: string | null;
@@ -60,6 +61,9 @@ export default function SubscriptionBadge({
   const [error, setError] = useState<string | null>(null);
   const [errorKind, setErrorKind] = useState<"generic" | "insufficient_balance">("generic");
   const [subscribing, setSubscribing] = useState(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
 
   const { activeAgentId, sessionMode, activeIdentityType } = useDashboardSessionStore(useShallow((state) => ({
     activeAgentId: state.activeAgentId,
@@ -103,10 +107,22 @@ export default function SubscriptionBadge({
   const alreadySubscribed = subscription?.status === "active";
   const isInsufficientBalance = errorKind === "insufficient_balance";
 
+  const closeWithMotion = useCallback((afterClose?: () => void) => {
+    cleanupAnime(animationRef.current);
+    animationRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      contentSelector: "[data-motion-item]",
+      onComplete: () => {
+        setShowModal(false);
+        afterClose?.();
+      },
+    });
+  }, []);
+
   const handleOpenWallet = () => {
-    setShowModal(false);
-    setSidebarTab("wallet");
-    router.push("/chats/wallet");
+    closeWithMotion(() => {
+      setSidebarTab("wallet");
+      router.push("/chats/wallet");
+    });
   };
 
   // Eagerly load product data on mount so the badge can show subscriber count
@@ -146,6 +162,21 @@ export default function SubscriptionBadge({
       cancelled = true;
     };
   }, [activeAgentId, isAgentMode, ensureSubscriptions, isAuthedReady]);
+
+  useEffect(() => {
+    if (!showModal) return;
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current, {
+      contentSelector: "[data-motion-item]",
+    });
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") closeWithMotion();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      cleanupAnime(animationRef.current);
+    };
+  }, [closeWithMotion, showModal]);
 
   if (!productId) return null;
 
@@ -205,7 +236,7 @@ export default function SubscriptionBadge({
         startPrimaryNavigation("messages", path);
         router.push(path);
       }
-      setShowModal(false);
+      closeWithMotion();
     } catch (err) {
       const raw = err instanceof Error ? err.message : "";
       setErrorKind(INSUFFICIENT_BALANCE_RE.test(raw) ? "insufficient_balance" : "generic");
@@ -267,14 +298,18 @@ export default function SubscriptionBadge({
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
           onClick={(event) => {
             event.stopPropagation();
-            setShowModal(false);
+            closeWithMotion();
           }}
+          ref={overlayRef}
         >
           <div
+            ref={panelRef}
+            role="dialog"
+            aria-modal="true"
             className="w-full max-w-sm rounded-xl border border-glass-border bg-deep-black p-6 shadow-xl"
             onClick={(event) => event.stopPropagation()}
           >
-            <h2 className="mb-2 flex items-center gap-2 text-lg font-semibold text-yellow-500">
+            <h2 data-motion-item className="mb-2 flex items-center gap-2 text-lg font-semibold text-yellow-500">
               <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
               </svg>
@@ -288,7 +323,7 @@ export default function SubscriptionBadge({
                 textClassName="text-center text-sm text-text-secondary animate-pulse"
               />
             ) : productData ? (
-              <div className="space-y-4">
+              <div data-motion-item className="space-y-4">
                 <div className="flex items-start justify-between gap-3">
                   <div>
                     <h3 className="text-base font-medium text-text-primary">{productData.name}</h3>
@@ -365,7 +400,7 @@ export default function SubscriptionBadge({
 
                 <div className="flex justify-end gap-2 pt-2">
                   <button
-                    onClick={() => setShowModal(false)}
+                    onClick={() => closeWithMotion()}
                     className="rounded border border-glass-border px-4 py-2 text-sm text-text-secondary hover:text-text-primary"
                   >
                     {t.close}
@@ -392,7 +427,7 @@ export default function SubscriptionBadge({
                 </div>
                 <div className="flex justify-end">
                   <button
-                    onClick={() => setShowModal(false)}
+                    onClick={() => closeWithMotion()}
                     className="rounded border border-glass-border px-4 py-2 text-sm text-text-secondary hover:text-text-primary"
                   >
                     {t.close}

--- a/frontend/src/components/dashboard/ToolResultContent.tsx
+++ b/frontend/src/components/dashboard/ToolResultContent.tsx
@@ -5,10 +5,11 @@
  * copy-to-clipboard, and full-screen overlay for large payloads.
  */
 
-import { useState, useMemo, useCallback, useEffect } from "react";
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { Copy, Check, Maximize2, X } from "lucide-react";
 import MarkdownContent from "@/components/ui/MarkdownContent";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from "@/lib/anime";
 
 // ---------------------------------------------------------------------------
 // Content type detection
@@ -142,47 +143,68 @@ function FullScreenOverlay({
   contentType: ContentType;
   onClose: () => void;
 }) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
+
+  const closeWithMotion = useCallback(() => {
+    cleanupAnime(animationRef.current);
+    animationRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      direction: "bottom",
+      onComplete: onClose,
+    });
+  }, [onClose]);
+
   // Close on Escape
   useEffect(() => {
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current, {
+      direction: "bottom",
+    });
     const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") closeWithMotion();
     };
     document.addEventListener("keydown", handler);
-    return () => document.removeEventListener("keydown", handler);
-  }, [onClose]);
+    return () => {
+      document.removeEventListener("keydown", handler);
+      cleanupAnime(animationRef.current);
+    };
+  }, [closeWithMotion]);
 
   return createPortal(
     <div
+      ref={overlayRef}
       className="fixed inset-0 z-[9999] flex flex-col bg-black/90 backdrop-blur-sm"
       onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
+        if (e.target === e.currentTarget) closeWithMotion();
       }}
     >
-      {/* Header */}
-      <div className="flex items-center justify-between px-6 py-3 border-b border-glass-border bg-zinc-950/80">
-        <div className="flex items-center gap-3">
-          <span className="text-sm font-mono text-emerald-400">{title}</span>
-          <span className="text-xs text-zinc-500 bg-zinc-800 px-2 py-0.5 rounded">
-            {contentType.toUpperCase()}
-          </span>
-          <span className="text-xs text-zinc-600">
-            {rawText.length.toLocaleString()} 字符
-          </span>
+      <div ref={panelRef} role="dialog" aria-modal="true" className="flex min-h-0 flex-1 flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-3 border-b border-glass-border bg-zinc-950/80">
+          <div className="flex items-center gap-3">
+            <span className="text-sm font-mono text-emerald-400">{title}</span>
+            <span className="text-xs text-zinc-500 bg-zinc-800 px-2 py-0.5 rounded">
+              {contentType.toUpperCase()}
+            </span>
+            <span className="text-xs text-zinc-600">
+              {rawText.length.toLocaleString()} 字符
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <CopyButton text={rawText} />
+            <button
+              onClick={closeWithMotion}
+              className="p-1 rounded hover:bg-white/10 transition-colors"
+            >
+              <X className="w-4 h-4 text-zinc-400 hover:text-zinc-200" />
+            </button>
+          </div>
         </div>
-        <div className="flex items-center gap-2">
-          <CopyButton text={rawText} />
-          <button
-            onClick={onClose}
-            className="p-1 rounded hover:bg-white/10 transition-colors"
-          >
-            <X className="w-4 h-4 text-zinc-400 hover:text-zinc-200" />
-          </button>
-        </div>
-      </div>
-      {/* Content */}
-      <div className="flex-1 overflow-auto p-6">
-        <div className="max-w-4xl mx-auto">
-          <ResultRenderer text={rawText} contentType={contentType} fullMode />
+        {/* Content */}
+        <div className="flex-1 overflow-auto p-6">
+          <div className="max-w-4xl mx-auto">
+            <ResultRenderer text={rawText} contentType={contentType} fullMode />
+          </div>
         </div>
       </div>
     </div>,

--- a/frontend/src/components/dashboard/TopupDialog.tsx
+++ b/frontend/src/components/dashboard/TopupDialog.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useCallback, useState, useEffect, useRef } from "react";
 import { useLanguage } from '@/lib/i18n';
 import { topupDialog } from '@/lib/i18n/translations/dashboard';
 import { api, ApiError, type ActiveIdentity } from "@/lib/api";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, animatePop, cleanupAnime } from "@/lib/anime";
 import type { StripePackageItem } from "@/lib/types";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { saveStripeTopupContext } from "@/lib/stripe-topup-context";
@@ -48,6 +49,12 @@ export default function TopupDialog({ viewer, onClose, onSuccess }: TopupDialogP
   const [quantity, setQuantity] = useState(1);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
+  const [closing, setClosing] = useState(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const errorRef = useRef<HTMLParagraphElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
+  const errorAnimationRef = useRef<ReturnType<typeof animatePop>>(null);
 
   useEffect(() => {
     api.getStripePackages()
@@ -100,17 +107,48 @@ export default function TopupDialog({ viewer, onClose, onSuccess }: TopupDialogP
     }
   };
 
+  const closeWithMotion = useCallback(() => {
+    if (submitting || closing) return;
+    setClosing(true);
+    cleanupAnime(animationRef.current);
+    animationRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      onComplete: onClose,
+    });
+  }, [closing, onClose, submitting]);
+
+  useEffect(() => {
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current);
+    return () => cleanupAnime(animationRef.current);
+  }, []);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") closeWithMotion();
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [closeWithMotion]);
+
+  useEffect(() => {
+    if (!error || !errorRef.current) return;
+    cleanupAnime(errorAnimationRef.current);
+    errorAnimationRef.current = animatePop(errorRef.current);
+    return () => cleanupAnime(errorAnimationRef.current);
+  }, [error]);
+
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
-      onClick={onClose}
+      ref={overlayRef}
+      className={`fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`}
+      onClick={closeWithMotion}
     >
       <div
+        ref={panelRef}
         className="relative flex max-h-[90vh] w-full max-w-md flex-col rounded-2xl border border-glass-border bg-glass-bg backdrop-blur-xl"
         onClick={(e) => e.stopPropagation()}
       >
         <button
-          onClick={onClose}
+          onClick={closeWithMotion}
           className="absolute right-4 top-4 z-10 rounded p-1 text-text-secondary hover:text-text-primary"
         >
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
@@ -243,7 +281,7 @@ export default function TopupDialog({ viewer, onClose, onSuccess }: TopupDialogP
               </>
             ) : null}
 
-            {error && <p className="mt-3 text-sm text-red-400">{error}</p>}
+            {error && <p ref={errorRef} className="mt-3 text-sm text-red-400">{error}</p>}
           </>
         )}
 

--- a/frontend/src/components/dashboard/TransferDialog.tsx
+++ b/frontend/src/components/dashboard/TransferDialog.tsx
@@ -7,10 +7,11 @@
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLanguage } from "@/lib/i18n";
 import { transferDialog, walletPanel } from "@/lib/i18n/translations/dashboard";
 import { api, ApiError, type ActiveIdentity } from "@/lib/api";
+import { animateIfMotion, animateOverlayPanelEnter, animateOverlayPanelExit, animatePop, cleanupAnime } from "@/lib/anime";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardWalletStore } from "@/store/useDashboardWalletStore";
@@ -165,6 +166,12 @@ export default function TransferDialog({ viewer, onClose, onSuccess }: TransferD
   const [memo, setMemo] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
+  const [closing, setClosing] = useState(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const errorRef = useRef<HTMLParagraphElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
+  const errorAnimationRef = useRef<ReturnType<typeof animatePop>>(null);
 
   const amountNumber = useMemo(() => {
     if (!/^[1-9]\d*$/.test(amount.trim())) return null;
@@ -223,17 +230,48 @@ export default function TransferDialog({ viewer, onClose, onSuccess }: TransferD
     return base.filter((n) => n * 100 <= availableMinor);
   }, [availableMinor]);
 
+  const closeWithMotion = useCallback(() => {
+    if (submitting || closing) return;
+    setClosing(true);
+    cleanupAnime(animationRef.current);
+    animationRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      onComplete: onClose,
+    });
+  }, [closing, onClose, submitting]);
+
+  useEffect(() => {
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current);
+    return () => cleanupAnime(animationRef.current);
+  }, []);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") closeWithMotion();
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [closeWithMotion]);
+
+  useEffect(() => {
+    if (!error || !errorRef.current) return;
+    cleanupAnime(errorAnimationRef.current);
+    errorAnimationRef.current = animatePop(errorRef.current);
+    return () => cleanupAnime(errorAnimationRef.current);
+  }, [error]);
+
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
-      onClick={onClose}
+      ref={overlayRef}
+      className={`fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`}
+      onClick={closeWithMotion}
     >
       <div
+        ref={panelRef}
         className="relative flex max-h-[90vh] w-full max-w-md flex-col rounded-2xl border border-glass-border bg-glass-bg backdrop-blur-xl"
         onClick={(e) => e.stopPropagation()}
       >
         <button
-          onClick={onClose}
+          onClick={closeWithMotion}
           aria-label="close"
           className="absolute right-4 top-4 z-10 rounded p-1 text-text-secondary hover:text-text-primary"
         >
@@ -390,7 +428,7 @@ export default function TransferDialog({ viewer, onClose, onSuccess }: TransferD
             />
           </div>
 
-          {error && <p className="text-sm text-red-400">{error}</p>}
+          {error && <p ref={errorRef} className="text-sm text-red-400">{error}</p>}
         </form>
 
         <div className="shrink-0 border-t border-glass-border bg-glass-bg/40 px-6 py-4">
@@ -433,6 +471,21 @@ function FromCard({
   disabled: boolean;
 }) {
   const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const menuAnimationRef = useRef<ReturnType<typeof animateIfMotion>>(null);
+
+  useEffect(() => {
+    if (!open || disabled || !menuRef.current) return;
+    cleanupAnime(menuAnimationRef.current);
+    menuAnimationRef.current = animateIfMotion(menuRef.current, {
+      opacity: [0, 1],
+      translateY: [-4, 0],
+      scale: [0.98, 1],
+      duration: 160,
+      ease: "out(3)",
+    });
+    return () => cleanupAnime(menuAnimationRef.current);
+  }, [disabled, open]);
 
   return (
     <div className="relative">
@@ -452,7 +505,7 @@ function FromCard({
         {!disabled ? <ChevronDown className="h-3.5 w-3.5 shrink-0 text-text-secondary/60" /> : null}
       </button>
       {open && !disabled ? (
-        <div className="absolute left-0 right-0 top-full z-30 mt-1 overflow-hidden rounded-lg border border-glass-border bg-deep-black-light shadow-lg">
+        <div ref={menuRef} className="absolute left-0 right-0 top-full z-30 mt-1 overflow-hidden rounded-lg border border-glass-border bg-deep-black-light shadow-lg">
           {options.map((opt) => {
             const selected =
               value?.type === opt.identity.type && value.id === opt.identity.id;
@@ -510,6 +563,21 @@ function RecipientPicker({
     for (const opt of options) buckets[opt.group].push(opt);
     return buckets;
   }, [options]);
+  const pickerRef = useRef<HTMLDivElement>(null);
+  const pickerAnimationRef = useRef<ReturnType<typeof animateIfMotion>>(null);
+
+  useEffect(() => {
+    if (!open || !pickerRef.current) return;
+    cleanupAnime(pickerAnimationRef.current);
+    pickerAnimationRef.current = animateIfMotion(pickerRef.current, {
+      opacity: [0, 1],
+      translateY: [-4, 0],
+      scale: [0.98, 1],
+      duration: 160,
+      ease: "out(3)",
+    });
+    return () => cleanupAnime(pickerAnimationRef.current);
+  }, [open]);
 
   return (
     <div className="relative">
@@ -523,7 +591,7 @@ function RecipientPicker({
         <ChevronDown className="h-3.5 w-3.5 shrink-0 text-text-secondary/60" />
       </button>
       {open ? (
-        <div className="absolute left-0 right-0 top-full z-30 mt-1 max-h-72 overflow-y-auto rounded-lg border border-glass-border bg-deep-black-light shadow-lg">
+        <div ref={pickerRef} className="absolute left-0 right-0 top-full z-30 mt-1 max-h-72 overflow-y-auto rounded-lg border border-glass-border bg-deep-black-light shadow-lg">
           {(["human-self", "my-bot", "contact"] as const).map((group) => {
             const items = grouped[group];
             if (items.length === 0) return null;

--- a/frontend/src/components/dashboard/TransferOwnershipDialog.tsx
+++ b/frontend/src/components/dashboard/TransferOwnershipDialog.tsx
@@ -7,9 +7,10 @@
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
 
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { PublicRoomMember } from "@/lib/types";
 import { humansApi } from "@/lib/api";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from "@/lib/anime";
 import { useLanguage } from "@/lib/i18n";
 import { agentBrowser } from "@/lib/i18n/translations/dashboard";
 import DashboardSelect from "./DashboardSelect";
@@ -43,6 +44,10 @@ export default function TransferOwnershipDialog({
   const [selectedId, setSelectedId] = useState<string>(candidates[0]?.agent_id ?? "");
   const [confirmText, setConfirmText] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [closing, setClosing] = useState(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
 
   const selected = candidates.find((c) => c.agent_id === selectedId);
   // Require the user to type the room name exactly — this is a
@@ -55,7 +60,7 @@ export default function TransferOwnershipDialog({
     try {
       await humansApi.transferRoomOwnership(roomId, selected.agent_id);
       onSuccess();
-      onClose();
+      closeWithMotion();
     } catch (e: any) {
       onError(e?.message || t.transferFailed);
     } finally {
@@ -63,12 +68,36 @@ export default function TransferOwnershipDialog({
     }
   };
 
+  const closeWithMotion = useCallback(() => {
+    if (submitting || closing) return;
+    setClosing(true);
+    cleanupAnime(animationRef.current);
+    animationRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      onComplete: onClose,
+    });
+  }, [closing, onClose, submitting]);
+
+  useEffect(() => {
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current);
+    return () => cleanupAnime(animationRef.current);
+  }, []);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") closeWithMotion();
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [closeWithMotion]);
+
   return (
     <div
-      className="fixed inset-0 z-30 flex items-center justify-center bg-black/60"
-      onClick={onClose}
+      ref={overlayRef}
+      className={`fixed inset-0 z-30 flex items-center justify-center bg-black/60 ${closing ? "pointer-events-none" : ""}`}
+      onClick={closeWithMotion}
     >
       <div
+        ref={panelRef}
         className="w-[360px] rounded-lg border border-glass-border bg-deep-black-light p-4"
         onClick={(e) => e.stopPropagation()}
       >
@@ -120,7 +149,7 @@ export default function TransferOwnershipDialog({
 
         <div className="mt-1 flex justify-end gap-2">
           <button
-            onClick={onClose}
+            onClick={closeWithMotion}
             disabled={submitting}
             className="rounded border border-glass-border px-3 py-1.5 text-[11px] text-text-secondary hover:bg-glass-bg"
           >

--- a/frontend/src/components/dashboard/UnbindAgentDialog.tsx
+++ b/frontend/src/components/dashboard/UnbindAgentDialog.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { userApi } from "@/lib/api";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, animatePop, cleanupAnime } from "@/lib/anime";
 import { useLanguage } from "@/lib/i18n";
 import { unbindAgentDialog } from "@/lib/i18n/translations/dashboard";
 import { AlertTriangle, Loader2, Unlink, X } from "lucide-react";
@@ -49,6 +50,12 @@ export default function UnbindAgentDialog({
       };
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [closing, setClosing] = useState(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const errorRef = useRef<HTMLParagraphElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
+  const errorAnimationRef = useRef<ReturnType<typeof animatePop>>(null);
 
   async function handleUnbind() {
     setLoading(true);
@@ -60,18 +67,47 @@ export default function UnbindAgentDialog({
         await userApi.unbindAgent(agentId);
       }
       await onUnbound(agentId);
-      onClose();
+      closeWithMotion();
     } catch (err: any) {
       setError(err?.message || copy.failed);
       setLoading(false);
     }
   }
 
+  const closeWithMotion = useCallback(() => {
+    if (loading || closing) return;
+    setClosing(true);
+    cleanupAnime(animationRef.current);
+    animationRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      onComplete: onClose,
+    });
+  }, [closing, loading, onClose]);
+
+  useEffect(() => {
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current);
+    return () => cleanupAnime(animationRef.current);
+  }, []);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") closeWithMotion();
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [closeWithMotion]);
+
+  useEffect(() => {
+    if (!error || !errorRef.current) return;
+    cleanupAnime(errorAnimationRef.current);
+    errorAnimationRef.current = animatePop(errorRef.current);
+    return () => cleanupAnime(errorAnimationRef.current);
+  }, [error]);
+
   return (
-    <div className="fixed inset-0 z-[110] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm">
-      <div className="relative w-full max-w-md rounded-2xl border border-glass-border bg-deep-black-light p-5 shadow-2xl">
+    <div ref={overlayRef} className={`fixed inset-0 z-[110] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`} onMouseDown={(event) => { if (event.target === event.currentTarget) closeWithMotion(); }}>
+      <div ref={panelRef} className="relative w-full max-w-md rounded-2xl border border-glass-border bg-deep-black-light p-5 shadow-2xl">
         <button
-          onClick={onClose}
+          onClick={closeWithMotion}
           disabled={loading}
           className="absolute right-4 top-4 rounded-full p-1.5 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
         >
@@ -100,14 +136,14 @@ export default function UnbindAgentDialog({
         </p>
 
         {error && (
-          <p className="mt-4 rounded-lg border border-red-400/20 bg-red-400/10 p-2 text-xs text-red-400">
+          <p ref={errorRef} className="mt-4 rounded-lg border border-red-400/20 bg-red-400/10 p-2 text-xs text-red-400">
             {error}
           </p>
         )}
 
         <div className="mt-6 flex items-center justify-end gap-3">
           <button
-            onClick={onClose}
+            onClick={closeWithMotion}
             disabled={loading}
             className="rounded-xl border border-glass-border px-4 py-2.5 text-sm font-medium text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
           >

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -45,6 +45,9 @@ import {
   scrollToLatestVisibleAfterScroll,
   shouldShowScrollToLatestForNewContent,
 } from "./messageScroll";
+import { animateFadeUp, animateIfMotion, animatePop, cleanupAnime } from "@/lib/anime";
+
+const OWNER_CHAT_ENTRANCE_SETTLE_MS = 1200;
 
 // ---------------------------------------------------------------------------
 // TypewriterText
@@ -125,7 +128,14 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
   const scrollToLatestLabel = messageList[locale].scrollToLatest;
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const scrollToBottomButtonElementRef = useRef<HTMLButtonElement>(null);
+  const typingIndicatorRef = useRef<HTMLDivElement>(null);
   const animatedRef = useRef<Set<string>>(new Set());
+  const entranceAnimatedRef = useRef<Set<string>>(new Set());
+  const entrancePrimedRef = useRef(false);
+  const roomOpenedAtRef = useRef(0);
+  const previousStatusRef = useRef<Map<string, OwnerChatMessage["status"]>>(new Map());
+  const motionHandlesRef = useRef<Set<ReturnType<typeof animateIfMotion>>>(new Set());
   const initialLoadRef = useRef(true);
   const isLoadingMore = useRef(false);
   const prevLengthRef = useRef(0);
@@ -134,6 +144,21 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
   const showScrollToBottomButtonRef = useRef(false);
   const [showScrollToBottomButton, setShowScrollToBottomButton] = useState(false);
   const [, forceRender] = useState(0);
+
+  const registerMotion = useCallback((animation: ReturnType<typeof animateIfMotion>) => {
+    if (!animation) return;
+    motionHandlesRef.current.add(animation);
+    window.setTimeout(() => {
+      motionHandlesRef.current.delete(animation);
+    }, 1600);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      motionHandlesRef.current.forEach(cleanupAnime);
+      motionHandlesRef.current.clear();
+    };
+  }, []);
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior = "auto") => {
     const el = scrollContainerRef.current;
@@ -176,9 +201,13 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
     prevLengthRef.current = 0;
     prevMessageContentSignatureRef.current = "";
     wasNearBottomRef.current = true;
+    entrancePrimedRef.current = false;
+    roomOpenedAtRef.current = performance.now();
+    previousStatusRef.current = new Map();
     showScrollToBottomButtonRef.current = false;
     setShowScrollToBottomButton(false);
     animatedRef.current.clear();
+    entranceAnimatedRef.current.clear();
     setPreviewAttachment(null);
     useOwnerChatStore.getState().reset();
 
@@ -196,7 +225,12 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
         // already considers them animated.
         for (const msg of useOwnerChatStore.getState().messages) {
           animatedRef.current.add(msg.clientId);
+          entranceAnimatedRef.current.add(msg.clientId);
         }
+        entrancePrimedRef.current = true;
+        previousStatusRef.current = new Map(
+          useOwnerChatStore.getState().messages.map((msg) => [msg.clientId, msg.status]),
+        );
         initialLoadRef.current = false;
         scrollToBottomAfterLayout();
         // Restore in-flight stream blocks for any user message still awaiting a
@@ -237,6 +271,7 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
       ].join(":");
     }).join("|");
   }, [messages]);
+  const hasStreamingMsg = messages.some((m) => m.status === "streaming");
 
   useEffect(() => {
     if (messages.length > prevLengthRef.current && !isLoadingMore.current) {
@@ -270,6 +305,99 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
       setShowScrollToBottomButton(true);
     }
   }, [messageContentSignature, scrollToBottomAfterLayout]);
+
+  useEffect(() => {
+    if (messages.length === 0) return;
+    const seenIds = entranceAnimatedRef.current;
+
+    if (!entrancePrimedRef.current) {
+      for (const msg of messages) seenIds.add(msg.clientId);
+      entrancePrimedRef.current = true;
+      return;
+    }
+
+    const newlyVisible = messages.filter((msg) => !seenIds.has(msg.clientId));
+    for (const msg of messages) seenIds.add(msg.clientId);
+    if (newlyVisible.length === 0 || isLoadingMore.current) return;
+    if (performance.now() - roomOpenedAtRef.current < OWNER_CHAT_ENTRANCE_SETTLE_MS) return;
+
+    const newlyVisibleIds = newlyVisible.map((msg) => msg.clientId);
+    requestAnimationFrame(() => {
+      const container = scrollContainerRef.current;
+      if (!container) return;
+      newlyVisibleIds.slice(-6).forEach((id, index) => {
+        const el = container.querySelector<HTMLElement>(
+          `[data-owner-msg-key="${CSS.escape(id)}"]`,
+        );
+        if (!el) return;
+        registerMotion(animateIfMotion(el, {
+          opacity: [0, 1],
+          translateY: [10, 0],
+          scale: [0.985, 1],
+          duration: 340,
+          delay: index * 24,
+          ease: "out(3)",
+        }));
+      });
+    });
+  }, [messages, registerMotion]);
+
+  useEffect(() => {
+    if (messages.length === 0) {
+      previousStatusRef.current = new Map();
+      return;
+    }
+
+    const previousStatuses = previousStatusRef.current;
+    const nextStatuses = new Map<string, OwnerChatMessage["status"]>();
+    const newlyFailedIds: string[] = [];
+
+    for (const msg of messages) {
+      nextStatuses.set(msg.clientId, msg.status);
+      if (msg.status === "failed" && previousStatuses.get(msg.clientId) !== "failed") {
+        newlyFailedIds.push(msg.clientId);
+      }
+    }
+
+    previousStatusRef.current = nextStatuses;
+    if (initialLoadRef.current || newlyFailedIds.length === 0) return;
+
+    requestAnimationFrame(() => {
+      const container = scrollContainerRef.current;
+      if (!container) return;
+      newlyFailedIds.forEach((id) => {
+        const el = container.querySelector<HTMLElement>(
+          `[data-owner-msg-key="${CSS.escape(id)}"]`,
+        );
+        if (!el) return;
+        registerMotion(animateIfMotion(el, {
+          translateX: [0, -4, 4, -3, 3, 0],
+          scale: [1, 1.012, 1],
+          boxShadow: [
+            "0 0 0 rgba(248, 113, 113, 0)",
+            "0 0 16px rgba(248, 113, 113, 0.24)",
+            "0 0 0 rgba(248, 113, 113, 0)",
+          ],
+          duration: 420,
+          ease: "out(3)",
+        }));
+      });
+    });
+  }, [messages, registerMotion]);
+
+  useEffect(() => {
+    showScrollToBottomButtonRef.current = showScrollToBottomButton;
+  }, [showScrollToBottomButton]);
+
+  useEffect(() => {
+    if (!showScrollToBottomButton || !scrollToBottomButtonElementRef.current) return;
+    registerMotion(animatePop(scrollToBottomButtonElementRef.current));
+  }, [showScrollToBottomButton, registerMotion]);
+
+  useEffect(() => {
+    if (!agentTyping || hasStreamingMsg || !typingIndicatorRef.current) return;
+    registerMotion(animateFadeUp(typingIndicatorRef.current));
+  }, [agentTyping, hasStreamingMsg, registerMotion]);
 
   const handleScroll = useCallback(() => {
     const el = scrollContainerRef.current;
@@ -499,7 +627,6 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
     );
   }
 
-  const hasStreamingMsg = messages.some((m) => m.status === "streaming");
   const handleMobileBack = () => {
     if (agentId) {
       setSelectedBotAgentId(null);
@@ -581,7 +708,11 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
           // --- Notification ---
           if (isNotification) {
             return (
-              <div key={msg.clientId} className="flex justify-center">
+              <div
+                key={msg.clientId}
+                data-owner-msg-key={msg.clientId}
+                className="flex justify-center"
+              >
                 <div className="max-w-[85%] rounded-lg px-3 py-2 text-xs bg-amber-500/10 text-amber-300 border border-amber-500/20 flex items-start gap-2">
                   <Bell className="w-3.5 h-3.5 mt-0.5 shrink-0" />
                   <div>
@@ -597,7 +728,11 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
 
           if (isErrorMessage) {
             return (
-              <div key={msg.clientId} className="space-y-1.5">
+              <div
+                key={msg.clientId}
+                data-owner-msg-key={msg.clientId}
+                className="space-y-1.5"
+              >
                 <div className="flex justify-start">
                   <div className="max-w-[75%] rounded-lg border border-amber-400/25 bg-amber-400/10 px-3 py-2 text-sm text-amber-100">
                     <div className="mb-1 flex items-center gap-1.5">
@@ -650,7 +785,11 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
           // --- Streaming agent message ---
           if (msg.status === "streaming") {
             return (
-              <div key={msg.clientId} className="space-y-1.5">
+              <div
+                key={msg.clientId}
+                data-owner-msg-key={msg.clientId}
+                className="space-y-1.5"
+              >
                 <StreamBlocksView
                   key={`${msg.clientId}-streaming`}
                   blocks={msg.streamBlocks}
@@ -667,6 +806,7 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
             return (
               <div
                 key={msg.clientId}
+                data-owner-msg-key={msg.clientId}
                 className="flex items-start justify-end gap-2"
                 onMouseEnter={() => setHoveredActionId(msg.clientId)}
                 onMouseLeave={() => { setHoveredActionId(null); setActionMenuOpenId(null); }}
@@ -727,7 +867,11 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
           }
 
           return (
-            <div key={msg.clientId} className="space-y-1.5">
+            <div
+              key={msg.clientId}
+              data-owner-msg-key={msg.clientId}
+              className="space-y-1.5"
+            >
               {/* Finalized execution blocks above agent message */}
               {!isUser && msg.streamBlocks.length > 0 && (
                 <StreamBlocksView
@@ -834,7 +978,7 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
 
         {/* Typing indicator (only when no streaming message exists) */}
         {agentTyping && !hasStreamingMsg && (
-          <div className="flex justify-start">
+          <div ref={typingIndicatorRef} className="flex justify-start">
             <div className="rounded-lg px-3 py-2 bg-zinc-800 border border-zinc-700">
               <div className="flex items-center gap-1">
                 <span className="w-1.5 h-1.5 rounded-full bg-zinc-400 animate-bounce [animation-delay:0ms]" />
@@ -867,6 +1011,7 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
       </div>
       {showScrollToBottomButton && (
         <button
+          ref={scrollToBottomButtonElementRef}
           type="button"
           onClick={() => scrollToBottom("auto")}
           aria-label={scrollToLatestLabel}
@@ -897,13 +1042,20 @@ interface OwnerChatReplyingToBarProps {
 }
 
 function OwnerChatReplyingToBar({ target, locale, onCancel }: OwnerChatReplyingToBarProps) {
+  const barRef = useRef<HTMLDivElement>(null);
   const name = target.senderName || (locale === "zh" ? "消息" : "Message");
   const preview = (target.text || "").slice(0, 80);
   const replyingLabel = locale === "zh" ? "正在回复" : "Replying to";
   const cancelLabel = locale === "zh" ? "取消引用" : "Cancel reply";
 
+  useEffect(() => {
+    if (!barRef.current) return;
+    const animation = animateFadeUp(barRef.current);
+    return () => cleanupAnime(animation);
+  }, [target.clientId]);
+
   return (
-    <div className="mx-1 flex items-start gap-2 rounded-md border-l-2 border-neon-cyan/60 bg-glass-bg/60 pl-2 pr-1 py-1.5 text-xs">
+    <div ref={barRef} className="mx-1 flex items-start gap-2 rounded-md border-l-2 border-neon-cyan/60 bg-glass-bg/60 pl-2 pr-1 py-1.5 text-xs">
       <CornerUpLeft className="mt-0.5 h-3 w-3 shrink-0 text-neon-cyan/80" />
       <div className="min-w-0 flex-1">
         <div className="truncate text-[11px] font-medium text-neon-cyan/90">

--- a/frontend/src/components/dashboard/WithdrawDialog.tsx
+++ b/frontend/src/components/dashboard/WithdrawDialog.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useLanguage } from '@/lib/i18n';
 import { withdrawDialog } from '@/lib/i18n/translations/dashboard';
 import { api, ApiError, type ActiveIdentity } from "@/lib/api";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, animatePop, cleanupAnime } from "@/lib/anime";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardWalletStore } from "@/store/useDashboardWalletStore";
 import { useShallow } from "zustand/react/shallow";
@@ -64,6 +65,12 @@ export default function WithdrawDialog({ viewer, onClose, onSuccess, availableBa
   const [confirmed, setConfirmed] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
+  const [closing, setClosing] = useState(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const errorRef = useRef<HTMLParagraphElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
+  const errorAnimationRef = useRef<ReturnType<typeof animatePop>>(null);
 
   const availableMinor = parseInt(effectiveAvailable, 10) || 0;
   const availableMajor = availableMinor / 100;
@@ -125,17 +132,48 @@ export default function WithdrawDialog({ viewer, onClose, onSuccess, availableBa
     }
   };
 
+  const closeWithMotion = useCallback(() => {
+    if (submitting || closing) return;
+    setClosing(true);
+    cleanupAnime(animationRef.current);
+    animationRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      onComplete: onClose,
+    });
+  }, [closing, onClose, submitting]);
+
+  useEffect(() => {
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current);
+    return () => cleanupAnime(animationRef.current);
+  }, []);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") closeWithMotion();
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [closeWithMotion]);
+
+  useEffect(() => {
+    if (!error || !errorRef.current) return;
+    cleanupAnime(errorAnimationRef.current);
+    errorAnimationRef.current = animatePop(errorRef.current);
+    return () => cleanupAnime(errorAnimationRef.current);
+  }, [error]);
+
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
-      onClick={onClose}
+      ref={overlayRef}
+      className={`fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`}
+      onClick={closeWithMotion}
     >
       <div
+        ref={panelRef}
         className="relative flex max-h-[90vh] w-full max-w-md flex-col rounded-2xl border border-glass-border bg-glass-bg backdrop-blur-xl"
         onClick={(e) => e.stopPropagation()}
       >
         <button
-          onClick={onClose}
+          onClick={closeWithMotion}
           className="absolute right-4 top-4 z-10 rounded p-1 text-text-secondary hover:text-text-primary"
         >
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
@@ -287,7 +325,7 @@ export default function WithdrawDialog({ viewer, onClose, onSuccess, availableBa
             </label>
           </div>
 
-          {error && <p className="text-sm text-red-400">{error}</p>}
+          {error && <p ref={errorRef} className="text-sm text-red-400">{error}</p>}
         </form>
         </div>
 

--- a/frontend/src/components/dashboard/sidebar/ContactsPanel.tsx
+++ b/frontend/src/components/dashboard/sidebar/ContactsPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { startTransition, useState } from "react";
+import { startTransition, useEffect, useRef, useState } from "react";
 import { useRouter } from "nextjs-toploader/app";
 import { ChevronDown, UserPlus2, Users } from "lucide-react";
 import { CompositeAvatar } from "../CompositeAvatar";
@@ -13,6 +13,7 @@ import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import { useLanguage } from "@/lib/i18n";
 import { contactsUi as contactsUiI18n } from "@/lib/i18n/translations/dashboard";
+import { animateIfMotion, animeStagger, cleanupAnime } from "@/lib/anime";
 
 function Section({
   title,
@@ -26,6 +27,35 @@ function Section({
   children: React.ReactNode;
 }) {
   const [open, setOpen] = useState(defaultOpen);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    let animation: ReturnType<typeof animateIfMotion> = null;
+    const frameId = window.requestAnimationFrame(() => {
+      const content = contentRef.current;
+      if (!content) return;
+
+      const rows = Array.from(
+        content.querySelectorAll<HTMLElement>("[data-contact-section-item]"),
+      );
+
+      animation = animateIfMotion(rows.length > 0 ? rows : content, {
+        opacity: [0, 1],
+        translateY: [6, 0],
+        delay: rows.length > 0 ? animeStagger(18) : 0,
+        duration: 220,
+        ease: "out(3)",
+      });
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      cleanupAnime(animation);
+    };
+  }, [open, count]);
+
   return (
     <div className="border-b border-glass-border/50">
       <button
@@ -40,14 +70,14 @@ function Section({
         </span>
         <span className="text-[10px] font-medium text-text-secondary/50">{count}</span>
       </button>
-      {open ? <div className="pb-2">{children}</div> : null}
+      {open ? <div ref={contentRef} className="overflow-hidden pb-2">{children}</div> : null}
     </div>
   );
 }
 
 function SubGroupHeader({ title, count }: { title: string; count: number }) {
   return (
-    <div className="flex items-center justify-between px-3 pb-1 pt-2 text-[10px] font-medium uppercase tracking-[0.14em] text-text-secondary/45">
+    <div data-contact-section-item className="flex items-center justify-between px-3 pb-1 pt-2 text-[10px] font-medium uppercase tracking-[0.14em] text-text-secondary/45">
       <span>{title}</span>
       <span>{count}</span>
     </div>
@@ -71,6 +101,7 @@ function ListRow({
 }) {
   return (
     <button
+      data-contact-section-item
       onClick={onClick}
       className={`flex w-full items-center gap-2.5 px-3 py-2 text-left transition-colors ${
         active
@@ -258,14 +289,14 @@ export default function ContactsPanel({ onOpenAddFriend }: ContactsPanelProps) {
             />
           ))}
           {ownedAgents.length === 0 && agentContacts.length === 0 ? (
-            <p className="px-3 py-3 text-xs text-text-secondary/50">{t.noAgentsYet}</p>
+            <p data-contact-section-item className="px-3 py-3 text-xs text-text-secondary/50">{t.noAgentsYet}</p>
           ) : null}
         </Section>
 
         {/* Humans */}
         <Section title={t.humansGroup} count={humanContacts.length}>
           {humanContacts.length === 0 ? (
-            <p className="px-3 py-3 text-xs text-text-secondary/50">{t.noHumanContactsYet}</p>
+            <p data-contact-section-item className="px-3 py-3 text-xs text-text-secondary/50">{t.noHumanContactsYet}</p>
           ) : (
             humanContacts.map((c) => (
               <ListRow
@@ -284,7 +315,7 @@ export default function ContactsPanel({ onOpenAddFriend }: ContactsPanelProps) {
         {/* Groups */}
         <Section title={t.groupsGroup} count={groups.length}>
           {groups.length === 0 ? (
-            <p className="px-3 py-3 text-xs text-text-secondary/50">{t.noGroupsJoined}</p>
+            <p data-contact-section-item className="px-3 py-3 text-xs text-text-secondary/50">{t.noGroupsJoined}</p>
           ) : (
             groups.map((room) => (
               <ListRow

--- a/frontend/src/components/dashboard/sidebar/DeviceSettingsModal.tsx
+++ b/frontend/src/components/dashboard/sidebar/DeviceSettingsModal.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { RefreshCw, Loader2, Check, Trash2, FileArchive, Download, Send } from "lucide-react";
 import DaemonInstallCommand from "@/components/daemon/DaemonInstallCommand";
 import ForwardModal from "@/components/dashboard/ForwardModal";
 import { downloadApiFile } from "@/lib/api";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, animatePop, cleanupAnime } from "@/lib/anime";
 import type { DiagnosticBundleResult } from "@/store/useDaemonStore";
 
 interface DeviceSettingsModalProps {
@@ -54,6 +55,14 @@ export default function DeviceSettingsModal({
   const [confirmRemove, setConfirmRemove] = useState(false);
   const [removeError, setRemoveError] = useState<string | null>(null);
   const [forwardLogs, setForwardLogs] = useState(false);
+  const [closing, setClosing] = useState(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const nameButtonRef = useRef<HTMLButtonElement>(null);
+  const diagnosticResultRef = useRef<HTMLDivElement>(null);
+  const removeErrorRef = useRef<HTMLParagraphElement>(null);
+  const animationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
+  const feedbackAnimationRef = useRef<ReturnType<typeof animatePop>>(null);
 
   async function handleRename() {
     if (editingName.trim() === label) return;
@@ -70,6 +79,36 @@ export default function DeviceSettingsModal({
       setRemoveError(err instanceof Error ? err.message : String(err));
     }
   }
+
+  const closeWithMotion = useCallback(() => {
+    if (isRemoving || closing) return;
+    setClosing(true);
+    cleanupAnime(animationRef.current);
+    animationRef.current = animateOverlayPanelExit(overlayRef.current, panelRef.current, {
+      onComplete: onClose,
+    });
+  }, [closing, isRemoving, onClose]);
+
+  useEffect(() => {
+    animationRef.current = animateOverlayPanelEnter(overlayRef.current, panelRef.current);
+    return () => cleanupAnime(animationRef.current);
+  }, []);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") closeWithMotion();
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [closeWithMotion]);
+
+  useEffect(() => {
+    const target = nameSaved ? nameButtonRef.current : removeError ? removeErrorRef.current : diagnosticResult ? diagnosticResultRef.current : null;
+    if (!target) return;
+    cleanupAnime(feedbackAnimationRef.current);
+    feedbackAnimationRef.current = animatePop(target);
+    return () => cleanupAnime(feedbackAnimationRef.current);
+  }, [diagnosticResult, nameSaved, removeError]);
 
   const statusColor =
     status === "online"
@@ -95,15 +134,15 @@ export default function DeviceSettingsModal({
     ? `/daemon/diagnostics/${encodeURIComponent(diagnosticResult.bundle_id)}/download`
     : "";
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" onClick={onClose}>
-      <div className="relative w-full max-w-sm rounded-2xl border border-glass-border bg-deep-black-light shadow-2xl" onClick={(e) => e.stopPropagation()}>
+    <div ref={overlayRef} className={`fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`} onClick={closeWithMotion}>
+      <div ref={panelRef} className="relative w-full max-w-sm rounded-2xl border border-glass-border bg-deep-black-light shadow-2xl" onClick={(e) => e.stopPropagation()}>
         {/* Header */}
         <div className="flex items-center gap-3 border-b border-glass-border/50 px-5 py-4">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-4 w-4 flex-shrink-0 text-text-secondary/60">
             <path strokeLinecap="round" strokeLinejoin="round" d="M9 17.25v1.007a3 3 0 0 1-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0 1 15 18.257V17.25m6-12V15a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 15V5.25m18 0A2.25 2.25 0 0 0 18.75 3H5.25A2.25 2.25 0 0 0 3 5.25m18 0H3" />
           </svg>
           <span className="flex-1 text-sm font-semibold text-text-primary truncate">{label || daemonId.slice(0, 12)}</span>
-          <button type="button" onClick={onClose} className="flex h-7 w-7 items-center justify-center rounded-lg text-text-secondary/60 transition-colors hover:bg-glass-bg hover:text-text-primary">
+          <button type="button" onClick={closeWithMotion} className="flex h-7 w-7 items-center justify-center rounded-lg text-text-secondary/60 transition-colors hover:bg-glass-bg hover:text-text-primary">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="h-4 w-4"><path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
           </button>
         </div>
@@ -115,6 +154,7 @@ export default function DeviceSettingsModal({
             <div className="flex items-center gap-2">
               <span className={`text-xs font-medium ${statusColor}`}>{statusLabel}</span>
               <button
+                ref={nameButtonRef}
                 type="button"
                 disabled={isRefreshing}
                 onClick={onRefreshDaemons}
@@ -230,7 +270,7 @@ export default function DeviceSettingsModal({
               </button>
             </div>
             {diagnosticResult && (
-              <div className="mt-2 flex items-center gap-2 rounded-md border border-neon-green/20 bg-neon-green/10 px-2 py-2">
+              <div ref={diagnosticResultRef} className="mt-2 flex items-center gap-2 rounded-md border border-neon-green/20 bg-neon-green/10 px-2 py-2">
                 <FileArchive className="h-4 w-4 shrink-0 text-neon-green" />
                 <div className="min-w-0 flex-1">
                   <p className="truncate text-[11px] font-medium text-neon-green">
@@ -319,7 +359,7 @@ export default function DeviceSettingsModal({
                   </p>
                 )}
                 {removeError && (
-                  <p className="text-[11px] text-red-400">{removeError}</p>
+                  <p ref={removeErrorRef} className="text-[11px] text-red-400">{removeError}</p>
                 )}
                 <div className="flex flex-wrap items-center justify-end gap-2">
                   <button

--- a/frontend/src/components/dashboard/sidebar/MessagesPanel.tsx
+++ b/frontend/src/components/dashboard/sidebar/MessagesPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { startTransition, useEffect, useMemo, useState } from "react";
+import { startTransition, useEffect, useMemo, useRef, useState } from "react";
 // messagesFilter is in useDashboardUIStore so ChatPane can also read it.
 import { useRouter } from "nextjs-toploader/app";
 import { useLanguage } from "@/lib/i18n";
@@ -20,6 +20,7 @@ import type { DashboardRoom } from "@/lib/types";
 import RoomList from "../RoomList";
 import RoomZeroState from "../RoomZeroState";
 import SearchBar from "../SearchBar";
+import { animateFadeUp, animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from "@/lib/anime";
 
 interface MessagesPanelProps {
   isGuest: boolean;
@@ -85,6 +86,11 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
 
   const [messageQuery, setMessageQuery] = useState("");
   const [mobileGroupingOpen, setMobileGroupingOpen] = useState(false);
+  const [mobileGroupingRendered, setMobileGroupingRendered] = useState(false);
+  const mobileGroupingOverlayRef = useRef<HTMLButtonElement | null>(null);
+  const mobileGroupingPanelRef = useRef<HTMLDivElement | null>(null);
+  const mobileGroupingAnimationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
+  const emptyStateRef = useRef<HTMLDivElement | null>(null);
 
   // Owner-unified Messages list: my own conversations + tagged bot conversations.
   const visibleMessageRooms = useMemo<DashboardRoom[]>(() => {
@@ -184,6 +190,71 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [mobileGroupingOpen]);
 
+  useEffect(() => {
+    if (mobileGroupingOpen) {
+      setMobileGroupingRendered(true);
+      return;
+    }
+
+    if (!mobileGroupingRendered) return;
+
+    cleanupAnime(mobileGroupingAnimationRef.current);
+    if (mobileGroupingOverlayRef.current) {
+      mobileGroupingOverlayRef.current.style.opacity = "1";
+    }
+    if (mobileGroupingPanelRef.current) {
+      mobileGroupingPanelRef.current.style.opacity = "1";
+      mobileGroupingPanelRef.current.style.transform = "translate3d(0, 0, 0) scale(1)";
+      mobileGroupingPanelRef.current
+        .querySelectorAll<HTMLElement>("[data-mobile-grouping-motion]")
+        .forEach((part) => {
+          part.style.opacity = "1";
+          part.style.transform = "translateY(0)";
+        });
+    }
+    mobileGroupingAnimationRef.current = animateOverlayPanelExit(
+      mobileGroupingOverlayRef.current,
+      mobileGroupingPanelRef.current,
+      {
+        direction: "left",
+        contentSelector: "[data-mobile-grouping-motion]",
+        onComplete: () => {
+          setMobileGroupingRendered(false);
+          mobileGroupingAnimationRef.current = null;
+        },
+      },
+    );
+  }, [mobileGroupingOpen, mobileGroupingRendered]);
+
+  useEffect(() => {
+    if (!mobileGroupingOpen || !mobileGroupingRendered) return;
+
+    const frameId = window.requestAnimationFrame(() => {
+      cleanupAnime(mobileGroupingAnimationRef.current);
+      mobileGroupingAnimationRef.current = animateOverlayPanelEnter(
+        mobileGroupingOverlayRef.current,
+        mobileGroupingPanelRef.current,
+        {
+          direction: "left",
+          contentSelector: "[data-mobile-grouping-motion]",
+        },
+      );
+    });
+
+    return () => window.cancelAnimationFrame(frameId);
+  }, [mobileGroupingOpen, mobileGroupingRendered]);
+
+  useEffect(() => () => cleanupAnime(mobileGroupingAnimationRef.current), []);
+
+  useEffect(() => {
+    if (showOverviewSkeleton) return;
+    const emptyState = emptyStateRef.current;
+    if (!emptyState) return;
+
+    const animation = animateFadeUp(emptyState);
+    return () => cleanupAnime(animation);
+  }, [filteredMessageRooms.length, isBotsScope, ownedAgents.length, showOverviewSkeleton, visibleMessageRooms.length]);
+
   // (filter chips moved into MessagesGroupingSidebar as expandable children)
 
   const toggleMessagesSearch = () => {
@@ -250,7 +321,7 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
           </div>
         )}
       </div>
-      {!isGuest && mobileGroupingOpen ? (
+      {!isGuest && mobileGroupingRendered ? (
         <div
           className="fixed inset-0 z-50 hidden max-md:block"
           role="dialog"
@@ -258,17 +329,23 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
           aria-label={tGrouping.header}
         >
           <button
+            ref={mobileGroupingOverlayRef}
             type="button"
             aria-label={tGrouping.collapse}
             className="absolute inset-0 bg-black/45 backdrop-blur-sm"
             onClick={() => setMobileGroupingOpen(false)}
           />
-          <div className="absolute bottom-[calc(4.5rem+env(safe-area-inset-bottom))] left-0 top-0 w-[min(84vw,280px)] overflow-hidden border-r border-glass-border bg-deep-black-light shadow-2xl shadow-black/60">
+          <div
+            ref={mobileGroupingPanelRef}
+            className="absolute bottom-[calc(4.5rem+env(safe-area-inset-bottom))] left-0 top-0 w-[min(84vw,280px)] overflow-hidden border-r border-glass-border bg-deep-black-light shadow-2xl shadow-black/60"
+          >
+            <div data-mobile-grouping-motion className="h-full">
             <MessagesGroupingSidebar
               fullWidth
               onCollapse={() => setMobileGroupingOpen(false)}
               onFilterSelect={() => setMobileGroupingOpen(false)}
             />
+            </div>
           </div>
         </div>
       ) : null}
@@ -316,7 +393,7 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
         </div>
       ) : null}
       {isBotsScope && ownedAgents.length === 0 ? (
-        <div className="flex flex-1 flex-col items-center justify-center px-6 py-12 text-center">
+        <div ref={emptyStateRef} className="flex flex-1 flex-col items-center justify-center px-6 py-12 text-center">
           <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl border border-glass-border bg-glass-bg/40">
             <Bot className="h-7 w-7 text-text-secondary/70" />
           </div>
@@ -333,9 +410,11 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
           </button>
         </div>
       ) : visibleMessageRooms.length === 0 ? (
-        <RoomZeroState compact />
+        <div ref={emptyStateRef}>
+          <RoomZeroState compact />
+        </div>
       ) : !showOverviewSkeleton && filteredMessageRooms.length === 0 ? (
-        <div className="px-4 py-6 text-center text-xs text-text-secondary">
+        <div ref={emptyStateRef} className="px-4 py-6 text-center text-xs text-text-secondary">
           {t.noMessages}
         </div>
       ) : (

--- a/frontend/src/components/dashboard/sidebar/index.tsx
+++ b/frontend/src/components/dashboard/sidebar/index.tsx
@@ -25,6 +25,7 @@ import { useDashboardWalletStore } from "@/store/useDashboardWalletStore";
 import { useDaemonStore } from "@/store/useDaemonStore";
 import { buildVisibleMessageRooms } from "@/store/dashboard-shared";
 import { createClient } from "@/lib/supabase/client";
+import { animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from "@/lib/anime";
 
 import AccountMenu from "../AccountMenu";
 import AddFriendModal from "../AddFriendModal";
@@ -187,6 +188,10 @@ function Sidebar({
   const [showCreateRoom, setShowCreateRoom] = useState(false);
   const [refreshingBots, setRefreshingBots] = useState(false);
   const [createBotForDaemonId, setCreateBotForDaemonId] = useState<string | null>(null);
+  const [mobileSecondaryRendered, setMobileSecondaryRendered] = useState(mobileSecondaryOpen);
+  const mobileSecondaryOverlayRef = useRef<HTMLButtonElement | null>(null);
+  const mobileSecondaryPanelRef = useRef<HTMLDivElement | null>(null);
+  const mobileSecondaryAnimationRef = useRef<ReturnType<typeof animateOverlayPanelEnter>>(null);
 
   const showCreateBot = uiStore.createBotModalOpen;
   const setShowCreateBot = (v: boolean) => v ? uiStore.openCreateBotModal() : uiStore.closeCreateBotModal();
@@ -286,6 +291,71 @@ function Sidebar({
   useEffect(() => {
     if (!isGuest) void contactStore.loadContactRequests();
   }, [contactStore.loadContactRequests, isGuest]);
+
+  useEffect(() => {
+    if (!mobileHideSecondary) {
+      setMobileSecondaryRendered(false);
+      cleanupAnime(mobileSecondaryAnimationRef.current);
+      mobileSecondaryAnimationRef.current = null;
+      return;
+    }
+
+    if (mobileSecondaryOpen) {
+      setMobileSecondaryRendered(true);
+      return;
+    }
+
+    if (!mobileSecondaryRendered) return;
+
+    cleanupAnime(mobileSecondaryAnimationRef.current);
+    if (mobileSecondaryOverlayRef.current) {
+      mobileSecondaryOverlayRef.current.style.opacity = "1";
+    }
+    if (mobileSecondaryPanelRef.current) {
+      mobileSecondaryPanelRef.current.style.opacity = "1";
+      mobileSecondaryPanelRef.current.style.transform = "translate3d(0, 0, 0) scale(1)";
+      mobileSecondaryPanelRef.current
+        .querySelectorAll<HTMLElement>("[data-mobile-secondary-motion]")
+        .forEach((part) => {
+          part.style.opacity = "1";
+          part.style.transform = "translateY(0)";
+        });
+    }
+    mobileSecondaryAnimationRef.current = animateOverlayPanelExit(
+      mobileSecondaryOverlayRef.current,
+      mobileSecondaryPanelRef.current,
+      {
+        direction: "bottom",
+        contentSelector: "[data-mobile-secondary-motion]",
+        onComplete: () => {
+          setMobileSecondaryRendered(false);
+          mobileSecondaryAnimationRef.current = null;
+        },
+      },
+    );
+  }, [mobileHideSecondary, mobileSecondaryOpen, mobileSecondaryRendered]);
+
+  useEffect(() => {
+    if (!mobileHideSecondary || !mobileSecondaryOpen || !mobileSecondaryRendered) return;
+
+    const frameId = window.requestAnimationFrame(() => {
+      cleanupAnime(mobileSecondaryAnimationRef.current);
+      mobileSecondaryAnimationRef.current = animateOverlayPanelEnter(
+        mobileSecondaryOverlayRef.current,
+        mobileSecondaryPanelRef.current,
+        {
+          direction: "bottom",
+          contentSelector: "[data-mobile-secondary-motion]",
+        },
+      );
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+    };
+  }, [mobileHideSecondary, mobileSecondaryOpen, mobileSecondaryRendered, visibleSidebarTab]);
+
+  useEffect(() => () => cleanupAnime(mobileSecondaryAnimationRef.current), []);
 
   const showLoginModal = () => router.push("/login");
 
@@ -440,8 +510,9 @@ function Sidebar({
         />
       )}
 
-      {mobileHideSecondary && mobileSecondaryOpen && (
+      {mobileHideSecondary && mobileSecondaryRendered && (
         <button
+          ref={mobileSecondaryOverlayRef}
           type="button"
           aria-label="Close sidebar"
           className="fixed inset-x-0 bottom-[calc(4rem+env(safe-area-inset-bottom))] top-0 z-30 hidden bg-black/45 backdrop-blur-sm max-md:block"
@@ -454,7 +525,7 @@ function Sidebar({
       <div
         className={`relative flex h-full flex-col border-r border-glass-border bg-deep-black-light max-md:min-h-0 max-md:flex-1 max-md:!min-w-0 max-md:border-r-0 ${
           mobileHideSecondary
-            ? mobileSecondaryOpen
+            ? mobileSecondaryRendered
               ? "max-md:fixed max-md:inset-x-3 max-md:bottom-[calc(5rem+env(safe-area-inset-bottom))] max-md:top-4 max-md:z-40 max-md:!w-auto max-md:rounded-xl max-md:border max-md:border-glass-border max-md:shadow-2xl max-md:shadow-black/50"
               : "max-md:hidden"
             : "max-md:!w-full"
@@ -465,6 +536,7 @@ function Sidebar({
             : uiStore.sidebarWidth,
           minWidth: SIDEBAR_MIN,
         }}
+        ref={mobileSecondaryPanelRef}
       >
         {/* Resize handle */}
         <div
@@ -509,7 +581,7 @@ function Sidebar({
         {/* Contacts: legacy 4-subtab nav replaced by single-column ContactsPanel below. */}
 
         {/* Panel content */}
-        <div className="flex flex-1 min-h-0">
+        <div className="flex flex-1 min-h-0" data-mobile-secondary-motion>
           {!secondaryPanelLoading && showMessagesGrouping && (
             <div className="max-md:hidden">
               <MessagesGroupingSidebar />

--- a/frontend/src/lib/anime.ts
+++ b/frontend/src/lib/anime.ts
@@ -4,6 +4,13 @@ import { animate, createTimeline, utils } from "animejs";
 import type { JSAnimation, Timeline } from "animejs";
 
 type AnimeHandle = JSAnimation | Timeline | null | undefined;
+type PanelDirection = "center" | "right" | "left" | "bottom";
+
+interface OverlayPanelMotionOptions {
+  direction?: PanelDirection;
+  contentSelector?: string;
+  onComplete?: () => void;
+}
 
 const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
 
@@ -51,6 +58,136 @@ export function animatePop(target: HTMLElement): JSAnimation | null {
     scale: [0.88, 1.04, 1],
     translateY: [6, -1, 0],
     duration: 360,
+    ease: "out(3)",
+  });
+}
+
+function panelEnterTransform(direction: PanelDirection): { translateX?: number[]; translateY?: number[]; scale?: number[] } {
+  if (direction === "right") return { translateX: [28, 0] };
+  if (direction === "left") return { translateX: [-28, 0] };
+  if (direction === "bottom") return { translateY: [22, 0] };
+  return { translateY: [14, 0], scale: [0.96, 1] };
+}
+
+function panelExitTransform(direction: PanelDirection): { translateX?: number; translateY?: number; scale?: number } {
+  if (direction === "right") return { translateX: 24 };
+  if (direction === "left") return { translateX: -24 };
+  if (direction === "bottom") return { translateY: 18 };
+  return { translateY: 8, scale: 0.98 };
+}
+
+export function animateOverlayPanelEnter(
+  overlay: HTMLElement | null,
+  panel: HTMLElement | null,
+  options: OverlayPanelMotionOptions = {},
+): Timeline | null {
+  if (!panel) return null;
+
+  const direction = options.direction ?? "center";
+  const parts = options.contentSelector
+    ? Array.from(panel.querySelectorAll<HTMLElement>(options.contentSelector))
+    : [];
+
+  if (overlay) overlay.style.opacity = "0";
+  panel.style.opacity = "0";
+  parts.forEach((part) => {
+    part.style.opacity = "0";
+    part.style.transform = "translateY(8px)";
+  });
+
+  const timeline = createTimelineIfMotion({ onComplete: options.onComplete });
+  if (!timeline) {
+    if (overlay) overlay.style.opacity = "1";
+    panel.style.opacity = "1";
+    panel.style.transform = "translate3d(0, 0, 0) scale(1)";
+    parts.forEach((part) => {
+      part.style.opacity = "1";
+      part.style.transform = "translateY(0)";
+    });
+    options.onComplete?.();
+    return null;
+  }
+
+  if (overlay) {
+    timeline.add(overlay, {
+      opacity: [0, 1],
+      duration: 170,
+      ease: "linear",
+    }, 0);
+  }
+
+  timeline.add(panel, {
+    opacity: [0, 1],
+    ...panelEnterTransform(direction),
+    duration: direction === "center" ? 260 : 240,
+    ease: "out(3)",
+  }, direction === "center" ? 10 : 0);
+
+  if (parts.length) {
+    timeline.add(parts, {
+      opacity: [0, 1],
+      translateY: [8, 0],
+      duration: 210,
+      delay: animeStagger(18),
+      ease: "out(3)",
+    }, 70);
+  }
+
+  return timeline;
+}
+
+export function animateOverlayPanelExit(
+  overlay: HTMLElement | null,
+  panel: HTMLElement | null,
+  options: OverlayPanelMotionOptions = {},
+): Timeline | null {
+  const direction = options.direction ?? "center";
+  const parts = panel && options.contentSelector
+    ? Array.from(panel.querySelectorAll<HTMLElement>(options.contentSelector))
+    : [];
+
+  const timeline = createTimelineIfMotion({ onComplete: options.onComplete });
+  if (!timeline) {
+    options.onComplete?.();
+    return null;
+  }
+
+  if (parts.length) {
+    timeline.add(parts, {
+      opacity: 0,
+      translateY: -4,
+      duration: 90,
+      delay: animeStagger(8, { reversed: true }),
+      ease: "in(2)",
+    }, 0);
+  }
+
+  if (panel) {
+    timeline.add(panel, {
+      opacity: 0,
+      ...panelExitTransform(direction),
+      duration: 150,
+      ease: "in(2)",
+    }, parts.length ? 30 : 0);
+  }
+
+  if (overlay) {
+    timeline.add(overlay, {
+      opacity: 0,
+      duration: 130,
+      ease: "linear",
+    }, parts.length ? 30 : 0);
+  }
+
+  return timeline;
+}
+
+export function animateFadeUp(target: Parameters<typeof animate>[0], delay = 0): JSAnimation | null {
+  return animateIfMotion(target, {
+    opacity: [0, 1],
+    translateY: [8, 0],
+    duration: 220,
+    delay,
     ease: "out(3)",
   });
 }


### PR DESCRIPTION
## Summary
- Add shared animejs helpers for overlay, panel, drawer, fade-up, and staggered motion patterns.
- Apply reduced-motion-aware enter/exit animation across dashboard modals, drawers, popovers, mobile sidebars, stream blocks, attachment previews, and chat state transitions.
- Improve message/list/search continuity with staggered result entry, typing/reply/scroll affordance motion, and dialog accessibility markers where missing.

## Verification
- `git diff --check origin/main..HEAD`
- `pnpm exec vitest run src/components/dashboard/MessageComposer.test.ts src/components/dashboard/MessageList.test.ts src/components/dashboard/RoomHumanComposer.test.ts src/components/dashboard/StreamBlocksView.test.ts src/components/dashboard/DocumentPreviewPane.test.ts`
- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy pnpm run build`
- `pnpm exec tsc --noEmit --pretty false` still has existing unrelated test/API fixture errors; touched-file filter had no matches.

## Risk / rollout
- Frontend-only visual polish. Business logic and API calls are intended to remain unchanged.
- Uses existing reduced-motion guard for Anime.js paths.