### PR TITLE
Fix Kimi CLI work-dir compatibility

### DIFF
--- a/packages/daemon/src/gateway/__tests__/kimi-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/kimi-adapter.test.ts
@@ -77,6 +77,48 @@ process.stdout.write(JSON.stringify({role:"assistant", content:JSON.stringify(ar
     expect(argv).toContain("--afk");
   });
 
+  it("passes --work-dir when the Kimi CLI advertises support", async () => {
+    const script = makeScript(
+      "work-dir-supported.js",
+      `
+const argv = process.argv.slice(2);
+if (argv.includes("--help")) {
+  process.stdout.write("Usage: kimi --work-dir <dir> --print\\n");
+  process.exit(0);
+}
+process.stdout.write(JSON.stringify({role:"assistant", content:JSON.stringify({argv, cwd:process.cwd()})}) + "\\n");
+`,
+    );
+    const res = await runAdapter(script, "sid-123");
+    const seen = JSON.parse(res.text) as { argv: string[]; cwd: string };
+    expect(seen.argv).toContain("--work-dir");
+    expect(seen.argv[seen.argv.indexOf("--work-dir") + 1]).toBe(tmpRoot);
+    expect(seen.cwd).toBe(tmpRoot);
+  });
+
+  it("omits --work-dir and relies on child cwd when the Kimi CLI lacks support", async () => {
+    const script = makeScript(
+      "work-dir-unsupported.js",
+      `
+const argv = process.argv.slice(2);
+if (argv.includes("--help")) {
+  process.stdout.write("Usage: kimi --print\\n");
+  process.exit(0);
+}
+if (argv.includes("--work-dir")) {
+  process.stderr.write("unknown option '--work-dir'\\n");
+  process.exit(1);
+}
+process.stdout.write(JSON.stringify({role:"assistant", content:JSON.stringify({argv, cwd:process.cwd()})}) + "\\n");
+`,
+    );
+    const res = await runAdapter(script, "sid-123");
+    const seen = JSON.parse(res.text) as { argv: string[]; cwd: string };
+    expect(seen.argv).not.toContain("--work-dir");
+    expect(seen.cwd).toBe(tmpRoot);
+    expect(res.error).toBeUndefined();
+  });
+
   it("drops non-Kimi inherited extraArgs and their values", async () => {
     const script = makeScript(
       "filter-foreign-argv.js",
@@ -146,6 +188,10 @@ process.stdout.write(JSON.stringify({role:"assistant", content:JSON.stringify(ar
       "evil-session",
       "--prompt",
       "evil prompt",
+      "--work-dir",
+      "/tmp/evil",
+      "-w",
+      "/tmp/evil2",
       "--plan",
     ]);
     const argv = JSON.parse(res.text) as string[];
@@ -158,6 +204,9 @@ process.stdout.write(JSON.stringify({role:"assistant", content:JSON.stringify(ar
     expect(argv).toContain("--plan");
     expect(argv).not.toContain("evil-session");
     expect(argv).not.toContain("evil prompt");
+    expect(argv).not.toContain("/tmp/evil");
+    expect(argv).not.toContain("-w");
+    expect(argv).not.toContain("/tmp/evil2");
   });
 
   it("rejects session ids that could be parsed as flags", async () => {

--- a/packages/daemon/src/gateway/runtimes/kimi.ts
+++ b/packages/daemon/src/gateway/runtimes/kimi.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { execFileSync } from "node:child_process";
 import path from "node:path";
 import { writeManagedSystemRulesFile } from "../../system-rules.js";
 import { buildCliEnv } from "../cli-resolver.js";
@@ -81,6 +82,8 @@ const KIMI_ADAPTER_OWNED_FLAGS = new Set([
   "-w",
 ]);
 
+const kimiWorkDirSupport = new Map<string, boolean>();
+
 function flagName(arg: string): string {
   if (!arg.startsWith("-")) return arg;
   const eq = arg.indexOf("=");
@@ -131,6 +134,33 @@ function sanitizeKimiExtraArgs(extraArgs: string[] | undefined): string[] {
   return out;
 }
 
+function parseKimiVersionMajor(version: string | null): number | null {
+  const match = version?.match(/\b(\d+)\.(\d+)\.(\d+)\b/);
+  if (!match) return null;
+  return Number.parseInt(match[1], 10);
+}
+
+function probeKimiSupportsWorkDir(command: string): boolean {
+  const cached = kimiWorkDirSupport.get(command);
+  if (cached !== undefined) return cached;
+
+  let supported = false;
+  try {
+    const help = execFileSync(command, ["--help"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 5000,
+    });
+    supported = /(?:^|\s)--work-dir(?:[=\s,]|$)/.test(help);
+  } catch {
+    const major = parseKimiVersionMajor(readCommandVersion(command));
+    supported = major !== null && major >= 1;
+  }
+
+  kimiWorkDirSupport.set(command, supported);
+  return supported;
+}
+
 /** Resolve the Kimi CLI executable on PATH. */
 export function resolveKimiCommand(deps: ProbeDeps = {}): string | null {
   return resolveCommandOnPath("kimi", deps);
@@ -150,7 +180,7 @@ export function probeKimi(deps: ProbeDeps = {}): RuntimeProbeResult {
 /**
  * Kimi CLI adapter — spawns:
  *
- *   kimi --work-dir <cwd> --print --output-format stream-json --session <sid> --afk --prompt <text>
+ *   kimi [--work-dir <cwd>] --print --output-format stream-json --session <sid> --afk --prompt <text>
  *
  * `--session <sid>` resumes an existing session or creates a new session with
  * that id, so the adapter generates a UUID on first turn and persists it for
@@ -196,8 +226,6 @@ export class KimiAdapter extends NdjsonStreamAdapter {
     if (!isValidKimiSessionId(sessionId)) throw new Error(invalidKimiSessionIdError());
 
     const args = [
-      "--work-dir",
-      opts.cwd,
       "--print",
       "--output-format",
       "stream-json",
@@ -205,6 +233,7 @@ export class KimiAdapter extends NdjsonStreamAdapter {
       sessionId,
       "--afk",
     ];
+    if (probeKimiSupportsWorkDir(this.resolveBinary())) args.unshift("--work-dir", opts.cwd);
     args.push(...sanitizeKimiExtraArgs(opts.extraArgs));
     args.push("--prompt", promptWithSystemContext(opts.text, opts.systemContext));
     return args;


### PR DESCRIPTION
## Summary
- probe Kimi CLI support before passing --work-dir
- rely on child cwd when older Kimi CLIs do not advertise --work-dir
- sanitize inherited work-dir flags from extraArgs

## Validation
- git diff --check
- Code Reviewer previously verified 14 Kimi adapter tests plus daemon tsc