### PR TITLE
fix: close owner-chat runs at turn end so refresh stops resurrecting stale reasoning

### DIFF
--- a/.changeset/owner-chat-stream-end.md
+++ b/.changeset/owner-chat-stream-end.md
@@ -1,0 +1,5 @@
+---
+"@botcord/daemon": patch
+---
+
+Signal the Hub at the end of every streamed owner-chat turn (`POST /hub/stream-end`) so runs that produced no owner-chat reply (autonomous work, empty/gated final text, timeout) are marked completed instead of dangling as restorable "running" runs. Without this, the dashboard resurrected their full reasoning trace on every refresh until the run TTL expired.

--- a/backend/hub/owner_chat_cache.py
+++ b/backend/hub/owner_chat_cache.py
@@ -267,23 +267,33 @@ async def append_event(trace_id: str, seq: int, block: dict) -> dict | None:
         return None
 
 
-async def mark_run_completed(trace_id: str, *, final_msg_id: str) -> None:
-    """Mark a run completed and shorten both keys to the completed TTL."""
+async def mark_run_completed(trace_id: str, *, final_msg_id: str = "") -> None:
+    """Mark a run completed and shorten both keys to the completed TTL.
+
+    First-wins: only a run still in ``status="running"`` is transitioned. This
+    lets two independent terminal signals race safely — the reply path (which
+    carries the real ``final_msg_id``) and the daemon's ``/hub/stream-end``
+    signal (which carries none, used when the turn produced no owner-chat
+    reply). Whichever lands first completes the run; the later one is a no-op
+    and never clobbers a recorded ``final_msg_id``.
+    """
     client = get_redis()
     if client is None:
         return
     try:
         run_key = _run_key(trace_id)
-        if not await client.exists(run_key):
+        # Returns None when the key is gone (expired / never created) — both
+        # cases fall through to the no-op below.
+        status = await client.hget(run_key, "status")
+        if status != "running":
             return
-        await client.hset(
-            run_key,
-            mapping={
-                "status": "completed",
-                "completed_at": _now_iso(),
-                "final_msg_id": final_msg_id,
-            },
-        )
+        mapping: dict[str, Any] = {
+            "status": "completed",
+            "completed_at": _now_iso(),
+        }
+        if final_msg_id:
+            mapping["final_msg_id"] = final_msg_id
+        await client.hset(run_key, mapping=mapping)
         ttl = hub_config.OWNER_CHAT_RUN_COMPLETED_TTL_SECONDS
         await client.expire(run_key, ttl)
         await client.expire(_events_key(trace_id), ttl)

--- a/backend/hub/routers/owner_chat_ws.py
+++ b/backend/hub/routers/owner_chat_ws.py
@@ -790,6 +790,45 @@ async def receive_stream_block(
 
 
 # ---------------------------------------------------------------------------
+# Stream end HTTP endpoint (called by connected agents)
+# ---------------------------------------------------------------------------
+
+
+class StreamEndBody(BaseModel):
+    trace_id: str = Field(..., max_length=48)
+
+
+@router.post("/hub/stream-end", status_code=204)
+async def receive_stream_end(
+    body: StreamEndBody,
+    agent_id: str = Depends(get_current_agent),
+):
+    """Signal that an owner-chat run has ended (turn terminated).
+
+    The daemon fires this on every terminal turn path, so runs that produced no
+    owner-chat reply (autonomous work, empty/gated final text, timeout) still
+    get marked completed instead of dangling at ``status="running"`` for the
+    full run TTL — which is what made stale reasoning resurface on every
+    dashboard refresh. ``mark_run_completed`` is first-wins, so when the agent
+    *did* reply this is a harmless no-op (the reply path already completed it).
+    """
+    # Authorize: the run must belong to the calling agent. The in-memory
+    # subscription map only covers this Hub instance (the run may have been
+    # registered on another), so fall back to the Redis run metadata, mirroring
+    # the get_run_stream_blocks ownership check.
+    sub = _oc_trace_subs.get(body.trace_id)
+    if sub is not None:
+        if sub[1] != agent_id:
+            return
+    else:
+        run = await owner_chat_cache.load_run(body.trace_id)
+        if run is not None and run.get("agent_id") != agent_id:
+            return
+    await owner_chat_cache.mark_run_completed(body.trace_id)
+    _cleanup_trace(body.trace_id)
+
+
+# ---------------------------------------------------------------------------
 # Notify owner HTTP endpoint (called by connected agents)
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_owner_chat_cache.py
+++ b/backend/tests/test_owner_chat_cache.py
@@ -275,6 +275,41 @@ async def test_mark_completed_shortens_ttl(fake_redis):
 
 
 @pytest.mark.asyncio
+async def test_mark_completed_no_final_msg_id(fake_redis):
+    # stream-end path completes a reply-less run without a final_msg_id.
+    await owner_chat_cache.write_run_metadata(
+        "h_t4b", user_id="usr1", agent_id="ag_1", room_id="rm_oc_x", trigger_msg_id="h_t4b",
+    )
+    await owner_chat_cache.mark_run_completed("h_t4b")
+    h = fake_redis.hashes["owner_chat_run:h_t4b"]
+    assert h["status"] == "completed"
+    # final_msg_id stays at its initial empty value (not clobbered with junk).
+    assert h["final_msg_id"] == ""
+    assert fake_redis.ttls["owner_chat_run:h_t4b"] == owner_chat_cache.hub_config.OWNER_CHAT_RUN_COMPLETED_TTL_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_mark_completed_first_wins(fake_redis):
+    # The reply path completes with a real id; a later stream-end must not
+    # clobber it (or re-open the run).
+    await owner_chat_cache.write_run_metadata(
+        "h_t4c", user_id="usr1", agent_id="ag_1", room_id="rm_oc_x", trigger_msg_id="h_t4c",
+    )
+    await owner_chat_cache.mark_run_completed("h_t4c", final_msg_id="h_real")
+    await owner_chat_cache.mark_run_completed("h_t4c")  # late stream-end, no id
+    h = fake_redis.hashes["owner_chat_run:h_t4c"]
+    assert h["status"] == "completed"
+    assert h["final_msg_id"] == "h_real"
+
+
+@pytest.mark.asyncio
+async def test_mark_completed_missing_run_is_noop(fake_redis):
+    # No key yet (expired / never created) — must not create a phantom run.
+    await owner_chat_cache.mark_run_completed("h_gone")
+    assert "owner_chat_run:h_gone" not in fake_redis.hashes
+
+
+@pytest.mark.asyncio
 async def test_load_run_shapes_events(fake_redis):
     await owner_chat_cache.write_run_metadata(
         "h_t5", user_id="usr1", agent_id="ag_1", room_id="rm_oc_x", trigger_msg_id="h_t5",
@@ -437,3 +472,80 @@ async def test_stream_block_works_redis_disabled(
     finally:
         owner_chat_ws._oc_trace_subs.pop(trace_id, None)
         owner_chat_ws._oc_trace_block_count.pop(trace_id, None)
+
+
+# ---------------------------------------------------------------------------
+# /hub/stream-end — closes a reply-less run so it isn't restored on refresh
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_end_completes_run(
+    client: AsyncClient, db_session: AsyncSession, fake_redis,
+):
+    from hub.routers import owner_chat_ws
+    from hub.routers.dashboard_chat import _build_owner_chat_room_id
+
+    agent_id, token = await _register_and_verify(client, "EndAgent")
+    user_id = await _claim_agent(db_session, agent_id, "se")
+    room_id = _build_owner_chat_room_id(user_id, agent_id)
+
+    trace_id = "h_endtrace"
+    await owner_chat_cache.write_run_metadata(
+        trace_id, user_id=user_id, agent_id=agent_id, room_id=room_id, trigger_msg_id=trace_id,
+    )
+    owner_chat_ws._oc_trace_subs[trace_id] = (user_id, agent_id)
+    owner_chat_ws._oc_trace_block_count[trace_id] = 0
+    try:
+        resp = await client.post(
+            "/hub/stream-end",
+            json={"trace_id": trace_id},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 204
+        # Run is now completed and the local subscription cleaned up.
+        assert fake_redis.hashes[f"owner_chat_run:{trace_id}"]["status"] == "completed"
+        assert trace_id not in owner_chat_ws._oc_trace_subs
+    finally:
+        owner_chat_ws._oc_trace_subs.pop(trace_id, None)
+        owner_chat_ws._oc_trace_block_count.pop(trace_id, None)
+
+
+@pytest.mark.asyncio
+async def test_stream_end_wrong_owner_is_noop(
+    client: AsyncClient, db_session: AsyncSession, fake_redis,
+):
+    """A run owned by another agent must not be completed by this caller."""
+    agent_id, token = await _register_and_verify(client, "EndScopeAgent")
+    await _claim_agent(db_session, agent_id, "ses")
+
+    trace_id = "h_otherend"
+    await owner_chat_cache.write_run_metadata(
+        trace_id, user_id="usrZ", agent_id="ag_other", room_id="rm_oc_other", trigger_msg_id=trace_id,
+    )
+    resp = await client.post(
+        "/hub/stream-end",
+        json={"trace_id": trace_id},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 204
+    # Not this agent's run — left untouched (still running).
+    assert fake_redis.hashes[f"owner_chat_run:{trace_id}"]["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_stream_end_redis_disabled_noop(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch,
+):
+    monkeypatch.setattr(owner_chat_cache.hub_config, "BOTCORD_REDIS_URL", None)
+    monkeypatch.setattr(owner_chat_cache, "_redis_client", None)
+
+    agent_id, token = await _register_and_verify(client, "EndDisabledAgent")
+    await _claim_agent(db_session, agent_id, "sed")
+
+    resp = await client.post(
+        "/hub/stream-end",
+        json={"trace_id": "h_whatever"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 204

--- a/frontend/src/store/useOwnerChatStore.ts
+++ b/frontend/src/store/useOwnerChatStore.ts
@@ -26,9 +26,26 @@ import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 
 const MAX_BLOCKS_PER_TRACE = 200;
 
+// Backstop window for resurrecting in-flight runs on load/refresh. A run that
+// never produced an owner-chat reply stays uncovered indefinitely; restoring
+// such a trace replays its full reasoning trace as a standalone streaming
+// placeholder. The backend closes these runs at turn end, so this is a safety
+// net for the residual window where that signal was lost — comfortably longer
+// than a typical turn, well under the backend run TTL (1h).
+const RESTORE_MAX_AGE_MS = 15 * 60 * 1000;
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/** True when a message is too old to be worth restoring an in-flight run for.
+ *  Unparseable/missing timestamps are treated as old (skip restore). */
+function isRestoreTooOld(createdAt: string | undefined, now: number): boolean {
+  if (!createdAt) return true;
+  const t = Date.parse(createdAt);
+  if (Number.isNaN(t)) return true;
+  return now - t > RESTORE_MAX_AGE_MS;
+}
 
 /** Extract streamed assistant text from stream blocks.
  *  Supports three shapes:
@@ -654,13 +671,17 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
 
     // Candidate in-flight traces: confirmed/delivered user messages whose
     // hub_msg_id (== trace_id) has no agent reply or streaming placeholder yet.
+    // Stale messages are skipped (see RESTORE_MAX_AGE_MS) so uncovered runs that
+    // never produced a reply don't get resurrected on every refresh.
+    const now = Date.now();
     const candidates = messages
       .filter(
         (m) =>
           m.sender === "user" &&
           m.hubMsgId &&
           (m.status === "confirmed" || m.status === "delivered") &&
-          !coveredTraceIds.has(m.hubMsgId),
+          !coveredTraceIds.has(m.hubMsgId) &&
+          !isRestoreTooOld(m.createdAt, now),
       )
       .map((m) => m.hubMsgId!);
 

--- a/packages/daemon/src/gateway/channels/botcord.ts
+++ b/packages/daemon/src/gateway/channels/botcord.ts
@@ -18,6 +18,7 @@ import type {
   ChannelStatusSnapshot,
   ChannelStopContext,
   ChannelStreamBlockContext,
+  ChannelStreamEndContext,
   ChannelTypingContext,
   GatewayInboundEnvelope,
   GatewayInboundMessage,
@@ -1274,6 +1275,25 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
         }
       } catch (err) {
         ctx.log.warn("botcord stream-block failed", { err: String(err) });
+      }
+    },
+
+    async streamEnd(ctx: ChannelStreamEndContext): Promise<void> {
+      const client = ensureClient();
+      const hubUrl = options.hubBaseUrl ?? client.getHubUrl();
+      try {
+        const resp = await postControlWithRefresh(client, hubUrl, "/hub/stream-end", {
+          trace_id: ctx.traceId,
+        });
+        if (!resp.ok && resp.status !== 204) {
+          const body = await resp.text().catch(() => "");
+          ctx.log.warn("botcord stream-end non-ok", {
+            status: resp.status,
+            body: body.slice(0, 200),
+          });
+        }
+      } catch (err) {
+        ctx.log.warn("botcord stream-end failed", { err: String(err) });
       }
     },
 

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -2768,6 +2768,20 @@ export class Dispatcher {
       // superseder is about to run its own typing/thinking lifecycle.
       finalizeThinkingIfActive();
       await sendReplyingStatus("cleared");
+      // Close out the streamed run so a reply-less turn (empty/gated final
+      // text, timeout, error, or cancel-previous) doesn't dangle as a
+      // restorable "running" run — which would otherwise replay its full
+      // reasoning trace on every dashboard refresh until the run TTL expires.
+      // Idempotent on the hub side: when a reply was sent, that path already
+      // completed the run and this is a no-op. Fire-and-forget.
+      if (canStream && typeof traceId === "string" && channel.streamEnd) {
+        await channel.streamEnd({
+          traceId,
+          accountId: msg.accountId,
+          conversationId: msg.conversation.id,
+          log: this.log,
+        });
+      }
       // Clear slot ownership AFTER the reply has been sent (or skipped).
       // Only then do cancel-previous arrivals stop finding this slot — which
       // is exactly what we want: while we're in the post-runtime window, a

--- a/packages/daemon/src/gateway/types.ts
+++ b/packages/daemon/src/gateway/types.ts
@@ -275,6 +275,19 @@ export interface ChannelStreamBlockContext {
 }
 
 /**
+ * Context passed to `ChannelAdapter.streamEnd()` when a streamed turn reaches
+ * any terminal state. Lets the upstream close out the run's in-flight cache so
+ * a turn that streamed activity but produced no reply doesn't linger as a
+ * restorable run.
+ */
+export interface ChannelStreamEndContext {
+  traceId: string;
+  accountId: string;
+  conversationId: string;
+  log: GatewayLogger;
+}
+
+/**
  * Context passed to `ChannelAdapter.typing()` when the dispatcher signals
  * "agent has accepted this turn but no execution block has surfaced yet".
  * Adapters that bridge to a presence-style API (BotCord `/hub/typing`, etc.)
@@ -309,6 +322,12 @@ export interface ChannelAdapter {
   send(ctx: ChannelSendContext): Promise<ChannelSendResult>;
   status?(): ChannelStatusSnapshot;
   streamBlock?(ctx: ChannelStreamBlockContext): Promise<void>;
+  /**
+   * Optional terminal signal for a streamed turn. Fire-and-forget; failures
+   * must not break the turn. BotCord uses this to mark the owner-chat run
+   * completed so it isn't restored on refresh after a reply-less turn.
+   */
+  streamEnd?(ctx: ChannelStreamEndContext): Promise<void>;
   /**
    * Optional ephemeral "agent is responding" hint. Fire-and-forget; failures
    * must not break the turn. Channels without a presence concept should leave


### PR DESCRIPTION
## 问题

刷新 dashboard 后,owner-chat 面板冒出大量历史 reasoning 状态组("N reasoning" → Starting session / Thinking / 一堆 other)。

根因:owner-chat 的 run 只有在 **agent 发出最终回复** 时才会 `mark_run_completed`。自主任务的 turn(被 owner 触发,流式推送了 reasoning/tool 活动但没有以一条 owner-chat 文字回复收尾)会一直停在 `status="running"`,直到 Redis run TTL(默认 1h)过期。在这 1 小时窗口内,前端 `restoreActiveRuns` 每次刷新都会把这些「未被覆盖」的 trace 全量重放为独立的 streaming 占位块。

## 修复(1 + 2 组合)

**从源头收尾(后端 + daemon)**
- `owner_chat_cache.mark_run_completed` 改为 **first-wins**:只 `running→completed`,`final_msg_id` 可选;后到的终端信号既不覆盖真实 id 也不重开已完成的 run。
- 新增 `POST /hub/stream-end`(agent 鉴权:本机 `_oc_trace_subs` + 跨实例回退到 Redis run 元数据校验归属)。daemon 在 **每个** owner-chat 流式 turn 的终端 `finally` 里调用它(delivered / empty_text / timeout / 被抢占都覆盖),让无回复的 run 立即收尾。有回复时为幂等 no-op。

**前端兜底**
- `restoreActiveRuns` 跳过 `createdAt` 超过 15 分钟的候选 user 消息(`RESTORE_MAX_AGE_MS`),即使 stream-end 信号偶发丢失,陈旧孤儿 run 也不会被复活。

## 验证
- 后端:`test_owner_chat_cache.py` + `test_dashboard_chat.py` 30 passed(新增 first-wins / no-final-id / missing-run no-op / stream-end 完成 / 错误归属 no-op / Redis 关闭 no-op)。
- daemon:`tsc` 构建干净;dispatcher + botcord channel 155 passed。
- 前端:`useOwnerChatStore.ts` typecheck 干净。

含 `@botcord/daemon` changeset(patch)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)