### PR TITLE
fix: accept daemon 30min replying TTL in status-reaction schema (422 → ⏳)

### DIFF
--- a/backend/hub/schemas.py
+++ b/backend/hub/schemas.py
@@ -832,7 +832,10 @@ class MessageStatusReactionRequest(BaseModel):
     kind: Literal["replying"] = "replying"
     emoji: str = Field(default="⏳", min_length=1, max_length=16)
     turn_id: str = Field(..., min_length=1, max_length=128)
-    ttl_sec: int = Field(default=180, ge=5, le=600)
+    # Upper bound must match MAX_STATUS_TTL_SECONDS in
+    # hub.services.message_status_reactions; the daemon sends 1800 (30min) for
+    # the "replying" backstop TTL, and a stricter cap here 422s every call.
+    ttl_sec: int = Field(default=180, ge=5, le=1800)
 
 
 class MessageStatusReactionClearRequest(BaseModel):

--- a/backend/tests/test_message_status_reactions.py
+++ b/backend/tests/test_message_status_reactions.py
@@ -1,6 +1,26 @@
 import pytest
+from pydantic import ValidationError
 
+from hub.schemas import MessageStatusReactionRequest
 from hub.services import message_status_reactions
+
+
+def test_request_schema_accepts_daemon_replying_ttl():
+    # The daemon (botcord.ts REPLYING_STATUS_TTL_SEC) sends 1800s for the
+    # "replying" backstop; the request schema must accept it or every
+    # status-reaction call 422s and the ⏳ indicator never appears.
+    req = MessageStatusReactionRequest(
+        room_id="rm_1", turn_id="turn_1", ttl_sec=1800
+    )
+    assert req.ttl_sec == 1800
+    assert req.ttl_sec <= message_status_reactions.MAX_STATUS_TTL_SECONDS
+
+    with pytest.raises(ValidationError):
+        MessageStatusReactionRequest(
+            room_id="rm_1",
+            turn_id="turn_1",
+            ttl_sec=message_status_reactions.MAX_STATUS_TTL_SECONDS + 1,
+        )
 
 
 class FakeRedis:


### PR DESCRIPTION
## 问题

prod 群聊里 agent 回复时的 ⏳ "replying" 状态从 ~6-10 起不再显示。

## 真正的根因(契约不一致)

| 端 | 值 |
|---|---|
| daemon `botcord.ts` `REPLYING_STATUS_TTL_SEC` | **1800**(6-10 `8c10e5db0` 提到 30min) |
| backend `MessageStatusReactionRequest.ttl_sec` | `Field(..., le=`**`600`**`)` |

daemon 每次 `phase="started"` 都发 `ttl_sec=1800`,后端 schema 上限 600 → **每次 `POST /hub/messages/{id}/status-reactions` 返回 422**,reaction 从不落地、不广播,前端永远看不到。

aws-vm daemon 日志实证(60+ 条):
```
[WARN] botcord message status non-ok phase="started" status=422
  body="...ttl_sec...Input should be less than or equal to 600...input:1800..."
```

后端 service 层(`message_status_reactions.py`)本身 `MAX_STATUS_TTL_SECONDS=1800` + `clamp_ttl` 就支持到 1800 —— **是请求 schema 比自己的存储层还严**,纯属漏改。

## 修复

- `schemas.py`:`ttl_sec` 上限 `600 → 1800`,对齐 `MAX_STATUS_TTL_SECONDS`。
- 加回归测试锁定 daemon↔backend 的 TTL 契约(schema 必须接受 1800,拒绝 >1800)。

## 与 #970(CJK 门控)的关系

#970 让中文 mention 能**通过门控去尝试调用**;本 PR 修的是调用**被后端拒掉**。两者叠加才能让中文群恢复 ⏳。

## 验证

`uv run pytest tests/test_message_status_reactions.py` → 4 passed。

## 部署

后端改动,需走 `Release` workflow(`source_branch=main`, `targets=backend`)重建 `:prod` 镜像并 rollout。

🤖 Generated with [Claude Code](https://claude.com/claude-code)