### PR TITLE
fix(frontend): make the hero particle mesh readable in light mode

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -370,6 +370,26 @@ html[data-theme="dark"] .liquid-list-row.liquid-room-row-selected {
   background: rgba(35, 55, 79, 0.42);
 }
 
+/*
+ * The marketing hero renders a WebGL particle mesh behind the copy. On the
+ * light canvas the mesh has enough contrast to compete with the headline, so a
+ * radial wash of the page background fades it out where the text sits and lets
+ * it stay visible toward the edges. Dark mode needs no wash.
+ */
+.hero-scene-veil {
+  display: none;
+}
+
+html[data-theme="light"] .hero-scene-veil {
+  display: block;
+  background: radial-gradient(
+    92% 58% at 50% 30%,
+    rgba(238, 243, 249, 0.88) 0%,
+    rgba(238, 243, 249, 0.6) 42%,
+    rgba(238, 243, 249, 0) 76%
+  );
+}
+
 html[data-theme="dark"] .liquid-scrim {
   background: rgba(3, 10, 20, 0.62);
 }

--- a/frontend/src/components/three/ParticleNetwork.tsx
+++ b/frontend/src/components/three/ParticleNetwork.tsx
@@ -3,6 +3,7 @@
 import { useRef, useMemo, useEffect } from "react";
 import { useFrame, useThree } from "@react-three/fiber";
 import * as THREE from "three";
+import { useAppStore } from "@/store/useAppStore";
 
 /**
  * [INPUT]: 依赖 @react-three/fiber 的 useFrame/useThree 与 three 的 BufferGeometry 能力
@@ -12,6 +13,9 @@ import * as THREE from "three";
  */
 const PARTICLE_COUNT = 110;
 const CONNECTION_DISTANCE = 2.5;
+/* The light canvas is near-white, so the same web of links reads as hard
+ * scribble instead of a faint glow. A shorter link radius thins the mesh. */
+const CONNECTION_DISTANCE_LIGHT = 1.85;
 const PULSE_COUNT = 14;
 const CONNECTION_UPDATE_INTERVAL = 1 / 30;
 const CELL_BIAS = 64;
@@ -19,6 +23,37 @@ const CELL_BIAS = 64;
 function packCellKey(x: number, y: number, z: number) {
   return (x + CELL_BIAS) | ((y + CELL_BIAS) << 8) | ((z + CELL_BIAS) << 16);
 }
+
+/* Additive blending assumes a dark backdrop: on the transparent canvas it also
+ * accumulates alpha, so a dark teal line composited over the light page turns
+ * into a near-black stroke. Light mode therefore uses normal blending with a
+ * solid ink color and per-edge alpha carried in the vertex color. */
+const THEME_STYLE = {
+  dark: {
+    connectionDistance: CONNECTION_DISTANCE,
+    blending: THREE.AdditiveBlending,
+    lineColor: [0, 0.72, 0.78] as const,
+    lineAlpha: 0.12,
+    nodeColor: "#6aaeb5",
+    nodeOpacity: 0.42,
+    nodeSize: 0.04,
+    pulseColor: "#7ebbc2",
+    pulseOpacity: 0.45,
+    pulseSize: 0.06,
+  },
+  light: {
+    connectionDistance: CONNECTION_DISTANCE_LIGHT,
+    blending: THREE.NormalBlending,
+    lineColor: [0.05, 0.42, 0.5] as const,
+    lineAlpha: 0.26,
+    nodeColor: "#0d6f80",
+    nodeOpacity: 0.5,
+    nodeSize: 0.035,
+    pulseColor: "#0e7490",
+    pulseOpacity: 0.55,
+    pulseSize: 0.05,
+  },
+} as const;
 
 function isMobile() {
   return typeof window !== "undefined" && window.innerWidth < 768;
@@ -32,6 +67,8 @@ export default function ParticleNetwork() {
   const connectionTickRef = useRef(0);
   const hiddenRef = useRef(false);
   const { size } = useThree();
+  const theme = useAppStore((s) => s.theme);
+  const style = THEME_STYLE[theme === "dark" ? "dark" : "light"];
 
   const count = useMemo(
     () => (isMobile() ? Math.floor(PARTICLE_COUNT * 0.55) : PARTICLE_COUNT),
@@ -73,8 +110,10 @@ export default function ParticleNetwork() {
     () => new Float32Array(maxConnections * 6),
     [maxConnections]
   );
+  /* itemSize 4: the alpha channel fades each edge with distance, which normal
+   * blending needs and additive blending consumes identically. */
   const lineColors = useMemo(
-    () => new Float32Array(maxConnections * 6),
+    () => new Float32Array(maxConnections * 8),
     [maxConnections]
   );
 
@@ -138,8 +177,9 @@ export default function ParticleNetwork() {
       connectionTickRef.current += delta;
       if (connectionTickRef.current >= CONNECTION_UPDATE_INTERVAL) {
         connectionTickRef.current = 0;
-        const maxDistanceSq = CONNECTION_DISTANCE * CONNECTION_DISTANCE;
-        const invCellSize = 1 / CONNECTION_DISTANCE;
+        const connectionDistance = style.connectionDistance;
+        const maxDistanceSq = connectionDistance * connectionDistance;
+        const invCellSize = 1 / connectionDistance;
         const grid = new Map<number, number[]>();
         let lineIdx = 0;
 
@@ -194,13 +234,16 @@ export default function ParticleNetwork() {
                   linePositions[li + 4] = pos[jx + 1];
                   linePositions[li + 5] = pos[jx + 2];
 
-                  const a = alpha * 0.12;
-                  lineColors[li] = 0;
-                  lineColors[li + 1] = 0.72 * a;
-                  lineColors[li + 2] = 0.78 * a;
-                  lineColors[li + 3] = 0;
-                  lineColors[li + 4] = 0.72 * a;
-                  lineColors[li + 5] = 0.78 * a;
+                  const a = alpha * style.lineAlpha;
+                  const ci = lineIdx * 8;
+                  lineColors[ci] = style.lineColor[0];
+                  lineColors[ci + 1] = style.lineColor[1];
+                  lineColors[ci + 2] = style.lineColor[2];
+                  lineColors[ci + 3] = a;
+                  lineColors[ci + 4] = style.lineColor[0];
+                  lineColors[ci + 5] = style.lineColor[1];
+                  lineColors[ci + 6] = style.lineColor[2];
+                  lineColors[ci + 7] = a;
                   lineIdx++;
                 }
               }
@@ -262,12 +305,12 @@ export default function ParticleNetwork() {
           />
         </bufferGeometry>
         <pointsMaterial
-          size={0.04}
-          color="#6aaeb5"
+          size={style.nodeSize}
+          color={style.nodeColor}
           transparent
-          opacity={0.42}
+          opacity={style.nodeOpacity}
           sizeAttenuation
-          blending={THREE.AdditiveBlending}
+          blending={style.blending}
           depthWrite={false}
         />
       </points>
@@ -281,13 +324,13 @@ export default function ParticleNetwork() {
           />
           <bufferAttribute
             attach="attributes-color"
-            args={[lineColors, 3]}
+            args={[lineColors, 4]}
           />
         </bufferGeometry>
         <lineBasicMaterial
           vertexColors
           transparent
-          blending={THREE.AdditiveBlending}
+          blending={style.blending}
           depthWrite={false}
         />
       </lineSegments>
@@ -301,12 +344,12 @@ export default function ParticleNetwork() {
           />
         </bufferGeometry>
         <pointsMaterial
-          size={0.06}
-          color="#7ebbc2"
+          size={style.pulseSize}
+          color={style.pulseColor}
           transparent
-          opacity={0.45}
+          opacity={style.pulseOpacity}
           sizeAttenuation
-          blending={THREE.AdditiveBlending}
+          blending={style.blending}
           depthWrite={false}
         />
       </points>

--- a/frontend/src/components/three/ParticleNetworkScene.tsx
+++ b/frontend/src/components/three/ParticleNetworkScene.tsx
@@ -6,7 +6,7 @@ import ParticleNetwork from "./ParticleNetwork";
 /**
  * [INPUT]: 依赖 @react-three/fiber Canvas 与 ParticleNetwork 作为场景内容
  * [OUTPUT]: 对外提供固定定位的首页 WebGL 背景场景
- * [POS]: 首页营销页背景容器，管理画布分辨率与渲染参数
+ * [POS]: 首页营销页背景容器，管理画布分辨率、渲染参数与浅色模式雾化遮罩
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
 export default function ParticleNetworkScene() {
@@ -24,6 +24,8 @@ export default function ParticleNetworkScene() {
       >
         <ParticleNetwork />
       </Canvas>
+      {/* Light mode only: keeps the hero copy off the densest part of the mesh. */}
+      <div className="hero-scene-veil pointer-events-none absolute inset-0" />
     </div>
   );
 }


### PR DESCRIPTION
## 问题

首页 hero 的 WebGL 粒子网络在浅色模式下呈现为一片近黑色的乱线，直接穿过标题和副本，可读性很差。

根因：`ParticleNetwork` 的连线用 `AdditiveBlending` 画在透明 canvas 上。Additive 同时累加 alpha，导致 canvas 变得不透明、颜色接近 0，合成到浅色页面上就成了黑线（深色背景下看不出来，因为原本就是发光效果）。

## 改动

- 连线颜色改为 4 分量 vertex color（rgb + per-edge alpha），不再把 alpha 预乘进 rgb
- 浅色模式：`NormalBlending` + 深青实色 + 更短的连线半径（2.5 → 1.85），网格更疏更柔和
- 浅色模式新增 `.hero-scene-veil` 径向遮罩，用页面底色把标题区背景洗干净，边缘仍保留网格
- 深色模式视觉不变（vertex alpha 路径与原来的预乘颜色等价）

## 验证

- `pnpm build` 通过
- Playwright 截图对比浅色 / 深色首屏：浅色标题区干净可读，深色保持原发光效果