### PR TITLE
fix(daemon): seed skills for generic runtimes

### DIFF
--- a/packages/daemon/src/__tests__/agent-workspace.test.ts
+++ b/packages/daemon/src/__tests__/agent-workspace.test.ts
@@ -92,6 +92,14 @@ describe("ensureAgentWorkspace", () => {
     expect(existsSync(path.join(skillsDir, "botcord_memory", "SKILL.md"))).toBe(true);
   });
 
+  it("seeds bundled skills under workspace/skills/ for generic runtimes", () => {
+    ensureAgentWorkspace("ag_generic_skills", { runtime: "deepseek-tui" });
+    const skillsDir = path.join(agentWorkspaceDir("ag_generic_skills"), "skills");
+    expect(existsSync(path.join(skillsDir, "botcord", "SKILL.md"))).toBe(true);
+    expect(existsSync(path.join(skillsDir, "botcord-user-guide", "SKILL.md"))).toBe(true);
+    expect(existsSync(path.join(skillsDir, "botcord_memory", "SKILL.md"))).toBe(true);
+  });
+
   it("re-seeds skills on a second call so daemon upgrades propagate", () => {
     ensureAgentWorkspace("ag_skill_upgrade", {});
     const skillFile = path.join(

--- a/packages/daemon/src/__tests__/skill-index.test.ts
+++ b/packages/daemon/src/__tests__/skill-index.test.ts
@@ -6,6 +6,7 @@ import {
   agentCodexHomeDir,
   agentHermesHomeDir,
   agentWorkspaceDir,
+  ensureAgentWorkspace,
 } from "../agent-workspace.js";
 import { hermesProfileHomeDir } from "../gateway/runtimes/hermes-agent.js";
 import {
@@ -39,6 +40,36 @@ afterEach(() => {
 });
 
 describe("skill snapshots", () => {
+  it("discovers bundled workspace skills for DeepSeek TUI agents", () => {
+    const agentId = "ag_deepseek_skills";
+    ensureAgentWorkspace(agentId, { runtime: "deepseek-tui" });
+
+    const snapshot = collectAgentSkillSnapshot(agentId, { runtime: "deepseek-tui" });
+
+    expect(snapshot.runtime).toBe("deepseek-tui");
+    expect(snapshot.skills.map((skill) => skill.name)).toEqual([
+      "botcord",
+      "botcord_memory",
+      "botcord-user-guide",
+    ]);
+    expect(snapshot.skills).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "botcord",
+          source: "workspace",
+          sourceDetail: "agent-workspace",
+          runtime: "deepseek-tui",
+          path: path.join(
+            agentWorkspaceDir(agentId),
+            "skills",
+            "botcord",
+            "SKILL.md",
+          ),
+        }),
+      ]),
+    );
+  });
+
   it("scopes scans to the selected runtime and maps UI source buckets", () => {
     const agentId = "ag_skilltest";
     const claudePath = path.join(agentWorkspaceDir(agentId), ".claude", "skills");

--- a/packages/daemon/src/agent-workspace.ts
+++ b/packages/daemon/src/agent-workspace.ts
@@ -386,6 +386,7 @@ export function ensureAgentHermesWorkspace(
  *   - Claude Code: `<workspace>/.claude/skills/<name>/`
  *   - Codex:       `<codex-home>/skills/<name>/`
  *   - Hermes:      `<hermes-home>/skills/<name>/`
+ *   - Other:       `<workspace>/skills/<name>/`
  * Seeded fresh per `ensureAgent*` call (force-overwrite) so daemon
  * upgrades propagate.
  */
@@ -448,6 +449,15 @@ function seedClaudeCodeSkills(workspace: string): void {
 }
 
 /**
+ * Seed the generic workspace skill directory consumed by runtimes without
+ * their own native skill root (for example DeepSeek TUI). The daemon adds
+ * these skills to the soft skill index injected into the runtime context.
+ */
+function seedGenericWorkspaceSkills(workspace: string): void {
+  copyBundledSkills(path.join(workspace, "skills"));
+}
+
+/**
  * Seed Codex's `<CODEX_HOME>/skills/` discovery dir. The codex adapter
  * sets `CODEX_HOME=<agent>/codex-home/`, isolating per-agent skills from
  * the user's global `~/.codex/skills/` — so skills must be seeded here
@@ -507,6 +517,7 @@ export function ensureAgentWorkspace(agentId: string, seed: WorkspaceSeed): void
   writeIfMissing(path.join(workspace, "task.md"), TASK_MD);
   writeIfMissing(path.join(notes, ".gitkeep"), "");
   seedClaudeCodeSkills(workspace);
+  seedGenericWorkspaceSkills(workspace);
 }
 
 /** Patch fields accepted by {@link applyAgentIdentity}. `bio = null` clears it. */


### PR DESCRIPTION
## Summary
- seed bundled BotCord skills into the generic per-agent `workspace/skills` root
- let runtimes without a native skill directory, including DeepSeek TUI, expose bundled skills in runtime snapshots
- add workspace seeding and DeepSeek snapshot regression coverage

## Verification
- `cd packages/daemon && pnpm exec vitest run src/__tests__/agent-workspace.test.ts src/__tests__/skill-index.test.ts` (40 passed)
- `cd packages/daemon && pnpm test` (1111 passed)
- `cd packages/daemon && pnpm build`

## Risk / rollout
- existing cloud agents receive the generic skills through the daemon boot workspace backfill
- daemon users must upgrade/restart before refreshing the Skills snapshot