### PR TITLE
feat: list all daemon workspace files

### DIFF
--- a/backend/app/routers/runtime_files.py
+++ b/backend/app/routers/runtime_files.py
@@ -51,6 +51,7 @@ class AgentRuntimeFileOut(BaseModel):
     id: str
     name: str
     scope: Literal["workspace", "memory", "hermes", "openclaw"]
+    relativePath: str | None = None
     runtime: str | None = None
     profile: str | None = None
     size: int | None = None

--- a/frontend/src/components/dashboard/AgentSettingsDrawer.tsx
+++ b/frontend/src/components/dashboard/AgentSettingsDrawer.tsx
@@ -45,6 +45,7 @@ interface AgentRuntimeFile {
   id: string;
   name: string;
   scope: "workspace" | "memory" | "hermes" | "openclaw";
+  relativePath?: string;
   runtime?: string;
   profile?: string;
   size?: number;

--- a/frontend/src/components/dashboard/BotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/BotDetailDrawer.tsx
@@ -61,6 +61,7 @@ interface AgentRuntimeFile {
   id: string;
   name: string;
   scope: "workspace" | "memory" | "hermes" | "openclaw";
+  relativePath?: string;
   runtime?: string;
   profile?: string;
   size?: number;

--- a/packages/daemon/src/__tests__/provision.test.ts
+++ b/packages/daemon/src/__tests__/provision.test.ts
@@ -200,7 +200,7 @@ describe("list_agent_files handler", () => {
     }
   });
 
-  it("returns allowlisted workspace and attached hermes profile files for the requested agent", async () => {
+  it("returns workspace files recursively and attached hermes profile files for the requested agent", async () => {
     const os = await import("node:os");
     const fs = await import("node:fs");
     const nodePath = await import("node:path");
@@ -227,9 +227,16 @@ describe("list_agent_files handler", () => {
       const workspace = nodePath.join(tmp, ".botcord", "agents", "ag_hermes", "workspace");
       const memoryDir = nodePath.join(tmp, ".botcord", "memory", "ag_hermes");
       fs.mkdirSync(workspace, { recursive: true });
+      fs.mkdirSync(nodePath.join(workspace, "notes", "daily"), { recursive: true });
       fs.mkdirSync(memoryDir, { recursive: true });
       fs.writeFileSync(nodePath.join(memoryDir, "working-memory.json"), '{"sections":{}}\n');
       fs.writeFileSync(nodePath.join(workspace, "task.md"), "# Task\n");
+      fs.writeFileSync(nodePath.join(workspace, "notes", "daily", "plan.md"), "# Plan\n");
+      fs.writeFileSync(nodePath.join(tmp, "outside-secret.md"), "# Outside\n");
+      fs.symlinkSync(
+        nodePath.join(tmp, "outside-secret.md"),
+        nodePath.join(workspace, "linked-secret.md"),
+      );
 
       const hermesMem = nodePath.join(tmp, ".hermes", "memories");
       fs.mkdirSync(hermesMem, { recursive: true });
@@ -250,9 +257,12 @@ describe("list_agent_files handler", () => {
       const byName = Object.fromEntries(result.files.map((f: any) => [f.name, f]));
       expect(byName["memory/working-memory.json"].content).toBe('{"sections":{}}\n');
       expect(byName["workspace/task.md"].content).toBe("# Task\n");
+      expect(byName["workspace/notes/daily/plan.md"].relativePath).toBe("notes/daily/plan.md");
+      expect(byName["workspace/notes/daily/plan.md"].content).toBe("# Plan\n");
       expect(byName["hermes/default/SOUL.md"].content).toBe("# Soul\n");
       expect(byName["hermes/default/memories/MEMORY.md"].content).toBe("# Hermes Memory\n");
       expect(result.files.some((f: any) => f.name.includes("credentials"))).toBe(false);
+      expect(result.files.some((f: any) => f.name === "workspace/linked-secret.md")).toBe(false);
     } finally {
       if (prevHome === undefined) delete process.env.HOME;
       else process.env.HOME = prevHome;

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -4,7 +4,16 @@
  * side effects (register agent, write credentials, load route, add/remove
  * gateway channel) and return an ack payload.
  */
-import { existsSync, lstatSync, readdirSync, readFileSync, rmSync, statSync, unlinkSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  type Dirent,
+} from "node:fs";
 import { homedir } from "node:os";
 import { createRequire } from "node:module";
 import path from "node:path";
@@ -888,6 +897,7 @@ interface AgentRuntimeFile {
   id: string;
   name: string;
   scope: "workspace" | "memory" | "hermes" | "openclaw";
+  relativePath?: string;
   runtime?: string;
   profile?: string;
   size?: number;
@@ -957,7 +967,7 @@ function addWorkspaceFiles(
   runtime?: string,
 ): void {
   const root = agentWorkspaceDir(agentId);
-  for (const file of ["AGENTS.md", "CLAUDE.md", "identity.md", "task.md"]) {
+  for (const file of listWorkspaceRelativeFiles(root)) {
     out.push({
       id: `workspace:${file}`,
       name: `workspace/${file}`,
@@ -967,6 +977,38 @@ function addWorkspaceFiles(
       ...(runtime ? { runtime } : {}),
     });
   }
+}
+
+function listWorkspaceRelativeFiles(root: string): string[] {
+  const rootResolved = path.resolve(root);
+  const out: string[] = [];
+
+  function visit(relativeDir: string): void {
+    const dir = relativeDir ? path.join(rootResolved, relativeDir) : rootResolved;
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw err;
+    }
+
+    for (const entry of entries) {
+      const relativePath = relativeDir ? path.join(relativeDir, entry.name) : entry.name;
+      const normalized = relativePath.split(path.sep).join("/");
+      const resolved = path.resolve(rootResolved, relativePath);
+      if (resolved !== rootResolved && !resolved.startsWith(rootResolved + path.sep)) continue;
+      if (entry.isSymbolicLink()) continue;
+      if (entry.isDirectory()) {
+        visit(relativePath);
+        continue;
+      }
+      if (entry.isFile()) out.push(normalized);
+    }
+  }
+
+  visit("");
+  return out.sort((a, b) => a.localeCompare(b));
 }
 
 function addWorkingMemoryFile(
@@ -1065,6 +1107,7 @@ function readRuntimeFileCandidate(candidate: RuntimeFileCandidate): AgentRuntime
     id: candidate.id,
     name: candidate.name,
     scope: candidate.scope,
+    relativePath: candidate.relativePath.split(path.sep).join("/"),
     ...(candidate.runtime ? { runtime: candidate.runtime } : {}),
     ...(candidate.profile ? { profile: candidate.profile } : {}),
   };

--- a/packages/protocol-core/src/control-frame.ts
+++ b/packages/protocol-core/src/control-frame.ts
@@ -79,11 +79,12 @@ export const CONTROL_FRAME_TYPES = {
    */
   RESTART_DAEMON: "restart_daemon",
   /**
-   * Hub→daemon: list/read the small allowlisted Markdown files that belong to
-   * one BotCord agent's local runtime/profile binding. The Hub authorizes the
-   * dashboard user before sending this frame; the daemon accepts only
-   * `agentId`, resolves local credentials, and never accepts arbitrary paths
-   * from the client.
+   * Hub→daemon: list/read files that belong to one BotCord agent's local
+   * runtime/profile binding. Workspace scope returns every regular file under
+   * the agent workspace; runtime/profile scopes remain daemon allowlisted. The
+   * Hub authorizes the dashboard user before sending this frame; the daemon
+   * accepts only `agentId`/daemon-issued `fileId`, resolves local credentials,
+   * and never accepts arbitrary paths from the client.
    */
   LIST_AGENT_FILES: "list_agent_files",
   /**
@@ -404,10 +405,12 @@ export interface AgentRuntimeFile {
    * read one file; they must not construct filesystem paths.
    */
   id: string;
-  /** Display filename, e.g. `SOUL.md` or `memory/working-memory.json`. */
+  /** Display filename, e.g. `workspace/notes/today.md` or `memory/working-memory.json`. */
   name: string;
   /** Logical source bucket for UI grouping. */
   scope: "workspace" | "memory" | "hermes" | "openclaw";
+  /** Path relative to the file's source root. Uses `/` separators. */
+  relativePath?: string;
   /** Runtime that exposed this file. */
   runtime?: string;
   /** Runtime profile binding, when applicable. */


### PR DESCRIPTION
## Summary
- Recursively list every regular file under an agent workspace through `list_agent_files`.
- Preserve daemon-issued file ids and add `relativePath` to protocol, backend, and dashboard types.
- Keep runtime/profile file scopes allowlisted and skip symlinks to avoid following paths outside the workspace.

## Verification
- `cd packages/daemon && pnpm test -- --run src/__tests__/provision.test.ts`
- `cd packages/protocol-core && pnpm build`
- `cd packages/daemon && pnpm build`
- `cd frontend && npm run build`

## Risk / rollout
- Low risk; existing file content cap remains in place and workspace entries are limited to regular files.