### PR TITLE
fix(daemon): harden runtime against hangs and transient failures

### DIFF
--- a/.changeset/daemon-runtime-hang-watchdog.md
+++ b/.changeset/daemon-runtime-hang-watchdog.md
@@ -1,0 +1,9 @@
+---
+"@botcord/daemon": patch
+---
+
+Harden runtime stability against hangs and transient failures:
+
+- Kimi: stop passing `--work-dir` when the CLI can't be confirmed to support it (the `--help` probe timing out or exiting non-zero no longer falls back to a version guess that crashes builds without the flag — the spawn cwd already sets the working directory).
+- Hermes / OpenClaw (ACP): add a per-turn no-output watchdog (`BOTCORD_ACP_IDLE_TIMEOUT_MS`, default 10m). A hung prompt is now cancelled and surfaced as an error in minutes instead of sitting dead until the 30-minute turn timeout. OpenClaw rejects the hung turn without killing the shared pooled child.
+- Dispatcher: retry a turn once on a transient runtime failure (connection blip, 5xx, ACP `-32603` internal error), but only when the runtime emitted no output that turn, so the retry can never duplicate a tool call or sent message.

--- a/packages/daemon/src/__tests__/openclaw-acp.test.ts
+++ b/packages/daemon/src/__tests__/openclaw-acp.test.ts
@@ -787,4 +787,48 @@ describe("OpenclawAcpAdapter.run", () => {
       "session/prompt",
     ]);
   });
+
+  it("rejects a hung prompt via the per-turn idle watchdog and sends cancel", async () => {
+    const child = new FakeChild();
+    const adapter = new OpenclawAcpAdapter({ spawnFn: makeSpawn(child) });
+    const gateway: ResolvedOpenclawGateway = {
+      name: "local",
+      url: "ws://127.0.0.1:1",
+      openclawAgent: "main",
+    };
+    const methods: string[] = [];
+    child.stdin.on("data", (chunk: Buffer) => {
+      for (const line of chunk.toString("utf8").split("\n").filter(Boolean)) {
+        const frame = JSON.parse(line);
+        methods.push(frame.method);
+        if (frame.method === "initialize") {
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { protocolVersion: 1 } }) + "\n");
+        } else if (frame.method === "session/new") {
+          child.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { sessionId: "sid-hung" } }) + "\n");
+        }
+        // session/prompt: never reply, never stream — the hang we guard against.
+      }
+    });
+    const prev = process.env.BOTCORD_ACP_IDLE_TIMEOUT_MS;
+    process.env.BOTCORD_ACP_IDLE_TIMEOUT_MS = "200";
+    try {
+      const res = await adapter.run({
+        text: "hi",
+        sessionId: null,
+        cwd: "/tmp",
+        accountId: "ag_alice",
+        signal: new AbortController().signal,
+        trustLevel: "owner",
+        gateway,
+      });
+      expect(res.error).toMatch(/idle timeout/);
+      // The child must NOT be killed — the pool handle is shared across turns.
+      expect(child.killed).toBe(false);
+      // We asked OpenClaw to cancel the hung session rather than abandoning it.
+      expect(methods).toContain("session/cancel");
+    } finally {
+      if (prev === undefined) delete process.env.BOTCORD_ACP_IDLE_TIMEOUT_MS;
+      else process.env.BOTCORD_ACP_IDLE_TIMEOUT_MS = prev;
+    }
+  }, 15_000);
 });

--- a/packages/daemon/src/acp-logs.ts
+++ b/packages/daemon/src/acp-logs.ts
@@ -21,6 +21,7 @@ export type AcpTraceStream =
   | "stderr"
   | "stdout_non_json"
   | "turn_context"
+  | "idle_timeout"
   | "rpc_in"
   | "rpc_out";
 

--- a/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
+++ b/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
@@ -786,6 +786,72 @@ describe("Dispatcher", () => {
     ]);
   });
 
+  it("retries once on a transient runtime failure when no output was emitted", async () => {
+    const runtime: RuntimeAdapter = {
+      id: "hermes-agent",
+      run: vi.fn(async (): Promise<RuntimeRunResult> => {
+        if ((runtime.run as any).mock.calls.length === 1) {
+          // Transient failure, no blocks emitted, no reply → safe to retry.
+          return {
+            text: "",
+            newSessionId: "sid-1",
+            error: "acp error -32603: Internal error",
+          };
+        }
+        return { text: "recovered", newSessionId: "sid-1" };
+      }) as RuntimeAdapter["run"],
+    };
+    const { dispatcher, channel } = await scaffold({
+      config: baseConfig({
+        defaultRoute: { runtime: "hermes-agent", cwd: "/tmp/default" },
+      }),
+      runtimeFactory: () => runtime,
+      transcript: new CaptureTranscript(),
+    });
+
+    await dispatcher.handle(
+      makeEnvelope({
+        id: "m1",
+        conversation: { id: "rm_oc_transient", kind: "direct" },
+      })
+    );
+
+    expect(runtime.run).toHaveBeenCalledTimes(2);
+    expect(channel.sends.map((s) => s.message.text)).toEqual(["recovered"]);
+  }, 10_000);
+
+  it("does NOT retry a transient failure once the runtime has emitted output", async () => {
+    const runtime: RuntimeAdapter = {
+      id: "hermes-agent",
+      run: vi.fn(async (opts: RuntimeRunOptions): Promise<RuntimeRunResult> => {
+        // A tool ran (side effect) before the failure — retrying could duplicate it.
+        opts.onBlock?.({ raw: { name: "botcord_send" }, kind: "tool_use", seq: 1 });
+        return {
+          text: "",
+          newSessionId: "sid-1",
+          error: "acp error -32603: Internal error",
+        };
+      }) as RuntimeAdapter["run"],
+    };
+    const { dispatcher, channel } = await scaffold({
+      config: baseConfig({
+        defaultRoute: { runtime: "hermes-agent", cwd: "/tmp/default" },
+      }),
+      runtimeFactory: () => runtime,
+      transcript: new CaptureTranscript(),
+    });
+
+    await dispatcher.handle(
+      makeEnvelope({
+        id: "m1",
+        conversation: { id: "rm_oc_no_retry", kind: "direct" },
+      })
+    );
+
+    expect(runtime.run).toHaveBeenCalledTimes(1);
+    expect(channel.sends[channel.sends.length - 1].message.type).toBe("error");
+  });
+
   it("treats auth failure text as an error and does not persist the failed session", async () => {
     let callNo = 0;
     const runtimeFactory: RuntimeFactory = () => {

--- a/packages/daemon/src/gateway/__tests__/hermes-agent-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/hermes-agent-adapter.test.ts
@@ -527,4 +527,36 @@ describe("HermesAgentAdapter.spawnEnv attach mode", () => {
     expect(env.HERMES_HOME).toContain(path.join(".botcord", "agents", "ag_isolated"));
     expect(env.HERMES_HOME).not.toBe(hermesProfileHomeDir("default"));
   });
+
+  it("kills a hung turn via the idle watchdog instead of hanging forever", async () => {
+    // initialize + session/new reply normally (resets the idle clock), then
+    // session/prompt is swallowed with no reply and no further output — the
+    // exact hang shape we want the watchdog to catch.
+    const script = makeAcpServer(
+      "hung-prompt.js",
+      `
+        if (msg.method === "initialize") {
+          reply(msg, { protocolVersion: 1, agentCapabilities: {} });
+        } else if (msg.method === "session/new") {
+          reply(msg, { sessionId: "sess-hung" });
+        }
+        // session/prompt: intentionally drop — never reply, emit nothing.
+      `,
+    );
+    // Generous enough that the initialize + session/new handshake (which
+    // streams stdout and so keeps rearming the watchdog) always completes
+    // first — proving the timer fires on the prompt silence, not mid-handshake,
+    // even under heavy parallel test load.
+    const prev = process.env.BOTCORD_ACP_IDLE_TIMEOUT_MS;
+    process.env.BOTCORD_ACP_IDLE_TIMEOUT_MS = "2000";
+    try {
+      const res = await runAdapter(script);
+      expect(res.error).toBeDefined();
+      expect(res.error).toContain("idle timeout");
+      expect(res.newSessionId).toBe("sess-hung");
+    } finally {
+      if (prev === undefined) delete process.env.BOTCORD_ACP_IDLE_TIMEOUT_MS;
+      else process.env.BOTCORD_ACP_IDLE_TIMEOUT_MS = prev;
+    }
+  }, 15_000);
 });

--- a/packages/daemon/src/gateway/__tests__/kimi-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/kimi-adapter.test.ts
@@ -148,6 +148,32 @@ process.stdout.write(JSON.stringify({role:"assistant", content:JSON.stringify({a
     expect(res.error).toBeUndefined();
   });
 
+  it("omits --work-dir when the --help probe fails instead of guessing from version", async () => {
+    // Reproduces the prod crash: on a cold Python start `kimi --help` times out
+    // or exits non-zero, the probe can't confirm support, and we must fall back
+    // to cwd-only rather than passing an unknown option that crashes the turn.
+    const script = makeScript(
+      "work-dir-help-fails.js",
+      `
+const argv = process.argv.slice(2);
+if (argv.includes("--help")) {
+  process.stderr.write("boom\\n");
+  process.exit(2);
+}
+if (argv.includes("--work-dir")) {
+  process.stderr.write("error: unknown option '--work-dir'\\n");
+  process.exit(1);
+}
+process.stdout.write(JSON.stringify({role:"assistant", content:JSON.stringify({argv, cwd:process.cwd()})}) + "\\n");
+`,
+    );
+    const res = await runAdapter(script, "sid-123");
+    const seen = JSON.parse(res.text) as { argv: string[]; cwd: string };
+    expect(seen.argv).not.toContain("--work-dir");
+    expect(seen.cwd).toBe(realTmpRoot);
+    expect(res.error).toBeUndefined();
+  });
+
   it("drops non-Kimi inherited extraArgs and their values", async () => {
     const script = makeScript(
       "filter-foreign-argv.js",

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -15,6 +15,7 @@ import {
 import {
   formatUsageLimitMessage,
   looksLikeRuntimeAuthFailure,
+  looksLikeTransientRuntimeError,
   looksLikeUsageLimit,
 } from "./runtime-errors.js";
 import { resolveRoute } from "./router.js";
@@ -57,6 +58,8 @@ import type {
 } from "./types.js";
 
 const DEFAULT_TURN_TIMEOUT_MS = 30 * 60 * 1000;
+/** Backoff before a single transient-failure retry (see {@link looksLikeTransientRuntimeError}). */
+const TRANSIENT_RETRY_BACKOFF_MS = 1000;
 const DEFAULT_RUNTIME_AUTH_FAILURE_THRESHOLD = 3;
 const DEFAULT_RUNTIME_AUTH_FAILURE_COOLDOWN_MS = 10 * 60 * 1000;
 
@@ -283,6 +286,21 @@ function extractCloudRunBudget(
   return out.maxWallTimeMs !== undefined || out.maxToolCalls !== undefined
     ? out
     : undefined;
+}
+
+/** Resolve after `ms`, or immediately when `signal` aborts. Never rejects. */
+function sleepUnlessAborted(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const t = setTimeout(done, ms);
+    if (typeof t.unref === "function") t.unref();
+    function done(): void {
+      signal.removeEventListener("abort", done);
+      clearTimeout(t);
+      resolve();
+    }
+    signal.addEventListener("abort", done, { once: true });
+  });
 }
 
 function looksLikeRecoverableSessionFailure(error: string): boolean {
@@ -2238,6 +2256,26 @@ export class Dispatcher {
           !slot.timedOut &&
           !slot.budgetExceeded;
 
+        // Narrow, side-effect-safe retry for transient failures (connection
+        // blips, 5xx, ACP internal errors). Gated on `slot.blocks.length === 0`
+        // (and `shouldObserveBlocks`, so the count is meaningful): if the
+        // runtime emitted no block this turn it ran no tools and sent nothing,
+        // so re-running the same prompt on the same session cannot duplicate a
+        // side effect. Resumes the same session — a transient blip doesn't
+        // warrant a fresh-session reset.
+        const shouldRetryTransient =
+          !shouldRetryFresh &&
+          shouldObserveBlocks &&
+          slot.blocks.length === 0 &&
+          !!firstError &&
+          !firstReply &&
+          !looksLikeRuntimeAuthFailure(firstError) &&
+          !looksLikeUsageLimit(firstError) &&
+          looksLikeTransientRuntimeError(firstError) &&
+          !controller.signal.aborted &&
+          !slot.timedOut &&
+          !slot.budgetExceeded;
+
         if (shouldRetryFresh) {
           try {
             await this.sessionStore.delete(key);
@@ -2282,6 +2320,23 @@ export class Dispatcher {
             }
           );
           result = await runRuntime(runtimeText, null);
+        } else if (shouldRetryTransient) {
+          this.log.info(
+            "dispatcher: retrying transient runtime failure once (no output emitted)",
+            {
+              agentId: msg.accountId,
+              roomId: msg.conversation.id,
+              topicId: msg.conversation.threadId ?? null,
+              turnId,
+              queueKey,
+              runtime: route.runtime,
+              error: firstError,
+            }
+          );
+          await sleepUnlessAborted(TRANSIENT_RETRY_BACKOFF_MS, controller.signal);
+          if (!controller.signal.aborted && !slot.timedOut && !slot.budgetExceeded) {
+            result = await runRuntime(runtimeText, activeSessionId);
+          }
         }
       } catch (err) {
         threw = err;

--- a/packages/daemon/src/gateway/runtime-errors.ts
+++ b/packages/daemon/src/gateway/runtime-errors.ts
@@ -15,6 +15,30 @@ export function looksLikeRuntimeAuthFailure(text: string): boolean {
 }
 
 /**
+ * Transient (worth-one-retry) runtime failures: connection blips, 5xx-class
+ * gateway errors, and JSON-RPC internal errors (ACP code -32603, e.g. hermes
+ * raising an internal error mid-prompt). Intentionally narrow — a non-zero exit
+ * code, bad config, or unknown CLI option is permanent and must NOT match, or
+ * the dispatcher would loop on it. The caller additionally gates retries on
+ * "no output was produced yet" so retrying cannot duplicate side effects.
+ */
+const TRANSIENT_RUNTIME_ERROR_PATTERNS: RegExp[] = [
+  /\b(?:ECONNREFUSED|ECONNRESET|ETIMEDOUT|EAI_AGAIN|EPIPE)\b/i,
+  /\bsocket hang ?up\b/i,
+  /\bconnection (?:refused|reset|closed|timed out)\b/i,
+  /\b-32603\b/,
+  /\binternal error\b/i,
+  /\b(?:bad gateway|service unavailable|gateway timeout|temporarily unavailable)\b/i,
+  /\b50[0234]\b/,
+];
+
+export function looksLikeTransientRuntimeError(text: string): boolean {
+  const s = text?.trim();
+  if (!s) return false;
+  return TRANSIENT_RUNTIME_ERROR_PATTERNS.some((re) => re.test(s));
+}
+
+/**
  * Usage / rate-limit exhaustion is reported by runtimes as ordinary error text,
  * not a distinct status. Claude Code emits "Claude usage limit reached. Your
  * limit will reset at 2pm (America/New_York)"; Codex emits "You've reached your

--- a/packages/daemon/src/gateway/runtimes/acp-stream.ts
+++ b/packages/daemon/src/gateway/runtimes/acp-stream.ts
@@ -37,6 +37,25 @@ const KILL_GRACE_MS = 5_000;
 const INITIALIZE_TIMEOUT_MS = 30_000;
 /** Short drain window for late `session/update` chunks after a prompt RPC error. */
 const PROMPT_ERROR_DRAIN_MS = 750;
+/**
+ * No-output watchdog: if the ACP child produces zero stdout/stderr traffic for
+ * this long while a turn is in flight, treat it as hung and kill it. ACP agents
+ * stream `session/update` frames (tool calls, thought chunks, message chunks)
+ * frequently, so a long silence is a genuine hang (e.g. hermes raising an
+ * internal error that never returns an RPC reply) rather than slow-but-alive
+ * work. Without this, a stuck turn sits dead until the dispatcher's 30-min
+ * outer turn timeout. The default is intentionally generous to never cut off a
+ * legitimately long tool call; override per deployment, 0 disables.
+ */
+const DEFAULT_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
+
+function acpIdleTimeoutMs(): number {
+  const raw = process.env.BOTCORD_ACP_IDLE_TIMEOUT_MS;
+  if (raw === undefined || raw === "") return DEFAULT_IDLE_TIMEOUT_MS;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? Math.floor(n) : DEFAULT_IDLE_TIMEOUT_MS;
+}
+
 /** ACP protocol version this client targets. */
 export const ACP_PROTOCOL_VERSION = 1;
 
@@ -404,7 +423,7 @@ export abstract class AcpRuntimeAdapter implements RuntimeAdapter {
     });
 
     let killTimer: ReturnType<typeof setTimeout> | null = null;
-    const onAbort = () => {
+    const forceKill = () => {
       if (child.killed) return;
       try {
         child.stdin.end();
@@ -424,14 +443,8 @@ export abstract class AcpRuntimeAdapter implements RuntimeAdapter {
       }, KILL_GRACE_MS);
       if (typeof killTimer.unref === "function") killTimer.unref();
     };
+    const onAbort = () => forceKill();
     opts.signal.addEventListener("abort", onAbort, { once: true });
-
-    let stderrTail = "";
-    child.stderr.setEncoding("utf8");
-    child.stderr.on("data", (chunk: string) => {
-      stderrTail = (stderrTail + chunk).slice(-STDERR_TAIL_CAP);
-      trace?.write({ stream: "stderr", pid: child.pid, chunk });
-    });
 
     const state: AcpRunState = {
       finalText: "",
@@ -439,6 +452,48 @@ export abstract class AcpRuntimeAdapter implements RuntimeAdapter {
       assistantTextBytes: 0,
       assistantTextCapped: false,
     };
+
+    // No-output watchdog. `armIdle` is (re)called on every stdout/stderr chunk,
+    // so the timer only fires after a full window of silence. A hung ACP child
+    // (e.g. an internal error that never produces an RPC reply or a final
+    // `session/update`) is then killed here, surfacing as an error instead of
+    // sitting dead until the dispatcher's 30-min outer turn timeout. We stamp
+    // `errorText` BEFORE killing so it wins over the "stdout closed" rejection
+    // the kill triggers on the in-flight prompt RPC.
+    const idleMs = acpIdleTimeoutMs();
+    let idleTimer: ReturnType<typeof setTimeout> | null = null;
+    const clearIdle = () => {
+      if (idleTimer) {
+        clearTimeout(idleTimer);
+        idleTimer = null;
+      }
+    };
+    const armIdle = () => {
+      if (idleMs <= 0 || child.killed) return;
+      clearIdle();
+      idleTimer = setTimeout(() => {
+        if (child.killed) return;
+        log.warn(`${this.id} no ACP output for ${idleMs}ms; killing hung turn`);
+        trace?.write({ stream: "idle_timeout", pid: child.pid, params: { idleMs } });
+        state.errorText =
+          state.errorText ??
+          `${this.id} idle timeout: no output for ${idleMs}ms`;
+        forceKill();
+      }, idleMs);
+      if (typeof idleTimer.unref === "function") idleTimer.unref();
+    };
+
+    let stderrTail = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      armIdle();
+      stderrTail = (stderrTail + chunk).slice(-STDERR_TAIL_CAP);
+      trace?.write({ stream: "stderr", pid: child.pid, chunk });
+    });
+    // Rearm on stdout too — AcpConnection installs its own `data` listener for
+    // framing; this second listener only resets the watchdog (listeners coexist).
+    child.stdout.on("data", () => armIdle());
+    armIdle();
 
     const appendAssistantText = (text: string): void => {
       if (!text || state.assistantTextCapped) return;
@@ -624,6 +679,7 @@ export abstract class AcpRuntimeAdapter implements RuntimeAdapter {
     } finally {
       opts.signal.removeEventListener("abort", onAbort);
       if (killTimer) clearTimeout(killTimer);
+      clearIdle();
     }
 
     if (code !== 0 && !state.errorText) {

--- a/packages/daemon/src/gateway/runtimes/kimi.ts
+++ b/packages/daemon/src/gateway/runtimes/kimi.ts
@@ -134,12 +134,13 @@ function sanitizeKimiExtraArgs(extraArgs: string[] | undefined): string[] {
   return out;
 }
 
-function parseKimiVersionMajor(version: string | null): number | null {
-  const match = version?.match(/\b(\d+)\.(\d+)\.(\d+)\b/);
-  if (!match) return null;
-  return Number.parseInt(match[1], 10);
-}
-
+// `--work-dir` is redundant with the child's spawn cwd — Kimi defaults its
+// working directory to the process cwd, which the base adapter already sets to
+// `opts.cwd`. We only pass the explicit flag when `kimi --help` *positively*
+// advertises it. If the probe can't confirm support (help times out on a cold
+// Python start, or exits non-zero), we conservatively omit the flag: relying on
+// cwd is always correct, whereas passing an unknown option crashes the turn
+// (`error: unknown option '--work-dir'` on Kimi builds that lack it).
 function probeKimiSupportsWorkDir(command: string): boolean {
   const cached = kimiWorkDirSupport.get(command);
   if (cached !== undefined) return cached;
@@ -153,8 +154,7 @@ function probeKimiSupportsWorkDir(command: string): boolean {
     });
     supported = /(?:^|\s)--work-dir(?:[=\s,]|$)/.test(help);
   } catch {
-    const major = parseKimiVersionMajor(readCommandVersion(command));
-    supported = major !== null && major >= 1;
+    supported = false;
   }
 
   kimiWorkDirSupport.set(command, supported);

--- a/packages/daemon/src/gateway/runtimes/openclaw-acp.ts
+++ b/packages/daemon/src/gateway/runtimes/openclaw-acp.ts
@@ -22,6 +22,23 @@ const ACP_PROTOCOL_VERSION = 1;
 const ACP_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
 /** Cap for streamed assistant text per turn. */
 const ASSISTANT_TEXT_CAP = 1 * 1024 * 1024;
+/**
+ * Per-turn no-output watchdog. If a `session/prompt` produces no streamed
+ * notifications and no reply for this long, the gateway is treated as hung: we
+ * send `session/cancel` and reject the turn. Unlike the handle keepalive above,
+ * this guards a single in-flight turn — we never kill the pooled child, since
+ * other turns may share it. Reset on every notification for the turn; generous
+ * by default so a long-but-alive tool call is never cut off. 0 disables.
+ * Shares the `BOTCORD_ACP_IDLE_TIMEOUT_MS` knob with the hermes ACP adapter.
+ */
+const DEFAULT_TURN_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
+
+function turnIdleTimeoutMs(): number {
+  const raw = process.env.BOTCORD_ACP_IDLE_TIMEOUT_MS;
+  if (raw === undefined || raw === "") return DEFAULT_TURN_IDLE_TIMEOUT_MS;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? Math.floor(n) : DEFAULT_TURN_IDLE_TIMEOUT_MS;
+}
 
 // ---------------------------------------------------------------------------
 // Module-level process pool — survives across adapter instances. The
@@ -234,7 +251,30 @@ export class OpenclawAcpAdapter implements RuntimeAdapter {
       }
     };
 
+    // Per-turn no-output watchdog. `armTurnIdle` is (re)called when the prompt
+    // starts and on every notification for this turn; if it fires, the gateway
+    // is hung — we cancel and reject so the turn fails fast instead of hanging
+    // forever (the abort path only sends a fire-and-forget cancel and never
+    // unblocks the awaited prompt). The pooled child is left alive for other
+    // turns; the keepalive reaper reclaims it once inFlight hits 0.
+    const idleMs = turnIdleTimeoutMs();
+    let idleTimer: NodeJS.Timeout | undefined;
+    let onTurnIdle: (() => void) | undefined;
+    const clearTurnIdle = (): void => {
+      if (idleTimer) {
+        clearTimeout(idleTimer);
+        idleTimer = undefined;
+      }
+    };
+    const armTurnIdle = (): void => {
+      if (idleMs <= 0) return;
+      clearTurnIdle();
+      idleTimer = setTimeout(() => onTurnIdle?.(), idleMs);
+      idleTimer.unref?.();
+    };
+
     const onNotification = (note: AcpNotification): void => {
+      armTurnIdle();
       const update = note.params?.update;
       if (update?.sessionUpdate === "agent_message_chunk") {
         const text = assistantTextFilter.push(extractText(update.content));
@@ -319,12 +359,48 @@ export class OpenclawAcpAdapter implements RuntimeAdapter {
       };
       opts.signal?.addEventListener("abort", abortListener);
 
+      // Race the prompt against the per-turn idle watchdog. A late reply to an
+      // abandoned prompt is harmless: `settled` guards double-resolution and
+      // `routeMessage` still clears the pending entry when it eventually lands.
+      const guardedPrompt = (): Promise<any> =>
+        new Promise((resolve, reject) => {
+          let settled = false;
+          onTurnIdle = () => {
+            if (settled) return;
+            settled = true;
+            log.warn("openclaw-acp.turn-idle-timeout", {
+              accountId: opts.accountId,
+              sessionKey,
+              idleMs,
+            });
+            handle.trace?.write({
+              stream: "idle_timeout",
+              ...traceContext,
+              params: { idleMs },
+            });
+            sendNotification(handle, "session/cancel", { sessionId: acpSessionId });
+            reject(new Error(`openclaw-acp idle timeout: no output for ${idleMs}ms`));
+          };
+          armTurnIdle();
+          this.prompt(handle, { sessionId: acpSessionId, text: opts.text }).then(
+            (r) => {
+              if (settled) return;
+              settled = true;
+              clearTurnIdle();
+              resolve(r);
+            },
+            (e) => {
+              if (settled) return;
+              settled = true;
+              clearTurnIdle();
+              reject(e);
+            },
+          );
+        });
+
       let promptResult: any;
       try {
-        promptResult = await this.prompt(handle, {
-          sessionId: acpSessionId,
-          text: opts.text,
-        });
+        promptResult = await guardedPrompt();
       } catch (err) {
         // If the child says the session is gone (process restart, GC),
         // recreate it so the next turn doesn't hard-fail.
@@ -360,10 +436,7 @@ export class OpenclawAcpAdapter implements RuntimeAdapter {
               newSessionId: acpSessionId,
               sessionKey,
             });
-            promptResult = await this.prompt(handle, {
-              sessionId: acpSessionId,
-              text: opts.text,
-            });
+            promptResult = await guardedPrompt();
           } catch (err2) {
             throw new Error(`prompt failed after session reset: ${(err2 as Error).message}`);
           }
@@ -440,6 +513,7 @@ export class OpenclawAcpAdapter implements RuntimeAdapter {
           // ignore
         }
       }
+      clearTurnIdle();
       handle.subscribers.delete(acpSessionId);
       handle.inFlight = Math.max(0, handle.inFlight - 1);
       resetIdle(handle, key);


### PR DESCRIPTION
## Summary

Hardens daemon runtime stability for **kimi-cli / Hermes / OpenClaw**, driven by a diagnostics bundle showing a kimi `--work-dir` crash, hung Hermes turns, and an unbounded OpenClaw prompt. Composes with the recovery hardening in #960 / `harden daemon runtime recovery`.

### Fixes

1. **kimi `--work-dir` crash** — the support probe ran `kimi --help`; on a cold Python start that times out / exits non-zero, the fallback guessed "any v1 supports `--work-dir`" and passed it, crashing builds that lack the flag (`error: unknown option '--work-dir'`). The child is already spawned with `cwd`, and kimi defaults `--work-dir` to cwd, so the flag is redundant — the fallback now conservatively **omits** it when support can't be positively confirmed.

2. **Hermes / OpenClaw hang watchdog** — ACP `session/prompt` had no timeout: a hung agent sat dead until the 30-min outer turn timeout (OpenClaw was worse — `abort` only sent a fire-and-forget `session/cancel` that never unblocked the awaited prompt). Added a per-turn **no-output watchdog** (`BOTCORD_ACP_IDLE_TIMEOUT_MS`, default 10m), reset on any stream activity:
   - Hermes (`acp-stream`): kills the hung child, surfaces an `idle timeout` error.
   - OpenClaw (`openclaw-acp`): rejects + cancels the turn but **leaves the pooled child alive** for other turns; the keepalive reaper reclaims it.

3. **Transient-failure one-retry** — dispatcher now retries a turn **once** on a transient error (conn blip, 5xx, ACP `-32603` internal error), gated on **zero output emitted that turn** (`slot.blocks.length === 0`) so a retry can never duplicate a tool call or sent message. Permanent errors (exit codes, bad config, auth) are excluded.

### Investigated, no change

The `qclaw` `ECONNREFUSED` in the diagnostics is a stale `~/.qclaw/` config — OpenClaw connects on-demand per turn (no eager/periodic connect), so it causes no runtime churn and is a useful "stale instance" signal in `doctor`.

## Test

- `@botcord/daemon`: **1094 passed**, typecheck clean.
- New regression tests: kimi `--help`-probe-failure fallback; Hermes idle watchdog; OpenClaw per-turn idle guard (asserts child not killed + `session/cancel` sent); dispatcher transient retry + the no-retry-after-output side-effect gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)