### PR TITLE
fix: clarify CLI permission device context

### DIFF
--- a/cli/src/authorization-context.ts
+++ b/cli/src/authorization-context.ts
@@ -1,0 +1,48 @@
+import os from "node:os";
+import type { StoredBotCordCredentials } from "./credentials.js";
+
+const AUTH_CONTEXT_PARAMS = {
+  deviceName: "device_name",
+  credentialKeyId: "credential_key_id",
+  credentialName: "credential_name",
+  credentialSavedAt: "credential_saved_at",
+} as const;
+
+function setIfMissing(url: URL, key: string, value: string | undefined): void {
+  const trimmed = value?.trim();
+  if (!trimmed || url.searchParams.has(key)) return;
+  url.searchParams.set(key, trimmed);
+}
+
+export function addAuthorizationContextToUrl(
+  authorizeUrl: string,
+  credentials: StoredBotCordCredentials,
+): string {
+  try {
+    const url = new URL(authorizeUrl);
+    setIfMissing(url, AUTH_CONTEXT_PARAMS.deviceName, os.hostname());
+    setIfMissing(url, AUTH_CONTEXT_PARAMS.credentialKeyId, credentials.keyId);
+    setIfMissing(url, AUTH_CONTEXT_PARAMS.credentialName, credentials.displayName);
+    setIfMissing(url, AUTH_CONTEXT_PARAMS.credentialSavedAt, credentials.savedAt);
+    return url.toString();
+  } catch {
+    return authorizeUrl;
+  }
+}
+
+export function addAuthorizationContextToDetail(
+  detail: Record<string, unknown>,
+  credentials: StoredBotCordCredentials,
+): Record<string, unknown> {
+  if (
+    detail.code !== "management_permission_required" ||
+    typeof detail.authorize_url !== "string"
+  ) {
+    return detail;
+  }
+
+  return {
+    ...detail,
+    authorize_url: addAuthorizationContextToUrl(detail.authorize_url, credentials),
+  };
+}

--- a/cli/src/commands/bot.ts
+++ b/cli/src/commands/bot.ts
@@ -1,5 +1,7 @@
 import type { ParsedArgs } from "../args.js";
+import { addAuthorizationContextToDetail } from "../authorization-context.js";
 import { BotCordClient } from "../client.js";
+import type { StoredBotCordCredentials } from "../credentials.js";
 import { loadDefaultCredentials } from "../credentials.js";
 import { normalizeAndValidateHubUrl } from "../hub-url.js";
 import { outputError, outputErrorObject, outputJson } from "../output.js";
@@ -23,6 +25,7 @@ async function appPost(
   path: string,
   body: Record<string, unknown>,
   action: string,
+  credentials: StoredBotCordCredentials,
 ): Promise<unknown> {
   const resp = await fetch(`${hubUrl.replace(/\/+$/, "")}${path}`, {
     method: "POST",
@@ -43,7 +46,7 @@ async function appPost(
     outputErrorObject({
       error: detail.code || `${action}_failed`,
       status: resp.status,
-      ...detail,
+      ...addAuthorizationContextToDetail(detail, credentials),
     });
   }
   const text = json ? JSON.stringify(json) : await resp.text().catch(() => "");
@@ -120,7 +123,14 @@ Options:
     for (const key of Object.keys(body)) {
       if (body[key] === undefined) delete body[key];
     }
-    outputJson(await appPost(hubUrl, token, "/api/users/me/agents/provision", body, "bot_create"));
+    outputJson(await appPost(
+      hubUrl,
+      token,
+      "/api/users/me/agents/provision",
+      body,
+      "bot_create",
+      creds,
+    ));
     return;
   }
 
@@ -129,5 +139,12 @@ Options:
   for (const key of Object.keys(body)) {
     if (body[key] === undefined) delete body[key];
   }
-  outputJson(await appPost(hubUrl, token, "/api/cloud-agents", body, "bot_create"));
+  outputJson(await appPost(
+    hubUrl,
+    token,
+    "/api/cloud-agents",
+    body,
+    "bot_create",
+    creds,
+  ));
 }

--- a/cli/src/commands/team.ts
+++ b/cli/src/commands/team.ts
@@ -1,5 +1,7 @@
 import type { ParsedArgs } from "../args.js";
+import { addAuthorizationContextToDetail } from "../authorization-context.js";
 import { BotCordClient } from "../client.js";
+import type { StoredBotCordCredentials } from "../credentials.js";
 import { loadDefaultCredentials } from "../credentials.js";
 import { normalizeAndValidateHubUrl } from "../hub-url.js";
 import { outputError, outputErrorObject, outputJson } from "../output.js";
@@ -30,6 +32,7 @@ async function appPost(
   token: string,
   path: string,
   body: Record<string, unknown>,
+  credentials: StoredBotCordCredentials,
 ): Promise<unknown> {
   const resp = await fetch(`${hubUrl.replace(/\/+$/, "")}${path}`, {
     method: "POST",
@@ -50,7 +53,7 @@ async function appPost(
     outputErrorObject({
       error: detail.code || "team_create_failed",
       status: resp.status,
-      ...detail,
+      ...addAuthorizationContextToDetail(detail, credentials),
     });
   }
   const text = json ? JSON.stringify(json) : await resp.text().catch(() => "");
@@ -108,5 +111,11 @@ Options:
   });
   const token = await client.ensureToken();
 
-  outputJson(await appPost(hubUrl, token, "/api/team-orchestration/provision", body));
+  outputJson(await appPost(
+    hubUrl,
+    token,
+    "/api/team-orchestration/provision",
+    body,
+    creds,
+  ));
 }

--- a/cli/tests/authorization-context.test.mjs
+++ b/cli/tests/authorization-context.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  addAuthorizationContextToDetail,
+  addAuthorizationContextToUrl,
+} from "../dist/authorization-context.js";
+
+const credentials = {
+  version: 1,
+  hubUrl: "https://www.botcord.chat",
+  agentId: "ag_test",
+  keyId: "k_test",
+  privateKey: "private",
+  publicKey: "public",
+  displayName: "Work laptop CLI",
+  savedAt: "2026-06-25T00:00:00.000Z",
+};
+
+test("authorization context adds local credential hints to management links", () => {
+  const detail = addAuthorizationContextToDetail(
+    {
+      code: "management_permission_required",
+      authorize_url:
+        "https://www.botcord.chat/settings/agents/ag_test/cli-permissions?scopes=cloud_agents%3Acreate",
+    },
+    credentials,
+  );
+
+  const url = new URL(detail.authorize_url);
+  assert.equal(url.searchParams.get("credential_key_id"), "k_test");
+  assert.equal(url.searchParams.get("credential_name"), "Work laptop CLI");
+  assert.equal(url.searchParams.get("credential_saved_at"), credentials.savedAt);
+  assert.ok(url.searchParams.get("device_name"));
+});
+
+test("authorization context preserves existing query hints", () => {
+  const url = addAuthorizationContextToUrl(
+    "https://www.botcord.chat/settings/agents/ag_test/cli-permissions?scopes=x&device_name=Existing",
+    credentials,
+  );
+
+  assert.equal(new URL(url).searchParams.get("device_name"), "Existing");
+});
+
+test("authorization context ignores unrelated errors", () => {
+  const detail = { code: "other_error", authorize_url: "https://example.com" };
+  assert.equal(addAuthorizationContextToDetail(detail, credentials), detail);
+});

--- a/frontend/src/app/(dashboard)/settings/agents/[agentId]/cli-permissions/CliPermissionsClient.tsx
+++ b/frontend/src/app/(dashboard)/settings/agents/[agentId]/cli-permissions/CliPermissionsClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 /**
- * [INPUT]: CLI-requested agent management scopes and optional daemon_instance_id
+ * [INPUT]: CLI-requested agent management scopes, optional daemon_instance_id, optional credential context
  * [OUTPUT]: Owner approval UI that creates management grants through the Hub API
  * [POS]: dashboard settings client for CLI agent credential authorization
  * [PROTOCOL]: update header on changes
@@ -14,6 +14,8 @@ import {
   CheckCircle2,
   Clock3,
   Hash,
+  KeyRound,
+  Laptop,
   Loader2,
   ShieldCheck,
   Terminal,
@@ -70,6 +72,13 @@ interface GrantListResponse {
   grants: AgentManagementGrant[];
 }
 
+interface CliRequestContext {
+  deviceName: string | null;
+  credentialKeyId: string | null;
+  credentialName: string | null;
+  credentialSavedAt: string | null;
+}
+
 function parseScopes(scopeParams: string[]): string[] {
   return Array.from(
     new Set(
@@ -91,6 +100,13 @@ function scopeDescription(scope: string): string {
 
 function formatDate(value: string | null): string {
   if (!value) return "No expiration";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}
+
+function formatTimestamp(value: string | null): string | null {
+  if (!value) return null;
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
   return date.toLocaleString();
@@ -259,14 +275,81 @@ function ScopeList({
   );
 }
 
+function RequestContextPanel({
+  requestContext,
+}: {
+  requestContext: CliRequestContext;
+}) {
+  const hasDeviceName = Boolean(requestContext.deviceName);
+  const savedAt = formatTimestamp(requestContext.credentialSavedAt);
+  const credentialLabel =
+    requestContext.credentialName || requestContext.credentialKeyId || "Not included";
+
+  return (
+    <div className="mb-5 border-y border-glass-border py-4">
+      <div className="flex items-start gap-2">
+        <Laptop className="mt-0.5 h-4 w-4 shrink-0 text-text-secondary" />
+        <div className="min-w-0">
+          <div className="text-xs font-medium uppercase tracking-normal text-text-secondary">
+            Requesting device
+          </div>
+          <div
+            className={`mt-1 break-words text-sm ${
+              hasDeviceName ? "text-text-primary" : "text-yellow-200"
+            }`}
+          >
+            {requestContext.deviceName || "Device not included in this link"}
+          </div>
+          <p className="mt-1 text-xs text-text-secondary">
+            {hasDeviceName
+              ? "Hostname reported by the CLI that printed this authorization link."
+              : "Older CLI links only identify the agent credential. Approve only if this matches the terminal command you just ran."}
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-3">
+        <div className="min-w-0">
+          <div className="mb-1 flex items-center gap-1.5 text-xs font-medium uppercase tracking-normal text-text-secondary">
+            <KeyRound className="h-3.5 w-3.5" />
+            Credential
+          </div>
+          <div className="truncate text-sm text-text-primary">{credentialLabel}</div>
+        </div>
+        <div className="min-w-0">
+          <div className="mb-1 text-xs font-medium uppercase tracking-normal text-text-secondary">
+            Key ID
+          </div>
+          <div className="truncate font-mono text-sm text-text-primary">
+            {requestContext.credentialKeyId || "Not included"}
+          </div>
+        </div>
+        <div className="min-w-0">
+          <div className="mb-1 text-xs font-medium uppercase tracking-normal text-text-secondary">
+            Credential saved
+          </div>
+          <div className="truncate text-sm text-text-primary">{savedAt || "Not included"}</div>
+        </div>
+      </div>
+
+      <p className="mt-3 text-xs text-text-secondary">
+        Approval creates a management grant for this agent and scope. Device fields
+        are shown as context and are not the enforcement boundary.
+      </p>
+    </div>
+  );
+}
+
 export default function CliPermissionsClient({
   agentId,
   scopeParams,
   daemonInstanceId,
+  requestContext,
 }: {
   agentId: string;
   scopeParams: string[];
   daemonInstanceId: string | null;
+  requestContext: CliRequestContext;
 }) {
   const requestedScopes = useMemo(() => parseScopes(scopeParams), [scopeParams]);
   const [expiresInDays, setExpiresInDays] = useState(30);
@@ -411,6 +494,8 @@ export default function CliPermissionsClient({
             </div>
           ) : null}
         </div>
+
+        <RequestContextPanel requestContext={requestContext} />
 
         {!hasScopes ? (
           <Notice tone="error" icon={<XCircle className="h-4 w-4" />}>

--- a/frontend/src/app/(dashboard)/settings/agents/[agentId]/cli-permissions/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/agents/[agentId]/cli-permissions/page.tsx
@@ -1,5 +1,5 @@
 /**
- * [INPUT]: agentId route param and CLI authorization query params
+ * [INPUT]: agentId route param, CLI authorization query params, optional credential context
  * [OUTPUT]: /settings/agents/[agentId]/cli-permissions approval page
  * [POS]: dashboard entry point for owner-approved CLI management grants
  * [PROTOCOL]: update header on changes
@@ -34,6 +34,12 @@ export default async function Page({
       agentId={agentId}
       scopeParams={paramValues(query.scopes)}
       daemonInstanceId={firstParam(query.daemon_instance_id)}
+      requestContext={{
+        deviceName: firstParam(query.device_name) ?? firstParam(query.device),
+        credentialKeyId: firstParam(query.credential_key_id) ?? firstParam(query.key_id),
+        credentialName: firstParam(query.credential_name) ?? firstParam(query.credential_label),
+        credentialSavedAt: firstParam(query.credential_saved_at),
+      }}
     />
   );
 }


### PR DESCRIPTION
## Summary
- Add non-secret CLI context hints to management authorization links, including device hostname, credential key id, credential name, and credential saved time.
- Show requesting device and credential context on the CLI permissions approval page, with an explicit fallback for older links that do not include device info.
- Cover authorization-link context enrichment in CLI tests.

## Verification
- `cd cli && npm test`
- `cd frontend && npm run build`
- `git diff --check`

## Risk / rollout
- Low risk: device fields are display-only context and do not change the management grant enforcement boundary.
- Existing authorization links continue to work and display an explicit missing-device state.