### PR TITLE
fix: sanitize WeChat gateway observable errors

### DIFF
--- a/packages/gateway-ingress/src/__tests__/wechat.test.ts
+++ b/packages/gateway-ingress/src/__tests__/wechat.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { GatewayInboundMessage } from "@botcord/protocol-core";
+import type { IngressLogger } from "../log.js";
 import { noopLogger } from "../log.js";
 import { createWechatProvider } from "../providers/wechat.js";
 import type { ProviderRuntimeContext } from "../providers/types.js";
@@ -19,7 +20,11 @@ const conn: GatewayConnection = {
   updatedAt: 1,
 };
 
-function makeCtx(secret: Record<string, unknown>, abort: AbortController) {
+function makeCtx(
+  secret: Record<string, unknown>,
+  abort: AbortController,
+  log: IngressLogger = noopLogger,
+) {
   const emits: { msg: GatewayInboundMessage; providerEventId: string }[] = [];
   const cursors: Record<string, unknown>[] = [];
   const activity: {
@@ -30,7 +35,7 @@ function makeCtx(secret: Record<string, unknown>, abort: AbortController) {
   const ctx: ProviderRuntimeContext = {
     connection: conn,
     secret,
-    log: noopLogger,
+    log,
     abortSignal: abort.signal,
     async emit(msg, id) {
       emits.push({ msg, providerEventId: id });
@@ -50,6 +55,72 @@ function makeCtx(secret: Record<string, unknown>, abort: AbortController) {
 }
 
 describe("WeChat provider adapter", () => {
+  it("records only safe observable details when getupdates fetch rejects", async () => {
+    const secretToken = "wechat-secret-token";
+    const failure = new TypeError(
+      `fetch failed for https://ilinkai.weixin.qq.com/ilink/bot/getupdates?token=${secretToken}`,
+    );
+    (failure as { cause?: unknown }).cause = {
+      code: "ENOTFOUND",
+      errno: -3008,
+      hostname: "ilinkai.weixin.qq.com",
+      url: `https://ilinkai.weixin.qq.com/ilink/bot/getupdates?token=${secretToken}`,
+    };
+    let pollCount = 0;
+    const fetchImpl = (async (url: string, init?: RequestInit) => {
+      if (url.endsWith("/ilink/bot/getupdates")) {
+        pollCount += 1;
+        if (pollCount === 1) throw failure;
+        return new Promise<Response>((_res, rej) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => rej(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        });
+      }
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+    const logs: { message: string; meta?: Record<string, unknown> }[] = [];
+    const log: IngressLogger = {
+      ...noopLogger,
+      error(message, meta) {
+        logs.push({ message, meta });
+      },
+    };
+
+    const provider = createWechatProvider({
+      gatewayId: conn.id,
+      fetchImpl,
+    });
+    const abort = new AbortController();
+    const { ctx, activity } = makeCtx({ botToken: secretToken }, abort, log);
+    const running = provider.start(ctx);
+    const deadline = Date.now() + 1_000;
+    while (
+      Date.now() < deadline &&
+      !activity.some((patch) => patch.lastError === "TypeError: fetch_failed")
+    ) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    abort.abort();
+    await running;
+
+    expect(activity.some((patch) => patch.lastError === "TypeError: fetch_failed")).toBe(true);
+    expect(logs).toContainEqual({
+      message: "wechat poll failed",
+      meta: {
+        name: "TypeError",
+        message: "fetch_failed",
+        cause: { code: "ENOTFOUND", errno: -3008 },
+      },
+    });
+    const observable = JSON.stringify({ logs, activity });
+    expect(observable).not.toContain("ilinkai.weixin.qq.com");
+    expect(observable).not.toContain(secretToken);
+    expect(observable).not.toContain("https://");
+  });
+
   it("polls getupdates, normalizes text, advances cursor only after emit", async () => {
     let pollCount = 0;
     const fetchImpl = (async (url: string, init?: RequestInit) => {
@@ -236,6 +307,88 @@ describe("WeChat provider adapter", () => {
     ]);
   });
 
+  it("throws only safe observable error details when sendmessage fetch rejects", async () => {
+    const secretToken = "wechat-secret-token";
+    const failure = new TypeError(
+      `fetch failed for https://ilinkai.weixin.qq.com/ilink/bot/sendmessage?access_token=${secretToken}`,
+    );
+    (failure as { cause?: unknown }).cause = {
+      code: "ECONNRESET",
+      errno: "ECONNRESET",
+      hostname: "ilinkai.weixin.qq.com",
+      url: `https://ilinkai.weixin.qq.com/ilink/bot/sendmessage?access_token=${secretToken}`,
+    };
+    let pollCount = 0;
+    const fetchImpl = (async (url: string, init?: RequestInit) => {
+      if (url.endsWith("/ilink/bot/getupdates")) {
+        pollCount += 1;
+        if (pollCount === 1) {
+          return new Response(
+            JSON.stringify({
+              ret: 0,
+              get_updates_buf: "buf-3",
+              msgs: [
+                {
+                  message_type: 1,
+                  from_user_id: "alice",
+                  context_token: "ctx-tok-3",
+                  client_id: "wc_client_3",
+                  item_list: [{ type: 1, text_item: { text: "ping" } }],
+                },
+              ],
+            }),
+            { status: 200 },
+          );
+        }
+        return new Promise<Response>((_res, rej) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => rej(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        });
+      }
+      if (url.endsWith("/ilink/bot/sendmessage")) throw failure;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const provider = createWechatProvider({
+      gatewayId: conn.id,
+      fetchImpl,
+    });
+    const abort = new AbortController();
+    const { ctx, emits, activity } = makeCtx({ botToken: secretToken }, abort);
+    const running = provider.start(ctx);
+    const deadline = Date.now() + 1_000;
+    while (Date.now() < deadline && emits.length === 0) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+
+    let thrown: unknown;
+    try {
+      await provider.send({
+        gatewayId: conn.id,
+        conversationId: "wechat:user:alice",
+        text: "pong",
+        final: true,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    abort.abort();
+    await running;
+
+    expect(String(thrown)).toBe("TypeError: fetch_failed");
+    const observable = JSON.stringify({
+      persistedDeliveryLastError: String(thrown),
+      persistedEventLastError: `provider_send_failed: ${String(thrown)}`,
+      activity,
+    });
+    expect(observable).not.toContain("ilinkai.weixin.qq.com");
+    expect(observable).not.toContain(secretToken);
+    expect(observable).not.toContain("https://");
+  });
+
   it("typing() fetches typing_ticket via getconfig and posts sendtyping", async () => {
     let pollCount = 0;
     const getConfigBodies: unknown[] = [];
@@ -387,14 +540,20 @@ describe("WeChat provider adapter", () => {
     // Let start() install config + open poll.
     await new Promise((r) => setTimeout(r, 30));
 
-    await expect(
-      provider.send({
+    let thrown: unknown;
+    try {
+      await provider.send({
         gatewayId: conn.id,
         conversationId: "wechat:user:nobody",
         text: "hi",
         final: true,
-      }),
-    ).rejects.toThrow(/no context_token/);
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(String(thrown)).toBe("Error: wechat send: no_context_token");
+    expect(String(thrown)).not.toContain("nobody");
 
     abort.abort();
     await running;

--- a/packages/gateway-ingress/src/providers/wechat.ts
+++ b/packages/gateway-ingress/src/providers/wechat.ts
@@ -3,6 +3,7 @@ import { randomBytes, randomUUID } from "node:crypto";
 import { sanitizeUntrustedContent, splitText } from "@botcord/protocol-core";
 import type { GatewayInboundMessage } from "@botcord/protocol-core";
 
+import { safeObservableErrorMeta, safeObservableErrorSummary } from "../observable-error.js";
 import type { OutboundSendRequest, OutboundSendResult } from "../types.js";
 import type {
   OutboundTypingRequest,
@@ -113,11 +114,6 @@ function wechatHeaders(botToken: string): Record<string, string> {
     "X-WECHAT-UIN": wechatUinHeader(),
     Authorization: `Bearer ${botToken}`,
   };
-}
-
-function redactToken(input: string, token: string | undefined): string {
-  if (!token || !input) return input;
-  return input.split(token).join("[REDACTED]");
 }
 
 export interface WechatProviderOptions {
@@ -339,7 +335,7 @@ export function createWechatProvider(opts: WechatProviderOptions): ProviderAdapt
           } catch (err) {
             emitFailed = true;
             ctx.log.error("wechat emit threw — leaving cursor unchanged", {
-              err: redactToken(String(err), botToken),
+              err: safeObservableErrorSummary(err),
             });
             break;
           }
@@ -355,9 +351,8 @@ export function createWechatProvider(opts: WechatProviderOptions): ProviderAdapt
           await sleep(TRANSIENT_BACKOFF_MS, abortAggregate.signal);
           continue;
         }
-        const errStr = redactToken(String(err), botToken);
-        ctx.log.error("wechat poll failed", { err: errStr });
-        ctx.markActivity({ lastError: errStr });
+        ctx.log.error("wechat poll failed", safeObservableErrorMeta(err));
+        ctx.markActivity({ lastError: safeObservableErrorSummary(err) });
         await sleep(POLL_BACKOFF_MS, abortAggregate.signal);
       }
     }
@@ -408,7 +403,7 @@ export function createWechatProvider(opts: WechatProviderOptions): ProviderAdapt
       );
     } catch (err) {
       activeCtx?.log.debug("wechat typing failed", {
-        err: redactToken(String(err), botToken),
+        err: safeObservableErrorSummary(err),
       });
     }
   }
@@ -421,10 +416,7 @@ export function createWechatProvider(opts: WechatProviderOptions): ProviderAdapt
     // orchestrator surfaces the failure.
     const trace = lookupTraceByConversation(request.conversationId);
     if (!trace) {
-      throw new Error(
-        `wechat send: no context_token for conversation ${request.conversationId} ` +
-          `(expired or never bound — iLink does not support unsolicited replies)`,
-      );
+      throw new Error("wechat send: no_context_token");
     }
     const chunks = request.text.length > 0 ? splitText(request.text, splitAt) : [];
     let lastClientId: string | null = null;
@@ -441,14 +433,19 @@ export function createWechatProvider(opts: WechatProviderOptions): ProviderAdapt
           item_list: [{ type: 1, text_item: { text: chunk } }],
         },
       };
-      const resp = await callApi<WechatGenericResp>(
-        "ilink/bot/sendmessage",
-        body,
-        15_000,
-      );
+      let resp: WechatGenericResp;
+      try {
+        resp = await callApi<WechatGenericResp>(
+          "ilink/bot/sendmessage",
+          body,
+          15_000,
+        );
+      } catch (err) {
+        throw safeObservableError(err);
+      }
       if (resp.ret !== 0 && resp.ret !== undefined) {
         throw new Error(
-          redactToken(`wechat sendmessage failed: ret=${resp.ret}`, botToken),
+          safeObservableErrorSummary(new Error(`wechat sendmessage failed: ret=${resp.ret}`)),
         );
       }
       lastClientId = `wechat:${trace.fromUserId}:${clientId}`;
@@ -473,6 +470,13 @@ export function createWechatProvider(opts: WechatProviderOptions): ProviderAdapt
 
 export const wechatProviderFactory: ProviderAdapterFactory = (gatewayId) =>
   createWechatProvider({ gatewayId });
+
+function safeObservableError(err: unknown): Error {
+  const meta = safeObservableErrorMeta(err);
+  const safe = new Error(meta.message);
+  safe.name = meta.name;
+  return safe;
+}
 
 // ---------------------------------------------------------------------------
 // Local helpers


### PR DESCRIPTION
## Summary
- sanitize WeChat poll fetch failure logs and provider lastError with safe observable summaries
- sanitize outbound sendmessage transport rejections before orchestrator persists String(err)
- avoid raw error/conversation identifiers in typing, emit, and no-context observable paths
- add WeChat regression tests for poll/send leak prevention and no-context user id redaction

## Validation
- git diff --check
- cd packages/gateway-ingress && npm test -- --run src/__tests__/wechat.test.ts
- cd packages/gateway-ingress && npm run build
- Code Reviewer + sub-agent Euclid: no blocking findings; full gateway-ingress npm test passed, 14 files / 93 tests

Runtime scope: preview issue only; no prod deploy/restart/runtime/secrets touched by CTO.