### PR TITLE
chore: release daemon v0.4.2

### DIFF
--- a/packages/daemon/CHANGELOG.md
+++ b/packages/daemon/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @botcord/daemon
 
+## 0.4.2
+
+### Patch Changes
+
+- 010a506: Fix Kimi CLI work-dir compatibility by probing for `--work-dir` support before adding the flag. Older Kimi CLI builds now run with the daemon-provided child process cwd instead of failing on an unknown `--work-dir` option, while newer builds still receive the explicit work-dir flag.
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botcord/daemon",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "BotCord local daemon — bridges Hub inbox push to local Claude Code / Codex / Gemini CLIs",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- bump @botcord/daemon from 0.4.1 to 0.4.2
- add daemon changelog entry for the Kimi --work-dir compatibility fix from PR #953 / 010a506

## Validation
- corepack pnpm install --frozen-lockfile (passed; pnpm bin-link warnings because CLI dist was not built yet)
- corepack pnpm --filter @botcord/protocol-core build (passed)
- corepack pnpm --filter @botcord/daemon exec vitest run src/gateway/__tests__/kimi-adapter.test.ts (passed, 14 tests)
- corepack pnpm --filter @botcord/daemon build (passed)
- corepack pnpm --filter @botcord/daemon test (74 files passed, 3 failed due environment-sensitive existing issues: missing unzip for diagnostics tests; local OpenClaw systemd discovery adding ws://127.0.0.1:16200 to expectations)

No prod/preview deploy, restart, scale, or npm publish performed in this PR.