### PR TITLE
feat: add signing key rotation release gates

### DIFF
--- a/.changeset/tidy-hubs-rotate.md
+++ b/.changeset/tidy-hubs-rotate.md
@@ -1,0 +1,9 @@
+---
+"@botcord/daemon": patch
+"@botcord/protocol-core": patch
+---
+
+Support staged Hub control signing-key rotation by resolving a multi-key trust
+ring in protocol-core and accepting frames signed by any trusted key in the
+daemon. Runtime snapshots attest that ring using privacy-safe fingerprints, and
+the legacy singular public-key configuration remains compatible.

--- a/backend/hub/models.py
+++ b/backend/hub/models.py
@@ -1378,6 +1378,10 @@ class DaemonInstance(Base):
         DateTime(timezone=True), nullable=True
     )
     daemon_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    # Privacy-safe attestations only; raw control keys never enter inventory.
+    hub_control_trust_key_fingerprints: Mapped[list | None] = mapped_column(
+        JSON, nullable=True
+    )
 
 
 class DaemonAgentCleanup(Base):

--- a/backend/hub/routers/daemon_control.py
+++ b/backend/hub/routers/daemon_control.py
@@ -602,6 +602,14 @@ class _InstanceView(BaseModel):
     runtimes: list[dict[str, Any]] | None = None
     runtimes_probed_at: datetime.datetime | None = None
     daemon_version: str | None = None
+    hub_control_trust_key_fingerprints: list[str] | None = None
+    agent_bindings: list["_AgentBindingView"]
+
+
+class _AgentBindingView(BaseModel):
+    agent_id: str
+    status: str
+    traffic_eligible: bool
 
 
 def _instance_status(instance: DaemonInstance) -> str:
@@ -631,7 +639,38 @@ def _instance_online(instance: DaemonInstance) -> bool:
     return _REGISTRY.is_online(instance.id)
 
 
-def _instance_to_view(instance: DaemonInstance) -> _InstanceView:
+def _agent_to_binding(agent: Agent) -> _AgentBindingView:
+    return _AgentBindingView(
+        agent_id=agent.agent_id,
+        status=agent.status,
+        # Active, non-deleted agents are the control-delivery population used
+        # by the rotation gate. Retain ineligible bindings in the inventory so
+        # operators can prove why each agent was excluded.
+        traffic_eligible=agent.status == "active" and agent.deleted_at is None,
+    )
+
+
+async def _load_agent_bindings(
+    db: AsyncSession, daemon_instance_ids: list[str]
+) -> dict[str, list[_AgentBindingView]]:
+    bindings = {daemon_id: [] for daemon_id in daemon_instance_ids}
+    if not daemon_instance_ids:
+        return bindings
+    result = await db.execute(
+        select(Agent)
+        .where(Agent.daemon_instance_id.in_(daemon_instance_ids))
+        .order_by(Agent.agent_id)
+    )
+    for agent in result.scalars().all():
+        if agent.daemon_instance_id in bindings:
+            bindings[agent.daemon_instance_id].append(_agent_to_binding(agent))
+    return bindings
+
+
+def _instance_to_view(
+    instance: DaemonInstance,
+    agent_bindings: list[_AgentBindingView] | None = None,
+) -> _InstanceView:
     return _InstanceView(
         id=instance.id,
         label=instance.label,
@@ -646,6 +685,10 @@ def _instance_to_view(instance: DaemonInstance) -> _InstanceView:
         runtimes=instance.runtimes_json if instance.runtimes_json else None,
         runtimes_probed_at=instance.runtimes_probed_at,
         daemon_version=instance.daemon_version,
+        hub_control_trust_key_fingerprints=(
+            instance.hub_control_trust_key_fingerprints
+        ),
+        agent_bindings=agent_bindings or [],
     )
 
 
@@ -667,7 +710,10 @@ async def list_instances(
         .order_by(DaemonInstance.created_at.desc())
     )
     rows = result.scalars().all()
-    return _InstancesResponse(instances=[_instance_to_view(row) for row in rows])
+    bindings = await _load_agent_bindings(db, [row.id for row in rows])
+    return _InstancesResponse(
+        instances=[_instance_to_view(row, bindings[row.id]) for row in rows]
+    )
 
 
 async def _load_owned_instance(
@@ -1177,6 +1223,8 @@ class _RefreshRuntimesResponse(BaseModel):
     runtimes: list[dict[str, Any]]
     runtimes_probed_at: datetime.datetime
     daemon_version: str | None = None
+    hub_control_trust_key_fingerprints: list[str] | None = None
+    agent_bindings: list[_AgentBindingView]
 
 
 _REFRESH_RUNTIMES_TIMEOUT_MS = 10000
@@ -1366,10 +1414,15 @@ async def refresh_instance_runtimes(
         await db.commit()
 
         runtimes, probed_dt = persisted
+        bindings = await _load_agent_bindings(db, [instance.id])
         return _RefreshRuntimesResponse(
             runtimes=runtimes,
             runtimes_probed_at=probed_dt,
             daemon_version=instance.daemon_version,
+            hub_control_trust_key_fingerprints=(
+                instance.hub_control_trust_key_fingerprints
+            ),
+            agent_bindings=bindings[instance.id],
         )
 
     conn = _REGISTRY.get(daemon_instance_id)
@@ -1417,10 +1470,15 @@ async def refresh_instance_runtimes(
     await db.commit()
 
     runtimes, probed_dt = persisted
+    bindings = await _load_agent_bindings(db, [instance.id])
     return _RefreshRuntimesResponse(
         runtimes=runtimes,
         runtimes_probed_at=probed_dt,
         daemon_version=instance.daemon_version,
+        hub_control_trust_key_fingerprints=(
+            instance.hub_control_trust_key_fingerprints
+        ),
+        agent_bindings=bindings[instance.id],
     )
 
 
@@ -1733,11 +1791,14 @@ _DAEMON_INITIATED_TYPES = {
 
 def _parse_runtime_snapshot_params(
     params: Any,
-) -> tuple[list[dict[str, Any]], datetime.datetime, str | None] | None:
+) -> (
+    tuple[list[dict[str, Any]], datetime.datetime, str | None, list[str] | None]
+    | None
+):
     """Validate a ``runtime_snapshot`` / ``list_runtimes`` ack payload.
 
-    Returns ``(runtimes, probed_at_utc, daemon_version)`` on success, ``None``
-    on malformed input (caller should respond with ``bad_params``).
+    Returns runtimes, probe time, daemon version, and trust-key fingerprints
+    on success, or ``None`` on malformed input.
     """
     if not isinstance(params, dict):
         return None
@@ -1801,7 +1862,23 @@ def _parse_runtime_snapshot_params(
         if not isinstance(daemon_version, str) or len(daemon_version) > 64:
             return None
         daemon_version = daemon_version.strip() or None
-    return runtimes, probed_dt, daemon_version
+    fingerprints = params.get("hubControlTrustKeyFingerprints")
+    if fingerprints is not None:
+        if not isinstance(fingerprints, list) or len(fingerprints) > 16:
+            return None
+        normalized_fingerprints: list[str] = []
+        for fingerprint in fingerprints:
+            if (
+                not isinstance(fingerprint, str)
+                or len(fingerprint) != 71
+                or not fingerprint.startswith("sha256:")
+                or any(c not in "0123456789abcdef" for c in fingerprint[7:])
+            ):
+                return None
+            if fingerprint not in normalized_fingerprints:
+                normalized_fingerprints.append(fingerprint)
+        fingerprints = normalized_fingerprints
+    return runtimes, probed_dt, daemon_version, fingerprints
 
 
 async def _persist_runtime_snapshot(
@@ -1818,11 +1895,14 @@ async def _persist_runtime_snapshot(
     parsed = _parse_runtime_snapshot_params(params)
     if parsed is None:
         return None
-    runtimes, probed_dt, daemon_version = parsed
+    runtimes, probed_dt, daemon_version, fingerprints = parsed
     instance.runtimes_json = runtimes
     instance.runtimes_probed_at = probed_dt
-    if daemon_version is not None:
-        instance.daemon_version = daemon_version
+    # Absence means incompatible/unknown; never pair a fresh probe/ring with a
+    # stale version from an earlier snapshot.
+    instance.daemon_version = daemon_version
+    # Absence means incompatible/unknown; never retain a stale attestation.
+    instance.hub_control_trust_key_fingerprints = fingerprints
     return runtimes, probed_dt
 
 

--- a/backend/migrations/001_add_daemon_trust_key_fingerprints.sql
+++ b/backend/migrations/001_add_daemon_trust_key_fingerprints.sql
@@ -1,0 +1,2 @@
+ALTER TABLE daemon_instances
+    ADD COLUMN IF NOT EXISTS hub_control_trust_key_fingerprints JSONB;

--- a/backend/tests/test_app/test_daemon_control.py
+++ b/backend/tests/test_app/test_daemon_control.py
@@ -495,6 +495,49 @@ async def test_list_instances(client: AsyncClient, seed_user):
     for entry in data["instances"]:
         assert entry["id"].startswith("dm_")
         assert entry["online"] is False
+        assert entry["agent_bindings"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_instances_includes_multi_agent_traffic_eligibility(
+    client: AsyncClient, seed_user, db_session: AsyncSession
+):
+    bundle = await _provision_instance_via_device_code(client, seed_user)
+    instance_id = bundle["daemon_instance_id"]
+    db_session.add_all(
+        [
+            Agent(
+                agent_id="ag_inventory_active",
+                display_name="Inventory Active",
+                user_id=seed_user["user_id"],
+                daemon_instance_id=instance_id,
+                message_policy=MessagePolicy.contacts_only,
+                status="active",
+            ),
+            Agent(
+                agent_id="ag_inventory_deleted",
+                display_name="Inventory Deleted",
+                user_id=seed_user["user_id"],
+                daemon_instance_id=instance_id,
+                message_policy=MessagePolicy.contacts_only,
+                status="deleted",
+                deleted_at=datetime.datetime.now(datetime.timezone.utc),
+            ),
+        ]
+    )
+    await db_session.commit()
+    response = await client.get(
+        "/daemon/instances",
+        headers={"Authorization": f"Bearer {seed_user['token']}"},
+    )
+    assert response.status_code == 200, response.text
+    instance = next(
+        row for row in response.json()["instances"] if row["id"] == instance_id
+    )
+    assert instance["agent_bindings"] == [
+        {"agent_id": "ag_inventory_active", "status": "active", "traffic_eligible": True},
+        {"agent_id": "ag_inventory_deleted", "status": "deleted", "traffic_eligible": False},
+    ]
 
 
 @pytest.mark.asyncio
@@ -1070,6 +1113,7 @@ async def test_runtime_snapshot_event_persists_to_db(
         },
         {"id": "codex", "available": False, "error": "not found"},
     ]
+    fingerprints = ["sha256:" + "a" * 64, "sha256:" + "b" * 64]
     await _handle_daemon_event(
         conn,
         {
@@ -1079,6 +1123,7 @@ async def test_runtime_snapshot_event_persists_to_db(
                 "runtimes": runtimes,
                 "probedAt": probed_at,
                 "daemonVersion": "0.2.96",
+                "hubControlTrustKeyFingerprints": fingerprints,
             },
         },
     )
@@ -1101,6 +1146,7 @@ async def test_runtime_snapshot_event_persists_to_db(
     assert stored == runtimes
     assert inst.runtimes_probed_at is not None
     assert inst.daemon_version == "0.2.96"
+    assert inst.hub_control_trust_key_fingerprints == fingerprints
 
     # list_instances surfaces it.
     r = await client.get(
@@ -1113,6 +1159,21 @@ async def test_runtime_snapshot_event_persists_to_db(
     assert entry["runtimes"] == runtimes
     assert entry["runtimes_probed_at"] is not None
     assert entry["daemon_version"] == "0.2.96"
+    assert entry["hub_control_trust_key_fingerprints"] == fingerprints
+
+    # A fresh snapshot without optional attestations clears stale evidence.
+    await _handle_daemon_event(
+        conn,
+        {
+            "id": "frm_rs_2",
+            "type": "runtime_snapshot",
+            "params": {"runtimes": runtimes, "probedAt": _probed_now_ms()},
+        },
+    )
+    await db_session.commit()
+    await db_session.refresh(inst)
+    assert inst.daemon_version is None
+    assert inst.hub_control_trust_key_fingerprints is None
 
 
 @pytest.mark.asyncio
@@ -1165,6 +1226,24 @@ async def test_runtime_snapshot_bad_params_rejected(
     assert ack["ok"] is False
     assert ack["error"]["code"] == "bad_params"
 
+    # Raw/malformed key material must never be accepted as an attestation.
+    fake_ws.sent.clear()
+    await _handle_daemon_event(
+        conn,
+        {
+            "id": "frm_rs_raw_key",
+            "type": "runtime_snapshot",
+            "params": {
+                "runtimes": [],
+                "probedAt": _probed_now_ms(),
+                "hubControlTrustKeyFingerprints": ["raw-public-key"],
+            },
+        },
+    )
+    ack = json.loads(fake_ws.sent[-1])
+    assert ack["ok"] is False
+    assert ack["error"]["code"] == "bad_params"
+
     # DB row runtimes_json remains null.
     await db_session.commit()
     res = await db_session.execute(
@@ -1173,6 +1252,7 @@ async def test_runtime_snapshot_bad_params_rejected(
     inst = res.scalar_one()
     assert inst.runtimes_json is None
     assert inst.runtimes_probed_at is None
+    assert inst.hub_control_trust_key_fingerprints is None
 
 
 @pytest.mark.asyncio
@@ -1423,6 +1503,23 @@ async def test_refresh_runtimes_success_persists_and_returns(
 
     bundle = await _provision_instance_via_device_code(client, seed_user)
     instance_id = bundle["daemon_instance_id"]
+    seeded = await db_session.scalar(
+        select(DaemonInstance).where(DaemonInstance.id == instance_id)
+    )
+    assert seeded is not None
+    seeded.daemon_version = "stale-version"
+    seeded.hub_control_trust_key_fingerprints = ["sha256:" + "f" * 64]
+    db_session.add(
+        Agent(
+            agent_id="ag_refresh_inventory",
+            display_name="Refresh Inventory",
+            user_id=seed_user["user_id"],
+            daemon_instance_id=instance_id,
+            message_policy=MessagePolicy.contacts_only,
+            status="active",
+        )
+    )
+    await db_session.commit()
 
     fake_ws = _FakeWS()
     conn = _DaemonConn(
@@ -1454,7 +1551,11 @@ async def test_refresh_runtimes_success_persists_and_returns(
                 "result": {
                     "runtimes": runtimes,
                     "probedAt": probed_at,
-                    "daemonVersion": "0.2.97",
+                    "hubControlTrustKeyFingerprints": [
+                        "sha256:" + "a" * 64,
+                        "sha256:" + "a" * 64,
+                        "sha256:" + "b" * 64,
+                    ],
                 },
             }
             fut = conn.pending_acks.get(sent["id"])
@@ -1471,7 +1572,14 @@ async def test_refresh_runtimes_success_persists_and_returns(
         body = r.json()
         assert body["runtimes"] == runtimes
         assert body["runtimes_probed_at"]
-        assert body["daemon_version"] == "0.2.97"
+        assert body["daemon_version"] is None
+        assert body["hub_control_trust_key_fingerprints"] == [
+            "sha256:" + "a" * 64,
+            "sha256:" + "b" * 64,
+        ]
+        assert body["agent_bindings"] == [
+            {"agent_id": "ag_refresh_inventory", "status": "active", "traffic_eligible": True}
+        ]
 
         # DB is updated.
         await db_session.commit()
@@ -1484,7 +1592,11 @@ async def test_refresh_runtimes_success_persists_and_returns(
             stored = json.loads(stored)
         assert stored == runtimes
         assert inst.runtimes_probed_at is not None
-        assert inst.daemon_version == "0.2.97"
+        assert inst.daemon_version is None
+        assert inst.hub_control_trust_key_fingerprints == [
+            "sha256:" + "a" * 64,
+            "sha256:" + "b" * 64,
+        ]
     finally:
         await registry.unregister(conn)
 

--- a/backend/tests/test_cloud_daemon_ws.py
+++ b/backend/tests/test_cloud_daemon_ws.py
@@ -367,6 +367,7 @@ async def test_runtime_snapshot_persists_to_daemon_instance(
         daemon_instance_id=daemon.id,
     )
     probed_at_ms = int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000)
+    fingerprints = ["sha256:" + "c" * 64, "sha256:" + "d" * 64]
     await _handle_cloud_daemon_event(
         conn,
         {
@@ -375,6 +376,7 @@ async def test_runtime_snapshot_persists_to_daemon_instance(
             "params": {
                 "runtimes": [{"id": "deepseek-tui", "available": True}],
                 "probedAt": probed_at_ms,
+                "hubControlTrustKeyFingerprints": fingerprints,
             },
         },
     )
@@ -390,6 +392,7 @@ async def test_runtime_snapshot_persists_to_daemon_instance(
     assert refreshed is not None
     assert refreshed.runtimes_json == [{"id": "deepseek-tui", "available": True}]
     assert refreshed.runtimes_probed_at is not None
+    assert refreshed.hub_control_trust_key_fingerprints == fingerprints
 
 
 @pytest.mark.asyncio

--- a/docs/hub-control-signing-key-rotation.md
+++ b/docs/hub-control-signing-key-rotation.md
@@ -7,18 +7,99 @@ supported single-key fallback, and an embedded development public key is used
 only when neither variable supplies a key. Never put a private key in either
 public-key variable.
 
+## Release and fleet prerequisites
+
+The key-ring code must be published before any production signer change. This
+repository releases JavaScript packages through Changesets: merge a changeset,
+run the `Release Packages` workflow to create and merge its version PR, then run
+the workflow again to publish. The version PR is expected to bump both
+`@botcord/protocol-core` and `@botcord/daemon`; the daemon's `workspace:^`
+dependency is converted to the matching published protocol-core range by the
+publish flow. Do not use a backend release as evidence of a daemon release.
+
+Before approving the Version Packages PR, inspect its complete package and
+changeset list. The repository may contain unrelated pending changesets that
+the workflow will bundle into the same release. Either approve and attest the
+entire bundled release (including every unrelated change), or isolate the
+key-ring changes into a release branch/workflow that contains no unapproved
+changesets. The key-ring changeset alone is not evidence that the resulting
+artifacts are keyring-only.
+
+Record the package workflow run, immutable source commit, package names and
+versions, and npm tarball integrity values. Before rollout, install the exact
+daemon version in a clean environment (never `@latest`) and confirm its
+installed dependency tree contains the released protocol-core version. Also
+exercise one frame signed by each overlap key against that installed artifact.
+Only after those checks pass may `CLOUD_DAEMON_NPM_SPEC` be pinned to the exact
+attested daemon version for newly created E2B sandboxes.
+
+Inventory cloud and local daemons by agent, daemon version, last-seen time, and
+whether their configured trust ring contains both overlap keys. Treat a missing
+version or missing trust evidence as incompatible. The signer-switch gate is:
+
+- every cloud sandbox created before the exact package pin and overlap ring
+  took effect has been replaced/recreated; restart is acceptable only when
+  launch-time evidence already proves that exact pin and ring were present;
+- every local daemon seen during the agreed activity window (at least 24 hours,
+  extended to cover known intermittent agents) reports the attested version and
+  overlap ring; and
+- every remaining old or unknown daemon is explicitly disabled, disconnected,
+  or routed away from control frames, with an owner and recovery plan recorded.
+
+Counts alone are not sufficient. Save the agent-level inventory before and
+after migration, and require zero traffic-eligible incompatible/unknown entries
+before switching the signer. If local daemons cannot be upgraded or isolated,
+keep the old signer active; do not accept loss of control as a migration step.
+
+The released daemon reports `hubControlTrustKeyFingerprints` in each
+`runtime_snapshot`/`list_runtimes` result. Each value is
+`sha256:<64 lowercase hex characters>` computed from one configured public-key
+string; raw keys are never sent or stored. Apply
+`backend/migrations/001_add_daemon_trust_key_fingerprints.sql` and deploy the
+compatible Hub before collecting the gate inventory. Query
+`GET /daemon/instances` (and explicitly refresh online instances first) and
+compare each instance's `hub_control_trust_key_fingerprints` with fingerprints
+computed offline from the approved old and new public keys. Require both exact
+fingerprints, the attested daemon version, and a fresh `runtimes_probed_at` for
+every traffic-eligible instance. Both the list and per-instance refresh
+responses include `agent_bindings`, containing each bound `agent_id`, its
+status, and `traffic_eligible`. That flag is true only for an active,
+non-deleted agent. Export those bindings for the required before/after
+agent-level inventory, and disable or isolate every incompatible binding that
+is still eligible. A null/empty field, malformed fingerprint,
+stale probe, or extra unapproved key is incompatible and must be upgraded or
+isolated. Store only the fingerprints and comparison result in rollout records.
+
+## Rotation procedure
+
 Use this order for a compatible rotation:
 
 1. Generate the new key through the approved secret-management path. Do not
    print or persist private key material in logs, manifests, or ConfigMaps.
-2. Set daemon consumers to `BOTCORD_HUB_CONTROL_PUBLIC_KEYS=old,new`, then
-   release the compatible daemon and update the full local and cloud fleet.
-3. Confirm both old- and new-signed test frames are accepted. Existing E2B
-   sandboxes retain their launch environment, so inventory and restart or
-   replace them before changing the signer.
-4. Inject the new private key into the Hub from a Kubernetes Secret and roll
-   out the Hub. Monitor control acknowledgements and `bad_signature` errors.
-5. After the rollback window, remove the old public key from every consumer.
+2. Configure consumers with
+   `BOTCORD_HUB_CONTROL_PUBLIC_KEYS=old,new`. Publish and attest the compatible
+   packages as described above, pin cloud creation to the exact daemon version,
+   and update the fleet.
+3. Replace/recreate every E2B sandbox launched before the exact package pin and
+   overlap ring took effect. An E2B sandbox retains its launch environment, so
+   restart does not acquire either setting. Restart is sufficient only for a
+   sandbox whose recorded launch-time evidence already proves both settings.
+   Confirm the pinned artifact, overlap ring, and acceptance of both old- and
+   new-signed test frames on the replacement fleet.
+4. Enforce the zero-incompatible fleet gate above. Keep incompatible local
+   agents disconnected from control delivery until upgraded and re-attested.
+5. With production approval, inject the new private key into the Hub from a
+   Kubernetes Secret and roll out the Hub. Record source SHA and resulting image
+   digest, and monitor control acknowledgements and `bad_signature` errors.
+6. During the rollback window, keep both public keys deployed. If errors rise,
+   restore the old signer while the old key is still trusted, isolate newly
+   incompatible agents, and verify acknowledgements recover. A backend rollback
+   does not restore E2B launch-time environment; sandbox replacement is a
+   separate rollback action.
+7. After the rollback window and a fresh zero-incompatible inventory, remove
+   the old public key, replace/restart E2B sandboxes again, and verify that only
+   the new key remains trusted. Retire old private material through the approved
+   secret-management process.
 
 The Hub includes its currently active signing public key in the ring passed to
 new E2B daemons. Additional future/previous keys are configured on the Hub via

--- a/packages/daemon/src/__tests__/runtime-discovery.test.ts
+++ b/packages/daemon/src/__tests__/runtime-discovery.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { createHash } from "node:crypto";
 
 // Hoisted mock for `../adapters/runtimes.js` so each suite can stub
 // `detectRuntimes()` independently — we want coverage of the "empty
@@ -49,6 +50,30 @@ function setRuntimes(entries: typeof mockState.entries): void {
 }
 
 describe("collectRuntimeSnapshot", () => {
+  it("attests the configured trust ring using fingerprints, never raw keys", () => {
+    const previousPlural = process.env.BOTCORD_HUB_CONTROL_PUBLIC_KEYS;
+    const previousSingular = process.env.BOTCORD_HUB_CONTROL_PUBLIC_KEY;
+    process.env.BOTCORD_HUB_CONTROL_PUBLIC_KEYS = "old-public-key,new-public-key";
+    delete process.env.BOTCORD_HUB_CONTROL_PUBLIC_KEY;
+    try {
+      const snap = collectRuntimeSnapshot({ force: true });
+      const fingerprint = (key: string) =>
+        `sha256:${createHash("sha256").update(key, "utf8").digest("hex")}`;
+      expect(snap.hubControlTrustKeyFingerprints).toEqual([
+        fingerprint("old-public-key"),
+        fingerprint("new-public-key"),
+      ]);
+      expect(JSON.stringify(snap)).not.toContain("old-public-key");
+      expect(JSON.stringify(snap)).not.toContain("new-public-key");
+    } finally {
+      if (previousPlural === undefined) delete process.env.BOTCORD_HUB_CONTROL_PUBLIC_KEYS;
+      else process.env.BOTCORD_HUB_CONTROL_PUBLIC_KEYS = previousPlural;
+      if (previousSingular === undefined) delete process.env.BOTCORD_HUB_CONTROL_PUBLIC_KEY;
+      else process.env.BOTCORD_HUB_CONTROL_PUBLIC_KEY = previousSingular;
+      clearRuntimeProbeCache();
+    }
+  });
+
   it("returns an empty runtimes array when no adapters are registered", () => {
     setRuntimes([]);
     const snap = collectRuntimeSnapshot();

--- a/packages/daemon/src/provision.ts
+++ b/packages/daemon/src/provision.ts
@@ -16,6 +16,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { createRequire } from "node:module";
+import { createHash } from "node:crypto";
 import path from "node:path";
 import {
   BotCordClient,
@@ -24,6 +25,7 @@ import {
   derivePublicKey,
   loadStoredCredentials,
   normalizeTokenExpiresAt,
+  resolveHubControlPublicKeys,
   writeCredentialsFile,
   type AgentIdentitySnapshot,
   type ControlAck,
@@ -2281,6 +2283,9 @@ export function collectRuntimeSnapshot(opts: { force?: boolean } = {}): ListRunt
   const value: ListRuntimesResult = { runtimes, probedAt: Date.now() };
   const version = daemonPackageVersion();
   if (version) value.daemonVersion = version;
+  value.hubControlTrustKeyFingerprints = resolveHubControlPublicKeys().map(
+    (key) => `sha256:${createHash("sha256").update(key, "utf8").digest("hex")}`,
+  );
   _runtimeProbeCache = { at: Date.now(), value };
   return value;
 }

--- a/packages/protocol-core/src/control-frame.ts
+++ b/packages/protocol-core/src/control-frame.ts
@@ -827,6 +827,8 @@ export interface RuntimeSnapshotParams {
   runtimes: RuntimeProbeResult[];
   probedAt: number;
   daemonVersion?: string;
+  /** SHA-256 fingerprints of trusted Hub control keys; never raw keys. */
+  hubControlTrustKeyFingerprints?: string[];
 }
 
 /**
@@ -839,6 +841,7 @@ export interface ListRuntimesResult {
   runtimes: RuntimeProbeResult[];
   probedAt: number;
   daemonVersion?: string;
+  hubControlTrustKeyFingerprints?: string[];
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- attest daemon Hub-control trust rings with privacy-safe SHA-256 fingerprints and persist them in fleet inventory
- expose daemon-to-agent bindings and traffic eligibility for executable zero-incompatible fleet gates
- add migration, stale snapshot handling, focused regression coverage, changeset, and staged rotation runbook

## Validation
- Code Reviewer second review: no findings
- monorepo package build: pass
- protocol-core full tests: 52 passed
- gateway-ingress full tests: 98 passed
- CLI full tests: 4 passed
- daemon focused keyring/control tests: 27 passed
- backend focused daemon-control/cloud-WS tests: 67 passed
- pnpm tarballs installed in an empty temp project; exact dependency tree verified; old/new test-key frames both accepted by installed daemon (2/2)
- git diff --check: pass

## Known environment gaps
- daemon full suite: 1111 passed, 11 environment failures (3 require missing unzip; 8 discover the host OpenClaw systemd unit)
- ruff unavailable in the current environment
- live PostgreSQL migration, live E2E/fleet inventory, npm publish, deploy, ConfigMap changes, and real-key operations were not run

## Release gate
The Version Packages PR must review or isolate all pending changesets before publishing. Package publication and production rollout remain separately approval-gated.