### PR TITLE
fix: include botlearn origins in CORS

### DIFF
--- a/backend/hub/main.py
+++ b/backend/hub/main.py
@@ -190,14 +190,21 @@ if hub_config.SENTRY_DSN:
 
 app = FastAPI(title="BotCord Hub", version="1.0.1", lifespan=lifespan)
 
-_cors_origins = [
-    "http://localhost:4321",
-    "http://localhost:3000",
-    "https://botcord.vercel.app",
-    "https://preview.botcord.chat",
-    "https://botcord.chat",
-    "https://www.botcord.chat",
-]
+
+def _build_cors_origins(extra_origins: list[str]) -> list[str]:
+    origins = [
+        "http://localhost:4321",
+        "http://localhost:3000",
+        "https://botcord.vercel.app",
+        "https://preview.botcord.chat",
+        "https://botcord.chat",
+        "https://www.botcord.chat",
+        *(origin.strip().rstrip("/") for origin in extra_origins if origin.strip()),
+    ]
+    return list(dict.fromkeys(origins))
+
+
+_cors_origins = _build_cors_origins(hub_config.BOTLEARN_ALLOWED_ORIGINS)
 
 # Browsers treat http://localhost:P1 → http://localhost:P2 as cross-origin when P1 ≠ P2.
 # With allow_credentials=True, the reflected Origin must match exactly; a regex covers any

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -31,3 +31,14 @@ async def test_deployed_frontend_origins_pass_preflight(origin: str):
     assert res.headers["access-control-allow-origin"] == origin
     assert "authorization" in res.headers["access-control-allow-headers"].lower()
     assert "x-active-agent" in res.headers["access-control-allow-headers"].lower()
+
+
+def test_botlearn_allowed_origins_are_included_in_global_cors():
+    from hub.main import _build_cors_origins
+
+    origin = "https://app.botlearn-course.test.rd.ai"
+    origins = _build_cors_origins([f"{origin}/", ""])
+
+    assert origin in origins
+    assert f"{origin}/" not in origins
+    assert origins.count(origin) == 1


### PR DESCRIPTION
## Summary
- include BOTLEARN_ALLOWED_ORIGINS in BotCord Hub global CORS middleware
- normalize and dedupe extra origins before passing them to CORSMiddleware
- add regression coverage for the botlearn-course HTTPS test origin

## Verification
- uv run python -m pytest tests/test_cors.py

## Risk / rollout
- Low risk; this aligns browser preflight behavior with the existing BotLearn origin gate for session and WebSocket endpoints.