### PR TITLE
test(hub): make claim gift window deterministic

### DIFF
--- a/backend/tests/test_app/test_app_user_agents.py
+++ b/backend/tests/test_app/test_app_user_agents.py
@@ -1096,8 +1096,16 @@ async def test_credential_reset_ticket_returns_valid_ticket(
 
 
 @pytest.mark.asyncio
-async def test_claim_resolve_success(client: AsyncClient, seed_user: dict, db_session: AsyncSession):
+async def test_claim_resolve_success(
+    client: AsyncClient,
+    seed_user: dict,
+    db_session: AsyncSession,
+    monkeypatch,
+):
     """Claiming an unclaimed agent binds it to the user."""
+    import hub.config
+
+    monkeypatch.setattr(hub.config, "is_claim_gift_active", lambda: True)
     token = seed_user["token"]
 
     # Create a new unclaimed agent
@@ -1281,9 +1289,14 @@ async def seed_user_for_claim(db_session: AsyncSession, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_claim_agent_with_token_success(
-    client: AsyncClient, seed_user_for_claim: dict
+    client: AsyncClient,
+    seed_user_for_claim: dict,
+    monkeypatch,
 ):
     """Successful claim with agent_token (mock verify returns True)."""
+    import hub.config
+
+    monkeypatch.setattr(hub.config, "is_claim_gift_active", lambda: True)
     token = seed_user_for_claim["token"]
 
     with _mock_verify_agent_control(True):
@@ -1325,11 +1338,7 @@ async def test_claim_gift_skips_after_window(
     import hub.config
 
     token = seed_user_for_claim["token"]
-    monkeypatch.setattr(
-        hub.config,
-        "CLAIM_GIFT_WINDOW_END_AT_EXCLUSIVE",
-        datetime.datetime(2026, 4, 7, 0, 0, 0, tzinfo=datetime.timezone.utc),
-    )
+    monkeypatch.setattr(hub.config, "is_claim_gift_active", lambda: False)
 
     with _mock_verify_agent_control(True):
         resp = await client.post(


### PR DESCRIPTION
## Description

Make claim-gift endpoint tests explicitly control whether the promotional gift window is active.

The fixed production window ended on 2026-07-08, so two success tests started failing based on wall-clock time. That failure blocked the backend preview deployment for #982 even though all 1538 other backend tests passed.

## Type of Change

- [x] Test reliability fix

## Component(s) Affected

- [x] Backend tests (`backend/tests/`)

## How Has This Been Tested?

- `uv run pytest -q tests/test_app/test_app_user_agents.py` — 41 passed
- `uvx ruff check backend/tests/test_app/test_app_user_agents.py` — passed
- `git diff --check` — passed

The preceding main CI run completed the full suite with 1538 passed and only these two date-sensitive failures.

## Additional Context

Test-only change; production claim-gift dates and behavior are unchanged.
