### PR TITLE
Fail fast on cloud agent owner-chat errors

### DIFF
--- a/backend/hub/routers/dashboard_chat.py
+++ b/backend/hub/routers/dashboard_chat.py
@@ -9,7 +9,8 @@ import logging
 import time
 import uuid
 
-from fastapi import APIRouter, Depends, Request
+import sentry_sdk
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
@@ -249,11 +250,27 @@ async def send_chat_message(
                 agent_id=agent_id,
             )
         except (CloudAgentError, ValueError) as exc:
+            code = getattr(exc, "code", "cloud_resume_failed")
+            message = (
+                "Cloud agent is still starting. Please retry in a moment."
+                if code == "not_ready"
+                else "Cloud agent is temporarily unavailable. Please retry in a moment."
+            )
             logger.warning(
-                "Dashboard chat cloud resume skipped: agent=%s err=%s",
+                "Dashboard chat cloud resume failed before enqueue: "
+                "agent=%s code=%s err=%s",
                 agent_id,
+                code,
                 exc,
             )
+            raise HTTPException(
+                status_code=getattr(exc, "http_status", 409),
+                detail={
+                    "code": code,
+                    "message": message,
+                    "retryable": True,
+                },
+            ) from exc
         except Exception as exc:  # noqa: BLE001
             logger.error(
                 "Dashboard chat cloud resume failed: agent=%s err=%s",
@@ -261,6 +278,19 @@ async def send_chat_message(
                 exc,
                 exc_info=True,
             )
+            with sentry_sdk.new_scope() as scope:
+                scope.set_tag("component", "dashboard_chat")
+                scope.set_tag("agent_id", agent_id)
+                scope.set_tag("dashboard_chat.error_code", "cloud_resume_failed")
+                sentry_sdk.capture_exception(exc)
+            raise HTTPException(
+                status_code=502,
+                detail={
+                    "code": "cloud_resume_failed",
+                    "message": "Cloud agent is temporarily unavailable. Please retry in a moment.",
+                    "retryable": True,
+                },
+            ) from exc
 
     # Ensure room exists
     room_id = await _ensure_owner_chat_room(db, user_id, agent_id, agent_display_name)

--- a/backend/hub/routers/owner_chat_ws.py
+++ b/backend/hub/routers/owner_chat_ws.py
@@ -37,7 +37,7 @@ from hub.routers.hub import (
     build_message_realtime_event,
     notify_inbox,
 )
-from hub.services.cloud_agent import resume_cloud_agent_for_inbox
+from hub.services.cloud_agent import CloudAgentError, resume_cloud_agent_for_inbox
 from hub.validators import normalize_file_url
 from hub import owner_chat_cache
 
@@ -80,6 +80,12 @@ def _oc_ws_connection_counts(key: tuple[str, str] | None = None) -> dict[str, in
     if key is not None:
         counts["pair_connections"] = len(_oc_ws_connections.get(key, set()))
     return counts
+
+
+def _owner_chat_cloud_error_message(code: str | None) -> str:
+    if code == "not_ready":
+        return "Cloud agent is still starting. Please retry in a moment."
+    return "Cloud agent is temporarily unavailable. Please retry in a moment."
 
 
 def _register_ws(user_id: str, agent_id: str, ws: WebSocket) -> None:
@@ -291,6 +297,53 @@ async def notify_oc_ws_message(
     # (no-op when Redis is disabled).
     for tid in traces_to_complete:
         await owner_chat_cache.mark_run_completed(tid, final_msg_id=hub_msg_id)
+
+
+async def notify_oc_ws_error(
+    *,
+    room_id: str,
+    hub_msg_id: str,
+    code: str,
+    message: str,
+    trace_id: str | None = None,
+    retryable: bool = True,
+    created_at: datetime.datetime | None = None,
+) -> None:
+    """Push a terminal owner-chat run error to connected clients.
+
+    ``hub_msg_id`` is the trigger message id. Clients use it to mark the
+    user turn failed and stop any local typing/streaming placeholder.
+    """
+    target_keys: list[tuple[str, str]] = []
+    for (uid, aid), ws_set in _oc_ws_connections.items():
+        if ws_set and _build_owner_chat_room_id(uid, aid) == room_id:
+            target_keys.append((uid, aid))
+
+    effective_trace_id = trace_id or hub_msg_id
+    ts = (
+        created_at.isoformat()
+        if created_at
+        else datetime.datetime.now(datetime.timezone.utc).isoformat()
+    )
+    frame = {
+        "type": "error",
+        "hub_msg_id": hub_msg_id,
+        "trace_id": effective_trace_id,
+        "room_id": room_id,
+        "message": message,
+        "created_at": ts,
+        "error": {
+            "code": code,
+            "message": message,
+            "retryable": retryable,
+        },
+    }
+
+    for uid, aid in target_keys:
+        await _send_to_oc_ws(uid, aid, frame)
+
+    await owner_chat_cache.mark_run_failed(effective_trace_id)
+    _cleanup_trace(effective_trace_id)
 
 
 async def notify_oc_ws_typing(*, agent_id: str, room_id: str) -> None:
@@ -564,7 +617,59 @@ async def owner_chat_ws(ws: WebSocket):
                         previews = await _load_reply_previews(db, {canonical_reply_msg_id})
                         reply_preview = previews.get(canonical_reply_msg_id)
 
-                    cloud_resume_ok = await resume_cloud_agent_for_inbox(db, agent_id)
+                    try:
+                        cloud_resume_ok = await resume_cloud_agent_for_inbox(
+                            db,
+                            agent_id,
+                            raise_on_error=True,
+                        )
+                    except CloudAgentError as exc:
+                        logger.warning(
+                            "Owner-chat cloud resume failed before enqueue: "
+                            "agent=%s code=%s err=%s",
+                            agent_id,
+                            exc.code,
+                            exc.message,
+                        )
+                        resume_err: dict[str, Any] = {
+                            "type": "error",
+                            "message": _owner_chat_cloud_error_message(exc.code),
+                            "error": {
+                                "code": exc.code,
+                                "message": _owner_chat_cloud_error_message(exc.code),
+                                "retryable": True,
+                            },
+                        }
+                        if client_msg_id:
+                            resume_err["client_msg_id"] = str(client_msg_id)[:64]
+                        await ws.send_json(resume_err)
+                        continue
+                    except Exception as exc:  # noqa: BLE001
+                        logger.error(
+                            "Owner-chat cloud resume crashed before enqueue: "
+                            "agent=%s err=%s",
+                            agent_id,
+                            exc,
+                            exc_info=True,
+                        )
+                        with sentry_sdk.new_scope() as scope:
+                            scope.set_tag("component", "owner_chat")
+                            scope.set_tag("agent_id", agent_id)
+                            scope.set_tag("owner_chat.error_code", "cloud_resume_failed")
+                            sentry_sdk.capture_exception(exc)
+                        resume_err = {
+                            "type": "error",
+                            "message": _owner_chat_cloud_error_message(None),
+                            "error": {
+                                "code": "cloud_resume_failed",
+                                "message": _owner_chat_cloud_error_message(None),
+                                "retryable": True,
+                            },
+                        }
+                        if client_msg_id:
+                            resume_err["client_msg_id"] = str(client_msg_id)[:64]
+                        await ws.send_json(resume_err)
+                        continue
 
                     # Create MessageRecord (same logic as dashboard_chat.send_chat_message)
                     msg_id = str(uuid.uuid4())

--- a/backend/hub/services/cloud_agent.py
+++ b/backend/hub/services/cloud_agent.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass
 import copy
 from typing import Any
 
+import sentry_sdk
 from nacl.signing import SigningKey as NaClSigningKey
 from sqlalchemy import func, or_, select, text as sa_text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -77,6 +78,10 @@ from hub.services.wallet import get_or_create_wallet
 from hub.services.new_api import NewApiError, NewApiService
 
 logger = logging.getLogger(__name__)
+
+_OWNER_CHAT_CLOUD_AGENT_RETRY_MESSAGE = (
+    "Cloud agent is temporarily unavailable. Please retry in a moment."
+)
 
 
 class CloudAgentError(Exception):
@@ -806,12 +811,13 @@ class CloudAgentService:
                 await db.refresh(cdi)
                 await db.refresh(agent)
                 return _make_view(agent, cai, cdi)
-            if not daemon_online:
-                _ensure_provisioning_metadata(db, cai, agent)
-                cai.status = "provisioning"
-                cai.error_code = None
-                cai.error_message = None
-                await db.commit()
+            _ensure_provisioning_metadata(db, cai, agent)
+            cai.status = "provisioning"
+            cai.error_code = None
+            cai.error_message = None
+            cdi.error_code = None
+            cdi.error_message = None
+            await db.commit()
             launch_token = _cloud_daemon_launch_token_for_start(cdi)
             handle = await provider.create_or_resume(
                 cloud_daemon_instance_id=cdi.id,
@@ -1334,6 +1340,93 @@ class CloudAgentService:
                 changed = True
         if changed:
             await db.commit()
+
+    async def _fail_pending_owner_chat_messages(
+        self,
+        db: AsyncSession,
+        *,
+        agent_id: str,
+        code: str,
+        internal_message: str,
+        public_message: str = _OWNER_CHAT_CLOUD_AGENT_RETRY_MESSAGE,
+    ) -> int:
+        """Fail active owner-chat turns and notify live owner-chat clients.
+
+        Owner-chat callers often wait synchronously on the WS for a terminal
+        frame. Leaving the trigger message queued after a cloud-agent lifecycle
+        failure makes those callers wait for their outer timeout instead of
+        retrying immediately.
+        """
+        records = (
+            await db.execute(
+                select(MessageRecord).where(
+                    MessageRecord.receiver_id == agent_id,
+                    MessageRecord.source_type == "dashboard_user_chat",
+                    MessageRecord.source_session_kind == "owner_chat",
+                    MessageRecord.state.in_(
+                        (MessageState.queued, MessageState.processing)
+                    ),
+                )
+            )
+        ).scalars().all()
+        if not records:
+            return 0
+
+        for record in records:
+            record.state = MessageState.failed
+            record.last_error = code
+        await db.flush()
+
+        from hub.routers.owner_chat_ws import notify_oc_ws_error
+
+        for record in records:
+            if not record.room_id:
+                continue
+            await notify_oc_ws_error(
+                room_id=record.room_id,
+                hub_msg_id=record.hub_msg_id,
+                trace_id=record.hub_msg_id,
+                code=code,
+                message=public_message,
+                retryable=True,
+            )
+
+        logger.warning(
+            "failed pending owner-chat messages for cloud agent: "
+            "agent=%s code=%s count=%d err=%s",
+            agent_id,
+            code,
+            len(records),
+            internal_message,
+        )
+        return len(records)
+
+    def _report_cloud_agent_terminal_error(
+        self,
+        *,
+        agent_id: str,
+        cloud_daemon_instance_id: str,
+        code: str,
+        message: str,
+    ) -> None:
+        with sentry_sdk.new_scope() as scope:
+            scope.set_tag("component", "cloud_agent")
+            scope.set_tag("cloud_agent.error_code", code)
+            scope.set_tag("agent_id", agent_id)
+            scope.set_tag("cloud_daemon_instance_id", cloud_daemon_instance_id)
+            scope.set_context(
+                "cloud_agent_failure",
+                {
+                    "agent_id": agent_id,
+                    "cloud_daemon_instance_id": cloud_daemon_instance_id,
+                    "code": code,
+                    "message": message,
+                },
+            )
+            sentry_sdk.capture_message(
+                "cloud agent terminal provisioning failure",
+                level="error",
+            )
 
     async def provision_pending_for_cloud_daemon(
         self,
@@ -1859,10 +1952,22 @@ class CloudAgentService:
         key_id = provisioning.get("key_id")
         public_key_b64 = provisioning.get("public_key_b64")
         if not private_key_b64 or not key_id:
+            code = "missing_credentials"
+            message = "cloud_agent_instances.metadata_json lacks provisioning credentials"
             cai.status = "failed"
-            cai.error_code = "missing_credentials"
-            cai.error_message = (
-                "cloud_agent_instances.metadata_json lacks provisioning credentials"
+            cai.error_code = code
+            cai.error_message = message
+            await self._fail_pending_owner_chat_messages(
+                db,
+                agent_id=cai.agent_id,
+                code=code,
+                internal_message=message,
+            )
+            self._report_cloud_agent_terminal_error(
+                agent_id=cai.agent_id,
+                cloud_daemon_instance_id=cdi.id,
+                code=code,
+                message=message,
             )
             await db.commit()
             return
@@ -1920,6 +2025,19 @@ class CloudAgentService:
             )
             cai.error_code = exc.code
             cai.error_message = exc.message
+            failed_count = await self._fail_pending_owner_chat_messages(
+                db,
+                agent_id=cai.agent_id,
+                code=exc.code,
+                internal_message=exc.message,
+            )
+            if failed_count:
+                self._report_cloud_agent_terminal_error(
+                    agent_id=cai.agent_id,
+                    cloud_daemon_instance_id=cdi.id,
+                    code=exc.code,
+                    message=exc.message,
+                )
             await db.commit()
             return
 
@@ -1927,6 +2045,19 @@ class CloudAgentService:
             err = ack.get("error") or {}
             cai.error_code = err.get("code") or "provision_rejected"
             cai.error_message = err.get("message") or "daemon rejected provision_agent"
+            failed_count = await self._fail_pending_owner_chat_messages(
+                db,
+                agent_id=cai.agent_id,
+                code=cai.error_code,
+                internal_message=cai.error_message,
+            )
+            if failed_count:
+                self._report_cloud_agent_terminal_error(
+                    agent_id=cai.agent_id,
+                    cloud_daemon_instance_id=cdi.id,
+                    code=cai.error_code,
+                    message=cai.error_message,
+                )
             await db.commit()
             return
 
@@ -2313,6 +2444,8 @@ async def _notify_inbox(agent_id: str, db: AsyncSession) -> int:
 async def resume_cloud_agent_for_inbox(
     db: AsyncSession,
     agent_id: str,
+    *,
+    raise_on_error: bool = False,
 ) -> bool:
     """Best-effort wakeup for a cloud-hosted agent with queued inbox work.
 
@@ -2324,6 +2457,8 @@ async def resume_cloud_agent_for_inbox(
         agent = await db.scalar(select(Agent).where(Agent.agent_id == agent_id))
     except Exception as exc:  # noqa: BLE001
         logger.debug("cloud inbox resume lookup failed: agent=%s err=%s", agent_id, exc)
+        if raise_on_error:
+            raise
         return False
 
     if agent is None or agent.hosting_kind != "cloud" or agent.user_id is None:
@@ -2343,6 +2478,8 @@ async def resume_cloud_agent_for_inbox(
             exc.code,
             exc.message,
         )
+        if raise_on_error:
+            raise
     except Exception as exc:  # noqa: BLE001
         logger.error(
             "cloud inbox resume failed: agent=%s err=%s",
@@ -2350,6 +2487,8 @@ async def resume_cloud_agent_for_inbox(
             exc,
             exc_info=True,
         )
+        if raise_on_error:
+            raise
     return False
 
 

--- a/backend/tests/test_cloud_agent_provisioning.py
+++ b/backend/tests/test_cloud_agent_provisioning.py
@@ -18,12 +18,13 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 import hub.services.cloud_agent as cloud_agent_module
-from hub.enums import AttentionMode
+from hub.enums import AttentionMode, MessageState
 from hub.models import (
     Agent,
     Base,
     CloudAgentInstance,
     CloudDaemonInstance,
+    MessageRecord,
 )
 from hub.routers.cloud_daemon_control import (
     CloudDaemonDispatchError,
@@ -470,6 +471,64 @@ async def test_resume_ready_agent_offline_rotates_key_for_reprovision(db_session
 
 
 @pytest.mark.asyncio
+async def test_resume_paused_agent_with_stale_online_conn_rotates_key(
+    db_session,
+):
+    client = FakeE2BSandboxClient()
+    service = _make_e2b_service(client=client)
+    user_id = uuid.uuid4()
+    view = await service.create_cloud_agent(
+        db_session, user_id=user_id, body=CreateCloudAgentInput(name="A")
+    )
+
+    conn, ws = await _register_fake_conn(
+        view.cloud_daemon_instance_id, "dm_stale_online"
+    )
+    try:
+        t = asyncio.create_task(
+            _ack_frame_when_sent(conn, ws, expected_type="provision_agent")
+        )
+        await service.provision_pending_for_cloud_daemon(
+            db_session, cloud_daemon_instance_id=view.cloud_daemon_instance_id
+        )
+        await t
+
+        cai = await db_session.scalar(
+            select(CloudAgentInstance).where(
+                CloudAgentInstance.agent_id == view.agent_id
+            )
+        )
+        cdi = await db_session.scalar(
+            select(CloudDaemonInstance).where(
+                CloudDaemonInstance.id == view.cloud_daemon_instance_id
+            )
+        )
+        assert cai is not None
+        assert cdi is not None
+        assert "provisioning" not in (cai.metadata_json or {})
+
+        # Simulate an idle-paused sandbox while the old control WS is still
+        # registered. This used to skip _ensure_provisioning_metadata because
+        # daemon_online=True, then fail as missing_credentials on replay.
+        cai.status = "paused"
+        cdi.status = "paused"
+        await db_session.commit()
+
+        resumed = await service.resume_cloud_agent(
+            db_session, user_id=user_id, agent_id=view.agent_id
+        )
+
+        assert resumed.status == "provisioning"
+        await db_session.refresh(cai)
+        provisioning = (cai.metadata_json or {}).get("provisioning")
+        assert provisioning["private_key_b64"]
+        assert provisioning["public_key_b64"]
+        assert provisioning["key_id"]
+    finally:
+        await _registry_for_tests().unregister(conn)
+
+
+@pytest.mark.asyncio
 async def test_resume_while_starting_reuses_inflight_start(db_session):
     client = FakeE2BSandboxClient()
     service = _make_e2b_service(client=client)
@@ -530,6 +589,90 @@ async def test_provision_dispatch_offline_records_error(db_session):
     )
     assert refreshed.status == "provisioning"
     assert refreshed.error_code == "cloud_daemon_offline"
+
+
+@pytest.mark.asyncio
+async def test_missing_credentials_fails_pending_owner_chat_and_reports(
+    db_session,
+    monkeypatch,
+):
+    service = _make_e2b_service()
+    user_id = uuid.uuid4()
+    view = await service.create_cloud_agent(
+        db_session, user_id=user_id, body=CreateCloudAgentInput(name="A")
+    )
+
+    row = (
+        await db_session.execute(
+            select(CloudAgentInstance, Agent, CloudDaemonInstance)
+            .join(Agent, Agent.agent_id == CloudAgentInstance.agent_id)
+            .join(
+                CloudDaemonInstance,
+                CloudDaemonInstance.id == CloudAgentInstance.cloud_daemon_instance_id,
+            )
+            .where(CloudAgentInstance.agent_id == view.agent_id)
+        )
+    ).one()
+    cai, agent, cdi = row
+    cai.status = "ready"
+    cai.metadata_json = {}
+    record = MessageRecord(
+        hub_msg_id="h_owner_missing_credentials",
+        msg_id=str(uuid.uuid4()),
+        sender_id=view.agent_id,
+        receiver_id=view.agent_id,
+        room_id="rm_oc_missing_credentials",
+        state=MessageState.queued,
+        envelope_json=json.dumps(
+            {
+                "type": "message",
+                "payload": {"text": "hello"},
+            }
+        ),
+        ttl_sec=3600,
+        mentioned=True,
+        source_type="dashboard_user_chat",
+        source_session_kind="owner_chat",
+    )
+    db_session.add(record)
+    await db_session.commit()
+
+    from hub.routers import owner_chat_ws
+
+    sent_errors: list[dict] = []
+    captured: list[tuple[str, str]] = []
+
+    async def _fake_notify_oc_ws_error(**kwargs):
+        sent_errors.append(kwargs)
+
+    monkeypatch.setattr(owner_chat_ws, "notify_oc_ws_error", _fake_notify_oc_ws_error)
+    monkeypatch.setattr(
+        cloud_agent_module.sentry_sdk,
+        "capture_message",
+        lambda message, level=None: captured.append((message, level)),
+    )
+
+    await service._provision_one(db_session, cai, agent, cdi)
+
+    await db_session.refresh(cai)
+    await db_session.refresh(record)
+    assert cai.status == "failed"
+    assert cai.error_code == "missing_credentials"
+    assert record.state == MessageState.failed
+    assert record.last_error == "missing_credentials"
+    assert sent_errors == [
+        {
+            "room_id": "rm_oc_missing_credentials",
+            "hub_msg_id": "h_owner_missing_credentials",
+            "trace_id": "h_owner_missing_credentials",
+            "code": "missing_credentials",
+            "message": "Cloud agent is temporarily unavailable. Please retry in a moment.",
+            "retryable": True,
+        }
+    ]
+    assert captured == [
+        ("cloud agent terminal provisioning failure", "error")
+    ]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_owner_chat_trace_binding.py
+++ b/backend/tests/test_owner_chat_trace_binding.py
@@ -120,5 +120,60 @@ async def test_legacy_no_trace_id_falls_back_to_most_recent(
         owner_chat_ws._cleanup_trace(newer)
 
 
+@pytest.mark.asyncio
+async def test_error_frame_fails_explicit_trace_and_preserves_shape(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    user_id = "u_error"
+    agent_id = "ag_error"
+    room_id = owner_chat_ws._build_owner_chat_room_id(user_id, agent_id)
+    trace_id = "h_trigger_error"
+    owner_chat_ws._oc_trace_subs[trace_id] = (user_id, agent_id)
+    owner_chat_ws._oc_trace_block_count[trace_id] = 3
+
+    ws = _FakeWS()
+    owner_chat_ws._oc_ws_connections[(user_id, agent_id)] = {ws}
+
+    failed: list[str] = []
+
+    async def _fake_mark_failed(tid: str) -> None:
+        failed.append(tid)
+
+    monkeypatch.setattr(
+        owner_chat_ws.owner_chat_cache, "mark_run_failed", _fake_mark_failed
+    )
+
+    try:
+        await owner_chat_ws.notify_oc_ws_error(
+            room_id=room_id,
+            hub_msg_id=trace_id,
+            trace_id=trace_id,
+            code="missing_credentials",
+            message="Cloud agent is temporarily unavailable. Please retry in a moment.",
+        )
+
+        assert ws.sent == [
+            {
+                "type": "error",
+                "hub_msg_id": trace_id,
+                "trace_id": trace_id,
+                "room_id": room_id,
+                "message": "Cloud agent is temporarily unavailable. Please retry in a moment.",
+                "created_at": ws.sent[0]["created_at"],
+                "error": {
+                    "code": "missing_credentials",
+                    "message": "Cloud agent is temporarily unavailable. Please retry in a moment.",
+                    "retryable": True,
+                },
+            }
+        ]
+        assert failed == [trace_id]
+        assert trace_id not in owner_chat_ws._oc_trace_subs
+        assert trace_id not in owner_chat_ws._oc_trace_block_count
+    finally:
+        owner_chat_ws._oc_ws_connections.pop((user_id, agent_id), None)
+        owner_chat_ws._cleanup_trace(trace_id)
+
+
 async def _noop() -> None:
     return None

--- a/frontend/src/hooks/useOwnerChatWs.ts
+++ b/frontend/src/hooks/useOwnerChatWs.ts
@@ -160,6 +160,16 @@ export function useOwnerChatWs({
         store.getState().upsertMessage(notifMsg);
       },
 
+      onRunFailed: (err) => {
+        store.getState().failRun({
+          hubMsgId: err.hub_msg_id ?? null,
+          traceId: err.trace_id ?? err.hub_msg_id ?? null,
+          error: err.error?.message || err.message || "Cloud agent is temporarily unavailable. Please retry in a moment.",
+          code: err.error?.code || null,
+          createdAt: err.created_at || null,
+        });
+      },
+
       onStatusChange: (connected) => {
         if (connected) {
           store.getState().setWsConnected(true);

--- a/frontend/src/lib/api.remove-member.test.ts
+++ b/frontend/src/lib/api.remove-member.test.ts
@@ -65,4 +65,27 @@ describe("humansApi.removeRoomMember", () => {
     const { humansApi, ApiError } = await import("./api");
     await expect(humansApi.removeRoomMember("rm_x", "hu_x")).rejects.toBeInstanceOf(ApiError);
   });
+
+  it("surfaces structured FastAPI detail.message responses", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          detail: {
+            code: "cloud_resume_failed",
+            message: "Cloud agent is temporarily unavailable. Please retry in a moment.",
+            retryable: true,
+          },
+        }),
+        {
+          status: 409,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+
+    const { api } = await import("./api");
+    await expect(api.sendUserChatMessage("hello", undefined, "ag_cloud")).rejects.toThrow(
+      "Cloud agent is temporarily unavailable. Please retry in a moment.",
+    );
+  });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -171,6 +171,10 @@ function extractErrorMessage(body: Record<string, unknown>, fallback: string): s
   if (typeof body.error === "string") return body.error;
   const detail = body.detail;
   if (typeof detail === "string") return detail;
+  if (detail && typeof detail === "object" && !Array.isArray(detail)) {
+    const message = (detail as { message?: unknown }).message;
+    if (typeof message === "string") return message;
+  }
   if (Array.isArray(detail)) {
     return detail.map((d: { msg?: string }) => d.msg ?? JSON.stringify(d)).join("; ");
   }

--- a/frontend/src/lib/owner-chat-ws.ts
+++ b/frontend/src/lib/owner-chat-ws.ts
@@ -3,7 +3,7 @@
  * Connects to Hub's /dashboard/chat/ws for real-time messaging
  * and execution block streaming.
  */
-import type { OwnerChatWsMessage, OwnerChatNotification, StreamBlockEntry } from "./types";
+import type { OwnerChatWsError, OwnerChatWsMessage, OwnerChatNotification, StreamBlockEntry } from "./types";
 
 export interface OwnerChatWsOptions {
   hubBaseUrl: string;
@@ -13,6 +13,7 @@ export interface OwnerChatWsOptions {
   onStreamBlock: (block: StreamBlockEntry) => void;
   onTyping?: () => void;
   onNotification?: (notif: OwnerChatNotification) => void;
+  onRunFailed?: (error: OwnerChatWsError) => void;
   onAuthOk: (data: { agent_id: string; room_id: string }) => void;
   onStatusChange?: (connected: boolean) => void;
   onSendFailed?: (text: string, clientMsgId?: string) => void;
@@ -118,8 +119,12 @@ export function createOwnerChatWs(opts: OwnerChatWsOptions): OwnerChatWsClient {
 
           case "error":
             console.warn("[owner-chat-ws] Server error:", data.message);
-            // Server rejected a send — notify caller so pending msg can be marked failed
-            opts.onSendFailed?.(data.message || "Server error", data.client_msg_id);
+            if (data.hub_msg_id || data.trace_id) {
+              opts.onRunFailed?.(data as OwnerChatWsError);
+            } else {
+              // Server rejected a send — notify caller so pending msg can be marked failed
+              opts.onSendFailed?.(data.message || "Server error", data.client_msg_id);
+            }
             break;
         }
       };

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -330,6 +330,7 @@ export function dashboardMsgToOwnerChat(
   agentName: string,
 ): OwnerChatMessage {
   const isUser = msg.source_type === "dashboard_user_chat";
+  const failedUserMessage = isUser && msg.state === "failed";
   return {
     clientId: msg.hub_msg_id,
     hubMsgId: msg.hub_msg_id,
@@ -338,7 +339,8 @@ export function dashboardMsgToOwnerChat(
     payload: msg.payload,
     attachments: (msg.payload?.attachments as Attachment[] | undefined) ?? undefined,
     streamBlocks: [],
-    status: "delivered",
+    status: failedUserMessage ? "failed" : "delivered",
+    error: failedUserMessage ? "Cloud agent is temporarily unavailable. Please retry in a moment." : undefined,
     createdAt: msg.created_at,
     senderName: isUser ? "You" : (msg.sender_name || agentName),
     type:
@@ -348,6 +350,7 @@ export function dashboardMsgToOwnerChat(
           ? "error"
           : "message",
     traceId: !isUser ? dashboardMessageTraceId(msg) : undefined,
+    sendText: failedUserMessage ? msg.text || "" : undefined,
     replyPreview: msg.reply_preview ?? undefined,
   };
 }
@@ -360,6 +363,21 @@ export interface OwnerChatWsMessage {
   text: string;
   created_at: string;
   ext?: Record<string, unknown>;
+}
+
+export interface OwnerChatWsError {
+  type: "error";
+  message: string;
+  hub_msg_id?: string;
+  trace_id?: string;
+  room_id?: string;
+  client_msg_id?: string;
+  created_at?: string;
+  error?: {
+    code?: string;
+    message?: string;
+    retryable?: boolean;
+  };
 }
 
 export interface OwnerChatNotification {

--- a/frontend/src/store/useOwnerChatStore.test.ts
+++ b/frontend/src/store/useOwnerChatStore.test.ts
@@ -212,6 +212,59 @@ describe("useOwnerChatStore empty message handling", () => {
   });
 });
 
+describe("useOwnerChatStore run failure handling", () => {
+  beforeEach(() => {
+    useOwnerChatStore.getState().reset();
+    useDashboardChatStore.setState({
+      ownedAgentRooms: [makeOwnedAgentRoom()],
+      optimisticOwnerChatRooms: {},
+    });
+    useOwnerChatStore.getState().setRoom("rm_oc_real", "Owned bot");
+  });
+
+  it("marks the trigger message failed and appends an agent error", () => {
+    useOwnerChatStore.getState().addOptimistic(makeOwnerChatMessage({
+      clientId: "client_turn",
+      text: "hello",
+    }));
+    useOwnerChatStore.getState().confirmOptimistic(
+      "client_turn",
+      "h_turn",
+      "2026-05-19T09:00:01.000Z",
+    );
+
+    useOwnerChatStore.getState().failRun({
+      hubMsgId: "h_turn",
+      traceId: "h_turn",
+      error: "Cloud agent is temporarily unavailable. Please retry in a moment.",
+      code: "missing_credentials",
+      createdAt: "2026-05-19T09:00:02.000Z",
+    });
+
+    expect(useOwnerChatStore.getState().messages).toMatchObject([
+      {
+        clientId: "client_turn",
+        hubMsgId: "h_turn",
+        status: "failed",
+        error: "Cloud agent is temporarily unavailable. Please retry in a moment.",
+        sendText: "hello",
+      },
+      {
+        clientId: "err_h_turn",
+        type: "error",
+        sender: "agent",
+        text: "Cloud agent is temporarily unavailable. Please retry in a moment.",
+        payload: {
+          error: {
+            code: "missing_credentials",
+            retryable: true,
+          },
+        },
+      },
+    ]);
+  });
+});
+
 describe("useOwnerChatStore stream terminal handling", () => {
   beforeEach(() => {
     mocks.getRoomMessages.mockReset();
@@ -280,6 +333,31 @@ describe("useOwnerChatStore stream terminal handling", () => {
       status: "delivered",
       streamBlocks: [{ block: { kind: "other" } }],
     });
+  });
+
+  it("drops a streaming placeholder when the run fails", () => {
+    useOwnerChatStore.setState({ agentTyping: true, activeTraceId: "msg_trace" });
+    useOwnerChatStore.getState().appendStreamBlock({
+      trace_id: "msg_trace",
+      seq: 1,
+      created_at: "2026-05-19T09:00:00.000Z",
+      block: { kind: "thinking", payload: { phase: "updated", label: "Thinking" } },
+    });
+
+    useOwnerChatStore.getState().failRun({
+      hubMsgId: "msg_trace",
+      traceId: "msg_trace",
+      error: "Cloud agent is temporarily unavailable. Please retry in a moment.",
+    });
+
+    expect(useOwnerChatStore.getState().messages).toMatchObject([
+      {
+        clientId: "err_msg_trace",
+        type: "error",
+      },
+    ]);
+    expect(useOwnerChatStore.getState().agentTyping).toBe(false);
+    expect(useOwnerChatStore.getState().activeTraceId).toBeNull();
   });
 
   it("merges a traced API final message into an existing stream placeholder", () => {

--- a/frontend/src/store/useOwnerChatStore.ts
+++ b/frontend/src/store/useOwnerChatStore.ts
@@ -198,6 +198,13 @@ export interface OwnerChatState {
   addOptimistic: (msg: OwnerChatMessage) => void;
   confirmOptimistic: (clientId: string, hubMsgId: string, createdAt: string, attachments?: Attachment[]) => void;
   failOptimistic: (clientId: string, error: string) => void;
+  failRun: (input: {
+    hubMsgId?: string | null;
+    traceId?: string | null;
+    error: string;
+    code?: string | null;
+    createdAt?: string | null;
+  }) => void;
   resetForRetry: (clientId: string) => void;
 
   // Server-delivered messages
@@ -403,6 +410,55 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
           : m
       ),
     })),
+
+  failRun: ({ hubMsgId, traceId, error, code, createdAt }) => {
+    const errorId = `err_${traceId || hubMsgId || Date.now()}`;
+    set((state) => {
+      let hasErrorMessage = false;
+      const messages = state.messages
+        .map((m) => {
+          if (m.clientId === errorId) hasErrorMessage = true;
+          if (hubMsgId && m.sender === "user" && m.hubMsgId === hubMsgId) {
+            return {
+              ...m,
+              status: "failed" as const,
+              error,
+              sendText: m.sendText ?? m.text,
+            };
+          }
+          return m;
+        })
+        .filter((m) => !(traceId && m.status === "streaming" && m.traceId === traceId));
+
+      if (!hasErrorMessage) {
+        messages.push({
+          clientId: errorId,
+          hubMsgId: errorId,
+          sender: "agent",
+          text: error,
+          payload: {
+            error: {
+              code: code || "cloud_agent_unavailable",
+              message: error,
+              retryable: true,
+            },
+          },
+          streamBlocks: [],
+          status: "delivered",
+          createdAt: createdAt || new Date().toISOString(),
+          senderName: state.agentName,
+          type: "error",
+          traceId: traceId || undefined,
+        });
+      }
+
+      return {
+        messages,
+        agentTyping: false,
+        activeTraceId: state.activeTraceId === traceId ? null : state.activeTraceId,
+      };
+    });
+  },
 
   resetForRetry: (clientId) =>
     set((state) => ({


### PR DESCRIPTION
## Summary
- Regenerate provisioning credentials when resuming a paused cloud daemon even if a stale control WS still appears online.
- Convert terminal cloud-agent provisioning failures into failed owner-chat turns, retryable WS error frames, and Sentry reports.
- Fail owner-chat WS/REST sends before enqueue when cloud resume fails, and preserve frontend retry state/error messages.

## Verification
- `uv run pytest tests/test_cloud_agent_provisioning.py tests/test_owner_chat_trace_binding.py`
- `pnpm test -- useOwnerChatStore.test.ts api.remove-member.test.ts`
- `uv run python -m compileall hub/services/cloud_agent.py hub/routers/dashboard_chat.py hub/routers/owner_chat_ws.py`
- `git diff --check`

## Risk / rollout
- Owner-chat cloud-agent lifecycle errors now surface immediately instead of leaving queued turns to timeout.
- Frontend receives sanitized retryable messages; Sentry captures backend details for terminal failures.