### PR TITLE
fix(frontend): stop stranding owner-chat stream rows at opacity:0

### DIFF
--- a/frontend/src/components/dashboard/StreamBlocksView.tsx
+++ b/frontend/src/components/dashboard/StreamBlocksView.tsx
@@ -1004,7 +1004,23 @@ export default function StreamBlocksView({
         return !!rowKey && !previousKeys.has(rowKey);
       });
 
-      cleanupAnime(rowAnimationRef.current);
+      // Stop the previous batch's animation WITHOUT reverting it. revert()
+      // restores those rows to their opacity:0 baseline (set imperatively
+      // below) — and since they are no longer "entering", they'd never be
+      // animated back to 1, leaving them invisible but still occupying height.
+      // During fast multi-block streaming this strands every row but the last
+      // at opacity:0, producing a large blank gap above the visible content.
+      rowAnimationRef.current?.pause();
+      rowAnimationRef.current = null;
+
+      // Force every already-settled row fully visible, clearing any
+      // opacity/transform left behind by an interrupted enter animation.
+      rows.forEach((row) => {
+        if (enteringRows.includes(row)) return;
+        row.style.opacity = "1";
+        row.style.transform = "translateY(0)";
+      });
+
       if (enteringRows.length > 0) {
         enteringRows.forEach((row) => {
           row.style.opacity = "0";


### PR DESCRIPTION
## 问题

Owner-chat 流式输出时,执行块区域出现一大片空白,只有最新的 `command_execution` 行和 `Composing` 文本可见(quant agent 跑大量 tool call 的场景下尤为明显)。

## 根因

`StreamBlocksView` 的逐行进入动画:
1. 新进入的行被设成内联 `opacity:0`,animejs 将其记为动画基线。
2. 流式每来一个新 block,effect 重跑并对上一批动画调用 `revert()`,把那些行**还原回 `opacity:0`**。
3. 这些行已不属于"进入中",再也不会被恢复到 1 → 不可见但仍占高度 → 一大片空白。

## 修复

- per-batch 清理由 `revert()` 改为 `pause()`,不还原内联样式;
- 把所有非进入行强制设为 `opacity:1 / translateY(0)`,清掉被中断动画的残留。

改动仅限该 effect,1 文件。`tsc --noEmit` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)