### PR TITLE
fix: retry runtime files startup ack timeout

### DIFF
--- a/backend/app/routers/runtime_files.py
+++ b/backend/app/routers/runtime_files.py
@@ -36,6 +36,7 @@ router = APIRouter(prefix="/api/agents", tags=["app-runtime-files"])
 
 _CLOUD_RUNTIME_FILES_RESUME_WAIT_SECONDS = 20.0
 _CLOUD_RUNTIME_FILES_RESUME_POLL_SECONDS = 0.5
+_RUNTIME_FILES_DISPATCH_TIMEOUT_MS = 5000
 _CLOUD_RUNTIME_FILES_DISPATCH_RETRY_CODES = {
     "cloud_daemon_offline",
     "cloud_daemon_disconnected",
@@ -128,7 +129,7 @@ async def _send_runtime_files_control_frame(
                 host.cloud_daemon_instance_id,
                 "list_agent_files",
                 params,
-                timeout_ms=5000,
+                timeout_ms=_RUNTIME_FILES_DISPATCH_TIMEOUT_MS,
             )
         except CloudDaemonDispatchError as exc:
             if exc.code in _CLOUD_RUNTIME_FILES_DISPATCH_RETRY_CODES:
@@ -152,7 +153,26 @@ async def _send_runtime_files_control_frame(
                         host.cloud_daemon_instance_id,
                         "list_agent_files",
                         params,
-                        timeout_ms=5000,
+                        timeout_ms=_RUNTIME_FILES_DISPATCH_TIMEOUT_MS,
+                    )
+                except CloudDaemonDispatchError as retry_exc:
+                    exc = retry_exc
+            elif exc.code == "cloud_daemon_ack_timeout":
+                logger.warning(
+                    "cloud runtime files daemon ack timed out during startup; "
+                    "retrying once: agent=%s daemon=%s cloud=%s frame=%s timeout_ms=%s",
+                    agent.agent_id,
+                    host.daemon_instance_id,
+                    host.cloud_daemon_instance_id,
+                    "list_agent_files",
+                    _RUNTIME_FILES_DISPATCH_TIMEOUT_MS,
+                )
+                try:
+                    return await send_cloud_control_frame(
+                        host.cloud_daemon_instance_id,
+                        "list_agent_files",
+                        params,
+                        timeout_ms=_RUNTIME_FILES_DISPATCH_TIMEOUT_MS,
                     )
                 except CloudDaemonDispatchError as retry_exc:
                     exc = retry_exc
@@ -170,7 +190,7 @@ async def _send_runtime_files_control_frame(
                     host.daemon_instance_id,
                     host.cloud_daemon_instance_id,
                     "list_agent_files",
-                    5000,
+                    _RUNTIME_FILES_DISPATCH_TIMEOUT_MS,
                 )
                 raise HTTPException(status_code=504, detail="daemon_ack_timeout") from exc
             raise HTTPException(
@@ -185,7 +205,7 @@ async def _send_runtime_files_control_frame(
             host.daemon_instance_id,
             "list_agent_files",
             params,
-            timeout_ms=5000,
+            timeout_ms=_RUNTIME_FILES_DISPATCH_TIMEOUT_MS,
         )
     except HTTPException as exc:
         if exc.status_code == 504 and exc.detail == "daemon_ack_timeout":
@@ -196,7 +216,7 @@ async def _send_runtime_files_control_frame(
                 host.daemon_instance_id,
                 host.cloud_daemon_instance_id,
                 "list_agent_files",
-                5000,
+                _RUNTIME_FILES_DISPATCH_TIMEOUT_MS,
             )
         raise
 

--- a/backend/tests/test_app/test_app_policy.py
+++ b/backend/tests/test_app/test_app_policy.py
@@ -854,6 +854,185 @@ async def test_runtime_files_for_cloud_agent_retries_after_missing_credentials_a
 
 
 @pytest.mark.asyncio
+async def test_runtime_files_for_cloud_agent_retries_after_initial_ack_timeout(
+    client, seed, db_session, monkeypatch
+):
+    from app.routers import runtime_files as runtime_files_mod
+
+    row = await db_session.execute(select(Agent).where(Agent.agent_id == "ag_owned"))
+    agent = row.scalar_one()
+    agent.hosting_kind = "cloud"
+    agent.daemon_instance_id = "dm_cloud_timeout_retry_files"
+    agent.runtime = "codex"
+    daemon = DaemonInstance(
+        id="dm_cloud_timeout_retry_files",
+        user_id=agent.user_id,
+        kind="cloud",
+        refresh_token_hash="hash",
+    )
+    cloud_daemon = CloudDaemonInstance(
+        id="cloud_dm_timeout_retry_files",
+        user_id=agent.user_id,
+        daemon_instance_id=daemon.id,
+        provider="e2b",
+        status="ready",
+        runtime="codex",
+        max_agents=1,
+        active_agent_count=1,
+    )
+    cloud_binding = CloudAgentInstance(
+        id="cloud_ag_timeout_retry_files",
+        user_id=agent.user_id,
+        agent_id=agent.agent_id,
+        cloud_daemon_instance_id=cloud_daemon.id,
+        daemon_instance_id=daemon.id,
+        runtime="codex",
+        model_profile="default",
+        status="ready",
+    )
+    db_session.add_all([daemon, cloud_daemon, cloud_binding])
+    await db_session.commit()
+
+    monkeypatch.setattr(runtime_files_mod, "is_cloud_daemon_online", lambda _id: True)
+
+    resume_calls = []
+
+    class FakeCloudAgentService:
+        async def resume_cloud_agent(self, db, *, user_id, agent_id):
+            resume_calls.append({"user_id": user_id, "agent_id": agent_id})
+            return None
+
+    monkeypatch.setattr(runtime_files_mod, "CloudAgentService", FakeCloudAgentService)
+
+    dispatch_calls = []
+
+    async def fake_send_cloud(cloud_daemon_instance_id, type_, params=None, timeout_ms=None):
+        dispatch_calls.append({
+            "cloud_daemon_instance_id": cloud_daemon_instance_id,
+            "type": type_,
+            "params": params,
+            "timeout_ms": timeout_ms,
+        })
+        if len(dispatch_calls) == 1:
+            raise runtime_files_mod.CloudDaemonDispatchError(
+                "cloud_daemon_ack_timeout",
+                "ack timeout after 5000ms",
+            )
+        return {
+            "ok": True,
+            "result": {
+                "agentId": "ag_owned",
+                "runtime": "codex",
+                "files": [
+                    {
+                        "id": "workspace:AGENTS.md",
+                        "name": "workspace/AGENTS.md",
+                        "scope": "workspace",
+                        "content": "# rules\n",
+                    }
+                ],
+            },
+        }
+
+    monkeypatch.setattr(runtime_files_mod, "send_cloud_control_frame", fake_send_cloud)
+
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    r = await client.get("/api/agents/ag_owned/runtime-files", headers=headers)
+    assert r.status_code == 200, r.text
+    assert r.json()["files"][0]["content"] == "# rules\n"
+    assert resume_calls == []
+    assert dispatch_calls == [
+        {
+            "cloud_daemon_instance_id": "cloud_dm_timeout_retry_files",
+            "type": "list_agent_files",
+            "params": {"agentId": "ag_owned"},
+            "timeout_ms": 5000,
+        },
+        {
+            "cloud_daemon_instance_id": "cloud_dm_timeout_retry_files",
+            "type": "list_agent_files",
+            "params": {"agentId": "ag_owned"},
+            "timeout_ms": 5000,
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_runtime_files_for_cloud_agent_keeps_504_after_persistent_ack_timeout(
+    client, seed, db_session, monkeypatch
+):
+    from app.routers import runtime_files as runtime_files_mod
+
+    row = await db_session.execute(select(Agent).where(Agent.agent_id == "ag_owned"))
+    agent = row.scalar_one()
+    agent.hosting_kind = "cloud"
+    agent.daemon_instance_id = "dm_cloud_timeout_files"
+    agent.runtime = "codex"
+    daemon = DaemonInstance(
+        id="dm_cloud_timeout_files",
+        user_id=agent.user_id,
+        kind="cloud",
+        refresh_token_hash="hash",
+    )
+    cloud_daemon = CloudDaemonInstance(
+        id="cloud_dm_timeout_files",
+        user_id=agent.user_id,
+        daemon_instance_id=daemon.id,
+        provider="e2b",
+        status="ready",
+        runtime="codex",
+        max_agents=1,
+        active_agent_count=1,
+    )
+    cloud_binding = CloudAgentInstance(
+        id="cloud_ag_timeout_files",
+        user_id=agent.user_id,
+        agent_id=agent.agent_id,
+        cloud_daemon_instance_id=cloud_daemon.id,
+        daemon_instance_id=daemon.id,
+        runtime="codex",
+        model_profile="default",
+        status="ready",
+    )
+    db_session.add_all([daemon, cloud_daemon, cloud_binding])
+    await db_session.commit()
+
+    monkeypatch.setattr(runtime_files_mod, "is_cloud_daemon_online", lambda _id: True)
+
+    resume_calls = []
+
+    class FakeCloudAgentService:
+        async def resume_cloud_agent(self, db, *, user_id, agent_id):
+            resume_calls.append({"user_id": user_id, "agent_id": agent_id})
+            return None
+
+    monkeypatch.setattr(runtime_files_mod, "CloudAgentService", FakeCloudAgentService)
+
+    dispatch_calls = []
+
+    async def fake_send_cloud(cloud_daemon_instance_id, type_, params=None, timeout_ms=None):
+        dispatch_calls.append({
+            "cloud_daemon_instance_id": cloud_daemon_instance_id,
+            "type": type_,
+            "params": params,
+            "timeout_ms": timeout_ms,
+        })
+        raise runtime_files_mod.CloudDaemonDispatchError(
+            "cloud_daemon_ack_timeout",
+            "ack timeout after 5000ms",
+        )
+
+    monkeypatch.setattr(runtime_files_mod, "send_cloud_control_frame", fake_send_cloud)
+
+    headers = {"Authorization": f"Bearer {seed['token']}"}
+    r = await client.get("/api/agents/ag_owned/runtime-files", headers=headers)
+    assert r.status_code == 504, r.text
+    assert r.json()["detail"] == "daemon_ack_timeout"
+    assert resume_calls == []
+    assert len(dispatch_calls) == 2
+
+
+@pytest.mark.asyncio
 async def test_runtime_files_rejects_unowned_or_offline_agent(
     client, seed, db_session, monkeypatch
 ):


### PR DESCRIPTION
## Description

Hardens BOTCORD-BACKEND-2K runtime-files startup readiness for the preview startup/lifecycle ack race. The cloud daemon can accept the WebSocket before the hosted agent finishes registering, causing the first `list_agent_files` call to return `cloud_daemon_ack_timeout`/504 even though a retry shortly after succeeds.

This change adds a narrow cloud-only single retry for the initial runtime files list path and preserves persistent gateway timeout behavior.

## Changed Files

- `backend/app/routers/runtime_files.py`
- `backend/tests/test_app/test_app_policy.py`

## Testing / Review

- `cd backend && uv run pytest tests/test_app/test_app_policy.py -q` -> 30 passed
- Code Reviewer `ag_db82c61581a2` reported no blocking findings in BotCord topic `tp_7fe208763ae7`
- GitHub checks before merge: Vercel pass; Vercel Preview Comments pass

## Runtime / Deploy Impact

No deploy, restart, kubectl/cloud/secret operation, preview/prod runtime mutation, or runtime repair was performed as part of this PR.