### PR TITLE
feat: add Cloud Agent progress reporting

### DIFF
--- a/.changeset/progress-wolves-report.md
+++ b/.changeset/progress-wolves-report.md
@@ -1,0 +1,5 @@
+---
+"@botcord/daemon": patch
+---
+
+Register a per-agent `report_progress` MCP tool for DeepSeek TUI and forward its bounded summaries as dedicated owner-chat progress blocks instead of ordinary tool cards.

--- a/packages/daemon/src/__tests__/report-progress-server.test.ts
+++ b/packages/daemon/src/__tests__/report-progress-server.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  handleReportProgressMcpMessage,
+  REPORT_PROGRESS_MAX_SUMMARY_LENGTH,
+} from "../mcp/report-progress-server.js";
+
+describe("report_progress MCP server", () => {
+  it("advertises one bounded progress tool", () => {
+    const response = handleReportProgressMcpMessage({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/list",
+      params: {},
+    });
+
+    expect(response).toMatchObject({
+      id: 1,
+      result: {
+        tools: [{
+          name: "report_progress",
+          inputSchema: {
+            additionalProperties: false,
+            required: ["summary", "status"],
+          },
+        }],
+      },
+    });
+  });
+
+  it("returns a structured acknowledgement for a valid report", () => {
+    const response = handleReportProgressMcpMessage({
+      jsonrpc: "2.0",
+      id: "call-1",
+      method: "tools/call",
+      params: {
+        name: "report_progress",
+        arguments: { summary: "已读取项目结构，正在检查测试入口。", status: "in_progress" },
+      },
+    });
+
+    const text = (response as any).result.content[0].text;
+    expect(JSON.parse(text)).toEqual({
+      schemaVersion: "tool-result/0.1",
+      ok: true,
+      code: "progress_reported",
+      data: { summary: "已读取项目结构，正在检查测试入口。", status: "in_progress" },
+      evidence: [],
+    });
+  });
+
+  it("rejects invalid status and oversized summaries", () => {
+    const invalidStatus = handleReportProgressMcpMessage({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/call",
+      params: {
+        name: "report_progress",
+        arguments: { summary: "working", status: "done" },
+      },
+    });
+    expect(invalidStatus).toMatchObject({ id: 2, error: { code: -32602 } });
+
+    const oversized = handleReportProgressMcpMessage({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: {
+        name: "report_progress",
+        arguments: { summary: "x".repeat(REPORT_PROGRESS_MAX_SUMMARY_LENGTH + 1), status: "completed" },
+      },
+    });
+    expect(oversized).toMatchObject({ id: 3, error: { code: -32602 } });
+  });
+
+  it("does not reply to notifications", () => {
+    expect(handleReportProgressMcpMessage({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    })).toBeNull();
+  });
+});

--- a/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
+++ b/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
@@ -1212,6 +1212,31 @@ describe("createBotCordChannel — ack + dedup", () => {
 // ---------------------------------------------------------------------------
 
 describe("createBotCordChannel — streamBlock()", () => {
+  it("normalizes user-visible progress without forwarding an internal tool envelope", () => {
+    expect(
+      __normalizeBlockForHubForTests(
+        {
+          kind: "progress",
+          seq: 1,
+          raw: {
+            summary: "已读取项目结构，正在核对测试入口。",
+            status: "in_progress",
+            source: "report_progress",
+            secret: "must-not-leak",
+          },
+        },
+        1,
+      ),
+    ).toEqual({
+      kind: "progress",
+      seq: 1,
+      payload: {
+        summary: "已读取项目结构，正在核对测试入口。",
+        status: "in_progress",
+      },
+    });
+  });
+
   it("normalizes Codex tool items without using internal ids as params", () => {
     expect(
       __normalizeBlockForHubForTests(

--- a/packages/daemon/src/gateway/__tests__/deepseek-tui-adapter.test.ts
+++ b/packages/daemon/src/gateway/__tests__/deepseek-tui-adapter.test.ts
@@ -1,9 +1,13 @@
 import { afterAll, describe, expect, it } from "vitest";
 import http, { type ServerResponse } from "node:http";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { DeepseekTuiAdapter } from "../runtimes/deepseek-tui.js";
+import {
+  __withReportProgressSystemPromptForTests,
+  __writeReportProgressMcpConfigForTests,
+  DeepseekTuiAdapter,
+} from "../runtimes/deepseek-tui.js";
 
 const tmpRoot = mkdtempSync(path.join(os.tmpdir(), "gateway-deepseek-tui-"));
 
@@ -147,6 +151,34 @@ function runAdapter(
 }
 
 describe("DeepseekTuiAdapter", () => {
+  it("adds stable progress reporting rules without replacing existing system context", () => {
+    const prompt = __withReportProgressSystemPromptForTests("course runtime rules", true);
+    expect(prompt).toContain("[BotCord User-Visible Progress]");
+    expect(prompt).toContain("mcp_botlearn_report_progress");
+    expect(prompt).toContain("Never include hidden reasoning");
+    expect(prompt).toContain("course runtime rules");
+    expect(__withReportProgressSystemPromptForTests("course runtime rules", false))
+      .toBe("course runtime rules");
+  });
+
+  it("writes an isolated, owner-only MCP config for the BotLearn progress server", () => {
+    const configPath = path.join(tmpRoot, "agent-progress", "mcp.json");
+    expect(__writeReportProgressMcpConfigForTests(configPath, "/opt/botcord/report-progress.js"))
+      .toBe(configPath);
+    expect(JSON.parse(readFileSync(configPath, "utf8"))).toEqual({
+      servers: {
+        botlearn: {
+          command: process.execPath,
+          args: ["/opt/botcord/report-progress.js"],
+          env: {},
+          disabled: false,
+          required: true,
+        },
+      },
+    });
+    expect(statSync(configPath).mode & 0o777).toBe(0o600);
+  });
+
   it("creates a thread, starts a turn, parses SSE assistant text, and emits tool blocks", async () => {
     const server = await startMockDeepseekServer();
     try {
@@ -337,6 +369,86 @@ describe("DeepseekTuiAdapter", () => {
       await expect(result).resolves.toMatchObject({ text: "done" });
       expect(blocks).toEqual(expect.arrayContaining(["tool_use", "tool_result", "assistant_text"]));
       expect(status).toContainEqual({ phase: "updated", label: "web_search" });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("turns report_progress into a dedicated block and suppresses its tool result", async () => {
+    const server = await startMockDeepseekServer({
+      events: [
+        {
+          event: "turn.started",
+          data: { thread_id: "thr_test", turn_id: "turn_test", event: "turn.started" },
+        },
+        {
+          event: "item.started",
+          data: {
+            thread_id: "thr_test",
+            turn_id: "turn_test",
+            event: "item.started",
+            payload: {
+              item: { id: "item_progress", kind: "tool_call", status: "in_progress" },
+              tool: {
+                id: "call_progress",
+                name: "mcp_botlearn_report_progress",
+                input: {
+                  summary: "已读取项目结构，正在核对测试入口。",
+                  status: "in_progress",
+                  secret: "must-not-leak",
+                },
+              },
+            },
+          },
+        },
+        {
+          event: "item.completed",
+          data: {
+            thread_id: "thr_test",
+            turn_id: "turn_test",
+            event: "item.completed",
+            payload: {
+              item: {
+                id: "item_progress",
+                kind: "tool_call",
+                status: "completed",
+                detail: "progress_reported",
+              },
+            },
+          },
+        },
+        {
+          event: "item.delta",
+          data: {
+            thread_id: "thr_test",
+            turn_id: "turn_test",
+            event: "item.delta",
+            payload: { kind: "agent_message", delta: "done" },
+          },
+        },
+        {
+          event: "turn.completed",
+          data: { thread_id: "thr_test", turn_id: "turn_test", event: "turn.completed" },
+        },
+      ],
+    });
+    try {
+      const { result, blocks, blockEvents, status } = runAdapter(server.baseUrl, server.token);
+      await expect(result).resolves.toMatchObject({ text: "done" });
+      expect(blocks).toContain("progress");
+      expect(blocks).not.toContain("tool_use");
+      expect(blocks).not.toContain("tool_result");
+      const progress = blockEvents.find((block) => block.kind === "progress");
+      expect(progress?.raw).toEqual({
+        summary: "已读取项目结构，正在核对测试入口。",
+        status: "in_progress",
+        source: "report_progress",
+      });
+      expect(JSON.stringify(progress)).not.toContain("must-not-leak");
+      expect(status).not.toContainEqual({
+        phase: "updated",
+        label: "mcp_botlearn_report_progress",
+      });
     } finally {
       await server.close();
     }

--- a/packages/daemon/src/gateway/channels/botcord.ts
+++ b/packages/daemon/src/gateway/channels/botcord.ts
@@ -1581,6 +1581,14 @@ function normalizeBlockForHub(
     return withRaw({ kind: "tool_result", seq, payload });
   }
 
+  if (kind === "progress") {
+    const summary = typeof raw?.summary === "string" ? raw.summary.trim().slice(0, 240) : "";
+    const status = raw?.status === "completed" ? "completed" : "in_progress";
+    if (summary) payload.summary = summary;
+    payload.status = status;
+    return { kind: "progress", seq, payload };
+  }
+
   if (kind === "system") {
     if (typeof raw?.subtype === "string") payload.subtype = raw.subtype;
     if (typeof raw?.session_id === "string") payload.session_id = raw.session_id;

--- a/packages/daemon/src/gateway/dispatcher.ts
+++ b/packages/daemon/src/gateway/dispatcher.ts
@@ -1955,8 +1955,9 @@ export class Dispatcher {
      * auto-synthesizing thinking on plain `system`/`other` blocks. This
      * prevents the post-prose flicker caused by Codex's `turn.completed` /
      * Claude Code's `result` (both arrive as system/other AFTER the prose).
-     * `tool_use` is the explicit exception — agents that legitimately go
-     * back to work after a partial answer should still drive "Thinking…".
+     * `tool_use` and user-visible `progress` are explicit exceptions — agents
+     * that legitimately go back to work after a partial answer should still
+     * drive "Thinking…".
      */
     let sawAssistantText = false;
     let blocksSent = 0;
@@ -2126,7 +2127,10 @@ export class Dispatcher {
           // `turn.completed`, claude `result`) would otherwise flicker
           // "Thinking…" right after the final answer.
           if (!thinkingActive && block.kind !== "assistant_text") {
-            const allowed = !sawAssistantText || block.kind === "tool_use";
+            const allowed =
+              !sawAssistantText ||
+              block.kind === "tool_use" ||
+              block.kind === "progress";
             if (allowed) {
               thinkingActive = true;
               sendThinkingMarker("started", undefined, "dispatcher");

--- a/packages/daemon/src/gateway/runtimes/deepseek-tui.ts
+++ b/packages/daemon/src/gateway/runtimes/deepseek-tui.ts
@@ -1,10 +1,14 @@
 import { spawn, type ChildProcess } from "node:child_process";
-import { existsSync, mkdirSync, realpathSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, realpathSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import net from "node:net";
 import { buildCliEnv } from "../cli-resolver.js";
 import { consoleLogger } from "../log.js";
+import {
+  REPORT_PROGRESS_MAX_SUMMARY_LENGTH,
+  reportProgressMcpServerPath,
+} from "../../mcp/report-progress-server.js";
 import { prependSystemRules } from "../../system-rules.js";
 import {
   readCommandVersion,
@@ -34,6 +38,25 @@ const REASONING_PROGRESS_INTERVAL_MS = 4_000;
 const STARTUP_TIMEOUT_MS = 30_000;
 const STARTUP_POLL_MS = 250;
 const SSE_TEXT_CAP = 1 * 1024 * 1024;
+const REPORT_PROGRESS_RUNTIME_TOOL_NAMES = new Set([
+  "report_progress",
+  "mcp_botlearn_report_progress",
+  "mcp__botlearn__report_progress",
+]);
+const REPORT_PROGRESS_SYSTEM_INSTRUCTIONS = [
+  "[BotCord User-Visible Progress]",
+  "For non-trivial work, call mcp_botlearn_report_progress after understanding the task and at meaningful phase boundaries.",
+  "Use status=in_progress while work continues and status=completed only when a meaningful phase has finished.",
+  "Keep summary to one short factual sentence about completed work or the next visible action.",
+  "Never include hidden reasoning, secrets, credentials, raw tool output, or unsupported claims.",
+  "This tool reports UI progress only. It does not complete a course task, replace the final answer, or prove acceptance criteria.",
+  "Do not call it for trivial requests or for every low-level tool invocation.",
+].join("\n");
+
+interface DeepseekProgressReport {
+  summary: string;
+  status: "in_progress" | "completed";
+}
 
 interface DeepseekProcessHandle {
   child: ChildProcess;
@@ -164,12 +187,16 @@ export class DeepseekTuiAdapter implements RuntimeAdapter {
 
       if (!threadId) {
         threadId = await this.createThread(handle.baseUrl, headers, opts, turnAbort.signal);
-      } else if (opts.systemContext !== undefined || opts.systemRules?.length) {
+      } else if (
+        opts.systemContext !== undefined ||
+        opts.systemRules?.length ||
+        this.progressReportingEnabled(opts)
+      ) {
         await this.patchThreadSystemContext(
           handle.baseUrl,
           headers,
           threadId,
-          prependSystemRules(opts.systemContext, opts.systemRules),
+          this.systemPrompt(opts),
           turnAbort.signal,
         );
       }
@@ -296,11 +323,24 @@ export class DeepseekTuiAdapter implements RuntimeAdapter {
       NO_COLOR: "1",
     };
     if (opts.accountId) {
-      const runtimeDir = path.join(agentDeepseekHomeDir(opts.accountId), "runtime");
+      const agentHome = agentDeepseekHomeDir(opts.accountId);
+      const runtimeDir = path.join(agentHome, "runtime");
       mkdirSync(runtimeDir, { recursive: true });
       env.DEEPSEEK_RUNTIME_DIR = runtimeDir;
+      env.DEEPSEEK_MCP_CONFIG = writeReportProgressMcpConfig(
+        path.join(agentHome, "mcp.json"),
+      );
     }
     return env;
+  }
+
+  private systemPrompt(opts: RuntimeRunOptions): string | undefined {
+    const base = prependSystemRules(opts.systemContext, opts.systemRules);
+    return withReportProgressSystemPrompt(base, this.progressReportingEnabled(opts));
+  }
+
+  private progressReportingEnabled(opts: RuntimeRunOptions): boolean {
+    return !this.explicitServerUrl && !!opts.accountId;
   }
 
   private async createThread(
@@ -320,7 +360,7 @@ export class DeepseekTuiAdapter implements RuntimeAdapter {
     const selection = parseDeepseekRuntimeSelection(opts.extraArgs);
     if (selection.model) body.model = selection.model;
     if (selection.reasoningEffort) body.reasoning_effort = selection.reasoningEffort;
-    const systemPrompt = prependSystemRules(opts.systemContext, opts.systemRules);
+    const systemPrompt = this.systemPrompt(opts);
     if (systemPrompt) body.system_prompt = systemPrompt;
     const res = await this.requestJson<any>(`${baseUrl}/v1/threads`, {
       method: "POST",
@@ -417,6 +457,7 @@ export class DeepseekTuiAdapter implements RuntimeAdapter {
       let errorText = "";
       let capped = false;
       let lastReasoningProgressAt = 0;
+      const progressToolIds = new Set<string>();
       let idleTimer: NodeJS.Timeout | undefined;
       let rejectIdle: ((err: Error) => void) | undefined;
       const idleFailure = new Promise<never>((_resolve, reject) => {
@@ -454,7 +495,7 @@ export class DeepseekTuiAdapter implements RuntimeAdapter {
         const eventTurnId = stringField(payload, "turn_id") ?? stringField(payload?.payload, "turn_id");
         if (turnId && eventTurnId && eventTurnId !== turnId) return false;
         seq += 1;
-        let block = normalizeDeepseekEvent(eventName, payload, seq);
+        let block = normalizeDeepseekEvent(eventName, payload, seq, progressToolIds);
         if (block?.kind === "thinking" && eventName === "item.delta") {
           const now = Date.now();
           if (now - lastReasoningProgressAt < REASONING_PROGRESS_INTERVAL_MS) {
@@ -473,7 +514,10 @@ export class DeepseekTuiAdapter implements RuntimeAdapter {
         }
         if (eventName === "turn.started" || embeddedDeepseekEvent(payload) === "turn.started") {
           opts.onStatus?.({ kind: "thinking", phase: "started", label: "Thinking" });
-        } else if (eventName === "tool.started" || isToolStarted(eventName, payload)) {
+        } else if (
+          (eventName === "tool.started" || isToolStarted(eventName, payload)) &&
+          !isReportProgressToolName(deepseekToolName(payload))
+        ) {
           const label =
             stringField(payload, "name") ??
             stringField(payload?.tool, "name") ??
@@ -544,14 +588,38 @@ export function __resetDeepseekTuiPoolForTests(): void {
   }
 }
 
-function normalizeDeepseekEvent(eventName: string, payload: any, seq: number): StreamBlock | null {
+function normalizeDeepseekEvent(
+  eventName: string,
+  payload: any,
+  seq: number,
+  progressToolIds: Set<string>,
+): StreamBlock | null {
   if (eventName === "message.delta") {
     return { raw: { event: eventName, payload }, kind: "assistant_text", seq };
   }
   if (eventName === "tool.started" || isToolStarted(eventName, payload)) {
+    const toolName = deepseekToolName(payload);
+    if (isReportProgressToolName(toolName)) {
+      for (const id of deepseekToolIds(payload)) progressToolIds.add(id);
+      const report = deepseekProgressReport(payload);
+      if (!report) return null;
+      return {
+        raw: { ...report, source: "report_progress" },
+        kind: "progress",
+        seq,
+      };
+    }
     return { raw: { event: eventName, payload }, kind: "tool_use", seq };
   }
   if (eventName === "tool.completed" || isToolCompleted(eventName, payload)) {
+    const ids = deepseekToolIds(payload);
+    const isProgressCompletion =
+      isReportProgressToolName(deepseekToolName(payload)) ||
+      ids.some((id) => progressToolIds.has(id));
+    if (isProgressCompletion) {
+      for (const id of ids) progressToolIds.delete(id);
+      return null;
+    }
     return { raw: { event: eventName, payload }, kind: "tool_result", seq };
   }
   if (eventName === "item.delta" && isAgentMessageDelta(payload)) {
@@ -650,6 +718,95 @@ function inferDeepseekToolName(item: any): string | undefined {
     if (match?.[1] && match[1] !== "tool_call") return match[1];
   }
   return undefined;
+}
+
+function deepseekPayloadLayers(payload: any): any[] {
+  const layers = [payload, payload?.payload, payload?.payload?.payload];
+  return layers.filter((value, index) => (
+    value && typeof value === "object" && layers.indexOf(value) === index
+  ));
+}
+
+function deepseekToolName(payload: any): string | undefined {
+  for (const layer of deepseekPayloadLayers(payload)) {
+    const tool = layer.tool && typeof layer.tool === "object" ? layer.tool : undefined;
+    const item = layer.item && typeof layer.item === "object" ? layer.item : undefined;
+    const name =
+      stringField(layer, "name") ??
+      stringField(tool, "name") ??
+      stringField(item, "name") ??
+      inferDeepseekToolName(item);
+    if (name) return name;
+  }
+  return undefined;
+}
+
+function isReportProgressToolName(name: string | undefined): boolean {
+  return !!name && REPORT_PROGRESS_RUNTIME_TOOL_NAMES.has(name.trim().toLowerCase());
+}
+
+function deepseekToolIds(payload: any): string[] {
+  const ids = new Set<string>();
+  for (const layer of deepseekPayloadLayers(payload)) {
+    const tool = layer.tool && typeof layer.tool === "object" ? layer.tool : undefined;
+    const item = layer.item && typeof layer.item === "object" ? layer.item : undefined;
+    for (const value of [
+      stringField(layer, "id"),
+      stringField(layer, "item_id"),
+      stringField(tool, "id"),
+      stringField(item, "id"),
+    ]) {
+      if (value) ids.add(value);
+    }
+  }
+  return [...ids];
+}
+
+function progressInput(payload: any): Record<string, unknown> | null {
+  for (const layer of deepseekPayloadLayers(payload)) {
+    const tool = layer.tool && typeof layer.tool === "object" ? layer.tool : undefined;
+    const item = layer.item && typeof layer.item === "object" ? layer.item : undefined;
+    const candidates = [
+      layer.input,
+      layer.arguments,
+      layer.params,
+      tool?.input,
+      tool?.arguments,
+      tool?.params,
+      item?.input,
+      item?.arguments,
+      item?.params,
+      item?.detail,
+    ];
+    for (const candidate of candidates) {
+      if (candidate && typeof candidate === "object" && !Array.isArray(candidate)) {
+        return candidate as Record<string, unknown>;
+      }
+      if (typeof candidate === "string") {
+        try {
+          const parsed = JSON.parse(candidate);
+          if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            return parsed as Record<string, unknown>;
+          }
+        } catch {
+          // Ignore display-only detail strings that are not JSON tool arguments.
+        }
+      }
+    }
+  }
+  return null;
+}
+
+function deepseekProgressReport(payload: any): DeepseekProgressReport | null {
+  const input = progressInput(payload);
+  if (!input) return null;
+  const summary = typeof input.summary === "string" ? input.summary.trim() : "";
+  const status = input.status;
+  if (!summary || (status !== "in_progress" && status !== "completed")) return null;
+  return {
+    summary: summary.slice(0, REPORT_PROGRESS_MAX_SUMMARY_LENGTH),
+    status,
+  };
 }
 
 function emptyCompletionError(stderrTail: string): string {
@@ -872,6 +1029,38 @@ function resolveDownloadedDeepseekBinary(onPath: string, deps: ProbeDeps = {}): 
 function agentDeepseekHomeDir(accountId: string): string {
   return path.join(homedir(), ".botcord", "agents", accountId, "deepseek-tui");
 }
+
+function writeReportProgressMcpConfig(configPath: string, serverPath = reportProgressMcpServerPath()): string {
+  mkdirSync(path.dirname(configPath), { recursive: true });
+  const config = {
+    servers: {
+      botlearn: {
+        command: process.execPath,
+        args: [serverPath],
+        env: {},
+        disabled: false,
+        required: true,
+      },
+    },
+  };
+  writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  chmodSync(configPath, 0o600);
+  return configPath;
+}
+
+export { writeReportProgressMcpConfig as __writeReportProgressMcpConfigForTests };
+
+function withReportProgressSystemPrompt(base: string | undefined, enabled: boolean): string | undefined {
+  if (!enabled) return base;
+  return base
+    ? `${REPORT_PROGRESS_SYSTEM_INSTRUCTIONS}\n\n${base}`
+    : REPORT_PROGRESS_SYSTEM_INSTRUCTIONS;
+}
+
+export { withReportProgressSystemPrompt as __withReportProgressSystemPromptForTests };
 
 function nullChild(): ChildProcess {
   return {

--- a/packages/daemon/src/gateway/types.ts
+++ b/packages/daemon/src/gateway/types.ts
@@ -355,7 +355,7 @@ export interface StreamBlock {
    * by an adapter) to represent "the runtime is busy but has nothing visible
    * to show yet" — see `RuntimeStatusEvent`.
    */
-  kind: "assistant_text" | "tool_use" | "tool_result" | "system" | "thinking" | "other";
+  kind: "assistant_text" | "tool_use" | "tool_result" | "system" | "thinking" | "progress" | "other";
   /** 1-based sequence number within this turn. */
   seq: number;
 }

--- a/packages/daemon/src/mcp/report-progress-server.ts
+++ b/packages/daemon/src/mcp/report-progress-server.ts
@@ -1,0 +1,183 @@
+import { createInterface } from "node:readline";
+import { fileURLToPath } from "node:url";
+
+export const REPORT_PROGRESS_TOOL_NAME = "report_progress";
+export const REPORT_PROGRESS_MAX_SUMMARY_LENGTH = 240;
+export const REPORT_PROGRESS_STATUSES = ["in_progress", "completed"] as const;
+
+export function reportProgressMcpServerPath(): string {
+  return fileURLToPath(import.meta.url);
+}
+
+type JsonRpcId = string | number | null;
+
+interface JsonRpcRequest {
+  jsonrpc?: unknown;
+  id?: unknown;
+  method?: unknown;
+  params?: unknown;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: JsonRpcId;
+  result?: unknown;
+  error?: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
+}
+
+function responseId(value: unknown): JsonRpcId {
+  return typeof value === "string" || typeof value === "number" || value === null
+    ? value
+    : null;
+}
+
+function errorResponse(id: JsonRpcId, code: number, message: string, data?: unknown): JsonRpcResponse {
+  return {
+    jsonrpc: "2.0",
+    id,
+    error: { code, message, ...(data === undefined ? {} : { data }) },
+  };
+}
+
+function progressToolResult(summary: string, status: typeof REPORT_PROGRESS_STATUSES[number]): unknown {
+  const envelope = {
+    schemaVersion: "tool-result/0.1",
+    ok: true,
+    code: "progress_reported",
+    data: { summary, status },
+    evidence: [],
+  };
+  return {
+    content: [{ type: "text", text: JSON.stringify(envelope) }],
+    isError: false,
+  };
+}
+
+function toolCallResult(params: unknown): unknown | JsonRpcResponse {
+  if (!params || typeof params !== "object" || Array.isArray(params)) {
+    return errorResponse(null, -32602, "tools/call params must be an object");
+  }
+  const record = params as Record<string, unknown>;
+  if (record.name !== REPORT_PROGRESS_TOOL_NAME) {
+    return errorResponse(null, -32602, "unknown progress tool");
+  }
+  const args = record.arguments;
+  if (!args || typeof args !== "object" || Array.isArray(args)) {
+    return errorResponse(null, -32602, "report_progress arguments must be an object");
+  }
+  const input = args as Record<string, unknown>;
+  const summary = typeof input.summary === "string" ? input.summary.trim() : "";
+  if (!summary || summary.length > REPORT_PROGRESS_MAX_SUMMARY_LENGTH) {
+    return errorResponse(
+      null,
+      -32602,
+      `summary must contain 1-${REPORT_PROGRESS_MAX_SUMMARY_LENGTH} characters`,
+    );
+  }
+  const status = input.status;
+  if (status !== "in_progress" && status !== "completed") {
+    return errorResponse(null, -32602, "status must be in_progress or completed");
+  }
+  return progressToolResult(summary, status);
+}
+
+/** Handle one MCP JSON-RPC message. Notifications intentionally return null. */
+export function handleReportProgressMcpMessage(message: unknown): JsonRpcResponse | null {
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return errorResponse(null, -32600, "invalid JSON-RPC request");
+  }
+  const request = message as JsonRpcRequest;
+  const id = responseId(request.id);
+  const method = typeof request.method === "string" ? request.method : "";
+
+  if (!Object.prototype.hasOwnProperty.call(request, "id")) {
+    return null;
+  }
+  if (method === "initialize") {
+    return {
+      jsonrpc: "2.0",
+      id,
+      result: {
+        protocolVersion: "2024-11-05",
+        capabilities: { tools: { listChanged: false } },
+        serverInfo: { name: "botcord-report-progress", version: "0.1.0" },
+      },
+    };
+  }
+  if (method === "ping") {
+    return { jsonrpc: "2.0", id, result: {} };
+  }
+  if (method === "tools/list") {
+    return {
+      jsonrpc: "2.0",
+      id,
+      result: {
+        tools: [{
+          name: REPORT_PROGRESS_TOOL_NAME,
+          description:
+            "Report one concise, user-visible execution update. Never include hidden reasoning, secrets, or raw tool output.",
+          inputSchema: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              summary: {
+                type: "string",
+                minLength: 1,
+                maxLength: REPORT_PROGRESS_MAX_SUMMARY_LENGTH,
+                description: "A short factual update describing completed work or the next visible action.",
+              },
+              status: {
+                type: "string",
+                enum: [...REPORT_PROGRESS_STATUSES],
+                description: "in_progress while working; completed after a meaningful phase finishes.",
+              },
+            },
+            required: ["summary", "status"],
+          },
+        }],
+      },
+    };
+  }
+  if (method === "tools/call") {
+    const result = toolCallResult(request.params);
+    if (result && typeof result === "object" && "error" in result) {
+      return { ...(result as JsonRpcResponse), id };
+    }
+    return { jsonrpc: "2.0", id, result };
+  }
+  if (
+    method === "resources/list" ||
+    method === "resources/templates/list" ||
+    method === "prompts/list"
+  ) {
+    const key = method === "resources/list"
+      ? "resources"
+      : method === "resources/templates/list"
+        ? "resourceTemplates"
+        : "prompts";
+    return { jsonrpc: "2.0", id, result: { [key]: [] } };
+  }
+  return errorResponse(id, -32601, `method not found: ${method}`);
+}
+
+export async function startReportProgressMcpServer(): Promise<void> {
+  const lines = createInterface({ input: process.stdin, crlfDelay: Infinity });
+  for await (const line of lines) {
+    if (!line.trim()) continue;
+    let response: JsonRpcResponse | null;
+    try {
+      response = handleReportProgressMcpMessage(JSON.parse(line));
+    } catch {
+      response = errorResponse(null, -32700, "parse error");
+    }
+    if (response) process.stdout.write(`${JSON.stringify(response)}\n`);
+  }
+}
+
+if (process.argv[1] && reportProgressMcpServerPath() === process.argv[1]) {
+  void startReportProgressMcpServer();
+}


### PR DESCRIPTION
## Summary
- Add a local `report_progress` MCP server and generate an owner-only MCP config for each DeepSeek Cloud Agent.
- Start locally managed `deepseek serve` processes with `DEEPSEEK_MCP_CONFIG` and user-visible progress instructions.
- Convert `mcp_botlearn_report_progress` calls into bounded `progress` stream blocks while suppressing ordinary tool cards and raw tool parameters.

## Verification
- `cd packages/daemon && pnpm test` — 79 files and 1126 tests passed.
- `cd packages/daemon && pnpm build` — passed.
- Started the installed DeepSeek TUI with the generated MCP config and verified `/v1/apps/mcp/tools` exposes `mcp_botlearn_report_progress` with the expected schema.

## Risk / rollout
- Publish and roll out the updated `@botcord/daemon`, then restart Cloud Agents so their locally managed DeepSeek server receives the new MCP config.
- The automatic config injection applies to DeepSeek servers spawned by the daemon. Deployments using `BOTCORD_DEEPSEEK_TUI_URL` must configure the external server separately.
- Progress payloads are restricted to a 240-character `summary` and `in_progress|completed`; model reasoning, secrets, and raw tool output are not forwarded.
