### PR TITLE
fix(frontend): rebuild every tab skeleton to match its loaded layout

### DIFF
--- a/frontend/src/app/(dashboard)/settings/policy/PolicySettingsClient.tsx
+++ b/frontend/src/app/(dashboard)/settings/policy/PolicySettingsClient.tsx
@@ -303,8 +303,7 @@ export default function PolicySettingsClient() {
     return (
       <div className="max-w-3xl">
         <Header />
-        <SkeletonCard />
-        <SkeletonCard />
+        <PolicyFormSkeleton />
       </div>
     );
   }
@@ -344,10 +343,7 @@ export default function PolicySettingsClient() {
       ) : null}
 
       {!policy || loadingPolicy ? (
-        <>
-          <SkeletonCard />
-          <SkeletonCard />
-        </>
+        <PolicyFormSkeleton />
       ) : (
         <PolicyForm policy={policy} saving={saving} onPatch={apply} />
       )}
@@ -372,16 +368,38 @@ function Header({ right }: { right?: React.ReactNode }) {
   );
 }
 
-function SkeletonCard() {
+/**
+ * Mirrors `PolicyForm`: a three-tile summary row followed by the two `Card`
+ * sections, so the loading frame has the same shape as the loaded form.
+ */
+function PolicyFormSkeleton() {
   return (
-    <section className="mb-6 animate-pulse rounded-2xl border border-glass-border bg-glass-bg/40 p-6">
-      <div className="mb-4 h-4 w-32 rounded bg-glass-bg" />
-      <div className="space-y-2">
-        <div className="h-10 rounded bg-glass-bg/70" />
-        <div className="h-10 rounded bg-glass-bg/70" />
-        <div className="h-10 rounded bg-glass-bg/70" />
+    <>
+      <div className="mb-6 grid gap-3 md:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, idx) => (
+          <div key={idx} className="rounded-xl border border-glass-border px-3 py-3">
+            <div className="mb-1 flex items-center gap-1.5">
+              <div className="dashboard-skeleton-block h-4 w-4 rounded" />
+              <div className="dashboard-skeleton-block h-2.5 w-16 rounded" />
+            </div>
+            <div className="dashboard-skeleton-block h-4 w-24 rounded" />
+          </div>
+        ))}
       </div>
-    </section>
+      {Array.from({ length: 2 }).map((_, idx) => (
+        <section key={idx} className="mb-6 rounded-2xl border border-glass-border bg-glass-bg/40 p-6">
+          <header className="mb-4">
+            <div className="dashboard-skeleton-block h-4 w-32 rounded" />
+            <div className="dashboard-skeleton-block mt-2 h-3 w-4/5 rounded" />
+          </header>
+          <div className="space-y-2">
+            <div className="dashboard-skeleton-block h-10 rounded-lg" />
+            <div className="dashboard-skeleton-block h-10 rounded-lg" />
+            <div className="dashboard-skeleton-block h-10 rounded-lg" />
+          </div>
+        </section>
+      ))}
+    </>
   );
 }
 

--- a/frontend/src/components/dashboard/DashboardApp.tsx
+++ b/frontend/src/components/dashboard/DashboardApp.tsx
@@ -1151,7 +1151,15 @@ export default function DashboardApp() {
       />
       <div ref={mainContentRef} className={mainPaneClass}>
         {primaryNavigationPending ? (
-          <DashboardTabSkeleton variant={visibleSidebarTab} />
+          // A pending click on Messages usually lands on the empty
+          // "pick a conversation" pane, so only paint a chat skeleton when a
+          // conversation is actually open.
+          <DashboardTabSkeleton
+            variant={visibleSidebarTab}
+            hasOpenConversation={
+              Boolean(uiStore.focusedRoomId) || uiStore.messagesPane === "user-chat"
+            }
+          />
         ) : visibleSidebarTab === "home" ? (
           <HomePanel />
         ) : visibleSidebarTab === "activity" ? (

--- a/frontend/src/components/dashboard/DashboardShellSkeleton.tsx
+++ b/frontend/src/components/dashboard/DashboardShellSkeleton.tsx
@@ -8,7 +8,12 @@
  */
 
 import DashboardMessagePaneSkeleton from "./DashboardMessagePaneSkeleton";
-import DashboardTabSkeleton, { RoomRowsSkeleton, SidebarListSkeleton } from "./DashboardTabSkeleton";
+import DashboardTabSkeleton, {
+  ContactSectionsSkeleton,
+  MessagesEmptyStateSkeleton,
+  PinnedRequestRowSkeleton,
+  RoomRowsSkeleton,
+} from "./DashboardTabSkeleton";
 import { BotCordLoader } from "@/components/ui/BotCordLoader";
 import { Activity, Bot, Home, LogIn, MessageSquare, Search, UserRound, Wallet } from "lucide-react";
 import { usePathname } from "next/navigation";
@@ -51,20 +56,6 @@ export function getShellSkeletonVariantFromPathname(pathname: string | null): Sh
   return "home";
 }
 
-/** Mirrors `ChatPane`'s `MessagesEmptyState`, which is what /chats/messages resolves to. */
-function MessagesEmptyStateSkeleton() {
-  return (
-    <div className="dashboard-main flex min-w-0 flex-1 items-center justify-center px-6 py-10" aria-busy="true">
-      <div className="w-full max-w-md text-center">
-        <SkeletonLine className="mx-auto mb-5 h-14 w-14 rounded-2xl bg-glass-border/35" />
-        <SkeletonLine className="mx-auto h-5 w-40" />
-        <SkeletonLine className="mx-auto mt-3 h-3.5 w-72 max-w-full bg-glass-border/40" />
-        <SkeletonLine className="mx-auto mt-5 h-6 w-56 max-w-full rounded-full bg-glass-border/30" />
-      </div>
-    </div>
-  );
-}
-
 function SecondaryPanelSkeleton({ variant }: { variant: ShellSkeletonVariant }) {
   if (variant === "messages") {
     return (
@@ -104,13 +95,21 @@ function SecondaryPanelSkeleton({ variant }: { variant: ShellSkeletonVariant }) 
 
   if (variant !== "contacts" && variant !== "activity") return null;
 
+  // The secondary panel is `sidebarWidth` wide (360 by default) and carries the
+  // tab title header. Activity has no secondary content at all, so its panel
+  // must stay empty below the header instead of showing a phantom list.
   return (
-    <div className="flex h-full w-[280px] shrink-0 flex-col border-r border-glass-border bg-deep-black-light">
-      <div className="flex h-14 items-center justify-between border-b border-glass-border px-4">
+    <div className="liquid-panel flex h-full w-[360px] shrink-0 flex-col border-r border-glass-border bg-deep-black-light">
+      <div className="flex min-h-14 items-center justify-between border-b border-glass-border px-4 py-3">
         <SkeletonLine className="h-4 w-24" />
-        <SkeletonLine className="h-8 w-8 rounded-lg bg-glass-border/40" />
+        {variant === "contacts" ? <SkeletonLine className="h-8 w-8 rounded-lg bg-glass-border/40" /> : null}
       </div>
-      <SidebarListSkeleton rows={variant === "contacts" ? 9 : 7} withAvatar={variant === "contacts"} />
+      {variant === "contacts" ? (
+        <>
+          <PinnedRequestRowSkeleton />
+          <ContactSectionsSkeleton />
+        </>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/components/dashboard/DashboardTabSkeleton.tsx
+++ b/frontend/src/components/dashboard/DashboardTabSkeleton.tsx
@@ -5,6 +5,12 @@
  * [OUTPUT]: Shared tab-specific skeletons for dashboard secondary panels and main panes
  * [POS]: Loading UI primitives for dashboard tab transitions and data hydration
  * [PROTOCOL]: Update this header when behavior changes, then check README.md
+ *
+ * Every skeleton here mirrors the geometry of the panel it stands in for —
+ * same page container (max width, padding), same section order, same card
+ * shape and grid columns. When a panel's layout changes, update its skeleton
+ * in the same commit, otherwise the first frame after a tab click no longer
+ * matches what loads.
  */
 import DashboardMessagePaneSkeleton from "./DashboardMessagePaneSkeleton";
 
@@ -12,31 +18,6 @@ type TabSkeletonVariant = "home" | "messages" | "contacts" | "explore" | "wallet
 
 export function SkeletonBlock({ className }: { className: string }) {
   return <div className={`dashboard-skeleton-block rounded ${className}`} />;
-}
-
-function HeaderSkeleton({ compact = false }: { compact?: boolean }) {
-  return (
-    <div className={compact ? "border-b border-glass-border px-3 py-3" : "border-b border-glass-border px-6 py-4"}>
-      <SkeletonBlock className={compact ? "h-4 w-28" : "h-5 w-36"} />
-      <SkeletonBlock className={compact ? "mt-2 h-3 w-40 bg-glass-border/40" : "mt-2 h-3 w-56 bg-glass-border/40"} />
-    </div>
-  );
-}
-
-export function SidebarListSkeleton({ rows = 7, withAvatar = true }: { rows?: number; withAvatar?: boolean }) {
-  return (
-    <div className="space-y-1 p-2">
-      {Array.from({ length: rows }).map((_, idx) => (
-        <div key={idx} className="flex items-center gap-3 rounded-lg px-2 py-2.5">
-          {withAvatar ? <SkeletonBlock className="h-9 w-9 shrink-0 rounded-xl" /> : null}
-          <div className="min-w-0 flex-1">
-            <SkeletonBlock className="h-3.5 w-3/5" />
-            <SkeletonBlock className="mt-2 h-2.5 w-4/5 bg-glass-border/40" />
-          </div>
-        </div>
-      ))}
-    </div>
-  );
 }
 
 /**
@@ -63,75 +44,243 @@ export function RoomRowsSkeleton({ rows = 6 }: { rows?: number }) {
   );
 }
 
-function CardGridSkeleton({ rows = 6, statCards = false }: { rows?: number; statCards?: boolean }) {
+/**
+ * `ContactsPanel`'s tree: collapsible section headers (uppercase, count on the
+ * right) over `ListRow`s (px-3 py-2, 32px avatar, name + subtitle).
+ */
+export function ContactSectionsSkeleton({ sections = [4, 3] }: { sections?: number[] }) {
   return (
-    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-      {Array.from({ length: rows }).map((_, idx) => (
-        <div key={idx} className="liquid-card rounded-2xl border border-glass-border p-4">
-          <div className="flex items-start gap-3">
-            <SkeletonBlock className="h-10 w-10 shrink-0 rounded-xl" />
-            <div className="min-w-0 flex-1">
-              <SkeletonBlock className="h-4 w-2/3" />
-              <SkeletonBlock className="mt-2 h-3 w-1/2 bg-glass-border/40" />
-              <SkeletonBlock className="mt-3 h-3 w-full bg-glass-border/40" />
+    <div>
+      {sections.map((rows, sectionIdx) => (
+        <div key={sectionIdx} className="border-b border-glass-border/50">
+          <div className="flex w-full items-center justify-between px-3 py-2">
+            <div className="flex items-center gap-1.5">
+              <SkeletonBlock className="h-3 w-3 rounded bg-glass-border/40" />
+              <SkeletonBlock className="h-2.5 w-16 bg-glass-border/45" />
             </div>
+            <SkeletonBlock className="h-2.5 w-4 bg-glass-border/30" />
           </div>
-          {statCards ? (
-            <div className="mt-4 grid grid-cols-4 gap-2 border-t border-glass-border pt-3">
-              {Array.from({ length: 4 }).map((_, statIdx) => (
-                <SkeletonBlock key={statIdx} className="h-10 rounded-lg bg-glass-border/40" />
-              ))}
-            </div>
-          ) : (
-            <SkeletonBlock className="mt-4 h-3 w-1/3 bg-glass-border/40" />
-          )}
+          <div className="pb-2">
+            {Array.from({ length: rows }).map((_, rowIdx) => (
+              <div key={rowIdx} className="flex w-full items-center gap-2.5 px-3 py-2">
+                <SkeletonBlock className="h-8 w-8 shrink-0 rounded-xl bg-glass-border/45" />
+                <div className="min-w-0 flex-1">
+                  <SkeletonBlock className="h-3.5 w-1/2" />
+                  <SkeletonBlock className="mt-1.5 h-2.5 w-3/4 bg-glass-border/40" />
+                </div>
+              </div>
+            ))}
+          </div>
         </div>
       ))}
     </div>
   );
 }
 
+/** `ContactsPanel`'s pinned "new requests" row: px-3 py-3, 40px avatar. */
+export function PinnedRequestRowSkeleton() {
+  return (
+    <div className="flex items-center gap-3 border-b border-glass-border px-3 py-3">
+      <SkeletonBlock className="h-10 w-10 shrink-0 rounded-full bg-glass-border/45" />
+      <div className="min-w-0 flex-1">
+        <SkeletonBlock className="h-3.5 w-32" />
+        <SkeletonBlock className="mt-2 h-2.5 w-24 bg-glass-border/40" />
+      </div>
+    </div>
+  );
+}
+
+/** Mirrors `ChatPane`'s `MessagesEmptyState` — what /chats/messages resolves to. */
+export function MessagesEmptyStateSkeleton() {
+  return (
+    <div className="dashboard-main flex min-w-0 flex-1 items-center justify-center px-6 py-10" aria-busy="true">
+      <div className="w-full max-w-md text-center">
+        <SkeletonBlock className="mx-auto mb-5 h-14 w-14 rounded-2xl bg-glass-border/35" />
+        <SkeletonBlock className="mx-auto h-5 w-40" />
+        <SkeletonBlock className="mx-auto mt-3 h-3.5 w-72 max-w-full bg-glass-border/40" />
+        <SkeletonBlock className="mx-auto mt-5 h-6 w-56 max-w-full rounded-full bg-glass-border/30" />
+      </div>
+    </div>
+  );
+}
+
+/** `HomePanel`'s SectionHeader: icon + title/subtitle on the left, "view all" on the right. */
+function SectionHeaderSkeleton({ titleWidth = "w-28", subtitleWidth = "w-56", withShowAll = true }: {
+  titleWidth?: string;
+  subtitleWidth?: string;
+  withShowAll?: boolean;
+}) {
+  return (
+    <div className="mb-3 flex items-end justify-between gap-4">
+      <div className="flex items-center gap-2">
+        <SkeletonBlock className="h-4 w-4 shrink-0 rounded bg-glass-border/45" />
+        <div>
+          <SkeletonBlock className={`h-4 ${titleWidth}`} />
+          <SkeletonBlock className={`mt-1.5 h-2.5 ${subtitleWidth} bg-glass-border/40`} />
+        </div>
+      </div>
+      {withShowAll ? <SkeletonBlock className="h-5 w-16 rounded-md bg-glass-border/35" /> : null}
+    </div>
+  );
+}
+
+/** `HomePanel`'s BotActivityCard: 36px avatar + name/status, then a 2x2 stat grid. */
+function BotActivityCardSkeleton() {
+  return (
+    <div className="liquid-card w-full rounded-2xl border border-glass-border p-4">
+      <div className="mb-3 flex items-center gap-2.5">
+        <SkeletonBlock className="h-9 w-9 shrink-0 rounded-xl bg-glass-border/45" />
+        <div className="min-w-0 flex-1">
+          <SkeletonBlock className="h-3.5 w-2/3" />
+          <SkeletonBlock className="mt-1.5 h-2.5 w-12 bg-glass-border/40" />
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        {Array.from({ length: 4 }).map((_, idx) => (
+          <div key={idx} className="liquid-tool-surface rounded-lg px-2 py-1.5">
+            <SkeletonBlock className="h-2 w-4/5 bg-glass-border/40" />
+            <SkeletonBlock className="mt-1.5 h-3.5 w-8" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** `HomePanel`'s PersonCard: 40px avatar + name + badge pill, then a two-line bio. */
+function PersonCardSkeleton() {
+  return (
+    <div className="liquid-card flex flex-col rounded-2xl border border-glass-border p-4">
+      <div className="mb-2 flex items-center gap-2">
+        <SkeletonBlock className="h-10 w-10 shrink-0 rounded-full bg-glass-border/45" />
+        <div className="min-w-0 flex-1">
+          <SkeletonBlock className="h-3.5 w-3/5" />
+          <SkeletonBlock className="mt-1 h-3 w-14 rounded-full bg-glass-border/35" />
+        </div>
+      </div>
+      <div className="min-h-[2rem]">
+        <SkeletonBlock className="h-2.5 w-full bg-glass-border/40" />
+        <SkeletonBlock className="mt-1.5 h-2.5 w-4/5 bg-glass-border/40" />
+      </div>
+    </div>
+  );
+}
+
+/** `ExploreEntityCard` kind="room": 56px patterned cover, then px-3 py-2 body. */
+function RoomEntityCardSkeleton() {
+  return (
+    <div className="liquid-card overflow-hidden rounded-xl border border-glass-border">
+      <div className="relative h-14 w-full bg-glass-bg/40">
+        <SkeletonBlock className="absolute left-3 top-2 h-7 w-7 rounded-md bg-glass-border/45" />
+        <SkeletonBlock className="absolute right-2 top-2 h-4 w-14 rounded-full bg-glass-border/35" />
+      </div>
+      <div className="px-3 py-2">
+        <SkeletonBlock className="h-3.5 w-3/5" />
+        <SkeletonBlock className="mt-1 h-2.5 w-2/5 bg-glass-border/35" />
+        <SkeletonBlock className="mt-1.5 h-2.5 w-full bg-glass-border/40" />
+        <SkeletonBlock className="mt-1 h-2.5 w-4/5 bg-glass-border/40" />
+        <div className="mt-1.5 flex items-center justify-end">
+          <SkeletonBlock className="h-2.5 w-12 bg-glass-border/30" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** `ExploreEntityCard` kind="agent"/"human": rounded-xl p-3, 36px avatar + two-line bio. */
+function PersonEntityCardSkeleton() {
+  return (
+    <div className="liquid-card rounded-xl border border-glass-border p-3">
+      <div className="flex items-start gap-2.5">
+        <SkeletonBlock className="h-9 w-9 shrink-0 rounded-full bg-glass-border/45" />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center justify-between gap-2">
+            <SkeletonBlock className="h-3.5 w-3/5" />
+            <SkeletonBlock className="h-3 w-12 shrink-0 rounded-full bg-glass-border/35" />
+          </div>
+          <SkeletonBlock className="mt-1 h-2.5 w-2/3 bg-glass-border/35" />
+        </div>
+      </div>
+      <SkeletonBlock className="mt-1.5 h-2.5 w-full bg-glass-border/40" />
+      <SkeletonBlock className="mt-1 h-2.5 w-5/6 bg-glass-border/40" />
+    </div>
+  );
+}
+
+/** `ChatPane`'s explore grid — same columns as EXPLORE_GRID_CLASS. */
 function ExploreGridSkeleton() {
   return (
     <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
       {Array.from({ length: 10 }).map((_, idx) => (
-        <div key={idx} className="liquid-card rounded-xl border border-glass-border p-3">
-          <SkeletonBlock className="h-11 w-11 rounded-xl" />
-          <SkeletonBlock className="mt-3 h-3.5 w-3/4" />
-          <SkeletonBlock className="mt-2 h-2.5 w-1/2 bg-glass-border/40" />
-          <SkeletonBlock className="mt-3 h-2.5 w-full bg-glass-border/40" />
-          <SkeletonBlock className="mt-1.5 h-2.5 w-5/6 bg-glass-border/40" />
+        <PersonEntityCardSkeleton key={idx} />
+      ))}
+    </div>
+  );
+}
+
+/** `ChatPane`'s contacts/joined-rooms grid: rounded-2xl p-4 cards, 1/2/3 columns. */
+function ContactsGridSkeleton({ rows = 6 }: { rows?: number }) {
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+      {Array.from({ length: rows }).map((_, idx) => (
+        <div key={idx} className="rounded-2xl border border-glass-border bg-deep-black-light p-4">
+          <div className="flex items-center justify-between gap-2">
+            <SkeletonBlock className="h-3.5 w-2/5" />
+            <SkeletonBlock className="h-4 w-12 shrink-0 rounded bg-glass-border/35" />
+          </div>
+          <SkeletonBlock className="mt-1.5 h-2.5 w-3/5 bg-glass-border/35" />
+          <SkeletonBlock className="mt-2.5 h-2.5 w-full bg-glass-border/40" />
+          <SkeletonBlock className="mt-1.5 h-2.5 w-4/5 bg-glass-border/40" />
+          <SkeletonBlock className="mt-2.5 h-2.5 w-1/3 bg-glass-border/30" />
         </div>
       ))}
     </div>
   );
 }
 
-function WalletSkeleton() {
+/** `MyBotsPanel`'s BotsView card: rounded-2xl p-5, 48px avatar, 4-column stats. */
+function BotCardSkeleton() {
   return (
-    <div className="mx-auto w-full max-w-2xl space-y-6">
-      <div className="liquid-card rounded-2xl border border-glass-border p-6">
-        <SkeletonBlock className="h-3 w-28" />
-        <SkeletonBlock className="mt-4 h-10 w-56" />
-        <div className="mt-5 grid grid-cols-2 gap-4">
-          <SkeletonBlock className="h-20 rounded-xl bg-glass-border/40" />
-          <SkeletonBlock className="h-20 rounded-xl bg-glass-border/40" />
+    <div className="liquid-card rounded-2xl border border-glass-border p-5">
+      <div className="mb-4 flex items-start gap-3">
+        <SkeletonBlock className="h-12 w-12 shrink-0 rounded-xl bg-glass-border/45" />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <SkeletonBlock className="h-4 w-1/3" />
+            <SkeletonBlock className="h-4 w-14 rounded-full bg-glass-border/35" />
+          </div>
+          <SkeletonBlock className="mt-2 h-2.5 w-full bg-glass-border/40" />
+          <SkeletonBlock className="mt-1.5 h-2.5 w-3/5 bg-glass-border/40" />
+          <SkeletonBlock className="mt-2.5 h-2.5 w-2/5 bg-glass-border/30" />
         </div>
       </div>
-      <div className="grid grid-cols-3 gap-3">
-        {Array.from({ length: 3 }).map((_, idx) => (
-          <SkeletonBlock key={idx} className="h-24 rounded-xl bg-glass-border/40" />
+      <div className="grid grid-cols-4 gap-2 border-t border-glass-border pt-3">
+        {Array.from({ length: 4 }).map((_, idx) => (
+          <div key={idx} className="liquid-tool-surface rounded-lg px-2 py-1.5">
+            <SkeletonBlock className="h-2 w-4/5 bg-glass-border/40" />
+            <SkeletonBlock className="mt-1.5 h-3.5 w-8" />
+          </div>
         ))}
       </div>
-      <div className="liquid-card rounded-2xl border border-glass-border p-5">
-        <SkeletonBlock className="h-4 w-36" />
-        <SkeletonBlock className="mt-2 h-3 w-52 bg-glass-border/40" />
-        <div className="mt-4 space-y-3">
-          {Array.from({ length: 3 }).map((_, idx) => (
-            <SkeletonBlock key={idx} className="h-16 rounded-xl bg-glass-border/40" />
-          ))}
-        </div>
+      <div className="mt-3 flex items-center justify-between border-t border-glass-border pt-2">
+        <SkeletonBlock className="h-2.5 w-24 bg-glass-border/30" />
+        <SkeletonBlock className="h-2.5 w-16 bg-glass-border/30" />
       </div>
+    </div>
+  );
+}
+
+/** `ActivityPanel`'s StatCard: rounded-xl p-4, label + mono value + optional sub. */
+function ActivityStatsSkeleton() {
+  return (
+    <div className="grid grid-cols-3 gap-3">
+      {Array.from({ length: 3 }).map((_, idx) => (
+        <div key={idx} className="liquid-card rounded-xl border border-glass-border p-4">
+          <SkeletonBlock className="mb-2 h-2 w-20 bg-glass-border/45" />
+          <SkeletonBlock className="h-5 w-16" />
+          <SkeletonBlock className="mt-2 h-2.5 w-24 bg-glass-border/35" />
+        </div>
+      ))}
     </div>
   );
 }
@@ -139,22 +288,18 @@ function WalletSkeleton() {
 function ActivitySkeleton() {
   return (
     <div className="space-y-6">
-      <div className="grid grid-cols-3 gap-3">
-        {Array.from({ length: 3 }).map((_, idx) => (
-          <SkeletonBlock key={idx} className="h-24 rounded-xl bg-glass-border/40" />
-        ))}
-      </div>
+      <ActivityStatsSkeleton />
       <div>
-        <SkeletonBlock className="mb-3 h-4 w-32" />
+        <SkeletonBlock className="mb-3 h-3.5 w-24" />
         <div className="space-y-2">
           {Array.from({ length: 7 }).map((_, idx) => (
-            <div key={idx} className="liquid-card flex gap-3 rounded-xl border border-glass-border p-3">
+            <div key={idx} className="liquid-list-row flex gap-3 rounded-xl border border-glass-border p-3">
               <SkeletonBlock className="h-8 w-8 shrink-0 rounded-lg" />
               <div className="min-w-0 flex-1">
                 <SkeletonBlock className="h-3.5 w-3/5" />
-                <SkeletonBlock className="mt-2 h-3 w-4/5 bg-glass-border/40" />
+                <SkeletonBlock className="mt-1.5 h-2.5 w-4/5 bg-glass-border/40" />
+                <SkeletonBlock className="mt-1.5 h-2 w-1/4 bg-glass-border/30" />
               </div>
-              <SkeletonBlock className="h-3 w-10 bg-glass-border/40" />
             </div>
           ))}
         </div>
@@ -163,42 +308,262 @@ function ActivitySkeleton() {
   );
 }
 
+/** A `SearchBar` input: rounded-lg border px-3 py-2 text-sm. */
+function SearchBarSkeleton({ className = "" }: { className?: string }) {
+  return <SkeletonBlock className={`h-[38px] rounded-lg bg-glass-border/30 ${className}`} />;
+}
+
+/** The pill tab control used by MyBots / Explore. */
+function PillTabsSkeleton({ tabs = 3, pillWidth = "w-16" }: { tabs?: number; pillWidth?: string }) {
+  return (
+    <div className="liquid-tabs inline-flex items-center gap-1 rounded-full border border-glass-border p-1">
+      {Array.from({ length: tabs }).map((_, idx) => (
+        <SkeletonBlock key={idx} className={`h-7 ${pillWidth} rounded-full bg-glass-border/35`} />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Body-level skeletons, for panels that own their header and render a skeleton
+ * only inside their scroll area (ActivityPanel, ChatPane's explore/contacts).
+ */
 export function DashboardMainSkeleton({ variant }: { variant: TabSkeletonVariant }) {
-  if (variant === "wallet") return <WalletSkeleton />;
   if (variant === "activity") return <ActivitySkeleton />;
   if (variant === "explore") return <ExploreGridSkeleton />;
-  if (variant === "bots") return <CardGridSkeleton rows={4} statCards />;
-  if (variant === "home") {
+  if (variant === "bots") {
     return (
-      <div className="space-y-8">
-        <div>
-          <SkeletonBlock className="h-10 w-72" />
-          <SkeletonBlock className="mt-3 h-4 w-96 bg-glass-border/40" />
-        </div>
-        <CardGridSkeleton rows={3} statCards />
-        <ExploreGridSkeleton />
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, idx) => <BotCardSkeleton key={idx} />)}
       </div>
     );
   }
-  return <CardGridSkeleton rows={6} />;
+  if (variant === "home") return <HomeSectionsSkeleton />;
+  if (variant === "wallet") return <WalletSectionsSkeleton />;
+  return <ContactsGridSkeleton />;
 }
 
+/** `HomePanel` body: greeting, my-bots grid, then three discovery sections. */
+function HomeSectionsSkeleton() {
+  return (
+    <>
+      <div className="mb-10">
+        <SkeletonBlock className="h-9 w-80 max-w-full" />
+        <SkeletonBlock className="mt-3 h-4 w-[26rem] max-w-full bg-glass-border/40" />
+      </div>
+
+      <section className="mb-10">
+        <SectionHeaderSkeleton titleWidth="w-24" subtitleWidth="w-64" />
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, idx) => <BotActivityCardSkeleton key={idx} />)}
+          <div className="liquid-empty-state flex min-h-[148px] w-full flex-col items-center justify-center rounded-2xl border border-dashed border-glass-border/80 p-4">
+            <SkeletonBlock className="mb-3 h-11 w-11 rounded-xl bg-glass-border/35" />
+            <SkeletonBlock className="h-3.5 w-24 bg-glass-border/40" />
+          </div>
+        </div>
+      </section>
+
+      <section className="mb-10">
+        <SectionHeaderSkeleton titleWidth="w-20" subtitleWidth="w-56" />
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, idx) => <RoomEntityCardSkeleton key={idx} />)}
+        </div>
+      </section>
+
+      <section className="mb-10">
+        <SectionHeaderSkeleton titleWidth="w-24" subtitleWidth="w-52" />
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, idx) => <PersonCardSkeleton key={idx} />)}
+        </div>
+      </section>
+
+      <section className="mb-6">
+        <SectionHeaderSkeleton titleWidth="w-20" subtitleWidth="w-48" />
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, idx) => <PersonCardSkeleton key={idx} />)}
+        </div>
+      </section>
+    </>
+  );
+}
+
+/** `WalletPanel` body: total card with CTAs, bot balances, then the ledger. */
+function WalletSectionsSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="liquid-card rounded-2xl border border-glass-border p-6">
+        <SkeletonBlock className="mb-1 h-3 w-28 bg-glass-border/45" />
+        <SkeletonBlock className="mb-5 h-9 w-56" />
+        <div className="grid grid-cols-2 gap-4">
+          {Array.from({ length: 2 }).map((_, idx) => (
+            <div key={idx} className="liquid-tool-surface rounded-xl border border-glass-border p-4">
+              <SkeletonBlock className="mb-1 h-2 w-20 bg-glass-border/45" />
+              <SkeletonBlock className="h-6 w-28" />
+            </div>
+          ))}
+        </div>
+        <div className="mt-5 grid grid-cols-3 gap-3">
+          {Array.from({ length: 3 }).map((_, idx) => (
+            <SkeletonBlock key={idx} className="h-11 rounded-xl bg-glass-border/35" />
+          ))}
+        </div>
+      </div>
+
+      <div className="liquid-card rounded-2xl border border-glass-border p-5">
+        <SkeletonBlock className="mb-3 h-3.5 w-28" />
+        <div className="space-y-2">
+          {Array.from({ length: 3 }).map((_, idx) => (
+            <div key={idx} className="flex items-center gap-3 rounded-xl border border-glass-border px-3.5 py-3">
+              <SkeletonBlock className="h-9 w-9 shrink-0 rounded-xl bg-glass-border/45" />
+              <div className="min-w-0 flex-1">
+                <SkeletonBlock className="h-3.5 w-2/5" />
+                <SkeletonBlock className="mt-1.5 h-2.5 w-3/5 bg-glass-border/35" />
+              </div>
+              <div className="text-right">
+                <SkeletonBlock className="ml-auto h-4 w-20" />
+                <SkeletonBlock className="ml-auto mt-1 h-2 w-10 bg-glass-border/35" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="liquid-card rounded-2xl border border-glass-border p-5">
+        <SkeletonBlock className="h-3.5 w-36" />
+        <SkeletonBlock className="mt-1.5 h-2.5 w-52 bg-glass-border/40" />
+        <div className="liquid-tool-surface mt-3 overflow-hidden rounded-xl border border-glass-border">
+          {Array.from({ length: 4 }).map((_, idx) => (
+            <div key={idx} className="flex items-center justify-between gap-4 border-b border-glass-border/40 px-4 py-3 last:border-b-0">
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <SkeletonBlock className="h-3.5 w-20" />
+                  <SkeletonBlock className="h-3.5 w-12 rounded bg-glass-border/35" />
+                </div>
+                <SkeletonBlock className="mt-1.5 h-2.5 w-32 bg-glass-border/35" />
+              </div>
+              <div className="text-right">
+                <SkeletonBlock className="ml-auto h-2.5 w-20 bg-glass-border/40" />
+                <SkeletonBlock className="ml-auto mt-1 h-2 w-8 bg-glass-border/30" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Full-pane skeletons used while a tab navigation is pending. Each branch
+ * reproduces the target panel's own page chrome — HomePanel/MyBotsPanel/
+ * WalletPanel are centered `max-w-5xl` pages with no toolbar, while
+ * ActivityPanel and ChatPane's contacts view do have one.
+ */
 export default function DashboardTabSkeleton({
   variant,
-  compactHeader = false,
+  hasOpenConversation = false,
 }: {
   variant: TabSkeletonVariant;
-  compactHeader?: boolean;
+  hasOpenConversation?: boolean;
 }) {
   if (variant === "messages") {
-    return <DashboardMessagePaneSkeleton />;
+    return hasOpenConversation ? <DashboardMessagePaneSkeleton /> : <MessagesEmptyStateSkeleton />;
   }
 
+  if (variant === "home") {
+    return (
+      <div className="dashboard-main h-full overflow-y-auto" aria-busy="true">
+        <div className="mx-auto max-w-5xl px-6 pb-10 pt-16">
+          <HomeSectionsSkeleton />
+        </div>
+      </div>
+    );
+  }
+
+  if (variant === "bots") {
+    return (
+      <div className="dashboard-main h-full overflow-y-auto" aria-busy="true">
+        <div className="mx-auto max-w-5xl px-6 py-8">
+          <div className="mb-6">
+            <SkeletonBlock className="h-7 w-40" />
+            <SkeletonBlock className="mt-2 h-3.5 w-72 max-w-full bg-glass-border/40" />
+          </div>
+          <div className="mb-8 flex flex-wrap items-center justify-between gap-3">
+            <PillTabsSkeleton tabs={2} pillWidth="w-20" />
+            <SkeletonBlock className="h-9 w-28 rounded-lg bg-glass-border/35" />
+          </div>
+          <DashboardMainSkeleton variant="bots" />
+        </div>
+      </div>
+    );
+  }
+
+  if (variant === "wallet") {
+    return (
+      <div className="dashboard-main h-full overflow-y-auto" aria-busy="true">
+        <div className="mx-auto max-w-5xl px-6 py-8">
+          <div className="mb-6 flex items-start justify-between gap-4">
+            <div>
+              <SkeletonBlock className="h-7 w-32" />
+              <SkeletonBlock className="mt-2 h-3.5 w-64 max-w-full bg-glass-border/40" />
+            </div>
+            <SkeletonBlock className="h-9 w-9 shrink-0 rounded-lg bg-glass-border/35" />
+          </div>
+          <WalletSectionsSkeleton />
+        </div>
+      </div>
+    );
+  }
+
+  if (variant === "explore") {
+    return (
+      <div className="dashboard-main relative flex h-full flex-col overflow-hidden" aria-busy="true">
+        <div className="mx-auto w-full max-w-5xl px-6 pt-8">
+          <SkeletonBlock className="h-7 w-24" />
+          <SkeletonBlock className="mt-2 h-3.5 w-80 max-w-full bg-glass-border/40" />
+          <div className="mt-5">
+            <PillTabsSkeleton tabs={3} pillWidth="w-16" />
+          </div>
+          <SearchBarSkeleton className="mt-5 w-full max-w-xl" />
+        </div>
+        <div className="mx-auto w-full max-w-5xl flex-1 overflow-y-auto px-6 py-6">
+          <ExploreGridSkeleton />
+        </div>
+      </div>
+    );
+  }
+
+  if (variant === "activity") {
+    return (
+      <div className="dashboard-main flex h-full flex-col overflow-hidden" aria-busy="true">
+        <div className="liquid-toolbar flex items-center justify-between border-b border-glass-border px-6 py-4">
+          <SkeletonBlock className="h-4 w-20" />
+          <div className="liquid-tabs flex gap-1 rounded-lg border border-glass-border p-0.5">
+            {Array.from({ length: 3 }).map((_, idx) => (
+              <SkeletonBlock key={idx} className="h-6 w-14 rounded-md bg-glass-border/35" />
+            ))}
+          </div>
+        </div>
+        <div className="flex-1 space-y-6 overflow-y-auto px-6 py-5">
+          <ActivitySkeleton />
+        </div>
+      </div>
+    );
+  }
+
+  // contacts
   return (
-    <div className="dashboard-main flex h-full flex-col">
-      <HeaderSkeleton compact={compactHeader} />
-      <div className={variant === "explore" || variant === "home" || variant === "bots" ? "flex-1 overflow-y-auto px-6 py-6" : "flex-1 overflow-y-auto px-5 py-4"}>
-        <DashboardMainSkeleton variant={variant} />
+    <div className="dashboard-main flex h-full flex-col overflow-hidden" aria-busy="true">
+      <div className="border-b border-glass-border px-5 py-4">
+        <SkeletonBlock className="h-4 w-24" />
+        <SkeletonBlock className="mt-2 h-3 w-56 max-w-full bg-glass-border/40" />
+        <div className="mt-3 flex flex-wrap items-center gap-3">
+          <SearchBarSkeleton className="min-w-[240px] max-w-xl flex-1" />
+          <SkeletonBlock className="h-9 w-24 rounded bg-glass-border/35" />
+        </div>
+      </div>
+      <div className="flex-1 overflow-y-auto px-5 py-4">
+        <ContactsGridSkeleton />
       </div>
     </div>
   );

--- a/frontend/src/components/dashboard/README.md
+++ b/frontend/src/components/dashboard/README.md
@@ -77,6 +77,7 @@ dashboard/
 
 ## 变更日志
 
+- 2026-08-27: `DashboardTabSkeleton.tsx` 按各面板真实布局重写全部 tab 骨架（Home/My Bots/Wallet 走 `max-w-5xl` 居中页且不再套顶栏，Explore/Activity/Contacts 复刻各自的工具栏与网格），并新增 `ContactSectionsSkeleton`、`RoomRowsSkeleton`、`MessagesEmptyStateSkeleton` 供 Sidebar、ContactsPanel、RoomList 共用；`/settings/policy` 的加载态同步改为 `PolicyFormSkeleton`。骨架与加载完成后的框架保持一致，改布局时需同步改骨架。
 - 2026-06-03: `MessageList.tsx` 与 `UserChatPane.tsx` 的消息滚动改为用户上滑后暂停自动追随，并显示紧凑的回到底部图标按钮；点击后恢复追随最新内容。
 - 2026-06-01: `MessageList.tsx` 的消息 React key 改为优先使用跨 fan-out 稳定的 `msg_id`，配合附件图片固定占位，减少后台同步时图片预览闪烁。
 - 2026-06-01: `DocumentPreviewPane.tsx` 的右侧附件预览支持桌面端拖拽左边缘调整宽度，并记住最近一次宽度。

--- a/frontend/src/components/dashboard/sidebar/ContactsPanel.tsx
+++ b/frontend/src/components/dashboard/sidebar/ContactsPanel.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "nextjs-toploader/app";
 import { ChevronDown, UserPlus2, Users } from "lucide-react";
 import { CompositeAvatar } from "../CompositeAvatar";
 import BotAvatar from "../BotAvatar";
-import { SidebarListSkeleton, SkeletonBlock } from "../DashboardTabSkeleton";
+import { ContactSectionsSkeleton, PinnedRequestRowSkeleton } from "../DashboardTabSkeleton";
 import { useShallow } from "zustand/shallow";
 import { useDashboardChatStore } from "@/store/useDashboardChatStore";
 import { useDashboardContactStore } from "@/store/useDashboardContactStore";
@@ -216,14 +216,8 @@ export default function ContactsPanel({ onOpenAddFriend }: ContactsPanelProps) {
   if (!overview) {
     return (
       <div className="flex h-full flex-col">
-        <div className="flex items-center gap-3 border-b border-glass-border px-3 py-3">
-          <SkeletonBlock className="h-10 w-10 rounded-full" />
-          <div className="min-w-0 flex-1">
-            <SkeletonBlock className="h-3.5 w-32" />
-            <SkeletonBlock className="mt-2 h-2.5 w-24 bg-glass-border/40" />
-          </div>
-        </div>
-        <SidebarListSkeleton rows={9} />
+        <PinnedRequestRowSkeleton />
+        <ContactSectionsSkeleton />
       </div>
     );
   }

--- a/frontend/src/components/dashboard/sidebar/index.tsx
+++ b/frontend/src/components/dashboard/sidebar/index.tsx
@@ -37,7 +37,7 @@ import ContactsPanel from "./ContactsPanel";
 import MessagesGroupingSidebar from "./MessagesGroupingSidebar";
 import BotsPanel from "./BotsPanel";
 import MessagesPanel from "./MessagesPanel";
-import { RoomRowsSkeleton, SidebarListSkeleton, SkeletonBlock } from "../DashboardTabSkeleton";
+import { ContactSectionsSkeleton, PinnedRequestRowSkeleton, RoomRowsSkeleton, SkeletonBlock } from "../DashboardTabSkeleton";
 
 import { UserPlus, LogIn, Bot, Plus, RefreshCw, MessageSquarePlus, Search, X } from "lucide-react";
 import { useAppStore } from "@/store/useAppStore";
@@ -605,9 +605,12 @@ function Sidebar({
                   </div>
                   <RoomRowsSkeleton />
                 </>
-              ) : (
-                <SidebarListSkeleton rows={visibleSidebarTab === "contacts" ? 9 : 7} />
-              )}
+              ) : visibleSidebarTab === "contacts" ? (
+                <>
+                  <PinnedRequestRowSkeleton />
+                  <ContactSectionsSkeleton />
+                </>
+              ) : null}
             </>
           ) : visibleSidebarTab === "messages" && (
             <MessagesPanel


### PR DESCRIPTION
## 问题

点击 tab 后的加载骨架和加载完成后的框架对不上：`DashboardTabSkeleton` 对所有 tab 都是「顶栏 + 通用卡片网格」，而真实面板里 Home / My Bots / Wallet 是 `max-w-5xl` 居中页且**没有顶栏**，Activity / Contacts 各有自己的工具栏。首帧是一套布局，加载完是另一套。

截图（首页）里能看到：骨架顶部有一条不存在的 header bar，内容铺满整宽而不是居中 `max-w-5xl`，卡片网格列数和卡片形状都和真实首页不同。

## 改动

每个 variant 复刻它所代表的面板：

| variant | 对齐到 |
|---|---|
| `home` | 无顶栏；`mx-auto max-w-5xl px-6 pb-10 pt-16`；greeting 块 + my-bots 网格（3 张 BotActivityCard + 虚线 create 卡）+ 三个 discovery section（room 卡带 56px 封面、PersonCard 带 40px 头像和两行 bio） |
| `bots` | `max-w-5xl px-6 py-8`；标题块 + pill 子 tab + 创建按钮；`grid-cols-1 md:grid-cols-2`，卡片 `rounded-2xl p-5` + 48px 头像 + 4 列 stats + 底部行 |
| `wallet` | `max-w-5xl px-6 py-8`；标题 + 隐藏金额按钮；总额卡（2-up 拆分 + 3 个 CTA）、Bot 余额列表、账本表格 |
| `explore` | `max-w-5xl` 头部（标题 + pill tabs + 搜索框）+ 与 `EXPLORE_GRID_CLASS` 相同列数的网格 |
| `activity` | `liquid-toolbar` 顶栏 + period tabs；stat 卡和 feed 行对齐 `StatCard`/`FeedItem` |
| `contacts` | `px-5 py-4` 头部（搜索 + 邀请按钮）+ 1/2/3 列卡片；侧栏树改为分组标题 + 32px 头像行 |
| `messages` | 没有真正打开会话时用空态骨架，不再闪聊天面板 |

其他：

- shell 骨架的二级面板宽度 280px → 360px（真实 `sidebarWidth` 默认值）
- Activity 没有二级面板内容，骨架不再画一列幽灵列表
- `/settings/policy` 的加载态从两张通用卡片改为对齐 `PolicyForm`（3 个 SummaryTile + 2 个 Card）
- 删除已无人使用的 `SidebarListSkeleton`（本次改动造成的孤儿）

## 验证

- `vitest run src/components/dashboard` — 41 passed
- `tsc --noEmit` — 无新增错误
- `next build` — Compiled successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)