### PR TITLE
fix: coordinate shared credential refreshes

### DIFF
--- a/.changeset/quiet-auth-coordinator.md
+++ b/.changeset/quiet-auth-coordinator.md
@@ -1,0 +1,6 @@
+---
+"@botcord/daemon": patch
+"@botcord/protocol-core": patch
+---
+
+Coordinate token generations across in-process clients that share agent credentials, serialize refreshes, and expose privacy-safe auth diagnostics.

--- a/packages/daemon/src/attention-policy-fetcher.ts
+++ b/packages/daemon/src/attention-policy-fetcher.ts
@@ -17,6 +17,7 @@ export interface AttentionPolicyFetcherOptions {
   hubBaseUrl?: string;
   log?: {
     warn: (msg: string, meta?: Record<string, unknown>) => void;
+    debug?: (msg: string, meta?: Record<string, unknown>) => void;
   };
 }
 
@@ -50,6 +51,9 @@ export function createAttentionPolicyFetcher(
         ...(creds.tokenExpiresAt !== undefined
           ? { tokenExpiresAt: creds.tokenExpiresAt }
           : {}),
+        authDiagnostic: (event) => {
+          opts.log?.debug?.("daemon.auth.coordination", { ...event });
+        },
       });
       client.onTokenRefresh = (token, expiresAt) => {
         try {

--- a/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
+++ b/packages/daemon/src/gateway/__tests__/botcord-channel.test.ts
@@ -1187,6 +1187,7 @@ describe("createBotCordChannel — ack + dedup", () => {
     await expect(startP).rejects.toMatchObject({ code: "channel_permanent_stop" });
     expect(AuthRejectedWebSocket.instances).toHaveLength(1);
     expect(client.refreshToken).toHaveBeenCalledTimes(1);
+    expect(client.refreshToken).toHaveBeenCalledWith("test-token");
     expect(localRevokeAgent).toHaveBeenCalledWith("ag_self", log);
     expect(logs.some((entry) => entry.msg === "botcord agent credentials rejected by Hub; revoked local binding"))
       .toBe(true);

--- a/packages/daemon/src/gateway/channels/botcord.ts
+++ b/packages/daemon/src/gateway/channels/botcord.ts
@@ -6,6 +6,7 @@ import {
   defaultCredentialsFile,
   loadStoredCredentials,
   updateCredentialsToken,
+  type BotCordAuthDiagnostic,
   type InboxMessage,
   type MessageAttachment,
 } from "@botcord/protocol-core";
@@ -61,7 +62,7 @@ type InboxDrainTrigger =
 /** Minimal surface the adapter needs from `BotCordClient`. Matches the subset used at runtime. */
 export interface BotCordChannelClient {
   ensureToken(): Promise<string>;
-  refreshToken(): Promise<string>;
+  refreshToken(failedToken?: string): Promise<string>;
   pollInbox(options?: {
     limit?: number;
     ack?: boolean;
@@ -106,6 +107,7 @@ export type BotCordClientFactory = (input: {
   agentId: string;
   hubBaseUrl?: string;
   credentialsPath?: string;
+  authDiagnostic?: (event: BotCordAuthDiagnostic) => void;
 }) => BotCordChannelClient;
 
 /** Options accepted by `createBotCordChannel()`. */
@@ -238,6 +240,7 @@ function defaultClientFactory(input: {
   agentId: string;
   hubBaseUrl?: string;
   credentialsPath?: string;
+  authDiagnostic?: (event: BotCordAuthDiagnostic) => void;
 }): BotCordChannelClient {
   const credFile = input.credentialsPath ?? defaultCredentialsFile(input.agentId);
   const creds = loadStoredCredentials(credFile);
@@ -248,6 +251,7 @@ function defaultClientFactory(input: {
     privateKey: creds.privateKey,
     token: creds.token,
     tokenExpiresAt: creds.tokenExpiresAt,
+    authDiagnostic: input.authDiagnostic,
   });
   client.onTokenRefresh = (token, expiresAt) => {
     try {
@@ -459,7 +463,7 @@ async function postControlWithRefresh(
     });
     if (resp.status === 401 && attempt === 0) {
       try {
-        token = await client.refreshToken();
+        token = await client.refreshToken(token);
       } catch (err) {
         await onTerminalCredentialError?.(err);
         throw err;
@@ -577,12 +581,15 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
     for (const stop of [...activeLeaseRenewals]) stop();
   }
 
-  function ensureClient(): BotCordChannelClient {
+  function ensureClient(log: GatewayLogger): BotCordChannelClient {
     if (!clientRef) {
       clientRef = factory({
         agentId: options.agentId,
         hubBaseUrl: options.hubBaseUrl,
         credentialsPath: options.credentialsPath,
+        authDiagnostic: (event) => {
+          log.debug("botcord.auth.coordination", { ...event });
+        },
       });
     }
     return clientRef;
@@ -1231,7 +1238,7 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
           }
           const refresh = (async () => {
             try {
-              await client.refreshToken();
+              await client.refreshToken(token);
             } catch (err) {
               if (await stopForTerminalCredentials(err)) {
                 return;
@@ -1295,7 +1302,7 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
     type: channelType,
 
     async start(ctx: ChannelStartContext): Promise<void> {
-      const client = ensureClient();
+      const client = ensureClient(ctx.log);
       setStatusCallback = ctx.setStatus;
       // Only patch fields owned by the adapter; the manager is the single
       // writer for `channel` (== adapter.id) and `accountId`.
@@ -1319,7 +1326,7 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
     },
 
     async send(ctx: ChannelSendContext): Promise<ChannelSendResult> {
-      const client = ensureClient();
+      const client = ensureClient(ctx.log);
       const { message } = ctx;
       const options: {
         replyTo?: string;
@@ -1356,7 +1363,7 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
     },
 
     async streamBlock(ctx: ChannelStreamBlockContext): Promise<void> {
-      const client = ensureClient();
+      const client = ensureClient(ctx.log);
       const hubUrl = options.hubBaseUrl ?? client.getHubUrl();
       try {
         const block = ctx.block as { raw?: unknown; kind?: string; seq?: number } | undefined;
@@ -1386,7 +1393,7 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
     },
 
     async streamEnd(ctx: ChannelStreamEndContext): Promise<void> {
-      const client = ensureClient();
+      const client = ensureClient(ctx.log);
       const hubUrl = options.hubBaseUrl ?? client.getHubUrl();
       try {
         const resp = await postControlWithRefresh(
@@ -1412,7 +1419,7 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
     },
 
     async typing(ctx: ChannelTypingContext): Promise<void> {
-      const client = ensureClient();
+      const client = ensureClient(ctx.log);
       const hubUrl = options.hubBaseUrl ?? client.getHubUrl();
       try {
         const resp = await postControlWithRefresh(
@@ -1438,7 +1445,7 @@ export function createBotCordChannel(options: BotCordChannelOptions): ChannelAda
     },
 
     async messageStatus(ctx: ChannelMessageStatusContext): Promise<void> {
-      const client = ensureClient();
+      const client = ensureClient(ctx.log);
       const hubUrl = options.hubBaseUrl ?? client.getHubUrl();
       const body = {
         room_id: ctx.conversationId,

--- a/packages/daemon/src/room-context-fetcher.ts
+++ b/packages/daemon/src/room-context-fetcher.ts
@@ -6,7 +6,11 @@
  * `{ room, members }` shape the builder expects. A single GET is enough —
  * Hub returns both the room record and its member list in one payload.
  */
-import { BotCordClient, loadStoredCredentials } from "@botcord/protocol-core";
+import {
+  BotCordClient,
+  loadStoredCredentials,
+  updateCredentialsToken,
+} from "@botcord/protocol-core";
 import type { RoomContextFetcher } from "./room-context.js";
 
 interface CachedClient {
@@ -23,6 +27,7 @@ export interface RoomContextFetcherOptions {
   hubBaseUrl?: string;
   log?: {
     warn: (msg: string, meta?: Record<string, unknown>) => void;
+    debug?: (msg: string, meta?: Record<string, unknown>) => void;
   };
 }
 
@@ -58,7 +63,17 @@ export function createRoomContextFetcher(
         ...(creds.tokenExpiresAt !== undefined
           ? { tokenExpiresAt: creds.tokenExpiresAt }
           : {}),
+        authDiagnostic: (event) => {
+          opts.log?.debug?.("daemon.auth.coordination", { ...event });
+        },
       });
+      client.onTokenRefresh = (token, expiresAt) => {
+        try {
+          updateCredentialsToken(credsPath, token, expiresAt);
+        } catch {
+          // Persistence failures are non-fatal; the next refresh retries.
+        }
+      };
       clients.set(accountId, { client, credentialsPath: credsPath });
       return client;
     } catch (err) {

--- a/packages/protocol-core/src/__tests__/client.test.ts
+++ b/packages/protocol-core/src/__tests__/client.test.ts
@@ -1,10 +1,18 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { BotCordClient } from "../client.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BotCordClient,
+  resetSharedCredentialStatesForTests,
+  type BotCordAuthDiagnostic,
+} from "../client.js";
 
 const privateKey = Buffer.alloc(32, 2).toString("base64");
 
 afterEach(() => {
   vi.unstubAllGlobals();
+});
+
+beforeEach(() => {
+  resetSharedCredentialStatesForTests();
 });
 
 describe("BotCordClient token refresh", () => {
@@ -66,6 +74,158 @@ describe("BotCordClient token refresh", () => {
     expect(inboxRequests).toHaveLength(2);
     expect(inboxRequests[0].authorization).toBe("Bearer old-token");
     expect(inboxRequests[1].authorization).toBe("Bearer new-token");
+  });
+
+  it("single-flights concurrent refreshes and shares the new generation across clients", async () => {
+    let releaseRefresh!: () => void;
+    const refreshGate = new Promise<void>((resolve) => {
+      releaseRefresh = resolve;
+    });
+    let refreshCount = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        if (String(input).endsWith("/token/refresh")) {
+          refreshCount += 1;
+          await refreshGate;
+          return Response.json({
+            agent_token: "shared-new-token",
+            expires_at: Math.floor(Date.now() / 1000) + 3600,
+          });
+        }
+        return Response.json({ messages: [], count: 0, has_more: false });
+      }),
+    );
+    const config = {
+      hubUrl: "https://hub.concurrent.example",
+      agentId: "ag_concurrent",
+      keyId: "k_concurrent",
+      privateKey,
+    };
+    const first = new BotCordClient(config);
+    const second = new BotCordClient(config);
+
+    const firstRefresh = first.ensureToken();
+    const secondRefresh = second.ensureToken();
+    releaseRefresh();
+
+    await expect(Promise.all([firstRefresh, secondRefresh])).resolves.toEqual([
+      "shared-new-token",
+      "shared-new-token",
+    ]);
+    expect(refreshCount).toBe(1);
+    expect(first.getToken()).toBe("shared-new-token");
+    expect(second.getToken()).toBe("shared-new-token");
+  });
+
+  it("reuses a peer generation when REST 401 recovery races a completed refresh", async () => {
+    const authorizations: string[] = [];
+    let refreshCount = 0;
+    let releaseStaleResponse!: () => void;
+    const staleResponseGate = new Promise<void>((resolve) => {
+      releaseStaleResponse = resolve;
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("/token/refresh")) {
+          refreshCount += 1;
+          return Response.json({
+            agent_token: "peer-new-token",
+            expires_at: Math.floor(Date.now() / 1000) + 3600,
+          });
+        }
+        authorizations.push(((init?.headers ?? {}) as Record<string, string>).Authorization);
+        if (authorizations.length === 1) {
+          await staleResponseGate;
+          return new Response("stale", { status: 401 });
+        }
+        return Response.json({ messages: [], count: 0, has_more: false });
+      }),
+    );
+    const config = {
+      hubUrl: "https://hub.rest-race.example",
+      agentId: "ag_rest_race",
+      keyId: "k_rest_race",
+      privateKey,
+      token: "old-token",
+      tokenExpiresAt: Math.floor(Date.now() / 1000) + 3600,
+    };
+    const restClient = new BotCordClient(config);
+    const peerClient = new BotCordClient(config);
+    const request = restClient.pollInbox();
+    await vi.waitFor(() => expect(authorizations).toHaveLength(1));
+    await peerClient.refreshToken("old-token");
+    releaseStaleResponse();
+    await request;
+
+    expect(refreshCount).toBe(1);
+    expect(authorizations).toEqual(["Bearer old-token", "Bearer peer-new-token"]);
+  });
+
+  it("emits privacy-safe auth generation diagnostics without credential material", async () => {
+    const events: BotCordAuthDiagnostic[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          agent_token: "super-secret-token",
+          expires_at: Math.floor(Date.now() / 1000) + 3600,
+        }),
+      ),
+    );
+    const client = new BotCordClient({
+      hubUrl: "https://hub.diagnostics.example",
+      agentId: "ag_diagnostics",
+      keyId: "k_diagnostics",
+      privateKey,
+      authDiagnostic: (event) => events.push(event),
+    });
+    await client.ensureToken();
+
+    expect(events.map((event) => event.event)).toEqual([
+      "client_created",
+      "refresh_started",
+      "refresh_succeeded",
+    ]);
+    expect(events[2]).toMatchObject({
+      generation: 1,
+      reason: "missing_or_expiring",
+    });
+    const serialized = JSON.stringify(events);
+    expect(serialized).not.toContain("super-secret-token");
+    expect(serialized).not.toContain(privateKey);
+    expect(serialized).not.toContain("ag_diagnostics");
+    expect(serialized).not.toContain("k_diagnostics");
+  });
+
+  it("reuses a peer generation when WS invalid_token reports the token used to authenticate", async () => {
+    let refreshCount = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        refreshCount += 1;
+        return Response.json({
+          agent_token: "peer-ws-token",
+          expires_at: Math.floor(Date.now() / 1000) + 3600,
+        });
+      }),
+    );
+    const config = {
+      hubUrl: "https://hub.ws-race.example",
+      agentId: "ag_ws_race",
+      keyId: "k_ws_race",
+      privateKey,
+      token: "ws-auth-token",
+      tokenExpiresAt: Math.floor(Date.now() / 1000) + 3600,
+    };
+    const wsClient = new BotCordClient(config);
+    const peerClient = new BotCordClient(config);
+
+    await peerClient.refreshToken("ws-auth-token");
+    await expect(wsClient.refreshToken("ws-auth-token")).resolves.toBe("peer-ws-token");
+    expect(refreshCount).toBe(1);
   });
 
   it("attaches status and code to token refresh failures", async () => {

--- a/packages/protocol-core/src/client.ts
+++ b/packages/protocol-core/src/client.ts
@@ -2,7 +2,7 @@
  * HTTP client for BotCord Hub REST API.
  * Handles JWT token lifecycle and request signing.
  */
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { buildSignedEnvelope, derivePublicKey, generateKeypair, signChallenge } from "./crypto.js";
 import { normalizeTokenExpiresAt } from "./credentials.js";
@@ -53,6 +53,36 @@ export interface BotCordClientConfig {
   privateKey: string;
   token?: string;
   tokenExpiresAt?: number;
+  authDiagnostic?: (event: BotCordAuthDiagnostic) => void;
+}
+
+export interface BotCordAuthDiagnostic {
+  event:
+    | "client_created"
+    | "refresh_started"
+    | "refresh_joined"
+    | "refresh_reused"
+    | "refresh_succeeded"
+    | "refresh_failed";
+  authScopeId: string;
+  clientInstanceId: string;
+  generation: number;
+  reason?: "missing_or_expiring" | "forced" | "rest_401";
+  status?: number;
+}
+
+interface SharedCredentialState {
+  token: string | null;
+  tokenExpiresAt: number;
+  generation: number;
+  refreshPromise: Promise<string> | null;
+}
+
+const sharedCredentialStates = new Map<string, SharedCredentialState>();
+
+/** @internal Test-only helper; production callers must not clear live auth coordination. */
+export function resetSharedCredentialStatesForTests(): void {
+  sharedCredentialStates.clear();
 }
 
 export class BotCordClient {
@@ -60,8 +90,10 @@ export class BotCordClient {
   private agentId: string;
   private keyId: string;
   private privateKey: string;
-  private jwtToken: string | null = null;
-  private tokenExpiresAt = 0;
+  private credentialState: SharedCredentialState;
+  private authScopeId: string;
+  private clientInstanceId = randomBytes(6).toString("hex");
+  private authDiagnostic?: (event: BotCordAuthDiagnostic) => void;
 
   /** Called after a token refresh so credentials can be persisted. */
   onTokenRefresh?: (token: string, expiresAt: number) => void;
@@ -74,35 +106,87 @@ export class BotCordClient {
     this.agentId = config.agentId;
     this.keyId = config.keyId;
     this.privateKey = config.privateKey;
-    if (config.token) {
-      this.jwtToken = config.token;
-      this.tokenExpiresAt = normalizeTokenExpiresAt(config.tokenExpiresAt) ?? 0;
+    const scopeKey = `${this.hubUrl}\0${this.agentId}\0${this.keyId}`;
+    this.authScopeId = createHash("sha256")
+      .update(scopeKey)
+      .digest("hex")
+      .slice(0, 16);
+    this.authDiagnostic = config.authDiagnostic;
+    const existing = sharedCredentialStates.get(scopeKey);
+    if (existing) {
+      this.credentialState = existing;
+    } else {
+      this.credentialState = {
+        token: config.token ?? null,
+        tokenExpiresAt: config.token
+          ? normalizeTokenExpiresAt(config.tokenExpiresAt) ?? 0
+          : 0,
+        generation: config.token ? 1 : 0,
+        refreshPromise: null,
+      };
+      sharedCredentialStates.set(scopeKey, this.credentialState);
     }
+    this.emitAuthDiagnostic("client_created");
   }
 
   // ── Token management ──────────────────────────────────────────
 
   async ensureToken(): Promise<string> {
-    if (this.jwtToken && Date.now() / 1000 < this.tokenExpiresAt - 60) {
-      return this.jwtToken;
+    if (
+      this.credentialState.token &&
+      Date.now() / 1000 < this.credentialState.tokenExpiresAt - 60
+    ) {
+      return this.credentialState.token;
     }
-    return this.refreshToken();
+    return this.refreshToken(undefined, "missing_or_expiring");
   }
 
-  async refreshToken(): Promise<string> {
+  async refreshToken(
+    failedToken?: string,
+    reason: "missing_or_expiring" | "forced" | "rest_401" = "forced",
+  ): Promise<string> {
+    if (
+      failedToken !== undefined &&
+      this.credentialState.token &&
+      this.credentialState.token !== failedToken
+    ) {
+      this.emitAuthDiagnostic("refresh_reused", reason);
+      return this.credentialState.token;
+    }
+    if (this.credentialState.refreshPromise) {
+      this.emitAuthDiagnostic("refresh_joined", reason);
+      return this.credentialState.refreshPromise;
+    }
+    this.emitAuthDiagnostic("refresh_started", reason);
+    const refreshPromise = this.performTokenRefresh(reason);
+    this.credentialState.refreshPromise = refreshPromise;
+    try {
+      return await refreshPromise;
+    } finally {
+      if (this.credentialState.refreshPromise === refreshPromise) {
+        this.credentialState.refreshPromise = null;
+      }
+    }
+  }
+
+  private async performTokenRefresh(
+    reason: "missing_or_expiring" | "forced" | "rest_401",
+  ): Promise<string> {
     const nonce = randomBytes(32).toString("base64");
     const sig = signChallenge(this.privateKey, nonce);
 
-    const resp = await fetch(`${this.hubUrl}/registry/agents/${this.agentId}/token/refresh`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        key_id: this.keyId,
-        nonce,
-        sig,
-      }),
-      signal: AbortSignal.timeout(10000),
-    });
+    let resp: Response;
+    try {
+      resp = await fetch(`${this.hubUrl}/registry/agents/${this.agentId}/token/refresh`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ key_id: this.keyId, nonce, sig }),
+        signal: AbortSignal.timeout(10000),
+      });
+    } catch (err) {
+      this.emitAuthDiagnostic("refresh_failed", reason);
+      throw err;
+    }
 
     if (!resp.ok) {
       const body = await resp.text().catch(() => "");
@@ -110,22 +194,56 @@ export class BotCordClient {
       (err as any).status = resp.status;
       const code = parseErrorCode(body);
       if (code) (err as any).code = code;
+      this.emitAuthDiagnostic("refresh_failed", reason, resp.status);
       throw err;
     }
 
     const data = (await resp.json()) as { agent_token: string; token?: string; expires_at?: number };
-    this.jwtToken = data.agent_token || data.token!;
-    this.tokenExpiresAt = data.expires_at ?? Date.now() / 1000 + 86400;
-    this.onTokenRefresh?.(this.jwtToken, this.tokenExpiresAt);
-    return this.jwtToken;
+    this.credentialState.token = data.agent_token || data.token!;
+    this.credentialState.tokenExpiresAt =
+      data.expires_at ?? Date.now() / 1000 + 86400;
+    this.credentialState.generation += 1;
+    this.onTokenRefresh?.(this.credentialState.token, this.credentialState.tokenExpiresAt);
+    this.emitAuthDiagnostic("refresh_succeeded", reason);
+    return this.credentialState.token;
   }
 
   getToken(): string | null {
-    return this.jwtToken;
+    return this.credentialState.token;
   }
 
   getTokenExpiresAt(): number {
-    return this.tokenExpiresAt;
+    return this.credentialState.tokenExpiresAt;
+  }
+
+  getAuthDiagnosticContext(): Pick<
+    BotCordAuthDiagnostic,
+    "authScopeId" | "clientInstanceId" | "generation"
+  > {
+    return {
+      authScopeId: this.authScopeId,
+      clientInstanceId: this.clientInstanceId,
+      generation: this.credentialState.generation,
+    };
+  }
+
+  private emitAuthDiagnostic(
+    event: BotCordAuthDiagnostic["event"],
+    reason?: BotCordAuthDiagnostic["reason"],
+    status?: number,
+  ): void {
+    try {
+      this.authDiagnostic?.({
+        event,
+        authScopeId: this.authScopeId,
+        clientInstanceId: this.clientInstanceId,
+        generation: this.credentialState.generation,
+        ...(reason ? { reason } : {}),
+        ...(status !== undefined ? { status } : {}),
+      });
+    } catch {
+      // Diagnostics must never affect authentication or refresh recovery.
+    }
   }
 
   // ── Authenticated fetch with rate-limit retry ─────────────────
@@ -151,7 +269,7 @@ export class BotCordClient {
       if (resp.ok) return resp;
 
       if (resp.status === 401 && attempt === 0) {
-        token = await this.refreshToken();
+        token = await this.refreshToken(token, "rest_401");
         continue;
       }
 


### PR DESCRIPTION
## Summary
- share token generation and single-flight refreshes across in-process BotCord clients scoped by normalized hub, agent, and key
- converge REST 401 and WebSocket invalid-token recovery without rotating an already-advanced peer credential
- persist room-context refreshed credentials and add privacy-safe generation diagnostics
- add concurrent REST/WebSocket regression coverage and a changeset

## Validation
- protocol-core: 44/44 tests; build passed
- daemon targeted: 50/50 tests; build passed
- daemon full: 1107/1118 passed; 11 environment-only failures (3 missing unzip, 8 live OpenClaw systemd gateway on :16200), with no auth/coordinator failures
- independent review: no blocking findings

## Scope / residual risk
- process-local only; cross-process clients still converge through 401 refresh under the backend single-current-token invariant
- does not address refresh 404s for deleted identities
- no production deployment or configuration change