### PR TITLE
fix: bind owner-chat replies to their run via explicit trace_id

### DIFF
--- a/.changeset/owner-chat-trace-binding.md
+++ b/.changeset/owner-chat-trace-binding.md
@@ -1,0 +1,6 @@
+---
+"@botcord/protocol-core": patch
+"@botcord/daemon": patch
+---
+
+Bind owner-chat agent replies to their originating run via an explicit `trace_id`, so streamed reasoning blocks merge into the final answer instead of orphaning into a separate collapsed block below the message. The daemon now forwards the run's `trace_id` (the trigger `hub_msg_id`) on the outbound reply, and `BotCordClient.sendMessage`/`sendTypedMessage` accept a `traceId` option that is sent as a non-signed `trace_id` field on `/hub/send`. The Hub honors this explicit trace instead of guessing the most-recently-registered one, which previously mis-attributed replies when owner-chat turns overlapped.

--- a/backend/hub/routers/hub.py
+++ b/backend/hub/routers/hub.py
@@ -1460,10 +1460,14 @@ async def _send_room_message(
         envelope.msg_id, envelope.from_, room_id, topic, receivers, _self_delivery,
     )
     envelope_data = envelope.model_dump(by_alias=True)
+    owner_chat_trace_id: str | None = None
     if is_owner_chat:
         from hub.routers.owner_chat_ws import current_owner_chat_trace_id
 
-        owner_chat_trace_id = current_owner_chat_trace_id(
+        # Prefer the sender-supplied trace_id (the daemon binds the reply to its
+        # originating run). Fall back to the most-recent registered trace only
+        # for legacy senders that don't stamp one.
+        owner_chat_trace_id = envelope.trace_id or current_owner_chat_trace_id(
             room_id=room_id,
             agent_id=envelope.from_,
         )
@@ -1616,6 +1620,7 @@ async def _send_room_message(
             room_id=room_id,
             hub_msg_id=first_hub_msg_id or "",
             sender_id=envelope.from_,
+            trace_id=owner_chat_trace_id,
             text=_oc_text,
             attachments=_oc_attachments if isinstance(_oc_attachments, list) else None,
             reply_preview=(

--- a/backend/hub/routers/owner_chat_ws.py
+++ b/backend/hub/routers/owner_chat_ws.py
@@ -216,6 +216,7 @@ async def notify_oc_ws_message(
     hub_msg_id: str,
     sender_id: str,
     text: str,
+    trace_id: str | None = None,
     created_at: datetime.datetime | None = None,
     attachments: list[dict[str, Any]] | None = None,
     reply_preview: dict[str, Any] | None = None,
@@ -242,19 +243,28 @@ async def notify_oc_ws_message(
         else datetime.datetime.now(datetime.timezone.utc).isoformat()
     )
 
-    # W1: Pop ALL traces for the matching user/agent pairs, not just the first.
-    # Attach the most recent one as trace_id in the message ext.
-    matched_traces: list[str] = []
-    for tid, sub in list(_oc_trace_subs.items()):
-        if sub in target_keys:
-            matched_traces.append(tid)
-
-    # Use the most recent trace_id (last added)
-    trace_id: str | None = matched_traces[-1] if matched_traces else None
-
-    # Clean up all matched traces
-    for tid in matched_traces:
-        _cleanup_trace(tid)
+    # Prefer the caller-supplied trace_id (bound to this reply's originating
+    # run). When present, clean up exactly that run and leave any other
+    # in-flight traces (e.g. a concurrent owner-chat turn) untouched.
+    #
+    # Legacy fallback (no explicit trace_id): pop ALL traces for the matching
+    # user/agent pairs and attach the most recent one. This can mis-attribute
+    # the reply when turns overlap, but is the best a trace-less sender allows.
+    if trace_id is not None:
+        traces_to_complete = [trace_id]
+        if trace_id in _oc_trace_subs:
+            _cleanup_trace(trace_id)
+    else:
+        matched_traces: list[str] = []
+        for tid, sub in list(_oc_trace_subs.items()):
+            if sub in target_keys:
+                matched_traces.append(tid)
+        # Use the most recent trace_id (last added)
+        trace_id = matched_traces[-1] if matched_traces else None
+        traces_to_complete = matched_traces
+        # Clean up all matched traces
+        for tid in matched_traces:
+            _cleanup_trace(tid)
 
     msg_data: dict[str, Any] = {
         "type": "message",
@@ -279,7 +289,7 @@ async def notify_oc_ws_message(
 
     # Mark matched in-flight runs completed in Redis and shorten their TTL
     # (no-op when Redis is disabled).
-    for tid in matched_traces:
+    for tid in traces_to_complete:
         await owner_chat_cache.mark_run_completed(tid, final_msg_id=hub_msg_id)
 
 

--- a/backend/hub/schemas.py
+++ b/backend/hub/schemas.py
@@ -42,6 +42,10 @@ class MessageEnvelope(BaseModel):
     payload_hash: str
     sig: Signature
     mentions: list[str] | None = None
+    # Non-signed correlation hint set by the sender (e.g. the daemon binding an
+    # owner-chat reply to its originating run). Excluded from the signing input
+    # (see ``crypto.build_signing_input``) so it never affects verification.
+    trace_id: str | None = None
 
     def to_text(
         self,

--- a/backend/tests/test_owner_chat_trace_binding.py
+++ b/backend/tests/test_owner_chat_trace_binding.py
@@ -1,0 +1,124 @@
+"""Regression tests for owner-chat reply ↔ run trace binding.
+
+The owner-chat WS pushes reasoning stream blocks keyed by the trigger's
+``trace_id`` (== trigger ``hub_msg_id``). The final agent reply must carry the
+SAME trace_id so the dashboard merges the reasoning above the answer instead of
+orphaning it into a separate placeholder. Previously the Hub guessed the trace
+from "most recent registered trace", which mis-attributed replies when turns
+overlapped. Now the daemon stamps an explicit ``trace_id`` on the reply and the
+Hub honors it.
+"""
+
+import datetime
+
+import pytest
+
+from hub.routers import owner_chat_ws
+
+
+class _FakeWS:
+    """Minimal stand-in for a connected owner-chat WebSocket."""
+
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+
+    async def send_json(self, data: dict) -> None:
+        self.sent.append(data)
+
+
+@pytest.mark.asyncio
+async def test_explicit_trace_id_wins_over_most_recent_and_preserves_others(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    user_id = "u_trace_bind"
+    agent_id = "ag_trace_bind"
+    room_id = owner_chat_ws._build_owner_chat_room_id(user_id, agent_id)
+
+    # Two overlapping runs registered for the same (user, agent). run1 is the
+    # one that actually produced this reply; run2 is a newer, still-in-flight
+    # turn whose trace the legacy "most recent" heuristic would wrongly pick.
+    run1 = "h_run1"
+    run2 = "h_run2"
+    owner_chat_ws._oc_trace_subs[run1] = (user_id, agent_id)
+    owner_chat_ws._oc_trace_subs[run2] = (user_id, agent_id)
+    owner_chat_ws._oc_trace_block_count[run1] = 0
+    owner_chat_ws._oc_trace_block_count[run2] = 0
+
+    ws = _FakeWS()
+    owner_chat_ws._oc_ws_connections[(user_id, agent_id)] = {ws}
+
+    completed: list[str] = []
+
+    async def _fake_mark_completed(tid: str, *, final_msg_id: str) -> None:
+        completed.append(tid)
+
+    monkeypatch.setattr(
+        owner_chat_ws.owner_chat_cache, "mark_run_completed", _fake_mark_completed
+    )
+
+    try:
+        await owner_chat_ws.notify_oc_ws_message(
+            room_id=room_id,
+            hub_msg_id="h_reply_1",
+            sender_id=agent_id,
+            trace_id=run1,
+            text="the answer",
+            created_at=datetime.datetime.now(datetime.timezone.utc),
+        )
+
+        # The pushed message carries the explicit trace, not the most-recent run2.
+        assert len(ws.sent) == 1
+        assert ws.sent[0]["ext"]["trace_id"] == run1
+
+        # Only run1 is cleaned up / completed; the concurrent run2 survives.
+        assert run1 not in owner_chat_ws._oc_trace_subs
+        assert run2 in owner_chat_ws._oc_trace_subs
+        assert completed == [run1]
+    finally:
+        owner_chat_ws._oc_ws_connections.pop((user_id, agent_id), None)
+        owner_chat_ws._cleanup_trace(run1)
+        owner_chat_ws._cleanup_trace(run2)
+
+
+@pytest.mark.asyncio
+async def test_legacy_no_trace_id_falls_back_to_most_recent(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Trace-less senders keep the old behavior: most-recent trace, pop all."""
+    user_id = "u_legacy"
+    agent_id = "ag_legacy"
+    room_id = owner_chat_ws._build_owner_chat_room_id(user_id, agent_id)
+
+    older = "h_older"
+    newer = "h_newer"
+    owner_chat_ws._oc_trace_subs[older] = (user_id, agent_id)
+    owner_chat_ws._oc_trace_subs[newer] = (user_id, agent_id)
+
+    ws = _FakeWS()
+    owner_chat_ws._oc_ws_connections[(user_id, agent_id)] = {ws}
+
+    monkeypatch.setattr(
+        owner_chat_ws.owner_chat_cache,
+        "mark_run_completed",
+        lambda *a, **k: _noop(),
+    )
+
+    try:
+        await owner_chat_ws.notify_oc_ws_message(
+            room_id=room_id,
+            hub_msg_id="h_reply_2",
+            sender_id=agent_id,
+            text="legacy answer",
+        )
+        assert ws.sent[0]["ext"]["trace_id"] == newer
+        # Legacy path pops all matched traces.
+        assert older not in owner_chat_ws._oc_trace_subs
+        assert newer not in owner_chat_ws._oc_trace_subs
+    finally:
+        owner_chat_ws._oc_ws_connections.pop((user_id, agent_id), None)
+        owner_chat_ws._cleanup_trace(older)
+        owner_chat_ws._cleanup_trace(newer)
+
+
+async def _noop() -> None:
+    return None

--- a/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
+++ b/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
@@ -124,6 +124,29 @@ describe("createBotCordChannel — send()", () => {
     expect(result.providerMessageId).toBe("m_provider");
   });
 
+  it("forwards traceId to client.sendMessage so the reply binds to its run", async () => {
+    const client = makeClient();
+    const channel = createBotCordChannel({
+      id: "botcord-main",
+      accountId: "ag_self",
+      agentId: "ag_self",
+      client,
+    });
+    await channel.send({
+      message: {
+        channel: "botcord",
+        accountId: "ag_self",
+        conversationId: "rm_oc_1",
+        text: "answer",
+        traceId: "h_trigger_abc",
+      },
+      log: silentLog,
+    });
+    expect(client.sendMessage).toHaveBeenCalledWith("rm_oc_1", "answer", {
+      traceId: "h_trigger_abc",
+    });
+  });
+
   it("uploads outbound attachments and includes them in sendMessage", async () => {
     const client = makeClient({
       uploadFile: vi.fn().mockResolvedValue({

--- a/packages/daemon/src/gateway/channels/botcord.ts
+++ b/packages/daemon/src/gateway/channels/botcord.ts
@@ -80,13 +80,19 @@ export interface BotCordChannelClient {
   sendMessage(
     to: string,
     text: string,
-    options?: { replyTo?: string; topic?: string; attachments?: MessageAttachment[] },
+    options?: { replyTo?: string; topic?: string; attachments?: MessageAttachment[]; traceId?: string | null },
   ): Promise<{ hub_msg_id?: string; message_id?: string } & Record<string, unknown>>;
   sendTypedMessage?(
     to: string,
     type: "result" | "error",
     text: string,
-    options?: { replyTo?: string; topic?: string; attachments?: MessageAttachment[]; errorRef?: string },
+    options?: {
+      replyTo?: string;
+      topic?: string;
+      attachments?: MessageAttachment[];
+      errorRef?: string;
+      traceId?: string | null;
+    },
   ): Promise<{ hub_msg_id?: string; message_id?: string } & Record<string, unknown>>;
   getHubUrl(): string;
   onTokenRefresh?: (token: string, expiresAt: number) => void;
@@ -1224,10 +1230,15 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
         topic?: string;
         attachments?: MessageAttachment[];
         errorRef?: string;
+        traceId?: string | null;
       } = {};
       if (message.replyTo) options.replyTo = message.replyTo;
       if (message.threadId) options.topic = message.threadId;
       if (message.errorRef) options.errorRef = message.errorRef;
+      // Bind the reply to its originating run so owner-chat stream blocks
+      // (keyed by the same trace_id) merge into this message instead of
+      // orphaning into a separate placeholder.
+      if (message.traceId) options.traceId = message.traceId;
       const upload = await uploadOutboundAttachments(client, message.attachments ?? [], ctx.log);
       if (upload.attachments.length > 0) options.attachments = upload.attachments;
       const text = rewriteUploadedAttachmentPaths(message.text, upload.replacements);

--- a/packages/protocol-core/src/client.ts
+++ b/packages/protocol-core/src/client.ts
@@ -215,6 +215,7 @@ export class BotCordClient {
       ttlSec?: number;
       attachments?: MessageAttachment[];
       mentions?: string[];
+      traceId?: string | null;
     },
   ): Promise<SendResponse> {
     const payload: Record<string, unknown> = { text };
@@ -239,6 +240,12 @@ export class BotCordClient {
     if (options?.mentions && options.mentions.length > 0) {
       body.mentions = options.mentions;
     }
+    // Non-signed correlation hint: lets the Hub bind the owner-chat reply to
+    // the originating run (== trigger hub_msg_id) instead of guessing the
+    // most-recent registered trace. Ignored by the signature check.
+    if (options?.traceId) {
+      body.trace_id = options.traceId;
+    }
 
     const topicQuery = options?.topic ? `?topic=${encodeURIComponent(options.topic)}` : "";
     const resp = await this.hubFetch(`/hub/send${topicQuery}`, {
@@ -252,7 +259,13 @@ export class BotCordClient {
     to: string,
     type: "result" | "error",
     text: string,
-    options?: { replyTo?: string; topic?: string; attachments?: MessageAttachment[]; errorRef?: string },
+    options?: {
+      replyTo?: string;
+      topic?: string;
+      attachments?: MessageAttachment[];
+      errorRef?: string;
+      traceId?: string | null;
+    },
   ): Promise<SendResponse> {
     const payload: Record<string, unknown> =
       type === "error"
@@ -279,10 +292,15 @@ export class BotCordClient {
       topic: options?.topic,
     });
 
+    const body: Record<string, unknown> = { ...envelope };
+    if (options?.traceId) {
+      body.trace_id = options.traceId;
+    }
+
     const topicQuery = options?.topic ? `?topic=${encodeURIComponent(options.topic)}` : "";
     const resp = await this.hubFetch(`/hub/send${topicQuery}`, {
       method: "POST",
-      body: JSON.stringify(envelope),
+      body: JSON.stringify(body),
     });
     return (await resp.json()) as SendResponse;
   }


### PR DESCRIPTION
## Problem

In the owner-chat dashboard, an agent's reasoning ("thinking" / stream) blocks sometimes render as a separate collapsed block **below** the finished answer instead of merging above it.

Root cause: owner-chat stream blocks are keyed by the trigger's `trace_id` (== trigger `hub_msg_id`), but the **final reply did not carry that trace_id end-to-end**. The Hub fell back to "the most-recently-registered trace" for the `(user, agent)` pair. When owner-chat turns overlap (or a prior reply already popped the trace set), the reply gets tagged with the wrong `trace_id` — or none — so the frontend can't match the streamed blocks to the answer and orphans them into a standalone placeholder message.

## Fix — propagate `trace_id` end-to-end

- **`@botcord/daemon`** (`channels/botcord.ts`): `send()` forwards `message.traceId` (the run's trace = trigger `hub_msg_id`, same value already used for stream-block frames) to the client. All dispatcher reply paths already set `traceId`; the channel was the missing hop.
- **`@botcord/protocol-core`** (`client.ts`): `sendMessage` / `sendTypedMessage` accept a `traceId` option, sent as a **non-signed** top-level `trace_id` field on `/hub/send` (excluded from the signing input, so verification is unaffected).
- **Hub** (`hub.py`, `owner_chat_ws.py`, `schemas.py`): `MessageEnvelope` gains optional `trace_id`; the owner-chat fan-out honors the explicit trace for both persistence and the WS push, and `notify_oc_ws_message` cleans up **only that run** (leaving concurrent in-flight turns intact). The "most-recent" heuristic remains as a legacy fallback for trace-less senders.

Frontend needs no change: with a consistent `trace_id`, `appendStreamBlock`'s streaming placeholder is upgraded in place by `finalizeStream` and the reasoning renders above the bubble.

## Tests

- New `backend/tests/test_owner_chat_trace_binding.py`: explicit trace wins over "most recent" and does not pop a concurrent run's trace; legacy fallback unchanged.
- New `botcord-channel.test.ts` case: `traceId` is forwarded to `sendMessage`.
- Regression: daemon 1088 passed; backend 203 passed / 1 skipped; full JS workspace build passes.

Includes a changeset (patch bump for `@botcord/protocol-core` + `@botcord/daemon`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)