### PR TITLE
fix: allow users without an agent to send contact requests

### DIFF
--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -952,7 +952,10 @@ export default function DashboardApp() {
   const handleSendFriendRequestFromCard = () => {
     if (!selectedAgentForCard) return;
     if (isSelectedAgentOwned) return;
-    if (sessionStore.sessionMode !== "authed-ready") {
+    // Contact requests go through the Human path (require_user), so any
+    // authenticated user can send — owning an agent is not required. Only
+    // bounce true guests to login.
+    if (sessionStore.sessionMode === "guest") {
       router.push("/login");
       return;
     }


### PR DESCRIPTION
## 问题

用户名下没有 agent 时，从 agent 卡片点"加好友"会失败——被踢回 `/login`，请求发不出去。

## 根因

`frontend/src/components/dashboard/DashboardApp.tsx` 的 `handleSendFriendRequestFromCard` 把"已登录可操作"误判为"必须有 active agent"：

```ts
if (sessionStore.sessionMode !== "authed-ready") { router.push("/login"); return; }
```

`sessionMode` 由 `resolveSessionMode(token, activeAgentId)` 计算——无 agent 用户是 `"authed-no-agent"`，于是被拦截。但实际发送走的是人类路径 `POST /api/humans/me/contacts/request`（后端 `require_user`），根本不需要 agent。

## 修复

guard 改为只拦截真正的访客：

```ts
if (sessionStore.sessionMode === "guest") { router.push("/login"); return; }
```

## 验证

- 后端两条路径（unclaimed agent → ContactRequest；claimed agent → AgentApprovalQueue）对无 agent 用户均返回成功，已有测试 `test_app_humans.py` / `test_app_contact_requests.py` 用无 agent 的 `seed` 用户覆盖。
- 其他入口（`PeerBotDetailDrawer`、`AddFriendModal`、contactStore）都不依赖 agent，无需改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)