### PR TITLE
fix: add image preview navigation

### DIFF
--- a/frontend/src/components/dashboard/ChatPane.tsx
+++ b/frontend/src/components/dashboard/ChatPane.tsx
@@ -31,6 +31,14 @@ import ExploreEntityCard from "./ExploreEntityCard";
 import type { Attachment, PublicHumanProfile, PublicRoom } from "@/lib/types";
 import { api } from "@/lib/api";
 import { animateIfMotion, animeStagger, cleanupAnime, prefersReducedMotion } from "@/lib/anime";
+import ImagePreviewOverlay from "@/components/ui/ImagePreviewOverlay";
+import {
+  attachmentGalleryIndex,
+  getPreviewableImageAttachments,
+  isImageAttachment,
+  rememberFailedAttachmentImageUrl,
+  resolveAttachmentUrl,
+} from "@/components/ui/AttachmentItem";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardContactStore } from "@/store/useDashboardContactStore";
 import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
@@ -44,6 +52,9 @@ import { DashboardMainSkeleton } from "./DashboardTabSkeleton";
 
 const EXPLORE_GRID_CLASS = "grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5";
 type ChatPaneTab = "messages" | "contacts" | "explore";
+type AttachmentPreviewState =
+  | { kind: "document"; attachment: Attachment }
+  | { kind: "image"; attachments: Attachment[]; index: number };
 
 function GridSkeletonCards() {
   return <DashboardMainSkeleton variant="explore" />;
@@ -740,7 +751,7 @@ export default function ChatPane({ onHumanOpen, sidebarTabOverride }: ChatPanePr
     getRoomSummary: state.getRoomSummary,
   })));
   const effectiveSidebarTab = sidebarTabOverride ?? sidebarTab;
-  const [previewAttachment, setPreviewAttachment] = useState<Attachment | null>(null);
+  const [attachmentPreview, setAttachmentPreview] = useState<AttachmentPreviewState | null>(null);
   const visibleMessageRooms = useMemo(
     () => buildVisibleMessageRooms({ overview, recentVisitedRooms, token, humanRooms }),
     [overview, recentVisitedRooms, token, humanRooms],
@@ -751,8 +762,25 @@ export default function ChatPane({ onHumanOpen, sidebarTabOverride }: ChatPanePr
   const showLoginModal = () => router.push("/login");
 
   useEffect(() => {
-    setPreviewAttachment(null);
+    setAttachmentPreview(null);
   }, [effectiveSidebarTab, openedRoomId]);
+
+  const handlePreviewAttachment = (attachment: Attachment, previewAttachments?: Attachment[]) => {
+    if (isImageAttachment(attachment)) {
+      const gallery = getPreviewableImageAttachments(
+        previewAttachments && previewAttachments.length > 0 ? previewAttachments : [attachment],
+      );
+      const index = attachmentGalleryIndex(gallery, attachment);
+      setAttachmentPreview({
+        kind: "image",
+        attachments: gallery.length > 0 ? gallery : [attachment],
+        index: index >= 0 ? index : 0,
+      });
+      return;
+    }
+
+    setAttachmentPreview({ kind: "document", attachment });
+  };
 
   if (effectiveSidebarTab === "explore") {
     return <ExploreMainPane onHumanOpen={onHumanOpen} />;
@@ -805,7 +833,7 @@ export default function ChatPane({ onHumanOpen, sidebarTabOverride }: ChatPanePr
                   loginHref={loginHref}
                 />
               ) : (
-                <MessageList onPreviewAttachment={setPreviewAttachment} />
+                <MessageList onPreviewAttachment={handlePreviewAttachment} />
               )
             ) : (
               <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-text-secondary">
@@ -845,13 +873,47 @@ export default function ChatPane({ onHumanOpen, sidebarTabOverride }: ChatPanePr
             </>
           )}
         </div>
-        {previewAttachment && (
+        {attachmentPreview?.kind === "document" && (
           <DocumentPreviewPane
-            attachment={previewAttachment}
-            onClose={() => setPreviewAttachment(null)}
+            attachment={attachmentPreview.attachment}
+            onClose={() => setAttachmentPreview(null)}
           />
         )}
       </div>
+      {attachmentPreview?.kind === "image" && (() => {
+        const attachment = attachmentPreview.attachments[attachmentPreview.index];
+        if (!attachment) return null;
+        const src = resolveAttachmentUrl(attachment.url);
+        const title = attachment.filename || "Image attachment";
+
+        return (
+          <ImagePreviewOverlay
+            src={src}
+            title={title}
+            currentIndex={attachmentPreview.index}
+            totalCount={attachmentPreview.attachments.length}
+            onPrevious={attachmentPreview.index > 0
+              ? () => setAttachmentPreview((preview) => (
+                  preview?.kind === "image"
+                    ? { ...preview, index: Math.max(0, preview.index - 1) }
+                    : preview
+                ))
+              : undefined}
+            onNext={attachmentPreview.index < attachmentPreview.attachments.length - 1
+              ? () => setAttachmentPreview((preview) => (
+                  preview?.kind === "image"
+                    ? { ...preview, index: Math.min(preview.attachments.length - 1, preview.index + 1) }
+                    : preview
+                ))
+              : undefined}
+            onClose={() => setAttachmentPreview(null)}
+            onImageError={() => {
+              rememberFailedAttachmentImageUrl(src);
+              setAttachmentPreview(null);
+            }}
+          />
+        );
+      })()}
       <TopicDrawer />
     </div>
   );

--- a/frontend/src/components/dashboard/MessageBubble.tsx
+++ b/frontend/src/components/dashboard/MessageBubble.tsx
@@ -17,7 +17,7 @@ import { messageBubble } from '@/lib/i18n/translations/dashboard';
 import { getActionMenuPosition } from "@/lib/message-action-menu";
 import { resolveMessageMentionTargets } from "@/lib/message-mentions";
 import { canRecallDashboardMessage, isDashboardMessageRecalled, recalledMessageLabel } from "@/lib/message-recall";
-import AttachmentItem from "@/components/ui/AttachmentItem";
+import AttachmentItem, { getPreviewableImageAttachments } from "@/components/ui/AttachmentItem";
 import CopyableId from "@/components/ui/CopyableId";
 import MarkdownContent from "@/components/ui/MarkdownContent";
 import type { MentionTextCandidate } from "@/components/ui/MarkdownContent";
@@ -42,7 +42,7 @@ interface MessageBubbleProps {
   sourceId?: string;
   /** Known participants used to resolve plain-text @display-name mentions. */
   mentionCandidates?: MentionTextCandidate[];
-  onPreviewAttachment?: (attachment: Attachment) => void;
+  onPreviewAttachment?: (attachment: Attachment, previewAttachments?: Attachment[]) => void;
 }
 
 const stateColors: Record<string, { color: string; icon: string }> = {
@@ -677,6 +677,7 @@ function MessageBubble({
   const attachments = Array.isArray(message.payload?.attachments)
     ? (message.payload.attachments as Attachment[])
     : [];
+  const imagePreviewAttachments = getPreviewableImageAttachments(attachments);
 
   const sc = stateConfig[message.state];
   const [, forceStatusReactionRender] = useState(0);
@@ -1144,6 +1145,7 @@ function MessageBubble({
               <AttachmentItem
                 key={`${att.filename}-${att.url}-${i}`}
                 attachment={att}
+                previewAttachments={imagePreviewAttachments}
                 onPreview={onPreviewAttachment}
               />
             ))}

--- a/frontend/src/components/dashboard/MessageList.tsx
+++ b/frontend/src/components/dashboard/MessageList.tsx
@@ -133,7 +133,7 @@ export function TopicCard({
   sourceName?: string;
   sourceId?: string;
   mentionCandidates?: MentionTextCandidate[];
-  onPreviewAttachment?: (attachment: Attachment) => void;
+  onPreviewAttachment?: (attachment: Attachment, previewAttachments?: Attachment[]) => void;
   onOpen: () => void;
 }) {
   const topicStatusConfig = useTopicStatusConfig();
@@ -298,7 +298,7 @@ function EmptyRoomGuide({
 export default function MessageList({
   onPreviewAttachment,
 }: {
-  onPreviewAttachment?: (attachment: Attachment) => void;
+  onPreviewAttachment?: (attachment: Attachment, previewAttachments?: Attachment[]) => void;
 } = {}) {
   const locale = useLanguage();
   const t = messageList[locale];

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -25,7 +25,14 @@ import { useOwnerChatWs } from "@/hooks/useOwnerChatWs";
 import { messageList } from "@/lib/i18n/translations/dashboard";
 import DashboardMessagePaneSkeleton from "./DashboardMessagePaneSkeleton";
 import MarkdownContent, { normalizeMessageContent } from "@/components/ui/MarkdownContent";
-import AttachmentItem from "@/components/ui/AttachmentItem";
+import AttachmentItem, {
+  attachmentGalleryIndex,
+  getPreviewableImageAttachments,
+  isImageAttachment,
+  rememberFailedAttachmentImageUrl,
+  resolveAttachmentUrl,
+} from "@/components/ui/AttachmentItem";
+import ImagePreviewOverlay from "@/components/ui/ImagePreviewOverlay";
 import StreamBlocksView from "./StreamBlocksView";
 import DocumentPreviewPane from "./DocumentPreviewPane";
 import RuntimeErrorDetailsDialog from "./RuntimeErrorDetailsDialog";
@@ -48,6 +55,9 @@ import {
 import { animateFadeUp, animateIfMotion, animatePop, cleanupAnime } from "@/lib/anime";
 
 const OWNER_CHAT_ENTRANCE_SETTLE_MS = 1200;
+type AttachmentPreviewState =
+  | { kind: "document"; attachment: Attachment }
+  | { kind: "image"; attachments: Attachment[]; index: number };
 
 // ---------------------------------------------------------------------------
 // TypewriterText
@@ -119,7 +129,7 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
   const [actionMenuOpenId, setActionMenuOpenId] = useState<string | null>(null);
   const [copiedMessageId, setCopiedMessageId] = useState<string | null>(null);
   const [forwardQuote, setForwardQuote] = useState<string | null>(null);
-  const [previewAttachment, setPreviewAttachment] = useState<Attachment | null>(null);
+  const [attachmentPreview, setAttachmentPreview] = useState<AttachmentPreviewState | null>(null);
   const settingsLabel = locale === "zh" ? "Bot 设置" : "Bot settings";
   const replyLabel = locale === "zh" ? "回复" : "Reply";
   const forwardLabel = locale === "zh" ? "转发" : "Forward";
@@ -181,6 +191,23 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
     }
   }, [scrollToBottom]);
 
+  const handlePreviewAttachment = useCallback((attachment: Attachment, previewAttachments?: Attachment[]) => {
+    if (isImageAttachment(attachment)) {
+      const gallery = getPreviewableImageAttachments(
+        previewAttachments && previewAttachments.length > 0 ? previewAttachments : [attachment],
+      );
+      const index = attachmentGalleryIndex(gallery, attachment);
+      setAttachmentPreview({
+        kind: "image",
+        attachments: gallery.length > 0 ? gallery : [attachment],
+        index: index >= 0 ? index : 0,
+      });
+      return;
+    }
+
+    setAttachmentPreview({ kind: "document", attachment });
+  }, []);
+
   // WS hook authenticates the selected owner-chat target explicitly.
   const { wsClientRef, streamedTraceIds } = useOwnerChatWs({
     activeAgentId: chatAgentId,
@@ -208,7 +235,7 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
     setShowScrollToBottomButton(false);
     animatedRef.current.clear();
     entranceAnimatedRef.current.clear();
-    setPreviewAttachment(null);
+    setAttachmentPreview(null);
     useOwnerChatStore.getState().reset();
 
     (async () => {
@@ -960,7 +987,8 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
                           <AttachmentItem
                             key={`${att.filename}-${att.url}-${idx}`}
                             attachment={att}
-                            onPreview={setPreviewAttachment}
+                            previewAttachments={getPreviewableImageAttachments(msg.attachments ?? [])}
+                            onPreview={handlePreviewAttachment}
                           />
                         ))}
                       </div>
@@ -1022,12 +1050,46 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
         </button>
       )}
       </div>
-      {previewAttachment && (
+      {attachmentPreview?.kind === "document" && (
         <DocumentPreviewPane
-          attachment={previewAttachment}
-          onClose={() => setPreviewAttachment(null)}
+          attachment={attachmentPreview.attachment}
+          onClose={() => setAttachmentPreview(null)}
         />
       )}
+      {attachmentPreview?.kind === "image" && (() => {
+        const attachment = attachmentPreview.attachments[attachmentPreview.index];
+        if (!attachment) return null;
+        const src = resolveAttachmentUrl(attachment.url);
+        const title = attachment.filename || "Image attachment";
+
+        return (
+          <ImagePreviewOverlay
+            src={src}
+            title={title}
+            currentIndex={attachmentPreview.index}
+            totalCount={attachmentPreview.attachments.length}
+            onPrevious={attachmentPreview.index > 0
+              ? () => setAttachmentPreview((preview) => (
+                  preview?.kind === "image"
+                    ? { ...preview, index: Math.max(0, preview.index - 1) }
+                    : preview
+                ))
+              : undefined}
+            onNext={attachmentPreview.index < attachmentPreview.attachments.length - 1
+              ? () => setAttachmentPreview((preview) => (
+                  preview?.kind === "image"
+                    ? { ...preview, index: Math.min(preview.attachments.length - 1, preview.index + 1) }
+                    : preview
+                ))
+              : undefined}
+            onClose={() => setAttachmentPreview(null)}
+            onImageError={() => {
+              rememberFailedAttachmentImageUrl(src);
+              setAttachmentPreview(null);
+            }}
+          />
+        );
+      })()}
       {forwardQuote && (
         <ForwardModal quoteText={forwardQuote} onClose={() => setForwardQuote(null)} />
       )}

--- a/frontend/src/components/ui/AttachmentItem.test.ts
+++ b/frontend/src/components/ui/AttachmentItem.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  attachmentGalleryIndex,
+  getPreviewableImageAttachments,
   hasFailedAttachmentImageUrl,
   isImageAttachment,
   rememberFailedAttachmentImageUrl,
@@ -27,6 +29,23 @@ describe("AttachmentItem helpers", () => {
       filename: "report.pdf",
       url: "/hub/files/f_789",
     })).toBe(false);
+  });
+
+  it("keeps only previewable images in preview navigation context", () => {
+    const attachments = [
+      { filename: "one.png", url: "/hub/files/f_one", content_type: "image/png" },
+      { filename: "report.pdf", url: "/hub/files/f_pdf", content_type: "application/pdf" },
+      { filename: "two.webp", url: "/hub/files/f_two" },
+    ];
+
+    const gallery = getPreviewableImageAttachments(attachments);
+
+    expect(gallery).toEqual([
+      attachments[0],
+      attachments[2],
+    ]);
+    expect(attachmentGalleryIndex(gallery, attachments[2])).toBe(1);
+    expect(attachmentGalleryIndex(gallery, attachments[1])).toBe(-1);
   });
 
   it("remembers failed image attachment URLs for the current session", () => {

--- a/frontend/src/components/ui/AttachmentItem.tsx
+++ b/frontend/src/components/ui/AttachmentItem.tsx
@@ -35,6 +35,21 @@ export function isImageAttachment(attachment: Attachment): boolean {
   return /\.(avif|bmp|gif|jpe?g|png|svg|webp)$/i.test(name);
 }
 
+export function getPreviewableImageAttachments(attachments: Attachment[]): Attachment[] {
+  return attachments.filter((attachment) => isImageAttachment(attachment) && isPreviewableAttachment(attachment));
+}
+
+export function attachmentIdentity(attachment: Attachment): string {
+  return `${attachment.url}\n${attachment.filename || ""}`;
+}
+
+export function attachmentGalleryIndex(attachments: Attachment[], attachment: Attachment): number {
+  const identity = attachmentIdentity(attachment);
+  const index = attachments.findIndex((item) => attachmentIdentity(item) === identity);
+  if (index >= 0) return index;
+  return attachments.findIndex((item) => item.url === attachment.url);
+}
+
 function attachmentImageFailureKey(url: string): string {
   return url.trim();
 }
@@ -53,7 +68,8 @@ export function hasFailedAttachmentImageUrl(url: string): boolean {
 
 interface AttachmentItemProps {
   attachment: Attachment;
-  onPreview?: (attachment: Attachment) => void;
+  previewAttachments?: Attachment[];
+  onPreview?: (attachment: Attachment, previewAttachments?: Attachment[]) => void;
 }
 
 function AttachmentFileLink({
@@ -63,7 +79,7 @@ function AttachmentFileLink({
 }: {
   attachment: Attachment;
   attachmentUrl: string;
-  onPreview?: (attachment: Attachment) => void;
+  onPreview?: (attachment: Attachment, previewAttachments?: Attachment[]) => void;
 }) {
   const canPreview = Boolean(onPreview && isPreviewableAttachment(attachment));
   const content = (
@@ -103,7 +119,7 @@ function AttachmentFileLink({
   );
 }
 
-export default function AttachmentItem({ attachment, onPreview }: AttachmentItemProps) {
+export default function AttachmentItem({ attachment, previewAttachments, onPreview }: AttachmentItemProps) {
   const attachmentUrl = resolveAttachmentUrl(attachment.url);
   const [previewOpen, setPreviewOpen] = useState(false);
   const [imageFailed, setImageFailed] = useState(() => hasFailedAttachmentImageUrl(attachmentUrl));
@@ -131,7 +147,7 @@ export default function AttachmentItem({ attachment, onPreview }: AttachmentItem
             onClick={(event) => {
               event.stopPropagation();
               if (onPreview) {
-                onPreview(attachment);
+                onPreview(attachment, previewAttachments);
               } else {
                 setPreviewOpen(true);
               }

--- a/frontend/src/components/ui/ImagePreviewOverlay.tsx
+++ b/frontend/src/components/ui/ImagePreviewOverlay.tsx
@@ -1,14 +1,19 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
+import type { PointerEvent as ReactPointerEvent } from "react";
 import { createPortal } from "react-dom";
-import { ExternalLink, X } from "lucide-react";
+import { ChevronLeft, ChevronRight, ExternalLink, X } from "lucide-react";
 
 interface ImagePreviewOverlayProps {
   src: string;
   title: string;
   onClose: () => void;
   onImageError: () => void;
+  currentIndex?: number;
+  totalCount?: number;
+  onPrevious?: () => void;
+  onNext?: () => void;
 }
 
 export default function ImagePreviewOverlay({
@@ -16,7 +21,16 @@ export default function ImagePreviewOverlay({
   title,
   onClose,
   onImageError,
+  currentIndex,
+  totalCount,
+  onPrevious,
+  onNext,
 }: ImagePreviewOverlayProps) {
+  const pointerStartRef = useRef<{ x: number; y: number } | null>(null);
+  const canGoPrevious = Boolean(onPrevious);
+  const canGoNext = Boolean(onNext);
+  const hasGallery = typeof currentIndex === "number" && typeof totalCount === "number" && totalCount > 1;
+
   useEffect(() => {
     const previousOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
@@ -25,6 +39,12 @@ export default function ImagePreviewOverlay({
       if (event.key === "Escape") {
         event.preventDefault();
         onClose();
+      } else if (event.key === "ArrowLeft" && onPrevious) {
+        event.preventDefault();
+        onPrevious();
+      } else if (event.key === "ArrowRight" && onNext) {
+        event.preventDefault();
+        onNext();
       }
     };
 
@@ -33,7 +53,27 @@ export default function ImagePreviewOverlay({
       document.body.style.overflow = previousOverflow;
       document.removeEventListener("keydown", handleKeyDown);
     };
-  }, [onClose]);
+  }, [onClose, onNext, onPrevious]);
+
+  const handlePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!hasGallery || (event.pointerType === "mouse" && event.button !== 0)) return;
+    pointerStartRef.current = { x: event.clientX, y: event.clientY };
+  };
+
+  const handlePointerUp = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const start = pointerStartRef.current;
+    pointerStartRef.current = null;
+    if (!start) return;
+
+    const deltaX = event.clientX - start.x;
+    const deltaY = event.clientY - start.y;
+    if (Math.abs(deltaX) < 48 || Math.abs(deltaY) > 80 || Math.abs(deltaY) > Math.abs(deltaX)) return;
+    if (deltaX > 0) {
+      onPrevious?.();
+    } else {
+      onNext?.();
+    }
+  };
 
   return createPortal(
     <div
@@ -44,9 +84,21 @@ export default function ImagePreviewOverlay({
       onClick={(event) => {
         if (event.target === event.currentTarget) onClose();
       }}
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={() => {
+        pointerStartRef.current = null;
+      }}
     >
       <div className="flex min-h-14 items-center justify-between gap-3 border-b border-glass-border bg-deep-black/85 px-3 py-2 sm:px-5">
-        <span className="min-w-0 truncate text-sm font-medium text-text-primary">{title}</span>
+        <div className="min-w-0">
+          <span className="block truncate text-sm font-medium text-text-primary">{title}</span>
+          {hasGallery && (
+            <span className="block text-[11px] text-text-secondary/70">
+              {currentIndex + 1} / {totalCount}
+            </span>
+          )}
+        </div>
         <div className="flex shrink-0 items-center gap-1.5">
           <a
             href={src}
@@ -71,13 +123,43 @@ export default function ImagePreviewOverlay({
           </button>
         </div>
       </div>
-      <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto p-3 sm:p-6">
+      <div className="relative flex min-h-0 flex-1 items-center justify-center overflow-auto p-3 sm:p-6">
+        {hasGallery && (
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              onPrevious?.();
+            }}
+            disabled={!canGoPrevious}
+            className="absolute left-3 top-1/2 z-10 hidden h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full border border-white/10 bg-black/55 text-text-primary shadow-lg transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-30 sm:inline-flex"
+            aria-label="Previous image"
+            title="Previous image"
+          >
+            <ChevronLeft className="h-6 w-6" />
+          </button>
+        )}
         <img
           src={src}
           alt={title}
           className="max-h-[calc(100vh-6.5rem)] max-w-full object-contain shadow-2xl"
           onError={onImageError}
         />
+        {hasGallery && (
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              onNext?.();
+            }}
+            disabled={!canGoNext}
+            className="absolute right-3 top-1/2 z-10 hidden h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full border border-white/10 bg-black/55 text-text-primary shadow-lg transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-30 sm:inline-flex"
+            aria-label="Next image"
+            title="Next image"
+          >
+            <ChevronRight className="h-6 w-6" />
+          </button>
+        )}
       </div>
     </div>,
     document.body,


### PR DESCRIPTION
## Summary
- add image preview previous/next navigation for attachment groups
- add swipe gesture navigation in the preview overlay
- cover navigation metadata in attachment item tests

Topic: tp_238fcb463d39
Review: Code Reviewer reported no blocking findings before merge-prep.

## Verification
- Prior CTO focused tests/diff-check passed
- Prior build compile+TS passed
- Prior prerender blocked by missing local Supabase env for /admin/codes