### PR TITLE
chore(release): version packages

### DIFF
--- a/.changeset/owner-chat-stream-end.md
+++ b/.changeset/owner-chat-stream-end.md
@@ -1,5 +1,0 @@
----
-"@botcord/daemon": patch
----
-
-Signal the Hub at the end of every streamed owner-chat turn (`POST /hub/stream-end`) so runs that produced no owner-chat reply (autonomous work, empty/gated final text, timeout) are marked completed instead of dangling as restorable "running" runs. Without this, the dashboard resurrected their full reasoning trace on every refresh until the run TTL expired.

--- a/packages/daemon/CHANGELOG.md
+++ b/packages/daemon/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @botcord/daemon
 
+## 0.4.5
+
+### Patch Changes
+
+- 65c578d: Signal the Hub at the end of every streamed owner-chat turn (`POST /hub/stream-end`) so runs that produced no owner-chat reply (autonomous work, empty/gated final text, timeout) are marked completed instead of dangling as restorable "running" runs. Without this, the dashboard resurrected their full reasoning trace on every refresh until the run TTL expired.
+- 8cd4512: Recursively list every regular file under an agent workspace through `list_agent_files`, expose `relativePath` in file metadata, and skip symlinks so workspace listing does not follow paths outside the workspace.
+
+### Updated Dependencies
+
+- @botcord/protocol-core@0.2.17
+
 ## 0.4.4
 
 ### Patch Changes

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botcord/daemon",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "BotCord local daemon — bridges Hub inbox push to local Claude Code / Codex / Gemini CLIs",
   "type": "module",
   "bin": {

--- a/packages/protocol-core/CHANGELOG.md
+++ b/packages/protocol-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @botcord/protocol-core
 
+## 0.2.17
+
+### Patch Changes
+
+- 8cd4512: Add `relativePath` to daemon runtime file metadata so dashboard and API consumers can distinguish workspace file paths while keeping daemon-issued file ids opaque.
+
 ## 0.2.16
 
 ### Patch Changes

--- a/packages/protocol-core/package.json
+++ b/packages/protocol-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botcord/protocol-core",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "description": "Shared protocol primitives for BotCord — Ed25519 signing, credentials I/O, session key derivation",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Bump `@botcord/protocol-core` to `0.2.17`.
- Bump `@botcord/daemon` to `0.4.5`.
- Consume the pending daemon changeset and include the workspace file listing protocol/daemon release notes.

## Verification
- `pnpm -r --filter "./packages/protocol-core" --filter "./packages/daemon" build`

## Risk / rollout
- Version-only release PR. Merging this enables the `Release Packages` workflow to publish from main.