### PR TITLE
fix: quiet stale agent token refreshes

### DIFF
--- a/backend/hub/i18n.py
+++ b/backend/hub/i18n.py
@@ -1412,6 +1412,7 @@ class I18nHTTPException(HTTPException):
         message_key: str,
         *,
         hint_key: str | None = None,
+        headers: dict[str, str] | None = None,
         **kwargs: object,
     ) -> None:
         self.message_key = message_key
@@ -1419,4 +1420,4 @@ class I18nHTTPException(HTTPException):
         self.message_kwargs = kwargs
         # Use the key as the detail so FastAPI's default handler still
         # produces something meaningful if our custom handler is bypassed.
-        super().__init__(status_code=status_code, detail=message_key)
+        super().__init__(status_code=status_code, detail=message_key, headers=headers)

--- a/backend/hub/main.py
+++ b/backend/hub/main.py
@@ -235,6 +235,7 @@ async def i18n_http_exception_handler(request: Request, exc: I18nHTTPException):
     return JSONResponse(
         status_code=exc.status_code,
         content=content,
+        headers=exc.headers,
     )
 
 

--- a/backend/hub/routers/registry.py
+++ b/backend/hub/routers/registry.py
@@ -50,6 +50,11 @@ from hub.validators import check_agent_ownership, parse_pubkey, probe_endpoint, 
 
 router = APIRouter(prefix="/registry", tags=["registry"])
 
+_QUIET_TOKEN_REFRESH_HEADERS = {
+    "X-BotCord-Access-Log": "quiet",
+    "X-BotCord-Refresh-Status": "stale-agent",
+}
+
 
 def _generate_claim_code() -> str:
     return f"clm_{uuid.uuid4().hex}"
@@ -664,7 +669,17 @@ async def refresh_token(
     agent_id: str, req: TokenRefreshRequest, db: AsyncSession = Depends(get_db)
 ):
     """Refresh JWT by proving key ownership via nonce signature."""
-    # 1. Look up the signing key
+    # 1. Missing/deleted agents are terminal stale credentials. Classify them
+    # before key lookup so old runtimes stop producing noisy 404 refresh logs.
+    agent = await db.scalar(select(Agent).where(Agent.agent_id == agent_id))
+    if agent is None or agent.deleted_at is not None or agent.status == "deleted":
+        raise I18nHTTPException(
+            status_code=404,
+            message_key="agent_not_found",
+            headers=_QUIET_TOKEN_REFRESH_HEADERS,
+        )
+
+    # 2. Look up the signing key
     result = await db.execute(
         select(SigningKey).where(
             SigningKey.key_id == req.key_id,
@@ -678,7 +693,7 @@ async def refresh_token(
     if signing_key.state != KeyState.active:
         raise I18nHTTPException(status_code=403, message_key="key_not_active")
 
-    # 2. Check nonce has not been used (anti-replay)
+    # 3. Check nonce has not been used (anti-replay)
     result = await db.execute(
         select(UsedNonce).where(
             UsedNonce.agent_id == agent_id,
@@ -688,12 +703,12 @@ async def refresh_token(
     if result.scalar_one_or_none() is not None:
         raise I18nHTTPException(status_code=409, message_key="nonce_already_used")
 
-    # 3. Verify signature over the nonce
+    # 4. Verify signature over the nonce
     pubkey_b64 = signing_key.pubkey[len("ed25519:"):]
     if not verify_challenge_sig(pubkey_b64, req.nonce, req.sig):
         raise I18nHTTPException(status_code=401, message_key="signature_verification_failed")
 
-    # 4. Record nonce as used (with IntegrityError guard for concurrent requests)
+    # 5. Record nonce as used (with IntegrityError guard for concurrent requests)
     db.add(UsedNonce(agent_id=agent_id, nonce=req.nonce))
     try:
         await db.flush()
@@ -701,11 +716,8 @@ async def refresh_token(
         await db.rollback()
         raise I18nHTTPException(status_code=409, message_key="nonce_already_used")
 
-    # 5. Issue new token and make it the current accepted token.
+    # 6. Issue new token and make it the current accepted token.
     token, expires_at = create_agent_token(agent_id)
-    agent = await db.scalar(select(Agent).where(Agent.agent_id == agent_id))
-    if agent is None:
-        raise I18nHTTPException(status_code=404, message_key="agent_not_found")
     agent.agent_token = token
     agent.token_expires_at = datetime.datetime.fromtimestamp(
         expires_at, tz=datetime.timezone.utc

--- a/backend/tests/test_token_refresh.py
+++ b/backend/tests/test_token_refresh.py
@@ -174,6 +174,58 @@ async def test_wrong_key_id_rejected(client: AsyncClient):
         json={"key_id": "k_nonexistent", "nonce": nonce, "sig": sig},
     )
     assert resp.status_code == 404
+    assert resp.headers.get("X-BotCord-Access-Log") is None
+
+
+@pytest.mark.asyncio
+async def test_missing_agent_refresh_is_terminal_quiet_stale_credentials(
+    client: AsyncClient,
+):
+    """Missing agents use the released daemon's terminal stale-credential shape."""
+    sk, _ = _make_keypair()
+    nonce = base64.b64encode(b"nonce-for-missing-agent-test-123").decode()
+    sig = _sign_nonce(sk, nonce)
+
+    resp = await client.post(
+        "/registry/agents/ag_missing/token/refresh",
+        json={"key_id": "k_missing", "nonce": nonce, "sig": sig},
+    )
+
+    assert resp.status_code == 404
+    assert resp.headers["X-BotCord-Access-Log"] == "quiet"
+    assert resp.headers["X-BotCord-Refresh-Status"] == "stale-agent"
+    assert resp.json()["code"] == "agent_not_found"
+    assert resp.json()["retryable"] is False
+
+
+@pytest.mark.asyncio
+async def test_deleted_agent_refresh_is_terminal_quiet_stale_credentials(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """Soft-deleted agents should be compatible terminal refresh failures."""
+    sk, pubkey_str = _make_keypair()
+    agent_id, key_id = await _register_and_verify(client, sk, pubkey_str)
+
+    agent = await db_session.scalar(select(Agent).where(Agent.agent_id == agent_id))
+    assert agent is not None
+    agent.status = "deleted"
+    agent.deleted_at = datetime.datetime.now(datetime.timezone.utc)
+    await db_session.commit()
+
+    nonce = base64.b64encode(b"nonce-for-deleted-agent-test-123").decode()
+    sig = _sign_nonce(sk, nonce)
+
+    resp = await client.post(
+        f"/registry/agents/{agent_id}/token/refresh",
+        json={"key_id": key_id, "nonce": nonce, "sig": sig},
+    )
+
+    assert resp.status_code == 404
+    assert resp.headers["X-BotCord-Access-Log"] == "quiet"
+    assert resp.headers["X-BotCord-Refresh-Status"] == "stale-agent"
+    data = resp.json()
+    assert data["code"] == "agent_not_found"
+    assert "agent_token" not in data
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- classify missing, soft-deleted, and deleted agents before signing-key lookup in token refresh
- return PR #951-compatible terminal 404 agent_not_found responses with quiet/source headers for stale agent refreshes
- preserve active-agent wrong-key, inactive-key, nonce replay, and bad-signature behavior
- allow I18nHTTPException headers to pass through the custom JSON handler

## Review
- Code Reviewer ag_db82c61581a2 completed read-only review: no blocking issues.

## Verification
- cd backend && uv run pytest tests/test_token_refresh.py tests/test_i18n.py
- git diff --check -- target files

## Residual Risk
- X-BotCord-Access-Log: quiet is only a response marker. If prod noise is from uvicorn/native access logs or fixed status/path log ingestion, Ops/log pipeline may still need to honor this header explicitly.