### PR TITLE
Fix owner chat idle pause restart guard

### DIFF
--- a/backend/hub/services/cloud_agent.py
+++ b/backend/hub/services/cloud_agent.py
@@ -26,7 +26,7 @@ import copy
 from typing import Any
 
 from nacl.signing import SigningKey as NaClSigningKey
-from sqlalchemy import func, select, text as sa_text
+from sqlalchemy import func, or_, select, text as sa_text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sqlalchemy.orm.attributes import flag_modified
@@ -2042,7 +2042,9 @@ class CloudAgentService:
             return False
         if any(agent.status == "provisioning" for agent in agents):
             return False
-        if await self._cloud_daemon_has_active_run(db, cdi.id):
+        if await self._cloud_daemon_has_active_run(
+            db, cdi.id, include_owner_chat_inbox=True
+        ):
             return False
 
         for agent in agents:
@@ -2074,7 +2076,11 @@ class CloudAgentService:
         return True
 
     async def _cloud_daemon_has_active_run(
-        self, db: AsyncSession, cloud_daemon_instance_id: str
+        self,
+        db: AsyncSession,
+        cloud_daemon_instance_id: str,
+        *,
+        include_owner_chat_inbox: bool = False,
     ) -> bool:
         agent_ids_subquery = (
             select(CloudAgentInstance.agent_id)
@@ -2095,13 +2101,29 @@ class CloudAgentService:
         if (active_reservations or 0) > 0:
             return True
 
+        active_message_filters = [
+            (
+                (MessageRecord.source_type == "cloud_agent_run")
+                & MessageRecord.state.notin_((MessageState.done, MessageState.failed))
+            )
+        ]
+        if include_owner_chat_inbox:
+            active_message_filters.append(
+                (
+                    (MessageRecord.source_type == "dashboard_user_chat")
+                    & (MessageRecord.source_session_kind == "owner_chat")
+                    & MessageRecord.state.in_(
+                        (MessageState.queued, MessageState.processing)
+                    )
+                )
+            )
+
         active_messages = await db.scalar(
             select(func.count())
             .select_from(MessageRecord)
             .where(
                 MessageRecord.receiver_id.in_(select(agent_ids_subquery.c.agent_id)),
-                MessageRecord.source_type == "cloud_agent_run",
-                MessageRecord.state.notin_((MessageState.done, MessageState.failed)),
+                or_(*active_message_filters),
             )
         )
         return (active_messages or 0) > 0

--- a/backend/tests/test_cloud_agent_service.py
+++ b/backend/tests/test_cloud_agent_service.py
@@ -1082,6 +1082,52 @@ async def test_restart_cloud_daemon_restarts_shared_sandbox(db_session):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("state", [MessageState.queued, MessageState.processing])
+async def test_restart_cloud_daemon_ignores_owner_chat_inbox_message(
+    db_session, state
+):
+    user_id = uuid.uuid4()
+    svc, fake = _make_service()
+    view = await svc.create_cloud_agent(
+        db_session, user_id=user_id, body=CreateCloudAgentInput(name="A")
+    )
+    daemon_instance_id = await db_session.scalar(
+        select(CloudDaemonInstance.daemon_instance_id).where(
+            CloudDaemonInstance.id == view.cloud_daemon_instance_id
+        )
+    )
+    assert daemon_instance_id is not None
+    db_session.add(
+        MessageRecord(
+            hub_msg_id=f"hub_msg_restart_owner_chat_{state.value}",
+            msg_id=f"msg_restart_owner_chat_{state.value}",
+            sender_id=view.agent_id,
+            receiver_id=view.agent_id,
+            state=state,
+            envelope_json="{}",
+            ttl_sec=300,
+            source_type="dashboard_user_chat",
+            source_session_kind="owner_chat",
+        )
+    )
+    await db_session.commit()
+
+    await svc.restart_cloud_daemon(
+        db_session,
+        user_id=user_id,
+        daemon_instance_id=daemon_instance_id,
+    )
+
+    cdi = await db_session.scalar(
+        select(CloudDaemonInstance).where(
+            CloudDaemonInstance.id == view.cloud_daemon_instance_id
+        )
+    )
+    assert cdi.status == "starting"
+    assert fake.calls(view.cloud_daemon_instance_id)["create"] == 2
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("failure_mode", ["exception", "failed"])
 async def test_restart_cloud_daemon_failure_keeps_previous_launch_token(
     db_session, monkeypatch, failure_mode
@@ -1363,6 +1409,83 @@ async def test_idle_pause_skips_active_cloud_run_message(db_session):
     assert paused_count == 0
     assert cdi.status == "ready"
     assert fake.calls(view.cloud_daemon_instance_id)["pause"] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("state", [MessageState.queued, MessageState.processing])
+async def test_idle_pause_skips_unacked_owner_chat_message(db_session, state):
+    user_id = uuid.uuid4()
+    svc, fake = _make_service()
+    view = await svc.create_cloud_agent(
+        db_session, user_id=user_id, body=CreateCloudAgentInput(name="A")
+    )
+    db_session.add(
+        MessageRecord(
+            hub_msg_id=f"hub_msg_owner_chat_{state.value}",
+            msg_id=f"msg_owner_chat_{state.value}",
+            sender_id=view.agent_id,
+            receiver_id=view.agent_id,
+            state=state,
+            envelope_json="{}",
+            ttl_sec=300,
+            source_type="dashboard_user_chat",
+            source_session_kind="owner_chat",
+        )
+    )
+    await db_session.commit()
+
+    paused_count = await svc.pause_idle_cloud_daemons(
+        db_session,
+        idle_seconds=300,
+        now=datetime.datetime(2030, 1, 1, tzinfo=datetime.timezone.utc),
+    )
+
+    cdi = await db_session.scalar(
+        select(CloudDaemonInstance).where(
+            CloudDaemonInstance.id == view.cloud_daemon_instance_id
+        )
+    )
+    assert paused_count == 0
+    assert cdi.status == "ready"
+    assert fake.calls(view.cloud_daemon_instance_id)["pause"] == 0
+
+
+@pytest.mark.asyncio
+async def test_idle_pause_ignores_acked_owner_chat_message(db_session):
+    user_id = uuid.uuid4()
+    svc, fake = _make_service()
+    view = await svc.create_cloud_agent(
+        db_session, user_id=user_id, body=CreateCloudAgentInput(name="A")
+    )
+    db_session.add(
+        MessageRecord(
+            hub_msg_id="hub_msg_owner_chat_delivered",
+            msg_id="msg_owner_chat_delivered",
+            sender_id=view.agent_id,
+            receiver_id=view.agent_id,
+            state=MessageState.delivered,
+            envelope_json="{}",
+            ttl_sec=300,
+            source_type="dashboard_user_chat",
+            source_session_kind="owner_chat",
+        )
+    )
+    await db_session.commit()
+
+    paused_count = await svc.pause_idle_cloud_daemons(
+        db_session,
+        idle_seconds=300,
+        now=datetime.datetime(2030, 1, 1, tzinfo=datetime.timezone.utc),
+    )
+
+    cdi = await db_session.scalar(
+        select(CloudDaemonInstance).where(
+            CloudDaemonInstance.id == view.cloud_daemon_instance_id
+        )
+    )
+    assert paused_count == 1
+    assert cdi.status == "paused"
+    assert fake.calls(view.cloud_daemon_instance_id)["pause"] == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- keep owner-chat queued/processing messages as idle-pause blockers
- keep restart recovery guard scoped to active cloud runs/reservations
- add regression coverage for restart and idle-pause behavior

## Verification
- cd backend && uv run pytest tests/test_cloud_agent_service.py -q -> 38 passed / 42 warnings

Code Reviewer re-review passed before PR creation; P1 closed.