### PR TITLE
fix: harden daemon runtime recovery

### DIFF
--- a/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
+++ b/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
@@ -490,6 +490,46 @@ describe("Dispatcher", () => {
     expect(lastCall.text).toContain("[BotCord Runtime Recovery Notice]");
   });
 
+  it("retries Hermes-style stale sessions in a fresh session with recovery context", async () => {
+    class RetryRuntime implements RuntimeAdapter {
+      readonly id = "hermes-agent";
+      readonly calls: RuntimeRunOptions[] = [];
+
+      async run(options: RuntimeRunOptions): Promise<RuntimeRunResult> {
+        this.calls.push(options);
+        if (this.calls.length === 1) {
+          return { text: "seed", newSessionId: "sid-stale" };
+        }
+        if (options.sessionId === "sid-stale") {
+          return {
+            text: "",
+            newSessionId: "",
+            error: "acp error -32602: Invalid params: {\"session_id\":\"Session not found\"}",
+          };
+        }
+        return { text: "recovered", newSessionId: "sid-fresh" };
+      }
+    }
+
+    const runtime = new RetryRuntime();
+    const { dispatcher, channel, store } = await scaffold({
+      config: baseConfig({ defaultRoute: { runtime: "hermes-agent", cwd: "/tmp/hermes" } }),
+      runtimeFactory: () => runtime,
+      buildRuntimeRecoveryContext: () => "[Recent Room Messages]\n- peer: previous context",
+    });
+
+    await dispatcher.handle(makeEnvelope({ id: "m1" }));
+    await dispatcher.handle(makeEnvelope({ id: "m2" }));
+
+    expect(runtime.calls).toHaveLength(3);
+    expect(runtime.calls[1].sessionId).toBe("sid-stale");
+    expect(runtime.calls[2].sessionId).toBeNull();
+    expect(runtime.calls[2].text).toContain("[BotCord Runtime Recovery Notice]");
+    expect(runtime.calls[2].text).toContain("Session not found");
+    expect(channel.sends[channel.sends.length - 1].message.text).toBe("recovered");
+    expect(store.all()[0].runtimeSessionId).toBe("sid-fresh");
+  });
+
   it("never rotates when both thresholds are disabled", async () => {
     const runtime = new FakeRuntime({ reply: "ok", newSessionId: "sid-1" });
     const { dispatcher, store } = await scaffold({

--- a/packages/daemon/src/gateway/__tests__/hermes-agent-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/hermes-agent-adapter.test.ts
@@ -183,6 +183,53 @@ describe("HermesAgentAdapter", () => {
     expect(res.error).toBeUndefined();
   });
 
+  it("session/load non-recoverable failure does not silently fall back to session/new", async () => {
+    const script = makeAcpServer(
+      "load-internal-error.js",
+      `
+        if (msg.method === "initialize") {
+          reply(msg, { protocolVersion: 1 });
+        } else if (msg.method === "session/load") {
+          err(msg, -32603, "database unavailable");
+        } else if (msg.method === "session/new") {
+          reply(msg, { sessionId: "should-not-be-used" });
+        }
+      `,
+    );
+    const res = await runAdapter(script, { sessionId: "sess-existing" });
+    expect(res.newSessionId).toBe("sess-existing");
+    expect(res.text).toBe("");
+    expect(res.error).toContain("session/load failed");
+    expect(res.error).toContain("database unavailable");
+  });
+
+  it("includes JSON-RPC error data in ACP prompt failures", async () => {
+    const script = makeAcpServer(
+      "prompt-error-data.js",
+      `
+        if (msg.method === "initialize") {
+          reply(msg, { protocolVersion: 1 });
+        } else if (msg.method === "session/new") {
+          reply(msg, { sessionId: "sess-error-data" });
+        } else if (msg.method === "session/prompt") {
+          send({
+            jsonrpc: "2.0",
+            id: msg.id,
+            error: {
+              code: -32602,
+              message: "Invalid params",
+              data: { session_id: "Session not found" }
+            }
+          });
+          process.exit(0);
+        }
+      `,
+    );
+    const res = await runAdapter(script);
+    expect(res.error).toContain("Invalid params");
+    expect(res.error).toContain("Session not found");
+  });
+
   it("drains late assistant text after a prompt RPC error before closing stdin", async () => {
     const script = makeAcpServer(
       "late-after-error.js",

--- a/packages/daemon/src/gateway/__tests__/kimi-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/kimi-adapter.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, describe, expect, it } from "vitest";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync, chmodSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { Buffer } from "node:buffer";
 import os from "node:os";
 import path from "node:path";
 import { KimiAdapter } from "../runtimes/kimi.js";
@@ -7,6 +8,7 @@ import { createRuntime, envVarForRuntime, listRuntimeIds } from "../runtimes/reg
 import type { RuntimeRunOptions } from "../types.js";
 
 const tmpRoot = mkdtempSync(path.join(os.tmpdir(), "gateway-kimi-"));
+const realTmpRoot = realpathSync(tmpRoot);
 
 function makeScript(name: string, body: string): string {
   const p = path.join(tmpRoot, name);
@@ -59,6 +61,33 @@ process.stdout.write(JSON.stringify({role:"assistant", content:"hello from kimi"
     expect(res.error).toBeUndefined();
   });
 
+  it("caps streamed assistant text by UTF-8 bytes without splitting characters", async () => {
+    const script = makeScript(
+      "large-utf8.js",
+      `
+const text = "你".repeat(400000);
+process.stdout.write(JSON.stringify({role:"assistant", content:text}) + "\\n");
+`,
+    );
+    const res = await runAdapter(script);
+    expect(res.error).toBeUndefined();
+    expect(Buffer.byteLength(res.text, "utf8")).toBeLessThanOrEqual(1024 * 1024);
+    expect(res.text).toMatch(/^你+$/);
+  });
+
+  it("surfaces terminal stderr errors when Kimi exits 0 without JSON output", async () => {
+    const script = makeScript(
+      "stderr-error.js",
+      `
+process.stderr.write("API call failed after 3 retries: rate limit exceeded\\n");
+process.exit(0);
+`,
+    );
+    const res = await runAdapter(script);
+    expect(res.text).toBe("");
+    expect(res.error).toContain("API call failed");
+  });
+
   it("passes an existing session id through --session", async () => {
     const script = makeScript(
       "resume-argv.js",
@@ -93,7 +122,7 @@ process.stdout.write(JSON.stringify({role:"assistant", content:JSON.stringify({a
     const seen = JSON.parse(res.text) as { argv: string[]; cwd: string };
     expect(seen.argv).toContain("--work-dir");
     expect(seen.argv[seen.argv.indexOf("--work-dir") + 1]).toBe(tmpRoot);
-    expect(seen.cwd).toBe(tmpRoot);
+    expect(seen.cwd).toBe(realTmpRoot);
   });
 
   it("omits --work-dir and relies on child cwd when the Kimi CLI lacks support", async () => {
@@ -115,7 +144,7 @@ process.stdout.write(JSON.stringify({role:"assistant", content:JSON.stringify({a
     const res = await runAdapter(script, "sid-123");
     const seen = JSON.parse(res.text) as { argv: string[]; cwd: string };
     expect(seen.argv).not.toContain("--work-dir");
-    expect(seen.cwd).toBe(tmpRoot);
+    expect(seen.cwd).toBe(realTmpRoot);
     expect(res.error).toBeUndefined();
   });
 

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -291,6 +291,13 @@ function looksLikeRecoverableSessionFailure(error: string): boolean {
   );
 }
 
+const FRESH_RETRY_SESSION_FAILURE_RUNTIMES = new Set([
+  "codex",
+  "hermes-agent",
+  "openclaw-acp",
+  "kimi-cli",
+]);
+
 function buildRuntimeRecoveryPrompt(args: {
   userTurn: string;
   runtimeLabel: string;
@@ -2221,7 +2228,7 @@ export class Dispatcher {
         const firstError = result.error ?? "";
         const firstReply = (result.text || "").trim();
         const shouldRetryFresh =
-          route.runtime === "codex" &&
+          FRESH_RETRY_SESSION_FAILURE_RUNTIMES.has(route.runtime) &&
           !!activeSessionId &&
           !!firstError &&
           !firstReply &&
@@ -2264,13 +2271,14 @@ export class Dispatcher {
             recoveryContext,
           });
           this.log.info(
-            "dispatcher: retrying codex turn in a fresh session with recovery context",
+            "dispatcher: retrying runtime turn in a fresh session with recovery context",
             {
               agentId: msg.accountId,
               roomId: msg.conversation.id,
               topicId: msg.conversation.threadId ?? null,
               turnId,
               queueKey,
+              runtime: route.runtime,
             }
           );
           result = await runRuntime(runtimeText, null);

--- a/packages/daemon/src/gateway/runtimes/acp-stream.ts
+++ b/packages/daemon/src/gateway/runtimes/acp-stream.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { createAcpTraceLogger, type AcpTraceLogger } from "../../acp-logs.js";
 import { consoleLogger } from "../log.js";
+import { sliceUtf8Bytes, utf8ByteLength } from "./text-cap.js";
 import type {
   RuntimeAdapter,
   RuntimeProbeResult,
@@ -175,9 +176,7 @@ class AcpConnection {
           code: typeof msg.error.code === "number" ? msg.error.code : undefined,
           error: msg.error.message ?? "(no message)",
         });
-        const err = new Error(
-          `acp error ${msg.error.code ?? "?"}: ${msg.error.message ?? "(no message)"}`,
-        );
+        const err = new Error(`acp error ${msg.error.code ?? "?"}: ${formatRpcError(msg.error)}`);
         pending.reject(err);
       } else {
         this.trace?.write({
@@ -448,14 +447,18 @@ export abstract class AcpRuntimeAdapter implements RuntimeAdapter {
         state.assistantTextCapped = true;
         return;
       }
-      if (text.length > budget) {
-        state.assistantTextChunks.push(text.slice(0, budget));
-        state.assistantTextBytes += budget;
+      const bytes = utf8ByteLength(text);
+      if (bytes > budget) {
+        const chunk = sliceUtf8Bytes(text, budget);
+        if (chunk) {
+          state.assistantTextChunks.push(chunk);
+          state.assistantTextBytes += utf8ByteLength(chunk);
+        }
         state.assistantTextCapped = true;
         return;
       }
       state.assistantTextChunks.push(text);
-      state.assistantTextBytes += text.length;
+      state.assistantTextBytes += bytes;
     };
 
     let seq = 0;
@@ -546,6 +549,9 @@ export abstract class AcpRuntimeAdapter implements RuntimeAdapter {
                 : "") || opts.sessionId;
           }
         } catch (err) {
+          if (!isRecoverableSessionLoadError(err)) {
+            throw new Error(`session/load failed: ${err instanceof Error ? err.message : String(err)}`);
+          }
           log.warn(`${this.id} session/load failed; falling back to new`, {
             err: err instanceof Error ? err.message : String(err),
           });
@@ -629,8 +635,8 @@ export abstract class AcpRuntimeAdapter implements RuntimeAdapter {
     const rawText =
       state.finalText || state.assistantTextChunks.join("").trim();
     const text =
-      rawText.length > ASSISTANT_TEXT_CAP
-        ? rawText.slice(0, ASSISTANT_TEXT_CAP)
+      utf8ByteLength(rawText) > ASSISTANT_TEXT_CAP
+        ? sliceUtf8Bytes(rawText, ASSISTANT_TEXT_CAP)
         : rawText;
 
     return {
@@ -659,6 +665,47 @@ export abstract class AcpRuntimeAdapter implements RuntimeAdapter {
       );
     });
   }
+}
+
+function formatRpcError(error: unknown): string {
+  if (!error || typeof error !== "object") return "(no message)";
+  const e = error as Record<string, unknown>;
+  const message = typeof e.message === "string" && e.message ? e.message : "(no message)";
+  const data = e.data;
+  if (data === undefined || data === null) return message;
+  let detail = "";
+  if (typeof data === "string") {
+    detail = data;
+  } else {
+    const dataObj = typeof data === "object" ? (data as Record<string, unknown>) : null;
+    const details = dataObj && typeof dataObj.details === "string" ? dataObj.details : "";
+    if (details) {
+      detail = details;
+    } else {
+      try {
+        detail = JSON.stringify(data);
+      } catch {
+        detail = String(data);
+      }
+    }
+  }
+  return detail ? `${message}: ${detail}` : message;
+}
+
+function isRecoverableSessionLoadError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return (
+    isSessionNotFoundError(err) ||
+    /\bnot\s+found\b/i.test(msg) ||
+    /method\s+not\s+found|unknown\s+method|not\s+implemented/i.test(msg)
+  );
+}
+
+function isSessionNotFoundError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /session(?:\s+[\w-]+)?\s+not\s+found|no\s+session\s+found|unknown\s+session/i.test(
+    msg,
+  );
 }
 
 function sleepUnlessAborted(ms: number, signal: AbortSignal): Promise<void> {

--- a/packages/daemon/src/gateway/runtimes/ndjson-stream.ts
+++ b/packages/daemon/src/gateway/runtimes/ndjson-stream.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { buildCliEnv } from "../cli-resolver.js";
 import { consoleLogger } from "../log.js";
 import { safeCommand, sanitizeRuntimeFailureText, tailText } from "../runtime-failure.js";
+import { sliceUtf8Bytes, utf8ByteLength } from "./text-cap.js";
 import type {
   RuntimeAdapter,
   RuntimeProbeResult,
@@ -175,15 +176,19 @@ export abstract class NdjsonStreamAdapter implements RuntimeAdapter {
         log.warn(`${this.id} assistant text exceeded ${ASSISTANT_TEXT_CAP} bytes; dropping further chunks`);
         return;
       }
-      if (text.length > budget) {
-        state.assistantTextChunks.push(text.slice(0, budget));
-        state.assistantTextBytes += budget;
+      const bytes = utf8ByteLength(text);
+      if (bytes > budget) {
+        const chunk = sliceUtf8Bytes(text, budget);
+        if (chunk) {
+          state.assistantTextChunks.push(chunk);
+          state.assistantTextBytes += utf8ByteLength(chunk);
+        }
         state.assistantTextCapped = true;
         log.warn(`${this.id} assistant text hit ${ASSISTANT_TEXT_CAP}-byte cap`);
         return;
       }
       state.assistantTextChunks.push(text);
-      state.assistantTextBytes += text.length;
+      state.assistantTextBytes += bytes;
     };
 
     let stderrTail = "";
@@ -257,8 +262,13 @@ export abstract class NdjsonStreamAdapter implements RuntimeAdapter {
     }
 
     const rawText = state.finalText || state.assistantTextChunks.join("").trim();
+    if (code === 0 && !state.errorText && !rawText && looksLikeTerminalStderr(stderrTail)) {
+      state.errorText = `${this.id} reported an error on stderr: ${stderrTail.slice(-STDERR_ERROR_SNIPPET)}`;
+    }
     const text =
-      rawText.length > ASSISTANT_TEXT_CAP ? rawText.slice(0, ASSISTANT_TEXT_CAP) : rawText;
+      utf8ByteLength(rawText) > ASSISTANT_TEXT_CAP
+        ? sliceUtf8Bytes(rawText, ASSISTANT_TEXT_CAP)
+        : rawText;
 
     return {
       text,
@@ -291,4 +301,11 @@ export abstract class NdjsonStreamAdapter implements RuntimeAdapter {
         : {}),
     };
   }
+}
+
+function looksLikeTerminalStderr(text: string): boolean {
+  if (!text.trim()) return false;
+  return /\b(error|failed|failure|exception|traceback|unauthorized|forbidden|authentication|permission denied)\b|rate limit|quota exceeded|invalid api key|api call failed/i.test(
+    text,
+  );
 }

--- a/packages/daemon/src/gateway/runtimes/openclaw-acp.ts
+++ b/packages/daemon/src/gateway/runtimes/openclaw-acp.ts
@@ -6,6 +6,7 @@ import {
   type ProbeDeps,
 } from "./probe.js";
 import { consoleLogger } from "../log.js";
+import { sliceUtf8Bytes } from "./text-cap.js";
 import type {
   RuntimeAdapter,
   RuntimeProbeResult,
@@ -240,6 +241,11 @@ export class OpenclawAcpAdapter implements RuntimeAdapter {
         if (text && !capped) {
           const bytes = Buffer.byteLength(text, "utf8");
           if (assistantBytes + bytes > ASSISTANT_TEXT_CAP) {
+            const chunk = sliceUtf8Bytes(text, ASSISTANT_TEXT_CAP - assistantBytes);
+            if (chunk) {
+              assistantText += chunk;
+              assistantBytes += Buffer.byteLength(chunk, "utf8");
+            }
             capped = true;
           } else {
             assistantText += text;
@@ -372,16 +378,21 @@ export class OpenclawAcpAdapter implements RuntimeAdapter {
       const tailText = assistantTextFilter.flush();
       if (tailText && !capped) {
         const bytes = Buffer.byteLength(tailText, "utf8");
-        if (assistantBytes + bytes <= ASSISTANT_TEXT_CAP) {
-          assistantText += tailText;
-          assistantBytes += bytes;
+        const textForBlock =
+          assistantBytes + bytes <= ASSISTANT_TEXT_CAP
+            ? tailText
+            : sliceUtf8Bytes(tailText, ASSISTANT_TEXT_CAP - assistantBytes);
+        if (textForBlock) {
+          assistantText += textForBlock;
+          assistantBytes += Buffer.byteLength(textForBlock, "utf8");
+          if (textForBlock !== tailText) capped = true;
           seq += 1;
           emitBlock({
             raw: {
               method: "session/update",
               params: {
                 sessionId: acpSessionId,
-                update: { sessionUpdate: "agent_message_chunk", content: [{ type: "text", text: tailText }] },
+                update: { sessionUpdate: "agent_message_chunk", content: [{ type: "text", text: textForBlock }] },
               },
             },
             kind: "assistant_text",

--- a/packages/daemon/src/gateway/runtimes/text-cap.ts
+++ b/packages/daemon/src/gateway/runtimes/text-cap.ts
@@ -1,0 +1,25 @@
+import { Buffer } from "node:buffer";
+
+/** Return the UTF-8 byte length of a string. */
+export function utf8ByteLength(text: string): number {
+  return Buffer.byteLength(text, "utf8");
+}
+
+/**
+ * Slice a string to at most `maxBytes` UTF-8 bytes without splitting a code
+ * point. Used by runtime adapters whose safety caps are byte-oriented.
+ */
+export function sliceUtf8Bytes(text: string, maxBytes: number): string {
+  if (maxBytes <= 0) return "";
+  if (utf8ByteLength(text) <= maxBytes) return text;
+
+  let used = 0;
+  let out = "";
+  for (const ch of text) {
+    const n = utf8ByteLength(ch);
+    if (used + n > maxBytes) break;
+    out += ch;
+    used += n;
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary
- add byte-safe runtime output caps for NDJSON/ACP adapters
- preserve ACP JSON-RPC error data and avoid hiding non-recoverable session/load failures
- retry stale Kimi/Hermes/OpenClaw runtime sessions once with recovery context

## Verification
- cd packages/daemon && npm test -- --run src/gateway/__tests__/kimi-adapter.test.ts src/gateway/__tests__/hermes-agent-adapter.test.ts src/__tests__/openclaw-acp.test.ts src/gateway/__tests__/dispatcher.test.ts
- cd packages/daemon && npm run build

## Risk / rollout
- daemon-only runtime behavior change; users need updated/restarted daemon to pick it up
- fresh-session retry remains limited to session/recovery-like failures and skips auth failures
