### PR TITLE
fix: harden idle pause and hub secrets

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -27,6 +27,8 @@ SUPABASE_STORAGE_BUCKET=botcord-files
 
 # Set to true to allow private/localhost endpoint URLs (dev only)
 ALLOW_PRIVATE_ENDPOINTS=false
+# Required base64-encoded 32-byte Ed25519 seed; generate a unique value per deployment.
+BOTCORD_HUB_CONTROL_PRIVATE_KEY=
 
 # Beta invite gate (true = require invite code, false = open registration)
 BETA_GATE_ENABLED=false

--- a/backend/hub/config.py
+++ b/backend/hub/config.py
@@ -62,10 +62,8 @@ ALLOW_PRIVATE_ENDPOINTS: bool = os.getenv("ALLOW_PRIVATE_ENDPOINTS", "false").lo
 INTERNAL_API_SECRET: str | None = os.getenv("INTERNAL_API_SECRET", None)
 
 if ALLOW_PRIVATE_ENDPOINTS and not INTERNAL_API_SECRET:
-    _logger.warning(
-        "ALLOW_PRIVATE_ENDPOINTS is enabled but INTERNAL_API_SECRET is not set. "
-        "Internal wallet endpoints are accessible WITHOUT authentication. "
-        "Set INTERNAL_API_SECRET to a strong random value in production."
+    raise RuntimeError(
+        "ALLOW_PRIVATE_ENDPOINTS requires INTERNAL_API_SECRET to be set"
     )
 
 # Shared secret used by the gateway-ingress service when it calls the
@@ -274,18 +272,19 @@ SENTRY_LOGS_LEVEL: int | None = _parse_log_level_env("SENTRY_LOGS_LEVEL", "INFO"
 # Daemon control plane
 # ---------------------------------------------------------------------------
 
-# Default development keypair — DO NOT use in production. Override
-# BOTCORD_HUB_CONTROL_PRIVATE_KEY with a freshly generated 32-byte Ed25519
-# seed (base64). The matching public key is shipped to the daemon for verification.
+# Legacy development keypair — never use it. Deployments must set
+# BOTCORD_HUB_CONTROL_PRIVATE_KEY to a persistent, freshly generated 32-byte
+# Ed25519 seed (base64).
 _DAEMON_DEFAULT_PRIVATE_KEY_B64 = "R9yHQWAP+oLdwuXW67TGSi/RWbkYPGf1a31by04W1zA="
 
 DAEMON_HUB_CONTROL_PRIVATE_KEY_B64: str = os.getenv(
-    "BOTCORD_HUB_CONTROL_PRIVATE_KEY", _DAEMON_DEFAULT_PRIVATE_KEY_B64
+    "BOTCORD_HUB_CONTROL_PRIVATE_KEY", ""
 )
+if not DAEMON_HUB_CONTROL_PRIVATE_KEY_B64:
+    raise RuntimeError("BOTCORD_HUB_CONTROL_PRIVATE_KEY must be set")
 if DAEMON_HUB_CONTROL_PRIVATE_KEY_B64 == _DAEMON_DEFAULT_PRIVATE_KEY_B64:
-    _logger.warning(
-        "BOTCORD_HUB_CONTROL_PRIVATE_KEY is using the insecure default seed. "
-        "Generate a fresh Ed25519 keypair before deploying to production."
+    raise RuntimeError(
+        "BOTCORD_HUB_CONTROL_PRIVATE_KEY must not use the insecure default seed"
     )
 
 DAEMON_ACCESS_TOKEN_EXPIRE_SECONDS: int = int(

--- a/backend/hub/services/cloud_agent.py
+++ b/backend/hub/services/cloud_agent.py
@@ -754,6 +754,8 @@ class CloudAgentService:
         paused = 0
 
         for cdi in candidates:
+            cloud_daemon_instance_id = cdi.id
+            provider_sandbox_id = cdi.provider_sandbox_id
             try:
                 if await self._pause_cloud_daemon_if_idle(
                     db, cdi, cutoff=cutoff, now=current
@@ -763,8 +765,8 @@ class CloudAgentService:
                 await db.rollback()
                 logger.warning(
                     "idle pause failed: cloud=%s sandbox=%s err=%s",
-                    cdi.id,
-                    cdi.provider_sandbox_id,
+                    cloud_daemon_instance_id,
+                    provider_sandbox_id,
                     exc,
                 )
 
@@ -2199,6 +2201,12 @@ class CloudAgentService:
             cloud_daemon_instance_id=cdi.id,
             provider_sandbox_id=cdi.provider_sandbox_id,
         )
+        if handle.status != "paused":
+            raise CloudAgentError(
+                handle.error_code or "cloud_daemon_pause_failed",
+                handle.error_message or "cloud daemon provider did not confirm pause",
+                http_status=502,
+            )
         _apply_handle_to_rows(cdi, handle)
         cdi.last_paused_at = now
         cdi.metadata_json = {

--- a/backend/hub/services/cloud_agent.py
+++ b/backend/hub/services/cloud_agent.py
@@ -745,18 +745,22 @@ class CloudAgentService:
         current = now or _now()
         cutoff = current - datetime.timedelta(seconds=idle_seconds)
         result = await db.execute(
-            select(CloudDaemonInstance)
+            select(
+                CloudDaemonInstance.id,
+                CloudDaemonInstance.provider_sandbox_id,
+            )
             .where(CloudDaemonInstance.status == "ready")
             .order_by(CloudDaemonInstance.updated_at.asc())
             .limit(limit)
         )
-        candidates = list(result.scalars().all())
+        candidates = list(result.all())
         paused = 0
 
-        for cdi in candidates:
-            cloud_daemon_instance_id = cdi.id
-            provider_sandbox_id = cdi.provider_sandbox_id
+        for cloud_daemon_instance_id, provider_sandbox_id in candidates:
             try:
+                cdi = await db.get(CloudDaemonInstance, cloud_daemon_instance_id)
+                if cdi is None or cdi.status != "ready":
+                    continue
                 if await self._pause_cloud_daemon_if_idle(
                     db, cdi, cutoff=cutoff, now=current
                 ):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,8 +1,15 @@
 import datetime
+import os
 
 import pytest
 from sqlalchemy import event
 from sqlalchemy.ext import asyncio as _sa_async
+
+# Hub startup intentionally requires an explicit daemon-control signing key.
+os.environ.setdefault(
+    "BOTCORD_HUB_CONTROL_PRIVATE_KEY",
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+)
 
 # Patch create_async_engine so SQLite test engines automatically map the
 # "public" schema (used by User/Role/Permission models) to None. SQLite has

--- a/backend/tests/test_cloud_agent_service.py
+++ b/backend/tests/test_cloud_agent_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import logging
 import uuid
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock
@@ -1368,6 +1369,79 @@ async def test_idle_pause_does_not_persist_or_report_failed_provider_pause(db_se
     assert cdi.status == "ready"
     assert cdi.last_paused_at is None
     assert "last_pause_reason" not in (cdi.metadata_json or {})
+
+
+@pytest.mark.asyncio
+async def test_idle_pause_continues_after_first_provider_pause_fails(
+    db_session, caplog
+):
+    class FirstPauseFailsProvider(FakeCloudDaemonProvider):
+        def __init__(self):
+            super().__init__()
+            self.pause_attempts: list[str] = []
+
+        async def pause(self, **kwargs):
+            handle = await super().pause(**kwargs)
+            self.pause_attempts.append(kwargs["cloud_daemon_instance_id"])
+            if len(self.pause_attempts) == 1:
+                handle.status = "failed"
+                handle.error_code = "e2b_pause_failed"
+                handle.error_message = "Response 409"
+            return handle
+
+    first_user_id = uuid.uuid4()
+    second_user_id = uuid.uuid4()
+    provider = FirstPauseFailsProvider()
+    svc, _fake = _make_service(provider=provider)
+    first = await svc.create_cloud_agent(
+        db_session,
+        user_id=first_user_id,
+        body=CreateCloudAgentInput(name="First"),
+    )
+    second = await svc.create_cloud_agent(
+        db_session,
+        user_id=second_user_id,
+        body=CreateCloudAgentInput(name="Second"),
+    )
+
+    with caplog.at_level(logging.INFO, logger=cloud_agent_service.__name__):
+        paused_count = await svc.pause_idle_cloud_daemons(
+            db_session,
+            idle_seconds=300,
+            now=datetime.datetime(2030, 1, 1, tzinfo=datetime.timezone.utc),
+        )
+
+    failed_cdi = await db_session.get(
+        CloudDaemonInstance, provider.pause_attempts[0]
+    )
+    succeeded_cdi = await db_session.get(
+        CloudDaemonInstance, provider.pause_attempts[1]
+    )
+    failed_cai = await db_session.scalar(
+        select(CloudAgentInstance).where(
+            CloudAgentInstance.cloud_daemon_instance_id == failed_cdi.id
+        )
+    )
+    succeeded_cai = await db_session.scalar(
+        select(CloudAgentInstance).where(
+            CloudAgentInstance.cloud_daemon_instance_id == succeeded_cdi.id
+        )
+    )
+
+    assert paused_count == 1
+    assert len(provider.pause_attempts) == 2
+    assert set(provider.pause_attempts) == {
+        first.cloud_daemon_instance_id,
+        second.cloud_daemon_instance_id,
+    }
+    assert failed_cdi.status == "ready"
+    assert failed_cai.status == "ready"
+    assert failed_cdi.last_paused_at is None
+    assert succeeded_cdi.status == "paused"
+    assert succeeded_cai.status == "paused"
+    assert succeeded_cdi.last_paused_at is not None
+    assert "idle pause failed" in caplog.text
+    assert "idle-paused cloud daemon" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_cloud_agent_service.py
+++ b/backend/tests/test_cloud_agent_service.py
@@ -1334,6 +1334,43 @@ async def test_idle_pause_pauses_ready_daemon_and_agents(db_session):
 
 
 @pytest.mark.asyncio
+async def test_idle_pause_does_not_persist_or_report_failed_provider_pause(db_session):
+    class FailedPauseProvider(FakeCloudDaemonProvider):
+        async def pause(self, **kwargs):
+            handle = await super().pause(**kwargs)
+            handle.status = "failed"
+            handle.error_code = "e2b_pause_failed"
+            handle.error_message = "Response 409"
+            return handle
+
+    user_id = uuid.uuid4()
+    svc, _fake = _make_service(provider=FailedPauseProvider())
+    view = await svc.create_cloud_agent(
+        db_session, user_id=user_id, body=CreateCloudAgentInput(name="A")
+    )
+
+    paused_count = await svc.pause_idle_cloud_daemons(
+        db_session,
+        idle_seconds=300,
+        now=datetime.datetime(2030, 1, 1, tzinfo=datetime.timezone.utc),
+    )
+
+    cai = await db_session.scalar(
+        select(CloudAgentInstance).where(CloudAgentInstance.agent_id == view.agent_id)
+    )
+    cdi = await db_session.scalar(
+        select(CloudDaemonInstance).where(
+            CloudDaemonInstance.id == view.cloud_daemon_instance_id
+        )
+    )
+    assert paused_count == 0
+    assert cai.status == "ready"
+    assert cdi.status == "ready"
+    assert cdi.last_paused_at is None
+    assert "last_pause_reason" not in (cdi.metadata_json or {})
+
+
+@pytest.mark.asyncio
 async def test_idle_pause_invalidates_control_connection(db_session, monkeypatch):
     user_id = uuid.uuid4()
     svc, _fake = _make_service()

--- a/backend/tests/test_config_security.py
+++ b/backend/tests/test_config_security.py
@@ -1,0 +1,56 @@
+"""Startup configuration safety checks isolated from the test process."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+def _import_config(**environment: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(environment)
+    env.pop("INTERNAL_API_SECRET", None)
+    env.pop("BOTCORD_HUB_CONTROL_PRIVATE_KEY", None)
+    env.update(environment)
+    return subprocess.run(
+        [sys.executable, "-c", "import hub.config"],
+        capture_output=True,
+        check=False,
+        env=env,
+        text=True,
+    )
+
+
+def test_private_endpoints_require_internal_api_secret():
+    result = _import_config(ALLOW_PRIVATE_ENDPOINTS="true")
+
+    assert result.returncode != 0
+    assert "ALLOW_PRIVATE_ENDPOINTS requires INTERNAL_API_SECRET" in result.stderr
+
+
+def test_private_endpoints_accept_configured_internal_api_secret():
+    result = _import_config(
+        ALLOW_PRIVATE_ENDPOINTS="true",
+        INTERNAL_API_SECRET="test-only-internal-secret",
+        BOTCORD_HUB_CONTROL_PRIVATE_KEY="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_legacy_hub_control_private_key_is_rejected():
+    result = _import_config(
+        ALLOW_PRIVATE_ENDPOINTS="false",
+        BOTCORD_HUB_CONTROL_PRIVATE_KEY="R9yHQWAP+oLdwuXW67TGSi/RWbkYPGf1a31by04W1zA=",
+    )
+
+    assert result.returncode != 0
+    assert "must not use the insecure default seed" in result.stderr
+
+
+def test_unset_hub_control_private_key_is_rejected():
+    result = _import_config(ALLOW_PRIVATE_ENDPOINTS="false")
+
+    assert result.returncode != 0
+    assert "BOTCORD_HUB_CONTROL_PRIVATE_KEY must be set" in result.stderr


### PR DESCRIPTION
## Summary
- mutate idle-pause state only after the E2B provider confirms `paused`
- preserve ready state and continue processing later candidates after provider failures/rollback
- require internal API and hub control secrets at startup and reject the legacy public seed

## Verification
- idle-pause tests: 12/12 passed
- cloud-agent service tests: 44/44 passed
- backend suite: 1555 passed, 30 skipped
- `git diff --check` clean
- Code Reviewer re-review of b0158039: no blocking findings

## Deployment note
This PR does not deploy or mutate runtime/secrets. Preview must receive approved `INTERNAL_API_SECRET` and `BOTCORD_HUB_CONTROL_PRIVATE_KEY` before deploying this change.