### PR TITLE
fix: stop route sync reverting eager explore sub-tab switch

### DIFF
--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -142,6 +142,7 @@ export default function DashboardApp() {
   const mainContentRef = useRef<HTMLDivElement | null>(null);
   const mainContentAnimationRef = useRef<ReturnType<typeof animateIfMotion>>(null);
   const previousMainContentKeyRef = useRef<string | null>(null);
+  const lastSubtabSyncedPathnameRef = useRef<string | null>(null);
   const pathnameParts = useMemo(() => pathname.split("/").filter(Boolean), [pathname]);
   const routeSidebarTab = useMemo(() => getSidebarTabFromPathParts(pathnameParts), [pathnameParts]);
   const userChatAgentIdFromQuery = searchParams.get("agent_id");
@@ -343,12 +344,27 @@ export default function DashboardApp() {
         return;
       }
 
-      if (tab === "explore" && (subtab === "rooms" || subtab === "agents" || subtab === "humans") && uiStore.exploreView !== subtab) {
+      // URL → store sub-view sync must only run when the pathname itself
+      // changed (deep link, back/forward, completed navigation). This effect
+      // also re-runs on store changes, where the pathname is still the OLD
+      // route while a sub-tab click's router.push is in flight — syncing then
+      // would revert the eager store update and bounce the view back to the
+      // previous sub-tab until the RSC navigation lands (~1s on slow links).
+      const subtabPathnameChanged = lastSubtabSyncedPathnameRef.current !== pathname;
+      lastSubtabSyncedPathnameRef.current = pathname;
+
+      if (
+        subtabPathnameChanged
+        && tab === "explore"
+        && (subtab === "rooms" || subtab === "agents" || subtab === "humans")
+        && uiStore.exploreView !== subtab
+      ) {
         uiStore.setExploreView(subtab);
       }
 
       if (
-        tab === "contacts"
+        subtabPathnameChanged
+        && tab === "contacts"
         && (subtab === "agents" || subtab === "requests" || subtab === "rooms" || subtab === "created")
         && uiStore.contactsView !== subtab
       ) {


### PR DESCRIPTION
## Problem

Even after #946/#947, switching the discover tabs still showed the old tab's content re-rendering with a replayed entrance animation before the new tab appeared (user screen recording, preview env: ~1s stuck on old tab → skeleton → **old list animates in again** → finally the clicked tab).

## Root cause

The animations were only the symptom. The real bug is a two-way-binding race:

1. Tab click eagerly sets `uiStore.exploreView` and pushes `/chats/explore/<view>` inside `startTransition`.
2. `DashboardApp`'s route-sync effect lists `uiStore.exploreView` in its deps, so the eager update re-runs it **while `pathname` still points at the old sub-tab route** (the RSC navigation takes ~1s on preview).
3. The URL→store sync sees `subtab !== exploreView` and **reverts the view to the old sub-tab**, which also re-triggers that view's reload + entrance animation.
4. Only when the RSC navigation lands does the route flip the view forward again.

Locally the RSC roundtrip is a frame or two, which is why this read as an animation glitch; on preview the window is ~1s.

## Fix

Gate the explore/contacts subtab URL→store sync on the pathname actually having changed since the last sync (tracked via ref). Deep links, back/forward and completed navigations still sync; store-change re-runs of the effect can no longer revert an in-flight sub-tab click.

## Verification

- `pnpm build` passes
- `pnpm test`: 38 files / 199 tests pass
- Preview check: 发现页连续切 tab，应立即高亮新 tab → 骨架 → 新内容一次入场，不再回弹旧 tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)