### PR TITLE
fix(hub): invalidate paused cloud daemon connections

### DIFF
--- a/backend/hub/routers/cloud_daemon_control.py
+++ b/backend/hub/routers/cloud_daemon_control.py
@@ -194,6 +194,42 @@ def is_cloud_daemon_online_by_daemon_id(daemon_instance_id: str) -> bool:
     return _REGISTRY.get_by_daemon(daemon_instance_id) is not None
 
 
+async def disconnect_cloud_daemon_control(
+    cloud_daemon_instance_id: str,
+    *,
+    reason: str = "cloud daemon paused",
+) -> bool:
+    """Invalidate and close a cloud daemon control connection.
+
+    Pausing a sandbox can freeze its WebSocket before the Hub observes a TCP
+    disconnect. Remove the connection from the online registry immediately so
+    new requests resume the sandbox instead of dispatching into a stale socket.
+    """
+    conn = _REGISTRY.get_by_cloud(cloud_daemon_instance_id)
+    if conn is None:
+        return False
+
+    await _REGISTRY.unregister(conn)
+    for fut in conn.pending_acks.values():
+        if not fut.done():
+            fut.set_exception(RuntimeError(reason))
+    conn.pending_acks.clear()
+    try:
+        await conn.ws.close(code=1012, reason=reason[:120])
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "cloud daemon control close failed after invalidation: cloud=%s err=%s",
+            cloud_daemon_instance_id,
+            exc,
+        )
+    logger.info(
+        "cloud daemon control connection invalidated: cloud=%s reason=%s",
+        cloud_daemon_instance_id,
+        reason,
+    )
+    return True
+
+
 def _registry_for_tests() -> _CloudDaemonRegistry:
     """Test-only accessor for injecting fake connections."""
     return _REGISTRY

--- a/backend/hub/services/cloud_agent.py
+++ b/backend/hub/services/cloud_agent.py
@@ -65,6 +65,7 @@ from hub.models import (
 )
 from hub.routers.cloud_daemon_control import (
     CloudDaemonDispatchError,
+    disconnect_cloud_daemon_control,
     is_cloud_daemon_online,
     send_cloud_control_frame,
 )
@@ -693,6 +694,7 @@ class CloudAgentService:
         provider = self._get_provider()
         cai.status = "paused"
         await db.flush()
+        daemon_paused = False
 
         # Cloud daemon pause is a per-sandbox operation. Pause the sandbox
         # only once every non-deleted peer on it is also paused.
@@ -711,7 +713,13 @@ class CloudAgentService:
             )
             _apply_handle_to_rows(cdi, handle)
             cdi.last_paused_at = _now()
+            daemon_paused = True
         await db.commit()
+        if daemon_paused:
+            await disconnect_cloud_daemon_control(
+                cdi.id,
+                reason="cloud daemon manually paused",
+            )
         await db.refresh(cai)
         await db.refresh(cdi)
         return _make_view(agent, cai, cdi)
@@ -2199,6 +2207,10 @@ class CloudAgentService:
             agent.error_code = None
             agent.error_message = None
         await db.commit()
+        await disconnect_cloud_daemon_control(
+            cdi.id,
+            reason="cloud daemon idle-paused",
+        )
         logger.info(
             "idle-paused cloud daemon %s after %d idle agent(s)",
             cdi.id,

--- a/backend/tests/test_cloud_agent_service.py
+++ b/backend/tests/test_cloud_agent_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import datetime
 import uuid
 from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
 
 import pytest
 import pytest_asyncio
@@ -1248,6 +1249,33 @@ async def test_pause_idempotent(db_session):
 
 
 @pytest.mark.asyncio
+async def test_manual_pause_invalidates_control_connection(db_session, monkeypatch):
+    user_id = uuid.uuid4()
+    svc, _fake = _make_service()
+    view = await svc.create_cloud_agent(
+        db_session, user_id=user_id, body=CreateCloudAgentInput(name="A")
+    )
+    disconnect = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        cloud_agent_service,
+        "disconnect_cloud_daemon_control",
+        disconnect,
+    )
+
+    paused = await svc.pause_cloud_agent(
+        db_session,
+        user_id=user_id,
+        agent_id=view.agent_id,
+    )
+
+    assert paused.status == "paused"
+    disconnect.assert_awaited_once_with(
+        view.cloud_daemon_instance_id,
+        reason="cloud daemon manually paused",
+    )
+
+
+@pytest.mark.asyncio
 async def test_pause_only_pauses_daemon_when_last_agent_paused(db_session):
     user_id = uuid.uuid4()
     svc, fake = _make_service(max_per_user=4, max_agents_per_daemon=2)
@@ -1303,6 +1331,33 @@ async def test_idle_pause_pauses_ready_daemon_and_agents(db_session):
     assert cdi.last_paused_at.replace(tzinfo=datetime.timezone.utc) == future_now
     assert cdi.metadata_json["last_pause_reason"] == "idle_timeout"
     assert fake.calls(view.cloud_daemon_instance_id)["pause"] == 1
+
+
+@pytest.mark.asyncio
+async def test_idle_pause_invalidates_control_connection(db_session, monkeypatch):
+    user_id = uuid.uuid4()
+    svc, _fake = _make_service()
+    view = await svc.create_cloud_agent(
+        db_session, user_id=user_id, body=CreateCloudAgentInput(name="A")
+    )
+    disconnect = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        cloud_agent_service,
+        "disconnect_cloud_daemon_control",
+        disconnect,
+    )
+
+    paused_count = await svc.pause_idle_cloud_daemons(
+        db_session,
+        idle_seconds=300,
+        now=datetime.datetime(2030, 1, 1, tzinfo=datetime.timezone.utc),
+    )
+
+    assert paused_count == 1
+    disconnect.assert_awaited_once_with(
+        view.cloud_daemon_instance_id,
+        reason="cloud daemon idle-paused",
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_cloud_daemon_ws.py
+++ b/backend/tests/test_cloud_daemon_ws.py
@@ -32,6 +32,7 @@ from hub.routers.cloud_daemon_control import (
     CLOUD_DAEMON_TOKEN_KIND,
     _CloudDaemonConn,
     _create_cloud_daemon_access_token,
+    disconnect_cloud_daemon_control,
     _handle_cloud_daemon_event,
     _registry_for_tests,
     _verify_cloud_daemon_access_token,
@@ -98,6 +99,32 @@ class _FakeWS:
 
     async def close(self, code: int = 1000, reason: str = "") -> None:
         self.closed_with = (code, reason)
+
+
+@pytest.mark.asyncio
+async def test_disconnect_cloud_daemon_control_invalidates_stale_connection():
+    ws = _FakeWS()
+    conn = _CloudDaemonConn(
+        ws=ws,
+        user_id="usr_pause",
+        cloud_daemon_instance_id="cloud_dm_pause",
+        daemon_instance_id="dm_pause",
+    )
+    pending = asyncio.get_running_loop().create_future()
+    conn.pending_acks["frame_pause"] = pending
+    registry = _registry_for_tests()
+    await registry.register(conn)
+
+    disconnected = await disconnect_cloud_daemon_control(
+        "cloud_dm_pause",
+        reason="cloud daemon idle-paused",
+    )
+
+    assert disconnected is True
+    assert registry.is_online("cloud_dm_pause") is False
+    assert ws.closed_with == (1012, "cloud daemon idle-paused")
+    with pytest.raises(RuntimeError, match="idle-paused"):
+        await pending
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Immediately unregister and close a cloud daemon control WebSocket after its sandbox is paused, both for manual pause and idle timeout. This prevents Files/Skills requests from being dispatched into a frozen-but-still-registered socket and timing out with an upstream 504.

Pending control acknowledgements are failed as part of invalidation so in-flight callers do not wait for the normal timeout.

## Related Issue

N/A — production incident follow-up.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Component(s) Affected

- [x] Backend (`backend/`)

## How Has This Been Tested?

- [x] Focused backend tests pass
- [x] Full backend suite was run

**Test Details:**

- `uv run pytest -q tests/test_cloud_daemon_ws.py tests/test_cloud_agent_service.py tests/test_cloud_agent_activity.py` — 71 passed
- Full suite — 1538 passed, 30 skipped; 2 unrelated date-sensitive claim-gift tests fail because their configured grant window ended on 2026-07-08
- `uv run python -m compileall -q ...` — passed
- `uvx ruff check` on changed production files and focused service test — passed

## Checklist

### Code Quality

- [x] My code follows the project's style guidelines
- [x] Server code uses `async def` for all route handlers and I/O functions
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my fix is effective
- [x] New and focused existing tests pass locally

### Documentation

- [x] No public documentation change is required
- [x] I have added/updated docstrings for new/modified functions

### Cross-Component

- [x] No crypto/signing or session-key changes

## Screenshots

N/A — backend-only fix.

## Additional Context

Observed sequence in preview: the E2B sandbox paused successfully, but the Hub continued to report the cloud daemon online until the stale WebSocket disconnected roughly 28 seconds later. Runtime Files and Skills refreshes sent during that window exhausted their ACK timeout and returned 504.

## Pre-Submission Verification

- [x] I have read the repository contribution guidance
- [x] I have not included unrelated changes in this PR
- [x] My PR title follows conventional commits format
