### PR TITLE
fix(ci): use setup-uv for prod migrations on arm64 runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,11 +136,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare.outputs.source_sha }}
-      - uses: actions/setup-python@v5
+      # setup-python has no prebuilt 3.12 for self-hosted arm64 runners;
+      # setup-uv ships a static binary and uv downloads the interpreter itself.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
         with:
           python-version: '3.12'
-      - name: Install uv
-        run: pip install uv
       - name: Install deps
         run: uv sync
       - name: Run SQL migrations


### PR DESCRIPTION
Release run [33146953234](https://github.com/botlearn-ai/botcord/actions/runs/33146953234) failed in `Migrate (production)`: `actions/setup-python@v5` has no prebuilt Python 3.12 for the self-hosted arm64 runner, which blocked the backend/frontend prod deploys.

Switch the migrate-prod job to `astral-sh/setup-uv@v6` — the same pattern `db-migrate.yml` already uses (static binary; uv downloads the interpreter itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)