### PR TITLE
Fix Telegram gateway observable error sanitization

### DIFF
--- a/packages/gateway-ingress/src/__tests__/health.test.ts
+++ b/packages/gateway-ingress/src/__tests__/health.test.ts
@@ -1,0 +1,93 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { startHealthServer } from "../health.js";
+import { noopLogger } from "../log.js";
+import type { IngressOrchestrator } from "../orchestrator.js";
+import type { ProviderRunner } from "../provider-runner.js";
+import { FileSystemIngressStore } from "../storage/store.js";
+import type { GatewayConnection } from "../types.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("health server", () => {
+  it("includes tracked provider state in /status without internal state", async () => {
+    const root = mkdtempSync(join(tmpdir(), "gateway-ingress-health-"));
+    tempDirs.push(root);
+    const store = new FileSystemIngressStore(root);
+    const conn: GatewayConnection = {
+      id: "gw_tg_status",
+      agentId: "ag_status",
+      provider: "telegram",
+      status: "active",
+      enabled: true,
+      config: {},
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    store.upsertConnection(conn);
+    store.updateState(conn.id, {
+      cursor: { offset: 123 },
+      dedupe: ["tg:gw_tg_status:122"],
+      lastPollAt: 111,
+      lastInboundAt: 222,
+      lastError: "TypeError: fetch failed for https://api.telegram.org/botsecret-token/getUpdates",
+    });
+
+    const runner = {
+      isRunning(gatewayId: string) {
+        return gatewayId === conn.id;
+      },
+    } as ProviderRunner;
+    const server = await startHealthServer({
+      host: "127.0.0.1",
+      port: 0,
+      log: noopLogger,
+      orchestrator: {} as IngressOrchestrator,
+      runner,
+      store,
+    });
+
+    try {
+      const res = await fetch(`${server.url}/status`);
+      expect(res.status).toBe(200);
+      const body = await res.json() as {
+        ok: boolean;
+        connections: Array<Record<string, unknown>>;
+        pending: number;
+      };
+      expect(body).toEqual({
+        ok: true,
+        connections: [
+          {
+            id: "gw_tg_status",
+            agentId: "ag_status",
+            provider: "telegram",
+            status: "active",
+            enabled: true,
+            running: true,
+            lastPollAt: 111,
+            lastInboundAt: 222,
+            lastError: "Error: fetch_failed",
+          },
+        ],
+        pending: 0,
+      });
+      expect(JSON.stringify(body)).not.toContain("api.telegram.org");
+      expect(JSON.stringify(body)).not.toContain("secret-token");
+      expect(JSON.stringify(body)).not.toContain("https://");
+      expect(body.connections[0]).not.toHaveProperty("cursor");
+      expect(body.connections[0]).not.toHaveProperty("dedupe");
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/packages/gateway-ingress/src/__tests__/telegram.test.ts
+++ b/packages/gateway-ingress/src/__tests__/telegram.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
+import type { IngressLogger } from "../log.js";
 import { noopLogger } from "../log.js";
 import { createTelegramProvider } from "../providers/telegram.js";
 import type { ProviderRuntimeContext } from "../providers/types.js";
@@ -50,6 +51,10 @@ function makeCtx(secret: Record<string, unknown>, abort: AbortController): {
   };
   return { ctx, emits, cursors, activity };
 }
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("Telegram provider adapter", () => {
   it("polls getUpdates, normalizes a message, advances cursor only after emit", async () => {
@@ -154,6 +159,66 @@ describe("Telegram provider adapter", () => {
     expect(sendCalls[0]!.body).toMatchObject({ chat_id: "42", text: "ack" });
   });
 
+  it("throws only safe observable error details when sendMessage fetch rejects", async () => {
+    const secretToken = "secret-token";
+    const failure = new TypeError(
+      `fetch failed for https://api.telegram.org/bot${secretToken}/sendMessage`,
+    );
+    (failure as { cause?: unknown }).cause = {
+      code: "ENOTFOUND",
+      errno: -3008,
+      hostname: "api.telegram.org",
+      url: `https://api.telegram.org/bot${secretToken}/sendMessage`,
+    };
+    const fetchImpl = (async (url: string, init?: RequestInit) => {
+      if (url.endsWith("/getUpdates")) {
+        return new Promise<Response>((_res, rej) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => rej(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        });
+      }
+      throw failure;
+    }) as unknown as typeof fetch;
+
+    const provider = createTelegramProvider({
+      gatewayId: conn.id,
+      fetchImpl,
+      pollTimeoutSeconds: 0,
+    });
+    const abort = new AbortController();
+    const { ctx, activity } = makeCtx({ botToken: secretToken }, abort);
+    const running = provider.start(ctx);
+    // Let start() install the token + config.
+    await new Promise((r) => setTimeout(r, 20));
+
+    let thrown: unknown;
+    try {
+      await provider.send({
+        gatewayId: conn.id,
+        conversationId: "telegram:user:42",
+        text: "ack",
+        final: true,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    abort.abort();
+    await running;
+
+    expect(String(thrown)).toBe("TypeError: fetch_failed");
+    const observable = JSON.stringify({
+      persistedDeliveryLastError: String(thrown),
+      persistedEventLastError: `provider_send_failed: ${String(thrown)}`,
+      activity,
+    });
+    expect(observable).not.toContain("api.telegram.org");
+    expect(observable).not.toContain(secretToken);
+    expect(observable).not.toContain("https://");
+  });
+
   it("rejects messages from disallowed sender or chat", async () => {
     const responses = [
       {
@@ -201,5 +266,73 @@ describe("Telegram provider adapter", () => {
     await running;
     expect(emits).toHaveLength(0);
     expect(cursors[0]).toEqual({ offset: 2 });
+  });
+
+  it("records and logs safe metadata when getUpdates fetch rejects", async () => {
+    vi.useFakeTimers();
+
+    const errors: { message: string; meta?: Record<string, unknown> }[] = [];
+    const logger: IngressLogger = {
+      ...noopLogger,
+      error(message, meta) {
+        errors.push({ message, meta });
+      },
+    };
+    const abort = new AbortController();
+    const calls: string[] = [];
+    const failure = new TypeError(
+      "fetch failed for https://api.telegram.org/botsecret-token/getUpdates",
+    );
+    (failure as { cause?: unknown }).cause = {
+      code: "ENOTFOUND",
+      errno: -3008,
+      hostname: "api.telegram.org",
+      url: "https://api.telegram.org/botsecret-token/getUpdates",
+    };
+    const fetchImpl = (async (url: string, init?: RequestInit) => {
+      calls.push(url);
+      if (calls.length === 1) throw failure;
+      return new Promise<Response>((_res, rej) => {
+        init?.signal?.addEventListener(
+          "abort",
+          () => rej(new DOMException("Aborted", "AbortError")),
+          { once: true },
+        );
+      });
+    }) as unknown as typeof fetch;
+
+    const provider = createTelegramProvider({
+      gatewayId: conn.id,
+      fetchImpl,
+      pollTimeoutSeconds: 25,
+    });
+    const { ctx, activity } = makeCtx({ botToken: "secret-token" }, abort);
+    ctx.log = logger;
+
+    const running = provider.start(ctx);
+    await vi.waitFor(() => {
+      expect(activity.some((patch) => patch.lastError === "TypeError: fetch_failed")).toBe(true);
+    });
+    expect(errors).toEqual([
+      {
+        message: "telegram poll failed",
+        meta: {
+          name: "TypeError",
+          message: "fetch_failed",
+          cause: { code: "ENOTFOUND", errno: -3008 },
+        },
+      },
+    ]);
+    const observable = JSON.stringify({ errors, activity });
+    expect(observable).not.toContain("api.telegram.org");
+    expect(observable).not.toContain("secret-token");
+    expect(observable).not.toContain("https://");
+
+    await vi.advanceTimersByTimeAsync(3_000);
+    await vi.waitFor(() => {
+      expect(calls).toHaveLength(2);
+    });
+    abort.abort();
+    await running;
   });
 });

--- a/packages/gateway-ingress/src/health.ts
+++ b/packages/gateway-ingress/src/health.ts
@@ -1,6 +1,7 @@
 import { createServer, type Server } from "node:http";
 
 import type { IngressLogger } from "./log.js";
+import { safeObservableStatusError } from "./observable-error.js";
 import type { IngressOrchestrator } from "./orchestrator.js";
 import type { ProviderRunner } from "./provider-runner.js";
 import type { IngressStore } from "./storage/store.js";
@@ -33,14 +34,22 @@ export async function startHealthServer(opts: HealthServerOptions): Promise<Heal
       return;
     }
     if (req.url === "/status") {
-      const conns = opts.store.listConnections().map((c) => ({
-        id: c.id,
-        agentId: c.agentId,
-        provider: c.provider,
-        status: c.status,
-        enabled: c.enabled,
-        running: opts.runner.isRunning(c.id),
-      }));
+      const conns = opts.store.listConnections().map((c) => {
+        const state = opts.store.getState(c.id);
+        return {
+          id: c.id,
+          agentId: c.agentId,
+          provider: c.provider,
+          status: c.status,
+          enabled: c.enabled,
+          running: opts.runner.isRunning(c.id),
+          ...(Number.isFinite(state?.lastPollAt) ? { lastPollAt: state!.lastPollAt } : {}),
+          ...(Number.isFinite(state?.lastInboundAt) ? { lastInboundAt: state!.lastInboundAt } : {}),
+          ...(typeof state?.lastError === "string" || state?.lastError === null
+            ? { lastError: safeObservableStatusError(state.lastError) }
+            : {}),
+        };
+      });
       const queued = opts.store.listEventsByStatus("queued", "delivering").length;
       res.writeHead(200, { "content-type": "application/json" });
       res.end(JSON.stringify({ ok: true, connections: conns, pending: queued }));

--- a/packages/gateway-ingress/src/observable-error.ts
+++ b/packages/gateway-ingress/src/observable-error.ts
@@ -1,0 +1,77 @@
+const SAFE_ERROR_NAME_RE = /^[A-Za-z][A-Za-z0-9_.-]{0,63}$/;
+const SAFE_ERRNO_CODE_RE = /^[A-Z0-9_]{1,64}$/;
+const SAFE_SUMMARY_RE = /^[A-Za-z][A-Za-z0-9_.-]{0,63}: [a-z][a-z0-9_]{0,63}$/;
+const MAX_SUMMARY_LENGTH = 96;
+
+export interface SafeObservableErrorMeta extends Record<string, unknown> {
+  name: string;
+  message: string;
+  cause?: {
+    code?: string;
+    errno?: string | number;
+  };
+}
+
+export function safeObservableErrorMeta(err: unknown): SafeObservableErrorMeta {
+  const error = err as { name?: unknown; message?: unknown; cause?: unknown };
+  const rawMessage = typeof error?.message === "string" ? error.message : String(err);
+  const meta: SafeObservableErrorMeta = {
+    name: safeErrorName(error?.name),
+    message: errorMessageCategory(rawMessage),
+  };
+
+  const cause = error?.cause as { code?: unknown; errno?: unknown } | undefined;
+  const code = safeCauseCode(cause?.code);
+  const errno = safeCauseErrno(cause?.errno);
+  if (code !== undefined || errno !== undefined) {
+    meta.cause = {
+      ...(code !== undefined ? { code } : {}),
+      ...(errno !== undefined ? { errno } : {}),
+    };
+  }
+  return meta;
+}
+
+export function safeObservableErrorSummary(err: unknown): string {
+  const meta = safeObservableErrorMeta(err);
+  return `${meta.name}: ${meta.message}`.slice(0, MAX_SUMMARY_LENGTH);
+}
+
+export function safeObservableStatusError(value: string | null | undefined): string | null | undefined {
+  if (value === null || value === undefined) return value;
+  if (SAFE_SUMMARY_RE.test(value)) return value;
+  return safeObservableErrorSummary(new Error(value));
+}
+
+function safeErrorName(value: unknown): string {
+  if (typeof value !== "string") return "Error";
+  return SAFE_ERROR_NAME_RE.test(value) ? value : "Error";
+}
+
+function safeCauseCode(value: unknown): string | undefined {
+  return typeof value === "string" && SAFE_ERRNO_CODE_RE.test(value) ? value : undefined;
+}
+
+function safeCauseErrno(value: unknown): string | number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  return safeCauseCode(value);
+}
+
+function errorMessageCategory(message: string): string {
+  const lower = message.toLowerCase();
+  if (lower.includes("fetch failed")) return "fetch_failed";
+  if (lower.includes("getupdates failed")) return "getupdates_failed";
+  if (lower.includes("sendmessage failed")) return "sendmessage_failed";
+  if (lower.includes("missing_secret") || lower.includes("bot token not loaded")) {
+    return "missing_secret";
+  }
+  if (lower.includes("unauthorized") || lower.includes("401")) return "unauthorized";
+  if (lower.includes("forbidden") || lower.includes("403")) return "forbidden";
+  if (lower.includes("too many requests") || lower.includes("rate limit") || lower.includes("429")) {
+    return "rate_limited";
+  }
+  if (lower.includes("timeout") || lower.includes("timed out")) return "timeout";
+  if (lower.includes("abort")) return "aborted";
+  if (lower.includes("network")) return "network_error";
+  return "error";
+}

--- a/packages/gateway-ingress/src/providers/telegram.ts
+++ b/packages/gateway-ingress/src/providers/telegram.ts
@@ -1,4 +1,5 @@
 import type { GatewayInboundMessage } from "@botcord/protocol-core";
+import { safeObservableErrorMeta, safeObservableErrorSummary } from "../observable-error.js";
 import type { OutboundSendRequest, OutboundSendResult } from "../types.js";
 import type {
   OutboundTypingRequest,
@@ -82,11 +83,6 @@ export function createTelegramProvider(opts: TelegramProviderOptions): ProviderA
   let allowedSenderIds = new Set<string>();
   let allowedChatIds = new Set<string>();
 
-  function redactToken(input: string): string {
-    if (!botToken || !input) return input;
-    return input.split(botToken).join("***");
-  }
-
   async function callApi<T>(
     method: string,
     params: Record<string, unknown>,
@@ -106,8 +102,9 @@ export function createTelegramProvider(opts: TelegramProviderOptions): ProviderA
       });
     } catch (err) {
       const e = err as Error;
-      const next = new Error(redactToken(e.message ?? String(err)));
+      const next = new Error(e.message ?? String(err));
       next.name = e.name ?? "Error";
+      (next as { cause?: unknown }).cause = (e as { cause?: unknown }).cause;
       throw next;
     } finally {
       lease.cleanup();
@@ -222,9 +219,15 @@ export function createTelegramProvider(opts: TelegramProviderOptions): ProviderA
         ctx.markActivity({ lastPollAt: Date.now() });
         if (!resp.ok) {
           ctx.log.warn("telegram getUpdates non-ok", {
-            description: redactToken(resp.description ?? ""),
+            description: safeObservableErrorSummary(
+              new Error(resp.description ?? "getUpdates failed"),
+            ),
           });
-          ctx.markActivity({ lastError: redactToken(resp.description ?? "getUpdates failed") });
+          ctx.markActivity({
+            lastError: safeObservableErrorSummary(
+              new Error(resp.description ?? "getUpdates failed"),
+            ),
+          });
           await sleep(POLL_BACKOFF_MS, abortAggregate.signal);
           continue;
         }
@@ -247,7 +250,7 @@ export function createTelegramProvider(opts: TelegramProviderOptions): ProviderA
           } catch (err) {
             failed = true;
             ctx.log.error("telegram emit threw — keeping cursor", {
-              err: redactToken(String(err)),
+              err: safeObservableErrorSummary(err),
             });
             break;
           }
@@ -263,8 +266,8 @@ export function createTelegramProvider(opts: TelegramProviderOptions): ProviderA
           await sleep(TRANSIENT_BACKOFF_MS, abortAggregate.signal);
           continue;
         }
-        ctx.log.error("telegram poll failed", { err: redactToken(String(err)) });
-        ctx.markActivity({ lastError: redactToken(String(err)) });
+        ctx.log.error("telegram poll failed", safeObservableErrorMeta(err));
+        ctx.markActivity({ lastError: safeObservableErrorSummary(err) });
         await sleep(POLL_BACKOFF_MS, abortAggregate.signal);
       }
     }
@@ -281,14 +284,21 @@ export function createTelegramProvider(opts: TelegramProviderOptions): ProviderA
     const chunks = splitText(request.text, splitAt);
     let lastMessageId: string | null = null;
     for (const chunk of chunks) {
-      const resp = await callApi<TelegramMessage>(
-        "sendMessage",
-        { chat_id: chatId, text: chunk, disable_web_page_preview: true },
-        15_000,
-      );
+      let resp: TelegramApiResult<TelegramMessage>;
+      try {
+        resp = await callApi<TelegramMessage>(
+          "sendMessage",
+          { chat_id: chatId, text: chunk, disable_web_page_preview: true },
+          15_000,
+        );
+      } catch (err) {
+        throw safeObservableError(err);
+      }
       if (!resp.ok) {
         throw new Error(
-          `telegram sendMessage failed: ${redactToken(resp.description ?? "unknown")}`,
+          safeObservableErrorSummary(
+            new Error(`telegram sendMessage failed: ${resp.description ?? "unknown"}`),
+          ),
         );
       }
       if (resp.result?.message_id !== undefined) {
@@ -309,7 +319,7 @@ export function createTelegramProvider(opts: TelegramProviderOptions): ProviderA
     try {
       await callApi("sendChatAction", { chat_id: chatId, action: "typing" }, 10_000);
     } catch (err) {
-      activeCtx?.log.debug("telegram typing failed", { err: redactToken(String(err)) });
+      activeCtx?.log.debug("telegram typing failed", { err: safeObservableErrorSummary(err) });
     }
   }
 
@@ -325,6 +335,13 @@ export function createTelegramProvider(opts: TelegramProviderOptions): ProviderA
     send,
     typing,
   };
+}
+
+function safeObservableError(err: unknown): Error {
+  const meta = safeObservableErrorMeta(err);
+  const safe = new Error(meta.message);
+  safe.name = meta.name;
+  return safe;
 }
 
 /** Factory used by `ProviderRunner.registerFactory("telegram", …)`. */


### PR DESCRIPTION
## Summary
- add shared safe observable error formatting for gateway-ingress Telegram errors
- expose only sanitized lastPollAt/lastInboundAt/lastError on /status
- sanitize sendMessage/callApi transport failures before orchestrator persistence

## Verification
- git diff --check
- cd packages/gateway-ingress && npm test -- --run src/__tests__/telegram.test.ts src/__tests__/health.test.ts
- cd packages/gateway-ingress && npm run build
- Code Reviewer + review sub-agent Epicurus: no blocking findings

## Runtime boundary
No deploy/restart/runtime/secrets touched; no prod, Gateway RWO, Kimi, or daemon hardening touched.