### PR TITLE
fix(frontend): refine light dashboard contrast

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -18,7 +18,7 @@
   --font-mono: var(--font-mono);
 }
 
-:root {
+html[data-theme="dark"] {
   color-scheme: dark;
   --liquid-canvas:
     radial-gradient(circle at 12% 8%, rgba(0, 240, 255, 0.11), transparent 30%),
@@ -46,8 +46,8 @@ html[data-theme="light"] {
   --color-neon-cyan-dim: #007b9330;
   --color-neon-purple-dim: #6d4dd830;
   --color-neon-green-dim: #087a5930;
-  --color-glass-bg: rgba(255, 255, 255, 0.58);
-  --color-glass-border: rgba(113, 137, 166, 0.34);
+  --color-glass-bg: rgba(255, 255, 255, 0.68);
+  --color-glass-border: rgba(101, 128, 158, 0.42);
   --color-text-primary: #17283d;
   --color-text-secondary: #52657c;
 
@@ -74,12 +74,12 @@ html[data-theme="light"] {
     radial-gradient(circle at 88% 5%, rgba(109, 77, 216, 0.12), transparent 28%),
     radial-gradient(circle at 50% 102%, rgba(64, 151, 200, 0.11), transparent 37%),
     linear-gradient(145deg, #f8fbff 0%, #edf3f9 48%, #e8eff7 100%);
-  --liquid-surface: linear-gradient(135deg, rgba(255, 255, 255, 0.84), rgba(247, 250, 255, 0.64));
-  --liquid-surface-strong: linear-gradient(135deg, rgba(255, 255, 255, 0.94), rgba(246, 250, 255, 0.84));
-  --liquid-border: rgba(255, 255, 255, 0.82);
-  --liquid-highlight: rgba(255, 255, 255, 0.82);
-  --liquid-control: rgba(255, 255, 255, 0.58);
-  --liquid-shadow: 0 18px 46px rgba(44, 69, 99, 0.13), inset 0 1px 0 rgba(255, 255, 255, 0.88);
+  --liquid-surface: linear-gradient(135deg, rgba(255, 255, 255, 0.94), rgba(238, 246, 255, 0.78));
+  --liquid-surface-strong: linear-gradient(135deg, rgba(255, 255, 255, 0.98), rgba(237, 246, 255, 0.90));
+  --liquid-border: rgba(92, 121, 153, 0.38);
+  --liquid-highlight: rgba(255, 255, 255, 0.94);
+  --liquid-control: rgba(255, 255, 255, 0.72);
+  --liquid-shadow: 0 20px 44px rgba(42, 69, 101, 0.17), 0 3px 10px rgba(42, 69, 101, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.94);
 }
 
 html {
@@ -146,6 +146,19 @@ body {
   background: var(--liquid-surface-strong);
 }
 
+/* The shared logo asset is white. Give its dashboard tile a solid brand
+ * surface in light mode so the mark retains reliable contrast. */
+html[data-theme="light"] .dashboard-brand-link {
+  border-color: rgba(0, 123, 147, 0.68);
+  background: linear-gradient(145deg, #0c7089, #005f75);
+  box-shadow: 0 10px 22px rgba(0, 123, 147, 0.22), inset 0 1px 0 rgba(255, 255, 255, 0.32);
+}
+
+html[data-theme="light"] .dashboard-brand-link:hover {
+  border-color: var(--color-neon-cyan);
+  background: linear-gradient(145deg, #0d7d98, #006a82);
+}
+
 .liquid-panel,
 .liquid-toolbar,
 .liquid-menu,
@@ -190,6 +203,37 @@ body {
   box-shadow: inset 0 1px 0 var(--liquid-highlight);
 }
 
+.liquid-list-row.liquid-room-row {
+  border-color: transparent;
+  background: linear-gradient(135deg, var(--liquid-control), transparent 92%);
+  box-shadow: inset 0 1px 0 transparent;
+}
+
+.liquid-list-row.liquid-room-row:hover,
+.liquid-list-row.liquid-room-row:focus-visible {
+  border-color: color-mix(in srgb, var(--color-neon-cyan) 20%, var(--liquid-border));
+  background: linear-gradient(135deg, var(--liquid-surface), var(--liquid-control));
+  box-shadow: 0 12px 26px rgba(44, 69, 99, 0.10), inset 0 1px 0 var(--liquid-highlight);
+  transform: translateY(-1px);
+}
+
+.liquid-list-row.liquid-room-row-selected {
+  border-color: color-mix(in srgb, var(--color-neon-cyan) 38%, var(--liquid-border));
+  background:
+    radial-gradient(circle at 8% 50%, color-mix(in srgb, var(--color-neon-cyan) 15%, transparent), transparent 42%),
+    var(--liquid-surface);
+  box-shadow: 0 12px 28px rgba(0, 123, 147, 0.12), inset 0 1px 0 var(--liquid-highlight);
+}
+
+html[data-theme="dark"] .liquid-list-row.liquid-room-row-selected {
+  box-shadow: 0 12px 28px rgba(0, 240, 255, 0.10), inset 0 1px 0 var(--liquid-highlight);
+}
+
+.liquid-list-row.liquid-room-row-attention {
+  border-color: color-mix(in srgb, var(--color-neon-cyan) 28%, var(--liquid-border));
+  background: linear-gradient(135deg, color-mix(in srgb, var(--color-neon-cyan) 9%, var(--liquid-control)), var(--liquid-control));
+}
+
 .liquid-action {
   border: 1px solid var(--liquid-border);
   background: var(--liquid-control);
@@ -209,19 +253,21 @@ body {
 }
 
 .liquid-scrim {
-  background: rgba(3, 10, 20, 0.58);
-}
-
-html[data-theme="light"] .liquid-scrim {
   background: rgba(35, 55, 79, 0.24);
 }
 
+html[data-theme="dark"] .liquid-scrim {
+  background: rgba(3, 10, 20, 0.58);
+}
+
 .liquid-toolbar {
-  box-shadow: 0 10px 26px rgba(15, 24, 40, 0.05), inset 0 1px 0 var(--liquid-highlight);
+  box-shadow: 0 12px 28px rgba(42, 69, 101, 0.10), inset 0 1px 0 var(--liquid-highlight);
 }
 
 .liquid-message {
-  box-shadow: inset 0 1px 0 var(--liquid-highlight), 0 8px 20px rgba(15, 24, 40, 0.05);
+  border-style: solid;
+  border-width: 1px;
+  box-shadow: inset 0 1px 0 var(--liquid-highlight), 0 12px 28px rgba(42, 69, 101, 0.12), 0 2px 8px rgba(42, 69, 101, 0.06);
 }
 
 .liquid-message-peer {
@@ -229,24 +275,42 @@ html[data-theme="light"] .liquid-scrim {
   border-color: var(--liquid-border);
 }
 
-.liquid-message-own {
-  background: linear-gradient(135deg, rgba(0, 155, 185, 0.28), rgba(0, 112, 145, 0.14));
-  border-color: rgba(0, 194, 229, 0.34);
+.liquid-message-action {
+  border: 1px solid var(--liquid-border);
+  background: var(--liquid-control);
+  box-shadow: 0 6px 16px rgba(42, 69, 101, 0.12), inset 0 1px 0 var(--liquid-highlight);
 }
 
-html[data-theme="light"] .liquid-message-own {
+.liquid-message-action:hover,
+.liquid-message-action:focus-visible {
+  border-color: color-mix(in srgb, var(--color-neon-cyan) 34%, var(--liquid-border));
+  background: var(--liquid-surface-strong);
+  box-shadow: 0 9px 20px rgba(42, 69, 101, 0.16), inset 0 1px 0 var(--liquid-highlight);
+}
+
+html[data-theme="dark"] .liquid-message,
+html[data-theme="dark"] .liquid-message-action {
+  box-shadow: inset 0 1px 0 var(--liquid-highlight), 0 8px 20px rgba(0, 0, 0, 0.18);
+}
+
+.liquid-message-own {
   background: linear-gradient(135deg, rgba(205, 243, 248, 0.92), rgba(221, 239, 255, 0.82));
   border-color: rgba(0, 123, 147, 0.23);
 }
 
-.liquid-message-error {
-  background: linear-gradient(135deg, rgba(127, 29, 29, 0.22), rgba(69, 10, 10, 0.12));
-  border-color: rgba(248, 113, 113, 0.28);
+html[data-theme="dark"] .liquid-message-own {
+  background: linear-gradient(135deg, rgba(0, 155, 185, 0.28), rgba(0, 112, 145, 0.14));
+  border-color: rgba(0, 194, 229, 0.34);
 }
 
-html[data-theme="light"] .liquid-message-error {
+.liquid-message-error {
   background: linear-gradient(135deg, rgba(255, 239, 239, 0.94), rgba(255, 248, 248, 0.80));
   border-color: rgba(220, 38, 38, 0.20);
+}
+
+html[data-theme="dark"] .liquid-message-error {
+  background: linear-gradient(135deg, rgba(127, 29, 29, 0.22), rgba(69, 10, 10, 0.12));
+  border-color: rgba(248, 113, 113, 0.28);
 }
 
 .liquid-input {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -33,7 +33,7 @@ export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   viewportFit: "cover",
-  themeColor: "#08111f",
+  themeColor: "#eef3f9",
 };
 
 export default function RootLayout({
@@ -42,16 +42,17 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning className={`${inter.variable} ${jetbrainsMono.variable}`}>
+    <html lang="en" data-theme="light" suppressHydrationWarning className={`${inter.variable} ${jetbrainsMono.variable}`}>
       <head>
         <Script id="botcord-theme" strategy="beforeInteractive">
           {`try {
             const stored = JSON.parse(localStorage.getItem("app-storage") || "{}");
             const theme = stored && stored.state && stored.state.theme;
-            if (theme === "light" || theme === "dark") {
-              document.documentElement.dataset.theme = theme;
-              document.documentElement.style.colorScheme = theme;
-            }
+            const resolvedTheme = theme === "dark" || theme === "light" ? theme : "light";
+            document.documentElement.dataset.theme = resolvedTheme;
+            document.documentElement.style.colorScheme = resolvedTheme;
+            const themeColor = document.querySelector('meta[name="theme-color"]');
+            if (themeColor) themeColor.content = resolvedTheme === "light" ? "#eef3f9" : "#08111f";
           } catch {}`}
         </Script>
       </head>

--- a/frontend/src/components/dashboard/MessageBubble.tsx
+++ b/frontend/src/components/dashboard/MessageBubble.tsx
@@ -941,7 +941,7 @@ function MessageBubble({
           updateActionMenuPosition();
           setMenuOpen(true);
         }}
-        className={`flex h-6 w-6 items-center justify-center rounded-lg text-text-secondary hover:bg-glass-bg hover:text-text-primary transition-colors ${hovered || menuOpen ? "opacity-100" : "opacity-0 pointer-events-none"}`}
+        className={`liquid-message-action flex h-8 w-8 items-center justify-center rounded-xl text-text-secondary transition-colors ${hovered || menuOpen ? "opacity-100" : "opacity-0 pointer-events-none"}`}
         aria-label="More actions"
         aria-expanded={menuOpen}
       >

--- a/frontend/src/components/dashboard/RoomList.tsx
+++ b/frontend/src/components/dashboard/RoomList.tsx
@@ -371,7 +371,7 @@ export default function RoomList({
   }
 
   return (
-    <div ref={roomListRef} className="py-1">
+    <div ref={roomListRef} className="py-2">
       {showUserChatEntry && (
         <div
           ref={userChatEntryRef}
@@ -382,12 +382,12 @@ export default function RoomList({
           title={t.userChatTooltip}
           onClick={handleSelectUserChat}
           onKeyDown={handleUserChatKeyDown}
-          className={`liquid-list-row relative w-full border-l-2 px-4 py-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-cyan/60 ${
+          className={`liquid-list-row liquid-room-row relative mx-2 my-1 rounded-2xl px-3 py-3 text-left transition-[transform,background-color,border-color,box-shadow] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-cyan/60 ${
             messagesPane === "user-chat"
-              ? "!border-neon-cyan !bg-neon-cyan/10"
+              ? "liquid-room-row-selected"
               : isOwnerChatEmpty
-                ? "!border-neon-cyan/50 !bg-neon-cyan/[0.06]"
-                : "border-transparent hover:bg-glass-bg"
+                ? "liquid-room-row-attention"
+                : ""
           }`}
         >
           <div className="flex items-center gap-3">
@@ -483,10 +483,10 @@ export default function RoomList({
             onMouseEnter={() => prefetchRoom(room)}
             onFocus={() => prefetchRoom(room)}
             onKeyDown={(event) => handleRoomKeyDown(event, room)}
-            className={`liquid-list-row w-full border-l-2 px-4 py-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-cyan/60 ${
+            className={`liquid-list-row liquid-room-row mx-2 my-1 rounded-2xl px-3 py-3 text-left transition-[transform,background-color,border-color,box-shadow] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neon-cyan/60 ${
               isSelected
-                ? "!border-neon-cyan !bg-neon-cyan/10"
-                : "border-transparent hover:bg-glass-bg"
+                ? "liquid-room-row-selected"
+                : ""
             }`}
           >
             <div className="flex items-center gap-3">

--- a/frontend/src/components/dashboard/ThemeToggle.tsx
+++ b/frontend/src/components/dashboard/ThemeToggle.tsx
@@ -6,7 +6,7 @@
  * [POS]: dashboard 侧栏的全局外观控制项
  */
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Moon, Sun } from "lucide-react";
 import { useLanguage } from "@/lib/i18n";
 import { useAppStore } from "@/store/useAppStore";
@@ -22,14 +22,22 @@ export default function ThemeToggle() {
   const locale = useLanguage();
   const theme = useAppStore((state) => state.theme);
   const setTheme = useAppStore((state) => state.setTheme);
+  const [hydrated, setHydrated] = useState(() => useAppStore.persist.hasHydrated());
   const isLight = theme === "light";
   const label = isLight
     ? (locale === "zh" ? "切换到深色模式" : "Switch to dark mode")
     : (locale === "zh" ? "切换到浅色模式" : "Switch to light mode");
 
   useEffect(() => {
+    const unsubscribe = useAppStore.persist.onFinishHydration(() => setHydrated(true));
+    setHydrated(useAppStore.persist.hasHydrated());
+    return unsubscribe;
+  }, []);
+
+  useEffect(() => {
+    if (!hydrated) return;
     applyTheme(theme);
-  }, [theme]);
+  }, [hydrated, theme]);
 
   return (
     <button

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -580,7 +580,7 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
         <button
           type="button"
           onClick={() => setActionMenuOpenId((current) => current === msg.clientId ? null : msg.clientId)}
-          className={`flex h-6 w-6 items-center justify-center rounded-lg text-text-secondary hover:bg-glass-bg hover:text-text-primary transition-colors ${visible ? "opacity-100" : "opacity-0 pointer-events-none"}`}
+          className={`liquid-message-action flex h-8 w-8 items-center justify-center rounded-xl text-text-secondary transition-colors ${visible ? "opacity-100" : "opacity-0 pointer-events-none"}`}
           aria-label="More actions"
         >
           <MoreHorizontal className="h-3.5 w-3.5" />

--- a/frontend/src/components/dashboard/sidebar/index.tsx
+++ b/frontend/src/components/dashboard/sidebar/index.tsx
@@ -398,7 +398,7 @@ function Sidebar({
       <div className="liquid-rail flex h-full w-16 min-w-[64px] flex-col items-center border-r border-glass-border bg-deep-black py-3 max-md:h-[calc(4rem+env(safe-area-inset-bottom))] max-md:w-full max-md:min-w-0 max-md:shrink-0 max-md:flex-row max-md:border-r-0 max-md:border-t max-md:px-2 max-md:pb-[env(safe-area-inset-bottom)] max-md:pt-2">
         <Link
           href="/"
-          className="mb-3 flex h-11 w-11 items-center justify-center rounded-xl border border-glass-border bg-deep-black-light transition-colors hover:border-neon-cyan/50 hover:bg-glass-bg max-md:mb-0 max-md:mr-2 max-md:hidden"
+          className="dashboard-brand-link mb-3 flex h-11 w-11 items-center justify-center rounded-xl border border-glass-border bg-deep-black-light transition-colors hover:border-neon-cyan/50 hover:bg-glass-bg max-md:mb-0 max-md:mr-2 max-md:hidden"
           title={tNav.home}
         >
           <img src="/logo.svg" alt="BotCord" className="h-6 w-6" />

--- a/frontend/src/store/useAppStore.test.ts
+++ b/frontend/src/store/useAppStore.test.ts
@@ -3,7 +3,11 @@ import { useAppStore } from "@/store/useAppStore";
 
 describe("useAppStore theme preference", () => {
   beforeEach(() => {
-    useAppStore.setState({ language: "en", theme: "dark" });
+    useAppStore.setState({ language: "en", theme: "light" });
+  });
+
+  it("defaults to the light theme", () => {
+    expect(useAppStore.getInitialState().theme).toBe("light");
   });
 
   it("switches between the persisted dark and light theme values", () => {

--- a/frontend/src/store/useAppStore.ts
+++ b/frontend/src/store/useAppStore.ts
@@ -14,7 +14,7 @@ export const useAppStore = create<AppState>()(
   persist(
     (set) => ({
       language: 'en',
-      theme: 'dark',
+      theme: 'light',
       setLanguage: (language) => set({ language }),
       setTheme: (theme) => set({ theme }),
     }),


### PR DESCRIPTION
## Summary
- make light mode the default theme while preserving an explicit saved preference
- reshape room rows into distinct liquid-glass cards
- strengthen light-mode surface, message, and action-button contrast

## Validation
- npm run test -- --run
- npm run build