### PR TITLE
fix(frontend): normalize dashboard overlay hierarchy

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -117,6 +117,41 @@ body {
   z-index: 1;
 }
 
+/* Viewport-level dashboard overlays are portaled here so their z-index is
+ * compared globally, rather than inside Sidebar or a pane's local stacking
+ * context. Dashboard panes deliberately create local stacking contexts, so
+ * this host must sit above every ordinary app surface. The app-wide confirm
+ * dialog (z-1100) and image preview layer (z-9999) remain above it. */
+#dashboard-overlay-root {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  pointer-events: none;
+  isolation: isolate;
+}
+
+#dashboard-overlay-root > * {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+#dashboard-overlay-root > .dashboard-overlay-layer-modal {
+  z-index: 1;
+}
+
+#dashboard-overlay-root > .dashboard-overlay-layer-nested {
+  z-index: 2;
+}
+
+#dashboard-overlay-root > .dashboard-overlay-layer-critical {
+  z-index: 3;
+}
+
+#dashboard-overlay-root > * > * {
+  pointer-events: auto;
+}
+
 .dashboard-main {
   background: transparent;
 }
@@ -139,6 +174,21 @@ body {
 .liquid-menu,
 .liquid-composer {
   border-color: var(--liquid-border);
+}
+
+/* Persistent dashboard columns sit alongside one another. Giving each one a
+ * large floating-card shadow made those shadows accumulate from left to right
+ * (rail → grouping → message list → chat), which read as a grey gradient
+ * rather than clear structure. Keep layout surfaces flat and let their
+ * borders define the split; only transient surfaces retain elevation. */
+.liquid-rail,
+.liquid-panel,
+.liquid-toolbar {
+  box-shadow: inset 0 1px 0 var(--liquid-highlight);
+}
+
+.liquid-menu,
+.liquid-composer {
   box-shadow: var(--liquid-shadow);
 }
 
@@ -183,6 +233,13 @@ html[data-theme="light"] .dashboard-brand-link:hover {
 .liquid-dialog,
 .liquid-empty-state {
   background: var(--liquid-surface);
+}
+
+/* A dialog is the foreground plane, not another translucent content card.
+ * Use the stronger surface so dimmed content remains contextual without
+ * competing with the active task, especially in the light theme. */
+.liquid-dialog {
+  background: var(--liquid-surface-strong);
 }
 
 .liquid-drawer,
@@ -253,15 +310,11 @@ html[data-theme="dark"] .liquid-list-row.liquid-room-row-selected {
 }
 
 .liquid-scrim {
-  background: rgba(35, 55, 79, 0.24);
+  background: rgba(35, 55, 79, 0.42);
 }
 
 html[data-theme="dark"] .liquid-scrim {
-  background: rgba(3, 10, 20, 0.58);
-}
-
-.liquid-toolbar {
-  box-shadow: 0 12px 28px rgba(42, 69, 101, 0.10), inset 0 1px 0 var(--liquid-highlight);
+  background: rgba(3, 10, 20, 0.62);
 }
 
 .liquid-message {

--- a/frontend/src/components/dashboard/AddDeviceDialog.tsx
+++ b/frontend/src/components/dashboard/AddDeviceDialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 /**
  * [INPUT]: daemon store refresh state + DeviceConnectPanel shared onboarding UI
  * [OUTPUT]: AddDeviceDialog — standalone add-device modal using the same device binding panel as CreateAgentDialog
@@ -18,7 +19,9 @@ interface AddDeviceDialogProps {
   onClose: () => void;
 }
 
-export default function AddDeviceDialog({ onClose }: AddDeviceDialogProps) {
+export default withDashboardOverlayPortal(AddDeviceDialog);
+
+function AddDeviceDialog({ onClose }: AddDeviceDialogProps) {
   const locale = useLanguage();
   const daemons = useDaemonStore((s) => s.daemons);
   const loading = useDaemonStore((s) => s.loading);

--- a/frontend/src/components/dashboard/AddFriendModal.tsx
+++ b/frontend/src/components/dashboard/AddFriendModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ArrowLeft, Check, Copy, Loader2, Search } from "lucide-react";
 import { api, humansApi } from "@/lib/api";
@@ -29,7 +30,9 @@ type PeerResult = {
   bio: string | null;
 };
 
-export default function AddFriendModal({ onClose }: AddFriendModalProps) {
+export default withDashboardOverlayPortal(AddFriendModal);
+
+function AddFriendModal({ onClose }: AddFriendModalProps) {
   const locale = useLanguage();
   const t = addFriendModal[locale];
   const tc = common[locale];

--- a/frontend/src/components/dashboard/AddRoomMemberModal.tsx
+++ b/frontend/src/components/dashboard/AddRoomMemberModal.tsx
@@ -6,6 +6,7 @@
  */
 "use client";
 
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Loader2, X } from "lucide-react";
 import { humansApi } from "@/lib/api";
@@ -35,7 +36,9 @@ interface AddRoomMemberModalProps {
 const EMPTY_CONTACTS: ContactInfo[] = [];
 const EMPTY_AGENTS: UserAgent[] = [];
 
-export default function AddRoomMemberModal({
+export default withDashboardOverlayPortal(AddRoomMemberModal, "nested");
+
+function AddRoomMemberModal({
   roomId,
   existingMemberIds,
   onClose,

--- a/frontend/src/components/dashboard/AgentCardModal.tsx
+++ b/frontend/src/components/dashboard/AgentCardModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 /**
  * [INPUT]: 依赖 agent 资料与联系人关系状态，依赖 i18n 提供文案
  * [OUTPUT]: 对外提供带 animejs 进出场动效的 AgentCardModal 统一 agent 详情模态框
@@ -41,7 +42,9 @@ function getModalParts(panel: HTMLElement | null): HTMLElement[] {
   return panel ? Array.from(panel.querySelectorAll<HTMLElement>(PROFILE_MODAL_PART_SELECTOR)) : [];
 }
 
-export default function AgentCardModal({
+export default withDashboardOverlayPortal(AgentCardModal);
+
+function AgentCardModal({
   isOpen,
   agent,
   loading = false,

--- a/frontend/src/components/dashboard/AgentChannelsTab.tsx
+++ b/frontend/src/components/dashboard/AgentChannelsTab.tsx
@@ -38,6 +38,7 @@ import {
 } from "@/store/useAgentGatewayStore";
 import { MobileBotCordLoading } from "@/components/ui/BotCordLoader";
 import { animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from "@/lib/anime";
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 
 interface Props {
   agentId: string;
@@ -498,7 +499,7 @@ export default function AgentChannelsTab({ agentId, hostingKind }: Props) {
       )}
 
       {pendingDelete && (
-        <DeleteConfirmDialog
+        <PortaledDeleteConfirmDialog
           gateway={pendingDelete}
           busy={busyId === pendingDelete.id}
           onCancel={() => setPendingDelete(null)}
@@ -940,7 +941,7 @@ function TelegramAddForm({
         </button>
       </div>
       {tokenGuideOpen && (
-        <TelegramTokenGuideDialog onClose={() => setTokenGuideOpen(false)} />
+        <PortaledTelegramTokenGuideDialog onClose={() => setTokenGuideOpen(false)} />
       )}
     </div>
   );
@@ -2737,3 +2738,6 @@ function DeleteConfirmDialog({
     </div>
   );
 }
+
+const PortaledTelegramTokenGuideDialog = withDashboardOverlayPortal(TelegramTokenGuideDialog, "nested");
+const PortaledDeleteConfirmDialog = withDashboardOverlayPortal(DeleteConfirmDialog, "nested");

--- a/frontend/src/components/dashboard/AgentGateModal.tsx
+++ b/frontend/src/components/dashboard/AgentGateModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 /**
  * [INPUT]: 依赖 react 的 useEffect/useRef/useState，依赖 userApi 轮询当前用户 agent 列表
  * [OUTPUT]: 对外提供 AgentGateModal 组件，在登录但无 agent 时强制阻塞 `/chats` 并自动等待可用身份出现
@@ -26,7 +27,9 @@ function pickPreferredAgent(agents: UserAgent[]): UserAgent | null {
   return agents.find((agent) => agent.is_default) ?? agents[0];
 }
 
-export default function AgentGateModal({ onAgentReady }: AgentGateModalProps) {
+export default withDashboardOverlayPortal(AgentGateModal, "critical");
+
+function AgentGateModal({ onAgentReady }: AgentGateModalProps) {
   const locale = useLanguage();
   const t = agentGateModal[locale];
   const [isResolving, setIsResolving] = useState(false);

--- a/frontend/src/components/dashboard/AgentProfileEditModal.tsx
+++ b/frontend/src/components/dashboard/AgentProfileEditModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Loader2, Settings, Trash2, X } from "lucide-react";
 import { userApi } from "@/lib/api";
@@ -18,7 +19,9 @@ interface AgentProfileEditModalProps {
   onSaved?: () => void;
 }
 
-export default function AgentProfileEditModal({
+export default withDashboardOverlayPortal(AgentProfileEditModal);
+
+function AgentProfileEditModal({
   agentId,
   initialDisplayName,
   initialBio,

--- a/frontend/src/components/dashboard/AgentSettingsDrawer.tsx
+++ b/frontend/src/components/dashboard/AgentSettingsDrawer.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Bell, Bot, Clock, FileText, Loader2, MessageSquare, Plug, RefreshCw, Shield, Sparkles, Trash2, User, UserRound, X } from "lucide-react";
 import { apiFetch, userApi } from "@/lib/api";
@@ -272,7 +273,9 @@ function SummaryTile({
   );
 }
 
-export default function AgentSettingsDrawer({
+export default withDashboardOverlayPortal(AgentSettingsDrawer);
+
+function AgentSettingsDrawer({
   agentId,
   displayName,
   bio,

--- a/frontend/src/components/dashboard/BotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/BotDetailDrawer.tsx
@@ -45,6 +45,7 @@ import { CompositeAvatar } from "./CompositeAvatar";
 import BotWalletTab from "./BotWalletTab";
 import DashboardSelect from "./DashboardSelect";
 import AgentSkillsTab from "./AgentSkillsTab";
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 import { mergeRuntimeFileContentResult, runtimeFileNeedsContentLoad } from "@/lib/runtime-files";
 
 type TabKey = "overview" | "wallet" | "settings" | "skills" | "files";
@@ -90,7 +91,7 @@ interface BotFriendRoom {
  * Right-side drawer for a single owned bot.
  * Top-level tabs keep the drawer compact: 概览 / 钱包 / 设置 / 文件.
  */
-export default memo(BotDetailDrawer);
+export default memo(withDashboardOverlayPortal(BotDetailDrawer));
 
 function BotDetailDrawer() {
   const router = useRouter();

--- a/frontend/src/components/dashboard/CreateAgentDialog.tsx
+++ b/frontend/src/components/dashboard/CreateAgentDialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 /**
  * [INPUT]: useDaemonStore for daemon/runtime discovery + provision_agent dispatch; i18n createAgentDialog
  * [OUTPUT]: CreateAgentDialog — picks a daemon + runtime, provisions a new agent on that daemon
@@ -259,7 +260,9 @@ function StepperPill({
   );
 }
 
-export default function CreateAgentDialog({
+export default withDashboardOverlayPortal(CreateAgentDialog);
+
+function CreateAgentDialog({
   onClose,
   onSuccess,
   preselectedDaemonId,

--- a/frontend/src/components/dashboard/CreateRoomModal.tsx
+++ b/frontend/src/components/dashboard/CreateRoomModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 /**
  * [INPUT]: 依赖 humansApi 的创建房间能力，依赖 dashboard/session store 提供联系人、Bot 与当前身份
  * [OUTPUT]: 对外提供 CreateRoomModal 组件，完成房间名称、描述与初始成员提交
@@ -26,7 +27,9 @@ interface CreateRoomModalProps {
   onCreated?: (room: HumanRoomSummary) => void;
 }
 
-export default function CreateRoomModal({ onClose, onCreated }: CreateRoomModalProps) {
+export default withDashboardOverlayPortal(CreateRoomModal);
+
+function CreateRoomModal({ onClose, onCreated }: CreateRoomModalProps) {
   const locale = useLanguage();
   const t = createRoomModal[locale];
   const tc = common[locale];

--- a/frontend/src/components/dashboard/CredentialResetDialog.tsx
+++ b/frontend/src/components/dashboard/CredentialResetDialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 /**
  * [INPUT]: 依赖 userApi 签发 reset_code，依赖 onboarding prompt 模板生成给 OpenClaw 的重置指令
  * [OUTPUT]: 对外提供 CredentialResetDialog，负责在 chats 左下角发起 Bot credential 重置流程
@@ -20,7 +21,9 @@ interface CredentialResetDialogProps {
   onClose: () => void;
 }
 
-export default function CredentialResetDialog({
+export default withDashboardOverlayPortal(CredentialResetDialog);
+
+function CredentialResetDialog({
   agentId,
   onClose,
 }: CredentialResetDialogProps) {

--- a/frontend/src/components/dashboard/DMSettingsModal.tsx
+++ b/frontend/src/components/dashboard/DMSettingsModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 /**
  * [INPUT]: 依赖 dashboard i18n 文案、contacts API 与 CopyableId 展示 DM 对侧或自有 Agent 的身份信息
  * [OUTPUT]: 对外提供 DMSettingsModal 组件，渲染私聊设置弹窗并支持解除好友关系
@@ -28,7 +29,9 @@ interface DMSettingsModalProps {
   onContactRemoved?: () => void;
 }
 
-export default function DMSettingsModal({
+export default withDashboardOverlayPortal(DMSettingsModal);
+
+function DMSettingsModal({
   contact,
   ownAgentName,
   ownAgentId,

--- a/frontend/src/components/dashboard/DashboardOverlayPortal.test.ts
+++ b/frontend/src/components/dashboard/DashboardOverlayPortal.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { getDashboardOverlayStackIndex } from "./DashboardOverlayPortal";
+
+describe("getDashboardOverlayStackIndex", () => {
+  it("keeps a later overlay above an earlier overlay in the same layer", () => {
+    expect(getDashboardOverlayStackIndex("modal", 2)).toBeGreaterThan(
+      getDashboardOverlayStackIndex("modal", 1),
+    );
+  });
+
+  it("keeps nested and critical overlays above normal modals", () => {
+    const newestModal = getDashboardOverlayStackIndex("modal", 99_999);
+
+    expect(getDashboardOverlayStackIndex("nested", 1)).toBeGreaterThan(newestModal);
+    expect(getDashboardOverlayStackIndex("critical", 1)).toBeGreaterThan(
+      getDashboardOverlayStackIndex("nested", 99_999),
+    );
+  });
+});

--- a/frontend/src/components/dashboard/DashboardOverlayPortal.tsx
+++ b/frontend/src/components/dashboard/DashboardOverlayPortal.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+/**
+ * [INPUT]: receives a viewport-level dashboard overlay as children
+ * [OUTPUT]: renders it in the shared overlay host, outside local stacking contexts
+ * [POS]: dashboard-wide escape hatch for dialogs, drawers, and blocking scrims
+ * [PROTOCOL]: keep the overlay root itself responsible for its z-index; use this
+ * component for full-viewport overlays, not anchored menus or tooltips
+ */
+
+import { useLayoutEffect, useRef, useState } from "react";
+import type { ComponentType, ReactNode } from "react";
+import { createPortal } from "react-dom";
+
+const OVERLAY_HOST_ID = "dashboard-overlay-root";
+
+const OVERLAY_LAYER_STACK_BASE: Record<DashboardOverlayLayer, number> = {
+  modal: 1_000_000,
+  nested: 2_000_000,
+  critical: 3_000_000,
+};
+
+let nextOverlayOpenOrder = 0;
+
+/**
+ * Gives every visible overlay a deterministic position in the global stack.
+ * A later modal must win over an earlier modal even when their React owners
+ * live in different dashboard panes.
+ */
+export function getDashboardOverlayStackIndex(
+  layer: DashboardOverlayLayer,
+  openOrder: number,
+): number {
+  return OVERLAY_LAYER_STACK_BASE[layer] + openOrder;
+}
+
+function claimDashboardOverlayStackIndex(layer: DashboardOverlayLayer): number {
+  nextOverlayOpenOrder += 1;
+  return getDashboardOverlayStackIndex(layer, nextOverlayOpenOrder);
+}
+
+function getOverlayHost(): HTMLElement {
+  const existing = document.getElementById(OVERLAY_HOST_ID);
+  if (existing) return existing;
+
+  const host = document.createElement("div");
+  host.id = OVERLAY_HOST_ID;
+  host.setAttribute("aria-live", "off");
+  document.body.appendChild(host);
+  return host;
+}
+
+interface DashboardOverlayPortalProps {
+  children: ReactNode;
+  layer?: DashboardOverlayLayer;
+}
+
+export type DashboardOverlayLayer = "modal" | "nested" | "critical";
+
+export default function DashboardOverlayPortal({
+  children,
+  layer = "modal",
+}: DashboardOverlayPortalProps) {
+  const [host, setHost] = useState<HTMLElement | null>(null);
+  const [stackIndex, setStackIndex] = useState<number | null>(null);
+  const layerRef = useRef<HTMLDivElement>(null);
+  const isActiveRef = useRef(false);
+
+  // Render in place for SSR, then move before the browser paints. This keeps
+  // the modal's existing ref-driven enter animations intact while avoiding a
+  // hydration-only portal branch.
+  useLayoutEffect(() => {
+    setHost(getOverlayHost());
+  }, []);
+
+  // Several dashboard overlays are mounted permanently and only render their
+  // scrim when store state opens them. Watch the rendered DOM rather than the
+  // HOC's mount order, so an overlay opened later always rises above its peers.
+  useLayoutEffect(() => {
+    const layerNode = layerRef.current;
+    if (!layerNode) return;
+
+    const syncActiveState = () => {
+      const isActive = layerNode.childElementCount > 0;
+      if (isActive && !isActiveRef.current) {
+        setStackIndex(claimDashboardOverlayStackIndex(layer));
+      } else if (!isActive && isActiveRef.current) {
+        setStackIndex(null);
+      }
+      isActiveRef.current = isActive;
+    };
+
+    syncActiveState();
+    const observer = new MutationObserver(syncActiveState);
+    observer.observe(layerNode, { childList: true });
+    return () => observer.disconnect();
+  }, [host, layer]);
+
+  return host
+    ? createPortal(
+      <div
+        ref={layerRef}
+        className={`dashboard-overlay-layer dashboard-overlay-layer-${layer}`}
+        style={stackIndex === null ? undefined : { zIndex: stackIndex }}
+      >
+        {children}
+      </div>,
+      host,
+    )
+    : children;
+}
+
+/**
+ * Keep full-screen overlay implementations self-contained: callers do not
+ * need to know whether an action originated in the sidebar, a drawer, or the
+ * main pane in order to get correct viewport-level stacking.
+ */
+export function withDashboardOverlayPortal<Props extends object>(
+  OverlayComponent: ComponentType<Props>,
+  layer: DashboardOverlayLayer = "modal",
+) {
+  function PortaledDashboardOverlay(props: Props) {
+    return (
+      <DashboardOverlayPortal layer={layer}>
+        <OverlayComponent {...props} />
+      </DashboardOverlayPortal>
+    );
+  }
+
+  PortaledDashboardOverlay.displayName = `withDashboardOverlayPortal(${OverlayComponent.displayName || OverlayComponent.name || "Overlay"})`;
+  return PortaledDashboardOverlay;
+}

--- a/frontend/src/components/dashboard/DeviceDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/DeviceDetailDrawer.tsx
@@ -26,12 +26,13 @@ import ForwardModal from "@/components/dashboard/ForwardModal";
 import { downloadApiFile } from "@/lib/api";
 import { animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from "@/lib/anime";
 import BotAvatar from "./BotAvatar";
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 
 /**
  * Right-edge slide-out drawer for one device's details + settings.
  * Driven by `selectedDeviceId` in the UI store; close = set it to null.
  */
-export default memo(DeviceDetailDrawer);
+export default memo(withDashboardOverlayPortal(DeviceDetailDrawer));
 
 function DeviceDetailDrawer() {
   const {

--- a/frontend/src/components/dashboard/ForwardModal.tsx
+++ b/frontend/src/components/dashboard/ForwardModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { CheckCircle2, FileArchive, Loader2, MessageSquare, Users, User, X } from "lucide-react";
@@ -30,7 +31,9 @@ interface ForwardModalProps {
   onClose: () => void;
 }
 
-export default function ForwardModal({ quoteText, sourceFile, onClose }: ForwardModalProps) {
+export default withDashboardOverlayPortal(ForwardModal, "nested");
+
+function ForwardModal({ quoteText, sourceFile, onClose }: ForwardModalProps) {
   const overlayRef = useRef<HTMLDivElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const statusRef = useRef<HTMLParagraphElement>(null);

--- a/frontend/src/components/dashboard/FriendInviteModal.tsx
+++ b/frontend/src/components/dashboard/FriendInviteModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 /**
  * [INPUT]: 依赖邀请 API 创建好友邀请码，依赖 onboarding Prompt 模板生成给 AI 的邀请文案
  * [OUTPUT]: 对外提供 FriendInviteModal 组件，展示好友邀请链接与复制 Prompt 操作
@@ -18,7 +19,9 @@ import { buildFriendInvitePrompt, rebaseToCurrentOrigin } from "@/lib/onboarding
 import { friendInviteModal } from "@/lib/i18n/translations/dashboard";
 import { Loader2 } from "lucide-react";
 
-export default function FriendInviteModal({ onClose }: { onClose: () => void }) {
+export default withDashboardOverlayPortal(FriendInviteModal);
+
+function FriendInviteModal({ onClose }: { onClose: () => void }) {
   const locale = useLanguage();
   const tc = common[locale];
   const t = friendInviteModal[locale];

--- a/frontend/src/components/dashboard/HumanCardModal.tsx
+++ b/frontend/src/components/dashboard/HumanCardModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 /**
  * [INPUT]: 依赖 human 资料与联系人关系状态，依赖 i18n 提供文案
  * [OUTPUT]: 对外提供带 animejs 进出场动效的 HumanCardModal 统一 human 详情模态框
@@ -37,7 +38,9 @@ function getModalParts(panel: HTMLElement | null): HTMLElement[] {
   return panel ? Array.from(panel.querySelectorAll<HTMLElement>(PROFILE_MODAL_PART_SELECTOR)) : [];
 }
 
-export default function HumanCardModal({
+export default withDashboardOverlayPortal(HumanCardModal);
+
+function HumanCardModal({
   isOpen,
   human,
   loading = false,

--- a/frontend/src/components/dashboard/HumanProfileEditModal.tsx
+++ b/frontend/src/components/dashboard/HumanProfileEditModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Loader2, UserRound, X } from "lucide-react";
 import { humansApi } from "@/lib/api";
@@ -11,7 +12,9 @@ interface HumanProfileEditModalProps {
   onClose: () => void;
 }
 
-export default function HumanProfileEditModal({ onClose }: HumanProfileEditModalProps) {
+export default withDashboardOverlayPortal(HumanProfileEditModal);
+
+function HumanProfileEditModal({ onClose }: HumanProfileEditModalProps) {
   const locale = useLanguage();
   const human = useDashboardSessionStore((s) => s.human);
   const setHuman = useDashboardSessionStore((s) => s.setHuman);

--- a/frontend/src/components/dashboard/MemberActionsMenu.tsx
+++ b/frontend/src/components/dashboard/MemberActionsMenu.tsx
@@ -14,6 +14,7 @@ import { animateIfMotion, animateOverlayPanelEnter, animateOverlayPanelExit, cle
 import { useLanguage } from "@/lib/i18n";
 import { agentBrowser } from "@/lib/i18n/translations/dashboard";
 import { useConfirm } from "@/store/useConfirmStore";
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 
 interface Props {
   roomId: string;
@@ -128,7 +129,7 @@ export default function MemberActionsMenu({
         </div>
       )}
       {permOpen && (
-        <PermissionsDialog
+        <PortaledPermissionsDialog
           roomId={roomId}
           member={member}
           onClose={() => setPermOpen(false)}
@@ -241,6 +242,8 @@ function PermissionsDialog({
     </div>
   );
 }
+
+const PortaledPermissionsDialog = withDashboardOverlayPortal(PermissionsDialog, "nested");
 
 function TriToggle({
   label, value, onChange, t,

--- a/frontend/src/components/dashboard/MessageBubble.tsx
+++ b/frontend/src/components/dashboard/MessageBubble.tsx
@@ -474,7 +474,7 @@ function MentionChip({
       {tooltipPosition && typeof document !== "undefined" && createPortal(
         <span
           ref={tooltipRef}
-          className="liquid-menu pointer-events-none fixed z-[9999] w-64 rounded-xl border border-glass-border bg-deep-black-light p-3 text-left shadow-xl shadow-black/30"
+          className="liquid-menu pointer-events-none fixed z-[900] w-64 rounded-xl border border-glass-border bg-deep-black-light p-3 text-left shadow-xl shadow-black/30"
           style={{ left: tooltipPosition.left, top: tooltipPosition.top }}
         >
           <span className="mb-1 flex items-center gap-2">
@@ -950,7 +950,7 @@ function MessageBubble({
       {menuOpen && menuPosition && typeof document !== "undefined" && createPortal(
         <div
           ref={actionMenuRef}
-          className="liquid-menu fixed z-[9999] min-w-[112px] rounded-xl border border-glass-border bg-deep-black-light py-1 shadow-xl"
+          className="liquid-menu fixed z-[900] min-w-[112px] rounded-xl border border-glass-border bg-deep-black-light py-1 shadow-xl"
           style={{ left: menuPosition.left, top: menuPosition.top }}
           onMouseDown={(event) => event.stopPropagation()}
         >

--- a/frontend/src/components/dashboard/PeerBotDetailDrawer.tsx
+++ b/frontend/src/components/dashboard/PeerBotDetailDrawer.tsx
@@ -9,6 +9,7 @@ import { animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from 
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import BotAvatar from "./BotAvatar";
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 
 const POLICY_LABEL: Record<string, string> = {
   open: "开放",
@@ -29,7 +30,7 @@ function formatDate(iso?: string): string {
  * Right-side drawer for a peer (non-owned) bot. Shows public info only.
  * No tabs — flat sections.
  */
-export default memo(PeerBotDetailDrawer);
+export default memo(withDashboardOverlayPortal(PeerBotDetailDrawer));
 
 function PeerBotDetailDrawer() {
   const router = useRouter();

--- a/frontend/src/components/dashboard/PlanChangeConfirmDialog.tsx
+++ b/frontend/src/components/dashboard/PlanChangeConfirmDialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Loader2, X } from "lucide-react";
 import { animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from "@/lib/anime";
@@ -15,7 +16,9 @@ interface PlanChangeConfirmDialogProps {
   onConfirm: () => void;
 }
 
-export default function PlanChangeConfirmDialog({
+export default withDashboardOverlayPortal(PlanChangeConfirmDialog, "nested");
+
+function PlanChangeConfirmDialog({
   fromLabel,
   toLabel,
   affectedCount,

--- a/frontend/src/components/dashboard/RoomHumanComposer.tsx
+++ b/frontend/src/components/dashboard/RoomHumanComposer.tsx
@@ -15,6 +15,7 @@ import { useMentionCandidates } from "@/hooks/useMentionCandidates";
 import { CornerUpLeft, Loader2, X } from "lucide-react";
 import DashboardSelect from "./DashboardSelect";
 import { animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from "@/lib/anime";
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 
 interface RoomHumanComposerProps {
   roomId: string;
@@ -226,6 +227,8 @@ function RoomTransferDialog({ roomId, members, senderIdentity, onClose, onSucces
     </div>
   );
 }
+
+const PortaledRoomTransferDialog = withDashboardOverlayPortal(RoomTransferDialog, "nested");
 
 export async function uploadRoomAttachments(
   files: File[],
@@ -479,7 +482,7 @@ export default function RoomHumanComposer({ roomId, topicId = null }: RoomHumanC
       />
       {error && <p className="text-[11px] text-red-400">{error}</p>}
       {transferOpen ? (
-        <RoomTransferDialog
+        <PortaledRoomTransferDialog
           roomId={roomId}
           members={members}
           senderIdentity={senderIdentity}

--- a/frontend/src/components/dashboard/RoomMemberSettingsModal.tsx
+++ b/frontend/src/components/dashboard/RoomMemberSettingsModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { useRouter } from "nextjs-toploader/app";
@@ -20,7 +21,9 @@ interface RoomMemberSettingsModalProps {
   onClose: () => void;
 }
 
-export default function RoomMemberSettingsModal({
+export default withDashboardOverlayPortal(RoomMemberSettingsModal, "nested");
+
+function RoomMemberSettingsModal({
   roomId,
   roomName,
   roomDescription,

--- a/frontend/src/components/dashboard/RoomPolicyModal.tsx
+++ b/frontend/src/components/dashboard/RoomPolicyModal.tsx
@@ -17,7 +17,6 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
 import { Bell, Loader2, RotateCcw, X } from "lucide-react";
 import { api } from "@/lib/api";
 import type { PublicRoomMember } from "@/lib/types";
@@ -28,6 +27,7 @@ import {
   type RoomPolicyEffective,
 } from "@/store/usePolicyStore";
 import { animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from "@/lib/anime";
+import DashboardOverlayPortal from "./DashboardOverlayPortal";
 
 const ATTENTION_OPTIONS: { value: AttentionMode; label: string; hint: string }[] = [
   { value: "always", label: "所有消息", hint: "本房间任何新消息都会唤醒 Bot" },
@@ -350,7 +350,7 @@ export default function RoomPolicyModal({
   );
 
   if (!mounted) return null;
-  return createPortal(modal, document.body);
+  return <DashboardOverlayPortal layer="nested">{modal}</DashboardOverlayPortal>;
 }
 
 function EffectiveBadge({

--- a/frontend/src/components/dashboard/RoomSettingsModal.tsx
+++ b/frontend/src/components/dashboard/RoomSettingsModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChevronDown, Loader2, Search, Trash2, X } from "lucide-react";
 import { useRouter } from "nextjs-toploader/app";
@@ -153,7 +154,11 @@ function formatWholeCoinAmount(amountMinor: string | number): string {
   return Number.isInteger(coins) ? String(coins) : String(coins);
 }
 
-export default function RoomSettingsModal({
+const PortaledActionConfirmDialog = withDashboardOverlayPortal(ActionConfirmDialog, "nested");
+
+export default withDashboardOverlayPortal(RoomSettingsModal);
+
+function RoomSettingsModal({
   roomId,
   roomOwnerType,
   viewerMode,
@@ -1317,7 +1322,7 @@ export default function RoomSettingsModal({
       )}
 
       {leaveDialogOpen && !isOwner && (
-        <ActionConfirmDialog
+        <PortaledActionConfirmDialog
           title={t.leaveRoomConfirmTitle}
           description={t.leaveRoomConfirmDescription}
           warning={t.leaveRoomWarning}
@@ -1354,7 +1359,7 @@ export default function RoomSettingsModal({
       )}
 
       {dissolveDialogOpen && isOwner && (
-        <ActionConfirmDialog
+        <PortaledActionConfirmDialog
           title={t.dissolveRoomConfirmTitle}
           description={t.dissolveRoomConfirmDescription}
           warning={t.dissolveRoomWarning}

--- a/frontend/src/components/dashboard/RuntimeErrorDetailsDialog.tsx
+++ b/frontend/src/components/dashboard/RuntimeErrorDetailsDialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Copy, X } from "lucide-react";
 import { animateOverlayPanelEnter, animateOverlayPanelExit, animatePop, cleanupAnime } from "@/lib/anime";
@@ -20,7 +21,9 @@ function prettyJson(value: unknown): string {
   }
 }
 
-export default function RuntimeErrorDetailsDialog({
+export default withDashboardOverlayPortal(RuntimeErrorDetailsDialog, "nested");
+
+function RuntimeErrorDetailsDialog({
   title = "Runtime error",
   message,
   code,

--- a/frontend/src/components/dashboard/SettingsModal.tsx
+++ b/frontend/src/components/dashboard/SettingsModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 /**
  * [INPUT]: PolicySettingsClient for agent policy configuration
  * [OUTPUT]: SettingsModal — modal overlay for dashboard settings (对话与回复)
@@ -15,7 +16,9 @@ interface SettingsModalProps {
   onClose: () => void;
 }
 
-export default function SettingsModal({ onClose }: SettingsModalProps) {
+export default withDashboardOverlayPortal(SettingsModal);
+
+function SettingsModal({ onClose }: SettingsModalProps) {
   const [closing, setClosing] = useState(false);
   const overlayRef = useRef<HTMLDivElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);

--- a/frontend/src/components/dashboard/ShareModal.tsx
+++ b/frontend/src/components/dashboard/ShareModal.tsx
@@ -6,6 +6,7 @@
  */
 "use client";
 
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLanguage } from "@/lib/i18n";
 import { shareModal } from "@/lib/i18n/translations/dashboard";
@@ -25,7 +26,9 @@ interface ShareModalProps {
   onClose: () => void;
 }
 
-export default function ShareModal({ roomId, roomName, roomVisibility, canInvite = true, onClose }: ShareModalProps) {
+export default withDashboardOverlayPortal(ShareModal);
+
+function ShareModal({ roomId, roomName, roomVisibility, canInvite = true, onClose }: ShareModalProps) {
   const locale = useLanguage();
   const t = shareModal[locale];
   const tc = common[locale];

--- a/frontend/src/components/dashboard/SubscriptionBadge.tsx
+++ b/frontend/src/components/dashboard/SubscriptionBadge.tsx
@@ -21,6 +21,7 @@ import { useDashboardSessionStore } from "@/store/useDashboardSessionStore";
 import { useDashboardSubscriptionStore } from "@/store/useDashboardSubscriptionStore";
 import { useDashboardUIStore } from "@/store/useDashboardUIStore";
 import { animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from "@/lib/anime";
+import DashboardOverlayPortal from "./DashboardOverlayPortal";
 
 interface SubscriptionBadgeProps {
   productId?: string | null;
@@ -294,21 +295,22 @@ export default function SubscriptionBadge({
       {trigger}
 
       {showModal && (
-        <div
-          className="liquid-scrim fixed inset-0 z-50 flex items-center justify-center p-4"
-          onClick={(event) => {
-            event.stopPropagation();
-            closeWithMotion();
-          }}
-          ref={overlayRef}
-        >
+        <DashboardOverlayPortal>
           <div
-            ref={panelRef}
-            role="dialog"
-            aria-modal="true"
-            className="liquid-dialog w-full max-w-sm rounded-xl border border-glass-border p-6 shadow-xl"
-            onClick={(event) => event.stopPropagation()}
+            className="liquid-scrim fixed inset-0 z-50 flex items-center justify-center p-4"
+            onClick={(event) => {
+              event.stopPropagation();
+              closeWithMotion();
+            }}
+            ref={overlayRef}
           >
+            <div
+              ref={panelRef}
+              role="dialog"
+              aria-modal="true"
+              className="liquid-dialog w-full max-w-sm rounded-xl border border-glass-border p-6 shadow-xl"
+              onClick={(event) => event.stopPropagation()}
+            >
             <h2 data-motion-item className="mb-2 flex items-center gap-2 text-lg font-semibold text-yellow-500">
               <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
@@ -435,8 +437,9 @@ export default function SubscriptionBadge({
                 </div>
               </div>
             )}
+            </div>
           </div>
-        </div>
+        </DashboardOverlayPortal>
       )}
     </>
   );

--- a/frontend/src/components/dashboard/TopicDrawer.tsx
+++ b/frontend/src/components/dashboard/TopicDrawer.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 /**
  * [INPUT]: 依赖 chat/ui/session store 的消息和焦点状态，复用 MessageBubble 和 RoomHumanComposer 渲染话题线程
  * [OUTPUT]: 对外提供带 animejs 进出场动效的 TopicDrawer 组件，作为从右侧滑出的话题详情面板
@@ -34,7 +35,9 @@ function getDrawerParts(drawer: HTMLElement | null): HTMLElement[] {
   return drawer ? Array.from(drawer.querySelectorAll<HTMLElement>(DRAWER_PART_SELECTOR)) : [];
 }
 
-export default function TopicDrawer() {
+export default withDashboardOverlayPortal(TopicDrawer);
+
+function TopicDrawer() {
   const locale = useLanguage();
   const t = messageList[locale];
 

--- a/frontend/src/components/dashboard/TopupDialog.tsx
+++ b/frontend/src/components/dashboard/TopupDialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 import { useCallback, useState, useEffect, useRef } from "react";
 import { useLanguage } from '@/lib/i18n';
 import { topupDialog } from '@/lib/i18n/translations/dashboard';
@@ -32,7 +33,9 @@ interface TopupDialogProps {
   onSuccess: () => void;
 }
 
-export default function TopupDialog({ viewer, onClose, onSuccess }: TopupDialogProps) {
+export default withDashboardOverlayPortal(TopupDialog, "nested");
+
+function TopupDialog({ viewer, onClose, onSuccess }: TopupDialogProps) {
   const locale = useLanguage();
   const t = topupDialog[locale];
   const human = useDashboardSessionStore((s) => s.human);

--- a/frontend/src/components/dashboard/TransferDialog.tsx
+++ b/frontend/src/components/dashboard/TransferDialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 /**
  * [INPUT]: 依赖 wallet store 获取来源账户的可用余额，依赖 session/chat store 列举可选收款方
  * [OUTPUT]: 重设计后的转账 dialog — 模仿标准银行/支付场景：From 卡片(显示余额) + 可视化 To 选择器 + 大额金额输入 + 快速金额 + 校验后才能提交
@@ -51,7 +52,9 @@ function showAmount(minorStr: string | null | undefined, hidden: boolean): strin
   return hidden ? "••••••" : formatCoin(minorStr);
 }
 
-export default function TransferDialog({ viewer, onClose, onSuccess }: TransferDialogProps) {
+export default withDashboardOverlayPortal(TransferDialog, "nested");
+
+function TransferDialog({ viewer, onClose, onSuccess }: TransferDialogProps) {
   const locale = useLanguage();
   const t = transferDialog[locale];
   const wt = walletPanel[locale];

--- a/frontend/src/components/dashboard/TransferOwnershipDialog.tsx
+++ b/frontend/src/components/dashboard/TransferOwnershipDialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 /**
  * [INPUT]: 接收当前房间、候选成员列表与关闭回调，依赖 humansApi.transferRoomOwnership 执行转让
  * [OUTPUT]: 对外提供 TransferOwnershipDialog — 下拉选择 + 二次文字确认的转让房主弹窗
@@ -25,7 +26,9 @@ interface Props {
   onError: (msg: string) => void;
 }
 
-export default function TransferOwnershipDialog({
+export default withDashboardOverlayPortal(TransferOwnershipDialog, "nested");
+
+function TransferOwnershipDialog({
   roomId, roomName, viewerHumanId, members, onClose, onSuccess, onError,
 }: Props) {
   const locale = useLanguage();

--- a/frontend/src/components/dashboard/UnbindAgentDialog.tsx
+++ b/frontend/src/components/dashboard/UnbindAgentDialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { userApi } from "@/lib/api";
 import { animateOverlayPanelEnter, animateOverlayPanelExit, animatePop, cleanupAnime } from "@/lib/anime";
@@ -15,7 +16,9 @@ interface UnbindAgentDialogProps {
   onUnbound: (agentId: string) => Promise<void> | void;
 }
 
-export default function UnbindAgentDialog({
+export default withDashboardOverlayPortal(UnbindAgentDialog, "nested");
+
+function UnbindAgentDialog({
   agentId,
   agentName,
   deleteMode = "unbind",

--- a/frontend/src/components/dashboard/WithdrawDialog.tsx
+++ b/frontend/src/components/dashboard/WithdrawDialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { withDashboardOverlayPortal } from "./DashboardOverlayPortal";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useLanguage } from '@/lib/i18n';
 import { withdrawDialog } from '@/lib/i18n/translations/dashboard';
@@ -34,7 +35,9 @@ function formatCoinAmount(minorStr: string): string {
   return major.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }
 
-export default function WithdrawDialog({ viewer, onClose, onSuccess, availableBalance }: WithdrawDialogProps) {
+export default withDashboardOverlayPortal(WithdrawDialog, "nested");
+
+function WithdrawDialog({ viewer, onClose, onSuccess, availableBalance }: WithdrawDialogProps) {
   const locale = useLanguage();
   const t = withdrawDialog[locale];
   const human = useDashboardSessionStore((s) => s.human);

--- a/frontend/src/components/dashboard/sidebar/DeviceSettingsModal.tsx
+++ b/frontend/src/components/dashboard/sidebar/DeviceSettingsModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { withDashboardOverlayPortal } from "../DashboardOverlayPortal";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { RefreshCw, Loader2, Check, Trash2, FileArchive, Download, Send } from "lucide-react";
 import DaemonInstallCommand from "@/components/daemon/DaemonInstallCommand";
@@ -29,7 +30,9 @@ interface DeviceSettingsModalProps {
   onRemove: (forgetIfOffline: boolean) => Promise<void>;
 }
 
-export default function DeviceSettingsModal({
+export default withDashboardOverlayPortal(DeviceSettingsModal);
+
+function DeviceSettingsModal({
   daemonId,
   label,
   status,

--- a/frontend/src/components/dashboard/sidebar/MessagesPanel.tsx
+++ b/frontend/src/components/dashboard/sidebar/MessagesPanel.tsx
@@ -21,6 +21,7 @@ import RoomList from "../RoomList";
 import RoomZeroState from "../RoomZeroState";
 import SearchBar from "../SearchBar";
 import { animateFadeUp, animateOverlayPanelEnter, animateOverlayPanelExit, cleanupAnime } from "@/lib/anime";
+import DashboardOverlayPortal from "../DashboardOverlayPortal";
 
 interface MessagesPanelProps {
   isGuest: boolean;
@@ -322,32 +323,34 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
         )}
       </div>
       {!isGuest && mobileGroupingRendered ? (
-        <div
-          className="fixed inset-0 z-50 hidden max-md:block"
-          role="dialog"
-          aria-modal="true"
-          aria-label={tGrouping.header}
-        >
-          <button
-            ref={mobileGroupingOverlayRef}
-            type="button"
-            aria-label={tGrouping.collapse}
-            className="liquid-scrim absolute inset-0 backdrop-blur-sm"
-            onClick={() => setMobileGroupingOpen(false)}
-          />
+        <DashboardOverlayPortal>
           <div
-            ref={mobileGroupingPanelRef}
-            className="liquid-drawer absolute bottom-[calc(4.5rem+env(safe-area-inset-bottom))] left-0 top-0 w-[min(84vw,280px)] overflow-hidden border-r border-glass-border"
+            className="fixed inset-0 z-50 hidden max-md:block"
+            role="dialog"
+            aria-modal="true"
+            aria-label={tGrouping.header}
           >
-            <div data-mobile-grouping-motion className="h-full">
-            <MessagesGroupingSidebar
-              fullWidth
-              onCollapse={() => setMobileGroupingOpen(false)}
-              onFilterSelect={() => setMobileGroupingOpen(false)}
+            <button
+              ref={mobileGroupingOverlayRef}
+              type="button"
+              aria-label={tGrouping.collapse}
+              className="liquid-scrim absolute inset-0 backdrop-blur-sm"
+              onClick={() => setMobileGroupingOpen(false)}
             />
+            <div
+              ref={mobileGroupingPanelRef}
+              className="liquid-drawer absolute bottom-[calc(4.5rem+env(safe-area-inset-bottom))] left-0 top-0 w-[min(84vw,280px)] overflow-hidden border-r border-glass-border"
+            >
+              <div data-mobile-grouping-motion className="h-full">
+                <MessagesGroupingSidebar
+                  fullWidth
+                  onCollapse={() => setMobileGroupingOpen(false)}
+                  onFilterSelect={() => setMobileGroupingOpen(false)}
+                />
+              </div>
             </div>
           </div>
-        </div>
+        </DashboardOverlayPortal>
       ) : null}
       {pendingRequestCount > 0 ? (
         <button

--- a/frontend/src/components/ui/ConfirmDialog.tsx
+++ b/frontend/src/components/ui/ConfirmDialog.tsx
@@ -48,7 +48,7 @@ export default function ConfirmDialog() {
 
   return (
     <div
-      className="liquid-scrim fixed inset-0 z-[120] flex items-center justify-center p-4"
+      className="liquid-scrim fixed inset-0 z-[1100] flex items-center justify-center p-4"
       role="presentation"
       onClick={() => close(isAlert)}
     >


### PR DESCRIPTION
## Summary
- portal dashboard dialogs and drawers into one global overlay stack
- preserve nested/critical dialog ordering and keep global confirmation above it
- flatten permanent dashboard columns so shadows no longer accumulate left-to-right

## Validation
- npm run test -- DashboardOverlayPortal.test.ts
- npm run build