### PR TITLE
chore(release): version packages

### DIFF
--- a/.changeset/calm-pandas-stream.md
+++ b/.changeset/calm-pandas-stream.md
@@ -1,5 +1,0 @@
----
-"@botcord/daemon": patch
----
-
-Forward DeepSeek `agent_reasoning` deltas as redacted owner-chat progress and fail an SSE turn that produces no runtime event for 60 seconds instead of hanging until the outer turn timeout.

--- a/.changeset/durable-inbox-lease.md
+++ b/.changeset/durable-inbox-lease.md
@@ -1,6 +1,0 @@
----
-"@botcord/daemon": patch
-"@botcord/protocol-core": patch
----
-
-Keep inbox messages under a renewable processing lease until runtime handling finishes, then acknowledge them explicitly so crashes requeue work instead of losing it.

--- a/.changeset/tidy-hubs-rotate.md
+++ b/.changeset/tidy-hubs-rotate.md
@@ -1,9 +1,0 @@
----
-"@botcord/daemon": patch
-"@botcord/protocol-core": patch
----
-
-Support staged Hub control signing-key rotation by resolving a multi-key trust
-ring in protocol-core and accepting frames signed by any trusted key in the
-daemon. Runtime snapshots attest that ring using privacy-safe fingerprints, and
-the legacy singular public-key configuration remains compatible.

--- a/packages/daemon/CHANGELOG.md
+++ b/packages/daemon/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @botcord/daemon
 
+## 0.4.9
+
+### Patch Changes
+
+- f7cdcd2: Forward DeepSeek `agent_reasoning` deltas as redacted owner-chat progress and fail an SSE turn that produces no runtime event for 60 seconds instead of hanging until the outer turn timeout.
+- 637d893: Keep inbox messages under a renewable processing lease until runtime handling finishes, then acknowledge them explicitly so crashes requeue work instead of losing it.
+- afd1bc7: Support staged Hub control signing-key rotation by resolving a multi-key trust
+  ring in protocol-core and accepting frames signed by any trusted key in the
+  daemon. Runtime snapshots attest that ring using privacy-safe fingerprints, and
+  the legacy singular public-key configuration remains compatible.
+- Updated dependencies [637d893]
+- Updated dependencies [afd1bc7]
+  - @botcord/protocol-core@0.2.19
+
 ## 0.4.8
 
 ### Patch Changes

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botcord/daemon",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "BotCord local daemon — bridges Hub inbox push to local Claude Code / Codex / Gemini CLIs",
   "type": "module",
   "bin": {

--- a/packages/protocol-core/CHANGELOG.md
+++ b/packages/protocol-core/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @botcord/protocol-core
 
+## 0.2.19
+
+### Patch Changes
+
+- 637d893: Keep inbox messages under a renewable processing lease until runtime handling finishes, then acknowledge them explicitly so crashes requeue work instead of losing it.
+- afd1bc7: Support staged Hub control signing-key rotation by resolving a multi-key trust
+  ring in protocol-core and accepting frames signed by any trusted key in the
+  daemon. Runtime snapshots attest that ring using privacy-safe fingerprints, and
+  the legacy singular public-key configuration remains compatible.
+
 ## 0.2.18
 
 ### Patch Changes

--- a/packages/protocol-core/package.json
+++ b/packages/protocol-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botcord/protocol-core",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "description": "Shared protocol primitives for BotCord — Ed25519 signing, credentials I/O, session key derivation",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Version bump from pending changesets: @botcord/daemon 0.4.9, @botcord/protocol-core 0.2.19.

Includes the hub-control signing-key ring support (#995), inbox processing lease, and DeepSeek owner-chat stream fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)