### PR TITLE
feat: add liquid glass light theme

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -18,6 +18,70 @@
   --font-mono: var(--font-mono);
 }
 
+:root {
+  color-scheme: dark;
+  --liquid-canvas:
+    radial-gradient(circle at 12% 8%, rgba(0, 240, 255, 0.11), transparent 30%),
+    radial-gradient(circle at 85% 13%, rgba(139, 92, 246, 0.10), transparent 29%),
+    linear-gradient(145deg, #09111f 0%, #080d18 48%, #0a0d17 100%);
+  --liquid-surface: linear-gradient(145deg, rgba(25, 36, 55, 0.78), rgba(12, 19, 32, 0.66));
+  --liquid-surface-strong: linear-gradient(145deg, rgba(24, 34, 52, 0.93), rgba(10, 16, 28, 0.89));
+  --liquid-border: rgba(255, 255, 255, 0.15);
+  --liquid-highlight: rgba(255, 255, 255, 0.09);
+  --liquid-control: rgba(255, 255, 255, 0.06);
+  --liquid-shadow: 0 20px 52px rgba(0, 0, 0, 0.28), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  --color-zinc-950: rgba(7, 11, 18, 0.90);
+  --color-zinc-900: rgba(18, 26, 39, 0.84);
+  --color-zinc-800: rgba(39, 50, 66, 0.76);
+  --color-zinc-700: rgba(82, 96, 118, 0.68);
+}
+
+html[data-theme="light"] {
+  color-scheme: light;
+  --color-deep-black: #eef3f9;
+  --color-deep-black-light: rgba(255, 255, 255, 0.72);
+  --color-neon-cyan: #007b93;
+  --color-neon-purple: #6d4dd8;
+  --color-neon-green: #087a59;
+  --color-neon-cyan-dim: #007b9330;
+  --color-neon-purple-dim: #6d4dd830;
+  --color-neon-green-dim: #087a5930;
+  --color-glass-bg: rgba(255, 255, 255, 0.58);
+  --color-glass-border: rgba(113, 137, 166, 0.34);
+  --color-text-primary: #17283d;
+  --color-text-secondary: #52657c;
+
+  /*
+   * Several established dashboard primitives use Tailwind's zinc palette
+   * directly. Remapping those variables keeps menus, input states, and
+   * streaming bubbles legible without duplicating a light-mode branch in each
+   * component.
+   */
+  --color-zinc-950: rgba(245, 248, 252, 0.94);
+  --color-zinc-900: rgba(232, 239, 247, 0.82);
+  --color-zinc-800: rgba(215, 226, 238, 0.78);
+  --color-zinc-700: rgba(194, 208, 222, 0.72);
+  --color-zinc-600: #8395aa;
+  --color-zinc-500: #64778d;
+  --color-zinc-400: #50637a;
+  --color-zinc-300: #3e5066;
+  --color-zinc-200: #2c3e54;
+  --color-zinc-100: #17283d;
+  --color-white: #17283d;
+
+  --liquid-canvas:
+    radial-gradient(circle at 10% 4%, rgba(0, 149, 182, 0.14), transparent 31%),
+    radial-gradient(circle at 88% 5%, rgba(109, 77, 216, 0.12), transparent 28%),
+    radial-gradient(circle at 50% 102%, rgba(64, 151, 200, 0.11), transparent 37%),
+    linear-gradient(145deg, #f8fbff 0%, #edf3f9 48%, #e8eff7 100%);
+  --liquid-surface: linear-gradient(135deg, rgba(255, 255, 255, 0.84), rgba(247, 250, 255, 0.64));
+  --liquid-surface-strong: linear-gradient(135deg, rgba(255, 255, 255, 0.94), rgba(246, 250, 255, 0.84));
+  --liquid-border: rgba(255, 255, 255, 0.82);
+  --liquid-highlight: rgba(255, 255, 255, 0.82);
+  --liquid-control: rgba(255, 255, 255, 0.58);
+  --liquid-shadow: 0 18px 46px rgba(44, 69, 99, 0.13), inset 0 1px 0 rgba(255, 255, 255, 0.88);
+}
+
 html {
   scroll-behavior: smooth;
 }
@@ -28,6 +92,246 @@ body {
   font-family: var(--font-sans);
   overflow-x: hidden;
   -webkit-tap-highlight-color: transparent;
+  transition: background-color 180ms ease, color 180ms ease;
+}
+
+.dashboard-root {
+  isolation: isolate;
+  background: var(--liquid-canvas);
+}
+
+.dashboard-root::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(115deg, transparent 15%, var(--liquid-highlight) 47%, transparent 74%),
+    radial-gradient(circle at 76% 88%, rgba(0, 240, 255, 0.06), transparent 27%);
+  opacity: 0.62;
+}
+
+.dashboard-root > * {
+  position: relative;
+  z-index: 1;
+}
+
+.dashboard-main {
+  background: transparent;
+}
+
+.dashboard-root [class*="bg-deep-black-light"],
+.dashboard-root [class*="bg-glass-bg"],
+.dashboard-root [class*="bg-zinc-"] {
+  background-image: linear-gradient(135deg, var(--liquid-highlight), transparent 56%);
+}
+
+[role="dialog"],
+[role="menu"],
+[role="listbox"] {
+  background-image: linear-gradient(135deg, var(--liquid-highlight), transparent 58%);
+}
+
+.liquid-rail,
+.liquid-panel,
+.liquid-toolbar,
+.liquid-menu,
+.liquid-composer {
+  border-color: var(--liquid-border);
+  box-shadow: var(--liquid-shadow);
+}
+
+.liquid-rail {
+  background: var(--liquid-surface-strong);
+}
+
+.liquid-panel,
+.liquid-toolbar,
+.liquid-menu,
+.liquid-composer {
+  background: var(--liquid-surface);
+}
+
+.liquid-menu {
+  border: 1px solid var(--liquid-border);
+}
+
+.liquid-card,
+.liquid-dialog,
+.liquid-drawer,
+.liquid-tool-surface,
+.liquid-empty-state {
+  border: 1px solid var(--liquid-border);
+  box-shadow: var(--liquid-shadow);
+}
+
+.liquid-card,
+.liquid-dialog,
+.liquid-empty-state {
+  background: var(--liquid-surface);
+}
+
+.liquid-drawer,
+.liquid-tool-surface {
+  background: var(--liquid-surface-strong);
+}
+
+.liquid-list-row {
+  border: 1px solid transparent;
+  background: transparent;
+  box-shadow: inset 0 1px 0 transparent;
+}
+
+.liquid-list-row:hover,
+.liquid-list-row:focus-visible {
+  border-color: var(--liquid-border);
+  background: var(--liquid-control);
+  box-shadow: inset 0 1px 0 var(--liquid-highlight);
+}
+
+.liquid-action {
+  border: 1px solid var(--liquid-border);
+  background: var(--liquid-control);
+  box-shadow: inset 0 1px 0 var(--liquid-highlight);
+}
+
+.liquid-action:hover,
+.liquid-action:focus-visible {
+  background: var(--liquid-surface);
+  box-shadow: var(--liquid-shadow);
+}
+
+.liquid-tabs {
+  border: 1px solid var(--liquid-border);
+  background: var(--liquid-control);
+  box-shadow: inset 0 1px 0 var(--liquid-highlight);
+}
+
+.liquid-scrim {
+  background: rgba(3, 10, 20, 0.58);
+}
+
+html[data-theme="light"] .liquid-scrim {
+  background: rgba(35, 55, 79, 0.24);
+}
+
+.liquid-toolbar {
+  box-shadow: 0 10px 26px rgba(15, 24, 40, 0.05), inset 0 1px 0 var(--liquid-highlight);
+}
+
+.liquid-message {
+  box-shadow: inset 0 1px 0 var(--liquid-highlight), 0 8px 20px rgba(15, 24, 40, 0.05);
+}
+
+.liquid-message-peer {
+  background: var(--liquid-surface);
+  border-color: var(--liquid-border);
+}
+
+.liquid-message-own {
+  background: linear-gradient(135deg, rgba(0, 155, 185, 0.28), rgba(0, 112, 145, 0.14));
+  border-color: rgba(0, 194, 229, 0.34);
+}
+
+html[data-theme="light"] .liquid-message-own {
+  background: linear-gradient(135deg, rgba(205, 243, 248, 0.92), rgba(221, 239, 255, 0.82));
+  border-color: rgba(0, 123, 147, 0.23);
+}
+
+.liquid-message-error {
+  background: linear-gradient(135deg, rgba(127, 29, 29, 0.22), rgba(69, 10, 10, 0.12));
+  border-color: rgba(248, 113, 113, 0.28);
+}
+
+html[data-theme="light"] .liquid-message-error {
+  background: linear-gradient(135deg, rgba(255, 239, 239, 0.94), rgba(255, 248, 248, 0.80));
+  border-color: rgba(220, 38, 38, 0.20);
+}
+
+.liquid-input {
+  border: 1px solid var(--liquid-border);
+  background: var(--liquid-control);
+  box-shadow: inset 0 1px 0 var(--liquid-highlight);
+}
+
+.liquid-input:focus {
+  border-color: color-mix(in srgb, var(--color-neon-cyan) 56%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-neon-cyan) 13%, transparent), inset 0 1px 0 var(--liquid-highlight);
+}
+
+.liquid-input[aria-invalid="true"],
+.liquid-input[aria-invalid="true"]:focus {
+  border-color: rgba(239, 68, 68, 0.72);
+  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.10), inset 0 1px 0 var(--liquid-highlight);
+}
+
+.liquid-send-button {
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 8px 18px rgba(0, 172, 205, 0.16);
+}
+
+.liquid-theme-toggle {
+  border: 1px solid transparent;
+  background: var(--liquid-control);
+  box-shadow: inset 0 1px 0 var(--liquid-highlight);
+}
+
+.liquid-empty-state.border-dashed {
+  border-style: dashed;
+}
+
+.liquid-theme-toggle:hover {
+  border-color: var(--liquid-border);
+  background: var(--liquid-surface);
+  box-shadow: var(--liquid-shadow);
+  transform: translateY(-1px);
+}
+
+.liquid-nav-button {
+  border: 1px solid transparent;
+  box-shadow: inset 0 1px 0 transparent;
+}
+
+.liquid-nav-button:hover,
+.liquid-nav-button:focus-visible {
+  border-color: var(--liquid-border);
+  box-shadow: inset 0 1px 0 var(--liquid-highlight);
+}
+
+@supports ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .liquid-rail,
+  .liquid-panel,
+  .liquid-toolbar,
+  .liquid-menu,
+  .liquid-composer,
+  .liquid-card,
+  .liquid-dialog,
+  .liquid-drawer,
+  .liquid-tool-surface,
+  .liquid-empty-state,
+  .liquid-action,
+  .liquid-tabs,
+  .liquid-theme-toggle {
+    -webkit-backdrop-filter: blur(20px) saturate(118%);
+    backdrop-filter: blur(20px) saturate(118%);
+  }
+
+  .liquid-scrim {
+    -webkit-backdrop-filter: blur(8px) saturate(105%);
+    backdrop-filter: blur(8px) saturate(105%);
+  }
+
+  .liquid-message-peer {
+    -webkit-backdrop-filter: blur(14px) saturate(112%);
+    backdrop-filter: blur(14px) saturate(112%);
+  }
+
+  [role="dialog"],
+  [role="menu"],
+  [role="listbox"] {
+    -webkit-backdrop-filter: blur(20px) saturate(118%);
+    backdrop-filter: blur(20px) saturate(118%);
+  }
 }
 
 /* iOS Safari/Chrome auto-zooms when focusing inputs with font-size < 16px.

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -8,6 +8,7 @@
 import type { Metadata, Viewport } from "next";
 import { Analytics } from "@vercel/analytics/next";
 import NextTopLoader from "nextjs-toploader";
+import Script from "next/script";
 import { inter, jetbrainsMono } from "@/lib/fonts";
 import { getAppBaseUrl } from "@/lib/share-metadata";
 import { GoogleAnalytics } from "@/components/analytics/GoogleAnalytics";
@@ -32,7 +33,7 @@ export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   viewportFit: "cover",
-  themeColor: "#0a0a0f",
+  themeColor: "#08111f",
 };
 
 export default function RootLayout({
@@ -41,7 +42,19 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable}`}>
+    <html lang="en" suppressHydrationWarning className={`${inter.variable} ${jetbrainsMono.variable}`}>
+      <head>
+        <Script id="botcord-theme" strategy="beforeInteractive">
+          {`try {
+            const stored = JSON.parse(localStorage.getItem("app-storage") || "{}");
+            const theme = stored && stored.state && stored.state.theme;
+            if (theme === "light" || theme === "dark") {
+              document.documentElement.dataset.theme = theme;
+              document.documentElement.style.colorScheme = theme;
+            }
+          } catch {}`}
+        </Script>
+      </head>
       <body className="min-h-screen bg-deep-black text-text-primary antialiased">
         <NextTopLoader
           color="#00f0ff"

--- a/frontend/src/components/dashboard/AccountMenu.tsx
+++ b/frontend/src/components/dashboard/AccountMenu.tsx
@@ -48,7 +48,7 @@ export default function AccountMenu({
       <DropdownMenu.Root open={open} onOpenChange={setOpen}>
         <DropdownMenu.Trigger asChild>
           <button
-            className="relative flex h-10 w-10 items-center justify-center rounded-2xl border border-glass-border/80 bg-deep-black-light text-sm font-bold text-neon-cyan shadow-[0_10px_30px_rgba(0,0,0,0.28)] transition-all hover:-translate-y-0.5 hover:border-neon-cyan/35 hover:shadow-[0_14px_34px_rgba(34,211,238,0.18)] focus:outline-none focus:ring-2 focus:ring-neon-cyan/50"
+            className="liquid-menu relative flex h-10 w-10 items-center justify-center rounded-2xl border border-glass-border/80 bg-deep-black-light text-sm font-bold text-neon-cyan shadow-[0_10px_30px_rgba(0,0,0,0.28)] transition-all hover:-translate-y-0.5 hover:border-neon-cyan/35 hover:shadow-[0_14px_34px_rgba(34,211,238,0.18)] focus:outline-none focus:ring-2 focus:ring-neon-cyan/50"
             title={t.account}
           >
             <span className="absolute inset-0 overflow-hidden rounded-[inherit]">
@@ -79,9 +79,9 @@ export default function AccountMenu({
             sideOffset={12}
             side="top"
             align="start"
-            className="z-[70] min-w-[300px] overflow-hidden rounded-[24px] border border-glass-border/80 bg-[linear-gradient(180deg,rgba(16,18,26,0.96),rgba(10,12,18,0.98))] p-1.5 shadow-[0_28px_90px_rgba(0,0,0,0.55)] backdrop-blur-xl animate-in fade-in-80 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-100 data-[state=closed]:zoom-out-95"
+            className="liquid-menu z-[70] min-w-[300px] overflow-hidden rounded-[24px] border border-glass-border/80 bg-deep-black-light p-1.5 shadow-[0_28px_90px_rgba(0,0,0,0.55)] backdrop-blur-xl animate-in fade-in-80 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-100 data-[state=closed]:zoom-out-95"
           >
-            <div className="relative mb-1 overflow-hidden rounded-[20px] border border-white/6 bg-[radial-gradient(circle_at_top_left,rgba(34,211,238,0.14),transparent_42%),linear-gradient(180deg,rgba(255,255,255,0.03),rgba(255,255,255,0.01))] px-3 py-3.5">
+            <div className="relative mb-1 overflow-hidden rounded-[20px] border border-glass-border bg-glass-bg px-3 py-3.5">
               <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/14 to-transparent" />
               <div className="flex items-center gap-3">
                 {user?.avatar_url ? (
@@ -92,13 +92,13 @@ export default function AccountMenu({
                     className="h-12 w-12 shrink-0 rounded-2xl border border-white/10 object-cover shadow-[0_12px_30px_rgba(0,0,0,0.28)]"
                   />
                 ) : (
-                  <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl border border-white/10 bg-[radial-gradient(circle_at_top,rgba(34,211,238,0.28),rgba(34,211,238,0.08)_55%,rgba(255,255,255,0.02)_100%)] text-base font-semibold text-white shadow-[0_12px_30px_rgba(0,0,0,0.28)]">
+                  <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl border border-glass-border bg-neon-cyan/10 text-base font-semibold text-neon-cyan shadow-[0_12px_30px_rgba(0,0,0,0.28)]">
                     {getAvatarSeed(user)}
                   </div>
                 )}
                 <div className="min-w-0 flex-1">
                   <div className="flex items-start justify-between gap-3">
-                    <p className="min-w-0 flex-1 truncate text-[18px] font-semibold tracking-tight text-white">
+                    <p className="min-w-0 flex-1 truncate text-[18px] font-semibold tracking-tight text-text-primary">
                       {user?.display_name || user?.email || t.user}
                     </p>
                     <div className="flex shrink-0 items-center gap-1.5">
@@ -123,7 +123,7 @@ export default function AccountMenu({
                 </div>
               </div>
               {human ? (
-                <div className="mt-3 inline-flex max-w-full items-center rounded-full border border-white/8 bg-white/[0.03] px-2.5 py-1 text-[11px] text-text-secondary/68">
+                <div className="mt-3 inline-flex max-w-full items-center rounded-full border border-glass-border bg-glass-bg px-2.5 py-1 text-[11px] text-text-secondary/68">
                   <span className="truncate" title={human.human_id}>
                     {human.human_id}
                   </span>

--- a/frontend/src/components/dashboard/ActivityPanel.tsx
+++ b/frontend/src/components/dashboard/ActivityPanel.tsx
@@ -33,7 +33,7 @@ function StatCard({
     purple: "text-neon-purple",
   };
   return (
-    <div className="rounded-xl border border-glass-border bg-glass-bg p-4">
+    <div className="liquid-card rounded-xl border border-glass-border p-4">
       <p className="mb-1 text-[10px] font-medium uppercase tracking-wider text-text-secondary">
         {label}
       </p>
@@ -133,10 +133,10 @@ function FeedItem({ item, zh }: { item: ActivityFeedItem; zh: boolean }) {
     : null;
 
   return (
-    <div className="flex gap-3 rounded-xl border border-glass-border bg-glass-bg p-3 transition-colors hover:border-glass-border/80">
+    <div className="liquid-list-row flex gap-3 rounded-xl border border-glass-border p-3 transition-colors hover:border-glass-border/80">
       {/* Icon */}
       <div
-        className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-glass-bg text-sm font-bold ${ev.color}`}
+        className={`liquid-tool-surface flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sm font-bold ${ev.color}`}
       >
         {ev.icon}
       </div>
@@ -256,14 +256,14 @@ function ActivityPanel() {
   };
 
   return (
-    <div className="flex flex-1 flex-col overflow-hidden bg-deep-black">
+    <div className="dashboard-main flex flex-1 flex-col overflow-hidden">
       {/* Header */}
-      <div className="flex items-center justify-between border-b border-glass-border px-6 py-4">
+      <div className="liquid-toolbar flex items-center justify-between border-b border-glass-border px-6 py-4">
         <h1 className="text-base font-semibold text-text-primary">
           {t.activity}
         </h1>
         {showPeriodTabs && (
-          <div className="flex gap-1 rounded-lg border border-glass-border bg-glass-bg p-0.5">
+          <div className="liquid-tabs flex gap-1 rounded-lg border border-glass-border p-0.5">
             {(["today", "7d", "30d"] as Period[]).map((p) => (
               <button
                 key={p}
@@ -288,7 +288,7 @@ function ActivityPanel() {
             <p className="text-sm text-red-400">{error}</p>
             <button
               onClick={() => loadAll(period, showPeriodTabs)}
-              className="rounded-lg border border-glass-border px-4 py-1.5 text-xs text-text-secondary hover:text-text-primary transition-colors"
+              className="liquid-action rounded-lg border border-glass-border px-4 py-1.5 text-xs text-text-secondary hover:text-text-primary transition-colors"
             >
               {zh ? "\u91CD\u8BD5" : "Retry"}
             </button>
@@ -325,7 +325,7 @@ function ActivityPanel() {
                 {zh ? "\u6700\u8FD1\u52A8\u6001" : "Recent Activity"}
               </h2>
               {feed.length === 0 ? (
-                <div className="rounded-xl border border-glass-border bg-glass-bg p-8 text-center">
+                <div className="liquid-empty-state rounded-xl border border-glass-border p-8 text-center">
                   <p className="text-xs text-text-secondary">
                     {zh ? "\u6682\u65E0\u52A8\u6001" : "No activity yet"}
                   </p>
@@ -343,7 +343,7 @@ function ActivityPanel() {
                     <button
                       onClick={loadMore}
                       disabled={loadingMore}
-                      className="mt-2 flex w-full items-center justify-center gap-2 rounded-lg border border-glass-border py-2 text-xs text-text-secondary transition-colors hover:text-text-primary disabled:opacity-50"
+                      className="liquid-action mt-2 flex w-full items-center justify-center gap-2 rounded-lg border border-glass-border py-2 text-xs text-text-secondary transition-colors hover:text-text-primary disabled:opacity-50"
                     >
                       {loadingMore ? (
                         <>

--- a/frontend/src/components/dashboard/AddDeviceDialog.tsx
+++ b/frontend/src/components/dashboard/AddDeviceDialog.tsx
@@ -69,7 +69,7 @@ export default function AddDeviceDialog({ onClose }: AddDeviceDialogProps) {
   return (
     <div
       ref={overlayRef}
-      className={`fixed inset-0 z-[110] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`}
+      className={`liquid-scrim fixed inset-0 z-[110] flex items-center justify-center p-4 ${closing ? "pointer-events-none" : ""}`}
       onMouseDown={(event) => {
         if (event.target === event.currentTarget) closeWithMotion();
       }}
@@ -79,9 +79,9 @@ export default function AddDeviceDialog({ onClose }: AddDeviceDialogProps) {
         role="dialog"
         aria-modal="true"
         aria-labelledby="add-device-title"
-        className="relative flex max-h-[calc(100dvh-2rem)] w-full max-w-xl flex-col overflow-hidden rounded-2xl border border-glass-border bg-deep-black-light shadow-2xl"
+        className="liquid-dialog relative flex max-h-[calc(100dvh-2rem)] w-full max-w-xl flex-col overflow-hidden rounded-2xl"
       >
-        <div className="flex shrink-0 items-center gap-3 border-b border-glass-border/40 px-4 py-3 sm:px-5">
+        <div className="liquid-toolbar flex shrink-0 items-center gap-3 border-b px-4 py-3 sm:px-5">
           <h3
             id="add-device-title"
             className="flex min-w-0 flex-1 items-center gap-2 text-base font-semibold text-text-primary"
@@ -93,7 +93,7 @@ export default function AddDeviceDialog({ onClose }: AddDeviceDialogProps) {
             type="button"
             onClick={closeWithMotion}
             aria-label={locale === "zh" ? "关闭" : "Close"}
-            className="shrink-0 rounded-full p-1.5 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
+            className="liquid-action shrink-0 rounded-full p-1.5 text-text-secondary transition-colors hover:text-text-primary"
           >
             <X className="h-5 w-5" />
           </button>

--- a/frontend/src/components/dashboard/AddFriendModal.tsx
+++ b/frontend/src/components/dashboard/AddFriendModal.tsx
@@ -64,17 +64,17 @@ export default function AddFriendModal({ onClose }: AddFriendModalProps) {
   return (
     <div
       ref={overlayRef}
-      className={`fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4 ${closing ? "pointer-events-none" : ""}`}
+      className={`liquid-scrim fixed inset-0 z-50 flex items-center justify-center px-4 ${closing ? "pointer-events-none" : ""}`}
       onClick={closeWithMotion}
     >
       <div
         ref={panelRef}
-        className="flex max-h-[90vh] w-full max-w-lg flex-col overflow-hidden rounded-xl border border-glass-border bg-deep-black"
+        className="liquid-dialog flex max-h-[90vh] w-full max-w-lg flex-col overflow-hidden rounded-2xl"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="border-b border-glass-border px-6 pt-4">
+        <div className="liquid-toolbar border-b px-6 pt-4">
           <h2 className="mb-3 text-lg font-semibold text-text-primary">{t.title}</h2>
-          <div className="flex gap-1">
+          <div className="liquid-tabs flex gap-1">
             {(["search", "invite"] as TabKey[]).map((k) => (
               <button
                 key={k}
@@ -95,10 +95,10 @@ export default function AddFriendModal({ onClose }: AddFriendModalProps) {
           {tab === "search" ? <SearchPane onClose={closeWithMotion} /> : <InvitePane />}
         </div>
 
-        <div className="flex justify-end gap-2 border-t border-glass-border px-6 py-3">
+        <div className="liquid-toolbar flex justify-end gap-2 border-t px-6 py-3">
           <button
             onClick={closeWithMotion}
-            className="rounded border border-glass-border px-4 py-2 text-sm text-text-secondary hover:text-text-primary"
+            className="liquid-action rounded-lg px-4 py-2 text-sm text-text-secondary hover:text-text-primary"
           >
             {t.close}
           </button>
@@ -269,12 +269,12 @@ function SearchPane({ onClose }: { onClose: () => void }) {
             setMessage("");
             setError(null);
           }}
-          className="inline-flex items-center gap-1 text-xs text-text-secondary hover:text-text-primary"
+          className="liquid-action inline-flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-text-secondary hover:text-text-primary"
         >
           <ArrowLeft className="h-3 w-3" /> {t.back}
         </button>
 
-        <div className="rounded border border-glass-border bg-glass-bg p-4">
+        <div className="liquid-card rounded-xl p-4">
           <div className="flex items-center gap-2">
             <p className="text-sm font-semibold text-text-primary">{selected.display_name}</p>
             <PeerKindBadge kind={selected.kind} />
@@ -290,15 +290,15 @@ function SearchPane({ onClose }: { onClose: () => void }) {
             {t.requestSent}
           </div>
         ) : status === "exists" ? (
-          <div ref={statusRef} className="rounded border border-glass-border px-3 py-2 text-sm text-text-secondary">
+          <div ref={statusRef} className="liquid-card rounded-lg px-3 py-2 text-sm text-text-secondary">
             {t.alreadyContact}
           </div>
         ) : status === "pending" ? (
-          <div ref={statusRef} className="rounded border border-glass-border px-3 py-2 text-sm text-text-secondary">
+          <div ref={statusRef} className="liquid-card rounded-lg px-3 py-2 text-sm text-text-secondary">
             {t.alreadyRequested}
           </div>
         ) : isContact ? (
-          <div className="rounded border border-glass-border px-3 py-2 text-sm text-text-secondary">
+          <div className="liquid-card rounded-lg px-3 py-2 text-sm text-text-secondary">
             {t.alreadyContact}
           </div>
         ) : (
@@ -309,7 +309,7 @@ function SearchPane({ onClose }: { onClose: () => void }) {
               placeholder={t.requestMessagePlaceholder}
               rows={3}
               maxLength={500}
-              className="w-full resize-none rounded border border-glass-border bg-glass-bg px-3 py-2 text-sm text-text-primary outline-none focus:border-neon-cyan/60"
+              className="liquid-input w-full resize-none rounded-lg border px-3 py-2 text-sm text-text-primary outline-none focus:border-neon-cyan/60"
             />
             {error && (
               <div ref={errorRef} className="rounded border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-400">
@@ -320,7 +320,7 @@ function SearchPane({ onClose }: { onClose: () => void }) {
               onClick={handleSend}
               disabled={sending || !identityReady}
               title={!identityReady ? t.requestFailed : undefined}
-              className="inline-flex w-full items-center justify-center gap-2 rounded border border-neon-cyan/50 bg-neon-cyan/10 px-4 py-2 text-sm text-neon-cyan hover:bg-neon-cyan/20 disabled:opacity-50"
+              className="liquid-action inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-cyan/50 bg-neon-cyan/10 px-4 py-2 text-sm text-neon-cyan hover:bg-neon-cyan/20 disabled:opacity-50"
             >
               {sending && <Loader2 className="h-4 w-4 animate-spin" />}
               {sending ? t.sending : t.sendRequest}
@@ -333,7 +333,7 @@ function SearchPane({ onClose }: { onClose: () => void }) {
 
   return (
     <div className="space-y-3">
-      <div className="flex items-center gap-2 rounded border border-glass-border bg-glass-bg px-3">
+      <div className="liquid-input flex items-center gap-2 rounded-lg border px-3">
         <Search className="h-4 w-4 text-text-secondary/70" />
         <input
           autoFocus
@@ -356,14 +356,14 @@ function SearchPane({ onClose }: { onClose: () => void }) {
       ) : !loading && results.length === 0 ? (
         <p className="py-8 text-center text-xs text-text-secondary/60">{t.searchEmpty}</p>
       ) : (
-        <div className="divide-y divide-glass-border/60 rounded border border-glass-border">
+        <div className="liquid-card divide-y divide-glass-border/60 overflow-hidden rounded-xl">
           {results.map((a) => {
             const isContact = contactIds.has(a.id);
             return (
               <button
                 key={a.id}
                 onClick={() => setSelected(a)}
-                className="flex w-full items-center gap-3 px-3 py-2.5 text-left hover:bg-glass-bg"
+                className="liquid-list-row flex w-full items-center gap-3 px-3 py-2.5 text-left"
               >
                 <div className="flex h-8 w-8 items-center justify-center rounded-full bg-neon-cyan/15 text-xs font-semibold uppercase text-neon-cyan">
                   {a.display_name.slice(0, 1)}
@@ -457,7 +457,7 @@ function InvitePane() {
         <button
           onClick={create}
           disabled={loading}
-          className="inline-flex w-full items-center justify-center gap-2 rounded border border-neon-cyan/50 bg-neon-cyan/10 px-4 py-2 text-sm text-neon-cyan hover:bg-neon-cyan/20 disabled:opacity-50"
+          className="liquid-action inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-cyan/50 bg-neon-cyan/10 px-4 py-2 text-sm text-neon-cyan hover:bg-neon-cyan/20 disabled:opacity-50"
         >
           {loading && <Loader2 className="h-4 w-4 animate-spin" />}
           {loading ? t.creating : t.createInvite}
@@ -471,7 +471,7 @@ function InvitePane() {
             <button
               ref={copyRef}
               onClick={() => copy("prompt")}
-              className="inline-flex items-center gap-1 rounded border border-neon-cyan/50 bg-neon-cyan/10 px-2.5 py-1 text-xs text-neon-cyan hover:bg-neon-cyan/20"
+              className="liquid-action inline-flex items-center gap-1 rounded-lg border border-neon-cyan/50 bg-neon-cyan/10 px-2.5 py-1 text-xs text-neon-cyan hover:bg-neon-cyan/20"
             >
               <Copy className="h-3 w-3" />
               {copied === "prompt" ? t.copied : t.copyPrompt}
@@ -481,7 +481,7 @@ function InvitePane() {
             readOnly
             rows={6}
             value={buildFriendInvitePrompt({ inviteCode: invite.code, locale })}
-            className="w-full resize-none rounded border border-glass-border bg-glass-bg px-3 py-2 font-mono text-xs leading-relaxed text-text-primary outline-none"
+            className="liquid-input w-full resize-none rounded-lg border px-3 py-2 font-mono text-xs leading-relaxed text-text-primary outline-none"
           />
         </div>
       )}

--- a/frontend/src/components/dashboard/AddRoomMemberModal.tsx
+++ b/frontend/src/components/dashboard/AddRoomMemberModal.tsx
@@ -130,10 +130,10 @@ export default function AddRoomMemberModal({
   }, [error]);
 
   return (
-    <div ref={overlayRef} className={`fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 ${closing ? "pointer-events-none" : ""}`} onClick={closeWithMotion}>
+    <div ref={overlayRef} className={`liquid-scrim fixed inset-0 z-50 flex items-center justify-center p-4 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`} onClick={closeWithMotion}>
       <div
         ref={panelRef}
-        className="flex h-[min(760px,calc(100dvh-2rem))] w-full max-w-2xl flex-col overflow-hidden rounded-xl border border-glass-border bg-deep-black"
+        className="liquid-dialog flex h-[min(760px,calc(100dvh-2rem))] w-full max-w-2xl flex-col overflow-hidden rounded-xl border"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between border-b border-glass-border px-6 py-4">
@@ -143,7 +143,7 @@ export default function AddRoomMemberModal({
           </div>
           <button
             onClick={closeWithMotion}
-            className="rounded p-1.5 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
+            className="liquid-action rounded p-1.5 text-text-secondary transition-colors hover:text-text-primary"
             aria-label={t.closeAddMemberModal}
             title={t.closeAddMemberModal}
           >
@@ -164,7 +164,7 @@ export default function AddRoomMemberModal({
           </div>
 
           {candidates.length === 0 ? (
-            <div className="rounded border border-dashed border-glass-border px-4 py-6 text-sm text-text-secondary/70">
+            <div className="liquid-empty-state rounded border border-dashed px-4 py-6 text-sm text-text-secondary/70">
               {t.noAddableMembers}
             </div>
           ) : (
@@ -191,14 +191,14 @@ export default function AddRoomMemberModal({
           <button
             onClick={closeWithMotion}
             disabled={saving}
-            className="rounded border border-glass-border px-4 py-2 text-sm text-text-secondary transition-colors hover:text-text-primary disabled:opacity-50"
+            className="liquid-action rounded px-4 py-2 text-sm text-text-secondary transition-colors hover:text-text-primary disabled:opacity-50"
           >
             {t.permCancel}
           </button>
           <button
             onClick={() => void handleAddMembers()}
             disabled={saving || selectedIds.size === 0}
-            className="inline-flex items-center gap-2 rounded border border-neon-cyan/40 bg-neon-cyan/10 px-4 py-2 text-sm font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/15 disabled:cursor-not-allowed disabled:opacity-50"
+            className="liquid-action inline-flex items-center gap-2 rounded border border-neon-cyan/40 bg-neon-cyan/10 px-4 py-2 text-sm font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/15 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
             {saving ? t.addingMembers : t.addMembersAction}

--- a/frontend/src/components/dashboard/AgentBrowser.tsx
+++ b/frontend/src/components/dashboard/AgentBrowser.tsx
@@ -182,13 +182,13 @@ function AgentBrowser() {
   };
 
   return (
-    <div className="flex h-full min-h-0 w-[320px] min-w-[320px] flex-col border-l border-glass-border bg-deep-black-light">
+    <div className="liquid-panel flex h-full min-h-0 w-[320px] min-w-[320px] flex-col border-l border-glass-border">
       {/* Header */}
-      <div className="shrink-0 flex min-h-14 items-center justify-between border-b border-glass-border px-4 py-3">
+      <div className="liquid-toolbar shrink-0 flex min-h-14 items-center justify-between border-b border-glass-border px-4 py-3">
         <h3 className="text-sm font-semibold text-text-primary">{t.agents}</h3>
         <button
           onClick={() => toggleRightPanel()}
-          className="rounded p-1 text-text-secondary hover:bg-glass-bg hover:text-text-primary"
+          className="liquid-action rounded p-1 text-text-secondary hover:bg-glass-bg hover:text-text-primary"
         >
           <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5">
             <path d="M3 3l8 8M11 3l-8 8" />
@@ -212,7 +212,7 @@ function AgentBrowser() {
               {activeIdentity?.type === "human" && joinedRoom && (joinedRoom.my_role === "owner" || joinedRoom.my_role === "admin") ? (
                 <button
                   onClick={() => setAddMemberModalOpen(true)}
-                  className="rounded border border-neon-cyan/30 bg-neon-cyan/10 px-2.5 py-1 text-[11px] font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/15"
+                  className="liquid-action rounded border border-neon-cyan/30 bg-neon-cyan/10 px-2.5 py-1 text-[11px] font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/15"
                 >
                   {t.addMembersEntry}
                 </button>
@@ -245,7 +245,7 @@ function AgentBrowser() {
                   return (
                     <div
                       key={member.agent_id}
-                      className="flex items-center justify-between rounded-lg px-2 py-1.5 transition-colors hover:bg-glass-bg"
+                      className="liquid-list-row flex items-center justify-between rounded-lg px-2 py-1.5 transition-colors"
                     >
                       <button
                         onClick={() => selectAgent(member.agent_id)}
@@ -309,7 +309,7 @@ function AgentBrowser() {
                   <button
                     onClick={() => void handleLeaveRoom()}
                     disabled={joinedRoom.my_role === "owner" || isLeavingCurrentRoom}
-                    className="w-full rounded border border-red-500/35 bg-red-500/10 px-3 py-2 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/15 disabled:cursor-not-allowed disabled:opacity-45"
+                    className="liquid-action w-full rounded border border-red-500/35 bg-red-500/10 px-3 py-2 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/15 disabled:cursor-not-allowed disabled:opacity-45"
                     title={joinedRoom.my_role === "owner" ? t.ownerCannotLeave : t.leaveRoom}
                   >
                     {isLeavingCurrentRoom ? t.leavingRoom : t.leaveRoom}
@@ -318,7 +318,7 @@ function AgentBrowser() {
                     <button
                       onClick={() => void handleCancelSubscription()}
                       disabled={cancellingSubscriptionId === activeSubscription.subscription_id}
-                      className="w-full rounded border border-yellow-500/35 bg-yellow-500/10 px-3 py-2 text-xs font-medium text-yellow-300 transition-colors hover:bg-yellow-500/15 disabled:cursor-not-allowed disabled:opacity-45"
+                      className="liquid-action w-full rounded border border-yellow-500/35 bg-yellow-500/10 px-3 py-2 text-xs font-medium text-yellow-300 transition-colors hover:bg-yellow-500/15 disabled:cursor-not-allowed disabled:opacity-45"
                     >
                       {cancellingSubscriptionId === activeSubscription.subscription_id
                         ? t.cancellingSubscription
@@ -344,7 +344,7 @@ function AgentBrowser() {
                           }
                         }}
                         disabled={mutingRoom}
-                        className="w-full rounded border border-glass-border bg-glass-bg px-3 py-2 text-xs font-medium text-text-secondary transition-colors hover:text-text-primary disabled:opacity-50"
+                        className="liquid-action w-full rounded border border-glass-border bg-glass-bg px-3 py-2 text-xs font-medium text-text-secondary transition-colors hover:text-text-primary disabled:opacity-50"
                       >
                         {isMuted ? t.unmuteRoom : t.muteRoom}
                       </button>
@@ -356,7 +356,7 @@ function AgentBrowser() {
                         setRoomActionError(null);
                         setTransferDialogOpen(true);
                       }}
-                      className="w-full rounded border border-neon-purple/35 bg-neon-purple/10 px-3 py-2 text-xs font-medium text-neon-purple transition-colors hover:bg-neon-purple/15"
+                      className="liquid-action w-full rounded border border-neon-purple/35 bg-neon-purple/10 px-3 py-2 text-xs font-medium text-neon-purple transition-colors hover:bg-neon-purple/15"
                     >
                       {t.transferOwnership}
                     </button>
@@ -404,7 +404,7 @@ function AgentBrowser() {
               searchResults.map((agent) => (
                 <div
                   key={agent.agent_id}
-                  className="mb-1 rounded-lg px-2 py-1.5 transition-colors hover:bg-glass-bg"
+                  className="liquid-list-row mb-1 rounded-lg px-2 py-1.5 transition-colors"
                 >
                   <button
                     onClick={() => selectAgent(agent.agent_id)}
@@ -461,7 +461,7 @@ function AgentBrowser() {
               selectedAgentConversations.map((room) => (
                 <div
                   key={room.room_id}
-                  className="mb-1 rounded-lg px-2 py-1.5 transition-colors hover:bg-glass-bg"
+                  className="liquid-list-row mb-1 rounded-lg px-2 py-1.5 transition-colors"
                 >
                   <div className="flex items-center gap-1.5 min-w-0">
                     <button

--- a/frontend/src/components/dashboard/AgentCardModal.tsx
+++ b/frontend/src/components/dashboard/AgentCardModal.tsx
@@ -232,7 +232,7 @@ export default function AgentCardModal({
   return (
     <div
       ref={overlayRef}
-      className="fixed inset-0 z-40 flex items-center justify-center bg-black/60 p-4"
+      className="liquid-scrim fixed inset-0 z-40 flex items-center justify-center p-4"
       onMouseDown={(event) => {
         if (event.target === event.currentTarget) handleClose();
       }}
@@ -241,7 +241,7 @@ export default function AgentCardModal({
         ref={panelRef}
         role="dialog"
         aria-modal="true"
-        className="w-full max-w-md rounded-2xl border border-glass-border bg-deep-black-light p-5"
+        className="liquid-dialog w-full max-w-md rounded-2xl p-5"
         onMouseDown={(event) => event.stopPropagation()}
       >
         <div data-profile-modal-part className="mb-3 flex items-start justify-between gap-3">
@@ -259,7 +259,7 @@ export default function AgentCardModal({
           </div>
           <button
             onClick={handleClose}
-            className="rounded border border-glass-border px-2 py-0.5 text-xs text-text-secondary hover:text-text-primary"
+            className="liquid-action rounded-lg px-2 py-1 text-xs text-text-secondary hover:text-text-primary"
           >
             {t.close}
           </button>
@@ -284,7 +284,7 @@ export default function AgentCardModal({
             <p className="text-sm text-red-400">{error}</p>
             <button
               onClick={onRetry}
-              className="w-full rounded-lg border border-glass-border py-2 text-xs text-text-primary transition-colors hover:bg-glass-bg"
+              className="liquid-action w-full rounded-lg py-2 text-xs text-text-primary transition-colors"
             >
               Retry
             </button>
@@ -317,7 +317,7 @@ export default function AgentCardModal({
               <button
                 data-profile-modal-part
                 onClick={onSendMessage}
-                className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-green/40 bg-neon-green/10 py-2 text-xs font-medium text-neon-green transition-colors hover:bg-neon-green/20"
+                className="liquid-action inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-green/40 bg-neon-green/10 py-2 text-xs font-medium text-neon-green transition-colors hover:bg-neon-green/20"
               >
                 {t.sendMessage}
               </button>
@@ -325,7 +325,7 @@ export default function AgentCardModal({
               <button
                 data-profile-modal-part
                 onClick={onSendMessage}
-                className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-green/40 bg-neon-green/10 py-2 text-xs font-medium text-neon-green transition-colors hover:bg-neon-green/20"
+                className="liquid-action inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-green/40 bg-neon-green/10 py-2 text-xs font-medium text-neon-green transition-colors hover:bg-neon-green/20"
               >
                 {t.sendMessage}
               </button>
@@ -336,7 +336,7 @@ export default function AgentCardModal({
                 data-profile-modal-part
                 onClick={onSendFriendRequest}
                 disabled={sendingFriendRequest}
-                className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 py-2 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20 disabled:cursor-not-allowed disabled:opacity-60"
+                className="liquid-action inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 py-2 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20 disabled:cursor-not-allowed disabled:opacity-60"
               >
                 {sendingFriendRequest ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
                 {sendingFriendRequest ? t.sendingFriendRequest : t.sendFriendRequest}

--- a/frontend/src/components/dashboard/AgentChannelsTab.tsx
+++ b/frontend/src/components/dashboard/AgentChannelsTab.tsx
@@ -158,7 +158,7 @@ function StepSection({
   children: React.ReactNode;
 }) {
   return (
-    <section className="rounded-xl border border-glass-border bg-deep-black/30 p-3">
+    <section className="liquid-card rounded-xl border border-glass-border p-3">
       <div className="mb-3 flex items-start gap-2.5">
         <span
           className={`mt-0.5 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full border text-[11px] font-semibold ${
@@ -269,7 +269,7 @@ export default function AgentChannelsTab({ agentId, hostingKind }: Props) {
 
   return (
     <div className="space-y-5">
-      <div className="rounded-lg border border-glass-border bg-glass-bg/40 px-3 py-2 text-[11px] text-text-tertiary">
+      <div className="liquid-card rounded-lg border border-glass-border px-3 py-2 text-[11px] text-text-tertiary">
         {isCloudAgent
           ? "Cloud Agent 的第三方接入由云端 ingress 服务托管，setup 不依赖你的本机。"
           : "Local Agent 的第三方接入运行在你本地 daemon 中。"}
@@ -320,7 +320,7 @@ export default function AgentChannelsTab({ agentId, hostingKind }: Props) {
         </div>
 
         {loading && list.length === 0 ? (
-          <div className="rounded-xl border border-glass-border bg-glass-bg/40 p-4 text-xs text-text-secondary">
+          <div className="liquid-empty-state rounded-xl border border-glass-border p-4 text-xs text-text-secondary">
             <MobileBotCordLoading
               label="加载中…"
               size="sm"
@@ -348,7 +348,7 @@ export default function AgentChannelsTab({ agentId, hostingKind }: Props) {
               return (
                 <li
                   key={g.id}
-                  className="rounded-xl border border-glass-border bg-glass-bg/40 p-3"
+                  className="liquid-card rounded-xl border border-glass-border p-3"
                 >
                   <div className="flex items-start justify-between gap-2">
                     <div className="min-w-0 flex-1">
@@ -444,7 +444,7 @@ export default function AgentChannelsTab({ agentId, hostingKind }: Props) {
 
       {/* Add gateway form. */}
       {addMode && (
-        <section className="rounded-2xl border border-glass-border bg-glass-bg/40 p-4">
+        <section className="liquid-card rounded-2xl border border-glass-border p-4">
           <div className="mb-3 flex items-center justify-between">
             <h3 className="text-sm font-semibold text-text-primary">添加接入</h3>
             <button
@@ -976,14 +976,14 @@ function TelegramTokenGuideDialog({ onClose }: { onClose: () => void }) {
   return (
     <div
       ref={overlayRef}
-      className="fixed inset-0 z-[70] flex items-center justify-center bg-black/70 px-4 backdrop-blur-sm"
+      className="liquid-scrim fixed inset-0 z-[70] flex items-center justify-center px-4 backdrop-blur-sm"
       onClick={closeWithMotion}
     >
       <div
         ref={panelRef}
         role="dialog"
         aria-modal="true"
-        className="w-full max-w-md rounded-2xl border border-glass-border bg-deep-black p-5 shadow-2xl"
+        className="liquid-dialog w-full max-w-md rounded-2xl border border-glass-border p-5 shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
         <div data-motion-item className="mb-4 flex items-start justify-between gap-3">
@@ -2693,14 +2693,14 @@ function DeleteConfirmDialog({
   return (
     <div
       ref={overlayRef}
-      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/70 px-4"
+      className="liquid-scrim fixed inset-0 z-[60] flex items-center justify-center px-4"
       onClick={closeWithMotion}
     >
       <div
         ref={panelRef}
         role="dialog"
         aria-modal="true"
-        className="w-full max-w-sm rounded-2xl border border-glass-border bg-deep-black p-5 shadow-2xl"
+        className="liquid-dialog w-full max-w-sm rounded-2xl border border-glass-border p-5 shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
         <h3 data-motion-item className="mb-2 text-base font-semibold text-text-primary">

--- a/frontend/src/components/dashboard/AgentGateModal.tsx
+++ b/frontend/src/components/dashboard/AgentGateModal.tsx
@@ -84,12 +84,12 @@ export default function AgentGateModal({ onAgentReady }: AgentGateModalProps) {
   }, []);
 
   return (
-    <div ref={overlayRef} className="fixed inset-0 z-[90] flex items-center justify-center bg-black/80 p-4 backdrop-blur-md">
+    <div ref={overlayRef} className="liquid-scrim fixed inset-0 z-[90] flex items-center justify-center p-4">
       <div
         ref={panelRef}
         role="dialog"
         aria-modal="true"
-        className="w-full max-w-2xl rounded-[28px] border border-glass-border bg-deep-black-light p-8 shadow-2xl"
+        className="liquid-dialog w-full max-w-2xl rounded-[28px] p-8"
       >
         <div data-agent-gate-part className="mx-auto max-w-xl text-center">
           <p className="text-[11px] font-bold uppercase tracking-[0.32em] text-neon-cyan/80">
@@ -103,7 +103,7 @@ export default function AgentGateModal({ onAgentReady }: AgentGateModalProps) {
           </p>
         </div>
 
-        <div data-agent-gate-part className="mt-6 rounded-2xl border border-glass-border bg-deep-black p-4">
+        <div data-agent-gate-part className="liquid-card mt-6 rounded-2xl p-4">
           {isResolving ? (
             <div className="flex items-center gap-3 text-sm text-text-secondary">
               <Loader2 className="h-4 w-4 animate-spin text-neon-cyan" />

--- a/frontend/src/components/dashboard/AgentProfileEditModal.tsx
+++ b/frontend/src/components/dashboard/AgentProfileEditModal.tsx
@@ -124,7 +124,7 @@ export default function AgentProfileEditModal({
   return (
     <div
       ref={overlayRef}
-      className={`fixed inset-0 z-[110] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`}
+      className={`liquid-scrim fixed inset-0 z-[110] flex items-center justify-center p-4 ${closing ? "pointer-events-none" : ""}`}
       onMouseDown={(event) => {
         if (event.target === event.currentTarget) closeWithMotion();
       }}
@@ -133,13 +133,13 @@ export default function AgentProfileEditModal({
         ref={panelRef}
         role="dialog"
         aria-modal="true"
-        className="relative w-full max-w-md rounded-2xl border border-glass-border bg-deep-black-light p-5 shadow-2xl"
+        className="liquid-dialog relative w-full max-w-md rounded-2xl p-5"
         onMouseDown={(event) => event.stopPropagation()}
       >
         <button
           onClick={() => closeWithMotion()}
           disabled={saving}
-          className="absolute right-4 top-4 rounded-full p-1.5 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+          className="liquid-action absolute right-4 top-4 rounded-full p-1.5 text-text-secondary transition-colors hover:text-text-primary disabled:opacity-50"
         >
           <X className="h-5 w-5" />
         </button>
@@ -166,7 +166,7 @@ export default function AgentProfileEditModal({
                   type="button"
                   onClick={() => setAvatarUrl(url)}
                   disabled={saving}
-                  className={`aspect-square overflow-hidden rounded-full border bg-glass-bg transition-all disabled:opacity-60 ${
+                  className={`liquid-action aspect-square overflow-hidden rounded-full border transition-all disabled:opacity-60 ${
                     selected
                       ? "border-neon-cyan ring-2 ring-neon-cyan/30"
                       : "border-glass-border hover:border-neon-cyan/50"
@@ -189,7 +189,7 @@ export default function AgentProfileEditModal({
             onChange={(e) => setDisplayName(e.target.value)}
             disabled={saving}
             maxLength={128}
-            className="w-full rounded-lg border border-glass-border bg-glass-bg px-3 py-2 text-sm text-text-primary outline-none transition-colors focus:border-neon-cyan/50 disabled:opacity-60"
+            className="liquid-input w-full rounded-lg border px-3 py-2 text-sm text-text-primary outline-none transition-colors focus:border-neon-cyan/50 disabled:opacity-60"
           />
         </label>
 
@@ -202,7 +202,7 @@ export default function AgentProfileEditModal({
             rows={4}
             maxLength={4000}
             placeholder={tBioPlaceholder}
-            className="w-full resize-none rounded-lg border border-glass-border bg-glass-bg px-3 py-2 text-sm text-text-primary outline-none transition-colors focus:border-neon-cyan/50 disabled:opacity-60"
+            className="liquid-input w-full resize-none rounded-lg border px-3 py-2 text-sm text-text-primary outline-none transition-colors focus:border-neon-cyan/50 disabled:opacity-60"
           />
         </label>
 
@@ -216,14 +216,14 @@ export default function AgentProfileEditModal({
           <button
             onClick={() => closeWithMotion()}
             disabled={saving}
-            className="rounded-xl border border-glass-border px-4 py-2.5 text-sm font-medium text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+            className="liquid-action rounded-xl px-4 py-2.5 text-sm font-medium text-text-secondary transition-colors hover:text-text-primary disabled:opacity-50"
           >
             {tCancel}
           </button>
           <button
             onClick={handleSave}
             disabled={!canSave}
-            className="flex items-center gap-2 rounded-xl border border-neon-cyan/40 bg-neon-cyan/10 px-4 py-2.5 text-sm font-bold text-neon-cyan transition-all hover:bg-neon-cyan/20 disabled:opacity-60"
+            className="liquid-action flex items-center gap-2 rounded-xl border border-neon-cyan/40 bg-neon-cyan/10 px-4 py-2.5 text-sm font-bold text-neon-cyan transition-all hover:bg-neon-cyan/20 disabled:opacity-60"
           >
             {saving ? (
               <>
@@ -240,7 +240,7 @@ export default function AgentProfileEditModal({
           <button
             onClick={() => setShowUnbind(true)}
             disabled={saving}
-            className="flex w-full items-center justify-center gap-2 rounded-xl border border-red-400/40 bg-red-500/10 px-4 py-2.5 text-sm font-bold text-red-400 transition-all hover:bg-red-500/20 disabled:opacity-60"
+            className="liquid-action flex w-full items-center justify-center gap-2 rounded-xl border border-red-400/40 bg-red-500/10 px-4 py-2.5 text-sm font-bold text-red-400 transition-all hover:bg-red-500/20 disabled:opacity-60"
           >
             <Trash2 className="h-4 w-4" />
             {tDelete}

--- a/frontend/src/components/dashboard/AgentSchedulesTab.tsx
+++ b/frontend/src/components/dashboard/AgentSchedulesTab.tsx
@@ -291,7 +291,7 @@ export default function AgentSchedulesTab({ agentId }: AgentSchedulesTabProps) {
       ) : null}
 
       {schedules.length === 0 && !loading ? (
-        <div className="rounded-xl border border-glass-border bg-glass-bg/40 px-4 py-8 text-center text-sm text-text-secondary">
+        <div className="liquid-empty-state rounded-xl border border-glass-border px-4 py-8 text-center text-sm text-text-secondary">
           暂无 schedule
         </div>
       ) : (
@@ -300,7 +300,7 @@ export default function AgentSchedulesTab({ agentId }: AgentSchedulesTabProps) {
             const lastRun = runsBySchedule[schedule.id]?.[0];
             const isRunningThisSchedule = runningScheduleId === schedule.id;
             return (
-              <section key={schedule.id} className="rounded-xl border border-glass-border bg-glass-bg/40 p-4">
+              <section key={schedule.id} className="liquid-card rounded-xl border border-glass-border p-4">
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
                     <div className="flex items-center gap-2">
@@ -370,7 +370,7 @@ export default function AgentSchedulesTab({ agentId }: AgentSchedulesTabProps) {
         </div>
       )}
 
-      <section className="rounded-xl border border-glass-border bg-glass-bg/40 p-4">
+      <section className="liquid-card rounded-xl border border-glass-border p-4">
         <div className="mb-3 flex items-center justify-between gap-3">
           <div className="flex items-center gap-2 text-sm font-medium text-text-primary">
             {editingScheduleId ? <Pencil className="h-4 w-4" /> : <Plus className="h-4 w-4" />}
@@ -392,7 +392,7 @@ export default function AgentSchedulesTab({ agentId }: AgentSchedulesTabProps) {
           <input
             value={name}
             onChange={(e) => setName(e.target.value)}
-            className="rounded-lg border border-glass-border bg-deep-black/40 px-3 py-2 text-sm text-text-primary outline-none focus:border-neon-cyan/50"
+            className="liquid-input rounded-lg border border-glass-border px-3 py-2 text-sm text-text-primary outline-none"
             placeholder="名称"
           />
           <div className="grid grid-cols-3 gap-2">
@@ -420,7 +420,7 @@ export default function AgentSchedulesTab({ agentId }: AgentSchedulesTabProps) {
                 step={5}
                 value={everyMinutes}
                 onChange={(e) => setEveryMinutes(Number(e.target.value))}
-                className="rounded-lg border border-glass-border bg-deep-black/40 px-3 py-2 text-sm text-text-primary outline-none focus:border-neon-cyan/50"
+                className="liquid-input rounded-lg border border-glass-border px-3 py-2 text-sm text-text-primary outline-none"
               />
             </label>
           ) : (
@@ -431,7 +431,7 @@ export default function AgentSchedulesTab({ agentId }: AgentSchedulesTabProps) {
                   type="time"
                   value={time}
                   onChange={(e) => setTime(e.target.value)}
-                  className="rounded-lg border border-glass-border bg-deep-black/40 px-3 py-2 text-sm text-text-primary outline-none focus:border-neon-cyan/50"
+                  className="liquid-input rounded-lg border border-glass-border px-3 py-2 text-sm text-text-primary outline-none"
                 />
               </label>
               {scheduleMode === "weekly" ? (
@@ -477,7 +477,7 @@ export default function AgentSchedulesTab({ agentId }: AgentSchedulesTabProps) {
             value={message}
             onChange={(e) => setMessage(e.target.value)}
             rows={3}
-            className="resize-none rounded-lg border border-glass-border bg-deep-black/40 px-3 py-2 text-sm text-text-primary outline-none focus:border-neon-cyan/50"
+            className="liquid-input resize-none rounded-lg border border-glass-border px-3 py-2 text-sm text-text-primary outline-none"
           />
           <button
             type="button"

--- a/frontend/src/components/dashboard/AgentSettingsDrawer.tsx
+++ b/frontend/src/components/dashboard/AgentSettingsDrawer.tsx
@@ -496,16 +496,16 @@ export default function AgentSettingsDrawer({
   }, [closeWithMotion]);
 
   return (
-    <div ref={overlayRef} className="fixed inset-0 z-50 bg-black/60" onClick={closeWithMotion}>
+    <div ref={overlayRef} className="liquid-scrim fixed inset-0 z-50" onClick={closeWithMotion}>
       <div
         ref={drawerRef}
         role="dialog"
         aria-modal="true"
-        className="ml-auto flex h-full w-full max-w-[480px] flex-col overflow-hidden border-l border-glass-border bg-deep-black shadow-2xl"
+        className="liquid-drawer ml-auto flex h-full w-full max-w-[480px] flex-col overflow-hidden border-l border-glass-border shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-glass-border px-6 py-4">
+        <div className="liquid-toolbar flex items-center justify-between border-b border-glass-border px-6 py-4">
           <div className="min-w-0">
             <h2 className="truncate text-base font-semibold text-text-primary">
               {displayName}
@@ -522,7 +522,7 @@ export default function AgentSettingsDrawer({
         </div>
 
         {/* Tabs */}
-        <div className="flex flex-nowrap overflow-x-auto border-b border-glass-border/60 px-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        <div className="liquid-tabs flex flex-nowrap overflow-x-auto border-b border-glass-border/60 px-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           {(["profile", "policy", "schedules", "gateways", "skills", "files"] as Tab[]).map((t) => (
             <button
               key={t}
@@ -604,7 +604,7 @@ export default function AgentSettingsDrawer({
                   onChange={(e) => setNameVal(e.target.value)}
                   disabled={profileSaving}
                   maxLength={128}
-                  className="w-full rounded-lg border border-glass-border bg-glass-bg px-3 py-2 text-sm text-text-primary outline-none transition-colors focus:border-neon-cyan/50 disabled:opacity-60"
+                  className="liquid-input w-full rounded-lg border border-glass-border px-3 py-2 text-sm text-text-primary outline-none transition-colors disabled:opacity-60"
                 />
               </div>
 
@@ -619,7 +619,7 @@ export default function AgentSettingsDrawer({
                   rows={4}
                   maxLength={4000}
                   placeholder={t.profile.bioPlaceholder}
-                  className="w-full resize-none rounded-lg border border-glass-border bg-glass-bg px-3 py-2 text-sm text-text-primary outline-none transition-colors focus:border-neon-cyan/50 disabled:opacity-60"
+                  className="liquid-input w-full resize-none rounded-lg border border-glass-border px-3 py-2 text-sm text-text-primary outline-none transition-colors disabled:opacity-60"
                 />
               </div>
 

--- a/frontend/src/components/dashboard/AgentSkillsTab.tsx
+++ b/frontend/src/components/dashboard/AgentSkillsTab.tsx
@@ -100,7 +100,7 @@ function SkillCard({
   sourceDetailLabel: string;
 }) {
   return (
-    <li className="rounded-xl border border-glass-border bg-glass-bg/35 px-3 py-3">
+    <li className="liquid-card rounded-xl border border-glass-border px-3 py-3">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
@@ -262,11 +262,11 @@ export default function AgentSkillsTab({ agentId }: { agentId: string }) {
       </div>
 
       <div className="grid grid-cols-2 gap-2">
-        <div className="rounded-xl border border-glass-border bg-glass-bg/30 px-3 py-2">
+        <div className="liquid-card rounded-xl border border-glass-border px-3 py-2">
           <div className="text-[10px] uppercase tracking-normal text-text-secondary/65">{copy.title}</div>
           <div className="mt-1 text-lg font-semibold text-text-primary">{total}</div>
         </div>
-        <div className="rounded-xl border border-glass-border bg-glass-bg/30 px-3 py-2">
+        <div className="liquid-card rounded-xl border border-glass-border px-3 py-2">
           <div className="text-[10px] uppercase tracking-normal text-text-secondary/65">
             {visibleSnapshot?.runtime ? copy.runtime : copy.lastSniffed}
           </div>
@@ -295,7 +295,7 @@ export default function AgentSkillsTab({ agentId }: { agentId: string }) {
           ))}
         </div>
       ) : total === 0 ? (
-        <div className="rounded-xl border border-glass-border bg-glass-bg/40 px-4 py-8 text-center text-sm text-text-secondary">
+        <div className="liquid-empty-state rounded-xl border border-glass-border px-4 py-8 text-center text-sm text-text-secondary">
           {copy.empty}
         </div>
       ) : (

--- a/frontend/src/components/dashboard/BotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/BotDetailDrawer.tsx
@@ -263,19 +263,19 @@ function BotDetailDrawer() {
     <>
       <div
         ref={overlayRef}
-        className="fixed inset-0 z-40 bg-black/40 backdrop-blur-[2px]"
+        className="liquid-scrim fixed inset-0 z-40 backdrop-blur-[2px]"
         onClick={closeDrawer}
         aria-hidden
       />
       <aside
         ref={panelRef}
-        className="fixed inset-y-0 right-0 z-50 flex w-full max-w-md flex-col border-l border-glass-border bg-deep-black-light shadow-2xl shadow-black/50"
+        className="liquid-drawer fixed inset-y-0 right-0 z-50 flex w-full max-w-md flex-col border-l border-glass-border"
         role="dialog"
         aria-modal="true"
         aria-label={t.ariaLabel}
       >
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-glass-border px-5 py-4" data-overlay-section>
+        <div className="liquid-toolbar flex items-center justify-between border-b border-glass-border px-5 py-4" data-overlay-section>
           <div className="flex min-w-0 items-center gap-3">
             <BotAvatar agentId={bot.agent_id} avatarUrl={bot.avatar_url} size={40} alt={bot.display_name} />
             <div className="min-w-0">
@@ -296,14 +296,14 @@ function BotDetailDrawer() {
             onClick={closeDrawer}
             title={t.close}
             aria-label={t.close}
-            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-secondary/70 transition-colors hover:bg-glass-bg hover:text-text-primary"
+            className="liquid-action flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-secondary/70 transition-colors hover:bg-glass-bg hover:text-text-primary"
           >
             <X className="h-4 w-4" />
           </button>
         </div>
 
         {/* Tab strip */}
-        <div className="grid grid-cols-5 border-b border-glass-border" data-overlay-section>
+        <div className="liquid-tabs grid grid-cols-5 border-b border-glass-border" data-overlay-section>
           {TABS.map(({ key, icon: Icon }) => {
             const active = tab === key;
             return (
@@ -427,7 +427,7 @@ function OverviewTab({
       />
 
       {stats ? (
-        <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
+        <section className="liquid-card rounded-2xl border border-glass-border p-4">
           <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-wider text-text-secondary/70">
             {t.overview.activity7d}
           </h3>
@@ -440,14 +440,14 @@ function OverviewTab({
         </section>
       ) : null}
 
-      <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
+      <section className="liquid-card rounded-2xl border border-glass-border p-4">
         <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-wider text-text-secondary/70">
           {t.overview.hostedDevice}
         </h3>
         {device ? (
           <button
             onClick={() => onJumpToDevice(device.id)}
-            className="flex w-full items-center justify-between gap-2 rounded-lg border border-glass-border bg-glass-bg/40 px-3 py-2 text-left transition-colors hover:border-neon-cyan/40"
+            className="liquid-list-row flex w-full items-center justify-between gap-2 rounded-lg border border-glass-border px-3 py-2 text-left transition-colors hover:border-neon-cyan/40"
           >
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-2">
@@ -474,7 +474,7 @@ function OverviewTab({
         )}
       </section>
 
-      <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
+      <section className="liquid-card rounded-2xl border border-glass-border p-4">
         <h3 className="mb-3 flex items-center justify-between text-[11px] font-semibold uppercase tracking-wider text-text-secondary/70">
           <span>{t.overview.friends(friends.length)}</span>
         </h3>
@@ -484,7 +484,7 @@ function OverviewTab({
               <li key={`${friend.type}-${friend.id}`}>
                 <button
                   onClick={() => onJumpToFriend(friend)}
-                  className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-glass-bg/60"
+                  className="liquid-list-row flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors"
                 >
                   {friend.type === "agent" ? (
                     <BotAvatar agentId={friend.id} size={28} alt={friend.display_name} />
@@ -516,7 +516,7 @@ function OverviewTab({
         )}
       </section>
 
-      <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
+      <section className="liquid-card rounded-2xl border border-glass-border p-4">
         <h3 className="mb-3 flex items-center justify-between text-[11px] font-semibold uppercase tracking-wider text-text-secondary/70">
           <span>{t.overview.groups(groups.length)}</span>
         </h3>
@@ -526,7 +526,7 @@ function OverviewTab({
               <li key={group.room_id}>
                 <button
                   onClick={() => onJumpToGroup(group)}
-                  className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-glass-bg/60"
+                  className="liquid-list-row flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors"
                 >
                   {group.bots.length >= 2 ? (
                     <CompositeAvatar
@@ -560,11 +560,11 @@ function OverviewTab({
         )}
       </section>
 
-      <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
+      <section className="liquid-card rounded-2xl border border-glass-border p-4">
         <div className="flex gap-2">
           <button
             onClick={onOpenChat}
-            className="flex flex-1 items-center justify-center gap-1.5 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-2 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20"
+            className="liquid-action flex flex-1 items-center justify-center gap-1.5 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-2 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20"
           >
             <MessageCircle className="h-3.5 w-3.5" />
             {t.overview.openChat}
@@ -648,7 +648,7 @@ function RuntimeChip({
   return (
     <span
       title={`${label}: ${runtimeId || unknownLabel}`}
-      className="inline-flex max-w-[180px] shrink-0 items-center gap-1.5 rounded-full border border-glass-border bg-deep-black/40 px-2 py-1"
+      className="liquid-tool-surface inline-flex max-w-[180px] shrink-0 items-center gap-1.5 rounded-full border border-glass-border px-2 py-1"
     >
       <RuntimeLogo runtimeId={runtimeId} />
       <span className="truncate font-mono text-[11px] text-text-primary">{runtimeId || unknownLabel}</span>
@@ -718,7 +718,7 @@ function ProfileEditor({
   };
 
   return (
-    <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
+    <section className="liquid-card rounded-2xl border border-glass-border p-4">
       <div className="mb-3 flex items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-2 text-[11px] font-semibold uppercase tracking-wider text-text-secondary/70">
           <Pencil className="h-3.5 w-3.5" />
@@ -731,7 +731,7 @@ function ProfileEditor({
         value={name}
         onChange={(e) => setName(e.target.value)}
         maxLength={128}
-        className="w-full rounded-lg border border-glass-border bg-glass-bg/30 px-3 py-2 text-sm text-text-primary outline-none focus:border-neon-cyan/40"
+        className="liquid-input w-full rounded-lg border border-glass-border px-3 py-2 text-sm text-text-primary outline-none focus:border-neon-cyan/40"
       />
       <label className="mb-1 mt-4 block text-xs text-text-secondary/65">{t.profile.bio}</label>
       <textarea
@@ -740,14 +740,14 @@ function ProfileEditor({
         rows={4}
         maxLength={4000}
         placeholder={t.profile.bioPlaceholder}
-        className="w-full resize-none rounded-lg border border-glass-border bg-glass-bg/30 px-3 py-2 text-sm text-text-primary outline-none focus:border-neon-cyan/40"
+        className="liquid-input w-full resize-none rounded-lg border border-glass-border px-3 py-2 text-sm text-text-primary outline-none focus:border-neon-cyan/40"
       />
       <div className="mt-4 flex items-center justify-between">
         <p className="font-mono text-[10px] text-text-secondary/55">{agentId}</p>
         <button
           onClick={() => void handleSave()}
           disabled={!dirty || saving}
-          className="rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-1.5 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20 disabled:opacity-50"
+          className="liquid-action rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-1.5 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20 disabled:opacity-50"
         >
           {saving ? t.profile.saving : saved ? `${t.profile.saved} ✓` : t.profile.save}
         </button>
@@ -866,7 +866,7 @@ function PolicyTab({ agentId, t }: { agentId: string; t: BotDetailDrawerCopy }) 
     return (
       <div className="space-y-4">
         {[1, 2].map((i) => (
-          <div key={i} className="animate-pulse rounded-2xl border border-glass-border bg-glass-bg/40 p-5">
+          <div key={i} className="liquid-card animate-pulse rounded-2xl border border-glass-border p-5">
             <div className="mb-3 h-4 w-28 rounded bg-glass-bg" />
             <div className="space-y-2">
               <div className="h-9 rounded bg-glass-bg/70" />
@@ -889,7 +889,7 @@ function PolicyTab({ agentId, t }: { agentId: string; t: BotDetailDrawerCopy }) 
     <div className="space-y-5">
       {error ? <div className="rounded-xl border border-red-400/20 bg-red-400/5 px-4 py-3 text-sm text-red-300">{error}</div> : null}
 
-      <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
+      <section className="liquid-card rounded-2xl border border-glass-border p-4">
         <h3 className="mb-1 text-sm font-semibold text-text-primary">{t.settings.contactTitle}</h3>
         <p className="mb-4 text-xs text-text-secondary/65">{t.settings.contactDescription}</p>
         <RadioGroup
@@ -919,13 +919,13 @@ function PolicyTab({ agentId, t }: { agentId: string; t: BotDetailDrawerCopy }) 
             disabled={saving}
             placeholder={t.settings.roomInvite}
             className="min-w-40"
-            buttonClassName="min-h-8 rounded-lg bg-deep-black/40 px-2 text-xs"
+            buttonClassName="liquid-input min-h-8 rounded-lg px-2 text-xs"
             options={roomInviteOptions.map((opt) => ({ value: opt.value, label: opt.label }))}
           />
         </label>
       </section>
 
-      <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
+      <section className="liquid-card rounded-2xl border border-glass-border p-4">
         <h3 className="mb-1 text-sm font-semibold text-text-primary">{t.settings.defaultReplyTitle}</h3>
         <p className="mb-4 text-xs text-text-secondary/65">{t.settings.defaultReplyDescription}</p>
         <RadioGroup
@@ -1080,7 +1080,7 @@ function FilesTab({ agentId, t }: { agentId: string; t: BotDetailDrawerCopy }) {
           type="button"
           onClick={() => void loadFiles()}
           disabled={loading}
-          className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-glass-border bg-glass-bg text-text-secondary transition-colors hover:text-text-primary disabled:opacity-60"
+          className="liquid-action inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-glass-border text-text-secondary transition-colors hover:text-text-primary disabled:opacity-60"
           title={t.files.refresh}
         >
           {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
@@ -1094,7 +1094,7 @@ function FilesTab({ agentId, t }: { agentId: string; t: BotDetailDrawerCopy }) {
           {[1, 2, 3].map((i) => <div key={i} className="h-14 animate-pulse rounded-xl bg-glass-bg/60" />)}
         </div>
       ) : files.length === 0 ? (
-        <div className="rounded-xl border border-glass-border bg-glass-bg/40 px-4 py-8 text-center text-sm text-text-secondary">
+        <div className="liquid-empty-state rounded-xl border border-glass-border px-4 py-8 text-center text-sm text-text-secondary">
           {t.files.empty}
         </div>
       ) : (
@@ -1107,7 +1107,7 @@ function FilesTab({ agentId, t }: { agentId: string; t: BotDetailDrawerCopy }) {
                   key={file.id}
                   type="button"
                   onClick={() => setSelectedFileId(file.id)}
-                  className={`flex min-h-[56px] items-center justify-between gap-3 rounded-xl border px-3 py-2 text-left transition-colors ${
+                  className={`liquid-list-row flex min-h-[56px] items-center justify-between gap-3 rounded-xl border px-3 py-2 text-left transition-colors ${
                     selected ? "border-neon-cyan/40 bg-neon-cyan/5" : "border-glass-border bg-glass-bg/40 hover:bg-glass-bg/70"
                   }`}
                 >
@@ -1126,7 +1126,7 @@ function FilesTab({ agentId, t }: { agentId: string; t: BotDetailDrawerCopy }) {
           </div>
 
           {selectedFile ? (
-            <section className="rounded-xl border border-glass-border bg-glass-bg/30">
+            <section className="liquid-tool-surface rounded-xl border border-glass-border">
               <div className="border-b border-glass-border px-3 py-2">
                 <div className="truncate text-xs font-medium text-text-primary">{selectedFile.name}</div>
               </div>
@@ -1169,7 +1169,7 @@ function RadioGroup<T extends string>({
         return (
           <label
             key={opt.value}
-            className={`flex cursor-pointer items-start gap-3 rounded-xl border px-3 py-2.5 transition-colors ${
+            className={`liquid-list-row flex cursor-pointer items-start gap-3 rounded-xl border px-3 py-2.5 transition-colors ${
               selected ? "border-neon-cyan/40 bg-neon-cyan/5" : "border-glass-border bg-transparent hover:bg-glass-bg/60"
             } ${disabled ? "pointer-events-none opacity-50" : ""}`}
           >
@@ -1195,7 +1195,7 @@ function RadioGroup<T extends string>({
 
 function Stat({ label, value, delta }: { label: string; value: number | string; delta?: string }) {
   return (
-    <div className="rounded-lg bg-glass-bg/50 px-2 py-1.5">
+    <div className="liquid-tool-surface rounded-lg px-2 py-1.5">
       <div className="text-[9px] uppercase tracking-wider text-text-secondary/55">{label}</div>
       <div className="flex items-baseline justify-center gap-1">
         <span className="text-sm font-semibold text-text-primary">{value}</span>

--- a/frontend/src/components/dashboard/BotRuntimeCapabilitiesPanel.tsx
+++ b/frontend/src/components/dashboard/BotRuntimeCapabilitiesPanel.tsx
@@ -332,7 +332,7 @@ export default function BotRuntimeCapabilitiesPanel({
   }
 
   return (
-    <section className={`rounded-2xl border border-glass-border bg-glass-bg/30 p-4 ${className ?? ""}`}>
+    <section className={`liquid-card rounded-2xl border border-glass-border p-4 ${className ?? ""}`}>
       <div className="mb-4 flex items-start justify-between gap-3">
         <div className="min-w-0">
           <div className="flex items-center gap-2 text-sm font-semibold text-text-primary">
@@ -353,7 +353,7 @@ export default function BotRuntimeCapabilitiesPanel({
           disabled={!daemon?.id || isRefreshing}
           onClick={handleRefresh}
           title={labels.refresh}
-          className="inline-flex min-h-8 items-center gap-2 rounded-lg border border-glass-border bg-deep-black/50 px-2.5 text-xs font-medium text-text-secondary transition-colors hover:border-neon-cyan/45 hover:text-neon-cyan disabled:cursor-not-allowed disabled:opacity-50"
+          className="liquid-action inline-flex min-h-8 items-center gap-2 rounded-lg border border-glass-border px-2.5 text-xs font-medium text-text-secondary transition-colors hover:border-neon-cyan/45 hover:text-neon-cyan disabled:cursor-not-allowed disabled:opacity-50"
         >
           <RefreshCw className={`h-3.5 w-3.5 ${isRefreshing ? "animate-spin" : ""}`} />
           {isRefreshing ? labels.refreshing : labels.refresh}
@@ -410,7 +410,7 @@ export default function BotRuntimeCapabilitiesPanel({
                     leadingIcon={<Brain className="h-4 w-4 text-neon-cyan" />}
                   />
                 ) : (
-                  <div className="flex min-h-10 items-center gap-2 rounded-xl border border-glass-border bg-deep-black px-3">
+                  <div className="liquid-tool-surface flex min-h-10 items-center gap-2 rounded-xl border border-glass-border px-3">
                     <Brain className="h-4 w-4 shrink-0 text-neon-cyan" />
                     <input
                       disabled={saving}
@@ -431,7 +431,7 @@ export default function BotRuntimeCapabilitiesPanel({
                   type="button"
                   disabled={saving}
                   onClick={() => setSelectedThinking((value) => value !== true)}
-                  className="flex min-h-10 w-full items-center justify-between gap-3 rounded-xl border border-glass-border bg-deep-black px-3 text-sm text-text-primary transition-colors hover:border-neon-cyan/45 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="liquid-action flex min-h-10 w-full items-center justify-between gap-3 rounded-xl border border-glass-border px-3 text-sm text-text-primary transition-colors hover:border-neon-cyan/45 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   <span className="flex items-center gap-2">
                     <Sparkles className="h-4 w-4 text-neon-cyan" />

--- a/frontend/src/components/dashboard/BotWalletTab.tsx
+++ b/frontend/src/components/dashboard/BotWalletTab.tsx
@@ -145,7 +145,7 @@ export default function BotWalletTab({
   return (
     <div className="space-y-4">
       {/* Balance card */}
-      <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
+      <section className="liquid-card rounded-2xl border border-glass-border p-4">
         <div className="mb-1 flex items-center justify-between">
           <span className="text-[10px] font-medium uppercase tracking-wider text-text-secondary">
             {t.totalBalance}
@@ -167,13 +167,13 @@ export default function BotWalletTab({
           <span className="text-xs font-medium text-text-secondary">{assetCode}</span>
         </div>
         <div className="grid grid-cols-2 gap-3">
-          <div className="rounded-lg border border-glass-border bg-deep-black-light p-2.5">
+          <div className="liquid-tool-surface rounded-lg border border-glass-border p-2.5">
             <div className="text-[10px] uppercase tracking-wider text-text-secondary">{t.available}</div>
             <div className="font-mono text-sm font-semibold text-neon-green">
               {showAmount(wallet.available_balance_minor, walletAmountsHidden)}
             </div>
           </div>
-          <div className="rounded-lg border border-glass-border bg-deep-black-light p-2.5">
+          <div className="liquid-tool-surface rounded-lg border border-glass-border p-2.5">
             <div className="text-[10px] uppercase tracking-wider text-text-secondary">{t.locked}</div>
             <div className="font-mono text-sm font-semibold text-text-secondary">
               {showAmount(wallet.locked_balance_minor, walletAmountsHidden)}
@@ -184,19 +184,19 @@ export default function BotWalletTab({
         <div className="mt-4 grid grid-cols-3 gap-2">
           <button
             onClick={() => setActiveDialog("topup")}
-            className="rounded-lg border border-glass-border bg-glass-bg px-2 py-2 text-xs font-medium text-neon-green transition-colors hover:bg-neon-green/10"
+            className="liquid-action rounded-lg border border-glass-border px-2 py-2 text-xs font-medium text-neon-green transition-colors hover:bg-neon-green/10"
           >
             {t.recharge}
           </button>
           <button
             onClick={() => setActiveDialog("transfer")}
-            className="rounded-lg border border-glass-border bg-glass-bg px-2 py-2 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/10"
+            className="liquid-action rounded-lg border border-glass-border px-2 py-2 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/10"
           >
             {t.transfer}
           </button>
           <button
             onClick={() => setActiveDialog("withdraw")}
-            className="rounded-lg border border-glass-border bg-glass-bg px-2 py-2 text-xs font-medium text-neon-purple transition-colors hover:bg-neon-purple/10"
+            className="liquid-action rounded-lg border border-glass-border px-2 py-2 text-xs font-medium text-neon-purple transition-colors hover:bg-neon-purple/10"
           >
             {t.withdraw}
           </button>
@@ -204,7 +204,7 @@ export default function BotWalletTab({
       </section>
 
       {/* Ledger */}
-      <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
+      <section className="liquid-card rounded-2xl border border-glass-border p-4">
         <div className="mb-3">
           <h3 className="text-xs font-semibold uppercase tracking-wider text-text-secondary/80">{t.ledger}</h3>
         </div>
@@ -213,7 +213,7 @@ export default function BotWalletTab({
             {t.noTransactions}
           </div>
         ) : (
-          <div className="overflow-hidden rounded-lg border border-glass-border bg-deep-black-light">
+          <div className="liquid-tool-surface overflow-hidden rounded-lg border border-glass-border">
             {walletLedger.map((entry) => {
               const isCredit = entry.direction === "credit";
               return (

--- a/frontend/src/components/dashboard/ChatPane.tsx
+++ b/frontend/src/components/dashboard/ChatPane.tsx
@@ -795,7 +795,7 @@ export default function ChatPane({ onHumanOpen, sidebarTabOverride }: ChatPanePr
 
   if (!focusedRoomId) {
     return (
-      <div className="flex flex-1 items-center justify-center overflow-y-auto bg-deep-black px-6 py-10">
+      <div className="dashboard-main flex flex-1 items-center justify-center overflow-y-auto bg-deep-black px-6 py-10">
         <MessagesEmptyState filter={messagesFilter} />
       </div>
     );
@@ -819,7 +819,7 @@ export default function ChatPane({ onHumanOpen, sidebarTabOverride }: ChatPanePr
   const loginHref = openedRoom ? `/login?next=${encodeURIComponent(`/chats/messages/${openedRoom.room_id}`)}` : "/login";
 
   return (
-    <div className="flex flex-1 flex-col bg-deep-black overflow-hidden">
+    <div className="dashboard-main flex flex-1 flex-col bg-deep-black overflow-hidden">
       {openedRoomId && <RoomHeader />}
       <div className="min-h-0 flex-1 overflow-hidden flex">
         <div className="min-w-0 flex-1 overflow-hidden flex flex-col">

--- a/frontend/src/components/dashboard/ContactList.tsx
+++ b/frontend/src/components/dashboard/ContactList.tsx
@@ -30,7 +30,7 @@ export default function ContactList() {
 
   if (contacts.length === 0) {
     return (
-      <div className="p-4 text-center text-xs text-text-secondary">
+      <div className="liquid-empty-state m-3 p-4 text-center text-xs text-text-secondary">
         {t.noContacts}
       </div>
     );
@@ -58,7 +58,7 @@ export default function ContactList() {
                 void selectAgent(contact.contact_agent_id);
               }
             }}
-            className="w-full px-4 py-2.5 text-left transition-colors hover:bg-glass-bg border-l-2 border-transparent"
+            className="liquid-list-row w-full border-l-2 border-transparent px-4 py-2.5 text-left transition-colors"
           >
             <div className="flex items-center gap-2.5">
               {contact.avatar_url ? (

--- a/frontend/src/components/dashboard/ContactRequestsInbox.tsx
+++ b/frontend/src/components/dashboard/ContactRequestsInbox.tsx
@@ -157,7 +157,7 @@ export default function ContactRequestsInbox({
   return (
     <div className="flex h-full flex-col">
       {(title || !hideTabs) && (
-        <div className="flex items-center justify-between gap-3 border-b border-glass-border px-5 py-3">
+        <div className="liquid-toolbar flex items-center justify-between gap-3 border-b border-glass-border px-5 py-3">
           {title ? <div className="min-w-0 text-sm font-semibold text-text-primary">{title}</div> : <span />}
           {!hideTabs ? (
             <div className="inline-flex items-center gap-1 rounded-full border border-glass-border bg-glass-bg/50 p-0.5">
@@ -227,7 +227,7 @@ export default function ContactRequestsInbox({
                       return (
                         <div
                           key={group.agentId}
-                          className="overflow-hidden rounded-2xl border border-glass-border bg-deep-black-light"
+                          className="liquid-card overflow-hidden rounded-2xl border border-glass-border"
                         >
                           <button
                             type="button"
@@ -362,7 +362,7 @@ function ReceivedRequestCard({
   const isHuman = isHumanId(req.from_agent_id);
   const initial = (req.from_display_name || req.from_agent_id).trim().charAt(0).toUpperCase();
   return (
-    <div className="rounded-2xl border border-glass-border bg-deep-black-light p-4">
+    <div className="liquid-card rounded-2xl border border-glass-border p-4">
       <div className="flex items-start gap-3">
         {isHuman ? (
           <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-neon-purple/15 text-sm font-semibold text-neon-purple">

--- a/frontend/src/components/dashboard/ContactsDetailPane.tsx
+++ b/frontend/src/components/dashboard/ContactsDetailPane.tsx
@@ -91,7 +91,7 @@ function ActionButton({
     <button
       onClick={onClick}
       disabled={disabled}
-      className={`flex h-20 w-28 flex-col items-center justify-center gap-2 rounded-2xl border transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${cls}`}
+      className={`liquid-action flex h-20 w-28 flex-col items-center justify-center gap-2 rounded-2xl border transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${cls}`}
     >
       <Icon className="h-5 w-5" />
       <span className="text-xs font-medium">{label}</span>
@@ -147,8 +147,8 @@ export default function ContactsDetailPane() {
 
   if (!target) {
     return (
-      <div className="flex h-full w-full flex-1 items-center justify-center bg-deep-black px-6">
-        <div className="max-w-md text-center">
+      <div className="dashboard-main flex h-full w-full flex-1 items-center justify-center px-6">
+        <div className="liquid-empty-state max-w-md rounded-2xl border border-glass-border p-6 text-center">
           <div className="mx-auto mb-5 flex h-14 w-14 items-center justify-center rounded-2xl border border-glass-border bg-glass-bg/40">
             <UserCircle className="h-6 w-6 text-neon-cyan/80" />
           </div>
@@ -270,11 +270,11 @@ export default function ContactsDetailPane() {
   };
 
   return (
-    <div className="relative flex h-full w-full flex-1 flex-col bg-deep-black">
+    <div className="dashboard-main relative flex h-full w-full flex-1 flex-col">
       <button
         type="button"
         onClick={() => setSelectedContactKey(null)}
-        className="absolute left-2 top-2 hidden h-9 w-9 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary max-md:inline-flex"
+        className="liquid-action absolute left-2 top-2 hidden h-9 w-9 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary max-md:inline-flex"
         aria-label="Back to contacts"
         title="Back to contacts"
       >

--- a/frontend/src/components/dashboard/CreateAgentDialog.tsx
+++ b/frontend/src/components/dashboard/CreateAgentDialog.tsx
@@ -795,7 +795,7 @@ export default function CreateAgentDialog({
   return (
     <div
       ref={overlayRef}
-      className={`fixed inset-0 z-[110] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`}
+      className={`liquid-scrim fixed inset-0 z-[110] flex items-center justify-center p-4 ${closing ? "pointer-events-none" : ""}`}
       onMouseDown={(event) => {
         if (event.target === event.currentTarget) closeWithMotion();
       }}
@@ -805,7 +805,7 @@ export default function CreateAgentDialog({
         role="dialog"
         aria-modal="true"
         aria-labelledby="create-agent-title"
-        className="relative flex max-h-[calc(100dvh-2rem)] w-full max-w-xl flex-col overflow-hidden rounded-2xl border border-glass-border bg-deep-black-light shadow-2xl"
+        className="liquid-dialog relative flex max-h-[calc(100dvh-2rem)] w-full max-w-xl flex-col overflow-hidden rounded-2xl"
       >
         {(() => {
           const onStep1 = showEmptyState || addingDevice;
@@ -817,7 +817,7 @@ export default function CreateAgentDialog({
             : t.step1Description;
           return (
             <>
-              <div className="flex shrink-0 items-center gap-3 border-b border-glass-border/40 px-4 py-3 sm:px-5">
+              <div className="liquid-toolbar flex shrink-0 items-center gap-3 border-b px-4 py-3 sm:px-5">
                 <div className="min-w-0 flex-1">
                   {!showWizardHeader ? (
                     <h3
@@ -841,7 +841,7 @@ export default function CreateAgentDialog({
                   onClick={() => closeWithMotion()}
                   disabled={submitting}
                   aria-label={t.cancel}
-                  className="shrink-0 rounded-full p-1.5 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+                  className="liquid-action shrink-0 rounded-full p-1.5 text-text-secondary transition-colors hover:text-text-primary disabled:opacity-50"
                 >
                   <X className="h-5 w-5" />
                 </button>
@@ -899,7 +899,7 @@ export default function CreateAgentDialog({
             <button
               type="button"
               onClick={() => setAddingDevice(false)}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-glass-border px-3 py-1.5 text-xs text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
+              className="liquid-action inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs text-text-secondary transition-colors hover:text-text-primary"
             >
               <ArrowLeft className="h-3.5 w-3.5" />
               {t.backLabel}
@@ -918,7 +918,7 @@ export default function CreateAgentDialog({
                 {t.runtimeSectionLabel}
               </div>
             )}
-            <div className={hasExistingBots ? "space-y-3.5" : "space-y-3.5 rounded-2xl border border-glass-border/60 bg-glass-bg/20 p-3.5"}>
+            <div className={hasExistingBots ? "space-y-3.5" : "liquid-card space-y-3.5 rounded-2xl p-3.5"}>
             <section>
               <div className="mb-1.5 flex items-center justify-between gap-3">
                 <label className="text-[13px] font-semibold uppercase tracking-wider text-text-secondary">
@@ -933,7 +933,7 @@ export default function CreateAgentDialog({
                     setAddingDevice(true);
                   }}
                   disabled={submitting}
-                  className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] font-medium text-neon-cyan/80 transition-colors hover:bg-neon-cyan/10 hover:text-neon-cyan disabled:opacity-50"
+                  className="liquid-action inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] font-medium text-neon-cyan/80 transition-colors hover:bg-neon-cyan/10 hover:text-neon-cyan disabled:opacity-50"
                 >
                   <Plus className="h-3 w-3" />
                   {t.addDeviceLabel}
@@ -956,7 +956,7 @@ export default function CreateAgentDialog({
                   options={deviceOptions}
                 />
               ) : isCloudAgentSelected ? (
-                <div className="flex h-11 items-center gap-2 rounded-xl border border-glass-border bg-deep-black px-3 text-xs text-text-secondary">
+                <div className="liquid-card flex h-11 items-center gap-2 rounded-xl px-3 text-xs text-text-secondary">
                   <Cloud className="h-3.5 w-3.5 text-neon-cyan" />
                   <span className="text-text-primary">
                     {t.cloudAgentOptionLabel}
@@ -966,7 +966,7 @@ export default function CreateAgentDialog({
                   </span>
                 </div>
               ) : selectedDaemon ? (
-                <div className="flex h-11 items-center gap-2 rounded-xl border border-glass-border bg-deep-black px-3 text-xs text-text-secondary">
+                <div className="liquid-card flex h-11 items-center gap-2 rounded-xl px-3 text-xs text-text-secondary">
                   <Server className="h-3.5 w-3.5 text-neon-cyan" />
                   <span className="text-text-primary">
                     {selectedDaemon.label || selectedDaemon.id}
@@ -1046,7 +1046,7 @@ export default function CreateAgentDialog({
                 {t.identitySectionLabel}
               </div>
             )}
-            <div className={hasExistingBots ? "space-y-3.5" : "space-y-3.5 rounded-2xl border border-glass-border/60 bg-glass-bg/20 p-3.5"}>
+            <div className={hasExistingBots ? "space-y-3.5" : "liquid-card space-y-3.5 rounded-2xl p-3.5"}>
             <section>
               <div className="mb-1 flex items-center justify-between gap-3">
                 <label className="text-[13px] font-semibold uppercase tracking-wider text-text-secondary">
@@ -1058,7 +1058,7 @@ export default function CreateAgentDialog({
                   disabled={submitting}
                   title={t.randomizeTooltip}
                   aria-label={t.randomizeTooltip}
-                  className="inline-flex items-center justify-center rounded-md p-1 text-text-secondary transition-colors hover:bg-glass-bg hover:text-neon-cyan disabled:opacity-50"
+                  className="liquid-action inline-flex items-center justify-center rounded-md p-1 text-text-secondary transition-colors hover:text-neon-cyan disabled:opacity-50"
                 >
                   <Sparkles className="h-3.5 w-3.5" />
                 </button>
@@ -1081,7 +1081,7 @@ export default function CreateAgentDialog({
                 }}
                 placeholder={t.namePlaceholder}
                 disabled={submitting}
-                className="h-10 w-full rounded-xl border border-glass-border bg-deep-black px-3 text-sm text-text-primary placeholder-text-tertiary focus:border-neon-cyan focus:outline-none focus:ring-1 focus:ring-neon-cyan/50 disabled:opacity-50"
+                className="liquid-input h-10 w-full rounded-xl border px-3 text-sm text-text-primary placeholder-text-tertiary focus:border-neon-cyan focus:outline-none focus:ring-1 focus:ring-neon-cyan/50 disabled:opacity-50"
                 maxLength={64}
               />
             </section>
@@ -1099,7 +1099,7 @@ export default function CreateAgentDialog({
                 placeholder={t.bioPlaceholder}
                 disabled={submitting}
                 rows={2}
-                className="h-16 w-full resize-none rounded-xl border border-glass-border bg-deep-black px-3 py-2 text-sm text-text-primary placeholder-text-tertiary focus:border-neon-cyan focus:outline-none focus:ring-1 focus:ring-neon-cyan/50 disabled:opacity-50"
+                className="liquid-input h-16 w-full resize-none rounded-xl border px-3 py-2 text-sm text-text-primary placeholder-text-tertiary focus:border-neon-cyan focus:outline-none focus:ring-1 focus:ring-neon-cyan/50 disabled:opacity-50"
                 maxLength={240}
               />
             </section>
@@ -1115,12 +1115,12 @@ export default function CreateAgentDialog({
               </div>
 
               {!showEmptyState && !addingDevice && loaded && (
-                <div className="flex shrink-0 items-center justify-end gap-3 border-t border-glass-border/40 px-4 py-3 sm:px-5">
+                <div className="liquid-toolbar flex shrink-0 items-center justify-end gap-3 border-t px-4 py-3 sm:px-5">
                   <button
                     type="button"
                     onClick={() => closeWithMotion()}
                     disabled={submitting}
-                    className="rounded-xl border border-glass-border px-4 py-2 text-sm font-medium text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+                    className="liquid-action rounded-xl px-4 py-2 text-sm font-medium text-text-secondary transition-colors hover:text-text-primary disabled:opacity-50"
                   >
                     {t.cancel}
                   </button>
@@ -1128,7 +1128,7 @@ export default function CreateAgentDialog({
                     type="button"
                     onClick={() => void handleSubmit()}
                     disabled={!canSubmit}
-                    className="flex items-center gap-2 rounded-xl border border-neon-cyan/50 bg-neon-cyan/10 px-4 py-2 text-sm font-bold text-neon-cyan transition-colors hover:bg-neon-cyan/20 disabled:cursor-not-allowed disabled:opacity-50"
+                    className="liquid-action flex items-center gap-2 rounded-xl border border-neon-cyan/50 bg-neon-cyan/10 px-4 py-2 text-sm font-bold text-neon-cyan transition-colors hover:bg-neon-cyan/20 disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     {submitting ? (
                       <>
@@ -1198,7 +1198,7 @@ function RuntimePicker({
           type="button"
           onClick={onRefresh}
           disabled={refreshing || disabled || !daemon}
-          className="inline-flex items-center gap-1 rounded-md border border-glass-border bg-glass-bg px-2 py-0.5 text-[11px] font-medium text-text-secondary transition-colors hover:border-neon-cyan/60 hover:bg-neon-cyan/10 hover:text-neon-cyan disabled:opacity-50"
+          className="liquid-action inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-[11px] font-medium text-text-secondary transition-colors hover:border-neon-cyan/60 hover:bg-neon-cyan/10 hover:text-neon-cyan disabled:opacity-50"
         >
           {refreshing ? (
             <Loader2 className="h-3 w-3 animate-spin" />
@@ -1210,7 +1210,7 @@ function RuntimePicker({
       </div>
 
       {!hasAny ? (
-        <div className="rounded-xl border border-dashed border-glass-border bg-glass-bg/40 px-3 py-4 text-center text-xs text-text-secondary">
+        <div className="liquid-empty-state rounded-xl border border-dashed px-3 py-4 text-center text-xs text-text-secondary">
           {labels.noRuntimesDetected}
         </div>
       ) : (
@@ -1235,7 +1235,7 @@ function RuntimePicker({
               })}
             </div>
           ) : (
-            <div className="rounded-xl border border-dashed border-glass-border bg-glass-bg/40 px-3 py-4 text-center text-xs text-text-secondary">
+            <div className="liquid-empty-state rounded-xl border border-dashed px-3 py-4 text-center text-xs text-text-secondary">
               {labels.noRuntimesDetected}
             </div>
           )}
@@ -1246,7 +1246,7 @@ function RuntimePicker({
                 type="button"
                 aria-expanded={unavailableExpanded}
                 onClick={() => setUnavailableExpanded((expanded) => !expanded)}
-                className="flex w-full items-center justify-between gap-3 rounded-xl border border-glass-border bg-glass-bg/30 px-3 py-2 text-left text-xs text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
+                className="liquid-action flex w-full items-center justify-between gap-3 rounded-xl px-3 py-2 text-left text-xs text-text-secondary transition-colors hover:text-text-primary"
               >
                 <span>
                   <span className="font-semibold uppercase tracking-wider">
@@ -1343,12 +1343,12 @@ function RuntimeCard({
   availableLabel?: string;
 }) {
   const base =
-    "flex w-full items-center gap-3 rounded-xl border px-3 py-2 text-left transition-colors";
+    "liquid-action flex w-full items-center gap-3 rounded-xl border px-3 py-2 text-left transition-colors";
   const state = !runtime.available
     ? "cursor-not-allowed border-glass-border bg-glass-bg/35 text-text-secondary/75"
     : selected
       ? "border-neon-cyan bg-neon-cyan/15 text-text-primary"
-      : "border-glass-border bg-deep-black text-text-primary hover:border-neon-cyan/45 hover:bg-neon-cyan/10";
+      : "border-glass-border text-text-primary hover:border-neon-cyan/45 hover:bg-neon-cyan/10";
   return (
     <button
       type="button"
@@ -1423,7 +1423,7 @@ function RuntimeModelOptions({
   if (models.length === 0 && !hasReasoning && !hasThinking) return null;
 
   return (
-    <section className="rounded-xl border border-glass-border bg-glass-bg/30 p-2.5">
+    <section className="liquid-card rounded-xl p-2.5">
       <div className="grid gap-2.5 sm:grid-cols-2">
         {models.length > 0 ? (
           <div className={hasReasoning || hasThinking ? "" : "sm:col-span-2"}>
@@ -1480,20 +1480,20 @@ function RuntimeModelOptions({
                 onChange={(event) =>
                   onSelectReasoningEffort(event.target.value.trim() || null)
                 }
-                className="h-10 w-full rounded-xl border border-glass-border bg-deep-black px-3 text-sm text-text-primary focus:border-neon-cyan focus:outline-none focus:ring-1 focus:ring-neon-cyan/50 disabled:opacity-50"
+                className="liquid-input h-10 w-full rounded-xl border px-3 text-sm text-text-primary focus:border-neon-cyan focus:outline-none focus:ring-1 focus:ring-neon-cyan/50 disabled:opacity-50"
               />
             )}
           </div>
         ) : null}
 
         {hasThinking ? (
-          <label className="flex min-h-10 items-center gap-2 rounded-xl border border-glass-border bg-deep-black px-3 text-sm text-text-primary sm:col-span-2">
+          <label className="liquid-card flex min-h-10 items-center gap-2 rounded-xl px-3 text-sm text-text-primary sm:col-span-2">
             <input
               type="checkbox"
               checked={selectedThinking === true}
               disabled={disabled}
               onChange={(event) => onSelectThinking(event.target.checked)}
-              className="h-4 w-4 rounded border-glass-border bg-deep-black text-neon-cyan focus:ring-neon-cyan/50"
+              className="h-4 w-4 rounded border-glass-border bg-transparent text-neon-cyan focus:ring-neon-cyan/50"
             />
             <span>{labels.thinkingLabel}</span>
           </label>
@@ -1535,7 +1535,7 @@ function OpenclawGatewayPicker({
   const boundCount = agents.length - availableAgents.length;
   if (endpoints.length === 0) {
     return (
-      <div className="rounded-xl border border-dashed border-glass-border bg-glass-bg/40 px-3 py-3 text-xs text-text-secondary">
+      <div className="liquid-empty-state rounded-xl border border-dashed px-3 py-3 text-xs text-text-secondary">
         No OpenClaw gateways configured on this daemon. Add an entry to
         <code className="mx-1 font-mono">openclawGateways</code>
         in the daemon config and refresh.
@@ -1544,7 +1544,7 @@ function OpenclawGatewayPicker({
   }
   return (
     <section>
-      <div className="rounded-xl border border-glass-border bg-glass-bg/30 p-2.5">
+      <div className="liquid-card rounded-xl p-2.5">
         <div className="grid gap-2.5">
       <div>
         <label className="mb-1 block text-[11px] font-semibold uppercase tracking-wider text-text-secondary">
@@ -1590,7 +1590,7 @@ function OpenclawGatewayPicker({
             value={selectedAgent ?? ""}
             placeholder={labels.subagentPlaceholder}
             onChange={(e) => onSelectAgent(e.target.value.trim() || null)}
-            className="h-10 w-full rounded-xl border border-glass-border bg-deep-black px-3 text-sm text-text-primary focus:border-neon-cyan focus:outline-none focus:ring-1 focus:ring-neon-cyan/50 disabled:opacity-50"
+            className="liquid-input h-10 w-full rounded-xl border px-3 text-sm text-text-primary focus:border-neon-cyan focus:outline-none focus:ring-1 focus:ring-neon-cyan/50 disabled:opacity-50"
           />
         ) : (
           <div className="relative">
@@ -1640,7 +1640,7 @@ function HermesProfilePicker({
   }
   if (profiles.length === 0) {
     return (
-      <div className="rounded-xl border border-dashed border-glass-border bg-glass-bg/40 px-3 py-3 text-xs text-text-secondary">
+      <div className="liquid-empty-state rounded-xl border border-dashed px-3 py-3 text-xs text-text-secondary">
         No hermes profiles detected. Make sure hermes is installed and run{" "}
         <code className="mx-1 font-mono">hermes profile create &lt;name&gt;</code>
         on this device, then refresh runtimes.
@@ -1805,7 +1805,7 @@ function OpenclawBranch({ onSuccess, onClose }: OpenclawBranchProps) {
           <button
             type="button"
             onClick={onClose}
-            className="rounded-xl border border-glass-border px-4 py-2 text-sm font-medium text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
+            className="liquid-action rounded-xl px-4 py-2 text-sm font-medium text-text-secondary transition-colors hover:text-text-primary"
           >
             Got it
           </button>
@@ -1849,7 +1849,7 @@ function OpenclawBranch({ onSuccess, onClose }: OpenclawBranchProps) {
             type="button"
             onClick={() => setTarget({ kind: "new" })}
             disabled={submitting}
-            className={`flex items-center justify-between gap-2 rounded-xl border px-3 py-2 text-left text-sm transition-colors ${
+            className={`liquid-action flex items-center justify-between gap-2 rounded-xl border px-3 py-2 text-left text-sm transition-colors ${
               target.kind === "new"
                 ? "border-neon-cyan/60 bg-neon-cyan/10 text-text-primary"
                 : "border-glass-border text-text-secondary hover:bg-glass-bg hover:text-text-primary"
@@ -1882,7 +1882,7 @@ function OpenclawBranch({ onSuccess, onClose }: OpenclawBranchProps) {
           onChange={(e) => setName(e.target.value)}
           placeholder="e.g. research-bot"
           disabled={submitting}
-          className="w-full rounded-xl border border-glass-border bg-deep-black px-3 py-2 text-sm text-text-primary placeholder-text-tertiary focus:border-neon-cyan focus:outline-none focus:ring-1 focus:ring-neon-cyan/50 disabled:opacity-50"
+          className="liquid-input w-full rounded-xl border px-3 py-2 text-sm text-text-primary placeholder-text-tertiary focus:border-neon-cyan focus:outline-none focus:ring-1 focus:ring-neon-cyan/50 disabled:opacity-50"
           maxLength={64}
         />
       </div>
@@ -1897,7 +1897,7 @@ function OpenclawBranch({ onSuccess, onClose }: OpenclawBranchProps) {
           placeholder="What this bot is for"
           disabled={submitting}
           rows={2}
-          className="w-full resize-none rounded-xl border border-glass-border bg-deep-black px-3 py-2 text-sm text-text-primary placeholder-text-tertiary focus:border-neon-cyan focus:outline-none focus:ring-1 focus:ring-neon-cyan/50 disabled:opacity-50"
+          className="liquid-input w-full resize-none rounded-xl border px-3 py-2 text-sm text-text-primary placeholder-text-tertiary focus:border-neon-cyan focus:outline-none focus:ring-1 focus:ring-neon-cyan/50 disabled:opacity-50"
           maxLength={240}
         />
       </div>
@@ -1913,7 +1913,7 @@ function OpenclawBranch({ onSuccess, onClose }: OpenclawBranchProps) {
           type="button"
           onClick={onClose}
           disabled={submitting}
-          className="rounded-xl border border-glass-border px-4 py-2.5 text-sm font-medium text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+          className="liquid-action rounded-xl px-4 py-2.5 text-sm font-medium text-text-secondary transition-colors hover:text-text-primary disabled:opacity-50"
         >
           Cancel
         </button>
@@ -1921,7 +1921,7 @@ function OpenclawBranch({ onSuccess, onClose }: OpenclawBranchProps) {
           type="button"
           onClick={() => void handleSubmit()}
           disabled={submitting || !name.trim()}
-          className="flex items-center gap-2 rounded-xl border border-neon-cyan/50 bg-neon-cyan/10 px-4 py-2.5 text-sm font-bold text-neon-cyan transition-all hover:bg-neon-cyan/20 disabled:cursor-not-allowed disabled:opacity-50"
+          className="liquid-action flex items-center gap-2 rounded-xl border border-neon-cyan/50 bg-neon-cyan/10 px-4 py-2.5 text-sm font-bold text-neon-cyan transition-all hover:bg-neon-cyan/20 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {submitting ? (
             <>
@@ -1955,7 +1955,7 @@ function HostCard({
       type="button"
       onClick={onSelect}
       disabled={disabled || !host.online}
-      className={`flex items-center justify-between gap-2 rounded-xl border px-3 py-2 text-left text-sm transition-colors ${
+      className={`liquid-action flex items-center justify-between gap-2 rounded-xl border px-3 py-2 text-left text-sm transition-colors ${
         selected
           ? "border-neon-cyan/60 bg-neon-cyan/10 text-text-primary"
           : "border-glass-border text-text-secondary hover:bg-glass-bg hover:text-text-primary"

--- a/frontend/src/components/dashboard/CreateRoomModal.tsx
+++ b/frontend/src/components/dashboard/CreateRoomModal.tsx
@@ -152,12 +152,12 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
   return (
     <div
       ref={overlayRef}
-      className={`fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4 ${closing ? "pointer-events-none" : ""}`}
+      className={`liquid-scrim fixed inset-0 z-50 flex items-center justify-center px-4 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`}
       onClick={closeWithMotion}
     >
       <div
         ref={panelRef}
-        className="flex max-h-[90vh] w-full max-w-lg flex-col overflow-hidden rounded-xl border border-glass-border bg-deep-black"
+        className="liquid-dialog flex max-h-[90vh] w-full max-w-lg flex-col overflow-hidden rounded-xl border"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="border-b border-glass-border px-6 py-4">
@@ -178,7 +178,7 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
                 onChange={(e) => setName(e.target.value)}
                 placeholder={t.namePlaceholder}
                 maxLength={128}
-                className="w-full rounded border border-glass-border bg-glass-bg px-3 py-2 text-sm text-text-primary outline-none focus:border-neon-cyan/60"
+                className="liquid-input w-full rounded border border-glass-border px-3 py-2 text-sm text-text-primary outline-none"
               />
             </label>
 
@@ -189,7 +189,7 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
                 placeholder={t.descriptionPlaceholder}
-                className="w-full resize-none rounded border border-glass-border bg-glass-bg px-3 py-2 text-sm text-text-primary outline-none focus:border-neon-cyan/60"
+                className="liquid-input w-full resize-none rounded border border-glass-border px-3 py-2 text-sm text-text-primary outline-none"
               />
             </label>
 
@@ -207,7 +207,7 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
               </div>
               <p className="mb-2 text-[11px] text-text-secondary/70">{t.membersHint}</p>
               {contacts.length === 0 && ownedAgents.length === 0 ? (
-                <p className="rounded border border-dashed border-glass-border px-3 py-3 text-xs text-text-secondary/70">
+                <p className="liquid-empty-state rounded border border-dashed px-3 py-3 text-xs text-text-secondary/70">
                   {t.noContacts}
                 </p>
               ) : (
@@ -235,7 +235,7 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
           <button
             onClick={closeWithMotion}
             disabled={saving}
-            className="rounded border border-glass-border px-4 py-2 text-sm text-text-secondary hover:text-text-primary disabled:opacity-50"
+            className="liquid-action rounded px-4 py-2 text-sm text-text-secondary hover:text-text-primary disabled:opacity-50"
           >
             {t.cancel}
           </button>
@@ -243,7 +243,7 @@ export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalP
             onClick={handleCreate}
             disabled={saving || !identityReady}
             title={!identityReady ? t.createFailed : undefined}
-            className="inline-flex items-center gap-2 rounded border border-neon-cyan/50 bg-neon-cyan/10 px-4 py-2 text-sm text-neon-cyan hover:bg-neon-cyan/20 disabled:opacity-50"
+            className="liquid-action inline-flex items-center gap-2 rounded border border-neon-cyan/50 bg-neon-cyan/10 px-4 py-2 text-sm text-neon-cyan hover:bg-neon-cyan/20 disabled:opacity-50"
           >
             {saving && <Loader2 className="h-4 w-4 animate-spin" />}
             {saving ? t.creating : t.create}

--- a/frontend/src/components/dashboard/CredentialResetDialog.tsx
+++ b/frontend/src/components/dashboard/CredentialResetDialog.tsx
@@ -111,11 +111,11 @@ export default function CredentialResetDialog({
   }, [copied, error]);
 
   return (
-    <div ref={overlayRef} className={`fixed inset-0 z-[110] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`} onMouseDown={(event) => { if (event.target === event.currentTarget) closeWithMotion(); }}>
-      <div ref={panelRef} className="relative w-full max-w-xl rounded-2xl border border-glass-border bg-deep-black-light p-5 shadow-2xl">
+    <div ref={overlayRef} className={`liquid-scrim fixed inset-0 z-[110] flex items-center justify-center p-4 ${closing ? "pointer-events-none" : ""}`} onMouseDown={(event) => { if (event.target === event.currentTarget) closeWithMotion(); }}>
+      <div ref={panelRef} className="liquid-dialog relative w-full max-w-xl rounded-2xl p-5">
         <button
           onClick={closeWithMotion}
-          className="absolute right-4 top-4 rounded-full p-1.5 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
+          className="liquid-action absolute right-4 top-4 rounded-full p-1.5 text-text-secondary transition-colors hover:text-text-primary"
         >
           <X className="h-5 w-5" />
         </button>
@@ -128,7 +128,7 @@ export default function CredentialResetDialog({
           </p>
         </div>
 
-        <div className="rounded-xl border border-glass-border bg-deep-black p-4">
+        <div className="liquid-card rounded-xl p-4">
           <div className="mb-3 flex items-center justify-between">
             <p className="text-[11px] font-bold uppercase tracking-widest text-text-secondary opacity-60">
               {t.prompt}
@@ -137,7 +137,7 @@ export default function CredentialResetDialog({
               ref={copyButtonRef}
               onClick={handleCopyPrompt}
               disabled={!promptText}
-              className="flex items-center gap-2 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-1.5 text-xs font-semibold text-neon-cyan transition-all hover:bg-neon-cyan/20 disabled:opacity-60"
+              className="liquid-action flex items-center gap-2 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-1.5 text-xs font-semibold text-neon-cyan transition-all hover:bg-neon-cyan/20 disabled:opacity-60"
             >
               {copied ? (
                 <>
@@ -154,7 +154,7 @@ export default function CredentialResetDialog({
           </div>
 
           {loading ? (
-            <div className="flex items-center justify-center rounded-lg border border-glass-border bg-deep-black-light p-6 text-neon-cyan">
+            <div className="liquid-tool-surface flex items-center justify-center rounded-lg p-6 text-neon-cyan">
               <Loader2 className="h-5 w-5 animate-spin" />
             </div>
           ) : (
@@ -162,7 +162,7 @@ export default function CredentialResetDialog({
               readOnly
               value={promptText}
               rows={9}
-              className="w-full resize-none rounded-lg border border-glass-border bg-deep-black-light p-3 font-mono text-[11px] leading-relaxed text-text-primary outline-none"
+              className="liquid-input w-full resize-none rounded-lg border p-3 font-mono text-[11px] leading-relaxed text-text-primary outline-none"
             />
           )}
 
@@ -182,7 +182,7 @@ export default function CredentialResetDialog({
         <div className="mt-6 flex items-center justify-center">
           <button
             onClick={closeWithMotion}
-            className="min-h-11 rounded-xl border border-neon-cyan/50 bg-neon-cyan px-5 py-3 text-sm font-bold text-black transition-all hover:bg-neon-cyan/90"
+            className="liquid-action min-h-11 rounded-xl border border-neon-cyan/50 bg-neon-cyan px-5 py-3 text-sm font-bold text-deep-black transition-all hover:bg-neon-cyan/90"
           >
             {t.close}
           </button>

--- a/frontend/src/components/dashboard/DMSettingsModal.tsx
+++ b/frontend/src/components/dashboard/DMSettingsModal.tsx
@@ -102,10 +102,10 @@ export default function DMSettingsModal({
   }, [confirming, error]);
 
   return (
-    <div ref={overlayRef} className={`fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4 ${closing ? "pointer-events-none" : ""}`} onClick={closeWithMotion}>
+    <div ref={overlayRef} className={`liquid-scrim fixed inset-0 z-50 flex items-center justify-center px-4 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`} onClick={closeWithMotion}>
       <div
         ref={panelRef}
-        className="flex max-h-[90vh] w-full max-w-sm flex-col overflow-hidden rounded-xl border border-glass-border bg-deep-black"
+        className="liquid-dialog flex max-h-[90vh] w-full max-w-sm flex-col overflow-hidden rounded-xl border"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="border-b border-glass-border px-6 py-4">
@@ -120,7 +120,7 @@ export default function DMSettingsModal({
           )}
 
           {isOwnAgent ? (
-            <div className="space-y-3">
+            <div className="liquid-card space-y-3 rounded-xl border p-3">
               <div>
                 <p className="mb-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-text-secondary/70">
                   {t.displayName}
@@ -135,7 +135,7 @@ export default function DMSettingsModal({
               </div>
             </div>
           ) : (
-            <div className="space-y-3">
+            <div className="liquid-card space-y-3 rounded-xl border p-3">
               <div>
                 <p className="mb-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-text-secondary/70">
                   {t.displayName}
@@ -158,7 +158,7 @@ export default function DMSettingsModal({
               ref={removeButtonRef}
               onClick={() => void handleRemove()}
               disabled={removing}
-              className="inline-flex items-center gap-1.5 rounded border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-400 hover:bg-red-500/20 disabled:opacity-50"
+              className="liquid-action inline-flex items-center gap-1.5 rounded border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-400 hover:bg-red-500/20 disabled:opacity-50"
             >
               {removing && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
               {confirming
@@ -168,7 +168,7 @@ export default function DMSettingsModal({
           )}
           <button
             onClick={closeWithMotion}
-            className="ml-auto rounded border border-glass-border px-4 py-2 text-sm text-text-secondary hover:text-text-primary"
+            className="liquid-action ml-auto rounded px-4 py-2 text-sm text-text-secondary hover:text-text-primary"
           >
             {t.close}
           </button>

--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -1140,7 +1140,7 @@ export default function DashboardApp() {
     || mobileContactsShowsMain;
   const mainPaneClass = `min-h-0 min-w-0 flex-1 ${mobileShowsMain ? "" : "max-md:hidden"}`;
   return (
-    <div className="fixed inset-0 flex overflow-hidden bg-deep-black max-md:flex-col-reverse">
+    <div className="dashboard-root fixed inset-0 flex overflow-hidden bg-deep-black max-md:flex-col-reverse">
       <Sidebar
         sidebarTabOverride={visibleSidebarTab}
         mobileHideSecondary={mobileHideSecondary}

--- a/frontend/src/components/dashboard/DashboardMessagePaneSkeleton.tsx
+++ b/frontend/src/components/dashboard/DashboardMessagePaneSkeleton.tsx
@@ -31,8 +31,8 @@ export default function DashboardMessagePaneSkeleton({
   roundedClassName = "rounded-2xl",
 }: DashboardMessagePaneSkeletonProps) {
   return (
-    <div className="flex min-w-0 flex-1 flex-col bg-deep-black">
-      <div className={`border-b border-glass-border ${headerPaddingClassName}`}>
+    <div className="dashboard-main flex min-w-0 flex-1 flex-col">
+      <div className={`liquid-toolbar border-b border-glass-border ${headerPaddingClassName}`}>
         <div className="flex items-center gap-2">
           {headerIcon ? (
             <div className="flex h-8 w-8 items-center justify-center rounded-lg border border-neon-cyan/20 bg-neon-cyan/5 text-neon-cyan/70">
@@ -51,7 +51,7 @@ export default function DashboardMessagePaneSkeleton({
           const isRight = idx % 2 === 1;
           return (
             <div key={idx} className={`flex ${isRight ? "justify-end" : "justify-start"}`}>
-              <div className={`w-full ${messageMaxWidthClassName} ${roundedClassName} border border-glass-border bg-deep-black-light p-4`}>
+              <div className={`liquid-card w-full ${messageMaxWidthClassName} ${roundedClassName} border border-glass-border p-4`}>
                 {!isRight && <SkeletonBlock className="h-3 w-20" />}
                 <SkeletonBlock className="mt-3 h-3 w-5/6 bg-glass-border/40" />
                 <SkeletonBlock className="mt-2 h-3 w-2/3 bg-glass-border/40" />
@@ -62,9 +62,9 @@ export default function DashboardMessagePaneSkeleton({
         })}
       </div>
 
-      <div className={`border-t border-glass-border ${composerPaddingClassName}`}>
+      <div className={`liquid-toolbar border-t border-glass-border ${composerPaddingClassName}`}>
         <div className="flex items-end gap-2">
-          <div className={`flex-1 ${roundedClassName} border border-glass-border bg-deep-black-light px-4 py-3`}>
+          <div className={`liquid-composer flex-1 ${roundedClassName} border border-glass-border px-4 py-3`}>
             <SkeletonBlock className="h-4 w-1/3" />
           </div>
           {headerIcon ? (

--- a/frontend/src/components/dashboard/DashboardMultiSelect.tsx
+++ b/frontend/src/components/dashboard/DashboardMultiSelect.tsx
@@ -43,7 +43,7 @@ const toneClasses = {
   cyan: "bg-neon-cyan/10 text-neon-cyan",
   green: "bg-neon-green/10 text-neon-green",
   purple: "bg-neon-purple/10 text-neon-purple",
-  zinc: "bg-zinc-700/50 text-zinc-300",
+  zinc: "bg-glass-bg/70 text-text-secondary",
 };
 
 export default function DashboardMultiSelect({
@@ -273,7 +273,7 @@ export default function DashboardMultiSelect({
         type="button"
         disabled={disabled}
         onClick={() => setOpen((next) => !next)}
-        className="flex min-h-11 w-full items-center justify-between gap-3 rounded-lg border border-glass-border bg-glass-bg px-3 py-2 text-left text-sm text-text-primary transition-colors hover:border-neon-cyan/30 disabled:cursor-not-allowed disabled:opacity-50"
+        className="liquid-input flex min-h-11 w-full items-center justify-between gap-3 rounded-lg border border-glass-border px-3 py-2 text-left text-sm text-text-primary transition-colors hover:border-neon-cyan/30 disabled:cursor-not-allowed disabled:opacity-50"
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-controls={`${id}-panel`}
@@ -298,7 +298,7 @@ export default function DashboardMultiSelect({
               {selectedOptions.length > 3 ? (
                 <span
                   ref={overflowChipRef}
-                  className="inline-block origin-center rounded border border-glass-border bg-deep-black-light px-2 py-0.5 text-xs text-text-secondary"
+                  className="inline-block origin-center rounded border border-glass-border bg-glass-bg/70 px-2 py-0.5 text-xs text-text-secondary"
                 >
                   +{selectedOptions.length - 3}
                 </span>
@@ -318,10 +318,10 @@ export default function DashboardMultiSelect({
         <div
           ref={panelRef}
           id={`${id}-panel`}
-          className={`absolute left-0 right-0 z-40 mt-2 overflow-hidden rounded-xl border border-glass-border bg-deep-black-light shadow-2xl shadow-black/40 ${panelClassName}`}
+          className={`liquid-menu absolute left-0 right-0 z-40 mt-2 overflow-hidden rounded-xl border border-glass-border ${panelClassName}`}
         >
           <div className="border-b border-glass-border p-2">
-            <div className="flex items-center gap-2 rounded-lg border border-glass-border bg-deep-black px-2.5">
+            <div className="liquid-input flex items-center gap-2 rounded-lg border border-glass-border px-2.5">
               <Search className="h-3.5 w-3.5 text-text-secondary/70" />
               <input
                 ref={searchRef}
@@ -364,8 +364,8 @@ export default function DashboardMultiSelect({
                         aria-selected={selected}
                         onClick={() => toggle(option.value)}
                         data-dashboard-multi-option
-                        className={`flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors ${
-                          selected ? "bg-neon-cyan/10 text-neon-cyan" : "text-text-primary hover:bg-glass-bg"
+                        className={`liquid-list-row flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors ${
+                          selected ? "!bg-neon-cyan/10 text-neon-cyan" : "text-text-primary hover:bg-glass-bg"
                         }`}
                       >
                         <span
@@ -376,7 +376,7 @@ export default function DashboardMultiSelect({
                           className={`flex h-4 w-4 shrink-0 origin-center items-center justify-center rounded border ${
                             selected
                               ? "border-neon-cyan bg-neon-cyan text-deep-black"
-                              : "border-glass-border bg-deep-black-light"
+                              : "border-glass-border bg-glass-bg/70"
                           }`}
                         >
                           {selected ? <Check className="h-3 w-3" /> : null}

--- a/frontend/src/components/dashboard/DashboardSelect.tsx
+++ b/frontend/src/components/dashboard/DashboardSelect.tsx
@@ -202,7 +202,7 @@ export default function DashboardSelect({
         type="button"
         disabled={disabled}
         onClick={() => setOpen((next) => !next)}
-        className={`flex min-h-10 w-full items-center justify-between gap-3 rounded-xl border border-glass-border bg-deep-black px-3 text-left text-sm text-text-primary transition-colors hover:border-neon-cyan/45 focus:border-neon-cyan focus:outline-none focus:ring-1 focus:ring-neon-cyan/50 disabled:cursor-not-allowed disabled:opacity-50 ${buttonClassName}`}
+        className={`liquid-input flex min-h-10 w-full items-center justify-between gap-3 rounded-xl border border-glass-border px-3 text-left text-sm text-text-primary transition-colors hover:border-neon-cyan/45 focus:border-neon-cyan focus:outline-none focus:ring-1 focus:ring-neon-cyan/50 disabled:cursor-not-allowed disabled:opacity-50 ${buttonClassName}`}
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-controls={`${id}-panel`}
@@ -228,7 +228,7 @@ export default function DashboardSelect({
           ref={panelRef}
           id={`${id}-panel`}
           role="listbox"
-          className={`absolute left-0 right-0 z-50 mt-2 max-h-64 overflow-y-auto rounded-xl border border-glass-border bg-deep-black-light py-1 shadow-2xl shadow-black/40 ${panelClassName}`}
+          className={`liquid-menu absolute left-0 right-0 z-50 mt-2 max-h-64 overflow-y-auto rounded-xl border border-glass-border py-1 ${panelClassName}`}
         >
           {options.length === 0 ? (
             <p className="px-3 py-3 text-xs text-text-secondary/70">{placeholder}</p>
@@ -249,8 +249,8 @@ export default function DashboardSelect({
                     closeAfterSelection(shouldDelayClose);
                   }}
                   data-dashboard-select-option
-                  className={`flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-45 ${
-                    isSelected ? "bg-neon-cyan/10 text-neon-cyan" : "text-text-primary hover:bg-glass-bg"
+                  className={`liquid-list-row flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-45 ${
+                    isSelected ? "!bg-neon-cyan/10 text-neon-cyan" : "text-text-primary hover:bg-glass-bg"
                   }`}
                 >
                   <span

--- a/frontend/src/components/dashboard/DashboardShellSkeleton.tsx
+++ b/frontend/src/components/dashboard/DashboardShellSkeleton.tsx
@@ -40,7 +40,7 @@ function SkeletonRoomList() {
   return (
     <div className="space-y-2 p-3">
       {Array.from({ length: 7 }).map((_, idx) => (
-        <div key={idx} className="rounded-lg border border-glass-border bg-deep-black-light p-3">
+        <div key={idx} className="liquid-card rounded-lg border border-glass-border p-3">
           <SkeletonLine className="h-3 w-2/3" />
           <SkeletonLine className="mt-2 h-2.5 w-1/2 bg-glass-border/40" />
         </div>
@@ -52,7 +52,7 @@ function SkeletonRoomList() {
 function SecondaryPanelSkeleton({ variant }: { variant: ShellSkeletonVariant }) {
   if (variant === "messages") {
     return (
-      <div className="flex h-full w-[200px] shrink-0 flex-col border-r border-glass-border bg-deep-black/50">
+      <div className="liquid-panel flex h-full w-[200px] shrink-0 flex-col border-r border-glass-border">
         <div className="flex h-14 items-center justify-between border-b border-glass-border px-3">
           <span className="text-[11px] font-semibold uppercase tracking-[0.16em] text-text-secondary/70">分组</span>
           <SkeletonLine className="h-3.5 w-3.5 bg-glass-border/50" />
@@ -113,9 +113,9 @@ export default function DashboardShellSkeleton({ variant: variantProp }: { varia
   ] as const;
 
   return (
-    <div className="relative flex h-screen overflow-hidden bg-deep-black">
-      <div className="flex h-full bg-deep-black-light">
-        <div className="flex h-full w-16 min-w-[64px] flex-col items-center border-r border-glass-border bg-deep-black py-3">
+    <div className="dashboard-root relative flex h-screen overflow-hidden">
+      <div className="liquid-panel flex h-full">
+        <div className="liquid-rail flex h-full w-16 min-w-[64px] flex-col items-center border-r border-glass-border py-3">
           <div className="mb-3 flex h-11 w-11 items-center justify-center">
             <BotCordLoader label="Loading BotCord" size="sm" showLabel={false} />
           </div>

--- a/frontend/src/components/dashboard/DashboardTabSkeleton.tsx
+++ b/frontend/src/components/dashboard/DashboardTabSkeleton.tsx
@@ -43,7 +43,7 @@ function CardGridSkeleton({ rows = 6, statCards = false }: { rows?: number; stat
   return (
     <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
       {Array.from({ length: rows }).map((_, idx) => (
-        <div key={idx} className="rounded-2xl border border-glass-border bg-deep-black-light p-4">
+        <div key={idx} className="liquid-card rounded-2xl border border-glass-border p-4">
           <div className="flex items-start gap-3">
             <SkeletonBlock className="h-10 w-10 shrink-0 rounded-xl" />
             <div className="min-w-0 flex-1">
@@ -71,7 +71,7 @@ function ExploreGridSkeleton() {
   return (
     <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
       {Array.from({ length: 10 }).map((_, idx) => (
-        <div key={idx} className="rounded-xl border border-glass-border bg-deep-black-light p-3">
+        <div key={idx} className="liquid-card rounded-xl border border-glass-border p-3">
           <SkeletonBlock className="h-11 w-11 rounded-xl" />
           <SkeletonBlock className="mt-3 h-3.5 w-3/4" />
           <SkeletonBlock className="mt-2 h-2.5 w-1/2 bg-glass-border/40" />
@@ -86,7 +86,7 @@ function ExploreGridSkeleton() {
 function WalletSkeleton() {
   return (
     <div className="mx-auto w-full max-w-2xl space-y-6">
-      <div className="rounded-2xl border border-glass-border bg-glass-bg p-6">
+      <div className="liquid-card rounded-2xl border border-glass-border p-6">
         <SkeletonBlock className="h-3 w-28" />
         <SkeletonBlock className="mt-4 h-10 w-56" />
         <div className="mt-5 grid grid-cols-2 gap-4">
@@ -99,7 +99,7 @@ function WalletSkeleton() {
           <SkeletonBlock key={idx} className="h-24 rounded-xl bg-glass-border/40" />
         ))}
       </div>
-      <div className="rounded-2xl border border-glass-border bg-glass-bg p-5">
+      <div className="liquid-card rounded-2xl border border-glass-border p-5">
         <SkeletonBlock className="h-4 w-36" />
         <SkeletonBlock className="mt-2 h-3 w-52 bg-glass-border/40" />
         <div className="mt-4 space-y-3">
@@ -124,7 +124,7 @@ function ActivitySkeleton() {
         <SkeletonBlock className="mb-3 h-4 w-32" />
         <div className="space-y-2">
           {Array.from({ length: 7 }).map((_, idx) => (
-            <div key={idx} className="flex gap-3 rounded-xl border border-glass-border bg-glass-bg p-3">
+            <div key={idx} className="liquid-card flex gap-3 rounded-xl border border-glass-border p-3">
               <SkeletonBlock className="h-8 w-8 shrink-0 rounded-lg" />
               <div className="min-w-0 flex-1">
                 <SkeletonBlock className="h-3.5 w-3/5" />
@@ -171,7 +171,7 @@ export default function DashboardTabSkeleton({
   }
 
   return (
-    <div className="flex h-full flex-col bg-deep-black">
+    <div className="dashboard-main flex h-full flex-col">
       <HeaderSkeleton compact={compactHeader} />
       <div className={variant === "explore" || variant === "home" || variant === "bots" ? "flex-1 overflow-y-auto px-6 py-6" : "flex-1 overflow-y-auto px-5 py-4"}>
         <DashboardMainSkeleton variant={variant} />

--- a/frontend/src/components/dashboard/DeviceDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/DeviceDetailDrawer.tsx
@@ -196,21 +196,21 @@ function DeviceDetailDrawer() {
       {/* Backdrop */}
       <div
         ref={overlayRef}
-        className="fixed inset-0 z-40 bg-black/40 backdrop-blur-[2px] transition-opacity"
+        className="liquid-scrim fixed inset-0 z-40 backdrop-blur-[2px] transition-opacity"
         onClick={closeDrawer}
         aria-hidden
       />
       {/* Drawer */}
       <aside
         ref={panelRef}
-        className="fixed inset-y-0 right-0 z-50 flex w-full max-w-md flex-col border-l border-glass-border bg-deep-black-light shadow-2xl shadow-black/50"
+        className="liquid-drawer fixed inset-y-0 right-0 z-50 flex w-full max-w-md flex-col border-l border-glass-border"
         role="dialog"
         aria-modal="true"
         aria-label="设备详情"
       >
         {/* Drawer header */}
-        <div className="flex items-center gap-3 border-b border-glass-border px-5 py-4" data-overlay-section>
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-glass-border bg-glass-bg/60 text-text-secondary">
+        <div className="liquid-toolbar flex items-center gap-3 border-b border-glass-border px-5 py-4" data-overlay-section>
+          <div className="liquid-tool-surface flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-glass-border text-text-secondary">
             <DeviceIcon className="h-5 w-5" />
           </div>
           <div className="min-w-0 flex-1">
@@ -241,7 +241,7 @@ function DeviceDetailDrawer() {
           disabled={isRefreshing}
           title="刷新"
           aria-label="刷新设备状态"
-          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-secondary/70 transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-40"
+          className="liquid-action flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-secondary/70 transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-40"
         >
           <RefreshCw className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`} />
         </button>
@@ -249,7 +249,7 @@ function DeviceDetailDrawer() {
           onClick={closeDrawer}
           title="关闭"
           aria-label="关闭"
-          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-secondary/70 transition-colors hover:bg-glass-bg hover:text-text-primary"
+          className="liquid-action flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-secondary/70 transition-colors hover:bg-glass-bg hover:text-text-primary"
         >
           <X className="h-4 w-4" />
         </button>
@@ -266,7 +266,7 @@ function DeviceDetailDrawer() {
         />
       ) : (<>
       {/* Hosted bots */}
-      <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
+      <section className="liquid-card rounded-2xl border border-glass-border p-4">
         <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-wider text-text-secondary/70">
           托管的 Bots · {hostedBots.length}
         </h3>
@@ -278,7 +278,7 @@ function DeviceDetailDrawer() {
               <button
                 key={bot.agent_id}
                 onClick={() => setViewingBotId(bot.agent_id)}
-                className="flex items-center gap-2.5 rounded-lg border border-glass-border bg-glass-bg/60 px-2 py-1.5 text-left transition-colors hover:border-neon-cyan/40 hover:bg-neon-cyan/5"
+                className="liquid-list-row flex items-center gap-2.5 rounded-lg border border-glass-border px-2 py-1.5 text-left transition-colors hover:border-neon-cyan/40 hover:bg-neon-cyan/5"
               >
                 <BotAvatar
                   agentId={bot.agent_id}
@@ -300,7 +300,7 @@ function DeviceDetailDrawer() {
       </section>
 
       {/* Device info */}
-      <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
+      <section className="liquid-card rounded-2xl border border-glass-border p-4">
         <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-wider text-text-secondary/70">
           设备信息
         </h3>
@@ -312,7 +312,7 @@ function DeviceDetailDrawer() {
                 onClick={() => void handleRefresh()}
                 disabled={isRefreshing}
                 title="检查连接"
-                className="flex h-6 w-6 items-center justify-center rounded text-text-secondary/55 transition-colors hover:bg-glass-bg hover:text-text-secondary disabled:opacity-40"
+                className="liquid-action flex h-6 w-6 items-center justify-center rounded text-text-secondary/55 transition-colors hover:bg-glass-bg hover:text-text-secondary disabled:opacity-40"
               >
                 <RefreshCw className={`h-3 w-3 ${isRefreshing ? "animate-spin" : ""}`} />
               </button>
@@ -340,7 +340,7 @@ function DeviceDetailDrawer() {
         </div>
       </section>
 
-      <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
+      <section className="liquid-card rounded-2xl border border-glass-border p-4">
         <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-wider text-text-secondary/70">
           {isCloud ? "云设备操作" : "设备操作"}
         </h3>
@@ -353,7 +353,7 @@ function DeviceDetailDrawer() {
           <button
             onClick={() => void handleRestartDevice()}
             disabled={restartingId === device.id || (!isCloud && !online)}
-            className="inline-flex items-center gap-2 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-2 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/15 disabled:opacity-50"
+            className="liquid-action inline-flex items-center gap-2 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-2 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/15 disabled:opacity-50"
           >
             {restartingId === device.id ? (
               <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -375,7 +375,7 @@ function DeviceDetailDrawer() {
       </section>
 
       {/* Rename */}
-      <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
+      <section className="liquid-card rounded-2xl border border-glass-border p-4">
         <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-wider text-text-secondary/70">
           设备名称
         </h3>
@@ -391,12 +391,12 @@ function DeviceDetailDrawer() {
             }}
             maxLength={64}
             placeholder={device.id.slice(0, 18)}
-            className="flex-1 rounded-lg border border-glass-border bg-glass-bg/30 px-3 py-2 text-sm text-text-primary placeholder-text-secondary/40 outline-none focus:border-neon-cyan/40"
+            className="liquid-input flex-1 rounded-lg border border-glass-border px-3 py-2 text-sm text-text-primary placeholder-text-secondary/40 outline-none focus:border-neon-cyan/40"
           />
           <button
             disabled={!editingName.trim() || editingName.trim() === device.label}
             onClick={() => void handleRename()}
-            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-glass-border bg-glass-bg/30 text-text-secondary transition-colors hover:border-neon-cyan/40 hover:text-neon-cyan disabled:opacity-40"
+            className="liquid-action flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-glass-border text-text-secondary transition-colors hover:border-neon-cyan/40 hover:text-neon-cyan disabled:opacity-40"
           >
             {nameSaved ? <Check className="h-4 w-4 text-neon-green" /> : <Check className="h-4 w-4" />}
           </button>
@@ -405,7 +405,7 @@ function DeviceDetailDrawer() {
 
       {/* Restart command (collapsible) */}
       {!isCloud ? (
-      <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
+      <section className="liquid-card rounded-2xl border border-glass-border p-4">
         <button
           onClick={() => setShowInstall((v) => !v)}
           className="flex w-full items-center justify-between"
@@ -437,7 +437,7 @@ function DeviceDetailDrawer() {
 
       {/* Diagnostic log (collapsible) */}
       {!isCloud ? (
-      <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
+      <section className="liquid-card rounded-2xl border border-glass-border p-4">
         <button
           onClick={() => setShowLogs((v) => !v)}
           className="flex w-full items-center justify-between"
@@ -474,7 +474,7 @@ function DeviceDetailDrawer() {
                   onClick={() => setForwardLogs(true)}
                   title="转发到聊天"
                   aria-label="转发日志到聊天"
-                  className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-neon-green/80 transition-colors hover:bg-neon-green/10 hover:text-neon-green"
+                className="liquid-action flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-neon-green/80 transition-colors hover:bg-neon-green/10 hover:text-neon-green"
                 >
                   <Send className="h-3.5 w-3.5" />
                 </button>
@@ -486,7 +486,7 @@ function DeviceDetailDrawer() {
                   )}
                   title="下载日志文件"
                   aria-label="下载日志文件"
-                  className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-neon-green/80 transition-colors hover:bg-neon-green/10 hover:text-neon-green"
+                  className="liquid-action flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-neon-green/80 transition-colors hover:bg-neon-green/10 hover:text-neon-green"
                 >
                   <Download className="h-3.5 w-3.5" />
                 </button>
@@ -545,14 +545,14 @@ function DeviceDetailDrawer() {
             <div className="flex flex-wrap items-center justify-end gap-2">
               <button
                 onClick={() => setConfirmRemove(false)}
-                className="rounded-lg border border-glass-border px-3 py-1.5 text-[11px] text-text-secondary transition-colors hover:bg-glass-bg"
+                className="liquid-action rounded-lg border border-glass-border px-3 py-1.5 text-[11px] text-text-secondary transition-colors hover:bg-glass-bg"
               >
                 取消
               </button>
               <button
                 onClick={() => void handleRemoveDevice()}
                 disabled={removingId === device.id}
-                className="inline-flex items-center gap-1.5 rounded-lg border border-red-500/60 bg-red-500/15 px-3 py-1.5 text-[11px] font-medium text-red-200 transition-colors hover:bg-red-500/25"
+                className="liquid-action inline-flex items-center gap-1.5 rounded-lg border border-red-500/60 bg-red-500/15 px-3 py-1.5 text-[11px] font-medium text-red-200 transition-colors hover:bg-red-500/25"
               >
                 {removingId === device.id ? <Loader2 className="h-3 w-3 animate-spin" /> : null}
                 {removingId === device.id ? "移除中..." : "移除设备"}
@@ -634,7 +634,7 @@ function BotDetailNested({
         ) : null}
       </div>
 
-      <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4 text-xs text-text-secondary/70">
+      <section className="liquid-card rounded-2xl border border-glass-border p-4 text-xs text-text-secondary/70">
         此处只展示真实设备绑定关系。Bot 对话、策略和自主任务请在 Bot 详情中管理。
       </section>
     </div>
@@ -643,7 +643,7 @@ function BotDetailNested({
 
 function Stat({ label, value, delta }: { label: string; value: number | string; delta?: string }) {
   return (
-    <div className="rounded-lg bg-glass-bg/50 px-2 py-1.5">
+    <div className="liquid-tool-surface rounded-lg px-2 py-1.5">
       <div className="text-[9px] uppercase tracking-wider text-text-secondary/55">{label}</div>
       <div className="flex items-baseline justify-center gap-1">
         <span className="text-sm font-semibold text-text-primary">{value}</span>

--- a/frontend/src/components/dashboard/DiscoverRoomList.tsx
+++ b/frontend/src/components/dashboard/DiscoverRoomList.tsx
@@ -64,7 +64,7 @@ export default function DiscoverRoomList() {
         return (
           <div
             key={room.room_id}
-            className="border-l-2 border-transparent px-4 py-2.5 hover:bg-glass-bg"
+            className="liquid-list-row border-l-2 border-transparent px-4 py-2.5"
           >
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-1.5 min-w-0">

--- a/frontend/src/components/dashboard/DocumentPreviewPane.tsx
+++ b/frontend/src/components/dashboard/DocumentPreviewPane.tsx
@@ -355,7 +355,7 @@ export default function DocumentPreviewPane({ attachment, onClose }: DocumentPre
     <aside
       ref={paneRef}
       style={paneStyle}
-      className="relative flex h-full w-[var(--document-preview-pane-width)] max-w-[78vw] min-w-[360px] shrink-0 flex-col border-l border-glass-border bg-deep-black shadow-2xl shadow-black/40 will-change-transform max-md:absolute max-md:inset-0 max-md:z-40 max-md:w-full max-md:max-w-none max-md:min-w-0"
+      className="liquid-drawer relative flex h-full w-[var(--document-preview-pane-width)] max-w-[78vw] min-w-[360px] shrink-0 flex-col border-l will-change-transform max-md:absolute max-md:inset-0 max-md:z-40 max-md:w-full max-md:max-w-none max-md:min-w-0"
     >
       {resizing && (
         <div className="fixed inset-0 z-[80] cursor-col-resize max-md:hidden" aria-hidden="true" />
@@ -376,7 +376,7 @@ export default function DocumentPreviewPane({ attachment, onClose }: DocumentPre
       >
         <span className="h-12 w-px rounded-full bg-text-secondary/40" />
       </div>
-      <div className="flex min-h-14 items-center gap-2 border-b border-glass-border px-3">
+      <div className="liquid-toolbar flex min-h-14 items-center gap-2 border-b border-glass-border px-3">
         <FileText className="h-4 w-4 shrink-0 text-neon-cyan" />
         <div className="min-w-0 flex-1">
           <div className="truncate text-sm font-medium text-text-primary">{title}</div>
@@ -389,7 +389,7 @@ export default function DocumentPreviewPane({ attachment, onClose }: DocumentPre
           target="_blank"
           rel="noopener noreferrer"
           download={title}
-          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-white/10 hover:text-text-primary"
+          className="liquid-action inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-secondary transition-colors hover:text-text-primary"
           aria-label="Download attachment"
           title="Download"
         >
@@ -398,14 +398,14 @@ export default function DocumentPreviewPane({ attachment, onClose }: DocumentPre
         <button
           type="button"
           onClick={handleClose}
-          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-white/10 hover:text-text-primary"
+          className="liquid-action inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-secondary transition-colors hover:text-text-primary"
           aria-label="Close preview"
           title="Close preview"
         >
           <X className="h-4 w-4" />
         </button>
       </div>
-      <div className={`min-h-0 flex-1 overflow-auto bg-zinc-950/30 ${resizing ? "pointer-events-none" : ""}`}>
+      <div className={`liquid-tool-surface min-h-0 flex-1 overflow-auto ${resizing ? "pointer-events-none" : ""}`}>
         {renderedBody}
       </div>
     </aside>

--- a/frontend/src/components/dashboard/ExploreEntityCard.tsx
+++ b/frontend/src/components/dashboard/ExploreEntityCard.tsx
@@ -103,7 +103,7 @@ export default function ExploreEntityCard(props: ExploreEntityCardProps) {
         tabIndex={0}
         onClick={() => props.onRoomOpen?.(room)}
         onKeyDown={(event) => handleKeyActivate(event, () => props.onRoomOpen?.(room))}
-        className={`group overflow-hidden rounded-xl border border-glass-border bg-deep-black-light text-left transition-all hover:border-neon-cyan/60 hover:shadow-md hover:shadow-neon-cyan/10 ${className}`}
+        className={`liquid-card group overflow-hidden rounded-xl border border-glass-border text-left transition-all hover:border-neon-cyan/60 hover:shadow-md hover:shadow-neon-cyan/10 ${className}`}
       >
         <div
           className="relative h-14 w-full"
@@ -115,14 +115,14 @@ export default function ExploreEntityCard(props: ExploreEntityCardProps) {
         >
           <div className="absolute left-3 top-2 flex items-center gap-2">
             <div
-              className="flex h-7 w-7 items-center justify-center rounded-md text-[11px] font-bold text-white/90 backdrop-blur-sm"
+              className="flex h-7 w-7 items-center justify-center rounded-md text-[11px] font-bold text-text-primary backdrop-blur-sm"
               style={{ background: theme.accentDim, boxShadow: `0 0 0 1px ${theme.accent}55` }}
             >
               {roomInitials}
             </div>
           </div>
           <span
-            className="absolute right-2 top-2 rounded-full bg-black/40 px-2 py-0.5 text-[10px] font-medium text-white/90 backdrop-blur-sm"
+            className="absolute right-2 top-2 rounded-full border border-glass-border bg-glass-bg/70 px-2 py-0.5 text-[10px] font-medium text-text-primary backdrop-blur-sm"
             style={{ boxShadow: `0 0 0 1px ${theme.accent}55` }}
           >
             {room.member_count} {memberWord}
@@ -170,7 +170,7 @@ export default function ExploreEntityCard(props: ExploreEntityCardProps) {
         tabIndex={0}
         onClick={() => props.onAgentOpen?.(agent)}
         onKeyDown={(event) => handleKeyActivate(event, () => props.onAgentOpen?.(agent))}
-        className={`group rounded-xl border border-glass-border bg-deep-black-light p-3 text-left transition-all hover:border-neon-purple/60 hover:bg-glass-bg ${className}`}
+        className={`liquid-card group rounded-xl border border-glass-border p-3 text-left transition-all hover:border-neon-purple/60 hover:bg-glass-bg ${className}`}
       >
         <div className="flex items-start gap-2.5">
           <div className="flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-full border border-neon-purple/30 bg-neon-purple/10 text-xs font-semibold text-neon-purple">
@@ -188,7 +188,7 @@ export default function ExploreEntityCard(props: ExploreEntityCardProps) {
                 className={`inline-flex shrink-0 items-center gap-1 rounded-full border px-1.5 py-0.5 text-[9px] font-medium leading-3 ${
                   online
                     ? "border-emerald-400/25 bg-emerald-400/10 text-emerald-300"
-                    : "border-white/10 bg-white/5 text-text-secondary/60"
+                    : "border-glass-border bg-glass-bg/60 text-text-secondary/60"
                 }`}
               >
                 <PresenceDot agentId={agent.agent_id} fallback={agent.online} size="xs" />
@@ -233,7 +233,7 @@ export default function ExploreEntityCard(props: ExploreEntityCardProps) {
       tabIndex={0}
       onClick={() => props.onHumanOpen?.(human)}
       onKeyDown={(event) => handleKeyActivate(event, () => props.onHumanOpen?.(human))}
-      className={`group rounded-xl border border-glass-border bg-deep-black-light p-3 text-left transition-all hover:border-neon-green/60 hover:bg-glass-bg ${className}`}
+      className={`liquid-card group rounded-xl border border-glass-border p-3 text-left transition-all hover:border-neon-green/60 hover:bg-glass-bg ${className}`}
     >
       <div className="flex items-start gap-2.5">
         {human.avatar_url ? (

--- a/frontend/src/components/dashboard/ForwardModal.tsx
+++ b/frontend/src/components/dashboard/ForwardModal.tsx
@@ -263,7 +263,7 @@ export default function ForwardModal({ quoteText, sourceFile, onClose }: Forward
   return (
     <div
       ref={overlayRef}
-      className={`fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`}
+      className={`liquid-scrim fixed inset-0 z-50 flex items-center justify-center backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`}
       onClick={(e) => {
         e.stopPropagation();
         if (e.target === e.currentTarget) closeModal();
@@ -273,15 +273,15 @@ export default function ForwardModal({ quoteText, sourceFile, onClose }: Forward
         ref={panelRef}
         role="dialog"
         aria-modal="true"
-        className="w-full max-w-sm rounded-xl border border-zinc-700 bg-zinc-900 shadow-2xl"
+        className="liquid-dialog w-full max-w-sm rounded-xl border"
       >
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-zinc-800 px-4 py-3">
-          <span className="text-sm font-medium text-zinc-200">转发消息</span>
+        <div className="flex items-center justify-between border-b border-glass-border px-4 py-3">
+          <span className="text-sm font-medium text-text-primary">转发消息</span>
           <button
             type="button"
             onClick={closeModal}
-            className="text-zinc-500 hover:text-zinc-300 transition-colors"
+            className="liquid-action rounded-md p-1 text-text-secondary transition-colors hover:text-text-primary"
             aria-label="Close forward modal"
           >
             <X className="h-4 w-4" />
@@ -289,19 +289,19 @@ export default function ForwardModal({ quoteText, sourceFile, onClose }: Forward
         </div>
 
         {/* Quote / file preview */}
-        <div className="mx-4 mt-3 rounded-lg border border-zinc-700 bg-zinc-800/60 px-3 py-2">
+        <div className="liquid-card mx-4 mt-3 rounded-lg border px-3 py-2">
           {sourceFile ? (
-            <div className="flex items-center gap-2 text-zinc-300">
+            <div className="flex items-center gap-2 text-text-primary">
               <FileArchive className="h-4 w-4 shrink-0 text-cyan-400" />
               <div className="min-w-0">
                 <p className="truncate text-xs font-medium">{sourceFile.filename}</p>
                 {sourceFile.sizeBytes != null && (
-                  <p className="text-[10px] text-zinc-500">{sourceFile.sizeBytes} bytes</p>
+                  <p className="text-[10px] text-text-secondary">{sourceFile.sizeBytes} bytes</p>
                 )}
               </div>
             </div>
           ) : (
-            <pre className="max-h-24 overflow-y-auto whitespace-pre-wrap font-mono text-[11px] text-zinc-400 leading-relaxed">
+            <pre className="max-h-24 overflow-y-auto whitespace-pre-wrap font-mono text-[11px] leading-relaxed text-text-secondary">
               {quoteText}
             </pre>
           )}
@@ -339,7 +339,7 @@ export default function ForwardModal({ quoteText, sourceFile, onClose }: Forward
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-between border-t border-zinc-800 px-4 py-3">
+        <div className="flex items-center justify-between border-t border-glass-border px-4 py-3">
           {error && <p className="text-[11px] text-red-400">{error}</p>}
           {done && (
             <p ref={statusRef} className="flex origin-center items-center gap-1.5 text-[11px] text-emerald-400">
@@ -348,7 +348,7 @@ export default function ForwardModal({ quoteText, sourceFile, onClose }: Forward
             </p>
           )}
           {!error && !done && (
-            <span className="text-[11px] text-zinc-500">
+            <span className="text-[11px] text-text-secondary">
               {selected.size > 0 ? `已选 ${selected.size} 个` : "选择发送目标"}
             </span>
           )}
@@ -356,7 +356,7 @@ export default function ForwardModal({ quoteText, sourceFile, onClose }: Forward
             type="button"
             disabled={selected.size === 0 || sending || done}
             onClick={handleSend}
-            className="ml-auto flex items-center gap-1.5 rounded-lg bg-cyan-500/20 px-3 py-1.5 text-xs font-medium text-cyan-400 hover:bg-cyan-500/30 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            className="liquid-action ml-auto flex items-center gap-1.5 rounded-lg border border-neon-cyan/35 bg-neon-cyan/15 px-3 py-1.5 text-xs font-medium text-neon-cyan hover:bg-neon-cyan/25 disabled:cursor-not-allowed disabled:opacity-40 transition-colors"
           >
             {sending && <Loader2 className="h-3 w-3 animate-spin" />}
             发送

--- a/frontend/src/components/dashboard/FriendInviteModal.tsx
+++ b/frontend/src/components/dashboard/FriendInviteModal.tsx
@@ -93,10 +93,10 @@ export default function FriendInviteModal({ onClose }: { onClose: () => void }) 
   }, [copied, error]);
 
   return (
-    <div ref={overlayRef} className={`fixed inset-0 z-50 flex items-center justify-center bg-black/60 ${closing ? "pointer-events-none" : ""}`} onClick={closeWithMotion}>
+    <div ref={overlayRef} className={`liquid-scrim fixed inset-0 z-50 flex items-center justify-center p-4 ${closing ? "pointer-events-none" : ""}`} onClick={closeWithMotion}>
       <div
         ref={panelRef}
-        className="mx-4 w-full max-w-md rounded-xl border border-glass-border bg-deep-black p-6"
+        className="liquid-dialog w-full max-w-md rounded-2xl p-6"
         onClick={(event) => event.stopPropagation()}
       >
         <h2 className="mb-1 text-lg font-semibold text-text-primary">{t.title}</h2>
@@ -114,14 +114,14 @@ export default function FriendInviteModal({ onClose }: { onClose: () => void }) 
           <div className="flex justify-end gap-2">
             <button
               onClick={closeWithMotion}
-              className="rounded border border-glass-border px-4 py-2 text-sm text-text-secondary hover:text-text-primary"
+              className="liquid-action rounded-lg px-4 py-2 text-sm text-text-secondary hover:text-text-primary"
             >
               {tc.cancel}
             </button>
             <button
               onClick={handleCreate}
               disabled={loading}
-              className="inline-flex items-center gap-2 rounded border border-neon-cyan/50 bg-neon-cyan/10 px-4 py-2 text-sm text-neon-cyan hover:bg-neon-cyan/20 disabled:opacity-50"
+              className="liquid-action inline-flex items-center gap-2 rounded-lg border border-neon-cyan/50 bg-neon-cyan/10 px-4 py-2 text-sm text-neon-cyan hover:bg-neon-cyan/20 disabled:opacity-50"
             >
               {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
               {loading ? t.creating : t.createInvite}
@@ -137,7 +137,7 @@ export default function FriendInviteModal({ onClose }: { onClose: () => void }) 
                 <button
                   ref={copyButtonRef}
                   onClick={() => copyField("prompt")}
-                  className="shrink-0 rounded border border-neon-cyan/50 bg-neon-cyan/10 px-3 py-1 text-xs text-neon-cyan hover:bg-neon-cyan/20"
+                  className="liquid-action shrink-0 rounded-lg border border-neon-cyan/50 bg-neon-cyan/10 px-3 py-1 text-xs text-neon-cyan hover:bg-neon-cyan/20"
                 >
                   {copied === "prompt" ? tc.copied : t.copyPrompt}
                 </button>
@@ -146,13 +146,13 @@ export default function FriendInviteModal({ onClose }: { onClose: () => void }) 
                 readOnly
                 rows={6}
                 value={buildFriendInvitePrompt({ inviteCode: invite.code, locale })}
-                className="w-full resize-none rounded border border-glass-border bg-glass-bg px-3 py-2 font-mono text-xs leading-relaxed text-text-primary outline-none"
+                className="liquid-input w-full resize-none rounded-lg border px-3 py-2 font-mono text-xs leading-relaxed text-text-primary outline-none"
               />
             </div>
             <div className="flex justify-end">
               <button
                 onClick={closeWithMotion}
-                className="rounded border border-glass-border px-4 py-2 text-sm text-text-secondary hover:text-text-primary"
+                className="liquid-action rounded-lg px-4 py-2 text-sm text-text-secondary hover:text-text-primary"
               >
                 {tc.done}
               </button>

--- a/frontend/src/components/dashboard/HomePanel.tsx
+++ b/frontend/src/components/dashboard/HomePanel.tsx
@@ -69,7 +69,7 @@ function SectionHeader({
       {onShowAll ? (
         <button
           onClick={onShowAll}
-          className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/10"
+          className="liquid-action inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/10"
         >
           {t.viewAll} <ArrowRight className="h-3 w-3" />
         </button>
@@ -90,7 +90,7 @@ function BotActivityCard({ bot, stats, onClick }: { bot: UserAgent; stats: Agent
     <button
       type="button"
       onClick={onClick}
-      className="w-full rounded-2xl border border-glass-border bg-deep-black-light p-4 text-left transition-colors hover:border-neon-cyan/40 focus:outline-none focus:ring-2 focus:ring-neon-cyan/40"
+      className="liquid-card w-full rounded-2xl border border-glass-border p-4 text-left transition-colors hover:border-neon-cyan/40 focus:outline-none focus:ring-2 focus:ring-neon-cyan/40"
     >
       <div className="mb-3 flex items-center gap-2.5">
         <BotAvatar agentId={bot.agent_id} avatarUrl={bot.avatar_url} size={36} alt={bot.display_name} />
@@ -118,7 +118,7 @@ function CreateNewBotCard({ onClick }: { onClick: () => void }) {
     <button
       type="button"
       onClick={onClick}
-      className="flex min-h-[148px] w-full flex-col items-center justify-center rounded-2xl border border-dashed border-glass-border/80 bg-deep-black-light/45 p-4 text-center opacity-85 transition-colors hover:border-text-secondary/45 hover:bg-glass-bg/35 hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-text-secondary/25"
+      className="liquid-empty-state flex min-h-[148px] w-full flex-col items-center justify-center rounded-2xl border border-dashed border-glass-border/80 p-4 text-center opacity-85 transition-colors hover:border-text-secondary/45 hover:bg-glass-bg/35 hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-text-secondary/25"
     >
       <div className="flex flex-col items-center">
         <div className="mb-3 flex h-11 w-11 items-center justify-center rounded-xl border border-glass-border bg-glass-bg/45 text-text-secondary">
@@ -132,7 +132,7 @@ function CreateNewBotCard({ onClick }: { onClick: () => void }) {
 
 function Stat({ label, value }: { label: string; value: number | string }) {
   return (
-    <div className="rounded-lg bg-glass-bg px-2 py-1.5">
+    <div className="liquid-tool-surface rounded-lg px-2 py-1.5">
       <div className="text-[10px] uppercase tracking-wider text-text-secondary/60">{label}</div>
       <div className="text-sm font-semibold text-text-primary">{value}</div>
     </div>
@@ -155,7 +155,7 @@ function InlineTooltip({
     <span className="group relative inline-flex focus:outline-none" tabIndex={0}>
       {children}
       <span
-        className={`pointer-events-none absolute left-1/2 top-full z-30 mt-2 -translate-x-1/2 rounded-lg border border-glass-border bg-deep-black px-3 py-2 text-left text-xs font-normal leading-relaxed text-text-secondary opacity-0 shadow-xl transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100 ${sizeClass}`}
+        className={`liquid-menu pointer-events-none absolute left-1/2 top-full z-30 mt-2 -translate-x-1/2 rounded-lg border border-glass-border px-3 py-2 text-left text-xs font-normal leading-relaxed text-text-secondary opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100 ${sizeClass}`}
       >
         {label}
       </span>
@@ -166,7 +166,7 @@ function InlineTooltip({
 export function BotEmptyHero({ onCreateBot }: { onCreateBot: () => void }) {
   const t = homePanelI18n[useLanguage()];
   return (
-    <div className="relative overflow-hidden rounded-2xl border border-dashed border-glass-border bg-deep-black-light/40">
+    <div className="liquid-empty-state relative overflow-hidden rounded-2xl border border-dashed border-glass-border">
       <div className="pointer-events-none absolute -left-12 -top-16 h-48 w-48 rounded-full bg-neon-cyan/10 blur-3xl" />
       <div className="pointer-events-none absolute -right-12 -bottom-16 h-48 w-48 rounded-full bg-neon-purple/10 blur-3xl" />
       <div className="relative flex flex-col items-center gap-5 px-6 py-12 text-center sm:py-14">
@@ -184,7 +184,7 @@ export function BotEmptyHero({ onCreateBot }: { onCreateBot: () => void }) {
         <button
           type="button"
           onClick={onCreateBot}
-          className="inline-flex h-11 items-center justify-center gap-2 rounded-xl border border-neon-cyan/50 bg-neon-cyan/15 px-5 text-sm font-semibold text-neon-cyan transition-colors hover:bg-neon-cyan/25"
+          className="liquid-action inline-flex h-11 items-center justify-center gap-2 rounded-xl border border-neon-cyan/50 bg-neon-cyan/15 px-5 text-sm font-semibold text-neon-cyan transition-colors hover:bg-neon-cyan/25"
         >
           <Plus className="h-4 w-4" />
           {t.createFirstBot}
@@ -212,7 +212,7 @@ export function BotOnboardingSteps({
       type="button"
       onClick={onCreateBot}
       disabled={!hasOnlineDaemon}
-      className={`inline-flex h-10 items-center justify-center gap-1.5 rounded-lg border px-4 text-sm font-medium transition-colors ${
+      className={`liquid-action inline-flex h-10 items-center justify-center gap-1.5 rounded-lg border px-4 text-sm font-medium transition-colors ${
         hasOnlineDaemon
           ? "border-neon-cyan/40 bg-neon-cyan/10 text-neon-cyan hover:bg-neon-cyan/20"
           : "cursor-not-allowed border-glass-border bg-glass-bg/35 text-text-secondary/50"
@@ -224,7 +224,7 @@ export function BotOnboardingSteps({
   );
 
   return (
-    <div className="rounded-2xl border border-dashed border-glass-border bg-deep-black-light/40">
+    <div className="liquid-card rounded-2xl border border-dashed border-glass-border">
       <div className="grid lg:grid-cols-2">
         <div className="flex min-h-48 flex-col justify-between gap-6 border-b border-glass-border/70 p-5 sm:p-6 lg:border-b-0 lg:border-r">
           <div>
@@ -265,7 +265,7 @@ export function BotOnboardingSteps({
             <button
               type="button"
               onClick={onConnectDevice}
-              className="inline-flex h-10 items-center justify-center gap-1.5 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-4 text-sm font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20"
+              className="liquid-action inline-flex h-10 items-center justify-center gap-1.5 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-4 text-sm font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20"
             >
               {t.connectDevice}
               <ArrowRight className="h-4 w-4" />
@@ -407,7 +407,7 @@ const TerminalHowToPopoverBody = forwardRef<
     <span
       ref={ref}
       style={{ top, left }}
-      className="pointer-events-none fixed z-[200] w-80 rounded-2xl border border-glass-border bg-deep-black-light p-4 text-left shadow-2xl shadow-black/50">
+      className="liquid-menu pointer-events-none fixed z-[200] w-80 rounded-2xl border border-glass-border p-4 text-left">
       <span className="block border-b border-glass-border pb-3">
         <span className="mb-2 inline-flex items-center gap-1.5 rounded-full border border-neon-cyan/25 bg-neon-cyan/10 px-2.5 py-1 text-xs font-medium text-neon-cyan">
           <Terminal className="h-3.5 w-3.5" />
@@ -439,7 +439,7 @@ const TerminalHowToPopoverBody = forwardRef<
                 </span>
               ) : null}
               {index === 1 ? (
-                <span className="mt-3 block rounded-xl border border-glass-border bg-deep-black">
+                <span className="liquid-tool-surface mt-3 block rounded-xl border border-glass-border">
                   <span className="flex items-center gap-2 border-b border-glass-border/60 px-3 py-2">
                     <span className="flex gap-1">
                       <span className="h-2 w-2 rounded-full bg-red-400/70" />
@@ -569,7 +569,7 @@ export function DeviceConnectPanel({
 
   return (
     <div className="space-y-4">
-          <div className="rounded-2xl border border-glass-border bg-glass-bg/25 p-4">
+          <div className="liquid-card rounded-2xl border border-glass-border p-4">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
               <div className="min-w-0">
                 <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-text-secondary/60">
@@ -586,7 +586,7 @@ export function DeviceConnectPanel({
               <TerminalHowToButton />
             </div>
 
-            <div className="mt-4 overflow-hidden rounded-xl border border-glass-border bg-deep-black">
+            <div className="liquid-tool-surface mt-4 overflow-hidden rounded-xl border border-glass-border">
               <div className="flex items-center justify-between border-b border-glass-border/60 px-3 py-2">
                 <div className="flex items-center gap-2">
                   <span className="flex gap-1">
@@ -611,7 +611,7 @@ export function DeviceConnectPanel({
                 onClick={() => void handleCopy()}
                 disabled={copyDisabled}
                 title={copyDisabled ? "Wait until the install command is ready" : "Copy"}
-                className={`inline-flex h-10 min-w-32 items-center justify-center gap-2 rounded-lg border px-5 text-sm font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+                className={`liquid-action inline-flex h-10 min-w-32 items-center justify-center gap-2 rounded-lg border px-5 text-sm font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
                   copied
                     ? "border-neon-green/50 bg-neon-green/15 text-neon-green hover:bg-neon-green/20"
                     : "border-neon-cyan/40 bg-neon-cyan/10 text-neon-cyan hover:bg-neon-cyan/20 disabled:hover:bg-neon-cyan/10"
@@ -636,7 +636,7 @@ export function DeviceConnectPanel({
                 type="button"
                 onClick={handleRefresh}
                 disabled={loading}
-                className="inline-flex h-9 items-center justify-center gap-1.5 rounded-lg border border-glass-border px-3 text-xs font-medium text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+                className="liquid-action inline-flex h-9 items-center justify-center gap-1.5 rounded-lg border border-glass-border px-3 text-xs font-medium text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
               >
                 {loading ? (
                   <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -675,7 +675,7 @@ function PersonCard({
     <button
       type="button"
       onClick={onClick}
-      className="flex flex-col rounded-2xl border border-glass-border bg-deep-black-light p-4 text-left transition-colors hover:border-neon-cyan/40 focus:outline-none focus:ring-2 focus:ring-neon-cyan/40"
+      className="liquid-card flex flex-col rounded-2xl border border-glass-border p-4 text-left transition-colors hover:border-neon-cyan/40 focus:outline-none focus:ring-2 focus:ring-neon-cyan/40"
     >
       <div className="mb-2 flex items-center gap-2">
         {badge === "AGENT" && agentId ? (
@@ -820,7 +820,7 @@ function HomePanel() {
     [publicRooms],
   );
   return (
-    <div className="h-full overflow-y-auto">
+    <div className="dashboard-main h-full overflow-y-auto">
       <div className="mx-auto max-w-5xl px-6 pb-10 pt-16">
         <div className="mb-10">
           <h1 className="text-4xl font-semibold tracking-tight text-text-primary">
@@ -884,7 +884,7 @@ function HomePanel() {
               ))}
             </div>
           ) : (
-            <p className="rounded-2xl border border-glass-border bg-deep-black-light/40 px-4 py-6 text-sm text-text-secondary/70">
+            <p className="liquid-empty-state rounded-2xl border border-glass-border px-4 py-6 text-sm text-text-secondary/70">
               {t.noPublicRooms}
             </p>
           )}
@@ -914,7 +914,7 @@ function HomePanel() {
               ))}
             </div>
           ) : (
-            <p className="rounded-2xl border border-glass-border bg-deep-black-light/40 px-4 py-6 text-sm text-text-secondary/70">
+            <p className="liquid-empty-state rounded-2xl border border-glass-border px-4 py-6 text-sm text-text-secondary/70">
               {t.noPublicBots}
             </p>
           )}
@@ -942,7 +942,7 @@ function HomePanel() {
               ))}
             </div>
           ) : (
-            <p className="rounded-2xl border border-glass-border bg-deep-black-light/40 px-4 py-6 text-sm text-text-secondary/70">
+            <p className="liquid-empty-state rounded-2xl border border-glass-border px-4 py-6 text-sm text-text-secondary/70">
               {t.noPublicHumans}
             </p>
           )}

--- a/frontend/src/components/dashboard/HumanCardModal.tsx
+++ b/frontend/src/components/dashboard/HumanCardModal.tsx
@@ -224,7 +224,7 @@ export default function HumanCardModal({
   return (
     <div
       ref={overlayRef}
-      className="fixed inset-0 z-40 flex items-center justify-center bg-black/60 p-4"
+      className="liquid-scrim fixed inset-0 z-40 flex items-center justify-center p-4"
       onMouseDown={(event) => {
         if (event.target === event.currentTarget) handleClose();
       }}
@@ -233,7 +233,7 @@ export default function HumanCardModal({
         ref={panelRef}
         role="dialog"
         aria-modal="true"
-        className="w-full max-w-md rounded-2xl border border-glass-border bg-deep-black-light p-5"
+        className="liquid-dialog w-full max-w-md rounded-2xl p-5"
         onMouseDown={(event) => event.stopPropagation()}
       >
         <div data-profile-modal-part className="mb-3 flex items-start justify-between">
@@ -257,7 +257,7 @@ export default function HumanCardModal({
           </div>
           <button
             onClick={handleClose}
-            className="rounded border border-glass-border px-2 py-0.5 text-xs text-text-secondary hover:text-text-primary"
+            className="liquid-action rounded-lg px-2 py-1 text-xs text-text-secondary hover:text-text-primary"
           >
             {t.close}
           </button>
@@ -276,7 +276,7 @@ export default function HumanCardModal({
             <p className="text-sm text-red-400">{error}</p>
             <button
               onClick={onRetry}
-              className="w-full rounded-lg border border-glass-border py-2 text-xs text-text-primary transition-colors hover:bg-glass-bg"
+              className="liquid-action w-full rounded-lg py-2 text-xs text-text-primary transition-colors"
             >
               Retry
             </button>
@@ -291,7 +291,7 @@ export default function HumanCardModal({
               <button
                 data-profile-modal-part
                 onClick={onSendMessage}
-                className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-green/40 bg-neon-green/10 py-2 text-xs font-medium text-neon-green transition-colors hover:bg-neon-green/20"
+                className="liquid-action inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-green/40 bg-neon-green/10 py-2 text-xs font-medium text-neon-green transition-colors hover:bg-neon-green/20"
               >
                 {t.sendMessage}
               </button>
@@ -302,7 +302,7 @@ export default function HumanCardModal({
                 data-profile-modal-part
                 onClick={onSendFriendRequest}
                 disabled={sendingFriendRequest}
-                className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-green/40 bg-neon-green/10 py-2 text-xs font-medium text-neon-green transition-colors hover:bg-neon-green/20 disabled:cursor-not-allowed disabled:opacity-60"
+                className="liquid-action inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-green/40 bg-neon-green/10 py-2 text-xs font-medium text-neon-green transition-colors hover:bg-neon-green/20 disabled:cursor-not-allowed disabled:opacity-60"
               >
                 {sendingFriendRequest ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
                 {sendingFriendRequest ? t.sendingFriendRequest : t.sendFriendRequest}

--- a/frontend/src/components/dashboard/HumanProfileEditModal.tsx
+++ b/frontend/src/components/dashboard/HumanProfileEditModal.tsx
@@ -105,7 +105,7 @@ export default function HumanProfileEditModal({ onClose }: HumanProfileEditModal
   return (
     <div
       ref={overlayRef}
-      className={`fixed inset-0 z-[110] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`}
+      className={`liquid-scrim fixed inset-0 z-[110] flex items-center justify-center p-4 ${closing ? "pointer-events-none" : ""}`}
       onMouseDown={(event) => {
         if (event.target === event.currentTarget) closeWithMotion();
       }}
@@ -114,13 +114,13 @@ export default function HumanProfileEditModal({ onClose }: HumanProfileEditModal
         ref={panelRef}
         role="dialog"
         aria-modal="true"
-        className="relative w-full max-w-md rounded-2xl border border-glass-border bg-deep-black-light p-5 shadow-2xl"
+        className="liquid-dialog relative w-full max-w-md rounded-2xl p-5"
         onMouseDown={(event) => event.stopPropagation()}
       >
         <button
           onClick={() => closeWithMotion()}
           disabled={saving}
-          className="absolute right-4 top-4 rounded-full p-1.5 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+          className="liquid-action absolute right-4 top-4 rounded-full p-1.5 text-text-secondary transition-colors hover:text-text-primary disabled:opacity-50"
         >
           <X className="h-5 w-5" />
         </button>
@@ -144,7 +144,7 @@ export default function HumanProfileEditModal({ onClose }: HumanProfileEditModal
             onChange={(e) => setDisplayName(e.target.value)}
             disabled={saving}
             maxLength={128}
-            className="w-full rounded-lg border border-glass-border bg-glass-bg px-3 py-2 text-sm text-text-primary outline-none transition-colors focus:border-neon-purple/50 disabled:opacity-60"
+            className="liquid-input w-full rounded-lg border px-3 py-2 text-sm text-text-primary outline-none transition-colors focus:border-neon-purple/50 disabled:opacity-60"
           />
         </label>
 
@@ -157,17 +157,17 @@ export default function HumanProfileEditModal({ onClose }: HumanProfileEditModal
             disabled={saving}
             maxLength={2048}
             placeholder={tAvatarPlaceholder}
-            className="w-full rounded-lg border border-glass-border bg-glass-bg px-3 py-2 text-sm text-text-primary outline-none transition-colors focus:border-neon-purple/50 disabled:opacity-60"
+            className="liquid-input w-full rounded-lg border px-3 py-2 text-sm text-text-primary outline-none transition-colors focus:border-neon-purple/50 disabled:opacity-60"
           />
         </label>
 
         {trimmedAvatar && (
-          <div data-human-profile-modal-part className="mt-3 flex items-center gap-2 rounded-lg border border-glass-border bg-glass-bg p-2">
+          <div data-human-profile-modal-part className="liquid-card mt-3 flex items-center gap-2 rounded-lg p-2">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
               src={trimmedAvatar}
               alt="Avatar preview"
-              className="h-10 w-10 rounded-full border border-white/10 object-cover"
+              className="h-10 w-10 rounded-full border border-glass-border object-cover"
               onError={(e) => {
                 (e.currentTarget as HTMLImageElement).style.display = "none";
               }}
@@ -186,14 +186,14 @@ export default function HumanProfileEditModal({ onClose }: HumanProfileEditModal
           <button
             onClick={() => closeWithMotion()}
             disabled={saving}
-            className="rounded-xl border border-glass-border px-4 py-2.5 text-sm font-medium text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+            className="liquid-action rounded-xl px-4 py-2.5 text-sm font-medium text-text-secondary transition-colors hover:text-text-primary disabled:opacity-50"
           >
             {tCancel}
           </button>
           <button
             onClick={handleSave}
             disabled={!canSave}
-            className="flex items-center gap-2 rounded-xl border border-neon-purple/40 bg-neon-purple/10 px-4 py-2.5 text-sm font-bold text-neon-purple transition-all hover:bg-neon-purple/20 disabled:opacity-60"
+            className="liquid-action flex items-center gap-2 rounded-xl border border-neon-purple/40 bg-neon-purple/10 px-4 py-2.5 text-sm font-bold text-neon-purple transition-all hover:bg-neon-purple/20 disabled:opacity-60"
           >
             {saving ? (
               <>

--- a/frontend/src/components/dashboard/InstallCommandPanel.tsx
+++ b/frontend/src/components/dashboard/InstallCommandPanel.tsx
@@ -98,12 +98,12 @@ export default function InstallCommandPanel({ ticket, onClaimed, onCancel }: Pro
 
   return (
     <div className="space-y-4">
-      <div className="rounded-xl border border-glass-border bg-glass-bg/40 p-3">
+      <div className="liquid-card rounded-xl border border-glass-border p-3">
         <p className="mb-2 text-xs text-text-secondary">
           Run this on your OpenClaw host (one-line install + bind):
         </p>
         <div className="flex items-stretch gap-2">
-          <code className="flex-1 overflow-x-auto whitespace-nowrap rounded-lg border border-glass-border bg-deep-black px-3 py-2 font-mono text-xs text-text-primary">
+          <code className="liquid-tool-surface flex-1 overflow-x-auto whitespace-nowrap rounded-lg border border-glass-border px-3 py-2 font-mono text-xs text-text-primary">
             {ticket.installCommand}
           </code>
           <button
@@ -126,7 +126,7 @@ export default function InstallCommandPanel({ ticket, onClaimed, onCancel }: Pro
         </div>
       </div>
 
-      <div className="flex items-center justify-between rounded-xl border border-glass-border bg-deep-black px-3 py-2 text-xs">
+      <div className="liquid-tool-surface flex items-center justify-between rounded-xl border border-glass-border px-3 py-2 text-xs">
         <span className="flex items-center gap-2 text-text-secondary">
           {!expired && <Loader2 className="h-3.5 w-3.5 animate-spin text-neon-cyan" />}
           {statusMessage}

--- a/frontend/src/components/dashboard/InviteOthersGuide.tsx
+++ b/frontend/src/components/dashboard/InviteOthersGuide.tsx
@@ -113,7 +113,7 @@ export default function InviteOthersGuide({ roomId, roomName, visibility, canInv
 
   if (!canInvite) {
     return (
-      <div className="rounded-lg border border-glass-border bg-glass-bg/30 p-3">
+      <div className="liquid-card rounded-lg border border-glass-border p-3">
         <div className="mb-2 flex items-center gap-2">
           <span className="text-sm">🔒</span>
           <h3 className="text-[11px] font-bold uppercase tracking-wider text-text-secondary/60">
@@ -128,7 +128,7 @@ export default function InviteOthersGuide({ roomId, roomName, visibility, canInv
   }
 
   return (
-    <div className="rounded-lg border border-glass-border bg-glass-bg/30 p-3">
+    <div className="liquid-card rounded-lg border border-glass-border p-3">
       <div className="mb-2 flex items-center justify-between">
         <div className="flex items-center gap-2">
           <span className="text-sm">🤖</span>
@@ -160,7 +160,7 @@ export default function InviteOthersGuide({ roomId, roomName, visibility, canInv
         </button>
       </div>
 
-      <div className="group relative overflow-hidden rounded border border-glass-border/50 bg-deep-black-light/50">
+      <div className="liquid-tool-surface group relative overflow-hidden rounded border border-glass-border/50">
         <div
           ref={promptRef}
           className="overflow-hidden bg-deep-black/30 p-2.5 font-mono text-[10px] leading-relaxed text-text-secondary/80 whitespace-pre-wrap break-all transition-[max-height] duration-200"

--- a/frontend/src/components/dashboard/JoinRequestsPanel.tsx
+++ b/frontend/src/components/dashboard/JoinRequestsPanel.tsx
@@ -98,7 +98,7 @@ export default function JoinRequestsPanel({ roomId }: JoinRequestsPanelProps) {
         return (
           <div
             key={req.request_id}
-            className="rounded-lg border border-glass-border bg-glass-bg/30 px-3 py-2"
+            className="liquid-card rounded-lg border border-glass-border px-3 py-2"
           >
             <div className="flex items-center justify-between gap-2">
               <div className="min-w-0">

--- a/frontend/src/components/dashboard/LedgerList.tsx
+++ b/frontend/src/components/dashboard/LedgerList.tsx
@@ -92,7 +92,7 @@ export default function LedgerList() {
         return (
           <div
             key={entry.entry_id}
-            className="flex items-center gap-3 rounded-xl border border-glass-border bg-glass-bg p-4 transition-colors hover:bg-glass-bg/80"
+            className="liquid-list-row flex items-center gap-3 rounded-xl border border-glass-border p-4 transition-colors"
           >
             {/* Direction icon */}
             <div

--- a/frontend/src/components/dashboard/MemberActionsMenu.tsx
+++ b/frontend/src/components/dashboard/MemberActionsMenu.tsx
@@ -100,7 +100,7 @@ export default function MemberActionsMenu({
         ⋯
       </button>
       {open && (
-        <div ref={menuRef} className="absolute right-0 z-20 mt-1 min-w-[140px] rounded-md border border-glass-border bg-deep-black-light p-1 shadow-lg">
+        <div ref={menuRef} className="liquid-menu absolute right-0 z-20 mt-1 min-w-[140px] rounded-md border border-glass-border p-1 shadow-lg">
           {canPromoteDemote && (
             <button
               onClick={toggleRole}
@@ -208,12 +208,12 @@ function PermissionsDialog({
   return (
     <div
       ref={overlayRef}
-      className={`fixed inset-0 z-30 flex items-center justify-center bg-black/60 ${closing ? "pointer-events-none" : ""}`}
+      className={`liquid-scrim fixed inset-0 z-30 flex items-center justify-center ${closing ? "pointer-events-none" : ""}`}
       onClick={closeWithMotion}
     >
       <div
         ref={panelRef}
-        className="w-[320px] rounded-lg border border-glass-border bg-deep-black-light p-4"
+        className="liquid-dialog w-[320px] rounded-lg border border-glass-border p-4"
         onClick={(e) => e.stopPropagation()}
       >
         <h3 className="mb-3 text-sm font-semibold text-text-primary">

--- a/frontend/src/components/dashboard/MessageBubble.tsx
+++ b/frontend/src/components/dashboard/MessageBubble.tsx
@@ -474,7 +474,7 @@ function MentionChip({
       {tooltipPosition && typeof document !== "undefined" && createPortal(
         <span
           ref={tooltipRef}
-          className="pointer-events-none fixed z-[9999] w-64 rounded-lg border border-glass-border bg-zinc-950/95 p-3 text-left shadow-xl shadow-black/30"
+          className="liquid-menu pointer-events-none fixed z-[9999] w-64 rounded-xl border border-glass-border bg-deep-black-light p-3 text-left shadow-xl shadow-black/30"
           style={{ left: tooltipPosition.left, top: tooltipPosition.top }}
         >
           <span className="mb-1 flex items-center gap-2">
@@ -941,7 +941,7 @@ function MessageBubble({
           updateActionMenuPosition();
           setMenuOpen(true);
         }}
-        className={`flex h-6 w-6 items-center justify-center rounded text-zinc-500 hover:bg-zinc-800 hover:text-zinc-300 transition-colors ${hovered || menuOpen ? "opacity-100" : "opacity-0 pointer-events-none"}`}
+        className={`flex h-6 w-6 items-center justify-center rounded-lg text-text-secondary hover:bg-glass-bg hover:text-text-primary transition-colors ${hovered || menuOpen ? "opacity-100" : "opacity-0 pointer-events-none"}`}
         aria-label="More actions"
         aria-expanded={menuOpen}
       >
@@ -950,7 +950,7 @@ function MessageBubble({
       {menuOpen && menuPosition && typeof document !== "undefined" && createPortal(
         <div
           ref={actionMenuRef}
-          className="fixed z-[9999] min-w-[112px] rounded-lg border border-zinc-700 bg-zinc-900 py-1 shadow-xl"
+          className="liquid-menu fixed z-[9999] min-w-[112px] rounded-xl border border-glass-border bg-deep-black-light py-1 shadow-xl"
           style={{ left: menuPosition.left, top: menuPosition.top }}
           onMouseDown={(event) => event.stopPropagation()}
         >
@@ -959,7 +959,7 @@ function MessageBubble({
               data-message-action-item
               type="button"
               onMouseDown={(e) => { e.preventDefault(); handleReplyClick(); }}
-              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100 transition-colors"
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-text-primary hover:bg-glass-bg transition-colors"
             >
               <CornerUpLeft className="h-3.5 w-3.5 text-zinc-500" />
               {locale === "zh" ? "回复" : "Reply"}
@@ -970,7 +970,7 @@ function MessageBubble({
               data-message-action-item
               type="button"
               onMouseDown={(e) => { e.preventDefault(); handleForwardClick(); }}
-              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100 transition-colors"
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-text-primary hover:bg-glass-bg transition-colors"
             >
               <Forward className="h-3.5 w-3.5 text-zinc-500" />
               转发
@@ -982,7 +982,7 @@ function MessageBubble({
               type="button"
               disabled={recallPending}
               onMouseDown={(e) => { e.preventDefault(); void handleRecallClick(); }}
-              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100 disabled:cursor-not-allowed disabled:opacity-60 transition-colors"
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-text-primary hover:bg-glass-bg disabled:cursor-not-allowed disabled:opacity-60 transition-colors"
             >
               <RotateCcw className="h-3.5 w-3.5 text-zinc-500" />
               {locale === "zh" ? "撤回" : "Recall"}
@@ -993,7 +993,7 @@ function MessageBubble({
               data-message-action-item
               type="button"
               onMouseDown={(e) => { e.preventDefault(); void handleCopyClick(); }}
-              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100 transition-colors"
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-text-primary hover:bg-glass-bg transition-colors"
             >
               {copied ? (
                 <Check className="h-3.5 w-3.5 text-emerald-400" />
@@ -1026,12 +1026,12 @@ function MessageBubble({
       {isOwn && !fullWidth && actionButtons}
       {!isOwn && sideAvatar}
       <div
-        className={`${fullWidth ? "w-full" : "max-w-[70%]"} rounded-xl px-3 py-2 ${
+        className={`${fullWidth ? "w-full" : "max-w-[70%]"} liquid-message rounded-2xl border px-3 py-2 ${
           isErrorMessage
-            ? "border border-zinc-700/45 bg-zinc-900/35"
+            ? "liquid-message-error"
             : isOwn
-              ? "border border-neon-cyan/30 bg-neon-cyan/5"
-              : "border border-glass-border bg-glass-bg"
+              ? "liquid-message-own"
+              : "liquid-message-peer"
         }`}
       >
         <div

--- a/frontend/src/components/dashboard/MessageComposer.tsx
+++ b/frontend/src/components/dashboard/MessageComposer.tsx
@@ -511,7 +511,7 @@ export default function MessageComposer({
   }, [canSend, handleSend]);
 
   return (
-    <div onDrop={handleDrop} onDragOver={handleDragOver}>
+    <div onDrop={handleDrop} onDragOver={handleDragOver} className="liquid-composer rounded-2xl border border-glass-border p-1.5">
       {hasLengthError && (
         <p className="mb-1 px-1 text-[11px] leading-4 text-red-400">
           Message cannot exceed {MESSAGE_MAX_LENGTH.toLocaleString()} characters.
@@ -522,7 +522,7 @@ export default function MessageComposer({
           {files.map((pf, idx) => (
             <div
               key={idx}
-              className="relative group flex items-center gap-1.5 bg-zinc-800 border border-zinc-700 rounded-lg px-2 py-1.5 text-xs text-zinc-300 max-w-[200px]"
+              className="relative group flex max-w-[200px] items-center gap-1.5 rounded-xl border border-glass-border bg-deep-black-light px-2 py-1.5 text-xs text-text-primary"
             >
               {pf.preview ? (
                 <img src={pf.preview} alt={pf.file.name} className="w-8 h-8 rounded object-cover shrink-0" />
@@ -556,7 +556,7 @@ export default function MessageComposer({
             )}
             <div className="relative">
               {actionMenuOpen && (
-                <div className="absolute bottom-full left-0 z-30 mb-2 w-36 rounded-lg border border-zinc-700 bg-zinc-900 p-1 shadow-xl">
+                <div className="liquid-menu absolute bottom-full left-0 z-30 mb-2 w-36 rounded-xl border border-glass-border bg-deep-black-light p-1 shadow-xl">
                   {allowAttachments && (
                     <button
                       type="button"
@@ -564,7 +564,7 @@ export default function MessageComposer({
                         setActionMenuOpen(false);
                         fileInputRef.current?.click();
                       }}
-                      className="flex w-full items-center gap-2 rounded px-2.5 py-2 text-left text-xs text-zinc-200 hover:bg-zinc-800"
+                      className="flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-xs text-text-primary hover:bg-glass-bg"
                     >
                       <FileUp className="h-4 w-4 text-zinc-400" />
                       <span>{actionLabels?.file ?? "File"}</span>
@@ -577,7 +577,7 @@ export default function MessageComposer({
                         setActionMenuOpen(false);
                         onTransfer();
                       }}
-                      className="flex w-full items-center gap-2 rounded px-2.5 py-2 text-left text-xs text-zinc-200 hover:bg-zinc-800"
+                      className="flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-xs text-text-primary hover:bg-glass-bg"
                     >
                       <Coins className="h-4 w-4 text-zinc-400" />
                       <span>{actionLabels?.transfer ?? "Transfer"}</span>
@@ -588,7 +588,7 @@ export default function MessageComposer({
               <button
                 type="button"
                 onClick={() => setActionMenuOpen((open) => !open)}
-                className="flex h-9 w-9 items-center justify-center rounded-lg text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-cyan-400"
+                className="flex h-9 w-9 items-center justify-center rounded-xl text-text-secondary transition-colors hover:bg-glass-bg hover:text-neon-cyan"
                 title={actionLabels?.add ?? "Add"}
                 aria-label={actionLabels?.add ?? "Open actions"}
                 aria-expanded={actionMenuOpen}
@@ -622,7 +622,8 @@ export default function MessageComposer({
           data-bwignore="true"
           data-protonpass-ignore="true"
           aria-autocomplete={MESSAGE_COMPOSER_TEXTAREA_ARIA_AUTOCOMPLETE}
-          className={`flex-1 bg-zinc-900 border rounded-lg px-3 py-2 text-sm text-zinc-200 placeholder-zinc-500 resize-none focus:outline-none focus:border-cyan-500/50 transition-all ${
+          aria-invalid={hasLengthError || undefined}
+          className={`liquid-input flex-1 resize-none rounded-xl border px-3 py-2 text-sm text-text-primary placeholder-text-secondary/65 transition-all focus:outline-none ${
             hasLengthError
               ? "border-red-500/70 focus:border-red-500/80"
               : emptyState
@@ -663,7 +664,7 @@ export default function MessageComposer({
         {mentionMatch && suggestions.length > 0 && (
           <div
             ref={mentionListRef}
-            className="absolute left-0 right-12 bottom-full mb-1 z-20 max-h-56 origin-bottom overflow-y-auto rounded-lg border border-zinc-700 bg-zinc-900 shadow-xl"
+            className="liquid-menu absolute bottom-full left-0 right-12 z-20 mb-1 max-h-56 origin-bottom overflow-y-auto rounded-xl border border-glass-border bg-deep-black-light shadow-xl"
             role="listbox"
           >
             {suggestions.map((s, i) => {
@@ -699,14 +700,14 @@ export default function MessageComposer({
                   onMouseEnter={() => setMentionIndex(i)}
                   className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition-colors ${
                     i === mentionIndex
-                      ? "bg-cyan-500/15 text-cyan-200"
-                      : "text-zinc-300 hover:bg-zinc-800"
+                      ? "bg-neon-cyan/15 text-neon-cyan"
+                      : "text-text-primary hover:bg-glass-bg"
                   }`}
                 >
                   <KindIcon className={`h-3.5 w-3.5 shrink-0 ${iconClass}`} />
                   <span className="truncate font-medium">{s.display_name}</span>
                   {kindLabel && (
-                    <span className={`shrink-0 rounded px-1 py-px text-[9px] font-medium uppercase tracking-wide ${iconClass} bg-zinc-800/60`}>
+                    <span className={`shrink-0 rounded px-1 py-px text-[9px] font-medium uppercase tracking-wide ${iconClass} bg-glass-bg`}>
                       {kindLabel}
                     </span>
                   )}
@@ -721,7 +722,7 @@ export default function MessageComposer({
           type="button"
           onClick={handleSendClick}
           disabled={!canSend}
-          className="flex items-center justify-center w-9 h-9 rounded-lg bg-cyan-500/20 text-cyan-400 hover:bg-cyan-500/30 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          className="liquid-send-button flex h-9 w-9 items-center justify-center rounded-xl bg-neon-cyan/15 text-neon-cyan transition-colors hover:bg-neon-cyan/25 disabled:cursor-not-allowed disabled:opacity-50"
           aria-label="Send message"
         >
           <Send ref={sendIconRef} className="w-4 h-4" />

--- a/frontend/src/components/dashboard/MessageList.tsx
+++ b/frontend/src/components/dashboard/MessageList.tsx
@@ -234,7 +234,7 @@ function EmptyRoomGuide({
 
   return (
     <div className="flex flex-1 items-center justify-center overflow-y-auto px-4 py-8">
-      <div className="w-full max-w-2xl rounded-lg border border-glass-border bg-deep-black-light/70 p-5 shadow-lg shadow-black/20">
+      <div className="liquid-empty-state w-full max-w-2xl rounded-lg border border-glass-border p-5 shadow-lg shadow-black/20">
         <div className="flex items-start gap-3">
           <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-neon-cyan/30 bg-neon-cyan/10 text-neon-cyan">
             <Bot className="h-5 w-5" />
@@ -278,7 +278,7 @@ function EmptyRoomGuide({
                 type="button"
                 key={prompt}
                 onClick={() => prefillComposer(prompt)}
-                className="group flex items-start justify-between gap-3 rounded-md border border-glass-border bg-deep-black px-3 py-2 text-left transition-colors hover:border-neon-cyan/40 hover:bg-neon-cyan/5"
+                className="liquid-list-row group flex items-start justify-between gap-3 rounded-md border border-glass-border px-3 py-2 text-left transition-colors hover:border-neon-cyan/40 hover:bg-neon-cyan/5"
               >
                 <span className="min-w-0 text-sm leading-5 text-text-secondary group-hover:text-text-primary">
                   {prompt}
@@ -642,7 +642,7 @@ export default function MessageList({
           {Array.from({ length: 8 }).map((_, idx) => (
             <div
               key={idx}
-              className={`h-11 w-full animate-pulse rounded-lg border border-glass-border/60 bg-deep-black-light ${
+        className={`liquid-card h-11 w-full animate-pulse rounded-lg border border-glass-border/60 ${
                 idx % 2 === 0 ? "max-w-[72%]" : "ml-auto max-w-[64%]"
               }`}
             />
@@ -663,7 +663,7 @@ export default function MessageList({
       onClick={() => scrollToBottom("auto")}
       aria-label={t.scrollToLatest}
       title={t.scrollToLatest}
-      className="absolute bottom-4 left-1/2 z-20 flex h-9 w-9 -translate-x-1/2 items-center justify-center rounded-full border border-neon-cyan/40 bg-deep-black-light/95 text-neon-cyan shadow-lg shadow-black/30 backdrop-blur transition-colors hover:bg-neon-cyan/15 hover:text-neon-cyan max-md:bottom-6"
+      className="liquid-action absolute bottom-4 left-1/2 z-20 flex h-9 w-9 -translate-x-1/2 items-center justify-center rounded-full border border-neon-cyan/40 text-neon-cyan shadow-lg shadow-black/30 backdrop-blur transition-colors hover:bg-neon-cyan/15 hover:text-neon-cyan max-md:bottom-6"
     >
       <ArrowDown className="h-4 w-4" />
     </button>

--- a/frontend/src/components/dashboard/MyBotsPanel.tsx
+++ b/frontend/src/components/dashboard/MyBotsPanel.tsx
@@ -46,7 +46,7 @@ function MyBotsPanel() {
   }
 
   return (
-    <div className="h-full overflow-y-auto">
+    <div className="dashboard-main h-full overflow-y-auto">
       <div className="mx-auto max-w-5xl px-6 py-8">
         <div className="mb-6">
           <h1 className="text-2xl font-semibold text-text-primary">{t.pageTitle}</h1>
@@ -57,7 +57,7 @@ function MyBotsPanel() {
 
         {/* Sub-tab pill control + matching create action on the right. */}
         <div className="mb-8 flex flex-wrap items-center justify-between gap-3">
-          <div className="inline-flex items-center gap-1 rounded-full border border-glass-border bg-glass-bg/60 p-1">
+          <div className="liquid-tabs inline-flex items-center gap-1 rounded-full border border-glass-border p-1">
             {SUB_TABS.map((tab) => {
               const active = myBotsTab === tab.key;
               return (
@@ -79,7 +79,7 @@ function MyBotsPanel() {
           {myBotsTab === "bots" ? (
             <button
               onClick={handleCreateBot}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-2 text-sm font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20"
+              className="liquid-action inline-flex items-center gap-1.5 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-2 text-sm font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20"
             >
               <Plus className="h-4 w-4" />
               {t.createBot}
@@ -87,7 +87,7 @@ function MyBotsPanel() {
           ) : (
             <button
               onClick={() => setShowAddDevice(true)}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-2 text-sm font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20"
+              className="liquid-action inline-flex items-center gap-1.5 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-2 text-sm font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20"
             >
               <Plus className="h-4 w-4" />
               {t.addDevice}
@@ -156,7 +156,7 @@ function BotsView({
               <button
                 key={agent.agent_id}
                 onClick={() => setBotDetailAgentId(agent.agent_id)}
-                className="rounded-2xl border border-glass-border bg-deep-black-light p-5 text-left transition-colors hover:border-neon-cyan/40"
+                className="liquid-card rounded-2xl border border-glass-border p-5 text-left transition-colors hover:border-neon-cyan/40"
               >
                 <div className="mb-4 flex items-start gap-3">
                   <BotAvatar agentId={agent.agent_id} avatarUrl={agent.avatar_url} size={48} alt={agent.display_name} />
@@ -220,7 +220,7 @@ function BotsView({
 
 function Stat({ label, value, delta }: { label: string; value: number | string; delta?: string }) {
   return (
-    <div className="rounded-lg bg-glass-bg px-2 py-1.5">
+    <div className="liquid-tool-surface rounded-lg px-2 py-1.5">
       <div className="text-[10px] uppercase tracking-wider text-text-secondary/60">{label}</div>
       <div className="flex items-baseline gap-1">
         <span className="text-sm font-semibold text-text-primary">{value}</span>

--- a/frontend/src/components/dashboard/MyDevicesView.tsx
+++ b/frontend/src/components/dashboard/MyDevicesView.tsx
@@ -62,7 +62,7 @@ export default function MyDevicesView() {
               <button
                 key={device.id}
                 onClick={() => setSelectedDeviceId(device.id)}
-                className="w-full rounded-2xl border border-glass-border bg-deep-black-light p-5 text-left transition-colors hover:border-neon-cyan/40"
+                className="liquid-card w-full rounded-2xl border border-glass-border p-5 text-left transition-colors hover:border-neon-cyan/40"
               >
                 <div className="flex items-start justify-between gap-4">
                   <div className="flex min-w-0 items-start gap-3">

--- a/frontend/src/components/dashboard/PaidRoomPreview.tsx
+++ b/frontend/src/components/dashboard/PaidRoomPreview.tsx
@@ -100,7 +100,7 @@ export default function PaidRoomPreview({
           </div>
 
           {loading ? (
-            <div className="flex items-center justify-center rounded-lg border border-glass-border bg-deep-black-light px-3 py-5 text-xs text-text-secondary">
+            <div className="liquid-empty-state flex items-center justify-center rounded-lg border border-glass-border px-3 py-5 text-xs text-text-secondary">
               <MobileBotCordLoading
                 label={t.loadingPreviewMessages}
                 size="sm"
@@ -112,7 +112,7 @@ export default function PaidRoomPreview({
               {previewMessages.map(({ message, text }) => (
                 <div
                   key={message.hub_msg_id}
-                  className="rounded-lg border border-glass-border bg-glass-bg px-3 py-2.5"
+                  className="liquid-card rounded-lg border border-glass-border px-3 py-2.5"
                 >
                   <div className="mb-1 flex min-w-0 items-center gap-2 text-[11px] text-text-secondary/70">
                     <span className="truncate font-medium text-neon-purple/90">{senderName(message)}</span>
@@ -124,7 +124,7 @@ export default function PaidRoomPreview({
               ))}
             </div>
           ) : (
-            <div className="rounded-lg border border-glass-border bg-deep-black-light px-3 py-5 text-center text-xs text-text-secondary">
+            <div className="liquid-empty-state rounded-lg border border-glass-border px-3 py-5 text-center text-xs text-text-secondary">
               {t.noPreviewMessages}
             </div>
           )}

--- a/frontend/src/components/dashboard/PeerBotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/PeerBotDetailDrawer.tsx
@@ -131,19 +131,19 @@ function PeerBotDetailDrawer() {
     <>
       <div
         ref={overlayRef}
-        className="fixed inset-0 z-40 bg-black/40 backdrop-blur-[2px]"
+        className="liquid-scrim fixed inset-0 z-40 backdrop-blur-[2px]"
         onClick={closeDrawer}
         aria-hidden
       />
       <aside
         ref={panelRef}
-        className="fixed inset-y-0 right-0 z-50 flex w-full max-w-md flex-col border-l border-glass-border bg-deep-black-light shadow-2xl shadow-black/50"
+        className="liquid-drawer fixed inset-y-0 right-0 z-50 flex w-full max-w-md flex-col border-l border-glass-border"
         role="dialog"
         aria-modal="true"
         aria-label="Bot 详情"
       >
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-glass-border px-5 py-4" data-overlay-section>
+        <div className="liquid-toolbar flex items-center justify-between border-b border-glass-border px-5 py-4" data-overlay-section>
           <div className="flex min-w-0 items-center gap-3">
             <BotAvatar agentId={agentId} size={40} alt={displayName} />
             <div className="min-w-0">
@@ -162,7 +162,7 @@ function PeerBotDetailDrawer() {
             onClick={closeDrawer}
             title="关闭"
             aria-label="关闭"
-            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-secondary/70 transition-colors hover:bg-glass-bg hover:text-text-primary"
+            className="liquid-action flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-secondary/70 transition-colors hover:bg-glass-bg hover:text-text-primary"
           >
             <X className="h-4 w-4" />
           </button>
@@ -170,7 +170,7 @@ function PeerBotDetailDrawer() {
 
         {/* Body */}
         <div className="flex-1 space-y-4 overflow-y-auto px-5 py-4" data-overlay-section>
-          <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
+          <section className="liquid-card rounded-2xl border border-glass-border p-4">
             <p className="font-mono text-[11px] text-text-secondary/55">{agentId}</p>
             {bio ? (
               <p className="mt-2 text-sm text-text-primary/85">{bio}</p>
@@ -179,7 +179,7 @@ function PeerBotDetailDrawer() {
             )}
           </section>
 
-          <section className="rounded-2xl border border-glass-border bg-glass-bg/30 p-4">
+          <section className="liquid-card rounded-2xl border border-glass-border p-4">
             <Row label="主人" value={ownerName ?? "—"} />
             <Row label="消息策略" value={policy ? POLICY_LABEL[policy] ?? policy : "—"} />
             <Row label="注册时间" value={formatDate(createdAt ?? undefined)} last />
@@ -194,7 +194,7 @@ function PeerBotDetailDrawer() {
         <div className="grid grid-cols-2 gap-2 border-t border-glass-border px-5 py-4" data-overlay-section>
           <button
             onClick={handleMessage}
-            className="col-span-2 inline-flex items-center justify-center gap-1.5 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-2 text-sm font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20"
+            className="liquid-action col-span-2 inline-flex items-center justify-center gap-1.5 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-2 text-sm font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20"
           >
             <MessageCircle className="h-4 w-4" />
             打开对话
@@ -202,7 +202,7 @@ function PeerBotDetailDrawer() {
           {alreadyContact ? (
             <button
               disabled
-              className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-glass-border bg-glass-bg/40 px-3 py-2 text-sm font-medium text-text-secondary/70"
+              className="liquid-tool-surface inline-flex items-center justify-center gap-1.5 rounded-lg border border-glass-border px-3 py-2 text-sm font-medium text-text-secondary/70"
             >
               <UserCheck className="h-4 w-4" />
               已是联系人
@@ -210,7 +210,7 @@ function PeerBotDetailDrawer() {
           ) : (
             <button
               onClick={() => void handleAddContact()}
-              className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-glass-border bg-glass-bg/40 px-3 py-2 text-sm font-medium text-text-primary transition-colors hover:border-neon-cyan/40 hover:text-neon-cyan"
+              className="liquid-action inline-flex items-center justify-center gap-1.5 rounded-lg border border-glass-border px-3 py-2 text-sm font-medium text-text-primary transition-colors hover:border-neon-cyan/40 hover:text-neon-cyan"
             >
               <UserPlus className="h-4 w-4" />
               加为联系人

--- a/frontend/src/components/dashboard/PendingApprovalsPanel.tsx
+++ b/frontend/src/components/dashboard/PendingApprovalsPanel.tsx
@@ -67,7 +67,7 @@ export default function PendingApprovalsPanel() {
 
   if (loading && approvals.length === 0) {
     return (
-      <div className="mb-4 rounded-2xl border border-glass-border bg-deep-black-light px-4 py-3">
+      <div className="liquid-card mb-4 rounded-2xl border border-glass-border px-4 py-3">
         <MobileBotCordLoading
           label={t.loading}
           size="sm"
@@ -87,7 +87,7 @@ export default function PendingApprovalsPanel() {
   return (
     <section
       aria-label="Pending approvals on agents you own"
-      className="mb-4 rounded-2xl border border-neon-purple/40 bg-neon-purple/5 p-4"
+      className="liquid-card mb-4 rounded-2xl border border-neon-purple/40 bg-neon-purple/5 p-4"
     >
       <header className="mb-3 flex items-center justify-between gap-2">
         <div>
@@ -130,7 +130,7 @@ export default function PendingApprovalsPanel() {
           return (
             <li
               key={entry.id}
-              className="rounded-xl border border-glass-border bg-deep-black-light/60 p-3"
+              className="liquid-list-row rounded-xl border border-glass-border p-3"
             >
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">

--- a/frontend/src/components/dashboard/PlanChangeConfirmDialog.tsx
+++ b/frontend/src/components/dashboard/PlanChangeConfirmDialog.tsx
@@ -63,19 +63,19 @@ export default function PlanChangeConfirmDialog({
   return (
     <div
       ref={overlayRef}
-      className={`fixed inset-0 z-[80] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`}
+      className={`liquid-scrim fixed inset-0 z-[80] flex items-center justify-center p-4 ${closing ? "pointer-events-none" : ""}`}
       onClick={closeWithMotion}
     >
       <div
         ref={panelRef}
-        className="relative w-full max-w-md rounded-2xl border border-glass-border bg-deep-black-light p-5 shadow-2xl"
+        className="liquid-dialog relative w-full max-w-md rounded-2xl p-5"
         onClick={(e) => e.stopPropagation()}
       >
         <button
           type="button"
           onClick={closeWithMotion}
           disabled={loading}
-          className="absolute right-4 top-4 rounded-full p-1.5 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+          className="liquid-action absolute right-4 top-4 rounded-full p-1.5 text-text-secondary transition-colors hover:text-text-primary disabled:opacity-50"
           aria-label={ta.planChangeCancel}
         >
           <X className="h-5 w-5" />
@@ -97,7 +97,7 @@ export default function PlanChangeConfirmDialog({
             type="button"
             onClick={closeWithMotion}
             disabled={loading}
-            className="rounded-lg border border-glass-border px-3 py-1.5 text-sm text-text-secondary transition-colors hover:bg-glass-bg disabled:opacity-50"
+            className="liquid-action rounded-lg px-3 py-1.5 text-sm text-text-secondary transition-colors disabled:opacity-50"
           >
             {ta.planChangeCancel}
           </button>
@@ -105,7 +105,7 @@ export default function PlanChangeConfirmDialog({
             type="button"
             onClick={onConfirm}
             disabled={loading}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-1.5 text-sm font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20 disabled:opacity-50"
+            className="liquid-action inline-flex items-center gap-1.5 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-1.5 text-sm font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20 disabled:opacity-50"
           >
             {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
             {ta.planChangeConfirm}

--- a/frontend/src/components/dashboard/PromptTemplates.tsx
+++ b/frontend/src/components/dashboard/PromptTemplates.tsx
@@ -101,7 +101,7 @@ function TemplateCardView({
   };
 
   return (
-    <div className="overflow-hidden rounded-2xl border border-glass-border bg-deep-black-light transition-colors hover:border-neon-purple/40">
+    <div className="liquid-card overflow-hidden rounded-2xl border border-glass-border transition-colors hover:border-neon-purple/40">
       {/* Header */}
       <div className="px-5 pt-5 pb-3">
         <h3 className="text-sm font-semibold text-text-primary">{t[card.titleKey]}</h3>
@@ -138,7 +138,7 @@ function TemplateCardView({
 
       {/* Expandable prompt preview */}
       {expanded && (
-        <div className="border-t border-glass-border/50 bg-deep-black/40">
+        <div className="liquid-tool-surface border-t border-glass-border/50">
           <pre className="max-h-80 overflow-y-auto whitespace-pre-wrap break-words px-5 py-4 font-mono text-[11px] leading-5 text-text-secondary/85">
             {prompt}
           </pre>
@@ -153,8 +153,8 @@ export default function PromptTemplates() {
   const t = promptTemplatesUi[locale];
 
   return (
-    <div className="relative flex flex-1 flex-col overflow-hidden bg-deep-black">
-      <div className="border-b border-glass-border px-5 py-4">
+    <div className="dashboard-main relative flex flex-1 flex-col overflow-hidden">
+      <div className="liquid-toolbar border-b border-glass-border px-5 py-4">
         <h2 className="text-base font-semibold text-text-primary">{t.title}</h2>
         <p className="mt-1 text-xs text-text-secondary">{t.subtitle}</p>
       </div>

--- a/frontend/src/components/dashboard/PublicAgentList.tsx
+++ b/frontend/src/components/dashboard/PublicAgentList.tsx
@@ -37,7 +37,7 @@ export default function PublicAgentList() {
 
   if (publicAgents.length === 0) {
     return (
-      <div className="p-4 text-center text-xs text-text-secondary">
+      <div className="liquid-empty-state m-3 p-4 text-center text-xs text-text-secondary">
         No agents yet
       </div>
     );
@@ -49,7 +49,7 @@ export default function PublicAgentList() {
         <button
           key={agent.agent_id}
           onClick={() => selectAgent(agent.agent_id)}
-          className="w-full px-4 py-2.5 text-left transition-colors hover:bg-glass-bg border-l-2 border-transparent"
+          className="liquid-list-row w-full border-l-2 border-transparent px-4 py-2.5 text-left transition-colors"
         >
           <div className="flex items-center gap-2 text-sm font-medium text-text-primary">
             <PresenceDot agentId={agent.agent_id} fallback={agent.online} />
@@ -68,7 +68,7 @@ export default function PublicAgentList() {
       ))}
       <button
         onClick={() => void loadPublicAgents()}
-        className="w-full py-2 text-xs text-text-secondary hover:text-neon-cyan"
+        className="liquid-action mx-3 mb-1 w-[calc(100%-1.5rem)] py-2 text-xs text-text-secondary hover:text-neon-cyan"
       >
         Refresh
       </button>

--- a/frontend/src/components/dashboard/PublicRoomList.tsx
+++ b/frontend/src/components/dashboard/PublicRoomList.tsx
@@ -60,7 +60,7 @@ export default function PublicRoomList() {
 
   if (publicRooms.length === 0) {
     return (
-      <div className="p-4 text-center text-xs text-text-secondary">
+      <div className="liquid-empty-state m-3 p-4 text-center text-xs text-text-secondary">
         {t.noPublicRooms}
       </div>
     );
@@ -87,9 +87,9 @@ export default function PublicRoomList() {
           <button
             key={room.room_id}
             onClick={() => handleSelect(room.room_id)}
-            className={`w-full px-4 py-2.5 text-left transition-colors ${
+            className={`liquid-list-row w-full px-4 py-2.5 text-left transition-colors ${
               isSelected
-                ? "bg-neon-cyan/10 border-l-2 border-neon-cyan"
+                ? "!border-neon-cyan !bg-neon-cyan/10 border-l-2"
                 : "hover:bg-glass-bg border-l-2 border-transparent"
             }`}
           >
@@ -127,7 +127,7 @@ export default function PublicRoomList() {
       })}
       <button
         onClick={() => void loadPublicRooms()}
-        className="w-full py-2 text-xs text-text-secondary hover:text-neon-cyan"
+        className="liquid-action mx-3 mb-1 w-[calc(100%-1.5rem)] py-2 text-xs text-text-secondary hover:text-neon-cyan"
       >
         {tc.refresh}
       </button>

--- a/frontend/src/components/dashboard/ReplyQuoteBlock.tsx
+++ b/frontend/src/components/dashboard/ReplyQuoteBlock.tsx
@@ -20,7 +20,7 @@ export default function ReplyQuoteBlock({ preview, onJump, className }: ReplyQuo
 
   const senderLabel = preview.sender_display_name || preview.sender_id || "Unknown";
   const baseClass =
-    "mb-1.5 flex items-start gap-1.5 rounded-md border-l-2 border-neon-cyan/40 bg-glass-bg/60 pl-2 py-1 pr-2 text-xs";
+    "liquid-tool-surface mb-1.5 flex items-start gap-1.5 rounded-md border-l-2 border-neon-cyan/40 pl-2 py-1 pr-2 text-xs";
   const interactive = preview.deleted
     ? "opacity-60"
     : "cursor-pointer transition-colors hover:bg-glass-bg hover:border-neon-cyan/70";

--- a/frontend/src/components/dashboard/RoomHeader.tsx
+++ b/frontend/src/components/dashboard/RoomHeader.tsx
@@ -348,7 +348,7 @@ export default function RoomHeader() {
 
   return (
     <>
-      <div className="flex min-h-16 items-center justify-between gap-2 border-b border-glass-border px-4 py-3 max-md:min-h-12 max-md:gap-1 max-md:px-2 max-md:py-2">
+      <div className="liquid-toolbar flex min-h-16 items-center justify-between gap-2 border-b border-glass-border px-4 py-3 max-md:min-h-12 max-md:gap-1 max-md:px-2 max-md:py-2">
         <button
           type="button"
           onClick={handleMobileBack}

--- a/frontend/src/components/dashboard/RoomHumanComposer.tsx
+++ b/frontend/src/components/dashboard/RoomHumanComposer.tsx
@@ -129,14 +129,14 @@ function RoomTransferDialog({ roomId, members, senderIdentity, onClose, onSucces
   return (
     <div
       ref={overlayRef}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4 backdrop-blur-sm"
+      className="liquid-scrim fixed inset-0 z-50 flex items-center justify-center px-4 backdrop-blur-sm"
       onClick={() => closeWithMotion()}
     >
       <div
         ref={panelRef}
         role="dialog"
         aria-modal="true"
-        className="relative w-full max-w-md rounded-xl border border-glass-border bg-glass-bg p-5 backdrop-blur-xl"
+        className="liquid-dialog relative w-full max-w-md rounded-xl border border-glass-border p-5 backdrop-blur-xl"
         onClick={(event) => event.stopPropagation()}
       >
         <button
@@ -184,7 +184,7 @@ function RoomTransferDialog({ roomId, members, senderIdentity, onClose, onSucces
               value={amount}
               onChange={(event) => setAmount(event.target.value)}
               placeholder="1"
-              className="w-full rounded-lg border border-glass-border bg-deep-black-light p-3 font-mono text-sm text-text-primary placeholder-text-secondary/50 outline-none focus:border-neon-cyan/50"
+              className="liquid-input w-full rounded-lg border border-glass-border p-3 font-mono text-sm text-text-primary placeholder-text-secondary/50 outline-none"
             />
           </div>
 
@@ -197,7 +197,7 @@ function RoomTransferDialog({ roomId, members, senderIdentity, onClose, onSucces
               value={memo}
               onChange={(event) => setMemo(event.target.value)}
               placeholder={t.memoPlaceholder}
-              className="w-full rounded-lg border border-glass-border bg-deep-black-light p-3 text-sm text-text-primary placeholder-text-secondary/50 outline-none focus:border-neon-cyan/50"
+              className="liquid-input w-full rounded-lg border border-glass-border p-3 text-sm text-text-primary placeholder-text-secondary/50 outline-none"
             />
           </div>
 

--- a/frontend/src/components/dashboard/RoomList.tsx
+++ b/frontend/src/components/dashboard/RoomList.tsx
@@ -103,7 +103,7 @@ function UnreadBadge({ count }: { count: number }) {
   return (
     <span
       ref={badgeRef}
-      className="flex h-5 min-w-[20px] items-center justify-center rounded-full bg-neon-cyan px-1.5 text-[10px] font-bold leading-none text-black shadow-[0_0_10px_rgba(34,211,238,0.55)]"
+      className="flex h-5 min-w-[20px] items-center justify-center rounded-full bg-neon-cyan px-1.5 text-[10px] font-bold leading-none text-text-primary shadow-[0_0_10px_rgba(34,211,238,0.55)]"
     >
       {formatUnreadCount(count)}
     </span>
@@ -382,11 +382,11 @@ export default function RoomList({
           title={t.userChatTooltip}
           onClick={handleSelectUserChat}
           onKeyDown={handleUserChatKeyDown}
-          className={`relative w-full border-l-2 px-4 py-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-cyan/60 ${
+          className={`liquid-list-row relative w-full border-l-2 px-4 py-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-cyan/60 ${
             messagesPane === "user-chat"
-              ? "border-neon-cyan bg-neon-cyan/10"
+              ? "!border-neon-cyan !bg-neon-cyan/10"
               : isOwnerChatEmpty
-                ? "border-neon-cyan/50 bg-neon-cyan/[0.06]"
+                ? "!border-neon-cyan/50 !bg-neon-cyan/[0.06]"
                 : "border-transparent hover:bg-glass-bg"
           }`}
         >
@@ -423,7 +423,7 @@ export default function RoomList({
         </div>
       )}
       {displayRooms.length === 0 && !showUserChatEntry && (
-        <div className="p-4 text-center text-xs text-text-secondary">
+        <div className="liquid-empty-state m-3 p-4 text-center text-xs text-text-secondary">
           {t.noRooms}
         </div>
       )}
@@ -483,9 +483,9 @@ export default function RoomList({
             onMouseEnter={() => prefetchRoom(room)}
             onFocus={() => prefetchRoom(room)}
             onKeyDown={(event) => handleRoomKeyDown(event, room)}
-            className={`w-full border-l-2 px-4 py-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-cyan/60 ${
+            className={`liquid-list-row w-full border-l-2 px-4 py-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-cyan/60 ${
               isSelected
-                ? "border-neon-cyan bg-neon-cyan/10"
+                ? "!border-neon-cyan !bg-neon-cyan/10"
                 : "border-transparent hover:bg-glass-bg"
             }`}
           >

--- a/frontend/src/components/dashboard/RoomMemberSettingsModal.tsx
+++ b/frontend/src/components/dashboard/RoomMemberSettingsModal.tsx
@@ -109,12 +109,12 @@ export default function RoomMemberSettingsModal({
   };
 
   return (
-    <div ref={overlayRef} className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4" onClick={() => closeWithMotion()}>
+    <div ref={overlayRef} className="liquid-scrim fixed inset-0 z-50 flex items-center justify-center px-4 backdrop-blur-sm" onClick={() => closeWithMotion()}>
       <div
         ref={panelRef}
         role="dialog"
         aria-modal="true"
-        className="flex max-h-[90vh] w-full max-w-sm flex-col overflow-hidden rounded-xl border border-glass-border bg-deep-black"
+        className="liquid-dialog flex max-h-[90vh] w-full max-w-sm flex-col overflow-hidden rounded-xl border"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="border-b border-glass-border px-6 py-4">
@@ -128,7 +128,7 @@ export default function RoomMemberSettingsModal({
             </div>
           )}
 
-          <div>
+          <div className="liquid-card rounded-xl border p-3">
             <p className="mb-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-text-secondary/70">
               {t.name}
             </p>
@@ -136,7 +136,7 @@ export default function RoomMemberSettingsModal({
           </div>
 
           {roomDescription && (
-            <div>
+            <div className="liquid-card rounded-xl border p-3">
               <p className="mb-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-text-secondary/70">
                 {t.description}
               </p>
@@ -145,7 +145,7 @@ export default function RoomMemberSettingsModal({
           )}
 
           {roomRule && (
-            <div>
+            <div className="liquid-card rounded-xl border p-3">
               <p className="mb-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-text-secondary/70">
                 {t.rule}
               </p>
@@ -166,7 +166,7 @@ export default function RoomMemberSettingsModal({
               <button
                 onClick={() => void handleCancelSubscription()}
                 disabled={cancellingSubscription}
-                className="inline-flex items-center gap-1.5 rounded border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-400 hover:bg-red-500/20 disabled:opacity-50"
+                className="liquid-action inline-flex items-center gap-1.5 rounded border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-400 hover:bg-red-500/20 disabled:opacity-50"
               >
                 {cancellingSubscription && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
                 {cancellingSubscription ? t.cancellingSubscription : t.cancelSubscription}
@@ -175,7 +175,7 @@ export default function RoomMemberSettingsModal({
               <button
                 onClick={() => void handleLeave()}
                 disabled={isLeaving}
-                className="inline-flex items-center gap-1.5 rounded border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-400 hover:bg-red-500/20 disabled:opacity-50"
+                className="liquid-action inline-flex items-center gap-1.5 rounded border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-400 hover:bg-red-500/20 disabled:opacity-50"
               >
                 {isLeaving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
                 {confirmingLeave
@@ -186,7 +186,7 @@ export default function RoomMemberSettingsModal({
           )}
           <button
             onClick={() => closeWithMotion()}
-            className="ml-auto rounded border border-glass-border px-4 py-2 text-sm text-text-secondary hover:text-text-primary"
+            className="liquid-action ml-auto rounded px-4 py-2 text-sm text-text-secondary hover:text-text-primary"
           >
             {t.close}
           </button>

--- a/frontend/src/components/dashboard/RoomPolicyModal.tsx
+++ b/frontend/src/components/dashboard/RoomPolicyModal.tsx
@@ -180,14 +180,14 @@ export default function RoomPolicyModal({
   const modal = (
     <div
       ref={overlayRef}
-      className="fixed inset-0 z-[80] flex items-center justify-center bg-black/70 px-4 py-6 backdrop-blur"
+      className="liquid-scrim fixed inset-0 z-[80] flex items-center justify-center px-4 py-6 backdrop-blur"
       onClick={closeWithMotion}
     >
       <div
         ref={panelRef}
         role="dialog"
         aria-modal="true"
-        className="max-h-[calc(100vh-48px)] w-full max-w-lg overflow-y-auto rounded-2xl border border-glass-border bg-deep-black-light p-5 shadow-2xl"
+        className="liquid-dialog max-h-[calc(100vh-48px)] w-full max-w-lg overflow-y-auto rounded-2xl border p-5"
         onClick={(event) => event.stopPropagation()}
       >
         <div data-motion-item className="mb-4 flex items-start justify-between">
@@ -204,7 +204,7 @@ export default function RoomPolicyModal({
           <button
             type="button"
             onClick={closeWithMotion}
-            className="rounded p-1 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
+            className="liquid-action rounded p-1 text-text-secondary transition-colors hover:text-text-primary"
             aria-label="关闭"
           >
             <X className="h-4 w-4" />
@@ -212,7 +212,7 @@ export default function RoomPolicyModal({
         </div>
 
         {loading && !data ? (
-          <div data-motion-item className="flex items-center gap-2 rounded-xl border border-glass-border bg-glass-bg/40 px-3 py-3 text-sm text-text-secondary">
+          <div data-motion-item className="liquid-card flex items-center gap-2 rounded-xl border px-3 py-3 text-sm text-text-secondary">
             <MobileBotCordLoading
               label="加载中…"
               size="sm"
@@ -226,7 +226,7 @@ export default function RoomPolicyModal({
           </div>
         ) : data && effective ? (
           isDM ? (
-            <div data-motion-item className="rounded-xl border border-neon-cyan/25 bg-neon-cyan/5 px-4 py-4">
+            <div data-motion-item className="liquid-card rounded-xl border border-neon-cyan/25 bg-neon-cyan/5 px-4 py-4">
               <div className="text-sm font-medium text-neon-cyan">私聊始终唤醒</div>
               <p className="mt-1 text-xs text-text-secondary">
                 DM 房间当前强制使用所有消息唤醒，不能在房间级静音或覆盖。
@@ -247,7 +247,7 @@ export default function RoomPolicyModal({
                     void apply(() => snoozeRoom(agentId, roomId, 60))
                   }
                   disabled={busy}
-                  className="rounded-lg border border-glass-border bg-glass-bg/40 px-3 py-1.5 text-xs text-text-primary transition-colors hover:bg-glass-bg disabled:opacity-50"
+                  className="liquid-action rounded-lg px-3 py-1.5 text-xs text-text-primary transition-colors disabled:opacity-50"
                 >
                   静音 1 小时
                 </button>
@@ -259,7 +259,7 @@ export default function RoomPolicyModal({
                     )
                   }
                   disabled={busy}
-                  className="rounded-lg border border-glass-border bg-glass-bg/40 px-3 py-1.5 text-xs text-text-primary transition-colors hover:bg-glass-bg disabled:opacity-50"
+                  className="liquid-action rounded-lg px-3 py-1.5 text-xs text-text-primary transition-colors disabled:opacity-50"
                 >
                   静音到今天结束
                 </button>
@@ -269,7 +269,7 @@ export default function RoomPolicyModal({
                     void apply(() => snoozeRoom(agentId, roomId, 7 * 24 * 60))
                   }
                   disabled={busy}
-                  className="rounded-lg border border-glass-border bg-glass-bg/40 px-3 py-1.5 text-xs text-text-primary transition-colors hover:bg-glass-bg disabled:opacity-50"
+                  className="liquid-action rounded-lg px-3 py-1.5 text-xs text-text-primary transition-colors disabled:opacity-50"
                 >
                   静音 7 天
                 </button>
@@ -281,14 +281,14 @@ export default function RoomPolicyModal({
                     )
                   }
                   disabled={busy}
-                  className="rounded-lg border border-glass-border bg-glass-bg/40 px-3 py-1.5 text-xs text-text-primary transition-colors hover:bg-glass-bg disabled:opacity-50"
+                  className="liquid-action rounded-lg px-3 py-1.5 text-xs text-text-primary transition-colors disabled:opacity-50"
                 >
                   永久静音
                 </button>
                 </div>
               </div>
 
-              <div data-motion-item className="mt-4 rounded-xl border border-glass-border bg-glass-bg/30 p-3">
+              <div data-motion-item className="liquid-card mt-4 rounded-xl border p-3">
                 <button
                   type="button"
                   onClick={() => setExpanded((v) => !v)}
@@ -332,7 +332,7 @@ export default function RoomPolicyModal({
                       )
                     }
                     disabled={busy}
-                    className="rounded-lg border border-glass-border px-3 py-1.5 text-xs text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+                    className="liquid-action rounded-lg px-3 py-1.5 text-xs text-text-secondary transition-colors hover:text-text-primary disabled:opacity-50"
                   >
                     恢复默认（继承全局）
                   </button>
@@ -369,7 +369,7 @@ function EffectiveBadge({
         ? "本房间专属"
         : "继承全局";
   return (
-    <div className="rounded-xl border border-glass-border bg-glass-bg/40 px-3 py-3">
+    <div className="liquid-card rounded-xl border px-3 py-3">
       <div className="text-xs text-text-secondary">当前</div>
       <div className="mt-1 flex flex-wrap items-center gap-2">
         <span className="text-sm font-medium text-text-primary">
@@ -395,7 +395,7 @@ function EffectiveBadge({
           {effective.keywords.map((k) => (
             <span
               key={k}
-              className="rounded-full border border-glass-border bg-glass-bg px-2 py-0.5 text-[10px] text-text-secondary"
+              className="liquid-card rounded-full border px-2 py-0.5 text-[10px] text-text-secondary"
             >
               {k}
             </span>
@@ -526,13 +526,13 @@ function OverrideForm({
             onBlur={addKeyword}
             disabled={busy}
             placeholder="输入关键词后按回车添加"
-            className="rounded-xl border border-glass-border bg-deep-black/40 px-3 py-2 text-sm text-text-primary placeholder:text-text-tertiary focus:border-neon-cyan/40 focus:outline-none disabled:opacity-50"
+            className="liquid-input rounded-xl border border-glass-border px-3 py-2 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none disabled:opacity-50"
           />
         </div>
       ) : null}
 
       {mode === "allowed_senders" ? (
-        <div className="mt-3 rounded-xl border border-glass-border bg-deep-black/30 p-2">
+        <div className="liquid-card mt-3 rounded-xl border p-2">
           {membersLoading ? (
             <div className="flex items-center gap-2 px-1 py-2 text-xs text-text-secondary">
               <MobileBotCordLoading
@@ -551,7 +551,7 @@ function OverrideForm({
                 return (
                   <label
                     key={member.agent_id}
-                    className="flex cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 text-sm text-text-primary hover:bg-glass-bg/50"
+                    className="liquid-list-row flex cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 text-sm text-text-primary"
                   >
                     <input
                       type="checkbox"
@@ -594,7 +594,7 @@ function OverrideForm({
               setAllowedSenderIds(currentAllowedSenderIds);
             }}
             disabled={busy}
-            className="mr-2 inline-flex items-center gap-1.5 rounded-lg border border-glass-border px-3 py-1.5 text-xs text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+            className="liquid-action mr-2 inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs text-text-secondary transition-colors hover:text-text-primary disabled:opacity-50"
           >
             <RotateCcw className="h-3.5 w-3.5" />
             撤销更改
@@ -604,7 +604,7 @@ function OverrideForm({
           type="button"
           onClick={() => onApply(mode, keywords, allowedSenderIds)}
           disabled={busy}
-          className="inline-flex items-center gap-1.5 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-1.5 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/15 disabled:opacity-50"
+          className="liquid-action inline-flex items-center gap-1.5 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-1.5 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/15 disabled:opacity-50"
         >
           {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
           应用到本房间

--- a/frontend/src/components/dashboard/RoomSettingsModal.tsx
+++ b/frontend/src/components/dashboard/RoomSettingsModal.tsx
@@ -82,18 +82,18 @@ function ActionConfirmDialog({
 }: ActionConfirmDialogProps) {
   return (
     <div
-      className="fixed inset-0 z-[70] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm"
+      className="liquid-scrim fixed inset-0 z-[70] flex items-center justify-center p-4 backdrop-blur-sm"
       onClick={onClose}
     >
       <div
-        className="relative w-full max-w-md rounded-2xl border border-glass-border bg-deep-black-light p-5 shadow-2xl"
+        className="liquid-dialog relative w-full max-w-md rounded-2xl border p-5"
         onClick={(e) => e.stopPropagation()}
       >
         <button
           type="button"
           onClick={onClose}
           disabled={loading}
-          className="absolute right-4 top-4 rounded-full p-1.5 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+          className="liquid-action absolute right-4 top-4 rounded-full p-1.5 text-text-secondary transition-colors hover:text-text-primary disabled:opacity-50"
           aria-label={cancelLabel}
         >
           <X className="h-5 w-5" />
@@ -112,7 +112,7 @@ function ActionConfirmDialog({
               value={confirmValue}
               onChange={(e) => onConfirmValueChange?.(e.target.value)}
               placeholder={confirmPlaceholder}
-              className="w-full rounded-xl border border-glass-border bg-deep-black px-3 py-2.5 text-sm text-text-primary outline-none focus:border-red-400/50 placeholder:text-text-secondary/40"
+              className="liquid-input w-full rounded-xl border border-glass-border px-3 py-2.5 text-sm text-text-primary outline-none placeholder:text-text-secondary/40"
             />
           </label>
         ) : null}
@@ -128,7 +128,7 @@ function ActionConfirmDialog({
             type="button"
             onClick={onClose}
             disabled={loading}
-            className="rounded-xl border border-glass-border px-4 py-2.5 text-sm font-medium text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+            className="liquid-action rounded-xl px-4 py-2.5 text-sm font-medium text-text-secondary transition-colors hover:text-text-primary disabled:opacity-50"
           >
             {cancelLabel}
           </button>
@@ -136,7 +136,7 @@ function ActionConfirmDialog({
             type="button"
             onClick={onConfirm}
             disabled={confirmDisabled || loading}
-            className="inline-flex items-center gap-2 rounded-xl border border-red-400/50 bg-red-500/10 px-4 py-2.5 text-sm font-bold text-red-300 transition-all hover:bg-red-500/20 disabled:cursor-not-allowed disabled:opacity-50"
+            className="liquid-action inline-flex items-center gap-2 rounded-xl border border-red-400/50 bg-red-500/10 px-4 py-2.5 text-sm font-bold text-red-300 transition-all hover:bg-red-500/20 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
             {loading ? loadingLabel ?? confirmLabel : confirmLabel}
@@ -677,10 +677,10 @@ export default function RoomSettingsModal({
   };
 
   return (
-    <div ref={overlayRef} className="fixed inset-0 z-50 bg-black/60" onClick={closeWithAnimation}>
+    <div ref={overlayRef} className="liquid-scrim fixed inset-0 z-50 backdrop-blur-sm" onClick={closeWithAnimation}>
       <div
         ref={panelRef}
-        className="ml-auto flex h-full w-full max-w-[520px] flex-col overflow-hidden border-l border-glass-border bg-deep-black shadow-2xl"
+        className="liquid-drawer ml-auto flex h-full w-full max-w-[520px] flex-col overflow-hidden border-l"
         onClick={(e) => e.stopPropagation()}
         role="dialog"
         aria-modal="true"
@@ -691,7 +691,7 @@ export default function RoomSettingsModal({
           <button
             type="button"
             onClick={closeWithAnimation}
-            className="rounded-full p-2 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
+            className="liquid-action rounded-full p-2 text-text-secondary transition-colors hover:text-text-primary"
             aria-label={t.cancel}
           >
             <X className="h-5 w-5" />
@@ -731,7 +731,7 @@ export default function RoomSettingsModal({
                         value={name}
                         onChange={(e) => setName(e.target.value)}
                         maxLength={120}
-                        className="w-full rounded-xl border border-glass-border bg-glass-bg px-3 py-2.5 text-sm text-text-primary outline-none focus:border-neon-cyan/50"
+                        className="liquid-input w-full rounded-xl border border-glass-border px-3 py-2.5 text-sm text-text-primary outline-none"
                       />
                     </div>
                     <div>
@@ -743,7 +743,7 @@ export default function RoomSettingsModal({
                         value={description}
                         onChange={(e) => setDescription(e.target.value)}
                         maxLength={500}
-                        className="w-full resize-none rounded-xl border border-glass-border bg-glass-bg px-3 py-2.5 text-sm text-text-primary outline-none focus:border-neon-cyan/50"
+                        className="liquid-input w-full resize-none rounded-xl border border-glass-border px-3 py-2.5 text-sm text-text-primary outline-none"
                       />
                     </div>
                     <div>
@@ -756,7 +756,7 @@ export default function RoomSettingsModal({
                         onChange={(e) => setRule(e.target.value)}
                         rows={4}
                         maxLength={4000}
-                        className="w-full resize-none rounded-xl border border-glass-border bg-glass-bg px-3 py-2.5 text-sm leading-relaxed text-text-primary outline-none focus:border-neon-cyan/50"
+                        className="liquid-input w-full resize-none rounded-xl border border-glass-border px-3 py-2.5 text-sm leading-relaxed text-text-primary outline-none"
                       />
                     </div>
                   </>
@@ -799,7 +799,7 @@ export default function RoomSettingsModal({
                   <button
                     type="button"
                     onClick={() => setAddMemberModalOpen(true)}
-                    className="rounded-xl border border-neon-cyan/30 bg-neon-cyan/10 px-3 py-1.5 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/15"
+                    className="liquid-action rounded-xl border border-neon-cyan/30 bg-neon-cyan/10 px-3 py-1.5 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/15"
                   >
                     {tm.addMembersEntry}
                   </button>
@@ -807,7 +807,7 @@ export default function RoomSettingsModal({
               </div>
 
               <div className="mt-4 space-y-4">
-                <div className="flex items-center gap-2 rounded-xl border border-glass-border bg-glass-bg px-3">
+                <div className="liquid-input flex items-center gap-2 rounded-xl border px-3">
                   <Search className="h-4 w-4 text-text-secondary/70" />
                   <input
                     value={memberQuery}
@@ -817,7 +817,7 @@ export default function RoomSettingsModal({
                   />
                 </div>
 
-                <div className="max-h-72 overflow-y-auto rounded-xl border border-glass-border bg-deep-black/40">
+                <div className="liquid-card max-h-72 overflow-y-auto rounded-xl border">
                   {membersLoading ? (
                     <MobileBotCordLoading
                       label={tm.loadingMembers}
@@ -837,7 +837,7 @@ export default function RoomSettingsModal({
                         return (
                           <div
                             key={member.agent_id}
-                            className="flex items-center justify-between gap-3 px-4 py-3"
+                            className="liquid-list-row flex items-center justify-between gap-3 px-4 py-3"
                           >
                             <div className="min-w-0 flex-1">
                               <div className="flex items-center gap-2">
@@ -874,7 +874,7 @@ export default function RoomSettingsModal({
                                     <button
                                       type="button"
                                       onClick={() => setConfirmRemoveId(null)}
-                                      className="rounded px-2 py-1 text-[11px] text-text-secondary hover:bg-glass-bg transition-colors"
+                                      className="liquid-action rounded px-2 py-1 text-[11px] text-text-secondary transition-colors"
                                     >
                                       取消
                                     </button>
@@ -882,7 +882,7 @@ export default function RoomSettingsModal({
                                       type="button"
                                       disabled={removingId === member.agent_id}
                                       onClick={() => void handleRemoveMember(member.agent_id)}
-                                      className="rounded bg-red-500/15 px-2 py-1 text-[11px] text-red-400 hover:bg-red-500/25 disabled:opacity-50 transition-colors"
+                                      className="liquid-action rounded border border-red-500/25 bg-red-500/15 px-2 py-1 text-[11px] text-red-400 hover:bg-red-500/25 disabled:opacity-50 transition-colors"
                                     >
                                       {removingId === member.agent_id ? "…" : "确认移除"}
                                     </button>
@@ -891,7 +891,7 @@ export default function RoomSettingsModal({
                                   <button
                                     type="button"
                                     onClick={() => setConfirmRemoveId(member.agent_id)}
-                                    className="rounded p-1.5 text-text-secondary/50 hover:bg-red-500/10 hover:text-red-400 transition-colors"
+                                    className="liquid-action rounded p-1.5 text-text-secondary/50 hover:bg-red-500/10 hover:text-red-400 transition-colors"
                                     title="移除成员"
                                   >
                                     <Trash2 className="h-3.5 w-3.5" />
@@ -919,7 +919,7 @@ export default function RoomSettingsModal({
 
             {sessionOwnedAgents.length > 0 ? (
               <section className="border-t border-glass-border/40 py-5">
-                <div className="rounded-xl border border-glass-border bg-glass-bg/30 px-3 py-3">
+                <div className="liquid-card rounded-xl border px-3 py-3">
                   <div className="mb-3">
                     <p className="text-sm font-semibold text-text-primary">
                       {locale === "zh" ? "本房间回复策略" : "Reply policy for this room"}
@@ -948,7 +948,7 @@ export default function RoomSettingsModal({
                       type="button"
                       onClick={() => setShowPolicyModal(true)}
                       disabled={!policyAgentId}
-                      className="inline-flex items-center justify-center gap-2 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-2 text-sm text-neon-cyan transition-colors hover:bg-neon-cyan/20 disabled:cursor-not-allowed disabled:opacity-50"
+                      className="liquid-action inline-flex items-center justify-center gap-2 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-2 text-sm text-neon-cyan transition-colors hover:bg-neon-cyan/20 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       {locale === "zh" ? "设置" : "Configure"}
                       <ChevronDown className="h-4 w-4 shrink-0 -rotate-90" />
@@ -996,7 +996,7 @@ export default function RoomSettingsModal({
                           if (value) setVisibility(value);
                         }}
                         placeholder={ta.visibilityLabel}
-                        buttonClassName="bg-glass-bg"
+                        buttonClassName="liquid-action"
                         options={[
                           { value: "private", label: ta.visibilityPrivate },
                           { value: "public", label: ta.visibilityPublic },
@@ -1012,7 +1012,7 @@ export default function RoomSettingsModal({
                           if (value) setJoinPolicy(value);
                         }}
                         placeholder={ta.joinPolicyLabel}
-                        buttonClassName="bg-glass-bg"
+                        buttonClassName="liquid-action"
                         options={[
                           { value: "invite_only", label: ta.joinPolicyInviteOnly },
                           { value: "open", label: ta.joinPolicyOpen },
@@ -1021,7 +1021,7 @@ export default function RoomSettingsModal({
                     </label>
                   </div>
                   <div className="grid gap-3">
-                    <label className="flex items-center gap-2 rounded-xl border border-glass-border bg-glass-bg px-3 py-3 text-xs text-text-secondary">
+                    <label className="liquid-card flex items-center gap-2 rounded-xl border px-3 py-3 text-xs text-text-secondary">
                       <input
                         type="checkbox"
                         disabled={!isOwner}
@@ -1031,7 +1031,7 @@ export default function RoomSettingsModal({
                       />
                       {ta.defaultSendLabel}
                     </label>
-                    <label className="flex items-center gap-2 rounded-xl border border-glass-border bg-glass-bg px-3 py-3 text-xs text-text-secondary">
+                    <label className="liquid-card flex items-center gap-2 rounded-xl border px-3 py-3 text-xs text-text-secondary">
                       <input
                         type="checkbox"
                         disabled={!isOwner}
@@ -1041,7 +1041,7 @@ export default function RoomSettingsModal({
                       />
                       {ta.defaultInviteLabel}
                     </label>
-                    <label className="flex items-center gap-2 rounded-xl border border-glass-border bg-glass-bg px-3 py-3 text-xs text-text-secondary">
+                    <label className="liquid-card flex items-center gap-2 rounded-xl border px-3 py-3 text-xs text-text-secondary">
                       <input
                         type="checkbox"
                         disabled={!isOwner}
@@ -1077,7 +1077,7 @@ export default function RoomSettingsModal({
                   {!isOwner && (
                     <p className="text-[11px] text-text-secondary/70">{ta.ownerOnly}</p>
                   )}
-                  <div className="flex items-center justify-between gap-4 rounded-xl border border-glass-border bg-glass-bg px-4 py-3">
+                  <div className="liquid-card flex items-center justify-between gap-4 rounded-xl border px-4 py-3">
                     <div className="min-w-0">
                       <p className="text-sm font-medium text-text-primary">{ta.subscriptionToggleLabel}</p>
                       <p className="mt-1 text-xs text-text-secondary/70">
@@ -1088,7 +1088,7 @@ export default function RoomSettingsModal({
                       type="button"
                       disabled={!isOwner || multiRoomBlocked}
                       onClick={() => setSubscriptionEnabled((v) => !v)}
-                      className={`shrink-0 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${subscriptionEnabled ? "border-neon-cyan/40 bg-neon-cyan/10 text-neon-cyan" : "border-glass-border text-text-secondary hover:bg-glass-bg"}`}
+                      className={`liquid-action shrink-0 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${subscriptionEnabled ? "border-neon-cyan/40 bg-neon-cyan/10 text-neon-cyan" : "border-glass-border text-text-secondary"}`}
                     >
                       {subscriptionEnabled ? ta.subscriptionToggleOn : ta.subscriptionToggleOff}
                     </button>
@@ -1101,7 +1101,7 @@ export default function RoomSettingsModal({
                   )}
 
                   {subscriptionEnabled && isOwner && (
-                    <div className="space-y-3 rounded-xl border border-glass-border bg-deep-black/40 px-4 py-3">
+                    <div className="liquid-card space-y-3 rounded-xl border px-4 py-3">
                       <div className="flex items-center gap-3">
                         <label className="text-sm text-text-primary">
                           {ta.subscriptionPriceLabel}
@@ -1119,7 +1119,7 @@ export default function RoomSettingsModal({
                               setPriceInput(e.target.value);
                             }
                           }}
-                          className="w-28 rounded-lg border border-glass-border bg-deep-black px-2 py-1 text-sm text-text-primary"
+                          className="liquid-input w-28 rounded-lg border border-glass-border px-2 py-1 text-sm text-text-primary"
                         />
                         <span className="text-xs text-text-secondary/80">Coin</span>
                       </div>
@@ -1205,7 +1205,7 @@ export default function RoomSettingsModal({
                     <button
                       onClick={() => setLeaveDialogOpen(true)}
                       disabled={isLeaving}
-                      className="shrink-0 rounded-lg border border-red-500/30 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10 disabled:cursor-not-allowed disabled:opacity-45"
+                      className="liquid-action shrink-0 rounded-lg border border-red-500/30 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10 disabled:cursor-not-allowed disabled:opacity-45"
                     >
                       {isLeaving ? tm.leavingRoom : tm.leaveRoom}
                     </button>
@@ -1220,7 +1220,7 @@ export default function RoomSettingsModal({
                     <button
                       onClick={() => void handleCancelSubscription()}
                       disabled={cancellingSubscription}
-                      className="shrink-0 rounded-lg border border-yellow-500/30 px-3 py-1.5 text-xs font-medium text-yellow-300 transition-colors hover:bg-yellow-500/10 disabled:cursor-not-allowed disabled:opacity-45"
+                      className="liquid-action shrink-0 rounded-lg border border-yellow-500/30 px-3 py-1.5 text-xs font-medium text-yellow-300 transition-colors hover:bg-yellow-500/10 disabled:cursor-not-allowed disabled:opacity-45"
                     >
                       {cancellingSubscription ? tm.cancellingSubscription : tm.cancelSubscription}
                     </button>
@@ -1234,7 +1234,7 @@ export default function RoomSettingsModal({
                     </div>
                     <button
                       onClick={() => setTransferDialogOpen(true)}
-                      className="shrink-0 rounded-lg border border-neon-purple/30 px-3 py-1.5 text-xs font-medium text-neon-purple transition-colors hover:bg-neon-purple/10"
+                      className="liquid-action shrink-0 rounded-lg border border-neon-purple/30 px-3 py-1.5 text-xs font-medium text-neon-purple transition-colors hover:bg-neon-purple/10"
                     >
                       {tm.transferOwnership}
                     </button>
@@ -1252,7 +1252,7 @@ export default function RoomSettingsModal({
                         setDissolveDialogOpen(true);
                       }}
                       disabled={dissolving}
-                      className="shrink-0 rounded-lg border border-red-500/35 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10 disabled:cursor-not-allowed disabled:opacity-45"
+                      className="liquid-action shrink-0 rounded-lg border border-red-500/35 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10 disabled:cursor-not-allowed disabled:opacity-45"
                     >
                       {dissolving ? t.dissolvingRoom : t.dissolveRoom}
                     </button>
@@ -1267,7 +1267,7 @@ export default function RoomSettingsModal({
           <button
             onClick={closeWithAnimation}
             disabled={saving}
-            className="rounded-xl border border-glass-border px-4 py-2.5 text-sm text-text-secondary hover:text-text-primary disabled:opacity-50"
+            className="liquid-action rounded-xl px-4 py-2.5 text-sm text-text-secondary hover:text-text-primary disabled:opacity-50"
           >
             {t.cancel}
           </button>
@@ -1275,7 +1275,7 @@ export default function RoomSettingsModal({
             <button
               onClick={() => void handleSave()}
               disabled={saving}
-              className="inline-flex items-center gap-2 rounded-xl border border-neon-cyan/50 bg-neon-cyan/10 px-4 py-2.5 text-sm text-neon-cyan hover:bg-neon-cyan/20 disabled:opacity-50"
+              className="liquid-action inline-flex items-center gap-2 rounded-xl border border-neon-cyan/50 bg-neon-cyan/10 px-4 py-2.5 text-sm text-neon-cyan hover:bg-neon-cyan/20 disabled:opacity-50"
             >
               {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
               {saving ? t.saving : t.save}

--- a/frontend/src/components/dashboard/RoomZeroState.tsx
+++ b/frontend/src/components/dashboard/RoomZeroState.tsx
@@ -114,7 +114,7 @@ export default function RoomZeroState({ compact = false, hasRooms = false, onHum
 
   if (compact) {
     return (
-      <div className="m-3 rounded-2xl border border-dashed border-glass-border bg-glass-bg/30 p-4">
+      <div className="liquid-empty-state m-3 rounded-2xl border border-dashed border-glass-border p-4">
         <p className="text-sm font-semibold text-text-primary">{titleCopy}</p>
         <p className="mt-1 text-xs leading-5 text-text-secondary">{descCopy}</p>
         <div className="mt-3 flex flex-col gap-2">
@@ -130,7 +130,7 @@ export default function RoomZeroState({ compact = false, hasRooms = false, onHum
           <button
             type="button"
             onClick={() => router.push("/chats/explore/rooms")}
-            className="rounded-xl border border-glass-border bg-deep-black-light px-4 py-2 text-xs font-medium text-text-primary transition-colors hover:border-neon-cyan/35 hover:text-neon-cyan"
+            className="liquid-action rounded-xl border border-glass-border px-4 py-2 text-xs font-medium text-text-primary transition-colors hover:border-neon-cyan/35 hover:text-neon-cyan"
           >
             {t.openExplore}
           </button>
@@ -199,7 +199,7 @@ export default function RoomZeroState({ compact = false, hasRooms = false, onHum
                   type="button"
                   disabled={joiningId === room.room_id}
                   onClick={() => handleJoin(room)}
-                  className="group overflow-hidden rounded-xl border border-glass-border bg-deep-black-light text-left transition-all hover:border-neon-cyan/60 hover:shadow-md hover:shadow-neon-cyan/10 disabled:opacity-60"
+                  className="liquid-card group overflow-hidden rounded-xl border border-glass-border text-left transition-all hover:border-neon-cyan/60 hover:shadow-md hover:shadow-neon-cyan/10 disabled:opacity-60"
                 >
                   <div
                     className="relative h-14 w-full"
@@ -257,7 +257,7 @@ export default function RoomZeroState({ compact = false, hasRooms = false, onHum
                   key={agent.agent_id}
                   type="button"
                   onClick={() => selectAgent(agent.agent_id)}
-                  className="group rounded-xl border border-glass-border bg-deep-black-light p-3 text-left transition-all hover:border-neon-purple/60 hover:bg-glass-bg"
+                  className="liquid-card group rounded-xl border border-glass-border p-3 text-left transition-all hover:border-neon-purple/60 hover:bg-glass-bg"
                 >
                   <div className="mb-2 flex items-center gap-2">
                     <div className="flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-full border border-neon-purple/30 bg-neon-purple/10 text-xs font-semibold text-neon-purple">
@@ -300,7 +300,7 @@ export default function RoomZeroState({ compact = false, hasRooms = false, onHum
                   key={human.human_id}
                   type="button"
                   onClick={() => onHumanOpen(human)}
-                  className="group rounded-xl border border-glass-border bg-deep-black-light p-3 text-left transition-all hover:border-neon-green/60 hover:bg-glass-bg"
+                  className="liquid-card group rounded-xl border border-glass-border p-3 text-left transition-all hover:border-neon-green/60 hover:bg-glass-bg"
                 >
                   <div className="mb-2 flex items-center gap-2">
                     {human.avatar_url ? (

--- a/frontend/src/components/dashboard/RuntimeErrorDetailsDialog.tsx
+++ b/frontend/src/components/dashboard/RuntimeErrorDetailsDialog.tsx
@@ -66,12 +66,12 @@ export default function RuntimeErrorDetailsDialog({
   return (
     <div
       ref={overlayRef}
-      className={`fixed inset-0 z-[80] flex items-center justify-center bg-black/60 px-4 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`}
+      className={`liquid-scrim fixed inset-0 z-[80] flex items-center justify-center px-4 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`}
       onClick={closeWithMotion}
     >
       <div
         ref={panelRef}
-        className="w-full max-w-lg rounded-xl border border-amber-400/25 bg-zinc-950 shadow-2xl"
+        className="liquid-dialog w-full max-w-lg rounded-xl border-amber-400/25"
         onClick={(event) => event.stopPropagation()}
       >
         <div className="flex items-center justify-between gap-3 border-b border-amber-400/15 px-4 py-3">
@@ -82,7 +82,7 @@ export default function RuntimeErrorDetailsDialog({
           <button
             type="button"
             onClick={closeWithMotion}
-            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-zinc-500 transition-colors hover:bg-zinc-800 hover:text-zinc-200"
+            className="liquid-action flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-text-secondary transition-colors hover:text-text-primary"
             aria-label="Close"
           >
             <X className="h-4 w-4" />
@@ -91,17 +91,17 @@ export default function RuntimeErrorDetailsDialog({
 
         <div className="max-h-[70vh] space-y-4 overflow-y-auto px-4 py-4">
           <div>
-            <p className="mb-1.5 text-xs font-medium uppercase tracking-wide text-zinc-500">Message</p>
+            <p className="mb-1.5 text-xs font-medium uppercase tracking-wide text-text-secondary">Message</p>
             <div className="whitespace-pre-wrap break-words rounded-lg border border-amber-400/15 bg-amber-400/10 px-3 py-2 text-sm leading-relaxed text-amber-100">
               {message || "Runtime error"}
             </div>
           </div>
 
           <details className="group">
-            <summary className="cursor-pointer select-none text-xs font-medium uppercase tracking-wide text-zinc-500 transition-colors hover:text-zinc-300">
+            <summary className="cursor-pointer select-none text-xs font-medium uppercase tracking-wide text-text-secondary transition-colors hover:text-text-primary">
               Raw payload
             </summary>
-            <pre className="mt-2 max-h-64 overflow-auto rounded-lg border border-zinc-800 bg-black/40 p-3 text-xs leading-relaxed text-zinc-300">
+            <pre className="liquid-tool-surface mt-2 max-h-64 overflow-auto rounded-lg border p-3 text-xs leading-relaxed text-text-primary">
               {raw}
             </pre>
           </details>
@@ -118,7 +118,7 @@ export default function RuntimeErrorDetailsDialog({
                 copyAnimationRef.current = animatePop(copyButtonRef.current);
               }
             }}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-zinc-700 px-3 py-1.5 text-xs text-zinc-300 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
+            className="liquid-action inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs text-text-secondary transition-colors hover:text-text-primary"
           >
             <Copy className="h-3.5 w-3.5" />
             Copy details
@@ -126,7 +126,7 @@ export default function RuntimeErrorDetailsDialog({
           <button
             type="button"
             onClick={closeWithMotion}
-            className="rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-1.5 text-xs font-medium text-amber-200 transition-colors hover:bg-amber-400/20"
+            className="liquid-action rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-1.5 text-xs font-medium text-amber-200 transition-colors hover:bg-amber-400/20"
           >
             Close
           </button>

--- a/frontend/src/components/dashboard/SearchBar.tsx
+++ b/frontend/src/components/dashboard/SearchBar.tsx
@@ -62,7 +62,7 @@ export default function SearchBar({ onSearch, placeholder }: SearchBarProps) {
       onChange={handleChange}
       onFocus={handleFocus}
       placeholder={resolvedPlaceholder}
-      className="w-full rounded-lg border border-glass-border bg-deep-black-light px-3 py-2 text-sm text-text-primary placeholder-text-secondary/50 outline-none transition-colors focus:border-neon-cyan/50"
+      className="liquid-input w-full rounded-lg border border-glass-border px-3 py-2 text-sm text-text-primary placeholder-text-secondary/50 outline-none transition-colors focus:border-neon-cyan/50"
     />
   );
 }

--- a/frontend/src/components/dashboard/SettingsModal.tsx
+++ b/frontend/src/components/dashboard/SettingsModal.tsx
@@ -51,14 +51,14 @@ export default function SettingsModal({ onClose }: SettingsModalProps) {
   return (
     <div
       ref={overlayRef}
-      className={`fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/60 backdrop-blur-sm py-8 px-4 ${closing ? "pointer-events-none" : ""}`}
+      className={`liquid-scrim fixed inset-0 z-50 flex items-start justify-center overflow-y-auto backdrop-blur-sm py-8 px-4 ${closing ? "pointer-events-none" : ""}`}
       onClick={closeWithMotion}
     >
       <div
         ref={panelRef}
         role="dialog"
         aria-modal="true"
-        className="relative w-full max-w-2xl rounded-2xl border border-glass-border bg-deep-black-light shadow-2xl"
+        className="liquid-dialog relative w-full max-w-2xl rounded-2xl border"
         onClick={(e) => e.stopPropagation()}
       >
         <div data-settings-modal-part className="flex items-center justify-between border-b border-glass-border/50 px-6 py-4">
@@ -66,7 +66,7 @@ export default function SettingsModal({ onClose }: SettingsModalProps) {
           <button
             type="button"
             onClick={closeWithMotion}
-            className="flex h-7 w-7 items-center justify-center rounded-lg text-text-secondary/60 transition-colors hover:bg-glass-bg hover:text-text-primary"
+            className="liquid-action flex h-7 w-7 items-center justify-center rounded-lg text-text-secondary/60 transition-colors hover:text-text-primary"
           >
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="h-4 w-4">
               <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />

--- a/frontend/src/components/dashboard/ShareModal.tsx
+++ b/frontend/src/components/dashboard/ShareModal.tsx
@@ -159,12 +159,12 @@ export default function ShareModal({ roomId, roomName, roomVisibility, canInvite
   return (
     <div
       ref={overlayRef}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4 py-6 backdrop-blur-sm"
+      className="liquid-scrim fixed inset-0 z-50 flex items-center justify-center px-4 py-6 backdrop-blur-sm"
       onClick={closeWithAnimation}
     >
       <div
         ref={panelRef}
-        className="relative w-full max-w-2xl overflow-hidden rounded-[28px] shadow-[0_32px_120px_rgba(0,0,0,0.45)]"
+        className="liquid-dialog relative w-full max-w-2xl overflow-hidden rounded-[28px] border"
         onClick={(e) => e.stopPropagation()}
         role="dialog"
         aria-modal="true"
@@ -173,7 +173,7 @@ export default function ShareModal({ roomId, roomName, roomVisibility, canInvite
         <div className="relative flex max-h-[90vh] flex-col overflow-hidden">
           <button
             onClick={closeWithAnimation}
-            className="absolute right-3 top-3 z-10 rounded-full bg-black/25 p-2 text-text-secondary transition-colors hover:bg-white/10 hover:text-text-primary"
+            className="liquid-action absolute right-3 top-3 z-10 rounded-full p-2 text-text-secondary transition-colors hover:text-text-primary"
             aria-label={common[locale].close}
             title={common[locale].close}
           >
@@ -189,7 +189,7 @@ export default function ShareModal({ roomId, roomName, roomVisibility, canInvite
 
             <section className="w-full" data-overlay-section>
               <div
-                className="relative h-56 overflow-hidden rounded-[28px] border border-white/10"
+                className="relative h-56 overflow-hidden rounded-[28px] border border-glass-border"
                 style={{ backgroundImage: roomVisualTheme.patternUrl, backgroundRepeat: "repeat" }}
               >
                 <div className="absolute inset-0 bg-[linear-gradient(135deg,rgba(7,10,22,0.18),rgba(7,10,22,0.82))]" />
@@ -198,22 +198,22 @@ export default function ShareModal({ roomId, roomName, roomVisibility, canInvite
                     <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-neon-cyan/80">{t.shareRoom}</p>
                   </div>
                   <div className="flex flex-wrap justify-end gap-2">
-                    <span className="rounded-full bg-black/25 px-3 py-1 text-[11px] font-medium text-white/85 backdrop-blur-sm">{visibilityLabel}</span>
-                    <span className="rounded-full bg-black/25 px-3 py-1 text-[11px] font-medium text-white/85 backdrop-blur-sm">{accessLabel}</span>
+                    <span className="liquid-card rounded-full px-3 py-1 text-[11px] font-medium text-text-primary">{visibilityLabel}</span>
+                    <span className="liquid-card rounded-full px-3 py-1 text-[11px] font-medium text-text-primary">{accessLabel}</span>
                   </div>
                 </div>
                 <div className="absolute inset-x-0 bottom-0 p-5">
                   <div className="space-y-4">
                     <div className="flex items-center gap-4">
                       <div
-                        className="flex h-16 w-16 items-center justify-center rounded-[20px] text-lg font-bold text-white/90 backdrop-blur-sm"
+                        className="liquid-card flex h-16 w-16 items-center justify-center rounded-[20px] text-lg font-bold text-text-primary"
                         style={{ background: roomVisualTheme.accentDim, boxShadow: `0 0 0 1px ${roomVisualTheme.accent}55` }}
                       >
                         {roomInitials}
                       </div>
                       <div className="min-w-0">
-                        <h2 id="share-modal-title" className="truncate text-[34px] font-semibold leading-none text-white">{roomName}</h2>
-                        <p className="mt-3 text-sm leading-6 text-white/72">{t.createShareAssets}</p>
+                        <h2 id="share-modal-title" className="truncate text-[34px] font-semibold leading-none text-text-primary">{roomName}</h2>
+                        <p className="mt-3 text-sm leading-6 text-text-secondary">{t.createShareAssets}</p>
                       </div>
                     </div>
                     {membersLoading ? (
@@ -221,24 +221,24 @@ export default function ShareModal({ roomId, roomName, roomVisibility, canInvite
                         {Array.from({ length: memberSkeletonCount }, (_, index) => (
                           <div
                             key={`member-skeleton-${index}`}
-                            className="h-10 w-10 shrink-0 animate-pulse rounded-full bg-white/12"
+                            className="liquid-card h-10 w-10 shrink-0 animate-pulse rounded-full"
                           />
                         ))}
-                        <div className="h-10 w-16 shrink-0 animate-pulse rounded-full bg-white/10" />
+                        <div className="liquid-card h-10 w-16 shrink-0 animate-pulse rounded-full" />
                       </div>
                     ) : visibleMembers.length > 0 ? (
                       <div className="flex items-center gap-2 overflow-hidden">
                         {visibleMembers.map((member, index) => (
                           <div
                             key={member.agent_id}
-                            className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gradient-to-br ${memberAvatarTones[index % memberAvatarTones.length]} text-xs font-semibold text-white shadow-[0_8px_24px_rgba(0,0,0,0.28)]`}
+                            className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gradient-to-br ${memberAvatarTones[index % memberAvatarTones.length]} text-xs font-semibold text-text-primary`}
                             title={member.display_name}
                           >
                             {initialsFromName(member.display_name || member.agent_id)}
                           </div>
                         ))}
                         {remainingMembers > 0 ? (
-                          <div className="flex h-10 shrink-0 items-center justify-center rounded-full bg-white/[0.08] px-3 text-xs font-semibold text-white/80">
+                          <div className="liquid-card flex h-10 shrink-0 items-center justify-center rounded-full px-3 text-xs font-semibold text-text-primary">
                             +{remainingMembers}
                           </div>
                         ) : null}
@@ -253,7 +253,7 @@ export default function ShareModal({ roomId, roomName, roomVisibility, canInvite
                   <div className="space-y-3">
                     <button
                       onClick={() => void handleCopyText(typeof window !== "undefined" ? window.location.href : "", "plain-link")}
-                      className="flex w-full items-start justify-between gap-4 rounded-2xl bg-black/20 px-4 py-4 text-left transition-colors hover:bg-white/5"
+                      className="liquid-list-row flex w-full items-start justify-between gap-4 rounded-2xl px-4 py-4 text-left transition-colors"
                     >
                       <div className="flex items-start gap-3">
                         <div className="mt-0.5 rounded-xl bg-neon-cyan/12 p-2 text-neon-cyan">
@@ -264,7 +264,7 @@ export default function ShareModal({ roomId, roomName, roomVisibility, canInvite
                           <p className="mt-1 text-xs leading-5 text-text-secondary">{t.copyCurrentUrlDescription}</p>
                         </div>
                       </div>
-                      <span className="shrink-0 rounded-full bg-white/[0.07] px-3 py-1 text-[11px] font-medium text-text-primary/90">
+                      <span className="liquid-card shrink-0 rounded-full px-3 py-1 text-[11px] font-medium text-text-primary/90">
                         {copiedField === "plain-link" ? tc.copied : tc.copy}
                       </span>
                     </button>
@@ -275,7 +275,7 @@ export default function ShareModal({ roomId, roomName, roomVisibility, canInvite
                       <button
                         onClick={handleCreate}
                         disabled={loading}
-                        className="inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-neon-cyan/15 px-4 py-3 text-sm font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20 disabled:cursor-not-allowed disabled:opacity-50"
+                        className="liquid-action inline-flex w-full items-center justify-center gap-2 rounded-2xl border border-neon-cyan/35 bg-neon-cyan/15 px-4 py-3 text-sm font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20 disabled:cursor-not-allowed disabled:opacity-50"
                       >
                         {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
                         {loading ? t.creating : t.createShareLink}
@@ -285,7 +285,7 @@ export default function ShareModal({ roomId, roomName, roomVisibility, canInvite
                     <div className="space-y-3">
                       <button
                         onClick={() => void handleCopyPlainLink()}
-                        className="flex w-full items-start justify-between gap-4 rounded-2xl bg-black/20 px-4 py-4 text-left transition-colors hover:bg-white/5"
+                        className="liquid-list-row flex w-full items-start justify-between gap-4 rounded-2xl px-4 py-4 text-left transition-colors"
                       >
                         <div className="flex items-start gap-3">
                           <div className="mt-0.5 rounded-xl bg-neon-cyan/12 p-2 text-neon-cyan">
@@ -299,7 +299,7 @@ export default function ShareModal({ roomId, roomName, roomVisibility, canInvite
                             ) : null}
                           </div>
                         </div>
-                        <span className="shrink-0 rounded-full bg-white/[0.07] px-3 py-1 text-[11px] font-medium text-text-primary/90">
+                        <span className="liquid-card shrink-0 rounded-full px-3 py-1 text-[11px] font-medium text-text-primary/90">
                           {copiedField === "plain-link" ? tc.copied : tc.copy}
                         </span>
                       </button>
@@ -307,7 +307,7 @@ export default function ShareModal({ roomId, roomName, roomVisibility, canInvite
                   )
                 }
 
-                <div className="rounded-2xl bg-black/20 px-4 py-4">
+                <div className="liquid-card rounded-2xl px-4 py-4">
                   <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-text-secondary/70">
                     {entryType === "private_invite" || roomVisibility === "private" ? <Lock className="h-3.5 w-3.5" /> : <Globe2 className="h-3.5 w-3.5" />}
                     {distributionLabel}

--- a/frontend/src/components/dashboard/StreamBlocksView.tsx
+++ b/frontend/src/components/dashboard/StreamBlocksView.tsx
@@ -720,18 +720,18 @@ function StreamBlockItem({
       <div className="py-1">
         <button
           onClick={() => details && setResultExpanded(!resultExpanded)}
-          className="flex items-center gap-2 group min-w-0 text-left"
+          className="liquid-action flex min-w-0 items-center gap-2 rounded-md px-1 py-0.5 text-left"
         >
           <ToolCallIcon name={name} />
           <span className="text-xs font-mono text-cyan-400">{name}</span>
           {details && (
             resultExpanded
-              ? <ChevronDown className="inline ml-1 w-2.5 h-2.5 text-zinc-500" />
-              : <ChevronRight className="inline ml-1 w-2.5 h-2.5 text-zinc-500" />
+              ? <ChevronDown className="ml-1 inline h-2.5 w-2.5 text-text-secondary" />
+              : <ChevronRight className="ml-1 inline h-2.5 w-2.5 text-text-secondary" />
           )}
         </button>
         {view.paramHint && !resultExpanded && (
-          <p className="mt-0.5 ml-5 text-[10px] text-zinc-500 truncate max-w-[400px]">
+          <p className="mt-0.5 ml-5 max-w-[400px] truncate text-[10px] text-text-secondary">
             {view.paramHint}
           </p>
         )}
@@ -749,19 +749,19 @@ function StreamBlockItem({
       <div className="py-1">
         <button
           onClick={() => resultStr && setResultExpanded(!resultExpanded)}
-          className="flex items-center gap-2 group"
+          className="liquid-action flex items-center gap-2 rounded-md px-1 py-0.5"
         >
           <CheckCircle2 className="w-3 h-3 text-emerald-400 shrink-0" />
           <span className="text-xs font-mono text-emerald-400">{name}</span>
-          <span className="text-[10px] text-zinc-500">returned</span>
+          <span className="text-[10px] text-text-secondary">returned</span>
           {resultStr && (
             resultExpanded
-              ? <ChevronDown className="w-2.5 h-2.5 text-zinc-500" />
-              : <ChevronRight className="w-2.5 h-2.5 text-zinc-500" />
+              ? <ChevronDown className="h-2.5 w-2.5 text-text-secondary" />
+              : <ChevronRight className="h-2.5 w-2.5 text-text-secondary" />
           )}
         </button>
         {resultStr && !resultExpanded && (
-          <p className="mt-0.5 ml-5 text-[10px] text-zinc-500 truncate max-w-[400px]">
+          <p className="mt-0.5 ml-5 max-w-[400px] truncate text-[10px] text-text-secondary">
             {summarizeResult(resultStr)}
           </p>
         )}
@@ -778,14 +778,14 @@ function StreamBlockItem({
       <div className="py-1">
         <button
           onClick={() => text && setResultExpanded(!resultExpanded)}
-          className="flex items-center gap-2 group"
+          className="liquid-action flex items-center gap-2 rounded-md px-1 py-0.5"
         >
           <Brain className="w-3 h-3 text-purple-400 shrink-0" />
           <span className="text-xs font-mono text-purple-300/80">{view.rawKind || "thinking"}</span>
           {text && (
             resultExpanded
-              ? <ChevronDown className="w-2.5 h-2.5 text-zinc-500" />
-              : <ChevronRight className="w-2.5 h-2.5 text-zinc-500" />
+              ? <ChevronDown className="h-2.5 w-2.5 text-text-secondary" />
+              : <ChevronRight className="h-2.5 w-2.5 text-text-secondary" />
           )}
         </button>
         {text && !resultExpanded && (
@@ -819,21 +819,21 @@ function StreamBlockItem({
           <ListTodo className="w-3 h-3 text-amber-400 shrink-0" />
           <span className="text-xs font-mono text-amber-400">todo_list</span>
           {items.length > 0 && (
-            <span className="text-[10px] text-zinc-500">{items.length} item{items.length !== 1 ? "s" : ""}</span>
+            <span className="text-[10px] text-text-secondary">{items.length} item{items.length !== 1 ? "s" : ""}</span>
           )}
         </div>
         {items.length > 0 && (
           <ul className="mt-0.5 ml-5 space-y-0.5">
             {items.slice(0, 6).map((it, idx) => (
-              <li key={idx} className="text-[10px] text-zinc-400 truncate">
-                <span className="text-zinc-600 mr-1">
+              <li key={idx} className="truncate text-[10px] text-text-primary/80">
+                <span className="mr-1 text-text-secondary/70">
                   {it.status === "completed" ? "✓" : it.status === "in_progress" ? "→" : "○"}
                 </span>
                 {it.text}
               </li>
             ))}
             {items.length > 6 && (
-              <li className="text-[10px] text-zinc-600">… {items.length - 6} more</li>
+              <li className="text-[10px] text-text-secondary/70">… {items.length - 6} more</li>
             )}
           </ul>
         )}
@@ -847,18 +847,18 @@ function StreamBlockItem({
       <div className="py-1">
         <button
           onClick={() => details && setResultExpanded(!resultExpanded)}
-          className="flex items-center gap-2 group"
+          className="liquid-action flex items-center gap-2 rounded-md px-1 py-0.5"
         >
-          <Info className="w-3 h-3 text-zinc-500 shrink-0" />
-          <span className="text-xs text-zinc-500 font-mono">{view.systemLabel || view.rawKind}</span>
+          <Info className="h-3 w-3 shrink-0 text-text-secondary" />
+          <span className="font-mono text-xs text-text-secondary">{view.systemLabel || view.rawKind}</span>
           {details && (
             resultExpanded
-              ? <ChevronDown className="w-2.5 h-2.5 text-zinc-500" />
-              : <ChevronRight className="w-2.5 h-2.5 text-zinc-500" />
+              ? <ChevronDown className="h-2.5 w-2.5 text-text-secondary" />
+              : <ChevronRight className="h-2.5 w-2.5 text-text-secondary" />
           )}
         </button>
         {details && !resultExpanded && (
-          <p className="mt-0.5 ml-5 text-[10px] text-zinc-500 truncate max-w-[400px]">
+          <p className="mt-0.5 ml-5 max-w-[400px] truncate text-[10px] text-text-secondary">
             {summarizeResult(details)}
           </p>
         )}
@@ -871,8 +871,8 @@ function StreamBlockItem({
 
   return (
     <div className="flex items-center gap-2 py-1">
-      <HelpCircle className="w-3 h-3 text-zinc-500 shrink-0" />
-      <span className="text-xs text-zinc-500 font-mono">{view.rawKind}</span>
+      <HelpCircle className="h-3 w-3 shrink-0 text-text-secondary" />
+      <span className="font-mono text-xs text-text-secondary">{view.rawKind}</span>
     </div>
   );
 }
@@ -1129,17 +1129,17 @@ export default function StreamBlocksView({
     <div className="flex justify-start">
       <div className="max-w-[85%] space-y-2">
         {displayBlocks.length > 0 && (
-          <div className="rounded-lg border border-zinc-700/40 bg-zinc-900/40 overflow-hidden">
-            <div className="flex items-center gap-2 px-3 py-1.5">
+          <div className="liquid-tool-surface overflow-hidden rounded-lg border">
+            <div className="liquid-toolbar flex items-center gap-2 px-3 py-1.5">
               <button
                 onClick={() => setExpanded(!expanded)}
-                className="flex min-w-0 flex-1 items-center gap-1.5 text-left text-xs text-zinc-400 hover:text-zinc-300 transition-colors"
+                className="liquid-action flex min-w-0 flex-1 items-center gap-1.5 rounded-md px-1 py-0.5 text-left text-xs text-text-secondary transition-colors hover:text-text-primary"
               >
                 <ChevronRight className={`w-3 h-3 shrink-0 transition-transform duration-200 ${expanded ? "rotate-90" : ""}`} />
                 <Wrench className="w-3 h-3 shrink-0" />
                 <span className="truncate">{summaryParts.join(", ")}</span>
               </button>
-              <label className="flex shrink-0 items-center gap-1.5 text-[10px] text-zinc-500">
+              <label className="flex shrink-0 items-center gap-1.5 text-[10px] text-text-secondary">
                 <span>Max</span>
                 <select
                   value={visibleBlockMax}
@@ -1147,7 +1147,7 @@ export default function StreamBlocksView({
                     setVisibleBlockMax(Number(event.target.value));
                     setOlderBlocksExpanded(false);
                   }}
-                  className="h-6 rounded border border-zinc-700/60 bg-zinc-950/80 px-1.5 text-[10px] text-zinc-300 outline-none transition-colors hover:border-zinc-600 focus:border-cyan-500/70"
+                  className="liquid-input h-6 rounded border border-glass-border px-1.5 text-[10px] text-text-primary outline-none"
                   aria-label="Maximum visible reasoning steps"
                 >
                   {VISIBLE_BLOCK_MAX_OPTIONS.map((option) => (
@@ -1161,27 +1161,27 @@ export default function StreamBlocksView({
             {renderExpandedContent && (
               <div
                 ref={contentRef}
-                className="border-t border-zinc-800/60 px-3 py-1 divide-y divide-zinc-800/40 will-change-transform"
+                className="divide-y divide-glass-border/60 border-t border-glass-border px-3 py-1 will-change-transform"
               >
                 {olderBlocks.length > 0 && (
                   <div className="py-1" data-stream-older-group>
                     <button
                       onClick={() => setOlderBlocksExpanded(!olderBlocksExpanded)}
-                      className="flex items-center gap-2 group text-left"
+                      className="liquid-action flex items-center gap-2 rounded-md px-1 py-0.5 text-left"
                       aria-expanded={olderBlocksExpanded}
                     >
                       {olderBlocksExpanded
-                        ? <ChevronDown className="w-2.5 h-2.5 text-zinc-500" />
-                        : <ChevronRight className="w-2.5 h-2.5 text-zinc-500" />}
-                      <span className="text-[10px] font-medium text-zinc-500">
+                        ? <ChevronDown className="h-2.5 w-2.5 text-text-secondary" />
+                        : <ChevronRight className="h-2.5 w-2.5 text-text-secondary" />}
+                      <span className="text-[10px] font-medium text-text-secondary">
                         {olderBlocks.length} older step{olderBlocks.length !== 1 ? "s" : ""}
                       </span>
-                      <span className="text-[10px] text-zinc-600">
+                      <span className="text-[10px] text-text-secondary/70">
                         {visibleBlockMax} newest shown
                       </span>
                     </button>
                     {olderBlocksExpanded && (
-                      <div className="mt-1 divide-y divide-zinc-800/40 border-t border-zinc-800/40">
+                      <div className="mt-1 divide-y divide-glass-border/60 border-t border-glass-border">
                         {olderBlocks.map((block) => {
                           const blockKey = streamBlockKey(block);
                           return (
@@ -1219,8 +1219,8 @@ export default function StreamBlocksView({
                 {composingText && (
                   <div data-stream-composing className="py-2 will-change-transform">
                     <div className="mb-1 flex items-center gap-1.5">
-                      <Bot className="w-3 h-3 text-zinc-400" />
-                      <span className="text-xs text-zinc-400">Composing...</span>
+                      <Bot className="h-3 w-3 text-text-primary/80" />
+                      <span className="text-xs text-text-primary/80">Composing...</span>
                     </div>
                     <MarkdownContent content={composingText} />
                   </div>

--- a/frontend/src/components/dashboard/StripeReturnBanner.tsx
+++ b/frontend/src/components/dashboard/StripeReturnBanner.tsx
@@ -89,7 +89,7 @@ function StripeReturnBanner() {
   // Cancelled
   if (mode === "cancelled") {
     return (
-      <div className="fixed bottom-4 right-4 z-40 max-w-sm rounded-xl border border-yellow-500/30 bg-yellow-500/10 p-4 backdrop-blur-xl">
+      <div className="liquid-card fixed bottom-4 right-4 z-40 max-w-sm rounded-xl border border-yellow-500/30 bg-yellow-500/10 p-4 backdrop-blur-xl">
         <div className="flex items-start gap-3">
           <span className="text-yellow-400 text-lg">!</span>
           <div className="flex-1">
@@ -112,7 +112,7 @@ function StripeReturnBanner() {
   const credited = status?.wallet_credited ?? false;
 
   return (
-    <div className={`fixed bottom-4 right-4 z-40 max-w-sm rounded-xl border p-4 backdrop-blur-xl ${
+    <div className={`liquid-card fixed bottom-4 right-4 z-40 max-w-sm rounded-xl border p-4 backdrop-blur-xl ${
       credited
         ? "border-neon-green/30 bg-neon-green/10"
         : "border-neon-cyan/30 bg-neon-cyan/10"

--- a/frontend/src/components/dashboard/SubscriptionBadge.tsx
+++ b/frontend/src/components/dashboard/SubscriptionBadge.tsx
@@ -295,7 +295,7 @@ export default function SubscriptionBadge({
 
       {showModal && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+          className="liquid-scrim fixed inset-0 z-50 flex items-center justify-center p-4"
           onClick={(event) => {
             event.stopPropagation();
             closeWithMotion();
@@ -306,7 +306,7 @@ export default function SubscriptionBadge({
             ref={panelRef}
             role="dialog"
             aria-modal="true"
-            className="w-full max-w-sm rounded-xl border border-glass-border bg-deep-black p-6 shadow-xl"
+            className="liquid-dialog w-full max-w-sm rounded-xl border border-glass-border p-6 shadow-xl"
             onClick={(event) => event.stopPropagation()}
           >
             <h2 data-motion-item className="mb-2 flex items-center gap-2 text-lg font-semibold text-yellow-500">

--- a/frontend/src/components/dashboard/ThemeToggle.tsx
+++ b/frontend/src/components/dashboard/ThemeToggle.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+/**
+ * [INPUT]: useAppStore 持久化的主题偏好与浏览器 document
+ * [OUTPUT]: 对外提供轻量的明暗主题切换按钮，并同步 HTML theme 属性
+ * [POS]: dashboard 侧栏的全局外观控制项
+ */
+
+import { useEffect } from "react";
+import { Moon, Sun } from "lucide-react";
+import { useLanguage } from "@/lib/i18n";
+import { useAppStore } from "@/store/useAppStore";
+
+function applyTheme(theme: "dark" | "light") {
+  document.documentElement.dataset.theme = theme;
+  document.documentElement.style.colorScheme = theme;
+  const themeColor = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
+  if (themeColor) themeColor.content = theme === "light" ? "#eef3f9" : "#08111f";
+}
+
+export default function ThemeToggle() {
+  const locale = useLanguage();
+  const theme = useAppStore((state) => state.theme);
+  const setTheme = useAppStore((state) => state.setTheme);
+  const isLight = theme === "light";
+  const label = isLight
+    ? (locale === "zh" ? "切换到深色模式" : "Switch to dark mode")
+    : (locale === "zh" ? "切换到浅色模式" : "Switch to light mode");
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  return (
+    <button
+      type="button"
+      onClick={() => setTheme(isLight ? "dark" : "light")}
+      aria-label={label}
+      aria-pressed={isLight}
+      title={label}
+      className="liquid-theme-toggle group relative flex h-10 w-12 items-center justify-center rounded-xl text-text-secondary transition-all duration-200 hover:text-text-primary max-md:w-10"
+    >
+      <Sun
+        aria-hidden="true"
+        className={isLight
+          ? "absolute h-4 w-4 rotate-0 scale-100 text-amber-500 transition-all duration-300"
+          : "absolute h-4 w-4 -rotate-90 scale-0 text-amber-500 opacity-0 transition-all duration-300"}
+      />
+      <Moon
+        aria-hidden="true"
+        className={isLight
+          ? "absolute h-4 w-4 rotate-90 scale-0 text-neon-cyan opacity-0 transition-all duration-300"
+          : "absolute h-4 w-4 rotate-0 scale-100 text-neon-cyan transition-all duration-300"}
+      />
+      <span className="sr-only">{label}</span>
+    </button>
+  );
+}

--- a/frontend/src/components/dashboard/ToolResultContent.tsx
+++ b/frontend/src/components/dashboard/ToolResultContent.tsx
@@ -58,7 +58,7 @@ function JsonHighlight({ text }: { text: string }) {
           <>
             <span>{indent}</span>
             <span className="text-cyan-400">{key}</span>
-            <span className="text-zinc-500">{colon}</span>
+            <span className="text-text-secondary">{colon}</span>
             <span className={getValueClass(value)}>{value}</span>
           </>
         );
@@ -91,9 +91,9 @@ function getValueClass(value: string): string {
   const v = value.trim().replace(/,\s*$/, "");
   if (v.startsWith('"')) return "text-emerald-400";
   if (v === "true" || v === "false") return "text-amber-400";
-  if (v === "null") return "text-zinc-500 italic";
+  if (v === "null") return "italic text-text-secondary";
   if (/^-?\d/.test(v)) return "text-purple-400";
-  return "text-zinc-400"; // punctuation: {, }, [, ]
+  return "text-text-secondary"; // punctuation: {, }, [, ]
 }
 
 // ---------------------------------------------------------------------------
@@ -116,13 +116,13 @@ function CopyButton({ text, className }: { text: string; className?: string }) {
   return (
     <button
       onClick={handleCopy}
-      className={`p-1 rounded hover:bg-white/10 transition-colors ${className ?? ""}`}
+      className={`liquid-action rounded p-1 transition-colors ${className ?? ""}`}
       title="复制"
     >
       {copied ? (
         <Check className="w-3 h-3 text-emerald-400" />
       ) : (
-        <Copy className="w-3 h-3 text-zinc-500 hover:text-zinc-300" />
+        <Copy className="h-3 w-3 text-text-secondary" />
       )}
     </button>
   );
@@ -173,20 +173,20 @@ function FullScreenOverlay({
   return createPortal(
     <div
       ref={overlayRef}
-      className="fixed inset-0 z-[9999] flex flex-col bg-black/90 backdrop-blur-sm"
+      className="liquid-scrim fixed inset-0 z-[9999] flex flex-col backdrop-blur-sm"
       onClick={(e) => {
         if (e.target === e.currentTarget) closeWithMotion();
       }}
     >
-      <div ref={panelRef} role="dialog" aria-modal="true" className="flex min-h-0 flex-1 flex-col">
+      <div ref={panelRef} role="dialog" aria-modal="true" className="liquid-dialog flex min-h-0 flex-1 flex-col rounded-none border-x-0 border-y-0">
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-3 border-b border-glass-border bg-zinc-950/80">
+        <div className="liquid-toolbar flex items-center justify-between border-b border-glass-border px-6 py-3">
           <div className="flex items-center gap-3">
             <span className="text-sm font-mono text-emerald-400">{title}</span>
-            <span className="text-xs text-zinc-500 bg-zinc-800 px-2 py-0.5 rounded">
+            <span className="liquid-card rounded px-2 py-0.5 text-xs text-text-secondary">
               {contentType.toUpperCase()}
             </span>
-            <span className="text-xs text-zinc-600">
+            <span className="text-xs text-text-secondary/75">
               {rawText.length.toLocaleString()} 字符
             </span>
           </div>
@@ -194,9 +194,9 @@ function FullScreenOverlay({
             <CopyButton text={rawText} />
             <button
               onClick={closeWithMotion}
-              className="p-1 rounded hover:bg-white/10 transition-colors"
+              className="liquid-action rounded p-1 transition-colors"
             >
-              <X className="w-4 h-4 text-zinc-400 hover:text-zinc-200" />
+              <X className="h-4 w-4 text-text-secondary" />
             </button>
           </div>
         </div>
@@ -236,7 +236,7 @@ function ResultRenderer({
 
   if (contentType === "json") {
     return (
-      <div className="bg-zinc-950/50 rounded-md px-3 py-2 overflow-x-auto">
+      <div className="liquid-tool-surface overflow-x-auto rounded-md px-3 py-2">
         <JsonHighlight text={formattedJson} />
       </div>
     );
@@ -244,7 +244,7 @@ function ResultRenderer({
 
   if (contentType === "markdown") {
     return (
-      <div className={`${fullMode ? "text-sm" : "text-xs"} text-zinc-300`}>
+      <div className={`${fullMode ? "text-sm" : "text-xs"} text-text-primary`}>
         <MarkdownContent content={text} />
       </div>
     );
@@ -252,7 +252,7 @@ function ResultRenderer({
 
   // Plain text
   return (
-    <pre className="text-[11px] text-zinc-400 font-mono bg-zinc-950/50 rounded-md px-3 py-2 overflow-x-auto whitespace-pre-wrap break-words">
+    <pre className="liquid-tool-surface overflow-x-auto rounded-md px-3 py-2 font-mono text-[11px] whitespace-pre-wrap break-words text-text-primary">
       {text}
     </pre>
   );
@@ -305,20 +305,20 @@ export default function ToolResultContent({
     : rawText;
 
   return (
-    <div className="mt-1 ml-5">
+    <div className="liquid-tool-surface mt-1 ml-5 rounded-lg p-1.5">
       {/* Toolbar */}
       <div className="flex items-center gap-1 mb-1">
-        <span className="text-[10px] text-zinc-600 bg-zinc-800/60 px-1.5 py-0.5 rounded">
+        <span className="liquid-card rounded px-1.5 py-0.5 text-[10px] text-text-secondary">
           {contentType === "json" ? "JSON" : contentType === "markdown" ? "Markdown" : "Text"}
         </span>
         <CopyButton text={rawText} />
         {(truncated || rawText.length > 500) && (
           <button
             onClick={() => setFullScreen(true)}
-            className="p-1 rounded hover:bg-white/10 transition-colors"
+            className="liquid-action rounded p-1 transition-colors"
             title="全屏查看"
           >
-            <Maximize2 className="w-3 h-3 text-zinc-500 hover:text-zinc-300" />
+            <Maximize2 className="h-3 w-3 text-text-secondary" />
           </button>
         )}
       </div>

--- a/frontend/src/components/dashboard/TopicDrawer.tsx
+++ b/frontend/src/components/dashboard/TopicDrawer.tsx
@@ -219,11 +219,11 @@ export default function TopicDrawer() {
       <div
         ref={overlayRef}
         onClick={closeDrawer}
-        className="fixed inset-0 z-30 bg-black/40 backdrop-blur-sm md:hidden"
+        className="liquid-scrim fixed inset-0 z-30 backdrop-blur-sm md:hidden"
       />
       <aside
         ref={drawerRef}
-        className="fixed right-0 top-0 z-40 flex h-full w-full max-w-[480px] flex-col border-l border-glass-border bg-deep-black shadow-2xl md:w-[440px]"
+        className="liquid-drawer fixed right-0 top-0 z-40 flex h-full w-full max-w-[480px] flex-col border-l md:w-[440px]"
       >
         <header data-topic-drawer-part className="flex items-start gap-2 border-b border-glass-border/60 px-4 py-3">
           <div className="min-w-0 flex-1">
@@ -243,7 +243,7 @@ export default function TopicDrawer() {
           </div>
           <button
             onClick={closeDrawer}
-            className="rounded-md p-1 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
+            className="liquid-action rounded-md p-1 text-text-secondary transition-colors hover:text-text-primary"
             aria-label="Close topic"
           >
             <X className="h-4 w-4" />
@@ -252,7 +252,7 @@ export default function TopicDrawer() {
 
         <div data-topic-drawer-part className="flex-1 overflow-y-auto px-3 py-3">
           {topicMessages.length === 0 ? (
-            <div className="flex h-full items-center justify-center text-sm text-text-secondary">
+            <div className="liquid-empty-state flex h-full items-center justify-center rounded-xl text-sm text-text-secondary">
               {t.noMessages}
             </div>
           ) : (

--- a/frontend/src/components/dashboard/TopupDialog.tsx
+++ b/frontend/src/components/dashboard/TopupDialog.tsx
@@ -139,17 +139,17 @@ export default function TopupDialog({ viewer, onClose, onSuccess }: TopupDialogP
   return (
     <div
       ref={overlayRef}
-      className={`fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`}
+      className={`liquid-scrim fixed inset-0 z-50 flex items-center justify-center ${closing ? "pointer-events-none" : ""}`}
       onClick={closeWithMotion}
     >
       <div
         ref={panelRef}
-        className="relative flex max-h-[90vh] w-full max-w-md flex-col rounded-2xl border border-glass-border bg-glass-bg backdrop-blur-xl"
+        className="liquid-dialog relative flex max-h-[90vh] w-full max-w-md flex-col rounded-2xl"
         onClick={(e) => e.stopPropagation()}
       >
         <button
           onClick={closeWithMotion}
-          className="absolute right-4 top-4 z-10 rounded p-1 text-text-secondary hover:text-text-primary"
+          className="liquid-action absolute right-4 top-4 z-10 rounded-lg p-1 text-text-secondary hover:text-text-primary"
         >
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
             <path d="M4 4l8 8M12 4l-8 8" />
@@ -184,10 +184,10 @@ export default function TopupDialog({ viewer, onClose, onSuccess }: TopupDialogP
                   <button
                     key={pkg.package_code}
                     onClick={() => setSelectedPackage(pkg.package_code)}
-                    className={`w-full rounded-xl border p-4 text-left transition-colors ${
+                    className={`liquid-action w-full rounded-xl border p-4 text-left transition-colors ${
                       activePackage?.package_code === pkg.package_code
                         ? "border-neon-green/50 bg-neon-green/5"
-                        : "border-glass-border bg-deep-black-light hover:border-glass-border/80"
+                        : "border-glass-border hover:border-glass-border/80"
                     }`}
                   >
                     <div className="flex items-center justify-between">
@@ -202,7 +202,7 @@ export default function TopupDialog({ viewer, onClose, onSuccess }: TopupDialogP
                 ))}
               </div>
             ) : activePackage ? (
-              <div className="rounded-xl border border-neon-green/30 bg-neon-green/5 p-4">
+              <div className="liquid-card rounded-xl border border-neon-green/30 bg-neon-green/5 p-4">
                 <div className="flex items-center justify-between">
                   <span className="text-xs font-medium uppercase tracking-wider text-text-secondary">
                     {t.unitPrice}
@@ -219,7 +219,7 @@ export default function TopupDialog({ viewer, onClose, onSuccess }: TopupDialogP
 
             {activePackage ? (
               <>
-                <div className="mt-4 rounded-xl border border-glass-border bg-deep-black-light p-4">
+                <div className="liquid-card mt-4 rounded-xl p-4">
                   <div className="mb-3 flex items-center justify-between">
                     <span className="text-sm font-medium text-text-primary">{t.quantity}</span>
                     <span className="text-xs text-text-secondary">{t.quantityRange}</span>
@@ -229,7 +229,7 @@ export default function TopupDialog({ viewer, onClose, onSuccess }: TopupDialogP
                       type="button"
                       onClick={() => updateQuantity(quantity - 1)}
                       disabled={quantity <= 1 || submitting}
-                      className="h-10 w-10 rounded-lg border border-glass-border text-lg text-text-primary transition-colors hover:border-neon-green/40 disabled:opacity-40"
+                      className="liquid-action h-10 w-10 rounded-lg text-lg text-text-primary transition-colors hover:border-neon-green/40 disabled:opacity-40"
                     >
                       -
                     </button>
@@ -240,20 +240,20 @@ export default function TopupDialog({ viewer, onClose, onSuccess }: TopupDialogP
                       step={1}
                       value={quantity}
                       onChange={(e) => updateQuantity(parseInt(e.target.value, 10))}
-                      className="h-10 flex-1 rounded-lg border border-glass-border bg-deep-black px-3 text-center font-mono text-text-primary outline-none transition-colors focus:border-neon-green/40"
+                      className="liquid-input h-10 flex-1 rounded-lg border px-3 text-center font-mono text-text-primary outline-none transition-colors focus:border-neon-green/40"
                     />
                     <button
                       type="button"
                       onClick={() => updateQuantity(quantity + 1)}
                       disabled={quantity >= 100 || submitting}
-                      className="h-10 w-10 rounded-lg border border-glass-border text-lg text-text-primary transition-colors hover:border-neon-green/40 disabled:opacity-40"
+                      className="liquid-action h-10 w-10 rounded-lg text-lg text-text-primary transition-colors hover:border-neon-green/40 disabled:opacity-40"
                     >
                       +
                     </button>
                   </div>
                 </div>
 
-                <div className="mt-4 rounded-xl border border-glass-border bg-deep-black-light p-4">
+                <div className="liquid-card mt-4 rounded-xl p-4">
                   <div className="flex items-center justify-between text-sm">
                     <span className="text-text-secondary">{t.perUnit}</span>
                     <span className="font-mono text-text-primary">
@@ -291,11 +291,11 @@ export default function TopupDialog({ viewer, onClose, onSuccess }: TopupDialogP
         </div>
 
         {!packagesLoading && !packagesError && packages.length > 0 ? (
-          <div className="shrink-0 border-t border-glass-border bg-glass-bg/40 px-6 py-4">
+          <div className="liquid-toolbar shrink-0 border-t px-6 py-4">
             <button
               onClick={handleCheckout}
               disabled={!activePackage || submitting}
-              className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-green/30 bg-neon-green/10 py-2.5 font-medium text-neon-green transition-colors hover:bg-neon-green/20 disabled:opacity-40"
+              className="liquid-action inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-green/30 bg-neon-green/10 py-2.5 font-medium text-neon-green transition-colors hover:bg-neon-green/20 disabled:opacity-40"
             >
               {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
               {submitting ? t.redirectingToStripe : `${t.continueToPayment}${activePackage ? ` • $${formatFiat(totalFiat)}` : ""}`}

--- a/frontend/src/components/dashboard/TransferCard.tsx
+++ b/frontend/src/components/dashboard/TransferCard.tsx
@@ -122,7 +122,7 @@ export default function TransferCard({ info, isNotice }: { info: TransferInfo; i
   const sc = statusStyles[info.status] ?? statusStyles.completed;
 
   return (
-    <div className="w-full min-w-[220px]">
+    <div className="liquid-card w-full min-w-[220px] rounded-xl border border-glass-border p-3">
       {/* Header */}
       <div className="mb-1.5 flex items-center justify-between">
         <div className="flex items-center gap-1.5">

--- a/frontend/src/components/dashboard/TransferDialog.tsx
+++ b/frontend/src/components/dashboard/TransferDialog.tsx
@@ -262,18 +262,18 @@ export default function TransferDialog({ viewer, onClose, onSuccess }: TransferD
   return (
     <div
       ref={overlayRef}
-      className={`fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`}
+      className={`liquid-scrim fixed inset-0 z-50 flex items-center justify-center ${closing ? "pointer-events-none" : ""}`}
       onClick={closeWithMotion}
     >
       <div
         ref={panelRef}
-        className="relative flex max-h-[90vh] w-full max-w-md flex-col rounded-2xl border border-glass-border bg-glass-bg backdrop-blur-xl"
+        className="liquid-dialog relative flex max-h-[90vh] w-full max-w-md flex-col rounded-2xl"
         onClick={(e) => e.stopPropagation()}
       >
         <button
           onClick={closeWithMotion}
           aria-label="close"
-          className="absolute right-4 top-4 z-10 rounded p-1 text-text-secondary hover:text-text-primary"
+          className="liquid-action absolute right-4 top-4 z-10 rounded-lg p-1 text-text-secondary hover:text-text-primary"
         >
           <X className="h-4 w-4" />
         </button>
@@ -322,7 +322,7 @@ export default function TransferDialog({ viewer, onClose, onSuccess }: TransferD
                   value={customRecipientId}
                   onChange={(e) => setCustomRecipientId(e.target.value)}
                   placeholder={t.enterCustomIdHint}
-                  className="w-full rounded-lg border border-glass-border bg-deep-black-light p-3 font-mono text-sm text-text-primary placeholder-text-secondary/40 outline-none focus:border-neon-cyan/50"
+                  className="liquid-input w-full rounded-lg border p-3 font-mono text-sm text-text-primary placeholder-text-secondary/40 outline-none focus:border-neon-cyan/50"
                 />
                 <button
                   type="button"
@@ -383,7 +383,7 @@ export default function TransferDialog({ viewer, onClose, onSuccess }: TransferD
                 value={amount}
                 onChange={(e) => setAmount(e.target.value.replace(/[^0-9]/g, ""))}
                 placeholder="0"
-                className={`w-full rounded-lg border bg-deep-black-light px-4 py-3 pr-16 font-mono text-2xl font-semibold text-text-primary placeholder-text-secondary/30 outline-none transition-colors ${
+                className={`liquid-input w-full rounded-lg border px-4 py-3 pr-16 font-mono text-2xl font-semibold text-text-primary placeholder-text-secondary/30 outline-none transition-colors ${
                   overBudget ? "border-red-400/50 focus:border-red-400/70" : "border-glass-border focus:border-neon-cyan/50"
                 }`}
               />
@@ -398,7 +398,7 @@ export default function TransferDialog({ viewer, onClose, onSuccess }: TransferD
                     key={n}
                     type="button"
                     onClick={() => setAmount(String(n))}
-                    className={`rounded-full border px-2.5 py-0.5 text-[11px] transition-colors ${
+                    className={`liquid-action rounded-full border px-2.5 py-0.5 text-[11px] transition-colors ${
                       amount === String(n)
                         ? "border-neon-cyan/40 bg-neon-cyan/10 text-neon-cyan"
                         : "border-glass-border text-text-secondary hover:border-glass-border/80 hover:text-text-primary"
@@ -424,19 +424,19 @@ export default function TransferDialog({ viewer, onClose, onSuccess }: TransferD
               value={memo}
               onChange={(e) => setMemo(e.target.value)}
               placeholder={t.memoPlaceholder}
-              className="w-full rounded-lg border border-glass-border bg-deep-black-light p-3 text-sm text-text-primary placeholder-text-secondary/50 outline-none focus:border-neon-cyan/50"
+              className="liquid-input w-full rounded-lg border p-3 text-sm text-text-primary placeholder-text-secondary/50 outline-none focus:border-neon-cyan/50"
             />
           </div>
 
           {error && <p ref={errorRef} className="text-sm text-red-400">{error}</p>}
         </form>
 
-        <div className="shrink-0 border-t border-glass-border bg-glass-bg/40 px-6 py-4">
+        <div className="liquid-toolbar shrink-0 border-t px-6 py-4">
           <button
             form="transferForm"
             type="submit"
             disabled={!isValid || submitting}
-            className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-cyan/30 bg-neon-cyan/10 py-3 font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-neon-cyan/10"
+            className="liquid-action inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-cyan/30 bg-neon-cyan/10 py-3 font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-neon-cyan/10"
           >
             {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
             {submitting
@@ -494,7 +494,7 @@ function FromCard({
         disabled={disabled}
         onClick={() => setOpen((v) => !v)}
         onBlur={() => setTimeout(() => setOpen(false), 120)}
-        className="flex w-full items-center justify-between gap-3 rounded-lg border border-glass-border bg-deep-black-light px-3.5 py-2.5 text-left transition-colors hover:border-neon-cyan/30 disabled:cursor-default disabled:hover:border-glass-border"
+        className="liquid-action flex w-full items-center justify-between gap-3 rounded-lg px-3.5 py-2.5 text-left transition-colors hover:border-neon-cyan/30 disabled:cursor-default disabled:hover:border-glass-border"
       >
         <div className="min-w-0 flex-1">
           <div className="truncate text-sm font-medium text-text-primary">{label}</div>
@@ -505,7 +505,7 @@ function FromCard({
         {!disabled ? <ChevronDown className="h-3.5 w-3.5 shrink-0 text-text-secondary/60" /> : null}
       </button>
       {open && !disabled ? (
-        <div ref={menuRef} className="absolute left-0 right-0 top-full z-30 mt-1 overflow-hidden rounded-lg border border-glass-border bg-deep-black-light shadow-lg">
+        <div ref={menuRef} className="liquid-menu absolute left-0 right-0 top-full z-30 mt-1 overflow-hidden rounded-lg">
           {options.map((opt) => {
             const selected =
               value?.type === opt.identity.type && value.id === opt.identity.id;
@@ -518,7 +518,7 @@ function FromCard({
                   onChange(opt.identity);
                   setOpen(false);
                 }}
-                className={`flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-xs transition-colors hover:bg-glass-bg ${
+                className={`liquid-list-row flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-xs transition-colors ${
                   selected ? "bg-neon-cyan/10 text-neon-cyan" : "text-text-primary"
                 }`}
               >
@@ -585,13 +585,13 @@ function RecipientPicker({
         type="button"
         onClick={() => setOpen(!open)}
         onBlur={() => setTimeout(() => setOpen(false), 150)}
-        className="flex w-full items-center justify-between gap-3 rounded-lg border border-glass-border bg-deep-black-light px-3.5 py-2.5 text-left text-sm text-text-secondary transition-colors hover:border-neon-cyan/30"
+        className="liquid-action flex w-full items-center justify-between gap-3 rounded-lg px-3.5 py-2.5 text-left text-sm text-text-secondary transition-colors hover:border-neon-cyan/30"
       >
         <span>{placeholder}</span>
         <ChevronDown className="h-3.5 w-3.5 shrink-0 text-text-secondary/60" />
       </button>
       {open ? (
-        <div ref={pickerRef} className="absolute left-0 right-0 top-full z-30 mt-1 max-h-72 overflow-y-auto rounded-lg border border-glass-border bg-deep-black-light shadow-lg">
+        <div ref={pickerRef} className="liquid-menu absolute left-0 right-0 top-full z-30 mt-1 max-h-72 overflow-y-auto rounded-lg">
           {(["human-self", "my-bot", "contact"] as const).map((group) => {
             const items = grouped[group];
             if (items.length === 0) return null;
@@ -608,7 +608,7 @@ function RecipientPicker({
                       e.preventDefault();
                       onPick(opt);
                     }}
-                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs transition-colors hover:bg-glass-bg"
+                    className="liquid-list-row flex w-full items-center gap-2 px-3 py-2 text-left text-xs transition-colors"
                   >
                     {opt.group === "human-self" ? (
                       <HumanInitial label={opt.label} />
@@ -630,7 +630,7 @@ function RecipientPicker({
               e.preventDefault();
               onCustom();
             }}
-            className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
+            className="liquid-list-row flex w-full items-center gap-2 px-3 py-2 text-left text-xs text-text-secondary transition-colors hover:text-text-primary"
           >
             <Pencil className="h-3.5 w-3.5" />
             {customLabel}
@@ -651,7 +651,7 @@ function RecipientChip({
   onChange: () => void;
 }) {
   return (
-    <div className="flex items-center gap-3 rounded-lg border border-glass-border bg-deep-black-light px-3.5 py-2.5">
+    <div className="liquid-card flex items-center gap-3 rounded-lg px-3.5 py-2.5">
       {option.group === "human-self" ? (
         <HumanInitial label={option.label} />
       ) : (
@@ -664,7 +664,7 @@ function RecipientChip({
       <button
         type="button"
         onClick={onChange}
-        className="rounded-md border border-glass-border px-2 py-1 text-[11px] text-text-secondary transition-colors hover:border-neon-cyan/30 hover:text-text-primary"
+        className="liquid-action rounded-md px-2 py-1 text-[11px] text-text-secondary transition-colors hover:border-neon-cyan/30 hover:text-text-primary"
       >
         {changeLabel}
       </button>

--- a/frontend/src/components/dashboard/TransferOwnershipDialog.tsx
+++ b/frontend/src/components/dashboard/TransferOwnershipDialog.tsx
@@ -93,12 +93,12 @@ export default function TransferOwnershipDialog({
   return (
     <div
       ref={overlayRef}
-      className={`fixed inset-0 z-30 flex items-center justify-center bg-black/60 ${closing ? "pointer-events-none" : ""}`}
+      className={`liquid-scrim fixed inset-0 z-30 flex items-center justify-center p-4 ${closing ? "pointer-events-none" : ""}`}
       onClick={closeWithMotion}
     >
       <div
         ref={panelRef}
-        className="w-[360px] rounded-lg border border-glass-border bg-deep-black-light p-4"
+        className="liquid-dialog w-full max-w-[360px] rounded-xl p-4"
         onClick={(e) => e.stopPropagation()}
       >
         <h3 className="mb-3 text-sm font-semibold text-text-primary">
@@ -137,7 +137,7 @@ export default function TransferOwnershipDialog({
                 value={confirmText}
                 onChange={(e) => setConfirmText(e.target.value)}
                 placeholder={roomName}
-                className="w-full rounded border border-glass-border bg-deep-black px-2 py-1.5 text-xs text-text-primary placeholder:text-text-secondary/40"
+                className="liquid-input w-full rounded-lg border px-2.5 py-2 text-xs text-text-primary placeholder:text-text-secondary/40"
               />
             </label>
 
@@ -151,7 +151,7 @@ export default function TransferOwnershipDialog({
           <button
             onClick={closeWithMotion}
             disabled={submitting}
-            className="rounded border border-glass-border px-3 py-1.5 text-[11px] text-text-secondary hover:bg-glass-bg"
+            className="liquid-action rounded-lg px-3 py-1.5 text-[11px] text-text-secondary"
           >
             {t.permCancel}
           </button>
@@ -159,7 +159,7 @@ export default function TransferOwnershipDialog({
             <button
               onClick={submit}
               disabled={!confirmArmed || !selected || submitting}
-              className="rounded border border-neon-purple/40 bg-neon-purple/10 px-3 py-1.5 text-[11px] text-neon-purple hover:bg-neon-purple/20 disabled:cursor-not-allowed disabled:opacity-40"
+              className="liquid-action rounded-lg border border-neon-purple/40 bg-neon-purple/10 px-3 py-1.5 text-[11px] text-neon-purple hover:bg-neon-purple/20 disabled:cursor-not-allowed disabled:opacity-40"
             >
               {submitting ? "…" : t.transferOwnership}
             </button>

--- a/frontend/src/components/dashboard/UnbindAgentDialog.tsx
+++ b/frontend/src/components/dashboard/UnbindAgentDialog.tsx
@@ -104,12 +104,12 @@ export default function UnbindAgentDialog({
   }, [error]);
 
   return (
-    <div ref={overlayRef} className={`fixed inset-0 z-[110] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`} onMouseDown={(event) => { if (event.target === event.currentTarget) closeWithMotion(); }}>
-      <div ref={panelRef} className="relative w-full max-w-md rounded-2xl border border-glass-border bg-deep-black-light p-5 shadow-2xl">
+    <div ref={overlayRef} className={`liquid-scrim fixed inset-0 z-[110] flex items-center justify-center p-4 ${closing ? "pointer-events-none" : ""}`} onMouseDown={(event) => { if (event.target === event.currentTarget) closeWithMotion(); }}>
+      <div ref={panelRef} className="liquid-dialog relative w-full max-w-md rounded-2xl p-5">
         <button
           onClick={closeWithMotion}
           disabled={loading}
-          className="absolute right-4 top-4 rounded-full p-1.5 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+          className="liquid-action absolute right-4 top-4 rounded-full p-1.5 text-text-secondary transition-colors hover:text-text-primary disabled:opacity-50"
         >
           <X className="h-5 w-5" />
         </button>
@@ -122,7 +122,7 @@ export default function UnbindAgentDialog({
           <p className="mt-2 text-sm text-text-secondary">{copy.description}</p>
         </div>
 
-        <div className="rounded-xl border border-amber-400/20 bg-amber-400/5 p-3">
+        <div className="liquid-card rounded-xl border border-amber-400/20 bg-amber-400/5 p-3">
           <div className="flex items-start gap-2">
             <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-400" />
             <p className="text-xs text-amber-300">{copy.warning}</p>
@@ -145,14 +145,14 @@ export default function UnbindAgentDialog({
           <button
             onClick={closeWithMotion}
             disabled={loading}
-            className="rounded-xl border border-glass-border px-4 py-2.5 text-sm font-medium text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary disabled:opacity-50"
+            className="liquid-action rounded-xl px-4 py-2.5 text-sm font-medium text-text-secondary transition-colors hover:text-text-primary disabled:opacity-50"
           >
             {t.cancel}
           </button>
           <button
             onClick={handleUnbind}
             disabled={loading}
-            className="flex items-center gap-2 rounded-xl border border-red-400/50 bg-red-500/10 px-4 py-2.5 text-sm font-bold text-red-400 transition-all hover:bg-red-500/20 disabled:opacity-60"
+            className="liquid-action flex items-center gap-2 rounded-xl border border-red-400/50 bg-red-500/10 px-4 py-2.5 text-sm font-bold text-red-400 transition-all hover:bg-red-500/20 disabled:opacity-60"
           >
             {loading ? (
               <>

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -580,18 +580,18 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
         <button
           type="button"
           onClick={() => setActionMenuOpenId((current) => current === msg.clientId ? null : msg.clientId)}
-          className={`flex h-6 w-6 items-center justify-center rounded text-zinc-500 hover:bg-zinc-800 hover:text-zinc-300 transition-colors ${visible ? "opacity-100" : "opacity-0 pointer-events-none"}`}
+          className={`flex h-6 w-6 items-center justify-center rounded-lg text-text-secondary hover:bg-glass-bg hover:text-text-primary transition-colors ${visible ? "opacity-100" : "opacity-0 pointer-events-none"}`}
           aria-label="More actions"
         >
           <MoreHorizontal className="h-3.5 w-3.5" />
         </button>
         {menuOpen && (
-          <div className={`absolute top-full mt-1 z-30 min-w-[96px] rounded-lg border border-zinc-700 bg-zinc-900 py-1 shadow-xl ${alignRight ? "right-0" : "left-0"}`}>
+          <div className={`liquid-menu absolute top-full z-30 mt-1 min-w-[96px] rounded-xl border border-glass-border bg-deep-black-light py-1 shadow-xl ${alignRight ? "right-0" : "left-0"}`}>
             {canReply && (
               <button
                 type="button"
                 onMouseDown={(event) => { event.preventDefault(); handleReply(msg); }}
-                className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100 transition-colors"
+                className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-text-primary hover:bg-glass-bg transition-colors"
               >
                 <CornerUpLeft className="h-3.5 w-3.5 text-zinc-500" />
                 {replyLabel}
@@ -600,7 +600,7 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
             <button
               type="button"
               onMouseDown={(event) => { event.preventDefault(); handleForward(msg); }}
-              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100 transition-colors"
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-text-primary hover:bg-glass-bg transition-colors"
             >
               <Forward className="h-3.5 w-3.5 text-zinc-500" />
               {forwardLabel}
@@ -608,7 +608,7 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
             <button
               type="button"
               onMouseDown={(event) => { event.preventDefault(); void handleCopy(msg); }}
-              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-zinc-300 hover:bg-zinc-800 hover:text-zinc-100 transition-colors"
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-text-primary hover:bg-glass-bg transition-colors"
             >
               {copied ? (
                 <Check className="h-3.5 w-3.5 text-emerald-400" />
@@ -665,10 +665,10 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
   };
 
   return (
-    <div className="relative flex h-full min-w-0">
+    <div className="dashboard-main relative flex h-full min-w-0">
       <div className="flex min-w-0 flex-1 flex-col">
       {/* Header */}
-      <div className="flex items-center gap-2 px-4 py-3 border-b border-zinc-800 max-md:px-3">
+      <div className="liquid-toolbar flex items-center gap-2 border-b border-glass-border px-4 py-3 max-md:px-3">
         <button
           type="button"
           onClick={handleMobileBack}
@@ -688,7 +688,7 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
           <PanelLeftOpen className="h-4 w-4" />
         </button>
         <MessageSquare className="w-4 h-4 text-cyan-400" />
-        <h2 className="min-w-0 truncate text-sm font-medium text-zinc-200">
+        <h2 className="min-w-0 truncate text-sm font-medium text-text-primary">
           {chatRoomName || "Agent"}
         </h2>
         <div className="ml-auto flex items-center gap-2">
@@ -761,7 +761,7 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
                 className="space-y-1.5"
               >
                 <div className="flex justify-start">
-                  <div className="max-w-[75%] rounded-lg border border-amber-400/25 bg-amber-400/10 px-3 py-2 text-sm text-amber-100">
+                  <div className="liquid-message liquid-message-error max-w-[75%] rounded-2xl border px-3 py-2 text-sm text-text-primary">
                     <div className="mb-1 flex items-center gap-1.5">
                       <span className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-purple-400/30 bg-purple-400/10 text-purple-300">
                         <Bot className="h-2.5 w-2.5" />
@@ -839,9 +839,9 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
                 onMouseLeave={() => { setHoveredActionId(null); setActionMenuOpenId(null); }}
               >
                 {renderMessageActions(msg, true)}
-                <div className="max-w-[75%] rounded-lg px-3 py-2 text-sm bg-cyan-500/20 text-cyan-100 border border-cyan-500/30">
+                <div className="liquid-message liquid-message-own max-w-[75%] rounded-2xl border px-3 py-2 text-sm text-text-primary">
                   <div className="mb-1 flex items-center justify-end gap-1.5">
-                    <span className="text-xs font-medium text-cyan-100/90">
+                    <span className="text-xs font-medium text-neon-cyan">
                       {msg.senderName}
                     </span>
                     <span
@@ -916,16 +916,16 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
                 >
                   {isUser && renderMessageActions(msg, true)}
                   <div
-                    className={`max-w-[75%] rounded-lg px-3 py-2 text-sm ${
+                    className={`liquid-message max-w-[75%] rounded-2xl border px-3 py-2 text-sm ${
                       isUser
-                        ? "bg-cyan-500/20 text-cyan-100 border border-cyan-500/30"
-                        : "bg-zinc-800 text-zinc-200 border border-zinc-700"
+                        ? "liquid-message-own text-text-primary"
+                        : "liquid-message-peer text-text-primary"
                     }`}
                   >
                     <div className={`mb-1 flex items-center gap-1.5 ${isUser ? "justify-end" : ""}`}>
                       {isUser ? (
                         <>
-                          <span className="text-xs font-medium text-cyan-100/90">
+                          <span className="text-xs font-medium text-neon-cyan">
                             {msg.senderName}
                           </span>
                           <span
@@ -945,7 +945,7 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
                           >
                             <Bot className="h-2.5 w-2.5" />
                           </span>
-                          <span className="text-xs font-medium text-zinc-300">
+                          <span className="text-xs font-medium text-text-primary">
                             {msg.senderName}
                           </span>
                           {chatAgentId && (
@@ -1007,7 +1007,7 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
         {/* Typing indicator (only when no streaming message exists) */}
         {agentTyping && !hasStreamingMsg && (
           <div ref={typingIndicatorRef} className="flex justify-start">
-            <div className="rounded-lg px-3 py-2 bg-zinc-800 border border-zinc-700">
+            <div className="liquid-message liquid-message-peer rounded-2xl border px-3 py-2">
               <div className="flex items-center gap-1">
                 <span className="w-1.5 h-1.5 rounded-full bg-zinc-400 animate-bounce [animation-delay:0ms]" />
                 <span className="w-1.5 h-1.5 rounded-full bg-zinc-400 animate-bounce [animation-delay:150ms]" />
@@ -1020,7 +1020,7 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
       </div>
 
       {/* Input */}
-      <div className="border-t border-zinc-800 px-4 py-3">
+      <div className="liquid-toolbar border-t border-glass-border px-4 py-3">
         <div className="flex flex-col gap-1">
           {replyingTo && (
             <OwnerChatReplyingToBar

--- a/frontend/src/components/dashboard/WalletAccountSelector.tsx
+++ b/frontend/src/components/dashboard/WalletAccountSelector.tsx
@@ -59,7 +59,7 @@ export default function WalletAccountSelector({ value, onChange, label }: Props)
   }
 
   return (
-    <div className="mb-4 rounded-xl border border-glass-border bg-deep-black-light px-3 py-2.5">
+    <div className="liquid-card mb-4 rounded-xl border border-glass-border px-3 py-2.5">
       <div className="flex items-center justify-between gap-3">
         <span className="text-[11px] font-medium uppercase tracking-wider text-text-secondary">
           {label ?? t.fromAccount}
@@ -69,13 +69,13 @@ export default function WalletAccountSelector({ value, onChange, label }: Props)
             type="button"
             onClick={() => setOpen((v) => !v)}
             onBlur={() => setTimeout(() => setOpen(false), 120)}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-glass-border bg-glass-bg px-2.5 py-1 text-xs text-text-primary hover:border-neon-cyan/30"
+            className="liquid-action inline-flex items-center gap-1.5 rounded-lg border border-glass-border px-2.5 py-1 text-xs text-text-primary hover:border-neon-cyan/30"
           >
             <span className="font-medium">{current?.label ?? "—"}</span>
             <ChevronDown className="h-3.5 w-3.5" />
           </button>
           {open ? (
-            <div className="absolute right-0 top-full z-30 mt-1 min-w-[220px] overflow-hidden rounded-lg border border-glass-border bg-deep-black-light shadow-lg">
+            <div className="liquid-menu absolute right-0 top-full z-30 mt-1 min-w-[220px] overflow-hidden rounded-lg border border-glass-border shadow-lg">
               {options.map((opt) => {
                 const selected = value?.type === opt.identity.type && value.id === opt.identity.id;
                 return (

--- a/frontend/src/components/dashboard/WalletPanel.tsx
+++ b/frontend/src/components/dashboard/WalletPanel.tsx
@@ -186,11 +186,11 @@ function WalletPanel() {
       return <DashboardTabSkeleton variant="wallet" />;
     }
     return (
-      <div className="flex flex-1 flex-col items-center justify-center bg-deep-black gap-3">
+      <div className="dashboard-main flex flex-1 flex-col items-center justify-center gap-3">
         <div className="text-sm text-red-400">{walletsError}</div>
         <button
           onClick={() => void loadAllWallets()}
-          className="rounded border border-glass-border px-4 py-2 text-xs text-text-secondary hover:text-text-primary"
+          className="liquid-action rounded border border-glass-border px-4 py-2 text-xs text-text-secondary hover:text-text-primary"
         >
           {tc.retry}
         </button>
@@ -199,7 +199,7 @@ function WalletPanel() {
   }
 
   return (
-    <div className="h-full overflow-y-auto bg-deep-black">
+    <div className="dashboard-main h-full overflow-y-auto">
       <div className="mx-auto max-w-5xl px-6 py-8">
         <div className="mb-6 flex items-start justify-between gap-4">
           <div>
@@ -211,7 +211,7 @@ function WalletPanel() {
             onClick={toggleWalletAmountsHidden}
             title={walletAmountsHidden ? "显示金额" : "隐藏金额"}
             aria-label={walletAmountsHidden ? "显示金额" : "隐藏金额"}
-            className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-glass-border text-text-secondary transition-colors hover:border-neon-cyan/30 hover:text-text-primary"
+            className="liquid-action inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-glass-border text-text-secondary transition-colors hover:border-neon-cyan/30 hover:text-text-primary"
           >
             {walletAmountsHidden ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
           </button>
@@ -219,7 +219,7 @@ function WalletPanel() {
 
         <div className="space-y-6">
           {/* Total disposable card */}
-          <div className="rounded-2xl border border-glass-border bg-glass-bg p-6 backdrop-blur-xl">
+          <div className="liquid-card rounded-2xl border border-glass-border p-6">
             <div className="mb-1 text-xs font-medium uppercase tracking-wider text-text-secondary">
               {t.totalDisposable}
             </div>
@@ -231,7 +231,7 @@ function WalletPanel() {
             </div>
 
             <div className="grid grid-cols-2 gap-4">
-              <div className="rounded-xl border border-glass-border bg-deep-black-light p-4">
+              <div className="liquid-tool-surface rounded-xl border border-glass-border p-4">
                 <div className="mb-1 text-[10px] font-medium uppercase tracking-wider text-text-secondary">
                   {t.humanShare}
                 </div>
@@ -239,7 +239,7 @@ function WalletPanel() {
                   {showAmount(humanShareMinor, walletAmountsHidden)}
                 </div>
               </div>
-              <div className="rounded-xl border border-glass-border bg-deep-black-light p-4">
+              <div className="liquid-tool-surface rounded-xl border border-glass-border p-4">
                 <div className="mb-1 flex items-baseline justify-between gap-2">
                   <span className="text-[10px] font-medium uppercase tracking-wider text-text-secondary">
                     {t.botShare}
@@ -381,7 +381,7 @@ function CtaButton({
   return (
     <button
       onClick={onClick}
-      className={`flex flex-col items-center gap-2 rounded-xl border border-glass-border bg-glass-bg p-4 transition-all ${palette.hoverBorder} ${palette.hoverBg}`}
+      className={`liquid-action flex flex-col items-center gap-2 rounded-xl border border-glass-border p-4 transition-all ${palette.hoverBorder} ${palette.hoverBg}`}
     >
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className={`h-6 w-6 ${palette.iconColor}`}>
         {icon}
@@ -409,12 +409,12 @@ function BotBalancesSection({
   onClickBot: (agentId: string) => void;
 }) {
   return (
-    <div className="rounded-2xl border border-glass-border bg-glass-bg p-5 backdrop-blur-xl">
+    <div className="liquid-card rounded-2xl border border-glass-border p-5">
       <div className="mb-3 flex items-center justify-between">
         <h3 className="text-sm font-semibold text-text-primary">{label}</h3>
       </div>
       {ownedAgents.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-glass-border bg-deep-black-light p-4 text-sm text-text-secondary">
+        <div className="liquid-empty-state rounded-xl border border-dashed border-glass-border p-4 text-sm text-text-secondary">
           {empty}
         </div>
       ) : (
@@ -425,7 +425,7 @@ function BotBalancesSection({
               <button
                 key={agent.agent_id}
                 onClick={() => onClickBot(agent.agent_id)}
-                className="flex w-full items-center gap-3 rounded-xl border border-glass-border bg-deep-black-light px-3.5 py-3 text-left transition-colors hover:border-neon-cyan/30 hover:bg-neon-cyan/5"
+                className="liquid-list-row flex w-full items-center gap-3 rounded-xl border border-glass-border px-3.5 py-3 text-left transition-colors hover:border-neon-cyan/30 hover:bg-neon-cyan/5"
               >
                 <BotAvatar agentId={agent.agent_id} alt={agent.display_name} avatarUrl={agent.avatar_url} size={36} />
                 <div className="min-w-0 flex-1">
@@ -486,24 +486,24 @@ function MergedLedgerSection({
   txTypeLabels: { topup: string; transfer: string; withdrawal: string; subscription: string; other: string };
 }) {
   return (
-    <div className="rounded-2xl border border-glass-border bg-glass-bg p-5 backdrop-blur-xl">
+    <div className="liquid-card rounded-2xl border border-glass-border p-5">
       <div className="mb-3">
         <h3 className="text-sm font-semibold text-text-primary">{title}</h3>
         <p className="text-xs text-text-secondary/70">{hint}</p>
       </div>
 
       {entries.length === 0 && !loading ? (
-        <div className="rounded-xl border border-dashed border-glass-border bg-deep-black-light p-4 text-sm text-text-secondary">
+        <div className="liquid-empty-state rounded-xl border border-dashed border-glass-border p-4 text-sm text-text-secondary">
           {emptyLabel}
         </div>
       ) : (
-        <div className="overflow-hidden rounded-xl border border-glass-border bg-deep-black-light">
+        <div className="liquid-tool-surface overflow-hidden rounded-xl border border-glass-border">
           {entries.map((entry) => {
             const isCredit = entry.direction === "credit";
             return (
               <div
                 key={entry.entry_id}
-                className="flex items-center justify-between gap-4 border-b border-glass-border/40 px-4 py-3 last:border-b-0"
+                className="liquid-list-row flex items-center justify-between gap-4 border-b border-glass-border/40 px-4 py-3 last:border-b-0"
               >
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
@@ -533,7 +533,7 @@ function MergedLedgerSection({
           <button
             onClick={onLoadMore}
             disabled={loading}
-            className="inline-flex min-w-[5.5rem] items-center justify-center gap-1.5 rounded-lg border border-glass-border px-4 py-1.5 text-[11px] text-text-secondary transition-colors hover:text-text-primary disabled:opacity-60"
+            className="liquid-action inline-flex min-w-[5.5rem] items-center justify-center gap-1.5 rounded-lg border border-glass-border px-4 py-1.5 text-[11px] text-text-secondary transition-colors hover:text-text-primary disabled:opacity-60"
           >
             {loading ? (
               <>
@@ -601,7 +601,7 @@ function RecentWithdrawals({
   );
 
   return (
-    <div className="rounded-2xl border border-glass-border bg-glass-bg p-5 backdrop-blur-xl">
+    <div className="liquid-card rounded-2xl border border-glass-border p-5">
       <div className="mb-4 flex items-center justify-between">
         <div>
           <h3 className="text-sm font-semibold text-text-primary">{t.recentWithdrawals}</h3>
@@ -610,7 +610,7 @@ function RecentWithdrawals({
         <button
           onClick={onRefresh}
           disabled={isRefreshing}
-          className="inline-flex items-center gap-1.5 rounded-lg border border-glass-border px-3 py-1 text-[11px] text-text-secondary transition-colors hover:text-text-primary disabled:opacity-60"
+          className="liquid-action inline-flex items-center gap-1.5 rounded-lg border border-glass-border px-3 py-1 text-[11px] text-text-secondary transition-colors hover:text-text-primary disabled:opacity-60"
         >
           {isRefreshing ? <Loader2 className="h-3 w-3 animate-spin" /> : null}
           {isRefreshing ? t.refreshing : t.refresh}
@@ -628,7 +628,7 @@ function RecentWithdrawals({
           {error}
         </div>
       ) : items.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-glass-border bg-deep-black-light p-4 text-sm text-text-secondary">
+        <div className="liquid-empty-state rounded-xl border border-dashed border-glass-border p-4 text-sm text-text-secondary">
           {t.noWithdrawals}
         </div>
       ) : (
@@ -638,7 +638,7 @@ function RecentWithdrawals({
             return (
               <div
                 key={item.withdrawal_id}
-                className="rounded-xl border border-glass-border bg-deep-black-light p-4"
+                className="liquid-tool-surface rounded-xl border border-glass-border p-4"
               >
                 <div className="mb-2 flex items-start justify-between gap-3">
                   <div>
@@ -655,10 +655,10 @@ function RecentWithdrawals({
                 </div>
 
                 <div className="flex flex-wrap gap-2 text-[11px] text-text-secondary">
-                  <span className="rounded bg-black/20 px-2 py-1">
+                  <span className="rounded bg-glass-bg/70 px-2 py-1">
                     {item.destination_type || "manual_review"}
                   </span>
-                  <span className="rounded bg-black/20 px-2 py-1">#{item.withdrawal_id}</span>
+                  <span className="rounded bg-glass-bg/70 px-2 py-1">#{item.withdrawal_id}</span>
                 </div>
 
                 {item.status === "pending" ? (
@@ -675,7 +675,7 @@ function RecentWithdrawals({
                   </div>
                 ) : null}
                 {item.review_note ? (
-                  <div className="mt-3 rounded-lg border border-glass-border bg-black/20 p-3 text-xs text-text-secondary">
+                  <div className="liquid-tool-surface mt-3 rounded-lg border border-glass-border p-3 text-xs text-text-secondary">
                     {item.review_note}
                   </div>
                 ) : null}
@@ -700,8 +700,8 @@ function getWithdrawalStatusMeta(status: string, t: (typeof walletPanel)["en"]) 
     case "rejected":
       return { label: t.rejected, className: "bg-red-500/15 text-red-300" };
     case "cancelled":
-      return { label: t.cancelled, className: "bg-white/10 text-text-secondary" };
+      return { label: t.cancelled, className: "bg-glass-bg/70 text-text-secondary" };
     default:
-      return { label: status, className: "bg-white/10 text-text-secondary" };
+      return { label: status, className: "bg-glass-bg/70 text-text-secondary" };
   }
 }

--- a/frontend/src/components/dashboard/WithdrawDialog.tsx
+++ b/frontend/src/components/dashboard/WithdrawDialog.tsx
@@ -164,17 +164,17 @@ export default function WithdrawDialog({ viewer, onClose, onSuccess, availableBa
   return (
     <div
       ref={overlayRef}
-      className={`fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`}
+      className={`liquid-scrim fixed inset-0 z-50 flex items-center justify-center ${closing ? "pointer-events-none" : ""}`}
       onClick={closeWithMotion}
     >
       <div
         ref={panelRef}
-        className="relative flex max-h-[90vh] w-full max-w-md flex-col rounded-2xl border border-glass-border bg-glass-bg backdrop-blur-xl"
+        className="liquid-dialog relative flex max-h-[90vh] w-full max-w-md flex-col rounded-2xl"
         onClick={(e) => e.stopPropagation()}
       >
         <button
           onClick={closeWithMotion}
-          className="absolute right-4 top-4 z-10 rounded p-1 text-text-secondary hover:text-text-primary"
+          className="liquid-action absolute right-4 top-4 z-10 rounded-lg p-1 text-text-secondary hover:text-text-primary"
         >
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
             <path d="M4 4l8 8M12 4l-8 8" />
@@ -190,7 +190,7 @@ export default function WithdrawDialog({ viewer, onClose, onSuccess, availableBa
         <WalletAccountSelector value={selectedViewer} onChange={setSelectedViewer} />
 
         <form id="withdrawForm" onSubmit={handleSubmit} className="space-y-4">
-          <div className="rounded-lg border border-glass-border bg-deep-black-light p-3">
+          <div className="liquid-card rounded-lg p-3">
             <div className="flex items-center justify-between">
               <span className="text-xs text-text-secondary">{t.availableBalance}</span>
               <span className="font-mono text-sm font-semibold text-neon-green">
@@ -211,7 +211,7 @@ export default function WithdrawDialog({ viewer, onClose, onSuccess, availableBa
               value={amount}
               onChange={(e) => setAmount(e.target.value)}
               placeholder="0.00"
-              className="w-full rounded-lg border border-glass-border bg-deep-black-light p-3 font-mono text-sm text-text-primary placeholder-text-secondary/50 outline-none focus:border-neon-purple/50"
+              className="liquid-input w-full rounded-lg border p-3 font-mono text-sm text-text-primary placeholder-text-secondary/50 outline-none focus:border-neon-purple/50"
             />
             <button
               type="button"
@@ -232,7 +232,7 @@ export default function WithdrawDialog({ viewer, onClose, onSuccess, availableBa
                 if (value) setDestinationType(value as "bank" | "usdt_trc20" | "paypal");
               }}
               placeholder={t.destinationType}
-              buttonClassName="min-h-11 bg-deep-black-light p-3 focus:border-neon-purple/50 focus:ring-neon-purple/40"
+              buttonClassName="liquid-input min-h-11 p-3 focus:border-neon-purple/50 focus:ring-neon-purple/40"
               options={[
                 { value: "bank", label: t.destinationTypeBank },
                 { value: "usdt_trc20", label: t.destinationTypeUsdt },
@@ -312,7 +312,7 @@ export default function WithdrawDialog({ viewer, onClose, onSuccess, availableBa
             placeholder="Telegram / email / memo"
           />
 
-          <div className="rounded-lg border border-glass-border bg-deep-black-light p-3">
+          <div className="liquid-card rounded-lg p-3">
             <p className="text-xs text-text-secondary">{t.reviewNotice}</p>
             <label className="mt-3 flex items-start gap-2 text-xs text-text-primary">
               <input
@@ -329,12 +329,12 @@ export default function WithdrawDialog({ viewer, onClose, onSuccess, availableBa
         </form>
         </div>
 
-        <div className="shrink-0 border-t border-glass-border bg-glass-bg/40 px-6 py-4">
+        <div className="liquid-toolbar shrink-0 border-t px-6 py-4">
           <button
             form="withdrawForm"
             type="submit"
             disabled={submitting}
-            className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-purple/30 bg-neon-purple/10 py-2.5 font-medium text-neon-purple transition-colors hover:bg-neon-purple/20 disabled:opacity-40"
+            className="liquid-action inline-flex w-full items-center justify-center gap-2 rounded-lg border border-neon-purple/30 bg-neon-purple/10 py-2.5 font-medium text-neon-purple transition-colors hover:bg-neon-purple/20 disabled:opacity-40"
           >
             {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
             {submitting ? t.submitting : t.submitWithdraw}
@@ -367,7 +367,7 @@ function FormField({
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
         disabled={disabled}
-        className="w-full rounded-lg border border-glass-border bg-deep-black-light p-3 text-sm text-text-primary placeholder-text-secondary/50 outline-none focus:border-neon-purple/50 disabled:opacity-60"
+        className="liquid-input w-full rounded-lg border p-3 text-sm text-text-primary placeholder-text-secondary/50 outline-none focus:border-neon-purple/50 disabled:opacity-60"
       />
     </div>
   );

--- a/frontend/src/components/dashboard/sidebar/BotsPanel.tsx
+++ b/frontend/src/components/dashboard/sidebar/BotsPanel.tsx
@@ -29,9 +29,9 @@ function AgentRow({ bot, isSelected, locale, onSelect, onOpenSettings }: AgentRo
     <div className="group relative">
       <button
         onClick={() => onSelect(bot.agent_id)}
-        className={`flex w-full items-center gap-2.5 rounded-lg border px-2.5 py-1.5 pr-11 text-left transition-colors ${
+        className={`liquid-list-row flex w-full items-center gap-2.5 rounded-lg border px-2.5 py-1.5 pr-11 text-left transition-colors ${
           isSelected
-            ? "border-neon-cyan/60 bg-neon-cyan/10 text-neon-cyan"
+            ? "!border-neon-cyan/60 !bg-neon-cyan/10 text-neon-cyan"
             : "border-transparent text-text-secondary hover:border-glass-border hover:bg-glass-bg hover:text-text-primary"
         }`}
       >
@@ -64,9 +64,9 @@ function AgentRow({ bot, isSelected, locale, onSelect, onOpenSettings }: AgentRo
         title={settingsLabel}
         aria-label={`${bot.display_name || bot.agent_id} ${settingsLabel}`}
         onClick={(e) => { e.stopPropagation(); onOpenSettings(bot); }}
-        className={`absolute right-2 top-1/2 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-md border transition-colors ${
+        className={`liquid-action absolute right-2 top-1/2 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-md border transition-colors ${
           isSelected
-            ? "border-neon-cyan/30 bg-deep-black/30 text-neon-cyan hover:bg-neon-cyan/10"
+            ? "border-neon-cyan/30 bg-glass-bg/70 text-neon-cyan hover:bg-neon-cyan/10"
             : "border-transparent text-text-secondary/60 hover:border-glass-border hover:bg-glass-bg hover:text-text-primary"
         }`}
       >
@@ -165,7 +165,7 @@ export default function BotsPanel({
         const label = daemon?.label || did.slice(0, 8);
         const isOnline = daemon?.status === "online";
         return (
-          <div key={did} className="rounded-xl border border-glass-border/50 bg-glass-bg/20">
+          <div key={did} className="liquid-card rounded-xl border border-glass-border/50">
             <div className="flex items-center gap-2 px-3 py-2">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-3.5 w-3.5 flex-shrink-0 text-text-secondary/60">
                 <path strokeLinecap="round" strokeLinejoin="round" d="M9 17.25v1.007a3 3 0 0 1-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0 1 15 18.257V17.25m6-12V15a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 15V5.25m18 0A2.25 2.25 0 0 0 18.75 3H5.25A2.25 2.25 0 0 0 3 5.25m18 0H3" />
@@ -219,7 +219,7 @@ export default function BotsPanel({
 
       {/* Unbound agents */}
       {unbound.length > 0 && (
-        <div className="rounded-xl border border-glass-border/50 bg-glass-bg/20">
+        <div className="liquid-card rounded-xl border border-glass-border/50">
           <div className="flex items-center gap-2 px-3 py-2">
             <Bot className="h-3.5 w-3.5 flex-shrink-0 text-text-secondary/60" />
             <span className="flex-1 text-[11px] font-semibold text-text-secondary/80">
@@ -243,12 +243,12 @@ export default function BotsPanel({
 
       {/* Empty state */}
       {isEmpty && (
-        <div className="rounded-lg border border-dashed border-glass-border px-3 py-6 text-center">
+        <div className="liquid-empty-state rounded-lg border border-dashed border-glass-border px-3 py-6 text-center">
           <p className="text-xs text-text-secondary/70">{t.myBotsEmpty}</p>
           <button
             type="button"
             onClick={onOpenCreateBot}
-            className="mt-4 inline-flex items-center gap-2 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-2 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20"
+            className="liquid-action mt-4 inline-flex items-center gap-2 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-2 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20"
           >
             <Plus className="h-3.5 w-3.5" />
             <span>{t.createBot}</span>
@@ -261,7 +261,7 @@ export default function BotsPanel({
         <button
           type="button"
           onClick={() => setShowAddDevice(true)}
-          className="flex w-full items-center gap-2 rounded-lg border border-dashed border-glass-border/60 px-3 py-2 text-left text-xs text-text-secondary/60 transition-colors hover:border-neon-cyan/30 hover:text-neon-cyan/80"
+          className="liquid-action flex w-full items-center gap-2 rounded-lg border border-dashed border-glass-border/60 px-3 py-2 text-left text-xs text-text-secondary/60 transition-colors hover:border-neon-cyan/30 hover:text-neon-cyan/80"
         >
           <Plus className="h-3.5 w-3.5" />
           <span>{locale === "zh" ? "添加设备" : "Add Device"}</span>

--- a/frontend/src/components/dashboard/sidebar/ContactsPanel.tsx
+++ b/frontend/src/components/dashboard/sidebar/ContactsPanel.tsx
@@ -60,7 +60,7 @@ function Section({
     <div className="border-b border-glass-border/50">
       <button
         onClick={() => setOpen((v) => !v)}
-        className="flex w-full items-center justify-between px-3 py-2 text-[11px] font-semibold uppercase tracking-wider text-text-secondary/70 transition-colors hover:text-text-primary"
+        className="liquid-list-row flex w-full items-center justify-between px-3 py-2 text-[11px] font-semibold uppercase tracking-wider text-text-secondary/70 transition-colors hover:text-text-primary"
       >
         <span className="flex items-center gap-1.5">
           <ChevronDown
@@ -103,9 +103,9 @@ function ListRow({
     <button
       data-contact-section-item
       onClick={onClick}
-      className={`flex w-full items-center gap-2.5 px-3 py-2 text-left transition-colors ${
+      className={`liquid-list-row flex w-full items-center gap-2.5 px-3 py-2 text-left transition-colors ${
         active
-          ? "bg-neon-cyan/10"
+          ? "!bg-neon-cyan/10"
           : "hover:bg-glass-bg/60"
       }`}
     >
@@ -113,7 +113,7 @@ function ListRow({
         {avatar}
         {online !== undefined ? (
           <span
-            className={`absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full ring-2 ring-deep-black-light ${
+            className={`absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full ring-2 ring-glass-border ${
               online ? "bg-neon-green" : "bg-text-secondary/40"
             }`}
           />
@@ -233,7 +233,7 @@ export default function ContactsPanel({ onOpenAddFriend }: ContactsPanelProps) {
       {/* Pinned: New Requests */}
       <button
         onClick={openRequests}
-        className="flex items-center gap-3 border-b border-glass-border px-3 py-3 text-left transition-colors hover:bg-glass-bg/60"
+        className="liquid-list-row flex items-center gap-3 border-b border-glass-border px-3 py-3 text-left transition-colors"
       >
         <div className="flex h-10 w-10 items-center justify-center rounded-full bg-orange-500/15 text-orange-400">
           <UserPlus2 className="h-4.5 w-4.5" />
@@ -242,7 +242,7 @@ export default function ContactsPanel({ onOpenAddFriend }: ContactsPanelProps) {
           <div className="flex items-center gap-2">
             <span className="text-sm font-medium text-text-primary">{t.newRequests}</span>
             {totalPendingRequests > 0 ? (
-              <span className="rounded-full bg-neon-cyan px-1.5 text-[10px] font-bold text-black">
+              <span className="rounded-full bg-neon-cyan px-1.5 text-[10px] font-bold text-text-primary">
                 {totalPendingRequests > 99 ? "99+" : totalPendingRequests}
               </span>
             ) : null}

--- a/frontend/src/components/dashboard/sidebar/DeviceSettingsModal.tsx
+++ b/frontend/src/components/dashboard/sidebar/DeviceSettingsModal.tsx
@@ -134,10 +134,10 @@ export default function DeviceSettingsModal({
     ? `/daemon/diagnostics/${encodeURIComponent(diagnosticResult.bundle_id)}/download`
     : "";
   return (
-    <div ref={overlayRef} className={`fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`} onClick={closeWithMotion}>
-      <div ref={panelRef} className="relative w-full max-w-sm rounded-2xl border border-glass-border bg-deep-black-light shadow-2xl" onClick={(e) => e.stopPropagation()}>
+    <div ref={overlayRef} className={`liquid-scrim fixed inset-0 z-50 flex items-center justify-center backdrop-blur-sm ${closing ? "pointer-events-none" : ""}`} onClick={closeWithMotion}>
+      <div ref={panelRef} className="liquid-dialog relative w-full max-w-sm rounded-2xl border border-glass-border shadow-2xl" onClick={(e) => e.stopPropagation()}>
         {/* Header */}
-        <div className="flex items-center gap-3 border-b border-glass-border/50 px-5 py-4">
+        <div className="liquid-toolbar flex items-center gap-3 border-b border-glass-border/50 px-5 py-4">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-4 w-4 flex-shrink-0 text-text-secondary/60">
             <path strokeLinecap="round" strokeLinejoin="round" d="M9 17.25v1.007a3 3 0 0 1-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0 1 15 18.257V17.25m6-12V15a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 15V5.25m18 0A2.25 2.25 0 0 0 18.75 3H5.25A2.25 2.25 0 0 0 3 5.25m18 0H3" />
           </svg>

--- a/frontend/src/components/dashboard/sidebar/MessagesGroupingSidebar.tsx
+++ b/frontend/src/components/dashboard/sidebar/MessagesGroupingSidebar.tsx
@@ -105,15 +105,15 @@ export default function MessagesGroupingSidebar({
   };
 
   return (
-    <div className={`flex h-full ${fullWidth ? "w-full" : "w-[200px]"} shrink-0 flex-col border-r border-glass-border bg-deep-black/50`}>
-      <div className="flex h-14 items-center justify-between border-b border-glass-border px-3">
+    <div className={`liquid-rail flex h-full ${fullWidth ? "w-full" : "w-[200px]"} shrink-0 flex-col border-r border-glass-border`}>
+      <div className="liquid-toolbar flex h-14 items-center justify-between border-b border-glass-border px-3">
         <span className="text-[11px] font-semibold uppercase tracking-[0.16em] text-text-secondary/70">{t.header}</span>
         <button
           type="button"
           onClick={() => (onCollapse ? onCollapse() : setMessagesGroupingOpen(false))}
           title={t.collapse}
           aria-label={t.collapse}
-          className="flex h-7 w-7 items-center justify-center rounded-md text-text-secondary/60 transition-colors hover:bg-glass-bg hover:text-text-primary"
+          className="liquid-action flex h-7 w-7 items-center justify-center rounded-md text-text-secondary/60 transition-colors hover:bg-glass-bg hover:text-text-primary"
         >
           <ChevronsLeft className="h-3.5 w-3.5" />
         </button>
@@ -191,7 +191,7 @@ function GroupHeader({
       type="button"
       onClick={onToggle}
       aria-expanded={open}
-      className="flex w-full items-center gap-1.5 px-3 py-2 text-left transition-colors hover:bg-glass-bg/40"
+      className="liquid-list-row flex w-full items-center gap-1.5 px-3 py-2 text-left transition-colors"
     >
       {open ? (
         <ChevronDown className="h-3 w-3 shrink-0 text-text-secondary/60" />
@@ -226,9 +226,9 @@ function FilterButton({
     <button
       type="button"
       onClick={onClick}
-      className={`flex w-full items-center justify-between gap-2 py-1.5 pl-[28px] pr-3 text-[12px] transition-colors ${
+      className={`liquid-list-row flex w-full items-center justify-between gap-2 py-1.5 pl-[28px] pr-3 text-[12px] transition-colors ${
         active
-          ? "bg-neon-cyan/10 text-neon-cyan"
+          ? "!bg-neon-cyan/10 text-neon-cyan"
           : "text-text-secondary hover:bg-glass-bg/50 hover:text-text-primary"
       }`}
     >

--- a/frontend/src/components/dashboard/sidebar/MessagesPanel.tsx
+++ b/frontend/src/components/dashboard/sidebar/MessagesPanel.tsx
@@ -268,14 +268,14 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
   return (
     <div className="flex min-h-full flex-col">
       {/* Column header — peer-level to MessagesGroupingSidebar's header */}
-      <div className="flex min-h-14 items-center justify-between border-b border-glass-border px-3 py-2.5">
+      <div className="liquid-toolbar flex min-h-14 items-center justify-between border-b border-glass-border px-3 py-2.5">
         <div className="flex min-w-0 items-center gap-2">
           {!isGuest && !messagesGroupingOpen ? (
             <button
               onClick={() => setMessagesGroupingOpen(true)}
               title="展开分组"
               aria-label="展开分组"
-              className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-glass-border text-text-secondary/70 transition-colors hover:border-neon-cyan/40 hover:text-neon-cyan max-md:hidden"
+              className="liquid-action flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-glass-border text-text-secondary/70 transition-colors hover:border-neon-cyan/40 hover:text-neon-cyan max-md:hidden"
             >
               <ChevronsRight className="h-3.5 w-3.5" />
             </button>
@@ -286,9 +286,9 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
               onClick={() => setMobileGroupingOpen((open) => !open)}
               title={tGrouping.header}
               aria-label={tGrouping.header}
-              className={`hidden h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors max-md:flex ${
+              className={`liquid-action hidden h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors max-md:flex ${
                 mobileGroupingOpen
-                  ? "bg-neon-cyan/10 text-neon-cyan"
+                  ? "!bg-neon-cyan/10 text-neon-cyan"
                   : "text-text-secondary hover:bg-neon-cyan/10 hover:text-neon-cyan"
               }`}
             >
@@ -332,12 +332,12 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
             ref={mobileGroupingOverlayRef}
             type="button"
             aria-label={tGrouping.collapse}
-            className="absolute inset-0 bg-black/45 backdrop-blur-sm"
+            className="liquid-scrim absolute inset-0 backdrop-blur-sm"
             onClick={() => setMobileGroupingOpen(false)}
           />
           <div
             ref={mobileGroupingPanelRef}
-            className="absolute bottom-[calc(4.5rem+env(safe-area-inset-bottom))] left-0 top-0 w-[min(84vw,280px)] overflow-hidden border-r border-glass-border bg-deep-black-light shadow-2xl shadow-black/60"
+            className="liquid-drawer absolute bottom-[calc(4.5rem+env(safe-area-inset-bottom))] left-0 top-0 w-[min(84vw,280px)] overflow-hidden border-r border-glass-border"
           >
             <div data-mobile-grouping-motion className="h-full">
             <MessagesGroupingSidebar
@@ -358,8 +358,8 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
             setOpenedTopicId(null);
             startTransition(() => router.push("/chats/messages"));
           }}
-          className={`flex items-center gap-3 border-b border-glass-border px-3 py-3 text-left transition-colors ${
-            messagesShowRequests ? "bg-neon-cyan/10" : "hover:bg-glass-bg/60"
+          className={`liquid-list-row flex items-center gap-3 border-b border-glass-border px-3 py-3 text-left transition-colors ${
+            messagesShowRequests ? "!bg-neon-cyan/10" : "hover:bg-glass-bg/60"
           }`}
         >
           <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-orange-500/15 text-orange-400">
@@ -370,7 +370,7 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
               <span className={`text-sm font-medium ${messagesShowRequests ? "text-neon-cyan" : "text-text-primary"}`}>
                 {locale === "zh" ? "新好友申请" : "New Requests"}
               </span>
-              <span className="rounded-full bg-neon-cyan px-1.5 text-[10px] font-bold text-black">
+              <span className="rounded-full bg-neon-cyan px-1.5 text-[10px] font-bold text-text-primary">
                 {pendingRequestCount}
               </span>
             </div>
@@ -393,7 +393,7 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
         </div>
       ) : null}
       {isBotsScope && ownedAgents.length === 0 ? (
-        <div ref={emptyStateRef} className="flex flex-1 flex-col items-center justify-center px-6 py-12 text-center">
+        <div ref={emptyStateRef} className="liquid-empty-state m-3 flex flex-1 flex-col items-center justify-center rounded-2xl border border-glass-border px-6 py-12 text-center">
           <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl border border-glass-border bg-glass-bg/40">
             <Bot className="h-7 w-7 text-text-secondary/70" />
           </div>
@@ -403,7 +403,7 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
           </p>
           <button
             onClick={() => openCreateBotModal()}
-            className="mt-5 inline-flex items-center gap-1.5 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3.5 py-2 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20"
+            className="liquid-action mt-5 inline-flex items-center gap-1.5 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3.5 py-2 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20"
           >
             <Plus className="h-3.5 w-3.5" />
             创建 Bot
@@ -414,7 +414,7 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
           <RoomZeroState compact />
         </div>
       ) : !showOverviewSkeleton && filteredMessageRooms.length === 0 ? (
-        <div ref={emptyStateRef} className="px-4 py-6 text-center text-xs text-text-secondary">
+        <div ref={emptyStateRef} className="liquid-empty-state m-3 rounded-2xl border border-glass-border px-4 py-6 text-center text-xs text-text-secondary">
           {t.noMessages}
         </div>
       ) : (
@@ -425,7 +425,7 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
             searchQuery={messageQuery}
           />
           {!showOverviewSkeleton && !normalizedMessageQuery && filteredMessageRooms.length < 5 && (
-            <div className="mx-3 mb-3 mt-auto rounded-2xl border border-dashed border-glass-border/60 bg-glass-bg/20 p-4">
+            <div className="liquid-card mx-3 mb-3 mt-auto rounded-2xl border border-dashed border-glass-border/60 p-4">
               <p className="text-[11px] font-semibold text-text-secondary/80">
                 {locale === "zh" ? "发现更多社区" : "Discover communities"}
               </p>
@@ -437,7 +437,7 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
                   <button
                     type="button"
                     onClick={onCreateRoom}
-                    className="rounded-xl border border-neon-purple/35 bg-neon-purple/10 px-3 py-1.5 text-[11px] font-medium text-neon-purple transition-colors hover:bg-neon-purple/20"
+                    className="liquid-action rounded-xl border border-neon-purple/35 bg-neon-purple/10 px-3 py-1.5 text-[11px] font-medium text-neon-purple transition-colors hover:bg-neon-purple/20"
                   >
                     {locale === "zh" ? "创建房间" : "Create a room"}
                   </button>
@@ -449,7 +449,7 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
                     useDashboardUIStore.getState().setSidebarTab("explore");
                     startTransition(() => { router.push("/chats/explore/rooms"); });
                   }}
-                  className="rounded-xl border border-glass-border/70 bg-deep-black-light px-3 py-1.5 text-[11px] font-medium text-text-secondary transition-colors hover:border-neon-cyan/35 hover:text-neon-cyan"
+                  className="liquid-action rounded-xl border border-glass-border/70 px-3 py-1.5 text-[11px] font-medium text-text-secondary transition-colors hover:border-neon-cyan/35 hover:text-neon-cyan"
                 >
                   {locale === "zh" ? "探索公开社区" : "Explore public rooms"}
                 </button>
@@ -479,15 +479,15 @@ function TooltipIconButton({
         type="button"
         onClick={onClick}
         aria-label={label}
-        className={`flex h-8 w-8 items-center justify-center rounded-lg transition-colors hover:bg-neon-cyan/10 hover:text-neon-cyan ${
-          active ? "bg-neon-cyan/10 text-neon-cyan" : "text-text-secondary"
+        className={`liquid-action flex h-8 w-8 items-center justify-center rounded-lg transition-colors hover:bg-neon-cyan/10 hover:text-neon-cyan ${
+          active ? "!bg-neon-cyan/10 text-neon-cyan" : "text-text-secondary"
         }`}
       >
         {children}
       </button>
       <span
         role="tooltip"
-        className="pointer-events-none absolute left-1/2 top-full z-20 mt-1.5 -translate-x-1/2 whitespace-nowrap rounded-md border border-glass-border bg-deep-black px-2 py-0.5 text-[11px] text-text-primary opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100"
+        className="liquid-menu pointer-events-none absolute left-1/2 top-full z-20 mt-1.5 -translate-x-1/2 whitespace-nowrap rounded-md border border-glass-border px-2 py-0.5 text-[11px] text-text-primary opacity-0 transition-opacity duration-150 group-hover:opacity-100"
       >
         {label}
       </span>

--- a/frontend/src/components/dashboard/sidebar/NavButtons.tsx
+++ b/frontend/src/components/dashboard/sidebar/NavButtons.tsx
@@ -76,7 +76,7 @@ export function PrimaryNavButton({
     <button
       ref={buttonRef}
       onClick={onClick}
-      className={`group relative flex h-12 w-12 flex-col items-center justify-center rounded-xl transition-all duration-200 max-md:h-12 max-md:min-w-0 max-md:flex-1 max-md:px-1 ${
+      className={`liquid-nav-button group relative flex h-12 w-12 flex-col items-center justify-center rounded-xl transition-all duration-200 max-md:h-12 max-md:min-w-0 max-md:flex-1 max-md:px-1 ${
         disabled
           ? "text-text-secondary/45 hover:bg-neon-cyan/10 hover:text-neon-cyan"
           : active

--- a/frontend/src/components/dashboard/sidebar/index.tsx
+++ b/frontend/src/components/dashboard/sidebar/index.tsx
@@ -28,6 +28,7 @@ import { createClient } from "@/lib/supabase/client";
 import { animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from "@/lib/anime";
 
 import AccountMenu from "../AccountMenu";
+import ThemeToggle from "../ThemeToggle";
 import AddFriendModal from "../AddFriendModal";
 import CreateRoomModal from "../CreateRoomModal";
 import CreateAgentDialog from "../CreateAgentDialog";
@@ -394,7 +395,7 @@ function Sidebar({
   return (
     <div className={`flex h-full max-md:w-full max-md:flex-col-reverse ${mobileHideSecondary ? "max-md:h-[calc(4rem+env(safe-area-inset-bottom))]" : "max-md:h-full"}`}>
       {/* Primary rail */}
-      <div className="flex h-full w-16 min-w-[64px] flex-col items-center border-r border-glass-border bg-deep-black py-3 max-md:h-[calc(4rem+env(safe-area-inset-bottom))] max-md:w-full max-md:min-w-0 max-md:shrink-0 max-md:flex-row max-md:border-r-0 max-md:border-t max-md:px-2 max-md:pb-[env(safe-area-inset-bottom)] max-md:pt-2">
+      <div className="liquid-rail flex h-full w-16 min-w-[64px] flex-col items-center border-r border-glass-border bg-deep-black py-3 max-md:h-[calc(4rem+env(safe-area-inset-bottom))] max-md:w-full max-md:min-w-0 max-md:shrink-0 max-md:flex-row max-md:border-r-0 max-md:border-t max-md:px-2 max-md:pb-[env(safe-area-inset-bottom)] max-md:pt-2">
         <Link
           href="/"
           className="mb-3 flex h-11 w-11 items-center justify-center rounded-xl border border-glass-border bg-deep-black-light transition-colors hover:border-neon-cyan/50 hover:bg-glass-bg max-md:mb-0 max-md:mr-2 max-md:hidden"
@@ -444,6 +445,7 @@ function Sidebar({
         </div>
 
         <div className="flex flex-col items-center gap-2 border-t border-glass-border pt-3 max-md:ml-1 max-md:shrink-0 max-md:gap-1 max-md:border-l max-md:border-t-0 max-md:pl-1 max-md:pt-0">
+          <ThemeToggle />
           <button
             onClick={() => setLanguage(locale === "zh" ? "en" : "zh")}
             aria-label="Toggle language"
@@ -523,7 +525,7 @@ function Sidebar({
       {/* Secondary panel — hidden on Home, My Bots, Explore, Wallet (those pages get full width). */}
       {visibleSidebarTab !== "home" && visibleSidebarTab !== "bots" && visibleSidebarTab !== "explore" && visibleSidebarTab !== "wallet" && (
       <div
-        className={`relative flex h-full flex-col border-r border-glass-border bg-deep-black-light max-md:min-h-0 max-md:flex-1 max-md:!min-w-0 max-md:border-r-0 ${
+        className={`liquid-panel relative flex h-full flex-col border-r border-glass-border bg-deep-black-light max-md:min-h-0 max-md:flex-1 max-md:!min-w-0 max-md:border-r-0 ${
           mobileHideSecondary
             ? mobileSecondaryRendered
               ? "max-md:fixed max-md:inset-x-3 max-md:bottom-[calc(5rem+env(safe-area-inset-bottom))] max-md:top-4 max-md:z-40 max-md:!w-auto max-md:rounded-xl max-md:border max-md:border-glass-border max-md:shadow-2xl max-md:shadow-black/50"

--- a/frontend/src/components/ui/AttachmentItem.tsx
+++ b/frontend/src/components/ui/AttachmentItem.tsx
@@ -100,7 +100,7 @@ function AttachmentFileLink({
           event.stopPropagation();
           onPreview?.(attachment);
         }}
-        className="flex max-w-full items-center gap-2 rounded-lg border border-glass-border bg-glass-bg/50 px-2.5 py-1.5 text-left text-xs text-text-primary hover:border-neon-cyan/30 transition-colors"
+        className="liquid-tool-surface flex max-w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left text-xs text-text-primary hover:border-neon-cyan/30 transition-colors"
       >
         {content}
       </button>
@@ -112,7 +112,7 @@ function AttachmentFileLink({
       href={attachmentUrl}
       target="_blank"
       rel="noopener noreferrer"
-      className="flex items-center gap-2 rounded-lg border border-glass-border bg-glass-bg/50 px-2.5 py-1.5 text-xs text-text-primary hover:border-neon-cyan/30 transition-colors"
+      className="liquid-tool-surface flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-xs text-text-primary hover:border-neon-cyan/30 transition-colors"
     >
       {content}
     </a>
@@ -152,7 +152,7 @@ export default function AttachmentItem({ attachment, previewAttachments, onPrevi
                 setPreviewOpen(true);
               }
             }}
-            className="group inline-flex min-h-24 min-w-24 max-w-full items-center justify-center overflow-hidden rounded-lg border border-glass-border bg-black/20 text-left"
+            className="liquid-tool-surface group inline-flex min-h-24 min-w-24 max-w-full items-center justify-center overflow-hidden rounded-xl text-left"
             aria-label={`Preview ${title}`}
           >
             <img

--- a/frontend/src/components/ui/ConfirmDialog.tsx
+++ b/frontend/src/components/ui/ConfirmDialog.tsx
@@ -48,7 +48,7 @@ export default function ConfirmDialog() {
 
   return (
     <div
-      className="fixed inset-0 z-[120] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm"
+      className="liquid-scrim fixed inset-0 z-[120] flex items-center justify-center p-4"
       role="presentation"
       onClick={() => close(isAlert)}
     >
@@ -56,13 +56,13 @@ export default function ConfirmDialog() {
         role="alertdialog"
         aria-modal="true"
         aria-label={current.title}
-        className="relative w-full max-w-md rounded-2xl border border-glass-border bg-deep-black-light p-5 shadow-2xl"
+        className="liquid-dialog relative w-full max-w-md rounded-2xl p-5"
         onClick={(e) => e.stopPropagation()}
       >
         <button
           type="button"
           onClick={() => close(isAlert)}
-          className="absolute right-4 top-4 rounded-full p-1.5 text-text-secondary transition-colors hover:bg-glass-bg hover:text-text-primary"
+          className="liquid-action absolute right-4 top-4 rounded-full p-1.5 text-text-secondary transition-colors hover:text-text-primary"
           aria-label={cancelLabel}
         >
           <X className="h-5 w-5" />
@@ -89,7 +89,7 @@ export default function ConfirmDialog() {
             <button
               type="button"
               onClick={() => close(false)}
-              className="rounded-lg border border-glass-border px-3 py-1.5 text-sm text-text-secondary transition-colors hover:bg-glass-bg"
+              className="liquid-action rounded-lg px-3 py-1.5 text-sm text-text-secondary transition-colors"
             >
               {cancelLabel}
             </button>
@@ -98,7 +98,7 @@ export default function ConfirmDialog() {
             ref={confirmButtonRef}
             type="button"
             onClick={() => close(true)}
-            className={`rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors ${confirmClasses}`}
+            className={`liquid-action rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors ${confirmClasses}`}
           >
             {confirmLabel}
           </button>

--- a/frontend/src/components/ui/GlassCard.tsx
+++ b/frontend/src/components/ui/GlassCard.tsx
@@ -30,7 +30,7 @@ export default function GlassCard({
       viewport={{ once: true, margin: "-50px" }}
       transition={{ duration: 0.6, ease: "easeOut" }}
       className={clsx(
-        "rounded-2xl border border-glass-border bg-glass-bg p-6 backdrop-blur-xl",
+        "liquid-card rounded-2xl p-6",
         "transition-all duration-300",
         glowMap[glowColor],
         className

--- a/frontend/src/components/ui/ImagePreviewOverlay.tsx
+++ b/frontend/src/components/ui/ImagePreviewOverlay.tsx
@@ -80,7 +80,7 @@ export default function ImagePreviewOverlay({
       role="dialog"
       aria-modal="true"
       aria-label={title}
-      className="fixed inset-0 z-[9999] flex flex-col bg-black/90 backdrop-blur-sm"
+      className="liquid-scrim fixed inset-0 z-[9999] flex flex-col"
       onClick={(event) => {
         if (event.target === event.currentTarget) onClose();
       }}
@@ -90,7 +90,7 @@ export default function ImagePreviewOverlay({
         pointerStartRef.current = null;
       }}
     >
-      <div className="flex min-h-14 items-center justify-between gap-3 border-b border-glass-border bg-deep-black/85 px-3 py-2 sm:px-5">
+      <div className="liquid-toolbar flex min-h-14 items-center justify-between gap-3 border-b px-3 py-2 sm:px-5">
         <div className="min-w-0">
           <span className="block truncate text-sm font-medium text-text-primary">{title}</span>
           {hasGallery && (
@@ -104,7 +104,7 @@ export default function ImagePreviewOverlay({
             href={src}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex h-9 w-9 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-white/10 hover:text-text-primary"
+            className="liquid-action inline-flex h-9 w-9 items-center justify-center rounded-lg text-text-secondary transition-colors hover:text-text-primary"
             aria-label="Open original image"
             onClick={(event) => event.stopPropagation()}
           >
@@ -116,7 +116,7 @@ export default function ImagePreviewOverlay({
               event.stopPropagation();
               onClose();
             }}
-            className="inline-flex h-9 w-9 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-white/10 hover:text-text-primary"
+            className="liquid-action inline-flex h-9 w-9 items-center justify-center rounded-lg text-text-secondary transition-colors hover:text-text-primary"
             aria-label="Close image preview"
           >
             <X className="h-5 w-5" />
@@ -132,7 +132,7 @@ export default function ImagePreviewOverlay({
               onPrevious?.();
             }}
             disabled={!canGoPrevious}
-            className="absolute left-3 top-1/2 z-10 hidden h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full border border-white/10 bg-black/55 text-text-primary shadow-lg transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-30 sm:inline-flex"
+            className="liquid-action absolute left-3 top-1/2 z-10 hidden h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full text-text-primary shadow-lg transition disabled:cursor-not-allowed disabled:opacity-30 sm:inline-flex"
             aria-label="Previous image"
             title="Previous image"
           >
@@ -153,7 +153,7 @@ export default function ImagePreviewOverlay({
               onNext?.();
             }}
             disabled={!canGoNext}
-            className="absolute right-3 top-1/2 z-10 hidden h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full border border-white/10 bg-black/55 text-text-primary shadow-lg transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-30 sm:inline-flex"
+            className="liquid-action absolute right-3 top-1/2 z-10 hidden h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full text-text-primary shadow-lg transition disabled:cursor-not-allowed disabled:opacity-30 sm:inline-flex"
             aria-label="Next image"
             title="Next image"
           >

--- a/frontend/src/components/ui/MarkdownContent.tsx
+++ b/frontend/src/components/ui/MarkdownContent.tsx
@@ -264,7 +264,7 @@ function MarkdownCodeBlock({ children }: { children: ReactNode }) {
       <button
         type="button"
         onClick={() => void handleCopy()}
-        className="absolute right-2 top-2 z-10 inline-flex h-7 items-center gap-1.5 rounded-md border border-glass-border bg-black/70 px-2 text-[11px] font-medium text-text-secondary shadow-lg shadow-black/20 transition hover:border-neon-cyan/40 hover:text-text-primary focus:outline-none focus:ring-1 focus:ring-neon-cyan/50"
+        className="liquid-action absolute right-2 top-2 z-10 inline-flex h-7 items-center gap-1.5 rounded-md border border-glass-border px-2 text-[11px] font-medium text-text-secondary shadow-lg shadow-black/20 transition hover:border-neon-cyan/40 hover:text-text-primary focus:outline-none focus:ring-1 focus:ring-neon-cyan/50"
         title={copied ? "Copied" : "Copy code"}
         aria-label={copied ? "Copied code" : "Copy code"}
       >
@@ -275,7 +275,7 @@ function MarkdownCodeBlock({ children }: { children: ReactNode }) {
         )}
         {copied ? "Copied" : "Copy"}
       </button>
-      <pre className="max-w-full overflow-x-auto rounded-lg border border-glass-border bg-black/40 p-3 pb-4 pr-20 font-mono text-xs text-neon-cyan/90 [scrollbar-width:thin] [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&>code]:!block [&>code]:!rounded-none [&>code]:!border-0 [&>code]:!bg-transparent [&>code]:!p-0 [&>code]:!text-xs [&>code]:!text-neon-cyan/90">
+      <pre className="liquid-tool-surface max-w-full overflow-x-auto rounded-lg border border-glass-border p-3 pb-4 pr-20 font-mono text-xs text-neon-cyan/90 [scrollbar-width:thin] [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&>code]:!block [&>code]:!rounded-none [&>code]:!border-0 [&>code]:!bg-transparent [&>code]:!p-0 [&>code]:!text-xs [&>code]:!text-neon-cyan/90">
         {children}
       </pre>
     </div>
@@ -284,7 +284,7 @@ function MarkdownCodeBlock({ children }: { children: ReactNode }) {
 
 function MarkdownImageFallback({ src, alt }: { src: string; alt?: string }) {
   return (
-    <code className="rounded border border-glass-border bg-black/30 px-1.5 py-0.5 font-mono text-xs text-neon-cyan/90">
+    <code className="liquid-tool-surface rounded border border-glass-border px-1.5 py-0.5 font-mono text-xs text-neon-cyan/90">
       {alt ? `${alt} (${src})` : src}
     </code>
   );
@@ -320,7 +320,7 @@ function MarkdownImage({ src, alt }: { src?: string; alt?: string }) {
           event.stopPropagation();
           setPreviewOpen(true);
         }}
-        className="group my-2 inline-flex max-w-full items-center justify-center overflow-hidden rounded-lg border border-glass-border bg-black/20 text-left"
+        className="liquid-tool-surface group my-2 inline-flex max-w-full items-center justify-center overflow-hidden rounded-lg border border-glass-border text-left"
         aria-label={`Preview ${title}`}
       >
         <img
@@ -398,7 +398,7 @@ function createComponents(renderMention?: MarkdownContentProps["renderMention"])
         );
       }
       return (
-        <code className="rounded border border-glass-border bg-black/30 px-1.5 py-0.5 font-mono text-xs text-neon-cyan/90">
+          <code className="liquid-tool-surface rounded border border-glass-border px-1.5 py-0.5 font-mono text-xs text-neon-cyan/90">
           {children}
         </code>
       );

--- a/frontend/src/components/ui/SystemMessageNotice.tsx
+++ b/frontend/src/components/ui/SystemMessageNotice.tsx
@@ -11,7 +11,7 @@ interface SystemMessageNoticeProps {
 export default function SystemMessageNotice({ text, timestamp, children }: SystemMessageNoticeProps) {
   return (
     <div className="my-3 flex justify-center px-3">
-      <div className="max-w-[82%] rounded-full border border-glass-border/60 bg-glass-bg/70 px-3 py-1.5 text-center text-xs leading-relaxed text-text-secondary shadow-sm">
+      <div className="liquid-card max-w-[82%] rounded-full px-3 py-1.5 text-center text-xs leading-relaxed text-text-secondary">
         <span className="break-words">{children ?? text ?? "System update"}</span>
         {timestamp && (
           <span className="ml-2 whitespace-nowrap font-mono text-[10px] text-text-secondary/45">

--- a/frontend/src/components/ui/Tooltip.tsx
+++ b/frontend/src/components/ui/Tooltip.tsx
@@ -15,7 +15,7 @@ const TooltipContent = forwardRef<
     <TooltipPrimitive.Content
       ref={ref}
       sideOffset={sideOffset}
-      className={`z-50 overflow-hidden rounded-md border border-glass-border bg-deep-black px-2.5 py-1 text-[11px] text-text-primary shadow-lg animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ${className}`}
+      className={`liquid-menu z-50 overflow-hidden rounded-md px-2.5 py-1 text-[11px] text-text-primary animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ${className}`}
       {...props}
     />
   </TooltipPrimitive.Portal>

--- a/frontend/src/components/ui/TypewriterCode.tsx
+++ b/frontend/src/components/ui/TypewriterCode.tsx
@@ -56,7 +56,7 @@ export default function TypewriterCode({
       whileInView={{ opacity: 1 }}
       viewport={{ once: true }}
       transition={{ duration: 0.5 }}
-      className="overflow-hidden rounded-xl border border-glass-border bg-deep-black-light"
+      className="liquid-tool-surface overflow-hidden rounded-xl border border-glass-border"
     >
       <div className="flex items-center gap-2 border-b border-glass-border px-4 py-2">
         <div className="h-3 w-3 rounded-full bg-red-500/60" />

--- a/frontend/src/store/useAppStore.test.ts
+++ b/frontend/src/store/useAppStore.test.ts
@@ -1,0 +1,18 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAppStore } from "@/store/useAppStore";
+
+describe("useAppStore theme preference", () => {
+  beforeEach(() => {
+    useAppStore.setState({ language: "en", theme: "dark" });
+  });
+
+  it("switches between the persisted dark and light theme values", () => {
+    useAppStore.getState().setTheme("light");
+
+    expect(useAppStore.getState().theme).toBe("light");
+
+    useAppStore.getState().setTheme("dark");
+
+    expect(useAppStore.getState().theme).toBe("dark");
+  });
+});

--- a/frontend/src/store/useAppStore.ts
+++ b/frontend/src/store/useAppStore.ts
@@ -1,20 +1,26 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 
+export type AppTheme = 'dark' | 'light'
+
 interface AppState {
   language: 'en' | 'zh'
+  theme: AppTheme
   setLanguage: (language: 'en' | 'zh') => void
+  setTheme: (theme: AppTheme) => void
 }
 
 export const useAppStore = create<AppState>()(
   persist(
     (set) => ({
       language: 'en',
+      theme: 'dark',
       setLanguage: (language) => set({ language }),
+      setTheme: (theme) => set({ theme }),
     }),
     {
       name: 'app-storage',
-      partialize: (state) => ({ language: state.language }),
+      partialize: (state) => ({ language: state.language, theme: state.theme }),
     }
   )
 )


### PR DESCRIPTION
## Summary
- add a persistent light/dark theme toggle for the dashboard
- introduce shared Liquid Glass surfaces, controls, overlays, and fallbacks
- migrate the chat, panels, lists, dialogs, drawers, wallet, settings, and loading states

## Validation
- npm run test -- --run
- npm run build
- git diff --check