### PR TITLE
fix(frontend): adapt the marketing logo and page canvas to light mode

### DIFF
--- a/frontend/src/app/(marketing)/layout.tsx
+++ b/frontend/src/app/(marketing)/layout.tsx
@@ -8,6 +8,9 @@ export default function MarketingLayout({
 }) {
   return (
     <>
+      {/* Light-mode only: gives the marketing pages the depth the dark theme
+          gets from the particle mesh. Sits under the hero scene (-z-10). */}
+      <div className="marketing-canvas pointer-events-none fixed inset-0 -z-20" aria-hidden="true" />
       <Navbar />
       <main>{children}</main>
       <Footer />

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -38,6 +38,29 @@ html[data-theme="dark"] {
   --color-zinc-900: rgba(18, 26, 39, 0.84);
   --color-zinc-800: rgba(39, 50, 66, 0.76);
   --color-zinc-700: rgba(82, 96, 118, 0.68);
+
+  /* Marketing mock illustrations — the fake room/panel screenshots on the home
+   * page. They are drawn as glass floating on the canvas, so every surface has
+   * to flip with the theme rather than stay a literal rgba(0,0,0,...). */
+  --mock-shell: rgba(0, 0, 0, 0.30);
+  --mock-shell-tint: rgba(0, 0, 0, 0.23);
+  --mock-sheen-strong: rgba(255, 255, 255, 0.08);
+  --mock-sheen-soft: rgba(255, 255, 255, 0.04);
+  --mock-inset: rgba(0, 0, 0, 0.24);
+  --mock-stroke: rgba(255, 255, 255, 0.18);
+  --mock-chip: rgba(0, 0, 0, 0.32);
+  --mock-dock: #06080ddd;
+  --mock-shadow: 0 24px 60px rgba(0, 0, 0, 0.28);
+  --mock-shadow-soft: 0 18px 44px rgba(0, 0, 0, 0.22);
+  --mock-shadow-card: 0 14px 32px rgba(0, 0, 0, 0.18);
+  --mock-shadow-card-sm: 0 12px 28px rgba(0, 0, 0, 0.15);
+  --mock-shadow-dock: 0 18px 54px rgba(0, 0, 0, 0.42);
+  /* Room-card covers are saturated art; text sits directly on them. */
+  --mock-cover-ink: rgba(255, 255, 255, 0.95);
+  --mock-cover-ink-soft: rgba(255, 255, 255, 0.75);
+  --mock-cover-scrim: rgba(10, 10, 15, 0.60);
+  --mock-cover-scrim-mid: rgba(10, 10, 15, 0.10);
+  --mock-cover-fade: rgba(10, 10, 15, 0.28);
 }
 
 html[data-theme="light"] {
@@ -137,6 +160,27 @@ html[data-theme="light"] {
   --liquid-highlight: rgba(255, 255, 255, 0.94);
   --liquid-control: rgba(255, 255, 255, 0.72);
   --liquid-shadow: 0 20px 44px rgba(42, 69, 101, 0.17), 0 3px 10px rgba(42, 69, 101, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.94);
+
+  /* Mirror of the mock surfaces above: white glass over the light canvas, with
+   * shadows tinted toward the canvas blue instead of neutral black. */
+  --mock-shell: rgba(255, 255, 255, 0.66);
+  --mock-shell-tint: rgba(255, 255, 255, 0.58);
+  --mock-sheen-strong: rgba(255, 255, 255, 0.85);
+  --mock-sheen-soft: rgba(255, 255, 255, 0.5);
+  --mock-inset: rgba(23, 40, 61, 0.05);
+  --mock-stroke: rgba(23, 40, 61, 0.2);
+  --mock-chip: rgba(255, 255, 255, 0.78);
+  --mock-dock: rgba(255, 255, 255, 0.94);
+  --mock-shadow: 0 22px 48px rgba(42, 69, 101, 0.14);
+  --mock-shadow-soft: 0 16px 34px rgba(42, 69, 101, 0.11);
+  --mock-shadow-card: 0 13px 28px rgba(42, 69, 101, 0.10);
+  --mock-shadow-card-sm: 0 11px 24px rgba(42, 69, 101, 0.09);
+  --mock-shadow-dock: 0 16px 42px rgba(42, 69, 101, 0.20);
+  --mock-cover-ink: rgba(23, 40, 61, 0.95);
+  --mock-cover-ink-soft: rgba(23, 40, 61, 0.80);
+  --mock-cover-scrim: rgba(255, 255, 255, 0.42);
+  --mock-cover-scrim-mid: rgba(255, 255, 255, 0.12);
+  --mock-cover-fade: rgba(255, 255, 255, 0.42);
 }
 
 html {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -371,6 +371,43 @@ html[data-theme="dark"] .liquid-list-row.liquid-room-row-selected {
 }
 
 /*
+ * The logo ships as a solid white SVG. Masking it with the same asset lets the
+ * mark take currentColor, so it stays legible on the light canvas without a
+ * second file or a per-theme <img> swap.
+ */
+.botcord-brand-mark {
+  background-color: currentColor;
+  -webkit-mask: url("/logo.svg") center / contain no-repeat;
+  mask: url("/logo.svg") center / contain no-repeat;
+}
+
+/*
+ * The marketing pages paint straight onto the body color, which reads as one
+ * flat slab of grey-blue in light mode — the dark theme gets its depth from the
+ * particle mesh glowing against near-black. This layer gives light mode an
+ * equivalent: a white crown behind the hero, faint brand-tinted corners, and a
+ * gentle cool falloff toward the footer.
+ */
+.marketing-canvas {
+  display: none;
+}
+
+html[data-theme="light"] .marketing-canvas {
+  display: block;
+  background:
+    radial-gradient(120% 66% at 50% -12%, #ffffff 0%, rgba(255, 255, 255, 0) 58%),
+    radial-gradient(64% 42% at 10% 6%, rgba(0, 123, 147, 0.09), transparent 62%),
+    radial-gradient(58% 40% at 90% 2%, rgba(109, 77, 216, 0.08), transparent 62%),
+    linear-gradient(180deg, #f5f9fd 0%, #eaf1f8 56%, #e5edf6 100%);
+}
+
+/* The nav floats over the white crown of that canvas, so the shared body tint
+ * would read as a darker band across the top. */
+html[data-theme="light"] .marketing-nav {
+  background: rgba(255, 255, 255, 0.72);
+}
+
+/*
  * The marketing hero renders a WebGL particle mesh behind the copy. On the
  * light canvas the mesh has enough contrast to compete with the headline, so a
  * radial wash of the page background fades it out where the text sits and lets
@@ -384,9 +421,9 @@ html[data-theme="light"] .hero-scene-veil {
   display: block;
   background: radial-gradient(
     92% 58% at 50% 30%,
-    rgba(238, 243, 249, 0.88) 0%,
-    rgba(238, 243, 249, 0.6) 42%,
-    rgba(238, 243, 249, 0) 76%
+    rgba(250, 252, 255, 0.9) 0%,
+    rgba(248, 251, 254, 0.6) 42%,
+    rgba(246, 250, 254, 0) 76%
   );
 }
 

--- a/frontend/src/components/home/AgentScenariosSection.tsx
+++ b/frontend/src/components/home/AgentScenariosSection.tsx
@@ -87,9 +87,9 @@ function VisualShell({
 }) {
   return (
     <div
-      className={`relative aspect-[4/3] overflow-hidden rounded-[26px] border border-white/10 bg-black/30 p-4 shadow-[0_24px_60px_rgba(0,0,0,0.28)] backdrop-blur-sm ${className}`}
+      className={`relative aspect-[4/3] overflow-hidden rounded-[26px] border border-white/10 bg-[var(--mock-shell)] p-4 shadow-[var(--mock-shadow)] backdrop-blur-sm ${className}`}
     >
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.08),transparent_42%),linear-gradient(180deg,rgba(255,255,255,0.04),transparent_70%)]" />
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,var(--mock-sheen-strong),transparent_42%),linear-gradient(180deg,var(--mock-sheen-soft),transparent_70%)]" />
       {children}
     </div>
   );
@@ -106,7 +106,7 @@ function ScenarioVisual({
 
   if (index === 0) {
     return (
-      <VisualShell className="bg-[radial-gradient(circle_at_top_right,rgba(0,240,255,0.15),transparent_38%),rgba(0,0,0,0.22)]">
+      <VisualShell className="bg-[radial-gradient(circle_at_top_right,rgba(0,240,255,0.15),transparent_38%),var(--mock-shell-tint)]">
         <div className="relative flex flex-wrap gap-2">
           {copy.chips.map((chip) => (
             <span
@@ -146,7 +146,7 @@ function ScenarioVisual({
               <div className="h-2 w-4/5 rounded-full bg-white/10" />
               <div className="h-2 w-3/5 rounded-full bg-white/10" />
             </div>
-            <div className="mt-auto rounded-2xl border border-white/8 bg-black/25 px-3 py-2 text-[10px] text-text-secondary">
+            <div className="mt-auto rounded-2xl border border-white/8 bg-[var(--mock-inset)] px-3 py-2 text-[10px] text-text-secondary">
               {copy.footer}
             </div>
           </div>
@@ -157,14 +157,14 @@ function ScenarioVisual({
 
   if (index === 1) {
     return (
-      <VisualShell className="bg-[radial-gradient(circle_at_center,rgba(139,92,246,0.16),transparent_36%),rgba(0,0,0,0.24)]">
+      <VisualShell className="bg-[radial-gradient(circle_at_center,rgba(139,92,246,0.16),transparent_36%),var(--mock-shell-tint)]">
         <svg
           className="pointer-events-none absolute inset-0 h-full w-full opacity-70"
           viewBox="0 0 100 100"
           preserveAspectRatio="none"
         >
           <path d="M22 24 C35 38, 42 48, 52 70" fill="none" stroke="rgba(139,92,246,0.28)" strokeWidth="1.2" />
-          <path d="M50 18 C58 34, 56 48, 52 70" fill="none" stroke="rgba(255,255,255,0.18)" strokeWidth="1" />
+          <path d="M50 18 C58 34, 56 48, 52 70" fill="none" stroke="var(--mock-stroke)" strokeWidth="1" />
           <path d="M78 28 C68 40, 60 50, 52 70" fill="none" stroke="rgba(0,240,255,0.22)" strokeWidth="1.2" />
         </svg>
 
@@ -203,7 +203,7 @@ function ScenarioVisual({
 
   if (index === 2) {
     return (
-      <VisualShell className="bg-[radial-gradient(circle_at_center,rgba(16,185,129,0.14),transparent_34%),rgba(0,0,0,0.24)]">
+      <VisualShell className="bg-[radial-gradient(circle_at_center,rgba(16,185,129,0.14),transparent_34%),var(--mock-shell-tint)]">
         <svg
           className="pointer-events-none absolute inset-0 h-full w-full opacity-60"
           viewBox="0 0 100 100"
@@ -247,7 +247,7 @@ function ScenarioVisual({
             ))}
           </div>
 
-          <div className="mt-4 rounded-2xl border border-white/8 bg-black/20 p-3">
+          <div className="mt-4 rounded-2xl border border-white/8 bg-[var(--mock-inset)] p-3">
             <p className="text-[10px] font-semibold uppercase tracking-[0.24em] text-neon-green/75">
               {copy.focus}
             </p>
@@ -263,7 +263,7 @@ function ScenarioVisual({
   }
 
   return (
-    <VisualShell className="bg-[radial-gradient(circle_at_top,rgba(0,240,255,0.12),transparent_32%),radial-gradient(circle_at_bottom_right,rgba(139,92,246,0.12),transparent_28%),rgba(0,0,0,0.26)]">
+    <VisualShell className="bg-[radial-gradient(circle_at_top,rgba(0,240,255,0.12),transparent_32%),radial-gradient(circle_at_bottom_right,rgba(139,92,246,0.12),transparent_28%),var(--mock-shell-tint)]">
       <div className="relative grid grid-cols-2 gap-3">
         {copy.chips.map((chip, idx) => (
           <div

--- a/frontend/src/components/home/PlatformStats.tsx
+++ b/frontend/src/components/home/PlatformStats.tsx
@@ -249,7 +249,7 @@ export default function PlatformStats() {
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true, margin: "-40px" }}
             transition={{ duration: 0.55 }}
-            className="rounded-[24px] border border-white/10 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.04),transparent_42%),linear-gradient(180deg,rgba(255,255,255,0.03),rgba(255,255,255,0.015))] px-4 py-4 shadow-[0_20px_54px_rgba(0,0,0,0.22)] backdrop-blur-xl sm:px-5 sm:py-5"
+            className="rounded-[24px] border border-white/10 bg-[radial-gradient(circle_at_top,var(--mock-sheen-soft),transparent_42%),var(--mock-shell)] px-4 py-4 shadow-[var(--mock-shadow-soft)] backdrop-blur-xl sm:px-5 sm:py-5"
           >
             <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
               <div className="space-y-2">
@@ -292,7 +292,7 @@ export default function PlatformStats() {
             transition={{ duration: 0.3, ease: "easeOut" }}
             className="fixed bottom-3 right-3 z-50 left-3 sm:left-auto sm:w-[min(82vw,29rem)]"
           >
-            <div className="rounded-[18px] border border-white/12 bg-[#06080ddd] p-3 shadow-[0_18px_54px_rgba(0,0,0,0.42)] backdrop-blur-2xl sm:p-3.5">
+            <div className="rounded-[18px] border border-white/12 bg-[var(--mock-dock)] p-3 shadow-[var(--mock-shadow-dock)] backdrop-blur-2xl sm:p-3.5">
               <div className="grid grid-cols-2 gap-4 sm:grid-cols-4 sm:gap-0">
                 {statItems.map((item, index) => (
                   <StatColumn

--- a/frontend/src/components/home/PublicRoomsSection.tsx
+++ b/frontend/src/components/home/PublicRoomsSection.tsx
@@ -126,7 +126,7 @@ function buildCoverStyle(room: PublicRoom) {
   return {
     theme,
     style: {
-      backgroundImage: `linear-gradient(135deg, ${theme.accentDim}, rgba(10,10,15,0.28)), ${theme.patternUrl}`,
+      backgroundImage: `linear-gradient(135deg, ${theme.accentDim}, var(--mock-cover-fade)), ${theme.patternUrl}`,
       backgroundRepeat: "no-repeat, repeat",
       backgroundSize: "cover, auto",
     } as const,
@@ -155,31 +155,31 @@ function FeaturedRoomCard({
     <Link href={roomHref(room.room_id)} className="group block h-full">
       <article
         className="flex h-full min-h-[320px] flex-col overflow-hidden rounded-[28px] border border-glass-border bg-deep-black-light/85 transition-all duration-300 hover:-translate-y-1 hover:border-neon-cyan/45"
-        style={{ boxShadow: `0 0 0 1px ${theme.accent}14, 0 18px 44px rgba(0, 0, 0, 0.22)` }}
+        style={{ boxShadow: `0 0 0 1px ${theme.accent}14, var(--mock-shadow-soft)` }}
       >
         <div className="relative min-h-[156px] px-5 py-5" style={style}>
-          <div className="absolute inset-0 bg-gradient-to-b from-transparent via-deep-black/10 to-deep-black/60" />
+          <div className="absolute inset-0 bg-[linear-gradient(180deg,transparent,var(--mock-cover-scrim-mid),var(--mock-cover-scrim))]" />
           <div className="relative flex items-start justify-between gap-4">
             <div className="inline-flex items-center gap-3">
               <div
-                className="flex h-11 w-11 items-center justify-center rounded-2xl text-sm font-bold text-white/95 backdrop-blur-sm"
+                className="flex h-11 w-11 items-center justify-center rounded-2xl text-sm font-bold text-[var(--mock-cover-ink)] backdrop-blur-sm"
                 style={{ background: theme.accentDim, boxShadow: `0 0 0 1px ${theme.accent}66` }}
               >
                 {initialsFromName(room.name || "Room")}
               </div>
               <div>
-                <p className="text-[10px] font-semibold uppercase tracking-[0.32em] text-white/75">
+                <p className="text-[10px] font-semibold uppercase tracking-[0.32em] text-[var(--mock-cover-ink-soft)]">
                   {strings.featuredLabel}
                 </p>
-                <p className="mt-1 text-sm text-white/90">
+                <p className="mt-1 text-sm text-[var(--mock-cover-ink)]">
                   {formatCompactCount(room.member_count, locale)} {memberWord}
                 </p>
               </div>
             </div>
 
             <span
-              className="rounded-full px-3 py-1 text-[11px] font-medium text-white/90 backdrop-blur-sm"
-              style={{ background: "rgba(0,0,0,0.32)", boxShadow: `0 0 0 1px ${theme.accent}55` }}
+              className="rounded-full px-3 py-1 text-[11px] font-medium text-[var(--mock-cover-ink)] backdrop-blur-sm"
+              style={{ background: "var(--mock-chip)", boxShadow: `0 0 0 1px ${theme.accent}55` }}
             >
               {formatRelativeTime(room.last_message_at, locale, strings)}
             </span>
@@ -239,19 +239,19 @@ function SpotlightRoomCard({
     <Link href={roomHref(room.room_id)} className="group block h-full">
       <article
         className="flex h-full min-h-[156px] flex-col overflow-hidden rounded-[24px] border border-glass-border bg-deep-black-light/82 transition-all duration-300 hover:-translate-y-1 hover:border-neon-cyan/35"
-        style={{ boxShadow: `0 0 0 1px ${theme.accent}12, 0 14px 32px rgba(0, 0, 0, 0.18)` }}
+        style={{ boxShadow: `0 0 0 1px ${theme.accent}12, var(--mock-shadow-card)` }}
       >
         <div className="relative h-[84px] px-4 py-3.5" style={style}>
-          <div className="absolute inset-0 bg-gradient-to-b from-transparent to-deep-black/60" />
+          <div className="absolute inset-0 bg-[linear-gradient(180deg,transparent,var(--mock-cover-scrim))]" />
           <div className="relative flex items-start justify-between gap-3">
             <div
-              className="flex h-9 w-9 items-center justify-center rounded-xl text-xs font-bold text-white/90 backdrop-blur-sm"
+              className="flex h-9 w-9 items-center justify-center rounded-xl text-xs font-bold text-[var(--mock-cover-ink)] backdrop-blur-sm"
               style={{ background: theme.accentDim, boxShadow: `0 0 0 1px ${theme.accent}55` }}
             >
               {initialsFromName(room.name || "Room")}
             </div>
             <span
-              className="rounded-full bg-black/30 px-2.5 py-1 text-[10px] font-medium text-white/85 backdrop-blur-sm"
+              className="rounded-full bg-[var(--mock-chip)] px-2.5 py-1 text-[10px] font-medium text-[var(--mock-cover-ink)] backdrop-blur-sm"
               style={{ boxShadow: `0 0 0 1px ${theme.accent}44` }}
             >
               {formatCompactCount(room.member_count, locale)} {memberWord}
@@ -306,23 +306,23 @@ function CompactRoomCard({
     <Link href={roomHref(room.room_id)} className="group block h-full">
       <article
         className="flex h-full flex-col overflow-hidden rounded-[22px] border border-glass-border bg-deep-black-light/80 transition-all duration-300 hover:-translate-y-1 hover:border-neon-cyan/30"
-        style={{ boxShadow: `0 0 0 1px ${theme.accent}10, 0 12px 28px rgba(0, 0, 0, 0.15)` }}
+        style={{ boxShadow: `0 0 0 1px ${theme.accent}10, var(--mock-shadow-card-sm)` }}
       >
         <div className="relative h-14 px-3.5 py-2.5" style={style}>
-          <div className="absolute inset-0 bg-gradient-to-b from-transparent to-deep-black/55" />
+          <div className="absolute inset-0 bg-[linear-gradient(180deg,transparent,var(--mock-cover-scrim))]" />
           <div className="relative flex items-center justify-between gap-3">
             <div className="inline-flex items-center gap-2.5">
               <div
-                className="flex h-8 w-8 items-center justify-center rounded-lg text-[11px] font-bold text-white/90"
+                className="flex h-8 w-8 items-center justify-center rounded-lg text-[11px] font-bold text-[var(--mock-cover-ink)]"
                 style={{ background: theme.accentDim, boxShadow: `0 0 0 1px ${theme.accent}55` }}
               >
                 {initialsFromName(room.name || "Room")}
               </div>
-              <span className="text-[10px] font-medium text-white/80">
+              <span className="text-[10px] font-medium text-[var(--mock-cover-ink)]">
                 {formatCompactCount(room.member_count, locale)} {memberWord}
               </span>
             </div>
-            <span className="text-[10px] text-white/75">
+            <span className="text-[10px] text-[var(--mock-cover-ink-soft)]">
               {formatRelativeTime(room.last_message_at, locale, strings)}
             </span>
           </div>

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useLanguage } from "@/lib/i18n";
 import { footer, nav, navLinks } from "@/lib/i18n/translations/common";
+import BrandMark from "@/components/ui/BrandMark";
 
 export default function Footer() {
   const locale = useLanguage();
@@ -16,10 +17,10 @@ export default function Footer() {
           <div>
             <Link
               href="/"
-              className="flex items-center gap-2 text-lg font-bold"
+              className="flex items-center gap-2 text-lg font-bold text-text-primary"
             >
-              <img src="/logo.svg" alt="BotCord" className="h-6 w-6" />
-              <span className="text-text-primary">BotCord</span>
+              <BrandMark className="h-6 w-6" />
+              <span>BotCord</span>
             </Link>
             <p className="mt-2 text-sm text-text-secondary">
               {t.tagline}

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -7,6 +7,7 @@ import clsx from "clsx";
 import { useLanguage } from "@/lib/i18n";
 import { nav, navLinks } from "@/lib/i18n/translations/common";
 import { useAppStore } from "@/store/useAppStore";
+import BrandMark from "@/components/ui/BrandMark";
 
 export default function Navbar() {
   const pathname = usePathname();
@@ -27,11 +28,11 @@ export default function Navbar() {
   }, []);
 
   return (
-    <nav className="fixed top-0 z-50 w-full border-b border-glass-border bg-deep-black/70 backdrop-blur-xl">
+    <nav className="marketing-nav fixed top-0 z-50 w-full border-b border-glass-border bg-deep-black/70 backdrop-blur-xl">
       <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-6">
-        <Link href="/" className="flex items-center gap-2 text-lg font-bold">
-          <img src="/logo.svg" alt="BotCord" className="h-8 w-8" />
-          <span className="text-text-primary">BotCord</span>
+        <Link href="/" className="flex items-center gap-2 text-lg font-bold text-text-primary">
+          <BrandMark className="h-8 w-8" />
+          <span>BotCord</span>
         </Link>
 
         <div className="hidden items-center gap-8 md:flex">

--- a/frontend/src/components/ui/BrandMark.tsx
+++ b/frontend/src/components/ui/BrandMark.tsx
@@ -1,0 +1,22 @@
+/**
+ * [INPUT]: 依赖 /logo.svg 作为遮罩源与 clsx 组合外部样式
+ * [OUTPUT]: 对外提供跟随 currentColor 着色的 BotCord 标志组件
+ * [POS]: ui 品牌原语，供 Navbar、Footer 等浅/深双主题表面复用
+ * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
+ */
+
+import { clsx } from "clsx";
+
+/**
+ * The shipped logo asset is a solid white SVG, so an <img> of it vanishes on
+ * the light canvas. Painting it as a CSS mask keeps one asset while letting the
+ * mark inherit the surrounding text color in either theme.
+ */
+export default function BrandMark({ className }: { className?: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={clsx("botcord-brand-mark inline-block shrink-0", className)}
+    />
+  );
+}


### PR DESCRIPTION
## 问题

浅色模式下：

1. **Logo 看不见** —— `public/logo.svg` 是纯白填充，Navbar / Footer 直接 `<img>` 引用，在浅色背景上完全消失，只剩 "BotCord" 文字
2. **背景没有浅色适配** —— marketing 页直接用扁平的 body 底色（`#eef3f9`），整页一块灰蓝，缺少深色模式那种「粒子网在近黑背景上发光」的层次

## 改动

- 新增 `BrandMark` 组件：用 CSS mask（`mask: url(/logo.svg)` + `background-color: currentColor`）渲染 logo，自动继承所在文字颜色，一份资源同时适配深浅两个主题。替换 Navbar / Footer 的 `<img>`
  - dashboard sidebar 的 logo 已有 `.dashboard-brand-link` 深色底托，不动；`BotCordLoader` 的 logo 位于深色 core 上，也不动
- 新增 `.marketing-canvas` 浅色专属背景层（fixed，`-z-20`，深色下 `display:none`）：hero 后方的白色冠部 + 极淡的青/紫角落光晕 + 向 footer 的冷色渐落
- `.marketing-nav` 浅色下改用纯白半透明，避免共享 body 色在白色冠部上形成一条更暗的顶栏
- hero 遮罩颜色跟随新的冠部色，避免色差

## 验证

- `pnpm build` 通过
- Playwright 截图：浅色下 Navbar / Footer logo 清晰可见、整页有纵向层次；深色模式与改动前一致