### PR TITLE
fix: harden native websocket liveness

### DIFF
--- a/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
+++ b/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { WebSocketServer, type WebSocket as WsType } from "ws";
+import { EventEmitter } from "node:events";
+import WebSocket, { WebSocketServer, type WebSocket as WsType } from "ws";
 import type { AddressInfo } from "node:net";
 import {
   createBotCordChannel,
@@ -1629,6 +1630,185 @@ describe("createBotCordChannel — typing()", () => {
 });
 
 describe("createBotCordChannel — websocket logging", () => {
+  it("terminates and reconnects when websocket handshake never completes", async () => {
+    class HangingWebSocket extends EventEmitter {
+      static instances: HangingWebSocket[] = [];
+
+      readyState = WebSocket.CONNECTING;
+      send = vi.fn();
+      close = vi.fn(() => {
+        this.readyState = WebSocket.CLOSED;
+      });
+      terminate = vi.fn(() => {
+        this.readyState = WebSocket.CLOSED;
+      });
+
+      constructor(readonly url: string) {
+        super();
+        HangingWebSocket.instances.push(this);
+      }
+    }
+
+    const statuses: Array<Record<string, unknown>> = [];
+    const log: GatewayLogger = {
+      ...silentLog,
+      info: vi.fn(),
+      warn: vi.fn(),
+    };
+    const client = makeClient();
+    const channel = createBotCordChannel({
+      id: "botcord-main",
+      accountId: "ag_self",
+      agentId: "ag_self",
+      client,
+      webSocketCtor: HangingWebSocket as unknown as typeof WebSocket,
+      wsHandshakeTimeoutMs: 5,
+    });
+    const abort = new AbortController();
+    const startPromise = channel.start({
+      config: stubConfig,
+      accountId: "ag_self",
+      abortSignal: abort.signal,
+      log,
+      emit: async () => {},
+      setStatus: (patch) => statuses.push(patch),
+    });
+
+    try {
+      await vi.waitFor(() => {
+        expect(HangingWebSocket.instances).toHaveLength(1);
+        expect(HangingWebSocket.instances[0]!.terminate).toHaveBeenCalledTimes(1);
+        expect(log.warn).toHaveBeenCalledWith(
+          "botcord ws handshake timeout",
+          expect.objectContaining({
+            agentId: "ag_self",
+            timeoutMs: 5,
+          }),
+        );
+        expect(statuses).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              connected: false,
+              lastError: "botcord ws handshake timeout after 5ms",
+            }),
+            expect.objectContaining({
+              connected: false,
+              restartPending: true,
+              reconnectAttempts: 1,
+            }),
+          ]),
+        );
+      });
+    } finally {
+      abort.abort();
+      await startPromise;
+    }
+  });
+
+  it("terminates and reconnects when an authenticated websocket stops receiving server frames", async () => {
+    class AuthOnlyWebSocket extends EventEmitter {
+      static instances: AuthOnlyWebSocket[] = [];
+
+      readyState = WebSocket.CONNECTING;
+      close = vi.fn(() => {
+        this.readyState = WebSocket.CLOSED;
+      });
+      terminate = vi.fn(() => {
+        this.readyState = WebSocket.CLOSED;
+      });
+      send = vi.fn((data: string) => {
+        let msg: { type?: string } | null = null;
+        try {
+          msg = JSON.parse(String(data));
+        } catch {
+          return;
+        }
+        if (msg?.type === "auth") {
+          setImmediate(() => {
+            this.emit("message", JSON.stringify({ type: "auth_ok", agent_id: "ag_self" }));
+          });
+        }
+      });
+
+      constructor(readonly url: string) {
+        super();
+        AuthOnlyWebSocket.instances.push(this);
+        setImmediate(() => {
+          this.readyState = WebSocket.OPEN;
+          this.emit("open");
+        });
+      }
+    }
+
+    const statuses: Array<Record<string, unknown>> = [];
+    const log: GatewayLogger = {
+      ...silentLog,
+      info: vi.fn(),
+      warn: vi.fn(),
+    };
+    const client = makeClient();
+    const channel = createBotCordChannel({
+      id: "botcord-main",
+      accountId: "ag_self",
+      agentId: "ag_self",
+      client,
+      pollIntervalMs: 0,
+      webSocketCtor: AuthOnlyWebSocket as unknown as typeof WebSocket,
+      wsHandshakeTimeoutMs: 50,
+      wsStaleTimeoutMs: 5,
+    });
+    const abort = new AbortController();
+    const startPromise = channel.start({
+      config: stubConfig,
+      accountId: "ag_self",
+      abortSignal: abort.signal,
+      log,
+      emit: async () => {},
+      setStatus: (patch) => statuses.push(patch),
+    });
+
+    try {
+      await vi.waitFor(() => {
+        expect(log.info).toHaveBeenCalledWith(
+          "botcord ws authenticated",
+          expect.objectContaining({ agentId: "ag_self" }),
+        );
+      });
+      await vi.waitFor(() => {
+        expect(AuthOnlyWebSocket.instances).toHaveLength(1);
+        expect(AuthOnlyWebSocket.instances[0]!.terminate).toHaveBeenCalledTimes(1);
+        expect(log.warn).toHaveBeenCalledWith(
+          "botcord ws stale",
+          expect.objectContaining({
+            agentId: "ag_self",
+            timeoutMs: 5,
+          }),
+        );
+        expect(statuses).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              connected: true,
+              reconnectAttempts: 0,
+              lastError: null,
+            }),
+            expect.objectContaining({
+              connected: false,
+              lastError: "botcord ws stale after 5ms without server frame",
+            }),
+            expect.objectContaining({
+              connected: false,
+              restartPending: true,
+              reconnectAttempts: 1,
+            }),
+          ]),
+        );
+      });
+    } finally {
+      abort.abort();
+      await startPromise;
+    }
+  });
+
   it("includes the agent id on websocket server errors", async () => {
     const server = await startAuthOkServer();
     const client = makeClient({

--- a/packages/daemon/src/gateway/channels/botcord.ts
+++ b/packages/daemon/src/gateway/channels/botcord.ts
@@ -30,6 +30,8 @@ import { revokeAgent } from "../../provision.js";
 const RECONNECT_BACKOFF = [1000, 2000, 4000, 8000, 16000, 30000];
 const RECONNECT_JITTER_RATIO = 0.25;
 const KEEPALIVE_INTERVAL = 20_000;
+const WS_HANDSHAKE_TIMEOUT_MS = 15_000;
+const WS_STALE_TIMEOUT_MS = 60_000;
 const MAX_AUTH_FAILURES = 5;
 const SEEN_MESSAGES_CAP = 500;
 const OWNER_CHAT_PREFIX = "rm_oc_";
@@ -120,6 +122,10 @@ export interface BotCordChannelOptions {
    * can't spin up a real WS server.
    */
   webSocketCtor?: typeof WebSocket;
+  /** Test hook: override the connect/auth watchdog. Set <=0 to disable. Defaults to 15s. */
+  wsHandshakeTimeoutMs?: number;
+  /** Test hook: override the post-auth server-frame watchdog. Set <=0 to disable. Defaults to 60s. */
+  wsStaleTimeoutMs?: number;
   /** Test hook: override local cleanup after Hub says the agent is unclaimed. */
   localRevokeAgent?: (agentId: string, log: GatewayLogger) => Promise<unknown>;
 }
@@ -648,6 +654,8 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
 
     let ws: WebSocket | null = null;
     let reconnectTimer: NodeJS.Timeout | null = null;
+    let handshakeTimer: NodeJS.Timeout | null = null;
+    let staleTimer: NodeJS.Timeout | null = null;
     let keepaliveTimer: NodeJS.Timeout | null = null;
     let pollTimer: NodeJS.Timeout | null = null;
     let reconnectAttempt = 0;
@@ -666,11 +674,27 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
       rejectLoop = reject;
     });
 
+    function clearHandshakeTimer() {
+      if (handshakeTimer) {
+        clearTimeout(handshakeTimer);
+        handshakeTimer = null;
+      }
+    }
+
+    function clearStaleTimer() {
+      if (staleTimer) {
+        clearTimeout(staleTimer);
+        staleTimer = null;
+      }
+    }
+
     function clearTimers() {
       if (reconnectTimer) {
         clearTimeout(reconnectTimer);
         reconnectTimer = null;
       }
+      clearHandshakeTimer();
+      clearStaleTimer();
       if (keepaliveTimer) {
         clearInterval(keepaliveTimer);
         keepaliveTimer = null;
@@ -684,6 +708,58 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
     function markStatus(patch: Partial<ChannelStatusSnapshot>) {
       statusSnapshot = { ...statusSnapshot, ...patch };
       setStatus(patch);
+    }
+
+    function terminateSocket(socket: WebSocket) {
+      try {
+        socket.terminate();
+      } catch {
+        try {
+          socket.close();
+        } catch {
+          // ignore
+        }
+      }
+    }
+
+    function armHandshakeTimeout(socket: WebSocket, connectionId: number, agentId: string) {
+      clearHandshakeTimer();
+      const timeoutMs = options.wsHandshakeTimeoutMs ?? WS_HANDSHAKE_TIMEOUT_MS;
+      if (timeoutMs <= 0) return;
+      handshakeTimer = setTimeout(() => {
+        handshakeTimer = null;
+        if (!running || ws !== socket || connectionId !== connectionSeq) {
+          return;
+        }
+        const readyState = socket.readyState;
+        const lastError = `botcord ws handshake timeout after ${timeoutMs}ms`;
+        log.warn("botcord ws handshake timeout", { agentId, timeoutMs, readyState });
+        ws = null;
+        markStatus({ connected: false, lastError });
+        terminateSocket(socket);
+        scheduleReconnect();
+      }, timeoutMs);
+      handshakeTimer.unref?.();
+    }
+
+    function armStaleTimeout(socket: WebSocket, connectionId: number, agentId: string) {
+      clearStaleTimer();
+      const timeoutMs = options.wsStaleTimeoutMs ?? WS_STALE_TIMEOUT_MS;
+      if (timeoutMs <= 0) return;
+      staleTimer = setTimeout(() => {
+        staleTimer = null;
+        if (!running || ws !== socket || connectionId !== connectionSeq) {
+          return;
+        }
+        const readyState = socket.readyState;
+        const lastError = `botcord ws stale after ${timeoutMs}ms without server frame`;
+        log.warn("botcord ws stale", { agentId, timeoutMs, readyState });
+        ws = null;
+        markStatus({ connected: false, lastError });
+        terminateSocket(socket);
+        scheduleReconnect();
+      }, timeoutMs);
+      staleTimer.unref?.();
     }
 
     async function revokeLocalUnclaimedAgent(err: unknown) {
@@ -859,6 +935,7 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
         }
         socket.send(JSON.stringify({ type: "auth", token }));
       });
+      armHandshakeTimeout(socket, connectionId, agentId);
 
       socket.on("message", (data: WebSocket.RawData) => {
         if (ws !== socket || connectionId !== connectionSeq) return;
@@ -870,6 +947,8 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
         }
         if (!msg || typeof msg.type !== "string") return;
         if (msg.type === "auth_ok") {
+          clearHandshakeTimer();
+          armStaleTimeout(socket, connectionId, agentId);
           reconnectAttempt = 0;
           consecutiveAuthFailures = 0;
           markStatus({
@@ -902,11 +981,16 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
             }
           }, KEEPALIVE_INTERVAL);
         } else if (msg.type === "inbox_update") {
+          armStaleTimeout(socket, connectionId, agentId);
           log.info("botcord ws inbox_update received");
           void fireInbox("ws_inbox_update");
         } else if (msg.type === "heartbeat" || msg.type === "pong") {
+          armStaleTimeout(socket, connectionId, agentId);
           // no-op
         } else if (msg.type === "error" || msg.type === "auth_failed") {
+          if (statusSnapshot.connected) {
+            armStaleTimeout(socket, connectionId, agentId);
+          }
           log.warn("botcord ws server error", { agentId, msg });
         }
       });


### PR DESCRIPTION
## Summary
- add native BotCord websocket handshake timeout so CONNECTING sockets cannot block reconnect forever
- add post-auth stale server-frame watchdog so authenticated sockets recover when heartbeat/pong/inbox frames stop arriving
- add daemon channel regression tests for stuck handshake and stale authenticated websocket recovery

## Verification
- pnpm --dir packages/daemon test src/gateway/__tests__/botcord-channel.test.ts
- pnpm --dir packages/daemon build
- pnpm --dir packages/daemon test

## Risk / rollout
- daemon-only change; existing close/error reconnect behavior is preserved
- affected daemon processes need the updated daemon package and restart to pick up the watchdogs