### PR TITLE
fix: preserve trusted auth failure attribution

### DIFF
--- a/backend/hub/auth.py
+++ b/backend/hub/auth.py
@@ -53,14 +53,19 @@ def create_agent_token(agent_id: str) -> tuple[str, int]:
     return token, int(expires_at.timestamp())
 
 
-def verify_agent_token(token: str) -> str:
+def verify_agent_token(token: str, *, verify_expiration: bool = True) -> str:
     """Verify a JWT token and return the agent_id.
 
     Raises:
         jwt.ExpiredSignatureError: If the token has expired.
         jwt.InvalidTokenError: If the token is invalid.
     """
-    payload = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
+    payload = jwt.decode(
+        token,
+        JWT_SECRET,
+        algorithms=[JWT_ALGORITHM],
+        options={"verify_exp": verify_expiration},
+    )
     agent_id = payload.get("agent_id")
     if not agent_id:
         raise jwt.InvalidTokenError("Missing agent_id claim")
@@ -95,9 +100,19 @@ def get_current_agent(
     token = authorization[len("Bearer "):]
     try:
         agent_id = verify_agent_token(token)
+        request.state.verified_agent_id = agent_id
         request.state.authenticated_agent_id = agent_id
         return agent_id
     except jwt.ExpiredSignatureError:
+        # Expiry does not invalidate the JWT signature or its identity claims.
+        # Re-verify with only the time check disabled so the failure log can
+        # contain a server-trusted principal without logging token material.
+        try:
+            request.state.verified_agent_id = verify_agent_token(
+                token, verify_expiration=False
+            )
+        except jwt.InvalidTokenError:
+            pass
         _log_agent_auth_failure(request, "expired")
         raise I18nHTTPException(status_code=401, message_key="token_expired")
     except jwt.InvalidTokenError:
@@ -134,7 +149,14 @@ async def get_current_claimed_agent(
     token = authorization[len("Bearer "):]
     try:
         agent_id = verify_agent_token(token)
+        request.state.verified_agent_id = agent_id
     except jwt.ExpiredSignatureError:
+        try:
+            request.state.verified_agent_id = verify_agent_token(
+                token, verify_expiration=False
+            )
+        except jwt.InvalidTokenError:
+            pass
         _log_agent_auth_failure(request, "expired")
         raise I18nHTTPException(status_code=401, message_key="token_expired")
     except jwt.InvalidTokenError:
@@ -230,6 +252,7 @@ def verify_supabase_token(token: str) -> str:
 def _parse_dashboard_token(
     authorization: str,
     x_active_agent: str | None,
+    request: Request | None = None,
 ) -> tuple[str, str | None, str | None]:
     """Parse a dashboard Authorization header.
 
@@ -239,12 +262,27 @@ def _parse_dashboard_token(
     and must be verified against the agent's ``user_id`` by the caller.
     """
     if not authorization.startswith("Bearer "):
+        if request is not None:
+            _log_agent_auth_failure(request, "malformed")
         raise I18nHTTPException(status_code=401, message_key="invalid_authorization_header")
     token = authorization[len("Bearer "):]
 
     # Fast path: botcord agent JWT — agent_id is embedded, already trusted.
+    agent_failure = "invalid"
     try:
-        return verify_agent_token(token), None, token
+        agent_id = verify_agent_token(token)
+        if request is not None:
+            request.state.verified_agent_id = agent_id
+        return agent_id, None, token
+    except jwt.ExpiredSignatureError:
+        agent_failure = "expired"
+        if request is not None:
+            try:
+                request.state.verified_agent_id = verify_agent_token(
+                    token, verify_expiration=False
+                )
+            except jwt.InvalidTokenError:
+                pass
     except jwt.InvalidTokenError:
         pass
 
@@ -252,6 +290,8 @@ def _parse_dashboard_token(
     try:
         supabase_user_id = verify_supabase_token(token)
     except jwt.InvalidTokenError:
+        if request is not None:
+            _log_agent_auth_failure(request, agent_failure)
         raise I18nHTTPException(status_code=401, message_key="invalid_token")
 
     if not x_active_agent:
@@ -309,6 +349,7 @@ async def get_dashboard_agent(
 
 
 async def get_dashboard_claimed_agent(
+    request: Request,
     authorization: str = Header(...),
     x_active_agent: str | None = Header(default=None, alias="X-Active-Agent"),
     db: AsyncSession = Depends(get_db),
@@ -317,14 +358,25 @@ async def get_dashboard_claimed_agent(
 
     When using Supabase JWT, verifies agent ownership via ``users`` → ``agents.user_id``.
     """
-    agent_id, supabase_uid, agent_token = _parse_dashboard_token(authorization, x_active_agent)
+    agent_id, supabase_uid, agent_token = _parse_dashboard_token(
+        authorization, x_active_agent, request
+    )
 
     result = await db.execute(select(Agent).where(Agent.agent_id == agent_id))
     agent = result.scalar_one_or_none()
     if agent is None:
         raise I18nHTTPException(status_code=404, message_key="agent_not_found")
     if supabase_uid is None and agent_token is not None:
-        assert_current_agent_token(agent, agent_token)
+        try:
+            assert_current_agent_token(agent, agent_token)
+        except I18nHTTPException as exc:
+            failure = (
+                "expired"
+                if getattr(exc, "message_key", None) == "token_expired"
+                else "stale_or_revoked"
+            )
+            _log_agent_auth_failure(request, failure)
+            raise
     elif agent.status != "active":
         raise I18nHTTPException(status_code=404, message_key="agent_not_found")
     if agent.claimed_at is None:
@@ -334,6 +386,7 @@ async def get_dashboard_claimed_agent(
         if internal_uid is None or str(agent.user_id) != internal_uid:
             raise I18nHTTPException(status_code=403, message_key="agent_not_owned_by_user")
 
+    request.state.authenticated_agent_id = agent_id
     return agent_id
 
 

--- a/backend/hub/auth.py
+++ b/backend/hub/auth.py
@@ -112,7 +112,8 @@ def get_current_agent(
                 token, verify_expiration=False
             )
         except jwt.InvalidTokenError:
-            pass
+            _log_agent_auth_failure(request, "invalid")
+            raise I18nHTTPException(status_code=401, message_key="invalid_token")
         _log_agent_auth_failure(request, "expired")
         raise I18nHTTPException(status_code=401, message_key="token_expired")
     except jwt.InvalidTokenError:
@@ -156,7 +157,8 @@ async def get_current_claimed_agent(
                 token, verify_expiration=False
             )
         except jwt.InvalidTokenError:
-            pass
+            _log_agent_auth_failure(request, "invalid")
+            raise I18nHTTPException(status_code=401, message_key="invalid_token")
         _log_agent_auth_failure(request, "expired")
         raise I18nHTTPException(status_code=401, message_key="token_expired")
     except jwt.InvalidTokenError:
@@ -279,7 +281,6 @@ def _parse_dashboard_token(
             request.state.verified_agent_id = agent_id
         return agent_id, None, token
     except jwt.ExpiredSignatureError:
-        agent_failure = "expired"
         if request is not None:
             try:
                 request.state.verified_agent_id = verify_agent_token(
@@ -287,6 +288,15 @@ def _parse_dashboard_token(
                 )
             except jwt.InvalidTokenError:
                 pass
+            else:
+                agent_failure = "expired"
+        else:
+            try:
+                verify_agent_token(token, verify_expiration=False)
+            except jwt.InvalidTokenError:
+                pass
+            else:
+                agent_failure = "expired"
     except jwt.InvalidTokenError:
         pass
 

--- a/backend/hub/auth.py
+++ b/backend/hub/auth.py
@@ -250,7 +250,7 @@ def verify_supabase_token(token: str) -> str:
 
 
 def _parse_dashboard_token(
-    authorization: str,
+    authorization: str | None,
     x_active_agent: str | None,
     request: Request | None = None,
 ) -> tuple[str, str | None, str | None]:
@@ -261,6 +261,10 @@ def _parse_dashboard_token(
     When the token is a Supabase JWT, supabase_user_id is extracted from ``sub``
     and must be verified against the agent's ``user_id`` by the caller.
     """
+    if not authorization:
+        if request is not None:
+            _log_agent_auth_failure(request, "missing")
+        raise I18nHTTPException(status_code=401, message_key="invalid_authorization_header")
     if not authorization.startswith("Bearer "):
         if request is not None:
             _log_agent_auth_failure(request, "malformed")
@@ -350,7 +354,7 @@ async def get_dashboard_agent(
 
 async def get_dashboard_claimed_agent(
     request: Request,
-    authorization: str = Header(...),
+    authorization: str | None = Header(default=None),
     x_active_agent: str | None = Header(default=None, alias="X-Active-Agent"),
     db: AsyncSession = Depends(get_db),
 ) -> str:

--- a/backend/hub/request_observability.py
+++ b/backend/hub/request_observability.py
@@ -53,6 +53,9 @@ def auth_failure_context(request: Request, failure: str) -> dict[str, str | None
         "caller": _caller_hint(request),
         "caller_version": _matching_header(request, "x-botcord-caller-version", _VERSION),
         "agent_id_hint": _matching_header(request, "x-botcord-agent-id", _AGENT_ID),
+        # Set only after the Hub has verified the JWT signature and claims.
+        # Unlike agent_id_hint, this value is never accepted from a header.
+        "verified_agent_id": getattr(request.state, "verified_agent_id", None),
         "credential_key_id": _matching_header(request, "x-botcord-credential-key-id", _KEY_ID),
         "user_agent_hash": _user_agent_hash(request),
     }

--- a/backend/tests/test_m3_hub.py
+++ b/backend/tests/test_m3_hub.py
@@ -9,6 +9,7 @@ import time
 import uuid
 
 import jcs
+import jwt
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
@@ -18,6 +19,7 @@ from unittest.mock import AsyncMock
 
 from sqlalchemy import select
 
+from hub import auth
 from hub.models import Base, MessageRecord, MessageState
 
 # ---------------------------------------------------------------------------
@@ -686,6 +688,46 @@ async def test_receipt_forwarding_delivered_immediately(
 # ===========================================================================
 # GET /hub/inbox (polling) tests
 # ===========================================================================
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method", "path", "body"),
+    [
+        ("GET", "/hub/inbox", None),
+        ("POST", "/hub/inbox/ack", {"message_ids": []}),
+        ("POST", "/hub/inbox/lease/renew", {"message_ids": []}),
+    ],
+)
+async def test_inbox_routes_log_expired_signature_verified_principal(
+    client: AsyncClient,
+    caplog: pytest.LogCaptureFixture,
+    method: str,
+    path: str,
+    body: dict | None,
+):
+    token = jwt.encode(
+        {
+            "agent_id": "ag_trusted_expired_inbox",
+            "exp": dt.datetime.now(dt.timezone.utc) - dt.timedelta(seconds=1),
+            "iss": "botcord",
+        },
+        auth.JWT_SECRET,
+        algorithm=auth.JWT_ALGORITHM,
+    )
+    caplog.set_level(logging.WARNING, logger="hub.auth")
+
+    response = await client.request(
+        method,
+        path,
+        headers=_auth_header(token),
+        json=body,
+    )
+
+    assert response.status_code == 401
+    assert '"failure": "expired"' in caplog.text
+    assert '"verified_agent_id": "ag_trusted_expired_inbox"' in caplog.text
+    assert token not in caplog.text
 
 
 async def _setup_two_agents_no_endpoint(client: AsyncClient):

--- a/backend/tests/test_request_observability.py
+++ b/backend/tests/test_request_observability.py
@@ -165,6 +165,75 @@ def test_expired_agent_auth_logs_signature_verified_principal(
     assert token not in caplog.text
 
 
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"agent_id": "ag_untrusted", "iss": "not-botcord"},
+        {"iss": "botcord"},
+    ],
+    ids=["wrong-issuer", "missing-agent-id"],
+)
+def test_expired_current_agent_with_invalid_claims_is_logged_as_invalid(
+    payload: dict[str, str],
+    caplog: pytest.LogCaptureFixture,
+):
+    request = _request()
+    token = jwt.encode(
+        {
+            **payload,
+            "exp": datetime.datetime.now(datetime.timezone.utc)
+            - datetime.timedelta(seconds=1),
+        },
+        auth.JWT_SECRET,
+        algorithm=auth.JWT_ALGORITHM,
+    )
+    caplog.set_level(logging.WARNING, logger="hub.auth")
+
+    with pytest.raises(I18nHTTPException) as exc_info:
+        auth.get_current_agent(request, f"Bearer {token}")
+
+    assert exc_info.value.message_key == "invalid_token"
+    assert '"failure": "invalid"' in caplog.text
+    assert '"failure": "expired"' not in caplog.text
+    assert getattr(request.state, "verified_agent_id", None) is None
+    assert token not in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"agent_id": "ag_untrusted", "iss": "not-botcord"},
+        {"iss": "botcord"},
+    ],
+    ids=["wrong-issuer", "missing-agent-id"],
+)
+async def test_expired_current_claimed_agent_with_invalid_claims_is_logged_as_invalid(
+    payload: dict[str, str],
+    caplog: pytest.LogCaptureFixture,
+):
+    request = _request()
+    token = jwt.encode(
+        {
+            **payload,
+            "exp": datetime.datetime.now(datetime.timezone.utc)
+            - datetime.timedelta(seconds=1),
+        },
+        auth.JWT_SECRET,
+        algorithm=auth.JWT_ALGORITHM,
+    )
+    caplog.set_level(logging.WARNING, logger="hub.auth")
+
+    with pytest.raises(I18nHTTPException) as exc_info:
+        await auth.get_current_claimed_agent(request, f"Bearer {token}", None)
+
+    assert exc_info.value.message_key == "invalid_token"
+    assert '"failure": "invalid"' in caplog.text
+    assert '"failure": "expired"' not in caplog.text
+    assert getattr(request.state, "verified_agent_id", None) is None
+    assert token not in caplog.text
+
+
 @pytest.mark.asyncio
 async def test_persisted_token_expiry_is_not_logged_as_stale_or_revoked(
     monkeypatch: pytest.MonkeyPatch,
@@ -296,6 +365,8 @@ def test_expired_dashboard_token_never_attributes_unverified_principal(
     with pytest.raises(I18nHTTPException):
         auth._parse_dashboard_token(f"Bearer {token}", None, request)
 
+    assert '"failure": "invalid"' in caplog.text
+    assert '"failure": "expired"' not in caplog.text
     assert getattr(request.state, "verified_agent_id", None) is None
     assert '"verified_agent_id": null' in caplog.text
     assert token not in caplog.text

--- a/backend/tests/test_request_observability.py
+++ b/backend/tests/test_request_observability.py
@@ -4,6 +4,7 @@ import datetime
 import hashlib
 from unittest.mock import AsyncMock
 
+import jwt
 import pytest
 from starlette.requests import Request
 
@@ -52,6 +53,7 @@ def test_auth_failure_context_only_includes_safe_non_secret_metadata():
         "caller": "protocol-core",
         "caller_version": "0.2.17",
         "agent_id_hint": "ag_0123456789abcdef",
+        "verified_agent_id": None,
         "credential_key_id": "k_0123456789abcdef",
         "user_agent_hash": hashlib.sha256(b"undici").hexdigest()[:16],
     }
@@ -111,6 +113,15 @@ def test_user_agent_is_hashed_instead_of_logged_verbatim():
     assert secret not in json.dumps(context)
 
 
+def test_agent_id_header_cannot_forge_verified_principal():
+    context = auth_failure_context(
+        _request([(b"x-botcord-agent-id", b"ag_0123456789abcdef")]), "invalid"
+    )
+
+    assert context["agent_id_hint"] == "ag_0123456789abcdef"
+    assert context["verified_agent_id"] is None
+
+
 @pytest.mark.parametrize(
     ("authorization", "failure"),
     [(None, "missing"), ("Basic abc", "malformed"), ("Bearer bad", "invalid")],
@@ -128,6 +139,30 @@ def test_agent_auth_failure_is_classified_without_token(
 
     assert f'"failure": "{failure}"' in caplog.text
     assert "Bearer bad" not in caplog.text
+
+
+def test_expired_agent_auth_logs_signature_verified_principal(
+    caplog: pytest.LogCaptureFixture,
+):
+    request = _request([(b"x-botcord-agent-id", b"ag_untrusted_hint")])
+    token = jwt.encode(
+        {
+            "agent_id": "ag_trusted_expired",
+            "exp": datetime.datetime.now(datetime.timezone.utc)
+            - datetime.timedelta(seconds=1),
+            "iss": "botcord",
+        },
+        auth.JWT_SECRET,
+        algorithm=auth.JWT_ALGORITHM,
+    )
+    caplog.set_level(logging.WARNING, logger="hub.auth")
+
+    with pytest.raises(I18nHTTPException):
+        auth.get_current_agent(request, f"Bearer {token}")
+
+    assert '"failure": "expired"' in caplog.text
+    assert '"verified_agent_id": "ag_trusted_expired"' in caplog.text
+    assert token not in caplog.text
 
 
 @pytest.mark.asyncio
@@ -153,4 +188,66 @@ async def test_persisted_token_expiry_is_not_logged_as_stale_or_revoked(
 
     assert exc_info.value.message_key == "token_expired"
     assert '"failure": "expired"' in caplog.text
+    assert '"verified_agent_id": "ag_test"' in caplog.text
     assert "stale_or_revoked" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_dashboard_claimed_agent_logs_expired_trusted_principal(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    request = _request()
+    token = jwt.encode(
+        {
+            "agent_id": "ag_trusted_inbox",
+            "exp": datetime.datetime.now(datetime.timezone.utc)
+            - datetime.timedelta(seconds=1),
+            "iss": "botcord",
+        },
+        auth.JWT_SECRET,
+        algorithm=auth.JWT_ALGORITHM,
+    )
+    monkeypatch.setattr(
+        auth,
+        "verify_supabase_token",
+        lambda _token: (_ for _ in ()).throw(jwt.InvalidTokenError()),
+    )
+    caplog.set_level(logging.WARNING, logger="hub.auth")
+
+    with pytest.raises(I18nHTTPException) as exc_info:
+        await auth.get_dashboard_claimed_agent(request, f"Bearer {token}", None, None)
+
+    assert exc_info.value.message_key == "invalid_token"
+    assert '"failure": "expired"' in caplog.text
+    assert '"path": "/hub/inbox"' in caplog.text
+    assert '"verified_agent_id": "ag_trusted_inbox"' in caplog.text
+    assert token not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_dashboard_claimed_agent_logs_stale_token_without_secret(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    request = _request()
+    agent = type("AgentStub", (), {
+        "agent_id": "ag_trusted_inbox",
+        "status": "active",
+        "agent_token": "replacement-token",
+        "token_expires_at": None,
+        "claimed_at": datetime.datetime.now(datetime.timezone.utc),
+    })()
+    result = type("ResultStub", (), {"scalar_one_or_none": lambda self: agent})()
+    db = type("DbStub", (), {"execute": AsyncMock(return_value=result)})()
+    monkeypatch.setattr(auth, "verify_agent_token", lambda _token, **_kwargs: agent.agent_id)
+    caplog.set_level(logging.WARNING, logger="hub.auth")
+
+    with pytest.raises(I18nHTTPException):
+        await auth.get_dashboard_claimed_agent(
+            request, "Bearer stale-secret-token", None, db
+        )
+
+    assert '"failure": "stale_or_revoked"' in caplog.text
+    assert '"verified_agent_id": "ag_trusted_inbox"' in caplog.text
+    assert "stale-secret-token" not in caplog.text

--- a/backend/tests/test_request_observability.py
+++ b/backend/tests/test_request_observability.py
@@ -227,7 +227,6 @@ async def test_dashboard_claimed_agent_logs_expired_trusted_principal(
 
 @pytest.mark.asyncio
 async def test_dashboard_claimed_agent_logs_stale_token_without_secret(
-    monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ):
     request = _request()
@@ -240,14 +239,88 @@ async def test_dashboard_claimed_agent_logs_stale_token_without_secret(
     })()
     result = type("ResultStub", (), {"scalar_one_or_none": lambda self: agent})()
     db = type("DbStub", (), {"execute": AsyncMock(return_value=result)})()
-    monkeypatch.setattr(auth, "verify_agent_token", lambda _token, **_kwargs: agent.agent_id)
+    token = jwt.encode(
+        {
+            "agent_id": agent.agent_id,
+            "exp": datetime.datetime.now(datetime.timezone.utc)
+            + datetime.timedelta(hours=1),
+            "iss": "botcord",
+        },
+        auth.JWT_SECRET,
+        algorithm=auth.JWT_ALGORITHM,
+    )
     caplog.set_level(logging.WARNING, logger="hub.auth")
 
     with pytest.raises(I18nHTTPException):
         await auth.get_dashboard_claimed_agent(
-            request, "Bearer stale-secret-token", None, db
+            request, f"Bearer {token}", None, db
         )
 
     assert '"failure": "stale_or_revoked"' in caplog.text
     assert '"verified_agent_id": "ag_trusted_inbox"' in caplog.text
-    assert "stale-secret-token" not in caplog.text
+    assert token not in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("payload", "secret"),
+    [
+        ({"agent_id": "ag_untrusted", "iss": "botcord"}, "wrong-signing-secret"),
+        ({"agent_id": "ag_untrusted", "iss": "not-botcord"}, auth.JWT_SECRET),
+        ({"iss": "botcord"}, auth.JWT_SECRET),
+    ],
+    ids=["wrong-signature", "wrong-issuer", "missing-agent-id"],
+)
+def test_expired_dashboard_token_never_attributes_unverified_principal(
+    payload: dict[str, str],
+    secret: str,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    request = _request()
+    token = jwt.encode(
+        {
+            **payload,
+            "exp": datetime.datetime.now(datetime.timezone.utc)
+            - datetime.timedelta(seconds=1),
+        },
+        secret,
+        algorithm=auth.JWT_ALGORITHM,
+    )
+    monkeypatch.setattr(
+        auth,
+        "verify_supabase_token",
+        lambda _token: (_ for _ in ()).throw(jwt.InvalidTokenError()),
+    )
+    caplog.set_level(logging.WARNING, logger="hub.auth")
+
+    with pytest.raises(I18nHTTPException):
+        auth._parse_dashboard_token(f"Bearer {token}", None, request)
+
+    assert getattr(request.state, "verified_agent_id", None) is None
+    assert '"verified_agent_id": null' in caplog.text
+    assert token not in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("authorization", "failure"),
+    [(None, "missing"), ("Basic abc", "malformed"), ("Bearer bad", "invalid")],
+)
+def test_dashboard_auth_failure_without_trusted_token_has_no_principal(
+    authorization: str | None,
+    failure: str,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    request = _request()
+    monkeypatch.setattr(
+        auth,
+        "verify_supabase_token",
+        lambda _token: (_ for _ in ()).throw(jwt.InvalidTokenError()),
+    )
+    caplog.set_level(logging.WARNING, logger="hub.auth")
+
+    with pytest.raises(I18nHTTPException):
+        auth._parse_dashboard_token(authorization, None, request)
+
+    assert f'"failure": "{failure}"' in caplog.text
+    assert '"verified_agent_id": null' in caplog.text


### PR DESCRIPTION
## Summary
- derive trusted principals for signed stale/revoked auth failures without trusting unverified claims
- cover dashboard-authenticated Hub routes and keep invalid expired-token claims classified as invalid
- ensure failed authentication emits one safe observability event without credential leakage

## Verification
- `uv run pytest tests/test_request_observability.py tests/test_m3_hub.py`: 75 passed (review verification)
- targeted expired-token subset: 36 passed (review verification)
- `git diff --check 9807f21a..HEAD`

## Safety
- Code Reviewer completed defect-first review with no blocking findings
- no deployment or runtime mutation included