### PR TITLE
fix: acknowledge inbox after runtime completion

### DIFF
--- a/.changeset/durable-inbox-lease.md
+++ b/.changeset/durable-inbox-lease.md
@@ -1,0 +1,6 @@
+---
+"@botcord/daemon": patch
+"@botcord/protocol-core": patch
+---
+
+Keep inbox messages under a renewable processing lease until runtime handling finishes, then acknowledge them explicitly so crashes requeue work instead of losing it.

--- a/backend/hub/constants.py
+++ b/backend/hub/constants.py
@@ -5,6 +5,7 @@ import uuid
 PROTOCOL_VERSION = "a2a/0.1"
 DEFAULT_TTL_SEC = 3600
 BACKOFF_SCHEDULE = [1, 2, 4, 8, 16, 32, 60]
+INBOX_PROCESSING_LEASE_SECONDS = 120
 
 # UUID v5 namespace for deriving deterministic session keys from room/topic
 SESSION_KEY_NAMESPACE = uuid.uuid5(uuid.NAMESPACE_DNS, "botcord")

--- a/backend/hub/expiry.py
+++ b/backend/hub/expiry.py
@@ -61,7 +61,7 @@ async def _reclaim_stale_processing() -> None:
     After reclaiming, notifies affected agents so WS/long-poll consumers
     re-fetch immediately instead of waiting for the next new message.
     """
-    from hub.routers.hub import notify_inbox
+    from hub.routers.hub import notify_inbox, notify_owner_chat_delivery_state
     from sqlalchemy import select, update
 
     now = datetime.datetime.now(datetime.timezone.utc)
@@ -69,17 +69,17 @@ async def _reclaim_stale_processing() -> None:
     async with async_session() as session:
         # First, find which agents are affected so we can notify them
         affected_stmt = (
-            select(MessageRecord.receiver_id)
+            select(MessageRecord)
             .where(
                 MessageRecord.state == MessageState.processing,
                 MessageRecord.next_retry_at <= now,
             )
-            .distinct()
         )
         affected_result = await session.execute(affected_stmt)
-        affected_agents = [row[0] for row in affected_result.all()]
+        affected_records = list(affected_result.scalars().all())
+        affected_by_id = {record.id: record for record in affected_records}
 
-        if not affected_agents:
+        if not affected_records:
             return
 
         # Bulk revert
@@ -90,11 +90,28 @@ async def _reclaim_stale_processing() -> None:
                 MessageRecord.next_retry_at <= now,
             )
             .values(state=MessageState.queued, next_retry_at=None)
+            .returning(MessageRecord.id)
         )
         result = await session.execute(stmt)
+        reclaimed_ids = set(result.scalars().all())
         await session.commit()
 
-        logger.info("Reclaimed %d stale processing messages back to queued", result.rowcount)
+        reclaimed_records = [
+            affected_by_id[record_id]
+            for record_id in reclaimed_ids
+            if record_id in affected_by_id
+        ]
+        affected_agents = {record.receiver_id for record in reclaimed_records}
+        logger.info(
+            "Reclaimed %d stale processing messages back to queued",
+            len(reclaimed_records),
+        )
+
+        await notify_owner_chat_delivery_state(
+            reclaimed_records,
+            state=MessageState.queued,
+            reason="processing_lease_expired",
+        )
 
         # Notify affected agents so they re-poll
         for agent_id in affected_agents:

--- a/backend/hub/owner_chat_cache.py
+++ b/backend/hub/owner_chat_cache.py
@@ -52,6 +52,16 @@ def register_fanout_delivery(
     _fanout_delivery = fn
 
 
+async def deliver_local(user_id: str, agent_id: str, data: dict) -> None:
+    """Best-effort delivery to owner-chat WebSockets held by this Hub process."""
+    if _fanout_delivery is None:
+        return
+    try:
+        await _fanout_delivery(user_id, agent_id, data)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("owner_chat_cache.local delivery failed: %s", exc)
+
+
 def redis_enabled() -> bool:
     return bool(getattr(hub_config, "BOTCORD_REDIS_URL", None))
 

--- a/backend/hub/routers/hub.py
+++ b/backend/hub/routers/hub.py
@@ -14,9 +14,10 @@ import sentry_sdk
 from cachetools import TTLCache
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, WebSocket, WebSocketDisconnect
+from hub import owner_chat_cache
 from hub.i18n import I18nHTTPException
 from pydantic import BaseModel, Field
-from sqlalchemy import func, select, text
+from sqlalchemy import func, select, text, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -33,6 +34,7 @@ from hub.config import (
     PAIR_RATE_LIMIT_PER_MINUTE,
     RATE_LIMIT_PER_MINUTE,
 )
+from hub.constants import INBOX_PROCESSING_LEASE_SECONDS
 from hub.validators import normalize_file_url
 from hub.crypto import check_timestamp, verify_envelope_sig, verify_payload_hash
 from hub.dashboard_message_shaping import load_user_display_names
@@ -74,6 +76,8 @@ from hub.schemas import (
     HistoryResponse,
     InboxAckRequest,
     InboxAckResponse,
+    InboxLeaseRenewRequest,
+    InboxLeaseRenewResponse,
     InboxMessage,
     InboxPollResponse,
     MessageEnvelope,
@@ -1949,6 +1953,53 @@ async def _fetch_queued_messages(
     return list(result.scalars().all())
 
 
+async def notify_owner_chat_delivery_state(
+    records: list[MessageRecord],
+    *,
+    state: MessageState,
+    reason: str | None = None,
+) -> None:
+    """Push durable inbox state changes to owner-chat clients.
+
+    PostgreSQL remains the delivery source of truth. These WebSocket/Redis
+    notifications are best-effort observability only and must never decide
+    whether a message is claimed, retried, or acknowledged.
+    """
+    updated_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    for rec in records:
+        if (
+            rec.source_session_kind != "owner_chat"
+            or not rec.source_user_id
+            or not rec.room_id
+        ):
+            continue
+        data: dict[str, Any] = {
+            "type": "delivery_status",
+            "hub_msg_id": rec.hub_msg_id,
+            "trace_id": rec.hub_msg_id,
+            "room_id": rec.room_id,
+            "state": state.value,
+            "updated_at": updated_at,
+        }
+        if reason:
+            data["reason"] = reason
+
+        await owner_chat_cache.deliver_local(
+            rec.source_user_id,
+            rec.receiver_id,
+            data,
+        )
+        if owner_chat_cache.redis_enabled():
+            await owner_chat_cache.publish_fanout(
+                {
+                    "type": "delivery_status",
+                    "user_id": rec.source_user_id,
+                    "agent_id": rec.receiver_id,
+                    "data": data,
+                }
+            )
+
+
 @router.get("/inbox", response_model=InboxPollResponse)
 async def poll_inbox(
     db: AsyncSession = Depends(get_db),
@@ -2081,10 +2132,17 @@ async def poll_inbox(
             # Set next_retry_at as the processing timeout — the expiry loop will
             # revert stale processing records back to queued after this time.
             rec.state = MessageState.processing
-            rec.next_retry_at = now + datetime.timedelta(seconds=120)
+            rec.next_retry_at = now + datetime.timedelta(
+                seconds=INBOX_PROCESSING_LEASE_SECONDS
+            )
 
     if messages:
         await db.commit()
+        if not ack:
+            await notify_owner_chat_delivery_state(
+                rows,
+                state=MessageState.processing,
+            )
 
     return InboxPollResponse(
         messages=messages,
@@ -2127,6 +2185,7 @@ async def ack_inbox_messages(
     for rec in rows:
         rec.state = MessageState.delivered
         rec.delivered_at = now
+        rec.acked_at = now
         rec.next_retry_at = None
 
     await db.commit()
@@ -2137,6 +2196,45 @@ async def ack_inbox_messages(
         len(body.message_ids),
     )
     return InboxAckResponse(acked=len(rows))
+
+
+# ---------------------------------------------------------------------------
+# POST /hub/inbox/lease/renew — extend two-phase processing ownership
+# ---------------------------------------------------------------------------
+
+
+@router.post("/inbox/lease/renew", response_model=InboxLeaseRenewResponse)
+async def renew_inbox_message_leases(
+    body: InboxLeaseRenewRequest,
+    db: AsyncSession = Depends(get_db),
+    current_agent: str = Depends(get_dashboard_claimed_agent),
+):
+    """Extend processing leases for messages currently owned by this agent."""
+    if not body.message_ids:
+        return InboxLeaseRenewResponse(renewed=0)
+
+    deadline = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
+        seconds=INBOX_PROCESSING_LEASE_SECONDS
+    )
+    stmt = (
+        update(MessageRecord)
+        .where(
+            MessageRecord.receiver_id == current_agent,
+            MessageRecord.hub_msg_id.in_(body.message_ids),
+            MessageRecord.state == MessageState.processing,
+        )
+        .values(next_retry_at=deadline)
+    )
+    result = await db.execute(stmt)
+    renewed = result.rowcount or 0
+    await db.commit()
+    logger.debug(
+        "Renewed %d inbox message leases for agent=%s (requested %d)",
+        renewed,
+        current_agent,
+        len(body.message_ids),
+    )
+    return InboxLeaseRenewResponse(renewed=renewed)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/hub/routers/owner_chat_ws.py
+++ b/backend/hub/routers/owner_chat_ws.py
@@ -911,6 +911,7 @@ async def owner_chat_ws(ws: WebSocket):
                     "sender": "user",
                     "room_id": room_id,
                     "text": text,
+                    "delivery_state": MessageState.queued.value,
                     "created_at": now,
                 }
                 if client_msg_id:

--- a/backend/hub/schemas.py
+++ b/backend/hub/schemas.py
@@ -374,6 +374,14 @@ class InboxAckResponse(BaseModel):
     acked: int
 
 
+class InboxLeaseRenewRequest(BaseModel):
+    message_ids: list[str]
+
+
+class InboxLeaseRenewResponse(BaseModel):
+    renewed: int
+
+
 # --- History schemas ---
 
 

--- a/backend/tests/test_m3_hub.py
+++ b/backend/tests/test_m3_hub.py
@@ -1,6 +1,7 @@
 """Tests for M3 Hub/Router: send, receipt, status, inbox, history."""
 
 import base64
+import datetime as dt
 import hashlib
 import json
 import time
@@ -794,7 +795,7 @@ async def test_inbox_poll_marks_delivered(client: AsyncClient, db_session: Async
 
 @pytest.mark.asyncio
 async def test_inbox_poll_peek_mode(client: AsyncClient, db_session: AsyncSession):
-    """ack=false leaves messages in queued state."""
+    """ack=false claims messages without marking them delivered."""
     (sk_a, alice_id, alice_key, alice_token), (
         sk_b,
         bob_id,
@@ -822,6 +823,124 @@ async def test_inbox_poll_peek_mode(client: AsyncClient, db_session: AsyncSessio
     )
     rec = result.scalar_one()
     assert rec.state == MessageState.processing
+
+
+@pytest.mark.asyncio
+async def test_inbox_claim_notifies_owner_chat_processing_state(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """ack=false exposes the real daemon claim without making status delivery authoritative."""
+    (sk_a, alice_id, alice_key, alice_token), (
+        _sk_b,
+        bob_id,
+        _bob_key,
+        bob_token,
+    ) = await _setup_two_agents_no_endpoint(client)
+    envelope = await _send_queued_message(
+        client, sk_a, alice_key, alice_id, bob_id, alice_token
+    )
+    result = await db_session.execute(
+        select(MessageRecord).where(MessageRecord.msg_id == envelope["msg_id"])
+    )
+    rec = result.scalar_one()
+    rec.room_id = "rm_oc_delivery_state"
+    rec.source_user_id = "owner-user-id"
+    rec.source_session_kind = "owner_chat"
+    await db_session.commit()
+
+    deliver_local = AsyncMock()
+    monkeypatch.setattr("hub.routers.hub.owner_chat_cache.deliver_local", deliver_local)
+    monkeypatch.setattr("hub.routers.hub.owner_chat_cache.redis_enabled", lambda: False)
+
+    resp = await client.get(
+        "/hub/inbox",
+        headers=_auth_header(bob_token),
+        params={"ack": "false", "timeout": 0},
+    )
+
+    assert resp.status_code == 200
+    deliver_local.assert_awaited_once()
+    user_id, agent_id, frame = deliver_local.await_args.args
+    assert user_id == "owner-user-id"
+    assert agent_id == bob_id
+    assert frame == {
+        "type": "delivery_status",
+        "hub_msg_id": rec.hub_msg_id,
+        "trace_id": rec.hub_msg_id,
+        "room_id": "rm_oc_delivery_state",
+        "state": "processing",
+        "updated_at": frame["updated_at"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_inbox_processing_lease_renews_until_explicit_ack(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """Only the receiver can renew a processing lease; explicit ack ends it."""
+    (sk_a, alice_id, alice_key, alice_token), (
+        sk_b,
+        bob_id,
+        bob_key,
+        bob_token,
+    ) = await _setup_two_agents_no_endpoint(client)
+
+    envelope = await _send_queued_message(
+        client, sk_a, alice_key, alice_id, bob_id, alice_token
+    )
+    poll = await client.get(
+        "/hub/inbox",
+        headers=_auth_header(bob_token),
+        params={"ack": "false", "timeout": 0},
+    )
+    assert poll.status_code == 200
+    hub_msg_id = poll.json()["messages"][0]["hub_msg_id"]
+
+    result = await db_session.execute(
+        select(MessageRecord).where(MessageRecord.msg_id == envelope["msg_id"])
+    )
+    rec = result.scalar_one()
+    short_deadline = dt.datetime.now(dt.timezone.utc) + dt.timedelta(seconds=5)
+    rec.next_retry_at = short_deadline
+    await db_session.commit()
+
+    wrong_owner = await client.post(
+        "/hub/inbox/lease/renew",
+        headers=_auth_header(alice_token),
+        json={"message_ids": [hub_msg_id]},
+    )
+    assert wrong_owner.status_code == 200
+    assert wrong_owner.json() == {"renewed": 0}
+
+    renewed = await client.post(
+        "/hub/inbox/lease/renew",
+        headers=_auth_header(bob_token),
+        json={"message_ids": [hub_msg_id]},
+    )
+    assert renewed.status_code == 200
+    assert renewed.json() == {"renewed": 1}
+    await db_session.refresh(rec)
+    assert rec.state == MessageState.processing
+    assert rec.next_retry_at is not None
+    renewed_deadline = rec.next_retry_at
+    if renewed_deadline.tzinfo is None:
+        renewed_deadline = renewed_deadline.replace(tzinfo=dt.timezone.utc)
+    assert renewed_deadline > short_deadline
+
+    acked = await client.post(
+        "/hub/inbox/ack",
+        headers=_auth_header(bob_token),
+        json={"message_ids": [hub_msg_id]},
+    )
+    assert acked.status_code == 200
+    assert acked.json() == {"acked": 1}
+    await db_session.refresh(rec)
+    assert rec.state == MessageState.delivered
+    assert rec.delivered_at is not None
+    assert rec.acked_at is not None
+    assert rec.next_retry_at is None
 
 
 @pytest.mark.asyncio
@@ -1241,6 +1360,54 @@ def _patch_expiry_session(db_session):
 
 
 @pytest.mark.asyncio
+async def test_expired_inbox_processing_lease_requeues_message(
+    client, db_session, monkeypatch: pytest.MonkeyPatch
+):
+    """A crashed consumer's processing message becomes pollable again."""
+    from hub.expiry import _reclaim_stale_processing
+
+    (sk_a, alice_id, alice_key, alice_token), (
+        _sk_b,
+        bob_id,
+        _bob_key,
+        bob_token,
+    ) = await _setup_two_agents_no_endpoint(client)
+    envelope = await _send_queued_message(
+        client, sk_a, alice_key, alice_id, bob_id, alice_token
+    )
+    poll = await client.get(
+        "/hub/inbox",
+        headers=_auth_header(bob_token),
+        params={"ack": "false", "timeout": 0},
+    )
+    assert poll.status_code == 200
+
+    result = await db_session.execute(
+        select(MessageRecord).where(MessageRecord.msg_id == envelope["msg_id"])
+    )
+    rec = result.scalar_one()
+    rec.next_retry_at = dt.datetime.now(dt.timezone.utc) - dt.timedelta(seconds=1)
+    await db_session.commit()
+
+    delivery_state = AsyncMock()
+    monkeypatch.setattr(
+        "hub.routers.hub.notify_owner_chat_delivery_state",
+        delivery_state,
+    )
+    with _patch_expiry_session(db_session):
+        await _reclaim_stale_processing()
+
+    await db_session.refresh(rec)
+    assert rec.state == MessageState.queued
+    assert rec.next_retry_at is None
+    delivery_state.assert_awaited_once()
+    assert delivery_state.await_args.kwargs == {
+        "state": MessageState.queued,
+        "reason": "processing_lease_expired",
+    }
+
+
+@pytest.mark.asyncio
 async def test_expiry_loop_marks_expired_message_as_failed(client, db_session):
     """message_expiry_loop should mark queued messages past TTL as failed."""
     from hub.expiry import _expire_batch
@@ -1462,5 +1629,3 @@ async def test_expiry_loop_starvation_long_ttl_does_not_block_short(client, db_s
         "Expired short-TTL message was starved by older non-expired long-TTL messages"
     )
     assert expired_record.last_error == "TTL_EXPIRED"
-
-

--- a/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
+++ b/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
@@ -29,6 +29,7 @@ function makeClient(overrides: Partial<BotCordChannelClient> = {}): BotCordChann
     refreshToken: vi.fn(async () => "test-token-2"),
     pollInbox: vi.fn().mockResolvedValue({ messages: [], count: 0, has_more: false }),
     ackMessages: vi.fn().mockResolvedValue(undefined),
+    renewInboxLease: vi.fn().mockResolvedValue(undefined),
     sendMessage: vi
       .fn()
       .mockResolvedValue({ hub_msg_id: "m_provider", queued: true, status: "queued" }),
@@ -701,6 +702,64 @@ describe("createBotCordChannel — inbox normalization", () => {
 // ---------------------------------------------------------------------------
 
 describe("createBotCordChannel — ack + dedup", () => {
+  it("renews a processing lease until the envelope is accepted", async () => {
+    const server = await startAuthOkServer();
+    try {
+      const msg = makeInbox({ hub_msg_id: "m_lease_1" });
+      const client = makeClient({
+        pollInbox: vi.fn().mockResolvedValueOnce({
+          messages: [msg],
+          count: 1,
+          has_more: false,
+        }).mockResolvedValue({ messages: [], count: 0, has_more: false }),
+        getHubUrl: vi.fn().mockReturnValue(server.url),
+      });
+      const channel = createBotCordChannel({
+        id: "botcord-main",
+        accountId: "ag_self",
+        agentId: "ag_self",
+        client,
+        hubBaseUrl: server.url,
+        pollIntervalMs: 0,
+        inboxLeaseRenewIntervalMs: 10,
+      });
+      const abort = new AbortController();
+      const emits: GatewayInboundEnvelope[] = [];
+      let releaseEmit!: () => void;
+      const emitBlocked = new Promise<void>((resolve) => {
+        releaseEmit = resolve;
+      });
+      const startP = channel.start({
+        config: stubConfig,
+        accountId: "ag_self",
+        abortSignal: abort.signal,
+        log: silentLog,
+        emit: async (env) => {
+          emits.push(env);
+          await emitBlocked;
+        },
+        setStatus: () => {},
+      });
+
+      await vi.waitFor(() => expect(emits).toHaveLength(1));
+      await vi.waitFor(() =>
+        expect(client.renewInboxLease).toHaveBeenCalledWith(["m_lease_1"]),
+      );
+
+      await emits[0]!.ack!.accept();
+      const renewCount = vi.mocked(client.renewInboxLease).mock.calls.length;
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      expect(client.renewInboxLease).toHaveBeenCalledTimes(renewCount);
+      expect(client.ackMessages).toHaveBeenCalledWith(["m_lease_1"]);
+
+      releaseEmit();
+      abort.abort();
+      await startP;
+    } finally {
+      await server.close();
+    }
+  });
+
   it("envelope.ack.accept() calls client.ackMessages with the hub_msg_id", async () => {
     const server = await startAuthOkServer();
     try {

--- a/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
+++ b/packages/daemon/src/gateway/__tests__/dispatcher.test.ts
@@ -2730,19 +2730,33 @@ describe("Dispatcher", () => {
     expect(Object.keys(dispatcher.turns()).length).toBe(0);
   });
 
-  it("ack.accept() is called before runtime.run() starts", async () => {
+  it("ack.accept() is called only after runtime.run() finishes", async () => {
     const order: string[] = [];
-    const runtime = new FakeRuntime({
-      observeRun: () => order.push("run"),
-      newSessionId: "sid",
+    let finishRun!: () => void;
+    const runBlocked = new Promise<void>((resolve) => {
+      finishRun = resolve;
     });
+    const runtime: RuntimeAdapter = {
+      id: "claude-code",
+      run: async () => {
+        order.push("run:start");
+        await runBlocked;
+        order.push("run:end");
+        return { text: "ok", newSessionId: "sid" };
+      },
+    };
     const { dispatcher } = await scaffold({ runtimeFactory: () => runtime });
     const accept = vi.fn(async () => {
       order.push("accept");
     });
 
-    await dispatcher.handle(makeEnvelope({}, { accept }));
-    expect(order).toEqual(["accept", "run"]);
+    const handling = dispatcher.handle(makeEnvelope({}, { accept }));
+    await vi.waitFor(() => expect(order).toEqual(["run:start"]));
+    expect(accept).not.toHaveBeenCalled();
+
+    finishRun();
+    await handling;
+    expect(order).toEqual(["run:start", "run:end", "accept"]);
   });
 
   it("route match wins over default: uses match's cwd / runtime / extraArgs", async () => {
@@ -3039,7 +3053,7 @@ describe("Dispatcher", () => {
     expect(store.all()[0].memoryVersion).toBe("wm-sha256:same");
   });
 
-  it("onInbound: observer is invoked with the message between ack and runtime.run", async () => {
+  it("onInbound: observer runs before runtime and terminal ack", async () => {
     const order: string[] = [];
     const runtime = new FakeRuntime({
       newSessionId: "sid",
@@ -3066,7 +3080,7 @@ describe("Dispatcher", () => {
     });
 
     await dispatcher.handle(makeEnvelope({ id: "msg_obs_1" }, { accept }));
-    expect(order).toEqual(["ack", "observe", "run"]);
+    expect(order).toEqual(["observe", "run", "ack"]);
     expect(seen).toEqual(["msg_obs_1"]);
   });
 
@@ -3590,34 +3604,49 @@ describe("Dispatcher", () => {
     });
 
     // m1 arrives → triggers immediate turn.
+    const accept1 = vi.fn(async () => {});
+    const accept2 = vi.fn(async () => {});
+    const accept3 = vi.fn(async () => {});
     const p1 = dispatcher.handle(
-      makeEnvelope({
-        id: "m1",
-        text: "hello",
-        raw: { hub_msg_id: "m1", text: "hello" },
-        conversation: { id: "rm_grp_x", kind: "group" },
-      })
+      makeEnvelope(
+        {
+          id: "m1",
+          text: "hello",
+          raw: { hub_msg_id: "m1", text: "hello" },
+          conversation: { id: "rm_grp_x", kind: "group" },
+        },
+        { accept: accept1 }
+      )
     );
     // Let the worker start runtime.run for m1.
     await Promise.resolve();
     await Promise.resolve();
     // m2 + m3 arrive while m1 is in flight → buffered, must coalesce.
     const p2 = dispatcher.handle(
-      makeEnvelope({
-        id: "m2",
-        text: "second",
-        raw: { hub_msg_id: "m2", text: "second" },
-        conversation: { id: "rm_grp_x", kind: "group" },
-      })
+      makeEnvelope(
+        {
+          id: "m2",
+          text: "second",
+          raw: { hub_msg_id: "m2", text: "second" },
+          conversation: { id: "rm_grp_x", kind: "group" },
+        },
+        { accept: accept2 }
+      )
     );
     const p3 = dispatcher.handle(
-      makeEnvelope({
-        id: "m3",
-        text: "third",
-        raw: { hub_msg_id: "m3", text: "third" },
-        conversation: { id: "rm_grp_x", kind: "group" },
-      })
+      makeEnvelope(
+        {
+          id: "m3",
+          text: "third",
+          raw: { hub_msg_id: "m3", text: "third" },
+          conversation: { id: "rm_grp_x", kind: "group" },
+        },
+        { accept: accept3 }
+      )
     );
+    expect(accept1).not.toHaveBeenCalled();
+    expect(accept2).not.toHaveBeenCalled();
+    expect(accept3).not.toHaveBeenCalled();
     await Promise.all([p1, p2, p3]);
 
     // Exactly two runtime turns: m1 alone, then a single coalesced turn merging m2+m3.
@@ -3627,6 +3656,9 @@ describe("Dispatcher", () => {
     // Anchor of merged turn is the latest entry (m3); raw.batch holds both.
     expect(composeCalls[1].id).toBe("m3");
     expect(composeCalls[1].batchSize).toBe(2);
+    expect(accept1).toHaveBeenCalledTimes(1);
+    expect(accept2).toHaveBeenCalledTimes(1);
+    expect(accept3).toHaveBeenCalledTimes(1);
     // Sends gated for non-owner-chat room.
     expect(channel.sends.length).toBe(0);
   });

--- a/packages/daemon/src/gateway/channels/botcord.ts
+++ b/packages/daemon/src/gateway/channels/botcord.ts
@@ -38,6 +38,7 @@ const SEEN_MESSAGES_CAP = 500;
 const OWNER_CHAT_PREFIX = "rm_oc_";
 const DM_ROOM_PREFIX = "rm_dm_";
 const INBOX_POLL_LIMIT = 50;
+const INBOX_LEASE_RENEW_INTERVAL_MS = 40_000;
 const CHANNEL_PERMANENT_STOP = "channel_permanent_stop";
 const DEFAULT_REPLYING_STATUS_EMOJI = "⏳";
 // Matches the dispatcher's 30-minute turn hard timeout — a turn can never
@@ -68,6 +69,7 @@ export interface BotCordChannelClient {
     roomId?: string;
   }): Promise<{ messages: InboxMessage[]; count: number; has_more: boolean }>;
   ackMessages(messageIds: string[]): Promise<void>;
+  renewInboxLease(messageIds: string[]): Promise<void>;
   uploadFile?(
     filePath: string,
     filename: string,
@@ -120,6 +122,8 @@ export interface BotCordChannelOptions {
   hubBaseUrl?: string;
   /** Periodic inbox polling fallback. Set to 0 to disable. Defaults to 30s. */
   pollIntervalMs?: number;
+  /** Test hook: override the processing-lease renewal interval. Defaults to 40s. */
+  inboxLeaseRenewIntervalMs?: number;
   /** Test hook: supply a pre-built client instead of loading credentials from disk. */
   client?: BotCordChannelClient;
   /** Test hook: supply a client factory. Ignored when `client` is provided. */
@@ -481,6 +485,7 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
   const seenMessages = new Set<string>();
   const pendingHandoffMessages = new Set<string>();
   const handoffTails = new Map<string, Promise<void>>();
+  const activeLeaseRenewals = new Set<() => void>();
   let stopCallback: (() => void) | null = null;
   let setStatusCallback: ((patch: Partial<ChannelStatusSnapshot>) => void) | null = null;
 
@@ -524,6 +529,52 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
         handoffTails.delete(groupKey);
       }
     });
+  }
+
+  function startInboxLeaseRenewal(
+    client: BotCordChannelClient,
+    hubMsgIds: string[],
+    log: GatewayLogger,
+  ): () => void {
+    const intervalMs = options.inboxLeaseRenewIntervalMs ?? INBOX_LEASE_RENEW_INTERVAL_MS;
+    if (intervalMs <= 0 || hubMsgIds.length === 0) return () => undefined;
+
+    let stopped = false;
+    let renewing = false;
+    const timer = setInterval(() => {
+      if (stopped || renewing) return;
+      renewing = true;
+      void client
+        .renewInboxLease(hubMsgIds)
+        .then(() => {
+          log.debug("botcord inbox processing lease renewed", {
+            hubMsgIds,
+          });
+        })
+        .catch((err) => {
+          log.warn("botcord inbox processing lease renewal failed", {
+            hubMsgIds,
+            err: String(err),
+          });
+        })
+        .finally(() => {
+          renewing = false;
+        });
+    }, intervalMs);
+    timer.unref?.();
+
+    const stop = () => {
+      if (stopped) return;
+      stopped = true;
+      clearInterval(timer);
+      activeLeaseRenewals.delete(stop);
+    };
+    activeLeaseRenewals.add(stop);
+    return stop;
+  }
+
+  function stopInboxLeaseRenewals(): void {
+    for (const stop of [...activeLeaseRenewals]) stop();
   }
 
   function ensureClient(): BotCordChannelClient {
@@ -696,16 +747,21 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
 
       const hubIds = group.map((m) => m.hub_msg_id);
       for (const hubId of hubIds) pendingHandoffMessages.add(hubId);
+      const stopLeaseRenewal = startInboxLeaseRenewal(client, hubIds, log);
       let accepted = false;
       const markAccepted = () => {
         if (accepted) return;
         accepted = true;
+        stopLeaseRenewal();
         for (const hubId of hubIds) pendingHandoffMessages.delete(hubId);
       };
       const envelope: GatewayInboundEnvelope = {
         message: normalized,
         ack: {
           accept: async () => {
+            // Runtime handling is terminal now; stop extending ownership so
+            // an ACK failure naturally falls back to Hub lease expiry/retry.
+            stopLeaseRenewal();
             try {
               // Ack the entire batch together so Hub never re-delivers any
               // member of this turn if the agent succeeds on the group.
@@ -731,6 +787,7 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
           await emit(envelope);
           markAccepted();
         } catch (err) {
+          stopLeaseRenewal();
           if (!accepted) forgetSeen(hubIds);
           log.error("botcord emit threw", {
             hubMsgIds: hubIds,
@@ -866,6 +923,7 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
       running = false;
       permanentStopping = true;
       clearTimers();
+      stopInboxLeaseRenewals();
       try {
         ws?.close();
       } catch {
@@ -931,6 +989,7 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
       running = false;
       permanentStopping = true;
       clearTimers();
+      stopInboxLeaseRenewals();
       try {
         ws?.close();
       } catch {
@@ -1155,6 +1214,7 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
               failures: consecutiveAuthFailures,
             });
             running = false;
+            stopInboxLeaseRenewals();
             markStatus({
               running: false,
               connected: false,
@@ -1202,6 +1262,7 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
       if (!running) return;
       running = false;
       clearTimers();
+      stopInboxLeaseRenewals();
       markStatus({
         running: false,
         connected: false,

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -648,6 +648,11 @@ interface BufferedSerialEntry {
   channel: ChannelAdapter;
   /** Per-arrival turnId; preserved through merge so transcript can record dropped/dispatched correctly. */
   turnId: string;
+  /** Settles the originating handle only after this entry reaches a terminal queue outcome. */
+  completion?: {
+    resolve(): void;
+    reject(error: unknown): void;
+  };
 }
 
 interface QueueState {
@@ -842,7 +847,7 @@ export class Dispatcher {
     }
   }
 
-  /** Consume one inbound envelope, ack it once ownership is decided, then run its turn. */
+  /** Consume one inbound envelope and ack it only after terminal handling. */
   async handle(envelope: GatewayInboundEnvelope): Promise<void> {
     const msg = envelope.message;
 
@@ -983,9 +988,6 @@ export class Dispatcher {
       }
     }
 
-    // Ack immediately: once the dispatcher has a route + queue key, ownership is decided.
-    await this.safeAck(envelope);
-
     // Inbound transcript record — always before observers / gates so we have a
     // grounded turnId for any downstream attention_skipped / dropped / etc.
     this.emitInbound(turnId, msg);
@@ -1046,6 +1048,7 @@ export class Dispatcher {
           topicId: dispatchMsg.conversation.threadId ?? null,
           reason: "attention_gate_false",
         });
+        await this.safeAck(envelope);
         return;
       }
     }
@@ -1096,6 +1099,7 @@ export class Dispatcher {
         dispatchChannel,
         dispatchTurnId
       );
+      await this.safeAck(envelope);
       return;
     }
 
@@ -1120,6 +1124,7 @@ export class Dispatcher {
         mergedFromDeferredTurnIds
       );
     }
+    await this.safeAck(envelope);
   }
 
   /** Snapshot of currently running turns keyed by queue key. */
@@ -1495,7 +1500,22 @@ export class Dispatcher {
   ): Promise<void> {
     const q = this.getQueue(queueKey);
     this.supersedePendingPark(q);
-    q.serialBuffer.push({ route, msg, channel, turnId });
+    let resolveCompletion!: () => void;
+    let rejectCompletion!: (error: unknown) => void;
+    const completion = new Promise<void>((resolve, reject) => {
+      resolveCompletion = resolve;
+      rejectCompletion = reject;
+    });
+    q.serialBuffer.push({
+      route,
+      msg,
+      channel,
+      turnId,
+      completion: {
+        resolve: resolveCompletion,
+        reject: rejectCompletion,
+      },
+    });
     while (q.serialBuffer.length > MAX_BATCH_BUFFER_ENTRIES) {
       const dropped = q.serialBuffer.shift()!;
       this.log.warn(
@@ -1516,51 +1536,70 @@ export class Dispatcher {
         reason: "queue_overflow",
         supersededBy: null,
       });
+      dropped.completion?.resolve();
     }
-    if (q.serialWorkerActive) return;
-    q.serialWorkerActive = true;
-    try {
-      while (q.serialBuffer.length > 0) {
-        const drained = q.serialBuffer.splice(0, q.serialBuffer.length);
-        const merged = this.mergeSerialBuffer(drained, queueKey);
-        if (!merged) continue;
-        // Drained entries other than the winner get a `batch_merged` dropped
-        // record now (winner is always the last entry — see mergeSerialBuffer).
-        if (drained.length > 1) {
-          for (let i = 0; i < drained.length - 1; i++) {
-            const lost = drained[i]!;
-            this.transcript.write({
-              ts: nowIso(),
-              kind: "dropped",
-              turnId: lost.turnId,
-              agentId: lost.msg.accountId,
-              roomId: lost.msg.conversation.id,
-              topicId: lost.msg.conversation.threadId ?? null,
-              reason: "batch_merged",
-              supersededBy: merged.turnId,
-            });
+    if (!q.serialWorkerActive) {
+      q.serialWorkerActive = true;
+      let pendingMergedFromTurnIds = mergedFromTurnIds;
+      try {
+        while (q.serialBuffer.length > 0) {
+          const drained = q.serialBuffer.splice(0, q.serialBuffer.length);
+          try {
+            const merged = this.mergeSerialBuffer(drained, queueKey);
+            if (!merged) {
+              for (const entry of drained) entry.completion?.resolve();
+              continue;
+            }
+            // Drained entries other than the winner get a `batch_merged` dropped
+            // record now (winner is always the last entry — see mergeSerialBuffer).
+            if (drained.length > 1) {
+              for (let i = 0; i < drained.length - 1; i++) {
+                const lost = drained[i]!;
+                this.transcript.write({
+                  ts: nowIso(),
+                  kind: "dropped",
+                  turnId: lost.turnId,
+                  agentId: lost.msg.accountId,
+                  roomId: lost.msg.conversation.id,
+                  topicId: lost.msg.conversation.threadId ?? null,
+                  reason: "batch_merged",
+                  supersededBy: merged.turnId,
+                });
+              }
+            }
+            const mergedTurnIds =
+              drained.length > 1
+                ? [
+                    ...pendingMergedFromTurnIds,
+                    ...drained.slice(0, -1).map((e) => e.turnId),
+                  ]
+                : pendingMergedFromTurnIds;
+            pendingMergedFromTurnIds = [];
+            await this.runTurn(
+              queueKey,
+              merged.route,
+              merged.text,
+              merged.msg,
+              merged.channel,
+              merged.turnId,
+              mergedTurnIds
+            );
+            for (const entry of drained) entry.completion?.resolve();
+          } catch (err) {
+            for (const entry of drained) entry.completion?.reject(err);
+            throw err;
           }
         }
-        const mergedTurnIds =
-          drained.length > 1
-            ? [
-                ...mergedFromTurnIds,
-                ...drained.slice(0, -1).map((e) => e.turnId),
-              ]
-            : mergedFromTurnIds;
-        await this.runTurn(
-          queueKey,
-          merged.route,
-          merged.text,
-          merged.msg,
-          merged.channel,
-          merged.turnId,
-          mergedTurnIds
-        );
+      } catch (err) {
+        // An unexpected dispatcher failure is non-terminal: reject every
+        // waiting handle so its Hub lease can expire and the message retries.
+        const pending = q.serialBuffer.splice(0, q.serialBuffer.length);
+        for (const entry of pending) entry.completion?.reject(err);
+      } finally {
+        q.serialWorkerActive = false;
       }
-    } finally {
-      q.serialWorkerActive = false;
     }
+    await completion;
   }
 
   /**

--- a/packages/protocol-core/src/__tests__/client.test.ts
+++ b/packages/protocol-core/src/__tests__/client.test.ts
@@ -127,3 +127,50 @@ describe("BotCordClient token refresh", () => {
     });
   });
 });
+
+describe("BotCordClient inbox leases", () => {
+  it("serializes ack=false explicitly when polling", async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({ messages: [], count: 0, has_more: false }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new BotCordClient({
+      hubUrl: "https://hub.example",
+      agentId: "ag_test",
+      keyId: "k_test",
+      privateKey,
+      token: "cached-token",
+      tokenExpiresAt: Math.floor(Date.now() / 1000) + 3600,
+    });
+
+    await client.pollInbox({ limit: 50, ack: false });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://hub.example/hub/inbox?limit=50&ack=false",
+      expect.any(Object),
+    );
+  });
+
+  it("renews processing leases for explicit message ids", async () => {
+    const fetchMock = vi.fn(async () => Response.json({ renewed: 2 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new BotCordClient({
+      hubUrl: "https://hub.example",
+      agentId: "ag_test",
+      keyId: "k_test",
+      privateKey,
+      token: "cached-token",
+      tokenExpiresAt: Math.floor(Date.now() / 1000) + 3600,
+    });
+
+    await client.renewInboxLease(["m_1", "m_2"]);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://hub.example/hub/inbox/lease/renew",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ message_ids: ["m_1", "m_2"] }),
+      }),
+    );
+  });
+});

--- a/packages/protocol-core/src/client.ts
+++ b/packages/protocol-core/src/client.ts
@@ -360,7 +360,7 @@ export class BotCordClient {
   }): Promise<InboxPollResponse> {
     const params = new URLSearchParams();
     if (options?.limit) params.set("limit", String(options.limit));
-    if (options?.ack) params.set("ack", "true");
+    if (options?.ack !== undefined) params.set("ack", String(options.ack));
     if (options?.timeout) params.set("timeout", String(options.timeout));
     if (options?.roomId) params.set("room_id", options.roomId);
 
@@ -371,6 +371,14 @@ export class BotCordClient {
   async ackMessages(messageIds: string[]): Promise<void> {
     if (messageIds.length === 0) return;
     await this.hubFetch("/hub/inbox/ack", {
+      method: "POST",
+      body: JSON.stringify({ message_ids: messageIds }),
+    });
+  }
+
+  async renewInboxLease(messageIds: string[]): Promise<void> {
+    if (messageIds.length === 0) return;
+    await this.hubFetch("/hub/inbox/lease/renew", {
       method: "POST",
       body: JSON.stringify({ message_ids: messageIds }),
     });


### PR DESCRIPTION
## Description

修复 Cloud Agent inbox 在 daemon 领取后立即 ACK、进程崩溃时消息静默丢失的问题。Hub 现在以 PostgreSQL `processing` 租约作为投递真相源，daemon 在 runtime 处理完成后才显式 ACK；处理期间周期续租，崩溃或租约失效时自动回到 `queued`。

同时向 owner-chat 推送 `queued` / `processing` 状态，供 BotLearn Course 展示真实投递阶段。

## Related Issue

无独立 Issue；这是用户直接授权的 Cloud Agent 消息丢失修复。

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement

## Component(s) Affected

- [x] Backend (`backend/`)
- [ ] CLI (`cli/`)
- [x] Daemon (`packages/daemon/`)
- [x] Protocol Core (`packages/protocol-core/`)
- [ ] Frontend (`frontend/`)

## How Has This Been Tested?

- [x] Backend tests pass (`cd backend && uv run pytest tests/test_m3_hub.py`，45 passed)
- [ ] Frontend builds successfully (`cd frontend && npm run build`)
- [x] Package tests pass for changed TypeScript packages
- [ ] Manual testing performed (describe below)

**Test Details:**

- `pnpm --filter @botcord/protocol-core test`（36 passed）
- `pnpm --filter @botcord/daemon test`（1118 passed）
- `pnpm --filter @botcord/protocol-core build`
- `pnpm --filter @botcord/daemon build`

## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] Server code uses `async def` for all route handlers and I/O functions
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors

### Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

### Documentation
- [x] I have updated relevant documentation (if applicable)
- [x] I have added/updated docstrings for new/modified functions

### Cross-Component
- [x] If modifying crypto/signing logic, changes are consistent across backend and package consumers
- [x] If modifying session key derivation, changes are consistent across backend and daemon paths

## Screenshots (if applicable)

不适用：没有前端视觉改动。

## Additional Context

- 发布顺序：先部署 Hub，再发布并重启 daemon。
- 不涉及数据库迁移或新增环境变量；复用现有 `MessageRecord.state`、`next_retry_at` 与 `acked_at`。
- 新增 changeset，为 `@botcord/daemon` 与 `@botcord/protocol-core` 发布 patch 版本。
- 语义为至少一次投递：若 runtime 已产生外部副作用但 daemon 在 ACK 前崩溃，消息会重试，极端情况下可能重复执行。

## Pre-Submission Verification

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] This PR addresses an approved issue that was assigned to me
- [x] I have not included unrelated changes in this PR
- [x] My PR title follows conventional commits format (e.g., `feat: add user authentication`)
