### PR TITLE
fix(daemon): bound WeChat login fetches

### DIFF
--- a/packages/daemon/src/__tests__/wechat-login.test.ts
+++ b/packages/daemon/src/__tests__/wechat-login.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { FetchLike } from "../gateway/channels/wechat-http.js";
+import {
+  DEFAULT_WECHAT_LOGIN_TIMEOUT_MS,
+  getBotQrcode,
+  getQrcodeStatus,
+} from "../gateway/channels/wechat-login.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function installAbortableHangingFetch(): FetchLike {
+  return vi.fn((_url, init) => {
+    const signal = init?.signal;
+    return new Promise((_resolve, reject) => {
+      signal?.addEventListener(
+        "abort",
+        () => reject(signal.reason ?? new DOMException("Aborted", "AbortError")),
+        { once: true },
+      );
+    });
+  }) as FetchLike;
+}
+
+function mockTimeoutSignal(): ReturnType<typeof vi.spyOn> {
+  return vi.spyOn(AbortSignal, "timeout").mockImplementation(() => {
+    const controller = new AbortController();
+    queueMicrotask(() => controller.abort(new DOMException("Timed out", "TimeoutError")));
+    return controller.signal;
+  });
+}
+
+describe("WeChat login request timeouts", () => {
+  it("aborts a hanging get_bot_qrcode fetch after the default 10s budget", async () => {
+    const timeout = mockTimeoutSignal();
+    const fetchImpl = installAbortableHangingFetch();
+
+    await expect(getBotQrcode({ fetchImpl })).rejects.toMatchObject({ name: "TimeoutError" });
+    expect(timeout).toHaveBeenCalledWith(DEFAULT_WECHAT_LOGIN_TIMEOUT_MS);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it("aborts a hanging get_qrcode_status fetch after a configured budget", async () => {
+    const timeout = mockTimeoutSignal();
+    const fetchImpl = installAbortableHangingFetch();
+
+    await expect(getQrcodeStatus("QR", { fetchImpl, timeoutMs: 25 })).rejects.toMatchObject({
+      name: "TimeoutError",
+    });
+    expect(timeout).toHaveBeenCalledWith(25);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/daemon/src/gateway/channels/wechat-login.ts
+++ b/packages/daemon/src/gateway/channels/wechat-login.ts
@@ -14,6 +14,7 @@ import { wechatHeaders, type FetchLike } from "./wechat-http.js";
 import { assertSafeBaseUrl } from "./url-guard.js";
 
 export const DEFAULT_WECHAT_BASE_URL = "https://ilinkai.weixin.qq.com";
+export const DEFAULT_WECHAT_LOGIN_TIMEOUT_MS = 10_000;
 
 export interface WechatQrcode {
   qrcode: string;
@@ -31,6 +32,7 @@ export interface WechatQrcodeStatus {
 export interface WechatLoginOptions {
   baseUrl?: string;
   fetchImpl?: FetchLike;
+  timeoutMs?: number;
 }
 
 /** `GET /ilink/bot/get_bot_qrcode?bot_type=3` — fetch a fresh login QR. */
@@ -42,6 +44,7 @@ export async function getBotQrcode(opts: WechatLoginOptions = {}): Promise<Wecha
   const res = await fetcher(`${base}/ilink/bot/get_bot_qrcode?bot_type=3`, {
     method: "GET",
     headers: wechatHeaders(),
+    signal: AbortSignal.timeout(opts.timeoutMs ?? DEFAULT_WECHAT_LOGIN_TIMEOUT_MS),
   });
   const data = (await safeJson(res)) ?? {};
   const qrcode = typeof data.qrcode === "string" ? data.qrcode : "";
@@ -70,7 +73,11 @@ export async function getQrcodeStatus(
   const fetcher = opts.fetchImpl ?? (globalThis.fetch as FetchLike);
   const res = await fetcher(
     `${base}/ilink/bot/get_qrcode_status?qrcode=${encodeURIComponent(qrcode)}`,
-    { method: "GET", headers: wechatHeaders() },
+    {
+      method: "GET",
+      headers: wechatHeaders(),
+      signal: AbortSignal.timeout(opts.timeoutMs ?? DEFAULT_WECHAT_LOGIN_TIMEOUT_MS),
+    },
   );
   const data = (await safeJson(res)) ?? {};
   const status = typeof data.status === "string" ? data.status : "unknown";


### PR DESCRIPTION
## Summary
- bound WeChat QR start and status provider fetches with `AbortSignal.timeout`
- default provider timeout to 10 seconds, below the Hub 30-second ack deadline
- retain the existing `provider_unreachable` gateway-control error mapping
- cover hanging start/status fetches with regression tests

## Verification
- focused Vitest: 2 files / 41 tests passed
- protocol-core build passed
- gateway-ingress build passed
- CLI build passed
- daemon TypeScript build passed
- `git diff --check` passed
- independent code review: no blocking findings

## Rollback
Revert commit `dc1a964afaa2d370cc64e4a4904ecba685eae57e` (or the resulting merge commit). No deployment, restart, or runtime mutation is part of this PR.