### PR TITLE
fix: allow office document uploads

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -3649,9 +3649,20 @@ async def get_chat_room(
 
 # Allowed MIME type prefixes (mirrors hub/routers/files.py)
 _ALLOWED_MIME_PREFIXES = (
-    "text/", "image/", "audio/", "video/",
-    "application/pdf", "application/json", "application/xml",
-    "application/zip", "application/gzip", "application/octet-stream",
+    "text/",
+    "image/",
+    "audio/",
+    "video/",
+    "application/pdf",
+    "application/json",
+    "application/xml",
+    "application/zip",
+    "application/gzip",
+    "application/octet-stream",
+    "application/msword",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.ms-excel",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 )
 
 

--- a/backend/hub/routers/files.py
+++ b/backend/hub/routers/files.py
@@ -37,6 +37,10 @@ _ALLOWED_MIME_PREFIXES = (
     "application/zip",
     "application/gzip",
     "application/octet-stream",
+    "application/msword",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.ms-excel",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 )
 
 

--- a/backend/tests/test_app/test_dashboard_upload.py
+++ b/backend/tests/test_app/test_dashboard_upload.py
@@ -138,3 +138,40 @@ async def test_dashboard_upload_with_agent_query_keeps_agent_uploader(
     )
     assert record is not None
     assert record.uploader_id == "ag_uploadowner"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("filename", "content_type"),
+    [
+        ("meeting.doc", "application/msword"),
+        ("meeting.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
+        ("sheet.xls", "application/vnd.ms-excel"),
+        ("sheet.xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
+    ],
+)
+async def test_dashboard_upload_allows_word_and_excel_mime_types(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    filename: str,
+    content_type: str,
+):
+    supabase_uid = uuid.uuid4()
+    user = User(
+        supabase_user_id=supabase_uid,
+        display_name="Office Upload",
+        email="office@example.com",
+    )
+    db_session.add(user)
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/dashboard/upload",
+        headers={"Authorization": f"Bearer {_make_token(str(supabase_uid))}"},
+        files={"file": (filename, io.BytesIO(b"office bytes"), content_type)},
+    )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["original_filename"] == filename
+    assert data["content_type"] == content_type

--- a/backend/tests/test_files.py
+++ b/backend/tests/test_files.py
@@ -233,6 +233,34 @@ async def test_upload_image_mime_allowed(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("filename", "content_type"),
+    [
+        ("meeting.doc", "application/msword"),
+        ("meeting.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
+        ("sheet.xls", "application/vnd.ms-excel"),
+        ("sheet.xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
+    ],
+)
+async def test_upload_office_mime_allowed(
+    client: AsyncClient,
+    filename: str,
+    content_type: str,
+):
+    sk, pubkey = _make_keypair()
+    _, _, token = await _register_and_verify(client, sk, pubkey)
+
+    resp = await client.post(
+        "/hub/upload",
+        headers=_auth_header(token),
+        files={"file": (filename, io.BytesIO(b"office bytes"), content_type)},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["content_type"] == content_type
+
+
+@pytest.mark.asyncio
 async def test_upload_multiple_files_same_agent(client: AsyncClient):
     """Same agent can upload multiple files, each gets a unique file_id."""
     sk, pubkey = _make_keypair()


### PR DESCRIPTION
## Summary
- allow Word and Excel MIME types for dashboard and hub uploads
- add focused coverage for .doc, .docx, .xls, and .xlsx uploads

## Verification
- cd backend && uv run pytest tests/test_app/test_dashboard_upload.py tests/test_files.py -q

## Risk / rollout
- Supabase bucket allowedMimeTypes must include the same Office MIME types if bucket restrictions are enabled.