### PR TITLE
fix: name bot-to-bot DM rooms

### DIFF
--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -26,6 +26,7 @@ from app.auth_room import (
 )
 from app.helpers import escape_like, extract_text_from_envelope
 from hub.database import get_db
+from hub.dm_room_names import build_dm_room_name
 from hub.dashboard_message_shaping import (
     HUMAN_SOURCE_TYPES,
     derive_sender_fields,
@@ -620,7 +621,8 @@ async def _build_rooms_from_membership(
             "visibility": room.visibility.value if hasattr(room.visibility, "value") else str(room.visibility),
             "join_policy": room.join_policy.value if hasattr(room.join_policy, "value") else str(room.join_policy),
             "member_count": member_counts.get(rid, 0),
-            "members_preview": members_preview.get(rid) if member_counts.get(rid, 0) > 2 else None,
+            "members_preview": members_preview.get(rid)
+            if rid.startswith("rm_dm_") or member_counts.get(rid, 0) > 2 else None,
             "my_role": my_role,
             "can_invite": computed_can_invite,
             "allow_human_send": room.allow_human_send,
@@ -2779,7 +2781,7 @@ async def _ensure_dashboard_dm_room(
 
     room = Room(
         room_id=room_id,
-        name=f"DM {a} & {b}",
+        name=await build_dm_room_name(db, [a, b]),
         owner_id=sender_id,
         visibility=RoomVisibility.private,
         join_policy=RoomJoinPolicy.invite_only,

--- a/backend/app/routers/humans.py
+++ b/backend/app/routers/humans.py
@@ -720,7 +720,7 @@ async def list_human_rooms(
                 effective_roles.get(room.room_id, role),
                 member_count=member_counts.get(room.room_id, 0),
                 members_preview=previews_by_room.get(room.room_id)
-                if member_counts.get(room.room_id, 0) > 2 else None,
+                if room.room_id.startswith("rm_dm_") or member_counts.get(room.room_id, 0) > 2 else None,
             )
         )
     return HumanRoomListResponse(rooms=rooms)
@@ -808,7 +808,7 @@ async def list_owned_agent_only_rooms(
                 last_sender_name=preview.get("last_sender_name"),
                 allow_human_send=preview.get("allow_human_send"),
                 members_preview=previews_by_room.get(room_id)
-                if int(preview.get("member_count") or 0) > 2 else None,
+                if room_id.startswith("rm_dm_") or int(preview.get("member_count") or 0) > 2 else None,
                 bots=sorted(bots, key=lambda bot: agent_names.get(bot.agent_id) or bot.agent_id),
             )
         )

--- a/backend/hub/dm_room_names.py
+++ b/backend/hub/dm_room_names.py
@@ -1,0 +1,80 @@
+"""Display-name helpers for system-created direct-message rooms.
+
+DM room IDs stay deterministic and machine-readable. The room title is
+user-facing, so it should use the participants' names rather than their IDs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from hub.models import Agent, User
+
+
+_DM_ROOM_NAME_LIMIT = 128
+_DM_ROOM_NAME_SEPARATOR = " & "
+_DM_ROOM_NAME_SUFFIX = " 的私聊"
+
+
+def _truncate(value: str, limit: int) -> str:
+    if len(value) <= limit:
+        return value
+    if limit <= 1:
+        return value[:limit]
+    return f"{value[:limit - 1]}…"
+
+
+def format_dm_room_name(participant_names: Sequence[str]) -> str:
+    """Return the persisted title for a two-person DM within ``Room.name``."""
+    if len(participant_names) != 2:
+        raise ValueError("A DM room must have exactly two participant names")
+
+    first, second = (name.strip() or "Unknown" for name in participant_names)
+    title = f"{first}{_DM_ROOM_NAME_SEPARATOR}{second}{_DM_ROOM_NAME_SUFFIX}"
+    if len(title) <= _DM_ROOM_NAME_LIMIT:
+        return title
+
+    available = _DM_ROOM_NAME_LIMIT - len(_DM_ROOM_NAME_SEPARATOR) - len(_DM_ROOM_NAME_SUFFIX)
+    first_limit = (available + 1) // 2
+    second_limit = available - first_limit
+    return (
+        f"{_truncate(first, first_limit)}{_DM_ROOM_NAME_SEPARATOR}"
+        f"{_truncate(second, second_limit)}{_DM_ROOM_NAME_SUFFIX}"
+    )
+
+
+async def build_dm_room_name(
+    db: AsyncSession,
+    participant_ids: Sequence[str],
+) -> str:
+    """Resolve a friendly persisted title for an agent/human DM pair.
+
+    Missing legacy identities deliberately fall back to their IDs so room
+    creation remains resilient even if a profile was deleted concurrently.
+    """
+    if len(participant_ids) != 2:
+        raise ValueError("A DM room must have exactly two participants")
+
+    agent_ids = [participant_id for participant_id in participant_ids if participant_id.startswith("ag_")]
+    human_ids = [participant_id for participant_id in participant_ids if participant_id.startswith("hu_")]
+    display_names: dict[str, str] = {}
+
+    if agent_ids:
+        result = await db.execute(
+            select(Agent.agent_id, Agent.display_name).where(Agent.agent_id.in_(agent_ids))
+        )
+        display_names.update({agent_id: display_name for agent_id, display_name in result.all()})
+
+    if human_ids:
+        result = await db.execute(
+            select(User.human_id, User.display_name).where(User.human_id.in_(human_ids))
+        )
+        display_names.update({human_id: display_name for human_id, display_name in result.all() if human_id})
+
+    return format_dm_room_name([
+        display_names.get(participant_id, participant_id)
+        for participant_id in participant_ids
+    ])

--- a/backend/hub/routers/dashboard.py
+++ b/backend/hub/routers/dashboard.py
@@ -298,7 +298,7 @@ async def _build_dashboard_rooms(
 
         member_count = member_counts.get(rid, 0)
         previews: list[RoomMemberPreview] | None = None
-        if member_count > 2:
+        if room.room_id.startswith("rm_dm_") or member_count > 2:
             entries = members_by_room.get(rid, [])
             previews_list: list[RoomMemberPreview] = []
             for pid, ptype in entries:

--- a/backend/hub/routers/hub.py
+++ b/backend/hub/routers/hub.py
@@ -40,6 +40,7 @@ from hub.validators import normalize_file_url
 from hub.crypto import check_timestamp, verify_envelope_sig, verify_payload_hash
 from hub.dashboard_message_shaping import load_user_display_names
 from hub.database import async_session, get_db
+from hub.dm_room_names import build_dm_room_name
 from hub.services import presence as presence_service
 from hub.services.cloud_agent_activity import (
     bump_if_cloud_agent,
@@ -1060,7 +1061,7 @@ async def _ensure_dm_room(
 
     room = Room(
         room_id=room_id,
-        name=f"DM {ids[0]} & {ids[1]}",
+        name=await build_dm_room_name(db, ids),
         owner_id=sender_id,
         visibility="private",
         join_policy="invite_only",

--- a/backend/tests/test_app/test_app_dashboard.py
+++ b/backend/tests/test_app/test_app_dashboard.py
@@ -834,6 +834,9 @@ async def test_human_owner_can_open_dm_with_own_contacts_only_agent(
     member_ids = {m.agent_id for m in members}
     assert agent_id in member_ids
     assert any(m.participant_type == ParticipantType.human for m in members)
+    room = await db_session.scalar(select(Room).where(Room.room_id == room_id))
+    assert room is not None
+    assert room.name == "Owned Bot & Dashboard User 的私聊"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_app/test_app_humans.py
+++ b/backend/tests/test_app/test_app_humans.py
@@ -772,6 +772,63 @@ async def test_list_owned_agent_rooms_excludes_current_human_rooms(
 
 
 @pytest.mark.asyncio
+async def test_list_owned_agent_rooms_includes_member_names_for_legacy_bot_dm(
+    client, seed, db_session: AsyncSession
+):
+    """Old ID-based DM titles still include enough names for the UI to relabel them."""
+    owned_bot = Agent(
+        agent_id="ag_alpha00001",
+        display_name="Alpha Bot",
+        message_policy=MessagePolicy.open,
+        user_id=seed["user_id"],
+    )
+    peer_bot = Agent(
+        agent_id="ag_beta000001",
+        display_name="Beta Bot",
+        message_policy=MessagePolicy.open,
+    )
+    room = Room(
+        room_id="rm_dm_ag_alpha00001_ag_beta000001",
+        name="DM ag_alpha00001 & ag_beta000001",
+        description="",
+        owner_id=owned_bot.agent_id,
+        owner_type=ParticipantType.agent,
+        visibility=RoomVisibility.private,
+        join_policy=RoomJoinPolicy.invite_only,
+    )
+    db_session.add_all([
+        owned_bot,
+        peer_bot,
+        room,
+        RoomMember(
+            room_id=room.room_id,
+            agent_id=owned_bot.agent_id,
+            participant_type=ParticipantType.agent,
+            role=RoomRole.member,
+        ),
+        RoomMember(
+            room_id=room.room_id,
+            agent_id=peer_bot.agent_id,
+            participant_type=ParticipantType.agent,
+            role=RoomRole.member,
+        ),
+    ])
+    await db_session.commit()
+
+    response = await client.get(
+        "/api/humans/me/agent-rooms",
+        headers={"Authorization": f"Bearer {seed['token']}"},
+    )
+
+    assert response.status_code == 200, response.text
+    [result] = response.json()["rooms"]
+    assert result["members_preview"] == [
+        {"agent_id": "ag_alpha00001", "avatar_url": None, "display_name": "Alpha Bot"},
+        {"agent_id": "ag_beta000001", "avatar_url": None, "display_name": "Beta Bot"},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_list_owned_agent_rooms_keeps_owner_chat_even_with_human_member(
     client, seed, db_session: AsyncSession
 ):

--- a/backend/tests/test_room.py
+++ b/backend/tests/test_room.py
@@ -1186,6 +1186,11 @@ async def test_dm_room_order_independent(client: AsyncClient):
     assert len(a_dm) == 1
     assert len(b_dm) == 1
     assert a_dm[0]["room_id"] == b_dm[0]["room_id"]
+    names_by_id = {a_id: "alice", b_id: "bob"}
+    assert a_dm[0]["name"] == (
+        f"{names_by_id[sorted(names_by_id)[0]]} & "
+        f"{names_by_id[sorted(names_by_id)[1]]} 的私聊"
+    )
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/dashboard/RoomHeader.tsx
+++ b/frontend/src/components/dashboard/RoomHeader.tsx
@@ -110,10 +110,17 @@ export default function RoomHeader() {
   const dmContact = isDMRoom && dmPartnerAgentId
     ? (overview?.contacts.find((c) => c.contact_agent_id === dmPartnerAgentId) ?? null)
     : null;
-  // For DMs, surface the peer's display name instead of the raw "DM ag_X & ag_Y"
-  // string the backend stores on Room.name.
+  // For participant views, show the peer. For an owner observing a bot-to-bot
+  // DM, show both Bot names rather than the persisted legacy ID title.
   const titleText = isDMRoom && room
-    ? resolveDmDisplayName(openedRoomId, selfId, overview?.contacts ?? [], room.name)
+    ? resolveDmDisplayName(
+      openedRoomId,
+      selfId,
+      overview?.contacts ?? [],
+      room.name,
+      room.members_preview,
+      locale,
+    )
     : room?.name ?? "";
   const canInvite = isHumanView
     ? isOwnerOrAdmin || (Boolean(myRole) && Boolean(humanRoom?.default_invite))

--- a/frontend/src/components/dashboard/RoomList.tsx
+++ b/frontend/src/components/dashboard/RoomList.tsx
@@ -456,7 +456,14 @@ export default function RoomList({
         const metaLine = roomMeta?.[room.room_id] ?? null;
         const messageTime = formatLastMessageTime(ownerChatLatestForRoom?.createdAt || room.last_message_at || cachedLatestMessage?.created_at || null);
         const selfRoomId = viewMode === "human" ? humanId : activeAgentId;
-        const displayName = resolveDmDisplayName(room.room_id, selfRoomId, contacts, room.name);
+        const displayName = resolveDmDisplayName(
+          room.room_id,
+          selfRoomId,
+          contacts,
+          room.name,
+          room.members_preview,
+          locale,
+        );
         const avatarLabel = buildRoomAvatarLabel(displayName);
         const avatarTone = buildAvatarTone(room.room_id);
         const isGroup = (room.member_count ?? 0) > 2;

--- a/frontend/src/components/dashboard/dmRoom.test.ts
+++ b/frontend/src/components/dashboard/dmRoom.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveDmDisplayName } from "./dmRoom";
+
+const ROOM_ID = "rm_dm_ag_alpha_ag_beta";
+const MEMBERS = [
+  { agent_id: "ag_alpha", display_name: "Alpha Bot" },
+  { agent_id: "ag_beta", display_name: "Beta Bot" },
+];
+
+describe("resolveDmDisplayName", () => {
+  it("keeps the peer-focused label for a Bot participating in the DM", () => {
+    expect(resolveDmDisplayName(
+      ROOM_ID,
+      "ag_alpha",
+      [],
+      "legacy ID title",
+      MEMBERS,
+      "zh",
+    )).toBe("Beta Bot");
+  });
+
+  it("uses both Bot names for a Human owner observing a bot-to-bot DM", () => {
+    expect(resolveDmDisplayName(
+      ROOM_ID,
+      "hu_owner",
+      [],
+      "DM ag_alpha & ag_beta",
+      MEMBERS,
+      "zh",
+    )).toBe("Alpha Bot & Beta Bot 的私聊");
+  });
+
+  it("retains the stored title until both legacy DM member names are available", () => {
+    expect(resolveDmDisplayName(
+      ROOM_ID,
+      "hu_owner",
+      [],
+      "DM ag_alpha & ag_beta",
+      [{ agent_id: "ag_alpha", display_name: "Alpha Bot" }],
+      "zh",
+    )).toBe("DM ag_alpha & ag_beta");
+  });
+});

--- a/frontend/src/components/dashboard/dmRoom.ts
+++ b/frontend/src/components/dashboard/dmRoom.ts
@@ -1,6 +1,6 @@
 /**
  * [INPUT]: 依赖 rm_dm_* 房间 ID 形态与 dashboard 的联系人/会话列表
- * [OUTPUT]: 对外提供 DM 房间 ID 解析与 peer 显示名解析的统一工具
+ * [OUTPUT]: 对外提供 DM 房间 ID 解析与标题/peer 显示名解析的统一工具
  * [POS]: dashboard DM 渲染共用层，避免 RoomHeader / RoomList / ChatPane 各自实现
  * [PROTOCOL]: 变更时更新此头部，然后检查 README.md
  */
@@ -33,15 +33,64 @@ export interface DmContactLike {
   display_name: string;
 }
 
+export interface DmMemberLike {
+  agent_id?: string | null;
+  display_name: string;
+}
+
+type DmTitleLocale = "en" | "zh";
+
+function dmMemberNames(
+  roomId: string | null | undefined,
+  members: DmMemberLike[] | null | undefined,
+): [string, string] | null {
+  const parsed = parseDmRoomId(roomId);
+  if (!parsed || !members || members.length < 2) return null;
+
+  const namesById = new Map(
+    members
+      .filter((member) => member.agent_id && member.display_name.trim())
+      .map((member) => [member.agent_id!, member.display_name.trim()]),
+  );
+  const first = namesById.get(parsed.a);
+  const second = namesById.get(parsed.b);
+  return first && second ? [first, second] : null;
+}
+
+function observedBotDmTitle(
+  roomId: string | null | undefined,
+  members: DmMemberLike[] | null | undefined,
+  locale: DmTitleLocale,
+): string | null {
+  const parsed = parseDmRoomId(roomId);
+  if (!parsed || !parsed.a.startsWith("ag_") || !parsed.b.startsWith("ag_")) return null;
+
+  const names = dmMemberNames(roomId, members);
+  if (!names) return null;
+  return locale === "zh"
+    ? `${names[0]} & ${names[1]} 的私聊`
+    : `${names[0]} & ${names[1]} private chat`;
+}
+
 export function resolveDmDisplayName(
   roomId: string | null | undefined,
   selfId: string | null | undefined,
   contacts: DmContactLike[],
   fallback: string,
+  members?: DmMemberLike[] | null,
+  locale: DmTitleLocale = "en",
 ): string {
   const peer = dmPeerId(roomId, selfId);
-  if (!peer) return fallback;
-  const contact = contacts.find((c) => c.contact_agent_id === peer);
-  if (contact) return contact.alias || contact.display_name || peer;
-  return peer;
+  if (peer) {
+    const contact = contacts.find((c) => c.contact_agent_id === peer);
+    if (contact) return contact.alias || contact.display_name || peer;
+    const memberName = dmMemberNames(roomId, members)?.[
+      parseDmRoomId(roomId)?.a === peer ? 0 : 1
+    ];
+    return memberName || peer;
+  }
+
+  // A Human owner observing a bot-to-bot DM is not one of its participants.
+  // In that case, show both Bot names instead of the persisted legacy ID title.
+  return observedBotDmTitle(roomId, members, locale) || fallback;
 }


### PR DESCRIPTION
## Summary
- create new DM room titles from participant display names
- render existing bot-to-bot DM titles from member names in Messages
- retain deterministic room IDs for protocol behavior

## Validation
- cd backend && uv run pytest tests/test_room.py tests/test_app/test_app_dashboard.py tests/test_app/test_app_humans.py
- cd frontend && npm test -- --run src/components/dashboard/dmRoom.test.ts
- cd frontend && npm run build