### PR TITLE
chore: correct preview Docker Compose paths

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -68,8 +68,8 @@ jobs:
     steps:
       - name: docker compose down/up
         run: |
-          docker compose -f ${{ secrets.DEPLOY_ROOT }}/$PROJECT-preview/docker-compose.yaml down
-          docker compose -f ${{ secrets.DEPLOY_ROOT }}/$PROJECT-preview/docker-compose.yaml up -d
+          docker compose -f ${{ secrets.DEPLOY_ROOT }}/$PROJECT/docker-compose.yaml down
+          docker compose -f ${{ secrets.DEPLOY_ROOT }}/$PROJECT/docker-compose.yaml up -d
           echo "✅ Preview restarted"
 
   # ── Rollout prod (k8s) ───────────────────────────────────────────────────────

--- a/.github/workflows/deploy-gateway-ingress.yml
+++ b/.github/workflows/deploy-gateway-ingress.yml
@@ -80,8 +80,8 @@ jobs:
     steps:
       - name: docker compose down/up
         run: |
-          docker compose -f ${{ secrets.DEPLOY_ROOT }}/$PROJECT-preview/docker-compose.yaml down
-          docker compose -f ${{ secrets.DEPLOY_ROOT }}/$PROJECT-preview/docker-compose.yaml up -d
+          docker compose -f ${{ secrets.DEPLOY_ROOT }}/$PROJECT/docker-compose.yaml down
+          docker compose -f ${{ secrets.DEPLOY_ROOT }}/$PROJECT/docker-compose.yaml up -d
           echo "✅ Preview restarted"
 
   # ── Rollout prod (k8s) ───────────────────────────────────────────────────────


### PR DESCRIPTION
## What changed

- Update backend preview rollout to use `${DEPLOY_ROOT}/${PROJECT}/docker-compose.yaml`.
- Update gateway ingress preview rollout to use the same Compose directory convention.

## Why

The preview restart steps referenced `${PROJECT}-preview`, while the deployed Compose files live under `${PROJECT}`. This caused the rollout commands to target the wrong path.

## Validation

- `git diff --check origin/main..HEAD`
- `actionlint -ignore SC2086 .github/workflows/deploy-backend.yml .github/workflows/deploy-gateway-ingress.yml`

`SC2086` is ignored because both workflows already contain existing unquoted-variable warnings outside this focused path correction.