### PR TITLE
fix(daemon): show group replying status reaction for CJK action mentions

### DIFF
--- a/.changeset/replying-status-cjk-mentions.md
+++ b/.changeset/replying-status-cjk-mentions.md
@@ -1,0 +1,13 @@
+---
+"@botcord/daemon": patch
+---
+
+fix(daemon): show group "replying" status reaction for CJK action mentions
+
+The group-room replying status reaction (⏳) was gated behind an English-only
+keyword regex (`ACTION_MENTION_RE` / `STRONG_ACTION_MENTION_RE` / `FYI_MENTION_RE`)
+plus `?`/`？`. zh-only team rooms whose messages carry no Latin token (e.g.
+"什么结论了", "帮忙改一下") never matched, so the reaction silently stopped
+appearing after the 6-13 mention-handling hardening. Extend the gates to cover
+CJK action verbs, question markers, and no-action/FYI phrases, with a negation/
+done-state lookbehind so "不用处理"/"已经修复" stay suppressed.

--- a/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
+++ b/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   Dispatcher,
   pickMessageStatusTarget,
+  shouldShowReplyingStatus,
   type RuntimeFactory,
 } from "../dispatcher.js";
 import { SessionStore } from "../session-store.js";
@@ -263,6 +264,56 @@ describe("pickMessageStatusTarget", () => {
     });
 
     expect(pickMessageStatusTarget(msg)).toBe("msg_2");
+  });
+});
+
+describe("shouldShowReplyingStatus", () => {
+  function groupMention(text: string): GatewayInboundMessage {
+    return makeMessage({
+      conversation: { id: "rm_group_1", kind: "group" },
+      mentioned: true,
+      text,
+    });
+  }
+
+  it("shows for English action mentions", () => {
+    expect(shouldShowReplyingStatus(groupMention("@me can you deploy this?"))).toBe(
+      true
+    );
+  });
+
+  it("shows for CJK action requests without an English keyword or '?'", () => {
+    // Regression: zh-only team rooms saw no replying reaction because the gate
+    // only matched English keywords / "?". See dispatcher CJK_ACTION.
+    for (const text of [
+      "什么结论了",
+      "帮忙改一下日志",
+      "请部署一下",
+      "这个能不能搞定",
+      "麻烦排查下报错",
+    ]) {
+      expect(shouldShowReplyingStatus(groupMention(text))).toBe(true);
+    }
+  });
+
+  it("stays suppressed for CJK FYI / no-action and acknowledgements", () => {
+    for (const text of [
+      "仅供参考，不用处理",
+      "已经修复了，周知",
+      "我同步一下进展",
+      "收到，谢谢",
+    ]) {
+      expect(shouldShowReplyingStatus(groupMention(text))).toBe(false);
+    }
+  });
+
+  it("never shows outside group rooms", () => {
+    const dm = makeMessage({
+      conversation: { id: "rm_oc_1", kind: "direct" },
+      mentioned: true,
+      text: "请部署一下",
+    });
+    expect(shouldShowReplyingStatus(dm)).toBe(false);
   });
 });
 

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -409,12 +409,31 @@ function rawEntryText(entry: unknown): string {
   return "";
 }
 
-const FYI_MENTION_RE =
-  /\b(?:fyi|for your awareness|for visibility|heads up|cc\b|no[- ]action|no[- ]reply(?: needed)?|no[- ]response(?: needed)?|just sharing|just noting|ack only|context[- ]only)\b/i;
-const STRONG_ACTION_MENTION_RE =
-  /\b(?:can you|could you|would you|need you|take a look|review|fix|implement|publish|deploy|restart|verify|investigate|check|confirm|approve|blocker|blocked|error|failed|failure|incident|rollback|release|ship|merge)\b|[?？]/i;
-const ACTION_MENTION_RE =
-  /\b(?:please|pls|can you|could you|would you|need you|take a look|review|fix|implement|publish|deploy|restart|verify|investigate|check|confirm|approve|blocker|blocked|error|failed|failure|incident|rollback|release|ship|merge)\b|[?？]/i;
+// CJK callers rarely include an English keyword or a "?" — e.g. zh-only team
+// rooms say "什么结论了" / "帮忙改一下" with no Latin token. Gate the replying
+// status on CJK action verbs / question markers too, otherwise those rooms
+// never see the reaction. CJK has no word boundaries, so these fragments match
+// as bare substrings; a lookbehind drops negated / already-done verbs ("不用处理",
+// "已经修复") so FYI suppression still works.
+const CJK_NEG = "不用|无需|不需要|不必|不想|暂不|先不|别|勿|没必要|已经|已|刚刚|刚|正在|正";
+const CJK_ACTION =
+  `(?<!${CJK_NEG})(?:请|麻烦|帮忙|帮我|帮个忙|处理|修复|修一下|改一下|改下|调整|看一下|看下|看看|瞧瞧|检查|确认|核对|核实|排查|调查|审查|审核|复核|评审|部署|发布|上线|重启|回滚|合并|推进|跟进|落实|执行|安排|搞定|搞一下|弄一下|验证|复现|定位|优化|解决)`;
+const CJK_QUESTION =
+  "吗|呢|嘛|是否|能否|可否|是不是|能不能|可不可以|行不行|怎么|怎样|咋办|如何|为什么|为何|啥|什么|多少|哪个|哪些|何时|多久";
+const CJK_FYI =
+  "仅供参考|供参考|仅参考|周知|知会|抄送|备忘|知悉即可|看到即可|仅通知|仅同步|仅周知|不用回复|无需回复|不用回|无需回|不用处理|无需处理|不需要处理";
+const FYI_MENTION_RE = new RegExp(
+  `\\b(?:fyi|for your awareness|for visibility|heads up|cc\\b|no[- ]action|no[- ]reply(?: needed)?|no[- ]response(?: needed)?|just sharing|just noting|ack only|context[- ]only)\\b|${CJK_FYI}`,
+  "i",
+);
+const STRONG_ACTION_MENTION_RE = new RegExp(
+  `\\b(?:can you|could you|would you|need you|take a look|review|fix|implement|publish|deploy|restart|verify|investigate|check|confirm|approve|blocker|blocked|error|failed|failure|incident|rollback|release|ship|merge)\\b|[?？]|${CJK_ACTION}|${CJK_QUESTION}`,
+  "i",
+);
+const ACTION_MENTION_RE = new RegExp(
+  `\\b(?:please|pls|can you|could you|would you|need you|take a look|review|fix|implement|publish|deploy|restart|verify|investigate|check|confirm|approve|blocker|blocked|error|failed|failure|incident|rollback|release|ship|merge)\\b|[?？]|${CJK_ACTION}|${CJK_QUESTION}`,
+  "i",
+);
 
 /**
  * Status reactions are visible room noise. Only show "replying" when a


### PR DESCRIPTION
## 问题

prod 环境核心团队群聊里,agent 回复时的 ⏳ "replying" 状态从 ~6-13 起不再显示。

## 根因

`b1de4de7f "Harden daemon room mention handling"`(2026-06-13)给 group 房间的 replying status reaction 加了门控 `shouldShowReplyingStatus()`,要求 `group + @mention + ACTION_MENTION_RE`。而 `ACTION_MENTION_RE` / `STRONG_ACTION_MENTION_RE` / `FYI_MENTION_RE` 是**纯英文关键词 + `?`/`？`**。

核心团队群是**中文**沟通,像 "什么结论了" / "帮忙改一下" 这类中文动作请求既无英文词也无问号 → 门控判 `false` → 静默跳过,不发 reaction。aws-vm(botcord-dev)的 daemon 在 6-13 更新到带此门控的版本后,中文群里 ⏳ 就"没了"。

> 基础设施侧已逐一排除:prod Redis 已配、Supabase realtime 授权 policy/函数都在、后端 `/status-reactions` 端点 + `human:hu_*` 广播完整、前端消费逻辑完好。坏的只有 daemon 这层门控。

## 修复

给三个正则补上 CJK 支持(中文无词边界,不用 `\b`):
- **动作词**:请/麻烦/帮忙/处理/修复/改一下/部署/发布/重启/排查/审核/推进/解决 …
- **问句**:吗/呢/是否/能否/能不能/怎么/如何/为什么/什么/多少/哪个 …
- **FYI/no-action**:仅供参考/周知/抄送/不用回复/无需处理 …
- 动作词加**否定/完成态前瞻**(不用/无需/已经/正在…),保留"中文 FYI 仍抑制 ⏳"的降噪语义,例如 "不用处理" / "已经修复了,周知" 不亮 ⏳。

## 测试

- 新增 `shouldShowReplyingStatus` 单元测试(英文动作 / 中文动作 / 中文 FYI / 非群聊)
- 全量 daemon 套件:**77 files / 1102 tests 通过**,`tsc` 干净

## 部署提醒

daemon 不会自更新自身。合并 + 发布新版后,需在 **aws-vm(botcord-dev)** 重装 daemon + 重启 `botcord-daemon.service` 才能在 prod 生效。

🤖 Generated with [Claude Code](https://claude.com/claude-code)