### PR TITLE
fix(frontend): give semantic status colors a light-mode set

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -20,6 +20,10 @@
 
 html[data-theme="dark"] {
   color-scheme: dark;
+  /* Foreground for filled neon-accent surfaces (unread pills, badges). The
+   * accent flips from bright neon on dark to a deep teal on light, so the text
+   * on top has to flip the other way. */
+  --color-on-accent: #0a0a0f;
   --liquid-canvas:
     radial-gradient(circle at 12% 8%, rgba(0, 240, 255, 0.11), transparent 30%),
     radial-gradient(circle at 85% 13%, rgba(139, 92, 246, 0.10), transparent 29%),
@@ -38,6 +42,7 @@ html[data-theme="dark"] {
 
 html[data-theme="light"] {
   color-scheme: light;
+  --color-on-accent: #ffffff;
   --color-deep-black: #eef3f9;
   --color-deep-black-light: rgba(255, 255, 255, 0.72);
   --color-neon-cyan: #007b93;
@@ -68,6 +73,58 @@ html[data-theme="light"] {
   --color-zinc-200: #2c3e54;
   --color-zinc-100: #17283d;
   --color-white: #17283d;
+
+  /*
+   * Semantic status colors (danger / warning / success / info) are used as raw
+   * Tailwind palette classes across the dashboard — `text-red-400`,
+   * `bg-amber-400/10`, `border-emerald-400/30` and friends. Those shades were
+   * picked to glow on a near-black canvas; on the light canvas they wash out
+   * (text-red-400 lands around 2.5:1 against white). Tailwind v4 resolves each
+   * of them to `var(--color-<name>-<shade>)`, so remapping the shades actually
+   * in use shifts every occurrence at once — including the `color-mix`-based
+   * `/10` and `/40` tints, which stay correctly pale because they are mixed
+   * from the new darker base.
+   *
+   * The mapping keeps hue and moves each shade down the official Tailwind
+   * ramp (200-400 -> 700/800, 500 -> 600) so contrast on a light surface lands
+   * above 4.5:1 while solid dots and fills read darker rather than neon.
+   */
+  --color-red-200: #991b1b;
+  --color-red-300: #b91c1c;
+  --color-red-400: #b91c1c;
+  --color-red-500: #dc2626;
+  --color-orange-300: #c2410c;
+  --color-orange-400: #c2410c;
+  --color-orange-500: #ea580c;
+  --color-amber-100: #78350f;
+  --color-amber-200: #92400e;
+  --color-amber-300: #b45309;
+  --color-amber-400: #b45309;
+  --color-amber-500: #d97706;
+  --color-yellow-100: #713f12;
+  --color-yellow-200: #854d0e;
+  --color-yellow-300: #a16207;
+  --color-yellow-400: #a16207;
+  --color-yellow-500: #ca8a04;
+  --color-green-300: #15803d;
+  --color-green-400: #16a34a;
+  --color-green-500: #16a34a;
+  --color-emerald-200: #065f46;
+  --color-emerald-300: #047857;
+  --color-emerald-400: #047857;
+  --color-emerald-500: #059669;
+  --color-teal-300: #0f766e;
+  --color-cyan-200: #155e75;
+  --color-cyan-300: #0e7490;
+  --color-cyan-400: #0e7490;
+  --color-cyan-500: #0891b2;
+  --color-sky-300: #0369a1;
+  --color-sky-400: #0369a1;
+  --color-sky-500: #0284c7;
+  --color-blue-400: #1d4ed8;
+  --color-rose-300: #be123c;
+  --color-rose-400: #be123c;
+  --color-pink-500: #db2777;
 
   --liquid-canvas:
     radial-gradient(circle at 10% 4%, rgba(0, 149, 182, 0.14), transparent 31%),

--- a/frontend/src/components/dashboard/AccountMenu.tsx
+++ b/frontend/src/components/dashboard/AccountMenu.tsx
@@ -67,7 +67,7 @@ export default function AccountMenu({
             </span>
             <span className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border-2 border-deep-black-light bg-neon-purple" />
             {pendingRequests > 0 && (
-              <span className="absolute -right-1 -top-1 flex h-4 min-w-[16px] items-center justify-center rounded-full bg-neon-purple px-1 text-[9px] font-bold text-black">
+              <span className="absolute -right-1 -top-1 flex h-4 min-w-[16px] items-center justify-center rounded-full bg-neon-purple px-1 text-[9px] font-bold text-[var(--color-on-accent)]">
                 {pendingRequests > 9 ? "9+" : pendingRequests}
               </span>
             )}

--- a/frontend/src/components/dashboard/AgentChannelsTab.tsx
+++ b/frontend/src/components/dashboard/AgentChannelsTab.tsx
@@ -1314,7 +1314,7 @@ function FeishuAddForm({
           <div className="space-y-2">
             <div className="text-xs text-text-secondary">{statusText[status]}</div>
             {phase === "scanning" && qrcodeUrl ? (
-              <div className="inline-block rounded-xl border border-glass-border bg-white p-3">
+              <div className="inline-block rounded-xl border border-glass-border bg-[#ffffff] p-3">
                 <QRCodeSVG value={qrcodeUrl} size={176} />
               </div>
             ) : null}
@@ -1739,7 +1739,7 @@ function WechatAddForm({
               <WechatLoginExpiryNotice remainingMs={loginRemainingMs} />
             </div>
             {qrcodeUrl ? (
-              <div className="inline-flex h-44 w-44 items-center justify-center rounded-md border border-glass-border bg-white p-2">
+              <div className="inline-flex h-44 w-44 items-center justify-center rounded-md border border-glass-border bg-[#ffffff] p-2">
                 <QRCodeSVG
                   value={qrcodeUrl}
                   size={160}
@@ -2532,7 +2532,7 @@ function GatewayEditForm({
                   {wechatStatusText[wechatStatus]}
                 </div>
                 {wechatQrcodeUrl ? (
-                  <div className="inline-flex h-36 w-36 items-center justify-center rounded-md border border-glass-border bg-white p-2">
+                  <div className="inline-flex h-36 w-36 items-center justify-center rounded-md border border-glass-border bg-[#ffffff] p-2">
                     <QRCodeSVG
                       value={wechatQrcodeUrl}
                       size={128}

--- a/frontend/src/components/dashboard/ContactRequestsInbox.tsx
+++ b/frontend/src/components/dashboard/ContactRequestsInbox.tsx
@@ -248,7 +248,7 @@ export default function ContactRequestsInbox({
                                 {group.agentId}
                               </p>
                             </div>
-                            <span className="rounded-full bg-neon-cyan px-1.5 text-[10px] font-bold text-black">
+                            <span className="rounded-full bg-neon-cyan px-1.5 text-[10px] font-bold text-[var(--color-on-accent)]">
                               {group.approvals.length}
                             </span>
                             <ChevronDown

--- a/frontend/src/components/dashboard/DocumentPreviewPane.tsx
+++ b/frontend/src/components/dashboard/DocumentPreviewPane.tsx
@@ -304,7 +304,7 @@ export default function DocumentPreviewPane({ attachment, onClose }: DocumentPre
           title={title}
           sandbox="allow-popups"
           srcDoc={content}
-          className="h-full w-full border-0 bg-white"
+          className="h-full w-full border-0 bg-[#ffffff]"
         />
       );
     }

--- a/frontend/src/components/dashboard/RoomList.tsx
+++ b/frontend/src/components/dashboard/RoomList.tsx
@@ -103,7 +103,7 @@ function UnreadBadge({ count }: { count: number }) {
   return (
     <span
       ref={badgeRef}
-      className="flex h-5 min-w-[20px] items-center justify-center rounded-full bg-neon-cyan px-1.5 text-[10px] font-bold leading-none text-text-primary shadow-[0_0_10px_rgba(34,211,238,0.55)]"
+      className="flex h-5 min-w-[20px] items-center justify-center rounded-full bg-neon-cyan px-1.5 text-[10px] font-bold leading-none text-[var(--color-on-accent)] shadow-[0_0_10px_rgba(34,211,238,0.55)]"
     >
       {formatUnreadCount(count)}
     </span>

--- a/frontend/src/components/dashboard/RoomZeroState.tsx
+++ b/frontend/src/components/dashboard/RoomZeroState.tsx
@@ -218,7 +218,7 @@ export default function RoomZeroState({ compact = false, hasRooms = false, onHum
                       </div>
                     </div>
                     <span
-                      className="absolute right-2 top-2 rounded-full bg-black/40 px-2 py-0.5 text-[10px] font-medium text-white/90 backdrop-blur-sm"
+                      className="absolute right-2 top-2 rounded-full bg-black/40 px-2 py-0.5 text-[10px] font-medium text-[#ffffff]/90 backdrop-blur-sm"
                       style={{ boxShadow: `0 0 0 1px ${theme.accent}55` }}
                     >
                       {room.member_count} {memberWord}

--- a/frontend/src/components/dashboard/sidebar/ContactsPanel.tsx
+++ b/frontend/src/components/dashboard/sidebar/ContactsPanel.tsx
@@ -236,7 +236,7 @@ export default function ContactsPanel({ onOpenAddFriend }: ContactsPanelProps) {
           <div className="flex items-center gap-2">
             <span className="text-sm font-medium text-text-primary">{t.newRequests}</span>
             {totalPendingRequests > 0 ? (
-              <span className="rounded-full bg-neon-cyan px-1.5 text-[10px] font-bold text-text-primary">
+              <span className="rounded-full bg-neon-cyan px-1.5 text-[10px] font-bold text-[var(--color-on-accent)]">
                 {totalPendingRequests > 99 ? "99+" : totalPendingRequests}
               </span>
             ) : null}

--- a/frontend/src/components/dashboard/sidebar/MessagesPanel.tsx
+++ b/frontend/src/components/dashboard/sidebar/MessagesPanel.tsx
@@ -373,7 +373,7 @@ export default function MessagesPanel({ isGuest, onCreateRoom, onAddFriend }: Me
               <span className={`text-sm font-medium ${messagesShowRequests ? "text-neon-cyan" : "text-text-primary"}`}>
                 {locale === "zh" ? "新好友申请" : "New Requests"}
               </span>
-              <span className="rounded-full bg-neon-cyan px-1.5 text-[10px] font-bold text-text-primary">
+              <span className="rounded-full bg-neon-cyan px-1.5 text-[10px] font-bold text-[var(--color-on-accent)]">
                 {pendingRequestCount}
               </span>
             </div>

--- a/frontend/src/components/dashboard/sidebar/index.tsx
+++ b/frontend/src/components/dashboard/sidebar/index.tsx
@@ -412,7 +412,7 @@ function Sidebar({
               badge = (
                 <span
                   data-primary-nav-badge
-                  className="absolute -right-1 -top-1 flex h-4 min-w-[16px] items-center justify-center rounded-full bg-neon-cyan px-1 text-[9px] font-bold leading-none text-black shadow-[0_0_12px_rgba(34,211,238,0.45)]"
+                  className="absolute -right-1 -top-1 flex h-4 min-w-[16px] items-center justify-center rounded-full bg-neon-cyan px-1 text-[9px] font-bold leading-none text-[var(--color-on-accent)] shadow-[0_0_12px_rgba(34,211,238,0.45)]"
                 >
                   {formatBadgeCount(unreadMessageCount)}
                 </span>
@@ -422,7 +422,7 @@ function Sidebar({
               badge = (
                 <span
                   data-primary-nav-badge
-                  className="absolute -right-1 -top-1 flex h-4 min-w-[16px] items-center justify-center rounded-full bg-neon-cyan px-1 text-[9px] font-bold text-black shadow-[0_0_12px_rgba(34,211,238,0.45)]"
+                  className="absolute -right-1 -top-1 flex h-4 min-w-[16px] items-center justify-center rounded-full bg-neon-cyan px-1 text-[9px] font-bold text-[var(--color-on-accent)] shadow-[0_0_12px_rgba(34,211,238,0.45)]"
                 >
                   {formatBadgeCount(pendingContactRequests)}
                 </span>


### PR DESCRIPTION
## 回答「是不是所有颜色都有两套」

**不是。** 主题层只给自己的 token 做了两套，Tailwind 原生调色板没有。

**有两套的**（`html[data-theme="light"]` 里重映射）：`deep-black`、`deep-black-light`、`neon-cyan/purple/green`、`glass-bg`、`glass-border`、`text-primary`、`text-secondary`、`zinc-*`、`white`、`liquid-*`。

**没有两套的**：dashboard 里约 **600 处**直接用的语义色 —— `text-red-400`、`bg-amber-400/10`、`border-emerald-400/30`、`text-yellow-300`、`text-cyan-400`…… 这些档位是为近黑画布挑的发光色，放到浅色画布上：`text-red-400` 对白底只有约 2.5:1，amber/yellow/emerald 文字几乎看不见。

## 改动

Tailwind v4 把每个具名色编译成 `var(--color-<name>-<shade>)`（已在构建产物中确认），所以在 light 主题里重映射实际用到的 35 个档位即可一次性覆盖全部约 600 处，包括基于 `color-mix` 的 `/10`、`/40` 透明变体（它们从新的深色基底混合，仍然是淡底）。映射规则：保持色相，档位整体下移（200–400 → 700/800，500 → 600）。

顺带修了三处「现有重映射反而搞坏了」的地方：

1. **QR 码扫不出来**：`bg-white` 解析为 `var(--color-white)`，light 下被映射成 `#17283d`，于是三个二维码容器和文档预览 iframe 的背景变成深蓝黑。改用字面量 `#ffffff`（这些地方需要真白，与主题无关）。
2. **实心 accent 徽章对比不足**：`text-black` 保持纯黑，而 accent 本身在 light 下变成深青 `#007b93`。新增 `--color-on-accent`（dark `#0a0a0f` / light `#ffffff`），用于这些徽章，包括原本 `bg-neon-cyan` + `text-text-primary` 的未读气泡。
3. **房间封面成员数徽章**：底色固定 `bg-black/40`，文字改为固定白色，不再跟随 `--color-white`。

## 验证

- `vitest run src` — 205 passed
- `next build` — Compiled successfully，并确认产物里 light 块输出 `--color-red-400:#b91c1c`、`--color-emerald-400:#047857`，dark 块保持原值

## 已知未覆盖（本 PR 不含）

- **动效发光**：约 20 处内联 `rgba(34,211,238,…)` / `rgba(0,240,255,…)` 的 box-shadow 关键帧（RoomList 未读脉冲、SearchBar/MessageComposer focus glow、MessageList 高亮）。它们是 anime.js 的插值关键帧，用 `var()` 会失去 tween 能力，需要单独改造。浅色下表现为「发光变弱」，不影响可读性。
- **营销站** `components/home/*`：约 40 处 `bg-white/[0.03]`、`border-white/10`、`text-white/90`。默认主题就是 light，需要单独确认每个区块的底色再判断。

🤖 Generated with [Claude Code](https://claude.com/claude-code)