### PR TITLE
fix(frontend): align messages loading skeleton with loaded layout

### DIFF
--- a/frontend/src/components/dashboard/DashboardShellSkeleton.test.ts
+++ b/frontend/src/components/dashboard/DashboardShellSkeleton.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getShellSkeletonVariantFromPathname } from "./DashboardShellSkeleton";
+import { getShellSkeletonVariantFromPathname, shellSkeletonHasOpenConversation } from "./DashboardShellSkeleton";
 
 describe("getShellSkeletonVariantFromPathname", () => {
   it("treats /chats root and home routes as home", () => {
@@ -22,5 +22,22 @@ describe("getShellSkeletonVariantFromPathname", () => {
     expect(getShellSkeletonVariantFromPathname("/chats/wallet")).toBe("wallet");
     expect(getShellSkeletonVariantFromPathname("/chats/activity")).toBe("activity");
     expect(getShellSkeletonVariantFromPathname("/chats/bots")).toBe("bots");
+  });
+});
+
+describe("shellSkeletonHasOpenConversation", () => {
+  it("treats room-less message routes as the empty state", () => {
+    expect(shellSkeletonHasOpenConversation("/chats/messages")).toBe(false);
+    expect(shellSkeletonHasOpenConversation("/chats/dm")).toBe(false);
+    expect(shellSkeletonHasOpenConversation("/chats/rooms")).toBe(false);
+    expect(shellSkeletonHasOpenConversation("/chats/contacts")).toBe(false);
+    expect(shellSkeletonHasOpenConversation(null)).toBe(false);
+  });
+
+  it("detects routes that resolve to an open conversation", () => {
+    expect(shellSkeletonHasOpenConversation("/chats/messages/rm_123")).toBe(true);
+    expect(shellSkeletonHasOpenConversation("/chats/dm/rm_dm_123")).toBe(true);
+    expect(shellSkeletonHasOpenConversation("/chats/rooms/rm_123")).toBe(true);
+    expect(shellSkeletonHasOpenConversation("/chats/user-chat")).toBe(true);
   });
 });

--- a/frontend/src/components/dashboard/DashboardShellSkeleton.tsx
+++ b/frontend/src/components/dashboard/DashboardShellSkeleton.tsx
@@ -8,7 +8,7 @@
  */
 
 import DashboardMessagePaneSkeleton from "./DashboardMessagePaneSkeleton";
-import DashboardTabSkeleton, { SidebarListSkeleton } from "./DashboardTabSkeleton";
+import DashboardTabSkeleton, { RoomRowsSkeleton, SidebarListSkeleton } from "./DashboardTabSkeleton";
 import { BotCordLoader } from "@/components/ui/BotCordLoader";
 import { Activity, Bot, Home, LogIn, MessageSquare, Search, UserRound, Wallet } from "lucide-react";
 import { usePathname } from "next/navigation";
@@ -17,6 +17,21 @@ type ShellSkeletonVariant = "home" | "messages" | "bots" | "contacts" | "explore
 
 function SkeletonLine({ className }: { className: string }) {
   return <div className={`dashboard-skeleton-block rounded ${className}`} />;
+}
+
+/**
+ * `/chats/messages` without a room id lands on the empty "pick a conversation"
+ * state, not on a chat pane — so the shell skeleton must not paint a message
+ * feed there. Only routes that actually resolve to a room (or an explicit
+ * user-chat deep link) get the conversation skeleton.
+ */
+export function shellSkeletonHasOpenConversation(pathname: string | null): boolean {
+  const parts = (pathname || "/chats").split("/").filter(Boolean);
+  const tab = parts[1];
+  const subtab = parts[2];
+  if (tab === "user-chat") return true;
+  if (tab === "dm" || tab === "rooms" || tab === "messages") return Boolean(subtab);
+  return false;
 }
 
 export function getShellSkeletonVariantFromPathname(pathname: string | null): ShellSkeletonVariant {
@@ -36,15 +51,16 @@ export function getShellSkeletonVariantFromPathname(pathname: string | null): Sh
   return "home";
 }
 
-function SkeletonRoomList() {
+/** Mirrors `ChatPane`'s `MessagesEmptyState`, which is what /chats/messages resolves to. */
+function MessagesEmptyStateSkeleton() {
   return (
-    <div className="space-y-2 p-3">
-      {Array.from({ length: 7 }).map((_, idx) => (
-        <div key={idx} className="liquid-card rounded-lg border border-glass-border p-3">
-          <SkeletonLine className="h-3 w-2/3" />
-          <SkeletonLine className="mt-2 h-2.5 w-1/2 bg-glass-border/40" />
-        </div>
-      ))}
+    <div className="dashboard-main flex min-w-0 flex-1 items-center justify-center px-6 py-10" aria-busy="true">
+      <div className="w-full max-w-md text-center">
+        <SkeletonLine className="mx-auto mb-5 h-14 w-14 rounded-2xl bg-glass-border/35" />
+        <SkeletonLine className="mx-auto h-5 w-40" />
+        <SkeletonLine className="mx-auto mt-3 h-3.5 w-72 max-w-full bg-glass-border/40" />
+        <SkeletonLine className="mx-auto mt-5 h-6 w-56 max-w-full rounded-full bg-glass-border/30" />
+      </div>
     </div>
   );
 }
@@ -74,7 +90,7 @@ function SecondaryPanelSkeleton({ variant }: { variant: ShellSkeletonVariant }) 
             <SkeletonLine className="h-3 w-20" />
             <SkeletonLine className="mt-2 h-2.5 w-28 bg-glass-border/40" />
           </div>
-          {Array.from({ length: 4 }).map((_, idx) => (
+          {Array.from({ length: 5 }).map((_, idx) => (
             <div key={`bots-${idx}`} className="flex items-center gap-2 py-1.5 pl-[28px] pr-3">
               <SkeletonLine className="h-3.5 w-3.5 bg-glass-border/45" />
               <SkeletonLine className="h-3 w-24 bg-glass-border/45" />
@@ -102,6 +118,7 @@ function SecondaryPanelSkeleton({ variant }: { variant: ShellSkeletonVariant }) 
 export default function DashboardShellSkeleton({ variant: variantProp }: { variant?: ShellSkeletonVariant }) {
   const pathname = usePathname();
   const variant = variantProp ?? getShellSkeletonVariantFromPathname(pathname);
+  const hasOpenConversation = shellSkeletonHasOpenConversation(pathname);
   const primaryNav = [
     { key: "home", label: "Home", icon: <Home className="h-5 w-5" strokeWidth={1.5} /> },
     { key: "messages", label: "Messages", icon: <MessageSquare className="h-5 w-5" strokeWidth={1.5} /> },
@@ -142,22 +159,22 @@ export default function DashboardShellSkeleton({ variant: variantProp }: { varia
         <SecondaryPanelSkeleton variant={variant} />
 
         {variant === "messages" ? (
-          <div className="flex h-full min-w-0 flex-1 flex-col border-r border-glass-border">
-          <div className="flex h-14 items-center justify-between border-b border-glass-border px-3">
-            <span className="text-sm font-semibold text-text-primary">Messages</span>
-            <div className="flex items-center gap-3 text-text-secondary">
-              <Search className="h-4 w-4" />
-              <UserRound className="h-4 w-4" />
-              <MessageSquare className="h-4 w-4" />
+          <div className="flex h-full w-[360px] shrink-0 flex-col border-r border-glass-border">
+            <div className="liquid-toolbar flex min-h-14 items-center justify-between border-b border-glass-border px-3 py-2.5">
+              <span className="text-sm font-semibold text-text-primary">Messages</span>
+              <div className="flex items-center gap-1" aria-hidden="true">
+                <SkeletonLine className="h-8 w-8 rounded-lg bg-glass-border/35" />
+                <SkeletonLine className="h-8 w-8 rounded-lg bg-glass-border/35" />
+                <SkeletonLine className="h-8 w-8 rounded-lg bg-glass-border/35" />
+              </div>
             </div>
-          </div>
-          <SkeletonRoomList />
+            <RoomRowsSkeleton />
           </div>
         ) : null}
       </div>
 
       {variant === "messages" ? (
-        <DashboardMessagePaneSkeleton />
+        hasOpenConversation ? <DashboardMessagePaneSkeleton /> : <MessagesEmptyStateSkeleton />
       ) : (
         <div className="min-w-0 flex-1">
           <DashboardTabSkeleton variant={variant} />

--- a/frontend/src/components/dashboard/DashboardTabSkeleton.tsx
+++ b/frontend/src/components/dashboard/DashboardTabSkeleton.tsx
@@ -39,6 +39,30 @@ export function SidebarListSkeleton({ rows = 7, withAvatar = true }: { rows?: nu
   );
 }
 
+/**
+ * Room rows are visually distinct from the generic sidebar list: `RoomList`
+ * renders `mx-2 my-1 rounded-2xl px-3 py-3` cards with a 40px avatar and a
+ * trailing timestamp. Keeping one shared implementation stops the shell
+ * skeleton, the sidebar bootstrap skeleton and the in-list refresh skeleton
+ * from drifting apart from the loaded layout.
+ */
+export function RoomRowsSkeleton({ rows = 6 }: { rows?: number }) {
+  return (
+    <div className="py-1">
+      {Array.from({ length: rows }).map((_, idx) => (
+        <div key={idx} className="mx-2 my-1 flex items-center gap-3 rounded-2xl px-3 py-3">
+          <SkeletonBlock className="h-10 w-10 shrink-0 rounded-xl bg-glass-border/45" />
+          <div className="min-w-0 flex-1">
+            <SkeletonBlock className="h-3.5 w-1/2" />
+            <SkeletonBlock className="mt-2 h-2.5 w-4/5 bg-glass-border/40" />
+          </div>
+          <SkeletonBlock className="h-2.5 w-10 shrink-0 bg-glass-border/30" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function CardGridSkeleton({ rows = 6, statCards = false }: { rows?: number; statCards?: boolean }) {
   return (
     <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">

--- a/frontend/src/components/dashboard/RoomList.tsx
+++ b/frontend/src/components/dashboard/RoomList.tsx
@@ -26,7 +26,7 @@ import SubscriptionBadge from "./SubscriptionBadge";
 import { resolveDmDisplayName } from "./dmRoom";
 import { CompositeAvatar } from "./CompositeAvatar";
 import BotAvatar from "./BotAvatar";
-import { SidebarListSkeleton } from "./DashboardTabSkeleton";
+import { RoomRowsSkeleton } from "./DashboardTabSkeleton";
 
 interface RoomListProps {
   rooms?: DashboardRoom[];
@@ -365,11 +365,7 @@ export default function RoomList({
   };
 
   if (loading) {
-    return (
-      <div className="py-1">
-        <SidebarListSkeleton rows={6} />
-      </div>
-    );
+    return <RoomRowsSkeleton rows={6} />;
   }
 
   return (

--- a/frontend/src/components/dashboard/sidebar/index.tsx
+++ b/frontend/src/components/dashboard/sidebar/index.tsx
@@ -37,7 +37,7 @@ import ContactsPanel from "./ContactsPanel";
 import MessagesGroupingSidebar from "./MessagesGroupingSidebar";
 import BotsPanel from "./BotsPanel";
 import MessagesPanel from "./MessagesPanel";
-import { SidebarListSkeleton, SkeletonBlock } from "../DashboardTabSkeleton";
+import { RoomRowsSkeleton, SidebarListSkeleton, SkeletonBlock } from "../DashboardTabSkeleton";
 
 import { UserPlus, LogIn, Bot, Plus, RefreshCw, MessageSquarePlus, Search, X } from "lucide-react";
 import { useAppStore } from "@/store/useAppStore";
@@ -593,15 +593,21 @@ function Sidebar({
           {secondaryPanelLoading ? (
             <>
               {visibleSidebarTab === "messages" ? (
-                <div className="flex min-h-14 items-center justify-between border-b border-glass-border px-3 py-2.5">
-                  <SkeletonBlock className="h-4 w-28" />
-                  <div className="flex gap-1">
-                    <SkeletonBlock className="h-8 w-8 rounded-lg" />
-                    <SkeletonBlock className="h-8 w-8 rounded-lg" />
+                <>
+                  {/* Mirrors MessagesPanel's toolbar: title + three icon buttons. */}
+                  <div className="liquid-toolbar flex min-h-14 items-center justify-between border-b border-glass-border px-3 py-2.5">
+                    <SkeletonBlock className="h-4 w-28" />
+                    <div className="flex gap-1">
+                      <SkeletonBlock className="h-8 w-8 rounded-lg" />
+                      <SkeletonBlock className="h-8 w-8 rounded-lg" />
+                      <SkeletonBlock className="h-8 w-8 rounded-lg" />
+                    </div>
                   </div>
-                </div>
-              ) : null}
-              <SidebarListSkeleton rows={visibleSidebarTab === "contacts" ? 9 : 7} />
+                  <RoomRowsSkeleton />
+                </>
+              ) : (
+                <SidebarListSkeleton rows={visibleSidebarTab === "contacts" ? 9 : 7} />
+              )}
             </>
           ) : visibleSidebarTab === "messages" && (
             <MessagesPanel


### PR DESCRIPTION
## 问题

`/chats` 的 bootstrap 骨架和加载完成后的布局对不上，首帧是另一套界面：

- `/chats/messages`（无 roomId）加载完成后主区是 ChatPane 的「选择一个对话」空态，骨架却画了整套聊天面板（header + 消息气泡 + 输入框）
- 会话列表列用 `flex-1`，被主区挤到约 166px；真实 secondary panel 是固定 `sidebarWidth`（默认 360）+ 分组栏 200
- 三套会话行骨架（shell / sidebar bootstrap / RoomList 刷新）互不一致，也都不匹配真实 `RoomList` 行几何
- 列表工具栏骨架是裸 lucide 图标 + 2 个按钮，实际是 3 个 `h-8 w-8` 按钮

## 改动

- 新增 `shellSkeletonHasOpenConversation()`：只有真正解析到房间的路由（`/chats/messages/rm_x`、`/chats/dm/x`、`/chats/rooms/x`、`/chats/user-chat`）才渲染消息面板骨架，其余渲染对齐 `MessagesEmptyState` 的空态骨架
- 会话列表列固定 `w-[360px] shrink-0`，与 `sidebar/index.tsx` 的真实宽度一致
- 抽出共享 `RoomRowsSkeleton`（40px 头像 + 两行文字 + 右侧时间条），shell 骨架 / sidebar bootstrap 骨架 / `RoomList` 刷新骨架三处共用
- 工具栏骨架对齐 `MessagesPanel`（`liquid-toolbar` + 三个图标按钮），分组栏第二段行数对齐真实项数

## 验证

- `vitest run src/components/dashboard` — 41 passed（含新增的路由判定用例 5 项）
- `next build` — Compiled successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)