### PR TITLE
fix: improve chat loading transitions

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -456,7 +456,44 @@ html[data-theme="dark"] .liquid-message-error {
 
 .dashboard-skeleton-block {
   background-color: rgba(148, 163, 184, 0.12);
-  animation: dashboard-skeleton-breathe 1.8s ease-in-out infinite;
+  background-image: linear-gradient(
+    100deg,
+    rgba(148, 163, 184, 0.08) 22%,
+    rgba(226, 232, 240, 0.2) 46%,
+    rgba(148, 163, 184, 0.08) 70%
+  );
+  background-position: 120% 0;
+  background-size: 230% 100%;
+  animation: dashboard-skeleton-shimmer 1.65s ease-in-out infinite;
+  will-change: background-position, opacity;
+}
+
+.dashboard-message-loading-bar {
+  height: 2px;
+  overflow: hidden;
+  background: rgba(34, 211, 238, 0.08);
+}
+
+.dashboard-message-loading-bar::after {
+  content: "";
+  display: block;
+  height: 100%;
+  width: 38%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, transparent, rgba(34, 211, 238, 0.9), transparent);
+  animation: dashboard-message-loading-bar 1.05s ease-in-out infinite;
+}
+
+.dashboard-history-loader {
+  display: inline-block;
+  background: linear-gradient(90deg, rgba(34, 211, 238, 0.12), rgba(34, 211, 238, 0.7), rgba(34, 211, 238, 0.12));
+  background-position: 120% 0;
+  background-size: 220% 100%;
+  animation: dashboard-skeleton-shimmer 1.1s ease-in-out infinite;
+}
+
+.dashboard-message-feed-enter {
+  animation: dashboard-message-feed-enter 180ms ease-out both;
 }
 
 .botcord-loader {
@@ -579,16 +616,33 @@ html[data-theme="dark"] .liquid-message-error {
   }
 }
 
-@keyframes dashboard-skeleton-breathe {
+@keyframes dashboard-skeleton-shimmer {
   0%,
   100% {
-    opacity: 0.55;
-    background-color: rgba(148, 163, 184, 0.1);
+    opacity: 0.62;
+    background-position: 120% 0;
   }
 
   50% {
-    opacity: 0.9;
-    background-color: rgba(148, 163, 184, 0.18);
+    opacity: 0.98;
+    background-position: -80% 0;
+  }
+}
+
+@keyframes dashboard-message-loading-bar {
+  from { transform: translateX(-130%); }
+  to { transform: translateX(310%); }
+}
+
+@keyframes dashboard-message-feed-enter {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }
 

--- a/frontend/src/components/dashboard/ChatPane.tsx
+++ b/frontend/src/components/dashboard/ChatPane.tsx
@@ -49,6 +49,7 @@ import { initialsFromName } from "./roomVisualTheme";
 import { dmPeerId } from "./dmRoom";
 import ContactsDetailPane from "./ContactsDetailPane";
 import { DashboardMainSkeleton } from "./DashboardTabSkeleton";
+import { MessageComposerSkeleton } from "./DashboardMessagePaneSkeleton";
 
 const EXPLORE_GRID_CLASS = "grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5";
 type ChatPaneTab = "messages" | "contacts" | "explore";
@@ -833,7 +834,7 @@ export default function ChatPane({ onHumanOpen, sidebarTabOverride }: ChatPanePr
                   loginHref={loginHref}
                 />
               ) : (
-                <MessageList onPreviewAttachment={handlePreviewAttachment} />
+                <MessageList key={openedRoomId} onPreviewAttachment={handlePreviewAttachment} />
               )
             ) : (
               <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-text-secondary">
@@ -841,7 +842,11 @@ export default function ChatPane({ onHumanOpen, sidebarTabOverride }: ChatPanePr
               </div>
             )}
           </div>
-          {openedRoomId && !isPaidAndNotJoined && (
+          {openedRoomId && !openedRoom ? (
+            <div className="border-t border-glass-border px-4 py-2" aria-busy="true">
+              <MessageComposerSkeleton />
+            </div>
+          ) : openedRoomId && !isPaidAndNotJoined && (
             <>
               {originAgent ? (
                 <div className="border-t border-glass-border bg-glass-bg/30 px-4 py-2.5">

--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -49,6 +49,7 @@ import { animateIfMotion, cleanupAnime, prefersReducedMotion } from "@/lib/anime
 const USER_CHAT_SUBTAB = "__user-chat__";
 type DashboardSidebarTab = "home" | "messages" | "contacts" | "explore" | "wallet" | "activity" | "bots";
 const MESSAGES_DIRECTORY_SYNC_INTERVAL_MS = 30_000;
+const PRIMARY_NAVIGATION_MIN_VISIBLE_MS = 180;
 
 type BotcordDebugRealtimeSnapshot = {
   supabaseUrl: string | undefined;
@@ -147,22 +148,16 @@ export default function DashboardApp() {
   const routeSidebarTab = useMemo(() => getSidebarTabFromPathParts(pathnameParts), [pathnameParts]);
   const userChatAgentIdFromQuery = searchParams.get("agent_id");
   const shouldShowBootstrapSkeleton = !sessionStore.authResolved || sessionStore.authBootstrapping;
-  const primaryNavigationPending = Boolean(
-    uiStore.pendingPrimaryNavigation && pathname !== uiStore.pendingPrimaryNavigation.path,
-  );
+  const primaryNavigationPending = Boolean(uiStore.pendingPrimaryNavigation);
   const visibleSidebarTab = primaryNavigationPending
     ? uiStore.pendingPrimaryNavigation?.tab ?? uiStore.sidebarTab
     : routeSidebarTab;
-  // Sub-view switches inside explore/contacts animate themselves (MotionGrid
-  // entrance in ChatPane); replaying the whole-pane fade on top reads as the
-  // page rendering twice, so exploreView/contactsView stay out of this key.
+  // Room changes have their own local loading states in MessageList. Keeping
+  // room/pane ids out of this key prevents the header, composer, and adjacent
+  // panes from fading out together every time a conversation is selected.
   const mainContentAnimationKey = [
     primaryNavigationPending ? "pending" : "ready",
     visibleSidebarTab,
-    uiStore.messagesPane,
-    uiStore.messagesShowRequests ? "requests" : "",
-    uiStore.openedRoomId ?? "",
-    uiStore.selectedContactKey ?? "",
   ].join(":");
   // Human-first: never force-block on "no agent". Authed users always proceed
   // into /chats as their Human identity; creating an Agent is a later,
@@ -311,7 +306,14 @@ export default function DashboardApp() {
     const pendingPrimaryNavigation = uiStore.pendingPrimaryNavigation;
     if (pendingPrimaryNavigation) {
       if (pathname === pendingPrimaryNavigation.path) {
-        uiStore.clearPrimaryNavigation();
+        const remaining = Math.max(
+          0,
+          PRIMARY_NAVIGATION_MIN_VISIBLE_MS - (Date.now() - pendingPrimaryNavigation.startedAt),
+        );
+        const timer = window.setTimeout(() => {
+          uiStore.clearPrimaryNavigation(pendingPrimaryNavigation.id);
+        }, remaining);
+        return () => window.clearTimeout(timer);
       } else {
         return;
       }

--- a/frontend/src/components/dashboard/DashboardMessagePaneSkeleton.tsx
+++ b/frontend/src/components/dashboard/DashboardMessagePaneSkeleton.tsx
@@ -13,6 +13,111 @@ function SkeletonBlock({ className }: { className: string }) {
   return <div className={`dashboard-skeleton-block rounded ${className}`} />;
 }
 
+type MessageFeedSkeletonProps = {
+  className?: string;
+  contentClassName?: string;
+  rows?: number;
+  label?: string;
+  bubbleMaxWidthClassName?: string;
+  bubbleRoundedClassName?: string;
+};
+
+const messageWidths = ["w-[72%]", "w-[56%]", "w-[82%]", "w-[64%]", "w-[48%]", "w-[76%]"];
+
+/**
+ * The message body skeleton intentionally mirrors `MessageBubble`: sender
+ * avatar/action slot, sender metadata, variable copy width, and a timestamp.
+ * Keeping it separate lets the ordinary room pane and the owner-chat shell
+ * share the same geometry instead of falling back to generic rectangular rows.
+ */
+export function MessageFeedSkeleton({
+  className = "",
+  contentClassName = "px-4 py-3",
+  rows = 6,
+  label = "Loading messages",
+  bubbleMaxWidthClassName = "max-w-[70%]",
+  bubbleRoundedClassName = "rounded-2xl",
+}: MessageFeedSkeletonProps) {
+  return (
+    <div
+      className={`relative min-h-0 flex-1 overflow-hidden ${className}`}
+      role="status"
+      aria-label={label}
+      aria-busy="true"
+    >
+      <span className="sr-only">{label}</span>
+      <div aria-hidden="true" className={`h-full space-y-3 overflow-hidden ${contentClassName}`}>
+        {Array.from({ length: rows }).map((_, idx) => {
+          const isOwn = idx % 3 === 1;
+          const bodyWidth = messageWidths[idx % messageWidths.length];
+          return (
+            <div
+              key={idx}
+              className={`flex items-start gap-2 ${isOwn ? "justify-end" : "justify-start"}`}
+              style={{ animationDelay: `${idx * 70}ms` }}
+            >
+              {isOwn ? <SkeletonBlock className="mt-1 h-8 w-8 shrink-0 rounded-xl bg-glass-border/35" /> : null}
+              {!isOwn ? <SkeletonBlock className="mt-0.5 h-8 w-8 shrink-0 rounded-full bg-glass-border/35" /> : null}
+              <div
+                className={`liquid-message ${bodyWidth} ${bubbleMaxWidthClassName} min-w-[11rem] ${bubbleRoundedClassName} border border-glass-border px-3 py-2 ${
+                  isOwn ? "bg-neon-cyan/5" : "bg-glass-bg/35"
+                }`}
+              >
+                <div className={`flex items-center gap-1.5 ${isOwn ? "justify-end" : ""}`}>
+                  <SkeletonBlock className="h-4 w-4 rounded-full bg-glass-border/45" />
+                  <SkeletonBlock className="h-3 w-16 bg-glass-border/45" />
+                  {!isOwn ? <SkeletonBlock className="h-3 w-10 bg-glass-border/30" /> : null}
+                </div>
+                <SkeletonBlock className="mt-2 h-3 w-full bg-glass-border/40" />
+                <SkeletonBlock className={`mt-1.5 h-3 ${idx % 2 === 0 ? "w-4/5" : "w-3/5"} bg-glass-border/35`} />
+                {idx % 4 === 0 ? <SkeletonBlock className="mt-1.5 h-3 w-2/5 bg-glass-border/30" /> : null}
+                <SkeletonBlock className={`mt-2 h-2.5 w-12 bg-glass-border/30 ${isOwn ? "ml-auto" : ""}`} />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function MessageHistoryLoading({ label }: { label: string }) {
+  return (
+    <div className="flex items-center justify-center gap-2 py-1.5" role="status" aria-live="polite">
+      <span className="dashboard-history-loader h-2 w-16 rounded-full" aria-hidden="true" />
+      <span className="text-[11px] text-text-secondary">{label}</span>
+    </div>
+  );
+}
+
+export function MessageRoomHeaderSkeleton({ label = "Loading room" }: { label?: string }) {
+  return (
+    <div className="liquid-toolbar flex min-h-16 items-center justify-between gap-2 border-b border-glass-border px-4 py-3 max-md:min-h-12 max-md:px-2 max-md:py-2" role="status" aria-label={label}>
+      <span className="sr-only">{label}</span>
+      <div aria-hidden="true" className="min-w-0 flex-1">
+        <SkeletonBlock className="h-4 w-36 max-w-[60%]" />
+        <SkeletonBlock className="mt-2 h-3 w-52 max-w-[78%] bg-glass-border/40" />
+      </div>
+      <div aria-hidden="true" className="flex shrink-0 items-center gap-1.5">
+        <SkeletonBlock className="h-8 w-8 rounded-lg bg-glass-border/40" />
+        <SkeletonBlock className="h-8 w-8 rounded-lg bg-glass-border/40" />
+      </div>
+    </div>
+  );
+}
+
+export function MessageComposerSkeleton({ label = "Loading message composer" }: { label?: string }) {
+  return (
+    <div className="flex items-end gap-2" role="status" aria-label={label}>
+      <span className="sr-only">{label}</span>
+      <div aria-hidden="true" className="liquid-composer flex h-12 flex-1 items-center rounded-2xl border border-glass-border px-3">
+        <SkeletonBlock className="h-3 w-2/5 bg-glass-border/40" />
+      </div>
+      <SkeletonBlock className="h-9 w-9 shrink-0 rounded-xl bg-neon-cyan/15" />
+    </div>
+  );
+}
+
 interface DashboardMessagePaneSkeletonProps {
   headerIcon?: ReactNode;
   headerPaddingClassName?: string;
@@ -31,7 +136,7 @@ export default function DashboardMessagePaneSkeleton({
   roundedClassName = "rounded-2xl",
 }: DashboardMessagePaneSkeletonProps) {
   return (
-    <div className="dashboard-main flex min-w-0 flex-1 flex-col">
+    <div className="dashboard-main flex min-w-0 flex-1 flex-col" aria-busy="true">
       <div className={`liquid-toolbar border-b border-glass-border ${headerPaddingClassName}`}>
         <div className="flex items-center gap-2">
           {headerIcon ? (
@@ -43,36 +148,21 @@ export default function DashboardMessagePaneSkeleton({
             <SkeletonBlock className="h-4 w-32" />
             <SkeletonBlock className="mt-2 h-3 w-48 bg-glass-border/40" />
           </div>
+          <div className="flex shrink-0 items-center gap-1.5" aria-hidden="true">
+            <SkeletonBlock className="h-8 w-8 rounded-lg bg-glass-border/35" />
+            <SkeletonBlock className="h-8 w-8 rounded-lg bg-glass-border/35" />
+          </div>
         </div>
       </div>
 
-      <div className={`flex-1 space-y-4 overflow-x-hidden overflow-y-auto ${bodyPaddingClassName}`}>
-        {Array.from({ length: 6 }).map((_, idx) => {
-          const isRight = idx % 2 === 1;
-          return (
-            <div key={idx} className={`flex ${isRight ? "justify-end" : "justify-start"}`}>
-              <div className={`liquid-card w-full ${messageMaxWidthClassName} ${roundedClassName} border border-glass-border p-4`}>
-                {!isRight && <SkeletonBlock className="h-3 w-20" />}
-                <SkeletonBlock className="mt-3 h-3 w-5/6 bg-glass-border/40" />
-                <SkeletonBlock className="mt-2 h-3 w-2/3 bg-glass-border/40" />
-                <SkeletonBlock className="mt-3 ml-auto h-2.5 w-12 bg-glass-border/30" />
-              </div>
-            </div>
-          );
-        })}
-      </div>
+      <MessageFeedSkeleton
+        contentClassName={bodyPaddingClassName}
+        bubbleMaxWidthClassName={messageMaxWidthClassName}
+        bubbleRoundedClassName={roundedClassName}
+      />
 
       <div className={`liquid-toolbar border-t border-glass-border ${composerPaddingClassName}`}>
-        <div className="flex items-end gap-2">
-          <div className={`liquid-composer flex-1 ${roundedClassName} border border-glass-border px-4 py-3`}>
-            <SkeletonBlock className="h-4 w-1/3" />
-          </div>
-          {headerIcon ? (
-            <div className="flex h-9 w-9 items-center justify-center rounded-lg border border-neon-cyan/20 bg-neon-cyan/10 text-neon-cyan/70">
-              {headerIcon}
-            </div>
-          ) : null}
-        </div>
+        <MessageComposerSkeleton />
       </div>
     </div>
   );

--- a/frontend/src/components/dashboard/MessageList.tsx
+++ b/frontend/src/components/dashboard/MessageList.tsx
@@ -7,17 +7,21 @@
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
 
-import { useEffect, useRef, useCallback, useMemo, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useCallback, useMemo, useState } from "react";
 import { useLanguage } from '@/lib/i18n';
+import { common } from "@/lib/i18n/translations/common";
 import { messageList } from '@/lib/i18n/translations/dashboard';
 import { useShallow } from "zustand/react/shallow";
 import { ArrowDown, Bot, Settings, UserPlus } from "lucide-react";
 import MessageBubble from "./MessageBubble";
 import { JUMP_TO_MESSAGE_EVENT, type JumpToMessageDetail } from "./messageNavigation";
 import {
+  captureVisibleMessageScrollAnchor,
   isNearScrollBottom,
+  restoreVisibleMessageScrollAnchor,
   scrollToLatestVisibleAfterScroll,
   shouldShowScrollToLatestForNewContent,
+  type VisibleMessageScrollAnchor,
 } from "./messageScroll";
 import type { Attachment, DashboardMessage, PublicRoomMember, TopicInfo } from "@/lib/types";
 import type { MentionTextCandidate } from "@/components/ui/MarkdownContent";
@@ -28,6 +32,7 @@ import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import { useDashboardUnreadStore } from "@/store/useDashboardUnreadStore";
 import { usePresenceStore } from "@/store/usePresenceStore";
 import { animateIfMotion, animatePop, cleanupAnime } from "@/lib/anime";
+import { MessageFeedSkeleton, MessageHistoryLoading } from "./DashboardMessagePaneSkeleton";
 
 const topicStatusColors: Record<string, { color: string; icon: string }> = {
   open:      { color: "text-neon-cyan bg-neon-cyan/10 border-neon-cyan/30",       icon: "●" },
@@ -302,17 +307,34 @@ export default function MessageList({
 } = {}) {
   const locale = useLanguage();
   const t = messageList[locale];
+  const tc = common[locale];
   const { openedRoomId, setOpenedTopicId } = useDashboardUIStore(useShallow((state) => ({
     openedRoomId: state.openedRoomId,
     setOpenedTopicId: state.setOpenedTopicId,
   })));
   const roomId = openedRoomId;
-  const { messages, hasMessagesCache, isRoomMessagesLoading, hasMore, loadRoomMessages, loadMoreMessages, overview, roomMembers, loadRoomMembers } = useDashboardChatStore(
+  const {
+    messages,
+    hasMessagesCache,
+    isRoomMessagesLoading,
+    roomMessageError,
+    hasMore,
+    isRoomMessagesLoadingMore,
+    roomMoreError,
+    loadRoomMessages,
+    loadMoreMessages,
+    overview,
+    roomMembers,
+    loadRoomMembers,
+  } = useDashboardChatStore(
     useShallow((state) => ({
       messages: roomId ? (state.messages[roomId] ?? EMPTY_MESSAGES) : EMPTY_MESSAGES,
       hasMessagesCache: roomId ? Object.prototype.hasOwnProperty.call(state.messages, roomId) : false,
       isRoomMessagesLoading: roomId ? (state.messagesLoading[roomId] ?? false) : false,
+      roomMessageError: roomId ? (state.messagesErrors[roomId] ?? null) : null,
       hasMore: roomId ? (state.messagesHasMore[roomId] ?? false) : false,
+      isRoomMessagesLoadingMore: roomId ? (state.messagesLoadingMore[roomId] ?? false) : false,
+      roomMoreError: roomId ? (state.messagesMoreErrors[roomId] ?? null) : null,
       loadRoomMessages: state.loadRoomMessages,
       loadMoreMessages: state.loadMoreMessages,
       overview: state.overview,
@@ -330,7 +352,13 @@ export default function MessageList({
   const bottomRef = useRef<HTMLDivElement>(null);
   const scrollToBottomButtonRef = useRef<HTMLButtonElement>(null);
   const prevLengthRef = useRef(0);
-  const isLoadingMore = useRef(false);
+  const isLoadingMoreRef = useRef(false);
+  const historyPrependAppliedRef = useRef(false);
+  const historyAnchorRef = useRef<{
+    roomId: string;
+    oldestMessageKey: string;
+    visibleMessage: VisibleMessageScrollAnchor | null;
+  } | null>(null);
   const messageAnimationRoomRef = useRef<string | null>(null);
   const messageAnimationPrimedRef = useRef(false);
   const animatedMessageKeysRef = useRef<Set<string>>(new Set());
@@ -461,9 +489,36 @@ export default function MessageList({
     messageAnimationPrimedRef.current = false;
     animatedMessageKeysRef.current = new Set();
     roomOpenedAtRef.current = performance.now();
+    historyAnchorRef.current = null;
+    historyPrependAppliedRef.current = false;
     showScrollToBottomButtonRef.current = false;
     setShowScrollToBottomButton(false);
   }, [roomId, setOpenedTopicId]);
+
+  // Restore only after the oldest message actually changes. A realtime append
+  // can arrive while history is fetching; anchoring to a visible message (not
+  // scrollHeight) prevents that bottom append from pushing the reader down.
+  useLayoutEffect(() => {
+    const anchor = historyAnchorRef.current;
+    const container = containerRef.current;
+    if (!anchor || !container) return;
+    if (anchor.roomId !== roomId) {
+      historyAnchorRef.current = null;
+      return;
+    }
+    const currentOldestMessageKey = messages[0] ? messageRenderKey(messages[0]) : null;
+    if (currentOldestMessageKey === anchor.oldestMessageKey) return;
+    if (anchor.visibleMessage) {
+      restoreVisibleMessageScrollAnchor(
+        container,
+        "[data-msg-key]",
+        "data-msg-key",
+        anchor.visibleMessage,
+      );
+    }
+    historyPrependAppliedRef.current = true;
+    historyAnchorRef.current = null;
+  }, [messages, roomId]);
 
   const topicsMap = useMemo(() => {
     const m = new Map<string, TopicInfo>();
@@ -539,7 +594,7 @@ export default function MessageList({
     // must not replay the entrance animation.
     const newlyVisible = messages.filter((msg) => messageSeenIds(msg).every((id) => !seenIds.has(id)));
     for (const msg of messages) for (const id of messageSeenIds(msg)) seenIds.add(id);
-    if (newlyVisible.length === 0 || isLoadingMore.current) return;
+    if (newlyVisible.length === 0 || isLoadingMoreRef.current) return;
     if (performance.now() - roomOpenedAtRef.current < MESSAGE_ENTRANCE_SETTLE_MS) return;
 
     const newlyVisibleKeys = newlyVisible.map(messageRenderKey);
@@ -568,7 +623,8 @@ export default function MessageList({
   // Uses wasNearBottomRef (snapshotted on scroll events, before DOM changes)
   // to decide whether to auto-scroll or let the user resume manually.
   useEffect(() => {
-    if (messages.length > prevLengthRef.current && !isLoadingMore.current) {
+    const loadingMoreAtChange = isLoadingMoreRef.current;
+    if (messages.length > prevLengthRef.current && !loadingMoreAtChange) {
       if (wasNearBottomRef.current) {
         scrollToBottomAfterLayout();
         showScrollToBottomButtonRef.current = false;
@@ -579,7 +635,7 @@ export default function MessageList({
       } else if (shouldShowScrollToLatestForNewContent({
         wasNearBottom: wasNearBottomRef.current,
         hadPreviousContent: prevLengthRef.current > 0,
-        isLoadingMore: isLoadingMore.current,
+        isLoadingMore: isLoadingMoreRef.current,
       })) {
         // User is reading history, so expose an explicit way to resume following.
         showScrollToBottomButtonRef.current = true;
@@ -587,7 +643,10 @@ export default function MessageList({
       }
     }
     prevLengthRef.current = messages.length;
-    isLoadingMore.current = false;
+    if (historyPrependAppliedRef.current) {
+      historyPrependAppliedRef.current = false;
+      isLoadingMoreRef.current = false;
+    }
   }, [messages.length, roomId, commitRoomSeen, scrollToBottomAfterLayout]);
 
   // Keep ref in sync with state for use in scroll handler
@@ -600,6 +659,45 @@ export default function MessageList({
     const animation = animatePop(scrollToBottomButtonRef.current);
     return () => cleanupAnime(animation);
   }, [showScrollToBottomButton]);
+
+  const requestMoreMessages = useCallback(() => {
+    const container = containerRef.current;
+    const oldestMessage = messages[0];
+    if (
+      !container
+      || !roomId
+      || !oldestMessage
+      || !hasMore
+      || isRoomMessagesLoadingMore
+      || isLoadingMoreRef.current
+    ) {
+      return;
+    }
+
+    const oldestMessageKey = messageRenderKey(oldestMessage);
+    const previousLength = messages.length;
+    historyAnchorRef.current = {
+      roomId,
+      oldestMessageKey,
+      visibleMessage: captureVisibleMessageScrollAnchor(
+        container,
+        "[data-msg-key]",
+        "data-msg-key",
+      ),
+    };
+    isLoadingMoreRef.current = true;
+    void loadMoreMessages(roomId).finally(() => {
+      const currentMessages = useDashboardChatStore.getState().messages[roomId] ?? [];
+      const currentOldestMessageKey = currentMessages[0]
+        ? messageRenderKey(currentMessages[0])
+        : null;
+      if (currentOldestMessageKey === oldestMessageKey || currentMessages.length === previousLength) {
+        isLoadingMoreRef.current = false;
+        historyPrependAppliedRef.current = false;
+        historyAnchorRef.current = null;
+      }
+    });
+  }, [roomId, messages, hasMore, isRoomMessagesLoadingMore, loadMoreMessages]);
 
   // Track scroll position & handle infinite scroll up
   const handleScroll = useCallback(() => {
@@ -617,15 +715,14 @@ export default function MessageList({
     }
 
     // Infinite scroll up
-    if (hasMore && !isLoadingMore.current && containerRef.current.scrollTop < 100) {
-      isLoadingMore.current = true;
-      loadMoreMessages(roomId);
+    if (containerRef.current.scrollTop < 100) {
+      requestMoreMessages();
     }
 
     if (wasNearBottomRef.current) {
       commitRoomSeen(roomId);
     }
-  }, [roomId, hasMore, loadMoreMessages, commitRoomSeen]);
+  }, [roomId, requestMoreMessages, commitRoomSeen]);
 
   // Reset follow control on room change
   useEffect(() => {
@@ -635,25 +732,52 @@ export default function MessageList({
 
   if (!roomId) return null;
 
-  if (isRoomMessagesLoading && messages.length === 0) {
+  // An opened room without a cache is always an initial-load state, including
+  // the render before the `useEffect` has had a chance to start its request.
+  // This removes the empty-room flash that used to occur on deep links and
+  // Explore/Contacts entry points.
+  if (!hasMessagesCache && !roomMessageError) {
+    return <MessageFeedSkeleton label={t.loadingMessages} />;
+  }
+
+  if (!hasMessagesCache && roomMessageError) {
     return (
-      <div className="flex-1 overflow-y-auto px-4 py-3">
-        <div className="space-y-3">
-          {Array.from({ length: 8 }).map((_, idx) => (
-            <div
-              key={idx}
-        className={`liquid-card h-11 w-full animate-pulse rounded-lg border border-glass-border/60 ${
-                idx % 2 === 0 ? "max-w-[72%]" : "ml-auto max-w-[64%]"
-              }`}
-            />
-          ))}
+      <div className="flex flex-1 items-center justify-center px-4 py-8" role="alert">
+        <div className="liquid-empty-state w-full max-w-sm rounded-2xl border border-glass-border px-5 py-6 text-center">
+          <p className="text-sm font-medium text-text-primary">{t.loadMessagesFailed}</p>
+          <p className="mt-1 text-xs text-text-secondary">{roomMessageError}</p>
+          <button
+            type="button"
+            onClick={() => void loadRoomMessages(roomId, { force: true })}
+            className="liquid-action mt-4 rounded-lg border border-neon-cyan/40 bg-neon-cyan/10 px-3 py-1.5 text-xs font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/20"
+          >
+            {tc.retry}
+          </button>
         </div>
       </div>
     );
   }
 
   if (messages.length === 0) {
-    return <EmptyRoomGuide room={currentRoom} />;
+    return (
+      <div className="relative flex min-h-0 flex-1">
+        <EmptyRoomGuide room={currentRoom} />
+        {roomMessageError ? (
+          <div className="absolute inset-x-0 top-0 z-20 flex min-h-7 items-center justify-center gap-2 border-b border-amber-300/15 bg-amber-300/[0.06] px-3 text-[11px] text-text-secondary" role="status">
+            <span>{t.loadMessagesFailed}</span>
+            <button
+              type="button"
+              onClick={() => void loadRoomMessages(roomId, { force: true })}
+              className="rounded px-1.5 py-0.5 font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/10"
+            >
+              {tc.retry}
+            </button>
+          </div>
+        ) : isRoomMessagesLoading ? (
+          <div className="dashboard-message-loading-bar absolute inset-x-0 top-0" role="status" aria-label={t.loadingMessages} />
+        ) : null}
+      </div>
+    );
   }
 
   const scrollToBottomButton = showScrollToBottomButton && (
@@ -670,17 +794,44 @@ export default function MessageList({
   );
 
   return (
-    <div className="relative flex-1">
+    <div className="relative flex-1" aria-busy={isRoomMessagesLoading}>
+      {roomMessageError ? (
+        <div className="absolute inset-x-0 top-0 z-20 flex min-h-7 items-center justify-center gap-2 border-b border-amber-300/15 bg-amber-300/[0.06] px-3 text-[11px] text-text-secondary" role="status">
+          <span>{t.loadMessagesFailed}</span>
+          <button
+            type="button"
+            onClick={() => void loadRoomMessages(roomId, { force: true })}
+            className="rounded px-1.5 py-0.5 font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/10"
+          >
+            {tc.retry}
+          </button>
+        </div>
+      ) : isRoomMessagesLoading ? (
+        <div className="dashboard-message-loading-bar absolute inset-x-0 top-0 z-20" role="status" aria-label={t.loadingMessages} />
+      ) : null}
       <div
         ref={containerRef}
         onScroll={handleScroll}
-        className="absolute inset-0 overflow-y-auto px-4 py-3"
+        className="dashboard-message-feed-enter absolute inset-0 overflow-y-auto px-4 py-3"
       >
-        {hasMore && (
+        {isRoomMessagesLoadingMore ? (
+          <MessageHistoryLoading label={t.loadingEarlier} />
+        ) : roomMoreError ? (
+          <div className="mb-2 flex items-center justify-center gap-2 text-xs text-text-secondary" role="status">
+            <span>{t.loadEarlierFailed}</span>
+            <button
+              type="button"
+              onClick={requestMoreMessages}
+              className="rounded px-1.5 py-0.5 font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/10"
+            >
+              {tc.retry}
+            </button>
+          </div>
+        ) : hasMore ? (
           <div className="mb-3 text-center text-xs text-text-secondary animate-pulse">
             {t.scrollUp}
           </div>
-        )}
+        ) : null}
         {timelineItems.map((item) => {
           if (item.kind === "message") {
             const msg = item.message;

--- a/frontend/src/components/dashboard/RoomHeader.tsx
+++ b/frontend/src/components/dashboard/RoomHeader.tsx
@@ -23,6 +23,7 @@ import ShareModal from "./ShareModal";
 import RoomSettingsModal from "./RoomSettingsModal";
 import DMSettingsModal from "./DMSettingsModal";
 import AddRoomMemberModal from "./AddRoomMemberModal";
+import { MessageRoomHeaderSkeleton } from "./DashboardMessagePaneSkeleton";
 import { dmPeerId, resolveDmDisplayName } from "./dmRoom";
 import { animateIfMotion, cleanupAnime } from "@/lib/anime";
 
@@ -66,10 +67,11 @@ export default function RoomHeader() {
     setMessagesPane: state.setMessagesPane,
     openMobileSidebar: state.openMobileSidebar,
   })));
-  const { overview, getRoomSummary, refreshOverview } = useDashboardChatStore(useShallow((state) => ({
+  const { overview, getRoomSummary, refreshOverview, roomMessagesLoading } = useDashboardChatStore(useShallow((state) => ({
     overview: state.overview,
     getRoomSummary: state.getRoomSummary,
     refreshOverview: state.refreshOverview,
+    roomMessagesLoading: openedRoomId ? Boolean(state.messagesLoading[openedRoomId]) : false,
   })));
   const { joinRoom, joiningRoomId } = useDashboardChatStore(useShallow((state) => ({
     joinRoom: state.joinRoom,
@@ -277,7 +279,10 @@ export default function RoomHeader() {
     };
   }, [canAddMembers, handleOpenAddMemberModal]);
 
-  if (!room) return null;
+  // A deep-linked/public room can render before its summary request resolves.
+  // Keep the header slot mounted at its final height so the message viewport
+  // and composer do not jump once the metadata arrives.
+  if (!room) return <MessageRoomHeaderSkeleton label={tc.loading} />;
 
   const handleMobileBack = () => {
     setMessagesPane("room");
@@ -370,6 +375,12 @@ export default function RoomHeader() {
         <div className="min-w-0 flex-1 py-0.5 max-md:py-0">
           <div className="flex items-center gap-2">
             <h3 className="truncate text-sm font-semibold text-text-primary">{titleText}</h3>
+            {roomMessagesLoading ? (
+              <span className="inline-flex shrink-0 text-neon-cyan" role="status" aria-label={tc.loading}>
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                <span className="sr-only">{tc.loading}</span>
+              </span>
+            ) : null}
             {room.required_subscription_product_id ? (
               <SubscriptionBadge productId={room.required_subscription_product_id} roomId={room.room_id} />
             ) : null}

--- a/frontend/src/components/dashboard/RoomList.tsx
+++ b/frontend/src/components/dashboard/RoomList.tsx
@@ -318,7 +318,9 @@ export default function RoomList({
     closeMobileSidebar();
     const chatStore = useDashboardChatStore.getState();
     if (Object.prototype.hasOwnProperty.call(chatStore.messages, room.room_id)) {
-      void chatStore.pollNewMessages(room.room_id);
+      // Keep cached conversation content in place, but make an intentional
+      // room switch visibly responsive while its delta check is running.
+      void chatStore.pollNewMessages(room.room_id, { showLoading: true });
     } else {
       void chatStore.loadRoomMessages(room.room_id);
     }

--- a/frontend/src/components/dashboard/UserChatPane.tsx
+++ b/frontend/src/components/dashboard/UserChatPane.tsx
@@ -23,7 +23,7 @@ import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import { useOwnerChatStore } from "@/store/useOwnerChatStore";
 import { useOwnerChatWs } from "@/hooks/useOwnerChatWs";
 import { messageList } from "@/lib/i18n/translations/dashboard";
-import DashboardMessagePaneSkeleton from "./DashboardMessagePaneSkeleton";
+import DashboardMessagePaneSkeleton, { MessageHistoryLoading } from "./DashboardMessagePaneSkeleton";
 import MarkdownContent, { normalizeMessageContent } from "@/components/ui/MarkdownContent";
 import AttachmentItem, {
   attachmentGalleryIndex,
@@ -48,9 +48,12 @@ import {
   ownerChatReplyTargetId,
 } from "@/lib/owner-chat-actions";
 import {
+  captureVisibleMessageScrollAnchor,
   isNearScrollBottom,
+  restoreVisibleMessageScrollAnchor,
   scrollToLatestVisibleAfterScroll,
   shouldShowScrollToLatestForNewContent,
+  type VisibleMessageScrollAnchor,
 } from "./messageScroll";
 import { animateFadeUp, animateIfMotion, animatePop, cleanupAnime } from "@/lib/anime";
 
@@ -114,6 +117,8 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
   const messages = useOwnerChatStore((s) => s.messages);
   const hasMore = useOwnerChatStore((s) => s.hasMore);
   const loading = useOwnerChatStore((s) => s.loading);
+  const loadingMore = useOwnerChatStore((s) => s.loadingMore);
+  const moreError = useOwnerChatStore((s) => s.moreError);
   const storeError = useOwnerChatStore((s) => s.error);
   const wsConnected = useOwnerChatStore((s) => s.wsConnected);
   const agentTyping = useOwnerChatStore((s) => s.agentTyping);
@@ -135,7 +140,8 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
   const forwardLabel = locale === "zh" ? "转发" : "Forward";
   const copyLabel = locale === "zh" ? "复制" : "Copy";
   const copiedLabel = locale === "zh" ? "已复制" : "Copied";
-  const scrollToLatestLabel = messageList[locale].scrollToLatest;
+  const tMessages = messageList[locale];
+  const scrollToLatestLabel = tMessages.scrollToLatest;
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const scrollToBottomButtonElementRef = useRef<HTMLButtonElement>(null);
@@ -148,6 +154,12 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
   const motionHandlesRef = useRef<Set<ReturnType<typeof animateIfMotion>>>(new Set());
   const initialLoadRef = useRef(true);
   const isLoadingMore = useRef(false);
+  const historyPrependAppliedRef = useRef(false);
+  const historyAnchorRef = useRef<{
+    roomId: string;
+    oldestMessageKey: string;
+    visibleMessage: VisibleMessageScrollAnchor | null;
+  } | null>(null);
   const prevLengthRef = useRef(0);
   const prevMessageContentSignatureRef = useRef("");
   const wasNearBottomRef = useRef(true);
@@ -230,6 +242,8 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
     wasNearBottomRef.current = true;
     entrancePrimedRef.current = false;
     roomOpenedAtRef.current = performance.now();
+    historyAnchorRef.current = null;
+    historyPrependAppliedRef.current = false;
     previousStatusRef.current = new Map();
     showScrollToBottomButtonRef.current = false;
     setShowScrollToBottomButton(false);
@@ -300,8 +314,34 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
   }, [messages]);
   const hasStreamingMsg = messages.some((m) => m.status === "streaming");
 
+  // Apply a history anchor only when the oldest message changes. A live
+  // append can land while pagination is pending; anchoring to the visible
+  // message keeps that append from being mistaken for prepended history.
+  useLayoutEffect(() => {
+    const anchor = historyAnchorRef.current;
+    const container = scrollContainerRef.current;
+    if (!anchor || !container) return;
+    if (anchor.roomId !== roomId) {
+      historyAnchorRef.current = null;
+      return;
+    }
+    const currentOldestMessageKey = messages[0]?.clientId ?? null;
+    if (currentOldestMessageKey === anchor.oldestMessageKey) return;
+    if (anchor.visibleMessage) {
+      restoreVisibleMessageScrollAnchor(
+        container,
+        "[data-owner-msg-key]",
+        "data-owner-msg-key",
+        anchor.visibleMessage,
+      );
+    }
+    historyPrependAppliedRef.current = true;
+    historyAnchorRef.current = null;
+  }, [messages, roomId]);
+
   useEffect(() => {
-    if (messages.length > prevLengthRef.current && !isLoadingMore.current) {
+    const loadingMoreAtChange = isLoadingMore.current;
+    if (messages.length > prevLengthRef.current && !loadingMoreAtChange) {
       if (wasNearBottomRef.current) scrollToBottom();
       else if (shouldShowScrollToLatestForNewContent({
         wasNearBottom: wasNearBottomRef.current,
@@ -313,7 +353,10 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
       }
     }
     prevLengthRef.current = messages.length;
-    isLoadingMore.current = false;
+    if (historyPrependAppliedRef.current) {
+      historyPrependAppliedRef.current = false;
+      isLoadingMore.current = false;
+    }
   }, [messages.length, scrollToBottom]);
 
   useLayoutEffect(() => {
@@ -426,6 +469,43 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
     registerMotion(animateFadeUp(typingIndicatorRef.current));
   }, [agentTyping, hasStreamingMsg, registerMotion]);
 
+  const requestMoreMessages = useCallback(() => {
+    const container = scrollContainerRef.current;
+    const oldestMessage = messages[0];
+    if (
+      !container
+      || !roomId
+      || !oldestMessage
+      || !hasMore
+      || loadingMore
+      || isLoadingMore.current
+    ) {
+      return;
+    }
+
+    const oldestMessageKey = oldestMessage.clientId;
+    const previousLength = messages.length;
+    historyAnchorRef.current = {
+      roomId,
+      oldestMessageKey,
+      visibleMessage: captureVisibleMessageScrollAnchor(
+        container,
+        "[data-owner-msg-key]",
+        "data-owner-msg-key",
+      ),
+    };
+    isLoadingMore.current = true;
+    void useOwnerChatStore.getState().loadMore().finally(() => {
+      const currentMessages = useOwnerChatStore.getState().messages;
+      const currentOldestMessageKey = currentMessages[0]?.clientId ?? null;
+      if (currentOldestMessageKey === oldestMessageKey || currentMessages.length === previousLength) {
+        isLoadingMore.current = false;
+        historyPrependAppliedRef.current = false;
+        historyAnchorRef.current = null;
+      }
+    });
+  }, [roomId, messages, hasMore, loadingMore]);
+
   const handleScroll = useCallback(() => {
     const el = scrollContainerRef.current;
     if (!el) return;
@@ -438,11 +518,10 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
       showScrollToBottomButtonRef.current = shouldShow;
       setShowScrollToBottomButton(shouldShow);
     }
-    if (hasMore && !isLoadingMore.current && el.scrollTop < 100) {
-      isLoadingMore.current = true;
-      useOwnerChatStore.getState().loadMore();
+    if (el.scrollTop < 100) {
+      requestMoreMessages();
     }
-  }, [hasMore]);
+  }, [requestMoreMessages]);
 
   // ------ Typing auto-dismiss ------
   useEffect(() => {
@@ -712,11 +791,24 @@ function UserChatPane({ agentId }: { agentId?: string | null }) {
 
       {/* Messages */}
       <div ref={scrollContainerRef} onScroll={handleScroll} className="flex-1 overflow-y-auto px-4 py-3 space-y-3">
-        {hasMore && (
-          <div className="mb-1 text-center text-xs text-zinc-500 animate-pulse">
-            Scroll up for older messages
+        {loadingMore ? (
+          <MessageHistoryLoading label={tMessages.loadingEarlier} />
+        ) : moreError ? (
+          <div className="mb-1 flex items-center justify-center gap-2 text-xs text-text-secondary" role="status">
+            <span>{tMessages.loadEarlierFailed}</span>
+            <button
+              type="button"
+              onClick={requestMoreMessages}
+              className="rounded px-1.5 py-0.5 font-medium text-neon-cyan transition-colors hover:bg-neon-cyan/10"
+            >
+              {locale === "zh" ? "重试" : "Retry"}
+            </button>
           </div>
-        )}
+        ) : hasMore ? (
+          <div className="mb-1 text-center text-xs text-zinc-500 animate-pulse">
+            {tMessages.scrollUp}
+          </div>
+        ) : null}
 
         {messages.map((msg) => {
           const isUser = msg.sender === "user";

--- a/frontend/src/components/dashboard/messageScroll.ts
+++ b/frontend/src/components/dashboard/messageScroll.ts
@@ -27,3 +27,44 @@ export function shouldShowScrollToLatestForNewContent({
 }): boolean {
   return !isLoadingMore && hadPreviousContent && !wasNearBottom;
 }
+
+/** A stable, visible message element used to preserve the reader's viewport
+ * while an older page is prepended. Unlike scrollHeight deltas, this remains
+ * correct if a realtime message is appended at the bottom mid-request. */
+export type VisibleMessageScrollAnchor = {
+  key: string;
+  offsetFromViewportTop: number;
+};
+
+export function captureVisibleMessageScrollAnchor(
+  container: HTMLElement,
+  selector: string,
+  keyAttribute: string,
+): VisibleMessageScrollAnchor | null {
+  const containerTop = container.getBoundingClientRect().top;
+  const message = Array.from(container.querySelectorAll<HTMLElement>(selector)).find(
+    (element) => element.getBoundingClientRect().bottom > containerTop,
+  );
+  const key = message?.getAttribute(keyAttribute);
+  if (!message || !key) return null;
+  return {
+    key,
+    offsetFromViewportTop: message.getBoundingClientRect().top - containerTop,
+  };
+}
+
+export function restoreVisibleMessageScrollAnchor(
+  container: HTMLElement,
+  selector: string,
+  keyAttribute: string,
+  anchor: VisibleMessageScrollAnchor,
+): boolean {
+  const message = Array.from(container.querySelectorAll<HTMLElement>(selector)).find(
+    (element) => element.getAttribute(keyAttribute) === anchor.key,
+  );
+  if (!message) return false;
+  const nextOffset = message.getBoundingClientRect().top - container.getBoundingClientRect().top;
+  const delta = nextOffset - anchor.offsetFromViewportTop;
+  if (delta !== 0) container.scrollTop += delta;
+  return true;
+}

--- a/frontend/src/hooks/useOwnerChatWs.ts
+++ b/frontend/src/hooks/useOwnerChatWs.ts
@@ -48,6 +48,16 @@ export function useOwnerChatWs({
 
     // Reset grace period when switching agents
     lastAgentMsgRef.current = null;
+    let disposed = false;
+    // `auth_ok` can correct a provisional room id. Keep the socket's current
+    // room separate from the React closure so queued events can be fenced.
+    let socketRoomId = roomId;
+    const isActiveSocketRoom = (eventRoomId?: string | null) => {
+      const targetRoomId = eventRoomId || socketRoomId;
+      return !disposed
+        && targetRoomId === socketRoomId
+        && store.getState().roomId === targetRoomId;
+    };
 
     const supabase = createClient();
 
@@ -60,7 +70,13 @@ export function useOwnerChatWs({
       agentId: activeAgentId,
 
       onAuthOk: (data) => {
-        if (data.room_id && data.room_id !== roomId) {
+        if (disposed) return;
+        const currentRoomId = store.getState().roomId;
+        // A detached socket can still emit a queued auth frame after the
+        // reader has selected another Bot. Never let it retarget the store.
+        if (currentRoomId !== roomId && currentRoomId !== data.room_id) return;
+        socketRoomId = data.room_id || roomId;
+        if (data.room_id && currentRoomId !== data.room_id) {
           setUserChatRoomId(data.room_id);
           // Re-initialize the store for the corrected room
           store.getState().setRoom(data.room_id, agentName);
@@ -69,13 +85,15 @@ export function useOwnerChatWs({
       },
 
       onTyping: () => {
+        if (!isActiveSocketRoom()) return;
         const grace = lastAgentMsgRef.current;
-        if (grace && grace.roomId === roomId && Date.now() - grace.at < 5_000) return;
+        if (grace && grace.roomId === socketRoomId && Date.now() - grace.at < 5_000) return;
         store.getState().setAgentTyping(true);
       },
 
       onMessage: (msg) => {
-        const msgRoomId = msg.room_id || roomId;
+        const msgRoomId = msg.room_id || socketRoomId;
+        if (!isActiveSocketRoom(msgRoomId)) return;
 
         // Agent message with trace_id → finalize the streaming placeholder
         if (msg.sender === "agent" && msg.ext?.trace_id) {
@@ -138,6 +156,7 @@ export function useOwnerChatWs({
       },
 
       onStreamBlock: (block) => {
+        if (!isActiveSocketRoom(block.room_id)) return;
         store.getState().appendStreamBlock(block);
         if (block.block.kind === "assistant") {
           streamedTraceIds.current.add(block.trace_id);
@@ -145,6 +164,7 @@ export function useOwnerChatWs({
       },
 
       onNotification: (notif) => {
+        if (!isActiveSocketRoom()) return;
         const notifId = `notif_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
         const notifMsg: OwnerChatMessage = {
           clientId: notifId,
@@ -161,6 +181,7 @@ export function useOwnerChatWs({
       },
 
       onRunFailed: (err) => {
+        if (!isActiveSocketRoom(err.room_id)) return;
         store.getState().failRun({
           hubMsgId: err.hub_msg_id ?? null,
           traceId: err.trace_id ?? err.hub_msg_id ?? null,
@@ -171,6 +192,7 @@ export function useOwnerChatWs({
       },
 
       onStatusChange: (connected) => {
+        if (!isActiveSocketRoom()) return;
         if (connected) {
           store.getState().setWsConnected(true);
           // Reconcile failed/partial messages against server state after reconnect
@@ -181,6 +203,7 @@ export function useOwnerChatWs({
       },
 
       onSendFailed: (errorOrText: string, clientMsgId?: string) => {
+        if (!isActiveSocketRoom()) return;
         const reason = errorOrText || "WebSocket send failed";
         if (clientMsgId) {
           store.getState().failOptimistic(clientMsgId, reason);
@@ -198,9 +221,12 @@ export function useOwnerChatWs({
     wsClientRef.current = wsClient;
 
     return () => {
+      disposed = true;
       wsClient.close();
-      wsClientRef.current = null;
-      store.getState().setWsConnected(false);
+      if (wsClientRef.current === wsClient) wsClientRef.current = null;
+      if (store.getState().roomId === socketRoomId) {
+        store.getState().setWsConnected(false);
+      }
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeAgentId, roomId]);

--- a/frontend/src/lib/i18n/translations/dashboard.ts
+++ b/frontend/src/lib/i18n/translations/dashboard.ts
@@ -2063,6 +2063,10 @@ export const messageList: TranslationMap<{
   expired: string
   general: string
   noMessages: string
+  loadingMessages: string
+  loadingEarlier: string
+  loadMessagesFailed: string
+  loadEarlierFailed: string
   scrollUp: string
   msg: string
   msgs: string
@@ -2089,6 +2093,10 @@ export const messageList: TranslationMap<{
     expired: 'Expired',
     general: 'General',
     noMessages: 'No messages yet',
+    loadingMessages: 'Loading messages…',
+    loadingEarlier: 'Loading earlier messages…',
+    loadMessagesFailed: 'Couldn’t load this room’s messages.',
+    loadEarlierFailed: 'Couldn’t load earlier messages.',
     scrollUp: 'Scroll up for older messages...',
     msg: 'msg',
     msgs: 'msgs',
@@ -2115,6 +2123,10 @@ export const messageList: TranslationMap<{
     expired: '已过期',
     general: '通用',
     noMessages: '暂无消息',
+    loadingMessages: '正在加载消息…',
+    loadingEarlier: '正在加载更早的消息…',
+    loadMessagesFailed: '消息加载失败，请重试。',
+    loadEarlierFailed: '更早的消息加载失败。',
     scrollUp: '向上滚动查看更早的消息...',
     msg: '条消息',
     msgs: '条消息',

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -247,6 +247,8 @@ export interface FileUploadResult {
 export interface StreamBlockEntry {
   trace_id: string;
   seq: number;
+  /** Present on live owner-chat WebSocket blocks; absent on cached run rows. */
+  room_id?: string | null;
   block: {
     kind: string;
     /** Legacy shape: structured payload. */

--- a/frontend/src/store/useDashboardChatStore.test.ts
+++ b/frontend/src/store/useDashboardChatStore.test.ts
@@ -113,6 +113,9 @@ describe("useDashboardChatStore message polling", () => {
     mocks.getPublicRoom.mockReset();
     mocks.recallRoomMessage.mockReset();
     mocks.listAgentRooms.mockReset();
+    // Clear module-scoped request/history guards as well as Zustand state so
+    // every test starts with an independent room lifecycle.
+    useDashboardChatStore.getState().resetChatState();
     useDashboardSessionStore.setState({
       token: "test-token",
       activeIdentity: { type: "human", id: "hu_1" },
@@ -129,7 +132,10 @@ describe("useDashboardChatStore message polling", () => {
       error: null,
       messages: {},
       messagesLoading: {},
+      messagesErrors: {},
       messagesHasMore: {},
+      messagesLoadingMore: {},
+      messagesMoreErrors: {},
       ownedAgentRooms: [],
       optimisticOwnerChatRooms: {},
     });
@@ -233,6 +239,130 @@ describe("useDashboardChatStore message polling", () => {
 
     expect(useDashboardChatStore.getState().messages.rm_empty).toHaveLength(1);
     expect(useDashboardChatStore.getState().messages.rm_empty[0].hub_msg_id).toBe("hub_sender_row");
+  });
+
+  it("keeps a realtime message while an older history page is loading", async () => {
+    let resolvePage!: (result: { messages: DashboardMessage[]; has_more: boolean }) => void;
+    mocks.getRoomMessages.mockReturnValue(new Promise((resolve) => {
+      resolvePage = resolve;
+    }));
+    useDashboardChatStore.setState({
+      messages: {
+        rm_empty: [makeMessage({
+          hub_msg_id: "hub_current",
+          msg_id: "msg_current",
+          created_at: "2026-05-11T10:00:00Z",
+        })],
+      },
+      messagesHasMore: { rm_empty: true },
+    });
+
+    const request = useDashboardChatStore.getState().loadMoreMessages("rm_empty");
+    expect(useDashboardChatStore.getState().messagesLoadingMore.rm_empty).toBe(true);
+    expect(mocks.getRoomMessages).toHaveBeenCalledWith("rm_empty", {
+      before: "hub_current",
+      limit: 50,
+    });
+
+    useDashboardChatStore.getState().insertMessage("rm_empty", makeMessage({
+      hub_msg_id: "hub_live",
+      msg_id: "msg_live",
+      text: "arrived over realtime",
+      created_at: "2026-05-11T10:01:00Z",
+    }));
+    resolvePage({
+      messages: [makeMessage({
+        hub_msg_id: "hub_older",
+        msg_id: "msg_older",
+        text: "older history",
+        created_at: "2026-05-11T09:00:00Z",
+      })],
+      has_more: false,
+    });
+    await request;
+
+    expect(useDashboardChatStore.getState().messages.rm_empty.map((message) => message.hub_msg_id)).toEqual([
+      "hub_older",
+      "hub_current",
+      "hub_live",
+    ]);
+    expect(useDashboardChatStore.getState().messagesLoadingMore.rm_empty).toBe(false);
+  });
+
+  it("discards a late older-page response after the room is left", async () => {
+    let resolvePage!: (result: { messages: DashboardMessage[]; has_more: boolean }) => void;
+    mocks.getRoomMessages.mockReturnValue(new Promise((resolve) => {
+      resolvePage = resolve;
+    }));
+    mocks.leaveRoom.mockResolvedValue(undefined);
+    mocks.getOverview.mockResolvedValue({ ...makeOverview(), rooms: [] });
+    mocks.getPublicRoom.mockResolvedValue({ rooms: [] });
+    useDashboardChatStore.setState({
+      messages: { rm_empty: [makeMessage({ hub_msg_id: "hub_current", msg_id: "msg_current" })] },
+      messagesHasMore: { rm_empty: true },
+    });
+
+    const request = useDashboardChatStore.getState().loadMoreMessages("rm_empty");
+    await useDashboardChatStore.getState().leaveRoom("rm_empty");
+    resolvePage({
+      messages: [makeMessage({ hub_msg_id: "hub_old", msg_id: "msg_old" })],
+      has_more: false,
+    });
+    await request;
+
+    const state = useDashboardChatStore.getState();
+    expect(state.messages.rm_empty).toBeUndefined();
+    expect(state.messagesLoadingMore.rm_empty).toBeUndefined();
+    expect(state.messagesMoreErrors.rm_empty).toBeUndefined();
+  });
+
+  it("releases invalidated loading state when leaving a room fails", async () => {
+    let resolvePage!: (result: { messages: DashboardMessage[]; has_more: boolean }) => void;
+    mocks.getRoomMessages.mockReturnValue(new Promise((resolve) => {
+      resolvePage = resolve;
+    }));
+    mocks.leaveRoom.mockRejectedValue(new Error("leave failed"));
+    useDashboardChatStore.setState({
+      messages: { rm_empty: [makeMessage({ hub_msg_id: "hub_current", msg_id: "msg_current" })] },
+      messagesHasMore: { rm_empty: true },
+    });
+
+    const pageRequest = useDashboardChatStore.getState().loadMoreMessages("rm_empty");
+    await expect(useDashboardChatStore.getState().leaveRoom("rm_empty")).rejects.toThrow("leave failed");
+    resolvePage({ messages: [], has_more: false });
+    await pageRequest;
+
+    const state = useDashboardChatStore.getState();
+    expect(state.messages.rm_empty).toHaveLength(1);
+    expect(state.messagesLoading.rm_empty).toBeUndefined();
+    expect(state.messagesLoadingMore.rm_empty).toBeUndefined();
+  });
+
+  it("keeps exhausted history exhausted after a newest-page refresh", async () => {
+    const current = makeMessage({
+      hub_msg_id: "hub_current",
+      msg_id: "msg_current",
+      created_at: "2026-05-11T10:00:00Z",
+    });
+    mocks.getRoomMessages
+      .mockResolvedValueOnce({
+        messages: [makeMessage({
+          hub_msg_id: "hub_oldest",
+          msg_id: "msg_oldest",
+          created_at: "2026-05-11T09:00:00Z",
+        })],
+        has_more: false,
+      })
+      .mockResolvedValueOnce({ messages: [current], has_more: true });
+    useDashboardChatStore.setState({
+      messages: { rm_empty: [current] },
+      messagesHasMore: { rm_empty: true },
+    });
+
+    await useDashboardChatStore.getState().loadMoreMessages("rm_empty");
+    await useDashboardChatStore.getState().loadRoomMessages("rm_empty");
+
+    expect(useDashboardChatStore.getState().messagesHasMore.rm_empty).toBe(false);
   });
 
   it("marks a cached message recalled after the backend confirms recall", async () => {

--- a/frontend/src/store/useDashboardChatStore.ts
+++ b/frontend/src/store/useDashboardChatStore.ts
@@ -39,6 +39,52 @@ let publicRoomsRequestSeq = 0;
 let publicAgentsRequestSeq = 0;
 let publicHumansRequestSeq = 0;
 const emptyRoomMessageSnapshot = new Map<string, string | null>();
+const fullyLoadedRoomHistory = new Set<string>();
+let roomMessageRequestSequence = 0;
+const roomMessageEpochByRoom = new Map<string, number>();
+const roomMessageLoadRequestByRoom = new Map<string, number>();
+const roomMessagePollRequestByRoom = new Map<string, number>();
+const roomMessageMoreRequestByRoom = new Map<string, number>();
+
+function roomMessageEpoch(roomId: string): number {
+  return roomMessageEpochByRoom.get(roomId) ?? 0;
+}
+
+function isCurrentRoomMessageRequest(
+  roomId: string,
+  epoch: number,
+  requestId: number,
+  requests: Map<string, number>,
+): boolean {
+  return roomMessageEpoch(roomId) === epoch && requests.get(roomId) === requestId;
+}
+
+function invalidateRoomMessageRequests(roomId: string): void {
+  roomMessageEpochByRoom.set(roomId, roomMessageEpoch(roomId) + 1);
+  roomMessagesInFlight.delete(roomId);
+  roomMessagesReloadPending.delete(roomId);
+  roomPollInFlight.delete(roomId);
+  roomMessageLoadRequestByRoom.delete(roomId);
+  roomMessagePollRequestByRoom.delete(roomId);
+  roomMessageMoreRequestByRoom.delete(roomId);
+  emptyRoomMessageSnapshot.delete(roomId);
+  fullyLoadedRoomHistory.delete(roomId);
+}
+
+function invalidateAllRoomMessageRequests(): void {
+  const roomIds = new Set([
+    ...roomMessageEpochByRoom.keys(),
+    ...roomMessagesInFlight,
+    ...roomMessagesReloadPending,
+    ...roomPollInFlight,
+    ...roomMessageLoadRequestByRoom.keys(),
+    ...roomMessagePollRequestByRoom.keys(),
+    ...roomMessageMoreRequestByRoom.keys(),
+    ...emptyRoomMessageSnapshot.keys(),
+    ...fullyLoadedRoomHistory,
+  ]);
+  for (const roomId of roomIds) invalidateRoomMessageRequests(roomId);
+}
 
 /**
  * Structural equality for overview snapshots. `DashboardOverview` is plain JSON
@@ -198,6 +244,19 @@ function preserveStableAttachmentPayload(
   };
 }
 
+function sortRoomMessagesChronologically(messages: DashboardMessage[]): DashboardMessage[] {
+  return messages
+    .map((message, index) => ({ message, index }))
+    .sort((a, b) => {
+      const aTime = Date.parse(a.message.created_at);
+      const bTime = Date.parse(b.message.created_at);
+      const normalizedA = Number.isNaN(aTime) ? 0 : aTime;
+      const normalizedB = Number.isNaN(bTime) ? 0 : bTime;
+      return normalizedA - normalizedB || a.index - b.index;
+    })
+    .map(({ message }) => message);
+}
+
 function mergeLoadedRoomMessages(
   currentMessages: DashboardMessage[] | undefined,
   loadedNewestFirst: DashboardMessage[],
@@ -212,11 +271,25 @@ function mergeLoadedRoomMessages(
     byHubMsgId.set(message.hub_msg_id, message);
   }
 
-  return loadedChronological.map((incoming) => {
+  const merged = loadedChronological.map((incoming) => {
     const existing = byStableId.get(dashboardMessageStableId(incoming))
       ?? byHubMsgId.get(incoming.hub_msg_id);
     return existing ? preserveStableAttachmentPayload(existing, incoming) : incoming;
   });
+
+  const loadedStableIds = new Set(merged.map(dashboardMessageStableId));
+  const loadedHubMsgIds = new Set(merged.map((message) => message.hub_msg_id));
+  for (const existing of currentMessages) {
+    if (
+      loadedStableIds.has(dashboardMessageStableId(existing))
+      || loadedHubMsgIds.has(existing.hub_msg_id)
+    ) {
+      continue;
+    }
+    merged.push(existing);
+  }
+
+  return sortRoomMessagesChronologically(merged);
 }
 
 function ownerChatRoomIdForOptimistic(agentId: string): string {
@@ -326,7 +399,10 @@ interface DashboardChatState {
   overview: DashboardOverview | null;
   messages: Record<string, DashboardMessage[]>;
   messagesLoading: Record<string, boolean>;
+  messagesErrors: Record<string, string>;
   messagesHasMore: Record<string, boolean>;
+  messagesLoadingMore: Record<string, boolean>;
+  messagesMoreErrors: Record<string, string>;
   roomMembersByRoom: Record<string, PublicRoomMember[]>;
   roomMembersLoading: Record<string, boolean>;
   error: string | null;
@@ -381,7 +457,12 @@ interface DashboardChatState {
   recallMessage: (roomId: string, msgId: string) => Promise<void>;
   loadRoomMessages: (roomId: string, opts?: { force?: boolean }) => Promise<void>;
   prefetchRoomMessages: (roomId: string) => Promise<void>;
-  pollNewMessages: (roomId: string, opts?: { expectedHubMsgId?: string | null; retries?: number }) => Promise<void>;
+  pollNewMessages: (roomId: string, opts?: {
+    expectedHubMsgId?: string | null;
+    retries?: number;
+    /** Surface a lightweight refresh signal when a user actively opens a cached room. */
+    showLoading?: boolean;
+  }) => Promise<void>;
   loadMoreMessages: (roomId: string) => Promise<void>;
   loadRoomMembers: (roomId: string, opts?: { force?: boolean }) => Promise<PublicRoomMember[]>;
   selectAgent: (agentId: string) => Promise<void>;
@@ -404,7 +485,10 @@ const initialChatState = {
   overview: null,
   messages: {},
   messagesLoading: {},
+  messagesErrors: {},
   messagesHasMore: {},
+  messagesLoadingMore: {},
+  messagesMoreErrors: {},
   roomMembersByRoom: {},
   roomMembersLoading: {},
   error: null,
@@ -444,7 +528,10 @@ function hasTransientChatState(state: DashboardChatState): boolean {
     || state.overview !== null
     || Object.keys(state.messages).length > 0
     || Object.keys(state.messagesLoading).length > 0
+    || Object.keys(state.messagesErrors).length > 0
     || Object.keys(state.messagesHasMore).length > 0
+    || Object.keys(state.messagesLoadingMore).length > 0
+    || Object.keys(state.messagesMoreErrors).length > 0
     || Object.keys(state.roomMembersByRoom).length > 0
     || Object.keys(state.roomMembersLoading).length > 0
     || state.error !== null
@@ -501,7 +588,8 @@ export const useDashboardChatStore = create<DashboardChatState>()(
           replyingTo: { ...state.replyingTo, [roomId]: message },
         })),
 
-      resetChatState: () =>
+      resetChatState: () => {
+        invalidateAllRoomMessageRequests();
         set((state) => {
           if (!hasTransientChatState(state)) {
             return state;
@@ -513,10 +601,13 @@ export const useDashboardChatStore = create<DashboardChatState>()(
             publicAgents: state.publicAgents,
             publicRoomDetails: state.publicRoomDetails,
           };
-        }),
+        });
+      },
 
-      logout: () =>
-        set({ ...initialChatState }),
+      logout: () => {
+        invalidateAllRoomMessageRequests();
+        set({ ...initialChatState });
+      },
 
       closeAgentCardState: () =>
         set((state) => ({
@@ -778,29 +869,55 @@ export const useDashboardChatStore = create<DashboardChatState>()(
           }
           return;
         }
-        set((state) => ({
-          messagesLoading: { ...state.messagesLoading, [roomId]: true },
-        }));
+        const epoch = roomMessageEpoch(roomId);
+        const requestId = ++roomMessageRequestSequence;
+        roomMessageLoadRequestByRoom.set(roomId, requestId);
+        set((state) => {
+          const messagesErrors = { ...state.messagesErrors };
+          delete messagesErrors[roomId];
+          return {
+            messagesLoading: { ...state.messagesLoading, [roomId]: true },
+            messagesErrors,
+          };
+        });
         roomMessagesInFlight.add(roomId);
 
         try {
           const result = await api.getRoomMessages(roomId, { limit: 50 });
+          if (!isCurrentRoomMessageRequest(roomId, epoch, requestId, roomMessageLoadRequestByRoom)) return;
           if (result.messages.length === 0) {
             emptyRoomMessageSnapshot.set(roomId, getRoomMessageSnapshot(get().getRoomSummary(roomId)));
           } else {
             emptyRoomMessageSnapshot.delete(roomId);
           }
-          set((state) => ({
-            messages: {
-              ...state.messages,
-              [roomId]: mergeLoadedRoomMessages(state.messages[roomId], result.messages),
-            },
-            messagesHasMore: { ...state.messagesHasMore, [roomId]: result.has_more },
-          }));
+          if (!result.has_more) fullyLoadedRoomHistory.add(roomId);
+          set((state) => {
+            if (!isCurrentRoomMessageRequest(roomId, epoch, requestId, roomMessageLoadRequestByRoom)) return state;
+            return {
+              messages: {
+                ...state.messages,
+                [roomId]: mergeLoadedRoomMessages(state.messages[roomId], result.messages),
+              },
+              // A full refresh only returns the newest page. Once pagination
+              // already reached the oldest message, keep that terminal state
+              // instead of reviving a misleading "load earlier" affordance.
+              messagesHasMore: {
+                ...state.messagesHasMore,
+                [roomId]: fullyLoadedRoomHistory.has(roomId) ? false : result.has_more,
+              },
+            };
+          });
         } catch (error) {
           console.error("[ChatStore] Failed to load messages:", error);
+          if (!isCurrentRoomMessageRequest(roomId, epoch, requestId, roomMessageLoadRequestByRoom)) return;
+          const message = error instanceof Error ? error.message : "Failed to load messages";
+          set((state) => ({
+            messagesErrors: { ...state.messagesErrors, [roomId]: message },
+          }));
         } finally {
+          if (!isCurrentRoomMessageRequest(roomId, epoch, requestId, roomMessageLoadRequestByRoom)) return;
           roomMessagesInFlight.delete(roomId);
+          roomMessageLoadRequestByRoom.delete(roomId);
           set((state) => ({
             messagesLoading: { ...state.messagesLoading, [roomId]: false },
           }));
@@ -819,6 +936,21 @@ export const useDashboardChatStore = create<DashboardChatState>()(
 
       pollNewMessages: async (roomId: string, opts) => {
         if (roomPollInFlight.has(roomId)) return;
+        const epoch = roomMessageEpoch(roomId);
+        const requestId = ++roomMessageRequestSequence;
+        roomMessagePollRequestByRoom.set(roomId, requestId);
+        const hadCachedMessages = Object.prototype.hasOwnProperty.call(get().messages, roomId);
+        const showLoading = Boolean(opts?.showLoading && hadCachedMessages);
+        if (showLoading) {
+          set((state) => {
+            const messagesErrors = { ...state.messagesErrors };
+            delete messagesErrors[roomId];
+            return {
+              messagesLoading: { ...state.messagesLoading, [roomId]: true },
+              messagesErrors,
+            };
+          });
+        }
         roomPollInFlight.add(roomId);
         try {
           const existing = get().messages[roomId];
@@ -848,8 +980,10 @@ export const useDashboardChatStore = create<DashboardChatState>()(
             }
             const result = await api.getRoomMessages(roomId, { after: newestPersisted.hub_msg_id, limit: 50 });
             if (result.messages.length > 0) {
+              if (!isCurrentRoomMessageRequest(roomId, epoch, requestId, roomMessagePollRequestByRoom)) return;
               const newMsgs = result.messages.reverse();
               set((state) => {
+                if (!isCurrentRoomMessageRequest(roomId, epoch, requestId, roomMessagePollRequestByRoom)) return state;
                 const current = state.messages[roomId] || [];
                 const existingStableIds = new Set(current.map(dashboardMessageStableId));
                 const existingHubMsgIds = new Set(current.map((message) => message.hub_msg_id));
@@ -876,14 +1010,28 @@ export const useDashboardChatStore = create<DashboardChatState>()(
           }
         } catch (error) {
           console.error("[ChatStore] Failed to poll new messages:", error);
+          if (showLoading && isCurrentRoomMessageRequest(roomId, epoch, requestId, roomMessagePollRequestByRoom)) {
+            const message = error instanceof Error ? error.message : "Failed to refresh messages";
+            set((state) => ({
+              messagesErrors: { ...state.messagesErrors, [roomId]: message },
+            }));
+          }
         } finally {
+          if (!isCurrentRoomMessageRequest(roomId, epoch, requestId, roomMessagePollRequestByRoom)) return;
           roomPollInFlight.delete(roomId);
+          roomMessagePollRequestByRoom.delete(roomId);
+          if (showLoading) {
+            set((state) => ({
+              messagesLoading: { ...state.messagesLoading, [roomId]: false },
+            }));
+          }
         }
 
         const expectedHubMsgId = opts?.expectedHubMsgId ?? null;
         const retries = opts?.retries ?? 0;
         if (
-          expectedHubMsgId
+          roomMessageEpoch(roomId) === epoch
+          && expectedHubMsgId
           && retries > 0
           && !get().hasMessage(roomId, expectedHubMsgId)
         ) {
@@ -891,23 +1039,57 @@ export const useDashboardChatStore = create<DashboardChatState>()(
           await get().pollNewMessages(roomId, {
             expectedHubMsgId,
             retries: retries - 1,
+            showLoading: opts?.showLoading,
           });
         }
       },
 
       loadMoreMessages: async (roomId: string) => {
         const existing = get().messages[roomId];
-        if (!existing || existing.length === 0) return;
+        if (!existing || existing.length === 0 || get().messagesLoadingMore[roomId]) return;
 
         const oldest = existing[0];
+        const epoch = roomMessageEpoch(roomId);
+        const requestId = ++roomMessageRequestSequence;
+        roomMessageMoreRequestByRoom.set(roomId, requestId);
+        set((state) => {
+          const messagesMoreErrors = { ...state.messagesMoreErrors };
+          delete messagesMoreErrors[roomId];
+          return {
+            messagesLoadingMore: { ...state.messagesLoadingMore, [roomId]: true },
+            messagesMoreErrors,
+          };
+        });
         try {
           const result = await api.getRoomMessages(roomId, { before: oldest.hub_msg_id, limit: 50 });
-          set((state) => ({
-            messages: { ...state.messages, [roomId]: [...result.messages.reverse(), ...existing] },
-            messagesHasMore: { ...state.messagesHasMore, [roomId]: result.has_more },
-          }));
+          if (!isCurrentRoomMessageRequest(roomId, epoch, requestId, roomMessageMoreRequestByRoom)) return;
+          if (!result.has_more) fullyLoadedRoomHistory.add(roomId);
+          set((state) => {
+            if (!isCurrentRoomMessageRequest(roomId, epoch, requestId, roomMessageMoreRequestByRoom)) return state;
+            return {
+              messages: {
+                ...state.messages,
+                [roomId]: mergeLoadedRoomMessages(
+                  state.messages[roomId] ?? existing,
+                  result.messages,
+                ),
+              },
+              messagesHasMore: { ...state.messagesHasMore, [roomId]: result.has_more },
+            };
+          });
         } catch (error) {
           console.error("[ChatStore] Failed to load more messages:", error);
+          if (!isCurrentRoomMessageRequest(roomId, epoch, requestId, roomMessageMoreRequestByRoom)) return;
+          const message = error instanceof Error ? error.message : "Failed to load older messages";
+          set((state) => ({
+            messagesMoreErrors: { ...state.messagesMoreErrors, [roomId]: message },
+          }));
+        } finally {
+          if (!isCurrentRoomMessageRequest(roomId, epoch, requestId, roomMessageMoreRequestByRoom)) return;
+          roomMessageMoreRequestByRoom.delete(roomId);
+          set((state) => ({
+            messagesLoadingMore: { ...state.messagesLoadingMore, [roomId]: false },
+          }));
         }
       },
 
@@ -1072,6 +1254,9 @@ export const useDashboardChatStore = create<DashboardChatState>()(
       leaveRoom: async (roomId: string) => {
         const { token } = useDashboardSessionStore.getState();
         if (!token) return;
+        // A leave removes this cache. Invalidate every outstanding page/poll
+        // first so a late response cannot recreate the room after cleanup.
+        invalidateRoomMessageRequests(roomId);
         set({ leavingRoomId: roomId });
         try {
           await api.leaveRoom(roomId);
@@ -1082,15 +1267,31 @@ export const useDashboardChatStore = create<DashboardChatState>()(
           set((state) => {
             const messages = { ...state.messages };
             const messagesLoading = { ...state.messagesLoading };
+            const messagesErrors = { ...state.messagesErrors };
             const messagesHasMore = { ...state.messagesHasMore };
+            const messagesLoadingMore = { ...state.messagesLoadingMore };
+            const messagesMoreErrors = { ...state.messagesMoreErrors };
             const roomMembersByRoom = { ...state.roomMembersByRoom };
             const roomMembersLoading = { ...state.roomMembersLoading };
             delete messages[roomId];
             delete messagesLoading[roomId];
+            delete messagesErrors[roomId];
             delete messagesHasMore[roomId];
+            delete messagesLoadingMore[roomId];
+            delete messagesMoreErrors[roomId];
             delete roomMembersByRoom[roomId];
             delete roomMembersLoading[roomId];
-            return { leavingRoomId: null, messages, messagesLoading, messagesHasMore, roomMembersByRoom, roomMembersLoading };
+            return {
+              leavingRoomId: null,
+              messages,
+              messagesLoading,
+              messagesErrors,
+              messagesHasMore,
+              messagesLoadingMore,
+              messagesMoreErrors,
+              roomMembersByRoom,
+              roomMembersLoading,
+            };
           });
           const ui = useDashboardUIStore.getState();
           if (ui.openedRoomId === roomId || ui.focusedRoomId === roomId) {
@@ -1100,7 +1301,17 @@ export const useDashboardChatStore = create<DashboardChatState>()(
           }
           get().replaceOverview(overview);
         } catch (error) {
-          set({ leavingRoomId: null });
+          // Requests that started before the leave attempt were invalidated so
+          // a late response cannot re-create this room. If leaving fails, they
+          // will no longer run their own finally blocks, so release their UI
+          // loading flags here while keeping the existing cached messages.
+          set((state) => {
+            const messagesLoading = { ...state.messagesLoading };
+            const messagesLoadingMore = { ...state.messagesLoadingMore };
+            delete messagesLoading[roomId];
+            delete messagesLoadingMore[roomId];
+            return { leavingRoomId: null, messagesLoading, messagesLoadingMore };
+          });
           throw error;
         }
       },

--- a/frontend/src/store/useDashboardRealtimeStore.ts
+++ b/frontend/src/store/useDashboardRealtimeStore.ts
@@ -98,8 +98,13 @@ export const useDashboardRealtimeStore = create<DashboardRealtimeState>()((set) 
 
         // Owner-chat WS handles its own realtime delivery — skip Supabase
         // realtime events for the owner-chat room when the WS is connected.
-        const ownerChatWsConnected = useOwnerChatStore.getState().wsConnected;
-        const isOwnerChatEvent = userChatRoomId && currentEvent?.room_id === userChatRoomId;
+        const ownerChatState = useOwnerChatStore.getState();
+        const ownerChatWsConnected = ownerChatState.wsConnected;
+        const isOwnerChatEvent = Boolean(
+          userChatRoomId
+          && ownerChatState.roomId === userChatRoomId
+          && currentEvent?.room_id === userChatRoomId,
+        );
 
         // Handle typing events — just toggle the UI flag, no data fetching
         if (currentEvent && isTypingRealtimeEvent(currentEvent.type)) {
@@ -193,6 +198,7 @@ export const useDashboardRealtimeStore = create<DashboardRealtimeState>()((set) 
           && userChatRoomId !== openedRoomId
           && (!currentEvent || currentEvent.room_id === userChatRoomId)
           && !ownerChatWsConnected
+          && ownerChatState.roomId === userChatRoomId
         ) {
           try {
             const ocStore = useOwnerChatStore.getState();
@@ -201,8 +207,15 @@ export const useDashboardRealtimeStore = create<DashboardRealtimeState>()((set) 
             const result = newest?.hubMsgId
               ? await api.getRoomMessages(userChatRoomId, { after: newest.hubMsgId, limit: 50 })
               : await api.getRoomMessages(userChatRoomId, { limit: 50 });
-            if (result.messages.length > 0) {
-              ocStore.mergeApiMessages(result.messages, "append");
+            const currentUiState = useDashboardUIStore.getState();
+            const currentOwnerChat = useOwnerChatStore.getState();
+            if (
+              result.messages.length > 0
+              && currentUiState.userChatRoomId === userChatRoomId
+              && currentOwnerChat.roomId === userChatRoomId
+              && !currentOwnerChat.wsConnected
+            ) {
+              currentOwnerChat.mergeApiMessages(result.messages, "append");
             }
           } catch { /* non-critical */ }
         }

--- a/frontend/src/store/useDashboardUIStore.test.ts
+++ b/frontend/src/store/useDashboardUIStore.test.ts
@@ -19,4 +19,20 @@ describe("useDashboardUIStore", () => {
     expect(useDashboardUIStore.getState().messagesScope).toEqual({ type: "human" });
     expect(useDashboardUIStore.getState().messagesBotScope).toBe("all");
   });
+
+  it("does not let an older navigation completion clear a newer pending tab", () => {
+    const store = useDashboardUIStore.getState();
+    store.startPrimaryNavigation("home", "/chats/home");
+    const first = useDashboardUIStore.getState().pendingPrimaryNavigation;
+    store.startPrimaryNavigation("wallet", "/chats/wallet");
+    const second = useDashboardUIStore.getState().pendingPrimaryNavigation;
+
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    store.clearPrimaryNavigation(first!.id);
+
+    expect(useDashboardUIStore.getState().pendingPrimaryNavigation?.id).toBe(second!.id);
+    store.clearPrimaryNavigation(second!.id);
+    expect(useDashboardUIStore.getState().pendingPrimaryNavigation).toBeNull();
+  });
 });

--- a/frontend/src/store/useDashboardUIStore.ts
+++ b/frontend/src/store/useDashboardUIStore.ts
@@ -23,7 +23,14 @@ export interface DashboardUIState {
   /** Mobile-only temporary drawer for the secondary sidebar/list panel. */
   mobileSidebarOpen: boolean;
   sidebarTab: "home" | "messages" | "contacts" | "explore" | "wallet" | "activity" | "bots";
-  pendingPrimaryNavigation: { tab: DashboardUIState["sidebarTab"]; path: string } | null;
+  pendingPrimaryNavigation: {
+    id: number;
+    tab: DashboardUIState["sidebarTab"];
+    path: string;
+    startedAt: number;
+  } | null;
+  /** Monotonic token used to prevent an old navigation timer from clearing a newer one. */
+  primaryNavigationSequence: number;
   /** Currently selected owned bot (agent_id) in the My Bots tab. Null = list view. */
   selectedBotAgentId: string | null;
   /** Active sub-tab inside the My Bots tab. */
@@ -93,7 +100,7 @@ export interface DashboardUIState {
   setUserChatAgentId: (agentId: string | null) => void;
   setSidebarTab: (tab: DashboardUIState["sidebarTab"]) => void;
   startPrimaryNavigation: (tab: DashboardUIState["sidebarTab"], path: string) => void;
-  clearPrimaryNavigation: () => void;
+  clearPrimaryNavigation: (id?: number) => void;
   setMessagesPane: (pane: DashboardUIState["messagesPane"]) => void;
   setMessagesFilter: (filter: DashboardUIState["messagesFilter"]) => void;
   setMessagesScope: (scope: DashboardUIState["messagesScope"]) => void;
@@ -133,6 +140,7 @@ const initialUIState = {
   mobileSidebarOpen: false,
   sidebarTab: "messages" as DashboardUIState["sidebarTab"],
   pendingPrimaryNavigation: null as DashboardUIState["pendingPrimaryNavigation"],
+  primaryNavigationSequence: 0,
   selectedBotAgentId: null as string | null,
   myBotsTab: "bots" as DashboardUIState["myBotsTab"],
   selectedDeviceId: null as string | null,
@@ -179,8 +187,20 @@ export const useDashboardUIStore = create<DashboardUIState>()((set) => ({
         : { sidebarTab, pendingPrimaryNavigation: null }
     )),
   startPrimaryNavigation: (sidebarTab, path) =>
-    set({ sidebarTab, pendingPrimaryNavigation: { tab: sidebarTab, path } }),
-  clearPrimaryNavigation: () => set({ pendingPrimaryNavigation: null }),
+    set((state) => {
+      const id = state.primaryNavigationSequence + 1;
+      return {
+        sidebarTab,
+        primaryNavigationSequence: id,
+        pendingPrimaryNavigation: { id, tab: sidebarTab, path, startedAt: Date.now() },
+      };
+    }),
+  clearPrimaryNavigation: (id) =>
+    set((state) => {
+      if (!state.pendingPrimaryNavigation) return state;
+      if (id !== undefined && state.pendingPrimaryNavigation.id !== id) return state;
+      return { pendingPrimaryNavigation: null };
+    }),
   setMyBotsTab: (myBotsTab) =>
     set((state) => (state.myBotsTab === myBotsTab ? state : { myBotsTab })),
   setSelectedDeviceId: (selectedDeviceId) =>

--- a/frontend/src/store/useOwnerChatStore.test.ts
+++ b/frontend/src/store/useOwnerChatStore.test.ts
@@ -212,6 +212,59 @@ describe("useOwnerChatStore empty message handling", () => {
   });
 });
 
+describe("useOwnerChatStore history loading", () => {
+  beforeEach(() => {
+    mocks.getRoomMessages.mockReset();
+    useOwnerChatStore.getState().reset();
+    useDashboardChatStore.setState({
+      ownedAgentRooms: [makeOwnedAgentRoom()],
+      optimisticOwnerChatRooms: {},
+    });
+    useOwnerChatStore.getState().setRoom("rm_oc_real", "Owned bot");
+  });
+
+  it("drops an older-page response after the owner-chat room changes", async () => {
+    let resolvePage!: (result: { messages: DashboardMessage[]; has_more: boolean }) => void;
+    mocks.getRoomMessages.mockReturnValue(new Promise((resolve) => {
+      resolvePage = resolve;
+    }));
+    useOwnerChatStore.setState({
+      messages: [makeOwnerChatMessage({
+        clientId: "current-message",
+        hubMsgId: "hub_current",
+        sender: "agent",
+        senderName: "Owned bot",
+        status: "delivered",
+      })],
+      hasMore: true,
+    });
+
+    const request = useOwnerChatStore.getState().loadMore();
+    expect(useOwnerChatStore.getState().loadingMore).toBe(true);
+
+    useOwnerChatStore.getState().setRoom("rm_oc_other", "Other bot");
+    useOwnerChatStore.getState().addOptimistic(makeOwnerChatMessage({
+      clientId: "other-room-local",
+      text: "new room message",
+    }));
+    resolvePage({
+      messages: [makeDashboardMessage({
+        hub_msg_id: "hub_old_history",
+        msg_id: "msg_old_history",
+        room_id: "rm_oc_real",
+        created_at: "2026-05-19T07:00:00.000Z",
+      })],
+      has_more: false,
+    });
+    await request;
+
+    const state = useOwnerChatStore.getState();
+    expect(state.roomId).toBe("rm_oc_other");
+    expect(state.messages.map((message) => message.clientId)).toEqual(["other-room-local"]);
+    expect(state.loadingMore).toBe(false);
+  });
+});
+
 describe("useOwnerChatStore run failure handling", () => {
   beforeEach(() => {
     useOwnerChatStore.getState().reset();
@@ -527,6 +580,37 @@ describe("useOwnerChatStore stream-cache restore", () => {
     expect(streaming).toBeTruthy();
   });
 
+  it("drops a restored run when the reader switches to another Bot", async () => {
+    let resolveRun!: (run: RunStreamBlocksResponse) => void;
+    mocks.getRunStreamBlocks.mockReturnValue(new Promise((resolve) => {
+      resolveRun = resolve;
+    }));
+    useOwnerChatStore.getState().upsertMessage(
+      makeOwnerChatMessage({
+        clientId: "u1",
+        hubMsgId: "msg_trace",
+        sender: "user",
+        status: "confirmed",
+        text: "do a thing",
+        createdAt: new Date().toISOString(),
+      }),
+    );
+
+    const request = useOwnerChatStore.getState().restoreActiveRuns("ag_bot");
+    useOwnerChatStore.getState().setRoom("rm_oc_other", "Other bot");
+    useOwnerChatStore.getState().addOptimistic(makeOwnerChatMessage({
+      clientId: "other-room-local",
+      text: "new room message",
+    }));
+    resolveRun(runningRun());
+    await request;
+
+    const state = useOwnerChatStore.getState();
+    expect(state.roomId).toBe("rm_oc_other");
+    expect(state.messages.map((message) => message.clientId)).toEqual(["other-room-local"]);
+    expect(state.messages.some((message) => message.status === "streaming")).toBe(false);
+  });
+
   it("restoreActiveRuns skips uncovered user messages older than the restore window", async () => {
     // An uncovered run that never produced a reply (autonomous work) stays
     // "running" for the full run TTL; stale ones must not be resurrected.
@@ -628,5 +712,44 @@ describe("useOwnerChatStore stream-cache restore", () => {
     expect(
       useOwnerChatStore.getState().messages.some((m) => m.status === "streaming"),
     ).toBe(false);
+  });
+});
+
+describe("useOwnerChatStore reconnect reconciliation", () => {
+  beforeEach(() => {
+    mocks.getRoomMessages.mockReset();
+    useOwnerChatStore.getState().reset();
+    useDashboardChatStore.setState({
+      ownedAgentRooms: [makeOwnedAgentRoom()],
+      optimisticOwnerChatRooms: {},
+    });
+    useOwnerChatStore.getState().setRoom("rm_oc_real", "Owned bot");
+  });
+
+  it("drops a reconnect response after the reader switches rooms", async () => {
+    let resolvePage!: (result: { messages: DashboardMessage[]; has_more: boolean }) => void;
+    mocks.getRoomMessages.mockReturnValue(new Promise((resolve) => {
+      resolvePage = resolve;
+    }));
+    useOwnerChatStore.setState({
+      messages: [makeOwnerChatMessage({
+        clientId: "failed-send",
+        status: "failed",
+        error: "Connection lost",
+      })],
+    });
+
+    const request = useOwnerChatStore.getState().reconcileAfterReconnect();
+    useOwnerChatStore.getState().setRoom("rm_oc_other", "Other bot");
+    useOwnerChatStore.getState().addOptimistic(makeOwnerChatMessage({
+      clientId: "other-room-local",
+      text: "new room message",
+    }));
+    resolvePage({ messages: [makeDashboardMessage()], has_more: false });
+    await request;
+
+    const state = useOwnerChatStore.getState();
+    expect(state.roomId).toBe("rm_oc_other");
+    expect(state.messages.map((message) => message.clientId)).toEqual(["other-room-local"]);
   });
 });

--- a/frontend/src/store/useOwnerChatStore.ts
+++ b/frontend/src/store/useOwnerChatStore.ts
@@ -173,6 +173,9 @@ let loadInFlight = false;
 let loadRequestId = 0;
 /** In-flight guard to prevent concurrent loadMore calls. */
 let moreInFlight = false;
+let moreRequestId = 0;
+/** Changes whenever the active owner-chat room/session is replaced. */
+let roomSessionId = 0;
 
 // ---------------------------------------------------------------------------
 // State definition
@@ -184,6 +187,8 @@ export interface OwnerChatState {
   messages: OwnerChatMessage[];
   hasMore: boolean;
   loading: boolean;
+  loadingMore: boolean;
+  moreError: string | null;
   error: string | null;
   wsConnected: boolean;
   agentTyping: boolean;
@@ -246,6 +251,8 @@ const initialState = {
   messages: [] as OwnerChatMessage[],
   hasMore: false,
   loading: false,
+  loadingMore: false,
+  moreError: null as string | null,
   error: null as string | null,
   wsConnected: false,
   agentTyping: false,
@@ -262,7 +269,35 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
 
   // ------ Initialization ------
 
-  setRoom: (roomId, agentName) => set({ roomId, agentName }),
+  setRoom: (roomId, agentName) => {
+    if (get().roomId !== roomId) {
+      // `onAuthOk` can correct a provisional owner-chat room after the socket
+      // connects. Treat that as a true conversation switch: invalidate both
+      // requests and clear room-scoped content before the new initial page
+      // arrives, otherwise a late page (or prior messages) can bleed into the
+      // newly selected Bot conversation.
+      loadInFlight = false;
+      loadRequestId++;
+      moreInFlight = false;
+      moreRequestId++;
+      roomSessionId++;
+      set({
+        roomId,
+        agentName,
+        messages: [],
+        hasMore: false,
+        loading: false,
+        loadingMore: false,
+        moreError: null,
+        error: null,
+        agentTyping: false,
+        activeTraceId: null,
+        replyingTo: null,
+      });
+      return;
+    }
+    set({ roomId, agentName, loadingMore: false, moreError: null });
+  },
 
   setReplyingTo: (msg) => set({ replyingTo: msg }),
 
@@ -344,11 +379,23 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
           roomId,
         };
       });
-      syncOwnerChatRoomSummary(roomId, get().messages);
+      if (thisRequestId === loadRequestId && get().roomId === roomId) {
+        syncOwnerChatRoomSummary(roomId, get().messages);
+      }
     } catch (err: any) {
-      set({ error: err?.message || "Failed to load messages", loading: false });
+      // A request from a previously selected Bot can fail after the reader has
+      // already switched rooms. Keep that failure scoped to its own request so
+      // it never replaces the active conversation with an unrelated error.
+      if (thisRequestId === loadRequestId && get().roomId === roomId) {
+        set({ error: err?.message || "Failed to load messages", loading: false });
+      }
     } finally {
-      loadInFlight = false;
+      // Do not release the global guard for a newer request. Without this
+      // token check, an old room response could allow duplicate initial loads
+      // while the current room was still fetching.
+      if (thisRequestId === loadRequestId) {
+        loadInFlight = false;
+      }
     }
   },
 
@@ -361,26 +408,51 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
     if (!oldest?.hubMsgId) return;
 
     moreInFlight = true;
+    const thisRequestId = ++moreRequestId;
+    set({ loadingMore: true, moreError: null });
     try {
       const result = await api.getRoomMessages(roomId, {
         before: oldest.hubMsgId,
         limit: 50,
       });
+      // Switching bots resets the store in an effect. A late response from the
+      // old room must never prepend its history into the new conversation.
+      if (thisRequestId !== moreRequestId || get().roomId !== roomId) return;
+
       const agentName = get().agentName;
       const older = result.messages
         .reverse()
         .map((m) => dashboardMsgToOwnerChat(m, agentName))
         .filter(hasVisibleOwnerChatContent);
 
-      set((state) => ({
-        messages: [...older, ...state.messages],
-        hasMore: result.has_more,
-      }));
-      syncOwnerChatRoomSummary(roomId, get().messages);
+      set((state) => {
+        if (state.roomId !== roomId || thisRequestId !== moreRequestId) return state;
+        const currentHubIds = new Set(
+          state.messages
+            .map((message) => message.hubMsgId)
+            .filter((hubMsgId): hubMsgId is string => Boolean(hubMsgId)),
+        );
+        const dedupedOlder = older.filter((message) => !message.hubMsgId || !currentHubIds.has(message.hubMsgId));
+        return {
+          messages: [...dedupedOlder, ...state.messages],
+          hasMore: result.has_more,
+        };
+      });
+      if (thisRequestId === moreRequestId && get().roomId === roomId) {
+        syncOwnerChatRoomSummary(roomId, get().messages);
+      }
     } catch (err) {
       console.error("[OwnerChatStore] Failed to load more:", err);
+      if (thisRequestId === moreRequestId && get().roomId === roomId) {
+        set({ moreError: err instanceof Error ? err.message : "Failed to load older messages" });
+      }
     } finally {
-      moreInFlight = false;
+      if (thisRequestId === moreRequestId) {
+        moreInFlight = false;
+      }
+      if (thisRequestId === moreRequestId && get().roomId === roomId) {
+        set({ loadingMore: false });
+      }
     }
   },
 
@@ -715,7 +787,9 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
 
   restoreActiveRuns: async (agentId) => {
     if (!agentId) return;
-    const { messages } = get();
+    const { roomId, messages } = get();
+    if (!roomId) return;
+    const sessionId = roomSessionId;
 
     // Trace ids already covered by a streaming placeholder or a finalized
     // agent reply — never re-restore those.
@@ -747,6 +821,9 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
       candidates.map(async (traceId) => {
         try {
           const run = await api.getRunStreamBlocks(traceId, agentId);
+          // A restore can outlive the selected room. It must not create a
+          // streaming placeholder in whichever Bot the reader opened later.
+          if (roomSessionId !== sessionId || get().roomId !== roomId) return;
           // Discard stale result if the trace got covered while we were fetching.
           const covered = get().messages.some(
             (m) =>
@@ -873,6 +950,7 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
   reconcileAfterReconnect: async () => {
     const { roomId, messages, agentName } = get();
     if (!roomId) return;
+    const sessionId = roomSessionId;
 
     // Find failed user messages that were caused by disconnect (candidates for reconciliation)
     const failedMsgs = messages.filter(
@@ -887,6 +965,7 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
         ? await api.getRoomMessages(roomId, { after: newest.hubMsgId, limit: 50 })
         : await api.getRoomMessages(roomId, { limit: 50 });
 
+      if (roomSessionId !== sessionId || get().roomId !== roomId) return;
       if (result.messages.length === 0) return;
 
       const serverMsgs = result.messages
@@ -894,6 +973,7 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
         .filter(hasVisibleOwnerChatContent);
 
       set((state) => {
+        if (roomSessionId !== sessionId || state.roomId !== roomId) return state;
         const existingHubIds = new Set(
           state.messages.filter((m) => m.hubMsgId).map((m) => m.hubMsgId!)
         );
@@ -971,6 +1051,8 @@ export const useOwnerChatStore = create<OwnerChatState>()((set, get) => ({
     loadInFlight = false;
     moreInFlight = false;
     loadRequestId++;
+    moreRequestId++;
+    roomSessionId++;
     set({ ...initialState });
   },
 }));


### PR DESCRIPTION
## Summary

- replace generic chat placeholders with layout-matched loading states and transitions
- preserve cached conversations during refresh with clear loading and retry affordances
- harden room switching, pagination, reconnect, and owner-chat WebSocket races

## Validation

- npm test -- --run src/store/useDashboardChatStore.test.ts src/store/useOwnerChatStore.test.ts src/store/useDashboardUIStore.test.ts src/components/dashboard/MessageList.test.ts
- npm run build