### PR TITLE
Fix stale token refresh credential loops

### DIFF
--- a/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
+++ b/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
@@ -921,6 +921,152 @@ describe("createBotCordChannel — ack + dedup", () => {
       await server.close();
     }
   });
+
+  it("locally revokes stale credentials when token refresh returns a terminal 404", async () => {
+    const err = new Error(
+      'Token refresh failed: 404 {"code":"key_not_found","retryable":false}',
+    ) as Error & { status?: number; code?: string };
+    err.status = 404;
+    err.code = "key_not_found";
+    const client = makeClient({
+      ensureToken: vi.fn().mockRejectedValue(err),
+    });
+    const localRevokeAgent = vi.fn().mockResolvedValue({
+      agentId: "ag_self",
+      credentialsDeleted: true,
+      stateDeleted: true,
+      workspaceDeleted: false,
+    });
+    const statuses: Record<string, unknown>[] = [];
+    const logs: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+    const log: GatewayLogger = {
+      ...silentLog,
+      warn: (msg, meta) => logs.push({ msg, meta }),
+    };
+    const channel = createBotCordChannel({
+      id: "botcord-main",
+      accountId: "ag_self",
+      agentId: "ag_self",
+      client,
+      hubBaseUrl: "https://hub.example",
+      localRevokeAgent,
+    });
+
+    const startP = channel.start({
+      config: stubConfig,
+      accountId: "ag_self",
+      abortSignal: new AbortController().signal,
+      log,
+      emit: async () => undefined,
+      setStatus: (patch) => statuses.push(patch),
+    });
+
+    await expect(startP).rejects.toMatchObject({ code: "channel_permanent_stop" });
+    expect(localRevokeAgent).toHaveBeenCalledWith("ag_self", log);
+    expect(client.refreshToken).not.toHaveBeenCalled();
+    expect(logs.some((entry) => entry.msg === "botcord agent credentials rejected by Hub; revoked local binding"))
+      .toBe(true);
+    expect(statuses.at(-1)).toMatchObject({
+      running: false,
+      connected: false,
+      restartPending: false,
+      lastError: "agent credentials rejected by Hub; local binding revoked",
+    });
+  });
+
+  it("locally revokes stale credentials when forced websocket refresh returns a terminal 404", async () => {
+    class AuthRejectedWebSocket extends EventEmitter {
+      static instances: AuthRejectedWebSocket[] = [];
+
+      readyState = WebSocket.CONNECTING;
+      close = vi.fn(() => {
+        this.readyState = WebSocket.CLOSED;
+      });
+      send = vi.fn((data: string) => {
+        let msg: { type?: string } | null = null;
+        try {
+          msg = JSON.parse(String(data));
+        } catch {
+          return;
+        }
+        if (msg?.type === "auth") {
+          setImmediate(() => {
+            this.readyState = WebSocket.CLOSED;
+            this.emit("close", 4001, Buffer.from("auth failed"));
+          });
+        }
+      });
+
+      constructor(readonly url: string) {
+        super();
+        AuthRejectedWebSocket.instances.push(this);
+        setImmediate(() => {
+          this.readyState = WebSocket.OPEN;
+          this.emit("open");
+        });
+      }
+    }
+
+    const err = new Error(
+      'Token refresh failed: 404 {"code":"key_not_found","retryable":false}',
+    ) as Error & { status?: number; code?: string };
+    err.status = 404;
+    err.code = "key_not_found";
+    const client = makeClient({
+      refreshToken: vi.fn().mockRejectedValue(err),
+    });
+    const localRevokeAgent = vi.fn().mockResolvedValue({
+      agentId: "ag_self",
+      credentialsDeleted: true,
+      stateDeleted: true,
+      workspaceDeleted: false,
+    });
+    const statuses: Record<string, unknown>[] = [];
+    const logs: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+    const log: GatewayLogger = {
+      ...silentLog,
+      warn: (msg, meta) => logs.push({ msg, meta }),
+    };
+    const channel = createBotCordChannel({
+      id: "botcord-main",
+      accountId: "ag_self",
+      agentId: "ag_self",
+      client,
+      hubBaseUrl: "https://hub.example",
+      localRevokeAgent,
+      webSocketCtor: AuthRejectedWebSocket as unknown as typeof WebSocket,
+    });
+
+    const startP = channel.start({
+      config: stubConfig,
+      accountId: "ag_self",
+      abortSignal: new AbortController().signal,
+      log,
+      emit: async () => undefined,
+      setStatus: (patch) => statuses.push(patch),
+    });
+
+    await expect(startP).rejects.toMatchObject({ code: "channel_permanent_stop" });
+    expect(AuthRejectedWebSocket.instances).toHaveLength(1);
+    expect(client.refreshToken).toHaveBeenCalledTimes(1);
+    expect(localRevokeAgent).toHaveBeenCalledWith("ag_self", log);
+    expect(logs.some((entry) => entry.msg === "botcord agent credentials rejected by Hub; revoked local binding"))
+      .toBe(true);
+    expect(statuses).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          restartPending: true,
+          reconnectAttempts: 1,
+        }),
+      ]),
+    );
+    expect(statuses.at(-1)).toMatchObject({
+      running: false,
+      connected: false,
+      restartPending: false,
+      lastError: "agent credentials rejected by Hub; local binding revoked",
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/gateway/channels/botcord.ts
+++ b/packages/daemon/src/gateway/channels/botcord.ts
@@ -142,6 +142,27 @@ function isUnclaimedAgentError(err: unknown): boolean {
   );
 }
 
+function isTerminalAgentCredentialError(err: unknown): boolean {
+  const status = (err as { status?: unknown } | null)?.status;
+  const code = (err as { code?: unknown } | null)?.code;
+  if (
+    (status === 404 && (code === "key_not_found" || code === "agent_not_found")) ||
+    (status === 403 && code === "key_not_active")
+  ) {
+    return true;
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return (
+    (message.includes('"code":"key_not_found"') ||
+      message.includes('"code":"agent_not_found"') ||
+      message.includes('"code":"key_not_active"') ||
+      message.includes("key_not_found") ||
+      message.includes("agent_not_found") ||
+      message.includes("key_not_active")) &&
+    (message.includes("Token refresh failed: 404") || message.includes("Token refresh failed: 403"))
+  );
+}
+
 async function uploadOutboundAttachments(
   client: BotCordChannelClient,
   attachments: NonNullable<ChannelSendContext["message"]["attachments"]>,
@@ -827,6 +848,74 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
       return true;
     }
 
+    async function revokeLocalTerminalCredentials(err: unknown) {
+      if (!isTerminalAgentCredentialError(err)) return false;
+      running = false;
+      permanentStopping = true;
+      clearTimers();
+      try {
+        ws?.close();
+      } catch {
+        // ignore
+      }
+      try {
+        const result = options.localRevokeAgent
+          ? await options.localRevokeAgent(options.agentId, log)
+          : await revokeAgent(
+              {
+                agentId: options.agentId,
+                deleteCredentials: true,
+                deleteState: true,
+                deleteWorkspace: false,
+              },
+              {
+                gateway: {
+                  removeChannel: async () => undefined,
+                  removeManagedRoute: () => undefined,
+                } as unknown as Gateway,
+              },
+            );
+        log.warn("botcord agent credentials rejected by Hub; revoked local binding", {
+          agentId: options.agentId,
+          err: String(err),
+          result,
+        });
+        markStatus({
+          running: false,
+          connected: false,
+          restartPending: false,
+          lastStopAt: Date.now(),
+          lastError: "agent credentials rejected by Hub; local binding revoked",
+        });
+      } catch (cleanupErr) {
+        log.error("botcord terminal credential local revoke failed", {
+          agentId: options.agentId,
+          err: String(cleanupErr),
+        });
+        markStatus({
+          running: false,
+          connected: false,
+          restartPending: false,
+          lastStopAt: Date.now(),
+          lastError: String(cleanupErr),
+        });
+      }
+      permanentStopping = false;
+      if (rejectLoop) {
+        const r = rejectLoop;
+        rejectLoop = null;
+        resolveLoop = null;
+        const stopErr = new Error(
+          "agent credentials rejected by Hub; local binding revoked",
+        ) as Error & {
+          code?: string;
+        };
+        stopErr.code = CHANNEL_PERMANENT_STOP;
+        r(stopErr);
+      }
+      return true;
+    }
+
     async function fireInbox(trigger: InboxDrainTrigger) {
       if (processing) {
         pendingUpdate = true;
@@ -903,6 +992,9 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
       try {
         token = await client.ensureToken();
       } catch (err) {
+        if (await revokeLocalTerminalCredentials(err)) {
+          return;
+        }
         log.error("botcord ws token refresh failed", { agentId, err: String(err) });
         markStatus({ lastError: String(err) });
         scheduleReconnect();
@@ -1037,9 +1129,24 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
             }
             return;
           }
-          pendingRefresh = client
-            .refreshToken()
-            .catch((err) => log.error("botcord ws forced refresh failed", { agentId, err: String(err) }));
+          const refresh = (async () => {
+            try {
+              await client.refreshToken();
+            } catch (err) {
+              if (await revokeLocalTerminalCredentials(err)) {
+                return;
+              }
+              log.error("botcord ws forced refresh failed", { agentId, err: String(err) });
+            }
+          })();
+          pendingRefresh = refresh;
+          void refresh.then(() => {
+            if (pendingRefresh === refresh) {
+              pendingRefresh = null;
+            }
+            scheduleReconnect();
+          });
+          return;
         }
         scheduleReconnect();
       });

--- a/packages/protocol-core/src/__tests__/client.test.ts
+++ b/packages/protocol-core/src/__tests__/client.test.ts
@@ -68,6 +68,34 @@ describe("BotCordClient token refresh", () => {
     expect(inboxRequests[1].authorization).toBe("Bearer new-token");
   });
 
+  it("attaches status and code to token refresh failures", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json(
+          {
+            code: "key_not_found",
+            detail: "Key not found",
+            retryable: false,
+          },
+          { status: 404 },
+        ),
+      ),
+    );
+
+    const client = new BotCordClient({
+      hubUrl: "https://hub.example",
+      agentId: "ag_test",
+      keyId: "k_stale",
+      privateKey,
+    });
+
+    await expect(client.refreshToken()).rejects.toMatchObject({
+      status: 404,
+      code: "key_not_found",
+    });
+  });
+
   it("includes structured error_ref on typed error messages", async () => {
     let sentBody: any;
     vi.stubGlobal(

--- a/packages/protocol-core/src/client.ts
+++ b/packages/protocol-core/src/client.ts
@@ -35,6 +35,17 @@ import type { AttentionPolicy } from "./should-wake.js";
 const MAX_RETRIES = 2;
 const RETRY_BASE_MS = 1000;
 
+function parseErrorCode(body: string): string | undefined {
+  try {
+    const parsed = JSON.parse(body) as { code?: unknown; detail?: unknown };
+    if (typeof parsed.code === "string") return parsed.code;
+    if (typeof parsed.detail === "string") return parsed.detail;
+  } catch {
+    // Non-JSON error bodies are still included in the thrown message.
+  }
+  return undefined;
+}
+
 export interface BotCordClientConfig {
   hubUrl: string;
   agentId: string;
@@ -95,7 +106,11 @@ export class BotCordClient {
 
     if (!resp.ok) {
       const body = await resp.text().catch(() => "");
-      throw new Error(`Token refresh failed: ${resp.status} ${body}`);
+      const err = new Error(`Token refresh failed: ${resp.status} ${body}`);
+      (err as any).status = resp.status;
+      const code = parseErrorCode(body);
+      if (code) (err as any).code = code;
+      throw err;
     }
 
     const data = (await resp.json()) as { agent_token: string; token?: string; expires_at?: number };


### PR DESCRIPTION
## Summary
- preserve token refresh HTTP status/error code in protocol client errors
- treat terminal refresh errors (key_not_found / agent_not_found / key_not_active) as stale local credentials in daemon channel startup
- apply the same local revoke/permanent stop behavior after websocket auth close 4001 forced refresh failures

## Context
Ops reported sustained prod /registry/agents/.../token/refresh 404 volume across stale agents plus websocket ghost closures. The backend 404 is valid for missing/inactive credentials; the daemon needed to stop retrying terminal stale credentials and revoke the local binding.

## Verification
- git diff --check
- corepack pnpm --filter @botcord/protocol-core test -- src/__tests__/client.test.ts
- corepack pnpm --filter @botcord/daemon test -- src/gateway/__tests__/botcord-channel.test.ts

Code Reviewer re-review passed with no blocking issues before PR creation.